### PR TITLE
Chore: Bundle a single copy of RxJS

### DIFF
--- a/scripts/webpack/webpack.common.ts
+++ b/scripts/webpack/webpack.common.ts
@@ -58,6 +58,12 @@ export default (env: Env = {}): Configuration => ({
       '@locker/near-membrane-dom/custom-devtools-formatter': require.resolve(
         '@locker/near-membrane-dom/custom-devtools-formatter.js'
       ),
+      // rxjs' package exports map `require` to dist/cjs and everything else to dist/esm5, so a
+      // single CommonJS dependency is enough to bundle a second, un-tree-shakeable copy of the
+      // whole library. Pin every request to the ESM build the rest of the app already uses.
+      // The dist/esm5 directory mirrors the package's subpath layout, so `rxjs/operators` and
+      // friends keep resolving.
+      rxjs: path.join(path.dirname(require.resolve('rxjs/package.json')), 'dist/esm5'),
     },
     modules: [
       // default value


### PR DESCRIPTION
**What is this feature?**

Aliases `rxjs` to its ESM build so the app bundles one copy instead of two.

**Why do we need this feature?**

rxjs' package `exports` map sends the `require` condition to `dist/cjs` and everything else to `dist/esm5`. `@grafana/assistant` ships a CommonJS bundle with no `module`/`exports` field, so its `require('rxjs')` resolved to `dist/cjs` while the rest of the app resolved to `dist/esm5` — two complete copies of RxJS in the initial chunks. Because the CommonJS one is reached through `require`, webpack cannot tree-shake it, so all of it shipped.

Measured on the `app` entrypoint's initial JS, against `7b7f70746bc` with a cold webpack cache:

| | raw | gzip |
|---|---|---|
| before | 10,571,294 B | 2,952,679 B |
| after | 10,469,948 B | 2,932,294 B |
| **saving** | **-99 KiB** | **-20 KiB** |

**Who is this feature for?**

All Grafana users — this is initial page load weight.

**Special notes for your reviewer:**

`dist/esm5` mirrors the package's subpath layout, so `rxjs/operators`, `rxjs/fetch` and `rxjs/testing` keep resolving. I verified after the change that the bundle contains only `dist/esm5` modules and no `dist/cjs` ones (dumped module paths from webpack stats and grouped by dist flavour).

The path is derived from `rxjs/package.json` rather than the dist file directly, because the package's `exports` map refuses to resolve `rxjs/dist/esm5/index.js`.

Sharing one RxJS instance is also more correct than having two: operators and Observables from different copies don't `instanceof` each other.

Core-app build config only — plugin builds resolve rxjs through `packages/grafana-plugin-configs/webpack.config.ts`, untouched.

⚠️ If you re-measure this locally: `cache.buildDependencies` only lists `webpack.prod.ts`, so edits to `webpack.common.ts` do **not** invalidate the persistent cache and a warm rebuild reports **zero** change. Clear `node_modules/.cache/webpack` first. (This caught me out — worth fixing separately.)

One of five independent PRs reducing initial chunk size. They can merge in any order.