### PR TITLE
Live: Add support for additional CSRF host headers when validating allowed origin (#118205)

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2249,6 +2249,12 @@ client_queue_max_size = 4194304
 # If not set then origin will be matched over root_url. Supports wildcard symbol "*".
 allowed_origins =
 
+# csrf_additional_headers is a comma-separated list of additional headers with hosts to check when validating
+# Origin header for CSRF protection. If any of the values of the specified headers match the Origin header, the
+# request is allowed. This is useful when Grafana is behind a proxy that sets a custom header with the original
+# request origin, e.g. "X-Forwarded-Host".
+csrf_additional_headers =
+
 # engine defines an HA (high availability) engine to use for Grafana Live. By default no engine used - in
 # this case Live features work only on a single Grafana server.
 # Available options: "redis".

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -2047,6 +2047,12 @@ default_datasource_uid =
 # If not set then origin will be matched over root_url. Supports wildcard symbol "*".
 ;allowed_origins =
 
+# csrf_additional_headers is a comma-separated list of additional headers with hosts to check when validating
+# Origin header for CSRF protection. If any of the values of the specified headers match the Origin header, the
+# request is allowed. This is useful when Grafana is behind a proxy that sets a custom header with the original
+# request origin, e.g. "X-Forwarded-Host".
+;csrf_additional_headers =
+
 # engine defines an HA (high availability) engine to use for Grafana Live. By default no engine used - in
 # this case Live features work only on a single Grafana server. Available options: "redis".
 ;ha_engine =

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2837,6 +2837,19 @@ For example:
 allowed_origins = "https://*.example.com"
 ```
 
+#### `csrf_additional_headers`
+
+The `csrf_additional_headers` option is a comma-separated list of additional HTTP headers that Grafana Live accepts for CSRF protection during WebSocket connection establishment.
+
+If not set (default), then only the `Host` header is used for CSRF protection, which should be sufficient for most scenarios.
+
+For example:
+
+```ini
+[live]
+csrf_additional_headers = "X-Forwarded-Host,X-Original-Host"
+```
+
 #### `ha_engine`
 
 **Experimental**

--- a/docs/sources/setup-grafana/set-up-grafana-live.md
+++ b/docs/sources/setup-grafana/set-up-grafana-live.md
@@ -153,6 +153,8 @@ By default, Live accepts connections with Origin header that matches configured 
 
 It is possible to provide a list of additional origin patterns to allow WebSocket connections from. This can be achieved using the [allowed_origins](../configure-grafana/#allowed_origins) option of Grafana Live configuration.
 
+If Grafana is run behind a reverse proxy which overrides the Host header additional headers which contain the real host may be specified via [csrf_additional_headers](../configure-grafana/#csrf_additional_headers) option to check the origin of WebSocket requests.
+
 #### Resource usage
 
 Each persistent connection costs some memory on a server. Typically, this should be about 50 KB per connection at this moment. Thus a server with 1 GB RAM is expected to handle about 20k connections max. Each active connection consumes additional CPU resources since the client and server send PING/PONG frames to each other to maintain a connection.

--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -339,7 +339,7 @@ func ProvideService(cfg *setting.Cfg, routeRegister routing.RouteRegister, plugC
 
 	originPatterns := g.Cfg.LiveAllowedOrigins
 	originGlobs, _ := setting.GetAllowedOriginGlobs(originPatterns) // error already checked on config load.
-	checkOrigin := getCheckOriginFunc(appURL, originPatterns, originGlobs)
+	checkOrigin := getCheckOriginFunc(appURL, originPatterns, originGlobs, cfg.LiveCSRFAdditionalHeaders)
 
 	wsCfg := centrifuge.WebsocketConfig{
 		ReadBufferSize:   1024,
@@ -539,7 +539,7 @@ func (g *GrafanaLive) Run(ctx context.Context) error {
 	return eGroup.Wait()
 }
 
-func getCheckOriginFunc(appURL *url.URL, originPatterns []string, originGlobs []glob.Glob) func(r *http.Request) bool {
+func getCheckOriginFunc(appURL *url.URL, originPatterns []string, originGlobs []glob.Glob, csrfAdditionalHeaders []string) func(r *http.Request) bool {
 	return func(r *http.Request) bool {
 		origin := r.Header.Get("Origin")
 		if origin == "" {
@@ -557,7 +557,15 @@ func getCheckOriginFunc(appURL *url.URL, originPatterns []string, originGlobs []
 		if strings.EqualFold(originURL.Host, r.Host) {
 			return true
 		}
-		ok, err := checkAllowedOrigin(origin, originURL, appURL, originGlobs)
+		ok, err := checkAllowedAdditionalCSRFHeaders(r, originURL, csrfAdditionalHeaders)
+		if err != nil {
+			logger.Warn("Error checking additional CSRF headers", "error", err, "origin", origin)
+			return false
+		}
+		if ok {
+			return true
+		}
+		ok, err = checkAllowedOrigin(origin, originURL, appURL, originGlobs)
 		if err != nil {
 			logger.Warn("Error parsing request origin", "error", err, "origin", origin)
 			return false
@@ -568,6 +576,24 @@ func getCheckOriginFunc(appURL *url.URL, originPatterns []string, originGlobs []
 		}
 		return true
 	}
+}
+
+func checkAllowedAdditionalCSRFHeaders(r *http.Request, originURL *url.URL, csrfAdditionalHeaders []string) (bool, error) {
+	origin := originURL.Hostname()
+	for _, header := range csrfAdditionalHeaders {
+		customHost := r.Header.Get(header)
+		if customHost == "" {
+			continue
+		}
+		addr, err := util.SplitHostPortDefault(customHost, "", "0") // we ignore the port
+		if err != nil {
+			return false, fmt.Errorf("error parsing additional CSRF header %s: %w", header, err)
+		}
+		if addr.Host == origin {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func checkAllowedOrigin(origin string, originURL *url.URL, appURL *url.URL, originGlobs []glob.Glob) (bool, error) {

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -571,6 +571,10 @@ type Cfg struct {
 	// LiveAllowedOrigins is a set of origins accepted by Live. If not provided
 	// then Live uses AppURL as the only allowed origin.
 	LiveAllowedOrigins []string
+	// csrf_additional_headers is a comma-separated list of additional headers to check when validating
+	// Origin header for CSRF protection. The first non-empty header value will be used as the origin.
+	// This is useful when Grafana is behind a proxy that sets a custom header with the original request origin.
+	LiveCSRFAdditionalHeaders []string
 	// LiveMessageSizeLimit is the maximum size in bytes of Websocket messages
 	// from clients. Defaults to 64KB.
 	LiveMessageSizeLimit int
@@ -2514,6 +2518,18 @@ func (cfg *Cfg) readLiveSettings(iniFile *ini.File) error {
 	}
 
 	cfg.LiveAllowedOrigins = originPatterns
+
+	csrfAdditionalHeaders := section.Key("csrf_additional_headers").MustString("")
+	headers := strings.Split(csrfAdditionalHeaders, ",")
+	headerList := make([]string, 0, len(headers))
+	for _, header := range headers {
+		header = strings.TrimSpace(header)
+		if header != "" {
+			headerList = append(headerList, header)
+		}
+	}
+	cfg.LiveCSRFAdditionalHeaders = headerList
+
 	return nil
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds support for specifying additional host headers to check for when validating allowed origin in Grafana Live. This option already exists for Grafana's main API but was still missing in Grafana Live.

**Why do we need this feature?**

Behind reverse proxy setups the "Host" header in HTTP 1/ is usually overridden and the real host of the request mirrored in X-Forwarded-Host or similar semi-standardized proxy headers. Since host is no longer the original host of the request any request to Grafana Live will fail with Origin validation errors. This allows specifying custom headers which contain the real host in such setups to be taken into consideration.

**Who is this feature for?**

Users who run Grafana behind complex reverse-proxy setups with the need of overriding the Host headers to route the request correctly.

**Which issue(s) does this PR fix?**:

Fixes #118205 

**Special notes for your reviewer:**

From my perspective this requires both "add to changelog" as well as "add to what's new" labels. However, I seem to lack permissions to add such labels to this PR.

This is my second PR attempt for this issue as the original PR has been marked stale and was therefore closed.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.