### PR TITLE
Notebooks: Add sidebar and command palette integrations

### DIFF
--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -17,6 +17,7 @@ const (
 	WeightDashboard
 	WeightExplore
 	WeightDrilldown
+	WeightNotebooks
 	WeightAssistant
 	WeightSigil
 	WeightAlerting
@@ -43,6 +44,7 @@ const (
 	NavIDDashboards           = "dashboards/browse"
 	NavIDExplore              = "explore"
 	NavIDDrilldown            = "drilldown"
+	NavIDNotebooks            = "notebooks"
 	NavIDAdaptiveTelemetry    = "adaptive-telemetry"
 	NavIDCfg                  = "cfg" // NavIDCfg is the id for org configuration navigation node
 	NavIDAlertsAndIncidents   = "alerts-and-incidents"

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -1,6 +1,7 @@
 package navtreeimpl
 
 import (
+	"github.com/open-feature/go-sdk/openfeature"
 	"go.opentelemetry.io/otel"
 
 	"github.com/grafana/grafana/pkg/api/dtos"
@@ -147,7 +148,12 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 		})
 	}
 
-	if c.IsSignedIn && s.features.IsEnabled(c.Req.Context(), featuremgmt.FlagDashboardNotebooks) {
+	if c.IsSignedIn && openfeature.NewDefaultClient().Boolean(
+		c.Req.Context(),
+		featuremgmt.FlagDashboardNotebooks,
+		false,
+		openfeature.TransactionContext(c.Req.Context()),
+	) {
 		treeRoot.AddSection(&navtree.NavLink{
 			Text:       "Notebooks",
 			Id:         navtree.NavIDNotebooks,

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -147,6 +147,17 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 		})
 	}
 
+	if c.IsSignedIn && s.features.IsEnabled(c.Req.Context(), featuremgmt.FlagDashboardNotebooks) {
+		treeRoot.AddSection(&navtree.NavLink{
+			Text:       "Notebooks",
+			Id:         navtree.NavIDNotebooks,
+			SubTitle:   "Capture investigations with narrative text and live visualizations",
+			Icon:       "book",
+			SortWeight: navtree.WeightNotebooks,
+			Url:        s.cfg.AppSubURL + "/notebooks",
+		})
+	}
+
 	if s.cfg.ProfileEnabled && c.IsSignedIn {
 		treeRoot.AddSection(s.getProfileNode(c))
 	}

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.test.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.test.tsx
@@ -10,7 +10,6 @@ import {
   useExtensionSidebarContext,
   getComponentIdFromComponentMeta,
   getComponentMetaFromComponentId,
-  getInteractiveLearningPluginId,
   EXTENSION_SIDEBAR_DOCKED_LOCAL_STORAGE_KEY,
 } from './ExtensionSidebarProvider';
 
@@ -140,21 +139,6 @@ describe('ExtensionSidebarProvider', () => {
 
     expect(screen.getByTestId('is-open')).toHaveTextContent('true');
     expect(screen.getByTestId('docked-component-id')).toHaveTextContent(componentId);
-  });
-
-  it('should clear a docked component that is no longer available', () => {
-    // A component of a permitted plugin that is not among its added components anymore.
-    const componentId = getComponentIdFromComponentMeta(mockPluginMeta.pluginId, 'Removed Component');
-    (store.get as jest.Mock).mockReturnValue(componentId);
-
-    render(
-      <ExtensionSidebarContextProvider>
-        <TestComponent />
-      </ExtensionSidebarContextProvider>
-    );
-
-    expect(screen.getByTestId('is-open')).toHaveTextContent('false');
-    expect(screen.getByTestId('docked-component-id')).toHaveTextContent('undefined');
   });
 
   it('should update storage when docked component changes', () => {
@@ -670,27 +654,6 @@ describe('Utility Functions', () => {
     it('should return undefined for wrong field types', () => {
       const meta = getComponentMetaFromComponentId(JSON.stringify({ pluginId: 123, componentTitle: 'Test Component' }));
       expect(meta).toBeUndefined();
-    });
-  });
-
-  describe('getInteractiveLearningPluginId', () => {
-    const emptyMeta = { addedComponents: [], addedLinks: [] };
-
-    it('prefers the pathfinder plugin when both learning plugins are available', () => {
-      const components = new Map([
-        ['grafana-pathfinder-app', emptyMeta],
-        ['grafana-grafanadocsplugin-app', emptyMeta],
-      ]);
-      expect(getInteractiveLearningPluginId(components)).toBe('grafana-pathfinder-app');
-    });
-
-    it('falls back to the docs plugin when pathfinder is not available', () => {
-      const components = new Map([['grafana-grafanadocsplugin-app', emptyMeta]]);
-      expect(getInteractiveLearningPluginId(components)).toBe('grafana-grafanadocsplugin-app');
-    });
-
-    it('returns undefined when no learning plugin is available', () => {
-      expect(getInteractiveLearningPluginId(new Map())).toBeUndefined();
     });
   });
 });

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.test.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, act } from '@testing-library/react';
 import { useAsync } from 'react-use';
 
 import { store, EventBusSrv, type EventBus, type ExtensionInfo } from '@grafana/data';
-import { getAppEvents, setAppEvents, locationService } from '@grafana/runtime';
+import { getAppEvents, setAppEvents, locationService, usePluginLinks } from '@grafana/runtime';
 import { OpenExtensionSidebarEvent, CloseExtensionSidebarEvent, ToggleExtensionSidebarEvent } from 'app/types/events';
 
 import {
@@ -10,6 +10,7 @@ import {
   useExtensionSidebarContext,
   getComponentIdFromComponentMeta,
   getComponentMetaFromComponentId,
+  getInteractiveLearningPluginId,
   EXTENSION_SIDEBAR_DOCKED_LOCAL_STORAGE_KEY,
 } from './ExtensionSidebarProvider';
 
@@ -141,6 +142,21 @@ describe('ExtensionSidebarProvider', () => {
     expect(screen.getByTestId('docked-component-id')).toHaveTextContent(componentId);
   });
 
+  it('should clear a docked component that is no longer available', () => {
+    // A component of a permitted plugin that is not among its added components anymore.
+    const componentId = getComponentIdFromComponentMeta(mockPluginMeta.pluginId, 'Removed Component');
+    (store.get as jest.Mock).mockReturnValue(componentId);
+
+    render(
+      <ExtensionSidebarContextProvider>
+        <TestComponent />
+      </ExtensionSidebarContextProvider>
+    );
+
+    expect(screen.getByTestId('is-open')).toHaveTextContent('false');
+    expect(screen.getByTestId('docked-component-id')).toHaveTextContent('undefined');
+  });
+
   it('should update storage when docked component changes', () => {
     const componentId = getComponentIdFromComponentMeta(mockPluginMeta.pluginId, mockComponent.title);
 
@@ -215,6 +231,61 @@ describe('ExtensionSidebarProvider', () => {
     // Should only include the enabled plugin
     expect(screen.getByTestId('available-components-size')).toHaveTextContent('1');
     expect(screen.getByTestId('plugin-ids')).toHaveTextContent(permittedPluginMeta.pluginId);
+  });
+
+  it('should synthesize an available component for core-registered sidebar links', () => {
+    // Core components (pluginId 'grafana') are not app plugins: they have no entry in
+    // the app plugin meta map and are derived from their registered links instead.
+    const usePluginLinksMock = jest.mocked(usePluginLinks);
+    usePluginLinksMock.mockReturnValue({
+      links: [
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- only the fields the provider reads
+        { pluginId: 'grafana', title: 'Notebooks', description: 'Core notebooks panel' } as ReturnType<
+          typeof usePluginLinks
+        >['links'][number],
+      ],
+      isLoading: false,
+    });
+    useAsyncMock.mockReturnValue({ loading: false, value: new Map() });
+
+    try {
+      render(
+        <ExtensionSidebarContextProvider>
+          <TestComponent />
+        </ExtensionSidebarContextProvider>
+      );
+
+      expect(screen.getByTestId('available-components-size')).toHaveTextContent('1');
+      expect(screen.getByTestId('plugin-ids')).toHaveTextContent('grafana');
+
+      // Opening a core-synthesized component exercises the same permission path as plugin apps.
+      act(() => {
+        const openCall = subscribeSpy.mock.calls.find((call) => call[0] === OpenExtensionSidebarEvent);
+        const [, subscriberFn] = openCall!;
+        subscriberFn(
+          new OpenExtensionSidebarEvent({
+            pluginId: 'grafana',
+            componentTitle: 'Notebooks',
+          })
+        );
+      });
+
+      expect(screen.getByTestId('is-open')).toHaveTextContent('true');
+      expect(screen.getByTestId('docked-component-id')).toHaveTextContent(
+        JSON.stringify({ pluginId: 'grafana', componentTitle: 'Notebooks' })
+      );
+    } finally {
+      // Later tests rely on the module-level default implementation.
+      usePluginLinksMock.mockImplementation(() => ({
+        links: [
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- only the fields the provider reads
+          { pluginId: mockPluginMeta.pluginId, title: mockComponent.title } as ReturnType<
+            typeof usePluginLinks
+          >['links'][number],
+        ],
+        isLoading: false,
+      }));
+    }
   });
 
   it('should subscribe to OpenExtensionSidebarEvent and CloseExtensionSidebarEvent when feature is enabled', async () => {
@@ -599,6 +670,27 @@ describe('Utility Functions', () => {
     it('should return undefined for wrong field types', () => {
       const meta = getComponentMetaFromComponentId(JSON.stringify({ pluginId: 123, componentTitle: 'Test Component' }));
       expect(meta).toBeUndefined();
+    });
+  });
+
+  describe('getInteractiveLearningPluginId', () => {
+    const emptyMeta = { addedComponents: [], addedLinks: [] };
+
+    it('prefers the pathfinder plugin when both learning plugins are available', () => {
+      const components = new Map([
+        ['grafana-pathfinder-app', emptyMeta],
+        ['grafana-grafanadocsplugin-app', emptyMeta],
+      ]);
+      expect(getInteractiveLearningPluginId(components)).toBe('grafana-pathfinder-app');
+    });
+
+    it('falls back to the docs plugin when pathfinder is not available', () => {
+      const components = new Map([['grafana-grafanadocsplugin-app', emptyMeta]]);
+      expect(getInteractiveLearningPluginId(components)).toBe('grafana-grafanadocsplugin-app');
+    });
+
+    it('returns undefined when no learning plugin is available', () => {
+      expect(getInteractiveLearningPluginId(new Map())).toBeUndefined();
     });
   });
 });

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx
@@ -16,6 +16,8 @@ import {
 export const EXTENSION_SIDEBAR_DOCKED_LOCAL_STORAGE_KEY = 'grafana.navigation.extensionSidebarDocked';
 const EXTENSION_SIDEBAR_WIDTH_LOCAL_STORAGE_KEY = 'grafana.navigation.extensionSidebarWidth';
 const PERMITTED_EXTENSION_SIDEBAR_PLUGINS = [
+  // Core-provided sidebar components (e.g. the notebooks workspace panel).
+  'grafana',
   'grafana-assistant-app',
   'grafana-assistant-onboarding-app',
   'grafana-dash-app',
@@ -114,21 +116,40 @@ export const ExtensionSidebarContextProvider = ({ children }: ExtensionSidebarCo
 
   // get all components for this extension point, but only for the permitted plugins
   // if the extension sidebar is not enabled, we will return an empty map
-  const availableComponents = useMemo(
-    () =>
-      new Map(
-        Array.from(pluginMap?.entries() || []).filter(
-          ([pluginId, pluginMeta]) =>
-            PERMITTED_EXTENSION_SIDEBAR_PLUGINS.includes(pluginId) &&
-            links.some(
-              (link) =>
-                link.pluginId === pluginId &&
-                pluginMeta.addedComponents.some((component) => component.title === link.title)
-            )
-        )
-      ),
-    [links, pluginMap]
-  );
+  const availableComponents = useMemo(() => {
+    const map = new Map(
+      Array.from(pluginMap?.entries() || []).filter(
+        ([pluginId, pluginMeta]) =>
+          PERMITTED_EXTENSION_SIDEBAR_PLUGINS.includes(pluginId) &&
+          links.some(
+            (link) =>
+              link.pluginId === pluginId &&
+              pluginMeta.addedComponents.some((component) => component.title === link.title)
+          )
+      )
+    );
+
+    // Core-registered sidebar components (pluginId 'grafana') are not app plugins, so
+    // they are absent from the app plugin meta map; synthesize their entry from the
+    // registered links (core also registers a component with the matching title).
+    const coreLinks = links.filter((link) => link.pluginId === 'grafana' && link.title);
+    if (coreLinks.length > 0) {
+      map.set('grafana', {
+        addedComponents: coreLinks.map((link) => ({
+          targets: [PluginExtensionPoints.ExtensionSidebar],
+          title: link.title,
+          description: link.description,
+        })),
+        addedLinks: coreLinks.map((link) => ({
+          targets: [PluginExtensionPoints.ExtensionSidebar],
+          title: link.title,
+          description: link.description,
+        })),
+      });
+    }
+
+    return map;
+  }, [links, pluginMap]);
 
   // check if the stored docked component is still available
   let defaultDockedComponentId: string | undefined;

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItemButton.test.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItemButton.test.tsx
@@ -51,6 +51,8 @@ describe('ExtensionToolbarItemButton', () => {
     ['grafana-grafanadocsplugin-app', 'book'],
     ['grafana-pathfinder-app', 'book'],
     ['grafana-grotfood-app', 'gf-grotfood'],
+    // Core-provided sidebar components (e.g. the notebooks workspace panel).
+    ['grafana', 'book-open'],
   ])('renders the correct icon for pluginId "%s" (%s)', (pluginId, iconName) => {
     render(<ExtensionToolbarItemButton isOpen={false} pluginId={pluginId} />);
 

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItemButton.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItemButton.tsx
@@ -19,6 +19,9 @@ function getPluginIcon(pluginId?: string): IconName {
       return 'book';
     case 'grafana-grotfood-app':
       return 'gf-grotfood';
+    // Core-provided sidebar components (currently the notebooks workspace panel).
+    case 'grafana':
+      return 'book-open';
     default:
       return 'ai-sparkle';
   }

--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -63,6 +63,8 @@ export function getNavTitle(navId: string | undefined) {
       return t('nav.explore.title', 'Explore');
     case 'drilldown':
       return t('nav.drilldown.title', 'Drilldown');
+    case 'notebooks':
+      return t('nav.notebooks.title', 'Notebooks');
     case 'alerting':
       return t('nav.alerting.title', 'Alerting');
     case 'plugin-page-grafana-oncall-app':
@@ -214,6 +216,8 @@ export function getNavSubTitle(navId: string | undefined) {
       return t('nav.dashboards.subtitle', 'Create and manage dashboards to visualize your data');
     case 'dashboards/browse':
       return t('nav.dashboards.subtitle', 'Create and manage dashboards to visualize your data');
+    case 'notebooks':
+      return t('nav.notebooks.subtitle', 'Capture investigations with narrative text and live visualizations');
     case 'manage-folder':
       return t('nav.manage-folder.subtitle', 'Manage folder dashboards and permissions');
     case 'dashboards/playlists':

--- a/public/app/features/notebook/extensions/getNotebookExtensionConfigs.test.tsx
+++ b/public/app/features/notebook/extensions/getNotebookExtensionConfigs.test.tsx
@@ -1,3 +1,4 @@
+import { PluginExtensionPoints } from '@grafana/data';
 import { getFeatureFlagClient } from '@grafana/runtime/internal';
 import { contextSrv } from 'app/core/services/context_srv';
 
@@ -50,6 +51,15 @@ describe('getNotebookExtensionConfigs', () => {
 
     getLastUsedNotebookMock.mockReturnValue(undefined);
     expect(configure('Add to last notebook')).toBeUndefined();
+  });
+
+  it('hides the editing sidebar without notebook write permissions', () => {
+    contextSrvMock.hasPermission.mockReturnValue(false);
+    const sidebar = getNotebookExtensionConfigs().find((config) =>
+      config.targets.includes(PluginExtensionPoints.ExtensionSidebar)
+    );
+
+    expect(sidebar?.configure?.(undefined)).toBeUndefined();
   });
 });
 

--- a/public/app/features/notebook/extensions/getNotebookExtensionConfigs.tsx
+++ b/public/app/features/notebook/extensions/getNotebookExtensionConfigs.tsx
@@ -1,12 +1,19 @@
 /* eslint-disable @grafana/i18n/no-untranslated-strings -- extension configs are registered at bootstrap, before i18n is ready (same as getExploreExtensionConfigs) */
 import { type PluginExtensionAddedLinkConfig, PluginExtensionPoints } from '@grafana/data';
+import { locationService } from '@grafana/runtime';
 import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 import { contextSrv } from 'app/core/services/context_srv';
 import { createAddedLinkConfig } from 'app/features/plugins/extensions/utils';
 import { AccessControlAction } from 'app/types/accessControl';
 
 import { type PluginExtensionExploreContext } from '../../explore/extensions/ToolbarExtensionPoint';
+import { createNotebook, notebookEditUrl } from '../api/notebookAPI';
 import { getLastUsedNotebook } from '../model/lastUsedNotebook';
+import { markNotebookAsNew } from '../model/newNotebookSignal';
+import { newNotebookSpec, newNotebookTitle } from '../model/notebookSpec';
+
+/** Title shared by the sidebar added link and added component (the sidebar matches them by title). */
+export const NOTEBOOKS_SIDEBAR_COMPONENT_TITLE = 'Notebooks';
 
 function notebooksEnabled(): boolean {
   return getFeatureFlagClient().getBooleanValue(FlagKeys.DashboardNotebooks, false);
@@ -78,6 +85,40 @@ export function getNotebookExtensionConfigs(): PluginExtensionAddedLinkConfig[] 
             'app/features/notebook/addToNotebook/quickAddFromExplore'
           );
           await quickAddExploreToLastNotebook(context.exploreId);
+        },
+      }),
+
+      // Extension sidebar ("workspace") → notebooks panel docked next to any page.
+      // The sidebar requires a link and a component with the same title; the component
+      // is registered in the plugin extension registry setup.
+      createAddedLinkConfig({
+        title: NOTEBOOKS_SIDEBAR_COMPONENT_TITLE,
+        description: 'Browse notebooks and capture quick notes alongside any Grafana page',
+        targets: [PluginExtensionPoints.ExtensionSidebar],
+        icon: 'book-open',
+        configure: () => (notebooksEnabled() && canEditNotebooks() ? {} : undefined),
+        onClick: (_, { openSidebar }) => {
+          openSidebar(NOTEBOOKS_SIDEBAR_COMPONENT_TITLE);
+        },
+      }),
+
+      // Command palette → quick "New notebook" from anywhere (matches "New dashboard").
+      createAddedLinkConfig({
+        title: 'New notebook',
+        description: 'Create a new notebook to capture an investigation',
+        targets: [PluginExtensionPoints.CommandPalette],
+        icon: 'book-open',
+        category: 'Notebooks',
+        configure: () => {
+          if (!notebooksEnabled() || !canEditNotebooks()) {
+            return undefined;
+          }
+          return {};
+        },
+        onClick: async () => {
+          const created = await createNotebook(newNotebookSpec(newNotebookTitle()));
+          markNotebookAsNew(created.metadata.name);
+          locationService.push(notebookEditUrl(created.metadata.name));
         },
       }),
     ];

--- a/public/app/features/notebook/sidebar/NotebooksSidebarPanel.test.tsx
+++ b/public/app/features/notebook/sidebar/NotebooksSidebarPanel.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from 'test/test-utils';
+
+import { useFlagDashboardNotebooks } from '@grafana/runtime/internal';
+import { useListNotebookQuery } from 'app/api/clients/dashboard/v2beta1';
+import { contextSrv } from 'app/core/services/context_srv';
+
+import { NotebooksSidebarPanel } from './NotebooksSidebarPanel';
+
+jest.mock('@grafana/runtime/internal', () => ({
+  ...jest.requireActual('@grafana/runtime/internal'),
+  useFlagDashboardNotebooks: jest.fn(),
+}));
+jest.mock('app/api/clients/dashboard/v2beta1', () => ({
+  useListNotebookQuery: jest.fn(),
+}));
+jest.mock('app/core/services/context_srv');
+jest.mock('react-router-dom-v5-compat', () => ({
+  ...jest.requireActual('react-router-dom-v5-compat'),
+  useLocation: () => ({ pathname: '/' }),
+}));
+
+const useFlagDashboardNotebooksMock = jest.mocked(useFlagDashboardNotebooks);
+const useListNotebookQueryMock = jest.mocked(useListNotebookQuery);
+const contextSrvMock = jest.mocked(contextSrv);
+
+describe('NotebooksSidebarPanel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useFlagDashboardNotebooksMock.mockReturnValue(true);
+    contextSrvMock.hasPermission.mockReturnValue(true);
+    useListNotebookQueryMock.mockReturnValue({
+      data: { items: [] },
+      isLoading: false,
+      error: undefined,
+    } as never);
+  });
+
+  it('does not render when notebooks are disabled', () => {
+    useFlagDashboardNotebooksMock.mockReturnValue(false);
+
+    const { container } = render(<NotebooksSidebarPanel />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('does not render without notebook write permissions', () => {
+    contextSrvMock.hasPermission.mockReturnValue(false);
+
+    const { container } = render(<NotebooksSidebarPanel />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the empty state when the notebook list is empty', () => {
+    render(<NotebooksSidebarPanel />);
+
+    expect(screen.getByText('No notebooks yet — create one to start capturing findings.')).toBeInTheDocument();
+  });
+
+  it('renders an error instead of the empty state when listing fails', () => {
+    useListNotebookQueryMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: { status: 500 },
+    } as never);
+
+    render(<NotebooksSidebarPanel />);
+
+    expect(screen.getByText('Failed to load notebooks')).toBeInTheDocument();
+    expect(screen.queryByText('No notebooks yet — create one to start capturing findings.')).not.toBeInTheDocument();
+  });
+});

--- a/public/app/features/notebook/sidebar/NotebooksSidebarPanel.tsx
+++ b/public/app/features/notebook/sidebar/NotebooksSidebarPanel.tsx
@@ -1,0 +1,471 @@
+import { css, cx } from '@emotion/css';
+import { DragDropContext, Draggable, Droppable, type DropResult } from '@hello-pangea/dnd';
+import { skipToken } from '@reduxjs/toolkit/query';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useLocation } from 'react-router-dom-v5-compat';
+
+import { type GrafanaTheme2, type SelectableValue } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { locationService } from '@grafana/runtime';
+import { useFlagDashboardNotebooks } from '@grafana/runtime/internal';
+import {
+  Alert,
+  Button,
+  Icon,
+  IconButton,
+  LinkButton,
+  Select,
+  Spinner,
+  Stack,
+  Text,
+  TextArea,
+  useStyles2,
+} from '@grafana/ui';
+import { useListNotebookQuery } from 'app/api/clients/dashboard/v2beta1';
+import { useExtensionSidebarContext } from 'app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider';
+import { contextSrv } from 'app/core/services/context_srv';
+import { AccessControlAction } from 'app/types/accessControl';
+
+import { createNotebook, notebookEditUrl, notebookViewUrl } from '../api/notebookAPI';
+import { mergeRemoteSpec } from '../collab/mergeRemoteSpec';
+import { resourceVersionTs, useNotebookCollab } from '../collab/useNotebookCollab';
+import { MarkdownCellEditor } from '../editor/cells/MarkdownCellEditor';
+import { PanelCellView } from '../editor/cells/PanelCellView';
+import { useNotebookEditorState } from '../editor/useNotebookEditorState';
+import { getLastUsedNotebook } from '../model/lastUsedNotebook';
+import {
+  insertElement,
+  moveCell,
+  newMarkdownElement,
+  newNotebookSpec,
+  newNotebookTitleDate,
+  removeCellAt,
+  resolveCells,
+  updateMarkdownText,
+} from '../model/notebookSpec';
+
+const SIDEBAR_PANEL_HEIGHT = 180;
+
+/**
+ * The notebooks workspace panel, docked in the extension sidebar so notebooks are
+ * reachable next to any Grafana page. Hosts a compact editor for the selected
+ * notebook (markdown editing, reorder, live panels) plus a capture box pinned at
+ * the bottom — jot findings without leaving the dashboard or Explore.
+ */
+export function NotebooksSidebarPanel() {
+  const notebooksEnabled = useFlagDashboardNotebooks();
+  const styles = useStyles2(getStyles);
+  const [selectedUid, setSelectedUid] = useState<string | undefined>(() => getLastUsedNotebook()?.uid);
+  const location = useLocation();
+  const canEditNotebooks =
+    contextSrv.hasPermission(AccessControlAction.DashboardsCreate) ||
+    contextSrv.hasPermission(AccessControlAction.DashboardsWrite);
+
+  const { data, isLoading, error } = useListNotebookQuery(notebooksEnabled && canEditNotebooks ? {} : skipToken);
+
+  // The sidebar follows along: navigating to a notebook page selects that notebook here.
+  useEffect(() => {
+    const match = location.pathname.match(/^\/(?:notebooks\/edit|notebook)\/([^/]+)/);
+    if (match) {
+      setSelectedUid(match[1]);
+    }
+  }, [location.pathname]);
+
+  const options: Array<SelectableValue<string>> = useMemo(
+    () =>
+      (data?.items ?? [])
+        .map((nb) => ({ label: nb.spec.title, value: nb.metadata.name ?? '' }))
+        .filter((option) => option.value !== ''),
+    [data]
+  );
+
+  if (!notebooksEnabled || !canEditNotebooks) {
+    return null;
+  }
+
+  const effectiveUid = selectedUid && options.some((o) => o.value === selectedUid) ? selectedUid : options[0]?.value;
+
+  const onCreate = async () => {
+    const created = await createNotebook(
+      newNotebookSpec(
+        t('notebooks.list.new-notebook-title', 'Investigation — {{date}}', { date: newNotebookTitleDate() })
+      )
+    );
+    setSelectedUid(created.metadata.name);
+  };
+
+  return (
+    <div className={styles.panel} data-testid="notebooks-sidebar-panel">
+      <div className={styles.header}>
+        <Stack direction="row" gap={1} alignItems="center">
+          <Icon name="book-open" />
+          <Text element="h2" variant="h5">
+            <Trans i18nKey="notebooks.sidebar.title">Notebooks</Trans>
+          </Text>
+        </Stack>
+        <Stack direction="row" gap={0.5}>
+          <LinkButton size="sm" fill="text" variant="secondary" href="/notebooks">
+            <Trans i18nKey="notebooks.sidebar.view-all">View all</Trans>
+          </LinkButton>
+          <Button size="sm" icon="plus" variant="secondary" onClick={onCreate}>
+            <Trans i18nKey="notebooks.sidebar.new">New</Trans>
+          </Button>
+        </Stack>
+      </div>
+
+      {isLoading && <Spinner />}
+
+      {!isLoading && Boolean(error) && (
+        <Alert severity="error" title={t('notebooks.sidebar.load-error', 'Failed to load notebooks')} />
+      )}
+
+      {!isLoading && !error && options.length === 0 && (
+        <Text color="secondary">
+          <Trans i18nKey="notebooks.sidebar.empty">No notebooks yet — create one to start capturing findings.</Trans>
+        </Text>
+      )}
+
+      {options.length > 0 && (
+        <Select
+          options={options}
+          value={effectiveUid}
+          onChange={(option) => setSelectedUid(option?.value)}
+          aria-label={t('notebooks.sidebar.picker', 'Notebook')}
+        />
+      )}
+
+      {effectiveUid && <SidebarNotebookEditor key={effectiveUid} uid={effectiveUid} />}
+    </div>
+  );
+}
+
+/**
+ * Compact inline editor for one notebook. Joins the same Live collaboration channel
+ * as the full editor, so sidebar edits show up live in open editors (and vice versa),
+ * and the sidebar counts as a presence.
+ */
+function SidebarNotebookEditor({ uid }: { uid: string }) {
+  const styles = useStyles2(getStyles);
+  const editor = useNotebookEditorState(uid);
+  const { spec, loading, loadError, dirty, saving } = editor.state;
+  const { setDockedComponentId } = useExtensionSidebarContext();
+  const [note, setNote] = useState('');
+  const [editingKey, setEditingKey] = useState<string | null>(null);
+
+  // Jumping to the full page is a context switch — the sidebar closes with it.
+  const onNavigate = (url: string) => {
+    setDockedComponentId(undefined);
+    locationService.push(url);
+  };
+  const editingKeyRef = useRef<string | null>(null);
+  editingKeyRef.current = editingKey;
+  const blocksRef = useRef<HTMLDivElement>(null);
+
+  const collab = useNotebookCollab({
+    uid,
+    enabled: !loading && !!spec,
+    getSpec: editor.getSpec,
+    initialDocTs: resourceVersionTs(editor.state.resource),
+    onRemoteSpec: useCallback(
+      (remoteSpec) => {
+        editor.applyRemoteSpec(mergeRemoteSpec(remoteSpec, editor.getSpec(), editingKeyRef.current));
+      },
+      [editor]
+    ),
+  });
+
+  const update = useCallback(
+    (mutate: Parameters<typeof editor.updateSpec>[0]) => {
+      editor.updateSpec(mutate);
+      collab.notifyLocalEdit();
+    },
+    [editor, collab]
+  );
+
+  if (loadError) {
+    return <Alert severity="error" title={t('notebooks.editor.load-error', 'Failed to load notebook')} />;
+  }
+
+  if (loading || !spec) {
+    return <Spinner />;
+  }
+
+  const cells = resolveCells(spec);
+
+  const onAddNote = () => {
+    const text = note.trim();
+    if (!text) {
+      return;
+    }
+    let newKey: string | undefined;
+    update((s) => {
+      const result = insertElement(s, newMarkdownElement(text), { source: 'user' });
+      newKey = result.elementName;
+      return result.spec;
+    });
+    if (newKey) {
+      collab.sendActivity(t('notebooks.activity.added-note', 'added a note'), newKey);
+    }
+    setNote('');
+    // New notes append at the end; keep them in view.
+    requestAnimationFrame(() => {
+      blocksRef.current?.scrollTo({ top: blocksRef.current.scrollHeight, behavior: 'smooth' });
+    });
+  };
+
+  const onDragEnd = (result: DropResult) => {
+    if (result.destination && result.destination.index !== result.source.index) {
+      update((s) => moveCell(s, result.source.index, result.destination!.index));
+    }
+  };
+
+  return (
+    <div className={styles.editor}>
+      <div className={styles.blocks} ref={blocksRef}>
+        {cells.length === 0 ? (
+          <div className={styles.blocksEmpty}>
+            <Icon name="document-info" size="lg" />
+            <Text variant="bodySmall" color="secondary" textAlignment="center">
+              <Trans i18nKey="notebooks.sidebar.no-blocks">
+                Nothing here yet — capture your first note below, or add panels from any dashboard.
+              </Trans>
+            </Text>
+          </div>
+        ) : (
+          <DragDropContext onDragEnd={onDragEnd}>
+            <Droppable droppableId="notebook-sidebar-cells">
+              {(droppable) => (
+                <div ref={droppable.innerRef} {...droppable.droppableProps} className={styles.cells}>
+                  {cells.map((cell, index) => {
+                    const { element, elementName } = cell;
+
+                    return (
+                      <Draggable draggableId={elementName} index={index} key={elementName}>
+                        {(draggable, snapshot) => (
+                          <div
+                            ref={draggable.innerRef}
+                            {...draggable.draggableProps}
+                            className={cx(styles.cellRow, snapshot.isDragging && styles.cellDragging)}
+                          >
+                            <div
+                              className={cx('sidebar-cell-drag-handle', styles.cellDragHandle)}
+                              {...draggable.dragHandleProps}
+                              aria-label={t('notebooks.cell.drag', 'Drag to reorder block')}
+                            >
+                              <Icon name="draggabledots" size="sm" />
+                            </div>
+                            <div className={styles.cellBody}>
+                              {element.kind === 'Panel' && (
+                                <PanelCellView
+                                  panel={element}
+                                  timeFrom={cell.timeFrom ?? spec.timeSettings.from}
+                                  timeTo={cell.timeTo ?? spec.timeSettings.to}
+                                  height={SIDEBAR_PANEL_HEIGHT}
+                                />
+                              )}
+                              {element.kind === 'LibraryPanel' && <Text color="secondary">{element.spec.title}</Text>}
+                              {element.kind === 'Cell' && element.spec.content.kind === 'Markdown' && (
+                                <MarkdownCellEditor
+                                  value={element.spec.content.spec.text}
+                                  editing={editingKey === elementName}
+                                  onStartEdit={() => setEditingKey(elementName)}
+                                  onChange={(text) => update((s) => updateMarkdownText(s, elementName, text))}
+                                  onDone={() => setEditingKey(null)}
+                                />
+                              )}
+                              {element.kind === 'Cell' && element.spec.content.kind === 'Code' && (
+                                <pre className={styles.code}>{element.spec.content.spec.code}</pre>
+                              )}
+                            </div>
+                            <div className={cx('sidebar-cell-actions', styles.cellActions)}>
+                              <IconButton
+                                name="trash-alt"
+                                size="sm"
+                                tooltip={t('notebooks.sidebar.delete-block', 'Delete block')}
+                                onClick={() => update((s) => removeCellAt(s, index))}
+                              />
+                            </div>
+                          </div>
+                        )}
+                      </Draggable>
+                    );
+                  })}
+                  {droppable.placeholder}
+                </div>
+              )}
+            </Droppable>
+          </DragDropContext>
+        )}
+      </div>
+
+      <div className={styles.footer}>
+        <Text variant="bodySmall" color="secondary">
+          {saving
+            ? t('notebooks.editor.status-saving', 'Saving…')
+            : dirty
+              ? t('notebooks.editor.status-unsaved', 'Unsaved changes')
+              : t('notebooks.sidebar.status-synced', 'All changes saved')}
+        </Text>
+        <Stack direction="row" gap={0.25}>
+          <IconButton
+            name="book-open"
+            tooltip={t('notebooks.sidebar.open', 'Open notebook')}
+            onClick={() => onNavigate(notebookViewUrl(uid))}
+          />
+          <IconButton
+            name="pen"
+            tooltip={t('notebooks.sidebar.edit', 'Open in editor')}
+            onClick={() => onNavigate(notebookEditUrl(uid))}
+          />
+        </Stack>
+      </div>
+
+      <div className={styles.noteBox}>
+        <TextArea
+          value={note}
+          rows={2}
+          placeholder={t('notebooks.sidebar.note-placeholder', 'Jot a quick note — Enter to add')}
+          onChange={(e) => setNote(e.currentTarget.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault();
+              onAddNote();
+            }
+          }}
+          data-testid="notebooks-sidebar-note"
+        />
+        <IconButton
+          name="message"
+          size="lg"
+          disabled={!note.trim()}
+          onClick={onAddNote}
+          tooltip={t('notebooks.sidebar.add-note', 'Add note (Enter)')}
+        />
+      </div>
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  panel: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1.5),
+    padding: theme.spacing(2, 2, 1.5, 2),
+    height: '100%',
+    overflow: 'hidden',
+  }),
+  header: css({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: theme.spacing(1),
+    flexShrink: 0,
+  }),
+  editor: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+    flex: 1,
+    minHeight: 0,
+  }),
+  blocks: css({
+    flex: 1,
+    minHeight: 0,
+    overflowY: 'auto',
+    // Breathing room so hover outlines and the drag handle are not clipped.
+    padding: theme.spacing(0.5, 0.5, 0.5, 0),
+    margin: theme.spacing(-0.5, -0.5, 0, 0),
+  }),
+  blocksEmpty: css({
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: theme.spacing(1),
+    height: '100%',
+    minHeight: 120,
+    color: theme.colors.text.secondary,
+    border: `1px dashed ${theme.colors.border.medium}`,
+    borderRadius: theme.shape.radius.default,
+    padding: theme.spacing(2),
+  }),
+  cells: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1.5),
+  }),
+  cellRow: css({
+    position: 'relative',
+    borderRadius: theme.shape.radius.default,
+    padding: theme.spacing(0.5),
+    paddingLeft: theme.spacing(2.5),
+
+    '&:hover': {
+      outline: `1px solid ${theme.colors.border.weak}`,
+    },
+
+    '&:hover .sidebar-cell-actions, &:hover .sidebar-cell-drag-handle': {
+      opacity: 1,
+    },
+  }),
+  cellDragging: css({
+    outline: `1px solid ${theme.colors.primary.border}`,
+    background: theme.colors.background.primary,
+    boxShadow: theme.shadows.z2,
+  }),
+  cellDragHandle: css({
+    position: 'absolute',
+    left: 0,
+    top: '50%',
+    transform: 'translateY(-50%)',
+    display: 'flex',
+    alignItems: 'center',
+    padding: theme.spacing(0, 0.25),
+    opacity: 0,
+    color: theme.colors.text.secondary,
+    cursor: 'grab',
+  }),
+  cellBody: css({
+    minWidth: 0,
+  }),
+  cellActions: css({
+    position: 'absolute',
+    top: theme.spacing(0.5),
+    right: theme.spacing(0.5),
+    display: 'flex',
+    gap: theme.spacing(0.25),
+    opacity: 0,
+    background: theme.colors.background.primary,
+    borderRadius: theme.shape.radius.default,
+    zIndex: 2,
+    padding: theme.spacing(0.25),
+  }),
+  code: css({
+    background: theme.colors.background.secondary,
+    borderRadius: theme.shape.radius.default,
+    padding: theme.spacing(1),
+    fontSize: theme.typography.bodySmall.fontSize,
+    fontFamily: theme.typography.fontFamilyMonospace,
+    overflow: 'auto',
+    maxHeight: 160,
+    margin: 0,
+  }),
+  footer: css({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: theme.spacing(1),
+    borderTop: `1px solid ${theme.colors.border.weak}`,
+    paddingTop: theme.spacing(0.75),
+    flexShrink: 0,
+  }),
+  noteBox: css({
+    display: 'flex',
+    alignItems: 'flex-end',
+    gap: theme.spacing(1),
+    flexShrink: 0,
+  }),
+});
+
+export default NotebooksSidebarPanel;

--- a/public/app/features/notebook/sidebar/NotebooksSidebarPanelLoader.tsx
+++ b/public/app/features/notebook/sidebar/NotebooksSidebarPanelLoader.tsx
@@ -1,0 +1,16 @@
+import { Suspense, lazy } from 'react';
+
+import PageLoader from 'app/core/components/PageLoader/PageLoader';
+
+// This wrapper is imported in the plugin extension registry bootstrap path, so it must
+// stay dependency-free: the actual panel (and the notebook feature it pulls in) is only
+// loaded when the sidebar component is opened.
+const NotebooksSidebarPanel = lazy(() => import('./NotebooksSidebarPanel'));
+
+export function NotebooksSidebarPanelLoader() {
+  return (
+    <Suspense fallback={<PageLoader />}>
+      <NotebooksSidebarPanel />
+    </Suspense>
+  );
+}

--- a/public/app/features/plugins/extensions/registry/setup.ts
+++ b/public/app/features/plugins/extensions/registry/setup.ts
@@ -1,11 +1,13 @@
 /* eslint-disable @grafana/i18n/no-untranslated-strings */
-import { type AppPluginConfig, PluginExtensionExposedComponents } from '@grafana/data';
+import { type AppPluginConfig, PluginExtensionExposedComponents, PluginExtensionPoints } from '@grafana/data';
 import { getAppPluginMetas, getCachedPromise } from '@grafana/runtime/internal';
 import CentralAlertHistorySceneExposedComponent from 'app/features/alerting/unified/components/rules/central-state-history/CentralAlertHistorySceneExposedComponent';
 import { CreateAlertFromPanelExposedComponent } from 'app/features/alerting/unified/extensions/CreateAlertFromPanelExposedComponent';
 import { AddToDashboardFormExposedComponent } from 'app/features/dashboard-scene/addToDashboard/AddToDashboardFormExposedComponent';
 import { OpenQueryLibraryExposedComponent } from 'app/features/explore/QueryLibrary/OpenQueryLibraryExposedComponent';
 import { PrometheusQueryResultsContainer } from 'app/features/explore/RawPrometheus/PrometheusQueryResultsContainer';
+import { NOTEBOOKS_SIDEBAR_COMPONENT_TITLE } from 'app/features/notebook/extensions/getNotebookExtensionConfigs';
+import { NotebooksSidebarPanelLoader } from 'app/features/notebook/sidebar/NotebooksSidebarPanelLoader';
 
 import { getCoreExtensionConfigurations } from '../getCoreExtensionConfigurations';
 
@@ -23,11 +25,29 @@ function initRegistries(apps: AppPluginConfig[]): PluginExtensionRegistries {
   return { addedComponentsRegistry, addedFunctionsRegistry, addedLinksRegistry, exposedComponentsRegistry };
 }
 
-function registerCoreExtensions({ addedLinksRegistry, exposedComponentsRegistry }: PluginExtensionRegistries) {
+function registerCoreExtensions({
+  addedComponentsRegistry,
+  addedLinksRegistry,
+  exposedComponentsRegistry,
+}: PluginExtensionRegistries) {
   // Registering core extension links
   addedLinksRegistry.register({
     pluginId: 'grafana',
     configs: getCoreExtensionConfigurations(),
+  });
+
+  // The notebooks workspace panel for the extension sidebar. The matching added link
+  // (which gates visibility on the feature flag) is part of getCoreExtensionConfigurations.
+  addedComponentsRegistry.register({
+    pluginId: 'grafana',
+    configs: [
+      {
+        targets: [PluginExtensionPoints.ExtensionSidebar],
+        title: NOTEBOOKS_SIDEBAR_COMPONENT_TITLE,
+        description: 'Browse notebooks and capture quick notes alongside any Grafana page',
+        component: NotebooksSidebarPanelLoader,
+      },
+    ],
   });
 
   // Registering core exposed components

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12689,6 +12689,7 @@
   "notebooks": {
     "activity": {
       "added-code": "added a code block",
+      "added-note": "added a note",
       "added-text": "added a text block",
       "added-viz": "added a visualization",
       "changed-time": "changed the notebook time range",
@@ -12790,6 +12791,7 @@
       "status-pending": "Saving shortly…",
       "status-saved": "Saved {{when}}",
       "status-saving": "Saving…",
+      "status-unsaved": "Unsaved changes",
       "stop-following": "Stop following",
       "tags-placeholder": "Add tags",
       "title-label": "Notebook title",
@@ -12859,6 +12861,21 @@
     },
     "quick-add": {
       "added": "Added to notebook"
+    },
+    "sidebar": {
+      "add-note": "Add note (Enter)",
+      "delete-block": "Delete block",
+      "edit": "Open in editor",
+      "empty": "No notebooks yet — create one to start capturing findings.",
+      "load-error": "Failed to load notebooks",
+      "new": "New",
+      "no-blocks": "Nothing here yet — capture your first note below, or add panels from any dashboard.",
+      "note-placeholder": "Jot a quick note — Enter to add",
+      "open": "Open notebook",
+      "picker": "Notebook",
+      "status-synced": "All changes saved",
+      "title": "Notebooks",
+      "view-all": "View all"
     },
     "viz-suggestions": {
       "no-data": "No data yet — suggestions appear once the panel has results.",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12381,6 +12381,10 @@
     "new-folder": {
       "title": "New folder"
     },
+    "notebooks": {
+      "subtitle": "Capture investigations with narrative text and live visualizations",
+      "title": "Notebooks"
+    },
     "oncall": {
       "title": "OnCall"
     },


### PR DESCRIPTION
## What this adds

- Adds the notebook sidebar workspace and loader.
- Registers notebook actions in the command palette.
- Adds the translated primary navigation entry behind `dashboard.notebooks`.
- Adds supporting navigation state, localization, and tests.

## Why

These are both global ways to discover and open notebooks outside notebook pages. Grouping them keeps the navigation review cohesive without creating two very small PRs.

## Stack

Layer 7 of 8. Builds on the core notebook and capture experiences.

## Validation

Review follow-up validation passed: focused notebook, route, and dashboard suites (18 suites, 140 tests), `go test ./pkg/services/navtree/navtreeimpl -count=1`, `yarn typecheck`, the production frontend build, the React 19 frontend build, and formatting checks.

## Dogfooding

Use the [original combined POC environment](https://ephemeral15111821129904nmarrs.grafana-dev.net/notebooks) for the clearest end-to-end demo.

[Open this PR's ephemeral notebook instance](https://ephemeral15111821129977nmarrs.grafana-dev.net/notebooks) to smoke-test the cumulative branch containing backend, core notebooks, collaboration, dashboard and Explore capture, and global navigation entry points. This environment is primarily useful for verifying Grafana starts cleanly and the changes through this layer do not introduce runtime regressions.