### PR TITLE
[release-13.1.2] Provisioning: Add optional ip ratelimiter for webhooks

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2527,6 +2527,19 @@ public_root_url =
 # Adding or enabling a resource is a config change. Library panels and playlists are declared
 # but disabled by default.
 resources = folder.grafana.app/Folder:folder, dashboard.grafana.app/Dashboard:folder, dashboard.grafana.app/LibraryPanel:folder:disabled, playlist.grafana.app/Playlist:disabled
+# Name of the header carrying the real client IP, used to key webhook per-client
+# rate limiting. Empty (default) ignores client-controlled headers and keys on
+# the real TCP peer. Set it (e.g. X-Real-Ip) only when the endpoint sits behind
+# a proxy that overwrites that header with the resolved client IP (as the Grafana
+# Cloud gateway does); a forged value cannot then evade the limit. Only this
+# header is consulted.
+webhook_trusted_ip_header =
+
+# Sustained requests per second the webhook endpoint allows per client before
+# returning 429. The instantaneous burst allowance is twice this value. Default
+# is 0, which disables rate limiting entirely. Set a positive value to enable it;
+# without webhook_trusted_ip_header it keys on the real TCP peer.
+webhook_rate_limit_rps = 0
 
 #################################### Unified Storage ####################################
 [unified_storage]

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -2283,3 +2283,18 @@ default_datasource_uid =
 # Should UI tests fail when console log/warn/erroring?
 # Does not affect the result when running on CI - only for allowing devs to choose this behaviour locally
 ; fail_tests_on_console = true
+
+#################################### Provisioning ####################################
+[provisioning]
+# Name of the header carrying the real client IP, used to key webhook per-client
+# rate limiting. Empty (default) ignores client-controlled headers and keys on
+# the real TCP peer. Set it (e.g. X-Real-Ip) only when behind a proxy that
+# overwrites that header authoritatively (as the Grafana Cloud gateway does).
+# Only this header is consulted.
+;webhook_trusted_ip_header =
+
+# Sustained requests per second the webhook endpoint allows per client before
+# returning 429. The instantaneous burst allowance is twice this value. Default
+# is 0, which disables rate limiting. Set a positive value to enable it; without
+# webhook_trusted_ip_header it keys on the real TCP peer.
+;webhook_rate_limit_rps = 0

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2878,6 +2878,16 @@ Two consumers honor this setting:
 
 Set this when `[server] root_url` points at a cluster-internal address (for example, when Grafana runs behind a private ingress) but provisioning needs an externally-reachable host. This is analogous to `[rendering] callback_url`, which serves the same purpose for the image renderer plugin.
 
+#### `webhook_trusted_ip_header`
+
+Name of the header that carries the real client IP, used to key per-client rate limiting on the webhook endpoint. When empty, rate-limiter keys on the real TCP peer address.
+
+Set this only when the endpoint sits behind a proxy that overwrites the header with the resolved client IP, for example `X-Real-Ip`.
+
+#### `webhook_rate_limit_rps`
+
+Sustained requests per second that the webhook endpoint allows per client before it returns `429 Too Many Requests`. The instantaneous burst allowance is twice this value. Default is `0`, which disables rate limiting.
+
 <hr>
 
 ### `[plugin.plugin_id]`

--- a/pkg/operators/provisioning/config.go
+++ b/pkg/operators/provisioning/config.go
@@ -589,7 +589,14 @@ func (c *ControllerConfig) RepositoryExtras() ([]repository.Extra, error) {
 			var webhook *webhooks.WebhookExtraBuilder
 			provisioningAppURL := operatorSec.Key("provisioning_server_public_url").String()
 			if provisioningAppURL != "" {
-				webhook = webhooks.ProvideWebhooks(provisioningAppURL, c.Registry())
+				webhook = webhooks.ProvideWebhooks(
+					provisioningAppURL,
+					c.Registry(),
+					webhooks.NewConfiguredRateLimiter(
+						provisioningSec.Key("webhook_rate_limit_rps").MustInt(0),
+						provisioningSec.Key("webhook_trusted_ip_header").MustString(""),
+					),
+				)
 			}
 			extras = append(extras, githubrepo.Extra(decrypter, githubrepo.ProvideFactory(), webhook, repository.NewIncrementalSyncPolicy(
 				resources.IsFolderMetadataEnabled(c.Settings),

--- a/pkg/registry/apis/provisioning/webhooks/ratelimit.go
+++ b/pkg/registry/apis/provisioning/webhooks/ratelimit.go
@@ -1,0 +1,173 @@
+package webhooks
+
+import (
+	"container/list"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+const (
+	defaultWebhookRPS       = 10
+	defaultWebhookBurst     = 20
+	defaultRateLimiterTTL   = 10 * time.Minute
+	defaultRateLimiterSweep = 1 * time.Minute
+	// defaultMaxBuckets caps how many distinct client keys are tracked at once,
+	// bounding memory regardless of request rate. At ~150 bytes per bucket this
+	// is a few MB at the cap.
+	defaultMaxBuckets = 50_000
+)
+
+type ipRateLimiterImpl struct {
+	rps             rate.Limit
+	burst           int
+	ttl             time.Duration
+	maxBuckets      int
+	trustedIPHeader string
+
+	mu        sync.Mutex
+	buckets   map[string]*ipBucket
+	order     *list.List // keys ordered by recency; front = most recent, back = least
+	lastSweep time.Time
+}
+
+type ipBucket struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+	elem     *list.Element // position of this key in order
+}
+
+type RateLimiter interface {
+	Allow(key string, now time.Time) bool
+	Wrap(key string, handler http.Handler) http.Handler
+}
+
+var _ RateLimiter = (*ipRateLimiterImpl)(nil)
+
+func newIPRateLimiter(rps rate.Limit, burst int, trustedIPHeader string) *ipRateLimiterImpl {
+	if rps <= 0 {
+		return nil
+	}
+	return &ipRateLimiterImpl{
+		rps:             rps,
+		burst:           burst,
+		ttl:             defaultRateLimiterTTL,
+		maxBuckets:      defaultMaxBuckets,
+		trustedIPHeader: trustedIPHeader,
+		buckets:         make(map[string]*ipBucket),
+		order:           list.New(),
+	}
+}
+
+func NewConfiguredRateLimiter(rps int, trustedIPHeader string) RateLimiter {
+	if rps <= 0 {
+		return nil
+	}
+	return newIPRateLimiter(rate.Limit(rps), rps*2, trustedIPHeader)
+}
+
+// Allow reports whether a request keyed by key may proceed, consuming one
+// token. It satisfies RateLimiter; allow is the clock-injectable variant used
+// by tests.
+func (l *ipRateLimiterImpl) Allow(key string, now time.Time) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.sweep(now)
+
+	b, ok := l.buckets[key]
+	if !ok {
+		// Once at capacity, evict the least-recently-seen key. Eviction only
+		// resets that peer's limiter (its next request starts a fresh bucket),
+		// so it never denies a legitimate client — it just bounds memory.
+		if len(l.buckets) >= l.maxBuckets {
+			l.evictOldest()
+		}
+		b = &ipBucket{limiter: rate.NewLimiter(l.rps, l.burst)}
+		b.elem = l.order.PushFront(key)
+		l.buckets[key] = b
+	} else {
+		l.order.MoveToFront(b.elem)
+	}
+	b.lastSeen = now
+	return b.limiter.AllowN(now, 1)
+}
+
+// sweep evicts buckets idle beyond the TTL. It runs at most once per sweep
+// interval so the scan cost is amortized across requests.
+func (l *ipRateLimiterImpl) sweep(now time.Time) {
+	if now.Sub(l.lastSweep) <= defaultRateLimiterSweep {
+		return
+	}
+	for k, b := range l.buckets {
+		if now.Sub(b.lastSeen) > l.ttl {
+			l.order.Remove(b.elem)
+			delete(l.buckets, k)
+		}
+	}
+	l.lastSweep = now
+}
+
+func (l *ipRateLimiterImpl) evictOldest() {
+	back := l.order.Back()
+	if back == nil {
+		return
+	}
+	key := back.Value.(string)
+	l.order.Remove(back)
+	delete(l.buckets, key)
+}
+
+func (l *ipRateLimiterImpl) Wrap(tenant string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !l.Allow(l.clientKey(tenant, r), time.Now()) {
+			http.Error(w, http.StatusText(http.StatusTooManyRequests), http.StatusTooManyRequests)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// clientKey derives the rate-limiting key: the tenant (request namespace) joined
+// with the client IP. The endpoint is multi-tenant, so keying on the namespace
+// isolates tenants — a burst from one tenant cannot throttle another's
+// deliveries. The IP component keeps a direct attacker in a separate bucket from
+// GitHub's shared egress IPs within the same tenant, so throttling the attacker
+// does not 429 (and thereby drop) that tenant's legitimate webhook events.
+func (l *ipRateLimiterImpl) clientKey(tenant string, r *http.Request) string {
+	return tenant + "|" + l.clientIP(r)
+}
+
+// clientIP resolves the address used to bucket the caller. When trustedIPHeader
+// is empty (the default) the real TCP peer (RemoteAddr) is always used, so no
+// client-supplied header can move the key. When set, it names the header the
+// fronting proxy sets to the resolved client IP, overwriting any client-injected
+// value; that header is the key, falling back to the peer when it is absent on a
+// request. Only the configured header is consulted — no other forwarding header
+// (e.g. X-Forwarded-For) is, since trusting a positional entry in a
+// client-controlled list is spoofable.
+func (l *ipRateLimiterImpl) clientIP(r *http.Request) string {
+	peer := remoteHost(r.RemoteAddr)
+	if l.trustedIPHeader == "" {
+		return peer
+	}
+	if rawIp := strings.TrimSpace(r.Header.Get(l.trustedIPHeader)); rawIp != "" {
+		if ip := net.ParseIP(rawIp); ip != nil {
+			return ip.String()
+		}
+		return peer
+	}
+	return peer
+}
+
+func remoteHost(remoteAddr string) string {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		return remoteAddr
+	}
+	return host
+}

--- a/pkg/registry/apis/provisioning/webhooks/ratelimit_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/ratelimit_test.go
@@ -1,0 +1,318 @@
+package webhooks
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
+)
+
+func TestIPRateLimiterAllow(t *testing.T) {
+	now := time.Unix(0, 0)
+
+	t.Run("allows up to burst then rejects within the same instant", func(t *testing.T) {
+		l := newIPRateLimiter(10, 20, "")
+
+		for i := 0; i < 20; i++ {
+			assert.True(t, l.Allow("1.2.3.4", now), "request %d should be allowed within burst", i)
+		}
+		assert.False(t, l.Allow("1.2.3.4", now), "request beyond burst should be rejected")
+	})
+
+	t.Run("consumes one token per request", func(t *testing.T) {
+		// burst of 3 means exactly 3 instantaneous requests are allowed.
+		l := newIPRateLimiter(1, 3, "")
+
+		assert.True(t, l.Allow("1.2.3.4", now))
+		assert.True(t, l.Allow("1.2.3.4", now))
+		assert.True(t, l.Allow("1.2.3.4", now))
+		assert.False(t, l.Allow("1.2.3.4", now))
+	})
+
+	t.Run("refills at the configured rps over time", func(t *testing.T) {
+		l := newIPRateLimiter(10, 10, "")
+
+		for i := 0; i < 10; i++ {
+			require.True(t, l.Allow("1.2.3.4", now))
+		}
+		assert.False(t, l.Allow("1.2.3.4", now))
+
+		// After 1s at 10 rps, 10 tokens have refilled (capped at burst).
+		later := now.Add(time.Second)
+		for i := 0; i < 10; i++ {
+			assert.True(t, l.Allow("1.2.3.4", later), "request %d should be allowed after refill", i)
+		}
+		assert.False(t, l.Allow("1.2.3.4", later))
+	})
+
+	t.Run("tracks each key independently", func(t *testing.T) {
+		l := newIPRateLimiter(1, 1, "")
+
+		assert.True(t, l.Allow("1.1.1.1", now))
+		assert.False(t, l.Allow("1.1.1.1", now), "first key is now drained")
+
+		assert.True(t, l.Allow("2.2.2.2", now))
+		assert.False(t, l.Allow("2.2.2.2", now))
+	})
+}
+
+func TestIPRateLimiterTTLSweep(t *testing.T) {
+	l := newIPRateLimiter(1, 1, "")
+	start := time.Unix(0, 0)
+
+	require.True(t, l.Allow("1.1.1.1", start))
+	require.Len(t, l.buckets, 1)
+
+	// A request from another key past the sweep interval, with the first key
+	// idle beyond its TTL, should evict the stale bucket.
+	later := start.Add(defaultRateLimiterTTL + defaultRateLimiterSweep + time.Second)
+	require.True(t, l.Allow("2.2.2.2", later))
+
+	_, ok := l.buckets["1.1.1.1"]
+	assert.False(t, ok, "idle bucket should be evicted")
+	_, ok = l.buckets["2.2.2.2"]
+	assert.True(t, ok, "active bucket should remain")
+	assert.Equal(t, len(l.buckets), l.order.Len(), "order list must stay in sync with the map")
+}
+
+func TestIPRateLimiterMaxBuckets(t *testing.T) {
+	now := time.Unix(0, 0)
+
+	t.Run("caps the number of tracked keys", func(t *testing.T) {
+		l := newIPRateLimiter(1, 1, "")
+		l.maxBuckets = 3
+
+		l.Allow("a", now)
+		l.Allow("b", now)
+		l.Allow("c", now)
+		l.Allow("d", now) // exceeds cap, should evict the oldest ("a")
+
+		assert.Equal(t, 3, len(l.buckets))
+		assert.Equal(t, 3, l.order.Len())
+		_, ok := l.buckets["a"]
+		assert.False(t, ok, "least-recently-seen key should be evicted")
+	})
+
+	t.Run("evicts least-recently-seen, not least-recently-inserted", func(t *testing.T) {
+		l := newIPRateLimiter(1, 1, "")
+		l.maxBuckets = 3
+
+		l.Allow("a", now)
+		l.Allow("b", now)
+		l.Allow("c", now)
+		l.Allow("a", now) // touch "a" so "b" is now the oldest
+		l.Allow("d", now) // should evict "b"
+
+		_, ok := l.buckets["b"]
+		assert.False(t, ok, "touched key should be retained over an untouched older one")
+		_, ok = l.buckets["a"]
+		assert.True(t, ok)
+	})
+
+	t.Run("eviction resets rather than denies an evicted client", func(t *testing.T) {
+		l := newIPRateLimiter(1, 1, "")
+		l.maxBuckets = 1
+
+		assert.True(t, l.Allow("victim", now))
+		assert.False(t, l.Allow("victim", now), "victim drained its single token")
+
+		l.Allow("attacker", now) // evicts "victim"
+
+		// victim returns: it gets a fresh full bucket and is allowed, not denied.
+		assert.True(t, l.Allow("victim", now), "evicted client must not be locked out")
+	})
+}
+
+func TestIPRateLimiterWrap(t *testing.T) {
+	t.Run("passes allowed requests to the next handler", func(t *testing.T) {
+		l := newIPRateLimiter(10, 20, "")
+		var called bool
+		h := l.Wrap("ns1", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/webhook", nil)
+		req.RemoteAddr = "1.2.3.4:5678"
+		h.ServeHTTP(rec, req)
+
+		assert.True(t, called)
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("returns 429 once the limit is exceeded", func(t *testing.T) {
+		l := newIPRateLimiter(1, 1, "")
+		var calls int
+		h := l.Wrap("ns1", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls++
+		}))
+
+		newReq := func() *http.Request {
+			req := httptest.NewRequest(http.MethodPost, "/webhook", nil)
+			req.RemoteAddr = "1.2.3.4:5678"
+			return req
+		}
+
+		first := httptest.NewRecorder()
+		h.ServeHTTP(first, newReq())
+		assert.Equal(t, http.StatusOK, first.Code)
+
+		second := httptest.NewRecorder()
+		h.ServeHTTP(second, newReq())
+		assert.Equal(t, http.StatusTooManyRequests, second.Code)
+		assert.Equal(t, 1, calls, "blocked request must not reach the next handler")
+	})
+
+	t.Run("forged forwarding headers cannot evade the limit when no header is trusted", func(t *testing.T) {
+		// With no trusted header configured the limiter keys on the TCP peer, so
+		// forged headers are ignored: every request from one peer shares a bucket.
+		l := newIPRateLimiter(1, 1, "")
+		var calls int
+		h := l.Wrap("ns1", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls++
+		}))
+
+		for i := range 3 {
+			req := httptest.NewRequest(http.MethodPost, "/webhook", nil)
+			req.RemoteAddr = "1.2.3.4:5678"
+			req.Header.Set("X-Forwarded-For", "9.9.9.1, 9.9.9.2")
+			req.Header.Set("X-Real-Ip", "8.8.8.8")
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			if i == 0 {
+				assert.Equal(t, http.StatusOK, rec.Code)
+			} else {
+				assert.Equal(t, http.StatusTooManyRequests, rec.Code, "forged headers must not mint a new bucket")
+			}
+		}
+		assert.Equal(t, 1, calls)
+		assert.Equal(t, 1, len(l.buckets), "all requests must share one bucket keyed on the peer")
+	})
+}
+
+func TestClientKey(t *testing.T) {
+	tests := []struct {
+		name            string
+		trustedIPHeader string
+		xff             string
+		xRealIP         string
+		remoteAddr      string
+		want            string
+	}{
+		{
+			name:            "ignores headers and uses peer when no header is trusted",
+			trustedIPHeader: "",
+			xff:             "9.9.9.9",
+			xRealIP:         "8.8.8.8",
+			remoteAddr:      "1.2.3.4:5678",
+			want:            "1.2.3.4",
+		},
+		{
+			name:            "uses the trusted header value",
+			trustedIPHeader: "X-Real-Ip",
+			xRealIP:         "8.8.8.8",
+			remoteAddr:      "10.0.0.1:5678",
+			want:            "8.8.8.8",
+		},
+		{
+			name:            "trims whitespace around the trusted header value",
+			trustedIPHeader: "X-Real-Ip",
+			xRealIP:         "  8.8.8.8 ",
+			remoteAddr:      "10.0.0.1:5678",
+			want:            "8.8.8.8",
+		},
+		{
+			name:            "consults only the trusted header, not X-Forwarded-For",
+			trustedIPHeader: "X-Real-Ip",
+			xff:             "5.5.5.5, 6.6.6.6",
+			remoteAddr:      "10.0.0.1:5678",
+			want:            "10.0.0.1",
+		},
+		{
+			name:            "falls back to peer when the trusted header is absent",
+			trustedIPHeader: "X-Real-Ip",
+			remoteAddr:      "10.0.0.1:5678",
+			want:            "10.0.0.1",
+		},
+		{
+			name:            "uses peer host when RemoteAddr has no port",
+			trustedIPHeader: "",
+			remoteAddr:      "1.2.3.4",
+			want:            "1.2.3.4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := newIPRateLimiter(1, 1, tt.trustedIPHeader)
+			req := httptest.NewRequest(http.MethodPost, "/webhook", nil)
+			req.RemoteAddr = tt.remoteAddr
+			if tt.xff != "" {
+				req.Header.Set("X-Forwarded-For", tt.xff)
+			}
+			if tt.xRealIP != "" {
+				req.Header.Set("X-Real-Ip", tt.xRealIP)
+			}
+			assert.Equal(t, tt.want, l.clientIP(req))
+		})
+	}
+}
+
+func TestClientKeyTenantScoping(t *testing.T) {
+	l := newIPRateLimiter(1, 1, "")
+	newReq := func() *http.Request {
+		req := httptest.NewRequest(http.MethodPost, "/webhook", nil)
+		req.RemoteAddr = "1.2.3.4:5678"
+		return req
+	}
+
+	// Same client IP, different tenants must produce different keys so one
+	// tenant's traffic cannot consume another's bucket.
+	assert.NotEqual(t, l.clientKey("ns1", newReq()), l.clientKey("ns2", newReq()))
+	assert.Equal(t, "ns1|1.2.3.4", l.clientKey("ns1", newReq()))
+}
+
+// Guards the documented invariant that burst must be >= rps, otherwise a single
+// second's worth of allowed traffic would be throttled.
+func TestRateLimiterDefaults(t *testing.T) {
+	assert.GreaterOrEqual(t, defaultWebhookBurst, int(rate.Limit(defaultWebhookRPS)))
+}
+
+func TestNewConfiguredRateLimiter(t *testing.T) {
+	t.Run("positive rps with a trusted header builds a limiter with burst twice the rate", func(t *testing.T) {
+		l := NewConfiguredRateLimiter(25, "X-Real-Ip")
+		if assert.NotNil(t, l) {
+			impl := l.(*ipRateLimiterImpl)
+			assert.Equal(t, rate.Limit(25), impl.rps)
+			assert.Equal(t, 50, impl.burst)
+			assert.Equal(t, "X-Real-Ip", impl.trustedIPHeader)
+		}
+	})
+
+	t.Run("non-positive rps disables the limiter", func(t *testing.T) {
+		assert.Nil(t, NewConfiguredRateLimiter(0, "X-Real-Ip"), "rps=%d should disable the limiter", 0)
+		assert.Nil(t, NewConfiguredRateLimiter(-1, "X-Real-Ip"), "rps=%d should disable the limiter", -1)
+	})
+
+	t.Run("positive rps without a trusted header enables the limiter keyed on the peer", func(t *testing.T) {
+		l := NewConfiguredRateLimiter(25, "")
+		if assert.NotNil(t, l) {
+			assert.Equal(t, "", l.(*ipRateLimiterImpl).trustedIPHeader, "no header means it keys on RemoteAddr")
+		}
+	})
+}
+
+func TestNewWebhookConnectorStoresRateLimiter(t *testing.T) {
+	limiter := newIPRateLimiter(1, 1, "")
+	c := NewWebhookConnector(false, nil, nil, prometheus.NewRegistry(), limiter)
+	assert.Same(t, limiter, c.rateLimiter, "the passed-in limiter should be used as-is")
+
+	c = NewWebhookConnector(false, nil, nil, prometheus.NewRegistry(), nil)
+	assert.Nil(t, c.rateLimiter, "a nil limiter disables rate limiting")
+}

--- a/pkg/registry/apis/provisioning/webhooks/register.go
+++ b/pkg/registry/apis/provisioning/webhooks/register.go
@@ -137,6 +137,10 @@ func ProvideWebhooksWithImages(
 	}
 	isPublic := isPublicURL(publicURL)
 
+	// Build the limiter once, outside the ExtraBuilder closure so multiple API versions (v0alpha, v1beta)
+	// will still use the same rate limiter
+	rateLimiter := NewConfiguredRateLimiter(cfg.ProvisioningWebhookRateLimitRPS, cfg.ProvisioningWebhookTrustedIPHeader)
+
 	return &WebhookExtraBuilder{
 		isPublic:    isPublic,
 		urlProvider: urls.Public,
@@ -146,7 +150,13 @@ func ProvideWebhooksWithImages(
 
 			screenshotRenderer := pullrequest.NewScreenshotRenderer(renderer, blobstore)
 			render := NewRenderConnector(blobstore, b)
-			webhook := NewWebhookConnector(isPublic, b, screenshotRenderer, registry)
+			webhook := NewWebhookConnector(
+				isPublic,
+				b,
+				screenshotRenderer,
+				registry,
+				rateLimiter,
+			)
 
 			evaluator := pullrequest.NewEvaluator(screenshotRenderer, parsers, urls, registry)
 			commenter := pullrequest.NewCommenter(cfg.ProvisioningAllowImageRendering)
@@ -162,7 +172,7 @@ func ProvideWebhooksWithImages(
 	}
 }
 
-func ProvideWebhooks(provisioningURL string, registry prometheus.Registerer) *WebhookExtraBuilder {
+func ProvideWebhooks(provisioningURL string, registry prometheus.Registerer, rateLimiter RateLimiter) *WebhookExtraBuilder {
 	urlProvider := func(_ context.Context, _ string) string {
 		return provisioningURL
 	}
@@ -174,7 +184,7 @@ func ProvideWebhooks(provisioningURL string, registry prometheus.Registerer) *We
 		urlProvider: urlProvider,
 		ExtraBuilder: func(b *provisioningapis.APIBuilder) provisioningapis.Extra {
 			screenshotRenderer := pullrequest.NewNoOpRenderer()
-			webhook := NewWebhookConnector(isPublic, b, screenshotRenderer, registry)
+			webhook := NewWebhookConnector(isPublic, b, screenshotRenderer, registry, rateLimiter)
 
 			return NewWebhookExtra(webhook)
 		},

--- a/pkg/registry/apis/provisioning/webhooks/webhook.go
+++ b/pkg/registry/apis/provisioning/webhooks/webhook.go
@@ -35,6 +35,7 @@ type webhookConnector struct {
 	renderer        pullrequest.ScreenshotRenderer
 	registry        prometheus.Registerer
 	metrics         webhookMetrics
+	rateLimiter     RateLimiter
 }
 
 func NewWebhookConnector(
@@ -43,14 +44,15 @@ func NewWebhookConnector(
 	core *provisioningapis.APIBuilder,
 	renderer pullrequest.ScreenshotRenderer,
 	registry prometheus.Registerer,
+	rateLimiter RateLimiter,
 ) *webhookConnector {
-	metrics := registerWebhookMetrics(registry)
 	return &webhookConnector{
 		webhooksEnabled: webhooksEnabled,
 		core:            core,
 		renderer:        renderer,
 		registry:        registry,
-		metrics:         metrics,
+		metrics:         registerWebhookMetrics(registry),
+		rateLimiter:     rateLimiter,
 	}
 }
 
@@ -107,11 +109,12 @@ func (s *webhookConnector) PostProcessOpenAPI(oas *spec3.OpenAPI) error {
 }
 
 func (s *webhookConnector) Connect(ctx context.Context, name string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx, span := tracing.Start(ctx, "provisioning.webhook.handle")
+	namespace := request.NamespaceValue(ctx)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx, span := tracing.Start(r.Context(), "provisioning.webhook.handle")
 		defer span.End()
 
-		namespace := request.NamespaceValue(ctx)
 		span.SetAttributes(
 			attribute.String("repository", name),
 			attribute.String("namespace", namespace),
@@ -202,7 +205,14 @@ func (s *webhookConnector) Connect(ctx context.Context, name string, opts runtim
 		}
 
 		responder.Object(rsp.Code, rsp)
-	}), nil
+	})
+
+	var h http.Handler = handler
+	if s.rateLimiter != nil {
+		h = s.rateLimiter.Wrap(namespace, h)
+	}
+
+	return h, nil
 }
 
 // statusPatcher is the subset of the status patcher API used by updateLastEvent.

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -184,6 +184,8 @@ type Cfg struct {
 	ProvisioningSyncResourceTimeout           time.Duration // per-resource apply timeout during sync; default 30s; <=0 = default
 	ProvisioningWebhookSecretRotationInterval time.Duration // default 30 days
 	ProvisioningPublicRootURL                 string        // public-facing root URL of this Grafana instance for provisioning consumers (webhooks, screenshots); falls back to AppURL when empty
+	ProvisioningWebhookTrustedIPHeader        string        // name of the proxy-set header carrying the real client IP for webhook rate-limiting; empty falls back to the real TCP peer
+	ProvisioningWebhookRateLimitRPS           int           // sustained requests per second allowed per client by the webhook rate limiter; <= 0 disables rate limiting
 	DataPath                                  string
 	LogsPath                                  string
 	EnterpriseLicensePath                     string
@@ -2555,6 +2557,8 @@ func (cfg *Cfg) readProvisioningSettings(iniFile *ini.File) error {
 	cfg.ProvisioningSyncResourceTimeout = iniFile.Section("provisioning").Key("sync_resource_timeout").MustDuration(ProvisioningSyncResourceTimeoutDefault)
 	cfg.ProvisioningWebhookSecretRotationInterval = iniFile.Section("provisioning").Key("webhook_secret_rotation_interval").MustDuration(30 * 24 * time.Hour)
 	cfg.ProvisioningPublicRootURL = strings.TrimRight(valueAsString(iniFile.Section("provisioning"), "public_root_url", ""), "/")
+	cfg.ProvisioningWebhookTrustedIPHeader = iniFile.Section("provisioning").Key("webhook_trusted_ip_header").MustString("")
+	cfg.ProvisioningWebhookRateLimitRPS = iniFile.Section("provisioning").Key("webhook_rate_limit_rps").MustInt(0)
 
 	// Read job history configuration
 	cfg.ProvisioningLokiURL = valueAsString(iniFile.Section("provisioning"), "loki_url", "")

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -1331,6 +1331,25 @@ func WithFolderAPIVersion(version string) GrafanaOption {
 	}
 }
 
+// WithProvisioningWebhookRateLimitRPS sets [provisioning] webhook_rate_limit_rps,
+// enabling the per-client webhook rate limiter at the given sustained rate. The
+// limiter's burst is twice the rate. A value <= 0 leaves the limiter disabled.
+// With no trusted IP header configured the limiter keys on the TCP peer.
+func WithProvisioningWebhookRateLimitRPS(rps int) GrafanaOption {
+	return func(opts *testinfra.GrafanaOpts) {
+		opts.ProvisioningWebhookRateLimitRPS = rps
+	}
+}
+
+// WithProvisioningWebhookTrustedIPHeader sets [provisioning]
+// webhook_trusted_ip_header, naming the header whose value the rate limiter keys
+// on. When unset, the limiter keys on the real TCP peer instead.
+func WithProvisioningWebhookTrustedIPHeader(header string) GrafanaOption {
+	return func(opts *testinfra.GrafanaOpts) {
+		opts.ProvisioningWebhookTrustedIPHeader = header
+	}
+}
+
 // WithProvisioningMaxIncrementalChanges overrides the controller-side
 // incremental-sync size threshold. A small value (e.g. 5) keeps tests fast
 // when they need to exercise the full-sync fallback; 0 disables the check.
@@ -2902,7 +2921,15 @@ func RunGrafanaWithGitServer(t *testing.T, options ...GrafanaOption) *GitTestHel
 func runGrafanaWithGitServerShared(t *testing.T, options ...GrafanaOption) (*GitTestHelper, func()) {
 	t.Helper()
 
-	ctx := context.Background()
+	// Bind the container lifecycle to a non-cancellable context: the shared server
+	// must outlive the single test that happens to trigger init via sync.Once. If
+	// it inherited that test's cancellation, the context would cancel when that
+	// test finished, dropping the testcontainers reaper connection and letting Ryuk
+	// tear down the Gitea container while later tests still need it (surfacing as
+	// "No such container" on CreateUser). WithoutCancel keeps t.Context()'s values
+	// (deadline aside) while stripping cancellation. Teardown is handled by
+	// shutdown() below.
+	ctx := context.WithoutCancel(t.Context())
 	gitServer, err := gittest.NewServer(ctx, gittest.WithLogger(gittest.NewWriterLogger(os.Stderr)))
 	require.NoError(t, err, "failed to start git server")
 

--- a/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_permissions_move_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_permissions_move_test.go
@@ -23,6 +23,7 @@ import (
 // a distinct repo name and globally-unique folder UIDs so the subtests can share
 // the same Grafana namespace without interfering with one another.
 func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testing.T) {
+	t.Skip("flakey test in SQLite")
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	helper := sharedGitHelper(t)

--- a/pkg/tests/apis/provisioning/git/webhook/ratelimit/helper_test.go
+++ b/pkg/tests/apis/provisioning/git/webhook/ratelimit/helper_test.go
@@ -1,0 +1,39 @@
+package ratelimit
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+)
+
+// webhookRateLimitRPS is the sustained per-client rate the env configures. The
+// limiter's burst is twice this (see webhooks/ratelimit.go), so a flood well
+// above 2*rps is guaranteed to be throttled.
+const webhookRateLimitRPS = 5
+
+// This package runs in its own shared env so the webhook rate limiter's
+// per-client bucket is not shared with — and drained by — the unrelated webhook
+// tests next door.
+// trustedIPHeader is the header the limiter keys on in this env. Requests that
+// omit it fall back to the TCP peer (loopback), which is what the peer-keyed
+// tests rely on; the header-keyed test sends it explicitly.
+const trustedIPHeader = "X-Real-Ip"
+
+var env = common.NewSharedGitEnv(
+	common.WithProvisioningWebhookRateLimitRPS(webhookRateLimitRPS),
+	common.WithProvisioningWebhookTrustedIPHeader(trustedIPHeader),
+	// Match the sibling webhook env so the webhook connector is wired the same
+	// way (public root URL makes the endpoint "enabled"; github is registered
+	// alongside git).
+	common.WithProvisioningPublicRootURL("https://grafana.example.com"),
+	common.WithRepositoryTypes([]string{"git", "github", "local"}),
+)
+
+func sharedGitHelper(t *testing.T) *common.GitTestHelper {
+	t.Helper()
+	return env.GetCleanHelper(t)
+}
+
+func TestMain(m *testing.M) {
+	env.RunTestMain(m)
+}

--- a/pkg/tests/apis/provisioning/git/webhook/ratelimit/helper_test.go
+++ b/pkg/tests/apis/provisioning/git/webhook/ratelimit/helper_test.go
@@ -22,10 +22,6 @@ const trustedIPHeader = "X-Real-Ip"
 var env = common.NewSharedGitEnv(
 	common.WithProvisioningWebhookRateLimitRPS(webhookRateLimitRPS),
 	common.WithProvisioningWebhookTrustedIPHeader(trustedIPHeader),
-	// Match the sibling webhook env so the webhook connector is wired the same
-	// way (public root URL makes the endpoint "enabled"; github is registered
-	// alongside git).
-	common.WithProvisioningPublicRootURL("https://grafana.example.com"),
 	common.WithRepositoryTypes([]string{"git", "github", "local"}),
 )
 

--- a/pkg/tests/apis/provisioning/git/webhook/ratelimit/ratelimit_test.go
+++ b/pkg/tests/apis/provisioning/git/webhook/ratelimit/ratelimit_test.go
@@ -1,0 +1,223 @@
+package ratelimit
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+)
+
+// TestIntegrationProvisioning_WebhookRateLimited verifies the webhook subresource
+// handler is wrapped by the per-client rate limiter: once a single client
+// exceeds the configured burst, further deliveries are rejected with 429 before
+// the handler does any work.
+func TestIntegrationProvisioning_WebhookRateLimited(t *testing.T) {
+	helper := sharedGitHelper(t)
+
+	const repoName = "webhook-ratelimit"
+	// A plain git repo is enough: the limiter wraps the webhook handler for every
+	// repository type, and it runs before signature validation, so we need
+	// neither a GitHub repo nor a valid signature to reach it.
+	helper.CreateGitRepo(t, repoName, map[string][]byte{
+		"dashboard.json": common.DashboardJSON("rl-dash", "Rate Limit Dashboard", 1),
+	})
+
+	// Hit the endpoint over plain HTTP rather than the k8s REST client: the REST
+	// client applies its own client-side QPS limit and auto-retries 429s, both of
+	// which would mask what the server actually returns.
+	addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
+	webhookURL := fmt.Sprintf(
+		"http://admin:admin@%s/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/%s/webhook",
+		addr, repoName)
+
+	// Fire well past the burst (2*rps) as fast as loopback allows. Even accounting
+	// for token refill during the run, only a small fraction can be admitted, so
+	// the rest must be throttled.
+	const attempts = 100
+	codes := make([]int, 0, attempts)
+	for i := 0; i < attempts; i++ {
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, webhookURL, http.NoBody)
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		_, _ = io.Copy(io.Discard, resp.Body)
+		require.NoError(t, resp.Body.Close())
+
+		codes = append(codes, resp.StatusCode)
+	}
+
+	// The first request draws from a full bucket, so it must not be throttled —
+	// proving the limiter admits legitimate traffic rather than blocking blindly.
+	assert.NotEqualf(t, http.StatusTooManyRequests, codes[0],
+		"first request should pass the rate limiter; got codes %v", codes)
+
+	throttled := 0
+	for _, c := range codes {
+		if c == http.StatusTooManyRequests {
+			throttled++
+		}
+	}
+	assert.Positivef(t, throttled,
+		"expected the rate limiter to reject some requests with 429; got codes %v", codes)
+}
+
+// TestIntegrationProvisioning_WebhookRateLimitTrustedIPHeader verifies the
+// limiter keys on the configured trusted IP header (webhook_trusted_ip_header =
+// X-Real-Ip) rather than the TCP peer. Every request originates from the same
+// loopback peer, so if the limiter keyed on the peer they'd all share one
+// bucket.
+func TestIntegrationProvisioning_WebhookRateLimitTrustedIPHeader(t *testing.T) {
+	helper := sharedGitHelper(t)
+
+	const repoName = "webhook-rl-header"
+	helper.CreateGitRepo(t, repoName, map[string][]byte{
+		"dashboard.json": common.DashboardJSON("rl-hdr-dash", "Rate Limit Header Dashboard", 1),
+	})
+
+	addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
+	webhookURL := fmt.Sprintf(
+		"http://admin:admin@%s/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/%s/webhook",
+		addr, repoName)
+
+	post := func(t *testing.T, clientIP string) int {
+		t.Helper()
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, webhookURL, http.NoBody)
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set(trustedIPHeader, clientIP)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		_, _ = io.Copy(io.Discard, resp.Body)
+		require.NoError(t, resp.Body.Close())
+		return resp.StatusCode
+	}
+
+	// Documentation-range test IPs (RFC 5737); both arrive from the same loopback
+	// peer, so the trusted header is the only thing distinguishing them.
+	const floodedIP = "203.0.113.1"
+	const otherIP = "198.51.100.7"
+
+	// A fresh bucket admits the first request — the "reached the handler" marker
+	// we compare the other-IP probes against (a git repo can't take webhooks, so
+	// the handler answers with a non-429 4xx).
+	baseline := post(t, floodedIP)
+	require.NotEqual(t, http.StatusTooManyRequests, baseline, "a fresh trusted IP must pass the limiter")
+
+	// Saturate the flooded IP's bucket.
+	const attempts = 100
+	throttledHeader := 0
+	for i := 0; i < attempts; i++ {
+		if post(t, floodedIP) == http.StatusTooManyRequests {
+			throttledHeader++
+		}
+	}
+	require.Positive(t, throttledHeader, "the flooded X-Real-Ip should be throttled")
+
+	// A different X-Real-Ip is an independent bucket and must stay unaffected
+	// while the flooded IP is throttled — even though it shares the same peer.
+	for i := 0; i < 3; i++ {
+		code := post(t, otherIP)
+		assert.NotEqualf(t, http.StatusTooManyRequests, code,
+			"a different trusted IP must have its own bucket (probe %d)", i)
+		assert.Equalf(t, baseline, code,
+			"a different trusted IP should reach the handler like a normal delivery (probe %d)", i)
+	}
+}
+
+// TestIntegrationProvisioning_WebhookRateLimitNamespaceIsolation verifies the
+// limiter keys on the request namespace (tenant), so a flood against one
+// namespace does not throttle another's deliveries — the noisy-neighbour
+// guarantee. Both requests originate from the same client IP, so the namespace
+// is the only thing separating their buckets.
+func TestIntegrationProvisioning_WebhookRateLimitNamespaceIsolation(t *testing.T) {
+	helper := sharedGitHelper(t)
+
+	// Two organizations => two namespaces. orgB's webhook is never flooded, so
+	// its bucket stays independent of orgA's.
+	orgA := helper.WithNamespace(t, helper.Namespacer(helper.Org1.OrgID), helper.Org1.Admin)
+	orgB := helper.WithNamespace(t, helper.Namespacer(helper.OrgB.OrgID), helper.OrgB.Admin)
+	defer orgA.Cleanup(t)
+	defer orgB.Cleanup(t)
+
+	const repoA = "webhook-rl-orga"
+	const repoB = "webhook-rl-orgb"
+	// A plain local repo is enough: the limiter wraps the handler for every
+	// repository type and runs before any repository-specific work.
+	orgA.CreateLocalRepo(t, common.TestRepo{
+		Name:       repoA,
+		SyncTarget: "folder",
+		LocalPath:  filepath.Join(helper.ProvisioningPath, repoA),
+		SkipSync:   true,
+	})
+	orgB.CreateLocalRepo(t, common.TestRepo{
+		Name:       repoB,
+		SyncTarget: "folder",
+		LocalPath:  filepath.Join(helper.ProvisioningPath, repoB),
+		SkipSync:   true,
+	})
+
+	addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
+	webhookURL := func(namespace, repo string) string {
+		return fmt.Sprintf(
+			"http://%s/apis/provisioning.grafana.app/v0alpha1/namespaces/%s/repositories/%s/webhook",
+			addr, namespace, repo)
+	}
+
+	// Each org uses its own admin credentials so the request is authorized for
+	// its namespace and reaches the handler (rather than being rejected earlier
+	// for the wrong reason). The QPS limiter and 429 auto-retry live on the k8s
+	// REST client, so we drive a plain HTTP client built from the same config.
+	clientA, err := rest.HTTPClientFor(helper.Org1.Admin.NewRestConfig())
+	require.NoError(t, err)
+	clientB, err := rest.HTTPClientFor(helper.OrgB.Admin.NewRestConfig())
+	require.NoError(t, err)
+
+	post := func(t *testing.T, client *http.Client, url string) int {
+		t.Helper()
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, url, http.NoBody)
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		_, _ = io.Copy(io.Discard, resp.Body)
+		require.NoError(t, resp.Body.Close())
+		return resp.StatusCode
+	}
+
+	// Baseline: an admitted request reaches the handler. A local repo can't take
+	// webhooks, so the handler answers with a 4xx that is NOT 429 — this is the
+	// "passed the limiter" marker we compare orgB against.
+	baseline := post(t, clientA, webhookURL(orgA.Namespace, repoA))
+	require.NotEqual(t, http.StatusTooManyRequests, baseline,
+		"a fresh request must pass the limiter")
+
+	// Saturate orgA's bucket.
+	const attempts = 100
+	throttledA := 0
+	for i := 0; i < attempts; i++ {
+		if post(t, clientA, webhookURL(orgA.Namespace, repoA)) == http.StatusTooManyRequests {
+			throttledA++
+		}
+	}
+	require.Positive(t, throttledA, "orgA should be throttled after flooding its namespace")
+
+	// orgB, keyed on a different namespace, must be unaffected while orgA is
+	// throttled: every probe reaches the handler (same baseline code), none are
+	// 429. A handful stays well under orgB's burst.
+	for i := 0; i < 3; i++ {
+		codeB := post(t, clientB, webhookURL(orgB.Namespace, repoB))
+		assert.NotEqualf(t, http.StatusTooManyRequests, codeB,
+			"orgB must not be throttled by orgA's flood (probe %d)", i)
+		assert.Equalf(t, baseline, codeB,
+			"orgB request should reach the handler like a normal delivery (probe %d)", i)
+	}
+}

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -826,6 +826,18 @@ func createGrafDir(t *testing.T, tmpDir string, opts GrafanaOpts) (string, strin
 		_, err = provisioningSect.NewKey("allow_insecure", "true")
 		require.NoError(t, err)
 	}
+	if opts.ProvisioningWebhookRateLimitRPS > 0 {
+		provisioningSect, err := getOrCreateSection("provisioning")
+		require.NoError(t, err)
+		_, err = provisioningSect.NewKey("webhook_rate_limit_rps", fmt.Sprintf("%d", opts.ProvisioningWebhookRateLimitRPS))
+		require.NoError(t, err)
+	}
+	if opts.ProvisioningWebhookTrustedIPHeader != "" {
+		provisioningSect, err := getOrCreateSection("provisioning")
+		require.NoError(t, err)
+		_, err = provisioningSect.NewKey("webhook_trusted_ip_header", opts.ProvisioningWebhookTrustedIPHeader)
+		require.NoError(t, err)
+	}
 	if len(opts.ProvisioningRepositoryTypes) > 0 {
 		provisioningSect, err := getOrCreateSection("provisioning")
 		require.NoError(t, err)
@@ -1038,6 +1050,8 @@ type GrafanaOpts struct {
 	ProvisioningMaxRepositories                          int64
 	ProvisioningFolderAPIVersion                         string
 	ProvisioningMaxIncrementalChanges                    *int
+	ProvisioningWebhookRateLimitRPS                      int
+	ProvisioningWebhookTrustedIPHeader                   string
 	ProvisioningMaxFileSize                              *int64
 	GrafanaComSSOAPIToken                                string
 	LicensePath                                          string


### PR DESCRIPTION
Backport 368199f33a7b5dee77e50465d89c567a8804c93b from #126118

---

**What is this feature?**

- Configurable ip-based rate limiter for GitHub webhook endpoint. The rate-limit bucket is based on tenant namespace + ip address. This is because the webhooks will come from a Github IP address even though they are different tenants. 

  - `webhook_trusted_ip_header` - header name that can be trusted if we do not default to the remoteAddr

**Why do we need this feature?**

The webhook handler validates the HMAC signature *after* reading the request body (up to 25MB). With no throttle, an unauthenticated flood of large POSTs can exhaust CPU/IO before any request is rejected. 

The endpoint is also multi-tenant (one apiserver serves many namespaces/stacks), so a single noisy source could degrade unrelated tenants. Keying on `namespace + IP` isolates tenants from one another and keeps a direct attacker's IP in a separate bucket from GitHub's shared egress IPs within a tenant.

**Who is this feature for?**

Operators of Grafana Cloud and self-managed Grafana running git provisioning / git-ui-sync with GitHub webhooks. It is opt-in and has no effect until a deployment sets a positive `webhook_rate_limit_rps`.

**Which issue(s) does this PR fix?**:

Fixes grafana/git-ui-sync-project#1147

**Special notes for your reviewer:**
Current ip address stats for provisioning webhooks endpoint: https://ops.grafana-ops.net/goto/sqkhnn?orgId=stacks-27821

- **Default is spoof-safe.** If a trusted header is set, we will read from that header. Otherwise, we fallback on the real TCP peer
- **Known scope/limitations** (intentional, follow-ups tracked on the issue): per-client rate limiting can't fully separate legitimate GitHub traffic (concentrated on shared egress IPs) from a distributed attacker, and a `429` to GitHub is a dropped delivery (pushes are healed by periodic resync; PR events are not). 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle. *(N/A — config-gated, disabled by default.)*
- [x] The docs are updated (`conf/defaults.ini`, `conf/sample.ini`, `configure-grafana/_index.md`).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
