### PR TITLE
Frontend logging: Parse and log Faro events payload field

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1407,6 +1407,9 @@ instrumentations_csp_enabled = true
 # See https://grafana.com/docs/grafana-cloud/monitor-applications/frontend-observability/instrument/tracing-instrumentation/
 instrumentations_tracing_enabled = true
 
+# Forwards interaction events reported via reportInteraction to Grafana Faro.
+instrumentations_interaction_events_enabled = false
+
 # Requests per second limit enforced per an extended period, for Grafana backend log ingestion endpoint (/log).
 log_endpoint_requests_per_second_limit = 3
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1268,6 +1268,9 @@
 # See https://grafana.com/docs/grafana-cloud/monitor-applications/frontend-observability/instrument/tracing-instrumentation/
 ;instrumentations_tracing_enabled = true
 
+# Forwards interaction events reported via reportInteraction to Grafana Faro.
+;instrumentations_interaction_events_enabled = false
+
 # Enables the bot filter for the Grafana Faro JavaScript agent integration. Default is `false`. When enabled, it will filter out requests from known bots and crawlers.
 ;bot_filter_enabled = false
 

--- a/pkg/api/frontend_logging.go
+++ b/pkg/api/frontend_logging.go
@@ -75,6 +75,20 @@ func GrafanaJavascriptAgentLogMessageHandler(store *frontendlogging.SourceMapSto
 				}
 			}
 		}
+		if len(event.Events) > 0 {
+			for _, eventEntry := range event.Events {
+				var ctx = frontendlogging.CtxVector{}
+				ctx = event.AddMetaToContext(ctx)
+				ctx = append(ctx, "kind", "event", "event_name", eventEntry.Name, "original_timestamp", eventEntry.Timestamp)
+				if eventEntry.Domain != "" {
+					ctx = append(ctx, "event_domain", eventEntry.Domain)
+				}
+				for k, v := range eventEntry.Attributes {
+					ctx = append(ctx, "event_data_"+k, v)
+				}
+				frontendLogger.Info("Event: "+eventEntry.Name, ctx...)
+			}
+		}
 		if len(event.Exceptions) > 0 {
 			for _, exception := range event.Exceptions {
 				var ctx = frontendlogging.CtxVector{}

--- a/pkg/api/frontendlogging/grafana_javascript_agent.go
+++ b/pkg/api/frontendlogging/grafana_javascript_agent.go
@@ -10,6 +10,7 @@ type FrontendGrafanaJavascriptAgentEvent struct {
 	Exceptions   []Exception   `json:"exceptions,omitempty"`
 	Logs         []Log         `json:"logs,omitempty"`
 	Measurements []Measurement `json:"measurements,omitempty"`
+	Events       []Event       `json:"events,omitempty"`
 	Meta         Meta          `json:"meta,omitempty"`
 	Traces       *Traces       `json:"traces,omitempty"`
 }

--- a/pkg/api/frontendlogging/grafana_javascript_agent_payload.go
+++ b/pkg/api/frontendlogging/grafana_javascript_agent_payload.go
@@ -259,6 +259,15 @@ func (l Log) KeyValContext() *KeyVal {
 	return kv
 }
 
+// Event holds the data for a faro event signal, e.g. user interactions
+type Event struct {
+	Name       string            `json:"name"`
+	Domain     string            `json:"domain,omitempty"`
+	Attributes map[string]string `json:"attributes,omitempty"`
+	Timestamp  time.Time         `json:"timestamp,omitempty"`
+	Trace      TraceContext      `json:"trace,omitempty"`
+}
+
 // Measurement holds the data for user provided measurements
 type Measurement struct {
 	Values    map[string]float64 `json:"values,omitempty"`

--- a/pkg/setting/setting_grafana_javascript_agent.go
+++ b/pkg/setting/setting_grafana_javascript_agent.go
@@ -5,15 +5,16 @@ type GrafanaJavascriptAgent struct {
 	EndpointBurst int `json:"-"`
 
 	// Faro config
-	Enabled                               bool   `json:"enabled"`
-	CustomEndpoint                        string `json:"customEndpoint"`
-	ApiKey                                string `json:"apiKey"`
-	InternalLoggerLevel                   int    `json:"internalLoggerLevel"`
-	ConsoleInstrumentalizationEnabled     bool   `json:"consoleInstrumentalizationEnabled"`
-	PerformanceInstrumentalizationEnabled bool   `json:"performanceInstrumentalizationEnabled"`
-	CSPInstrumentalizationEnabled         bool   `json:"cspInstrumentalizationEnabled"`
-	TracingInstrumentalizationEnabled     bool   `json:"tracingInstrumentalizationEnabled"`
-	BotFilterEnabled                      bool   `json:"botFilterEnabled"`
+	Enabled                                     bool   `json:"enabled"`
+	CustomEndpoint                              string `json:"customEndpoint"`
+	ApiKey                                      string `json:"apiKey"`
+	InternalLoggerLevel                         int    `json:"internalLoggerLevel"`
+	ConsoleInstrumentalizationEnabled           bool   `json:"consoleInstrumentalizationEnabled"`
+	PerformanceInstrumentalizationEnabled       bool   `json:"performanceInstrumentalizationEnabled"`
+	CSPInstrumentalizationEnabled               bool   `json:"cspInstrumentalizationEnabled"`
+	TracingInstrumentalizationEnabled           bool   `json:"tracingInstrumentalizationEnabled"`
+	InteractionEventsInstrumentalizationEnabled bool   `json:"interactionEventsInstrumentalizationEnabled"`
+	BotFilterEnabled                            bool   `json:"botFilterEnabled"`
 }
 
 func (cfg *Cfg) readGrafanaJavascriptAgentConfig() {
@@ -23,14 +24,15 @@ func (cfg *Cfg) readGrafanaJavascriptAgentConfig() {
 		EndpointBurst: raw.Key("log_endpoint_burst_limit").MustInt(15),
 
 		// Faro config
-		Enabled:                               raw.Key("enabled").MustBool(false),
-		CustomEndpoint:                        raw.Key("custom_endpoint").MustString("/log-grafana-javascript-agent"),
-		ApiKey:                                raw.Key("api_key").String(),
-		InternalLoggerLevel:                   raw.Key("internal_logger_level").MustInt(0),
-		ConsoleInstrumentalizationEnabled:     raw.Key("instrumentations_console_enabled").MustBool(true),
-		PerformanceInstrumentalizationEnabled: raw.Key("instrumentations_performance_enabled").MustBool(true),
-		CSPInstrumentalizationEnabled:         raw.Key("instrumentations_csp_enabled").MustBool(true),
-		TracingInstrumentalizationEnabled:     raw.Key("instrumentations_tracing_enabled").MustBool(true),
-		BotFilterEnabled:                      raw.Key("bot_filter_enabled").MustBool(false),
+		Enabled:                                     raw.Key("enabled").MustBool(false),
+		CustomEndpoint:                              raw.Key("custom_endpoint").MustString("/log-grafana-javascript-agent"),
+		ApiKey:                                      raw.Key("api_key").String(),
+		InternalLoggerLevel:                         raw.Key("internal_logger_level").MustInt(0),
+		ConsoleInstrumentalizationEnabled:           raw.Key("instrumentations_console_enabled").MustBool(true),
+		PerformanceInstrumentalizationEnabled:       raw.Key("instrumentations_performance_enabled").MustBool(true),
+		CSPInstrumentalizationEnabled:               raw.Key("instrumentations_csp_enabled").MustBool(true),
+		TracingInstrumentalizationEnabled:           raw.Key("instrumentations_tracing_enabled").MustBool(true),
+		InteractionEventsInstrumentalizationEnabled: raw.Key("instrumentations_interaction_events_enabled").MustBool(false),
+		BotFilterEnabled:                            raw.Key("bot_filter_enabled").MustBool(false),
 	}
 }


### PR DESCRIPTION
**What is this feature?**

Two backend pieces of the interaction-events-to-Faro work (frontend half: #130005):

1. The same-origin `/log-grafana-javascript-agent` receiver silently discarded the `events` field of the Faro payload — the payload struct simply had no `Events` member. This adds the `Event` struct and logs each event via the frontend logger as `kind=event` with `event_name` and `event_data_*` attributes, matching how logs, measurements, and exceptions are already handled.
2. A new `[log.frontend] instrumentations_interaction_events_enabled` setting (default `false`), matching the existing `instrumentations_*_enabled` flags. It reaches the frontend through the embedded `GrafanaJavascriptAgent` struct in frontend settings; #130005 gates the forwarding on it. In Cloud it can be rolled out per cluster/wave via instance config.

**Why do we need this feature?**

Faro's `pushEvent` API produces `events` payload entries, and #130005 makes Grafana emit interaction events through Faro when the setting is enabled. Without the receiver change, self-hosted instances using the default same-origin endpoint would silently drop those events.

The two PRs are independently deployable in either order: the receiver parses a field that doesn't arrive until something sends it, and until this PR ships the frontend reads an absent setting as disabled.

**Who is this feature for?**

Self-hosted Grafana users ingesting frontend telemetry via the built-in `[log.frontend]` endpoint; groundwork for interaction-event dogfooding in Frontend Observability.

**Which issue(s) does this PR fix?**:

Related: #130005 (frontend half)

**Special notes for your reviewer:**

- Purely additive: payloads without `events` behave exactly as before, and the setting defaults to off.
- `event_data_*` attribute prefix matches the convention the OpenTelemetry Collector's Faro translator uses for event attributes, so Loki queries look the same regardless of ingestion path.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. (config setting, default off, per review feedback on #130005)
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.