### PR TITLE
Notebooks: Add realtime collaboration POC

### DIFF
--- a/public/app/features/notebook/collab/ActivityFeed.tsx
+++ b/public/app/features/notebook/collab/ActivityFeed.tsx
@@ -1,0 +1,137 @@
+import { css } from '@emotion/css';
+import { useState } from 'react';
+
+import { dateTimeFormatTimeAgo, type GrafanaTheme2 } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { IconButton, Text, Toggletip, useStyles2 } from '@grafana/ui';
+
+import { type ActivityEvent } from './types';
+
+interface Props {
+  activity: ActivityEvent[];
+  /** Scrolls to the block an entry refers to. */
+  onJumpToCell?: (cellKey: string) => void;
+}
+
+/**
+ * Toolbar popover showing the session's shared activity feed: who added, moved
+ * or changed which block, newest first. Session-scoped by design — history that
+ * matters long-term lives in the saved notebook, not here.
+ */
+export function ActivityFeedButton({ activity, onJumpToCell }: Props) {
+  const styles = useStyles2(getStyles);
+  const [open, setOpen] = useState(false);
+
+  const content = (
+    <div className={styles.panel}>
+      {activity.length === 0 ? (
+        <Text variant="bodySmall" color="secondary">
+          <Trans i18nKey="notebooks.activity.empty">Edits made while this notebook is open will show up here.</Trans>
+        </Text>
+      ) : (
+        <ul className={styles.list}>
+          {activity.map((event) => {
+            const name = event.user.name || event.user.login;
+            const row = (
+              <>
+                <span className={styles.dot} style={{ backgroundColor: event.color }} />
+                <span className={styles.text}>
+                  <strong>{name}</strong> {event.label}
+                </span>
+                <span className={styles.when}>{dateTimeFormatTimeAgo(event.ts)}</span>
+              </>
+            );
+
+            return (
+              <li key={event.id}>
+                {event.cellKey && onJumpToCell ? (
+                  <button
+                    type="button"
+                    className={styles.rowButton}
+                    onClick={() => {
+                      onJumpToCell(event.cellKey!);
+                      setOpen(false);
+                    }}
+                  >
+                    {row}
+                  </button>
+                ) : (
+                  <span className={styles.row}>{row}</span>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+
+  return (
+    <Toggletip
+      content={content}
+      title={t('notebooks.activity.title', 'Activity')}
+      placement="bottom-end"
+      closeButton={false}
+      show={open}
+      onOpen={() => setOpen(true)}
+      onClose={() => setOpen(false)}
+    >
+      <IconButton name="list-ul" size="lg" tooltip={t('notebooks.activity.tooltip', 'Activity')} />
+    </Toggletip>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  panel: css({
+    width: 300,
+    maxHeight: 320,
+    overflow: 'auto',
+  }),
+  list: css({
+    listStyle: 'none',
+    margin: 0,
+    padding: 0,
+  }),
+  row: css({
+    display: 'flex',
+    alignItems: 'baseline',
+    gap: theme.spacing(1),
+    padding: theme.spacing(0.75, 0.5),
+    width: '100%',
+  }),
+  rowButton: css({
+    display: 'flex',
+    alignItems: 'baseline',
+    gap: theme.spacing(1),
+    padding: theme.spacing(0.75, 0.5),
+    width: '100%',
+    background: 'none',
+    border: 'none',
+    textAlign: 'left',
+    cursor: 'pointer',
+    color: 'inherit',
+    borderRadius: theme.shape.radius.default,
+
+    '&:hover': {
+      background: theme.colors.action.hover,
+    },
+  }),
+  dot: css({
+    width: 8,
+    height: 8,
+    borderRadius: theme.shape.radius.circle,
+    flexShrink: 0,
+    alignSelf: 'center',
+  }),
+  text: css({
+    flex: 1,
+    minWidth: 0,
+    fontSize: theme.typography.bodySmall.fontSize,
+    color: theme.colors.text.primary,
+  }),
+  when: css({
+    flexShrink: 0,
+    fontSize: theme.typography.bodySmall.fontSize,
+    color: theme.colors.text.secondary,
+  }),
+});

--- a/public/app/features/notebook/collab/CollabCursors.tsx
+++ b/public/app/features/notebook/collab/CollabCursors.tsx
@@ -1,0 +1,117 @@
+import { css } from '@emotion/css';
+import { useEffect, useState } from 'react';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { useStyles2 } from '@grafana/ui';
+
+import { type RemotePeer } from './types';
+
+const CURSOR_FRESHNESS_MS = 6000;
+const POLL_INTERVAL_MS = 80;
+
+interface CursorView {
+  sid: string;
+  x: number;
+  y: number;
+  color: string;
+  label: string;
+}
+
+/**
+ * Live cursor overlay: renders collaborators' pointers (caret + name pill in
+ * their color) in notebook-document coordinates. Positions are polled from the
+ * collab peers ref rather than passed as React state — cursor moves arrive at
+ * pointer frequency and must only re-render this tiny layer, not the editor.
+ * Must be mounted inside a position:relative container matching the coordinate
+ * space cursors were captured in.
+ */
+export function CollabCursors({ getPeers }: { getPeers: () => RemotePeer[] }) {
+  const styles = useStyles2(getStyles);
+  const [cursors, setCursors] = useState<CursorView[]>([]);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      const now = Date.now();
+      const next = getPeers()
+        .filter((peer) => peer.cursor && now - peer.cursor.ts < CURSOR_FRESHNESS_MS)
+        .map((peer) => ({
+          sid: peer.sid,
+          x: peer.cursor!.x,
+          y: peer.cursor!.y,
+          color: peer.color,
+          label: peer.user.name || peer.user.login,
+        }));
+
+      setCursors((current) => (cursorsEqual(current, next) ? current : next));
+    }, POLL_INTERVAL_MS);
+    return () => clearInterval(timer);
+  }, [getPeers]);
+
+  if (cursors.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={styles.layer} aria-hidden>
+      {cursors.map((cursor) => (
+        <div
+          key={cursor.sid}
+          className={styles.cursor}
+          style={{ transform: `translate(${cursor.x}px, ${cursor.y}px)` }}
+        >
+          <svg width="14" height="18" viewBox="0 0 14 18" className={styles.caret}>
+            <path d="M1 1 L13 9 L7 10.5 L4.5 17 Z" fill={cursor.color} stroke="white" strokeWidth="1" />
+          </svg>
+          <span className={styles.pill} style={{ backgroundColor: cursor.color }}>
+            {cursor.label}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function cursorsEqual(a: CursorView[], b: CursorView[]): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  return a.every((cursor, i) => {
+    const other = b[i];
+    return cursor.sid === other.sid && cursor.x === other.x && cursor.y === other.y && cursor.color === other.color;
+  });
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  layer: css({
+    position: 'absolute',
+    inset: 0,
+    overflow: 'hidden',
+    pointerEvents: 'none',
+    zIndex: theme.zIndex.tooltip,
+  }),
+  cursor: css({
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: 2,
+
+    [theme.transitions.handleMotion('no-preference')]: {
+      transition: 'transform 80ms linear',
+    },
+  }),
+  caret: css({
+    filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.4))',
+  }),
+  pill: css({
+    marginTop: 10,
+    color: '#fff',
+    fontSize: theme.typography.bodySmall.fontSize,
+    lineHeight: 1.6,
+    padding: theme.spacing(0, 0.75),
+    borderRadius: theme.shape.radius.pill,
+    whiteSpace: 'nowrap',
+    boxShadow: theme.shadows.z1,
+  }),
+});

--- a/public/app/features/notebook/collab/PresenceAvatars.tsx
+++ b/public/app/features/notebook/collab/PresenceAvatars.tsx
@@ -1,0 +1,109 @@
+import { css, cx } from '@emotion/css';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { Tooltip, useStyles2 } from '@grafana/ui';
+
+import { type RemotePeer } from './types';
+
+interface Props {
+  peers: RemotePeer[];
+  /** Session id of the peer currently being followed, if any. */
+  followedSid?: string | null;
+  /** When set, avatars become buttons that toggle following that collaborator. */
+  onToggleFollow?: (peer: RemotePeer) => void;
+}
+
+/** Compact row of colored initials for everyone else connected to the notebook. */
+export function PresenceAvatars({ peers, followedSid, onToggleFollow }: Props) {
+  const styles = useStyles2(getStyles);
+
+  if (peers.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={styles.row} data-testid="notebook-presence">
+      {peers.map((peer) => {
+        const label = peer.user.name || peer.user.login;
+        const following = followedSid === peer.sid;
+        const tooltip = onToggleFollow
+          ? following
+            ? t('notebooks.presence.stop-following', 'Following {{name}} — click to stop', { name: label })
+            : t('notebooks.presence.click-to-follow', '{{name}} is in this notebook — click to follow', {
+                name: label,
+              })
+          : t('notebooks.presence.viewing', '{{name}} is in this notebook', { name: label });
+
+        if (!onToggleFollow) {
+          return (
+            <Tooltip key={peer.sid} content={tooltip}>
+              <span className={styles.avatar} style={{ backgroundColor: peer.color }}>
+                {initials(label)}
+              </span>
+            </Tooltip>
+          );
+        }
+
+        return (
+          <Tooltip key={peer.sid} content={tooltip}>
+            <button
+              type="button"
+              className={cx(styles.avatar, styles.clickable, following && styles.following)}
+              style={{ backgroundColor: peer.color, ...(following ? { outlineColor: peer.color } : {}) }}
+              onClick={() => onToggleFollow(peer)}
+              aria-label={tooltip}
+              aria-pressed={following}
+            >
+              {initials(label)}
+            </button>
+          </Tooltip>
+        );
+      })}
+    </div>
+  );
+}
+
+function initials(name: string): string {
+  const parts = name.trim().split(/\s+/);
+  const first = parts[0]?.[0] ?? '?';
+  const last = parts.length > 1 ? parts[parts.length - 1][0] : '';
+  return (first + last).toUpperCase();
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  row: css({
+    display: 'flex',
+    alignItems: 'center',
+
+    '& > * + *': {
+      marginLeft: -6,
+    },
+  }),
+  avatar: css({
+    width: 26,
+    height: 26,
+    borderRadius: theme.shape.radius.circle,
+    border: `2px solid ${theme.colors.background.primary}`,
+    color: '#fff',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    fontSize: theme.typography.bodySmall.fontSize,
+    fontWeight: theme.typography.fontWeightMedium,
+    cursor: 'default',
+    padding: 0,
+  }),
+  clickable: css({
+    cursor: 'pointer',
+
+    '&:hover': {
+      transform: 'scale(1.1)',
+    },
+  }),
+  following: css({
+    outlineStyle: 'solid',
+    outlineWidth: 2,
+    outlineOffset: 1,
+  }),
+});

--- a/public/app/features/notebook/collab/mergeRemoteSpec.test.ts
+++ b/public/app/features/notebook/collab/mergeRemoteSpec.test.ts
@@ -1,0 +1,48 @@
+import { insertElement, newMarkdownElement, newNotebookSpec, updateMarkdownText } from '../model/notebookSpec';
+
+import { mergeRemoteSpec } from './mergeRemoteSpec';
+
+describe('mergeRemoteSpec', () => {
+  function setup() {
+    let spec = newNotebookSpec('nb');
+    const a = insertElement(spec, newMarkdownElement('a'));
+    const b = insertElement(a.spec, newMarkdownElement('b'));
+    return { spec: b.spec, aKey: a.elementName, bKey: b.elementName };
+  }
+
+  it('returns the remote spec when not editing', () => {
+    const { spec } = setup();
+    const remote = updateMarkdownText(spec, Object.keys(spec.elements)[0], 'remote edit');
+
+    expect(mergeRemoteSpec(remote, spec, null)).toBe(remote);
+    expect(mergeRemoteSpec(remote, undefined, 'anything')).toBe(remote);
+  });
+
+  it('keeps the locally edited cell while taking remote changes elsewhere', () => {
+    const { spec, aKey, bKey } = setup();
+    const local = updateMarkdownText(spec, aKey, 'local typing in progress');
+    const remote = updateMarkdownText(spec, bKey, 'remote edit');
+
+    const merged = mergeRemoteSpec(remote, local, aKey);
+
+    const mergedA = merged.elements[aKey];
+    const mergedB = merged.elements[bKey];
+    if (mergedA.kind !== 'Cell' || mergedA.spec.content.kind !== 'Markdown') {
+      throw new Error('expected markdown cell');
+    }
+    if (mergedB.kind !== 'Cell' || mergedB.spec.content.kind !== 'Markdown') {
+      throw new Error('expected markdown cell');
+    }
+    expect(mergedA.spec.content.spec.text).toBe('local typing in progress');
+    expect(mergedB.spec.content.spec.text).toBe('remote edit');
+  });
+
+  it('accepts a remote deletion of the cell being edited', () => {
+    const { spec, aKey } = setup();
+    const local = updateMarkdownText(spec, aKey, 'local typing');
+    const remote = { ...spec, elements: { ...spec.elements } };
+    delete remote.elements[aKey];
+
+    expect(mergeRemoteSpec(remote, local, aKey)).toBe(remote);
+  });
+});

--- a/public/app/features/notebook/collab/mergeRemoteSpec.ts
+++ b/public/app/features/notebook/collab/mergeRemoteSpec.ts
@@ -1,0 +1,28 @@
+import { type Spec as NotebookSpec } from '@grafana/schema/apis/notebook/v2beta1';
+
+/**
+ * Applies a collaborator's document while protecting the cell the local user is
+ * actively editing: the remote doc wins everywhere (last-write-wins), except the
+ * locally-focused element keeps its local content so concurrent typing in
+ * different cells doesn't clobber in-progress input.
+ */
+export function mergeRemoteSpec(
+  remote: NotebookSpec,
+  local: NotebookSpec | undefined,
+  editingCellKey: string | null | undefined
+): NotebookSpec {
+  if (!local || !editingCellKey) {
+    return remote;
+  }
+
+  const localElement = local.elements[editingCellKey];
+  // If the collaborator deleted the cell we're editing, accept the deletion.
+  if (!localElement || !remote.elements[editingCellKey]) {
+    return remote;
+  }
+
+  return {
+    ...remote,
+    elements: { ...remote.elements, [editingCellKey]: localElement },
+  };
+}

--- a/public/app/features/notebook/collab/types.ts
+++ b/public/app/features/notebook/collab/types.ts
@@ -1,0 +1,88 @@
+import { type Spec as NotebookSpec } from '@grafana/schema/apis/notebook/v2beta1';
+
+export interface CollabUser {
+  login: string;
+  name: string;
+  avatarUrl?: string;
+}
+
+interface CollabMessageBase {
+  /** Session id of the sender — one per open editor tab, used to ignore own messages. */
+  sid: string;
+  /**
+   * For doc messages: the document's version timestamp (the edit that produced it),
+   * used for last-write-wins convergence. For everything else: the send time.
+   */
+  ts: number;
+  user: CollabUser;
+}
+
+/** Full working-copy broadcast, sent debounced after local edits and in reply to `hello`. */
+interface CollabDocMessage extends CollabMessageBase {
+  t: 'doc';
+  spec: NotebookSpec;
+  /** Sent by one-shot flows (e.g. add-to-notebook) — not a session; skip presence tracking. */
+  transient?: boolean;
+}
+
+/** Cursor position in notebook-document coordinates plus the cell the user is in. */
+interface CollabCursorMessage extends CollabMessageBase {
+  t: 'cursor';
+  x: number;
+  y: number;
+  /** Element name of the cell being edited or hovered, null when outside any cell. */
+  cellKey: string | null;
+}
+
+/** Sent on join and as heartbeat so peers can discover each other. */
+interface CollabHelloMessage extends CollabMessageBase {
+  t: 'hello';
+}
+
+/** Sent on leave for immediate presence cleanup (heartbeat expiry is the fallback). */
+interface CollabByeMessage extends CollabMessageBase {
+  t: 'bye';
+}
+
+/** Sender's viewport position (the cell nearest its center), powering follow mode. */
+interface CollabViewMessage extends CollabMessageBase {
+  t: 'view';
+  cellKey: string | null;
+}
+
+/** A human-readable edit event ("added a text block") for the activity feed. */
+interface CollabActivityMessage extends CollabMessageBase {
+  t: 'activity';
+  label: string;
+  cellKey?: string;
+}
+
+export type CollabMessage =
+  | CollabDocMessage
+  | CollabCursorMessage
+  | CollabHelloMessage
+  | CollabByeMessage
+  | CollabViewMessage
+  | CollabActivityMessage;
+
+export interface RemotePeer {
+  sid: string;
+  user: CollabUser;
+  color: string;
+  lastSeen: number;
+  cursor?: { x: number; y: number; ts: number };
+  cellKey?: string | null;
+  /** Cell nearest the peer's viewport center — where followers scroll to. */
+  viewCell?: string | null;
+}
+
+/** One entry of the session's activity feed (own actions included). */
+export interface ActivityEvent {
+  id: string;
+  sid: string;
+  user: CollabUser;
+  color: string;
+  label: string;
+  cellKey?: string;
+  ts: number;
+}

--- a/public/app/features/notebook/collab/useNotebookCollab.ts
+++ b/public/app/features/notebook/collab/useNotebookCollab.ts
@@ -1,0 +1,365 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { type Unsubscribable } from 'rxjs';
+
+import {
+  generateUUID,
+  isLiveChannelMessageEvent,
+  isLiveChannelStatusEvent,
+  type LiveChannelAddress,
+  LiveChannelConnectionState,
+  LiveChannelScope,
+} from '@grafana/data';
+import { getGrafanaLiveSrv } from '@grafana/runtime';
+import { type Spec as NotebookSpec } from '@grafana/schema/apis/notebook/v2beta1';
+import { contextSrv } from 'app/core/services/context_srv';
+import { AnnoKeyUpdatedTimestamp, type Resource } from 'app/features/apiserver/types';
+
+import { type ActivityEvent, type CollabMessage, type CollabUser, type RemotePeer } from './types';
+
+const DOC_BROADCAST_DEBOUNCE_MS = 350;
+const CURSOR_THROTTLE_MS = 60;
+const VIEW_THROTTLE_MS = 250;
+const HEARTBEAT_INTERVAL_MS = 8000;
+const PEER_EXPIRY_MS = 20000;
+const ACTIVITY_FEED_LIMIT = 30;
+
+// Classic Grafana visualization palette — stable, high-contrast colors for collaborators.
+const PEER_COLORS = ['#7EB26D', '#EAB839', '#6ED0E0', '#EF843C', '#E24D42', '#1F78C1', '#BA43A9', '#705DA0'];
+
+export interface NotebookCollabApi {
+  /**
+   * Other sessions currently connected to this notebook (excludes self). Updates on
+   * structural changes (join/leave, block focus, viewport) — NOT on every cursor
+   * move, so consuming components don't re-render at pointer frequency.
+   */
+  peers: RemotePeer[];
+  /** Latest peers including live cursor positions — for the cursor overlay, which polls. */
+  getPeers: () => RemotePeer[];
+  /** Recent edit events from everyone (own actions included), newest first. */
+  activity: ActivityEvent[];
+  /** Call after every local spec change; broadcasts the doc debounced. */
+  notifyLocalEdit: () => void;
+  /** Call from pointer tracking; broadcasts the cursor throttled. */
+  sendCursor: (x: number, y: number, cellKey: string | null) => void;
+  /** Call from scroll tracking; broadcasts the viewport cell for follow mode. */
+  sendView: (cellKey: string | null) => void;
+  /** Announces a labeled edit ("added a text block") to the shared activity feed. */
+  sendActivity: (label: string, cellKey?: string) => void;
+  /** This session's collaborator color (used for own feed entries). */
+  selfColor: string;
+  sessionId: string;
+}
+
+interface Options {
+  uid: string;
+  enabled: boolean;
+  getSpec: () => NotebookSpec | undefined;
+  /** Called when a newer document arrives from a collaborator. */
+  onRemoteSpec: (spec: NotebookSpec) => void;
+  /**
+   * The saved-version timestamp (ms) of the loaded document. Doc broadcasts carry the
+   * timestamp of the edit that produced the document — not the send time — so a session
+   * holding an older working copy can never clobber a fresher one just by replying later.
+   */
+  initialDocTs?: number;
+}
+
+/** The saved version's timestamp (ms) of a notebook resource, seeding the doc-version clock. */
+export function resourceVersionTs(resource?: Resource<NotebookSpec>): number | undefined {
+  const stamp = resource?.metadata.annotations?.[AnnoKeyUpdatedTimestamp] ?? resource?.metadata.creationTimestamp;
+  const parsed = stamp ? Date.parse(stamp) : NaN;
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+function colorForSession(sid: string): string {
+  let hash = 0;
+  for (let i = 0; i < sid.length; i++) {
+    hash = (hash * 31 + sid.charCodeAt(i)) | 0;
+  }
+  return PEER_COLORS[Math.abs(hash) % PEER_COLORS.length];
+}
+
+/**
+ * Real-time collaboration for one notebook over a Grafana Live channel
+ * (`grafana/notebook/uid/<uid>`, relayed by the backend NotebookHandler):
+ * presence (who is here), live cursors and last-write-wins doc sync. The
+ * notebook API remains the source of truth — this only syncs working copies.
+ */
+export function useNotebookCollab({ uid, enabled, getSpec, onRemoteSpec, initialDocTs }: Options): NotebookCollabApi {
+  const sessionId = useMemo(() => generateUUID(), []);
+  const [peers, setPeers] = useState<RemotePeer[]>([]);
+  const [activity, setActivity] = useState<ActivityEvent[]>([]);
+
+  const peersRef = useRef(new Map<string, RemotePeer>());
+  // Version timestamp of the current working copy: the saved version's timestamp at
+  // load, bumped by local edits (to now) and by accepted remote documents (to their ts).
+  const docTs = useRef(0);
+  if (initialDocTs && docTs.current === 0) {
+    docTs.current = initialDocTs;
+  }
+  const lastCursorSentAt = useRef(0);
+  const lastViewSentAt = useRef(0);
+  const lastViewCell = useRef<string | null | undefined>(undefined);
+  const lastHelloReplyAt = useRef(0);
+  const docTimer = useRef<ReturnType<typeof setTimeout>>();
+
+  // Keep latest callbacks in refs so the channel subscription effect only depends on uid/enabled.
+  const getSpecRef = useRef(getSpec);
+  getSpecRef.current = getSpec;
+  const onRemoteSpecRef = useRef(onRemoteSpec);
+  onRemoteSpecRef.current = onRemoteSpec;
+
+  const user: CollabUser = useMemo(
+    () => ({
+      login: contextSrv.user.login,
+      name: contextSrv.user.name || contextSrv.user.login,
+      avatarUrl: contextSrv.user.gravatarUrl,
+    }),
+    []
+  );
+
+  const address: LiveChannelAddress = useMemo(
+    () => ({ scope: LiveChannelScope.Grafana, stream: 'notebook', path: `uid/${uid}` }),
+    [uid]
+  );
+
+  const publish = useCallback(
+    (message: CollabMessage, opts?: { socket?: boolean }) => {
+      getGrafanaLiveSrv()
+        .publish(address, message, opts?.socket ? { useSocket: true } : undefined)
+        .catch(() => {
+          // Collaboration is best-effort: a dropped message is recovered by the
+          // next heartbeat/doc broadcast, so failures are intentionally silent.
+        });
+    },
+    [address]
+  );
+
+  const flushPeers = useCallback(() => {
+    setPeers(
+      Array.from(peersRef.current.values(), (peer) => ({
+        ...peer,
+        user: { ...peer.user },
+        cursor: peer.cursor ? { ...peer.cursor } : undefined,
+      }))
+    );
+  }, []);
+
+  const touchPeer = useCallback(
+    (message: CollabMessage) => {
+      const existing = peersRef.current.get(message.sid);
+      const peer: RemotePeer = existing ?? {
+        sid: message.sid,
+        user: message.user,
+        color: colorForSession(message.sid),
+        lastSeen: Date.now(),
+      };
+      peer.lastSeen = Date.now();
+      peer.user = message.user;
+
+      // Re-rendering consumers at cursor frequency (~16/s per peer) can saturate the
+      // main thread on large notebooks, so pure position updates only mutate the ref
+      // (polled by the cursor overlay). State flushes are reserved for structural
+      // changes: new peers, block focus changes and viewport moves.
+      let structural = !existing;
+      if (message.t === 'cursor') {
+        peer.cursor = { x: message.x, y: message.y, ts: Date.now() };
+        if (peer.cellKey !== message.cellKey) {
+          peer.cellKey = message.cellKey;
+          structural = true;
+        }
+      }
+      if (message.t === 'view' && peer.viewCell !== message.cellKey) {
+        peer.viewCell = message.cellKey;
+        structural = true;
+      }
+      peersRef.current.set(message.sid, peer);
+      if (structural) {
+        flushPeers();
+      }
+    },
+    [flushPeers]
+  );
+
+  const appendActivity = useCallback((event: ActivityEvent) => {
+    setActivity((current) => [event, ...current].slice(0, ACTIVITY_FEED_LIMIT));
+  }, []);
+
+  const broadcastDocNow = useCallback(() => {
+    const spec = getSpecRef.current();
+    if (!spec) {
+      return;
+    }
+    // ts is the document's version timestamp, never the send time: replying to a
+    // hello with an old working copy must not out-rank fresher documents.
+    publish({ t: 'doc', sid: sessionId, ts: docTs.current || Date.now(), user, spec });
+  }, [publish, sessionId, user]);
+
+  useEffect(() => {
+    if (!enabled || !uid) {
+      return;
+    }
+
+    let subscription: Unsubscribable | undefined;
+    const live = getGrafanaLiveSrv();
+    const peersAtSubscribe = peersRef.current;
+
+    subscription = live.getStream<CollabMessage>(address).subscribe({
+      next: (event) => {
+        if (isLiveChannelStatusEvent(event) && event.state === LiveChannelConnectionState.Connected) {
+          publish({ t: 'hello', sid: sessionId, ts: Date.now(), user });
+          return;
+        }
+
+        if (!isLiveChannelMessageEvent(event)) {
+          return;
+        }
+        const message = event.message;
+        if (!message || typeof message !== 'object' || !('sid' in message) || message.sid === sessionId) {
+          return;
+        }
+
+        switch (message.t) {
+          case 'hello': {
+            touchPeer(message);
+            // Announce ourselves and share our working copy so the newcomer converges.
+            // Throttled: several peers replying in the same window is fine, the newest ts wins.
+            if (Date.now() - lastHelloReplyAt.current > 2000) {
+              lastHelloReplyAt.current = Date.now();
+              publish({ t: 'hello', sid: sessionId, ts: Date.now(), user });
+              broadcastDocNow();
+            }
+            break;
+          }
+          case 'doc': {
+            if (!message.transient) {
+              touchPeer(message);
+            }
+            // Last write wins on document-version timestamps: apply only when the
+            // remote document is strictly newer than ours (concurrently-typed local
+            // cells are protected by the editor's merge). Equal timestamps mean both
+            // sessions hold the same saved version — nothing to converge.
+            if (message.ts > docTs.current) {
+              docTs.current = message.ts;
+              onRemoteSpecRef.current(message.spec);
+            }
+            break;
+          }
+          case 'cursor': {
+            touchPeer(message);
+            break;
+          }
+          case 'view': {
+            touchPeer(message);
+            break;
+          }
+          case 'activity': {
+            touchPeer(message);
+            appendActivity({
+              id: `${message.sid}-${message.ts}`,
+              sid: message.sid,
+              user: message.user,
+              color: colorForSession(message.sid),
+              label: message.label,
+              cellKey: message.cellKey,
+              ts: message.ts,
+            });
+            break;
+          }
+          case 'bye': {
+            peersRef.current.delete(message.sid);
+            flushPeers();
+            break;
+          }
+        }
+      },
+    });
+
+    const heartbeat = setInterval(() => {
+      publish({ t: 'hello', sid: sessionId, ts: Date.now(), user });
+
+      let changed = false;
+      for (const [sid, peer] of peersRef.current) {
+        if (Date.now() - peer.lastSeen > PEER_EXPIRY_MS) {
+          peersRef.current.delete(sid);
+          changed = true;
+        }
+      }
+      if (changed) {
+        flushPeers();
+      }
+    }, HEARTBEAT_INTERVAL_MS);
+
+    return () => {
+      publish({ t: 'bye', sid: sessionId, ts: Date.now(), user });
+      clearInterval(heartbeat);
+      clearTimeout(docTimer.current);
+      subscription?.unsubscribe();
+      peersAtSubscribe.clear();
+      setPeers([]);
+    };
+  }, [address, enabled, uid, publish, sessionId, user, touchPeer, flushPeers, broadcastDocNow, appendActivity]);
+
+  const notifyLocalEdit = useCallback(() => {
+    docTs.current = Date.now();
+    if (!enabled) {
+      return;
+    }
+    clearTimeout(docTimer.current);
+    docTimer.current = setTimeout(broadcastDocNow, DOC_BROADCAST_DEBOUNCE_MS);
+  }, [enabled, broadcastDocNow]);
+
+  const sendCursor = useCallback(
+    (x: number, y: number, cellKey: string | null) => {
+      if (!enabled) {
+        return;
+      }
+      const now = Date.now();
+      if (now - lastCursorSentAt.current < CURSOR_THROTTLE_MS) {
+        return;
+      }
+      lastCursorSentAt.current = now;
+      // Cursor updates ride the websocket: they are high-frequency and lossy by nature.
+      publish(
+        { t: 'cursor', sid: sessionId, ts: now, user, x: Math.round(x), y: Math.round(y), cellKey },
+        { socket: true }
+      );
+    },
+    [enabled, publish, sessionId, user]
+  );
+
+  const sendView = useCallback(
+    (cellKey: string | null) => {
+      if (!enabled) {
+        return;
+      }
+      const now = Date.now();
+      // Skip unchanged positions and rate-limit: followers only need transitions.
+      if (cellKey === lastViewCell.current || now - lastViewSentAt.current < VIEW_THROTTLE_MS) {
+        return;
+      }
+      lastViewCell.current = cellKey;
+      lastViewSentAt.current = now;
+      publish({ t: 'view', sid: sessionId, ts: now, user, cellKey }, { socket: true });
+    },
+    [enabled, publish, sessionId, user]
+  );
+
+  const selfColor = useMemo(() => colorForSession(sessionId), [sessionId]);
+
+  const sendActivity = useCallback(
+    (label: string, cellKey?: string) => {
+      const ts = Date.now();
+      // Own actions appear in the local feed immediately; peers get them over Live.
+      appendActivity({ id: `${sessionId}-${ts}`, sid: sessionId, user, color: selfColor, label, cellKey, ts });
+      if (enabled) {
+        publish({ t: 'activity', sid: sessionId, ts, user, label, cellKey });
+      }
+    },
+    [enabled, publish, sessionId, user, selfColor, appendActivity]
+  );
+
+  const getPeers = useCallback(() => Array.from(peersRef.current.values()), []);
+
+  return { peers, getPeers, activity, notifyLocalEdit, sendCursor, sendView, sendActivity, selfColor, sessionId };
+}

--- a/public/app/features/notebook/editor/NotebookEditor.tsx
+++ b/public/app/features/notebook/editor/NotebookEditor.tsx
@@ -19,6 +19,7 @@ import {
   Button,
   ConfirmModal,
   Dropdown,
+  Icon,
   IconButton,
   LinkButton,
   Menu,
@@ -39,6 +40,11 @@ import { getShiftedTimeRange, getZoomedTimeRange } from 'app/core/utils/timePick
 import { dispatch } from 'app/store/store';
 
 import { deleteNotebook, duplicateNotebook, notebookEditUrl, notebookViewUrl } from '../api/notebookAPI';
+import { ActivityFeedButton } from '../collab/ActivityFeed';
+import { CollabCursors } from '../collab/CollabCursors';
+import { PresenceAvatars } from '../collab/PresenceAvatars';
+import { mergeRemoteSpec } from '../collab/mergeRemoteSpec';
+import { resourceVersionTs, useNotebookCollab } from '../collab/useNotebookCollab';
 import { setLastUsedNotebook } from '../model/lastUsedNotebook';
 import { consumeNewNotebook } from '../model/newNotebookSignal';
 import {
@@ -76,12 +82,17 @@ export function NotebookEditor({ uid }: Props) {
   const { spec, loading, loadError, saving, dirty, lastSavedAt } = editor.state;
 
   const [editingCellKey, setEditingCellKey] = useState<string | null>(null);
+  const editingCellKeyRef = useRef<string | null>(null);
+  editingCellKeyRef.current = editingCellKey;
+
   const [renamingKey, setRenamingKey] = useState<string | null>(null);
   const [timeEditKey, setTimeEditKey] = useState<string | null>(null);
   const [queryEditKey, setQueryEditKey] = useState<string | null>(null);
   const [highlightKey, setHighlightKey] = useState<string | null>(null);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [refreshNonce, setRefreshNonce] = useState(0);
+  const [followSid, setFollowSid] = useState<string | null>(null);
+  const documentRef = useRef<HTMLDivElement>(null);
   const titleInputRef = useRef<HTMLInputElement>(null);
   const highlightTimer = useRef<ReturnType<typeof setTimeout>>();
   // Latest query-result readers per panel cell, powering the viz suggestions previews.
@@ -101,20 +112,43 @@ export function NotebookEditor({ uid }: Props) {
     }
   }, [uid, loadedTitle]);
 
+  const collab = useNotebookCollab({
+    uid,
+    enabled: !loading && !loadError,
+    getSpec: editor.getSpec,
+    initialDocTs: resourceVersionTs(editor.state.resource),
+    onRemoteSpec: useCallback(
+      (remoteSpec) => {
+        editor.applyRemoteSpec(mergeRemoteSpec(remoteSpec, editor.getSpec(), editingCellKeyRef.current));
+      },
+      [editor]
+    ),
+  });
+
+  // Every local mutation goes through here so collaborators get the update too.
+  // Structural edits pass an `activity` label that lands in everyone's feed.
   const update = useCallback(
-    (mutate: Parameters<typeof editor.updateSpec>[0]) => {
+    (mutate: Parameters<typeof editor.updateSpec>[0], activity?: { label: string; cellKey?: string }) => {
       editor.updateSpec(mutate);
+      collab.notifyLocalEdit();
+      if (activity) {
+        collab.sendActivity(activity.label, activity.cellKey);
+      }
     },
-    [editor]
+    [editor, collab]
   );
 
   const undo = useCallback(() => {
-    editor.undo();
-  }, [editor]);
+    if (editor.undo()) {
+      collab.notifyLocalEdit();
+    }
+  }, [editor, collab]);
 
   const redo = useCallback(() => {
-    editor.redo();
-  }, [editor]);
+    if (editor.redo()) {
+      collab.notifyLocalEdit();
+    }
+  }, [editor, collab]);
 
   const jumpToCell = useCallback((cellKey: string) => {
     document.querySelector(`[data-cell-key="${CSS.escape(cellKey)}"]`)?.scrollIntoView({
@@ -126,6 +160,20 @@ export function NotebookEditor({ uid }: Props) {
     highlightTimer.current = setTimeout(() => setHighlightKey(null), 2500);
   }, []);
 
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      const container = documentRef.current;
+      if (!container) {
+        return;
+      }
+      const rect = container.getBoundingClientRect();
+      const target = e.target instanceof Element ? e.target : null;
+      const hoveredCell = target?.closest('[data-cell-key]')?.getAttribute('data-cell-key') ?? null;
+      collab.sendCursor(e.clientX - rect.left, e.clientY - rect.top, editingCellKeyRef.current ?? hoveredCell);
+    },
+    [collab]
+  );
+
   const insertTextAt = useCallback(
     (index: number) => {
       let newKey: string | undefined;
@@ -136,19 +184,25 @@ export function NotebookEditor({ uid }: Props) {
       });
       if (newKey) {
         setEditingCellKey(newKey);
+        collab.sendActivity(t('notebooks.activity.added-text', 'added a text block'), newKey);
       }
     },
-    [update]
+    [update, collab]
   );
 
   const insertCodeAt = useCallback(
     (index: number) => {
+      let newKey: string | undefined;
       update((s) => {
         const result = insertElement(s, newCodeElement('', ''), { index });
+        newKey = result.elementName;
         return result.spec;
       });
+      if (newKey) {
+        collab.sendActivity(t('notebooks.activity.added-code', 'added a code block'), newKey);
+      }
     },
-    [update]
+    [update, collab]
   );
 
   const insertVizAt = useCallback(
@@ -169,6 +223,7 @@ export function NotebookEditor({ uid }: Props) {
         return result.spec;
       });
       if (newKey) {
+        collab.sendActivity(t('notebooks.activity.added-viz', 'added a visualization'), newKey);
         jumpToCell(newKey);
         autoVizCells.current.add(newKey);
         // A panel with an empty query renders "no data" — open the query editor
@@ -178,7 +233,7 @@ export function NotebookEditor({ uid }: Props) {
         }
       }
     },
-    [update, jumpToCell]
+    [update, collab, jumpToCell]
   );
 
   // First data for a freshly added panel: adopt the viz the frames prefer, unless
@@ -201,7 +256,10 @@ export function NotebookEditor({ uid }: Props) {
   const onDragEnd = useCallback(
     (result: DropResult) => {
       if (result.destination && result.destination.index !== result.source.index) {
-        update((s) => moveCell(s, result.source.index, result.destination!.index));
+        update((s) => moveCell(s, result.source.index, result.destination!.index), {
+          label: t('notebooks.activity.moved-block', 'moved a block'),
+          cellKey: result.draggableId,
+        });
       }
     },
     [update]
@@ -234,6 +292,73 @@ export function NotebookEditor({ uid }: Props) {
     document.addEventListener('keydown', onKeyDown);
     return () => document.removeEventListener('keydown', onKeyDown);
   }, [editor, undo, redo]);
+
+  // Broadcast which block sits at our viewport center so collaborators can follow us.
+  useEffect(() => {
+    let lastMeasure = 0;
+    const onScroll = () => {
+      const container = documentRef.current;
+      if (!container) {
+        return;
+      }
+      // Measuring every block per scroll event causes layout thrash on large
+      // notebooks; a coarse gate is plenty for follow mode.
+      const now = Date.now();
+      if (now - lastMeasure < 200) {
+        return;
+      }
+      lastMeasure = now;
+      const centerY = window.innerHeight / 2;
+      let best: { key: string; distance: number } | undefined;
+      for (const node of container.querySelectorAll('[data-cell-key]')) {
+        const rect = node.getBoundingClientRect();
+        const distance = Math.abs((rect.top + rect.bottom) / 2 - centerY);
+        const key = node.getAttribute('data-cell-key');
+        if (key && (!best || distance < best.distance)) {
+          best = { key, distance };
+        }
+      }
+      collab.sendView(best?.key ?? null);
+    };
+    // Capture phase: the page content scrolls inside a nested scroller, not the window.
+    window.addEventListener('scroll', onScroll, { capture: true, passive: true });
+    return () => window.removeEventListener('scroll', onScroll, { capture: true });
+  }, [collab]);
+
+  // Follow mode: ride along with the followed collaborator's viewport.
+  const followedPeer = followSid ? collab.peers.find((p) => p.sid === followSid) : undefined;
+  const followedViewCell = followedPeer?.viewCell;
+  useEffect(() => {
+    if (!followSid) {
+      return;
+    }
+    if (!followedPeer) {
+      // The peer left; following ends with them.
+      setFollowSid(null);
+      return;
+    }
+    if (followedViewCell) {
+      document.querySelector(`[data-cell-key="${CSS.escape(followedViewCell)}"]`)?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center',
+      });
+    }
+  }, [followSid, followedPeer, followedViewCell]);
+
+  // Any deliberate scroll input (wheel, touch) means the user wants their own viewport
+  // back — these events only come from the user, never from scrollIntoView.
+  useEffect(() => {
+    if (!followSid) {
+      return;
+    }
+    const stop = () => setFollowSid(null);
+    window.addEventListener('wheel', stop, { passive: true });
+    window.addEventListener('touchmove', stop, { passive: true });
+    return () => {
+      window.removeEventListener('wheel', stop);
+      window.removeEventListener('touchmove', stop);
+    };
+  }, [followSid]);
 
   // Auto-refresh: re-run all panels on the notebook's refresh interval.
   const autoRefresh = spec?.timeSettings.autoRefresh;
@@ -354,7 +479,12 @@ export function NotebookEditor({ uid }: Props) {
   const cells = resolveCells(spec);
   const timeRange = rangeUtil.convertRawToRange({ from: spec.timeSettings.from, to: spec.timeSettings.to });
 
-  const commitTimeRange = (from: string, to: string) => update((s) => setNotebookTimeRange(s, from, to));
+  // The notebook time range is shared document state (autosaved, synced to
+  // collaborators) — every change is announced like any other structural edit.
+  const commitTimeRange = (from: string, to: string) =>
+    update((s) => setNotebookTimeRange(s, from, to), {
+      label: t('notebooks.activity.changed-time', 'changed the notebook time range'),
+    });
   const shiftTimeRange = (direction: number) => {
     const shifted = getShiftedTimeRange(direction, timeRange);
     commitTimeRange(toUtc(shifted.from).toISOString(), toUtc(shifted.to).toISOString());
@@ -402,6 +532,11 @@ export function NotebookEditor({ uid }: Props) {
 
   const actions = (
     <Stack direction="row" gap={1} alignItems="center" wrap="wrap" justifyContent="flex-end">
+      <PresenceAvatars
+        peers={collab.peers}
+        followedSid={followSid}
+        onToggleFollow={(peer) => setFollowSid((cur) => (cur === peer.sid ? null : peer.sid))}
+      />
       <IconButton
         name="history"
         size="lg"
@@ -418,6 +553,7 @@ export function NotebookEditor({ uid }: Props) {
         onClick={redo}
         tooltip={t('notebooks.editor.redo', 'Redo (⇧⌘Z)')}
       />
+      <ActivityFeedButton activity={collab.activity} onJumpToCell={jumpToCell} />
       {/* The dashboards-style picker: its popup is right-edge aligned (TimeRangeInput's
           overflows the viewport from a right-anchored toolbar) and it brings the
           shift/zoom arrows Grafana users expect. */}
@@ -464,7 +600,27 @@ export function NotebookEditor({ uid }: Props) {
   return (
     <Page navId="notebooks" pageNav={pageNav} renderTitle={() => titleInput} actions={actions}>
       <Page.Contents>
-        <div className={styles.document}>
+        {/* Pointer tracking is presence telemetry for collaborators, not an interaction. */}
+        {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
+        <div className={styles.document} ref={documentRef} onPointerMove={onPointerMove}>
+          <CollabCursors getPeers={collab.getPeers} />
+
+          {followedPeer && (
+            <div className={styles.followingPill} style={{ backgroundColor: followedPeer.color }}>
+              <Icon name="eye" size="sm" />
+              {t('notebooks.editor.following', 'Following {{name}}', {
+                name: followedPeer.user.name || followedPeer.user.login,
+              })}
+              <IconButton
+                name="times"
+                size="sm"
+                variant="secondary"
+                tooltip={t('notebooks.editor.stop-following', 'Stop following')}
+                onClick={() => setFollowSid(null)}
+              />
+            </div>
+          )}
+
           <div className={styles.metaRow}>
             <TagsInput
               tags={spec.tags}
@@ -485,6 +641,10 @@ export function NotebookEditor({ uid }: Props) {
                 {(droppable) => (
                   <div ref={droppable.innerRef} {...droppable.droppableProps} className={styles.cells}>
                     {cells.map((cell, index) => {
+                      const peersInCell = collab.peers
+                        .filter((p) => p.cellKey === cell.elementName)
+                        .map((p) => ({ name: p.user.name || p.user.login, color: p.color }));
+
                       return (
                         <Draggable draggableId={cell.elementName} index={index} key={cell.elementName}>
                           {(draggable, snapshot) => (
@@ -509,13 +669,20 @@ export function NotebookEditor({ uid }: Props) {
                               <CellFrame
                                 cellKey={cell.elementName}
                                 source={cell.source}
-                                peers={[]}
+                                peers={peersInCell}
                                 highlighted={highlightKey === cell.elementName}
                                 isDragging={snapshot.isDragging}
                                 dragHandleProps={draggable.dragHandleProps}
-                                onDuplicate={() => update((s) => duplicateCellAt(s, index))}
+                                onDuplicate={() =>
+                                  update((s) => duplicateCellAt(s, index), {
+                                    label: t('notebooks.activity.duplicated-block', 'duplicated a block'),
+                                    cellKey: cell.elementName,
+                                  })
+                                }
                                 onDelete={() => {
-                                  update((s) => removeCellAt(s, index));
+                                  update((s) => removeCellAt(s, index), {
+                                    label: t('notebooks.activity.deleted-block', 'deleted a block'),
+                                  });
                                   dispatch(
                                     notifyApp(
                                       createSuccessNotification(
@@ -547,7 +714,10 @@ export function NotebookEditor({ uid }: Props) {
                                           // A manual choice always wins over data-driven auto-pick.
                                           autoVizCells.current.delete(cell.elementName);
                                           manualVizCells.current.add(cell.elementName);
-                                          update((s) => updatePanelViz(s, cell.elementName, suggestion));
+                                          update((s) => updatePanelViz(s, cell.elementName, suggestion), {
+                                            label: t('notebooks.activity.changed-viz', 'changed a visualization'),
+                                            cellKey: cell.elementName,
+                                          });
                                         }}
                                       />
                                       <IconButton
@@ -707,6 +877,21 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   redoIcon: css({
     transform: 'scaleX(-1)',
+  }),
+  followingPill: css({
+    position: 'fixed',
+    top: theme.spacing(10),
+    left: '50%',
+    transform: 'translateX(-50%)',
+    zIndex: theme.zIndex.portal,
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.75),
+    color: '#fff',
+    padding: theme.spacing(0.5, 0.75, 0.5, 1.5),
+    borderRadius: theme.shape.radius.pill,
+    boxShadow: theme.shadows.z3,
+    fontWeight: theme.typography.fontWeightMedium,
   }),
   titleInput: css({
     border: 'none',

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12688,9 +12688,20 @@
   },
   "notebooks": {
     "activity": {
+      "added-code": "added a code block",
+      "added-text": "added a text block",
+      "added-viz": "added a visualization",
+      "changed-time": "changed the notebook time range",
+      "changed-viz": "changed a visualization",
+      "deleted-block": "deleted a block",
+      "duplicated-block": "duplicated a block",
       "edited-query": "edited a query",
+      "empty": "Edits made while this notebook is open will show up here.",
       "locked-time": "locked a block to a time range",
+      "moved-block": "moved a block",
       "renamed-panel": "renamed a panel",
+      "title": "Activity",
+      "tooltip": "Activity",
       "unlocked-time": "synced a block back to notebook time"
     },
     "add-cell": {
@@ -12736,6 +12747,7 @@
       "empty-dashboards": "Browse dashboards",
       "empty-explore": "Open Explore",
       "empty-title": "Start your investigation",
+      "following": "Following {{name}}",
       "library-panel": "Library panel — open the notebook view to render it",
       "link-copied": "Notebook link copied",
       "load-error": "Failed to load notebook",
@@ -12746,6 +12758,7 @@
       "status-pending": "Saving shortly…",
       "status-saved": "Saved {{when}}",
       "status-saving": "Saving…",
+      "stop-following": "Stop following",
       "tags-placeholder": "Add tags",
       "title-label": "Notebook title",
       "title-placeholder": "Give this notebook a title",
@@ -12798,6 +12811,11 @@
     },
     "panel-cell": {
       "resize": "Resize panel"
+    },
+    "presence": {
+      "click-to-follow": "{{name}} is in this notebook — click to follow",
+      "stop-following": "Following {{name}} — click to stop",
+      "viewing": "{{name}} is in this notebook"
     },
     "query-editor": {
       "close": "Close query editor",


### PR DESCRIPTION
## What this adds

- Synchronizes notebook document changes through Grafana Live.
- Adds presence avatars, collaborative cursors, activity, and follow behavior.
- Merges remote notebook updates with local editor state.
- Adds focused tests for remote document merging.

## Why

The core editor updates and autosaves locally without this layer. Collaboration is required for changes from other editors—and later dashboard or Explore capture actions—to appear in an already-open notebook without a refresh. Keeping it separate makes the initial realtime design explicit and independently reviewable.

## POC scope

This is included for internal dogfooding and early feedback. Access is limited to signed-in users in the organization, but the initial implementation does not enforce per-notebook ACLs. Authorization, resilience, conflict handling, and operational hardening are intentionally deferred before any broader rollout.

## Stack

Layer 4 of 8. Depends on backend Grafana Live support in #129915 through the lower stack layers.

## Validation

Review follow-up validation passed: focused notebook, route, and dashboard suites (18 suites, 140 tests), `yarn typecheck`, the production frontend build, and the React 19 frontend build.

## Dogfooding

Use the [original combined POC environment](https://ephemeral15111821129904nmarrs.grafana-dev.net/notebooks) for the clearest end-to-end demo.

[Open this PR's ephemeral notebook instance](https://ephemeral15111821129973nmarrs.grafana-dev.net/notebooks) to smoke-test the cumulative branch containing backend, core notebook experience, and realtime collaboration. This environment is primarily useful for verifying Grafana starts cleanly and the changes through this layer do not introduce runtime regressions.