### PR TITLE
chore: [front-end] convert provisioning feature toggle to config param

### DIFF
--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -310,6 +310,7 @@ export interface GrafanaConfig {
   sharedWithMeFolderUID: string;
   rootFolderUID: string;
   localFileSystemAvailable: boolean;
+  provisioningEnabled: boolean;
   cloudMigrationEnabled: boolean;
   cloudMigrationIsTarget: boolean;
   cloudMigrationPollIntervalMs: number;

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -251,6 +251,7 @@ export class GrafanaBootConfig {
   sharedWithMeFolderUID?: string;
   rootFolderUID?: string;
   localFileSystemAvailable?: boolean;
+  provisioningEnabled = true;
   cloudMigrationEnabled?: boolean;
   cloudMigrationIsTarget?: boolean;
   cloudMigrationPollIntervalMs = 2000;

--- a/public/app/api/clients/folder/v1beta1/hooks.test.ts
+++ b/public/app/api/clients/folder/v1beta1/hooks.test.ts
@@ -134,9 +134,12 @@ const setupCreateFolderHandler = (onCreate?: jest.Mock) => {
 };
 
 const originalToggles = { ...config.featureToggles };
+const originalProvisioningEnabled = config.provisioningEnabled;
+config.provisioningEnabled = false;
 afterAll(() => {
   // Restore the original feature toggle value changed during tests
   config.featureToggles = originalToggles;
+  config.provisioningEnabled = originalProvisioningEnabled;
 });
 
 describe('useGetFolderQueryFacade', () => {

--- a/public/app/api/clients/folder/v1beta1/utils.ts
+++ b/public/app/api/clients/folder/v1beta1/utils.ts
@@ -14,7 +14,7 @@ export async function isProvisionedFolderCheck(
   folderUID: string,
   options?: { warning?: string }
 ) {
-  if (config.featureToggles.provisioning) {
+  if (config.provisioningEnabled) {
     const folder = await dispatch(folderAPI.endpoints.getFolder.initiate({ name: folderUID }));
     // TODO: taken from browseDashboardAPI as it is, but this error handling should be moved up to UI code.
     if (folder.data && isProvisionedFolder(folder.data)) {

--- a/public/app/core/components/NestedFolderPicker/FolderRepo.test.tsx
+++ b/public/app/core/components/NestedFolderPicker/FolderRepo.test.tsx
@@ -12,7 +12,7 @@ import { FolderRepo } from './FolderRepo';
 jest.mock('@grafana/runtime', () => {
   return {
     ...jest.requireActual('@grafana/runtime'),
-    config: { featureToggles: { provisioning: true } },
+    config: { featureToggles: {}, provisioningEnabled: true },
   };
 });
 

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.test.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.test.ts
@@ -1,7 +1,7 @@
 import { configureStore, type Middleware, isAnyOf } from '@reduxjs/toolkit';
 import { http, HttpResponse } from 'msw';
 import { type Store } from 'redux';
-import { testWithFeatureToggles, waitFor } from 'test/test-utils';
+import { waitFor } from 'test/test-utils';
 
 import { folderAPIVersionResolver } from '@grafana/api-clients/rtkq/folder/v1beta1';
 import * as quotasAPI from '@grafana/api-clients/rtkq/quotas/v0alpha1';
@@ -107,12 +107,18 @@ describe('browseDashboardsAPI', () => {
     return { store: makeRecorderStore(recorder), updateNamePayloads };
   };
 
-  testWithFeatureToggles({ disable: ['provisioning'] });
+  let originalProvisioningEnabled: boolean;
 
   beforeEach(() => {
+    originalProvisioningEnabled = config.provisioningEnabled;
+    config.provisioningEnabled = false;
     getDashboardAPIMock.mockReset();
     folderAPIVersionResolver.set('v1beta1');
     server.use(http.get('/api/access-control/user/actions', () => HttpResponse.json({})));
+  });
+
+  afterEach(() => {
+    config.provisioningEnabled = originalProvisioningEnabled;
   });
 
   const createMockDashboardAPI = (saveDashboard: jest.Mock) =>
@@ -211,7 +217,7 @@ describe('browseDashboardsAPI', () => {
 
   it('does not check whether a single delete target is provisioned before deleting it', async () => {
     const store = createTestStore();
-    config.featureToggles.provisioning = true;
+    config.provisioningEnabled = true;
 
     const getProvisionedFolderSpy = jest.fn();
     const deleteFolderSpy = jest.fn();
@@ -458,7 +464,7 @@ describe('browseDashboardsAPI', () => {
 
     it('does not delete provisioned folders during bulk delete', async () => {
       const store = createTestStore();
-      config.featureToggles.provisioning = true;
+      config.provisioningEnabled = true;
 
       const deleteSpy = jest.fn();
 
@@ -506,7 +512,7 @@ describe('browseDashboardsAPI', () => {
     });
 
     it('only un-stars folders that were actually deleted when some are provisioned', async () => {
-      config.featureToggles.provisioning = true;
+      config.provisioningEnabled = true;
       const { store, setStarredPayloads } = createStoreWithSetStarredRecorder();
 
       const deletedUids: string[] = [];

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
@@ -273,7 +273,7 @@ export const browseDashboardsAPI = createApi({
           const dashboard = isDashboardV2Resource(fullDash) ? fullDash.spec : fullDash.dashboard;
           const k8s = isDashboardV2Resource(fullDash) ? fullDash.metadata : undefined;
 
-          if (config.featureToggles.provisioning) {
+          if (config.provisioningEnabled) {
             if (isProvisionedDashboard(fullDash)) {
               appEvents.publish({
                 type: AppEvents.alertWarning.name,
@@ -395,7 +395,7 @@ export const browseDashboardsAPI = createApi({
           for (const dashboardUID of dashboardUIDs) {
             // It's not possible to select a mix of provisioned and non-provisioned dashboards
             // from the UI, so this is mostly a guard in case that somehow happens
-            if (config.featureToggles.provisioning) {
+            if (config.provisioningEnabled) {
               const dto = await api.getDashboardDTO(dashboardUID);
               if (isProvisionedDashboard(dto)) {
                 appEvents.publish({

--- a/public/app/features/browse-dashboards/components/BrowseActions/BrowseActions.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseActions/BrowseActions.tsx
@@ -42,7 +42,7 @@ export function BrowseActions({ folderDTO }: Props) {
   const [moveFolders] = useMoveMultipleFoldersMutationFacade();
   const [moveDashboards] = useMoveDashboardsMutation();
   const [, stateManager] = useSearchStateManager();
-  const provisioningEnabled = config.featureToggles.provisioning;
+  const provisioningEnabled = config.provisioningEnabled;
 
   const { hasProvisioned, hasNonProvisioned } = useSelectionProvisioningStatus(
     selectedItems,

--- a/public/app/features/browse-dashboards/components/BrowseView.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseView.tsx
@@ -58,7 +58,7 @@ export function BrowseView({
   const selectedItems = useCheckboxSelectionState();
   const childrenByParentUID = useChildrenByParentUIDState();
   const canSelect = canSelectItems(permissions);
-  const provisioningEnabled = config.featureToggles.provisioning;
+  const provisioningEnabled = config.provisioningEnabled;
   const { data: settingsData } = useGetFrontendSettingsQuery(!provisioningEnabled ? skipToken : undefined);
   const isProvisionedInstance = useIsProvisionedInstance({ settings: settingsData });
   const rootItems = useSelector(rootItemsSelector);

--- a/public/app/features/commandPalette/ResultItem.test.tsx
+++ b/public/app/features/commandPalette/ResultItem.test.tsx
@@ -16,14 +16,14 @@ function createActionImpl(props: Record<string, unknown> = {}): ActionImpl {
 }
 
 describe('ResultItem', () => {
-  let originalProvisioning: boolean | undefined;
+  let originalProvisioning: boolean;
 
   beforeEach(() => {
-    originalProvisioning = config.featureToggles.provisioning;
+    originalProvisioning = config.provisioningEnabled;
   });
 
   afterEach(() => {
-    config.featureToggles.provisioning = originalProvisioning;
+    config.provisioningEnabled = originalProvisioning;
   });
 
   it('renders the action name', () => {
@@ -33,42 +33,35 @@ describe('ResultItem', () => {
   });
 
   it('renders the managed badge when managedBy is Repo and provisioning toggle is on', () => {
-    config.featureToggles.provisioning = true;
+    config.provisioningEnabled = true;
     const action = createActionImpl({ managedBy: ManagerKind.Repo });
     render(<ResultItem action={action} active={false} currentRootActionId="" />);
     expect(screen.getByTestId('icon-exchange-alt')).toBeInTheDocument();
   });
 
   it('does not render the managed badge when managedBy is undefined', () => {
-    config.featureToggles.provisioning = true;
+    config.provisioningEnabled = true;
     const action = createActionImpl();
     render(<ResultItem action={action} active={false} currentRootActionId="" />);
     expect(screen.queryByTestId('icon-exchange-alt')).not.toBeInTheDocument();
   });
 
   it('renders the managed badge when managedBy is a non-Repo kind', () => {
-    config.featureToggles.provisioning = true;
+    config.provisioningEnabled = true;
     const action = createActionImpl({ managedBy: ManagerKind.Terraform });
     render(<ResultItem action={action} active={false} currentRootActionId="" />);
     expect(screen.getByTestId('icon-exchange-alt')).toBeInTheDocument();
   });
 
   it('renders the managed badge for plugin-managed resources', () => {
-    config.featureToggles.provisioning = true;
+    config.provisioningEnabled = true;
     const action = createActionImpl({ managedBy: ManagerKind.Plugin });
     render(<ResultItem action={action} active={false} currentRootActionId="" />);
     expect(screen.getByTestId('icon-exchange-alt')).toBeInTheDocument();
   });
 
   it('does not render the managed badge when provisioning toggle is off', () => {
-    config.featureToggles.provisioning = false;
-    const action = createActionImpl({ managedBy: ManagerKind.Repo });
-    render(<ResultItem action={action} active={false} currentRootActionId="" />);
-    expect(screen.queryByTestId('icon-exchange-alt')).not.toBeInTheDocument();
-  });
-
-  it('does not render the managed badge when provisioning toggle is undefined', () => {
-    config.featureToggles.provisioning = undefined;
+    config.provisioningEnabled = false;
     const action = createActionImpl({ managedBy: ManagerKind.Repo });
     render(<ResultItem action={action} active={false} currentRootActionId="" />);
     expect(screen.queryByTestId('icon-exchange-alt')).not.toBeInTheDocument();

--- a/public/app/features/commandPalette/ResultItem.tsx
+++ b/public/app/features/commandPalette/ResultItem.tsx
@@ -41,7 +41,7 @@ export const ResultItem = React.forwardRef(
     // See the same pattern for `url` in KBarResults.tsx and below command url
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const managedBy = (action as ActionImpl & { managedBy?: ManagerKind }).managedBy;
-    const showProvisionedBadge = config.featureToggles.provisioning && Boolean(managedBy);
+    const showProvisionedBadge = config.provisioningEnabled && Boolean(managedBy);
 
     let name = action.name;
 

--- a/public/app/features/dashboard-scene/saving/SaveDashboardDrawer.test.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveDashboardDrawer.test.tsx
@@ -237,11 +237,11 @@ describe('SaveDashboardDrawer', () => {
 
   describe('When a dashboard is managed by an external system', () => {
     beforeEach(() => {
-      config.featureToggles.provisioning = true;
+      config.provisioningEnabled = true;
     });
 
     afterEach(() => {
-      config.featureToggles.provisioning = false;
+      config.provisioningEnabled = false;
     });
 
     it('It should show the changes tab if the resource can be edited', async () => {

--- a/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
@@ -2017,11 +2017,11 @@ describe('DashboardScene', () => {
 
   describe('When checking dashboard managed by an external system', () => {
     beforeEach(() => {
-      config.featureToggles.provisioning = true;
+      config.provisioningEnabled = true;
     });
 
     afterEach(() => {
-      config.featureToggles.provisioning = false;
+      config.provisioningEnabled = false;
     });
 
     it('should return true if the dashboard is managed', () => {

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -1484,7 +1484,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
   }
 
   isManagedRepository() {
-    if (!config.featureToggles.provisioning) {
+    if (!config.provisioningEnabled) {
       return false;
     }
     return Boolean(this.getManagerKind() === ManagerKind.Repo);

--- a/public/app/features/dashboard-scene/scene/ManagedDashboardNavBarBadge.test.tsx
+++ b/public/app/features/dashboard-scene/scene/ManagedDashboardNavBarBadge.test.tsx
@@ -32,15 +32,15 @@ function buildDashboard(kind?: ManagerKind, id?: string): DashboardScene {
 }
 
 describe('ManagedDashboardNavBarBadge', () => {
-  let originalProvisioning: boolean | undefined;
+  let originalProvisioning: boolean;
 
   beforeEach(() => {
-    originalProvisioning = config.featureToggles.provisioning;
-    config.featureToggles.provisioning = true;
+    originalProvisioning = config.provisioningEnabled;
+    config.provisioningEnabled = true;
   });
 
   afterEach(() => {
-    config.featureToggles.provisioning = originalProvisioning;
+    config.provisioningEnabled = originalProvisioning;
     jest.restoreAllMocks();
   });
 

--- a/public/app/features/dashboard-scene/settings/VersionsEditView.test.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.test.tsx
@@ -257,11 +257,11 @@ describe('VersionsEditView', () => {
 
   describe('Provisioned dashboards', () => {
     beforeEach(() => {
-      config.featureToggles.provisioning = true;
+      config.provisioningEnabled = true;
     });
 
     afterEach(() => {
-      config.featureToggles.provisioning = false;
+      config.provisioningEnabled = false;
       jest.clearAllMocks();
     });
 

--- a/public/app/features/provisioning/GettingStarted/GettingStarted.tsx
+++ b/public/app/features/provisioning/GettingStarted/GettingStarted.tsx
@@ -124,7 +124,7 @@ interface Props {
 
 export default function GettingStarted({ items }: Props) {
   const styles = useStyles2(getStyles);
-  const settingsArg = config.featureToggles.provisioning ? undefined : skipToken;
+  const settingsArg = config.provisioningEnabled ? undefined : skipToken;
   const settingsQuery = useGetFrontendSettingsQuery(settingsArg, {
     refetchOnMountOrArgChange: true,
   });

--- a/public/app/features/provisioning/components/Dashboards/DashboardPreviewBanner.test.tsx
+++ b/public/app/features/provisioning/components/Dashboards/DashboardPreviewBanner.test.tsx
@@ -16,7 +16,7 @@ jest.mock('@grafana/runtime', () => {
     ...actual,
     config: {
       ...actual.config,
-      featureToggles: { provisioning: true },
+      provisioningEnabled: true,
     },
   };
 });

--- a/public/app/features/provisioning/components/Dashboards/DashboardPreviewBanner.tsx
+++ b/public/app/features/provisioning/components/Dashboards/DashboardPreviewBanner.tsx
@@ -58,7 +58,7 @@ function DashboardPreviewBannerContent({ queryParams, slug, path }: DashboardPre
 }
 
 export function DashboardPreviewBanner({ queryParams, route, slug, path }: DashboardPreviewBannerProps) {
-  const provisioningEnabled = config.featureToggles.provisioning;
+  const provisioningEnabled = config.provisioningEnabled;
   if (!provisioningEnabled || 'kiosk' in queryParams || !path || route !== DashboardRoutes.Provisioning || !slug) {
     return null;
   }

--- a/public/app/features/provisioning/components/Dashboards/OrphanedDashboardBanner.tsx
+++ b/public/app/features/provisioning/components/Dashboards/OrphanedDashboardBanner.tsx
@@ -18,7 +18,7 @@ export function OrphanedDashboardBanner({ dashboard }: Props) {
   const kind = dashboard.getManagerKind();
   const name = dashboard.getManagerIdentity();
 
-  const shouldSkip = !config.featureToggles.provisioning || kind !== ManagerKind.Repo || !name;
+  const shouldSkip = !config.provisioningEnabled || kind !== ManagerKind.Repo || !name;
 
   const { status } = useGetResourceRepositoryView({
     name: shouldSkip ? undefined : name,

--- a/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.test.tsx
+++ b/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.test.tsx
@@ -28,6 +28,9 @@ jest.mock('@grafana/runtime', () => {
           state: 'alpha',
         },
       },
+      // getProvisionedMeta's k8s folder lookup isn't mocked in this suite; keep it disabled
+      // so folder selection doesn't attempt a real getFolder query.
+      provisioningEnabled: false,
     },
   };
 });

--- a/public/app/features/provisioning/components/Folders/FixFolderMetadataDrawer.test.tsx
+++ b/public/app/features/provisioning/components/Folders/FixFolderMetadataDrawer.test.tsx
@@ -1,5 +1,5 @@
 import { HttpResponse, http } from 'msw';
-import { render, screen, testWithFeatureToggles, waitFor } from 'test/test-utils';
+import { render, screen, waitFor } from 'test/test-utils';
 
 import { PROVISIONING_API_BASE as BASE } from '@grafana/test-utils/handlers';
 
@@ -32,8 +32,6 @@ const defaultSettings = {
 };
 
 describe('FixFolderMetadataDrawer', () => {
-  testWithFeatureToggles({ enable: ['provisioning'] });
-
   beforeEach(() => {
     server.use(
       http.get(`${BASE}/settings`, () => HttpResponse.json(defaultSettings)),

--- a/public/app/features/provisioning/components/Folders/MissingFolderMetadataBanner.test.tsx
+++ b/public/app/features/provisioning/components/Folders/MissingFolderMetadataBanner.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, testWithFeatureToggles } from 'test/test-utils';
+import { render, screen } from 'test/test-utils';
 
 import { config } from '@grafana/runtime';
 import { setTestFlags } from '@grafana/test-utils/unstable';
@@ -72,10 +72,16 @@ describe('MissingFolderMetadataBanner', () => {
 });
 
 describe('FolderPermissions', () => {
-  testWithFeatureToggles({ enable: ['provisioning'] });
+  let originalProvisioningEnabled: boolean;
 
   beforeEach(() => {
+    originalProvisioningEnabled = config.provisioningEnabled;
+    config.provisioningEnabled = true;
     jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    config.provisioningEnabled = originalProvisioningEnabled;
   });
 
   beforeEach(() => {
@@ -92,7 +98,7 @@ describe('FolderPermissions', () => {
   });
 
   it('renders permissions directly when feature toggles are disabled', () => {
-    config.featureToggles.provisioning = false;
+    config.provisioningEnabled = false;
 
     render(<FolderPermissions folderUID="folder-1" canSetPermissions={true} isProvisionedFolder={true} />);
 

--- a/public/app/features/provisioning/components/Folders/MissingFolderMetadataBanner.tsx
+++ b/public/app/features/provisioning/components/Folders/MissingFolderMetadataBanner.tsx
@@ -78,7 +78,7 @@ interface FolderPermissionsProps {
 export function FolderPermissions({ folderUID, canSetPermissions, isProvisionedFolder }: FolderPermissionsProps) {
   const provisioningFolderMetadataEnabled = useBooleanFlagValue('provisioningFolderMetadata', false);
 
-  if (!isProvisionedFolder || !config.featureToggles.provisioning || !provisioningFolderMetadataEnabled) {
+  if (!isProvisionedFolder || !config.provisioningEnabled || !provisioningFolderMetadataEnabled) {
     return <Permissions resource="folders" resourceId={folderUID} canSetPermissions={canSetPermissions} />;
   }
 

--- a/public/app/features/provisioning/components/Folders/ProvisionedFolderPreviewBanner.tsx
+++ b/public/app/features/provisioning/components/Folders/ProvisionedFolderPreviewBanner.tsx
@@ -8,7 +8,7 @@ import { usePullRequestParam } from 'app/features/provisioning/hooks/usePullRequ
 import { PROVISIONING_URL } from '../../constants';
 
 export function ProvisionedFolderPreviewBanner({ queryParams }: CommonBannerProps) {
-  const provisioningEnabled = config.featureToggles.provisioning;
+  const provisioningEnabled = config.provisioningEnabled;
   const { prURL, newPrURL, repoURL, resourcePushedTo } = usePullRequestParam();
 
   if (!provisioningEnabled || 'kiosk' in queryParams) {

--- a/public/app/features/provisioning/components/ManagedBadge.test.tsx
+++ b/public/app/features/provisioning/components/ManagedBadge.test.tsx
@@ -44,19 +44,19 @@ function setPermissions({ isEditor = false, canManageRepositories = false } = {}
 }
 
 describe('ManagedBadge', () => {
-  let originalProvisioning: boolean | undefined;
+  let originalProvisioning: boolean;
   let originalIsEditor: boolean;
 
   beforeEach(() => {
-    originalProvisioning = config.featureToggles.provisioning;
+    originalProvisioning = config.provisioningEnabled;
     originalIsEditor = contextSrv.isEditor;
-    config.featureToggles.provisioning = true;
+    config.provisioningEnabled = true;
     hasPermissionSpy = jest.spyOn(contextSrv, 'hasPermission');
     setPermissions();
   });
 
   afterEach(() => {
-    config.featureToggles.provisioning = originalProvisioning;
+    config.provisioningEnabled = originalProvisioning;
     contextSrv.isEditor = originalIsEditor;
     jest.restoreAllMocks();
   });
@@ -244,7 +244,7 @@ describe('ManagedBadge', () => {
 
     it('renders a plain badge when the provisioning feature toggle is off', () => {
       setPermissions({ isEditor: true, canManageRepositories: true });
-      config.featureToggles.provisioning = false;
+      config.provisioningEnabled = false;
 
       render(<ManagedBadge managerKind={ManagerKind.Repo} repositoryName="my-repo" sourcePath="dashboards/foo.json" />);
 

--- a/public/app/features/provisioning/components/ManagedBadge.tsx
+++ b/public/app/features/provisioning/components/ManagedBadge.tsx
@@ -48,7 +48,7 @@ interface ManagedBadgeProps {
 export function ManagedBadge({ managerKind, name, isOrphaned = false, repositoryName, sourcePath }: ManagedBadgeProps) {
   // The interactive variant is a separate component so the RTK Query hook only runs (and only
   // requires a store context) when a repository lookup can actually yield actions.
-  if (config.featureToggles.provisioning && managerKind === ManagerKind.Repo && repositoryName && !isOrphaned) {
+  if (config.provisioningEnabled && managerKind === ManagerKind.Repo && repositoryName && !isOrphaned) {
     return <RepoManagedBadge name={name} repositoryName={repositoryName} sourcePath={sourcePath} />;
   }
 

--- a/public/app/features/provisioning/components/Shared/ProvisioningAwareFolderPicker.test.tsx
+++ b/public/app/features/provisioning/components/Shared/ProvisioningAwareFolderPicker.test.tsx
@@ -55,7 +55,7 @@ describe('ProvisioningAwareFolderPicker', () => {
       refetch: jest.fn(),
     });
 
-    config.featureToggles = { provisioning: true };
+    config.provisioningEnabled = true;
   });
 
   describe('Provisioned Instance', () => {
@@ -97,7 +97,7 @@ describe('ProvisioningAwareFolderPicker', () => {
   describe('Feature Toggle Disabled', () => {
     beforeEach(() => {
       mockUseIsProvisionedInstance.mockReturnValue(false);
-      config.featureToggles.provisioning = false;
+      config.provisioningEnabled = false;
     });
 
     it('should not apply restrictions', () => {

--- a/public/app/features/provisioning/components/Shared/ProvisioningAwareFolderPicker.tsx
+++ b/public/app/features/provisioning/components/Shared/ProvisioningAwareFolderPicker.tsx
@@ -21,7 +21,7 @@ interface Props extends NestedFolderPickerProps {
 
 export function ProvisioningAwareFolderPicker({ repositoryName, showAllFolders, ...props }: Props) {
   const isProvisionedInstance = useIsProvisionedInstance();
-  const provisioningEnabled = config.featureToggles.provisioning;
+  const provisioningEnabled = config.provisioningEnabled;
   const { data: settingsData } = useGetFrontendSettingsQuery(provisioningEnabled ? undefined : skipToken);
   const isNonProvisionedResource = !repositoryName;
 

--- a/public/app/features/provisioning/components/utils/getProvisionedMeta.ts
+++ b/public/app/features/provisioning/components/utils/getProvisionedMeta.ts
@@ -7,7 +7,7 @@ import { dispatch } from 'app/store/store';
  * Get k8s dashboard metadata based on the selected folder
  */
 export async function getProvisionedMeta(folderUid?: string) {
-  if (!folderUid || !config.featureToggles.provisioning) {
+  if (!folderUid || !config.provisioningEnabled) {
     return {};
   }
   const folderQuery = await dispatch(folderAPI.endpoints.getFolder.initiate({ name: folderUid })).unwrap();

--- a/public/app/features/provisioning/hooks/useGetResourceRepositoryView.test.ts
+++ b/public/app/features/provisioning/hooks/useGetResourceRepositoryView.test.ts
@@ -67,20 +67,20 @@ function setupMocks({
 }
 
 describe('useGetResourceRepositoryView', () => {
-  const originalToggles = config.featureToggles;
+  const originalProvisioningEnabled = config.provisioningEnabled;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    config.featureToggles = { ...originalToggles, provisioning: true };
+    config.provisioningEnabled = true;
   });
 
   afterEach(() => {
-    config.featureToggles = originalToggles;
+    config.provisioningEnabled = originalProvisioningEnabled;
   });
 
   describe('provisioning disabled', () => {
     it('returns Disabled status', () => {
-      config.featureToggles = { ...originalToggles, provisioning: false };
+      config.provisioningEnabled = false;
       setupMocks();
 
       const { result } = renderHook(() => useGetResourceRepositoryView({ folderName: 'some-folder' }));
@@ -427,7 +427,7 @@ describe('useGetResourceRepositoryView', () => {
     });
 
     it('is true when provisioning is disabled (no repository can exist)', () => {
-      config.featureToggles = { ...originalToggles, provisioning: false };
+      config.provisioningEnabled = false;
       setupMocks();
 
       const { result } = renderHook(() => useGetResourceRepositoryView({ folderName: 'some-folder' }));

--- a/public/app/features/provisioning/hooks/useGetResourceRepositoryView.ts
+++ b/public/app/features/provisioning/hooks/useGetResourceRepositoryView.ts
@@ -56,7 +56,7 @@ const useResourceRepositoryViewData = ({
   skipQuery,
   includeInstance,
 }: GetResourceRepositoryArgs): Omit<RepositoryViewData, 'isMissingRepo'> => {
-  const provisioningEnabled = config.featureToggles.provisioning;
+  const provisioningEnabled = config.provisioningEnabled;
   // Skip when caller has no target. This query is shared across many
   // components, so a failing fetch would cycle all of them through retries.
   // `includeInstance` overrides the skip for root-level instance lookups.

--- a/public/app/features/provisioning/hooks/useIsProvisionedInstance.ts
+++ b/public/app/features/provisioning/hooks/useIsProvisionedInstance.ts
@@ -10,7 +10,7 @@ interface UseIsProvisionedInstanceOptions {
 
 export function useIsProvisionedInstance(options: UseIsProvisionedInstanceOptions = {}) {
   const { settings, skip: skipQuery } = options;
-  const skip = !config.featureToggles.provisioning || skipQuery;
+  const skip = !config.provisioningEnabled || skipQuery;
 
   const settingsQuery = useGetFrontendSettingsQuery(settings || skip ? skipToken : undefined);
 

--- a/public/app/features/provisioning/hooks/useIsProvisionedNG.ts
+++ b/public/app/features/provisioning/hooks/useIsProvisionedNG.ts
@@ -10,7 +10,7 @@ export function useIsProvisionedNG(dashboard: DashboardScene): boolean {
 
   const { repository, isInstanceManaged } = useGetResourceRepositoryView({ folderName });
 
-  if (!config.featureToggles.provisioning) {
+  if (!config.provisioningEnabled) {
     return false;
   }
   return dashboard.isManagedRepository() || Boolean(repository) || isInstanceManaged;

--- a/public/app/features/provisioning/hooks/useProvisionedDashboardData.test.ts
+++ b/public/app/features/provisioning/hooks/useProvisionedDashboardData.test.ts
@@ -64,11 +64,11 @@ const mockMeta = {
 };
 
 beforeEach(() => {
-  config.featureToggles.provisioning = true;
+  config.provisioningEnabled = true;
 });
 
 afterEach(() => {
-  config.featureToggles.provisioning = false;
+  config.provisioningEnabled = false;
 });
 
 describe('useDefaultValues', () => {

--- a/public/app/features/provisioning/hooks/useResourceRepositorySelection.test.ts
+++ b/public/app/features/provisioning/hooks/useResourceRepositorySelection.test.ts
@@ -18,12 +18,12 @@ const repo = { name: 'r1', title: 'R1', target: 'instance', type: 'git', workflo
 
 describe('useResourceRepositorySelection', () => {
   beforeEach(() => {
-    config.featureToggles.provisioning = true;
+    config.provisioningEnabled = true;
     mockQuery.mockReturnValue({ data: undefined });
   });
 
   it('is unavailable when provisioning is disabled', () => {
-    config.featureToggles.provisioning = false;
+    config.provisioningEnabled = false;
     const { result } = renderHook(() => useResourceRepositorySelection(resourceKindInfos.playlist));
     expect(result.current.isAvailable).toBe(false);
   });

--- a/public/app/features/provisioning/hooks/useResourceRepositorySelection.ts
+++ b/public/app/features/provisioning/hooks/useResourceRepositorySelection.ts
@@ -25,7 +25,7 @@ export interface ResourceRepositorySelection {
  * settings response doesn't fall back to "all kinds available").
  */
 export function useResourceRepositorySelection(info: ResourceKindInfo): ResourceRepositorySelection {
-  const provisioningEnabled = Boolean(config.featureToggles.provisioning);
+  const provisioningEnabled = Boolean(config.provisioningEnabled);
   const { data } = useGetFrontendSettingsQuery(provisioningEnabled ? undefined : skipToken);
 
   const repositories = data?.items ?? [];

--- a/public/app/features/provisioning/hooks/useSelectionProvisioningStatus.ts
+++ b/public/app/features/provisioning/hooks/useSelectionProvisioningStatus.ts
@@ -22,7 +22,7 @@ export function useSelectionProvisioningStatus(
   const isProvisionedInstance = useIsProvisionedInstance();
   const [, stateManager] = useSearchStateManager();
   const isSearching = stateManager.hasSearchFilters();
-  const provisioningEnabled = config.featureToggles.provisioning;
+  const provisioningEnabled = config.provisioningEnabled;
 
   const [status, setStatus] = useState({ hasProvisioned: false, hasNonProvisioned: false });
   const [folderCache, setFolderCache] = useState<Record<string, boolean>>({});

--- a/public/app/features/provisioning/hooks/useSelectionRepoValidation.ts
+++ b/public/app/features/provisioning/hooks/useSelectionRepoValidation.ts
@@ -12,7 +12,7 @@ import { useChildrenByParentUIDState, rootItemsSelector } from '../../browse-das
 
 // This hook is responsible for validating if all selected resources (dashboard folders and dashboards) are in the same repository
 export function useSelectionRepoValidation(selectedItems: Omit<DashboardTreeSelection, 'panel' | '$all'>) {
-  const provisioningEnabled = config.featureToggles.provisioning;
+  const provisioningEnabled = config.provisioningEnabled;
   const childrenByParentUID = useChildrenByParentUIDState();
   const rootItems = useSelector(rootItemsSelector)?.items ?? [];
   const isProvisionedInstance = useIsProvisionedInstance();

--- a/public/app/features/provisioning/utils/routes.tsx
+++ b/public/app/features/provisioning/utils/routes.tsx
@@ -29,8 +29,7 @@ const connectionRoles = () =>
   ]);
 
 export function getProvisioningRoutes(): RouteDescriptor[] {
-  const featureToggles = config.featureToggles || {};
-  if (!featureToggles.provisioning) {
+  if (!config.provisioningEnabled) {
     return [];
   }
 


### PR DESCRIPTION
Provisioning is in GA. To provide control over provisioning in on-prem environment, replacing this toggle with config param.

Since provisioning is now GA, we can initialize the config parameter to true. This will provide coverage until the BE changes have been rolled out across all Cloud environments and channels.

On-prem release is covered with the following BE pr https://github.com/grafana/grafana/pull/129030