### PR TITLE
E2E Selectors: Add selector for viz type picker search input

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -783,6 +783,11 @@ export const versionedComponents = {
       '10.0.0': 'data-testid toggle-viz-picker',
       '8.0.0': 'toggle-viz-picker',
     },
+    VizTypePicker: {
+      searchInput: {
+        '13.2.0': 'data-testid Panel editor viz type picker search input',
+      },
+    },
     toggleVizOptions: {
       '10.1.0': 'data-testid toggle-viz-options',
       [MIN_GRAFANA_VERSION]: 'toggle-viz-options',

--- a/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
@@ -162,6 +162,7 @@ export function PanelVizTypePicker({
               value={searchQuery}
               onChange={setSearchQuery}
               placeholder={t('dashboard-scene.panel-viz-type-picker.placeholder-search-for', 'Search for...')}
+              data-testid={selectors.components.PanelEditor.VizTypePicker.searchInput}
             />
           </Stack>
         </Field>


### PR DESCRIPTION
Part of #129672 (Group 3 — Dashboards).

Replaces a weak Pathfinder guide selector with a versioned `@grafana/e2e-selectors` entry wired as `data-testid`, covering the `infinity-csv-lj/build-dashboard` guide — the panel editor's viz type picker search input (`components.PanelEditor.VizTypePicker.searchInput`).

**Structure (2 commits):**
1. `test(e2e-selectors)` — selector definition only
2. `test(dashboards)` — JSX wiring (under `public/app`)

No existing selector values modified or deleted. Verified with `yarn typecheck`, ESLint, and `yarn nx run @grafana/e2e-selectors:build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)