### PR TITLE
Short URL: Fix 404 loop

### DIFF
--- a/public/app/routes/routes.test.tsx
+++ b/public/app/routes/routes.test.tsx
@@ -1,0 +1,22 @@
+import { isValidGotoPath } from './routes';
+
+describe('isValidGotoPath', () => {
+  it('accepts a well-formed single-segment short URL', () => {
+    expect(isValidGotoPath('/goto/abc123')).toBe(true);
+    expect(isValidGotoPath('/goto/A_b-9')).toBe(true);
+  });
+
+  // Regression: a double slash makes the backend `/goto/:uid` route miss, so the SPA is served
+  // back with a 404. Bouncing to the server here would loop forever, so these must be rejected.
+  it('rejects a double-slash path', () => {
+    expect(isValidGotoPath('/goto//a')).toBe(false);
+  });
+
+  it('rejects an empty uid', () => {
+    expect(isValidGotoPath('/goto/')).toBe(false);
+  });
+
+  it('rejects extra path segments', () => {
+    expect(isValidGotoPath('/goto/a/b')).toBe(false);
+  });
+});

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -666,13 +666,25 @@ function DataSourceEditRoute() {
   return <Navigate replace to={CONNECTIONS_ROUTES.DataSourcesEdit.replace(':uid', uid)} />;
 }
 
+// A well-formed short URL is exactly `/goto/<uid>` — a single, non-empty uid segment using the
+// short-uid charset. Malformed paths (double slash `/goto//a`, empty uid, extra segments) never
+// match the backend `/goto/:uid` route, so the server re-serves the SPA (HTTP 404); bouncing to
+// the server here would hard-navigate straight back into an infinite loop.
+export function isValidGotoPath(pathname: string): boolean {
+  const uid = pathname.replace(/^\/goto\//, '');
+  return /^[a-zA-Z0-9\-_]+$/.test(uid);
+}
+
 // Explicitly send "goto" URLs to server, bypassing client-side routing
 function HandleGoToRedirect() {
   const { pathname } = useLocation();
+  const isValid = isValidGotoPath(pathname);
 
   useEffect(() => {
-    window.location.href = pathname;
-  }, [pathname]);
+    if (isValid) {
+      window.location.href = pathname;
+    }
+  }, [pathname, isValid]);
 
-  return null;
+  return isValid ? null : <PageNotFound />;
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fixes an infinite 404 loop when visiting a malformed short-URL path such as `/goto//a` (a double slash after `/goto`). The frontend `HandleGoToRedirect` handler now only hard-navigates to the server for a well-formed short URL (a single, non-empty uid segment); for malformed paths it renders the standard 404 page instead.

**Why do we need this feature?**

A double slash creates an empty path segment that the backend `/goto/:uid` route can't match, so the request falls through to the NotFound handler, which serves the SPA back with an HTTP 404. React Router then matches `/goto/*` → `HandleGoToRedirect`, which unconditionally ran `window.location.href = pathname` and hard-navigated to the same malformed URL — looping forever. Because there are no HTTP 3xx redirects involved, the browser's redirect-loop protection never trips, so the UI never loads and the tab spins indefinitely. Guarding the redirect breaks the loop and shows a proper 404, consistent with every other unknown route.

**Who is this feature for?**

Everyone — anyone who lands on a malformed `/goto/` link (mistyped, truncated, or badly generated) instead of being stuck in an unrecoverable 404 spiral.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #117391

**Special notes for your reviewer:**

Frontend-only change in `public/app/routes/routes.tsx` plus unit tests in `public/app/routes/routes.test.tsx`. To reproduce before the fix: visit `/goto//a` and observe the never-ending 404 reload; after the fix it renders the 404 page and stays. Valid `/goto/<uid>` redirects are unaffected.

Not addressed here (separate backend concern): `IsValidShortUID("")` returns `true` because its regex uses `*` (`pkg/util/shortid_generator.go`); the double-slash path never reaches that code, so it's out of scope for this PR.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

### Before:

https://github.com/user-attachments/assets/f955fc12-5f8e-472f-a436-16e9ccbcaea3



### After:

https://github.com/user-attachments/assets/3f352547-e63f-4891-8fc6-34ada6e0c4cf

