### PR TITLE
Provisioning: (1/8) Add connection factory and test result helpers

### DIFF
--- a/apps/provisioning/pkg/connection/factory.go
+++ b/apps/provisioning/pkg/connection/factory.go
@@ -32,6 +32,16 @@ type factory struct {
 	enabled map[provisioning.ConnectionType]struct{}
 }
 
+// ToConnectionTypes maps the configured repository types to the connection
+// types they enable.
+func ToConnectionTypes(repositoryTypes []string) map[provisioning.ConnectionType]struct{} {
+	enabled := make(map[provisioning.ConnectionType]struct{}, len(repositoryTypes))
+	for _, t := range repositoryTypes {
+		enabled[provisioning.ConnectionType(t)] = struct{}{}
+	}
+	return enabled
+}
+
 func ProvideFactory(enabled map[provisioning.ConnectionType]struct{}, extras []Extra) (Factory, error) {
 	f := &factory{
 		enabled: enabled,

--- a/apps/provisioning/pkg/connection/github/connection.go
+++ b/apps/provisioning/pkg/connection/github/connection.go
@@ -112,21 +112,16 @@ func (c *Connection) Test(ctx context.Context) (*provisioning.TestResults, error
 		if err != nil {
 			// Error generating JWT token means the privateKey is not valid.
 			logger.Info("JWT token generation failed during connection test", "appID", c.cfg.AppID())
-			return &provisioning.TestResults{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: provisioning.APIVERSION,
-					Kind:       "TestResults",
-				},
-				Code:    http.StatusUnauthorized,
-				Success: false,
-				Errors: []provisioning.ErrorDetails{
+			return connection.FailedTestResults(
+				http.StatusUnauthorized,
+				[]provisioning.ErrorDetails{
 					{
 						Type:   metav1.CauseTypeFieldValueInvalid,
 						Field:  field.NewPath("secure", "privateKey").String(),
 						Detail: "invalid private key",
 					},
 				},
-			}, nil
+			), nil
 		}
 		c.obj.Secure.Token.Create = token
 		c.secrets.Token = token
@@ -136,32 +131,22 @@ func (c *Connection) Test(ctx context.Context) (*provisioning.TestResults, error
 		if err != nil {
 			// Error parsing JWT token means the given private key is invalid
 			logger.Info("JWT token parsing failed during connection test", "appID", c.cfg.AppID())
-			return &provisioning.TestResults{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: provisioning.APIVERSION,
-					Kind:       "TestResults",
-				},
-				Code:    http.StatusUnauthorized,
-				Success: false,
-				Errors: []provisioning.ErrorDetails{
+			return connection.FailedTestResults(
+				http.StatusUnauthorized,
+				[]provisioning.ErrorDetails{
 					{
 						Type:   metav1.CauseTypeFieldValueInvalid,
 						Field:  field.NewPath("secure", "privateKey").String(),
 						Detail: "invalid private key",
 					},
 				},
-			}, nil
+			), nil
 		}
 		if claims.Issuer != c.cfg.AppID() {
 			logger.Info("JWT issuer mismatch", "expected", c.cfg.AppID(), "got", claims.Issuer)
-			return &provisioning.TestResults{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: provisioning.APIVERSION,
-					Kind:       "TestResults",
-				},
-				Code:    http.StatusUnauthorized,
-				Success: false,
-				Errors: []provisioning.ErrorDetails{
+			return connection.FailedTestResults(
+				http.StatusUnauthorized,
+				[]provisioning.ErrorDetails{
 					{
 						Type:     metav1.CauseTypeFieldValueInvalid,
 						Field:    field.NewPath("spec", string(c.obj.Spec.Type), "appID").String(),
@@ -169,7 +154,7 @@ func (c *Connection) Test(ctx context.Context) (*provisioning.TestResults, error
 						BadValue: c.cfg.AppID(),
 					},
 				},
-			}, nil
+			), nil
 		}
 	}
 
@@ -187,14 +172,9 @@ func (c *Connection) Test(ctx context.Context) (*provisioning.TestResults, error
 		case errors.Is(err, ErrAuthentication):
 			// ErrAuthentication is returned when the underlying JWT is invalid.
 			// This means that appID and/or privateKey are not correct.
-			return &provisioning.TestResults{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: provisioning.APIVERSION,
-					Kind:       "TestResults",
-				},
-				Code:    http.StatusUnauthorized,
-				Success: false,
-				Errors: []provisioning.ErrorDetails{
+			return connection.FailedTestResults(
+				http.StatusUnauthorized,
+				[]provisioning.ErrorDetails{
 					{
 						Type:     metav1.CauseTypeFieldValueInvalid,
 						Field:    field.NewPath("spec", string(c.obj.Spec.Type), "appID").String(),
@@ -208,16 +188,11 @@ func (c *Connection) Test(ctx context.Context) (*provisioning.TestResults, error
 						BadValue: "****",
 					},
 				},
-			}, nil
+			), nil
 		case errors.Is(err, ErrNotFound):
-			return &provisioning.TestResults{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: provisioning.APIVERSION,
-					Kind:       "TestResults",
-				},
-				Code:    http.StatusNotFound,
-				Success: false,
-				Errors: []provisioning.ErrorDetails{
+			return connection.FailedTestResults(
+				http.StatusNotFound,
+				[]provisioning.ErrorDetails{
 					{
 						Type:     metav1.CauseTypeFieldValueNotFound,
 						Field:    field.NewPath("spec", string(c.obj.Spec.Type), "appID").String(),
@@ -225,51 +200,36 @@ func (c *Connection) Test(ctx context.Context) (*provisioning.TestResults, error
 						BadValue: c.cfg.AppID(),
 					},
 				},
-			}, nil
+			), nil
 		case errors.Is(err, ErrServiceUnavailable):
-			return &provisioning.TestResults{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: provisioning.APIVERSION,
-					Kind:       "TestResults",
-				},
-				Code:    http.StatusServiceUnavailable,
-				Success: false,
-				Errors: []provisioning.ErrorDetails{
+			return connection.FailedTestResults(
+				http.StatusServiceUnavailable,
+				[]provisioning.ErrorDetails{
 					{
 						Type:   metav1.CauseTypeInternal,
 						Detail: ErrServiceUnavailable.Error(),
 					},
 				},
-			}, nil
+			), nil
 		default:
 			// Generic error
-			return &provisioning.TestResults{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: provisioning.APIVERSION,
-					Kind:       "TestResults",
-				},
-				Code:    http.StatusUnprocessableEntity,
-				Success: false,
-				Errors: []provisioning.ErrorDetails{
+			return connection.FailedTestResults(
+				http.StatusUnprocessableEntity,
+				[]provisioning.ErrorDetails{
 					{
 						Type:   metav1.CauseTypeFieldValueInvalid,
 						Detail: fmt.Errorf("failed to GET app: %w", err).Error(),
 					},
 				},
-			}, nil
+			), nil
 		}
 	}
 
 	if fmt.Sprintf("%d", app.ID) != c.cfg.AppID() {
 		logger.Info("app ID mismatch", "expected", c.cfg.AppID(), "got", app.ID)
-		return &provisioning.TestResults{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: provisioning.APIVERSION,
-				Kind:       "TestResults",
-			},
-			Code:    http.StatusBadRequest,
-			Success: false,
-			Errors: []provisioning.ErrorDetails{
+		return connection.FailedTestResults(
+			http.StatusBadRequest,
+			[]provisioning.ErrorDetails{
 				{
 					Type:     metav1.CauseTypeFieldValueInvalid,
 					Field:    field.NewPath("spec", string(c.obj.Spec.Type), "appID").String(),
@@ -277,22 +237,14 @@ func (c *Connection) Test(ctx context.Context) (*provisioning.TestResults, error
 					BadValue: c.cfg.AppID(),
 				},
 			},
-		}, nil
+		), nil
 	}
 
 	// Validate the app's permissions.
 	permissionErrors := c.validatePermissions(permissionTargetApp, c.cfg.AppID(), app.Permissions)
 	if len(permissionErrors) > 0 {
 		logger.Info("GitHub App permission validation failed", "appID", c.cfg.AppID(), "errorCount", len(permissionErrors))
-		return &provisioning.TestResults{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: provisioning.APIVERSION,
-				Kind:       "TestResults",
-			},
-			Code:    http.StatusForbidden,
-			Success: false,
-			Errors:  permissionErrors,
-		}, nil
+		return connection.FailedTestResults(http.StatusForbidden, permissionErrors), nil
 	}
 
 	installation, err := ghClient.GetAppInstallation(ctx, c.cfg.InstallationID())
@@ -301,14 +253,9 @@ func (c *Connection) Test(ctx context.Context) (*provisioning.TestResults, error
 		// Check for specific error types
 		switch {
 		case errors.Is(err, ErrAuthentication):
-			return &provisioning.TestResults{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: provisioning.APIVERSION,
-					Kind:       "TestResults",
-				},
-				Code:    http.StatusUnauthorized,
-				Success: false,
-				Errors: []provisioning.ErrorDetails{
+			return connection.FailedTestResults(
+				http.StatusUnauthorized,
+				[]provisioning.ErrorDetails{
 					{
 						Type:     metav1.CauseTypeFieldValueInvalid,
 						Field:    field.NewPath("spec", string(c.obj.Spec.Type), "installationID").String(),
@@ -316,16 +263,11 @@ func (c *Connection) Test(ctx context.Context) (*provisioning.TestResults, error
 						BadValue: c.cfg.InstallationID(),
 					},
 				},
-			}, nil
+			), nil
 		case errors.Is(err, ErrNotFound):
-			return &provisioning.TestResults{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: provisioning.APIVERSION,
-					Kind:       "TestResults",
-				},
-				Code:    http.StatusNotFound,
-				Success: false,
-				Errors: []provisioning.ErrorDetails{
+			return connection.FailedTestResults(
+				http.StatusNotFound,
+				[]provisioning.ErrorDetails{
 					{
 						Type:     metav1.CauseTypeFieldValueInvalid,
 						Field:    field.NewPath("spec", string(c.obj.Spec.Type), "installationID").String(),
@@ -333,16 +275,11 @@ func (c *Connection) Test(ctx context.Context) (*provisioning.TestResults, error
 						BadValue: c.cfg.InstallationID(),
 					},
 				},
-			}, nil
+			), nil
 		case errors.Is(err, ErrServiceUnavailable):
-			return &provisioning.TestResults{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: provisioning.APIVERSION,
-					Kind:       "TestResults",
-				},
-				Code:    http.StatusServiceUnavailable,
-				Success: false,
-				Errors: []provisioning.ErrorDetails{
+			return connection.FailedTestResults(
+				http.StatusServiceUnavailable,
+				[]provisioning.ErrorDetails{
 					{
 						Type:     metav1.CauseTypeFieldValueInvalid,
 						Field:    field.NewPath("spec", string(c.obj.Spec.Type), "installationID").String(),
@@ -350,23 +287,18 @@ func (c *Connection) Test(ctx context.Context) (*provisioning.TestResults, error
 						BadValue: c.cfg.InstallationID(),
 					},
 				},
-			}, nil
+			), nil
 		default:
 			// Generic error
-			return &provisioning.TestResults{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: provisioning.APIVERSION,
-					Kind:       "TestResults",
-				},
-				Code:    http.StatusUnprocessableEntity,
-				Success: false,
-				Errors: []provisioning.ErrorDetails{
+			return connection.FailedTestResults(
+				http.StatusUnprocessableEntity,
+				[]provisioning.ErrorDetails{
 					{
 						Type:   metav1.CauseTypeFieldValueInvalid,
 						Detail: fmt.Errorf("failed to GET app installation: %w", err).Error(),
 					},
 				},
-			}, nil
+			), nil
 		}
 	}
 
@@ -375,25 +307,10 @@ func (c *Connection) Test(ctx context.Context) (*provisioning.TestResults, error
 	// permissions but the installation owner has not yet accepted them on GitHub.
 	installationPermErrors := c.validatePermissions(permissionTargetInstallation, c.cfg.InstallationID(), installation.Permissions)
 	if len(installationPermErrors) > 0 {
-		return &provisioning.TestResults{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: provisioning.APIVERSION,
-				Kind:       "TestResults",
-			},
-			Code:    http.StatusForbidden,
-			Success: false,
-			Errors:  installationPermErrors,
-		}, nil
+		return connection.FailedTestResults(http.StatusForbidden, installationPermErrors), nil
 	}
 
-	return &provisioning.TestResults{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: provisioning.APIVERSION,
-			Kind:       "TestResults",
-		},
-		Code:    http.StatusOK,
-		Success: true,
-	}, nil
+	return connection.SuccessTestResults(), nil
 }
 
 // GenerateRepositoryToken generates a repository-scoped access token.

--- a/apps/provisioning/pkg/connection/testresults.go
+++ b/apps/provisioning/pkg/connection/testresults.go
@@ -1,0 +1,34 @@
+package connection
+
+import (
+	"net/http"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+)
+
+// SuccessTestResults returns a successful TestResults.
+func SuccessTestResults() *provisioning.TestResults {
+	return &provisioning.TestResults{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: provisioning.APIVERSION,
+			Kind:       "TestResults",
+		},
+		Code:    http.StatusOK,
+		Success: true,
+	}
+}
+
+// FailedTestResults returns a failed TestResults with the given code and errors.
+func FailedTestResults(code int, errs []provisioning.ErrorDetails) *provisioning.TestResults {
+	return &provisioning.TestResults{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: provisioning.APIVERSION,
+			Kind:       "TestResults",
+		},
+		Code:    code,
+		Success: false,
+		Errors:  errs,
+	}
+}

--- a/pkg/registry/apis/provisioning/extras/register.go
+++ b/pkg/registry/apis/provisioning/extras/register.go
@@ -95,10 +95,6 @@ func ProvideConnectionFactoryFromConfig(cfg *setting.Cfg, extras []connection.Ex
 		// Enforcing default connection values if settings are not set
 		types = []string{"github"}
 	}
-	enabledTypes := make(map[apisprovisioning.ConnectionType]struct{}, len(types))
-	for _, e := range types {
-		enabledTypes[apisprovisioning.ConnectionType(e)] = struct{}{}
-	}
 
-	return connection.ProvideFactory(enabledTypes, extras)
+	return connection.ProvideFactory(connection.ToConnectionTypes(types), extras)
 }


### PR DESCRIPTION
**What is this feature?**

Adds two small helpers for provisioning connections: one that derives the enabled connection types from the configured repository types, and constructors for connection test results.

**Why do we need this feature?**

Groundwork for OAuth app connections. The rest of the stack uses these helpers.

**Who is this feature for?**

No user-facing change.

---

*PR description generated by Claude Code*