### PR TITLE
fix(alerting): fallback to contains search for long contact point queries

### DIFF
--- a/public/app/features/alerting/unified/components/contact-points/useContactPointsSearch.test.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/useContactPointsSearch.test.tsx
@@ -1,0 +1,59 @@
+import { renderHook } from 'test/test-utils';
+
+import { RECEIVER_META_KEY } from './constants';
+import { useContactPointsSearch } from './useContactPointsSearch';
+import { type ContactPointWithMetadata } from './utils';
+
+const makeContactPoint = (name: string, receiverTypeName: string): ContactPointWithMetadata => ({
+  id: name,
+  name,
+  grafana_managed_receiver_configs: [
+    {
+      name: receiverTypeName,
+      type: 'email',
+      disableResolveMessage: false,
+      settings: {},
+      [RECEIVER_META_KEY]: {
+        name: receiverTypeName,
+      },
+    },
+  ],
+});
+
+describe('useContactPointsSearch', () => {
+  const contactPoints: ContactPointWithMetadata[] = [
+    makeContactPoint('team-primary-email', 'Email'),
+    makeContactPoint('pagerduty-critical', 'PagerDuty'),
+    makeContactPoint('RBAC_Team_Alert_Writer-UPDATED-admin-contact-point-1784911123489', 'Webhook'),
+  ];
+
+  it('returns all contact points when search is empty', () => {
+    const { result } = renderHook(() => useContactPointsSearch(contactPoints, ''));
+
+    expect(result.current).toHaveLength(3);
+  });
+
+  it('uses fuzzy matching for short queries', () => {
+    const { result } = renderHook(() => useContactPointsSearch(contactPoints, 'pagerduty'));
+
+    expect(result.current).toEqual([contactPoints[1]]);
+  });
+
+  it('uses contains matching for long queries and still finds exact-ish contact point names', () => {
+    const longSearch = 'RBAC_Team_Alert_Writer-UPDATED-admin-contact-point-1784911123489';
+
+    const { result } = renderHook(() => useContactPointsSearch(contactPoints, longSearch));
+
+    expect(result.current).toEqual([contactPoints[2]]);
+  });
+
+  it('uses contains matching for long queries against receiver type names', () => {
+    const longSearch = 'pagerduty-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+    const cpWithLongType = makeContactPoint('alerts-oncall', longSearch);
+
+    const { result } = renderHook(() => useContactPointsSearch([...contactPoints, cpWithLongType], longSearch));
+
+    expect(result.current).toEqual([cpWithLongType]);
+  });
+});

--- a/public/app/features/alerting/unified/components/contact-points/useContactPointsSearch.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/useContactPointsSearch.tsx
@@ -5,6 +5,8 @@ import { useMemo } from 'react';
 import { RECEIVER_META_KEY } from 'app/features/alerting/unified/components/contact-points/constants';
 import { type ContactPointWithMetadata } from 'app/features/alerting/unified/components/contact-points/utils';
 
+const LONG_QUERY_LENGTH_THRESHOLD = 40;
+
 const fuzzyFinder = new uFuzzy({
   intraMode: 1,
   intraIns: 1,
@@ -18,6 +20,8 @@ export const useContactPointsSearch = (
   contactPoints: ContactPointWithMetadata[],
   search?: string | null
 ): ContactPointWithMetadata[] => {
+  const normalizedSearch = search?.trim();
+
   const nameHaystack = useMemo(() => {
     return contactPoints.map((contactPoint) => contactPoint.name);
   }, [contactPoints]);
@@ -29,12 +33,31 @@ export const useContactPointsSearch = (
     );
   }, [contactPoints]);
 
-  if (!search) {
+  if (!normalizedSearch) {
     return contactPoints;
   }
 
-  const nameHits = fuzzyFinder.filter(nameHaystack, search) ?? [];
-  const typeHits = fuzzyFinder.filter(typeHaystack, search) ?? [];
+  // Long, separator-heavy queries can trigger expensive regex backtracking in fuzzy matching.
+  // For these cases, use a deterministic contains check to keep typing responsive.
+  if (normalizedSearch.length >= LONG_QUERY_LENGTH_THRESHOLD) {
+    const lowerSearch = normalizedSearch.toLocaleLowerCase();
+
+    const hits = contactPoints
+      .map((contactPoint, index) => ({ contactPoint, index }))
+      .filter(({ contactPoint }) => {
+        const nameMatch = contactPoint.name.toLocaleLowerCase().includes(lowerSearch);
+        const typeMatch = contactPoint.grafana_managed_receiver_configs
+          .some((receiver) => receiver[RECEIVER_META_KEY].name.toLocaleLowerCase().includes(lowerSearch));
+
+        return nameMatch || typeMatch;
+      })
+      .map(({ index }) => index);
+
+    return hits.map((id) => contactPoints[id]);
+  }
+
+  const nameHits = fuzzyFinder.filter(nameHaystack, normalizedSearch) ?? [];
+  const typeHits = fuzzyFinder.filter(typeHaystack, normalizedSearch) ?? [];
 
   const hits = [...nameHits, ...typeHits];
 

--- a/public/app/features/alerting/unified/components/contact-points/useContactPointsSearch.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/useContactPointsSearch.tsx
@@ -1,19 +1,9 @@
-import uFuzzy from '@leeoniya/ufuzzy';
+import { fuzzySearch } from '@grafana/data';
 import { uniq } from 'lodash';
 import { useMemo } from 'react';
 
 import { RECEIVER_META_KEY } from 'app/features/alerting/unified/components/contact-points/constants';
 import { type ContactPointWithMetadata } from 'app/features/alerting/unified/components/contact-points/utils';
-
-const LONG_QUERY_LENGTH_THRESHOLD = 40;
-
-const fuzzyFinder = new uFuzzy({
-  intraMode: 1,
-  intraIns: 1,
-  intraSub: 1,
-  intraDel: 1,
-  intraTrn: 1,
-});
 
 // let's search in two different haystacks, the name of the contact point and the type of the receiver(s)
 export const useContactPointsSearch = (
@@ -37,27 +27,8 @@ export const useContactPointsSearch = (
     return contactPoints;
   }
 
-  // Long, separator-heavy queries can trigger expensive regex backtracking in fuzzy matching.
-  // For these cases, use a deterministic contains check to keep typing responsive.
-  if (normalizedSearch.length >= LONG_QUERY_LENGTH_THRESHOLD) {
-    const lowerSearch = normalizedSearch.toLocaleLowerCase();
-
-    const hits = contactPoints
-      .map((contactPoint, index) => ({ contactPoint, index }))
-      .filter(({ contactPoint }) => {
-        const nameMatch = contactPoint.name.toLocaleLowerCase().includes(lowerSearch);
-        const typeMatch = contactPoint.grafana_managed_receiver_configs
-          .some((receiver) => receiver[RECEIVER_META_KEY].name.toLocaleLowerCase().includes(lowerSearch));
-
-        return nameMatch || typeMatch;
-      })
-      .map(({ index }) => index);
-
-    return hits.map((id) => contactPoints[id]);
-  }
-
-  const nameHits = fuzzyFinder.filter(nameHaystack, normalizedSearch) ?? [];
-  const typeHits = fuzzyFinder.filter(typeHaystack, normalizedSearch) ?? [];
+  const nameHits = fuzzySearch(nameHaystack, normalizedSearch);
+  const typeHits = fuzzySearch(typeHaystack, normalizedSearch);
 
   const hits = [...nameHits, ...typeHits];
 

--- a/public/app/features/alerting/unified/components/contact-points/useContactPointsSearch.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/useContactPointsSearch.tsx
@@ -1,7 +1,7 @@
-import { fuzzySearch } from '@grafana/data';
 import { uniq } from 'lodash';
 import { useMemo } from 'react';
 
+import { fuzzySearch } from '@grafana/data';
 import { RECEIVER_META_KEY } from 'app/features/alerting/unified/components/contact-points/constants';
 import { type ContactPointWithMetadata } from 'app/features/alerting/unified/components/contact-points/utils';
 


### PR DESCRIPTION
**What is this feature?**

This PR improves Contact Point search performance in Alerting by introducing a hybrid search strategy:
- Keep fuzzy search for short queries.
- Fallback to deterministic case-insensitive `contains` matching for long queries.

It specifically updates `useContactPointsSearch` to avoid expensive fuzzy-regex paths on long, separator-heavy inputs.

**Why do we need this feature?**

Searching with long Contact Point names (for example full generated names with many separators) can cause the page to become unresponsive while typing.  
This change prevents that slowdown by avoiding the fuzzy path when input length reaches a threshold, preserving responsiveness without removing fuzzy search for normal short queries.

**Who is this feature for?**

This is for Grafana users configuring Alerting notifications, especially users who search Contact Points using long names (common in automated or RBAC-generated naming patterns).

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/129351

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.

Additional reviewer context:
- Added unit tests for:
  - empty search behavior
  - short-query fuzzy behavior
  - long-query contains fallback by contact point name
  - long-query contains fallback by receiver type
- Targeted test run passed:
  - `yarn jest --no-watch public/app/features/alerting/unified/components/contact-points/useContactPointsSearch.test.tsx`