### PR TITLE
Transformations: Fix field name deduplication in Extract fields

### DIFF
--- a/public/app/features/transformers/extractFields/extractFields.ts
+++ b/public/app/features/transformers/extractFields/extractFields.ts
@@ -7,7 +7,6 @@ import {
   type Field,
   FieldType,
   getFieldTypeFromValue,
-  getUniqueFieldName,
   type SynchronousDataTransformerInfo,
 } from '@grafana/data';
 import { findField } from 'app/features/dimensions/utils';
@@ -96,27 +95,43 @@ export function addExtractedFields(frame: DataFrame, options: ExtractFieldsOptio
     }
   }
 
+  const sourceTime = options.keepTime ? findField(frame, 'Time') || findField(frame, 'time') : undefined;
+
+  // Only names that actually survive into the output can force a rename: `replace` discards the
+  // original fields, and each extracted name has to be deduped against the ones already assigned
+  // here, not just against the incoming frame.
+  const taken = new Set<string>();
+  if (!options.replace) {
+    frame.fields.forEach((f) => taken.add(f.name));
+  }
+  if (sourceTime) {
+    taken.add(sourceTime.name);
+  }
+
   const fields = names.map((name) => {
     const buffer = values.get(name);
     // this should never happen, but let's be safe
     if (!buffer) {
       throw new Error(`Could not find field with name: ${name}`);
     }
+
+    let unique = name;
+    for (let dupe = 1; taken.has(unique); dupe++) {
+      unique = `${name} ${dupe}`;
+    }
+    taken.add(unique);
+
     const field: Field = {
-      name,
+      name: unique,
       values: buffer,
       type: buffer ? getFieldTypeFromValue(buffer.find((v) => v != null)) : FieldType.other,
       config: {},
     };
-    field.name = getUniqueFieldName(field, frame);
     return field;
   });
 
-  if (options.keepTime) {
-    const sourceTime = findField(frame, 'Time') || findField(frame, 'time');
-    if (sourceTime) {
-      fields.unshift(sourceTime);
-    }
+  if (sourceTime) {
+    fields.unshift(sourceTime);
   }
 
   if (!options.replace) {

--- a/public/app/features/transformers/extractFields/fieldExtractor.test.ts
+++ b/public/app/features/transformers/extractFields/fieldExtractor.test.ts
@@ -133,6 +133,52 @@ describe('Extract fields from text', () => {
     expect(newFrame.fields[1].name).toBe('bar');
   });
 
+  it('deduplicates extracted names against each other', async () => {
+    const frame = toDataFrame({
+      fields: [{ name: 'foo', type: FieldType.string, values: ['{"foo":"extracedValue1","foo 1":"extracedValue2"}'] }],
+    });
+    const newFrame = addExtractedFields(frame, { format: FieldExtractorID.JSON, source: 'foo' });
+    expect(newFrame.fields.map((f) => f.name)).toEqual(['foo', 'foo 1', 'foo 1 1']);
+  });
+
+  it('does not deduplicate against fields discarded by replace', async () => {
+    const frame = toDataFrame({
+      fields: [
+        { name: 'Line', type: FieldType.string, values: ['{"id":"abc","level":"warn"}'] },
+        { name: 'id', type: FieldType.string, values: ['originalId'] },
+      ],
+    });
+    const newFrame = addExtractedFields(frame, { format: FieldExtractorID.JSON, source: 'Line', replace: true });
+    expect(newFrame.fields.map((f) => f.name)).toEqual(['id', 'level']);
+  });
+
+  it('deduplicates against fields kept by replace: false', async () => {
+    const frame = toDataFrame({
+      fields: [
+        { name: 'Line', type: FieldType.string, values: ['{"id":"abc","level":"warn"}'] },
+        { name: 'id', type: FieldType.string, values: ['originalId'] },
+      ],
+    });
+    const newFrame = addExtractedFields(frame, { format: FieldExtractorID.JSON, source: 'Line', replace: false });
+    expect(newFrame.fields.map((f) => f.name)).toEqual(['Line', 'id', 'id 1', 'level']);
+  });
+
+  it('deduplicates against the time field kept by keepTime', async () => {
+    const frame = toDataFrame({
+      fields: [
+        { name: 'Time', type: FieldType.time, values: [1] },
+        { name: 'Line', type: FieldType.string, values: ['{"Time":"extracedValue1","level":"warn"}'] },
+      ],
+    });
+    const newFrame = addExtractedFields(frame, {
+      format: FieldExtractorID.JSON,
+      source: 'Line',
+      replace: true,
+      keepTime: true,
+    });
+    expect(newFrame.fields.map((f) => f.name)).toEqual(['Time', 'Time 1', 'level']);
+  });
+
   it('splits by regexp', async () => {
     const extractor = fieldExtractors.get(FieldExtractorID.RegExp);
     const opts: ExtractFieldsOptions = { regExp: '/^(?<FieldA>\\w+)[^\\w]+(?<FieldB>\\w+)$/' };


### PR DESCRIPTION
# What is this feature?

`extractFields` passed `getUniqueFieldName(field, frame)` a field literal that isn't in `frame.fields`. That function finds the field by object identity to set `foundSelf`, so `foundSelf` was never true and the call degenerated to "count frame fields with this name." Two consequences:

1. Extracted names were deduped against the incoming frame but never against each other — a frame with `foo` plus JSON keys `foo` and `foo 1` produced two fields both named `foo 1`.
2. With `replace: true` the original fields are discarded but still counted, so an extracted key matching an original name got a spurious ` 1` suffix — a Loki frame with an `id` field extracting a JSON `id` key produced `id 1` with nothing named `id` left.

The fix drops that call: build a `taken` set from the fields that actually survive into the output (`frame.fields` only when `!options.replace`, plus the time field when `keepTime`) and suffix against it. `getUniqueFieldName` is untouched — `getFieldDisplayName` is now its only caller, which also unblocks the optimization @leeoniya was after when he filed this.

# Behaviour change

Output field names change in two cases, breaking any field override or downstream transformation that references the old name:

- `replace: true` no longer suffixes against discarded fields: `id 1` becomes `id`.
- A frame that already contains a duplicate name now yields `foo 1` rather than `foo 2`.

Genuine collisions with kept fields still suffix. Every in-tree consumer (logstable, Explore `LogsTable`, `addToDashboard`) and `grafana/logs-drilldown` uses `replace: false`, so none hit the first case; Enterprise has no references.

# Which issue(s) does this PR fix?

Fixes #81424

# Special notes for your reviewer

Four tests in `fieldExtractor.test.ts`: dedup among extracted names, `replace: true` not suffixing against discarded fields, genuine collisions still suffixing, and `keepTime` reserving the time field name. Also confirmed in a dev instance.

Two pre-existing quirks left alone so they aren't read as fallout from this change: `keepTime` with `replace: false` emits the time field twice (verified identical on the parent commit), and `JSONPathEditor.tsx` passes an optional `alias` as `value`, logging React's controlled-input warning (this PR changes no `.tsx`).

cc @leeoniya
