### PR TITLE
Notifications: Don't stop sending emails after the first failure

### DIFF
--- a/pkg/services/notifications/smtp.go
+++ b/pkg/services/notifications/smtp.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -55,16 +56,18 @@ func (sc *SmtpClient) Send(ctx context.Context, messages ...*Message) (int, erro
 		return sentEmailsCount, err
 	}
 
+	var errs []error
+
 	for _, msg := range messages {
 		err := sc.sendMessage(ctx, dialer, msg)
 		if err != nil {
-			return sentEmailsCount, err
+			errs = append(errs, err)
+			continue
 		}
-
 		sentEmailsCount++
 	}
 
-	return sentEmailsCount, nil
+	return sentEmailsCount, errors.Join(errs...)
 }
 
 func (sc *SmtpClient) sendMessage(ctx context.Context, dialer *gomail.Dialer, msg *Message) error {

--- a/pkg/services/notifications/smtp_test.go
+++ b/pkg/services/notifications/smtp_test.go
@@ -342,3 +342,53 @@ func TestSmtpSend(t *testing.T) {
 		}
 	})
 }
+
+func TestSmtpSendPartialFailure(t *testing.T) {
+	srv := smtpmock.New(smtpmock.ConfigurationAttr{
+		HostAddress:               "127.0.0.1",
+		BlacklistedRcpttoEmails:   []string{"rejected@example.com"},
+		MsgRcpttoBlacklistedEmail: "550 5.1.1 User unknown",
+	})
+	require.NoError(t, srv.Start())
+	defer func() { _ = srv.Stop() }()
+
+	cfg := createSmtpConfig()
+	cfg.Smtp.Host = fmt.Sprintf("127.0.0.1:%d", srv.PortNumber())
+
+	client, err := NewSmtpClient(cfg.Smtp)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	t.Run("rejected recipient does not block the remaining messages", func(t *testing.T) {
+		msgs := []*Message{
+			{From: "from@example.com", To: []string{"rcpt1@example.com"},
+				Subject: "subject", Body: map[string]string{"text/plain": "hello world"}},
+			{From: "from@example.com", To: []string{"rejected@example.com"},
+				Subject: "subject", Body: map[string]string{"text/plain": "hello world"}},
+			{From: "from@example.com", To: []string{"rcpt3@example.com"},
+				Subject: "subject", Body: map[string]string{"text/plain": "hello world"}},
+		}
+
+		count, err := client.Send(ctx, msgs...)
+		require.Equal(t, 2, count)
+		require.ErrorContains(t, err, "5.1.1 User unknown")
+
+		// every SMTP session is recorded, but only the two accepted
+		// recipients have consistent (fully delivered) messages
+		messages, err := srv.WaitForMessagesAndPurge(3, 5*time.Second)
+		require.NoError(t, err)
+
+		var delivered []string
+		for _, sentMsg := range messages {
+			if sentMsg.IsConsistent() {
+				delivered = append(delivered, sentMsg.RcpttoRequestResponse()[0][0])
+			}
+		}
+		sort.Strings(delivered)
+		require.Equal(t, []string{
+			"RCPT TO:<rcpt1@example.com>",
+			"RCPT TO:<rcpt3@example.com>",
+		}, delivered)
+	})
+}


### PR DESCRIPTION
Regressed in #90559, originally fixed in #16881.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fixes email notifications so one failed address doesn't stop the rest of the list. The send loop in pkg/services/notifications/smtp.go returned on the first error, skipping every remaining recipient. It now attempts all messages and returns the errors joined.

**Why do we need this feature?**

One stale address in an email contact point silently blocks everyone after it from getting alert emails. This was fixed in #16881 but regressed in #90559 during a tracing refactor.

**Who is this feature for?**

Anyone using email contact points with multiple addresses.

**Which issue(s) does this PR fix?**:

Fixes #129917

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer:**

The regression test fails on main (count 1 instead of 2) and passes with the fix.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
