### PR TITLE
fix: add allow_git_private_ip setting for private Git repository URLs [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2577,6 +2577,13 @@ allow_insecure = false
 # the host is used), a literal IP, or a CIDR. Empty by default.
 allowed_git_urls =
 
+# If true, allows repository URLs that resolve to private (RFC 1918) IP addresses.
+# This is a security-sensitive setting — only enable it when you are certain the
+# Git server is on a trusted network. When false, private IPs are rejected by
+# default and must be explicitly allowed via allowed_git_urls.
+# Default: false.
+allow_git_private_ip = false
+
 # The minimum sync interval that can be set for a repository. This is how often the controller
 # will check if there has been any changes to the repository not propagated by a webhook.
 # The minimum value is 10 seconds.

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -369,6 +369,23 @@ func RegisterAPIService(
 	if err != nil {
 		return nil, fmt.Errorf("invalid allowed_git_urls configuration: %w", err)
 	}
+
+	// allow_git_private_ip controls whether private (RFC 1918) IP addresses are allowed
+	// for Git repository URLs. When true, private IP ranges are added to the allowlist
+	// so that the URL validator does not reject them. This is a security-sensitive setting
+	// that should only be enabled when the Git server is on a trusted network.
+	allowPrivateIP := provisioningSec.Key("allow_git_private_ip").MustBool(false)
+	if allowPrivateIP {
+		// Add RFC 1918 private IP ranges to the allowlist
+		allowlist, err = repository.NewAllowlist(append(allowListConfig,
+			"10.0.0.0/8",
+			"172.16.0.0/12",
+			"192.168.0.0/16",
+		))
+		if err != nil {
+			return nil, fmt.Errorf("failed to build allowlist with private IP ranges: %w", err)
+		}
+	}
 	urlValidator := repository.NewURLValidator(allowlist, net.DefaultResolver.LookupIPAddr)
 	repoValidatorOpts := []repository.ValidatorOption{repository.WithURLValidator(urlValidator)}
 


### PR DESCRIPTION
Fixes #129664

## Problem

The private-endpoint validation introduced in the current release (validatePrivateEndpoint in apps/provisioning/pkg/repository/validator.go) rejects Git repository URLs that resolve to private (RFC 1918) IP addresses by default. This breaks existing deployments that use on-prem Git servers on private networks.

Users who previously had their Git sync working now see:
> repository URL host must resolve to a public or allowed address

## Solution

Add a new `allow_git_private_ip` configuration setting under the `[provisioning]` section. When set to `true`, the RFC 1918 private IP ranges (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) are added to the URL allowlist so that the URL validator does not reject private Git repository URLs.

This is a security-sensitive setting that defaults to `false`, preserving the SSRF protection by default. Users with on-prem Git servers on private networks can enable it via environment variable:

```
GF_PROVISIONING_ALLOW_GIT_PRIVATE_IP=true
```

Or in the configuration file:

```ini
[provisioning]
allow_git_private_ip = true
```

## Testing

- Set `allow_git_private_ip = true` and verify private Git repository URLs (e.g., `http://192.168.1.100/myrepo.git`) are accepted
- Default (`false`) should still reject private IPs unless they are explicitly added to `allowed_git_urls`
