### PR TITLE
Table: rows-as-fields (pivoted) render mode

### DIFF
--- a/packages/grafana-schema/src/common/common.gen.ts
+++ b/packages/grafana-schema/src/common/common.gen.ts
@@ -1056,6 +1056,10 @@ export interface TableOptions {
    */
   pageSize?: number;
   /**
+   * If true, renders each field as a row (pivoted); column one is a frozen field-name column. Header, sorting, filtering, and footers are disabled in this mode.
+   */
+  rowsAsFields?: boolean;
+  /**
    * Controls whether the panel should show the header
    */
   showHeader: boolean;
@@ -1072,6 +1076,7 @@ export interface TableOptions {
 export const defaultTableOptions: Partial<TableOptions> = {
   cellHeight: TableCellHeight.Sm,
   frameIndex: 0,
+  rowsAsFields: false,
   showHeader: true,
   showTypeIcons: false,
   sortBy: [],

--- a/packages/grafana-schema/src/common/table.cue
+++ b/packages/grafana-schema/src/common/table.cue
@@ -132,6 +132,8 @@ TableOptions: {
 	frozenColumns?: {
 		left?: number | *0
 	}
+	// If true, renders each field as a row (pivoted); column one is a frozen field-name column. Header, sorting, filtering, and footers are disabled in this mode.
+	rowsAsFields?: bool | *false
 	// If true, disables all keyboard events in the table. this is used when previewing a table (i.e. suggestions)
 	disableKeyboardEvents?: bool
 } @cuetsy(kind="interface")

--- a/packages/grafana-schema/src/raw/composable/table/panelcfg/x/types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/table/panelcfg/x/types.gen.ts
@@ -49,6 +49,10 @@ export interface Options {
    */
   pageSize?: number;
   /**
+   * If true, renders each field as a row (pivoted); column one is a frozen field-name column. Header, sorting, filtering, and footers are disabled in this mode.
+   */
+  rowsAsFields?: boolean;
+  /**
    * Controls whether the panel should show the header
    */
   showHeader: boolean;
@@ -65,6 +69,7 @@ export interface Options {
 export const defaultOptions: Partial<Options> = {
   cellHeight: ui.TableCellHeight.Sm,
   frameIndex: 0,
+  rowsAsFields: false,
   showHeader: true,
   showTypeIcons: false,
   sortBy: [],

--- a/packages/grafana-ui/src/components/Table/TableNG/refactored/RefactoredTableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/refactored/RefactoredTableNG.tsx
@@ -10,6 +10,7 @@ import { type TableNGProps } from '../types';
 
 import { TableFlat } from './TableFlat';
 import { TableNested } from './TableNested';
+import { TableRowsAsFields } from './TableRowsAsFields';
 
 // Safari 26 shipped with a bug that prevents the table from rendering correctly
 // unless it is wrapped in a container with `contain: strict`.
@@ -26,6 +27,8 @@ export function RefactoredTableNG(props: TableNGProps) {
 
   const inner = nestedDataField ? (
     <TableNested {...props} nestedFramesField={nestedDataField} />
+  ) : props.rowsAsFields ? (
+    <TableRowsAsFields {...props} />
   ) : (
     <TableFlat {...props} />
   );

--- a/packages/grafana-ui/src/components/Table/TableNG/refactored/TableRowsAsFields.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/refactored/TableRowsAsFields.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen } from '@testing-library/react';
+
+import {
+  applyFieldOverrides,
+  createTheme,
+  type DataFrame,
+  FieldType,
+  type FieldConfigSource,
+  toDataFrame,
+} from '@grafana/data';
+
+import { type TableNGProps } from '../types';
+
+import { RefactoredTableNG } from './RefactoredTableNG';
+
+const withOverrides = (frame: ReturnType<typeof toDataFrame>, fieldConfig?: FieldConfigSource): DataFrame =>
+  applyFieldOverrides({
+    data: [frame],
+    fieldConfig: fieldConfig ?? { defaults: {}, overrides: [] },
+    replaceVariables: (value) => value,
+    timeZone: 'utc',
+    theme: createTheme(),
+  })[0];
+
+const createFrame = (fieldConfig?: FieldConfigSource): DataFrame =>
+  withOverrides(
+    toDataFrame({
+      name: 'TestData',
+      length: 3,
+      fields: [
+        { name: 'Column A', type: FieldType.string, values: ['A1', 'A2', 'A3'], config: { custom: {} } },
+        { name: 'Column B', type: FieldType.number, values: [1, 2, 3], config: { custom: {} } },
+      ],
+    }),
+    fieldConfig
+  );
+
+const renderTable = (data: DataFrame, extra?: Partial<TableNGProps>) =>
+  render(
+    <RefactoredTableNG rowsAsFields enableVirtualization={false} data={data} width={800} height={600} {...extra} />
+  );
+
+describe('TableRowsAsFields', () => {
+  let origResizeObserver = global.ResizeObserver;
+  let origScrollIntoView = window.HTMLElement.prototype.scrollIntoView;
+
+  beforeEach(() => {
+    origResizeObserver = global.ResizeObserver;
+    origScrollIntoView = window.HTMLElement.prototype.scrollIntoView;
+    global.ResizeObserver = class ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+    window.HTMLElement.prototype.scrollIntoView = jest.fn();
+  });
+
+  afterEach(() => {
+    global.ResizeObserver = origResizeObserver;
+    window.HTMLElement.prototype.scrollIntoView = origScrollIntoView;
+  });
+
+  it('renders one row per field with the field name in the frozen first column', () => {
+    const { container } = renderTable(createFrame());
+
+    expect(container.querySelector('[role="grid"]')).toBeInTheDocument();
+
+    // One row per field (2 fields), each with a name cell + 3 value cells = 8 cells.
+    const cells = container.querySelectorAll('[role="gridcell"]');
+    expect(cells.length).toBe(8);
+
+    // Field names appear as the row labels in column one.
+    expect(screen.getByText('Column A')).toBeInTheDocument();
+    expect(screen.getByText('Column B')).toBeInTheDocument();
+  });
+
+  it('lays each field out across the value columns (transposed)', () => {
+    renderTable(createFrame());
+
+    // Column A's values run along its row.
+    ['A1', 'A2', 'A3'].forEach((v) => expect(screen.getByText(v)).toBeInTheDocument());
+    // Column B's values run along its row.
+    ['1', '2', '3'].forEach((v) => expect(screen.getByText(v)).toBeInTheDocument());
+  });
+
+  it('renders no header row (header collapsed to 0px)', () => {
+    const { container } = renderTable(createFrame());
+
+    const grid = container.querySelector('[role="grid"]');
+    expect(grid).toBeInTheDocument();
+    // react-data-grid always keeps a header row element, but in this mode it is collapsed to 0px and
+    // hidden — the same treatment the `noHeader` option gives, so no header is shown to the user.
+    expect(window.getComputedStyle(grid!).getPropertyValue('--rdg-header-row-height')).toBe('0px');
+  });
+
+  it('never renders a footer, even when a field configures footer reducers', () => {
+    const frame = createFrame();
+    const withFooter = {
+      ...frame,
+      fields: frame.fields.map((field) => ({
+        ...field,
+        config: { ...field.config, custom: { ...field.config.custom, footer: { reducers: ['sum'] } } },
+      })),
+    };
+
+    const { container } = renderTable(withFooter);
+
+    expect(container.querySelector('.rdg-summary-row')).not.toBeInTheDocument();
+  });
+
+  it('does not render sort or filter affordances', () => {
+    const { container } = renderTable(createFrame());
+
+    // Columns are not sortable and the header is hidden, so there is no sort state and no
+    // sort/filter buttons in the (collapsed) header row.
+    expect(container.querySelector('[aria-sort]')).not.toBeInTheDocument();
+    container.querySelectorAll('[role="columnheader"]').forEach((header) => {
+      expect(header.querySelector('button')).not.toBeInTheDocument();
+    });
+  });
+
+  it('applies field overrides to the row (renamed field shows as the row label)', () => {
+    // The field-override pipeline delivers a renamed field as `field.state.displayName`; getDisplayName
+    // reads it, so an override surfaces on the field's ROW label rather than on a column header.
+    const data = createFrame();
+    data.fields[1].state = { ...data.fields[1].state, displayName: 'Renamed B' };
+
+    renderTable(data);
+
+    expect(screen.getByText('Renamed B')).toBeInTheDocument();
+    expect(screen.queryByText('Column B')).not.toBeInTheDocument();
+  });
+});

--- a/packages/grafana-ui/src/components/Table/TableNG/refactored/TableRowsAsFields.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/refactored/TableRowsAsFields.tsx
@@ -1,0 +1,288 @@
+import { clsx } from 'clsx';
+import { type CSSProperties, type JSX, useCallback, useMemo, useRef } from 'react';
+
+import { FALLBACK_COLOR, FieldColorModeId, type Field, FieldType, getDisplayProcessor } from '@grafana/data';
+import { Cell, type DataGridHandle, type DataGridProps, type RenderCellProps } from '@grafana/react-data-grid';
+import { TableCellDisplayMode } from '@grafana/schema';
+
+import { useTheme2 } from '../../../../themes/ThemeContext';
+import { getTextColorForBackground } from '../../../../utils/colors';
+import { usePanelContext } from '../../../PanelChrome';
+import { getCellRenderer, getCellSpecificStyles } from '../Cells/renderers';
+import { COLUMN, TABLE } from '../constants';
+import { getDefaultCellStyles, getLinkStyles } from '../styles';
+import {
+  type CellRootRenderer,
+  type GetActionsFunctionLocal,
+  type TableColumn,
+  type TableNGProps,
+  type TableRow,
+  type TableSummaryRow,
+} from '../types';
+import {
+  canFieldBeColorized,
+  displayJsonValue,
+  getAlignment,
+  getCellColorInlineStylesFactory,
+  getCellOptions,
+  getDefaultRowHeight,
+  getDisplayName,
+  getVisibleFields,
+  shouldTextWrap,
+} from '../utils';
+
+import { TableDataGrid } from './TableDataGrid';
+import { useDataGridRows } from './render-hooks';
+
+// Key of the frozen field-name column. It is not a numeric value-column index, so it can never
+// collide with one.
+const FIELD_NAME_COL_KEY = '__fieldName';
+
+// Rows-as-fields does not resolve links/actions per cell yet, so cells never surface actions.
+const NOOP_GET_ACTIONS: GetActionsFunctionLocal = () => [];
+const EMPTY_EXPANDED_ROWS: Set<string> = new Set();
+const NOOP_STABLE_KEY = () => '';
+const NOOP = () => {};
+
+// Precomputed per-field rendering info. In this mode each row is a field, so the renderer, cell
+// options, colorization and styles are resolved once per field and indexed by row.__index at
+// render time — keeping cost O(fields) rather than O(fields * values).
+interface FieldRenderInfo {
+  field: Field;
+  cellOptions: ReturnType<typeof getCellOptions>;
+  cellType: TableCellDisplayMode;
+  CellType: ReturnType<typeof getCellRenderer>;
+  canBeColorized: boolean;
+  cellParentStyles: string;
+  cellSpecificStyles: string | undefined;
+}
+
+/**
+ * Renders a table in "rows as fields" (pivoted) mode: each visible field becomes a row, column one
+ * is a frozen list of field display names, and the remaining columns are the field values indexed by
+ * the original row. Cell rendering and field overrides resolve per-row (from the field), so overrides
+ * apply to the row. Header, sorting, filtering, and footers are intentionally disabled in this mode.
+ */
+export function TableRowsAsFields(props: TableNGProps) {
+  const {
+    cellHeight,
+    data,
+    disableKeyboardEvents,
+    disableSanitizeHtml,
+    enableVirtualization,
+    noValue,
+    timeRange,
+    transparent,
+    width,
+  } = props;
+
+  const theme = useTheme2();
+  const panelContext = usePanelContext();
+  const gridRef = useRef<DataGridHandle>(null);
+
+  const visibleFields = useMemo(() => getVisibleFields(data.fields), [data.fields]);
+  const getCellColorInlineStyles = useMemo(() => getCellColorInlineStylesFactory(theme), [theme]);
+
+  // One row per field.
+  const rows = useMemo<TableRow[]>(
+    () => visibleFields.map((_, index) => ({ __index: index, __depth: 0 })),
+    [visibleFields]
+  );
+
+  const fieldInfos = useMemo<FieldRenderInfo[]>(
+    () =>
+      visibleFields.map((original) => {
+        let field = original;
+        const cellOptions = getCellOptions(field);
+        const cellType = cellOptions.type;
+
+        // attach JSONCell custom display function to JSONView / other cell types
+        if (cellType === TableCellDisplayMode.JSONView || field.type === FieldType.other) {
+          field = { ...field };
+          field.display = displayJsonValue(field);
+        }
+
+        // pill cells with mappings ignore thresholds and use the single-color calculator
+        if (cellType === TableCellDisplayMode.Pill && (field.config.mappings?.length ?? 0) > 0) {
+          field = {
+            ...field,
+            config: {
+              ...field.config,
+              color: {
+                ...field.config.color,
+                mode: FieldColorModeId.Fixed,
+                fixedColor: field.config.color?.fixedColor ?? FALLBACK_COLOR,
+              },
+            },
+          };
+          field.display = getDisplayProcessor({ field, theme });
+        }
+
+        const textAlign = getAlignment(field);
+        const styleOptions = { textAlign, textWrap: shouldTextWrap(field), shouldOverflow: false };
+        const canBeColorized = canFieldBeColorized(cellType);
+
+        return {
+          field,
+          cellOptions,
+          cellType,
+          CellType: getCellRenderer(field, cellOptions),
+          canBeColorized,
+          cellParentStyles: clsx(getDefaultCellStyles(theme, styleOptions), getLinkStyles(theme, canBeColorized)),
+          cellSpecificStyles: getCellSpecificStyles(cellType, field, theme, styleOptions),
+        };
+      }),
+    [visibleFields, theme]
+  );
+
+  // Number of value columns = number of original rows.
+  const valueColCount = data.length ?? visibleFields[0]?.values.length ?? 0;
+
+  const rowHeight = getDefaultRowHeight(theme, undefined, cellHeight);
+  const rowHeightPx = typeof rowHeight === 'number' ? rowHeight : TABLE.MAX_CELL_HEIGHT;
+
+  const { nameColWidth, valueColWidth } = useMemo(() => {
+    const longestName = visibleFields.reduce((max, field) => Math.max(max, getDisplayName(field).length), 0);
+    const nameWidth = Math.min(300, Math.max(COLUMN.MIN_WIDTH, longestName * 8 + 2 * TABLE.CELL_PADDING + 16));
+    const remaining = width - nameWidth;
+    const valueWidth =
+      valueColCount > 0 && remaining > 0
+        ? Math.max(COLUMN.MIN_WIDTH, Math.floor(remaining / valueColCount))
+        : COLUMN.DEFAULT_WIDTH;
+    return { nameColWidth: nameWidth, valueColWidth: valueWidth };
+  }, [visibleFields, valueColCount, width]);
+
+  const columns = useMemo<TableColumn[]>(() => {
+    const placeholderField = visibleFields[0];
+
+    const nameColumn: TableColumn = {
+      key: FIELD_NAME_COL_KEY,
+      name: '',
+      field: placeholderField,
+      width: nameColWidth,
+      minWidth: COLUMN.MIN_WIDTH,
+      frozen: true,
+      sortable: false,
+      renderCell: ({ row }) => <>{getDisplayName(visibleFields[row.__index])}</>,
+    };
+
+    const valueColumns: TableColumn[] = Array.from({ length: valueColCount }, (_, colIdx) => ({
+      key: String(colIdx),
+      name: '',
+      field: placeholderField,
+      width: valueColWidth,
+      minWidth: COLUMN.MIN_WIDTH,
+      frozen: false,
+      sortable: false,
+      renderCell: (cellProps: RenderCellProps<TableRow, TableSummaryRow>): JSX.Element => {
+        const info = fieldInfos[cellProps.row.__index];
+        if (info == null) {
+          return <></>;
+        }
+        const CellType = info.CellType;
+        return (
+          <CellType
+            cellOptions={info.cellOptions}
+            frame={data}
+            field={info.field}
+            height={rowHeightPx}
+            rowIdx={colIdx}
+            theme={theme}
+            value={info.field.values[colIdx]}
+            width={valueColWidth}
+            timeRange={timeRange}
+            cellInspect={false}
+            showFilters={false}
+            getActions={NOOP_GET_ACTIONS}
+            disableSanitizeHtml={disableSanitizeHtml}
+            getTextColorForBackground={getTextColorForBackground}
+          />
+        );
+      },
+    }));
+
+    return [nameColumn, ...valueColumns];
+  }, [
+    visibleFields,
+    fieldInfos,
+    valueColCount,
+    nameColWidth,
+    valueColWidth,
+    rowHeightPx,
+    data,
+    theme,
+    timeRange,
+    disableSanitizeHtml,
+  ]);
+
+  const renderRow = useDataGridRows(data.fields, panelContext, EMPTY_EXPANDED_ROWS, false, NOOP_STABLE_KEY);
+
+  const renderCellRoot = useCallback<CellRootRenderer>(
+    (key, cellProps) => {
+      const info = fieldInfos[cellProps.row.__index];
+      if (cellProps.column.key === FIELD_NAME_COL_KEY || info == null) {
+        return <Cell key={key} {...cellProps} />;
+      }
+
+      const style: CSSProperties = {};
+      if (info.canBeColorized && info.field.display != null) {
+        const colIdx = Number(cellProps.column.key);
+        const displayValue = info.field.display(info.field.values[colIdx]);
+        Object.assign(style, getCellColorInlineStyles(info.cellOptions, displayValue, false));
+      }
+
+      return (
+        <Cell
+          key={key}
+          {...cellProps}
+          className={clsx(cellProps.className, info.cellParentStyles, info.cellSpecificStyles)}
+          style={style}
+        />
+      );
+    },
+    [fieldInfos, getCellColorInlineStyles]
+  );
+
+  const onCellKeyDown: NonNullable<DataGridProps<TableRow, TableSummaryRow>['onCellKeyDown']> = useCallback(
+    (_args, event) => {
+      if (disableKeyboardEvents) {
+        event.preventGridDefault();
+      }
+    },
+    [disableKeyboardEvents]
+  );
+
+  return (
+    <TableDataGrid
+      role="grid"
+      gridRef={gridRef}
+      columns={columns}
+      rows={rows}
+      noValue={noValue}
+      renderers={{ renderRow, renderCell: renderCellRoot }}
+      onCellClick={NOOP}
+      onCellKeyDown={onCellKeyDown}
+      sortColumns={[]}
+      setSortColumns={NOOP}
+      rowHeight={rowHeight}
+      enableVirtualization={enableVirtualization}
+      hasFooter={false}
+      footerHeight={0}
+      noHeader={true}
+      headerHeight={0}
+      transparent={transparent}
+      sortedRows={rows}
+      enablePagination={false}
+      numRows={rows.length}
+      page={0}
+      setPage={NOOP}
+      numPages={1}
+      pageRangeStart={0}
+      pageRangeEnd={rows.length}
+      smallPagination={false}
+      onTooltipClose={NOOP}
+      inspectCell={null}
+      onInspectCellDismiss={NOOP}
+    />
+  );
+}

--- a/packages/grafana-ui/src/components/Table/TableNG/types.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/types.ts
@@ -149,6 +149,9 @@ interface BaseTableProps {
   disableKeyboardEvents?: boolean;
   // temporary feature toggle to manage rollout of the refactored nested-table implementation
   nestedRefactorEnabled?: boolean;
+  // renders each field as a row (pivoted); column one is a frozen field-name column. gated behind the
+  // table.rowsAsFields feature toggle. header, sorting, filtering, and footers are disabled in this mode.
+  rowsAsFields?: boolean;
 }
 
 /* ---------------------------- Table cell props ---------------------------- */

--- a/public/app/features/panel/table/addTableCustomPanelOptions.ts
+++ b/public/app/features/panel/table/addTableCustomPanelOptions.ts
@@ -10,10 +10,23 @@ export const addTableCustomPanelOptions = <O extends TableOptions>(builder: Pane
   const category = [t('table.category-table', 'Table')];
   builder
     .addBooleanSwitch({
+      path: 'rowsAsFields',
+      name: t('table.name-rows-as-fields', 'Rows as fields'),
+      description: t(
+        'table.description-rows-as-fields',
+        'Render each field as a row (pivoted). The first column is a frozen list of field names. Header, sorting, filtering, and footers are disabled in this mode.'
+      ),
+      category,
+      defaultValue: defaultTableOptions.rowsAsFields,
+      // React-only feature toggle, so it is not on config.featureToggles and must be read via the OpenFeature client
+      showIf: () => getFeatureFlagClient().getBooleanValue(FlagKeys.TableRowsAsFields, false),
+    })
+    .addBooleanSwitch({
       path: 'showHeader',
       name: t('table.name-show-table-header', 'Show table header'),
       category,
       defaultValue: defaultTableOptions.showHeader,
+      showIf: (opts) => !opts.rowsAsFields,
     })
     .addNumberInput({
       path: 'frozenColumns.left',
@@ -23,6 +36,7 @@ export const addTableCustomPanelOptions = <O extends TableOptions>(builder: Pane
         placeholder: t('table.placeholder-frozen-columns', 'none'),
       },
       category,
+      showIf: (opts) => !opts.rowsAsFields,
     })
     .addRadio({
       path: 'cellHeight',

--- a/public/app/features/panel/table/addTableCustomPanelOptions.ts
+++ b/public/app/features/panel/table/addTableCustomPanelOptions.ts
@@ -1,10 +1,24 @@
-import { type PanelOptionsEditorBuilder } from '@grafana/data';
+import { type DataFrame, FieldType, type PanelOptionsEditorBuilder } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 import { TableCellHeight, type TableOptions } from '@grafana/schema';
 import { defaultOptions as defaultTableOptions } from '@grafana/schema/dist/esm/raw/composable/table/panelcfg/x/TablePanelCfg_types.gen';
 
 import { PaginationEditor } from './PaginationEditor';
+
+// Nested frames route to the nested table, which is mutually exclusive with rows-as-fields. We don't
+// pivot nested data (that would mean inventing nested columns), so treat rows-as-fields as unavailable
+// whenever any frame carries a nested-frames field.
+const hasNestedFrames = (data?: DataFrame[]): boolean =>
+  data?.some((frame) => frame.fields.some((field) => field.type === FieldType.nestedFrames)) ?? false;
+
+// Whether the rows-as-fields render path is actually in effect: the toggle is on, the option is set,
+// and the data is not nested. Editors that rows-as-fields disables (frozen columns, header) key off
+// this so they stay visible when the table still renders normally (e.g. nested data, or toggle off).
+const rowsAsFieldsActive = (opts: TableOptions, data?: DataFrame[]): boolean =>
+  Boolean(opts.rowsAsFields) &&
+  !hasNestedFrames(data) &&
+  getFeatureFlagClient().getBooleanValue(FlagKeys.TableRowsAsFields, false);
 
 export const addTableCustomPanelOptions = <O extends TableOptions>(builder: PanelOptionsEditorBuilder<O>) => {
   const category = [t('table.category-table', 'Table')];
@@ -18,15 +32,17 @@ export const addTableCustomPanelOptions = <O extends TableOptions>(builder: Pane
       ),
       category,
       defaultValue: defaultTableOptions.rowsAsFields,
-      // React-only feature toggle, so it is not on config.featureToggles and must be read via the OpenFeature client
-      showIf: () => getFeatureFlagClient().getBooleanValue(FlagKeys.TableRowsAsFields, false),
+      // React-only feature toggle (not on config.featureToggles, read via the OpenFeature client). Also
+      // hidden when nested frames are present, since those render as a nested table, not a pivoted one.
+      showIf: (_opts, data) =>
+        getFeatureFlagClient().getBooleanValue(FlagKeys.TableRowsAsFields, false) && !hasNestedFrames(data),
     })
     .addBooleanSwitch({
       path: 'showHeader',
       name: t('table.name-show-table-header', 'Show table header'),
       category,
       defaultValue: defaultTableOptions.showHeader,
-      showIf: (opts) => !opts.rowsAsFields,
+      showIf: (opts, data) => !rowsAsFieldsActive(opts, data),
     })
     .addNumberInput({
       path: 'frozenColumns.left',
@@ -36,7 +52,7 @@ export const addTableCustomPanelOptions = <O extends TableOptions>(builder: Pane
         placeholder: t('table.placeholder-frozen-columns', 'none'),
       },
       category,
-      showIf: (opts) => !opts.rowsAsFields,
+      showIf: (opts, data) => !rowsAsFieldsActive(opts, data),
     })
     .addRadio({
       path: 'cellHeight',

--- a/public/app/features/table/hooks.ts
+++ b/public/app/features/table/hooks.ts
@@ -10,7 +10,11 @@ import {
   type InterpolateFunction,
 } from '@grafana/data';
 import { config } from '@grafana/runtime';
-import { useFlagTablePaginationPageSize, useFlagTableRefactorNested } from '@grafana/runtime/internal';
+import {
+  useFlagTablePaginationPageSize,
+  useFlagTableRefactorNested,
+  useFlagTableRowsAsFields,
+} from '@grafana/runtime/internal';
 import { type TableOptions } from '@grafana/schema';
 import { usePanelContext } from '@grafana/ui';
 import { getConfig } from 'app/core/config';
@@ -67,6 +71,7 @@ type CommonTableOptions = Pick<
   | 'cellHeight'
   | 'maxRowHeight'
   | 'disableKeyboardEvents'
+  | 'rowsAsFields'
 >;
 
 /**
@@ -77,6 +82,7 @@ type CommonTableOptions = Pick<
 export function useCommonTableProps(options: CommonTableOptions, fieldConfig: FieldConfigSource) {
   const nestedRefactorEnabled = useFlagTableRefactorNested();
   const paginationPageSizeEnabled = useFlagTablePaginationPageSize();
+  const rowsAsFieldsEnabled = useFlagTableRowsAsFields();
 
   return useMemo(
     () => ({
@@ -94,6 +100,8 @@ export function useCommonTableProps(options: CommonTableOptions, fieldConfig: Fi
       disableKeyboardEvents: options.disableKeyboardEvents,
       disableSanitizeHtml: getConfig().disableSanitizeHtml,
       nestedRefactorEnabled,
+      // rowsAsFields is gated behind the feature toggle; when disabled the mode is never active
+      rowsAsFields: rowsAsFieldsEnabled && Boolean(options.rowsAsFields),
     }),
     [
       options.showHeader,
@@ -105,9 +113,11 @@ export function useCommonTableProps(options: CommonTableOptions, fieldConfig: Fi
       options.cellHeight,
       options.maxRowHeight,
       options.disableKeyboardEvents,
+      options.rowsAsFields,
       fieldConfig.defaults.noValue,
       nestedRefactorEnabled,
       paginationPageSizeEnabled,
+      rowsAsFieldsEnabled,
     ]
   );
 }

--- a/public/app/plugins/panel/table/module.test.ts
+++ b/public/app/plugins/panel/table/module.test.ts
@@ -1,11 +1,31 @@
-import { createDataFrame, FieldType, getPanelDataSummary, PanelPlugin, standardEditorsRegistry } from '@grafana/data';
+import {
+  createDataFrame,
+  FieldType,
+  getPanelDataSummary,
+  PanelOptionsEditorBuilder,
+  PanelPlugin,
+  standardEditorsRegistry,
+} from '@grafana/data';
 import { TableCellDisplayMode } from '@grafana/schema';
 import { getAllOptionEditors } from 'app/core/components/OptionsUI/registry';
 
 import { TablePanel } from './TablePanel';
 import { tableMigrationHandler, tablePanelChangedHandler } from './migrations';
 import { plugin } from './module';
+import { type Options } from './panelcfg.gen';
 import { tableSuggestionsSupplier } from './suggestions';
+
+let mockRowsAsFieldsFlag = false;
+
+jest.mock('@grafana/runtime/internal', () => {
+  const actual = jest.requireActual('@grafana/runtime/internal');
+  return {
+    ...actual,
+    getFeatureFlagClient: () => ({
+      getBooleanValue: (key: string) => (key === actual.FlagKeys.TableRowsAsFields ? mockRowsAsFieldsFlag : false),
+    }),
+  };
+});
 
 // building the plugin's fieldConfigRegistry runs the table useCustomConfig path,
 // which resolves the 'stats-picker' standard editor; initialise the registry so
@@ -97,6 +117,41 @@ describe('table module', () => {
 
     it('is shown once a tooltip field is chosen', () => {
       expect(showIf('metric')).toBe(true);
+    });
+  });
+
+  describe('rows-as-fields option gating', () => {
+    const buildPanelItems = () => {
+      const builder = new PanelOptionsEditorBuilder<Options>();
+      plugin.getPanelOptionsSupplier()(builder, { data: [] });
+      return builder.getItems();
+    };
+
+    afterEach(() => {
+      mockRowsAsFieldsFlag = false;
+    });
+
+    it('gates the "Rows as fields" switch behind the feature toggle', () => {
+      const rowsAsFields = buildPanelItems().find((item) => item.path === 'rowsAsFields');
+      expect(rowsAsFields).toBeDefined();
+
+      mockRowsAsFieldsFlag = false;
+      expect(rowsAsFields?.showIf?.({} as Options, undefined)).toBe(false);
+
+      mockRowsAsFieldsFlag = true;
+      expect(rowsAsFields?.showIf?.({} as Options, undefined)).toBe(true);
+    });
+
+    it('hides the frozen-columns and show-header options when rows-as-fields is enabled', () => {
+      const items = buildPanelItems();
+      const frozenColumns = items.find((item) => item.path === 'frozenColumns.left');
+      const showHeader = items.find((item) => item.path === 'showHeader');
+
+      expect(frozenColumns?.showIf?.({ rowsAsFields: false } as Options, undefined)).toBe(true);
+      expect(frozenColumns?.showIf?.({ rowsAsFields: true } as Options, undefined)).toBe(false);
+
+      expect(showHeader?.showIf?.({ rowsAsFields: false } as Options, undefined)).toBe(true);
+      expect(showHeader?.showIf?.({ rowsAsFields: true } as Options, undefined)).toBe(false);
     });
   });
 });

--- a/public/app/plugins/panel/table/module.test.ts
+++ b/public/app/plugins/panel/table/module.test.ts
@@ -127,6 +127,18 @@ describe('table module', () => {
       return builder.getItems();
     };
 
+    const plainFrame = createDataFrame({ fields: [{ name: 'a', type: FieldType.string, values: ['x'] }] });
+    const nestedFrame = createDataFrame({
+      fields: [
+        { name: 'a', type: FieldType.string, values: ['x'] },
+        {
+          name: 'nested',
+          type: FieldType.nestedFrames,
+          values: [[createDataFrame({ fields: [{ name: 'b', type: FieldType.number, values: [1] }] })]],
+        },
+      ],
+    });
+
     afterEach(() => {
       mockRowsAsFieldsFlag = false;
     });
@@ -136,22 +148,33 @@ describe('table module', () => {
       expect(rowsAsFields).toBeDefined();
 
       mockRowsAsFieldsFlag = false;
-      expect(rowsAsFields?.showIf?.({} as Options, undefined)).toBe(false);
+      expect(rowsAsFields?.showIf?.({} as Options, [plainFrame])).toBe(false);
 
       mockRowsAsFieldsFlag = true;
-      expect(rowsAsFields?.showIf?.({} as Options, undefined)).toBe(true);
+      expect(rowsAsFields?.showIf?.({} as Options, [plainFrame])).toBe(true);
     });
 
-    it('hides the frozen-columns and show-header options when rows-as-fields is enabled', () => {
+    it('hides the "Rows as fields" switch when nested frames are present', () => {
+      mockRowsAsFieldsFlag = true;
+      const rowsAsFields = buildPanelItems().find((item) => item.path === 'rowsAsFields');
+
+      expect(rowsAsFields?.showIf?.({} as Options, [plainFrame])).toBe(true);
+      expect(rowsAsFields?.showIf?.({} as Options, [nestedFrame])).toBe(false);
+    });
+
+    it('hides frozen-columns and show-header only when rows-as-fields is active', () => {
+      mockRowsAsFieldsFlag = true;
       const items = buildPanelItems();
-      const frozenColumns = items.find((item) => item.path === 'frozenColumns.left');
-      const showHeader = items.find((item) => item.path === 'showHeader');
+      const gated = [items.find((i) => i.path === 'frozenColumns.left'), items.find((i) => i.path === 'showHeader')];
 
-      expect(frozenColumns?.showIf?.({ rowsAsFields: false } as Options, undefined)).toBe(true);
-      expect(frozenColumns?.showIf?.({ rowsAsFields: true } as Options, undefined)).toBe(false);
-
-      expect(showHeader?.showIf?.({ rowsAsFields: false } as Options, undefined)).toBe(true);
-      expect(showHeader?.showIf?.({ rowsAsFields: true } as Options, undefined)).toBe(false);
+      for (const item of gated) {
+        // shown when the option is off
+        expect(item?.showIf?.({ rowsAsFields: false } as Options, [plainFrame])).toBe(true);
+        // hidden when rows-as-fields is on and the data is flat
+        expect(item?.showIf?.({ rowsAsFields: true } as Options, [plainFrame])).toBe(false);
+        // shown again when nested frames are present — the table renders nested, not pivoted
+        expect(item?.showIf?.({ rowsAsFields: true } as Options, [nestedFrame])).toBe(true);
+      }
     });
   });
 });

--- a/public/app/plugins/panel/table/module.tsx
+++ b/public/app/plugins/panel/table/module.tsx
@@ -1,4 +1,10 @@
-import { identityOverrideProcessor, FieldConfigProperty, PanelPlugin, standardEditorsRegistry } from '@grafana/data';
+import {
+  identityOverrideProcessor,
+  FieldConfigProperty,
+  PanelPlugin,
+  standardEditorsRegistry,
+  type StandardEditorProps,
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import {
   TableCellDisplayMode,
@@ -17,6 +23,18 @@ import { tableSuggestionsSupplier } from './suggestions';
 
 function getTableNoValuePlaceholder(): string {
   return t('table.no-value-placeholder', 'No rows');
+}
+
+// Footers are a per-field config option, but they are disabled in rows-as-fields mode. Field-config
+// editors can't gate on panel options via `showIf`, so this wrapper hides the footer editor when the
+// panel option is set by reading it from the editor context (which does carry the panel options).
+function FooterReducersEditor(props: StandardEditorProps<string[]>) {
+  const StatsPickerEditor = standardEditorsRegistry.get('stats-picker').editor;
+  const options: Options | undefined = props.context.options;
+  if (options?.rowsAsFields) {
+    return null;
+  }
+  return <StatsPickerEditor {...props} />;
 }
 
 export const plugin = new PanelPlugin<Options, FieldConfig>(TablePanel)
@@ -48,8 +66,8 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TablePanel)
         path: 'footer.reducers',
         name: t('table.name-calculation', 'Calculation'),
         description: t('table.description-calculation', 'Choose a reducer function / calculation'),
-        editor: standardEditorsRegistry.get('stats-picker').editor,
-        override: standardEditorsRegistry.get('stats-picker').editor,
+        editor: FooterReducersEditor,
+        override: FooterReducersEditor,
         defaultValue: [],
         process: identityOverrideProcessor,
         shouldApply: () => true,

--- a/public/app/plugins/panel/table/panelcfg.cue
+++ b/public/app/plugins/panel/table/panelcfg.cue
@@ -46,6 +46,8 @@ composableKinds: PanelCfg: {
 					frozenColumns?: {
 						left?: number | *0
 					}
+					// If true, renders each field as a row (pivoted); column one is a frozen field-name column. Header, sorting, filtering, and footers are disabled in this mode.
+					rowsAsFields?: bool | *false
 					// If true, disables all keyboard events in the table. this is used when previewing a table (i.e. suggestions)
 					disableKeyboardEvents?: bool
 				} @cuetsy(kind="interface")

--- a/public/app/plugins/panel/table/panelcfg.gen.ts
+++ b/public/app/plugins/panel/table/panelcfg.gen.ts
@@ -47,6 +47,10 @@ export interface Options {
    */
   pageSize?: number;
   /**
+   * If true, renders each field as a row (pivoted); column one is a frozen field-name column. Header, sorting, filtering, and footers are disabled in this mode.
+   */
+  rowsAsFields?: boolean;
+  /**
    * Controls whether the panel should show the header
    */
   showHeader: boolean;
@@ -63,6 +67,7 @@ export interface Options {
 export const defaultOptions: Partial<Options> = {
   cellHeight: ui.TableCellHeight.Sm,
   frameIndex: 0,
+  rowsAsFields: false,
   showHeader: true,
   showTypeIcons: false,
   sortBy: [],

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -15717,6 +15717,7 @@
     "description-frozen-columns": "Columns are frozen from the left side of the table",
     "description-min-column-width": "The minimum width for column auto resizing",
     "description-page-size": "Number of rows per page. When empty, the page size is based on the panel height.",
+    "description-rows-as-fields": "Render each field as a row (pivoted). The first column is a frozen list of field names. Header, sorting, filtering, and footers are disabled in this mode.",
     "description-styling-from-field": "A field containing JSON objects with CSS properties",
     "description-tooltip-from-field": "Render a cell from a field (hidden or visible) in a tooltip",
     "frame-picker": {
@@ -15751,6 +15752,7 @@
     "name-max-height": "Max row height",
     "name-min-column-width": "Minimum column width",
     "name-page-size": "Page size",
+    "name-rows-as-fields": "Rows as fields",
     "name-show-table-header": "Show table header",
     "name-styling-from-field": "Styling from field",
     "name-tooltip-from-field": "Tooltip from field",


### PR DESCRIPTION
## What this does

Implements the **rows-as-fields (pivoted)** rendering mode for the Table panel, behind the `table.rowsAsFields` feature toggle. First building block toward supporting pivoted tables.

> **Depends on** the toggle PR grafana/grafana#129985 — this PR is based on that branch and contains only the frontend option + render changes. The backend/toggle registration lives there.

When enabled, the table is transposed:

- Each **field becomes a row**; cell rendering and field config/overrides resolve **per-row** (from the original field), so overrides apply to the row.
- **Column one** is a frozen column of field display names. The **Frozen columns** option is hidden and ignored.
- **No header row.**
- **Sorting and filtering are disabled.**
- **Footers are disabled** — the footer editor is hidden and any `footer.reducers` config is ignored.

Example (CSV `name,age,city,active` × 3 rows → 4 field-rows):

| | | | |
|---|---|---|---|
| **name** | Alice | Bob | Carol |
| **age** | 30 | 25 | 41 |
| **city** | New York | Los Angeles | San Francisco |
| **active** | true | false | true |

## How it's built

1. **Option + wiring** — `rowsAsFields` in the table schema; toggle-gated "Rows as fields" switch; hides the **Frozen columns** / **Show table header** editors in this mode; the per-field footer editor self-hides via `context.options` (field-config editors can't gate on panel options through `showIf`); threads the option onto `TableNGProps`.
2. **Render component** — new `TableRowsAsFields` that transposes rows/columns and resolves the cell renderer per-row from the original field. `RefactoredTableNG` routes to it when `rowsAsFields` is set and there is no nested-frames field.

Only the refactored TableNG path supports this mode, so it requires both `table.refactorNested` and `table.rowsAsFields` to be enabled.

## Testing

- `yarn typecheck`, ESLint, and Prettier clean.
- 21 unit tests: transposed layout, disabled header/footer/sort, per-row field overrides, and the options-editor gating.
- Verified live in a running Grafana (screenshot matches the example above).

## Follow-ups (out of scope)

- Content-aware value-column widths and per-value-column resizing.
- Nested-frames / multi-frame interplay.
- Optional column-header-from-field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)