### PR TITLE
TraceView: order resource attribute categories by gravity

### DIFF
--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/attributeCategories.test.ts
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/attributeCategories.test.ts
@@ -186,21 +186,37 @@ describe('groupAttributesByCategory', () => {
     expect(grouped.map(({ category }) => category.id)).toEqual(['kubernetes', SERVICE_CATEGORY_ID]);
   });
 
-  it('orders service first and alphabetizes remaining resource categories', () => {
+  it('orders resource categories by gravity', () => {
     const attributes = [
       { key: 'telemetry.sdk.language', value: 'go' },
       { key: 'k8s.namespace.name', value: 'default' },
       { key: 'service.name', value: 'api' },
       { key: 'cloud.provider', value: 'aws' },
+      { key: 'browser.name', value: 'Chrome' },
+      { key: 'deployment.environment', value: 'production' },
+      { key: 'db.system', value: 'postgres' },
+      { key: 'process.pid', value: '1' },
+      { key: 'jvm.memory.used', value: '512' },
+      { key: 'container.id', value: 'abc' },
+      { key: 'host.name', value: 'node-1' },
+      { key: 'custom.field', value: 'value' },
     ];
 
     const grouped = groupAttributesByCategory(attributes, 'resource');
 
     expect(grouped.map(({ category }) => category.id)).toEqual([
+      'frontend',
       SERVICE_CATEGORY_ID,
-      'cloud',
+      'deployment',
+      'database',
+      'process',
+      'runtime',
+      'container',
       'kubernetes',
+      'host-os',
+      'cloud',
       'telemetry-sdk',
+      'other',
     ]);
   });
 

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/attributeCategories.ts
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/attributeCategories.ts
@@ -160,8 +160,21 @@ const ATTRIBUTE_CATEGORY_CONFIG: AttributeCategoryConfig[] = [
   },
 ];
 
+/** Resource categories ordered by "gravity" (user-facing → infrastructure → telemetry). */
 const SECTION_CATEGORY_PRIORITY: Record<AttributeSectionType, string[]> = {
-  resource: [SERVICE_CATEGORY_ID],
+  resource: [
+    'frontend',
+    SERVICE_CATEGORY_ID,
+    'deployment',
+    'database',
+    'process',
+    'runtime',
+    'container',
+    'kubernetes',
+    'host-os',
+    'cloud',
+    'telemetry-sdk',
+  ],
   span: ['http', 'url'],
 };
 


### PR DESCRIPTION
**What is this feature?**

Part of https://github.com/grafana/grafana/issues/129072

Order resource attribute categories by gravity in the trace view.

**Why do we need this feature?**

Matches the mega menu for the Observability apps.

**Who is this feature for?**

Trace view users.