### PR TITLE
Search: allow sorting on numeric fields

### DIFF
--- a/pkg/apis/search/v0alpha1/types.go
+++ b/pkg/apis/search/v0alpha1/types.go
@@ -92,7 +92,8 @@ type ExistsPredicate struct {
 }
 
 // SortField names a field to sort by and a direction ("asc" or "desc"). V1
-// allows sorting only on scalar string fields that declare the sort capability.
+// allows sorting only on scalar string and numeric fields that declare the sort
+// capability.
 //
 // +k8s:deepcopy-gen=true
 type SortField struct {

--- a/pkg/apis/search/v0alpha1/zz_generated.openapi.go
+++ b/pkg/apis/search/v0alpha1/zz_generated.openapi.go
@@ -460,7 +460,7 @@ func schema_pkg_apis_search_v0alpha1_SortField(ref common.ReferenceCallback) com
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "SortField names a field to sort by and a direction (\"asc\" or \"desc\"). V1 allows sorting only on scalar string fields that declare the sort capability.",
+				Description: "SortField names a field to sort by and a direction (\"asc\" or \"desc\"). V1 allows sorting only on scalar string and numeric fields that declare the sort capability.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"field": {

--- a/pkg/registry/apis/search/translate.go
+++ b/pkg/registry/apis/search/translate.go
@@ -148,12 +148,18 @@ func trashFieldSet() *fieldSet {
 	def := func(name string, caps ...resource.SearchCapability) resource.SearchFieldDefinition {
 		return resource.SearchFieldDefinition{Name: name, Type: resource.SearchFieldTypeString, Capabilities: caps}
 	}
+	// The two numeric fields are typed from the backend declarations, so both sides
+	// agree a timestamp is a number and it sorts in time order.
+	trash := map[string]resource.SearchFieldDefinition{}
+	for _, d := range resource.TrashSearchFieldDefinitions() {
+		trash[d.Name] = d
+	}
 	return &fieldSet{byName: map[string]resource.SearchFieldDefinition{
 		trashFieldTitle:        def(trashFieldTitle, resource.SearchCapabilityText, resource.SearchCapabilitySort, resource.SearchCapabilityRetrieve),
 		trashFieldFolder:       def(trashFieldFolder, resource.SearchCapabilityFilter, resource.SearchCapabilitySort, resource.SearchCapabilityRetrieve),
-		trashFieldDeletedBy:    def(trashFieldDeletedBy, resource.SearchCapabilityFilter, resource.SearchCapabilitySort, resource.SearchCapabilityRetrieve),
-		trashFieldDeletionTime: def(trashFieldDeletionTime, resource.SearchCapabilitySort, resource.SearchCapabilityRetrieve),
-		trashFieldDeletedRV:    def(trashFieldDeletedRV, resource.SearchCapabilityRetrieve),
+		trashFieldDeletedBy:    trash[trashFieldDeletedBy],
+		trashFieldDeletionTime: trash[trashFieldDeletionTime],
+		trashFieldDeletedRV:    trash[trashFieldDeletedRV],
 	}}
 }
 
@@ -323,14 +329,29 @@ func validateSort(sorts []searchv0.SortField, fs *fieldSet, p *field.Path) field
 		fp := sp.Child("field")
 		capErrs := checkCapability(fs, s.Field, resource.SearchCapabilitySort, fp)
 		errs = append(errs, capErrs...)
-		// v1 sorts scalar string fields only.
+		// Sorting a list of values has no defined meaning, so only scalars are
+		// sortable. Numbers are included because trash orders by a timestamp.
 		if len(capErrs) == 0 {
-			if def := fs.byName[s.Field]; def.Type != resource.SearchFieldTypeString || def.Array {
-				errs = append(errs, field.Invalid(fp, s.Field, "v1 supports sorting on scalar string fields only"))
+			if def := fs.byName[s.Field]; def.Array || !sortableFieldType(def.Type) {
+				errs = append(errs, field.Invalid(fp, s.Field, "v1 supports sorting on scalar string and numeric fields only"))
 			}
 		}
 	}
 	return errs
+}
+
+// sortableFieldType reports whether values of this type have a defined order.
+func sortableFieldType(t resource.SearchFieldType) bool {
+	switch t {
+	case resource.SearchFieldTypeString, resource.SearchFieldTypeInt64, resource.SearchFieldTypeDouble:
+		return true
+	case resource.SearchFieldTypeBoolean, resource.SearchFieldTypeDate, resource.SearchFieldTypeUnknown:
+		// A boolean has nothing useful to order by, and no field declares a date
+		// today, so nothing maps one to sort on.
+		return false
+	default:
+		return false
+	}
 }
 
 func validateReturnFields(fields []string, fs *fieldSet, p *field.Path) field.ErrorList {

--- a/pkg/registry/apis/search/translate_test.go
+++ b/pkg/registry/apis/search/translate_test.go
@@ -251,6 +251,15 @@ func TestTranslateSearchQuery_ValidationErrors(t *testing.T) {
 			wantField: "where.filter.field",
 		},
 		{
+			// Trash fields exist in the index but are declared apart from the standard
+			// ones, so live search must not see them.
+			name: "filter on a trash field",
+			mutate: func(q *searchv0.SearchQuery) {
+				q.Where = &searchv0.WhereNode{Filter: &searchv0.FilterPredicate{Field: "deleted_by", Operator: "In", Values: []string{"user:alice"}}}
+			},
+			wantField: "where.filter.field",
+		},
+		{
 			name: "filter bad operator",
 			mutate: func(q *searchv0.SearchQuery) {
 				q.Where = &searchv0.WhereNode{Filter: &searchv0.FilterPredicate{Field: "folder", Operator: "Equals", Values: []string{"a"}}}
@@ -274,11 +283,6 @@ func TestTranslateSearchQuery_ValidationErrors(t *testing.T) {
 		{
 			name:      "sort on non-sortable field",
 			mutate:    func(q *searchv0.SearchQuery) { q.Sort = []searchv0.SortField{{Field: "panel_type"}} },
-			wantField: "sort[0].field",
-		},
-		{
-			name:      "sort on non-string field",
-			mutate:    func(q *searchv0.SearchQuery) { q.Sort = []searchv0.SortField{{Field: "panel_id"}} },
 			wantField: "sort[0].field",
 		},
 		{
@@ -378,6 +382,30 @@ func TestTranslateTrashQuery_SortByTitleAllowed(t *testing.T) {
 	require.Len(t, req.SortBy, 1)
 	assert.Equal(t, trashFieldTitle, req.SortBy[0].Field)
 	assert.False(t, req.SortBy[0].Desc)
+}
+
+// deletion_time is the order trash comes back in by default, so a caller has to be
+// able to ask for it explicitly too.
+func TestTranslateTrashQuery_SortByDeletionTimeAllowed(t *testing.T) {
+	q := trashQuery(nil)
+	q.Sort = []searchv0.SortField{{Field: trashFieldDeletionTime, Direction: "desc"}}
+	req, errs := TranslateTrashQuery(q, dashboardsGVR, "default")
+	require.Empty(t, errs)
+	require.Len(t, req.SortBy, 1)
+	assert.Equal(t, trashFieldDeletionTime, req.SortBy[0].Field)
+	assert.True(t, req.SortBy[0].Desc)
+}
+
+// Kinds declare sortable numeric fields (dashboard usage counters, user
+// lastSeenAt), and the index gives them doc values, so sorting on one is valid.
+func TestTranslateSearchQuery_SortByNumericFieldAllowed(t *testing.T) {
+	q := searchQuery(nil)
+	q.Sort = []searchv0.SortField{{Field: "panel_id", Direction: "desc"}}
+	req, errs := TranslateSearchQuery(q, dashboardsGVR, "default", testProvider())
+	require.Empty(t, errs)
+	require.Len(t, req.SortBy, 1)
+	assert.Equal(t, "panel_id", req.SortBy[0].Field)
+	assert.True(t, req.SortBy[0].Desc)
 }
 
 func TestTranslateTrashQuery_ExplicitFieldsAddDeletedRV(t *testing.T) {


### PR DESCRIPTION
Kinds already declare numeric fields as sortable — the dashboard usage counters and user `lastSeenAt` — and the index maps them with doc values. But the v1 validator rejected a sort on anything that isn't a string, so those declarations meant nothing and the only thing refusing was the validator.

Trash needs it concretely: `deletion_time` is the order `/trash` returns by default, so until now a caller could not ask for that order explicitly. Sorting a list of values still has no defined meaning, so arrays stay rejected.

The trash field types now come from the backend declarations instead of being assumed to be strings, so both sides agree which fields are numbers.

Stacked on #129699, which adds those declarations. Base will retarget to main once it merges.
