### PR TITLE
fix: use user locale for moment.js locale instead of UI language (#129829)

### DIFF
--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -217,7 +217,10 @@ export class GrafanaApp {
         registry.warnUnregistered();
       }
 
-      setLocale(contextSrv.user.language);
+      // Use the user locale (which includes regional info) for moment.js locale,
+      // falling back to the UI language. The locale field is returned by the
+      // backend as part of the user's browser locale.
+      setLocale((contextSrv.user as any).locale || contextSrv.user.language);
       setWeekStart(contextSrv.user.weekStart);
       setPanelRenderer(PanelRenderer);
       setPluginPage(PluginPage);


### PR DESCRIPTION
## Description

Fixes #129829

In Grafana 12, the `locale` preference was split into `language` (UI language) and `regionalFormat` (regional format). The `setLocale()` call in `app.ts` was changed to use the UI language (`contextSrv.user.language`), which is always `en-US` by default, losing the regional information from the browser locale.

This causes the `now/w` time range to always start on Sunday, even for locales like `en-GB` or `de-DE` where Monday is the first day of the week.

### Root cause

In 11.6.16, `getLocale()` returned region-specific values:
| Browser locale | `getLocale()` |
|---|---|
| en-GB | `en-gb` |
| de-DE | `de` |
| ja-JP | `ja` |

In 13.1.1, `getLocale()` always returns `en` because `setLocale()` is called with the UI language (`en-US`) instead of the browser locale.

`Intl.Locale('en').weekInfo.firstDay` is `7` (Sunday), which matches the observed behaviour exactly.

### Fix

Use `contextSrv.user.locale` (which includes regional info like `en-GB`) with a fallback to `contextSrv.user.language`. The `locale` field is returned by the backend as part of the `CurrentUser` DTO.

### Verification

- en-GB browser locale: `getLocale()` returns `en-gb` → `Intl.Locale('en-gb').weekInfo.firstDay` = 1 (Monday) ✅
- de-DE browser locale: `getLocale()` returns `de` → `Intl.Locale('de').weekInfo.firstDay` = 1 (Monday) ✅
- en-US browser locale: `getLocale()` returns `en` → `Intl.Locale('en').weekInfo.firstDay` = 7 (Sunday) ✅ (unchanged)
- ja-JP browser locale: `getLocale()` returns `ja` → `Intl.Locale('ja').weekInfo.firstDay` = 7 (Sunday) ✅ (unchanged)