### PR TITLE
Dashboards: Load the panel editor on demand

### DIFF
--- a/public/app/features/dashboard-scene/mutation-api/commands/applySpec.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/applySpec.test.ts
@@ -8,6 +8,7 @@
  * that is what is asserted.
  */
 
+import { waitFor } from '@testing-library/react';
 import { cloneDeep } from 'lodash';
 
 import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
@@ -142,7 +143,8 @@ describe('APPLY_SPEC with a panel open for editing', () => {
     expect(editedPanelKey(scene)).toBeUndefined();
 
     libPanel.setState({ isLoaded: true });
-    expect(editedPanelKey(scene)).toBe('panel-2');
+    // The panel editor is code split, so editPanel lands in a follow-up state update.
+    await waitFor(() => expect(editedPanelKey(scene)).toBe('panel-2'));
     expect(editorIsAttached(scene)).toBe(true);
   });
 
@@ -161,7 +163,7 @@ describe('APPLY_SPEC with a panel open for editing', () => {
     expect(editedPanelKey(scene)).toBeUndefined();
 
     getLibraryPanelBehavior(findVizPanelByKey(scene, 'panel-2')!)!.setState({ isLoaded: true });
-    expect(editedPanelKey(scene)).toBe('panel-2');
+    await waitFor(() => expect(editedPanelKey(scene)).toBe('panel-2'));
     expect(editorIsAttached(scene)).toBe(true);
   });
 
@@ -178,7 +180,7 @@ describe('APPLY_SPEC with a panel open for editing', () => {
     stale.setState({ isLoaded: true });
     getLibraryPanelBehavior(findVizPanelByKey(scene, 'panel-2')!)!.setState({ isLoaded: true });
 
-    expect(editedPanelKey(scene)).toBe('panel-2');
+    await waitFor(() => expect(editedPanelKey(scene)).toBe('panel-2'));
     expect(editorIsAttached(scene)).toBe(true);
   });
 

--- a/public/app/features/dashboard-scene/panel-edit/openPanelEditor.ts
+++ b/public/app/features/dashboard-scene/panel-edit/openPanelEditor.ts
@@ -1,0 +1,16 @@
+import { type VizPanel } from '@grafana/scenes';
+
+import { type DashboardScene } from '../scene/DashboardScene';
+
+/**
+ * Enters panel edit for `panel`.
+ *
+ * The panel editor pulls in the options pane, the data pane and the alerting tab — over a
+ * megabyte that most sessions never render — so it is fetched on demand instead of being part
+ * of the initial bundle. Callers must therefore not assume `dashboard.state.editPanel` is set
+ * by the time this returns.
+ */
+export async function openPanelEditor(dashboard: DashboardScene, panel: VizPanel, isNewPanel = false) {
+  const { buildPanelEditScene } = await import(/* webpackChunkName: "panel-edit" */ './PanelEditor');
+  dashboard.setState({ editPanel: buildPanelEditScene(panel, isNewPanel) });
+}

--- a/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.test.tsx
@@ -411,6 +411,9 @@ describe('DashboardDatasourceBehaviour', () => {
 
   describe('Library panels', () => {
     it('should re-run queries when library panel re-runs query', async () => {
+      // The unloaded library panel triggers a real request that jsdom cannot serve, same as the
+      // test below.
+      jest.spyOn(console, 'error').mockImplementation();
       const libPanelBehavior = new LibraryPanelBehavior({
         isLoaded: false,
         uid: 'fdcvggvfy2qdca',

--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.test.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.test.ts
@@ -1,3 +1,5 @@
+import { waitFor } from '@testing-library/react';
+
 import { SceneQueryRunner, VizPanel } from '@grafana/scenes';
 
 import { DashboardScene } from './DashboardScene';
@@ -24,13 +26,15 @@ describe('DashboardSceneUrlSync', () => {
   });
 
   describe('entering edit mode', () => {
-    it('it should be possible to go from the view panel view to the edit view when the dashboard is not in edit mdoe', () => {
+    it('it should be possible to go from the view panel view to the edit view when the dashboard is not in edit mdoe', async () => {
       const scene = buildTestScene();
       scene.setState({ isEditing: false });
       scene.urlSync?.updateFromUrl({ viewPanel: 'panel-1' });
       expect(scene.state.viewPanel).toBeDefined();
       scene.urlSync?.updateFromUrl({ editPanel: 'panel-1' });
-      expect(scene.state.editPanel).toBeDefined();
+      // The panel editor is code split, so editPanel lands in a follow-up state update.
+      await waitFor(() => expect(scene.state.editPanel).toBeDefined());
+      expect(scene.state.viewPanel).toBeUndefined();
     });
   });
 });

--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.test.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.test.ts
@@ -1,3 +1,5 @@
+import { waitFor } from '@testing-library/react';
+
 import { locationService } from '@grafana/runtime';
 import { NewSceneObjectAddedEvent, SceneQueryRunner, VizPanel } from '@grafana/scenes';
 
@@ -259,13 +261,15 @@ describe('DashboardSceneUrlSync', () => {
   });
 
   describe('entering edit mode', () => {
-    it('it should be possible to go from the view panel view to the edit view when the dashboard is not in edit mdoe', () => {
+    it('it should be possible to go from the view panel view to the edit view when the dashboard is not in edit mdoe', async () => {
       const scene = buildTestScene();
       scene.setState({ isEditing: false });
       scene.urlSync?.updateFromUrl({ viewPanel: 'panel-1' });
       expect(scene.state.viewPanel).toBeDefined();
       scene.urlSync?.updateFromUrl({ editPanel: 'panel-1' });
-      expect(scene.state.editPanel).toBeDefined();
+      // The panel editor is code split, so editPanel lands in a follow-up state update.
+      await waitFor(() => expect(scene.state.editPanel).toBeDefined());
+      expect(scene.state.viewPanel).toBeUndefined();
     });
   });
 });

--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
@@ -1,8 +1,8 @@
 import { type Unsubscribable } from 'rxjs';
 
-import { type SceneObjectUrlSyncHandler, type SceneObjectUrlValues } from '@grafana/scenes';
+import { type SceneObjectUrlSyncHandler, type SceneObjectUrlValues, type VizPanel } from '@grafana/scenes';
 
-import { buildPanelEditScene } from '../panel-edit/PanelEditor';
+import { openPanelEditor } from '../panel-edit/openPanelEditor';
 import { createDashboardEditViewFor } from '../settings/createDashboardEditViewFor';
 import { ShareDrawer } from '../sharing/ShareDrawer/ShareDrawer';
 import { findEditPanel, getLibraryPanelBehavior } from '../utils/utils';
@@ -126,8 +126,7 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
         return;
       }
 
-      this._releaseEditPanel();
-      update.editPanel = buildPanelEditScene(panel, panel.state.pluginId === UNCONFIGURED_PANEL_PLUGIN_ID);
+      this._enterPanelEdit(values.editPanel, panel);
     } else if (values.editPanel === null) {
       // Closing the pane supersedes a re-open still waiting on a library panel.
       this._releaseEditPanel();
@@ -216,8 +215,23 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
       return;
     }
 
-    this._scene.setState({
-      editPanel: buildPanelEditScene(panel, panel.state.pluginId === UNCONFIGURED_PANEL_PLUGIN_ID),
+    this._enterPanelEdit(panelId, panel);
+  }
+
+  /**
+   * The editor is code split, so the pane only lands in a follow-up state update once the chunk has
+   * loaded. The hold stands for that window, the same way it does for the library panel wait: any
+   * state change in between would otherwise write `?editPanel=` out of the URL.
+   */
+  private _enterPanelEdit(panelId: string, panel: VizPanel) {
+    this._libPanelSub?.unsubscribe();
+    this._libPanelSub = undefined;
+    this._heldEditPanelId = panelId;
+
+    openPanelEditor(this._scene, panel, panel.state.pluginId === UNCONFIGURED_PANEL_PLUGIN_ID).then(() => {
+      if (this._heldEditPanelId === panelId) {
+        this._heldEditPanelId = undefined;
+      }
     });
   }
 }

--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
@@ -1,8 +1,8 @@
 import { type Unsubscribable } from 'rxjs';
 
-import { type SceneObjectUrlSyncHandler, type SceneObjectUrlValues } from '@grafana/scenes';
+import { type SceneObjectUrlSyncHandler, type SceneObjectUrlValues, type VizPanel } from '@grafana/scenes';
 
-import { buildPanelEditScene } from '../panel-edit/PanelEditor';
+import { openPanelEditor } from '../panel-edit/openPanelEditor';
 import { createDashboardEditViewFor } from '../settings/createDashboardEditViewFor';
 import { ShareDrawer } from '../sharing/ShareDrawer/ShareDrawer';
 import { findEditPanel, getLibraryPanelBehavior } from '../utils/utils';
@@ -126,8 +126,7 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
         return;
       }
 
-      this._releaseEditPanel();
-      update.editPanel = buildPanelEditScene(panel, panel.state.pluginId === UNCONFIGURED_PANEL_PLUGIN_ID);
+      this._enterPanelEdit(values.editPanel, panel);
     } else if (values.editPanel === null) {
       // Closing the pane supersedes a re-open still waiting on a library panel.
       this._releaseEditPanel();
@@ -212,8 +211,23 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
       return;
     }
 
-    this._scene.setState({
-      editPanel: buildPanelEditScene(panel, panel.state.pluginId === UNCONFIGURED_PANEL_PLUGIN_ID),
+    this._enterPanelEdit(panelId, panel);
+  }
+
+  /**
+   * The editor is code split, so the pane only lands in a follow-up state update once the chunk has
+   * loaded. The hold stands for that window, the same way it does for the library panel wait: any
+   * state change in between would otherwise write `?editPanel=` out of the URL.
+   */
+  private _enterPanelEdit(panelId: string, panel: VizPanel) {
+    this._libPanelSub?.unsubscribe();
+    this._libPanelSub = undefined;
+    this._heldEditPanelId = panelId;
+
+    openPanelEditor(this._scene, panel, panel.state.pluginId === UNCONFIGURED_PANEL_PLUGIN_ID).then(() => {
+      if (this._heldEditPanelId === panelId) {
+        this._heldEditPanelId = undefined;
+      }
     });
   }
 }

--- a/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
+++ b/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
@@ -20,7 +20,7 @@ import { StarToolbarButton } from 'app/features/stars/StarToolbarButton';
 import { useSelector } from 'app/types/store';
 
 import { selectFolderRepository } from '../../provisioning/utils/selectors';
-import { buildPanelEditScene } from '../panel-edit/PanelEditor';
+import { openPanelEditor } from '../panel-edit/openPanelEditor';
 import ExportButton from '../sharing/ExportButton/ExportButton';
 import ShareButton from '../sharing/ShareButton/ShareButton';
 import { DashboardInteractions } from '../utils/interactions';
@@ -176,7 +176,7 @@ export function ToolbarActions({ dashboard }: Props) {
               onClick={() => {
                 const vizPanel = dashboard.onCreateNewPanel();
                 DashboardInteractions.toolbarAddButtonClicked({ item: 'add_visualization' });
-                dashboard.setState({ editPanel: buildPanelEditScene(vizPanel, true) });
+                openPanelEditor(dashboard, vizPanel, true);
               }}
             />
             <Menu.Item

--- a/public/app/features/dashboard/dashgrid/DashboardEmpty/DashboardEmptyHooks.ts
+++ b/public/app/features/dashboard/dashgrid/DashboardEmpty/DashboardEmptyHooks.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 
 import { locationService } from '@grafana/runtime';
-import { buildPanelEditScene } from 'app/features/dashboard-scene/panel-edit/PanelEditor';
+import { openPanelEditor } from 'app/features/dashboard-scene/panel-edit/openPanelEditor';
 import { DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
 import { DashboardInteractions } from 'app/features/dashboard-scene/utils/interactions';
 import { useGetResourceRepositoryView } from 'app/features/provisioning/hooks/useGetResourceRepositoryView';
@@ -47,7 +47,7 @@ export const useOnAddVisualization = ({ dashboard, canCreate, isReadOnlyRepo }: 
     return () => {
       if (dashboard instanceof DashboardScene) {
         const panel = dashboard.onCreateNewPanel();
-        dashboard.setState({ editPanel: buildPanelEditScene(panel, true) });
+        openPanelEditor(dashboard, panel, true);
         locationService.partial({ firstPanel: true });
       } else {
         const id = onCreateNewPanel(dashboard, initialDatasource);


### PR DESCRIPTION
**What is this feature?**

Moves the dashboard-scene panel editor out of the `app` entrypoint's initial chunks and loads it when the user actually opens it.

Only three modules imported `PanelEditor` as a value, all just to call `buildPanelEditScene`:

- `scene/DashboardSceneUrlSync.ts` — `?editPanel=` in the URL
- `scene/NavToolbarActions.tsx` — **Add → Visualization**
- `dashgrid/DashboardEmpty/DashboardEmptyHooks.ts` — **Add visualization** on an empty dashboard

Every other importer uses `import { type PanelEditor }`, which is erased. Those three now go through a new `openPanelEditor()` that dynamically imports the editor and then sets `editPanel`.

**Why do we need this feature?**

Every page load — including ones that never open a dashboard — was downloading and parsing PanelEditor plus 139 concatenated modules, which also drags in the panel data pane and, via `PanelDataAlertingTab`, the alerting rules table.

Measured on the `app` entrypoint's initial JS (every file in `entrypoints.app.assets.js`, i.e. what `webassets.go` turns into `<script>` tags), against `a2cf8afa187`:

| | raw | gzip |
|---|---|---|
| before | 10,591,195 B | 2,995,836 B |
| after | 9,901,454 B | 2,795,897 B |
| **saving** | **-674 KiB** | **-195 KiB** |

**Who is this feature for?**

All Grafana users — this is initial page load weight.

**Special notes for your reviewer:**

`DashboardSceneUrlSync.updateFromUrl` is synchronous and cannot await, so `editPanel` now lands in a follow-up state update. This is not a new pattern for that class: `_waitForLibPanelToLoadBeforeEnteringPanelEdit` already returns early and sets `editPanel` from a subscription once the library panel resolves.

Both places that open the editor from that class go through one `_enterPanelEdit()` helper, which holds `_heldEditPanelId` for the duration of the chunk fetch. Without the hold, `?editPanel=` would be written out of the URL by any state change landing while the chunk is in flight — the same window the library-panel wait already holds for.
