### PR TITLE
API Server: Report abandoned requests as 499 instead of 504

### DIFF
--- a/pkg/apiserver/endpoints/filters/canceled_request.go
+++ b/pkg/apiserver/endpoints/filters/canceled_request.go
@@ -1,0 +1,51 @@
+package filters
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"k8s.io/apiserver/pkg/endpoints/responsewriter"
+)
+
+// statusClientClosedRequest is the non-standard status used to record a request
+// the client abandoned before the server responded. Grafana already reports this
+// case as 499 in the query API and in the aggregator proxy.
+const statusClientClosedRequest = 499
+
+// WithCanceledRequestStatus reports an abandoned request as 499 rather than 504.
+//
+// The apiserver's WithTimeoutForNonLongRunningRequests filter selects on
+// req.Context().Done(), which fires on client cancellation as well as on deadline
+// expiry, but reports either as a timeout: it writes 504 with a "request did not
+// complete within the allotted timeout" body. When a browser abandons an in-flight
+// request that misattributes a client disconnect to a server-side timeout, which
+// surfaces as a status_source=server 5xx in request logs and error-rate panels.
+//
+// Only a 504 on a canceled context is rewritten, so genuine deadline expiry
+// (context.DeadlineExceeded) still reports 504.
+//
+// This filter must be installed outside DefaultBuildHandlerChain so that it wraps
+// the ResponseWriter the timeout filter writes to.
+func WithCanceledRequestStatus(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		decorator := &canceledRequestWriter{ResponseWriter: w, req: req}
+		handler.ServeHTTP(responsewriter.WrapForHTTP1Or2(decorator), req)
+	})
+}
+
+type canceledRequestWriter struct {
+	http.ResponseWriter
+	req *http.Request
+}
+
+var _ responsewriter.UserProvidedDecorator = &canceledRequestWriter{}
+
+func (w *canceledRequestWriter) Unwrap() http.ResponseWriter { return w.ResponseWriter }
+
+func (w *canceledRequestWriter) WriteHeader(code int) {
+	if code == http.StatusGatewayTimeout && errors.Is(w.req.Context().Err(), context.Canceled) {
+		code = statusClientClosedRequest
+	}
+	w.ResponseWriter.WriteHeader(code)
+}

--- a/pkg/apiserver/endpoints/filters/canceled_request_test.go
+++ b/pkg/apiserver/endpoints/filters/canceled_request_test.go
@@ -1,0 +1,105 @@
+package filters
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// connResponseWriter mimics the net/http ResponseWriter implementations, which
+// implement both http.CloseNotifier and http.Flusher. httptest.ResponseRecorder
+// implements Flusher but not CloseNotifier, so on its own it cannot exercise
+// responsewriter.WrapForHTTP1Or2's interface preservation.
+type connResponseWriter struct {
+	*httptest.ResponseRecorder
+}
+
+func (w *connResponseWriter) CloseNotify() <-chan bool { return make(chan bool) }
+
+// canceledContextRequest returns a request whose context is already canceled,
+// mirroring what the net/http server does when a client disconnects.
+func canceledContextRequest(t *testing.T) *http.Request {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	return httptest.NewRequest(http.MethodPost, "/apis/query.grafana.app/v0alpha1/namespaces/stacks-1/query", nil).WithContext(ctx)
+}
+
+func TestWithCanceledRequestStatus(t *testing.T) {
+	t.Run("rewrites 504 to 499 when the client canceled the request", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+
+		WithCanceledRequestStatus(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusGatewayTimeout)
+		})).ServeHTTP(rec, canceledContextRequest(t))
+
+		require.Equal(t, statusClientClosedRequest, rec.Code)
+	})
+
+	t.Run("keeps 504 when the context was not canceled", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+
+		WithCanceledRequestStatus(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusGatewayTimeout)
+		})).ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/apis/query.grafana.app/v0alpha1/namespaces/stacks-1/query", nil))
+
+		require.Equal(t, http.StatusGatewayTimeout, rec.Code)
+	})
+
+	t.Run("keeps 504 when the deadline was exceeded rather than canceled", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+		defer cancel()
+		req := httptest.NewRequest(http.MethodPost, "/apis/query.grafana.app/v0alpha1/namespaces/stacks-1/query", nil).WithContext(ctx)
+
+		WithCanceledRequestStatus(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusGatewayTimeout)
+		})).ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusGatewayTimeout, rec.Code)
+	})
+
+	t.Run("leaves non-504 statuses untouched on a canceled request", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+
+		WithCanceledRequestStatus(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		})).ServeHTTP(rec, canceledContextRequest(t))
+
+		require.Equal(t, http.StatusInternalServerError, rec.Code)
+	})
+
+	t.Run("passes the body through unchanged", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+
+		WithCanceledRequestStatus(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusGatewayTimeout)
+			_, _ = w.Write([]byte(`{"code":504}`))
+		})).ServeHTTP(rec, canceledContextRequest(t))
+
+		require.Equal(t, statusClientClosedRequest, rec.Code)
+		require.Equal(t, `{"code":504}`, rec.Body.String())
+	})
+
+	t.Run("keeps the ResponseWriter flushable and close-notifiable for streaming handlers", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		inner := &connResponseWriter{ResponseRecorder: rec}
+		var flushable, closeNotifiable bool
+
+		WithCanceledRequestStatus(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, flushable = w.(http.Flusher)
+			_, closeNotifiable = w.(http.CloseNotifier)
+			w.WriteHeader(http.StatusGatewayTimeout)
+		})).ServeHTTP(inner, canceledContextRequest(t))
+
+		require.True(t, flushable, "wrapped ResponseWriter must still implement http.Flusher")
+		require.True(t, closeNotifiable, "wrapped ResponseWriter must still implement http.CloseNotifier")
+		// The rewrite must still apply through responsewriter.WrapForHTTP1Or2.
+		require.Equal(t, statusClientClosedRequest, rec.Code)
+	})
+}

--- a/pkg/services/apiserver/builder/helper.go
+++ b/pkg/services/apiserver/builder/helper.go
@@ -102,6 +102,10 @@ func GetDefaultBuildHandlerChainFunc(builders []APIGroupBuilder, reg prometheus.
 		// DefaultBuildHandlerChain provides many things, notably CORS, HSTS, cache-control, authz and latency tracking
 		handler = genericapiserver.DefaultBuildHandlerChain(handler, c)
 
+		// Must wrap DefaultBuildHandlerChain: it reports a client disconnect as a 504
+		// timeout, and this rewrites that to 499. See filters.WithCanceledRequestStatus.
+		handler = filters.WithCanceledRequestStatus(handler)
+
 		handler = filters.WithAcceptHeader(handler)
 		handler = filters.WithPathRewriters(handler, PathRewriters)
 		handler = k8stracing.WithTracing(handler, c.TracerProvider, "KubernetesAPI")


### PR DESCRIPTION
**What is this feature?**

Adds `filters.WithCanceledRequestStatus`, installed in the Grafana apiserver handler chain outside `DefaultBuildHandlerChain`. It rewrites a 504 to 499 when the request context was canceled, leaving genuine deadline expiry as 504.

**Why do we need this feature?**

The apiserver's `WithTimeoutForNonLongRunningRequests` filter selects on `req.Context().Done()`:

```go
timeoutCh := r.Context().Done()   // timeout.go:91
...
case <-timeoutCh:
    tw.timeout(err)               // timeout.go:147 -> WriteHeader(504)
```

That channel closes on client cancellation as well as on deadline expiry, but the error is built unconditionally before the select — `apierrors.NewTimeoutError(...)`, which hardcodes `Code: http.StatusGatewayTimeout`. The filter never inspects *why* the context ended, so a browser abandoning an in-flight request is reported as a server-side timeout.

On `/apis/query.grafana.app/.../query` this shows up as a `status_source=server` 5xx in request logs and error-rate panels, for something that is purely client-initiated.

The query API already maps `context.Canceled` to 499 (`pkg/registry/apis/query/query.go`), but it loses the race: `<-timeoutCh` fires the instant the client disconnects, while the handler still has to unwind its datasource calls and build a response. `tw.timeout()` only defers to the handler if `tw.wroteHeader` is already true, so in practice the 499 path is rarely reached.

**Who is this feature for?**

Anyone reading Grafana request logs or SLO/error-rate dashboards — client disconnects stop being counted as server errors.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**



🤖 Generated with [Claude Code](https://claude.com/claude-code)