### PR TITLE
Datasources: Migrate the
  `useDatasources()` hook to async DataSource APIs

### DIFF
--- a/public/app/features/alerting/unified/components/import-to-gma/ImportToGMARules.test.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ImportToGMARules.test.tsx
@@ -55,11 +55,14 @@ describe('ImportToGMARules', () => {
   grantUserPermissions([AccessControlAction.AlertingRuleExternalRead, AccessControlAction.AlertingRuleCreate]);
   testWithFeatureToggles({ enable: ['alertingImportYAMLUI', 'alertingMigrationUI'] });
 
-  it('should render the import source options', () => {
+  it('should render the import source options', async () => {
     render(<ImportToGMARules />);
 
     expect(ui.importSource.existingDatasource.get()).toBeInTheDocument();
     expect(ui.importSource.yaml.get()).toBeInTheDocument();
+
+    // Wait for the picker's async data source lookup so the state update doesn't escape act().
+    await waitFor(() => expect(ui.dsImport.dsPicker.get()).toBeEnabled());
   });
 
   describe('existing datasource', () => {

--- a/public/app/features/dashboard-scene/settings/variables/components/AdHocVariableForm.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/AdHocVariableForm.test.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { selectors } from '@grafana/e2e-selectors';
 import { mockBoundingClientRect } from '@grafana/test-utils';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
+import { useDatasources } from 'app/features/datasources/hooks';
 
 import { AdHocVariableForm, type AdHocVariableFormProps } from './AdHocVariableForm';
 
@@ -28,6 +29,15 @@ jest.mock('@grafana/runtime', () => ({
     getInstanceSettings: () => ({ ...defaultDatasource }),
   }),
 }));
+
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // Stub the async useDatasources() so no state update escapes act(). Wired below —
+  // jest.mock factories cannot reference file-scope variables.
+  useDatasources: jest.fn(),
+}));
+
+jest.mocked(useDatasources).mockImplementation(() => [defaultDatasource, promDatasource]);
 
 describe('AdHocVariableForm', () => {
   beforeAll(() => {

--- a/public/app/features/dashboard-scene/settings/variables/components/GroupByVariableForm.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/GroupByVariableForm.test.tsx
@@ -6,6 +6,7 @@ import { VariableSupportType } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { mockBoundingClientRect } from '@grafana/test-utils';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
+import { useDatasources } from 'app/features/datasources/hooks';
 import { LegacyVariableQueryEditor } from 'app/features/variables/editor/LegacyVariableQueryEditor';
 
 import { GroupByVariableForm, type GroupByVariableFormProps } from './GroupByVariableForm';
@@ -35,6 +36,15 @@ jest.mock('@grafana/runtime', () => ({
     getInstanceSettings: () => ({ ...defaultDatasource }),
   }),
 }));
+
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // Stub the async useDatasources() so no state update escapes act(). Wired below —
+  // jest.mock factories cannot reference file-scope variables.
+  useDatasources: jest.fn(),
+}));
+
+jest.mocked(useDatasources).mockImplementation(() => [defaultDatasource, promDatasource]);
 
 describe('GroupByVariableForm', () => {
   beforeAll(() => {

--- a/public/app/features/dashboard-scene/settings/variables/components/QueryVariableForm.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/QueryVariableForm.test.tsx
@@ -17,6 +17,7 @@ import { setRunRequest } from '@grafana/runtime';
 import { VariableRefresh, VariableSort } from '@grafana/schema';
 import { mockBoundingClientRect } from '@grafana/test-utils';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
+import { useDatasources } from 'app/features/datasources/hooks';
 import { LegacyVariableQueryEditor } from 'app/features/variables/editor/LegacyVariableQueryEditor';
 import { getVariableQueryEditor } from 'app/features/variables/editor/getVariableQueryEditor';
 
@@ -47,6 +48,15 @@ jest.mock('@grafana/runtime', () => ({
     getInstanceSettings: (uid: string) => (uid === promDatasource.uid ? promDatasource : defaultDatasource),
   }),
 }));
+
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // Stub the async useDatasources() so no state update escapes act(). Wired below —
+  // jest.mock factories cannot reference file-scope variables.
+  useDatasources: jest.fn(),
+}));
+
+jest.mocked(useDatasources).mockImplementation(() => [defaultDatasource, promDatasource]);
 
 const runRequestMock = jest.fn().mockReturnValue(
   of<PanelData>({

--- a/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.test.tsx
@@ -18,6 +18,7 @@ import { AdHocFiltersVariable } from '@grafana/scenes';
 import { mockBoundingClientRect } from '@grafana/test-utils';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
+import { useDatasources } from 'app/features/datasources/hooks';
 import { LegacyVariableQueryEditor } from 'app/features/variables/editor/LegacyVariableQueryEditor';
 
 import { type AdHocOriginFiltersController } from '../components/AdHocOriginFiltersController';
@@ -79,6 +80,15 @@ jest.mock('@grafana/runtime', () => ({
     getInstanceSettings: () => ({ ...defaultDatasource }),
   }),
 }));
+
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // Stub the async useDatasources() so no state update escapes act(). Wired below —
+  // jest.mock factories cannot reference file-scope variables.
+  useDatasources: jest.fn(),
+}));
+
+jest.mocked(useDatasources).mockImplementation(() => [defaultDatasource, promDatasource]);
 
 const runRequestMock = jest.fn().mockReturnValue(
   of<PanelData>({

--- a/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.test.tsx
@@ -7,6 +7,7 @@ import { GroupByVariable } from '@grafana/scenes';
 import { mockBoundingClientRect } from '@grafana/test-utils';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
+import { useDatasources } from 'app/features/datasources/hooks';
 import { LegacyVariableQueryEditor } from 'app/features/variables/editor/LegacyVariableQueryEditor';
 
 import { getGroupByVariableOptions, GroupByVariableEditor } from './GroupByVariableEditor';
@@ -44,6 +45,15 @@ jest.mock('@grafana/runtime', () => ({
     getInstanceSettings: () => ({ ...defaultDatasource }),
   }),
 }));
+
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // Stub the async useDatasources() so no state update escapes act(). Wired below —
+  // jest.mock factories cannot reference file-scope variables.
+  useDatasources: jest.fn(),
+}));
+
+jest.mocked(useDatasources).mockImplementation(() => [defaultDatasource, promDatasource]);
 
 describe('GroupByVariableEditor', () => {
   beforeAll(() => {

--- a/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/QueryVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/QueryVariableEditor.test.tsx
@@ -18,6 +18,7 @@ import { VariableRefresh, VariableSort } from '@grafana/schema';
 import { mockBoundingClientRect } from '@grafana/test-utils';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
+import { useDatasources } from 'app/features/datasources/hooks';
 import { LegacyVariableQueryEditor } from 'app/features/variables/editor/LegacyVariableQueryEditor';
 
 import { QueryVariableEditor, Editor } from './QueryVariableEditor';
@@ -54,6 +55,15 @@ jest.mock('@grafana/runtime', () => ({
     getInstanceSettings: () => ({ ...defaultDatasource }),
   }),
 }));
+
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // Stub the async useDatasources() so no state update escapes act(). Wired below —
+  // jest.mock factories cannot reference file-scope variables.
+  useDatasources: jest.fn(),
+}));
+
+jest.mocked(useDatasources).mockImplementation(() => [defaultDatasource, promDatasource]);
 
 const runRequestMock = jest.fn().mockReturnValue(
   of<PanelData>({

--- a/public/app/features/datasources/components/picker/DataSourceList.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceList.tsx
@@ -49,6 +49,7 @@ export interface DataSourceListProps {
   onClear?: () => void;
   onClickEmptyStateCTA?: () => void;
   enableKeyboardNavigation?: boolean;
+  /** @deprecated Pre-dates the in-memory data source cache — omit it and let the list fetch. */
   dataSources?: Array<DataSourceInstanceSettings<DataSourceJsonData>>;
   favoriteDataSources: FavoriteDatasources;
   /** Ref to the scroll container element, used by the virtualizer */

--- a/public/app/features/datasources/components/picker/DataSourceModal.test.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import {
@@ -9,6 +9,7 @@ import {
   PluginType,
   locationUtil,
 } from '@grafana/data';
+import { type DataSourceSrv, type TemplateSrv, setDataSourceSrv, setTemplateSrv } from '@grafana/runtime';
 import { mockBoundingClientRect } from '@grafana/test-utils';
 
 import { DataSourceModal, type DataSourceModalProps } from './DataSourceModal';
@@ -47,6 +48,19 @@ const mockDSList = [mockDS1, mockDS2, mockDSBuiltIn];
 
 beforeAll(() => {
   mockBoundingClientRect();
+
+  // The async data source APIs fall back to the runtime-internal singletons, which the
+  // jest.mock of '@grafana/runtime' below doesn't cover — wire the mocks into them too.
+  setDataSourceSrv({
+    getList: getListMock,
+    getInstanceSettings: getInstanceSettingsMock,
+  } as unknown as DataSourceSrv);
+  setTemplateSrv({
+    getVariables: () => [],
+    replace: (target?: string) => target ?? '',
+    containsTemplate: () => false,
+    updateTimeRange: () => {},
+  } as unknown as TemplateSrv);
 });
 
 const setup = (partialProps: Partial<DataSourceModalProps> = {}) => {
@@ -83,9 +97,17 @@ locationUtil.initialize({
 
 const getListMock = jest.fn();
 const getInstanceSettingsMock = jest.fn();
+
+function mockInstanceSettingsFromList(list: DataSourceInstanceSettings[]) {
+  getInstanceSettingsMock.mockImplementation((ref: string | { uid?: string } | null | undefined) => {
+    const uid = typeof ref === 'string' ? ref : ref?.uid;
+    return list.find((ds) => ds.uid === uid) ?? list[0];
+  });
+}
+
 beforeEach(() => {
   getListMock.mockReturnValue(mockDSList);
-  getInstanceSettingsMock.mockReturnValue(mockDS1);
+  mockInstanceSettingsFromList(mockDSList);
 });
 
 function createMockDSList(count: number) {
@@ -93,8 +115,11 @@ function createMockDSList(count: number) {
 }
 
 describe('DataSourceDropdown', () => {
-  it('should render', () => {
+  it('should render', async () => {
     expect(() => setup()).not.toThrow();
+
+    // Wait for the async data sources so the state update doesn't escape act().
+    expect(await screen.findByText(mockDS1.name, { selector: 'span' })).toBeInTheDocument();
   });
 
   describe('configuration', () => {
@@ -139,7 +164,7 @@ describe('DataSourceDropdown', () => {
       render(<DataSourceModal {...props}></DataSourceModal>);
 
       // Every call to the service must contain same filters
-      expect(getListMock).toHaveBeenCalled();
+      await waitFor(() => expect(getListMock).toHaveBeenCalled());
       getListMock.mock.calls.forEach((call) =>
         expect(call[0]).toMatchObject({
           ...filters,
@@ -181,11 +206,14 @@ describe('DataSourceDropdown with virtualized list', () => {
 
   beforeEach(() => {
     getListMock.mockReturnValue(largeMockDSList);
-    getInstanceSettingsMock.mockReturnValue(largeMockDSList[0]);
+    mockInstanceSettingsFromList(largeMockDSList);
   });
 
-  it('should render without errors', () => {
+  it('should render without errors', async () => {
     expect(() => setup({ current: largeMockDSList[0] })).not.toThrow();
+
+    // Wait for the async data sources so the state update doesn't escape act().
+    expect(await screen.findAllByTestId(/^data-testid data source card/)).not.toHaveLength(0);
   });
 
   it('should render only a subset of items in the DOM', async () => {

--- a/public/app/features/datasources/hooks.test.ts
+++ b/public/app/features/datasources/hooks.test.ts
@@ -1,15 +1,26 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+import { type DataSourceInstanceListItem, type DataSourceInstanceSettings } from '@grafana/data';
+import { getDataSourceInstanceList, getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 
 import { TestDataSettings } from '../query/state/mocks/mockDataSource';
 
-import { useRecentlyUsedDataSources } from './hooks';
+import { useDatasources, useRecentlyUsedDataSources } from './hooks';
 
-// Mock react-use's useLocalStorage
+// Mock react-use's useLocalStorage, keeping the real useAsync
 jest.mock('react-use', () => ({
+  ...jest.requireActual('react-use'),
   useLocalStorage: jest.fn(),
 }));
 
+jest.mock('@grafana/runtime/unstable', () => ({
+  getDataSourceInstanceList: jest.fn(),
+  getDataSourceInstanceSettings: jest.fn(),
+}));
+
 const mockUseLocalStorage = jest.requireMock('react-use').useLocalStorage;
+const mockGetDataSourceInstanceList = jest.mocked(getDataSourceInstanceList);
+const mockGetDataSourceInstanceSettings = jest.mocked(getDataSourceInstanceSettings);
 
 describe('useRecentlyUsedDataSources', () => {
   let mockSetStorage: jest.Mock;
@@ -110,5 +121,90 @@ describe('useRecentlyUsedDataSources', () => {
       // Should remove the first item and add new one at the end
       expect(mockSetStorage).toHaveBeenCalledWith(['uid2', 'uid3', 'uid4', 'uid5', 'test-uid']);
     });
+  });
+});
+
+describe('useDatasources', () => {
+  function createSettings(uid: string, name: string): DataSourceInstanceSettings {
+    return { ...TestDataSettings, uid, name };
+  }
+
+  function toListItem(settings: DataSourceInstanceSettings): DataSourceInstanceListItem {
+    const { uid, type, name, meta, readOnly } = settings;
+    return { uid, type, name, meta, readOnly, isDefault: settings.isDefault ?? false };
+  }
+
+  const settingsA = createSettings('uid-a', 'Datasource A');
+  const settingsB = createSettings('uid-b', 'Datasource B');
+  const settingsByUid: Record<string, DataSourceInstanceSettings> = {
+    [settingsA.uid]: settingsA,
+    [settingsB.uid]: settingsB,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetDataSourceInstanceList.mockResolvedValue([settingsA, settingsB].map(toListItem));
+    mockGetDataSourceInstanceSettings.mockImplementation(async (ref) =>
+      typeof ref === 'string' ? settingsByUid[ref] : undefined
+    );
+  });
+
+  it('should resolve the full settings for each listed data source, preserving order', async () => {
+    const { result } = renderHook(() => useDatasources({}));
+
+    await waitFor(() => expect(result.current).toEqual([settingsA, settingsB]));
+  });
+
+  it('should forward the filters to getDataSourceInstanceList', async () => {
+    const filters = { alerting: true, type: 'prometheus' };
+
+    renderHook(() => useDatasources(filters));
+
+    await waitFor(() => expect(mockGetDataSourceInstanceList).toHaveBeenCalledWith(filters));
+  });
+
+  it('should return the provided data sources without fetching when they are set', async () => {
+    const provided = [settingsB];
+
+    const { result } = renderHook(() => useDatasources({}, provided));
+
+    expect(result.current).toBe(provided);
+    // Flush microtasks so any fetch would have started by now.
+    await act(async () => {});
+    expect(mockGetDataSourceInstanceList).not.toHaveBeenCalled();
+  });
+
+  it('should re-fetch when the filters change value, but not for a value-equal object', async () => {
+    const { rerender } = renderHook(({ filters }) => useDatasources(filters), {
+      initialProps: { filters: { alerting: true } },
+    });
+
+    await waitFor(() => expect(mockGetDataSourceInstanceList).toHaveBeenCalledTimes(1));
+
+    rerender({ filters: { alerting: true } });
+    await act(async () => {});
+    expect(mockGetDataSourceInstanceList).toHaveBeenCalledTimes(1);
+
+    rerender({ filters: { alerting: false } });
+    await waitFor(() => expect(mockGetDataSourceInstanceList).toHaveBeenCalledTimes(2));
+  });
+
+  it('should return an empty array while the lookup is pending', () => {
+    // Never resolves so the hook stays in its loading state.
+    mockGetDataSourceInstanceList.mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => useDatasources({}));
+
+    expect(result.current).toEqual([]);
+  });
+
+  it('should omit data sources whose settings cannot be resolved', async () => {
+    mockGetDataSourceInstanceSettings.mockImplementation(async (ref) =>
+      ref === settingsA.uid ? settingsA : undefined
+    );
+
+    const { result } = renderHook(() => useDatasources({}));
+
+    await waitFor(() => expect(result.current).toEqual([settingsA]));
   });
 });

--- a/public/app/features/datasources/hooks.ts
+++ b/public/app/features/datasources/hooks.ts
@@ -1,10 +1,15 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type * as React from 'react';
-import { useLocalStorage } from 'react-use';
+import { useAsync, useLocalStorage } from 'react-use';
 import { type Observable } from 'rxjs';
 
 import { type DataSourceInstanceSettings, type DataSourceRef, type ScopedVars } from '@grafana/data';
-import { type GetDataSourceListFilters, getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceSrv } from '@grafana/runtime';
+import {
+  type GetDataSourceInstanceListFilters,
+  getDataSourceInstanceList,
+  getDataSourceInstanceSettings,
+} from '@grafana/runtime/unstable';
 
 const LOCAL_STORAGE_KEY = 'grafana.features.datasources.components.picker.DataSourceDropDown.history';
 
@@ -42,14 +47,40 @@ export function useRecentlyUsedDataSources(): [string[], (ds: DataSourceInstance
   return [value, pushRecentlyUsedDataSource];
 }
 
-export function useDatasources(filters: GetDataSourceListFilters, datasources?: DataSourceInstanceSettings[]) {
-  if (datasources) {
-    return datasources;
-  }
-  const dataSourceSrv = getDataSourceSrv();
-  const dataSources = dataSourceSrv.getList(filters);
+/**
+ * Returns the data sources matching `filters`, resolved from the in-memory cache.
+ *
+ * @param datasources — deprecated. Pre-dates the in-memory cache, when skipping a re-fetch
+ * mattered. Fetching is now a cached lookup, so let the hook fetch instead.
+ */
+export function useDatasources(
+  filters: GetDataSourceInstanceListFilters,
+  datasources?: DataSourceInstanceSettings[]
+): DataSourceInstanceSettings[] {
+  // Consumers pass `filters` as an inline object literal — a new reference on every render.
+  // Serialize it for the useAsync() deps so the fetch only re-runs when a filter value
+  // actually changes. The `filter` callback can't be serialized; it is compared by reference.
+  const { filter: filterFunc, ...serializableFilters } = filters;
+  const filtersKey = JSON.stringify(serializableFilters);
 
-  return dataSources;
+  const { value } = useAsync(
+    async () => {
+      if (datasources) {
+        // The caller already has the list — skip the needless fetch.
+        return datasources;
+      }
+      const items = await getDataSourceInstanceList(filters);
+      // getDataSourceInstanceList() returns slim list items, but the pickers built on this
+      // hook pass full DataSourceInstanceSettings to their public onChange/filter props, so
+      // fetch the full settings for each item. Both calls read the same in-memory cache.
+      const settings = await Promise.all(items.map((item) => getDataSourceInstanceSettings(item.uid)));
+      return settings.filter((s) => s !== undefined);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [filtersKey, filterFunc, datasources]
+  );
+
+  return datasources ?? value ?? [];
 }
 
 export function useDatasource(

--- a/public/app/features/explore/Explore.test.tsx
+++ b/public/app/features/explore/Explore.test.tsx
@@ -136,6 +136,12 @@ jest.mock('@grafana/runtime', () => ({
   usePluginLinks: jest.fn(() => ({ links: [] })),
 }));
 
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // Stub the async useDatasources() so no state update escapes act().
+  useDatasources: jest.fn(() => []),
+}));
+
 jest.mock('app/core/services/context_srv', () => ({
   contextSrv: {
     ...jest.requireActual('app/core/services/context_srv').contextSrv,

--- a/public/app/features/query/components/QueryEditorRowHeader.test.tsx
+++ b/public/app/features/query/components/QueryEditorRowHeader.test.tsx
@@ -6,6 +6,7 @@ import { selectors } from '@grafana/e2e-selectors';
 import { mockBoundingClientRect } from '@grafana/test-utils';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
 import { DataSourceType } from 'app/features/alerting/unified/utils/datasource';
+import { useDatasources } from 'app/features/datasources/hooks';
 
 import { type Props, QueryEditorRowHeader } from './QueryEditorRowHeader';
 
@@ -27,6 +28,15 @@ jest.mock('@grafana/runtime', () => ({
     getInstanceSettings: () => mockDS,
   }),
 }));
+
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // Stub the async useDatasources() so no state update escapes act(). Wired below —
+  // jest.mock factories cannot reference file-scope variables.
+  useDatasources: jest.fn(),
+}));
+
+jest.mocked(useDatasources).mockImplementation(({ variables }) => (variables ? [mockDS, mockVariable] : [mockDS]));
 
 describe('QueryEditorRowHeader', () => {
   beforeAll(() => {


### PR DESCRIPTION
Part of #127035
Related issue: #125083
**Enterprise companion:** https://github.com/grafana/grafana-enterprise/pull/12924

### What changed?
Migrated the `useDatasources()` hook from the deprecated `getDataSourceSrv().getList()` to the async  `getDataSourceInstanceList()` API. The hook still returns full `DataSourceInstanceSettings[]` — the pickers consuming it expose settings through their public props (`onChange`, `filter`) — so each slim list item is resolved via
  `getDataSourceInstanceSettings()`; both lookups are served from the same in-memory cache. Tests rendering `DataSourcePicker` now stub `useDatasources` or wait for the async lookup to settle, same as #128098.