### PR TITLE
Search: refuse federated trash queries

### DIFF
--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -668,6 +668,16 @@ func (s *searchServer) Search(ctx context.Context, req *resourcepb.ResourceSearc
 		}, nil
 	}
 
+	// Trash authorizes each hit against one index's group and resource, so hits
+	// federated in from another index would be checked against the wrong one.
+	// Refused here rather than further in because resolving a federated index below
+	// can build one.
+	if req.IsDeleted && len(req.Federated) > 0 {
+		return &resourcepb.ResourceSearchResponse{
+			Error: NewBadRequestError("searching deleted resources does not support federated queries"),
+		}, nil
+	}
+
 	stats := NewSearchStats("Search")
 	defer s.logStats(ctx, stats, span, "namespace", req.Options.Key.Namespace, "group", req.Options.Key.Group, "resource", req.Options.Key.Resource, "query", req.Query)
 

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -1366,6 +1366,54 @@ func TestSearchValidatesNegativeLimitAndOffset(t *testing.T) {
 	})
 }
 
+// Trash authorizes each hit against one index's group and resource, so a federated
+// trash search has no correct answer and is refused. The refusal has to come
+// before the federated indexes are resolved, because resolving one can build an
+// index -- hence the assertion on BuildIndex.
+func TestSearchRejectsFederatedTrashQueries(t *testing.T) {
+	backend := &mockSearchBackend{}
+	opts := SearchOptions{
+		Backend: backend,
+		Resources: &TestDocumentBuilderSupplier{
+			GroupsResources: map[string]string{
+				"group": "resource",
+			},
+		},
+		InitMinCount: 1,
+	}
+
+	support, err := newSearchServer(opts, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, support)
+
+	req := &resourcepb.ResourceSearchRequest{
+		Options: &resourcepb.ListOptions{
+			Key: &resourcepb.ResourceKey{
+				Namespace: "ns",
+				Group:     "group",
+				Resource:  "resource",
+			},
+		},
+		Federated: []*resourcepb.ResourceKey{{
+			Namespace: "ns",
+			Group:     "group",
+			Resource:  "resource",
+		}},
+		Limit:     10,
+		IsDeleted: true,
+	}
+
+	rsp, err := support.Search(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, rsp.Error)
+	require.Equal(t, http.StatusBadRequest, int(rsp.Error.Code))
+	require.Equal(t, "searching deleted resources does not support federated queries", rsp.Error.Message)
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	require.Empty(t, backend.buildIndexCalls, "the request must be refused before any index is resolved")
+}
+
 func TestJitterForKey(t *testing.T) {
 	maxAge := 24 * time.Hour
 

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -2327,7 +2327,7 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 	ctx, span := tracer.Start(ctx, "search.bleveIndex.toBleveSearchRequest") //nolint:staticcheck,ineffassign // SA4006: ctx intentionally kept so future code added to this function inherits the traced span
 	defer span.End()
 
-	if errResult := rejectTrashFieldsOnLiveSearch(req); errResult != nil {
+	if errResult := validateTrashRequest(req); errResult != nil {
 		return nil, errResult
 	}
 
@@ -2544,12 +2544,26 @@ func combineFilterAndTextQueries(filters []query.Query, textQuery query.Query) q
 	return bq
 }
 
+// validateTrashRequest enforces the rules that separate trash from live search: a
+// live search cannot name trash-only fields, and a trash search cannot federate.
+// Both live here so a read path cannot apply one rule without the other.
+func validateTrashRequest(req *resourcepb.ResourceSearchRequest) *resourcepb.ErrorResult {
+	if !req.IsDeleted {
+		return rejectTrashFieldsOnLiveSearch(req)
+	}
+	// Trash authorizes each hit against one index's group and resource, so hits
+	// federated in from another index would be checked against the wrong one.
+	// searchServer.Search refuses this before the indexes are resolved; this is the
+	// backstop for callers that reach an index directly.
+	if len(req.Federated) > 0 {
+		return resource.NewBadRequestError("searching deleted resources does not support federated queries")
+	}
+	return nil
+}
+
 // rejectTrashFieldsOnLiveSearch refuses a live search naming a field only deleted
 // documents carry, so a filter that would match nothing fails loudly instead.
 func rejectTrashFieldsOnLiveSearch(req *resourcepb.ResourceSearchRequest) *resourcepb.ErrorResult {
-	if req.IsDeleted {
-		return nil
-	}
 	refused := func(key string) *resourcepb.ErrorResult {
 		return resource.NewBadRequestError(fmt.Sprintf("field %q is only available when searching deleted resources", key))
 	}

--- a/pkg/storage/unified/search/bleve_trash_internal_test.go
+++ b/pkg/storage/unified/search/bleve_trash_internal_test.go
@@ -1,0 +1,81 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+)
+
+// The two rules in validateTrashRequest apply to opposite kinds of request, so
+// each is checked against both kinds: a guard that fires on the wrong one is as
+// broken as a guard that never fires.
+func TestValidateTrashRequest(t *testing.T) {
+	trashField := func(q *resourcepb.ResourceSearchRequest) {
+		q.Fields = []string{resource.SEARCH_FIELD_DELETED_BY}
+	}
+	federated := func(q *resourcepb.ResourceSearchRequest) {
+		q.Federated = []*resourcepb.ResourceKey{{
+			Namespace: "default",
+			Group:     "folder.grafana.app",
+			Resource:  "folders",
+		}}
+	}
+
+	cases := []struct {
+		name    string
+		deleted bool
+		mutate  func(*resourcepb.ResourceSearchRequest)
+		wantMsg string // empty means the request is accepted
+	}{
+		{name: "plain live search", deleted: false},
+		{name: "plain trash search", deleted: true},
+		{
+			name:    "live search naming a trash field",
+			deleted: false,
+			mutate:  trashField,
+			wantMsg: `field "deleted_by" is only available when searching deleted resources`,
+		},
+		{
+			name:    "trash search naming a trash field",
+			deleted: true,
+			mutate:  trashField,
+		},
+		{
+			// Federation is refused for trash only: live search federates
+			// dashboards and folders on the main search path.
+			name:    "live search with federation",
+			deleted: false,
+			mutate:  federated,
+		},
+		{
+			name:    "trash search with federation",
+			deleted: true,
+			mutate:  federated,
+			wantMsg: "searching deleted resources does not support federated queries",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			q := &resourcepb.ResourceSearchRequest{
+				Options:   &resourcepb.ListOptions{Key: &resourcepb.ResourceKey{Namespace: "default"}},
+				IsDeleted: tc.deleted,
+			}
+			if tc.mutate != nil {
+				tc.mutate(q)
+			}
+
+			got := validateTrashRequest(q)
+			if tc.wantMsg == "" {
+				require.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			require.Equal(t, int32(400), got.Code)
+			require.Equal(t, tc.wantMsg, got.Message)
+		})
+	}
+}


### PR DESCRIPTION
Trash authorizes each hit against a single index's group and resource. A federated search joins in hits from another index, which would then be checked against the wrong one, so the two cannot be combined.

Refused in two places. `searchServer.Search` rejects the request before it resolves the federated indexes, because resolving one can build an index. The bleve index repeats the check for callers that reach it directly, next to the existing rule that keeps trash-only fields out of a live search, so a read path cannot apply one rule without the other.

The only caller that sets both flags is the legacy `/api/search?deleted=true` path, which federates dashboards and folders whenever no `type` is given. That path returns nothing today — deleted objects only enter the index when `index_deleted_documents` is set, and it defaults to off — and nothing in the frontend calls it, since the "Recently deleted" page is served by the list path instead. So this turns an empty response into an error rather than changing a working one.

Preparation for trash authorization on the search path, which needs the single-index guarantee.
