### PR TITLE
Provisioning: Per-worker queue wait-time metric for repo and connection controllers

### DIFF
--- a/pkg/registry/apis/provisioning/controller/connection.go
+++ b/pkg/registry/apis/provisioning/controller/connection.go
@@ -88,7 +88,8 @@ func NewConnectionController(
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[*connectionQueueItem](),
 			workqueue.TypedRateLimitingQueueConfig[*connectionQueueItem]{
-				Name: "provisioningConnectionController",
+				Name:            "provisioningConnectionController",
+				MetricsProvider: newWorkerQueueWaitProvider(registry, "connection"),
 			},
 		),
 		statusPatcher:     statusPatcher,

--- a/pkg/registry/apis/provisioning/controller/repository.go
+++ b/pkg/registry/apis/provisioning/controller/repository.go
@@ -126,7 +126,8 @@ func NewRepositoryController(
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{
-				Name: "provisioningRepositoryController",
+				Name:            "provisioningRepositoryController",
+				MetricsProvider: newWorkerQueueWaitProvider(registry, "repository"),
 			},
 		),
 		repoFactory:       repoFactory,

--- a/pkg/registry/apis/provisioning/controller/worker_queue_metrics.go
+++ b/pkg/registry/apis/provisioning/controller/worker_queue_metrics.go
@@ -1,0 +1,73 @@
+package controller
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/client-go/util/workqueue"
+)
+
+// workerQueueWaitBuckets mirrors the job queue's grafana_provisioning_jobs_queue_wait_seconds
+// buckets so controller and job-driver queue latencies are directly comparable on the same
+// dashboards.
+var workerQueueWaitBuckets = []float64{1.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0}
+
+// newWorkerQueueWaitProvider registers a per-replica histogram named
+// grafana_provisioning_<component>_worker_queue_wait_seconds and returns a
+// workqueue.MetricsProvider that feeds only the queue's latency observations into it. The
+// workqueue records when a key first enters the queue and observes the elapsed time when a
+// worker picks it up, so coalesced re-adds are measured from the first enqueue — the true
+// backlog wait. Every other workqueue metric is a no-op: queue depth is already exposed as a
+// scrape-time GaugeFunc, and the rest are not needed here.
+//
+// The provider must be non-empty (a name is set on the queue config) or client-go falls back
+// to its no-op metrics and never records the latency.
+func newWorkerQueueWaitProvider(registry prometheus.Registerer, component string) workqueue.MetricsProvider {
+	waitTime := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "grafana_provisioning_" + component + "_worker_queue_wait_seconds",
+		Help:    "Time " + component + " keys spend waiting in this replica's local work queue before a worker picks them up",
+		Buckets: workerQueueWaitBuckets,
+	})
+	registry.MustRegister(waitTime)
+	return workerQueueWaitMetricsProvider{latency: waitTime}
+}
+
+// workerQueueWaitMetricsProvider implements workqueue.MetricsProvider, wiring only the
+// queue-latency histogram and no-opping every other workqueue metric.
+type workerQueueWaitMetricsProvider struct {
+	latency prometheus.Histogram
+}
+
+func (p workerQueueWaitMetricsProvider) NewLatencyMetric(string) workqueue.HistogramMetric {
+	return p.latency
+}
+
+func (workerQueueWaitMetricsProvider) NewDepthMetric(string) workqueue.GaugeMetric {
+	return noopWorkqueueMetric{}
+}
+
+func (workerQueueWaitMetricsProvider) NewAddsMetric(string) workqueue.CounterMetric {
+	return noopWorkqueueMetric{}
+}
+
+func (workerQueueWaitMetricsProvider) NewWorkDurationMetric(string) workqueue.HistogramMetric {
+	return noopWorkqueueMetric{}
+}
+
+func (workerQueueWaitMetricsProvider) NewUnfinishedWorkSecondsMetric(string) workqueue.SettableGaugeMetric {
+	return noopWorkqueueMetric{}
+}
+
+func (workerQueueWaitMetricsProvider) NewLongestRunningProcessorSecondsMetric(string) workqueue.SettableGaugeMetric {
+	return noopWorkqueueMetric{}
+}
+
+func (workerQueueWaitMetricsProvider) NewRetriesMetric(string) workqueue.CounterMetric {
+	return noopWorkqueueMetric{}
+}
+
+// noopWorkqueueMetric satisfies every workqueue metric interface without recording anything.
+type noopWorkqueueMetric struct{}
+
+func (noopWorkqueueMetric) Inc()            {}
+func (noopWorkqueueMetric) Dec()            {}
+func (noopWorkqueueMetric) Set(float64)     {}
+func (noopWorkqueueMetric) Observe(float64) {}

--- a/pkg/registry/apis/provisioning/controller/worker_queue_metrics_test.go
+++ b/pkg/registry/apis/provisioning/controller/worker_queue_metrics_test.go
@@ -25,6 +25,84 @@ func gaugeValueByName(t *testing.T, g prometheus.Gatherer, name string) float64 
 	return 0
 }
 
+// histogramSampleCountByName reads the observation count of the histogram `name`.
+func histogramSampleCountByName(t *testing.T, g prometheus.Gatherer, name string) uint64 {
+	t.Helper()
+	mfs, err := g.Gather()
+	require.NoError(t, err)
+	for _, mf := range mfs {
+		if mf.GetName() == name {
+			require.Len(t, mf.GetMetric(), 1)
+			return mf.GetMetric()[0].GetHistogram().GetSampleCount()
+		}
+	}
+	t.Fatalf("metric %q not found", name)
+	return 0
+}
+
+// TestRepositoryController_WorkerQueueWaitHistogram verifies the queue-wait histogram
+// records one observation each time a worker picks a key up off the queue.
+func TestRepositoryController_WorkerQueueWaitHistogram(t *testing.T) {
+	const metricName = "grafana_provisioning_repository_worker_queue_wait_seconds"
+
+	reg := prometheus.NewRegistry()
+	rc := NewRepositoryController(
+		nil, nil, nil, nil, nil, nil, nil, nil, nil,
+		reg,
+		nil,
+		1,
+		time.Minute, time.Minute, 30*time.Second,
+		nil, nil,
+		repository.IncrementalSyncPolicy{},
+		30*time.Second,
+		false,
+	)
+
+	require.Equal(t, uint64(0), histogramSampleCountByName(t, reg, metricName))
+
+	// Two distinct keys, but repo-a is enqueued twice: the workqueue coalesces the
+	// re-add onto the still-queued key, so only two keys are ever picked up and only
+	// two wait times are observed.
+	rc.queue.Add("ns/repo-a")
+	rc.queue.Add("ns/repo-a")
+	rc.queue.Add("ns/repo-b")
+
+	key, _ := rc.queue.Get()
+	rc.queue.Done(key)
+	require.Equal(t, uint64(1), histogramSampleCountByName(t, reg, metricName))
+
+	key, _ = rc.queue.Get()
+	rc.queue.Done(key)
+	require.Equal(t, uint64(2), histogramSampleCountByName(t, reg, metricName))
+}
+
+// TestConnectionController_WorkerQueueWaitHistogram verifies the queue-wait histogram
+// records one observation each time a worker picks an item up off the queue.
+func TestConnectionController_WorkerQueueWaitHistogram(t *testing.T) {
+	const metricName = "grafana_provisioning_connection_worker_queue_wait_seconds"
+
+	reg := prometheus.NewRegistry()
+	cc := NewConnectionController(
+		nil, nil, nil, nil,
+		time.Minute, 30*time.Second,
+		reg,
+		false,
+	)
+
+	require.Equal(t, uint64(0), histogramSampleCountByName(t, reg, metricName))
+
+	cc.queue.Add(&connectionQueueItem{key: "ns/conn-a"})
+	cc.queue.Add(&connectionQueueItem{key: "ns/conn-b"})
+
+	item, _ := cc.queue.Get()
+	cc.queue.Done(item)
+	require.Equal(t, uint64(1), histogramSampleCountByName(t, reg, metricName))
+
+	item, _ = cc.queue.Get()
+	cc.queue.Done(item)
+	require.Equal(t, uint64(2), histogramSampleCountByName(t, reg, metricName))
+}
+
 // TestRepositoryController_WorkerQueueSizeGauge verifies the worker-queue-size gauge
 // reports the live depth of the replica's local work queue at scrape time.
 func TestRepositoryController_WorkerQueueSizeGauge(t *testing.T) {


### PR DESCRIPTION
## What

Adds a per-replica **worker-queue-wait-time** histogram to the **repository** and **connection** controllers:

- `grafana_provisioning_repository_worker_queue_wait_seconds`
- `grafana_provisioning_connection_worker_queue_wait_seconds`

Each measures how long a key waits in that replica's local work queue before a worker picks it up.

## Why

Follow-up to #129810, which added the per-replica worker-queue-**size** gauge to these two controllers. Size tells you the backlog depth; it doesn't tell you how long work is actually sitting there. This adds the latency signal — the same one the job queue already exposes as `grafana_provisioning_jobs_queue_wait_seconds` — so the repository and connection controllers have a comparable "time spent waiting" measurement for autoscaling and observability.

## How

Rather than hand-rolling enqueue-timestamp bookkeeping (error-prone with the workqueue's key coalescing, and awkward across the two controllers' differing item types — `string` keys for repositories, `*connectionQueueItem` pointers for connections), each controller wires client-go's own `workqueue.MetricsProvider` into its queue config.

- The provider feeds **only** the queue-latency observations into the histogram; every other workqueue metric is a no-op (`NewLatencyMetric` returns the histogram, the rest return a shared no-op). Queue depth stays on #129810's existing scrape-time `GaugeFunc`, so there's no duplication.
- The workqueue records when a key first enters the queue and observes the elapsed time on `Get()`, so coalesced re-adds are measured from the **first** enqueue — the true backlog wait.
- Per-replica, **no metric label** — Prometheus pod/instance target labels distinguish replicas (same idiom as #129810).
- Buckets `{1, 5, 10, 30, 60, 120, 300}` match the job queue so controller and job-driver queue latencies are directly comparable on the same dashboards.

## Testing

- `TestRepositoryController_WorkerQueueWaitHistogram`, `TestConnectionController_WorkerQueueWaitHistogram` — one observation recorded per pickup, including the repository key-coalescing case.
- `go test ./pkg/registry/apis/provisioning/controller/` green; `gofmt` clean; `make lint-go-diff` → 0 issues.

## Checklist
- [x] Tests added/updated
- [x] No breaking changes (additive metrics only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)