### PR TITLE
InfluxDB: Add e2e selectors for config page pathfinder guides

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -307,6 +307,31 @@ export const versionedComponents = {
         [MIN_GRAFANA_VERSION]: 'Trace ID',
       },
     },
+    InfluxDB: {
+      configPage: {
+        urlInput: {
+          '13.2.0': 'data-testid influxdb-v2-config-url-input',
+          [MIN_GRAFANA_VERSION]: 'influxdb-v2-config-url-input',
+        },
+        productSelect: {
+          '13.2.0': 'data-testid influxdb-v2-config-product-select',
+          [MIN_GRAFANA_VERSION]: 'influxdb-v2-config-product-select',
+        },
+        queryLanguageSelect: {
+          '13.2.0': 'data-testid influxdb-v2-config-query-language-select',
+          [MIN_GRAFANA_VERSION]: 'influxdb-v2-config-query-language-select',
+        },
+        organizationInput: {
+          '13.2.0': 'data-testid influxdb-v2-config-organization-input',
+        },
+        defaultBucketInput: {
+          '13.2.0': 'data-testid influxdb-v2-config-default-bucket-input',
+        },
+        tokenInput: {
+          '13.2.0': 'data-testid influxdb-v2-config-token-input',
+        },
+      },
+    },
     Prometheus: {
       configPage: {
         connectionSettings: {

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/InfluxFluxDBConnection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/InfluxFluxDBConnection.tsx
@@ -6,6 +6,7 @@ import {
   onUpdateDatasourceSecureJsonDataOption,
   updateDatasourcePluginResetOption,
 } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { Input, SecretInput, Field, Space, Box } from '@grafana/ui';
 
 import {
@@ -65,6 +66,7 @@ export const InfluxFluxDBConnection = (props: Props) => {
       >
         <Input
           id="organization"
+          data-testid={selectors.components.DataSource.InfluxDB.configPage.organizationInput}
           placeholder="myorg"
           onBlur={trackInfluxDBConfigV2FluxDBDetailsOrgInputField}
           onChange={onUpdateDatasourceJsonDataOption(props, 'organization')}
@@ -81,6 +83,7 @@ export const InfluxFluxDBConnection = (props: Props) => {
       >
         <Input
           id="default-bucket"
+          data-testid={selectors.components.DataSource.InfluxDB.configPage.defaultBucketInput}
           onBlur={trackInfluxDBConfigV2FluxDBDetailsDefaultBucketInputField}
           onChange={onUpdateDatasourceJsonDataOption(props, 'defaultBucket')}
           placeholder="mybucket"
@@ -91,6 +94,7 @@ export const InfluxFluxDBConnection = (props: Props) => {
       <Field label="Token" required noMargin invalid={!!fieldErrors.token} error={fieldErrors.token}>
         <SecretInput
           id="token"
+          data-testid={selectors.components.DataSource.InfluxDB.configPage.tokenInput}
           isConfigured={tokenConfigured}
           onBlur={trackInfluxDBConfigV2FluxDBDetailsTokenInputField}
           onChange={onUpdateDatasourceSecureJsonDataOption(props, 'token')}

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/InfluxSQLDBConnection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/InfluxSQLDBConnection.tsx
@@ -6,6 +6,7 @@ import {
   onUpdateDatasourceSecureJsonDataOption,
   updateDatasourcePluginResetOption,
 } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { Input, SecretInput, Field, Space, Box } from '@grafana/ui';
 
 import {
@@ -59,6 +60,7 @@ export const InfluxSQLDBConnection = (props: Props) => {
       <Field label="Token" required noMargin invalid={!!fieldErrors.token} error={fieldErrors.token}>
         <SecretInput
           id="token"
+          data-testid={selectors.components.DataSource.InfluxDB.configPage.tokenInput}
           isConfigured={tokenConfigured}
           onBlur={trackInfluxDBConfigV2SQLDBDetailsTokenInputField}
           onChange={onUpdateDatasourceSecureJsonDataOption(props, 'token')}

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.test.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.test.tsx
@@ -10,6 +10,7 @@ jest.mock('@grafana/runtime', () => ({
 import { act, render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { of } from 'rxjs';
 
+import { selectors } from '@grafana/e2e-selectors';
 import { type BackendSrv } from '@grafana/runtime';
 
 import { InfluxVersion } from '../../../types';
@@ -73,7 +74,7 @@ describe('UrlAndAuthenticationSection', () => {
   it('calls onOptionsChange when URL is changed', () => {
     render(<UrlAndAuthenticationSection {...defaultProps} />);
 
-    const input = screen.getByTestId('influxdb-v2-config-url-input');
+    const input = screen.getByTestId(selectors.components.DataSource.InfluxDB.configPage.urlInput);
     fireEvent.change(input, { target: { value: 'http://example.com' } });
 
     expect(onOptionsChangeMock).toHaveBeenCalled();
@@ -142,7 +143,7 @@ describe('UrlAndAuthenticationSection', () => {
 
     render(<UrlAndAuthenticationSection {...props} />);
 
-    const input = screen.getByTestId('influxdb-v2-config-url-input');
+    const input = screen.getByTestId(selectors.components.DataSource.InfluxDB.configPage.urlInput);
     onOptionsChangeMock.mockClear();
     fireEvent.blur(input, { target: { value: 'https://some-random-host.example.com' } });
 
@@ -169,7 +170,7 @@ describe('UrlAndAuthenticationSection', () => {
 
     render(<UrlAndAuthenticationSection {...props} />);
 
-    const input = screen.getByTestId('influxdb-v2-config-url-input');
+    const input = screen.getByTestId(selectors.components.DataSource.InfluxDB.configPage.urlInput);
     onOptionsChangeMock.mockClear();
     fireEvent.blur(input, { target: { value: 'influxdb.io' } });
 
@@ -195,7 +196,7 @@ describe('UrlAndAuthenticationSection', () => {
     };
 
     render(<UrlAndAuthenticationSection {...props} />);
-    const input = screen.getByTestId('influxdb-v2-config-url-input');
+    const input = screen.getByTestId(selectors.components.DataSource.InfluxDB.configPage.urlInput);
 
     onOptionsChangeMock.mockClear();
     fireEvent.blur(input, { target: { value: 'https://us-east-1-1.aws.cloud2.influxdata.com' } });
@@ -222,7 +223,7 @@ describe('UrlAndAuthenticationSection', () => {
     };
 
     render(<UrlAndAuthenticationSection {...props} />);
-    const input = screen.getByTestId('influxdb-v2-config-url-input');
+    const input = screen.getByTestId(selectors.components.DataSource.InfluxDB.configPage.urlInput);
 
     onOptionsChangeMock.mockClear();
     fireEvent.blur(input, { target: { value: 'https://us-west-2-1.aws.cloud2.influxdata.com' } });
@@ -249,7 +250,7 @@ describe('UrlAndAuthenticationSection', () => {
     };
 
     render(<UrlAndAuthenticationSection {...props} />);
-    const input = screen.getByTestId('influxdb-v2-config-url-input');
+    const input = screen.getByTestId(selectors.components.DataSource.InfluxDB.configPage.urlInput);
 
     onOptionsChangeMock.mockClear();
     fireEvent.blur(input, { target: { value: 'https://influxcloud.net' } });
@@ -278,7 +279,7 @@ describe('UrlAndAuthenticationSection', () => {
     mockFetchPing({ build: 'OSS', version: '1.8.10' });
 
     render(<UrlAndAuthenticationSection {...props} />);
-    const input = screen.getByTestId('influxdb-v2-config-url-input');
+    const input = screen.getByTestId(selectors.components.DataSource.InfluxDB.configPage.urlInput);
 
     onOptionsChangeMock.mockClear();
     fireEvent.blur(input, { target: { value: 'https://someinfluxoss1url.com' } });
@@ -307,7 +308,7 @@ describe('UrlAndAuthenticationSection', () => {
     mockFetchPing({ build: 'OSS', version: '2.7.1' });
 
     render(<UrlAndAuthenticationSection {...props} />);
-    const input = screen.getByTestId('influxdb-v2-config-url-input');
+    const input = screen.getByTestId(selectors.components.DataSource.InfluxDB.configPage.urlInput);
 
     onOptionsChangeMock.mockClear();
     fireEvent.blur(input, { target: { value: 'https://someinfluxoss2url.com' } });
@@ -336,7 +337,7 @@ describe('UrlAndAuthenticationSection', () => {
     mockFetchPing({ build: undefined, version: undefined });
 
     render(<UrlAndAuthenticationSection {...props} />);
-    const input = screen.getByTestId('influxdb-v2-config-url-input');
+    const input = screen.getByTestId(selectors.components.DataSource.InfluxDB.configPage.urlInput);
 
     onOptionsChangeMock.mockClear();
     fireEvent.blur(input, { target: { value: 'https://no-known-pattern.example.com' } });
@@ -411,7 +412,7 @@ describe('UrlAndAuthenticationSection', () => {
     };
 
     render(<UrlAndAuthenticationSection {...props} />);
-    const input = screen.getByTestId('influxdb-v2-config-url-input');
+    const input = screen.getByTestId(selectors.components.DataSource.InfluxDB.configPage.urlInput);
 
     onOptionsChangeMock.mockClear();
     fireEvent.blur(input, { target: { value: 'https://us-east-1-1.aws.cloud2.influxdata.com' } });

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { firstValueFrom } from 'rxjs';
 
 import { onUpdateDatasourceJsonDataOptionSelect, onUpdateDatasourceOption } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { getBackendSrv } from '@grafana/runtime';
 import {
   Box,
@@ -213,7 +214,7 @@ export const UrlAndAuthenticationSection = (props: Props) => {
         <Box direction="column" marginTop={3}>
           <Field label="URL" noMargin required invalid={!!fieldErrors.url} error={fieldErrors.url}>
             <Input
-              data-testid="influxdb-v2-config-url-input"
+              data-testid={selectors.components.DataSource.InfluxDB.configPage.urlInput}
               placeholder="example: http://localhost:8086/"
               onChange={onUrlChange}
               value={options.url || ''}
@@ -250,7 +251,7 @@ export const UrlAndAuthenticationSection = (props: Props) => {
                     error={fieldErrors.product}
                   >
                     <Combobox
-                      data-testid="influxdb-v2-config-product-select"
+                      data-testid={selectors.components.DataSource.InfluxDB.configPage.productSelect}
                       value={options.jsonData.product}
                       options={INFLUXDB_VERSION_MAP.map(({ name }) => ({ value: name }))}
                       onChange={onProductChange}
@@ -269,7 +270,7 @@ export const UrlAndAuthenticationSection = (props: Props) => {
                     error={fieldErrors.version}
                   >
                     <Combobox
-                      data-testid="influxdb-v2-config-query-language-select"
+                      data-testid={selectors.components.DataSource.InfluxDB.configPage.queryLanguageSelect}
                       value={options.jsonData.product !== '' ? options.jsonData.version : ''}
                       options={getQueryLanguageOptions(options.jsonData.product || '')}
                       onChange={onQueryLanguageChange}


### PR DESCRIPTION
Part of #129672 (Group 8 — Sweep-up).

Replaces weak Pathfinder guide selectors with versioned `@grafana/e2e-selectors` entries wired as `data-testid`, covering the `influxdb-data-source-lj` guides — a new `components.DataSource.InfluxDB.configPage` subgroup (6 entries) wired across the URL/auth section and the Flux/SQL connection forms.

**Reviewer note:** the three pre-existing `influxdb-v2-config-*` hardcoded literals are promoted to versioned entries with `data-testid `-prefixed `13.2.0` values; the bare literals are preserved under `MIN_GRAFANA_VERSION` and all in-repo usages (including the config test suite, 19/19 passing) are updated. External code hardcoding the old literals needs a one-line update.

**Structure (2 commits):** selector definitions first, JSX wiring second (InfluxDB core datasource is not a decoupled workspace).

No existing selector values modified or deleted. Verified with `yarn typecheck`, ESLint, `yarn nx run @grafana/e2e-selectors:build`, and the InfluxDB config jest suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## MT compatibility exception (`no-check-mt-service-compatibility`)

Why these changes are safe to couple, verified in code and agreed with @joshhunt:

- `@grafana/e2e-selectors` is **not** in the plugin webpack externals (`packages/grafana-plugin-configs/webpack.config.ts`) — each decoupled plugin bundles its own copy of the selector values.
- The static `selectors` export resolves `'latest'` **against its own bundle at module init** (`selectors/index.ts`) with no reads from core runtime, so core/plugin version skew cannot change what the plugin renders or references.
- The resolver falls back to the newest available key when a requested version has no match (`resolver.ts`), so a missing selector path or version key can never occur at runtime.
- Consumers of the affected values were enumerated: no in-repo test or live guide targets the old values in a way this change breaks; guide retargets are sequenced after plugin rollout via the migration map for #129672.

Net: there is no runtime contract across the frontend/plugin version boundary for this change; the coupling is safe.
