### PR TITLE
Table: add table.rowsAsFields feature toggle

### DIFF
--- a/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
@@ -75,6 +75,7 @@ declare module "@openfeature/core" {
     | "table.refactorNested"
     | "table.paginationPageSize"
     | "table.autoColumnWidths"
+    | "table.rowsAsFields"
     | "dataviz.experimentalColorSchemes"
     | "grafana.customizableMegaMenu"
     | "grafana.dashboardSettingsRedesign"

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
@@ -73,6 +73,7 @@ declare module "@openfeature/core" {
     | "table.protoRowParser"
     | "grafana.queryVarEditorRedesign"
     | "table.refactorNested"
+    | "table.paginationPageSize"
     | "table.autoColumnWidths"
     | "dataviz.experimentalColorSchemes"
     | "grafana.customizableMegaMenu"

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -159,6 +159,8 @@ export const FlagKeys = {
   TableProtoRowParser: "table.protoRowParser",
   /** Enables the refactored TableNG nested-table implementation */
   TableRefactorNested: "table.refactorNested",
+  /** Enables a rows-as-fields (pivoted) rendering mode for the table panel */
+  TableRowsAsFields: "table.rowsAsFields",
   /** Routes short URL requests from /api to the /apis endpoint in the frontend. Depends on kubernetesShortURLs */
   UseKubernetesShortURLsAPI: "useKubernetesShortURLsAPI",
 } as const;
@@ -964,6 +966,17 @@ export const useFlagTableProtoRowParser = (options?: ReactFlagEvaluationOptions)
  */
 export const useFlagTableRefactorNested = (options?: ReactFlagEvaluationOptions): boolean => {
   return useFlag("table.refactorNested", false, options).value;
+};
+
+/**
+ * Enables a rows-as-fields (pivoted) rendering mode for the table panel
+ *
+ * **Details:**
+ * - flag key: `table.rowsAsFields`
+ * - default value: `false`
+ */
+export const useFlagTableRowsAsFields = (options?: ReactFlagEvaluationOptions): boolean => {
+  return useFlag("table.rowsAsFields", false, options).value;
 };
 
 /**

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -153,6 +153,8 @@ export const FlagKeys = {
   SuggestedDashboardsAssistantButton: "suggestedDashboardsAssistantButton",
   /** Sizes TableNG auto-width columns to fit their content instead of distributing evenly */
   TableAutoColumnWidths: "table.autoColumnWidths",
+  /** Enables configuring a fixed page size for paginated tables instead of deriving it from the panel height */
+  TablePaginationPageSize: "table.paginationPageSize",
   /** Enables a new internal parser for table panel which doesn't rely on constructing a dynamic function and works in more browser environments. */
   TableProtoRowParser: "table.protoRowParser",
   /** Enables the refactored TableNG nested-table implementation */
@@ -929,6 +931,17 @@ export const useFlagSuggestedDashboardsAssistantButton = (options?: ReactFlagEva
  */
 export const useFlagTableAutoColumnWidths = (options?: ReactFlagEvaluationOptions): boolean => {
   return useFlag("table.autoColumnWidths", false, options).value;
+};
+
+/**
+ * Enables configuring a fixed page size for paginated tables instead of deriving it from the panel height
+ *
+ * **Details:**
+ * - flag key: `table.paginationPageSize`
+ * - default value: `false`
+ */
+export const useFlagTablePaginationPageSize = (options?: ReactFlagEvaluationOptions): boolean => {
+  return useFlag("table.paginationPageSize", false, options).value;
 };
 
 /**

--- a/packages/grafana-schema/src/common/common.gen.ts
+++ b/packages/grafana-schema/src/common/common.gen.ts
@@ -1052,6 +1052,10 @@ export interface TableOptions {
    */
   maxRowHeight?: number;
   /**
+   * When pagination is enabled, sets a fixed number of rows per page. When unset, the page size is derived from the panel height.
+   */
+  pageSize?: number;
+  /**
    * Controls whether the panel should show the header
    */
   showHeader: boolean;

--- a/packages/grafana-schema/src/common/table.cue
+++ b/packages/grafana-schema/src/common/table.cue
@@ -122,6 +122,8 @@ TableOptions: {
 	sortBy?: [...TableSortByFieldState]
 	// Enable pagination on the table
 	enablePagination?: bool
+	// When pagination is enabled, sets a fixed number of rows per page. When unset, the page size is derived from the panel height.
+	pageSize?: number
 	// Controls the height of the rows
 	cellHeight?: TableCellHeight & (*"sm" | _)
 	// limits the maximum height of a row, if text wrapping or dynamic height is enabled

--- a/packages/grafana-schema/src/raw/composable/table/panelcfg/x/types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/table/panelcfg/x/types.gen.ts
@@ -45,6 +45,10 @@ export interface Options {
    */
   maxRowHeight?: number;
   /**
+   * When pagination is enabled, sets a fixed number of rows per page. When unset, the page size is derived from the panel height.
+   */
+  pageSize?: number;
+  /**
    * Controls whether the panel should show the header
    */
   showHeader: boolean;

--- a/packages/grafana-ui/src/components/Table/TableNG/hooks.test.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/hooks.test.ts
@@ -385,6 +385,56 @@ describe('TableNG hooks', () => {
       expect(result.current.pageRangeEnd).toBe(5);
       expect(result.current.rowsPerPage).toBe(2);
     });
+
+    it('should use pageSize for rowsPerPage instead of deriving it from the panel height', () => {
+      // height alone would fit all 3 rows on one page ((300 - 38) / 10 = 26 rows); pageSize must win.
+      const { rows } = setupData();
+      const { result } = renderHook(() =>
+        usePaginatedRows(rows, {
+          enabled: true,
+          height: 300,
+          width: 800,
+          rowHeight: 10,
+          headerHeight: 0,
+          footerHeight: 0,
+          pageSize: 2,
+        })
+      );
+
+      expect(result.current.rowsPerPage).toBe(2);
+      expect(result.current.numPages).toBe(2);
+      expect(result.current.pageRangeStart).toBe(1);
+      expect(result.current.pageRangeEnd).toBe(2);
+      expect(result.current.rows.length).toBe(2);
+
+      act(() => {
+        result.current.setPage(1);
+      });
+
+      expect(result.current.pageRangeStart).toBe(3);
+      expect(result.current.pageRangeEnd).toBe(3);
+      expect(result.current.rows.length).toBe(1);
+      expect(result.current.rows[0].__index).toBe(2);
+    });
+
+    it('should fall back to the height-derived page size when pageSize is not a positive number', () => {
+      // (60 - 38) / 10 = 2 rows per page from height; pageSize: 0 must not override that.
+      const { rows } = setupData();
+      const { result } = renderHook(() =>
+        usePaginatedRows(rows, {
+          enabled: true,
+          height: 60,
+          width: 800,
+          rowHeight: 10,
+          headerHeight: 0,
+          footerHeight: 0,
+          pageSize: 0,
+        })
+      );
+
+      expect(result.current.rowsPerPage).toBe(2);
+      expect(result.current.numPages).toBe(2);
+    });
   });
 
   describe('useNestedRows', () => {

--- a/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
@@ -140,6 +140,8 @@ export interface PaginatedRowsOptions {
   paginationHeight?: number;
   enabled: boolean;
   hasNestedFrames?: boolean;
+  /** When set to a positive value, fixes the number of rows per page instead of deriving it from the panel height. */
+  pageSize?: number;
 }
 
 export interface PaginatedRowsResult {
@@ -159,7 +161,7 @@ const PAGINATION_HEIGHT = 38;
 
 export function usePaginatedRows(
   rows: TableRow[],
-  { height, width, headerHeight, footerHeight, rowHeight, enabled, hasNestedFrames }: PaginatedRowsOptions
+  { height, width, headerHeight, footerHeight, rowHeight, enabled, hasNestedFrames, pageSize }: PaginatedRowsOptions
 ): PaginatedRowsResult {
   // TODO: allow persisted page selection via url
   const [page, setPage] = useState(0);
@@ -209,11 +211,16 @@ export function usePaginatedRows(
       return { numPages: 0, rowsPerPage: 0, pageRangeStart: 1, pageRangeEnd: numRows };
     }
 
-    // calculate number of rowsPerPage based on height stack
-    const rowAreaHeight = height - headerHeight - footerHeight - PAGINATION_HEIGHT;
-    const heightPerRow = Math.floor(rowAreaHeight / (avgRowHeight || 1));
-    // ensure at least one row per page is displayed
-    let rowsPerPage = heightPerRow > 1 ? heightPerRow : 1;
+    // a user-configured page size takes precedence; otherwise derive rowsPerPage from the height stack
+    let rowsPerPage: number;
+    if (pageSize != null && pageSize > 0) {
+      rowsPerPage = Math.floor(pageSize);
+    } else {
+      const rowAreaHeight = height - headerHeight - footerHeight - PAGINATION_HEIGHT;
+      const heightPerRow = Math.floor(rowAreaHeight / (avgRowHeight || 1));
+      // ensure at least one row per page is displayed
+      rowsPerPage = heightPerRow > 1 ? heightPerRow : 1;
+    }
 
     // calculate row range for pagination summary display
     const pageRangeStart = page * rowsPerPage + 1;
@@ -229,7 +236,7 @@ export function usePaginatedRows(
       pageRangeStart,
       pageRangeEnd,
     };
-  }, [height, headerHeight, footerHeight, avgRowHeight, enabled, numRows, page]);
+  }, [height, headerHeight, footerHeight, avgRowHeight, enabled, numRows, page, pageSize]);
 
   // safeguard against page overflow on panel resize or other factors
   useLayoutEffect(() => {

--- a/packages/grafana-ui/src/components/Table/TableNG/legacy/LegacyTableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/legacy/LegacyTableNG.tsx
@@ -132,6 +132,7 @@ export function LegacyTableNG(props: TableNGProps) {
     frozenColumns: _frozenColumns = 0,
     getActions = () => [],
     height,
+    pageSize,
     maxRowHeight: _maxRowHeight,
     noHeader,
     noValue,
@@ -391,6 +392,7 @@ export function LegacyTableNG(props: TableNGProps) {
     headerHeight: hasHeader ? headerHeight : 0,
     rowHeight,
     hasNestedFrames,
+    pageSize,
   });
 
   const showPagination = enablePagination && numRows > 0;

--- a/packages/grafana-ui/src/components/Table/TableNG/refactored/TableFlat.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/refactored/TableFlat.tsx
@@ -62,6 +62,7 @@ export function TableFlat(props: TableNGProps) {
     frozenColumns: _frozenColumns = 0,
     getActions = () => [],
     height,
+    pageSize,
     maxRowHeight: _maxRowHeight,
     noHeader,
     noValue,
@@ -220,6 +221,7 @@ export function TableFlat(props: TableNGProps) {
     footerHeight,
     headerHeight: hasHeader ? headerHeight : 0,
     rowHeight,
+    pageSize,
   });
 
   const rowHeightFn = useMemo((): ((row: TableRow) => number) => {

--- a/packages/grafana-ui/src/components/Table/TableNG/refactored/TableNested.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/refactored/TableNested.tsx
@@ -74,6 +74,7 @@ export function TableNested(props: TableNGProps & { nestedFramesField: Field<Dat
     enableVirtualization,
     getActions = () => [],
     height,
+    pageSize,
     maxRowHeight: _maxRowHeight,
     nestedFramesField,
     noHeader,
@@ -300,6 +301,7 @@ export function TableNested(props: TableNGProps & { nestedFramesField: Field<Dat
     headerHeight: hasHeader ? headerHeight : 0,
     rowHeight,
     hasNestedFrames: true,
+    pageSize,
   });
 
   const showPagination = enablePagination && numRows > 0;

--- a/packages/grafana-ui/src/components/Table/TableNG/types.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/types.ts
@@ -126,6 +126,8 @@ interface BaseTableProps {
   footerValues?: FooterItem[];
   frozenColumns?: number;
   enablePagination?: boolean;
+  /** When pagination is enabled, fixes the number of rows per page instead of deriving it from the panel height. */
+  pageSize?: number;
   cellHeight?: TableCellHeight;
   maxRowHeight?: number;
   structureRev?: number;

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -3000,6 +3000,15 @@ var (
 			Generate:     Generate{React: true},
 		},
 		{
+			Name:         "table.paginationPageSize",
+			Description:  "Enables configuring a fixed page size for paginated tables instead of deriving it from the panel height",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaDatavizSquad,
+			HideFromDocs: true,
+			Expression:   "false",
+			Generate:     Generate{React: true},
+		},
+		{
 			Name:         "table.autoColumnWidths",
 			Description:  "Sizes TableNG auto-width columns to fit their content instead of distributing evenly",
 			Stage:        FeatureStageExperimental,

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -3018,6 +3018,15 @@ var (
 			Generate:     Generate{React: true},
 		},
 		{
+			Name:         "table.rowsAsFields",
+			Description:  "Enables a rows-as-fields (pivoted) rendering mode for the table panel",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaDatavizSquad,
+			HideFromDocs: true,
+			Expression:   "false",
+			Generate:     Generate{React: true},
+		},
+		{
 			Name:         "dataviz.experimentalColorSchemes",
 			Description:  "Enables additional experimental color schemes for visualizations.",
 			Stage:        FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -348,6 +348,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-06-22,table.protoRowParser,experimental,@grafana/dataviz-squad,false,false,true
 2026-06-17,grafana.queryVarEditorRedesign,GA,@grafana/dashboards-squad,false,false,true
 2026-06-25,table.refactorNested,experimental,@grafana/dataviz-squad,false,false,true
+2026-07-29,table.paginationPageSize,experimental,@grafana/dataviz-squad,false,false,true
 2026-07-24,table.autoColumnWidths,experimental,@grafana/dataviz-squad,false,false,true
 2026-06-23,dataviz.experimentalColorSchemes,experimental,@grafana/dataviz-squad,false,false,true
 2026-06-25,grafana.customizableMegaMenu,experimental,@grafana/grafana-frontend-navigation,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -350,6 +350,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-06-25,table.refactorNested,experimental,@grafana/dataviz-squad,false,false,true
 2026-07-29,table.paginationPageSize,experimental,@grafana/dataviz-squad,false,false,true
 2026-07-24,table.autoColumnWidths,experimental,@grafana/dataviz-squad,false,false,true
+2026-08-03,table.rowsAsFields,experimental,@grafana/dataviz-squad,false,false,true
 2026-06-23,dataviz.experimentalColorSchemes,experimental,@grafana/dataviz-squad,false,false,true
 2026-06-25,grafana.customizableMegaMenu,experimental,@grafana/grafana-frontend-navigation,false,false,true
 2026-04-20,cujTracking,experimental,@grafana/dashboards-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -5956,6 +5956,21 @@
     },
     {
       "metadata": {
+        "name": "table.rowsAsFields",
+        "resourceVersion": "1785777632172",
+        "creationTimestamp": "2026-08-03T17:20:32Z"
+      },
+      "spec": {
+        "description": "Enables a rows-as-fields (pivoted) rendering mode for the table panel",
+        "stage": "experimental",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true,
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "tableSharedCrosshair",
         "resourceVersion": "1779440584464",
         "creationTimestamp": "2023-12-13T09:33:14Z"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -5911,6 +5911,21 @@
     },
     {
       "metadata": {
+        "name": "table.paginationPageSize",
+        "resourceVersion": "1785352708239",
+        "creationTimestamp": "2026-07-29T19:18:28Z"
+      },
+      "spec": {
+        "description": "Enables configuring a fixed page size for paginated tables instead of deriving it from the panel height",
+        "stage": "experimental",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true,
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "table.protoRowParser",
         "resourceVersion": "1782139478281",
         "creationTimestamp": "2026-06-22T14:44:38Z"

--- a/public/app/features/panel/table/addTableCustomPanelOptions.ts
+++ b/public/app/features/panel/table/addTableCustomPanelOptions.ts
@@ -1,5 +1,6 @@
 import { type PanelOptionsEditorBuilder } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 import { TableCellHeight, type TableOptions } from '@grafana/schema';
 import { defaultOptions as defaultTableOptions } from '@grafana/schema/dist/esm/raw/composable/table/panelcfg/x/TablePanelCfg_types.gen';
 
@@ -52,5 +53,23 @@ export const addTableCustomPanelOptions = <O extends TableOptions>(builder: Pane
       category,
       editor: PaginationEditor,
       defaultValue: defaultTableOptions?.enablePagination,
+    })
+    .addNumberInput({
+      path: 'pageSize',
+      name: t('table.name-page-size', 'Page size'),
+      description: t(
+        'table.description-page-size',
+        'Number of rows per page. When empty, the page size is based on the panel height.'
+      ),
+      category,
+      settings: {
+        placeholder: t('table.placeholder-page-size', 'auto'),
+        min: 1,
+        integer: true,
+      },
+      // React-only feature toggle, so it is not on config.featureToggles and must be read via the OpenFeature client
+      showIf: (opts) =>
+        Boolean(opts.enablePagination) &&
+        getFeatureFlagClient().getBooleanValue(FlagKeys.TablePaginationPageSize, false),
     });
 };

--- a/public/app/features/table/hooks.test.tsx
+++ b/public/app/features/table/hooks.test.tsx
@@ -218,6 +218,24 @@ describe('useCommonTableProps', () => {
     expect(result.current.nestedRefactorEnabled).toBe(true);
   });
 
+  it('passes pageSize through when the pagination-page-size flag is on', () => {
+    setTestFlags({ [FlagKeys.TablePaginationPageSize]: true });
+    const { result } = renderHook(() => useCommonTableProps({ ...options, pageSize: 25 }, fieldConfig), {
+      wrapper: FeatureFlagsProvider,
+    });
+
+    expect(result.current.pageSize).toBe(25);
+  });
+
+  it('drops pageSize when the pagination-page-size flag is off', () => {
+    setTestFlags({ [FlagKeys.TablePaginationPageSize]: false });
+    const { result } = renderHook(() => useCommonTableProps({ ...options, pageSize: 25 }, fieldConfig), {
+      wrapper: FeatureFlagsProvider,
+    });
+
+    expect(result.current.pageSize).toBeUndefined();
+  });
+
   it('returns a stable reference when inputs do not change', () => {
     const { result, rerender } = renderHook(() => useCommonTableProps(options, fieldConfig), {
       wrapper: FeatureFlagsProvider,

--- a/public/app/features/table/hooks.ts
+++ b/public/app/features/table/hooks.ts
@@ -10,7 +10,7 @@ import {
   type InterpolateFunction,
 } from '@grafana/data';
 import { config } from '@grafana/runtime';
-import { useFlagTableRefactorNested } from '@grafana/runtime/internal';
+import { useFlagTablePaginationPageSize, useFlagTableRefactorNested } from '@grafana/runtime/internal';
 import { type TableOptions } from '@grafana/schema';
 import { usePanelContext } from '@grafana/ui';
 import { getConfig } from 'app/core/config';
@@ -63,6 +63,7 @@ type CommonTableOptions = Pick<
   | 'sortBy'
   | 'frozenColumns'
   | 'enablePagination'
+  | 'pageSize'
   | 'cellHeight'
   | 'maxRowHeight'
   | 'disableKeyboardEvents'
@@ -75,6 +76,7 @@ type CommonTableOptions = Pick<
  */
 export function useCommonTableProps(options: CommonTableOptions, fieldConfig: FieldConfigSource) {
   const nestedRefactorEnabled = useFlagTableRefactorNested();
+  const paginationPageSizeEnabled = useFlagTablePaginationPageSize();
 
   return useMemo(
     () => ({
@@ -85,6 +87,8 @@ export function useCommonTableProps(options: CommonTableOptions, fieldConfig: Fi
       sortBy: options.sortBy,
       frozenColumns: options.frozenColumns?.left,
       enablePagination: options.enablePagination,
+      // pageSize is gated behind the feature toggle; when disabled the page size falls back to the panel height
+      pageSize: paginationPageSizeEnabled ? options.pageSize : undefined,
       cellHeight: options.cellHeight,
       maxRowHeight: options.maxRowHeight,
       disableKeyboardEvents: options.disableKeyboardEvents,
@@ -97,11 +101,13 @@ export function useCommonTableProps(options: CommonTableOptions, fieldConfig: Fi
       options.sortBy,
       options.frozenColumns?.left,
       options.enablePagination,
+      options.pageSize,
       options.cellHeight,
       options.maxRowHeight,
       options.disableKeyboardEvents,
       fieldConfig.defaults.noValue,
       nestedRefactorEnabled,
+      paginationPageSizeEnabled,
     ]
   );
 }

--- a/public/app/plugins/panel/table/panelcfg.cue
+++ b/public/app/plugins/panel/table/panelcfg.cue
@@ -36,6 +36,8 @@ composableKinds: PanelCfg: {
 					sortBy?: [...ui.TableSortByFieldState]
 					// Enable pagination on the table
 					enablePagination?: bool
+					// When pagination is enabled, sets a fixed number of rows per page. When unset, the page size is derived from the panel height.
+					pageSize?: number
 					// Controls the height of the rows
 					cellHeight?: ui.TableCellHeight & (*"sm" | _)
 					// limits the maximum height of a row, if text wrapping or dynamic height is enabled

--- a/public/app/plugins/panel/table/panelcfg.gen.ts
+++ b/public/app/plugins/panel/table/panelcfg.gen.ts
@@ -43,6 +43,10 @@ export interface Options {
    */
   maxRowHeight?: number;
   /**
+   * When pagination is enabled, sets a fixed number of rows per page. When unset, the page size is derived from the panel height.
+   */
+  pageSize?: number;
+  /**
    * Controls whether the panel should show the header
    */
   showHeader: boolean;

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -15716,6 +15716,7 @@
     "description-column-filter": "Enables/disables field filters in table",
     "description-frozen-columns": "Columns are frozen from the left side of the table",
     "description-min-column-width": "The minimum width for column auto resizing",
+    "description-page-size": "Number of rows per page. When empty, the page size is based on the panel height.",
     "description-styling-from-field": "A field containing JSON objects with CSS properties",
     "description-tooltip-from-field": "Render a cell from a field (hidden or visible) in a tooltip",
     "frame-picker": {
@@ -15749,6 +15750,7 @@
     "name-hide-in-table": "Hide in table",
     "name-max-height": "Max row height",
     "name-min-column-width": "Minimum column width",
+    "name-page-size": "Page size",
     "name-show-table-header": "Show table header",
     "name-styling-from-field": "Styling from field",
     "name-tooltip-from-field": "Tooltip from field",
@@ -15759,6 +15761,7 @@
     "placeholder-column-width": "auto",
     "placeholder-frozen-columns": "none",
     "placeholder-max-height": "none",
+    "placeholder-page-size": "auto",
     "tooltip-placement-options": {
       "label-auto": "Auto",
       "label-bottom": "Bottom",


### PR DESCRIPTION
## What this does

Introduces the experimental `table.rowsAsFields` React feature toggle. **Toggle only — no behavior change.**

It will gate the upcoming rows-as-fields (pivoted) rendering mode for the Table panel, landing as a separate frontend PR that depends on this flag: grafana/grafana#129984.

## Details

- `registry.go`: one `FeatureFlag` entry (`FeatureStageExperimental`, `@grafana/dataviz-squad`, `Generate{React: true}`), mirroring the other `table.*` React-only flags.
- Generated files updated via `make gen-feature-toggles` (`toggles_gen.csv`/`.json`, OpenFeature `openfeature.gen.ts` / `openfeature-types.gen.d.ts` — adds `FlagKeys.TableRowsAsFields` + `useFlagTableRowsAsFields`).

Stacked on `paulmarbach/table-page-size-impl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
