### PR TITLE
E2E Selectors: Add NavMenu section toggle selector for pathfinder guides

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -1199,6 +1199,9 @@ export const versionedComponents = {
     item: {
       '9.5.0': 'data-testid Nav menu item',
     },
+    sectionToggleButton: {
+      '13.2.0': (navUrl: string) => `data-testid navigation mega-menu section toggle ${navUrl}`,
+    },
   },
   NavToolbar: {
     container: {

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.tsx
@@ -7,6 +7,7 @@ import { useLocation } from 'react-router-dom-v5-compat';
 import { useLocalStorage } from 'react-use';
 
 import { FeatureState, type GrafanaTheme2, type NavModelItem, toIconName } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { useStyles2, Text, IconButton, Icon, Stack, FeatureBadge, Box } from '@grafana/ui';
 import { useGrafana } from 'app/core/context/GrafanaContext';
@@ -247,6 +248,7 @@ export function MegaMenuItem({
                     })
               }
               aria-expanded={Boolean(sectionExpanded)}
+              data-testid={selectors.components.NavMenu.sectionToggleButton(link.url)}
               className={styles.collapseButton}
               onClick={() => setSectionExpanded(!sectionExpanded)}
               name={getIconName(Boolean(sectionExpanded))}


### PR DESCRIPTION
Part of #129672 (Group 5 — Nav & chrome).

Replaces weak Pathfinder guide selectors with a single parameterized `@grafana/e2e-selectors` entry: `components.NavMenu.sectionToggleButton(navUrl)`, wired on the mega-menu section expand/collapse button in `MegaMenuItem.tsx` (one selector on the recursive row per the loop rule, keyed by the section's stable nav URL). Covers 7 anchor uses across the mysql/postgresql observability and adaptive-metrics guides; the remaining nav anchors resolve via the existing `NavMenu.item` + href compound with zero code.

**Structure (2 commits):**
1. `test(e2e-selectors)` — selector definition only
2. wiring in `MegaMenuItem.tsx` (under `public/app`)

No existing selector values modified or deleted. Verified with `yarn typecheck`, ESLint, and `yarn nx run @grafana/e2e-selectors:build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)