### PR TITLE
chore: add satokengen/apikey to generated enterprise imports

### DIFF
--- a/pkg/extensions/enterprise_imports.go
+++ b/pkg/extensions/enterprise_imports.go
@@ -165,6 +165,7 @@ import (
 	_ "github.com/grafana/grafana/pkg/components/loki/logproto"
 	_ "github.com/grafana/grafana/pkg/components/loki/lokigrpc"
 	_ "github.com/grafana/grafana/pkg/components/loki/lokihttp"
+	_ "github.com/grafana/grafana/pkg/components/satokengen"
 	_ "github.com/grafana/grafana/pkg/components/simplejson"
 	_ "github.com/grafana/grafana/pkg/configprovider"
 	_ "github.com/grafana/grafana/pkg/events"

--- a/pkg/extensions/enterprise_imports.go
+++ b/pkg/extensions/enterprise_imports.go
@@ -157,6 +157,7 @@ import (
 	_ "github.com/grafana/grafana/pkg/components/loki/logproto"
 	_ "github.com/grafana/grafana/pkg/components/loki/lokigrpc"
 	_ "github.com/grafana/grafana/pkg/components/loki/lokihttp"
+	_ "github.com/grafana/grafana/pkg/components/satokengen"
 	_ "github.com/grafana/grafana/pkg/components/simplejson"
 	_ "github.com/grafana/grafana/pkg/configprovider"
 	_ "github.com/grafana/grafana/pkg/events"

--- a/pkg/extensions/enterprise_imports_test.go
+++ b/pkg/extensions/enterprise_imports_test.go
@@ -24,6 +24,8 @@ import (
 	_ "github.com/grafana/grafana/pkg/registry/apis/secret/testutils"
 	_ "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
 	_ "github.com/grafana/grafana/pkg/services/anonymous/anontest"
+	_ "github.com/grafana/grafana/pkg/services/apikey"
+	_ "github.com/grafana/grafana/pkg/services/apikey/apikeytest"
 	_ "github.com/grafana/grafana/pkg/services/authn/authntest"
 	_ "github.com/grafana/grafana/pkg/services/authz/zanzana/client"
 	_ "github.com/grafana/grafana/pkg/services/authz/zanzana/server"


### PR DESCRIPTION
Regenerates `pkg/extensions/enterprise_imports.go` via `make update-workspace` to include `github.com/grafana/grafana/pkg/components/satokengen` and `github.com/grafana/grafana/pkg/services/apikey{,/apikeytest}`.