### PR TITLE
Dashboard: Fix missing Filter (AdHoc) variable type in dashboard variable editor

### DIFF
--- a/public/app/features/dashboard-scene/settings/variables/utils.test.ts
+++ b/public/app/features/dashboard-scene/settings/variables/utils.test.ts
@@ -230,8 +230,11 @@ describe('getVariableTypeSelectOptions', () => {
     });
 
     it('should show adhoc as "Filter" in the dashboard context', () => {
-      const values = getVariableTypeSelectOptions().map((o) => o.value);
-      expect(values).toContain('adhoc');
+      const options = getVariableTypeSelectOptions();
+      const adhoc = options.find((o) => o.value === 'adhoc');
+
+      expect(adhoc).toBeDefined();
+      expect(adhoc?.label).toBe('Filter');
     });
 
     it('should show adhoc as "Filter and Group by" in the standalone context', () => {

--- a/public/app/features/dashboard-scene/settings/variables/utils.test.ts
+++ b/public/app/features/dashboard-scene/settings/variables/utils.test.ts
@@ -229,9 +229,9 @@ describe('getVariableTypeSelectOptions', () => {
       config.featureToggles.dashboardUnifiedDrilldownControls = false;
     });
 
-    it('should hide adhoc in the dashboard context', () => {
+    it('should show adhoc as "Filter" in the dashboard context', () => {
       const values = getVariableTypeSelectOptions().map((o) => o.value);
-      expect(values).not.toContain('adhoc');
+      expect(values).toContain('adhoc');
     });
 
     it('should show adhoc as "Filter and Group by" in the standalone context', () => {

--- a/public/app/features/dashboard-scene/settings/variables/utils.ts
+++ b/public/app/features/dashboard-scene/settings/variables/utils.ts
@@ -211,10 +211,6 @@ export function getVariableTypeSelectOptions({ standalone }: VariableTypeSelectO
     if (!config.featureToggles.groupByVariable && option.value === 'groupby') {
       return false;
     }
-    if (option.value === 'adhoc' && unifiedDrilldown && !standalone) {
-      // Dashboards have a dedicated "Filter and Group by" entry point instead.
-      return false;
-    }
 
     return true;
   });


### PR DESCRIPTION
What is this feature?

This pull request restores the `Filter` (formerly `AdHoc`) variable type to the "Add variable" dropdown in the dashboard settings.

Why do we need this feature?

In Grafana 13.1, when `dashboardUnifiedDrilldownControls` was enabled by default, the `adhoc` variable type was intentionally hidden from the variable creation dropdown because it has a dedicated "Filter and Group by" entry point. However, this prevented users from manually creating AdHoc variables if they needed to, causing confusion. Some users would even edit the JSON manually to change the kind to `AdhocVariable`, but it would still show up as "Query" in the UI because the dropdown options couldn't find the `adhoc` type.

This change ensures the variable type is visible as "Filter" in the dashboard context and can be selected.

Fixes #129433