### PR TITLE
TestData: Add e2e-selectors data-testid key and wiring for series count

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -283,6 +283,7 @@ export const versionedComponents = {
           [MIN_GRAFANA_VERSION]: 'TestData noise',
         },
         seriesCount: {
+          '13.2.0': 'data-testid TestData series count',
           [MIN_GRAFANA_VERSION]: 'TestData series count',
         },
         spread: {

--- a/public/app/plugins/datasource/grafana-testdata-datasource/components/RandomWalkEditor.tsx
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/components/RandomWalkEditor.tsx
@@ -38,12 +38,16 @@ export const RandomWalkEditor = ({ onChange, query }: EditorProps) => {
     <InlineFieldRow>
       {randomWalkFields.map(({ label, id, min, step, placeholder, tooltip }) => {
         const selector = testSelectors[id];
+        // Entries upgraded to data-testid matching resolve to a 'data-testid ...' string, which
+        // must not become the accessible name — fall back to the visible label for those.
+        const ariaLabel = selector.startsWith('data-testid') ? label : selector;
         return (
-          <InlineField label={label} labelWidth={14} key={id} aria-label={selector} tooltip={tooltip}>
+          <InlineField label={label} labelWidth={14} key={id} aria-label={ariaLabel} tooltip={tooltip}>
             <Input
               width={32}
               name={id}
               type="number"
+              data-testid={selector}
               id={`randomWalk-${id}-${query.refId}`}
               min={min}
               step={step}


### PR DESCRIPTION
Part of #129672 (Group 3 — Dashboards).

Upgrades the `DataSource.TestData.QueryTab.seriesCount` selector from aria-label matching to `data-testid` matching, and wires it in the testdata plugin's `RandomWalkEditor` — used by the `dynamic-dashboards-tour` Pathfinder guide.

**Why defs + wiring ship together (single PR, unlike the other slices):** this entry is actively consumed via `aria-label` in `RandomWalkEditor`, and app code resolves selectors to `latest` — landing the prefixed key without the wiring would break the field's accessible name and leave `getByGrafanaSelector` matching nothing (flagged by Cursor Bugbot on #129749, where the key was originally staged and has been removed). The wiring also adds an aria-label fallback to the visible label for any entry that resolves to a `data-testid` string; the six sibling fields keep their aria-label-matched legacy selectors untouched.

**Structure (2 commits):**
1. `test(e2e-selectors)` — the `13.2.0` prefixed key (legacy value preserved under `MIN_GRAFANA_VERSION`)
2. `test(testdata)` — wiring + aria-label fallback in the decoupled `grafana-testdata-datasource` workspace

Verified with `yarn typecheck` and ESLint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## MT compatibility exception (`no-check-mt-service-compatibility`)

Why these changes are safe to couple, verified in code and agreed with @joshhunt:

- `@grafana/e2e-selectors` is **not** in the plugin webpack externals (`packages/grafana-plugin-configs/webpack.config.ts`) — each decoupled plugin bundles its own copy of the selector values.
- The static `selectors` export resolves `'latest'` **against its own bundle at module init** (`selectors/index.ts`) with no reads from core runtime, so core/plugin version skew cannot change what the plugin renders or references.
- The resolver falls back to the newest available key when a requested version has no match (`resolver.ts`), so a missing selector path or version key can never occur at runtime.
- Consumers of the affected values were enumerated: no in-repo test or live guide targets the old values in a way this change breaks; guide retargets are sequenced after plugin rollout via the migration map for #129672.

Net: there is no runtime contract across the frontend/plugin version boundary for this change; the coupling is safe.
