### PR TITLE
Combobox: Fix duplicate async requests and stale errors overwriting fresh options

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
@@ -559,6 +559,90 @@ describe('Combobox', () => {
       expect(asyncSpy).toHaveBeenCalledTimes(1); // Called only for 'abc'
     });
 
+    it('should debounce to a single request when a re-rendering parent recreates the options function', async () => {
+      const loaderSpy = jest.fn((searchTerm: string) => Promise.resolve(simpleAsyncOptions));
+
+      // Mimics consumers like query editors: the parent re-renders on every keystroke and
+      // passes an inline arrow as `options`, minting a new function identity each render.
+      const Wrapper = () => {
+        const [, setKeystrokes] = React.useState(0);
+        return (
+          <div onKeyDown={() => setKeystrokes((count) => count + 1)}>
+            <Combobox options={(inputValue: string) => loaderSpy(inputValue)} value={null} onChange={onChangeHandler} />
+          </div>
+        );
+      };
+
+      render(<Wrapper />);
+
+      const input = screen.getByRole('combobox');
+      await user.click(input);
+
+      await user.keyboard('a');
+      await act(async () => jest.advanceTimersByTime(10));
+      await user.keyboard('b');
+      await act(async () => jest.advanceTimersByTime(10));
+      await user.keyboard('c');
+      await act(async () => jest.advanceTimersByTime(DEBOUNCE_TIME_MS));
+
+      expect(loaderSpy).toHaveBeenCalledTimes(1);
+      expect(loaderSpy).toHaveBeenCalledWith('abc');
+    });
+
+    it('should not show an error when a stale request rejects after a newer request has succeeded', async () => {
+      jest.spyOn(console, 'error').mockImplementation();
+
+      const asyncOptions = jest.fn(async (searchTerm: string) => {
+        if (searchTerm === 'a') {
+          return new Promise<ComboboxOption[]>((_resolve, reject) =>
+            setTimeout(() => reject(new Error('slow failure')), 1500)
+          );
+        }
+        return new Promise<ComboboxOption[]>((resolve) => setTimeout(() => resolve([{ value: 'fresh result' }]), 500));
+      });
+
+      render(<Combobox options={asyncOptions} value={null} onChange={onChangeHandler} />);
+
+      const input = screen.getByRole('combobox');
+      await user.click(input);
+      await act(async () => {
+        await user.keyboard('a');
+        jest.advanceTimersByTime(DEBOUNCE_TIME_MS); // Start request A (slow, will reject)
+        await user.keyboard('b');
+        jest.advanceTimersByTime(DEBOUNCE_TIME_MS); // Start request B (fast, will resolve)
+        jest.advanceTimersByTime(500); // Resolve request B
+      });
+
+      expect(await screen.findByRole('option', { name: 'fresh result' })).toBeInTheDocument();
+
+      await act(async () => {
+        jest.advanceTimersByTime(1500); // Reject request A, long after B already rendered
+      });
+
+      expect(screen.queryByText('An error occurred while loading options.')).not.toBeInTheDocument();
+      expect(screen.getByRole('option', { name: 'fresh result' })).toBeInTheDocument();
+    });
+
+    it('should not load options if unmounted while a debounced load is pending', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+      const asyncOptions = jest.fn(() => Promise.resolve(simpleAsyncOptions));
+
+      const { unmount } = render(<Combobox options={asyncOptions} value={null} onChange={onChangeHandler} />);
+
+      const input = screen.getByRole('combobox');
+      await user.click(input);
+      await user.keyboard('a'); // Schedule a debounced load
+
+      unmount();
+
+      await act(async () => {
+        jest.advanceTimersByTime(DEBOUNCE_TIME_MS * 2);
+      });
+
+      expect(asyncOptions).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+
     it('should allow custom value while async is being run', async () => {
       const asyncOptions = jest.fn(async () => {
         return new Promise<ComboboxOption[]>((resolve) => setTimeout(() => resolve([{ value: 'first' }]), 2000));

--- a/packages/grafana-ui/src/components/Combobox/useLatestAsyncCall.test.ts
+++ b/packages/grafana-ui/src/components/Combobox/useLatestAsyncCall.test.ts
@@ -1,0 +1,67 @@
+import { renderHook } from '@testing-library/react';
+
+import { StaleResultError, useLatestAsyncCall } from './useLatestAsyncCall';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('useLatestAsyncCall', () => {
+  it('resolves the latest call with its result', async () => {
+    const fn = (value: string) => Promise.resolve(`result for ${value}`);
+    const { result } = renderHook(() => useLatestAsyncCall(fn));
+
+    await expect(result.current('a')).resolves.toBe('result for a');
+  });
+
+  it('rejects a superseded success with StaleResultError', async () => {
+    const first = deferred<string>();
+    const second = deferred<string>();
+    const responses = [first.promise, second.promise];
+    const fn = (_value: string) => responses.shift() ?? Promise.reject(new Error('no response set up'));
+
+    const { result } = renderHook(() => useLatestAsyncCall(fn));
+
+    const firstCall = result.current('a');
+    const secondCall = result.current('b');
+
+    second.resolve('second result');
+    await expect(secondCall).resolves.toBe('second result');
+
+    // The first (superseded) request resolving late must not surface its result
+    first.resolve('first result');
+    await expect(firstCall).rejects.toBeInstanceOf(StaleResultError);
+  });
+
+  it('rejects a superseded failure with StaleResultError instead of the original error', async () => {
+    const first = deferred<string>();
+    const second = deferred<string>();
+    const responses = [first.promise, second.promise];
+    const fn = (_value: string) => responses.shift() ?? Promise.reject(new Error('no response set up'));
+
+    const { result } = renderHook(() => useLatestAsyncCall(fn));
+
+    const firstCall = result.current('a');
+    const secondCall = result.current('b');
+
+    second.resolve('second result');
+    await expect(secondCall).resolves.toBe('second result');
+
+    // The first (superseded) request failing late is just as stale as it succeeding late
+    first.reject(new Error('slow failure'));
+    await expect(firstCall).rejects.toBeInstanceOf(StaleResultError);
+  });
+
+  it('rejects the latest call with its original error when it fails', async () => {
+    const fn = (_value: string) => Promise.reject(new Error('real failure'));
+    const { result } = renderHook(() => useLatestAsyncCall(fn));
+
+    await expect(result.current('a')).rejects.toThrow('real failure');
+  });
+});

--- a/packages/grafana-ui/src/components/Combobox/useLatestAsyncCall.ts
+++ b/packages/grafana-ui/src/components/Combobox/useLatestAsyncCall.ts
@@ -24,7 +24,14 @@ export function useLatestAsyncCall<T, V>(fn: AsyncFn<T, V>): AsyncFn<T, V> {
               reject(new StaleResultError());
             }
           })
-          .catch(reject);
+          .catch((error) => {
+            // A failure from a superseded request is just as stale as a success
+            if (requestCount === latestValueCount.current) {
+              reject(error);
+            } else {
+              reject(new StaleResultError());
+            }
+          });
       });
     },
     [fn]

--- a/packages/grafana-ui/src/components/Combobox/useOptions.ts
+++ b/packages/grafana-ui/src/components/Combobox/useOptions.ts
@@ -2,7 +2,7 @@
 /* eslint no-restricted-syntax: ["error", "SpreadElement"] */
 
 import { debounce } from 'lodash';
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 
 import { t } from '@grafana/i18n';
 
@@ -34,7 +34,18 @@ export function useOptions<T extends string | number>(
 ) {
   const isAsync = typeof rawOptions === 'function';
 
-  const loadOptions = useLatestAsyncCall(isAsync ? rawOptions : asyncNoop);
+  // Consumers typically pass an inline arrow as `options`, giving it a new identity on every
+  // parent render. Read it from a ref so the loader (and the debounce built on it) can stay
+  // stable for the lifetime of the component instead of being recreated mid-debounce.
+  const rawOptionsRef = useRef(rawOptions);
+  rawOptionsRef.current = rawOptions;
+
+  const stableRawOptions = useCallback((searchTerm: string) => {
+    const currentRawOptions = rawOptionsRef.current;
+    return typeof currentRawOptions === 'function' ? currentRawOptions(searchTerm) : asyncNoop();
+  }, []);
+
+  const loadOptions = useLatestAsyncCall(stableRawOptions);
 
   const debouncedLoadOptions = useMemo(
     () =>
@@ -58,6 +69,8 @@ export function useOptions<T extends string | number>(
       }, DEBOUNCE_TIME_MS),
     [loadOptions]
   );
+
+  useEffect(() => () => debouncedLoadOptions.cancel(), [debouncedLoadOptions]);
 
   const [asyncOptions, setAsyncOptions] = useState<Array<ComboboxOption<T>>>([]);
   const [asyncLoading, setAsyncLoading] = useState(false);

--- a/packages/grafana-ui/src/components/Combobox/useOptions.ts
+++ b/packages/grafana-ui/src/components/Combobox/useOptions.ts
@@ -34,11 +34,9 @@ export function useOptions<T extends string | number>(
 ) {
   const isAsync = typeof rawOptions === 'function';
 
-  // Consumers typically pass an inline arrow as `options`, giving it a new identity on every
-  // parent render. Read it from a ref ("latest ref" pattern — what React's experimental
-  // useEffectEvent formalises) so the loader (and the debounce built on it) keeps a stable
-  // identity for the lifetime of the component instead of being recreated mid-debounce,
-  // while still invoking the consumer's most recent closure when it fires.
+  // Read `options` through a ref so the debounced loader keeps a stable identity even when
+  // consumers pass a new function on every render.
+  // TODO: switch to useEffectEvent once React stabilises it.
   const rawOptionsRef = useRef(rawOptions);
   rawOptionsRef.current = rawOptions;
 
@@ -72,10 +70,8 @@ export function useOptions<T extends string | number>(
     [loadOptions]
   );
 
-  // debouncedLoadOptions is stable for the component's lifetime, so this cleanup runs only on
-  // unmount. It cancels a scheduled-but-not-yet-fired load so the timer can't fire (and set
-  // state) after unmount. Requests already in flight are not aborted here — late results from
-  // those are discarded by useLatestAsyncCall's staleness guard instead.
+  // Runs only on unmount (debouncedLoadOptions is stable): cancels a pending debounce timer
+  // so it can't fire after unmount. In-flight requests are handled by useLatestAsyncCall.
   useEffect(() => () => debouncedLoadOptions.cancel(), [debouncedLoadOptions]);
 
   const [asyncOptions, setAsyncOptions] = useState<Array<ComboboxOption<T>>>([]);

--- a/packages/grafana-ui/src/components/Combobox/useOptions.ts
+++ b/packages/grafana-ui/src/components/Combobox/useOptions.ts
@@ -35,8 +35,10 @@ export function useOptions<T extends string | number>(
   const isAsync = typeof rawOptions === 'function';
 
   // Consumers typically pass an inline arrow as `options`, giving it a new identity on every
-  // parent render. Read it from a ref so the loader (and the debounce built on it) can stay
-  // stable for the lifetime of the component instead of being recreated mid-debounce.
+  // parent render. Read it from a ref ("latest ref" pattern — what React's experimental
+  // useEffectEvent formalises) so the loader (and the debounce built on it) keeps a stable
+  // identity for the lifetime of the component instead of being recreated mid-debounce,
+  // while still invoking the consumer's most recent closure when it fires.
   const rawOptionsRef = useRef(rawOptions);
   rawOptionsRef.current = rawOptions;
 
@@ -70,6 +72,10 @@ export function useOptions<T extends string | number>(
     [loadOptions]
   );
 
+  // debouncedLoadOptions is stable for the component's lifetime, so this cleanup runs only on
+  // unmount. It cancels a scheduled-but-not-yet-fired load so the timer can't fire (and set
+  // state) after unmount. Requests already in flight are not aborted here — late results from
+  // those are discarded by useLatestAsyncCall's staleness guard instead.
   useEffect(() => () => debouncedLoadOptions.cancel(), [debouncedLoadOptions]);
 
   const [asyncOptions, setAsyncOptions] = useState<Array<ComboboxOption<T>>>([]);


### PR DESCRIPTION
🤖

**What is this feature?**

Two fixes in the async loader that every `Combobox` and `MultiCombobox` shares:

- `useOptions` reads the consumer's `options` function through a ref, so the debounced loader keeps one identity. Before, a parent re-render inside the 200 ms window made a second debounce and left the first lodash timer to fire, so one search sent several datasource requests.
- `useLatestAsyncCall` rejects a superseded failure with `StaleResultError`, the same as a superseded success. Before, a late rejection put "An error occurred while loading options." over a newer, good list.
- A pending debounce timer is now cancelled on unmount.

**Why do we need this feature?**

So a query editor that re-renders while the user types makes one request per search term, and a slow failure cannot erase fresh options.

**Who is this feature for?**

Anyone who uses an async Combobox: datasource query editors and alerting label-value pickers.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-frontend-platform/issues/230

**Special notes for your reviewer:**

FEP needs to make one call. The loader now calls the newest `options` closure, not the one captured when the debounce timer started, so a closure that reads props or state sees the latest render. The alternative is to keep the captured closure and cancel the old timer, which sends the request with stale props. Tell me if you want that instead.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
