### PR TITLE
Provisioning: Per-worker queue size metric for repo and connection controllers

### DIFF
--- a/pkg/registry/apis/provisioning/controller/connection.go
+++ b/pkg/registry/apis/provisioning/controller/connection.go
@@ -102,6 +102,18 @@ func NewConnectionController(
 
 	cc.processFn = cc.process
 
+	// Expose the local work-queue depth as a scrape-time gauge. The queue is
+	// per-replica, so Prometheus target labels (pod/instance) distinguish replicas;
+	// no metric label is needed. A GaugeFunc reads the authoritative Len() at scrape
+	// time, so it cannot drift the way manual inc/dec would.
+	registry.MustRegister(prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Name: "grafana_provisioning_connection_worker_queue_size",
+			Help: "Number of connection keys waiting in this replica's local work queue",
+		},
+		func() float64 { return float64(cc.queue.Len()) },
+	))
+
 	return cc
 }
 

--- a/pkg/registry/apis/provisioning/controller/repository.go
+++ b/pkg/registry/apis/provisioning/controller/repository.go
@@ -158,6 +158,18 @@ func NewRepositoryController(
 	rc.enqueueRepository = rc.enqueue
 	rc.keyFunc = repoKeyFunc
 
+	// Expose the local work-queue depth as a scrape-time gauge. The queue is
+	// per-replica, so Prometheus target labels (pod/instance) distinguish replicas;
+	// no metric label is needed. A GaugeFunc reads the authoritative Len() at scrape
+	// time, so it cannot drift the way manual inc/dec would.
+	registry.MustRegister(prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Name: "grafana_provisioning_repository_worker_queue_size",
+			Help: "Number of repository keys waiting in this replica's local work queue",
+		},
+		func() float64 { return float64(rc.queue.Len()) },
+	))
+
 	return rc
 }
 

--- a/pkg/registry/apis/provisioning/controller/worker_queue_metrics_test.go
+++ b/pkg/registry/apis/provisioning/controller/worker_queue_metrics_test.go
@@ -1,0 +1,81 @@
+package controller
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+)
+
+// gaugeValueByName reads the single-sample gauge `name` from the gatherer.
+func gaugeValueByName(t *testing.T, g prometheus.Gatherer, name string) float64 {
+	t.Helper()
+	mfs, err := g.Gather()
+	require.NoError(t, err)
+	for _, mf := range mfs {
+		if mf.GetName() == name {
+			require.Len(t, mf.GetMetric(), 1)
+			return mf.GetMetric()[0].GetGauge().GetValue()
+		}
+	}
+	t.Fatalf("metric %q not found", name)
+	return 0
+}
+
+// TestRepositoryController_WorkerQueueSizeGauge verifies the worker-queue-size gauge
+// reports the live depth of the replica's local work queue at scrape time.
+func TestRepositoryController_WorkerQueueSizeGauge(t *testing.T) {
+	const metricName = "grafana_provisioning_repository_worker_queue_size"
+
+	reg := prometheus.NewRegistry()
+	rc := NewRepositoryController(
+		nil, nil, nil, nil, nil, nil, nil, nil, nil,
+		reg,
+		nil,
+		1,
+		time.Minute, time.Minute, 30*time.Second,
+		nil, nil,
+		repository.IncrementalSyncPolicy{},
+		30*time.Second,
+		false,
+	)
+
+	require.Equal(t, 0.0, gaugeValueByName(t, reg, metricName))
+
+	rc.queue.Add("ns/repo-a")
+	rc.queue.Add("ns/repo-b")
+	require.Equal(t, 2.0, gaugeValueByName(t, reg, metricName))
+
+	// Get removes the key from the queue (Len drops); Done clears it from processing.
+	key, _ := rc.queue.Get()
+	rc.queue.Done(key)
+	require.Equal(t, 1.0, gaugeValueByName(t, reg, metricName))
+}
+
+// TestConnectionController_WorkerQueueSizeGauge verifies the worker-queue-size gauge
+// reports the live depth of the replica's local work queue at scrape time.
+func TestConnectionController_WorkerQueueSizeGauge(t *testing.T) {
+	const metricName = "grafana_provisioning_connection_worker_queue_size"
+
+	reg := prometheus.NewRegistry()
+	cc := NewConnectionController(
+		nil, nil, nil, nil,
+		time.Minute, 30*time.Second,
+		reg,
+		false,
+	)
+
+	require.Equal(t, 0.0, gaugeValueByName(t, reg, metricName))
+
+	cc.queue.Add(&connectionQueueItem{key: "ns/conn-a"})
+	cc.queue.Add(&connectionQueueItem{key: "ns/conn-b"})
+	require.Equal(t, 2.0, gaugeValueByName(t, reg, metricName))
+
+	// Get removes the item from the queue (Len drops); Done clears it from processing.
+	item, _ := cc.queue.Get()
+	cc.queue.Done(item)
+	require.Equal(t, 1.0, gaugeValueByName(t, reg, metricName))
+}


### PR DESCRIPTION
## What

Adds a per-replica **worker-queue-size** gauge to the **repository** and **connection** controllers:

- `grafana_provisioning_repository_worker_queue_size`
- `grafana_provisioning_connection_worker_queue_size`

## Why

Follow-up to #129693, which replaced the drift-prone `grafana_provisioning_jobs_queue_size` with a scrape-time `grafana_provisioning_jobs_worker_queue_size` gauge on the job driver. The repository and connection controllers are the other two provisioning components that own a work queue, and they had no equivalent backlog signal for autoscaling/observability.

The HistoryJobController (`apps/provisioning/pkg/controller/historyjob.go`) has **no work queue** — it reconciles cleanup directly in the informer `AddFunc`/`UpdateFunc` — so no equivalent gauge applies there.

## How

Each controller constructor now registers a scrape-time `GaugeFunc` reading its local `queue.Len()`:

- Per-replica, **no metric label** — Prometheus pod/instance target labels distinguish replicas.
- Reading `Len()` at scrape time can't drift the way manual inc/dec would.
- Same idiom as #129693; metric names use the singular `repository`/`connection` prefix to match the sibling `..._token_*` metrics already in the package.

## Testing

- `TestRepositoryController_WorkerQueueSizeGauge`, `TestConnectionController_WorkerQueueSizeGauge` — gauge tracks `queue.Len()` across `Add`/`Get`/`Done`.
- `go test ./pkg/registry/apis/provisioning/controller/` green; `gofmt` clean; `make lint-go-diff` → 0 issues.

## Checklist
- [x] Tests added/updated
- [x] No breaking changes (additive metrics only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)