### PR TITLE
Diagnostics: log bundle generation outcomes and failures

### DIFF
--- a/pkg/api/ds_query_dashboard_diagnostics.go
+++ b/pkg/api/ds_query_dashboard_diagnostics.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"runtime/debug"
 	"sort"
 	"sync"
 	"time"
@@ -17,6 +18,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/infra/httpclient/harcapture"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/diagnostics"
@@ -277,13 +279,24 @@ func (hs *HTTPServer) QueryDashboardDiagnostics(c *contextmodel.ReqContext) resp
 		return response.Error(http.StatusBadRequest, "at least one panel is required", nil)
 	}
 
+	// FromContext copies the request's log fields (trace ID) into the logger rather than holding the
+	// context, so the detached goroutine below keeps them for the whole run even though the request that
+	// started it is long gone. Every line also carries the job UID, which is what the status/download
+	// calls arrive with.
+	logger := diagnosticsLogger.FromContext(c.Req.Context())
+
 	job, ok := dashboardDiagnosticsJobs.create(len(reqDTO.Panels), c.SignedInUser)
 	if !ok {
+		// Worth a line rather than only a 429: the cap is process-wide, so a rejection means someone
+		// else's runs are saturating it, which the rejected caller's own retries can never resolve.
+		logger.Warn("Rejected dashboard diagnostics run: too many already in progress",
+			"panels", len(reqDTO.Panels), "maxInFlight", diagnosticsMaxInFlightJobs)
 		return response.Error(http.StatusTooManyRequests, "too many dashboard diagnostics jobs are already in progress; try again once one finishes", nil)
 	}
 	if hs.diagnosticsMetrics != nil {
 		hs.diagnosticsMetrics.RecordStarted(c.Req.Context(), diagnostics.ScopeDashboard)
 	}
+	logger.Info("Started dashboard diagnostics run", "jobUid", job.UID, "panels", len(reqDTO.Panels))
 
 	// Snapshot the identity + cache flag + Query V2 signal; the goroutine must not touch the request
 	// or its context (both are tied to the HTTP request's lifetime, which ends when we return 202).
@@ -315,6 +328,13 @@ func (hs *HTTPServer) QueryDashboardDiagnostics(c *contextmodel.ReqContext) resp
 				if hs.diagnosticsMetrics != nil {
 					hs.diagnosticsMetrics.RecordCompleted(detachedCtx, diagnostics.ScopeDashboard, diagnostics.ResultError)
 				}
+				// The job record keeps the panic value but not where it came from, and this goroutine is
+				// detached from the request that would otherwise log the stack. Without this the only
+				// trace of a panicking plugin is "dashboard diagnostics panic: ..." in a job that expires
+				// within the hour. Logged like the support bundle's collector panic, which is the same
+				// shape of failure: a detached generation that dies mid-flight.
+				logger.Error("Dashboard diagnostics run panicked", "jobUid", uid, "panels", len(req.Panels),
+					"err", r, "stack", string(debug.Stack()))
 			}
 		}()
 
@@ -324,6 +344,7 @@ func (hs *HTTPServer) QueryDashboardDiagnostics(c *contextmodel.ReqContext) resp
 			if hs.diagnosticsMetrics != nil {
 				hs.diagnosticsMetrics.RecordCompleted(detachedCtx, diagnostics.ScopeDashboard, diagnostics.ResultError)
 			}
+			logger.Error("Dashboard diagnostics run failed", "jobUid", uid, "panels", len(req.Panels), "err", err)
 			return
 		}
 		dashboardDiagnosticsJobs.complete(uid, archive)
@@ -363,6 +384,10 @@ func (hs *HTTPServer) DownloadDashboardDiagnostics(c *contextmodel.ReqContext) r
 	uid := web.Params(c.Req)[":uid"]
 	archive, state, ok := dashboardDiagnosticsJobs.archiveOf(uid, c.SignedInUser)
 	if !ok {
+		// A download that arrives after the job was pruned (retention TTL, max-entries eviction, or a
+		// restart -- the store is in-memory) looks identical to a bad UID from the client's side. Log it
+		// so "the download 404s" can be told apart from "generation never ran".
+		diagnosticsLogger.FromContext(c.Req.Context()).Info("Diagnostics download for an unknown or expired job", "jobUid", uid)
 		return response.Error(http.StatusNotFound, "diagnostics job not found (it may have expired)", nil)
 	}
 	if state != jobComplete {
@@ -382,6 +407,9 @@ func (hs *HTTPServer) DownloadDashboardDiagnostics(c *contextmodel.ReqContext) r
 // job progress as panels complete, then delegates archive assembly to the diagnostics service. A
 // non-data panel (no queries) is recorded as skipped rather than run.
 func (hs *HTTPServer) buildDashboardDiagnosticsArchive(ctx context.Context, user identity.Requester, skipDSCache, useQueryDataNew bool, reqDTO dashboardDiagnosticsRequest, jobUID string) ([]byte, error) {
+	logger := diagnosticsLogger.FromContext(ctx)
+	started := time.Now()
+
 	queryData := hs.queryDataService.QueryData
 	if useQueryDataNew {
 		queryData = hs.queryDataService.QueryDataNew
@@ -391,6 +419,7 @@ func (hs *HTTPServer) buildDashboardDiagnosticsArchive(ctx context.Context, user
 	vizPluginIDByPanelID := diagnostics.PanelPluginIDs(reqDTO.Dashboard)
 	var envRefs diagnostics.EnvironmentRefs
 
+	outcome := dashboardDiagnosticsOutcome{jobUID: jobUID, panelsTotal: len(reqDTO.Panels)}
 	panels := make([]diagnostics.DashboardPanel, 0, len(reqDTO.Panels))
 	for i, p := range reqDTO.Panels {
 		// ctx is detachedCtx (see QueryDashboardDiagnostics), derived from context.WithoutCancel, so
@@ -425,6 +454,7 @@ func (hs *HTTPServer) buildDashboardDiagnosticsArchive(ctx context.Context, user
 
 		if len(p.Queries) == 0 {
 			panel.Skipped = "no queries (non-data panel)"
+			outcome.panelsSkipped++
 			panels = append(panels, panel)
 			dashboardDiagnosticsJobs.setProgress(jobUID, i+1)
 			continue
@@ -443,13 +473,64 @@ func (hs *HTTPServer) buildDashboardDiagnosticsArchive(ctx context.Context, user
 		if panel.QueryErr == nil {
 			panel.QueryErr = errors.Join(diagnostics.ResponseError(resp), diagnostics.PluginCaptureError(resp))
 		}
+		if panel.QueryErr != nil {
+			outcome.panelsFailed++
+			// Per panel, at debug: the summary below reports how many failed, and this is what says which
+			// ones and why without asking the operator to unpack the archive's manifest.json.
+			logger.Debug("Dashboard diagnostics panel query failed", "jobUid", jobUID, "panelId", p.ID, "err", panel.QueryErr)
+		}
+		// Asked before BuildDashboard consumes the external plugins' __har__ responses out of resp; after
+		// it, every externalized datasource would report as having captured nothing.
+		if diagnostics.HasCapturedHAR(resp, harBuffer) {
+			outcome.panelsCaptured++
+		}
 
 		panels = append(panels, panel)
 		dashboardDiagnosticsJobs.setProgress(jobUID, i+1)
 	}
 
 	env := diagnostics.CollectEnvironment(ctx, hs.Cfg, hs.pluginStore, envRefs)
-	return diagnostics.NewBundler(env).BuildDashboard(reqDTO.Dashboard, panels)
+	archive, err := diagnostics.NewBundler(env).BuildDashboard(reqDTO.Dashboard, panels)
+	if err != nil {
+		return nil, err
+	}
+	outcome.durationMs = time.Since(started).Milliseconds()
+	outcome.bundleBytes = len(archive)
+	logDashboardDiagnosticsBundle(logger, outcome)
+	return archive, nil
+}
+
+// dashboardDiagnosticsOutcome is what one whole-dashboard run produced, for the terminal log line.
+// Ratios, not identities: which panels and datasources were involved is in the archive's manifest.json.
+type dashboardDiagnosticsOutcome struct {
+	jobUID      string
+	durationMs  int64
+	bundleBytes int
+	panelsTotal int
+	// panelsSkipped counts non-data panels, which never ran and are not failures.
+	panelsSkipped int
+	// panelsFailed counts panels whose queries errored. Captured failures are what the bundle is for, so
+	// this is a property of the dashboard, not of the run.
+	panelsFailed int
+	// panelsCaptured counts panels that produced HTTP traffic. Run panels beyond this count contributed
+	// no traffic.har at all.
+	panelsCaptured int
+}
+
+// logDashboardDiagnosticsBundle logs a completed archive, warning when no panel that ran produced any
+// captured traffic -- an archive of panel JSON and nothing to diagnose, which is what a non-HTTP
+// datasource (SQL, Mongo) or a plugin with its own HTTP client yields. A partial capture stays at info:
+// a mixed dashboard legitimately has panels of both kinds, and the manifest names which is which.
+func logDashboardDiagnosticsBundle(logger log.Logger, o dashboardDiagnosticsOutcome) {
+	panelsRun := o.panelsTotal - o.panelsSkipped
+	args := []any{"jobUid", o.jobUID, "durationMs", o.durationMs, "bundleBytes", o.bundleBytes,
+		"panelsTotal", o.panelsTotal, "panelsRun", panelsRun, "panelsSkipped", o.panelsSkipped,
+		"panelsFailed", o.panelsFailed, "panelsCaptured", o.panelsCaptured}
+	if panelsRun > 0 && o.panelsCaptured == 0 {
+		logger.Warn("Generated dashboard diagnostics bundle with no captured traffic", args...)
+		return
+	}
+	logger.Info("Generated dashboard diagnostics bundle", args...)
 }
 
 // panelEnvironmentRefs collects the plugins one panel referenced, from the payload the client

--- a/pkg/api/ds_query_diagnostics.go
+++ b/pkg/api/ds_query_diagnostics.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/infra/httpclient/harcapture"
+	"github.com/grafana/grafana/pkg/infra/log"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/diagnostics"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -32,6 +33,14 @@ type diagnosticsRequest struct {
 // evaluated via OpenFeature rather than featuremgmt.FeatureToggles.IsEnabled, which is deprecated
 // (staticcheck SA1019) and slated for removal.
 var diagnosticsFeatureClient = openfeature.NewDefaultClient()
+
+// diagnosticsLogger is the named logger shared by both diagnostics endpoints, so an operator can raise
+// only this feature ([log] filters = diagnostics:debug) instead of http.server as a whole.
+//
+// Every run reaches a terminal line here, because a failed generation is otherwise invisible on the
+// server that ran it: the panel path reports the failure only in the requesting browser, and the
+// dashboard path only in a job record that expires within the hour.
+var diagnosticsLogger = log.New("diagnostics")
 
 // QueryDiagnostics executes the supplied datasource queries with HAR capture active and returns a
 // .tar.gz diagnostic bundle (captured traffic and the panel/dashboard JSON). Bundle assembly lives
@@ -60,6 +69,11 @@ func (hs *HTTPServer) QueryDiagnostics(c *contextmodel.ReqContext) response.Resp
 			hs.diagnosticsMetrics.RecordCompleted(ctx, diagnostics.ScopePanel, result)
 		}()
 	}
+
+	// FromContext so the run's lines carry the request's trace ID, which is what ties them to the
+	// datasource and plugin lines emitted while the queries below run.
+	logger := diagnosticsLogger.FromContext(ctx)
+	started := time.Now()
 
 	captureCtx, harBuffer := harcapture.WithCapture(ctx)
 
@@ -99,8 +113,13 @@ func (hs *HTTPServer) QueryDiagnostics(c *contextmodel.ReqContext) response.Resp
 	// failure is a client error (400). A failure that did hit the wire leaves captured traffic and
 	// falls through — that captured failure is exactly what the bundle is for, recorded alongside
 	// query-error.txt.
-	if !diagnostics.HasCapturedHAR(resp, harBuffer) {
+	// Read before Build: collectHAR consumes the external plugins' __har__ responses out of resp, so
+	// asking afterwards would report "nothing captured" for every externalized datasource.
+	capturedHAR := diagnostics.HasCapturedHAR(resp, harBuffer)
+	if !capturedHAR {
 		if r := hs.diagnosticsNoCaptureError(queryErr, respErr); r != nil {
+			logger.Warn("Panel diagnostics failed before any traffic was captured", "durationMs", time.Since(started).Milliseconds(),
+				"queries", len(reqDTO.Queries), "err", errors.Join(queryErr, respErr))
 			return r
 		}
 	}
@@ -122,8 +141,19 @@ func (hs *HTTPServer) QueryDiagnostics(c *contextmodel.ReqContext) response.Resp
 	bundle, err := diagnostics.NewBundler(env).Build(resp, harBuffer, reqDTO.Panel, reqDTO.Dashboard, queryRequestJSON, marshalErr, bundleErr,
 		diagnostics.WithPanelData(reqDTO.PanelData))
 	if err != nil {
+		logger.Error("Failed to build panel diagnostics bundle", "durationMs", time.Since(started).Milliseconds(),
+			"queries", len(reqDTO.Queries), "capturedHar", capturedHAR, "err", err)
 		return response.Error(http.StatusInternalServerError, "failed to build diagnostics bundle", err)
 	}
+	logPanelDiagnosticsBundle(logger, panelDiagnosticsOutcome{
+		durationMs:   time.Since(started).Milliseconds(),
+		queries:      len(reqDTO.Queries),
+		bundleBytes:  len(bundle),
+		harEntries:   harBuffer.Len(),
+		capturedHAR:  capturedHAR,
+		queryFailed:  bundleErr != nil,
+		requestError: marshalErr != nil,
+	})
 
 	filename := fmt.Sprintf("diagnostics-%s.tar.gz", time.Now().UTC().Format("20060102-150405"))
 	header := http.Header{}
@@ -131,6 +161,37 @@ func (hs *HTTPServer) QueryDiagnostics(c *contextmodel.ReqContext) response.Resp
 	header.Set("Content-Type", "application/tar+gzip")
 	result = diagnostics.ResultSuccess
 	return response.CreateNormalResponse(header, bundle, http.StatusOK)
+}
+
+// panelDiagnosticsOutcome is what one single-panel run produced, for the terminal log line.
+type panelDiagnosticsOutcome struct {
+	durationMs  int64
+	queries     int
+	bundleBytes int
+	harEntries  int // in-process (core plugin) entries only; an externalized plugin's arrive pre-serialized
+	capturedHAR bool
+	// queryFailed records that the run captured a query failure; it does not record a
+	// failure in generating a diagnostic bundle, which should NOT happen
+	queryFailed bool
+	// requestError records that the submitted queries could not be serialized, so the bundle has no
+	// request to compare its captured traffic against.
+	requestError bool
+}
+
+// logPanelDiagnosticsBundle logs a delivered bundle, warning when it is missing an artifact the reader
+// will expect. A bundle with no traffic.har is the failure worth a warning even though the request
+// succeeded: the datasource may not run its HTTP through the instrumented client (SQL and other
+// non-HTTP plugins never do), or the failure may be in a call diagnostics does not capture -- and
+// without this line, the only symptom is a support engineer opening an archive with nothing in it.
+func logPanelDiagnosticsBundle(logger log.Logger, o panelDiagnosticsOutcome) {
+	args := []any{"durationMs", o.durationMs, "queries", o.queries, "bundleBytes", o.bundleBytes,
+		"harEntries", o.harEntries, "capturedHar", o.capturedHAR, "queryFailed", o.queryFailed,
+		"requestSerializeFailed", o.requestError}
+	if !o.capturedHAR || o.requestError {
+		logger.Warn("Generated panel diagnostics bundle with missing artifacts", args...)
+		return
+	}
+	logger.Info("Generated panel diagnostics bundle", args...)
 }
 
 // diagnosticsNoCaptureError returns the response to send when a query failed and nothing was

--- a/pkg/api/ds_query_diagnostics_log_test.go
+++ b/pkg/api/ds_query_diagnostics_log_test.go
@@ -1,0 +1,93 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/log/logtest"
+)
+
+func ctxValue(t *testing.T, ctx []any, key string) any {
+	t.Helper()
+	for i := 0; i+1 < len(ctx); i += 2 {
+		if ctx[i] == key {
+			return ctx[i+1]
+		}
+	}
+	t.Fatalf("log line has no %q field: %v", key, ctx)
+	return nil
+}
+
+func TestLogPanelDiagnosticsBundle(t *testing.T) {
+	t.Run("a complete bundle is logged at info", func(t *testing.T) {
+		fake := &logtest.Fake{}
+		logPanelDiagnosticsBundle(fake, panelDiagnosticsOutcome{
+			durationMs: 12, queries: 2, bundleBytes: 4096, harEntries: 3, capturedHAR: true,
+		})
+
+		require.Equal(t, 1, fake.InfoLogs.Calls)
+		require.Zero(t, fake.WarnLogs.Calls)
+		require.Equal(t, 3, ctxValue(t, fake.InfoLogs.Ctx, "harEntries"))
+		require.Equal(t, 4096, ctxValue(t, fake.InfoLogs.Ctx, "bundleBytes"))
+	})
+
+	t.Run("a captured query failure is still a successful run", func(t *testing.T) {
+		fake := &logtest.Fake{}
+		logPanelDiagnosticsBundle(fake, panelDiagnosticsOutcome{capturedHAR: true, harEntries: 1, queryFailed: true})
+
+		require.Equal(t, 1, fake.InfoLogs.Calls)
+		require.Zero(t, fake.WarnLogs.Calls)
+		require.Equal(t, true, ctxValue(t, fake.InfoLogs.Ctx, "queryFailed"))
+	})
+
+	t.Run("a bundle with no captured traffic warns", func(t *testing.T) {
+		fake := &logtest.Fake{}
+		logPanelDiagnosticsBundle(fake, panelDiagnosticsOutcome{queries: 1, bundleBytes: 512})
+
+		require.Equal(t, 1, fake.WarnLogs.Calls)
+		require.Zero(t, fake.InfoLogs.Calls)
+		require.Equal(t, false, ctxValue(t, fake.WarnLogs.Ctx, "capturedHar"))
+	})
+
+	t.Run("an unserializable request warns even with captured traffic", func(t *testing.T) {
+		fake := &logtest.Fake{}
+		logPanelDiagnosticsBundle(fake, panelDiagnosticsOutcome{capturedHAR: true, harEntries: 2, requestError: true})
+
+		require.Equal(t, 1, fake.WarnLogs.Calls)
+		require.Zero(t, fake.InfoLogs.Calls)
+		require.Equal(t, true, ctxValue(t, fake.WarnLogs.Ctx, "requestSerializeFailed"))
+	})
+}
+
+func TestLogDashboardDiagnosticsBundle(t *testing.T) {
+	t.Run("panelsRun is reported net of skipped panels", func(t *testing.T) {
+		fake := &logtest.Fake{}
+		logDashboardDiagnosticsBundle(fake, dashboardDiagnosticsOutcome{
+			jobUID: "job-1", panelsTotal: 5, panelsSkipped: 2, panelsFailed: 1, panelsCaptured: 3,
+		})
+
+		require.Equal(t, 1, fake.InfoLogs.Calls)
+		require.Zero(t, fake.WarnLogs.Calls)
+		require.Equal(t, 3, ctxValue(t, fake.InfoLogs.Ctx, "panelsRun"))
+		require.Equal(t, "job-1", ctxValue(t, fake.InfoLogs.Ctx, "jobUid"))
+	})
+
+	t.Run("run panels that captured nothing warn", func(t *testing.T) {
+		fake := &logtest.Fake{}
+		logDashboardDiagnosticsBundle(fake, dashboardDiagnosticsOutcome{jobUID: "job-2", panelsTotal: 3})
+
+		require.Equal(t, 1, fake.WarnLogs.Calls)
+		require.Zero(t, fake.InfoLogs.Calls)
+		require.Equal(t, 0, ctxValue(t, fake.WarnLogs.Ctx, "panelsCaptured"))
+	})
+
+	t.Run("a dashboard of only skipped panels does not warn", func(t *testing.T) {
+		fake := &logtest.Fake{}
+		logDashboardDiagnosticsBundle(fake, dashboardDiagnosticsOutcome{jobUID: "job-3", panelsTotal: 2, panelsSkipped: 2})
+
+		require.Equal(t, 1, fake.InfoLogs.Calls)
+		require.Zero(t, fake.WarnLogs.Calls)
+		require.Equal(t, 0, ctxValue(t, fake.InfoLogs.Ctx, "panelsRun"))
+	})
+}


### PR DESCRIPTION
## What this PR does

On-demand datasource diagnostics generation emitted **no server logs at all**. This adds a named `diagnostics` logger and takes every run to a terminal line.

## Out of scope

- Frontend reporting — separate PR per `check-separation`.
- Audit logging of *who* generated a bundle — these lines are operational, not an audit trail.
