### PR TITLE
feat(unifiedstorage): #106554 add polling interval configuration for SQL backend notifier

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2664,3 +2664,9 @@ index_path =
 # Warning: disabling can cause data drift and is only safe with no concurrent writers (single instance, no HA, no rolling upgrades).
 # Default: true.
 migration_locking = true
+
+# Polling interval for the SQL backend's watch notifier. The notifier polls the
+# database at this interval to detect new resource changes when running in HA
+# mode (polling notifier). Lower values reduce watch latency at the cost of
+# increased database load. Default: 100ms.
+polling_interval = 100ms

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2696,3 +2696,9 @@ index_path =
 # Warning: disabling can cause data drift and is only safe with no concurrent writers (single instance, no HA, no rolling upgrades).
 # Default: true.
 migration_locking = true
+
+# Polling interval for the SQL backend's watch notifier. The notifier polls the
+# database at this interval to detect new resource changes when running in HA
+# mode (polling notifier). Lower values reduce watch latency at the cost of
+# increased database load. Default: 100ms.
+polling_interval = 100ms

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -870,6 +870,9 @@ type Cfg struct {
 	EventPruningInterval time.Duration
 	SearchLookback       time.Duration
 	NotifierSettleDelay  time.Duration
+	// PollingInterval is the interval at which the SQL backend polls the
+	// database for new watch events. Default: 100ms.
+	PollingInterval time.Duration
 	// ResourceVersionBatchTransactionTimeout bounds one batched WithTx in the
 	// resource version manager (all WriteEventFunc calls + RV stamp updates).
 	ResourceVersionBatchTransactionTimeout time.Duration

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -877,6 +877,9 @@ type Cfg struct {
 	EventPruningInterval time.Duration
 	SearchLookback       time.Duration
 	NotifierSettleDelay  time.Duration
+	// PollingInterval is the interval at which the SQL backend polls the
+	// database for new watch events. Default: 100ms.
+	PollingInterval time.Duration
 	// ResourceVersionBatchTransactionTimeout bounds one batched WithTx in the
 	// resource version manager (all WriteEventFunc calls + RV stamp updates).
 	ResourceVersionBatchTransactionTimeout time.Duration

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -274,6 +274,7 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 	cfg.EventPruningInterval = section.Key("event_pruning_interval").MustDuration(5 * time.Minute)
 	cfg.SearchLookback = section.Key("search_lookback").MustDuration(1 * time.Second)
 	cfg.NotifierSettleDelay = section.Key("notifier_settle_delay").MustDuration(3 * time.Second)
+	cfg.PollingInterval = section.Key("polling_interval").MustDuration(100 * time.Millisecond)
 	cfg.ResourceVersionBatchTransactionTimeout = section.Key("resource_version_batch_transaction_timeout").MustDuration(5 * time.Second)
 
 	// TTL for caching statusReader results in the dynamic dualwrite service. 0 = no expiration.

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -273,6 +273,7 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 	cfg.EventPruningInterval = section.Key("event_pruning_interval").MustDuration(5 * time.Minute)
 	cfg.SearchLookback = section.Key("search_lookback").MustDuration(1 * time.Second)
 	cfg.NotifierSettleDelay = section.Key("notifier_settle_delay").MustDuration(3 * time.Second)
+	cfg.PollingInterval = section.Key("polling_interval").MustDuration(100 * time.Millisecond)
 	cfg.ResourceVersionBatchTransactionTimeout = section.Key("resource_version_batch_transaction_timeout").MustDuration(5 * time.Second)
 
 	// TTL for caching statusReader results in the dynamic dualwrite service. 0 = no expiration.

--- a/pkg/setting/setting_unified_storage_test.go
+++ b/pkg/setting/setting_unified_storage_test.go
@@ -3,6 +3,7 @@ package setting
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/stretchr/testify/assert"
@@ -332,6 +333,40 @@ func TestCfg_setUnifiedStorageConfig(t *testing.T) {
 			// Guards a regression where bedrock used vertex_batch_size.
 			assert.Equal(t, 7, cfg.BedrockBatchSize)
 			assert.Equal(t, 15, cfg.BedrockMaxAttempts)
+		})
+	})
+
+	t.Run("polling_interval", func(t *testing.T) {
+		setSectionKey := func(cfg *Cfg, key, value string) {
+			section := cfg.Raw.Section("unified_storage")
+			_, err := section.NewKey(key, value)
+			assert.NoError(t, err)
+		}
+
+		t.Run("defaults to 100ms", func(t *testing.T) {
+			cfg := NewCfg()
+			err := cfg.Load(CommandLineArgs{HomePath: "../../", Config: "../../conf/defaults.ini"})
+			assert.NoError(t, err)
+			cfg.setUnifiedStorageConfig()
+			assert.Equal(t, 100*time.Millisecond, cfg.PollingInterval)
+		})
+
+		t.Run("reads configured value", func(t *testing.T) {
+			cfg := NewCfg()
+			err := cfg.Load(CommandLineArgs{HomePath: "../../", Config: "../../conf/defaults.ini"})
+			assert.NoError(t, err)
+			setSectionKey(cfg, "polling_interval", "500ms")
+			cfg.setUnifiedStorageConfig()
+			assert.Equal(t, 500*time.Millisecond, cfg.PollingInterval)
+		})
+
+		t.Run("reads configured value from env var", func(t *testing.T) {
+			t.Setenv("GF_UNIFIED_STORAGE_POLLING_INTERVAL", "1s")
+			cfg := NewCfg()
+			err := cfg.Load(CommandLineArgs{HomePath: "../../", Config: "../../conf/defaults.ini"})
+			assert.NoError(t, err)
+			cfg.setUnifiedStorageConfig()
+			assert.Equal(t, 1*time.Second, cfg.PollingInterval)
 		})
 	})
 

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -177,6 +177,7 @@ func NewStorageBackend(
 			DBProvider:              eDB,
 			Reg:                     reg,
 			IsHA:                    isHA,
+			PollingInterval:         cfg.PollingInterval,
 			storageMetrics:          storageMetrics,
 			LastImportTimeMaxAge:    cfg.MaxFileIndexAge,
 			GCGate:                  gcGate,

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -171,6 +171,7 @@ func NewStorageBackend(
 			DBProvider:              eDB,
 			Reg:                     reg,
 			IsHA:                    isHA,
+			PollingInterval:         cfg.PollingInterval,
 			storageMetrics:          storageMetrics,
 			LastImportTimeMaxAge:    cfg.MaxFileIndexAge,
 			GCGate:                  gcGate,

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -802,6 +802,12 @@ func createGrafDir(t *testing.T, tmpDir string, opts GrafanaOpts) (string, strin
 		_, err = section.NewKey("resource_version_batch_transaction_timeout", opts.UnifiedStorageResourceVersionBatchTransactionTimeout.String())
 		require.NoError(t, err)
 	}
+	if opts.UnifiedStoragePollingInterval > 0 {
+		section, err := getOrCreateSection("unified_storage")
+		require.NoError(t, err)
+		_, err = section.NewKey("polling_interval", opts.UnifiedStoragePollingInterval.String())
+		require.NoError(t, err)
+	}
 	if opts.MigrationParquetBuffer {
 		section, err := getOrCreateSection("unified_storage")
 		require.NoError(t, err)
@@ -1134,6 +1140,7 @@ type GrafanaOpts struct {
 	// server's ini. Bounds one batched RV WithTx; used by provisioning
 	// integration tests on slow CI.
 	UnifiedStorageResourceVersionBatchTransactionTimeout time.Duration
+	UnifiedStoragePollingInterval 						 time.Duration
 	PermittedProvisioningPaths                           string
 	// Provisioning controls [provisioning] enabled. Zero value (FeatureEnabled)
 	// matches the ini default; set FeatureDisabled for DualWriterMode0/1 tests

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -802,6 +802,12 @@ func createGrafDir(t *testing.T, tmpDir string, opts GrafanaOpts) (string, strin
 		_, err = section.NewKey("resource_version_batch_transaction_timeout", opts.UnifiedStorageResourceVersionBatchTransactionTimeout.String())
 		require.NoError(t, err)
 	}
+	if opts.UnifiedStoragePollingInterval > 0 {
+		section, err := getOrCreateSection("unified_storage")
+		require.NoError(t, err)
+		_, err = section.NewKey("polling_interval", opts.UnifiedStoragePollingInterval.String())
+		require.NoError(t, err)
+	}
 	if opts.MigrationParquetBuffer {
 		section, err := getOrCreateSection("unified_storage")
 		require.NoError(t, err)
@@ -1140,6 +1146,7 @@ type GrafanaOpts struct {
 	// server's ini. Bounds one batched RV WithTx; used by provisioning
 	// integration tests on slow CI.
 	UnifiedStorageResourceVersionBatchTransactionTimeout time.Duration
+	UnifiedStoragePollingInterval 						 time.Duration
 	PermittedProvisioningPaths                           string
 	// Provisioning controls [provisioning] enabled. Zero value (FeatureEnabled)
 	// matches the ini default; set FeatureDisabled for DualWriterMode0/1 tests


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR makes the polling interval used for unified storage with HA configurable.

**Why do we need this feature?**

As described in #106554 current polling may cause intensive database load.

**Who is this feature for?**

Grafana devops

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #106554

**Special notes for your reviewer:** This feature has been implemented with an LLM and reviewed by a human.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
