### PR TITLE
AppChrome: Wire dormant NavBar toggle selector on mega menu button

### DIFF
--- a/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
+++ b/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
@@ -74,6 +74,7 @@ export const SingleTopBar = memo(function SingleTopBar({
             <ToolbarButton
               narrow
               id={MEGA_MENU_TOGGLE_ID}
+              data-testid={Components.NavBar.Toggle.button}
               onClick={onToggleMegaMenu}
               tooltip={t('navigation.megamenu.open', 'Main menu')}
               aria-expanded={state.megaMenuOpen}


### PR DESCRIPTION
Part of #129672 (Group 8 — Sweep-up).

Wires the existing dormant `components.NavBar.Toggle.button` selector (defined since 10.2.3, never bound in JSX) as `data-testid` on the mega-menu toggle in `SingleTopBar.tsx` — used by the `how-to-setup-secrets-tutorial` Pathfinder guide.

Wiring-only change (1 file, 1 commit): the selector entry already carries a `data-testid `-prefixed value, so no `packages/*` changes are needed.

Verified with `yarn typecheck` and ESLint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)