### PR TITLE
Canvas, Geomap: Announce the alert help buttons as documentation links

### DIFF
--- a/public/app/features/geo/editor/locationModeEditor.tsx
+++ b/public/app/features/geo/editor/locationModeEditor.tsx
@@ -5,7 +5,7 @@ import { type StandardEditorProps, type DataFrame, type GrafanaTheme2 } from '@g
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { type FrameGeometrySource, FrameGeometrySourceMode } from '@grafana/schema';
-import { Alert, Icon, Select, useStyles2 } from '@grafana/ui';
+import { Alert, Button, Icon, Select, useStyles2 } from '@grafana/ui';
 
 import { type FrameGeometryField, getGeometryField, getLocationMatchers } from '../utils/location';
 
@@ -78,14 +78,24 @@ export const LocationModeEditor = ({
           <Alert
             title={info.warning}
             severity="warning"
-            buttonContent={<Icon name="question-circle" size="xl" />}
             className={styles.alert}
-            onRemove={() => {
-              const newWindow = window.open(helpUrl, '_blank', 'noopener,noreferrer');
-              if (newWindow) {
-                newWindow.opener = null;
-              }
-            }}
+            action={
+              <Button
+                aria-label={t(
+                  'geo.location-more-editor.aria-label-open-documentation',
+                  'Open geospatial data documentation'
+                )}
+                variant="secondary"
+                onClick={() => {
+                  const newWindow = window.open(helpUrl, '_blank', 'noopener,noreferrer');
+                  if (newWindow) {
+                    newWindow.opener = null;
+                  }
+                }}
+              >
+                <Icon name="question-circle" size="xl" />
+              </Button>
+            }
           />
         );
       } else if (value === FrameGeometrySourceMode.Auto && info.description) {

--- a/public/app/features/geo/editor/locationModeEditor.tsx
+++ b/public/app/features/geo/editor/locationModeEditor.tsx
@@ -5,7 +5,7 @@ import { type StandardEditorProps, type DataFrame, type GrafanaTheme2 } from '@g
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { type FrameGeometrySource, FrameGeometrySourceMode } from '@grafana/schema';
-import { Alert, Button, Icon, Select, useStyles2 } from '@grafana/ui';
+import { Alert, Icon, LinkButton, Select, useStyles2 } from '@grafana/ui';
 
 import { type FrameGeometryField, getGeometryField, getLocationMatchers } from '../utils/location';
 
@@ -80,21 +80,18 @@ export const LocationModeEditor = ({
             severity="warning"
             className={styles.alert}
             action={
-              <Button
+              <LinkButton
                 aria-label={t(
                   'geo.location-more-editor.aria-label-open-documentation',
                   'Open geospatial data documentation'
                 )}
                 variant="secondary"
-                onClick={() => {
-                  const newWindow = window.open(helpUrl, '_blank', 'noopener,noreferrer');
-                  if (newWindow) {
-                    newWindow.opener = null;
-                  }
-                }}
+                href={helpUrl}
+                target="_blank"
+                rel="noreferrer noopener"
               >
                 <Icon name="question-circle" size="xl" />
-              </Button>
+              </LinkButton>
             }
           />
         );

--- a/public/app/plugins/panel/canvas/editor/panZoomHelp.tsx
+++ b/public/app/plugins/panel/canvas/editor/panZoomHelp.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 
 import { type StandardEditorProps, type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { Alert, Button, Icon, Stack, useStyles2 } from '@grafana/ui';
+import { Alert, Icon, LinkButton, Stack, useStyles2 } from '@grafana/ui';
 
 const helpUrl = 'https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/canvas/';
 
@@ -17,18 +17,15 @@ export const PanZoomHelp = ({}: StandardEditorProps<string, unknown, unknown, un
           severity="info"
           className={styles.alert}
           action={
-            <Button
+            <LinkButton
               aria-label={t('canvas.pan-zoom-help.aria-label-open-documentation', 'Open Canvas documentation')}
               variant="secondary"
-              onClick={() => {
-                const newWindow = window.open(helpUrl, '_blank', 'noopener,noreferrer');
-                if (newWindow) {
-                  newWindow.opener = null;
-                }
-              }}
+              href={helpUrl}
+              target="_blank"
+              rel="noreferrer noopener"
             >
               <Icon name="question-circle" size="xl" />
-            </Button>
+            </LinkButton>
           }
         >
           <Stack direction="column">

--- a/public/app/plugins/panel/canvas/editor/panZoomHelp.tsx
+++ b/public/app/plugins/panel/canvas/editor/panZoomHelp.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 
 import { type StandardEditorProps, type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { Alert, Icon, Stack, useStyles2 } from '@grafana/ui';
+import { Alert, Button, Icon, Stack, useStyles2 } from '@grafana/ui';
 
 const helpUrl = 'https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/canvas/';
 
@@ -15,14 +15,21 @@ export const PanZoomHelp = ({}: StandardEditorProps<string, unknown, unknown, un
         <Alert
           title={t('canvas.pan-zoom-help.title-pan-and-zoom-controls', 'Pan and zoom controls')}
           severity="info"
-          buttonContent={<Icon name="question-circle" size="xl" />}
           className={styles.alert}
-          onRemove={() => {
-            const newWindow = window.open(helpUrl, '_blank', 'noopener,noreferrer');
-            if (newWindow) {
-              newWindow.opener = null;
-            }
-          }}
+          action={
+            <Button
+              aria-label={t('canvas.pan-zoom-help.aria-label-open-documentation', 'Open Canvas documentation')}
+              variant="secondary"
+              onClick={() => {
+                const newWindow = window.open(helpUrl, '_blank', 'noopener,noreferrer');
+                if (newWindow) {
+                  newWindow.opener = null;
+                }
+              }}
+            >
+              <Icon name="question-circle" size="xl" />
+            </Button>
+          }
         >
           <Stack direction="column">
             <ul>

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -4832,6 +4832,7 @@
       "not-found": "<0>Not found: </0><config />"
     },
     "pan-zoom-help": {
+      "aria-label-open-documentation": "Open Canvas documentation",
       "ctrl-right-mouse": "CTRL + right mouse",
       "middle-mouse": "Middle mouse",
       "pan-title": "Pan:",
@@ -9249,6 +9250,7 @@
       "name-lookup-field": "Lookup field"
     },
     "location-more-editor": {
+      "aria-label-open-documentation": "Open geospatial data documentation",
       "mode-options": {
         "description-auto": "Automatically identify location data based on default field names",
         "description-coords": "Specify latitude and longitude fields",


### PR DESCRIPTION
**What is this feature?**

The help buttons in the Canvas pan/zoom editor and the Geomap location mode editor open documentation in a new tab, but they were passed to `<Alert>` as `buttonContent` + `onRemove`, which is the dismiss-button slot. Both now use the `action` prop, which exists for custom buttons independent of dismissal, and carry an accessible name that says what they do.

The rendered button is unchanged — same `variant="secondary"`, same icon, same position in the alert's button area — and the click behaviour is identical.

**Why do we need this feature?**

`buttonContent` hardcodes the button's accessible name to "Close alert". Both of these buttons open a documentation page instead, so screen-reader users were told the button dismisses the alert, and speech-input users had no visible label to say. Surfaced while working on #129954, which notes that consumers whose button isn't a dismiss action are better served by `action`.

**Who is this feature for?**

Screen reader and speech-input users of the Canvas and Geomap panel editors.

**Which issue(s) does this PR fix?**

Relates to #129954 — that issue is fixed separately in the `Alert` component itself; this PR moves the two non-dismiss call sites onto the right prop.

**Special notes for your reviewer:**

- Neither editor has an existing test file, and this introduces no new behaviour, so no tests were added. The `action` prop itself is covered in `Alert.test.tsx`.
- New i18n keys were extracted with `i18next-cli extract --sync-primary`; the only catalog change is the two added strings.
