### PR TITLE
E2E Selectors: Add selectors for gauge effects editor switches

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -853,6 +853,17 @@ export const versionedComponents = {
       },
     },
   },
+  GaugeEffectsEditor: {
+    gradientSwitch: {
+      '13.2.0': 'data-testid Gauge effects editor gradient switch',
+    },
+    barGlowSwitch: {
+      '13.2.0': 'data-testid Gauge effects editor bar glow switch',
+    },
+    centerGlowSwitch: {
+      '13.2.0': 'data-testid Gauge effects editor center glow switch',
+    },
+  },
   PanelInspector: {
     Data: {
       content: {

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -779,6 +779,19 @@ export const versionedComponents = {
       '9.2.0': 'show measure tools',
     },
 
+    // [Gauge] Effects options
+    Gauge: {
+      gradientSwitch: {
+        '13.2.0': 'data-testid Gauge effects editor gradient switch',
+      },
+      barGlowSwitch: {
+        '13.2.0': 'data-testid Gauge effects editor bar glow switch',
+      },
+      centerGlowSwitch: {
+        '13.2.0': 'data-testid Gauge effects editor center glow switch',
+      },
+    },
+
     Outline: {
       section: {
         '12.0.0': 'data-testid Outline section',
@@ -851,17 +864,6 @@ export const versionedComponents = {
           '12.3.0': 'data-testid row title input',
         },
       },
-    },
-  },
-  GaugeEffectsEditor: {
-    gradientSwitch: {
-      '13.2.0': 'data-testid Gauge effects editor gradient switch',
-    },
-    barGlowSwitch: {
-      '13.2.0': 'data-testid Gauge effects editor bar glow switch',
-    },
-    centerGlowSwitch: {
-      '13.2.0': 'data-testid Gauge effects editor center glow switch',
     },
   },
   PanelInspector: {

--- a/public/app/plugins/panel/gauge/EffectsEditor.tsx
+++ b/public/app/plugins/panel/gauge/EffectsEditor.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/css';
 import { type ComponentProps, useId } from 'react';
 
 import { type GrafanaTheme2, type StandardEditorProps } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { Stack, Switch, Label, Tooltip, Grid, useStyles2 } from '@grafana/ui';
 
@@ -43,16 +44,19 @@ export function EffectsEditor(props: StandardEditorProps<GaugePanelEffects>) {
         label={t('gauge.config.effects.gradient', 'Gradient')}
         value={!!props.value?.gradient}
         onChange={(e) => props.onChange({ ...props.value, gradient: e.currentTarget.checked })}
+        data-testid={selectors.components.GaugeEffectsEditor.gradientSwitch}
       />
       <EffectsEditorInput
         label={t('gauge.config.effects.bar-glow', 'Bar glow')}
         value={!!props.value?.barGlow}
         onChange={(e) => props.onChange({ ...props.value, barGlow: e.currentTarget.checked })}
+        data-testid={selectors.components.GaugeEffectsEditor.barGlowSwitch}
       />
       <EffectsEditorInput
         label={t('gauge.config.effects.center-glow', 'Center glow')}
         value={!!props.value?.centerGlow}
         onChange={(e) => props.onChange({ ...props.value, centerGlow: e.currentTarget.checked })}
+        data-testid={selectors.components.GaugeEffectsEditor.centerGlowSwitch}
       />
     </Grid>
   );

--- a/public/app/plugins/panel/gauge/EffectsEditor.tsx
+++ b/public/app/plugins/panel/gauge/EffectsEditor.tsx
@@ -44,19 +44,19 @@ export function EffectsEditor(props: StandardEditorProps<GaugePanelEffects>) {
         label={t('gauge.config.effects.gradient', 'Gradient')}
         value={!!props.value?.gradient}
         onChange={(e) => props.onChange({ ...props.value, gradient: e.currentTarget.checked })}
-        data-testid={selectors.components.GaugeEffectsEditor.gradientSwitch}
+        data-testid={selectors.components.PanelEditor.Gauge.gradientSwitch}
       />
       <EffectsEditorInput
         label={t('gauge.config.effects.bar-glow', 'Bar glow')}
         value={!!props.value?.barGlow}
         onChange={(e) => props.onChange({ ...props.value, barGlow: e.currentTarget.checked })}
-        data-testid={selectors.components.GaugeEffectsEditor.barGlowSwitch}
+        data-testid={selectors.components.PanelEditor.Gauge.barGlowSwitch}
       />
       <EffectsEditorInput
         label={t('gauge.config.effects.center-glow', 'Center glow')}
         value={!!props.value?.centerGlow}
         onChange={(e) => props.onChange({ ...props.value, centerGlow: e.currentTarget.checked })}
-        data-testid={selectors.components.GaugeEffectsEditor.centerGlowSwitch}
+        data-testid={selectors.components.PanelEditor.Gauge.centerGlowSwitch}
       />
     </Grid>
   );


### PR DESCRIPTION
Part of #129672 (Group 1 — Shared UI, final slice).

Replaces a weak Pathfinder guide selector with versioned `@grafana/e2e-selectors` entries wired as `data-testid`, covering the gauge panel's effects editor switches (from the `grafana-13-tour-play`/`rca-demo` guide cluster).

**Structure (2 commits):**
1. `test(e2e-selectors)` — selector definitions only (`components.ts`, version key `13.2.0`)
2. `test(gauge)` — JSX wiring in `EffectsEditor.tsx` (under `public/app`)

No existing selector values modified or deleted. Verified with `yarn typecheck` and ESLint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)