### PR TITLE
SQLite: Parse legacy persisted time values

### DIFF
--- a/pkg/util/xorm/session_convert.go
+++ b/pkg/util/xorm/session_convert.go
@@ -52,6 +52,19 @@ func (session *Session) str2Time(col *core.Column, data string) (outTime time.Ti
 			x, err = time.ParseInLocation("2006-01-02 15:04:05.9999999 Z07:00", sdata, parseLoc)
 			//session.engine.logger.Debugf("time(3) key[%v]: %+v | sdata: [%v]\n", col.FieldName, x, sdata)
 		}
+		if err != nil {
+			legacyTime := sdata
+			if monotonicClock := strings.Index(legacyTime, " m="); monotonicClock >= 0 {
+				legacyTime = legacyTime[:monotonicClock]
+			}
+			x, err = time.ParseInLocation("2006-01-02 15:04:05.999999999 -0700 MST", legacyTime, parseLoc)
+			if err != nil {
+				parts := strings.Fields(legacyTime)
+				if len(parts) == 4 && parts[2] == parts[3] {
+					x, err = time.ParseInLocation("2006-01-02 15:04:05.999999999 -0700", strings.Join(parts[:3], " "), parseLoc)
+				}
+			}
+		}
 	} else if len(sdata) == 19 && strings.Contains(sdata, "-") {
 		x, err = time.ParseInLocation("2006-01-02 15:04:05", sdata, parseLoc)
 		//session.engine.logger.Debugf("time(4) key[%v]: %+v | sdata: [%v]\n", col.FieldName, x, sdata)

--- a/pkg/util/xorm/xorm_test.go
+++ b/pkg/util/xorm/xorm_test.go
@@ -3,10 +3,33 @@ package xorm
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	_ "github.com/grafana/grafana/pkg/util/sqlite"
+	"github.com/grafana/grafana/pkg/util/xorm/core"
 	"github.com/stretchr/testify/require"
 )
+
+func TestStr2TimeParsesLegacySQLiteTimestamp(t *testing.T) {
+	eng, err := NewEngine("sqlite3", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, eng.Close()) })
+
+	session := eng.NewSession()
+	t.Cleanup(session.Close)
+
+	want := time.Date(2026, time.July, 26, 8, 17, 47, 112233638, time.UTC)
+	for _, timestamp := range []string{
+		"2026-07-26 11:47:47.112233638 +0330 +0330 m=+84630.747193824",
+		"2026-07-26 11:47:47.112233638 +0330 +0330",
+	} {
+		t.Run(timestamp, func(t *testing.T) {
+			got, err := session.str2Time(&core.Column{SQLType: core.SQLType{Name: core.DateTime}}, timestamp)
+			require.NoError(t, err)
+			require.True(t, got.Equal(want), "got %s, want %s", got, want)
+		})
+	}
+}
 
 func TestBasicOperationsWithSqlite(t *testing.T) {
 	eng, err := NewEngine("sqlite3", ":memory:")


### PR DESCRIPTION
**What is this feature?**

Adds backward-compatible parsing for malformed SQLite timestamps previously serialized by modernc as Go time.Time.String values.

**Why do we need this feature?**

Grafana now writes stable SQLite time values via _time_format=sqlite, but existing databases can contain legacy values with a duplicated numeric offset and monotonic clock suffix. Those values prevent Grafana from starting after an upgrade.

**Who is this feature for?**

Grafana administrators upgrading an existing SQLite-backed installation.

**Which issue(s) does this PR fix?**

Fixes #129295

**Special notes for your reviewer:**

- Preserves existing timestamp formats and adds the legacy parsing only as a fallback.
- Includes regression coverage for the exact reported timestamp and the no-monotonic-suffix variant.
- Verified with:
  - `go test ./pkg/util/xorm -count=1`
  - `go test ./pkg/util/sqlite -run TestStableTimeFormat -count=1`