### PR TITLE
fix: write terminal sync status back to repository on early sync-job failures

### DIFF
--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/jobs.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/jobs.go
@@ -386,6 +386,11 @@ func (in JobStatus) ToSyncStatus(jobId string) SyncStatus {
 		s.Message = in.Errors
 	} else if len(in.Warnings) > 0 {
 		s.Message = in.Warnings
+	} else if in.State == JobStateError && in.Message != "" {
+		// Failures that happen outside per-resource processing (e.g. job setup)
+		// are only recorded in Message, not Errors; without this fallback the
+		// sync status would report an error state with no reason.
+		s.Message = []string{in.Message}
 	}
 
 	return s

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/jobs.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/jobs.go
@@ -387,9 +387,6 @@ func (in JobStatus) ToSyncStatus(jobId string) SyncStatus {
 	} else if len(in.Warnings) > 0 {
 		s.Message = in.Warnings
 	} else if in.State == JobStateError && in.Message != "" {
-		// Failures that happen outside per-resource processing (e.g. job setup)
-		// are only recorded in Message, not Errors; without this fallback the
-		// sync status would report an error state with no reason.
 		s.Message = []string{in.Message}
 	}
 

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/jobs_test.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/jobs_test.go
@@ -1,0 +1,62 @@
+package v0alpha1_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+)
+
+func TestJobStatus_ToSyncStatus(t *testing.T) {
+	tests := []struct {
+		name        string
+		status      v0alpha1.JobStatus
+		wantMessage []string
+	}{
+		{
+			name: "errors take precedence",
+			status: v0alpha1.JobStatus{
+				State:    v0alpha1.JobStateError,
+				Message:  "completed with errors",
+				Errors:   []string{"error one", "error two"},
+				Warnings: []string{"warning"},
+			},
+			wantMessage: []string{"error one", "error two"},
+		},
+		{
+			name: "warnings used when no errors",
+			status: v0alpha1.JobStatus{
+				State:    v0alpha1.JobStateWarning,
+				Message:  "completed with warnings",
+				Warnings: []string{"warning"},
+			},
+			wantMessage: []string{"warning"},
+		},
+		{
+			name: "error state falls back to job message",
+			status: v0alpha1.JobStatus{
+				State:   v0alpha1.JobStateError,
+				Message: "create repository resources client: boom",
+			},
+			wantMessage: []string{"create repository resources client: boom"},
+		},
+		{
+			name: "success message is not copied",
+			status: v0alpha1.JobStatus{
+				State:   v0alpha1.JobStateSuccess,
+				Message: "completed successfully",
+			},
+			wantMessage: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			syncStatus := tt.status.ToSyncStatus("test-job")
+			assert.Equal(t, "test-job", syncStatus.JobID)
+			assert.Equal(t, tt.status.State, syncStatus.State)
+			assert.Equal(t, tt.wantMessage, syncStatus.Message)
+		})
+	}
+}

--- a/pkg/registry/apis/provisioning/jobs/driver.go
+++ b/pkg/registry/apis/provisioning/jobs/driver.go
@@ -206,7 +206,7 @@ func (d *jobProcessor) processKey(ctx context.Context, namespace, name string, t
 	go d.leaseRenewalLoop(leaseRenewalCtx, logger, leaseExpired)
 	defer cancelLeaseRenewal()
 
-	recorder := newJobProgressRecorder(d.onProgress(), d.metrics, claimedJob.Spec.Action)
+	recorder := NewJobProgressRecorder(d.onProgress(), d.metrics, claimedJob.Spec.Action)
 	recorder.SetMessage(ctx, "start job")
 
 	// Process the job with lease loss detection

--- a/pkg/registry/apis/provisioning/jobs/progress.go
+++ b/pkg/registry/apis/provisioning/jobs/progress.go
@@ -65,7 +65,7 @@ type jobProgressRecorder struct {
 	action              provisioning.JobAction
 }
 
-func newJobProgressRecorder(progressFn ProgressFn, metrics *JobMetrics, action provisioning.JobAction) JobProgressRecorder {
+func NewJobProgressRecorder(progressFn ProgressFn, metrics *JobMetrics, action provisioning.JobAction) JobProgressRecorder {
 	return &jobProgressRecorder{
 		started:             time.Now(),
 		notifyImmediatelyFn: maybeNotifyProgress(NotifyThrottleInterval, progressFn),

--- a/pkg/registry/apis/provisioning/jobs/progress_test.go
+++ b/pkg/registry/apis/provisioning/jobs/progress_test.go
@@ -123,7 +123,7 @@ func TestJobProgressRecorderSetRefURLs(t *testing.T) {
 	mockProgressFn := func(ctx context.Context, status provisioning.JobStatus) error {
 		return nil
 	}
-	recorder := newJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
+	recorder := NewJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
 
 	// Test setting RefURLs
 	expectedRefURLs := &provisioning.RepositoryURLs{
@@ -151,7 +151,7 @@ func TestJobProgressRecorderSetRefURLsNil(t *testing.T) {
 	mockProgressFn := func(ctx context.Context, status provisioning.JobStatus) error {
 		return nil
 	}
-	recorder := newJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
+	recorder := NewJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
 
 	// Test setting nil RefURLs
 	recorder.SetRefURLs(ctx, nil)
@@ -173,7 +173,7 @@ func TestJobProgressRecorderCompleteIncludesRefURLs(t *testing.T) {
 	mockProgressFn := func(ctx context.Context, status provisioning.JobStatus) error {
 		return nil
 	}
-	recorder := newJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
+	recorder := NewJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
 
 	// Set some RefURLs
 	refURLs := &provisioning.RepositoryURLs{
@@ -198,7 +198,7 @@ func TestJobProgressRecorderWarningStatus(t *testing.T) {
 	mockProgressFn := func(ctx context.Context, status provisioning.JobStatus) error {
 		return nil
 	}
-	recorder := newJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
+	recorder := NewJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
 
 	// Record a result with a warning
 	warningErr := errors.New("deprecated API used")
@@ -287,7 +287,7 @@ func TestJobProgressRecorderWarningWithErrors(t *testing.T) {
 	mockProgressFn := func(ctx context.Context, status provisioning.JobStatus) error {
 		return nil
 	}
-	recorder := newJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
+	recorder := NewJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
 
 	// Record a result with an error (errors take precedence)
 	errorErr := errors.New("failed to process")
@@ -336,7 +336,7 @@ func TestJobProgressRecorderWarningOnlyNoErrors(t *testing.T) {
 	mockProgressFn := func(ctx context.Context, status provisioning.JobStatus) error {
 		return nil
 	}
-	recorder := newJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
+	recorder := NewJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
 
 	// Record only warnings, no errors
 	warningErr := errors.New("deprecated API used")
@@ -368,7 +368,7 @@ func TestJobProgressRecorderFolderFailureTracking(t *testing.T) {
 	mockProgressFn := func(ctx context.Context, status provisioning.JobStatus) error {
 		return nil
 	}
-	recorder := newJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
+	recorder := NewJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
 
 	// Record a folder creation failure with PathCreationError
 	pathErr := &resources.PathCreationError{
@@ -459,7 +459,7 @@ func TestUpdateSummary_TotalChanges(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			recorder := newJobProgressRecorder(noop, nil, tt.action).(*jobProgressRecorder)
+			recorder := NewJobProgressRecorder(noop, nil, tt.action).(*jobProgressRecorder)
 			for _, a := range tt.actions {
 				recorder.Record(ctx, NewPathOnlyResult("file.json").
 					WithAction(a).
@@ -479,7 +479,7 @@ func TestJobProgressRecorderFolderFailureTrackingFromWarning(t *testing.T) {
 	mockProgressFn := func(ctx context.Context, status provisioning.JobStatus) error {
 		return nil
 	}
-	recorder := newJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
+	recorder := NewJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
 
 	// Folder depth violations are surfaced as warnings instead of errors so
 	// the job is not retried in a loop. They must still populate
@@ -512,7 +512,7 @@ func TestJobProgressRecorderFolderUIDTooLongFailureTrackingFromWarning(t *testin
 	mockProgressFn := func(ctx context.Context, status provisioning.JobStatus) error {
 		return nil
 	}
-	recorder := newJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
+	recorder := NewJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
 
 	// Folder UID-length violations are surfaced as warnings instead of
 	// errors so the job is not retried in a loop. They must still populate
@@ -546,7 +546,7 @@ func TestJobProgressRecorderFolderValidationFailureTrackingFromWarning(t *testin
 	mockProgressFn := func(ctx context.Context, status provisioning.JobStatus) error {
 		return nil
 	}
-	recorder := newJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
+	recorder := NewJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
 
 	// Generic folder-API validation rejections (illegal-uid-chars,
 	// reserved-uid, future folder validations) must follow the same
@@ -580,7 +580,7 @@ func TestJobProgressRecorderHasDirPathFailedCreation(t *testing.T) {
 	mockProgressFn := func(ctx context.Context, status provisioning.JobStatus) error {
 		return nil
 	}
-	recorder := newJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
+	recorder := NewJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
 
 	// Add failed creations via Record
 	pathErr1 := &resources.PathCreationError{
@@ -621,7 +621,7 @@ func TestJobProgressRecorderHasDirPathFailedDeletion(t *testing.T) {
 	mockProgressFn := func(ctx context.Context, status provisioning.JobStatus) error {
 		return nil
 	}
-	recorder := newJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
+	recorder := NewJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
 
 	// Add failed deletions via Record
 	recorder.Record(ctx, NewPathOnlyResult("folder1/file1.json").
@@ -662,7 +662,7 @@ func TestJobProgressRecorderHasChildPathFailedCreation(t *testing.T) {
 	mockProgressFn := func(ctx context.Context, status provisioning.JobStatus) error {
 		return nil
 	}
-	recorder := newJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
+	recorder := NewJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
 
 	pathErr1 := &resources.PathCreationError{
 		Path: "alpha/beta/",
@@ -697,7 +697,7 @@ func TestJobProgressRecorderHasChildPathFailedCreation(t *testing.T) {
 	assert.False(t, recorder.HasChildPathFailedCreation("x/y/z/deeper/"), "nothing nested deeper than x/y/z/")
 
 	// Empty recorder should always return false
-	emptyRecorder := newJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
+	emptyRecorder := NewJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
 	assert.False(t, emptyRecorder.HasChildPathFailedCreation("alpha/"))
 }
 
@@ -707,7 +707,7 @@ func TestJobProgressRecorderHasChildPathFailedUpdate(t *testing.T) {
 	mockProgressFn := func(ctx context.Context, status provisioning.JobStatus) error {
 		return nil
 	}
-	recorder := newJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
+	recorder := NewJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
 
 	recorder.Record(ctx, NewResourceResult().
 		WithPath("alpha/beta/dash.json").
@@ -803,7 +803,7 @@ func TestJobProgressRecorderHasChildPathFailedUpdate(t *testing.T) {
 	assert.True(t, recorder.HasChildPathFailedUpdate("new-warn/"), "warning-level rename failures must protect the destination folder")
 
 	// Empty recorder should always return false
-	emptyRecorder := newJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
+	emptyRecorder := NewJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
 	assert.False(t, emptyRecorder.HasChildPathFailedUpdate("alpha/"))
 }
 
@@ -813,7 +813,7 @@ func TestJobProgressRecorderFailedUpdatesTracking(t *testing.T) {
 	mockProgressFn := func(ctx context.Context, status provisioning.JobStatus) error {
 		return nil
 	}
-	recorder := newJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
+	recorder := NewJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
 
 	// Record update failures
 	recorder.Record(ctx, NewResourceResult().
@@ -849,7 +849,7 @@ func TestJobProgressRecorderResetResults(t *testing.T) {
 	mockProgressFn := func(ctx context.Context, status provisioning.JobStatus) error {
 		return nil
 	}
-	recorder := newJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
+	recorder := NewJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
 
 	// Add some data via Record
 	pathErr := &resources.PathCreationError{
@@ -890,7 +890,7 @@ func TestJobProgressRecorderLogsWarningsAtWarnLevel(t *testing.T) {
 	mockProgressFn := func(ctx context.Context, status provisioning.JobStatus) error {
 		return nil
 	}
-	recorder := newJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
+	recorder := NewJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
 
 	// Record a result with a warning (validation error)
 	validationErr := resources.NewResourceValidationError(errors.New("missing name in resource"))
@@ -926,7 +926,7 @@ func TestJobProgressRecorderLogsErrorsAtErrorLevel(t *testing.T) {
 	mockProgressFn := func(ctx context.Context, status provisioning.JobStatus) error {
 		return nil
 	}
-	recorder := newJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
+	recorder := NewJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
 
 	// Record a result with an actual error (not a validation error)
 	actualError := errors.New("network failure")
@@ -962,7 +962,7 @@ func TestJobProgressRecorderLogsSuccessAtInfoLevel(t *testing.T) {
 	mockProgressFn := func(ctx context.Context, status provisioning.JobStatus) error {
 		return nil
 	}
-	recorder := newJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
+	recorder := NewJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
 
 	// Record a successful result
 	result := NewResourceResult().
@@ -995,7 +995,7 @@ func TestJobProgressRecorderIgnoredActionsDontCountAsErrors(t *testing.T) {
 	mockProgressFn := func(ctx context.Context, status provisioning.JobStatus) error {
 		return nil
 	}
-	recorder := newJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
+	recorder := NewJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
 
 	// Record an ignored action with error
 	recorder.Record(ctx, NewPathOnlyResult("folder1/file1.json").
@@ -1021,7 +1021,7 @@ func TestJobProgressRecorderResultReasons(t *testing.T) {
 
 	t.Run("Record accumulates warning reasons from results", func(t *testing.T) {
 		mockProgressFn := func(ctx context.Context, status provisioning.JobStatus) error { return nil }
-		recorder := newJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
+		recorder := NewJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
 
 		quotaErr := quotas.NewQuotaExceededError(errors.New("over quota"))
 		recorder.Record(ctx, NewResourceResult().WithError(quotaErr).Build())
@@ -1031,7 +1031,7 @@ func TestJobProgressRecorderResultReasons(t *testing.T) {
 
 	t.Run("duplicate warning reasons are deduplicated", func(t *testing.T) {
 		mockProgressFn := func(ctx context.Context, status provisioning.JobStatus) error { return nil }
-		recorder := newJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
+		recorder := NewJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
 
 		quotaErr1 := quotas.NewQuotaExceededError(errors.New("over quota 1"))
 		quotaErr2 := quotas.NewQuotaExceededError(errors.New("over quota 2"))
@@ -1045,7 +1045,7 @@ func TestJobProgressRecorderResultReasons(t *testing.T) {
 
 	t.Run("Complete with warning error does not set Error state", func(t *testing.T) {
 		mockProgressFn := func(ctx context.Context, status provisioning.JobStatus) error { return nil }
-		recorder := newJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
+		recorder := NewJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
 
 		quotaErr := quotas.NewQuotaExceededError(errors.New("over quota"))
 		recorder.Record(ctx, NewResourceResult().WithError(quotaErr).Build())
@@ -1057,7 +1057,7 @@ func TestJobProgressRecorderResultReasons(t *testing.T) {
 
 	t.Run("Complete with real error still sets Error state", func(t *testing.T) {
 		mockProgressFn := func(ctx context.Context, status provisioning.JobStatus) error { return nil }
-		recorder := newJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
+		recorder := NewJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
 
 		finalStatus := recorder.Complete(ctx, errors.New("network failure"))
 		assert.Equal(t, provisioning.JobStateError, finalStatus.State)
@@ -1066,7 +1066,7 @@ func TestJobProgressRecorderResultReasons(t *testing.T) {
 
 	t.Run("ResetResults with keepWarnings=true preserves warning reasons", func(t *testing.T) {
 		mockProgressFn := func(ctx context.Context, status provisioning.JobStatus) error { return nil }
-		recorder := newJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
+		recorder := NewJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
 
 		quotaErr := quotas.NewQuotaExceededError(errors.New("over quota"))
 		recorder.Record(ctx, NewResourceResult().WithError(quotaErr).Build())
@@ -1080,7 +1080,7 @@ func TestJobProgressRecorderResultReasons(t *testing.T) {
 
 	t.Run("ResetResults with keepWarnings=false clears warning reasons", func(t *testing.T) {
 		mockProgressFn := func(ctx context.Context, status provisioning.JobStatus) error { return nil }
-		recorder := newJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
+		recorder := NewJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
 
 		quotaErr := quotas.NewQuotaExceededError(errors.New("over quota"))
 		recorder.Record(ctx, NewResourceResult().WithError(quotaErr).Build())
@@ -1097,7 +1097,7 @@ func TestJobProgressRecorderTooManyErrorsConcurrency(t *testing.T) {
 	ctx := context.Background()
 
 	mockProgressFn := func(ctx context.Context, status provisioning.JobStatus) error { return nil }
-	recorder := newJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
+	recorder := NewJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
 
 	const maxErrors = 5
 	const goroutines = 20

--- a/pkg/registry/apis/provisioning/jobs/sync/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/worker.go
@@ -163,7 +163,7 @@ func (r *SyncWorker) Process(ctx context.Context, repo repository.Repository, jo
 		setupSpan.End()
 		logger.Error("failed to create repository resources client", "error", err)
 		setupError := fmt.Errorf("create repository resources client: %w", err)
-		progress.Complete(ctx, setupError)
+		r.completeFailedSync(ctx, cfg, job, progress, lastRef, setupError)
 		return tracing.Error(span, setupError)
 	}
 	clients, err := r.clients.Clients(setupCtx, cfg.Namespace)
@@ -171,7 +171,7 @@ func (r *SyncWorker) Process(ctx context.Context, repo repository.Repository, jo
 		setupSpan.End()
 		logger.Error("failed to get clients for the repository", "error", err)
 		setupError := fmt.Errorf("get clients for %s: %w", cfg.Name, err)
-		progress.Complete(ctx, setupError)
+		r.completeFailedSync(ctx, cfg, job, progress, lastRef, setupError)
 		return tracing.Error(span, setupError)
 	}
 	setupSpan.End()
@@ -263,4 +263,22 @@ func (r *SyncWorker) Process(ctx context.Context, repo repository.Repository, jo
 	finalSpan.End()
 
 	return syncError
+}
+
+// completeFailedSync finalizes the job progress after a failure that happens once the repository
+// has already been marked as 'working', and writes the terminal state back to the repository.
+// Without this writeback the repository would report 'working' forever: sync jobs are singletons
+// per repository and failed syncs are not re-enqueued.
+func (r *SyncWorker) completeFailedSync(ctx context.Context, cfg *provisioning.Repository, job provisioning.Job, progress jobs.JobProgressRecorder, lastRef string, syncErr error) {
+	jobStatus := progress.Complete(ctx, syncErr)
+	syncStatus := jobStatus.ToSyncStatus(job.Name)
+	syncStatus.LastRef = lastRef
+
+	if err := r.patchStatus(ctx, cfg, map[string]interface{}{
+		"op":    "replace",
+		"path":  "/status/sync",
+		"value": syncStatus,
+	}); err != nil {
+		logging.FromContext(ctx).Error("failed to update the repository sync status after a failed sync", "error", err)
+	}
 }

--- a/pkg/registry/apis/provisioning/jobs/sync/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/worker.go
@@ -274,11 +274,20 @@ func (r *SyncWorker) completeFailedSync(ctx context.Context, cfg *provisioning.R
 	syncStatus := jobStatus.ToSyncStatus(job.Name)
 	syncStatus.LastRef = lastRef
 
-	if err := r.patchStatus(ctx, cfg, map[string]interface{}{
-		"op":    "replace",
-		"path":  "/status/sync",
-		"value": syncStatus,
-	}); err != nil {
+	patchOperations := []map[string]interface{}{
+		{
+			"op":    "replace",
+			"path":  "/status/sync",
+			"value": syncStatus,
+		},
+	}
+
+	syncCondition := EvaluatePullCondition(jobStatus.State, progress.ResultReasons())
+	if conditionOps := controller.BuildConditionPatchOpsFromExisting(cfg.Status.Conditions, cfg.GetGeneration(), syncCondition); conditionOps != nil {
+		patchOperations = append(patchOperations, conditionOps...)
+	}
+
+	if err := r.patchStatus(ctx, cfg, patchOperations...); err != nil {
 		logging.FromContext(ctx).Error("failed to update the repository sync status after a failed sync", "error", err)
 	}
 }

--- a/pkg/registry/apis/provisioning/jobs/sync/worker_integration_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/worker_integration_test.go
@@ -1,0 +1,105 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
+	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
+)
+
+func TestIntegrationSyncWorker_EarlySetupFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	repoResourcesFactory := resources.NewMockRepositoryResourcesFactory(t)
+	repoResourcesFactory.On("Client", mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("boom"))
+
+	readerWriter := &mockReaderWriter{
+		MockRepository: repository.NewMockRepository(t),
+		MockVersioned:  repository.NewMockVersioned(t),
+	}
+	repoConfig := &provisioning.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-repo",
+			Namespace:  "test-namespace",
+			Generation: 3,
+		},
+		Status: provisioning.RepositoryStatus{
+			Sync: provisioning.SyncStatus{
+				LastRef: "existing-ref",
+			},
+		},
+	}
+	readerWriter.MockRepository.On("Config").Return(repoConfig)
+
+	var patchCalls [][]map[string]interface{}
+	patchFn := func(ctx context.Context, repo *provisioning.Repository, ops ...map[string]interface{}) error {
+		patchCalls = append(patchCalls, ops)
+		return nil
+	}
+
+	worker := NewSyncWorker(
+		resources.NewMockClientFactory(t),
+		repoResourcesFactory,
+		patchFn,
+		NewMockSyncer(t),
+		jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()),
+		tracing.NewNoopTracerService(),
+		10,
+		0,
+	)
+
+	progress := jobs.NewJobProgressRecorder(func(ctx context.Context, status provisioning.JobStatus) error {
+		return nil
+	}, nil, provisioning.JobActionPull)
+
+	job := provisioning.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-job"},
+		Spec: provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{},
+		},
+	}
+
+	err := worker.Process(context.Background(), readerWriter, job, progress)
+	require.EqualError(t, err, "create repository resources client: boom")
+
+	require.Len(t, patchCalls, 2)
+	require.Len(t, patchCalls[0], 3)
+
+	final := patchCalls[1]
+	require.Len(t, final, 2)
+
+	require.Equal(t, "replace", final[0]["op"])
+	require.Equal(t, "/status/sync", final[0]["path"])
+	syncStatus, ok := final[0]["value"].(provisioning.SyncStatus)
+	require.True(t, ok)
+	require.Equal(t, provisioning.JobStateError, syncStatus.State)
+	require.Equal(t, "test-job", syncStatus.JobID)
+	require.Equal(t, "existing-ref", syncStatus.LastRef)
+	require.Equal(t, []string{"create repository resources client: boom"}, syncStatus.Message)
+	require.NotZero(t, syncStatus.Started)
+	require.NotZero(t, syncStatus.Finished)
+
+	require.Equal(t, "replace", final[1]["op"])
+	require.Equal(t, "/status/conditions", final[1]["path"])
+	conditions, ok := final[1]["value"].([]metav1.Condition)
+	require.True(t, ok)
+	require.Len(t, conditions, 1)
+	require.Equal(t, provisioning.ConditionTypePullStatus, conditions[0].Type)
+	require.Equal(t, metav1.ConditionFalse, conditions[0].Status)
+	require.Equal(t, provisioning.ReasonFailure, conditions[0].Reason)
+	require.Equal(t, int64(3), conditions[0].ObservedGeneration)
+	require.False(t, conditions[0].LastTransitionTime.IsZero())
+}

--- a/pkg/registry/apis/provisioning/jobs/sync/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/worker_test.go
@@ -368,6 +368,52 @@ func TestSyncWorker_Process_PullCondition(t *testing.T) {
 	}
 }
 
+func matchPatchPath(path string) func(map[string]interface{}) bool {
+	return func(patch map[string]interface{}) bool {
+		return patch["path"] == path
+	}
+}
+
+func matchReplacePatch(path string) func(map[string]interface{}) bool {
+	return func(patch map[string]interface{}) bool {
+		return patch["op"] == "replace" && patch["path"] == path
+	}
+}
+
+// matchSyncStatusPatch matches a replace patch on /status/sync with the given
+// state and lastRef; jobID is only checked when non-empty.
+func matchSyncStatusPatch(state provisioning.JobState, jobID, lastRef string) func(map[string]interface{}) bool {
+	return func(patch map[string]interface{}) bool {
+		syncStatus, ok := patch["value"].(provisioning.SyncStatus)
+		if !ok || patch["op"] != "replace" || patch["path"] != "/status/sync" {
+			return false
+		}
+		if jobID != "" && syncStatus.JobID != jobID {
+			return false
+		}
+		return syncStatus.State == state && syncStatus.LastRef == lastRef
+	}
+}
+
+func matchStatsPatch(group, resource string, count int64) func(map[string]interface{}) bool {
+	return func(patch map[string]interface{}) bool {
+		if patch["path"] != "/status/stats" {
+			return false
+		}
+		value, ok := patch["value"].([]provisioning.ResourceCount)
+		if !ok || len(value) != 1 {
+			return false
+		}
+		return value[0].Group == group && value[0].Resource == resource && value[0].Count == count
+	}
+}
+
+func matchErrorMessage(msg string) func(error) bool {
+	return func(err error) bool {
+		return err != nil && err.Error() == msg
+	}
+}
+
 func TestSyncWorker_Process(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -397,15 +443,9 @@ func TestSyncWorker_Process(t *testing.T) {
 
 				// Expect granular patches for state, job, and started fields
 				rpf.On("Execute", mock.Anything, repoConfig,
-					mock.MatchedBy(func(patch map[string]interface{}) bool {
-						return patch["op"] == "replace" && patch["path"] == "/status/sync/state"
-					}),
-					mock.MatchedBy(func(patch map[string]interface{}) bool {
-						return patch["op"] == "replace" && patch["path"] == "/status/sync/job"
-					}),
-					mock.MatchedBy(func(patch map[string]interface{}) bool {
-						return patch["op"] == "replace" && patch["path"] == "/status/sync/started"
-					}),
+					mock.MatchedBy(matchReplacePatch("/status/sync/state")),
+					mock.MatchedBy(matchReplacePatch("/status/sync/job")),
+					mock.MatchedBy(matchReplacePatch("/status/sync/started")),
 				).Return(errors.New("failed to patch status"))
 			},
 			expectedError: "update repo with job status at start: failed to patch status",
@@ -437,20 +477,13 @@ func TestSyncWorker_Process(t *testing.T) {
 				rrf.On("Client", mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("failed to create repository resources client"))
 
 				// Progress.Complete should be called with the error
-				pr.On("Complete", mock.Anything, mock.MatchedBy(func(err error) bool {
-					return err != nil && err.Error() == "create repository resources client: failed to create repository resources client"
-				})).Return(provisioning.JobStatus{State: provisioning.JobStateError})
+				pr.On("Complete", mock.Anything, mock.MatchedBy(
+					matchErrorMessage("create repository resources client: failed to create repository resources client"),
+				)).Return(provisioning.JobStatus{State: provisioning.JobStateError})
 
 				// The terminal state must be written back so the repository does not stay 'working'
 				rpf.On("Execute", mock.Anything, repoConfig,
-					mock.MatchedBy(func(patch map[string]interface{}) bool {
-						syncStatus, ok := patch["value"].(provisioning.SyncStatus)
-						return ok && patch["op"] == "replace" &&
-							patch["path"] == "/status/sync" &&
-							syncStatus.State == provisioning.JobStateError &&
-							syncStatus.JobID == "test-job" &&
-							syncStatus.LastRef == "existing-ref"
-					}),
+					mock.MatchedBy(matchSyncStatusPatch(provisioning.JobStateError, "test-job", "existing-ref")),
 				).Return(nil).Once()
 			},
 			expectedError: "create repository resources client: failed to create repository resources client",
@@ -486,20 +519,13 @@ func TestSyncWorker_Process(t *testing.T) {
 				cf.On("Clients", mock.Anything, "test-namespace").Return(nil, errors.New("failed to get clients"))
 
 				// Progress.Complete should be called with the error
-				pr.On("Complete", mock.Anything, mock.MatchedBy(func(err error) bool {
-					return err != nil && err.Error() == "get clients for test-repo: failed to get clients"
-				})).Return(provisioning.JobStatus{State: provisioning.JobStateError})
+				pr.On("Complete", mock.Anything, mock.MatchedBy(
+					matchErrorMessage("get clients for test-repo: failed to get clients"),
+				)).Return(provisioning.JobStatus{State: provisioning.JobStateError})
 
 				// The terminal state must be written back so the repository does not stay 'working'
 				rpf.On("Execute", mock.Anything, repoConfig,
-					mock.MatchedBy(func(patch map[string]interface{}) bool {
-						syncStatus, ok := patch["value"].(provisioning.SyncStatus)
-						return ok && patch["op"] == "replace" &&
-							patch["path"] == "/status/sync" &&
-							syncStatus.State == provisioning.JobStateError &&
-							syncStatus.JobID == "test-job" &&
-							syncStatus.LastRef == "existing-ref"
-					}),
+					mock.MatchedBy(matchSyncStatusPatch(provisioning.JobStateError, "test-job", "existing-ref")),
 				).Return(nil).Once()
 			},
 			expectedError: "get clients for test-repo: failed to get clients",
@@ -535,9 +561,7 @@ func TestSyncWorker_Process(t *testing.T) {
 				// Sync execution succeeds
 				pr.On("SetMessage", mock.Anything, "execute sync job").Return()
 				pr.On("StrictMaxErrors", 20).Return()
-				s.On("Sync", mock.Anything, rw, mock.MatchedBy(func(opts provisioning.SyncJobOptions) bool {
-					return true // Add specific sync options validation if needed
-				}), mockRepoResources, mock.Anything, pr, mock.Anything).Return("new-ref", nil)
+				s.On("Sync", mock.Anything, rw, mock.Anything, mockRepoResources, mock.Anything, pr, mock.Anything).Return("new-ref", nil)
 
 				// Final status updates
 				pr.On("Complete", mock.Anything, nil).Return(provisioning.JobStatus{State: provisioning.JobStateSuccess})
@@ -546,16 +570,8 @@ func TestSyncWorker_Process(t *testing.T) {
 
 				// Final patch should include new ref and quota condition
 				rpf.On("Execute", mock.Anything, repoConfig,
-					mock.MatchedBy(func(patch map[string]interface{}) bool {
-						if patch["op"] != "replace" || patch["path"] != "/status/sync" {
-							return false
-						}
-						syncStatus := patch["value"].(provisioning.SyncStatus)
-						return syncStatus.LastRef == "new-ref" && syncStatus.State == provisioning.JobStateSuccess
-					}),
-					mock.MatchedBy(func(patch map[string]interface{}) bool {
-						return patch["path"] == "/status/conditions"
-					}),
+					mock.MatchedBy(matchSyncStatusPatch(provisioning.JobStateSuccess, "", "new-ref")),
+					mock.MatchedBy(matchPatchPath("/status/conditions")),
 				).Return(nil).Once()
 			},
 			expectedError: "",
@@ -592,9 +608,7 @@ func TestSyncWorker_Process(t *testing.T) {
 				pr.On("SetMessage", mock.Anything, "execute sync job").Return()
 				pr.On("StrictMaxErrors", 20).Return()
 				syncError := errors.New("sync operation failed")
-				s.On("Sync", mock.Anything, rw, mock.MatchedBy(func(opts provisioning.SyncJobOptions) bool {
-					return true // Add specific sync options validation if needed
-				}), mockRepoResources, mock.Anything, pr, mock.Anything).Return("", syncError)
+				s.On("Sync", mock.Anything, rw, mock.Anything, mockRepoResources, mock.Anything, pr, mock.Anything).Return("", syncError)
 
 				// Final status updates
 				pr.On("Complete", mock.Anything, syncError).Return(provisioning.JobStatus{State: provisioning.JobStateError})
@@ -603,16 +617,8 @@ func TestSyncWorker_Process(t *testing.T) {
 
 				// Final patch should preserve existing ref on failure and include quota condition
 				rpf.On("Execute", mock.Anything, repoConfig,
-					mock.MatchedBy(func(patch map[string]interface{}) bool {
-						syncStatus := patch["value"].(provisioning.SyncStatus)
-						return patch["op"] == "replace" &&
-							patch["path"] == "/status/sync" &&
-							syncStatus.LastRef == "existing-ref" && // LastRef should not change on failure
-							syncStatus.State == provisioning.JobStateError
-					}),
-					mock.MatchedBy(func(patch map[string]interface{}) bool {
-						return patch["path"] == "/status/conditions"
-					}),
+					mock.MatchedBy(matchSyncStatusPatch(provisioning.JobStateError, "", "existing-ref")),
+					mock.MatchedBy(matchPatchPath("/status/conditions")),
 				).Return(nil).Once()
 			},
 			expectedError: "sync operation failed",
@@ -666,12 +672,8 @@ func TestSyncWorker_Process(t *testing.T) {
 
 				// Verify sync status and conditions are patched for final update
 				rpf.On("Execute", mock.Anything, mock.Anything,
-					mock.MatchedBy(func(patch map[string]interface{}) bool {
-						return patch["path"] == "/status/sync"
-					}),
-					mock.MatchedBy(func(patch map[string]interface{}) bool {
-						return patch["path"] == "/status/conditions"
-					}),
+					mock.MatchedBy(matchPatchPath("/status/sync")),
+					mock.MatchedBy(matchPatchPath("/status/conditions")),
 				).Return(nil).Once()
 
 				// Simple mocks for other calls
@@ -717,28 +719,9 @@ func TestSyncWorker_Process(t *testing.T) {
 
 				// Verify sync status, stats, and conditions are patched
 				rpf.On("Execute", mock.Anything, mock.Anything,
-					mock.MatchedBy(func(patch map[string]interface{}) bool {
-						return patch["path"] == "/status/sync"
-					}),
-					mock.MatchedBy(func(patch map[string]interface{}) bool {
-						if patch["path"] != "/status/stats" {
-							return false
-						}
-
-						value := patch["value"].([]provisioning.ResourceCount)
-						if len(value) != 1 {
-							return false
-						}
-
-						if value[0].Group != "test" || value[0].Resource != "test" || value[0].Count != 42 {
-							return false
-						}
-
-						return true
-					}),
-					mock.MatchedBy(func(patch map[string]interface{}) bool {
-						return patch["path"] == "/status/conditions"
-					}),
+					mock.MatchedBy(matchPatchPath("/status/sync")),
+					mock.MatchedBy(matchStatsPatch("test", "test", 42)),
+					mock.MatchedBy(matchPatchPath("/status/conditions")),
 				).Return(nil).Once()
 
 				// Simple mocks for other calls
@@ -794,12 +777,8 @@ func TestSyncWorker_Process(t *testing.T) {
 
 				// Verify sync status and conditions are patched (multiple stats should be ignored)
 				rpf.On("Execute", mock.Anything, mock.Anything,
-					mock.MatchedBy(func(patch map[string]interface{}) bool {
-						return patch["path"] == "/status/sync"
-					}),
-					mock.MatchedBy(func(patch map[string]interface{}) bool {
-						return patch["path"] == "/status/conditions"
-					}),
+					mock.MatchedBy(matchPatchPath("/status/sync")),
+					mock.MatchedBy(matchPatchPath("/status/conditions")),
 				).Return(nil).Once()
 
 				// Simple mocks for other calls
@@ -843,9 +822,7 @@ func TestSyncWorker_Process(t *testing.T) {
 
 				pr.On("SetMessage", mock.Anything, "execute sync job").Return()
 				pr.On("StrictMaxErrors", 20).Return()
-				s.On("Sync", mock.Anything, rw, mock.MatchedBy(func(opts provisioning.SyncJobOptions) bool {
-					return true
-				}), mockRepoResources, mock.Anything, pr, mock.Anything).Return("new-ref", nil)
+				s.On("Sync", mock.Anything, rw, mock.Anything, mockRepoResources, mock.Anything, pr, mock.Anything).Return("new-ref", nil)
 
 				// Complete with warning state and QuotaExceeded reason
 				pr.On("Complete", mock.Anything, nil).Return(provisioning.JobStatus{State: provisioning.JobStateWarning})
@@ -854,17 +831,8 @@ func TestSyncWorker_Process(t *testing.T) {
 
 				// Final patch should preserve existing-ref despite Warning state (not Error)
 				rpf.On("Execute", mock.Anything, repoConfig,
-					mock.MatchedBy(func(patch map[string]interface{}) bool {
-						if patch["op"] != "replace" || patch["path"] != "/status/sync" {
-							return false
-						}
-						syncStatus := patch["value"].(provisioning.SyncStatus)
-						return syncStatus.LastRef == "existing-ref" && // LastRef preserved on quota error
-							syncStatus.State == provisioning.JobStateWarning
-					}),
-					mock.MatchedBy(func(patch map[string]interface{}) bool {
-						return patch["path"] == "/status/conditions"
-					}),
+					mock.MatchedBy(matchSyncStatusPatch(provisioning.JobStateWarning, "", "existing-ref")),
+					mock.MatchedBy(matchPatchPath("/status/conditions")),
 				).Return(nil).Once()
 			},
 			expectedError: "", // quota errors are not returned by Process

--- a/pkg/registry/apis/provisioning/jobs/sync/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/worker_test.go
@@ -440,6 +440,18 @@ func TestSyncWorker_Process(t *testing.T) {
 				pr.On("Complete", mock.Anything, mock.MatchedBy(func(err error) bool {
 					return err != nil && err.Error() == "create repository resources client: failed to create repository resources client"
 				})).Return(provisioning.JobStatus{State: provisioning.JobStateError})
+
+				// The terminal state must be written back so the repository does not stay 'working'
+				rpf.On("Execute", mock.Anything, repoConfig,
+					mock.MatchedBy(func(patch map[string]interface{}) bool {
+						syncStatus, ok := patch["value"].(provisioning.SyncStatus)
+						return ok && patch["op"] == "replace" &&
+							patch["path"] == "/status/sync" &&
+							syncStatus.State == provisioning.JobStateError &&
+							syncStatus.JobID == "test-job" &&
+							syncStatus.LastRef == "existing-ref"
+					}),
+				).Return(nil).Once()
 			},
 			expectedError: "create repository resources client: failed to create repository resources client",
 		},
@@ -477,6 +489,18 @@ func TestSyncWorker_Process(t *testing.T) {
 				pr.On("Complete", mock.Anything, mock.MatchedBy(func(err error) bool {
 					return err != nil && err.Error() == "get clients for test-repo: failed to get clients"
 				})).Return(provisioning.JobStatus{State: provisioning.JobStateError})
+
+				// The terminal state must be written back so the repository does not stay 'working'
+				rpf.On("Execute", mock.Anything, repoConfig,
+					mock.MatchedBy(func(patch map[string]interface{}) bool {
+						syncStatus, ok := patch["value"].(provisioning.SyncStatus)
+						return ok && patch["op"] == "replace" &&
+							patch["path"] == "/status/sync" &&
+							syncStatus.State == provisioning.JobStateError &&
+							syncStatus.JobID == "test-job" &&
+							syncStatus.LastRef == "existing-ref"
+					}),
+				).Return(nil).Once()
 			},
 			expectedError: "get clients for test-repo: failed to get clients",
 		},

--- a/pkg/registry/apis/provisioning/jobs/sync/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/worker_test.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -381,8 +382,8 @@ func matchReplacePatch(path string) func(map[string]interface{}) bool {
 }
 
 // matchSyncStatusPatch matches a replace patch on /status/sync with the given
-// state and lastRef; jobID is only checked when non-empty.
-func matchSyncStatusPatch(state provisioning.JobState, jobID, lastRef string) func(map[string]interface{}) bool {
+// state and lastRef; jobID and message are only checked when non-empty.
+func matchSyncStatusPatch(state provisioning.JobState, jobID, lastRef, message string) func(map[string]interface{}) bool {
 	return func(patch map[string]interface{}) bool {
 		syncStatus, ok := patch["value"].(provisioning.SyncStatus)
 		if !ok || patch["op"] != "replace" || patch["path"] != "/status/sync" {
@@ -391,7 +392,30 @@ func matchSyncStatusPatch(state provisioning.JobState, jobID, lastRef string) fu
 		if jobID != "" && syncStatus.JobID != jobID {
 			return false
 		}
+		if message != "" && !slices.Contains(syncStatus.Message, message) {
+			return false
+		}
 		return syncStatus.State == state && syncStatus.LastRef == lastRef
+	}
+}
+
+// matchConditionPatch matches a /status/conditions patch containing a condition
+// with the given type, reason, and status.
+func matchConditionPatch(condType, reason string, status metav1.ConditionStatus) func(map[string]interface{}) bool {
+	return func(patch map[string]interface{}) bool {
+		if patch["path"] != "/status/conditions" {
+			return false
+		}
+		conditions, ok := patch["value"].([]metav1.Condition)
+		if !ok {
+			return false
+		}
+		for _, c := range conditions {
+			if c.Type == condType && c.Reason == reason && c.Status == status {
+				return true
+			}
+		}
+		return false
 	}
 }
 
@@ -479,11 +503,18 @@ func TestSyncWorker_Process(t *testing.T) {
 				// Progress.Complete should be called with the error
 				pr.On("Complete", mock.Anything, mock.MatchedBy(
 					matchErrorMessage("create repository resources client: failed to create repository resources client"),
-				)).Return(provisioning.JobStatus{State: provisioning.JobStateError})
+				)).Return(provisioning.JobStatus{
+					State:   provisioning.JobStateError,
+					Message: "create repository resources client: failed to create repository resources client",
+				})
+				pr.On("ResultReasons").Return([]string(nil))
 
-				// The terminal state must be written back so the repository does not stay 'working'
+				// The terminal state, failure reason, and pull condition must be written back
+				// so the repository does not stay 'working' without explanation
 				rpf.On("Execute", mock.Anything, repoConfig,
-					mock.MatchedBy(matchSyncStatusPatch(provisioning.JobStateError, "test-job", "existing-ref")),
+					mock.MatchedBy(matchSyncStatusPatch(provisioning.JobStateError, "test-job", "existing-ref",
+						"create repository resources client: failed to create repository resources client")),
+					mock.MatchedBy(matchConditionPatch(provisioning.ConditionTypePullStatus, provisioning.ReasonFailure, metav1.ConditionFalse)),
 				).Return(nil).Once()
 			},
 			expectedError: "create repository resources client: failed to create repository resources client",
@@ -521,11 +552,18 @@ func TestSyncWorker_Process(t *testing.T) {
 				// Progress.Complete should be called with the error
 				pr.On("Complete", mock.Anything, mock.MatchedBy(
 					matchErrorMessage("get clients for test-repo: failed to get clients"),
-				)).Return(provisioning.JobStatus{State: provisioning.JobStateError})
+				)).Return(provisioning.JobStatus{
+					State:   provisioning.JobStateError,
+					Message: "get clients for test-repo: failed to get clients",
+				})
+				pr.On("ResultReasons").Return([]string(nil))
 
-				// The terminal state must be written back so the repository does not stay 'working'
+				// The terminal state, failure reason, and pull condition must be written back
+				// so the repository does not stay 'working' without explanation
 				rpf.On("Execute", mock.Anything, repoConfig,
-					mock.MatchedBy(matchSyncStatusPatch(provisioning.JobStateError, "test-job", "existing-ref")),
+					mock.MatchedBy(matchSyncStatusPatch(provisioning.JobStateError, "test-job", "existing-ref",
+						"get clients for test-repo: failed to get clients")),
+					mock.MatchedBy(matchConditionPatch(provisioning.ConditionTypePullStatus, provisioning.ReasonFailure, metav1.ConditionFalse)),
 				).Return(nil).Once()
 			},
 			expectedError: "get clients for test-repo: failed to get clients",
@@ -570,7 +608,7 @@ func TestSyncWorker_Process(t *testing.T) {
 
 				// Final patch should include new ref and quota condition
 				rpf.On("Execute", mock.Anything, repoConfig,
-					mock.MatchedBy(matchSyncStatusPatch(provisioning.JobStateSuccess, "", "new-ref")),
+					mock.MatchedBy(matchSyncStatusPatch(provisioning.JobStateSuccess, "", "new-ref", "")),
 					mock.MatchedBy(matchPatchPath("/status/conditions")),
 				).Return(nil).Once()
 			},
@@ -617,7 +655,7 @@ func TestSyncWorker_Process(t *testing.T) {
 
 				// Final patch should preserve existing ref on failure and include quota condition
 				rpf.On("Execute", mock.Anything, repoConfig,
-					mock.MatchedBy(matchSyncStatusPatch(provisioning.JobStateError, "", "existing-ref")),
+					mock.MatchedBy(matchSyncStatusPatch(provisioning.JobStateError, "", "existing-ref", "")),
 					mock.MatchedBy(matchPatchPath("/status/conditions")),
 				).Return(nil).Once()
 			},
@@ -831,7 +869,7 @@ func TestSyncWorker_Process(t *testing.T) {
 
 				// Final patch should preserve existing-ref despite Warning state (not Error)
 				rpf.On("Execute", mock.Anything, repoConfig,
-					mock.MatchedBy(matchSyncStatusPatch(provisioning.JobStateWarning, "", "existing-ref")),
+					mock.MatchedBy(matchSyncStatusPatch(provisioning.JobStateWarning, "", "existing-ref", "")),
 					mock.MatchedBy(matchPatchPath("/status/conditions")),
 				).Return(nil).Once()
 			},


### PR DESCRIPTION
## What

Fixes a bug where a sync job that failed during client setup left the repository stuck at `status.sync.state=working` forever.

`SyncWorker.Process()` patches `/status/sync/{state,job,started}` to `working` at the start of every sync. The only place that wrote the terminal state back was the final status patch at the end of the happy path. Two early-return error paths sat between those points:

- `repositoryResources.Client(...)` fails (create repository resources client)
- `clients.Clients(...)` fails (get clients for the namespace)

Both completed the **Job** as `error` (historic job saved, job deleted from the store) but never updated the **Repository**, so `status.sync` stayed at `working` with no terminal write. Since `{repo}-sync` jobs are per-repo singletons and failed syncs are not re-enqueued, no retry ever corrected it — the repo showed "working" indefinitely, and anything gating on sync state (UI, health checks) hung.

This was observed in a dev environment when a transient folder-app apiserver outage caused `clients.Clients` to fail with `connection refused`; the repository remained `working` for 2.5h+ until manual cleanup.

## How

Added a `completeFailedSync` helper that both early-error paths now call instead of a bare `progress.Complete`:

1. `progress.Complete(ctx, setupError)` → terminal job status
2. `jobStatus.ToSyncStatus(job.Name)`, preserving the previous `LastRef` (same as the happy path does on sync errors)
3. A single patch on the repository containing `{op: replace, path: /status/sync}` **plus** a `PullStatus` condition update (via `EvaluatePullCondition` + `controller.BuildConditionPatchOpsFromExisting`), so `status.conditions` reflects the failure the same way the happy path's error branch does. The quota condition is intentionally left untouched on this path — there are no fresh quota stats to report.

`JobStatus.ToSyncStatus` also got a fallback: it previously only copied `Errors`/`Warnings` into `SyncStatus.Message`, but setup failures (like the ones above) are only recorded in `JobStatus.Message`, never `Record`ed as a per-resource error. Without the fallback, sync would report `state=error` with an empty message. Added: when state is `error` and there are no errors/warnings, fall back to `[Message]`. This is deliberately scoped to the error state so successful syncs don't get "completed successfully" written into `sync.message`. This also fixes the same empty-message gap on the main path (a top-level `syncer.Sync` error with no per-file records).

A failure of the writeback patch itself is logged but doesn't mask the original setup error.

The `move` and `delete` workers were checked for the same pattern: they don't patch repository status themselves (no `RepositoryPatchFn`), only via delegation to the sync worker, so they are not affected.

## Testing

- Extended the two existing early-error cases in `worker_test.go` (`failed getting repository resources`, `failed getting clients for namespace`) to assert the terminal `/status/sync` patch: `state=error`, `JobID` set, `LastRef` preserved, and the `PullStatus` condition patch.
- Added `worker_integration_test.go` (jobs/sync), which exercises the same early-setup-failure path with the *real* `jobs.JobProgressRecorder` (now exported as `jobs.NewJobProgressRecorder`) and the real condition builder — only the failing `RepositoryResourcesFactory` and a patch-capturing function are stubbed. It asserts both the terminal sync status fields and the `PullStatus=Failure` condition with the correct `ObservedGeneration`. This closes a gap the existing unit tests (which use a fake recorder) couldn't cover.
- Full `./pkg/registry/apis/provisioning/jobs/...` suite passes.

Repro without the fix: make any `clients.Clients` dependency (e.g. the folder app) unreachable while a sync job starts — the repository sticks at `working` permanently.