### PR TITLE
unified-storage: on list stream keys into batchget

### DIFF
--- a/pkg/storage/unified/resource/datastore.go
+++ b/pkg/storage/unified/resource/datastore.go
@@ -50,6 +50,8 @@ const (
 	groupResourcesCacheKey = "group-resources"
 	// batch operations
 	dataBatchSize = 50 // default batch size for BatchGet operations
+	// keyPageSize is the number of raw keys fetched per key-scan page.
+	keyPageSize = 500
 )
 
 // dataStore is a data store that uses a KV store to store data.
@@ -378,6 +380,48 @@ func (d *dataStore) ListLatestResourceKeys(ctx context.Context, key ListRequestK
 	})
 }
 
+// pagedKeys scans keys in the given range one bounded page at a time. Each page
+// is read fully into memory (which lets the underlying KV close its cursor)
+// before its keys are yielded, so no cursor is held open while the consumer
+// reads. It yields the same lexical key sequence as a single unbounded scan.
+func pagedKeys(ctx context.Context, kv KV, section string, base ListOptions, pageSize int) iter.Seq2[string, error] {
+	return func(yield func(string, error) bool) {
+		opts := base
+		opts.Limit = int64(pageSize)
+
+		for {
+			page := make([]string, 0, pageSize)
+			var scanErr error
+			for key, err := range kv.Keys(ctx, section, opts) {
+				if err != nil {
+					scanErr = err
+					break
+				}
+				page = append(page, key)
+			}
+			// The KV cursor for this page is now closed.
+			if scanErr != nil {
+				yield("", scanErr)
+				return
+			}
+
+			for _, key := range page {
+				if !yield(key, nil) {
+					return
+				}
+			}
+
+			// A short page means we reached the end of the range.
+			if len(page) < pageSize {
+				return
+			}
+
+			// StartKey is inclusive, so advance past the last key we saw.
+			opts.StartKey = PrefixRangeEnd(page[len(page)-1])
+		}
+	}
+}
+
 // ListResourceKeysAtRevision returns an iterator over data keys for resources at a specific revision.
 // If rv is 0, it returns the latest versions. Only returns keys for resources that are not deleted at the given revision.
 func (d *dataStore) ListResourceKeysAtRevision(ctx context.Context, options ListRequestOptions) iter.Seq2[DataKey, error] {
@@ -420,8 +464,7 @@ func (d *dataStore) ListResourceKeysAtRevision(ctx context.Context, options List
 		attribute.Int64("resourceVersion", rv),
 	))
 
-	// List all keys in the prefix.
-	iter := d.kv.Keys(ctx, dataSection, listOptions)
+	iter := pagedKeys(ctx, d.kv, dataSection, listOptions, keyPageSize)
 
 	return func(yield func(DataKey, error) bool) {
 		defer span.End()

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -1907,7 +1907,6 @@ func (s *searchServer) build(ctx context.Context, nsr NamespacedResource, size i
 		span.AddEvent("building index", trace.WithAttributes(attribute.Int64("size", size), attribute.String("reason", indexBuildReason)))
 
 		listRV, err := s.storage.ListIterator(ctx, &resourcepb.ListRequest{
-			Limit: listEverything,
 			Options: &resourcepb.ListOptions{
 				Key: &resourcepb.ResourceKey{
 					Group:     nsr.Group,

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -1507,24 +1507,7 @@ func (k *kvStorageBackend) ListIterator(ctx context.Context, req *resourcepb.Lis
 		listRV = listOptions.ResourceVersion
 	}
 
-	// Fetch the latest objects.
-	// TODO: stream keys into BatchGet instead of materializing the whole list.
-	// For unbounded list calls (e.g. index build with req.Limit == 0) at 1M
-	// rows this allocates ~250 MB of DataKey before any reads start. Pipe
-	// ListResourceKeysAtRevision through a bounded channel into BatchGet so
-	// memory is O(chunk), not O(N).
-	keys := make([]DataKey, 0, min(defaultListBufferSize, req.Limit+1))
-	for dataKey, err := range k.dataStore.ListResourceKeysAtRevision(ctx, listOptions) {
-		if err != nil {
-			return 0, err
-		}
-
-		keys = append(keys, dataKey)
-		// Only fetch the first limit items + 1 to get the next token.
-		if req.Limit > 0 && len(keys) >= int(req.Limit+1) {
-			break
-		}
-	}
+	keys := k.dataStore.ListResourceKeysAtRevision(ctx, listOptions)
 	iter := newKvListIterator(ctx, k.dataStore, keys, listRV, req.Options.Key.Namespace == "")
 	defer iter.stop()
 
@@ -1535,14 +1518,46 @@ func (k *kvStorageBackend) ListIterator(ctx context.Context, req *resourcepb.Lis
 	return listRV, nil
 }
 
-// newKvListIterator builds a kvListIterator over dataStore.BatchGet(keys).
-func newKvListIterator(ctx context.Context, ds *dataStore, keys []DataKey, listRV int64, isCrossNamespace bool) *kvListIterator {
-	next, stopFn := iter.Pull2(ds.BatchGet(ctx, keys))
+// newKvListIterator builds a kvListIterator that reads keys in bounded batches.
+func newKvListIterator(ctx context.Context, ds *dataStore, keys iter.Seq2[DataKey, error], listRV int64, isCrossNamespace bool) *kvListIterator {
+	next, stopFn := iter.Pull2(batchGetResourceKeys(ctx, ds, keys))
 	return &kvListIterator{
 		listRV:           listRV,
 		isCrossNamespace: isCrossNamespace,
 		next:             next,
 		stopFn:           stopFn,
+	}
+}
+
+func batchGetResourceKeys(ctx context.Context, ds *dataStore, keys iter.Seq2[DataKey, error]) iter.Seq2[DataObj, error] {
+	return func(yield func(DataObj, error) bool) {
+		batch := make([]DataKey, 0, dataBatchSize)
+
+		flush := func() bool {
+			for obj, err := range ds.BatchGet(ctx, batch) {
+				if !yield(obj, err) || err != nil {
+					return false
+				}
+			}
+			batch = batch[:0]
+			return true
+		}
+
+		for key, err := range keys {
+			if err != nil {
+				yield(DataObj{}, err)
+				return
+			}
+
+			batch = append(batch, key)
+			if len(batch) == dataBatchSize && !flush() {
+				return
+			}
+		}
+
+		if len(batch) > 0 {
+			flush()
+		}
 	}
 }
 

--- a/pkg/storage/unified/resource/storage_backend_test.go
+++ b/pkg/storage/unified/resource/storage_backend_test.go
@@ -1338,7 +1338,8 @@ func TestKvStorageBackend_ListIterator_Success(t *testing.T) {
 }
 
 func TestKvStorageBackend_ListIterator_StreamsKeysInBatches(t *testing.T) {
-	const numResources = 2*dataBatchSize + 1
+	// Span more than one key page so the page-bounded scan is observable.
+	const numResources = keyPageSize + 2*dataBatchSize + 1
 
 	for name, setup := range map[string]func(*testing.T) KV{
 		"badger": setupBadgerKV,
@@ -1390,6 +1391,8 @@ func TestKvStorageBackend_ListIterator_StreamsKeysInBatches(t *testing.T) {
 			listedAfter := kvStore.listed()
 			assert.Equal(t, 1, tripsAfter-tripsBefore)
 			assert.Equal(t, dataBatchSize, keysReadAfter-keysReadBefore)
+			assert.Equal(t, keyPageSize, listedAfter-listedBefore,
+				"the key scan must materialize at most one page, not the whole list")
 			assert.Less(t, listedAfter-listedBefore, numResources,
 				"stopping the consumer must stop the key scan before all keys are materialized")
 		})

--- a/pkg/storage/unified/resource/storage_backend_test.go
+++ b/pkg/storage/unified/resource/storage_backend_test.go
@@ -601,6 +601,7 @@ type countingKV struct {
 	mu         sync.Mutex
 	roundTrips int
 	keysRead   int
+	keysListed int
 }
 
 func (k *countingKV) count(section string, keys int) {
@@ -619,6 +620,31 @@ func (k *countingKV) stats() (roundTrips, keysRead int) {
 	k.mu.Lock()
 	defer k.mu.Unlock()
 	return k.roundTrips, k.keysRead
+}
+
+func (k *countingKV) listed() int {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	return k.keysListed
+}
+
+func (k *countingKV) Keys(ctx context.Context, section string, opt ListOptions) iter.Seq2[string, error] {
+	keys := k.KV.Keys(ctx, section, opt)
+	if section != kv.DataSection {
+		return keys
+	}
+	return func(yield func(string, error) bool) {
+		for key, err := range keys {
+			if err == nil {
+				k.mu.Lock()
+				k.keysListed++
+				k.mu.Unlock()
+			}
+			if !yield(key, err) {
+				return
+			}
+		}
+	}
 }
 
 func (k *countingKV) Get(ctx context.Context, section string, key string) (io.ReadCloser, error) {
@@ -1311,6 +1337,65 @@ func TestKvStorageBackend_ListIterator_Success(t *testing.T) {
 	require.Equal(t, []string{"resource-1", "resource-2"}, names)
 }
 
+func TestKvStorageBackend_ListIterator_StreamsKeysInBatches(t *testing.T) {
+	const numResources = 2*dataBatchSize + 1
+
+	for name, setup := range map[string]func(*testing.T) KV{
+		"badger": setupBadgerKV,
+		"sql":    setupSqlKV,
+	} {
+		t.Run(name, func(t *testing.T) {
+			kvStore := &countingKV{KV: setup(t)}
+			backend := setupTestStorageBackend(t, withKV(kvStore))
+			ctx := t.Context()
+
+			for i := range numResources {
+				resourceName := fmt.Sprintf("resource-%03d", i)
+				testObj, err := createTestObjectWithName(resourceName, appsNamespace, fmt.Sprintf("data-%d", i))
+				require.NoError(t, err)
+				metaAccessor, err := utils.MetaAccessor(testObj)
+				require.NoError(t, err)
+
+				_, err = backend.WriteEvent(ctx, WriteEvent{
+					Type: resourcepb.WatchEvent_ADDED,
+					Key: &resourcepb.ResourceKey{
+						Namespace: appsNamespace.Namespace,
+						Group:     appsNamespace.Group,
+						Resource:  appsNamespace.Resource,
+						Name:      resourceName,
+					},
+					Value:      objectToJSONBytes(t, testObj),
+					Object:     metaAccessor,
+					PreviousRV: 0,
+				})
+				require.NoError(t, err)
+			}
+
+			listedBefore := kvStore.listed()
+			tripsBefore, keysReadBefore := kvStore.stats()
+
+			_, err := backend.ListIterator(ctx, &resourcepb.ListRequest{
+				Options: &resourcepb.ListOptions{Key: &resourcepb.ResourceKey{
+					Namespace: appsNamespace.Namespace,
+					Group:     appsNamespace.Group,
+					Resource:  appsNamespace.Resource,
+				}},
+			}, func(iter ListIterator) error {
+				require.True(t, iter.Next())
+				return iter.Error()
+			})
+			require.NoError(t, err)
+
+			tripsAfter, keysReadAfter := kvStore.stats()
+			listedAfter := kvStore.listed()
+			assert.Equal(t, 1, tripsAfter-tripsBefore)
+			assert.Equal(t, dataBatchSize, keysReadAfter-keysReadBefore)
+			assert.Less(t, listedAfter-listedBefore, numResources,
+				"stopping the consumer must stop the key scan before all keys are materialized")
+		})
+	}
+}
+
 func TestKvStorageBackend_ListIterator_WithPagination(t *testing.T) {
 	backend := setupTestStorageBackend(t)
 	ctx := context.Background()
@@ -1429,7 +1514,20 @@ func TestKvStorageBackend_ListIterator_WithPagination(t *testing.T) {
 	require.Equal(t, 1, len(thirdPageItems))
 	require.Equal(t, []string{"resource-5"}, thirdPageItems)
 	require.Empty(t, continueToken3)
+
+	// Limit belongs to the consumer; the backend continues while it is being consumed.
+	listReq.NextPageToken = ""
+	var allItems []string
+	_, err = backend.ListIterator(ctx, listReq, func(iter ListIterator) error {
+		for iter.Next() {
+			allItems = append(allItems, iter.Name())
+		}
+		return iter.Error()
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"resource-1", "resource-2", "resource-3", "resource-4", "resource-5"}, allItems)
 }
+
 func TestKvStorageBackend_ListIterator_EmptyResult(t *testing.T) {
 	backend := setupTestStorageBackend(t)
 	ctx := context.Background()


### PR DESCRIPTION
addresses the TODO, basically instead of buffering all the keys the tenant has before sending it, we stream the payload as we go. this will help a bit with memory usage for larger tenants