### PR TITLE
fix: add bounded timeout to CloudWatch Logs monitoring-account pre-check (#129766)

### DIFF
--- a/pkg/tsdb/cloudwatch/log_actions.go
+++ b/pkg/tsdb/cloudwatch/log_actions.go
@@ -224,7 +224,18 @@ func (ds *DataSource) executeStartQuery(ctx context.Context, logsClient models.C
 
 	isMonitoringAccount := false
 	if features.IsEnabled(ctx, features.FlagCloudWatchCrossAccountQuerying) && region != "" {
-		monitoringAccountStatus, err := ds.isMonitoringAccount(ctx, region)
+		// Use a short timeout for the monitoring account pre-check. If the OAM
+		// endpoint is unreachable (network black-hole), the default socket idle
+		// timeout is ~60s. A bounded timeout prevents blocking the Logs query
+		// for the entire duration. The existing error branch degrades gracefully
+		// to isMonitoringAccount = false, so a timeout is safe.
+		checkCtx := ctx
+		if deadline, ok := ctx.Deadline(); !ok || time.Until(deadline) > 5*time.Second {
+			var cancel context.CancelFunc
+			checkCtx, cancel = context.WithTimeout(ctx, 5*time.Second)
+			defer cancel()
+		}
+		monitoringAccountStatus, err := ds.isMonitoringAccount(checkCtx, region)
 		if err != nil {
 			ds.logger.FromContext(ctx).Debug("failed to determine monitoring account status", "err", err)
 		} else {


### PR DESCRIPTION
## Description

Fixes #129766

CloudWatch Logs Insights queries hang for ~60 seconds and return HTTP 502 when the OAM endpoint (oam.`<region>`.amazonaws.com) is unreachable — e.g. inside a VPC with no route/VPC endpoint/NAT path to OAM.

### Root cause

In `executeStartQuery` (`pkg/tsdb/cloudwatch/log_actions.go`), when the `cloudWatchCrossAccountQuerying` feature is enabled, the backend calls `ds.isMonitoringAccount(ctx, region)` before issuing `StartQuery`. This call performs `GetAccountsForCurrentUserOrRole` → `oam:ListSinks` synchronously with **no bounded timeout**. If the OAM endpoint is network-black-holed (packets dropped, no RST/response), it blocks until the socket idle timeout (~60s). Because the pre-check runs before `StartQuery`, the Logs query is never actually submitted, and the request surfaces as an HTTP 502.

Notably, a fast failure (AccessDenied / connection refused) does NOT cause this: the error branch is already handled (logged at Debug, proceeds with `isMonitoringAccount = false`). Only a network hang triggers the ~60s block.

### Fix

Wrap the `isMonitoringAccount` call with a 5-second timeout context. If the parent context already has a shorter deadline, respect that instead. On timeout (or any error), the existing error branch gracefully degrades to `isMonitoringAccount = false` and proceeds to `StartQuery`.

### Verification

- CloudWatch Metrics queries are unaffected (they don't call `isMonitoringAccount` on the query path)
- The existing error branch for fast failures (AccessDenied, connection refused) is unchanged
- The monitoring-account cache (`ds.monitoringAccountCache`) is preserved — only the first uncached call is affected
- All existing tests pass unchanged