### PR TITLE
Search: let callers filter on managedBy, not just facet it

### DIFF
--- a/pkg/storage/unified/resource/search_field_test.go
+++ b/pkg/storage/unified/resource/search_field_test.go
@@ -233,7 +233,7 @@ func TestMapProvider_IndexAffectingHash_GoldenHash(t *testing.T) {
 	}, nil)
 
 	// Standard tags declare facet capability so Bleve facets use their keyword-analyzed mapping.
-	const expected = "0f114ef8fa64163466eb9d3477163cfe964b5a626c37279d5e60a2586c18a064"
+	const expected = "9b3e4e7d3fc3a15bd674dcfc2cd0ee7c243826a83df2b7bf7246a372875fcb29"
 	assert.Equal(t, expected, p.IndexAffectingHash(group, resource),
 		"canonical hash drifted. If json.Marshal output changed (Go release), update the literal; otherwise a code change shifted the canonical form.")
 }

--- a/pkg/storage/unified/resource/standard_search_fields.go
+++ b/pkg/storage/unified/resource/standard_search_fields.go
@@ -76,11 +76,13 @@ func StandardSearchFieldDefinitions() []SearchFieldDefinition {
 			Capabilities: []SearchCapability{SearchCapabilityFilter, SearchCapabilityRetrieve},
 			Description:  "Owner references in format {Group}/{Kind}/{Name}.",
 		},
+		// Objects with no manager hold an empty value here, so "unmanaged only" is a
+		// filter for the empty string and "anything managed" is one against it.
 		{
 			Name:         SEARCH_FIELD_MANAGED_BY,
 			Type:         SearchFieldTypeString,
-			Capabilities: []SearchCapability{SearchCapabilityFacet},
-			Description:  "Manager identity in format {kind}:{id}; used for faceting.",
+			Capabilities: []SearchCapability{SearchCapabilityFilter, SearchCapabilityFacet},
+			Description:  "Manager identity in format {kind}:{id}, empty when unmanaged.",
 		},
 		// created and updated are unix-millis timestamps, mapped as numeric bleve
 		// fields and stored so retrieve returns the value in search results. They

--- a/pkg/storage/unified/search/bleve_mappings_internal_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_internal_test.go
@@ -248,7 +248,7 @@ func TestKeywordFieldsForMapping(t *testing.T) {
 	assert.Equal(t, keywordField{name: "fields.login", filterable: true}, fields["fields.login"])
 	// A text field's keyword form is a separate, lowercased variant.
 	assert.Equal(t, keywordField{name: "fields.summary_keyword", lowered: true, filterable: true}, fields["fields.summary"])
-	// tags is both filterable and facetable; managedBy is facet-only.
+	// tags and managedBy are both filterable and facetable.
 	assert.Equal(t, keywordField{name: resource.SEARCH_FIELD_TAGS, filterable: true, facetable: true}, fields[resource.SEARCH_FIELD_TAGS])
 	// A facet-only field has a keyword form, but filtering it is not declared.
 	assert.Equal(t, keywordField{name: "fields.category", facetable: true}, fields["fields.category"])
@@ -256,7 +256,7 @@ func TestKeywordFieldsForMapping(t *testing.T) {
 	assert.Equal(t, keywordField{name: resource.SEARCH_FIELD_TITLE_PHRASE, lowered: true, filterable: true}, fields[resource.SEARCH_FIELD_TITLE])
 	assert.Equal(t, keywordField{name: resource.SEARCH_FIELD_CREATED_BY, filterable: true}, fields[resource.SEARCH_FIELD_CREATED_BY])
 	assert.Equal(t, keywordField{name: resource.SEARCH_FIELD_OWNER_REFERENCES, filterable: true}, fields[resource.SEARCH_FIELD_OWNER_REFERENCES])
-	assert.Equal(t, keywordField{name: resource.SEARCH_FIELD_MANAGED_BY, facetable: true}, fields[resource.SEARCH_FIELD_MANAGED_BY])
+	assert.Equal(t, keywordField{name: resource.SEARCH_FIELD_MANAGED_BY, filterable: true, facetable: true}, fields[resource.SEARCH_FIELD_MANAGED_BY])
 	assert.Equal(t, keywordField{name: resource.SEARCH_SELECTABLE_FIELDS_PREFIX + "spec.login", filterable: true}, fields[resource.SEARCH_SELECTABLE_FIELDS_PREFIX+"spec.login"])
 
 	// Facet requests may name a per-kind field with or without the prefix.

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -726,6 +726,70 @@ func TestTitleSetFilterExactMatch(t *testing.T) {
 	})
 }
 
+// TestManagedByFilter covers filtering on managedBy, which was facet-only until
+// it gained the filter capability: callers could count managed objects but not
+// narrow to them.
+func TestManagedByFilter(t *testing.T) {
+	key := resource.NamespacedResource{Namespace: "default", Group: "dashboard.grafana.app", Resource: "dashboards"}
+	index := newTestDashboardsIndex(t, threshold, 4, noop)
+	doc := func(name string, mgr *utils.ManagerProperties) *resource.BulkIndexItem {
+		d := &resource.IndexableDocument{
+			Key:   &resourcepb.ResourceKey{Namespace: key.Namespace, Group: key.Group, Resource: key.Resource, Name: name},
+			Name:  name,
+			Title: name,
+		}
+		d.Manager = mgr
+		return &resource.BulkIndexItem{Action: resource.ActionIndex, Doc: d.UpdateCopyFields()}
+	}
+	require.NoError(t, index.BulkIndex(&resource.BulkIndexRequest{Items: []*resource.BulkIndexItem{
+		doc("from-repo", &utils.ManagerProperties{Kind: utils.ManagerKindRepo, Identity: "repo-a"}),
+		doc("from-terraform", &utils.ManagerProperties{Kind: utils.ManagerKindTerraform, Identity: "tf-a"}),
+		doc("hand-made", nil),
+	}}))
+
+	filter := func(op string, values ...string) *resourcepb.ResourceSearchRequest {
+		return &resourcepb.ResourceSearchRequest{
+			Options: &resourcepb.ListOptions{
+				Key: &resourcepb.ResourceKey{Namespace: key.Namespace, Group: key.Group, Resource: key.Resource},
+				Fields: []*resourcepb.Requirement{{
+					Key: resource.SEARCH_FIELD_MANAGED_BY, Operator: op, Values: values,
+				}},
+			},
+			Limit: 100,
+		}
+	}
+
+	t.Run("narrow to one manager", func(t *testing.T) {
+		checkSearchQuery(t, index, filter("in", "repo:repo-a"), []string{"from-repo"})
+	})
+
+	t.Run("narrow to several managers", func(t *testing.T) {
+		checkSearchQuery(t, index, filter("in", "repo:repo-a", "terraform:tf-a"), []string{"from-repo", "from-terraform"})
+	})
+
+	t.Run("exclude one manager", func(t *testing.T) {
+		checkSearchQuery(t, index, filter("notin", "repo:repo-a"), []string{"from-terraform", "hand-made"})
+	})
+
+	// An object with no manager holds an empty value rather than no field at all,
+	// which is what makes these two expressible. If managedBy ever became a
+	// pointer, bleve would omit the field and both would silently return nothing.
+	t.Run("only unmanaged objects", func(t *testing.T) {
+		checkSearchQuery(t, index, filter("in", ""), []string{"hand-made"})
+	})
+
+	t.Run("only managed objects, whatever manages them", func(t *testing.T) {
+		checkSearchQuery(t, index, filter("notin", ""), []string{"from-repo", "from-terraform"})
+	})
+
+	// The kind alone is not a value of this field, so "everything managed by a
+	// repo, whichever repo" needs the ids enumerated. Declaring manager.kind is
+	// what would fix that; see the PR description.
+	t.Run("the kind alone matches nothing", func(t *testing.T) {
+		checkSearchQuery(t, index, filter("in", "repo"), nil)
+	})
+}
+
 // TestPublicFieldNameFilter checks the filter path resolves a public field name
 // to its physical fields.* location, so callers don't supply the prefix.
 func TestPublicFieldNameFilter(t *testing.T) {


### PR DESCRIPTION
`managedBy` declared the facet capability only, so a caller could group results by manager and see that forty dashboards are provisioned, but could not narrow to them or exclude them. Adding the filter capability is the whole change, since the exact-term filter path is already capability-driven.

Objects with no manager hold an empty value, so "unmanaged only" and "anything managed" are filters for and against the empty string. Both are tested, because making `ManagedBy` a pointer would make bleve drop the field and both would quietly return nothing.

`manager.kind` stays undeclared. It would answer "managed by a repo, whichever repo", but declaring it means teaching the mapping builder to descend into sub-documents, which is a change to the field model rather than a capability.

This moves the index-affecting hash, so every index with a provider rebuilds once after it ships.

Part of grafana/search-and-storage-team#869.
