### PR TITLE
Fix: Correct test expectations for cloudwatch decoupling

### DIFF
--- a/pkg/plugins/manager/loader/loader_test.go
+++ b/pkg/plugins/manager/loader/loader_test.go
@@ -101,8 +101,9 @@ func TestLoader_Load(t *testing.T) {
 							{Name: "RDS", Path: "dashboards/RDS.json", Type: "dashboard", Role: "Viewer"},
 						},
 						Dependencies: plugins.Dependencies{
-							GrafanaVersion: "*",
-							Plugins:        []plugins.Dependency{},
+							GrafanaDependency: ">=12.3.0",
+							GrafanaVersion:    "*",
+							Plugins:           []plugins.Dependency{},
 							Extensions: plugins.ExtensionsDependencies{
 								ExposedComponents: []string{},
 							},
@@ -116,6 +117,7 @@ func TestLoader_Load(t *testing.T) {
 						},
 						Category:     "cloud",
 						Annotations:  true,
+						Executable:   "gpx_cloudwatch",
 						Metrics:      true,
 						Alerting:     true,
 						Logs:         true,

--- a/pkg/services/pluginsintegration/loader/loader_test.go
+++ b/pkg/services/pluginsintegration/loader/loader_test.go
@@ -99,8 +99,9 @@ func TestLoader_Load(t *testing.T) {
 							{Name: "RDS", Path: "dashboards/RDS.json", Type: "dashboard", Role: "Viewer"},
 						},
 						Dependencies: plugins.Dependencies{
-							GrafanaVersion: "*",
-							Plugins:        []plugins.Dependency{},
+							GrafanaDependency: ">=12.3.0",
+							GrafanaVersion:    "*",
+							Plugins:           []plugins.Dependency{},
 							Extensions: plugins.ExtensionsDependencies{
 								ExposedComponents: []string{},
 							},
@@ -114,6 +115,7 @@ func TestLoader_Load(t *testing.T) {
 						},
 						Category:     "cloud",
 						Annotations:  true,
+						Executable:   "gpx_cloudwatch",
 						Metrics:      true,
 						Alerting:     true,
 						Logs:         true,

--- a/pkg/tests/api/plugins/data/expectedListResp.json
+++ b/pkg/tests/api/plugins/data/expectedListResp.json
@@ -481,7 +481,7 @@
       ]
     },
     "dependencies": {
-      "grafanaDependency": "",
+      "grafanaDependency": ">=12.3.0",
       "grafanaVersion": "*",
       "plugins": [],
       "extensions": {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
The [PR](https://github.com/grafana/grafana/pull/129585) to finish decoupling the CloudWatch core datasource introduced some test failures - not caught because the changes were frontend-only and backend tests were skipped.
