### PR TITLE
Chore: Only bundle the moment locales Grafana can use

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1146,6 +1146,7 @@ scripts/verify-pkg-stig.sh @grafana/grafana-backend-services-squad
 /jest.config.codeowner.js @grafana/dataviz-squad
 
 /scripts/**/generate-transformations* @grafana/datapro
+/scripts/**/momentLocales* @grafana/grafana-frontend-platform
 /scripts/webpack/ @grafana/grafana-frontend-platform
 /scripts/test-aliases.py @grafana/docs-tooling @jtvdez
 eslint-suppressions.json @grafanabot

--- a/scripts/tests/momentLocales.test.ts
+++ b/scripts/tests/momentLocales.test.ts
@@ -1,0 +1,51 @@
+import { existsSync } from 'fs';
+import moment from 'moment';
+import path from 'path';
+
+import { LANGUAGES } from '../../packages/grafana-i18n/src/languages.ts';
+import { getMomentLocaleCandidates, getMomentLocaleRegExp } from '../webpack/momentLocales.ts';
+
+const MOMENT_LOCALE_DIR = path.join(__dirname, '../../node_modules/moment/locale');
+
+describe('moment locale allowlist', () => {
+  const candidates = getMomentLocaleCandidates();
+  const regexp = getMomentLocaleRegExp();
+
+  it('covers every locale moment actually resolves for a supported language', () => {
+    for (const { code } of LANGUAGES) {
+      // Whatever locale moment settles on for this language must survive the allowlist,
+      // otherwise the webpack context drops the file and dates silently fall back to English.
+      const resolved = moment.locale(code);
+
+      if (resolved === 'en') {
+        // moment has no locale for this tag and falls back to its built-in English.
+        continue;
+      }
+
+      expect(regexp.test(`./${resolved}`)).toBe(true);
+    }
+  });
+
+  it('only keeps locales moment can be asked for', () => {
+    // A candidate that does not exist on disk is harmless, but one that exists and is not
+    // reachable from LANGUAGES is dead weight in the bundle.
+    const reachable = new Set<string>();
+    for (const { code } of LANGUAGES) {
+      const parts = code.toLowerCase().split('-');
+      for (let i = parts.length; i > 0; i--) {
+        reachable.add(parts.slice(0, i).join('-'));
+      }
+    }
+
+    for (const candidate of candidates) {
+      expect(reachable.has(candidate)).toBe(true);
+    }
+  });
+
+  it('is much smaller than bundling everything', () => {
+    const onDisk = candidates.filter((locale) => existsSync(path.join(MOMENT_LOCALE_DIR, `${locale}.js`)));
+
+    expect(onDisk.length).toBeGreaterThan(0);
+    expect(onDisk.length).toBeLessThan(30);
+  });
+});

--- a/scripts/webpack/momentLocales.ts
+++ b/scripts/webpack/momentLocales.ts
@@ -1,0 +1,50 @@
+// Imports the language constants rather than LANGUAGES from `../languages.ts`, because that
+// module uses extensionless relative imports which node cannot resolve when it loads the
+// webpack config. Every constant here feeds LANGUAGES, and momentLocales.test.ts asserts that
+// the allowlist covers every entry of LANGUAGES so the two cannot drift apart.
+import * as languageConstants from '../../packages/grafana-i18n/src/constants.ts';
+
+/** Not a language; the pseudo locale is only used for translation QA. */
+const NOT_A_LANGUAGE = new Set(['PSEUDO_LOCALE']);
+
+function getSupportedLanguageCodes(): string[] {
+  return Object.entries(languageConstants)
+    .filter(([name, code]) => !NOT_A_LANGUAGE.has(name) && typeof code === 'string')
+    .map(([, code]) => code);
+}
+
+/**
+ * moment resolves a locale by lowercasing the requested tag and then trying progressively
+ * shorter prefixes: `moment.locale('pt-BR')` looks for `pt-br`, then `pt`. So the set of
+ * locale files moment can ever ask for is every prefix of every language Grafana supports.
+ *
+ * Prefixes moment does not ship (`zh-hans`, `zh`, `fr-fr`, ...) are simply absent from the
+ * require context and cost nothing.
+ */
+export function getMomentLocaleCandidates(): string[] {
+  const candidates = new Set<string>();
+
+  for (const code of getSupportedLanguageCodes()) {
+    const parts = code.toLowerCase().split('-');
+    for (let i = parts.length; i > 0; i--) {
+      candidates.add(parts.slice(0, i).join('-'));
+    }
+  }
+
+  // moment has `en` built in and never loads it from ./locale.
+  candidates.delete('en');
+
+  return [...candidates].sort();
+}
+
+/**
+ * Matches the requests moment makes into its `./locale` context, restricted to the languages
+ * Grafana ships. Bundling all ~137 locales instead costs ~300 KiB in the initial chunks.
+ */
+export function getMomentLocaleRegExp(): RegExp {
+  const alternation = getMomentLocaleCandidates()
+    .map((locale) => locale.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('|');
+
+  return new RegExp(`^\\./(${alternation})$`);
+}

--- a/scripts/webpack/webpack.common.ts
+++ b/scripts/webpack/webpack.common.ts
@@ -7,6 +7,7 @@ import webpack, { type Configuration } from 'webpack';
 
 import { getEnvConfig } from '../cli/env-util.ts';
 
+import { getMomentLocaleRegExp } from './momentLocales.ts';
 import CorsWorkerPlugin from './plugins/CorsWorkerPlugin.ts';
 import { esbuildRule, sassRule } from './rules.ts';
 
@@ -103,6 +104,9 @@ export default (env: Env = {}): Configuration => ({
         ]
       : []),
     new CorsWorkerPlugin(),
+    // moment requires its locales through a dynamic expression, so webpack bundles all ~137 of
+    // them. Grafana only ever calls moment.locale() with a language it ships translations for.
+    new webpack.ContextReplacementPlugin(/moment[\\/]locale$/, getMomentLocaleRegExp()),
     new webpack.ProvidePlugin({
       Buffer: ['buffer', 'Buffer'],
     }),


### PR DESCRIPTION
**What is this feature?**

Narrows moment's `./locale` require context to the languages Grafana ships, so webpack bundles 16 locale files instead of all 137.

**Why do we need this feature?**

moment loads locales with `require('./locale/' + name)`. Webpack cannot statically resolve that expression, so it bundles the entire directory into the `app` entrypoint's initial chunks. Grafana only ever calls `setLocale()` with the user's language — one of the 19 tags in `packages/grafana-i18n/src/constants.ts`.

Measured on the `app` entrypoint's initial JS, against `7b7f70746bc`:

| | raw | gzip |
|---|---|---|
| before | 10,571,294 B | 2,952,679 B |
| after | 10,257,482 B | 2,893,519 B |
| **saving** | **-306 KiB** | **-58 KiB** |

**Who is this feature for?**

All Grafana users — this is initial page load weight.

**Special notes for your reviewer:**

The allowlist is **derived** from the language constants, not hand-written, and expands each tag into the prefixes moment actually tries (`moment.locale('pt-BR')` looks for `pt-br`, then `pt`), so it cannot drift as languages are added. `scripts/tests/momentLocales.test.ts` asserts it covers every entry of `LANGUAGES`.

The locale files stay in the initial chunks — that's what moment's synchronous require needs. There are just 16 of them. `en` is excluded because moment has it built in.

`momentLocales.ts` imports the constants module directly rather than `LANGUAGES`, because `languages.ts` uses extensionless relative imports that node cannot resolve when it loads the webpack config.

⚠️ **The one thing worth pushing back on:** `moment` is a SystemJS shared dependency, so plugins get Grafana's instance. A plugin calling `moment.locale()` with a tag outside our supported set now silently keeps the current locale instead of switching. Overriding the global locale would already corrupt Grafana's own date formatting, so it isn't a pattern we support — but it *is* a behaviour change for any plugin doing it. Adding a tag back is a one-line change. Happy to drop this PR if that trade isn't wanted.

zh-Hans and zh-Hant are unaffected: moment ships no `zh` locale, only `zh-cn`/`zh-tw`, which it never tries for those tags. Chinese users already got English moment formatting.

If you re-measure this locally: `cache.buildDependencies` only lists `webpack.prod.ts`, so edits to `webpack.common.ts` do **not** invalidate the persistent cache and a warm rebuild reports no change. Clear `node_modules/.cache/webpack` first.

One of five independent PRs reducing initial chunk size. They can merge in any order.