### PR TITLE
unified-search: keep waiting when another replica holds the build lock

### DIFF
--- a/pkg/storage/unified/search/kv_remote_index_store.go
+++ b/pkg/storage/unified/search/kv_remote_index_store.go
@@ -608,6 +608,9 @@ func (s *KVRemoteIndexStore) DeleteIndex(ctx context.Context, nsResource resourc
 // build version. The lease is automatically renewed in the background while
 // it is held; if renewal fails (e.g. another holder takes over), Lost() is
 // signaled and Release() returns ErrLeaseLost.
+//
+// If another replica already holds the lease, the returned error matches
+// errLockHeld.
 func (s *KVRemoteIndexStore) LockBuildIndex(ctx context.Context, nsResource resource.NamespacedResource, buildVersion string) (IndexStoreLock, error) {
 	if err := validateNsResource(nsResource); err != nil {
 		return nil, err
@@ -621,6 +624,9 @@ func (s *KVRemoteIndexStore) LockBuildIndex(ctx context.Context, nsResource reso
 // LockNamespaceForCleanup acquires the cleanup lease for the given namespace.
 // Uses a distinct key from LockBuildIndex so cleanup never blocks an in-flight
 // upload for any resource in the namespace.
+//
+// If another replica already holds the lease, the returned error matches
+// errLockHeld.
 func (s *KVRemoteIndexStore) LockNamespaceForCleanup(ctx context.Context, namespace string) (IndexStoreLock, error) {
 	if err := validateNamespace(namespace); err != nil {
 		return nil, err
@@ -655,6 +661,12 @@ func (s *KVRemoteIndexStore) acquireLock(ctx context.Context, name string, opts 
 
 	l, err := s.leaseMgr.Acquire(ctx, name, lease.WithTTL(ttl), lease.WithAutoRenew())
 	if err != nil {
+		// Callers match errLockHeld to decide whether to keep waiting for the
+		// leader. Translated rather than wrapped so the lease sentinel stays an
+		// implementation detail of this store.
+		if errors.Is(err, lease.ErrLeaseAlreadyHeld) {
+			return nil, fmt.Errorf("acquiring lease %q: %w: %v", name, errLockHeld, err)
+		}
 		return nil, fmt.Errorf("acquiring lease %q: %w", name, err)
 	}
 	return &kvIndexStoreLock{

--- a/pkg/storage/unified/search/kv_remote_index_store_test.go
+++ b/pkg/storage/unified/search/kv_remote_index_store_test.go
@@ -477,7 +477,10 @@ func TestKVRemoteIndexStore_LockBuildIndex_Contention(t *testing.T) {
 
 	_, err = store2.LockBuildIndex(ctx, ns, "11.5.0")
 	require.Error(t, err)
-	require.ErrorIs(t, err, lease.ErrLeaseAlreadyHeld)
+	// Build coordination keeps waiting only for errLockHeld. The lease
+	// sentinel stays internal to the store.
+	require.ErrorIs(t, err, errLockHeld)
+	require.NotErrorIs(t, err, lease.ErrLeaseAlreadyHeld)
 
 	require.NoError(t, lock1.Release())
 
@@ -539,7 +542,7 @@ func TestKVRemoteIndexStore_LockNamespaceForCleanup_Contention(t *testing.T) {
 	t.Cleanup(func() { _ = lock1.Release() })
 
 	_, err = store2.LockNamespaceForCleanup(ctx, "stack-1")
-	require.ErrorIs(t, err, lease.ErrLeaseAlreadyHeld)
+	require.ErrorIs(t, err, errLockHeld)
 
 	// Different namespace must be acquirable independently.
 	lock2, err := store2.LockNamespaceForCleanup(ctx, "stack-2")

--- a/pkg/storage/unified/search/remote_index_store.go
+++ b/pkg/storage/unified/search/remote_index_store.go
@@ -122,11 +122,14 @@ type IndexStoreLock interface {
 type RemoteIndexStore interface {
 	// LockBuildIndex acquires a distributed build/upload lock for namespace/group/resource.
 	// buildVersion scopes contention to replicas running the same exact Grafana version.
+	// When another replica holds the lock, the returned error must match errLockHeld:
+	// build coordination relies on that to keep waiting instead of building alone.
 	LockBuildIndex(ctx context.Context, nsResource resource.NamespacedResource, buildVersion string) (IndexStoreLock, error)
 
 	// LockNamespaceForCleanup acquires a distributed cleanup lock for a namespace.
 	// Uses a different lock key than LockBuildIndex so cleanup never blocks an
 	// in-flight upload for any resource in the namespace.
+	// When another replica holds the lock, the returned error must match errLockHeld.
 	LockNamespaceForCleanup(ctx context.Context, namespace string) (IndexStoreLock, error)
 
 	// WriteSnapshotFile writes one data file at relPath under the snapshot


### PR DESCRIPTION
When several replicas start together and none can reuse an existing snapshot, one takes a lock and builds the index while the others wait and download the result.

The waiting side was broken for the KV-backed store: it returned a different error than the one the coordination loop expects, so a replica that lost the lock treated it as a failure and built the whole index by itself. Seen in dev-us-central-0 / grafana-kvtest on 2026-07-30, where a replica spent about 38 minutes duplicating the leader's work.

The store now reports contention using the expected error, keeping the lease-specific one internal. Periodic rebuilds and namespace cleanup check the same error, so they're fixed too. The interface now states this as part of its contract.

Existing lock contention tests extended; they fail without the fix.