### PR TITLE
E2E Selectors: Add selectors for table cell actions and ButtonSelect options

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -1287,11 +1287,13 @@ export const versionedComponents = {
   },
   ButtonSelect: {
     /**
-     * Identifies one option of a ButtonSelect menu by its `value`, so the selector does not
-     * depend on the option's translated label. Only rendered for scalar option values.
+     * Identifies one option of a ButtonSelect menu, keyed on the option's `value` when it is
+     * scalar so the selector does not depend on the option's translated label. Options whose
+     * values have no meaningful string form (objects, undefined) render the bare selector.
      */
     option: {
-      '13.2.0': (value: string) => `data-testid ButtonSelect option ${value}`,
+      '13.2.0': (value?: string) =>
+        value === undefined ? 'data-testid ButtonSelect option' : `data-testid ButtonSelect option ${value}`,
     },
   },
   Select: {

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -1293,7 +1293,7 @@ export const versionedComponents = {
      */
     option: {
       '13.2.0': (value?: string) =>
-        value === undefined ? 'data-testid ButtonSelect option' : `data-testid ButtonSelect option ${value}`,
+        value ? `data-testid ButtonSelect option ${value}` : 'data-testid ButtonSelect option',
     },
   },
   Select: {

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -611,6 +611,17 @@ export const versionedComponents = {
         RowExpander: {
           '12.4.0': 'data-testid tableng row expander',
         },
+        cellActions: {
+          inspectButton: {
+            '13.2.0': 'data-testid tableng cell-actions inspect-button',
+          },
+          filterForButton: {
+            '13.2.0': 'data-testid tableng cell-actions filter-for-button',
+          },
+          filterOutButton: {
+            '13.2.0': 'data-testid tableng cell-actions filter-out-button',
+          },
+        },
         Filters: {
           HeaderButton: {
             '12.1.0': 'data-testid tableng header filter',
@@ -1272,6 +1283,15 @@ export const versionedComponents = {
     },
     queryEditorRow: {
       '13.2.0': (dataSourceType: string, refId: string) => `data-testid Query editor row ${dataSourceType} ${refId}`,
+    },
+  },
+  ButtonSelect: {
+    /**
+     * Identifies one option of a ButtonSelect menu by its `value`, so the selector does not
+     * depend on the option's translated label. Only rendered for scalar option values.
+     */
+    option: {
+      '13.2.0': (value: string) => `data-testid ButtonSelect option ${value}`,
     },
   },
   Select: {

--- a/packages/grafana-ui/src/components/Dropdown/ButtonSelect.tsx
+++ b/packages/grafana-ui/src/components/Dropdown/ButtonSelect.tsx
@@ -1,6 +1,7 @@
 import { memo, type HTMLAttributes, useState } from 'react';
 
 import { type SelectableValue } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 
 import { Menu } from '../Menu/Menu';
 import { MenuItem } from '../Menu/MenuItem';
@@ -35,19 +36,29 @@ const ButtonSelectComponent = <T,>(props: Props<T>) => {
   const renderMenu = () => (
     <Menu tabIndex={-1} onClose={() => setIsOpen(false)}>
       <ScrollContainer maxHeight="100vh">
-        {options.map((item) => (
-          <MenuItem
-            key={`${item.value}`}
-            label={item.label ?? String(item.value)}
-            onClick={() => onChange(item)}
-            active={item.value === value?.value}
-            ariaChecked={item.value === value?.value}
-            ariaLabel={item.ariaLabel || item.label}
-            disabled={item.isDisabled}
-            component={item.component}
-            role="menuitemradio"
-          />
-        ))}
+        {options.map((item) => {
+          // Keyed on the option's value, not its label, so the selector survives translation.
+          // Skipped for objects and undefined, which have no meaningful string form.
+          const testIdValue =
+            typeof item.value === 'string' || typeof item.value === 'number' || typeof item.value === 'boolean'
+              ? String(item.value)
+              : undefined;
+
+          return (
+            <MenuItem
+              key={`${item.value}`}
+              testId={testIdValue === undefined ? undefined : selectors.components.ButtonSelect.option(testIdValue)}
+              label={item.label ?? String(item.value)}
+              onClick={() => onChange(item)}
+              active={item.value === value?.value}
+              ariaChecked={item.value === value?.value}
+              ariaLabel={item.ariaLabel || item.label}
+              disabled={item.isDisabled}
+              component={item.component}
+              role="menuitemradio"
+            />
+          );
+        })}
       </ScrollContainer>
     </Menu>
   );

--- a/packages/grafana-ui/src/components/Dropdown/ButtonSelect.tsx
+++ b/packages/grafana-ui/src/components/Dropdown/ButtonSelect.tsx
@@ -48,7 +48,7 @@ const ButtonSelectComponent = <T,>(props: Props<T>) => {
           return (
             <MenuItem
               key={`${item.value}`}
-              testId={selectors.components.ButtonSelect.option(testIdValue)}
+              testId={selectors.components.ButtonSelect.option(testIdValue ?? '')}
               label={item.label ?? String(item.value)}
               onClick={() => onChange(item)}
               active={item.value === value?.value}

--- a/packages/grafana-ui/src/components/Dropdown/ButtonSelect.tsx
+++ b/packages/grafana-ui/src/components/Dropdown/ButtonSelect.tsx
@@ -38,7 +38,8 @@ const ButtonSelectComponent = <T,>(props: Props<T>) => {
       <ScrollContainer maxHeight="100vh">
         {options.map((item) => {
           // Keyed on the option's value, not its label, so the selector survives translation.
-          // Skipped for objects and undefined, which have no meaningful string form.
+          // Objects and undefined have no meaningful string form, so those options get the
+          // bare selector without a disambiguator.
           const testIdValue =
             typeof item.value === 'string' || typeof item.value === 'number' || typeof item.value === 'boolean'
               ? String(item.value)
@@ -47,7 +48,7 @@ const ButtonSelectComponent = <T,>(props: Props<T>) => {
           return (
             <MenuItem
               key={`${item.value}`}
-              testId={testIdValue === undefined ? undefined : selectors.components.ButtonSelect.option(testIdValue)}
+              testId={selectors.components.ButtonSelect.option(testIdValue)}
               label={item.label ?? String(item.value)}
               onClick={() => onChange(item)}
               active={item.value === value?.value}

--- a/packages/grafana-ui/src/components/Table/TableNG/components/TableCellActions.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/TableCellActions.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
 
+import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 
 import { IconButton } from '../../../IconButton/IconButton';
@@ -19,6 +20,7 @@ export const TableCellActions = memo(
         {cellInspect && (
           <IconButton
             name="eye"
+            data-testid={selectors.components.Panels.Visualization.TableNG.cellActions.inspectButton}
             aria-label={t('grafana-ui.table.cell-inspect-tooltip', 'Inspect value')}
             onClick={() => {
               const [inspectValue, mode] = buildInspectValue(value, field, formatGeometry);
@@ -30,6 +32,7 @@ export const TableCellActions = memo(
           <>
             <IconButton
               name={'filter-plus'}
+              data-testid={selectors.components.Panels.Visualization.TableNG.cellActions.filterForButton}
               aria-label={t('grafana-ui.table.cell-filter-on', 'Filter for value')}
               onClick={() => {
                 onCellFilterAdded?.({
@@ -41,6 +44,7 @@ export const TableCellActions = memo(
             />
             <IconButton
               name={'filter-minus'}
+              data-testid={selectors.components.Panels.Visualization.TableNG.cellActions.filterOutButton}
               aria-label={t('grafana-ui.table.cell-filter-out', 'Filter out value')}
               onClick={() => {
                 onCellFilterAdded?.({


### PR DESCRIPTION
Part of #129672 (Group 1 — Shared UI).

Replaces weak Pathfinder guide selectors with versioned `@grafana/e2e-selectors` entries wired as `data-testid`, covering the TableNG cell-action buttons (×3) and `ButtonSelect` options — 4 anchors from the `enable-coda`/`semantic-layer-tutorial` guide cluster.

**Structure (2 commits, per the MT-compat guidance in the issue):**
1. `test(e2e-selectors)` — selector definitions only (`components.ts`, version key `13.2.0`)
2. `test(grafana-ui)` — JSX wiring in `TableCellActions.tsx` and `ButtonSelect.tsx`

No existing selector values modified or deleted. Verified with `yarn typecheck` and ESLint on changed files. Independent of #129698 (both based on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)