### PR TITLE
Alert: Use the visible button text as the accessible name

### DIFF
--- a/packages/grafana-ui/src/components/Alert/Alert.test.tsx
+++ b/packages/grafana-ui/src/components/Alert/Alert.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { Button } from '../Button/Button';
+import { Icon } from '../Icon/Icon';
 
 import { Alert } from './Alert';
 
@@ -71,10 +72,22 @@ describe('Alert', () => {
     });
   });
 
+  describe('buttonContent accessible name', () => {
+    it('uses the visible text as the accessible name when buttonContent is a string', () => {
+      render(<Alert title="Test" buttonContent="Go back to alert list" onRemove={jest.fn()} />);
+      expect(screen.getByRole('button', { name: 'Go back to alert list' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /close alert/i })).not.toBeInTheDocument();
+    });
+
+    it('falls back to the close label when buttonContent carries no text of its own', () => {
+      render(<Alert title="Test" buttonContent={<Icon name="question-circle" />} onRemove={jest.fn()} />);
+      expect(screen.getByRole('button', { name: /close alert/i })).toBeInTheDocument();
+    });
+  });
+
   describe('backward compatibility', () => {
     it('renders buttonContent with onRemove as before', () => {
       render(<Alert title="Test" buttonContent="Go back" onRemove={jest.fn()} />);
-      expect(screen.getByRole('button', { name: /close alert/i })).toBeInTheDocument();
       expect(screen.getByText('Go back')).toBeInTheDocument();
     });
 

--- a/packages/grafana-ui/src/components/Alert/Alert.tsx
+++ b/packages/grafana-ui/src/components/Alert/Alert.tsx
@@ -95,7 +95,14 @@ export const Alert = React.forwardRef<HTMLDivElement, Props>(
             <Stack alignItems="center" wrap="wrap">
               {action}
               {onRemove && buttonContent && (
-                <Button aria-label={closeLabel} variant="secondary" onClick={onRemove} type="button">
+                <Button
+                  // A string buttonContent is already the button's accessible name, so overriding it would announce
+                  // something other than what the user sees.
+                  aria-label={typeof buttonContent === 'string' ? undefined : closeLabel}
+                  variant="secondary"
+                  onClick={onRemove}
+                  type="button"
+                >
                   {buttonContent}
                 </Button>
               )}


### PR DESCRIPTION
**What is this feature?**

When `<Alert>` renders a button from `buttonContent`, the button's accessible name was hardcoded to "Close alert" and could not be overridden — `restProps` is spread onto the wrapper `div`, not the button. A string `buttonContent` now provides the accessible name itself. Content that carries no text of its own (icons) keeps the "Close alert" fallback, and the icon-only dismiss button is unchanged.

**Why do we need this feature?**

This is a WCAG 2.5.3 (Label in Name) failure: the accessible name does not contain the visible label. It also breaks speech-input users, who say what they see, and misinforms screen-reader users where the button navigates instead of dismissing.

**Who is this feature for?**

Screen reader and speech-input users of any Grafana page that renders an alert with a labelled button, and consumers of `@grafana/ui`.

**Which issue(s) does this PR fix?**

Fixes #129954

**Special notes for your reviewer:**

- One existing assertion under `backward compatibility` encoded the mismatch itself — it expected a button labelled "Go back" to announce as "close alert". That assertion is removed; the render check it accompanied stays, and two new tests cover both branches.
- Only `GrafanaModifyExport` and `ProvisionedFolderPreviewBanner` pass a plain string today, so those are the call sites this fixes. The others wrap the label in `<span>` or `<Stack>` and still announce "Close alert"; as the issue notes, they are better served by the `action` prop, which is out of scope here.
- Verified locally: `Alert.test.tsx` (11 passed) plus the consumer suites that assert on the close label — `GrafanaModifyExport`, `PreviewBannerViewPR`, `ProvisioningAlert` (28 passed) — along with `yarn typecheck`, eslint and prettier.
