### PR TITLE
fix: add readyz/livez handlers to main HTTP server for K8s probe compatibility

### DIFF
--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -718,6 +718,8 @@ func (hs *HTTPServer) addMiddlewaresAndStaticRoutes() {
 	// These endpoints are used for monitoring the Grafana instance
 	// and should not be redirected or rejected.
 	m.Use(hs.healthzHandler)
+	m.Use(hs.livezHandler)
+	m.Use(hs.readyzHandler)
 	m.Use(hs.apiHealthHandler)
 	m.Use(hs.metricsEndpoint)
 	m.Use(hs.pluginMetricsEndpoint)
@@ -773,6 +775,36 @@ func (hs *HTTPServer) healthzHandler(ctx *web.Context) {
 
 	ctx.Resp.WriteHeader(http.StatusOK)
 	if _, err := ctx.Resp.Write([]byte("Ok")); err != nil {
+		hs.log.Error("could not write to response", "err", err)
+	}
+}
+
+// livezHandler returns 200 OK for /livez, matching the instrumentation server's LivezHandler.
+// This is needed because the instrumentation server is a no-op in the default module mode,
+// so /livez would otherwise fall through to the auth middleware and redirect to login.
+func (hs *HTTPServer) livezHandler(ctx *web.Context) {
+	notHeadOrGet := ctx.Req.Method != http.MethodGet && ctx.Req.Method != http.MethodHead
+	if notHeadOrGet || ctx.Req.URL.Path != "/livez" {
+		return
+	}
+
+	ctx.Resp.WriteHeader(http.StatusOK)
+	if _, err := ctx.Resp.Write([]byte("OK")); err != nil {
+		hs.log.Error("could not write to response", "err", err)
+	}
+}
+
+// readyzHandler returns 200 OK for /readyz, matching the instrumentation server's ReadyzHandler.
+// In the default module mode the instrumentation server is a no-op, so /readyz requests
+// would otherwise be intercepted by the auth middleware and redirected to login.
+func (hs *HTTPServer) readyzHandler(ctx *web.Context) {
+	notHeadOrGet := ctx.Req.Method != http.MethodGet && ctx.Req.Method != http.MethodHead
+	if notHeadOrGet || ctx.Req.URL.Path != "/readyz" {
+		return
+	}
+
+	ctx.Resp.WriteHeader(http.StatusOK)
+	if _, err := ctx.Resp.Write([]byte("OK")); err != nil {
 		hs.log.Error("could not write to response", "err", err)
 	}
 }


### PR DESCRIPTION
## What

Add `/readyz` and `/livez` endpoint handlers to the main Grafana HTTP server, matching the existing `/healthz` handler pattern.

## Why

Fixes #129822

The `/readyz` and `/livez` endpoints are registered on the instrumentation server (see `pkg/server/instrumentation_service.go`), but the instrumentation server is a no-op in the default module mode (`All`, `Core`, `FrontendServer`). Requests to `/readyz` and `/livez` fall through to the main HTTP server's auth middleware, which redirects to `/login?redirectTo=%2Freadyz`, generating unwanted probe warning events in managed Kubernetes platforms.

## How

Added `readyzHandler` and `livezHandler` methods to `HTTPServer` in `pkg/api/http_server.go`, following the same pattern as the existing `healthzHandler`. Both return 200 OK without requiring authentication.

## Testing

- [x] `/healthz` continues to work (unchanged)
- [x] `/livez` now returns 200 OK without auth redirect
- [x] `/readyz` now returns 200 OK without auth redirect
- [x] All other paths continue to require auth (unchanged)