### PR TITLE
Alerting: Add e2e selectors for new rule and view contact points links

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -1107,6 +1107,9 @@ export const versionedComponents = {
       '13.2.0': (mode: string) => `data-testid alert-rule routing-options-${mode}`,
       [MIN_GRAFANA_VERSION]: (mode: string) => `routing-options-${mode}`,
     },
+    viewContactPointsLink: {
+      '13.2.0': 'data-testid alert-rule view-contact-points-link',
+    },
   },
   Alert: {
     alertV2: {

--- a/packages/grafana-e2e-selectors/src/selectors/pages.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/pages.ts
@@ -31,6 +31,9 @@ export const versionedPages = {
       emptyStateNewRuleLink: {
         '13.2.0': 'data-testid rule-list empty-state-new-rule-link',
       },
+      newAlertRuleLink: {
+        '13.2.0': 'data-testid rule-list new-alert-rule-link',
+      },
       moreMenu: {
         triggerButton: {
           '13.2.0': 'data-testid rule-list more-menu-trigger-button',

--- a/public/app/features/alerting/unified/components/RuleNotificationSection.tsx
+++ b/public/app/features/alerting/unified/components/RuleNotificationSection.tsx
@@ -4,6 +4,7 @@ import { useFormContext } from 'react-hook-form';
 
 import { notificationsAPIv0alpha1 } from '@grafana/alerting/unstable';
 import { type GrafanaTheme2, textUtil } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import {
   Button,
@@ -242,6 +243,7 @@ export function RuleNotificationSection() {
                       'alerting.link-to-contact-points.aria-label-view-or-create-contact-points',
                       'View or create contact points'
                     )}
+                    data-testid={selectors.components.AlertRules.viewContactPointsLink}
                   >
                     <Trans i18nKey="alerting.link-to-contact-points.view-or-create-contact-points">
                       View or create contact points

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/contactPoint/ContactPointSelector.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/contactPoint/ContactPointSelector.tsx
@@ -109,6 +109,7 @@ function LinkToContactPoints() {
         'alerting.link-to-contact-points.aria-label-view-or-create-contact-points',
         'View or create contact points'
       )}
+      data-testid={selectors.components.AlertRules.viewContactPointsLink}
     >
       <Trans i18nKey="alerting.link-to-contact-points.view-or-create-contact-points">
         View or create contact points

--- a/public/app/features/alerting/unified/rule-list/RuleList.v2.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v2.tsx
@@ -150,7 +150,12 @@ export function RuleListActions() {
   return (
     <Stack direction="row" gap={1}>
       {canCreateRules && (
-        <LinkButton variant="primary" icon="plus" href="/alerting/new/alerting">
+        <LinkButton
+          variant="primary"
+          icon="plus"
+          href="/alerting/new/alerting"
+          data-testid={selectors.pages.Alerting.RuleList.newAlertRuleLink}
+        >
           <Trans i18nKey="alerting.rule-list.new-alert-rule">New alert rule</Trans>
         </LinkButton>
       )}


### PR DESCRIPTION
Part of #129672 (Group 2 — Alerting, cluster 3 of 3 — the final slice of the programme's core work). Follows #129770 and #129809.

Replaces weak Pathfinder guide selectors with versioned `@grafana/e2e-selectors` entries wired as `data-testid`, covering the `infrastructure-alerting-lj` milestones — 2 new entries: `pages.Alerting.RuleList.newAlertRuleLink` and `components.AlertRules.viewContactPointsLink` (wired on both mutually-exclusive rule-form versions). The guides' remaining anchors resolve to selectors landed in the earlier alerting PRs.

**Structure (2 commits):** selector definitions first, JSX wiring second (all under `public/app/features/alerting`).

No existing selector values modified or deleted. Verified with `yarn typecheck` (re-run against current main after cherry-pick), ESLint, and `yarn nx run @grafana/e2e-selectors:build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)