### PR TITLE
FeatureToggles: Remove kubernetesQueryCaching and querycaching.redirectToK8SApi feature toggles

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -209,11 +209,6 @@ export interface FeatureToggles {
   */
   kubernetesLogsDrilldown?: boolean;
   /**
-  * Adds support for Kubernetes querycaching
-  * @default false
-  */
-  kubernetesQueryCaching?: boolean;
-  /**
   * Register legacy datasource apis that use the numeric id
   * @default false
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -462,15 +462,6 @@ var (
 			Generate:        Generate{LegacyGo: true, LegacyFrontend: true},
 		},
 		{
-			Name:            "kubernetesQueryCaching",
-			Description:     "Adds support for Kubernetes querycaching",
-			Stage:           FeatureStageExperimental,
-			Owner:           grafanaOperatorExperienceSquad,
-			RequiresRestart: true,
-			Expression:      "false",
-			Generate:        Generate{LegacyGo: true, LegacyFrontend: true},
-		},
-		{
 			Name:            "datasources.queryTypes",
 			Description:     "Load Query types from spec.{version}.query.{yaml|json}",
 			Stage:           FeatureStageExperimental,
@@ -2710,14 +2701,6 @@ var (
 			Expression:      "false",
 			RequiresRestart: true,
 			Generate:        Generate{LegacyGo: true, LegacyFrontend: true},
-		},
-		{
-			Name:        "querycaching.redirectToK8SApi",
-			Description: "Redirect caching service cache config reads from legacy storage to K8s API",
-			Stage:       FeatureStageExperimental,
-			Owner:       grafanaOperatorExperienceSquad,
-			Expression:  "false",
-			Generate:    Generate{Go: true},
 		},
 		{
 			Name:        "querycaching.enableConnectionsClient",

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -51,7 +51,6 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2025-08-29,useKubernetesShortURLsAPI,GA,@grafana/sharing-squad,false,false,true
 2025-08-29,kubernetesCorrelations,experimental,@grafana/datapro,false,true,false
 2025-10-16,kubernetesLogsDrilldown,experimental,@grafana/observability-logs,false,true,false
-2025-10-20,kubernetesQueryCaching,experimental,@grafana/grafana-operator-experience-squad,false,true,false
 2026-05-22,datasources.queryTypes,experimental,@grafana/grafana-app-platform-squad,false,true,false
 2026-05-22,datasources.loadOpenAPI,experimental,@grafana/grafana-app-platform-squad,false,true,false
 2026-05-22,datasources.chunkedQueryStreaming,experimental,@grafana/grafana-datasources-core-services,false,false,false
@@ -314,7 +313,6 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-05-22,tracesDrilldownTimeSeeker,experimental,@grafana/observability-traces-and-profiling,false,false,true
 2026-05-22,enableColorblindSafePanelOptions,experimental,@grafana/dataviz-squad,false,false,true
 2026-05-22,cacheConfigUnifiedStorageMigration,experimental,@grafana/grafana-operator-experience-squad,false,true,false
-2026-05-22,querycaching.redirectToK8SApi,experimental,@grafana/grafana-operator-experience-squad,false,false,false
 2026-05-22,querycaching.enableConnectionsClient,experimental,@grafana/grafana-operator-experience-squad,false,false,false
 2026-05-22,querycaching.useInQueryService,experimental,@grafana/grafana-operator-experience-squad,false,false,false
 2026-05-22,influxDBConfigValidation,experimental,@grafana/data-sources-plugins,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -159,10 +159,6 @@ const (
 	// Adds support for Kubernetes logs drilldown
 	FlagKubernetesLogsDrilldown = "kubernetesLogsDrilldown"
 
-	// FlagKubernetesQueryCaching
-	// Adds support for Kubernetes querycaching
-	FlagKubernetesQueryCaching = "kubernetesQueryCaching"
-
 	// FlagDatasourcesQueryTypes
 	// Load Query types from spec.{version}.query.{yaml|json}
 	FlagDatasourcesQueryTypes = "datasources.queryTypes"
@@ -881,10 +877,6 @@ const (
 	// FlagCacheConfigUnifiedStorageMigration
 	// Enables cache configs data migration to unified storage
 	FlagCacheConfigUnifiedStorageMigration = "cacheConfigUnifiedStorageMigration"
-
-	// FlagQuerycachingRedirectToK8SApi
-	// Redirect caching service cache config reads from legacy storage to K8s API
-	FlagQuerycachingRedirectToK8SApi = "querycaching.redirectToK8SApi"
 
 	// FlagQuerycachingEnableConnectionsClient
 	// Use connections client instead of storage to resolve datasource plugin ID in query caching

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -3829,7 +3829,8 @@
       "metadata": {
         "name": "kubernetesQueryCaching",
         "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-10-20T16:11:25Z"
+        "creationTimestamp": "2025-10-20T16:11:25Z",
+        "deletionTimestamp": "2026-08-04T08:36:41Z"
       },
       "spec": {
         "description": "Adds support for Kubernetes querycaching",
@@ -5280,7 +5281,8 @@
       "metadata": {
         "name": "querycaching.redirectToK8SApi",
         "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "deletionTimestamp": "2026-08-04T08:36:41Z"
       },
       "spec": {
         "description": "Redirect caching service cache config reads from legacy storage to K8s API",

--- a/pkg/storage/unified/migrations/testcases/querycacheconfigs.go
+++ b/pkg/storage/unified/migrations/testcases/querycacheconfigs.go
@@ -7,7 +7,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	authlib "github.com/grafana/authlib/types"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/grafana/grafana/pkg/tests/apis"
 )
@@ -27,7 +26,7 @@ func (tc *queryCacheConfigsTestCase) Name() string {
 }
 
 func (tc *queryCacheConfigsTestCase) FeatureToggles() []string {
-	return []string{featuremgmt.FlagKubernetesQueryCaching}
+	return []string{}
 }
 
 func (tc *queryCacheConfigsTestCase) RenameTables() []string {


### PR DESCRIPTION
## Summary

Deletes the `kubernetesQueryCaching` and `querycaching.redirectToK8SApi` feature toggles. Query caching always serves cache config through the `querycaching.grafana.app` API as of grafana/grafana-enterprise#12927, so nothing reads these toggles anymore.

- `pkg/services/featuremgmt/registry.go` — both toggle definitions removed, generated files regenerated (`make gen-feature-toggles`)
- `pkg/storage/unified/migrations/testcases/querycacheconfigs.go` — the migration testcase no longer needs the toggle

Follows the shorturl precedent (#126795).

## Merge order

⚠️ **Merge grafana/grafana-enterprise#12927 first.** Enterprise main still references the `FlagKubernetesQueryCaching` / `FlagQuerycachingRedirectToK8SApi` constants until that PR lands; merging this one first would break the enterprise build against OSS main. The matching branch name pins the two PRs' CI to each other in the meantime.

## Testing

- `go test ./pkg/services/featuremgmt/ ./pkg/storage/unified/migrations/...` — pass
- `go build -tags enterprise ./pkg/server/` with the enterprise PR branch synced — compiles clean against the reduced toggle set
- No remaining references to either toggle anywhere in OSS (code, frontend, docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)