### PR TITLE
Table: Fix sparkline threshold for type other

### DIFF
--- a/packages/grafana-ui/src/components/Table/Cells/SparklineCell.tsx
+++ b/packages/grafana-ui/src/components/Table/Cells/SparklineCell.tsx
@@ -78,8 +78,7 @@ export const SparklineCell = (props: TableCellProps) => {
 
   const config: FieldConfig<GraphFieldConfig> = {
     color: field.config.color,
-    // allValues sparklines are FieldType.other — nested frames never inherit parent thresholds
-    ...(field.config.thresholds ? { thresholds: field.config.thresholds } : undefined),
+    thresholds: field.config.thresholds,
     custom: {
       ...defaultSparklineCellConfig,
       ...cellOptions,

--- a/packages/grafana-ui/src/components/Table/Cells/SparklineCell.tsx
+++ b/packages/grafana-ui/src/components/Table/Cells/SparklineCell.tsx
@@ -78,6 +78,8 @@ export const SparklineCell = (props: TableCellProps) => {
 
   const config: FieldConfig<GraphFieldConfig> = {
     color: field.config.color,
+    // allValues sparklines are FieldType.other — nested frames never inherit parent thresholds
+    ...(field.config.thresholds ? { thresholds: field.config.thresholds } : undefined),
     custom: {
       ...defaultSparklineCellConfig,
       ...cellOptions,

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/SparklineCell.canvas.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/SparklineCell.canvas.test.tsx
@@ -138,6 +138,10 @@ describe('TableNG SparklineCell threshold wiring (canvas)', () => {
       sparklineField({
         custom: { cellOptions: { type: TableCellDisplayMode.Sparkline, gradientMode } },
         color: { mode: FieldColorModeId.ContinuousViridis },
+        thresholds: {
+          mode: ThresholdsMode.Absolute,
+          steps: [{ value: -Infinity, color: 'green' }],
+        },
       })
     );
 

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/SparklineCell.canvas.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/SparklineCell.canvas.test.tsx
@@ -22,14 +22,16 @@ import { SparklineCell } from './SparklineCell';
 const width = 300;
 const height = 25;
 
-const tsFrame = toDataFrame({
-  fields: [
-    { name: 'time', type: FieldType.time, values: [1000, 2000] },
-    { name: 'v', type: FieldType.number, values: [1, 99] },
-  ],
-});
+const getTsFrame = () =>
+  toDataFrame({
+    fields: [
+      { name: 'time', type: FieldType.time, values: [1000, 2000] },
+      { name: 'v', type: FieldType.number, values: [1, 99] },
+    ],
+  });
 
 function sparklineField(config: Field['config'], type: FieldType = FieldType.frame): Field {
+  const tsFrame = getTsFrame();
   const raw = toDataFrame({
     fields: [
       {
@@ -50,7 +52,7 @@ function sparklineField(config: Field['config'], type: FieldType = FieldType.fra
 }
 
 function renderSparklineCell(field: Field) {
-  return render(<SparklineCell field={field} rowIdx={0} theme={createTheme()} value={tsFrame} width={width} />);
+  return render(<SparklineCell field={field} rowIdx={0} theme={createTheme()} value={field.values[0]} width={width} />);
 }
 
 let uPlotInstance: InstanceType<typeof uPlot> | undefined;

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/SparklineCell.canvas.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/SparklineCell.canvas.test.tsx
@@ -29,12 +29,12 @@ const tsFrame = toDataFrame({
   ],
 });
 
-function sparklineField(config: Field['config']): Field {
+function sparklineField(config: Field['config'], type: FieldType = FieldType.frame): Field {
   const raw = toDataFrame({
     fields: [
       {
         name: 'trend',
-        type: FieldType.frame,
+        type,
         values: [tsFrame],
         config,
       },
@@ -103,6 +103,34 @@ describe('TableNG SparklineCell threshold wiring (canvas)', () => {
     );
 
     await assertCanvasOutput();
+  });
+
+  // Reduce allValues types the column as FieldType.other, so nested frames never inherit
+  // parent thresholds — SparklineCell must forward them for Scheme gradients.
+  it('renders scheme gradient for reduce/allValues FieldType.other sparklines', async () => {
+    expect(() =>
+      renderSparklineCell(
+        sparklineField(
+          {
+            custom: {
+              cellOptions: { type: TableCellDisplayMode.Sparkline, gradientMode: GraphGradientMode.Scheme },
+            },
+            color: { mode: FieldColorModeId.Thresholds },
+            thresholds: {
+              mode: ThresholdsMode.Absolute,
+              steps: [
+                { value: -Infinity, color: 'green' },
+                { value: 80, color: 'red' },
+              ],
+            },
+          },
+          FieldType.other
+        )
+      )
+    ).not.toThrow();
+
+    await waitFor(() => expect(uPlotInstance?.status).toBe(1));
+    await waitFor(() => expect(document.querySelector('.u-over')).toBeInTheDocument());
   });
 
   it.each(Object.values(GraphGradientMode))('renders %s gradient w/ continuous color mode', async (gradientMode) => {

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/SparklineCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/SparklineCell.tsx
@@ -72,6 +72,8 @@ export const SparklineCell = (props: SparklineCellProps) => {
 
   const config: FieldConfig<GraphFieldConfig> = {
     color: field.config.color,
+    // allValues sparklines are FieldType.other — nested frames never inherit parent thresholds
+    ...(field.config.thresholds ? { thresholds: field.config.thresholds } : undefined),
     custom: {
       ...defaultSparklineCellConfig,
       ...cellOptions,

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/SparklineCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/SparklineCell.tsx
@@ -72,8 +72,7 @@ export const SparklineCell = (props: SparklineCellProps) => {
 
   const config: FieldConfig<GraphFieldConfig> = {
     color: field.config.color,
-    // allValues sparklines are FieldType.other — nested frames never inherit parent thresholds
-    ...(field.config.thresholds ? { thresholds: field.config.thresholds } : undefined),
+    thresholds: field.config.thresholds,
     custom: {
       ...defaultSparklineCellConfig,
       ...cellOptions,


### PR DESCRIPTION
When a `Reduce` transformation is applied with calculations applied to `All values`, resulting in `FieldType.other`, sparkline was not able to inherit parent thresholds, so Scheme gradients threw “Missing thresholds required for color scheme gradients”.

To fix this, we forward parent thresholds into the sparkline config (legacy + TableNG).


Before:
<img width="2050" height="818" alt="Jul-30-2026 08-41-51" src="https://github.com/user-attachments/assets/8957b60d-9597-4735-9caf-78497146e181" />


After:
<img width="1308" height="994" alt="Jul-30-2026 08-34-52" src="https://github.com/user-attachments/assets/096c45fb-f437-49e0-8f3c-8f54e485bb96" />
