### PR TITLE
E2E Selectors: Add plugin catalog and editable title selectors for pathfinder guides

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -1286,6 +1286,14 @@ export const versionedComponents = {
       '9.5.0': (title: string) => `data-testid ${title}`,
     },
   },
+  EditableTitle: {
+    editButton: {
+      '13.2.0': 'data-testid Editable title edit button',
+    },
+    titleInput: {
+      '13.2.0': 'data-testid Editable title input',
+    },
+  },
   QueryEditorToolbarItem: {
     button: {
       [MIN_GRAFANA_VERSION]: (title: string) => `QueryEditor toolbar item button ${title}`,

--- a/packages/grafana-e2e-selectors/src/selectors/pages.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/pages.ts
@@ -97,6 +97,9 @@ export const versionedPages = {
       '9.3.1': (pluginName: string) => `Add new data source ${pluginName}`,
       [MIN_GRAFANA_VERSION]: (pluginName: string) => `Data source plugin item ${pluginName}`,
     },
+    searchInput: {
+      '13.2.0': 'data-testid Add data source search input',
+    },
   },
   Connections: {
     AddNewConnection: {
@@ -1093,10 +1096,12 @@ export const versionedPages = {
       [MIN_GRAFANA_VERSION]: 'Plugins list page',
     },
     list: {
+      '13.2.0': 'data-testid Plugins list',
       [MIN_GRAFANA_VERSION]: 'Plugins list',
     },
     listItem: {
-      [MIN_GRAFANA_VERSION]: 'Plugins list item',
+      '13.2.0': (pluginId: string) => `data-testid Plugins list item ${pluginId}`,
+      [MIN_GRAFANA_VERSION]: (_pluginId: string) => 'Plugins list item',
     },
     signatureErrorNotice: {
       '10.3.0': 'data-testid Unsigned plugins notice',

--- a/public/app/core/components/Page/EditableTitle.tsx
+++ b/public/app/core/components/Page/EditableTitle.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import * as React from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { isFetchError } from '@grafana/runtime';
 import { Field, IconButton, Input, useStyles2, Text } from '@grafana/ui';
@@ -89,6 +90,7 @@ export const EditableTitle = ({ value, onEdit }: Props) => {
           size="lg"
           tooltip={t('page.editable-title.edit-tooltip', 'Edit title')}
           onClick={() => setIsEditing(true)}
+          data-testid={selectors.components.EditableTitle.editButton}
         />
       </div>
     </div>
@@ -120,6 +122,7 @@ export const EditableTitle = ({ value, onEdit }: Props) => {
           onBlur={onBlur}
           onChange={(event) => setLocalValue(event.currentTarget.value)}
           onFocus={() => setIsEditing(true)}
+          data-testid={selectors.components.EditableTitle.titleInput}
         />
       </Field>
       <div className={styles.buttons}>

--- a/public/app/features/datasources/components/NewDataSource.tsx
+++ b/public/app/features/datasources/components/NewDataSource.tsx
@@ -1,6 +1,7 @@
 import { type Action } from 'redux';
 
 import { type DataSourcePluginMeta, PluginType } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
 import { LinkButton, FilterInput } from '@grafana/ui';
@@ -71,6 +72,7 @@ function NewDataSourceView({
             'datasources.new-data-source-view.placeholder-filter-by-name-or-type',
             'Filter by name or type'
           )}
+          data-testid={selectors.pages.AddDataSource.searchInput}
         />
         <div className="page-action-bar__spacer" />
         <LinkButton

--- a/public/app/features/plugins/admin/components/PluginList.test.tsx
+++ b/public/app/features/plugins/admin/components/PluginList.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 
 import { PluginSignatureStatus, PluginSignatureType, PluginType } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { config } from '@grafana/runtime';
 
 import { type CatalogPlugin } from '../types';
@@ -68,7 +69,7 @@ describe('PluginList', () => {
     const plugins = [mockPlugin, mockPlugin2];
     render(<PluginList plugins={plugins} isLoading={false} />);
 
-    expect(screen.getByTestId('plugin-list')).toBeInTheDocument();
+    expect(screen.getByTestId(selectors.pages.PluginsList.list)).toBeInTheDocument();
     expect(screen.getByText('Test Plugin')).toBeInTheDocument();
     expect(screen.getByText('Test Plugin 2')).toBeInTheDocument();
   });

--- a/public/app/features/plugins/admin/components/PluginList.tsx
+++ b/public/app/features/plugins/admin/components/PluginList.tsx
@@ -1,5 +1,6 @@
 import { useLocation, useSearchParams } from 'react-router-dom-v5-compat';
 
+import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { EmptyState, Grid } from '@grafana/ui';
@@ -32,7 +33,7 @@ export const PluginList = ({ plugins, isLoading }: Props) => {
   }
 
   return (
-    <Grid gap={3} {...{ minColumnWidth: 34 }} data-testid="plugin-list">
+    <Grid gap={3} {...{ minColumnWidth: 34 }} data-testid={selectors.pages.PluginsList.list}>
       {isLoading
         ? new Array(50).fill(null).map((_, index) => <PluginListItem.Skeleton key={index} />)
         : plugins.map((plugin) => <PluginListItem key={plugin.id} plugin={plugin} pathName={pathName} />)}

--- a/public/app/features/plugins/admin/components/PluginListItem.tsx
+++ b/public/app/features/plugins/admin/components/PluginListItem.tsx
@@ -2,6 +2,7 @@ import { css, cx } from '@emotion/css';
 import Skeleton from 'react-loading-skeleton';
 
 import { type GrafanaTheme2 } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { locationService, reportInteraction } from '@grafana/runtime';
 import { Badge, Icon, Stack, useStyles2 } from '@grafana/ui';
@@ -32,7 +33,12 @@ function PluginListItemComponent({ plugin, pathName }: Props) {
     }
   };
   return (
-    <a href={`${pathName}/${plugin.id}`} className={cx(styles.container)} onClick={reportUserClickInteraction}>
+    <a
+      href={`${pathName}/${plugin.id}`}
+      className={cx(styles.container)}
+      onClick={reportUserClickInteraction}
+      data-testid={selectors.pages.PluginsList.listItem(plugin.id)}
+    >
       <PluginLogo src={plugin.info.logos.small} className={styles.pluginLogo} height={LOGO_SIZE} alt="" />
       <h2 className={cx(styles.name, 'plugin-name')}>{plugin.name}</h2>
       <div className={cx(styles.content, 'plugin-content')}>

--- a/public/app/features/plugins/admin/pages/Browse.test.tsx
+++ b/public/app/features/plugins/admin/pages/Browse.test.tsx
@@ -2,6 +2,7 @@ import { render, type RenderResult, waitFor, within } from '@testing-library/rea
 import { TestProvider } from 'test/helpers/TestProvider';
 
 import { PluginType, escapeStringForRegex } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { locationService } from '@grafana/runtime';
 import { configureStore } from 'app/store/configureStore';
 
@@ -287,7 +288,7 @@ describe('Browse list of plugins', () => {
         getCatalogPluginMock({ id: 'acesvg', name: 'ACE.SVG' }),
       ]);
 
-      const pluginList = await findByTestId('plugin-list');
+      const pluginList = await findByTestId(selectors.pages.PluginsList.list);
       const pluginHeadings = within(pluginList).queryAllByRole('heading');
       expect(pluginHeadings.map((heading) => heading.innerHTML)).toStrictEqual([
         'ACE.SVG',
@@ -307,7 +308,7 @@ describe('Browse list of plugins', () => {
         getCatalogPluginMock({ id: 'acesvg', name: 'ACE.SVG' }),
       ]);
 
-      const pluginList = await findByTestId('plugin-list');
+      const pluginList = await findByTestId(selectors.pages.PluginsList.list);
       const pluginHeadings = within(pluginList).queryAllByRole('heading');
       expect(pluginHeadings.map((heading) => heading.innerHTML)).toStrictEqual([
         'Zabbix',
@@ -327,7 +328,7 @@ describe('Browse list of plugins', () => {
         getCatalogPluginMock({ id: '5', name: 'ACE.SVG', updatedAt: '2021-02-01T00:00:00.000Z' }),
       ]);
 
-      const pluginList = await findByTestId('plugin-list');
+      const pluginList = await findByTestId(selectors.pages.PluginsList.list);
       const pluginHeadings = within(pluginList).queryAllByRole('heading');
       expect(pluginHeadings.map((heading) => heading.innerHTML)).toStrictEqual([
         'Diagram',
@@ -347,7 +348,7 @@ describe('Browse list of plugins', () => {
         getCatalogPluginMock({ id: '5', name: 'ACE.SVG', publishedAt: '2021-02-01T00:00:00.000Z' }),
       ]);
 
-      const pluginList = await findByTestId('plugin-list');
+      const pluginList = await findByTestId(selectors.pages.PluginsList.list);
       const pluginHeadings = within(pluginList).queryAllByRole('heading');
       expect(pluginHeadings.map((heading) => heading.innerHTML)).toStrictEqual([
         'Diagram',
@@ -367,7 +368,7 @@ describe('Browse list of plugins', () => {
         getCatalogPluginMock({ id: '5', name: 'ACE.SVG', downloads: 40 }),
       ]);
 
-      const pluginList = await findByTestId('plugin-list');
+      const pluginList = await findByTestId(selectors.pages.PluginsList.list);
       const pluginHeadings = within(pluginList).queryAllByRole('heading');
       expect(pluginHeadings.map((heading) => heading.innerHTML)).toStrictEqual([
         'Zabbix',


### PR DESCRIPTION
Part of #129672 (Group 7 — Plugin catalog).

Replaces weak Pathfinder guide selectors with versioned `@grafana/e2e-selectors` entries wired as `data-testid`, covering the `first-dashboard`, `assistant-self-hosted` and `github-data-source-lj/install-github-plugin` guides.

**What's in it:**
- Revives two dormant `pages.PluginsList` entries: `listItem` upgraded to a parameterized `(pluginId)` selector wired on the plugin card, and `list` given a prefixed `13.2.0` key wired on the grid.
- New `pages.AddDataSource.searchInput` and `components.EditableTitle.{editButton,titleInput}`.

**Reviewer note:** the `plugin-list` DOM literal changes to `data-testid Plugins list` (a bare value would resolve as an aria-label match and never work). All 6 in-repo usages are updated; external code hardcoding the old literal needs a one-line update.

**Structure (2 commits):** selector definitions first, JSX wiring second.

No existing selector values modified or deleted. Verified with `yarn typecheck`, ESLint on all changed files, and `yarn nx run @grafana/e2e-selectors:build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)