### PR TITLE
Apistore: Clean up newly created inline secrets when preparation fails

### DIFF
--- a/pkg/storage/unified/apistore/managed.go
+++ b/pkg/storage/unified/apistore/managed.go
@@ -241,37 +241,41 @@ func managedResourceCommitMessage(obj utils.GrafanaMetaAccessor, action resource
 	}
 }
 
+// handleManagedResourceRouting re-routes a write for a repo-managed resource to the provisioning
+// files endpoint. cleanupSafe reports whether the write definitely did not persist (so a caller may
+// safely delete secrets it created for it): true only when the provisioning request was never sent,
+// false once it is sent because the endpoint may have committed the file even when it returns an error.
 func (s *Storage) handleManagedResourceRouting(ctx context.Context,
 	err error,
 	action resourcepb.WatchEvent_Type,
 	key string,
 	orig runtime.Object,
 	rsp runtime.Object,
-) error {
+) (cleanupSafe bool, _ error) {
 	if !errors.Is(err, errResourceIsManagedInRepository) || s.configProvider == nil {
-		return err
+		return true, err // not routed: the write was never attempted
 	}
 	obj, err := utils.MetaAccessor(orig)
 	if err != nil {
-		return err
+		return true, err
 	}
 	repo, ok := obj.GetManagerProperties()
 	if !ok {
-		return fmt.Errorf("expected managed resource")
+		return true, fmt.Errorf("expected managed resource")
 	}
 	if repo.Kind != utils.ManagerKindRepo {
 		if !repo.AllowsEdits {
-			return fmt.Errorf("managed resource does not allow edits")
+			return true, fmt.Errorf("managed resource does not allow edits")
 		}
 	}
 	src, ok := obj.GetSourceProperties()
 	if !ok || src.Path == "" {
-		return fmt.Errorf("managed resource is missing source path annotation")
+		return true, fmt.Errorf("managed resource is missing source path annotation")
 	}
 
 	cfg, err := s.configProvider.GetRestConfig(ctx)
 	if err != nil {
-		return err
+		return true, err
 	}
 	cfg.NegotiatedSerializer = serializer.WithoutConversionCodecFactory{CodecFactory: scheme.Codecs}
 	cfg.GroupVersion = &schema.GroupVersion{
@@ -280,13 +284,13 @@ func (s *Storage) handleManagedResourceRouting(ctx context.Context,
 	}
 	client, err := rest.RESTClientFor(cfg)
 	if err != nil {
-		return err
+		return true, err
 	}
 
 	if action == resourcepb.WatchEvent_DELETED {
 		// TODO? can we copy orig into rsp without a full get?
 		if err = s.Get(ctx, key, storage.GetOptions{}, rsp); err != nil { // COPY?
-			return err
+			return true, err
 		}
 		result := client.Delete().
 			Namespace(obj.GetNamespace()).
@@ -295,7 +299,7 @@ func (s *Storage) handleManagedResourceRouting(ctx context.Context,
 			Suffix("files", src.Path).
 			Param("message", managedResourceCommitMessage(obj, action)).
 			Do(ctx)
-		return result.Error()
+		return false, result.Error()
 	}
 
 	var req *rest.Request
@@ -305,7 +309,7 @@ func (s *Storage) handleManagedResourceRouting(ctx context.Context,
 	case resourcepb.WatchEvent_MODIFIED:
 		req = client.Put()
 	default:
-		return fmt.Errorf("unsupported provisioning action: %v, %w", action, err)
+		return true, fmt.Errorf("unsupported provisioning action: %v, %w", action, err)
 	}
 
 	// Execute the change. The provisioning files endpoint reads the commit
@@ -321,11 +325,13 @@ func (s *Storage) handleManagedResourceRouting(ctx context.Context,
 		Param("skipDryRun", "true").
 		Param("message", managedResourceCommitMessage(obj, action)).
 		Do(ctx)
-	err = result.Error()
-	if err != nil {
-		return err
+	if err = result.Error(); err != nil {
+		// The files endpoint may commit the repository file before returning an error
+		// (e.g. a 409 after the write), so any post-send failure is ambiguous: keep the
+		// secret rather than orphan a committed reference.
+		return false, err
 	}
 
-	// return the updated value
-	return s.Get(ctx, key, storage.GetOptions{}, rsp)
+	// The write persisted; keep any secrets even if the read-back fails.
+	return false, s.Get(ctx, key, storage.GetOptions{}, rsp)
 }

--- a/pkg/storage/unified/apistore/managed_test.go
+++ b/pkg/storage/unified/apistore/managed_test.go
@@ -662,7 +662,7 @@ func TestHandleManagedResourceRouting_ForwardsCommitMessage(t *testing.T) {
 				},
 			}
 
-			err := s.handleManagedResourceRouting(
+			cleanupSafe, err := s.handleManagedResourceRouting(
 				context.Background(),
 				errResourceIsManagedInRepository,
 				tt.action,
@@ -670,8 +670,10 @@ func TestHandleManagedResourceRouting_ForwardsCommitMessage(t *testing.T) {
 				obj,
 				&dashboard.Dashboard{},
 			)
-			// The test server returns 500; surface that as a non-nil error.
+			// The test server returns an error; surface that as a non-nil error.
 			require.Error(t, err)
+			// Once the request is sent the write may have applied, so cleanup is never safe.
+			require.False(t, cleanupSafe, "a sent request must not report cleanupSafe")
 
 			require.Equal(t, tt.wantMethod, captured.method, "HTTP method")
 			require.Contains(t, captured.path, "/namespaces/default/repositories/my-repo/files/dashboards/dash.json",

--- a/pkg/storage/unified/apistore/secure_test.go
+++ b/pkg/storage/unified/apistore/secure_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/storage"
@@ -449,4 +450,95 @@ func asJSON(v any, pretty bool) string {
 	}
 	bytes, _ := json.Marshal(v)
 	return string(bytes)
+}
+
+func TestCleanupSecretsAfterFailedPreparation(t *testing.T) {
+	newV := func() objectForStorage { return objectForStorage{createdSecureValues: []string{"NameForA"}} }
+	rejectErr := apierrors.NewBadRequest("rejected")
+
+	t.Run("cleanupSafe error deletes the created secrets", func(t *testing.T) {
+		secureStore := secret.NewMockInlineSecureValueSupport(t)
+		secureStore.On("DeleteWhenOwnedByResource", mock.Anything, mock.Anything, "NameForA").Return(nil).Once()
+		s := &Storage{opts: StorageOptions{SecureValues: secureStore}}
+		require.Equal(t, rejectErr, s.cleanupSecretsAfterFailedPreparation(context.Background(), newV(), true, rejectErr))
+		secureStore.AssertExpectations(t)
+	})
+
+	t.Run("ambiguous error keeps the secrets", func(t *testing.T) {
+		secureStore := secret.NewMockInlineSecureValueSupport(t) // no Delete expected
+		s := &Storage{opts: StorageOptions{SecureValues: secureStore}}
+		require.Equal(t, rejectErr, s.cleanupSecretsAfterFailedPreparation(context.Background(), newV(), false, rejectErr))
+		secureStore.AssertExpectations(t)
+	})
+
+	t.Run("success keeps the secrets", func(t *testing.T) {
+		secureStore := secret.NewMockInlineSecureValueSupport(t) // no Delete expected
+		s := &Storage{opts: StorageOptions{SecureValues: secureStore}}
+		require.NoError(t, s.cleanupSecretsAfterFailedPreparation(context.Background(), newV(), true, nil))
+		secureStore.AssertExpectations(t)
+	})
+}
+
+func TestHandleManagedResourceRoutingNotRouted(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "example.grafana.app/v1", "kind": "Example",
+		"metadata": map[string]any{"namespace": "default", "name": "d1"},
+	}}
+
+	t.Run("non-managed error is not routed and is cleanup-safe", func(t *testing.T) {
+		reject := apierrors.NewBadRequest("nope")
+		cleanupSafe, err := (&Storage{}).handleManagedResourceRouting(
+			context.Background(), reject, resourcepb.WatchEvent_MODIFIED, "/default/examples/d1", obj, obj)
+		require.Equal(t, reject, err)
+		require.True(t, cleanupSafe)
+	})
+
+	t.Run("managed error without configProvider is not routed and is cleanup-safe", func(t *testing.T) {
+		cleanupSafe, err := (&Storage{}).handleManagedResourceRouting(
+			context.Background(), errResourceIsManagedInRepository, resourcepb.WatchEvent_MODIFIED, "/default/examples/d1", obj, obj)
+		require.ErrorIs(t, err, errResourceIsManagedInRepository)
+		require.True(t, cleanupSafe)
+	})
+}
+
+// TestCreateCleansUpSecretsWhenPermissionCreationFails covers the Create path where preparation
+// succeeds (creating an inline secret) but afterCreatePermissionCreator rejects an invalid
+// grafana.app/grant-permissions value before anything is written. The created secret must be deleted.
+func TestCreateCleansUpSecretsWhenPermissionCreationFails(t *testing.T) {
+	secureStore := secret.NewMockInlineSecureValueSupport(t)
+	secureStore.On("CreateInline", mock.Anything, mock.Anything, common.RawSecureValue("SecretAAA"), (*string)(nil)).
+		Return("NameForA", nil).Once()
+	secureStore.On("DeleteWhenOwnedByResource", mock.Anything, mock.Anything, "NameForA").
+		Return(nil).Once()
+
+	// store is left nil: the object must never be written, so any store access would panic.
+	s := &Storage{
+		getKey: func(string) (*resourcepb.ResourceKey, error) {
+			return &resourcepb.ResourceKey{Namespace: "default", Resource: "customkinds", Name: "test"}, nil
+		},
+		opts: StorageOptions{
+			Scheme:               runtime.NewScheme(),
+			SecureValues:         secureStore,
+			MaximumNameLength:    100,
+			DeprecatedInternalID: DeprecatedID_None,
+		},
+	}
+
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "something.grafana.app/v1beta1",
+		"kind":       "CustomKind",
+		"metadata": map[string]any{
+			"namespace":   "default",
+			"name":        "test",
+			"annotations": map[string]any{utils.AnnoKeyGrantPermissions: "bogus"},
+		},
+		"secure": common.InlineSecureValues{"a": common.InlineSecureValue{Create: "SecretAAA"}},
+	}}
+
+	ctx := claims.WithAuthInfo(context.Background(),
+		&identity.StaticRequester{UserID: 1, UserUID: "user-uid", Type: claims.TypeUser})
+
+	err := s.Create(ctx, "/default/customkinds/test", obj, &unstructured.Unstructured{}, 0)
+	require.ErrorContains(t, err, "invalid permissions value")
+	secureStore.AssertExpectations(t) // secret created during preparation, then deleted
 }

--- a/pkg/storage/unified/apistore/store.go
+++ b/pkg/storage/unified/apistore/store.go
@@ -261,6 +261,15 @@ func (s *Storage) convertToObject(ctx context.Context, data []byte, obj runtime.
 	return obj, err
 }
 
+// cleanupSecretsAfterFailedPreparation deletes inline secrets a failed preparation created, but only
+// when cleanupSafe reports the write definitely did not persist; otherwise they may be referenced.
+func (s *Storage) cleanupSecretsAfterFailedPreparation(ctx context.Context, v objectForStorage, cleanupSafe bool, err error) error {
+	if err != nil && cleanupSafe {
+		return v.finish(ctx, err, s.opts.SecureValues)
+	}
+	return err
+}
+
 // Create adds a new object at a key unless it already exists. 'ttl' is time-to-live
 // in seconds (0 means forever). If no error is returned and out is not nil, out will be
 // set to the read value from database.
@@ -289,7 +298,9 @@ func (s *Storage) Create(ctx context.Context, key string, obj runtime.Object, ou
 
 	v, err := s.prepareObjectForStorage(ctx, obj)
 	if err != nil {
-		return s.handleManagedResourceRouting(ctx, err, resourcepb.WatchEvent_ADDED, key, obj, out)
+		// Re-route managed resources; clean up any secrets preparation created if the write failed.
+		cleanupSafe, err := s.handleManagedResourceRouting(ctx, err, resourcepb.WatchEvent_ADDED, key, obj, out)
+		return s.cleanupSecretsAfterFailedPreparation(ctx, v, cleanupSafe, err)
 	}
 	req := &resourcepb.CreateRequest{
 		Value: v.raw.Bytes(),
@@ -298,7 +309,8 @@ func (s *Storage) Create(ctx context.Context, key string, obj runtime.Object, ou
 
 	v.permissionCreator, err = afterCreatePermissionCreator(ctx, req.Key, v.grantPermissions, obj, s.opts.Permissions)
 	if err != nil {
-		return err
+		// Nothing has been written yet, so clean up any inline secrets preparation created.
+		return v.finish(ctx, err, s.opts.SecureValues)
 	}
 
 	rsp, err := s.store.Create(ctx, req)
@@ -395,7 +407,8 @@ func (s *Storage) Delete(
 			return fmt.Errorf("unable to read object %w", err)
 		}
 		if err = checkManagerPropertiesOnDelete(info, meta); err != nil {
-			return s.handleManagedResourceRouting(ctx, err, resourcepb.WatchEvent_DELETED, key, out, out)
+			_, err = s.handleManagedResourceRouting(ctx, err, resourcepb.WatchEvent_DELETED, key, out, out)
+			return err
 		}
 
 		cmd.ResourceVersion, err = meta.GetResourceVersionInt64()
@@ -761,7 +774,9 @@ func (s *Storage) GuaranteedUpdate(
 
 		v, err := s.prepareObjectForUpdate(ctx, updatedObj, existingObj)
 		if err != nil {
-			return s.handleManagedResourceRouting(ctx, err, resourcepb.WatchEvent_MODIFIED, key, updatedObj, destination)
+			// Re-route managed resources; clean up any secrets preparation created if the write failed.
+			cleanupSafe, err := s.handleManagedResourceRouting(ctx, err, resourcepb.WatchEvent_MODIFIED, key, updatedObj, destination)
+			return s.cleanupSecretsAfterFailedPreparation(ctx, v, cleanupSafe, err)
 		}
 
 		req.Value = v.raw.Bytes()


### PR DESCRIPTION
## What

`prepareObjectForStorage` / `prepareObjectForUpdate` persist new inline secure values, but the `Create` / `GuaranteedUpdate` callers only ran `objectForStorage.finish` on the success path. An error returned **after** `prepareSecureValues` (a folder/manager check, `encode`, a partial `prepareSecureValues` failure, or an `afterCreatePermissionCreator` failure) left the just-created secrets orphaned.

Cleanup now runs in the caller, gated on whether the write **definitely did not persist**.

## The re-route nuance

A repo-managed resource is re-routed to provisioning by `handleManagedResourceRouting`. The provisioning files endpoint can commit the repository file (with the secret reference) and *then* return an error — e.g. a 409 after the write — so a 4xx is **not** proof nothing landed. Deleting the secret in that case would orphan a live reference. `handleManagedResourceRouting` therefore returns `cleanupSafe`:

| situation | cleanupSafe | secrets |
|---|---|---|
| not routed / pre-send failure (not managed, no configProvider, invalid annotations, REST config error) | true | cleaned up |
| provisioning request **sent** (any outcome: error or success) | false | kept |

Cleanup is safe only before the request is sent. A genuine pre-commit reject keeps the secret too — avoiding data loss on a committed reference is the safer default.

## `Create` permission path

`Create` returns `afterCreatePermissionCreator`'s error before any storage write; it now routes through `v.finish` so those secrets are cleaned up. `GuaranteedUpdate` has no equivalent gap — every post-preparation exit already runs `v.finish`.

## Tests (`secure_test.go`, `managed_test.go`)

- `cleanupSecretsAfterFailedPreparation`: cleanup on `cleanupSafe` error, keep on ambiguous error / success
- `handleManagedResourceRouting`: not-routed → cleanupSafe=true; sent-request (test server errors) → cleanupSafe=false

Backend-only.
