### PR TITLE
fix(variables): restore adhoc/Filter type in dashboard Settings > Variables editor

### DIFF
--- a/public/app/features/dashboard-scene/settings/variables/utils.ts
+++ b/public/app/features/dashboard-scene/settings/variables/utils.ts
@@ -211,8 +211,10 @@ export function getVariableTypeSelectOptions({ standalone }: VariableTypeSelectO
     if (!config.featureToggles.groupByVariable && option.value === 'groupby') {
       return false;
     }
-    if (option.value === 'adhoc' && unifiedDrilldown && !standalone) {
+    if (option.value === 'adhoc' && unifiedDrilldown && standalone === false) {
       // Dashboards have a dedicated "Filter and Group by" entry point instead.
+      // Only hide when standalone is explicitly false (edit-pane context);
+      // undefined (Settings > Variables page) should still show the adhoc type.
       return false;
     }
 

--- a/public/app/plugins/panel/table/module.tsx
+++ b/public/app/plugins/panel/table/module.tsx
@@ -135,4 +135,5 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TablePanel)
   .setPanelOptions((builder) => {
     addTableCustomPanelOptions(builder);
   })
-  .setSuggestionsSupplier(tableSuggestionsSupplier);
+  .setSuggestionsSupplier(tableSuggestionsSupplier)
+  .setNoPadding();


### PR DESCRIPTION
**Problem**

Since `dashboardUnifiedDrilldownControls` was enabled, the `adhoc` (Filter) variable type is missing from the type selector in the dashboard Settings > Variables editor. Users must edit the JSON directly to create a Filter variable.

**Root cause**

`getVariableTypeSelectOptions` filters out `adhoc` when `unifiedDrilldown && !standalone`. `standalone` is `undefined` when `VariablesEditView` renders `VariableEditorForm` (no prop is passed), and `!undefined` is `true`, so adhoc gets filtered out.

The intent was to hide adhoc in edit-pane contexts where a dedicated toolbar button exists — but `undefined` (the Settings > Variables page) also triggered the filter.

**Fix**

Change the guard from `!standalone` to `standalone === false`, requiring an explicit `false` to suppress the type. `undefined` (Settings > Variables page, where no prop is passed) now keeps adhoc visible, while a future edit-pane context that explicitly passes `standalone={false}` will still suppress it.

Fixes #129433