### PR TITLE
Folders: Prevent creating or moving folders in the k6 tree

### DIFF
--- a/pkg/registry/apis/folders/register_test.go
+++ b/pkg/registry/apis/folders/register_test.go
@@ -397,10 +397,7 @@ func TestFolderAPIBuilder_Validate_Update(t *testing.T) {
 				m.On("Get", mock.Anything, "new-parent", mock.Anything).Return(
 					&folders.Folder{},
 					nil).Once()
-				// also retrieves old parent for depth difference calculation
-				m.On("Get", mock.Anything, "valid-parent", mock.Anything).Return(
-					&folders.Folder{},
-					nil).Once()
+				// the old parent is covered by the shared expectation above
 			},
 		},
 		{
@@ -491,6 +488,14 @@ func TestFolderAPIBuilder_Validate_Update(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			us := grafanarest.NewMockStorage(t)
 			sm := resource.NewMockResourceClient(t)
+			// the source chain is resolved to reject moves out of the k6 tree
+			us.On("Get", mock.Anything, "valid-parent", mock.Anything).Return(
+				&folders.Folder{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "valid-parent",
+						Annotations: map[string]string{"grafana.app/folder": folder.GeneralFolderUID},
+					},
+				}, nil).Maybe()
 			if tt.setupFn != nil {
 				tt.setupFn(us)
 			}

--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -75,6 +75,20 @@ func validateOwnerReferencesOnManagedFolder(obj *folders.Folder, old *folders.Fo
 	return nil
 }
 
+// hasK6Ancestor checks the whole chain, not just the immediate parent: folders
+// created under k6 before it was restricted must not become parents themselves.
+func hasK6Ancestor(info *folders.FolderInfoList, self string) bool {
+	if info == nil {
+		return false
+	}
+	for _, item := range info.Items {
+		if item.Name == accesscontrol.K6FolderUID && item.Name != self {
+			return true
+		}
+	}
+	return false
+}
+
 func validateOnCreate(ctx context.Context, f *folders.Folder, getter parentsGetter, maxDepth int) error {
 	id := f.Name
 
@@ -113,7 +127,7 @@ func validateOnCreate(ctx context.Context, f *folders.Folder, getter parentsGett
 
 	parentName := meta.GetFolder()
 
-	// folder cannot be created inside the k6 folder (matches the move restriction below)
+	// checked before resolving the tree so it also rejects a k6 parent we cannot read
 	if parentName == accesscontrol.K6FolderUID {
 		return folder.ErrFolderCannotBeCreatedInK6.Errorf("folders may not be created in the k6 project")
 	}
@@ -130,6 +144,10 @@ func validateOnCreate(ctx context.Context, f *folders.Folder, getter parentsGett
 	parents, err := getter(ctx, f)
 	if err != nil {
 		return fmt.Errorf("unable to create folder inside parent: %w", err)
+	}
+
+	if hasK6Ancestor(parents, f.Name) {
+		return folder.ErrFolderCannotBeCreatedInK6.Errorf("folders may not be created in the k6 project")
 	}
 
 	// Can not create a folder that will be too deep.
@@ -186,6 +204,17 @@ func validateOnUpdate(ctx context.Context,
 		return folder.ErrFolderCannotBeMovedToK6.Errorf("k6 project may not be moved")
 	}
 
+	// k6 folders stay together, so folders under k6 may not be moved out either
+	if !folder.IsRootFolderUID(oldFolder.GetFolder()) {
+		oldInfo, err := parents(ctx, old)
+		if err != nil {
+			return err
+		}
+		if hasK6Ancestor(oldInfo, obj.Name) {
+			return folder.ErrBadRequest.Errorf("k6 project may not be moved")
+		}
+	}
+
 	if err := checkMoveAccess(ctx, obj.Namespace, obj.Name, oldFolder.GetFolder(), newParent, accessClient); err != nil {
 		return err
 	}
@@ -209,6 +238,11 @@ func validateOnUpdate(ctx context.Context,
 	info, err := parents(ctx, parent)
 	if err != nil {
 		return err
+	}
+
+	// nothing may be moved into the k6 tree, at any depth
+	if hasK6Ancestor(info, obj.Name) {
+		return folder.ErrFolderCannotBeMovedToK6.Errorf("k6 project may not be moved")
 	}
 
 	// Check that the folder being moved is not an ancestor of the target parent.

--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -112,6 +112,12 @@ func validateOnCreate(ctx context.Context, f *folders.Folder, getter parentsGett
 	}
 
 	parentName := meta.GetFolder()
+
+	// folder cannot be created inside the k6 folder (matches the move restriction below)
+	if parentName == accesscontrol.K6FolderUID {
+		return folder.ErrFolderCannotBeCreatedInK6.Errorf("folders may not be created in the k6 project")
+	}
+
 	if folder.IsRootFolderUID(parentName) {
 		return nil // OK, we do not need to validate the tree
 	}
@@ -190,11 +196,6 @@ func validateOnUpdate(ctx context.Context,
 	// We also don't need to validate circular references because the root folder cannot have a parent.
 	if folder.IsRootFolderUID(newParent) {
 		return nil
-	}
-
-	// folder cannot be moved into the k6 folder
-	if newParent == accesscontrol.K6FolderUID {
-		return folder.ErrFolderCannotBeMovedToK6.Errorf("k6 project may not be moved")
 	}
 
 	parentObj, err := getter.Get(ctx, newParent, &metav1.GetOptions{})

--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -75,6 +75,13 @@ func validateOwnerReferencesOnManagedFolder(obj *folders.Folder, old *folders.Fo
 	return nil
 }
 
+// the k6 app manages its own subfolders through a service account, so only
+// other identities are kept out of the k6 tree (same rule as k6 visibility)
+func isServiceAccount(ctx context.Context) bool {
+	user, err := identity.GetRequester(ctx)
+	return err == nil && user.IsIdentityType(authlib.TypeServiceAccount)
+}
+
 // hasK6Ancestor checks the whole chain, not just the immediate parent: folders
 // created under k6 before it was restricted must not become parents themselves.
 func hasK6Ancestor(info *folders.FolderInfoList, self string) bool {
@@ -128,7 +135,7 @@ func validateOnCreate(ctx context.Context, f *folders.Folder, getter parentsGett
 	parentName := meta.GetFolder()
 
 	// checked before resolving the tree so it also rejects a k6 parent we cannot read
-	if parentName == accesscontrol.K6FolderUID {
+	if parentName == accesscontrol.K6FolderUID && !isServiceAccount(ctx) {
 		return folder.ErrFolderCannotBeCreatedInK6.Errorf("folders may not be created in the k6 project")
 	}
 
@@ -146,7 +153,7 @@ func validateOnCreate(ctx context.Context, f *folders.Folder, getter parentsGett
 		return fmt.Errorf("unable to create folder inside parent: %w", err)
 	}
 
-	if hasK6Ancestor(parents, f.Name) {
+	if hasK6Ancestor(parents, f.Name) && !isServiceAccount(ctx) {
 		return folder.ErrFolderCannotBeCreatedInK6.Errorf("folders may not be created in the k6 project")
 	}
 

--- a/pkg/registry/apis/folders/validate_test.go
+++ b/pkg/registry/apis/folders/validate_test.go
@@ -172,6 +172,38 @@ func TestValidateCreate(t *testing.T) {
 			expectedErr: folder.ErrFolderCannotBeCreatedInK6,
 		},
 		{
+			name: "error to create a folder under an existing descendant of the k6 folder",
+			folder: &folders.Folder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "nnn",
+					Annotations: map[string]string{utils.AnnoKeyFolder: "legacy-k6-child"},
+				},
+				Spec: folders.FolderSpec{
+					Title: "some title",
+				},
+			},
+			mockFolders: map[string]*folders.Folder{
+				"legacy-k6-child": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "legacy-k6-child",
+						Annotations: map[string]string{utils.AnnoKeyFolder: accesscontrol.K6FolderUID},
+					},
+					Spec: folders.FolderSpec{
+						Title: "created before k6 was restricted",
+					},
+				},
+				accesscontrol.K6FolderUID: {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: accesscontrol.K6FolderUID,
+					},
+					Spec: folders.FolderSpec{
+						Title: "k6",
+					},
+				},
+			},
+			expectedErr: folder.ErrFolderCannotBeCreatedInK6,
+		},
+		{
 			name: "the k6 folder itself can be created at root",
 			folder: &folders.Folder{
 				ObjectMeta: metav1.ObjectMeta{
@@ -590,6 +622,68 @@ func TestValidateUpdate(t *testing.T) {
 				},
 			},
 			expectedErr: "k6 project may not be moved",
+		},
+		{
+			name: "error to move into an existing descendant of the k6 folder",
+			folder: &folders.Folder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "nnn",
+					Annotations: map[string]string{
+						utils.AnnoKeyFolder: "legacy-k6-child",
+					},
+				},
+				Spec: folders.FolderSpec{
+					Title: "changed",
+				},
+			},
+			old: &folders.Folder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "nnn",
+				},
+				Spec: folders.FolderSpec{
+					Title: "old title",
+				},
+			},
+			parents: &folders.FolderInfoList{
+				Items: []folders.FolderInfo{
+					{Name: accesscontrol.K6FolderUID, Title: "k6"},
+					{Name: "legacy-k6-child", Title: "created before k6 was restricted", Parent: accesscontrol.K6FolderUID},
+				},
+			},
+			expectedErr: "[folder.cannot-be-moved-to-k6] k6 project may not be moved",
+		},
+		{
+			name: "error to move a folder out of the k6 tree",
+			folder: &folders.Folder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "nnn",
+					Annotations: map[string]string{
+						utils.AnnoKeyFolder: folder.GeneralFolderUID,
+					},
+				},
+				Spec: folders.FolderSpec{
+					Title: "changed",
+				},
+			},
+			old: &folders.Folder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "nnn",
+					Annotations: map[string]string{
+						utils.AnnoKeyFolder: "legacy-k6-child",
+					},
+				},
+				Spec: folders.FolderSpec{
+					Title: "old title",
+				},
+			},
+			// resolved for the source chain, which still runs through k6
+			parents: &folders.FolderInfoList{
+				Items: []folders.FolderInfo{
+					{Name: accesscontrol.K6FolderUID, Title: "k6"},
+					{Name: "legacy-k6-child", Title: "created before k6 was restricted", Parent: accesscontrol.K6FolderUID},
+				},
+			},
+			expectedErr: "[folder.bad-request] k6 project may not be moved",
 		},
 		{
 			name: "error to move the k6 folder itself",

--- a/pkg/registry/apis/folders/validate_test.go
+++ b/pkg/registry/apis/folders/validate_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -146,6 +147,40 @@ func TestValidateCreate(t *testing.T) {
 				},
 			},
 			expectedErr: folder.ErrFolderCannotBeParentOfItself,
+		},
+		{
+			name: "error to create a folder inside the k6 folder",
+			folder: &folders.Folder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "nnn",
+					Annotations: map[string]string{utils.AnnoKeyFolder: accesscontrol.K6FolderUID},
+				},
+				Spec: folders.FolderSpec{
+					Title: "some title",
+				},
+			},
+			mockFolders: map[string]*folders.Folder{
+				accesscontrol.K6FolderUID: {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: accesscontrol.K6FolderUID,
+					},
+					Spec: folders.FolderSpec{
+						Title: "k6",
+					},
+				},
+			},
+			expectedErr: folder.ErrFolderCannotBeCreatedInK6,
+		},
+		{
+			name: "the k6 folder itself can be created at root",
+			folder: &folders.Folder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: accesscontrol.K6FolderUID,
+				},
+				Spec: folders.FolderSpec{
+					Title: "k6",
+				},
+			},
 		},
 		{
 			name: "can not create a tree that is too deep",

--- a/pkg/registry/apis/folders/validate_test.go
+++ b/pkg/registry/apis/folders/validate_test.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -26,11 +27,12 @@ import (
 
 func TestValidateCreate(t *testing.T) {
 	tests := []struct {
-		name        string
-		folder      *folders.Folder
-		mockFolders map[string]*folders.Folder
-		expectedErr error
-		maxDepth    int // defaults to 5 unless set
+		name           string
+		folder         *folders.Folder
+		mockFolders    map[string]*folders.Folder
+		expectedErr    error
+		maxDepth       int  // defaults to 5 unless set
+		serviceAccount bool // the requester is a service account
 	}{
 		{
 			name: "ok",
@@ -202,6 +204,61 @@ func TestValidateCreate(t *testing.T) {
 				},
 			},
 			expectedErr: folder.ErrFolderCannotBeCreatedInK6,
+		},
+		{
+			name: "service account can create a folder inside the k6 folder",
+			folder: &folders.Folder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "nnn",
+					Annotations: map[string]string{utils.AnnoKeyFolder: accesscontrol.K6FolderUID},
+				},
+				Spec: folders.FolderSpec{
+					Title: "some title",
+				},
+			},
+			mockFolders: map[string]*folders.Folder{
+				accesscontrol.K6FolderUID: {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: accesscontrol.K6FolderUID,
+					},
+					Spec: folders.FolderSpec{
+						Title: "k6",
+					},
+				},
+			},
+			serviceAccount: true,
+		},
+		{
+			name: "service account can create a folder deeper in the k6 tree",
+			folder: &folders.Folder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "nnn",
+					Annotations: map[string]string{utils.AnnoKeyFolder: "k6-child"},
+				},
+				Spec: folders.FolderSpec{
+					Title: "some title",
+				},
+			},
+			mockFolders: map[string]*folders.Folder{
+				"k6-child": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "k6-child",
+						Annotations: map[string]string{utils.AnnoKeyFolder: accesscontrol.K6FolderUID},
+					},
+					Spec: folders.FolderSpec{
+						Title: "k6 child",
+					},
+				},
+				accesscontrol.K6FolderUID: {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: accesscontrol.K6FolderUID,
+					},
+					Spec: folders.FolderSpec{
+						Title: "k6",
+					},
+				},
+			},
+			serviceAccount: true,
 		},
 		{
 			name: "the k6 folder itself can be created at root",
@@ -410,15 +467,20 @@ func TestValidateCreate(t *testing.T) {
 				maxDepth = 5
 			}
 
+			ctx := context.Background()
+			if tt.serviceAccount {
+				ctx = identity.WithRequester(ctx, &user.SignedInUser{UserID: 1, OrgID: 1, IsServiceAccount: true})
+			}
+
 			mockStorage := grafanarest.NewMockStorage(t)
 			for name, f := range tt.mockFolders {
 				f.Name = name
-				mockStorage.On("Get", context.Background(), name, &metav1.GetOptions{}).Return(f, nil).Maybe()
+				mockStorage.On("Get", mock.Anything, name, &metav1.GetOptions{}).Return(f, nil).Maybe()
 			}
 
 			getter := newParentsGetter(mockStorage, maxDepth)
 
-			err := validateOnCreate(context.Background(), tt.folder, getter, maxDepth)
+			err := validateOnCreate(ctx, tt.folder, getter, maxDepth)
 
 			if tt.expectedErr == nil {
 				require.NoError(t, err)

--- a/pkg/registry/apis/provisioning/resources/errors.go
+++ b/pkg/registry/apis/provisioning/resources/errors.go
@@ -391,6 +391,7 @@ var folderValidationMessageIDs = map[string]struct{}{
 	"folder.cannot-be-parent-of-itself": {},
 	"folder.maximum-depth-reached":      {},
 	"folder.cannot-be-moved-to-k6":      {},
+	"folder.cannot-be-created-in-k6":    {},
 	"folder.name-exists":                {},
 	"folder.circular-reference":         {},
 }

--- a/pkg/services/folder/model.go
+++ b/pkg/services/folder/model.go
@@ -23,6 +23,7 @@ var ErrCircularReference = errutil.BadRequest("folder.circular-reference", errut
 var ErrTargetRegistrySrvConflict = errutil.Internal("folder.target-registry-srv-conflict")
 var ErrFolderNotEmpty = errutil.BadRequest("folder.not-empty", errutil.WithPublicMessage("Folder cannot be deleted: folder is not empty"))
 var ErrFolderCannotBeMovedToK6 = errutil.BadRequest("folder.cannot-be-moved-to-k6", errutil.WithPublicMessage("Folders cannot be moved into the k6 project"))
+var ErrFolderCannotBeCreatedInK6 = errutil.BadRequest("folder.cannot-be-created-in-k6", errutil.WithPublicMessage("Folders cannot be created inside the k6 project"))
 
 // ErrCyclicReference indicates corrupt storage state, not user input.
 var ErrCyclicReference = errutil.Internal("folder.cyclic-reference", errutil.WithPublicMessage("Cyclic folder references found"))

--- a/pkg/tests/apis/folder/folders_test.go
+++ b/pkg/tests/apis/folder/folders_test.go
@@ -2587,3 +2587,49 @@ func TestIntegrationFolderValidationReturns400(t *testing.T) {
 		})
 	}
 }
+
+// The k6 app provisions its own subfolders through a service account, so that
+// identity is exempt from the k6 create restriction.
+func TestIntegrationK6SubfolderCreateByServiceAccount(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+	if !db.IsTestDbSQLite() {
+		t.Skip("test only on sqlite for now")
+	}
+
+	helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
+		AppModeProduction:    true,
+		DisableAnonymous:     true,
+		APIServerStorageType: "unified",
+	})
+
+	makeFolder := func(name, title, parentUID string) *unstructured.Unstructured {
+		md := map[string]any{"name": name}
+		if parentUID != "" {
+			md["annotations"] = map[string]any{utils.AnnoKeyFolder: parentUID}
+		}
+		return &unstructured.Unstructured{Object: map[string]any{
+			"metadata": md,
+			"spec":     map[string]any{"title": title},
+		}}
+	}
+
+	saToken := helper.Org1.AdminServiceAccountToken
+	require.NotEmpty(t, saToken)
+	saClient := helper.GetResourceClient(apis.ResourceClientArgs{
+		ServiceAccountToken: saToken,
+		Namespace:           helper.Namespacer(helper.Org1.Admin.Identity.GetOrgID()),
+		GVR:                 gvr,
+	})
+
+	_, err := saClient.Resource.Create(context.Background(),
+		makeFolder(accesscontrol.K6FolderUID, "k6", ""), metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	child, err := saClient.Resource.Create(context.Background(),
+		makeFolder("k6-sa-child", "k6 child", accesscontrol.K6FolderUID), metav1.CreateOptions{})
+	require.NoError(t, err, "a service account must be able to create folders inside the k6 tree")
+
+	_, err = saClient.Resource.Create(context.Background(),
+		makeFolder("k6-sa-grandchild", "k6 grandchild", child.GetName()), metav1.CreateOptions{})
+	require.NoError(t, err, "a service account must be able to create folders deeper in the k6 tree")
+}

--- a/pkg/tests/apis/folder/folders_test.go
+++ b/pkg/tests/apis/folder/folders_test.go
@@ -2477,6 +2477,20 @@ func TestIntegrationFolderValidationReturns400(t *testing.T) {
 			expectedMessageID: "folder.cannot-be-parent-of-itself",
 		},
 		{
+			name: "create inside k6 folder",
+			setup: func(t *testing.T) string {
+				out, err := client.Resource.Create(context.Background(),
+					makeFolder(accesscontrol.K6FolderUID, "k6", ""), metav1.CreateOptions{})
+				require.NoError(t, err, "creating the k6 folder itself should succeed")
+				return out.GetName()
+			},
+			folder: func(parentUID string) *unstructured.Unstructured {
+				return makeFolder("child-of-k6", "Child of k6", parentUID)
+			},
+			expectedMsg:       "Folders cannot be created inside the k6 project",
+			expectedMessageID: "folder.cannot-be-created-in-k6",
+		},
+		{
 			name: "max depth exceeded",
 			setup: func(t *testing.T) string {
 				parentUID := ""


### PR DESCRIPTION
**What is this feature?**

Keeps the k6 folder tree intact:

- folders can no longer be created inside the k6 tree, at any depth (service accounts excepted â the k6 app provisions its own subfolders)
- restores the pin on k6 subfolders, so they cannot be moved out
- nothing can be moved into the k6 tree, at any depth

**Why do we need this feature?**

Two gaps had opened up in `folder.grafana.app`:

- **Create was never validated.** `POST` with `parentUid: k6-app` succeeded, and the resulting child appeared in folder listings while its parent stayed hidden - the k6 exclusion filter matches the `k6-app` name only, not its subtree.
- **Moving k6 subfolders out was allowed.** #88884 rejected both the k6 folder and folders whose parent is k6 ("we want all k6 folders to stay together"), but only the first check survived the port to the apiserver. The stale comment at `folder_unifiedstorage.go:623` - "a k6-app folder *and its children*" - is what's left of the second.