### PR TITLE
Docs: Add deprecation notice to Parca documentation

### DIFF
--- a/docs/sources/datasources/parca/_index.md
+++ b/docs/sources/datasources/parca/_index.md
@@ -23,6 +23,11 @@ review_date: 2026-04-10
 
 # Parca data source
 
+{{< admonition type="caution" >}}
+Starting January 2, 2027, the Parca data source plugin is deprecated.
+It will no longer receive updates after that date.
+{{< /admonition >}}
+
 Parca is a continuous profiling database for analysis of CPU and memory usage, down to the line number and throughout time. Grafana ships with built-in support for Parca, so you can add it as a data source and start querying your profiles in [Explore](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/explore/).
 
 Refer to the [Parca documentation](https://www.parca.dev/docs) to learn about continuous profiling and how to instrument your applications.

--- a/docs/sources/datasources/parca/configure/index.md
+++ b/docs/sources/datasources/parca/configure/index.md
@@ -22,6 +22,11 @@ review_date: 2026-04-10
 
 # Configure the Parca data source
 
+{{< admonition type="caution" >}}
+Starting January 2, 2027, the Parca data source plugin is deprecated.
+It will no longer receive updates after that date.
+{{< /admonition >}}
+
 This document explains how to configure the Parca data source in Grafana.
 
 You can configure the data source using the Grafana UI, a YAML provisioning file, or Terraform.

--- a/docs/sources/datasources/parca/query-editor/index.md
+++ b/docs/sources/datasources/parca/query-editor/index.md
@@ -20,6 +20,11 @@ review_date: 2026-04-10
 
 # Parca query editor
 
+{{< admonition type="caution" >}}
+Starting January 2, 2027, the Parca data source plugin is deprecated.
+It will no longer receive updates after that date.
+{{< /admonition >}}
+
 This document explains how to use the Parca query editor to query and visualize continuous profiling data.
 
 The query editor gives you access to a profile type selector, a label selector with autocomplete, and collapsible options for controlling query behavior.

--- a/docs/sources/datasources/parca/template-variables/index.md
+++ b/docs/sources/datasources/parca/template-variables/index.md
@@ -20,6 +20,11 @@ review_date: 2026-04-10
 
 # Parca template variables
 
+{{< admonition type="caution" >}}
+Starting January 2, 2027, the Parca data source plugin is deprecated.
+It will no longer receive updates after that date.
+{{< /admonition >}}
+
 Instead of hard-coding label values in your profiling queries, you can use template variables to create dynamic, reusable dashboards. Variables appear as drop-down menus at the top of the dashboard, making it easy to switch between services, instances, or environments without editing queries.
 
 For an introduction to template variables, refer to the [Variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/) documentation.

--- a/docs/sources/datasources/parca/troubleshooting/index.md
+++ b/docs/sources/datasources/parca/troubleshooting/index.md
@@ -19,6 +19,11 @@ review_date: 2026-04-10
 
 # Troubleshoot Parca data source issues
 
+{{< admonition type="caution" >}}
+Starting January 2, 2027, the Parca data source plugin is deprecated.
+It will no longer receive updates after that date.
+{{< /admonition >}}
+
 This page provides solutions to common issues you might encounter when configuring or using the Parca data source. For configuration instructions, refer to [Configure the Parca data source](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/parca/configure/).
 
 ## Connection errors


### PR DESCRIPTION

**What is this feature?**

Added a deprecation notice to all Parca data source docs.

**Why do we need this feature?**

Users need to be aware immediately when a data source/plugin is being deprecated. 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
