### PR TITLE
AuthZ: Allow registered wildcard group checks

### DIFF
--- a/pkg/services/authz/rbac/mapper.go
+++ b/pkg/services/authz/rbac/mapper.go
@@ -620,17 +620,19 @@ func NewMapperRegistry() MapperRegistry {
 	return mapper
 }
 
-// findGroupKey returns the registry key for group, using exact match first,
-// then wildcard match. A wildcard key has the form "*.<suffix>" (e.g. "*.datasource.grafana.app");
-// group matches if it has that suffix, is longer than the suffix (non-empty prefix), and the prefix
-// contains no dot (so "loki.datasource.grafana.app" matches but "foo.loki.datasource.grafana.app" does not).
-// Group starting with "*" never matches (so we never exact-match a wildcard registry key as input).
+// findGroupKey returns the registry key for group. An exact registered key is
+// returned first, including an explicitly registered wildcard key such as
+// "*.datasource.grafana.app". Unregistered wildcard inputs are rejected.
+//
+// Concrete groups may match a wildcard registry key of the form "*.<suffix>".
+// The concrete group must have a single, non-empty prefix segment, so
+// "loki.datasource.grafana.app" matches but "foo.loki.datasource.grafana.app" does not.
 func (m mapper) findGroupKey(group string) (string, bool) {
-	if strings.HasPrefix(group, "*") {
-		return "", false
-	}
 	if _, ok := m[group]; ok {
 		return group, true
+	}
+	if strings.HasPrefix(group, "*") {
+		return "", false
 	}
 	for key := range m {
 		// is this a wildcard key?

--- a/pkg/services/authz/rbac/mapper_test.go
+++ b/pkg/services/authz/rbac/mapper_test.go
@@ -39,9 +39,18 @@ func TestMapperRegistry_DatasourceWildcard(t *testing.T) {
 		require.Len(t, all, 2)
 	}
 
+	// The explicitly registered wildcard key is also a valid capability check.
+	wildcardMapping, ok := reg.Get("*.datasource.grafana.app", "datasources", "")
+	require.True(t, ok)
+	action, ok := wildcardMapping.Action(utils.VerbGet)
+	require.True(t, ok)
+	assert.Equal(t, "datasources:read", action)
+
 	// Security: wildcard-matched group must not resolve to resources from other groups
-	_, ok := reg.Get("loki.datasource.grafana.app", "dashboards", "")
-	assert.False(t, ok, "Get(datasource group, \"dashboards\") must not return a mapping")
+	for _, group := range []string{"loki.datasource.grafana.app", "*.datasource.grafana.app"} {
+		_, ok := reg.Get(group, "dashboards", "")
+		assert.False(t, ok, "Get(%q, \"dashboards\") must not return a mapping", group)
+	}
 }
 
 // TestMapperRegistry_Playlist verifies playlists map to their real two-action model
@@ -71,7 +80,7 @@ func TestMapperRegistry_Playlist(t *testing.T) {
 }
 
 // TestFindGroupKey_WildcardMatching exercises findGroupKey via a minimal mapper.
-// It covers: exact match, wildcard match, group starts with *, key not wildcard (continue),
+// It covers: exact match, wildcard match, unregistered wildcard input, key not wildcard (continue),
 // suffix mismatch, empty group, and no match.
 func TestFindGroupKey_WildcardMatching(t *testing.T) {
 	tests := []struct {
@@ -87,8 +96,9 @@ func TestFindGroupKey_WildcardMatching(t *testing.T) {
 		{"bar.test.grafana.app", []string{testWildcardPattern}, testWildcardPattern, true},
 		// group with nested dots does not match wildcard
 		{"bar.baz.test.grafana.app", []string{testWildcardPattern}, "", false},
-		// Group starts with *: never matches
-		{"*.test.grafana.app", []string{testWildcardPattern}, "", false},
+		// An explicitly registered wildcard key matches exactly; an unregistered one does not.
+		{"*.test.grafana.app", []string{testWildcardPattern}, testWildcardPattern, true},
+		{"*.unknown.grafana.app", []string{testWildcardPattern}, "", false},
 		// Key not a wildcard (no *.): iterate and continue, no match
 		{"foo.test.grafana.app", []string{"dashboard.grafana.app"}, "", false},
 		{"foo.test.grafana.app", []string{"*"}, "", false},
@@ -135,12 +145,18 @@ func TestMapperRegistry_WildcardGroup(t *testing.T) {
 		})
 	}
 
-	// Wildcard as input, wrong suffix, no prefix, or unknown group must not resolve
+	// The explicitly registered wildcard key resolves directly.
+	mapping, ok := reg.Get(testWildcardPattern, "testresources", "")
+	require.True(t, ok)
+	require.Equal(t, tr.Prefix(), mapping.Prefix())
+	require.Len(t, reg.GetAll(testWildcardPattern), 1)
+
+	// Unregistered wildcard input, wrong suffix, no prefix, or unknown group must not resolve.
 	denyCases := []struct {
 		name  string
 		group string
 	}{
-		{"wildcard_input", testWildcardPattern},
+		{"unregistered_wildcard_input", "*.unknown.grafana.app"},
 		{"wrong_suffix", "foo.test.grafana.app.evil"},
 		{"no_prefix", "test.grafana.app"},
 		{"unknown_group", "unknown.grafana.app"},

--- a/pkg/services/authz/rbac/service_test.go
+++ b/pkg/services/authz/rbac/service_test.go
@@ -1482,6 +1482,32 @@ func TestService_Check(t *testing.T) {
 			expected:    false,
 		},
 		{
+			name: "should allow registered wildcard datasource group with wildcard permission",
+			req: &authzv1.CheckRequest{
+				Namespace: "org-12",
+				Subject:   "user:test-uid",
+				Group:     "*.datasource.grafana.app",
+				Resource:  "datasources",
+				Verb:      "get",
+				Name:      "*",
+			},
+			permissions: []accesscontrol.Permission{{Action: "datasources:read", Scope: "datasources:*"}},
+			expected:    true,
+		},
+		{
+			name: "should deny registered wildcard datasource group with instance permission",
+			req: &authzv1.CheckRequest{
+				Namespace: "org-12",
+				Subject:   "user:test-uid",
+				Group:     "*.datasource.grafana.app",
+				Resource:  "datasources",
+				Verb:      "get",
+				Name:      "*",
+			},
+			permissions: []accesscontrol.Permission{{Action: "datasources:read", Scope: "datasources:uid:ds1"}},
+			expected:    false,
+		},
+		{
 			name: "should translate from id to uid based permissions",
 			req: &authzv1.CheckRequest{
 				Namespace: "org-12",
@@ -1626,6 +1652,9 @@ func TestService_Check(t *testing.T) {
 				}
 				if tc.req.Resource == "folders" {
 					expAction = "folders:delete"
+				}
+				if tc.req.Resource == "datasources" {
+					expAction = "datasources:read"
 				}
 				if tc.req.Subresource == "annotations" {
 					switch tc.req.Verb {


### PR DESCRIPTION
## Summary

- allow an exact lookup when a wildcard group is explicitly registered in the RBAC mapper
- continue rejecting unregistered wildcard group inputs
- authorize `*.datasource.grafana.app/datasources:get` through the existing `datasources:read` mapping
- verify that stack-wide datasource access is required and a single datasource UID is insufficient

## Tests

- `go test ./pkg/services/authz/rbac`
- `go test -tags enterprise -run "^TestIntegrationRoleAssignmentsK8sRedirect$" -count=1 ./pkg/extensions/apiserver/tests/iam`

## Alternative approach

This is the mapper-level alternative to draft grafana/grafana-enterprise#12904, which handles the same permission in RolePermissionValidator by falling back to legacy access control. The two drafts are intended for SME comparison; they should not both be merged.