### PR TITLE
CI: Ignore parallel configs in webpack stats config

### DIFF
--- a/scripts/webpack/webpack.stats.ts
+++ b/scripts/webpack/webpack.stats.ts
@@ -49,5 +49,20 @@ export default (env: Env = {}) => {
   }
 
   const baseConfig = prodConfig(env);
-  return merge(Array.isArray(baseConfig) ? baseConfig[0] : baseConfig, config);
+
+  if (Array.isArray(baseConfig)) {
+    // yarn build:stats --env configName=swagger
+    if (!env.configName) {
+      env.configName = baseConfig[0].name;
+    }
+
+    const namedConfig = baseConfig.find((c) => c.name === env.configName);
+    if (!namedConfig) {
+      throw new Error(`No config found with name ${env.configName}`);
+    }
+
+    return merge(namedConfig, config);
+  }
+
+  return merge(baseConfig, config);
 };

--- a/scripts/webpack/webpack.stats.ts
+++ b/scripts/webpack/webpack.stats.ts
@@ -48,5 +48,6 @@ export default (env: Env = {}) => {
     };
   }
 
-  return merge(prodConfig(env), config);
+  const baseConfig = prodConfig(env);
+  return merge(Array.isArray(baseConfig) ? baseConfig[0] : baseConfig, config);
 };


### PR DESCRIPTION
**What is this feature?**

Updates the webpack stats config to disregard any parallel configs generated by the webpack prod config, using the first config (or a specific named config from a CLI flag).

**Why do we need this feature?**

#123798 split the swagger build into a separate webpack config, breaking `yarn build:stats` and `yarn build:smolstats`.

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
