### PR TITLE
Provisioning: (6/8) Add GitHub OAuth app connections

### DIFF
--- a/apps/provisioning/kinds/connection.cue
+++ b/apps/provisioning/kinds/connection.cue
@@ -63,7 +63,7 @@ connection: {
 				}
 				spec: {
 					// The connection provider type
-					type: "github" | "githubEnterprise" | "bitbucket" | "gitlab"
+					type: "github" | "githubEnterprise" | "githubOAuth" | "bitbucket" | "gitlab"
 					// The connection URL.
 					url: *"" | string
 					// GitHub connection configuration.

--- a/apps/provisioning/kinds/connection.cue
+++ b/apps/provisioning/kinds/connection.cue
@@ -63,7 +63,7 @@ connection: {
 				}
 				spec: {
 					// The connection provider type
-					type: "github" | "githubEnterprise" | "bitbucketOAuth" | "gitlabOAuth"
+					type: "github" | "githubEnterprise" | "githubOAuth" | "bitbucketOAuth" | "gitlabOAuth"
 					// The connection URL.
 					url: *"" | string
 					// GitHub connection configuration.

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/connections.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/connections.go
@@ -117,6 +117,7 @@ func (ConnectionType) OpenAPIModelName() string {
 const (
 	GithubConnectionType           ConnectionType = "github"
 	GithubEnterpriseConnectionType ConnectionType = "githubEnterprise"
+	GithubOAuthConnectionType      ConnectionType = "githubOAuth"
 	GitlabConnectionType           ConnectionType = "gitlab"
 	BitbucketConnectionType        ConnectionType = "bitbucket"
 )

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/connections.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/connections.go
@@ -117,6 +117,7 @@ func (ConnectionType) OpenAPIModelName() string {
 const (
 	GithubConnectionType           ConnectionType = "github"
 	GithubEnterpriseConnectionType ConnectionType = "githubEnterprise"
+	GithubOAuthConnectionType      ConnectionType = "githubOAuth"
 	GitlabOAuthConnectionType      ConnectionType = "gitlabOAuth"
 	BitbucketOAuthConnectionType   ConnectionType = "bitbucketOAuth"
 )

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
@@ -601,11 +601,11 @@ func schema_pkg_apis_provisioning_v0alpha1_ConnectionSpec(ref common.ReferenceCa
 					},
 					"type": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The connection provider type\n\nPossible enum values:\n - `\"bitbucketOAuth\"`\n - `\"github\"`\n - `\"githubEnterprise\"`\n - `\"gitlabOAuth\"`",
+							Description: "The connection provider type\n\nPossible enum values:\n - `\"bitbucketOAuth\"`\n - `\"github\"`\n - `\"githubEnterprise\"`\n - `\"githubOAuth\"`\n - `\"gitlabOAuth\"`",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
-							Enum:        []interface{}{"bitbucketOAuth", "github", "githubEnterprise", "gitlabOAuth"},
+							Enum:        []interface{}{"bitbucketOAuth", "github", "githubEnterprise", "githubOAuth", "gitlabOAuth"},
 						},
 					},
 					"url": {
@@ -2956,7 +2956,7 @@ func schema_pkg_apis_provisioning_v0alpha1_RepositoryViewList(ref common.Referen
 										Default: "",
 										Type:    []string{"string"},
 										Format:  "",
-										Enum:    []interface{}{"bitbucketOAuth", "github", "githubEnterprise", "gitlabOAuth"},
+										Enum:    []interface{}{"bitbucketOAuth", "github", "githubEnterprise", "githubOAuth", "gitlabOAuth"},
 									},
 								},
 							},

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
@@ -601,11 +601,11 @@ func schema_pkg_apis_provisioning_v0alpha1_ConnectionSpec(ref common.ReferenceCa
 					},
 					"type": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The connection provider type\n\nPossible enum values:\n - `\"bitbucket\"`\n - `\"github\"`\n - `\"githubEnterprise\"`\n - `\"gitlab\"`",
+							Description: "The connection provider type\n\nPossible enum values:\n - `\"bitbucket\"`\n - `\"github\"`\n - `\"githubEnterprise\"`\n - `\"githubOAuth\"`\n - `\"gitlab\"`",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
-							Enum:        []interface{}{"bitbucket", "github", "githubEnterprise", "gitlab"},
+							Enum:        []interface{}{"bitbucket", "github", "githubEnterprise", "githubOAuth", "gitlab"},
 						},
 					},
 					"url": {

--- a/apps/provisioning/pkg/connection/factory.go
+++ b/apps/provisioning/pkg/connection/factory.go
@@ -33,11 +33,15 @@ type factory struct {
 }
 
 // ToConnectionTypes maps the configured repository types to the connection
-// types they enable.
+// types they enable. Connection types that serve another repository type
+// (githubOAuth serves github repositories) are enabled alongside it.
 func ToConnectionTypes(repositoryTypes []string) map[provisioning.ConnectionType]struct{} {
 	enabled := make(map[provisioning.ConnectionType]struct{}, len(repositoryTypes))
 	for _, t := range repositoryTypes {
 		enabled[provisioning.ConnectionType(t)] = struct{}{}
+	}
+	if _, ok := enabled[provisioning.GithubConnectionType]; ok {
+		enabled[provisioning.GithubOAuthConnectionType] = struct{}{}
 	}
 	return enabled
 }

--- a/apps/provisioning/pkg/connection/githuboauth/connection.go
+++ b/apps/provisioning/pkg/connection/githuboauth/connection.go
@@ -1,0 +1,45 @@
+package githuboauth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"golang.org/x/oauth2"
+	oauth2github "golang.org/x/oauth2/github"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/apps/provisioning/pkg/connection"
+	"github.com/grafana/grafana/apps/provisioning/pkg/connection/oauth"
+	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+	"github.com/grafana/grafana/apps/provisioning/pkg/repository/github"
+)
+
+// provider implements the GitHub-specific parts of an OAuth app connection.
+type provider struct {
+	httpClient *http.Client
+	client     github.Client
+}
+
+// HTTPClient returns the overriding HTTP client, if any. It exists primarily
+// for testing: the oauth exchange honors it in place of the default transport.
+func (p *provider) HTTPClient() *http.Client {
+	return p.httpClient
+}
+
+func (p *provider) Endpoint() oauth2.Endpoint {
+	return oauth2github.Endpoint
+}
+
+func (p *provider) ListRepositories(ctx context.Context) ([]provisioning.ExternalRepository, error) {
+	repos, err := p.client.ListRepositories(ctx)
+	if err != nil {
+		if errors.Is(err, repository.ErrUnauthorized) || errors.Is(err, repository.ErrPermissionDenied) {
+			return nil, connection.ErrAuthentication
+		}
+		return nil, err
+	}
+	return repos, nil
+}
+
+var _ oauth.Provider = (*provider)(nil)

--- a/apps/provisioning/pkg/connection/githuboauth/connection.go
+++ b/apps/provisioning/pkg/connection/githuboauth/connection.go
@@ -3,7 +3,6 @@ package githuboauth
 import (
 	"context"
 	"errors"
-	"net/http"
 
 	"golang.org/x/oauth2"
 	oauth2github "golang.org/x/oauth2/github"
@@ -17,14 +16,7 @@ import (
 
 // provider implements the GitHub-specific parts of an OAuth app connection.
 type provider struct {
-	httpClient *http.Client
-	client     github.Client
-}
-
-// HTTPClient returns the overriding HTTP client, if any. It exists primarily
-// for testing: the oauth exchange honors it in place of the default transport.
-func (p *provider) HTTPClient() *http.Client {
-	return p.httpClient
+	client github.Client
 }
 
 func (p *provider) Endpoint() oauth2.Endpoint {

--- a/apps/provisioning/pkg/connection/githuboauth/connection_test.go
+++ b/apps/provisioning/pkg/connection/githuboauth/connection_test.go
@@ -1,0 +1,62 @@
+package githuboauth
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	oauth2github "golang.org/x/oauth2/github"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/apps/provisioning/pkg/connection"
+	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+	"github.com/grafana/grafana/apps/provisioning/pkg/repository/github"
+)
+
+func TestProvider_ListRepositories(t *testing.T) {
+	repos := []provisioning.ExternalRepository{
+		{Name: "repo-one", Owner: "my-org", URL: "https://github.com/my-org/repo-one"},
+		{Name: "repo-two", Owner: "my-org", URL: "https://github.com/my-org/repo-two"},
+	}
+
+	client := github.NewMockClient(t)
+	client.EXPECT().ListRepositories(mock.Anything).Return(repos, nil)
+
+	p := &provider{client: client}
+	got, err := p.ListRepositories(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, repos, got)
+}
+
+func TestProvider_ListRepositories_Errors(t *testing.T) {
+	tests := []struct {
+		name      string
+		clientErr error
+		wantErr   error
+	}{
+		{name: "unauthorized maps to authentication error", clientErr: repository.ErrUnauthorized, wantErr: connection.ErrAuthentication},
+		{name: "permission denied maps to authentication error", clientErr: repository.ErrPermissionDenied, wantErr: connection.ErrAuthentication},
+		{name: "other errors are returned", clientErr: errors.New("boom")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := github.NewMockClient(t)
+			client.EXPECT().ListRepositories(mock.Anything).Return(nil, tt.clientErr)
+
+			p := &provider{client: client}
+			_, err := p.ListRepositories(t.Context())
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+			} else {
+				require.ErrorIs(t, err, tt.clientErr)
+			}
+		})
+	}
+}
+
+func TestProvider_Endpoint(t *testing.T) {
+	assert.Equal(t, oauth2github.Endpoint, (&provider{}).Endpoint())
+}

--- a/apps/provisioning/pkg/connection/githuboauth/extra.go
+++ b/apps/provisioning/pkg/connection/githuboauth/extra.go
@@ -1,0 +1,38 @@
+package githuboauth
+
+import (
+	"net/http"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/apps/provisioning/pkg/connection"
+	"github.com/grafana/grafana/apps/provisioning/pkg/connection/oauth"
+	"github.com/grafana/grafana/apps/provisioning/pkg/repository/github"
+	common "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
+)
+
+// Default holds the process-wide provider configuration. Client allows
+// overriding the HTTP client used for the token exchange and GitHub API
+// calls. It exists primarily for testing.
+var Default = struct {
+	Client *http.Client
+}{}
+
+func Extra(decrypter connection.Decrypter) connection.Extra {
+	return oauth.NewExtra(
+		decrypter,
+		provisioning.GithubOAuthConnectionType,
+		provisioning.GitHubRepositoryType,
+		newProvider,
+		nil,
+	)
+}
+
+func newProvider(_ provisioning.ConnectionSpec, accessToken string) (oauth.Provider, error) {
+	factory := github.ProvideFactory()
+	factory.Client = Default.Client
+	client, err := factory.New("", "", common.RawSecureValue(accessToken))
+	if err != nil {
+		return nil, err
+	}
+	return &provider{httpClient: Default.Client, client: client}, nil
+}

--- a/apps/provisioning/pkg/connection/githuboauth/extra.go
+++ b/apps/provisioning/pkg/connection/githuboauth/extra.go
@@ -1,8 +1,6 @@
 package githuboauth
 
 import (
-	"net/http"
-
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/connection"
 	"github.com/grafana/grafana/apps/provisioning/pkg/connection/oauth"
@@ -10,29 +8,22 @@ import (
 	common "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
 )
 
-// Default holds the process-wide provider configuration. Client allows
-// overriding the HTTP client used for the token exchange and GitHub API
-// calls. It exists primarily for testing.
-var Default = struct {
-	Client *http.Client
-}{}
-
-func Extra(decrypter connection.Decrypter) connection.Extra {
+func Extra(decrypter connection.Decrypter, factory *github.Factory) connection.Extra {
 	return oauth.NewExtra(
 		decrypter,
 		provisioning.GithubOAuthConnectionType,
 		provisioning.GitHubRepositoryType,
-		newProvider,
+		func(spec provisioning.ConnectionSpec, accessToken string) (oauth.Provider, error) {
+			return newProvider(factory, spec, accessToken)
+		},
 		nil,
 	)
 }
 
-func newProvider(_ provisioning.ConnectionSpec, accessToken string) (oauth.Provider, error) {
-	factory := github.ProvideFactory()
-	factory.Client = Default.Client
+func newProvider(factory *github.Factory, _ provisioning.ConnectionSpec, accessToken string) (oauth.Provider, error) {
 	client, err := factory.New("", "", common.RawSecureValue(accessToken))
 	if err != nil {
 		return nil, err
 	}
-	return &provider{httpClient: Default.Client, client: client}, nil
+	return &provider{client: client}, nil
 }

--- a/apps/provisioning/pkg/connection/oauth/connection.go
+++ b/apps/provisioning/pkg/connection/oauth/connection.go
@@ -161,6 +161,11 @@ func (c *oauthConnection) ExchangeAuthorizationCode(ctx context.Context, code, r
 		RedirectURL:  redirectURI,
 	}
 
+	// Providers can override the HTTP client used for the exchange (testing).
+	if hc, ok := c.provider.(interface{ HTTPClient() *http.Client }); ok && hc.HTTPClient() != nil {
+		ctx = context.WithValue(ctx, oauth2.HTTPClient, hc.HTTPClient())
+	}
+
 	token, err := cfg.Exchange(ctx, code)
 	if err != nil {
 		return "", fmt.Errorf("exchange authorization code: %w", err)

--- a/apps/provisioning/pkg/connection/oauth/connection.go
+++ b/apps/provisioning/pkg/connection/oauth/connection.go
@@ -161,11 +161,6 @@ func (c *oauthConnection) ExchangeAuthorizationCode(ctx context.Context, code, r
 		RedirectURL:  redirectURI,
 	}
 
-	// Providers can override the HTTP client used for the exchange (testing).
-	if hc, ok := c.provider.(interface{ HTTPClient() *http.Client }); ok && hc.HTTPClient() != nil {
-		ctx = context.WithValue(ctx, oauth2.HTTPClient, hc.HTTPClient())
-	}
-
 	token, err := cfg.Exchange(ctx, code)
 	if err != nil {
 		return "", fmt.Errorf("exchange authorization code: %w", err)

--- a/apps/provisioning/pkg/repository/github/client.go
+++ b/apps/provisioning/pkg/repository/github/client.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 )
 
@@ -17,6 +18,7 @@ type Client interface {
 
 	// Repositories
 	GetRepository(ctx context.Context) (Repository, error)
+	ListRepositories(ctx context.Context) ([]provisioning.ExternalRepository, error)
 
 	// Branch protection
 	GetBranchProtection(ctx context.Context, branch string) (*BranchProtection, error)

--- a/apps/provisioning/pkg/repository/github/factory.go
+++ b/apps/provisioning/pkg/repository/github/factory.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -64,7 +63,7 @@ func WithCustomServerURL(serverURL string) ClientOption {
 	}
 }
 
-func (r *Factory) New(ctx context.Context, owner, repo string, ghToken common.RawSecureValue, opts ...ClientOption) (Client, error) {
+func (r *Factory) New(owner, repo string, ghToken common.RawSecureValue, opts ...ClientOption) (Client, error) {
 	var options ClientOptions
 	for _, opt := range opts {
 		opt(&options)
@@ -76,10 +75,11 @@ func (r *Factory) New(ctx context.Context, owner, repo string, ghToken common.Ra
 
 	httpClient := &http.Client{}
 	if !ghToken.IsZero() {
-		tokenSrc := oauth2.StaticTokenSource(
-			&oauth2.Token{AccessToken: string(ghToken)},
-		)
-		httpClient = oauth2.NewClient(ctx, tokenSrc)
+		httpClient = &http.Client{
+			Transport: &oauth2.Transport{
+				Source: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: string(ghToken)}),
+			},
+		}
 	}
 
 	ghClient := github.NewClient(httpClient)

--- a/apps/provisioning/pkg/repository/github/factory.go
+++ b/apps/provisioning/pkg/repository/github/factory.go
@@ -69,16 +69,15 @@ func (r *Factory) New(owner, repo string, ghToken common.RawSecureValue, opts ..
 		opt(&options)
 	}
 
-	if r.Client != nil {
-		return NewClient(github.NewClient(r.Client), owner, repo), nil
-	}
-
 	httpClient := &http.Client{}
+	if r.Client != nil {
+		client := *r.Client
+		httpClient = &client
+	}
 	if !ghToken.IsZero() {
-		httpClient = &http.Client{
-			Transport: &oauth2.Transport{
-				Source: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: string(ghToken)}),
-			},
+		httpClient.Transport = &oauth2.Transport{
+			Source: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: string(ghToken)}),
+			Base:   httpClient.Transport,
 		}
 	}
 

--- a/apps/provisioning/pkg/repository/github/factory.go
+++ b/apps/provisioning/pkg/repository/github/factory.go
@@ -82,7 +82,7 @@ func (r *Factory) New(owner, repo string, ghToken common.RawSecureValue, opts ..
 	}
 
 	ghClient := github.NewClient(httpClient)
-	if options.customServerURL != "" {
+	if options.customServerURL != "" && r.Client == nil {
 		enterprise, err := ghClient.WithEnterpriseURLs(options.customServerURL, options.customServerURL)
 		if err != nil {
 			return nil, fmt.Errorf("failed to configure GitHub Enterprise URLs for %q: %w", options.customServerURL, err)

--- a/apps/provisioning/pkg/repository/github/impl.go
+++ b/apps/provisioning/pkg/repository/github/impl.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/go-github/v82/github"
 	"github.com/grafana/grafana-app-sdk/logging"
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	repo "github.com/grafana/grafana/apps/provisioning/pkg/repository"
 )
 
@@ -114,9 +115,10 @@ func formatGitHubErrorDetails(errs []github.Error) string {
 }
 
 const (
-	maxCommits  = 1000 // Maximum number of commits to fetch
-	maxWebhooks = 100  // Maximum number of webhooks allowed per repository
-	maxPRFiles  = 1000 // Maximum number of files allowed in a pull request
+	maxCommits      = 1000 // Maximum number of commits to fetch
+	maxWebhooks     = 100  // Maximum number of webhooks allowed per repository
+	maxPRFiles      = 1000 // Maximum number of files allowed in a pull request
+	maxRepositories = 1000 // Maximum number of repositories returned by a listing
 )
 
 func (r *githubClient) GetBranchProtection(ctx context.Context, branch string) (*BranchProtection, error) {
@@ -267,6 +269,41 @@ func (r *githubClient) GetRepository(ctx context.Context) (Repository, error) {
 		Name:          repo.GetName(),
 		DefaultBranch: repo.GetDefaultBranch(),
 	}, nil
+}
+
+// ListRepositories returns the repositories accessible to the authenticated
+// user, up to maxRepositories.
+func (r *githubClient) ListRepositories(ctx context.Context) ([]provisioning.ExternalRepository, error) {
+	opts := &github.RepositoryListByAuthenticatedUserOptions{
+		ListOptions: github.ListOptions{PerPage: 100},
+	}
+
+	var result []provisioning.ExternalRepository
+	for {
+		repos, resp, err := r.gh.Repositories.ListByAuthenticatedUser(ctx, opts)
+		if err != nil {
+			return nil, translateGitHubError(err)
+		}
+
+		for _, repo := range repos {
+			result = append(result, provisioning.ExternalRepository{
+				Name:  repo.GetName(),
+				Owner: repo.GetOwner().GetLogin(),
+				URL:   repo.GetHTMLURL(),
+			})
+		}
+
+		if len(result) >= maxRepositories {
+			return result[:maxRepositories], nil
+		}
+
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+
+	return result, nil
 }
 
 // Commits returns a list of commits for a given repository and branch.

--- a/apps/provisioning/pkg/repository/github/impl_test.go
+++ b/apps/provisioning/pkg/repository/github/impl_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	repo "github.com/grafana/grafana/apps/provisioning/pkg/repository"
 )
 
@@ -342,7 +343,7 @@ func TestGithubClient_GetCommits(t *testing.T) {
 			// Create a mock client
 			factory := ProvideFactory()
 			factory.Client = tt.mockHandler
-			client, err := factory.New(t.Context(), tt.owner, tt.repository, "")
+			client, err := factory.New(tt.owner, tt.repository, "")
 			assert.NoError(t, err)
 
 			// Call the method being tested
@@ -577,7 +578,7 @@ func TestGithubClient_CreateWebhook(t *testing.T) {
 			// Create a mock client
 			factory := ProvideFactory()
 			factory.Client = tt.mockHandler
-			client, err := factory.New(t.Context(), tt.owner, tt.repository, "")
+			client, err := factory.New(tt.owner, tt.repository, "")
 			assert.NoError(t, err)
 
 			// Call the method being tested
@@ -750,7 +751,7 @@ func TestGithubClient_GetWebhook(t *testing.T) {
 			// Create a mock client
 			factory := ProvideFactory()
 			factory.Client = tt.mockHandler
-			client, err := factory.New(t.Context(), tt.owner, tt.repository, "")
+			client, err := factory.New(tt.owner, tt.repository, "")
 			assert.NoError(t, err)
 
 			// Call the method being tested
@@ -889,7 +890,7 @@ func TestGithubClient_DeleteWebhook(t *testing.T) {
 			// Create a mock client
 			factory := ProvideFactory()
 			factory.Client = tt.mockHandler
-			client, err := factory.New(t.Context(), tt.owner, tt.repository, "")
+			client, err := factory.New(tt.owner, tt.repository, "")
 			assert.NoError(t, err)
 
 			// Call the method being tested
@@ -1079,7 +1080,7 @@ func TestGithubClient_EditWebhook(t *testing.T) {
 			// Create a mock client
 			factory := ProvideFactory()
 			factory.Client = tt.mockHandler
-			client, err := factory.New(t.Context(), tt.owner, tt.repository, "")
+			client, err := factory.New(tt.owner, tt.repository, "")
 			assert.NoError(t, err)
 
 			// Call the method being tested
@@ -1259,7 +1260,7 @@ func TestGithubClient_ListPullRequestFiles(t *testing.T) {
 			// Create a mock client
 			factory := ProvideFactory()
 			factory.Client = tt.mockHandler
-			client, err := factory.New(t.Context(), tt.owner, tt.repository, "")
+			client, err := factory.New(tt.owner, tt.repository, "")
 			assert.NoError(t, err)
 
 			// Call the method being tested
@@ -1379,7 +1380,7 @@ func TestCreatePullRequestComment(t *testing.T) {
 			// Create a mock client
 			factory := ProvideFactory()
 			factory.Client = tt.mockHandler
-			client, err := factory.New(t.Context(), tt.owner, tt.repository, "")
+			client, err := factory.New(tt.owner, tt.repository, "")
 			assert.NoError(t, err)
 
 			// Call the method being tested
@@ -2477,7 +2478,7 @@ func TestGithubClient_GetRepository(t *testing.T) {
 			// Create a mock client
 			factory := ProvideFactory()
 			factory.Client = tt.mockHandler
-			client, err := factory.New(t.Context(), tt.owner, tt.repository, "")
+			client, err := factory.New(tt.owner, tt.repository, "")
 			assert.NoError(t, err)
 
 			// Call the method being tested
@@ -2581,7 +2582,7 @@ func TestGithubClient_MergeBase(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			factory := ProvideFactory()
 			factory.Client = tt.mockHandler
-			client, err := factory.New(t.Context(), "test-owner", "test-repo", "")
+			client, err := factory.New("test-owner", "test-repo", "")
 			require.NoError(t, err)
 
 			sha, err := client.MergeBase(t.Context(), "main", "feature")
@@ -2598,6 +2599,83 @@ func TestGithubClient_MergeBase(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.wantSHA, sha)
 			}
+		})
+	}
+}
+
+func TestGithubClient_ListRepositories(t *testing.T) {
+	mockHandler := mockhub.NewMockedHTTPClient(
+		mockhub.WithRequestMatchPages(
+			mockhub.GetUserRepos,
+			[]*github.Repository{
+				{Name: new("repo-one"), HTMLURL: new("https://github.com/my-org/repo-one"), Owner: &github.User{Login: new("my-org")}},
+			},
+			[]*github.Repository{
+				{Name: new("repo-two"), HTMLURL: new("https://github.com/my-org/repo-two"), Owner: &github.User{Login: new("my-org")}},
+			},
+		),
+	)
+
+	factory := ProvideFactory()
+	factory.Client = mockHandler
+	client, err := factory.New("", "", "")
+	require.NoError(t, err)
+
+	repos, err := client.ListRepositories(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, []provisioning.ExternalRepository{
+		{Name: "repo-one", Owner: "my-org", URL: "https://github.com/my-org/repo-one"},
+		{Name: "repo-two", Owner: "my-org", URL: "https://github.com/my-org/repo-two"},
+	}, repos)
+}
+
+func TestGithubClient_ListRepositories_Errors(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  int
+		wantErr error
+	}{
+		{name: "unauthorized", status: http.StatusUnauthorized, wantErr: repo.ErrUnauthorized},
+		{name: "permission denied", status: http.StatusForbidden, wantErr: repo.ErrPermissionDenied},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockHandler := mockhub.NewMockedHTTPClient(
+				mockhub.WithRequestMatchHandler(
+					mockhub.GetUserRepos,
+					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						mockhub.WriteError(w, tt.status, "nope")
+					}),
+				),
+			)
+
+			factory := ProvideFactory()
+			factory.Client = mockHandler
+			client, err := factory.New("", "", "")
+			require.NoError(t, err)
+
+			_, err = client.ListRepositories(t.Context())
+			assert.ErrorIs(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestGithubClient_ListRepositories_ContextCancelled(t *testing.T) {
+	tests := map[string][]ClientOption{
+		"github":            nil,
+		"github enterprise": {WithCustomServerURL("https://ghes.example.com")},
+	}
+	for name, opts := range tests {
+		t.Run(name, func(t *testing.T) {
+			client, err := ProvideFactory().New("", "", "test-token", opts...)
+			require.NoError(t, err)
+
+			ctx, cancel := context.WithCancel(t.Context())
+			cancel()
+
+			_, err = client.ListRepositories(ctx)
+			require.ErrorIs(t, err, context.Canceled)
 		})
 	}
 }

--- a/apps/provisioning/pkg/repository/github/impl_test.go
+++ b/apps/provisioning/pkg/repository/github/impl_test.go
@@ -2629,6 +2629,26 @@ func TestGithubClient_ListRepositories(t *testing.T) {
 	}, repos)
 }
 
+func TestGithubClient_ListRepositories_CustomClientUsesToken(t *testing.T) {
+	mockHandler := mockhub.NewMockedHTTPClient(
+		mockhub.WithRequestMatchHandler(
+			mockhub.GetUserRepos,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+				_ = json.NewEncoder(w).Encode([]*github.Repository{})
+			}),
+		),
+	)
+
+	factory := ProvideFactory()
+	factory.Client = mockHandler
+	client, err := factory.New("", "", "test-token")
+	require.NoError(t, err)
+
+	_, err = client.ListRepositories(t.Context())
+	require.NoError(t, err)
+}
+
 func TestGithubClient_ListRepositories_Errors(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/apps/provisioning/pkg/repository/github/mock_client.go
+++ b/apps/provisioning/pkg/repository/github/mock_client.go
@@ -5,6 +5,7 @@ package github
 import (
 	context "context"
 
+	v0alpha1 "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	repository "github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -573,6 +574,64 @@ func (_c *MockClient_ListPullRequestFiles_Call) Return(_a0 []CommitFile, _a1 err
 }
 
 func (_c *MockClient_ListPullRequestFiles_Call) RunAndReturn(run func(context.Context, int) ([]CommitFile, error)) *MockClient_ListPullRequestFiles_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListRepositories provides a mock function with given fields: ctx
+func (_m *MockClient) ListRepositories(ctx context.Context) ([]v0alpha1.ExternalRepository, error) {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListRepositories")
+	}
+
+	var r0 []v0alpha1.ExternalRepository
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) ([]v0alpha1.ExternalRepository, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) []v0alpha1.ExternalRepository); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]v0alpha1.ExternalRepository)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClient_ListRepositories_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListRepositories'
+type MockClient_ListRepositories_Call struct {
+	*mock.Call
+}
+
+// ListRepositories is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *MockClient_Expecter) ListRepositories(ctx interface{}) *MockClient_ListRepositories_Call {
+	return &MockClient_ListRepositories_Call{Call: _e.mock.On("ListRepositories", ctx)}
+}
+
+func (_c *MockClient_ListRepositories_Call) Run(run func(ctx context.Context)) *MockClient_ListRepositories_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *MockClient_ListRepositories_Call) Return(_a0 []v0alpha1.ExternalRepository, _a1 error) *MockClient_ListRepositories_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClient_ListRepositories_Call) RunAndReturn(run func(context.Context) ([]v0alpha1.ExternalRepository, error)) *MockClient_ListRepositories_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/apps/provisioning/pkg/repository/github/repository.go
+++ b/apps/provisioning/pkg/repository/github/repository.go
@@ -68,7 +68,7 @@ func newRepository(
 		return nil, fmt.Errorf("parse owner and repo: %w", err)
 	}
 
-	ghClient, err := factory.New(ctx, owner, repo, token, opts...)
+	ghClient, err := factory.New(owner, repo, token, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("create github client: %w", err)
 	}

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2611,7 +2611,7 @@ repository_types =
 
 # List of enabled connection types, separated by |.
 # When empty, defaults are applied by each subsystem.
-# Supported types: github.
+# Supported types: github and githubOAuth.
 # Grafana Enterprise additionally supports githubEnterprise, bitbucketOAuth, and gitlabOAuth.
 connection_types =
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2916,7 +2916,7 @@ Supported types: `local`, `git`, `github`. Grafana Enterprise additionally suppo
 
 List of enabled connection types, separated by `|`. When empty, defaults are applied by each subsystem.
 
-Supported types: `github`. Grafana Enterprise additionally supports `githubEnterprise`, `bitbucketOAuth`, and `gitlabOAuth`.
+Supported types: `github` and `githubOAuth`. Grafana Enterprise additionally supports `githubEnterprise`, `bitbucketOAuth`, and `gitlabOAuth`.
 
 #### `max_repositories`
 

--- a/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
@@ -1517,8 +1517,9 @@ export type ConnectionSpec = {
      - `"bitbucket"`
      - `"github"`
      - `"githubEnterprise"`
+     - `"githubOAuth"`
      - `"gitlab"` */
-  type: 'bitbucket' | 'github' | 'githubEnterprise' | 'gitlab';
+  type: 'bitbucket' | 'github' | 'githubEnterprise' | 'githubOAuth' | 'gitlab';
   /** The connection URL */
   url?: string;
   /** Webhook configuration for this connection */

--- a/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
@@ -1517,8 +1517,9 @@ export type ConnectionSpec = {
      - `"bitbucketOAuth"`
      - `"github"`
      - `"githubEnterprise"`
+     - `"githubOAuth"`
      - `"gitlabOAuth"` */
-  type: 'bitbucketOAuth' | 'github' | 'githubEnterprise' | 'gitlabOAuth';
+  type: 'bitbucketOAuth' | 'github' | 'githubEnterprise' | 'githubOAuth' | 'gitlabOAuth';
   /** The connection URL */
   url?: string;
   /** Webhook configuration for this connection */
@@ -2291,7 +2292,7 @@ export type RepositoryViewList = {
   /** APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources */
   apiVersion?: string;
   /** AvailableConnectionTypes is the list of connection types supported in this instance */
-  availableConnectionTypes?: ('bitbucketOAuth' | 'github' | 'githubEnterprise' | 'gitlabOAuth')[];
+  availableConnectionTypes?: ('bitbucketOAuth' | 'github' | 'githubEnterprise' | 'githubOAuth' | 'gitlabOAuth')[];
   /** AvailableRepositoryTypes is the list of repository types supported in this instance (e.g. git, bitbucket, github, etc) */
   availableRepositoryTypes?: ('bitbucket' | 'git' | 'github' | 'githubEnterprise' | 'gitlab' | 'local')[];
   /** AvailableResources is the list of resource types declared for provisioning in this instance, including disabled ones (see SupportedResource.Disabled). */

--- a/packages/grafana-openapi/src/apis/provisioning.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/provisioning.grafana.app-v0alpha1.json
@@ -4127,10 +4127,10 @@
             "default": ""
           },
           "type": {
-            "description": "The connection provider type\n\nPossible enum values:\n - `\"bitbucket\"`\n - `\"github\"`\n - `\"githubEnterprise\"`\n - `\"gitlab\"`",
+            "description": "The connection provider type\n\nPossible enum values:\n - `\"bitbucket\"`\n - `\"github\"`\n - `\"githubEnterprise\"`\n - `\"githubOAuth\"`\n - `\"gitlab\"`",
             "type": "string",
             "default": "",
-            "enum": ["bitbucket", "github", "githubEnterprise", "gitlab"]
+            "enum": ["bitbucket", "github", "githubEnterprise", "githubOAuth", "gitlab"]
           },
           "url": {
             "description": "The connection URL",

--- a/packages/grafana-openapi/src/apis/provisioning.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/provisioning.grafana.app-v0alpha1.json
@@ -4127,10 +4127,10 @@
             "default": ""
           },
           "type": {
-            "description": "The connection provider type\n\nPossible enum values:\n - `\"bitbucketOAuth\"`\n - `\"github\"`\n - `\"githubEnterprise\"`\n - `\"gitlabOAuth\"`",
+            "description": "The connection provider type\n\nPossible enum values:\n - `\"bitbucketOAuth\"`\n - `\"github\"`\n - `\"githubEnterprise\"`\n - `\"githubOAuth\"`\n - `\"gitlabOAuth\"`",
             "type": "string",
             "default": "",
-            "enum": ["bitbucketOAuth", "github", "githubEnterprise", "gitlabOAuth"]
+            "enum": ["bitbucketOAuth", "github", "githubEnterprise", "githubOAuth", "gitlabOAuth"]
           },
           "url": {
             "description": "The connection URL",
@@ -5692,7 +5692,7 @@
             "items": {
               "type": "string",
               "default": "",
-              "enum": ["bitbucketOAuth", "github", "githubEnterprise", "gitlabOAuth"]
+              "enum": ["bitbucketOAuth", "github", "githubEnterprise", "githubOAuth", "gitlabOAuth"]
             }
           },
           "availableRepositoryTypes": {

--- a/packages/grafana-openapi/src/apis/provisioning.grafana.app-v1beta1.json
+++ b/packages/grafana-openapi/src/apis/provisioning.grafana.app-v1beta1.json
@@ -4040,10 +4040,10 @@
             "default": ""
           },
           "type": {
-            "description": "The connection provider type\n\nPossible enum values:\n - `\"bitbucket\"`\n - `\"github\"`\n - `\"githubEnterprise\"`\n - `\"gitlab\"`",
+            "description": "The connection provider type\n\nPossible enum values:\n - `\"bitbucket\"`\n - `\"github\"`\n - `\"githubEnterprise\"`\n - `\"githubOAuth\"`\n - `\"gitlab\"`",
             "type": "string",
             "default": "",
-            "enum": ["bitbucket", "github", "githubEnterprise", "gitlab"]
+            "enum": ["bitbucket", "github", "githubEnterprise", "githubOAuth", "gitlab"]
           },
           "url": {
             "description": "The connection URL",

--- a/packages/grafana-openapi/src/apis/provisioning.grafana.app-v1beta1.json
+++ b/packages/grafana-openapi/src/apis/provisioning.grafana.app-v1beta1.json
@@ -4040,10 +4040,10 @@
             "default": ""
           },
           "type": {
-            "description": "The connection provider type\n\nPossible enum values:\n - `\"bitbucketOAuth\"`\n - `\"github\"`\n - `\"githubEnterprise\"`\n - `\"gitlabOAuth\"`",
+            "description": "The connection provider type\n\nPossible enum values:\n - `\"bitbucketOAuth\"`\n - `\"github\"`\n - `\"githubEnterprise\"`\n - `\"githubOAuth\"`\n - `\"gitlabOAuth\"`",
             "type": "string",
             "default": "",
-            "enum": ["bitbucketOAuth", "github", "githubEnterprise", "gitlabOAuth"]
+            "enum": ["bitbucketOAuth", "github", "githubEnterprise", "githubOAuth", "gitlabOAuth"]
           },
           "url": {
             "description": "The connection URL",
@@ -5278,7 +5278,7 @@
             "items": {
               "type": "string",
               "default": "",
-              "enum": ["bitbucketOAuth", "github", "githubEnterprise", "gitlabOAuth"]
+              "enum": ["bitbucketOAuth", "github", "githubEnterprise", "githubOAuth", "gitlabOAuth"]
             }
           },
           "availableRepositoryTypes": {

--- a/pkg/extensions/enterprise_imports.go
+++ b/pkg/extensions/enterprise_imports.go
@@ -118,6 +118,7 @@ import (
 	_ "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	_ "github.com/grafana/grafana/apps/provisioning/pkg/connection"
 	_ "github.com/grafana/grafana/apps/provisioning/pkg/connection/github"
+	_ "github.com/grafana/grafana/apps/provisioning/pkg/connection/githuboauth"
 	_ "github.com/grafana/grafana/apps/provisioning/pkg/connection/oauth"
 	_ "github.com/grafana/grafana/apps/provisioning/pkg/quotas"
 	_ "github.com/grafana/grafana/apps/provisioning/pkg/repository"

--- a/pkg/extensions/enterprise_imports.go
+++ b/pkg/extensions/enterprise_imports.go
@@ -126,6 +126,7 @@ import (
 	_ "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	_ "github.com/grafana/grafana/apps/provisioning/pkg/connection"
 	_ "github.com/grafana/grafana/apps/provisioning/pkg/connection/github"
+	_ "github.com/grafana/grafana/apps/provisioning/pkg/connection/githuboauth"
 	_ "github.com/grafana/grafana/apps/provisioning/pkg/connection/oauth"
 	_ "github.com/grafana/grafana/apps/provisioning/pkg/quotas"
 	_ "github.com/grafana/grafana/apps/provisioning/pkg/repository"

--- a/pkg/operators/provisioning/config.go
+++ b/pkg/operators/provisioning/config.go
@@ -26,6 +26,7 @@ import (
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/connection"
 	githubconnection "github.com/grafana/grafana/apps/provisioning/pkg/connection/github"
+	"github.com/grafana/grafana/apps/provisioning/pkg/connection/githuboauth"
 	client "github.com/grafana/grafana/apps/provisioning/pkg/generated/clientset/versioned"
 	"github.com/grafana/grafana/apps/provisioning/pkg/quotas"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
@@ -655,6 +656,7 @@ func (c *ControllerConfig) ConnectionExtras() ([]connection.Extra, error) {
 
 	extras := []connection.Extra{
 		githubconnection.Extra(decrypter, githubconnection.ProvideFactory()),
+		githuboauth.Extra(decrypter),
 	}
 
 	c.connectionExtras = extras

--- a/pkg/operators/provisioning/config.go
+++ b/pkg/operators/provisioning/config.go
@@ -656,7 +656,7 @@ func (c *ControllerConfig) ConnectionExtras() ([]connection.Extra, error) {
 
 	extras := []connection.Extra{
 		githubconnection.Extra(decrypter, githubconnection.ProvideFactory()),
-		githuboauth.Extra(decrypter),
+		githuboauth.Extra(decrypter, githubrepo.ProvideFactory()),
 	}
 
 	c.connectionExtras = extras

--- a/pkg/operators/provisioning/config_test.go
+++ b/pkg/operators/provisioning/config_test.go
@@ -13,6 +13,7 @@ func TestDefaultConnectionTypes(t *testing.T) {
 	registeredTypes := []apisprovisioning.ConnectionType{
 		apisprovisioning.GithubConnectionType,
 		apisprovisioning.GithubEnterpriseConnectionType,
+		apisprovisioning.GithubOAuthConnectionType,
 		apisprovisioning.BitbucketOAuthConnectionType,
 		apisprovisioning.GitlabOAuthConnectionType,
 	}

--- a/pkg/registry/apis/provisioning/controller/webhook_integration_test.go
+++ b/pkg/registry/apis/provisioning/controller/webhook_integration_test.go
@@ -157,7 +157,7 @@ func TestIntegrationWebhookController_ReconcileLifecycle(t *testing.T) {
 	// paths match mockhub's matchers). It satisfies repository.WebhookClient.
 	factory := githubrepo.ProvideFactory()
 	factory.Client = mockHandler
-	ghClient, err := factory.New(context.Background(), owner, repoName, "")
+	ghClient, err := factory.New(owner, repoName, "")
 	require.NoError(t, err)
 
 	// A repo whose spec enables a workflow so the hooks actually register a webhook.

--- a/pkg/registry/apis/provisioning/extras/register.go
+++ b/pkg/registry/apis/provisioning/extras/register.go
@@ -6,6 +6,7 @@ import (
 	apisprovisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/connection"
 	ghconnection "github.com/grafana/grafana/apps/provisioning/pkg/connection/github"
+	"github.com/grafana/grafana/apps/provisioning/pkg/connection/githuboauth"
 	"github.com/grafana/grafana/apps/provisioning/pkg/quotas"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository/git"
@@ -61,6 +62,7 @@ func ProvideProvisioningOSSConnectionExtras(
 	decrypter := connection.ProvideDecrypter(decryptSvc, connection.RegisterDecryptMetrics(reg))
 	return []connection.Extra{
 		ghconnection.Extra(decrypter, ghFactory),
+		githuboauth.Extra(decrypter),
 	}
 }
 

--- a/pkg/registry/apis/provisioning/extras/register.go
+++ b/pkg/registry/apis/provisioning/extras/register.go
@@ -57,12 +57,13 @@ func ProvideProvisioningOSSConnectionExtras(
 	_ *setting.Cfg,
 	decryptSvc decrypt.DecryptService,
 	ghFactory ghconnection.GithubFactory,
+	ghRepoFactory *github.Factory,
 	reg prometheus.Registerer,
 ) []connection.Extra {
 	decrypter := connection.ProvideDecrypter(decryptSvc, connection.RegisterDecryptMetrics(reg))
 	return []connection.Extra{
 		ghconnection.Extra(decrypter, ghFactory),
-		githuboauth.Extra(decrypter),
+		githuboauth.Extra(decrypter, ghRepoFactory),
 	}
 }
 

--- a/pkg/server/bootstrap/wire/wire_gen.go
+++ b/pkg/server/bootstrap/wire/wire_gen.go
@@ -969,7 +969,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts server.Options, apiO
 		return nil, err
 	}
 	githubFactory := github2.ProvideFactory()
-	v14 := extras.ProvideProvisioningOSSConnectionExtras(cfg, decryptService, githubFactory, registerer)
+	v14 := extras.ProvideProvisioningOSSConnectionExtras(cfg, decryptService, githubFactory, factory, registerer)
 	connectionFactory, err := extras.ProvideConnectionFactoryFromConfig(cfg, v14)
 	if err != nil {
 		return nil, err
@@ -1730,7 +1730,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 		return nil, err
 	}
 	githubFactory := github2.ProvideFactory()
-	v14 := extras.ProvideProvisioningOSSConnectionExtras(cfg, decryptService, githubFactory, registerer)
+	v14 := extras.ProvideProvisioningOSSConnectionExtras(cfg, decryptService, githubFactory, factory, registerer)
 	connectionFactory, err := extras.ProvideConnectionFactoryFromConfig(cfg, v14)
 	if err != nil {
 		return nil, err

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
@@ -4489,13 +4489,14 @@
             "default": ""
           },
           "type": {
-            "description": "The connection provider type\n\nPossible enum values:\n - `\"bitbucketOAuth\"`\n - `\"github\"`\n - `\"githubEnterprise\"`\n - `\"gitlabOAuth\"`",
+            "description": "The connection provider type\n\nPossible enum values:\n - `\"bitbucketOAuth\"`\n - `\"github\"`\n - `\"githubEnterprise\"`\n - `\"githubOAuth\"`\n - `\"gitlabOAuth\"`",
             "type": "string",
             "default": "",
             "enum": [
               "bitbucketOAuth",
               "github",
               "githubEnterprise",
+              "githubOAuth",
               "gitlabOAuth"
             ]
           },
@@ -6174,6 +6175,7 @@
                 "bitbucketOAuth",
                 "github",
                 "githubEnterprise",
+                "githubOAuth",
                 "gitlabOAuth"
               ]
             }

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
@@ -4489,13 +4489,14 @@
             "default": ""
           },
           "type": {
-            "description": "The connection provider type\n\nPossible enum values:\n - `\"bitbucket\"`\n - `\"github\"`\n - `\"githubEnterprise\"`\n - `\"gitlab\"`",
+            "description": "The connection provider type\n\nPossible enum values:\n - `\"bitbucket\"`\n - `\"github\"`\n - `\"githubEnterprise\"`\n - `\"githubOAuth\"`\n - `\"gitlab\"`",
             "type": "string",
             "default": "",
             "enum": [
               "bitbucket",
               "github",
               "githubEnterprise",
+              "githubOAuth",
               "gitlab"
             ]
           },

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v1beta1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v1beta1.json
@@ -4402,13 +4402,14 @@
             "default": ""
           },
           "type": {
-            "description": "The connection provider type\n\nPossible enum values:\n - `\"bitbucket\"`\n - `\"github\"`\n - `\"githubEnterprise\"`\n - `\"gitlab\"`",
+            "description": "The connection provider type\n\nPossible enum values:\n - `\"bitbucket\"`\n - `\"github\"`\n - `\"githubEnterprise\"`\n - `\"githubOAuth\"`\n - `\"gitlab\"`",
             "type": "string",
             "default": "",
             "enum": [
               "bitbucket",
               "github",
               "githubEnterprise",
+              "githubOAuth",
               "gitlab"
             ]
           },

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v1beta1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v1beta1.json
@@ -4402,13 +4402,14 @@
             "default": ""
           },
           "type": {
-            "description": "The connection provider type\n\nPossible enum values:\n - `\"bitbucketOAuth\"`\n - `\"github\"`\n - `\"githubEnterprise\"`\n - `\"gitlabOAuth\"`",
+            "description": "The connection provider type\n\nPossible enum values:\n - `\"bitbucketOAuth\"`\n - `\"github\"`\n - `\"githubEnterprise\"`\n - `\"githubOAuth\"`\n - `\"gitlabOAuth\"`",
             "type": "string",
             "default": "",
             "enum": [
               "bitbucketOAuth",
               "github",
               "githubEnterprise",
+              "githubOAuth",
               "gitlabOAuth"
             ]
           },
@@ -5760,6 +5761,7 @@
                 "bitbucketOAuth",
                 "github",
                 "githubEnterprise",
+                "githubOAuth",
                 "gitlabOAuth"
               ]
             }

--- a/pkg/tests/apis/provisioning/connection/helpers_test.go
+++ b/pkg/tests/apis/provisioning/connection/helpers_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
 
-var env = common.NewSharedEnv()
+var env = common.NewSharedEnv(common.WithConnectionTypes([]string{"github", "githubOAuth"}))
 
 func sharedHelper(t *testing.T) *common.ProvisioningTestHelper {
 	t.Helper()

--- a/pkg/tests/apis/provisioning/connection/oauth_test.go
+++ b/pkg/tests/apis/provisioning/connection/oauth_test.go
@@ -1,0 +1,435 @@
+package connection
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/apps/provisioning/pkg/connection/githuboauth"
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+)
+
+// githubOAuthTransport fakes the two GitHub endpoints OAuth app connections
+// talk to: the authorization code exchange and the repository listing.
+type githubOAuthTransport struct {
+	accessToken string
+}
+
+func (f *githubOAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	var body string
+	switch {
+	case req.Method == http.MethodPost && strings.HasSuffix(req.URL.Path, "/login/oauth/access_token"):
+		body = fmt.Sprintf(`{"access_token":%q,"token_type":"bearer","scope":"repo"}`, f.accessToken)
+	case req.Method == http.MethodGet && strings.HasSuffix(req.URL.Path, "/user/repos"):
+		body = `[
+			{"name":"oauth-repo-1","owner":{"login":"oauth-owner-1"},"html_url":"https://github.com/oauth-owner-1/oauth-repo-1"},
+			{"name":"oauth-repo-2","owner":{"login":"oauth-owner-2"},"html_url":"https://github.com/oauth-owner-2/oauth-repo-2"}
+		]`
+	default:
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       io.NopCloser(strings.NewReader(`{"message":"Not Found"}`)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Request:    req,
+		}, nil
+	}
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Request:    req,
+	}, nil
+}
+
+func oauthHelper(t *testing.T) *common.ProvisioningTestHelper {
+	t.Helper()
+	helper := sharedHelper(t)
+	githuboauth.Default.Client = &http.Client{Transport: &githubOAuthTransport{accessToken: "fake-access-token"}}
+	t.Cleanup(func() { githuboauth.Default.Client = nil })
+	return helper
+}
+
+func newGithubOAuthConnection(name, clientID string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "provisioning.grafana.app/v0alpha1",
+		"kind":       "Connection",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": "default",
+		},
+		"spec": map[string]any{
+			"title": "Test GitHub OAuth Connection",
+			"type":  string(provisioning.GithubOAuthConnectionType),
+			"oauth": map[string]any{
+				"clientID": clientID,
+			},
+		},
+		"secure": map[string]any{
+			"clientSecret": map[string]any{
+				"create": "test-client-secret",
+			},
+		},
+	}}
+}
+
+func authorizeConnection(t *testing.T, helper *common.ProvisioningTestHelper, name string) {
+	t.Helper()
+	body, err := json.Marshal(&provisioning.ConnectionAuthorizeRequest{
+		Spec: provisioning.ConnectionAuthorizeRequestSpec{
+			Code:        "test-authorization-code",
+			RedirectURI: "https://grafana.example.com/callback",
+		},
+	})
+	require.NoError(t, err)
+
+	var statusCode int
+	result := helper.AdminREST.Post().
+		Namespace("default").
+		Resource("connections").
+		Name(name).
+		SubResource("authorize").
+		Body(body).
+		SetHeader("Content-Type", "application/json").
+		Do(t.Context()).
+		StatusCode(&statusCode)
+	require.NoError(t, result.Error(), "authorize should succeed")
+	require.Equal(t, http.StatusOK, statusCode)
+
+	var res provisioning.ConnectionAuthorizeRequest
+	require.NoError(t, result.Into(&res))
+	assert.True(t, res.Status.Authorized, "response should report authorized")
+	assert.Empty(t, res.Spec.Code, "authorization code should not be echoed back")
+}
+
+func TestIntegrationProvisioning_OAuthConnectionCRUDL(t *testing.T) {
+	helper := oauthHelper(t)
+
+	t.Run("should perform CRUDL requests on githubOAuth connection", func(t *testing.T) {
+		connection := newGithubOAuthConnection("oauth-crudl", "test-client-id")
+
+		// CREATE without a token: the connection is not authorized yet
+		c, err := helper.Connections.Resource.Create(t.Context(), connection, metav1.CreateOptions{FieldValidation: "Strict"})
+		require.NoError(t, err, "failed to create resource")
+		connectionName := c.GetName()
+
+		// READ
+		output, err := helper.Connections.Resource.Get(t.Context(), connectionName, metav1.GetOptions{})
+		require.NoError(t, err, "failed to read back resource")
+		spec := output.Object["spec"].(map[string]any)
+		assert.Equal(t, "githubOAuth", spec["type"], "type should be equal")
+		oauthInfo := spec["oauth"].(map[string]any)
+		assert.Equal(t, "test-client-id", oauthInfo["clientID"], "clientID should be equal")
+		require.Contains(t, output.Object, "secure", "object should contain secure")
+		secure := output.Object["secure"].(map[string]any)
+		assert.Contains(t, secure, "clientSecret", "secure should contain clientSecret")
+		assert.NotContains(t, secure, "token", "secure should not contain a token before authorization")
+
+		// LIST
+		list, err := helper.Connections.Resource.List(t.Context(), metav1.ListOptions{})
+		require.NoError(t, err, "failed to list resource")
+		assert.Equal(t, 1, len(list.Items), "should have one connection")
+
+		// UPDATE (same credentials)
+		updated := output.DeepCopy()
+		updated.SetResourceVersion("")
+		spec = updated.Object["spec"].(map[string]any)
+		spec["title"] = "Updated GitHub OAuth Connection"
+		res, err := helper.Connections.Resource.Update(t.Context(), updated, metav1.UpdateOptions{FieldValidation: "Strict"})
+		require.NoError(t, err, "failed to update resource")
+		assert.Equal(t, "Updated GitHub OAuth Connection", res.Object["spec"].(map[string]any)["title"])
+
+		// DELETE
+		require.Eventually(t, func() bool {
+			err := helper.Connections.Resource.Delete(t.Context(), connectionName, metav1.DeleteOptions{})
+			if err != nil {
+				return apierrors.IsNotFound(err)
+			}
+			return true
+		}, 5*time.Second, 100*time.Millisecond, "should successfully delete resource")
+	})
+}
+
+func TestIntegrationProvisioning_OAuthConnectionMutation(t *testing.T) {
+	helper := oauthHelper(t)
+
+	t.Run("should prefix generated githubOAuth connection names with type", func(t *testing.T) {
+		connection := newGithubOAuthConnection("", "test-client-id")
+
+		c, err := helper.Connections.Resource.Create(t.Context(), connection, metav1.CreateOptions{FieldValidation: "Strict"})
+		require.NoError(t, err, "failed to create resource")
+		require.Contains(t, c.GetName(), fmt.Sprintf("%s-", provisioning.GithubOAuthConnectionType), "name should have the type prefix")
+	})
+}
+
+func TestIntegrationProvisioning_OAuthConnectionValidation(t *testing.T) {
+	helper := oauthHelper(t)
+
+	t.Run("should fail when 'oauth' field is missing", func(t *testing.T) {
+		connection := newGithubOAuthConnection("oauth-validation-no-oauth", "test-client-id")
+		delete(connection.Object["spec"].(map[string]any), "oauth")
+
+		_, err := helper.Connections.Resource.Create(t.Context(), connection, metav1.CreateOptions{FieldValidation: "Strict"})
+		require.Error(t, err, "creation should fail")
+		assert.Contains(t, err.Error(), "oauth info must be specified for OAuth app connections")
+	})
+
+	t.Run("should fail when client secret is missing", func(t *testing.T) {
+		connection := newGithubOAuthConnection("oauth-validation-no-secret", "test-client-id")
+		delete(connection.Object, "secure")
+
+		_, err := helper.Connections.Resource.Create(t.Context(), connection, metav1.CreateOptions{FieldValidation: "Strict"})
+		require.Error(t, err, "creation should fail")
+		assert.Contains(t, err.Error(), "clientSecret must be specified for OAuth app connections")
+	})
+
+	t.Run("should fail when a private key is specified", func(t *testing.T) {
+		connection := newGithubOAuthConnection("oauth-validation-private-key", "test-client-id")
+		connection.Object["secure"].(map[string]any)["privateKey"] = map[string]any{
+			"create": "some-private-key",
+		}
+
+		_, err := helper.Connections.Resource.Create(t.Context(), connection, metav1.CreateOptions{FieldValidation: "Strict"})
+		require.Error(t, err, "creation should fail")
+		assert.Contains(t, err.Error(), "privateKey is forbidden in OAuth app connections")
+	})
+}
+
+func TestIntegrationProvisioning_OAuthConnectionAuthorize(t *testing.T) {
+	helper := oauthHelper(t)
+
+	t.Run("authorize exchanges the code and stores the token", func(t *testing.T) {
+		connection := newGithubOAuthConnection("oauth-authorize", "test-client-id")
+		_, err := helper.Connections.Resource.Create(t.Context(), connection, metav1.CreateOptions{FieldValidation: "Strict"})
+		require.NoError(t, err, "failed to create resource")
+
+		authorizeConnection(t, helper, "oauth-authorize")
+
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			output, err := helper.Connections.Resource.Get(t.Context(), "oauth-authorize", metav1.GetOptions{})
+			if !assert.NoError(collect, err) {
+				return
+			}
+			secure, _ := output.Object["secure"].(map[string]any)
+			assert.Contains(collect, secure, "token", "secure should contain the exchanged token")
+			status, _ := output.Object["status"].(map[string]any)
+			tokenStatus, _ := status["token"].(map[string]any)
+			if assert.NotNil(collect, tokenStatus, "status should contain token info") {
+				lastUpdated, _ := tokenStatus["lastUpdated"].(int64)
+				assert.Positive(collect, lastUpdated, "lastUpdated should be set")
+			}
+		}, 10*time.Second, 250*time.Millisecond, "token should be stored after authorize")
+	})
+
+	t.Run("authorize is rejected for non-OAuth connections", func(t *testing.T) {
+		privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
+		appConnection := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "provisioning.grafana.app/v0alpha1",
+			"kind":       "Connection",
+			"metadata": map[string]any{
+				"name":      "github-app-connection",
+				"namespace": "default",
+			},
+			"spec": map[string]any{
+				"title": "Test GitHub App Connection",
+				"type":  provisioning.GitHubRepositoryType,
+				"github": map[string]any{
+					"appID":          "123456",
+					"installationID": "454545",
+				},
+			},
+			"secure": map[string]any{
+				"privateKey": map[string]any{
+					"create": privateKeyBase64,
+				},
+			},
+		}}
+		_, err := helper.CreateGithubConnection(t, appConnection)
+		require.NoError(t, err)
+
+		body, err := json.Marshal(&provisioning.ConnectionAuthorizeRequest{
+			Spec: provisioning.ConnectionAuthorizeRequestSpec{Code: "test-authorization-code"},
+		})
+		require.NoError(t, err)
+
+		var statusCode int
+		result := helper.AdminREST.Post().
+			Namespace("default").
+			Resource("connections").
+			Name("github-app-connection").
+			SubResource("authorize").
+			Body(body).
+			SetHeader("Content-Type", "application/json").
+			Do(t.Context()).
+			StatusCode(&statusCode)
+		require.Error(t, result.Error(), "authorize should fail for github app connections")
+		require.Equal(t, http.StatusNotImplemented, statusCode, "should return 501 Not Implemented")
+	})
+
+	t.Run("viewer cannot authorize", func(t *testing.T) {
+		body, err := json.Marshal(&provisioning.ConnectionAuthorizeRequest{
+			Spec: provisioning.ConnectionAuthorizeRequestSpec{Code: "test-authorization-code"},
+		})
+		require.NoError(t, err)
+
+		var statusCode int
+		result := helper.ViewerREST.Post().
+			Namespace("default").
+			Resource("connections").
+			Name("oauth-authorize").
+			SubResource("authorize").
+			Body(body).
+			SetHeader("Content-Type", "application/json").
+			Do(t.Context()).
+			StatusCode(&statusCode)
+		require.Error(t, result.Error(), "viewer should not be able to authorize")
+		require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
+	})
+}
+
+func TestIntegrationProvisioning_OAuthConnectionTokenDropOnCredentialChange(t *testing.T) {
+	helper := oauthHelper(t)
+
+	setup := func(t *testing.T, name string) *unstructured.Unstructured {
+		t.Helper()
+		connection := newGithubOAuthConnection(name, "test-client-id")
+		_, err := helper.Connections.Resource.Create(t.Context(), connection, metav1.CreateOptions{FieldValidation: "Strict"})
+		require.NoError(t, err, "failed to create resource")
+		authorizeConnection(t, helper, name)
+
+		var output *unstructured.Unstructured
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			var err error
+			output, err = helper.Connections.Resource.Get(t.Context(), name, metav1.GetOptions{})
+			if !assert.NoError(collect, err) {
+				return
+			}
+			secure, _ := output.Object["secure"].(map[string]any)
+			assert.Contains(collect, secure, "token", "secure should contain the exchanged token")
+		}, 10*time.Second, 250*time.Millisecond, "token should be stored after authorize")
+		return output
+	}
+
+	update := func(t *testing.T, name string, mutate func(obj *unstructured.Unstructured)) {
+		t.Helper()
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			output, err := helper.Connections.Resource.Get(t.Context(), name, metav1.GetOptions{})
+			if !assert.NoError(collect, err) {
+				return
+			}
+			updated := output.DeepCopy()
+			delete(updated.Object["secure"].(map[string]any), "token")
+			mutate(updated)
+			_, err = helper.Connections.Resource.Update(t.Context(), updated, metav1.UpdateOptions{FieldValidation: "Strict"})
+			assert.NoError(collect, err)
+		}, 10*time.Second, 250*time.Millisecond, "update should succeed")
+	}
+
+	t.Run("token is kept when credentials are unchanged", func(t *testing.T) {
+		setup(t, "oauth-token-kept")
+
+		update(t, "oauth-token-kept", func(obj *unstructured.Unstructured) {
+			obj.Object["spec"].(map[string]any)["title"] = "Updated title"
+		})
+
+		output, err := helper.Connections.Resource.Get(t.Context(), "oauth-token-kept", metav1.GetOptions{})
+		require.NoError(t, err)
+		secure, _ := output.Object["secure"].(map[string]any)
+		assert.Contains(t, secure, "token", "token should be preserved when credentials are unchanged")
+	})
+
+	t.Run("token is dropped when the client ID is changed", func(t *testing.T) {
+		setup(t, "oauth-token-drop-id")
+
+		update(t, "oauth-token-drop-id", func(obj *unstructured.Unstructured) {
+			obj.Object["spec"].(map[string]any)["oauth"].(map[string]any)["clientID"] = "another-client-id"
+		})
+
+		output, err := helper.Connections.Resource.Get(t.Context(), "oauth-token-drop-id", metav1.GetOptions{})
+		require.NoError(t, err)
+		secure, _ := output.Object["secure"].(map[string]any)
+		assert.NotContains(t, secure, "token", "token should be dropped when the client ID changes")
+	})
+
+	t.Run("token is dropped when the client secret is changed", func(t *testing.T) {
+		setup(t, "oauth-token-drop-secret")
+
+		update(t, "oauth-token-drop-secret", func(obj *unstructured.Unstructured) {
+			obj.Object["secure"].(map[string]any)["clientSecret"] = map[string]any{
+				"create": "another-client-secret",
+			}
+		})
+
+		output, err := helper.Connections.Resource.Get(t.Context(), "oauth-token-drop-secret", metav1.GetOptions{})
+		require.NoError(t, err)
+		secure, _ := output.Object["secure"].(map[string]any)
+		assert.NotContains(t, secure, "token", "token should be dropped when the client secret changes")
+	})
+}
+
+func TestIntegrationProvisioning_OAuthConnectionRepositories(t *testing.T) {
+	helper := oauthHelper(t)
+
+	connection := newGithubOAuthConnection("oauth-repositories", "test-client-id")
+	_, err := helper.Connections.Resource.Create(t.Context(), connection, metav1.CreateOptions{FieldValidation: "Strict"})
+	require.NoError(t, err)
+	authorizeConnection(t, helper, "oauth-repositories")
+
+	t.Run("admin can list repositories through an authorized oauth connection", func(t *testing.T) {
+		var resultList provisioning.ExternalRepositoryList
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			result := helper.AdminREST.Get().
+				Namespace("default").
+				Resource("connections").
+				Name("oauth-repositories").
+				SubResource("repositories").
+				Do(t.Context())
+			if !assert.NoError(collect, result.Error()) {
+				return
+			}
+			assert.NoError(collect, result.Into(&resultList))
+		}, 10*time.Second, 250*time.Millisecond, "repositories listing should succeed")
+
+		require.Len(t, resultList.Items, 2, "should return 2 repositories")
+		assert.Equal(t, "oauth-repo-1", resultList.Items[0].Name)
+		assert.Equal(t, "oauth-owner-1", resultList.Items[0].Owner)
+		assert.Equal(t, "https://github.com/oauth-owner-1/oauth-repo-1", resultList.Items[0].URL)
+	})
+}
+
+func TestIntegrationConnectionController_OAuthNoTokenGeneration(t *testing.T) {
+	helper := oauthHelper(t)
+
+	t.Run("controller does not mint tokens for unauthorized oauth connections", func(t *testing.T) {
+		connection := newGithubOAuthConnection("oauth-no-mint", "test-client-id")
+		_, err := helper.Connections.Resource.Create(t.Context(), connection, metav1.CreateOptions{FieldValidation: "Strict"})
+		require.NoError(t, err)
+
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			output, err := helper.Connections.Resource.Get(t.Context(), "oauth-no-mint", metav1.GetOptions{})
+			if !assert.NoError(collect, err) {
+				return
+			}
+			status, _ := output.Object["status"].(map[string]any)
+			observed, _ := status["observedGeneration"].(int64)
+			assert.Equal(collect, int64(1), observed, "controller should have reconciled the connection")
+		}, 10*time.Second, 250*time.Millisecond, "connection should be reconciled")
+
+		output, err := helper.Connections.Resource.Get(t.Context(), "oauth-no-mint", metav1.GetOptions{})
+		require.NoError(t, err)
+		secure, _ := output.Object["secure"].(map[string]any)
+		assert.NotContains(t, secure, "token", "controller must not mint a token for oauth connections")
+	})
+}

--- a/pkg/tests/apis/provisioning/connection/oauth_test.go
+++ b/pkg/tests/apis/provisioning/connection/oauth_test.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
-	"github.com/grafana/grafana/apps/provisioning/pkg/connection/githuboauth"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
 
@@ -25,6 +24,7 @@ import (
 // talk to: the authorization code exchange and the repository listing.
 type githubOAuthTransport struct {
 	accessToken string
+	base        http.RoundTripper
 }
 
 func (f *githubOAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -38,6 +38,9 @@ func (f *githubOAuthTransport) RoundTrip(req *http.Request) (*http.Response, err
 			{"name":"oauth-repo-2","owner":{"login":"oauth-owner-2"},"html_url":"https://github.com/oauth-owner-2/oauth-repo-2"}
 		]`
 	default:
+		if f.base != nil {
+			return f.base.RoundTrip(req)
+		}
 		return &http.Response{
 			StatusCode: http.StatusNotFound,
 			Body:       io.NopCloser(strings.NewReader(`{"message":"Not Found"}`)),
@@ -56,9 +59,13 @@ func (f *githubOAuthTransport) RoundTrip(req *http.Request) (*http.Response, err
 
 func oauthHelper(t *testing.T) *common.ProvisioningTestHelper {
 	t.Helper()
+	const accessToken = "fake-access-token"
+	base := http.DefaultTransport
+	http.DefaultTransport = &githubOAuthTransport{accessToken: accessToken, base: base}
+	t.Cleanup(func() { http.DefaultTransport = base })
+
 	helper := sharedHelper(t)
-	githuboauth.Default.Client = &http.Client{Transport: &githubOAuthTransport{accessToken: "fake-access-token"}}
-	t.Cleanup(func() { githuboauth.Default.Client = nil })
+	helper.GetEnv().GithubRepoFactory.Client = &http.Client{Transport: &githubOAuthTransport{accessToken: accessToken}}
 	return helper
 }
 

--- a/public/app/features/provisioning/Connection/ConnectionListItem.tsx
+++ b/public/app/features/provisioning/Connection/ConnectionListItem.tsx
@@ -22,7 +22,13 @@ export function ConnectionListItem({ connection, isSelected, onClick }: Props) {
   const description = spec?.description;
   const url = spec?.url;
   const providerType: RepoType =
-    spec?.type === 'bitbucketOAuth' ? 'bitbucket' : spec?.type === 'gitlabOAuth' ? 'gitlab' : (spec?.type ?? 'github');
+    spec?.type === 'bitbucketOAuth'
+      ? 'bitbucket'
+      : spec?.type === 'gitlabOAuth'
+        ? 'gitlab'
+        : spec?.type === 'githubOAuth'
+          ? 'github'
+          : (spec?.type ?? 'github');
   return (
     <Card noMargin key={name} isSelected={isSelected} onClick={onClick}>
       <Card.Figure>

--- a/public/app/features/provisioning/Connection/ConnectionListItem.tsx
+++ b/public/app/features/provisioning/Connection/ConnectionListItem.tsx
@@ -21,7 +21,7 @@ export function ConnectionListItem({ connection, isSelected, onClick }: Props) {
   const title = spec?.title || name;
   const description = spec?.description;
   const url = spec?.url;
-  const providerType: RepoType = spec?.type ?? 'github';
+  const providerType: RepoType = spec?.type === 'githubOAuth' ? 'github' : (spec?.type ?? 'github');
   return (
     <Card noMargin key={name} isSelected={isSelected} onClick={onClick}>
       <Card.Figure>


### PR DESCRIPTION
**What is this feature?**

Adds GitHub OAuth apps as a connection type. These connections serve GitHub repositories as a lighter alternative to GitHub App connections. GitHub issues non-expiring tokens for OAuth apps, so no background refresh is involved.

**Why do we need this feature?**

GitHub Apps take more setup. An OAuth app only needs its client credentials and a one-time authorization.

**Who is this feature for?**

Admins setting up git sync.

**Special notes for your reviewer:**

Stacked on #129742.

---

*PR description generated by Claude Code*