### PR TITLE
fix: allow single @ prefix in ColName for Elasticsearch @timestamp columns

### DIFF
--- a/pkg/expr/sql/parser_allow.go
+++ b/pkg/expr/sql/parser_allow.go
@@ -98,7 +98,7 @@ func allowedNode(node sqlparser.SQLNode) (b bool) {
 		// These are parsed as ColName with the @@ prefix in Name.val.
 		// Also reject @@global.hostname where @@ is in the Qualifier.
 		name := v.Name.String()
-		if strings.HasPrefix(name, "@@") || strings.HasPrefix(name, "@") {
+		if strings.HasPrefix(name, "@@") {
 			return false
 		}
 		if qual := v.Qualifier.Name.String(); strings.HasPrefix(qual, "@@") {


### PR DESCRIPTION
## Description

**Fix**: Allow single `@` prefix in SQL expression column names for Elasticsearch compatibility.

The CVE fix for MySQL system variable access (`@@hostname`, `@@version`, etc.) was too strict — it blocked ALL column names starting with `@`, including legitimate Elasticsearch columns like `@timestamp`.

### Root Cause

In `pkg/expr/sql/parser_allow.go`, the `ColName` case in `allowedNode()` checks for both `@@` and `@` prefixes:

```go
if strings.HasPrefix(name, "@@") || strings.HasPrefix(name, "@") {
    return false
}
```

MySQL uses `@@` for system variables (e.g., `@@hostname`, `@@version`, `@@secure_file_priv`), but `@` alone is used for user-defined variables AND as a valid column name prefix in Elasticsearch (`@timestamp`).

### Fix

Only block `@@` (MySQL system variables), allow `@` prefix:

```go
if strings.HasPrefix(name, "@@") {
    return false
}
```

### Related Issue

Closes #129928
