### PR TITLE
Chore: Fix out-of-sync lockfile + package.json

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/package.json
+++ b/public/app/plugins/datasource/cloudwatch/package.json
@@ -5,9 +5,9 @@
   "version": "13.2.0-pre",
   "dependencies": {
     "@emotion/css": "11.13.5",
-    "@grafana/aws-sdk": "^0.10.1",
+    "@grafana/aws-sdk": "^0.12.0",
     "@grafana/data": "13.2.0-pre",
-    "@grafana/plugin-ui": "^0.13.1",
+    "@grafana/plugin-ui": "^0.17.3",
     "@grafana/runtime": "13.2.0-pre",
     "@grafana/scenes": "8.13.5",
     "@grafana/schema": "13.2.0-pre",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2055,11 +2055,11 @@ __metadata:
   resolution: "@grafana-plugins/grafana-cloudwatch-datasource@workspace:public/app/plugins/datasource/cloudwatch"
   dependencies:
     "@emotion/css": "npm:11.13.5"
-    "@grafana/aws-sdk": "npm:^0.10.1"
+    "@grafana/aws-sdk": "npm:^0.12.0"
     "@grafana/data": "npm:13.2.0-pre"
     "@grafana/e2e-selectors": "npm:13.2.0-pre"
     "@grafana/plugin-configs": "npm:13.2.0-pre"
-    "@grafana/plugin-ui": "npm:^0.13.1"
+    "@grafana/plugin-ui": "npm:^0.17.3"
     "@grafana/runtime": "npm:13.2.0-pre"
     "@grafana/scenes": "npm:8.13.5"
     "@grafana/schema": "npm:13.2.0-pre"


### PR DESCRIPTION
**What is this feature?**

Updates the aws-sdk version for the cloudwatch datasource plugin, and syncs the lockfile. Also updates the plugin-ui version, as a newer version is required by the newer version of aws-sdk.

**Why do we need this feature?**

#129585 landed with an outdated version of aws-sdk, resulting in the lockfile being out-of-sync, and causing a significant diff if simply synced w/o updating the version.

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
