### PR TITLE
Chore: Switch to Zod mini to reduce bundle size

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -175,6 +175,7 @@ module.exports = [
       '@grafana/no-border-radius-literal': 'error',
       '@grafana/no-unreduced-motion': 'error',
       '@grafana/no-restricted-img-srcs': 'error',
+      '@grafana/zod-import-namespace': 'error',
       '@grafana/no-direct-date-fns': 'error',
       '@grafana/no-direct-create-monitoring-logger': 'error',
       'react-prefer-function-component/react-prefer-function-component': ['error', { allowJsxUtilityClass: true }],

--- a/packages/grafana-data/src/themes/createColors.ts
+++ b/packages/grafana-data/src/themes/createColors.ts
@@ -1,5 +1,5 @@
 import { merge } from 'lodash';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { alpha, darken, emphasize, getContrastRatio, lighten } from './colorManipulator';
 import { palette } from './palette';

--- a/packages/grafana-data/src/themes/createShadows.ts
+++ b/packages/grafana-data/src/themes/createShadows.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { type ThemeColors } from './createColors';
 

--- a/packages/grafana-data/src/themes/createShape.ts
+++ b/packages/grafana-data/src/themes/createShape.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import * as z from 'zod';
 
 const DEFAULT_BORDER_RADIUS_SM = 4;
 const DEFAULT_BORDER_RADIUS_MD = 6;

--- a/packages/grafana-data/src/themes/createSpacing.ts
+++ b/packages/grafana-data/src/themes/createSpacing.ts
@@ -1,7 +1,7 @@
 // Code based on Material UI
 // The MIT License (MIT)
 // Copyright (c) 2014 Call-Em-All
-import { z } from 'zod';
+import * as z from 'zod';
 
 /** @internal */
 export const ThemeSpacingOptionsSchema = z.object({

--- a/packages/grafana-data/src/themes/createTypography.ts
+++ b/packages/grafana-data/src/themes/createTypography.ts
@@ -1,7 +1,7 @@
 // Code based on Material UI
 // The MIT License (MIT)
 // Copyright (c) 2014 Call-Em-All
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { type ThemeColors } from './createColors';
 

--- a/packages/grafana-data/src/themes/createVisualizationColors.ts
+++ b/packages/grafana-data/src/themes/createVisualizationColors.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { FALLBACK_COLOR } from '../types/fieldColor';
 

--- a/packages/grafana-data/src/themes/types.ts
+++ b/packages/grafana-data/src/themes/types.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { type GrafanaTheme } from '../types/theme';
 

--- a/packages/grafana-eslint-rules/README.md
+++ b/packages/grafana-eslint-rules/README.md
@@ -234,6 +234,34 @@ When a violation is detected, the rule reports:
 Import '../status-history/utils' reaches outside the 'histogram' plugin directory. Plugins should only import from external dependencies or relative paths within their own directory.
 ```
 
+### `zod-import-namespace`
+
+Require all zod imports to use a namespace named `z` from the root `zod` package.
+
+This rule allows only:
+
+```ts
+import * as z from 'zod';
+import type * as z from 'zod';
+```
+
+It disallows any other zod import style, including named/default imports and all zod subpath imports such as `zod/mini`. This ensures that all zod imports are consistent, allowing for a smaller bundle size.
+
+#### Examples
+
+```ts
+// Bad ❌
+import { z } from 'zod';
+import z from 'zod';
+import * as zod from 'zod';
+import type { ZodType } from 'zod';
+import * as z from 'zod/mini';
+
+// Good ✅
+import * as z from 'zod';
+import type * as z from 'zod';
+```
+
 ### `define-feature-events`
 
 Enforces best practices when using `defineFeatureEvents` from `@grafana/runtime/internal`.

--- a/packages/grafana-eslint-rules/rules/no-restricted-syntax.cjs
+++ b/packages/grafana-eslint-rules/rules/no-restricted-syntax.cjs
@@ -62,5 +62,14 @@ module.exports = createNoRestrictedSyntax(
     ].join(', '),
     message:
       'Direct usage of createMonitoringLogger is not allowed. Register your logger source in packages/grafana-runtime/src/services/logging/loggers.ts and use getLogger from @grafana/runtime/unstable instead.',
+  },
+  {
+    name: 'zod-import-namespace',
+    selector: [
+      "ImportDeclaration[source.value=/^zod.+/]:not([source.value='zod'])",
+      "ImportDeclaration[source.value='zod']:not([specifiers.length=1]:has(> ImportNamespaceSpecifier[local.name='z']))",
+    ].join(', '),
+    message:
+      "Zod imports must use exactly `import * as z from 'zod'` or `import type * as z from 'zod'`. Imports from zod subpaths are not allowed.",
   }
 );

--- a/packages/grafana-eslint-rules/tests/no-restricted-syntax.test.js
+++ b/packages/grafana-eslint-rules/tests/no-restricted-syntax.test.js
@@ -1,3 +1,4 @@
+import tsParser from '@typescript-eslint/parser';
 import { RuleTester } from 'eslint';
 
 import noRestrictedSyntax from '../rules/no-restricted-syntax.cjs';
@@ -6,16 +7,19 @@ RuleTester.setDefaultConfig({
   languageOptions: {
     ecmaVersion: 2020,
     sourceType: 'module',
-    parser: require('@typescript-eslint/parser'),
+    parser: tsParser,
   },
 });
 
 const ruleTester = new RuleTester();
 
 const rule = noRestrictedSyntax.rules['no-direct-create-monitoring-logger'];
+const zodImportNamespaceRule = noRestrictedSyntax.rules['zod-import-namespace'];
 
 const expectedMessage =
   'Direct usage of createMonitoringLogger is not allowed. Register your logger source in packages/grafana-runtime/src/services/logging/loggers.ts and use getLogger from @grafana/runtime/unstable instead.';
+const expectedZodImportMessage =
+  "Zod imports must use exactly `import * as z from 'zod'` or `import type * as z from 'zod'`. Imports from zod subpaths are not allowed.";
 
 ruleTester.run('no-direct-create-monitoring-logger', rule, {
   valid: [
@@ -57,6 +61,70 @@ ruleTester.run('no-direct-create-monitoring-logger', rule, {
       name: 'runtime star import from @grafana/runtime',
       code: `import * as runtime from '@grafana/runtime'; const logger = runtime.createMonitoringLogger('my-logger');`,
       errors: [{ message: expectedMessage }],
+    },
+  ],
+});
+
+ruleTester.run('zod-import-namespace', zodImportNamespaceRule, {
+  valid: [
+    {
+      name: 'value namespace import named z',
+      code: "import * as z from 'zod';",
+    },
+    {
+      name: 'type namespace import named z',
+      code: "import type * as z from 'zod';",
+    },
+    {
+      name: 'non-zod imports are ignored',
+      code: "import { z } from 'other-lib';",
+    },
+  ],
+  invalid: [
+    {
+      name: 'named import is disallowed',
+      code: "import { z } from 'zod';",
+      errors: [{ message: expectedZodImportMessage }],
+    },
+    {
+      name: 'default import is disallowed',
+      code: "import z from 'zod';",
+      errors: [{ message: expectedZodImportMessage }],
+    },
+    {
+      name: 'namespace alias different from z is disallowed',
+      code: "import * as zod from 'zod';",
+      errors: [{ message: expectedZodImportMessage }],
+    },
+    {
+      name: 'type named import is disallowed',
+      code: "import type { ZodType } from 'zod';",
+      errors: [{ message: expectedZodImportMessage }],
+    },
+    {
+      name: 'mixed specifiers are disallowed',
+      code: "import z, * as zns from 'zod';",
+      errors: [{ message: expectedZodImportMessage }],
+    },
+    {
+      name: 'side effect import is disallowed',
+      code: "import 'zod';",
+      errors: [{ message: expectedZodImportMessage }],
+    },
+    {
+      name: 'namespace import from zod subpath is disallowed',
+      code: "import * as z from 'zod/mini';",
+      errors: [{ message: expectedZodImportMessage }],
+    },
+    {
+      name: 'named import from zod subpath is disallowed',
+      code: "import { z } from 'zod/mini';",
+      errors: [{ message: expectedZodImportMessage }],
+    },
+    {
+      name: 'namespace alias from zod subpath different from z is disallowed',
+      code: "import * as zod from 'zod/v4';",
+      errors: [{ message: expectedZodImportMessage }],
     },
   ],
 });

--- a/public/app/features/admin/UserListPage.types.ts
+++ b/public/app/features/admin/UserListPage.types.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { isIconName } from '@grafana/data';
 

--- a/public/app/features/alerting/unified/components/saved-searches/savedSearchesSchema.ts
+++ b/public/app/features/alerting/unified/components/saved-searches/savedSearchesSchema.ts
@@ -12,7 +12,7 @@
  * - Alert Activity: URL parameters (e.g., "var-filters=...&var-groupBy=...&from=...&to=...")
  */
 
-import z from 'zod';
+import * as z from 'zod';
 
 import { t } from '@grafana/i18n';
 

--- a/public/app/features/alerting/unified/rule-editor/formDefaults.ts
+++ b/public/app/features/alerting/unified/rule-editor/formDefaults.ts
@@ -1,5 +1,5 @@
 import { clamp } from 'lodash';
-import z from 'zod';
+import * as z from 'zod';
 
 import { store } from '@grafana/data';
 import { config, getDataSourceSrv } from '@grafana/runtime';

--- a/public/app/features/alerting/unified/triage/hooks/useTriagePredefinedOverrides.ts
+++ b/public/app/features/alerting/unified/triage/hooks/useTriagePredefinedOverrides.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import z from 'zod';
+import * as z from 'zod';
 
 import { UserStorage } from '@grafana/runtime/internal';
 

--- a/public/app/features/alerting/unified/utils/parseJsonWithSchema.ts
+++ b/public/app/features/alerting/unified/utils/parseJsonWithSchema.ts
@@ -1,4 +1,4 @@
-import type { z } from 'zod';
+import type * as z from 'zod';
 
 /**
  * Parses a JSON string and validates it with a Zod schema.

--- a/public/app/features/dashboard-scene/mutation-api/commands/addAnnotation.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/addAnnotation.ts
@@ -4,7 +4,7 @@
  * Add a dashboard annotation layer using v2beta1 AnnotationQueryKind format.
  */
 
-import { type z } from 'zod';
+import type * as z from 'zod';
 
 import { type AnnotationQueryKind } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 

--- a/public/app/features/dashboard-scene/mutation-api/commands/addPanel.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/addPanel.ts
@@ -6,7 +6,7 @@
  * to match the target layout (warning emitted if converted).
  */
 
-import { type z } from 'zod';
+import type * as z from 'zod';
 
 import { ConditionalRenderingGroup } from '../../conditional-rendering/group/ConditionalRenderingGroup';
 import { AutoGridItem } from '../../scene/layout-auto-grid/AutoGridItem';

--- a/public/app/features/dashboard-scene/mutation-api/commands/addRow.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/addRow.ts
@@ -6,7 +6,7 @@
  * (preserving the original layout structure) rather than being flattened.
  */
 
-import { type z } from 'zod';
+import type * as z from 'zod';
 
 import { ConditionalRenderingGroup } from '../../conditional-rendering/group/ConditionalRenderingGroup';
 import { DefaultGridLayoutManager } from '../../scene/layout-default/DefaultGridLayoutManager';

--- a/public/app/features/dashboard-scene/mutation-api/commands/addTab.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/addTab.ts
@@ -6,7 +6,7 @@
  * (preserving the original layout structure) rather than being flattened.
  */
 
-import { type z } from 'zod';
+import type * as z from 'zod';
 
 import { ConditionalRenderingGroup } from '../../conditional-rendering/group/ConditionalRenderingGroup';
 import { DefaultGridLayoutManager } from '../../scene/layout-default/DefaultGridLayoutManager';

--- a/public/app/features/dashboard-scene/mutation-api/commands/addVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/addVariable.ts
@@ -4,7 +4,7 @@
  * Add a template variable to the dashboard using v2beta1 VariableKind format.
  */
 
-import { type z } from 'zod';
+import type * as z from 'zod';
 
 import type { VariableKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 

--- a/public/app/features/dashboard-scene/mutation-api/commands/applySpec.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/applySpec.ts
@@ -11,7 +11,7 @@
  * scroll position).
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { sceneUtils } from '@grafana/scenes';
 import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';

--- a/public/app/features/dashboard-scene/mutation-api/commands/getLayout.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/getLayout.ts
@@ -5,7 +5,7 @@
  * and a trimmed elements map (title, description, vizConfig.group only).
  */
 
-import { type z } from 'zod';
+import type * as z from 'zod';
 
 import type { Element, PanelKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 

--- a/public/app/features/dashboard-scene/mutation-api/commands/getSpec.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/getSpec.ts
@@ -5,7 +5,7 @@
  * model.
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { transformSceneToSaveModelSchemaV2 } from '../../serialization/transformSceneToSaveModelSchemaV2';
 import { dashboardV2SpecSchema } from '../../v2schema/dashboardV2Schema';

--- a/public/app/features/dashboard-scene/mutation-api/commands/listPanels.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/listPanels.ts
@@ -11,7 +11,7 @@
  *  - includeStatus: include runtime status and data frame schema per panel
  */
 
-import { type z } from 'zod';
+import type * as z from 'zod';
 
 import { type DataFrame, type DataQueryError, LoadingState } from '@grafana/data';
 import { sceneGraph, SceneDataTransformer, type SceneObject, type VizPanel } from '@grafana/scenes';

--- a/public/app/features/dashboard-scene/mutation-api/commands/listVariables.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/listVariables.ts
@@ -4,7 +4,7 @@
  * List template variables for a scope (dashboard or row/tab section) in v2beta1 VariableKind format.
  */
 
-import { type z } from 'zod';
+import type * as z from 'zod';
 
 import { SceneVariableSet } from '@grafana/scenes';
 

--- a/public/app/features/dashboard-scene/mutation-api/commands/movePanel.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/movePanel.ts
@@ -7,7 +7,7 @@
  * if converted). Supports panels in both DashboardGridItem and AutoGridItem.
  */
 
-import { type z } from 'zod';
+import type * as z from 'zod';
 
 import type { VizPanel } from '@grafana/scenes';
 

--- a/public/app/features/dashboard-scene/mutation-api/commands/moveRow.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/moveRow.ts
@@ -4,7 +4,7 @@
  * Reorder a row within its parent or move it to a different parent.
  */
 
-import { type z } from 'zod';
+import type * as z from 'zod';
 
 import { RowItem } from '../../scene/layout-rows/RowItem';
 import { RowsLayoutManager } from '../../scene/layout-rows/RowsLayoutManager';

--- a/public/app/features/dashboard-scene/mutation-api/commands/moveTab.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/moveTab.ts
@@ -4,7 +4,7 @@
  * Reorder a tab within its parent or move it to a different parent.
  */
 
-import { type z } from 'zod';
+import type * as z from 'zod';
 
 import { TabItem } from '../../scene/layout-tabs/TabItem';
 import { TabsLayoutManager } from '../../scene/layout-tabs/TabsLayoutManager';

--- a/public/app/features/dashboard-scene/mutation-api/commands/removeAnnotation.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/removeAnnotation.ts
@@ -5,7 +5,7 @@
  * cannot be removed (they are auto-injected on dashboard load).
  */
 
-import { type z } from 'zod';
+import type * as z from 'zod';
 
 import {
   findAnnotationLayer,

--- a/public/app/features/dashboard-scene/mutation-api/commands/removePanel.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/removePanel.ts
@@ -4,7 +4,7 @@
  * Remove one or more panels from the dashboard by element name.
  */
 
-import { type z } from 'zod';
+import type * as z from 'zod';
 
 import { getElements } from '../../serialization/layoutSerializers/utils';
 import { getLayoutManagerFor, getVizPanelKeyForPanelId } from '../../utils/utils';

--- a/public/app/features/dashboard-scene/mutation-api/commands/removeRow.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/removeRow.ts
@@ -4,7 +4,7 @@
  * Remove a row by path. Optionally move contained panels to another group.
  */
 
-import { type z } from 'zod';
+import type * as z from 'zod';
 
 import { RowItem } from '../../scene/layout-rows/RowItem';
 import { RowsLayoutManager } from '../../scene/layout-rows/RowsLayoutManager';

--- a/public/app/features/dashboard-scene/mutation-api/commands/removeTab.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/removeTab.ts
@@ -4,7 +4,7 @@
  * Remove a tab by path. Optionally move contained panels to another group.
  */
 
-import { type z } from 'zod';
+import type * as z from 'zod';
 
 import { TabItem } from '../../scene/layout-tabs/TabItem';
 import { TabsLayoutManager } from '../../scene/layout-tabs/TabsLayoutManager';

--- a/public/app/features/dashboard-scene/mutation-api/commands/removeVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/removeVariable.ts
@@ -4,7 +4,7 @@
  * Remove a template variable from the dashboard by name.
  */
 
-import { type z } from 'zod';
+import type * as z from 'zod';
 
 import { payloads } from './schemas';
 import { enterEditModeIfNeeded, requiresEdit, type MutationCommand } from './types';

--- a/public/app/features/dashboard-scene/mutation-api/commands/schemas.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/schemas.ts
@@ -21,7 +21,7 @@
  * `z.toJSONSchema()` and are used by LLM tool consumers for guidance.
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { FieldMatcherID } from '@grafana/data';
 import type { GridLayoutItemKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';

--- a/public/app/features/dashboard-scene/mutation-api/commands/types.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/types.ts
@@ -5,7 +5,7 @@
  * plus the MutationContext passed to handlers and reusable permission checks.
  */
 
-import { type z } from 'zod';
+import type * as z from 'zod';
 
 import { config } from '@grafana/runtime';
 

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateAnnotation.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateAnnotation.ts
@@ -8,7 +8,7 @@
  */
 
 import { cloneDeep, isArray, mergeWith } from 'lodash';
-import { type z } from 'zod';
+import type * as z from 'zod';
 
 import { type AnnotationQueryKind } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateDashboardSettings.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateDashboardSettings.ts
@@ -1,4 +1,4 @@
-import { type z } from 'zod';
+import type * as z from 'zod';
 
 import { textUtil } from '@grafana/data';
 import { sceneGraph } from '@grafana/scenes';

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateLayout.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateLayout.ts
@@ -8,7 +8,7 @@
  * If layoutType is omitted, keeps the current type and just applies options.
  */
 
-import { type z } from 'zod';
+import type * as z from 'zod';
 
 import { AutoGridLayoutManager } from '../../scene/layout-auto-grid/AutoGridLayoutManager';
 import { DefaultGridLayoutManager } from '../../scene/layout-default/DefaultGridLayoutManager';

--- a/public/app/features/dashboard-scene/mutation-api/commands/updatePanel.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updatePanel.ts
@@ -8,7 +8,7 @@
  */
 
 import { mergeWith, cloneDeep, isArray } from 'lodash';
-import { type z } from 'zod';
+import type * as z from 'zod';
 
 import { type FieldConfigSource } from '@grafana/data';
 

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateRow.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateRow.ts
@@ -4,7 +4,7 @@
  * Update a row's metadata (title, collapse, hideHeader, fillScreen) by path.
  */
 
-import { type z } from 'zod';
+import type * as z from 'zod';
 
 import { ConditionalRenderingGroup } from '../../conditional-rendering/group/ConditionalRenderingGroup';
 import { RowItem } from '../../scene/layout-rows/RowItem';

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateTab.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateTab.ts
@@ -4,7 +4,7 @@
  * Update a tab's metadata (title) by path.
  */
 
-import { type z } from 'zod';
+import type * as z from 'zod';
 
 import { ConditionalRenderingGroup } from '../../conditional-rendering/group/ConditionalRenderingGroup';
 import { TabItem } from '../../scene/layout-tabs/TabItem';

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateVariable.ts
@@ -4,7 +4,7 @@
  * Replace an existing template variable with a new definition, preserving its position.
  */
 
-import { type z } from 'zod';
+import type * as z from 'zod';
 
 import type { VariableKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 

--- a/public/app/features/dashboard-scene/v2schema/dashboardV2Schema.ts
+++ b/public/app/features/dashboard-scene/v2schema/dashboardV2Schema.ts
@@ -19,7 +19,7 @@
  * forward-compatible with newer schema fields.
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 import type {
   Spec as DashboardV2Spec,

--- a/public/app/features/dashboard-scene/v2schema/validation.ts
+++ b/public/app/features/dashboard-scene/v2schema/validation.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import * as z from 'zod';
 
 import {
   type GridLayoutItemKind,

--- a/public/app/features/home/DashboardTabs/types.ts
+++ b/public/app/features/home/DashboardTabs/types.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { isIconName } from '@grafana/data';
 

--- a/public/app/features/plugins/components/restrictedGrafanaApis/alerting/alertRuleFormSchema.ts
+++ b/public/app/features/plugins/components/restrictedGrafanaApis/alerting/alertRuleFormSchema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { RuleFormType } from 'app/features/alerting/unified/types/rule-form';
 import { GrafanaAlertStateDecision } from 'app/types/unified-alerting-dto';


### PR DESCRIPTION
**What is this feature?**

Based on #129880, switches all our Zod usage over to Zod mini to futher reduce the bundle size.

**Why do we need this feature?**

```patch
# mkdir -p stats

# git switch MattIPv4/zod-wildcard
# yarn build
# yarn bundle-size:stats > stats/wildcard.txt

# git switch MattIPv4/zod-mini
# yarn build
# yarn bundle-size:stats > stats/mini.txt

# git diff --no-index stats/wildcard.txt stats/mini.txt

...
```

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
