### PR TITLE
Theming: Make theme flags type generic record

### DIFF
--- a/packages/grafana-data/src/themes/types.ts
+++ b/packages/grafana-data/src/themes/types.ts
@@ -34,7 +34,12 @@ export interface GrafanaTheme2 {
   /** @deprecated Will be removed in a future version */
   v1: GrafanaTheme;
   /** feature flags that might impact component looks */
-  flags: Record<string, boolean>;
+  flags: {
+    /**
+     * @internal
+     */
+    visualDesignRefresh?: boolean;
+  } & Record<string, boolean>;
 }
 
 export const ThemeRichColorInputSchema = z.object({

--- a/packages/grafana-data/src/themes/types.ts
+++ b/packages/grafana-data/src/themes/types.ts
@@ -39,7 +39,7 @@ export interface GrafanaTheme2 {
      * @internal
      */
     visualDesignRefresh?: boolean;
-  } & Record<string, boolean>;
+  } & Record<string, boolean | undefined>;
 }
 
 export const ThemeRichColorInputSchema = z.object({

--- a/packages/grafana-data/src/themes/types.ts
+++ b/packages/grafana-data/src/themes/types.ts
@@ -34,12 +34,7 @@ export interface GrafanaTheme2 {
   /** @deprecated Will be removed in a future version */
   v1: GrafanaTheme;
   /** feature flags that might impact component looks */
-  flags: {
-    /**
-     * @internal
-     */
-    visualDesignRefresh?: boolean;
-  };
+  flags: Record<string, boolean>;
 }
 
 export const ThemeRichColorInputSchema = z.object({


### PR DESCRIPTION
**What is this feature?**

Updates the typing for `theme.flags` to be a generic record of booleans.

**Why do we need this feature?**

Very open to being told this isn't a good idea, but I think this would be a good move to future-proof against any other flags that may be used down the road. Plugins currently can't use the `visualDesignRefresh` flag as it doesn't exist in typings for a released version of the `@grafana/data` package (it'll be in 13.2) -- if this had already been a generic type it would've been accessible already, and so, if it becomes a generic type now, then any future flags will be immediately accessible to plugins due to the generic type.

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
