### PR TITLE
Apiserver: Enforce global maxAllowedVersion persist cap in apistore.encode

### DIFF
--- a/pkg/services/apiserver/preferred_version.go
+++ b/pkg/services/apiserver/preferred_version.go
@@ -28,7 +28,7 @@ func applyPreferredAPIVersions(logger log.Logger, cfg *setting.Cfg, scheme *runt
 		if part == "" {
 			continue
 		}
-		gv, err := ParseGroupVersionSetting(part)
+		gv, err := ParseGroupVersionSetting(part, "preferred_api_version")
 		if err != nil {
 			return err
 		}
@@ -41,12 +41,17 @@ func applyPreferredAPIVersions(logger log.Logger, cfg *setting.Cfg, scheme *runt
 
 // ParseGroupVersionSetting parses a "group/version" string (e.g.
 // "dashboard.grafana.app/v1") into a GroupVersion. It requires both
-// group and version to be present and non-empty.
-func ParseGroupVersionSetting(s string) (schema.GroupVersion, error) {
+// group and version to be present and non-empty. The optional settingName names
+// the offending config key in the error so a bad value points at the right setting.
+func ParseGroupVersionSetting(s string, settingName ...string) (schema.GroupVersion, error) {
+	key := "group/version"
+	if len(settingName) > 0 && settingName[0] != "" {
+		key = settingName[0]
+	}
 	parts := strings.Split(s, "/")
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		return schema.GroupVersion{}, fmt.Errorf(
-			"invalid preferred_api_version entry %q (expected format is group/version, e.g. dashboard.grafana.app/v1)", s)
+			"invalid %s entry %q (expected format is group/version, e.g. dashboard.grafana.app/v1)", key, s)
 	}
 	return schema.GroupVersion{Group: parts[0], Version: parts[1]}, nil
 }
@@ -117,7 +122,7 @@ func ReorderGroupVersionsForLegacyCodec(logger log.Logger, cfg *setting.Cfg, sch
 		if part == "" {
 			continue
 		}
-		gv, err := ParseGroupVersionSetting(part)
+		gv, err := ParseGroupVersionSetting(part, "preferred_api_version")
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/services/apiserver/preferred_version_test.go
+++ b/pkg/services/apiserver/preferred_version_test.go
@@ -25,6 +25,11 @@ func TestParseGroupVersionSetting(t *testing.T) {
 
 	_, err = ParseGroupVersionSetting("/v1")
 	require.Error(t, err)
+
+	// The error names the offending setting when one is passed.
+	_, err = ParseGroupVersionSetting("bad", "max_allowed_api_version")
+	require.ErrorContains(t, err, "max_allowed_api_version")
+	require.NotContains(t, err.Error(), "preferred_api_version")
 }
 
 func TestApplyPreferredForGroup_ReordersVersions(t *testing.T) {

--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -373,7 +373,7 @@ func (s *service) start(ctx context.Context) error {
 		if s.cfg.EnableVersionPolicy {
 			versionPolicyIni, err := buildVersionPolicyIniLayer(s.cfg)
 			if err != nil {
-				return fmt.Errorf("max_allowed_api_version/preferred_api_version: %w", err)
+				return err
 			}
 			s.vpRegistry = versionpolicy.NewVersionPolicyRegistry(
 				versionpolicy.NewResolver(naturalOrder),

--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -45,6 +45,7 @@ import (
 	grafanaapiserveroptions "github.com/grafana/grafana/pkg/services/apiserver/options"
 	"github.com/grafana/grafana/pkg/services/apiserver/searchroutes"
 	"github.com/grafana/grafana/pkg/services/apiserver/utils"
+	"github.com/grafana/grafana/pkg/services/apiserver/versionpolicy"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -107,6 +108,9 @@ type service struct {
 
 	auditBackend            audit.Backend
 	auditPolicyRuleProvider auditing.PolicyRuleProvider
+
+	// vpRegistry serves the resolved policy consulted by apistore.encode.
+	vpRegistry *versionpolicy.VersionPolicyRegistry
 }
 
 func ProvideService(
@@ -337,6 +341,9 @@ func (s *service) start(ctx context.Context) error {
 		return err
 	}
 
+	// Snapshot natural priority before applyPreferredAPIVersions reorders the scheme, so the cap ranks against natural order and preferred can't weaken it.
+	naturalOrder := naturalOrderSnapshot(s.scheme, groupVersions)
+
 	if err := applyPreferredAPIVersions(s.log, s.cfg, s.scheme, apiResourceConfig); err != nil {
 		return err
 	}
@@ -362,6 +369,19 @@ func (s *service) start(ctx context.Context) error {
 		}
 	} else {
 		getter := apistore.NewRESTOptionsGetterForClient(s.unified, s.secrets, o.RecommendedOptions.Etcd.StorageConfig, s.restConfigProvider)
+
+		if s.cfg.EnableVersionPolicy {
+			versionPolicyIni, err := buildVersionPolicyIniLayer(s.cfg)
+			if err != nil {
+				return fmt.Errorf("max_allowed_api_version/preferred_api_version: %w", err)
+			}
+			s.vpRegistry = versionpolicy.NewVersionPolicyRegistry(
+				versionpolicy.NewResolver(naturalOrder),
+				versionPolicyIni,
+			)
+			getter.SetVersionPolicy(s.vpRegistry)
+		}
+
 		optsregister = getter.RegisterOptions
 		serverConfig.RESTOptionsGetter = getter
 	}

--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -379,6 +379,9 @@ func (s *service) start(ctx context.Context) error {
 				versionpolicy.NewResolver(naturalOrder),
 				versionPolicyIni,
 			)
+			if err := s.vpRegistry.Validate(); err != nil {
+				return err
+			}
 			getter.SetVersionPolicy(s.vpRegistry)
 		}
 

--- a/pkg/services/apiserver/version_policy.go
+++ b/pkg/services/apiserver/version_policy.go
@@ -1,0 +1,68 @@
+package apiserver
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/grafana/grafana/pkg/services/apiserver/versionpolicy"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+// naturalOrderSnapshot captures each group's natural version priority (highest first) before
+// applyPreferredAPIVersions reorders the scheme, so the cap ranks against natural order.
+func naturalOrderSnapshot(scheme *runtime.Scheme, groupVersions []schema.GroupVersion) map[string][]string {
+	order := make(map[string][]string, len(groupVersions))
+	for _, gv := range groupVersions {
+		if _, ok := order[gv.Group]; ok {
+			continue
+		}
+		pvs := scheme.PrioritizedVersionsForGroup(gv.Group)
+		versions := make([]string, 0, len(pvs))
+		for _, v := range pvs {
+			versions = append(versions, v.Version)
+		}
+		order[gv.Group] = versions
+	}
+	return order
+}
+
+// buildVersionPolicyIniLayer parses preferred_api_version and max_allowed_api_version into the resolver's ini layer.
+func buildVersionPolicyIniLayer(cfg *setting.Cfg) (map[string]versionpolicy.VersionPolicy, error) {
+	layer := map[string]versionpolicy.VersionPolicy{}
+	section := cfg.SectionWithEnvOverrides("grafana-apiserver")
+
+	if err := mergeGroupVersionListSetting(section.Key("preferred_api_version").String(), layer,
+		func(p *versionpolicy.VersionPolicy, version string) { p.PreferredVersion = version }); err != nil {
+		return nil, err
+	}
+	if err := mergeGroupVersionListSetting(section.Key("max_allowed_api_version").String(), layer,
+		func(p *versionpolicy.VersionPolicy, version string) { p.MaxAllowedVersion = version }); err != nil {
+		return nil, err
+	}
+	return layer, nil
+}
+
+// mergeGroupVersionListSetting parses a comma-separated group/version list and folds each entry into
+// layer, using setVersion to write the parsed version onto that group's policy.
+func mergeGroupVersionListSetting(csvSetting string, layer map[string]versionpolicy.VersionPolicy, setVersion func(policy *versionpolicy.VersionPolicy, version string)) error {
+	csvSetting = strings.TrimSpace(csvSetting)
+	if csvSetting == "" {
+		return nil
+	}
+	for _, part := range strings.Split(csvSetting, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		gv, err := ParseGroupVersionSetting(part)
+		if err != nil {
+			return err
+		}
+		policy := layer[gv.Group]
+		setVersion(&policy, gv.Version)
+		layer[gv.Group] = policy
+	}
+	return nil
+}

--- a/pkg/services/apiserver/version_policy.go
+++ b/pkg/services/apiserver/version_policy.go
@@ -33,11 +33,11 @@ func buildVersionPolicyIniLayer(cfg *setting.Cfg) (map[string]versionpolicy.Vers
 	layer := map[string]versionpolicy.VersionPolicy{}
 	section := cfg.SectionWithEnvOverrides("grafana-apiserver")
 
-	if err := mergeGroupVersionListSetting(section.Key("preferred_api_version").String(), layer,
+	if err := mergeGroupVersionListSetting("preferred_api_version", section.Key("preferred_api_version").String(), layer,
 		func(p *versionpolicy.VersionPolicy, version string) { p.PreferredVersion = version }); err != nil {
 		return nil, err
 	}
-	if err := mergeGroupVersionListSetting(section.Key("max_allowed_api_version").String(), layer,
+	if err := mergeGroupVersionListSetting("max_allowed_api_version", section.Key("max_allowed_api_version").String(), layer,
 		func(p *versionpolicy.VersionPolicy, version string) { p.MaxAllowedVersion = version }); err != nil {
 		return nil, err
 	}
@@ -45,8 +45,9 @@ func buildVersionPolicyIniLayer(cfg *setting.Cfg) (map[string]versionpolicy.Vers
 }
 
 // mergeGroupVersionListSetting parses a comma-separated group/version list and folds each entry into
-// layer, using setVersion to write the parsed version onto that group's policy.
-func mergeGroupVersionListSetting(csvSetting string, layer map[string]versionpolicy.VersionPolicy, setVersion func(policy *versionpolicy.VersionPolicy, version string)) error {
+// layer, using setVersion to write the parsed version onto that group's policy. settingName names the
+// source config key so a bad entry points at the right setting.
+func mergeGroupVersionListSetting(settingName, csvSetting string, layer map[string]versionpolicy.VersionPolicy, setVersion func(policy *versionpolicy.VersionPolicy, version string)) error {
 	csvSetting = strings.TrimSpace(csvSetting)
 	if csvSetting == "" {
 		return nil
@@ -56,7 +57,7 @@ func mergeGroupVersionListSetting(csvSetting string, layer map[string]versionpol
 		if part == "" {
 			continue
 		}
-		gv, err := ParseGroupVersionSetting(part)
+		gv, err := ParseGroupVersionSetting(part, settingName)
 		if err != nil {
 			return err
 		}

--- a/pkg/services/apiserver/version_policy_test.go
+++ b/pkg/services/apiserver/version_policy_test.go
@@ -11,26 +11,17 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-// A preferred reorder of the scheme must not weaken the maxAllowedVersion cap: the resolver ranks
-// against an immutable snapshot captured before any preferred reorder.
-func TestNaturalOrderSnapshotDecouplesCapFromPreferred(t *testing.T) {
+// The maxAllowedVersion cap ranks major-first (a higher major always outranks), independent of scheme
+// priority — so a preferred reorder cannot move the ceiling, and the whole higher-major line is capped.
+func TestCapRanksMajorFirst(t *testing.T) {
 	const group = "dashboard.grafana.app"
-	v2 := schema.GroupVersion{Group: group, Version: "v2"}
-	v1 := schema.GroupVersion{Group: group, Version: "v1"}
+	gv := func(v string) schema.GroupVersion { return schema.GroupVersion{Group: group, Version: v} }
+	// Dashboard-style priority: the v2 line and v0alpha1 sit above v1 in scheme priority.
+	all := []schema.GroupVersion{gv("v2"), gv("v2beta1"), gv("v2alpha1"), gv("v0alpha1"), gv("v1"), gv("v1beta1")}
 
 	scheme := runtime.NewScheme()
-	// Natural (recency) order registered by the builder: v2 outranks v1.
-	require.NoError(t, scheme.SetVersionPriority(v2, v1))
-	groupVersions := []schema.GroupVersion{v2, v1}
-
-	// Snapshot captured BEFORE the preferred reorder.
-	natural := naturalOrderSnapshot(scheme, groupVersions)
-
-	// Simulate a preferred=v1 reorder: v1 now first in the live scheme.
-	require.NoError(t, scheme.SetVersionPriority(v1, v2))
-	require.Equal(t, "v1", scheme.PrioritizedVersionsForGroup(group)[0].Version,
-		"precondition: preferred reorder must put v1 first in the live scheme")
-	reordered := naturalOrderSnapshot(scheme, groupVersions)
+	require.NoError(t, scheme.SetVersionPriority(all...))
+	groupVersions := all
 
 	capRegistry := func(order map[string][]string) *versionpolicy.VersionPolicyRegistry {
 		return versionpolicy.NewVersionPolicyRegistry(
@@ -38,15 +29,27 @@ func TestNaturalOrderSnapshotDecouplesCapFromPreferred(t *testing.T) {
 			map[string]versionpolicy.VersionPolicy{group: {MaxAllowedVersion: "v1"}})
 	}
 
-	t.Run("snapshot taken before the reorder still rejects v2 over max=v1", func(t *testing.T) {
-		allowed, maxAllowed := capRegistry(natural).IsVersionAllowed(group, "v2")
-		require.False(t, allowed, "v2 must still outrank the max=v1 cap despite the preferred=v1 reorder")
-		require.Equal(t, "v1", maxAllowed)
+	t.Run("the whole v2 line outranks a v1 cap and is rejected", func(t *testing.T) {
+		reg := capRegistry(naturalOrderSnapshot(scheme, groupVersions))
+		for _, v := range []string{"v2", "v2beta1", "v2alpha1"} {
+			allowed, maxAllowed := reg.IsVersionAllowed(group, v)
+			require.False(t, allowed, "%s must be rejected by max=v1", v)
+			require.Equal(t, "v1", maxAllowed)
+		}
 	})
 
-	t.Run("order taken from the reordered scheme would wrongly allow v2 (why the snapshot must precede the reorder)", func(t *testing.T) {
-		allowed, _ := capRegistry(reordered).IsVersionAllowed(group, "v2")
-		require.True(t, allowed, "documents the defect the pre-reorder snapshot fixes")
+	t.Run("lower majors stay below the cap and are allowed", func(t *testing.T) {
+		reg := capRegistry(naturalOrderSnapshot(scheme, groupVersions))
+		for _, v := range []string{"v1", "v1beta1", "v0alpha1"} {
+			allowed, _ := reg.IsVersionAllowed(group, v)
+			require.True(t, allowed, "%s must be allowed under max=v1", v)
+		}
+	})
+
+	t.Run("reordering the scheme does not move the ceiling", func(t *testing.T) {
+		require.NoError(t, scheme.SetVersionPriority(gv("v1"), gv("v2"), gv("v0alpha1"), gv("v2beta1"), gv("v2alpha1"), gv("v1beta1")))
+		allowed, _ := capRegistry(naturalOrderSnapshot(scheme, groupVersions)).IsVersionAllowed(group, "v2beta1")
+		require.False(t, allowed, "v2beta1 still rejected: ranking is major-first, not registration order")
 	})
 }
 

--- a/pkg/services/apiserver/version_policy_test.go
+++ b/pkg/services/apiserver/version_policy_test.go
@@ -1,0 +1,125 @@
+package apiserver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/grafana/grafana/pkg/services/apiserver/versionpolicy"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+// A preferred reorder of the scheme must not weaken the maxAllowedVersion cap: the resolver ranks
+// against an immutable snapshot captured before any preferred reorder.
+func TestNaturalOrderSnapshotDecouplesCapFromPreferred(t *testing.T) {
+	const group = "dashboard.grafana.app"
+	v2 := schema.GroupVersion{Group: group, Version: "v2"}
+	v1 := schema.GroupVersion{Group: group, Version: "v1"}
+
+	scheme := runtime.NewScheme()
+	// Natural (recency) order registered by the builder: v2 outranks v1.
+	require.NoError(t, scheme.SetVersionPriority(v2, v1))
+	groupVersions := []schema.GroupVersion{v2, v1}
+
+	// Snapshot captured BEFORE the preferred reorder.
+	natural := naturalOrderSnapshot(scheme, groupVersions)
+
+	// Simulate a preferred=v1 reorder: v1 now first in the live scheme.
+	require.NoError(t, scheme.SetVersionPriority(v1, v2))
+	require.Equal(t, "v1", scheme.PrioritizedVersionsForGroup(group)[0].Version,
+		"precondition: preferred reorder must put v1 first in the live scheme")
+	reordered := naturalOrderSnapshot(scheme, groupVersions)
+
+	capRegistry := func(order map[string][]string) *versionpolicy.VersionPolicyRegistry {
+		return versionpolicy.NewVersionPolicyRegistry(
+			versionpolicy.NewResolver(order), nil,
+			map[string]versionpolicy.VersionPolicy{group: {MaxAllowedVersion: "v1"}})
+	}
+
+	t.Run("snapshot taken before the reorder still rejects v2 over max=v1", func(t *testing.T) {
+		allowed, maxAllowed := capRegistry(natural).IsVersionAllowed(group, "v2")
+		require.False(t, allowed, "v2 must still outrank the max=v1 cap despite the preferred=v1 reorder")
+		require.Equal(t, "v1", maxAllowed)
+	})
+
+	t.Run("order taken from the reordered scheme would wrongly allow v2 (why the snapshot must precede the reorder)", func(t *testing.T) {
+		allowed, _ := capRegistry(reordered).IsVersionAllowed(group, "v2")
+		require.True(t, allowed, "documents the defect the pre-reorder snapshot fixes")
+	})
+}
+
+func TestBuildVersionPolicyIniLayer(t *testing.T) {
+	t.Run("no settings yields an empty layer", func(t *testing.T) {
+		cfg := setting.NewCfg()
+		layer, err := buildVersionPolicyIniLayer(cfg)
+		require.NoError(t, err)
+		require.Empty(t, layer)
+	})
+
+	t.Run("preferred_api_version only sets PreferredVersion", func(t *testing.T) {
+		cfg := setting.NewCfg()
+		sec := cfg.Raw.Section("grafana-apiserver")
+		_, err := sec.NewKey("preferred_api_version", "dashboard.grafana.app/v1")
+		require.NoError(t, err)
+
+		layer, err := buildVersionPolicyIniLayer(cfg)
+		require.NoError(t, err)
+		require.Equal(t, map[string]versionpolicy.VersionPolicy{
+			"dashboard.grafana.app": {PreferredVersion: "v1"},
+		}, layer)
+	})
+
+	t.Run("max_allowed_api_version only sets MaxAllowedVersion", func(t *testing.T) {
+		cfg := setting.NewCfg()
+		sec := cfg.Raw.Section("grafana-apiserver")
+		_, err := sec.NewKey("max_allowed_api_version", "dashboard.grafana.app/v1")
+		require.NoError(t, err)
+
+		layer, err := buildVersionPolicyIniLayer(cfg)
+		require.NoError(t, err)
+		require.Equal(t, map[string]versionpolicy.VersionPolicy{
+			"dashboard.grafana.app": {MaxAllowedVersion: "v1"},
+		}, layer)
+	})
+
+	t.Run("both settings for the same group merge into one entry", func(t *testing.T) {
+		cfg := setting.NewCfg()
+		sec := cfg.Raw.Section("grafana-apiserver")
+		_, err := sec.NewKey("preferred_api_version", "dashboard.grafana.app/v1beta1")
+		require.NoError(t, err)
+		_, err = sec.NewKey("max_allowed_api_version", "dashboard.grafana.app/v2")
+		require.NoError(t, err)
+
+		layer, err := buildVersionPolicyIniLayer(cfg)
+		require.NoError(t, err)
+		require.Equal(t, map[string]versionpolicy.VersionPolicy{
+			"dashboard.grafana.app": {PreferredVersion: "v1beta1", MaxAllowedVersion: "v2"},
+		}, layer)
+	})
+
+	t.Run("multiple comma-separated groups", func(t *testing.T) {
+		cfg := setting.NewCfg()
+		sec := cfg.Raw.Section("grafana-apiserver")
+		_, err := sec.NewKey("max_allowed_api_version", "dashboard.grafana.app/v1, playlists.grafana.app/v1alpha1")
+		require.NoError(t, err)
+
+		layer, err := buildVersionPolicyIniLayer(cfg)
+		require.NoError(t, err)
+		require.Equal(t, map[string]versionpolicy.VersionPolicy{
+			"dashboard.grafana.app": {MaxAllowedVersion: "v1"},
+			"playlists.grafana.app": {MaxAllowedVersion: "v1alpha1"},
+		}, layer)
+	})
+
+	t.Run("invalid entry in max_allowed_api_version is an error", func(t *testing.T) {
+		cfg := setting.NewCfg()
+		sec := cfg.Raw.Section("grafana-apiserver")
+		_, err := sec.NewKey("max_allowed_api_version", "not-a-valid-gv")
+		require.NoError(t, err)
+
+		_, err = buildVersionPolicyIniLayer(cfg)
+		require.Error(t, err)
+	})
+}

--- a/pkg/services/apiserver/versionpolicy/registry.go
+++ b/pkg/services/apiserver/versionpolicy/registry.go
@@ -68,3 +68,11 @@ func (r *VersionPolicyRegistry) IsVersionAllowed(group, version string) (allowed
 	}
 	return true, max
 }
+
+// HasMaxAllowed reports whether a maxAllowedVersion ceiling is configured for the group. Used to skip
+// buffering on the enforce path when a group has no cap.
+func (r *VersionPolicyRegistry) HasMaxAllowed(group string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.global[group].MaxAllowedVersion != ""
+}

--- a/pkg/services/apiserver/versionpolicy/registry.go
+++ b/pkg/services/apiserver/versionpolicy/registry.go
@@ -4,6 +4,7 @@
 package versionpolicy
 
 import (
+	"fmt"
 	"maps"
 	"sync"
 )
@@ -63,6 +64,14 @@ func (r *VersionPolicyRegistry) IsVersionAllowed(group, version string) (allowed
 	if max == "" {
 		return true, ""
 	}
+	// A cap is configured: a write at an empty, unregistered, or unrankable version cannot be compared
+	// against it, so fail closed rather than let it slip past the ceiling.
+	if !r.resolver.isRegistered(group, version) {
+		return false, max
+	}
+	if _, ok := capRank(version); !ok {
+		return false, max
+	}
 	if r.resolver.Outranks(group, version, max) {
 		return false, max
 	}
@@ -75,4 +84,56 @@ func (r *VersionPolicyRegistry) HasMaxAllowed(group string) bool {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return r.global[group].MaxAllowedVersion != ""
+}
+
+// Validate checks the static boot configuration (defaults, ini) and fails fast on a misconfiguration.
+// The live runtime layer is deliberately not checked here: a bad runtime value must not crash a running
+// server (Resolve drops it with a warn and the last-known policy stands).
+func (r *VersionPolicyRegistry) Validate() error {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	// A typo'd version in boot config would otherwise be dropped silently, leaving the operator believing
+	// a cap is in force when it is not, so an unregistered version in a known group is a hard error. A
+	// whole unknown group, though, is expected on a shared/fleet config (feature toggle off, edition
+	// difference) — warn and skip it, matching applyPreferredAPIVersions, rather than fail this instance.
+	for _, layer := range r.base {
+		for group, p := range layer {
+			if !r.resolver.hasGroup(group) {
+				logger.Warn("ignoring version policy for group not registered on this instance", "group", group)
+				continue
+			}
+			if p.PreferredVersion != "" && !r.resolver.isRegistered(group, p.PreferredVersion) {
+				return fmt.Errorf("version policy: preferredVersion %q for group %q is not a registered version",
+					p.PreferredVersion, group)
+			}
+			if p.MaxAllowedVersion != "" && !r.resolver.isRegistered(group, p.MaxAllowedVersion) {
+				return fmt.Errorf("version policy: maxAllowedVersion %q for group %q is not a registered version",
+					p.MaxAllowedVersion, group)
+			}
+		}
+	}
+
+	// Discovery advertises the configured preferredVersion, or — when none is set — the group's natural
+	// first version. If that advertised version outranks the cap, discovery-following clients would write
+	// a version apistore.encode rejects (400). Capping below the natural preferred therefore requires
+	// also setting preferredVersion; reject the config at boot rather than serve a self-contradicting API.
+	for group, p := range r.global {
+		if p.MaxAllowedVersion == "" {
+			continue
+		}
+		advertised := p.PreferredVersion
+		if advertised == "" {
+			advertised = r.resolver.naturalPreferred(group)
+		}
+		if advertised != "" && r.resolver.Outranks(group, advertised, p.MaxAllowedVersion) {
+			if p.PreferredVersion == "" {
+				return fmt.Errorf("version policy for group %q: maxAllowedVersion %q is below the version %q that discovery advertises; set preferredVersion to %q or lower",
+					group, p.MaxAllowedVersion, advertised, p.MaxAllowedVersion)
+			}
+			return fmt.Errorf("version policy for group %q: preferredVersion %q outranks maxAllowedVersion %q",
+				group, p.PreferredVersion, p.MaxAllowedVersion)
+		}
+	}
+	return nil
 }

--- a/pkg/services/apiserver/versionpolicy/registry_test.go
+++ b/pkg/services/apiserver/versionpolicy/registry_test.go
@@ -87,8 +87,89 @@ func TestVersionPolicyRegistryIsVersionAllowed(t *testing.T) {
 		assert.True(t, allowed)
 		assert.Empty(t, maxAllowed)
 	})
-	t.Run("unregistered version is allowed (never ranks above the cap)", func(t *testing.T) {
-		allowed, _ := capReg("v1").IsVersionAllowed("foo.grafana.app", "v99")
-		assert.True(t, allowed)
+	t.Run("unregistered or empty version fails closed on a capped group", func(t *testing.T) {
+		allowed, maxAllowed := capReg("v1").IsVersionAllowed("foo.grafana.app", "v99")
+		assert.False(t, allowed)
+		assert.Equal(t, "v1", maxAllowed)
+
+		allowed, _ = capReg("v1").IsVersionAllowed("foo.grafana.app", "")
+		assert.False(t, allowed)
+	})
+
+	t.Run("a registered but unparseable version fails closed on a capped group", func(t *testing.T) {
+		// "weird" is in the registered set but does not parse as a Kubernetes version, so it cannot be
+		// ranked against the cap — it must fail closed rather than slip through.
+		order := map[string][]string{"foo.grafana.app": {"v1", "weird"}}
+		r := newTestRegistry(order, nil, map[string]VersionPolicy{"foo.grafana.app": {MaxAllowedVersion: "v1"}})
+		allowed, _ := r.IsVersionAllowed("foo.grafana.app", "weird")
+		assert.False(t, allowed)
+	})
+
+	t.Run("cap is major-first: v1 blocks the whole v2 line but allows lower majors", func(t *testing.T) {
+		// dashboard-style order: v0alpha1 sits above v1 in scheme priority, and CompareKubeAwareVersionStrings
+		// would rank GA v1 above v2beta1/v2alpha1 — both wrong for a persist ceiling.
+		order := map[string][]string{"foo.grafana.app": {"v2", "v2beta1", "v2alpha1", "v0alpha1", "v1", "v1beta1"}}
+		r := newTestRegistry(order, nil, map[string]VersionPolicy{"foo.grafana.app": {MaxAllowedVersion: "v1"}})
+
+		for _, blocked := range []string{"v2", "v2beta1", "v2alpha1"} {
+			allowed, _ := r.IsVersionAllowed("foo.grafana.app", blocked)
+			assert.False(t, allowed, "%s should be blocked by max=v1 (higher major)", blocked)
+		}
+		for _, ok := range []string{"v1", "v1beta1", "v0alpha1"} {
+			allowed, _ := r.IsVersionAllowed("foo.grafana.app", ok)
+			assert.True(t, allowed, "%s should be allowed under max=v1", ok)
+		}
+	})
+}
+
+func TestVersionPolicyRegistryValidate(t *testing.T) {
+	t.Run("preferred outranking max is rejected", func(t *testing.T) {
+		r := newTestRegistry(fooOrder, nil,
+			map[string]VersionPolicy{"foo.grafana.app": {PreferredVersion: "v2", MaxAllowedVersion: "v1"}})
+		err := r.Validate()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "foo.grafana.app")
+	})
+
+	t.Run("preferred at or below max is allowed", func(t *testing.T) {
+		r := newTestRegistry(fooOrder, nil,
+			map[string]VersionPolicy{"foo.grafana.app": {PreferredVersion: "v1beta1", MaxAllowedVersion: "v1"}})
+		assert.NoError(t, r.Validate())
+	})
+
+	// fooOrder's natural (highest-priority) version is v2, so it is what discovery advertises when no
+	// preferredVersion is configured.
+	t.Run("cap below the natural preferred with no preferredVersion set is rejected", func(t *testing.T) {
+		r := newTestRegistry(fooOrder, nil,
+			map[string]VersionPolicy{"foo.grafana.app": {MaxAllowedVersion: "v1"}})
+		err := r.Validate()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "discovery advertises")
+	})
+
+	t.Run("cap at or above the natural preferred with no preferredVersion set is allowed", func(t *testing.T) {
+		r := newTestRegistry(fooOrder, nil,
+			map[string]VersionPolicy{"foo.grafana.app": {MaxAllowedVersion: "v2"}})
+		assert.NoError(t, r.Validate())
+	})
+
+	t.Run("cap below the natural preferred is allowed once preferredVersion is set to the cap", func(t *testing.T) {
+		r := newTestRegistry(fooOrder, nil,
+			map[string]VersionPolicy{"foo.grafana.app": {PreferredVersion: "v1", MaxAllowedVersion: "v1"}})
+		assert.NoError(t, r.Validate())
+	})
+
+	t.Run("an unregistered version in a known group is a hard error, not a silent drop", func(t *testing.T) {
+		r := newTestRegistry(fooOrder, nil,
+			map[string]VersionPolicy{"foo.grafana.app": {MaxAllowedVersion: "vtypo"}})
+		err := r.Validate()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "vtypo")
+	})
+
+	t.Run("a policy for a group not registered on this instance is skipped, not a boot failure", func(t *testing.T) {
+		r := newTestRegistry(fooOrder, nil,
+			map[string]VersionPolicy{"not-on-this-instance.grafana.app": {PreferredVersion: "v1", MaxAllowedVersion: "v1"}})
+		assert.NoError(t, r.Validate())
 	})
 }

--- a/pkg/services/apiserver/versionpolicy/resolver.go
+++ b/pkg/services/apiserver/versionpolicy/resolver.go
@@ -1,19 +1,33 @@
 package versionpolicy
 
 import (
+	"regexp"
+	"strconv"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 )
 
 var logger = log.New("versionpolicy")
 
-// Resolver merges policy layers and ranks versions against an immutable snapshot of each group's
-// natural (registration) order — highest priority first. The snapshot is captured at construction, so
-// a later preferred-version change to the live scheme cannot move the enforcement ceiling.
+// versionRE parses a Kubernetes version string into (major, stage, stageNumber).
+var versionRE = regexp.MustCompile(`^v(\d+)(?:(alpha|beta)(\d+))?$`)
+
+// Resolver merges policy layers and ranks versions for the maxAllowedVersion ceiling. Ranking is
+// major-first, then maturity within the major (ga > beta > alpha), then stage number — so a higher
+// major always outranks (a v1 cap rejects v2, v2beta1 and v2alpha1 alike) while a lower major is below
+// the cap (v0alpha1 stays writable under a v1 cap). This is deliberately not scheme priority (which can
+// place v0alpha1 above v1) nor CompareKubeAwareVersionStrings (which ranks GA above every pre-release of
+// any major, letting v2beta1 slip under a v1 cap). Cap ranking does not use the per-group slice, but the
+// slice is still ordered and significant in two other ways: membership validates config and fails writes
+// at unknown versions closed, and its head (highest priority) is the group's natural preferred version —
+// what discovery advertises when no preferredVersion is configured (see naturalPreferred).
 type Resolver struct {
+	// order maps a group to its registered versions in scheme priority order, highest first.
 	order map[string][]string
 }
 
-// NewResolver captures an immutable snapshot of group -> versions (highest priority first).
+// NewResolver snapshots each group's registered versions in priority order (highest first); order[0] is
+// the group's natural preferred version.
 func NewResolver(order map[string][]string) *Resolver {
 	snapshot := make(map[string][]string, len(order))
 	for group, versions := range order {
@@ -78,28 +92,64 @@ func (r *Resolver) resolveField(group, field string, layers ...string) string {
 	return result
 }
 
-func (r *Resolver) isRegistered(group, version string) bool {
-	_, ok := r.rank(group, version)
-	return ok
+// hasGroup reports whether the group is registered (served) on this instance.
+func (r *Resolver) hasGroup(group string) bool {
+	return len(r.order[group]) > 0
 }
 
-// rank returns version's priority index (lower = higher priority) and whether it is registered,
-// against the immutable snapshot.
-func (r *Resolver) rank(group, version string) (int, bool) {
-	for i, v := range r.order[group] {
+// naturalPreferred returns the group's highest-priority registered version — what discovery advertises
+// as preferred when no preferredVersion is configured. "" if the group is unknown.
+func (r *Resolver) naturalPreferred(group string) string {
+	if o := r.order[group]; len(o) > 0 {
+		return o[0]
+	}
+	return ""
+}
+
+func (r *Resolver) isRegistered(group, version string) bool {
+	for _, v := range r.order[group] {
 		if v == version {
-			return i, true
+			return true
 		}
 	}
-	return 0, false
+	return false
 }
 
-// Outranks reports whether a ranks strictly higher than b; false if equal or either is unregistered.
+// Outranks reports whether version a is strictly above b for a persist ceiling (major, then maturity,
+// then stage number); false if equal or either is not a registered, parseable version for the group.
 func (r *Resolver) Outranks(group, a, b string) bool {
-	rankA, okA := r.rank(group, a)
-	rankB, okB := r.rank(group, b)
-	if !okA || !okB {
+	if !r.isRegistered(group, a) || !r.isRegistered(group, b) {
 		return false
 	}
-	return rankA < rankB
+	ra, oka := capRank(a)
+	rb, okb := capRank(b)
+	if !oka || !okb {
+		return false
+	}
+	for i := range ra {
+		if ra[i] != rb[i] {
+			return ra[i] > rb[i]
+		}
+	}
+	return false
+}
+
+// capRank turns a version string into a comparable [major, stage, stageNumber] tuple, stage being
+// alpha=0, beta=1, ga=2. ok is false when the string is not a recognized Kubernetes version.
+func capRank(version string) ([3]int, bool) {
+	m := versionRE.FindStringSubmatch(version)
+	if m == nil {
+		return [3]int{}, false
+	}
+	major, _ := strconv.Atoi(m[1])
+	switch m[2] {
+	case "": // no pre-release suffix: GA
+		return [3]int{major, 2, 0}, true
+	case "beta":
+		n, _ := strconv.Atoi(m[3])
+		return [3]int{major, 1, n}, true
+	default: // alpha
+		n, _ := strconv.Atoi(m[3])
+		return [3]int{major, 0, n}, true
+	}
 }

--- a/pkg/services/apiserver/versionpolicy/resolver_test.go
+++ b/pkg/services/apiserver/versionpolicy/resolver_test.go
@@ -122,3 +122,25 @@ func TestResolverOutranks(t *testing.T) {
 	assert.False(t, r.Outranks("foo.grafana.app", "v2", "v99"), "unregistered version never outranks or is outranked")
 	assert.False(t, r.Outranks("unknown.grafana.app", "v1", "v2"), "unregistered group never ranks")
 }
+
+func TestResolverOutranksMajorFirst(t *testing.T) {
+	// Registered set spanning two majors and all stages.
+	order := map[string][]string{"g": {"v2", "v2beta1", "v2alpha1", "v1", "v1beta1", "v1alpha1", "v0alpha1"}}
+	r := NewResolver(order)
+	o := func(a, b string) bool { return r.Outranks("g", a, b) }
+
+	// Higher major always outranks, regardless of stage — a v1 cap must reject the whole v2 line.
+	assert.True(t, o("v2", "v1"))
+	assert.True(t, o("v2beta1", "v1"), "v2beta1 outranks v1 (higher major)")
+	assert.True(t, o("v2alpha1", "v1"), "v2alpha1 outranks v1 (higher major)")
+
+	// Lower major stays below the cap.
+	assert.False(t, o("v0alpha1", "v1"), "v0alpha1 is below a v1 cap")
+	assert.False(t, o("v1beta1", "v1"), "v1beta1 (pre-release of same major) is below v1")
+	assert.False(t, o("v1alpha1", "v1"))
+
+	// Within a major: ga > beta > alpha, then stage number.
+	assert.True(t, o("v1", "v1beta1"))
+	assert.True(t, o("v2beta1", "v2alpha1"))
+	assert.False(t, o("v1", "v1"), "a version does not outrank itself")
+}

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -897,6 +897,12 @@ type Cfg struct {
 	// only; OSS keeps the no-op path. Default off.
 	EnableEmbeddedAPIExtensions bool
 
+	// EnableVersionPolicy turns on the global API version policy (preferred and
+	// max-allowed API version per group). Off leaves today's behavior unchanged.
+	// Temporary opt-in kill-switch while the feature is experimental; remove it and
+	// enforce unconditionally once the version policy is enabled by default.
+	EnableVersionPolicy bool
+
 	// Enable playlist reconciler
 	EnablePlaylistsReconciler bool
 }
@@ -1937,6 +1943,7 @@ func (cfg *Cfg) readStartupParams(iniFile *ini.File) {
 	cfg.EnableKubernetesAggregator = iniFile.Section("grafana-apiserver").Key("kubernetes_aggregator_enabled").MustBool(false)
 	cfg.EnableKubernetesAggregatorCapTokenAuth = iniFile.Section("grafana-apiserver").Key("kubernetes_aggregator_cap_token_auth_enabled").MustBool(false)
 	cfg.EnableEmbeddedAPIExtensions = iniFile.Section("grafana-apiserver").Key("apiextensions_enabled").MustBool(false)
+	cfg.EnableVersionPolicy = iniFile.Section("grafana-apiserver").Key("version_policy_enabled").MustBool(false)
 }
 func (cfg *Cfg) LogConfigSources() {
 	var text bytes.Buffer

--- a/pkg/storage/unified/apistore/prepare.go
+++ b/pkg/storage/unified/apistore/prepare.go
@@ -220,7 +220,7 @@ func (s *Storage) prepareObjectForStorage(ctx context.Context, newObject runtime
 		return v, err
 	}
 
-	err = s.encode(newObject, &v.raw)
+	err = s.encode(newObject, &v.raw, true)
 	return v, err
 }
 
@@ -365,7 +365,11 @@ func (s *Storage) prepareObjectForUpdate(ctx context.Context, updateObject runti
 		obj.SetAnnotation(utils.AnnoKeyUpdatedTimestamp, previous.GetAnnotation(utils.AnnoKeyUpdatedTimestamp))
 	}
 
-	err = s.encode(updateObject, &v.raw)
+	// Enforce the cap on updates too, so an object stored above the cap cannot keep being mutated — except
+	// for deletion. A soft delete sets the deletionTimestamp (and finalizer/status writes run while it is
+	// set); exempt those so an already-over-cap object stays removable. Net: over-cap objects are drain-only.
+	deleting := obj.GetDeletionTimestamp() != nil || previous.GetDeletionTimestamp() != nil
+	err = s.encode(updateObject, &v.raw, !deleting)
 	return v, err
 }
 
@@ -435,9 +439,12 @@ func (s *Storage) checkGVK(obj runtime.Object) error {
 	return nil
 }
 
-func (s *Storage) encode(obj runtime.Object, buf *bytes.Buffer) error {
+// encode serializes obj into buf. enforceCap applies the group's maxAllowedVersion ceiling. Callers pass
+// true on create and on non-deletion updates; deletion-related updates pass false so an object already
+// stored above the cap stays removable (its deletion, finalizer and status writes all go through here).
+func (s *Storage) encode(obj runtime.Object, buf *bytes.Buffer, enforceCap bool) error {
 	if s.opts.Scheme == nil {
-		return s.encodeViaCodec(obj, buf)
+		return s.encodeViaCodec(obj, buf, enforceCap)
 	}
 	if err := s.checkGVK(obj); err != nil {
 		return err
@@ -446,8 +453,10 @@ func (s *Storage) encode(obj runtime.Object, buf *bytes.Buffer) error {
 	// This always writes the saved GVK, unlike:
 	// https://github.com/kubernetes/kubernetes/blob/v1.34.3/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go#L267
 	// that picks an arbitrary GVK that may not match the same group!
-	if err := s.enforceMaxAllowedVersion(obj.GetObjectKind().GroupVersionKind().Version); err != nil {
-		return err
+	if enforceCap {
+		if err := s.enforceMaxAllowedVersion(obj.GetObjectKind().GroupVersionKind().Version); err != nil {
+			return err
+		}
 	}
 	return json.NewEncoder(buf).Encode(obj)
 }
@@ -456,14 +465,22 @@ func (s *Storage) encode(obj runtime.Object, buf *bytes.Buffer) error {
 // to a higher-priority storage version, so the cap is enforced against the persisted apiVersion read back
 // from the encoded bytes, not the declared version. Encoding goes straight into the destination buffer;
 // a rejected write resets it so no rejected payload is retained.
-func (s *Storage) encodeViaCodec(obj runtime.Object, buf *bytes.Buffer) error {
+func (s *Storage) encodeViaCodec(obj runtime.Object, buf *bytes.Buffer, enforceCap bool) error {
 	if err := s.codec.Encode(obj, buf); err != nil {
 		return err
 	}
-	if s.opts.VersionPolicy == nil || !s.opts.VersionPolicy.HasMaxAllowed(s.gr.Group) {
+	if !enforceCap || s.opts.VersionPolicy == nil || !s.opts.VersionPolicy.HasMaxAllowed(s.gr.Group) {
 		return nil
 	}
-	if err := s.enforceMaxAllowedVersion(persistedVersion(buf.Bytes(), obj)); err != nil {
+	gv := persistedVersion(buf.Bytes(), obj)
+	// The versioning codec may pick a GVK outside this resource's group. Such a version cannot be ranked
+	// against the group's cap (it would look unregistered and slip through), so reject rather than store it.
+	if gv.Group != s.gr.Group {
+		buf.Reset()
+		return apierrors.NewBadRequest(fmt.Sprintf(
+			"%s: encoded apiVersion group %q does not match resource group %q", s.gr.String(), gv.Group, s.gr.Group))
+	}
+	if err := s.enforceMaxAllowedVersion(gv.Version); err != nil {
 		buf.Reset()
 		return err
 	}
@@ -471,7 +488,9 @@ func (s *Storage) encodeViaCodec(obj runtime.Object, buf *bytes.Buffer) error {
 }
 
 // enforceMaxAllowedVersion rejects (never rewrites) a write whose version outranks the group's configured maxAllowedVersion.
-// Protects unified storage in every mode, but only fails the request when unified is synchronous; legacy-primary dual-write persists to legacy and rejects only the background unified copy.
+// This is a REST-write-path check in apistore.encode: it does not cover writes that bypass apistore (bulk
+// import via BulkStore, direct ResourceClient callers, migrations), and under legacy-primary dual-write an
+// over-cap write still lands in legacy while only the background unified copy is rejected.
 func (s *Storage) enforceMaxAllowedVersion(version string) error {
 	if s.opts.VersionPolicy == nil {
 		return nil
@@ -485,15 +504,15 @@ func (s *Storage) enforceMaxAllowedVersion(version string) error {
 		s.gr.String(), version, maxAllowed, s.gr.Group))
 }
 
-// persistedVersion reads the apiVersion actually written by the codec, so the cap is enforced against
-// the stored version. It falls back to the object's declared version if the encoded form has no
-// parseable TypeMeta, so it never silently skips the cap.
-func persistedVersion(encoded []byte, obj runtime.Object) string {
+// persistedVersion reads the group/version actually written by the codec, so the cap is enforced against
+// the stored version. It falls back to the object's declared GVK if the encoded form has no parseable
+// TypeMeta, so it never silently skips the cap.
+func persistedVersion(encoded []byte, obj runtime.Object) schema.GroupVersion {
 	var tm metav1.TypeMeta
 	if json.Unmarshal(encoded, &tm) == nil && tm.APIVersion != "" {
 		if gv, err := schema.ParseGroupVersion(tm.APIVersion); err == nil {
-			return gv.Version
+			return gv
 		}
 	}
-	return obj.GetObjectKind().GroupVersionKind().Version
+	return obj.GetObjectKind().GroupVersionKind().GroupVersion()
 }

--- a/pkg/storage/unified/apistore/prepare.go
+++ b/pkg/storage/unified/apistore/prepare.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"strconv"
 	"time"
 
@@ -15,6 +14,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -435,17 +435,65 @@ func (s *Storage) checkGVK(obj runtime.Object) error {
 	return nil
 }
 
-func (s *Storage) encode(obj runtime.Object, w io.Writer) error {
-	// The standard encoder is fine when only one type maps to a group
+func (s *Storage) encode(obj runtime.Object, buf *bytes.Buffer) error {
 	if s.opts.Scheme == nil {
-		return s.codec.Encode(obj, w)
+		return s.encodeViaCodec(obj, buf)
 	}
 	if err := s.checkGVK(obj); err != nil {
 		return err
 	}
-
-	// This will always write the saved GVK, unlike:
+	// The JSON encoder writes obj's own (checkGVK-resolved) GVK, so the checked version is the persisted version.
+	// This always writes the saved GVK, unlike:
 	// https://github.com/kubernetes/kubernetes/blob/v1.34.3/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go#L267
 	// that picks an arbitrary GVK that may not match the same group!
-	return json.NewEncoder(w).Encode(obj)
+	if err := s.enforceMaxAllowedVersion(obj.GetObjectKind().GroupVersionKind().Version); err != nil {
+		return err
+	}
+	return json.NewEncoder(buf).Encode(obj)
+}
+
+// encodeViaCodec serializes through the versioning codec (no scheme). That codec may convert the object
+// to a higher-priority storage version, so the cap is enforced against the persisted apiVersion read back
+// from the encoded bytes, not the declared version. Encoding goes straight into the destination buffer;
+// a rejected write resets it so no rejected payload is retained.
+func (s *Storage) encodeViaCodec(obj runtime.Object, buf *bytes.Buffer) error {
+	if err := s.codec.Encode(obj, buf); err != nil {
+		return err
+	}
+	if s.opts.VersionPolicy == nil || !s.opts.VersionPolicy.HasMaxAllowed(s.gr.Group) {
+		return nil
+	}
+	if err := s.enforceMaxAllowedVersion(persistedVersion(buf.Bytes(), obj)); err != nil {
+		buf.Reset()
+		return err
+	}
+	return nil
+}
+
+// enforceMaxAllowedVersion rejects (never rewrites) a write whose version outranks the group's configured maxAllowedVersion.
+// Protects unified storage in every mode, but only fails the request when unified is synchronous; legacy-primary dual-write persists to legacy and rejects only the background unified copy.
+func (s *Storage) enforceMaxAllowedVersion(version string) error {
+	if s.opts.VersionPolicy == nil {
+		return nil
+	}
+	allowed, maxAllowed := s.opts.VersionPolicy.IsVersionAllowed(s.gr.Group, version)
+	if allowed {
+		return nil
+	}
+	return apierrors.NewBadRequest(fmt.Sprintf(
+		"%s: version %s exceeds the configured maximum version %s for group %s",
+		s.gr.String(), version, maxAllowed, s.gr.Group))
+}
+
+// persistedVersion reads the apiVersion actually written by the codec, so the cap is enforced against
+// the stored version. It falls back to the object's declared version if the encoded form has no
+// parseable TypeMeta, so it never silently skips the cap.
+func persistedVersion(encoded []byte, obj runtime.Object) string {
+	var tm metav1.TypeMeta
+	if json.Unmarshal(encoded, &tm) == nil && tm.APIVersion != "" {
+		if gv, err := schema.ParseGroupVersion(tm.APIVersion); err == nil {
+			return gv.Version
+		}
+	}
+	return obj.GetObjectKind().GroupVersionKind().Version
 }

--- a/pkg/storage/unified/apistore/prepare_test.go
+++ b/pkg/storage/unified/apistore/prepare_test.go
@@ -896,7 +896,7 @@ func TestEncodeMaxVersionEnforcement(t *testing.T) {
 		s := newStorage(dashv1.DashboardResourceInfo.GroupResource(), reg)
 
 		var buf bytes.Buffer
-		err := s.encode(dashboardAt("v2"), &buf)
+		err := s.encode(dashboardAt("v2"), &buf, true)
 
 		require.Error(t, err)
 		require.True(t, apierrors.IsBadRequest(err) || apierrors.IsConflict(err), "expected a 4xx, got %v", err)
@@ -908,7 +908,7 @@ func TestEncodeMaxVersionEnforcement(t *testing.T) {
 		s := newStorage(dashv1.DashboardResourceInfo.GroupResource(), reg)
 
 		var buf bytes.Buffer
-		err := s.encode(dashboardAt("v1"), &buf)
+		err := s.encode(dashboardAt("v1"), &buf, true)
 		require.NoError(t, err)
 
 		out := &unstructured.Unstructured{}
@@ -920,7 +920,7 @@ func TestEncodeMaxVersionEnforcement(t *testing.T) {
 		s := newStorage(dashv1.DashboardResourceInfo.GroupResource(), nil)
 
 		var buf bytes.Buffer
-		err := s.encode(dashboardAt("v2"), &buf)
+		err := s.encode(dashboardAt("v2"), &buf, true)
 		require.NoError(t, err)
 	})
 
@@ -940,7 +940,7 @@ func TestEncodeMaxVersionEnforcement(t *testing.T) {
 		// declared version and let this through; the fix rejects against the persisted v2.
 		reg := newGlobalCapRegistry(group, []string{"v2", "v1"}, "v1")
 		var buf bytes.Buffer
-		err := codecStorage(reg, "v2").encode(dashboardAt("v1"), &buf)
+		err := codecStorage(reg, "v2").encode(dashboardAt("v1"), &buf, true)
 
 		require.Error(t, err)
 		require.True(t, apierrors.IsBadRequest(err), "expected a 4xx, got %v", err)
@@ -951,7 +951,7 @@ func TestEncodeMaxVersionEnforcement(t *testing.T) {
 	t.Run("codec path: persisted version at/under cap is allowed", func(t *testing.T) {
 		reg := newGlobalCapRegistry(group, []string{"v2", "v1"}, "v2")
 		var buf bytes.Buffer
-		require.NoError(t, codecStorage(reg, "v1").encode(dashboardAt("v1"), &buf))
+		require.NoError(t, codecStorage(reg, "v1").encode(dashboardAt("v1"), &buf, true))
 		out := &unstructured.Unstructured{}
 		require.NoError(t, json.Unmarshal(buf.Bytes(), out))
 		require.Equal(t, group+"/v1", out.GetAPIVersion())
@@ -960,7 +960,37 @@ func TestEncodeMaxVersionEnforcement(t *testing.T) {
 	t.Run("codec path: uncapped group encodes directly", func(t *testing.T) {
 		reg := newGlobalCapRegistry(group, []string{"v2", "v1"}, "") // no cap for the group
 		var buf bytes.Buffer
-		require.NoError(t, codecStorage(reg, "v2").encode(dashboardAt("v2"), &buf))
+		require.NoError(t, codecStorage(reg, "v2").encode(dashboardAt("v2"), &buf, true))
+	})
+
+	t.Run("codec path: a persisted version from another group is rejected, not silently allowed", func(t *testing.T) {
+		// The codec picks a GVK outside the resource's group. That version cannot be ranked against the
+		// group's cap, so it must be rejected rather than slip through as unregistered.
+		reg := newGlobalCapRegistry(group, []string{"v2", "v1"}, "v1")
+		s := &Storage{
+			gr: dashv1.DashboardResourceInfo.GroupResource(),
+			codec: upcastCodec{
+				Codec:      apitesting.TestCodec(rtcodecs, dashv1.DashboardResourceInfo.GroupVersion()),
+				apiVersion: "other.grafana.app/v1",
+			},
+			opts: StorageOptions{Scheme: nil, VersionPolicy: reg},
+		}
+		var buf bytes.Buffer
+		err := s.encode(dashboardAt("v1"), &buf, true)
+		require.True(t, apierrors.IsBadRequest(err), "expected a 4xx, got %v", err)
+		require.Contains(t, err.Error(), "does not match resource group")
+		require.Zero(t, buf.Len())
+	})
+
+	t.Run("enforceCap=false (deletion path) allows an over-cap write", func(t *testing.T) {
+		reg := newGlobalCapRegistry(group, []string{"v2", "v1"}, "v1")
+		s := newStorage(dashv1.DashboardResourceInfo.GroupResource(), reg)
+		var buf bytes.Buffer
+		// enforceCap=false is used for deletion-related updates: a v2 write (over the v1 cap) is allowed.
+		require.NoError(t, s.encode(dashboardAt("v2"), &buf, false))
+		out := &unstructured.Unstructured{}
+		require.NoError(t, json.Unmarshal(buf.Bytes(), out))
+		require.Equal(t, group+"/v2", out.GetAPIVersion())
 	})
 }
 
@@ -974,4 +1004,55 @@ type upcastCodec struct {
 func (c upcastCodec) Encode(_ runtime.Object, w io.Writer) error {
 	_, err := fmt.Fprintf(w, `{"apiVersion":%q,"kind":"Dashboard","metadata":{"name":"x"}}`, c.apiVersion)
 	return err
+}
+
+// TestUpdateCapExemptsDeletion covers the drain-only policy: an object stored above the cap cannot be
+// mutated by a regular update, but soft delete and the writes that complete deletion still go through.
+func TestUpdateCapExemptsDeletion(t *testing.T) {
+	_ = dashv1.AddToScheme(rtscheme)
+	group := dashv1.DashboardResourceInfo.GroupResource().Group
+	node, err := snowflake.NewNode(1)
+	require.NoError(t, err)
+	s := &Storage{
+		gr:        dashv1.DashboardResourceInfo.GroupResource(),
+		codec:     apitesting.TestCodec(rtcodecs, dashv1.DashboardResourceInfo.GroupVersion()),
+		snowflake: node,
+		opts: StorageOptions{
+			Scheme:            rtscheme,
+			MaximumNameLength: 100,
+			VersionPolicy:     newGlobalCapRegistry(group, []string{"v2", "v1"}, "v1"),
+		},
+	}
+	ctx := authlib.WithAuthInfo(context.Background(),
+		&identity.StaticRequester{UserID: 1, UserUID: "u1", Type: authlib.TypeUser})
+
+	// previous is stored above the v1 cap.
+	prev := func() *dashv1.Dashboard {
+		d := dashboardAt("v2")
+		d.UID = "uid-1"
+		return d
+	}
+
+	t.Run("a regular update to an over-cap object is rejected", func(t *testing.T) {
+		_, err := s.prepareObjectForUpdate(ctx, dashboardAt("v2"), prev())
+		require.True(t, apierrors.IsBadRequest(err), "expected a 4xx, got %v", err)
+	})
+
+	t.Run("a soft delete (sets deletionTimestamp) on an over-cap object is allowed", func(t *testing.T) {
+		now := v1.Now()
+		upd := dashboardAt("v2")
+		upd.DeletionTimestamp = &now
+		_, err := s.prepareObjectForUpdate(ctx, upd, prev())
+		require.NoError(t, err)
+	})
+
+	t.Run("a write while deletionTimestamp is already set is allowed (finalizer/status)", func(t *testing.T) {
+		now := v1.Now()
+		p := prev()
+		p.DeletionTimestamp = &now
+		upd := dashboardAt("v2")
+		upd.DeletionTimestamp = &now
+		_, err := s.prepareObjectForUpdate(ctx, upd, p)
+		require.NoError(t, err)
+	})
 }

--- a/pkg/storage/unified/apistore/prepare_test.go
+++ b/pkg/storage/unified/apistore/prepare_test.go
@@ -1,9 +1,12 @@
 package apistore
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"math/rand/v2"
 	"strings"
 	"testing"
@@ -17,6 +20,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/client-go/dynamic"
@@ -26,6 +30,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/services/apiserver/versionpolicy"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
@@ -846,4 +851,127 @@ func (f *fakeSearchIndex) Search(_ context.Context, req *resourcepb.ResourceSear
 		}
 	}
 	return rsp, nil
+}
+
+// fakeOrder builds an immutable version-order snapshot for a single group (highest first).
+func fakeOrder(group string, order ...string) map[string][]string {
+	return map[string][]string{group: order}
+}
+
+// dashboardAt returns a dashboard with TypeMeta set to version so checkGVK takes the resolved-GVK path.
+func dashboardAt(version string) *dashv1.Dashboard {
+	d := &dashv1.Dashboard{}
+	d.Name = "test-name"
+	d.APIVersion = dashv1.DashboardResourceInfo.GroupResource().Group + "/" + version
+	d.Kind = "Dashboard"
+	return d
+}
+
+// newGlobalCapRegistry builds a registry whose global (ini) layer caps group at maxVersion.
+func newGlobalCapRegistry(group string, order []string, maxVersion string) *versionpolicy.VersionPolicyRegistry {
+	return versionpolicy.NewVersionPolicyRegistry(
+		versionpolicy.NewResolver(fakeOrder(group, order...)),
+		nil,
+		map[string]versionpolicy.VersionPolicy{group: {MaxAllowedVersion: maxVersion}},
+	)
+}
+
+func TestEncodeMaxVersionEnforcement(t *testing.T) {
+	_ = dashv1.AddToScheme(rtscheme)
+	group := dashv1.DashboardResourceInfo.GroupResource().Group
+
+	newStorage := func(gr schema.GroupResource, vp *versionpolicy.VersionPolicyRegistry) *Storage {
+		return &Storage{
+			gr:    gr,
+			codec: apitesting.TestCodec(rtcodecs, dashv1.DashboardResourceInfo.GroupVersion()),
+			opts: StorageOptions{
+				Scheme:        rtscheme,
+				VersionPolicy: vp,
+			},
+		}
+	}
+
+	t.Run("max=v1 + object v2 is rejected with a 4xx naming the ceiling", func(t *testing.T) {
+		reg := newGlobalCapRegistry(group, []string{"v2", "v1"}, "v1")
+		s := newStorage(dashv1.DashboardResourceInfo.GroupResource(), reg)
+
+		var buf bytes.Buffer
+		err := s.encode(dashboardAt("v2"), &buf)
+
+		require.Error(t, err)
+		require.True(t, apierrors.IsBadRequest(err) || apierrors.IsConflict(err), "expected a 4xx, got %v", err)
+		require.Contains(t, err.Error(), "v1", "message should name the ceiling version")
+	})
+
+	t.Run("max=v2 + object v1 is stored as v1, unchanged (regression guard)", func(t *testing.T) {
+		reg := newGlobalCapRegistry(group, []string{"v2", "v1"}, "v2")
+		s := newStorage(dashv1.DashboardResourceInfo.GroupResource(), reg)
+
+		var buf bytes.Buffer
+		err := s.encode(dashboardAt("v1"), &buf)
+		require.NoError(t, err)
+
+		out := &unstructured.Unstructured{}
+		require.NoError(t, json.Unmarshal(buf.Bytes(), out))
+		require.Equal(t, group+"/v1", out.GetAPIVersion(), "no down/up-conversion: stored version must be exactly what was written")
+	})
+
+	t.Run("no policy set for the group leaves encode unchanged", func(t *testing.T) {
+		s := newStorage(dashv1.DashboardResourceInfo.GroupResource(), nil)
+
+		var buf bytes.Buffer
+		err := s.encode(dashboardAt("v2"), &buf)
+		require.NoError(t, err)
+	})
+
+	codecStorage := func(reg *versionpolicy.VersionPolicyRegistry, persistAs string) *Storage {
+		return &Storage{
+			gr: dashv1.DashboardResourceInfo.GroupResource(),
+			codec: upcastCodec{
+				Codec:      apitesting.TestCodec(rtcodecs, dashv1.DashboardResourceInfo.GroupVersion()),
+				apiVersion: group + "/" + persistAs,
+			},
+			opts: StorageOptions{Scheme: nil, VersionPolicy: reg}, // Scheme nil = codec path
+		}
+	}
+
+	t.Run("codec path: cap enforced against the persisted version, not the declared one", func(t *testing.T) {
+		// The codec converts up (persists v2) while the request declared v1 (<= cap). The old check read the
+		// declared version and let this through; the fix rejects against the persisted v2.
+		reg := newGlobalCapRegistry(group, []string{"v2", "v1"}, "v1")
+		var buf bytes.Buffer
+		err := codecStorage(reg, "v2").encode(dashboardAt("v1"), &buf)
+
+		require.Error(t, err)
+		require.True(t, apierrors.IsBadRequest(err), "expected a 4xx, got %v", err)
+		require.Contains(t, err.Error(), "v1", "message should name the ceiling version")
+		require.Zero(t, buf.Len(), "rejected write must not leave its payload in the destination buffer")
+	})
+
+	t.Run("codec path: persisted version at/under cap is allowed", func(t *testing.T) {
+		reg := newGlobalCapRegistry(group, []string{"v2", "v1"}, "v2")
+		var buf bytes.Buffer
+		require.NoError(t, codecStorage(reg, "v1").encode(dashboardAt("v1"), &buf))
+		out := &unstructured.Unstructured{}
+		require.NoError(t, json.Unmarshal(buf.Bytes(), out))
+		require.Equal(t, group+"/v1", out.GetAPIVersion())
+	})
+
+	t.Run("codec path: uncapped group encodes directly", func(t *testing.T) {
+		reg := newGlobalCapRegistry(group, []string{"v2", "v1"}, "") // no cap for the group
+		var buf bytes.Buffer
+		require.NoError(t, codecStorage(reg, "v2").encode(dashboardAt("v2"), &buf))
+	})
+}
+
+// upcastCodec is a codec whose Encode always writes a fixed apiVersion, simulating a versioning codec
+// that converts to a higher-priority storage version than the request declared. Decode is inherited.
+type upcastCodec struct {
+	runtime.Codec
+	apiVersion string
+}
+
+func (c upcastCodec) Encode(_ runtime.Object, w io.Writer) error {
+	_, err := fmt.Fprintf(w, `{"apiVersion":%q,"kind":"Dashboard","metadata":{"name":"x"}}`, c.apiVersion)
+	return err
 }

--- a/pkg/storage/unified/apistore/restoptions.go
+++ b/pkg/storage/unified/apistore/restoptions.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	secret "github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
+	"github.com/grafana/grafana/pkg/services/apiserver/versionpolicy"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 )
 
@@ -34,6 +35,15 @@ type RESTOptionsGetter struct {
 
 	// Each group+resource may need custom options
 	options map[string]StorageOptions
+
+	// versionPolicy is shared across every resource this getter serves; nil disables maxAllowedVersion enforcement.
+	versionPolicy *versionpolicy.VersionPolicyRegistry
+}
+
+// SetVersionPolicy sets the shared registry consulted by apistore.encode, so every resource served by
+// this getter enforces the cap against the same instance.
+func (r *RESTOptionsGetter) SetVersionPolicy(vp *versionpolicy.VersionPolicyRegistry) {
+	r.versionPolicy = vp
 }
 
 func NewRESTOptionsGetterForClient(
@@ -167,6 +177,7 @@ func (r *RESTOptionsGetter) GetRESTOptions(resource schema.GroupResource, _ runt
 		) (storage.Interface, factory.DestroyFunc, error) {
 			opts := r.options[resource.String()]
 			opts.SecureValues = r.secrets
+			opts.VersionPolicy = r.versionPolicy
 			return NewStorage(config, r.client, keyFunc, nil, newFunc, newListFunc, getAttrsFunc,
 				trigger, indexers, r.configProvider, opts)
 		},

--- a/pkg/storage/unified/apistore/store.go
+++ b/pkg/storage/unified/apistore/store.go
@@ -39,6 +39,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	grafanaregistry "github.com/grafana/grafana/pkg/apiserver/registry/generic"
 	secrets "github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
+	"github.com/grafana/grafana/pkg/services/apiserver/versionpolicy"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/rvmanager"
@@ -94,6 +95,10 @@ type StorageOptions struct {
 
 	// Temporary fix to support adding default permissions AfterCreate
 	Permissions DefaultPermissionSetter
+
+	// VersionPolicy rejects a write whose storage version outranks the group's maxAllowedVersion cap.
+	// Shared across resources (set via the RESTOptionsGetter); nil disables enforcement.
+	VersionPolicy *versionpolicy.VersionPolicyRegistry
 }
 
 // Storage implements storage.Interface and storage resources as JSON files on disk.


### PR DESCRIPTION
## What

Layer 2 of the runtime version-policy stack (grafana/search-and-storage-team#881). Enforces a global per-group **maxAllowedVersion** persist ceiling in `apistore.encode`: a write whose storage version outranks the group's cap is rejected with a 4xx. Reject-only — it never converts or rewrites.

- **Scheme path:** enforce against the object's checked GVK, which the JSON encoder writes (the persisted version).
- **Codec (no-scheme) path:** encode straight into the destination buffer, read back the persisted `apiVersion`, and reject (resetting the buffer) if it outranks the cap. Uncapped groups and scheme-backed resources incur no extra buffering.
- **Cap source:** the `versionpolicy` registry (layered resolver from #129667), seeded from the `[grafana-apiserver] max_api_version` ini layer and threaded into every resource's `StorageOptions` via the `RESTOptionsGetter` decorator.

Gated behind operator config `[grafana-apiserver] version_policy_enabled` (default off): the registry is only built and attached when enabled, so an operator-set `max_allowed_api_version` has no effect until version policy is turned on. Backend-only.

Error in Grafana Dashboard UI when blocking writes:
<img width="749" height="168" alt="image" src="https://github.com/user-attachments/assets/ae6a70d1-9d93-4d9e-8150-b52a0b1c37f5" />


## Stack

Builds on merged #129667 (`versionpolicy` core). Next layer re-prioritizes discovery to the global preferred version.

## Tests

- `TestEncodeMaxVersionEnforcement` — scheme + codec paths: reject over-cap, allow at/under-cap, uncapped no-op, enforce against the *persisted* (post-codec) version, and buffer reset on rejection.
- `version_policy_test.go` — ini layer parsing and per-field merge.



## Scope / limitations

- **Embedded apiserver only for now.** The cap is wired via `SetVersionPolicy` on the embedded single-binary apiserver's RESTOptionsGetter. The MT/standalone apiserver (`StorageOptions.ApplyTo`) and IAM's local store don't yet get it — deliberate sequencing; threading them is a follow-up (tracked in search-and-storage-team#881), and the MT wiring will be its own PR.


- **REST-write-path check only.** Enforcement lives in `apistore.encode`; writes that bypass apistore — bulk import via `BulkStore`, direct `ResourceClient` callers, migrations — are not capped.
- **Dual-write.** Under legacy-primary dual-write an over-cap write still lands in legacy and returns 200; only the background unified copy is rejected.
- Enforced on **create only** — updates re-encode at the (fixed) stored version and cannot raise it, so capping them would only make already-stored over-cap objects undeletable.

