### PR TITLE
fix: check rows.Err() after xorm row iteration in alert rule queries (#129342)

### DIFF
--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -139,6 +139,9 @@ func (st DBstore) getLatestVersionOfRulesByUID(ctx context.Context, orgID int64,
 			}
 			result = append(result, *rule)
 		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
 		return nil
 	})
 	if err != nil {
@@ -285,6 +288,9 @@ func (st DBstore) GetAlertRuleVersions(ctx context.Context, orgID int64, guid st
 			previousVersion = rule
 			alertRules = append(alertRules, &converted)
 		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
 		return nil
 	})
 	if err != nil {
@@ -349,6 +355,9 @@ func (st DBstore) ListDeletedRules(ctx context.Context, orgID int64) ([]*ngmodel
 				continue
 			}
 			alertRules = append(alertRules, &converted)
+		}
+		if err := rows.Err(); err != nil {
+			return err
 		}
 		return nil
 	})


### PR DESCRIPTION
## Description

Fixes #129342

Three functions in `pkg/services/ngalert/store/alert_rule.go` iterate xorm `Rows` but never call `rows.Err()` after the loop:

- `getLatestVersionOfRulesByUID`
- `GetAlertRuleVersions`
- `ListDeletedRules`

If the database connection drops or the cursor fails mid-iteration, `rows.Next()` returns `false` and the loop exits normally. The function then returns a **partial result with a `nil` error**, silently hiding the failure from the caller.

**Impact**: Alert rule queries return incomplete data with no error signal. Callers (scheduler, rule evaluator) operate on a truncated rule set, potentially missing active alert rules entirely.

**Fix**: Add `if err := rows.Err(); err != nil { return err }` after each `for rows.Next()` loop, following the standard Go pattern recommended by `database/sql` and xorm docs.
