### PR TITLE
Dashboards: Add multiple quick toggles for timeseries

### DIFF
--- a/public/app/plugins/panel/timeseries/module.tsx
+++ b/public/app/plugins/panel/timeseries/module.tsx
@@ -49,7 +49,7 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TimeSeriesPanel)
     fanout: { enabled: true },
     quickToggles: {
       optionProperties: ['legend.showLegend', 'legend.placement'],
-      fieldConfigProperties: ['custom.stacking'],
+      fieldConfigProperties: ['custom.stacking', 'custom.scaleDistribution'],
     },
   })
   .setDataSupport({ annotations: true, alertStates: true });

--- a/public/app/plugins/panel/timeseries/module.tsx
+++ b/public/app/plugins/panel/timeseries/module.tsx
@@ -48,7 +48,7 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TimeSeriesPanel)
   .setViewPanelOptions({
     fanout: { enabled: true },
     quickToggles: {
-      optionProperties: ['legend.showLegend'],
+      optionProperties: ['legend.showLegend', 'legend.placement'],
       fieldConfigProperties: ['custom.stacking'],
     },
   })


### PR DESCRIPTION
Much more elegant alternative to
https://github.com/grafana/grafana/pull/130027

Makes use of the new quick toggles functionality in grafana.

Adds legend placement and graph scale quick toggles

https://github.com/user-attachments/assets/1343262f-582a-44e7-9639-45c7d0dbba50

