### PR TITLE
Traceview: wrap long span attribute values to avoid horizontal scrolling

### DIFF
--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
@@ -127,6 +127,8 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
     jsonTable: css({
       display: 'block',
+      // `word-break: break-word` also shrinks min-content, which lets the table column narrow enough
+      // to wrap long unbroken values. `overflow-wrap: break-word` does not, and restores the scrollbar.
       wordBreak: 'break-word',
     }),
   };

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
@@ -124,7 +124,8 @@ const getStyles = (theme: GrafanaTheme2) => {
       flexShrink: 0,
     }),
     jsonTable: css({
-      display: 'inline-block',
+      display: 'block',
+      wordBreak: 'break-word',
     }),
   };
 };

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
@@ -85,7 +85,8 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
     linkValue: css({
       display: 'inline-flex',
-      alignItems: 'center',
+      // values wrap, so keep the icon on the first line instead of centering it across all of them
+      alignItems: 'flex-start',
       gap: theme.spacing(0.5),
     }),
     linkIcon: css({
@@ -93,7 +94,8 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
     multiLinkValue: css({
       display: 'inline-flex',
-      alignItems: 'center',
+      // values wrap, so keep the chevron on the first line instead of centering it across all of them
+      alignItems: 'flex-start',
       gap: theme.spacing(0.25),
     }),
     multiLinkContent: css({

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/pluginPromo/AttributePluginPromoTip.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/pluginPromo/AttributePluginPromoTip.tsx
@@ -53,7 +53,8 @@ export function AttributePluginPromoTip({ promo, children }: Props) {
 const getStyles = (theme: GrafanaTheme2) => ({
   trigger: css({
     display: 'inline-flex',
-    alignItems: 'center',
+    // attribute values wrap, so keep the icon on the first line instead of centering it across all of them
+    alignItems: 'flex-start',
     gap: theme.spacing(0.5),
     padding: 0,
     margin: 0,


### PR DESCRIPTION
Long span attribute values (URLs, base64 blobs, trace IDs) with no natural break points stretched the attribute table cell to the full content width, forcing horizontal scrolling across the whole span detail panel to read the value. They now wrap within the column.

`word-break: break-word` is the load-bearing change: the table uses auto layout at `width: 100%`, so column width tracks the value's intrinsic width, and `break-word` is the property that reduces the *min-content* contribution and lets the column shrink. A later cleanup to `overflow-wrap: break-word` would look more modern and silently undo the fix — there's now a comment in the file saying so. `display: block` is effectively inert now that the surrounding wrappers are flex containers, but it's harmless and documents the intent.

`type: 'code'` values render into `<pre>`, where soft wrapping is disallowed, so those still scroll horizontally — this addresses the common case, not every attribute type.

### Icon alignment follow-up

Making values wrap exposed a latent alignment bug: the three `inline-flex` value wrappers — the single-link anchor, the multi-link container, and the plugin-promo trigger — all used `align-items: center`. That was invisible while values were single-line, but with a wrapped value it centers the icon/chevron across *all* the lines, dropping it into the gutter between them. They now use `align-items: flex-start`, which puts them on the first line; verified in the browser against a five-line value, and no vertical nudge is needed to sit level with the first line's text.

The key column deliberately keeps `vertical-align: middle`. Switching it to `top` reads better on tall wrapped rows, but pushes every single-line row — the overwhelming majority — to the top of its fixed 30px cell. Doing that properly means replacing the fixed row height with padding, which is a broader change than this fix warrants.

Authored by @swetalin-10 in #125020, re-landed here because that PR's head branch was deleted by fork-side automation on 2026-06-22, leaving it unmergeable. Original commit cherry-picked unchanged, authorship preserved.

Fixes #124671
