### PR TITLE
Diagnostics: replace the per-artifact caps with one bundle size limit

### DIFF
--- a/pkg/api/ds_query_dashboard_diagnostics.go
+++ b/pkg/api/ds_query_dashboard_diagnostics.go
@@ -25,11 +25,14 @@ import (
 	"github.com/grafana/grafana/pkg/web"
 )
 
-// NOTE (MVP scope): resource limits are intentionally deferred to a follow-up PR (tracked) to keep
-// this experimental feature small: no panel-count cap, no per-run timeout, and no per-body/
-// per-request byte caps. See the "dashboard-level limits" follow-up. The in-memory job store is
-// still bounded (retention TTL + max-entries + in-flight caps below) so it can't grow without limit;
-// that is a correctness guard against unbounded memory, not one of the deferred resource limits.
+// NOTE (MVP scope): there is still no per-run timeout, and capture itself applies no per-body byte cap
+// on the in-process path (out-of-process plugins are bounded by the SDK's own capture budget).
+//
+// Size is bounded by two byte figures rather than by a set of per-artifact caps: diagnostics.MaxBundleBytes
+// for one bundle -- enforced during assembly AND, in buildDashboardDiagnosticsArchive, before each panel
+// runs, since this file's generation loop holds every panel's capture until the last one finishes -- and
+// diagnosticsJobStoreMaxBytes for everything the store retains. A panel-count cap is deliberately absent:
+// the byte budget stops the run instead, which bounds the same thing without a second number to tune.
 
 // diagnosticsEnabled reports whether the grafana.onDemandDiagnostics feature flag is on for the
 // current request. It reuses the shared OpenFeature client (see ds_query_diagnostics.go).
@@ -110,6 +113,17 @@ type diagnosticsJobSnapshot struct {
 type diagnosticsJobStore struct {
 	mu   sync.RWMutex
 	jobs map[string]*diagnosticsJob
+	// maxBytes overrides diagnosticsJobStoreMaxBytes; zero uses it. Only tests set it -- the real budget
+	// is far larger than a test can afford to allocate, so exercising eviction needs a smaller one.
+	maxBytes int
+}
+
+// budgetBytes returns the retained-archive budget in force for this store.
+func (s *diagnosticsJobStore) budgetBytes() int {
+	if s.maxBytes > 0 {
+		return s.maxBytes
+	}
+	return diagnosticsJobStoreMaxBytes
 }
 
 // dashboardDiagnosticsJobs is the process-wide job store. Package-level so the endpoint methods on
@@ -122,10 +136,17 @@ const (
 	// a job is created and when one goes terminal (no background sweeper for this experimental
 	// feature); finer-grained retention is part of the limits follow-up.
 	diagnosticsJobRetention = time.Hour
-	// diagnosticsJobMaxEntries is a hard cap on retained jobs so a burst of creations within the
-	// retention window still can't grow the store without bound. The oldest jobs by completion time
-	// are evicted first.
-	diagnosticsJobMaxEntries = 100
+	// diagnosticsJobStoreMaxBytes bounds the archive bytes the store retains, so a burst of creations
+	// within the retention window can't grow it without bound. The oldest jobs by completion time are
+	// evicted first.
+	//
+	// Bytes rather than a job count, because a count bounds nothing on its own: it multiplies against the
+	// per-bundle ceiling instead of constraining it, so the previous cap of 100 entries permitted a
+	// hundred times MaxBundleBytes. Expressed as a multiple of that ceiling for the same reason -- the two
+	// numbers only mean anything together, and a store smaller than one bundle would evict a full-size
+	// result the moment it completed. Two lets one large bundle coexist with another rather than
+	// displacing it.
+	diagnosticsJobStoreMaxBytes = 2 * diagnostics.MaxBundleBytes
 	// diagnosticsMaxInFlightJobs caps concurrently generating (pending) jobs. Pending jobs are never
 	// pruned -- their background goroutine is still writing to them -- so without this cap an admin
 	// repeatedly POSTing large dashboards could spawn unbounded long-lived goroutines, each holding
@@ -164,13 +185,14 @@ func (s *diagnosticsJobStore) create(total int, creator identity.Requester) (job
 	return j, true
 }
 
-// pruneLocked drops terminal jobs past the retention TTL, then evicts the oldest terminal jobs
-// beyond the max-entries cap. Caller must hold s.mu. This is what keeps the in-memory store bounded.
+// pruneLocked drops terminal jobs past the retention TTL, then evicts the oldest terminal jobs until the
+// retained archive bytes fit diagnosticsJobStoreMaxBytes. Caller must hold s.mu. This is what keeps the
+// in-memory store bounded.
 //
 // A still-pending job is never evicted: its background goroutine is still writing to it, so dropping
 // it would orphan the run -- complete/fail would no-op and status/download would 404 after expensive
-// generation. Only complete/error jobs are eligible here, so the store is bounded by (finished jobs
-// up to the cap) plus at most diagnosticsMaxInFlightJobs runs in flight (capped in create).
+// generation. Only complete/error jobs are eligible here, so the store is bounded by the byte budget
+// plus at most diagnosticsMaxInFlightJobs runs in flight (capped in create).
 //
 // Retention is measured from finishedAt (not CreatedAt): a run that takes longer than the retention
 // window would otherwise be prunable the instant it completes, 404-ing a download for a job that just
@@ -178,6 +200,7 @@ func (s *diagnosticsJobStore) create(total int, creator identity.Requester) (job
 // full window.
 func (s *diagnosticsJobStore) pruneLocked(now time.Time) {
 	terminal := make([]string, 0, len(s.jobs))
+	retained := 0
 	for uid, j := range s.jobs {
 		if j.State == jobPending {
 			continue
@@ -187,8 +210,10 @@ func (s *diagnosticsJobStore) pruneLocked(now time.Time) {
 			continue
 		}
 		terminal = append(terminal, uid)
+		retained += len(j.archive)
 	}
-	if len(terminal) <= diagnosticsJobMaxEntries {
+	budget := s.budgetBytes()
+	if retained <= budget {
 		return
 	}
 	// Evict by finishedAt, not CreatedAt: retention is measured from finishedAt, so a slow run with an
@@ -198,7 +223,15 @@ func (s *diagnosticsJobStore) pruneLocked(now time.Time) {
 	sort.Slice(terminal, func(a, b int) bool {
 		return s.jobs[terminal[a]].finishedAt.Before(s.jobs[terminal[b]].finishedAt)
 	})
-	for _, uid := range terminal[:len(terminal)-diagnosticsJobMaxEntries] {
+	// Oldest first until the rest fit. The newest job is never evicted even if it alone exceeds the
+	// budget: it is the result the caller is about to download, and dropping it would 404 a generation
+	// that just succeeded. Its size is already bounded by MaxBundleBytes, which is what makes leaving it
+	// in place safe.
+	for _, uid := range terminal[:len(terminal)-1] {
+		if retained <= budget {
+			break
+		}
+		retained -= len(s.jobs[uid].archive)
 		delete(s.jobs, uid)
 	}
 }

--- a/pkg/api/ds_query_dashboard_diagnostics.go
+++ b/pkg/api/ds_query_dashboard_diagnostics.go
@@ -496,11 +496,14 @@ func (hs *HTTPServer) buildDashboardDiagnosticsArchive(ctx context.Context, user
 			panel.QueryErr = errors.Join(diagnostics.ResponseError(resp), diagnostics.PluginCaptureError(resp))
 		}
 
-		// RetainedBytes rather than serializing the HAR: serializing to find out the size would allocate
-		// the very copy this accounting exists to avoid. It undercounts (bodies only, before JSON
-		// escaping), so the stop lands a little late -- acceptable, since one panel's overshoot is bounded
-		// by that panel's capture, while running the remaining panels is not.
-		capturedBytes += harBuffer.RetainedBytes()
+		// Both capture paths, because a panel's traffic can arrive by either: the buffer holds what the in-process RoundTripper recorded, while an out-of-process
+		// plugin returns its capture as __har__ frames on resp.
+		//
+		// Measured rather than serialized: serializing to learn the size would allocate the very copy this
+		// accounting exists to avoid. It undercounts (in-process bodies are counted before JSON escaping),
+		// so the stop lands a little late -- acceptable, since one panel's overshoot is bounded by that
+		// panel's capture, while running the remaining panels is not.
+		capturedBytes += harBuffer.RetainedBytes() + diagnostics.CapturedHARBytes(resp)
 		panels = append(panels, panel)
 		dashboardDiagnosticsJobs.setProgress(jobUID, i+1)
 	}

--- a/pkg/api/ds_query_dashboard_diagnostics.go
+++ b/pkg/api/ds_query_dashboard_diagnostics.go
@@ -73,7 +73,10 @@ type diagnosticsJob struct {
 	PanelsTotal int
 	PanelsDone  int
 	Err         string
-	archive     []byte
+	// Warning reports a bundle that was generated but is incomplete -- currently only the size limit
+	// dropping artifacts. Distinct from Err, which means no bundle exists to download.
+	Warning string
+	archive []byte
 
 	// createdByOrgID/createdByUID scope status/download to the identity that started the run. Jobs
 	// may hold verbatim captured HTTP traffic (see the harcapture package doc), so this is enforced
@@ -100,6 +103,7 @@ type diagnosticsJobSnapshot struct {
 	PanelsTotal int
 	PanelsDone  int
 	Err         string
+	Warning     string
 	CreatedAt   time.Time
 }
 
@@ -207,11 +211,14 @@ func (s *diagnosticsJobStore) setProgress(uid string, done int) {
 	s.mu.Unlock()
 }
 
-func (s *diagnosticsJobStore) complete(uid string, archive []byte) {
+func (s *diagnosticsJobStore) complete(uid string, archive []byte, result diagnostics.BundleResult) {
 	s.mu.Lock()
 	if j := s.jobs[uid]; j != nil {
 		j.State = jobComplete
 		j.archive = archive
+		if result.Partial() {
+			j.Warning = fmt.Sprintf("bundle size limit reached: %d artifact(s) omitted, see bundle-limit.txt", len(result.Dropped))
+		}
 		j.finishedAt = time.Now()
 		// Prune here too, not only on create: a job going terminal is when its archive bytes
 		// materialize and when it starts counting against the cap, and there may be no further
@@ -243,7 +250,7 @@ func (s *diagnosticsJobStore) snapshot(uid string, requester identity.Requester)
 	if j == nil || !jobOwnedBy(j, requester) {
 		return diagnosticsJobSnapshot{}, false
 	}
-	return diagnosticsJobSnapshot{j.UID, j.State, j.PanelsTotal, j.PanelsDone, j.Err, j.CreatedAt}, true
+	return diagnosticsJobSnapshot{j.UID, j.State, j.PanelsTotal, j.PanelsDone, j.Err, j.Warning, j.CreatedAt}, true
 }
 
 // archiveOf returns uid's archive, scoped to requester the same way snapshot is.
@@ -312,12 +319,12 @@ func (hs *HTTPServer) QueryDashboardDiagnostics(c *contextmodel.ReqContext) resp
 			}
 		}()
 
-		archive, err := hs.buildDashboardDiagnosticsArchive(detachedCtx, user, skipDSCache, useQueryDataNew, req, uid)
+		archive, result, err := hs.buildDashboardDiagnosticsArchive(detachedCtx, user, skipDSCache, useQueryDataNew, req, uid)
 		if err != nil {
 			dashboardDiagnosticsJobs.fail(uid, err)
 			return
 		}
-		dashboardDiagnosticsJobs.complete(uid, archive)
+		dashboardDiagnosticsJobs.complete(uid, archive, result)
 	}(job.UID, user, skipDSCache, useQueryDataNew, reqDTO)
 
 	return response.JSON(http.StatusAccepted, map[string]any{"uid": job.UID, "state": jobPending})
@@ -339,7 +346,10 @@ func (hs *HTTPServer) GetDashboardDiagnosticsStatus(c *contextmodel.ReqContext) 
 		"panelsTotal": snap.PanelsTotal,
 		"panelsDone":  snap.PanelsDone,
 		"error":       snap.Err,
-		"createdAt":   snap.CreatedAt.UTC().Format(time.RFC3339),
+		// A complete-but-incomplete bundle: downloadable, so not an error, but the caller should be told
+		// before reading it as a full picture of the dashboard.
+		"warning":   snap.Warning,
+		"createdAt": snap.CreatedAt.UTC().Format(time.RFC3339),
 	})
 }
 
@@ -369,7 +379,14 @@ func (hs *HTTPServer) DownloadDashboardDiagnostics(c *contextmodel.ReqContext) r
 // buildDashboardDiagnosticsArchive runs each panel's queries with independent HAR capture, updating
 // job progress as panels complete, then delegates archive assembly to the diagnostics service. A
 // non-data panel (no queries) is recorded as skipped rather than run.
-func (hs *HTTPServer) buildDashboardDiagnosticsArchive(ctx context.Context, user identity.Requester, skipDSCache, useQueryDataNew bool, reqDTO dashboardDiagnosticsRequest, jobUID string) ([]byte, error) {
+//
+// It stops running panels once the captures accumulated so far reach the bundle size limit. That stop
+// has to live here rather than in assembly: this loop holds every panel's capture buffer and response
+// simultaneously until the last panel finishes, so by the time the bundler could weigh them the memory
+// has already been spent. A dashboard big enough to matter would exhaust the process before assembly
+// ran at all. The remaining panels are recorded as skipped, so the manifest says what was not attempted
+// rather than leaving a short bundle that reads like the dashboard had fewer panels.
+func (hs *HTTPServer) buildDashboardDiagnosticsArchive(ctx context.Context, user identity.Requester, skipDSCache, useQueryDataNew bool, reqDTO dashboardDiagnosticsRequest, jobUID string) ([]byte, diagnostics.BundleResult, error) {
 	queryData := hs.queryDataService.QueryData
 	if useQueryDataNew {
 		queryData = hs.queryDataService.QueryDataNew
@@ -379,13 +396,14 @@ func (hs *HTTPServer) buildDashboardDiagnosticsArchive(ctx context.Context, user
 	vizPluginIDByPanelID := diagnostics.PanelPluginIDs(reqDTO.Dashboard)
 	var envRefs diagnostics.EnvironmentRefs
 
+	capturedBytes := 0
 	panels := make([]diagnostics.DashboardPanel, 0, len(reqDTO.Panels))
 	for i, p := range reqDTO.Panels {
 		// ctx is detachedCtx (see QueryDashboardDiagnostics), derived from context.WithoutCancel, so
 		// this never fires today -- there is no per-run timeout yet (MVP scope, see the NOTE above).
 		// Kept so this loop bails out for free once that follow-up wires up a cancelable context.
 		if err := ctx.Err(); err != nil {
-			return nil, err
+			return nil, diagnostics.BundleResult{}, err
 		}
 		panel := diagnostics.DashboardPanel{
 			ID:          p.ID,
@@ -418,6 +436,15 @@ func (hs *HTTPServer) buildDashboardDiagnosticsArchive(ctx context.Context, user
 			continue
 		}
 
+		// Checked before running rather than after: once a panel's queries execute, its capture is already
+		// in memory and the ceiling has been passed, not enforced.
+		if capturedBytes >= diagnostics.MaxBundleBytes {
+			panel.Skipped = fmt.Sprintf("not run: bundle size limit reached (%d bytes captured)", capturedBytes)
+			panels = append(panels, panel)
+			dashboardDiagnosticsJobs.setProgress(jobUID, i+1)
+			continue
+		}
+
 		pctx, harBuffer := harcapture.WithCapture(ctx) // capture each panel independently
 		resp, err := queryData(pctx, user, skipDSCache, p.MetricRequest)
 		panel.HARBuffer = harBuffer
@@ -432,6 +459,11 @@ func (hs *HTTPServer) buildDashboardDiagnosticsArchive(ctx context.Context, user
 			panel.QueryErr = errors.Join(diagnostics.ResponseError(resp), diagnostics.PluginCaptureError(resp))
 		}
 
+		// RetainedBytes rather than serializing the HAR: serializing to find out the size would allocate
+		// the very copy this accounting exists to avoid. It undercounts (bodies only, before JSON
+		// escaping), so the stop lands a little late -- acceptable, since one panel's overshoot is bounded
+		// by that panel's capture, while running the remaining panels is not.
+		capturedBytes += harBuffer.RetainedBytes()
 		panels = append(panels, panel)
 		dashboardDiagnosticsJobs.setProgress(jobUID, i+1)
 	}

--- a/pkg/api/ds_query_dashboard_diagnostics.go
+++ b/pkg/api/ds_query_dashboard_diagnostics.go
@@ -115,11 +115,11 @@ type diagnosticsJobStore struct {
 	jobs map[string]*diagnosticsJob
 	// maxBytes overrides diagnosticsJobStoreMaxBytes; zero uses it. Only tests set it -- the real budget
 	// is far larger than a test can afford to allocate, so exercising eviction needs a smaller one.
-	maxBytes int
+	maxBytes int64
 }
 
 // budgetBytes returns the retained-archive budget in force for this store.
-func (s *diagnosticsJobStore) budgetBytes() int {
+func (s *diagnosticsJobStore) budgetBytes() int64 {
 	if s.maxBytes > 0 {
 		return s.maxBytes
 	}
@@ -146,7 +146,11 @@ const (
 	// numbers only mean anything together, and a store smaller than one bundle would evict a full-size
 	// result the moment it completed. Two lets one large bundle coexist with another rather than
 	// displacing it.
-	diagnosticsJobStoreMaxBytes = 2 * diagnostics.MaxBundleBytes
+	//
+	// int64 because on a 32-bit build (armv6/armv7) this exceeds int: two times a 1 GiB ceiling is 2^31,
+	// one past math.MaxInt32. The byte counts it is compared against are int sums of len(), which cannot
+	// reach that on such a platform anyway, so only the budget itself needs the wider type.
+	diagnosticsJobStoreMaxBytes int64 = 2 * diagnostics.MaxBundleBytes
 	// diagnosticsMaxInFlightJobs caps concurrently generating (pending) jobs. Pending jobs are never
 	// pruned -- their background goroutine is still writing to them -- so without this cap an admin
 	// repeatedly POSTing large dashboards could spawn unbounded long-lived goroutines, each holding
@@ -213,7 +217,7 @@ func (s *diagnosticsJobStore) pruneLocked(now time.Time) {
 		retained += len(j.archive)
 	}
 	budget := s.budgetBytes()
-	if retained <= budget {
+	if int64(retained) <= budget {
 		return
 	}
 	// Evict by finishedAt, not CreatedAt: retention is measured from finishedAt, so a slow run with an
@@ -228,7 +232,7 @@ func (s *diagnosticsJobStore) pruneLocked(now time.Time) {
 	// that just succeeded. Its size is already bounded by MaxBundleBytes, which is what makes leaving it
 	// in place safe.
 	for _, uid := range terminal[:len(terminal)-1] {
-		if retained <= budget {
+		if int64(retained) <= budget {
 			break
 		}
 		retained -= len(s.jobs[uid].archive)

--- a/pkg/api/ds_query_dashboard_diagnostics_test.go
+++ b/pkg/api/ds_query_dashboard_diagnostics_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/contexthandler"
 	"github.com/grafana/grafana/pkg/services/contexthandler/ctxkey"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/diagnostics"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/query"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -177,7 +178,7 @@ func TestBuildDashboardDiagnosticsArchive_recordsPerRefIDQueryError(t *testing.T
 		}},
 	}
 
-	archive, err := hs.buildDashboardDiagnosticsArchive(context.Background(), &user.SignedInUser{OrgID: 1, UserUID: "u1"}, false, false, reqDTO, "job-1")
+	archive, _, err := hs.buildDashboardDiagnosticsArchive(context.Background(), &user.SignedInUser{OrgID: 1, UserUID: "u1"}, false, false, reqDTO, "job-1")
 	require.NoError(t, err)
 
 	files := readTarGzFiles(t, archive)
@@ -204,7 +205,7 @@ func TestBuildDashboardDiagnosticsArchive_recordsSubmittedQueryRequest(t *testin
 		}},
 	}
 
-	archive, err := hs.buildDashboardDiagnosticsArchive(context.Background(), &user.SignedInUser{OrgID: 1, UserUID: "u1"}, false, false, reqDTO, "job-querydata")
+	archive, _, err := hs.buildDashboardDiagnosticsArchive(context.Background(), &user.SignedInUser{OrgID: 1, UserUID: "u1"}, false, false, reqDTO, "job-querydata")
 	require.NoError(t, err)
 
 	files := readTarGzFiles(t, archive)
@@ -231,7 +232,7 @@ func TestBuildDashboardDiagnosticsArchive_queryV2Dispatch(t *testing.T) {
 		}},
 	}
 
-	_, err := hs.buildDashboardDiagnosticsArchive(context.Background(), &user.SignedInUser{OrgID: 1, UserUID: "u1"}, false, true, reqDTO, "job-2")
+	_, _, err := hs.buildDashboardDiagnosticsArchive(context.Background(), &user.SignedInUser{OrgID: 1, UserUID: "u1"}, false, true, reqDTO, "job-2")
 	require.NoError(t, err)
 }
 
@@ -277,7 +278,7 @@ func TestDiagnosticsJobStore_lifecycle(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, jobPending, state)
 
-	s.complete(job.UID, []byte("archive-bytes"))
+	s.complete(job.UID, []byte("archive-bytes"), diagnostics.BundleResult{})
 	archive, state, ok := s.archiveOf(job.UID, creator)
 	require.True(t, ok)
 	require.Equal(t, jobComplete, state)
@@ -310,7 +311,7 @@ func TestDiagnosticsJobStore_prune(t *testing.T) {
 	t.Run("evicts terminal jobs past the retention TTL", func(t *testing.T) {
 		s := &diagnosticsJobStore{jobs: map[string]*diagnosticsJob{}}
 		stale, _ := s.create(1, creator)
-		s.complete(stale.UID, []byte("done"))
+		s.complete(stale.UID, []byte("done"), diagnostics.BundleResult{})
 		// Retention is measured from finishedAt, so age that (not CreatedAt).
 		s.jobs[stale.UID].finishedAt = time.Now().Add(-diagnosticsJobRetention - time.Minute)
 
@@ -327,7 +328,7 @@ func TestDiagnosticsJobStore_prune(t *testing.T) {
 		s := &diagnosticsJobStore{jobs: map[string]*diagnosticsJob{}}
 		slow, _ := s.create(1, creator)
 		s.jobs[slow.UID].CreatedAt = time.Now().Add(-diagnosticsJobRetention - time.Hour) // long run
-		s.complete(slow.UID, []byte("done"))                                              // finishedAt = now
+		s.complete(slow.UID, []byte("done"), diagnostics.BundleResult{})                  // finishedAt = now
 
 		s.create(1, creator) // triggers pruneLocked
 		_, ok := s.snapshot(slow.UID, creator)
@@ -354,7 +355,7 @@ func TestDiagnosticsJobStore_prune(t *testing.T) {
 		var oldest string
 		for i := 0; i < diagnosticsJobMaxEntries; i++ {
 			j, _ := s.create(1, creator)
-			s.complete(j.UID, nil) // only terminal jobs count against the cap
+			s.complete(j.UID, nil, diagnostics.BundleResult{}) // only terminal jobs count against the cap
 			// Age them deterministically so eviction order is well-defined.
 			s.jobs[j.UID].CreatedAt = base.Add(time.Duration(i) * time.Second)
 			if i == 0 {
@@ -366,7 +367,7 @@ func TestDiagnosticsJobStore_prune(t *testing.T) {
 		// One more terminal job pushes over the cap and must evict exactly the oldest. complete()
 		// itself prunes, so no external sweep is needed.
 		newest, _ := s.create(1, creator)
-		s.complete(newest.UID, nil)
+		s.complete(newest.UID, nil, diagnostics.BundleResult{})
 		require.Len(t, s.jobs, diagnosticsJobMaxEntries)
 		_, ok := s.snapshot(oldest, creator)
 		require.False(t, ok, "oldest terminal job should have been evicted")
@@ -422,7 +423,7 @@ func TestDiagnosticsJobStore_prune(t *testing.T) {
 
 		// Completing it makes it terminal, pushing terminal jobs one over the cap; complete()'s own
 		// prune must bring the store back down without any create() being called.
-		s.complete("pending", nil)
+		s.complete("pending", nil, diagnostics.BundleResult{})
 		require.Len(t, s.jobs, diagnosticsJobMaxEntries, "complete() must evict down to the cap on its own")
 		require.Contains(t, s.jobs, "pending", "the just-completed job is the newest by finishedAt and must survive")
 	})
@@ -445,7 +446,7 @@ func TestDiagnosticsJobStore_prune(t *testing.T) {
 		require.Len(t, s.jobs, diagnosticsMaxInFlightJobs, "a rejected create must not add a job")
 
 		// Finishing one frees a slot, so a new create succeeds again.
-		s.complete(last.UID, nil)
+		s.complete(last.UID, nil, diagnostics.BundleResult{})
 		_, ok = s.create(1, creator)
 		require.True(t, ok, "a slot frees up once an in-flight job finishes")
 	})

--- a/pkg/api/ds_query_dashboard_diagnostics_test.go
+++ b/pkg/api/ds_query_dashboard_diagnostics_test.go
@@ -347,85 +347,110 @@ func TestDiagnosticsJobStore_prune(t *testing.T) {
 		require.True(t, ok, "a pending job must survive pruning regardless of age")
 	})
 
-	// Max-entries cap: a burst of finished jobs within the retention window still can't grow the
-	// store past the cap; the oldest terminal jobs are evicted first.
-	t.Run("evicts oldest terminal jobs beyond the max-entries cap", func(t *testing.T) {
-		s := &diagnosticsJobStore{jobs: map[string]*diagnosticsJob{}}
+	// Byte budget: a burst of finished jobs within the retention window can't grow the store past the
+	// retained-archive budget; the oldest terminal jobs are evicted first. A tiny per-store budget stands
+	// in for the real one, which is far larger than a test can afford to allocate.
+	t.Run("evicts oldest terminal jobs beyond the byte budget", func(t *testing.T) {
+		s := &diagnosticsJobStore{jobs: map[string]*diagnosticsJob{}, maxBytes: 300}
 		base := time.Now()
 		var oldest string
-		for i := 0; i < diagnosticsJobMaxEntries; i++ {
+		for i := 0; i < 3; i++ {
 			j, _ := s.create(1, creator)
-			s.complete(j.UID, nil, diagnostics.BundleResult{}) // only terminal jobs count against the cap
-			// Age them deterministically so eviction order is well-defined.
-			s.jobs[j.UID].CreatedAt = base.Add(time.Duration(i) * time.Second)
+			s.complete(j.UID, make([]byte, 100), diagnostics.BundleResult{})
+			s.jobs[j.UID].finishedAt = base.Add(time.Duration(i) * time.Second)
 			if i == 0 {
 				oldest = j.UID
 			}
 		}
-		require.Len(t, s.jobs, diagnosticsJobMaxEntries)
+		require.Len(t, s.jobs, 3, "three 100-byte archives exactly fill a 300-byte budget")
 
-		// One more terminal job pushes over the cap and must evict exactly the oldest. complete()
-		// itself prunes, so no external sweep is needed.
+		// A fourth pushes the total to 400 over a 300 budget, so exactly the oldest must go.
 		newest, _ := s.create(1, creator)
-		s.complete(newest.UID, nil, diagnostics.BundleResult{})
-		require.Len(t, s.jobs, diagnosticsJobMaxEntries)
+		s.complete(newest.UID, make([]byte, 100), diagnostics.BundleResult{})
+		require.Len(t, s.jobs, 3)
 		_, ok := s.snapshot(oldest, creator)
 		require.False(t, ok, "oldest terminal job should have been evicted")
 		_, ok = s.snapshot(newest.UID, creator)
 		require.True(t, ok, "newest job should remain")
 	})
 
-	// Max-entries eviction orders by finishedAt, not CreatedAt: a slow run created long ago but
-	// finished most recently is the freshest result and must survive, while a run created recently but
-	// finished earliest is the one to evict. Ordering by CreatedAt would 404 the just-finished bundle.
-	t.Run("evicts oldest by finishedAt not CreatedAt beyond the cap", func(t *testing.T) {
-		s := &diagnosticsJobStore{jobs: map[string]*diagnosticsJob{}}
+	// Eviction frees only as much as it must: one large archive can displace several small ones, and a
+	// count-based cap could not express that.
+	t.Run("evicts by bytes rather than by job count", func(t *testing.T) {
+		// 380 retained against 330: dropping the oldest 50 is enough, so the second small job survives.
+		s := &diagnosticsJobStore{jobs: map[string]*diagnosticsJob{}, maxBytes: 330}
+		base := time.Now()
+		add := func(uid string, size int, finished time.Time) {
+			s.jobs[uid] = &diagnosticsJob{
+				UID: uid, State: jobComplete, finishedAt: finished, archive: make([]byte, size),
+				createdByOrgID: creator.GetOrgID(), createdByUID: creator.GetUID(),
+			}
+		}
+		add("small-1", 50, base)
+		add("small-2", 50, base.Add(time.Second))
+		add("big", 280, base.Add(2*time.Second))
+
+		s.pruneLocked(base.Add(3 * time.Second))
+		require.NotContains(t, s.jobs, "small-1", "the oldest goes first")
+		require.Contains(t, s.jobs, "small-2", "eviction stops as soon as the rest fit")
+		require.Contains(t, s.jobs, "big")
+	})
+
+	// Eviction orders by finishedAt, not CreatedAt: a slow run created long ago but finished most
+	// recently is the freshest result and must survive, while a run created recently but finished
+	// earliest is the one to evict. Ordering by CreatedAt would 404 the just-finished bundle.
+	t.Run("evicts oldest by finishedAt not CreatedAt", func(t *testing.T) {
+		s := &diagnosticsJobStore{jobs: map[string]*diagnosticsJob{}, maxBytes: 200}
 		base := time.Now()
 		add := func(uid string, created, finished time.Time) {
 			s.jobs[uid] = &diagnosticsJob{
-				UID:            uid,
-				State:          jobComplete,
-				CreatedAt:      created,
-				finishedAt:     finished,
-				createdByOrgID: creator.GetOrgID(),
-				createdByUID:   creator.GetUID(),
+				UID: uid, State: jobComplete, CreatedAt: created, finishedAt: finished,
+				archive:        make([]byte, 100),
+				createdByOrgID: creator.GetOrgID(), createdByUID: creator.GetUID(),
 			}
 		}
-		// Fill exactly to the cap with baseline terminal jobs all finished at base.
-		for i := 0; i < diagnosticsJobMaxEntries; i++ {
-			add(fmt.Sprintf("fill-%d", i), base, base)
-		}
+		add("fill", base, base)
 		add("slow-but-fresh", base.Add(-time.Hour), base.Add(time.Minute))  // oldest CreatedAt, newest finishedAt
 		add("quick-but-stale", base.Add(time.Hour), base.Add(-time.Minute)) // newest CreatedAt, oldest finishedAt
 
-		s.pruneLocked(base.Add(2 * time.Minute)) // cap+2 terminal jobs -> evict the 2 oldest by finishedAt
-		require.Len(t, s.jobs, diagnosticsJobMaxEntries)
+		s.pruneLocked(base.Add(2 * time.Minute)) // 300 retained over a 200 budget
 		require.Contains(t, s.jobs, "slow-but-fresh",
 			"a job finished most recently must survive even if created long ago")
 		require.NotContains(t, s.jobs, "quick-but-stale",
 			"a job finished earliest must be evicted even if created most recently")
 	})
 
-	// Pruning must also happen when a job goes terminal, not only on create: if the store is already
-	// at the cap and one more job completes, complete() itself must evict down to the cap with no
-	// intervening create(). The store is built directly (bypassing create/complete) so the cap is only
-	// exercised by the single complete() under test.
-	t.Run("enforces the cap on complete without a later create", func(t *testing.T) {
-		s := &diagnosticsJobStore{jobs: map[string]*diagnosticsJob{}}
+	// The newest terminal job is never evicted, even alone over budget: it is the result the caller is
+	// about to download, and its size is already bounded by diagnostics.MaxBundleBytes.
+	t.Run("keeps the newest job even when it alone exceeds the budget", func(t *testing.T) {
+		s := &diagnosticsJobStore{jobs: map[string]*diagnosticsJob{}, maxBytes: 100}
 		base := time.Now()
-		for i := 0; i < diagnosticsJobMaxEntries; i++ {
-			uid := fmt.Sprintf("term-%d", i)
-			s.jobs[uid] = &diagnosticsJob{UID: uid, State: jobComplete, finishedAt: base}
-		}
-		// One extra in-flight job, also built directly so no prune has run yet.
-		s.jobs["pending"] = &diagnosticsJob{UID: "pending", State: jobPending, CreatedAt: base}
-		require.Len(t, s.jobs, diagnosticsJobMaxEntries+1)
+		s.jobs["old"] = &diagnosticsJob{UID: "old", State: jobComplete, finishedAt: base, archive: make([]byte, 50)}
+		s.jobs["huge"] = &diagnosticsJob{UID: "huge", State: jobComplete, finishedAt: base.Add(time.Second), archive: make([]byte, 5000)}
 
-		// Completing it makes it terminal, pushing terminal jobs one over the cap; complete()'s own
-		// prune must bring the store back down without any create() being called.
-		s.complete("pending", nil, diagnostics.BundleResult{})
-		require.Len(t, s.jobs, diagnosticsJobMaxEntries, "complete() must evict down to the cap on its own")
+		s.pruneLocked(base.Add(2 * time.Second))
+		require.NotContains(t, s.jobs, "old")
+		require.Contains(t, s.jobs, "huge", "the freshest result must survive rather than 404 a finished generation")
+	})
+
+	// Pruning must also happen when a job goes terminal, not only on create: if the store is already at
+	// the budget and one more job completes, complete() itself must evict with no intervening create().
+	t.Run("enforces the budget on complete without a later create", func(t *testing.T) {
+		s := &diagnosticsJobStore{jobs: map[string]*diagnosticsJob{}, maxBytes: 200}
+		base := time.Now()
+		for i := 0; i < 2; i++ {
+			uid := fmt.Sprintf("term-%d", i)
+			s.jobs[uid] = &diagnosticsJob{UID: uid, State: jobComplete, finishedAt: base.Add(time.Duration(i) * time.Second), archive: make([]byte, 100)}
+		}
+		// One extra in-flight job, built directly so no prune has run yet.
+		s.jobs["pending"] = &diagnosticsJob{UID: "pending", State: jobPending, CreatedAt: base}
+		require.Len(t, s.jobs, 3)
+
+		// Completing it adds 100 bytes over a 200 budget; complete()'s own prune must evict the oldest.
+		s.complete("pending", make([]byte, 100), diagnostics.BundleResult{})
+		require.Len(t, s.jobs, 2, "complete() must evict down to the budget on its own")
 		require.Contains(t, s.jobs, "pending", "the just-completed job is the newest by finishedAt and must survive")
+		require.NotContains(t, s.jobs, "term-0", "the oldest terminal job is the one evicted")
 	})
 
 	// In-flight cap: only diagnosticsMaxInFlightJobs generations may be pending at once. Further

--- a/pkg/api/ds_query_diagnostics.go
+++ b/pkg/api/ds_query_diagnostics.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/open-feature/go-sdk/openfeature"
@@ -111,7 +112,7 @@ func (hs *HTTPServer) QueryDiagnostics(c *contextmodel.ReqContext) response.Resp
 	}
 	refs := panelEnvironmentRefs(reqDTO.MetricRequest, reqDTO.Panel)
 	env := diagnostics.CollectEnvironment(ctx, hs.Cfg, hs.pluginStore, refs)
-	bundle, err := diagnostics.NewBundler(env).Build(resp, harBuffer, reqDTO.Panel, reqDTO.Dashboard, queryRequestJSON, marshalErr, bundleErr,
+	bundle, result, err := diagnostics.NewBundler(env).Build(resp, harBuffer, reqDTO.Panel, reqDTO.Dashboard, queryRequestJSON, marshalErr, bundleErr,
 		diagnostics.WithPanelData(reqDTO.PanelData))
 	if err != nil {
 		return response.Error(http.StatusInternalServerError, "failed to build diagnostics bundle", err)
@@ -121,8 +122,18 @@ func (hs *HTTPServer) QueryDiagnostics(c *contextmodel.ReqContext) response.Resp
 	header := http.Header{}
 	header.Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
 	header.Set("Content-Type", "application/tar+gzip")
+	// The body is a download, so a partial bundle cannot be reported in it: the drawer would have to
+	// unpack the archive to find bundle-limit.txt. A header carries it instead, on the same response as
+	// the bundle the caller is already receiving. The bundle still ships -- what fitted is worth having.
+	if result.Partial() {
+		header.Set(diagnosticsPartialHeader, strconv.Itoa(len(result.Dropped)))
+	}
 	return response.CreateNormalResponse(header, bundle, http.StatusOK)
 }
+
+// diagnosticsPartialHeader names how many artifacts the bundle size limit dropped. Absent means the
+// bundle is complete; the names are in the bundle's own bundle-limit.txt.
+const diagnosticsPartialHeader = "X-Diagnostics-Dropped-Artifacts"
 
 // diagnosticsNoCaptureError returns the response to send when a query failed and nothing was
 // captured — there is no traffic to diagnose, so surface the failure with the same status

--- a/pkg/infra/httpclient/harcapture/harcapture.go
+++ b/pkg/infra/httpclient/harcapture/harcapture.go
@@ -74,6 +74,31 @@ func (b *Buffer) Len() int {
 	return len(b.entries)
 }
 
+// RetainedBytes returns roughly how much body text this buffer holds: the sum of captured request and
+// response bodies. Thread-safe.
+//
+// An estimate, deliberately. It counts the bodies, which dominate, and ignores headers, URLs and
+// timings; nor is it the length of the serialized HAR, which JSON escaping and base64 inflate. It
+// exists so a caller running many captures can learn how much it has accumulated WITHOUT serializing
+// each one -- serializing to find out would allocate the very copy such a caller is trying to avoid.
+func (b *Buffer) RetainedBytes() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	total := 0
+	for _, e := range b.entries {
+		if e == nil {
+			continue
+		}
+		if e.Request != nil && e.Request.PostData != nil {
+			total += len(e.Request.PostData.Text)
+		}
+		if e.Response != nil && e.Response.Content != nil {
+			total += len(e.Response.Content.Text)
+		}
+	}
+	return total
+}
+
 // ToHAR serializes the captured entries to HAR 1.2 JSON. The entry types come from
 // github.com/chromedp/cdproto/har -- the same library the plugin SDK's e2e HAR storage uses -- so
 // the output stays replay-compatible with that fixture format.

--- a/pkg/infra/httpclient/harcapture/harcapture_test.go
+++ b/pkg/infra/httpclient/harcapture/harcapture_test.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -275,4 +277,22 @@ func (r *partialThenErrorReader) Read(p []byte) (int, error) {
 		return n, nil
 	}
 	return 0, r.err
+}
+
+func TestBuffer_RetainedBytes(t *testing.T) {
+	buf := &Buffer{}
+	require.Zero(t, buf.RetainedBytes(), "an empty buffer retains nothing")
+
+	body := strings.Repeat("x", 4096)
+	req := httptest.NewRequest(http.MethodPost, "http://example.com/api", strings.NewReader(body))
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+	buf.AddEntry(req, resp, nil, time.Now(), time.Millisecond)
+
+	// Bodies only, so the count tracks the request plus the response and ignores headers and URLs.
+	require.GreaterOrEqual(t, buf.RetainedBytes(), 2*len(body),
+		"both bodies must be counted so a caller can see what it has accumulated")
 }

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -27,16 +27,74 @@ type Bundler struct {
 	env *Environment
 }
 
-// Query responses can contain substantially more data than the diagnostic traffic itself. Keep
-// their uncompressed JSON bounded independently so adding querydata.json cannot multiply a large
-// panel/dashboard archive without an explicit truncation marker.
-const (
-	maxQueryDataArtifactBytes  = 8 << 20
-	maxDashboardQueryDataBytes = 32 << 20
-	// minQueryDataArtifactBytes is the smallest budget worth attempting: below it not even a truncated
-	// artifact (version + omission markers) fits, so the panel's query data is skipped up front.
-	minQueryDataArtifactBytes = 256
-)
+// MaxBundleBytes is the total uncompressed artifact bytes one diagnostic bundle may hold -- the single
+// size limit on the feature. Exported because the dashboard generation loop in pkg/api enforces the
+// same number against its running captures before starting each panel; assembly alone is too late,
+// since that loop holds every panel's capture in memory before the bundler ever sees it.
+//
+// It is a memory figure, not a disk one. Assembly holds every artifact in a map, gzips them into a
+// second in-memory buffer, and the dashboard job store retains the result.
+//
+// What it does and does not promise: the artifact total is honoured exactly, and dashboard generation
+// stops adding panels once its captures reach this much. Peak process memory is still not held to it,
+// because a panel's response and capture are resident before either check can weigh them, and
+// marshalling a response allocates its full JSON. Bounding peak memory too needs a cap on the
+// in-process capture itself, plus the archive spooled to a temp file rather than assembled in RAM.
+const MaxBundleBytes = 1 << 30 // 1 GiB
+
+// bundleBudget accumulates a bundle's artifacts against MaxBundleBytes.
+//
+// Artifacts are offered whole: one that would overrun the budget is dropped rather than clipped,
+// because half a JSON document or a truncated HAR diagnoses nothing, and every drop is named -- in
+// bundle-limit.txt for the reader and in BundleResult for the caller -- so a missing artifact is never
+// mistaken for "there was nothing to capture". Call order is therefore priority order: whatever is
+// added first is what survives a bundle that hits the ceiling.
+type bundleBudget struct {
+	files     map[string][]byte
+	remaining int
+	dropped   []string
+}
+
+func newBundleBudget() *bundleBudget {
+	return &bundleBudget{files: map[string][]byte{}, remaining: MaxBundleBytes}
+}
+
+// add offers data to the bundle under name, reporting whether it fitted. Empty data is skipped, so
+// callers don't each need a length check before offering an optional artifact.
+func (b *bundleBudget) add(name string, data []byte) bool {
+	if len(data) == 0 {
+		return true
+	}
+	if len(data) > b.remaining {
+		b.dropped = append(b.dropped, fmt.Sprintf("%s (%d bytes, %d remaining)", name, len(data), b.remaining))
+		return false
+	}
+	b.remaining -= len(data)
+	b.files[name] = data
+	return true
+}
+
+// finish records what the ceiling cost, then assembles the archive. bundle-limit.txt is written
+// outside the budget: it is a few hundred bytes, and a bundle that silently lost its largest artifact
+// is worse than one marginally over the ceiling.
+func (b *bundleBudget) finish() ([]byte, BundleResult, error) {
+	if len(b.dropped) > 0 {
+		b.files["bundle-limit.txt"] = []byte(fmt.Sprintf(
+			"bundle size limit: %d bytes\nartifacts dropped because they did not fit:\n  %s\n",
+			MaxBundleBytes, strings.Join(b.dropped, "\n  ")))
+	}
+	archive, err := buildTarGz(b.files)
+	return archive, BundleResult{Dropped: b.dropped}, err
+}
+
+// BundleResult reports what the size limit cost this bundle, so the HTTP layer can tell the caller
+// whether what they are downloading is complete.
+type BundleResult struct {
+	Dropped []string
+}
+
+// Partial reports whether the size limit dropped anything.
+func (r BundleResult) Partial() bool { return len(r.Dropped) > 0 }
 
 // queryDataArtifactVersion is the schema version stamped into every querydata.json (including its
 // truncated fallbacks) so a reader can tell how to interpret the artifact.
@@ -49,12 +107,12 @@ func NewBundler(env *Environment) *Bundler {
 
 // addEnvironment writes environment.json, if there is one. A marshal failure drops this artifact
 // alone rather than the captured traffic with it, as for manifest.json.
-func (b *Bundler) addEnvironment(files map[string][]byte) {
+func (b *Bundler) addEnvironment(budget *bundleBudget) {
 	if b == nil || b.env == nil {
 		return
 	}
 	if data, err := json.MarshalIndent(b.env, "", "  "); err == nil {
-		files["environment.json"] = data
+		budget.add("environment.json", data)
 	}
 }
 
@@ -88,20 +146,15 @@ type buildConfig struct {
 // is a well-formed payload of the wrong shape. This is an experimental, admin-only, on-prem-gated
 // feature.
 //
-// Size is the one failure this does NOT contain, and it is the client's to bound: web.MaxBindBodyBytes
-// caps the whole REQUEST (at 100MiB) rather than this field, so a payload past it fails web.Bind before
-// Build runs and costs the caller the entire bundle instead of just this artifact. Bounding it is
-// intentionally postponed.
+// Size is the one failure this does NOT contain on the way in, and it is the client's to bound:
+// web.MaxBindBodyBytes caps the whole REQUEST (at 100MiB) rather than this field, so a payload past it
+// fails web.Bind before Build runs and costs the caller the entire bundle instead of just this
+// artifact. Bounding it client-side is intentionally postponed.
 //
-// Leaving it uncapped is also deliberately asymmetric with querydata.json, which IS capped
-// (maxQueryDataArtifactBytes) and degrades to a frame summary above it. Matching that cap would cost
-// the common case a complete diff to make the rare oversized one symmetric.
-//
-// Note for whoever adds the client-side bound: that reasoning only holds BELOW
-// maxQueryDataArtifactBytes. Past it querydata.json is already a frame summary, so a complete
-// paneldata.json has no fields left to be diffed against -- only frame and row counts -- and the
-// uncapped side stops buying a complete diff exactly where the payload is heaviest. Pick the two caps
-// together rather than independently.
+// Once here it is bounded like every other artifact -- by the bundle budget, which drops it whole and
+// names it in bundle-limit.txt if it does not fit. It is offered last of the three bulk artifacts
+// because it is only meaningful diffed against querydata.json: keeping it while querydata.json was
+// dropped would leave nothing to diff it against.
 func WithPanelData(panelData json.RawMessage) BuildOption {
 	return func(cfg *buildConfig) {
 		cfg.panelData = panelData
@@ -114,14 +167,20 @@ func WithPanelData(panelData json.RawMessage) BuildOption {
 //
 // Server logs are intentionally omitted because they are not scoped to this request and would leak
 // unrelated activity into a bundle meant for external sharing; they will be tackled in a follow-up.
-func (b *Bundler) Build(resp *backend.QueryDataResponse, harBuffer *harcapture.Buffer, panelJSON, dashboardJSON, queryRequestJSON json.RawMessage, queryRequestErr, queryErr error, opts ...BuildOption) ([]byte, error) {
-	files := map[string][]byte{}
-	b.addEnvironment(files)
-
+//
+// Artifacts are added smallest-and-most-explanatory first so that a bundle which hits MaxBundleBytes
+// still says what happened: the error text and the panel/dashboard definitions are kilobytes and
+// always survive, and the ceiling falls on the three bulk artifacts. Among those, traffic.har goes
+// first -- it is the evidence the bundle exists for -- then querydata.json, then paneldata.json, which
+// is only meaningful diffed against querydata.json anyway.
+func (b *Bundler) Build(resp *backend.QueryDataResponse, harBuffer *harcapture.Buffer, panelJSON, dashboardJSON, queryRequestJSON json.RawMessage, queryRequestErr, queryErr error, opts ...BuildOption) ([]byte, BundleResult, error) {
 	cfg := buildConfig{}
 	for _, opt := range opts {
 		opt(&cfg)
 	}
+
+	budget := newBundleBudget()
+	b.addEnvironment(budget)
 
 	// queryRequestErr is the caller's failure to serialize the request into queryRequestJSON. Record it
 	// so a support engineer can tell the request JSON was omitted because serialization failed rather
@@ -130,55 +189,49 @@ func (b *Bundler) Build(resp *backend.QueryDataResponse, harBuffer *harcapture.B
 	if queryRequestErr != nil {
 		queryDataErr = fmt.Errorf("serialize query request: %w", queryRequestErr)
 	}
+	var queryData []byte
 	if resp != nil || len(queryRequestJSON) > 0 {
-		queryData, err := marshalQueryDataArtifact(queryRequestJSON, resp)
+		var err error
+		queryData, err = marshalQueryDataArtifact(queryRequestJSON, resp)
 		if err != nil {
 			// A query-data artifact that cannot be fully JSON-encoded must not sink the whole bundle:
 			// record the failure and still ship HAR and the other artifacts, mirroring how the dashboard
 			// path degrades per panel via manifest.queryDataError.
 			queryDataErr = errors.Join(queryDataErr, err)
 		}
-		// An unencodable response still leaves a degraded artifact (request plus frame summary), so ship
-		// whatever survived rather than discarding it along with the error.
-		if len(queryData) > 0 {
-			files["querydata.json"] = queryData
-		}
-	}
-	if queryDataErr != nil {
-		files["querydata-error.txt"] = []byte(queryDataErr.Error() + "\n")
 	}
 
 	har, err := collectHAR(resp, harBuffer)
 	if err != nil {
-		return nil, err
-	}
-	if len(har) > 0 {
-		files["traffic.har"] = har
-	}
-
-	// A bare "null" is 4 bytes of valid JSON, so it clears a length check: treat it as not supplied
-	// rather than bundling an artifact whose whole content reads as "the frontend was holding no
-	// frames". A real capture of zero frames ({"version":1,"frames":[]}) still ships -- that one IS a
-	// frontend loss worth seeing, and it must not collapse into "the client had nothing to send".
-	if panelData := bytes.TrimSpace(cfg.panelData); len(panelData) > 0 && !bytes.Equal(panelData, []byte("null")) {
-		// Stored as sent, not indented -- see WithPanelData for why.
-		files["paneldata.json"] = panelData
-	}
-
-	if len(panelJSON) > 0 {
-		files["panel.json"] = indentJSON(panelJSON)
-	}
-	if len(dashboardJSON) > 0 {
-		files["dashboard.json"] = indentJSON(dashboardJSON)
+		return nil, BundleResult{}, err
 	}
 
 	if queryErr != nil {
 		// Recorded verbatim -- redaction is intentionally deferred for this experimental feature
 		// (see the harcapture package doc); the error text can embed a request URL with credentials.
-		files["query-error.txt"] = []byte(queryErr.Error() + "\n")
+		budget.add("query-error.txt", []byte(queryErr.Error()+"\n"))
+	}
+	if queryDataErr != nil {
+		budget.add("querydata-error.txt", []byte(queryDataErr.Error()+"\n"))
+	}
+	budget.add("panel.json", indentJSON(panelJSON))
+	budget.add("dashboard.json", indentJSON(dashboardJSON))
+
+	budget.add("traffic.har", har)
+	// An unencodable response still leaves a degraded artifact (request plus frame summary), so ship
+	// whatever survived rather than discarding it along with the error.
+	budget.add("querydata.json", queryData)
+
+	// A bare "null" is 4 bytes of valid JSON, so it clears a length check: treat it as not supplied
+	// rather than bundling an artifact whose whole content reads as "the frontend was holding no
+	// frames". A real capture of zero frames ({"version":1,"frames":[]}) still ships -- that one IS a
+	// frontend loss worth seeing, and it must not collapse into "the client had nothing to send".
+	if panelData := bytes.TrimSpace(cfg.panelData); !bytes.Equal(panelData, []byte("null")) {
+		// Stored as sent, not indented -- see WithPanelData for why.
+		budget.add("paneldata.json", panelData)
 	}
 
-	return buildTarGz(files)
+	return budget.finish()
 }
 
 type queryDataArtifact struct {
@@ -186,13 +239,10 @@ type queryDataArtifact struct {
 	Request         json.RawMessage                     `json:"request,omitempty"`
 	Response        json.RawMessage                     `json:"response,omitempty"`
 	ResponseSummary map[string]queryDataResponseSummary `json:"responseSummary,omitempty"`
-	// ResponseError records why the full response is missing when it could not be JSON-encoded, so a
-	// reader can tell an unencodable response from one that was dropped to fit the size cap.
+	// ResponseError records why the full response is missing when it could not be JSON-encoded. Size is
+	// no longer a reason for it to be missing: an artifact too large for the bundle is dropped whole and
+	// named in bundle-limit.txt, so this field means "unencodable", nothing else.
 	ResponseError   string `json:"responseError,omitempty"`
-	Truncated       bool   `json:"truncated,omitempty"`
-	LimitBytes      int    `json:"limitBytes,omitempty"`
-	OriginalBytes   int    `json:"originalBytes,omitempty"`
-	RequestOmitted  bool   `json:"requestOmitted,omitempty"`
 	ResponseOmitted bool   `json:"responseOmitted,omitempty"`
 }
 
@@ -211,95 +261,35 @@ type queryDataFrameSummary struct {
 	Fields int    `json:"fields"`
 }
 
+// marshalQueryDataArtifact encodes querydata.json in full. Size is not its concern: the bundle budget
+// weighs the result and drops it whole if it does not fit, which is why the progressive-truncation
+// ladder this function used to carry is gone.
 func marshalQueryDataArtifact(request json.RawMessage, resp *backend.QueryDataResponse) ([]byte, error) {
-	data, _, err := marshalQueryDataArtifactWithLimit(request, resp, maxQueryDataArtifactBytes)
-	return data, err
-}
-
-// marshalQueryDataArtifactWithLimit returns the encoded querydata.json plus whether it had to drop
-// content to fit maxBytes, so callers don't have to re-parse the result to learn that.
-func marshalQueryDataArtifactWithLimit(request json.RawMessage, resp *backend.QueryDataResponse, maxBytes int) ([]byte, bool, error) {
 	artifact := queryDataArtifact{Version: queryDataArtifactVersion, Request: request}
 	if resp != nil {
-		// The SDK encoder returns a complete byte slice. The artifact/archive is bounded below, but
-		// serializing an oversized response can still temporarily allocate its full JSON size.
 		responseJSON, err := queryDataResponseWithoutCaptureFrames(resp).MarshalJSON()
 		if err != nil {
 			// A response that cannot be encoded (e.g. an unserializable value in a frame's Meta.Custom)
-			// usually still has a serializable request beside it. Degrade to the same request + summary
-			// shape the size cap uses instead of dropping both -- losing the submitted query in exactly
-			// the hard-to-encode cases this artifact exists to capture defeats its purpose.
+			// usually still has a serializable request beside it. Degrade to a request + frame summary
+			// instead of dropping both -- losing the submitted query in exactly the hard-to-encode cases
+			// this artifact exists to capture defeats its purpose.
 			//
 			// The error is returned as well, so both callers record it outside the artifact
-			// (querydata-error.txt, manifest.queryDataError). That makes the embedded copy a convenience:
-			// bound it by the budget so a verbose plugin error cannot crowd out the request, which is
-			// recorded nowhere else.
-			out, fallbackErr := fitQueryDataArtifact(queryDataArtifact{
+			// (querydata-error.txt, manifest.queryDataError); the embedded copy is a convenience.
+			out, fallbackErr := json.MarshalIndent(queryDataArtifact{
 				Version:         queryDataArtifactVersion,
+				Request:         request,
 				ResponseSummary: summarizeQueryDataResponse(resp),
-				ResponseError:   truncateDiagnosticString(err.Error(), min(1024, maxBytes/4)),
+				ResponseError:   err.Error(),
 				ResponseOmitted: true,
-			}, request, maxBytes)
+			}, "", "  ")
 			if fallbackErr != nil {
-				return nil, false, errors.Join(err, fallbackErr)
+				return nil, errors.Join(err, fallbackErr)
 			}
-			return out, false, err
+			return out, err
 		}
 		artifact.Response = responseJSON
 	}
-	full, err := json.MarshalIndent(artifact, "", "  ")
-	if err != nil || len(full) <= maxBytes {
-		return full, false, err
-	}
-
-	out, err := fitQueryDataArtifact(queryDataArtifact{
-		Version:         queryDataArtifactVersion,
-		ResponseSummary: summarizeQueryDataResponse(resp),
-		Truncated:       true,
-		LimitBytes:      maxBytes,
-		OriginalBytes:   len(full),
-		ResponseOmitted: resp != nil,
-	}, request, maxBytes)
-	return out, true, err
-}
-
-// fitQueryDataArtifact encodes artifact with progressively less content -- request kept, request
-// omitted, summary dropped, then markers only -- and returns the first encoding within maxBytes. The
-// last rung holds only fixed-size markers, which keeps it under minQueryDataArtifactBytes so the
-// budget gate in BuildDashboard stays meaningful; it is returned even when it somehow still doesn't
-// fit, because there is nothing further to drop, and callers enforcing a hard budget re-check length.
-func fitQueryDataArtifact(artifact queryDataArtifact, request json.RawMessage, maxBytes int) ([]byte, error) {
-	artifact.Request = request
-	out, err := json.MarshalIndent(artifact, "", "  ")
-	if err != nil {
-		return nil, err
-	}
-	if len(out) <= maxBytes {
-		return out, nil
-	}
-
-	artifact.Request = nil
-	artifact.RequestOmitted = len(request) > 0
-	out, err = json.MarshalIndent(artifact, "", "  ")
-	if err != nil {
-		return nil, err
-	}
-	if len(out) <= maxBytes {
-		return out, nil
-	}
-
-	artifact.ResponseSummary = nil
-	out, err = json.MarshalIndent(artifact, "", "  ")
-	if err != nil {
-		return nil, err
-	}
-	if len(out) <= maxBytes {
-		return out, nil
-	}
-
-	// ResponseError goes last: it is the only remaining field without a fixed size, and the same failure
-	// is recorded outside the artifact, so dropping it leaves markers a reader can still act on.
-	artifact.ResponseError = ""
 	return json.MarshalIndent(artifact, "", "  ")
 }
 
@@ -329,7 +319,7 @@ func summarizeQueryDataResponse(resp *backend.QueryDataResponse) map[string]quer
 			ErrorSource: response.ErrorSource,
 		}
 		if response.Error != nil {
-			summary.Error = truncateDiagnosticString(response.Error.Error(), 1024)
+			summary.Error = response.Error.Error()
 		}
 		for _, frame := range response.Frames {
 			if frame == nil {
@@ -416,20 +406,17 @@ type manifestPanelEntry struct {
 //
 // Like Build, captured traffic and error text are recorded VERBATIM -- redaction is intentionally
 // deferred (see the harcapture package doc) -- and server logs are omitted (not request-scoped).
-func (b *Bundler) BuildDashboard(dashboardJSON json.RawMessage, panels []DashboardPanel) ([]byte, error) {
+func (b *Bundler) BuildDashboard(dashboardJSON json.RawMessage, panels []DashboardPanel) ([]byte, BundleResult, error) {
 	manifest := dashboardManifest{
 		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
 		PanelsTotal: len(panels),
 	}
 
-	files := map[string][]byte{}
-	b.addEnvironment(files)
-	if len(dashboardJSON) > 0 {
-		files["dashboard.json"] = indentJSON(dashboardJSON)
-	}
+	budget := newBundleBudget()
+	b.addEnvironment(budget)
+	budget.add("dashboard.json", indentJSON(dashboardJSON))
 
 	usedDirs := map[string]bool{}
-	queryDataBytesRemaining := maxDashboardQueryDataBytes
 	panelJSONByID := indexPanelJSON(dashboardJSON)
 	for _, p := range panels {
 		entry := manifestPanelEntry{ID: p.ID, Title: p.Title, Datasources: p.Datasources, PluginIDs: p.PluginIDs}
@@ -448,46 +435,23 @@ func (b *Bundler) BuildDashboard(dashboardJSON json.RawMessage, panels []Dashboa
 		if len(panelJSON) == 0 {
 			panelJSON = panelJSONByID[p.ID]
 		}
-		if len(panelJSON) > 0 {
-			files[dir+"/panel.json"] = indentJSON(panelJSON)
-		}
+		budget.add(dir+"/panel.json", indentJSON(panelJSON))
 		// A panel can hit more than one query-data problem: an unserializable request still leaves a
-		// response to encode, which can itself fail or exhaust the dashboard budget. Collect them all so
-		// a later failure doesn't hide the request-serialize failure that explains the missing request --
-		// the single-panel Build path joins the same combination into querydata-error.txt.
+		// response to encode, which can itself fail. Collect them all so a later failure doesn't hide the
+		// request-serialize failure that explains the missing request -- the single-panel Build path joins
+		// the same combination into querydata-error.txt.
 		var queryDataErrs []string
 		if p.QueryRequestErr != nil {
 			queryDataErrs = append(queryDataErrs, "serialize query request: "+p.QueryRequestErr.Error())
 		}
+		var queryData []byte
 		if p.Resp != nil || len(p.QueryRequest) > 0 {
-			queryDataLimit := min(maxQueryDataArtifactBytes, queryDataBytesRemaining)
-			if queryDataLimit < minQueryDataArtifactBytes {
-				entry.QueryDataTruncated = true
-				queryDataErrs = append(queryDataErrs, fmt.Sprintf("remaining dashboard query-data budget (%d bytes) below the %d-byte minimum artifact size", queryDataBytesRemaining, minQueryDataArtifactBytes))
-			} else {
-				queryData, truncated, err := marshalQueryDataArtifactWithLimit(p.QueryRequest, p.Resp, queryDataLimit)
-				if err != nil {
-					queryDataErrs = append(queryDataErrs, err.Error())
-				}
-				// An unencodable response still leaves a degraded artifact (request plus frame summary),
-				// so write whatever survived instead of discarding it along with the error.
-				switch {
-				case len(queryData) == 0:
-					// Nothing survived the failure; the error above is the whole record.
-				case len(queryData) > queryDataLimit:
-					entry.QueryDataTruncated = true
-					queryDataErrs = append(queryDataErrs, "query-data artifact exceeded its assigned dashboard budget")
-				default:
-					files[dir+"/querydata.json"] = queryData
-					entry.QueryDataBytes = len(queryData)
-					queryDataBytesRemaining -= len(queryData)
-					entry.QueryDataTruncated = truncated
-				}
+			var err error
+			queryData, err = marshalQueryDataArtifact(p.QueryRequest, p.Resp)
+			if err != nil {
+				queryDataErrs = append(queryDataErrs, err.Error())
 			}
 		}
-		// Joined with "; " rather than errors.Join's newline so the manifest keeps one readable line per
-		// panel instead of embedded \n escapes.
-		entry.QueryDataError = strings.Join(queryDataErrs, "; ")
 
 		// A single panel's capture that fails to serialize must not sink the whole multi-panel bundle:
 		// record it against this panel in the manifest and keep everything else (dashboard.json, the
@@ -495,26 +459,44 @@ func (b *Bundler) BuildDashboard(dashboardJSON json.RawMessage, panels []Dashboa
 		har, err := collectHAR(p.Resp, p.HARBuffer)
 		if err != nil {
 			entry.CaptureError = err.Error()
-		} else if len(har) > 0 {
-			files[dir+"/traffic.har"] = har
-			entry.HARBytes = len(har)
 		}
 
 		if p.QueryErr != nil {
 			entry.Error = p.QueryErr.Error()
-			files[dir+"/query-error.txt"] = []byte(p.QueryErr.Error() + "\n")
+			budget.add(dir+"/query-error.txt", []byte(p.QueryErr.Error()+"\n"))
 		} else {
 			manifest.PanelsRun++
 		}
 
+		// Bulk artifacts last, and traffic before query data, matching Build's priority order: with one
+		// budget shared across every panel, whichever panel is assembled first spends it first. Early
+		// panels can therefore exhaust it and later ones record only their manifest entry -- the drops are
+		// listed in bundle-limit.txt, and the per-panel byte counts below stay honest about what landed.
+		if budget.add(dir+"/traffic.har", har) {
+			entry.HARBytes = len(har)
+		} else {
+			entry.QueryDataTruncated = true
+		}
+		if budget.add(dir+"/querydata.json", queryData) {
+			entry.QueryDataBytes = len(queryData)
+		} else {
+			entry.QueryDataTruncated = true
+			queryDataErrs = append(queryDataErrs, "dropped: bundle size limit reached")
+		}
+
+		// Joined with "; " rather than errors.Join's newline so the manifest keeps one readable line per
+		// panel instead of embedded \n escapes.
+		entry.QueryDataError = strings.Join(queryDataErrs, "; ")
 		manifest.Panels = append(manifest.Panels, entry)
 	}
 
+	// Outside the budget, like bundle-limit.txt: the manifest is the index a reader needs to interpret
+	// everything else, and it is the one artifact whose absence makes the rest ambiguous.
 	if manifestJSON, err := json.MarshalIndent(manifest, "", "  "); err == nil {
-		files["manifest.json"] = manifestJSON
+		budget.files["manifest.json"] = manifestJSON
 	}
 
-	return buildTarGz(files)
+	return budget.finish()
 }
 
 // indexPanelJSON indexes the raw panel JSON from v1 and v2 dashboard save models by panel id.

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -17,6 +17,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 
 	"github.com/grafana/grafana/pkg/infra/httpclient/harcapture"
 )
@@ -35,11 +36,15 @@ type Bundler struct {
 // It is a memory figure, not a disk one. Assembly holds every artifact in a map, gzips them into a
 // second in-memory buffer, and the dashboard job store retains the result.
 //
-// What it does and does not promise: the artifact total is honoured exactly, and dashboard generation
-// stops adding panels once its captures reach this much. Peak process memory is still not held to it,
-// because a panel's response and capture are resident before either check can weigh them, and
-// marshalling a response allocates its full JSON. Bounding peak memory too needs a cap on the
-// in-process capture itself, plus the archive spooled to a temp file rather than assembled in RAM.
+// The artifact total is honoured exactly; dashboard generation stops adding panels once its captures
+// reach this much; and a response whose JSON provably could not fit is never marshalled (see
+// queryDataLowerBoundBytes), so that allocation is bounded by this number too rather than by the
+// response.
+//
+// Peak process memory is still not held to it, because a panel's response and capture are resident
+// before any of those checks can weigh them, and a response that passes the floor check still allocates
+// its full JSON once. Bounding peak memory as well needs a cap on the in-process capture itself, plus
+// the archive spooled to a temp file rather than assembled in RAM.
 const MaxBundleBytes = 1 << 30 // 1 GiB
 
 // bundleBudget accumulates a bundle's artifacts against MaxBundleBytes.
@@ -72,6 +77,17 @@ func (b *bundleBudget) add(name string, data []byte) bool {
 	b.remaining -= len(data)
 	b.files[name] = data
 	return true
+}
+
+// fits reports whether an artifact of at least atLeast bytes could still be added, recording the drop
+// if it could not. For artifacts expensive to produce: it lets a caller decline to build one that
+// provably will not fit, instead of allocating it only to have add() reject it.
+func (b *bundleBudget) fits(name string, atLeast int) bool {
+	if atLeast <= b.remaining {
+		return true
+	}
+	b.dropped = append(b.dropped, fmt.Sprintf("%s (not built: at least %d bytes, %d remaining)", name, atLeast, b.remaining))
+	return false
 }
 
 // finish records what the ceiling cost, then assembles the archive. bundle-limit.txt is written
@@ -190,7 +206,13 @@ func (b *Bundler) Build(resp *backend.QueryDataResponse, harBuffer *harcapture.B
 		queryDataErr = fmt.Errorf("serialize query request: %w", queryRequestErr)
 	}
 	var queryData []byte
-	if resp != nil || len(queryRequestJSON) > 0 {
+	// Weighed before marshalling, not after: encoding a response allocates the whole document, so a
+	// response that cannot fit must be declined rather than built and rejected. The floor is charged
+	// against the full budget because the bulk artifacts have not been added yet.
+	switch {
+	case resp != nil && !budget.fits("querydata.json", queryDataLowerBoundBytes(resp)):
+		queryDataErr = errors.Join(queryDataErr, errors.New("query data not serialized: larger than the bundle size limit"))
+	case resp != nil || len(queryRequestJSON) > 0:
 		var err error
 		queryData, err = marshalQueryDataArtifact(queryRequestJSON, resp)
 		if err != nil {
@@ -291,6 +313,60 @@ func marshalQueryDataArtifact(request json.RawMessage, resp *backend.QueryDataRe
 		artifact.Response = responseJSON
 	}
 	return json.MarshalIndent(artifact, "", "  ")
+}
+
+// queryDataLowerBoundBytes returns a floor on the JSON size of resp: a byte count the encoded
+// querydata.json cannot come in under. It exists so a response that provably cannot fit the bundle
+// budget is never marshalled at all.
+//
+// It must stay a floor: erring low only costs a marshal that add() then rejects, while erring high
+// declines an artifact that would have fitted.
+//
+// Deliberately loose in two ways. It counts no separators, braces, field names or frame metadata, all of
+// which the real document pays for. And it walks values without copying any: string lengths are read
+// from their headers, so this stays far cheaper than the marshal it may avoid.
+//
+// HAR responses are skipped because queryDataResponseWithoutCaptureFrames strips them, and counting
+// bytes the artifact will not contain is the one way this could overestimate.
+func queryDataLowerBoundBytes(resp *backend.QueryDataResponse) int {
+	if resp == nil {
+		return 0
+	}
+	total := 0
+	for refID, response := range resp.Responses {
+		if isHARResponse(refID) {
+			continue
+		}
+		for _, frame := range response.Frames {
+			if frame == nil {
+				continue
+			}
+			for _, field := range frame.Fields {
+				if field == nil {
+					continue
+				}
+				switch field.Type() {
+				case data.FieldTypeString, data.FieldTypeNullableString:
+					// Strings are the only values whose JSON size isn't bounded below by a constant, and the
+					// case that matters: a few rows of log lines outweigh millions of numbers.
+					for i := 0; i < field.Len(); i++ {
+						if v, ok := field.ConcreteAt(i); ok {
+							if s, isString := v.(string); isString {
+								total += len(s) + len(`""`)
+								continue
+							}
+						}
+						total++ // a null, which costs 4; counting 1 keeps this a floor
+					}
+				default:
+					// Every other value encodes to at least one character (a single digit, or `0` for a
+					// null-free numeric), so the row count is a floor for the whole field.
+					total += field.Len()
+				}
+			}
+		}
+	}
+	return total
 }
 
 func summarizeQueryDataResponse(resp *backend.QueryDataResponse) map[string]queryDataResponseSummary {
@@ -445,7 +521,13 @@ func (b *Bundler) BuildDashboard(dashboardJSON json.RawMessage, panels []Dashboa
 			queryDataErrs = append(queryDataErrs, "serialize query request: "+p.QueryRequestErr.Error())
 		}
 		var queryData []byte
-		if p.Resp != nil || len(p.QueryRequest) > 0 {
+		// As in Build: decline a response that provably cannot fit rather than allocating its JSON to
+		// find out. Here the floor is weighed against what earlier panels have already spent.
+		switch {
+		case p.Resp != nil && !budget.fits(dir+"/querydata.json", queryDataLowerBoundBytes(p.Resp)):
+			entry.QueryDataTruncated = true
+			queryDataErrs = append(queryDataErrs, "not serialized: larger than the remaining bundle size limit")
+		case p.Resp != nil || len(p.QueryRequest) > 0:
 			var err error
 			queryData, err = marshalQueryDataArtifact(p.QueryRequest, p.Resp)
 			if err != nil {

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -206,12 +206,17 @@ func (b *Bundler) Build(resp *backend.QueryDataResponse, harBuffer *harcapture.B
 		queryDataErr = fmt.Errorf("serialize query request: %w", queryRequestErr)
 	}
 	var queryData []byte
-	// Weighed before marshalling, not after: encoding a response allocates the whole document, so a
-	// response that cannot fit must be declined rather than built and rejected. The floor is charged
-	// against the full budget because the bulk artifacts have not been added yet.
+	// Weighed before marshalling, not after: encoding a response allocates the whole document, so one
+	// that cannot fit is declined rather than built and rejected. The floor is charged against the full
+	// budget because the bulk artifacts have not been added yet.
+	// Only the response is declined -- the artifact is still written with the request and a frame summary,
+	// which cost kilobytes and are the part recorded nowhere else.
 	switch {
-	case resp != nil && !budget.fits("querydata.json", queryDataLowerBoundBytes(resp)):
-		queryDataErr = errors.Join(queryDataErr, errors.New("query data not serialized: larger than the bundle size limit"))
+	case resp != nil && !budget.fits("querydata.json response", queryDataLowerBoundBytes(resp)):
+		reason := "response omitted: larger than the bundle size limit"
+		var err error
+		queryData, err = marshalQueryDataWithoutResponse(queryRequestJSON, resp, reason)
+		queryDataErr = errors.Join(queryDataErr, err, errors.New(reason))
 	case resp != nil || len(queryRequestJSON) > 0:
 		var err error
 		queryData, err = marshalQueryDataArtifact(queryRequestJSON, resp)
@@ -298,13 +303,7 @@ func marshalQueryDataArtifact(request json.RawMessage, resp *backend.QueryDataRe
 			//
 			// The error is returned as well, so both callers record it outside the artifact
 			// (querydata-error.txt, manifest.queryDataError); the embedded copy is a convenience.
-			out, fallbackErr := json.MarshalIndent(queryDataArtifact{
-				Version:         queryDataArtifactVersion,
-				Request:         request,
-				ResponseSummary: summarizeQueryDataResponse(resp),
-				ResponseError:   err.Error(),
-				ResponseOmitted: true,
-			}, "", "  ")
+			out, fallbackErr := marshalQueryDataWithoutResponse(request, resp, err.Error())
 			if fallbackErr != nil {
 				return nil, errors.Join(err, fallbackErr)
 			}
@@ -313,6 +312,18 @@ func marshalQueryDataArtifact(request json.RawMessage, resp *backend.QueryDataRe
 		artifact.Response = responseJSON
 	}
 	return json.MarshalIndent(artifact, "", "  ")
+}
+
+// marshalQueryDataWithoutResponse encodes querydata.json carrying everything except the response
+// itself: the submitted request, a frame summary, and why the response is missing.
+func marshalQueryDataWithoutResponse(request json.RawMessage, resp *backend.QueryDataResponse, reason string) ([]byte, error) {
+	return json.MarshalIndent(queryDataArtifact{
+		Version:         queryDataArtifactVersion,
+		Request:         request,
+		ResponseSummary: summarizeQueryDataResponse(resp),
+		ResponseError:   reason,
+		ResponseOmitted: true,
+	}, "", "  ")
 }
 
 // queryDataLowerBoundBytes returns a floor on the JSON size of resp: a byte count the encoded
@@ -471,9 +482,10 @@ type manifestPanelEntry struct {
 	QueryDataError     string   `json:"queryDataError,omitempty"`
 	Skipped            string   `json:"skipped,omitempty"`
 	Error              string   `json:"error,omitempty"`
-	// CaptureError records a failure to serialize this panel's captured traffic. It's kept separate
-	// from Error (a query failure) so one unserializable buffer only loses this panel's traffic.har,
-	// not the whole multi-panel bundle.
+	// CaptureError records why this panel has no traffic.har despite having run -- either the capture
+	// could not be serialized, or it did not fit the bundle size limit. Kept separate from Error (a query
+	// failure) so one panel's lost traffic doesn't read as a failed query, and separate from
+	// QueryDataTruncated so a reader chasing missing traffic isn't sent to the wrong artifact.
 	CaptureError string `json:"captureError,omitempty"`
 }
 
@@ -521,12 +533,19 @@ func (b *Bundler) BuildDashboard(dashboardJSON json.RawMessage, panels []Dashboa
 			queryDataErrs = append(queryDataErrs, "serialize query request: "+p.QueryRequestErr.Error())
 		}
 		var queryData []byte
-		// As in Build: decline a response that provably cannot fit rather than allocating its JSON to
-		// find out. Here the floor is weighed against what earlier panels have already spent.
+		// As in Build: decline a response that provably cannot fit rather than allocating its JSON to find
+		// out, and keep the request either way. Here the floor is weighed against what earlier panels
+		// already spent.
 		switch {
-		case p.Resp != nil && !budget.fits(dir+"/querydata.json", queryDataLowerBoundBytes(p.Resp)):
+		case p.Resp != nil && !budget.fits(dir+"/querydata.json response", queryDataLowerBoundBytes(p.Resp)):
 			entry.QueryDataTruncated = true
-			queryDataErrs = append(queryDataErrs, "not serialized: larger than the remaining bundle size limit")
+			reason := "response omitted: larger than the remaining bundle size limit"
+			var err error
+			queryData, err = marshalQueryDataWithoutResponse(p.QueryRequest, p.Resp, reason)
+			if err != nil {
+				queryDataErrs = append(queryDataErrs, err.Error())
+			}
+			queryDataErrs = append(queryDataErrs, reason)
 		case p.Resp != nil || len(p.QueryRequest) > 0:
 			var err error
 			queryData, err = marshalQueryDataArtifact(p.QueryRequest, p.Resp)
@@ -557,7 +576,9 @@ func (b *Bundler) BuildDashboard(dashboardJSON json.RawMessage, panels []Dashboa
 		if budget.add(dir+"/traffic.har", har) {
 			entry.HARBytes = len(har)
 		} else {
-			entry.QueryDataTruncated = true
+			// Not QueryDataTruncated: that field says the query DATA was cut, and a reader chasing missing
+			// traffic would be looking at the wrong artifact.
+			entry.CaptureError = "traffic dropped: bundle size limit reached"
 		}
 		if budget.add(dir+"/querydata.json", queryData) {
 			entry.QueryDataBytes = len(queryData)
@@ -803,7 +824,43 @@ func HasCapturedHAR(resp *backend.QueryDataResponse, harBuffer *harcapture.Buffe
 	return captured
 }
 
+// CapturedHARBytes returns how much captured traffic resp carries from out-of-process plugins: the
+// length of the HAR payload in each __har__ frame. It is the counterpart to harcapture.Buffer.RetainedBytes,
+// and a caller sizing a panel's capture needs both -- an out-of-process plugin leaves that buffer empty
+// however much traffic it recorded, so counting the buffer alone would see nothing at all.
+//
+// IMPORTANT: must be called before collectHAR, which drains these responses out of resp. Nothing
+// enforces that -- a reorder would silently return zero rather than fail, so collectHAR carries the
+// matching note.
+func CapturedHARBytes(resp *backend.QueryDataResponse) int {
+	if resp == nil {
+		return 0
+	}
+	total := 0
+	for refID, harResp := range resp.Responses {
+		if !isHARResponse(refID) {
+			continue
+		}
+		for _, frame := range harResp.Frames {
+			if frame == nil || frame.Meta == nil {
+				continue
+			}
+			custom, ok := frame.Meta.Custom.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if harStr, ok := custom["har"].(string); ok {
+				total += len(harStr)
+			}
+		}
+	}
+	return total
+}
+
 // collectHAR returns the captured HTTP traffic as HAR 1.2 JSON.
+//
+// IMPORTANT: it CONSUMES the __har__ responses, deleting them from resp as it drains them, so anything
+// that needs to size an out-of-process plugin's capture (CapturedHARBytes) must run first.
 func collectHAR(resp *backend.QueryDataResponse, harBuffer *harcapture.Buffer) ([]byte, error) {
 	var bufferDoc []byte
 	if harBuffer != nil && harBuffer.Len() > 0 {

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -929,3 +929,79 @@ func TestBundleBudget_completeBundleIsUnmarked(t *testing.T) {
 	require.NotContains(t, readTarGz(t, archive), "bundle-limit.txt",
 		"a bundle that dropped nothing must carry no limit note")
 }
+
+func TestQueryDataLowerBoundBytes(t *testing.T) {
+	t.Run("nil and empty responses cost nothing", func(t *testing.T) {
+		require.Zero(t, queryDataLowerBoundBytes(nil))
+		require.Zero(t, queryDataLowerBoundBytes(backend.NewQueryDataResponse()))
+	})
+
+	t.Run("numeric fields are floored at one byte per value", func(t *testing.T) {
+		frame := data.NewFrame("cpu",
+			data.NewField("a", nil, []float64{1, 2, 3}),
+			data.NewField("b", nil, []int64{1, 2, 3}),
+		)
+		resp := &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{frame}}}}
+		require.Equal(t, 6, queryDataLowerBoundBytes(resp), "two fields of three values")
+	})
+
+	t.Run("string fields count their bytes plus quotes", func(t *testing.T) {
+		frame := data.NewFrame("logs", data.NewField("line", nil, []string{"hello", "hi"}))
+		resp := &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{frame}}}}
+		require.Equal(t, len(`"hello"`)+len(`"hi"`), queryDataLowerBoundBytes(resp))
+	})
+
+	t.Run("HAR frames are excluded, as the artifact excludes them", func(t *testing.T) {
+		payload := data.NewFrame("har", data.NewField("line", nil, []string{strings.Repeat("x", 1000)}))
+		resp := &backend.QueryDataResponse{Responses: backend.Responses{
+			harResponseRefIDPrefix + "abc": {Frames: data.Frames{payload}},
+		}}
+		require.Zero(t, queryDataLowerBoundBytes(resp),
+			"counting bytes the artifact won't contain is the one way this could overestimate")
+	})
+
+	// The whole point: the floor must never exceed the real encoding, or a response that would have fitted
+	// gets declined and its evidence is lost.
+	t.Run("the floor never exceeds the real encoded size", func(t *testing.T) {
+		for _, tc := range []struct {
+			name  string
+			frame *data.Frame
+		}{
+			{"numbers", data.NewFrame("n", data.NewField("v", nil, []float64{1.5, -2.25, 3}))},
+			{"strings", data.NewFrame("s", data.NewField("v", nil, []string{"", "a", "hello world"}))},
+			{"nullable strings", data.NewFrame("ns", data.NewField("v", nil, []*string{nil, ptr("x")}))},
+			{"mixed", data.NewFrame("m",
+				data.NewField("t", nil, []time.Time{time.Unix(0, 0)}),
+				data.NewField("v", nil, []string{"payload"}),
+			)},
+			{"empty frame", data.NewFrame("e", data.NewField("v", nil, []float64{}))},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				resp := &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{tc.frame}}}}
+				encoded, err := marshalQueryDataArtifact(nil, resp)
+				require.NoError(t, err)
+				require.LessOrEqual(t, queryDataLowerBoundBytes(resp), len(encoded),
+					"the floor must be a lower bound on the real artifact")
+			})
+		}
+	})
+}
+
+func ptr[T any](v T) *T { return &v }
+
+func TestBundler_Build_declinesQueryDataItCannotFit(t *testing.T) {
+	// A string field larger than the whole budget: the floor alone exceeds it, so the response must never
+	// be marshalled -- avoiding the allocation is the reason the check exists.
+	huge := data.NewFrame("logs", data.NewField("line", nil, []string{strings.Repeat("x", MaxBundleBytes+1)}))
+	resp := &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{huge}}}}
+
+	archive, result, err := NewBundler(nil).Build(resp, nil, nil, nil, json.RawMessage(`{"q":1}`), nil, nil)
+	require.NoError(t, err)
+	require.True(t, result.Partial())
+
+	files := readTarGz(t, archive)
+	require.NotContains(t, files, "querydata.json")
+	require.Contains(t, string(files["bundle-limit.txt"]), "not built",
+		"the reader must be able to tell it was declined rather than absent")
+	require.Contains(t, string(files["querydata-error.txt"]), "larger than the bundle size limit")
+}

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestBundler_Build(t *testing.T) {
 	// No HAR captured (empty buffer, nil response) -> traffic.har omitted; only panel.json present.
-	blob, err := NewBundler(nil).Build(nil, &harcapture.Buffer{}, json.RawMessage(`{"id":1}`), nil, nil, nil, nil)
+	blob, _, err := NewBundler(nil).Build(nil, &harcapture.Buffer{}, json.RawMessage(`{"id":1}`), nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -37,7 +37,7 @@ func TestBundler_Build(t *testing.T) {
 
 func TestBundler_Build_recordsQueryError(t *testing.T) {
 	// A failed query must still produce a bundle, with the error recorded (capture is not discarded).
-	blob, err := NewBundler(nil).Build(nil, &harcapture.Buffer{}, nil, nil, nil, nil, errors.New("datasource timeout"))
+	blob, _, err := NewBundler(nil).Build(nil, &harcapture.Buffer{}, nil, nil, nil, nil, errors.New("datasource timeout"))
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -51,7 +51,7 @@ func TestBundler_Build_recordsQueryDataMarshalError(t *testing.T) {
 	// error is recorded and the other artifacts still ship, mirroring the per-panel dashboard path.
 	buf := bufferWithEntry(t, "http://ds/1")
 
-	blob, err := NewBundler(nil).Build(nil, buf, nil, nil, json.RawMessage(`{invalid`), nil, nil)
+	blob, _, err := NewBundler(nil).Build(nil, buf, nil, nil, json.RawMessage(`{invalid`), nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -67,7 +67,7 @@ func TestBundler_Build_recordsQueryRequestSerializeError(t *testing.T) {
 	// mirroring how the per-panel dashboard path surfaces the same failure via manifest.queryDataError.
 	buf := bufferWithEntry(t, "http://ds/1")
 
-	blob, err := NewBundler(nil).Build(nil, buf, nil, nil, nil, errors.New("unsupported value: +Inf"), nil)
+	blob, _, err := NewBundler(nil).Build(nil, buf, nil, nil, nil, errors.New("unsupported value: +Inf"), nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -84,7 +84,7 @@ func TestBundler_Build_recordsQueryDataResponse(t *testing.T) {
 		"A": {Frames: data.Frames{frame}},
 	}}
 
-	blob, err := NewBundler(nil).Build(resp, &harcapture.Buffer{}, nil, nil, nil, nil, nil)
+	blob, _, err := NewBundler(nil).Build(resp, &harcapture.Buffer{}, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -96,7 +96,7 @@ func TestBundler_Build_recordsQueryDataResponse(t *testing.T) {
 func TestBundler_Build_recordsQueryDataRequest(t *testing.T) {
 	request := json.RawMessage(`{"from":"now-1h","to":"now","queries":[{"refId":"A","expr":"up"}]}`)
 
-	blob, err := NewBundler(nil).Build(nil, &harcapture.Buffer{}, nil, nil, request, nil, nil)
+	blob, _, err := NewBundler(nil).Build(nil, &harcapture.Buffer{}, nil, nil, request, nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -114,44 +114,12 @@ func TestBundler_Build_excludesCaptureFramesFromQueryData(t *testing.T) {
 		"__har__ds": {Frames: data.Frames{capture}},
 	}}
 
-	blob, err := NewBundler(nil).Build(resp, &harcapture.Buffer{}, nil, nil, nil, nil, nil)
+	blob, _, err := NewBundler(nil).Build(resp, &harcapture.Buffer{}, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
 	require.NotContains(t, string(files["querydata.json"]), "__har__")
 	require.Contains(t, string(files["querydata.json"]), `"A"`)
-}
-
-func TestBundler_Build_boundsOversizedQueryData(t *testing.T) {
-	frame := data.NewFrame("logs", data.NewField("line", nil, []string{strings.Repeat("x", maxQueryDataArtifactBytes)}))
-	resp := &backend.QueryDataResponse{Responses: backend.Responses{
-		"A": {Frames: data.Frames{frame}},
-	}}
-
-	blob, err := NewBundler(nil).Build(resp, &harcapture.Buffer{}, nil, nil, nil, nil, nil)
-	require.NoError(t, err)
-
-	files := readTarGz(t, blob)
-	queryData := files["querydata.json"]
-	require.LessOrEqual(t, len(queryData), maxQueryDataArtifactBytes)
-	require.Contains(t, string(queryData), `"truncated": true`)
-	require.Contains(t, string(queryData), `"rows": 1`)
-	require.Contains(t, string(queryData), `"refId": "A"`)
-}
-
-func TestBundler_Build_boundsOversizedRequestWithoutResponse(t *testing.T) {
-	// An oversized request with no response must truncate without claiming a response was omitted.
-	request := json.RawMessage(`{"expr":"` + strings.Repeat("x", maxQueryDataArtifactBytes) + `"}`)
-
-	blob, err := NewBundler(nil).Build(nil, &harcapture.Buffer{}, nil, nil, request, nil, nil)
-	require.NoError(t, err)
-
-	files := readTarGz(t, blob)
-	queryData := files["querydata.json"]
-	require.LessOrEqual(t, len(queryData), maxQueryDataArtifactBytes)
-	require.Contains(t, string(queryData), `"truncated": true`)
-	require.Contains(t, string(queryData), `"requestOmitted": true`)
-	require.NotContains(t, string(queryData), `"responseOmitted"`)
 }
 
 func TestBundler_Build_preservesUpstreamAndPluginResultsForComparison(t *testing.T) {
@@ -171,7 +139,7 @@ func TestBundler_Build_preservesUpstreamAndPluginResultsForComparison(t *testing
 	queryResp := &backend.QueryDataResponse{Responses: backend.Responses{
 		"A": {Frames: data.Frames{pluginFrame}},
 	}}
-	blob, err := NewBundler(nil).Build(queryResp, buf, nil, nil, nil, nil, nil)
+	blob, _, err := NewBundler(nil).Build(queryResp, buf, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -308,7 +276,7 @@ func TestCollectHAR_nilBuffer_noPanic(t *testing.T) {
 	require.Nil(t, out)
 
 	// A nil buffer must also flow through Build without panicking.
-	bundle, err := NewBundler(nil).Build(nil, nil, nil, nil, nil, nil, nil)
+	bundle, _, err := NewBundler(nil).Build(nil, nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, bundle)
 }
@@ -531,7 +499,7 @@ func TestBuildDashboard(t *testing.T) {
 		{ID: 1, Title: "CPU Usage", PanelJSON: json.RawMessage(`{"id":1}`), Datasources: []string{"prom"}, HARBuffer: bufferWithEntry(t, "http://ds/1")},
 		{ID: 2, Title: "Text panel", Skipped: "no queries (non-data panel)"},
 	}
-	blob, err := NewBundler(nil).BuildDashboard(json.RawMessage(`{"title":"My dash"}`), panels)
+	blob, _, err := NewBundler(nil).BuildDashboard(json.RawMessage(`{"title":"My dash"}`), panels)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -566,40 +534,13 @@ func TestBuildDashboard_recordsQueryDataPerPanel(t *testing.T) {
 		}},
 	}}
 
-	blob, err := NewBundler(nil).BuildDashboard(nil, panels)
+	blob, _, err := NewBundler(nil).BuildDashboard(nil, panels)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
 	require.Contains(t, files, "panels/1-cpu-usage/querydata.json")
 	require.Contains(t, string(files["panels/1-cpu-usage/querydata.json"]), `"refId": "A"`)
 	require.Contains(t, string(files["panels/1-cpu-usage/querydata.json"]), `42`)
-}
-
-func TestBuildDashboard_boundsAggregateQueryData(t *testing.T) {
-	panels := make([]DashboardPanel, 0, 5)
-	for i := 1; i <= 5; i++ {
-		frame := data.NewFrame("logs", data.NewField("line", nil, []string{strings.Repeat("x", maxQueryDataArtifactBytes-4096)}))
-		panels = append(panels, DashboardPanel{
-			ID:    int64(i),
-			Title: "Logs",
-			Resp: &backend.QueryDataResponse{Responses: backend.Responses{
-				"A": {Frames: data.Frames{frame}},
-			}},
-		})
-	}
-
-	blob, err := NewBundler(nil).BuildDashboard(nil, panels)
-	require.NoError(t, err)
-
-	files := readTarGz(t, blob)
-	queryDataBytes := 0
-	for name, contents := range files {
-		if strings.HasSuffix(name, "/querydata.json") {
-			queryDataBytes += len(contents)
-		}
-	}
-	require.LessOrEqual(t, queryDataBytes, maxDashboardQueryDataBytes)
-	require.Contains(t, string(files["manifest.json"]), `"queryDataTruncated": true`)
 }
 
 // The whole-dashboard client posts the dashboard save model once instead of each panel's JSON, so
@@ -620,7 +561,7 @@ func TestBuildDashboard_resolvesPanelJSONFromDashboardModel(t *testing.T) {
 		{ID: 1, Title: "CPU Usage", HARBuffer: bufferWithEntry(t, "http://ds/1")},
 		{ID: 2, Title: "Logs", HARBuffer: bufferWithEntry(t, "http://ds/2")},
 	}
-	blob, err := NewBundler(nil).BuildDashboard(dashboardJSON, panels)
+	blob, _, err := NewBundler(nil).BuildDashboard(dashboardJSON, panels)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -648,7 +589,7 @@ func TestBuildDashboard_resolvesPanelJSONFromDashboardV2Model(t *testing.T) {
 		{ID: 3, Title: "CPU Usage", HARBuffer: bufferWithEntry(t, "http://ds/3")},
 		{ID: 4, Title: "Shared Errors", HARBuffer: bufferWithEntry(t, "http://ds/4")},
 	}
-	blob, err := NewBundler(nil).BuildDashboard(dashboardJSON, panels)
+	blob, _, err := NewBundler(nil).BuildDashboard(dashboardJSON, panels)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -672,7 +613,7 @@ func TestBuildDashboard_recordsPanelQueryError(t *testing.T) {
 	panels := []DashboardPanel{
 		{ID: 7, Title: "Broken", QueryErr: errors.New("datasource exploded")},
 	}
-	blob, err := NewBundler(nil).BuildDashboard(nil, panels)
+	blob, _, err := NewBundler(nil).BuildDashboard(nil, panels)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -691,7 +632,7 @@ func TestBuildDashboard_dirCollision(t *testing.T) {
 		{ID: 3, Title: "Same", HARBuffer: bufferWithEntry(t, "http://ds/a")},
 		{ID: 3, Title: "Same", HARBuffer: bufferWithEntry(t, "http://ds/b")},
 	}
-	blob, err := NewBundler(nil).BuildDashboard(nil, panels)
+	blob, _, err := NewBundler(nil).BuildDashboard(nil, panels)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -710,7 +651,7 @@ func TestBuildDashboard_recordsQueryRequestError(t *testing.T) {
 		{ID: 1, Title: "Broken request", QueryRequestErr: errors.New("unsupported value: NaN")},
 		{ID: 2, Title: "CPU Usage", HARBuffer: bufferWithEntry(t, "http://ds/2")},
 	}
-	blob, err := NewBundler(nil).BuildDashboard(nil, panels)
+	blob, _, err := NewBundler(nil).BuildDashboard(nil, panels)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -735,7 +676,7 @@ func TestBuildDashboard_joinsQueryDataErrors(t *testing.T) {
 		QueryRequestErr: errors.New("request: unsupported value: +Inf"),
 		Resp:            &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{frame}}}},
 	}}
-	blob, err := NewBundler(nil).BuildDashboard(nil, panels)
+	blob, _, err := NewBundler(nil).BuildDashboard(nil, panels)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -761,7 +702,7 @@ func TestBundler_Build_keepsRequestWhenResponseEncodingFails(t *testing.T) {
 	resp := &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{frame}}}}
 	request := json.RawMessage(`{"queries":[{"refId":"A","expr":"up"}]}`)
 
-	blob, err := NewBundler(nil).Build(resp, &harcapture.Buffer{}, nil, nil, request, nil, nil)
+	blob, _, err := NewBundler(nil).Build(resp, &harcapture.Buffer{}, nil, nil, request, nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -785,7 +726,7 @@ func TestBuildDashboard_keepsRequestWhenResponseEncodingFails(t *testing.T) {
 		QueryRequest: json.RawMessage(`{"queries":[{"refId":"A","expr":"up"}]}`),
 		Resp:         &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{frame}}}},
 	}}
-	blob, err := NewBundler(nil).BuildDashboard(nil, panels)
+	blob, _, err := NewBundler(nil).BuildDashboard(nil, panels)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -797,27 +738,6 @@ func TestBuildDashboard_keepsRequestWhenResponseEncodingFails(t *testing.T) {
 	require.NoError(t, json.Unmarshal(files["manifest.json"], &m))
 	require.Contains(t, m.Panels[0].QueryDataError, "unsupported value: NaN")
 	require.NotZero(t, m.Panels[0].QueryDataBytes, "the surviving artifact is accounted for in the manifest")
-}
-
-func TestMarshalQueryDataArtifactWithLimit_encodeFailureFitsMinimumBudget(t *testing.T) {
-	// The BuildDashboard budget gate assumes the smallest artifact fits in minQueryDataArtifactBytes.
-	// An encode failure adds responseError, which must not push the floor past that assumption --
-	// otherwise a panel reaching the gate with a near-exhausted budget loses everything again.
-	resp := &backend.QueryDataResponse{Responses: backend.Responses{
-		"A": {Frames: data.Frames{frameWithUnencodableMeta(longMarshalError)}},
-	}}
-	request := json.RawMessage(`{"queries":[{"refId":"A","expr":"` + strings.Repeat("x", 4096) + `"}]}`)
-
-	out, _, err := marshalQueryDataArtifactWithLimit(request, resp, minQueryDataArtifactBytes)
-	require.Error(t, err, "the response still fails to encode")
-	require.NotEmpty(t, out, "a floor artifact is produced rather than nothing")
-	require.LessOrEqual(t, len(out), minQueryDataArtifactBytes)
-
-	var artifact queryDataArtifact
-	require.NoError(t, json.Unmarshal(out, &artifact), "the floor artifact is valid JSON")
-	require.Equal(t, queryDataArtifactVersion, artifact.Version)
-	require.True(t, artifact.ResponseOmitted)
-	require.True(t, artifact.RequestOmitted)
 }
 
 // longMarshalError stands in for a plugin whose own MarshalJSON fails with a verbose message: the
@@ -858,12 +778,12 @@ func TestSummarizeQueryDataResponse(t *testing.T) {
 		badRows := data.NewFrame("", data.NewField("a", nil, []int64{1, 2}), data.NewField("b", nil, []int64{1}))
 		resp := backend.NewQueryDataResponse()
 		resp.Responses["A"] = backend.DataResponse{
-			Error:  errors.New(strings.Repeat("e", 2000)),
+			Error:  errors.New(strings.Repeat("e", 8192)),
 			Frames: data.Frames{namedFrame, badRows},
 		}
 
 		a := summarizeQueryDataResponse(resp)["A"]
-		require.Len(t, a.Error, 1024+len("…"), "error must be truncated to 1024 bytes + ellipsis")
+		require.Len(t, a.Error, 8192, "errors are recorded whole -- the bundle budget is what bounds them now")
 		require.Len(t, a.Frames[0].Name, 256+len("…"), "frame name must be truncated to 256 bytes + ellipsis")
 		require.Len(t, a.Frames[0].RefID, 256+len("…"), "frame refId must be truncated to 256 bytes + ellipsis")
 		require.Equal(t, -1, a.Frames[1].Rows, "a frame whose RowLen() errors must record rows = -1")
@@ -892,86 +812,6 @@ func TestTruncateDiagnosticString(t *testing.T) {
 	got := truncateDiagnosticString("世界", 4)
 	require.True(t, utf8.ValidString(got), "truncation must not split a rune")
 	require.Equal(t, "世…", got)
-}
-
-func TestMarshalQueryDataArtifactWithLimit_reportsTruncation(t *testing.T) {
-	frame := data.NewFrame("logs", data.NewField("line", nil, []string{strings.Repeat("x", maxQueryDataArtifactBytes)}))
-	resp := &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{frame}}}}
-
-	_, truncated, err := marshalQueryDataArtifactWithLimit(nil, resp, maxQueryDataArtifactBytes)
-	require.NoError(t, err)
-	require.True(t, truncated, "an oversized response must report truncated=true")
-
-	small := &backend.QueryDataResponse{Responses: backend.Responses{
-		"A": {Frames: data.Frames{data.NewFrame("cpu", data.NewField("value", nil, []float64{42}))}},
-	}}
-	_, truncated, err = marshalQueryDataArtifactWithLimit(nil, small, maxQueryDataArtifactBytes)
-	require.NoError(t, err)
-	require.False(t, truncated, "a response that fits must report truncated=false")
-}
-
-func TestMarshalQueryDataArtifactWithLimit_truncationTiers(t *testing.T) {
-	// A request large enough that neither the full artifact nor the (request + summary) tier fits,
-	// forcing the ladder past tier 1.
-	bigRequest := json.RawMessage(`{"pad":"` + strings.Repeat("q", 4096) + `"}`)
-
-	t.Run("tier 2 drops the request but keeps the per-refID summary", func(t *testing.T) {
-		resp := backend.NewQueryDataResponse()
-		resp.Responses["A"] = backend.DataResponse{
-			Status: backend.StatusOK,
-			Frames: data.Frames{data.NewFrame("cpu", data.NewField("v", nil, []float64{1, 2, 3}))},
-		}
-		out, _, err := marshalQueryDataArtifactWithLimit(bigRequest, resp, 800)
-		require.NoError(t, err)
-		require.LessOrEqual(t, len(out), 800)
-
-		var art queryDataArtifact
-		require.NoError(t, json.Unmarshal(out, &art))
-		require.True(t, art.Truncated)
-		require.True(t, art.RequestOmitted)
-		require.True(t, art.ResponseOmitted)
-		require.Empty(t, art.Request, "the oversized request must be dropped at tier 2")
-		require.Contains(t, art.ResponseSummary, "A", "the per-refID summary must survive tier 2")
-	})
-
-	t.Run("tier 3 falls back to metadata only when even the summary is too big", func(t *testing.T) {
-		resp := backend.NewQueryDataResponse()
-		resp.Responses["A"] = backend.DataResponse{Error: errors.New(strings.Repeat("e", 4096))}
-		out, _, err := marshalQueryDataArtifactWithLimit(bigRequest, resp, 300)
-		require.NoError(t, err)
-		require.LessOrEqual(t, len(out), 300)
-
-		var art queryDataArtifact
-		require.NoError(t, json.Unmarshal(out, &art))
-		require.True(t, art.Truncated)
-		require.True(t, art.RequestOmitted)
-		require.True(t, art.ResponseOmitted)
-		require.Empty(t, art.Request)
-		require.Empty(t, art.ResponseSummary, "tier 3 drops even the per-refID summary")
-		require.Equal(t, 300, art.LimitBytes)
-		require.Positive(t, art.OriginalBytes)
-	})
-
-	// The two omission markers are how a reader tells "this was dropped to fit the cap" from "this was
-	// never supplied", so neither may claim a drop that didn't happen.
-	t.Run("omission markers only flag content that was actually dropped", func(t *testing.T) {
-		bigError := backend.NewQueryDataResponse()
-		bigError.Responses["A"] = backend.DataResponse{Error: errors.New(strings.Repeat("e", 4096))}
-
-		out, _, err := marshalQueryDataArtifactWithLimit(nil, bigError, 300)
-		require.NoError(t, err)
-		var noRequest queryDataArtifact
-		require.NoError(t, json.Unmarshal(out, &noRequest))
-		require.False(t, noRequest.RequestOmitted, "no request was supplied, so none was dropped")
-		require.True(t, noRequest.ResponseOmitted)
-
-		out, _, err = marshalQueryDataArtifactWithLimit(bigRequest, nil, 300)
-		require.NoError(t, err)
-		var noResponse queryDataArtifact
-		require.NoError(t, json.Unmarshal(out, &noResponse))
-		require.True(t, noResponse.RequestOmitted)
-		require.False(t, noResponse.ResponseOmitted, "no response was supplied, so none was dropped")
-	})
 }
 
 func TestPanelTitleSlug(t *testing.T) {
@@ -1015,7 +855,7 @@ func readTarGz(t *testing.T, data []byte) map[string][]byte {
 func TestBundler_Build_bundlesPanelData(t *testing.T) {
 	panelData := json.RawMessage(`{"version":1,"frames":[{"schema":{"name":"frontend-frames"}}]}`)
 
-	blob, err := NewBundler(nil).Build(nil, &harcapture.Buffer{}, nil, nil, nil, nil, nil,
+	blob, _, err := NewBundler(nil).Build(nil, &harcapture.Buffer{}, nil, nil, nil, nil, nil,
 		WithPanelData(panelData))
 	require.NoError(t, err)
 
@@ -1024,7 +864,7 @@ func TestBundler_Build_bundlesPanelData(t *testing.T) {
 }
 
 func TestBundler_Build_omitsPanelDataWhenNotSupplied(t *testing.T) {
-	blob, err := NewBundler(nil).Build(nil, &harcapture.Buffer{}, nil, nil, nil, nil, nil)
+	blob, _, err := NewBundler(nil).Build(nil, &harcapture.Buffer{}, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	require.NotContains(t, readTarGz(t, blob), "paneldata.json")
@@ -1034,7 +874,7 @@ func TestBundler_Build_omitsPanelDataWhenNull(t *testing.T) {
 	// A client that sends "panelData": null supplied nothing, so no artifact: one whose whole content is
 	// `null` reads as "the frontend was holding no frames", which is a frontend loss that never happened.
 	for _, payload := range []string{`null`, ` null `, ``} {
-		blob, err := NewBundler(nil).Build(nil, &harcapture.Buffer{}, nil, nil, nil, nil, nil,
+		blob, _, err := NewBundler(nil).Build(nil, &harcapture.Buffer{}, nil, nil, nil, nil, nil,
 			WithPanelData(json.RawMessage(payload)))
 		require.NoError(t, err)
 
@@ -1047,11 +887,45 @@ func TestBundler_Build_unparseablePanelDataDoesNotSinkTheBundle(t *testing.T) {
 	// bundle nothing else: every other artifact still ships. Unreachable through the HTTP endpoint --
 	// web.Bind rejects a body that isn't valid JSON before Build runs, so the worst that arrives there is
 	// a well-formed payload of the wrong shape -- this pins the contract for direct callers.
-	blob, err := NewBundler(nil).Build(nil, &harcapture.Buffer{}, json.RawMessage(`{"id":1}`), nil, nil, nil, nil,
+	blob, _, err := NewBundler(nil).Build(nil, &harcapture.Buffer{}, json.RawMessage(`{"id":1}`), nil, nil, nil, nil,
 		WithPanelData(json.RawMessage(`{"version":1,`)))
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
 	require.Contains(t, files, "panel.json")
 	require.Equal(t, `{"version":1,`, string(files["paneldata.json"]), "stored as sent")
+}
+
+func TestBundleBudget_dropsOversizedArtifactsWhole(t *testing.T) {
+	budget := newBundleBudget()
+
+	require.True(t, budget.add("small.json", []byte("{}")))
+	require.False(t, budget.add("huge.har", make([]byte, MaxBundleBytes+1)),
+		"an artifact larger than the whole budget must not fit")
+	require.True(t, budget.add("also-small.txt", []byte("still room")),
+		"a rejected artifact must not consume budget, so later ones still fit")
+
+	archive, result, err := budget.finish()
+	require.NoError(t, err)
+	require.True(t, result.Partial())
+	require.Len(t, result.Dropped, 1)
+	require.Contains(t, result.Dropped[0], "huge.har")
+
+	files := readTarGz(t, archive)
+	require.Contains(t, files, "small.json")
+	require.Contains(t, files, "also-small.txt")
+	require.NotContains(t, files, "huge.har", "an over-budget artifact must be dropped whole, not clipped")
+	require.Contains(t, string(files["bundle-limit.txt"]), "huge.har",
+		"a dropped artifact must be named, so its absence isn't read as nothing-to-capture")
+}
+
+func TestBundleBudget_completeBundleIsUnmarked(t *testing.T) {
+	budget := newBundleBudget()
+	require.True(t, budget.add("traffic.har", []byte(`{"log":{}}`)))
+
+	archive, result, err := budget.finish()
+	require.NoError(t, err)
+	require.False(t, result.Partial())
+	require.NotContains(t, readTarGz(t, archive), "bundle-limit.txt",
+		"a bundle that dropped nothing must carry no limit note")
 }

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -754,6 +754,28 @@ func frameWithUnencodableMeta(msg string) *data.Frame {
 	return frame
 }
 
+// A response that cannot be encoded still has a serializable request beside it, so the artifact
+// degrades to request + frame summary rather than being dropped whole -- losing the submitted query in
+// exactly the hard-to-encode cases the artifact exists to capture would defeat its purpose.
+func TestMarshalQueryDataArtifact_degradesOnUnencodableResponse(t *testing.T) {
+	resp := &backend.QueryDataResponse{Responses: backend.Responses{
+		"A": {Frames: data.Frames{frameWithUnencodableMeta(longMarshalError)}},
+	}}
+	request := json.RawMessage(`{"expr":"up"}`)
+
+	out, err := marshalQueryDataArtifact(request, resp)
+	require.Error(t, err, "the error is returned as well, so callers record it outside the artifact too")
+
+	var artifact queryDataArtifact
+	require.NoError(t, json.Unmarshal(out, &artifact))
+	require.JSONEq(t, string(request), string(artifact.Request),
+		"the submitted query is recorded nowhere else, so it must survive an unencodable response")
+	require.True(t, artifact.ResponseOmitted)
+	require.NotEmpty(t, artifact.ResponseSummary, "a frame summary stands in for the response")
+	require.Contains(t, artifact.ResponseError, "boom",
+		"the plugin's error is recorded whole; the bundle budget is what bounds it now")
+}
+
 func TestSummarizeQueryDataResponse(t *testing.T) {
 	t.Run("status never reports success next to an error", func(t *testing.T) {
 		// Core datasources run in-process, so nothing normalizes their status the way the SDK does on the

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -1011,19 +1011,68 @@ func TestQueryDataLowerBoundBytes(t *testing.T) {
 
 func ptr[T any](v T) *T { return &v }
 
-func TestBundler_Build_declinesQueryDataItCannotFit(t *testing.T) {
-	// A string field larger than the whole budget: the floor alone exceeds it, so the response must never
-	// be marshalled -- avoiding the allocation is the reason the check exists.
+// The pre-panel stop in pkg/api accumulates capture across panels, and most capture now arrives as
+// __har__ frames rather than in the in-process buffer: an out-of-process datasource leaves that buffer
+// empty however much traffic it recorded. Counting only the buffer would leave the accumulator at zero
+// for every external plugin, so the stop would never fire for them.
+func TestCapturedHARBytes(t *testing.T) {
+	harFrame := func(payload string) *data.Frame {
+		f := data.NewFrame("")
+		f.Meta = &data.FrameMeta{Custom: map[string]interface{}{"har": payload}}
+		return f
+	}
+
+	t.Run("nil and capture-free responses cost nothing", func(t *testing.T) {
+		require.Zero(t, CapturedHARBytes(nil))
+		require.Zero(t, CapturedHARBytes(&backend.QueryDataResponse{Responses: backend.Responses{
+			"A": {Frames: data.Frames{data.NewFrame("cpu", data.NewField("v", nil, []float64{1}))}},
+		}}))
+	})
+
+	t.Run("sums every __har__ frame across datasources", func(t *testing.T) {
+		a, b := strings.Repeat("x", 100), strings.Repeat("y", 250)
+		resp := &backend.QueryDataResponse{Responses: backend.Responses{
+			"A":                             {Frames: data.Frames{data.NewFrame("cpu", data.NewField("v", nil, []float64{1}))}},
+			harResponseRefIDPrefix + "ds-1": {Frames: data.Frames{harFrame(a)}},
+			harResponseRefIDPrefix + "ds-2": {Frames: data.Frames{harFrame(b)}},
+		}}
+		require.Equal(t, len(a)+len(b), CapturedHARBytes(resp),
+			"a multi-datasource panel yields one __har__ response each; all must be counted")
+	})
+
+	t.Run("counts a capture the in-process buffer knows nothing about", func(t *testing.T) {
+		payload := strings.Repeat("z", 512)
+		resp := &backend.QueryDataResponse{Responses: backend.Responses{
+			harResponseRefIDPrefix + "external": {Frames: data.Frames{harFrame(payload)}},
+		}}
+		buffer := &harcapture.Buffer{}
+
+		require.Zero(t, buffer.RetainedBytes(), "an out-of-process plugin leaves the buffer empty")
+		require.Equal(t, len(payload), CapturedHARBytes(resp),
+			"so this is the only accounting that sees the traffic at all")
+	})
+}
+
+// Declining the response must not take the request with it: the request appears nowhere else in the
+// bundle and is what a support engineer needs to reproduce the query.
+func TestBundler_Build_keepsTheRequestWhenTheResponseIsDeclined(t *testing.T) {
 	huge := data.NewFrame("logs", data.NewField("line", nil, []string{strings.Repeat("x", MaxBundleBytes+1)}))
 	resp := &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{huge}}}}
+	request := json.RawMessage(`{"expr":"up"}`)
 
-	archive, result, err := NewBundler(nil).Build(resp, nil, nil, nil, json.RawMessage(`{"q":1}`), nil, nil)
+	archive, result, err := NewBundler(nil).Build(resp, nil, nil, nil, request, nil, nil)
 	require.NoError(t, err)
 	require.True(t, result.Partial())
 
 	files := readTarGz(t, archive)
-	require.NotContains(t, files, "querydata.json")
-	require.Contains(t, string(files["bundle-limit.txt"]), "not built",
-		"the reader must be able to tell it was declined rather than absent")
-	require.Contains(t, string(files["querydata-error.txt"]), "larger than the bundle size limit")
+	require.Contains(t, files, "querydata.json", "the artifact still ships, minus the response")
+
+	var artifact queryDataArtifact
+	require.NoError(t, json.Unmarshal(files["querydata.json"], &artifact))
+	require.JSONEq(t, string(request), string(artifact.Request), "the submitted query must survive")
+	require.True(t, artifact.ResponseOmitted)
+	require.Contains(t, artifact.ResponseError, "larger than the bundle size limit")
+	require.NotEmpty(t, artifact.ResponseSummary, "a frame summary stands in for the response")
+	require.Contains(t, string(files["bundle-limit.txt"]), "querydata.json response",
+		"bundle-limit.txt must name the response, not the whole artifact, since the artifact is present")
 }

--- a/pkg/services/diagnostics/environment.go
+++ b/pkg/services/diagnostics/environment.go
@@ -192,7 +192,7 @@ func CollectEnvironment(ctx context.Context, cfg *setting.Cfg, store PluginVersi
 		}
 		if p.Error != nil {
 			// Bounded: the text is plugin-authored and this artifact is otherwise fixed-size.
-			entry.Error = truncateDiagnosticString(p.Error.Error(), 1024)
+			entry.Error = p.Error.Error()
 		}
 		env.Plugins[id] = entry
 	}

--- a/pkg/services/diagnostics/environment_test.go
+++ b/pkg/services/diagnostics/environment_test.go
@@ -3,7 +3,6 @@ package diagnostics
 import (
 	"context"
 	"encoding/json"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -229,7 +228,7 @@ func TestBundler_Build_writesEnvironment(t *testing.T) {
 	refs.AddDatasource("P123", "grafana-mongodb-datasource")
 	env := CollectEnvironment(context.Background(), testCfg(), pluginstore.NewFakePluginStore(externalPlugin()), refs)
 
-	blob, err := NewBundler(env).Build(nil, nil, json.RawMessage(`{"id":1,"type":"timeseries"}`), nil, nil, nil, nil)
+	blob, _, err := NewBundler(env).Build(nil, nil, json.RawMessage(`{"id":1,"type":"timeseries"}`), nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -245,7 +244,7 @@ func TestBundler_Build_writesEnvironment(t *testing.T) {
 }
 
 func TestBundler_Build_omitsEnvironmentWhenUnavailable(t *testing.T) {
-	blob, err := NewBundler(nil).Build(nil, nil, json.RawMessage(`{"id":1}`), nil, nil, nil, nil)
+	blob, _, err := NewBundler(nil).Build(nil, nil, json.RawMessage(`{"id":1}`), nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.NotContains(t, readTarGz(t, blob), "environment.json")
 }
@@ -263,7 +262,7 @@ func TestBundler_BuildDashboard_writesEnvironmentAndPanelPluginIDs(t *testing.T)
 		PluginIDs:   []string{"grafana-mongodb-datasource", "timeseries"},
 	}}
 
-	blob, err := NewBundler(env).BuildDashboard(json.RawMessage(`{"title":"My dash"}`), panels)
+	blob, _, err := NewBundler(env).BuildDashboard(json.RawMessage(`{"title":"My dash"}`), panels)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -283,17 +282,4 @@ func TestBundler_BuildDashboard_writesEnvironmentAndPanelPluginIDs(t *testing.T)
 	// Versions are recorded ONCE at instance level, not repeated per panel.
 	require.NotContains(t, string(files["manifest.json"]), "1.4.2")
 	require.Contains(t, string(files["environment.json"]), "1.4.2")
-}
-
-func TestCollectEnvironment_boundsPluginError(t *testing.T) {
-	broken := externalPlugin()
-	broken.Error = &plugins.Error{PluginID: strings.Repeat("x", 4096), ErrorCode: plugins.ErrorCodeSignatureModified}
-
-	var refs EnvironmentRefs
-	refs.AddDatasource("P123", broken.ID)
-
-	env := CollectEnvironment(context.Background(), testCfg(), pluginstore.NewFakePluginStore(broken), refs)
-	require.NotNil(t, env)
-	require.LessOrEqual(t, len(env.Plugins[broken.ID].Error), 1024+len("…"),
-		"environment.json is otherwise fixed-size; a plugin-authored error must not blow that up")
 }


### PR DESCRIPTION
## What this does

Replaces the six interacting per-artifact size caps in the on-demand diagnostics feature with a
single ceiling on total artifact bytes, and enforces it at the points where memory is actually spent
rather than only at the end.

Size for the whole feature is now **two byte figures**:

| Limit | Value | Enforced |
|---|---|---|
| `diagnostics.MaxBundleBytes` | 1 GiB | during assembly, **and** before each panel runs in the dashboard generation loop |
| `diagnosticsJobStoreMaxBytes` | `2 * MaxBundleBytes` | on every prune (job create and job complete) |

## Why

Fine-grained caps turned out to be difficult to manage, and the more we extend the feature and add support for more plugins, the harder it gets to properly cover such limits. This PR aims at simplify this.

## Design notes for reviewers

**Artifacts are offered whole.** An artifact that would overrun the budget is dropped, not clipped —
half a JSON document or a truncated HAR diagnoses nothing. Every drop is named in a new
`bundle-limit.txt`, so a missing artifact is never mistaken for "there was nothing to capture".
