### PR TITLE
Text: Vars autocomplete

### DIFF
--- a/public/app/plugins/panel/text/v2/TextNGPanel.tsx
+++ b/public/app/plugins/panel/text/v2/TextNGPanel.tsx
@@ -6,6 +6,7 @@ import { useDebounce } from 'react-use';
 import { CoreApp, type GrafanaTheme2, type PanelProps, type InterpolateFunction } from '@grafana/data';
 import { ScrollContainer, usePanelContext, useStyles2 } from '@grafana/ui';
 import config from 'app/core/config';
+import { getDataLinksVariableSuggestions } from 'app/features/panel/panellinks/link_srv';
 
 import { type CodeOptions, defaultCodeOptions, defaultOptions, type Options, TextMode } from '../panelcfg.gen';
 
@@ -19,11 +20,16 @@ export interface Props extends PanelProps<Options> {}
 
 export function TextNGPanel(props: Props) {
   const { app } = usePanelContext();
-  const { options, onOptionsChange, replaceVariables } = props;
+  const { options, onOptionsChange, replaceVariables, data } = props;
   const isEditing = app === CoreApp.PanelEditor;
   const content = options.content ?? defaultOptions.content ?? '';
 
   const interpolatedContent = isEditing ? '' : interpolateContent(options, replaceVariables);
+
+  const suggestions = useMemo(
+    () => (isEditing ? getDataLinksVariableSuggestions(data.series) : []),
+    [isEditing, data.series]
+  );
 
   const [processed, setProcessed] = useState<Options>(() => ({
     mode: options.mode,
@@ -72,6 +78,7 @@ export function TextNGPanel(props: Props) {
           showLineNumbers={options.code?.showLineNumbers ?? false}
           codeLanguage={options.code?.language}
           replaceVariables={replaceVariables}
+          suggestions={suggestions}
           onChange={(change) => onOptionsChange(applyEditorChange(options, change))}
         />
       </Suspense>

--- a/public/app/plugins/panel/text/v2/editor/TextNGEditor.tsx
+++ b/public/app/plugins/panel/text/v2/editor/TextNGEditor.tsx
@@ -3,7 +3,7 @@ import DangerouslySetHtmlContent from 'dangerously-set-html-content';
 import { useMemo, useRef, useState } from 'react';
 import { useDebounce } from 'react-use';
 
-import { type GrafanaTheme2, type InterpolateFunction } from '@grafana/data';
+import { type GrafanaTheme2, type InterpolateFunction, type VariableSuggestion } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Button, Dropdown, Icon, Menu, RadioButtonGroup, Stack, useStyles2, useTheme2 } from '@grafana/ui';
 import { CodeMirrorEditor, type CodeMirrorEditorLanguage } from '@grafana/ui/unstable';
@@ -14,6 +14,7 @@ import { TextNGCodeView } from '../TextNGCodeView';
 import { getInterpolateFormat, transformContent, getCodeMirrorLanguage } from '../utils';
 
 import { TextNGFormatToolbar } from './TextNGFormatToolbar';
+import { variableCompletion } from './variableCompletion';
 
 type ViewMode = 'write' | 'split' | 'preview';
 
@@ -32,6 +33,7 @@ export interface TextNGEditorProps {
   showLineNumbers: boolean;
   codeLanguage?: CodeLanguage;
   replaceVariables: InterpolateFunction;
+  suggestions?: VariableSuggestion[];
   onChange: (change: TextNGEditorChange) => void;
 }
 
@@ -58,6 +60,7 @@ export function TextNGEditor({
   showLineNumbers,
   codeLanguage,
   replaceVariables,
+  suggestions,
   onChange,
 }: TextNGEditorProps) {
   const theme = useTheme2();
@@ -136,6 +139,8 @@ export function TextNGEditor({
   } else if (mode === TextMode.Code) {
     editorLanguage = getCodeMirrorLanguage(codeLanguage);
   }
+
+  const completionSources = useMemo(() => [variableCompletion(suggestions ?? [])], [suggestions]);
 
   const basicSetup = useMemo(
     () => ({ lineNumbers: mode === TextMode.Code ? showLineNumbers : false }),
@@ -238,6 +243,7 @@ export function TextNGEditor({
               value={draft}
               onChange={handleDraftChange}
               language={editorLanguage}
+              completionSources={completionSources}
               lineWrapping
               basicSetup={basicSetup}
               height="100%"

--- a/public/app/plugins/panel/text/v2/editor/variableCompletion.test.ts
+++ b/public/app/plugins/panel/text/v2/editor/variableCompletion.test.ts
@@ -1,0 +1,47 @@
+import { CompletionContext } from '@codemirror/autocomplete';
+import { EditorState } from '@codemirror/state';
+
+import { VariableOrigin, type VariableSuggestion } from '@grafana/data';
+
+import { variableCompletion } from './variableCompletion';
+
+const suggestions: VariableSuggestion[] = [
+  { value: 'myVar', label: 'myVar', documentation: 'Custom variable', origin: VariableOrigin.Template },
+  { value: '__field.name', label: '__field.name', origin: VariableOrigin.Field },
+  { value: '__data.fields["Value"]', label: 'Value', origin: VariableOrigin.Fields },
+];
+
+function complete(doc: string, explicit = false) {
+  const source = variableCompletion(suggestions);
+  const context = new CompletionContext(EditorState.create({ doc }), doc.length, explicit);
+  return source(context);
+}
+
+describe('variableCompletion', () => {
+  it('offers every variable once `$` is typed', () => {
+    const result = complete('# Title\n$');
+    expect(result?.from).toBe(8);
+    expect(result?.options.map((o) => o.label)).toEqual(['${myVar}', '${__field.name}', '${__data.fields["Value"]}']);
+  });
+
+  it('replaces the whole reference being typed, including the brace', () => {
+    const result = complete('${myV');
+    expect(result?.from).toBe(0);
+    expect(result?.options.map((o) => o.label)).toEqual(['${myVar}']);
+  });
+
+  it('matches on the suggestion label as well as the value', () => {
+    expect(complete('$Value')?.options.map((o) => o.label)).toEqual(['${__data.fields["Value"]}']);
+  });
+
+  it('describes the origin, and the label when it differs from the value', () => {
+    const options = complete('$')?.options ?? [];
+    expect(options[0]).toMatchObject({ detail: VariableOrigin.Template, info: 'Custom variable' });
+    expect(options[2]).toMatchObject({ detail: `Value / ${VariableOrigin.Fields}` });
+  });
+
+  it('stays closed outside a variable reference, even when explicitly requested', () => {
+    expect(complete('some text')).toBeNull();
+    expect(complete('some text ', true)).toBeNull();
+  });
+});

--- a/public/app/plugins/panel/text/v2/editor/variableCompletion.ts
+++ b/public/app/plugins/panel/text/v2/editor/variableCompletion.ts
@@ -1,0 +1,40 @@
+import { type VariableSuggestion } from '@grafana/data';
+import {
+  type CodeMirrorCompletion,
+  type CodeMirrorCompletionContext,
+  type CodeMirrorCompletionResult,
+} from '@grafana/ui/unstable';
+
+// A variable being typed at the cursor: `$`, an optional brace, and the name so far.
+const TRIGGER_PATTERN = /\$\{?[\w.]*$/;
+
+const toCompletion = (suggestion: VariableSuggestion): CodeMirrorCompletion => ({
+  label: `\${${suggestion.value}}`,
+  detail: suggestion.value === suggestion.label ? suggestion.origin : `${suggestion.label} / ${suggestion.origin}`,
+  info: suggestion.documentation,
+  type: 'variable',
+});
+
+/**
+ * Autocompletion source for template and field variables, triggered by `$`.
+ *
+ * Options insert a full `${...}` reference, so the replaced range starts at the
+ * `$`. That `${` prefix would defeat CodeMirror's own matching, hence `filter: false`.
+ */
+export function variableCompletion(
+  suggestions: VariableSuggestion[]
+): (context: CodeMirrorCompletionContext) => CodeMirrorCompletionResult | null {
+  return (context) => {
+    const word = context.matchBefore(TRIGGER_PATTERN);
+    if (!word) {
+      return null;
+    }
+
+    const typed = word.text.replace(/^\$\{?/, '').toLowerCase();
+    const matches = typed
+      ? suggestions.filter((s) => s.value.toLowerCase().includes(typed) || s.label.toLowerCase().includes(typed))
+      : suggestions;
+
+    return { from: word.from, options: matches.map(toCompletion), filter: false };
+  };
+}

--- a/public/app/plugins/panel/text/v2/test-utils.tsx
+++ b/public/app/plugins/panel/text/v2/test-utils.tsx
@@ -1,11 +1,20 @@
 import { render } from '@testing-library/react';
 
 import { type CoreApp, dateTime, EventBusSrv, LoadingState } from '@grafana/data';
+import { setTemplateSrv } from '@grafana/runtime';
 import { PanelContextProvider, type PanelContext } from '@grafana/ui';
 
 import { TextMode } from '../panelcfg.gen';
 
 import { type Props, TextNGPanel } from './TextNGPanel';
+
+// Edit mode builds variable suggestions from the template service.
+setTemplateSrv({
+  getVariables: () => [],
+  replace: (target = '') => target,
+  containsTemplate: () => false,
+  updateTimeRange: () => {},
+});
 
 export function createProps(replaceVariables: Props['replaceVariables'], overrides: Partial<Props> = {}): Props {
   return {


### PR DESCRIPTION
Part of parity with Text v1 - it adds autocomplete when typing `$`. Interpolation only works for template vars currently. 


https://github.com/user-attachments/assets/1c8bd6c9-0557-4680-8d2e-7eeeff32fc5d




Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
