### PR TITLE
Datasources: Add on-prem diagnostics download e2e (Playwright)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1369,7 +1369,7 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/frontend-lint.yml @grafana/grafana-frontend-platform
 /.github/workflows/analytics-events-report.yml @grafana/grafana-frontend-platform
 /.github/workflows/pr-e2e-tests.yml @grafana/grafana-backend-services-squad
-/.github/workflows/pr-diagnostics-e2e.yml @grafana/grafana-backend-services-squad
+/.github/workflows/pr-diagnostics-e2e.yml @grafana/data-sources-plugins
 /.github/workflows/frontend-perf-tests.yaml @grafana/grafana-frontend-platform
 /.github/workflows/release-npm.yml @grafana/grafana-frontend-platform
 /.github/workflows/scripts/determine-npm-tag.sh @grafana/grafana-frontend-platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -424,6 +424,7 @@ i18next.config.ts @grafana/grafana-frontend-platform
 /public/app/core/internationalization/ @grafana/grafana-frontend-platform
 /e2e-playwright/alerting-suite/ @grafana/alerting-squad
 /e2e-playwright/cloud-plugins-suite/ @grafana/data-sources-plugins
+/e2e-playwright/diagnostics-suite/ @grafana/data-sources-plugins
 /e2e-playwright/dashboard-new-layouts/ @grafana/dashboards-squad
 /e2e-playwright/dashboard-cujs/ @grafana/dashboards-squad
 /e2e-playwright/journey-tracking/ @grafana/dashboards-squad

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1369,6 +1369,7 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/frontend-lint.yml @grafana/grafana-frontend-platform
 /.github/workflows/analytics-events-report.yml @grafana/grafana-frontend-platform
 /.github/workflows/pr-e2e-tests.yml @grafana/grafana-backend-services-squad
+/.github/workflows/pr-diagnostics-e2e.yml @grafana/grafana-backend-services-squad
 /.github/workflows/frontend-perf-tests.yaml @grafana/grafana-frontend-platform
 /.github/workflows/release-npm.yml @grafana/grafana-frontend-platform
 /.github/workflows/scripts/determine-npm-tag.sh @grafana/grafana-frontend-platform

--- a/.github/workflows/pr-diagnostics-e2e.yml
+++ b/.github/workflows/pr-diagnostics-e2e.yml
@@ -93,6 +93,9 @@ jobs:
         env:
           GRAFANA_URL: http://localhost:3002
           CI: true
+          # Without this, Node resolves @grafana/* workspace packages via their built dist/
+          # output (not built here), rather than source -- see yarn e2e:pw in package.json.
+          NODE_OPTIONS: '-C @grafana-app/source'
 
       - uses: actions/upload-artifact@v7
         if: always()

--- a/.github/workflows/pr-diagnostics-e2e.yml
+++ b/.github/workflows/pr-diagnostics-e2e.yml
@@ -1,0 +1,102 @@
+name: Diagnostics e2e (on-prem)
+
+# On-demand diagnostics is on-prem only (isOnPrem() requires an empty stack_id), but
+# run-playwright-tests's shared server sets stack_id = 12345 for K8s dashboard RBAC checks other
+# suites depend on -- the two requirements can't share one server. So this boots its own on-prem
+# instance, reusing the same build-backend/build-frontend artifacts rather than rebuilding them.
+on:
+  workflow_call:
+    inputs:
+      backend-artifact-name:
+        description: Name of the Actions artifact containing the built backend (bin/)
+        type: string
+        required: true
+      frontend-artifact-name:
+        description: Name of the Actions artifact containing the built frontend (public/)
+        type: string
+        required: true
+
+permissions: {}
+
+jobs:
+  run-diagnostics-e2e:
+    name: Download diagnostics e2e (on-prem)
+    runs-on: ubuntu-x64-large
+    timeout-minutes: 20
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node
+      - name: Install yarn dependencies
+        uses: ./.github/actions/yarn-install
+
+      # Download the grafana artifacts and stitch them together into a standalone prod-ish Grafana distribution
+      - name: Download backend artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ inputs.backend-artifact-name }}
+          path: grafana-server/bin
+      - name: Fix binary permissions
+        run: chmod +x grafana-server/bin/grafana*
+      - name: Download frontend artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ inputs.frontend-artifact-name }}
+          path: grafana-server/public
+      - name: Copy misc server files
+        run: cp -r conf/ grafana-server
+
+      # "prometheus" is preinstalled synchronously so it's ready before the server finishes
+      # starting, since the diagnostics-suite spec queries it as a real upstream.
+      - name: Configure for on-prem diagnostics testing
+        run: |
+          cat > grafana-server/conf/custom.ini <<'EOF'
+          [feature_toggles]
+          grafana.onDemandDiagnostics = true
+
+          [plugins]
+          preinstall_sync = prometheus
+          EOF
+
+      - name: Start Grafana server
+        run: |
+          grafana-server/bin/grafana server \
+            --homepath="$PWD/grafana-server" \
+            cfg:server.http_port=3002 \
+            > grafana-server/grafana.log 2>&1 &
+
+      - name: Install Playwright browsers
+        run: yarn playwright install chromium --with-deps
+
+      - name: Wait for Grafana server to start
+        run: |
+          timeout=90
+          elapsed=0
+          until curl -sf http://localhost:3002/api/health > /dev/null 2>&1; do
+            if [ "$elapsed" -ge "$timeout" ]; then
+              cat grafana-server/grafana.log
+              echo "Timeout after ${timeout}s waiting for Grafana"
+              exit 1
+            fi
+            sleep 2
+            elapsed=$((elapsed + 2))
+          done
+
+      - name: Run diagnostics e2e
+        run: yarn playwright test --project=diagnostics --reporter=list
+        env:
+          GRAFANA_URL: http://localhost:3002
+          CI: true
+
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: grafana-server-log-diagnostics
+          path: grafana-server/grafana.log
+          retention-days: 7

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -284,88 +284,13 @@ jobs:
     needs:
       - build-backend
       - build-frontend
-    name: Download diagnostics e2e (on-prem)
-    runs-on: ubuntu-x64-large
-    timeout-minutes: 20
+    name: Diagnostics e2e (on-prem)
     permissions:
       contents: read
-
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-
-      - name: Setup Node.js
-        uses: ./.github/actions/setup-node
-      - name: Install yarn dependencies
-        uses: ./.github/actions/yarn-install
-
-      # Download the grafana artifacts and stitch them together into a standalone prod-ish Grafana distribution
-      - name: Download backend artifacts
-        uses: actions/download-artifact@v8
-        with:
-          name: grafana-backend
-          path: grafana-server/bin
-      - name: Fix binary permissions
-        run: chmod +x grafana-server/bin/grafana*
-      - name: Download frontend artifacts
-        uses: actions/download-artifact@v8
-        with:
-          name: grafana-frontend
-          path: grafana-server/public
-      - name: Copy misc server files
-        run: cp -r conf/ grafana-server
-
-      # On-demand diagnostics only renders on-prem (empty stack_id) with the toggle on, unlike the
-      # shared cloud-mode server the other Playwright shards use (scripts/grafana-server/custom.ini
-      # sets stack_id = 12345). "prometheus" is preinstalled synchronously so it's ready before the
-      # server finishes starting, since the diagnostics-suite spec queries it as a real upstream.
-      - name: Configure for on-prem diagnostics testing
-        run: |
-          cat > grafana-server/conf/custom.ini <<'EOF'
-          [feature_toggles]
-          grafana.onDemandDiagnostics = true
-
-          [plugins]
-          preinstall_sync = prometheus
-          EOF
-
-      - name: Start Grafana server
-        run: |
-          grafana-server/bin/grafana server \
-            --homepath="$PWD/grafana-server" \
-            cfg:server.http_port=3002 \
-            > grafana-server/grafana.log 2>&1 &
-
-      - name: Install Playwright browsers
-        run: yarn playwright install chromium --with-deps
-
-      - name: Wait for Grafana server to start
-        run: |
-          timeout=90
-          elapsed=0
-          until curl -sf http://localhost:3002/api/health > /dev/null 2>&1; do
-            if [ "$elapsed" -ge "$timeout" ]; then
-              cat grafana-server/grafana.log
-              echo "Timeout after ${timeout}s waiting for Grafana"
-              exit 1
-            fi
-            sleep 2
-            elapsed=$((elapsed + 2))
-          done
-
-      - name: Run diagnostics e2e
-        run: yarn playwright test --project=diagnostics --reporter=list
-        env:
-          GRAFANA_URL: http://localhost:3002
-          CI: true
-
-      - uses: actions/upload-artifact@v7
-        if: always()
-        with:
-          name: grafana-server-log-diagnostics
-          path: grafana-server/grafana.log
-          retention-days: 7
+    uses: ./.github/workflows/pr-diagnostics-e2e.yml
+    with:
+      backend-artifact-name: grafana-backend
+      frontend-artifact-name: grafana-frontend
 
   required-playwright-tests:
     needs:

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -280,6 +280,93 @@ jobs:
           path: blob-report
           retention-days: 1
 
+  run-diagnostics-e2e:
+    needs:
+      - build-backend
+      - build-frontend
+    name: Download diagnostics e2e (on-prem)
+    runs-on: ubuntu-x64-large
+    timeout-minutes: 20
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node
+      - name: Install yarn dependencies
+        uses: ./.github/actions/yarn-install
+
+      # Download the grafana artifacts and stitch them together into a standalone prod-ish Grafana distribution
+      - name: Download backend artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: grafana-backend
+          path: grafana-server/bin
+      - name: Fix binary permissions
+        run: chmod +x grafana-server/bin/grafana*
+      - name: Download frontend artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: grafana-frontend
+          path: grafana-server/public
+      - name: Copy misc server files
+        run: cp -r conf/ grafana-server
+
+      # On-demand diagnostics only renders on-prem (empty stack_id) with the toggle on, unlike the
+      # shared cloud-mode server the other Playwright shards use (scripts/grafana-server/custom.ini
+      # sets stack_id = 12345). "prometheus" is preinstalled synchronously so it's ready before the
+      # server finishes starting, since the diagnostics-suite spec queries it as a real upstream.
+      - name: Configure for on-prem diagnostics testing
+        run: |
+          cat > grafana-server/conf/custom.ini <<'EOF'
+          [feature_toggles]
+          grafana.onDemandDiagnostics = true
+
+          [plugins]
+          preinstall_sync = prometheus
+          EOF
+
+      - name: Start Grafana server
+        run: |
+          grafana-server/bin/grafana server \
+            --homepath="$PWD/grafana-server" \
+            cfg:server.http_port=3002 \
+            > grafana-server/grafana.log 2>&1 &
+
+      - name: Install Playwright browsers
+        run: yarn playwright install chromium --with-deps
+
+      - name: Wait for Grafana server to start
+        run: |
+          timeout=90
+          elapsed=0
+          until curl -sf http://localhost:3002/api/health > /dev/null 2>&1; do
+            if [ "$elapsed" -ge "$timeout" ]; then
+              cat grafana-server/grafana.log
+              echo "Timeout after ${timeout}s waiting for Grafana"
+              exit 1
+            fi
+            sleep 2
+            elapsed=$((elapsed + 2))
+          done
+
+      - name: Run diagnostics e2e
+        run: yarn playwright test --project=diagnostics --reporter=list
+        env:
+          GRAFANA_URL: http://localhost:3002
+          CI: true
+
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: grafana-server-log-diagnostics
+          path: grafana-server/grafana.log
+          retention-days: 7
+
   required-playwright-tests:
     needs:
       - run-playwright-tests

--- a/e2e-playwright/diagnostics-suite/download-diagnostics.spec.ts
+++ b/e2e-playwright/diagnostics-suite/download-diagnostics.spec.ts
@@ -162,7 +162,10 @@ test.describe('diagnostics: Download diagnostics drawer', { tag: ['@diagnostics'
   let failureDsUid: string;
   let dashboardUid: string;
 
-  test.beforeAll(async ({ createDataSource, request }) => {
+  // createDataSource is a test-scoped fixture and can't be used from beforeAll (Playwright only
+  // allows worker-scoped fixtures there), so datasources are created via the API directly, same as
+  // the dashboard below.
+  test.beforeAll(async ({ request }) => {
     successUpstream = await startUpstream('success');
     failureUpstream = await startUpstream('failure');
 
@@ -170,21 +173,29 @@ test.describe('diagnostics: Download diagnostics drawer', { tag: ['@diagnostics'
     // more than once concurrently, and a fixed name would race across those runs.
     const runId = randomUUID();
 
-    const successDs = await createDataSource({
-      type: 'prometheus',
-      name: `e2e-diagnostics-prometheus-success-${runId}`,
-      url: successUpstream.url,
-      access: 'proxy',
+    const successDsResponse = await request.post('/api/datasources', {
+      data: {
+        type: 'prometheus',
+        name: `e2e-diagnostics-prometheus-success-${runId}`,
+        url: successUpstream.url,
+        access: 'proxy',
+        isDefault: false,
+      },
     });
-    successDsUid = successDs.uid;
+    const successDsBody = await successDsResponse.json();
+    successDsUid = successDsBody.datasource.uid;
 
-    const failureDs = await createDataSource({
-      type: 'prometheus',
-      name: `e2e-diagnostics-prometheus-failure-${runId}`,
-      url: failureUpstream.url,
-      access: 'proxy',
+    const failureDsResponse = await request.post('/api/datasources', {
+      data: {
+        type: 'prometheus',
+        name: `e2e-diagnostics-prometheus-failure-${runId}`,
+        url: failureUpstream.url,
+        access: 'proxy',
+        isDefault: false,
+      },
     });
-    failureDsUid = failureDs.uid;
+    const failureDsBody = await failureDsResponse.json();
+    failureDsUid = failureDsBody.datasource.uid;
 
     const response = await request.post('/api/dashboards/db', {
       data: buildDashboardRequestBody('Diagnostics download e2e', successDsUid, failureDsUid),

--- a/e2e-playwright/diagnostics-suite/download-diagnostics.spec.ts
+++ b/e2e-playwright/diagnostics-suite/download-diagnostics.spec.ts
@@ -21,6 +21,10 @@ async function skipUnlessOnPrem(page: Page) {
   test.skip(namespace.startsWith('stacks-'), 'on-demand diagnostics is on-prem only; e2e server runs in cloud mode');
 }
 
+// This only overrides the frontend's OFREP evaluation (so the menu item renders). The backend
+// evaluates the same flag separately for /api/ds/diagnostics, so the server this runs against
+// also needs `[feature_toggles] grafana.onDemandDiagnostics = true` set directly (see
+// pr-diagnostics-e2e.yml), or the download request 404s even with the menu item visible.
 test.use({
   openFeature: {
     flags: {

--- a/e2e-playwright/diagnostics-suite/download-diagnostics.spec.ts
+++ b/e2e-playwright/diagnostics-suite/download-diagnostics.spec.ts
@@ -4,7 +4,7 @@ import { mkdtempSync } from 'fs';
 import { createServer, type Server } from 'http';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { type Page } from 'playwright-core';
+import { type APIRequestContext, type Page } from 'playwright-core';
 
 import { type BootData } from '@grafana/data';
 import { test, expect, type DashboardPage, type E2ESelectorGroups } from '@grafana/plugin-e2e';
@@ -161,11 +161,17 @@ test.describe('diagnostics: Download diagnostics drawer', { tag: ['@diagnostics'
   let successDsUid: string;
   let failureDsUid: string;
   let dashboardUid: string;
+  let apiContext: APIRequestContext;
 
-  // createDataSource is a test-scoped fixture and can't be used from beforeAll (Playwright only
-  // allows worker-scoped fixtures there), so datasources are created via the API directly, same as
-  // the dashboard below.
-  test.beforeAll(async ({ request }) => {
+  // createDataSource and the `request` fixture are both test-scoped, and Playwright only allows
+  // worker-scoped fixtures in beforeAll/afterAll -- so setup/teardown go through a manually created
+  // APIRequestContext (via the worker-scoped `playwright` fixture) instead.
+  test.beforeAll(async ({ playwright }, testInfo) => {
+    apiContext = await playwright.request.newContext({
+      baseURL: testInfo.project.use.baseURL,
+      storageState: testInfo.project.use.storageState,
+    });
+
     successUpstream = await startUpstream('success');
     failureUpstream = await startUpstream('failure');
 
@@ -173,7 +179,7 @@ test.describe('diagnostics: Download diagnostics drawer', { tag: ['@diagnostics'
     // more than once concurrently, and a fixed name would race across those runs.
     const runId = randomUUID();
 
-    const successDsResponse = await request.post('/api/datasources', {
+    const successDsResponse = await apiContext.post('/api/datasources', {
       data: {
         type: 'prometheus',
         name: `e2e-diagnostics-prometheus-success-${runId}`,
@@ -185,7 +191,7 @@ test.describe('diagnostics: Download diagnostics drawer', { tag: ['@diagnostics'
     const successDsBody = await successDsResponse.json();
     successDsUid = successDsBody.datasource.uid;
 
-    const failureDsResponse = await request.post('/api/datasources', {
+    const failureDsResponse = await apiContext.post('/api/datasources', {
       data: {
         type: 'prometheus',
         name: `e2e-diagnostics-prometheus-failure-${runId}`,
@@ -197,23 +203,24 @@ test.describe('diagnostics: Download diagnostics drawer', { tag: ['@diagnostics'
     const failureDsBody = await failureDsResponse.json();
     failureDsUid = failureDsBody.datasource.uid;
 
-    const response = await request.post('/api/dashboards/db', {
+    const response = await apiContext.post('/api/dashboards/db', {
       data: buildDashboardRequestBody('Diagnostics download e2e', successDsUid, failureDsUid),
     });
     const body = await response.json();
     dashboardUid = body.uid;
   });
 
-  test.afterAll(async ({ request }) => {
+  test.afterAll(async () => {
     if (dashboardUid) {
-      await request.delete(`/api/dashboards/uid/${dashboardUid}`);
+      await apiContext.delete(`/api/dashboards/uid/${dashboardUid}`);
     }
     if (successDsUid) {
-      await request.delete(`/api/datasources/uid/${successDsUid}`);
+      await apiContext.delete(`/api/datasources/uid/${successDsUid}`);
     }
     if (failureDsUid) {
-      await request.delete(`/api/datasources/uid/${failureDsUid}`);
+      await apiContext.delete(`/api/datasources/uid/${failureDsUid}`);
     }
+    await apiContext.dispose();
     successUpstream?.server.close();
     failureUpstream?.server.close();
   });

--- a/e2e-playwright/diagnostics-suite/download-diagnostics.spec.ts
+++ b/e2e-playwright/diagnostics-suite/download-diagnostics.spec.ts
@@ -1,0 +1,256 @@
+import { execFileSync } from 'child_process';
+import { randomUUID } from 'crypto';
+import { mkdtempSync } from 'fs';
+import { createServer, type Server } from 'http';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { type Page } from 'playwright-core';
+
+import { type BootData } from '@grafana/data';
+import { test, expect, type DashboardPage, type E2ESelectorGroups } from '@grafana/plugin-e2e';
+
+// On-demand diagnostics is on-prem only: the frontend menu item is gated on isOnPrem() (namespace
+// must not start with "stacks-") and the backend registers /api/ds/diagnostics only when stack_id is
+// empty. The shared e2e-playwright server runs in cloud mode (stack_id = 12345, required by other
+// suites), so this spec self-skips there and is meant to run against an on-prem GRAFANA_URL instead.
+async function skipUnlessOnPrem(page: Page) {
+  const namespace = await page.evaluate(() => {
+    const win = window as typeof window & { grafanaBootData?: BootData };
+    return win.grafanaBootData?.settings?.namespace ?? '';
+  });
+  test.skip(namespace.startsWith('stacks-'), 'on-demand diagnostics is on-prem only; e2e server runs in cloud mode');
+}
+
+test.use({
+  openFeature: {
+    flags: {
+      'grafana.onDemandDiagnostics': true,
+    },
+  },
+});
+
+const SUCCESS_PANEL = 'Prometheus query (success)';
+const FAILURE_PANEL = 'Prometheus query (failure)';
+const DOWNLOAD_DIAGNOSTICS = 'Download diagnostics';
+const UPSTREAM_FAILURE_BODY = 'simulated upstream failure: connection reset by peer';
+
+/**
+ * Starts a bare-bones stand-in for a real Prometheus server: it doesn't validate the incoming
+ * PromQL, it just answers every request with the same canned outcome. The Prometheus datasource
+ * still makes a genuine HTTP round trip to it over loopback, so the backend query path, its error
+ * handling, and the diagnostics HAR capture are all exercised for real.
+ */
+function startUpstream(behavior: 'success' | 'failure'): Promise<{ server: Server; url: string }> {
+  return new Promise((resolve) => {
+    const server = createServer((req, res) => {
+      if (behavior === 'failure') {
+        res.writeHead(500, { 'Content-Type': 'text/plain' });
+        res.end(UPSTREAM_FAILURE_BODY);
+        return;
+      }
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          status: 'success',
+          data: {
+            resultType: 'matrix',
+            result: [
+              {
+                metric: { __name__: 'up', job: 'e2e-diagnostics' },
+                values: [
+                  [1700000000, '1'],
+                  [1700000060, '1'],
+                ],
+              },
+            ],
+          },
+        })
+      );
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as { port: number };
+      resolve({ server, url: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+function buildDashboardRequestBody(title: string, successDsUid: string, failureDsUid: string) {
+  return {
+    dashboard: {
+      annotations: { list: [] },
+      editable: true,
+      panels: [
+        {
+          datasource: { type: 'prometheus', uid: successDsUid },
+          gridPos: { h: 8, w: 12, x: 0, y: 0 },
+          id: 1,
+          targets: [{ datasource: { type: 'prometheus', uid: successDsUid }, refId: 'A', expr: 'up' }],
+          title: SUCCESS_PANEL,
+          type: 'timeseries',
+        },
+        {
+          datasource: { type: 'prometheus', uid: failureDsUid },
+          gridPos: { h: 8, w: 12, x: 12, y: 0 },
+          id: 2,
+          targets: [{ datasource: { type: 'prometheus', uid: failureDsUid }, refId: 'A', expr: 'up' }],
+          title: FAILURE_PANEL,
+          type: 'timeseries',
+        },
+      ],
+      schemaVersion: 39,
+      tags: [],
+      templating: { list: [] },
+      time: { from: 'now-6h', to: 'now' },
+      title: title,
+      uid: '',
+      version: 0,
+    },
+    folderUid: '',
+    overwrite: true,
+  };
+}
+
+/** Opens a panel's menu and walks the submenu path (e.g. ['More...', 'Download diagnostics']). */
+async function selectPanelMenuItem(
+  dashboardPage: DashboardPage,
+  selectors: E2ESelectorGroups,
+  panelTitle: string,
+  menuPath: string[]
+) {
+  await dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.title(panelTitle)).hover();
+  await dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.menu(panelTitle)).click({ force: true });
+  for (const item of menuPath.slice(0, -1)) {
+    await dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.menuItems(item)).hover();
+  }
+  await dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.menuItems(menuPath.at(-1)!)).click();
+}
+
+/** Clicks the drawer's "Download diagnostics" button and returns the downloaded bundle's member list. */
+async function downloadAndListBundle(page: Page) {
+  const downloadButton = page.getByRole('button', { name: DOWNLOAD_DIAGNOSTICS });
+  await expect(downloadButton).toBeVisible();
+
+  // The bundle is generated server-side from a real backend query, so allow more than the default
+  // action timeout.
+  const downloadPromise = page.waitForEvent('download', { timeout: 30_000 });
+  await downloadButton.click();
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toMatch(/\.tar\.gz$/);
+
+  const bundle = join(mkdtempSync(join(tmpdir(), 'diag-e2e-')), 'bundle.tar.gz');
+  await download.saveAs(bundle);
+  const members = execFileSync('tar', ['tzf', bundle], { encoding: 'utf8' }).split('\n').filter(Boolean);
+  return { bundle, members };
+}
+
+function readBundleMember(bundle: string, member: string) {
+  return execFileSync('tar', ['xOzf', bundle, member], { encoding: 'utf8' });
+}
+
+test.describe('diagnostics: Download diagnostics drawer', { tag: ['@diagnostics'] }, () => {
+  // Both tests share the fixtures set up in beforeAll (datasources, dashboard); run them in one
+  // worker so a parallel worker can't race the same beforeAll and collide on datasource names.
+  test.describe.configure({ mode: 'serial' });
+
+  let successUpstream: { server: Server; url: string };
+  let failureUpstream: { server: Server; url: string };
+  let successDsUid: string;
+  let failureDsUid: string;
+  let dashboardUid: string;
+
+  test.beforeAll(async ({ createDataSource, request }) => {
+    successUpstream = await startUpstream('success');
+    failureUpstream = await startUpstream('failure');
+
+    // Unique per run: repeated/sharded runs (e.g. `yarn e2e:playwright:10x`) can execute this file
+    // more than once concurrently, and a fixed name would race across those runs.
+    const runId = randomUUID();
+
+    const successDs = await createDataSource({
+      type: 'prometheus',
+      name: `e2e-diagnostics-prometheus-success-${runId}`,
+      url: successUpstream.url,
+      access: 'proxy',
+    });
+    successDsUid = successDs.uid;
+
+    const failureDs = await createDataSource({
+      type: 'prometheus',
+      name: `e2e-diagnostics-prometheus-failure-${runId}`,
+      url: failureUpstream.url,
+      access: 'proxy',
+    });
+    failureDsUid = failureDs.uid;
+
+    const response = await request.post('/api/dashboards/db', {
+      data: buildDashboardRequestBody('Diagnostics download e2e', successDsUid, failureDsUid),
+    });
+    const body = await response.json();
+    dashboardUid = body.uid;
+  });
+
+  test.afterAll(async ({ request }) => {
+    if (dashboardUid) {
+      await request.delete(`/api/dashboards/uid/${dashboardUid}`);
+    }
+    if (successDsUid) {
+      await request.delete(`/api/datasources/uid/${successDsUid}`);
+    }
+    if (failureDsUid) {
+      await request.delete(`/api/datasources/uid/${failureDsUid}`);
+    }
+    successUpstream?.server.close();
+    failureUpstream?.server.close();
+  });
+
+  test('successful query — the bundle carries the real upstream traffic, no error', async ({
+    page,
+    gotoDashboardPage,
+    selectors,
+  }) => {
+    const dashboardPage = await gotoDashboardPage({ uid: dashboardUid });
+    await skipUnlessOnPrem(page);
+
+    await selectPanelMenuItem(dashboardPage, selectors, SUCCESS_PANEL, ['More...', DOWNLOAD_DIAGNOSTICS]);
+    await expect(
+      dashboardPage.getByGrafanaSelector(selectors.components.Drawer.General.title(DOWNLOAD_DIAGNOSTICS))
+    ).toBeVisible();
+
+    const { bundle, members } = await downloadAndListBundle(page);
+
+    const har = members.find((m) => m === 'traffic.har' || m.endsWith('/traffic.har'));
+    const queryError = members.find((m) => m === 'query-error.txt' || m.endsWith('/query-error.txt'));
+    expect(har, `bundle should contain the captured upstream exchange (members: ${members.join(', ')})`).toBeTruthy();
+    expect(queryError, 'a successful query should not produce a query-error.txt').toBeFalsy();
+
+    const harText = readBundleMember(bundle, har!);
+    expect(harText, 'traffic.har should show the real 200 response from the upstream').toMatch(/"status":200/);
+    expect(harText, 'traffic.har should carry the real upstream URL').toContain(successUpstream.url);
+  });
+
+  test('upstream 500 — the bundle localizes the real error', async ({ page, gotoDashboardPage, selectors }) => {
+    const dashboardPage = await gotoDashboardPage({ uid: dashboardUid });
+    await skipUnlessOnPrem(page);
+
+    await selectPanelMenuItem(dashboardPage, selectors, FAILURE_PANEL, ['More...', DOWNLOAD_DIAGNOSTICS]);
+    await expect(
+      dashboardPage.getByGrafanaSelector(selectors.components.Drawer.General.title(DOWNLOAD_DIAGNOSTICS))
+    ).toBeVisible();
+
+    const { bundle, members } = await downloadAndListBundle(page);
+
+    const har = members.find((m) => m === 'traffic.har' || m.endsWith('/traffic.har'));
+    const queryError = members.find((m) => m === 'query-error.txt' || m.endsWith('/query-error.txt'));
+    expect(har, `bundle should contain the captured upstream exchange (members: ${members.join(', ')})`).toBeTruthy();
+    expect(queryError, `bundle should contain the verbatim query error (members: ${members.join(', ')})`).toBeTruthy();
+
+    const harText = readBundleMember(bundle, har!);
+    expect(harText, 'traffic.har should show the real upstream 500 + body').toMatch(/"status":500/);
+    expect(harText).toContain(UPSTREAM_FAILURE_BODY);
+
+    const queryErrorText = readBundleMember(bundle, queryError!);
+    expect(queryErrorText, 'query-error.txt should quote the upstream failure verbatim').toContain(
+      UPSTREAM_FAILURE_BODY
+    );
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -157,6 +157,10 @@ export default defineConfig<PluginOptions>({
       testDir: path.join(testDirRoot, '/dashboards-suite'),
     }),
     withAuth({
+      name: 'diagnostics',
+      testDir: path.join(testDirRoot, '/diagnostics-suite'),
+    }),
+    withAuth({
       name: 'cloud-plugins',
       testDir: path.join(testDirRoot, '/cloud-plugins-suite'),
     }),


### PR DESCRIPTION
## Summary

Adds a Playwright spec that drives the real **Download diagnostics** panel drawer end-to-end, covering both a successful query and a failing one, and asserts the downloaded bundle carries the real evidence for each. Also wires up the CI job needed to run it on every PR.

## What it does

`e2e-playwright/diagnostics-suite/download-diagnostics.spec.ts` provisions its own dashboard, two Prometheus datasources, and two tiny local HTTP servers standing in for a real upstream — one always answers 200, the other always answers 500. It then:

- Opens the panel menu → **More...** → **Download diagnostics** for each panel and downloads the bundle.
- **Success case**: asserts the bundle's `traffic.har` shows the real 200 response from the upstream, and that no `query-error.txt` was produced.
- **Failure case**: asserts `traffic.har` shows the real upstream 500 + body, and that `query-error.txt` quotes the failure verbatim.

Everything is self-provisioned through the Grafana API and `@grafana/plugin-e2e` fixtures (`createDataSource`, dashboard import) inside `beforeAll`/`afterAll`, and torn down after the run — no external provisioning script or fixture repo required. Datasource names are suffixed with a per-run UUID so repeated/sharded runs (e.g. `yarn e2e:playwright:10x`) don't collide.

Deliberately scoped to **panel-level** diagnostics only. Whole-dashboard bundle generation (a different code path with a nested `panels/<id>-<slug>/...` bundle layout) is left for a separate, dedicated PR.

Requires a separate job from `run-playwright-tests` as this only works for on-prem.

## CI wiring

It runs on every relevant PR alongside the other e2e jobs, but is **not** added to `required-playwright-tests` — informational only for now, since it's a new job with a network dependency (installing `prometheus` from the plugin catalog) and shouldn't block merges until it's proven stable.