### PR TITLE
Notebooks: Add IRM integration

### DIFF
--- a/public/app/features/notebook/editor/NotebookEditor.tsx
+++ b/public/app/features/notebook/editor/NotebookEditor.tsx
@@ -45,6 +45,8 @@ import { CollabCursors } from '../collab/CollabCursors';
 import { PresenceAvatars } from '../collab/PresenceAvatars';
 import { mergeRemoteSpec } from '../collab/mergeRemoteSpec';
 import { resourceVersionTs, useNotebookCollab } from '../collab/useNotebookCollab';
+import { DeclareIncidentFromNotebookButton } from '../extensions/DeclareIncidentFromNotebookButton';
+import { declareIncidentContextFromSpec } from '../extensions/declareIncidentFromNotebook';
 import { setLastUsedNotebook } from '../model/lastUsedNotebook';
 import { consumeNewNotebook } from '../model/newNotebookSignal';
 import {
@@ -504,6 +506,7 @@ export function NotebookEditor({ uid }: Props) {
           appEvents.emit(AppEvents.alertSuccess, [t('notebooks.editor.link-copied', 'Notebook link copied')]);
         }}
       />
+      <DeclareIncidentFromNotebookButton as="menu-item" {...declareIncidentContextFromSpec(uid, spec)} />
       <Menu.Item icon="copy" label={t('notebooks.editor.copy-markdown', 'Copy as Markdown')} onClick={onCopyMarkdown} />
       <Menu.Item
         icon="file-copy-alt"

--- a/public/app/features/notebook/extensions/DeclareIncidentFromNotebookButton.tsx
+++ b/public/app/features/notebook/extensions/DeclareIncidentFromNotebookButton.tsx
@@ -1,0 +1,66 @@
+import { css } from '@emotion/css';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { Icon, LinkButton, Menu, useStyles2, useTheme2 } from '@grafana/ui';
+import { createBridgeURL } from 'app/features/alerting/unified/components/PluginBridge';
+import { canAccessPluginPage, useIrmPlugin } from 'app/features/alerting/unified/hooks/usePluginBridge';
+import { SupportedPlugin } from 'app/features/alerting/unified/types/pluginBridges';
+
+import { buildDeclareIncidentParams, type DeclareIncidentNotebookContext } from './declareIncidentFromNotebook';
+
+const DECLARE_INCIDENT_PATH = '/incidents/declare';
+
+interface Props extends DeclareIncidentNotebookContext {
+  /** Toolbar control (default) or hamburger menu item. */
+  as?: 'button' | 'menu-item';
+}
+
+/**
+ * IRM entry point from a notebook: opens declare-incident prefilled with a sensible
+ * title, a labeled link back to the notebook, and a short description. Renders
+ * nothing when IRM/Incident isn't available.
+ */
+export function DeclareIncidentFromNotebookButton({ as = 'button', ...ctx }: Props) {
+  const theme = useTheme2();
+  const styles = useStyles2(getStyles);
+  const { pluginId, loading, installed, settings } = useIrmPlugin(SupportedPlugin.Incident);
+
+  if (loading || !installed || !settings) {
+    return null;
+  }
+
+  if (!canAccessPluginPage(settings, createBridgeURL(pluginId, DECLARE_INCIDENT_PATH))) {
+    return null;
+  }
+
+  const bridgeURL = createBridgeURL(pluginId, DECLARE_INCIDENT_PATH, buildDeclareIncidentParams(ctx));
+
+  const label = t('notebooks.declare-incident.button', 'Declare incident');
+  const fireColor = theme.colors.error.text;
+
+  if (as === 'menu-item') {
+    return (
+      <Menu.Item icon="fire" iconColor={fireColor} label={label} url={bridgeURL} testId="notebook-declare-incident" />
+    );
+  }
+
+  // Match Edit / time-picker chrome: secondary filled control with a colored fire glyph.
+  return (
+    <LinkButton
+      variant="secondary"
+      href={bridgeURL}
+      tooltip={label}
+      aria-label={label}
+      data-testid="notebook-declare-incident"
+    >
+      <Icon name="fire" className={styles.fireIcon} />
+    </LinkButton>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  fireIcon: css({
+    color: theme.colors.error.text,
+  }),
+});

--- a/public/app/features/notebook/extensions/declareIncidentFromNotebook.test.ts
+++ b/public/app/features/notebook/extensions/declareIncidentFromNotebook.test.ts
@@ -1,0 +1,118 @@
+import { defaultSpec as defaultNotebookSpec } from '@grafana/schema/apis/notebook/v2beta1';
+
+import { DEFAULT_NOTEBOOK_TITLE, newPanelForDatasource } from '../model/notebookSpec';
+
+import { buildDeclareIncidentParams, declareIncidentContextFromSpec } from './declareIncidentFromNotebook';
+
+describe('buildDeclareIncidentParams', () => {
+  const originalLocation = window.location;
+
+  beforeAll(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, origin: 'https://grafana.example' },
+    });
+  });
+
+  afterAll(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  it('prefixes a named title and attaches the notebook link with a caption', () => {
+    const params = buildDeclareIncidentParams({
+      uid: 'nb1',
+      title: 'Checkout latency',
+      tags: ['checkout'],
+      panelTitles: ['p99 latency'],
+      firstMarkdownLine: 'some notes',
+      description: 'API errors spiking',
+    });
+
+    // Named title beats markdown/description.
+    expect(params.title).toBe('Investigation: Checkout latency');
+    expect(params.url).toBe('https://grafana.example/notebook/nb1');
+    expect(params.caption).toBe('Notebook: Checkout latency');
+    expect(params.description).toContain(
+      'This incident was declared from this notebook: https://grafana.example/notebook/nb1'
+    );
+    expect(params.description).toContain('Notebook: Checkout latency');
+    expect(params.description).toContain('Tags: checkout');
+    expect(params.description).toContain('- p99 latency');
+  });
+
+  it('keeps dated Investigation create titles as the incident title', () => {
+    const params = buildDeclareIncidentParams({
+      uid: 'nb1',
+      title: 'Investigation — August 1, 2026 16:30',
+    });
+
+    expect(params.title).toBe('Investigation — August 1, 2026 16:30');
+    expect(params.caption).toBe('Notebook: Investigation — August 1, 2026 16:30');
+  });
+
+  it('falls back to the first markdown line when the title is still the default', () => {
+    const params = buildDeclareIncidentParams({
+      uid: 'nb1',
+      title: DEFAULT_NOTEBOOK_TITLE,
+      firstMarkdownLine: 'Checkout p99 over SLO in prod',
+      description: 'API errors spiking in us-east',
+    });
+
+    expect(params.title).toBe('Checkout p99 over SLO in prod');
+    expect(params.caption).toBe('Investigation notebook');
+  });
+
+  it('treats blank titles like the create default', () => {
+    const params = buildDeclareIncidentParams({
+      uid: 'nb1',
+      title: '   ',
+      description: 'API errors spiking in us-east',
+    });
+
+    expect(params.title).toBe('API errors spiking in us-east');
+  });
+
+  it('does not double-prefix titles that already say Investigation', () => {
+    const params = buildDeclareIncidentParams({
+      uid: 'nb1',
+      title: 'Investigation: payment timeouts',
+    });
+
+    expect(params.title).toBe('Investigation: payment timeouts');
+  });
+});
+
+describe('declareIncidentContextFromSpec', () => {
+  it('collects panel titles and the first markdown line from the notebook', () => {
+    const panel = newPanelForDatasource({ uid: 'prom', type: 'prometheus' }, { title: 'Error rate' });
+    const ctx = declareIncidentContextFromSpec('nb1', {
+      ...defaultNotebookSpec(),
+      title: 'Outage notes',
+      elements: {
+        md1: { kind: 'Cell', spec: { content: { kind: 'Markdown', spec: { text: '# Checkout p99\n\nDetails…' } } } },
+        p1: panel,
+      },
+      layout: {
+        kind: 'NotebookLayout',
+        spec: {
+          cells: [
+            {
+              kind: 'NotebookLayoutItem',
+              spec: { element: { kind: 'ElementReference', name: 'md1' }, source: 'user' },
+            },
+            {
+              kind: 'NotebookLayoutItem',
+              spec: { element: { kind: 'ElementReference', name: 'p1' }, source: 'user' },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(ctx.panelTitles).toEqual(['Error rate']);
+    expect(ctx.firstMarkdownLine).toBe('Checkout p99');
+  });
+});

--- a/public/app/features/notebook/extensions/declareIncidentFromNotebook.ts
+++ b/public/app/features/notebook/extensions/declareIncidentFromNotebook.ts
@@ -1,0 +1,138 @@
+import { type Spec as NotebookSpec } from '@grafana/schema/apis/notebook/v2beta1';
+
+import { notebookViewUrl } from '../api/notebookAPI';
+import { DEFAULT_NOTEBOOK_TITLE, isDefaultNotebookTitle, resolveCells } from '../model/notebookSpec';
+
+export interface DeclareIncidentNotebookContext {
+  uid: string;
+  title: string;
+  description?: string;
+  tags?: string[];
+  /** Panel titles when known — used for a short description bullet list. */
+  panelTitles?: string[];
+  /** First meaningful markdown line — used when the notebook title is still the create default. */
+  firstMarkdownLine?: string;
+}
+
+/**
+ * Prefill params for the IRM declare-incident form.
+ *
+ * Documented URL params are title / url / caption / description (plus severity, etc.).
+ * `status` is the lifecycle state (active/resolved), not a status-update message — so the
+ * “declared from this notebook” line goes in `description`, and the notebook is also
+ * attached via `url` + `caption` (IRM’s attached-context UI).
+ */
+export function buildDeclareIncidentParams(ctx: DeclareIncidentNotebookContext): Record<string, string> {
+  const notebookUrl = new URL(notebookViewUrl(ctx.uid), window.location.origin).toString();
+  const title = incidentTitle(ctx);
+  const description = incidentDescription(ctx, notebookUrl, title);
+
+  const captionTitle = ctx.title.trim();
+  return {
+    title,
+    url: notebookUrl,
+    caption:
+      captionTitle && !isDefaultNotebookTitle(captionTitle) ? `Notebook: ${captionTitle}` : 'Investigation notebook',
+    description,
+  };
+}
+
+export function declareIncidentContextFromSpec(uid: string, spec: NotebookSpec): DeclareIncidentNotebookContext {
+  const panelTitles: string[] = [];
+  let firstMarkdownLine: string | undefined;
+
+  for (const cell of resolveCells(spec)) {
+    if (cell.element.kind === 'Panel' || cell.element.kind === 'LibraryPanel') {
+      const panelTitle = cell.element.spec.title?.trim();
+      if (panelTitle) {
+        panelTitles.push(panelTitle);
+      }
+      continue;
+    }
+
+    if (!firstMarkdownLine && cell.element.kind === 'Cell' && cell.element.spec.content.kind === 'Markdown') {
+      firstMarkdownLine = firstMeaningfulLine(cell.element.spec.content.spec.text);
+    }
+  }
+
+  return {
+    uid,
+    title: spec.title,
+    description: spec.description,
+    tags: spec.tags,
+    panelTitles,
+    firstMarkdownLine,
+  };
+}
+
+function incidentTitle(ctx: DeclareIncidentNotebookContext): string {
+  // Named title wins (including dated `Investigation — …` create defaults).
+  // Only fall through when empty or still the legacy untitled placeholder.
+  const trimmedTitle = ctx.title?.trim() ?? '';
+  if (!isDefaultNotebookTitle(trimmedTitle)) {
+    if (/^investigation\b/i.test(trimmedTitle)) {
+      return trimmedTitle;
+    }
+    return `Investigation: ${trimmedTitle}`;
+  }
+
+  for (const candidate of [ctx.firstMarkdownLine, ctx.description]) {
+    const summary = asSingleLineSummary(candidate);
+    if (summary) {
+      return summary;
+    }
+  }
+
+  return `Investigation: ${DEFAULT_NOTEBOOK_TITLE}`;
+}
+
+function incidentDescription(ctx: DeclareIncidentNotebookContext, notebookUrl: string, title: string): string {
+  // Lead with the declaration line so it reads like the initial status / context
+  // responders see first. IRM has no documented URL param for a status-update body.
+  const lines = [
+    `This incident was declared from this notebook: ${notebookUrl}`,
+    '',
+    `Notebook: ${ctx.title.trim() || DEFAULT_NOTEBOOK_TITLE}`,
+  ];
+
+  const trimmedDescription = ctx.description?.trim();
+  if (trimmedDescription && trimmedDescription !== title) {
+    lines.push('', trimmedDescription);
+  }
+
+  if (ctx.tags?.length) {
+    lines.push('', `Tags: ${ctx.tags.join(', ')}`);
+  }
+
+  const panels = ctx.panelTitles?.filter(Boolean).slice(0, 8) ?? [];
+  if (panels.length) {
+    lines.push('', 'Panels:');
+    for (const panel of panels) {
+      lines.push(`- ${panel}`);
+    }
+    if ((ctx.panelTitles?.length ?? 0) > panels.length) {
+      lines.push(`- …and ${(ctx.panelTitles?.length ?? 0) - panels.length} more`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+/** First non-empty markdown line, stripped of heading markers — for incident title fallback. */
+function firstMeaningfulLine(text: string): string | undefined {
+  for (const raw of text.split('\n')) {
+    const line = raw.replace(/^#{1,6}\s+/, '').trim();
+    if (line) {
+      return line;
+    }
+  }
+  return undefined;
+}
+
+function asSingleLineSummary(value?: string): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed || trimmed.includes('\n') || trimmed.length > 120) {
+    return undefined;
+  }
+  return trimmed;
+}

--- a/public/app/features/notebook/extensions/getNotebookExtensionConfigs.tsx
+++ b/public/app/features/notebook/extensions/getNotebookExtensionConfigs.tsx
@@ -15,6 +15,10 @@ import { newNotebookSpec, newNotebookTitle } from '../model/notebookSpec';
 /** Title shared by the sidebar added link and added component (the sidebar matches them by title). */
 export const NOTEBOOKS_SIDEBAR_COMPONENT_TITLE = 'Notebooks';
 
+// The Alerts & IRM landing page renders extension links from this point as cards —
+// the lightweight IRM entry point into notebooks.
+const IRM_LANDING_CARDS_EXTENSION_POINT = 'grafana/dynamic/nav-landing-page/nav-id-alerts-and-incidents/cards/v1';
+
 function notebooksEnabled(): boolean {
   return getFeatureFlagClient().getBooleanValue(FlagKeys.DashboardNotebooks, false);
 }
@@ -99,6 +103,18 @@ export function getNotebookExtensionConfigs(): PluginExtensionAddedLinkConfig[] 
         configure: () => (notebooksEnabled() && canEditNotebooks() ? {} : undefined),
         onClick: (_, { openSidebar }) => {
           openSidebar(NOTEBOOKS_SIDEBAR_COMPONENT_TITLE);
+        },
+      }),
+
+      // Alerts & IRM landing page card → notebooks as the incident note-taking surface.
+      createAddedLinkConfig({
+        title: 'Notebooks',
+        description: 'Capture incident investigation notes with live panels and share findings with your team',
+        targets: [IRM_LANDING_CARDS_EXTENSION_POINT],
+        icon: 'book-open',
+        configure: () => (notebooksEnabled() ? {} : undefined),
+        onClick: () => {
+          locationService.push('/notebooks');
         },
       }),
 

--- a/public/app/features/notebook/pages/NotebookScenePage.tsx
+++ b/public/app/features/notebook/pages/NotebookScenePage.tsx
@@ -17,10 +17,12 @@ import { copyStringToClipboard } from 'app/core/utils/explore';
 import { DashboardPageError } from 'app/features/dashboard/containers/DashboardPageError';
 import { type DashboardControls } from 'app/features/dashboard-scene/scene/DashboardControls';
 import { type DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
+import { NotebookLayoutManager } from 'app/features/dashboard-scene/scene/layout-notebook/NotebookLayoutManager';
 import { AccessControlAction } from 'app/types/accessControl';
 import { DashboardRoutes } from 'app/types/dashboard';
 
 import { deleteNotebook, duplicateNotebook, fetchNotebook, notebookEditUrl } from '../api/notebookAPI';
+import { DeclareIncidentFromNotebookButton } from '../extensions/DeclareIncidentFromNotebookButton';
 
 import { getNotebookScenePageStateManager } from './NotebookScenePageStateManager';
 
@@ -82,7 +84,7 @@ export function NotebookScenePage() {
 // and outline sidebar out. The scene is activated so panels still run their queries and
 // resolve the shared time range; the title stays via the page breadcrumb (pageNav).
 function NotebookDocument({ scene }: { scene: DashboardScene }) {
-  const { body, controls, title, uid } = scene.useState();
+  const { body, controls, title, description, tags, uid } = scene.useState();
 
   useEffect(() => scene.activate(), [scene]);
 
@@ -93,7 +95,23 @@ function NotebookDocument({ scene }: { scene: DashboardScene }) {
     <Page navId="notebooks" pageNav={pageNav} layout={PageLayoutType.Custom}>
       {/* ScopesVariable (and other UNSAFE_renderAsHidden vars) must mount so query runners aren't blocked forever on dependsOnScopes — same as SoloPanelPage. */}
       {renderHiddenVariables(scene)}
-      {controls && <NotebookControls controls={controls} uid={uid} title={title} />}
+      {controls && (
+        <NotebookControls
+          controls={controls}
+          uid={uid}
+          title={title}
+          description={description}
+          tags={tags}
+          panelTitles={
+            body instanceof NotebookLayoutManager
+              ? body
+                  .getVizPanels()
+                  .map((panel) => panel.state.title)
+                  .filter((panelTitle): panelTitle is string => Boolean(panelTitle?.trim()))
+              : undefined
+          }
+        />
+      )}
       {body && <body.Component model={body} />}
     </Page>
   );
@@ -118,7 +136,21 @@ function renderHiddenVariables(scene: DashboardScene) {
 // Read-only notebooks still get the shared time range + refresh — but only those two
 // pickers, not the full dashboard controls bar (which carries edit/variable actions).
 // The Edit button is the entry into the collaborative notebook editor.
-function NotebookControls({ controls, uid, title }: { controls: DashboardControls; uid?: string; title?: string }) {
+function NotebookControls({
+  controls,
+  uid,
+  title,
+  description,
+  tags,
+  panelTitles,
+}: {
+  controls: DashboardControls;
+  uid?: string;
+  title?: string;
+  description?: string;
+  tags?: string[];
+  panelTitles?: string[];
+}) {
   const styles = useStyles2(getControlsStyles);
   const { timePicker, refreshPicker, hideTimeControls } = controls.useState();
   const [confirmDelete, setConfirmDelete] = useState(false);
@@ -194,6 +226,15 @@ function NotebookControls({ controls, uid, title }: { controls: DashboardControl
           }}
           data-testid="notebook-copy-link"
         />
+        {uid && (
+          <DeclareIncidentFromNotebookButton
+            uid={uid}
+            title={title ?? ''}
+            description={description}
+            tags={tags}
+            panelTitles={panelTitles}
+          />
+        )}
         {canEdit && uid && (
           <LinkButton variant="secondary" icon="pen" href={`/notebooks/edit/${uid}`} data-testid="notebook-edit-button">
             {t('notebook.edit-button', 'Edit')}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12770,6 +12770,9 @@
       "empty": "Click to add code — a query, a command, a config snippet…",
       "language": "Code language"
     },
+    "declare-incident": {
+      "button": "Declare incident"
+    },
     "editor": {
       "block-deleted": "Block deleted",
       "copied-markdown": "Notebook copied as Markdown",


### PR DESCRIPTION
## What this adds

- Adds an IRM action for declaring an incident from notebook context.
- Converts notebook content into the incident declaration payload.
- Registers the IRM extension and adds focused transformation tests.

## Why

IRM is a distinct product integration and review surface, so it remains the final optional layer of the notebook dogfooding stack.

## Stack

Layer 8 of 8 and the top of the stack.

## Validation

Review follow-up validation passed: focused notebook, route, and dashboard suites (18 suites, 140 tests), `yarn typecheck`, the production frontend build, and the React 19 frontend build.

## Dogfooding

Use the [original combined POC environment](https://ephemeral15111821129904nmarrs.grafana-dev.net/notebooks) for the clearest end-to-end demo.

[Open this PR's ephemeral notebook instance](https://ephemeral15111821129978nmarrs.grafana-dev.net/notebooks) to smoke-test the cumulative branch containing the complete stacked implementation through IRM. This environment is primarily useful for verifying Grafana starts cleanly and the changes through this layer do not introduce runtime regressions.