### PR TITLE
E2E Selectors: Add selectors for git-sync setup wizard and provisioned save flows

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -717,8 +717,14 @@ export const versionedComponents = {
         '11.1.0': 'data-testid Save as dashboard drawer button',
       },
       saveAsTitleInput: {
+        '13.2.0': 'data-testid Save dashboard title field',
         '11.1.0': 'Save dashboard title field',
       },
+    },
+  },
+  ProvisionedResourceForm: {
+    commentInput: {
+      '13.2.0': 'data-testid provisioned resource form comment input',
     },
   },
   Modal: {
@@ -1235,6 +1241,12 @@ export const versionedComponents = {
       },
       backToDashboardButton: {
         '11.1.0': 'data-testid Back to dashboard button',
+      },
+      saveAsCopyButton: {
+        '13.2.0': 'data-testid Save as copy button',
+      },
+      moreSaveOptionsButton: {
+        '13.2.0': 'data-testid More save options button',
       },
     },
   },

--- a/packages/grafana-e2e-selectors/src/selectors/pages.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/pages.ts
@@ -1165,6 +1165,46 @@ export const versionedPages = {
     },
   },
   Provisioning: {
+    repositoryTypeCard: {
+      '13.2.0': (type: string) => `data-testid Provisioning repository type card ${type}`,
+    },
+    ConnectionForm: {
+      titleInput: {
+        '13.2.0': 'data-testid Provisioning connection form title input',
+      },
+      descriptionInput: {
+        '13.2.0': 'data-testid Provisioning connection form description input',
+      },
+      serverUrlInput: {
+        '13.2.0': 'data-testid Provisioning connection form server url input',
+      },
+      appIdInput: {
+        '13.2.0': 'data-testid Provisioning connection form app id input',
+      },
+      installationIdInput: {
+        '13.2.0': 'data-testid Provisioning connection form installation id input',
+      },
+      privateKeyInput: {
+        '13.2.0': 'data-testid Provisioning connection form private key input',
+      },
+      submitButton: {
+        '13.2.0': 'data-testid Provisioning connection form submit button',
+      },
+    },
+    Wizard: {
+      repositoryUrlInput: {
+        '13.2.0': 'data-testid Provisioning wizard repository url input',
+      },
+      repositoryTitleInput: {
+        '13.2.0': 'data-testid Provisioning wizard repository title input',
+      },
+      nextButton: {
+        '13.2.0': 'data-testid Provisioning wizard next button',
+      },
+      previousButton: {
+        '13.2.0': 'data-testid Provisioning wizard previous button',
+      },
+    },
     RepositoryList: {
       viewLink: {
         '13.2.0': (name: string) => `data-testid Provisioning repository view link ${name}`,
@@ -1182,6 +1222,9 @@ export const versionedPages = {
       },
       pullStatusCard: {
         '13.2.0': 'data-testid Provisioning repository overview pull status card',
+      },
+      jobsCard: {
+        '13.2.0': 'data-testid Provisioning repository overview jobs card',
       },
     },
   },

--- a/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
+++ b/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
@@ -471,6 +471,7 @@ export function ToolbarActions({ dashboard }: Props) {
             onClick={() => {
               dashboard.openSaveDrawer({ saveAsCopy: true });
             }}
+            testId={selectors.components.NavToolbar.editDashboard.saveAsCopyButton}
           />
         </Menu>
       );
@@ -494,6 +495,7 @@ export function ToolbarActions({ dashboard }: Props) {
               icon="angle-down"
               variant={isDirty ? 'primary' : 'secondary'}
               size="sm"
+              data-testid={selectors.components.NavToolbar.editDashboard.moreSaveOptionsButton}
             />
           </Dropdown>
         </ButtonGroup>

--- a/public/app/features/dashboard-scene/scene/new-toolbar/actions/SaveDashboard.tsx
+++ b/public/app/features/dashboard-scene/scene/new-toolbar/actions/SaveDashboard.tsx
@@ -95,6 +95,7 @@ export const SaveDashboard = ({ dashboard }: ToolbarActionProps) => {
               label={t('dashboard.toolbar.new.save-dashboard-copy.label', 'Save as copy')}
               icon="copy"
               onClick={onSaveAsCopy}
+              testId={selectors.components.NavToolbar.editDashboard.saveAsCopyButton}
             />
             {isDashboardTemplatesFlagEnabled &&
               canManageDashboardTemplates() &&
@@ -119,6 +120,7 @@ export const SaveDashboard = ({ dashboard }: ToolbarActionProps) => {
           icon="angle-down"
           variant={isDirty ? 'primary' : 'secondary'}
           size={buttonSize}
+          data-testid={selectors.components.NavToolbar.editDashboard.moreSaveOptionsButton}
         />
       </Dropdown>
     </ButtonGroup>

--- a/public/app/features/provisioning/Job/RecentJobs.tsx
+++ b/public/app/features/provisioning/Job/RecentJobs.tsx
@@ -2,6 +2,7 @@ import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { useMemo, useRef } from 'react';
 
 import { intervalToAbbreviatedDurationString, type TraceKeyValuePair } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
 import { Badge, Box, Card, InteractiveTable, Spinner, Stack, Text } from '@grafana/ui';
 import { getErrorMessage } from 'app/api/clients/provisioning/utils/httpUtils';
@@ -267,7 +268,7 @@ export function RecentJobs({ repo }: Props) {
   };
 
   return (
-    <Card noMargin>
+    <Card noMargin data-testid={selectors.pages.Provisioning.RepositoryOverview.jobsCard}>
       <Card.Heading>
         <Trans i18nKey="provisioning.recent-jobs.jobs">Jobs</Trans>
       </Card.Heading>

--- a/public/app/features/provisioning/Shared/RepositoryTypeCards.tsx
+++ b/public/app/features/provisioning/Shared/RepositoryTypeCards.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/css';
 
 import { type GrafanaTheme2 } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { Trans } from '@grafana/i18n';
 import { Card, IconButton, Stack, Text, useStyles2 } from '@grafana/ui';
 import { useGetFrontendSettingsQuery } from 'app/api/clients/provisioning/v0alpha1';
@@ -38,6 +39,7 @@ export function RepositoryTypeCards({ disabled }: RepositoryTypeCardsProps) {
                 className={styles.card}
                 noMargin
                 disabled={disabled}
+                data-testid={selectors.pages.Provisioning.repositoryTypeCard(config.type)}
               >
                 <Card.Heading>
                   <Stack gap={2} alignItems="center">
@@ -81,6 +83,7 @@ export function RepositoryTypeCards({ disabled }: RepositoryTypeCardsProps) {
                 className={styles.card}
                 noMargin
                 disabled={disabled}
+                data-testid={selectors.pages.Provisioning.repositoryTypeCard(config.type)}
               >
                 <Card.Heading>
                   <Stack gap={2} alignItems="center">

--- a/public/app/features/provisioning/Wizard/BootstrapStep.tsx
+++ b/public/app/features/provisioning/Wizard/BootstrapStep.tsx
@@ -3,6 +3,7 @@ import { memo, useEffect } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 
 import { type GrafanaTheme2 } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { Box, Card, Field, Input, LoadingPlaceholder, Stack, Text, useStyles2 } from '@grafana/ui';
 import { type RepositoryViewList } from 'app/api/clients/provisioning/v0alpha1';
@@ -222,6 +223,7 @@ export const BootstrapStep = memo(function BootstrapStep({ settingsData, repoNam
           >
             <Input
               id="repository-title"
+              data-testid={selectors.pages.Provisioning.Wizard.repositoryTitleInput}
               {...register('repository.title', {
                 required: t('provisioning.bootstrap-step.error-field-required', 'This field is required.'),
               })}

--- a/public/app/features/provisioning/Wizard/components/RepositoryField.tsx
+++ b/public/app/features/provisioning/Wizard/components/RepositoryField.tsx
@@ -6,6 +6,7 @@ import {
   type GetConnectionRepositoriesApiResponse,
   useGetConnectionRepositoriesQuery,
 } from '@grafana/api-clients/rtkq/provisioning/v0alpha1';
+import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { Combobox, Field, Input } from '@grafana/ui';
 
@@ -79,6 +80,7 @@ export function RepositoryField({ isSelectedConnectionReady }: { isSelectedConne
           <>
             {isGitHubAppAuth ? (
               <Combobox
+                data-testid={selectors.pages.Provisioning.Wizard.repositoryUrlInput}
                 invalid={Boolean(errors?.repository?.url?.message || repositoriesError)}
                 onChange={(option) => onChange(option?.value || '')}
                 placeholder={gitFields.urlConfig.placeholder}
@@ -90,7 +92,13 @@ export function RepositoryField({ isSelectedConnectionReady }: { isSelectedConne
                 {...field}
               />
             ) : (
-              <Input {...field} id="repository-url" placeholder={gitFields.urlConfig.placeholder} onChange={onChange} />
+              <Input
+                {...field}
+                id="repository-url"
+                data-testid={selectors.pages.Provisioning.Wizard.repositoryUrlInput}
+                placeholder={gitFields.urlConfig.placeholder}
+                onChange={onChange}
+              />
             )}
           </>
         )}

--- a/public/app/features/provisioning/Wizard/components/WizardButtonBar.tsx
+++ b/public/app/features/provisioning/Wizard/components/WizardButtonBar.tsx
@@ -1,3 +1,4 @@
+import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { Button, Stack } from '@grafana/ui';
 
@@ -20,10 +21,19 @@ export function WizardButtonBar({
 }: WizardButtonBarProps) {
   return (
     <Stack gap={2} justifyContent="flex-end">
-      <Button variant="secondary" onClick={onPrevious} disabled={isPreviousDisabled}>
+      <Button
+        variant="secondary"
+        onClick={onPrevious}
+        disabled={isPreviousDisabled}
+        data-testid={selectors.pages.Provisioning.Wizard.previousButton}
+      >
         {previousText}
       </Button>
-      <Button type="submit" disabled={isNextDisabled || isSubmitting}>
+      <Button
+        type="submit"
+        disabled={isNextDisabled || isSubmitting}
+        data-testid={selectors.pages.Provisioning.Wizard.nextButton}
+      >
         {isSubmitting ? t('provisioning.wizard-content.button-submitting', 'Submitting...') : nextText}
       </Button>
     </Stack>

--- a/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.tsx
@@ -466,6 +466,7 @@ export function SaveProvisionedDashboardForm({
               >
                 <Input
                   id="dashboard-title"
+                  data-testid={selectors.components.Drawer.DashboardSaveDrawer.saveAsTitleInput}
                   {...register('title', {
                     required: t(
                       'dashboard-scene.save-provisioned-dashboard-form.title-required',

--- a/public/app/features/provisioning/components/Shared/GitHubConnectionFields.tsx
+++ b/public/app/features/provisioning/components/Shared/GitHubConnectionFields.tsx
@@ -1,6 +1,7 @@
 import { memo, useState } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 
+import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
 import { Button, Field, Input, SecretTextArea, Stack } from '@grafana/ui';
 
@@ -46,6 +47,7 @@ export const GitHubConnectionFields = memo<GitHubConnectionFieldsProps>(
         >
           <Input
             id="title"
+            data-testid={selectors.pages.Provisioning.ConnectionForm.titleInput}
             {...register('title', {
               required: requiredValidation,
             })}
@@ -65,6 +67,7 @@ export const GitHubConnectionFields = memo<GitHubConnectionFieldsProps>(
         >
           <Input
             id="description"
+            data-testid={selectors.pages.Provisioning.ConnectionForm.descriptionInput}
             {...register('description')}
             placeholder={t('provisioning.connection-form.placeholder-description', 'Optional description')}
           />
@@ -84,6 +87,7 @@ export const GitHubConnectionFields = memo<GitHubConnectionFieldsProps>(
           >
             <Input
               id="serverUrl"
+              data-testid={selectors.pages.Provisioning.ConnectionForm.serverUrlInput}
               {...register('serverUrl', {
                 required: requiredValidation,
               })}
@@ -103,6 +107,7 @@ export const GitHubConnectionFields = memo<GitHubConnectionFieldsProps>(
         >
           <Input
             id="appID"
+            data-testid={selectors.pages.Provisioning.ConnectionForm.appIdInput}
             {...register('appID', {
               required: requiredValidation,
             })}
@@ -123,6 +128,7 @@ export const GitHubConnectionFields = memo<GitHubConnectionFieldsProps>(
         >
           <Input
             id="installationID"
+            data-testid={selectors.pages.Provisioning.ConnectionForm.installationIdInput}
             {...register('installationID', {
               required: requiredValidation,
             })}
@@ -153,6 +159,7 @@ export const GitHubConnectionFields = memo<GitHubConnectionFieldsProps>(
               <SecretTextArea
                 {...field}
                 id="privateKey"
+                data-testid={selectors.pages.Provisioning.ConnectionForm.privateKeyInput}
                 invalid={!!errors.privateKey}
                 // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
                 placeholder="-----BEGIN RSA PRIVATE KEY-----..."
@@ -170,7 +177,11 @@ export const GitHubConnectionFields = memo<GitHubConnectionFieldsProps>(
 
         {onNewConnectionCreation && (
           <Stack>
-            <Button onClick={onNewConnectionCreation} disabled={isCreating}>
+            <Button
+              onClick={onNewConnectionCreation}
+              disabled={isCreating}
+              data-testid={selectors.pages.Provisioning.ConnectionForm.submitButton}
+            >
               {isCreating ? (
                 <Trans i18nKey="provisioning.connection-form.creating-connection-button">Creating connection...</Trans>
               ) : (

--- a/public/app/features/provisioning/components/Shared/ResourceEditFormSharedFields.tsx
+++ b/public/app/features/provisioning/components/Shared/ResourceEditFormSharedFields.tsx
@@ -2,6 +2,7 @@ import { skipToken } from '@reduxjs/toolkit/query/react';
 import { memo, useCallback } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 
+import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { Combobox, Field, Input, TextArea } from '@grafana/ui';
 import {
@@ -310,6 +311,7 @@ export const ResourceEditFormSharedFields = memo<DashboardEditFormSharedFieldsPr
             {lockComment ? (
               <TextArea
                 id="provisioned-resource-form-comment"
+                data-testid={selectors.components.ProvisionedResourceForm.commentInput}
                 value={commitMessage ?? ''}
                 readOnly
                 disabled={readOnly}
@@ -318,6 +320,7 @@ export const ResourceEditFormSharedFields = memo<DashboardEditFormSharedFieldsPr
             ) : (
               <TextArea
                 id="provisioned-resource-form-comment"
+                data-testid={selectors.components.ProvisionedResourceForm.commentInput}
                 {...register('comment')}
                 disabled={readOnly}
                 placeholder={t(


### PR DESCRIPTION
Part of #129672 (Group 4 — Provisioning). Pilot for the per-group waves.

Replaces weak Pathfinder guide selectors with versioned `@grafana/e2e-selectors` entries wired as `data-testid`, covering the `git-sync-setup` guide — 15 anchors via 16 new selector entries (new `pages.Provisioning` group: connection form, parameterized repository-type cards, wizard URL/title inputs, shared next/previous button) plus a `13.2.0` prefixed key on the existing `saveAsTitleInput` so it resolves as a data-testid match.

**Structure (2 commits, per the MT-compat guidance in the issue):**
1. `test(e2e-selectors)` — selector definitions only
2. `test(provisioning)` — JSX wiring (all under `public/app`)

Builds on the selectors merged in #129698 (repository cards, folder picker, modal close). No existing selector values modified or deleted. Verified with `yarn typecheck` and ESLint on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)