### PR TITLE
VizLegend: Fixes gap between viz and right legend when width is larger than maxWidth

### DIFF
--- a/packages/grafana-ui/src/components/VizLayout/VizLayout.test.tsx
+++ b/packages/grafana-ui/src/components/VizLayout/VizLayout.test.tsx
@@ -234,6 +234,27 @@ describe('VizLayout', () => {
       expect(children).toHaveBeenCalledWith(600, 600);
     });
 
+    it('prefers the measured legend width over the width prop once measured', () => {
+      // maxWidth can clamp the legend below the requested width. Sizing the chart from the
+      // raw prop would then leave a dead gap between the chart and the legend.
+      mockUseMeasure.mockReturnValue([jest.fn(), { ...noMeasure, width: 480 }]);
+      const children = jest.fn().mockReturnValue(null);
+      render(
+        <VizLayout
+          width={800}
+          height={600}
+          legend={
+            <VizLayout.Legend placement="right" width={600} maxWidth="60%">
+              <div />
+            </VizLayout.Legend>
+          }
+        >
+          {children}
+        </VizLayout>
+      );
+      expect(children).toHaveBeenCalledWith(320, 600);
+    });
+
     it('sets the legend width style when an explicit width prop is provided', () => {
       render(
         <VizLayout

--- a/packages/grafana-ui/src/components/VizLayout/VizLayout.tsx
+++ b/packages/grafana-ui/src/components/VizLayout/VizLayout.tsx
@@ -88,7 +88,14 @@ export const VizLayout: VizLayoutComponentType = ({ width, height, legend, child
 
       if (legend.props.width != null) {
         legendStyle.width = legend.props.width;
-        size = { width: width - legend.props.width, height };
+
+        // `maxWidth` can clamp the legend below the requested width, so subtracting the raw
+        // prop would size the viz for a wider legend than is actually rendered and leave a
+        // dead gap in the panel. Prefer the measured width; the prop is only the first-render
+        // fallback, before the legend has been measured in its new position.
+        if (!legendMeasure.width) {
+          size = { width: width - legend.props.width, height };
+        }
       }
       break;
   }


### PR DESCRIPTION
I've seen this issue when the legend width is large enough:

<img width="1478" height="991" alt="Screenshot 2026-08-04 at 10 34 36" src="https://github.com/user-attachments/assets/9a197b87-cdaf-4a60-8173-f2c5879308f2" />

This PR fixes that gap.

Repro is setting a numeric legend width larger than it's max width. The legend stops expanding, but the gap keeps growing over the viz. This does not repro with a percentage value like 80%