### PR TITLE
Scopes: fix nav_scope_path for dashboards under group folders

### DIFF
--- a/devenv/scopes/scopes-config.yaml
+++ b/devenv/scopes/scopes-config.yaml
@@ -195,6 +195,8 @@ navigationTree:
     subScope: shoes
     preLoadSubScopeChildren: true
     children:
+      # Direct dashboard under ChildScope — clicking this sets nav_scope_path.
+      # Contrast with shoes-grouped-* below.
       - name: shoes-overview
         title: Overview
         url: /d/5SdHCadmz
@@ -204,6 +206,23 @@ navigationTree:
         title: Team Overview
         url: /d/EJ8_d9jZk
         scope: shoes
+
+      # Dashboard under ChildScope → Group:
+      # RootScope (shoe-org) → ChildScope (shoes) → Group (Team Metrics) → Dashboard.
+      # Clicking this should set nav_scope_path in the URL.
+      - name: shoes-grouped-latency
+        title: Latency (under group)
+        url: /d/ZqZnVvFZz
+        scope: shoes
+        groups:
+          - Team Metrics
+
+      - name: shoes-grouped-errors
+        title: Errors (under group)
+        url: /d/xtY_uCAiz
+        scope: shoes
+        groups:
+          - Team Metrics
 
       - name: shoes-frontend
         title: Frontend
@@ -226,6 +245,14 @@ navigationTree:
             url: /d/5SdHCadmz
             scope: frontend
             subScope: shoes # This should be filtered out since 'shoes' is already in the path
+
+          # Nested ChildScope → Group → Dashboard (same pattern one level deeper)
+          - name: frontend-grouped-overview
+            title: Frontend Overview (under group)
+            url: /d/5Y0jv6pVz
+            scope: frontend
+            groups:
+              - Frontend Reports
 
       - name: shoes-database
         title: Database

--- a/public/app/features/scopes/dashboards/ScopesDashboardsTree.tsx
+++ b/public/app/features/scopes/dashboards/ScopesDashboardsTree.tsx
@@ -52,6 +52,9 @@ export function ScopesDashboardsTree({
       {regularFolders.map(([subFolderId, subFolder]) => (
         <ScopesDashboardsTreeFolderItem
           key={subFolderId}
+          // Inherit parent subScope so dashboards under group folders still write nav_scope_path.
+          subScope={subScope}
+          subScopePath={subScopePath}
           folder={subFolder}
           folders={folder.folders}
           folderPath={[...folderPath, subFolderId]}

--- a/public/app/features/scopes/dashboards/ScopesDashboardsTreeFolderItem.test.tsx
+++ b/public/app/features/scopes/dashboards/ScopesDashboardsTreeFolderItem.test.tsx
@@ -1,5 +1,10 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter, useLocation } from 'react-router-dom-v5-compat';
+
+import { locationService } from '@grafana/runtime';
+
+import { useScopesServices } from '../ScopesContextProvider';
 
 import { ScopesDashboardsTreeFolderItem } from './ScopesDashboardsTreeFolderItem';
 import { type SuggestedNavigationsFolder, type SuggestedNavigationsFoldersMap } from './types';
@@ -9,15 +14,31 @@ jest.mock('app/core/hooks/useQueryParams', () => ({
   useQueryParams: jest.fn(() => [{}]),
 }));
 
+jest.mock('react-router-dom-v5-compat', () => ({
+  ...jest.requireActual('react-router-dom-v5-compat'),
+  useLocation: jest.fn(),
+}));
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  locationService: {
+    push: jest.fn(),
+  },
+}));
+
 // Mock ScopesContextProvider
 const mockScopesSelectorService = {
   changeScopes: jest.fn(),
+  state: {
+    appliedScopes: [{ scopeId: 'shoe-org' }],
+  },
 };
 
 const mockScopesDashboardsService = {
   setNavigationScope: jest.fn(),
   state: {
-    navScopePath: undefined,
+    navScopePath: undefined as string[] | undefined,
+    navigationScope: undefined as string | undefined,
   },
 };
 
@@ -31,9 +52,20 @@ jest.mock('../ScopesContextProvider', () => ({
 
 describe('ScopesDashboardsTreeFolderItem', () => {
   const mockOnFolderUpdate = jest.fn();
+  const mockUseLocation = useLocation as jest.Mock;
+  const mockLocationServicePush = locationService.push as jest.Mock;
+  const mockUseScopesServices = useScopesServices as jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseLocation.mockReturnValue({ pathname: '/current-path' });
+    mockScopesSelectorService.state.appliedScopes = [{ scopeId: 'shoe-org' }];
+    mockScopesDashboardsService.state.navScopePath = undefined;
+    mockScopesDashboardsService.state.navigationScope = undefined;
+    mockUseScopesServices.mockReturnValue({
+      scopesSelectorService: mockScopesSelectorService,
+      scopesDashboardsService: mockScopesDashboardsService,
+    });
   });
 
   const createMockFolder = (overrides?: Partial<SuggestedNavigationsFolder>): SuggestedNavigationsFolder => ({
@@ -51,6 +83,10 @@ describe('ScopesDashboardsTreeFolderItem', () => {
       folders: {},
       suggestedNavigations: {},
     },
+  };
+
+  const renderWithRouter = (ui: React.ReactElement) => {
+    return render(<MemoryRouter>{ui}</MemoryRouter>);
   };
 
   it('renders folder with correct props', () => {
@@ -266,8 +302,7 @@ describe('ScopesDashboardsTreeFolderItem', () => {
     const user = userEvent.setup();
     const folder = createMockFolder({ subScopeName: 'subScope1' });
 
-    // Mock useScopesServices to return undefined
-    jest.spyOn(require('../ScopesContextProvider'), 'useScopesServices').mockReturnValue(undefined);
+    mockUseScopesServices.mockReturnValueOnce(undefined);
 
     render(
       <ScopesDashboardsTreeFolderItem
@@ -344,6 +379,113 @@ describe('ScopesDashboardsTreeFolderItem', () => {
 
       const exchangeButton = screen.getByRole('button', { name: /change root scope/i });
       expect(exchangeButton).toBeInTheDocument();
+    });
+  });
+
+  describe('inherited subScope for group folders', () => {
+    it('writes nav_scope_path when clicking a dashboard under a group inside a ChildScope', async () => {
+      const user = userEvent.setup();
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      Object.defineProperty(window, 'location', {
+        value: { origin: 'http://localhost' },
+        writable: true,
+      });
+
+      // ChildScope folder containing a group folder with a dashboard
+      const shoesFolder = createMockFolder({
+        title: 'Shoes',
+        expanded: true,
+        subScopeName: 'shoes',
+        folders: {
+          'Team Metrics': {
+            title: 'Team Metrics',
+            expanded: true,
+            folders: {},
+            suggestedNavigations: {
+              latency: {
+                id: 'latency',
+                title: 'Latency (under group)',
+                url: '/d/latency',
+              },
+            },
+          },
+        },
+      });
+
+      const folders: SuggestedNavigationsFoldersMap = {
+        '': shoesFolder,
+        'Team Metrics': shoesFolder.folders['Team Metrics'],
+      };
+
+      renderWithRouter(
+        <ScopesDashboardsTreeFolderItem
+          folder={shoesFolder}
+          folderPath={['']}
+          folders={folders}
+          onFolderUpdate={mockOnFolderUpdate}
+          subScopePath={['shoes']}
+        />
+      );
+
+      const link = screen.getByTestId('scopes-dashboards-latency');
+      await user.click(link);
+
+      expect(mockScopesSelectorService.changeScopes).toHaveBeenCalledWith(['shoes'], undefined, undefined, false);
+      expect(mockLocationServicePush).toHaveBeenCalled();
+      const pushedUrl = mockLocationServicePush.mock.calls[0][0];
+      expect(pushedUrl).toContain('scopes=shoes');
+      expect(pushedUrl).toContain('nav_scope_path=');
+      expect(decodeURIComponent(pushedUrl)).toContain('shoes');
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('writes nav_scope_path for a direct ChildScope dashboard when subScope prop is undefined', async () => {
+      const user = userEvent.setup();
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      Object.defineProperty(window, 'location', {
+        value: { origin: 'http://localhost' },
+        writable: true,
+      });
+
+      // Dashboard attached directly under ChildScope (no group). subScope prop omitted;
+      // folder.subScopeName alone should still drive nav_scope_path.
+      const shoesFolder = createMockFolder({
+        title: 'Shoes',
+        expanded: true,
+        subScopeName: 'shoes',
+        suggestedNavigations: {
+          overview: {
+            id: 'overview',
+            title: 'Overview',
+            url: '/d/overview',
+          },
+        },
+      });
+
+      const folders: SuggestedNavigationsFoldersMap = {
+        '': shoesFolder,
+      };
+
+      renderWithRouter(
+        <ScopesDashboardsTreeFolderItem
+          folder={shoesFolder}
+          folderPath={['']}
+          folders={folders}
+          onFolderUpdate={mockOnFolderUpdate}
+          subScopePath={['shoes']}
+        />
+      );
+
+      const link = screen.getByTestId('scopes-dashboards-overview');
+      await user.click(link);
+
+      expect(mockScopesSelectorService.changeScopes).toHaveBeenCalledWith(['shoes'], undefined, undefined, false);
+      expect(mockLocationServicePush).toHaveBeenCalled();
+      const pushedUrl = mockLocationServicePush.mock.calls[0][0];
+      expect(pushedUrl).toContain('scopes=shoes');
+      expect(pushedUrl).toContain('nav_scope_path=');
+      expect(decodeURIComponent(pushedUrl)).toContain('shoes');
+      consoleWarnSpy.mockRestore();
     });
   });
 });

--- a/public/app/features/scopes/dashboards/ScopesDashboardsTreeFolderItem.tsx
+++ b/public/app/features/scopes/dashboards/ScopesDashboardsTreeFolderItem.tsx
@@ -14,10 +14,13 @@ export interface ScopesDashboardsTreeFolderItemProps {
   folderPath: string[];
   folders: SuggestedNavigationsFoldersMap;
   onFolderUpdate: OnFolderUpdate;
+  /** Inherited from a parent ChildScope folder; used by group folders that have no subScopeName of their own. */
+  subScope?: string;
   subScopePath?: string[];
 }
 
 export function ScopesDashboardsTreeFolderItem({
+  subScope,
   subScopePath,
   folder,
   folderPath,
@@ -86,7 +89,7 @@ export function ScopesDashboardsTreeFolderItem({
         <div className={styles.children}>
           <ScopesDashboardsTree
             subScopePath={subScopePath}
-            subScope={folder.subScopeName}
+            subScope={folder.subScopeName ?? subScope}
             folders={folders}
             folderPath={folderPath}
             onFolderUpdate={onFolderUpdate}


### PR DESCRIPTION
## Summary
- Fix `nav_scope_path` not being set when clicking a dashboard under a group folder inside a ChildScope (it already worked for dashboards attached directly under the ChildScope).
- Thread inherited `subScope` / `subScopePath` through regular (group) folders via `folder.subScopeName ?? subScope` in `ScopesDashboardsTree` / `ScopesDashboardsTreeFolderItem`.
- Add grouped dashboards under Shoes / Frontend in `devenv/scopes/scopes-config.yaml` so the bug is reproducible locally.
- Cover the group-folder and direct-ChildScope cases in `ScopesDashboardsTreeFolderItem.test.tsx`.

Related: https://github.com/grafana/hyperion-planning/issues/610

## Steps to reproduce
After `./setup.sh scopes` (or `cd devenv/scopes && go run scopes.go`):

1. Select **Shoe organization** so the nav drawer opens.
2. Expand **Shoes**.
3. Click **Overview** → URL should include `nav_scope_path=...` (works before and after the fix).
4. Expand **Team Metrics**, then click **Latency (under group)** → before the fix the URL is missing `nav_scope_path`; after the fix it should be present.

Note: scope navigations are cached ~15 minutes; hard reload or Grafana restart may be needed after provisioning.

## Test plan
- [x] Unit: `yarn jest --no-watch public/app/features/scopes/dashboards/ScopesDashboardsTreeFolderItem.test.tsx`
- [x] Follow **Steps to reproduce** above and confirm `nav_scope_path` is set for the grouped dashboard.
- [ ] Click a dashboard under Frontend → Frontend Reports and confirm `nav_scope_path` is set for the nested ChildScope path as well.
- [ ] Expand/collapse and navigate between direct and grouped dashboards; tree behavior and scope application should remain unchanged aside from the URL param fix.

Made with [Cursor](https://cursor.com)