### PR TITLE
DashList: Show dashboard description tooltip when it's available

### DIFF
--- a/docs/sources/visualizations/panels-visualizations/visualizations/dashboard-list/index.md
+++ b/docs/sources/visualizations/panels-visualizations/visualizations/dashboard-list/index.md
@@ -40,6 +40,8 @@ Dashboard lists allow you to display dynamic links to other dashboards. You can 
 
 On each dashboard load, this panel queries the dashboard list, always providing the most up-to-date results.
 
+Dashboards that have a description show an info icon next to the dashboard link; hover over the icon to view the description.
+
 You can use a dashboard list visualization to display a list of important dashboards that you want to track.
 
 ## Configure a dashboard list visualization

--- a/public/app/plugins/panel/dashlist/DashList.test.tsx
+++ b/public/app/plugins/panel/dashlist/DashList.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen, testWithFeatureToggles } from 'test/test-utils';
 
 import { setBackendSrv } from '@grafana/runtime';
-import { setupMockServer } from '@grafana/test-utils/server';
+import { getCustomSearchHandler } from '@grafana/test-utils/handlers';
+import server, { setupMockServer } from '@grafana/test-utils/server';
 import { getFolderFixtures } from '@grafana/test-utils/unstable';
 import { backendSrv } from 'app/core/services/backend_srv';
 import impressionSrv from 'app/core/services/impression_srv';
@@ -129,5 +130,35 @@ describe.each(fixtures)('%s', (_title, featureTogglesSetup) => {
     render(<DashList {...props} />);
 
     expect(await screen.findByText(dashbdE.item.title)).toBeInTheDocument();
+  });
+
+  it('shows the dashboard description in a tooltip when hovering the description indicator', async () => {
+    server.use(
+      getCustomSearchHandler([
+        {
+          name: 'dash-uid',
+          title: 'Dashboard with description',
+          resource: 'dashboards',
+          description: 'Uptime overview',
+        },
+      ])
+    );
+    const props = getPanelProps({ ...defaultOptions, showSearch: true });
+    const { user } = render(<DashList {...props} />);
+
+    await user.hover(await screen.findByLabelText('Description'));
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('Uptime overview');
+  });
+
+  it('does not render a description tooltip indicator when a dashboard has no description', async () => {
+    server.use(
+      getCustomSearchHandler([{ name: 'dash-uid', title: 'Dashboard without description', resource: 'dashboards' }])
+    );
+    const props = getPanelProps({ ...defaultOptions, showSearch: true });
+    render(<DashList {...props} />);
+
+    expect(await screen.findByText('Dashboard without description')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Description')).not.toBeInTheDocument();
   });
 });

--- a/public/app/plugins/panel/dashlist/DashList.tsx
+++ b/public/app/plugins/panel/dashlist/DashList.tsx
@@ -193,6 +193,7 @@ export function DashList(props: PanelProps<Options>) {
               layoutMode="list"
               onStarChange={handleStarChange}
               source="dashListView"
+              showDescription
             />
           </li>
         );

--- a/public/app/plugins/panel/dashlist/DashListItem.tsx
+++ b/public/app/plugins/panel/dashlist/DashListItem.tsx
@@ -1,5 +1,6 @@
 import { reportInteraction } from '@grafana/runtime';
 import { Card, Icon, Link, Stack, Text, useStyles2 } from '@grafana/ui';
+import { DescriptionTooltip } from 'app/features/search/components/DescriptionTooltip';
 import { type LocationInfo } from 'app/features/search/service/types';
 import { StarToolbarButton } from 'app/features/stars/StarToolbarButton';
 
@@ -18,6 +19,9 @@ interface Props {
   onStarChange?: (id: string, isStarred: boolean) => void;
   // Row density for list mode. 'compact' gives denser rows for the redesigned homepage
   density?: 'default' | 'compact';
+  // Show an info icon with the dashboard description in list mode, when one exists.
+  // Defaults to false so shared consumers (homepage tabs, recently viewed) are unchanged.
+  showDescription?: boolean;
 }
 export function DashListItem({
   dashboard,
@@ -29,9 +33,20 @@ export function DashListItem({
   onStarChange,
   source,
   density = 'default',
+  showDescription = false,
 }: Props) {
   const css = useStyles2(getStyles);
   const isCompact = density === 'compact';
+
+  const starButton = (
+    <StarToolbarButton
+      title={dashboard.name}
+      group="dashboard.grafana.app"
+      kind="Dashboard"
+      id={dashboard.uid}
+      onStarChange={onStarChange}
+    />
+  );
 
   const onCardLinkClick = () => {
     reportInteraction('grafana_browse_dashboards_page_click_list_item', {
@@ -52,13 +67,14 @@ export function DashListItem({
           href={url}
           onClick={onCardLinkClick}
           trailing={
-            <StarToolbarButton
-              title={dashboard.name}
-              group="dashboard.grafana.app"
-              kind="Dashboard"
-              id={dashboard.uid}
-              onStarChange={onStarChange}
-            />
+            showDescription ? (
+              <Stack gap={0.5} alignItems="center">
+                <DescriptionTooltip description={dashboard.description} />
+                {starButton}
+              </Stack>
+            ) : (
+              starButton
+            )
           }
         />
       ) : (
@@ -91,13 +107,7 @@ export function DashListItem({
               )}
             </Link>
 
-            <StarToolbarButton
-              title={dashboard.name}
-              group="dashboard.grafana.app"
-              kind="Dashboard"
-              id={dashboard.uid}
-              onStarChange={onStarChange}
-            />
+            {starButton}
           </Stack>
         </Card>
       )}

--- a/public/app/plugins/panel/dashlist/DashListItem.tsx
+++ b/public/app/plugins/panel/dashlist/DashListItem.tsx
@@ -67,7 +67,7 @@ export function DashListItem({
           href={url}
           onClick={onCardLinkClick}
           trailing={
-            showDescription ? (
+            showDescription && dashboard.description ? (
               <Stack gap={0.5} alignItems="center">
                 <DescriptionTooltip description={dashboard.description} />
                 {starButton}


### PR DESCRIPTION
**What is this feature?**

Shows a description tooltip on dashboard list panel rows: dashboards that have a description get the same info-circle icon + tooltip that Browse Dashboards and the search page got in #127512, rendered only when a description exists.

**Why do we need this feature?**

The dashboard list panel renders only the title and folder name, so descriptions aren't discoverable from the panel. The old blocker on #69696 (description missing from the search response) is gone — unified search returns it and the frontend searcher already maps it into every result row — leaving just this render change.

**Who is this feature for?**

Anyone navigating between dashboards through the dashboard list panel, especially teams with many similarly named dashboards that use descriptions to tell them apart.

**Which issue(s) does this PR fix?**:

Fixes #69696

**Special notes for your reviewer:**

- Mirrors #127512 and reuses its `DescriptionTooltip` component and existing i18n key — no new strings, no new panel options.
- `DashListItem`/`ListRow` are shared with the homepage cards, so rendering is gated behind a `showDescription` prop that defaults to false and is enabled only from the panel; other consumers render exactly the same element tree as before.
- List mode only (the panel hard-codes `layoutMode="list"`). The icon sits in the row's trailing slot next to the star button, outside the row link, so it stays separately focusable.
- Tests extend `DashList.test.tsx` with the MSW `getCustomSearchHandler` pattern, asserting the `Description` label present/absent — mirroring `DashboardsTree.test.tsx`. Docs get a one-line mention.
- If you'd prefer a `Show description` panel switch instead of always-on-when-available, happy to add it here or as a follow-up; went without one to match #127512.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

---

This PR implements a customer request from Grafana's Voice of Customer (VoC) program (ref IDEASVOC-I-8918). It was prepared with AI assistance as part of an internal VoC→PR pilot and human-reviewed before submission; I'm the accountable author and will handle review feedback.
