### PR TITLE
Provisioning: Per-worker job queue size metric and job TotalChanges

### DIFF
--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/jobs.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/jobs.go
@@ -406,6 +406,11 @@ type JobResourceSummary struct {
 	// No action required (useful for sync)
 	Noop int64 `json:"noop,omitempty"`
 
+	// TotalChanges is the action-aware count of resources changed for this group/kind,
+	// set by the progress recorder as results are recorded. Used for the job-duration
+	// histogram's resources_changed bucket.
+	TotalChanges int64 `json:"totalChanges,omitempty"`
+
 	// Report errors/warnings for this resource type
 	// This may not be an exhaustive list and recommend looking at the logs for more info
 	Errors   []string `json:"errors,omitempty"`

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
@@ -1659,6 +1659,13 @@ func schema_pkg_apis_provisioning_v0alpha1_JobResourceSummary(ref common.Referen
 							Format:      "int64",
 						},
 					},
+					"totalChanges": {
+						SchemaProps: spec.SchemaProps{
+							Description: "TotalChanges is the action-aware count of resources changed for this group/kind, set by the progress recorder as results are recorded. Used for the job-duration histogram's resources_changed bucket.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
 					"errors": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Report errors/warnings for this resource type This may not be an exhaustive list and recommend looking at the logs for more info",

--- a/apps/provisioning/pkg/generated/applyconfiguration/provisioning/v0alpha1/jobresourcesummary.go
+++ b/apps/provisioning/pkg/generated/applyconfiguration/provisioning/v0alpha1/jobresourcesummary.go
@@ -20,6 +20,10 @@ type JobResourceSummaryApplyConfiguration struct {
 	Warning *int64 `json:"warning,omitempty"`
 	// No action required (useful for sync)
 	Noop *int64 `json:"noop,omitempty"`
+	// TotalChanges is the action-aware count of resources changed for this group/kind,
+	// set by the progress recorder as results are recorded. Used for the job-duration
+	// histogram's resources_changed bucket.
+	TotalChanges *int64 `json:"totalChanges,omitempty"`
 	// Report errors/warnings for this resource type
 	// This may not be an exhaustive list and recommend looking at the logs for more info
 	Errors   []string `json:"errors,omitempty"`
@@ -109,6 +113,14 @@ func (b *JobResourceSummaryApplyConfiguration) WithWarning(value int64) *JobReso
 // If called multiple times, the Noop field is set to the value of the last call.
 func (b *JobResourceSummaryApplyConfiguration) WithNoop(value int64) *JobResourceSummaryApplyConfiguration {
 	b.Noop = &value
+	return b
+}
+
+// WithTotalChanges sets the TotalChanges field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the TotalChanges field is set to the value of the last call.
+func (b *JobResourceSummaryApplyConfiguration) WithTotalChanges(value int64) *JobResourceSummaryApplyConfiguration {
+	b.TotalChanges = &value
 	return b
 }
 

--- a/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
@@ -1768,6 +1768,8 @@ export type JobResourceSummary = {
   /** No action required (useful for sync) */
   noop?: number;
   total?: number;
+  /** TotalChanges is the action-aware count of resources changed for this group/kind, set by the progress recorder as results are recorded. Used for the job-duration histogram's resources_changed bucket. */
+  totalChanges?: number;
   update?: number;
   /** The error count */
   warning?: number;

--- a/packages/grafana-openapi/src/apis/provisioning.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/provisioning.grafana.app-v0alpha1.json
@@ -4696,6 +4696,11 @@
             "type": "integer",
             "format": "int64"
           },
+          "totalChanges": {
+            "description": "TotalChanges is the action-aware count of resources changed for this group/kind, set by the progress recorder as results are recorded. Used for the job-duration histogram's resources_changed bucket.",
+            "type": "integer",
+            "format": "int64"
+          },
           "update": {
             "type": "integer",
             "format": "int64"

--- a/packages/grafana-openapi/src/apis/provisioning.grafana.app-v1beta1.json
+++ b/packages/grafana-openapi/src/apis/provisioning.grafana.app-v1beta1.json
@@ -4508,6 +4508,11 @@
             "type": "integer",
             "format": "int64"
           },
+          "totalChanges": {
+            "description": "TotalChanges is the action-aware count of resources changed for this group/kind, set by the progress recorder as results are recorded. Used for the job-duration histogram's resources_changed bucket.",
+            "type": "integer",
+            "format": "int64"
+          },
           "update": {
             "type": "integer",
             "format": "int64"

--- a/pkg/registry/apis/provisioning/jobs/concurrent_driver.go
+++ b/pkg/registry/apis/provisioning/jobs/concurrent_driver.go
@@ -117,7 +117,7 @@ func NewConcurrentJobDriver(
 
 	recordConcurrentDriverMetric(registry, numDrivers)
 
-	return &ConcurrentJobDriver{
+	driver := &ConcurrentJobDriver{
 		numDrivers:           numDrivers,
 		jobTimeout:           jobTimeout,
 		leaseRenewalInterval: leaseRenewalInterval,
@@ -137,7 +137,21 @@ func NewConcurrentJobDriver(
 		cooldowns: make(map[string]time.Time),
 		triggers:  make(map[string]queuedEvent),
 		logger:    logging.DefaultLogger.With("logger", "concurrent-job-driver"),
-	}, nil
+	}
+
+	// Expose the local work-queue depth as a scrape-time gauge. The queue is
+	// per-replica, so Prometheus target labels (pod/instance) distinguish replicas;
+	// no metric label is needed. A GaugeFunc reads the authoritative Len() at scrape
+	// time, so it cannot drift the way manual inc/dec would.
+	registry.MustRegister(prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Name: "grafana_provisioning_jobs_worker_queue_size",
+			Help: "Number of job keys waiting in this replica's local work queue",
+		},
+		func() float64 { return float64(driver.queue.Len()) },
+	))
+
+	return driver, nil
 }
 
 // EventHandler returns informer event handlers that feed the work queue.

--- a/pkg/registry/apis/provisioning/jobs/concurrent_driver_test.go
+++ b/pkg/registry/apis/provisioning/jobs/concurrent_driver_test.go
@@ -45,6 +45,47 @@ func TestNewConcurrentJobDriver_RejectsBadConfig(t *testing.T) {
 	require.ErrorContains(t, err, "numDrivers")
 }
 
+// gaugeValueByName reads the single-sample gauge `name` from the gatherer.
+func gaugeValueByName(t *testing.T, g prometheus.Gatherer, name string) float64 {
+	t.Helper()
+	mfs, err := g.Gather()
+	require.NoError(t, err)
+	for _, mf := range mfs {
+		if mf.GetName() == name {
+			require.Len(t, mf.GetMetric(), 1)
+			return mf.GetMetric()[0].GetGauge().GetValue()
+		}
+	}
+	t.Fatalf("metric %q not found", name)
+	return 0
+}
+
+// TestConcurrentJobDriver_WorkerQueueSizeGauge verifies the worker-queue-size gauge
+// reports the live depth of the replica's local work queue at scrape time.
+func TestConcurrentJobDriver_WorkerQueueSizeGauge(t *testing.T) {
+	const metricName = "grafana_provisioning_jobs_worker_queue_size"
+
+	reg := prometheus.NewRegistry()
+	driver, err := NewConcurrentJobDriver(
+		1,
+		time.Minute, 30*time.Second, 30*time.Second,
+		&MockStore{}, &MockRepoGetter{}, &MockHistoryWriter{},
+		reg, nil, false,
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, 0.0, gaugeValueByName(t, reg, metricName))
+
+	driver.queue.Add("ns/job-a")
+	driver.queue.Add("ns/job-b")
+	require.Equal(t, 2.0, gaugeValueByName(t, reg, metricName))
+
+	// Get removes the key from the queue (Len drops); Done clears it from processing.
+	key, _ := driver.queue.Get()
+	driver.queue.Done(key)
+	require.Equal(t, 1.0, gaugeValueByName(t, reg, metricName))
+}
+
 // TestConcurrentJobDriver_EventHandler_Enqueue verifies which informer add
 // events feed the work queue: minimal (NATS-style) objects and unclaimed full
 // objects enqueue, while full objects that already carry a claim are skipped.

--- a/pkg/registry/apis/provisioning/jobs/driver.go
+++ b/pkg/registry/apis/provisioning/jobs/driver.go
@@ -250,7 +250,7 @@ func (d *jobProcessor) processKey(ctx context.Context, namespace, name string, t
 		d.metrics.RecordJob(
 			string(d.currentJob.Spec.Action),
 			string(d.currentJob.Status.State),
-			resourceChangeCount(d.currentJob.Spec.Action, d.currentJob.Status.Summary),
+			sumTotalChanges(d.currentJob.Status.Summary),
 			duration.Seconds(),
 		)
 	}
@@ -508,27 +508,17 @@ func (d *jobProcessor) processJob(ctx context.Context, recorder JobProgressRecor
 	return err
 }
 
-// resourceChangeCount totals the resources a job changed, for the duration histogram
-// bucket. It is action-aware to match each worker's original counting: push counts
-// writes; delete counts deletes; move counts creates only (a rename is recorded as
-// both a create and a delete, so summing would double-count); everything else (pull,
-// migrate, ...) sums create+update+delete.
-func resourceChangeCount(action provisioning.JobAction, summaries []*provisioning.JobResourceSummary) int {
+// sumTotalChanges totals the per-summary TotalChanges for the duration-histogram
+// bucket. Each JobResourceSummary carries an action-aware change count set by the
+// progress recorder as results are recorded (see updateSummary), so the driver only
+// has to add them up.
+func sumTotalChanges(summaries []*provisioning.JobResourceSummary) int {
 	total := 0
 	for _, s := range summaries {
 		if s == nil {
 			continue
 		}
-		switch action {
-		case provisioning.JobActionPush:
-			total += int(s.Write)
-		case provisioning.JobActionDelete:
-			total += int(s.Delete)
-		case provisioning.JobActionMove:
-			total += int(s.Create)
-		default:
-			total += int(s.Create + s.Update + s.Delete)
-		}
+		total += int(s.TotalChanges)
 	}
 	return total
 }

--- a/pkg/registry/apis/provisioning/jobs/driver_test.go
+++ b/pkg/registry/apis/provisioning/jobs/driver_test.go
@@ -27,23 +27,18 @@ func newConflictError() error {
 	)
 }
 
-func TestResourceChangeCount(t *testing.T) {
+// TestSumTotalChanges verifies the driver totals the per-summary TotalChanges the
+// recorder set (see TestUpdateSummary_TotalChanges for the action-aware population),
+// skipping nil entries.
+func TestSumTotalChanges(t *testing.T) {
+	require.Equal(t, 0, sumTotalChanges(nil))
+
 	summaries := []*provisioning.JobResourceSummary{
-		{Create: 2, Update: 3, Delete: 4, Write: 5},
+		{TotalChanges: 5},
 		nil,
-		{Create: 1, Update: 1, Delete: 1, Write: 1},
+		{TotalChanges: 3},
 	}
-
-	require.Equal(t, 0, resourceChangeCount(provisioning.JobActionPull, nil))
-
-	// pull (default): create+update+delete = (2+3+4)+(1+1+1) = 12
-	require.Equal(t, 12, resourceChangeCount(provisioning.JobActionPull, summaries))
-	// push: writes only = 5+1
-	require.Equal(t, 6, resourceChangeCount(provisioning.JobActionPush, summaries))
-	// delete: deletes only = 4+1
-	require.Equal(t, 5, resourceChangeCount(provisioning.JobActionDelete, summaries))
-	// move: creates only (a rename is both create+delete; count once) = 2+1
-	require.Equal(t, 3, resourceChangeCount(provisioning.JobActionMove, summaries))
+	require.Equal(t, 8, sumTotalChanges(summaries))
 }
 
 func makeTestJob(rv string) *provisioning.Job {

--- a/pkg/registry/apis/provisioning/jobs/metrics.go
+++ b/pkg/registry/apis/provisioning/jobs/metrics.go
@@ -42,7 +42,6 @@ const (
 const resourceLabelJobs = "jobs"
 
 type QueueMetrics struct {
-	queueSize     *prometheus.GaugeVec
 	queueWaitTime *prometheus.HistogramVec
 
 	// Claim metrics, per driver_id. These count per CAS (compare-and-swap) attempt on a
@@ -69,15 +68,6 @@ var (
 
 func RegisterQueueMetrics(registry prometheus.Registerer) QueueMetrics {
 	queueOnce.Do(func() {
-		queueSize := prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "grafana_provisioning_jobs_queue_size",
-				Help: "Number of jobs currently in the queue",
-			},
-			[]string{"action"},
-		)
-		registry.MustRegister(queueSize)
-
 		queueWaitTime := prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
 				Name:    "grafana_provisioning_jobs_queue_wait_seconds",
@@ -125,7 +115,6 @@ func RegisterQueueMetrics(registry prometheus.Registerer) QueueMetrics {
 		registry.MustRegister(claimRoundsCont)
 
 		queueMetrics = QueueMetrics{
-			queueSize:       queueSize,
 			queueWaitTime:   queueWaitTime,
 			claimed:         claimed,
 			claimConflicts:  claimConflicts,
@@ -134,14 +123,6 @@ func RegisterQueueMetrics(registry prometheus.Registerer) QueueMetrics {
 		}
 	})
 	return queueMetrics
-}
-
-func (m *QueueMetrics) IncreaseQueueSize(action string) {
-	m.queueSize.WithLabelValues(action).Inc()
-}
-
-func (m *QueueMetrics) DecreaseQueueSize(action string) {
-	m.queueSize.WithLabelValues(action).Dec()
 }
 
 func (m *QueueMetrics) RecordWaitTime(action string, waitSeconds float64) {

--- a/pkg/registry/apis/provisioning/jobs/persistentstore.go
+++ b/pkg/registry/apis/provisioning/jobs/persistentstore.go
@@ -377,7 +377,6 @@ func (s *persistentStore) Complete(ctx context.Context, job *provisioning.Job) e
 	}
 	delete(job.Labels, LabelJobClaim)
 	delete(job.Labels, LabelJobClaimOwner)
-	s.queueMetrics.DecreaseQueueSize(string(job.Spec.Action))
 
 	logger.Debug("complete job complete")
 	return nil
@@ -578,8 +577,6 @@ func (s *persistentStore) Insert(ctx context.Context, namespace string, spec pro
 		return nil, apifmt.Errorf("failed to create job '%s' in '%s': %w", job.GetName(), job.GetNamespace(), err)
 	}
 
-	s.queueMetrics.IncreaseQueueSize(string(job.Spec.Action))
-
 	logger.Info("insert job complete")
 	return created, nil
 }
@@ -665,7 +662,6 @@ func (s *persistentStore) CleanupQueue(ctx context.Context, namespace, repositor
 			return deleted, apifmt.Errorf("failed to delete job '%s' in '%s': %w", job.GetName(), namespace, err)
 		}
 
-		s.queueMetrics.DecreaseQueueSize(string(job.Spec.Action))
 		deleted++
 	}
 

--- a/pkg/registry/apis/provisioning/jobs/persistentstore_test.go
+++ b/pkg/registry/apis/provisioning/jobs/persistentstore_test.go
@@ -538,7 +538,6 @@ func TestRenewLease_StaleResourceVersion(t *testing.T) {
 		clock:  time.Now,
 		expiry: 30 * time.Second,
 		queueMetrics: QueueMetrics{
-			queueSize:     nil,
 			queueWaitTime: nil,
 		},
 	}
@@ -589,7 +588,6 @@ func TestRenewLease_ResourceVersionProgresses(t *testing.T) {
 		clock:  time.Now,
 		expiry: 30 * time.Second,
 		queueMetrics: QueueMetrics{
-			queueSize:     nil,
 			queueWaitTime: nil,
 		},
 	}
@@ -641,7 +639,6 @@ func TestRenewLease_ThenUpdateDoesNotConflict(t *testing.T) {
 		clock:  time.Now,
 		expiry: 30 * time.Second,
 		queueMetrics: QueueMetrics{
-			queueSize:     nil,
 			queueWaitTime: nil,
 		},
 	}

--- a/pkg/registry/apis/provisioning/jobs/progress.go
+++ b/pkg/registry/apis/provisioning/jobs/progress.go
@@ -310,6 +310,22 @@ func (r *jobProgressRecorder) updateSummary(result JobResourceResult) {
 			summary.Create++
 		}
 		summary.Write = summary.Create + summary.Update
+
+		// Action-aware total, kept in sync with the counters above so the driver can
+		// sum it without re-deriving per action. Each single-purpose worker records
+		// one FileAction type: push writes, delete deletes, move renames (recorded as
+		// create+delete, so count creates only to avoid double-counting). Everything
+		// else (pull, migrate) sums create+update+delete.
+		switch r.action {
+		case provisioning.JobActionPush:
+			summary.TotalChanges = summary.Write
+		case provisioning.JobActionDelete:
+			summary.TotalChanges = summary.Delete
+		case provisioning.JobActionMove:
+			summary.TotalChanges = summary.Create
+		default:
+			summary.TotalChanges = summary.Create + summary.Update + summary.Delete
+		}
 	}
 }
 

--- a/pkg/registry/apis/provisioning/jobs/progress_test.go
+++ b/pkg/registry/apis/provisioning/jobs/progress_test.go
@@ -417,6 +417,62 @@ func TestJobProgressRecorderFolderFailureTracking(t *testing.T) {
 	recorder.mu.RUnlock()
 }
 
+// TestUpdateSummary_TotalChanges verifies the recorder sets the action-aware
+// TotalChanges on each summary as successful results are recorded, matching what
+// each single-purpose worker records: push→writes, delete→deletes, move→creates
+// (a rename is recorded as create+delete, so count creates once), else→create+update+delete.
+func TestUpdateSummary_TotalChanges(t *testing.T) {
+	ctx := context.Background()
+	noop := func(ctx context.Context, status provisioning.JobStatus) error { return nil }
+
+	tests := []struct {
+		name    string
+		action  provisioning.JobAction
+		actions []repository.FileAction
+		want    int64
+	}{
+		{
+			name:    "push counts writes",
+			action:  provisioning.JobActionPush,
+			actions: []repository.FileAction{repository.FileActionCreated, repository.FileActionCreated},
+			want:    2,
+		},
+		{
+			name:    "delete counts deletes",
+			action:  provisioning.JobActionDelete,
+			actions: []repository.FileAction{repository.FileActionDeleted, repository.FileActionDeleted},
+			want:    2,
+		},
+		{
+			name:    "move counts creates only",
+			action:  provisioning.JobActionMove,
+			actions: []repository.FileAction{repository.FileActionRenamed, repository.FileActionRenamed},
+			want:    2,
+		},
+		{
+			name:    "pull sums create+update+delete",
+			action:  provisioning.JobActionPull,
+			actions: []repository.FileAction{repository.FileActionCreated, repository.FileActionUpdated, repository.FileActionDeleted},
+			want:    3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := newJobProgressRecorder(noop, nil, tt.action).(*jobProgressRecorder)
+			for _, a := range tt.actions {
+				recorder.Record(ctx, NewPathOnlyResult("file.json").
+					WithAction(a).
+					Build())
+			}
+
+			summaries := recorder.summary()
+			require.Len(t, summaries, 1)
+			require.Equal(t, tt.want, summaries[0].TotalChanges)
+		})
+	}
+}
+
 func TestJobProgressRecorderFolderFailureTrackingFromWarning(t *testing.T) {
 	ctx := context.Background()
 

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
@@ -5088,6 +5088,11 @@
             "type": "integer",
             "format": "int64"
           },
+          "totalChanges": {
+            "description": "TotalChanges is the action-aware count of resources changed for this group/kind, set by the progress recorder as results are recorded. Used for the job-duration histogram's resources_changed bucket.",
+            "type": "integer",
+            "format": "int64"
+          },
           "update": {
             "type": "integer",
             "format": "int64"

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v1beta1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v1beta1.json
@@ -4900,6 +4900,11 @@
             "type": "integer",
             "format": "int64"
           },
+          "totalChanges": {
+            "description": "TotalChanges is the action-aware count of resources changed for this group/kind, set by the progress recorder as results are recorded. Used for the job-duration histogram's resources_changed bucket.",
+            "type": "integer",
+            "format": "int64"
+          },
           "update": {
             "type": "integer",
             "format": "int64"


### PR DESCRIPTION
## What & why

Two follow-ups to #128989 (job worker saturation metrics for autoscaling).

### 1. Per-replica queue-size metric
The old `grafana_provisioning_jobs_queue_size` gauge was incremented/decremented per job `action` at Insert/Complete/Cleanup. It **drifts across replicas**: a job inserted on pod A but completed on pod B leaves A's gauge stuck high and drives B's negative, so it never reflects real backlog.

Replaced with **`grafana_provisioning_jobs_worker_queue_size`** — a scrape-time `GaugeFunc` reading each replica's local work queue (`ConcurrentJobDriver.queue.Len()`). Accurate, LIST-free backlog signal for autoscaling; the queue is per-pod, so Prometheus target labels (pod/instance) distinguish replicas. Reading `Len()` at scrape can't drift the way manual inc/dec does (the workqueue dedups `Add` and keys leave via several paths).

### 2. `TotalChanges` on the job summary
Addresses a review comment on #128989: the resources-changed count used for the duration-histogram bucket should live on the job summary object, not be re-derived by the driver.

Added a `TotalChanges` field to `JobResourceSummary`, populated by the progress recorder (which already knows the job action) as results are recorded. The driver now just sums it. The action mapping was **verified against the workers** (each single-purpose worker records one FileAction type): push → writes, delete → deletes, move → creates (a rename is create+delete, counted once), pull/migrate → create+update+delete.

## ⚠️ Metric-contract change
`grafana_provisioning_jobs_queue_size` is **removed**. Any external dashboard/autoscaling config on that series must move to `grafana_provisioning_jobs_worker_queue_size`. Intended — the old gauge was unreliable.

## Tests
- `TestSumTotalChanges` (driver), `TestUpdateSummary_TotalChanges` (recorder, per action), `TestConcurrentJobDriver_WorkerQueueSizeGauge` (gauge tracks `queue.Len()`).
- `go test ./pkg/registry/apis/provisioning/jobs/...` green; `gofmt` clean; `make lint-go-diff` → 0 issues; codegen re-run (`totalChanges` only).

Closes https://github.com/grafana/git-ui-sync-project/issues/1251

🤖 Generated with [Claude Code](https://claude.com/claude-code)
