### PR TITLE
Fix week start resolution falling back to UI language instead of regi…

### DIFF
--- a/packages/grafana-data/src/datetime/moment_wrapper.ts
+++ b/packages/grafana-data/src/datetime/moment_wrapper.ts
@@ -165,6 +165,44 @@ export const setWeekStart = (weekStart?: string) => {
       },
     });
   } else {
+    // If the user hasn't explicitly set a weekStart preference, we try to infer it
+    // from the browser's regional format.
+    // The backend provides the parsed Accept-Language header in bootData.user.locale.
+    const w = typeof window !== 'undefined' ? (window as any) : undefined;
+    const regionalFormat = w?.grafanaBootData?.user?.locale || w?.navigator?.language;
+    
+    if (regionalFormat && regionalFormat !== language) {
+      let regionalDow: number | undefined;
+
+      try {
+        // Try to use modern Intl.Locale API to get the first day of the week
+        // Intl.Locale firstDay: 1 = Monday, 7 = Sunday
+        // Moment dow: 0 = Sunday, 1 = Monday, ..., 6 = Saturday
+        const localeObj = new Intl.Locale(regionalFormat) as any;
+        const weekInfo = localeObj.weekInfo || localeObj.getWeekInfo?.();
+        if (weekInfo && typeof weekInfo.firstDay === 'number') {
+          regionalDow = weekInfo.firstDay === 7 ? 0 : weekInfo.firstDay;
+        }
+      } catch (e) {
+        // Ignore Intl.Locale errors (e.g. unsupported in older browsers)
+      }
+
+      if (regionalDow === undefined) {
+        // Fallback to moment (only works if the locale pack was actually loaded)
+        regionalDow = moment.localeData(regionalFormat)?.firstDayOfWeek();
+      }
+
+      if (regionalDow !== undefined && regionalDow !== moment.localeData(language)?.firstDayOfWeek()) {
+        moment.updateLocale(language + suffix, {
+          parentLocale: language,
+          week: {
+            dow: regionalDow,
+          },
+        });
+        return;
+      }
+    }
+
     setLocale(language);
   }
 };


### PR DESCRIPTION
**What is this feature?**

This pull request fixes a regression in the date-math logic where the `now/w` (This week) time range incorrectly resolves to a Sunday week start for locales that are Monday-first (e.g., `en-GB`, `de-DE`), whenever the Grafana UI language is left at its default (English).

The fix updates the `setWeekStart` function inside `@grafana/data` to explicitly detect and fall back to the user's regional format (by inspecting `window.grafanaBootData.user.locale` or `window.navigator.language`) if an explicit `weekStart` preference has not been set by the user or organization.

**Why do we need this feature?**

In Grafana 12/13, the regional format logic was decoupled from the translation language, and the explicit `regionalFormat` dropdown was removed from the frontend (PR #124323). This caused `moment.locale` to default purely to the UI language (e.g. `en-US`), inadvertently stripping the user's regional week-start preferences. 

As a result, a user in Europe using the default English UI language would experience dashboard time ranges starting on Sunday instead of Monday, which is incredibly confusing and disruptive to localized reporting. This change restores the correct fallback behavior seen in 11.6.16.

**Who is this feature for?**

Users in regions outside of the US (such as Europe, Asia, etc.) who use the default English translation for the Grafana UI but expect their dashboard time ranges (`now/w`) to respect their local week-start rules based on their browser's regional settings.

**Which issue(s) does this PR fix?**:
<!--
- Automatically closes linked issue when the Pull Request is merged.
Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"
-->
Fixes #129829

**Special notes for your reviewer:**
- The fallback logic is strictly isolated to when `weekStart` is empty (the inherit/default path).
- The solution safely handles cases where `window` or `grafanaBootData` is undefined by using optional chaining and type guards, preventing any risk of crashes in server-side or test environments.
- Tested against various combinations of `bootData.user.locale` and `navigator.language` to ensure proper `firstDayOfWeek` extraction via `moment`.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.