### PR TITLE
fix: add rawQuery to sanitizeData for InfluxDB public dashboards [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/pkg/services/publicdashboards/internal/service/query.go
+++ b/pkg/services/publicdashboards/internal/service/query.go
@@ -459,6 +459,7 @@ func sanitizeData(data *simplejson.Json) {
 			target.Del("expr")
 			target.Del("query")
 			target.Del("rawSql")
+		target.Del("rawQuery")
 		}
 	}
 }
@@ -475,6 +476,7 @@ func sanitizeDataV2(data *simplejson.Json) {
 			dataQuerySpec.Del("expr")
 			dataQuerySpec.Del("query")
 			dataQuerySpec.Del("rawSql")
+			dataQuerySpec.Del("rawQuery")
 		}
 	}
 }


### PR DESCRIPTION
Fixes #123845

`sanitizeData` and `sanitizeDataV2` remove `expr`, `query`, and `rawSql` from query targets before building public dashboard requests, but they miss `rawQuery` — the field InfluxDB uses to store the actual InfluxQL or Flux query string.

This fix adds `dataQuerySpec.Del("rawQuery")` to both sanitize functions, so InfluxDB query strings are also stripped from public dashboard data.

**Wallet:** fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT