### PR TITLE
Notebooks: Add document model and rendering foundation

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-notebook/NotebookCellItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-notebook/NotebookCellItem.tsx
@@ -10,6 +10,11 @@ export interface NotebookCellItemState extends SceneObjectState {
   source: 'assistant' | 'user';
   // Optional to mirror the schema: an omitted `collapsed` must round-trip as omitted, not `false`.
   collapsed?: boolean;
+  // Rendered height in pixels for panel cells; omitted means the default height.
+  height?: number;
+  // When both set, the panel is locked to this time range instead of the notebook's.
+  timeFrom?: string;
+  timeTo?: string;
   // A cell is either a panel or narrative content, never both. `body` deliberately follows the
   // DashboardLayoutItem convention (every layout item exposes its wrapped VizPanel at
   // `.state.body`, set via setElementBody) so the panel editor and scene-graph tooling can find

--- a/public/app/features/dashboard-scene/scene/layout-notebook/NotebookCellRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-notebook/NotebookCellRenderer.tsx
@@ -1,29 +1,30 @@
 import { css } from '@emotion/css';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { rangeUtil, type GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
 import { type VizPanel } from '@grafana/scenes';
 import { type CellContentKind } from '@grafana/schema/apis/notebook/v2beta1';
-import { useStyles2 } from '@grafana/ui';
+import { Icon, Text, useStyles2 } from '@grafana/ui';
 
 import { type NotebookCellItem } from './NotebookCellItem';
 import { cellTypeRegistry } from './cells/cellTypeRegistry';
 
 // A lone VizPanel fills its parent, so the parent needs a resolved height (not just
 // min-height) or PanelChrome measures 0 and nothing shows.
-const PANEL_HEIGHT = 300;
+const DEFAULT_PANEL_HEIGHT = 300;
 
 // A notebook cell is one of two things: a panel (a chart) or narrative content (a markdown or
 // code block). This chooses the matching renderer, or shows a compact placeholder when the cell
 // is collapsed.
 export function NotebookCellRenderer({ cell }: { cell: NotebookCellItem }) {
-  const { body: panel, content: narrative, collapsed, elementName } = cell.useState();
+  const { body: panel, content: narrative, collapsed, elementName, height, timeFrom, timeTo } = cell.useState();
 
   if (collapsed) {
-    return <CollapsedCell name={elementName} />;
+    return <CollapsedCell label={collapsedLabel(panel, narrative) ?? elementName} />;
   }
 
   if (panel) {
-    return <PanelCell panel={panel} />;
+    return <PanelCell panel={panel} height={height} timeFrom={timeFrom} timeTo={timeTo} />;
   }
 
   if (narrative) {
@@ -34,14 +35,63 @@ export function NotebookCellRenderer({ cell }: { cell: NotebookCellItem }) {
 }
 
 // A chart cell: delegates to its VizPanel, which brings its own PanelChrome (title, menu, legend).
-function PanelCell({ panel }: { panel: VizPanel }) {
+// Cells locked to their own time range say so, since they deviate from the header's range.
+function PanelCell({
+  panel,
+  height,
+  timeFrom,
+  timeTo,
+}: {
+  panel: VizPanel;
+  height?: number;
+  timeFrom?: string;
+  timeTo?: string;
+}) {
   const styles = useStyles2(getStyles);
+  const isLocked = Boolean(timeFrom && timeTo);
 
   return (
-    <div className={styles.panel}>
-      <panel.Component model={panel} />
+    <div>
+      {isLocked && (
+        <div className={styles.lockRow}>
+          <Icon name="lock" size="xs" />
+          <Text variant="bodySmall" color="secondary">
+            {t('dashboard.notebook-layout.locked-range', 'Locked: {{range}}', {
+              range: formatLockedRange(timeFrom!, timeTo!),
+            })}
+          </Text>
+        </div>
+      )}
+      <div className={styles.panel} style={{ height: height ?? DEFAULT_PANEL_HEIGHT }}>
+        <panel.Component model={panel} />
+      </div>
     </div>
   );
+}
+
+/** A human-readable label for collapsed cells (panel title or first line of text). */
+function collapsedLabel(panel?: VizPanel, narrative?: CellContentKind): string | undefined {
+  if (panel) {
+    return panel.state.title;
+  }
+  if (narrative?.kind === 'Markdown') {
+    return narrative.spec.text
+      .split('\n')
+      .map((line) => line.replace(/^[#>\-*\s`]+/, '').trim())
+      .find((line) => line.length > 0);
+  }
+  if (narrative?.kind === 'Code') {
+    return narrative.spec.language || undefined;
+  }
+  return undefined;
+}
+
+function formatLockedRange(from: string, to: string): string {
+  if (rangeUtil.isRelativeTimeRange({ from, to })) {
+    return `${from} → ${to}`;
+  }
+  const range = rangeUtil.convertRawToRange({ from, to });
+  return `${range.from.format('MMM D, HH:mm')} → ${range.to.format('HH:mm')}`;
 }
 
 // A narrative cell: markdown or code, rendered by the component registered for its content kind.
@@ -61,17 +111,23 @@ function NarrativeCell({ content }: { content: CellContentKind }) {
   );
 }
 
-// A collapsed cell: shows only the element name, whatever the cell's type.
-function CollapsedCell({ name }: { name: string }) {
+// A collapsed cell: shows a compact summary, whatever the cell's type.
+function CollapsedCell({ label }: { label: string }) {
   const styles = useStyles2(getStyles);
 
-  return <div className={styles.collapsed}>{name}</div>;
+  return <div className={styles.collapsed}>{label}</div>;
 }
 
 const getStyles = (theme: GrafanaTheme2) => ({
   panel: css({
-    height: PANEL_HEIGHT,
     position: 'relative',
+  }),
+  lockRow: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+    color: theme.colors.text.secondary,
+    marginBottom: theme.spacing(0.5),
   }),
   content: css({
     padding: theme.spacing(1, 0),

--- a/public/app/features/dashboard-scene/scene/layout-notebook/NotebookDocumentHeader.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-notebook/NotebookDocumentHeader.tsx
@@ -14,7 +14,7 @@ interface Props {
 export function NotebookDocumentHeader({ title, tags, timeFrom, timeTo }: Props) {
   return (
     <Stack direction="column" gap={1} alignItems="flex-start">
-      <Badge text={t('dashboard.notebook-layout.pill', 'Published Notebook')} color="blue" icon="book" />
+      <Badge text={t('dashboard.notebook-layout.pill', 'Notebook')} color="blue" icon="book" />
       {title ? (
         <Text element="h1" variant="h1">
           {title}

--- a/public/app/features/dashboard-scene/scene/layout-notebook/NotebookLayoutManager.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-notebook/NotebookLayoutManager.test.tsx
@@ -36,7 +36,7 @@ describe('NotebookLayoutManager', () => {
   it('renders the document header with badge, title, time range and tags', async () => {
     renderNotebook();
 
-    expect(screen.getByText('Published Notebook')).toBeInTheDocument();
+    expect(screen.getByText('Notebook')).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'My notebook' })).toBeInTheDocument();
     expect(screen.getByText(/now-6h/)).toBeInTheDocument();
     expect(screen.getByText('incident')).toBeInTheDocument();

--- a/public/app/features/dashboard-scene/scene/layout-notebook/NotebookLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-notebook/NotebookLayoutManager.tsx
@@ -62,8 +62,11 @@ export class NotebookLayoutManager
       spec: {
         element: { kind: 'ElementReference', name: cell.state.elementName },
         source: cell.state.source,
-        // Emit collapsed only when it was set, so an omitted value stays omitted on round-trip.
+        // Emit collapsed/height/time lock only when they were set, so omitted values stay omitted on round-trip.
         ...(cell.state.collapsed !== undefined ? { collapsed: cell.state.collapsed } : {}),
+        ...(cell.state.height !== undefined ? { height: cell.state.height } : {}),
+        ...(cell.state.timeFrom !== undefined ? { timeFrom: cell.state.timeFrom } : {}),
+        ...(cell.state.timeTo !== undefined ? { timeTo: cell.state.timeTo } : {}),
       },
     }));
 

--- a/public/app/features/dashboard-scene/scene/layout-notebook/cells/CodeCell.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-notebook/cells/CodeCell.tsx
@@ -1,28 +1,94 @@
+import { css, cx } from '@emotion/css';
+
+import { AppEvents, type GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
 import { type CellContentKind } from '@grafana/schema/apis/notebook/v2beta1';
-import { CodeEditor } from '@grafana/ui';
+import { Badge, CodeEditor, IconButton, Stack, useStyles2 } from '@grafana/ui';
+import { appEvents } from 'app/core/app_events';
+import { copyStringToClipboard } from 'app/core/utils/explore';
 
 const LINE_HEIGHT = 18;
 const MIN_LINES = 3;
 const MAX_LINES = 30;
+const TOOLBAR_CLASS = 'notebook-code-cell-toolbar';
+
+const LANGUAGE_LABELS: Record<string, string> = {
+  sql: 'SQL',
+  promql: 'PromQL',
+  logql: 'LogQL',
+  json: 'JSON',
+  yaml: 'YAML',
+  python: 'Python',
+  go: 'Go',
+  javascript: 'JavaScript',
+  shell: 'Shell',
+};
 
 // Monaco needs an explicit height; approximate it from the line count so short
 // snippets stay compact and long ones cap out with an internal scroll.
 export function CodeCell({ content }: { content: CellContentKind }) {
+  const styles = useStyles2(getStyles);
+
   if (content.kind !== 'Code') {
     return null;
   }
 
-  const lines = content.spec.code.split('\n').length;
+  const { code, language } = content.spec;
+  const lines = code.split('\n').length;
   const height = Math.min(Math.max(lines, MIN_LINES), MAX_LINES) * LINE_HEIGHT;
+  const languageLabel = language ? (LANGUAGE_LABELS[language] ?? language) : undefined;
+
+  const onCopy = () => {
+    copyStringToClipboard(code);
+    appEvents.emit(AppEvents.alertSuccess, [t('dashboard.notebook-layout.code-copied', 'Code copied')]);
+  };
 
   return (
-    <CodeEditor
-      value={content.spec.code}
-      language={content.spec.language}
-      height={height}
-      width="100%"
-      readOnly
-      showLineNumbers
-    />
+    <div className={styles.wrapper}>
+      {/* Float over the editor on hover — no reserved strip, no layout shift. */}
+      <div className={cx(styles.toolbar, TOOLBAR_CLASS)}>
+        <Stack direction="row" gap={1} alignItems="center">
+          {languageLabel && <Badge text={languageLabel} color="darkgrey" />}
+          <IconButton
+            name="copy"
+            size="sm"
+            tooltip={t('dashboard.notebook-layout.copy-code', 'Copy code')}
+            onClick={onCopy}
+            data-testid="notebook-code-copy"
+          />
+        </Stack>
+      </div>
+      <CodeEditor value={code} language={language} height={height} width="100%" readOnly showLineNumbers />
+    </div>
   );
 }
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  wrapper: css({
+    position: 'relative',
+    width: '100%',
+    [`&:hover .${TOOLBAR_CLASS}, &:focus-within .${TOOLBAR_CLASS}`]: {
+      opacity: 1,
+      pointerEvents: 'auto',
+    },
+  }),
+  toolbar: css({
+    position: 'absolute',
+    top: theme.spacing(0.5),
+    // Keep clear of Monaco's vertical scrollbar track.
+    right: theme.spacing(2),
+    zIndex: 2,
+    display: 'flex',
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+    padding: theme.spacing(0.25, 0, 0.25, 0.5),
+    borderRadius: theme.shape.radius.default,
+    background: theme.colors.background.primary,
+    boxShadow: theme.shadows.z1,
+    opacity: 0,
+    pointerEvents: 'none',
+    [theme.transitions.handleMotion('no-preference')]: {
+      transition: theme.transitions.create('opacity', { duration: 120 }),
+    },
+  }),
+});

--- a/public/app/features/dashboard-scene/scene/layout-notebook/cells/MarkdownCell.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-notebook/cells/MarkdownCell.tsx
@@ -17,7 +17,10 @@ export function MarkdownCell({ content }: { content: CellContentKind }) {
   }
 
   const html = renderTextPanelMarkdown(content.spec.text);
-  return <DangerouslySetHtmlContent html={html} className={cx('markdown-html', styles.markdown)} />;
+  // allowRerender: the component defaults to injecting the html only on first mount,
+  // but the notebook editor re-renders this preview when the cell text changes
+  // (local typing or a collaborator's live edit).
+  return <DangerouslySetHtmlContent html={html} allowRerender className={cx('markdown-html', styles.markdown)} />;
 }
 
 const getStyles = (theme: GrafanaTheme2) => ({

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/NotebookLayoutSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/NotebookLayoutSerializer.ts
@@ -1,3 +1,4 @@
+import { SceneTimeRange } from '@grafana/scenes';
 import {
   type LibraryPanelKind as DashboardLibraryPanelKind,
   type PanelKind as DashboardPanelKind,
@@ -10,6 +11,12 @@ import { NotebookLayoutManager } from '../../scene/layout-notebook/NotebookLayou
 import { type PanelIdGenerator } from '../../utils/dashboardSceneGraph';
 
 import { buildLibraryPanel, buildVizPanel } from './utils';
+
+type NotebookLayoutItemSpecWithPresentation = NotebookLayoutKind['spec']['cells'][number]['spec'] & {
+  height?: number;
+  timeFrom?: string;
+  timeTo?: string;
+};
 
 export function deserializeNotebookLayout(
   layout: DashboardV2Spec['layout'],
@@ -26,7 +33,8 @@ export function deserializeNotebookLayout(
 
   const cells: NotebookCellItem[] = [];
   for (const item of notebookLayout.spec.cells) {
-    const elementName = item.spec.element.name;
+    const itemSpec: NotebookLayoutItemSpecWithPresentation = item.spec;
+    const elementName = itemSpec.element.name;
     // `elements` is typed DashboardV2Spec['elements'] = Record<string, PanelKind | LibraryPanelKind>
     // (the dashboard element union, which has no CellKind). A notebook's elements really do
     // include CellKind at runtime, and we branch on element.kind === 'Cell' below. TS rejects a
@@ -38,11 +46,15 @@ export function deserializeNotebookLayout(
       continue;
     }
 
-    // collapsed is optional in the schema; keep it undefined when omitted so serialize round-trips faithfully.
+    // collapsed/height/time lock are optional in the schema; keep them undefined when omitted so
+    // serialize round-trips faithfully.
     const base = {
       elementName,
-      source: item.spec.source,
-      collapsed: item.spec.collapsed,
+      source: itemSpec.source,
+      collapsed: itemSpec.collapsed,
+      height: itemSpec.height,
+      timeFrom: itemSpec.timeFrom,
+      timeTo: itemSpec.timeTo,
     };
 
     if (element.kind === 'Panel') {
@@ -51,7 +63,12 @@ export function deserializeNotebookLayout(
       // so buildVizPanel (dashboard-typed) rejects the notebook-typed value without this bridge.
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- identical leaf type across the two schemas
       const panel = element as unknown as DashboardPanelKind;
-      cells.push(new NotebookCellItem({ ...base, body: buildVizPanel(panel, panelIdGenerator?.()) }));
+      const body = buildVizPanel(panel, panelIdGenerator?.());
+      // A locked cell gets its own time range instead of following the notebook's.
+      if (itemSpec.timeFrom && itemSpec.timeTo) {
+        body.setState({ $timeRange: new SceneTimeRange({ from: itemSpec.timeFrom, to: itemSpec.timeTo }) });
+      }
+      cells.push(new NotebookCellItem({ ...base, body }));
     } else if (element.kind === 'LibraryPanel') {
       // Same bridge as the Panel branch: identical generated LibraryPanelKind, different module,
       // so buildLibraryPanel (dashboard-typed) needs the notebook-typed value widened through unknown.

--- a/public/app/features/notebook/model/lastUsedNotebook.test.ts
+++ b/public/app/features/notebook/model/lastUsedNotebook.test.ts
@@ -28,4 +28,12 @@ describe('lastUsedNotebook', () => {
     window.localStorage.setItem('grafana.notebooks.lastUsed', JSON.stringify({ nope: true }));
     expect(getLastUsedNotebook()).toBeUndefined();
   });
+
+  it.each([undefined, 'recently', null])('rejects a partially valid value with timestamp %p', (at) => {
+    window.localStorage.setItem(
+      'grafana.notebooks.lastUsed',
+      JSON.stringify({ uid: 'nb1', title: 'Investigation', at })
+    );
+    expect(getLastUsedNotebook()).toBeUndefined();
+  });
 });

--- a/public/app/features/notebook/model/lastUsedNotebook.test.ts
+++ b/public/app/features/notebook/model/lastUsedNotebook.test.ts
@@ -1,0 +1,31 @@
+import { clearLastUsedNotebook, getLastUsedNotebook, setLastUsedNotebook } from './lastUsedNotebook';
+
+describe('lastUsedNotebook', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('round-trips the last used notebook', () => {
+    expect(getLastUsedNotebook()).toBeUndefined();
+
+    setLastUsedNotebook('nb123', 'Checkout latency investigation');
+    const value = getLastUsedNotebook();
+    expect(value?.uid).toBe('nb123');
+    expect(value?.title).toBe('Checkout latency investigation');
+    expect(value?.at).toBeGreaterThan(0);
+  });
+
+  it('ignores empty uids and clears correctly', () => {
+    setLastUsedNotebook('', 'nope');
+    expect(getLastUsedNotebook()).toBeUndefined();
+
+    setLastUsedNotebook('nb1', 'one');
+    clearLastUsedNotebook();
+    expect(getLastUsedNotebook()).toBeUndefined();
+  });
+
+  it('rejects malformed stored values', () => {
+    window.localStorage.setItem('grafana.notebooks.lastUsed', JSON.stringify({ nope: true }));
+    expect(getLastUsedNotebook()).toBeUndefined();
+  });
+});

--- a/public/app/features/notebook/model/lastUsedNotebook.ts
+++ b/public/app/features/notebook/model/lastUsedNotebook.ts
@@ -15,7 +15,14 @@ export interface LastUsedNotebook {
  */
 export function getLastUsedNotebook(): LastUsedNotebook | undefined {
   const value = store.getObject<LastUsedNotebook>(LAST_USED_NOTEBOOK_KEY);
-  if (!value || typeof value.uid !== 'string' || value.uid === '' || typeof value.title !== 'string') {
+  if (
+    !value ||
+    typeof value.uid !== 'string' ||
+    value.uid === '' ||
+    typeof value.title !== 'string' ||
+    typeof value.at !== 'number' ||
+    !Number.isFinite(value.at)
+  ) {
     return undefined;
   }
   return value;

--- a/public/app/features/notebook/model/lastUsedNotebook.ts
+++ b/public/app/features/notebook/model/lastUsedNotebook.ts
@@ -1,0 +1,34 @@
+import { store } from '@grafana/data';
+
+const LAST_USED_NOTEBOOK_KEY = 'grafana.notebooks.lastUsed';
+
+export interface LastUsedNotebook {
+  uid: string;
+  title: string;
+  at: number;
+}
+
+/**
+ * Remembers the notebook the user most recently created, opened or added to.
+ * Powers the "Add to last notebook" quick actions (Figma: the default notebook
+ * is the last used one) and the add-to-notebook form's default target.
+ */
+export function getLastUsedNotebook(): LastUsedNotebook | undefined {
+  const value = store.getObject<LastUsedNotebook>(LAST_USED_NOTEBOOK_KEY);
+  if (!value || typeof value.uid !== 'string' || value.uid === '' || typeof value.title !== 'string') {
+    return undefined;
+  }
+  return value;
+}
+
+export function setLastUsedNotebook(uid: string, title: string): void {
+  if (!uid) {
+    return;
+  }
+  store.setObject(LAST_USED_NOTEBOOK_KEY, { uid, title, at: Date.now() });
+}
+
+/** Called when a quick-add fails because the notebook no longer exists. */
+export function clearLastUsedNotebook(): void {
+  store.delete(LAST_USED_NOTEBOOK_KEY);
+}

--- a/public/app/features/notebook/model/notebookSpec.test.ts
+++ b/public/app/features/notebook/model/notebookSpec.test.ts
@@ -1,0 +1,352 @@
+import { type PanelKind } from '@grafana/schema/apis/notebook/v2beta1';
+
+import {
+  clearCellTimeOverride,
+  DEFAULT_NOTEBOOK_TITLE,
+  duplicateCellAt,
+  insertElement,
+  isDefaultNotebookTitle,
+  moveCell,
+  newCodeElement,
+  newMarkdownElement,
+  newNotebookSpec,
+  newNotebookTitle,
+  newNotebookTitleDate,
+  newPanelForDatasource,
+  nextPanelId,
+  normalizeNotebookSpec,
+  removeCellAt,
+  resolveCells,
+  setCellHeight,
+  setCellTimeOverride,
+  setNotebookTimeRange,
+  updateCodeCell,
+  updateMarkdownText,
+  updatePanelQuery,
+  updatePanelTitle,
+  updatePanelViz,
+} from './notebookSpec';
+
+function newPanelElement(id = 0): PanelKind {
+  return {
+    kind: 'Panel',
+    spec: {
+      id,
+      title: 'CPU usage',
+      links: [],
+      data: { kind: 'QueryGroup', spec: { queries: [], transformations: [], queryOptions: {} } },
+      vizConfig: {
+        kind: 'VizConfig',
+        group: 'timeseries',
+        version: '',
+        spec: { options: {}, fieldConfig: { defaults: {}, overrides: [] } },
+      },
+    },
+  };
+}
+
+describe('notebookSpec', () => {
+  it('treats blank and legacy untitled titles as the default notebook title', () => {
+    expect(DEFAULT_NOTEBOOK_TITLE).toBe('Untitled notebook');
+    expect(isDefaultNotebookTitle(DEFAULT_NOTEBOOK_TITLE)).toBe(true);
+    expect(isDefaultNotebookTitle('  untitled notebook  ')).toBe(true);
+    expect(isDefaultNotebookTitle('')).toBe(true);
+    expect(isDefaultNotebookTitle('   ')).toBe(true);
+    expect(isDefaultNotebookTitle(undefined)).toBe(true);
+    expect(isDefaultNotebookTitle('Checkout latency')).toBe(false);
+    expect(isDefaultNotebookTitle(newNotebookTitle())).toBe(false);
+  });
+
+  it('names new notebooks with a stable month/day/year + time title', () => {
+    const now = new Date('2026-08-01T15:30:00Z');
+    // Explicit format (not toLocaleDateString) so titles stay readable across locales.
+    expect(newNotebookTitleDate(now)).toMatch(/^[A-Z][a-z]+ \d{1,2}, \d{4} \d{2}:\d{2}$/);
+    expect(newNotebookTitle(now)).toBe(`Investigation — ${newNotebookTitleDate(now)}`);
+    expect(newNotebookSpec().title.startsWith('Investigation — ')).toBe(true);
+  });
+
+  it('normalizes null arrays/maps from API-created notebooks', () => {
+    // Go marshals unset slices/maps as null; notebooks created directly through
+    // the resource API arrive like this and must not crash the UI.
+    const nullish = {
+      title: 'api notebook',
+      tags: null,
+      elements: null,
+      timeSettings: { from: 'now-6h', to: 'now', timezone: 'browser', autoRefresh: '', autoRefreshIntervals: null },
+      layout: { kind: 'NotebookLayout', spec: { cells: null } },
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- simulating the raw API payload shape
+    } as unknown as ReturnType<typeof newNotebookSpec>;
+
+    const spec = normalizeNotebookSpec(nullish);
+
+    expect(spec.tags).toEqual([]);
+    expect(spec.elements).toEqual({});
+    expect(spec.layout.spec.cells).toEqual([]);
+    expect(Array.isArray(spec.timeSettings.autoRefreshIntervals)).toBe(true);
+    expect(spec.timeSettings.autoRefreshIntervals!.length).toBeGreaterThan(0);
+    expect(resolveCells(spec)).toEqual([]);
+  });
+
+  it('updates one query of a panel element, stripping runtime-only keys', () => {
+    const base = newNotebookSpec('nb');
+    const panel = newPanelForDatasource({ uid: 'ds-uid', type: 'prometheus' });
+    const { spec, elementName } = insertElement(base, panel);
+
+    const updated = updatePanelQuery(spec, elementName, 'A', {
+      refId: 'A',
+      datasource: { uid: 'ds-uid', type: 'prometheus' },
+      hide: false,
+      expr: 'up',
+      instant: true,
+    });
+
+    const element = updated.elements[elementName];
+    if (element.kind !== 'Panel') {
+      throw new Error('expected panel element');
+    }
+    const query = element.spec.data.spec.queries[0];
+    expect(query.spec.refId).toBe('A');
+    expect(query.spec.query.spec).toEqual({ expr: 'up', instant: true });
+    // Datasource wiring on the envelope is untouched.
+    expect(query.spec.query.datasource?.name).toBe('ds-uid');
+    expect(query.spec.query.group).toBe('prometheus');
+    // Unknown refIds leave the spec unchanged.
+    expect(updatePanelQuery(updated, elementName, 'Z', { expr: 'down' })).toEqual(updated);
+  });
+
+  it('creates an empty notebook with the requested time range', () => {
+    const spec = newNotebookSpec('My investigation', { from: 'now-1h', to: 'now' });
+
+    expect(spec.title).toBe('My investigation');
+    expect(spec.timeSettings.from).toBe('now-1h');
+    expect(spec.timeSettings.to).toBe('now');
+    expect(spec.layout.spec.cells).toHaveLength(0);
+    expect(Object.keys(spec.elements)).toHaveLength(0);
+  });
+
+  it('inserts elements and keeps layout order', () => {
+    let spec = newNotebookSpec('nb');
+    const first = insertElement(spec, newMarkdownElement('# Findings'));
+    const second = insertElement(first.spec, newCodeElement('sql', 'SELECT 1'), { source: 'assistant' });
+    spec = second.spec;
+
+    const cells = resolveCells(spec);
+    expect(cells).toHaveLength(2);
+    expect(cells[0].elementName).toBe(first.elementName);
+    expect(cells[1].elementName).toBe(second.elementName);
+    expect(cells[1].source).toBe('assistant');
+  });
+
+  it('inserts at a specific index', () => {
+    let spec = newNotebookSpec('nb');
+    const a = insertElement(spec, newMarkdownElement('a'));
+    const b = insertElement(a.spec, newMarkdownElement('b'));
+    const middle = insertElement(b.spec, newMarkdownElement('middle'), { index: 1 });
+
+    const order = resolveCells(middle.spec).map((c) => c.elementName);
+    expect(order).toEqual([a.elementName, middle.elementName, b.elementName]);
+  });
+
+  it('assigns unique ids to inserted panels', () => {
+    let spec = newNotebookSpec('nb');
+    const first = insertElement(spec, newPanelElement());
+    const second = insertElement(first.spec, newPanelElement());
+    spec = second.spec;
+
+    const firstPanel = spec.elements[first.elementName];
+    const secondPanel = spec.elements[second.elementName];
+    if (firstPanel.kind !== 'Panel' || secondPanel.kind !== 'Panel') {
+      throw new Error('expected panels');
+    }
+    expect(firstPanel.spec.id).toBe(1);
+    expect(secondPanel.spec.id).toBe(2);
+    expect(nextPanelId(spec)).toBe(3);
+  });
+
+  it('removes a cell and its unreferenced element', () => {
+    let spec = newNotebookSpec('nb');
+    const a = insertElement(spec, newMarkdownElement('a'));
+    const b = insertElement(a.spec, newMarkdownElement('b'));
+    spec = removeCellAt(b.spec, 0);
+
+    expect(resolveCells(spec)).toHaveLength(1);
+    expect(spec.elements[a.elementName]).toBeUndefined();
+    expect(spec.elements[b.elementName]).toBeDefined();
+  });
+
+  it('moves cells within bounds and ignores out-of-range moves', () => {
+    let spec = newNotebookSpec('nb');
+    const a = insertElement(spec, newMarkdownElement('a'));
+    const b = insertElement(a.spec, newMarkdownElement('b'));
+    const c = insertElement(b.spec, newMarkdownElement('c'));
+    spec = c.spec;
+
+    const moved = moveCell(spec, 2, 0);
+    expect(resolveCells(moved).map((x) => x.elementName)).toEqual([c.elementName, a.elementName, b.elementName]);
+
+    expect(moveCell(spec, 5, 0)).toBe(spec);
+    expect(moveCell(spec, 0, 0)).toBe(spec);
+  });
+
+  it('updates markdown and code cells immutably', () => {
+    let spec = newNotebookSpec('nb');
+    const md = insertElement(spec, newMarkdownElement('old'));
+    const code = insertElement(md.spec, newCodeElement('sql', 'SELECT 1'));
+    spec = code.spec;
+
+    const updated = updateCodeCell(updateMarkdownText(spec, md.elementName, 'new'), code.elementName, {
+      code: 'SELECT 2',
+    });
+
+    const mdElement = updated.elements[md.elementName];
+    const codeElement = updated.elements[code.elementName];
+    if (mdElement.kind !== 'Cell' || mdElement.spec.content.kind !== 'Markdown') {
+      throw new Error('expected markdown cell');
+    }
+    if (codeElement.kind !== 'Cell' || codeElement.spec.content.kind !== 'Code') {
+      throw new Error('expected code cell');
+    }
+    expect(mdElement.spec.content.spec.text).toBe('new');
+    expect(codeElement.spec.content.spec.code).toBe('SELECT 2');
+    expect(codeElement.spec.content.spec.language).toBe('sql');
+
+    // original untouched
+    const originalMd = spec.elements[md.elementName];
+    if (originalMd.kind !== 'Cell' || originalMd.spec.content.kind !== 'Markdown') {
+      throw new Error('expected markdown cell');
+    }
+    expect(originalMd.spec.content.spec.text).toBe('old');
+  });
+
+  it('updates the time range without dropping other settings', () => {
+    const spec = newNotebookSpec('nb');
+    const updated = setNotebookTimeRange(spec, 'now-24h', 'now');
+    expect(updated.timeSettings.from).toBe('now-24h');
+    expect(updated.timeSettings.to).toBe('now');
+    expect(updated.timeSettings.autoRefreshIntervals).toEqual(spec.timeSettings.autoRefreshIntervals);
+  });
+
+  it('duplicates a cell with a fresh element name and unique panel id', () => {
+    let spec = newNotebookSpec('nb');
+    const md = insertElement(spec, newMarkdownElement('copy me'));
+    const panel = insertElement(md.spec, newPanelElement());
+    spec = setCellHeight(panel.spec, 1, 480);
+
+    const duplicated = duplicateCellAt(spec, 1);
+    const cells = resolveCells(duplicated);
+
+    expect(cells).toHaveLength(3);
+    expect(cells[2].elementName).not.toBe(panel.elementName);
+    expect(cells[2].height).toBe(480);
+    const original = duplicated.elements[panel.elementName];
+    const copy = duplicated.elements[cells[2].elementName];
+    if (original.kind !== 'Panel' || copy.kind !== 'Panel') {
+      throw new Error('expected panels');
+    }
+    expect(copy.spec.title).toBe(original.spec.title);
+    expect(copy.spec.id).not.toBe(original.spec.id);
+
+    // duplicating an out-of-range index is a no-op
+    expect(duplicateCellAt(duplicated, 99)).toBe(duplicated);
+  });
+
+  it('sets height on layout items', () => {
+    let spec = newNotebookSpec('nb');
+    spec = insertElement(spec, newMarkdownElement('a')).spec;
+
+    const sized = setCellHeight(spec, 0, 456.7);
+    expect(resolveCells(sized)[0].height).toBe(457);
+
+    expect(setCellHeight(sized, 5, 100)).toBe(sized);
+  });
+
+  it('renames panel elements only', () => {
+    let spec = newNotebookSpec('nb');
+    const md = insertElement(spec, newMarkdownElement('a'));
+    const panel = insertElement(md.spec, newPanelElement());
+    spec = panel.spec;
+
+    const renamed = updatePanelTitle(spec, panel.elementName, 'Renamed panel');
+    const element = renamed.elements[panel.elementName];
+    if (element.kind !== 'Panel') {
+      throw new Error('expected panel');
+    }
+    expect(element.spec.title).toBe('Renamed panel');
+
+    expect(updatePanelTitle(spec, md.elementName, 'nope')).toBe(spec);
+    expect(updatePanelTitle(spec, 'missing', 'nope')).toBe(spec);
+  });
+
+  it('locks and unlocks a per-cell time range', () => {
+    let spec = newNotebookSpec('nb');
+    spec = insertElement(spec, newPanelElement()).spec;
+
+    const locked = setCellTimeOverride(spec, 0, '2026-07-31T16:00:00Z', '2026-07-31T17:00:00Z');
+    const lockedCell = resolveCells(locked)[0];
+    expect(lockedCell.timeFrom).toBe('2026-07-31T16:00:00Z');
+    expect(lockedCell.timeTo).toBe('2026-07-31T17:00:00Z');
+
+    const unlocked = clearCellTimeOverride(locked, 0);
+    const unlockedCell = resolveCells(unlocked)[0];
+    expect(unlockedCell.timeFrom).toBeUndefined();
+    expect(unlockedCell.timeTo).toBeUndefined();
+  });
+
+  it('inserts elements with a time override', () => {
+    const spec = newNotebookSpec('nb');
+    const { spec: withPanel } = insertElement(spec, newPanelElement(), {
+      timeOverride: { from: '2026-07-31T16:00:00Z', to: '2026-07-31T17:00:00Z' },
+    });
+    const cell = resolveCells(withPanel)[0];
+    expect(cell.timeFrom).toBe('2026-07-31T16:00:00Z');
+    expect(cell.timeTo).toBe('2026-07-31T17:00:00Z');
+  });
+
+  it('swaps a panel visualization while keeping queries', () => {
+    let spec = newNotebookSpec('nb');
+    const panel = insertElement(spec, newPanelElement());
+    spec = panel.spec;
+
+    const swapped = updatePanelViz(spec, panel.elementName, {
+      pluginId: 'stat',
+      options: { textMode: 'auto' },
+    });
+
+    const element = swapped.elements[panel.elementName];
+    if (element.kind !== 'Panel') {
+      throw new Error('expected panel');
+    }
+    expect(element.spec.vizConfig.group).toBe('stat');
+    expect(element.spec.vizConfig.spec.options).toEqual({ textMode: 'auto' });
+    expect(element.spec.data.spec.queries).toEqual(
+      (() => {
+        const original = spec.elements[panel.elementName];
+        return original.kind === 'Panel' ? original.spec.data.spec.queries : [];
+      })()
+    );
+
+    expect(updatePanelViz(spec, 'missing', { pluginId: 'stat' })).toBe(spec);
+  });
+
+  it('drops dangling element references when resolving cells', () => {
+    let spec = newNotebookSpec('nb');
+    const a = insertElement(spec, newMarkdownElement('a'));
+    spec = {
+      ...a.spec,
+      layout: {
+        ...a.spec.layout,
+        spec: {
+          cells: [
+            ...a.spec.layout.spec.cells,
+            {
+              kind: 'NotebookLayoutItem',
+              spec: { element: { kind: 'ElementReference', name: 'missing' }, source: 'user' },
+            },
+          ],
+        },
+      },
+    };
+
+    expect(resolveCells(spec)).toHaveLength(1);
+  });
+});

--- a/public/app/features/notebook/model/notebookSpec.ts
+++ b/public/app/features/notebook/model/notebookSpec.ts
@@ -1,0 +1,496 @@
+import { nanoid } from 'nanoid';
+
+import { dateTimeFormat } from '@grafana/data';
+import {
+  defaultTimeSettingsSpec,
+  type CellKind,
+  type NotebookElement,
+  type NotebookLayoutItemKind,
+  type PanelKind,
+  type Spec as NotebookSpec,
+} from '@grafana/schema/apis/notebook/v2beta1';
+
+export type CellSource = NotebookLayoutItemKind['spec']['source'];
+
+type NotebookLayoutItemSpecWithPresentation = NotebookLayoutItemKind['spec'] & {
+  height?: number;
+  timeFrom?: string;
+  timeTo?: string;
+};
+
+/** A notebook cell paired with the element it references, resolved for rendering/editing. */
+export interface ResolvedCell {
+  /** Element name in the spec's elements map — also used as the stable React key. */
+  elementName: string;
+  source: CellSource;
+  collapsed?: boolean;
+  /** Rendered height in pixels for panel cells. */
+  height?: number;
+  /** When both set, the panel is locked to this time range instead of the notebook's. */
+  timeFrom?: string;
+  timeTo?: string;
+  element: NotebookElement;
+}
+
+/**
+ * Repairs specs that arrive from the API with `null` where the UI expects arrays/maps.
+ * Go marshals unset slices and maps as `null` (no omitempty), so notebooks created
+ * directly through the resource API — rather than this UI — need this on load.
+ */
+export function normalizeNotebookSpec(spec: NotebookSpec): NotebookSpec {
+  return {
+    ...spec,
+    tags: spec.tags ?? [],
+    elements: spec.elements ?? {},
+    timeSettings: {
+      ...spec.timeSettings,
+      autoRefreshIntervals: spec.timeSettings.autoRefreshIntervals ?? defaultTimeSettingsSpec().autoRefreshIntervals,
+    },
+    layout: {
+      ...spec.layout,
+      spec: { ...spec.layout.spec, cells: spec.layout.spec.cells ?? [] },
+    },
+  };
+}
+
+/**
+ * Legacy / empty-title fallback shown in the editor when a notebook has no name.
+ * New notebooks are created with {@link newNotebookTitle} instead.
+ */
+export const DEFAULT_NOTEBOOK_TITLE = 'Untitled notebook';
+
+/** True when the title is missing/blank or still the legacy untitled placeholder. */
+export function isDefaultNotebookTitle(title: string | undefined | null): boolean {
+  const trimmed = title?.trim() ?? '';
+  return !trimmed || trimmed.toLowerCase() === DEFAULT_NOTEBOOK_TITLE.toLowerCase();
+}
+
+/**
+ * Stable date/time segment for {@link newNotebookTitle} (also for i18n `{{date}}`).
+ * Uses an explicit month/day/year + time format so locale quirks from
+ * `toLocaleDateString()` don't produce unreadable titles.
+ */
+export function newNotebookTitleDate(now: Date = new Date()): string {
+  return dateTimeFormat(now, { format: 'MMMM D, YYYY HH:mm', timeZone: 'browser' });
+}
+
+/**
+ * Title for newly created notebooks — dated so capture/quick-add targets are easy
+ * to find later (list, sidebar, command palette, add-to-notebook).
+ * Example: `Investigation — August 1, 2026 16:30`
+ */
+export function newNotebookTitle(now: Date = new Date()): string {
+  return `Investigation — ${newNotebookTitleDate(now)}`;
+}
+
+export function newNotebookSpec(
+  title: string = newNotebookTitle(),
+  options?: { description?: string; from?: string; to?: string }
+): NotebookSpec {
+  const timeSettings = defaultTimeSettingsSpec();
+  if (options?.from) {
+    timeSettings.from = options.from;
+  }
+  if (options?.to) {
+    timeSettings.to = options.to;
+  }
+
+  return {
+    title,
+    description: options?.description,
+    tags: [],
+    timeSettings,
+    elements: {},
+    layout: { kind: 'NotebookLayout', spec: { cells: [] } },
+  };
+}
+
+export function newMarkdownElement(text = ''): CellKind {
+  return { kind: 'Cell', spec: { content: { kind: 'Markdown', spec: { text } } } };
+}
+
+export function newCodeElement(language = '', code = ''): CellKind {
+  return { kind: 'Cell', spec: { content: { kind: 'Code', spec: { language, code } } } };
+}
+
+/** The visualization that best fits what a datasource type typically returns. */
+function defaultVizForDatasource(datasourceType: string): string {
+  switch (datasourceType) {
+    case 'loki':
+      return 'logs';
+    case 'tempo':
+    case 'jaeger':
+    case 'zipkin':
+      return 'traces';
+    case 'grafana-pyroscope-datasource':
+    case 'parca':
+      return 'flamegraph';
+    case 'mysql':
+    case 'postgres':
+    case 'mssql':
+      return 'table';
+    default:
+      return 'timeseries';
+  }
+}
+
+/**
+ * A fresh panel wired to a datasource with one empty query — the in-editor
+ * "Add visualization" starting point. The id is reassigned on insert.
+ */
+export function newPanelForDatasource(
+  datasource: { uid: string; type: string },
+  options?: { title?: string; querySpec?: Record<string, unknown>; vizType?: string }
+): PanelKind {
+  return {
+    kind: 'Panel',
+    spec: {
+      id: 0,
+      title: options?.title ?? '',
+      links: [],
+      data: {
+        kind: 'QueryGroup',
+        spec: {
+          queries: [
+            {
+              kind: 'PanelQuery',
+              spec: {
+                refId: 'A',
+                hidden: false,
+                query: {
+                  kind: 'DataQuery',
+                  group: datasource.type,
+                  version: 'v0',
+                  datasource: { name: datasource.uid },
+                  spec: options?.querySpec ?? {},
+                },
+              },
+            },
+          ],
+          transformations: [],
+          queryOptions: {},
+        },
+      },
+      vizConfig: {
+        kind: 'VizConfig',
+        group: options?.vizType ?? defaultVizForDatasource(datasource.type),
+        version: '',
+        spec: { options: {}, fieldConfig: { defaults: {}, overrides: [] } },
+      },
+    },
+  };
+}
+
+/**
+ * Replaces one query of a panel element with an edited data query. The runtime-only
+ * keys (refId, datasource, hide) live on the query envelope, not in the stored spec.
+ * When `datasource` is provided the envelope's datasource wiring is updated too.
+ */
+export function updatePanelQuery(
+  spec: NotebookSpec,
+  elementName: string,
+  refId: string,
+  dataQuery: Record<string, unknown>,
+  datasource?: { uid: string; type: string }
+): NotebookSpec {
+  const element = spec.elements[elementName];
+  if (!element || element.kind !== 'Panel') {
+    return spec;
+  }
+
+  const { refId: _refId, datasource: _datasource, hide: _hide, ...querySpec } = dataQuery;
+
+  const queries = element.spec.data.spec.queries.map((query) =>
+    query.spec.refId === refId
+      ? {
+          ...query,
+          spec: {
+            ...query.spec,
+            query: {
+              ...query.spec.query,
+              ...(datasource ? { group: datasource.type, datasource: { name: datasource.uid } } : {}),
+              spec: querySpec,
+            },
+          },
+        }
+      : query
+  );
+
+  return {
+    ...spec,
+    elements: {
+      ...spec.elements,
+      [elementName]: {
+        ...element,
+        spec: {
+          ...element.spec,
+          data: { ...element.spec.data, spec: { ...element.spec.data.spec, queries } },
+        },
+      },
+    },
+  };
+}
+
+/** Panel ids must be unique within a notebook: scene panel keys are derived from them. */
+export function nextPanelId(spec: NotebookSpec): number {
+  let max = 0;
+  for (const element of Object.values(spec.elements)) {
+    if (element.kind === 'Panel' || element.kind === 'LibraryPanel') {
+      max = Math.max(max, element.spec.id);
+    }
+  }
+  return max + 1;
+}
+
+function elementNamePrefix(element: NotebookElement): string {
+  if (element.kind === 'Panel' || element.kind === 'LibraryPanel') {
+    return 'panel';
+  }
+  return element.spec.content.kind === 'Code' ? 'code' : 'md';
+}
+
+/**
+ * Adds an element to the notebook and references it from a new layout cell.
+ * Panels get a fresh unique numeric id. Returns the new spec and the generated
+ * element name (which doubles as the cell key).
+ */
+export function insertElement(
+  spec: NotebookSpec,
+  element: NotebookElement,
+  options?: { source?: CellSource; index?: number; timeOverride?: { from: string; to: string } }
+): { spec: NotebookSpec; elementName: string } {
+  const elementName = `${elementNamePrefix(element)}-${nanoid(8)}`;
+
+  let toInsert = element;
+  if (element.kind === 'Panel') {
+    toInsert = { ...element, spec: { ...element.spec, id: nextPanelId(spec) } };
+  } else if (element.kind === 'LibraryPanel') {
+    toInsert = { ...element, spec: { ...element.spec, id: nextPanelId(spec) } };
+  }
+
+  const cell: NotebookLayoutItemKind = {
+    kind: 'NotebookLayoutItem',
+    spec: {
+      element: { kind: 'ElementReference', name: elementName },
+      source: options?.source ?? 'user',
+      ...(options?.timeOverride ? { timeFrom: options.timeOverride.from, timeTo: options.timeOverride.to } : {}),
+    },
+  };
+
+  const cells = [...spec.layout.spec.cells];
+  const index = options?.index ?? cells.length;
+  cells.splice(Math.max(0, Math.min(index, cells.length)), 0, cell);
+
+  return {
+    spec: {
+      ...spec,
+      elements: { ...spec.elements, [elementName]: toInsert },
+      layout: { ...spec.layout, spec: { cells } },
+    },
+    elementName,
+  };
+}
+
+/** Removes the layout cell at `index` and its element when nothing else references it. */
+export function removeCellAt(spec: NotebookSpec, index: number): NotebookSpec {
+  const cells = spec.layout.spec.cells;
+  const cell = cells[index];
+  if (!cell) {
+    return spec;
+  }
+
+  const remaining = cells.filter((_, i) => i !== index);
+  const elementName = cell.spec.element.name;
+  const stillReferenced = remaining.some((c) => c.spec.element.name === elementName);
+
+  let elements = spec.elements;
+  if (!stillReferenced) {
+    elements = { ...spec.elements };
+    delete elements[elementName];
+  }
+
+  return { ...spec, elements, layout: { ...spec.layout, spec: { cells: remaining } } };
+}
+
+export function moveCell(spec: NotebookSpec, from: number, to: number): NotebookSpec {
+  const cells = [...spec.layout.spec.cells];
+  if (from < 0 || from >= cells.length || to < 0 || to >= cells.length || from === to) {
+    return spec;
+  }
+  const [cell] = cells.splice(from, 1);
+  cells.splice(to, 0, cell);
+  return { ...spec, layout: { ...spec.layout, spec: { cells } } };
+}
+
+/** Deep-copies the cell at `index` (element included) and inserts the copy right below it. */
+export function duplicateCellAt(spec: NotebookSpec, index: number): NotebookSpec {
+  const cell = spec.layout.spec.cells[index];
+  const element = cell && spec.elements[cell.spec.element.name];
+  if (!cell || !element) {
+    return spec;
+  }
+
+  const cellSpec: NotebookLayoutItemSpecWithPresentation = cell.spec;
+
+  const copy: NotebookElement = JSON.parse(JSON.stringify(element));
+  const { spec: withCopy, elementName } = insertElement(spec, copy, {
+    source: cellSpec.source,
+    index: index + 1,
+  });
+
+  // Carry over the layout-item presentation (collapsed/height/time lock) onto the new cell.
+  const cells = withCopy.layout.spec.cells.map((item) =>
+    item.spec.element.name === elementName
+      ? {
+          ...item,
+          spec: {
+            ...item.spec,
+            collapsed: cellSpec.collapsed,
+            height: cellSpec.height,
+            timeFrom: cellSpec.timeFrom,
+            timeTo: cellSpec.timeTo,
+          },
+        }
+      : item
+  );
+
+  return { ...withCopy, layout: { ...withCopy.layout, spec: { cells } } };
+}
+
+function updateLayoutItemAt(
+  spec: NotebookSpec,
+  index: number,
+  changes: Partial<Pick<NotebookLayoutItemSpecWithPresentation, 'collapsed' | 'height' | 'timeFrom' | 'timeTo'>>
+): NotebookSpec {
+  const cells = spec.layout.spec.cells;
+  if (!cells[index]) {
+    return spec;
+  }
+  const updated = cells.map((item, i) => (i === index ? { ...item, spec: { ...item.spec, ...changes } } : item));
+  return { ...spec, layout: { ...spec.layout, spec: { cells: updated } } };
+}
+
+export function setCellHeight(spec: NotebookSpec, index: number, height: number): NotebookSpec {
+  return updateLayoutItemAt(spec, index, { height: Math.round(height) });
+}
+
+/** Locks a panel cell to its own time range instead of the notebook's global one. */
+export function setCellTimeOverride(spec: NotebookSpec, index: number, from: string, to: string): NotebookSpec {
+  return updateLayoutItemAt(spec, index, { timeFrom: from, timeTo: to });
+}
+
+/** Syncs a panel cell back to the notebook's global time range. */
+export function clearCellTimeOverride(spec: NotebookSpec, index: number): NotebookSpec {
+  return updateLayoutItemAt(spec, index, { timeFrom: undefined, timeTo: undefined });
+}
+
+/** Swaps a panel's visualization (from a suggestion), keeping its queries. */
+export function updatePanelViz(
+  spec: NotebookSpec,
+  elementName: string,
+  viz: { pluginId: string; options?: unknown; fieldConfig?: unknown }
+): NotebookSpec {
+  const element = spec.elements[elementName];
+  if (!element || element.kind !== 'Panel') {
+    return spec;
+  }
+  return {
+    ...spec,
+    elements: {
+      ...spec.elements,
+      [elementName]: {
+        ...element,
+        spec: {
+          ...element.spec,
+          vizConfig: {
+            kind: 'VizConfig',
+            group: viz.pluginId,
+            version: '',
+            spec: {
+              // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- suggestion options/fieldConfig are stored as-is, same seam as dashboard capture
+              options: (viz.options ?? {}) as Record<string, unknown>,
+              // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- suggestion options/fieldConfig are stored as-is, same seam as dashboard capture
+              fieldConfig: (viz.fieldConfig ?? {
+                defaults: {},
+                overrides: [],
+              }) as PanelKind['spec']['vizConfig']['spec']['fieldConfig'],
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+export function updatePanelTitle(spec: NotebookSpec, elementName: string, title: string): NotebookSpec {
+  const element = spec.elements[elementName];
+  if (!element || element.kind !== 'Panel') {
+    return spec;
+  }
+  return {
+    ...spec,
+    elements: { ...spec.elements, [elementName]: { ...element, spec: { ...element.spec, title } } },
+  };
+}
+
+export function updateMarkdownText(spec: NotebookSpec, elementName: string, text: string): NotebookSpec {
+  const element = spec.elements[elementName];
+  if (!element || element.kind !== 'Cell' || element.spec.content.kind !== 'Markdown') {
+    return spec;
+  }
+  const updated: CellKind = { ...element, spec: { content: { kind: 'Markdown', spec: { text } } } };
+  return { ...spec, elements: { ...spec.elements, [elementName]: updated } };
+}
+
+export function updateCodeCell(
+  spec: NotebookSpec,
+  elementName: string,
+  changes: { language?: string; code?: string }
+): NotebookSpec {
+  const element = spec.elements[elementName];
+  if (!element || element.kind !== 'Cell' || element.spec.content.kind !== 'Code') {
+    return spec;
+  }
+  const content = element.spec.content;
+  const updated: CellKind = {
+    ...element,
+    spec: {
+      content: {
+        kind: 'Code',
+        spec: {
+          ...content.spec,
+          language: changes.language ?? content.spec.language,
+          code: changes.code ?? content.spec.code,
+        },
+      },
+    },
+  };
+  return { ...spec, elements: { ...spec.elements, [elementName]: updated } };
+}
+
+export function setNotebookTimeRange(spec: NotebookSpec, from: string, to: string): NotebookSpec {
+  return { ...spec, timeSettings: { ...spec.timeSettings, from, to } };
+}
+
+/** Resolves layout cells against the elements map, dropping dangling references. */
+export function resolveCells(spec: NotebookSpec): ResolvedCell[] {
+  const result: ResolvedCell[] = [];
+  for (const cell of spec.layout.spec.cells) {
+    const cellSpec: NotebookLayoutItemSpecWithPresentation = cell.spec;
+    const elementName = cellSpec.element.name;
+    const element = spec.elements[elementName];
+    if (!element) {
+      continue;
+    }
+    result.push({
+      elementName,
+      source: cellSpec.source,
+      collapsed: cellSpec.collapsed,
+      height: cellSpec.height,
+      timeFrom: cellSpec.timeFrom,
+      timeTo: cellSpec.timeTo,
+      element,
+    });
+  }
+  return result;
+}

--- a/public/app/features/notebook/model/notebookToMarkdown.test.ts
+++ b/public/app/features/notebook/model/notebookToMarkdown.test.ts
@@ -1,0 +1,75 @@
+import { type PanelKind } from '@grafana/schema/apis/notebook/v2beta1';
+
+import { insertElement, newCodeElement, newMarkdownElement, newNotebookSpec } from './notebookSpec';
+import { notebookToMarkdown } from './notebookToMarkdown';
+
+function panelElement(): PanelKind {
+  return {
+    kind: 'Panel',
+    spec: {
+      id: 1,
+      title: 'Latency p99',
+      subtitle: 'From dashboard: Checkout',
+      links: [],
+      data: {
+        kind: 'QueryGroup',
+        spec: {
+          queries: [
+            {
+              kind: 'PanelQuery',
+              spec: {
+                refId: 'A',
+                hidden: false,
+                query: {
+                  kind: 'DataQuery',
+                  group: 'prometheus',
+                  version: 'v0',
+                  datasource: { name: 'prom-1' },
+                  spec: { expr: 'histogram_quantile(0.99, http_request_duration_seconds_bucket)' },
+                },
+              },
+            },
+          ],
+          transformations: [],
+          queryOptions: {},
+        },
+      },
+      vizConfig: {
+        kind: 'VizConfig',
+        group: 'timeseries',
+        version: '',
+        spec: { options: {}, fieldConfig: { defaults: {}, overrides: [] } },
+      },
+    },
+  };
+}
+
+describe('notebookToMarkdown', () => {
+  it('serializes title, meta and all cell types', () => {
+    let spec = newNotebookSpec('Checkout investigation', { description: 'Latency spike', from: 'now-1h', to: 'now' });
+    spec = { ...spec, tags: ['incident'] };
+    spec = insertElement(spec, newMarkdownElement('## Symptoms\n\nLatency **spiked**.')).spec;
+    spec = insertElement(spec, newCodeElement('sql', 'SELECT 1;')).spec;
+    spec = insertElement(spec, panelElement()).spec;
+
+    const markdown = notebookToMarkdown(spec, { notebookUrl: 'https://grafana.example/notebook/abc' });
+
+    expect(markdown).toContain('# Checkout investigation');
+    expect(markdown).toContain('Latency spike');
+    expect(markdown).toContain('_Time range: now-1h → now_');
+    expect(markdown).toContain('_Tags: incident_');
+    expect(markdown).toContain('_Notebook: https://grafana.example/notebook/abc_');
+    expect(markdown).toContain('## Symptoms');
+    expect(markdown).toContain('```sql\nSELECT 1;\n```');
+    expect(markdown).toContain('> 📊 **Latency p99** (timeseries)');
+    expect(markdown).toContain('> From dashboard: Checkout');
+    expect(markdown).toContain('`A` (prometheus): `histogram_quantile');
+  });
+
+  it('skips empty markdown cells', () => {
+    let spec = newNotebookSpec('nb');
+    spec = insertElement(spec, newMarkdownElement('   ')).spec;
+    const markdown = notebookToMarkdown(spec);
+    expect(markdown).toBe('# nb\n\n_Time range: now-6h → now_\n');
+  });
+});

--- a/public/app/features/notebook/model/notebookToMarkdown.ts
+++ b/public/app/features/notebook/model/notebookToMarkdown.ts
@@ -1,0 +1,74 @@
+import { type Spec as NotebookSpec } from '@grafana/schema/apis/notebook/v2beta1';
+
+import { resolveCells } from './notebookSpec';
+
+/**
+ * Serializes a notebook to plain markdown for sharing (Slack, docs, PRs).
+ * Panels can't be embedded in markdown, so they become a compact blockquote
+ * with the panel title, provenance and queries.
+ */
+export function notebookToMarkdown(spec: NotebookSpec, options?: { notebookUrl?: string }): string {
+  const parts: string[] = [`# ${spec.title}`.trimEnd()];
+
+  if (spec.description) {
+    parts.push(spec.description);
+  }
+
+  const meta = [`_Time range: ${spec.timeSettings.from} → ${spec.timeSettings.to}_`];
+  if (spec.tags.length > 0) {
+    meta.push(`_Tags: ${spec.tags.join(', ')}_`);
+  }
+  if (options?.notebookUrl) {
+    meta.push(`_Notebook: ${options.notebookUrl}_`);
+  }
+  parts.push(meta.join('\n'));
+
+  for (const cell of resolveCells(spec)) {
+    const { element } = cell;
+
+    if (element.kind === 'Panel') {
+      const lines = [`> 📊 **${element.spec.title || 'Panel'}** (${element.spec.vizConfig.group})`];
+      if (element.spec.subtitle) {
+        lines.push(`> ${element.spec.subtitle}`);
+      }
+      for (const query of element.spec.data.spec.queries) {
+        const summary = summarizeQuery(query.spec.query.spec);
+        lines.push(`> - \`${query.spec.refId}\` (${query.spec.query.group}): \`${summary}\``);
+      }
+      parts.push(lines.join('\n'));
+      continue;
+    }
+
+    if (element.kind === 'LibraryPanel') {
+      parts.push(`> 📊 **${element.spec.title || 'Library panel'}** (library panel)`);
+      continue;
+    }
+
+    const content = element.spec.content;
+    if (content.kind === 'Markdown') {
+      if (content.spec.text.trim()) {
+        parts.push(content.spec.text.trim());
+      }
+      continue;
+    }
+
+    parts.push(`\`\`\`${content.spec.language}\n${content.spec.code}\n\`\`\``);
+  }
+
+  return parts.join('\n\n') + '\n';
+}
+
+function summarizeQuery(query: Record<string, unknown>): string {
+  // Prefer the human-readable query expression when the datasource has one.
+  for (const key of ['expr', 'query', 'rawSql', 'target']) {
+    const value = query[key];
+    if (typeof value === 'string' && value.trim()) {
+      return truncate(value.trim(), 120);
+    }
+  }
+  return truncate(JSON.stringify(query), 120);
+}
+
+function truncate(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max)}…` : value;
+}

--- a/public/app/features/notebook/model/preferredViz.test.ts
+++ b/public/app/features/notebook/model/preferredViz.test.ts
@@ -1,0 +1,39 @@
+import { FieldType, LoadingState, getDefaultTimeRange, toDataFrame, type PanelData } from '@grafana/data';
+
+import { preferredVizForData } from './preferredViz';
+
+function dataWith(frames: Array<ReturnType<typeof toDataFrame>>): PanelData {
+  return { state: LoadingState.Done, series: frames, timeRange: getDefaultTimeRange() };
+}
+
+describe('preferredVizForData', () => {
+  it('uses an explicit preferred plugin id from frame meta first', () => {
+    const frame = toDataFrame({ fields: [{ name: 'value', type: FieldType.number, values: [1] }] });
+    frame.meta = { preferredVisualisationPluginId: 'nodeGraph', preferredVisualisationType: 'logs' };
+    expect(preferredVizForData(dataWith([frame]))).toBe('nodeGraph');
+  });
+
+  it('maps preferred visualisation types to panel plugins', () => {
+    const frame = toDataFrame({ fields: [{ name: 'line', type: FieldType.string, values: ['a'] }] });
+    frame.meta = { preferredVisualisationType: 'logs' };
+    expect(preferredVizForData(dataWith([frame]))).toBe('logs');
+  });
+
+  it('detects time series shapes and falls back to table otherwise', () => {
+    const timeSeries = toDataFrame({
+      fields: [
+        { name: 'time', type: FieldType.time, values: [1, 2] },
+        { name: 'value', type: FieldType.number, values: [1, 2] },
+      ],
+    });
+    expect(preferredVizForData(dataWith([timeSeries]))).toBe('timeseries');
+
+    const tabular = toDataFrame({
+      fields: [
+        { name: 'name', type: FieldType.string, values: ['a'] },
+        { name: 'count', type: FieldType.number, values: [1] },
+      ],
+    });
+    expect(preferredVizForData(dataWith([tabular]))).toBe('table');
+  });
+});

--- a/public/app/features/notebook/model/preferredViz.ts
+++ b/public/app/features/notebook/model/preferredViz.ts
@@ -1,0 +1,38 @@
+import { isTimeSeriesFrames, type PanelData } from '@grafana/data';
+
+/**
+ * Picks the visualization that makes the most sense for returned data, using the
+ * frames' own metadata (same approach as the saved-queries inline editor):
+ * 1. an explicit preferred panel plugin declared by the datasource on the frame meta,
+ * 2. the preferred visualisation type (logs, traces, node graph, flame graph, ...),
+ * 3. time series heuristic, falling back to table for anything not graphable.
+ */
+export function preferredVizForData(data: PanelData): string {
+  const frames = data.series;
+
+  const preferredPluginId = frames.find((frame) => frame.meta?.preferredVisualisationPluginId)?.meta
+    ?.preferredVisualisationPluginId;
+  if (preferredPluginId) {
+    return preferredPluginId;
+  }
+
+  const preferredType = frames.find((frame) => frame.meta?.preferredVisualisationType)?.meta
+    ?.preferredVisualisationType;
+  switch (preferredType) {
+    case 'graph':
+      return 'timeseries';
+    case 'logs':
+      return 'logs';
+    case 'trace':
+      return 'traces';
+    case 'nodeGraph':
+      return 'nodeGraph';
+    case 'flamegraph':
+      return 'flamegraph';
+    case 'table':
+    case 'rawPrometheus':
+      return 'table';
+  }
+
+  return isTimeSeriesFrames(frames) ? 'timeseries' : 'table';
+}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5914,9 +5914,12 @@
     },
     "new-panel-title": "New panel",
     "notebook-layout": {
+      "code-copied": "Code copied",
+      "copy-code": "Copy code",
       "description": "A vertical sequence of panels, text, and code cells",
+      "locked-range": "Locked: {{range}}",
       "name": "Notebook",
-      "pill": "Published Notebook",
+      "pill": "Notebook",
       "time": "Time"
     },
     "on-create-new-row": {


### PR DESCRIPTION
## What this adds

- Defines the notebook document model and normalization helpers.
- Adds notebook-to-Markdown rendering and shared time/visualization helpers.
- Extends notebook layout rendering for the new cell types.
- Adds focused unit coverage for the model and rendering utilities.

## Why

This is the frontend foundation for the notebook dogfooding POC. Keeping the data model and rendering primitives separate gives reviewers a stable contract before reviewing the editor and product workflows.

## Stack

Layer 2 of 8. This PR is based on backend support in #129915.

## Validation

Review follow-up validation passed: focused notebook, route, and dashboard suites (18 suites, 140 tests), `yarn typecheck`, the production frontend build, and the React 19 frontend build.

## Dogfooding

Try the complete end-to-end notebook experience in the [ephemeral notebook environment](https://ephemeral15111821129904nmarrs.grafana-dev.net/notebooks). It is deployed from the original combined POC in #129904; the stacked PRs preserve that combined behavior while presenting smaller review layers.