### PR TITLE
UI: Add noscript fallback when JavaScript is disabled

### DIFF
--- a/pkg/services/frontend/index.html
+++ b/pkg/services/frontend/index.html
@@ -157,6 +157,26 @@
       </div>
   </div>
 
+    <noscript>
+      <style>
+        .preloader {
+          display: none;
+        }
+
+        .js-required-message {
+          margin: 48px auto;
+          max-width: 720px;
+          padding: 0 16px;
+          font-family: Sans-serif;
+          line-height: 1.5;
+        }
+      </style>
+      <main class="js-required-message">
+        <h1>JavaScript is required to run Grafana</h1>
+        <p>Please enable JavaScript in your browser and reload the page.</p>
+      </main>
+    </noscript>
+
     <div id="reactRoot"></div>
 
     <script nonce="[[.Nonce]]">

--- a/pkg/services/frontend/index.html
+++ b/pkg/services/frontend/index.html
@@ -169,6 +169,14 @@
           padding: 0 16px;
           font-family: Sans-serif;
           line-height: 1.5;
+          color: #52545c;
+        }
+
+        /* No theme-* body classes here without JS; follow system preference like the loader. */
+        @media (prefers-color-scheme: dark) {
+          .js-required-message {
+            color: #d8d9da;
+          }
         }
       </style>
       <main class="js-required-message">

--- a/public/views/index.html
+++ b/public/views/index.html
@@ -265,6 +265,34 @@
       </script>
     </div>
 
+    <noscript>
+      <style>
+        .preloader {
+          display: none;
+        }
+
+        .js-required-message {
+          margin: 48px auto;
+          max-width: 720px;
+          padding: 0 16px;
+          font-family: Sans-serif;
+          line-height: 1.5;
+        }
+
+        .theme-light .js-required-message {
+          color: #52545c;
+        }
+
+        .theme-dark .js-required-message {
+          color: #d8d9da;
+        }
+      </style>
+      <main class="js-required-message">
+        <h1>JavaScript is required to run Grafana</h1>
+        <p>Please enable JavaScript in your browser and reload the page.</p>
+      </main>
+    </noscript>
+
     <div id="reactRoot"></div>
 
     <script nonce="[[.Nonce]]">


### PR DESCRIPTION
## What
Adds a clear `<noscript>` message in both index templates so users with JavaScript disabled see why Grafana cannot load, instead of an infinite loading logo.

## Where
- `public/views/index.html`
- `pkg/services/frontend/index.html`

Per @ashharrison90 on #117243.

## Testing
Automated frontend/backend suites do not cover the JS-disabled bootstrap path (static HTML only), so `yarn test` / `go test` were not applicable here.

Manual verification performed:
- Confirmed identical `<noscript>` markup was added in both templates
- Confirmed the message is inside `<noscript>` (only rendered when JS is disabled)
- Confirmed `.preloader { display: none; }` is scoped inside `<noscript>` so the bouncing logo is hidden in that path
- `git diff --check` passes

Recommended reviewer check: open Grafana with JavaScript disabled and confirm the fallback message appears instead of the infinite loading logo.

Fixes #117243