### PR TITLE
Explore: Fix table panel never showing a loading indicator

### DIFF
--- a/public/app/features/explore/Table/TableContainer.test.tsx
+++ b/public/app/features/explore/Table/TableContainer.test.tsx
@@ -68,9 +68,17 @@ const dataFrame = toDataFrame({
   ],
 });
 
+// Tempo appends this frame to every streaming search response, including the final one, so it
+// outlives the query that produced it.
+const tempoStreamingProgressFrame = toDataFrame({
+  refId: 'streaming-progress',
+  name: 'Streaming Progress',
+  fields: [{ name: 'state', type: FieldType.string, values: ['Done'] }],
+});
+
 const defaultProps = {
   exploreId: 'left',
-  loading: false,
+  panelLoadingState: undefined,
   queryStreaming: false,
   width: 800,
   onCellFilterAdded: jest.fn(),
@@ -217,12 +225,25 @@ describe('TableContainer', () => {
       return state;
     }
 
-    it('is not loading when the query has settled without any data', () => {
-      expect(mapStateToProps(makeState(LoadingState.Done, null), ownProps).loading).toBe(false);
+    it('has no panel loading state when the query has settled without any data', () => {
+      expect(mapStateToProps(makeState(LoadingState.Done, null), ownProps).panelLoadingState).toBeUndefined();
     });
 
     it('is loading while a query is running and no data has arrived yet', () => {
-      expect(mapStateToProps(makeState(LoadingState.Loading, null), ownProps).loading).toBe(true);
+      expect(mapStateToProps(makeState(LoadingState.Loading, null), ownProps).panelLoadingState).toBe(
+        LoadingState.Loading
+      );
+    });
+
+    it('is streaming while a query is streaming', () => {
+      expect(mapStateToProps(makeState(LoadingState.Streaming, [dataFrame]), ownProps).panelLoadingState).toBe(
+        LoadingState.Streaming
+      );
+    });
+
+    it('is loading, not streaming, when a stale Tempo streaming-progress frame outlives its query', () => {
+      const state = makeState(LoadingState.Loading, [dataFrame, tempoStreamingProgressFrame]);
+      expect(mapStateToProps(state, ownProps).panelLoadingState).toBe(LoadingState.Loading);
     });
   });
 
@@ -279,6 +300,13 @@ describe('TableContainer', () => {
       expect(screen.getByTestId('panel-streaming')).toBeInTheDocument();
       expect(queryLoadingBars()).toHaveLength(0);
       expect(getLastRenderedState()).toBe(LoadingState.Streaming);
+    });
+
+    it('shows a loading bar when a re-query leaves a stale Tempo streaming-progress frame behind', () => {
+      setup(LoadingState.Loading, [dataFrame, tempoStreamingProgressFrame]);
+      expect(queryLoadingBars()).toHaveLength(2);
+      expect(screen.queryByTestId('panel-streaming')).not.toBeInTheDocument();
+      expect(getLastRenderedState()).toBe(LoadingState.Loading);
     });
   });
 

--- a/public/app/features/explore/Table/TableContainer.test.tsx
+++ b/public/app/features/explore/Table/TableContainer.test.tsx
@@ -1,10 +1,20 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { type DataFrame, FieldType, getDefaultTimeRange, InternalTimeZones, toDataFrame } from '@grafana/data';
+import {
+  type DataFrame,
+  FieldType,
+  getDefaultTimeRange,
+  InternalTimeZones,
+  LoadingState,
+  toDataFrame,
+} from '@grafana/data';
 import { setPanelRenderer } from '@grafana/runtime/internal';
 
-import { TableContainer } from './TableContainer';
+import { configureStore } from '../../../store/configureStore';
+import { createEmptyQueryResponse, makeExplorePaneState } from '../state/utils';
+
+import { mapStateToProps, TableContainer } from './TableContainer';
 
 const mockRenderedSeries: DataFrame[][] = [];
 
@@ -171,6 +181,36 @@ describe('TableContainer', () => {
       rendered.fields.forEach((field) => {
         expect(field.config.custom?.hideFrom?.viz).toBe(false);
       });
+    });
+  });
+
+  describe('mapStateToProps', () => {
+    const ownProps = {
+      exploreId: 'left',
+      width: 800,
+      timeZone: InternalTimeZones.utc,
+      splitOpenFn: () => {},
+    };
+
+    function makeState(queryState: LoadingState, tableResult: DataFrame[] | null) {
+      const store = configureStore();
+      const state = store.getState();
+      state.explore.panes = {
+        left: {
+          ...makeExplorePaneState(),
+          tableResult,
+          queryResponse: { ...createEmptyQueryResponse(), state: queryState },
+        },
+      };
+      return state;
+    }
+
+    it('is not loading when the query has settled without any data', () => {
+      expect(mapStateToProps(makeState(LoadingState.Done, null), ownProps).loading).toBe(false);
+    });
+
+    it('is loading while a query is running and no data has arrived yet', () => {
+      expect(mapStateToProps(makeState(LoadingState.Loading, null), ownProps).loading).toBe(true);
     });
   });
 

--- a/public/app/features/explore/Table/TableContainer.test.tsx
+++ b/public/app/features/explore/Table/TableContainer.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { TestProvider } from 'test/helpers/TestProvider';
 
 import {
   type DataFrame,
@@ -14,12 +15,14 @@ import { setPanelRenderer } from '@grafana/runtime/internal';
 import { configureStore } from '../../../store/configureStore';
 import { createEmptyQueryResponse, makeExplorePaneState } from '../state/utils';
 
-import { mapStateToProps, TableContainer } from './TableContainer';
+import ConnectedTableContainer, { mapStateToProps, TableContainer } from './TableContainer';
 
 const mockRenderedSeries: DataFrame[][] = [];
+const mockRenderedStates: Array<LoadingState | undefined> = [];
 
 setPanelRenderer((props) => {
   mockRenderedSeries.push(props.data?.series ?? []);
+  mockRenderedStates.push(props.data?.state);
   return <div>PanelRenderer</div>;
 });
 
@@ -29,6 +32,14 @@ function getPanels(): HTMLElement[] {
 
 function getLastRenderedFrame(): DataFrame {
   return mockRenderedSeries[mockRenderedSeries.length - 1][0];
+}
+
+function getLastRenderedState(): LoadingState | undefined {
+  return mockRenderedStates[mockRenderedStates.length - 1];
+}
+
+function queryLoadingBars(): HTMLElement[] {
+  return screen.queryAllByLabelText('Panel loading bar');
 }
 
 const dataFrame = toDataFrame({
@@ -72,6 +83,7 @@ const defaultProps = {
 describe('TableContainer', () => {
   beforeEach(() => {
     mockRenderedSeries.length = 0;
+    mockRenderedStates.length = 0;
   });
 
   describe('With one main frame', () => {
@@ -211,6 +223,62 @@ describe('TableContainer', () => {
 
     it('is loading while a query is running and no data has arrived yet', () => {
       expect(mapStateToProps(makeState(LoadingState.Loading, null), ownProps).loading).toBe(true);
+    });
+  });
+
+  describe('loading indicator', () => {
+    const emptyFrame: DataFrame = { name: 'A', fields: [], length: 0 };
+
+    function setup(queryState: LoadingState, tableResult: DataFrame[] | null) {
+      const store = configureStore();
+      store.getState().explore.panes = {
+        left: {
+          ...makeExplorePaneState(),
+          tableResult,
+          queryResponse: { ...createEmptyQueryResponse(), state: queryState },
+        },
+      };
+
+      render(
+        <TestProvider store={store}>
+          <ConnectedTableContainer
+            exploreId="left"
+            width={800}
+            timeZone={InternalTimeZones.utc}
+            splitOpenFn={() => {}}
+          />
+        </TestProvider>
+      );
+    }
+
+    it('shows no loading indicator once a query has settled with rows', () => {
+      setup(LoadingState.Done, [dataFrame]);
+      expect(queryLoadingBars()).toHaveLength(0);
+      expect(getLastRenderedState()).toBe(LoadingState.Done);
+    });
+
+    it('shows a loading indicator over previous rows while a query is running', () => {
+      setup(LoadingState.Loading, [dataFrame]);
+      expect(queryLoadingBars()).toHaveLength(1);
+      expect(getLastRenderedState()).toBe(LoadingState.Loading);
+    });
+
+    it('shows no loading indicator once a query has settled with zero rows', () => {
+      setup(LoadingState.Done, [emptyFrame]);
+      expect(screen.getByText('0 series returned')).toBeInTheDocument();
+      expect(queryLoadingBars()).toHaveLength(0);
+    });
+
+    it('shows a loading indicator while a query is running and has returned zero rows so far', () => {
+      setup(LoadingState.Loading, [emptyFrame]);
+      expect(queryLoadingBars()).toHaveLength(1);
+    });
+
+    it('shows the streaming indicator rather than a loading bar while a query is streaming', () => {
+      setup(LoadingState.Streaming, [dataFrame]);
+      expect(screen.getByTestId('panel-streaming')).toBeInTheDocument();
+      expect(queryLoadingBars()).toHaveLength(0);
+      expect(getLastRenderedState()).toBe(LoadingState.Streaming);
     });
   });
 

--- a/public/app/features/explore/Table/TableContainer.tsx
+++ b/public/app/features/explore/Table/TableContainer.tsx
@@ -41,11 +41,11 @@ interface TableContainerProps {
   ariaLabel?: string;
 }
 
-function mapStateToProps(state: StoreState, { exploreId }: TableContainerProps) {
+export function mapStateToProps(state: StoreState, { exploreId }: TableContainerProps) {
   const explore = state.explore;
   const item: ExploreItemState = explore.panes[exploreId]!;
   const { tableResult, range } = item;
-  const loadingInState = selectIsWaitingForData(exploreId);
+  const loadingInState = selectIsWaitingForData(exploreId)(state);
   const loading = tableResult && tableResult.length > 0 ? false : loadingInState;
   const hasTempoStreamingProgressTable = tableResult?.some((f) => f.refId === TEMPO_STREAMING_PROGRESS_REF_ID);
   return {

--- a/public/app/features/explore/Table/TableContainer.tsx
+++ b/public/app/features/explore/Table/TableContainer.tsx
@@ -45,8 +45,7 @@ export function mapStateToProps(state: StoreState, { exploreId }: TableContainer
   const explore = state.explore;
   const item: ExploreItemState = explore.panes[exploreId]!;
   const { tableResult, range } = item;
-  const loadingInState = selectIsWaitingForData(exploreId)(state);
-  const loading = tableResult && tableResult.length > 0 ? false : loadingInState;
+  const loading = selectIsWaitingForData(exploreId)(state);
   const hasTempoStreamingProgressTable = tableResult?.some((f) => f.refId === TEMPO_STREAMING_PROGRESS_REF_ID);
   return {
     loading,
@@ -101,6 +100,14 @@ export const TableContainer = memo(function TableContainer({
     return name
       ? t('explore.table.title-with-name', 'Table - {{name}}', { name, interpolation: { escapeValue: false } })
       : t('explore.table.title', 'Table');
+  }
+
+  // PanelChrome renders a loading bar for Loading and a streaming indicator for Streaming. Gate both
+  // on a query actually being in flight, so a leftover Tempo streaming-progress frame cannot pin the
+  // streaming indicator on after the query has finished.
+  let panelLoadingState: LoadingState | undefined;
+  if (loading) {
+    panelLoadingState = queryStreaming ? LoadingState.Streaming : LoadingState.Loading;
   }
 
   let dataFrames = hasDeprecatedParentRowIndex(tableResult)
@@ -161,7 +168,12 @@ export const TableContainer = memo(function TableContainer({
   return (
     <>
       {frames && frames.length === 0 && (
-        <PanelChrome title={t('explore.table.title', 'Table')} width={width} height={200}>
+        <PanelChrome
+          title={t('explore.table.title', 'Table')}
+          width={width}
+          height={200}
+          loadingState={panelLoadingState}
+        >
           {() => <MetaInfoText metaItems={[{ value: t('explore.table.no-data', '0 series returned') }]} />}
         </PanelChrome>
       )}
@@ -191,7 +203,7 @@ export const TableContainer = memo(function TableContainer({
               ]}
               width={width}
               height={getTableHeight(data.length, hasSubFrames(data), queryStreaming)}
-              loadingState={loading ? LoadingState.Loading : undefined}
+              loadingState={panelLoadingState}
             >
               {(innerWidth, innerHeight) => (
                 <DataLinksContext.Provider value={{ dataLinkPostProcessor }}>
@@ -205,7 +217,7 @@ export const TableContainer = memo(function TableContainer({
                     <PanelRenderer
                       data={{
                         series: [data],
-                        state: loading ? LoadingState.Loading : LoadingState.Done,
+                        state: panelLoadingState ?? LoadingState.Done,
                         timeRange: range,
                       }}
                       pluginId={'table'}

--- a/public/app/features/explore/Table/TableContainer.tsx
+++ b/public/app/features/explore/Table/TableContainer.tsx
@@ -48,7 +48,10 @@ export function mapStateToProps(state: StoreState, { exploreId }: TableContainer
   const loading = selectIsWaitingForData(exploreId)(state);
   const hasTempoStreamingProgressTable = tableResult?.some((f) => f.refId === TEMPO_STREAMING_PROGRESS_REF_ID);
   return {
-    loading,
+    // PanelChrome renders a loading bar for Loading and a streaming indicator for Streaming. Mirror the
+    // query state only while a query is in flight, so neither indicator can outlive the query. Reading
+    // the state directly keeps a leftover Tempo streaming-progress frame from picking the indicator.
+    panelLoadingState: loading ? item.queryResponse.state : undefined,
     tableResult,
     range,
     queryStreaming: item.queryResponse.state === LoadingState.Streaming || Boolean(hasTempoStreamingProgressTable),
@@ -59,7 +62,7 @@ const connector = connect(mapStateToProps, {});
 type Props = TableContainerProps & ConnectedProps<typeof connector>;
 
 export const TableContainer = memo(function TableContainer({
-  loading,
+  panelLoadingState,
   onCellFilterAdded,
   tableResult,
   width,
@@ -100,14 +103,6 @@ export const TableContainer = memo(function TableContainer({
     return name
       ? t('explore.table.title-with-name', 'Table - {{name}}', { name, interpolation: { escapeValue: false } })
       : t('explore.table.title', 'Table');
-  }
-
-  // PanelChrome renders a loading bar for Loading and a streaming indicator for Streaming. Gate both
-  // on a query actually being in flight, so a leftover Tempo streaming-progress frame cannot pin the
-  // streaming indicator on after the query has finished.
-  let panelLoadingState: LoadingState | undefined;
-  if (loading) {
-    panelLoadingState = queryStreaming ? LoadingState.Streaming : LoadingState.Loading;
   }
 
   let dataFrames = hasDeprecatedParentRowIndex(tableResult)


### PR DESCRIPTION
Fixes #129752

## Description

The Explore table panel has never shown a loading indicator. `selectIsWaitingForData` is
curried, but `TableContainer`'s `mapStateToProps` never invoked it with `state`, so
`loading` held a function (since #70324, 2023). Even fixed, the value was unreachable: it
was gated behind `tableResult.length > 0 ? false : ...`, and `loading` is only read inside
the `frames.length > 0` branch — which requires that same condition (since #36027, 2021).
The Graph panel directly above the table has always shown both indicators.

Note the issue describes a perpetual spinner on zero rows; that doesn't reproduce. The bug
runs the other way — the indicator never appears.

## Changes

* Evaluate the curried selector: `selectIsWaitingForData(exploreId)(state)`.
* Drop the self-defeating `tableResult.length > 0` gate, matching `LogsContainer` and `Explore`.
* Derive one `panelLoadingState` for both `PanelChrome`s and the `PanelRenderer` data:
  `Streaming` while streaming, `Loading` while loading, otherwise `undefined`. Gating on
  `loading` stops a leftover Tempo `streaming-progress` frame pinning the streaming dot on.
* Pass `loadingState` to the no-data `PanelChrome`, which previously received none — an
  in-flight query over an empty result no longer looks frozen at "0 series returned".
* Export `mapStateToProps` for testing; add 7 tests (3 fail against the pre-fix component).

## Risks

* Most visible: the table now shows a loading bar over stale rows on every re-query.
  Intentional, and consistent with the Graph panel above it.
* `PanelRenderer` now receives `Loading`/`Streaming` in `data.state` instead of always
  `Done`. `TablePanel` doesn't read `data.state`, so no behaviour change expected.
* Out of scope, and correct as-is: on a first query Explore hasn't decided a table applies
  (`showTable: !!tableResult?.length`), so `TableContainer` isn't mounted. A logs-only
  response has no table, and mounting one that later vanishes would be worse. That window
  is covered by the toolbar's Run query → Cancel state, which was never broken.

## Demo

Counts of loading bars / streaming dots in Explore against `gdev-testdata`. Pre-fix counts
of 1 are the **Graph** panel — the table contributed nothing.

| Scenario | Before | After |
| --- | --- | --- |
| Rows, settled | 0 bars | 0 bars |
| Rows, re-query in flight | 1 bar (graph only) | **2 bars** (graph + table) |
| Zero-row frame, settled | 0 bars, "0 series returned" | unchanged |
| Zero-row frame, in flight | **0 bars** — no feedback | **1 bar** + "0 series returned" |
| Streaming | 1 dot (graph only) | **2 dots**, 0 bars |

<!-- Attach: re-query and streaming before/after -->

## Testing Instructions

If testdata fails to load in a fresh worktree, run
`yarn workspace @grafana-plugins/grafana-testdata-datasource build`.

* **Slow Query** (`6s`): let it settle, then Run query — a loading bar crosses the Table
  panel while old rows stay visible, then clears.
* **CSV Content** with `time,value` and an empty line: settled shows "0 series returned"
  with no bar; re-run (throttled) shows a bar above it.
* **Streaming Client** (type `Signal`): the Table header shows the pulsing streaming dot,
  same as the Graph, and no loading bar for the life of the stream.

## Reviewer Checklist

- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable
