### PR TITLE
Notebooks: Add shared capture workflow and dashboard capture

### DIFF
--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
@@ -175,6 +175,45 @@ export function panelMenuBehavior(menu: VizPanelMenu) {
       },
     });
 
+    if (
+      contextSrv.isSignedIn &&
+      !isEditingPanel &&
+      (contextSrv.hasPermission(AccessControlAction.DashboardsCreate) ||
+        contextSrv.hasPermission(AccessControlAction.DashboardsWrite)) &&
+      getFeatureFlagClient().getBooleanValue(FlagKeys.DashboardNotebooks, false)
+    ) {
+      items.push({
+        text: t('panel.header-menu.add-to-notebook', 'Add to notebook'),
+        iconClassName: 'book-open',
+        onClick: (e) => {
+          e.preventDefault();
+          // Loaded lazily so the notebooks feature stays out of the dashboard bundle path.
+          import('app/features/notebook/addToNotebook/addPanelToNotebookFromMenu').then((m) =>
+            m.addPanelToNotebookFromMenu(panel, dashboard)
+          );
+        },
+      });
+
+      // One-click append to the most recently used notebook (skips the picker).
+      const lastUsedNotebook = await import('app/features/notebook/model/lastUsedNotebook')
+        .then(({ getLastUsedNotebook }) => getLastUsedNotebook())
+        .catch(() => undefined);
+      if (lastUsedNotebook) {
+        const shortTitle =
+          lastUsedNotebook.title.length > 25 ? `${lastUsedNotebook.title.slice(0, 25)}…` : lastUsedNotebook.title;
+        items.push({
+          text: t('panel.header-menu.add-to-last-notebook', 'Add to "{{title}}"', { title: shortTitle }),
+          iconClassName: 'bolt',
+          onClick: (e) => {
+            e.preventDefault();
+            import('app/features/notebook/addToNotebook/addPanelToNotebookFromMenu').then((m) =>
+              m.quickAddPanelToLastNotebookFromMenu(panel, dashboard)
+            );
+          },
+        });
+      }
+    }
+
     if (dashboard.state.isEditing && !isReadOnlyRepeat && !isEditingPanel) {
       moreSubMenu.push({
         text: t('panel.header-menu.duplicate', `Duplicate`),

--- a/public/app/features/notebook/README.md
+++ b/public/app/features/notebook/README.md
@@ -1,0 +1,110 @@
+# Notebooks (POC)
+
+Living documents for investigations: narrative text, code snippets and **live panels**
+captured from dashboards or Explore, with real-time collaboration. Behind the
+`dashboard.notebooks` feature toggle.
+
+Notebooks are stored as a `Notebook` resource in the `dashboard.grafana.app/v2beta1`
+API group (spec defined in `apps/dashboard/kinds/v2beta1/notebook_spec.cue`). A
+notebook is a flat list of layout cells referencing elements: markdown/code cells and
+panels that reuse the dashboard v2 `PanelKind` shape, so panels round-trip cleanly
+between dashboards, Explore and notebooks.
+
+## Directory map
+
+| Path             | What lives there                                                                                                                                                                                 |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `model/`         | Pure functions over the `NotebookSpec` (insert/move/duplicate/update blocks, time locks, normalization) — everything here is unit-tested and side-effect free                                    |
+| `api/`           | Imperative CRUD over the generated RTK client, plus URL helpers and the last-used-notebook store                                                                                                 |
+| `editor/`        | The block editor: dnd reordering, markdown/code editing, inline datasource query editing (`cells/PanelQueryEditor`), viz suggestions, per-panel time locks, undo/redo (`useNotebookEditorState`) |
+| `collab/`        | Real-time layer over Grafana Live: presence, live cursors, follow mode, activity feed, last-write-wins doc sync (`useNotebookCollab`, `mergeRemoteSpec`)                                         |
+| `addToNotebook/` | Capture entry points: dashboard panel menu, Explore toolbar, quick-add-to-last-notebook                                                                                                          |
+| `sidebar/`       | Compact companion editor docked in the extension sidebar                                                                                                                                         |
+| `pages/`         | List page, editor page, read-only view page (renders through the dashboard scene pipeline)                                                                                                       |
+| `extensions/`    | Core extension-point registrations (Explore, sidebar, IRM landing card, command palette) and the declare-incident button                                                                         |
+
+Related code outside this folder:
+
+- `public/app/features/dashboard-scene/scene/layout-notebook/` — the read-only view renderer (pre-existed this POC; the editor reuses its markdown cell and panel-building utils).
+- `pkg/services/live/features/notebook.go` — the Live channel relay for collaboration.
+- `pkg/services/navtree` — the nav entry.
+
+## Architecture notes
+
+- **Durable model**: the `Notebook` resource + shared dashboard `PanelKind` leaf types.
+  Scenes/`VizPanel` are how we render live panels (same stack as dashboards/Explore),
+  not the source of truth. Capture and round-trip stay cheap because of that reuse.
+- **Edit and view are separate surfaces (intentional)**:
+  - **Edit**: Notion-style block editor — dnd, inline query/markdown editing, autosave,
+    collab overlays. Each panel is a small `EmbeddedScene` + `VizPanel`
+    (`editor/cells/PanelCellView` / `buildNotebookVizPanel`). Notebooks aren’t dashboards,
+    so this doesn’t go through DashboardScene edit chrome.
+  - **View**: read-only document page via the `layout-notebook` dashboard-scene pipeline
+    (`NotebookScenePageStateManager` + `buildNotebookEnvelope`) for URL sync, time
+    controls, and panel chrome.
+  - Both read the same `NotebookSpec` and build the same kind of `VizPanel`. Keep panel /
+    narrative construction shared so the two surfaces don’t drift; don’t force edit into
+    a dashboard scene just to have “one path.”
+- **Editing model**: all mutations are immutable spec transforms in `model/notebookSpec.ts`,
+  applied through `useNotebookEditorState` (debounced autosave with optimistic-concurrency
+  retry, snapshot-based undo/redo with typing coalescing).
+- **Collaboration**: ephemeral messages relayed verbatim over `grafana/notebook/uid/<uid>`.
+  Presence/cursors/follow/activity are production-shaped; **document sync is deliberately
+  POC-grade** (full-doc broadcast, wall-clock last-write-wins, per-block merge protection
+  only for the actively edited block). The block-structured spec was chosen so the real
+  implementation can be per-block revisions / ops rather than general collaborative text.
+- **Query editing**: embeds each datasource's own `QueryEditor` with `CoreApp.Correlations`
+  (the established value for standalone embeds), local draft state, explicit commit on run —
+  same pattern as the saved-queries inline editor.
+
+## Known limitations / next steps
+
+- Doc sync loses concurrent structural edits beyond ~5 active editors (see above) —
+  needs per-block versioning, a single-writer save election, and server-side identity
+  stamping in the Live handler before real multiplayer use.
+- Assistant integration (context handoff + write-back functions) was built and then
+  deliberately removed to keep the core lean; it lives in git history.
+- No template gallery, slash-menu insertion, or export beyond copy-as-Markdown — parked
+  pending user feedback.
+- Notebooks are not in the search index: no "recent notebooks" or search results in the
+  command palette (dashboards get this via unified search). Indexing the notebook
+  resource is the natural GA path; the list page's content search is client-side.
+- View-mode time controls are hidden when a notebook has no visualization panels
+  (nothing for the shared range to drive); they stay editable when panels are present.
+- Notebook `description` exists on the spec (list search / declare-incident can use it)
+  but is **not editable in the POC UI** — fast follow. Declare-incident title order:
+  named title → first markdown line → description → `Investigation: Untitled notebook`.
+  New notebooks are titled `Investigation — {Month D, YYYY HH:mm}` (browser TZ; not
+  Untitled) so capture targets are easier to find. Declare-incident attaches the
+  notebook via url/caption and leads the description with
+  “This incident was declared from this notebook: {url}” (IRM has no URL param for
+  a status-update body — `status` is lifecycle only).
+
+## Review notes (private preview readiness)
+
+- **Permissions**: editing is gated on the dashboards `create`/`write` actions as a
+  POC shortcut. A real rollout wants notebook-scoped actions (or at least a
+  deliberate decision to inherit dashboard permissions) plus folder placement.
+- **Generated files**: the schema change (`height`, `timeFrom`, `timeTo` on
+  `NotebookLayoutItemSpec`) lives in `apps/dashboard/kinds/v2beta1/notebook_spec.cue`;
+  the Go/OpenAPI/TS outputs were generated and committed together — CI's codegen
+  verification should pass as-is.
+- **Security posture**: markdown renders through the standard text-panel sanitizer
+  (js-xss whitelist; `data:image/` is allowed for img src by its defaults, which the
+  image paste feature relies on — pasted images are downscaled and capped at ~500KB).
+  The Live channel is org-isolated upstream; the relay handler does **not** stamp
+  sender identity server-side yet, so collab messages trust the client-supplied user
+  (fine for preview, must fix before GA — the handler receives the authenticated
+  requester and can stamp it).
+- **Shipping split**: per repo convention the backend (CUE schema, Live handler,
+  navtree) and frontend should land as separate PRs; the backend diff is ~130 lines
+  and has no frontend dependency.
+- **Test coverage**: model/spec transforms, editor state (undo/autosave), collab
+  merge, capture orchestration, markdown export, view-page loading are covered.
+  Not covered: the Live hook itself (`useNotebookCollab` — needs a Live mock
+  harness) and the editor component tree (exercised manually).
+
+## Running it
+
+`make run` + `yarn start`, with `dashboard.notebooks = true` under `[feature_toggles]`.
+Open `/notebooks`. For the collaboration demo, open the same notebook in two windows.

--- a/public/app/features/notebook/addToNotebook/AddToNotebookForm.tsx
+++ b/public/app/features/notebook/addToNotebook/AddToNotebookForm.tsx
@@ -1,0 +1,174 @@
+import { useMemo, useState } from 'react';
+
+import { AppEvents, rangeUtil, type RawTimeRange, type SelectableValue } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { locationService } from '@grafana/runtime';
+import { type NotebookElement } from '@grafana/schema/apis/notebook/v2beta1';
+import { Alert, Button, Checkbox, Field, Input, Modal, RadioButtonGroup, Select, Stack, Text } from '@grafana/ui';
+import { useListNotebookQuery } from 'app/api/clients/dashboard/v2beta1';
+import { appEvents } from 'app/core/app_events';
+
+import { notebookEditUrl } from '../api/notebookAPI';
+import { getLastUsedNotebook } from '../model/lastUsedNotebook';
+import { newNotebookTitleDate } from '../model/notebookSpec';
+
+import { addElementToNotebook, type AddToNotebookTarget } from './addToNotebook';
+
+enum SaveTarget {
+  New = 'new',
+  Existing = 'existing',
+}
+
+export interface AddToNotebookFormProps {
+  /** The element being added — a panel captured from a dashboard or Explore. */
+  element: NotebookElement;
+  /** Where the element came from, shown as context in the form. */
+  sourceName?: string;
+  /** Source time range; becomes the notebook time range when creating a new notebook. */
+  timeRange?: RawTimeRange;
+  onDismiss: () => void;
+}
+
+/**
+ * The shared "Add to notebook" flow (Figma: click add to notebook → new notebook /
+ * select existing → item added to draft notebook). Chrome-less so it can live in
+ * the extension modal (Explore) and the panel-menu modal alike.
+ */
+export function AddToNotebookForm({ element, sourceName, timeRange, onDismiss }: AddToNotebookFormProps) {
+  // Default to the most recently used notebook (the Figma's "default notebook" is
+  // the last used one); fall back to creating a new notebook.
+  const [lastUsed] = useState(getLastUsedNotebook);
+  const [saveTarget, setSaveTarget] = useState<SaveTarget>(lastUsed ? SaveTarget.Existing : SaveTarget.New);
+  const [title, setTitle] = useState(defaultTitle());
+  const [existingUid, setExistingUid] = useState<string | undefined>(lastUsed?.uid);
+  // An absolute source range means the user was looking at a specific window (e.g.
+  // zoomed into a spike) — capture what they saw by defaulting the lock on. Relative
+  // ranges ("last 6 hours") follow the notebook's time by default.
+  const [lockTimeRange, setLockTimeRange] = useState(() =>
+    Boolean(timeRange && !rangeUtil.isRelativeTimeRange(timeRange))
+  );
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | undefined>();
+
+  const { data, isLoading } = useListNotebookQuery({});
+
+  const notebookOptions: Array<SelectableValue<string>> = useMemo(
+    () =>
+      (data?.items ?? [])
+        .map((nb) => ({ label: nb.spec.title, value: nb.metadata.name ?? '' }))
+        .filter((option) => option.value !== ''),
+    [data]
+  );
+
+  const targets = [
+    { label: t('notebooks.add-form.new', 'New notebook'), value: SaveTarget.New },
+    {
+      label: t('notebooks.add-form.existing', 'Existing notebook'),
+      value: SaveTarget.Existing,
+      description: notebookOptions.length === 0 ? t('notebooks.add-form.none-yet', 'No notebooks yet') : undefined,
+    },
+  ];
+
+  const onSubmit = async (openAfter: boolean) => {
+    setError(undefined);
+
+    const target: AddToNotebookTarget =
+      saveTarget === SaveTarget.New
+        ? { type: 'new', title: title.trim() || defaultTitle() }
+        : { type: 'existing', uid: existingUid ?? '' };
+
+    if (target.type === 'existing' && !target.uid) {
+      setError(t('notebooks.add-form.select-required', 'Select a notebook to add to.'));
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const result = await addElementToNotebook(target, element, { timeRange, source: 'user', lockTimeRange });
+      onDismiss();
+      if (openAfter) {
+        locationService.push(`${notebookEditUrl(result.uid)}?cell=${encodeURIComponent(result.elementName)}`);
+      } else {
+        appEvents.emit(AppEvents.alertSuccess, [t('notebooks.add-form.added', 'Added to notebook'), result.title]);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t('notebooks.add-form.failed', 'Failed to add to notebook'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Stack direction="column" gap={1}>
+      {sourceName && (
+        <Text color="secondary" variant="bodySmall">
+          <Trans i18nKey="notebooks.add-form.source">Adding a live panel from {{ sourceName }}.</Trans>
+        </Text>
+      )}
+
+      <Field noMargin label={t('notebooks.add-form.target-label', 'Target notebook')}>
+        <RadioButtonGroup options={targets} value={saveTarget} onChange={setSaveTarget} />
+      </Field>
+
+      {saveTarget === SaveTarget.New ? (
+        <Field noMargin label={t('notebooks.add-form.title-label', 'Notebook name')}>
+          <Input value={title} onChange={(e) => setTitle(e.currentTarget.value)} data-testid="add-to-notebook-title" />
+        </Field>
+      ) : (
+        <Field noMargin label={t('notebooks.add-form.notebook-label', 'Notebook')}>
+          <Select
+            options={notebookOptions}
+            isLoading={isLoading}
+            value={existingUid}
+            onChange={(option) => setExistingUid(option?.value)}
+            placeholder={t('notebooks.add-form.notebook-placeholder', 'Choose a notebook')}
+            data-testid="add-to-notebook-picker"
+          />
+        </Field>
+      )}
+
+      {timeRange && (
+        // alignSelf keeps the checkbox's inline-grid hugging the left edge instead of
+        // stretching (which centers its label/description in the modal).
+        <div style={{ alignSelf: 'flex-start' }}>
+          <Checkbox
+            value={lockTimeRange}
+            onChange={(e) => setLockTimeRange(e.currentTarget.checked)}
+            label={t('notebooks.add-form.lock-time', 'Lock this panel to the current time window')}
+            description={t('notebooks.add-form.lock-time-description', '{{from}} → {{to}}', absoluteRange(timeRange))}
+          />
+        </div>
+      )}
+
+      {error && (
+        <Alert severity="error" title={t('notebooks.add-form.error-title', 'Could not add to notebook')}>
+          {error}
+        </Alert>
+      )}
+
+      <Modal.ButtonRow>
+        <Button variant="secondary" fill="outline" onClick={onDismiss} disabled={submitting}>
+          <Trans i18nKey="notebooks.add-form.cancel">Cancel</Trans>
+        </Button>
+        <Button variant="secondary" onClick={() => onSubmit(false)} disabled={submitting} icon="book-open">
+          <Trans i18nKey="notebooks.add-form.add">Add</Trans>
+        </Button>
+        <Button variant="primary" onClick={() => onSubmit(true)} disabled={submitting} icon="external-link-alt">
+          <Trans i18nKey="notebooks.add-form.add-open">Add & open notebook</Trans>
+        </Button>
+      </Modal.ButtonRow>
+    </Stack>
+  );
+}
+
+function defaultTitle(): string {
+  // Same dated shape as list/sidebar/command-palette creates (i18n-wrapped).
+  return t('notebooks.add-form.default-title', 'Investigation — {{date}}', {
+    date: newNotebookTitleDate(),
+  });
+}
+
+function absoluteRange(raw: RawTimeRange): { from: string; to: string } {
+  const range = rangeUtil.convertRawToRange(raw);
+  return { from: range.from.format('YYYY-MM-DD HH:mm'), to: range.to.format('YYYY-MM-DD HH:mm') };
+}

--- a/public/app/features/notebook/addToNotebook/AddToNotebookModal.tsx
+++ b/public/app/features/notebook/addToNotebook/AddToNotebookModal.tsx
@@ -1,0 +1,22 @@
+import { t } from '@grafana/i18n';
+import { Modal } from '@grafana/ui';
+
+import { AddToNotebookForm, type AddToNotebookFormProps } from './AddToNotebookForm';
+
+interface Props extends Omit<AddToNotebookFormProps, 'onDismiss'> {
+  onDismiss?: () => void;
+}
+
+/**
+ * Self-contained modal wrapper around AddToNotebookForm, for imperative openers
+ * (ShowModalReactEvent from the dashboard panel menu). The modals context provider
+ * injects onDismiss.
+ */
+export function AddToNotebookModal({ onDismiss, ...formProps }: Props) {
+  const close = onDismiss ?? (() => {});
+  return (
+    <Modal title={t('notebooks.add-modal.title', 'Add to notebook')} isOpen onDismiss={close}>
+      <AddToNotebookForm {...formProps} onDismiss={close} />
+    </Modal>
+  );
+}

--- a/public/app/features/notebook/addToNotebook/addPanelToNotebookFromMenu.tsx
+++ b/public/app/features/notebook/addToNotebook/addPanelToNotebookFromMenu.tsx
@@ -1,0 +1,107 @@
+import { t } from '@grafana/i18n';
+import { sceneGraph, type VizPanel } from '@grafana/scenes';
+import { type NotebookElement, type PanelKind } from '@grafana/schema/apis/notebook/v2beta1';
+import { appEvents } from 'app/core/app_events';
+import { type DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
+import { vizPanelToSchemaV2 } from 'app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2';
+import { ShowModalReactEvent } from 'app/types/events';
+
+import { AddToNotebookModal } from './AddToNotebookModal';
+import { quickAddToLastNotebook } from './quickAddToLastNotebook';
+
+function capturePanel(panel: VizPanel, dashboard: DashboardScene): NotebookElement {
+  // The dashboard and notebook Panel/LibraryPanel kinds are generated identically
+  // from the same OpenAPI source; bridge them at this seam.
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- identical leaf type across the two schemas
+  const element = vizPanelToSchemaV2(panel) as unknown as NotebookElement;
+  if (element.kind === 'Panel') {
+    interpolateVariables(element, panel);
+    annotateOrigin(element, dashboard);
+  }
+  return element;
+}
+
+/**
+ * Dashboard panels usually reference template variables ($instance, $job, ...) that
+ * don't exist in a notebook. Resolve them to their current values at capture time —
+ * in queries, the title and panel options (e.g. text panel content) — so the
+ * notebook panel keeps showing what the user was looking at.
+ */
+function interpolateVariables(element: PanelKind, panel: VizPanel) {
+  element.spec.title = sceneGraph.interpolate(panel, element.spec.title);
+  element.spec.data.spec.queries = element.spec.data.spec.queries.map((query) => ({
+    ...query,
+    spec: {
+      ...query.spec,
+      query: {
+        ...query.spec.query,
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- deep-walk preserves the query spec shape
+        spec: interpolateDeep(query.spec.query.spec, panel) as Record<string, unknown>,
+      },
+    },
+  }));
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- deep-walk preserves the options shape
+  element.spec.vizConfig.spec.options = interpolateDeep(element.spec.vizConfig.spec.options, panel) as Record<
+    string,
+    unknown
+  >;
+}
+
+// Query-time macros ($__rate_interval, $__timeFilter, ${__field.*}) are not dashboard
+// variables: scene interpolation leaves them unresolved, so they stay dynamic.
+function interpolateDeep(value: unknown, panel: VizPanel): unknown {
+  if (typeof value === 'string') {
+    return value.includes('$') ? sceneGraph.interpolate(panel, value) : value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => interpolateDeep(item, panel));
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, interpolateDeep(item, panel)]));
+  }
+  return value;
+}
+
+/**
+ * Dashboard panel menu → "Add to notebook": captures the panel's full definition
+ * (queries, datasource, viz options, field config) as a notebook panel element and
+ * opens the shared add-to-notebook flow. Loaded lazily from the menu behavior to
+ * keep notebooks code out of the dashboard bundle path.
+ */
+export function addPanelToNotebookFromMenu(panel: VizPanel, dashboard: DashboardScene) {
+  const element = capturePanel(panel, dashboard);
+  const timeRange = sceneGraph.getTimeRange(panel).state.value.raw;
+
+  appEvents.publish(
+    new ShowModalReactEvent({
+      component: AddToNotebookModal,
+      props: {
+        element,
+        timeRange,
+        sourceName: dashboard.state.title || t('notebooks.add-from-panel.unnamed-dashboard', 'this dashboard'),
+      },
+    })
+  );
+}
+
+/**
+ * Dashboard panel menu → "Add to <last notebook>": appends straight to the most
+ * recently used notebook; falls back to the picker modal when that is not possible.
+ */
+export async function quickAddPanelToLastNotebookFromMenu(panel: VizPanel, dashboard: DashboardScene) {
+  const element = capturePanel(panel, dashboard);
+  const timeRange = sceneGraph.getTimeRange(panel).state.value.raw;
+
+  const added = await quickAddToLastNotebook(element, { timeRange });
+  if (!added) {
+    addPanelToNotebookFromMenu(panel, dashboard);
+  }
+}
+
+function annotateOrigin(element: PanelKind, dashboard: DashboardScene) {
+  if (!element.spec.subtitle && dashboard.state.title) {
+    element.spec.subtitle = t('notebooks.add-from-panel.origin', 'From dashboard: {{title}}', {
+      title: dashboard.state.title,
+    });
+  }
+}

--- a/public/app/features/notebook/addToNotebook/addToNotebook.test.ts
+++ b/public/app/features/notebook/addToNotebook/addToNotebook.test.ts
@@ -1,0 +1,75 @@
+import { newMarkdownElement, newNotebookSpec, resolveCells } from '../model/notebookSpec';
+
+import { addElementToNotebook } from './addToNotebook';
+
+const mockCreateNotebook = jest.fn();
+const mockFetchNotebook = jest.fn();
+const mockSaveNotebook = jest.fn();
+const mockBroadcast = jest.fn();
+
+jest.mock('../api/notebookAPI', () => ({
+  createNotebook: (spec: unknown) => mockCreateNotebook(spec),
+  fetchNotebook: (uid: string) => mockFetchNotebook(uid),
+  saveNotebook: (resource: unknown) => mockSaveNotebook(resource),
+}));
+
+jest.mock('../collab/useNotebookCollab', () => ({
+  broadcastNotebookDoc: (uid: string, spec: unknown) => mockBroadcast(uid, spec),
+}));
+
+describe('addElementToNotebook', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateNotebook.mockImplementation(async (spec) => ({
+      metadata: { name: 'nb-new', resourceVersion: '1' },
+      spec,
+    }));
+    mockSaveNotebook.mockImplementation(async (resource) => resource);
+  });
+
+  it('creates a new notebook carrying the source time range', async () => {
+    const element = newMarkdownElement('captured');
+
+    const result = await addElementToNotebook({ type: 'new', title: 'Fresh investigation' }, element, {
+      timeRange: { from: 'now-1h', to: 'now' },
+      source: 'user',
+    });
+
+    expect(result.uid).toBe('nb-new');
+    expect(result.title).toBe('Fresh investigation');
+    const createdSpec = mockCreateNotebook.mock.calls[0][0];
+    expect(createdSpec.timeSettings.from).toBe('now-1h');
+    const cells = resolveCells(createdSpec);
+    expect(cells).toHaveLength(1);
+    expect(result.elementName).toBe(cells[0].elementName);
+    // Nobody can have a not-yet-created notebook open — nothing to broadcast.
+    expect(mockBroadcast).not.toHaveBeenCalled();
+  });
+
+  it('appends to an existing notebook, saves and broadcasts the saved document', async () => {
+    const existing = newNotebookSpec('Ongoing');
+    mockFetchNotebook.mockResolvedValue({ metadata: { name: 'nb-1', resourceVersion: '5' }, spec: existing });
+
+    const result = await addElementToNotebook({ type: 'existing', uid: 'nb-1' }, newMarkdownElement('more'));
+
+    expect(mockFetchNotebook).toHaveBeenCalledWith('nb-1');
+    const savedResource = mockSaveNotebook.mock.calls[0][0];
+    expect(resolveCells(savedResource.spec)).toHaveLength(1);
+    expect(mockBroadcast).toHaveBeenCalledWith('nb-1', savedResource.spec);
+    expect(result.uid).toBe('nb-1');
+  });
+
+  it('locks the block to the absolute capture window when requested', async () => {
+    const existing = newNotebookSpec('Ongoing');
+    mockFetchNotebook.mockResolvedValue({ metadata: { name: 'nb-1', resourceVersion: '5' }, spec: existing });
+
+    await addElementToNotebook({ type: 'existing', uid: 'nb-1' }, newMarkdownElement('spike'), {
+      timeRange: { from: '2026-08-01T00:00:00.000Z', to: '2026-08-01T01:00:00.000Z' },
+      lockTimeRange: true,
+    });
+
+    const cell = resolveCells(mockSaveNotebook.mock.calls[0][0].spec)[0];
+    expect(cell.timeFrom).toBe('2026-08-01T00:00:00.000Z');
+    expect(cell.timeTo).toBe('2026-08-01T01:00:00.000Z');
+  });
+});

--- a/public/app/features/notebook/addToNotebook/addToNotebook.ts
+++ b/public/app/features/notebook/addToNotebook/addToNotebook.ts
@@ -1,0 +1,57 @@
+import { rangeUtil, type RawTimeRange } from '@grafana/data';
+import { type NotebookElement } from '@grafana/schema/apis/notebook/v2beta1';
+
+import { createNotebook, fetchNotebook, saveNotebook } from '../api/notebookAPI';
+import { broadcastNotebookDoc } from '../collab/useNotebookCollab';
+import { insertElement, newNotebookSpec, type CellSource } from '../model/notebookSpec';
+
+export type AddToNotebookTarget = { type: 'new'; title: string } | { type: 'existing'; uid: string };
+
+export interface AddToNotebookResult {
+  uid: string;
+  title: string;
+  /** Name of the newly added element — used to scroll it into view when opening the notebook. */
+  elementName: string;
+}
+
+/**
+ * Adds an element (typically a panel captured from a dashboard or Explore) to a
+ * notebook. For a new notebook the source time range becomes the notebook's time
+ * range; when adding to an existing notebook the panel follows the notebook's
+ * global time range (the private-preview default). With `lockTimeRange`, the
+ * panel is instead pinned to the absolute time window it was captured in.
+ */
+export async function addElementToNotebook(
+  target: AddToNotebookTarget,
+  element: NotebookElement,
+  options?: { timeRange?: RawTimeRange; source?: CellSource; lockTimeRange?: boolean }
+): Promise<AddToNotebookResult> {
+  // Lock resolves the range to absolute timestamps: "the window I was looking at",
+  // not "the last 6 hours from whenever the notebook is opened".
+  const timeOverride = options?.lockTimeRange && options.timeRange ? resolveToAbsolute(options.timeRange) : undefined;
+
+  if (target.type === 'new') {
+    const from = options?.timeRange ? rawToString(options.timeRange.from) : undefined;
+    const to = options?.timeRange ? rawToString(options.timeRange.to) : undefined;
+    const base = newNotebookSpec(target.title, { from, to });
+    const { spec, elementName } = insertElement(base, element, { source: options?.source, timeOverride });
+    const created = await createNotebook(spec);
+    return { uid: created.metadata.name, title: created.spec.title, elementName };
+  }
+
+  const notebook = await fetchNotebook(target.uid);
+  const { spec, elementName } = insertElement(notebook.spec, element, { source: options?.source, timeOverride });
+  const saved = await saveNotebook({ ...notebook, spec });
+  // Any editor with this notebook open shows the new block immediately.
+  broadcastNotebookDoc(saved.metadata.name, saved.spec);
+  return { uid: saved.metadata.name, title: saved.spec.title, elementName };
+}
+
+function resolveToAbsolute(raw: RawTimeRange): { from: string; to: string } {
+  const range = rangeUtil.convertRawToRange(raw);
+  return { from: range.from.toISOString(), to: range.to.toISOString() };
+}
+
+function rawToString(value: RawTimeRange['from']): string {
+  return typeof value === 'string' ? value : value.toISOString();
+}

--- a/public/app/features/notebook/addToNotebook/legacyPanelToNotebookPanel.test.ts
+++ b/public/app/features/notebook/addToNotebook/legacyPanelToNotebookPanel.test.ts
@@ -1,0 +1,42 @@
+import { legacyPanelToNotebookPanel } from './legacyPanelToNotebookPanel';
+
+describe('legacyPanelToNotebookPanel', () => {
+  it('converts targets, datasource and viz type to the notebook panel shape', () => {
+    const panel = {
+      type: 'timeseries',
+      title: 'Explore result',
+      datasource: { type: 'prometheus', uid: 'prom-1' },
+      targets: [
+        { refId: 'A', expr: 'up' },
+        { refId: 'B', expr: 'rate(http_requests_total[5m])', hide: true },
+      ],
+      gridPos: { x: 0, y: 0, w: 12, h: 8 },
+    };
+
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- test fixture matching the loose legacy panel shape
+    const result = legacyPanelToNotebookPanel(panel as never, { subtitle: 'From Explore' });
+
+    expect(result.kind).toBe('Panel');
+    expect(result.spec.title).toBe('Explore result');
+    expect(result.spec.subtitle).toBe('From Explore');
+    expect(result.spec.vizConfig.group).toBe('timeseries');
+
+    const queries = result.spec.data.spec.queries;
+    expect(queries).toHaveLength(2);
+    expect(queries[0].spec.refId).toBe('A');
+    expect(queries[0].spec.hidden).toBe(false);
+    expect(queries[0].spec.query.group).toBe('prometheus');
+    expect(queries[0].spec.query.datasource?.name).toBe('prom-1');
+    expect(queries[0].spec.query.spec.expr).toBe('up');
+    expect(queries[1].spec.hidden).toBe(true);
+  });
+
+  it('falls back to empty defaults for minimal panels', () => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- test fixture matching the loose legacy panel shape
+    const result = legacyPanelToNotebookPanel({ type: 'table' } as never);
+
+    expect(result.spec.title).toBe('');
+    expect(result.spec.data.spec.queries).toHaveLength(0);
+    expect(result.spec.vizConfig.spec.fieldConfig).toEqual({ defaults: {}, overrides: [] });
+  });
+});

--- a/public/app/features/notebook/addToNotebook/legacyPanelToNotebookPanel.ts
+++ b/public/app/features/notebook/addToNotebook/legacyPanelToNotebookPanel.ts
@@ -1,0 +1,55 @@
+import { type DataQuery, type Panel } from '@grafana/schema';
+import { type PanelKind, type PanelQueryKind, type TransformationKind } from '@grafana/schema/apis/notebook/v2beta1';
+import { getPanelQueries } from 'app/features/dashboard/api/ResponseTransformers';
+
+/**
+ * Converts a legacy (v1) panel model — as produced by Explore's
+ * buildDashboardPanelFromExploreState — into a notebook panel element (v2 shape).
+ */
+export function legacyPanelToNotebookPanel(panel: Panel, options?: { title?: string; subtitle?: string }): PanelKind {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- legacy Panel.targets is loosely typed
+  const targets = (panel.targets ?? []) as unknown as DataQuery[];
+  const datasource = panel.datasource ?? {};
+
+  // getPanelQueries produces the dashboard-schema PanelQueryKind; the notebook
+  // schema generates the identical shape in a sibling module.
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- identical leaf type across the two schemas
+  const queries = (getPanelQueries(targets, datasource) ?? []) as unknown as PanelQueryKind[];
+
+  const transformations: TransformationKind[] = (panel.transformations ?? []).map((transformation) => ({
+    kind: transformation.id,
+    spec: transformation,
+  }));
+
+  return {
+    kind: 'Panel',
+    spec: {
+      // Reassigned to a unique id when inserted into a notebook.
+      id: 0,
+      title: options?.title ?? panel.title ?? '',
+      subtitle: options?.subtitle,
+      links: [],
+      data: {
+        kind: 'QueryGroup',
+        spec: {
+          queries,
+          transformations,
+          queryOptions: {},
+        },
+      },
+      vizConfig: {
+        kind: 'VizConfig',
+        group: panel.type,
+        version: '',
+        spec: {
+          options: panel.options ?? {},
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- identical field config shape across schema versions
+          fieldConfig: (panel.fieldConfig ?? {
+            defaults: {},
+            overrides: [],
+          }) as PanelKind['spec']['vizConfig']['spec']['fieldConfig'],
+        },
+      },
+    },
+  };
+}

--- a/public/app/features/notebook/addToNotebook/quickAddToLastNotebook.test.ts
+++ b/public/app/features/notebook/addToNotebook/quickAddToLastNotebook.test.ts
@@ -1,0 +1,52 @@
+import { type NotebookElement } from '@grafana/schema/apis/notebook/v2beta1';
+
+import { addElementToNotebook } from './addToNotebook';
+import { quickAddToLastNotebook } from './quickAddToLastNotebook';
+
+jest.mock('./addToNotebook', () => ({
+  addElementToNotebook: jest.fn(),
+}));
+
+jest.mock('../model/lastUsedNotebook', () => ({
+  getLastUsedNotebook: jest.fn(() => ({ uid: 'nb-1', title: 'Spike notes' })),
+  clearLastUsedNotebook: jest.fn(),
+}));
+
+jest.mock('app/core/app_events', () => ({
+  appEvents: { emit: jest.fn() },
+}));
+
+const addElementToNotebookMock = jest.mocked(addElementToNotebook);
+
+describe('quickAddToLastNotebook', () => {
+  const element = { kind: 'Panel', spec: { title: 'p' } } as unknown as NotebookElement;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    addElementToNotebookMock.mockResolvedValue({ uid: 'nb-1', title: 'Spike notes', elementName: 'el-1' });
+  });
+
+  it('locks the time range when the source range is absolute (e.g. after zoom)', async () => {
+    await quickAddToLastNotebook(element, {
+      timeRange: { from: '2026-08-01T00:00:00.000Z', to: '2026-08-01T01:00:00.000Z' },
+    });
+
+    expect(addElementToNotebookMock).toHaveBeenCalledWith(
+      { type: 'existing', uid: 'nb-1' },
+      element,
+      expect.objectContaining({ lockTimeRange: true })
+    );
+  });
+
+  it('does not lock relative time ranges', async () => {
+    await quickAddToLastNotebook(element, {
+      timeRange: { from: 'now-1h', to: 'now' },
+    });
+
+    expect(addElementToNotebookMock).toHaveBeenCalledWith(
+      { type: 'existing', uid: 'nb-1' },
+      element,
+      expect.objectContaining({ lockTimeRange: false })
+    );
+  });
+});

--- a/public/app/features/notebook/addToNotebook/quickAddToLastNotebook.ts
+++ b/public/app/features/notebook/addToNotebook/quickAddToLastNotebook.ts
@@ -1,0 +1,43 @@
+import { AppEvents, rangeUtil, type RawTimeRange } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { type NotebookElement } from '@grafana/schema/apis/notebook/v2beta1';
+import { appEvents } from 'app/core/app_events';
+
+import { clearLastUsedNotebook, getLastUsedNotebook } from '../model/lastUsedNotebook';
+
+import { addElementToNotebook } from './addToNotebook';
+
+/**
+ * One-click "Add to last notebook": appends the element to the most recently used
+ * notebook without going through the picker modal. Returns false when there is no
+ * usable last notebook (callers should fall back to the full add-to-notebook flow).
+ *
+ * Absolute source ranges (e.g. after a panel zoom) are locked onto the block so
+ * the quick path matches the multi-step form's default.
+ */
+export async function quickAddToLastNotebook(
+  element: NotebookElement,
+  options?: { timeRange?: RawTimeRange }
+): Promise<boolean> {
+  const lastUsed = getLastUsedNotebook();
+  if (!lastUsed) {
+    return false;
+  }
+
+  const lockTimeRange = Boolean(options?.timeRange && !rangeUtil.isRelativeTimeRange(options.timeRange));
+
+  try {
+    const result = await addElementToNotebook({ type: 'existing', uid: lastUsed.uid }, element, {
+      timeRange: options?.timeRange,
+      source: 'user',
+      lockTimeRange,
+    });
+    appEvents.emit(AppEvents.alertSuccess, [t('notebooks.quick-add.added', 'Added to notebook'), result.title]);
+    return true;
+  } catch (error) {
+    // Most likely the notebook was deleted; forget it and let the caller fall
+    // back to the picker.
+    clearLastUsedNotebook();
+    return false;
+  }
+}

--- a/public/app/features/notebook/collab/useNotebookCollab.ts
+++ b/public/app/features/notebook/collab/useNotebookCollab.ts
@@ -71,6 +71,31 @@ export function resourceVersionTs(resource?: Resource<NotebookSpec>): number | u
   return Number.isNaN(parsed) ? undefined : parsed;
 }
 
+/**
+ * One-shot document broadcast for flows that save over HTTP outside an editor
+ * session (add-to-notebook from dashboards/Explore) — open editors of the same
+ * notebook apply the fresh document immediately instead of waiting for a reload.
+ */
+export function broadcastNotebookDoc(uid: string, spec: NotebookSpec) {
+  const message: CollabMessage = {
+    t: 'doc',
+    sid: `oneshot-${generateUUID()}`,
+    ts: Date.now(),
+    user: {
+      login: contextSrv.user.login,
+      name: contextSrv.user.name || contextSrv.user.login,
+      avatarUrl: contextSrv.user.gravatarUrl,
+    },
+    spec,
+    transient: true,
+  };
+  getGrafanaLiveSrv()
+    .publish({ scope: LiveChannelScope.Grafana, stream: 'notebook', path: `uid/${uid}` }, message)
+    .catch(() => {
+      // Best-effort: open editors fall back to seeing the change on reload.
+    });
+}
+
 function colorForSession(sid: string): string {
   let hash = 0;
   for (let i = 0; i < sid.length; i++) {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12711,6 +12711,33 @@
       "viz-cancel": "Cancel",
       "viz-hint": "Tip: any dashboard panel or Explore query can also be added via “Add to notebook”."
     },
+    "add-form": {
+      "add": "Add",
+      "add-open": "Add & open notebook",
+      "added": "Added to notebook",
+      "cancel": "Cancel",
+      "default-title": "Investigation — {{date}}",
+      "error-title": "Could not add to notebook",
+      "existing": "Existing notebook",
+      "failed": "Failed to add to notebook",
+      "lock-time": "Lock this panel to the current time window",
+      "lock-time-description": "{{from}} → {{to}}",
+      "new": "New notebook",
+      "none-yet": "No notebooks yet",
+      "notebook-label": "Notebook",
+      "notebook-placeholder": "Choose a notebook",
+      "select-required": "Select a notebook to add to.",
+      "source": "Adding a live panel from {{sourceName}}.",
+      "target-label": "Target notebook",
+      "title-label": "Notebook name"
+    },
+    "add-from-panel": {
+      "origin": "From dashboard: {{title}}",
+      "unnamed-dashboard": "this dashboard"
+    },
+    "add-modal": {
+      "title": "Add to notebook"
+    },
     "cell": {
       "assistant-badge": "Assistant",
       "delete": "Delete block",
@@ -12824,6 +12851,9 @@
       "query-picker": "Query to edit",
       "run": "Run query",
       "run-tooltip": "Ctrl/Cmd + Enter to run"
+    },
+    "quick-add": {
+      "added": "Added to notebook"
     },
     "viz-suggestions": {
       "no-data": "No data yet — suggestions appear once the panel has results.",
@@ -12994,6 +13024,8 @@
       }
     },
     "header-menu": {
+      "add-to-last-notebook": "Add to \"{{title}}\"",
+      "add-to-notebook": "Add to notebook",
       "copy": "Copy",
       "copy-styles": "Copy styles",
       "download-diagnostics": "Download diagnostics",


### PR DESCRIPTION
## What this adds

- Defines the shared add-to-notebook workflow and modal.
- Adds dashboard panel capture and conversion into notebook cells.
- Supports quick capture into the most recently used notebook.
- Broadcasts capture updates to active notebook sessions.
- Adds focused conversion and capture tests.

## Why

This layer establishes the reusable capture contract and the first product integration together, avoiding a tiny abstraction-only PR while keeping dashboard-specific review focused.

## Stack

Layer 5 of 8. Depends on the collaboration POC so capture changes can update already-open notebooks.

## Validation

Review follow-up validation passed: focused notebook, route, and dashboard suites (18 suites, 140 tests), `yarn typecheck`, the production frontend build, and the React 19 frontend build.

## Dogfooding

Use the [original combined POC environment](https://ephemeral15111821129904nmarrs.grafana-dev.net/notebooks) for the clearest end-to-end demo.

[Open this PR's ephemeral notebook instance](https://ephemeral15111821129974nmarrs.grafana-dev.net/notebooks) to smoke-test the cumulative branch containing backend, core notebooks, collaboration, and dashboard capture. This environment is primarily useful for verifying Grafana starts cleanly and the changes through this layer do not introduce runtime regressions.