### PR TITLE
Notebooks: Add Explore capture integration

### DIFF
--- a/public/app/features/explore/extensions/ToolbarExtensionPoint.tsx
+++ b/public/app/features/explore/extensions/ToolbarExtensionPoint.tsx
@@ -42,7 +42,9 @@ export function ToolbarExtensionPoint(props: Props): ReactElement | null {
   const { links } = usePluginLinks({
     extensionPointId: PluginExtensionPoints.ExploreToolbarAction,
     context: context,
-    limitPerPlugin: 3,
+    // Core ('grafana') registers four links here: add to dashboard, add correlation,
+    // add to notebook and add to "<named>" notebook.
+    limitPerPlugin: 4,
   });
   const selectExploreItem = getExploreItemSelector(exploreId);
   const noQueriesInPane = Boolean(useSelector(selectExploreItem)?.queries?.length);

--- a/public/app/features/notebook/addToNotebook/ExploreAddToNotebook.tsx
+++ b/public/app/features/notebook/addToNotebook/ExploreAddToNotebook.tsx
@@ -1,0 +1,48 @@
+import { t } from '@grafana/i18n';
+import { buildDashboardPanelFromExploreState } from 'app/features/explore/extensions/AddToDashboard/addToDashboard';
+import { getExploreItemSelector } from 'app/features/explore/state/selectors';
+import { useSelector } from 'app/types/store';
+
+import { AddToNotebookForm } from './AddToNotebookForm';
+import { legacyPanelToNotebookPanel } from './legacyPanelToNotebookPanel';
+
+interface Props {
+  exploreId: string;
+  onClose: () => void;
+}
+
+/**
+ * Explore toolbar → "Add to notebook": reuses the add-to-dashboard panel builder
+ * (queries + datasource + panel type inferred from the response frames) and
+ * converts the result into a notebook panel element.
+ */
+export function ExploreAddToNotebook({ exploreId, onClose }: Props) {
+  const exploreItem = useSelector(getExploreItemSelector(exploreId));
+
+  if (!exploreItem) {
+    return null;
+  }
+
+  const legacyPanel = buildDashboardPanelFromExploreState({
+    datasource: exploreItem.datasourceInstance?.getRef(),
+    queries: exploreItem.queries,
+    queryResponse: exploreItem.queryResponse,
+    panelState: exploreItem.panelsState,
+  });
+
+  const element = legacyPanelToNotebookPanel(legacyPanel, {
+    title: t('notebooks.add-from-explore.panel-title', 'Explore query'),
+    subtitle: t('notebooks.add-from-explore.origin', 'From Explore ({{datasource}})', {
+      datasource: exploreItem.datasourceInstance?.name ?? '',
+    }),
+  });
+
+  return (
+    <AddToNotebookForm
+      element={element}
+      sourceName={t('notebooks.add-from-explore.source', 'Explore')}
+      timeRange={exploreItem.range.raw}
+      onDismiss={onClose}
+    />
+  );
+}

--- a/public/app/features/notebook/addToNotebook/quickAddFromExplore.test.ts
+++ b/public/app/features/notebook/addToNotebook/quickAddFromExplore.test.ts
@@ -1,0 +1,76 @@
+import { buildDashboardPanelFromExploreState } from 'app/features/explore/extensions/AddToDashboard/addToDashboard';
+import { getExploreItemSelector } from 'app/features/explore/state/selectors';
+import { getState } from 'app/store/store';
+
+import { legacyPanelToNotebookPanel } from './legacyPanelToNotebookPanel';
+import { quickAddExploreToLastNotebook } from './quickAddFromExplore';
+import { quickAddToLastNotebook } from './quickAddToLastNotebook';
+
+jest.mock('app/features/explore/extensions/AddToDashboard/addToDashboard', () => ({
+  buildDashboardPanelFromExploreState: jest.fn(),
+}));
+jest.mock('app/features/explore/state/selectors', () => ({
+  getExploreItemSelector: jest.fn(),
+}));
+jest.mock('app/store/store', () => ({
+  getState: jest.fn(),
+}));
+jest.mock('./legacyPanelToNotebookPanel', () => ({
+  legacyPanelToNotebookPanel: jest.fn(),
+}));
+jest.mock('./quickAddToLastNotebook', () => ({
+  quickAddToLastNotebook: jest.fn(),
+}));
+
+const buildPanelMock = jest.mocked(buildDashboardPanelFromExploreState);
+const getExploreItemSelectorMock = jest.mocked(getExploreItemSelector);
+const getStateMock = jest.mocked(getState);
+const legacyPanelToNotebookPanelMock = jest.mocked(legacyPanelToNotebookPanel);
+const quickAddToLastNotebookMock = jest.mocked(quickAddToLastNotebook);
+const selectExploreItem = jest.fn();
+
+describe('quickAddExploreToLastNotebook', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getExploreItemSelectorMock.mockReturnValue(selectExploreItem as never);
+    getStateMock.mockReturnValue({} as never);
+  });
+
+  it('returns false when the Explore pane is missing', async () => {
+    selectExploreItem.mockReturnValue(undefined);
+
+    await expect(quickAddExploreToLastNotebook('left')).resolves.toBe(false);
+    expect(buildPanelMock).not.toHaveBeenCalled();
+    expect(quickAddToLastNotebookMock).not.toHaveBeenCalled();
+  });
+
+  it('converts the Explore panel and preserves its raw time range', async () => {
+    const rawTimeRange = { from: 'now-2h', to: 'now' };
+    const exploreItem = {
+      datasourceInstance: { name: 'Prometheus', getRef: () => ({ uid: 'prometheus' }) },
+      queries: [{ refId: 'A' }],
+      queryResponse: { series: [] },
+      panelsState: { trace: null },
+      range: { raw: rawTimeRange },
+    };
+    const legacyPanel = { title: 'Explore query' };
+    const notebookPanel = { kind: 'Panel', spec: { title: 'Explore query' } };
+    selectExploreItem.mockReturnValue(exploreItem);
+    buildPanelMock.mockReturnValue(legacyPanel as never);
+    legacyPanelToNotebookPanelMock.mockReturnValue(notebookPanel as never);
+    quickAddToLastNotebookMock.mockResolvedValue(true);
+
+    await expect(quickAddExploreToLastNotebook('left')).resolves.toBe(true);
+    expect(buildPanelMock).toHaveBeenCalledWith({
+      datasource: { uid: 'prometheus' },
+      queries: exploreItem.queries,
+      queryResponse: exploreItem.queryResponse,
+      panelState: exploreItem.panelsState,
+    });
+    expect(legacyPanelToNotebookPanelMock).toHaveBeenCalledWith(
+      legacyPanel,
+      expect.objectContaining({ title: 'Explore query', subtitle: 'From Explore (Prometheus)' })
+    );
+    expect(quickAddToLastNotebookMock).toHaveBeenCalledWith(notebookPanel, { timeRange: rawTimeRange });
+  });
+});

--- a/public/app/features/notebook/addToNotebook/quickAddFromExplore.ts
+++ b/public/app/features/notebook/addToNotebook/quickAddFromExplore.ts
@@ -1,0 +1,35 @@
+import { t } from '@grafana/i18n';
+import { buildDashboardPanelFromExploreState } from 'app/features/explore/extensions/AddToDashboard/addToDashboard';
+import { getExploreItemSelector } from 'app/features/explore/state/selectors';
+import { getState } from 'app/store/store';
+
+import { legacyPanelToNotebookPanel } from './legacyPanelToNotebookPanel';
+import { quickAddToLastNotebook } from './quickAddToLastNotebook';
+
+/**
+ * Explore toolbar → "Add to last notebook": captures the current query/visualization
+ * (same panel builder as the modal flow) and appends it to the most recently used
+ * notebook in one click. Returns false when there is no last notebook to add to.
+ */
+export async function quickAddExploreToLastNotebook(exploreId: string): Promise<boolean> {
+  const exploreItem = getExploreItemSelector(exploreId)(getState());
+  if (!exploreItem) {
+    return false;
+  }
+
+  const legacyPanel = buildDashboardPanelFromExploreState({
+    datasource: exploreItem.datasourceInstance?.getRef(),
+    queries: exploreItem.queries,
+    queryResponse: exploreItem.queryResponse,
+    panelState: exploreItem.panelsState,
+  });
+
+  const element = legacyPanelToNotebookPanel(legacyPanel, {
+    title: t('notebooks.add-from-explore.panel-title', 'Explore query'),
+    subtitle: t('notebooks.add-from-explore.origin', 'From Explore ({{datasource}})', {
+      datasource: exploreItem.datasourceInstance?.name ?? '',
+    }),
+  });
+
+  return quickAddToLastNotebook(element, { timeRange: exploreItem.range.raw });
+}

--- a/public/app/features/notebook/extensions/getNotebookExtensionConfigs.test.tsx
+++ b/public/app/features/notebook/extensions/getNotebookExtensionConfigs.test.tsx
@@ -1,0 +1,60 @@
+import { getFeatureFlagClient } from '@grafana/runtime/internal';
+import { contextSrv } from 'app/core/services/context_srv';
+
+import { getLastUsedNotebook } from '../model/lastUsedNotebook';
+
+import { getNotebookExtensionConfigs } from './getNotebookExtensionConfigs';
+
+jest.mock('@grafana/runtime/internal', () => ({
+  ...jest.requireActual('@grafana/runtime/internal'),
+  getFeatureFlagClient: jest.fn(),
+}));
+jest.mock('app/core/services/context_srv');
+jest.mock('../model/lastUsedNotebook', () => ({
+  getLastUsedNotebook: jest.fn(),
+}));
+
+const getFeatureFlagClientMock = jest.mocked(getFeatureFlagClient);
+const contextSrvMock = jest.mocked(contextSrv);
+const getLastUsedNotebookMock = jest.mocked(getLastUsedNotebook);
+const getBooleanValue = jest.fn();
+
+describe('getNotebookExtensionConfigs', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getFeatureFlagClientMock.mockReturnValue({ getBooleanValue } as never);
+    getBooleanValue.mockReturnValue(true);
+    contextSrvMock.hasPermission.mockReturnValue(true);
+    getLastUsedNotebookMock.mockReturnValue({ uid: 'nb-1', title: 'Investigation notes', at: 1 });
+  });
+
+  it('hides Explore capture actions when notebooks are disabled', () => {
+    getBooleanValue.mockReturnValue(false);
+
+    expect(configure('Add to notebook')).toBeUndefined();
+    expect(configure('Add to last notebook')).toBeUndefined();
+  });
+
+  it('hides Explore capture actions without notebook write permissions', () => {
+    contextSrvMock.hasPermission.mockReturnValue(false);
+
+    expect(configure('Add to notebook')).toBeUndefined();
+    expect(configure('Add to last notebook')).toBeUndefined();
+  });
+
+  it('only exposes quick capture when a last-used notebook exists', () => {
+    expect(configure('Add to notebook')).toEqual({});
+    expect(configure('Add to last notebook')).toEqual(
+      expect.objectContaining({ title: 'Add to "Investigation notes"' })
+    );
+
+    getLastUsedNotebookMock.mockReturnValue(undefined);
+    expect(configure('Add to last notebook')).toBeUndefined();
+  });
+});
+
+function configure(title: string) {
+  const extension = getNotebookExtensionConfigs().find((config) => config.title === title);
+  expect(extension).toBeDefined();
+  return extension?.configure?.(undefined);
+}

--- a/public/app/features/notebook/extensions/getNotebookExtensionConfigs.tsx
+++ b/public/app/features/notebook/extensions/getNotebookExtensionConfigs.tsx
@@ -1,0 +1,88 @@
+/* eslint-disable @grafana/i18n/no-untranslated-strings -- extension configs are registered at bootstrap, before i18n is ready (same as getExploreExtensionConfigs) */
+import { type PluginExtensionAddedLinkConfig, PluginExtensionPoints } from '@grafana/data';
+import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
+import { contextSrv } from 'app/core/services/context_srv';
+import { createAddedLinkConfig } from 'app/features/plugins/extensions/utils';
+import { AccessControlAction } from 'app/types/accessControl';
+
+import { type PluginExtensionExploreContext } from '../../explore/extensions/ToolbarExtensionPoint';
+import { getLastUsedNotebook } from '../model/lastUsedNotebook';
+
+function notebooksEnabled(): boolean {
+  return getFeatureFlagClient().getBooleanValue(FlagKeys.DashboardNotebooks, false);
+}
+
+function canEditNotebooks(): boolean {
+  return (
+    contextSrv.hasPermission(AccessControlAction.DashboardsCreate) ||
+    contextSrv.hasPermission(AccessControlAction.DashboardsWrite)
+  );
+}
+
+export function getNotebookExtensionConfigs(): PluginExtensionAddedLinkConfig[] {
+  try {
+    return [
+      // Explore toolbar → "Add to notebook" (sibling of the core "Add to dashboard" action).
+      createAddedLinkConfig<PluginExtensionExploreContext>({
+        title: 'Add to notebook',
+        description: 'Capture the current query and visualization as a live panel in a notebook',
+        targets: [PluginExtensionPoints.ExploreToolbarAction],
+        icon: 'book-open',
+        category: 'Notebooks',
+        configure: () => {
+          if (!notebooksEnabled() || !canEditNotebooks()) {
+            return undefined;
+          }
+          return {};
+        },
+        onClick: async (_, { context, openModal }) => {
+          if (!context?.exploreId) {
+            return;
+          }
+          const { ExploreAddToNotebook } = await import('app/features/notebook/addToNotebook/ExploreAddToNotebook');
+          openModal({
+            title: 'Add to notebook',
+            body: ({ onDismiss }) => <ExploreAddToNotebook exploreId={context.exploreId} onClose={onDismiss!} />,
+          });
+        },
+      }),
+
+      // Explore toolbar → one-click append to the most recently used notebook.
+      // Title is overridden in configure to match the dashboard panel menu:
+      // `Add to "<notebook name>"` (truncated).
+      createAddedLinkConfig<PluginExtensionExploreContext>({
+        title: 'Add to last notebook',
+        description: 'Append the current query to your most recent notebook without any dialogs',
+        targets: [PluginExtensionPoints.ExploreToolbarAction],
+        icon: 'bolt',
+        category: 'Notebooks',
+        configure: () => {
+          if (!notebooksEnabled() || !canEditNotebooks()) {
+            return undefined;
+          }
+          const lastUsed = getLastUsedNotebook();
+          if (!lastUsed) {
+            return undefined;
+          }
+          const shortTitle = lastUsed.title.length > 25 ? `${lastUsed.title.slice(0, 25)}…` : lastUsed.title;
+          return {
+            title: `Add to "${shortTitle}"`,
+            description: `Append the current query to "${lastUsed.title}"`,
+          };
+        },
+        onClick: async (_, { context }) => {
+          if (!context?.exploreId) {
+            return;
+          }
+          const { quickAddExploreToLastNotebook } = await import(
+            'app/features/notebook/addToNotebook/quickAddFromExplore'
+          );
+          await quickAddExploreToLastNotebook(context.exploreId);
+        },
+      }),
+    ];
+  } catch (error) {
+    console.warn('Could not configure notebook extensions', error);
+    return [];
+  }
+}

--- a/public/app/features/plugins/extensions/getCoreExtensionConfigurations.ts
+++ b/public/app/features/plugins/extensions/getCoreExtensionConfigurations.ts
@@ -1,6 +1,7 @@
 import { type PluginExtensionAddedLinkConfig } from '@grafana/data';
 import { getExploreExtensionConfigs } from 'app/features/explore/extensions/getExploreExtensionConfigs';
+import { getNotebookExtensionConfigs } from 'app/features/notebook/extensions/getNotebookExtensionConfigs';
 
 export function getCoreExtensionConfigurations(): PluginExtensionAddedLinkConfig[] {
-  return [...getExploreExtensionConfigs()];
+  return [...getExploreExtensionConfigs(), ...getNotebookExtensionConfigs()];
 }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12731,6 +12731,11 @@
       "target-label": "Target notebook",
       "title-label": "Notebook name"
     },
+    "add-from-explore": {
+      "origin": "From Explore ({{datasource}})",
+      "panel-title": "Explore query",
+      "source": "Explore"
+    },
     "add-from-panel": {
       "origin": "From dashboard: {{title}}",
       "unnamed-dashboard": "this dashboard"


### PR DESCRIPTION
## What this adds

- Adds notebook capture actions to Explore.
- Converts current Explore queries and context into notebook cells.
- Supports quick capture into the most recently used notebook.
- Registers the Explore notebook extension configuration.

## Why

Explore is an independent extension point over the shared capture workflow, so it can be reviewed and tested separately from dashboard capture.

## Stack

Layer 6 of 8. Builds on the shared capture workflow and dashboard integration.

## Validation

Review follow-up validation passed: focused notebook, route, and dashboard suites (18 suites, 140 tests), `yarn typecheck`, the production frontend build, and the React 19 frontend build.

## Dogfooding

Use the [original combined POC environment](https://ephemeral15111821129904nmarrs.grafana-dev.net/notebooks) for the clearest end-to-end demo.

[Open this PR's ephemeral notebook instance](https://ephemeral15111821129975nmarrs.grafana-dev.net/notebooks) to smoke-test the cumulative branch containing backend, core notebooks, collaboration, dashboard capture, and Explore capture. This environment is primarily useful for verifying Grafana starts cleanly and the changes through this layer do not introduce runtime regressions.