### PR TITLE
Notebooks: Make`DashboardLayoutManager` generic so sibling layouts serialize their own kind

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -120,7 +120,7 @@ import { DefaultGridLayoutManager } from './layout-default/DefaultGridLayoutMana
 import { addNewRowTo } from './layouts-shared/addNew';
 import { clearClipboard } from './layouts-shared/paste';
 import { getUpdatedHoverHeader } from './panel-timerange/utils';
-import { type DashboardLayoutManager } from './types/DashboardLayoutManager';
+import { type AnyDashboardLayoutManager, type DashboardLayoutManager } from './types/DashboardLayoutManager';
 import { type DashboardSceneLike, type DashboardSceneState } from './types/dashboard';
 
 export const PERSISTED_PROPS = ['title', 'description', 'tags', 'editable', 'graphTooltip', 'links', 'meta', 'preload'];
@@ -1184,7 +1184,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
     }
   }
 
-  public getLayout(): DashboardLayoutManager {
+  public getLayout(): AnyDashboardLayoutManager {
     return this.state.body;
   }
 

--- a/public/app/features/dashboard-scene/scene/layout-notebook/NotebookLayoutManager.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-notebook/NotebookLayoutManager.test.tsx
@@ -2,6 +2,7 @@ import { screen } from '@testing-library/react';
 import { render } from 'test/test-utils';
 
 import { SceneTimeRange } from '@grafana/scenes';
+import { type NotebookLayoutKind } from '@grafana/schema/apis/notebook/v2beta1';
 
 import { DashboardScene } from '../DashboardScene';
 
@@ -49,5 +50,18 @@ describe('NotebookLayoutManager', () => {
     expect(await screen.findByText('Hello notebook')).toBeInTheDocument();
     // The collapsed cell renders only its element name, not its content.
     expect(screen.getByText('hidden-panel')).toBeInTheDocument();
+  });
+
+  it('serializes to the notebook layout kind, not a dashboard layout kind', () => {
+    const manager = new NotebookLayoutManager({
+      cells: [new NotebookCellItem({ elementName: 'md1', source: 'assistant' })],
+    });
+
+    // The annotation is the assertion here: serialize() is typed as returning the notebook's own
+    // kind, so this line stops compiling if the return type is ever widened back to the dashboard
+    // layout union and laundered through a cast.
+    const result: NotebookLayoutKind = manager.serialize();
+
+    expect(result.kind).toBe('NotebookLayout');
   });
 });

--- a/public/app/features/dashboard-scene/scene/layout-notebook/NotebookLayoutManager.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-notebook/NotebookLayoutManager.test.tsx
@@ -57,9 +57,9 @@ describe('NotebookLayoutManager', () => {
       cells: [new NotebookCellItem({ elementName: 'md1', source: 'assistant' })],
     });
 
-    // The annotation is the assertion here: serialize() is typed as returning the notebook's own
-    // kind, so this line stops compiling if the return type is ever widened back to the dashboard
-    // layout union and laundered through a cast.
+    // The annotation carries the real check: serialize() is typed as the notebook's own kind, so
+    // widening it back to the dashboard layout union fails `yarn typecheck`. It does not fail this
+    // test run, since jest strips the types.
     const result: NotebookLayoutKind = manager.serialize();
 
     expect(result.kind).toBe('NotebookLayout');

--- a/public/app/features/dashboard-scene/scene/layout-notebook/NotebookLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-notebook/NotebookLayoutManager.tsx
@@ -14,7 +14,7 @@ import { type NotebookLayoutItemKind, type NotebookLayoutKind } from '@grafana/s
 import { useStyles2 } from '@grafana/ui';
 
 import { type PanelIdGenerator } from '../../utils/dashboardSceneGraph';
-import { type AnyDashboardLayoutManager, type DashboardLayoutManager } from '../types/DashboardLayoutManager';
+import { type DashboardLayoutManager } from '../types/DashboardLayoutManager';
 import { type LayoutRegistryItem } from '../types/LayoutRegistryItem';
 
 import { type NotebookCellItem } from './NotebookCellItem';
@@ -80,11 +80,11 @@ export class NotebookLayoutManager
   // DashboardLayoutManager contract minimally.
   public addPanel(): void {}
 
-  public cloneLayout(): AnyDashboardLayoutManager {
+  public cloneLayout(): NotebookLayoutManager {
     return this.clone({});
   }
 
-  public duplicate(_panelIdGenerator?: PanelIdGenerator): AnyDashboardLayoutManager {
+  public duplicate(_panelIdGenerator?: PanelIdGenerator): NotebookLayoutManager {
     return this.clone({ key: undefined });
   }
 

--- a/public/app/features/dashboard-scene/scene/layout-notebook/NotebookLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-notebook/NotebookLayoutManager.tsx
@@ -10,12 +10,11 @@ import {
   type SceneObjectState,
   type VizPanel,
 } from '@grafana/scenes';
-import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { type NotebookLayoutItemKind, type NotebookLayoutKind } from '@grafana/schema/apis/notebook/v2beta1';
 import { useStyles2 } from '@grafana/ui';
 
 import { type PanelIdGenerator } from '../../utils/dashboardSceneGraph';
-import { type DashboardLayoutManager } from '../types/DashboardLayoutManager';
+import { type AnyDashboardLayoutManager, type DashboardLayoutManager } from '../types/DashboardLayoutManager';
 import { type LayoutRegistryItem } from '../types/LayoutRegistryItem';
 
 import { type NotebookCellItem } from './NotebookCellItem';
@@ -34,7 +33,7 @@ interface NotebookLayoutManagerState extends SceneObjectState {
 
 export class NotebookLayoutManager
   extends SceneObjectBase<NotebookLayoutManagerState>
-  implements DashboardLayoutManager
+  implements DashboardLayoutManager<{}, NotebookLayoutKind>
 {
   public static Component = NotebookLayoutManagerRenderer;
   public readonly isDashboardLayoutManager = true;
@@ -57,7 +56,7 @@ export class NotebookLayoutManager
   // Serialization lives here (not in a standalone helper) so the manager doesn't import the
   // serializer module — that mutual import is what forms a dependency cycle. The serializer
   // still imports this manager to construct it in deserialize, which stays one-directional.
-  public serialize(): DashboardV2Spec['layout'] {
+  public serialize(): NotebookLayoutKind {
     const cells: NotebookLayoutItemKind[] = this.state.cells.map((cell) => ({
       kind: 'NotebookLayoutItem',
       spec: {
@@ -68,13 +67,7 @@ export class NotebookLayoutManager
       },
     }));
 
-    const layout: NotebookLayoutKind = { kind: 'NotebookLayout', spec: { cells } };
-    // TODO: if the layout-manager-generic RFC lands (DashboardLayoutManager made generic over its
-    // serialize() return type), drop this cast and return NotebookLayoutKind directly; otherwise
-    // keep it as is. The shared interface only knows the dashboard layout union, so a sibling kind
-    // must be laundered through unknown here.
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- notebook layout is a sibling kind not in DashboardV2Spec['layout']
-    return layout as unknown as DashboardV2Spec['layout'];
+    return { kind: 'NotebookLayout', spec: { cells } };
   }
 
   // Only panel cells are viz panels; markdown/code cells are narrative content and are
@@ -87,11 +80,11 @@ export class NotebookLayoutManager
   // DashboardLayoutManager contract minimally.
   public addPanel(): void {}
 
-  public cloneLayout(): DashboardLayoutManager {
+  public cloneLayout(): AnyDashboardLayoutManager {
     return this.clone({});
   }
 
-  public duplicate(_panelIdGenerator?: PanelIdGenerator): DashboardLayoutManager {
+  public duplicate(_panelIdGenerator?: PanelIdGenerator): AnyDashboardLayoutManager {
     return this.clone({ key: undefined });
   }
 

--- a/public/app/features/dashboard-scene/scene/types/DashboardLayoutManager.ts
+++ b/public/app/features/dashboard-scene/scene/types/DashboardLayoutManager.ts
@@ -7,10 +7,21 @@ import { type PanelIdGenerator } from '../../utils/dashboardSceneGraph';
 import { type LayoutRegistryItem } from './LayoutRegistryItem';
 
 /**
+ * A layout manager of any layout kind, regardless of what its serialize() returns. Needed where
+ * managers of different kinds are held or returned together: a sibling layout (e.g. the notebook
+ * layout) parameterizes TLayout with a kind outside the dashboard layout union, so it is not
+ * assignable to the bare DashboardLayoutManager. Only TLayout is erased; `any` (not `unknown`) is
+ * required because these results flow back into bare `DashboardLayoutManager` fields and `any` is
+ * bidirectionally assignable, so those consumers keep compiling unchanged.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- erases only the serialize() kind so sibling layout managers fit
+export type AnyDashboardLayoutManager = DashboardLayoutManager<{}, any>;
+
+/**
  * A scene object that usually wraps an underlying layout
  * Dealing with all the state management and editing of the layout
  */
-export interface DashboardLayoutManager<S = {}> extends SceneObject {
+export interface DashboardLayoutManager<S = {}, TLayout = DashboardV2Spec['layout']> extends SceneObject {
   /** Marks it as a DashboardLayoutManager */
   isDashboardLayoutManager: true;
 
@@ -20,9 +31,10 @@ export interface DashboardLayoutManager<S = {}> extends SceneObject {
   descriptor: Readonly<LayoutRegistryItem>;
 
   /**
-   * Serializer for layout
+   * Serializer for layout. TLayout defaults to the dashboard layout union; sibling kinds
+   * (e.g. the notebook layout) override it to return their own kind without a cast.
    */
-  serialize(isSnapshot?: boolean): DashboardV2Spec['layout'];
+  serialize(isSnapshot?: boolean): TLayout;
 
   /**
    * Adds a new panel to the layout
@@ -72,14 +84,14 @@ export interface DashboardLayoutManager<S = {}> extends SceneObject {
    * @param ancestorKey
    * @param isSource
    */
-  cloneLayout(ancestorKey: string, isSource: boolean): DashboardLayoutManager;
+  cloneLayout(ancestorKey: string, isSource: boolean): AnyDashboardLayoutManager;
 
   /**
    * Duplicate, like clone but with new keys.
    * @param panelIdGenerator Optional sequential ID generator shared across
    *   sibling layouts to prevent duplicate panel IDs.
    */
-  duplicate(panelIdGenerator?: PanelIdGenerator): DashboardLayoutManager;
+  duplicate(panelIdGenerator?: PanelIdGenerator): AnyDashboardLayoutManager;
 
   /**
    * Paste a panel from the clipboard

--- a/public/app/features/dashboard-scene/scene/types/DashboardLayoutManager.ts
+++ b/public/app/features/dashboard-scene/scene/types/DashboardLayoutManager.ts
@@ -7,17 +7,12 @@ import { type PanelIdGenerator } from '../../utils/dashboardSceneGraph';
 import { type LayoutRegistryItem } from './LayoutRegistryItem';
 
 /**
- * A layout manager of any layout kind, regardless of what its serialize() returns. Needed where
- * managers of different kinds are held or returned together: a sibling layout (e.g. the notebook
- * layout) parameterizes TLayout with a kind outside the dashboard layout union, so it is not
- * assignable to the bare DashboardLayoutManager. Only TLayout is erased; `any` (not `unknown`) is
- * required because these results flow back into bare `DashboardLayoutManager` fields and `any` is
- * bidirectionally assignable, so those consumers keep compiling unchanged.
+ * A layout manager of any layout kind, whatever its serialize() returns. Needed where managers of
+ * different kinds are held together: the notebook layout serializes a kind outside the dashboard
+ * layout union, so it does not fit the plain DashboardLayoutManager.
  *
- * Because TLayout is `any`, serialize() through this alias is unchecked: its result assigns to any
- * layout kind without complaint. Callers that need a specific kind must narrow to the concrete
- * manager first (e.g. `body instanceof NotebookLayoutManager`) and call serialize() on that, which
- * restores the real return type and fails loudly when the body is not the expected layout.
+ * serialize() is not type-checked through this alias. Narrow to the concrete manager first
+ * (e.g. `body instanceof NotebookLayoutManager`) if you need a specific kind.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- erases only the serialize() kind so sibling layout managers fit
 export type AnyDashboardLayoutManager = DashboardLayoutManager<{}, any>;

--- a/public/app/features/dashboard-scene/scene/types/DashboardLayoutManager.ts
+++ b/public/app/features/dashboard-scene/scene/types/DashboardLayoutManager.ts
@@ -13,6 +13,11 @@ import { type LayoutRegistryItem } from './LayoutRegistryItem';
  * assignable to the bare DashboardLayoutManager. Only TLayout is erased; `any` (not `unknown`) is
  * required because these results flow back into bare `DashboardLayoutManager` fields and `any` is
  * bidirectionally assignable, so those consumers keep compiling unchanged.
+ *
+ * Because TLayout is `any`, serialize() through this alias is unchecked: its result assigns to any
+ * layout kind without complaint. Callers that need a specific kind must narrow to the concrete
+ * manager first (e.g. `body instanceof NotebookLayoutManager`) and call serialize() on that, which
+ * restores the real return type and fails loudly when the body is not the expected layout.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- erases only the serialize() kind so sibling layout managers fit
 export type AnyDashboardLayoutManager = DashboardLayoutManager<{}, any>;

--- a/public/app/features/dashboard-scene/scene/types/LayoutParent.ts
+++ b/public/app/features/dashboard-scene/scene/types/LayoutParent.ts
@@ -1,13 +1,14 @@
-import { type DashboardLayoutManager } from './DashboardLayoutManager';
+import { type AnyDashboardLayoutManager, type DashboardLayoutManager } from './DashboardLayoutManager';
 
 /**
  * This interface is needed to support layouts existing on different levels of the scene (DashboardScene and inside the TabsLayoutManager)
  */
 export interface LayoutParent {
   /**
-   * Returns the inner layout manager
+   * Returns the inner layout manager. Any kind, to match DashboardScene.getLayout(): the same
+   * object is reachable through this interface, and on a notebook it is a notebook layout manager.
    */
-  getLayout(): DashboardLayoutManager;
+  getLayout(): AnyDashboardLayoutManager;
 
   /**
    * Switches the inner layout manager

--- a/public/app/features/dashboard-scene/scene/types/LayoutRegistryItem.ts
+++ b/public/app/features/dashboard-scene/scene/types/LayoutRegistryItem.ts
@@ -1,6 +1,6 @@
 import { type IconName, type RegistryItem } from '@grafana/data';
 
-import { type DashboardLayoutManager } from './DashboardLayoutManager';
+import { type AnyDashboardLayoutManager } from './DashboardLayoutManager';
 
 /**
  * The layout descriptor used when selecting / switching layouts
@@ -10,7 +10,7 @@ export interface LayoutRegistryItem extends RegistryItem {
    * When switching between layouts
    * @param currentLayout
    */
-  createFromLayout(currentLayout: DashboardLayoutManager): DashboardLayoutManager;
+  createFromLayout(currentLayout: AnyDashboardLayoutManager): AnyDashboardLayoutManager;
 
   /**
    * Is grid layout (that contains panels)

--- a/public/app/features/dashboard-scene/scene/types/dashboard.ts
+++ b/public/app/features/dashboard-scene/scene/types/dashboard.ts
@@ -9,7 +9,7 @@ import { type DashboardSidebarLike } from '../../sidebar/types';
 import { type DashboardControls } from '../DashboardControls';
 import { type DashboardLayoutOrchestrator } from '../DashboardLayoutOrchestrator';
 
-import { type DashboardLayoutManager } from './DashboardLayoutManager';
+import { type AnyDashboardLayoutManager, type DashboardLayoutManager } from './DashboardLayoutManager';
 import { type LayoutParent } from './LayoutParent';
 
 export interface DashboardSceneState extends SceneObjectState {
@@ -32,8 +32,11 @@ export interface DashboardSceneState extends SceneObjectState {
   uid?: string;
   /** @experimental */
   scopeMeta?: ScopeMeta;
-  /** Layout of panels */
-  body: DashboardLayoutManager;
+  /**
+   * Layout of panels. Any kind, because a sibling resource's layout manager (the notebook) also
+   * rides this scene and serializes its own kind rather than a dashboard layout kind.
+   */
+  body: AnyDashboardLayoutManager;
   /** NavToolbar actions */
   actions?: SceneObject[];
   /** Fixed row at the top of the canvas with for example variables and time range controls */

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/layoutSerializerRegistry.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/layoutSerializerRegistry.ts
@@ -1,7 +1,7 @@
 import { Registry, type RegistryItem } from '@grafana/data';
 import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 
-import { type DashboardLayoutManager } from '../../scene/types/DashboardLayoutManager';
+import { type AnyDashboardLayoutManager } from '../../scene/types/DashboardLayoutManager';
 import { type PanelIdGenerator } from '../../utils/dashboardSceneGraph';
 
 import { deserializeAutoGridLayout } from './AutoGridLayoutSerializer';
@@ -16,7 +16,7 @@ interface LayoutSerializerRegistryItem extends RegistryItem {
     elements: DashboardV2Spec['elements'],
     preload: boolean,
     panelIdGenerator?: PanelIdGenerator
-  ) => DashboardLayoutManager;
+  ) => AnyDashboardLayoutManager;
 }
 
 export const layoutDeserializerRegistry: Registry<LayoutSerializerRegistryItem> =

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -160,6 +160,12 @@ export function transformSceneToSaveModelSchemaV2(scene: DashboardScene, isSnaps
     // EOF annotations
 
     // layout
+    // Unchecked: body is AnyDashboardLayoutManager, so serialize() is typed `any` and any layout
+    // kind assigns here. validateDashboardSchemaV2 below only dispatches on GridLayout and
+    // RowsLayout, so a sibling kind (e.g. a notebook layout) passes validation and is written out
+    // silently. Reachable only via getSaveModel, which is gated behind edit mode. A save path for a
+    // sibling resource must not reuse this function -- narrow to the concrete manager first and
+    // serialize that, so the compiler checks the kind and a wrong body fails loudly.
     layout: sceneDash.body.serialize(isSnapshot),
     // EOF layout
   };

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -160,12 +160,10 @@ export function transformSceneToSaveModelSchemaV2(scene: DashboardScene, isSnaps
     // EOF annotations
 
     // layout
-    // Unchecked: body is AnyDashboardLayoutManager, so serialize() is typed `any` and any layout
-    // kind assigns here. validateDashboardSchemaV2 below only dispatches on GridLayout and
-    // RowsLayout, so a sibling kind (e.g. a notebook layout) passes validation and is written out
-    // silently. Reachable only via getSaveModel, which is gated behind edit mode. A save path for a
-    // sibling resource must not reuse this function -- narrow to the concrete manager first and
-    // serialize that, so the compiler checks the kind and a wrong body fails loudly.
+    // Not type-checked: body is AnyDashboardLayoutManager, so serialize() is typed `any` and any
+    // layout kind assigns here. validateDashboardSchemaV2 only dispatches on GridLayout and
+    // RowsLayout, so a sibling kind like the notebook layout passes and is written out silently.
+    // A save path for a sibling resource should narrow to its own manager instead of reusing this.
     layout: sceneDash.body.serialize(isSnapshot),
     // EOF layout
   };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

 ## What

  `DashboardLayoutManager` now takes a second type parameter for what `serialize()` returns. It defaults to the dashboard layout union, so every existing layout manager is unchanged. A new `AnyDashboardLayoutManager` alias is used in the few places that hold or return managers of different kinds together.

  ## Why

The notebook is a sibling resource that rides the dashboard scene, and its layout manager serializes `NotebookLayout`, a kind that is not in the dashboard layout union. Before this change it had to launder its return value through `as unknown as DashboardV2Spec['layout']`. That cast hid a real type from the compiler, and it left a TODO asking for exactly this change.

Now `NotebookLayoutManager.serialize()` is declared as returning `NotebookLayoutKind` and the cast is gone.

## Questions you might have:

**Why `any` for the type parameter and not `unknown`?**

`unknown` is not assignable to the plain `DashboardLayoutManager`, so every function that takes a plain manager and receives `scene.state.body` would stop compiling: `getMaxYFromLayout`, `addNewRowTo`, `useLayoutCategory`,
`resolveLayoutPath`, `movePanelsToLayout`, `getGroupDepth`, and others. That is a much larger change than this one. The trade-off is that `serialize()` is not type-checked when called through `AnyDashboardLayoutManager`, which is documented at the alias and at the one place in the save path that relies on it.

**Why is there still a cast in the notebook serializer?**

Only the serialize direction is fixed here. Deserialize still bridges the two unions through `unknown`, because the layout serializer registry's input types are still dashboard-typed. Both casts there are checked at runtime with a `kind` check that throws, so they are safe. Making the registry generic on its inputs too is a separate change.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
