### PR TITLE
Saved Queries: Simplify navigation subtitle

### DIFF
--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -235,7 +235,7 @@ export function getNavSubTitle(navId: string | undefined) {
         'Deleted dashboards are kept for up to 12 months or until the history limit of 1000 dashboards is reached.'
       );
     case 'saved-queries':
-      return t('nav.saved-queries.subtitle', 'Reusable queries you can use across panels and Explore');
+      return t('nav.saved-queries.subtitle', 'Reusable queries across Grafana');
     case 'alerting':
       return t('nav.alerting.subtitle', 'Learn about problems in your systems moments after they occur');
     case 'alerting-upgrade':

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12418,7 +12418,7 @@
       "title": "Reporting"
     },
     "saved-queries": {
-      "subtitle": "Reusable queries you can use across panels and Explore",
+      "subtitle": "Reusable queries across Grafana",
       "title": "Saved queries"
     },
     "scenes": {


### PR DESCRIPTION
## What is this?

Updates the OSS navigation translation for Saved queries to use the simpler subtitle "Reusable queries across Grafana".

This is the OSS companion to grafana/grafana-enterprise#12914. Grafana's frontend translation layer overrides the backend-provided subtitle, so the two sources need to stay aligned.

Part of grafana/grafana-enterprise#12906.

## Test plan

- [x] ESLint
- [x] Prettier
- [x] navModel and navBarTree tests (20 tests)