### PR TITLE
I18n: Add translations for the Alerting Watchers nav entry

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -964,7 +964,7 @@ playwright.storybook.config.ts @grafana/grafana-frontend-platform
 /public/app/core/utils/isOnPrem.ts @grafana/grafana-frontend-navigation
 /public/app/core/utils/isRecord.ts @grafana/dashboards-squad
 /public/app/core/utils/kbn* @grafana/grafana-frontend-platform
-/public/app/core/utils/navBarItem-translations.ts @grafana/grafana-frontend-navigation
+/public/app/core/utils/navBarItem-translations* @grafana/grafana-frontend-navigation
 /public/app/core/utils/object* @grafana/grafana-frontend-platform
 /public/app/core/utils/query* @grafana/grafana-datasources-core-services
 /public/app/core/utils/richHistory* @grafana/datapro

--- a/public/app/core/utils/navBarItem-translations.test.ts
+++ b/public/app/core/utils/navBarItem-translations.test.ts
@@ -1,0 +1,33 @@
+import { getNavSubTitle, getNavTitle } from './navBarItem-translations';
+
+describe('navBarItem-translations', () => {
+  describe('getNavTitle', () => {
+    it('returns the title for the Alerting Watchers nav item', () => {
+      expect(getNavTitle('standalone-plugin-page-assistant-watchers')).toBe('Watchers');
+    });
+
+    it('returns undefined for an unknown nav ID', () => {
+      expect(getNavTitle('not-a-real-nav-id')).toBeUndefined();
+    });
+
+    it('returns undefined when no nav ID is given', () => {
+      expect(getNavTitle(undefined)).toBeUndefined();
+    });
+  });
+
+  describe('getNavSubTitle', () => {
+    it('returns the subtitle for the Alerting Watchers nav item', () => {
+      expect(getNavSubTitle('standalone-plugin-page-assistant-watchers')).toBe(
+        'Let the Assistant watch your data and notify you when something needs attention'
+      );
+    });
+
+    it('returns undefined for an unknown nav ID', () => {
+      expect(getNavSubTitle('not-a-real-nav-id')).toBeUndefined();
+    });
+
+    it('returns undefined when no nav ID is given', () => {
+      expect(getNavSubTitle(undefined)).toBeUndefined();
+    });
+  });
+});

--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -77,6 +77,8 @@ export function getNavTitle(navId: string | undefined) {
       return t('nav.alerting-list.title', 'Alert rules');
     case 'alert-list-legacy':
       return t('nav.alert-list-legacy.title', 'Alert rules');
+    case 'standalone-plugin-page-assistant-watchers':
+      return t('nav.alerting-watchers.title', 'Watchers');
     case 'receivers':
       return t('nav.alerting-receivers.title', 'Contact points');
     case 'am-routes':
@@ -250,6 +252,11 @@ export function getNavSubTitle(navId: string | undefined) {
       );
     case 'alert-list':
       return t('nav.alerting-list.subtitle', 'Rules that determine whether an alert will fire');
+    case 'standalone-plugin-page-assistant-watchers':
+      return t(
+        'nav.alerting-watchers.subtitle',
+        'Let the Assistant watch your data and notify you when something needs attention'
+      );
     case 'receivers':
       return t(
         'nav.alerting-receivers.subtitle',

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12208,6 +12208,10 @@
       "subtitle": "Upgrade your existing legacy alerts and notification channels to the new Grafana Alerting",
       "title": "Alerting upgrade"
     },
+    "alerting-watchers": {
+      "subtitle": "Let the Assistant watch your data and notify you when something needs attention",
+      "title": "Watchers"
+    },
     "alerts-and-incidents": {
       "subtitle": "Alerting and incident management apps",
       "title": "Alerts & IRM"


### PR DESCRIPTION
**What is this feature?**

Adds `nav.alerting-watchers` title and subtitle strings for the **Watchers** item added to the Alerting section in #130037.

**Why do we need this feature?**

Without them the nav item falls back to the untranslated, backend-supplied text.

**Who is this feature for?**

Users of Grafana Alerting on stacks where the Assistant plugin is available.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Split out from #130037 to keep frontend and backend changes deployable independently. The two are compatible in either order — the nav reducers fall back to the backend text when a nav ID has no translation, and an unused translation key is harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)