### PR TITLE
fix: graphite tags parsing error

### DIFF
--- a/public/app/plugins/datasource/graphite/migrations.test.ts
+++ b/public/app/plugins/datasource/graphite/migrations.test.ts
@@ -1,0 +1,109 @@
+import { prepareAnnotation } from './migrations';
+
+describe('Graphite annotation migrations', () => {
+  describe('legacy target annotations', () => {
+    it('migrates a legacy graphite query string into a target', () => {
+      expect(prepareAnnotation({ target: 'statsd.application.counters.*.count' }).target).toEqual({
+        fromAnnotations: true,
+        target: 'statsd.application.counters.*.count',
+        textEditor: true,
+      });
+    });
+
+    it('leaves an already migrated target untouched', () => {
+      const target = { queryType: 'tags', tags: ['deploy'], fromAnnotations: true };
+
+      expect(prepareAnnotation({ target }).target).toBe(target);
+    });
+
+    it('treats an empty target string as a tags annotation', () => {
+      expect(prepareAnnotation({ target: '' }).target).toEqual({
+        queryType: 'tags',
+        tags: [],
+        fromAnnotations: true,
+      });
+    });
+  });
+
+  describe('legacy tags annotations', () => {
+    it('splits a space-separated tags string', () => {
+      expect(prepareAnnotation({ tags: 'deploy success' }).target).toEqual({
+        queryType: 'tags',
+        tags: ['deploy', 'success'],
+        fromAnnotations: true,
+      });
+    });
+
+    it('drops empty segments from a padded tags string', () => {
+      expect(prepareAnnotation({ tags: '  deploy   success ' }).target).toMatchObject({
+        tags: ['deploy', 'success'],
+      });
+    });
+
+    it('accepts an array of tags without throwing', () => {
+      expect(prepareAnnotation({ tags: ['deploy', 'success'] }).target).toEqual({
+        queryType: 'tags',
+        tags: ['deploy', 'success'],
+        fromAnnotations: true,
+      });
+    });
+
+    it('preserves array tags that contain spaces', () => {
+      expect(prepareAnnotation({ tags: ['event=deploy status=success'] }).target).toMatchObject({
+        tags: ['event=deploy status=success'],
+      });
+    });
+
+    it('coerces non-string array entries', () => {
+      expect(prepareAnnotation({ tags: [1, 'deploy', null, undefined, ''] }).target).toMatchObject({
+        tags: ['1', 'deploy'],
+      });
+    });
+
+    it('yields no tags for an empty array', () => {
+      expect(prepareAnnotation({ tags: [] }).target).toMatchObject({ tags: [] });
+    });
+
+    it('yields no tags when tags are missing', () => {
+      expect(prepareAnnotation({}).target).toEqual({
+        queryType: 'tags',
+        tags: [],
+        fromAnnotations: true,
+      });
+    });
+  });
+
+  describe('dashboard schema v2 annotations', () => {
+    // v2 stores the query under annotation.query.spec, so target is falsy and the legacy
+    // migration branch runs on every open of the annotations editor
+    it('does not throw when the query lives under query.spec', () => {
+      const annotation = {
+        name: 'Completed Deployments',
+        query: { kind: 'DataQuery', spec: { queryType: 'tags', tags: ['deploy'] } },
+      };
+
+      expect(prepareAnnotation(annotation).target).toEqual({
+        queryType: 'tags',
+        tags: [],
+        fromAnnotations: true,
+      });
+    });
+  });
+
+  describe('annotations carried over from the built-in Grafana datasource', () => {
+    // the built-in annotation datasource writes root-level tags as string[]; switching such an
+    // annotation to Graphite used to throw `json.tags.split is not a function`
+    it('does not throw on a built-in annotation shape', () => {
+      const annotation = {
+        name: 'Failed Deployments',
+        type: 'tags',
+        limit: 100,
+        matchAny: false,
+        tags: ['deploy', 'failed'],
+      };
+
+      expect(() => prepareAnnotation(annotation)).not.toThrow();
+      expect(prepareAnnotation(annotation).target).toMatchObject({ tags: ['deploy', 'failed'] });
+    });
+  });
+});

--- a/public/app/plugins/datasource/graphite/migrations.ts
+++ b/public/app/plugins/datasource/graphite/migrations.ts
@@ -1,6 +1,16 @@
 type LegacyAnnotation = {
   target?: string;
-  tags?: string;
+  tags?: string | string[];
+};
+
+// legacy annotations stored tags as a space-separated string, but Grafana's annotation model
+// uses string[] (AnnotationEvent.tags), so both shapes reach this migration
+const migrateLegacyTags = (tags: LegacyAnnotation['tags']): string[] => {
+  if (Array.isArray(tags)) {
+    return tags.filter(Boolean).map(String);
+  }
+
+  return (typeof tags === 'string' ? tags : '').split(' ').filter(Boolean);
 };
 
 // this becomes the target in the migrated annotations
@@ -17,7 +27,7 @@ const migrateLegacyAnnotation = (json: LegacyAnnotation) => {
   // return the tags annotation
   return {
     queryType: 'tags',
-    tags: (json.tags || '').split(' '),
+    tags: migrateLegacyTags(json.tags),
     fromAnnotations: true,
   };
 };


### PR DESCRIPTION
legacy annotations stored tags as a space-separated string, but Grafana's annotation model uses string[] (AnnotationEvent.tags), so both shapes now reach migrateLegacyTags. this adds handling for string[]

Fixes #129778 

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
