### PR TITLE
AuthN: extend multi-tenant settings projection with OAuth and URL fields

### DIFF
--- a/pkg/setting/setting_authn.go
+++ b/pkg/setting/setting_authn.go
@@ -3,6 +3,9 @@ package setting
 import (
 	"errors"
 	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
@@ -31,6 +34,10 @@ func (cfg *Cfg) ApplyAuthnSettings(iniFile *ini.File) error {
 	if err := readSessionAuthSettings(iniFile, cfg); err != nil {
 		return err
 	}
+	readOAuthSettings(iniFile, cfg)
+	readCookieSecuritySettings(iniFile, cfg)
+	readServerURLSettings(iniFile, cfg)
+	readGrafanaComSettings(iniFile, cfg)
 	return readUserLastSeenUpdateInterval(iniFile, cfg)
 }
 
@@ -62,6 +69,54 @@ func readSessionAuthSettings(iniFile *ini.File, cfg *Cfg) error {
 		cfg.TokenRotationIntervalMinutes = 2
 	}
 	return nil
+}
+
+func readOAuthSettings(iniFile *ini.File, cfg *Cfg) {
+	auth := iniFile.Section("auth")
+	cfg.OAuthCookieMaxAge = auth.Key("oauth_state_cookie_max_age").MustInt(600)
+}
+
+func readCookieSecuritySettings(iniFile *ini.File, cfg *Cfg) {
+	security := iniFile.Section("security")
+	cfg.CookieSecure = security.Key("cookie_secure").MustBool(false)
+
+	samesiteString := valueAsString(security, "cookie_samesite", "lax")
+	if samesiteString == "disabled" {
+		cfg.CookieSameSiteDisabled = true
+	} else {
+		validSameSiteValues := map[string]http.SameSite{
+			"lax":    http.SameSiteLaxMode,
+			"strict": http.SameSiteStrictMode,
+			"none":   http.SameSiteNoneMode,
+		}
+		if samesite, ok := validSameSiteValues[samesiteString]; ok {
+			cfg.CookieSameSiteMode = samesite
+		} else {
+			cfg.CookieSameSiteMode = http.SameSiteLaxMode
+		}
+	}
+}
+
+func readServerURLSettings(iniFile *ini.File, cfg *Cfg) {
+	server := iniFile.Section("server")
+	appURL := valueAsString(server, "root_url", "http://localhost:3000/")
+	if appURL[len(appURL)-1] != '/' {
+		appURL += "/"
+	}
+	cfg.AppURL = appURL
+
+	if parsed, err := url.Parse(appURL); err == nil {
+		cfg.AppSubURL = strings.TrimSuffix(parsed.Path, "/")
+	}
+}
+
+func readGrafanaComSettings(iniFile *ini.File, cfg *Cfg) {
+	grafanaComURL := valueAsString(iniFile.Section("grafana_net"), "url", "")
+	if grafanaComURL == "" {
+		grafanaComURL = valueAsString(iniFile.Section("grafana_com"), "url", "https://grafana.com")
+	}
+	cfg.GrafanaComURL = grafanaComURL
+	cfg.GrafanaComAPIURL = valueAsString(iniFile.Section("grafana_com"), "api_url", grafanaComURL+"/api")
 }
 
 func readUserLastSeenUpdateInterval(iniFile *ini.File, cfg *Cfg) error {

--- a/pkg/setting/setting_authn_test.go
+++ b/pkg/setting/setting_authn_test.go
@@ -19,6 +19,10 @@ func TestApplyAuthnSettings(t *testing.T) {
 		require.NoError(t, err)
 		_, err = security.NewKey("encryption_provider", "secretKey.v1")
 		require.NoError(t, err)
+		_, err = security.NewKey("cookie_secure", "true")
+		require.NoError(t, err)
+		_, err = security.NewKey("cookie_samesite", "strict")
+		require.NoError(t, err)
 
 		auth, err := settings.NewSection("auth")
 		require.NoError(t, err)
@@ -30,10 +34,22 @@ func TestApplyAuthnSettings(t *testing.T) {
 		require.NoError(t, err)
 		_, err = auth.NewKey("token_rotation_interval_minutes", "3")
 		require.NoError(t, err)
+		_, err = auth.NewKey("oauth_state_cookie_max_age", "900")
+		require.NoError(t, err)
 
 		users, err := settings.NewSection("users")
 		require.NoError(t, err)
 		_, err = users.NewKey("last_seen_update_interval", "30m")
+		require.NoError(t, err)
+
+		server, err := settings.NewSection("server")
+		require.NoError(t, err)
+		_, err = server.NewKey("root_url", "http://localtest.example.com:8080/")
+		require.NoError(t, err)
+
+		grafanaCom, err := settings.NewSection("grafana_com")
+		require.NoError(t, err)
+		_, err = grafanaCom.NewKey("url", "http://localhost:13001")
 		require.NoError(t, err)
 
 		cfg := NewCfg()
@@ -48,6 +64,12 @@ func TestApplyAuthnSettings(t *testing.T) {
 		assert.Equal(t, 3, cfg.TokenRotationIntervalMinutes)
 		assert.Equal(t, 30*time.Minute, cfg.UserLastSeenUpdateInterval)
 		assert.Equal(t, "secretKey.v1", cfg.Raw.Section("security").Key("encryption_provider").String())
+		assert.Equal(t, 900, cfg.OAuthCookieMaxAge)
+		assert.True(t, cfg.CookieSecure)
+		assert.Equal(t, http.SameSiteStrictMode, cfg.CookieSameSiteMode)
+		assert.Equal(t, "http://localtest.example.com:8080/", cfg.AppURL)
+		assert.Empty(t, cfg.AppSubURL)
+		assert.Equal(t, "http://localhost:13001", cfg.GrafanaComURL)
 	})
 
 	t.Run("applies Grafana defaults", func(t *testing.T) {
@@ -66,6 +88,11 @@ func TestApplyAuthnSettings(t *testing.T) {
 		assert.Equal(t, 30*24*time.Hour, cfg.LoginMaxLifetime)
 		assert.Equal(t, 10, cfg.TokenRotationIntervalMinutes)
 		assert.Equal(t, 15*time.Minute, cfg.UserLastSeenUpdateInterval)
+		assert.Equal(t, 600, cfg.OAuthCookieMaxAge)
+		assert.False(t, cfg.CookieSecure)
+		assert.Equal(t, http.SameSiteLaxMode, cfg.CookieSameSiteMode)
+		assert.Equal(t, "http://localhost:3000/", cfg.AppURL)
+		assert.Equal(t, "https://grafana.com", cfg.GrafanaComURL)
 	})
 
 	t.Run("does not mutate compatibility globals", func(t *testing.T) {


### PR DESCRIPTION
## Why

The MT OAuth login handler (`authn-service`) generates relative authorize and redirect URIs because `ApplyAuthnSettings` doesn't project `server.root_url`, `grafana_com.url`, or cookie security settings into the `*setting.Cfg` it builds. This breaks the OAuth flow entirely.

## What

- Add `readServerURLSettings` — populates `AppURL` and `AppSubURL`
- Add `readGrafanaComSettings` — populates `GrafanaComURL` and `GrafanaComAPIURL`
- Add `readOAuthSettings` — populates `OAuthCookieMaxAge`
- Add `readCookieSecuritySettings` — populates `CookieSecure` and `CookieSameSiteMode`