### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Grafana allows you to query, visualize, alert on and understand your metrics no 
 
 - [Get Grafana](https://grafana.com/get)
 - [Installation guides](https://grafana.com/docs/grafana/latest/setup-grafana/installation/)
+- [![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/grafana) one-click managed Grafana, no server to run
 
 Unsure if Grafana is for you? Watch Grafana in action on [play.grafana.org](https://play.grafana.org/)!
 


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Grafana to our marketplace, so this PR adds a small "Deploy with Zenith" badge under the README's "Get started" list (links to https://zenith.hosting/host/grafana).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

**What is this feature?**

A one line addition to the README "Get started" list: a "Deploy with Zenith" badge pointing at https://zenith.hosting/host/grafana, where someone can get a managed Grafana instance without standing up a server first.

**Why do we need this feature?**

Readers who land on the README and want to try Grafana today choose between Grafana Cloud and a full self-hosted install. This adds one more low-effort entry point next to the existing installation guides. Docs only, no code changes.

**Who is this feature for?**

People who want a running Grafana without managing the infrastructure under it.

**Which issue(s) does this PR fix?**:

N/A, no linked issue.

**Special notes for your reviewer:**

Single line added to README.md, nothing else touched. Happy to reword the descriptor, move it lower, or close this if you would rather keep that list to first-party links only.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle. (N/A, docs only)
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc. (README only, nothing for What's New)
