### PR TITLE
InfluxDB: Remove gf-form from PartListSection

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2754,11 +2754,6 @@
       "count": 3
     }
   },
-  "public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/PartListSection.tsx": {
-    "@grafana/no-gf-form": {
-      "count": 2
-    }
-  },
   "public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/TagsSection.tsx": {
     "@grafana/no-gf-form": {
       "count": 1

--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/PartListSection.test.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/PartListSection.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { PartListSection, type PartParams } from './PartListSection';
+
+const parts: Array<{ name: string; params: PartParams }> = [
+  {
+    name: 'mean',
+    params: [{ value: 'temperature', options: () => Promise.resolve(['temperature', 'humidity']) }],
+  },
+  {
+    name: 'alias',
+    params: [{ value: 'series', options: null }],
+  },
+];
+
+const getNewPartOptions = () => Promise.resolve([{ label: 'max', value: 'max' }]);
+
+describe('PartListSection', () => {
+  it('renders part names as labels with specific remove actions', () => {
+    render(
+      <PartListSection
+        parts={parts}
+        getNewPartOptions={getNewPartOptions}
+        onChange={jest.fn()}
+        onRemovePart={jest.fn()}
+        onAddNewPart={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('mean', { selector: 'span' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'mean' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Remove mean' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Remove alias' })).toBeInTheDocument();
+  });
+
+  it('removes the selected part', async () => {
+    const user = userEvent.setup();
+    const onRemovePart = jest.fn();
+
+    render(
+      <PartListSection
+        parts={parts}
+        getNewPartOptions={getNewPartOptions}
+        onChange={jest.fn()}
+        onRemovePart={onRemovePart}
+        onAddNewPart={jest.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Remove alias' }));
+
+    expect(onRemovePart).toHaveBeenCalledWith(1);
+  });
+
+  it('updates an editable parameter', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+
+    render(
+      <PartListSection
+        parts={parts}
+        getNewPartOptions={getNewPartOptions}
+        onChange={onChange}
+        onRemovePart={jest.fn()}
+        onAddNewPart={jest.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'series' }));
+    const input = screen.getByRole('textbox');
+    await user.clear(input);
+    await user.type(input, 'renamed{Enter}');
+
+    expect(onChange).toHaveBeenCalledWith(1, ['renamed']);
+  });
+});

--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/PartListSection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/PartListSection.tsx
@@ -1,9 +1,9 @@
-import { css, cx } from '@emotion/css';
-import { Fragment, useMemo, type JSX } from 'react';
+import { css } from '@emotion/css';
+import { Fragment, type JSX } from 'react';
 
 import { type GrafanaTheme2, type SelectableValue } from '@grafana/data';
 import { AccessoryButton } from '@grafana/plugin-ui';
-import { useTheme2 } from '@grafana/ui';
+import { InlineLabel, useStyles2 } from '@grafana/ui';
 
 import { toSelectableValue } from '../utils/toSelectableValue';
 import { unwrap } from '../utils/unwrap';
@@ -27,41 +27,35 @@ type Props = {
   onAddNewPart: (type: string) => void;
 };
 
-const noRightMarginPaddingClass = css({
-  paddingRight: '0',
-  marginRight: '0',
-});
-
 type PartProps = {
   name: string;
   params: PartParams;
-  onRemove: () => void;
   onChange: (paramValues: string[]) => void;
 };
 
-const noHorizMarginPaddingClass = css({
-  paddingLeft: '0',
-  paddingRight: '0',
-  marginLeft: '0',
-  marginRight: '0',
+const getStyles = (theme: GrafanaTheme2) => ({
+  part: css({
+    paddingLeft: 0,
+    paddingRight: 0,
+    marginLeft: 0,
+    marginRight: 0,
+    lineHeight: theme.typography.body.lineHeight,
+    fontSize: theme.typography.body.fontSize,
+  }),
+  name: css({
+    paddingRight: 0,
+    marginRight: 0,
+  }),
+  segmentButton: css({
+    paddingLeft: 0,
+    paddingRight: 0,
+    marginLeft: 0,
+    marginRight: 0,
+  }),
 });
 
-const getPartClass = (theme: GrafanaTheme2) => {
-  return cx(
-    'gf-form-label',
-    css({
-      paddingLeft: '0',
-      // gf-form-label class makes certain css attributes incorrect
-      // for the selectbox-dropdown, so we have to "reset" them back
-      lineHeight: theme.typography.body.lineHeight,
-      fontSize: theme.typography.body.fontSize,
-    })
-  );
-};
-
 const Part = ({ name, params, onChange }: PartProps): JSX.Element => {
-  const theme = useTheme2();
-  const partClass = useMemo(() => getPartClass(theme), [theme]);
+  const styles = useStyles2(getStyles);
 
   const onParamChange = (par: string, i: number) => {
     const newParams = params.map((p) => p.value);
@@ -69,8 +63,11 @@ const Part = ({ name, params, onChange }: PartProps): JSX.Element => {
     onChange(newParams);
   };
   return (
-    <div className={partClass}>
-      <button className={cx('gf-form-label', noRightMarginPaddingClass)}>{name}</button>(
+    <InlineLabel as="div" width="auto" className={styles.part}>
+      <InlineLabel as="span" width="auto" className={styles.name}>
+        {name}
+      </InlineLabel>
+      (
       {params.map((p, i) => {
         const { value, options } = p;
         const isLast = i === params.length - 1;
@@ -81,7 +78,7 @@ const Part = ({ name, params, onChange }: PartProps): JSX.Element => {
             <Seg
               allowCustomValue
               value={value}
-              buttonClassName={noHorizMarginPaddingClass}
+              buttonClassName={styles.segmentButton}
               loadOptions={loadOptions}
               onChange={(v) => {
                 onParamChange(unwrap(v.value), i);
@@ -92,7 +89,7 @@ const Part = ({ name, params, onChange }: PartProps): JSX.Element => {
         );
       })}
       )
-    </div>
+    </InlineLabel>
   );
 };
 
@@ -110,16 +107,13 @@ export const PartListSection = ({
           <Part
             name={part.name}
             params={part.params}
-            onRemove={() => {
-              onRemovePart(index);
-            }}
             onChange={(pars) => {
               onChange(index, pars);
             }}
           />
           <AccessoryButton
             style={{ marginRight: '4px' }}
-            aria-label="remove"
+            aria-label={`Remove ${part.name}`}
             icon="times"
             variant="secondary"
             onClick={() => {


### PR DESCRIPTION
**What is this feature?**

Migrates `PartListSection` in the InfluxQL visual query editor from deprecated `gf-form-label` SASS classes to `InlineLabel` and Emotion styles. It also replaces non-functional button markup for part names with semantic labels and adds descriptive accessible names to remove actions.

**Why do we need this feature?**

This removes one remaining `gf-form` occurrence tracked in #65513, aligns the component with Grafana UI styling conventions, and improves semantics and accessibility.

**Who is this feature for?**

Users and maintainers of the InfluxDB InfluxQL visual query editor.

**Which issue(s) does this PR fix?**

Part of #65513.

**Special notes for your reviewer:**

Verification:
- focused `PartListSection` tests
- full `@grafana-plugins/influxdb` test suite (29 suites, 265 tests)
- `@grafana-plugins/influxdb` build
- targeted ESLint and Prettier checks

Please check that:
- [x] It works as expected from a user's perspective.
- [x] This is not a pre-GA feature change.
- [x] Documentation is unaffected because user-visible behavior and configuration are unchanged.
