### PR TITLE
Auth: Skip session token rotation when request is not session authenticated

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -946,7 +946,7 @@ playwright.storybook.config.ts @grafana/grafana-frontend-platform
 /public/app/core/utils/applyStateChanges.ts @grafana/dashboards-squad
 /public/app/core/utils/arrayMove.ts @grafana/grafana-frontend-platform
 /public/app/core/utils/isFrontendService.ts @grafana/grafana-frontend-platform
-/public/app/core/utils/auth.ts @grafana/identity-access-team
+/public/app/core/utils/auth* @grafana/identity-access-team
 /public/app/core/utils/browser* @grafana/grafana-frontend-platform
 /public/app/core/utils/colors.ts @grafana/grafana-frontend-platform
 /public/app/core/utils/debugLog.ts @grafana/dashboards-squad

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -35,7 +35,7 @@ import {
 } from '@grafana/runtime';
 import { appEvents } from 'app/core/app_events';
 import { getConfig } from 'app/core/config';
-import { canRotateSessionToken, getSessionExpiry, hasSessionExpiry } from 'app/core/utils/auth';
+import { getSessionExpiry, hasRotatableSession } from 'app/core/utils/auth';
 import { loadUrlToken } from 'app/core/utils/urlToken';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
 import { type DashboardSearchItem } from 'app/features/search/types';
@@ -511,7 +511,7 @@ export class BackendSrv implements BackendService {
                 }
 
                 let authChecker = this.loginPing();
-                if (hasSessionExpiry() && canRotateSessionToken(this.dependencies.contextSrv.user.authenticatedBy)) {
+                if (hasRotatableSession(this.dependencies.contextSrv.user.authenticatedBy)) {
                   const expired = getSessionExpiry() * 1000 < Date.now();
                   if (expired) {
                     authChecker = this.rotateToken();

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -35,7 +35,7 @@ import {
 } from '@grafana/runtime';
 import { appEvents } from 'app/core/app_events';
 import { getConfig } from 'app/core/config';
-import { getSessionExpiry, hasSessionExpiry } from 'app/core/utils/auth';
+import { canRotateSessionToken, getSessionExpiry, hasSessionExpiry } from 'app/core/utils/auth';
 import { loadUrlToken } from 'app/core/utils/urlToken';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
 import { type DashboardSearchItem } from 'app/features/search/types';
@@ -511,7 +511,7 @@ export class BackendSrv implements BackendService {
                 }
 
                 let authChecker = this.loginPing();
-                if (hasSessionExpiry()) {
+                if (hasSessionExpiry() && canRotateSessionToken(this.dependencies.contextSrv.user.authenticatedBy)) {
                   const expired = getSessionExpiry() * 1000 < Date.now();
                   if (expired) {
                     authChecker = this.rotateToken();

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -10,7 +10,7 @@ import {
   userHasAnyPermission,
 } from '@grafana/data';
 import { featureEnabled, getBackendSrv } from '@grafana/runtime';
-import { getSessionExpiry } from 'app/core/utils/auth';
+import { canRotateSessionToken, getSessionExpiry } from 'app/core/utils/auth';
 import { type UserPermission, AccessControlAction } from 'app/types/accessControl';
 import { type CurrentUserInternal } from 'app/types/config';
 
@@ -222,6 +222,11 @@ export class ContextSrv {
   private canScheduleRotation() {
     // skip if user is not signed in, this happens on login page or when using anonymous auth
     if (!this.isSignedIn) {
+      return false;
+    }
+
+    // skip if the request was authenticated without a session e.g. JWT
+    if (!canRotateSessionToken(this.user.authenticatedBy)) {
       return false;
     }
 

--- a/public/app/core/specs/backend_srv.test.ts
+++ b/public/app/core/specs/backend_srv.test.ts
@@ -90,7 +90,9 @@ const getTestContext = (overides?: object, mockFromFetch = true) => {
 jest.mock('app/core/utils/auth', () => ({
   ...jest.requireActual('app/core/utils/auth'),
   getSessionExpiry: () => 1,
-  hasSessionExpiry: () => true,
+  // pretend the session expiry cookie is always present so only the auth method decides
+  hasRotatableSession: (authenticatedBy?: string) =>
+    jest.requireActual('app/core/utils/auth').canRotateSessionToken(authenticatedBy),
 }));
 
 describe('backendSrv', () => {

--- a/public/app/core/specs/backend_srv.test.ts
+++ b/public/app/core/specs/backend_srv.test.ts
@@ -18,6 +18,7 @@ const getTestContext = (overides?: object, mockFromFetch = true) => {
     statusText: 'Ok',
     isSignedIn: true,
     orgId: 1337,
+    authenticatedBy: undefined as string | undefined,
     redirected: false,
     type: 'basic',
     url: 'http://localhost:3000/api/some-mock',
@@ -47,6 +48,7 @@ const getTestContext = (overides?: object, mockFromFetch = true) => {
   const user: User = {
     isSignedIn: props.isSignedIn,
     orgId: props.orgId,
+    authenticatedBy: props.authenticatedBy,
   } as jest.MockedObject<User>;
   const contextSrvMock: ContextSrv = {
     user,
@@ -86,6 +88,7 @@ const getTestContext = (overides?: object, mockFromFetch = true) => {
 };
 
 jest.mock('app/core/utils/auth', () => ({
+  ...jest.requireActual('app/core/utils/auth'),
   getSessionExpiry: () => 1,
   hasSessionExpiry: () => true,
 }));
@@ -213,6 +216,29 @@ describe('backendSrv', () => {
           expect(logoutMock).not.toHaveBeenCalled();
           expect(backendSrv.rotateToken).toHaveBeenCalledTimes(1);
           expect(fetchMock).toHaveBeenCalledTimes(2); // expecting 2 calls because of retry and because the tokenRotation is mocked
+        });
+      });
+    });
+
+    describe('when making an unsuccessful call and the request was authenticated without a session', () => {
+      it('then it should not rotate the token', async () => {
+        const url = '/api/dashboard/';
+        const { backendSrv, logoutMock } = getTestContext({
+          ok: false,
+          status: 401,
+          statusText: errorMessage,
+          data: { message: errorMessage },
+          url,
+          authenticatedBy: 'jwt',
+        });
+
+        backendSrv.rotateToken = jest.fn();
+        backendSrv.loginPing = jest.fn().mockResolvedValue({ ok: true } as FetchResponse);
+
+        await backendSrv.request({ url, method: 'GET', retry: 0 }).catch(() => {
+          expect(backendSrv.rotateToken).not.toHaveBeenCalled();
+          expect(backendSrv.loginPing).toHaveBeenCalledTimes(1);
+          expect(logoutMock).not.toHaveBeenCalled();
         });
       });
     });

--- a/public/app/core/utils/auth.test.ts
+++ b/public/app/core/utils/auth.test.ts
@@ -1,0 +1,19 @@
+import { canRotateSessionToken } from './auth';
+
+describe('canRotateSessionToken', () => {
+  it.each(['jwt', 'extendedjwt'])('returns false when authenticated by %s', (authenticatedBy) => {
+    expect(canRotateSessionToken(authenticatedBy)).toBe(false);
+  });
+
+  it.each(['password', 'oauth_azuread', 'auth.saml', 'ldap', 'authproxy'])(
+    'returns true when authenticated by %s',
+    (authenticatedBy) => {
+      expect(canRotateSessionToken(authenticatedBy)).toBe(true);
+    }
+  );
+
+  it('returns true when the auth method is unknown', () => {
+    expect(canRotateSessionToken(undefined)).toBe(true);
+    expect(canRotateSessionToken('')).toBe(true);
+  });
+});

--- a/public/app/core/utils/auth.test.ts
+++ b/public/app/core/utils/auth.test.ts
@@ -1,4 +1,4 @@
-import { canRotateSessionToken } from './auth';
+import { canRotateSessionToken, hasRotatableSession } from './auth';
 
 describe('canRotateSessionToken', () => {
   it.each(['jwt', 'extendedjwt'])('returns false when authenticated by %s', (authenticatedBy) => {
@@ -15,5 +15,25 @@ describe('canRotateSessionToken', () => {
   it('returns true when the auth method is unknown', () => {
     expect(canRotateSessionToken(undefined)).toBe(true);
     expect(canRotateSessionToken('')).toBe(true);
+  });
+});
+
+describe('hasRotatableSession', () => {
+  afterEach(() => {
+    document.cookie = 'grafana_session_expiry=; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+  });
+
+  it('returns true when the session expiry cookie is present and the auth method rotates', () => {
+    document.cookie = 'grafana_session_expiry=1743967026';
+    expect(hasRotatableSession('password')).toBe(true);
+  });
+
+  it('returns false when the session expiry cookie is present but the request was not session authenticated', () => {
+    document.cookie = 'grafana_session_expiry=1743967026';
+    expect(hasRotatableSession('jwt')).toBe(false);
+  });
+
+  it('returns false when there is no session expiry cookie', () => {
+    expect(hasRotatableSession('password')).toBe(false);
   });
 });

--- a/public/app/core/utils/auth.ts
+++ b/public/app/core/utils/auth.ts
@@ -15,3 +15,7 @@ export function getSessionExpiry() {
 export function hasSessionExpiry() {
   return document.cookie.split('; ').findIndex((row) => row.startsWith('grafana_session_expiry=')) > -1;
 }
+
+export function canRotateSessionToken(authenticatedBy?: string) {
+  return authenticatedBy !== 'jwt' && authenticatedBy !== 'extendedjwt';
+}

--- a/public/app/core/utils/auth.ts
+++ b/public/app/core/utils/auth.ts
@@ -12,10 +12,14 @@ export function getSessionExpiry() {
   return parseInt(expiresStr, 10);
 }
 
-export function hasSessionExpiry() {
+function hasSessionExpiry() {
   return document.cookie.split('; ').findIndex((row) => row.startsWith('grafana_session_expiry=')) > -1;
 }
 
 export function canRotateSessionToken(authenticatedBy?: string) {
   return authenticatedBy !== 'jwt' && authenticatedBy !== 'extendedjwt';
+}
+
+export function hasRotatableSession(authenticatedBy?: string) {
+  return hasSessionExpiry() && canRotateSessionToken(authenticatedBy);
 }


### PR DESCRIPTION
**What is this feature?**

The frontend no longer rotates the session token when the request was authenticated without a session such as a JWT. A new `canRotateSessionToken()` helper is checked in two places that trigger a rotation for the background job in `context_srv.ts` and the 401 handler in `backend_srv.ts`

**Why do we need this feature?**

A browser that logged in with OAuth keeps a `grafana_session_expiry` cookie. If it later opens a dashboard authenticated by JWT, the frontend sees that cookie and rotates, but a JWT request has no session. The rotate 401s, the page reloads, and it loops. The iframe flickers.

**Who is this feature for?**

Anyone embedding dashboards with a JWT on the same host as a cookie based login.

**Which issue(s) does this PR fix?**:

Fixes #129386 

**Special notes for your reviewer:**

Tested with `[auth.jwt] url_login = true` and a stale expiry cookie. Without the guard there were 6 rotate requests which were all 401s resulting in 6 navigations total. With the guard that is now down to none with 2 navigations total.

`enable_login_token` doesn't exist for `[auth.jwt]` so JWT never has a session and auth proxy is left out because with that enabled it does.

Also worth considering that `RotateUserAuthToken` deletes the session cookies when roatition fails with `ErrInvalidSessionToken` which would stop this after one iteration but a stale cookie with a token no longer in the database fails with `ErrUserTokenNotFound` and returns a 401 without clearing. Clearing there too would be a partial fix but it's a backend change so I haven't included it however can create a separate issue/PR if helpful.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
