### PR TITLE
CloudWatch: Forward per-datasource grafanaExternalId for Assume Role

### DIFF
--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -69,15 +69,17 @@ func (ds *DataSource) newAWSConfig(ctx context.Context, region string) (aws.Conf
 		region = ds.Settings.Region
 	}
 	authSettings := awsauth.Settings{
-		CredentialsProfile: ds.Settings.Profile,
-		LegacyAuthType:     ds.Settings.AuthType,
-		AssumeRoleARN:      ds.Settings.AssumeRoleARN,
-		ExternalID:         ds.Settings.ExternalID,
-		Endpoint:           ds.Settings.Endpoint,
-		Region:             region,
-		AccessKey:          ds.Settings.AccessKey,
-		SecretKey:          ds.Settings.SecretKey,
-		HTTPClient:         &http.Client{},
+		CredentialsProfile:         ds.Settings.Profile,
+		LegacyAuthType:             ds.Settings.AuthType,
+		AssumeRoleARN:              ds.Settings.AssumeRoleARN,
+		ExternalID:                 ds.Settings.ExternalID,
+		GrafanaExternalID:          ds.Settings.GrafanaExternalID,
+		UsePerDatasourceExternalID: ds.Settings.UsePerDatasourceExternalID,
+		Endpoint:                   ds.Settings.Endpoint,
+		Region:                     region,
+		AccessKey:                  ds.Settings.AccessKey,
+		SecretKey:                  ds.Settings.SecretKey,
+		HTTPClient:                 &http.Client{},
 	}
 	if ds.Settings.GrafanaSettings.SecureSocksDSProxyEnabled && ds.Settings.SecureSocksProxyEnabled {
 		authSettings.ProxyOptions = ds.ProxyOpts

--- a/pkg/tsdb/cloudwatch/cloudwatch_test.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch_test.go
@@ -223,6 +223,33 @@ func TestGetAWSConfig_passes_authSettings(t *testing.T) {
 	require.NoError(t, err)
 }
 
+type spyConfigProvider struct {
+	captured awsauth.Settings
+}
+
+func (s *spyConfigProvider) GetConfig(_ context.Context, settings awsauth.Settings) (aws.Config, error) {
+	s.captured = settings
+	return aws.Config{}, nil
+}
+
+func TestNewAWSConfig_passesGrafanaExternalIDFields(t *testing.T) {
+	spy := &spyConfigProvider{}
+	usePerDS := true
+	ds := newTestDatasource(func(ds *DataSource) {
+		ds.AWSConfigProvider = spy
+		ds.Settings.AuthType = awsds.AuthTypeGrafanaAssumeRole
+		ds.Settings.AssumeRoleARN = "arn:aws:iam::123456789012:role/test"
+		ds.Settings.GrafanaExternalID = "stackABC-dsUid1"
+		ds.Settings.UsePerDatasourceExternalID = &usePerDS
+	})
+
+	_, err := ds.newAWSConfig(context.Background(), "us-east-1")
+	require.NoError(t, err)
+	assert.Equal(t, "stackABC-dsUid1", spy.captured.GrafanaExternalID)
+	require.NotNil(t, spy.captured.UsePerDatasourceExternalID)
+	assert.True(t, *spy.captured.UsePerDatasourceExternalID)
+}
+
 func TestQuery_ResourceRequest_DescribeLogGroups_with_CrossAccountQuerying(t *testing.T) {
 	sender := &mockedCallResourceResponseSenderForOauth{}
 	origNewMetricsAPI := NewCWClient

--- a/pkg/tsdb/cloudwatch/external_id_test.go
+++ b/pkg/tsdb/cloudwatch/external_id_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func Test_external_id_route(t *testing.T) {
-	t.Run("successfully returns an external id from the instance", func(t *testing.T) {
+	t.Run("successfully returns stack external id for legacy datasources", func(t *testing.T) {
 		t.Setenv("AWS_AUTH_EXTERNAL_ID", "mock-external-id")
 		rr := httptest.NewRecorder()
 
@@ -23,6 +23,40 @@ func Test_external_id_route(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, rr.Code)
 		assert.JSONEq(t, `{"externalId":"mock-external-id"}`, rr.Body.String())
+	})
+
+	t.Run("returns stack external id even when per-datasource mode is enabled", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		usePerDS := true
+
+		ds := newTestDatasource(func(ds *DataSource) {
+			ds.Settings.GrafanaSettings.ExternalID = "stack-id"
+			ds.Settings.GrafanaExternalID = "stackABC-dsUid1"
+			ds.Settings.UsePerDatasourceExternalID = &usePerDS
+		})
+		handler := http.HandlerFunc(ds.resourceRequestMiddleware(ds.ExternalIdHandler))
+		req := httptest.NewRequest("GET", "/external-id", nil)
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.JSONEq(t, `{"externalId":"stack-id"}`, rr.Body.String())
+	})
+
+	t.Run("returns stack external id when bool unset even if per-DS ID is stored", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+
+		ds := newTestDatasource(func(ds *DataSource) {
+			ds.Settings.GrafanaSettings.ExternalID = "stack-id"
+			ds.Settings.GrafanaExternalID = "stackABC-dsUid1"
+		})
+		handler := http.HandlerFunc(ds.resourceRequestMiddleware(ds.ExternalIdHandler))
+		req := httptest.NewRequest("GET", "/external-id", nil)
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.JSONEq(t, `{"externalId":"stack-id"}`, rr.Body.String())
 	})
 
 	t.Run("returns an empty string if there is no external id", func(t *testing.T) {

--- a/pkg/tsdb/cloudwatch/resource_handler.go
+++ b/pkg/tsdb/cloudwatch/resource_handler.go
@@ -329,6 +329,8 @@ func (ds *DataSource) LogGroupFieldsHandler(ctx context.Context, parameters url.
 }
 
 func (ds *DataSource) ExternalIdHandler(_ context.Context, _ url.Values) ([]byte, *models.HttpError) {
+	// Always return the stack external ID. ConnectionConfig uses this as the mint/display
+	// base and chooses per-DS vs stack from jsonData (usePerDatasourceExternalId + grafanaExternalId).
 	response := map[string]string{
 		"externalId": ds.Settings.GrafanaSettings.ExternalID,
 	}


### PR DESCRIPTION
## Summary
- Port of [grafana-cloudwatch-datasource@4a7cb1b](https://github.com/grafana/grafana-cloudwatch-datasource/commit/4a7cb1b32485ffb9c7c88e134b4cfc942feb04b9) / [#582](https://github.com/grafana/grafana-cloudwatch-datasource/pull/582) into the monorepo CloudWatch backend.
- Forward `GrafanaExternalID` and `UsePerDatasourceExternalID` from datasource settings into `awsauth.Settings` so Grafana Assume Role STS can use the per-datasource external ID when enabled.
- Keep `/external-id` returning the stack external ID only (ConnectionConfig resolves per-DS vs stack from `jsonData`).

## Context
Monorepo already mints/preserves `jsonData.grafanaExternalId` (#128628) and has grafana-aws-sdk ≥ 1.5.1 for bool-gated resolution (#128886). This wires CloudWatch to actually pass those fields at assume-role time.

## Test plan
- [x] `go test -run 'TestNewAWSConfig_passesGrafanaExternalIDFields|Test_external_id_route' ./pkg/tsdb/cloudwatch/`
- [ ] With `awsAssumeRolePerDatasourceExternalId` enabled, create a CloudWatch DS with Grafana Assume Role and confirm STS uses `{stackId}-{dsUid}` when `usePerDatasourceExternalId` is true
- [ ] Confirm `/external-id` still returns the stack external ID (not the per-DS ID)
- [ ] With the flag unset/false, confirm stack external ID is still used for Assume Role even if a dormant per-DS ID is stored