### PR TITLE
Notebooks: Add frontend experience for internal dogfooding

### DIFF
--- a/packages/grafana-data/src/panel/getPanelOptionsWithDefaults.test.ts
+++ b/packages/grafana-data/src/panel/getPanelOptionsWithDefaults.test.ts
@@ -4,7 +4,7 @@ import { standardEditorsRegistry, standardFieldConfigEditorRegistry } from '../f
 import { type FieldConfig } from '../types/dataFrame';
 import { FieldColorModeId } from '../types/fieldColor';
 import { type ConfigOverrideRule, FieldConfigProperty, type FieldConfigSource } from '../types/fieldOverrides';
-import { ThresholdsMode } from '../types/thresholds';
+import { type ThresholdsConfig, ThresholdsMode } from '../types/thresholds';
 
 import { type PanelPlugin, type StandardOptionConfig } from './PanelPlugin';
 import { getPanelOptionsWithDefaults, restoreCustomOverrideRules } from './getPanelOptionsWithDefaults';
@@ -265,6 +265,35 @@ describe('getPanelOptionsWithDefaults', () => {
       });
 
       expect(result.fieldConfig.defaults.thresholds).toBeUndefined();
+    });
+  });
+
+  describe('when fieldConfig comes from an immutable source', () => {
+    it('should normalize threshold base value without mutating frozen steps', () => {
+      const steps = Object.freeze([
+        Object.freeze({ color: 'green', value: null as unknown as number }),
+        Object.freeze({ color: 'red', value: 80 }),
+      ]);
+      // Simulate an Immer/RTK-frozen thresholds object from an API response.
+      // Cast through unknown: Object.freeze widens to readonly types that aren't
+      // assignable to ThresholdsConfig, but that's the runtime shape we care about.
+      const thresholds = Object.freeze({
+        mode: ThresholdsMode.Absolute,
+        steps,
+      }) as unknown as ThresholdsConfig;
+
+      const result = getPanelOptionsWithDefaults({
+        plugin: pluginA,
+        currentOptions: {},
+        currentFieldConfig: {
+          defaults: { thresholds },
+          overrides: [],
+        },
+        isAfterPluginChange: false,
+      });
+
+      expect(result.fieldConfig.defaults.thresholds?.steps[0].value).toBe(-Infinity);
+      expect(steps[0].value).toBeNull();
     });
   });
 

--- a/packages/grafana-data/src/panel/getPanelOptionsWithDefaults.ts
+++ b/packages/grafana-data/src/panel/getPanelOptionsWithDefaults.ts
@@ -191,9 +191,9 @@ function fixThresholds(thresholds: ThresholdsConfig) {
   if (!thresholds.steps) {
     thresholds.steps = [];
   } else if (thresholds.steps.length) {
-    // First value is always -Infinity
-    // JSON saves it as null
-    thresholds.steps[0].value = -Infinity;
+    // First value is always -Infinity (JSON saves it as null). Clone the steps
+    // array/objects so we never mutate immutable sources (RTK Query / Immer).
+    thresholds.steps = thresholds.steps.map((step, index) => (index === 0 ? { ...step, value: -Infinity } : step));
   }
 }
 

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -200,6 +200,9 @@ export const versionedComponents = {
     zoomOut: {
       '12.4.0': 'data-testid explore-toolbar-timepicker-zoom-out-button',
     },
+    zoomIn: {
+      '13.2.0': 'data-testid TimePicker zoom in button',
+    },
     openButton: {
       [MIN_GRAFANA_VERSION]: 'data-testid TimePicker Open Button',
     },

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.test.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.test.tsx
@@ -172,6 +172,41 @@ it('shows t - in zoom out tooltip', async () => {
   expect(await screen.findByText(/t -/)).toBeInTheDocument();
 });
 
+it('renders zoom in when onZoomIn is provided', async () => {
+  const onZoomIn = jest.fn();
+  render(
+    <TimeRangePicker
+      onChangeTimeZone={() => {}}
+      onChange={(value) => {}}
+      value={value}
+      onMoveBackward={() => {}}
+      onMoveForward={() => {}}
+      onZoom={() => {}}
+      onZoomIn={onZoomIn}
+    />
+  );
+
+  const zoomInButton = screen.getByLabelText('Zoom in time range');
+  expect(zoomInButton).toBeInTheDocument();
+  await userEvent.click(zoomInButton);
+  expect(onZoomIn).toHaveBeenCalledTimes(1);
+});
+
+it('hides zoom in when onZoomIn is omitted', () => {
+  render(
+    <TimeRangePicker
+      onChangeTimeZone={() => {}}
+      onChange={(value) => {}}
+      value={value}
+      onMoveBackward={() => {}}
+      onMoveForward={() => {}}
+      onZoom={() => {}}
+    />
+  );
+
+  expect(screen.queryByLabelText('Zoom in time range')).not.toBeInTheDocument();
+});
+
 describe('TimePickerTooltip', () => {
   beforeAll(() => {
     const mockIntl = {

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
@@ -59,6 +59,8 @@ export interface TimeRangePickerProps {
   moveForwardTooltip?: string;
   moveBackwardTooltip?: string;
   onZoom: () => void;
+  /** Optional zoom-in control (shown next to zoom-out when provided). */
+  onZoomIn?: () => void;
   onError?: (error?: string) => void;
   history?: TimeRange[];
   quickRanges?: TimeOption[];
@@ -83,6 +85,7 @@ export function TimeRangePicker(props: TimeRangePickerProps) {
     moveForwardTooltip,
     moveBackwardTooltip,
     onZoom,
+    onZoomIn,
     onError,
     timeZone,
     fiscalYearStartMonth,
@@ -237,11 +240,32 @@ export function TimeRangePicker(props: TimeRangePickerProps) {
           variant={variant}
         />
       </Tooltip>
+
+      {onZoomIn && (
+        <Tooltip content={ZoomInTooltip} placement="bottom">
+          <ToolbarButton
+            aria-label={t('time-picker.range-picker.zoom-in-button', 'Zoom in time range')}
+            onClick={onZoomIn}
+            icon="search-plus"
+            type="button"
+            data-testid={selectors.components.TimePicker.zoomIn}
+            variant={variant}
+          />
+        </Tooltip>
+      )}
     </ButtonGroup>
   );
 }
 
 TimeRangePicker.displayName = 'TimeRangePicker';
+
+const ZoomInTooltip = () => {
+  return (
+    <Trans i18nKey="time-picker.range-picker.zoom-in-tooltip">
+      Time range zoom in <br /> t +
+    </Trans>
+  );
+};
 
 const ZoomOutTooltip = () => {
   return (

--- a/public/app/api/clients/dashboard/v2beta1/index.ts
+++ b/public/app/api/clients/dashboard/v2beta1/index.ts
@@ -102,6 +102,11 @@ export const {
   useUpdateVariableMutation,
   useDeleteVariableMutation,
   useReplaceVariableMutation,
+  useListNotebookQuery,
+  useGetNotebookQuery,
+  useCreateNotebookMutation,
+  useReplaceNotebookMutation,
+  useDeleteNotebookMutation,
 } = dashboardAPIv2beta1;
 
 // eslint-disable-next-line no-barrel-files/no-barrel-files
@@ -112,4 +117,7 @@ export type {
   ListVariableApiResponse,
   CreateVariableApiArg,
   UpdateVariableApiArg,
+  Notebook,
+  NotebookList,
+  NotebookSpec,
 } from '@grafana/api-clients/rtkq/dashboard/v2beta1';

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.test.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, act } from '@testing-library/react';
 import { useAsync } from 'react-use';
 
 import { store, EventBusSrv, type EventBus, type ExtensionInfo } from '@grafana/data';
-import { getAppEvents, setAppEvents, locationService } from '@grafana/runtime';
+import { getAppEvents, setAppEvents, locationService, usePluginLinks } from '@grafana/runtime';
 import { OpenExtensionSidebarEvent, CloseExtensionSidebarEvent, ToggleExtensionSidebarEvent } from 'app/types/events';
 
 import {
@@ -10,6 +10,7 @@ import {
   useExtensionSidebarContext,
   getComponentIdFromComponentMeta,
   getComponentMetaFromComponentId,
+  getInteractiveLearningPluginId,
   EXTENSION_SIDEBAR_DOCKED_LOCAL_STORAGE_KEY,
 } from './ExtensionSidebarProvider';
 
@@ -141,6 +142,21 @@ describe('ExtensionSidebarProvider', () => {
     expect(screen.getByTestId('docked-component-id')).toHaveTextContent(componentId);
   });
 
+  it('should clear a docked component that is no longer available', () => {
+    // A component of a permitted plugin that is not among its added components anymore.
+    const componentId = getComponentIdFromComponentMeta(mockPluginMeta.pluginId, 'Removed Component');
+    (store.get as jest.Mock).mockReturnValue(componentId);
+
+    render(
+      <ExtensionSidebarContextProvider>
+        <TestComponent />
+      </ExtensionSidebarContextProvider>
+    );
+
+    expect(screen.getByTestId('is-open')).toHaveTextContent('false');
+    expect(screen.getByTestId('docked-component-id')).toHaveTextContent('undefined');
+  });
+
   it('should update storage when docked component changes', () => {
     const componentId = getComponentIdFromComponentMeta(mockPluginMeta.pluginId, mockComponent.title);
 
@@ -215,6 +231,61 @@ describe('ExtensionSidebarProvider', () => {
     // Should only include the enabled plugin
     expect(screen.getByTestId('available-components-size')).toHaveTextContent('1');
     expect(screen.getByTestId('plugin-ids')).toHaveTextContent(permittedPluginMeta.pluginId);
+  });
+
+  it('should synthesize an available component for core-registered sidebar links', () => {
+    // Core components (pluginId 'grafana') are not app plugins: they have no entry in
+    // the app plugin meta map and are derived from their registered links instead.
+    const usePluginLinksMock = jest.mocked(usePluginLinks);
+    usePluginLinksMock.mockReturnValue({
+      links: [
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- only the fields the provider reads
+        { pluginId: 'grafana', title: 'Notebooks', description: 'Core notebooks panel' } as ReturnType<
+          typeof usePluginLinks
+        >['links'][number],
+      ],
+      isLoading: false,
+    });
+    useAsyncMock.mockReturnValue({ loading: false, value: new Map() });
+
+    try {
+      render(
+        <ExtensionSidebarContextProvider>
+          <TestComponent />
+        </ExtensionSidebarContextProvider>
+      );
+
+      expect(screen.getByTestId('available-components-size')).toHaveTextContent('1');
+      expect(screen.getByTestId('plugin-ids')).toHaveTextContent('grafana');
+
+      // Opening a core-synthesized component exercises the same permission path as plugin apps.
+      act(() => {
+        const openCall = subscribeSpy.mock.calls.find((call) => call[0] === OpenExtensionSidebarEvent);
+        const [, subscriberFn] = openCall!;
+        subscriberFn(
+          new OpenExtensionSidebarEvent({
+            pluginId: 'grafana',
+            componentTitle: 'Notebooks',
+          })
+        );
+      });
+
+      expect(screen.getByTestId('is-open')).toHaveTextContent('true');
+      expect(screen.getByTestId('docked-component-id')).toHaveTextContent(
+        JSON.stringify({ pluginId: 'grafana', componentTitle: 'Notebooks' })
+      );
+    } finally {
+      // Later tests rely on the module-level default implementation.
+      usePluginLinksMock.mockImplementation(() => ({
+        links: [
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- only the fields the provider reads
+          { pluginId: mockPluginMeta.pluginId, title: mockComponent.title } as ReturnType<
+            typeof usePluginLinks
+          >['links'][number],
+        ],
+        isLoading: false,
+      }));
+    }
   });
 
   it('should subscribe to OpenExtensionSidebarEvent and CloseExtensionSidebarEvent when feature is enabled', async () => {
@@ -599,6 +670,27 @@ describe('Utility Functions', () => {
     it('should return undefined for wrong field types', () => {
       const meta = getComponentMetaFromComponentId(JSON.stringify({ pluginId: 123, componentTitle: 'Test Component' }));
       expect(meta).toBeUndefined();
+    });
+  });
+
+  describe('getInteractiveLearningPluginId', () => {
+    const emptyMeta = { addedComponents: [], addedLinks: [] };
+
+    it('prefers the pathfinder plugin when both learning plugins are available', () => {
+      const components = new Map([
+        ['grafana-pathfinder-app', emptyMeta],
+        ['grafana-grafanadocsplugin-app', emptyMeta],
+      ]);
+      expect(getInteractiveLearningPluginId(components)).toBe('grafana-pathfinder-app');
+    });
+
+    it('falls back to the docs plugin when pathfinder is not available', () => {
+      const components = new Map([['grafana-grafanadocsplugin-app', emptyMeta]]);
+      expect(getInteractiveLearningPluginId(components)).toBe('grafana-grafanadocsplugin-app');
+    });
+
+    it('returns undefined when no learning plugin is available', () => {
+      expect(getInteractiveLearningPluginId(new Map())).toBeUndefined();
     });
   });
 });

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx
@@ -16,6 +16,8 @@ import {
 export const EXTENSION_SIDEBAR_DOCKED_LOCAL_STORAGE_KEY = 'grafana.navigation.extensionSidebarDocked';
 const EXTENSION_SIDEBAR_WIDTH_LOCAL_STORAGE_KEY = 'grafana.navigation.extensionSidebarWidth';
 const PERMITTED_EXTENSION_SIDEBAR_PLUGINS = [
+  // Core-provided sidebar components (e.g. the notebooks workspace panel).
+  'grafana',
   'grafana-assistant-app',
   'grafana-assistant-onboarding-app',
   'grafana-dash-app',
@@ -114,21 +116,40 @@ export const ExtensionSidebarContextProvider = ({ children }: ExtensionSidebarCo
 
   // get all components for this extension point, but only for the permitted plugins
   // if the extension sidebar is not enabled, we will return an empty map
-  const availableComponents = useMemo(
-    () =>
-      new Map(
-        Array.from(pluginMap?.entries() || []).filter(
-          ([pluginId, pluginMeta]) =>
-            PERMITTED_EXTENSION_SIDEBAR_PLUGINS.includes(pluginId) &&
-            links.some(
-              (link) =>
-                link.pluginId === pluginId &&
-                pluginMeta.addedComponents.some((component) => component.title === link.title)
-            )
-        )
-      ),
-    [links, pluginMap]
-  );
+  const availableComponents = useMemo(() => {
+    const map = new Map(
+      Array.from(pluginMap?.entries() || []).filter(
+        ([pluginId, pluginMeta]) =>
+          PERMITTED_EXTENSION_SIDEBAR_PLUGINS.includes(pluginId) &&
+          links.some(
+            (link) =>
+              link.pluginId === pluginId &&
+              pluginMeta.addedComponents.some((component) => component.title === link.title)
+          )
+      )
+    );
+
+    // Core-registered sidebar components (pluginId 'grafana') are not app plugins, so
+    // they are absent from the app plugin meta map; synthesize their entry from the
+    // registered links (core also registers a component with the matching title).
+    const coreLinks = links.filter((link) => link.pluginId === 'grafana' && link.title);
+    if (coreLinks.length > 0) {
+      map.set('grafana', {
+        addedComponents: coreLinks.map((link) => ({
+          targets: [PluginExtensionPoints.ExtensionSidebar],
+          title: link.title,
+          description: link.description,
+        })),
+        addedLinks: coreLinks.map((link) => ({
+          targets: [PluginExtensionPoints.ExtensionSidebar],
+          title: link.title,
+          description: link.description,
+        })),
+      });
+    }
+
+    return map;
+  }, [links, pluginMap]);
 
   // check if the stored docked component is still available
   let defaultDockedComponentId: string | undefined;

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItemButton.test.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItemButton.test.tsx
@@ -51,6 +51,8 @@ describe('ExtensionToolbarItemButton', () => {
     ['grafana-grafanadocsplugin-app', 'book'],
     ['grafana-pathfinder-app', 'book'],
     ['grafana-grotfood-app', 'gf-grotfood'],
+    // Core-provided sidebar components (e.g. the notebooks workspace panel).
+    ['grafana', 'book-open'],
   ])('renders the correct icon for pluginId "%s" (%s)', (pluginId, iconName) => {
     render(<ExtensionToolbarItemButton isOpen={false} pluginId={pluginId} />);
 

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItemButton.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItemButton.tsx
@@ -19,6 +19,9 @@ function getPluginIcon(pluginId?: string): IconName {
       return 'book';
     case 'grafana-grotfood-app':
       return 'gf-grotfood';
+    // Core-provided sidebar components (currently the notebooks workspace panel).
+    case 'grafana':
+      return 'book-open';
     default:
       return 'ai-sparkle';
   }

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.test.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.test.ts
@@ -49,7 +49,8 @@ describe('browseDashboardsAPI', () => {
         browseDashboards: browseDashboardsReducer,
       },
       middleware: (getDefaultMiddleware) =>
-        getDefaultMiddleware().concat(
+        // CI runners can exceed RTK's invariant middleware timing threshold and fail via jest-fail-on-console.
+        getDefaultMiddleware({ serializableCheck: false, immutableCheck: false }).concat(
           browseDashboardsAPI.middleware,
           folderAPIv1beta1.middleware,
           legacyAPI.middleware
@@ -70,7 +71,7 @@ describe('browseDashboardsAPI', () => {
         browseDashboards: browseDashboardsReducer,
       },
       middleware: (getDefaultMiddleware) =>
-        getDefaultMiddleware().concat(
+        getDefaultMiddleware({ serializableCheck: false, immutableCheck: false }).concat(
           browseDashboardsAPI.middleware,
           folderAPIv1beta1.middleware,
           legacyAPI.middleware,

--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
@@ -175,6 +175,42 @@ export function panelMenuBehavior(menu: VizPanelMenu) {
       },
     });
 
+    if (
+      contextSrv.isSignedIn &&
+      !isEditingPanel &&
+      getFeatureFlagClient().getBooleanValue(FlagKeys.DashboardNotebooks, false)
+    ) {
+      items.push({
+        text: t('panel.header-menu.add-to-notebook', 'Add to notebook'),
+        iconClassName: 'book-open',
+        onClick: (e) => {
+          e.preventDefault();
+          // Loaded lazily so the notebooks feature stays out of the dashboard bundle path.
+          import('app/features/notebook/addToNotebook/addPanelToNotebookFromMenu').then((m) =>
+            m.addPanelToNotebookFromMenu(panel, dashboard)
+          );
+        },
+      });
+
+      // One-click append to the most recently used notebook (skips the picker).
+      const { getLastUsedNotebook } = await import('app/features/notebook/model/lastUsedNotebook');
+      const lastUsedNotebook = getLastUsedNotebook();
+      if (lastUsedNotebook) {
+        const shortTitle =
+          lastUsedNotebook.title.length > 25 ? `${lastUsedNotebook.title.slice(0, 25)}…` : lastUsedNotebook.title;
+        items.push({
+          text: t('panel.header-menu.add-to-last-notebook', 'Add to "{{title}}"', { title: shortTitle }),
+          iconClassName: 'bolt',
+          onClick: (e) => {
+            e.preventDefault();
+            import('app/features/notebook/addToNotebook/addPanelToNotebookFromMenu').then((m) =>
+              m.quickAddPanelToLastNotebookFromMenu(panel, dashboard)
+            );
+          },
+        });
+      }
+    }
+
     if (dashboard.state.isEditing && !isReadOnlyRepeat && !isEditingPanel) {
       moreSubMenu.push({
         text: t('panel.header-menu.duplicate', `Duplicate`),

--- a/public/app/features/dashboard-scene/scene/layout-notebook/NotebookCellItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-notebook/NotebookCellItem.tsx
@@ -10,6 +10,11 @@ export interface NotebookCellItemState extends SceneObjectState {
   source: 'assistant' | 'user';
   // Optional to mirror the schema: an omitted `collapsed` must round-trip as omitted, not `false`.
   collapsed?: boolean;
+  // Rendered height in pixels for panel cells; omitted means the default height.
+  height?: number;
+  // When both set, the panel is locked to this time range instead of the notebook's.
+  timeFrom?: string;
+  timeTo?: string;
   // A cell is either a panel or narrative content, never both. `body` deliberately follows the
   // DashboardLayoutItem convention (every layout item exposes its wrapped VizPanel at
   // `.state.body`, set via setElementBody) so the panel editor and scene-graph tooling can find

--- a/public/app/features/dashboard-scene/scene/layout-notebook/NotebookCellRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-notebook/NotebookCellRenderer.tsx
@@ -1,29 +1,30 @@
 import { css } from '@emotion/css';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { rangeUtil, type GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
 import { type VizPanel } from '@grafana/scenes';
 import { type CellContentKind } from '@grafana/schema/apis/notebook/v2beta1';
-import { useStyles2 } from '@grafana/ui';
+import { Icon, Text, useStyles2 } from '@grafana/ui';
 
 import { type NotebookCellItem } from './NotebookCellItem';
 import { cellTypeRegistry } from './cells/cellTypeRegistry';
 
 // A lone VizPanel fills its parent, so the parent needs a resolved height (not just
 // min-height) or PanelChrome measures 0 and nothing shows.
-const PANEL_HEIGHT = 300;
+const DEFAULT_PANEL_HEIGHT = 300;
 
 // A notebook cell is one of two things: a panel (a chart) or narrative content (a markdown or
 // code block). This chooses the matching renderer, or shows a compact placeholder when the cell
 // is collapsed.
 export function NotebookCellRenderer({ cell }: { cell: NotebookCellItem }) {
-  const { body: panel, content: narrative, collapsed, elementName } = cell.useState();
+  const { body: panel, content: narrative, collapsed, elementName, height, timeFrom, timeTo } = cell.useState();
 
   if (collapsed) {
-    return <CollapsedCell name={elementName} />;
+    return <CollapsedCell label={collapsedLabel(panel, narrative) ?? elementName} />;
   }
 
   if (panel) {
-    return <PanelCell panel={panel} />;
+    return <PanelCell panel={panel} height={height} timeFrom={timeFrom} timeTo={timeTo} />;
   }
 
   if (narrative) {
@@ -34,14 +35,63 @@ export function NotebookCellRenderer({ cell }: { cell: NotebookCellItem }) {
 }
 
 // A chart cell: delegates to its VizPanel, which brings its own PanelChrome (title, menu, legend).
-function PanelCell({ panel }: { panel: VizPanel }) {
+// Cells locked to their own time range say so, since they deviate from the header's range.
+function PanelCell({
+  panel,
+  height,
+  timeFrom,
+  timeTo,
+}: {
+  panel: VizPanel;
+  height?: number;
+  timeFrom?: string;
+  timeTo?: string;
+}) {
   const styles = useStyles2(getStyles);
+  const isLocked = Boolean(timeFrom && timeTo);
 
   return (
-    <div className={styles.panel}>
-      <panel.Component model={panel} />
+    <div>
+      {isLocked && (
+        <div className={styles.lockRow}>
+          <Icon name="lock" size="xs" />
+          <Text variant="bodySmall" color="secondary">
+            {t('dashboard.notebook-layout.locked-range', 'Locked: {{range}}', {
+              range: formatLockedRange(timeFrom!, timeTo!),
+            })}
+          </Text>
+        </div>
+      )}
+      <div className={styles.panel} style={{ height: height ?? DEFAULT_PANEL_HEIGHT }}>
+        <panel.Component model={panel} />
+      </div>
     </div>
   );
+}
+
+/** A human-readable label for collapsed cells (panel title or first line of text). */
+function collapsedLabel(panel?: VizPanel, narrative?: CellContentKind): string | undefined {
+  if (panel) {
+    return panel.state.title;
+  }
+  if (narrative?.kind === 'Markdown') {
+    return narrative.spec.text
+      .split('\n')
+      .map((line) => line.replace(/^[#>\-*\s`]+/, '').trim())
+      .find((line) => line.length > 0);
+  }
+  if (narrative?.kind === 'Code') {
+    return narrative.spec.language || undefined;
+  }
+  return undefined;
+}
+
+function formatLockedRange(from: string, to: string): string {
+  if (rangeUtil.isRelativeTimeRange({ from, to })) {
+    return `${from} → ${to}`;
+  }
+  const range = rangeUtil.convertRawToRange({ from, to });
+  return `${range.from.format('MMM D, HH:mm')} → ${range.to.format('HH:mm')}`;
 }
 
 // A narrative cell: markdown or code, rendered by the component registered for its content kind.
@@ -61,17 +111,23 @@ function NarrativeCell({ content }: { content: CellContentKind }) {
   );
 }
 
-// A collapsed cell: shows only the element name, whatever the cell's type.
-function CollapsedCell({ name }: { name: string }) {
+// A collapsed cell: shows a compact summary, whatever the cell's type.
+function CollapsedCell({ label }: { label: string }) {
   const styles = useStyles2(getStyles);
 
-  return <div className={styles.collapsed}>{name}</div>;
+  return <div className={styles.collapsed}>{label}</div>;
 }
 
 const getStyles = (theme: GrafanaTheme2) => ({
   panel: css({
-    height: PANEL_HEIGHT,
     position: 'relative',
+  }),
+  lockRow: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+    color: theme.colors.text.secondary,
+    marginBottom: theme.spacing(0.5),
   }),
   content: css({
     padding: theme.spacing(1, 0),

--- a/public/app/features/dashboard-scene/scene/layout-notebook/NotebookDocumentHeader.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-notebook/NotebookDocumentHeader.tsx
@@ -14,7 +14,7 @@ interface Props {
 export function NotebookDocumentHeader({ title, tags, timeFrom, timeTo }: Props) {
   return (
     <Stack direction="column" gap={1} alignItems="flex-start">
-      <Badge text={t('dashboard.notebook-layout.pill', 'Published Notebook')} color="blue" icon="book" />
+      <Badge text={t('dashboard.notebook-layout.pill', 'Notebook')} color="blue" icon="book" />
       {title ? (
         <Text element="h1" variant="h1">
           {title}

--- a/public/app/features/dashboard-scene/scene/layout-notebook/NotebookLayoutManager.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-notebook/NotebookLayoutManager.test.tsx
@@ -35,7 +35,7 @@ describe('NotebookLayoutManager', () => {
   it('renders the document header with badge, title, time range and tags', async () => {
     renderNotebook();
 
-    expect(screen.getByText('Published Notebook')).toBeInTheDocument();
+    expect(screen.getByText('Notebook')).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'My notebook' })).toBeInTheDocument();
     expect(screen.getByText(/now-6h/)).toBeInTheDocument();
     expect(screen.getByText('incident')).toBeInTheDocument();

--- a/public/app/features/dashboard-scene/scene/layout-notebook/NotebookLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-notebook/NotebookLayoutManager.tsx
@@ -63,8 +63,11 @@ export class NotebookLayoutManager
       spec: {
         element: { kind: 'ElementReference', name: cell.state.elementName },
         source: cell.state.source,
-        // Emit collapsed only when it was set, so an omitted value stays omitted on round-trip.
+        // Emit collapsed/height/time lock only when they were set, so omitted values stay omitted on round-trip.
         ...(cell.state.collapsed !== undefined ? { collapsed: cell.state.collapsed } : {}),
+        ...(cell.state.height !== undefined ? { height: cell.state.height } : {}),
+        ...(cell.state.timeFrom !== undefined ? { timeFrom: cell.state.timeFrom } : {}),
+        ...(cell.state.timeTo !== undefined ? { timeTo: cell.state.timeTo } : {}),
       },
     }));
 

--- a/public/app/features/dashboard-scene/scene/layout-notebook/cells/CodeCell.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-notebook/cells/CodeCell.tsx
@@ -1,28 +1,94 @@
+import { css, cx } from '@emotion/css';
+
+import { AppEvents, type GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
 import { type CellContentKind } from '@grafana/schema/apis/notebook/v2beta1';
-import { CodeEditor } from '@grafana/ui';
+import { Badge, CodeEditor, IconButton, Stack, useStyles2 } from '@grafana/ui';
+import { appEvents } from 'app/core/app_events';
+import { copyStringToClipboard } from 'app/core/utils/explore';
 
 const LINE_HEIGHT = 18;
 const MIN_LINES = 3;
 const MAX_LINES = 30;
+const TOOLBAR_CLASS = 'notebook-code-cell-toolbar';
+
+const LANGUAGE_LABELS: Record<string, string> = {
+  sql: 'SQL',
+  promql: 'PromQL',
+  logql: 'LogQL',
+  json: 'JSON',
+  yaml: 'YAML',
+  python: 'Python',
+  go: 'Go',
+  javascript: 'JavaScript',
+  shell: 'Shell',
+};
 
 // Monaco needs an explicit height; approximate it from the line count so short
 // snippets stay compact and long ones cap out with an internal scroll.
 export function CodeCell({ content }: { content: CellContentKind }) {
+  const styles = useStyles2(getStyles);
+
   if (content.kind !== 'Code') {
     return null;
   }
 
-  const lines = content.spec.code.split('\n').length;
+  const { code, language } = content.spec;
+  const lines = code.split('\n').length;
   const height = Math.min(Math.max(lines, MIN_LINES), MAX_LINES) * LINE_HEIGHT;
+  const languageLabel = language ? (LANGUAGE_LABELS[language] ?? language) : undefined;
+
+  const onCopy = () => {
+    copyStringToClipboard(code);
+    appEvents.emit(AppEvents.alertSuccess, [t('dashboard.notebook-layout.code-copied', 'Code copied')]);
+  };
 
   return (
-    <CodeEditor
-      value={content.spec.code}
-      language={content.spec.language}
-      height={height}
-      width="100%"
-      readOnly
-      showLineNumbers
-    />
+    <div className={styles.wrapper}>
+      {/* Float over the editor on hover — no reserved strip, no layout shift. */}
+      <div className={cx(styles.toolbar, TOOLBAR_CLASS)}>
+        <Stack direction="row" gap={1} alignItems="center">
+          {languageLabel && <Badge text={languageLabel} color="darkgrey" />}
+          <IconButton
+            name="copy"
+            size="sm"
+            tooltip={t('dashboard.notebook-layout.copy-code', 'Copy code')}
+            onClick={onCopy}
+            data-testid="notebook-code-copy"
+          />
+        </Stack>
+      </div>
+      <CodeEditor value={code} language={language} height={height} width="100%" readOnly showLineNumbers />
+    </div>
   );
 }
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  wrapper: css({
+    position: 'relative',
+    width: '100%',
+    [`&:hover .${TOOLBAR_CLASS}, &:focus-within .${TOOLBAR_CLASS}`]: {
+      opacity: 1,
+      pointerEvents: 'auto',
+    },
+  }),
+  toolbar: css({
+    position: 'absolute',
+    top: theme.spacing(0.5),
+    // Keep clear of Monaco's vertical scrollbar track.
+    right: theme.spacing(2),
+    zIndex: 2,
+    display: 'flex',
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+    padding: theme.spacing(0.25, 0, 0.25, 0.5),
+    borderRadius: theme.shape.radius.default,
+    background: theme.colors.background.primary,
+    boxShadow: theme.shadows.z1,
+    opacity: 0,
+    pointerEvents: 'none',
+    [theme.transitions.handleMotion('no-preference')]: {
+      transition: theme.transitions.create('opacity', { duration: 120 }),
+    },
+  }),
+});

--- a/public/app/features/dashboard-scene/scene/layout-notebook/cells/MarkdownCell.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-notebook/cells/MarkdownCell.tsx
@@ -17,7 +17,10 @@ export function MarkdownCell({ content }: { content: CellContentKind }) {
   }
 
   const html = renderTextPanelMarkdown(content.spec.text);
-  return <DangerouslySetHtmlContent html={html} className={cx('markdown-html', styles.markdown)} />;
+  // allowRerender: the component defaults to injecting the html only on first mount,
+  // but the notebook editor re-renders this preview when the cell text changes
+  // (local typing or a collaborator's live edit).
+  return <DangerouslySetHtmlContent html={html} allowRerender className={cx('markdown-html', styles.markdown)} />;
 }
 
 const getStyles = (theme: GrafanaTheme2) => ({

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/NotebookLayoutSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/NotebookLayoutSerializer.ts
@@ -1,3 +1,4 @@
+import { SceneTimeRange } from '@grafana/scenes';
 import {
   type LibraryPanelKind as DashboardLibraryPanelKind,
   type PanelKind as DashboardPanelKind,
@@ -10,6 +11,12 @@ import { NotebookLayoutManager } from '../../scene/layout-notebook/NotebookLayou
 import { type PanelIdGenerator } from '../../utils/dashboardSceneGraph';
 
 import { buildLibraryPanel, buildVizPanel } from './utils';
+
+type NotebookLayoutItemSpecWithPresentation = NotebookLayoutKind['spec']['cells'][number]['spec'] & {
+  height?: number;
+  timeFrom?: string;
+  timeTo?: string;
+};
 
 export function deserializeNotebookLayout(
   layout: DashboardV2Spec['layout'],
@@ -26,7 +33,8 @@ export function deserializeNotebookLayout(
 
   const cells: NotebookCellItem[] = [];
   for (const item of notebookLayout.spec.cells) {
-    const elementName = item.spec.element.name;
+    const itemSpec: NotebookLayoutItemSpecWithPresentation = item.spec;
+    const elementName = itemSpec.element.name;
     // `elements` is typed DashboardV2Spec['elements'] = Record<string, PanelKind | LibraryPanelKind>
     // (the dashboard element union, which has no CellKind). A notebook's elements really do
     // include CellKind at runtime, and we branch on element.kind === 'Cell' below. TS rejects a
@@ -38,11 +46,15 @@ export function deserializeNotebookLayout(
       continue;
     }
 
-    // collapsed is optional in the schema; keep it undefined when omitted so serialize round-trips faithfully.
+    // collapsed/height/time lock are optional in the schema; keep them undefined when omitted so
+    // serialize round-trips faithfully.
     const base = {
       elementName,
-      source: item.spec.source,
-      collapsed: item.spec.collapsed,
+      source: itemSpec.source,
+      collapsed: itemSpec.collapsed,
+      height: itemSpec.height,
+      timeFrom: itemSpec.timeFrom,
+      timeTo: itemSpec.timeTo,
     };
 
     if (element.kind === 'Panel') {
@@ -51,7 +63,12 @@ export function deserializeNotebookLayout(
       // so buildVizPanel (dashboard-typed) rejects the notebook-typed value without this bridge.
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- identical leaf type across the two schemas
       const panel = element as unknown as DashboardPanelKind;
-      cells.push(new NotebookCellItem({ ...base, body: buildVizPanel(panel, panelIdGenerator?.()) }));
+      const body = buildVizPanel(panel, panelIdGenerator?.());
+      // A locked cell gets its own time range instead of following the notebook's.
+      if (itemSpec.timeFrom && itemSpec.timeTo) {
+        body.setState({ $timeRange: new SceneTimeRange({ from: itemSpec.timeFrom, to: itemSpec.timeTo }) });
+      }
+      cells.push(new NotebookCellItem({ ...base, body }));
     } else if (element.kind === 'LibraryPanel') {
       // Same bridge as the Panel branch: identical generated LibraryPanelKind, different module,
       // so buildLibraryPanel (dashboard-typed) needs the notebook-typed value widened through unknown.

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
@@ -184,7 +184,10 @@ export function buildLibraryPanel(panel: LibraryPanelKind, id?: number): VizPane
   return new VizPanel(vizPanelState);
 }
 
-function createPanelDataProvider(
+// Exported so the notebooks editor can build standalone viz panels from a PanelKind
+// without pulling in the dashboard-scene-coupled parts of buildVizPanel (menu, header
+// actions, panel context) that require a DashboardScene ancestor.
+export function createPanelDataProvider(
   panelKind: PanelKind,
   panelMetas: PanelPluginMetas = getPanelPluginMetasMapSync()
 ): SceneDataProvider | undefined {

--- a/public/app/features/explore/extensions/ToolbarExtensionPoint.tsx
+++ b/public/app/features/explore/extensions/ToolbarExtensionPoint.tsx
@@ -42,7 +42,9 @@ export function ToolbarExtensionPoint(props: Props): ReactElement | null {
   const { links } = usePluginLinks({
     extensionPointId: PluginExtensionPoints.ExploreToolbarAction,
     context: context,
-    limitPerPlugin: 3,
+    // Core ('grafana') registers four links here: add to dashboard, add correlation,
+    // add to notebook and add to "<named>" notebook.
+    limitPerPlugin: 4,
   });
   const selectExploreItem = getExploreItemSelector(exploreId);
   const noQueriesInPane = Boolean(useSelector(selectExploreItem)?.queries?.length);

--- a/public/app/features/notebook/README.md
+++ b/public/app/features/notebook/README.md
@@ -1,0 +1,110 @@
+# Notebooks (POC)
+
+Living documents for investigations: narrative text, code snippets and **live panels**
+captured from dashboards or Explore, with real-time collaboration. Behind the
+`dashboard.notebooks` feature toggle.
+
+Notebooks are stored as a `Notebook` resource in the `dashboard.grafana.app/v2beta1`
+API group (spec defined in `apps/dashboard/kinds/v2beta1/notebook_spec.cue`). A
+notebook is a flat list of layout cells referencing elements: markdown/code cells and
+panels that reuse the dashboard v2 `PanelKind` shape, so panels round-trip cleanly
+between dashboards, Explore and notebooks.
+
+## Directory map
+
+| Path             | What lives there                                                                                                                                                                                 |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `model/`         | Pure functions over the `NotebookSpec` (insert/move/duplicate/update blocks, time locks, normalization) — everything here is unit-tested and side-effect free                                    |
+| `api/`           | Imperative CRUD over the generated RTK client, plus URL helpers and the last-used-notebook store                                                                                                 |
+| `editor/`        | The block editor: dnd reordering, markdown/code editing, inline datasource query editing (`cells/PanelQueryEditor`), viz suggestions, per-panel time locks, undo/redo (`useNotebookEditorState`) |
+| `collab/`        | Real-time layer over Grafana Live: presence, live cursors, follow mode, activity feed, last-write-wins doc sync (`useNotebookCollab`, `mergeRemoteSpec`)                                         |
+| `addToNotebook/` | Capture entry points: dashboard panel menu, Explore toolbar, quick-add-to-last-notebook                                                                                                          |
+| `sidebar/`       | Compact companion editor docked in the extension sidebar                                                                                                                                         |
+| `pages/`         | List page, editor page, read-only view page (renders through the dashboard scene pipeline)                                                                                                       |
+| `extensions/`    | Core extension-point registrations (Explore, sidebar, IRM landing card, command palette) and the declare-incident button                                                                         |
+
+Related code outside this folder:
+
+- `public/app/features/dashboard-scene/scene/layout-notebook/` — the read-only view renderer (pre-existed this POC; the editor reuses its markdown cell and panel-building utils).
+- `pkg/services/live/features/notebook.go` — the Live channel relay for collaboration.
+- `pkg/services/navtree` — the nav entry.
+
+## Architecture notes
+
+- **Durable model**: the `Notebook` resource + shared dashboard `PanelKind` leaf types.
+  Scenes/`VizPanel` are how we render live panels (same stack as dashboards/Explore),
+  not the source of truth. Capture and round-trip stay cheap because of that reuse.
+- **Edit and view are separate surfaces (intentional)**:
+  - **Edit**: Notion-style block editor — dnd, inline query/markdown editing, autosave,
+    collab overlays. Each panel is a small `EmbeddedScene` + `VizPanel`
+    (`editor/cells/PanelCellView` / `buildNotebookVizPanel`). Notebooks aren’t dashboards,
+    so this doesn’t go through DashboardScene edit chrome.
+  - **View**: read-only document page via the `layout-notebook` dashboard-scene pipeline
+    (`NotebookScenePageStateManager` + `buildNotebookEnvelope`) for URL sync, time
+    controls, and panel chrome.
+  - Both read the same `NotebookSpec` and build the same kind of `VizPanel`. Keep panel /
+    narrative construction shared so the two surfaces don’t drift; don’t force edit into
+    a dashboard scene just to have “one path.”
+- **Editing model**: all mutations are immutable spec transforms in `model/notebookSpec.ts`,
+  applied through `useNotebookEditorState` (debounced autosave with optimistic-concurrency
+  retry, snapshot-based undo/redo with typing coalescing).
+- **Collaboration**: ephemeral messages relayed verbatim over `grafana/notebook/uid/<uid>`.
+  Presence/cursors/follow/activity are production-shaped; **document sync is deliberately
+  POC-grade** (full-doc broadcast, wall-clock last-write-wins, per-block merge protection
+  only for the actively edited block). The block-structured spec was chosen so the real
+  implementation can be per-block revisions / ops rather than general collaborative text.
+- **Query editing**: embeds each datasource's own `QueryEditor` with `CoreApp.Correlations`
+  (the established value for standalone embeds), local draft state, explicit commit on run —
+  same pattern as the saved-queries inline editor.
+
+## Known limitations / next steps
+
+- Doc sync loses concurrent structural edits beyond ~5 active editors (see above) —
+  needs per-block versioning, a single-writer save election, and server-side identity
+  stamping in the Live handler before real multiplayer use.
+- Assistant integration (context handoff + write-back functions) was built and then
+  deliberately removed to keep the core lean; it lives in git history.
+- No template gallery, slash-menu insertion, or export beyond copy-as-Markdown — parked
+  pending user feedback.
+- Notebooks are not in the search index: no "recent notebooks" or search results in the
+  command palette (dashboards get this via unified search). Indexing the notebook
+  resource is the natural GA path; the list page's content search is client-side.
+- View-mode time controls are hidden when a notebook has no visualization panels
+  (nothing for the shared range to drive); they stay editable when panels are present.
+- Notebook `description` exists on the spec (list search / declare-incident can use it)
+  but is **not editable in the POC UI** — fast follow. Declare-incident title order:
+  named title → first markdown line → description → `Investigation: Untitled notebook`.
+  New notebooks are titled `Investigation — {Month D, YYYY HH:mm}` (browser TZ; not
+  Untitled) so capture targets are easier to find. Declare-incident attaches the
+  notebook via url/caption and leads the description with
+  “This incident was declared from this notebook: {url}” (IRM has no URL param for
+  a status-update body — `status` is lifecycle only).
+
+## Review notes (private preview readiness)
+
+- **Permissions**: editing is gated on the dashboards `create`/`write` actions as a
+  POC shortcut. A real rollout wants notebook-scoped actions (or at least a
+  deliberate decision to inherit dashboard permissions) plus folder placement.
+- **Generated files**: the schema change (`height`, `timeFrom`, `timeTo` on
+  `NotebookLayoutItemSpec`) lives in `apps/dashboard/kinds/v2beta1/notebook_spec.cue`;
+  the Go/OpenAPI/TS outputs were generated and committed together — CI's codegen
+  verification should pass as-is.
+- **Security posture**: markdown renders through the standard text-panel sanitizer
+  (js-xss whitelist; `data:image/` is allowed for img src by its defaults, which the
+  image paste feature relies on — pasted images are downscaled and capped at ~500KB).
+  The Live channel is org-isolated upstream; the relay handler does **not** stamp
+  sender identity server-side yet, so collab messages trust the client-supplied user
+  (fine for preview, must fix before GA — the handler receives the authenticated
+  requester and can stamp it).
+- **Shipping split**: per repo convention the backend (CUE schema, Live handler,
+  navtree) and frontend should land as separate PRs; the backend diff is ~130 lines
+  and has no frontend dependency.
+- **Test coverage**: model/spec transforms, editor state (undo/autosave), collab
+  merge, capture orchestration, markdown export, view-page loading are covered.
+  Not covered: the Live hook itself (`useNotebookCollab` — needs a Live mock
+  harness) and the editor component tree (exercised manually).
+
+## Running it
+
+`make run` + `yarn start`, with `dashboard.notebooks = true` under `[feature_toggles]`.
+Open `/notebooks`. For the collaboration demo, open the same notebook in two windows.

--- a/public/app/features/notebook/addToNotebook/AddToNotebookForm.tsx
+++ b/public/app/features/notebook/addToNotebook/AddToNotebookForm.tsx
@@ -1,0 +1,174 @@
+import { useMemo, useState } from 'react';
+
+import { AppEvents, rangeUtil, type RawTimeRange, type SelectableValue } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { locationService } from '@grafana/runtime';
+import { type NotebookElement } from '@grafana/schema/apis/notebook/v2beta1';
+import { Alert, Button, Checkbox, Field, Input, Modal, RadioButtonGroup, Select, Stack, Text } from '@grafana/ui';
+import { useListNotebookQuery } from 'app/api/clients/dashboard/v2beta1';
+import { appEvents } from 'app/core/app_events';
+
+import { notebookEditUrl } from '../api/notebookAPI';
+import { getLastUsedNotebook } from '../model/lastUsedNotebook';
+import { newNotebookTitleDate } from '../model/notebookSpec';
+
+import { addElementToNotebook, type AddToNotebookTarget } from './addToNotebook';
+
+enum SaveTarget {
+  New = 'new',
+  Existing = 'existing',
+}
+
+export interface AddToNotebookFormProps {
+  /** The element being added — a panel captured from a dashboard or Explore. */
+  element: NotebookElement;
+  /** Where the element came from, shown as context in the form. */
+  sourceName?: string;
+  /** Source time range; becomes the notebook time range when creating a new notebook. */
+  timeRange?: RawTimeRange;
+  onDismiss: () => void;
+}
+
+/**
+ * The shared "Add to notebook" flow (Figma: click add to notebook → new notebook /
+ * select existing → item added to draft notebook). Chrome-less so it can live in
+ * the extension modal (Explore) and the panel-menu modal alike.
+ */
+export function AddToNotebookForm({ element, sourceName, timeRange, onDismiss }: AddToNotebookFormProps) {
+  // Default to the most recently used notebook (the Figma's "default notebook" is
+  // the last used one); fall back to creating a new notebook.
+  const [lastUsed] = useState(getLastUsedNotebook);
+  const [saveTarget, setSaveTarget] = useState<SaveTarget>(lastUsed ? SaveTarget.Existing : SaveTarget.New);
+  const [title, setTitle] = useState(defaultTitle());
+  const [existingUid, setExistingUid] = useState<string | undefined>(lastUsed?.uid);
+  // An absolute source range means the user was looking at a specific window (e.g.
+  // zoomed into a spike) — capture what they saw by defaulting the lock on. Relative
+  // ranges ("last 6 hours") follow the notebook's time by default.
+  const [lockTimeRange, setLockTimeRange] = useState(() =>
+    Boolean(timeRange && !rangeUtil.isRelativeTimeRange(timeRange))
+  );
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | undefined>();
+
+  const { data, isLoading } = useListNotebookQuery({});
+
+  const notebookOptions: Array<SelectableValue<string>> = useMemo(
+    () =>
+      (data?.items ?? [])
+        .map((nb) => ({ label: nb.spec.title, value: nb.metadata.name ?? '' }))
+        .filter((option) => option.value !== ''),
+    [data]
+  );
+
+  const targets = [
+    { label: t('notebooks.add-form.new', 'New notebook'), value: SaveTarget.New },
+    {
+      label: t('notebooks.add-form.existing', 'Existing notebook'),
+      value: SaveTarget.Existing,
+      description: notebookOptions.length === 0 ? t('notebooks.add-form.none-yet', 'No notebooks yet') : undefined,
+    },
+  ];
+
+  const onSubmit = async (openAfter: boolean) => {
+    setError(undefined);
+
+    const target: AddToNotebookTarget =
+      saveTarget === SaveTarget.New
+        ? { type: 'new', title: title.trim() || defaultTitle() }
+        : { type: 'existing', uid: existingUid ?? '' };
+
+    if (target.type === 'existing' && !target.uid) {
+      setError(t('notebooks.add-form.select-required', 'Select a notebook to add to.'));
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const result = await addElementToNotebook(target, element, { timeRange, source: 'user', lockTimeRange });
+      onDismiss();
+      if (openAfter) {
+        locationService.push(`${notebookEditUrl(result.uid)}?cell=${encodeURIComponent(result.elementName)}`);
+      } else {
+        appEvents.emit(AppEvents.alertSuccess, [t('notebooks.add-form.added', 'Added to notebook'), result.title]);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t('notebooks.add-form.failed', 'Failed to add to notebook'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Stack direction="column" gap={1}>
+      {sourceName && (
+        <Text color="secondary" variant="bodySmall">
+          <Trans i18nKey="notebooks.add-form.source">Adding a live panel from {{ sourceName }}.</Trans>
+        </Text>
+      )}
+
+      <Field noMargin label={t('notebooks.add-form.target-label', 'Target notebook')}>
+        <RadioButtonGroup options={targets} value={saveTarget} onChange={setSaveTarget} />
+      </Field>
+
+      {saveTarget === SaveTarget.New ? (
+        <Field noMargin label={t('notebooks.add-form.title-label', 'Notebook name')}>
+          <Input value={title} onChange={(e) => setTitle(e.currentTarget.value)} data-testid="add-to-notebook-title" />
+        </Field>
+      ) : (
+        <Field noMargin label={t('notebooks.add-form.notebook-label', 'Notebook')}>
+          <Select
+            options={notebookOptions}
+            isLoading={isLoading}
+            value={existingUid}
+            onChange={(option) => setExistingUid(option?.value)}
+            placeholder={t('notebooks.add-form.notebook-placeholder', 'Choose a notebook')}
+            data-testid="add-to-notebook-picker"
+          />
+        </Field>
+      )}
+
+      {timeRange && (
+        // alignSelf keeps the checkbox's inline-grid hugging the left edge instead of
+        // stretching (which centers its label/description in the modal).
+        <div style={{ alignSelf: 'flex-start' }}>
+          <Checkbox
+            value={lockTimeRange}
+            onChange={(e) => setLockTimeRange(e.currentTarget.checked)}
+            label={t('notebooks.add-form.lock-time', 'Lock this panel to the current time window')}
+            description={t('notebooks.add-form.lock-time-description', '{{from}} → {{to}}', absoluteRange(timeRange))}
+          />
+        </div>
+      )}
+
+      {error && (
+        <Alert severity="error" title={t('notebooks.add-form.error-title', 'Could not add to notebook')}>
+          {error}
+        </Alert>
+      )}
+
+      <Modal.ButtonRow>
+        <Button variant="secondary" fill="outline" onClick={onDismiss} disabled={submitting}>
+          <Trans i18nKey="notebooks.add-form.cancel">Cancel</Trans>
+        </Button>
+        <Button variant="secondary" onClick={() => onSubmit(false)} disabled={submitting} icon="book-open">
+          <Trans i18nKey="notebooks.add-form.add">Add</Trans>
+        </Button>
+        <Button variant="primary" onClick={() => onSubmit(true)} disabled={submitting} icon="external-link-alt">
+          <Trans i18nKey="notebooks.add-form.add-open">Add & open notebook</Trans>
+        </Button>
+      </Modal.ButtonRow>
+    </Stack>
+  );
+}
+
+function defaultTitle(): string {
+  // Same dated shape as list/sidebar/command-palette creates (i18n-wrapped).
+  return t('notebooks.add-form.default-title', 'Investigation — {{date}}', {
+    date: newNotebookTitleDate(),
+  });
+}
+
+function absoluteRange(raw: RawTimeRange): { from: string; to: string } {
+  const range = rangeUtil.convertRawToRange(raw);
+  return { from: range.from.format('YYYY-MM-DD HH:mm'), to: range.to.format('YYYY-MM-DD HH:mm') };
+}

--- a/public/app/features/notebook/addToNotebook/AddToNotebookModal.tsx
+++ b/public/app/features/notebook/addToNotebook/AddToNotebookModal.tsx
@@ -1,0 +1,22 @@
+import { t } from '@grafana/i18n';
+import { Modal } from '@grafana/ui';
+
+import { AddToNotebookForm, type AddToNotebookFormProps } from './AddToNotebookForm';
+
+interface Props extends Omit<AddToNotebookFormProps, 'onDismiss'> {
+  onDismiss?: () => void;
+}
+
+/**
+ * Self-contained modal wrapper around AddToNotebookForm, for imperative openers
+ * (ShowModalReactEvent from the dashboard panel menu). The modals context provider
+ * injects onDismiss.
+ */
+export function AddToNotebookModal({ onDismiss, ...formProps }: Props) {
+  const close = onDismiss ?? (() => {});
+  return (
+    <Modal title={t('notebooks.add-modal.title', 'Add to notebook')} isOpen onDismiss={close}>
+      <AddToNotebookForm {...formProps} onDismiss={close} />
+    </Modal>
+  );
+}

--- a/public/app/features/notebook/addToNotebook/ExploreAddToNotebook.tsx
+++ b/public/app/features/notebook/addToNotebook/ExploreAddToNotebook.tsx
@@ -1,0 +1,48 @@
+import { t } from '@grafana/i18n';
+import { buildDashboardPanelFromExploreState } from 'app/features/explore/extensions/AddToDashboard/addToDashboard';
+import { getExploreItemSelector } from 'app/features/explore/state/selectors';
+import { useSelector } from 'app/types/store';
+
+import { AddToNotebookForm } from './AddToNotebookForm';
+import { legacyPanelToNotebookPanel } from './legacyPanelToNotebookPanel';
+
+interface Props {
+  exploreId: string;
+  onClose: () => void;
+}
+
+/**
+ * Explore toolbar → "Add to notebook": reuses the add-to-dashboard panel builder
+ * (queries + datasource + panel type inferred from the response frames) and
+ * converts the result into a notebook panel element.
+ */
+export function ExploreAddToNotebook({ exploreId, onClose }: Props) {
+  const exploreItem = useSelector(getExploreItemSelector(exploreId));
+
+  if (!exploreItem) {
+    return null;
+  }
+
+  const legacyPanel = buildDashboardPanelFromExploreState({
+    datasource: exploreItem.datasourceInstance?.getRef(),
+    queries: exploreItem.queries,
+    queryResponse: exploreItem.queryResponse,
+    panelState: exploreItem.panelsState,
+  });
+
+  const element = legacyPanelToNotebookPanel(legacyPanel, {
+    title: t('notebooks.add-from-explore.panel-title', 'Explore query'),
+    subtitle: t('notebooks.add-from-explore.origin', 'From Explore ({{datasource}})', {
+      datasource: exploreItem.datasourceInstance?.name ?? '',
+    }),
+  });
+
+  return (
+    <AddToNotebookForm
+      element={element}
+      sourceName={t('notebooks.add-from-explore.source', 'Explore')}
+      timeRange={exploreItem.range.raw}
+      onDismiss={onClose}
+    />
+  );
+}

--- a/public/app/features/notebook/addToNotebook/addPanelToNotebookFromMenu.tsx
+++ b/public/app/features/notebook/addToNotebook/addPanelToNotebookFromMenu.tsx
@@ -1,0 +1,107 @@
+import { t } from '@grafana/i18n';
+import { sceneGraph, type VizPanel } from '@grafana/scenes';
+import { type NotebookElement, type PanelKind } from '@grafana/schema/apis/notebook/v2beta1';
+import { appEvents } from 'app/core/app_events';
+import { type DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
+import { vizPanelToSchemaV2 } from 'app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2';
+import { ShowModalReactEvent } from 'app/types/events';
+
+import { AddToNotebookModal } from './AddToNotebookModal';
+import { quickAddToLastNotebook } from './quickAddToLastNotebook';
+
+function capturePanel(panel: VizPanel, dashboard: DashboardScene): NotebookElement {
+  // The dashboard and notebook Panel/LibraryPanel kinds are generated identically
+  // from the same OpenAPI source; bridge them at this seam.
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- identical leaf type across the two schemas
+  const element = vizPanelToSchemaV2(panel) as unknown as NotebookElement;
+  if (element.kind === 'Panel') {
+    interpolateVariables(element, panel);
+    annotateOrigin(element, dashboard);
+  }
+  return element;
+}
+
+/**
+ * Dashboard panels usually reference template variables ($instance, $job, ...) that
+ * don't exist in a notebook. Resolve them to their current values at capture time —
+ * in queries, the title and panel options (e.g. text panel content) — so the
+ * notebook panel keeps showing what the user was looking at.
+ */
+function interpolateVariables(element: PanelKind, panel: VizPanel) {
+  element.spec.title = sceneGraph.interpolate(panel, element.spec.title);
+  element.spec.data.spec.queries = element.spec.data.spec.queries.map((query) => ({
+    ...query,
+    spec: {
+      ...query.spec,
+      query: {
+        ...query.spec.query,
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- deep-walk preserves the query spec shape
+        spec: interpolateDeep(query.spec.query.spec, panel) as Record<string, unknown>,
+      },
+    },
+  }));
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- deep-walk preserves the options shape
+  element.spec.vizConfig.spec.options = interpolateDeep(element.spec.vizConfig.spec.options, panel) as Record<
+    string,
+    unknown
+  >;
+}
+
+// Query-time macros ($__rate_interval, $__timeFilter, ${__field.*}) are not dashboard
+// variables: scene interpolation leaves them unresolved, so they stay dynamic.
+function interpolateDeep(value: unknown, panel: VizPanel): unknown {
+  if (typeof value === 'string') {
+    return value.includes('$') ? sceneGraph.interpolate(panel, value) : value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => interpolateDeep(item, panel));
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, interpolateDeep(item, panel)]));
+  }
+  return value;
+}
+
+/**
+ * Dashboard panel menu → "Add to notebook": captures the panel's full definition
+ * (queries, datasource, viz options, field config) as a notebook panel element and
+ * opens the shared add-to-notebook flow. Loaded lazily from the menu behavior to
+ * keep notebooks code out of the dashboard bundle path.
+ */
+export function addPanelToNotebookFromMenu(panel: VizPanel, dashboard: DashboardScene) {
+  const element = capturePanel(panel, dashboard);
+  const timeRange = sceneGraph.getTimeRange(panel).state.value.raw;
+
+  appEvents.publish(
+    new ShowModalReactEvent({
+      component: AddToNotebookModal,
+      props: {
+        element,
+        timeRange,
+        sourceName: dashboard.state.title || t('notebooks.add-from-panel.unnamed-dashboard', 'this dashboard'),
+      },
+    })
+  );
+}
+
+/**
+ * Dashboard panel menu → "Add to <last notebook>": appends straight to the most
+ * recently used notebook; falls back to the picker modal when that is not possible.
+ */
+export async function quickAddPanelToLastNotebookFromMenu(panel: VizPanel, dashboard: DashboardScene) {
+  const element = capturePanel(panel, dashboard);
+  const timeRange = sceneGraph.getTimeRange(panel).state.value.raw;
+
+  const added = await quickAddToLastNotebook(element, { timeRange });
+  if (!added) {
+    addPanelToNotebookFromMenu(panel, dashboard);
+  }
+}
+
+function annotateOrigin(element: PanelKind, dashboard: DashboardScene) {
+  if (!element.spec.subtitle && dashboard.state.title) {
+    element.spec.subtitle = t('notebooks.add-from-panel.origin', 'From dashboard: {{title}}', {
+      title: dashboard.state.title,
+    });
+  }
+}

--- a/public/app/features/notebook/addToNotebook/addToNotebook.test.ts
+++ b/public/app/features/notebook/addToNotebook/addToNotebook.test.ts
@@ -1,0 +1,75 @@
+import { newMarkdownElement, newNotebookSpec, resolveCells } from '../model/notebookSpec';
+
+import { addElementToNotebook } from './addToNotebook';
+
+const mockCreateNotebook = jest.fn();
+const mockFetchNotebook = jest.fn();
+const mockSaveNotebook = jest.fn();
+const mockBroadcast = jest.fn();
+
+jest.mock('../api/notebookAPI', () => ({
+  createNotebook: (spec: unknown) => mockCreateNotebook(spec),
+  fetchNotebook: (uid: string) => mockFetchNotebook(uid),
+  saveNotebook: (resource: unknown) => mockSaveNotebook(resource),
+}));
+
+jest.mock('../collab/useNotebookCollab', () => ({
+  broadcastNotebookDoc: (uid: string, spec: unknown) => mockBroadcast(uid, spec),
+}));
+
+describe('addElementToNotebook', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateNotebook.mockImplementation(async (spec) => ({
+      metadata: { name: 'nb-new', resourceVersion: '1' },
+      spec,
+    }));
+    mockSaveNotebook.mockImplementation(async (resource) => resource);
+  });
+
+  it('creates a new notebook carrying the source time range', async () => {
+    const element = newMarkdownElement('captured');
+
+    const result = await addElementToNotebook({ type: 'new', title: 'Fresh investigation' }, element, {
+      timeRange: { from: 'now-1h', to: 'now' },
+      source: 'user',
+    });
+
+    expect(result.uid).toBe('nb-new');
+    expect(result.title).toBe('Fresh investigation');
+    const createdSpec = mockCreateNotebook.mock.calls[0][0];
+    expect(createdSpec.timeSettings.from).toBe('now-1h');
+    const cells = resolveCells(createdSpec);
+    expect(cells).toHaveLength(1);
+    expect(result.elementName).toBe(cells[0].elementName);
+    // Nobody can have a not-yet-created notebook open — nothing to broadcast.
+    expect(mockBroadcast).not.toHaveBeenCalled();
+  });
+
+  it('appends to an existing notebook, saves and broadcasts the saved document', async () => {
+    const existing = newNotebookSpec('Ongoing');
+    mockFetchNotebook.mockResolvedValue({ metadata: { name: 'nb-1', resourceVersion: '5' }, spec: existing });
+
+    const result = await addElementToNotebook({ type: 'existing', uid: 'nb-1' }, newMarkdownElement('more'));
+
+    expect(mockFetchNotebook).toHaveBeenCalledWith('nb-1');
+    const savedResource = mockSaveNotebook.mock.calls[0][0];
+    expect(resolveCells(savedResource.spec)).toHaveLength(1);
+    expect(mockBroadcast).toHaveBeenCalledWith('nb-1', savedResource.spec);
+    expect(result.uid).toBe('nb-1');
+  });
+
+  it('locks the block to the absolute capture window when requested', async () => {
+    const existing = newNotebookSpec('Ongoing');
+    mockFetchNotebook.mockResolvedValue({ metadata: { name: 'nb-1', resourceVersion: '5' }, spec: existing });
+
+    await addElementToNotebook({ type: 'existing', uid: 'nb-1' }, newMarkdownElement('spike'), {
+      timeRange: { from: '2026-08-01T00:00:00.000Z', to: '2026-08-01T01:00:00.000Z' },
+      lockTimeRange: true,
+    });
+
+    const cell = resolveCells(mockSaveNotebook.mock.calls[0][0].spec)[0];
+    expect(cell.timeFrom).toBe('2026-08-01T00:00:00.000Z');
+    expect(cell.timeTo).toBe('2026-08-01T01:00:00.000Z');
+  });
+});

--- a/public/app/features/notebook/addToNotebook/addToNotebook.ts
+++ b/public/app/features/notebook/addToNotebook/addToNotebook.ts
@@ -1,0 +1,57 @@
+import { rangeUtil, type RawTimeRange } from '@grafana/data';
+import { type NotebookElement } from '@grafana/schema/apis/notebook/v2beta1';
+
+import { createNotebook, fetchNotebook, saveNotebook } from '../api/notebookAPI';
+import { broadcastNotebookDoc } from '../collab/useNotebookCollab';
+import { insertElement, newNotebookSpec, type CellSource } from '../model/notebookSpec';
+
+export type AddToNotebookTarget = { type: 'new'; title: string } | { type: 'existing'; uid: string };
+
+export interface AddToNotebookResult {
+  uid: string;
+  title: string;
+  /** Name of the newly added element — used to scroll it into view when opening the notebook. */
+  elementName: string;
+}
+
+/**
+ * Adds an element (typically a panel captured from a dashboard or Explore) to a
+ * notebook. For a new notebook the source time range becomes the notebook's time
+ * range; when adding to an existing notebook the panel follows the notebook's
+ * global time range (the private-preview default). With `lockTimeRange`, the
+ * panel is instead pinned to the absolute time window it was captured in.
+ */
+export async function addElementToNotebook(
+  target: AddToNotebookTarget,
+  element: NotebookElement,
+  options?: { timeRange?: RawTimeRange; source?: CellSource; lockTimeRange?: boolean }
+): Promise<AddToNotebookResult> {
+  // Lock resolves the range to absolute timestamps: "the window I was looking at",
+  // not "the last 6 hours from whenever the notebook is opened".
+  const timeOverride = options?.lockTimeRange && options.timeRange ? resolveToAbsolute(options.timeRange) : undefined;
+
+  if (target.type === 'new') {
+    const from = options?.timeRange ? rawToString(options.timeRange.from) : undefined;
+    const to = options?.timeRange ? rawToString(options.timeRange.to) : undefined;
+    const base = newNotebookSpec(target.title, { from, to });
+    const { spec, elementName } = insertElement(base, element, { source: options?.source, timeOverride });
+    const created = await createNotebook(spec);
+    return { uid: created.metadata.name, title: created.spec.title, elementName };
+  }
+
+  const notebook = await fetchNotebook(target.uid);
+  const { spec, elementName } = insertElement(notebook.spec, element, { source: options?.source, timeOverride });
+  const saved = await saveNotebook({ ...notebook, spec });
+  // Any editor with this notebook open shows the new block immediately.
+  broadcastNotebookDoc(saved.metadata.name, saved.spec);
+  return { uid: saved.metadata.name, title: saved.spec.title, elementName };
+}
+
+function resolveToAbsolute(raw: RawTimeRange): { from: string; to: string } {
+  const range = rangeUtil.convertRawToRange(raw);
+  return { from: range.from.toISOString(), to: range.to.toISOString() };
+}
+
+function rawToString(value: RawTimeRange['from']): string {
+  return typeof value === 'string' ? value : value.toISOString();
+}

--- a/public/app/features/notebook/addToNotebook/legacyPanelToNotebookPanel.test.ts
+++ b/public/app/features/notebook/addToNotebook/legacyPanelToNotebookPanel.test.ts
@@ -1,0 +1,42 @@
+import { legacyPanelToNotebookPanel } from './legacyPanelToNotebookPanel';
+
+describe('legacyPanelToNotebookPanel', () => {
+  it('converts targets, datasource and viz type to the notebook panel shape', () => {
+    const panel = {
+      type: 'timeseries',
+      title: 'Explore result',
+      datasource: { type: 'prometheus', uid: 'prom-1' },
+      targets: [
+        { refId: 'A', expr: 'up' },
+        { refId: 'B', expr: 'rate(http_requests_total[5m])', hide: true },
+      ],
+      gridPos: { x: 0, y: 0, w: 12, h: 8 },
+    };
+
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- test fixture matching the loose legacy panel shape
+    const result = legacyPanelToNotebookPanel(panel as never, { subtitle: 'From Explore' });
+
+    expect(result.kind).toBe('Panel');
+    expect(result.spec.title).toBe('Explore result');
+    expect(result.spec.subtitle).toBe('From Explore');
+    expect(result.spec.vizConfig.group).toBe('timeseries');
+
+    const queries = result.spec.data.spec.queries;
+    expect(queries).toHaveLength(2);
+    expect(queries[0].spec.refId).toBe('A');
+    expect(queries[0].spec.hidden).toBe(false);
+    expect(queries[0].spec.query.group).toBe('prometheus');
+    expect(queries[0].spec.query.datasource?.name).toBe('prom-1');
+    expect(queries[0].spec.query.spec.expr).toBe('up');
+    expect(queries[1].spec.hidden).toBe(true);
+  });
+
+  it('falls back to empty defaults for minimal panels', () => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- test fixture matching the loose legacy panel shape
+    const result = legacyPanelToNotebookPanel({ type: 'table' } as never);
+
+    expect(result.spec.title).toBe('');
+    expect(result.spec.data.spec.queries).toHaveLength(0);
+    expect(result.spec.vizConfig.spec.fieldConfig).toEqual({ defaults: {}, overrides: [] });
+  });
+});

--- a/public/app/features/notebook/addToNotebook/legacyPanelToNotebookPanel.ts
+++ b/public/app/features/notebook/addToNotebook/legacyPanelToNotebookPanel.ts
@@ -1,0 +1,55 @@
+import { type DataQuery, type Panel } from '@grafana/schema';
+import { type PanelKind, type PanelQueryKind, type TransformationKind } from '@grafana/schema/apis/notebook/v2beta1';
+import { getPanelQueries } from 'app/features/dashboard/api/ResponseTransformers';
+
+/**
+ * Converts a legacy (v1) panel model — as produced by Explore's
+ * buildDashboardPanelFromExploreState — into a notebook panel element (v2 shape).
+ */
+export function legacyPanelToNotebookPanel(panel: Panel, options?: { title?: string; subtitle?: string }): PanelKind {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- legacy Panel.targets is loosely typed
+  const targets = (panel.targets ?? []) as unknown as DataQuery[];
+  const datasource = panel.datasource ?? {};
+
+  // getPanelQueries produces the dashboard-schema PanelQueryKind; the notebook
+  // schema generates the identical shape in a sibling module.
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- identical leaf type across the two schemas
+  const queries = (getPanelQueries(targets, datasource) ?? []) as unknown as PanelQueryKind[];
+
+  const transformations: TransformationKind[] = (panel.transformations ?? []).map((transformation) => ({
+    kind: transformation.id,
+    spec: transformation,
+  }));
+
+  return {
+    kind: 'Panel',
+    spec: {
+      // Reassigned to a unique id when inserted into a notebook.
+      id: 0,
+      title: options?.title ?? panel.title ?? '',
+      subtitle: options?.subtitle,
+      links: [],
+      data: {
+        kind: 'QueryGroup',
+        spec: {
+          queries,
+          transformations,
+          queryOptions: {},
+        },
+      },
+      vizConfig: {
+        kind: 'VizConfig',
+        group: panel.type,
+        version: '',
+        spec: {
+          options: panel.options ?? {},
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- identical field config shape across schema versions
+          fieldConfig: (panel.fieldConfig ?? {
+            defaults: {},
+            overrides: [],
+          }) as PanelKind['spec']['vizConfig']['spec']['fieldConfig'],
+        },
+      },
+    },
+  };
+}

--- a/public/app/features/notebook/addToNotebook/quickAddFromExplore.ts
+++ b/public/app/features/notebook/addToNotebook/quickAddFromExplore.ts
@@ -1,0 +1,35 @@
+import { t } from '@grafana/i18n';
+import { buildDashboardPanelFromExploreState } from 'app/features/explore/extensions/AddToDashboard/addToDashboard';
+import { getExploreItemSelector } from 'app/features/explore/state/selectors';
+import { getState } from 'app/store/store';
+
+import { legacyPanelToNotebookPanel } from './legacyPanelToNotebookPanel';
+import { quickAddToLastNotebook } from './quickAddToLastNotebook';
+
+/**
+ * Explore toolbar → "Add to last notebook": captures the current query/visualization
+ * (same panel builder as the modal flow) and appends it to the most recently used
+ * notebook in one click. Returns false when there is no last notebook to add to.
+ */
+export async function quickAddExploreToLastNotebook(exploreId: string): Promise<boolean> {
+  const exploreItem = getExploreItemSelector(exploreId)(getState());
+  if (!exploreItem) {
+    return false;
+  }
+
+  const legacyPanel = buildDashboardPanelFromExploreState({
+    datasource: exploreItem.datasourceInstance?.getRef(),
+    queries: exploreItem.queries,
+    queryResponse: exploreItem.queryResponse,
+    panelState: exploreItem.panelsState,
+  });
+
+  const element = legacyPanelToNotebookPanel(legacyPanel, {
+    title: t('notebooks.add-from-explore.panel-title', 'Explore query'),
+    subtitle: t('notebooks.add-from-explore.origin', 'From Explore ({{datasource}})', {
+      datasource: exploreItem.datasourceInstance?.name ?? '',
+    }),
+  });
+
+  return quickAddToLastNotebook(element, { timeRange: exploreItem.range.raw });
+}

--- a/public/app/features/notebook/addToNotebook/quickAddToLastNotebook.test.ts
+++ b/public/app/features/notebook/addToNotebook/quickAddToLastNotebook.test.ts
@@ -1,0 +1,52 @@
+import { type NotebookElement } from '@grafana/schema/apis/notebook/v2beta1';
+
+import { addElementToNotebook } from './addToNotebook';
+import { quickAddToLastNotebook } from './quickAddToLastNotebook';
+
+jest.mock('./addToNotebook', () => ({
+  addElementToNotebook: jest.fn(),
+}));
+
+jest.mock('../model/lastUsedNotebook', () => ({
+  getLastUsedNotebook: jest.fn(() => ({ uid: 'nb-1', title: 'Spike notes' })),
+  clearLastUsedNotebook: jest.fn(),
+}));
+
+jest.mock('app/core/app_events', () => ({
+  appEvents: { emit: jest.fn() },
+}));
+
+const addElementToNotebookMock = jest.mocked(addElementToNotebook);
+
+describe('quickAddToLastNotebook', () => {
+  const element = { kind: 'Panel', spec: { title: 'p' } } as unknown as NotebookElement;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    addElementToNotebookMock.mockResolvedValue({ uid: 'nb-1', title: 'Spike notes', elementName: 'el-1' });
+  });
+
+  it('locks the time range when the source range is absolute (e.g. after zoom)', async () => {
+    await quickAddToLastNotebook(element, {
+      timeRange: { from: '2026-08-01T00:00:00.000Z', to: '2026-08-01T01:00:00.000Z' },
+    });
+
+    expect(addElementToNotebookMock).toHaveBeenCalledWith(
+      { type: 'existing', uid: 'nb-1' },
+      element,
+      expect.objectContaining({ lockTimeRange: true })
+    );
+  });
+
+  it('does not lock relative time ranges', async () => {
+    await quickAddToLastNotebook(element, {
+      timeRange: { from: 'now-1h', to: 'now' },
+    });
+
+    expect(addElementToNotebookMock).toHaveBeenCalledWith(
+      { type: 'existing', uid: 'nb-1' },
+      element,
+      expect.objectContaining({ lockTimeRange: false })
+    );
+  });
+});

--- a/public/app/features/notebook/addToNotebook/quickAddToLastNotebook.ts
+++ b/public/app/features/notebook/addToNotebook/quickAddToLastNotebook.ts
@@ -1,0 +1,43 @@
+import { AppEvents, rangeUtil, type RawTimeRange } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { type NotebookElement } from '@grafana/schema/apis/notebook/v2beta1';
+import { appEvents } from 'app/core/app_events';
+
+import { clearLastUsedNotebook, getLastUsedNotebook } from '../model/lastUsedNotebook';
+
+import { addElementToNotebook } from './addToNotebook';
+
+/**
+ * One-click "Add to last notebook": appends the element to the most recently used
+ * notebook without going through the picker modal. Returns false when there is no
+ * usable last notebook (callers should fall back to the full add-to-notebook flow).
+ *
+ * Absolute source ranges (e.g. after a panel zoom) are locked onto the block so
+ * the quick path matches the multi-step form's default.
+ */
+export async function quickAddToLastNotebook(
+  element: NotebookElement,
+  options?: { timeRange?: RawTimeRange }
+): Promise<boolean> {
+  const lastUsed = getLastUsedNotebook();
+  if (!lastUsed) {
+    return false;
+  }
+
+  const lockTimeRange = Boolean(options?.timeRange && !rangeUtil.isRelativeTimeRange(options.timeRange));
+
+  try {
+    const result = await addElementToNotebook({ type: 'existing', uid: lastUsed.uid }, element, {
+      timeRange: options?.timeRange,
+      source: 'user',
+      lockTimeRange,
+    });
+    appEvents.emit(AppEvents.alertSuccess, [t('notebooks.quick-add.added', 'Added to notebook'), result.title]);
+    return true;
+  } catch (error) {
+    // Most likely the notebook was deleted; forget it and let the caller fall
+    // back to the picker.
+    clearLastUsedNotebook();
+    return false;
+  }
+}

--- a/public/app/features/notebook/api/notebookAPI.ts
+++ b/public/app/features/notebook/api/notebookAPI.ts
@@ -1,0 +1,99 @@
+import { type Spec as NotebookSpec } from '@grafana/schema/apis/notebook/v2beta1';
+import { dashboardAPIv2beta1 } from 'app/api/clients/dashboard/v2beta1';
+import { type Resource } from 'app/features/apiserver/types';
+import { dispatch } from 'app/store/store';
+
+import { setLastUsedNotebook } from '../model/lastUsedNotebook';
+import { markNotebookAsNew } from '../model/newNotebookSignal';
+import { normalizeNotebookSpec } from '../model/notebookSpec';
+
+// The generated RTK types and the @grafana/schema notebook types are produced from the same
+// OpenAPI source and are structurally identical at runtime. The rest of the notebook feature
+// works with the schema types (same convention as NotebookScenePageStateManager), so all
+// casting between the two happens here, at the API seam.
+
+export function notebookViewUrl(uid: string): string {
+  return `/notebook/${uid}`;
+}
+
+export function notebookEditUrl(uid: string): string {
+  return `/notebooks/edit/${uid}`;
+}
+
+export async function fetchNotebook(uid: string): Promise<Resource<NotebookSpec>> {
+  const result = await dispatch(
+    dashboardAPIv2beta1.endpoints.getNotebook.initiate({ name: uid }, { subscribe: false, forceRefetch: true })
+  );
+  if ('error' in result && result.error) {
+    throw result.error;
+  }
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- generated client type bridged to the schema resource type at the fetch seam
+  const resource = result.data as unknown as Resource<NotebookSpec>;
+  // RTK Query freezes cached responses (Immer); clone so editor mutations stay safe.
+  const mutable = structuredClone(resource);
+  return { ...mutable, spec: normalizeNotebookSpec(mutable.spec) };
+}
+
+export async function createNotebook(spec: NotebookSpec): Promise<Resource<NotebookSpec>> {
+  const result = await dispatch(
+    dashboardAPIv2beta1.endpoints.createNotebook.initiate({
+      notebook: {
+        metadata: { generateName: 'nb' },
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- schema spec bridged to the generated client type at the API seam
+        spec: spec as unknown as Parameters<
+          typeof dashboardAPIv2beta1.endpoints.createNotebook.initiate
+        >[0]['notebook']['spec'],
+      },
+    })
+  );
+  if ('error' in result && result.error) {
+    throw result.error;
+  }
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- generated client type bridged to the schema resource type at the fetch seam
+  const created = result.data as unknown as Resource<NotebookSpec>;
+  setLastUsedNotebook(created.metadata.name, created.spec.title);
+  return created;
+}
+
+export async function saveNotebook(resource: Resource<NotebookSpec>): Promise<Resource<NotebookSpec>> {
+  const result = await dispatch(
+    dashboardAPIv2beta1.endpoints.replaceNotebook.initiate({
+      name: resource.metadata.name,
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- schema resource bridged to the generated client type at the API seam
+      notebook: resource as unknown as Parameters<
+        typeof dashboardAPIv2beta1.endpoints.replaceNotebook.initiate
+      >[0]['notebook'],
+    })
+  );
+  if ('error' in result && result.error) {
+    throw result.error;
+  }
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- generated client type bridged to the schema resource type at the fetch seam
+  const saved = result.data as unknown as Resource<NotebookSpec>;
+  setLastUsedNotebook(saved.metadata.name, saved.spec.title);
+  return saved;
+}
+
+/**
+ * Creates a copy of a notebook under a new title. The copy is marked as freshly
+ * created so opening it in the editor focuses the title, ready to rename.
+ */
+export async function duplicateNotebook(spec: NotebookSpec, copyTitle: string): Promise<Resource<NotebookSpec>> {
+  const copy: NotebookSpec = JSON.parse(JSON.stringify(spec));
+  copy.title = copyTitle;
+  const created = await createNotebook(copy);
+  markNotebookAsNew(created.metadata.name);
+  return created;
+}
+
+export async function deleteNotebook(uid: string): Promise<void> {
+  const result = await dispatch(dashboardAPIv2beta1.endpoints.deleteNotebook.initiate({ name: uid }));
+  if ('error' in result && result.error) {
+    throw result.error;
+  }
+}
+
+/** True when the error is a 409 optimistic-concurrency conflict from the apiserver. */
+export function isConflictError(error: unknown): boolean {
+  return typeof error === 'object' && error != null && 'status' in error && error.status === 409;
+}

--- a/public/app/features/notebook/collab/ActivityFeed.tsx
+++ b/public/app/features/notebook/collab/ActivityFeed.tsx
@@ -1,0 +1,137 @@
+import { css } from '@emotion/css';
+import { useState } from 'react';
+
+import { dateTimeFormatTimeAgo, type GrafanaTheme2 } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { IconButton, Text, Toggletip, useStyles2 } from '@grafana/ui';
+
+import { type ActivityEvent } from './types';
+
+interface Props {
+  activity: ActivityEvent[];
+  /** Scrolls to the block an entry refers to. */
+  onJumpToCell?: (cellKey: string) => void;
+}
+
+/**
+ * Toolbar popover showing the session's shared activity feed: who added, moved
+ * or changed which block, newest first. Session-scoped by design — history that
+ * matters long-term lives in the saved notebook, not here.
+ */
+export function ActivityFeedButton({ activity, onJumpToCell }: Props) {
+  const styles = useStyles2(getStyles);
+  const [open, setOpen] = useState(false);
+
+  const content = (
+    <div className={styles.panel}>
+      {activity.length === 0 ? (
+        <Text variant="bodySmall" color="secondary">
+          <Trans i18nKey="notebooks.activity.empty">Edits made while this notebook is open will show up here.</Trans>
+        </Text>
+      ) : (
+        <ul className={styles.list}>
+          {activity.map((event) => {
+            const name = event.user.name || event.user.login;
+            const row = (
+              <>
+                <span className={styles.dot} style={{ backgroundColor: event.color }} />
+                <span className={styles.text}>
+                  <strong>{name}</strong> {event.label}
+                </span>
+                <span className={styles.when}>{dateTimeFormatTimeAgo(event.ts)}</span>
+              </>
+            );
+
+            return (
+              <li key={event.id}>
+                {event.cellKey && onJumpToCell ? (
+                  <button
+                    type="button"
+                    className={styles.rowButton}
+                    onClick={() => {
+                      onJumpToCell(event.cellKey!);
+                      setOpen(false);
+                    }}
+                  >
+                    {row}
+                  </button>
+                ) : (
+                  <span className={styles.row}>{row}</span>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+
+  return (
+    <Toggletip
+      content={content}
+      title={t('notebooks.activity.title', 'Activity')}
+      placement="bottom-end"
+      closeButton={false}
+      show={open}
+      onOpen={() => setOpen(true)}
+      onClose={() => setOpen(false)}
+    >
+      <IconButton name="list-ul" size="lg" tooltip={t('notebooks.activity.tooltip', 'Activity')} />
+    </Toggletip>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  panel: css({
+    width: 300,
+    maxHeight: 320,
+    overflow: 'auto',
+  }),
+  list: css({
+    listStyle: 'none',
+    margin: 0,
+    padding: 0,
+  }),
+  row: css({
+    display: 'flex',
+    alignItems: 'baseline',
+    gap: theme.spacing(1),
+    padding: theme.spacing(0.75, 0.5),
+    width: '100%',
+  }),
+  rowButton: css({
+    display: 'flex',
+    alignItems: 'baseline',
+    gap: theme.spacing(1),
+    padding: theme.spacing(0.75, 0.5),
+    width: '100%',
+    background: 'none',
+    border: 'none',
+    textAlign: 'left',
+    cursor: 'pointer',
+    color: 'inherit',
+    borderRadius: theme.shape.radius.default,
+
+    '&:hover': {
+      background: theme.colors.action.hover,
+    },
+  }),
+  dot: css({
+    width: 8,
+    height: 8,
+    borderRadius: theme.shape.radius.circle,
+    flexShrink: 0,
+    alignSelf: 'center',
+  }),
+  text: css({
+    flex: 1,
+    minWidth: 0,
+    fontSize: theme.typography.bodySmall.fontSize,
+    color: theme.colors.text.primary,
+  }),
+  when: css({
+    flexShrink: 0,
+    fontSize: theme.typography.bodySmall.fontSize,
+    color: theme.colors.text.secondary,
+  }),
+});

--- a/public/app/features/notebook/collab/CollabCursors.tsx
+++ b/public/app/features/notebook/collab/CollabCursors.tsx
@@ -1,0 +1,117 @@
+import { css } from '@emotion/css';
+import { useEffect, useState } from 'react';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { useStyles2 } from '@grafana/ui';
+
+import { type RemotePeer } from './types';
+
+const CURSOR_FRESHNESS_MS = 6000;
+const POLL_INTERVAL_MS = 80;
+
+interface CursorView {
+  sid: string;
+  x: number;
+  y: number;
+  color: string;
+  label: string;
+}
+
+/**
+ * Live cursor overlay: renders collaborators' pointers (caret + name pill in
+ * their color) in notebook-document coordinates. Positions are polled from the
+ * collab peers ref rather than passed as React state — cursor moves arrive at
+ * pointer frequency and must only re-render this tiny layer, not the editor.
+ * Must be mounted inside a position:relative container matching the coordinate
+ * space cursors were captured in.
+ */
+export function CollabCursors({ getPeers }: { getPeers: () => RemotePeer[] }) {
+  const styles = useStyles2(getStyles);
+  const [cursors, setCursors] = useState<CursorView[]>([]);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      const now = Date.now();
+      const next = getPeers()
+        .filter((peer) => peer.cursor && now - peer.cursor.ts < CURSOR_FRESHNESS_MS)
+        .map((peer) => ({
+          sid: peer.sid,
+          x: peer.cursor!.x,
+          y: peer.cursor!.y,
+          color: peer.color,
+          label: peer.user.name || peer.user.login,
+        }));
+
+      setCursors((current) => (cursorsEqual(current, next) ? current : next));
+    }, POLL_INTERVAL_MS);
+    return () => clearInterval(timer);
+  }, [getPeers]);
+
+  if (cursors.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={styles.layer} aria-hidden>
+      {cursors.map((cursor) => (
+        <div
+          key={cursor.sid}
+          className={styles.cursor}
+          style={{ transform: `translate(${cursor.x}px, ${cursor.y}px)` }}
+        >
+          <svg width="14" height="18" viewBox="0 0 14 18" className={styles.caret}>
+            <path d="M1 1 L13 9 L7 10.5 L4.5 17 Z" fill={cursor.color} stroke="white" strokeWidth="1" />
+          </svg>
+          <span className={styles.pill} style={{ backgroundColor: cursor.color }}>
+            {cursor.label}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function cursorsEqual(a: CursorView[], b: CursorView[]): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  return a.every((cursor, i) => {
+    const other = b[i];
+    return cursor.sid === other.sid && cursor.x === other.x && cursor.y === other.y && cursor.color === other.color;
+  });
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  layer: css({
+    position: 'absolute',
+    inset: 0,
+    overflow: 'hidden',
+    pointerEvents: 'none',
+    zIndex: theme.zIndex.tooltip,
+  }),
+  cursor: css({
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: 2,
+
+    [theme.transitions.handleMotion('no-preference')]: {
+      transition: 'transform 80ms linear',
+    },
+  }),
+  caret: css({
+    filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.4))',
+  }),
+  pill: css({
+    marginTop: 10,
+    color: '#fff',
+    fontSize: theme.typography.bodySmall.fontSize,
+    lineHeight: 1.6,
+    padding: theme.spacing(0, 0.75),
+    borderRadius: theme.shape.radius.pill,
+    whiteSpace: 'nowrap',
+    boxShadow: theme.shadows.z1,
+  }),
+});

--- a/public/app/features/notebook/collab/PresenceAvatars.tsx
+++ b/public/app/features/notebook/collab/PresenceAvatars.tsx
@@ -1,0 +1,108 @@
+import { css, cx } from '@emotion/css';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { Tooltip, useStyles2 } from '@grafana/ui';
+
+import { type RemotePeer } from './types';
+
+interface Props {
+  peers: RemotePeer[];
+  /** Session id of the peer currently being followed, if any. */
+  followedSid?: string | null;
+  /** When set, avatars become buttons that toggle following that collaborator. */
+  onToggleFollow?: (peer: RemotePeer) => void;
+}
+
+/** Compact row of colored initials for everyone else connected to the notebook. */
+export function PresenceAvatars({ peers, followedSid, onToggleFollow }: Props) {
+  const styles = useStyles2(getStyles);
+
+  if (peers.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={styles.row} data-testid="notebook-presence">
+      {peers.map((peer) => {
+        const label = peer.user.name || peer.user.login;
+        const following = followedSid === peer.sid;
+        const tooltip = onToggleFollow
+          ? following
+            ? t('notebooks.presence.stop-following', 'Following {{name}} — click to stop', { name: label })
+            : t('notebooks.presence.click-to-follow', '{{name}} is in this notebook — click to follow', {
+                name: label,
+              })
+          : t('notebooks.presence.viewing', '{{name}} is in this notebook', { name: label });
+
+        if (!onToggleFollow) {
+          return (
+            <Tooltip key={peer.sid} content={tooltip}>
+              <span className={styles.avatar} style={{ backgroundColor: peer.color }}>
+                {initials(label)}
+              </span>
+            </Tooltip>
+          );
+        }
+
+        return (
+          <Tooltip key={peer.sid} content={tooltip}>
+            <button
+              type="button"
+              className={cx(styles.avatar, styles.clickable, following && styles.following)}
+              style={{ backgroundColor: peer.color, ...(following ? { outlineColor: peer.color } : {}) }}
+              onClick={() => onToggleFollow(peer)}
+              aria-pressed={following}
+            >
+              {initials(label)}
+            </button>
+          </Tooltip>
+        );
+      })}
+    </div>
+  );
+}
+
+function initials(name: string): string {
+  const parts = name.trim().split(/\s+/);
+  const first = parts[0]?.[0] ?? '?';
+  const last = parts.length > 1 ? parts[parts.length - 1][0] : '';
+  return (first + last).toUpperCase();
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  row: css({
+    display: 'flex',
+    alignItems: 'center',
+
+    '& > * + *': {
+      marginLeft: -6,
+    },
+  }),
+  avatar: css({
+    width: 26,
+    height: 26,
+    borderRadius: theme.shape.radius.circle,
+    border: `2px solid ${theme.colors.background.primary}`,
+    color: '#fff',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    fontSize: theme.typography.bodySmall.fontSize,
+    fontWeight: theme.typography.fontWeightMedium,
+    cursor: 'default',
+    padding: 0,
+  }),
+  clickable: css({
+    cursor: 'pointer',
+
+    '&:hover': {
+      transform: 'scale(1.1)',
+    },
+  }),
+  following: css({
+    outlineStyle: 'solid',
+    outlineWidth: 2,
+    outlineOffset: 1,
+  }),
+});

--- a/public/app/features/notebook/collab/mergeRemoteSpec.test.ts
+++ b/public/app/features/notebook/collab/mergeRemoteSpec.test.ts
@@ -1,0 +1,48 @@
+import { insertElement, newMarkdownElement, newNotebookSpec, updateMarkdownText } from '../model/notebookSpec';
+
+import { mergeRemoteSpec } from './mergeRemoteSpec';
+
+describe('mergeRemoteSpec', () => {
+  function setup() {
+    let spec = newNotebookSpec('nb');
+    const a = insertElement(spec, newMarkdownElement('a'));
+    const b = insertElement(a.spec, newMarkdownElement('b'));
+    return { spec: b.spec, aKey: a.elementName, bKey: b.elementName };
+  }
+
+  it('returns the remote spec when not editing', () => {
+    const { spec } = setup();
+    const remote = updateMarkdownText(spec, Object.keys(spec.elements)[0], 'remote edit');
+
+    expect(mergeRemoteSpec(remote, spec, null)).toBe(remote);
+    expect(mergeRemoteSpec(remote, undefined, 'anything')).toBe(remote);
+  });
+
+  it('keeps the locally edited cell while taking remote changes elsewhere', () => {
+    const { spec, aKey, bKey } = setup();
+    const local = updateMarkdownText(spec, aKey, 'local typing in progress');
+    const remote = updateMarkdownText(spec, bKey, 'remote edit');
+
+    const merged = mergeRemoteSpec(remote, local, aKey);
+
+    const mergedA = merged.elements[aKey];
+    const mergedB = merged.elements[bKey];
+    if (mergedA.kind !== 'Cell' || mergedA.spec.content.kind !== 'Markdown') {
+      throw new Error('expected markdown cell');
+    }
+    if (mergedB.kind !== 'Cell' || mergedB.spec.content.kind !== 'Markdown') {
+      throw new Error('expected markdown cell');
+    }
+    expect(mergedA.spec.content.spec.text).toBe('local typing in progress');
+    expect(mergedB.spec.content.spec.text).toBe('remote edit');
+  });
+
+  it('accepts a remote deletion of the cell being edited', () => {
+    const { spec, aKey } = setup();
+    const local = updateMarkdownText(spec, aKey, 'local typing');
+    const remote = { ...spec, elements: { ...spec.elements } };
+    delete remote.elements[aKey];
+
+    expect(mergeRemoteSpec(remote, local, aKey)).toBe(remote);
+  });
+});

--- a/public/app/features/notebook/collab/mergeRemoteSpec.ts
+++ b/public/app/features/notebook/collab/mergeRemoteSpec.ts
@@ -1,0 +1,28 @@
+import { type Spec as NotebookSpec } from '@grafana/schema/apis/notebook/v2beta1';
+
+/**
+ * Applies a collaborator's document while protecting the cell the local user is
+ * actively editing: the remote doc wins everywhere (last-write-wins), except the
+ * locally-focused element keeps its local content so concurrent typing in
+ * different cells doesn't clobber in-progress input.
+ */
+export function mergeRemoteSpec(
+  remote: NotebookSpec,
+  local: NotebookSpec | undefined,
+  editingCellKey: string | null | undefined
+): NotebookSpec {
+  if (!local || !editingCellKey) {
+    return remote;
+  }
+
+  const localElement = local.elements[editingCellKey];
+  // If the collaborator deleted the cell we're editing, accept the deletion.
+  if (!localElement || !remote.elements[editingCellKey]) {
+    return remote;
+  }
+
+  return {
+    ...remote,
+    elements: { ...remote.elements, [editingCellKey]: localElement },
+  };
+}

--- a/public/app/features/notebook/collab/types.ts
+++ b/public/app/features/notebook/collab/types.ts
@@ -1,0 +1,88 @@
+import { type Spec as NotebookSpec } from '@grafana/schema/apis/notebook/v2beta1';
+
+export interface CollabUser {
+  login: string;
+  name: string;
+  avatarUrl?: string;
+}
+
+interface CollabMessageBase {
+  /** Session id of the sender — one per open editor tab, used to ignore own messages. */
+  sid: string;
+  /**
+   * For doc messages: the document's version timestamp (the edit that produced it),
+   * used for last-write-wins convergence. For everything else: the send time.
+   */
+  ts: number;
+  user: CollabUser;
+}
+
+/** Full working-copy broadcast, sent debounced after local edits and in reply to `hello`. */
+interface CollabDocMessage extends CollabMessageBase {
+  t: 'doc';
+  spec: NotebookSpec;
+  /** Sent by one-shot flows (e.g. add-to-notebook) — not a session; skip presence tracking. */
+  transient?: boolean;
+}
+
+/** Cursor position in notebook-document coordinates plus the cell the user is in. */
+interface CollabCursorMessage extends CollabMessageBase {
+  t: 'cursor';
+  x: number;
+  y: number;
+  /** Element name of the cell being edited or hovered, null when outside any cell. */
+  cellKey: string | null;
+}
+
+/** Sent on join and as heartbeat so peers can discover each other. */
+interface CollabHelloMessage extends CollabMessageBase {
+  t: 'hello';
+}
+
+/** Sent on leave for immediate presence cleanup (heartbeat expiry is the fallback). */
+interface CollabByeMessage extends CollabMessageBase {
+  t: 'bye';
+}
+
+/** Sender's viewport position (the cell nearest its center), powering follow mode. */
+interface CollabViewMessage extends CollabMessageBase {
+  t: 'view';
+  cellKey: string | null;
+}
+
+/** A human-readable edit event ("added a text block") for the activity feed. */
+interface CollabActivityMessage extends CollabMessageBase {
+  t: 'activity';
+  label: string;
+  cellKey?: string;
+}
+
+export type CollabMessage =
+  | CollabDocMessage
+  | CollabCursorMessage
+  | CollabHelloMessage
+  | CollabByeMessage
+  | CollabViewMessage
+  | CollabActivityMessage;
+
+export interface RemotePeer {
+  sid: string;
+  user: CollabUser;
+  color: string;
+  lastSeen: number;
+  cursor?: { x: number; y: number; ts: number };
+  cellKey?: string | null;
+  /** Cell nearest the peer's viewport center — where followers scroll to. */
+  viewCell?: string | null;
+}
+
+/** One entry of the session's activity feed (own actions included). */
+export interface ActivityEvent {
+  id: string;
+  sid: string;
+  user: CollabUser;
+  color: string;
+  label: string;
+  cellKey?: string;
+  ts: number;
+}

--- a/public/app/features/notebook/collab/useNotebookCollab.ts
+++ b/public/app/features/notebook/collab/useNotebookCollab.ts
@@ -1,0 +1,384 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { type Unsubscribable } from 'rxjs';
+
+import {
+  generateUUID,
+  isLiveChannelMessageEvent,
+  isLiveChannelStatusEvent,
+  type LiveChannelAddress,
+  LiveChannelConnectionState,
+  LiveChannelScope,
+} from '@grafana/data';
+import { getGrafanaLiveSrv } from '@grafana/runtime';
+import { type Spec as NotebookSpec } from '@grafana/schema/apis/notebook/v2beta1';
+import { contextSrv } from 'app/core/services/context_srv';
+import { AnnoKeyUpdatedTimestamp, type Resource } from 'app/features/apiserver/types';
+
+import { type ActivityEvent, type CollabMessage, type CollabUser, type RemotePeer } from './types';
+
+const DOC_BROADCAST_DEBOUNCE_MS = 350;
+const CURSOR_THROTTLE_MS = 60;
+const VIEW_THROTTLE_MS = 250;
+const HEARTBEAT_INTERVAL_MS = 8000;
+const PEER_EXPIRY_MS = 20000;
+const ACTIVITY_FEED_LIMIT = 30;
+
+// Classic Grafana visualization palette — stable, high-contrast colors for collaborators.
+const PEER_COLORS = ['#7EB26D', '#EAB839', '#6ED0E0', '#EF843C', '#E24D42', '#1F78C1', '#BA43A9', '#705DA0'];
+
+export interface NotebookCollabApi {
+  /**
+   * Other sessions currently connected to this notebook (excludes self). Updates on
+   * structural changes (join/leave, block focus, viewport) — NOT on every cursor
+   * move, so consuming components don't re-render at pointer frequency.
+   */
+  peers: RemotePeer[];
+  /** Latest peers including live cursor positions — for the cursor overlay, which polls. */
+  getPeers: () => RemotePeer[];
+  /** Recent edit events from everyone (own actions included), newest first. */
+  activity: ActivityEvent[];
+  /** Call after every local spec change; broadcasts the doc debounced. */
+  notifyLocalEdit: () => void;
+  /** Call from pointer tracking; broadcasts the cursor throttled. */
+  sendCursor: (x: number, y: number, cellKey: string | null) => void;
+  /** Call from scroll tracking; broadcasts the viewport cell for follow mode. */
+  sendView: (cellKey: string | null) => void;
+  /** Announces a labeled edit ("added a text block") to the shared activity feed. */
+  sendActivity: (label: string, cellKey?: string) => void;
+  /** This session's collaborator color (used for own feed entries). */
+  selfColor: string;
+  sessionId: string;
+}
+
+interface Options {
+  uid: string;
+  enabled: boolean;
+  getSpec: () => NotebookSpec | undefined;
+  /** Called when a newer document arrives from a collaborator. */
+  onRemoteSpec: (spec: NotebookSpec) => void;
+  /**
+   * The saved-version timestamp (ms) of the loaded document. Doc broadcasts carry the
+   * timestamp of the edit that produced the document — not the send time — so a session
+   * holding an older working copy can never clobber a fresher one just by replying later.
+   */
+  initialDocTs?: number;
+}
+
+/** The saved version's timestamp (ms) of a notebook resource, seeding the doc-version clock. */
+export function resourceVersionTs(resource?: Resource<NotebookSpec>): number | undefined {
+  const stamp = resource?.metadata.annotations?.[AnnoKeyUpdatedTimestamp] ?? resource?.metadata.creationTimestamp;
+  const parsed = stamp ? Date.parse(stamp) : NaN;
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+/**
+ * One-shot document broadcast for flows that save over HTTP outside an editor
+ * session (add-to-notebook from dashboards/Explore) — open editors of the same
+ * notebook apply the fresh document immediately instead of waiting for a reload.
+ */
+export function broadcastNotebookDoc(uid: string, spec: NotebookSpec) {
+  const message: CollabMessage = {
+    t: 'doc',
+    sid: `oneshot-${generateUUID()}`,
+    ts: Date.now(),
+    user: {
+      login: contextSrv.user.login,
+      name: contextSrv.user.name || contextSrv.user.login,
+      avatarUrl: contextSrv.user.gravatarUrl,
+    },
+    spec,
+    transient: true,
+  };
+  getGrafanaLiveSrv()
+    .publish({ scope: LiveChannelScope.Grafana, stream: 'notebook', path: `uid/${uid}` }, message)
+    .catch(() => {
+      // Best-effort: open editors fall back to seeing the change on reload.
+    });
+}
+
+function colorForSession(sid: string): string {
+  let hash = 0;
+  for (let i = 0; i < sid.length; i++) {
+    hash = (hash * 31 + sid.charCodeAt(i)) | 0;
+  }
+  return PEER_COLORS[Math.abs(hash) % PEER_COLORS.length];
+}
+
+/**
+ * Real-time collaboration for one notebook over a Grafana Live channel
+ * (`grafana/notebook/uid/<uid>`, relayed by the backend NotebookHandler):
+ * presence (who is here), live cursors and last-write-wins doc sync. The
+ * notebook API remains the source of truth — this only syncs working copies.
+ */
+export function useNotebookCollab({ uid, enabled, getSpec, onRemoteSpec, initialDocTs }: Options): NotebookCollabApi {
+  const sessionId = useMemo(() => generateUUID(), []);
+  const [peers, setPeers] = useState<RemotePeer[]>([]);
+  const [activity, setActivity] = useState<ActivityEvent[]>([]);
+
+  const peersRef = useRef(new Map<string, RemotePeer>());
+  // Version timestamp of the current working copy: the saved version's timestamp at
+  // load, bumped by local edits (to now) and by accepted remote documents (to their ts).
+  const docTs = useRef(0);
+  if (initialDocTs && docTs.current === 0) {
+    docTs.current = initialDocTs;
+  }
+  const lastCursorSentAt = useRef(0);
+  const lastViewSentAt = useRef(0);
+  const lastViewCell = useRef<string | null | undefined>(undefined);
+  const lastHelloReplyAt = useRef(0);
+  const docTimer = useRef<ReturnType<typeof setTimeout>>();
+
+  // Keep latest callbacks in refs so the channel subscription effect only depends on uid/enabled.
+  const getSpecRef = useRef(getSpec);
+  getSpecRef.current = getSpec;
+  const onRemoteSpecRef = useRef(onRemoteSpec);
+  onRemoteSpecRef.current = onRemoteSpec;
+
+  const user: CollabUser = useMemo(
+    () => ({
+      login: contextSrv.user.login,
+      name: contextSrv.user.name || contextSrv.user.login,
+      avatarUrl: contextSrv.user.gravatarUrl,
+    }),
+    []
+  );
+
+  const address: LiveChannelAddress = useMemo(
+    () => ({ scope: LiveChannelScope.Grafana, stream: 'notebook', path: `uid/${uid}` }),
+    [uid]
+  );
+
+  const publish = useCallback(
+    (message: CollabMessage, opts?: { socket?: boolean }) => {
+      getGrafanaLiveSrv()
+        .publish(address, message, opts?.socket ? { useSocket: true } : undefined)
+        .catch(() => {
+          // Collaboration is best-effort: a dropped message is recovered by the
+          // next heartbeat/doc broadcast, so failures are intentionally silent.
+        });
+    },
+    [address]
+  );
+
+  const flushPeers = useCallback(() => {
+    setPeers(Array.from(peersRef.current.values()));
+  }, []);
+
+  const touchPeer = useCallback(
+    (message: CollabMessage) => {
+      const existing = peersRef.current.get(message.sid);
+      const peer: RemotePeer = existing ?? {
+        sid: message.sid,
+        user: message.user,
+        color: colorForSession(message.sid),
+        lastSeen: Date.now(),
+      };
+      peer.lastSeen = Date.now();
+      peer.user = message.user;
+
+      // Re-rendering consumers at cursor frequency (~16/s per peer) can saturate the
+      // main thread on large notebooks, so pure position updates only mutate the ref
+      // (polled by the cursor overlay). State flushes are reserved for structural
+      // changes: new peers, block focus changes and viewport moves.
+      let structural = !existing;
+      if (message.t === 'cursor') {
+        peer.cursor = { x: message.x, y: message.y, ts: Date.now() };
+        if (peer.cellKey !== message.cellKey) {
+          peer.cellKey = message.cellKey;
+          structural = true;
+        }
+      }
+      if (message.t === 'view' && peer.viewCell !== message.cellKey) {
+        peer.viewCell = message.cellKey;
+        structural = true;
+      }
+      peersRef.current.set(message.sid, peer);
+      if (structural) {
+        flushPeers();
+      }
+    },
+    [flushPeers]
+  );
+
+  const appendActivity = useCallback((event: ActivityEvent) => {
+    setActivity((current) => [event, ...current].slice(0, ACTIVITY_FEED_LIMIT));
+  }, []);
+
+  const broadcastDocNow = useCallback(() => {
+    const spec = getSpecRef.current();
+    if (!spec) {
+      return;
+    }
+    // ts is the document's version timestamp, never the send time: replying to a
+    // hello with an old working copy must not out-rank fresher documents.
+    publish({ t: 'doc', sid: sessionId, ts: docTs.current || Date.now(), user, spec });
+  }, [publish, sessionId, user]);
+
+  useEffect(() => {
+    if (!enabled || !uid) {
+      return;
+    }
+
+    let subscription: Unsubscribable | undefined;
+    const live = getGrafanaLiveSrv();
+    const peersAtSubscribe = peersRef.current;
+
+    subscription = live.getStream<CollabMessage>(address).subscribe({
+      next: (event) => {
+        if (isLiveChannelStatusEvent(event) && event.state === LiveChannelConnectionState.Connected) {
+          publish({ t: 'hello', sid: sessionId, ts: Date.now(), user });
+          return;
+        }
+
+        if (!isLiveChannelMessageEvent(event)) {
+          return;
+        }
+        const message = event.message;
+        if (!message || typeof message !== 'object' || !('sid' in message) || message.sid === sessionId) {
+          return;
+        }
+
+        switch (message.t) {
+          case 'hello': {
+            touchPeer(message);
+            // Announce ourselves and share our working copy so the newcomer converges.
+            // Throttled: several peers replying in the same window is fine, the newest ts wins.
+            if (Date.now() - lastHelloReplyAt.current > 2000) {
+              lastHelloReplyAt.current = Date.now();
+              publish({ t: 'hello', sid: sessionId, ts: Date.now(), user });
+              broadcastDocNow();
+            }
+            break;
+          }
+          case 'doc': {
+            if (!message.transient) {
+              touchPeer(message);
+            }
+            // Last write wins on document-version timestamps: apply only when the
+            // remote document is strictly newer than ours (concurrently-typed local
+            // cells are protected by the editor's merge). Equal timestamps mean both
+            // sessions hold the same saved version — nothing to converge.
+            if (message.ts > docTs.current) {
+              docTs.current = message.ts;
+              onRemoteSpecRef.current(message.spec);
+            }
+            break;
+          }
+          case 'cursor': {
+            touchPeer(message);
+            break;
+          }
+          case 'view': {
+            touchPeer(message);
+            break;
+          }
+          case 'activity': {
+            touchPeer(message);
+            appendActivity({
+              id: `${message.sid}-${message.ts}`,
+              sid: message.sid,
+              user: message.user,
+              color: colorForSession(message.sid),
+              label: message.label,
+              cellKey: message.cellKey,
+              ts: message.ts,
+            });
+            break;
+          }
+          case 'bye': {
+            peersRef.current.delete(message.sid);
+            flushPeers();
+            break;
+          }
+        }
+      },
+    });
+
+    const heartbeat = setInterval(() => {
+      publish({ t: 'hello', sid: sessionId, ts: Date.now(), user });
+
+      let changed = false;
+      for (const [sid, peer] of peersRef.current) {
+        if (Date.now() - peer.lastSeen > PEER_EXPIRY_MS) {
+          peersRef.current.delete(sid);
+          changed = true;
+        }
+      }
+      if (changed) {
+        flushPeers();
+      }
+    }, HEARTBEAT_INTERVAL_MS);
+
+    return () => {
+      publish({ t: 'bye', sid: sessionId, ts: Date.now(), user });
+      clearInterval(heartbeat);
+      clearTimeout(docTimer.current);
+      subscription?.unsubscribe();
+      peersAtSubscribe.clear();
+      setPeers([]);
+    };
+  }, [address, enabled, uid, publish, sessionId, user, touchPeer, flushPeers, broadcastDocNow, appendActivity]);
+
+  const notifyLocalEdit = useCallback(() => {
+    docTs.current = Date.now();
+    if (!enabled) {
+      return;
+    }
+    clearTimeout(docTimer.current);
+    docTimer.current = setTimeout(broadcastDocNow, DOC_BROADCAST_DEBOUNCE_MS);
+  }, [enabled, broadcastDocNow]);
+
+  const sendCursor = useCallback(
+    (x: number, y: number, cellKey: string | null) => {
+      if (!enabled) {
+        return;
+      }
+      const now = Date.now();
+      if (now - lastCursorSentAt.current < CURSOR_THROTTLE_MS) {
+        return;
+      }
+      lastCursorSentAt.current = now;
+      // Cursor updates ride the websocket: they are high-frequency and lossy by nature.
+      publish(
+        { t: 'cursor', sid: sessionId, ts: now, user, x: Math.round(x), y: Math.round(y), cellKey },
+        { socket: true }
+      );
+    },
+    [enabled, publish, sessionId, user]
+  );
+
+  const sendView = useCallback(
+    (cellKey: string | null) => {
+      if (!enabled) {
+        return;
+      }
+      const now = Date.now();
+      // Skip unchanged positions and rate-limit: followers only need transitions.
+      if (cellKey === lastViewCell.current || now - lastViewSentAt.current < VIEW_THROTTLE_MS) {
+        return;
+      }
+      lastViewCell.current = cellKey;
+      lastViewSentAt.current = now;
+      publish({ t: 'view', sid: sessionId, ts: now, user, cellKey }, { socket: true });
+    },
+    [enabled, publish, sessionId, user]
+  );
+
+  const selfColor = useMemo(() => colorForSession(sessionId), [sessionId]);
+
+  const sendActivity = useCallback(
+    (label: string, cellKey?: string) => {
+      const ts = Date.now();
+      // Own actions appear in the local feed immediately; peers get them over Live.
+      appendActivity({ id: `${sessionId}-${ts}`, sid: sessionId, user, color: selfColor, label, cellKey, ts });
+      if (enabled) {
+        publish({ t: 'activity', sid: sessionId, ts, user, label, cellKey });
+      }
+    },
+    [enabled, publish, sessionId, user, selfColor, appendActivity]
+  );
+
+  const getPeers = useCallback(() => Array.from(peersRef.current.values()), []);
+
+  return { peers, getPeers, activity, notifyLocalEdit, sendCursor, sendView, sendActivity, selfColor, sessionId };
+}

--- a/public/app/features/notebook/editor/AddCellRow.tsx
+++ b/public/app/features/notebook/editor/AddCellRow.tsx
@@ -1,0 +1,64 @@
+import { css } from '@emotion/css';
+import { useState } from 'react';
+
+import { type DataSourceInstanceSettings, type GrafanaTheme2 } from '@grafana/data';
+import { Trans } from '@grafana/i18n';
+import { Button, Stack, useStyles2 } from '@grafana/ui';
+
+import { InlineDataSourcePicker } from './InlineDataSourcePicker';
+
+interface Props {
+  onAddText: () => void;
+  onAddCode: () => void;
+  onAddViz: (datasource: DataSourceInstanceSettings) => void;
+}
+
+/**
+ * "Add block" affordance at the end of the notebook. Text and code blocks are
+ * created inline; a visualization starts from a datasource pick (and can also be
+ * captured from any dashboard panel menu or Explore).
+ */
+export function AddCellRow({ onAddText, onAddCode, onAddViz }: Props) {
+  const styles = useStyles2(getStyles);
+  const [pickingDatasource, setPickingDatasource] = useState(false);
+
+  return (
+    <div className={styles.row} data-testid="notebook-add-cell">
+      {pickingDatasource ? (
+        <InlineDataSourcePicker
+          onSelect={(ds) => {
+            setPickingDatasource(false);
+            onAddViz(ds);
+          }}
+          onCancel={() => setPickingDatasource(false)}
+        />
+      ) : (
+        <Stack direction="row" gap={1} alignItems="center">
+          <Button variant="secondary" fill="outline" size="sm" icon="text-fields" onClick={onAddText}>
+            <Trans i18nKey="notebooks.add-cell.text">Text</Trans>
+          </Button>
+          <Button variant="secondary" fill="outline" size="sm" icon="brackets-curly" onClick={onAddCode}>
+            <Trans i18nKey="notebooks.add-cell.code">Code</Trans>
+          </Button>
+          <Button
+            variant="secondary"
+            fill="outline"
+            size="sm"
+            icon="graph-bar"
+            onClick={() => setPickingDatasource(true)}
+          >
+            <Trans i18nKey="notebooks.add-cell.visualization">Visualization</Trans>
+          </Button>
+        </Stack>
+      )}
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  row: css({
+    paddingTop: theme.spacing(2),
+    borderTop: `1px dashed ${theme.colors.border.weak}`,
+    marginTop: theme.spacing(2),
+  }),
+});

--- a/public/app/features/notebook/editor/InlineDataSourcePicker.tsx
+++ b/public/app/features/notebook/editor/InlineDataSourcePicker.tsx
@@ -1,0 +1,39 @@
+import { css } from '@emotion/css';
+
+import { type DataSourceInstanceSettings, type GrafanaTheme2 } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { DataSourcePicker } from '@grafana/runtime';
+import { IconButton, Stack, Text, useStyles2 } from '@grafana/ui';
+
+interface Props {
+  onSelect: (datasource: DataSourceInstanceSettings) => void;
+  onCancel: () => void;
+}
+
+/**
+ * The "pick a datasource to start a visualization" row, shared by the add-block
+ * row and the between-blocks insert divider.
+ */
+export function InlineDataSourcePicker({ onSelect, onCancel }: Props) {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <Stack direction="row" gap={1} alignItems="center">
+      <div className={styles.picker}>
+        <DataSourcePicker current={null} autoFocus openMenuOnFocus onChange={onSelect} />
+      </div>
+      <IconButton name="times" tooltip={t('notebooks.add-cell.viz-cancel', 'Cancel')} onClick={onCancel} />
+      <Text variant="bodySmall" color="secondary">
+        <Trans i18nKey="notebooks.add-cell.viz-hint">
+          Tip: any dashboard panel or Explore query can also be added via “Add to notebook”.
+        </Trans>
+      </Text>
+    </Stack>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  picker: css({
+    minWidth: 320,
+  }),
+});

--- a/public/app/features/notebook/editor/InsertCellDivider.tsx
+++ b/public/app/features/notebook/editor/InsertCellDivider.tsx
@@ -1,0 +1,89 @@
+import { css } from '@emotion/css';
+import { useState } from 'react';
+
+import { type DataSourceInstanceSettings, type GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { Dropdown, IconButton, Menu, useStyles2 } from '@grafana/ui';
+
+import { InlineDataSourcePicker } from './InlineDataSourcePicker';
+
+interface Props {
+  onInsertText: () => void;
+  onInsertCode: () => void;
+  onInsertViz: (datasource: DataSourceInstanceSettings) => void;
+}
+
+/**
+ * Notion-style hover affordance between cells: a thin line with a "+" that inserts
+ * a new text, code or visualization block at that position.
+ */
+export function InsertCellDivider({ onInsertText, onInsertCode, onInsertViz }: Props) {
+  const styles = useStyles2(getStyles);
+  const [pickingDatasource, setPickingDatasource] = useState(false);
+
+  if (pickingDatasource) {
+    return (
+      <div className={styles.pickerRow}>
+        <InlineDataSourcePicker
+          onSelect={(ds) => {
+            setPickingDatasource(false);
+            onInsertViz(ds);
+          }}
+          onCancel={() => setPickingDatasource(false)}
+        />
+      </div>
+    );
+  }
+
+  const menu = (
+    <Menu>
+      <Menu.Item icon="text-fields" label={t('notebooks.insert-divider.text', 'Text')} onClick={onInsertText} />
+      <Menu.Item icon="brackets-curly" label={t('notebooks.insert-divider.code', 'Code')} onClick={onInsertCode} />
+      <Menu.Item
+        icon="graph-bar"
+        label={t('notebooks.insert-divider.visualization', 'Visualization')}
+        onClick={() => setPickingDatasource(true)}
+      />
+    </Menu>
+  );
+
+  return (
+    <div className={styles.divider}>
+      <div className={styles.line} />
+      <Dropdown overlay={menu} placement="bottom-start">
+        <IconButton
+          name="plus-circle"
+          size="sm"
+          className={styles.button}
+          tooltip={t('notebooks.insert-divider.tooltip', 'Insert block here')}
+        />
+      </Dropdown>
+      <div className={styles.line} />
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  divider: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    height: theme.spacing(2),
+    opacity: 0,
+
+    '&:hover, &:focus-within': {
+      opacity: 1,
+    },
+  }),
+  pickerRow: css({
+    padding: theme.spacing(1, 0),
+  }),
+  line: css({
+    flex: 1,
+    height: 1,
+    background: theme.colors.border.medium,
+  }),
+  button: css({
+    color: theme.colors.text.secondary,
+  }),
+});

--- a/public/app/features/notebook/editor/NotebookCellBody.tsx
+++ b/public/app/features/notebook/editor/NotebookCellBody.tsx
@@ -1,0 +1,221 @@
+import { rangeUtil, type PanelData } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { type Spec as NotebookSpec } from '@grafana/schema/apis/notebook/v2beta1';
+import { Alert, Button, Icon, IconButton, Input, Stack, Text, TimeRangeInput } from '@grafana/ui';
+
+import {
+  clearCellTimeOverride,
+  setCellHeight,
+  setCellTimeOverride,
+  updateCodeCell,
+  updateMarkdownText,
+  updatePanelQuery,
+  updatePanelTitle,
+  type ResolvedCell,
+} from '../model/notebookSpec';
+import { formatLockedRange, rawToString } from '../model/timeFormat';
+
+import { CodeCellEditor } from './cells/CodeCellEditor';
+import { MarkdownCellEditor } from './cells/MarkdownCellEditor';
+import { PanelCellView } from './cells/PanelCellView';
+import { PanelQueryEditor } from './cells/PanelQueryEditor';
+
+export interface CellBodyProps {
+  cell: ResolvedCell;
+  spec: NotebookSpec;
+  index: number;
+  editing: boolean;
+  renaming: boolean;
+  timeEditing: boolean;
+  queryEditing: boolean;
+  refreshNonce: number;
+  onStartEdit: () => void;
+  onDoneEdit: () => void;
+  onDoneRename: () => void;
+  onDoneTimeEdit: () => void;
+  onDoneQueryEdit: () => void;
+  getPanelData: () => PanelData | undefined;
+  onRegisterDataReader: (getData: () => PanelData | undefined) => void;
+  onPreferredViz: (pluginId: string) => void;
+  onQueryApplied: () => void;
+  update: (mutate: (spec: NotebookSpec) => NotebookSpec, activity?: { label: string; cellKey?: string }) => void;
+}
+
+/**
+ * The type-specific body of one notebook block: a live panel (with rename, time
+ * lock and inline query editing), editable markdown, or an editable code snippet.
+ */
+export function NotebookCellBody({
+  cell,
+  spec,
+  index,
+  editing,
+  renaming,
+  timeEditing,
+  queryEditing,
+  refreshNonce,
+  onStartEdit,
+  onDoneEdit,
+  onDoneRename,
+  onDoneTimeEdit,
+  onDoneQueryEdit,
+  getPanelData,
+  onRegisterDataReader,
+  onPreferredViz,
+  onQueryApplied,
+  update,
+}: CellBodyProps) {
+  const { element, elementName } = cell;
+
+  if (element.kind === 'Panel') {
+    const commitRename = (value: string) => {
+      update((s) => updatePanelTitle(s, elementName, value), {
+        label: t('notebooks.activity.renamed-panel', 'renamed a panel'),
+        cellKey: elementName,
+      });
+      onDoneRename();
+    };
+
+    const isLocked = Boolean(cell.timeFrom && cell.timeTo);
+    const effectiveFrom = cell.timeFrom ?? spec.timeSettings.from;
+    const effectiveTo = cell.timeTo ?? spec.timeSettings.to;
+
+    return (
+      <>
+        {renaming && (
+          <Input
+            autoFocus
+            defaultValue={element.spec.title}
+            aria-label={t('notebooks.cell.rename-label', 'Panel title')}
+            onBlur={(e) => commitRename(e.currentTarget.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                commitRename(e.currentTarget.value);
+              }
+              if (e.key === 'Escape') {
+                onDoneTimeEdit();
+                onDoneRename();
+              }
+            }}
+          />
+        )}
+        {timeEditing && (
+          <Stack direction="row" gap={1} alignItems="center">
+            <TimeRangeInput
+              value={rangeUtil.convertRawToRange({ from: effectiveFrom, to: effectiveTo })}
+              onChange={(tr) => {
+                update((s) => setCellTimeOverride(s, index, rawToString(tr.raw.from), rawToString(tr.raw.to)), {
+                  label: t('notebooks.activity.locked-time', 'locked a block to a time range'),
+                  cellKey: elementName,
+                });
+                onDoneTimeEdit();
+              }}
+            />
+            <Button
+              size="sm"
+              variant="secondary"
+              fill="outline"
+              onClick={() => {
+                update((s) => clearCellTimeOverride(s, index), {
+                  label: t('notebooks.activity.unlocked-time', 'synced a block back to notebook time'),
+                  cellKey: elementName,
+                });
+                onDoneTimeEdit();
+              }}
+            >
+              <Trans i18nKey="notebooks.cell.time-sync">Use notebook time</Trans>
+            </Button>
+            <IconButton name="times" tooltip={t('notebooks.cell.time-close', 'Close')} onClick={onDoneTimeEdit} />
+          </Stack>
+        )}
+        {isLocked && !timeEditing && (
+          <Stack direction="row" gap={0.5} alignItems="center">
+            <Icon name="lock" size="xs" />
+            <Text variant="bodySmall" color="secondary">
+              {t('notebooks.cell.locked-range', 'Locked: {{range}}', {
+                range: formatLockedRange(cell.timeFrom!, cell.timeTo!),
+              })}
+            </Text>
+            <IconButton
+              name="times"
+              size="sm"
+              tooltip={t('notebooks.cell.unlock', 'Sync back to notebook time range')}
+              onClick={() =>
+                update((s) => clearCellTimeOverride(s, index), {
+                  label: t('notebooks.activity.unlocked-time', 'synced a block back to notebook time'),
+                  cellKey: elementName,
+                })
+              }
+            />
+          </Stack>
+        )}
+        {queryEditing && (
+          <PanelQueryEditor
+            panel={element}
+            timeFrom={effectiveFrom}
+            timeTo={effectiveTo}
+            getData={getPanelData}
+            onApply={(refId, query, datasource) => {
+              update((s) => updatePanelQuery(s, elementName, refId, { ...query }, datasource), {
+                label: t('notebooks.activity.edited-query', 'edited a query'),
+                cellKey: elementName,
+              });
+              onQueryApplied();
+            }}
+            onClose={onDoneQueryEdit}
+          />
+        )}
+        <PanelCellView
+          panel={element}
+          timeFrom={effectiveFrom}
+          timeTo={effectiveTo}
+          refreshNonce={refreshNonce}
+          height={cell.height}
+          onHeightChange={(height) => update((s) => setCellHeight(s, index, height))}
+          onDataReaderReady={onRegisterDataReader}
+          onPreferredViz={onPreferredViz}
+          revertUserTimeChanges={isLocked}
+          onUserTimeChange={(from, to) =>
+            update((s) => setCellTimeOverride(s, index, from, to), {
+              label: t('notebooks.activity.locked-time', 'locked a block to a time range'),
+              cellKey: elementName,
+            })
+          }
+        />
+      </>
+    );
+  }
+
+  if (element.kind === 'LibraryPanel') {
+    return (
+      <Alert
+        severity="info"
+        title={t('notebooks.editor.library-panel', 'Library panel — open the notebook view to render it')}
+      />
+    );
+  }
+
+  const content = element.spec.content;
+  if (content.kind === 'Markdown') {
+    return (
+      <MarkdownCellEditor
+        value={content.spec.text}
+        editing={editing}
+        onStartEdit={onStartEdit}
+        onChange={(text) => update((s) => updateMarkdownText(s, elementName, text))}
+        onDone={onDoneEdit}
+      />
+    );
+  }
+
+  return (
+    <CodeCellEditor
+      code={content.spec.code}
+      language={content.spec.language}
+      editing={editing}
+      onStartEdit={onStartEdit}
+      onChange={(changes) => update((s) => updateCodeCell(s, elementName, changes))}
+      onDone={onDoneEdit}
+    />
+  );
+}

--- a/public/app/features/notebook/editor/NotebookEditor.tsx
+++ b/public/app/features/notebook/editor/NotebookEditor.tsx
@@ -1,0 +1,934 @@
+import { css } from '@emotion/css';
+import { DragDropContext, Draggable, Droppable, type DropResult } from '@hello-pangea/dnd';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import {
+  AppEvents,
+  dateTimeFormatTimeAgo,
+  rangeUtil,
+  toUtc,
+  type DataSourceInstanceSettings,
+  type GrafanaTheme2,
+  type PanelData,
+} from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { locationService } from '@grafana/runtime';
+import { type PanelKind, type Spec as NotebookSpec } from '@grafana/schema/apis/notebook/v2beta1';
+import {
+  Alert,
+  Button,
+  ConfirmModal,
+  Dropdown,
+  Icon,
+  IconButton,
+  LinkButton,
+  Menu,
+  RefreshPicker,
+  Stack,
+  TagsInput,
+  Text,
+  TimeRangePicker,
+  useStyles2,
+} from '@grafana/ui';
+import { appEvents } from 'app/core/app_events';
+import { Page } from 'app/core/components/Page/Page';
+import PageLoader from 'app/core/components/PageLoader/PageLoader';
+import { createSuccessNotification } from 'app/core/copy/appNotification';
+import { notifyApp } from 'app/core/reducers/appNotification';
+import { copyStringToClipboard } from 'app/core/utils/explore';
+import { getShiftedTimeRange, getZoomedTimeRange } from 'app/core/utils/timePicker';
+import { dispatch } from 'app/store/store';
+
+import { deleteNotebook, duplicateNotebook, notebookEditUrl, notebookViewUrl } from '../api/notebookAPI';
+import { ActivityFeedButton } from '../collab/ActivityFeed';
+import { CollabCursors } from '../collab/CollabCursors';
+import { PresenceAvatars } from '../collab/PresenceAvatars';
+import { mergeRemoteSpec } from '../collab/mergeRemoteSpec';
+import { resourceVersionTs, useNotebookCollab } from '../collab/useNotebookCollab';
+import { DeclareIncidentFromNotebookButton } from '../extensions/DeclareIncidentFromNotebookButton';
+import { declareIncidentContextFromSpec } from '../extensions/declareIncidentFromNotebook';
+import { setLastUsedNotebook } from '../model/lastUsedNotebook';
+import { consumeNewNotebook } from '../model/newNotebookSignal';
+import {
+  DEFAULT_NOTEBOOK_TITLE,
+  duplicateCellAt,
+  insertElement,
+  moveCell,
+  newCodeElement,
+  newMarkdownElement,
+  newPanelForDatasource,
+  removeCellAt,
+  resolveCells,
+  setNotebookTimeRange,
+  setNotebookTitle,
+  updatePanelViz,
+} from '../model/notebookSpec';
+import { notebookToMarkdown } from '../model/notebookToMarkdown';
+import { rawToString } from '../model/timeFormat';
+
+import { AddCellRow } from './AddCellRow';
+import { InsertCellDivider } from './InsertCellDivider';
+import { NotebookCellBody } from './NotebookCellBody';
+import { CellFrame } from './cells/CellFrame';
+import { getExploreUrlForPanel } from './cells/PanelCellView';
+import { VizSuggestionsButton } from './cells/VizSuggestionsButton';
+import { useNotebookEditorState } from './useNotebookEditorState';
+
+interface Props {
+  uid: string;
+}
+
+export function NotebookEditor({ uid }: Props) {
+  const styles = useStyles2(getStyles);
+  const editor = useNotebookEditorState(uid);
+  const { spec, loading, loadError, saving, dirty, lastSavedAt } = editor.state;
+
+  const [editingCellKey, setEditingCellKey] = useState<string | null>(null);
+  const editingCellKeyRef = useRef<string | null>(null);
+  editingCellKeyRef.current = editingCellKey;
+
+  const [renamingKey, setRenamingKey] = useState<string | null>(null);
+  const [timeEditKey, setTimeEditKey] = useState<string | null>(null);
+  const [queryEditKey, setQueryEditKey] = useState<string | null>(null);
+  const [highlightKey, setHighlightKey] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [refreshNonce, setRefreshNonce] = useState(0);
+  const [followSid, setFollowSid] = useState<string | null>(null);
+  const documentRef = useRef<HTMLDivElement>(null);
+  const titleInputRef = useRef<HTMLInputElement>(null);
+  const highlightTimer = useRef<ReturnType<typeof setTimeout>>();
+  // Latest query-result readers per panel cell, powering the viz suggestions previews.
+  const dataReaders = useRef(new Map<string, () => PanelData | undefined>());
+  // Panels added in-editor whose viz is still the pre-data default: their first
+  // results auto-pick the visualization the data prefers (frame metadata). Cleared
+  // by the first arrival or any manual viz choice.
+  const autoVizCells = useRef(new Set<string>());
+  // Panels whose viz the user picked explicitly — auto-pick never touches these.
+  const manualVizCells = useRef(new Set<string>());
+
+  // Opening a notebook makes it the target of the "Add to last notebook" quick actions.
+  const loadedTitle = !loading && !loadError ? spec?.title : undefined;
+  useEffect(() => {
+    if (loadedTitle !== undefined) {
+      setLastUsedNotebook(uid, loadedTitle);
+    }
+  }, [uid, loadedTitle]);
+
+  const collab = useNotebookCollab({
+    uid,
+    enabled: !loading && !loadError,
+    getSpec: editor.getSpec,
+    initialDocTs: resourceVersionTs(editor.state.resource),
+    onRemoteSpec: useCallback(
+      (remoteSpec) => {
+        editor.applyRemoteSpec(mergeRemoteSpec(remoteSpec, editor.getSpec(), editingCellKeyRef.current));
+      },
+      [editor]
+    ),
+  });
+
+  // Every local mutation goes through here so collaborators get the update too.
+  // Structural edits pass an `activity` label that lands in everyone's feed.
+  const update = useCallback(
+    (mutate: Parameters<typeof editor.updateSpec>[0], activity?: { label: string; cellKey?: string }) => {
+      editor.updateSpec(mutate);
+      collab.notifyLocalEdit();
+      if (activity) {
+        collab.sendActivity(activity.label, activity.cellKey);
+      }
+    },
+    [editor, collab]
+  );
+
+  const undo = useCallback(() => {
+    if (editor.undo()) {
+      collab.notifyLocalEdit();
+    }
+  }, [editor, collab]);
+
+  const redo = useCallback(() => {
+    if (editor.redo()) {
+      collab.notifyLocalEdit();
+    }
+  }, [editor, collab]);
+
+  const jumpToCell = useCallback((cellKey: string) => {
+    document.querySelector(`[data-cell-key="${CSS.escape(cellKey)}"]`)?.scrollIntoView({
+      behavior: 'smooth',
+      block: 'center',
+    });
+    setHighlightKey(cellKey);
+    clearTimeout(highlightTimer.current);
+    highlightTimer.current = setTimeout(() => setHighlightKey(null), 2500);
+  }, []);
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      const container = documentRef.current;
+      if (!container) {
+        return;
+      }
+      const rect = container.getBoundingClientRect();
+      const target = e.target instanceof Element ? e.target : null;
+      const hoveredCell = target?.closest('[data-cell-key]')?.getAttribute('data-cell-key') ?? null;
+      collab.sendCursor(e.clientX - rect.left, e.clientY - rect.top, editingCellKeyRef.current ?? hoveredCell);
+    },
+    [collab]
+  );
+
+  const insertTextAt = useCallback(
+    (index: number) => {
+      let newKey: string | undefined;
+      update((s) => {
+        const result = insertElement(s, newMarkdownElement(''), { index });
+        newKey = result.elementName;
+        return result.spec;
+      });
+      if (newKey) {
+        setEditingCellKey(newKey);
+        collab.sendActivity(t('notebooks.activity.added-text', 'added a text block'), newKey);
+      }
+    },
+    [update, collab]
+  );
+
+  const insertCodeAt = useCallback(
+    (index: number) => {
+      let newKey: string | undefined;
+      update((s) => {
+        const result = insertElement(s, newCodeElement('', ''), { index });
+        newKey = result.elementName;
+        return result.spec;
+      });
+      if (newKey) {
+        collab.sendActivity(t('notebooks.activity.added-code', 'added a code block'), newKey);
+      }
+    },
+    [update, collab]
+  );
+
+  const insertVizAt = useCallback(
+    (index: number, ds: DataSourceInstanceSettings) => {
+      // The testdata datasource gets a scenario so the new panel renders data immediately.
+      const isTestdata = ds.type === 'grafana-testdata-datasource';
+      const querySpec = isTestdata ? { scenarioId: 'random_walk' } : {};
+      let newKey: string | undefined;
+      update((s) => {
+        const result = insertElement(
+          s,
+          newPanelForDatasource({ uid: ds.uid, type: ds.type }, { title: ds.name, querySpec }),
+          {
+            index,
+          }
+        );
+        newKey = result.elementName;
+        return result.spec;
+      });
+      if (newKey) {
+        collab.sendActivity(t('notebooks.activity.added-viz', 'added a visualization'), newKey);
+        jumpToCell(newKey);
+        autoVizCells.current.add(newKey);
+        // A panel with an empty query renders "no data" — open the query editor
+        // right away so the next step is obvious. Testdata already shows data.
+        if (!isTestdata) {
+          setQueryEditKey(newKey);
+        }
+      }
+    },
+    [update, collab, jumpToCell]
+  );
+
+  // First data for a freshly added panel: adopt the viz the frames prefer, unless
+  // the user already picked one themselves.
+  const onPreferredViz = useCallback(
+    (elementName: string, pluginId: string) => {
+      if (!autoVizCells.current.has(elementName)) {
+        return;
+      }
+      autoVizCells.current.delete(elementName);
+      const element = editor.getSpec()?.elements[elementName];
+      if (element?.kind !== 'Panel' || element.spec.vizConfig.group === pluginId) {
+        return;
+      }
+      update((s) => updatePanelViz(s, elementName, { pluginId }));
+    },
+    [editor, update]
+  );
+
+  const onDragEnd = useCallback(
+    (result: DropResult) => {
+      if (result.destination && result.destination.index !== result.source.index) {
+        update((s) => moveCell(s, result.source.index, result.destination!.index), {
+          label: t('notebooks.activity.moved-block', 'moved a block'),
+          cellKey: result.draggableId,
+        });
+      }
+    },
+    [update]
+  );
+
+  // Cmd/Ctrl+S saves; Cmd/Ctrl+Z / Shift+Cmd/Ctrl+Z step through local history.
+  // Undo/redo is left to the browser while typing in a field (native text undo).
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 's' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        editor.save();
+        return;
+      }
+      if (e.key.toLowerCase() === 'z' && (e.metaKey || e.ctrlKey)) {
+        const target = e.target instanceof HTMLElement ? e.target : null;
+        const typing =
+          target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable);
+        if (typing) {
+          return;
+        }
+        e.preventDefault();
+        if (e.shiftKey) {
+          redo();
+        } else {
+          undo();
+        }
+      }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [editor, undo, redo]);
+
+  // Broadcast which block sits at our viewport center so collaborators can follow us.
+  useEffect(() => {
+    let lastMeasure = 0;
+    const onScroll = () => {
+      const container = documentRef.current;
+      if (!container) {
+        return;
+      }
+      // Measuring every block per scroll event causes layout thrash on large
+      // notebooks; a coarse gate is plenty for follow mode.
+      const now = Date.now();
+      if (now - lastMeasure < 200) {
+        return;
+      }
+      lastMeasure = now;
+      const centerY = window.innerHeight / 2;
+      let best: { key: string; distance: number } | undefined;
+      for (const node of container.querySelectorAll('[data-cell-key]')) {
+        const rect = node.getBoundingClientRect();
+        const distance = Math.abs((rect.top + rect.bottom) / 2 - centerY);
+        const key = node.getAttribute('data-cell-key');
+        if (key && (!best || distance < best.distance)) {
+          best = { key, distance };
+        }
+      }
+      collab.sendView(best?.key ?? null);
+    };
+    // Capture phase: the page content scrolls inside a nested scroller, not the window.
+    window.addEventListener('scroll', onScroll, { capture: true, passive: true });
+    return () => window.removeEventListener('scroll', onScroll, { capture: true });
+  }, [collab]);
+
+  // Follow mode: ride along with the followed collaborator's viewport.
+  const followedPeer = followSid ? collab.peers.find((p) => p.sid === followSid) : undefined;
+  const followedViewCell = followedPeer?.viewCell;
+  useEffect(() => {
+    if (!followSid) {
+      return;
+    }
+    if (!followedPeer) {
+      // The peer left; following ends with them.
+      setFollowSid(null);
+      return;
+    }
+    if (followedViewCell) {
+      document.querySelector(`[data-cell-key="${CSS.escape(followedViewCell)}"]`)?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center',
+      });
+    }
+  }, [followSid, followedPeer, followedViewCell]);
+
+  // Any deliberate scroll input (wheel, touch) means the user wants their own viewport
+  // back — these events only come from the user, never from scrollIntoView.
+  useEffect(() => {
+    if (!followSid) {
+      return;
+    }
+    const stop = () => setFollowSid(null);
+    window.addEventListener('wheel', stop, { passive: true });
+    window.addEventListener('touchmove', stop, { passive: true });
+    return () => {
+      window.removeEventListener('wheel', stop);
+      window.removeEventListener('touchmove', stop);
+    };
+  }, [followSid]);
+
+  // Auto-refresh: re-run all panels on the notebook's refresh interval.
+  const autoRefresh = spec?.timeSettings.autoRefresh;
+  useEffect(() => {
+    if (!autoRefresh) {
+      return;
+    }
+    let ms: number;
+    try {
+      ms = rangeUtil.intervalToMs(autoRefresh);
+    } catch {
+      return;
+    }
+    if (!ms || ms < 1000) {
+      return;
+    }
+    const timer = setInterval(() => setRefreshNonce((n) => n + 1), ms);
+    return () => clearInterval(timer);
+  }, [autoRefresh]);
+
+  // Freshly created notebooks start with the title focused and selected, so typing
+  // immediately focuses the title for rename.
+  const isLoaded = !loading && !!spec;
+  useEffect(() => {
+    if (!isLoaded) {
+      return;
+    }
+    const isNew = consumeNewNotebook(uid) || new URLSearchParams(locationService.getLocation().search).has('new');
+    if (!isNew) {
+      return;
+    }
+    locationService.partial({ new: null }, true);
+    // The app chrome moves focus for a11y shortly after navigation, so a single
+    // focus() loses the race — retry briefly until the title actually holds focus.
+    let cancelled = false;
+    let attempts = 0;
+    const tryFocus = () => {
+      if (cancelled) {
+        return;
+      }
+      const input = titleInputRef.current;
+      if (input && document.activeElement !== input) {
+        input.focus();
+        input.select();
+      }
+      if (document.activeElement !== titleInputRef.current && attempts++ < 15) {
+        setTimeout(tryFocus, 150);
+      }
+    };
+    requestAnimationFrame(tryFocus);
+    return () => {
+      cancelled = true;
+    };
+  }, [isLoaded, uid]);
+
+  // Scroll to and briefly highlight a cell linked via ?cell= (used by "Add & open notebook").
+  useEffect(() => {
+    if (!isLoaded) {
+      return;
+    }
+    const cellParam = new URLSearchParams(locationService.getLocation().search).get('cell');
+    if (!cellParam) {
+      return;
+    }
+    locationService.partial({ cell: null }, true);
+    requestAnimationFrame(() => {
+      document.querySelector(`[data-cell-key="${CSS.escape(cellParam)}"]`)?.scrollIntoView({ block: 'center' });
+    });
+    setHighlightKey(cellParam);
+    const timer = setTimeout(() => setHighlightKey(null), 2500);
+    return () => clearTimeout(timer);
+  }, [isLoaded]);
+
+  const openPanelInExplore = useCallback(async (panel: PanelKind, s: NotebookSpec) => {
+    const url = await getExploreUrlForPanel(panel, s.timeSettings.from, s.timeSettings.to);
+    if (url) {
+      window.open(url, '_blank', 'noopener');
+    }
+  }, []);
+
+  const onCopyMarkdown = useCallback(async () => {
+    const current = editor.getSpec();
+    if (!current) {
+      return;
+    }
+    const markdown = notebookToMarkdown(current, {
+      notebookUrl: new URL(notebookViewUrl(uid), window.location.origin).toString(),
+    });
+    copyStringToClipboard(markdown);
+    appEvents.emit(AppEvents.alertSuccess, [t('notebooks.editor.copied-markdown', 'Notebook copied as Markdown')]);
+  }, [editor, uid]);
+
+  const pageNav = {
+    text: spec?.title || t('notebooks.editor.untitled', DEFAULT_NOTEBOOK_TITLE),
+    parentItem: { text: t('notebook.breadcrumb-title', 'Notebooks'), url: '/notebooks' },
+  };
+
+  if (loading) {
+    return (
+      <Page navId="notebooks" pageNav={pageNav}>
+        <PageLoader />
+      </Page>
+    );
+  }
+
+  if (loadError || !spec) {
+    return (
+      <Page navId="notebooks" pageNav={pageNav}>
+        <Page.Contents>
+          <Alert severity="error" title={t('notebooks.editor.load-error', 'Failed to load notebook')}>
+            {loadError instanceof Error ? loadError.message : ''}
+          </Alert>
+        </Page.Contents>
+      </Page>
+    );
+  }
+
+  const cells = resolveCells(spec);
+  const timeRange = rangeUtil.convertRawToRange({ from: spec.timeSettings.from, to: spec.timeSettings.to });
+
+  // The notebook time range is shared document state (autosaved, synced to
+  // collaborators) — every change is announced like any other structural edit.
+  const commitTimeRange = (from: string, to: string) =>
+    update((s) => setNotebookTimeRange(s, from, to), {
+      label: t('notebooks.activity.changed-time', 'changed the notebook time range'),
+    });
+  const shiftTimeRange = (direction: number) => {
+    const shifted = getShiftedTimeRange(direction, timeRange);
+    commitTimeRange(toUtc(shifted.from).toISOString(), toUtc(shifted.to).toISOString());
+  };
+  const zoomTimeRange = (factor: number) => {
+    const zoomed = getZoomedTimeRange(timeRange, factor);
+    commitTimeRange(toUtc(zoomed.from).toISOString(), toUtc(zoomed.to).toISOString());
+  };
+
+  const moreMenu = (
+    <Menu>
+      <Menu.Item
+        icon="link"
+        label={t('notebooks.editor.copy-link', 'Copy link')}
+        onClick={() => {
+          copyStringToClipboard(new URL(notebookViewUrl(uid), window.location.origin).toString());
+          appEvents.emit(AppEvents.alertSuccess, [t('notebooks.editor.link-copied', 'Notebook link copied')]);
+        }}
+      />
+      <DeclareIncidentFromNotebookButton as="menu-item" {...declareIncidentContextFromSpec(uid, spec)} />
+      <Menu.Item icon="copy" label={t('notebooks.editor.copy-markdown', 'Copy as Markdown')} onClick={onCopyMarkdown} />
+      <Menu.Item
+        icon="file-copy-alt"
+        label={t('notebooks.editor.duplicate', 'Duplicate notebook')}
+        onClick={async () => {
+          const current = editor.getSpec();
+          if (!current) {
+            return;
+          }
+          const created = await duplicateNotebook(
+            current,
+            t('notebooks.list.copy-title', '{{title}} (copy)', { title: current.title })
+          );
+          locationService.push(notebookEditUrl(created.metadata.name));
+        }}
+      />
+      <Menu.Divider />
+      <Menu.Item
+        icon="trash-alt"
+        destructive
+        label={t('notebooks.editor.delete', 'Delete notebook')}
+        onClick={() => setConfirmDelete(true)}
+      />
+    </Menu>
+  );
+
+  const actions = (
+    <Stack direction="row" gap={1} alignItems="center" wrap="wrap" justifyContent="flex-end">
+      <PresenceAvatars
+        peers={collab.peers}
+        followedSid={followSid}
+        onToggleFollow={(peer) => setFollowSid((cur) => (cur === peer.sid ? null : peer.sid))}
+      />
+      <IconButton
+        name="history"
+        size="lg"
+        disabled={!editor.state.canUndo}
+        onClick={undo}
+        tooltip={t('notebooks.editor.undo', 'Undo (⌘Z)')}
+      />
+      {/* No mirrored circular-arrow icon exists in the icon set; flip the undo glyph. */}
+      <IconButton
+        name="history"
+        size="lg"
+        className={styles.redoIcon}
+        disabled={!editor.state.canRedo}
+        onClick={redo}
+        tooltip={t('notebooks.editor.redo', 'Redo (⇧⌘Z)')}
+      />
+      <ActivityFeedButton activity={collab.activity} onJumpToCell={jumpToCell} />
+      {/* The dashboards-style picker: its popup is right-edge aligned (TimeRangeInput's
+          overflows the viewport from a right-anchored toolbar) and it brings the
+          shift/zoom arrows Grafana users expect. */}
+      <TimeRangePicker
+        value={timeRange}
+        onChange={(tr) => commitTimeRange(rawToString(tr.raw.from), rawToString(tr.raw.to))}
+        onChangeTimeZone={() => {}}
+        onMoveBackward={() => shiftTimeRange(-1)}
+        onMoveForward={() => shiftTimeRange(1)}
+        onZoom={() => zoomTimeRange(2)}
+        onZoomIn={() => zoomTimeRange(0.5)}
+      />
+      <RefreshPicker
+        value={spec.timeSettings.autoRefresh}
+        intervals={spec.timeSettings.autoRefreshIntervals}
+        onRefresh={() => setRefreshNonce((n) => n + 1)}
+        onIntervalChanged={(interval) =>
+          update((s) => ({ ...s, timeSettings: { ...s.timeSettings, autoRefresh: interval } }))
+        }
+      />
+      <LinkButton variant="primary" href={notebookViewUrl(uid)} icon="book-open">
+        <Trans i18nKey="notebooks.editor.view">View</Trans>
+      </LinkButton>
+      <Dropdown overlay={moreMenu} placement="bottom-end">
+        <IconButton name="ellipsis-v" tooltip={t('notebooks.editor.more', 'More actions')} size="lg" />
+      </Dropdown>
+    </Stack>
+  );
+
+  const titleInput = (
+    <input
+      ref={titleInputRef}
+      className={styles.titleInput}
+      value={spec.title}
+      placeholder={t('notebooks.editor.title-placeholder', 'Give this notebook a title')}
+      onChange={(e) => update((s) => setNotebookTitle(s, e.currentTarget.value))}
+      // Fresh notebooks carry a placeholder-ish title; selecting it on focus means
+      // typing replaces it instead of appending to it.
+      onFocus={(e) => e.currentTarget.select()}
+      aria-label={t('notebooks.editor.title-label', 'Notebook title')}
+      data-testid="notebook-title-input"
+    />
+  );
+
+  return (
+    <Page navId="notebooks" pageNav={pageNav} renderTitle={() => titleInput} actions={actions}>
+      <Page.Contents>
+        {/* Pointer tracking is presence telemetry for collaborators, not an interaction. */}
+        {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
+        <div className={styles.document} ref={documentRef} onPointerMove={onPointerMove}>
+          <CollabCursors getPeers={collab.getPeers} />
+
+          {followedPeer && (
+            <div className={styles.followingPill} style={{ backgroundColor: followedPeer.color }}>
+              <Icon name="eye" size="sm" />
+              {t('notebooks.editor.following', 'Following {{name}}', {
+                name: followedPeer.user.name || followedPeer.user.login,
+              })}
+              <IconButton
+                name="times"
+                size="sm"
+                variant="secondary"
+                tooltip={t('notebooks.editor.stop-following', 'Stop following')}
+                onClick={() => setFollowSid(null)}
+              />
+            </div>
+          )}
+
+          <div className={styles.metaRow}>
+            <TagsInput
+              tags={spec.tags}
+              onChange={(tags) => update((s) => ({ ...s, tags }))}
+              placeholder={t('notebooks.editor.tags-placeholder', 'Add tags')}
+              width={40}
+            />
+            <Text variant="bodySmall" color="secondary">
+              {saveStatusText(saving, dirty, lastSavedAt)}
+            </Text>
+          </div>
+
+          {cells.length === 0 ? (
+            <EmptyNotebook />
+          ) : (
+            <DragDropContext onDragEnd={onDragEnd}>
+              <Droppable droppableId="notebook-cells">
+                {(droppable) => (
+                  <div ref={droppable.innerRef} {...droppable.droppableProps} className={styles.cells}>
+                    {cells.map((cell, index) => {
+                      const peersInCell = collab.peers
+                        .filter((p) => p.cellKey === cell.elementName)
+                        .map((p) => ({ name: p.user.name || p.user.login, color: p.color }));
+
+                      return (
+                        <Draggable draggableId={cell.elementName} index={index} key={cell.elementName}>
+                          {(draggable, snapshot) => (
+                            <div
+                              ref={draggable.innerRef}
+                              {...draggable.draggableProps}
+                              onFocusCapture={() => setEditingCellKey(cell.elementName)}
+                              onBlurCapture={(e) => {
+                                // Focus moving between controls inside the same cell (e.g. code
+                                // editor → its language picker) is not "done editing".
+                                if (e.relatedTarget instanceof Node && e.currentTarget.contains(e.relatedTarget)) {
+                                  return;
+                                }
+                                setEditingCellKey((cur) => (cur === cell.elementName ? null : cur));
+                              }}
+                            >
+                              <InsertCellDivider
+                                onInsertText={() => insertTextAt(index)}
+                                onInsertCode={() => insertCodeAt(index)}
+                                onInsertViz={(ds) => insertVizAt(index, ds)}
+                              />
+                              <CellFrame
+                                cellKey={cell.elementName}
+                                source={cell.source}
+                                peers={peersInCell}
+                                highlighted={highlightKey === cell.elementName}
+                                isDragging={snapshot.isDragging}
+                                dragHandleProps={draggable.dragHandleProps}
+                                onDuplicate={() =>
+                                  update((s) => duplicateCellAt(s, index), {
+                                    label: t('notebooks.activity.duplicated-block', 'duplicated a block'),
+                                    cellKey: cell.elementName,
+                                  })
+                                }
+                                onDelete={() => {
+                                  update((s) => removeCellAt(s, index), {
+                                    label: t('notebooks.activity.deleted-block', 'deleted a block'),
+                                  });
+                                  dispatch(
+                                    notifyApp(
+                                      createSuccessNotification(
+                                        t('notebooks.editor.block-deleted', 'Block deleted'),
+                                        undefined,
+                                        undefined,
+                                        <Button variant="secondary" size="sm" onClick={undo}>
+                                          <Trans i18nKey="notebooks.editor.undo-delete">Undo</Trans>
+                                        </Button>
+                                      )
+                                    )
+                                  );
+                                }}
+                                extraActions={
+                                  cell.element.kind === 'Panel' ? (
+                                    <>
+                                      <IconButton
+                                        name="database"
+                                        size="sm"
+                                        onClick={() =>
+                                          setQueryEditKey((cur) => (cur === cell.elementName ? null : cell.elementName))
+                                        }
+                                        tooltip={t('notebooks.cell.edit-query', 'Edit query')}
+                                      />
+                                      <VizSuggestionsButton
+                                        currentPluginId={cell.element.spec.vizConfig.group}
+                                        getData={() => dataReaders.current.get(cell.elementName)?.()}
+                                        onSelect={(suggestion) => {
+                                          // A manual choice always wins over data-driven auto-pick.
+                                          autoVizCells.current.delete(cell.elementName);
+                                          manualVizCells.current.add(cell.elementName);
+                                          update((s) => updatePanelViz(s, cell.elementName, suggestion), {
+                                            label: t('notebooks.activity.changed-viz', 'changed a visualization'),
+                                            cellKey: cell.elementName,
+                                          });
+                                        }}
+                                      />
+                                      <IconButton
+                                        name="clock-nine"
+                                        size="sm"
+                                        onClick={() =>
+                                          setTimeEditKey((cur) => (cur === cell.elementName ? null : cell.elementName))
+                                        }
+                                        tooltip={
+                                          cell.timeFrom
+                                            ? t('notebooks.cell.time-locked', 'Edit locked time range')
+                                            : t('notebooks.cell.time-lock', 'Lock to a specific time range')
+                                        }
+                                      />
+                                      <IconButton
+                                        name="pen"
+                                        size="sm"
+                                        onClick={() => setRenamingKey(cell.elementName)}
+                                        tooltip={t('notebooks.cell.rename', 'Rename panel')}
+                                      />
+                                      <IconButton
+                                        name="compass"
+                                        size="sm"
+                                        onClick={() => {
+                                          if (cell.element.kind === 'Panel') {
+                                            openPanelInExplore(cell.element, spec);
+                                          }
+                                        }}
+                                        tooltip={t('notebooks.cell.explore', 'Open in Explore')}
+                                      />
+                                    </>
+                                  ) : undefined
+                                }
+                              >
+                                <NotebookCellBody
+                                  cell={cell}
+                                  spec={spec}
+                                  index={index}
+                                  editing={editingCellKey === cell.elementName}
+                                  renaming={renamingKey === cell.elementName}
+                                  timeEditing={timeEditKey === cell.elementName}
+                                  queryEditing={queryEditKey === cell.elementName}
+                                  refreshNonce={refreshNonce}
+                                  onStartEdit={() => setEditingCellKey(cell.elementName)}
+                                  onDoneEdit={() => setEditingCellKey(null)}
+                                  onDoneRename={() => setRenamingKey(null)}
+                                  onDoneTimeEdit={() => setTimeEditKey(null)}
+                                  onDoneQueryEdit={() => setQueryEditKey(null)}
+                                  getPanelData={() => dataReaders.current.get(cell.elementName)?.()}
+                                  onRegisterDataReader={(getData) => dataReaders.current.set(cell.elementName, getData)}
+                                  onPreferredViz={(pluginId) => onPreferredViz(cell.elementName, pluginId)}
+                                  onQueryApplied={() => {
+                                    // A new query means a possibly new data shape (e.g. no time
+                                    // field → table); re-arm auto-pick unless the viz was chosen
+                                    // manually.
+                                    if (!manualVizCells.current.has(cell.elementName)) {
+                                      autoVizCells.current.add(cell.elementName);
+                                    }
+                                  }}
+                                  update={update}
+                                />
+                              </CellFrame>
+                            </div>
+                          )}
+                        </Draggable>
+                      );
+                    })}
+                    {droppable.placeholder}
+                  </div>
+                )}
+              </Droppable>
+            </DragDropContext>
+          )}
+
+          <AddCellRow
+            onAddText={() => insertTextAt(cells.length)}
+            onAddCode={() => insertCodeAt(cells.length)}
+            onAddViz={(ds) => insertVizAt(cells.length, ds)}
+          />
+        </div>
+
+        <ConfirmModal
+          isOpen={confirmDelete}
+          title={t('notebooks.editor.delete-title', 'Delete notebook')}
+          body={t('notebooks.editor.delete-body', 'Are you sure you want to delete "{{title}}"?', {
+            title: spec.title,
+          })}
+          confirmText={t('notebooks.editor.delete-confirm', 'Delete')}
+          onConfirm={async () => {
+            await deleteNotebook(uid);
+            locationService.push('/notebooks');
+          }}
+          onDismiss={() => setConfirmDelete(false)}
+        />
+      </Page.Contents>
+    </Page>
+  );
+}
+
+function EmptyNotebook() {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <div className={styles.empty} data-testid="notebook-empty-state">
+      <Text element="h3" variant="h4">
+        <Trans i18nKey="notebooks.editor.empty-title">Start your investigation</Trans>
+      </Text>
+      <Text color="secondary">
+        <Trans i18nKey="notebooks.editor.empty-body">
+          Write down what you are seeing, then bring in live data — add a visualization below, or capture any dashboard
+          panel or Explore query with “Add to notebook”.
+        </Trans>
+      </Text>
+      <Stack direction="row" gap={1} wrap="wrap" justifyContent="center">
+        <LinkButton variant="secondary" icon="apps" href="/dashboards">
+          <Trans i18nKey="notebooks.editor.empty-dashboards">Browse dashboards</Trans>
+        </LinkButton>
+        <LinkButton variant="secondary" icon="compass" href="/explore">
+          <Trans i18nKey="notebooks.editor.empty-explore">Open Explore</Trans>
+        </LinkButton>
+      </Stack>
+    </div>
+  );
+}
+
+// With no explicit Save button (the editor autosaves), this line is the save UI —
+// it must always show a definite state so users trust edits are persisted.
+function saveStatusText(saving: boolean, dirty: boolean, lastSavedAt?: number): string {
+  if (saving) {
+    return t('notebooks.editor.status-saving', 'Saving…');
+  }
+  if (dirty) {
+    return t('notebooks.editor.status-pending', 'Saving shortly…');
+  }
+  if (lastSavedAt) {
+    return t('notebooks.editor.status-saved', 'Saved {{when}}', { when: dateTimeFormatTimeAgo(lastSavedAt) });
+  }
+  return t('notebooks.editor.status-clean', 'All changes saved');
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  document: css({
+    position: 'relative',
+    maxWidth: 900,
+    margin: '0 auto',
+    width: '100%',
+    paddingBottom: theme.spacing(8),
+  }),
+  metaRow: css({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: theme.spacing(2),
+    marginBottom: theme.spacing(2),
+    paddingBottom: theme.spacing(2),
+    borderBottom: `1px solid ${theme.colors.border.weak}`,
+  }),
+  redoIcon: css({
+    transform: 'scaleX(-1)',
+  }),
+  followingPill: css({
+    position: 'fixed',
+    top: theme.spacing(10),
+    left: '50%',
+    transform: 'translateX(-50%)',
+    zIndex: theme.zIndex.portal,
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.75),
+    color: '#fff',
+    padding: theme.spacing(0.5, 0.75, 0.5, 1.5),
+    borderRadius: theme.shape.radius.pill,
+    boxShadow: theme.shadows.z3,
+    fontWeight: theme.typography.fontWeightMedium,
+  }),
+  titleInput: css({
+    border: 'none',
+    outline: 'none',
+    background: 'transparent',
+    width: '100%',
+    fontSize: theme.typography.h1.fontSize,
+    fontWeight: theme.typography.h1.fontWeight,
+    lineHeight: theme.typography.h1.lineHeight,
+    color: theme.colors.text.primary,
+    padding: 0,
+
+    '&::placeholder': {
+      color: theme.colors.text.disabled,
+    },
+    '&:focus-visible': {
+      outline: `2px solid ${theme.colors.primary.border}`,
+      outlineOffset: 4,
+      borderRadius: theme.shape.radius.default,
+    },
+  }),
+  cells: css({
+    display: 'flex',
+    flexDirection: 'column',
+  }),
+  empty: css({
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: theme.spacing(2),
+    textAlign: 'center',
+    padding: theme.spacing(8, 2),
+    border: `1px dashed ${theme.colors.border.medium}`,
+    borderRadius: theme.shape.radius.default,
+  }),
+});

--- a/public/app/features/notebook/editor/cells/CellFrame.tsx
+++ b/public/app/features/notebook/editor/cells/CellFrame.tsx
@@ -1,0 +1,173 @@
+import { css, cx } from '@emotion/css';
+import { type DraggableProvidedDragHandleProps } from '@hello-pangea/dnd';
+import { type ReactNode } from 'react';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { Badge, Icon, IconButton, Stack, useStyles2 } from '@grafana/ui';
+
+import { type CellSource } from '../../model/notebookSpec';
+
+interface CellPeer {
+  name: string;
+  color: string;
+}
+
+interface Props {
+  cellKey: string;
+  source: CellSource;
+  /** Collaborators currently editing this cell — the frame is outlined in their color. */
+  peers?: CellPeer[];
+  /** Briefly highlighted (e.g. right after being added from a dashboard or Explore). */
+  highlighted?: boolean;
+  isDragging?: boolean;
+  dragHandleProps?: DraggableProvidedDragHandleProps | null;
+  onDuplicate: () => void;
+  onDelete: () => void;
+  /** Cell-type specific actions (e.g. rename / open in Explore for panels). */
+  extraActions?: ReactNode;
+  children: ReactNode;
+}
+
+/**
+ * Shared chrome for every notebook cell in edit mode: a drag handle, hover toolbar
+ * (collapse/duplicate/delete plus cell-specific actions), provenance badge for
+ * assistant-authored cells and a presence outline when a collaborator is editing it.
+ */
+export function CellFrame({
+  cellKey,
+  source,
+  peers,
+  highlighted,
+  isDragging,
+  dragHandleProps,
+  onDuplicate,
+  onDelete,
+  extraActions,
+  children,
+}: Props) {
+  const styles = useStyles2(getStyles);
+  const activePeer = peers?.[0];
+
+  return (
+    <div
+      className={cx(styles.frame, isDragging && styles.dragging, highlighted && styles.highlighted)}
+      style={activePeer ? { boxShadow: `0 0 0 2px ${activePeer.color}` } : undefined}
+      data-cell-key={cellKey}
+      data-testid={`notebook-cell-${cellKey}`}
+    >
+      {activePeer && (
+        <span className={styles.peerChip} style={{ backgroundColor: activePeer.color }}>
+          {activePeer.name}
+        </span>
+      )}
+
+      <div
+        className={cx('notebook-cell-drag-handle', styles.dragHandle)}
+        {...dragHandleProps}
+        aria-label={t('notebooks.cell.drag', 'Drag to reorder block')}
+      >
+        <Icon name="draggabledots" size="sm" />
+      </div>
+
+      <div className={cx('notebook-cell-toolbar', styles.toolbar)}>
+        <Stack direction="row" gap={0.5} alignItems="center">
+          {source === 'assistant' && (
+            <Badge text={t('notebooks.cell.assistant-badge', 'Assistant')} color="purple" icon="ai" />
+          )}
+          {extraActions}
+          <IconButton
+            name="copy"
+            size="sm"
+            onClick={onDuplicate}
+            tooltip={t('notebooks.cell.duplicate', 'Duplicate block')}
+          />
+          <IconButton
+            name="trash-alt"
+            size="sm"
+            onClick={onDelete}
+            tooltip={t('notebooks.cell.delete', 'Delete block')}
+          />
+        </Stack>
+      </div>
+
+      {children}
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  frame: css({
+    position: 'relative',
+    borderRadius: theme.shape.radius.default,
+    padding: theme.spacing(0.5, 0.5, 0.5, 3),
+    margin: theme.spacing(0, -0.5, 0, -3),
+
+    '&:hover, &:focus-within': {
+      outline: `1px solid ${theme.colors.border.weak}`,
+    },
+
+    '&:hover .notebook-cell-toolbar, &:focus-within .notebook-cell-toolbar': {
+      opacity: 1,
+      pointerEvents: 'auto',
+    },
+
+    '&:hover .notebook-cell-drag-handle, &:focus-within .notebook-cell-drag-handle': {
+      opacity: 1,
+    },
+  }),
+  dragging: css({
+    outline: `1px solid ${theme.colors.primary.border}`,
+    background: theme.colors.background.secondary,
+    boxShadow: theme.shadows.z3,
+  }),
+  highlighted: css({
+    outline: `2px solid ${theme.colors.primary.border}`,
+    background: theme.colors.primary.transparent,
+  }),
+  dragHandle: css({
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    left: 0,
+    width: theme.spacing(3),
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    color: theme.colors.text.disabled,
+    opacity: 0,
+    cursor: 'grab',
+
+    '&:hover': {
+      color: theme.colors.text.secondary,
+    },
+
+    '&:active': {
+      cursor: 'grabbing',
+    },
+  }),
+  toolbar: css({
+    position: 'absolute',
+    top: theme.spacing(-1.5),
+    right: theme.spacing(1),
+    zIndex: 2,
+    opacity: 0,
+    pointerEvents: 'none',
+    background: theme.colors.background.primary,
+    border: `1px solid ${theme.colors.border.weak}`,
+    borderRadius: theme.shape.radius.default,
+    padding: theme.spacing(0.25, 0.5),
+    boxShadow: theme.shadows.z1,
+  }),
+  peerChip: css({
+    position: 'absolute',
+    top: theme.spacing(-1.5),
+    left: theme.spacing(1),
+    zIndex: 2,
+    color: theme.colors.getContrastText(theme.colors.primary.main),
+    fontSize: theme.typography.bodySmall.fontSize,
+    lineHeight: 1.5,
+    padding: theme.spacing(0, 0.75),
+    borderRadius: theme.shape.radius.pill,
+  }),
+});

--- a/public/app/features/notebook/editor/cells/CodeCellEditor.tsx
+++ b/public/app/features/notebook/editor/cells/CodeCellEditor.tsx
@@ -1,0 +1,160 @@
+import { css } from '@emotion/css';
+
+import { type GrafanaTheme2, type SelectableValue } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { Badge, CodeEditor, IconButton, Select, useStyles2 } from '@grafana/ui';
+
+const LINE_HEIGHT = 18;
+const MIN_LINES = 3;
+const MAX_LINES = 30;
+
+const LANGUAGES: Array<SelectableValue<string>> = [
+  { label: 'Plain text', value: '' },
+  { label: 'SQL', value: 'sql' },
+  { label: 'PromQL', value: 'promql' },
+  { label: 'LogQL', value: 'logql' },
+  { label: 'JSON', value: 'json' },
+  { label: 'YAML', value: 'yaml' },
+  { label: 'Python', value: 'python' },
+  { label: 'Go', value: 'go' },
+  { label: 'JavaScript', value: 'javascript' },
+  { label: 'Shell', value: 'shell' },
+];
+
+interface Props {
+  code: string;
+  language: string;
+  editing: boolean;
+  onStartEdit: () => void;
+  onChange: (changes: { code?: string; language?: string }) => void;
+  onDone: () => void;
+}
+
+/**
+ * Code block with the same interaction model as text blocks: a quiet preview that
+ * switches to the Monaco editor (plus language picker) on click, and exits via the
+ * check button or clicking away.
+ */
+export function CodeCellEditor({ code, language, editing, onStartEdit, onChange, onDone }: Props) {
+  const styles = useStyles2(getStyles);
+  const lines = code.split('\n').length;
+  const height = Math.min(Math.max(lines + 1, MIN_LINES), MAX_LINES) * LINE_HEIGHT;
+
+  if (!editing) {
+    const languageLabel = LANGUAGES.find((option) => option.value === language)?.label ?? language;
+
+    return (
+      <div
+        role="button"
+        tabIndex={0}
+        className={styles.preview}
+        onClick={onStartEdit}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onStartEdit();
+          }
+        }}
+        aria-label={t('notebooks.code-cell.edit-label', 'Edit code block')}
+        data-testid="notebook-code-preview"
+      >
+        {language && (
+          <span className={styles.languageBadge}>
+            <Badge text={languageLabel} color="darkgrey" />
+          </span>
+        )}
+        {code.trim() ? (
+          <pre className={styles.pre}>{code}</pre>
+        ) : (
+          <span className={styles.placeholder}>
+            <Trans i18nKey="notebooks.code-cell.empty">Click to add code — a query, a command, a config snippet…</Trans>
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.header}>
+        <Select
+          width={20}
+          options={LANGUAGES}
+          value={language}
+          onChange={(v) => onChange({ language: v.value ?? '' })}
+          aria-label={t('notebooks.code-cell.language', 'Code language')}
+          allowCustomValue
+        />
+        <IconButton
+          name="check"
+          size="lg"
+          tooltip={t('notebooks.code-cell.done', 'Done editing')}
+          onClick={onDone}
+          data-testid="notebook-code-done"
+        />
+      </div>
+      <CodeEditor
+        value={code}
+        language={language || 'plaintext'}
+        height={height}
+        width="100%"
+        showLineNumbers
+        onChange={(value) => onChange({ code: value })}
+        onBlur={(value) => {
+          onChange({ code: value });
+          onDone();
+        }}
+        onEditorDidMount={(editor) => editor.focus()}
+      />
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  wrapper: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(0.5),
+  }),
+  header: css({
+    display: 'flex',
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+  }),
+  preview: css({
+    position: 'relative',
+    cursor: 'text',
+    width: '100%',
+    textAlign: 'left',
+    padding: 0,
+
+    '&:focus-visible': {
+      outline: `2px solid ${theme.colors.primary.border}`,
+      outlineOffset: 2,
+    },
+  }),
+  pre: css({
+    background: theme.colors.background.secondary,
+    borderRadius: theme.shape.radius.default,
+    padding: theme.spacing(1.5),
+    fontSize: theme.typography.bodySmall.fontSize,
+    fontFamily: theme.typography.fontFamilyMonospace,
+    overflow: 'auto',
+    maxHeight: MAX_LINES * LINE_HEIGHT,
+    margin: 0,
+  }),
+  languageBadge: css({
+    position: 'absolute',
+    top: theme.spacing(0.75),
+    right: theme.spacing(0.75),
+    zIndex: 1,
+    opacity: 0.85,
+  }),
+  placeholder: css({
+    display: 'block',
+    color: theme.colors.text.disabled,
+    fontStyle: 'italic',
+    padding: theme.spacing(0.5, 0),
+  }),
+});

--- a/public/app/features/notebook/editor/cells/MarkdownCellEditor.tsx
+++ b/public/app/features/notebook/editor/cells/MarkdownCellEditor.tsx
@@ -1,0 +1,147 @@
+import { css } from '@emotion/css';
+import { useEffect, useRef } from 'react';
+
+import { AppEvents, type GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { TextArea, useStyles2 } from '@grafana/ui';
+import { appEvents } from 'app/core/app_events';
+import { MarkdownCell } from 'app/features/dashboard-scene/scene/layout-notebook/cells/MarkdownCell';
+
+import { imageFileFromEvent, imageFileToMarkdown } from './imagePaste';
+
+interface Props {
+  value: string;
+  editing: boolean;
+  onStartEdit: () => void;
+  onChange: (text: string) => void;
+  onDone: () => void;
+}
+
+/**
+ * Notion-style markdown cell: rendered preview that switches to a textarea on
+ * click, committing on blur / Escape / mod+Enter. Preview rendering reuses the
+ * read-only notebook MarkdownCell (sanitized markdown). Images can be pasted or
+ * dropped straight in — they embed as downscaled data URIs.
+ */
+export function MarkdownCellEditor({ value, editing, onStartEdit, onChange, onDone }: Props) {
+  const styles = useStyles2(getStyles);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (editing && textareaRef.current) {
+      textareaRef.current.focus();
+      // Put the caret at the end rather than selecting everything.
+      const length = textareaRef.current.value.length;
+      textareaRef.current.setSelectionRange(length, length);
+    }
+  }, [editing]);
+
+  const embedImage = async (file: File, position?: number) => {
+    const result = await imageFileToMarkdown(file);
+    if (!result.ok) {
+      appEvents.emit(AppEvents.alertWarning, [
+        result.reason === 'too-large'
+          ? t('notebooks.markdown-cell.image-too-large', 'Image is too large to embed (roughly 500KB max)')
+          : t('notebooks.markdown-cell.image-unsupported', 'This file type cannot be embedded'),
+      ]);
+      return;
+    }
+    if (position === undefined) {
+      onChange(value.trim() ? `${value}\n\n${result.markdown}` : result.markdown);
+    } else {
+      onChange(`${value.slice(0, position)}${result.markdown}${value.slice(position)}`);
+    }
+  };
+
+  if (editing) {
+    const rows = Math.min(Math.max(value.split('\n').length + 1, 3), 30);
+    return (
+      <TextArea
+        ref={textareaRef}
+        value={value}
+        rows={rows}
+        placeholder={t('notebooks.markdown-cell.placeholder', 'Write markdown… (paste or drop images)')}
+        onChange={(e) => onChange(e.currentTarget.value)}
+        onBlur={onDone}
+        onPaste={(e) => {
+          const file = imageFileFromEvent(e);
+          if (file) {
+            e.preventDefault();
+            embedImage(file, e.currentTarget.selectionStart ?? undefined);
+          }
+        }}
+        onDragOver={(e) => e.preventDefault()}
+        onDrop={(e) => {
+          const file = imageFileFromEvent(e);
+          if (file) {
+            e.preventDefault();
+            embedImage(file, e.currentTarget.selectionStart ?? undefined);
+          }
+        }}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape' || (e.key === 'Enter' && (e.metaKey || e.ctrlKey))) {
+            e.preventDefault();
+            onDone();
+          }
+        }}
+        className={styles.textarea}
+        data-testid="notebook-markdown-input"
+      />
+    );
+  }
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      className={styles.preview}
+      onClick={onStartEdit}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onStartEdit();
+        }
+      }}
+      onDragOver={(e) => e.preventDefault()}
+      onDrop={(e) => {
+        const file = imageFileFromEvent(e);
+        if (file) {
+          e.preventDefault();
+          embedImage(file);
+        }
+      }}
+      aria-label={t('notebooks.markdown-cell.edit-label', 'Edit text cell')}
+      data-testid="notebook-markdown-preview"
+    >
+      {value.trim() ? (
+        <MarkdownCell content={{ kind: 'Markdown', spec: { text: value } }} />
+      ) : (
+        <span className={styles.placeholder}>
+          {t('notebooks.markdown-cell.empty', 'Click to add text — markdown, links and images supported')}
+        </span>
+      )}
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  textarea: css({
+    fontFamily: theme.typography.fontFamilyMonospace,
+    fontSize: theme.typography.bodySmall.fontSize,
+  }),
+  preview: css({
+    cursor: 'text',
+    width: '100%',
+    textAlign: 'left',
+    padding: theme.spacing(0.5, 0),
+
+    '&:focus-visible': {
+      outline: `2px solid ${theme.colors.primary.border}`,
+      outlineOffset: 2,
+    },
+  }),
+  placeholder: css({
+    color: theme.colors.text.disabled,
+    fontStyle: 'italic',
+  }),
+});

--- a/public/app/features/notebook/editor/cells/PanelCellView.tsx
+++ b/public/app/features/notebook/editor/cells/PanelCellView.tsx
@@ -1,0 +1,280 @@
+import { css } from '@emotion/css';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { LoadingState, rangeUtil, type DataQuery, type GrafanaTheme2, type PanelData } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import {
+  EmbeddedScene,
+  SceneFlexItem,
+  SceneFlexLayout,
+  SceneTimeRange,
+  sceneGraph,
+  type VizPanel,
+} from '@grafana/scenes';
+import { type PanelKind } from '@grafana/schema/apis/notebook/v2beta1';
+import { useStyles2 } from '@grafana/ui';
+import { getExploreUrl } from 'app/core/utils/explore';
+
+import { preferredVizForData } from '../../model/preferredViz';
+
+import { buildNotebookVizPanel } from './buildNotebookVizPanel';
+
+const DEFAULT_PANEL_HEIGHT = 320;
+const MIN_PANEL_HEIGHT = 120;
+const MAX_PANEL_HEIGHT = 1200;
+
+interface Props {
+  panel: PanelKind;
+  timeFrom: string;
+  timeTo: string;
+  /** Bump to re-run the queries with the same time range. */
+  refreshNonce?: number;
+  /** Rendered height in pixels; falls back to the default when unset. */
+  height?: number;
+  /** Called with the final height when the user finishes a resize drag. */
+  onHeightChange?: (height: number) => void;
+  /** Exposes a reader for the panel's latest query result (used by viz suggestions). */
+  onDataReaderReady?: (getData: () => PanelData | undefined) => void;
+  /**
+   * Called when the user changes this panel's time range from inside the panel
+   * (drag-to-zoom, zoom out) — the editor turns it into a per-block time lock.
+   */
+  onUserTimeChange?: (from: string, to: string) => void;
+  /**
+   * When set, in-panel time gestures snap back instead of reporting up — used for
+   * blocks already locked to a window, whose range should not shift accidentally.
+   */
+  revertUserTimeChanges?: boolean;
+  /**
+   * Called whenever a query run completes with data, with the visualization the
+   * result frames themselves prefer (frame metadata). The editor uses it to
+   * auto-pick the right viz for freshly added panels.
+   */
+  onPreferredViz?: (pluginId: string) => void;
+}
+
+/**
+ * Renders one notebook panel element as a self-contained embedded scene with a
+ * bottom-edge resize handle. Each cell gets its own scene so cells can be
+ * added/removed/reordered independently; the notebook-level time range is pushed
+ * down into every cell's SceneTimeRange.
+ */
+export function PanelCellView({
+  panel,
+  timeFrom,
+  timeTo,
+  refreshNonce,
+  height,
+  onHeightChange,
+  onDataReaderReady,
+  onUserTimeChange,
+  revertUserTimeChanges,
+  onPreferredViz,
+}: Props) {
+  const styles = useStyles2(getStyles);
+
+  // Live height during a resize drag; the committed value comes from props.
+  const [draggingHeight, setDraggingHeight] = useState<number | undefined>();
+  const dragState = useRef<{ startY: number; startHeight: number } | undefined>(undefined);
+  const vizPanelRef = useRef<VizPanel | undefined>(undefined);
+
+  // Rebuild the scene only when the panel definition itself changes.
+  const panelJson = JSON.stringify(panel);
+
+  const scene = useMemo(() => {
+    const parsed: PanelKind = JSON.parse(panelJson);
+    const vizPanel = buildNotebookVizPanel(parsed);
+    vizPanelRef.current = vizPanel;
+    return new EmbeddedScene({
+      $timeRange: new SceneTimeRange({ from: timeFrom, to: timeTo }),
+      body: new SceneFlexLayout({
+        direction: 'column',
+        children: [new SceneFlexItem({ height: '100%', body: vizPanel })],
+      }),
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- time range changes are synced onto the existing scene below
+  }, [panelJson]);
+
+  useEffect(() => {
+    onDataReaderReady?.(() => {
+      const vizPanel = vizPanelRef.current;
+      return vizPanel ? sceneGraph.getData(vizPanel).state.data : undefined;
+    });
+  }, [scene, onDataReaderReady]);
+
+  // Report the viz the result frames prefer once a run completes with data.
+  const onPreferredVizRef = useRef(onPreferredViz);
+  onPreferredVizRef.current = onPreferredViz;
+  useEffect(() => {
+    const vizPanel = vizPanelRef.current;
+    if (!vizPanel || !onPreferredVizRef.current) {
+      return;
+    }
+    const sub = sceneGraph.getData(vizPanel).subscribeToState((state) => {
+      if (state.data?.state === LoadingState.Done && state.data.series.length > 0) {
+        onPreferredVizRef.current?.(preferredVizForData(state.data));
+      }
+    });
+    return () => sub.unsubscribe();
+  }, [scene]);
+
+  useEffect(() => {
+    const timeRange = scene.state.$timeRange;
+    if (!timeRange) {
+      return;
+    }
+    if (timeRange.state.from !== timeFrom || timeRange.state.to !== timeTo) {
+      timeRange.onTimeRangeChange(rangeUtil.convertRawToRange({ from: timeFrom, to: timeTo }));
+    }
+  }, [scene, timeFrom, timeTo]);
+
+  // Drag-to-zoom (and other in-panel time interactions) change this cell's scene
+  // range. Anything that differs from the props is a user gesture — report it up so
+  // it becomes a persistent per-block time lock instead of silently vanishing on the
+  // next spec-driven rebuild. Props-driven syncs (above) settle equal and are ignored.
+  const timeFromRef = useRef(timeFrom);
+  timeFromRef.current = timeFrom;
+  const timeToRef = useRef(timeTo);
+  timeToRef.current = timeTo;
+  const onUserTimeChangeRef = useRef(onUserTimeChange);
+  onUserTimeChangeRef.current = onUserTimeChange;
+  const revertUserTimeRef = useRef(revertUserTimeChanges);
+  revertUserTimeRef.current = revertUserTimeChanges;
+
+  useEffect(() => {
+    const timeRange = scene.state.$timeRange;
+    if (!timeRange) {
+      return;
+    }
+    const sub = timeRange.subscribeToState((state) => {
+      if (state.from === timeFromRef.current && state.to === timeToRef.current) {
+        return;
+      }
+      if (revertUserTimeRef.current) {
+        // Locked blocks keep their window: snap the gesture back.
+        timeRange.onTimeRangeChange(rangeUtil.convertRawToRange({ from: timeFromRef.current, to: timeToRef.current }));
+        return;
+      }
+      onUserTimeChangeRef.current?.(state.from, state.to);
+    });
+    return () => sub.unsubscribe();
+  }, [scene]);
+
+  useEffect(() => {
+    if (refreshNonce) {
+      scene.state.$timeRange?.onRefresh();
+    }
+  }, [scene, refreshNonce]);
+
+  const onResizeStart = useCallback(
+    (e: React.PointerEvent) => {
+      if (!onHeightChange) {
+        return;
+      }
+      e.preventDefault();
+      e.currentTarget.setPointerCapture(e.pointerId);
+      dragState.current = { startY: e.clientY, startHeight: height ?? DEFAULT_PANEL_HEIGHT };
+    },
+    [onHeightChange, height]
+  );
+
+  const onResizeMove = useCallback((e: React.PointerEvent) => {
+    if (!dragState.current) {
+      return;
+    }
+    const next = dragState.current.startHeight + (e.clientY - dragState.current.startY);
+    setDraggingHeight(Math.min(Math.max(next, MIN_PANEL_HEIGHT), MAX_PANEL_HEIGHT));
+  }, []);
+
+  const onResizeEnd = useCallback(() => {
+    if (dragState.current === undefined) {
+      return;
+    }
+    dragState.current = undefined;
+    setDraggingHeight((finalHeight) => {
+      if (finalHeight !== undefined) {
+        onHeightChange?.(finalHeight);
+      }
+      return undefined;
+    });
+  }, [onHeightChange]);
+
+  const renderedHeight = draggingHeight ?? height ?? DEFAULT_PANEL_HEIGHT;
+
+  return (
+    <div className={styles.wrapper}>
+      <div style={{ height: renderedHeight }}>
+        <scene.Component model={scene} />
+      </div>
+      {onHeightChange && (
+        <div
+          className={styles.resizeHandle}
+          onPointerDown={onResizeStart}
+          onPointerMove={onResizeMove}
+          onPointerUp={onResizeEnd}
+          onPointerCancel={onResizeEnd}
+          role="separator"
+          aria-orientation="horizontal"
+          aria-label={t('notebooks.panel-cell.resize', 'Resize panel')}
+          data-testid="notebook-panel-resize"
+        >
+          <div className={styles.resizeGrip} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Converts a notebook panel's queries back to the legacy shape Explore understands. */
+function panelToExploreQueries(panel: PanelKind): DataQuery[] {
+  return panel.spec.data.spec.queries.map((query) => ({
+    refId: query.spec.refId,
+    ...query.spec.query.spec,
+    datasource: {
+      type: query.spec.query.group,
+      uid: query.spec.query.datasource?.name,
+    },
+  }));
+}
+
+/** Builds an Explore URL for a notebook panel using the notebook's time range. */
+export async function getExploreUrlForPanel(
+  panel: PanelKind,
+  timeFrom: string,
+  timeTo: string
+): Promise<string | undefined> {
+  const queries = panelToExploreQueries(panel);
+  if (queries.length === 0) {
+    return undefined;
+  }
+  return getExploreUrl({
+    queries,
+    dsRef: queries[0].datasource,
+    timeRange: rangeUtil.convertRawToRange({ from: timeFrom, to: timeTo }),
+    scopedVars: undefined,
+  });
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  wrapper: css({
+    position: 'relative',
+  }),
+  resizeHandle: css({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: theme.spacing(1.5),
+    cursor: 'ns-resize',
+    touchAction: 'none',
+
+    '&:hover > div, &:active > div': {
+      background: theme.colors.primary.border,
+    },
+  }),
+  resizeGrip: css({
+    width: theme.spacing(6),
+    height: 4,
+    borderRadius: theme.shape.radius.pill,
+    background: theme.colors.border.medium,
+  }),
+});

--- a/public/app/features/notebook/editor/cells/PanelQueryEditor.tsx
+++ b/public/app/features/notebook/editor/cells/PanelQueryEditor.tsx
@@ -1,0 +1,222 @@
+import { css } from '@emotion/css';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useAsync } from 'react-use';
+
+import {
+  CoreApp,
+  DataSourcePluginContextProvider,
+  rangeUtil,
+  type DataQuery,
+  type DataSourceInstanceSettings,
+  type GrafanaTheme2,
+  type PanelData,
+} from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { DataSourcePicker, getDataSourceSrv } from '@grafana/runtime';
+import { type PanelKind } from '@grafana/schema/apis/notebook/v2beta1';
+import { Alert, Button, IconButton, Select, Spinner, Stack, useStyles2 } from '@grafana/ui';
+
+// The established CoreApp value for embedded, standalone query editors (same choice as
+// the saved-queries inline editor): datasource editors gate host-specific chrome like
+// "Query with Assistant" to Explore/Dashboard/PanelEditor.
+const EDITOR_APP = CoreApp.Correlations;
+
+interface Props {
+  panel: PanelKind;
+  /** The block's effective time range, passed to the editor for hints/preview. */
+  timeFrom: string;
+  timeTo: string;
+  /** Latest query results of the panel, for editors that render field pickers etc. */
+  getData?: () => PanelData | undefined;
+  /** Commits the edited query (and datasource, when changed) — the panel re-runs. */
+  onApply: (refId: string, query: DataQuery, datasource: { uid: string; type: string }) => void;
+  onClose: () => void;
+}
+
+/**
+ * Inline query editing for a notebook panel block: renders the datasource's own
+ * query editor (the same component Explore embeds). Edits are local drafts until
+ * "Run query" (or Ctrl/Cmd+Enter) commits them to the notebook, which re-runs the
+ * panel — so keystrokes never thrash queries, and every run lands in autosave.
+ */
+export function PanelQueryEditor({ panel, timeFrom, timeTo, getData, onApply, onClose }: Props) {
+  const styles = useStyles2(getStyles);
+  const queries = panel.spec.data.spec.queries;
+  const [selectedRefId, setSelectedRefId] = useState(queries[0]?.spec.refId ?? 'A');
+  const selected = queries.find((query) => query.spec.refId === selectedRefId) ?? queries[0];
+
+  // The panel's stored datasource — overridable via the picker below.
+  const [datasource, setDatasource] = useState<{ uid: string; type: string }>(() => ({
+    uid: selected?.spec.query.datasource?.name ?? '',
+    type: selected?.spec.query.group ?? '',
+  }));
+
+  const baseline = useMemo<DataQuery>(
+    () => ({
+      refId: selected?.spec.refId ?? 'A',
+      ...selected?.spec.query.spec,
+      datasource: { uid: datasource.uid, type: datasource.type },
+    }),
+    [selected, datasource]
+  );
+
+  const [draft, setDraft] = useState<DataQuery>(baseline);
+  const draftRef = useRef(draft);
+  draftRef.current = draft;
+
+  // Reset the draft only when the underlying stored query *content* changes (apply,
+  // remote update, switching refId) — collaboration churn that replaces spec object
+  // identities without changing content must never clobber in-progress typing.
+  const baselineJson = JSON.stringify(baseline);
+  const lastBaselineJson = useRef(baselineJson);
+  useEffect(() => {
+    if (lastBaselineJson.current !== baselineJson) {
+      lastBaselineJson.current = baselineJson;
+      const next: DataQuery = JSON.parse(baselineJson);
+      setDraft(next);
+      draftRef.current = next;
+    }
+  }, [baselineJson]);
+
+  // Primitive deps: spec object identity churns with every collaboration sync, the
+  // uid/type strings do not — the datasource must not reload (and the editor must
+  // not unmount) unless the actual datasource changed.
+  const { value: datasourceApi, loading: datasourceLoading } = useAsync(
+    () => getDataSourceSrv().get({ uid: datasource.uid, type: datasource.type }),
+    [datasource.uid, datasource.type]
+  );
+
+  const editorRange = useMemo(() => rangeUtil.convertRawToRange({ from: timeFrom, to: timeTo }), [timeFrom, timeTo]);
+
+  const apply = () => {
+    onApply(selectedRefId, draftRef.current, datasource);
+  };
+
+  const onChangeDatasource = (ds: DataSourceInstanceSettings) => {
+    setDatasource({ uid: ds.uid, type: ds.type });
+    // Query models are datasource-specific; a different type starts a fresh query.
+    if (ds.type !== datasource.type) {
+      const fresh: DataQuery = { refId: selectedRefId, datasource: { uid: ds.uid, type: ds.type } };
+      setDraft(fresh);
+      draftRef.current = fresh;
+    }
+  };
+
+  const QueryEditor = datasourceApi?.components?.QueryEditor;
+  const instanceSettings = datasource.uid ? getDataSourceSrv().getInstanceSettings(datasource.uid) : undefined;
+
+  const refIdOptions = queries.map((query) => ({ label: query.spec.refId, value: query.spec.refId }));
+
+  return (
+    <div className={styles.container} data-testid="notebook-panel-query-editor">
+      <div className={styles.header}>
+        <Stack direction="row" gap={1} alignItems="center">
+          <div className={styles.dsPicker}>
+            <DataSourcePicker current={datasource.uid || null} onChange={onChangeDatasource} />
+          </div>
+          {queries.length > 1 && (
+            <Select
+              width={10}
+              options={refIdOptions}
+              value={selectedRefId}
+              onChange={(option) => option.value && setSelectedRefId(option.value)}
+              aria-label={t('notebooks.query-editor.query-picker', 'Query to edit')}
+            />
+          )}
+        </Stack>
+        <Stack direction="row" gap={1} alignItems="center">
+          <Button
+            size="sm"
+            variant="primary"
+            icon="play"
+            onClick={apply}
+            disabled={!datasourceApi}
+            tooltip={t('notebooks.query-editor.run-tooltip', 'Ctrl/Cmd + Enter to run')}
+          >
+            <Trans i18nKey="notebooks.query-editor.run">Run query</Trans>
+          </Button>
+          <IconButton
+            name="times"
+            tooltip={t('notebooks.query-editor.close', 'Close query editor')}
+            onClick={onClose}
+          />
+        </Stack>
+      </div>
+
+      {/* Only the very first datasource load shows a spinner. Background reloads keep
+          the previous editor mounted, preserving focus and typing state. */}
+      {!datasourceApi && datasourceLoading && <Spinner />}
+
+      {QueryEditor && instanceSettings && datasourceApi && (
+        // Ctrl/Cmd+Enter runs from anywhere in the editor — Explore muscle memory.
+        // Code-mode editors (Monaco) handle it themselves via onRunQuery.
+        // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+        <div
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
+              event.preventDefault();
+              apply();
+            }
+          }}
+        >
+          <DataSourcePluginContextProvider instanceSettings={instanceSettings}>
+            <QueryEditor
+              app={EDITOR_APP}
+              datasource={datasourceApi}
+              query={draft}
+              onChange={(updated: DataQuery) => {
+                // Editors may call onChange then onRunQuery synchronously — keep the
+                // ref current so the run commits the just-typed version.
+                draftRef.current = updated;
+                setDraft(updated);
+              }}
+              onRunQuery={apply}
+              data={getData?.()}
+              range={editorRange}
+            />
+          </DataSourcePluginContextProvider>
+        </div>
+      )}
+
+      {!datasourceLoading && datasourceApi && !QueryEditor && (
+        <Alert
+          severity="warning"
+          title={t(
+            'notebooks.query-editor.no-editor',
+            'This data source does not provide a query editor that can be embedded here.'
+          )}
+        />
+      )}
+
+      {!datasourceLoading && !datasourceApi && (
+        <Alert
+          severity="warning"
+          title={t('notebooks.query-editor.no-datasource', 'The data source for this panel could not be loaded.')}
+        />
+      )}
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  container: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+    backgroundColor: theme.colors.background.primary,
+    borderRadius: theme.shape.radius.default,
+    border: `1px solid ${theme.colors.border.weak}`,
+    padding: theme.spacing(1),
+    marginBottom: theme.spacing(1),
+  }),
+  header: css({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: theme.spacing(1),
+    flexWrap: 'wrap',
+  }),
+  dsPicker: css({
+    minWidth: 200,
+  }),
+});

--- a/public/app/features/notebook/editor/cells/VizSuggestionsButton.tsx
+++ b/public/app/features/notebook/editor/cells/VizSuggestionsButton.tsx
@@ -1,0 +1,99 @@
+import { css } from '@emotion/css';
+import { useEffect, useState } from 'react';
+
+import { type GrafanaTheme2, type PanelData, type PanelPluginVisualizationSuggestion } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { IconButton, Spinner, Text, Toggletip, useStyles2 } from '@grafana/ui';
+import { VisualizationSuggestionCard } from 'app/features/panel/components/VizTypePicker/VisualizationSuggestionCard';
+import { getAllSuggestions } from 'app/features/panel/suggestions/getAllSuggestions';
+
+const CARD_WIDTH = 150;
+const MAX_SUGGESTIONS = 8;
+
+interface Props {
+  currentPluginId: string;
+  /** Reads the panel's latest query result — suggestions are ranked against real data. */
+  getData: () => PanelData | undefined;
+  onSelect: (suggestion: PanelPluginVisualizationSuggestion) => void;
+}
+
+/**
+ * "Change visualization" for a notebook panel: a small icon that opens Grafana's
+ * data-driven visualization suggestions (live previews rendered against the
+ * panel's current data). Picking one swaps the panel's viz while keeping queries.
+ */
+export function VizSuggestionsButton({ currentPluginId, getData, onSelect }: Props) {
+  return (
+    <Toggletip
+      content={<SuggestionsContent currentPluginId={currentPluginId} getData={getData} onSelect={onSelect} />}
+      placement="bottom-end"
+      closeButton={false}
+    >
+      <IconButton
+        name="chart-line"
+        size="sm"
+        tooltip={t('notebooks.viz-suggestions.tooltip', 'Change visualization')}
+      />
+    </Toggletip>
+  );
+}
+
+function SuggestionsContent({ currentPluginId, getData, onSelect }: Props) {
+  const styles = useStyles2(getStyles);
+  const [data] = useState(getData);
+  const [suggestions, setSuggestions] = useState<PanelPluginVisualizationSuggestion[] | undefined>();
+
+  useEffect(() => {
+    let cancelled = false;
+    getAllSuggestions(data?.series).then((result) => {
+      if (!cancelled) {
+        setSuggestions(result.suggestions.slice(0, MAX_SUGGESTIONS));
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [data]);
+
+  if (!data || data.series.length === 0) {
+    return (
+      <Text color="secondary">
+        {t('notebooks.viz-suggestions.no-data', 'No data yet — suggestions appear once the panel has results.')}
+      </Text>
+    );
+  }
+
+  if (!suggestions) {
+    return <Spinner />;
+  }
+
+  if (suggestions.length === 0) {
+    return <Text color="secondary">{t('notebooks.viz-suggestions.none', 'No suggestions for this data shape.')}</Text>;
+  }
+
+  return (
+    <div className={styles.grid} data-testid="notebook-viz-suggestions">
+      {suggestions.map((suggestion, index) => (
+        <VisualizationSuggestionCard
+          key={index}
+          data={data}
+          suggestion={suggestion}
+          width={CARD_WIDTH}
+          isSelected={suggestion.pluginId === currentPluginId}
+          onClick={() => onSelect(suggestion)}
+        />
+      ))}
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  grid: css({
+    display: 'grid',
+    gridTemplateColumns: `repeat(2, ${CARD_WIDTH}px)`,
+    gap: theme.spacing(1),
+    maxHeight: 420,
+    overflowY: 'auto',
+    padding: theme.spacing(0.5),
+  }),
+});

--- a/public/app/features/notebook/editor/cells/buildNotebookVizPanel.ts
+++ b/public/app/features/notebook/editor/cells/buildNotebookVizPanel.ts
@@ -1,0 +1,35 @@
+import { config } from '@grafana/runtime';
+import { VizPanel } from '@grafana/scenes';
+import { type PanelKind as DashboardPanelKind } from '@grafana/schema/apis/dashboard.grafana.app/v2';
+import { type PanelKind } from '@grafana/schema/apis/notebook/v2beta1';
+import { createPanelDataProvider } from 'app/features/dashboard-scene/serialization/layoutSerializers/utils';
+import { transformMappingsToV1 } from 'app/features/dashboard-scene/serialization/transformToV1TypesUtils';
+import { getVizPanelKeyForPanelId } from 'app/features/dashboard-scene/utils/utils';
+
+/**
+ * Builds a standalone VizPanel from a notebook panel element. Unlike the dashboard
+ * serializer's buildVizPanel, this deliberately skips the parts that require a
+ * DashboardScene ancestor (panel menu, header actions, dashboard panel context) so
+ * the panel can live inside the notebook editor's own embedded scene.
+ */
+export function buildNotebookVizPanel(panel: PanelKind): VizPanel {
+  // The notebook and dashboard PanelKind types are generated identically from the same
+  // OpenAPI source but live in sibling modules; bridge them here (same convention as
+  // the notebook layout serializer).
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- identical leaf type across the two schemas
+  const dashPanel = panel as unknown as DashboardPanelKind;
+  const spec = dashPanel.spec;
+
+  return new VizPanel({
+    key: getVizPanelKeyForPanelId(spec.id),
+    title: spec.title?.substring(0, 5000),
+    description: spec.description || undefined,
+    pluginId: spec.vizConfig.group,
+    options: spec.vizConfig.spec.options ?? {},
+    fieldConfig: transformMappingsToV1(spec.vizConfig.spec.fieldConfig),
+    pluginVersion: spec.vizConfig.version || undefined,
+    displayMode: spec.transparent ? 'transparent' : 'default',
+    seriesLimit: config.panelSeriesLimit,
+    $data: createPanelDataProvider(dashPanel),
+  });
+}

--- a/public/app/features/notebook/editor/cells/imagePaste.ts
+++ b/public/app/features/notebook/editor/cells/imagePaste.ts
@@ -1,0 +1,58 @@
+const MAX_WIDTH = 1280;
+// Data-URI markdown is stored inside the notebook spec; cap the embedded size so a
+// screenshot cannot balloon the resource (~500KB decoded).
+const MAX_ENCODED_CHARS = 700_000;
+
+export type PastedImageResult = { ok: true; markdown: string } | { ok: false; reason: 'too-large' | 'unsupported' };
+
+/**
+ * Converts a pasted/dropped image file into an embeddable markdown image: downscaled
+ * to a sane width, re-encoded as JPEG and inlined as a data URI (which the text-panel
+ * sanitizer explicitly allows for img src).
+ */
+export async function imageFileToMarkdown(file: File): Promise<PastedImageResult> {
+  if (!file.type.startsWith('image/')) {
+    return { ok: false, reason: 'unsupported' };
+  }
+
+  let bitmap: ImageBitmap;
+  try {
+    bitmap = await createImageBitmap(file);
+  } catch {
+    return { ok: false, reason: 'unsupported' };
+  }
+
+  const scale = Math.min(1, MAX_WIDTH / bitmap.width);
+  const canvas = document.createElement('canvas');
+  canvas.width = Math.max(1, Math.round(bitmap.width * scale));
+  canvas.height = Math.max(1, Math.round(bitmap.height * scale));
+  const context = canvas.getContext('2d');
+  if (!context) {
+    return { ok: false, reason: 'unsupported' };
+  }
+  context.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+  bitmap.close();
+
+  const dataUrl = canvas.toDataURL('image/jpeg', 0.85);
+  if (dataUrl.length > MAX_ENCODED_CHARS) {
+    return { ok: false, reason: 'too-large' };
+  }
+
+  // Brackets/parens in the alt text would break the markdown image syntax.
+  const alt = (file.name || 'image').replace(/[[\]()]/g, '');
+  return { ok: true, markdown: `![${alt}](${dataUrl})` };
+}
+
+/** The image file of a paste or drop event, if there is one. */
+export function imageFileFromEvent(e: React.ClipboardEvent | React.DragEvent): File | undefined {
+  const transfer = 'clipboardData' in e ? e.clipboardData : e.dataTransfer;
+  if (!transfer) {
+    return undefined;
+  }
+  for (const item of Array.from(transfer.items)) {
+    if (item.kind === 'file' && item.type.startsWith('image/')) {
+      return item.getAsFile() ?? undefined;
+    }
+  }
+  return undefined;
+}

--- a/public/app/features/notebook/editor/useNotebookEditorState.test.ts
+++ b/public/app/features/notebook/editor/useNotebookEditorState.test.ts
@@ -1,0 +1,124 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import { newNotebookSpec, setNotebookTitle } from '../model/notebookSpec';
+
+import { useNotebookEditorState } from './useNotebookEditorState';
+
+const mockFetchNotebook = jest.fn();
+const mockSaveNotebook = jest.fn();
+
+jest.mock('../api/notebookAPI', () => ({
+  fetchNotebook: (uid: string) => mockFetchNotebook(uid),
+  saveNotebook: (resource: unknown) => mockSaveNotebook(resource),
+  isConflictError: () => false,
+}));
+
+function resourceWithTitle(title: string) {
+  return {
+    apiVersion: 'dashboard.grafana.app/v2beta1',
+    kind: 'Notebook',
+    metadata: { name: 'nb-1', resourceVersion: '1', creationTimestamp: '' },
+    spec: newNotebookSpec(title),
+  };
+}
+
+describe('useNotebookEditorState undo/redo', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockFetchNotebook.mockResolvedValue(resourceWithTitle('original'));
+    mockSaveNotebook.mockImplementation(async (resource) => resource);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  async function renderLoaded() {
+    const hook = renderHook(() => useNotebookEditorState('nb-1'));
+    await waitFor(() => expect(hook.result.current.state.loading).toBe(false));
+    return hook;
+  }
+
+  it('undoes and redoes local edits', async () => {
+    const { result } = await renderLoaded();
+    expect(result.current.state.canUndo).toBe(false);
+
+    act(() => {
+      result.current.updateSpec((s) => setNotebookTitle(s, 'first'));
+    });
+    act(() => {
+      jest.advanceTimersByTime(1000); // beyond the coalesce window
+      result.current.updateSpec((s) => setNotebookTitle(s, 'second'));
+    });
+
+    expect(result.current.state.spec?.title).toBe('second');
+    expect(result.current.state.canUndo).toBe(true);
+    expect(result.current.state.canRedo).toBe(false);
+
+    act(() => {
+      expect(result.current.undo()).toBe(true);
+    });
+    expect(result.current.state.spec?.title).toBe('first');
+    expect(result.current.state.canRedo).toBe(true);
+
+    act(() => {
+      expect(result.current.undo()).toBe(true);
+    });
+    expect(result.current.state.spec?.title).toBe('original');
+    expect(result.current.state.canUndo).toBe(false);
+
+    act(() => {
+      expect(result.current.undo()).toBe(false);
+    });
+
+    act(() => {
+      expect(result.current.redo()).toBe(true);
+    });
+    expect(result.current.state.spec?.title).toBe('first');
+
+    act(() => {
+      expect(result.current.redo()).toBe(true);
+    });
+    expect(result.current.state.spec?.title).toBe('second');
+    expect(result.current.state.canRedo).toBe(false);
+  });
+
+  it('coalesces rapid edits into one undo step', async () => {
+    const { result } = await renderLoaded();
+
+    // Simulates typing: several updates within the coalesce window.
+    act(() => {
+      result.current.updateSpec((s) => setNotebookTitle(s, 'a'));
+      jest.advanceTimersByTime(100);
+      result.current.updateSpec((s) => setNotebookTitle(s, 'ab'));
+      jest.advanceTimersByTime(100);
+      result.current.updateSpec((s) => setNotebookTitle(s, 'abc'));
+    });
+
+    act(() => {
+      expect(result.current.undo()).toBe(true);
+    });
+    expect(result.current.state.spec?.title).toBe('original');
+    expect(result.current.state.canUndo).toBe(false);
+  });
+
+  it('a new edit after undo clears the redo stack', async () => {
+    const { result } = await renderLoaded();
+
+    act(() => {
+      result.current.updateSpec((s) => setNotebookTitle(s, 'first'));
+    });
+    act(() => {
+      expect(result.current.undo()).toBe(true);
+    });
+    expect(result.current.state.canRedo).toBe(true);
+
+    act(() => {
+      result.current.updateSpec((s) => setNotebookTitle(s, 'branched'));
+    });
+    expect(result.current.state.canRedo).toBe(false);
+    expect(result.current.redo()).toBe(false);
+    expect(result.current.state.spec?.title).toBe('branched');
+  });
+});

--- a/public/app/features/notebook/editor/useNotebookEditorState.ts
+++ b/public/app/features/notebook/editor/useNotebookEditorState.ts
@@ -1,0 +1,249 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { AppEvents } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { type Spec as NotebookSpec } from '@grafana/schema/apis/notebook/v2beta1';
+import { appEvents } from 'app/core/app_events';
+import { type Resource } from 'app/features/apiserver/types';
+
+import { fetchNotebook, isConflictError, saveNotebook } from '../api/notebookAPI';
+
+const AUTOSAVE_DEBOUNCE_MS = 1200;
+const UNDO_STACK_LIMIT = 100;
+/** Edits closer together than this collapse into one undo step (e.g. typing bursts). */
+const UNDO_COALESCE_MS = 800;
+
+interface NotebookEditorState {
+  resource?: Resource<NotebookSpec>;
+  spec?: NotebookSpec;
+  loading: boolean;
+  loadError?: unknown;
+  saving: boolean;
+  dirty: boolean;
+  lastSavedAt?: number;
+  canUndo: boolean;
+  canRedo: boolean;
+}
+
+export interface NotebookEditorApi {
+  state: NotebookEditorState;
+  /** Applies a local edit. Marks the document dirty and schedules an autosave. */
+  updateSpec: (mutate: (spec: NotebookSpec) => NotebookSpec) => void;
+  /** Applies a document received from a collaborator. Does not trigger an autosave on this client. */
+  applyRemoteSpec: (spec: NotebookSpec) => void;
+  /** Reverts the most recent local edit step. Returns true when something was undone. */
+  undo: () => boolean;
+  /** Re-applies the most recently undone step. Returns true when something was redone. */
+  redo: () => boolean;
+  save: () => Promise<void>;
+  /** Latest working copy, readable from event handlers without stale closures. */
+  getSpec: () => NotebookSpec | undefined;
+}
+
+/**
+ * Owns the notebook editor working copy: load, local edits, remote (collaborative)
+ * edits and debounced autosave with optimistic-concurrency conflict retry.
+ */
+export function useNotebookEditorState(uid: string): NotebookEditorApi {
+  const [state, setState] = useState<NotebookEditorState>({
+    loading: true,
+    saving: false,
+    dirty: false,
+    canUndo: false,
+    canRedo: false,
+  });
+
+  // Refs mirror the parts of the state that async flows (autosave, collab) need
+  // to read without re-subscribing on every keystroke.
+  const specRef = useRef<NotebookSpec | undefined>(undefined);
+  const resourceRef = useRef<Resource<NotebookSpec> | undefined>(undefined);
+  const savingRef = useRef(false);
+  const dirtyRef = useRef(false);
+  const autosaveTimer = useRef<ReturnType<typeof setTimeout>>();
+
+  // Snapshot-based local history. Remote (collaborator) documents never enter the
+  // stacks: undo always steps through this user's own edits.
+  const undoStack = useRef<NotebookSpec[]>([]);
+  const redoStack = useRef<NotebookSpec[]>([]);
+  const lastUndoPushAt = useRef(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    undoStack.current = [];
+    redoStack.current = [];
+    setState({ loading: true, saving: false, dirty: false, canUndo: false, canRedo: false });
+
+    fetchNotebook(uid)
+      .then((resource) => {
+        if (cancelled) {
+          return;
+        }
+        specRef.current = resource.spec;
+        resourceRef.current = resource;
+        setState({
+          resource,
+          spec: resource.spec,
+          loading: false,
+          saving: false,
+          dirty: false,
+          canUndo: false,
+          canRedo: false,
+        });
+      })
+      .catch((loadError) => {
+        if (!cancelled) {
+          setState({ loading: false, saving: false, dirty: false, loadError, canUndo: false, canRedo: false });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+      clearTimeout(autosaveTimer.current);
+      // Flush edits still waiting on the autosave debounce so navigating away
+      // (Done button, breadcrumbs) never drops the last keystrokes.
+      if (dirtyRef.current && resourceRef.current && specRef.current) {
+        dirtyRef.current = false;
+        saveNotebook({ ...resourceRef.current, spec: specRef.current }).catch(() => {});
+      }
+    };
+  }, [uid]);
+
+  const save = useCallback(async () => {
+    const resource = resourceRef.current;
+    const specAtStart = specRef.current;
+    if (!resource || !specAtStart || savingRef.current) {
+      return;
+    }
+
+    savingRef.current = true;
+    setState((s) => ({ ...s, saving: true }));
+
+    try {
+      let saved: Resource<NotebookSpec>;
+      try {
+        saved = await saveNotebook({ ...resource, spec: specAtStart });
+      } catch (error) {
+        if (!isConflictError(error)) {
+          throw error;
+        }
+        // A collaborator saved since our last write. Live sync keeps working copies
+        // converged, so adopt the latest metadata (resourceVersion) and retry once.
+        const latest = await fetchNotebook(uid);
+        saved = await saveNotebook({ ...latest, spec: specRef.current ?? specAtStart });
+      }
+
+      resourceRef.current = saved;
+      // Edits may have landed while the request was in flight; stay dirty in that case.
+      const stillDirty = specRef.current !== specAtStart;
+      dirtyRef.current = stillDirty;
+      setState((s) => ({
+        ...s,
+        resource: saved,
+        saving: false,
+        dirty: stillDirty,
+        lastSavedAt: Date.now(),
+      }));
+      if (stillDirty) {
+        scheduleAutosave();
+      }
+    } catch (error) {
+      setState((s) => ({ ...s, saving: false }));
+      appEvents.emit(AppEvents.alertError, [
+        t('notebooks.editor.save-failed', 'Failed to save notebook'),
+        error instanceof Error ? error.message : '',
+      ]);
+    } finally {
+      savingRef.current = false;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- scheduleAutosave is stable (defined below with the same deps)
+  }, [uid]);
+
+  const scheduleAutosave = useCallback(() => {
+    clearTimeout(autosaveTimer.current);
+    autosaveTimer.current = setTimeout(() => {
+      save();
+    }, AUTOSAVE_DEBOUNCE_MS);
+  }, [save]);
+
+  const updateSpec = useCallback(
+    (mutate: (spec: NotebookSpec) => NotebookSpec) => {
+      const current = specRef.current;
+      if (!current) {
+        return;
+      }
+      const next = mutate(current);
+      if (next === current) {
+        return;
+      }
+
+      // Coalesce rapid successive edits (typing) into a single undo step.
+      const now = Date.now();
+      if (undoStack.current.length === 0 || now - lastUndoPushAt.current > UNDO_COALESCE_MS) {
+        undoStack.current.push(current);
+        if (undoStack.current.length > UNDO_STACK_LIMIT) {
+          undoStack.current.shift();
+        }
+      }
+      lastUndoPushAt.current = now;
+      redoStack.current = [];
+
+      specRef.current = next;
+      dirtyRef.current = true;
+      setState((s) => ({ ...s, spec: next, dirty: true, canUndo: true, canRedo: false }));
+      scheduleAutosave();
+    },
+    [scheduleAutosave]
+  );
+
+  const applyHistorySpec = useCallback(
+    (spec: NotebookSpec) => {
+      specRef.current = spec;
+      dirtyRef.current = true;
+      setState((s) => ({
+        ...s,
+        spec,
+        dirty: true,
+        canUndo: undoStack.current.length > 0,
+        canRedo: redoStack.current.length > 0,
+      }));
+      scheduleAutosave();
+    },
+    [scheduleAutosave]
+  );
+
+  const undo = useCallback(() => {
+    const previous = undoStack.current.pop();
+    const current = specRef.current;
+    if (!previous || !current) {
+      return false;
+    }
+    redoStack.current.push(current);
+    // The next edit after an undo starts a fresh step instead of coalescing into it.
+    lastUndoPushAt.current = 0;
+    applyHistorySpec(previous);
+    return true;
+  }, [applyHistorySpec]);
+
+  const redo = useCallback(() => {
+    const next = redoStack.current.pop();
+    const current = specRef.current;
+    if (!next || !current) {
+      return false;
+    }
+    undoStack.current.push(current);
+    lastUndoPushAt.current = 0;
+    applyHistorySpec(next);
+    return true;
+  }, [applyHistorySpec]);
+
+  const applyRemoteSpec = useCallback((spec: NotebookSpec) => {
+    specRef.current = spec;
+    // Remote specs are the sender's responsibility to persist; applying one here
+    // must not schedule an autosave, or every participant would race PUTs.
+    setState((s) => ({ ...s, spec }));
+  }, []);
+
+  const getSpec = useCallback(() => specRef.current, []);
+
+  return { state, updateSpec, applyRemoteSpec, undo, redo, save, getSpec };
+}

--- a/public/app/features/notebook/extensions/DeclareIncidentFromNotebookButton.tsx
+++ b/public/app/features/notebook/extensions/DeclareIncidentFromNotebookButton.tsx
@@ -1,0 +1,66 @@
+import { css } from '@emotion/css';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { Icon, LinkButton, Menu, useStyles2, useTheme2 } from '@grafana/ui';
+import { createBridgeURL } from 'app/features/alerting/unified/components/PluginBridge';
+import { canAccessPluginPage, useIrmPlugin } from 'app/features/alerting/unified/hooks/usePluginBridge';
+import { SupportedPlugin } from 'app/features/alerting/unified/types/pluginBridges';
+
+import { buildDeclareIncidentParams, type DeclareIncidentNotebookContext } from './declareIncidentFromNotebook';
+
+const DECLARE_INCIDENT_PATH = '/incidents/declare';
+
+interface Props extends DeclareIncidentNotebookContext {
+  /** Toolbar control (default) or hamburger menu item. */
+  as?: 'button' | 'menu-item';
+}
+
+/**
+ * IRM entry point from a notebook: opens declare-incident prefilled with a sensible
+ * title, a labeled link back to the notebook, and a short description. Renders
+ * nothing when IRM/Incident isn't available.
+ */
+export function DeclareIncidentFromNotebookButton({ as = 'button', ...ctx }: Props) {
+  const theme = useTheme2();
+  const styles = useStyles2(getStyles);
+  const { pluginId, loading, installed, settings } = useIrmPlugin(SupportedPlugin.Incident);
+
+  if (loading || !installed || !settings) {
+    return null;
+  }
+
+  if (!canAccessPluginPage(settings, createBridgeURL(pluginId, DECLARE_INCIDENT_PATH))) {
+    return null;
+  }
+
+  const bridgeURL = createBridgeURL(pluginId, DECLARE_INCIDENT_PATH, buildDeclareIncidentParams(ctx));
+
+  const label = t('notebooks.declare-incident.button', 'Declare incident');
+  const fireColor = theme.colors.error.text;
+
+  if (as === 'menu-item') {
+    return (
+      <Menu.Item icon="fire" iconColor={fireColor} label={label} url={bridgeURL} testId="notebook-declare-incident" />
+    );
+  }
+
+  // Match Edit / time-picker chrome: secondary filled control with a colored fire glyph.
+  return (
+    <LinkButton
+      variant="secondary"
+      href={bridgeURL}
+      tooltip={label}
+      aria-label={label}
+      data-testid="notebook-declare-incident"
+    >
+      <Icon name="fire" className={styles.fireIcon} />
+    </LinkButton>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  fireIcon: css({
+    color: theme.colors.error.text,
+  }),
+});

--- a/public/app/features/notebook/extensions/declareIncidentFromNotebook.test.ts
+++ b/public/app/features/notebook/extensions/declareIncidentFromNotebook.test.ts
@@ -1,0 +1,118 @@
+import { defaultSpec as defaultNotebookSpec } from '@grafana/schema/apis/notebook/v2beta1';
+
+import { DEFAULT_NOTEBOOK_TITLE, newPanelForDatasource } from '../model/notebookSpec';
+
+import { buildDeclareIncidentParams, declareIncidentContextFromSpec } from './declareIncidentFromNotebook';
+
+describe('buildDeclareIncidentParams', () => {
+  const originalLocation = window.location;
+
+  beforeAll(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, origin: 'https://grafana.example' },
+    });
+  });
+
+  afterAll(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  it('prefixes a named title and attaches the notebook link with a caption', () => {
+    const params = buildDeclareIncidentParams({
+      uid: 'nb1',
+      title: 'Checkout latency',
+      tags: ['checkout'],
+      panelTitles: ['p99 latency'],
+      firstMarkdownLine: 'some notes',
+      description: 'API errors spiking',
+    });
+
+    // Named title beats markdown/description.
+    expect(params.title).toBe('Investigation: Checkout latency');
+    expect(params.url).toBe('https://grafana.example/notebook/nb1');
+    expect(params.caption).toBe('Notebook: Checkout latency');
+    expect(params.description).toContain(
+      'This incident was declared from this notebook: https://grafana.example/notebook/nb1'
+    );
+    expect(params.description).toContain('Notebook: Checkout latency');
+    expect(params.description).toContain('Tags: checkout');
+    expect(params.description).toContain('- p99 latency');
+  });
+
+  it('keeps dated Investigation create titles as the incident title', () => {
+    const params = buildDeclareIncidentParams({
+      uid: 'nb1',
+      title: 'Investigation — August 1, 2026 16:30',
+    });
+
+    expect(params.title).toBe('Investigation — August 1, 2026 16:30');
+    expect(params.caption).toBe('Notebook: Investigation — August 1, 2026 16:30');
+  });
+
+  it('falls back to the first markdown line when the title is still the default', () => {
+    const params = buildDeclareIncidentParams({
+      uid: 'nb1',
+      title: DEFAULT_NOTEBOOK_TITLE,
+      firstMarkdownLine: 'Checkout p99 over SLO in prod',
+      description: 'API errors spiking in us-east',
+    });
+
+    expect(params.title).toBe('Checkout p99 over SLO in prod');
+    expect(params.caption).toBe('Investigation notebook');
+  });
+
+  it('treats blank titles like the create default', () => {
+    const params = buildDeclareIncidentParams({
+      uid: 'nb1',
+      title: '   ',
+      description: 'API errors spiking in us-east',
+    });
+
+    expect(params.title).toBe('API errors spiking in us-east');
+  });
+
+  it('does not double-prefix titles that already say Investigation', () => {
+    const params = buildDeclareIncidentParams({
+      uid: 'nb1',
+      title: 'Investigation: payment timeouts',
+    });
+
+    expect(params.title).toBe('Investigation: payment timeouts');
+  });
+});
+
+describe('declareIncidentContextFromSpec', () => {
+  it('collects panel titles and the first markdown line from the notebook', () => {
+    const panel = newPanelForDatasource({ uid: 'prom', type: 'prometheus' }, { title: 'Error rate' });
+    const ctx = declareIncidentContextFromSpec('nb1', {
+      ...defaultNotebookSpec(),
+      title: 'Outage notes',
+      elements: {
+        md1: { kind: 'Cell', spec: { content: { kind: 'Markdown', spec: { text: '# Checkout p99\n\nDetails…' } } } },
+        p1: panel,
+      },
+      layout: {
+        kind: 'NotebookLayout',
+        spec: {
+          cells: [
+            {
+              kind: 'NotebookLayoutItem',
+              spec: { element: { kind: 'ElementReference', name: 'md1' }, source: 'user' },
+            },
+            {
+              kind: 'NotebookLayoutItem',
+              spec: { element: { kind: 'ElementReference', name: 'p1' }, source: 'user' },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(ctx.panelTitles).toEqual(['Error rate']);
+    expect(ctx.firstMarkdownLine).toBe('Checkout p99');
+  });
+});

--- a/public/app/features/notebook/extensions/declareIncidentFromNotebook.ts
+++ b/public/app/features/notebook/extensions/declareIncidentFromNotebook.ts
@@ -1,0 +1,138 @@
+import { type Spec as NotebookSpec } from '@grafana/schema/apis/notebook/v2beta1';
+
+import { notebookViewUrl } from '../api/notebookAPI';
+import { DEFAULT_NOTEBOOK_TITLE, isDefaultNotebookTitle, resolveCells } from '../model/notebookSpec';
+
+export interface DeclareIncidentNotebookContext {
+  uid: string;
+  title: string;
+  description?: string;
+  tags?: string[];
+  /** Panel titles when known — used for a short description bullet list. */
+  panelTitles?: string[];
+  /** First meaningful markdown line — used when the notebook title is still the create default. */
+  firstMarkdownLine?: string;
+}
+
+/**
+ * Prefill params for the IRM declare-incident form.
+ *
+ * Documented URL params are title / url / caption / description (plus severity, etc.).
+ * `status` is the lifecycle state (active/resolved), not a status-update message — so the
+ * “declared from this notebook” line goes in `description`, and the notebook is also
+ * attached via `url` + `caption` (IRM’s attached-context UI).
+ */
+export function buildDeclareIncidentParams(ctx: DeclareIncidentNotebookContext): Record<string, string> {
+  const notebookUrl = new URL(notebookViewUrl(ctx.uid), window.location.origin).toString();
+  const title = incidentTitle(ctx);
+  const description = incidentDescription(ctx, notebookUrl, title);
+
+  const captionTitle = ctx.title.trim();
+  return {
+    title,
+    url: notebookUrl,
+    caption:
+      captionTitle && !isDefaultNotebookTitle(captionTitle) ? `Notebook: ${captionTitle}` : 'Investigation notebook',
+    description,
+  };
+}
+
+export function declareIncidentContextFromSpec(uid: string, spec: NotebookSpec): DeclareIncidentNotebookContext {
+  const panelTitles: string[] = [];
+  let firstMarkdownLine: string | undefined;
+
+  for (const cell of resolveCells(spec)) {
+    if (cell.element.kind === 'Panel' || cell.element.kind === 'LibraryPanel') {
+      const panelTitle = cell.element.spec.title?.trim();
+      if (panelTitle) {
+        panelTitles.push(panelTitle);
+      }
+      continue;
+    }
+
+    if (!firstMarkdownLine && cell.element.kind === 'Cell' && cell.element.spec.content.kind === 'Markdown') {
+      firstMarkdownLine = firstMeaningfulLine(cell.element.spec.content.spec.text);
+    }
+  }
+
+  return {
+    uid,
+    title: spec.title,
+    description: spec.description,
+    tags: spec.tags,
+    panelTitles,
+    firstMarkdownLine,
+  };
+}
+
+function incidentTitle(ctx: DeclareIncidentNotebookContext): string {
+  // Named title wins (including dated `Investigation — …` create defaults).
+  // Only fall through when empty or still the legacy untitled placeholder.
+  const trimmedTitle = ctx.title?.trim() ?? '';
+  if (!isDefaultNotebookTitle(trimmedTitle)) {
+    if (/^investigation\b/i.test(trimmedTitle)) {
+      return trimmedTitle;
+    }
+    return `Investigation: ${trimmedTitle}`;
+  }
+
+  for (const candidate of [ctx.firstMarkdownLine, ctx.description]) {
+    const summary = asSingleLineSummary(candidate);
+    if (summary) {
+      return summary;
+    }
+  }
+
+  return `Investigation: ${DEFAULT_NOTEBOOK_TITLE}`;
+}
+
+function incidentDescription(ctx: DeclareIncidentNotebookContext, notebookUrl: string, title: string): string {
+  // Lead with the declaration line so it reads like the initial status / context
+  // responders see first. IRM has no documented URL param for a status-update body.
+  const lines = [
+    `This incident was declared from this notebook: ${notebookUrl}`,
+    '',
+    `Notebook: ${ctx.title.trim() || DEFAULT_NOTEBOOK_TITLE}`,
+  ];
+
+  const trimmedDescription = ctx.description?.trim();
+  if (trimmedDescription && trimmedDescription !== title) {
+    lines.push('', trimmedDescription);
+  }
+
+  if (ctx.tags?.length) {
+    lines.push('', `Tags: ${ctx.tags.join(', ')}`);
+  }
+
+  const panels = ctx.panelTitles?.filter(Boolean).slice(0, 8) ?? [];
+  if (panels.length) {
+    lines.push('', 'Panels:');
+    for (const panel of panels) {
+      lines.push(`- ${panel}`);
+    }
+    if ((ctx.panelTitles?.length ?? 0) > panels.length) {
+      lines.push(`- …and ${(ctx.panelTitles?.length ?? 0) - panels.length} more`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+/** First non-empty markdown line, stripped of heading markers — for incident title fallback. */
+function firstMeaningfulLine(text: string): string | undefined {
+  for (const raw of text.split('\n')) {
+    const line = raw.replace(/^#{1,6}\s+/, '').trim();
+    if (line) {
+      return line;
+    }
+  }
+  return undefined;
+}
+
+function asSingleLineSummary(value?: string): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed || trimmed.includes('\n') || trimmed.length > 120) {
+    return undefined;
+  }
+  return trimmed;
+}

--- a/public/app/features/notebook/extensions/getNotebookExtensionConfigs.tsx
+++ b/public/app/features/notebook/extensions/getNotebookExtensionConfigs.tsx
@@ -1,0 +1,145 @@
+/* eslint-disable @grafana/i18n/no-untranslated-strings -- extension configs are registered at bootstrap, before i18n is ready (same as getExploreExtensionConfigs) */
+import { type PluginExtensionAddedLinkConfig, PluginExtensionPoints } from '@grafana/data';
+import { locationService } from '@grafana/runtime';
+import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
+import { contextSrv } from 'app/core/services/context_srv';
+import { createAddedLinkConfig } from 'app/features/plugins/extensions/utils';
+import { AccessControlAction } from 'app/types/accessControl';
+
+import { type PluginExtensionExploreContext } from '../../explore/extensions/ToolbarExtensionPoint';
+import { createNotebook, notebookEditUrl } from '../api/notebookAPI';
+import { getLastUsedNotebook } from '../model/lastUsedNotebook';
+import { markNotebookAsNew } from '../model/newNotebookSignal';
+import { newNotebookSpec, newNotebookTitle } from '../model/notebookSpec';
+
+/** Title shared by the sidebar added link and added component (the sidebar matches them by title). */
+export const NOTEBOOKS_SIDEBAR_COMPONENT_TITLE = 'Notebooks';
+
+// The Alerts & IRM landing page renders extension links from this point as cards —
+// the lightweight IRM entry point into notebooks.
+const IRM_LANDING_CARDS_EXTENSION_POINT = 'grafana/dynamic/nav-landing-page/nav-id-alerts-and-incidents/cards/v1';
+
+function notebooksEnabled(): boolean {
+  return getFeatureFlagClient().getBooleanValue(FlagKeys.DashboardNotebooks, false);
+}
+
+function canEditNotebooks(): boolean {
+  return (
+    contextSrv.hasPermission(AccessControlAction.DashboardsCreate) ||
+    contextSrv.hasPermission(AccessControlAction.DashboardsWrite)
+  );
+}
+
+export function getNotebookExtensionConfigs(): PluginExtensionAddedLinkConfig[] {
+  try {
+    return [
+      // Explore toolbar → "Add to notebook" (sibling of the core "Add to dashboard" action).
+      createAddedLinkConfig<PluginExtensionExploreContext>({
+        title: 'Add to notebook',
+        description: 'Capture the current query and visualization as a live panel in a notebook',
+        targets: [PluginExtensionPoints.ExploreToolbarAction],
+        icon: 'book-open',
+        category: 'Notebooks',
+        configure: () => {
+          if (!notebooksEnabled() || !canEditNotebooks()) {
+            return undefined;
+          }
+          return {};
+        },
+        onClick: async (_, { context, openModal }) => {
+          if (!context?.exploreId) {
+            return;
+          }
+          const { ExploreAddToNotebook } = await import('app/features/notebook/addToNotebook/ExploreAddToNotebook');
+          openModal({
+            title: 'Add to notebook',
+            body: ({ onDismiss }) => <ExploreAddToNotebook exploreId={context.exploreId} onClose={onDismiss!} />,
+          });
+        },
+      }),
+
+      // Explore toolbar → one-click append to the most recently used notebook.
+      // Title is overridden in configure to match the dashboard panel menu:
+      // `Add to "<notebook name>"` (truncated).
+      createAddedLinkConfig<PluginExtensionExploreContext>({
+        title: 'Add to last notebook',
+        description: 'Append the current query to your most recent notebook without any dialogs',
+        targets: [PluginExtensionPoints.ExploreToolbarAction],
+        icon: 'bolt',
+        category: 'Notebooks',
+        configure: () => {
+          if (!notebooksEnabled() || !canEditNotebooks()) {
+            return undefined;
+          }
+          const lastUsed = getLastUsedNotebook();
+          if (!lastUsed) {
+            return undefined;
+          }
+          const shortTitle = lastUsed.title.length > 25 ? `${lastUsed.title.slice(0, 25)}…` : lastUsed.title;
+          return {
+            title: `Add to "${shortTitle}"`,
+            description: `Append the current query to "${lastUsed.title}"`,
+          };
+        },
+        onClick: async (_, { context }) => {
+          if (!context?.exploreId) {
+            return;
+          }
+          const { quickAddExploreToLastNotebook } = await import(
+            'app/features/notebook/addToNotebook/quickAddFromExplore'
+          );
+          await quickAddExploreToLastNotebook(context.exploreId);
+        },
+      }),
+
+      // Extension sidebar ("workspace") → notebooks panel docked next to any page.
+      // The sidebar requires a link and a component with the same title; the component
+      // is registered in the plugin extension registry setup.
+      createAddedLinkConfig({
+        title: NOTEBOOKS_SIDEBAR_COMPONENT_TITLE,
+        description: 'Browse notebooks and capture quick notes alongside any Grafana page',
+        targets: [PluginExtensionPoints.ExtensionSidebar],
+        icon: 'book-open',
+        configure: () => (notebooksEnabled() ? {} : undefined),
+        onClick: (_, { openSidebar }) => {
+          openSidebar(NOTEBOOKS_SIDEBAR_COMPONENT_TITLE);
+        },
+      }),
+
+      // Alerts & IRM landing page card → notebooks as the incident note-taking surface.
+      createAddedLinkConfig({
+        title: 'Notebooks',
+        description: 'Capture incident investigation notes with live panels and share findings with your team',
+        targets: [IRM_LANDING_CARDS_EXTENSION_POINT],
+        icon: 'book-open',
+        configure: () => (notebooksEnabled() ? {} : undefined),
+        onClick: () => {
+          locationService.push('/notebooks');
+        },
+      }),
+
+      // Command palette → quick "New notebook" from anywhere (matches "New dashboard").
+      createAddedLinkConfig({
+        title: 'New notebook',
+        description: 'Create a new notebook to capture an investigation',
+        targets: [PluginExtensionPoints.CommandPalette],
+        icon: 'book-open',
+        category: 'Notebooks',
+        configure: () => {
+          if (!notebooksEnabled() || !canEditNotebooks()) {
+            return undefined;
+          }
+          return {};
+        },
+        onClick: async () => {
+          const created = await createNotebook(newNotebookSpec(newNotebookTitle()));
+          markNotebookAsNew(created.metadata.name);
+          locationService.push(notebookEditUrl(created.metadata.name));
+        },
+      }),
+    ];
+  } catch (error) {
+    console.warn('Could not configure notebook extensions', error);
+    return [];
+  }
+}

--- a/public/app/features/notebook/model/lastUsedNotebook.test.ts
+++ b/public/app/features/notebook/model/lastUsedNotebook.test.ts
@@ -1,0 +1,31 @@
+import { clearLastUsedNotebook, getLastUsedNotebook, setLastUsedNotebook } from './lastUsedNotebook';
+
+describe('lastUsedNotebook', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('round-trips the last used notebook', () => {
+    expect(getLastUsedNotebook()).toBeUndefined();
+
+    setLastUsedNotebook('nb123', 'Checkout latency investigation');
+    const value = getLastUsedNotebook();
+    expect(value?.uid).toBe('nb123');
+    expect(value?.title).toBe('Checkout latency investigation');
+    expect(value?.at).toBeGreaterThan(0);
+  });
+
+  it('ignores empty uids and clears correctly', () => {
+    setLastUsedNotebook('', 'nope');
+    expect(getLastUsedNotebook()).toBeUndefined();
+
+    setLastUsedNotebook('nb1', 'one');
+    clearLastUsedNotebook();
+    expect(getLastUsedNotebook()).toBeUndefined();
+  });
+
+  it('rejects malformed stored values', () => {
+    window.localStorage.setItem('grafana.notebooks.lastUsed', JSON.stringify({ nope: true }));
+    expect(getLastUsedNotebook()).toBeUndefined();
+  });
+});

--- a/public/app/features/notebook/model/lastUsedNotebook.ts
+++ b/public/app/features/notebook/model/lastUsedNotebook.ts
@@ -1,0 +1,34 @@
+import { store } from '@grafana/data';
+
+const LAST_USED_NOTEBOOK_KEY = 'grafana.notebooks.lastUsed';
+
+export interface LastUsedNotebook {
+  uid: string;
+  title: string;
+  at: number;
+}
+
+/**
+ * Remembers the notebook the user most recently created, opened or added to.
+ * Powers the "Add to last notebook" quick actions (Figma: the default notebook
+ * is the last used one) and the add-to-notebook form's default target.
+ */
+export function getLastUsedNotebook(): LastUsedNotebook | undefined {
+  const value = store.getObject<LastUsedNotebook>(LAST_USED_NOTEBOOK_KEY);
+  if (!value || typeof value.uid !== 'string' || value.uid === '' || typeof value.title !== 'string') {
+    return undefined;
+  }
+  return value;
+}
+
+export function setLastUsedNotebook(uid: string, title: string): void {
+  if (!uid) {
+    return;
+  }
+  store.setObject(LAST_USED_NOTEBOOK_KEY, { uid, title, at: Date.now() });
+}
+
+/** Called when a quick-add fails because the notebook no longer exists. */
+export function clearLastUsedNotebook(): void {
+  store.delete(LAST_USED_NOTEBOOK_KEY);
+}

--- a/public/app/features/notebook/model/newNotebookSignal.ts
+++ b/public/app/features/notebook/model/newNotebookSignal.ts
@@ -1,0 +1,16 @@
+// In-memory "this notebook was just created" signal between the create flows and
+// the editor. More reliable than a URL param, which router-level URL syncing can
+// drop before the editor reads it. Same-tab by design: creation and the editor
+// opening always happen in the same tab.
+const newNotebooks = new Set<string>();
+
+export function markNotebookAsNew(uid: string) {
+  newNotebooks.add(uid);
+}
+
+/** True (once) when the notebook was just created in this tab — used to focus the title. */
+export function consumeNewNotebook(uid: string): boolean {
+  const isNew = newNotebooks.has(uid);
+  newNotebooks.delete(uid);
+  return isNew;
+}

--- a/public/app/features/notebook/model/notebookSpec.test.ts
+++ b/public/app/features/notebook/model/notebookSpec.test.ts
@@ -1,0 +1,359 @@
+import { type PanelKind } from '@grafana/schema/apis/notebook/v2beta1';
+
+import {
+  clearCellTimeOverride,
+  DEFAULT_NOTEBOOK_TITLE,
+  duplicateCellAt,
+  insertElement,
+  isDefaultNotebookTitle,
+  moveCell,
+  newCodeElement,
+  newMarkdownElement,
+  newNotebookSpec,
+  newNotebookTitle,
+  newNotebookTitleDate,
+  newPanelForDatasource,
+  nextPanelId,
+  normalizeNotebookSpec,
+  removeCellAt,
+  resolveCells,
+  setCellCollapsed,
+  setCellHeight,
+  setCellTimeOverride,
+  setNotebookTimeRange,
+  updateCodeCell,
+  updateMarkdownText,
+  updatePanelQuery,
+  updatePanelTitle,
+  updatePanelViz,
+} from './notebookSpec';
+
+function newPanelElement(id = 0): PanelKind {
+  return {
+    kind: 'Panel',
+    spec: {
+      id,
+      title: 'CPU usage',
+      links: [],
+      data: { kind: 'QueryGroup', spec: { queries: [], transformations: [], queryOptions: {} } },
+      vizConfig: {
+        kind: 'VizConfig',
+        group: 'timeseries',
+        version: '',
+        spec: { options: {}, fieldConfig: { defaults: {}, overrides: [] } },
+      },
+    },
+  };
+}
+
+describe('notebookSpec', () => {
+  it('treats blank and legacy untitled titles as the default notebook title', () => {
+    expect(DEFAULT_NOTEBOOK_TITLE).toBe('Untitled notebook');
+    expect(isDefaultNotebookTitle(DEFAULT_NOTEBOOK_TITLE)).toBe(true);
+    expect(isDefaultNotebookTitle('  untitled notebook  ')).toBe(true);
+    expect(isDefaultNotebookTitle('')).toBe(true);
+    expect(isDefaultNotebookTitle('   ')).toBe(true);
+    expect(isDefaultNotebookTitle(undefined)).toBe(true);
+    expect(isDefaultNotebookTitle('Checkout latency')).toBe(false);
+    expect(isDefaultNotebookTitle(newNotebookTitle())).toBe(false);
+  });
+
+  it('names new notebooks with a stable month/day/year + time title', () => {
+    const now = new Date('2026-08-01T15:30:00Z');
+    // Explicit format (not toLocaleDateString) so titles stay readable across locales.
+    expect(newNotebookTitleDate(now)).toMatch(/^[A-Z][a-z]+ \d{1,2}, \d{4} \d{2}:\d{2}$/);
+    expect(newNotebookTitle(now)).toBe(`Investigation — ${newNotebookTitleDate(now)}`);
+    expect(newNotebookSpec().title.startsWith('Investigation — ')).toBe(true);
+  });
+
+  it('normalizes null arrays/maps from API-created notebooks', () => {
+    // Go marshals unset slices/maps as null; notebooks created directly through
+    // the resource API arrive like this and must not crash the UI.
+    const nullish = {
+      title: 'api notebook',
+      tags: null,
+      elements: null,
+      timeSettings: { from: 'now-6h', to: 'now', timezone: 'browser', autoRefresh: '', autoRefreshIntervals: null },
+      layout: { kind: 'NotebookLayout', spec: { cells: null } },
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- simulating the raw API payload shape
+    } as unknown as ReturnType<typeof newNotebookSpec>;
+
+    const spec = normalizeNotebookSpec(nullish);
+
+    expect(spec.tags).toEqual([]);
+    expect(spec.elements).toEqual({});
+    expect(spec.layout.spec.cells).toEqual([]);
+    expect(Array.isArray(spec.timeSettings.autoRefreshIntervals)).toBe(true);
+    expect(spec.timeSettings.autoRefreshIntervals!.length).toBeGreaterThan(0);
+    expect(resolveCells(spec)).toEqual([]);
+  });
+
+  it('updates one query of a panel element, stripping runtime-only keys', () => {
+    const base = newNotebookSpec('nb');
+    const panel = newPanelForDatasource({ uid: 'ds-uid', type: 'prometheus' });
+    const { spec, elementName } = insertElement(base, panel);
+
+    const updated = updatePanelQuery(spec, elementName, 'A', {
+      refId: 'A',
+      datasource: { uid: 'ds-uid', type: 'prometheus' },
+      hide: false,
+      expr: 'up',
+      instant: true,
+    });
+
+    const element = updated.elements[elementName];
+    if (element.kind !== 'Panel') {
+      throw new Error('expected panel element');
+    }
+    const query = element.spec.data.spec.queries[0];
+    expect(query.spec.refId).toBe('A');
+    expect(query.spec.query.spec).toEqual({ expr: 'up', instant: true });
+    // Datasource wiring on the envelope is untouched.
+    expect(query.spec.query.datasource?.name).toBe('ds-uid');
+    expect(query.spec.query.group).toBe('prometheus');
+    // Unknown refIds leave the spec unchanged.
+    expect(updatePanelQuery(updated, elementName, 'Z', { expr: 'down' })).toEqual(updated);
+  });
+
+  it('creates an empty notebook with the requested time range', () => {
+    const spec = newNotebookSpec('My investigation', { from: 'now-1h', to: 'now' });
+
+    expect(spec.title).toBe('My investigation');
+    expect(spec.timeSettings.from).toBe('now-1h');
+    expect(spec.timeSettings.to).toBe('now');
+    expect(spec.layout.spec.cells).toHaveLength(0);
+    expect(Object.keys(spec.elements)).toHaveLength(0);
+  });
+
+  it('inserts elements and keeps layout order', () => {
+    let spec = newNotebookSpec('nb');
+    const first = insertElement(spec, newMarkdownElement('# Findings'));
+    const second = insertElement(first.spec, newCodeElement('sql', 'SELECT 1'), { source: 'assistant' });
+    spec = second.spec;
+
+    const cells = resolveCells(spec);
+    expect(cells).toHaveLength(2);
+    expect(cells[0].elementName).toBe(first.elementName);
+    expect(cells[1].elementName).toBe(second.elementName);
+    expect(cells[1].source).toBe('assistant');
+  });
+
+  it('inserts at a specific index', () => {
+    let spec = newNotebookSpec('nb');
+    const a = insertElement(spec, newMarkdownElement('a'));
+    const b = insertElement(a.spec, newMarkdownElement('b'));
+    const middle = insertElement(b.spec, newMarkdownElement('middle'), { index: 1 });
+
+    const order = resolveCells(middle.spec).map((c) => c.elementName);
+    expect(order).toEqual([a.elementName, middle.elementName, b.elementName]);
+  });
+
+  it('assigns unique ids to inserted panels', () => {
+    let spec = newNotebookSpec('nb');
+    const first = insertElement(spec, newPanelElement());
+    const second = insertElement(first.spec, newPanelElement());
+    spec = second.spec;
+
+    const firstPanel = spec.elements[first.elementName];
+    const secondPanel = spec.elements[second.elementName];
+    if (firstPanel.kind !== 'Panel' || secondPanel.kind !== 'Panel') {
+      throw new Error('expected panels');
+    }
+    expect(firstPanel.spec.id).toBe(1);
+    expect(secondPanel.spec.id).toBe(2);
+    expect(nextPanelId(spec)).toBe(3);
+  });
+
+  it('removes a cell and its unreferenced element', () => {
+    let spec = newNotebookSpec('nb');
+    const a = insertElement(spec, newMarkdownElement('a'));
+    const b = insertElement(a.spec, newMarkdownElement('b'));
+    spec = removeCellAt(b.spec, 0);
+
+    expect(resolveCells(spec)).toHaveLength(1);
+    expect(spec.elements[a.elementName]).toBeUndefined();
+    expect(spec.elements[b.elementName]).toBeDefined();
+  });
+
+  it('moves cells within bounds and ignores out-of-range moves', () => {
+    let spec = newNotebookSpec('nb');
+    const a = insertElement(spec, newMarkdownElement('a'));
+    const b = insertElement(a.spec, newMarkdownElement('b'));
+    const c = insertElement(b.spec, newMarkdownElement('c'));
+    spec = c.spec;
+
+    const moved = moveCell(spec, 2, 0);
+    expect(resolveCells(moved).map((x) => x.elementName)).toEqual([c.elementName, a.elementName, b.elementName]);
+
+    expect(moveCell(spec, 5, 0)).toBe(spec);
+    expect(moveCell(spec, 0, 0)).toBe(spec);
+  });
+
+  it('updates markdown and code cells immutably', () => {
+    let spec = newNotebookSpec('nb');
+    const md = insertElement(spec, newMarkdownElement('old'));
+    const code = insertElement(md.spec, newCodeElement('sql', 'SELECT 1'));
+    spec = code.spec;
+
+    const updated = updateCodeCell(updateMarkdownText(spec, md.elementName, 'new'), code.elementName, {
+      code: 'SELECT 2',
+    });
+
+    const mdElement = updated.elements[md.elementName];
+    const codeElement = updated.elements[code.elementName];
+    if (mdElement.kind !== 'Cell' || mdElement.spec.content.kind !== 'Markdown') {
+      throw new Error('expected markdown cell');
+    }
+    if (codeElement.kind !== 'Cell' || codeElement.spec.content.kind !== 'Code') {
+      throw new Error('expected code cell');
+    }
+    expect(mdElement.spec.content.spec.text).toBe('new');
+    expect(codeElement.spec.content.spec.code).toBe('SELECT 2');
+    expect(codeElement.spec.content.spec.language).toBe('sql');
+
+    // original untouched
+    const originalMd = spec.elements[md.elementName];
+    if (originalMd.kind !== 'Cell' || originalMd.spec.content.kind !== 'Markdown') {
+      throw new Error('expected markdown cell');
+    }
+    expect(originalMd.spec.content.spec.text).toBe('old');
+  });
+
+  it('updates the time range without dropping other settings', () => {
+    const spec = newNotebookSpec('nb');
+    const updated = setNotebookTimeRange(spec, 'now-24h', 'now');
+    expect(updated.timeSettings.from).toBe('now-24h');
+    expect(updated.timeSettings.to).toBe('now');
+    expect(updated.timeSettings.autoRefreshIntervals).toEqual(spec.timeSettings.autoRefreshIntervals);
+  });
+
+  it('duplicates a cell with a fresh element name and unique panel id', () => {
+    let spec = newNotebookSpec('nb');
+    const md = insertElement(spec, newMarkdownElement('copy me'));
+    const panel = insertElement(md.spec, newPanelElement());
+    spec = setCellHeight(panel.spec, 1, 480);
+
+    const duplicated = duplicateCellAt(spec, 1);
+    const cells = resolveCells(duplicated);
+
+    expect(cells).toHaveLength(3);
+    expect(cells[2].elementName).not.toBe(panel.elementName);
+    expect(cells[2].height).toBe(480);
+    const original = duplicated.elements[panel.elementName];
+    const copy = duplicated.elements[cells[2].elementName];
+    if (original.kind !== 'Panel' || copy.kind !== 'Panel') {
+      throw new Error('expected panels');
+    }
+    expect(copy.spec.title).toBe(original.spec.title);
+    expect(copy.spec.id).not.toBe(original.spec.id);
+
+    // duplicating an out-of-range index is a no-op
+    expect(duplicateCellAt(duplicated, 99)).toBe(duplicated);
+  });
+
+  it('toggles collapsed and sets height on layout items', () => {
+    let spec = newNotebookSpec('nb');
+    spec = insertElement(spec, newMarkdownElement('a')).spec;
+
+    const collapsed = setCellCollapsed(spec, 0, true);
+    expect(resolveCells(collapsed)[0].collapsed).toBe(true);
+
+    const expanded = setCellCollapsed(collapsed, 0, false);
+    expect(resolveCells(expanded)[0].collapsed).toBeUndefined();
+
+    const sized = setCellHeight(expanded, 0, 456.7);
+    expect(resolveCells(sized)[0].height).toBe(457);
+
+    expect(setCellHeight(sized, 5, 100)).toBe(sized);
+  });
+
+  it('renames panel elements only', () => {
+    let spec = newNotebookSpec('nb');
+    const md = insertElement(spec, newMarkdownElement('a'));
+    const panel = insertElement(md.spec, newPanelElement());
+    spec = panel.spec;
+
+    const renamed = updatePanelTitle(spec, panel.elementName, 'Renamed panel');
+    const element = renamed.elements[panel.elementName];
+    if (element.kind !== 'Panel') {
+      throw new Error('expected panel');
+    }
+    expect(element.spec.title).toBe('Renamed panel');
+
+    expect(updatePanelTitle(spec, md.elementName, 'nope')).toBe(spec);
+    expect(updatePanelTitle(spec, 'missing', 'nope')).toBe(spec);
+  });
+
+  it('locks and unlocks a per-cell time range', () => {
+    let spec = newNotebookSpec('nb');
+    spec = insertElement(spec, newPanelElement()).spec;
+
+    const locked = setCellTimeOverride(spec, 0, '2026-07-31T16:00:00Z', '2026-07-31T17:00:00Z');
+    const lockedCell = resolveCells(locked)[0];
+    expect(lockedCell.timeFrom).toBe('2026-07-31T16:00:00Z');
+    expect(lockedCell.timeTo).toBe('2026-07-31T17:00:00Z');
+
+    const unlocked = clearCellTimeOverride(locked, 0);
+    const unlockedCell = resolveCells(unlocked)[0];
+    expect(unlockedCell.timeFrom).toBeUndefined();
+    expect(unlockedCell.timeTo).toBeUndefined();
+  });
+
+  it('inserts elements with a time override', () => {
+    const spec = newNotebookSpec('nb');
+    const { spec: withPanel } = insertElement(spec, newPanelElement(), {
+      timeOverride: { from: '2026-07-31T16:00:00Z', to: '2026-07-31T17:00:00Z' },
+    });
+    const cell = resolveCells(withPanel)[0];
+    expect(cell.timeFrom).toBe('2026-07-31T16:00:00Z');
+    expect(cell.timeTo).toBe('2026-07-31T17:00:00Z');
+  });
+
+  it('swaps a panel visualization while keeping queries', () => {
+    let spec = newNotebookSpec('nb');
+    const panel = insertElement(spec, newPanelElement());
+    spec = panel.spec;
+
+    const swapped = updatePanelViz(spec, panel.elementName, {
+      pluginId: 'stat',
+      options: { textMode: 'auto' },
+    });
+
+    const element = swapped.elements[panel.elementName];
+    if (element.kind !== 'Panel') {
+      throw new Error('expected panel');
+    }
+    expect(element.spec.vizConfig.group).toBe('stat');
+    expect(element.spec.vizConfig.spec.options).toEqual({ textMode: 'auto' });
+    expect(element.spec.data.spec.queries).toEqual(
+      (() => {
+        const original = spec.elements[panel.elementName];
+        return original.kind === 'Panel' ? original.spec.data.spec.queries : [];
+      })()
+    );
+
+    expect(updatePanelViz(spec, 'missing', { pluginId: 'stat' })).toBe(spec);
+  });
+
+  it('drops dangling element references when resolving cells', () => {
+    let spec = newNotebookSpec('nb');
+    const a = insertElement(spec, newMarkdownElement('a'));
+    spec = {
+      ...a.spec,
+      layout: {
+        ...a.spec.layout,
+        spec: {
+          cells: [
+            ...a.spec.layout.spec.cells,
+            {
+              kind: 'NotebookLayoutItem',
+              spec: { element: { kind: 'ElementReference', name: 'missing' }, source: 'user' },
+            },
+          ],
+        },
+      },
+    };
+
+    expect(resolveCells(spec)).toHaveLength(1);
+  });
+});

--- a/public/app/features/notebook/model/notebookSpec.ts
+++ b/public/app/features/notebook/model/notebookSpec.ts
@@ -1,0 +1,504 @@
+import { nanoid } from 'nanoid';
+
+import { dateTimeFormat } from '@grafana/data';
+import {
+  defaultTimeSettingsSpec,
+  type CellKind,
+  type NotebookElement,
+  type NotebookLayoutItemKind,
+  type PanelKind,
+  type Spec as NotebookSpec,
+} from '@grafana/schema/apis/notebook/v2beta1';
+
+export type CellSource = NotebookLayoutItemKind['spec']['source'];
+
+type NotebookLayoutItemSpecWithPresentation = NotebookLayoutItemKind['spec'] & {
+  height?: number;
+  timeFrom?: string;
+  timeTo?: string;
+};
+
+/** A notebook cell paired with the element it references, resolved for rendering/editing. */
+export interface ResolvedCell {
+  /** Element name in the spec's elements map — also used as the stable React key. */
+  elementName: string;
+  source: CellSource;
+  collapsed?: boolean;
+  /** Rendered height in pixels for panel cells. */
+  height?: number;
+  /** When both set, the panel is locked to this time range instead of the notebook's. */
+  timeFrom?: string;
+  timeTo?: string;
+  element: NotebookElement;
+}
+
+/**
+ * Repairs specs that arrive from the API with `null` where the UI expects arrays/maps.
+ * Go marshals unset slices and maps as `null` (no omitempty), so notebooks created
+ * directly through the resource API — rather than this UI — need this on load.
+ */
+export function normalizeNotebookSpec(spec: NotebookSpec): NotebookSpec {
+  return {
+    ...spec,
+    tags: spec.tags ?? [],
+    elements: spec.elements ?? {},
+    timeSettings: {
+      ...spec.timeSettings,
+      autoRefreshIntervals: spec.timeSettings.autoRefreshIntervals ?? defaultTimeSettingsSpec().autoRefreshIntervals,
+    },
+    layout: {
+      ...spec.layout,
+      spec: { ...spec.layout.spec, cells: spec.layout.spec.cells ?? [] },
+    },
+  };
+}
+
+/**
+ * Legacy / empty-title fallback shown in the editor when a notebook has no name.
+ * New notebooks are created with {@link newNotebookTitle} instead.
+ */
+export const DEFAULT_NOTEBOOK_TITLE = 'Untitled notebook';
+
+/** True when the title is missing/blank or still the legacy untitled placeholder. */
+export function isDefaultNotebookTitle(title: string | undefined | null): boolean {
+  const trimmed = title?.trim() ?? '';
+  return !trimmed || trimmed.toLowerCase() === DEFAULT_NOTEBOOK_TITLE.toLowerCase();
+}
+
+/**
+ * Stable date/time segment for {@link newNotebookTitle} (also for i18n `{{date}}`).
+ * Uses an explicit month/day/year + time format so locale quirks from
+ * `toLocaleDateString()` don't produce unreadable titles.
+ */
+export function newNotebookTitleDate(now: Date = new Date()): string {
+  return dateTimeFormat(now, { format: 'MMMM D, YYYY HH:mm', timeZone: 'browser' });
+}
+
+/**
+ * Title for newly created notebooks — dated so capture/quick-add targets are easy
+ * to find later (list, sidebar, command palette, add-to-notebook).
+ * Example: `Investigation — August 1, 2026 16:30`
+ */
+export function newNotebookTitle(now: Date = new Date()): string {
+  return `Investigation — ${newNotebookTitleDate(now)}`;
+}
+
+export function newNotebookSpec(
+  title: string = newNotebookTitle(),
+  options?: { description?: string; from?: string; to?: string }
+): NotebookSpec {
+  const timeSettings = defaultTimeSettingsSpec();
+  if (options?.from) {
+    timeSettings.from = options.from;
+  }
+  if (options?.to) {
+    timeSettings.to = options.to;
+  }
+
+  return {
+    title,
+    description: options?.description,
+    tags: [],
+    timeSettings,
+    elements: {},
+    layout: { kind: 'NotebookLayout', spec: { cells: [] } },
+  };
+}
+
+export function newMarkdownElement(text = ''): CellKind {
+  return { kind: 'Cell', spec: { content: { kind: 'Markdown', spec: { text } } } };
+}
+
+export function newCodeElement(language = '', code = ''): CellKind {
+  return { kind: 'Cell', spec: { content: { kind: 'Code', spec: { language, code } } } };
+}
+
+/** The visualization that best fits what a datasource type typically returns. */
+function defaultVizForDatasource(datasourceType: string): string {
+  switch (datasourceType) {
+    case 'loki':
+      return 'logs';
+    case 'tempo':
+    case 'jaeger':
+    case 'zipkin':
+      return 'traces';
+    case 'grafana-pyroscope-datasource':
+    case 'parca':
+      return 'flamegraph';
+    case 'mysql':
+    case 'postgres':
+    case 'mssql':
+      return 'table';
+    default:
+      return 'timeseries';
+  }
+}
+
+/**
+ * A fresh panel wired to a datasource with one empty query — the in-editor
+ * "Add visualization" starting point. The id is reassigned on insert.
+ */
+export function newPanelForDatasource(
+  datasource: { uid: string; type: string },
+  options?: { title?: string; querySpec?: Record<string, unknown>; vizType?: string }
+): PanelKind {
+  return {
+    kind: 'Panel',
+    spec: {
+      id: 0,
+      title: options?.title ?? '',
+      links: [],
+      data: {
+        kind: 'QueryGroup',
+        spec: {
+          queries: [
+            {
+              kind: 'PanelQuery',
+              spec: {
+                refId: 'A',
+                hidden: false,
+                query: {
+                  kind: 'DataQuery',
+                  group: datasource.type,
+                  version: 'v0',
+                  datasource: { name: datasource.uid },
+                  spec: options?.querySpec ?? {},
+                },
+              },
+            },
+          ],
+          transformations: [],
+          queryOptions: {},
+        },
+      },
+      vizConfig: {
+        kind: 'VizConfig',
+        group: options?.vizType ?? defaultVizForDatasource(datasource.type),
+        version: '',
+        spec: { options: {}, fieldConfig: { defaults: {}, overrides: [] } },
+      },
+    },
+  };
+}
+
+/**
+ * Replaces one query of a panel element with an edited data query. The runtime-only
+ * keys (refId, datasource, hide) live on the query envelope, not in the stored spec.
+ * When `datasource` is provided the envelope's datasource wiring is updated too.
+ */
+export function updatePanelQuery(
+  spec: NotebookSpec,
+  elementName: string,
+  refId: string,
+  dataQuery: Record<string, unknown>,
+  datasource?: { uid: string; type: string }
+): NotebookSpec {
+  const element = spec.elements[elementName];
+  if (!element || element.kind !== 'Panel') {
+    return spec;
+  }
+
+  const { refId: _refId, datasource: _datasource, hide: _hide, ...querySpec } = dataQuery;
+
+  const queries = element.spec.data.spec.queries.map((query) =>
+    query.spec.refId === refId
+      ? {
+          ...query,
+          spec: {
+            ...query.spec,
+            query: {
+              ...query.spec.query,
+              ...(datasource ? { group: datasource.type, datasource: { name: datasource.uid } } : {}),
+              spec: querySpec,
+            },
+          },
+        }
+      : query
+  );
+
+  return {
+    ...spec,
+    elements: {
+      ...spec.elements,
+      [elementName]: {
+        ...element,
+        spec: {
+          ...element.spec,
+          data: { ...element.spec.data, spec: { ...element.spec.data.spec, queries } },
+        },
+      },
+    },
+  };
+}
+
+/** Panel ids must be unique within a notebook: scene panel keys are derived from them. */
+export function nextPanelId(spec: NotebookSpec): number {
+  let max = 0;
+  for (const element of Object.values(spec.elements)) {
+    if (element.kind === 'Panel' || element.kind === 'LibraryPanel') {
+      max = Math.max(max, element.spec.id);
+    }
+  }
+  return max + 1;
+}
+
+function elementNamePrefix(element: NotebookElement): string {
+  if (element.kind === 'Panel' || element.kind === 'LibraryPanel') {
+    return 'panel';
+  }
+  return element.spec.content.kind === 'Code' ? 'code' : 'md';
+}
+
+/**
+ * Adds an element to the notebook and references it from a new layout cell.
+ * Panels get a fresh unique numeric id. Returns the new spec and the generated
+ * element name (which doubles as the cell key).
+ */
+export function insertElement(
+  spec: NotebookSpec,
+  element: NotebookElement,
+  options?: { source?: CellSource; index?: number; timeOverride?: { from: string; to: string } }
+): { spec: NotebookSpec; elementName: string } {
+  const elementName = `${elementNamePrefix(element)}-${nanoid(8)}`;
+
+  let toInsert = element;
+  if (element.kind === 'Panel') {
+    toInsert = { ...element, spec: { ...element.spec, id: nextPanelId(spec) } };
+  } else if (element.kind === 'LibraryPanel') {
+    toInsert = { ...element, spec: { ...element.spec, id: nextPanelId(spec) } };
+  }
+
+  const cell: NotebookLayoutItemKind = {
+    kind: 'NotebookLayoutItem',
+    spec: {
+      element: { kind: 'ElementReference', name: elementName },
+      source: options?.source ?? 'user',
+      ...(options?.timeOverride ? { timeFrom: options.timeOverride.from, timeTo: options.timeOverride.to } : {}),
+    },
+  };
+
+  const cells = [...spec.layout.spec.cells];
+  const index = options?.index ?? cells.length;
+  cells.splice(Math.max(0, Math.min(index, cells.length)), 0, cell);
+
+  return {
+    spec: {
+      ...spec,
+      elements: { ...spec.elements, [elementName]: toInsert },
+      layout: { ...spec.layout, spec: { cells } },
+    },
+    elementName,
+  };
+}
+
+/** Removes the layout cell at `index` and its element when nothing else references it. */
+export function removeCellAt(spec: NotebookSpec, index: number): NotebookSpec {
+  const cells = spec.layout.spec.cells;
+  const cell = cells[index];
+  if (!cell) {
+    return spec;
+  }
+
+  const remaining = cells.filter((_, i) => i !== index);
+  const elementName = cell.spec.element.name;
+  const stillReferenced = remaining.some((c) => c.spec.element.name === elementName);
+
+  let elements = spec.elements;
+  if (!stillReferenced) {
+    elements = { ...spec.elements };
+    delete elements[elementName];
+  }
+
+  return { ...spec, elements, layout: { ...spec.layout, spec: { cells: remaining } } };
+}
+
+export function moveCell(spec: NotebookSpec, from: number, to: number): NotebookSpec {
+  const cells = [...spec.layout.spec.cells];
+  if (from < 0 || from >= cells.length || to < 0 || to >= cells.length || from === to) {
+    return spec;
+  }
+  const [cell] = cells.splice(from, 1);
+  cells.splice(to, 0, cell);
+  return { ...spec, layout: { ...spec.layout, spec: { cells } } };
+}
+
+/** Deep-copies the cell at `index` (element included) and inserts the copy right below it. */
+export function duplicateCellAt(spec: NotebookSpec, index: number): NotebookSpec {
+  const cell = spec.layout.spec.cells[index];
+  const element = cell && spec.elements[cell.spec.element.name];
+  if (!cell || !element) {
+    return spec;
+  }
+
+  const cellSpec: NotebookLayoutItemSpecWithPresentation = cell.spec;
+
+  const copy: NotebookElement = JSON.parse(JSON.stringify(element));
+  const { spec: withCopy, elementName } = insertElement(spec, copy, {
+    source: cellSpec.source,
+    index: index + 1,
+  });
+
+  // Carry over the layout-item presentation (collapsed/height/time lock) onto the new cell.
+  const cells = withCopy.layout.spec.cells.map((item) =>
+    item.spec.element.name === elementName
+      ? {
+          ...item,
+          spec: {
+            ...item.spec,
+            collapsed: cellSpec.collapsed,
+            height: cellSpec.height,
+            timeFrom: cellSpec.timeFrom,
+            timeTo: cellSpec.timeTo,
+          },
+        }
+      : item
+  );
+
+  return { ...withCopy, layout: { ...withCopy.layout, spec: { cells } } };
+}
+
+function updateLayoutItemAt(
+  spec: NotebookSpec,
+  index: number,
+  changes: Partial<Pick<NotebookLayoutItemSpecWithPresentation, 'collapsed' | 'height' | 'timeFrom' | 'timeTo'>>
+): NotebookSpec {
+  const cells = spec.layout.spec.cells;
+  if (!cells[index]) {
+    return spec;
+  }
+  const updated = cells.map((item, i) => (i === index ? { ...item, spec: { ...item.spec, ...changes } } : item));
+  return { ...spec, layout: { ...spec.layout, spec: { cells: updated } } };
+}
+
+export function setCellCollapsed(spec: NotebookSpec, index: number, collapsed: boolean): NotebookSpec {
+  return updateLayoutItemAt(spec, index, { collapsed: collapsed ? true : undefined });
+}
+
+export function setCellHeight(spec: NotebookSpec, index: number, height: number): NotebookSpec {
+  return updateLayoutItemAt(spec, index, { height: Math.round(height) });
+}
+
+/** Locks a panel cell to its own time range instead of the notebook's global one. */
+export function setCellTimeOverride(spec: NotebookSpec, index: number, from: string, to: string): NotebookSpec {
+  return updateLayoutItemAt(spec, index, { timeFrom: from, timeTo: to });
+}
+
+/** Syncs a panel cell back to the notebook's global time range. */
+export function clearCellTimeOverride(spec: NotebookSpec, index: number): NotebookSpec {
+  return updateLayoutItemAt(spec, index, { timeFrom: undefined, timeTo: undefined });
+}
+
+/** Swaps a panel's visualization (from a suggestion), keeping its queries. */
+export function updatePanelViz(
+  spec: NotebookSpec,
+  elementName: string,
+  viz: { pluginId: string; options?: unknown; fieldConfig?: unknown }
+): NotebookSpec {
+  const element = spec.elements[elementName];
+  if (!element || element.kind !== 'Panel') {
+    return spec;
+  }
+  return {
+    ...spec,
+    elements: {
+      ...spec.elements,
+      [elementName]: {
+        ...element,
+        spec: {
+          ...element.spec,
+          vizConfig: {
+            kind: 'VizConfig',
+            group: viz.pluginId,
+            version: '',
+            spec: {
+              // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- suggestion options/fieldConfig are stored as-is, same seam as dashboard capture
+              options: (viz.options ?? {}) as Record<string, unknown>,
+              // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- suggestion options/fieldConfig are stored as-is, same seam as dashboard capture
+              fieldConfig: (viz.fieldConfig ?? {
+                defaults: {},
+                overrides: [],
+              }) as PanelKind['spec']['vizConfig']['spec']['fieldConfig'],
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+export function updatePanelTitle(spec: NotebookSpec, elementName: string, title: string): NotebookSpec {
+  const element = spec.elements[elementName];
+  if (!element || element.kind !== 'Panel') {
+    return spec;
+  }
+  return {
+    ...spec,
+    elements: { ...spec.elements, [elementName]: { ...element, spec: { ...element.spec, title } } },
+  };
+}
+
+export function updateMarkdownText(spec: NotebookSpec, elementName: string, text: string): NotebookSpec {
+  const element = spec.elements[elementName];
+  if (!element || element.kind !== 'Cell' || element.spec.content.kind !== 'Markdown') {
+    return spec;
+  }
+  const updated: CellKind = { ...element, spec: { content: { kind: 'Markdown', spec: { text } } } };
+  return { ...spec, elements: { ...spec.elements, [elementName]: updated } };
+}
+
+export function updateCodeCell(
+  spec: NotebookSpec,
+  elementName: string,
+  changes: { language?: string; code?: string }
+): NotebookSpec {
+  const element = spec.elements[elementName];
+  if (!element || element.kind !== 'Cell' || element.spec.content.kind !== 'Code') {
+    return spec;
+  }
+  const content = element.spec.content;
+  const updated: CellKind = {
+    ...element,
+    spec: {
+      content: {
+        kind: 'Code',
+        spec: {
+          ...content.spec,
+          language: changes.language ?? content.spec.language,
+          code: changes.code ?? content.spec.code,
+        },
+      },
+    },
+  };
+  return { ...spec, elements: { ...spec.elements, [elementName]: updated } };
+}
+
+export function setNotebookTitle(spec: NotebookSpec, title: string): NotebookSpec {
+  return { ...spec, title };
+}
+
+export function setNotebookTimeRange(spec: NotebookSpec, from: string, to: string): NotebookSpec {
+  return { ...spec, timeSettings: { ...spec.timeSettings, from, to } };
+}
+
+/** Resolves layout cells against the elements map, dropping dangling references. */
+export function resolveCells(spec: NotebookSpec): ResolvedCell[] {
+  const result: ResolvedCell[] = [];
+  for (const cell of spec.layout.spec.cells) {
+    const cellSpec: NotebookLayoutItemSpecWithPresentation = cell.spec;
+    const elementName = cellSpec.element.name;
+    const element = spec.elements[elementName];
+    if (!element) {
+      continue;
+    }
+    result.push({
+      elementName,
+      source: cellSpec.source,
+      collapsed: cellSpec.collapsed,
+      height: cellSpec.height,
+      timeFrom: cellSpec.timeFrom,
+      timeTo: cellSpec.timeTo,
+      element,
+    });
+  }
+  return result;
+}

--- a/public/app/features/notebook/model/notebookToMarkdown.test.ts
+++ b/public/app/features/notebook/model/notebookToMarkdown.test.ts
@@ -1,0 +1,75 @@
+import { type PanelKind } from '@grafana/schema/apis/notebook/v2beta1';
+
+import { insertElement, newCodeElement, newMarkdownElement, newNotebookSpec } from './notebookSpec';
+import { notebookToMarkdown } from './notebookToMarkdown';
+
+function panelElement(): PanelKind {
+  return {
+    kind: 'Panel',
+    spec: {
+      id: 1,
+      title: 'Latency p99',
+      subtitle: 'From dashboard: Checkout',
+      links: [],
+      data: {
+        kind: 'QueryGroup',
+        spec: {
+          queries: [
+            {
+              kind: 'PanelQuery',
+              spec: {
+                refId: 'A',
+                hidden: false,
+                query: {
+                  kind: 'DataQuery',
+                  group: 'prometheus',
+                  version: 'v0',
+                  datasource: { name: 'prom-1' },
+                  spec: { expr: 'histogram_quantile(0.99, http_request_duration_seconds_bucket)' },
+                },
+              },
+            },
+          ],
+          transformations: [],
+          queryOptions: {},
+        },
+      },
+      vizConfig: {
+        kind: 'VizConfig',
+        group: 'timeseries',
+        version: '',
+        spec: { options: {}, fieldConfig: { defaults: {}, overrides: [] } },
+      },
+    },
+  };
+}
+
+describe('notebookToMarkdown', () => {
+  it('serializes title, meta and all cell types', () => {
+    let spec = newNotebookSpec('Checkout investigation', { description: 'Latency spike', from: 'now-1h', to: 'now' });
+    spec = { ...spec, tags: ['incident'] };
+    spec = insertElement(spec, newMarkdownElement('## Symptoms\n\nLatency **spiked**.')).spec;
+    spec = insertElement(spec, newCodeElement('sql', 'SELECT 1;')).spec;
+    spec = insertElement(spec, panelElement()).spec;
+
+    const markdown = notebookToMarkdown(spec, { notebookUrl: 'https://grafana.example/notebook/abc' });
+
+    expect(markdown).toContain('# Checkout investigation');
+    expect(markdown).toContain('Latency spike');
+    expect(markdown).toContain('_Time range: now-1h → now_');
+    expect(markdown).toContain('_Tags: incident_');
+    expect(markdown).toContain('_Notebook: https://grafana.example/notebook/abc_');
+    expect(markdown).toContain('## Symptoms');
+    expect(markdown).toContain('```sql\nSELECT 1;\n```');
+    expect(markdown).toContain('> 📊 **Latency p99** (timeseries)');
+    expect(markdown).toContain('> From dashboard: Checkout');
+    expect(markdown).toContain('`A` (prometheus): `histogram_quantile');
+  });
+
+  it('skips empty markdown cells', () => {
+    let spec = newNotebookSpec('nb');
+    spec = insertElement(spec, newMarkdownElement('   ')).spec;
+    const markdown = notebookToMarkdown(spec);
+    expect(markdown).toBe('# nb\n\n_Time range: now-6h → now_\n');
+  });
+});

--- a/public/app/features/notebook/model/notebookToMarkdown.ts
+++ b/public/app/features/notebook/model/notebookToMarkdown.ts
@@ -1,0 +1,74 @@
+import { type Spec as NotebookSpec } from '@grafana/schema/apis/notebook/v2beta1';
+
+import { resolveCells } from './notebookSpec';
+
+/**
+ * Serializes a notebook to plain markdown for sharing (Slack, docs, PRs).
+ * Panels can't be embedded in markdown, so they become a compact blockquote
+ * with the panel title, provenance and queries.
+ */
+export function notebookToMarkdown(spec: NotebookSpec, options?: { notebookUrl?: string }): string {
+  const parts: string[] = [`# ${spec.title}`.trimEnd()];
+
+  if (spec.description) {
+    parts.push(spec.description);
+  }
+
+  const meta = [`_Time range: ${spec.timeSettings.from} → ${spec.timeSettings.to}_`];
+  if (spec.tags.length > 0) {
+    meta.push(`_Tags: ${spec.tags.join(', ')}_`);
+  }
+  if (options?.notebookUrl) {
+    meta.push(`_Notebook: ${options.notebookUrl}_`);
+  }
+  parts.push(meta.join('\n'));
+
+  for (const cell of resolveCells(spec)) {
+    const { element } = cell;
+
+    if (element.kind === 'Panel') {
+      const lines = [`> 📊 **${element.spec.title || 'Panel'}** (${element.spec.vizConfig.group})`];
+      if (element.spec.subtitle) {
+        lines.push(`> ${element.spec.subtitle}`);
+      }
+      for (const query of element.spec.data.spec.queries) {
+        const summary = summarizeQuery(query.spec.query.spec);
+        lines.push(`> - \`${query.spec.refId}\` (${query.spec.query.group}): \`${summary}\``);
+      }
+      parts.push(lines.join('\n'));
+      continue;
+    }
+
+    if (element.kind === 'LibraryPanel') {
+      parts.push(`> 📊 **${element.spec.title || 'Library panel'}** (library panel)`);
+      continue;
+    }
+
+    const content = element.spec.content;
+    if (content.kind === 'Markdown') {
+      if (content.spec.text.trim()) {
+        parts.push(content.spec.text.trim());
+      }
+      continue;
+    }
+
+    parts.push(`\`\`\`${content.spec.language}\n${content.spec.code}\n\`\`\``);
+  }
+
+  return parts.join('\n\n') + '\n';
+}
+
+function summarizeQuery(query: Record<string, unknown>): string {
+  // Prefer the human-readable query expression when the datasource has one.
+  for (const key of ['expr', 'query', 'rawSql', 'target']) {
+    const value = query[key];
+    if (typeof value === 'string' && value.trim()) {
+      return truncate(value.trim(), 120);
+    }
+  }
+  return truncate(JSON.stringify(query), 120);
+}
+
+function truncate(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max)}…` : value;
+}

--- a/public/app/features/notebook/model/preferredViz.test.ts
+++ b/public/app/features/notebook/model/preferredViz.test.ts
@@ -1,0 +1,39 @@
+import { FieldType, LoadingState, getDefaultTimeRange, toDataFrame, type PanelData } from '@grafana/data';
+
+import { preferredVizForData } from './preferredViz';
+
+function dataWith(frames: Array<ReturnType<typeof toDataFrame>>): PanelData {
+  return { state: LoadingState.Done, series: frames, timeRange: getDefaultTimeRange() };
+}
+
+describe('preferredVizForData', () => {
+  it('uses an explicit preferred plugin id from frame meta first', () => {
+    const frame = toDataFrame({ fields: [{ name: 'value', type: FieldType.number, values: [1] }] });
+    frame.meta = { preferredVisualisationPluginId: 'nodeGraph', preferredVisualisationType: 'logs' };
+    expect(preferredVizForData(dataWith([frame]))).toBe('nodeGraph');
+  });
+
+  it('maps preferred visualisation types to panel plugins', () => {
+    const frame = toDataFrame({ fields: [{ name: 'line', type: FieldType.string, values: ['a'] }] });
+    frame.meta = { preferredVisualisationType: 'logs' };
+    expect(preferredVizForData(dataWith([frame]))).toBe('logs');
+  });
+
+  it('detects time series shapes and falls back to table otherwise', () => {
+    const timeSeries = toDataFrame({
+      fields: [
+        { name: 'time', type: FieldType.time, values: [1, 2] },
+        { name: 'value', type: FieldType.number, values: [1, 2] },
+      ],
+    });
+    expect(preferredVizForData(dataWith([timeSeries]))).toBe('timeseries');
+
+    const tabular = toDataFrame({
+      fields: [
+        { name: 'name', type: FieldType.string, values: ['a'] },
+        { name: 'count', type: FieldType.number, values: [1] },
+      ],
+    });
+    expect(preferredVizForData(dataWith([tabular]))).toBe('table');
+  });
+});

--- a/public/app/features/notebook/model/preferredViz.ts
+++ b/public/app/features/notebook/model/preferredViz.ts
@@ -1,0 +1,38 @@
+import { isTimeSeriesFrames, type PanelData } from '@grafana/data';
+
+/**
+ * Picks the visualization that makes the most sense for returned data, using the
+ * frames' own metadata (same approach as the saved-queries inline editor):
+ * 1. an explicit preferred panel plugin declared by the datasource on the frame meta,
+ * 2. the preferred visualisation type (logs, traces, node graph, flame graph, ...),
+ * 3. time series heuristic, falling back to table for anything not graphable.
+ */
+export function preferredVizForData(data: PanelData): string {
+  const frames = data.series;
+
+  const preferredPluginId = frames.find((frame) => frame.meta?.preferredVisualisationPluginId)?.meta
+    ?.preferredVisualisationPluginId;
+  if (preferredPluginId) {
+    return preferredPluginId;
+  }
+
+  const preferredType = frames.find((frame) => frame.meta?.preferredVisualisationType)?.meta
+    ?.preferredVisualisationType;
+  switch (preferredType) {
+    case 'graph':
+      return 'timeseries';
+    case 'logs':
+      return 'logs';
+    case 'trace':
+      return 'traces';
+    case 'nodeGraph':
+      return 'nodeGraph';
+    case 'flamegraph':
+      return 'flamegraph';
+    case 'table':
+    case 'rawPrometheus':
+      return 'table';
+  }
+
+  return isTimeSeriesFrames(frames) ? 'timeseries' : 'table';
+}

--- a/public/app/features/notebook/model/timeFormat.ts
+++ b/public/app/features/notebook/model/timeFormat.ts
@@ -1,0 +1,14 @@
+import { rangeUtil, type RawTimeRange } from '@grafana/data';
+
+export function rawToString(value: RawTimeRange['from']): string {
+  return typeof value === 'string' ? value : value.toISOString();
+}
+
+/** Locked ranges are usually absolute timestamps; show them in a readable local format. */
+export function formatLockedRange(from: string, to: string): string {
+  const range = rangeUtil.convertRawToRange({ from, to });
+  if (rangeUtil.isRelativeTimeRange({ from, to })) {
+    return `${from} → ${to}`;
+  }
+  return `${range.from.format('MMM D, HH:mm')} → ${range.to.format('HH:mm')}`;
+}

--- a/public/app/features/notebook/pages/NotebookEditorPage.tsx
+++ b/public/app/features/notebook/pages/NotebookEditorPage.tsx
@@ -1,0 +1,21 @@
+import { useParams } from 'react-router-dom-v5-compat';
+
+import { useFlagDashboardNotebooks } from '@grafana/runtime/internal';
+import { PageNotFound } from 'app/core/components/PageNotFound/PageNotFound';
+
+import { NotebookEditor } from '../editor/NotebookEditor';
+
+export function NotebookEditorPage() {
+  // Routes are registered unconditionally (same as NotebookScenePage), so the
+  // feature flag is enforced here.
+  const notebooksEnabled = useFlagDashboardNotebooks();
+  const { uid } = useParams();
+
+  if (!notebooksEnabled || !uid) {
+    return <PageNotFound />;
+  }
+
+  return <NotebookEditor uid={uid} />;
+}
+
+export default NotebookEditorPage;

--- a/public/app/features/notebook/pages/NotebookScenePage.tsx
+++ b/public/app/features/notebook/pages/NotebookScenePage.tsx
@@ -1,21 +1,31 @@
 import { css } from '@emotion/css';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom-v5-compat';
 
-import { type GrafanaTheme2, PageLayoutType } from '@grafana/data';
+import { AppEvents, type GrafanaTheme2, PageLayoutType } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { locationService } from '@grafana/runtime';
 import { useFlagDashboardNotebooks } from '@grafana/runtime/internal';
 import { UrlSyncContextProvider } from '@grafana/scenes';
-import { Box, useStyles2 } from '@grafana/ui';
+import { Box, Button, ConfirmModal, Dropdown, IconButton, LinkButton, Menu, useStyles2 } from '@grafana/ui';
+import { appEvents } from 'app/core/app_events';
 import { Page } from 'app/core/components/Page/Page';
 import PageLoader from 'app/core/components/PageLoader/PageLoader';
 import { PageNotFound } from 'app/core/components/PageNotFound/PageNotFound';
+import { contextSrv } from 'app/core/services/context_srv';
+import { copyStringToClipboard } from 'app/core/utils/explore';
 import { DashboardPageError } from 'app/features/dashboard/containers/DashboardPageError';
 import { type DashboardControls } from 'app/features/dashboard-scene/scene/DashboardControls';
 import { type DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
+import { NotebookLayoutManager } from 'app/features/dashboard-scene/scene/layout-notebook/NotebookLayoutManager';
+import { AccessControlAction } from 'app/types/accessControl';
 import { DashboardRoutes } from 'app/types/dashboard';
 
+import { deleteNotebook, duplicateNotebook, fetchNotebook, notebookEditUrl } from '../api/notebookAPI';
+import { DeclareIncidentFromNotebookButton } from '../extensions/DeclareIncidentFromNotebookButton';
+
 import { getNotebookScenePageStateManager } from './NotebookScenePageStateManager';
+import { NotebookSceneTimePicker } from './NotebookSceneTimePicker';
 
 // Fetch a notebook, wrap it into the scene envelope, hand it to the existing transformer
 // via the notebook state manager, and render the resulting scene body read-only.
@@ -70,25 +80,39 @@ export function NotebookScenePage() {
   );
 }
 
-// The POC notebook is a read-only document, so we render the scene body inside a plain
-// Page instead of DashboardScene.Component — that keeps the dashboard toolbar, sidebar
+// The notebook view is a read-only document, so we render the scene body inside a plain
+// Page instead of DashboardScene.Component — that keeps the dashboard toolbar, edit pane
 // and outline sidebar out. The scene is activated so panels still run their queries and
 // resolve the shared time range; the title stays via the page breadcrumb (pageNav).
 function NotebookDocument({ scene }: { scene: DashboardScene }) {
-  const { body, controls, title } = scene.useState();
+  const { body, controls, title, description, tags, uid } = scene.useState();
 
   useEffect(() => scene.activate(), [scene]);
 
-  // Show a "Notebooks" breadcrumb parent rather than nesting under the raw title.
-  const pageNav = { text: title, parentItem: { text: t('notebook.breadcrumb-title', 'Notebooks') } };
+  // Show a "Notebooks" breadcrumb parent linking back to the notebooks list.
+  const pageNav = { text: title, parentItem: { text: t('notebook.breadcrumb-title', 'Notebooks'), url: '/notebooks' } };
 
-  // Notebooks currently live under the Dashboards nav section, so the page highlights it. A
-  // dedicated top-level Notebooks nav section is deferred to its own follow-up.
   return (
-    <Page navId="dashboards/browse" pageNav={pageNav} layout={PageLayoutType.Custom}>
+    <Page navId="notebooks" pageNav={pageNav} layout={PageLayoutType.Custom}>
       {/* ScopesVariable (and other UNSAFE_renderAsHidden vars) must mount so query runners aren't blocked forever on dependsOnScopes — same as SoloPanelPage. */}
       {renderHiddenVariables(scene)}
-      {controls && <NotebookControls controls={controls} />}
+      {controls && (
+        <NotebookControls
+          controls={controls}
+          uid={uid}
+          title={title}
+          description={description}
+          tags={tags}
+          panelTitles={
+            body instanceof NotebookLayoutManager
+              ? body
+                  .getVizPanels()
+                  .map((panel) => panel.state.title)
+                  .filter((panelTitle): panelTitle is string => Boolean(panelTitle?.trim()))
+              : undefined
+          }
+        />
+      )}
       {body && <body.Component model={body} />}
     </Page>
   );
@@ -112,18 +136,130 @@ function renderHiddenVariables(scene: DashboardScene) {
 
 // Read-only notebooks still get the shared time range + refresh — but only those two
 // pickers, not the full dashboard controls bar (which carries edit/variable actions).
-function NotebookControls({ controls }: { controls: DashboardControls }) {
+// The Edit button is the entry into the collaborative notebook editor.
+function NotebookControls({
+  controls,
+  uid,
+  title,
+  description,
+  tags,
+  panelTitles,
+}: {
+  controls: DashboardControls;
+  uid?: string;
+  title?: string;
+  description?: string;
+  tags?: string[];
+  panelTitles?: string[];
+}) {
   const styles = useStyles2(getControlsStyles);
   const { timePicker, refreshPicker, hideTimeControls } = controls.useState();
+  const [confirmDelete, setConfirmDelete] = useState(false);
 
-  if (hideTimeControls) {
+  const canEdit =
+    contextSrv.hasPermission(AccessControlAction.DashboardsCreate) ||
+    contextSrv.hasPermission(AccessControlAction.DashboardsWrite);
+
+  if (hideTimeControls && !canEdit) {
     return null;
   }
 
+  const onDuplicate = async () => {
+    if (!uid) {
+      return;
+    }
+    // Fetch fresh: the scene envelope does not retain the raw notebook spec.
+    const notebook = await fetchNotebook(uid);
+    const created = await duplicateNotebook(
+      notebook.spec,
+      t('notebooks.list.copy-title', '{{title}} (copy)', { title: notebook.spec.title })
+    );
+    locationService.push(notebookEditUrl(created.metadata.name));
+  };
+
+  const moreMenu = (
+    <Menu>
+      <Menu.Item
+        icon="file-copy-alt"
+        label={t('notebook.duplicate', 'Duplicate notebook')}
+        onClick={() => {
+          onDuplicate();
+        }}
+      />
+      <Menu.Divider />
+      <Menu.Item
+        icon="trash-alt"
+        destructive
+        label={t('notebook.delete', 'Delete notebook')}
+        onClick={() => setConfirmDelete(true)}
+      />
+    </Menu>
+  );
+
   return (
     <div className={styles.controls}>
-      <timePicker.Component model={timePicker} />
-      <refreshPicker.Component model={refreshPicker} />
+      <LinkButton
+        variant="secondary"
+        fill="text"
+        icon="arrow-left"
+        href="/notebooks"
+        data-testid="notebook-back-button"
+      >
+        {t('notebook.back-button', 'All notebooks')}
+      </LinkButton>
+      <div className={styles.controlsRight}>
+        {/* Match Edit / time-picker chrome: secondary filled controls (not bare IconButtons). */}
+        <Button
+          variant="secondary"
+          icon="link"
+          tooltip={t('notebook.copy-link', 'Copy link')}
+          aria-label={t('notebook.copy-link', 'Copy link')}
+          onClick={() => {
+            copyStringToClipboard(window.location.href);
+            appEvents.emit(AppEvents.alertSuccess, [t('notebook.link-copied', 'Notebook link copied')]);
+          }}
+          data-testid="notebook-copy-link"
+        />
+        {uid && title && (
+          <DeclareIncidentFromNotebookButton
+            uid={uid}
+            title={title}
+            description={description}
+            tags={tags}
+            panelTitles={panelTitles}
+          />
+        )}
+        {canEdit && uid && (
+          <LinkButton variant="secondary" icon="pen" href={`/notebooks/edit/${uid}`} data-testid="notebook-edit-button">
+            {t('notebook.edit-button', 'Edit')}
+          </LinkButton>
+        )}
+        {!hideTimeControls && (
+          <>
+            <NotebookSceneTimePicker model={timePicker} />
+            <refreshPicker.Component model={refreshPicker} />
+          </>
+        )}
+        {canEdit && uid && (
+          <Dropdown overlay={moreMenu} placement="bottom-end">
+            <IconButton name="ellipsis-v" size="lg" tooltip={t('notebook.more-actions', 'More actions')} />
+          </Dropdown>
+        )}
+      </div>
+
+      <ConfirmModal
+        isOpen={confirmDelete}
+        title={t('notebook.delete-title', 'Delete notebook')}
+        body={t('notebook.delete-body', 'Are you sure you want to delete this notebook?')}
+        confirmText={t('notebook.delete-confirm', 'Delete')}
+        onConfirm={async () => {
+          if (uid) {
+            await deleteNotebook(uid);
+          }
+          locationService.push('/notebooks');
+        }}
+        onDismiss={() => setConfirmDelete(false)}
+      />
     </div>
   );
 }
@@ -131,9 +267,16 @@ function NotebookControls({ controls }: { controls: DashboardControls }) {
 const getControlsStyles = (theme: GrafanaTheme2) => ({
   controls: css({
     display: 'flex',
-    justifyContent: 'flex-end',
+    alignItems: 'center',
+    justifyContent: 'space-between',
     gap: theme.spacing(1),
     padding: theme.spacing(1, 2),
+  }),
+  controlsRight: css({
+    display: 'flex',
+    gap: theme.spacing(1),
+    flexWrap: 'wrap',
+    justifyContent: 'flex-end',
   }),
 });
 

--- a/public/app/features/notebook/pages/NotebookScenePageStateManager.test.ts
+++ b/public/app/features/notebook/pages/NotebookScenePageStateManager.test.ts
@@ -11,6 +11,7 @@ import { NotebookLayoutManager } from 'app/features/dashboard-scene/scene/layout
 import { dispatch } from 'app/store/store';
 import { DashboardRoutes } from 'app/types/dashboard';
 
+import { newPanelForDatasource } from '../model/notebookSpec';
 import { buildNotebookEnvelope } from '../scene/buildNotebookEnvelope';
 
 import { getNotebookScenePageStateManager } from './NotebookScenePageStateManager';
@@ -138,6 +139,48 @@ describe('NotebookScenePageStateManager', () => {
 
       // The page keys the picker + URL sync off this, so the notebook's hideTimepicker must reach it.
       expect(scene?.state.controls?.state.hideTimeControls).toBe(true);
+    });
+
+    it('hides the time controls when the notebook has no visualization panels', () => {
+      // notebookResource() is markdown-only — picker would do nothing.
+      const notebook = notebookResource();
+      notebook.metadata.name = 'nb-no-viz';
+
+      const scene = getNotebookScenePageStateManager().transformResponseToScene(buildNotebookEnvelope(notebook), {
+        uid: 'nb-no-viz',
+        route: DashboardRoutes.Notebook,
+      });
+
+      expect(scene?.state.controls?.state.hideTimeControls).toBe(true);
+    });
+
+    it('keeps the time controls when the notebook has a visualization panel', () => {
+      const panel = newPanelForDatasource({ uid: 'prom', type: 'prometheus' });
+      const notebook = notebookResource();
+      notebook.metadata.name = 'nb-with-viz';
+      notebook.spec.elements = {
+        ...notebook.spec.elements,
+        panel1: panel,
+      };
+      notebook.spec.layout = {
+        kind: 'NotebookLayout',
+        spec: {
+          cells: [
+            ...notebook.spec.layout.spec.cells,
+            {
+              kind: 'NotebookLayoutItem',
+              spec: { element: { kind: 'ElementReference', name: 'panel1' }, source: 'user' },
+            },
+          ],
+        },
+      };
+
+      const scene = getNotebookScenePageStateManager().transformResponseToScene(buildNotebookEnvelope(notebook), {
+        uid: 'nb-with-viz',
+        route: DashboardRoutes.Notebook,
+      });
+
+      expect(scene?.state.controls?.state.hideTimeControls).toBe(false);
     });
   });
 });

--- a/public/app/features/notebook/pages/NotebookScenePageStateManager.ts
+++ b/public/app/features/notebook/pages/NotebookScenePageStateManager.ts
@@ -11,6 +11,8 @@ import { type DashboardScene } from 'app/features/dashboard-scene/scene/Dashboar
 import { NotebookLayoutManager } from 'app/features/dashboard-scene/scene/layout-notebook/NotebookLayoutManager';
 import { dispatch } from 'app/store/store';
 
+import { setLastUsedNotebook } from '../model/lastUsedNotebook';
+import { normalizeNotebookSpec } from '../model/notebookSpec';
 import { buildNotebookEnvelope } from '../scene/buildNotebookEnvelope';
 
 // A notebook renders through the same scene pipeline as a v2 dashboard, so we reuse
@@ -46,7 +48,12 @@ export class NotebookScenePageStateManager extends DashboardScenePageStateManage
     // stay on the @grafana/schema notebook types.
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- generated client type bridged to the schema resource type at the fetch seam
     const notebook = result.data as unknown as Resource<NotebookSpec>;
-    return buildNotebookEnvelope(notebook);
+    // RTK Query freezes cached responses (Immer). The scene pipeline mutates nested panel
+    // fieldConfig (e.g. threshold base → -Infinity), so clone before building the envelope.
+    const mutable = structuredClone(notebook);
+    // Viewing counts as "using": quick-add targets and the sidebar follow the last opened notebook.
+    setLastUsedNotebook(mutable.metadata.name, mutable.spec.title);
+    return buildNotebookEnvelope({ ...mutable, spec: normalizeNotebookSpec(mutable.spec) });
   }
 
   public transformResponseToScene(
@@ -54,17 +61,28 @@ export class NotebookScenePageStateManager extends DashboardScenePageStateManage
     options: LoadDashboardOptions
   ): DashboardScene | null {
     const scene = super.transformResponseToScene(rsp, options);
+    if (!scene) {
+      return null;
+    }
+
     // The POC notebook is read-only. Marking the scene as embedded hides the dashboard
     // edit/share/export toolbar actions and the outline/sidebar (canEditDashboard() and
     // the share button both require !isEmbedded) while the page + title still render.
-    scene?.setState({ meta: { ...scene.state.meta, isEmbedded: true } });
+    scene.setState({ meta: { ...scene.state.meta, isEmbedded: true } });
 
     // Surface the notebook's title and tags on the layout manager's own state so its header can
     // show them. The manager deliberately doesn't read them off the DashboardScene (that import
     // would form a dependency cycle), so the loader pushes them down here.
-    const body = scene?.state.body;
+    const body = scene.state.body;
     if (body instanceof NotebookLayoutManager) {
       body.setState({ title: rsp?.spec.title, tags: rsp?.spec.tags });
+
+      // No visualizations → nothing for the shared time range to drive. Hide the picker
+      // (and skip URL time sync) so markdown/code-only notebooks aren't showing dead chrome.
+      // Spec hideTimepicker already sets this; OR so we never un-hide an author preference.
+      if (body.getVizPanels().length === 0 && scene.state.controls) {
+        scene.state.controls.setState({ hideTimeControls: true });
+      }
     }
 
     return scene;

--- a/public/app/features/notebook/pages/NotebookSceneTimePicker.tsx
+++ b/public/app/features/notebook/pages/NotebookSceneTimePicker.tsx
@@ -1,0 +1,62 @@
+import { dateTime, intervalToAbbreviatedDurationString } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { sceneGraph, type SceneTimePicker } from '@grafana/scenes';
+import { TimeRangePicker } from '@grafana/ui';
+import { getZoomedTimeRange } from 'app/core/utils/timePicker';
+
+/**
+ * View-page time picker that mirrors SceneTimePicker but also exposes zoom-in.
+ * SceneTimePicker in @grafana/scenes only wires zoom-out today.
+ */
+export function NotebookSceneTimePicker({ model }: { model: SceneTimePicker }) {
+  const { hidePicker, isOnCanvas, quickRanges } = model.useState();
+  const timeRange = sceneGraph.getTimeRange(model);
+  const timeZone = timeRange.getTimeZone();
+  const { value, fiscalYearStartMonth, weekStart } = timeRange.useState();
+
+  if (hidePicker) {
+    return null;
+  }
+
+  const halfSpanMs = (value.to.valueOf() - value.from.valueOf()) / 2;
+  const moveBackwardDuration = intervalToAbbreviatedDurationString({
+    start: new Date(value.from.valueOf()),
+    end: new Date(value.from.valueOf() + halfSpanMs),
+  });
+  const canMoveForward = value.to.valueOf() + halfSpanMs <= Date.now();
+  const moveForwardDuration = canMoveForward ? moveBackwardDuration : undefined;
+
+  const zoomBy = (factor: number) => {
+    const zoomed = getZoomedTimeRange(value, factor);
+    const from = dateTime(zoomed.from);
+    const to = dateTime(zoomed.to);
+    timeRange.onTimeRangeChange({ from, to, raw: { from, to } });
+  };
+
+  return (
+    <TimeRangePicker
+      isOnCanvas={isOnCanvas ?? true}
+      value={value}
+      timeZone={timeZone}
+      fiscalYearStartMonth={fiscalYearStartMonth}
+      weekStart={weekStart}
+      quickRanges={quickRanges}
+      onChange={(range) => timeRange.onTimeRangeChange(range)}
+      onChangeTimeZone={timeRange.onTimeZoneChange}
+      onMoveBackward={() => model.onMoveBackward()}
+      onMoveForward={() => model.onMoveForward()}
+      moveBackwardTooltip={t('notebook.time-picker.move-backward-tooltip', 'Move {{duration}} backward', {
+        duration: moveBackwardDuration,
+      })}
+      moveForwardTooltip={
+        moveForwardDuration
+          ? t('notebook.time-picker.move-forward-tooltip', 'Move {{duration}} forward', {
+              duration: moveForwardDuration,
+            })
+          : undefined
+      }
+      onZoom={() => zoomBy(2)}
+      onZoomIn={() => zoomBy(0.5)}
+    />
+  );
+}

--- a/public/app/features/notebook/pages/NotebooksListPage.tsx
+++ b/public/app/features/notebook/pages/NotebooksListPage.tsx
@@ -1,0 +1,326 @@
+import { css } from '@emotion/css';
+import { skipToken } from '@reduxjs/toolkit/query';
+import { useMemo, useState } from 'react';
+
+import { AppEvents, dateTimeFormatTimeAgo, type GrafanaTheme2 } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { locationService } from '@grafana/runtime';
+import { useFlagDashboardNotebooks } from '@grafana/runtime/internal';
+import { type NotebookElement } from '@grafana/schema/apis/notebook/v2beta1';
+import {
+  Button,
+  Card,
+  ConfirmModal,
+  EmptyState,
+  FilterInput,
+  Icon,
+  LinkButton,
+  Spinner,
+  Stack,
+  TagList,
+  useStyles2,
+} from '@grafana/ui';
+import { useDeleteNotebookMutation, useListNotebookQuery, type Notebook } from 'app/api/clients/dashboard/v2beta1';
+import { appEvents } from 'app/core/app_events';
+import { Page } from 'app/core/components/Page/Page';
+import { PageNotFound } from 'app/core/components/PageNotFound/PageNotFound';
+import { copyStringToClipboard } from 'app/core/utils/explore';
+
+import { createNotebook, duplicateNotebook, notebookEditUrl, notebookViewUrl } from '../api/notebookAPI';
+import { markNotebookAsNew } from '../model/newNotebookSignal';
+import { newNotebookSpec, newNotebookTitleDate } from '../model/notebookSpec';
+
+export function NotebooksListPage() {
+  const notebooksEnabled = useFlagDashboardNotebooks();
+  const styles = useStyles2(getStyles);
+  const [search, setSearch] = useState('');
+  const [deleteTarget, setDeleteTarget] = useState<Notebook | undefined>();
+  const [creating, setCreating] = useState(false);
+
+  const { data, isLoading, error } = useListNotebookQuery(notebooksEnabled ? {} : skipToken);
+  const [deleteNotebook] = useDeleteNotebookMutation();
+
+  const notebooks = useMemo(() => {
+    const items = [...(data?.items ?? [])];
+    // ISO timestamps sort correctly with plain string comparison.
+    items.sort((a, b) => {
+      const aUpdated = lastUpdated(a);
+      const bUpdated = lastUpdated(b);
+      if (bUpdated > aUpdated) {
+        return 1;
+      }
+      if (bUpdated < aUpdated) {
+        return -1;
+      }
+      return 0;
+    });
+    if (!search) {
+      return items;
+    }
+    const needle = search.toLowerCase();
+    return items.filter(
+      (nb) =>
+        nb.spec.title.toLowerCase().includes(needle) ||
+        (nb.spec.description ?? '').toLowerCase().includes(needle) ||
+        nb.spec.tags.some((tag) => tag.toLowerCase().includes(needle)) ||
+        contentMatches(nb, needle)
+    );
+  }, [data, search]);
+
+  if (!notebooksEnabled) {
+    return <PageNotFound />;
+  }
+
+  const onCreate = async () => {
+    setCreating(true);
+    try {
+      const created = await createNotebook(
+        newNotebookSpec(
+          t('notebooks.list.new-notebook-title', 'Investigation — {{date}}', { date: newNotebookTitleDate() })
+        )
+      );
+      markNotebookAsNew(created.metadata.name);
+      locationService.push(notebookEditUrl(created.metadata.name));
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const onCopyLink = (notebook: Notebook) => {
+    copyStringToClipboard(new URL(notebookViewUrl(notebook.metadata.name ?? ''), window.location.origin).toString());
+    appEvents.emit(AppEvents.alertSuccess, [t('notebooks.list.link-copied', 'Notebook link copied')]);
+  };
+
+  // Duplicating makes notebooks reusable as investigation templates. The copy opens
+  // in the editor with its title focused, ready to rename.
+  const onDuplicate = async (notebook: Notebook) => {
+    const created = await duplicateNotebook(
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- generated client spec bridged to the schema spec at the API seam
+      notebook.spec as Parameters<typeof duplicateNotebook>[0],
+      t('notebooks.list.copy-title', '{{title}} (copy)', { title: notebook.spec.title })
+    );
+    locationService.push(notebookEditUrl(created.metadata.name));
+  };
+
+  const createButton = (
+    <Button icon="plus" onClick={onCreate} disabled={creating} data-testid="notebooks-create">
+      <Trans i18nKey="notebooks.list.new-notebook">New notebook</Trans>
+    </Button>
+  );
+
+  return (
+    <Page
+      navId="notebooks"
+      subTitle={t(
+        'notebooks.list.subtitle',
+        'Capture investigations combining narrative text with live visualizations from your dashboards and Explore.'
+      )}
+      actions={createButton}
+    >
+      <Page.Contents>
+        <Stack direction="column" gap={2}>
+          <FilterInput
+            value={search}
+            onChange={setSearch}
+            placeholder={t('notebooks.list.search-placeholder', 'Search notebooks by name, description or tag')}
+          />
+
+          {isLoading && <Spinner />}
+
+          {!isLoading && !error && notebooks.length === 0 && !search && (
+            <EmptyState
+              variant="call-to-action"
+              message={t('notebooks.list.empty-title', 'You have not created any notebooks yet')}
+              button={createButton}
+            >
+              <Trans i18nKey="notebooks.list.empty-body">
+                Notebooks are living documents for investigations: mix text with live panels added from dashboards and
+                Explore, and collaborate with your team in real time.
+              </Trans>
+            </EmptyState>
+          )}
+
+          {!isLoading && notebooks.length === 0 && search && (
+            <EmptyState
+              variant="not-found"
+              message={t('notebooks.list.no-results', 'No notebooks match your search')}
+            />
+          )}
+
+          <ul className={styles.list}>
+            {notebooks.map((notebook) => {
+              const name = notebook.metadata.name ?? '';
+              const cells = countCells(notebook);
+              const panels = countPanels(notebook);
+              return (
+                <li key={name}>
+                  <Card noMargin href={notebookViewUrl(name)} data-testid={`notebook-card-${name}`}>
+                    <Card.Figure>
+                      <Icon name="book-open" size="xl" />
+                    </Card.Figure>
+                    <Card.Heading>{notebook.spec.title}</Card.Heading>
+                    {notebook.spec.description && <Card.Description>{notebook.spec.description}</Card.Description>}
+                    <Card.Meta>
+                      {[
+                        t('notebooks.list.updated', 'Updated {{when}}', {
+                          when: dateTimeFormatTimeAgo(lastUpdated(notebook)),
+                        }),
+                        // Live panels are the load-bearing content — lead with them; text-only
+                        // notebooks fall back to the block count.
+                        panels > 0
+                          ? t('notebooks.list.panel-count', '', {
+                              count: panels,
+                              defaultValue_one: '{{count}} panel',
+                              defaultValue_other: '{{count}} panels',
+                            })
+                          : t('notebooks.list.cell-count', '', {
+                              count: cells,
+                              defaultValue_one: '{{count}} block',
+                              defaultValue_other: '{{count}} blocks',
+                            }),
+                      ]}
+                    </Card.Meta>
+                    {notebook.spec.tags.length > 0 && (
+                      <Card.Tags>
+                        <TagList tags={notebook.spec.tags} />
+                      </Card.Tags>
+                    )}
+                    <Card.SecondaryActions className={styles.cardActions}>
+                      <LinkButton
+                        key="edit"
+                        variant="secondary"
+                        fill="outline"
+                        size="sm"
+                        icon="pen"
+                        href={notebookEditUrl(name)}
+                      >
+                        <Trans i18nKey="notebooks.list.edit">Edit</Trans>
+                      </LinkButton>
+                      <Button
+                        key="copy-link"
+                        variant="secondary"
+                        fill="outline"
+                        size="sm"
+                        icon="link"
+                        onClick={(e) => {
+                          // Never let the click reach the card's navigation link.
+                          e.preventDefault();
+                          e.stopPropagation();
+                          onCopyLink(notebook);
+                        }}
+                        tooltip={t('notebooks.list.copy-link', 'Copy link')}
+                        aria-label={t('notebooks.list.copy-link-label', 'Copy link to notebook {{title}}', {
+                          title: notebook.spec.title,
+                        })}
+                      />
+                      <Button
+                        key="duplicate"
+                        variant="secondary"
+                        fill="outline"
+                        size="sm"
+                        icon="copy"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          onDuplicate(notebook);
+                        }}
+                        tooltip={t('notebooks.list.duplicate', 'Duplicate')}
+                        aria-label={t('notebooks.list.duplicate-label', 'Duplicate notebook {{title}}', {
+                          title: notebook.spec.title,
+                        })}
+                      />
+                      <Button
+                        key="delete"
+                        variant="destructive"
+                        fill="outline"
+                        size="sm"
+                        icon="trash-alt"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          setDeleteTarget(notebook);
+                        }}
+                        tooltip={t('notebooks.list.delete', 'Delete')}
+                        aria-label={t('notebooks.list.delete-label', 'Delete notebook {{title}}', {
+                          title: notebook.spec.title,
+                        })}
+                      />
+                    </Card.SecondaryActions>
+                  </Card>
+                </li>
+              );
+            })}
+          </ul>
+        </Stack>
+
+        <ConfirmModal
+          isOpen={!!deleteTarget}
+          title={t('notebooks.list.delete-title', 'Delete notebook')}
+          body={t('notebooks.list.delete-body', 'Are you sure you want to delete "{{title}}"?', {
+            title: deleteTarget?.spec.title ?? '',
+          })}
+          confirmText={t('notebooks.list.delete-confirm', 'Delete')}
+          onConfirm={async () => {
+            if (deleteTarget?.metadata.name) {
+              await deleteNotebook({ name: deleteTarget.metadata.name });
+            }
+            setDeleteTarget(undefined);
+          }}
+          onDismiss={() => setDeleteTarget(undefined)}
+        />
+      </Page.Contents>
+    </Page>
+  );
+}
+
+function lastUpdated(notebook: Notebook): string {
+  return notebook.metadata.annotations?.['grafana.app/updatedTimestamp'] ?? notebook.metadata.creationTimestamp ?? '';
+}
+
+function countCells(notebook: Notebook): number {
+  return notebook.spec.layout.spec.cells.length;
+}
+
+function countPanels(notebook: Notebook): number {
+  return notebookElements(notebook).filter((element) => element.kind === 'Panel' || element.kind === 'LibraryPanel')
+    .length;
+}
+
+function notebookElements(notebook: Notebook): NotebookElement[] {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- generated client element union bridged to the schema union at the read seam
+  return Object.values(notebook.spec.elements) as unknown as NotebookElement[];
+}
+
+// The list endpoint returns full specs, so block contents are searchable client-side
+// at POC scale (a proper search index is the GA path).
+function contentMatches(notebook: Notebook, needle: string): boolean {
+  return notebookElements(notebook).some((element) => {
+    if (element.kind === 'Panel' || element.kind === 'LibraryPanel') {
+      return element.spec.title.toLowerCase().includes(needle);
+    }
+    if (element.kind === 'Cell') {
+      const content = element.spec.content;
+      const text = content.kind === 'Markdown' ? content.spec.text : content.kind === 'Code' ? content.spec.code : '';
+      return text.toLowerCase().includes(needle);
+    }
+    return false;
+  });
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  list: css({
+    display: 'grid',
+    gap: theme.spacing(1),
+    listStyle: 'none',
+    margin: 0,
+    padding: 0,
+  }),
+  // The card's href renders as an absolutely-positioned overlay covering the whole
+  // card, which paints above static children — without a z-index the action buttons
+  // are neither hoverable (no tooltips) nor clickable (same trick as Card.Meta).
+  cardActions: css({
+    zIndex: 1,
+  }),
+});
+
+export default NotebooksListPage;

--- a/public/app/features/notebook/sidebar/NotebooksSidebarPanel.tsx
+++ b/public/app/features/notebook/sidebar/NotebooksSidebarPanel.tsx
@@ -1,0 +1,446 @@
+import { css, cx } from '@emotion/css';
+import { DragDropContext, Draggable, Droppable, type DropResult } from '@hello-pangea/dnd';
+import { skipToken } from '@reduxjs/toolkit/query';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useLocation } from 'react-router-dom-v5-compat';
+
+import { type GrafanaTheme2, type SelectableValue } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { locationService } from '@grafana/runtime';
+import { useFlagDashboardNotebooks } from '@grafana/runtime/internal';
+import { Button, Icon, IconButton, LinkButton, Select, Spinner, Stack, Text, TextArea, useStyles2 } from '@grafana/ui';
+import { useListNotebookQuery } from 'app/api/clients/dashboard/v2beta1';
+import { useExtensionSidebarContext } from 'app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider';
+
+import { createNotebook, notebookEditUrl, notebookViewUrl } from '../api/notebookAPI';
+import { mergeRemoteSpec } from '../collab/mergeRemoteSpec';
+import { resourceVersionTs, useNotebookCollab } from '../collab/useNotebookCollab';
+import { MarkdownCellEditor } from '../editor/cells/MarkdownCellEditor';
+import { PanelCellView } from '../editor/cells/PanelCellView';
+import { useNotebookEditorState } from '../editor/useNotebookEditorState';
+import { getLastUsedNotebook } from '../model/lastUsedNotebook';
+import {
+  insertElement,
+  moveCell,
+  newMarkdownElement,
+  newNotebookSpec,
+  newNotebookTitleDate,
+  removeCellAt,
+  resolveCells,
+  updateMarkdownText,
+} from '../model/notebookSpec';
+
+const SIDEBAR_PANEL_HEIGHT = 180;
+
+/**
+ * The notebooks workspace panel, docked in the extension sidebar so notebooks are
+ * reachable next to any Grafana page. Hosts a compact editor for the selected
+ * notebook (markdown editing, reorder, live panels) plus a capture box pinned at
+ * the bottom — jot findings without leaving the dashboard or Explore.
+ */
+export function NotebooksSidebarPanel() {
+  const notebooksEnabled = useFlagDashboardNotebooks();
+  const styles = useStyles2(getStyles);
+  const [selectedUid, setSelectedUid] = useState<string | undefined>(() => getLastUsedNotebook()?.uid);
+  const location = useLocation();
+
+  const { data, isLoading } = useListNotebookQuery(notebooksEnabled ? {} : skipToken);
+
+  // The sidebar follows along: navigating to a notebook page selects that notebook here.
+  useEffect(() => {
+    const match = location.pathname.match(/^\/(?:notebooks\/edit|notebook)\/([^/]+)/);
+    if (match) {
+      setSelectedUid(match[1]);
+    }
+  }, [location.pathname]);
+
+  const options: Array<SelectableValue<string>> = useMemo(
+    () =>
+      (data?.items ?? [])
+        .map((nb) => ({ label: nb.spec.title, value: nb.metadata.name ?? '' }))
+        .filter((option) => option.value !== ''),
+    [data]
+  );
+
+  if (!notebooksEnabled) {
+    return null;
+  }
+
+  const effectiveUid = selectedUid && options.some((o) => o.value === selectedUid) ? selectedUid : options[0]?.value;
+
+  const onCreate = async () => {
+    const created = await createNotebook(
+      newNotebookSpec(
+        t('notebooks.list.new-notebook-title', 'Investigation — {{date}}', { date: newNotebookTitleDate() })
+      )
+    );
+    setSelectedUid(created.metadata.name);
+  };
+
+  return (
+    <div className={styles.panel} data-testid="notebooks-sidebar-panel">
+      <div className={styles.header}>
+        <Stack direction="row" gap={1} alignItems="center">
+          <Icon name="book-open" />
+          <Text element="h2" variant="h5">
+            <Trans i18nKey="notebooks.sidebar.title">Notebooks</Trans>
+          </Text>
+        </Stack>
+        <Stack direction="row" gap={0.5}>
+          <LinkButton size="sm" fill="text" variant="secondary" href="/notebooks">
+            <Trans i18nKey="notebooks.sidebar.view-all">View all</Trans>
+          </LinkButton>
+          <Button size="sm" icon="plus" variant="secondary" onClick={onCreate}>
+            <Trans i18nKey="notebooks.sidebar.new">New</Trans>
+          </Button>
+        </Stack>
+      </div>
+
+      {isLoading && <Spinner />}
+
+      {!isLoading && options.length === 0 && (
+        <Text color="secondary">
+          <Trans i18nKey="notebooks.sidebar.empty">No notebooks yet — create one to start capturing findings.</Trans>
+        </Text>
+      )}
+
+      {options.length > 0 && (
+        <Select
+          options={options}
+          value={effectiveUid}
+          onChange={(option) => setSelectedUid(option?.value)}
+          aria-label={t('notebooks.sidebar.picker', 'Notebook')}
+        />
+      )}
+
+      {effectiveUid && <SidebarNotebookEditor key={effectiveUid} uid={effectiveUid} />}
+    </div>
+  );
+}
+
+/**
+ * Compact inline editor for one notebook. Joins the same Live collaboration channel
+ * as the full editor, so sidebar edits show up live in open editors (and vice versa),
+ * and the sidebar counts as a presence.
+ */
+function SidebarNotebookEditor({ uid }: { uid: string }) {
+  const styles = useStyles2(getStyles);
+  const editor = useNotebookEditorState(uid);
+  const { spec, loading, dirty, saving } = editor.state;
+  const { setDockedComponentId } = useExtensionSidebarContext();
+  const [note, setNote] = useState('');
+  const [editingKey, setEditingKey] = useState<string | null>(null);
+
+  // Jumping to the full page is a context switch — the sidebar closes with it.
+  const onNavigate = (url: string) => {
+    setDockedComponentId(undefined);
+    locationService.push(url);
+  };
+  const editingKeyRef = useRef<string | null>(null);
+  editingKeyRef.current = editingKey;
+  const blocksRef = useRef<HTMLDivElement>(null);
+
+  const collab = useNotebookCollab({
+    uid,
+    enabled: !loading && !!spec,
+    getSpec: editor.getSpec,
+    initialDocTs: resourceVersionTs(editor.state.resource),
+    onRemoteSpec: useCallback(
+      (remoteSpec) => {
+        editor.applyRemoteSpec(mergeRemoteSpec(remoteSpec, editor.getSpec(), editingKeyRef.current));
+      },
+      [editor]
+    ),
+  });
+
+  const update = useCallback(
+    (mutate: Parameters<typeof editor.updateSpec>[0]) => {
+      editor.updateSpec(mutate);
+      collab.notifyLocalEdit();
+    },
+    [editor, collab]
+  );
+
+  if (loading || !spec) {
+    return <Spinner />;
+  }
+
+  const cells = resolveCells(spec);
+
+  const onAddNote = () => {
+    const text = note.trim();
+    if (!text) {
+      return;
+    }
+    let newKey: string | undefined;
+    update((s) => {
+      const result = insertElement(s, newMarkdownElement(text), { source: 'user' });
+      newKey = result.elementName;
+      return result.spec;
+    });
+    if (newKey) {
+      collab.sendActivity(t('notebooks.activity.added-note', 'added a note'), newKey);
+    }
+    setNote('');
+    // New notes append at the end; keep them in view.
+    requestAnimationFrame(() => {
+      blocksRef.current?.scrollTo({ top: blocksRef.current.scrollHeight, behavior: 'smooth' });
+    });
+  };
+
+  const onDragEnd = (result: DropResult) => {
+    if (result.destination && result.destination.index !== result.source.index) {
+      update((s) => moveCell(s, result.source.index, result.destination!.index));
+    }
+  };
+
+  return (
+    <div className={styles.editor}>
+      <div className={styles.blocks} ref={blocksRef}>
+        {cells.length === 0 ? (
+          <div className={styles.blocksEmpty}>
+            <Icon name="document-info" size="lg" />
+            <Text variant="bodySmall" color="secondary" textAlignment="center">
+              <Trans i18nKey="notebooks.sidebar.no-blocks">
+                Nothing here yet — capture your first note below, or add panels from any dashboard.
+              </Trans>
+            </Text>
+          </div>
+        ) : (
+          <DragDropContext onDragEnd={onDragEnd}>
+            <Droppable droppableId="notebook-sidebar-cells">
+              {(droppable) => (
+                <div ref={droppable.innerRef} {...droppable.droppableProps} className={styles.cells}>
+                  {cells.map((cell, index) => {
+                    const { element, elementName } = cell;
+
+                    return (
+                      <Draggable draggableId={elementName} index={index} key={elementName}>
+                        {(draggable, snapshot) => (
+                          <div
+                            ref={draggable.innerRef}
+                            {...draggable.draggableProps}
+                            className={cx(styles.cellRow, snapshot.isDragging && styles.cellDragging)}
+                          >
+                            <div
+                              className={cx('sidebar-cell-drag-handle', styles.cellDragHandle)}
+                              {...draggable.dragHandleProps}
+                              aria-label={t('notebooks.cell.drag', 'Drag to reorder block')}
+                            >
+                              <Icon name="draggabledots" size="sm" />
+                            </div>
+                            <div className={styles.cellBody}>
+                              {element.kind === 'Panel' && (
+                                <PanelCellView
+                                  panel={element}
+                                  timeFrom={cell.timeFrom ?? spec.timeSettings.from}
+                                  timeTo={cell.timeTo ?? spec.timeSettings.to}
+                                  height={SIDEBAR_PANEL_HEIGHT}
+                                />
+                              )}
+                              {element.kind === 'LibraryPanel' && <Text color="secondary">{element.spec.title}</Text>}
+                              {element.kind === 'Cell' && element.spec.content.kind === 'Markdown' && (
+                                <MarkdownCellEditor
+                                  value={element.spec.content.spec.text}
+                                  editing={editingKey === elementName}
+                                  onStartEdit={() => setEditingKey(elementName)}
+                                  onChange={(text) => update((s) => updateMarkdownText(s, elementName, text))}
+                                  onDone={() => setEditingKey(null)}
+                                />
+                              )}
+                              {element.kind === 'Cell' && element.spec.content.kind === 'Code' && (
+                                <pre className={styles.code}>{element.spec.content.spec.code}</pre>
+                              )}
+                            </div>
+                            <div className={cx('sidebar-cell-actions', styles.cellActions)}>
+                              <IconButton
+                                name="trash-alt"
+                                size="sm"
+                                tooltip={t('notebooks.sidebar.delete-block', 'Delete block')}
+                                onClick={() => update((s) => removeCellAt(s, index))}
+                              />
+                            </div>
+                          </div>
+                        )}
+                      </Draggable>
+                    );
+                  })}
+                  {droppable.placeholder}
+                </div>
+              )}
+            </Droppable>
+          </DragDropContext>
+        )}
+      </div>
+
+      <div className={styles.footer}>
+        <Text variant="bodySmall" color="secondary">
+          {saving
+            ? t('notebooks.editor.status-saving', 'Saving…')
+            : dirty
+              ? t('notebooks.editor.status-unsaved', 'Unsaved changes')
+              : t('notebooks.sidebar.status-synced', 'All changes saved')}
+        </Text>
+        <Stack direction="row" gap={0.25}>
+          <IconButton
+            name="book-open"
+            tooltip={t('notebooks.sidebar.open', 'Open notebook')}
+            onClick={() => onNavigate(notebookViewUrl(uid))}
+          />
+          <IconButton
+            name="pen"
+            tooltip={t('notebooks.sidebar.edit', 'Open in editor')}
+            onClick={() => onNavigate(notebookEditUrl(uid))}
+          />
+        </Stack>
+      </div>
+
+      <div className={styles.noteBox}>
+        <TextArea
+          value={note}
+          rows={2}
+          placeholder={t('notebooks.sidebar.note-placeholder', 'Jot a quick note — Enter to add')}
+          onChange={(e) => setNote(e.currentTarget.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault();
+              onAddNote();
+            }
+          }}
+          data-testid="notebooks-sidebar-note"
+        />
+        <IconButton
+          name="message"
+          size="lg"
+          disabled={!note.trim()}
+          onClick={onAddNote}
+          tooltip={t('notebooks.sidebar.add-note', 'Add note (Enter)')}
+        />
+      </div>
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  panel: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1.5),
+    padding: theme.spacing(2, 2, 1.5, 2),
+    height: '100%',
+    overflow: 'hidden',
+  }),
+  header: css({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: theme.spacing(1),
+    flexShrink: 0,
+  }),
+  editor: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+    flex: 1,
+    minHeight: 0,
+  }),
+  blocks: css({
+    flex: 1,
+    minHeight: 0,
+    overflowY: 'auto',
+    // Breathing room so hover outlines and the drag handle are not clipped.
+    padding: theme.spacing(0.5, 0.5, 0.5, 0),
+    margin: theme.spacing(-0.5, -0.5, 0, 0),
+  }),
+  blocksEmpty: css({
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: theme.spacing(1),
+    height: '100%',
+    minHeight: 120,
+    color: theme.colors.text.secondary,
+    border: `1px dashed ${theme.colors.border.medium}`,
+    borderRadius: theme.shape.radius.default,
+    padding: theme.spacing(2),
+  }),
+  cells: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1.5),
+  }),
+  cellRow: css({
+    position: 'relative',
+    borderRadius: theme.shape.radius.default,
+    padding: theme.spacing(0.5),
+    paddingLeft: theme.spacing(2.5),
+
+    '&:hover': {
+      outline: `1px solid ${theme.colors.border.weak}`,
+    },
+
+    '&:hover .sidebar-cell-actions, &:hover .sidebar-cell-drag-handle': {
+      opacity: 1,
+    },
+  }),
+  cellDragging: css({
+    outline: `1px solid ${theme.colors.primary.border}`,
+    background: theme.colors.background.primary,
+    boxShadow: theme.shadows.z2,
+  }),
+  cellDragHandle: css({
+    position: 'absolute',
+    left: 0,
+    top: '50%',
+    transform: 'translateY(-50%)',
+    display: 'flex',
+    alignItems: 'center',
+    padding: theme.spacing(0, 0.25),
+    opacity: 0,
+    color: theme.colors.text.secondary,
+    cursor: 'grab',
+  }),
+  cellBody: css({
+    minWidth: 0,
+  }),
+  cellActions: css({
+    position: 'absolute',
+    top: theme.spacing(0.5),
+    right: theme.spacing(0.5),
+    display: 'flex',
+    gap: theme.spacing(0.25),
+    opacity: 0,
+    background: theme.colors.background.primary,
+    borderRadius: theme.shape.radius.default,
+    zIndex: 2,
+    padding: theme.spacing(0.25),
+  }),
+  code: css({
+    background: theme.colors.background.secondary,
+    borderRadius: theme.shape.radius.default,
+    padding: theme.spacing(1),
+    fontSize: theme.typography.bodySmall.fontSize,
+    fontFamily: theme.typography.fontFamilyMonospace,
+    overflow: 'auto',
+    maxHeight: 160,
+    margin: 0,
+  }),
+  footer: css({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: theme.spacing(1),
+    borderTop: `1px solid ${theme.colors.border.weak}`,
+    paddingTop: theme.spacing(0.75),
+    flexShrink: 0,
+  }),
+  noteBox: css({
+    display: 'flex',
+    alignItems: 'flex-end',
+    gap: theme.spacing(1),
+    flexShrink: 0,
+  }),
+});
+
+export default NotebooksSidebarPanel;

--- a/public/app/features/notebook/sidebar/NotebooksSidebarPanelLoader.tsx
+++ b/public/app/features/notebook/sidebar/NotebooksSidebarPanelLoader.tsx
@@ -1,0 +1,16 @@
+import { Suspense, lazy } from 'react';
+
+import PageLoader from 'app/core/components/PageLoader/PageLoader';
+
+// This wrapper is imported in the plugin extension registry bootstrap path, so it must
+// stay dependency-free: the actual panel (and the notebook feature it pulls in) is only
+// loaded when the sidebar component is opened.
+const NotebooksSidebarPanel = lazy(() => import('./NotebooksSidebarPanel'));
+
+export function NotebooksSidebarPanelLoader() {
+  return (
+    <Suspense fallback={<PageLoader />}>
+      <NotebooksSidebarPanel />
+    </Suspense>
+  );
+}

--- a/public/app/features/plugins/extensions/getCoreExtensionConfigurations.ts
+++ b/public/app/features/plugins/extensions/getCoreExtensionConfigurations.ts
@@ -1,6 +1,7 @@
 import { type PluginExtensionAddedLinkConfig } from '@grafana/data';
 import { getExploreExtensionConfigs } from 'app/features/explore/extensions/getExploreExtensionConfigs';
+import { getNotebookExtensionConfigs } from 'app/features/notebook/extensions/getNotebookExtensionConfigs';
 
 export function getCoreExtensionConfigurations(): PluginExtensionAddedLinkConfig[] {
-  return [...getExploreExtensionConfigs()];
+  return [...getExploreExtensionConfigs(), ...getNotebookExtensionConfigs()];
 }

--- a/public/app/features/plugins/extensions/registry/setup.ts
+++ b/public/app/features/plugins/extensions/registry/setup.ts
@@ -1,11 +1,13 @@
 /* eslint-disable @grafana/i18n/no-untranslated-strings */
-import { type AppPluginConfig, PluginExtensionExposedComponents } from '@grafana/data';
+import { type AppPluginConfig, PluginExtensionExposedComponents, PluginExtensionPoints } from '@grafana/data';
 import { getAppPluginMetas, getCachedPromise } from '@grafana/runtime/internal';
 import CentralAlertHistorySceneExposedComponent from 'app/features/alerting/unified/components/rules/central-state-history/CentralAlertHistorySceneExposedComponent';
 import { CreateAlertFromPanelExposedComponent } from 'app/features/alerting/unified/extensions/CreateAlertFromPanelExposedComponent';
 import { AddToDashboardFormExposedComponent } from 'app/features/dashboard-scene/addToDashboard/AddToDashboardFormExposedComponent';
 import { OpenQueryLibraryExposedComponent } from 'app/features/explore/QueryLibrary/OpenQueryLibraryExposedComponent';
 import { PrometheusQueryResultsContainer } from 'app/features/explore/RawPrometheus/PrometheusQueryResultsContainer';
+import { NOTEBOOKS_SIDEBAR_COMPONENT_TITLE } from 'app/features/notebook/extensions/getNotebookExtensionConfigs';
+import { NotebooksSidebarPanelLoader } from 'app/features/notebook/sidebar/NotebooksSidebarPanelLoader';
 
 import { getCoreExtensionConfigurations } from '../getCoreExtensionConfigurations';
 
@@ -23,11 +25,29 @@ function initRegistries(apps: AppPluginConfig[]): PluginExtensionRegistries {
   return { addedComponentsRegistry, addedFunctionsRegistry, addedLinksRegistry, exposedComponentsRegistry };
 }
 
-function registerCoreExtensions({ addedLinksRegistry, exposedComponentsRegistry }: PluginExtensionRegistries) {
+function registerCoreExtensions({
+  addedComponentsRegistry,
+  addedLinksRegistry,
+  exposedComponentsRegistry,
+}: PluginExtensionRegistries) {
   // Registering core extension links
   addedLinksRegistry.register({
     pluginId: 'grafana',
     configs: getCoreExtensionConfigurations(),
+  });
+
+  // The notebooks workspace panel for the extension sidebar. The matching added link
+  // (which gates visibility on the feature flag) is part of getCoreExtensionConfigurations.
+  addedComponentsRegistry.register({
+    pluginId: 'grafana',
+    configs: [
+      {
+        targets: [PluginExtensionPoints.ExtensionSidebar],
+        title: NOTEBOOKS_SIDEBAR_COMPONENT_TITLE,
+        description: 'Browse notebooks and capture quick notes alongside any Grafana page',
+        component: NotebooksSidebarPanelLoader,
+      },
+    ],
   });
 
   // Registering core exposed components

--- a/public/app/routes/notebookRoutes.test.ts
+++ b/public/app/routes/notebookRoutes.test.ts
@@ -1,0 +1,28 @@
+import { loadNotebookEditorPage, loadNotebookScenePage, loadNotebooksListPage } from './routes';
+
+jest.mock('../features/notebook/pages/NotebookScenePage', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('../features/notebook/pages/NotebooksListPage', () => ({
+  __esModule: true,
+  NotebooksListPage: () => null,
+}));
+
+jest.mock('../features/notebook/pages/NotebookEditorPage', () => ({
+  __esModule: true,
+  NotebookEditorPage: () => null,
+}));
+
+describe('notebook route loaders', () => {
+  it('resolves notebook page modules', async () => {
+    await expect(loadNotebookScenePage()).resolves.toEqual(expect.objectContaining({ default: expect.any(Function) }));
+    await expect(loadNotebooksListPage()).resolves.toEqual(
+      expect.objectContaining({ NotebooksListPage: expect.any(Function) })
+    );
+    await expect(loadNotebookEditorPage()).resolves.toEqual(
+      expect.objectContaining({ NotebookEditorPage: expect.any(Function) })
+    );
+  });
+});

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -28,6 +28,19 @@ import { getProvisioningRoutes } from '../features/provisioning/utils/routes';
 const isDevEnv = config.buildInfo.env === 'development';
 export const extraRoutes: RouteDescriptor[] = [];
 
+/** Named loaders so notebook routes stay coverage-friendly for navigation owners. */
+export function loadNotebookScenePage() {
+  return import(/* webpackChunkName: "NotebookScenePage" */ '../features/notebook/pages/NotebookScenePage');
+}
+
+export function loadNotebooksListPage() {
+  return import(/* webpackChunkName: "NotebooksListPage" */ '../features/notebook/pages/NotebooksListPage');
+}
+
+export function loadNotebookEditorPage() {
+  return import(/* webpackChunkName: "NotebookEditorPage" */ '../features/notebook/pages/NotebookEditorPage');
+}
+
 export function getAppRoutes(): RouteDescriptor[] {
   const routes: Array<RouteDescriptor | undefined | false> = [
     // Based on the Grafana configuration standalone plugin pages can even override and extend existing core pages, or they can register new routes under existing ones.
@@ -60,9 +73,15 @@ export function getAppRoutes(): RouteDescriptor[] {
       path: '/notebook/:uid/:slug?',
       pageClass: 'page-dashboard',
       routeName: DashboardRoutes.Notebook,
-      component: SafeDynamicImport(
-        () => import(/* webpackChunkName: "NotebookScenePage" */ '../features/notebook/pages/NotebookScenePage')
-      ),
+      component: SafeDynamicImport(loadNotebookScenePage),
+    },
+    {
+      path: '/notebooks',
+      component: SafeDynamicImport(loadNotebooksListPage),
+    },
+    {
+      path: '/notebooks/edit/:uid',
+      component: SafeDynamicImport(loadNotebookEditorPage),
     },
     {
       path: '/dashboard/assistant-preview/*',

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5910,9 +5910,12 @@
     },
     "new-panel-title": "New panel",
     "notebook-layout": {
+      "code-copied": "Code copied",
+      "copy-code": "Copy code",
       "description": "A vertical sequence of panels, text, and code cells",
+      "locked-range": "Locked: {{range}}",
       "name": "Notebook",
-      "pill": "Published Notebook",
+      "pill": "Notebook",
       "time": "Time"
     },
     "on-create-new-row": {
@@ -12684,7 +12687,217 @@
     }
   },
   "notebook": {
-    "breadcrumb-title": "Notebooks"
+    "back-button": "All notebooks",
+    "breadcrumb-title": "Notebooks",
+    "copy-link": "Copy link",
+    "delete": "Delete notebook",
+    "delete-body": "Are you sure you want to delete this notebook?",
+    "delete-confirm": "Delete",
+    "delete-title": "Delete notebook",
+    "duplicate": "Duplicate notebook",
+    "edit-button": "Edit",
+    "link-copied": "Notebook link copied",
+    "more-actions": "More actions",
+    "time-picker": {
+      "move-backward-tooltip": "Move {{duration}} backward",
+      "move-forward-tooltip": "Move {{duration}} forward"
+    }
+  },
+  "notebooks": {
+    "activity": {
+      "added-code": "added a code block",
+      "added-note": "added a note",
+      "added-text": "added a text block",
+      "added-viz": "added a visualization",
+      "changed-time": "changed the notebook time range",
+      "changed-viz": "changed a visualization",
+      "deleted-block": "deleted a block",
+      "duplicated-block": "duplicated a block",
+      "edited-query": "edited a query",
+      "empty": "Edits made while this notebook is open will show up here.",
+      "locked-time": "locked a block to a time range",
+      "moved-block": "moved a block",
+      "renamed-panel": "renamed a panel",
+      "title": "Activity",
+      "tooltip": "Activity",
+      "unlocked-time": "synced a block back to notebook time"
+    },
+    "add-cell": {
+      "code": "Code",
+      "text": "Text",
+      "visualization": "Visualization",
+      "viz-cancel": "Cancel",
+      "viz-hint": "Tip: any dashboard panel or Explore query can also be added via “Add to notebook”."
+    },
+    "add-form": {
+      "add": "Add",
+      "add-open": "Add & open notebook",
+      "added": "Added to notebook",
+      "cancel": "Cancel",
+      "default-title": "Investigation — {{date}}",
+      "error-title": "Could not add to notebook",
+      "existing": "Existing notebook",
+      "failed": "Failed to add to notebook",
+      "lock-time": "Lock this panel to the current time window",
+      "lock-time-description": "{{from}} → {{to}}",
+      "new": "New notebook",
+      "none-yet": "No notebooks yet",
+      "notebook-label": "Notebook",
+      "notebook-placeholder": "Choose a notebook",
+      "select-required": "Select a notebook to add to.",
+      "source": "Adding a live panel from {{sourceName}}.",
+      "target-label": "Target notebook",
+      "title-label": "Notebook name"
+    },
+    "add-from-explore": {
+      "origin": "From Explore ({{datasource}})",
+      "panel-title": "Explore query",
+      "source": "Explore"
+    },
+    "add-from-panel": {
+      "origin": "From dashboard: {{title}}",
+      "unnamed-dashboard": "this dashboard"
+    },
+    "add-modal": {
+      "title": "Add to notebook"
+    },
+    "cell": {
+      "assistant-badge": "Assistant",
+      "delete": "Delete block",
+      "drag": "Drag to reorder block",
+      "duplicate": "Duplicate block",
+      "edit-query": "Edit query",
+      "explore": "Open in Explore",
+      "locked-range": "Locked: {{range}}",
+      "rename": "Rename panel",
+      "rename-label": "Panel title",
+      "time-close": "Close",
+      "time-lock": "Lock to a specific time range",
+      "time-locked": "Edit locked time range",
+      "time-sync": "Use notebook time",
+      "unlock": "Sync back to notebook time range"
+    },
+    "code-cell": {
+      "done": "Done editing",
+      "edit-label": "Edit code block",
+      "empty": "Click to add code — a query, a command, a config snippet…",
+      "language": "Code language"
+    },
+    "declare-incident": {
+      "button": "Declare incident"
+    },
+    "editor": {
+      "block-deleted": "Block deleted",
+      "copied-markdown": "Notebook copied as Markdown",
+      "copy-link": "Copy link",
+      "copy-markdown": "Copy as Markdown",
+      "delete": "Delete notebook",
+      "delete-body": "Are you sure you want to delete \"{{title}}\"?",
+      "delete-confirm": "Delete",
+      "delete-title": "Delete notebook",
+      "duplicate": "Duplicate notebook",
+      "empty-body": "Write down what you are seeing, then bring in live data — add a visualization below, or capture any dashboard panel or Explore query with “Add to notebook”.",
+      "empty-dashboards": "Browse dashboards",
+      "empty-explore": "Open Explore",
+      "empty-title": "Start your investigation",
+      "following": "Following {{name}}",
+      "library-panel": "Library panel — open the notebook view to render it",
+      "link-copied": "Notebook link copied",
+      "load-error": "Failed to load notebook",
+      "more": "More actions",
+      "redo": "Redo (⇧⌘Z)",
+      "save-failed": "Failed to save notebook",
+      "status-clean": "All changes saved",
+      "status-pending": "Saving shortly…",
+      "status-saved": "Saved {{when}}",
+      "status-saving": "Saving…",
+      "status-unsaved": "Unsaved changes",
+      "stop-following": "Stop following",
+      "tags-placeholder": "Add tags",
+      "title-label": "Notebook title",
+      "title-placeholder": "Give this notebook a title",
+      "undo": "Undo (⌘Z)",
+      "undo-delete": "Undo",
+      "untitled": "Untitled notebook",
+      "view": "View"
+    },
+    "insert-divider": {
+      "code": "Code",
+      "text": "Text",
+      "tooltip": "Insert block here",
+      "visualization": "Visualization"
+    },
+    "list": {
+      "cell-count_one": "{{count}} block",
+      "cell-count_other": "{{count}} blocks",
+      "copy-link": "Copy link",
+      "copy-link-label": "Copy link to notebook {{title}}",
+      "copy-title": "{{title}} (copy)",
+      "delete": "Delete",
+      "delete-body": "Are you sure you want to delete \"{{title}}\"?",
+      "delete-confirm": "Delete",
+      "delete-label": "Delete notebook {{title}}",
+      "delete-title": "Delete notebook",
+      "duplicate": "Duplicate",
+      "duplicate-label": "Duplicate notebook {{title}}",
+      "edit": "Edit",
+      "empty-body": "Notebooks are living documents for investigations: mix text with live panels added from dashboards and Explore, and collaborate with your team in real time.",
+      "empty-title": "You have not created any notebooks yet",
+      "link-copied": "Notebook link copied",
+      "new-notebook": "New notebook",
+      "new-notebook-title": "Investigation — {{date}}",
+      "no-results": "No notebooks match your search",
+      "panel-count_one": "{{count}} panel",
+      "panel-count_other": "{{count}} panels",
+      "search-placeholder": "Search notebooks by name, description or tag",
+      "subtitle": "Capture investigations combining narrative text with live visualizations from your dashboards and Explore.",
+      "updated": "Updated {{when}}"
+    },
+    "markdown-cell": {
+      "edit-label": "Edit text cell",
+      "empty": "Click to add text — markdown, links and images supported",
+      "image-too-large": "Image is too large to embed (roughly 500KB max)",
+      "image-unsupported": "This file type cannot be embedded",
+      "placeholder": "Write markdown… (paste or drop images)"
+    },
+    "panel-cell": {
+      "resize": "Resize panel"
+    },
+    "presence": {
+      "click-to-follow": "{{name}} is in this notebook — click to follow",
+      "stop-following": "Following {{name}} — click to stop",
+      "viewing": "{{name}} is in this notebook"
+    },
+    "query-editor": {
+      "close": "Close query editor",
+      "no-datasource": "The data source for this panel could not be loaded.",
+      "no-editor": "This data source does not provide a query editor that can be embedded here.",
+      "query-picker": "Query to edit",
+      "run": "Run query",
+      "run-tooltip": "Ctrl/Cmd + Enter to run"
+    },
+    "quick-add": {
+      "added": "Added to notebook"
+    },
+    "sidebar": {
+      "add-note": "Add note (Enter)",
+      "delete-block": "Delete block",
+      "edit": "Open in editor",
+      "empty": "No notebooks yet — create one to start capturing findings.",
+      "new": "New",
+      "no-blocks": "Nothing here yet — capture your first note below, or add panels from any dashboard.",
+      "note-placeholder": "Jot a quick note — Enter to add",
+      "open": "Open notebook",
+      "picker": "Notebook",
+      "status-synced": "All changes saved",
+      "title": "Notebooks",
+      "view-all": "View all"
+    },
+    "viz-suggestions": {
+      "no-data": "No data yet — suggestions appear once the panel has results.",
+      "none": "No suggestions for this data shape.",
+      "tooltip": "Change visualization"
+    }
   },
   "notifications": {
     "empty-state": {
@@ -12849,6 +13062,8 @@
       }
     },
     "header-menu": {
+      "add-to-last-notebook": "Add to \"{{title}}\"",
+      "add-to-notebook": "Add to notebook",
       "copy": "Copy",
       "copy-styles": "Copy styles",
       "download-diagnostics": "Download diagnostics",
@@ -16033,6 +16248,8 @@
       "current-time-selected": "Time range selected: {{currentTimeRange}}",
       "forwards-time-aria-label": "Move time range forwards",
       "to": "to",
+      "zoom-in-button": "Zoom in time range",
+      "zoom-in-tooltip": "Time range zoom in <br/> t +",
       "zoom-out-button": "Zoom out time range",
       "zoom-out-tooltip-new": "Time range zoom out <br/> t -"
     },


### PR DESCRIPTION
## What changed

Extracts the frontend portion of #129904 into an independently buildable notebooks experience:

- notebook list, editor, and read-only scene view
- markdown, code, and visualization cells with autosave and undo/redo
- capture from dashboard panels and Explore, including quick-add to the last notebook
- docked notebook sidebar companion
- panel time locking, resizing, visualization suggestions, and query editing
- best-effort Live collaboration UI for presence, cursors, activity, follow, and document convergence
- share, duplicate, Markdown export, and declare-incident entry points

## Why

This makes the POC releasable for internal dogfooding while keeping frontend and backend deployment cadences separate.

Backend counterpart: #129915.

## Safety and compatibility

- all entry points remain behind `dashboard.notebooks`
- the frontend compiles against current `main` without including backend-generated schema files
- a local compatibility type covers the optional layout fields owned by #129915
- existing dashboard, Explore, time picker, and extension behavior is covered by focused tests

## Validation

- `yarn typecheck`
- 18 changed Jest suites: 136 tests passed
- `yarn build` including React 18 and React 19 production bundles
- pre-commit frontend lint and formatting

Split from draft POC #129904.

## Dogfooding

Try the complete end-to-end notebook experience in the [ephemeral notebook environment](https://ephemeral15111821129904nmarrs.grafana-dev.net/notebooks). It is deployed from the original combined POC in #129904; the stacked PRs preserve that combined behavior while presenting smaller review layers.

## Review stack

This combined POC has been split into GitHub native stack **#129979** for focused review and CI:

1. [#129915 — Schema, live sync, and navigation support](https://github.com/grafana/grafana/pull/129915)
2. [#129971 — Document model and rendering foundation](https://github.com/grafana/grafana/pull/129971)
3. [#129972 — Core notebook experience](https://github.com/grafana/grafana/pull/129972)
4. [#129973 — Realtime collaboration POC](https://github.com/grafana/grafana/pull/129973)
5. [#129974 — Shared capture workflow and dashboard capture](https://github.com/grafana/grafana/pull/129974)
6. [#129975 — Explore capture integration](https://github.com/grafana/grafana/pull/129975)
7. [#129977 — Sidebar and command palette integrations](https://github.com/grafana/grafana/pull/129977)
8. [#129978 — IRM integration](https://github.com/grafana/grafana/pull/129978)

Please review the smaller stacked PRs rather than this combined diff. This PR remains useful as end-to-end implementation and deployment context.