### PR TITLE
Query Editor: Use primary text color instead of maxContrast

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/SqlExpressionsCTA.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/SqlExpressionsCTA.tsx
@@ -7,7 +7,7 @@ export function SqlExpressionsCTA({ onAddSqlExpression }: { onAddSqlExpression: 
       <Stack direction="row" alignItems="center" gap={1} justifyContent="space-between">
         <Stack alignItems="center" gap={1}>
           <Icon name="database" />
-          <Text variant="bodySmall" color="maxContrast">
+          <Text variant="bodySmall" color="primary">
             <Trans i18nKey="dashboard.transformation-type-picker.sql-cta-description">
               Prefer SQL? Add a SQL expression to your queries instead.
             </Trans>

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/CollapsableSection.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/CollapsableSection.tsx
@@ -28,7 +28,7 @@ export const CollapsableSection = ({ label, isOpen, onToggle, headerAction, chil
           aria-controls={contentId}
         >
           <Icon name={isOpen ? 'angle-down' : 'angle-right'} />
-          <Text color="maxContrast" variant="bodySmall" weight="light">
+          <Text color="primary" variant="bodySmall" weight="light">
             {label}
           </Text>
         </button>


### PR DESCRIPTION
## Description
<!--- A high level description of what this PR is doing -->
The new panel editor used the `maxContrast` text color in two places where it doesn't apply. `maxContrast` is intended for text on saturated colored backgrounds, but both call sites render on the default surface, so they read brighter than the labels around them. Fixes #129654.

## Changes
<!--- Describe your changes in detail -->
* `SqlExpressionsCTA` — the CTA description now uses `color="primary"`. Its `Box backgroundColor="info"` resolves to a 15% alpha tint rather than a solid fill, so maximum contrast was never needed.
* Sidebar `CollapsableSection` — the section label now uses `color="primary"`, matching the adjacent chevron icon that already inherited the ambient text color.
* The shared `grafana-ui` `Collapse/CollapsableSection` also sets `text.maxContrast` on its label, but that is design-system owned and would move VRT baselines app-wide, so it is intentionally left out of scope.

## Risks
<!--- Describe what risks you've considered i.e. what features are most likely to break -->
Visual only, scoped to two components in the new panel edit experience. Contrast stays above the WCAG AAA 7:1 threshold in both themes.

## Demo
<!--- Attach a demo gif/video or screenshots of the changes if applicable -->
N/A

## Testing Instructions
<!--- Provide step by step instructions and the dashboard if applicable -->
* Open a panel in the new panel editor and confirm the "Queries & Expressions" and "Transformations" sidebar headers render in the standard body text color, matching their chevron icons.
* With the `sqlExpressions` toggle enabled and a backend datasource selected, open the transformation picker and confirm the "Prefer SQL?" CTA text is legible on the blue-tinted box.
* Check both light and dark themes.

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable

Close DPRO-267