### PR TITLE
Text: Add editor footer

### DIFF
--- a/public/app/plugins/panel/text/v2/TextNGPanel.test.tsx
+++ b/public/app/plugins/panel/text/v2/TextNGPanel.test.tsx
@@ -235,6 +235,42 @@ describe('TextNGPanel', () => {
       });
     });
 
+    describe('line numbers toggled in the editor footer', () => {
+      const toggleLineNumbers = async (options: Props['options']) => {
+        replaceVariablesMock.mockImplementation((str: string) => str);
+        const onOptionsChange = jest.fn();
+
+        setup(Object.assign({}, defaultProps, { options, onOptionsChange }), CoreApp.PanelEditor);
+        await userEvent.click(await screen.findByRole('switch', { name: 'Line numbers' }));
+
+        return onOptionsChange;
+      };
+
+      it('keeps the existing code options', async () => {
+        const onOptionsChange = await toggleLineNumbers({
+          content: 'SELECT 1',
+          mode: TextMode.Code,
+          code: { language: CodeLanguage.Sql, showLineNumbers: false, showMiniMap: false },
+        });
+
+        expect(onOptionsChange).toHaveBeenCalledWith({
+          content: 'SELECT 1',
+          mode: TextMode.Code,
+          code: { language: CodeLanguage.Sql, showLineNumbers: true, showMiniMap: false },
+        });
+      });
+
+      it('fills in the defaults when no code options are set', async () => {
+        const onOptionsChange = await toggleLineNumbers({ content: 'SELECT 1', mode: TextMode.Code });
+
+        expect(onOptionsChange).toHaveBeenCalledWith({
+          content: 'SELECT 1',
+          mode: TextMode.Code,
+          code: { language: CodeLanguage.Plaintext, showLineNumbers: true, showMiniMap: false },
+        });
+      });
+    });
+
     it('does not render the inline editor in view mode', () => {
       const props = Object.assign({}, defaultProps, {
         options: { content: '# Hello', mode: TextMode.Markdown },

--- a/public/app/plugins/panel/text/v2/TextNGPanel.tsx
+++ b/public/app/plugins/panel/text/v2/TextNGPanel.tsx
@@ -4,13 +4,21 @@ import { lazy, Suspense, useMemo, useState } from 'react';
 import { useDebounce } from 'react-use';
 
 import { CoreApp, type GrafanaTheme2, type PanelProps, type InterpolateFunction } from '@grafana/data';
-import { ScrollContainer, usePanelContext, useStyles2 } from '@grafana/ui';
+import { ScrollContainer, Stack, usePanelContext, useStyles2, useTheme2 } from '@grafana/ui';
 import config from 'app/core/config';
 
-import { type CodeOptions, defaultCodeOptions, defaultOptions, type Options, TextMode } from '../panelcfg.gen';
+import {
+  type CodeOptions,
+  defaultCodeLanguage,
+  defaultCodeOptions,
+  defaultOptions,
+  type Options,
+  TextMode,
+} from '../panelcfg.gen';
 
 import { TextNGCodeView } from './TextNGCodeView';
 import { type TextNGEditorChange } from './editor/TextNGEditor';
+import { getEditorLayoutStyles } from './editor/editorLayout';
 import { getInterpolateFormat, transformContent } from './utils';
 
 const TextNGEditor = lazy(() => import('./editor/TextNGEditor').then((m) => ({ default: m.TextNGEditor })));
@@ -126,19 +134,40 @@ function EditorLoadingFallback({
   options: Options;
   replaceVariables: InterpolateFunction;
 }) {
+  const theme = useTheme2();
+  const layout = useStyles2(getEditorLayoutStyles);
   const content = useMemo(
     () => transformContent(options.mode, interpolateContent(options, replaceVariables), config.disableSanitizeHtml),
     [options, replaceVariables]
   );
+  const isCode = options.mode === TextMode.Code;
 
-  return <TextNGView mode={options.mode} content={content} code={options.code} />;
+  return (
+    <div className={layout.wrapper}>
+      <Stack minHeight={theme.components.height.md} />
+      <div className={layout.body}>
+        <div className={cx(layout.pane, layout.previewPane, !isCode && layout.htmlPreviewPane)}>
+          <TextNGView mode={options.mode} content={content} code={options.code} />
+        </div>
+      </div>
+      {isCode && <Stack minHeight={theme.components.height.md} />}
+    </div>
+  );
 }
 
 function applyEditorChange(options: Options, change: TextNGEditorChange): Options {
-  const { content, mode = options.mode, codeLanguage } = change;
-  const code: CodeOptions | undefined = codeLanguage
-    ? { showLineNumbers: false, showMiniMap: false, ...options.code, language: codeLanguage }
-    : options.code;
+  const { content, mode = options.mode, codeLanguage, showLineNumbers } = change;
+
+  if (codeLanguage === undefined && showLineNumbers === undefined) {
+    return { ...options, content, mode };
+  }
+
+  const code: CodeOptions = {
+    showMiniMap: false,
+    ...options.code,
+    language: codeLanguage ?? options.code?.language ?? defaultCodeLanguage,
+    showLineNumbers: showLineNumbers ?? options.code?.showLineNumbers ?? false,
+  };
 
   return { ...options, content, mode, code };
 }

--- a/public/app/plugins/panel/text/v2/editor/TextNGEditor.test.tsx
+++ b/public/app/plugins/panel/text/v2/editor/TextNGEditor.test.tsx
@@ -7,6 +7,7 @@ import config from 'app/core/config';
 import { CodeLanguage, TextMode } from '../../panelcfg.gen';
 
 import { PREVIEW_TEST_ID, TextNGEditor, type TextNGEditorChange } from './TextNGEditor';
+import { FOOTER_TEST_ID } from './TextNGEditorFooter';
 import { FORMAT_TOOLBAR_TEST_ID } from './TextNGFormatToolbar';
 
 // The real CodeMirrorEditor pulls in a heavy, lazily-loaded CodeMirror bundle;
@@ -36,7 +37,7 @@ jest.mock('@grafana/ui/unstable', () => ({
 function ControlledEditor({
   initialValue,
   mode: initialMode,
-  showLineNumbers = false,
+  showLineNumbers: initialShowLineNumbers = false,
   codeLanguage: initialLanguage,
   replaceVariables = (value: string) => value,
   onChange,
@@ -51,6 +52,7 @@ function ControlledEditor({
   const [value, setValue] = useState(initialValue);
   const [mode, setMode] = useState(initialMode);
   const [codeLanguage, setCodeLanguage] = useState(initialLanguage);
+  const [showLineNumbers, setShowLineNumbers] = useState(initialShowLineNumbers);
   return (
     <TextNGEditor
       content={value}
@@ -65,6 +67,9 @@ function ControlledEditor({
         }
         if (change.codeLanguage !== undefined) {
           setCodeLanguage(change.codeLanguage);
+        }
+        if (change.showLineNumbers !== undefined) {
+          setShowLineNumbers(change.showLineNumbers);
         }
         onChange(change);
       }}
@@ -472,6 +477,47 @@ describe('TextNGEditor', () => {
       await enterWriteMode();
 
       expect(screen.getByRole('textbox')).toHaveAttribute('data-line-numbers', 'false');
+    });
+  });
+
+  describe('footer', () => {
+    const lineNumbersToggle = () => screen.getByRole('switch', { name: 'Line numbers' });
+
+    it('only shows the footer in Code mode', async () => {
+      setup('# Hello', TextMode.Markdown);
+
+      expect(screen.queryByTestId(FOOTER_TEST_ID)).not.toBeInTheDocument();
+
+      await selectLanguage('JSON');
+      expect(screen.getByTestId(FOOTER_TEST_ID)).toBeInTheDocument();
+    });
+
+    it('keeps the footer in Preview view, where the editor is hidden', () => {
+      setup('const a = 1;', TextMode.Code, jest.fn(), false, CodeLanguage.Typescript);
+
+      expect(screen.getByRole('radio', { name: 'Preview' })).toBeChecked();
+      expect(screen.getByTestId(FOOTER_TEST_ID)).toBeInTheDocument();
+    });
+
+    it('turns line numbers on and applies them to the editor', async () => {
+      const { onChange } = setup('const a = 1;', TextMode.Code, jest.fn(), false, CodeLanguage.Typescript);
+      await enterWriteMode();
+
+      await userEvent.click(lineNumbersToggle());
+
+      expect(onChange).toHaveBeenLastCalledWith({ showLineNumbers: true, content: 'const a = 1;' });
+      expect(screen.getByRole('textbox')).toHaveAttribute('data-line-numbers', 'true');
+    });
+
+    it('sends the pending draft with the line numbers change, so typing is not lost', async () => {
+      const { onChange } = setup('const a = 1;', TextMode.Code, jest.fn(), false, CodeLanguage.Typescript);
+      await enterWriteMode();
+
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: 'const b = 2;' } });
+      await userEvent.click(lineNumbersToggle());
+
+      expect(onChange).toHaveBeenLastCalledWith({ showLineNumbers: true, content: 'const b = 2;' });
+      expect(screen.getByRole('textbox')).toHaveValue('const b = 2;');
     });
   });
 });

--- a/public/app/plugins/panel/text/v2/editor/TextNGEditor.tsx
+++ b/public/app/plugins/panel/text/v2/editor/TextNGEditor.tsx
@@ -13,7 +13,9 @@ import { CodeLanguage, defaultCodeLanguage, TextMode } from '../../panelcfg.gen'
 import { TextNGCodeView } from '../TextNGCodeView';
 import { getInterpolateFormat, transformContent, getCodeMirrorLanguage } from '../utils';
 
+import { TextNGEditorFooter } from './TextNGEditorFooter';
 import { TextNGFormatToolbar } from './TextNGFormatToolbar';
+import { getEditorLayoutStyles } from './editorLayout';
 
 type ViewMode = 'write' | 'split' | 'preview';
 
@@ -24,6 +26,7 @@ export interface TextNGEditorChange {
   content: string;
   mode?: TextMode;
   codeLanguage?: CodeLanguage;
+  showLineNumbers?: boolean;
 }
 
 export interface TextNGEditorProps {
@@ -192,17 +195,18 @@ export function TextNGEditor({
   );
 
   const showEditor = view !== 'preview';
+  const isCode = mode === TextMode.Code;
 
   const renderOutput = (testId: string) =>
-    mode === TextMode.Code ? (
-      <div className={styles.codeView} data-testid={testId}>
+    isCode ? (
+      <div className={styles.fullHeight} data-testid={testId}>
         <TextNGCodeView content={interpolatedContent} language={codeLanguage} showLineNumbers={showLineNumbers} />
       </div>
     ) : (
       <DangerouslySetHtmlContent
         allowRerender
         html={previewHtml}
-        className={cx('markdown-html', styles.markdownHtml)}
+        className={cx('markdown-html', styles.fullHeight)}
         data-testid={testId}
       />
     );
@@ -245,21 +249,25 @@ export function TextNGEditor({
             />
           </div>
         )}
-        {showPreview && <div className={cx(styles.pane, styles.previewPane)}>{renderOutput(PREVIEW_TEST_ID)}</div>}
+        {showPreview && (
+          <div className={cx(styles.pane, styles.previewPane, !isCode && styles.htmlPreviewPane)}>
+            {renderOutput(PREVIEW_TEST_ID)}
+          </div>
+        )}
       </div>
+
+      {isCode && (
+        <TextNGEditorFooter
+          showLineNumbers={showLineNumbers}
+          onShowLineNumbersChange={(next) => changeOption({ showLineNumbers: next })}
+        />
+      )}
     </div>
   );
 }
 
 const getStyles = (theme: GrafanaTheme2) => ({
-  wrapper: css({
-    label: 'textNGEditor',
-    display: 'flex',
-    flexDirection: 'column',
-    gap: theme.spacing(1),
-    width: '100%',
-    height: '100%',
-  }),
+  ...getEditorLayoutStyles(theme),
   modePicker: css({
     marginLeft: 'auto',
   }),
@@ -269,41 +277,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   pickerLabel: css({
     color: theme.colors.text.secondary,
   }),
-  body: css({
-    display: 'flex',
-    flex: 1,
-    width: '100%',
-    minHeight: 0,
-  }),
-  splitBody: css({
-    gap: theme.spacing(1),
-  }),
-  pane: css({
-    flex: 1,
-    minWidth: 0,
-    overflow: 'hidden',
-    border: `1px solid ${theme.colors.border.weak}`,
-    borderRadius: theme.shape.radius.default,
-  }),
-  editorPane: css({
-    display: 'flex',
-    flexDirection: 'column',
-    // Give CodeMirror a bounded height so it scrolls internally instead of growing.
-    '& > *': {
-      flex: 1,
-      minHeight: 0,
-      overflow: 'auto',
-    },
-  }),
-  previewPane: css({
-    overflow: 'auto',
-    padding: theme.spacing(1, 2),
-    background: theme.colors.background.primary,
-  }),
-  markdownHtml: css({
-    height: '100%',
-  }),
-  codeView: css({
+  fullHeight: css({
     height: '100%',
   }),
 });

--- a/public/app/plugins/panel/text/v2/editor/TextNGEditorFooter.test.tsx
+++ b/public/app/plugins/panel/text/v2/editor/TextNGEditorFooter.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { TextNGEditorFooter } from './TextNGEditorFooter';
+
+const setup = (showLineNumbers: boolean) => {
+  const onShowLineNumbersChange = jest.fn();
+  render(<TextNGEditorFooter showLineNumbers={showLineNumbers} onShowLineNumbersChange={onShowLineNumbersChange} />);
+  return { onShowLineNumbersChange, toggle: screen.getByRole('switch', { name: 'Line numbers' }) };
+};
+
+describe('TextNGEditorFooter', () => {
+  it('checks the toggle when line numbers are on', () => {
+    expect(setup(true).toggle).toBeChecked();
+  });
+
+  it('unchecks the toggle when line numbers are off', () => {
+    expect(setup(false).toggle).not.toBeChecked();
+  });
+
+  it.each([true, false])('toggles line numbers when they are %s', async (showLineNumbers) => {
+    const { onShowLineNumbersChange, toggle } = setup(showLineNumbers);
+
+    await userEvent.click(toggle);
+
+    expect(onShowLineNumbersChange).toHaveBeenCalledWith(!showLineNumbers);
+  });
+});

--- a/public/app/plugins/panel/text/v2/editor/TextNGEditorFooter.tsx
+++ b/public/app/plugins/panel/text/v2/editor/TextNGEditorFooter.tsx
@@ -1,0 +1,41 @@
+import { css } from '@emotion/css';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { InlineSwitch, Stack, useStyles2, useTheme2 } from '@grafana/ui';
+
+export const FOOTER_TEST_ID = 'TextNGEditor-footer';
+
+export interface TextNGEditorFooterProps {
+  showLineNumbers: boolean;
+  onShowLineNumbersChange: (showLineNumbers: boolean) => void;
+}
+
+export function TextNGEditorFooter({ showLineNumbers, onShowLineNumbersChange }: TextNGEditorFooterProps) {
+  const theme = useTheme2();
+  const styles = useStyles2(getStyles);
+
+  return (
+    <Stack
+      justifyContent="flex-end"
+      alignItems="center"
+      minHeight={theme.components.height.md}
+      data-testid={FOOTER_TEST_ID}
+    >
+      <InlineSwitch
+        className={styles.lineNumbers}
+        showLabel
+        transparent
+        label={t('textng.editor.footer-line-numbers', 'Line numbers')}
+        value={showLineNumbers}
+        onChange={() => onShowLineNumbersChange(!showLineNumbers)}
+      />
+    </Stack>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  lineNumbers: css({
+    fontSize: theme.typography.size.sm,
+  }),
+});

--- a/public/app/plugins/panel/text/v2/editor/editorLayout.ts
+++ b/public/app/plugins/panel/text/v2/editor/editorLayout.ts
@@ -1,0 +1,61 @@
+import { css } from '@emotion/css';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+
+/** Shared by the editor and the fallback shown while its lazy chunk loads, so content does not shift when it mounts. */
+export const getEditorLayoutStyles = (theme: GrafanaTheme2) => {
+  // Padding CodeMirror's own content instead of the pane keeps the raw text
+  // aligned with the rendered preview when switching views.
+  const codeMirrorPadding = {
+    '.cm-content': { padding: theme.spacing(1, 0) },
+    '.cm-line': { padding: theme.spacing(0, 2) },
+    '.cm-gutters': { paddingLeft: theme.spacing(1) },
+  };
+
+  return {
+    wrapper: css({
+      label: 'textNGEditor',
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(1),
+      width: '100%',
+      height: '100%',
+    }),
+    body: css({
+      display: 'flex',
+      flex: 1,
+      width: '100%',
+      minHeight: 0,
+    }),
+    splitBody: css({
+      gap: theme.spacing(1),
+    }),
+    pane: css({
+      flex: 1,
+      minWidth: 0,
+      overflow: 'hidden',
+      border: `1px solid ${theme.colors.border.weak}`,
+      borderRadius: theme.shape.radius.default,
+    }),
+    editorPane: css({
+      display: 'flex',
+      flexDirection: 'column',
+      // Give CodeMirror a bounded height so it scrolls internally instead of growing.
+      '& > *': {
+        flex: 1,
+        minHeight: 0,
+        overflow: 'auto',
+      },
+      ...codeMirrorPadding,
+    }),
+    previewPane: css({
+      overflow: 'auto',
+      background: theme.colors.background.primary,
+      ...codeMirrorPadding,
+    }),
+    // Rendered markdown and HTML bring no padding of their own.
+    htmlPreviewPane: css({
+      padding: theme.spacing(1, 2),
+    }),
+  };
+};

--- a/public/app/plugins/panel/text/v2/module.tsx
+++ b/public/app/plugins/panel/text/v2/module.tsx
@@ -1,7 +1,7 @@
 import { PanelPlugin } from '@grafana/data';
 import { t } from '@grafana/i18n';
 
-import { defaultCodeOptions, defaultOptions, type Options, TextMode } from '../panelcfg.gen';
+import { defaultCodeOptions, defaultOptions, type Options } from '../panelcfg.gen';
 
 import { TextNGPanel } from './TextNGPanel';
 import { textPanelMigrationHandler } from './textPanelMigrationHandler';
@@ -9,43 +9,24 @@ import { textPanelMigrationHandler } from './textPanelMigrationHandler';
 export const plugin = new PanelPlugin<Options>(TextNGPanel)
   .setPanelOptions((builder) => {
     const category = [t('textng.category-text', 'Text')];
-    builder
-      // Mode and code language are edited in the panel toolbar; they stay
-      // registered here only so their defaults are applied.
-      .addCustomEditor({
-        id: 'mode',
-        path: 'mode',
+
+    // Everything is edited in the panel itself, so options are registered here
+    // only so their defaults are applied.
+    const addHiddenOption = <T,>(path: string, defaultValue: T) =>
+      builder.addCustomEditor({
+        id: path,
+        path,
         name: '',
         category,
         editor: () => null,
-        defaultValue: defaultOptions.mode,
-        showIf: () => false,
-      })
-      .addCustomEditor({
-        id: 'code.language',
-        path: 'code.language',
-        name: '',
-        category,
-        editor: () => null,
-        defaultValue: defaultCodeOptions.language,
-        showIf: () => false,
-      })
-      .addBooleanSwitch({
-        path: 'code.showLineNumbers',
-        name: t('textng.name-show-line-numbers', 'Show line numbers'),
-        category,
-        defaultValue: defaultCodeOptions.showLineNumbers,
-        showIf: (v) => v.mode === TextMode.Code,
-      })
-      .addCustomEditor({
-        id: 'content',
-        path: 'content',
-        name: '',
-        category,
-        editor: () => null,
-        defaultValue: defaultOptions.content,
+        defaultValue,
         showIf: () => false,
       });
+
+    addHiddenOption('mode', defaultOptions.mode);
+    addHiddenOption('content', defaultOptions.content);
+    addHiddenOption('code.language', defaultCodeOptions.language);
+    addHiddenOption('code.showLineNumbers', defaultCodeOptions.showLineNumbers);
   })
   .setMigrationHandler(textPanelMigrationHandler)
   .setSuggestionsSupplier(() => []);

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -15938,6 +15938,7 @@
     "editor": {
       "aria-label-content": "Text content",
       "aria-label-mode": "Text mode: {{mode}}",
+      "footer-line-numbers": "Line numbers",
       "format-bold": "B",
       "format-heading": "H",
       "format-italic": "I",
@@ -15958,8 +15959,7 @@
       "view-preview": "Preview",
       "view-split": "Split",
       "view-write": "Write"
-    },
-    "name-show-line-numbers": "Show line numbers"
+    }
   },
   "theme-playground": {
     "label-base-theme": "Base theme",


### PR DESCRIPTION
This PR:

- Adds a footer for code
- Moves the `Line numbers` options to the footer
- Adds some styling to avoid the editor moving due to the top toolbar loading after the editor.

https://github.com/user-attachments/assets/069c43ac-9c5c-42f7-bb16-4af4dcdb9821


Fixes https://github.com/grafana/grafana/issues/129980

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
