### PR TITLE
Org: inject legacy database provider

### DIFF
--- a/pkg/api/folder_bench_test.go
+++ b/pkg/api/folder_bench_test.go
@@ -170,7 +170,7 @@ func setupDB(b testing.TB) benchScenario {
 
 	teamSvc, err := teamimpl.ProvideService(legacysql.NewDatabaseProvider(db), cfg, tracing.InitializeTracerForTest(), nil)
 	require.NoError(b, err)
-	orgService, err := orgimpl.ProvideService(db, cfg, quotaService)
+	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(db), cfg, quotaService)
 	require.NoError(b, err)
 
 	cache := localcache.ProvideService()

--- a/pkg/api/org_users_test.go
+++ b/pkg/api/org_users_test.go
@@ -55,7 +55,7 @@ func setUpGetOrgUsersDB(t *testing.T, sqlStore db.DB, cfg *setting.Cfg) {
 	cfgProvider, err := configprovider.ProvideService(cfg)
 	require.NoError(t, err)
 	quotaService := quotaimpl.ProvideService(context.Background(), legacysql.NewDatabaseProvider(sqlStore), cfgProvider)
-	orgService, err := orgimpl.ProvideService(sqlStore, cfg, quotaService)
+	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(sqlStore), cfg, quotaService)
 	require.NoError(t, err)
 	usrSvc, err := userimpl.ProvideService(
 		sqlStore, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),

--- a/pkg/api/user_test.go
+++ b/pkg/api/user_test.go
@@ -91,7 +91,7 @@ func TestIntegrationUserAPIEndpoint_userLoggedIn(t *testing.T) {
 		srv := authinfoimpl.ProvideService(
 			authInfoStore, remotecache.NewFakeCacheStorage(), secretsService)
 		hs.authInfoService = srv
-		orgSvc, err := orgimpl.ProvideService(sqlStore, settings, quotatest.New(false, nil))
+		orgSvc, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(sqlStore), settings, quotatest.New(false, nil))
 		require.NoError(t, err)
 		userSvc, err := userimpl.ProvideService(
 			sqlStore, orgSvc, sc.cfg, nil, nil, tracing.InitializeTracerForTest(),
@@ -166,7 +166,7 @@ func TestIntegrationUserAPIEndpoint_userLoggedIn(t *testing.T) {
 			Login:   "admin",
 			IsAdmin: true,
 		}
-		orgSvc, err := orgimpl.ProvideService(sqlStore, sc.cfg, quotatest.New(false, nil))
+		orgSvc, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(sqlStore), sc.cfg, quotatest.New(false, nil))
 		require.NoError(t, err)
 		userSvc, err := userimpl.ProvideService(
 			sqlStore, orgSvc, sc.cfg, nil, nil, tracing.InitializeTracerForTest(),
@@ -198,7 +198,7 @@ func TestIntegrationUserAPIEndpoint_userLoggedIn(t *testing.T) {
 			Login:   "multi",
 			IsAdmin: true,
 		}
-		orgSvc, err := orgimpl.ProvideService(sqlStore, sc.cfg, quotatest.New(false, nil))
+		orgSvc, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(sqlStore), sc.cfg, quotatest.New(false, nil))
 		require.NoError(t, err)
 		userSvc, err := userimpl.ProvideService(
 			sqlStore, orgSvc, sc.cfg, nil, nil, tracing.InitializeTracerForTest(),
@@ -674,7 +674,7 @@ func setupUpdateEmailTests(t *testing.T, cfg *setting.Cfg) (*user.User, *HTTPSer
 	sqlStore := db.InitTestDB(t, sqlstore.InitTestDBOpt{Cfg: cfg})
 
 	tempUserService := tempuserimpl.ProvideService(sqlStore, cfg)
-	orgSvc, err := orgimpl.ProvideService(sqlStore, cfg, quotatest.New(false, nil))
+	orgSvc, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(sqlStore), cfg, quotatest.New(false, nil))
 	require.NoError(t, err)
 	userSvc, err := userimpl.ProvideService(
 		sqlStore, orgSvc, cfg, nil, nil, tracing.InitializeTracerForTest(),
@@ -905,7 +905,7 @@ func TestIntegrationUser_UpdateEmail(t *testing.T) {
 		sqlStore := db.InitTestDB(t, sqlstore.InitTestDBOpt{Cfg: settings})
 
 		tempUserSvc := tempuserimpl.ProvideService(sqlStore, settings)
-		orgSvc, err := orgimpl.ProvideService(sqlStore, settings, quotatest.New(false, nil))
+		orgSvc, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(sqlStore), settings, quotatest.New(false, nil))
 		require.NoError(t, err)
 		userSvc, err := userimpl.ProvideService(
 			sqlStore, orgSvc, settings, nil, nil, tracing.InitializeTracerForTest(),

--- a/pkg/extensions/enterprise_imports.go
+++ b/pkg/extensions/enterprise_imports.go
@@ -429,6 +429,7 @@ import (
 	_ "github.com/grafana/grafana/pkg/services/oauthtoken"
 	_ "github.com/grafana/grafana/pkg/services/oauthtoken/oauthtokentest"
 	_ "github.com/grafana/grafana/pkg/services/org"
+	_ "github.com/grafana/grafana/pkg/services/org/orgdelete"
 	_ "github.com/grafana/grafana/pkg/services/org/orgimpl"
 	_ "github.com/grafana/grafana/pkg/services/plugindashboards/service"
 	_ "github.com/grafana/grafana/pkg/services/pluginsintegration"

--- a/pkg/server/bootstrap/wire/sets.go
+++ b/pkg/server/bootstrap/wire/sets.go
@@ -126,6 +126,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/notifications"
 	"github.com/grafana/grafana/pkg/services/oauthtoken"
 	"github.com/grafana/grafana/pkg/services/oauthtoken/oauthtokentest"
+	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
 	"github.com/grafana/grafana/pkg/services/plugindashboards"
 	plugindashboardsservice "github.com/grafana/grafana/pkg/services/plugindashboards/service"
@@ -373,6 +374,8 @@ var Basic = wire.NewSet(
 	wire.Bind(new(user.Service), new(*userimpl.Service)),
 	orgimpl.ProvideService,
 	orgimpl.ProvideDeletionService,
+	orgimpl.ProvideDeleteRegistrar,
+	wire.Bind(new(org.DeletionService), new(*orgimpl.DeletionService)),
 	statsimpl.ProvideService,
 	grpccontext.ProvideContextHandler,
 	grpcserver.ProvideHealthService,

--- a/pkg/server/bootstrap/wire/wire_gen.go
+++ b/pkg/server/bootstrap/wire/wire_gen.go
@@ -365,7 +365,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts server.Options, apiO
 	processService := process.ProvideService()
 	legacyDatabaseProvider := legacysql.NewDatabaseProvider(sqlStore)
 	quotaService := quotaimpl.ProvideService(ctx, legacyDatabaseProvider, configProvider)
-	orgService, err := orgimpl.ProvideService(sqlStore, cfg, quotaService)
+	orgService, err := orgimpl.ProvideService(legacyDatabaseProvider, cfg, quotaService)
 	if err != nil {
 		return nil, err
 	}
@@ -759,7 +759,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts server.Options, apiO
 	v5 := publicdashboards.ProvideMiddleware()
 	v6 := publicdashboards.ProvideApi(v4, routeRegisterImpl, accessControl, featureToggles, v5, cfg, ossLicensingService)
 	loginattemptimplService := loginattemptimpl.ProvideService(sqlStore, cfg, serverLockService)
-	deletionService, err := orgimpl.ProvideDeletionService(sqlStore, cfg, dashboardService, accessControl, eventualRestConfigProvider)
+	deletionService, err := orgimpl.ProvideDeletionService(legacyDatabaseProvider, cfg, dashboardService, accessControl, eventualRestConfigProvider)
 	if err != nil {
 		return nil, err
 	}
@@ -1126,7 +1126,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	processService := process.ProvideService()
 	legacyDatabaseProvider := legacysql.NewDatabaseProvider(sqlStore)
 	quotaService := quotaimpl.ProvideService(ctx, legacyDatabaseProvider, configProvider)
-	orgService, err := orgimpl.ProvideService(sqlStore, cfg, quotaService)
+	orgService, err := orgimpl.ProvideService(legacyDatabaseProvider, cfg, quotaService)
 	if err != nil {
 		return nil, err
 	}
@@ -1519,7 +1519,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	v5 := publicdashboards.ProvideMiddleware()
 	v6 := publicdashboards.ProvideApi(v4, routeRegisterImpl, accessControl, featureToggles, v5, cfg, ossLicensingService)
 	loginattemptimplService := loginattemptimpl.ProvideService(sqlStore, cfg, serverLockService)
-	deletionService, err := orgimpl.ProvideDeletionService(sqlStore, cfg, dashboardService, accessControl, eventualRestConfigProvider)
+	deletionService, err := orgimpl.ProvideDeletionService(legacyDatabaseProvider, cfg, dashboardService, accessControl, eventualRestConfigProvider)
 	if err != nil {
 		return nil, err
 	}
@@ -1829,7 +1829,7 @@ func InitializeForCLI(ctx context.Context, cfg *setting.Cfg) (server.Runner, err
 	secretsMigrator := migrator7.ProvideSecretsMigrator(serviceService, secretsService, sqlStore, ossImpl, featureToggles)
 	legacyDatabaseProvider := legacysql.NewDatabaseProvider(sqlStore)
 	quotaService := quotaimpl.ProvideService(ctx, legacyDatabaseProvider, configProvider)
-	orgService, err := orgimpl.ProvideService(sqlStore, cfg, quotaService)
+	orgService, err := orgimpl.ProvideService(legacyDatabaseProvider, cfg, quotaService)
 	if err != nil {
 		return server.Runner{}, err
 	}

--- a/pkg/server/wire_core.go
+++ b/pkg/server/wire_core.go
@@ -125,6 +125,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/notifications"
 	"github.com/grafana/grafana/pkg/services/oauthtoken"
 	"github.com/grafana/grafana/pkg/services/oauthtoken/oauthtokentest"
+	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
 	"github.com/grafana/grafana/pkg/services/plugindashboards"
 	plugindashboardsservice "github.com/grafana/grafana/pkg/services/plugindashboards/service"
@@ -372,6 +373,8 @@ var wireBasicSet = wire.NewSet(
 	wire.Bind(new(user.Service), new(*userimpl.Service)),
 	orgimpl.ProvideService,
 	orgimpl.ProvideDeletionService,
+	orgimpl.ProvideDeleteRegistrar,
+	wire.Bind(new(org.DeletionService), new(*orgimpl.DeletionService)),
 	statsimpl.ProvideService,
 	grpccontext.ProvideContextHandler,
 	grpcserver.ProvideHealthService,

--- a/pkg/services/accesscontrol/database/database_test.go
+++ b/pkg/services/accesscontrol/database/database_test.go
@@ -628,7 +628,7 @@ func setupTestEnv(t testing.TB) (*database.AccessControlStore, rs.Store, user.Se
 	permissionStore := rs.NewStore(cfg, sql, featuremgmt.WithFeatures())
 	teamService, err := teamimpl.ProvideService(legacysql.NewDatabaseProvider(sql), cfg, tracing.InitializeTracerForTest(), nil)
 	require.NoError(t, err)
-	orgService, err := orgimpl.ProvideService(sql, cfg, quotatest.New(false, nil))
+	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(sql), cfg, quotatest.New(false, nil))
 	require.NoError(t, err)
 
 	orgID, err := orgService.GetOrCreate(context.Background(), "test")

--- a/pkg/services/accesscontrol/dualwrite/collectors_test.go
+++ b/pkg/services/accesscontrol/dualwrite/collectors_test.go
@@ -61,7 +61,7 @@ func setupTestEnv(t *testing.T) *testEnv {
 	teamService, err := teamimpl.ProvideService(legacysql.NewDatabaseProvider(sql), cfg, tracing.InitializeTracerForTest(), nil)
 	require.NoError(t, err)
 
-	orgService, err := orgimpl.ProvideService(sql, cfg, quotatest.New(false, nil))
+	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(sql), cfg, quotatest.New(false, nil))
 	require.NoError(t, err)
 
 	userService, err := userimpl.ProvideService(

--- a/pkg/services/accesscontrol/ossaccesscontrol/testutil/testutil.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/testutil/testutil.go
@@ -26,6 +26,7 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/legacysql"
 
+	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	resourcepb "github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
@@ -50,7 +51,7 @@ func ProvideFolderPermissions(
 		nil,
 	)
 
-	orgService, err := orgimpl.ProvideService(sqlStore, cfg, quotaService)
+	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(sqlStore), cfg, quotaService)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/accesscontrol/ossaccesscontrol/testutil/testutil.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/testutil/testutil.go
@@ -26,7 +26,6 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/legacysql"
 
-	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	resourcepb "github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )

--- a/pkg/services/accesscontrol/resourcepermissions/service_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service_test.go
@@ -844,7 +844,7 @@ func setupTestEnvironmentWithCfg(t *testing.T, ops Options, features featuremgmt
 	teamSvc, err := teamimpl.ProvideService(legacysql.NewDatabaseProvider(sql), cfg, tracer, nil)
 	require.NoError(t, err)
 
-	orgSvc, err := orgimpl.ProvideService(sql, cfg, quotatest.New(false, nil))
+	orgSvc, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(sql), cfg, quotatest.New(false, nil))
 	require.NoError(t, err)
 
 	userSvc, err := userimpl.ProvideService(

--- a/pkg/services/accesscontrol/resourcepermissions/store_bench_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/store_bench_test.go
@@ -150,7 +150,7 @@ func generateTeamsAndUsers(b *testing.B, store db.DB, cfg *setting.Cfg, users in
 	numberOfTeams := int(math.Ceil(float64(users) / UsersPerTeam))
 	globalUserId := 0
 	qs := quotatest.New(false, nil)
-	orgSvc, err := orgimpl.ProvideService(store, cfg, qs)
+	orgSvc, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(store), cfg, qs)
 	require.NoError(b, err)
 	usrSvc, err := userimpl.ProvideService(
 		store, orgSvc, cfg, nil, nil, tracing.InitializeTracerForTest(),

--- a/pkg/services/accesscontrol/resourcepermissions/store_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/store_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/userimpl"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
@@ -468,7 +469,7 @@ func TestIntegrationStore_GetResourcePermissions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			store, sql, cfg := setupTestEnv(t)
-			orgService, err := orgimpl.ProvideService(sql, cfg, quotatest.New(false, nil))
+			orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(sql), cfg, quotatest.New(false, nil))
 			require.NoError(t, err)
 
 			err = sql.WithDbSession(context.Background(), func(sess *db.Session) error {

--- a/pkg/services/libraryelements/libraryelements_permissions_test.go
+++ b/pkg/services/libraryelements/libraryelements_permissions_test.go
@@ -39,7 +39,7 @@ func TestIntegrationLibraryElementPermissions(t *testing.T) {
 	cfgProvider, err := configprovider.ProvideService(env.Cfg)
 	require.NoError(t, err)
 	quotaService := quotaimpl.ProvideService(context.Background(), legacysql.NewDatabaseProvider(env.SQLStore), cfgProvider)
-	orgService, err := orgimpl.ProvideService(env.SQLStore, env.Cfg, quotaService)
+	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(env.SQLStore), env.Cfg, quotaService)
 	require.NoError(t, err)
 
 	sharedOrg, err := orgService.CreateWithMember(context.Background(), &org.CreateOrgCommand{Name: "test org"})
@@ -148,7 +148,7 @@ func TestIntegrationLibraryElementGranularPermissions(t *testing.T) {
 	cfgProvider, err := configprovider.ProvideService(env.Cfg)
 	require.NoError(t, err)
 	quotaService := quotaimpl.ProvideService(context.Background(), legacysql.NewDatabaseProvider(env.SQLStore), cfgProvider)
-	orgService, err := orgimpl.ProvideService(env.SQLStore, env.Cfg, quotaService)
+	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(env.SQLStore), env.Cfg, quotaService)
 	require.NoError(t, err)
 
 	sharedOrg, err := orgService.CreateWithMember(context.Background(), &org.CreateOrgCommand{Name: "test org"})
@@ -270,7 +270,7 @@ func TestIntegrationLibraryElementNameRouteRequiresReadPermission(t *testing.T) 
 	cfgProvider, err := configprovider.ProvideService(env.Cfg)
 	require.NoError(t, err)
 	quotaService := quotaimpl.ProvideService(context.Background(), legacysql.NewDatabaseProvider(env.SQLStore), cfgProvider)
-	orgService, err := orgimpl.ProvideService(env.SQLStore, env.Cfg, quotaService)
+	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(env.SQLStore), env.Cfg, quotaService)
 	require.NoError(t, err)
 
 	sharedOrg, err := orgService.CreateWithMember(context.Background(), &org.CreateOrgCommand{Name: "test org"})
@@ -441,7 +441,7 @@ func createUserInOrg(t *testing.T, db db.DB, cfg *setting.Cfg, cmd user.CreateUs
 	cfgProvider, err := configprovider.ProvideService(cfg)
 	require.NoError(t, err)
 	quotaService := quotaimpl.ProvideService(context.Background(), legacysql.NewDatabaseProvider(db), cfgProvider)
-	orgService, err := orgimpl.ProvideService(db, cfg, quotaService)
+	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(db), cfg, quotaService)
 	require.NoError(t, err)
 	usrSvc, err := userimpl.ProvideService(
 		db, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),

--- a/pkg/services/libraryelements/libraryelements_test.go
+++ b/pkg/services/libraryelements/libraryelements_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/supportbundles/supportbundlestest"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/userimpl"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 	"github.com/grafana/grafana/pkg/util/testutil"
 	"github.com/grafana/grafana/pkg/web"
@@ -349,7 +350,7 @@ func setupTestScenario(t *testing.T) scenarioContext {
 		Name:  "User In DB",
 		Login: userInDbName,
 	}
-	orgSvc, err := orgimpl.ProvideService(sqlStore, cfg, quotaService)
+	orgSvc, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(sqlStore), cfg, quotaService)
 	require.NoError(t, err)
 	usrSvc, err := userimpl.ProvideService(
 		sqlStore, orgSvc, cfg, nil, nil, tracer,

--- a/pkg/services/librarypanels/librarypanels_test.go
+++ b/pkg/services/librarypanels/librarypanels_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/supportbundles/supportbundlestest"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/userimpl"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
@@ -529,7 +530,7 @@ func testScenario(t *testing.T, desc string, fn func(t *testing.T, sc scenarioCo
 			Login: userInDbName,
 		}
 		ctx := identity.WithRequester(context.Background(), usr)
-		orgSvc, err := orgimpl.ProvideService(sqlStore, cfg, quotaService)
+		orgSvc, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(sqlStore), cfg, quotaService)
 		require.NoError(t, err)
 		usrSvc, err := userimpl.ProvideService(
 			sqlStore, orgSvc, cfg, nil, nil, tracing.InitializeTracerForTest(),

--- a/pkg/services/ngalert/testutil/testutil.go
+++ b/pkg/services/ngalert/testutil/testutil.go
@@ -94,5 +94,5 @@ func SetupDashboardService(tb testing.TB, sqlStore db.DB, cfg *setting.Cfg) *das
 func SetupOrgService(tb testing.TB, sqlStore db.DB, cfg *setting.Cfg) (org.Service, error) {
 	tb.Helper()
 	quotaService := quotatest.New(false, nil)
-	return orgimpl.ProvideService(sqlStore, cfg, quotaService)
+	return orgimpl.ProvideService(legacysql.NewDatabaseProvider(sqlStore), cfg, quotaService)
 }

--- a/pkg/services/org/org.go
+++ b/pkg/services/org/org.go
@@ -4,6 +4,13 @@ import (
 	"context"
 )
 
+type DeleteQueryHelper interface {
+	Table(name string) string
+	Quote(identifier string) string
+}
+
+type DeleteQueryRenderer func(dbHelper DeleteQueryHelper) string
+
 //go:generate mockery --name Service --structname MockService --outpkg orgtest --filename mock.go --output ./orgtest/
 type Service interface {
 	GetIDForNewUser(context.Context, GetOrgIDForNewUserCommand) (int64, error)
@@ -25,7 +32,7 @@ type Service interface {
 	// SearchOrgUsersByEmails returns org members whose emails match the given list.
 	// Email matching is case-insensitive. Service accounts are excluded from results.
 	SearchOrgUsersByEmails(context.Context, *SearchOrgUsersByEmailsQuery) ([]*OrgUserDTO, error)
-	RegisterDelete(query string)
+	RegisterDelete(renderer DeleteQueryRenderer)
 }
 
 type DeletionService interface {

--- a/pkg/services/org/org.go
+++ b/pkg/services/org/org.go
@@ -4,13 +4,6 @@ import (
 	"context"
 )
 
-type DeleteQueryHelper interface {
-	Table(name string) string
-	Quote(identifier string) string
-}
-
-type DeleteQueryRenderer func(dbHelper DeleteQueryHelper) string
-
 //go:generate mockery --name Service --structname MockService --outpkg orgtest --filename mock.go --output ./orgtest/
 type Service interface {
 	GetIDForNewUser(context.Context, GetOrgIDForNewUserCommand) (int64, error)
@@ -32,7 +25,6 @@ type Service interface {
 	// SearchOrgUsersByEmails returns org members whose emails match the given list.
 	// Email matching is case-insensitive. Service accounts are excluded from results.
 	SearchOrgUsersByEmails(context.Context, *SearchOrgUsersByEmailsQuery) ([]*OrgUserDTO, error)
-	RegisterDelete(renderer DeleteQueryRenderer)
 }
 
 type DeletionService interface {

--- a/pkg/services/org/orgdelete/delete.go
+++ b/pkg/services/org/orgdelete/delete.go
@@ -1,0 +1,14 @@
+package orgdelete
+
+import "github.com/grafana/grafana/pkg/storage/legacysql"
+
+type Query struct {
+	SQL  string
+	Args []any
+}
+
+type Renderer func(dbHelper *legacysql.LegacyDatabaseHelper, orgID int64) (Query, error)
+
+type Registrar interface {
+	RegisterDelete(Renderer)
+}

--- a/pkg/services/org/orgimpl/org.go
+++ b/pkg/services/org/orgimpl/org.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/util"
 )
 
@@ -20,14 +20,13 @@ type Service struct {
 	log   log.Logger
 }
 
-func ProvideService(db db.DB, cfg *setting.Cfg, quotaService quota.Service) (org.Service, error) {
+func ProvideService(sql legacysql.LegacyDatabaseProvider, cfg *setting.Cfg, quotaService quota.Service) (org.Service, error) {
 	log := log.New("org service")
 	s := &Service{
 		store: &sqlStore{
-			db:      db,
-			dialect: db.GetDialect(),
-			log:     log,
-			cfg:     cfg,
+			sql: sql,
+			log: log,
+			cfg: cfg,
 		},
 		cfg: cfg,
 		log: log,
@@ -241,6 +240,6 @@ func readQuotaConfig(cfg *setting.Cfg) (*quota.Map, error) {
 	return limits, nil
 }
 
-func (s *Service) RegisterDelete(query string) {
-	s.store.RegisterDelete(query)
+func (s *Service) RegisterDelete(renderer org.DeleteQueryRenderer) {
+	s.store.RegisterDelete(renderer)
 }

--- a/pkg/services/org/orgimpl/org.go
+++ b/pkg/services/org/orgimpl/org.go
@@ -239,7 +239,3 @@ func readQuotaConfig(cfg *setting.Cfg) (*quota.Map, error) {
 	limits.Set(userTag, cfg.Quota.User.Org)
 	return limits, nil
 }
-
-func (s *Service) RegisterDelete(renderer org.DeleteQueryRenderer) {
-	s.store.RegisterDelete(renderer)
-}

--- a/pkg/services/org/orgimpl/org_delete_svc.go
+++ b/pkg/services/org/orgimpl/org_delete_svc.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/apiserver"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/services/org/orgdelete"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/legacysql"
 )
@@ -24,7 +25,10 @@ type DeletionService struct {
 	k8sDeleter resourceDeleter
 }
 
-func ProvideDeletionService(sql legacysql.LegacyDatabaseProvider, cfg *setting.Cfg, dashboardService dashboards.DashboardService, ac accesscontrol.AccessControl, restCfg apiserver.RestConfigProvider) (org.DeletionService, error) {
+var _ org.DeletionService = (*DeletionService)(nil)
+var _ orgdelete.Registrar = (*DeletionService)(nil)
+
+func ProvideDeletionService(sql legacysql.LegacyDatabaseProvider, cfg *setting.Cfg, dashboardService dashboards.DashboardService, ac accesscontrol.AccessControl, restCfg apiserver.RestConfigProvider) (*DeletionService, error) {
 	log := log.New("org deletion service")
 	s := &DeletionService{
 		store: &sqlStore{
@@ -39,6 +43,14 @@ func ProvideDeletionService(sql legacysql.LegacyDatabaseProvider, cfg *setting.C
 	}
 
 	return s, nil
+}
+
+func ProvideDeleteRegistrar(service *DeletionService) orgdelete.Registrar {
+	return service
+}
+
+func (s *DeletionService) RegisterDelete(renderer orgdelete.Renderer) {
+	s.store.RegisterDelete(renderer)
 }
 
 func (s *DeletionService) Delete(ctx context.Context, cmd *org.DeleteOrgCommand) error {

--- a/pkg/services/org/orgimpl/org_delete_svc.go
+++ b/pkg/services/org/orgimpl/org_delete_svc.go
@@ -6,13 +6,13 @@ import (
 	"fmt"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
-	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/apiserver"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
 )
 
 type DeletionService struct {
@@ -24,13 +24,12 @@ type DeletionService struct {
 	k8sDeleter resourceDeleter
 }
 
-func ProvideDeletionService(db db.DB, cfg *setting.Cfg, dashboardService dashboards.DashboardService, ac accesscontrol.AccessControl, restCfg apiserver.RestConfigProvider) (org.DeletionService, error) {
+func ProvideDeletionService(sql legacysql.LegacyDatabaseProvider, cfg *setting.Cfg, dashboardService dashboards.DashboardService, ac accesscontrol.AccessControl, restCfg apiserver.RestConfigProvider) (org.DeletionService, error) {
 	log := log.New("org deletion service")
 	s := &DeletionService{
 		store: &sqlStore{
-			db:      db,
-			dialect: db.GetDialect(),
-			log:     log,
+			sql: sql,
+			log: log,
 		},
 		cfg:        cfg,
 		dashSvc:    dashboardService,

--- a/pkg/services/org/orgimpl/org_test.go
+++ b/pkg/services/org/orgimpl/org_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/services/org/orgdelete"
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -160,5 +161,5 @@ func (f *FakeOrgStore) Count(ctx context.Context, _ *quota.ScopeParameters) (*qu
 	return nil, nil
 }
 
-func (f *FakeOrgStore) RegisterDelete(renderer org.DeleteQueryRenderer) {
+func (f *FakeOrgStore) RegisterDelete(renderer orgdelete.Renderer) {
 }

--- a/pkg/services/org/orgimpl/org_test.go
+++ b/pkg/services/org/orgimpl/org_test.go
@@ -160,5 +160,5 @@ func (f *FakeOrgStore) Count(ctx context.Context, _ *quota.ScopeParameters) (*qu
 	return nil, nil
 }
 
-func (f *FakeOrgStore) RegisterDelete(query string) {
+func (f *FakeOrgStore) RegisterDelete(renderer org.DeleteQueryRenderer) {
 }

--- a/pkg/services/org/orgimpl/store.go
+++ b/pkg/services/org/orgimpl/store.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/services/org/orgdelete"
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
@@ -48,27 +49,20 @@ type store interface {
 	RemoveOrgUser(context.Context, *org.RemoveOrgUserCommand) error
 
 	Count(context.Context, *quota.ScopeParameters) (*quota.Map, error)
-	RegisterDelete(renderer org.DeleteQueryRenderer)
+	RegisterDelete(renderer orgdelete.Renderer)
 }
 
 type sqlStore struct {
 	sql legacysql.LegacyDatabaseProvider
 	// TODO: moved to service
 	log             log.Logger
-	deleteRenderers []org.DeleteQueryRenderer
+	deleteRenderers []orgdelete.Renderer
 	cfg             *setting.Cfg
 }
 
-type deleteQueryHelper struct {
-	dbHelper *legacysql.LegacyDatabaseHelper
-}
-
-func (h deleteQueryHelper) Table(name string) string {
-	return h.dbHelper.Table(name)
-}
-
-func (h deleteQueryHelper) Quote(identifier string) string {
-	return h.dbHelper.DB.Quote(identifier)
+// quoteTable resolves a table name and quotes it for use in raw SQL.
+func quoteTable(dbHelper *legacysql.LegacyDatabaseHelper, name string) string {
+	return dbHelper.DB.Quote(dbHelper.Table(name))
 }
 
 func (ss *sqlStore) Get(ctx context.Context, orgID int64) (*org.Org, error) {
@@ -115,7 +109,7 @@ func (ss *sqlStore) Insert(ctx context.Context, orga *org.Org) (int64, error) {
 		orgID = orga.ID
 
 		if orga.ID != 0 && dbHelper.DB.GetDialect().DriverName() == migrator.Postgres {
-			orgTable := dbHelper.DB.Quote(dbHelper.Table("org"))
+			orgTable := quoteTable(dbHelper, "org")
 			if _, err := sess.Exec("SELECT setval(?::regclass, (SELECT max(id) FROM "+orgTable+"));", dbHelper.Table("org_id_seq")); err != nil {
 				return fmt.Errorf("failed to sync primary key for org table: %w", err)
 			}
@@ -154,7 +148,7 @@ func (ss *sqlStore) DeleteUserFromAll(ctx context.Context, userID int64) error {
 	}
 
 	return dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
-		query := "DELETE FROM " + dbHelper.DB.Quote(dbHelper.Table("org_user")) + " WHERE user_id = ?"
+		query := "DELETE FROM " + quoteTable(dbHelper, "org_user") + " WHERE user_id = ?"
 		if _, err := sess.Exec(query, userID); err != nil {
 			return err
 		}
@@ -245,7 +239,7 @@ func (ss *sqlStore) Delete(ctx context.Context, cmd *org.DeleteOrgCommand) error
 	}
 
 	return dbHelper.DB.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
-		orgTable := dbHelper.DB.Quote(dbHelper.Table("org"))
+		orgTable := quoteTable(dbHelper, "org")
 		if res, err := sess.Query("SELECT 1 FROM "+orgTable+" WHERE id=?", cmd.ID); err != nil {
 			return err
 		} else if len(res) != 1 {
@@ -258,43 +252,46 @@ func (ss *sqlStore) Delete(ctx context.Context, cmd *org.DeleteOrgCommand) error
 			}
 		}
 
+		for _, render := range ss.deleteRenderers {
+			query, err := render(dbHelper, cmd.ID)
+			if err != nil {
+				return err
+			}
+			if _, err := sess.Exec(append([]any{query.SQL}, query.Args...)...); err != nil {
+				return err
+			}
+		}
+
 		return nil
 	})
 }
 
 func (ss *sqlStore) orgDeletions(dbHelper *legacysql.LegacyDatabaseHelper) []string {
-	quoteTable := func(name string) string {
-		return dbHelper.DB.Quote(dbHelper.Table(name))
-	}
-	alertRuleTagTable := quoteTable("alert_rule_tag")
+	alertRuleTagTable := quoteTable(dbHelper, "alert_rule_tag")
 	deletes := []string{ //nolint:prealloc
-		"DELETE FROM " + quoteTable("star") + " WHERE org_id = ?",
-		"DELETE FROM " + quoteTable("dashboard_tag") + " WHERE org_id = ?",
-		"DELETE FROM " + quoteTable("api_key") + " WHERE org_id = ?",
-		"DELETE FROM " + quoteTable("data_source") + " WHERE org_id = ?",
-		"DELETE FROM " + quoteTable("org_user") + " WHERE org_id = ?",
-		"DELETE FROM " + quoteTable("org") + " WHERE id = ?",
-		"DELETE FROM " + quoteTable("temp_user") + " WHERE org_id = ?",
-		"DELETE FROM " + quoteTable("ngalert_configuration") + " WHERE org_id = ?",
-		"DELETE FROM " + quoteTable("alert_configuration") + " WHERE org_id = ?",
-		"DELETE FROM " + quoteTable("alert_instance") + " WHERE rule_org_id = ?",
-		"DELETE FROM " + quoteTable("alert_notification") + " WHERE org_id = ?",
-		"DELETE FROM " + quoteTable("alert_notification_state") + " WHERE org_id = ?",
-		"DELETE FROM " + quoteTable("alert_rule") + " WHERE org_id = ?",
-		"DELETE FROM " + alertRuleTagTable + " AS alert_rule_tag WHERE EXISTS (SELECT 1 FROM " + quoteTable("alert") + " AS alert WHERE alert.org_id = ? AND alert.id = alert_rule_tag.alert_id)",
-		"DELETE FROM " + quoteTable("alert_rule_version") + " WHERE rule_org_id = ?",
-		"DELETE FROM " + quoteTable("alert") + " WHERE org_id = ?",
-		"DELETE FROM " + quoteTable("annotation") + " WHERE org_id = ?",
-		"DELETE FROM " + quoteTable("kv_store") + " WHERE org_id = ?",
-		"DELETE FROM " + quoteTable("team") + " WHERE org_id = ?",
-		"DELETE FROM " + quoteTable("team_member") + " WHERE org_id = ?",
-		"DELETE FROM " + quoteTable("team_role") + " WHERE org_id = ?",
-		"DELETE FROM " + quoteTable("user_role") + " WHERE org_id = ?",
-		"DELETE FROM " + quoteTable("builtin_role") + " WHERE org_id = ?",
-	}
-
-	for _, render := range ss.deleteRenderers {
-		deletes = append(deletes, render(deleteQueryHelper{dbHelper: dbHelper}))
+		"DELETE FROM " + quoteTable(dbHelper, "star") + " WHERE org_id = ?",
+		"DELETE FROM " + quoteTable(dbHelper, "dashboard_tag") + " WHERE org_id = ?",
+		"DELETE FROM " + quoteTable(dbHelper, "api_key") + " WHERE org_id = ?",
+		"DELETE FROM " + quoteTable(dbHelper, "data_source") + " WHERE org_id = ?",
+		"DELETE FROM " + quoteTable(dbHelper, "org_user") + " WHERE org_id = ?",
+		"DELETE FROM " + quoteTable(dbHelper, "org") + " WHERE id = ?",
+		"DELETE FROM " + quoteTable(dbHelper, "temp_user") + " WHERE org_id = ?",
+		"DELETE FROM " + quoteTable(dbHelper, "ngalert_configuration") + " WHERE org_id = ?",
+		"DELETE FROM " + quoteTable(dbHelper, "alert_configuration") + " WHERE org_id = ?",
+		"DELETE FROM " + quoteTable(dbHelper, "alert_instance") + " WHERE rule_org_id = ?",
+		"DELETE FROM " + quoteTable(dbHelper, "alert_notification") + " WHERE org_id = ?",
+		"DELETE FROM " + quoteTable(dbHelper, "alert_notification_state") + " WHERE org_id = ?",
+		"DELETE FROM " + quoteTable(dbHelper, "alert_rule") + " WHERE org_id = ?",
+		"DELETE FROM " + alertRuleTagTable + " WHERE EXISTS (SELECT 1 FROM " + quoteTable(dbHelper, "alert") + " AS alert WHERE alert.org_id = ? AND alert.id = alert_rule_tag.alert_id)",
+		"DELETE FROM " + quoteTable(dbHelper, "alert_rule_version") + " WHERE rule_org_id = ?",
+		"DELETE FROM " + quoteTable(dbHelper, "alert") + " WHERE org_id = ?",
+		"DELETE FROM " + quoteTable(dbHelper, "annotation") + " WHERE org_id = ?",
+		"DELETE FROM " + quoteTable(dbHelper, "kv_store") + " WHERE org_id = ?",
+		"DELETE FROM " + quoteTable(dbHelper, "team") + " WHERE org_id = ?",
+		"DELETE FROM " + quoteTable(dbHelper, "team_member") + " WHERE org_id = ?",
+		"DELETE FROM " + quoteTable(dbHelper, "team_role") + " WHERE org_id = ?",
+		"DELETE FROM " + quoteTable(dbHelper, "user_role") + " WHERE org_id = ?",
+		"DELETE FROM " + quoteTable(dbHelper, "builtin_role") + " WHERE org_id = ?",
 	}
 
 	return deletes
@@ -309,10 +306,11 @@ func (ss *sqlStore) GetUserOrgList(ctx context.Context, query *org.GetUserOrgLis
 
 	result := make([]*org.UserOrgDTO, 0)
 	err = dbHelper.DB.WithDbSession(ctx, func(dbSess *db.Session) error {
-		userTable := dbHelper.DB.Quote(dbHelper.Table("user"))
+		userTable := dbHelper.Table("user")
+		userRef := dbHelper.DB.GetDialect().Quote("user")
 		sess := dbSess.Table(dbHelper.Table("org_user"))
-		sess.Join("INNER", dbHelper.DB.Quote(dbHelper.Table("org")), "org_user.org_id=org.id")
-		sess.Join("INNER", userTable, fmt.Sprintf("org_user.user_id=%s.id", userTable))
+		sess.Join("INNER", []string{dbHelper.Table("org"), "org"}, "org_user.org_id=org.id")
+		sess.Join("INNER", []string{userTable, "user"}, fmt.Sprintf("org_user.user_id=%s.id", userRef))
 		sess.Where("org_user.user_id=?", query.UserID)
 		sess.Where(ss.notServiceAccountFilter(dbHelper))
 		sess.Cols("org.name", "org_user.role", "org_user.org_id")
@@ -329,7 +327,7 @@ func (ss *sqlStore) GetUserOrgList(ctx context.Context, query *org.GetUserOrgLis
 
 func (ss *sqlStore) notServiceAccountFilter(dbHelper *legacysql.LegacyDatabaseHelper) string {
 	return fmt.Sprintf("%s.is_service_account = %s",
-		dbHelper.DB.Quote(dbHelper.Table("user")),
+		dbHelper.DB.GetDialect().Quote("user"),
 		dbHelper.DB.GetDialect().BooleanStr(false))
 }
 
@@ -427,14 +425,14 @@ func (ss *sqlStore) AddOrgUser(ctx context.Context, cmd *org.AddOrgUserCommand) 
 			return user.ErrUserNotFound
 		}
 
-		orgUserTable := dbHelper.DB.Quote(dbHelper.Table("org_user"))
+		orgUserTable := quoteTable(dbHelper, "org_user")
 		if res, err := sess.Query("SELECT 1 FROM "+orgUserTable+" WHERE org_id=? and user_id=?", cmd.OrgID, usr.ID); err != nil {
 			return err
 		} else if len(res) == 1 {
 			return org.ErrOrgUserAlreadyAdded
 		}
 
-		orgTable := dbHelper.DB.Quote(dbHelper.Table("org"))
+		orgTable := quoteTable(dbHelper, "org")
 		if res, err := sess.Query("SELECT 1 FROM "+orgTable+" WHERE id=?", cmd.OrgID); err != nil {
 			return err
 		} else if len(res) != 1 {
@@ -456,7 +454,7 @@ func (ss *sqlStore) AddOrgUser(ctx context.Context, cmd *org.AddOrgUserCommand) 
 
 		var userOrgs []*org.UserOrgDTO
 		sess.Table(dbHelper.Table("org_user"))
-		sess.Join("INNER", orgTable, "org_user.org_id=org.id")
+		sess.Join("INNER", []string{dbHelper.Table("org"), "org"}, "org_user.org_id=org.id")
 		sess.Where("org_user.user_id=? AND org_user.org_id=?", usr.ID, usr.OrgID)
 		sess.Cols("org.name", "org_user.role", "org_user.org_id")
 		err = sess.Find(&userOrgs)
@@ -486,7 +484,7 @@ func (ss *sqlStore) Count(ctx context.Context, scopeParams *quota.ScopeParameter
 
 	r := result{}
 	if err := dbHelper.DB.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
-		rawSQL := "SELECT COUNT(*) as count FROM " + dbHelper.DB.Quote(dbHelper.Table("org"))
+		rawSQL := "SELECT COUNT(*) as count FROM " + quoteTable(dbHelper, "org")
 		if _, err := sess.SQL(rawSQL).Get(&r); err != nil {
 			return err
 		}
@@ -504,8 +502,8 @@ func (ss *sqlStore) Count(ctx context.Context, scopeParams *quota.ScopeParameter
 	if scopeParams != nil && scopeParams.OrgID != 0 {
 		if err := dbHelper.DB.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
 			rawSQL := fmt.Sprintf("SELECT COUNT(*) AS count FROM (SELECT user_id FROM %s WHERE org_id=? AND user_id IN (SELECT id AS user_id FROM %s WHERE is_service_account=%s)) as subq",
-				dbHelper.DB.Quote(dbHelper.Table("org_user")),
-				dbHelper.DB.Quote(dbHelper.Table("user")),
+				quoteTable(dbHelper, "org_user"),
+				quoteTable(dbHelper, "user"),
 				dbHelper.DB.GetDialect().BooleanStr(false),
 			)
 			if _, err := sess.SQL(rawSQL, scopeParams.OrgID).Get(&r); err != nil {
@@ -526,7 +524,7 @@ func (ss *sqlStore) Count(ctx context.Context, scopeParams *quota.ScopeParameter
 	if scopeParams != nil && scopeParams.UserID != 0 {
 		if err := dbHelper.DB.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
 			// should we exclude service accounts?
-			rawSQL := "SELECT COUNT(*) AS count FROM " + dbHelper.DB.Quote(dbHelper.Table("org_user")) + " WHERE user_id=?"
+			rawSQL := "SELECT COUNT(*) AS count FROM " + quoteTable(dbHelper, "org_user") + " WHERE user_id=?"
 			if _, err := sess.SQL(rawSQL, scopeParams.UserID).Get(&r); err != nil {
 				return err
 			}
@@ -585,7 +583,7 @@ func (ss *sqlStore) UpdateOrgUser(ctx context.Context, cmd *org.UpdateOrgUserCom
 
 // validate that there is an org admin user left
 func validateOneAdminLeftInOrg(dbHelper *legacysql.LegacyDatabaseHelper, orgID int64, sess *db.Session) error {
-	query := "SELECT 1 FROM " + dbHelper.DB.Quote(dbHelper.Table("org_user")) + " WHERE org_id=? and role='Admin'"
+	query := "SELECT 1 FROM " + quoteTable(dbHelper, "org_user") + " WHERE org_id=? and role='Admin'"
 	res, err := sess.Query(query, orgID)
 	if err != nil {
 		return err
@@ -632,7 +630,7 @@ func (ss *sqlStore) SearchOrgUsers(ctx context.Context, query *org.SearchOrgUser
 		OrgUsers: make([]*org.OrgUserDTO, 0),
 	}
 	err = dbHelper.DB.WithDbSession(ctx, func(dbSession *db.Session) error {
-		userTable := dbHelper.DB.Quote(dbHelper.Table("user"))
+		userTable := dbHelper.Table("user")
 		sess := dbSession.Table(dbHelper.Table("org_user"))
 		sess.Join("INNER", []string{userTable, "u"}, "org_user.user_id=u.id")
 
@@ -779,7 +777,7 @@ func (ss *sqlStore) SearchOrgUsersByEmails(ctx context.Context, query *org.Searc
 		}
 
 		sess := dbSession.Table(dbHelper.Table("org_user")).
-			Join("INNER", []string{dbHelper.DB.Quote(dbHelper.Table("user")), "u"}, "org_user.user_id=u.id").
+			Join("INNER", []string{dbHelper.Table("user"), "u"}, "org_user.user_id=u.id").
 			Where(strings.Join(whereConditions, " AND "), whereParams...).
 			Cols(
 				"org_user.org_id",
@@ -853,14 +851,11 @@ func (ss *sqlStore) RemoveOrgUser(ctx context.Context, cmd *org.RemoveOrgUserCom
 			return nil
 		}
 
-		quoteTable := func(name string) string {
-			return dbHelper.DB.Quote(dbHelper.Table(name))
-		}
 		deletes := []string{
-			"DELETE FROM " + quoteTable("org_user") + " WHERE org_id=? and user_id=?",
-			"DELETE FROM " + quoteTable("dashboard_acl") + " WHERE org_id=? and user_id = ?",
-			"DELETE FROM " + quoteTable("team_member") + " WHERE org_id=? and user_id = ?",
-			"DELETE FROM " + quoteTable("query_history_star") + " WHERE org_id=? and user_id = ?",
+			"DELETE FROM " + quoteTable(dbHelper, "org_user") + " WHERE org_id=? and user_id=?",
+			"DELETE FROM " + quoteTable(dbHelper, "dashboard_acl") + " WHERE org_id=? and user_id = ?",
+			"DELETE FROM " + quoteTable(dbHelper, "team_member") + " WHERE org_id=? and user_id = ?",
+			"DELETE FROM " + quoteTable(dbHelper, "query_history_star") + " WHERE org_id=? and user_id = ?",
 		}
 
 		for _, sql := range deletes {
@@ -878,7 +873,7 @@ func (ss *sqlStore) RemoveOrgUser(ctx context.Context, cmd *org.RemoveOrgUserCom
 		// check user other orgs and update user current org
 		var userOrgs []*org.UserOrgDTO
 		sess.Table(dbHelper.Table("org_user"))
-		sess.Join("INNER", dbHelper.DB.Quote(dbHelper.Table("org")), "org_user.org_id=org.id")
+		sess.Join("INNER", []string{dbHelper.Table("org"), "org"}, "org_user.org_id=org.id")
 		sess.Where("org_user.user_id=?", usr.ID)
 		sess.Cols("org.name", "org_user.role", "org_user.org_id")
 		err := sess.Find(&userOrgs)
@@ -943,18 +938,18 @@ func (ss *sqlStore) deleteUserInTransaction(dbHelper *legacysql.LegacyDatabaseHe
 
 func deleteUserAccessControl(dbHelper *legacysql.LegacyDatabaseHelper, sess *db.Session, userID int64) error {
 	// Delete user role assignments
-	if _, err := sess.Exec("DELETE FROM "+dbHelper.DB.Quote(dbHelper.Table("user_role"))+" WHERE user_id = ?", userID); err != nil {
+	if _, err := sess.Exec("DELETE FROM "+quoteTable(dbHelper, "user_role")+" WHERE user_id = ?", userID); err != nil {
 		return err
 	}
 
 	// Delete permissions that are scoped to user
-	permissionTable := dbHelper.DB.Quote(dbHelper.Table("permission"))
+	permissionTable := quoteTable(dbHelper, "permission")
 	if _, err := sess.Exec("DELETE FROM "+permissionTable+" WHERE scope = ?", accesscontrol.Scope("users", "id", strconv.FormatInt(userID, 10))); err != nil {
 		return err
 	}
 
 	var roleIDs []int64
-	roleTable := dbHelper.DB.Quote(dbHelper.Table("role"))
+	roleTable := quoteTable(dbHelper, "role")
 	if err := sess.SQL("SELECT id FROM "+roleTable+" WHERE name = ?", accesscontrol.ManagedUserRoleName(userID)).Find(&roleIDs); err != nil {
 		return err
 	}
@@ -984,19 +979,16 @@ func deleteUserAccessControl(dbHelper *legacysql.LegacyDatabaseHelper, sess *db.
 }
 
 func (ss *sqlStore) userDeletions(dbHelper *legacysql.LegacyDatabaseHelper) []string {
-	quoteTable := func(name string) string {
-		return dbHelper.DB.Quote(dbHelper.Table(name))
-	}
 	deletes := []string{
-		"DELETE FROM " + quoteTable("star") + " WHERE user_id = ?",
-		"DELETE FROM " + quoteTable("user") + " WHERE id = ?",
-		"DELETE FROM " + quoteTable("org_user") + " WHERE user_id = ?",
-		"DELETE FROM " + quoteTable("dashboard_acl") + " WHERE user_id = ?",
-		"DELETE FROM " + quoteTable("preferences") + " WHERE user_id = ?",
-		"DELETE FROM " + quoteTable("team_member") + " WHERE user_id = ?",
-		"DELETE FROM " + quoteTable("user_auth") + " WHERE user_id = ?",
-		"DELETE FROM " + quoteTable("user_auth_token") + " WHERE user_id = ?",
-		"DELETE FROM " + quoteTable("quota") + " WHERE user_id = ?",
+		"DELETE FROM " + quoteTable(dbHelper, "star") + " WHERE user_id = ?",
+		"DELETE FROM " + quoteTable(dbHelper, "user") + " WHERE id = ?",
+		"DELETE FROM " + quoteTable(dbHelper, "org_user") + " WHERE user_id = ?",
+		"DELETE FROM " + quoteTable(dbHelper, "dashboard_acl") + " WHERE user_id = ?",
+		"DELETE FROM " + quoteTable(dbHelper, "preferences") + " WHERE user_id = ?",
+		"DELETE FROM " + quoteTable(dbHelper, "team_member") + " WHERE user_id = ?",
+		"DELETE FROM " + quoteTable(dbHelper, "user_auth") + " WHERE user_id = ?",
+		"DELETE FROM " + quoteTable(dbHelper, "user_auth_token") + " WHERE user_id = ?",
+		"DELETE FROM " + quoteTable(dbHelper, "quota") + " WHERE user_id = ?",
 	}
 	return deletes
 }
@@ -1011,8 +1003,7 @@ func removeUserOrg(dbHelper *legacysql.LegacyDatabaseHelper, sess *db.Session, u
 	return err
 }
 
-// RegisterDelete registers a query to run when an org is deleted.
-func (ss *sqlStore) RegisterDelete(renderer org.DeleteQueryRenderer) {
+func (ss *sqlStore) RegisterDelete(renderer orgdelete.Renderer) {
 	ss.deleteRenderers = append(ss.deleteRenderers, renderer)
 }
 

--- a/pkg/services/org/orgimpl/store.go
+++ b/pkg/services/org/orgimpl/store.go
@@ -110,7 +110,8 @@ func (ss *sqlStore) Insert(ctx context.Context, orga *org.Org) (int64, error) {
 
 		if orga.ID != 0 && dbHelper.DB.GetDialect().DriverName() == migrator.Postgres {
 			orgTable := quoteTable(dbHelper, "org")
-			if _, err := sess.Exec("SELECT setval(?::regclass, (SELECT max(id) FROM "+orgTable+"));", dbHelper.Table("org_id_seq")); err != nil {
+			orgSequence := quoteTable(dbHelper, "org_id_seq")
+			if _, err := sess.Exec("SELECT setval(?::regclass, (SELECT max(id) FROM "+orgTable+"));", orgSequence); err != nil {
 				return fmt.Errorf("failed to sync primary key for org table: %w", err)
 			}
 		}

--- a/pkg/services/org/orgimpl/store.go
+++ b/pkg/services/org/orgimpl/store.go
@@ -246,7 +246,6 @@ func (ss *sqlStore) Delete(ctx context.Context, cmd *org.DeleteOrgCommand) error
 			return org.ErrOrgNotFound.Errorf("failed to delete organisation with ID: %d", cmd.ID)
 		}
 
-		alertRuleTagTable := quoteTable(dbHelper, "alert_rule_tag")
 		deletes := []string{ //nolint:prealloc
 			"DELETE FROM " + quoteTable(dbHelper, "star") + " WHERE org_id = ?",
 			"DELETE FROM " + quoteTable(dbHelper, "dashboard_tag") + " WHERE org_id = ?",
@@ -261,7 +260,7 @@ func (ss *sqlStore) Delete(ctx context.Context, cmd *org.DeleteOrgCommand) error
 			"DELETE FROM " + quoteTable(dbHelper, "alert_notification") + " WHERE org_id = ?",
 			"DELETE FROM " + quoteTable(dbHelper, "alert_notification_state") + " WHERE org_id = ?",
 			"DELETE FROM " + quoteTable(dbHelper, "alert_rule") + " WHERE org_id = ?",
-			"DELETE FROM " + alertRuleTagTable + " WHERE EXISTS (SELECT 1 FROM " + quoteTable(dbHelper, "alert") + " AS alert WHERE alert.org_id = ? AND alert.id = alert_rule_tag.alert_id)",
+			"DELETE FROM " + quoteTable(dbHelper, "alert_rule_tag") + " WHERE EXISTS (SELECT 1 FROM " + quoteTable(dbHelper, "alert") + " AS alert WHERE alert.org_id = ? AND alert.id = alert_rule_tag.alert_id)",
 			"DELETE FROM " + quoteTable(dbHelper, "alert_rule_version") + " WHERE rule_org_id = ?",
 			"DELETE FROM " + quoteTable(dbHelper, "alert") + " WHERE org_id = ?",
 			"DELETE FROM " + quoteTable(dbHelper, "annotation") + " WHERE org_id = ?",
@@ -302,11 +301,9 @@ func (ss *sqlStore) GetUserOrgList(ctx context.Context, query *org.GetUserOrgLis
 
 	result := make([]*org.UserOrgDTO, 0)
 	err = dbHelper.DB.WithDbSession(ctx, func(dbSess *db.Session) error {
-		userTable := dbHelper.Table("user")
-		userRef := dbHelper.DB.GetDialect().Quote("user")
 		sess := dbSess.Table(dbHelper.Table("org_user"))
 		sess.Join("INNER", []string{dbHelper.Table("org"), "org"}, "org_user.org_id=org.id")
-		sess.Join("INNER", []string{userTable, "user"}, fmt.Sprintf("org_user.user_id=%s.id", userRef))
+		sess.Join("INNER", []string{dbHelper.Table("user"), "user"}, fmt.Sprintf("org_user.user_id=%s.id", dbHelper.DB.GetDialect().Quote("user")))
 		sess.Where("org_user.user_id=?", query.UserID)
 		sess.Where(ss.notServiceAccountFilter(dbHelper))
 		sess.Cols("org.name", "org_user.role", "org_user.org_id")

--- a/pkg/services/org/orgimpl/store.go
+++ b/pkg/services/org/orgimpl/store.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/util"
 )
 
@@ -47,22 +48,38 @@ type store interface {
 	RemoveOrgUser(context.Context, *org.RemoveOrgUserCommand) error
 
 	Count(context.Context, *quota.ScopeParameters) (*quota.Map, error)
-	RegisterDelete(query string)
+	RegisterDelete(renderer org.DeleteQueryRenderer)
 }
 
 type sqlStore struct {
-	db      db.DB
-	dialect migrator.Dialect
+	sql legacysql.LegacyDatabaseProvider
 	// TODO: moved to service
-	log     log.Logger
-	deletes []string
-	cfg     *setting.Cfg
+	log             log.Logger
+	deleteRenderers []org.DeleteQueryRenderer
+	cfg             *setting.Cfg
+}
+
+type deleteQueryHelper struct {
+	dbHelper *legacysql.LegacyDatabaseHelper
+}
+
+func (h deleteQueryHelper) Table(name string) string {
+	return h.dbHelper.Table(name)
+}
+
+func (h deleteQueryHelper) Quote(identifier string) string {
+	return h.dbHelper.DB.Quote(identifier)
 }
 
 func (ss *sqlStore) Get(ctx context.Context, orgID int64) (*org.Org, error) {
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
+
 	var orga org.Org
-	err := ss.db.WithDbSession(ctx, func(sess *db.Session) error {
-		has, err := sess.Where("id=?", orgID).Get(&orga)
+	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
+		has, err := sess.Table(dbHelper.Table("org")).Where("id=?", orgID).Get(&orga)
 		if err != nil {
 			return err
 		}
@@ -78,25 +95,29 @@ func (ss *sqlStore) Get(ctx context.Context, orgID int64) (*org.Org, error) {
 }
 
 func (ss *sqlStore) Insert(ctx context.Context, orga *org.Org) (int64, error) {
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("get legacy DB: %w", err)
+	}
+
 	var orgID int64
-	var err error
-	err = ss.db.WithDbSession(ctx, func(sess *db.Session) error {
-		if isNameTaken, err := isOrgNameTaken(orga.Name, orga.ID, sess); err != nil {
+	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
+		if isNameTaken, err := isOrgNameTaken(dbHelper, orga.Name, orga.ID, sess); err != nil {
 			return err
 		} else if isNameTaken {
 			return org.ErrOrgNameTaken
 		}
 
-		if _, err = sess.Insert(orga); err != nil {
+		if _, err = sess.Table(dbHelper.Table("org")).Insert(orga); err != nil {
 			return err
 		}
 
 		orgID = orga.ID
 
-		if orga.ID != 0 {
-			// it sets the setval in the sequence
-			if err := ss.dialect.PostInsertId("org", sess.Session); err != nil {
-				return err
+		if orga.ID != 0 && dbHelper.DB.GetDialect().DriverName() == migrator.Postgres {
+			orgTable := dbHelper.DB.Quote(dbHelper.Table("org"))
+			if _, err := sess.Exec("SELECT setval(?::regclass, (SELECT max(id) FROM "+orgTable+"));", dbHelper.Table("org_id_seq")); err != nil {
+				return fmt.Errorf("failed to sync primary key for org table: %w", err)
 			}
 		}
 		return nil
@@ -109,9 +130,13 @@ func (ss *sqlStore) Insert(ctx context.Context, orga *org.Org) (int64, error) {
 
 // InsertOrgUser adds a new membership record for a user in an organization.
 func (ss *sqlStore) InsertOrgUser(ctx context.Context, cmd *org.OrgUser) (int64, error) {
-	var err error
-	err = ss.db.WithDbSession(ctx, func(sess *db.Session) error {
-		if _, err = sess.Insert(cmd); err != nil {
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
+		if _, err = sess.Table(dbHelper.Table("org_user")).Insert(cmd); err != nil {
 			return err
 		}
 		return nil
@@ -123,8 +148,14 @@ func (ss *sqlStore) InsertOrgUser(ctx context.Context, cmd *org.OrgUser) (int64,
 }
 
 func (ss *sqlStore) DeleteUserFromAll(ctx context.Context, userID int64) error {
-	return ss.db.WithDbSession(ctx, func(sess *db.Session) error {
-		if _, err := sess.Exec("DELETE FROM org_user WHERE user_id = ?", userID); err != nil {
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	return dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
+		query := "DELETE FROM " + dbHelper.DB.Quote(dbHelper.Table("org_user")) + " WHERE user_id = ?"
+		if _, err := sess.Exec(query, userID); err != nil {
 			return err
 		}
 		return nil
@@ -132,8 +163,13 @@ func (ss *sqlStore) DeleteUserFromAll(ctx context.Context, userID int64) error {
 }
 
 func (ss *sqlStore) Update(ctx context.Context, cmd *org.UpdateOrgCommand) error {
-	return ss.db.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
-		if isNameTaken, err := isOrgNameTaken(cmd.Name, cmd.OrgId, sess); err != nil {
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	return dbHelper.DB.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
+		if isNameTaken, err := isOrgNameTaken(dbHelper, cmd.Name, cmd.OrgId, sess); err != nil {
 			return err
 		} else if isNameTaken {
 			return org.ErrOrgNameTaken
@@ -144,7 +180,7 @@ func (ss *sqlStore) Update(ctx context.Context, cmd *org.UpdateOrgCommand) error
 			Updated: time.Now(),
 		}
 
-		affectedRows, err := sess.ID(cmd.OrgId).Update(&orga)
+		affectedRows, err := sess.Table(dbHelper.Table("org")).ID(cmd.OrgId).Update(&orga)
 
 		if err != nil {
 			return err
@@ -158,10 +194,10 @@ func (ss *sqlStore) Update(ctx context.Context, cmd *org.UpdateOrgCommand) error
 	})
 }
 
-func isOrgNameTaken(name string, existingId int64, sess *db.Session) (bool, error) {
+func isOrgNameTaken(dbHelper *legacysql.LegacyDatabaseHelper, name string, existingId int64, sess *db.Session) (bool, error) {
 	// check if org name is taken
 	var org org.Org
-	exists, err := sess.Where("name=?", name).Get(&org)
+	exists, err := sess.Table(dbHelper.Table("org")).Where("name=?", name).Get(&org)
 
 	if err != nil {
 		return false, nil
@@ -176,7 +212,12 @@ func isOrgNameTaken(name string, existingId int64, sess *db.Session) (bool, erro
 
 // TODO: refactor move logic to service method
 func (ss *sqlStore) UpdateAddress(ctx context.Context, cmd *org.UpdateOrgAddressCommand) error {
-	return ss.db.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	return dbHelper.DB.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
 		org := org.Org{
 			Address1: cmd.Address1,
 			Address2: cmd.Address2,
@@ -188,7 +229,7 @@ func (ss *sqlStore) UpdateAddress(ctx context.Context, cmd *org.UpdateOrgAddress
 			Updated: time.Now(),
 		}
 
-		if _, err := sess.ID(cmd.OrgID).Update(&org); err != nil {
+		if _, err := sess.Table(dbHelper.Table("org")).ID(cmd.OrgID).Update(&org); err != nil {
 			return err
 		}
 
@@ -198,42 +239,20 @@ func (ss *sqlStore) UpdateAddress(ctx context.Context, cmd *org.UpdateOrgAddress
 
 // TODO: refactor move logic to service method
 func (ss *sqlStore) Delete(ctx context.Context, cmd *org.DeleteOrgCommand) error {
-	return ss.db.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
-		if res, err := sess.Query("SELECT 1 from org WHERE id=?", cmd.ID); err != nil {
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	return dbHelper.DB.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
+		orgTable := dbHelper.DB.Quote(dbHelper.Table("org"))
+		if res, err := sess.Query("SELECT 1 FROM "+orgTable+" WHERE id=?", cmd.ID); err != nil {
 			return err
 		} else if len(res) != 1 {
 			return org.ErrOrgNotFound.Errorf("failed to delete organisation with ID: %d", cmd.ID)
 		}
 
-		deletes := []string{ //nolint:prealloc
-			"DELETE FROM star WHERE org_id = ?",
-			"DELETE FROM dashboard_tag WHERE org_id = ?",
-			"DELETE FROM api_key WHERE org_id = ?",
-			"DELETE FROM data_source WHERE org_id = ?",
-			"DELETE FROM org_user WHERE org_id = ?",
-			"DELETE FROM org WHERE id = ?",
-			"DELETE FROM temp_user WHERE org_id = ?",
-			"DELETE FROM ngalert_configuration WHERE org_id = ?",
-			"DELETE FROM alert_configuration WHERE org_id = ?",
-			"DELETE FROM alert_instance WHERE rule_org_id = ?",
-			"DELETE FROM alert_notification WHERE org_id = ?",
-			"DELETE FROM alert_notification_state WHERE org_id = ?",
-			"DELETE FROM alert_rule WHERE org_id = ?",
-			"DELETE FROM alert_rule_tag WHERE EXISTS (SELECT 1 FROM alert WHERE alert.org_id = ? AND alert.id = alert_rule_tag.alert_id)",
-			"DELETE FROM alert_rule_version WHERE rule_org_id = ?",
-			"DELETE FROM alert WHERE org_id = ?",
-			"DELETE FROM annotation WHERE org_id = ?",
-			"DELETE FROM kv_store WHERE org_id = ?",
-			"DELETE FROM team WHERE org_id = ?",
-			"DELETE FROM team_member WHERE org_id = ?",
-			"DELETE FROM team_role WHERE org_id = ?",
-			"DELETE FROM user_role WHERE org_id = ?",
-			"DELETE FROM builtin_role WHERE org_id = ?",
-		}
-
-		deletes = append(deletes, ss.deletes...)
-
-		for _, sql := range deletes {
+		for _, sql := range ss.orgDeletions(dbHelper) {
 			if _, err := sess.Exec(sql, cmd.ID); err != nil {
 				return err
 			}
@@ -243,15 +262,59 @@ func (ss *sqlStore) Delete(ctx context.Context, cmd *org.DeleteOrgCommand) error
 	})
 }
 
+func (ss *sqlStore) orgDeletions(dbHelper *legacysql.LegacyDatabaseHelper) []string {
+	quoteTable := func(name string) string {
+		return dbHelper.DB.Quote(dbHelper.Table(name))
+	}
+	alertRuleTagTable := quoteTable("alert_rule_tag")
+	deletes := []string{ //nolint:prealloc
+		"DELETE FROM " + quoteTable("star") + " WHERE org_id = ?",
+		"DELETE FROM " + quoteTable("dashboard_tag") + " WHERE org_id = ?",
+		"DELETE FROM " + quoteTable("api_key") + " WHERE org_id = ?",
+		"DELETE FROM " + quoteTable("data_source") + " WHERE org_id = ?",
+		"DELETE FROM " + quoteTable("org_user") + " WHERE org_id = ?",
+		"DELETE FROM " + quoteTable("org") + " WHERE id = ?",
+		"DELETE FROM " + quoteTable("temp_user") + " WHERE org_id = ?",
+		"DELETE FROM " + quoteTable("ngalert_configuration") + " WHERE org_id = ?",
+		"DELETE FROM " + quoteTable("alert_configuration") + " WHERE org_id = ?",
+		"DELETE FROM " + quoteTable("alert_instance") + " WHERE rule_org_id = ?",
+		"DELETE FROM " + quoteTable("alert_notification") + " WHERE org_id = ?",
+		"DELETE FROM " + quoteTable("alert_notification_state") + " WHERE org_id = ?",
+		"DELETE FROM " + quoteTable("alert_rule") + " WHERE org_id = ?",
+		"DELETE FROM " + alertRuleTagTable + " AS alert_rule_tag WHERE EXISTS (SELECT 1 FROM " + quoteTable("alert") + " AS alert WHERE alert.org_id = ? AND alert.id = alert_rule_tag.alert_id)",
+		"DELETE FROM " + quoteTable("alert_rule_version") + " WHERE rule_org_id = ?",
+		"DELETE FROM " + quoteTable("alert") + " WHERE org_id = ?",
+		"DELETE FROM " + quoteTable("annotation") + " WHERE org_id = ?",
+		"DELETE FROM " + quoteTable("kv_store") + " WHERE org_id = ?",
+		"DELETE FROM " + quoteTable("team") + " WHERE org_id = ?",
+		"DELETE FROM " + quoteTable("team_member") + " WHERE org_id = ?",
+		"DELETE FROM " + quoteTable("team_role") + " WHERE org_id = ?",
+		"DELETE FROM " + quoteTable("user_role") + " WHERE org_id = ?",
+		"DELETE FROM " + quoteTable("builtin_role") + " WHERE org_id = ?",
+	}
+
+	for _, render := range ss.deleteRenderers {
+		deletes = append(deletes, render(deleteQueryHelper{dbHelper: dbHelper}))
+	}
+
+	return deletes
+}
+
 // TODO: refactor move logic to service method
 func (ss *sqlStore) GetUserOrgList(ctx context.Context, query *org.GetUserOrgListQuery) ([]*org.UserOrgDTO, error) {
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
+
 	result := make([]*org.UserOrgDTO, 0)
-	err := ss.db.WithDbSession(ctx, func(dbSess *db.Session) error {
-		sess := dbSess.Table("org_user")
-		sess.Join("INNER", "org", "org_user.org_id=org.id")
-		sess.Join("INNER", ss.dialect.Quote("user"), fmt.Sprintf("org_user.user_id=%s.id", ss.dialect.Quote("user")))
+	err = dbHelper.DB.WithDbSession(ctx, func(dbSess *db.Session) error {
+		userTable := dbHelper.DB.Quote(dbHelper.Table("user"))
+		sess := dbSess.Table(dbHelper.Table("org_user"))
+		sess.Join("INNER", dbHelper.DB.Quote(dbHelper.Table("org")), "org_user.org_id=org.id")
+		sess.Join("INNER", userTable, fmt.Sprintf("org_user.user_id=%s.id", userTable))
 		sess.Where("org_user.user_id=?", query.UserID)
-		sess.Where(ss.notServiceAccountFilter())
+		sess.Where(ss.notServiceAccountFilter(dbHelper))
 		sess.Cols("org.name", "org_user.role", "org_user.org_id")
 		sess.OrderBy("org.name")
 		err := sess.Find(&result)
@@ -264,16 +327,21 @@ func (ss *sqlStore) GetUserOrgList(ctx context.Context, query *org.GetUserOrgLis
 	return result, nil
 }
 
-func (ss *sqlStore) notServiceAccountFilter() string {
+func (ss *sqlStore) notServiceAccountFilter(dbHelper *legacysql.LegacyDatabaseHelper) string {
 	return fmt.Sprintf("%s.is_service_account = %s",
-		ss.dialect.Quote("user"),
-		ss.dialect.BooleanStr(false))
+		dbHelper.DB.Quote(dbHelper.Table("user")),
+		dbHelper.DB.GetDialect().BooleanStr(false))
 }
 
 func (ss *sqlStore) Search(ctx context.Context, query *org.SearchOrgsQuery) ([]*org.OrgDTO, error) {
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
+
 	result := make([]*org.OrgDTO, 0)
-	err := ss.db.WithDbSession(ctx, func(dbSession *db.Session) error {
-		sess := dbSession.Table("org")
+	err = dbHelper.DB.WithDbSession(ctx, func(dbSession *db.Session) error {
+		sess := dbSession.Table(dbHelper.Table("org"))
 		if query.Query != "" {
 			sess.Where("name LIKE ?", query.Query+"%")
 		}
@@ -301,19 +369,24 @@ func (ss *sqlStore) Search(ctx context.Context, query *org.SearchOrgsQuery) ([]*
 
 // CreateWithMember creates an organization with a certain name and a certain user as member.
 func (ss *sqlStore) CreateWithMember(ctx context.Context, cmd *org.CreateOrgCommand) (*org.Org, error) {
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
+
 	orga := org.Org{
 		Name:    cmd.Name,
 		Created: time.Now(),
 		Updated: time.Now(),
 	}
-	if err := ss.db.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
-		if isNameTaken, err := isOrgNameTaken(cmd.Name, 0, sess); err != nil {
+	if err := dbHelper.DB.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
+		if isNameTaken, err := isOrgNameTaken(dbHelper, cmd.Name, 0, sess); err != nil {
 			return err
 		} else if isNameTaken {
 			return org.ErrOrgNameTaken
 		}
 
-		if _, err := sess.Insert(&orga); err != nil {
+		if _, err := sess.Table(dbHelper.Table("org")).Insert(&orga); err != nil {
 			return err
 		}
 
@@ -325,7 +398,7 @@ func (ss *sqlStore) CreateWithMember(ctx context.Context, cmd *org.CreateOrgComm
 			Updated: time.Now(),
 		}
 
-		_, err := sess.Insert(&user)
+		_, err := sess.Table(dbHelper.Table("org_user")).Insert(&user)
 
 		return err
 	}); err != nil {
@@ -335,12 +408,17 @@ func (ss *sqlStore) CreateWithMember(ctx context.Context, cmd *org.CreateOrgComm
 }
 
 func (ss *sqlStore) AddOrgUser(ctx context.Context, cmd *org.AddOrgUserCommand) error {
-	return ss.db.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	return dbHelper.DB.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
 		// check if user exists
 		var usr user.User
-		session := sess.ID(cmd.UserID)
+		session := sess.Table(dbHelper.Table("user")).ID(cmd.UserID)
 		if !cmd.AllowAddingServiceAccount {
-			session = session.Where(ss.notServiceAccountFilter())
+			session = session.Where(ss.notServiceAccountFilter(dbHelper))
 		}
 
 		if exists, err := session.Get(&usr); err != nil {
@@ -349,13 +427,15 @@ func (ss *sqlStore) AddOrgUser(ctx context.Context, cmd *org.AddOrgUserCommand) 
 			return user.ErrUserNotFound
 		}
 
-		if res, err := sess.Query("SELECT 1 from org_user WHERE org_id=? and user_id=?", cmd.OrgID, usr.ID); err != nil {
+		orgUserTable := dbHelper.DB.Quote(dbHelper.Table("org_user"))
+		if res, err := sess.Query("SELECT 1 FROM "+orgUserTable+" WHERE org_id=? and user_id=?", cmd.OrgID, usr.ID); err != nil {
 			return err
 		} else if len(res) == 1 {
 			return org.ErrOrgUserAlreadyAdded
 		}
 
-		if res, err := sess.Query("SELECT 1 from org WHERE id=?", cmd.OrgID); err != nil {
+		orgTable := dbHelper.DB.Quote(dbHelper.Table("org"))
+		if res, err := sess.Query("SELECT 1 FROM "+orgTable+" WHERE id=?", cmd.OrgID); err != nil {
 			return err
 		} else if len(res) != 1 {
 			return org.ErrOrgNotFound.Errorf("failed to add user to organization with ID: %d", cmd.OrgID)
@@ -369,14 +449,14 @@ func (ss *sqlStore) AddOrgUser(ctx context.Context, cmd *org.AddOrgUserCommand) 
 			Updated: time.Now(),
 		}
 
-		_, err := sess.Insert(&entity)
+		_, err := sess.Table(dbHelper.Table("org_user")).Insert(&entity)
 		if err != nil {
 			return err
 		}
 
 		var userOrgs []*org.UserOrgDTO
-		sess.Table("org_user")
-		sess.Join("INNER", "org", "org_user.org_id=org.id")
+		sess.Table(dbHelper.Table("org_user"))
+		sess.Join("INNER", orgTable, "org_user.org_id=org.id")
 		sess.Where("org_user.user_id=? AND org_user.org_id=?", usr.ID, usr.OrgID)
 		sess.Cols("org.name", "org_user.role", "org_user.org_id")
 		err = sess.Find(&userOrgs)
@@ -386,7 +466,7 @@ func (ss *sqlStore) AddOrgUser(ctx context.Context, cmd *org.AddOrgUserCommand) 
 		}
 
 		if len(userOrgs) == 0 {
-			return setUsingOrgInTransaction(sess, usr.ID, cmd.OrgID)
+			return setUsingOrgInTransaction(dbHelper, sess, usr.ID, cmd.OrgID)
 		}
 
 		return nil
@@ -394,14 +474,19 @@ func (ss *sqlStore) AddOrgUser(ctx context.Context, cmd *org.AddOrgUserCommand) 
 }
 
 func (ss *sqlStore) Count(ctx context.Context, scopeParams *quota.ScopeParameters) (*quota.Map, error) {
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
+
 	u := &quota.Map{}
 	type result struct {
 		Count int64
 	}
 
 	r := result{}
-	if err := ss.db.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
-		rawSQL := "SELECT COUNT(*) as count from org"
+	if err := dbHelper.DB.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
+		rawSQL := "SELECT COUNT(*) as count FROM " + dbHelper.DB.Quote(dbHelper.Table("org"))
 		if _, err := sess.SQL(rawSQL).Get(&r); err != nil {
 			return err
 		}
@@ -417,10 +502,11 @@ func (ss *sqlStore) Count(ctx context.Context, scopeParams *quota.ScopeParameter
 	}
 
 	if scopeParams != nil && scopeParams.OrgID != 0 {
-		if err := ss.db.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
-			rawSQL := fmt.Sprintf("SELECT COUNT(*) AS count FROM (SELECT user_id FROM org_user WHERE org_id=? AND user_id IN (SELECT id AS user_id FROM %s WHERE is_service_account=%s)) as subq",
-				ss.db.GetDialect().Quote("user"),
-				ss.db.GetDialect().BooleanStr(false),
+		if err := dbHelper.DB.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
+			rawSQL := fmt.Sprintf("SELECT COUNT(*) AS count FROM (SELECT user_id FROM %s WHERE org_id=? AND user_id IN (SELECT id AS user_id FROM %s WHERE is_service_account=%s)) as subq",
+				dbHelper.DB.Quote(dbHelper.Table("org_user")),
+				dbHelper.DB.Quote(dbHelper.Table("user")),
+				dbHelper.DB.GetDialect().BooleanStr(false),
 			)
 			if _, err := sess.SQL(rawSQL, scopeParams.OrgID).Get(&r); err != nil {
 				return err
@@ -438,9 +524,9 @@ func (ss *sqlStore) Count(ctx context.Context, scopeParams *quota.ScopeParameter
 	}
 
 	if scopeParams != nil && scopeParams.UserID != 0 {
-		if err := ss.db.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
+		if err := dbHelper.DB.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
 			// should we exclude service accounts?
-			rawSQL := "SELECT COUNT(*) AS count FROM org_user WHERE user_id=?"
+			rawSQL := "SELECT COUNT(*) AS count FROM " + dbHelper.DB.Quote(dbHelper.Table("org_user")) + " WHERE user_id=?"
 			if _, err := sess.SQL(rawSQL, scopeParams.UserID).Get(&r); err != nil {
 				return err
 			}
@@ -459,20 +545,25 @@ func (ss *sqlStore) Count(ctx context.Context, scopeParams *quota.ScopeParameter
 	return u, nil
 }
 
-func setUsingOrgInTransaction(sess *db.Session, userID int64, orgID int64) error {
+func setUsingOrgInTransaction(dbHelper *legacysql.LegacyDatabaseHelper, sess *db.Session, userID int64, orgID int64) error {
 	user := user.User{
 		ID:    userID,
 		OrgID: orgID,
 	}
 
-	_, err := sess.ID(userID).Update(&user)
+	_, err := sess.Table(dbHelper.Table("user")).ID(userID).Update(&user)
 	return err
 }
 
 func (ss *sqlStore) UpdateOrgUser(ctx context.Context, cmd *org.UpdateOrgUserCommand) error {
-	return ss.db.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	return dbHelper.DB.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
 		var orgUser org.OrgUser
-		exists, err := sess.Where("org_id=? AND user_id=?", cmd.OrgID, cmd.UserID).Get(&orgUser)
+		exists, err := sess.Table(dbHelper.Table("org_user")).Where("org_id=? AND user_id=?", cmd.OrgID, cmd.UserID).Get(&orgUser)
 		if err != nil {
 			return err
 		}
@@ -483,18 +574,19 @@ func (ss *sqlStore) UpdateOrgUser(ctx context.Context, cmd *org.UpdateOrgUserCom
 
 		orgUser.Role = cmd.Role
 		orgUser.Updated = time.Now()
-		_, err = sess.ID(orgUser.ID).Update(&orgUser)
+		_, err = sess.Table(dbHelper.Table("org_user")).ID(orgUser.ID).Update(&orgUser)
 		if err != nil {
 			return err
 		}
 
-		return validateOneAdminLeftInOrg(cmd.OrgID, sess)
+		return validateOneAdminLeftInOrg(dbHelper, cmd.OrgID, sess)
 	})
 }
 
 // validate that there is an org admin user left
-func validateOneAdminLeftInOrg(orgID int64, sess *db.Session) error {
-	res, err := sess.Query("SELECT 1 from org_user WHERE org_id=? and role='Admin'", orgID)
+func validateOneAdminLeftInOrg(dbHelper *legacysql.LegacyDatabaseHelper, orgID int64, sess *db.Session) error {
+	query := "SELECT 1 FROM " + dbHelper.DB.Quote(dbHelper.Table("org_user")) + " WHERE org_id=? and role='Admin'"
+	res, err := sess.Query(query, orgID)
 	if err != nil {
 		return err
 	}
@@ -507,9 +599,14 @@ func validateOneAdminLeftInOrg(orgID int64, sess *db.Session) error {
 }
 
 func (ss *sqlStore) GetByID(ctx context.Context, query *org.GetOrgByIDQuery) (*org.Org, error) {
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
+
 	var orga org.Org
-	err := ss.db.WithDbSession(ctx, func(dbSession *db.Session) error {
-		exists, err := dbSession.ID(query.ID).Get(&orga)
+	err = dbHelper.DB.WithDbSession(ctx, func(dbSession *db.Session) error {
+		exists, err := dbSession.Table(dbHelper.Table("org")).ID(query.ID).Get(&orga)
 		if err != nil {
 			return err
 		}
@@ -526,12 +623,18 @@ func (ss *sqlStore) GetByID(ctx context.Context, query *org.GetOrgByIDQuery) (*o
 }
 
 func (ss *sqlStore) SearchOrgUsers(ctx context.Context, query *org.SearchOrgUsersQuery) (*org.SearchOrgUsersQueryResult, error) {
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
+
 	result := org.SearchOrgUsersQueryResult{
 		OrgUsers: make([]*org.OrgUserDTO, 0),
 	}
-	err := ss.db.WithDbSession(ctx, func(dbSession *db.Session) error {
-		sess := dbSession.Table("org_user")
-		sess.Join("INNER", []string{ss.dialect.Quote("user"), "u"}, "org_user.user_id=u.id")
+	err = dbHelper.DB.WithDbSession(ctx, func(dbSession *db.Session) error {
+		userTable := dbHelper.DB.Quote(dbHelper.Table("user"))
+		sess := dbSession.Table(dbHelper.Table("org_user"))
+		sess.Join("INNER", []string{userTable, "u"}, "org_user.user_id=u.id")
 
 		whereConditions := make([]string, 0)
 		whereParams := make([]any, 0)
@@ -545,7 +648,7 @@ func (ss *sqlStore) SearchOrgUsers(ctx context.Context, query *org.SearchOrgUser
 		}
 
 		whereConditions = append(whereConditions, "u.is_service_account = ?")
-		whereParams = append(whereParams, ss.dialect.BooleanValue(false))
+		whereParams = append(whereParams, dbHelper.DB.GetDialect().BooleanValue(false))
 
 		if query.User == nil {
 			ss.log.Warn("Query user not set for filtering.")
@@ -569,9 +672,9 @@ func (ss *sqlStore) SearchOrgUsers(ctx context.Context, query *org.SearchOrgUser
 		}
 
 		if query.Query != "" {
-			sql1, param1 := ss.dialect.LikeOperator("email", true, query.Query, true)
-			sql2, param2 := ss.dialect.LikeOperator("name", true, query.Query, true)
-			sql3, param3 := ss.dialect.LikeOperator("login", true, query.Query, true)
+			sql1, param1 := dbHelper.DB.GetDialect().LikeOperator("email", true, query.Query, true)
+			sql2, param2 := dbHelper.DB.GetDialect().LikeOperator("name", true, query.Query, true)
+			sql3, param3 := dbHelper.DB.GetDialect().LikeOperator("login", true, query.Query, true)
 			whereConditions = append(whereConditions, fmt.Sprintf("(%s OR %s OR %s)", sql1, sql2, sql3))
 			whereParams = append(whereParams, param1, param2, param3)
 		}
@@ -616,8 +719,8 @@ func (ss *sqlStore) SearchOrgUsers(ctx context.Context, query *org.SearchOrgUser
 
 		// get total count
 		orgUser := org.OrgUser{}
-		countSess := dbSession.Table("org_user").
-			Join("INNER", []string{ss.dialect.Quote("user"), "u"}, "org_user.user_id=u.id")
+		countSess := dbSession.Table(dbHelper.Table("org_user")).
+			Join("INNER", []string{userTable, "u"}, "org_user.user_id=u.id")
 
 		if len(whereConditions) > 0 {
 			countSess.Where(strings.Join(whereConditions, " AND "), whereParams...)
@@ -646,7 +749,12 @@ func (ss *sqlStore) SearchOrgUsersByEmails(ctx context.Context, query *org.Searc
 	if len(query.Emails) == 0 {
 		return result, nil
 	}
-	err := ss.db.WithDbSession(ctx, func(dbSession *db.Session) error {
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	err = dbHelper.DB.WithDbSession(ctx, func(dbSession *db.Session) error {
 		emailArgs := make([]any, len(query.Emails))
 		for i, e := range query.Emails {
 			emailArgs[i] = strings.ToLower(e)
@@ -660,7 +768,7 @@ func (ss *sqlStore) SearchOrgUsersByEmails(ctx context.Context, query *org.Searc
 			"u.is_service_account = ?",
 		}
 		whereParams := append([]any{query.OrgID}, emailArgs...)
-		whereParams = append(whereParams, ss.dialect.BooleanValue(false))
+		whereParams = append(whereParams, dbHelper.DB.GetDialect().BooleanValue(false))
 
 		if query.ExcludeHiddenUsers && ss.cfg != nil {
 			cond, params := buildHiddenUsersFilter(nil, ss.cfg.HiddenUsers)
@@ -670,8 +778,8 @@ func (ss *sqlStore) SearchOrgUsersByEmails(ctx context.Context, query *org.Searc
 			}
 		}
 
-		sess := dbSession.Table("org_user").
-			Join("INNER", []string{ss.dialect.Quote("user"), "u"}, "org_user.user_id=u.id").
+		sess := dbSession.Table(dbHelper.Table("org_user")).
+			Join("INNER", []string{dbHelper.DB.Quote(dbHelper.Table("user")), "u"}, "org_user.user_id=u.id").
 			Where(strings.Join(whereConditions, " AND "), whereParams...).
 			Cols(
 				"org_user.org_id",
@@ -698,9 +806,14 @@ func (ss *sqlStore) SearchOrgUsersByEmails(ctx context.Context, query *org.Searc
 }
 
 func (ss *sqlStore) GetByName(ctx context.Context, query *org.GetOrgByNameQuery) (*org.Org, error) {
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
+
 	var orga org.Org
-	err := ss.db.WithDbSession(ctx, func(dbSession *db.Session) error {
-		exists, err := dbSession.Where("name=?", query.Name).Get(&orga)
+	err = dbHelper.DB.WithDbSession(ctx, func(dbSession *db.Session) error {
+		exists, err := dbSession.Table(dbHelper.Table("org")).Where("name=?", query.Name).Get(&orga)
 		if err != nil {
 			return err
 		}
@@ -717,10 +830,15 @@ func (ss *sqlStore) GetByName(ctx context.Context, query *org.GetOrgByNameQuery)
 }
 
 func (ss *sqlStore) RemoveOrgUser(ctx context.Context, cmd *org.RemoveOrgUserCommand) error {
-	return ss.db.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	return dbHelper.DB.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
 		// check if user exists
 		var usr user.User
-		if exists, err := sess.ID(cmd.UserID).Where(ss.notServiceAccountFilter()).Get(&usr); err != nil {
+		if exists, err := sess.Table(dbHelper.Table("user")).ID(cmd.UserID).Where(ss.notServiceAccountFilter(dbHelper)).Get(&usr); err != nil {
 			return err
 		} else if !exists {
 			return user.ErrUserNotFound
@@ -728,18 +846,21 @@ func (ss *sqlStore) RemoveOrgUser(ctx context.Context, cmd *org.RemoveOrgUserCom
 
 		// check if user belongs to org
 		var orgUser org.OrgUser
-		if exists, err := sess.Where("org_id=? AND user_id=?", cmd.OrgID, cmd.UserID).Get(&orgUser); err != nil {
+		if exists, err := sess.Table(dbHelper.Table("org_user")).Where("org_id=? AND user_id=?", cmd.OrgID, cmd.UserID).Get(&orgUser); err != nil {
 			return err
 		} else if !exists {
 			ss.log.Debug("User not in org, nothing to do", "user_id", cmd.UserID, "org_id", cmd.OrgID)
 			return nil
 		}
 
+		quoteTable := func(name string) string {
+			return dbHelper.DB.Quote(dbHelper.Table(name))
+		}
 		deletes := []string{
-			"DELETE FROM org_user WHERE org_id=? and user_id=?",
-			"DELETE FROM dashboard_acl WHERE org_id=? and user_id = ?",
-			"DELETE FROM team_member WHERE org_id=? and user_id = ?",
-			"DELETE FROM query_history_star WHERE org_id=? and user_id = ?",
+			"DELETE FROM " + quoteTable("org_user") + " WHERE org_id=? and user_id=?",
+			"DELETE FROM " + quoteTable("dashboard_acl") + " WHERE org_id=? and user_id = ?",
+			"DELETE FROM " + quoteTable("team_member") + " WHERE org_id=? and user_id = ?",
+			"DELETE FROM " + quoteTable("query_history_star") + " WHERE org_id=? and user_id = ?",
 		}
 
 		for _, sql := range deletes {
@@ -750,14 +871,14 @@ func (ss *sqlStore) RemoveOrgUser(ctx context.Context, cmd *org.RemoveOrgUserCom
 		}
 
 		// validate that after delete, there is at least one user with admin role in org
-		if err := validateOneAdminLeftInOrg(cmd.OrgID, sess); err != nil {
+		if err := validateOneAdminLeftInOrg(dbHelper, cmd.OrgID, sess); err != nil {
 			return err
 		}
 
 		// check user other orgs and update user current org
 		var userOrgs []*org.UserOrgDTO
-		sess.Table("org_user")
-		sess.Join("INNER", "org", "org_user.org_id=org.id")
+		sess.Table(dbHelper.Table("org_user"))
+		sess.Join("INNER", dbHelper.DB.Quote(dbHelper.Table("org")), "org_user.org_id=org.id")
 		sess.Where("org_user.user_id=?", usr.ID)
 		sess.Cols("org.name", "org_user.role", "org_user.org_id")
 		err := sess.Find(&userOrgs)
@@ -776,21 +897,21 @@ func (ss *sqlStore) RemoveOrgUser(ctx context.Context, cmd *org.RemoveOrgUserCom
 			}
 
 			if !hasCurrentOrgSet {
-				err = setUsingOrgInTransaction(sess, usr.ID, userOrgs[0].OrgID)
+				err = setUsingOrgInTransaction(dbHelper, sess, usr.ID, userOrgs[0].OrgID)
 				if err != nil {
 					return err
 				}
 			}
 		} else if cmd.ShouldDeleteOrphanedUser && !usr.IsAdmin {
 			// no other orgs, delete the full user
-			if err := ss.deleteUserInTransaction(sess, &user.DeleteUserCommand{UserID: usr.ID}); err != nil {
+			if err := ss.deleteUserInTransaction(dbHelper, sess, &user.DeleteUserCommand{UserID: usr.ID}); err != nil {
 				return err
 			}
 
 			cmd.UserWasDeleted = true
 		} else {
 			// no orgs, but keep the user -> clean up orgId
-			err = removeUserOrg(sess, usr.ID)
+			err = removeUserOrg(dbHelper, sess, usr.ID)
 			if err != nil {
 				return err
 			}
@@ -800,39 +921,41 @@ func (ss *sqlStore) RemoveOrgUser(ctx context.Context, cmd *org.RemoveOrgUserCom
 	})
 }
 
-func (ss *sqlStore) deleteUserInTransaction(sess *db.Session, cmd *user.DeleteUserCommand) error {
+func (ss *sqlStore) deleteUserInTransaction(dbHelper *legacysql.LegacyDatabaseHelper, sess *db.Session, cmd *user.DeleteUserCommand) error {
 	// Check if user exists
 	usr := user.User{ID: cmd.UserID}
-	has, err := sess.Where(ss.notServiceAccountFilter()).Get(&usr)
+	has, err := sess.Table(dbHelper.Table("user")).Where(ss.notServiceAccountFilter(dbHelper)).Get(&usr)
 	if err != nil {
 		return err
 	}
 	if !has {
 		return user.ErrUserNotFound
 	}
-	for _, sql := range ss.userDeletions() {
+	for _, sql := range ss.userDeletions(dbHelper) {
 		_, err := sess.Exec(sql, cmd.UserID)
 		if err != nil {
 			return err
 		}
 	}
 
-	return deleteUserAccessControl(sess, cmd.UserID)
+	return deleteUserAccessControl(dbHelper, sess, cmd.UserID)
 }
 
-func deleteUserAccessControl(sess *db.Session, userID int64) error {
+func deleteUserAccessControl(dbHelper *legacysql.LegacyDatabaseHelper, sess *db.Session, userID int64) error {
 	// Delete user role assignments
-	if _, err := sess.Exec("DELETE FROM user_role WHERE user_id = ?", userID); err != nil {
+	if _, err := sess.Exec("DELETE FROM "+dbHelper.DB.Quote(dbHelper.Table("user_role"))+" WHERE user_id = ?", userID); err != nil {
 		return err
 	}
 
 	// Delete permissions that are scoped to user
-	if _, err := sess.Exec("DELETE FROM permission WHERE scope = ?", accesscontrol.Scope("users", "id", strconv.FormatInt(userID, 10))); err != nil {
+	permissionTable := dbHelper.DB.Quote(dbHelper.Table("permission"))
+	if _, err := sess.Exec("DELETE FROM "+permissionTable+" WHERE scope = ?", accesscontrol.Scope("users", "id", strconv.FormatInt(userID, 10))); err != nil {
 		return err
 	}
 
 	var roleIDs []int64
-	if err := sess.SQL("SELECT id FROM role WHERE name = ?", accesscontrol.ManagedUserRoleName(userID)).Find(&roleIDs); err != nil {
+	roleTable := dbHelper.DB.Quote(dbHelper.Table("role"))
+	if err := sess.SQL("SELECT id FROM "+roleTable+" WHERE name = ?", accesscontrol.ManagedUserRoleName(userID)).Find(&roleIDs); err != nil {
 		return err
 	}
 
@@ -840,7 +963,7 @@ func deleteUserAccessControl(sess *db.Session, userID int64) error {
 		return nil
 	}
 
-	query := "DELETE FROM permission WHERE role_id IN(? " + strings.Repeat(",?", len(roleIDs)-1) + ")"
+	query := "DELETE FROM " + permissionTable + " WHERE role_id IN(? " + strings.Repeat(",?", len(roleIDs)-1) + ")"
 	args := make([]any, 0, len(roleIDs)+1)
 	args = append(args, query)
 	for _, id := range roleIDs {
@@ -853,41 +976,44 @@ func deleteUserAccessControl(sess *db.Session, userID int64) error {
 	}
 
 	// Delete managed user roles
-	if _, err := sess.Exec("DELETE FROM role WHERE name = ?", accesscontrol.ManagedUserRoleName(userID)); err != nil {
+	if _, err := sess.Exec("DELETE FROM "+roleTable+" WHERE name = ?", accesscontrol.ManagedUserRoleName(userID)); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (ss *sqlStore) userDeletions() []string {
+func (ss *sqlStore) userDeletions(dbHelper *legacysql.LegacyDatabaseHelper) []string {
+	quoteTable := func(name string) string {
+		return dbHelper.DB.Quote(dbHelper.Table(name))
+	}
 	deletes := []string{
-		"DELETE FROM star WHERE user_id = ?",
-		"DELETE FROM " + ss.dialect.Quote("user") + " WHERE id = ?",
-		"DELETE FROM org_user WHERE user_id = ?",
-		"DELETE FROM dashboard_acl WHERE user_id = ?",
-		"DELETE FROM preferences WHERE user_id = ?",
-		"DELETE FROM team_member WHERE user_id = ?",
-		"DELETE FROM user_auth WHERE user_id = ?",
-		"DELETE FROM user_auth_token WHERE user_id = ?",
-		"DELETE FROM quota WHERE user_id = ?",
+		"DELETE FROM " + quoteTable("star") + " WHERE user_id = ?",
+		"DELETE FROM " + quoteTable("user") + " WHERE id = ?",
+		"DELETE FROM " + quoteTable("org_user") + " WHERE user_id = ?",
+		"DELETE FROM " + quoteTable("dashboard_acl") + " WHERE user_id = ?",
+		"DELETE FROM " + quoteTable("preferences") + " WHERE user_id = ?",
+		"DELETE FROM " + quoteTable("team_member") + " WHERE user_id = ?",
+		"DELETE FROM " + quoteTable("user_auth") + " WHERE user_id = ?",
+		"DELETE FROM " + quoteTable("user_auth_token") + " WHERE user_id = ?",
+		"DELETE FROM " + quoteTable("quota") + " WHERE user_id = ?",
 	}
 	return deletes
 }
 
-func removeUserOrg(sess *db.Session, userID int64) error {
+func removeUserOrg(dbHelper *legacysql.LegacyDatabaseHelper, sess *db.Session, userID int64) error {
 	user := user.User{
 		ID:    userID,
 		OrgID: 0,
 	}
 
-	_, err := sess.ID(userID).MustCols("org_id").Update(&user)
+	_, err := sess.Table(dbHelper.Table("user")).ID(userID).MustCols("org_id").Update(&user)
 	return err
 }
 
-// RegisterDelete registers a delete query to be executed when an org is deleted, used to delete enterprise data.
-func (ss *sqlStore) RegisterDelete(query string) {
-	ss.deletes = append(ss.deletes, query)
+// RegisterDelete registers a query to run when an org is deleted.
+func (ss *sqlStore) RegisterDelete(renderer org.DeleteQueryRenderer) {
+	ss.deleteRenderers = append(ss.deleteRenderers, renderer)
 }
 
 func buildHiddenUsersFilter(requester identity.Requester, hiddenUsersMap map[string]struct{}) (string, []any) {

--- a/pkg/services/org/orgimpl/store.go
+++ b/pkg/services/org/orgimpl/store.go
@@ -246,7 +246,34 @@ func (ss *sqlStore) Delete(ctx context.Context, cmd *org.DeleteOrgCommand) error
 			return org.ErrOrgNotFound.Errorf("failed to delete organisation with ID: %d", cmd.ID)
 		}
 
-		for _, sql := range ss.orgDeletions(dbHelper) {
+		alertRuleTagTable := quoteTable(dbHelper, "alert_rule_tag")
+		deletes := []string{ //nolint:prealloc
+			"DELETE FROM " + quoteTable(dbHelper, "star") + " WHERE org_id = ?",
+			"DELETE FROM " + quoteTable(dbHelper, "dashboard_tag") + " WHERE org_id = ?",
+			"DELETE FROM " + quoteTable(dbHelper, "api_key") + " WHERE org_id = ?",
+			"DELETE FROM " + quoteTable(dbHelper, "data_source") + " WHERE org_id = ?",
+			"DELETE FROM " + quoteTable(dbHelper, "org_user") + " WHERE org_id = ?",
+			"DELETE FROM " + quoteTable(dbHelper, "org") + " WHERE id = ?",
+			"DELETE FROM " + quoteTable(dbHelper, "temp_user") + " WHERE org_id = ?",
+			"DELETE FROM " + quoteTable(dbHelper, "ngalert_configuration") + " WHERE org_id = ?",
+			"DELETE FROM " + quoteTable(dbHelper, "alert_configuration") + " WHERE org_id = ?",
+			"DELETE FROM " + quoteTable(dbHelper, "alert_instance") + " WHERE rule_org_id = ?",
+			"DELETE FROM " + quoteTable(dbHelper, "alert_notification") + " WHERE org_id = ?",
+			"DELETE FROM " + quoteTable(dbHelper, "alert_notification_state") + " WHERE org_id = ?",
+			"DELETE FROM " + quoteTable(dbHelper, "alert_rule") + " WHERE org_id = ?",
+			"DELETE FROM " + alertRuleTagTable + " WHERE EXISTS (SELECT 1 FROM " + quoteTable(dbHelper, "alert") + " AS alert WHERE alert.org_id = ? AND alert.id = alert_rule_tag.alert_id)",
+			"DELETE FROM " + quoteTable(dbHelper, "alert_rule_version") + " WHERE rule_org_id = ?",
+			"DELETE FROM " + quoteTable(dbHelper, "alert") + " WHERE org_id = ?",
+			"DELETE FROM " + quoteTable(dbHelper, "annotation") + " WHERE org_id = ?",
+			"DELETE FROM " + quoteTable(dbHelper, "kv_store") + " WHERE org_id = ?",
+			"DELETE FROM " + quoteTable(dbHelper, "team") + " WHERE org_id = ?",
+			"DELETE FROM " + quoteTable(dbHelper, "team_member") + " WHERE org_id = ?",
+			"DELETE FROM " + quoteTable(dbHelper, "team_role") + " WHERE org_id = ?",
+			"DELETE FROM " + quoteTable(dbHelper, "user_role") + " WHERE org_id = ?",
+			"DELETE FROM " + quoteTable(dbHelper, "builtin_role") + " WHERE org_id = ?",
+		}
+
+		for _, sql := range deletes {
 			if _, err := sess.Exec(sql, cmd.ID); err != nil {
 				return err
 			}
@@ -264,37 +291,6 @@ func (ss *sqlStore) Delete(ctx context.Context, cmd *org.DeleteOrgCommand) error
 
 		return nil
 	})
-}
-
-func (ss *sqlStore) orgDeletions(dbHelper *legacysql.LegacyDatabaseHelper) []string {
-	alertRuleTagTable := quoteTable(dbHelper, "alert_rule_tag")
-	deletes := []string{ //nolint:prealloc
-		"DELETE FROM " + quoteTable(dbHelper, "star") + " WHERE org_id = ?",
-		"DELETE FROM " + quoteTable(dbHelper, "dashboard_tag") + " WHERE org_id = ?",
-		"DELETE FROM " + quoteTable(dbHelper, "api_key") + " WHERE org_id = ?",
-		"DELETE FROM " + quoteTable(dbHelper, "data_source") + " WHERE org_id = ?",
-		"DELETE FROM " + quoteTable(dbHelper, "org_user") + " WHERE org_id = ?",
-		"DELETE FROM " + quoteTable(dbHelper, "org") + " WHERE id = ?",
-		"DELETE FROM " + quoteTable(dbHelper, "temp_user") + " WHERE org_id = ?",
-		"DELETE FROM " + quoteTable(dbHelper, "ngalert_configuration") + " WHERE org_id = ?",
-		"DELETE FROM " + quoteTable(dbHelper, "alert_configuration") + " WHERE org_id = ?",
-		"DELETE FROM " + quoteTable(dbHelper, "alert_instance") + " WHERE rule_org_id = ?",
-		"DELETE FROM " + quoteTable(dbHelper, "alert_notification") + " WHERE org_id = ?",
-		"DELETE FROM " + quoteTable(dbHelper, "alert_notification_state") + " WHERE org_id = ?",
-		"DELETE FROM " + quoteTable(dbHelper, "alert_rule") + " WHERE org_id = ?",
-		"DELETE FROM " + alertRuleTagTable + " WHERE EXISTS (SELECT 1 FROM " + quoteTable(dbHelper, "alert") + " AS alert WHERE alert.org_id = ? AND alert.id = alert_rule_tag.alert_id)",
-		"DELETE FROM " + quoteTable(dbHelper, "alert_rule_version") + " WHERE rule_org_id = ?",
-		"DELETE FROM " + quoteTable(dbHelper, "alert") + " WHERE org_id = ?",
-		"DELETE FROM " + quoteTable(dbHelper, "annotation") + " WHERE org_id = ?",
-		"DELETE FROM " + quoteTable(dbHelper, "kv_store") + " WHERE org_id = ?",
-		"DELETE FROM " + quoteTable(dbHelper, "team") + " WHERE org_id = ?",
-		"DELETE FROM " + quoteTable(dbHelper, "team_member") + " WHERE org_id = ?",
-		"DELETE FROM " + quoteTable(dbHelper, "team_role") + " WHERE org_id = ?",
-		"DELETE FROM " + quoteTable(dbHelper, "user_role") + " WHERE org_id = ?",
-		"DELETE FROM " + quoteTable(dbHelper, "builtin_role") + " WHERE org_id = ?",
-	}
-
-	return deletes
 }
 
 // TODO: refactor move logic to service method

--- a/pkg/services/org/orgimpl/store_test.go
+++ b/pkg/services/org/orgimpl/store_test.go
@@ -3,16 +3,20 @@ package orgimpl
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/configprovider"
 	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/infra/db/dbtest"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -20,6 +24,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/quota/quotaimpl"
 	"github.com/grafana/grafana/pkg/services/searchusers/sortopts"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/grafana/grafana/pkg/services/supportbundles/supportbundlestest"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/userimpl"
@@ -27,10 +32,101 @@ import (
 	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 	"github.com/grafana/grafana/pkg/util/testutil"
+	"github.com/grafana/grafana/pkg/util/xorm"
+	"github.com/grafana/grafana/pkg/util/xorm/core"
 )
 
 func TestMain(m *testing.M) {
 	testsuite.Run(m)
+}
+
+var registerOrgSQLMockXormDriverOnce sync.Once
+
+type orgSQLMockXormDriver struct{}
+
+func (orgSQLMockXormDriver) Parse(string, string) (*core.Uri, error) {
+	return &core.Uri{DbType: core.SQLITE}, nil
+}
+
+type sqlmockOrgDB struct {
+	dbtest.FakeDB
+	engine *xorm.Engine
+}
+
+func (d *sqlmockOrgDB) WithDbSession(_ context.Context, callback sqlstore.DBTransactionFunc) error {
+	return d.withSession(callback)
+}
+
+func (d *sqlmockOrgDB) WithTransactionalDbSession(_ context.Context, callback sqlstore.DBTransactionFunc) error {
+	return d.withSession(callback)
+}
+
+func (d *sqlmockOrgDB) withSession(callback sqlstore.DBTransactionFunc) error {
+	sess := &sqlstore.DBSession{Session: d.engine.NewSession()}
+	defer sess.Close()
+	return callback(sess)
+}
+
+func (d *sqlmockOrgDB) GetDBType() core.DbType {
+	return core.SQLITE
+}
+
+func (d *sqlmockOrgDB) GetDialect() migrator.Dialect {
+	return migrator.NewSQLite3Dialect()
+}
+
+func (d *sqlmockOrgDB) Quote(value string) string {
+	return d.engine.Quote(value)
+}
+
+func TestStoreUsesProviderTables(t *testing.T) {
+	registerOrgSQLMockXormDriverOnce.Do(func() {
+		if core.QueryDriver("sqlmock") == nil {
+			core.RegisterDriver("sqlmock", orgSQLMockXormDriver{})
+		}
+	})
+
+	dsn := "orgimpl-store"
+	mockDB, mock, err := sqlmock.NewWithDSN(dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mockDB.Close() })
+
+	engine, err := xorm.NewEngine("sqlmock", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = engine.Close() })
+
+	legacyDB := &sqlmockOrgDB{engine: engine}
+	type contextKey struct{}
+	ctx := context.WithValue(context.Background(), contextKey{}, "provider context")
+	calls := 0
+	tables := make([]string, 0, 2)
+	provider := func(gotCtx context.Context) (*legacysql.LegacyDatabaseHelper, error) {
+		require.Equal(t, "provider context", gotCtx.Value(contextKey{}))
+		calls++
+		return &legacysql.LegacyDatabaseHelper{
+			DB: legacyDB,
+			Table: func(name string) string {
+				tables = append(tables, name)
+				return "test_schema." + name
+			},
+		}, nil
+	}
+	store := &sqlStore{sql: provider, log: log.NewNopLogger()}
+
+	mock.ExpectQuery(regexp.QuoteMeta("FROM `test_schema`.`org`")).
+		WithArgs(int64(42)).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(42)))
+	_, err = store.Get(ctx, 42)
+	require.NoError(t, err)
+
+	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM `test_schema`.`org_user` WHERE user_id = ?")).
+		WithArgs(int64(42)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	require.NoError(t, store.DeleteUserFromAll(ctx, 42))
+
+	require.Equal(t, 2, calls)
+	require.Equal(t, []string{"org", "org_user"}, tables)
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestIntegrationOrgDataAccess(t *testing.T) {
@@ -38,9 +134,8 @@ func TestIntegrationOrgDataAccess(t *testing.T) {
 
 	ss := db.InitTestDB(t)
 	orgStore := sqlStore{
-		db:      ss,
-		dialect: ss.GetDialect(),
-		log:     log.NewNopLogger(),
+		sql: legacysql.NewDatabaseProvider(ss),
+		log: log.NewNopLogger(),
 	}
 
 	t.Run("org not found", func(t *testing.T) {
@@ -209,8 +304,7 @@ func TestIntegrationOrgDataAccess(t *testing.T) {
 	t.Run("Testing Account DB Access", func(t *testing.T) {
 		ss := db.InitTestDB(t)
 		orgStore = sqlStore{
-			db:      ss,
-			dialect: ss.GetDialect(),
+			sql: legacysql.NewDatabaseProvider(ss),
 		}
 		ids := []int64{}
 
@@ -260,9 +354,8 @@ func TestIntegrationOrgUserDataAccess(t *testing.T) {
 
 	ss := db.InitTestDB(t)
 	orgUserStore := sqlStore{
-		db:      ss,
-		dialect: ss.GetDialect(),
-		log:     log.NewNopLogger(),
+		sql: legacysql.NewDatabaseProvider(ss),
+		log: log.NewNopLogger(),
 	}
 
 	t.Run("org user inserted", func(t *testing.T) {
@@ -505,7 +598,7 @@ func TestIntegrationOrgUserDataAccess(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		store := sqlStore{db: ss, dialect: ss.GetDialect(), log: log.NewNopLogger()}
+		store := sqlStore{sql: legacysql.NewDatabaseProvider(ss), log: log.NewNopLogger()}
 
 		t.Run("returns matched members", func(t *testing.T) {
 			result, err := store.SearchOrgUsersByEmails(context.Background(), &org.SearchOrgUsersByEmailsQuery{
@@ -548,10 +641,9 @@ func TestIntegrationOrgUserDataAccess(t *testing.T) {
 
 		t.Run("excludes hidden users when ExcludeHiddenUsers is set", func(t *testing.T) {
 			storeWithHidden := sqlStore{
-				db:      ss,
-				dialect: ss.GetDialect(),
-				log:     log.NewNopLogger(),
-				cfg:     &setting.Cfg{HiddenUsers: map[string]struct{}{ac2.Login: {}}},
+				sql: legacysql.NewDatabaseProvider(ss),
+				log: log.NewNopLogger(),
+				cfg: &setting.Cfg{HiddenUsers: map[string]struct{}{ac2.Login: {}}},
 			}
 			result, err := storeWithHidden.SearchOrgUsersByEmails(context.Background(), &org.SearchOrgUsersByEmailsQuery{
 				OrgID:              ac1.OrgID,
@@ -599,10 +691,9 @@ func TestIntegrationOrgUserDataAccess(t *testing.T) {
 
 		t.Run("returns hidden users when ExcludeHiddenUsers is false", func(t *testing.T) {
 			storeWithHidden := sqlStore{
-				db:      ss,
-				dialect: ss.GetDialect(),
-				log:     log.NewNopLogger(),
-				cfg:     &setting.Cfg{HiddenUsers: map[string]struct{}{ac2.Login: {}}},
+				sql: legacysql.NewDatabaseProvider(ss),
+				log: log.NewNopLogger(),
+				cfg: &setting.Cfg{HiddenUsers: map[string]struct{}{ac2.Login: {}}},
 			}
 			result, err := storeWithHidden.SearchOrgUsersByEmails(context.Background(), &org.SearchOrgUsersByEmailsQuery{
 				OrgID:  ac1.OrgID,
@@ -680,9 +771,8 @@ func TestIntegrationSQLStore_AddOrgUser(t *testing.T) {
 	cfg.AutoAssignOrgId = 1
 	cfg.AutoAssignOrgRole = "Viewer"
 	orgUserStore := sqlStore{
-		db:      store,
-		dialect: store.GetDialect(),
-		log:     log.NewNopLogger(),
+		sql: legacysql.NewDatabaseProvider(store),
+		log: log.NewNopLogger(),
 	}
 	orgSvc, usrSvc := createOrgAndUserSvc(t, store, cfg)
 
@@ -744,9 +834,8 @@ func TestIntegration_SQLStore_GetOrgUsers(t *testing.T) {
 
 	store, cfg := db.InitTestDBWithCfg(t)
 	orgUserStore := sqlStore{
-		db:      store,
-		dialect: store.GetDialect(),
-		log:     log.NewNopLogger(),
+		sql: legacysql.NewDatabaseProvider(store),
+		log: log.NewNopLogger(),
 	}
 	cfg.IsEnterprise = true
 	defer func() {
@@ -862,9 +951,8 @@ func TestIntegration_SQLStore_GetOrgUsers_PopulatesCorrectly(t *testing.T) {
 
 	store, cfg := db.InitTestDBWithCfg(t, sqlstore.InitTestDBOpt{})
 	orgUserStore := sqlStore{
-		db:      store,
-		dialect: store.GetDialect(),
-		log:     log.NewNopLogger(),
+		sql: legacysql.NewDatabaseProvider(store),
+		log: log.NewNopLogger(),
 	}
 	_, usrSvc := createOrgAndUserSvc(t, store, cfg)
 
@@ -922,10 +1010,9 @@ func TestIntegration_SQLStore_SearchOrgUsers(t *testing.T) {
 
 	store, cfg := db.InitTestDBWithCfg(t, sqlstore.InitTestDBOpt{})
 	orgUserStore := sqlStore{
-		db:      store,
-		dialect: store.GetDialect(),
-		log:     log.NewNopLogger(),
-		cfg:     cfg,
+		sql: legacysql.NewDatabaseProvider(store),
+		log: log.NewNopLogger(),
+		cfg: cfg,
 	}
 
 	orgSvc, userSvc := createOrgAndUserSvc(t, store, cfg)
@@ -1101,9 +1188,8 @@ func TestIntegration_SQLStore_RemoveOrgUser(t *testing.T) {
 
 	store, cfg := db.InitTestDBWithCfg(t)
 	orgUserStore := sqlStore{
-		db:      store,
-		dialect: store.GetDialect(),
-		log:     log.NewNopLogger(),
+		sql: legacysql.NewDatabaseProvider(store),
+		log: log.NewNopLogger(),
 	}
 
 	orgSvc, usrSvc := createOrgAndUserSvc(t, store, cfg)
@@ -1241,7 +1327,7 @@ func createOrgAndUserSvc(t *testing.T, store db.DB, cfg *setting.Cfg) (org.Servi
 	cfgProvider, err := configprovider.ProvideService(cfg)
 	require.NoError(t, err)
 	quotaService := quotaimpl.ProvideService(context.Background(), legacysql.NewDatabaseProvider(store), cfgProvider)
-	orgService, err := ProvideService(store, cfg, quotaService)
+	orgService, err := ProvideService(legacysql.NewDatabaseProvider(store), cfg, quotaService)
 	require.NoError(t, err)
 	usrSvc, err := userimpl.ProvideService(
 		store, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),

--- a/pkg/services/org/orgimpl/store_test.go
+++ b/pkg/services/org/orgimpl/store_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/services/org/orgdelete"
 	"github.com/grafana/grafana/pkg/services/quota/quotaimpl"
 	"github.com/grafana/grafana/pkg/services/searchusers/sortopts"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
@@ -127,6 +128,54 @@ func TestStoreUsesProviderTables(t *testing.T) {
 	require.Equal(t, 2, calls)
 	require.Equal(t, []string{"org", "org_user"}, tables)
 	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestIntegrationOrgDeleteRenderers(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	type deleteRecord struct {
+		OrgID  int64  `xorm:"org_id"`
+		Marker string `xorm:"marker"`
+	}
+
+	dbStore := db.InitTestDB(t)
+	store := &sqlStore{sql: legacysql.NewDatabaseProvider(dbStore), log: log.NewNopLogger()}
+	err := dbStore.WithDbSession(context.Background(), func(sess *db.Session) error {
+		if _, err := sess.Exec("DROP TABLE IF EXISTS org_delete_renderer_test"); err != nil {
+			return err
+		}
+		_, err := sess.Exec("CREATE TABLE org_delete_renderer_test (org_id INTEGER, marker TEXT)")
+		return err
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := dbStore.WithDbSession(context.Background(), func(sess *db.Session) error {
+			_, err := sess.Exec("DROP TABLE IF EXISTS org_delete_renderer_test")
+			return err
+		})
+		require.NoError(t, err)
+	})
+
+	created := &org.Org{Name: "delete-renderer-test", Created: time.Now(), Updated: time.Now()}
+	_, err = store.Insert(context.Background(), created)
+	require.NoError(t, err)
+
+	deletionService := &DeletionService{store: store}
+	deletionService.RegisterDelete(func(dbHelper *legacysql.LegacyDatabaseHelper, orgID int64) (orgdelete.Query, error) {
+		return orgdelete.Query{
+			SQL:  "INSERT INTO " + quoteTable(dbHelper, "org_delete_renderer_test") + " (org_id, marker) VALUES (?, ?)",
+			Args: []any{orgID, "rendered"},
+		}, nil
+	})
+
+	require.NoError(t, store.Delete(context.Background(), &org.DeleteOrgCommand{ID: created.ID}))
+
+	var records []deleteRecord
+	err = dbStore.WithDbSession(context.Background(), func(sess *db.Session) error {
+		return sess.Table("org_delete_renderer_test").Find(&records)
+	})
+	require.NoError(t, err)
+	require.Equal(t, []deleteRecord{{OrgID: created.ID, Marker: "rendered"}}, records)
 }
 
 func TestIntegrationOrgDataAccess(t *testing.T) {

--- a/pkg/services/org/orgtest/fake.go
+++ b/pkg/services/org/orgtest/fake.go
@@ -118,7 +118,7 @@ func (f *FakeOrgService) SearchOrgUsersByEmails(ctx context.Context, query *org.
 	return f.ExpectedSearchOrgUsersByEmailsResult, f.ExpectedError
 }
 
-func (f *FakeOrgService) RegisterDelete(query string) {
+func (f *FakeOrgService) RegisterDelete(renderer org.DeleteQueryRenderer) {
 }
 
 type FakeOrgDeletionService struct {

--- a/pkg/services/org/orgtest/fake.go
+++ b/pkg/services/org/orgtest/fake.go
@@ -118,9 +118,6 @@ func (f *FakeOrgService) SearchOrgUsersByEmails(ctx context.Context, query *org.
 	return f.ExpectedSearchOrgUsersByEmailsResult, f.ExpectedError
 }
 
-func (f *FakeOrgService) RegisterDelete(renderer org.DeleteQueryRenderer) {
-}
-
 type FakeOrgDeletionService struct {
 	ExpectedError error
 }

--- a/pkg/services/org/orgtest/mock.go
+++ b/pkg/services/org/orgtest/mock.go
@@ -284,9 +284,9 @@ func (_m *MockService) InsertOrgUser(_a0 context.Context, _a1 *org.OrgUser) (int
 	return r0, r1
 }
 
-// RegisterDelete provides a mock function with given fields: query
-func (_m *MockService) RegisterDelete(query string) {
-	_m.Called(query)
+// RegisterDelete provides a mock function with given fields: renderer
+func (_m *MockService) RegisterDelete(renderer org.DeleteQueryRenderer) {
+	_m.Called(renderer)
 }
 
 // RemoveOrgUser provides a mock function with given fields: _a0, _a1

--- a/pkg/services/org/orgtest/mock.go
+++ b/pkg/services/org/orgtest/mock.go
@@ -284,11 +284,6 @@ func (_m *MockService) InsertOrgUser(_a0 context.Context, _a1 *org.OrgUser) (int
 	return r0, r1
 }
 
-// RegisterDelete provides a mock function with given fields: renderer
-func (_m *MockService) RegisterDelete(renderer org.DeleteQueryRenderer) {
-	_m.Called(renderer)
-}
-
 // RemoveOrgUser provides a mock function with given fields: _a0, _a1
 func (_m *MockService) RemoveOrgUser(_a0 context.Context, _a1 *org.RemoveOrgUserCommand) error {
 	ret := _m.Called(_a0, _a1)

--- a/pkg/services/queryhistory/queryhistory_test.go
+++ b/pkg/services/queryhistory/queryhistory_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/userimpl"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 	"github.com/grafana/grafana/pkg/web"
 )
@@ -67,7 +68,7 @@ func testScenario(t *testing.T, desc string, isViewer bool, hasDatasourceExplore
 		}
 		service.Cfg.QueryHistoryEnabled = true
 		quotaService := quotatest.New(false, nil)
-		orgSvc, err := orgimpl.ProvideService(sqlStore, cfg, quotaService)
+		orgSvc, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(sqlStore), cfg, quotaService)
 		require.NoError(t, err)
 		usrSvc, err := userimpl.ProvideService(
 			sqlStore, orgSvc, cfg, nil, nil, tracing.InitializeTracerForTest(),

--- a/pkg/services/quota/quotaimpl/quota_test.go
+++ b/pkg/services/quota/quotaimpl/quota_test.go
@@ -112,7 +112,7 @@ func TestIntegrationQuotaCommandsAndQueries(t *testing.T) {
 	cfgProvider, err := configprovider.ProvideService(cfg)
 	require.NoError(t, err)
 	quotaService := ProvideService(context.Background(), legacysql.NewDatabaseProvider(sqlStore), cfgProvider)
-	orgService, err := orgimpl.ProvideService(sqlStore, cfg, quotaService)
+	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(sqlStore), cfg, quotaService)
 	require.NoError(t, err)
 	userService, err := userimpl.ProvideService(
 		sqlStore, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
@@ -513,7 +513,7 @@ func setupEnv(t *testing.T, sqlStore db.DB, cfg *setting.Cfg, b bus.Bus, quotaSe
 	folderSearchMock.On("GetStats", mock.Anything, mock.Anything, mock.Anything).Return(emptyStatsResponse, nil).Maybe()
 	folderSvc := folderimpl.ProvideService(acmock.New(),
 		nil, featuremgmt.WithFeatures(), supportbundlestest.NewFakeBundleService(), nil, cfg, nil, tracing.InitializeTracerForTest(), folderSearchMock, sort.ProvideService(), apiserver.WithoutRestConfig)
-	orgService, err := orgimpl.ProvideService(sqlStore, cfg, quotaService)
+	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(sqlStore), cfg, quotaService)
 	require.NoError(t, err)
 	dashSearchMock := resource.NewMockResourceClient(t)
 	dashSearchMock.On("Search", mock.Anything, mock.Anything, mock.Anything).Return(emptySearchResponse, nil).Maybe()

--- a/pkg/services/serviceaccounts/database/store_test.go
+++ b/pkg/services/serviceaccounts/database/store_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/supportbundles/supportbundlestest"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/userimpl"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
@@ -248,7 +249,7 @@ func setupTestDatabase(t *testing.T) (db.DB, *ServiceAccountsStoreImpl) {
 	apiKeyService, err := apikeyimpl.ProvideService(db, cfg, quotaService)
 	require.NoError(t, err)
 	kvStore := kvstore.ProvideService(db)
-	orgService, err := orgimpl.ProvideService(db, cfg, quotaService)
+	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(db), cfg, quotaService)
 	require.NoError(t, err)
 	userSvc, err := userimpl.ProvideService(
 		db, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),

--- a/pkg/services/serviceaccounts/tests/common.go
+++ b/pkg/services/serviceaccounts/tests/common.go
@@ -48,7 +48,7 @@ func SetupUserServiceAccount(t *testing.T, db db.DB, cfg *setting.Cfg, testUser 
 	cfgProvider, err := configprovider.ProvideService(cfg)
 	require.NoError(t, err)
 	quotaService := quotaimpl.ProvideService(context.Background(), legacysql.NewDatabaseProvider(db), cfgProvider)
-	orgService, err := orgimpl.ProvideService(db, cfg, quotaService)
+	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(db), cfg, quotaService)
 	require.NoError(t, err)
 	usrSvc, err := userimpl.ProvideService(
 		db, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
@@ -129,7 +129,7 @@ func SetupUsersServiceAccounts(t *testing.T, sqlStore db.DB, cfg *setting.Cfg, t
 	cfgProvider, err := configprovider.ProvideService(cfg)
 	require.NoError(t, err)
 	quotaService := quotaimpl.ProvideService(context.Background(), legacysql.NewDatabaseProvider(sqlStore), cfgProvider)
-	orgService, err := orgimpl.ProvideService(sqlStore, cfg, quotaService)
+	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(sqlStore), cfg, quotaService)
 	require.NoError(t, err)
 	usrSvc, err := userimpl.ProvideService(
 		sqlStore, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),

--- a/pkg/services/stats/statsimpl/stats_test.go
+++ b/pkg/services/stats/statsimpl/stats_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/userimpl"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
@@ -150,7 +151,7 @@ func TestIntegrationStatsDataAccess(t *testing.T) {
 func populateDB(t *testing.T, db db.DB, cfg *setting.Cfg) org.Service {
 	t.Helper()
 
-	orgService, _ := orgimpl.ProvideService(db, cfg, quotatest.New(false, nil))
+	orgService, _ := orgimpl.ProvideService(legacysql.NewDatabaseProvider(db), cfg, quotatest.New(false, nil))
 	userSvc, _ := userimpl.ProvideService(
 		db, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
 		&quotatest.FakeQuotaService{}, supportbundlestest.NewFakeBundleService(), nil,

--- a/pkg/services/team/teamimpl/store_test.go
+++ b/pkg/services/team/teamimpl/store_test.go
@@ -54,7 +54,7 @@ func TestIntegrationTeamCommandsAndQueries(t *testing.T) {
 		cfgProvider, err := configprovider.ProvideService(cfg)
 		require.NoError(t, err)
 		quotaService := quotaimpl.ProvideService(context.Background(), legacysql.NewDatabaseProvider(sqlStore), cfgProvider)
-		orgSvc, err := orgimpl.ProvideService(sqlStore, cfg, quotaService)
+		orgSvc, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(sqlStore), cfg, quotaService)
 		require.NoError(t, err)
 		userSvc, err := userimpl.ProvideService(
 			sqlStore, orgSvc, cfg, teamSvc, nil, tracing.InitializeTracerForTest(),
@@ -506,7 +506,7 @@ func TestIntegrationTeamCommandsAndQueries(t *testing.T) {
 				cfgProvider, err := configprovider.ProvideService(cfg)
 				require.NoError(t, err)
 				quotaService := quotaimpl.ProvideService(context.Background(), legacysql.NewDatabaseProvider(sqlStore), cfgProvider)
-				orgSvc, err := orgimpl.ProvideService(sqlStore, cfg, quotaService)
+				orgSvc, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(sqlStore), cfg, quotaService)
 				require.NoError(t, err)
 				userSvc, err := userimpl.ProvideService(
 					sqlStore, orgSvc, cfg, teamSvc, nil, tracing.InitializeTracerForTest(),
@@ -752,7 +752,7 @@ func TestIntegrationSQLStore_GetTeamMembers_ACFilter(t *testing.T) {
 		cfgProvider, err := configprovider.ProvideService(cfg)
 		require.NoError(t, err)
 		quotaService := quotaimpl.ProvideService(context.Background(), legacysql.NewDatabaseProvider(store), cfgProvider)
-		orgSvc, err := orgimpl.ProvideService(store, cfg, quotaService)
+		orgSvc, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(store), cfg, quotaService)
 		require.NoError(t, err)
 		userSvc, err := userimpl.ProvideService(
 			store, orgSvc, cfg, teamSvc, nil, tracing.InitializeTracerForTest(),

--- a/pkg/services/user/userimpl/store_test.go
+++ b/pkg/services/user/userimpl/store_test.go
@@ -41,7 +41,7 @@ func TestIntegrationUserDataAccess(t *testing.T) {
 	cfgProvider, err := configprovider.ProvideService(cfg)
 	require.NoError(t, err)
 	quotaService := quotaimpl.ProvideService(context.Background(), legacysql.NewDatabaseProvider(ss), cfgProvider)
-	orgService, err := orgimpl.ProvideService(ss, cfg, quotaService)
+	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(ss), cfg, quotaService)
 	require.NoError(t, err)
 	userStore := ProvideStore(ss, setting.NewCfg())
 	usrSvc, err := ProvideService(
@@ -558,7 +558,7 @@ func TestIntegrationUserDataAccess(t *testing.T) {
 
 	t.Run("Testing DB - return list of users that the SignedInUser has permission to read", func(t *testing.T) {
 		ss := db.InitTestDB(t)
-		orgService, err := orgimpl.ProvideService(ss, cfg, quotaService)
+		orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(ss), cfg, quotaService)
 		require.NoError(t, err)
 		usrSvc, err := ProvideService(
 			ss, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
@@ -1088,7 +1088,7 @@ func TestIntegrationMetricsUsage(t *testing.T) {
 	cfgProvider, err := configprovider.ProvideService(cfg)
 	require.NoError(t, err)
 	quotaService := quotaimpl.ProvideService(context.Background(), legacysql.NewDatabaseProvider(ss), cfgProvider)
-	orgService, err := orgimpl.ProvideService(ss, cfg, quotaService)
+	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(ss), cfg, quotaService)
 	require.NoError(t, err)
 
 	_, usrSvc := createOrgAndUserSvc(t, ss, cfg)
@@ -1137,7 +1137,7 @@ func createOrgAndUserSvc(t *testing.T, store db.DB, cfg *setting.Cfg) (org.Servi
 	cfgProvider, err := configprovider.ProvideService(cfg)
 	require.NoError(t, err)
 	quotaService := quotaimpl.ProvideService(context.Background(), legacysql.NewDatabaseProvider(store), cfgProvider)
-	orgService, err := orgimpl.ProvideService(store, cfg, quotaService)
+	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(store), cfg, quotaService)
 	require.NoError(t, err)
 	usrSvc, err := ProvideService(
 		store, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),

--- a/pkg/tests/api/alerting/api_admin_configuration_test.go
+++ b/pkg/tests/api/alerting/api_admin_configuration_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
 	"github.com/grafana/grafana/pkg/services/quota/quotatest"
 	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
@@ -45,7 +46,7 @@ func TestIntegrationAdminConfiguration_SendingToExternalAlertmanagers(t *testing
 
 	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
-	orgService, err := orgimpl.ProvideService(env.SQLStore, env.Cfg, quotatest.New(false, nil))
+	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(env.SQLStore), env.Cfg, quotatest.New(false, nil))
 	require.NoError(t, err)
 
 	// Create a user to make authenticated requests

--- a/pkg/tests/api/alerting/api_namespace_test.go
+++ b/pkg/tests/api/alerting/api_namespace_test.go
@@ -183,7 +183,7 @@ func TestIntegration_NamespacingForRules(t *testing.T) {
 	t.Run("org separation", func(t *testing.T) {
 		cfgProvider, err := configprovider.ProvideService(cfg)
 		require.NoError(t, err)
-		orgService, err := orgimpl.ProvideService(store, cfg, quotaimpl.ProvideService(context.Background(), legacysql.NewDatabaseProvider(store), cfgProvider))
+		orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(store), cfg, quotaimpl.ProvideService(context.Background(), legacysql.NewDatabaseProvider(store), cfgProvider))
 		require.NoError(t, err)
 		newOrg, err := orgService.CreateWithMember(context.Background(), &org.CreateOrgCommand{Name: "Test Org 2"})
 		require.NoError(t, err)
@@ -390,7 +390,7 @@ func TestIntegration_NamespacingForPrometheusRules(t *testing.T) {
 	t.Run("should maintain org separation for Prometheus rules", func(t *testing.T) {
 		cfgProvider, err := configprovider.ProvideService(cfg)
 		require.NoError(t, err)
-		orgService, err := orgimpl.ProvideService(store, cfg, quotaimpl.ProvideService(context.Background(), legacysql.NewDatabaseProvider(store), cfgProvider))
+		orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(store), cfg, quotaimpl.ProvideService(context.Background(), legacysql.NewDatabaseProvider(store), cfgProvider))
 		require.NoError(t, err)
 		newOrg, err := orgService.CreateWithMember(context.Background(), &org.CreateOrgCommand{Name: "Prometheus Test Org 2"})
 		require.NoError(t, err)

--- a/pkg/tests/api/alerting/testing.go
+++ b/pkg/tests/api/alerting/testing.go
@@ -1646,7 +1646,7 @@ func createUser(t *testing.T, db db.DB, cfg *setting.Cfg, cmd user.CreateUserCom
 	cfgProvider, err := configprovider.ProvideService(cfg)
 	require.NoError(t, err)
 	quotaService := quotaimpl.ProvideService(context.Background(), legacysql.NewDatabaseProvider(db), cfgProvider)
-	orgService, err := orgimpl.ProvideService(db, cfg, quotaService)
+	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(db), cfg, quotaService)
 	require.NoError(t, err)
 	usrSvc, err := userimpl.ProvideService(
 		db, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),

--- a/pkg/tests/api/correlations/common_test.go
+++ b/pkg/tests/api/correlations/common_test.go
@@ -149,7 +149,7 @@ func (c TestContext) createOrg(name string) int64 {
 	cfgProvider, err := configprovider.ProvideService(c.env.Cfg)
 	require.NoError(c.t, err)
 	quotaService := quotaimpl.ProvideService(context.Background(), legacysql.NewDatabaseProvider(store), cfgProvider)
-	orgService, err := orgimpl.ProvideService(store, c.env.Cfg, quotaService)
+	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(store), c.env.Cfg, quotaService)
 	require.NoError(c.t, err)
 	orgId, err := orgService.GetOrCreate(context.Background(), name)
 	require.NoError(c.t, err)
@@ -165,7 +165,7 @@ func (c TestContext) createUser(cmd user.CreateUserCommand) User {
 	cfgProvider, err := configprovider.ProvideService(c.env.Cfg)
 	require.NoError(c.t, err)
 	quotaService := quotaimpl.ProvideService(context.Background(), legacysql.NewDatabaseProvider(store), cfgProvider)
-	orgService, err := orgimpl.ProvideService(store, c.env.Cfg, quotaService)
+	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(store), c.env.Cfg, quotaService)
 	require.NoError(c.t, err)
 	usrSvc, err := userimpl.ProvideService(
 		store, orgService, c.env.Cfg, nil, nil, tracing.InitializeTracerForTest(),

--- a/pkg/tests/api/plugins/api_plugins_test.go
+++ b/pkg/tests/api/plugins/api_plugins_test.go
@@ -201,7 +201,7 @@ func createUser(t *testing.T, db db.DB, cfg *setting.Cfg, cmd user.CreateUserCom
 	cfgProvider, err := configprovider.ProvideService(cfg)
 	require.NoError(t, err)
 	quotaService := quotaimpl.ProvideService(context.Background(), legacysql.NewDatabaseProvider(db), cfgProvider)
-	orgService, err := orgimpl.ProvideService(db, cfg, quotaService)
+	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(db), cfg, quotaService)
 	require.NoError(t, err)
 	usrSvc, err := userimpl.ProvideService(
 		db, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),

--- a/pkg/tests/api/shorturl/short_url_test.go
+++ b/pkg/tests/api/shorturl/short_url_test.go
@@ -115,7 +115,7 @@ func createUser(t *testing.T, db db.DB, cfg *setting.Cfg, cmd user.CreateUserCom
 	cfgProvider, err := configprovider.ProvideService(cfg)
 	require.NoError(t, err)
 	quotaService := quotaimpl.ProvideService(context.Background(), legacysql.NewDatabaseProvider(db), cfgProvider)
-	orgService, err := orgimpl.ProvideService(db, cfg, quotaService)
+	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(db), cfg, quotaService)
 	require.NoError(t, err)
 	usrSvc, err := userimpl.ProvideService(
 		db, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),

--- a/pkg/tests/api/stats/admin_test.go
+++ b/pkg/tests/api/stats/admin_test.go
@@ -95,7 +95,7 @@ func createUser(t *testing.T, db db.DB, cfg *setting.Cfg, cmd user.CreateUserCom
 	cfgProvider, err := configprovider.ProvideService(cfg)
 	require.NoError(t, err)
 	quotaService := quotaimpl.ProvideService(context.Background(), legacysql.NewDatabaseProvider(db), cfgProvider)
-	orgService, err := orgimpl.ProvideService(db, cfg, quotaService)
+	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(db), cfg, quotaService)
 	require.NoError(t, err)
 	usrSvc, err := userimpl.ProvideService(
 		db, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),

--- a/pkg/tests/apis/helper.go
+++ b/pkg/tests/apis/helper.go
@@ -198,7 +198,7 @@ func buildK8sTestHelper(t *testing.T, opts K8sTestHelperOpts, listenerAddress st
 	cfgProvider, err := configprovider.ProvideService(c.env.Cfg)
 	require.NoError(c.t, err)
 	quotaService := quotaimpl.ProvideService(context.Background(), legacysql.NewDatabaseProvider(c.env.SQLStore), cfgProvider)
-	orgSvc, err := orgimpl.ProvideService(c.env.SQLStore, c.env.Cfg, quotaService)
+	orgSvc, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(c.env.SQLStore), c.env.Cfg, quotaService)
 	require.NoError(c.t, err)
 	c.orgSvc = orgSvc
 

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -1238,7 +1238,7 @@ func CreateUser(t *testing.T, store db.DB, cfg *setting.Cfg, cmd user.CreateUser
 	cfgProvider, err := configprovider.ProvideService(cfg)
 	require.NoError(t, err)
 	quotaService := quotaimpl.ProvideService(context.Background(), legacysql.NewDatabaseProvider(store), cfgProvider)
-	orgService, err := orgimpl.ProvideService(store, cfg, quotaService)
+	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(store), cfg, quotaService)
 	require.NoError(t, err)
 	usrSvc, err := userimpl.ProvideService(
 		store, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(), quotaService, supportbundlestest.NewFakeBundleService(), nil,

--- a/pkg/tests/utils.go
+++ b/pkg/tests/utils.go
@@ -34,7 +34,7 @@ func CreateUser(t *testing.T, db db.DB, cfg *setting.Cfg, cmd user.CreateUserCom
 	cfgProvider, err := configprovider.ProvideService(cfg)
 	require.NoError(t, err)
 	quotaService := quotaimpl.ProvideService(context.Background(), legacysql.NewDatabaseProvider(db), cfgProvider)
-	orgService, err := orgimpl.ProvideService(db, cfg, quotaService)
+	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(db), cfg, quotaService)
 	require.NoError(t, err)
 	usrSvc, err := userimpl.ProvideService(
 		db, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),


### PR DESCRIPTION
## What changed

- `orgimpl.ProvideService` and `ProvideDeletionService` now accept `LegacyDatabaseProvider`.
- Each org-store operation resolves that provider from its operation context and qualifies all raw and XORM table accesses.
- Organization deletion uses an `orgdelete.Registrar`; renderers receive the resolved database helper, can return bound arguments and errors, and execute in the deletion transaction.
- Server wiring and fixed-database callers use `legacysql.NewDatabaseProvider`.

## Why

The organization service remains in the session-auth dependency graph through user handling. Its cached instance must resolve table names from each request context instead of retaining a database whose default schema was selected at construction.

This prepares the store for the session-auth path without converting queries to SQL templates.

## Related

Enterprise wiring: https://github.com/grafana/grafana-enterprise/pull/12869