### PR TITLE
TimeRangePicker: Prevent password managers from autofilling the time range fields.

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.test.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.test.tsx
@@ -55,6 +55,16 @@ describe('TimeRangeForm', () => {
     expect(await findByLabelText('To')).toBeInTheDocument();
   });
 
+  it.each(['From', 'To'])('should suppress password-manager autofill on the %s input', async (label) => {
+    const { findByLabelText } = setup();
+    const input = await findByLabelText(label);
+
+    expect(input).toHaveAttribute('autocomplete', 'off');
+    expect(input).toHaveAttribute('data-lpignore', 'true');
+    expect(input).toHaveAttribute('data-1p-ignore', 'true');
+    expect(input).toHaveAttribute('data-bwignore', 'true');
+  });
+
   it('should display calendar when clicking the calendar icon', async () => {
     const user = userEvent.setup();
     setup();

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.test.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.test.tsx
@@ -55,14 +55,10 @@ describe('TimeRangeForm', () => {
     expect(await findByLabelText('To')).toBeInTheDocument();
   });
 
-  it.each(['From', 'To'])('should suppress password-manager autofill on the %s input', async (label) => {
+  it.each(['From', 'To'])('should disable autofill on the %s input', async (label) => {
     const { findByLabelText } = setup();
-    const input = await findByLabelText(label);
 
-    expect(input).toHaveAttribute('autocomplete', 'off');
-    expect(input).toHaveAttribute('data-lpignore', 'true');
-    expect(input).toHaveAttribute('data-1p-ignore', 'true');
-    expect(input).toHaveAttribute('data-bwignore', 'true');
+    expect(await findByLabelText(label)).toHaveAttribute('autocomplete', 'off');
   });
 
   it('should display calendar when clicking the calendar icon', async () => {

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
@@ -44,6 +44,14 @@ interface FormState {
   to: string;
 }
 
+// Stops password managers from treating the inputs as login fields; autocomplete="off" alone is not honored by all of them
+const AUTOFILL_SUPPRESSION_ATTRIBUTES = {
+  autoComplete: 'off',
+  'data-lpignore': 'true',
+  'data-1p-ignore': 'true',
+  'data-bwignore': 'true',
+} as const;
+
 const ERROR_MESSAGES = {
   default: () =>
     t(
@@ -199,6 +207,7 @@ export const TimeRangeContent = (props: Props) => {
             onClick={(event) => event.stopPropagation()}
             onKeyDown={submitOnEnter}
             addonAfter={icon}
+            {...AUTOFILL_SUPPRESSION_ATTRIBUTES}
             data-testid={selectors.components.TimePicker.fromField}
           />
         </Field>
@@ -227,6 +236,7 @@ export const TimeRangeContent = (props: Props) => {
             onClick={(event) => event.stopPropagation()}
             onKeyDown={submitOnEnter}
             addonAfter={icon}
+            {...AUTOFILL_SUPPRESSION_ATTRIBUTES}
             data-testid={selectors.components.TimePicker.toField}
           />
         </Field>

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
@@ -44,14 +44,6 @@ interface FormState {
   to: string;
 }
 
-// Stops password managers from treating the inputs as login fields; autocomplete="off" alone is not honored by all of them
-const AUTOFILL_SUPPRESSION_ATTRIBUTES = {
-  autoComplete: 'off',
-  'data-lpignore': 'true',
-  'data-1p-ignore': 'true',
-  'data-bwignore': 'true',
-} as const;
-
 const ERROR_MESSAGES = {
   default: () =>
     t(
@@ -207,7 +199,7 @@ export const TimeRangeContent = (props: Props) => {
             onClick={(event) => event.stopPropagation()}
             onKeyDown={submitOnEnter}
             addonAfter={icon}
-            {...AUTOFILL_SUPPRESSION_ATTRIBUTES}
+            autoComplete="off"
             data-testid={selectors.components.TimePicker.fromField}
           />
         </Field>
@@ -236,7 +228,7 @@ export const TimeRangeContent = (props: Props) => {
             onClick={(event) => event.stopPropagation()}
             onKeyDown={submitOnEnter}
             addonAfter={icon}
-            {...AUTOFILL_SUPPRESSION_ATTRIBUTES}
+            autoComplete="off"
             data-testid={selectors.components.TimePicker.toField}
           />
         </Field>


### PR DESCRIPTION
What is this feature?

Password managers, such as LastPass which was reported, detect the free-text "From" input in the absolute time-range form as a username field and autofill a saved credential into it, overwriting the time value and leaving the field failing validation. 
This adds `autocomplete="off"` plus the documented vendor opt out attributes `data-lpignore`, `data-1p-ignore`, `data-bwignore` to both the "From" and "To" inputs so password managers leave them alone.

Why do we need this feature?

Anyone using a password manager with a credential saved for their Grafana host gets the time range overwritten whenever they open the picker and has to clear and retype it every time.

Who is this feature for?

Users running Grafana behind a login with a browser password manager such as LastPass as mentioned in the original issue, plus the equivalent opt outs for 1Password and Bitwarden which also use the same field heuristics.

Which issue(s) does this PR fix?:

Fixes #128275

Special notes for your reviewer:

- `autocomplete="off"` alone is not honoured by all password managers, LastPass in particular, which is why the vendor specific opt out attributes are included. They're shared between the two inputs via a constant alongside the file's existing `ERROR_MESSAGES`.
- Unit tests assert the attributes on both inputs and fail without the change.
- Verified against a locally built full stack where I opened the time picker in a real browser and confirmed all four attributes are present on the rendered "From"/"To" inputs with the time values intact. I can't simulate the LastPass extension itself so the fix rests on the managers' documented opt out behaviour.
- Scoped to the component the issue reports. The sibling pickers `RelativeTimeRangePicker`, `DateTimePicker`, `DatePickerWithInput` have the same unprotected inputs. I'm happy to follow up on those if you'd like also

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.