### PR TITLE
Transformations: Show SQL expression card for query-level datasources

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/utils.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/utils.test.ts
@@ -1,6 +1,7 @@
 import { type DataSourceInstanceSettings } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
+import { ExpressionDatasourceUID } from 'app/features/expressions/types';
 import { SHARED_DASHBOARD_QUERY } from 'app/plugins/datasource/dashboard/constants';
 
 import { hasBackendDatasource } from './utils';
@@ -12,6 +13,27 @@ jest.mock('@grafana/runtime', () => ({
 
 describe('hasBackendDatasource', () => {
   const mockGetDataSourceSrv = getDataSourceSrv as jest.Mock;
+
+  const prometheusSettings = {
+    uid: 'prometheus-uid',
+    type: 'prometheus',
+    name: 'Prometheus',
+    meta: { backend: true },
+  } as DataSourceInstanceSettings;
+
+  // The expression datasource resolves to settings without meta.backend - see ExpressionDatasource.ts
+  const expressionSettings = {
+    uid: ExpressionDatasourceUID,
+    type: ExpressionDatasourceUID,
+    name: 'Expression',
+    meta: {},
+  } as DataSourceInstanceSettings;
+
+  function mockInstanceSettings(...available: DataSourceInstanceSettings[]) {
+    mockGetDataSourceSrv.mockReturnValue({
+      getInstanceSettings: jest.fn((uid: string) => available.find((settings) => settings.uid === uid) ?? null),
+    });
+  }
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -104,5 +126,46 @@ describe('hasBackendDatasource', () => {
 
     const result = hasBackendDatasource({ datasourceUid: 'mixed-uid', queries });
     expect(result).toBe(true);
+  });
+
+  // V2 panels only carry a panel level datasource when their queries are mixed.
+  it('should fall back to the queries when there is no panel level datasource', () => {
+    mockInstanceSettings(prometheusSettings);
+
+    const queries: DataQuery[] = [{ refId: 'A', datasource: { uid: 'prometheus-uid', type: 'prometheus' } }];
+
+    const result = hasBackendDatasource({ datasourceUid: undefined, queries });
+    expect(result).toBe(true);
+  });
+
+  // Callers that infer the panel datasource from the first query land here when it is an expression.
+  it('should fall back to the queries when the panel level datasource is an expression', () => {
+    mockInstanceSettings(expressionSettings, prometheusSettings);
+
+    const queries: DataQuery[] = [
+      { refId: 'A', datasource: { uid: ExpressionDatasourceUID, type: ExpressionDatasourceUID } },
+      { refId: 'B', datasource: { uid: 'prometheus-uid', type: 'prometheus' } },
+    ];
+
+    const result = hasBackendDatasource({ datasourceUid: ExpressionDatasourceUID, queries });
+    expect(result).toBe(true);
+  });
+
+  it('should return false when the queries only use expressions', () => {
+    mockInstanceSettings(expressionSettings);
+
+    const queries: DataQuery[] = [
+      { refId: 'A', datasource: { uid: ExpressionDatasourceUID, type: ExpressionDatasourceUID } },
+    ];
+
+    const result = hasBackendDatasource({ datasourceUid: undefined, queries });
+    expect(result).toBe(false);
+  });
+
+  it('should return false when neither the panel nor its queries have a datasource', () => {
+    mockInstanceSettings(prometheusSettings);
+
+    const result = hasBackendDatasource({ datasourceUid: undefined, queries: [{ refId: 'A' }] });
+    expect(result).toBe(false);
   });
 });

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/utils.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/utils.ts
@@ -1,4 +1,4 @@
-import { getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceSrv, isExpressionReference } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
 import { SHARED_DASHBOARD_QUERY } from 'app/plugins/datasource/dashboard/constants';
 
@@ -21,20 +21,20 @@ export function hasBackendDatasource({
   datasourceUid: string | undefined;
   queries?: DataQuery[];
 }): boolean {
-  if (!datasourceUid || datasourceUid === SHARED_DASHBOARD_QUERY) {
+  if (datasourceUid === SHARED_DASHBOARD_QUERY) {
     return false;
   }
 
-  const mainDsSettings = getDataSourceSrv().getInstanceSettings(datasourceUid);
-  if (!mainDsSettings) {
-    return false;
+  // A panel level datasource only answers this on its own when every query runs through it. V2
+  // panels don't carry one unless the queries are mixed, and callers that infer it from the first
+  // query can land on an expression ref, so both of those fall through to the queries below.
+  if (datasourceUid && !isExpressionReference(datasourceUid)) {
+    const mainDsSettings = getDataSourceSrv().getInstanceSettings(datasourceUid);
+    if (mainDsSettings && !mainDsSettings.meta.mixed) {
+      return mainDsSettings.meta.backend === true;
+    }
   }
 
-  // For mixed datasource, check if any query uses a backend datasource
-  if (mainDsSettings.meta.mixed && queries) {
-    return queries.some((query) => query.datasource?.uid && isBackendDatasource(query.datasource.uid));
-  }
-
-  // For non-mixed, check the main datasource
-  return mainDsSettings.meta.backend === true;
+  // Expression queries resolve to settings without meta.backend, so they never count as backend.
+  return queries?.some((query) => query.datasource?.uid && isBackendDatasource(query.datasource.uid)) ?? false;
 }


### PR DESCRIPTION
## Description

The "Transform with SQL" card was missing from the empty Transformations tab for panels that only carry a datasource on their queries. `hasBackendDatasource` bailed out whenever the panel level uid was absent or unresolvable, so it never got as far as inspecting the queries it was already being handed.

## Changes

* `hasBackendDatasource` now only trusts the panel level datasource when it is a real, non-mixed one, and otherwise answers its documented question by scanning the queries for a backend datasource.
* Expression refs passed as the panel level datasource fall through to that same scan, so a panel whose first query is an expression resolves to the real datasource behind it.
* The mixed branch folded into the shared fallback rather than staying a special case. `-- Dashboard --` still returns `false` immediately, unchanged.
* Added coverage in `utils.test.ts` for the no-panel-datasource, expression-ref, expression-only, and nothing-anywhere cases.

## Risks

The helper is shared by three surfaces: the transformations empty state, the expression dropdown in the queries tab, and `TransformationTypePicker` in the new editor. The change only turns previous `false` answers into `true`, so the failure mode is offering SQL where it is not usable rather than hiding it. Dashboard datasource panels and frontend-only panels keep their existing behaviour, both covered by pre-existing tests.

## Demo

<!--- screenshot of the empty Transformations tab showing the card after reload -->

## Testing Instructions

* Enable the `sqlExpressions` and `transformationsEmptyPlaceholder` feature toggles.
* Open a dashboard panel that has one query against a backend datasource (for example `gdev-testdata`), no transformations, and no top-level `datasource` in its panel JSON.
* Edit the panel, switch to the Transformations tab, and reload the page. The "Transform with SQL" card should be visible. On `main` it is not.
* Repeat with a frontend-only datasource and confirm the card stays hidden.

## Reviewer Checklist

- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable

Close DPRO-271