### PR TITLE
Chore: Keep the OTLP exporter out of the initial bundle

### DIFF
--- a/public/app/features/inspector/utils/transformToOTLP.test.ts
+++ b/public/app/features/inspector/utils/transformToOTLP.test.ts
@@ -1,0 +1,21 @@
+// This is the one place allowed to import the exporter's runtime value. transformToOTLP.ts
+// imports it as a type only, so the exporter's ~54 module runtime graph stays out of the app
+// bundle; tests are not bundled, so importing it here is free.
+import { collectorTypes } from '@opentelemetry/exporter-collector';
+
+import { SpanKind } from './transformToOTLP';
+
+describe('transformToOTLP SpanKind', () => {
+  it('mirrors the exporter enum exactly', () => {
+    // TypeScript numeric enums are two-way maps at runtime (name -> value and value -> name).
+    // Keep only the forward direction so this compares like for like.
+    const enumMembers = Object.fromEntries(
+      Object.entries(collectorTypes.opentelemetryProto.trace.v1.Span.SpanKind).filter(([key]) =>
+        Number.isNaN(Number(key))
+      )
+    );
+
+    // Fails if a member is added, removed, renamed or renumbered upstream.
+    expect(SpanKind).toEqual(enumMembers);
+  });
+});

--- a/public/app/features/inspector/utils/transformToOTLP.ts
+++ b/public/app/features/inspector/utils/transformToOTLP.ts
@@ -2,7 +2,9 @@
 // from core and moved to an external repo, but the core trace download utility still needs to support
 // converting DataFrames to OTLP format for existing traces tagged with traceFormat: 'otlp'.
 import { type SpanStatus } from '@opentelemetry/api';
-import { collectorTypes } from '@opentelemetry/exporter-collector';
+// Type-only: importing the value pulls the exporter's whole runtime (~54 modules) into the
+// initial bundle just for the SpanKind numbers, which are inlined in getOTLPSpanKind instead.
+import { type collectorTypes } from '@opentelemetry/exporter-collector';
 
 import {
   type MutableDataFrame,
@@ -80,11 +82,29 @@ export function transformToOTLP(data: MutableDataFrame): {
   return result;
 }
 
-function getOTLPSpanKind(kind: string): collectorTypes.opentelemetryProto.trace.v1.Span.SpanKind | undefined {
+type OTLPSpanKind = collectorTypes.opentelemetryProto.trace.v1.Span.SpanKind;
+
+/**
+ * OTLP `Span.SpanKind` wire values, mirrored from the exporter's enum so the import above can
+ * stay type-only.
+ *
+ * A type-only import cannot reach the enum's member names, so the compiler cannot check this
+ * mirrors the real thing. `transformToOTLP.test.ts` asserts it against the enum instead —
+ * the test may import the value because tests are not part of the app bundle.
+ */
+export const SpanKind = {
+  SPAN_KIND_UNSPECIFIED: 0,
+  SPAN_KIND_INTERNAL: 1,
+  SPAN_KIND_SERVER: 2,
+  SPAN_KIND_CLIENT: 3,
+  SPAN_KIND_PRODUCER: 4,
+  SPAN_KIND_CONSUMER: 5,
+};
+
+function getOTLPSpanKind(kind: string): OTLPSpanKind | undefined {
   if (!kind) {
     return undefined;
   }
-  const { SpanKind } = collectorTypes.opentelemetryProto.trace.v1.Span;
   switch (kind) {
     case 'server':
       return SpanKind.SPAN_KIND_SERVER;


### PR DESCRIPTION
**What is this feature?**

Makes `transformToOTLP.ts`'s import of `@opentelemetry/exporter-collector` type-only, mirrors the six `SpanKind` wire values it actually used, and adds a test that keeps those values honest.

**Why do we need this feature?**

`transformToOTLP.ts` imported `collectorTypes` as a value. Every other reference in the file is a type position; the only runtime use was destructuring six integers out of the `Span.SpanKind` enum. That one value import pulled the exporter's whole 54-module runtime graph into the `app` entrypoint's initial chunks, downloaded and executed on every page load — for something only needed when a user clicks **Download traces** in the panel inspector.

Measured on the `app` entrypoint's initial JS (every file in `entrypoints.app.assets.js`, i.e. what `webassets.go` turns into `<script>` tags), against `7b7f70746bc` with a cold webpack cache:

| | raw | gzip |
|---|---|---|
| before | 10,571,294 B | 2,952,679 B |
| after | 10,484,929 B | 2,928,318 B |
| **saving** | **-84 KiB** | **-24 KiB** |

**Who is this feature for?**

All Grafana users — this is initial page load weight.

**Special notes for your reviewer:**

<details>
<summary><b>Why webpack can't just tree shake this</b></summary>

The exporter resolves to its ESM build, so this is not the CommonJS-`require` problem that defeats tree shaking elsewhere. The blocker is that it does not declare `sideEffects: false`, and its barrel is:

```js
export * from './CollectorExporterBase';
export * from './platform';
import * as collectorTypes_1 from './types';
export { collectorTypes_1 as collectorTypes };
```

Without the declaration webpack must assume every module reached by those `export *` statements has side effects, so all 55 are kept even though only `collectorTypes` is used.

I measured the alternative — forcing `sideEffects: false` on the package from `webpack.common.ts`, keeping the original value import:

| | raw | gzip | exporter modules left initial |
|---|---|---|---|
| base (as published) | 10,571,294 B | 2,952,679 B | 55 |
| + `sideEffects: false` override | 10,487,001 B | 2,928,869 B | 1 (`types.js`, 9.8 KiB) |
| this PR (type-only import) | 10,484,929 B | 2,928,318 B | 0 |

So the missing declaration accounts for essentially the whole saving. I went with the type-only import anyway, because `sideEffects: false` would be an unverifiable claim about a third-party package's purity, asserted from our build config, where a mistake surfaces as a silent missing side effect at runtime rather than a build error. The type-only import removes the dependency outright instead of trimming it, and needs no such claim.
</details>

**On the mirrored constants and the test**

A type-only import cannot reach the enum's member names (`keyof typeof X` needs `X` as a value), so the compiler *cannot* check that the mirrored values match. `transformToOTLP.test.ts` asserts them against the real enum instead — a test may import the value, because tests are not bundled.

It filters out the reverse mappings that TypeScript numeric enums create at runtime (`{ 2: 'SPAN_KIND_SERVER' }`) so it compares like for like, and `toEqual` is exact in both directions, so it fails if a member is added, removed, renamed or renumbered upstream.

I verified the test actually bites rather than just passing: changing `SPAN_KIND_SERVER: 2` to `9` fails it, and deleting `SPAN_KIND_CONSUMER` fails it.

No type assertion is needed on the constants — `SpanKind` is an *ambient* enum from a `.d.ts`, so TypeScript keeps the permissive numeric-enum assignability rule and plain number literals are assignable. (The literal-union narrowing that would reject them only applies to enums declared in source.)

**No API or behaviour change.** Nothing is deferred; the dependency simply stops being emitted. `app/features/inspector/utils/download` is not in the SystemJS plugin shared-dependency allowlist, so this is not observable by plugin authors.

One of five independent PRs reducing initial chunk size. They can merge in any order.