### PR TITLE
AuthN: share settings readers between single and multi-tenant paths

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -933,22 +933,9 @@ type CommandLineArgs struct {
 	Args     []string
 }
 
-func (cfg *Cfg) parseAppUrlAndSubUrl(section *ini.Section) (string, string, error) {
-	appUrl := valueAsString(section, "root_url", "http://localhost:3000/")
-
-	if appUrl[len(appUrl)-1] != '/' {
-		appUrl += "/"
-	}
-
-	// Check if has app suburl.
-	url, err := url.Parse(appUrl)
-	if err != nil {
-		cfg.Logger.Error("Invalid root_url.", "url", appUrl, "error", err)
-		os.Exit(1)
-	}
-
-	appSubUrl := strings.TrimSuffix(url.Path, "/")
-	return appUrl, appSubUrl, nil
+func copyServerURLSettingsToGlobals(cfg *Cfg) {
+	AppUrl = cfg.AppURL
+	AppSubUrl = cfg.AppSubURL
 }
 
 func ToAbsUrl(relativeUrl string) string {
@@ -1790,14 +1777,7 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 		cfg.Logger.Warn("require_email_validation is enabled but smtp is disabled")
 	}
 
-	// check old key name
-	grafanaComUrl := valueAsString(iniFile.Section("grafana_net"), "url", "")
-	if grafanaComUrl == "" {
-		grafanaComUrl = valueAsString(iniFile.Section("grafana_com"), "url", "https://grafana.com")
-	}
-	cfg.GrafanaComURL = grafanaComUrl
-
-	cfg.GrafanaComAPIURL = valueAsString(iniFile.Section("grafana_com"), "api_url", grafanaComUrl+"/api")
+	readGrafanaComSettings(iniFile, cfg)
 	cfg.GrafanaComSSOAPIToken = valueAsString(iniFile.Section("grafana_com"), "sso_api_token", "")
 	cfg.GrafanaComProxyAPIToken = valueAsString(iniFile.Section("grafana_com"), "proxy_token", "")
 	imageUploadingSection := iniFile.Section("external_image_storage")
@@ -2042,29 +2022,9 @@ func readSecuritySettings(iniFile *ini.File, cfg *Cfg) error {
 		cfg.BruteForceLoginProtectionMaxAttempts = 1
 	}
 
-	CookieSecure = security.Key("cookie_secure").MustBool(false)
-	cfg.CookieSecure = CookieSecure
+	readCookieSecuritySettings(iniFile, cfg)
+	copyCookieSecuritySettingsToGlobals(cfg)
 
-	samesiteString := valueAsString(security, "cookie_samesite", "lax")
-
-	if samesiteString == "disabled" {
-		CookieSameSiteDisabled = true
-		cfg.CookieSameSiteDisabled = CookieSameSiteDisabled
-	} else {
-		validSameSiteValues := map[string]http.SameSite{
-			"lax":    http.SameSiteLaxMode,
-			"strict": http.SameSiteStrictMode,
-			"none":   http.SameSiteNoneMode,
-		}
-
-		if samesite, ok := validSameSiteValues[samesiteString]; ok {
-			CookieSameSiteMode = samesite
-			cfg.CookieSameSiteMode = CookieSameSiteMode
-		} else {
-			CookieSameSiteMode = http.SameSiteLaxMode
-			cfg.CookieSameSiteMode = CookieSameSiteMode
-		}
-	}
 	cfg.AllowEmbedding = security.Key("allow_embedding").MustBool(false)
 
 	cfg.ContentTypeProtectionHeader = security.Key("x_content_type_options").MustBool(true)
@@ -2111,6 +2071,15 @@ func readSecuritySettings(iniFile *ini.File, cfg *Cfg) error {
 	return nil
 }
 
+func copyCookieSecuritySettingsToGlobals(cfg *Cfg) {
+	CookieSecure = cfg.CookieSecure
+	if cfg.CookieSameSiteDisabled {
+		CookieSameSiteDisabled = cfg.CookieSameSiteDisabled
+	} else {
+		CookieSameSiteMode = cfg.CookieSameSiteMode
+	}
+}
+
 func readAuthSettings(iniFile *ini.File, cfg *Cfg) (err error) {
 	if err := readSessionAuthSettings(iniFile, cfg); err != nil {
 		return err
@@ -2133,7 +2102,7 @@ func readAuthSettings(iniFile *ini.File, cfg *Cfg) (err error) {
 
 	// Default to the translation key used in the frontend
 	cfg.OAuthLoginErrorMessage = valueAsString(auth, "oauth_login_error_message", "oauth.login.error")
-	cfg.OAuthCookieMaxAge = auth.Key("oauth_state_cookie_max_age").MustInt(600)
+	readOAuthCookieMaxAge(iniFile, cfg)
 	cfg.OAuthRefreshTokenServerLockMinWaitMs = auth.Key("oauth_refresh_token_server_lock_min_wait_ms").MustInt64(1000)
 	cfg.SignoutRedirectUrl = valueAsString(auth, "signout_redirect_url", "")
 
@@ -2316,14 +2285,12 @@ func readSnapshotsSettings(cfg *Cfg, iniFile *ini.File) error {
 
 func (cfg *Cfg) readServerSettings(iniFile *ini.File) error {
 	server := iniFile.Section("server")
-	var err error
-	AppUrl, AppSubUrl, err = cfg.parseAppUrlAndSubUrl(server)
-	if err != nil {
-		return err
+	if err := readServerURLSettings(iniFile, cfg); err != nil {
+		cfg.Logger.Error("Invalid root_url.", "url", cfg.AppURL, "error", err)
+		os.Exit(1)
 	}
+	copyServerURLSettingsToGlobals(cfg)
 
-	cfg.AppURL = AppUrl
-	cfg.AppSubURL = AppSubUrl
 	cfg.Protocol = HTTPScheme
 	cfg.ServeFromSubPath = server.Key("serve_from_sub_path").MustBool(false)
 	cfg.CertWatchInterval = server.Key("certs_watch_interval").MustDuration(0)
@@ -2385,10 +2352,11 @@ func (cfg *Cfg) readServerSettings(iniFile *ini.File) error {
 
 	cdnURL := valueAsString(server, "cdn_url", "")
 	if cdnURL != "" {
-		cfg.CDNRootURL, err = url.Parse(cdnURL)
+		parsedCDNURL, err := url.Parse(cdnURL)
 		if err != nil {
 			return err
 		}
+		cfg.CDNRootURL = parsedCDNURL
 	}
 
 	cfg.ReadTimeout = server.Key("read_timeout").MustDuration(0)

--- a/pkg/setting/setting_authn.go
+++ b/pkg/setting/setting_authn.go
@@ -34,9 +34,11 @@ func (cfg *Cfg) ApplyAuthnSettings(iniFile *ini.File) error {
 	if err := readSessionAuthSettings(iniFile, cfg); err != nil {
 		return err
 	}
-	readOAuthSettings(iniFile, cfg)
+	readOAuthCookieMaxAge(iniFile, cfg)
 	readCookieSecuritySettings(iniFile, cfg)
-	readServerURLSettings(iniFile, cfg)
+	if err := readServerURLSettings(iniFile, cfg); err != nil {
+		return err
+	}
 	readGrafanaComSettings(iniFile, cfg)
 	return readUserLastSeenUpdateInterval(iniFile, cfg)
 }
@@ -71,9 +73,8 @@ func readSessionAuthSettings(iniFile *ini.File, cfg *Cfg) error {
 	return nil
 }
 
-func readOAuthSettings(iniFile *ini.File, cfg *Cfg) {
-	auth := iniFile.Section("auth")
-	cfg.OAuthCookieMaxAge = auth.Key("oauth_state_cookie_max_age").MustInt(600)
+func readOAuthCookieMaxAge(iniFile *ini.File, cfg *Cfg) {
+	cfg.OAuthCookieMaxAge = iniFile.Section("auth").Key("oauth_state_cookie_max_age").MustInt(600)
 }
 
 func readCookieSecuritySettings(iniFile *ini.File, cfg *Cfg) {
@@ -97,7 +98,9 @@ func readCookieSecuritySettings(iniFile *ini.File, cfg *Cfg) {
 	}
 }
 
-func readServerURLSettings(iniFile *ini.File, cfg *Cfg) {
+// readServerURLSettings sets AppURL even when the URL fails to parse, so
+// callers can include the offending value in their error reporting.
+func readServerURLSettings(iniFile *ini.File, cfg *Cfg) error {
 	server := iniFile.Section("server")
 	appURL := valueAsString(server, "root_url", "http://localhost:3000/")
 	if appURL[len(appURL)-1] != '/' {
@@ -105,9 +108,12 @@ func readServerURLSettings(iniFile *ini.File, cfg *Cfg) {
 	}
 	cfg.AppURL = appURL
 
-	if parsed, err := url.Parse(appURL); err == nil {
-		cfg.AppSubURL = strings.TrimSuffix(parsed.Path, "/")
+	parsed, err := url.Parse(appURL)
+	if err != nil {
+		return fmt.Errorf("server.root_url: %w", err)
 	}
+	cfg.AppSubURL = strings.TrimSuffix(parsed.Path, "/")
+	return nil
 }
 
 func readGrafanaComSettings(iniFile *ini.File, cfg *Cfg) {

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -456,10 +456,9 @@ func TestParseAppURLAndSubURL(t *testing.T) {
 		require.NoError(t, err)
 		_, err = s.NewKey("root_url", tc.rootURL)
 		require.NoError(t, err)
-		appURL, appSubURL, err := cfg.parseAppUrlAndSubUrl(s)
-		require.NoError(t, err)
-		require.Equal(t, tc.expectedAppURL, appURL)
-		require.Equal(t, tc.expectedAppSubURL, appSubURL)
+		require.NoError(t, readServerURLSettings(f, cfg))
+		require.Equal(t, tc.expectedAppURL, cfg.AppURL)
+		require.Equal(t, tc.expectedAppSubURL, cfg.AppSubURL)
 	}
 }
 


### PR DESCRIPTION
## Why

Follow-up to #129777. [Review feedback](https://github.com/grafana/grafana/pull/129777#pullrequestreview-4831058914) pointed out that the readers added there duplicate logic already in `setting.go`. This points the single-tenant loader at the shared readers so there's one place to change when a setting's parsing rules move.

## What

- Use `readGrafanaComSettings`, `readCookieSecuritySettings`, `readOAuthCookieMaxAge`, and `readServerURLSettings` in the single-tenant loader; drop `parseAppUrlAndSubUrl`
- Move the package-global writes into `copyCookieSecuritySettingsToGlobals` and `copyServerURLSettingsToGlobals` so the shared readers stay free of side effects on package state
- Rename `readOAuthSettings` → `readOAuthCookieMaxAge`, which is all it reads
- `readServerURLSettings` returns the parse error instead of swallowing it. The single-tenant caller keeps its `os.Exit(1)`; the MT caller propagates.

Made with [Cursor](https://cursor.com)