### PR TITLE
Feature: Include flags from registry in FeatureControl

### DIFF
--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlag.test.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlag.test.tsx
@@ -2,7 +2,6 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ComponentProps } from 'react';
 
-import * as runtimeInternal from '@grafana/runtime/internal';
 import { getLocalStorageProvider } from '@grafana/runtime/internal';
 import { mockComboboxRect } from '@grafana/test-utils';
 import type { CodeEditor } from '@grafana/ui';
@@ -10,6 +9,17 @@ import type { CodeEditor } from '@grafana/ui';
 import { FeatureControlFlag, type FeatureControlFlagProps } from './FeatureControlFlag';
 
 type CodeEditorProps = ComponentProps<typeof CodeEditor>;
+
+jest.mock('@grafana/runtime/internal', () => ({
+  ...jest.requireActual('@grafana/runtime/internal'),
+  FlagKeys: {
+    FeatureControlFlagTestOnly: 'feature-gamma',
+  },
+  getOFREPWebProvider: jest.fn().mockReturnValue({
+    flagCache: { 'feature-alpha': true, 'feature-beta': false } as Record<string, unknown>,
+    events: { addHandler: jest.fn(), removeHandler: jest.fn() },
+  } as never),
+}));
 
 jest.mock('@grafana/ui', () => ({
   ...jest.requireActual('@grafana/ui'),
@@ -130,17 +140,12 @@ describe('FeatureControlFlag', () => {
   });
 
   it('shows known flag names in the flag key combobox', async () => {
-    const mockOFREPProvider = {
-      flagCache: { 'feature-alpha': true, 'feature-beta': false } as Record<string, unknown>,
-      events: { addHandler: jest.fn(), removeHandler: jest.fn() },
-    };
-    jest.spyOn(runtimeInternal, 'getOFREPWebProvider').mockReturnValue(mockOFREPProvider as never);
-
     renderComponent();
     await expandFlag('new-flag-override');
 
     await userEvent.click(screen.getByRole('combobox', { name: 'Flag key' }));
     expect(screen.getByRole('option', { name: 'feature-alpha' })).toBeInTheDocument();
     expect(screen.getByRole('option', { name: 'feature-beta' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'feature-gamma' })).toBeInTheDocument();
   });
 });

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlag.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlag.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useId, useRef, useState } from 'react';
 
 import type { GrafanaTheme2 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
-import { getLocalStorageProvider, getOFREPWebProvider } from '@grafana/runtime/internal';
+import { FlagKeys, getLocalStorageProvider, getOFREPWebProvider } from '@grafana/runtime/internal';
 import {
   Badge,
   type BadgeColor,
@@ -85,7 +85,7 @@ const FeatureControlKey = ({ value, onChange }: { value: string; onChange: (valu
   useEffect(() => {
     const loadKeys = () => {
       setKeys(
-        Object.keys(getOFREPWebProvider().flagCache)
+        [...new Set(Object.keys(getOFREPWebProvider().flagCache).concat(Object.values(FlagKeys)))]
           .sort((a, b) => compare(a, b))
           .map((k) => ({ label: k, value: k }))
       );


### PR DESCRIPTION
**What is this feature?**

Populates all frontend feature flags from the registry in the Feature Control UI.

**Why do we need this feature?**

Auto-complete for flags that are not currently enabled, and so are not present in the OFREP response.

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
