### PR TITLE
E2E Selectors: Add selectors for git-sync and dashboard creation pathfinder guides

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -64,6 +64,17 @@ export const versionedComponents = {
     newDashboardLink: {
       '13.2.0': 'data-testid CreateNewButton New dashboard link',
     },
+    newTemplateDashboardLink: {
+      '13.2.0': 'data-testid CreateNewButton New template dashboard link',
+    },
+  },
+  BuildDashboardButton: {
+    triggerButton: {
+      '13.2.0': 'data-testid BuildDashboardButton trigger button',
+    },
+    fromSuggestionsButton: {
+      '13.2.0': 'data-testid BuildDashboardButton from suggestions button',
+    },
   },
   /**
    * @deprecated use DashboardSidebarSplitter instead
@@ -697,6 +708,11 @@ export const versionedComponents = {
       },
     },
   },
+  Modal: {
+    closeButton: {
+      '13.2.0': 'data-testid Modal close button',
+    },
+  },
   UnconfiguredPanel: {
     actionButton: {
       '13.2.0': (key: string) => `data-testid UnconfiguredPanel action-button ${key}`,
@@ -1220,6 +1236,11 @@ export const versionedComponents = {
     },
   },
 
+  PageActionBar: {
+    searchInput: {
+      '13.2.0': 'data-testid PageActionBar search input',
+    },
+  },
   PageToolbar: {
     container: { [MIN_GRAFANA_VERSION]: () => '.page-toolbar' },
     item: {
@@ -1332,6 +1353,9 @@ export const versionedComponents = {
     },
     input: {
       '10.4.0': 'data-testid folder-picker-input',
+    },
+    triggerButton: {
+      '13.2.0': 'data-testid folder-picker-trigger-button',
     },
   },
   ReadonlyFolderPicker: {

--- a/packages/grafana-e2e-selectors/src/selectors/pages.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/pages.ts
@@ -1152,6 +1152,35 @@ export const versionedPages = {
         '10.2.0': 'data-testid new-folder-create-button',
       },
     },
+    actions: {
+      deleteButton: {
+        '13.2.0': 'data-testid browse dashboards delete button',
+      },
+      moveButton: {
+        '13.2.0': 'data-testid browse dashboards move button',
+      },
+    },
+  },
+  Provisioning: {
+    RepositoryList: {
+      viewLink: {
+        '13.2.0': (name: string) => `data-testid Provisioning repository view link ${name}`,
+      },
+    },
+    RepositoryOverview: {
+      resourcesCard: {
+        '13.2.0': 'data-testid Provisioning repository overview resources card',
+      },
+      healthCard: {
+        '13.2.0': 'data-testid Provisioning repository overview health card',
+      },
+      webhookCard: {
+        '13.2.0': 'data-testid Provisioning repository overview webhook card',
+      },
+      pullStatusCard: {
+        '13.2.0': 'data-testid Provisioning repository overview pull status card',
+      },
+    },
   },
   SearchDashboards: {
     table: {

--- a/packages/grafana-ui/src/components/Modal/Modal.tsx
+++ b/packages/grafana-ui/src/components/Modal/Modal.tsx
@@ -1,6 +1,7 @@
 import { cx } from '@emotion/css';
 import { type PropsWithChildren, type ReactNode, useId, type JSX } from 'react';
 
+import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 
 import { useStyles2 } from '../../themes/ThemeContext';
@@ -86,6 +87,7 @@ export function Modal(props: PropsWithChildren<Props>) {
             name="times"
             size="xl"
             onClick={onDismiss}
+            data-testid={selectors.components.Modal.closeButton}
             aria-label={t('grafana-ui.modal.close-tooltip', 'Close')}
           />
         </div>

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import * as React from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { Alert, floatingUtils, Icon, Input, LoadingBar, Stack, Text, useStyles2 } from '@grafana/ui';
 import { useGetFolderQueryFacade } from 'app/api/clients/folder/v1beta1/hooks';
@@ -314,6 +315,7 @@ export function NestedFolderPicker({
     return (
       <Trigger
         id={id}
+        data-testid={selectors.components.FolderPicker.triggerButton}
         label={labelComponent}
         handleClearSelection={clearable && value !== undefined ? handleClearSelection : undefined}
         invalid={invalid}
@@ -338,6 +340,7 @@ export function NestedFolderPicker({
       <Input
         ref={refs.setReference}
         autoFocus
+        data-testid={selectors.components.FolderPicker.input}
         prefix={label ? <Icon name="folder" /> : <Icon name="search" />}
         placeholder={label ?? t('browse-dashboards.folder-picker.search-placeholder', 'Search folders')}
         value={search}

--- a/public/app/core/components/PageActionBar/PageActionBar.tsx
+++ b/public/app/core/components/PageActionBar/PageActionBar.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/css';
 
 import { type SelectableValue, type GrafanaTheme2 } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { LinkButton, FilterInput, InlineField, Checkbox, useStyles2 } from '@grafana/ui';
 
 import { SortPicker } from '../Select/SortPicker';
@@ -47,7 +48,12 @@ export default function PageActionBar({
   return (
     <div className={styles.container}>
       <InlineField grow>
-        <FilterInput value={searchQuery} onChange={setSearchQuery} placeholder={placeholder} />
+        <FilterInput
+          value={searchQuery}
+          onChange={setSearchQuery}
+          placeholder={placeholder}
+          data-testid={selectors.components.PageActionBar.searchInput}
+        />
       </InlineField>
       {filterCheckbox && (
         <Checkbox

--- a/public/app/features/browse-dashboards/components/BrowseActions/BrowseActions.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseActions/BrowseActions.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
 import { Button, Drawer, Stack, Text } from '@grafana/ui';
@@ -133,7 +134,11 @@ export function BrowseActions({ folderDTO }: Props) {
   };
 
   const moveButton = (
-    <Button onClick={showMoveModal} variant="secondary">
+    <Button
+      onClick={showMoveModal}
+      variant="secondary"
+      data-testid={selectors.pages.BrowseDashboards.actions.moveButton}
+    >
       <Trans i18nKey="browse-dashboards.action.move-button">Move</Trans>
     </Button>
   );
@@ -143,7 +148,11 @@ export function BrowseActions({ folderDTO }: Props) {
       <Stack gap={1} data-testid="manage-actions">
         {moveButton}
 
-        <Button onClick={showDeleteModal} variant="destructive">
+        <Button
+          onClick={showDeleteModal}
+          variant="destructive"
+          data-testid={selectors.pages.BrowseDashboards.actions.deleteButton}
+        >
           <Trans i18nKey="browse-dashboards.action.delete-button">Delete</Trans>
         </Button>
       </Stack>

--- a/public/app/features/browse-dashboards/components/CreateNewButton.tsx
+++ b/public/app/features/browse-dashboards/components/CreateNewButton.tsx
@@ -150,6 +150,7 @@ export default function CreateNewButton({
                     })
               }
               url={buildUrl('/dashboards?templateDashboards=true&source=createNewButton', parentFolder?.uid)}
+              testId={selectors.components.CreateNewButton.newTemplateDashboardLink}
             />
           )}
         </Menu.Group>

--- a/public/app/features/datasources/components/BuildDashboardButton.tsx
+++ b/public/app/features/datasources/components/BuildDashboardButton.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/css';
 
 import { type DataSourceSettings, type GrafanaTheme2 } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { Button, type ComponentSize, Dropdown, Icon, LinkButton, Menu, useStyles2 } from '@grafana/ui';
@@ -67,6 +68,7 @@ export const BuildDashboardButton = ({ dataSource, size, fill, context }: BuildD
           overlay={
             <Menu>
               <Menu.Item
+                testId={selectors.components.BuildDashboardButton.fromSuggestionsButton}
                 label={t('datasources.build-a-dashboard-button.from-suggestions', 'From suggestions')}
                 icon={fetchStatus === 'loading' ? 'spinner' : 'lightbulb-alt'}
                 disabled={fetchStatus === 'loading' || (fetchStatus === 'done' && !hasDashboards)}
@@ -116,7 +118,12 @@ export const BuildDashboardButton = ({ dataSource, size, fill, context }: BuildD
             }
           }}
         >
-          <Button size={size} variant="secondary" fill={fill}>
+          <Button
+            size={size}
+            variant="secondary"
+            fill={fill}
+            data-testid={selectors.components.BuildDashboardButton.triggerButton}
+          >
             <Trans i18nKey="datasources.build-a-dashboard-button.build-a-dashboard">Build a dashboard</Trans>
             <Icon name="angle-down" />
           </Button>

--- a/public/app/features/provisioning/Repository/RepositoryHealthCard.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryHealthCard.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/css';
 import { Link } from 'react-router-dom-v5-compat';
 
 import { type GrafanaTheme2 } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
 import { Badge, Card, Grid, Stack, Text, useStyles2 } from '@grafana/ui';
 import { type Repository } from 'app/api/clients/provisioning/v0alpha1';
@@ -18,7 +19,7 @@ export function RepositoryHealthCard({ repo }: { repo: Repository }) {
   const { connection } = useConnectionStatus(connectionName);
 
   return (
-    <Card noMargin className={styles.card}>
+    <Card noMargin className={styles.card} data-testid={selectors.pages.Provisioning.RepositoryOverview.healthCard}>
       <Card.Heading>
         <Trans i18nKey="provisioning.repository-overview.health">Health</Trans>
       </Card.Heading>

--- a/public/app/features/provisioning/Repository/RepositoryListItem.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryListItem.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/css';
 import { type ReactNode } from 'react';
 
 import { type GrafanaTheme2, dateTimeFormatTimeAgo } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
 import { Button, Card, LinkButton, Stack, Text, TextLink, useStyles2 } from '@grafana/ui';
@@ -105,7 +106,13 @@ export function RepositoryListItem({ repository }: Props) {
 
       <Card.Actions>
         <Stack gap={1} direction="row">
-          <LinkButton icon="eye" href={`${PROVISIONING_URL}/${name}`} variant="primary" size="md">
+          <LinkButton
+            icon="eye"
+            href={`${PROVISIONING_URL}/${name}`}
+            variant="primary"
+            size="md"
+            data-testid={selectors.pages.Provisioning.RepositoryList.viewLink(name)}
+          >
             <Trans i18nKey="provisioning.repository-card.view">View</Trans>
           </LinkButton>
           <SyncRepository repository={repository} />

--- a/public/app/features/provisioning/Repository/RepositoryOverview.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryOverview.tsx
@@ -3,6 +3,7 @@ import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { useMemo } from 'react';
 
 import { textUtil, type GrafanaTheme2 } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { Trans } from '@grafana/i18n';
 import {
   Box,
@@ -103,7 +104,11 @@ export function RepositoryOverview({ repo }: { repo: Repository }) {
         )}
         <Grid columns={{ xs: 1, sm: 2, lg: lgColumn, xxl: xxlColumn }} gap={2} alignItems={'flex-start'}>
           <div className={styles.cardContainer}>
-            <Card noMargin className={styles.card}>
+            <Card
+              noMargin
+              className={styles.card}
+              data-testid={selectors.pages.Provisioning.RepositoryOverview.resourcesCard}
+            >
               <Card.Heading>
                 <Trans i18nKey="provisioning.repository-overview.resources">Resources</Trans>
               </Card.Heading>
@@ -133,7 +138,11 @@ export function RepositoryOverview({ repo }: { repo: Repository }) {
           {/* Webhook */}
           {status?.webhook && (
             <div className={styles.cardContainer}>
-              <Card noMargin className={styles.card}>
+              <Card
+                noMargin
+                className={styles.card}
+                data-testid={selectors.pages.Provisioning.RepositoryOverview.webhookCard}
+              >
                 <Card.Heading>
                   <Trans i18nKey="provisioning.repository-overview.webhook">Webhook</Trans>
                 </Card.Heading>

--- a/public/app/features/provisioning/Repository/RepositoryPullStatusCard.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryPullStatusCard.tsx
@@ -1,6 +1,7 @@
 import { css, cx } from '@emotion/css';
 
 import { type GrafanaTheme2 } from '@grafana/data/';
+import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
 import { Badge, Card, Grid, Text, TextLink, useStyles2 } from '@grafana/ui';
 import { type Repository } from 'app/api/clients/provisioning/v0alpha1';
@@ -30,7 +31,7 @@ export function RepositoryPullStatusCard({ repo }: { repo: Repository }) {
   const { url: lastCommitUrl, hasUrl } = getRepoCommitUrl(repo.spec, status?.sync.lastRef);
 
   return (
-    <Card noMargin className={styles.card}>
+    <Card noMargin className={styles.card} data-testid={selectors.pages.Provisioning.RepositoryOverview.pullStatusCard}>
       <Card.Heading>
         <Trans i18nKey="provisioning.repository-overview.pull-status">Pull status</Trans>
       </Card.Heading>

--- a/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.tsx
@@ -3,6 +3,7 @@ import { Controller, useForm, FormProvider } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { locationUtil } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { locationService, reportInteraction } from '@grafana/runtime';
 import { type Dashboard } from '@grafana/schema';
@@ -598,6 +599,7 @@ export function SaveProvisionedDashboardForm({
             <Button
               variant="primary"
               type="submit"
+              data-testid={selectors.components.Drawer.DashboardSaveDrawer.saveButton}
               disabled={
                 request.isLoading || readOnly || !isDirtyState || isSubmitting || isValidating || isCreatingFolder
               }


### PR DESCRIPTION
Part of #129672 (Group 1 — Shared UI).

Replaces weak Pathfinder guide selectors (text/aria-label/positional CSS) with versioned `@grafana/e2e-selectors` entries wired as `data-testid`, covering the `git-sync-guide` and `grafana-13-tour-learn` guides — 12 anchors across git-sync/provisioning cards and the dashboard-creation flows.

**Structure (2 commits, per the MT-compat guidance in the issue):**
1. `test(e2e-selectors)` — selector definitions only (`components.ts`, `pages.ts`, version key `13.2.0`)
2. `test(dashboards)` — JSX wiring (Modal close, NestedFolderPicker trigger + dormant `FolderPicker.input` revival, PageActionBar search, BrowseActions delete/move, CreateNewButton template link, BuildDashboardButton, provisioning repository cards/overview, SaveProvisionedDashboardForm)

No existing selector values were modified or deleted; new entries follow the package's versioned-key scheme. Verified with `yarn typecheck` and ESLint on all changed files.

The weak→new selector mapping for the guide-side updates in `interactive-tutorials` is tracked in the parent issue's workstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)