### PR TITLE
Search: index the fields trash search needs

### DIFF
--- a/pkg/storage/unified/resource/document.go
+++ b/pkg/storage/unified/resource/document.go
@@ -161,9 +161,12 @@ type IndexableDocument struct {
 	// Who deleted the object, in the same form as CreatedBy.
 	DeletedBy *string `json:"deleted_by,omitempty"`
 
-	// When the object was deleted (unix millis), and the resource version of the delete.
+	// When the object was deleted (unix millis).
 	DeletionTime *int64 `json:"deletion_time,omitempty"`
-	DeletedRV    *int64 `json:"deleted_rv,omitempty"`
+
+	// Resource version of the delete, as a string because it does not survive a
+	// float64 (see TrashSearchFieldDefinitions).
+	DeletedRV *string `json:"deleted_rv,omitempty"`
 }
 
 func (m *IndexableDocument) UpdateCopyFields() *IndexableDocument {
@@ -685,7 +688,7 @@ func StandardSearchFields() SearchableDocumentFields {
 			},
 			{
 				Name:        SEARCH_FIELD_DELETED_RV,
-				Type:        resourcepb.ResourceTableColumnDefinition_INT64,
+				Type:        resourcepb.ResourceTableColumnDefinition_STRING,
 				Description: "Resource version of the delete",
 			},
 		})

--- a/pkg/storage/unified/resource/document.go
+++ b/pkg/storage/unified/resource/document.go
@@ -151,6 +151,19 @@ type IndexableDocument struct {
 	// never returns those, and a deleted document keeps no manager fields to work
 	// it out later. Pointer for the same reason as IsDeleted.
 	IsProvisioned *bool `json:"_provisioned,omitempty"`
+
+	// Fields below are only ever set by buildDeletedDocument, the one place a
+	// deleted document is built. Nothing else enforces that.
+	//
+	// Pointers for the same reason as the markers above: a value would be added to
+	// every live document for nothing to read.
+
+	// Who deleted the object, in the same form as CreatedBy.
+	DeletedBy *string `json:"deleted_by,omitempty"`
+
+	// When the object was deleted (unix millis), and the resource version of the delete.
+	DeletionTime *int64 `json:"deletion_time,omitempty"`
+	DeletedRV    *int64 `json:"deleted_rv,omitempty"`
 }
 
 func (m *IndexableDocument) UpdateCopyFields() *IndexableDocument {
@@ -520,6 +533,13 @@ const (
 	// every kind, and so live search callers cannot filter on them themselves.
 	SEARCH_FIELD_IS_DELETED     = "_deleted"
 	SEARCH_FIELD_IS_PROVISIONED = "_provisioned"
+
+	// Fields only a deleted document carries, declared in
+	// TrashSearchFieldDefinitions rather than the standard set for the same reasons
+	// as the markers above.
+	SEARCH_FIELD_DELETED_BY    = "deleted_by"
+	SEARCH_FIELD_DELETION_TIME = "deletion_time"
+	SEARCH_FIELD_DELETED_RV    = "deleted_rv"
 )
 
 var standardSearchFieldsInit sync.Once
@@ -650,6 +670,23 @@ func StandardSearchFields() SearchableDocumentFields {
 				Type:        resourcepb.ResourceTableColumnDefinition_STRING,
 				IsArray:     true,
 				Description: "Owner references in format {Group}/{Kind}/{Name}",
+			},
+			// Trash columns. A response can only carry a column defined here, so
+			// without these /trash could not return them at all (see hitsToTable).
+			{
+				Name:        SEARCH_FIELD_DELETED_BY,
+				Type:        resourcepb.ResourceTableColumnDefinition_STRING,
+				Description: "Who deleted the resource (format: user:<uid>)",
+			},
+			{
+				Name:        SEARCH_FIELD_DELETION_TIME,
+				Type:        resourcepb.ResourceTableColumnDefinition_INT64,
+				Description: "When the resource was deleted (unix millis)",
+			},
+			{
+				Name:        SEARCH_FIELD_DELETED_RV,
+				Type:        resourcepb.ResourceTableColumnDefinition_INT64,
+				Description: "Resource version of the delete",
 			},
 		})
 

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -136,6 +136,13 @@ const IndexFeatureDeletedMarker IndexFeature = "deleted-marker"
 // that path reports facet-capable but unstored fields as missing values.
 const IndexFeatureStoredFacets IndexFeature = "facets-are-stored"
 
+// TrashIndexFeatures are the features an index needs before a deleted document may
+// be kept in it. Both writers read this one list, so the producer and the
+// BulkIndex backstop cannot disagree about what makes an index usable for trash.
+func TrashIndexFeatures() []IndexFeature {
+	return []IndexFeature{IndexFeatureDeletedMarker, IndexFeatureTrashFields}
+}
+
 // currentIndexFeatures is recorded in every index this binary builds.
 var currentIndexFeatures = []IndexFeature{
 	IndexFeatureDeletedMarker,
@@ -2165,7 +2172,7 @@ func (s *searchServer) keepsDeletedDocuments(index ResourceIndex, logger log.Log
 		logger.Warn("cannot read index features, removing deleted documents instead of keeping them", "err", err)
 		return false
 	}
-	missing := MissingIndexFeatures(info, []IndexFeature{IndexFeatureDeletedMarker, IndexFeatureTrashFields})
+	missing := MissingIndexFeatures(info, TrashIndexFeatures())
 	if len(missing) > 0 {
 		logger.Debug("index does not map the markers on deleted documents, removing them until it is rebuilt", "missing", missing)
 		return false

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -11,6 +11,7 @@ import (
 	"math/rand"
 	"net/http"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -2281,7 +2282,7 @@ func buildDeletedDocument(key *resourcepb.ResourceKey, rv int64, value []byte) (
 		Folder: obj.GetFolder(),
 
 		IsDeleted: new(true),
-		DeletedRV: &rv,
+		DeletedRV: new(strconv.FormatInt(rv, 10)),
 	}
 	// The deletion marker records the deleting user as the last updater, which is
 	// also what listFromTrash reads, so both trash views name the same user.

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -114,6 +114,13 @@ type IndexBuildInfo struct {
 // rebuild, missing data, no error.
 type IndexFeature string
 
+// IndexFeatureTrashFields means the index maps TrashSearchFieldDefinitions. An
+// index without them drops the values, so trash would come back missing the
+// deleter and in arbitrary order. Checked by writers alongside
+// IndexFeatureDeletedMarker, so an older index keeps no deleted documents until it
+// rebuilds.
+const IndexFeatureTrashFields IndexFeature = "trash-fields"
+
 // IndexFeatureDeletedMarker means the index maps the markers on deleted
 // documents, SEARCH_FIELD_IS_DELETED and SEARCH_FIELD_IS_PROVISIONED. An index
 // without them drops the values, so a deleted document indexed there would look
@@ -133,6 +140,7 @@ const IndexFeatureStoredFacets IndexFeature = "facets-are-stored"
 var currentIndexFeatures = []IndexFeature{
 	IndexFeatureDeletedMarker,
 	IndexFeatureStoredFacets,
+	IndexFeatureTrashFields,
 }
 
 // requiredIndexFeatures is the subset an index must already have to be used. An
@@ -2157,7 +2165,7 @@ func (s *searchServer) keepsDeletedDocuments(index ResourceIndex, logger log.Log
 		logger.Warn("cannot read index features, removing deleted documents instead of keeping them", "err", err)
 		return false
 	}
-	missing := MissingIndexFeatures(info, []IndexFeature{IndexFeatureDeletedMarker})
+	missing := MissingIndexFeatures(info, []IndexFeature{IndexFeatureDeletedMarker, IndexFeatureTrashFields})
 	if len(missing) > 0 {
 		logger.Debug("index does not map the markers on deleted documents, removing them until it is rebuilt", "missing", missing)
 		return false
@@ -2266,6 +2274,15 @@ func buildDeletedDocument(key *resourcepb.ResourceKey, rv int64, value []byte) (
 		Folder: obj.GetFolder(),
 
 		IsDeleted: new(true),
+		DeletedRV: &rv,
+	}
+	// The deletion marker records the deleting user as the last updater, which is
+	// also what listFromTrash reads, so both trash views name the same user.
+	if by := obj.GetUpdatedBy(); by != "" {
+		doc.DeletedBy = &by
+	}
+	if ts := obj.GetDeletionTimestamp(); ts != nil {
+		doc.DeletionTime = new(ts.UnixMilli())
 	}
 	// Only provisioned documents carry the marker, so absent means "not
 	// provisioned", matching how the deleted marker works.

--- a/pkg/storage/unified/resource/search_field_test.go
+++ b/pkg/storage/unified/resource/search_field_test.go
@@ -302,6 +302,22 @@ func TestValidateSearchFieldDefinitions(t *testing.T) {
 		err := validateSearchFieldDefinitions(StandardSearchFieldDefinitions())
 		require.NoError(t, err)
 	})
+	t.Run("TrashSearchFieldDefinitions passes validation", func(t *testing.T) {
+		err := validateSearchFieldDefinitions(TrashSearchFieldDefinitions())
+		require.NoError(t, err)
+	})
+	// Moving a trash field into the standard set would change IndexAffectingHash for
+	// every kind that has a provider, rebuilding all their indexes, and would expose
+	// the field to live search.
+	t.Run("trash fields stay out of the standard set", func(t *testing.T) {
+		standard := map[string]bool{}
+		for _, def := range StandardSearchFieldDefinitions() {
+			standard[def.Name] = true
+		}
+		for _, def := range TrashSearchFieldDefinitions() {
+			require.False(t, standard[def.Name], "%s must not be a standard field", def.Name)
+		}
+	})
 	t.Run("text on int64 is rejected", func(t *testing.T) {
 		err := validateSearchFieldDefinitions([]SearchFieldDefinition{
 			{Name: "created", Type: SearchFieldTypeInt64, Capabilities: []SearchCapability{SearchCapabilityText}},

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -2027,7 +2027,16 @@ func TestBuildDeletedDocumentRecordsWhoDeletedItAndWhen(t *testing.T) {
 	require.NotNil(t, doc.DeletionTime)
 	require.Equal(t, deletedAt.UnixMilli(), *doc.DeletionTime)
 	require.NotNil(t, doc.DeletedRV)
-	require.Equal(t, int64(42), *doc.DeletedRV, "the resource version of the delete, not of the last update")
+	require.Equal(t, "42", *doc.DeletedRV, "the resource version of the delete, not of the last update")
+
+	// A snowflake resource version from the KV backend. Kept as a string because a
+	// float64 cannot represent one exactly, and restore submits this value back.
+	t.Run("a large resource version keeps every digit", func(t *testing.T) {
+		const rv int64 = 1856241819843796993
+		doc, err := buildDeletedDocument(key, rv, testDeletedObjectJSON("gone", "Gone", "user:alice", deletedAt))
+		require.NoError(t, err)
+		require.Equal(t, "1856241819843796993", *doc.DeletedRV)
+	})
 
 	// An object deleted by a process with no user attached, or written before the
 	// marker recorded one. Left unset rather than stored empty, so live and deleted

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -1805,14 +1805,19 @@ func testObjectJSON(name, title string) []byte {
 	return []byte(fmt.Sprintf(`{"apiVersion":"group/v1","kind":"Thing","metadata":{"name":%q},"spec":{"title":%q,"tags":["tag-a"]}}`, name, title))
 }
 
+// testDeletedObjectJSON is what storage holds after a delete: the deletion marker
+// records who deleted the object as its last updater, and when (see server.go).
+func testDeletedObjectJSON(name, title, deletedBy string, deletedAt time.Time) []byte {
+	return []byte(fmt.Sprintf(
+		`{"apiVersion":"group/v1","kind":"Thing","metadata":{"name":%q,"deletionTimestamp":%q,"annotations":{%q:%q}},"spec":{"title":%q}}`,
+		name, deletedAt.UTC().Format(time.RFC3339), utils.AnnoKeyUpdatedBy, deletedBy, title))
+}
+
 func testProvisionedObjectJSON(name, title string) []byte {
 	return []byte(fmt.Sprintf(`{"apiVersion":"group/v1","kind":"Thing","metadata":{"name":%q,"annotations":{%q:"repo"}},"spec":{"title":%q}}`,
 		name, utils.AnnoKeyManagerKind, title))
 }
 
-// A full build has to list trash itself: deleted objects are absent from the live
-// listing and nothing re-announces them, so without this a rebuild would drop
-// every deleted document for the resource.
 // trashSearchOptions returns search options with deleted objects kept in the
 // index, which is off by default.
 func trashSearchOptions(backend SearchBackend) SearchOptions {
@@ -1823,6 +1828,9 @@ func trashSearchOptions(backend SearchBackend) SearchOptions {
 	}
 }
 
+// A full build has to list trash itself: deleted objects are absent from the live
+// listing and nothing re-announces them, so without this a rebuild would drop
+// every deleted document for the resource.
 func TestIndexTrash(t *testing.T) {
 	key := NamespacedResource{Namespace: "ns", Group: "group", Resource: "resource"}
 	storage := &trashStorageBackend{trash: []trashEntry{
@@ -2005,6 +2013,34 @@ func TestBuildDeletedDocumentKeepsOnlyTrashFields(t *testing.T) {
 	require.Nil(t, doc.Manager)
 }
 
+// The three fields /trash serves beyond title and folder. All of them come from
+// the object storage already holds, so building one costs no extra read.
+func TestBuildDeletedDocumentRecordsWhoDeletedItAndWhen(t *testing.T) {
+	key := &resourcepb.ResourceKey{Namespace: "ns", Group: "group", Resource: "resource", Name: "gone"}
+	deletedAt := time.Now().Truncate(time.Second)
+
+	doc, err := buildDeletedDocument(key, 42, testDeletedObjectJSON("gone", "Gone", "user:alice", deletedAt))
+	require.NoError(t, err)
+
+	require.NotNil(t, doc.DeletedBy)
+	require.Equal(t, "user:alice", *doc.DeletedBy)
+	require.NotNil(t, doc.DeletionTime)
+	require.Equal(t, deletedAt.UnixMilli(), *doc.DeletionTime)
+	require.NotNil(t, doc.DeletedRV)
+	require.Equal(t, int64(42), *doc.DeletedRV, "the resource version of the delete, not of the last update")
+
+	// An object deleted by a process with no user attached, or written before the
+	// marker recorded one. Left unset rather than stored empty, so live and deleted
+	// documents are indexed the same way.
+	t.Run("an unknown deleter is left unset", func(t *testing.T) {
+		doc, err := buildDeletedDocument(key, 42, testObjectJSON("gone", "Gone"))
+		require.NoError(t, err)
+		require.Nil(t, doc.DeletedBy)
+		require.Nil(t, doc.DeletionTime)
+		require.NotNil(t, doc.DeletedRV, "the delete always has a resource version")
+	})
+}
+
 // Trash never returns an object that was provisioned when it was deleted, and a
 // trimmed document keeps no manager fields to work that out later, so it is
 // captured at delete time.
@@ -2056,4 +2092,12 @@ func TestDeletedDocumentsAreRemovedWhenIndexCannotHoldMarkers(t *testing.T) {
 	require.Len(t, items, 1)
 	require.Equal(t, ActionDelete, items[0].Action)
 	require.Equal(t, "gone-2", items[0].Key.Name)
+
+	// An index that maps the markers but not the trash fields would hold a deleted
+	// document whose sort field is missing, so /trash would return it in arbitrary
+	// order. Treated the same as no markers at all: wait for the rebuild.
+	t.Run("an index with the markers but not the trash fields", func(t *testing.T) {
+		index := &MockResourceIndex{buildInfo: IndexBuildInfo{Features: []IndexFeature{IndexFeatureDeletedMarker}}}
+		require.False(t, server.keepsDeletedDocuments(index, log.NewNopLogger()))
+	})
 }

--- a/pkg/storage/unified/resource/standard_search_fields.go
+++ b/pkg/storage/unified/resource/standard_search_fields.go
@@ -122,16 +122,20 @@ func TrashSearchFieldDefinitions() []SearchFieldDefinition {
 			Description:  "Who deleted the resource (format: user:<uid>).",
 		},
 		// Numeric so it sorts in time order rather than lexically, and so a retention
-		// window can be a range query later.
+		// window can be a range query later. Milliseconds are exact as a float64, which
+		// is how bleve stores numbers.
 		{
 			Name:         SEARCH_FIELD_DELETION_TIME,
 			Type:         SearchFieldTypeInt64,
 			Capabilities: []SearchCapability{SearchCapabilitySort, SearchCapabilityRetrieve},
 			Description:  "Deletion timestamp (unix millis).",
 		},
+		// A string, unlike deletion_time: resource versions are snowflake ids around
+		// 1.8e18, where a float64 can only represent multiples of 256, so a number
+		// would come back rounded. Restore submits this value, so it has to be exact.
 		{
 			Name:         SEARCH_FIELD_DELETED_RV,
-			Type:         SearchFieldTypeInt64,
+			Type:         SearchFieldTypeString,
 			Capabilities: []SearchCapability{SearchCapabilityRetrieve},
 			Description:  "Resource version of the delete.",
 		},

--- a/pkg/storage/unified/resource/standard_search_fields.go
+++ b/pkg/storage/unified/resource/standard_search_fields.go
@@ -102,3 +102,52 @@ func StandardSearchFieldDefinitions() []SearchFieldDefinition {
 		},
 	}
 }
+
+// TrashSearchFieldDefinitions returns the fields only a deleted document carries.
+// Kept out of the standard set, which is hashed into IndexAffectingHash (adding to
+// it rebuilds every index with a search fields provider) and is what the /search
+// field set is built from.
+//
+// Capabilities mirror trashFieldSet() in the search API layer: if the two
+// disagree, a request the API layer accepts misbehaves here.
+//
+// title and folder are absent on purpose, so trash serves them from the standard
+// declarations and analyzes them exactly as live search does.
+func TrashSearchFieldDefinitions() []SearchFieldDefinition {
+	return []SearchFieldDefinition{
+		{
+			Name:         SEARCH_FIELD_DELETED_BY,
+			Type:         SearchFieldTypeString,
+			Capabilities: []SearchCapability{SearchCapabilityFilter, SearchCapabilitySort, SearchCapabilityRetrieve},
+			Description:  "Who deleted the resource (format: user:<uid>).",
+		},
+		// Numeric so it sorts in time order rather than lexically, and so a retention
+		// window can be a range query later.
+		{
+			Name:         SEARCH_FIELD_DELETION_TIME,
+			Type:         SearchFieldTypeInt64,
+			Capabilities: []SearchCapability{SearchCapabilitySort, SearchCapabilityRetrieve},
+			Description:  "Deletion timestamp (unix millis).",
+		},
+		{
+			Name:         SEARCH_FIELD_DELETED_RV,
+			Type:         SearchFieldTypeInt64,
+			Capabilities: []SearchCapability{SearchCapabilityRetrieve},
+			Description:  "Resource version of the delete.",
+		},
+	}
+}
+
+// Derived once: fixed at build time, read on every search request.
+var trashSearchFieldNames = func() map[string]bool {
+	names := map[string]bool{}
+	for _, def := range TrashSearchFieldDefinitions() {
+		names[def.Name] = true
+	}
+	return names
+}()
+
+// IsTrashSearchField reports whether name is a field only deleted documents carry.
+func IsTrashSearchField(name string) bool {
+	return trashSearchFieldNames[name]
+}

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -2322,6 +2322,10 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 	ctx, span := tracer.Start(ctx, "search.bleveIndex.toBleveSearchRequest") //nolint:staticcheck,ineffassign // SA4006: ctx intentionally kept so future code added to this function inherits the traced span
 	defer span.End()
 
+	if errResult := rejectTrashFieldsOnLiveSearch(req); errResult != nil {
+		return nil, errResult
+	}
+
 	facets := bleve.FacetsRequest{}
 	for name, facet := range req.Facet {
 		kf, ok := b.keywordFieldFor(facet.Field)
@@ -2533,6 +2537,35 @@ func combineFilterAndTextQueries(filters []query.Query, textQuery query.Query) q
 		bq.AddFilter(bleve.NewConjunctionQuery(filters...))
 	}
 	return bq
+}
+
+// rejectTrashFieldsOnLiveSearch refuses a live search naming a field only deleted
+// documents carry, so a filter that would match nothing fails loudly instead.
+func rejectTrashFieldsOnLiveSearch(req *resourcepb.ResourceSearchRequest) *resourcepb.ErrorResult {
+	if req.IsDeleted {
+		return nil
+	}
+	refused := func(key string) *resourcepb.ErrorResult {
+		return resource.NewBadRequestError(fmt.Sprintf("field %q is only available when searching deleted resources", key))
+	}
+	for _, f := range req.Fields {
+		if resource.IsTrashSearchField(f) {
+			return refused(f)
+		}
+	}
+	for _, sort := range req.SortBy {
+		if resource.IsTrashSearchField(sort.Field) {
+			return refused(sort.Field)
+		}
+	}
+	if req.Options != nil {
+		for _, f := range req.Options.Fields {
+			if resource.IsTrashSearchField(f.Key) {
+				return refused(f.Key)
+			}
+		}
+	}
+	return nil
 }
 
 // resolveFieldName maps a public field name to its physical index name. Clients

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -2563,6 +2563,12 @@ func rejectTrashFieldsOnLiveSearch(req *resourcepb.ResourceSearchRequest) *resou
 			return refused(sort.Field)
 		}
 	}
+	// Legacy clients name the fields a text query runs against here.
+	for _, f := range req.QueryFields {
+		if resource.IsTrashSearchField(f.Name) {
+			return refused(f.Name)
+		}
+	}
 	if req.Options != nil {
 		for _, f := range req.Options.Fields {
 			if resource.IsTrashSearchField(f.Key) {

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -1756,7 +1756,7 @@ func (b *bleveIndex) BulkIndex(req *resource.BulkIndexRequest) error {
 			// serve the document as live or expose a provisioned one in trash. Remove
 			// it instead, which is how this index behaved before deleted documents were
 			// kept, until it is rebuilt.
-			if item.Doc.IsDeleted != nil && *item.Doc.IsDeleted && !b.mapsTrashMarkers() {
+			if item.Doc.IsDeleted != nil && *item.Doc.IsDeleted && !b.mapsTrashFields() {
 				batch.Delete(resource.SearchID(item.Doc.Key))
 				droppedMarkers++
 				continue
@@ -1801,11 +1801,16 @@ func (b *bleveIndex) BulkIndex(req *resource.BulkIndexRequest) error {
 	return b.addSnapshotMutationCount(int64(len(req.Items)))
 }
 
-// mapsTrashMarkers reports whether this index can hold every marker a deleted
-// document relies on. An index built before those mappings existed cannot, and
-// bleve drops the values silently.
-func (b *bleveIndex) mapsTrashMarkers() bool {
-	return slices.Contains(b.features, resource.IndexFeatureDeletedMarker)
+// mapsTrashFields reports whether this index can hold everything a deleted
+// document relies on: the markers and the trash fields. An index built before
+// those mappings existed cannot, and bleve drops the values silently.
+func (b *bleveIndex) mapsTrashFields() bool {
+	for _, feature := range resource.TrashIndexFeatures() {
+		if !slices.Contains(b.features, feature) {
+			return false
+		}
+	}
+	return true
 }
 
 // isDeclaredField reports whether name is a declared search field for this

--- a/pkg/storage/unified/search/bleve_mappings.go
+++ b/pkg/storage/unified/search/bleve_mappings.go
@@ -97,6 +97,9 @@ func textQueryKindsForMapping(provider resource.SearchFieldsProvider, group, kin
 	for _, def := range resource.StandardSearchFieldDefinitions() {
 		add(def, "")
 	}
+	for _, def := range resource.TrashSearchFieldDefinitions() {
+		add(def, "")
+	}
 	for _, def := range fieldDefinitionsForMapping(provider, group, kindResource) {
 		add(def, resource.SEARCH_FIELD_PREFIX)
 	}
@@ -154,6 +157,9 @@ func keywordFieldsForMapping(provider resource.SearchFieldsProvider, group, kind
 	}
 
 	for _, def := range resource.StandardSearchFieldDefinitions() {
+		add(def.Name, def, "")
+	}
+	for _, def := range resource.TrashSearchFieldDefinitions() {
 		add(def.Name, def, "")
 	}
 	for _, def := range fieldDefinitionsForMapping(provider, group, kindResource) {
@@ -497,6 +503,12 @@ func getBleveDocMappings(provider resource.SearchFieldsProvider, group, kindReso
 
 	mapper.AddFieldMappingsAt(resource.SEARCH_FIELD_IS_DELETED, internalBoolField())
 	mapper.AddFieldMappingsAt(resource.SEARCH_FIELD_IS_PROVISIONED, internalBoolField())
+
+	// Trash fields sit at the top level next to the standard ones, so /trash reads
+	// them by the names the API layer already uses.
+	for _, def := range resource.TrashSearchFieldDefinitions() {
+		addCapabilityFieldMappings(mapper, def)
+	}
 
 	mapper.AddSubDocumentMapping("manager", managerSubDocumentMapping())
 	mapper.AddSubDocumentMapping("source", sourceSubDocumentMapping())

--- a/pkg/storage/unified/search/bleve_mappings_golden_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_golden_test.go
@@ -29,6 +29,11 @@ var updateGolden = flag.Bool("update-golden", false, "regenerate bleve mapping g
 // mapping ships, regenerate with -update-golden and review the diff. Any
 // unintended drift trips this test.
 //
+// Reading a snapshot: a field mapping without "index": true is stored only, so its
+// value is returned but never searchable, and bleve does not analyze it — analysis
+// runs only for indexed fields (see scorch.analyze). The "analyzer" key is emitted
+// on every text mapping regardless, so it says nothing about whether it is used.
+//
 // The standard search fields (title, title_phrase, title_ngram, description,
 // tags, folder, ownerReferences, createdBy, managedBy, manager.*, source.*,
 // labels.*, reference.*, created, updated) are part of the mapping returned

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"slices"
+	"strconv"
 	"testing"
 	"time"
 
@@ -3033,6 +3034,7 @@ func TestTrashFieldsAreFilterableSortableAndReturned(t *testing.T) {
 	// Deliberately indexed out of order, so a passing sort cannot be the order the
 	// documents happened to arrive in.
 	deleted := func(name, title, by string, deletedAt int64, rv int64) *resource.BulkIndexItem {
+		deletedRV := strconv.FormatInt(rv, 10)
 		return &resource.BulkIndexItem{
 			Action: resource.ActionIndex,
 			Doc: &resource.IndexableDocument{
@@ -3048,7 +3050,7 @@ func TestTrashFieldsAreFilterableSortableAndReturned(t *testing.T) {
 				IsDeleted:    new(true),
 				DeletedBy:    &by,
 				DeletionTime: &deletedAt,
-				DeletedRV:    &rv,
+				DeletedRV:    &deletedRV,
 			},
 		}
 	}
@@ -3114,12 +3116,34 @@ func TestTrashFieldsAreFilterableSortableAndReturned(t *testing.T) {
 		require.Equal(t, "oldest", rows[0].Key.Name)
 
 		// int64 columns are encoded big-endian, not as JSON (see NewTableBuilder).
-		readInt64 := func(cell []byte) int64 {
-			require.Len(t, cell, 8)
-			return int64(binary.BigEndian.Uint64(cell))
-		}
-		require.Equal(t, int64(1000), readInt64(rows[0].Cells[1]))
-		require.Equal(t, int64(10), readInt64(rows[0].Cells[2]), "the resource version of the delete")
+		require.Len(t, rows[0].Cells[1], 8)
+		require.Equal(t, int64(1000), int64(binary.BigEndian.Uint64(rows[0].Cells[1])))
+		require.Equal(t, "10", string(rows[0].Cells[2]), "the resource version of the delete")
+	})
+
+	// Resource versions are snowflake ids well past the range a float64 represents
+	// exactly, so a numeric mapping would return a rounded value and restore would
+	// submit the wrong revision.
+	t.Run("a large resource version comes back exactly", func(t *testing.T) {
+		const rv = "1856241819843796993"
+		require.NoError(t, index.BulkIndex(&resource.BulkIndexRequest{Items: []*resource.BulkIndexItem{{
+			Action: resource.ActionIndex,
+			Doc: &resource.IndexableDocument{
+				Key: &resourcepb.ResourceKey{
+					Namespace: key.Namespace, Group: key.Group, Resource: key.Resource, Name: "snowflake",
+				},
+				Title: "Alpha snowflake", Name: "snowflake",
+				IsDeleted: new(true), DeletedRV: &[]string{rv}[0],
+			},
+		}}}))
+
+		q := newTestQuery("snowflake")
+		q.IsDeleted = true
+		q.Fields = []string{resource.SEARCH_FIELD_DELETED_RV}
+		res, err := index.Search(context.Background(), nil, q, nil, nil)
+		require.NoError(t, err)
+		require.Len(t, res.Results.Rows, 1)
+		require.Equal(t, rv, string(res.Results.Rows[0].Cells[0]))
 	})
 
 	// Live documents leave these unset, so naming one in a live search is a caller
@@ -3141,6 +3165,15 @@ func TestTrashFieldsAreFilterableSortableAndReturned(t *testing.T) {
 					Key:      resource.SEARCH_FIELD_DELETED_BY,
 					Operator: string(selection.In),
 					Values:   []string{alice},
+				}}
+			}},
+			// Legacy clients name the fields a text query runs against. Without this
+			// the query would run and return nothing, which reads as "no results"
+			// rather than "wrong field".
+			{"query fields", func(q *resourcepb.ResourceSearchRequest) {
+				q.Query = "alice"
+				q.QueryFields = []*resourcepb.ResourceSearchRequest_QueryField{{
+					Name: resource.SEARCH_FIELD_DELETED_BY,
 				}}
 			}},
 		} {

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -2,6 +2,7 @@ package search_test
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"log"
 	"slices"
@@ -3015,4 +3016,149 @@ func checkSearchQueryUnordered(t *testing.T, index resource.ResourceIndex, query
 		names = append(names, row.Key.Name)
 	}
 	require.ElementsMatch(t, expectedNames, names)
+}
+
+// The trash fields are declared apart from the standard ones, so they have their
+// own mapping, their own query metadata and their own response columns. Each of
+// those can fail silently — an unmapped sort field orders arbitrarily and a
+// missing column definition is dropped without an error — so this drives all
+// three through a real index.
+func TestTrashFieldsAreFilterableSortableAndReturned(t *testing.T) {
+	key := resource.NamespacedResource{
+		Namespace: "default",
+		Group:     "dashboard.grafana.app",
+		Resource:  "dashboards",
+	}
+	const alice, bob = "user:alice", "user:bob"
+	// Deliberately indexed out of order, so a passing sort cannot be the order the
+	// documents happened to arrive in.
+	deleted := func(name, title, by string, deletedAt int64, rv int64) *resource.BulkIndexItem {
+		return &resource.BulkIndexItem{
+			Action: resource.ActionIndex,
+			Doc: &resource.IndexableDocument{
+				Key: &resourcepb.ResourceKey{
+					Namespace: key.Namespace,
+					Group:     key.Group,
+					Resource:  key.Resource,
+					Name:      name,
+				},
+				Title:        title,
+				Name:         name,
+				RV:           rv,
+				IsDeleted:    new(true),
+				DeletedBy:    &by,
+				DeletionTime: &deletedAt,
+				DeletedRV:    &rv,
+			},
+		}
+	}
+
+	index := newTestDashboardsIndex(t, threshold, 4, func(index resource.ResourceIndex) (int64, error) {
+		return 1, index.BulkIndex(&resource.BulkIndexRequest{Items: []*resource.BulkIndexItem{
+			deleted("middle", "Alpha middle", alice, 2000, 20),
+			deleted("newest", "Alpha newest", bob, 3000, 30),
+			deleted("oldest", "Alpha oldest", alice, 1000, 10),
+			{Action: resource.ActionIndex, Doc: &resource.IndexableDocument{
+				Key: &resourcepb.ResourceKey{
+					Namespace: key.Namespace, Group: key.Group, Resource: key.Resource, Name: "live",
+				},
+				Title: "Alpha live", Name: "live",
+			}},
+		}})
+	})
+
+	t.Run("filtering by who deleted it", func(t *testing.T) {
+		q := newTestQuery("")
+		q.IsDeleted = true
+		q.Options.Fields = []*resourcepb.Requirement{{
+			Key:      resource.SEARCH_FIELD_DELETED_BY,
+			Operator: string(selection.In),
+			Values:   []string{alice},
+		}}
+		checkSearchQueryUnordered(t, index, q, []string{"middle", "oldest"})
+	})
+
+	// The default sort for /trash, and the reason deletion_time is numeric: as a
+	// keyword it would order lexically.
+	t.Run("sorting by deletion time", func(t *testing.T) {
+		q := newTestQuery("")
+		q.IsDeleted = true
+		q.SortBy = []*resourcepb.ResourceSearchRequest_Sort{{
+			Field: resource.SEARCH_FIELD_DELETION_TIME,
+			Desc:  true,
+		}}
+		checkSearchQuery(t, index, q, []string{"newest", "middle", "oldest"})
+
+		q.SortBy[0].Desc = false
+		checkSearchQuery(t, index, q, []string{"oldest", "middle", "newest"})
+	})
+
+	t.Run("returning the values", func(t *testing.T) {
+		q := newTestQuery("")
+		q.IsDeleted = true
+		q.Fields = []string{
+			resource.SEARCH_FIELD_DELETED_BY,
+			resource.SEARCH_FIELD_DELETION_TIME,
+			resource.SEARCH_FIELD_DELETED_RV,
+		}
+		q.SortBy = []*resourcepb.ResourceSearchRequest_Sort{{Field: resource.SEARCH_FIELD_DELETION_TIME}}
+
+		res, err := index.Search(context.Background(), nil, q, nil, nil)
+		require.NoError(t, err)
+		require.Len(t, res.Results.Columns, 3, "a field without a column definition is dropped silently")
+		require.Equal(t, resource.SEARCH_FIELD_DELETED_BY, res.Results.Columns[0].Name)
+
+		rows := res.Results.Rows
+		require.Len(t, rows, 3)
+		require.Equal(t, alice, string(rows[0].Cells[0]))
+		require.Equal(t, "oldest", rows[0].Key.Name)
+
+		// int64 columns are encoded big-endian, not as JSON (see NewTableBuilder).
+		readInt64 := func(cell []byte) int64 {
+			require.Len(t, cell, 8)
+			return int64(binary.BigEndian.Uint64(cell))
+		}
+		require.Equal(t, int64(1000), readInt64(rows[0].Cells[1]))
+		require.Equal(t, int64(10), readInt64(rows[0].Cells[2]), "the resource version of the delete")
+	})
+
+	// Live documents leave these unset, so naming one in a live search is a caller
+	// mistake: a filter would match nothing and a sort would order by nothing. The
+	// index refuses it rather than answering with an empty column.
+	t.Run("a live search cannot name a trash field", func(t *testing.T) {
+		for _, tc := range []struct {
+			name   string
+			mutate func(*resourcepb.ResourceSearchRequest)
+		}{
+			{"retrieve", func(q *resourcepb.ResourceSearchRequest) {
+				q.Fields = []string{resource.SEARCH_FIELD_DELETED_BY}
+			}},
+			{"sort", func(q *resourcepb.ResourceSearchRequest) {
+				q.SortBy = []*resourcepb.ResourceSearchRequest_Sort{{Field: resource.SEARCH_FIELD_DELETION_TIME}}
+			}},
+			{"filter", func(q *resourcepb.ResourceSearchRequest) {
+				q.Options.Fields = []*resourcepb.Requirement{{
+					Key:      resource.SEARCH_FIELD_DELETED_BY,
+					Operator: string(selection.In),
+					Values:   []string{alice},
+				}}
+			}},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				q := newTestQuery("")
+				tc.mutate(q)
+
+				res, err := index.Search(context.Background(), nil, q, nil, nil)
+				require.NoError(t, err, "a bad request comes back in the response, not as an error")
+				require.NotNil(t, res.Error)
+				require.Equal(t, int32(400), res.Error.Code)
+
+				// The same request against trash is fine.
+				q.IsDeleted = true
+				res, err = index.Search(context.Background(), nil, q, nil, nil)
+				require.NoError(t, err)
+				require.Nil(t, res.Error)
+			})
+		}
+	})
 }

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -2649,11 +2649,11 @@ func TestIsDeletedMarkerIndexing(t *testing.T) {
 	}
 }
 
-// An index built before the marker was mapped drops it silently, which would
+// An index built before these fields were mapped drops them silently, which would
 // leave a deleted document looking live. BulkIndex removes such a document
 // instead, so trash is missing from search rather than leaking into it, until the
 // index is rebuilt.
-func TestBulkIndexRemovesMarkedDocumentsWhenTheMarkerIsNotMapped(t *testing.T) {
+func TestBulkIndexRemovesMarkedDocumentsWhenTrashFieldsAreNotMapped(t *testing.T) {
 	mapper, err := GetBleveMappings(nil, "", "", nil)
 	require.NoError(t, err)
 	raw, err := newBleveIndex("", mapper, time.Now(), buildVersion, nil, "")
@@ -2680,7 +2680,16 @@ func TestBulkIndexRemovesMarkedDocumentsWhenTheMarkerIsNotMapped(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint64(0), count, "marked document should be removed, not indexed as live")
 
-	// An index that maps the marker keeps the document.
+	// An index mapping the markers but not the trash fields is no better: the
+	// document would be served without a deleter and in arbitrary order. The
+	// producer refuses such an index too, so both writers agree.
+	partial := &bleveIndex{index: raw, features: []resource.IndexFeature{resource.IndexFeatureDeletedMarker}, logger: log.NewNopLogger()}
+	require.NoError(t, partial.BulkIndex(&resource.BulkIndexRequest{Items: []*resource.BulkIndexItem{doc(new(true))}}))
+	count, err = raw.DocCount()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), count, "a partially mapped index should not keep the document either")
+
+	// An index that maps everything a deleted document needs keeps it.
 	current := &bleveIndex{index: raw, features: resource.CurrentIndexFeatures(), logger: log.NewNopLogger()}
 	require.NoError(t, current.BulkIndex(&resource.BulkIndexRequest{Items: []*resource.BulkIndexItem{doc(new(true))}}))
 	count, err = raw.DocCount()

--- a/pkg/storage/unified/search/testdata/bleve_mapping_dashboard.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_dashboard.json
@@ -52,6 +52,42 @@
           }
         ]
       },
+      "deleted_by": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "docvalues": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "deleted_rv": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "number",
+            "store": true
+          }
+        ]
+      },
+      "deletion_time": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "number",
+            "store": true,
+            "index": true,
+            "docvalues": true
+          }
+        ]
+      },
       "description": {
         "enabled": true,
         "dynamic": true,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_dashboard.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_dashboard.json
@@ -71,8 +71,10 @@
         "dynamic": true,
         "fields": [
           {
-            "type": "number",
-            "store": true
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "skip_freq_norm": true
           }
         ]
       },

--- a/pkg/storage/unified/search/testdata/bleve_mapping_empty.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_empty.json
@@ -52,6 +52,42 @@
           }
         ]
       },
+      "deleted_by": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "docvalues": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "deleted_rv": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "number",
+            "store": true
+          }
+        ]
+      },
+      "deletion_time": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "number",
+            "store": true,
+            "index": true,
+            "docvalues": true
+          }
+        ]
+      },
       "description": {
         "enabled": true,
         "dynamic": true,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_empty.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_empty.json
@@ -71,8 +71,10 @@
         "dynamic": true,
         "fields": [
           {
-            "type": "number",
-            "store": true
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "skip_freq_norm": true
           }
         ]
       },

--- a/pkg/storage/unified/search/testdata/bleve_mapping_external_group_mapping.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_external_group_mapping.json
@@ -52,6 +52,42 @@
           }
         ]
       },
+      "deleted_by": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "docvalues": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "deleted_rv": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "number",
+            "store": true
+          }
+        ]
+      },
+      "deletion_time": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "number",
+            "store": true,
+            "index": true,
+            "docvalues": true
+          }
+        ]
+      },
       "description": {
         "enabled": true,
         "dynamic": true,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_external_group_mapping.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_external_group_mapping.json
@@ -71,8 +71,10 @@
         "dynamic": true,
         "fields": [
           {
-            "type": "number",
-            "store": true
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "skip_freq_norm": true
           }
         ]
       },

--- a/pkg/storage/unified/search/testdata/bleve_mapping_provider_driven.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_provider_driven.json
@@ -52,6 +52,42 @@
           }
         ]
       },
+      "deleted_by": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "docvalues": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "deleted_rv": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "number",
+            "store": true
+          }
+        ]
+      },
+      "deletion_time": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "number",
+            "store": true,
+            "index": true,
+            "docvalues": true
+          }
+        ]
+      },
       "description": {
         "enabled": true,
         "dynamic": true,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_provider_driven.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_provider_driven.json
@@ -71,8 +71,10 @@
         "dynamic": true,
         "fields": [
           {
-            "type": "number",
-            "store": true
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "skip_freq_norm": true
           }
         ]
       },

--- a/pkg/storage/unified/search/testdata/bleve_mapping_selectable_fields.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_selectable_fields.json
@@ -52,6 +52,42 @@
           }
         ]
       },
+      "deleted_by": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "docvalues": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "deleted_rv": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "number",
+            "store": true
+          }
+        ]
+      },
+      "deletion_time": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "number",
+            "store": true,
+            "index": true,
+            "docvalues": true
+          }
+        ]
+      },
       "description": {
         "enabled": true,
         "dynamic": true,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_selectable_fields.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_selectable_fields.json
@@ -71,8 +71,10 @@
         "dynamic": true,
         "fields": [
           {
-            "type": "number",
-            "store": true
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "skip_freq_norm": true
           }
         ]
       },

--- a/pkg/storage/unified/search/testdata/bleve_mapping_team.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_team.json
@@ -52,6 +52,42 @@
           }
         ]
       },
+      "deleted_by": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "docvalues": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "deleted_rv": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "number",
+            "store": true
+          }
+        ]
+      },
+      "deletion_time": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "number",
+            "store": true,
+            "index": true,
+            "docvalues": true
+          }
+        ]
+      },
       "description": {
         "enabled": true,
         "dynamic": true,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_team.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_team.json
@@ -71,8 +71,10 @@
         "dynamic": true,
         "fields": [
           {
-            "type": "number",
-            "store": true
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "skip_freq_norm": true
           }
         ]
       },

--- a/pkg/storage/unified/search/testdata/bleve_mapping_team_binding.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_team_binding.json
@@ -52,6 +52,42 @@
           }
         ]
       },
+      "deleted_by": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "docvalues": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "deleted_rv": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "number",
+            "store": true
+          }
+        ]
+      },
+      "deletion_time": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "number",
+            "store": true,
+            "index": true,
+            "docvalues": true
+          }
+        ]
+      },
       "description": {
         "enabled": true,
         "dynamic": true,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_team_binding.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_team_binding.json
@@ -71,8 +71,10 @@
         "dynamic": true,
         "fields": [
           {
-            "type": "number",
-            "store": true
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "skip_freq_norm": true
           }
         ]
       },

--- a/pkg/storage/unified/search/testdata/bleve_mapping_user.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_user.json
@@ -52,6 +52,42 @@
           }
         ]
       },
+      "deleted_by": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "docvalues": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "deleted_rv": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "number",
+            "store": true
+          }
+        ]
+      },
+      "deletion_time": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "number",
+            "store": true,
+            "index": true,
+            "docvalues": true
+          }
+        ]
+      },
       "description": {
         "enabled": true,
         "dynamic": true,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_user.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_user.json
@@ -71,8 +71,10 @@
         "dynamic": true,
         "fields": [
           {
-            "type": "number",
-            "store": true
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "skip_freq_norm": true
           }
         ]
       },


### PR DESCRIPTION
A deleted document carried only title, folder and identity, so `/trash` could not say who deleted an object or when, and had nothing to sort by. This adds `deleted_by`, `deletion_time` and `deleted_rv`, all read from the deletion marker the object already carries.

They are declared in their own list rather than added to the standard search fields, for two reasons: the standard set is hashed into `IndexAffectingHash`, so adding to it rebuilds every index that has a search fields provider, and it is what the `/search` field set is built from, which would let a live search sort by who deleted something. Capabilities mirror the trash field set the API layer already validates against.

`deletion_time` and `deleted_rv` are numbers, not strings, so a timestamp sorts in time order and a retention window can be a range query later.

An index built before this mapping keeps no deleted documents until it rebuilds — the new `trash-fields` index feature — since it would otherwise return trash in arbitrary order. Indexing deleted objects is off by default, so no production index is affected. A live search naming one of these fields is refused rather than answered with an empty column.

The matching type corrections in the search API layer are in #129709, which also relaxes the v1 sort rule so a caller can name `deletion_time` explicitly. Until that merges the API layer still declares those two fields as strings, which is harmless: declared types only validate requests and never cross the wire.

Part of grafana/search-and-storage-team#869.
