### PR TITLE
Reporting: Wait for repeat panel clones to settle before signaling render readiness

### DIFF
--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.test.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.test.ts
@@ -1050,7 +1050,7 @@ describe('DashboardScenePageStateManager v2', () => {
       try {
         await loader.loadDashboard({ uid: 'fake-dash', route: DashboardRoutes.Normal });
         expect(getDashSpy).toHaveBeenCalledTimes(1);
-        expect(initializeReportRenderReadinessObserver as jest.Mock).toHaveBeenCalled();
+        expect(initializeReportRenderReadinessObserver as jest.Mock).toHaveBeenCalledWith(expect.any(DashboardScene));
       } finally {
         contextSrv.user.authenticatedBy = originalAuthBy;
       }

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -479,7 +479,7 @@ abstract class DashboardScenePageStateManagerBase<T>
       if (renderTarget) {
         // Register the report render readiness observer so the image renderer can detect
         // when the dashboard has fully rendered (queries + transforms + fieldConfig + render)
-        initializeReportRenderReadinessObserver();
+        initializeReportRenderReadinessObserver(dashboard);
       }
 
       // Start dashboard_view profiling (both services are now guaranteed to be listening)

--- a/public/app/features/dashboard/services/ReportRenderReadinessObserver.repeats.test.ts
+++ b/public/app/features/dashboard/services/ReportRenderReadinessObserver.repeats.test.ts
@@ -1,0 +1,643 @@
+import { of } from 'rxjs';
+
+import { getDefaultTimeRange } from '@grafana/data';
+import {
+  behaviors,
+  ConstantVariable,
+  performanceUtils,
+  sceneGraph,
+  SceneGridLayout,
+  SceneGridRow,
+  SceneObjectBase,
+  SceneVariableSet,
+  TestVariable,
+  VizPanel,
+  type MultiValueVariable,
+  type SceneDataProvider,
+  type SceneDataProviderResult,
+  type SceneDataState,
+  type SceneQueryControllerEntry,
+  type SceneVariable,
+} from '@grafana/scenes';
+import { LoadingState } from '@grafana/schema';
+import { DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
+import { AutoGridItem } from 'app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItem';
+import { AutoGridLayout } from 'app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayout';
+import { AutoGridLayoutManager } from 'app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager';
+import { DashboardGridItem } from 'app/features/dashboard-scene/scene/layout-default/DashboardGridItem';
+import { DefaultGridLayoutManager } from 'app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager';
+import { RowRepeaterBehavior } from 'app/features/dashboard-scene/scene/layout-default/RowRepeaterBehavior';
+import { RowItem } from 'app/features/dashboard-scene/scene/layout-rows/RowItem';
+import { performRowRepeats } from 'app/features/dashboard-scene/scene/layout-rows/RowItemRepeater';
+import { RowsLayoutManager } from 'app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager';
+import { TabItem } from 'app/features/dashboard-scene/scene/layout-tabs/TabItem';
+import { performTabRepeats } from 'app/features/dashboard-scene/scene/layout-tabs/TabItemRepeater';
+import { TabsLayoutManager } from 'app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager';
+import { activateFullSceneTree } from 'app/features/dashboard-scene/utils/test-utils';
+
+import {
+  ReportRenderReadinessObserver,
+  SETTLE_MAX_WAIT_MS,
+  SETTLE_POLL_INTERVAL_MS,
+} from './ReportRenderReadinessObserver';
+
+const POST_STORM_WINDOW = 2000; // keep in sync with @grafana/scenes
+
+// VizPanel activation loads its panel plugin through the runtime registry, which is
+// only populated in a running Grafana instance. Serve a fake plugin from cache.
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getPluginImportUtils: () => ({
+    getPanelPluginFromCache: () => {
+      const { getPanelPlugin } = jest.requireActual('@grafana/data/test');
+      return getPanelPlugin({ id: 'timeseries' });
+    },
+  }),
+}));
+
+/**
+ * Stands in for SceneQueryRunner. Data stays `undefined` (panel not settled) until the
+ * test explicitly runs the query — the equivalent of React mounting the panel.
+ */
+class FakePanelDataProvider extends SceneObjectBase<SceneDataState> implements SceneDataProvider {
+  #entry: SceneQueryControllerEntry | undefined;
+
+  public constructor() {
+    super({ data: undefined });
+  }
+
+  public startQuery() {
+    this.#entry = { type: 'data', origin: this, cancel: () => {} };
+    sceneGraph.getQueryController(this)?.queryStarted(this.#entry);
+  }
+
+  public completeQuery() {
+    this.setState({ data: { state: LoadingState.Done, series: [], timeRange: getDefaultTimeRange() } });
+    if (this.#entry) {
+      sceneGraph.getQueryController(this)?.queryCompleted(this.#entry);
+    }
+  }
+
+  public getResultsStream() {
+    return of<SceneDataProviderResult>({ origin: this, data: this.state.data! });
+  }
+}
+
+/**
+ * Builds a profiled DashboardScene with a single panel that repeats by the given variable.
+ * The variable and the panel query are both under manual test control:
+ * `variable.signalUpdateCompleted()` finishes the default variable's update, and
+ * `sourceDataProvider.startQuery()` / `completeQuery()` simulate the panel query lifecycle.
+ */
+function buildRepeatDashboard<T extends SceneVariable = TestVariable>(variable?: T) {
+  // Default: a real repeat variable that registers a 'variable' entry with the
+  // controller while loading, completing only when signalUpdateCompleted() is called.
+  const repeatVariable =
+    variable ??
+    new TestVariable({
+      name: 'metric',
+      query: '',
+      optionsToReturn: [
+        { label: 'a', value: 'a' },
+        { label: 'b', value: 'b' },
+      ],
+      isMulti: true,
+      includeAll: true,
+      value: ['$__all'],
+      text: ['All'],
+    });
+
+  const sourceDataProvider = new FakePanelDataProvider();
+  const panel = new VizPanel({ key: 'panel-1', pluginId: 'timeseries', $data: sourceDataProvider });
+  const gridItem = new DashboardGridItem({ variableName: 'metric', body: panel, x: 0, y: 0, width: 24, height: 8 });
+
+  const profiler = new performanceUtils.SceneRenderProfiler();
+  const queryController = new behaviors.SceneQueryController({ enableProfiling: true }, profiler);
+
+  const dashboard = new DashboardScene({
+    $variables: new SceneVariableSet({ variables: [repeatVariable] }),
+    $behaviors: [queryController],
+    body: new DefaultGridLayoutManager({ grid: new SceneGridLayout({ children: [gridItem] }) }),
+  });
+
+  return { dashboard, gridItem, variable: repeatVariable, sourceDataProvider, queryController };
+}
+
+/**
+ * Builds a profiled DashboardScene using the rows layout: a single RowItem repeating by
+ * the default variable, containing one panel. Unlike DashboardGridItem, whose repeats run
+ * from an activation handler, RowItem repeats run from its React renderer (RowItemRepeater) —
+ * tests simulate that render by calling `performRowRepeats(variable, row, false)` manually.
+ *
+ * Pass `repeatByVariable` / `variables` to cover missing-target cases (renderer never
+ * mounts RowItemRepeater unless lookup finds a MultiValueVariable).
+ */
+function buildRowRepeatDashboard(options?: { repeatByVariable?: string; variables?: SceneVariable[] }) {
+  // A real repeat variable that registers a 'variable' entry with the controller
+  // while loading, completing only when signalUpdateCompleted() is called.
+  const repeatVariable = new TestVariable({
+    name: 'metric',
+    query: '',
+    optionsToReturn: [
+      { label: 'a', value: 'a' },
+      { label: 'b', value: 'b' },
+    ],
+    isMulti: true,
+    includeAll: true,
+    value: ['$__all'],
+    text: ['All'],
+  });
+
+  const sourceDataProvider = new FakePanelDataProvider();
+  const panel = new VizPanel({ key: 'panel-1', pluginId: 'timeseries', $data: sourceDataProvider });
+  const row = new RowItem({
+    key: 'row-1',
+    title: 'Row $metric',
+    repeatByVariable: options?.repeatByVariable ?? 'metric',
+    layout: new AutoGridLayoutManager({
+      layout: new AutoGridLayout({ children: [new AutoGridItem({ body: panel })] }),
+    }),
+  });
+
+  const profiler = new performanceUtils.SceneRenderProfiler();
+  const queryController = new behaviors.SceneQueryController({ enableProfiling: true }, profiler);
+
+  const dashboard = new DashboardScene({
+    $variables: new SceneVariableSet({ variables: options?.variables ?? [repeatVariable] }),
+    $behaviors: [queryController],
+    body: new RowsLayoutManager({ rows: [row] }),
+  });
+
+  return { dashboard, row, variable: repeatVariable, sourceDataProvider, queryController };
+}
+
+/**
+ * Builds a profiled DashboardScene using the default grid: a SceneGridRow with
+ * RowRepeaterBehavior (the V1 / report-route path). Unlike RowItem, clones are inserted
+ * into the SceneGridLayout as siblings with `repeatSourceKey` when the variable completes.
+ */
+function buildDefaultGridRowRepeatDashboard() {
+  const repeatVariable = new TestVariable({
+    name: 'metric',
+    query: '',
+    optionsToReturn: [
+      { label: 'a', value: 'a' },
+      { label: 'b', value: 'b' },
+    ],
+    isMulti: true,
+    includeAll: true,
+    value: ['$__all'],
+    text: ['All'],
+  });
+
+  const sourceDataProvider = new FakePanelDataProvider();
+  const panel = new VizPanel({ key: 'panel-1', pluginId: 'timeseries', $data: sourceDataProvider });
+  const gridItem = new DashboardGridItem({ body: panel, x: 0, y: 1, width: 24, height: 8 });
+  const row = new SceneGridRow({
+    key: 'row-1',
+    title: 'Row $metric',
+    children: [gridItem],
+    $behaviors: [new RowRepeaterBehavior({ variableName: 'metric' })],
+  });
+
+  const profiler = new performanceUtils.SceneRenderProfiler();
+  const queryController = new behaviors.SceneQueryController({ enableProfiling: true }, profiler);
+
+  const dashboard = new DashboardScene({
+    $variables: new SceneVariableSet({ variables: [repeatVariable] }),
+    $behaviors: [queryController],
+    body: new DefaultGridLayoutManager({
+      grid: new SceneGridLayout({ children: [row] }),
+    }),
+  });
+
+  return { dashboard, row, variable: repeatVariable, sourceDataProvider, queryController };
+}
+
+/**
+ * Builds a profiled DashboardScene using the tabs layout: a single TabItem repeating by
+ * the default variable, containing one panel. Like RowItem, TabItem repeats run from its
+ * React renderer (TabItemRepeater) — tests simulate that render by calling
+ * `performTabRepeats(variable, tab, false)` manually.
+ */
+function buildTabRepeatDashboard() {
+  // A real repeat variable that registers a 'variable' entry with the controller
+  // while loading, completing only when signalUpdateCompleted() is called.
+  const repeatVariable = new TestVariable({
+    name: 'metric',
+    query: '',
+    optionsToReturn: [
+      { label: 'a', value: 'a' },
+      { label: 'b', value: 'b' },
+    ],
+    isMulti: true,
+    includeAll: true,
+    value: ['$__all'],
+    text: ['All'],
+  });
+
+  const sourceDataProvider = new FakePanelDataProvider();
+  const panel = new VizPanel({ key: 'panel-1', pluginId: 'timeseries', $data: sourceDataProvider });
+  const tab = new TabItem({
+    key: 'tab-1',
+    title: 'Tab $metric',
+    repeatByVariable: 'metric',
+    layout: new AutoGridLayoutManager({
+      layout: new AutoGridLayout({ children: [new AutoGridItem({ body: panel })] }),
+    }),
+  });
+
+  const profiler = new performanceUtils.SceneRenderProfiler();
+  const queryController = new behaviors.SceneQueryController({ enableProfiling: true }, profiler);
+
+  const dashboard = new DashboardScene({
+    $variables: new SceneVariableSet({ variables: [repeatVariable] }),
+    $behaviors: [queryController],
+    body: new TabsLayoutManager({ tabs: [tab] }),
+  });
+
+  return { dashboard, tab, variable: repeatVariable, sourceDataProvider, queryController };
+}
+
+describe('ReportRenderReadinessObserver — integration with a repeat dashboard', () => {
+  let imageRendererMessageChannel: jest.Mock;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    // jest's fake performance lacks resource-timing APIs the profiler uses on completion
+    const perf = performance as unknown as Record<string, unknown>;
+    perf.getEntriesByType = () => [];
+    perf.clearResourceTimings = () => {};
+    imageRendererMessageChannel = jest.fn();
+    window.__grafanaImageRendererMessageChannel = imageRendererMessageChannel;
+    window.__grafanaRunningQueryCount = 0;
+  });
+
+  afterEach(() => {
+    performanceUtils.getScenePerformanceTracker().clearObservers();
+    delete (window as Record<string, unknown>).__grafanaImageRendererMessageChannel;
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  describe('repeated panels', () => {
+    test('withholds REPORT_RENDER_COMPLETE until the repeat panels have real data', () => {
+      const { dashboard, gridItem, variable, sourceDataProvider, queryController } = buildRepeatDashboard();
+
+      const observer = new ReportRenderReadinessObserver();
+      observer.setScene(dashboard);
+      performanceUtils.getScenePerformanceTracker().addObserver(observer);
+
+      // Activation kicks off the variable update; performRepeat early-returns (variable loading).
+      activateFullSceneTree(dashboard);
+      queryController.startProfile('dashboard_view');
+      expect(queryController.runningQueriesCount()).toBe(1); // the variable
+      expect(gridItem.state.repeatedPanels).toBeUndefined();
+
+      // The variable completes → count hits 0 → performRepeat creates clones, but nothing
+      // has "mounted" them: no panel queries registered. This is the race window, held open.
+      variable.signalUpdateCompleted();
+      expect(queryController.runningQueriesCount()).toBe(0);
+      expect(gridItem.state.repeatedPanels).toHaveLength(1); // 'a' reuses body, 'b' is the clone
+
+      // Profiler tail elapses and dashboard_view completes prematurely…
+      jest.advanceTimersByTime(POST_STORM_WINDOW + 500);
+
+      // Observer withholds REPORT_RENDER_COMPLETE: the source panel has no data yet
+      expect(imageRendererMessageChannel).not.toHaveBeenCalled();
+
+      // "React mounts the source panel": its query registers and completes.
+      sourceDataProvider.startQuery();
+      expect(window.__grafanaRunningQueryCount).toBe(1);
+      sourceDataProvider.completeQuery();
+
+      // The clone still has no data — settlement must keep being withheld.
+      jest.advanceTimersByTime(SETTLE_POLL_INTERVAL_MS + 50);
+      expect(imageRendererMessageChannel).not.toHaveBeenCalled();
+
+      // The clone mounts too: its own (cloned) provider completes.
+      const clonePanel = gridItem.state.repeatedPanels![0];
+      const cloneDataProvider = sceneGraph.getData(clonePanel) as FakePanelDataProvider;
+      cloneDataProvider.startQuery();
+      cloneDataProvider.completeQuery();
+
+      // Next settlement poll sends the message exactly once.
+      jest.advanceTimersByTime(SETTLE_POLL_INTERVAL_MS + 50);
+      expect(imageRendererMessageChannel).toHaveBeenCalledTimes(1);
+      expect(imageRendererMessageChannel).toHaveBeenCalledWith(
+        JSON.stringify({ type: 'REPORT_RENDER_COMPLETE', data: { success: true } })
+      );
+    });
+
+    test('sends a best-effort REPORT_RENDER_COMPLETE at the deadline when a repeat clone never settles', () => {
+      const { dashboard, gridItem, variable, sourceDataProvider, queryController } = buildRepeatDashboard();
+
+      const observer = new ReportRenderReadinessObserver();
+      observer.setScene(dashboard);
+      performanceUtils.getScenePerformanceTracker().addObserver(observer);
+
+      activateFullSceneTree(dashboard);
+      queryController.startProfile('dashboard_view');
+
+      // Variable completes and the source panel loads, but the clone is stuck:
+      // it never "mounts", so its data provider never produces data.
+      variable.signalUpdateCompleted();
+      sourceDataProvider.startQuery();
+      sourceDataProvider.completeQuery();
+
+      // dashboard_view completes after the profiler tail; the deadline countdown
+      // starts here. Settlement is withheld because the clone has no data.
+      jest.advanceTimersByTime(POST_STORM_WINDOW + 500);
+      expect(imageRendererMessageChannel).not.toHaveBeenCalled();
+
+      // Polling keeps withholding the message for (almost) the full deadline window.
+      // Stay 1s short of SETTLE_MAX_WAIT: the countdown started up to 500ms into the
+      // previous advance, so anywhere in its last second the deadline may already fire.
+      jest.advanceTimersByTime(SETTLE_MAX_WAIT_MS - 1000);
+      expect(imageRendererMessageChannel).not.toHaveBeenCalled();
+
+      // The deadline elapses → best-effort send: the report captures whatever has
+      // loaded instead of stalling until the renderer's own (fatal) readiness timeout.
+      jest.advanceTimersByTime(1500 + SETTLE_POLL_INTERVAL_MS + 50); // remaining window + poll
+      expect(imageRendererMessageChannel).toHaveBeenCalledTimes(1);
+      expect(imageRendererMessageChannel).toHaveBeenCalledWith(
+        JSON.stringify({ type: 'REPORT_RENDER_COMPLETE', data: { success: true } })
+      );
+
+      // The clone is still unsettled — the send was the deadline safety valve, and
+      // polling stopped with it: nothing fires again afterwards.
+      const clonePanel = gridItem.state.repeatedPanels![0];
+      expect(sceneGraph.getData(clonePanel).state.data).toBeUndefined();
+      jest.advanceTimersByTime(1000);
+      expect(imageRendererMessageChannel).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not wait for panels that never mount (solo panel render)', () => {
+      const { dashboard, gridItem, variable, sourceDataProvider, queryController } = buildRepeatDashboard();
+
+      const observer = new ReportRenderReadinessObserver();
+      observer.setScene(dashboard);
+      performanceUtils.getScenePerformanceTracker().addObserver(observer);
+
+      // Only the dashboard root activates ($variables, behaviors). The body layout is
+      // never mounted — the d-solo page renders a single panel outside the dashboard body,
+      // so the grid item stays inactive and never creates its repeat clones.
+      dashboard.activate();
+      const soloPanel = gridItem.state.body;
+      soloPanel.activate();
+
+      queryController.startProfile('dashboard_view');
+      sourceDataProvider.startQuery();
+      sourceDataProvider.completeQuery();
+      variable.signalUpdateCompleted();
+      expect(queryController.runningQueriesCount()).toBe(0);
+      expect(gridItem.isActive).toBe(false);
+      expect(gridItem.state.repeatedPanels).toBeUndefined();
+
+      // dashboard_view completes after the profiler tail. The inactive repeater and its
+      // unmounted panel must not block settlement: the message goes out on the first
+      // check instead of stalling until the 20s deadline.
+      jest.advanceTimersByTime(POST_STORM_WINDOW + 500);
+      expect(imageRendererMessageChannel).toHaveBeenCalledTimes(1);
+      expect(imageRendererMessageChannel).toHaveBeenCalledWith(
+        JSON.stringify({ type: 'REPORT_RENDER_COMPLETE', data: { success: true } })
+      );
+    });
+
+    test('does not wait for a repeater whose variable can never repeat (non-multi-value)', () => {
+      // performRepeat() refuses non-multi-value variables with a console.error and an
+      // early return, so repeatedPanels stays undefined forever.
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      const { dashboard, gridItem, sourceDataProvider, queryController } = buildRepeatDashboard(
+        new ConstantVariable({ name: 'metric', value: 'a' })
+      );
+
+      const observer = new ReportRenderReadinessObserver();
+      observer.setScene(dashboard);
+      performanceUtils.getScenePerformanceTracker().addObserver(observer);
+
+      activateFullSceneTree(dashboard);
+      queryController.startProfile('dashboard_view');
+      sourceDataProvider.startQuery();
+      sourceDataProvider.completeQuery();
+
+      // The repeater is active but permanently refuses to create clones.
+      expect(gridItem.isActive).toBe(true);
+      expect(gridItem.state.repeatedPanels).toBeUndefined();
+
+      // dashboard_view completes after the profiler tail. The unrepeatable repeater must
+      // not block settlement: the message goes out on the first check, not at the deadline.
+      jest.advanceTimersByTime(POST_STORM_WINDOW + 500);
+      expect(imageRendererMessageChannel).toHaveBeenCalledTimes(1);
+      expect(imageRendererMessageChannel).toHaveBeenCalledWith(
+        JSON.stringify({ type: 'REPORT_RENDER_COMPLETE', data: { success: true } })
+      );
+    });
+  });
+
+  describe('repeated rows', () => {
+    test('does not wait when repeatByVariable target is missing', () => {
+      // RowsLayoutManagerRenderer only mounts RowItemRepeater for a MultiValueVariable.
+      // A missing target leaves repeatedRows undefined forever — must not stall 20s.
+      const { dashboard, row, sourceDataProvider, queryController } = buildRowRepeatDashboard({
+        repeatByVariable: 'does-not-exist',
+        variables: [],
+      });
+
+      const observer = new ReportRenderReadinessObserver();
+      observer.setScene(dashboard);
+      performanceUtils.getScenePerformanceTracker().addObserver(observer);
+
+      activateFullSceneTree(dashboard);
+      queryController.startProfile('dashboard_view');
+      sourceDataProvider.startQuery();
+      sourceDataProvider.completeQuery();
+
+      expect(row.isActive).toBe(true);
+      expect(row.state.repeatByVariable).toBe('does-not-exist');
+      expect(sceneGraph.lookupVariable('does-not-exist', row)).toBeNull();
+      expect(row.state.repeatedRows).toBeUndefined();
+
+      // dashboard_view completes after the profiler tail. Settlement must succeed on the
+      // first check instead of waiting until SETTLE_MAX_WAIT_MS.
+      jest.advanceTimersByTime(POST_STORM_WINDOW + 500);
+      expect(imageRendererMessageChannel).toHaveBeenCalledTimes(1);
+      expect(imageRendererMessageChannel).toHaveBeenCalledWith(
+        JSON.stringify({ type: 'REPORT_RENDER_COMPLETE', data: { success: true } })
+      );
+    });
+
+    test('withholds REPORT_RENDER_COMPLETE until repeated rows exist and their panels have data', () => {
+      const { dashboard, row, variable, sourceDataProvider, queryController } = buildRowRepeatDashboard();
+
+      const observer = new ReportRenderReadinessObserver();
+      observer.setScene(dashboard);
+      performanceUtils.getScenePerformanceTracker().addObserver(observer);
+
+      activateFullSceneTree(dashboard);
+      queryController.startProfile('dashboard_view');
+
+      // The variable completes and the source panel loads, but RowItem repeats only run
+      // from its React renderer — nothing has rendered the row yet, so repeatedRows stays
+      // undefined. This is the pending-repeat window (#hasPendingRepeat's repeatByVariable branch).
+      variable.signalUpdateCompleted();
+      sourceDataProvider.startQuery();
+      sourceDataProvider.completeQuery();
+      expect(row.state.repeatedRows).toBeUndefined();
+
+      // dashboard_view completes after the profiler tail. The observer sees the active
+      // row repeater with no clones yet and withholds the message.
+      jest.advanceTimersByTime(POST_STORM_WINDOW + 500);
+      expect(imageRendererMessageChannel).not.toHaveBeenCalled();
+
+      // "React renders the repeater": clones are created ('a' reuses the source row,
+      // 'b' is the clone) but React has NOT mounted them yet — repeatedRows is set
+      // while the clone row is still inactive.
+      performRowRepeats(variable as unknown as MultiValueVariable, row, false);
+      expect(row.state.repeatedRows).toHaveLength(1);
+      const cloneRow = row.state.repeatedRows![0];
+      expect(cloneRow.isActive).toBe(false);
+
+      // A settlement poll fires inside this window. WITHOUT the fix the clone panel
+      // is filtered out of the per-panel check (inactive parent grid item) and the
+      // message is sent prematurely — this assertion FAILS. WITH the fix, the
+      // not-yet-active clone keeps the repeater pending.
+      jest.advanceTimersByTime(SETTLE_POLL_INTERVAL_MS + 50);
+      expect(imageRendererMessageChannel).not.toHaveBeenCalled();
+
+      // The clone row mounts, but its cloned panel provider has produced no data
+      // yet, so the per-panel check keeps withholding settlement.
+      activateFullSceneTree(cloneRow);
+      jest.advanceTimersByTime(SETTLE_POLL_INTERVAL_MS + 50);
+      expect(imageRendererMessageChannel).not.toHaveBeenCalled();
+
+      // The clone panel's own (cloned) provider completes.
+      const clonePanel = sceneGraph.findAllObjects(cloneRow, (obj) => obj instanceof VizPanel)[0];
+      const cloneDataProvider = sceneGraph.getData(clonePanel) as FakePanelDataProvider;
+      cloneDataProvider.startQuery();
+      cloneDataProvider.completeQuery();
+
+      // Next settlement poll sends the message exactly once.
+      jest.advanceTimersByTime(SETTLE_POLL_INTERVAL_MS + 50);
+      expect(imageRendererMessageChannel).toHaveBeenCalledTimes(1);
+      expect(imageRendererMessageChannel).toHaveBeenCalledWith(
+        JSON.stringify({ type: 'REPORT_RENDER_COMPLETE', data: { success: true } })
+      );
+    });
+  });
+
+  describe('repeated rows (default grid / RowRepeaterBehavior)', () => {
+    test('withholds REPORT_RENDER_COMPLETE until clone rows mount and their panels have data', () => {
+      const { dashboard, row, variable, sourceDataProvider, queryController } = buildDefaultGridRowRepeatDashboard();
+
+      const observer = new ReportRenderReadinessObserver();
+      observer.setScene(dashboard);
+      performanceUtils.getScenePerformanceTracker().addObserver(observer);
+
+      // Activation kicks off the variable update; performRepeat early-returns (variable loading).
+      activateFullSceneTree(dashboard);
+      queryController.startProfile('dashboard_view');
+
+      // The variable completes → RowRepeaterBehavior.performRepeat inserts clone rows into
+      // the layout (with repeatSourceKey). React has NOT mounted them yet — clones stay
+      // inactive. This is the race window the report path hits (reports force V1 layout).
+      variable.signalUpdateCompleted();
+      sourceDataProvider.startQuery();
+      sourceDataProvider.completeQuery();
+
+      const layout = row.parent as SceneGridLayout;
+      const cloneRow = layout.state.children.find(
+        (child): child is SceneGridRow => child instanceof SceneGridRow && child.state.repeatSourceKey === row.state.key
+      );
+      expect(cloneRow).toBeDefined();
+      expect(cloneRow!.isActive).toBe(false);
+
+      // dashboard_view completes after the profiler tail. WITHOUT the fix the inactive
+      // clone panels are filtered out of the per-panel check and the message is sent
+      // prematurely — this assertion FAILS. WITH the fix, the not-yet-active clone row
+      // (repeatSourceKey under an active layout) keeps settlement pending.
+      jest.advanceTimersByTime(POST_STORM_WINDOW + 500);
+      expect(imageRendererMessageChannel).not.toHaveBeenCalled();
+
+      // The clone row mounts, but its cloned panel provider has produced no data
+      // yet, so the per-panel check keeps withholding settlement.
+      activateFullSceneTree(cloneRow!);
+      jest.advanceTimersByTime(SETTLE_POLL_INTERVAL_MS + 50);
+      expect(imageRendererMessageChannel).not.toHaveBeenCalled();
+
+      // The clone panel's own (cloned) provider completes.
+      const clonePanel = sceneGraph.findAllObjects(cloneRow!, (obj) => obj instanceof VizPanel)[0];
+      const cloneDataProvider = sceneGraph.getData(clonePanel) as FakePanelDataProvider;
+      cloneDataProvider.startQuery();
+      cloneDataProvider.completeQuery();
+
+      // Next settlement poll sends the message exactly once.
+      jest.advanceTimersByTime(SETTLE_POLL_INTERVAL_MS + 50);
+      expect(imageRendererMessageChannel).toHaveBeenCalledTimes(1);
+      expect(imageRendererMessageChannel).toHaveBeenCalledWith(
+        JSON.stringify({ type: 'REPORT_RENDER_COMPLETE', data: { success: true } })
+      );
+    });
+  });
+
+  describe('repeated tabs', () => {
+    test('withholds REPORT_RENDER_COMPLETE until repeated tabs exist and their panels have data', () => {
+      const { dashboard, tab, variable, sourceDataProvider, queryController } = buildTabRepeatDashboard();
+
+      const observer = new ReportRenderReadinessObserver();
+      observer.setScene(dashboard);
+      performanceUtils.getScenePerformanceTracker().addObserver(observer);
+
+      activateFullSceneTree(dashboard);
+      queryController.startProfile('dashboard_view');
+
+      // The variable completes and the source panel loads, but TabItem repeats only run
+      // from its React renderer — nothing has rendered the tab yet, so repeatedTabs stays
+      // undefined. This is the pending-repeat window (#hasPendingRepeat's repeatByVariable branch).
+      variable.signalUpdateCompleted();
+      sourceDataProvider.startQuery();
+      sourceDataProvider.completeQuery();
+      expect(tab.state.repeatedTabs).toBeUndefined();
+
+      // dashboard_view completes after the profiler tail. The observer sees the active
+      // tab repeater with no clones yet and withholds the message.
+      jest.advanceTimersByTime(POST_STORM_WINDOW + 500);
+      expect(imageRendererMessageChannel).not.toHaveBeenCalled();
+
+      // "React renders the repeater": clones are created ('a' reuses the source tab,
+      // 'b' is the clone) but React has NOT mounted them yet — repeatedTabs is set
+      // while the clone tab is still inactive.
+      performTabRepeats(variable as unknown as MultiValueVariable, tab, false);
+      expect(tab.state.repeatedTabs).toHaveLength(1);
+      const cloneTab = tab.state.repeatedTabs![0];
+      expect(cloneTab.isActive).toBe(false);
+
+      // A settlement poll fires inside this window. WITHOUT the fix the clone panel
+      // is filtered out of the per-panel check (inactive parent grid item) and the
+      // message is sent prematurely — this assertion FAILS. WITH the fix, the
+      // not-yet-active clone keeps the repeater pending.
+      jest.advanceTimersByTime(SETTLE_POLL_INTERVAL_MS + 50);
+      expect(imageRendererMessageChannel).not.toHaveBeenCalled();
+
+      // The clone tab mounts, but its cloned panel provider has produced no data
+      // yet, so the per-panel check keeps withholding settlement.
+      activateFullSceneTree(cloneTab);
+      jest.advanceTimersByTime(SETTLE_POLL_INTERVAL_MS + 50);
+      expect(imageRendererMessageChannel).not.toHaveBeenCalled();
+
+      // The clone panel's own (cloned) provider completes.
+      const clonePanel = sceneGraph.findAllObjects(cloneTab, (obj) => obj instanceof VizPanel)[0];
+      const cloneDataProvider = sceneGraph.getData(clonePanel) as FakePanelDataProvider;
+      cloneDataProvider.startQuery();
+      cloneDataProvider.completeQuery();
+
+      // Next settlement poll sends the message exactly once.
+      jest.advanceTimersByTime(SETTLE_POLL_INTERVAL_MS + 50);
+      expect(imageRendererMessageChannel).toHaveBeenCalledTimes(1);
+      expect(imageRendererMessageChannel).toHaveBeenCalledWith(
+        JSON.stringify({ type: 'REPORT_RENDER_COMPLETE', data: { success: true } })
+      );
+    });
+  });
+});

--- a/public/app/features/dashboard/services/ReportRenderReadinessObserver.test.ts
+++ b/public/app/features/dashboard/services/ReportRenderReadinessObserver.test.ts
@@ -1,4 +1,5 @@
 import { performanceUtils } from '@grafana/scenes';
+import { DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
 
 import {
   ReportRenderReadinessObserver,
@@ -82,7 +83,8 @@ describe('ReportRenderReadinessObserver', () => {
     });
 
     it('should register the observer with the performance tracker', () => {
-      initializeReportRenderReadinessObserver();
+      const dashboard = new DashboardScene({});
+      initializeReportRenderReadinessObserver(dashboard);
 
       expect(addObserverSpy).toHaveBeenCalledWith(expect.any(ReportRenderReadinessObserver));
     });

--- a/public/app/features/dashboard/services/ReportRenderReadinessObserver.ts
+++ b/public/app/features/dashboard/services/ReportRenderReadinessObserver.ts
@@ -1,4 +1,16 @@
-import { type performanceUtils } from '@grafana/scenes';
+import {
+  MultiValueVariable,
+  sceneGraph,
+  SceneGridRow,
+  SceneObjectBase,
+  VizPanel,
+  type performanceUtils,
+  type SceneObject,
+  type SceneObjectState,
+  type SceneVariable,
+} from '@grafana/scenes';
+import { LoadingState } from '@grafana/schema';
+import { type DashboardSceneLike } from 'app/features/dashboard-scene/scene/types/dashboard';
 
 import { registerPerformanceObserver } from './performanceUtils';
 
@@ -13,32 +25,272 @@ interface RenderBindingMessage<T extends MessageEventType> {
   data: MessageEventPayloadMap[T];
 }
 
+export const SETTLE_POLL_INTERVAL_MS = 500;
+// Give up waiting and send the "ready" signal after this long. Must stay well below
+// the renderer's --browser.readiness.timeout (default 30s), which starts counting
+// earlier than we do: if the renderer gives up first, the whole render fails with a
+// timeout error instead of producing a report from whatever has loaded so far.
+export const SETTLE_MAX_WAIT_MS = 20_000;
+
+/**
+ * Duck-typed view of the repeater state fields, avoiding runtime imports from
+ * dashboard-scene (import cycle):
+ * - DashboardGridItem / AutoGridItem: `variableName` + `body` + `repeatedPanels`
+ * - RowRepeaterBehavior:              `variableName` only (clones live as SceneGridRow
+ *                                     siblings with `repeatSourceKey` in the layout)
+ * - RowItem / TabItem:                `repeatByVariable` + `repeatedRows` / `repeatedTabs`
+ */
+interface RepeaterLikeState extends SceneObjectState {
+  variableName?: string;
+  repeatByVariable?: string;
+  body?: VizPanel;
+  repeatedPanels?: unknown[];
+  repeatedRows?: unknown[];
+  repeatedTabs?: unknown[];
+}
+
+/**
+ * Walk descendants of `root` (not `root` itself — matches sceneGraph.findAllObjects)
+ * and return true as soon as `pred` matches. Used instead of findAllObjects when the
+ * visitor is only a side-effecting pending check.
+ */
+function sceneSome(root: SceneObject, pred: (obj: SceneObject) => boolean): boolean {
+  let hit = false;
+
+  const visit = (obj: SceneObject) => {
+    obj.forEachChild((child) => {
+      if (hit) {
+        return;
+      }
+      if (pred(child)) {
+        hit = true;
+        return;
+      }
+      visit(child);
+    });
+  };
+
+  visit(root);
+  return hit;
+}
+
+/** True when this object sits under a default-grid row-repeat clone whose layout is active. */
+function isUnderActiveDefaultGridRowClone(panel: SceneObject): boolean {
+  for (let obj = panel.parent; obj; obj = obj.parent) {
+    if (obj instanceof SceneGridRow && obj.state.repeatSourceKey && obj.parent?.isActive === true) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Default-grid row repeats (RowRepeaterBehavior): clones are inserted into the
+ * SceneGridLayout as SceneGridRow siblings with repeatSourceKey. Their clone list
+ * is private on the behavior, so we detect the mount gap here instead.
+ * Only wait while the parent layout is active — otherwise solo/unmounted layouts
+ * would stall until the deadline. Must be checked before any !isActive early-return:
+ * clone rows are inactive by definition in this window.
+ */
+function isUnmountedDefaultGridRowClone(obj: SceneObject): boolean {
+  return (
+    obj instanceof SceneGridRow && Boolean(obj.state.repeatSourceKey) && obj.parent?.isActive === true && !obj.isActive
+  );
+}
+
+/**
+ * Row/tab clones are created but React has not mounted them yet — their panels sit
+ * under inactive nested grid items, invisible to the per-panel data check.
+ * Waiting on clone activation cannot stall: row clones mount their header even when
+ * collapsed or conditionally hidden (CSS only), and tab clones mount their header in
+ * the tabs bar even when not the current tab.
+ *
+ * Must run before variable checks: performing a row/tab repeat replaces the source
+ * row/tab's $variables with a LocalValueVariable shadowing the repeat variable, so
+ * once clones exist lookupVariable resolves the shadow (not multi-value) and would
+ * skip this repeater entirely.
+ */
+function hasInactiveRowOrTabClones(state: RepeaterLikeState): boolean {
+  const clones = state.repeatedRows ?? state.repeatedTabs;
+  if (state.repeatByVariable === undefined || clones === undefined) {
+    return false;
+  }
+  return clones.some((clone) => clone instanceof SceneObjectBase && !clone.isActive);
+}
+
+/**
+ * The repeat variable is still loading, or it is done but clones have not been
+ * created yet — the race window from grafana/grafana#128536. Repeaters never clone
+ * for non-multi-value variables. Panel repeaters still clone when the named variable
+ * is missing (they synthesize a placeholder CustomVariable), so a null lookup must
+ * keep waiting for repeatedPanels. Row/tab repeaters never mount without a real
+ * MultiValueVariable, so a missing target must not wait.
+ * RowRepeaterBehavior clones are detected via isUnmountedDefaultGridRowClone instead.
+ */
+function isWaitingForCloneCreation(state: RepeaterLikeState, variable: SceneVariable | null): boolean {
+  const isPanelRepeater = state.variableName !== undefined && state.body instanceof VizPanel;
+  const isRowOrTabRepeater = state.repeatByVariable !== undefined;
+
+  // Missing variable: panel repeaters still clone; row/tab repeaters never do.
+  if (!variable) {
+    return isPanelRepeater && state.repeatedPanels === undefined;
+  }
+
+  if (!(variable instanceof MultiValueVariable)) {
+    return false;
+  }
+
+  if (variable.state.loading || sceneGraph.hasVariableDependencyInLoadingState(variable)) {
+    return true;
+  }
+
+  return (
+    (isPanelRepeater && state.repeatedPanels === undefined) ||
+    (isRowOrTabRepeater && state.repeatedRows === undefined && state.repeatedTabs === undefined)
+  );
+}
+
+function isRepeatPending(obj: SceneObject): boolean {
+  if (isUnmountedDefaultGridRowClone(obj)) {
+    return true;
+  }
+
+  // Inactive repeaters (unmounted tab, collapsed row, solo-panel body) never create
+  // clones — waiting on them would only stall until the deadline.
+  if (!obj.isActive) {
+    return false;
+  }
+
+  const state: RepeaterLikeState = obj.state;
+  const repeatVariableName = state.variableName ?? state.repeatByVariable;
+  if (!repeatVariableName) {
+    return false;
+  }
+
+  const isRowOrTabRepeater = state.repeatByVariable !== undefined;
+  const clones = state.repeatedRows ?? state.repeatedTabs;
+  if (isRowOrTabRepeater && clones !== undefined) {
+    return hasInactiveRowOrTabClones(state);
+  }
+
+  return isWaitingForCloneCreation(state, sceneGraph.lookupVariable(repeatVariableName, obj));
+}
+
+/**
+ * Skip panels that will never mount and thus never produce data: inactive tabs,
+ * collapsed rows, solo-panel renders (the /d-solo route mounts a single panel, not
+ * the body). A freshly created panel-repeat clone is inactive too, but its owning
+ * repeater (parent) is active — keep those, they are exactly the race being fixed.
+ * Row/tab clone panels sit under inactive nested grid items and are dropped here;
+ * they are guarded by the clone-activation check in isRepeatPending instead.
+ * Default-grid row-repeat clones (RowRepeaterBehavior) keep panels under an inactive
+ * nested grid item even after the clone row is created — keep those while the layout
+ * is active so we wait for their data after the clone mounts.
+ */
+function isRelevantReportPanel(panel: SceneObject): boolean {
+  return panel.isActive || panel.parent?.isActive === true || isUnderActiveDefaultGridRowClone(panel);
+}
+
+function isPanelSettled(panel: SceneObject): boolean {
+  // Only wait on variables this panel actually depends on (directly or through a
+  // chain). A loading-but-unused variable does not block the report.
+  if (sceneGraph.hasVariableDependencyInLoadingState(panel)) {
+    return false;
+  }
+
+  // Queryless panels resolve to Done via the default SceneDataNode. `undefined`
+  // means a data provider exists but has not produced data yet (e.g. a freshly
+  // created repeat clone that is not mounted) — not settled.
+  const dataState = sceneGraph.getData(panel).state.data?.state;
+  return dataState === LoadingState.Done || dataState === LoadingState.Error || dataState === LoadingState.Streaming;
+}
+
 /**
  * Performance observer that signals to the grafana-image-renderer when a dashboard
  * has finished rendering all panels for report capture.
  *
- * Sends a `REPORT_RENDER_COMPLETE` message via the `window.__grafanaImageRendererMessageChannel`
- * chromedp binding when a `dashboard_view` interaction completes, meaning all panels have gone
- * through the full lifecycle (queries, transforms, field config, rendering).
- *
- * This observer is only registered for report routes to avoid any overhead on
- * normal dashboard usage.
+ * The `dashboard_view` completion event can fire prematurely: when a repeat variable
+ * finishes, the running-query count briefly hits 0 before the repeated panels have
+ * registered their queries (race described in grafana/grafana#128536). So instead of
+ * forwarding the event immediately, we verify the scene has actually settled
+ * (no running queries, no pending repeats, all panel data resolved) and poll until
+ * it has before sending `REPORT_RENDER_COMPLETE`.
  */
 export class ReportRenderReadinessObserver implements performanceUtils.ScenePerformanceObserver {
-  onDashboardInteractionComplete = (data: performanceUtils.DashboardInteractionCompleteData): void => {
-    if (data.interactionType === 'dashboard_view') {
-      sendMessageEvent('REPORT_RENDER_COMPLETE', { success: true });
+  #scene: DashboardSceneLike | undefined;
+  #pollTimeoutId: ReturnType<typeof setTimeout> | undefined;
+  #deadline = 0;
+
+  public setScene(scene: DashboardSceneLike | undefined): void {
+    this.#scene = scene;
+    this.#cancelPendingPoll();
+  }
+
+  public onDashboardInteractionComplete = (data: performanceUtils.DashboardInteractionCompleteData): void => {
+    if (data.interactionType !== 'dashboard_view') {
+      return;
     }
+
+    this.#cancelPendingPoll();
+    this.#deadline = Date.now() + SETTLE_MAX_WAIT_MS;
+    this.#sendWhenSettled();
   };
+
+  #sendWhenSettled = (): void => {
+    this.#pollTimeoutId = undefined;
+
+    if (this.#isSettled() || Date.now() >= this.#deadline) {
+      sendMessageEvent('REPORT_RENDER_COMPLETE', { success: true });
+      return;
+    }
+
+    this.#pollTimeoutId = setTimeout(this.#sendWhenSettled, SETTLE_POLL_INTERVAL_MS);
+  };
+
+  #isSettled(): boolean {
+    // Without a scene reference we cannot verify anything; keep old behavior (send immediately).
+    if (!this.#scene) {
+      return true;
+    }
+
+    if ((window.__grafanaRunningQueryCount ?? 0) > 0) {
+      return false;
+    }
+
+    if (this.#hasPendingRepeat(this.#scene)) {
+      return false;
+    }
+
+    // getVizPanels() only returns each repeater's source panel. Repeat clones live in
+    // repeatedPanels / repeatedRows / repeatedTabs state arrays, which forEachChild
+    // traverses, so a full scene-graph walk catches them too.
+    const panels = sceneGraph
+      .findAllObjects(this.#scene.state.body, (obj) => obj instanceof VizPanel)
+      .filter(isRelevantReportPanel);
+
+    return panels.every(isPanelSettled);
+  }
+
+  #hasPendingRepeat(scene: DashboardSceneLike): boolean {
+    return sceneSome(scene, isRepeatPending);
+  }
+
+  #cancelPendingPoll(): void {
+    if (this.#pollTimeoutId !== undefined) {
+      clearTimeout(this.#pollTimeoutId);
+      this.#pollTimeoutId = undefined;
+    }
+  }
 }
 
 let instance: ReportRenderReadinessObserver | null = null;
 
-export function initializeReportRenderReadinessObserver(): void {
+export function initializeReportRenderReadinessObserver(scene: DashboardSceneLike): void {
   if (!instance) {
     instance = new ReportRenderReadinessObserver();
     registerPerformanceObserver(instance, 'RRO');
   }
+  instance.setScene(scene);
 }
 
 const createMessageEvent = <T extends MessageEventType>(


### PR DESCRIPTION
## Goal

Fixes https://github.com/grafana/support-escalations/issues/23324 by ensuring that the image renderer captures reports only after repeated panels have finished loading, instead of racing ahead when a repeat variable completes.

See the last section below for an alternative approach/PR.

## Problem

Reports for dashboards using panel/row/tab repeats could be captured before the repeated panels had any data, producing empty or partially rendered PDFs (race described in #128536 + customer escalation).

The root cause is a race in how readiness was signaled:
- the Scenes profiler (`SceneRenderProfiler`) observes the `SceneQueryController`'s running-query count
- once the count reaches 0, it initiates a 2s tail-recording window (`POST_STORM_WINDOW`) and, provided no query registers during that interval, finalizes the profile
- it dispatches the interaction-complete notification to its observers (`dashboard_view` event)
- `ReportRenderReadinessObserver` subscribes to that notification and unconditionally propagates it to the image renderer as `REPORT_RENDER_COMPLETE`

With repeats, this termination occurs prematurely. When a repeat variable query finishes, the running-query count briefly drops to 0 _before_ the repeated panel clones are created and register their own queries. But React still has to mount the (potentially large) list of repeated panel components into the DOM before any of their queries start, so the gap can exceed the Scenes profiler's 2 s post-storm window and the profiler concludes `dashboard_view` prematurely.

## Approach

Instead of forwarding the completion event immediately, the observer now holds a reference to the `DashboardScene` and verifies the scene graph has actually settled before sending `REPORT_RENDER_COMPLETE`:

1. No queries running (`window.__grafanaRunningQueryCount`).
2. Every repeater has finished its work: its variable is done loading, its clones are created, and, for row/tab repeats, React has mounted every clone.
3. Every `VizPanel` that is mounted or about to mount (active, or child of an active repeater, i.e. freshly created panel-repeat clones) has no loading variable dependency and resolved data (`Done` / `Error` / `Streaming`). Panels that will never mount, collapsed rows, inactive tabs are excluded so they cannot stall settlement.

If not settled, it polls every 500 ms, with a 20s cap as a safety valve so a stuck panel degrades to the old behavior (capture whatever has loaded).

## Key changes

1. `ReportRenderReadinessObserver.ts` contains the new settlement logic. Before reviewing, note:
   - Repeaters are detected by the shape of their state, not by importing `DashboardGridItem`, `RowItem`, etc. Runtime imports would create an import cycle with `dashboard-scene`. This covers the default grid, auto grid, and rows/tabs layouts.
   - Row/tab clone panels are invisible to the per-panel check until React mounts them, so the repeater stays pending until all clones are active.
   - `RowRepeaterBehavior` keeps its clone list private. We detect pending clones as inactive `SceneGridRow`s with `repeatSourceKey` under an active layout, then wait for those panels' data like any other panel.
   - Panels are collected with a full scene-graph walk (`sceneGraph.findAllObjects`) because `getVizPanels()` skips repeat clones.
   - A panel with `undefined` data counts as not settled. This is the state of a fresh, unmounted repeat clone, which is exactly the race being fixed.
   - The 20s max wait stays below the renderer's `--browser.readiness.timeout` (30 s by default). If we waited longer, the render would fail with a timeout instead of producing a best-effort report.
   - A loading variable only blocks panels that depend on it (`hasVariableDependencyInLoadingState`). Unrelated loading variables are ignored.
   - Repeaters that will never clone don't block the report: row/tab repeaters with a missing or non-multi-value variable are skipped.
2. New integration test `ReportRenderReadinessObserver.repeats.test.ts` reproduces the race end to end.

## How to test

Setup: a dashboard with a panel repeated by a multi-value variable (ideally a slow variable query and/or slow panel queries to widen the race window), rendering via grafana-image-renderer report/PDF generation.

- Generate a report for the repeat dashboard: all repeated panel instances show data (previously some could be blank).
- Repeat with rows/tabs repeats (auto grid and default grid layouts).
- Dashboard without repeats: report renders as before, no added delay beyond one settlement check.
- Stuck-panel edge case (e.g. a query that never resolves): the ready signal is sent after ~20 s and the report captures whatever has loaded, instead of the renderer timing out.
- Unit tests: `yarn test public/app/features/dashboard/services/ReportRenderReadinessObserver`

## Alternative fix

The root can also be addressed in `@grafana/scenes`. A proper fix (repeaters registering an entry with the query controller until their clones mount) would benefit all profiler consumers and let us simplify the polling added here. 

**See this [alternative draft PR](https://github.com/grafana/grafana/pull/129758).**


