### PR TITLE
I18n: Fix key nesting conflicts that silently dropped 13 strings from the catalog

### DIFF
--- a/packages/grafana-ui/src/components/MatchersUI/utils.ts
+++ b/packages/grafana-ui/src/components/MatchersUI/utils.ts
@@ -102,13 +102,13 @@ export function getGroupLabelForScope(scope?: MatcherScope): string | undefined 
 export function getGroupDescriptionForScope(scope: MatcherScope): string | undefined {
   switch (scope) {
     case 'nested':
-      return t('grafana-ui.matchers.groups.nested.description', 'Fields from nested dataframes.');
+      return t('grafana-ui.matchers.groups.nested-description', 'Fields from nested dataframes.');
     case 'annotation':
-      return t('grafana-ui.matchers.groups.annotation.description', 'Annotations series for this panel.');
+      return t('grafana-ui.matchers.groups.annotation-description', 'Annotations series for this panel.');
     case 'series':
-      return t('grafana-ui.matchers.groups.series.description', 'Fields from the dataframes in this panel.');
+      return t('grafana-ui.matchers.groups.series-description', 'Fields from the dataframes in this panel.');
     case 'exemplar':
-      return t('grafana-ui.matchers.groups.exemplar.description', 'Trace exemplars for this panel.');
+      return t('grafana-ui.matchers.groups.exemplar-description', 'Trace exemplars for this panel.');
     default:
       return undefined;
   }

--- a/public/app/features/alerting/unified/components/rules/central-state-history/HistoryErrorMessage.tsx
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/HistoryErrorMessage.tsx
@@ -37,7 +37,7 @@ export function HistoryErrorMessage({ error }: HistoryErrorMessageProps) {
         )}
         severity="error"
       >
-        <Trans i18nKey="alerting.central-alert-history.error.server-error.description">
+        <Trans i18nKey="alerting.central-alert-history.error.server-error-description">
           This can happen when a regex or negation label filter matches too many alert instances and the response
           exceeds the server&apos;s size limit. Try using a shorter time range or a more specific filter (e.g. an exact
           match instead of a regex).
@@ -46,7 +46,7 @@ export function HistoryErrorMessage({ error }: HistoryErrorMessageProps) {
     );
   }
 
-  const title = t('alerting.central-alert-history.error', 'Something went wrong loading the alert state history');
+  const title = t('alerting.central-alert-history.error.title', 'Something went wrong loading the alert state history');
   const errorStr = stringifyErrorLike(error);
 
   return <Alert title={title}>{errorStr}</Alert>;

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.tsx
@@ -199,7 +199,7 @@ export function getLogsButtonTooltip(
       );
     }
     return t(
-      'explore.span-detail-link-buttons.related-logs.no-logs-tooltip',
+      'explore.span-detail-link-buttons.related-logs-no-logs-tooltip',
       'No related logs found using the trace data source configuration.'
     );
   }

--- a/public/app/features/panel/options/builder/annotations.ts
+++ b/public/app/features/panel/options/builder/annotations.ts
@@ -17,9 +17,9 @@ export function addAnnotationOptions<T extends common.OptionsWithAnnotations>(bu
   builder.addBooleanSwitch({
     path: 'annotations.multiLane',
     category,
-    name: t('grafana-ui.builder.annotations.multi-lane-name', 'Enable multi-row annotations'),
+    name: t('grafana-ui.builder.annotation-options.multi-lane-name', 'Enable multi-row annotations'),
     description: t(
-      'grafana-ui.builder.annotations.multi-row-desc',
+      'grafana-ui.builder.annotation-options.multi-row-desc',
       'Breaks each annotation frame into a separate row in the visualization'
     ),
     showIf: (_, __, annotations) =>
@@ -32,9 +32,9 @@ export function addAnnotationOptions<T extends common.OptionsWithAnnotations>(bu
     id: 'clusteringSwitchEditor',
     path: 'annotations.clustering',
     category,
-    name: t('grafana-ui.builder.annotations.clustering.name', 'Enable annotation clustering'),
+    name: t('grafana-ui.builder.annotation-options.clustering-name', 'Enable annotation clustering'),
     description: t(
-      'grafana-ui.builder.annotations.clustering.desc',
+      'grafana-ui.builder.annotation-options.clustering-desc',
       'Combines high density point annotations into region annotations'
     ),
     showIf: (_, __, annotations) => annotations?.some((df) => df.meta?.dataTopic === DataTopic.Annotations),
@@ -45,9 +45,9 @@ export function addAnnotationOptions<T extends common.OptionsWithAnnotations>(bu
     id: 'canvasSwitchEditor',
     path: 'annotations',
     category,
-    name: t('grafana-ui.builder.annotations.canvasControls.name', 'Hide lines and areas'),
+    name: t('grafana-ui.builder.annotation-options.canvas-controls-name', 'Hide lines and areas'),
     description: t(
-      'grafana-ui.builder.annotations.canvasControls.desc',
+      'grafana-ui.builder.annotation-options.canvas-controls-desc',
       'Hides annotation indicator lines and shaded regions'
     ),
     defaultValue: undefined,

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -793,7 +793,9 @@
         "value-in-transition": "Value in transition"
       },
       "error": {
-        "server-error": "The alert state history query failed — the server returned an error"
+        "server-error": "The alert state history query failed — the server returned an error",
+        "server-error-description": "This can happen when a regex or negation label filter matches too many alert instances and the response exceeds the server's size limit. Try using a shorter time range or a more specific filter (e.g. an exact match instead of a regex).",
+        "title": "Something went wrong loading the alert state history"
       },
       "filter": {
         "clear": "Clear filters",
@@ -8871,6 +8873,7 @@
       "open-in-profiles-drilldown": "Open in Profiles Drilldown",
       "profiles-for-this-span": "Profiles for this span",
       "related-logs": "Related logs",
+      "related-logs-no-logs-tooltip": "No related logs found using the trace data source configuration.",
       "related-logs-tooltip": "View related logs using the trace data source configuration.",
       "session-for-this-span": "Session for this span"
     },
@@ -10040,6 +10043,14 @@
       "log-base": "Log base"
     },
     "builder": {
+      "annotation-options": {
+        "canvas-controls-desc": "Hides annotation indicator lines and shaded regions",
+        "canvas-controls-name": "Hide lines and areas",
+        "clustering-desc": "Combines high density point annotations into region annotations",
+        "clustering-name": "Enable annotation clustering",
+        "multi-lane-name": "Enable multi-row annotations",
+        "multi-row-desc": "Breaks each annotation frame into a separate row in the visualization"
+      },
       "annotations": "Annotations",
       "axis": {
         "category-axis": "Axis",
@@ -10375,9 +10386,13 @@
     "matchers": {
       "groups": {
         "annotation": "Annotations",
+        "annotation-description": "Annotations series for this panel.",
         "exemplar": "Exemplars",
+        "exemplar-description": "Trace exemplars for this panel.",
         "nested": "Nested",
-        "series": "Dataframe"
+        "nested-description": "Fields from nested dataframes.",
+        "series": "Dataframe",
+        "series-description": "Fields from the dataframes in this panel."
       },
       "labels": {
         "base-field-name": "{{name}} (base field name)",


### PR DESCRIPTION
**What is this feature?**

Renames 13 translation keys so they stop colliding with sibling keys, and regenerates
`public/locales/en-US/grafana.json`.

i18next uses `.` as a key separator, so a key cannot be both a leaf string *and* a parent
namespace. Where both existed, the extractor kept the shallower key and **skipped** the
deeper one — printing `Error:` for each, then exiting 0 and reporting success.

Four groups, four files:

| File | Fix |
| -- | -- |
| `MatchersUI/utils.ts` | children → `groups.{nested,annotation,series,exemplar}-description` |
| `panel/options/builder/annotations.ts` | children → `grafana-ui.builder.annotation-options.*` |
| `HistoryErrorMessage.tsx` | parent → `…error.title`; child → `…error.server-error-description` |
| `TraceView/…/LogsLink.tsx` | child → `…related-logs-no-logs-tooltip` |

**Note: this is 13 conflicts, not the 12 in the issue.** The extra one
(`explore.span-detail-link-buttons.related-logs`) landed after the issue was written, and
is why traces-and-profiling is on this review.

**Why do we need this feature?**

Two failures:

1. **12 strings never reached the catalog**, so they could never be translated in any
   locale — and never reached Crowdin, so translators couldn't fix it even in principle.
2. **`alerting.central-alert-history.error` resolved to an object**, rendering
   `key '…' returned an object instead of string.` in the UI — in **every** locale,
   including en-US. Not a graceful fallback; English users saw it too.

**Who is this feature for?**

All non-English users (12 strings now translatable), and all users of the alerting central
history error state (a visibly broken string, now fixed).

**Which issue(s) does this PR fix?**:

Fixes #129942

**Special notes for your reviewer:**

The key choice matters here, so it's worth a look. The obvious fix is to rename the
*parent* to clear the namespace — **wrong for two of the four groups.** Those parents are
already translated in all 19 locales, and renaming them orphans every translation, trading
12 missing strings for 5 working ones.

So: rename whichever side of the collision has nothing to lose. Children in groups 1, 2 and
4 (already missing → free); parent in group 3 (an object in every locale, never resolved →
also free).

Verified:
- `yarn i18next-cli extract --sync-primary` → **0** nesting conflicts (was 13)
- `make i18n-extract` → committed tree is byte-identical and idempotent
- **Zero keys removed** from `en-US`; the 6 previously-translated parent leaves still
  resolve to their translations (spot-checked de-DE at runtime against the real catalogs)
- Cross-locale orphan count unchanged (804 → 804, all pre-existing plural forms)
- The whole diff is **14 string literals** — no exported symbol, logic, or English copy changed
- **No matching grafana-enterprise change needed** — enterprise extracts to a separate
  namespace (`grafana-enterprise.json`), references none of these keys in source or in any
  of its 20 catalogs, and shares no call sites

Follow-up: the extractor still exits 0 on conflicts, which is why this went unnoticed.
Tracked as GRA-1861 and **must land after this**, or CI goes red on conflicts that no
longer exist. (Enterprise extracts 0 conflicts today, so that guard won't turn it red either.)

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. — n/a
- [x] The docs are updated — n/a
