### PR TITLE
Panel options: Document onChange merge semantics for option editors

### DIFF
--- a/packages/grafana-data/src/field/standardFieldConfigEditorRegistry.ts
+++ b/packages/grafana-data/src/field/standardFieldConfigEditorRegistry.ts
@@ -21,6 +21,16 @@ export interface StandardEditorContext<TOptions, TState = any> {
 
 export interface StandardEditorProps<TValue = any, TSettings = any, TOptions = any, TState = any> {
   value: TValue;
+  /**
+   * Commits a new value for the option this editor is registered against.
+   *
+   * How an object value is applied depends on where the editor is registered:
+   *
+   * - **Panel options** are merged into the current value, so leaving a key out does not remove it.
+   *   Set the key to `undefined` to clear it — `onChange({ ...value, age: undefined })` clears `age`,
+   *   whereas passing an object that simply omits `age` leaves the old value in place.
+   * - **Field config** values are replaced, so leaving a key out does remove it.
+   */
   onChange: (value?: TValue) => void;
   context: StandardEditorContext<TOptions, TState>;
   id?: string;

--- a/public/app/features/dashboard/components/PanelEditor/getVisualizationOptions.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/getVisualizationOptions.tsx
@@ -235,6 +235,9 @@ export function getVisualizationOptions2(props: OptionPaneRenderProps2): Options
     getValue: (path) => lodashGet(currentOptions, path),
     onChange: (path, value) => {
       const newOptions = setOptionImmutably(currentOptions, path, value);
+      // Merged rather than replaced, so an editor that drops a key from an object value keeps the old
+      // key — clearing requires setting it to undefined. Documented on StandardEditorProps.onChange.
+      // Switching to replace here would break editors that emit partial values for their own path.
       panel.onOptionsChange(newOptions);
       // Record interaction for analytics
       DashboardInteractions.setVisualOption({


### PR DESCRIPTION
## What is this?

Documentation only — no behaviour change.

A custom panel option editor that drops a key from an object value keeps the old key. Field config editors behave the opposite way. Nothing documented either, so plugin authors had no way to predict which they'd get.

Ref #105322

## Why the two differ

Both kinds of editor receive `StandardEditorProps`, but the code that commits their value doesn't treat them the same:

| Editor registered as | Commit call | Result |
|---|---|---|
| Panel option | `panel.onOptionsChange(newOptions)` — no flag | **merged** |
| Field config | `panel.onFieldConfigChange(config, true)` | **replaced** |

`VizPanel.onOptionsChange(update, replace = false)` in `@grafana/scenes` runs a lodash `mergeWith` when `replace` is falsy, and a deep merge cannot drop a key that is absent from the source. Its customizer has an explicit `typeof srcValue === 'undefined'` branch, so setting a key to `undefined` does clear it — that is the intended way to remove a value.

Note `setOptionImmutably` is not involved: it replaces correctly at the leaf and hands `onOptionsChange` a complete options object.

## Why not just make options replace too

Tempting, and it would make the two consistent — but it's a silent breaking change for third-party plugins. An editor that emits a *partial* object for its own path relies on merge today, and those keys would start disappearing. We can't audit editors we don't ship, so this PR documents the current behaviour rather than changing it.

The inconsistency is still worth resolving; it just isn't something to change quietly. Not attempted here.

## Changes

- TSDoc on `StandardEditorProps.onChange` covering both cases, so it appears in IntelliSense and the generated `@grafana/data` docs. This is the props type a custom editor actually receives.
- A comment at the `getVisualizationOptions2` call site, which currently reads as a missing `replace` argument — that's how the reporter of #105322 read it.

## Notes for reviewers

`public/app/features/dashboard/` is @grafana/dashboards-squad (CODEOWNERS:988).

`packages/grafana-data/src/field/standardFieldConfigEditorRegistry.ts` matches no CODEOWNERS line — only specific files in that package are assigned — so flagging @grafana/grafana-frontend-platform as a courtesy since it's a public API doc in their package.

Worth a second opinion on one thing: I've asserted field config replaces based on the `true` argument at the two `onFieldConfigChange` call sites in panel edit. If there's a path where field config is merged instead, the TSDoc needs qualifying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)