### PR TITLE
CI: Cache public/build-swagger for e2e frontend build

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -89,9 +89,10 @@ jobs:
         uses: actions/cache@v5  # zizmor: ignore[cache-poisoning] key derived only from hashFiles of tracked source
         id: cache
         with:
-          key: "e2e-build-frontend-${{ runner.os }}-${{ hashFiles('yarn.lock', 'package.json', 'packages/**', 'public/**', 'scripts/webpack/**', '!**/*.test.ts', '!**/*.test.tsx', 'tsconfig.json', '.browserslistrc', 'nx.json', 'project.json', '.nvmrc') }}"
+          key: "e2e-build-frontend-v2-${{ runner.os }}-${{ hashFiles('yarn.lock', 'package.json', 'packages/**', 'public/**', 'scripts/webpack/**', '!**/*.test.ts', '!**/*.test.tsx', 'tsconfig.json', '.browserslistrc', 'nx.json', 'project.json', '.nvmrc') }}"
           path: |
             public/build
+            public/build-swagger
             public/app/plugins/*/*/dist
 
       - name: Setup Node.js


### PR DESCRIPTION
**What is this feature?**

Adds `public/build-swagger` to the paths saved by the frontend build cache in `pr-e2e-tests.yml`, and bumps the cache key to `v2`.

**Why do we need this feature?**

#123798 moved the swagger bundle out of `public/build` and into its own output directory, but the e2e cache definition was not updated. On a cache hit the build step is skipped entirely, so `public/build-swagger` is never produced, the `/swagger` page renders blank, and `swagger.spec.ts` fails. This is why e2e is currently failing on every PR.

The key needs the `v2` prefix because caches saved under the old definition do not contain the swagger directory. Without it, those caches keep getting restored and the fix has no effect.

**Who is this feature for?**

Grafana developers, whose PRs are all currently blocked by red e2e runs.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

The `v2` prefix causes a one-time cache miss, so the first run on each branch rebuilds the frontend.
