### PR TITLE
Chore: Load the frontend plugin sandbox on demand

### DIFF
--- a/public/app/features/plugins/importer/importPluginModule.ts
+++ b/public/app/features/plugins/importer/importPluginModule.ts
@@ -7,7 +7,6 @@ import builtInPlugins, { isBuiltinPluginPath } from '../built_in_plugins';
 import { registerPluginInfoInCache } from '../loader/pluginInfoCache';
 import { SystemJS } from '../loader/systemjs';
 import { resolveModulePath } from '../loader/utils';
-import { importPluginModuleInSandbox } from '../sandbox/sandboxPluginLoader';
 import { shouldLoadPluginInFrontendSandbox } from '../sandbox/sandboxPluginLoaderRegistry';
 
 import { addTranslationsToI18n } from './addTranslationsToI18n';
@@ -65,6 +64,11 @@ export async function importPluginModule({
 
   // the sandboxing environment code cannot work in nodejs and requires a real browser
   if (await shouldLoadPluginInFrontendSandbox({ pluginId })) {
+    // Loaded on demand: the near-membrane runtime behind this is large and most installs
+    // never sandbox a plugin, so it should not be in the initial bundle.
+    const { importPluginModuleInSandbox } = await import(
+      /* webpackChunkName: "pluginSandbox" */ '../sandbox/sandboxPluginLoader'
+    );
     return importPluginModuleInSandbox({ pluginId });
   }
 


### PR DESCRIPTION
**What is this feature?**

Defers `sandboxPluginLoader` behind a dynamic import so `@locker/near-membrane-*` leaves the initial bundle.

**Why do we need this feature?**

`importPluginModule` statically imported `sandboxPluginLoader`, which pulls in `@locker/near-membrane-dom` and `@locker/near-membrane-base`. That put the whole near-membrane runtime in the `app` entrypoint's initial chunks for every user, even though the sandbox is only entered when `shouldLoadPluginInFrontendSandbox()` returns true — an uncommon configuration, and one most installs never hit at all.

Measured on the `app` entrypoint's initial JS, against `7b7f70746bc`:

| | raw | gzip |
|---|---|---|
| before | 10,571,294 B | 2,952,679 B |
| after | 10,503,190 B | 2,931,376 B |
| **saving** | **-67 KiB** | **-21 KiB** |

**Who is this feature for?**

All Grafana users — this is initial page load weight.

**Special notes for your reviewer:**

The call site is already inside an `await`ed async function, so this needs no restructuring and no change to `importPluginModule`'s signature or behaviour — the chunk is fetched at the point the sandbox was about to be used. `sandboxPluginLoader` has exactly one importer in the repo, so this is the only edge to cut.

Sandboxed plugin loads now wait on one extra chunk request. Plugin authors see no change: internal loader path, no `@grafana/*` export or plugin contract involved.

`public/app/features/plugins/importer` and `.../sandbox` tests pass (34).

One of five independent PRs reducing initial chunk size. They can merge in any order.