### PR TITLE
Query Editor: Let stacked view coexist with multi-select and the alerts view

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/ContentHeader.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/ContentHeader.test.tsx
@@ -1,11 +1,12 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 import { type DataSourceInstanceSettings, type DataSourcePluginMeta, type ScopedVars } from '@grafana/data';
 import { type DataQuery } from '@grafana/schema';
 
 import { QueryEditorType } from '../../constants';
+import { renderWithQueryEditorProvider } from '../testUtils';
 
-import { ContentHeader } from './ContentHeader';
+import { ContentHeader, ContentHeaderSceneWrapper } from './ContentHeader';
 
 // Capture the picker props so we can assert how `current` and `scopedVars` are resolved.
 const mockDataSourcePicker = jest.fn();
@@ -17,9 +18,8 @@ jest.mock('app/features/datasources/components/picker/DataSourcePicker', () => (
   },
 }));
 
-// These read from QueryEditor context, which is out of scope for these prop-based wiring tests.
+// Reads from QueryEditor context, which is out of scope for these header wiring tests.
 jest.mock('./HeaderActions', () => ({ HeaderActions: () => null }));
-jest.mock('./EditableQueryName', () => ({ EditableQueryName: () => null }));
 
 const resolvedSettings: DataSourceInstanceSettings = {
   uid: '${metrics_source}',
@@ -78,5 +78,20 @@ describe('ContentHeader datasource picker', () => {
     renderHeader({ refId: 'A' }, { scopedVars });
 
     expect(pickerProps().scopedVars).toBe(scopedVars);
+  });
+});
+
+describe('ContentHeader query name', () => {
+  it('stays editable while a bulk selection is active', () => {
+    // The header describes the active card only, so a bulk selection elsewhere in the sidebar
+    // is no reason to lock renaming.
+    const query = { refId: 'A' };
+    renderWithQueryEditorProvider(<ContentHeaderSceneWrapper />, {
+      queries: [query, { refId: 'B' }],
+      selectedQuery: query,
+      uiStateOverrides: { multiSelectMode: true, selectedQueryRefIds: ['A', 'B'] },
+    });
+
+    expect(screen.getByRole('button', { name: 'Edit query name' })).toBeInTheDocument();
   });
 });

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/ContentHeader.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/ContentHeader.tsx
@@ -95,7 +95,6 @@ interface ContentHeaderProps {
   onCancelPendingTransformation?: () => void;
   onChangeDataSource: (ds: DataSourceInstanceSettings, refId: string) => void;
   onUpdateQuery: (updatedQuery: DataQuery, originalRefId: string) => void;
-  isMultiSelection?: boolean;
   currentDatasource?: DataSourceInstanceSettings;
   scopedVars?: ScopedVars;
   /**
@@ -141,7 +140,6 @@ export function ContentHeader({
   onCancelPendingTransformation,
   onChangeDataSource,
   onUpdateQuery,
-  isMultiSelection,
   renderHeaderExtras,
   containerRef: externalContainerRef,
   typeConfig: typeConfigProp,
@@ -244,7 +242,6 @@ export function ContentHeader({
               query={selectedQuery}
               queries={queries}
               onQueryUpdate={onUpdateQuery}
-              readOnly={isMultiSelection}
             />
             {renderHeaderExtras && <div className={styles.headerExtras}>{renderHeaderExtras()}</div>}
           </>
@@ -272,9 +269,6 @@ export function ContentHeaderSceneWrapper({
     selectedAlert,
     selectedQuery,
     selectedTransformation,
-    selectedQueryRefIds,
-    selectedTransformationIds,
-    multiSelectMode,
     cardType,
     pendingExpression,
     setPendingExpression,
@@ -300,7 +294,6 @@ export function ContentHeaderSceneWrapper({
       onCancelPendingTransformation={() => setPendingTransformation(null)}
       onChangeDataSource={changeDataSource}
       onUpdateQuery={updateSelectedQuery}
-      isMultiSelection={multiSelectMode && (selectedQueryRefIds.length > 0 || selectedTransformationIds.length > 0)}
       renderHeaderExtras={renderHeaderExtras}
       typeConfig={typeConfig}
       currentDatasource={selectedQueryDsData?.dsSettings}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/EditableQueryName.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/EditableQueryName.tsx
@@ -13,10 +13,9 @@ interface EditableQueryNameProps {
   query: DataQuery;
   queries: DataQuery[];
   onQueryUpdate: (updatedQuery: DataQuery, originalRefId: string) => void;
-  readOnly?: boolean;
 }
 
-export function EditableQueryName({ query, queries, onQueryUpdate, readOnly }: EditableQueryNameProps) {
+export function EditableQueryName({ query, queries, onQueryUpdate }: EditableQueryNameProps) {
   const styles = useStyles2(getStyles);
 
   const [isEditing, setIsEditing] = useState(false);
@@ -103,16 +102,6 @@ export function EditableQueryName({ query, queries, onQueryUpdate, readOnly }: E
   const onFocus = (event: React.FocusEvent<HTMLInputElement>) => {
     event.target.select();
   };
-
-  if (readOnly) {
-    return (
-      <span className={styles.queryNameText}>
-        <Text color="primary" truncate variant="code">
-          {query.refId}
-        </Text>
-      </span>
-    );
-  }
 
   if (isEditing) {
     return (

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.test.ts
@@ -723,9 +723,8 @@ describe('QueryEditorContextWrapper - stacked mode', () => {
       loading: false,
       isDashboardSaved: true,
     });
-    // Stacked mode is single-select and drives the active card (selectedQuery /
-    // selectedTransformation), so the query runner must expose real queries for the active
-    // selection to resolve through useSelectedCard.
+    // Stacked mode drives the active card (selectedQuery / selectedTransformation), so the query
+    // runner must expose real queries for the active selection to resolve through useSelectedCard.
     const { getQueryRunnerFor } = require('../../../utils/utils');
     getQueryRunnerFor.mockReturnValue({ useState: () => ({ queries: stackedQueries }) });
   });
@@ -735,19 +734,19 @@ describe('QueryEditorContextWrapper - stacked mode', () => {
     getQueryRunnerFor.mockReturnValue(null);
   });
 
-  it('selects a clicked query as a single selection in stacked mode (scrolling is the renderer’s job)', () => {
+  it('activates a clicked query in stacked mode (scrolling is the renderer’s job)', () => {
     const dataPane = makeMockDataPane();
     const { result } = renderWithWrapper(dataPane);
 
     act(() => result.current.stackedMode.enter());
     act(() => result.current.toggleQuerySelection({ refId: 'B' } as DataQuery));
 
-    // Stacked mode is single-select: the click drives the active card, not the bulk selection.
+    // A plain click drives the active card; with multi-select off there is no bulk selection.
     expect(result.current.selectedQuery?.refId).toBe('B');
     expect(result.current.selectedQueryRefIds).toEqual([]);
   });
 
-  it('selects a clicked transformation as a single selection in stacked mode', () => {
+  it('activates a clicked transformation in stacked mode', () => {
     const { useTransformations } = require('./hooks/useTransformations');
     const mockTransformation: Transformation = {
       registryItem: undefined,
@@ -761,12 +760,12 @@ describe('QueryEditorContextWrapper - stacked mode', () => {
     act(() => result.current.stackedMode.enter());
     act(() => result.current.toggleTransformationSelection(mockTransformation));
 
-    // Stacked mode is single-select: the click drives the active card, not the bulk selection.
+    // A plain click drives the active card; with multi-select off there is no bulk selection.
     expect(result.current.selectedTransformation).toEqual(mockTransformation);
     expect(result.current.selectedTransformationIds).toEqual([]);
   });
 
-  it('syncStackedActiveItem mirrors observer-driven activations into the active card selection', () => {
+  it('syncActiveItem mirrors observer-driven activations into the active card selection', () => {
     const reduce: Transformation = {
       registryItem: undefined,
       transformId: 'reduce-0',
@@ -788,7 +787,9 @@ describe('QueryEditorContextWrapper - stacked mode', () => {
     expect(result.current.selectedQuery).toBeNull();
   });
 
-  it('exits stacked mode when an alert is selected', () => {
+  // The alerts view takes over the content pane, so it suppresses the stack rather than turning
+  // it off — leaving the alerts view puts the user back where they were.
+  it('suppresses stacked mode while an alert is selected and restores it on return', () => {
     mockUseAlertRulesForPanel.mockReturnValue({
       alertRules: [mockAlert],
       loading: false,
@@ -800,41 +801,78 @@ describe('QueryEditorContextWrapper - stacked mode', () => {
     expect(result.current.stackedMode.enabled).toBe(true);
 
     act(() => result.current.setSelectedAlert(mockAlert));
-
     expect(result.current.stackedMode.enabled).toBe(false);
-  });
 
-  it('entering stacked mode collapses existing multi-selection to the primary item', () => {
-    const dataPane = makeMockDataPane();
-    const { result } = renderWithWrapper(dataPane);
-
-    // Entering multi-select seeds the active card (A); Cmd+click B to build a two-item selection.
-    act(() => result.current.setMultiSelectMode(true));
-    act(() => result.current.toggleQuerySelection({ refId: 'B' } as DataQuery, { multi: true }));
-
-    expect(result.current.selectedQueryRefIds).toEqual(['A', 'B']);
-    expect(result.current.multiSelectMode).toBe(true);
-
-    act(() => result.current.stackedMode.enter());
-
-    // Entering stacked mode exits multi-select and collapses the bulk set to the primary
-    // (most-recently-selected) card, which becomes the single active selection.
-    expect(result.current.multiSelectMode).toBe(false);
-    expect(result.current.selectedQuery?.refId).toBe('B');
-    expect(result.current.selectedQueryRefIds).toEqual([]);
-  });
-
-  it('entering multi-select mode exits stacked mode', () => {
-    const dataPane = makeMockDataPane();
-    const { result } = renderWithWrapper(dataPane);
-
-    act(() => result.current.stackedMode.enter());
+    act(() => result.current.setSelectedAlert(null));
     expect(result.current.stackedMode.enabled).toBe(true);
+  });
 
-    act(() => result.current.setMultiSelectMode(true));
+  it('stays off after returning from the alerts view when the user never turned it on', () => {
+    mockUseAlertRulesForPanel.mockReturnValue({
+      alertRules: [mockAlert],
+      loading: false,
+      isDashboardSaved: true,
+    });
+    const { result } = renderWithWrapper(makeMockDataPane());
 
-    expect(result.current.multiSelectMode).toBe(true);
+    act(() => result.current.setSelectedAlert(mockAlert));
+    act(() => result.current.setSelectedAlert(null));
+
     expect(result.current.stackedMode.enabled).toBe(false);
+  });
+
+  // Multi-select lives in the sidebar and stacked view owns the content pane, so the two coexist.
+  describe('with multi-select mode', () => {
+    it('entering stacked mode keeps an existing multi-selection', () => {
+      const { result } = renderWithWrapper(makeMockDataPane());
+
+      // Entering multi-select seeds the active card (A); Cmd+click B to build a two-item selection.
+      act(() => result.current.setMultiSelectMode(true));
+      act(() => result.current.toggleQuerySelection({ refId: 'B' } as DataQuery, { multi: true }));
+      expect(result.current.selectedQueryRefIds).toEqual(['A', 'B']);
+
+      act(() => result.current.stackedMode.enter());
+
+      expect(result.current.stackedMode.enabled).toBe(true);
+      expect(result.current.multiSelectMode).toBe(true);
+      expect(result.current.selectedQueryRefIds).toEqual(['A', 'B']);
+    });
+
+    it('entering multi-select mode keeps stacked mode on', () => {
+      const { result } = renderWithWrapper(makeMockDataPane());
+
+      act(() => result.current.stackedMode.enter());
+      act(() => result.current.setMultiSelectMode(true));
+
+      expect(result.current.multiSelectMode).toBe(true);
+      expect(result.current.stackedMode.enabled).toBe(true);
+      // Seeded from the active card, as in the single-card view.
+      expect(result.current.selectedQueryRefIds).toEqual(['A']);
+    });
+
+    it('keeps the bulk selection when scrolling the stack activates another card', () => {
+      const { result } = renderWithWrapper(makeMockDataPane());
+
+      act(() => result.current.setMultiSelectMode(true));
+      act(() => result.current.toggleQuerySelection({ refId: 'B' } as DataQuery, { multi: true }));
+      act(() => result.current.stackedMode.enter());
+
+      act(() => result.current.stackedMode.syncActiveItem({ type: QueryEditorType.Query, id: 'B' }));
+
+      expect(result.current.selectedQuery?.refId).toBe('B');
+      expect(result.current.selectedQueryRefIds).toEqual(['A', 'B']);
+    });
+
+    it('supports Cmd+click bulk selection while stacked mode is on', () => {
+      const { result } = renderWithWrapper(makeMockDataPane());
+
+      act(() => result.current.stackedMode.enter());
+      act(() => result.current.setMultiSelectMode(true));
+      act(() => result.current.toggleQuerySelection({ refId: 'B' } as DataQuery, { multi: true }));
+
+      expect(result.current.stackedMode.enabled).toBe(true);
+      expect(result.current.selectedQueryRefIds).toEqual(['A', 'B']);
+    });
   });
 
   // Opening a picker temporarily swaps to the single pane (expression/transformation) or a

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.test.ts
@@ -5,6 +5,7 @@ import { AlertState } from '@grafana/data';
 import { type VizPanel } from '@grafana/scenes';
 import { type DataQuery } from '@grafana/schema';
 import { mockCombinedRule } from 'app/features/alerting/unified/mocks';
+import { ExpressionQueryType } from 'app/features/expressions/types';
 
 import { type PanelDataPaneNext } from '../PanelDataPaneNext';
 import { QueryEditorType } from '../constants';
@@ -629,11 +630,44 @@ describe('QueryEditorContextWrapper - delete actions', () => {
   });
 });
 
+describe('QueryEditorContextWrapper - query rename', () => {
+  beforeEach(() => {
+    mockUseAlertRulesForPanel.mockReturnValue({
+      alertRules: [],
+      loading: false,
+      isDashboardSaved: true,
+    });
+  });
+
+  it('remaps the active card and the bulk selection when a query is renamed', () => {
+    mockQueryRunnerQueries([{ refId: 'A' }, { refId: 'B' }] as DataQuery[]);
+    const dataPane = makeMockDataPane();
+    const { result } = renderWithBothContexts(dataPane);
+
+    // Make B the active card, then enter multi-select (seeds B) and Cmd+click A alongside it.
+    // B is deliberately not queries[0], so the assertions below can't pass on the auto-select
+    // fallback that kicks in when an id goes stale.
+    act(() => result.current.ui.setSelectedQuery({ refId: 'B' } as DataQuery));
+    act(() => result.current.ui.setMultiSelectMode(true));
+    act(() => result.current.ui.toggleQuerySelection({ refId: 'A' } as DataQuery, { multi: true }));
+    expect(result.current.ui.selectedQueryRefIds).toEqual(['B', 'A']);
+
+    // Renaming the active card from its header re-emits the query list under the new refId, so
+    // the wrapper has to follow the id rather than dropping the card out of the selection.
+    mockQueryRunnerQueries([{ refId: 'A' }, { refId: 'renamed' }] as DataQuery[]);
+    act(() => result.current.actions.updateSelectedQuery({ refId: 'renamed' } as DataQuery, 'B'));
+
+    expect(dataPane.updateSelectedQuery).toHaveBeenCalledWith({ refId: 'renamed' }, 'B');
+    expect(result.current.ui.selectedQuery?.refId).toBe('renamed');
+    expect(result.current.ui.selectedQueryRefIds).toEqual(['renamed', 'A']);
+  });
+});
+
 // Regression: opening a pending picker (+Expression / +Transformation) while in multi-select
 // mode and then cancelling must NOT wipe the bulk selection or silently leave multi-select
 // mode on with empty checkboxes. These tests exercise the REAL pending hooks (the suites above
 // mock them) to cover the full wrapper -> hook -> selection-state flow.
-describe('QueryEditorContextWrapper - pending picker cancel preserves multi-select', () => {
+describe('QueryEditorContextWrapper - pending pickers and multi-select', () => {
   beforeEach(() => {
     mockUseAlertRulesForPanel.mockReturnValue({
       alertRules: [],
@@ -706,6 +740,38 @@ describe('QueryEditorContextWrapper - pending picker cancel preserves multi-sele
     expect(result.current.pendingTransformation).toBeNull();
     expect(result.current.selectedTransformationIds).toEqual(['reduce-0', 'organize-1']);
     expect(result.current.multiSelectMode).toBe(true);
+  });
+
+  it('reseeds the bulk selection to the new card when a pending expression resolves', () => {
+    mockQueryRunnerQueries([{ refId: 'A' }, { refId: 'B' }] as DataQuery[]);
+    const dataPane = makeMockDataPane();
+    jest.mocked(dataPane.addQuery).mockReturnValue('C');
+    const { result } = renderWithWrapper(dataPane);
+
+    act(() => result.current.setMultiSelectMode(true));
+    act(() => result.current.toggleQuerySelection({ refId: 'B' } as DataQuery, { multi: true }));
+    expect(result.current.selectedQueryRefIds).toEqual(['A', 'B']);
+
+    act(() => result.current.setPendingExpression({ insertAfter: 'B' }));
+    act(() => result.current.finalizePendingExpression(ExpressionQueryType.math));
+
+    // The card the user just created becomes the whole selection, so the checkboxes describe it
+    // rather than the stale set from before the picker.
+    expect(result.current.selectedQueryRefIds).toEqual(['C']);
+    expect(result.current.multiSelectMode).toBe(true);
+  });
+
+  it('leaves the bulk selection empty when a pending expression resolves outside multi-select mode', () => {
+    mockQueryRunnerQueries([{ refId: 'A' }] as DataQuery[]);
+    const dataPane = makeMockDataPane();
+    jest.mocked(dataPane.addQuery).mockReturnValue('C');
+    const { result } = renderWithWrapper(dataPane);
+
+    act(() => result.current.setPendingExpression({ insertAfter: 'A' }));
+    act(() => result.current.finalizePendingExpression(ExpressionQueryType.math));
+
+    expect(result.current.selectedQueryRefIds).toEqual([]);
+    expect(result.current.multiSelectMode).toBe(false);
   });
 });
 
@@ -805,6 +871,16 @@ describe('QueryEditorContextWrapper - stacked mode', () => {
 
     act(() => result.current.setSelectedAlert(null));
     expect(result.current.stackedMode.enabled).toBe(true);
+  });
+
+  it('turns the stack off when the user exits it', () => {
+    const { result } = renderWithWrapper(makeMockDataPane());
+
+    act(() => result.current.stackedMode.enter());
+    expect(result.current.stackedMode.enabled).toBe(true);
+
+    act(() => result.current.stackedMode.exit());
+    expect(result.current.stackedMode.enabled).toBe(false);
   });
 
   it('stays off after returning from the alerts view when the user never turned it on', () => {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.tsx
@@ -21,7 +21,7 @@ import { useQueryEditorUIToggles } from './hooks/useQueryEditorUIToggles';
 import { useQueryOptions } from './hooks/useQueryOptions';
 import { useSelectedCard } from './hooks/useSelectedCard';
 import { useSelectedQueryDatasource } from './hooks/useSelectedQueryDatasource';
-import { useSelectionState } from './hooks/useSelectionState';
+import { type CardSelectionOptions, useSelectionState } from './hooks/useSelectionState';
 import { useTransformations } from './hooks/useTransformations';
 import { type AlertRule, type Transformation } from './types';
 import { getEditorType, getTransformId } from './utils';
@@ -99,7 +99,7 @@ export function QueryEditorContextWrapper({
   // Wrap each selection mutator to clear alert selection (cross-type exclusivity) and dismiss any
   // open inline delete confirmation because both are selection-scoped UI state.
   const onCardSelectionChange = useCallback(
-    (queryRefId: string | null, transformationId: string | null, options?: { seedBulk?: boolean }) => {
+    (queryRefId: string | null, transformationId: string | null, options?: CardSelectionOptions) => {
       setSelectedAlertId(null);
       setConfirmingDeleteActionKey(null);
       onCardSelectionChangeRaw(queryRefId, transformationId, options);
@@ -107,28 +107,12 @@ export function QueryEditorContextWrapper({
     [onCardSelectionChangeRaw]
   );
 
-  const stackedMode = useStackedModeOrchestration({
-    onCardSelectionChange,
-    selectedQueryRefIds,
-    selectedTransformationIds,
-    // Entering stacked mode clears cross-mode UI state (alert selection, multi-select).
-    onEnter: () => {
-      setSelectedAlertId(null);
-      setMultiSelectMode(false);
-    },
-  });
-  // Destructured for tight dep arrays in the selection handlers below — these property reads
-  // are referentially stable when their underlying state doesn't change.
-  const { enabled: isStackedMode, exit: exitStackedMode } = stackedMode;
-
+  // Bulk-selection entry points, driven by the sidebar card checkboxes (plain card clicks go
+  // through setSelectedQuery / setSelectedTransformation instead). Ticking a checkbox means the
+  // same thing whether or not the stacked view is showing, so there is no stacked-specific branch.
   const toggleQuerySelection = useCallback(
     (query: DataQuery | ExpressionQuery, modifiers?: SelectionModifiers) => {
       setSelectedAlertId(null);
-      if (isStackedMode) {
-        // Stacked mode is single-select; the renderer scrolls to whatever becomes selected.
-        onCardSelectionChange(query.refId, null);
-        return;
-      }
       setConfirmingDeleteActionKey(null);
       if (modifiers?.multi || modifiers?.range) {
         if (!multiSelectMode) {
@@ -139,16 +123,12 @@ export function QueryEditorContextWrapper({
       }
       activateQueryRaw(query);
     },
-    [isStackedMode, onCardSelectionChange, multiSelectMode, activateQueryRaw, toggleQuerySelectionRaw]
+    [multiSelectMode, activateQueryRaw, toggleQuerySelectionRaw]
   );
 
   const toggleTransformationSelection = useCallback(
     (transformation: Transformation, modifiers?: SelectionModifiers) => {
       setSelectedAlertId(null);
-      if (isStackedMode) {
-        onCardSelectionChange(null, transformation.transformId);
-        return;
-      }
       setConfirmingDeleteActionKey(null);
       if (modifiers?.multi || modifiers?.range) {
         if (!multiSelectMode) {
@@ -159,18 +139,17 @@ export function QueryEditorContextWrapper({
       }
       activateTransformationRaw(transformation);
     },
-    [isStackedMode, onCardSelectionChange, multiSelectMode, activateTransformationRaw, toggleTransformationSelectionRaw]
+    [multiSelectMode, activateTransformationRaw, toggleTransformationSelectionRaw]
   );
 
   const resetSelectionState = useCallback(
     (alertId: string | null) => {
-      exitStackedMode();
       setSelectedAlertId(alertId);
       setMultiSelectMode(false);
       setConfirmingDeleteActionKey(null);
       clearSelectionRaw();
     },
-    [clearSelectionRaw, exitStackedMode]
+    [clearSelectionRaw]
   );
 
   const clearSelection = useCallback(() => resetSelectionState(null), [resetSelectionState]);
@@ -185,22 +164,13 @@ export function QueryEditorContextWrapper({
         if (!hasCards) {
           return;
         }
-        // Multi-select and stacked mode are mutually exclusive, so leaving stacked mode here
-        // keeps the two views from being active at once before seeding the bulk selection.
-        exitStackedMode();
         selectActiveInMultiSelectionRaw();
       } else {
         clearMultiSelectionRaw();
       }
       setMultiSelectMode(enabled);
     },
-    [
-      queryRunnerState?.queries,
-      transformations,
-      exitStackedMode,
-      clearMultiSelectionRaw,
-      selectActiveInMultiSelectionRaw,
-    ]
+    [queryRunnerState?.queries, transformations, clearMultiSelectionRaw, selectActiveInMultiSelectionRaw]
   );
 
   // Wraps onCardSelectionChange with a UI reset for use in finalizePendingExpression /
@@ -209,7 +179,7 @@ export function QueryEditorContextWrapper({
   // remain visible after the picker resolves.
   const onFinalizeCardSelection = useCallback(
     (queryRefId: string | null, transformationId: string | null) => {
-      onCardSelectionChange(queryRefId, transformationId, { seedBulk: multiSelectMode });
+      onCardSelectionChange(queryRefId, transformationId, { bulk: multiSelectMode ? 'seed' : 'clear' });
       resetUIToggles();
     },
     [onCardSelectionChange, multiSelectMode, resetUIToggles]
@@ -353,6 +323,22 @@ export function QueryEditorContextWrapper({
   );
 
   const { selectedQueryDsData, selectedQueryDsLoading } = useSelectedQueryDatasource(selectedQuery, dsSettings, panel);
+
+  // Scrolling the stack activates the card coming into view, which is navigation — so keep the
+  // bulk selection so checkboxes ticked in the sidebar survive scrolling the stack.
+  const activateStackedItem = useCallback(
+    (queryRefId: string | null, transformationId: string | null) => {
+      onCardSelectionChange(queryRefId, transformationId, { bulk: 'keep' });
+    },
+    [onCardSelectionChange]
+  );
+
+  // Composed after useSelectedCard so `isAlertView` reads the resolved alert card, matching the
+  // condition QueryEditorContent uses to hand the content pane over to the alerts view.
+  const stackedMode = useStackedModeOrchestration({
+    activateItem: activateStackedItem,
+    isAlertView: selectedAlert !== null,
+  });
 
   const uiState = useMemo(
     () => ({

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/StackedEditor/useStackedModeOrchestration.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/StackedEditor/useStackedModeOrchestration.ts
@@ -1,85 +1,57 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { QueryEditorType } from '../../constants';
 import { type StackedEditorItem, type StackedEditorState } from '../QueryEditorContext';
 
 interface UseStackedModeOrchestrationArgs {
   /**
-   * Card selection writer. Used by `enter` to promote a primary item into the selection and
-   * by `syncActiveItem` to mirror observer-driven activations back into selection state.
+   * Moves the active card by id, leaving the bulk selection alone. Scrolling the stack activates
+   * whichever card comes into view, which is navigation rather than a selection change — so it
+   * must not disturb checkboxes the user ticked.
    */
-  onCardSelectionChange: (queryRefId: string | null, transformationId: string | null) => void;
-  selectedQueryRefIds: readonly string[];
-  selectedTransformationIds: readonly string[];
-  /**
-   * Cross-mode cleanup invoked on `enter` (e.g. clear alert selection, exit multi-select).
-   * Captured via ref so callers can pass an inline function without re-creating `enter`.
-   */
-  onEnter?: () => void;
+  activateItem: (queryRefId: string | null, transformationId: string | null) => void;
+  /** True while the alerts view owns the content pane, which leaves no room for the stack. */
+  isAlertView: boolean;
 }
 
 /**
- * Owns the stacked-mode state machine: the on/off boolean, the imperative scroll bridge,
- * and the `enter` / `exit` / `syncActiveItem` callbacks.
+ * Owns the stacked-mode state machine: the user's on/off choice and the scroll-to-selection bridge.
+ *
+ * `enabled` is derived rather than stored so that views which take over the content pane can
+ * pre-empt the stack without discarding the user's choice — switching to alerts and back leaves
+ * them where they were.
  *
  * Lives outside `QueryEditorContextWrapper` so the wrapper doesn't carry the stacked-only
  * plumbing inline. The wrapper composes this hook and exposes the returned `stackedMode`
- * on its context. Callers that need to force-exit reach for `stackedMode.exit`.
+ * on its context.
  */
 export function useStackedModeOrchestration({
-  onCardSelectionChange,
-  selectedQueryRefIds,
-  selectedTransformationIds,
-  onEnter,
+  activateItem,
+  isAlertView,
 }: UseStackedModeOrchestrationArgs): StackedEditorState {
-  const [isStackedMode, setIsStackedMode] = useState(false);
+  const [prefersStackedMode, setPrefersStackedMode] = useState(false);
 
-  // `enter` is invoked imperatively from a button click, so reading the latest selection
-  // and onEnter via refs is safe and keeps `enter` referentially stable across selections.
-  const selectedQueryRefIdsRef = useRef(selectedQueryRefIds);
-  selectedQueryRefIdsRef.current = selectedQueryRefIds;
-  const selectedTransformationIdsRef = useRef(selectedTransformationIds);
-  selectedTransformationIdsRef.current = selectedTransformationIds;
-  const onEnterRef = useRef(onEnter);
-  onEnterRef.current = onEnter;
-
-  const enter = useCallback(() => {
-    onEnterRef.current?.();
-    // Prefer the most-recently-selected transformation as the primary card. Transformations are
-    // downstream of queries in the pipeline, so if both are selected the user is most likely
-    // working on the transformation step.
-    const primaryTransformationId = selectedTransformationIdsRef.current.at(-1);
-    const primaryQueryRefId = selectedQueryRefIdsRef.current.at(-1);
-    if (primaryTransformationId) {
-      onCardSelectionChange(null, primaryTransformationId);
-    } else if (primaryQueryRefId) {
-      onCardSelectionChange(primaryQueryRefId, null);
-    }
-    setIsStackedMode(true);
-  }, [onCardSelectionChange]);
-
-  const exit = useCallback(() => {
-    setIsStackedMode(false);
-  }, []);
+  const enter = useCallback(() => setPrefersStackedMode(true), []);
+  const exit = useCallback(() => setPrefersStackedMode(false), []);
 
   const syncActiveItem = useCallback(
     (item: StackedEditorItem) => {
       if (item.type === QueryEditorType.Transformation) {
-        onCardSelectionChange(null, item.id);
+        activateItem(null, item.id);
       } else {
-        onCardSelectionChange(item.id, null);
+        activateItem(item.id, null);
       }
     },
-    [onCardSelectionChange]
+    [activateItem]
   );
 
   return useMemo<StackedEditorState>(
     () => ({
-      enabled: isStackedMode,
+      enabled: prefersStackedMode && !isAlertView,
       enter,
       exit,
       syncActiveItem,
     }),
-    [isStackedMode, enter, exit, syncActiveItem]
+    [prefersStackedMode, isAlertView, enter, exit, syncActiveItem]
   );
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectionState.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectionState.test.ts
@@ -420,10 +420,10 @@ describe('useSelectionState', () => {
     });
   });
 
-  describe('onCardSelectionChange — seedBulk', () => {
+  describe("onCardSelectionChange — bulk: 'seed'", () => {
     it('seeds the bulk selection with the activated query', () => {
       const { result } = setup();
-      act(() => result.current.onCardSelectionChange('B', null, { seedBulk: true }));
+      act(() => result.current.onCardSelectionChange('B', null, { bulk: 'seed' }));
       expect(result.current.activeQueryRefId).toBe('B');
       expect(result.current.selectedQueryRefIds).toEqual(['B']);
       expect(result.current.selectedTransformationIds).toEqual([]);
@@ -431,7 +431,7 @@ describe('useSelectionState', () => {
 
     it('seeds the bulk selection with the activated transformation', () => {
       const { result } = setup();
-      act(() => result.current.onCardSelectionChange(null, 'tx-1', { seedBulk: true }));
+      act(() => result.current.onCardSelectionChange(null, 'tx-1', { bulk: 'seed' }));
       expect(result.current.activeTransformationId).toBe('tx-1');
       expect(result.current.selectedTransformationIds).toEqual(['tx-1']);
       expect(result.current.selectedQueryRefIds).toEqual([]);
@@ -439,7 +439,7 @@ describe('useSelectionState', () => {
 
     it('seeds the query anchor so a follow-up Shift+Click ranges from it', () => {
       const { result } = setup();
-      act(() => result.current.onCardSelectionChange('B', null, { seedBulk: true }));
+      act(() => result.current.onCardSelectionChange('B', null, { bulk: 'seed' }));
       act(() => result.current.toggleQuerySelection({ refId: 'D' }, { range: true }));
       expect(result.current.selectedQueryRefIds).toEqual(['B', 'C', 'D']);
     });
@@ -447,9 +447,45 @@ describe('useSelectionState', () => {
     it('seeds nothing when activating with null ids', () => {
       const { result } = setup();
       act(() => result.current.toggleQuerySelection({ refId: 'A' }));
-      act(() => result.current.onCardSelectionChange(null, null, { seedBulk: true }));
+      act(() => result.current.onCardSelectionChange(null, null, { bulk: 'seed' }));
       expect(result.current.selectedQueryRefIds).toEqual([]);
       expect(result.current.selectedTransformationIds).toEqual([]);
+    });
+  });
+
+  // Used by the stacked view, where scrolling moves the active card as a side effect of
+  // navigation and must not disturb what the user has checked.
+  describe("onCardSelectionChange — bulk: 'keep'", () => {
+    it('moves the active query without touching the bulk selection', () => {
+      const { result } = setup();
+      act(() => result.current.toggleQuerySelection({ refId: 'A' }, { multi: true }));
+      act(() => result.current.toggleQuerySelection({ refId: 'B' }, { multi: true }));
+
+      act(() => result.current.onCardSelectionChange('C', null, { bulk: 'keep' }));
+
+      expect(result.current.activeQueryRefId).toBe('C');
+      expect(result.current.selectedQueryRefIds).toEqual(['A', 'B']);
+    });
+
+    it('moves the active transformation without touching the bulk selection', () => {
+      const { result } = setup();
+      act(() => result.current.toggleTransformationSelection(mockTransformations[0], { multi: true }));
+
+      act(() => result.current.onCardSelectionChange(null, 'tx-2', { bulk: 'keep' }));
+
+      expect(result.current.activeTransformationId).toBe('tx-2');
+      expect(result.current.selectedTransformationIds).toEqual(['tx-0']);
+    });
+
+    it('leaves the range anchor intact so a follow-up Shift+Click still ranges from it', () => {
+      const { result } = setup();
+      act(() => result.current.toggleQuerySelection({ refId: 'B' }, { multi: true }));
+
+      // Scrolling past another card must not re-anchor the range.
+      act(() => result.current.onCardSelectionChange('D', null, { bulk: 'keep' }));
+      act(() => result.current.toggleQuerySelection({ refId: 'D' }, { range: true }));
+
+      expect(result.current.selectedQueryRefIds).toEqual(['B', 'C', 'D']);
     });
   });
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectionState.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectionState.ts
@@ -20,7 +20,7 @@ export interface UseSelectionStateOptions {
  * - `keep`: leave it — and the range anchors — untouched, for the stacked view where scrolling
  *   moves the active card as a side effect of navigation rather than a selection change.
  */
-export type BulkSelectionEffect = 'clear' | 'seed' | 'keep';
+type BulkSelectionEffect = 'clear' | 'seed' | 'keep';
 
 export interface CardSelectionOptions {
   bulk?: BulkSelectionEffect;

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectionState.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectionState.ts
@@ -12,6 +12,20 @@ export interface UseSelectionStateOptions {
   onClearSideEffects?: () => void;
 }
 
+/**
+ * What happens to the bulk (checkbox) selection when the active card moves.
+ *
+ * - `clear` (default): drop it, for a deliberate single-card pick.
+ * - `seed`: replace it with just the newly active card.
+ * - `keep`: leave it — and the range anchors — untouched, for the stacked view where scrolling
+ *   moves the active card as a side effect of navigation rather than a selection change.
+ */
+export type BulkSelectionEffect = 'clear' | 'seed' | 'keep';
+
+export interface CardSelectionOptions {
+  bulk?: BulkSelectionEffect;
+}
+
 export interface UseSelectionStateResult {
   activeQueryRefId: string | null;
   activeTransformationId: string | null;
@@ -20,7 +34,7 @@ export interface UseSelectionStateResult {
   onCardSelectionChange: (
     queryRefId: string | null,
     transformationId: string | null,
-    options?: { seedBulk?: boolean }
+    options?: CardSelectionOptions
   ) => void;
   trackQueryRename: (originalRefId: string, updatedRefId: string) => void;
   activateQuery: (query: DataQuery | ExpressionQuery) => void;
@@ -147,11 +161,17 @@ export function useSelectionState({
   }, [transformations, activeTransformationId, queries]);
 
   const onCardSelectionChange = useCallback(
-    (queryRefId: string | null, transformationId: string | null, options?: { seedBulk?: boolean }) => {
+    (queryRefId: string | null, transformationId: string | null, options?: CardSelectionOptions) => {
       setActiveQueryRefId(queryRefId);
       setActiveTransformationId(transformationId);
+
+      const bulk = options?.bulk ?? 'clear';
+      if (bulk === 'keep') {
+        return;
+      }
+
       resetSelectionAnchors();
-      if (options?.seedBulk) {
+      if (bulk === 'seed') {
         setSelectedQueryRefIds(queryRefId ? [queryRefId] : []);
         setSelectedTransformationIds(transformationId ? [transformationId] : []);
         queryAnchorRef.current = queryRefId;


### PR DESCRIPTION
## Description

The stacked view in the new query editor was implemented as a mode that was mutually exclusive with multi-select and with the alerts view, so it was force-exited (and the user's choice thrown away) whenever either was used. This makes it a layout choice instead: it stays on while the user multi-selects, and the alerts view only suppresses it while it owns the content pane.

## Changes

* `useStackedModeOrchestration` now stores the user's on/off choice and derives `enabled` as `prefersStackedMode && !isAlertView`, so returning from the alerts view restores the stack without any explicit restore step.
* Dropped the cross-mode teardown from the hook — no more `onEnter` clearing the alert selection and multi-select, and no more reading the current selection to promote a primary card.
* `onCardSelectionChange` takes a `bulk: 'clear' | 'seed' | 'keep'` effect (replacing the boolean `seedBulk`). Scrolling the stack now activates cards with `keep`, so navigation no longer clears checkboxes or range anchors.
* Removed the stacked-only single-select branches from `toggleQuerySelection` / `toggleTransformationSelection`, and the `exitStackedMode()` calls from `resetSelectionState` / `setMultiSelectModeState`.

## Risks

Contained to the new query editor behind the `queryEditorNext` flag; the v1 editor is untouched. The blast radius is card selection, so the things to watch are bulk selection (cmd/shift+click, range anchors after a scroll) and the alerts view round-trip. The `bulk` option is a rename of an existing internal flag with one call site, so no behaviour change for the finalize-expression path.

## Demo

<!--- TODO: gif of toggling stacked view with a multi-selection active, then a round-trip through the alerts view -->

## Testing Instructions

* Enable the `queryEditorNext` flag, open a panel with several queries and at least one transformation, and switch to the new query editor.
* Turn on the stacked view, then cmd+click a couple of sidebar cards — the stack stays open and the checkboxes stick.
* Scroll the stack up and down — the active card follows the scroll, the checkboxes are untouched, and a following shift+click still ranges from the original anchor.
* With the stacked view on, open an alert from the sidebar — the stack gives way to the alerts view — then select a query again and confirm the stack comes back.
* Turn multi-select on and off from the header while the stacked view is on and confirm it stays on.
* Run `yarn test public/app/features/dashboard-scene/panel-edit/PanelEditNext`.

## Reviewer Checklist

- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable

Close DPRO-287