### PR TITLE
E2E Selectors: Add selectors for dynamic dashboards tour and transform data guides

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -289,7 +289,6 @@ export const versionedComponents = {
           [MIN_GRAFANA_VERSION]: 'TestData noise',
         },
         seriesCount: {
-          '13.2.0': 'data-testid TestData series count',
           [MIN_GRAFANA_VERSION]: 'TestData series count',
         },
         spread: {

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -142,6 +142,12 @@ export const versionedComponents = {
       '13.2.0': 'data-testid sidebar add new variable button',
       '13.1.0': 'data-testid edit pane add new variable button',
     },
+    addNewRowButton: {
+      '13.2.0': 'data-testid sidebar add new row button',
+    },
+    addNewTabButton: {
+      '13.2.0': 'data-testid sidebar add new tab button',
+    },
   },
   EditPaneHeader: {
     deleteButton: {
@@ -283,6 +289,7 @@ export const versionedComponents = {
           [MIN_GRAFANA_VERSION]: 'TestData noise',
         },
         seriesCount: {
+          '13.2.0': 'data-testid TestData series count',
           [MIN_GRAFANA_VERSION]: 'TestData series count',
         },
         spread: {
@@ -1075,6 +1082,14 @@ export const versionedComponents = {
     disableTransformationButton: {
       '10.4.0': 'data-testid Disable transformation button',
     },
+    filterEditor: {
+      container: {
+        '13.2.0': 'data-testid transformation filter editor container',
+      },
+      topicSelect: {
+        '13.2.0': 'data-testid transformation filter topic select',
+      },
+    },
     FilterByValue: {
       addConditionButton: {
         '13.2.0': 'data-testid Transforms FilterByValue add-condition-button',
@@ -1200,6 +1215,9 @@ export const versionedComponents = {
     },
     commandPaletteTrigger: {
       '11.5.0': 'data-testid Command palette trigger',
+    },
+    quickAddButton: {
+      '13.2.0': 'data-testid Quick add button',
     },
     shareDashboard: {
       '11.1.0': 'data-testid Share dashboard',

--- a/packages/grafana-e2e-selectors/src/selectors/pages.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/pages.ts
@@ -195,6 +195,9 @@ export const versionedPages = {
       addButton: {
         '12.4.0': 'data-testid Dashboard Sidebar new button',
       },
+      codeButton: {
+        '13.2.0': 'data-testid Dashboard Sidebar code button',
+      },
       viewPanelControls: {
         '13.0.0': 'data-testid Dashboard Sidebar view panel controls',
       },

--- a/public/app/core/components/AppChrome/QuickAdd/QuickAdd.tsx
+++ b/public/app/core/components/AppChrome/QuickAdd/QuickAdd.tsx
@@ -2,6 +2,7 @@ import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { Fragment, useMemo, useState } from 'react';
 
 import { type NavModelItem } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
 import { useFlagGrafanaCustomDashboardTemplates } from '@grafana/runtime/internal';
@@ -134,6 +135,7 @@ export const QuickAdd = ({}: Props) => {
           icon={'plus'}
           isOpen={isOpen}
           aria-label={t('navigation.quick-add.aria-label', 'New')}
+          data-testid={selectors.components.NavToolbar.quickAddButton}
         />
       </Dropdown>
       <NavToolbarSeparator />

--- a/public/app/features/dashboard-scene/scene/layouts-shared/DashboardLayoutSelector.tsx
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/DashboardLayoutSelector.tsx
@@ -65,7 +65,7 @@ export function DashboardLayoutSelector({ layoutManager }: Props) {
 
   const onDismissNewLayout = useCallback(() => setNewLayout(undefined), []);
 
-  const disabledOptions: LayoutRegistryItem[] = [];
+  const disabledOptions: string[] = [];
 
   const radioOptions = options.map((opt) => {
     let description = opt.description;
@@ -78,11 +78,13 @@ export function DashboardLayoutSelector({ layoutManager }: Props) {
           'Cannot change to tabs because a row already contains tabs'
         );
       }
-      disabledOptions.push(opt);
+      disabledOptions.push(opt.id);
     }
 
+    // The option value is the layout's stable id (not the registry item object) so that
+    // RadioButtonGroup can emit a per-option data-testid keyed on it.
     return {
-      value: opt,
+      value: opt.id,
       label: opt.name,
       icon: opt.icon,
       description,
@@ -90,14 +92,30 @@ export function DashboardLayoutSelector({ layoutManager }: Props) {
     };
   });
 
+  const onChangeLayout = useCallback(
+    (id: string) => {
+      const layoutItem = options.find((opt) => opt.id === id);
+      if (!layoutItem) {
+        return;
+      }
+
+      if (isGridLayout) {
+        promptLayoutChange(layoutItem);
+      } else {
+        switchLayout(layoutItem);
+      }
+    },
+    [options, isGridLayout, promptLayoutChange, switchLayout]
+  );
+
   return (
     <>
       <Box paddingBottom={2} display="flex" grow={1} alignItems="stretch" gap={2} direction={'column'}>
         <RadioButtonGroup
           fullWidth
-          value={layoutManager.descriptor}
+          value={layoutManager.descriptor.id}
           options={radioOptions}
-          onChange={!isGridLayout ? switchLayout : promptLayoutChange}
+          onChange={onChangeLayout}
           disabledOptions={disabledOptions}
         />
       </Box>

--- a/public/app/features/dashboard-scene/sidebar/DashboardSidebarRenderer.tsx
+++ b/public/app/features/dashboard-scene/sidebar/DashboardSidebarRenderer.tsx
@@ -112,6 +112,7 @@ export function DashboardSidebarRenderer({ dashboard }: Props) {
               title={t('dashboard.sidebar.edit-schema.title', 'Code')}
               icon="brackets-curly"
               onClick={() => sidebar.openPane(new DashboardCodePane({}))}
+              data-testid={selectors.pages.Dashboard.Sidebar.codeButton}
               active={openPane instanceof DashboardCodePane}
             />
             {globalDashboardVariablesEnabled && (

--- a/public/app/features/dashboard-scene/sidebar/add-new/AddRow.tsx
+++ b/public/app/features/dashboard-scene/sidebar/add-new/AddRow.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react';
 
+import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { type SceneObject } from '@grafana/scenes';
 
@@ -46,6 +47,7 @@ export function AddRow({ dashboardScene, selectedElement }: AddRowProps) {
     <AddButton
       icon="list-ul"
       label={label}
+      testId={selectors.components.Sidebar.addNewRowButton}
       onClick={onAddRowClick}
       disabled={disableGrouping}
       tooltip={disableGrouping ? getNestingRestrictionMessage() : undefined}

--- a/public/app/features/dashboard-scene/sidebar/add-new/AddTab.tsx
+++ b/public/app/features/dashboard-scene/sidebar/add-new/AddTab.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react';
 
+import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { type SceneObject } from '@grafana/scenes';
 
@@ -44,6 +45,13 @@ export function AddTab({ dashboardScene, selectedElement }: AddTabProps) {
   }, [layout]);
 
   return (
-    <AddButton icon="layers" label={label} onClick={onAddTabClick} disabled={disableTabs} tooltip={disabledTooltip} />
+    <AddButton
+      icon="layers"
+      label={label}
+      testId={selectors.components.Sidebar.addNewTabButton}
+      onClick={onAddTabClick}
+      disabled={disableTabs}
+      tooltip={disabledTooltip}
+    />
   );
 }

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationFilter.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationFilter.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/css';
 import { useMemo } from 'react';
 
 import { type DataFrame, type DataTransformerConfig, type GrafanaTheme2 } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { DataTopic } from '@grafana/schema';
 import { Field, Select, useStyles2 } from '@grafana/ui';
@@ -33,11 +34,12 @@ export const TransformationFilter = ({ index, annotations, config, onChange, dat
   }, [data, annotations?.length, config.topic]);
 
   return (
-    <div className={styles.wrapper}>
+    <div className={styles.wrapper} data-testid={selectors.components.Transforms.filterEditor.container}>
       <Field label={t('dashboard.transformation-filter.label-apply-transformation-to', 'Apply transformation to')}>
         <>
           {opts.showTopic && (
             <Select
+              data-testid={selectors.components.Transforms.filterEditor.topicSelect}
               isClearable={true}
               options={opts.source}
               value={opts.source.find((v) => v.value === config.topic)}


### PR DESCRIPTION
Part of #129672 (Group 3 — Dashboards).

Replaces weak Pathfinder guide selectors with versioned `@grafana/e2e-selectors` entries wired as `data-testid`, covering the `dynamic-dashboards-tour`, `transform-data` and `welcome-to-play` guides — 7 anchors (dashboard sidebar code/add-row/add-tab buttons, NavToolbar quick-add, transforms filter editor, layout selector options).

**Structure (2 commits):**
1. `test(e2e-selectors)` — selector definitions only
2. `test(dashboards)` — JSX wiring (all under `public/app`)

**Reviewer note:** this includes a small behavioural change in `DashboardLayoutSelector` — its RadioButtonGroup option values switch from `LayoutRegistryItem` objects to stable `opt.id` strings, so the `RadioButton.option(id)` selector from #129669 covers each layout option. Aria-labels and existing tests are preserved (component tests pass, 7/7); RadioButtonGroup itself is untouched.

The TestData series-count selector was moved out of this PR entirely: its entry is consumed via aria-label in the decoupled testdata plugin, so the new key and its wiring must land atomically in a separate PR.

No existing selector values modified or deleted. Verified with `yarn typecheck`, ESLint on changed files, and `yarn nx run @grafana/e2e-selectors:build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

