### PR TITLE
Query Editor: Use consistent expression labels in stacked view

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/ContentHeader.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/ContentHeader.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/css';
-import { upperFirst } from 'lodash';
 import { type RefObject, useMemo, useRef } from 'react';
 
 import { type DataSourceInstanceSettings, type GrafanaTheme2, type ScopedVars } from '@grafana/data';
@@ -19,7 +18,7 @@ import {
 } from '../QueryEditorContext';
 import { usePanelScopedVars } from '../hooks/usePanelScopedVars';
 import { type AlertRule, type Transformation } from '../types';
-import { getEditorBorderColor } from '../utils';
+import { getEditorBorderColor, getExpressionSectionLabel } from '../utils';
 
 import { EditableQueryName } from './EditableQueryName';
 import { HeaderActions } from './HeaderActions';
@@ -219,7 +218,7 @@ export function ContentHeader({
         {cardType === QueryEditorType.Expression && selectedQuery && 'type' in selectedQuery && (
           <>
             <Text weight="light" variant="body" color="primary">
-              {upperFirst(selectedQuery.type)} <Trans i18nKey="query-editor-next.header.expression">Expression</Trans>
+              {getExpressionSectionLabel(selectedQuery)}
             </Text>
             <NavToolbarSeparator />
           </>

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/StackedEditor/StackedItem.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/StackedEditor/StackedItem.tsx
@@ -6,6 +6,7 @@ import { t, Trans } from '@grafana/i18n';
 import { type DataQuery } from '@grafana/schema';
 import { Icon, useStyles2 } from '@grafana/ui';
 import { DataSourceLogo } from 'app/features/datasources/components/picker/DataSourceLogo';
+import { isExpressionQuery } from 'app/features/expressions/guards';
 
 import { QueryEditorType } from '../../constants';
 import { EditableQueryName } from '../Header/EditableQueryName';
@@ -20,6 +21,7 @@ import { QueryEditorPanel } from '../QueryEditorRenderer';
 import { TransformationEditorPanel } from '../TransformationEditorRenderer';
 import { useQueryDatasource } from '../hooks/useQueryDatasource';
 import { type Transformation } from '../types';
+import { getExpressionSectionLabel } from '../utils';
 
 import { getStackedQueryEditorType } from './utils';
 
@@ -85,7 +87,7 @@ export function StackedQueryItem({ query, headingId }: StackedQueryItemProps) {
     <DataSourceLogo dataSource={queryDsData?.dsSettings} size={18} />
   );
 
-  const label = isExpression ? typeConfig[editorType].getLabel() : queryDsData?.dsSettings.name;
+  const label = isExpressionQuery(query) ? getExpressionSectionLabel(query) : queryDsData?.dsSettings.name;
 
   return (
     <>

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/utils.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/utils.test.ts
@@ -1,6 +1,7 @@
 import { createTheme } from '@grafana/data';
+import { ExpressionQueryType, type ExpressionQuery } from 'app/features/expressions/types';
 
-import { getHiddenMaskStyles } from './utils';
+import { getExpressionSectionLabel, getHiddenMaskStyles } from './utils';
 
 describe('getHiddenMaskStyles', () => {
   it('desaturates and applies a stronger dim in dark mode', () => {
@@ -13,5 +14,19 @@ describe('getHiddenMaskStyles', () => {
     const styles = getHiddenMaskStyles(createTheme({ colors: { mode: 'light' } }));
 
     expect(styles).toEqual({ opacity: 0.7, filter: 'grayscale(0.8)' });
+  });
+});
+
+describe('getExpressionSectionLabel', () => {
+  function expressionQuery(type: ExpressionQueryType): ExpressionQuery {
+    return { refId: 'A', type };
+  }
+
+  it.each([
+    [ExpressionQueryType.sql, 'Sql Expression'],
+    [ExpressionQueryType.math, 'Math Expression'],
+    [ExpressionQueryType.threshold, 'Threshold Expression'],
+  ])('capitalizes the %s expression type', (type, expected) => {
+    expect(getExpressionSectionLabel(expressionQuery(type))).toBe(expected);
   });
 });

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/utils.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/utils.test.ts
@@ -23,10 +23,19 @@ describe('getExpressionSectionLabel', () => {
   }
 
   it.each([
-    [ExpressionQueryType.sql, 'Sql Expression'],
+    [ExpressionQueryType.sql, 'SQL Expression'],
     [ExpressionQueryType.math, 'Math Expression'],
     [ExpressionQueryType.threshold, 'Threshold Expression'],
-  ])('capitalizes the %s expression type', (type, expected) => {
+    [ExpressionQueryType.classic, 'Classic condition (legacy) Expression'],
+  ])('uses the human-readable name for the %s expression type', (type, expected) => {
     expect(getExpressionSectionLabel(expressionQuery(type))).toBe(expected);
+  });
+
+  it('falls back to the raw type when it is not a known expression type', () => {
+    // Reachable at runtime: isExpressionQuery narrows on the __expr__ datasource ref alone, so a
+    // query can be treated as an expression while carrying a type outside the enum.
+    const query = { refId: 'A', type: 'custom_thing' } as unknown as ExpressionQuery;
+
+    expect(getExpressionSectionLabel(query)).toBe('Custom_thing Expression');
   });
 });

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/utils.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/utils.ts
@@ -1,3 +1,5 @@
+import { upperFirst } from 'lodash';
+
 import {
   type AlertState,
   type DataTransformerConfig,
@@ -9,6 +11,7 @@ import { t } from '@grafana/i18n';
 import { type CustomTransformerDefinition, SafeSerializableSceneObject, type VizPanel } from '@grafana/scenes';
 import { type DataQuery } from '@grafana/schema';
 import { isExpressionQuery } from 'app/features/expressions/guards';
+import { type ExpressionQuery } from 'app/features/expressions/types';
 
 import { getAlertStateColor, getQueryEditorTypeConfig, QueryEditorType } from '../constants';
 
@@ -50,6 +53,14 @@ export function getEditorType(
   }
 
   return QueryEditorType.Query;
+}
+
+/**
+ * Section label for an expression card, e.g. "Sql Expression". Shared by the single-edit header and
+ * the stacked editor so both render expression labels identically.
+ */
+export function getExpressionSectionLabel(query: ExpressionQuery): string {
+  return t('query-editor-next.labels.expression-title', '{{type}} Expression', { type: upperFirst(query.type) });
 }
 
 function isDataTransformerConfig(

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/utils.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/utils.ts
@@ -11,7 +11,7 @@ import { t } from '@grafana/i18n';
 import { type CustomTransformerDefinition, SafeSerializableSceneObject, type VizPanel } from '@grafana/scenes';
 import { type DataQuery } from '@grafana/schema';
 import { isExpressionQuery } from 'app/features/expressions/guards';
-import { type ExpressionQuery } from 'app/features/expressions/types';
+import { getExpressionLabel, type ExpressionQuery } from 'app/features/expressions/types';
 
 import { getAlertStateColor, getQueryEditorTypeConfig, QueryEditorType } from '../constants';
 
@@ -56,11 +56,17 @@ export function getEditorType(
 }
 
 /**
- * Section label for an expression card, e.g. "Sql Expression". Shared by the single-edit header and
- * the stacked editor so both render expression labels identically.
+ * Section label for an expression card, e.g. "SQL Expression". Shared by the single-edit header and
+ * the stacked editor so both render expression labels identically, matching the names on the
+ * expression type picker cards.
  */
 export function getExpressionSectionLabel(query: ExpressionQuery): string {
-  return t('query-editor-next.labels.expression-title', '{{type}} Expression', { type: upperFirst(query.type) });
+  // The fallback looks unreachable because `type` is typed as an enum member, but isExpressionQuery
+  // accepts any query pointing at the __expr__ datasource without validating `type`, so an absent
+  // or unrecognised type reaches here at runtime.
+  const typeName = getExpressionLabel(query.type) ?? upperFirst(query.type);
+
+  return t('query-editor-next.labels.expression-title', '{{type}} Expression', { type: typeName });
 }
 
 function isDataTransformerConfig(

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -14693,7 +14693,6 @@
     },
     "header": {
       "alert": "Alert",
-      "expression": "Expression",
       "pending-expression": "Select an expression",
       "pending-expression-cancel": "Cancel",
       "pending-transformation": "Select a transformation",
@@ -14707,6 +14706,7 @@
     "labels": {
       "alert": "alert",
       "expression": "expression",
+      "expression-title": "{{type}} Expression",
       "query": "query",
       "transformation": "transformation"
     },


### PR DESCRIPTION
## Description

Stacked view rendered expression section titles in lowercase (`expression`) while the single-edit header rendered them in title case (`Sql Expression`). Both views now resolve the label through one shared helper, so the formatting cannot drift again. Fixes grafana/grafana#129996.

## Changes

* Added `getExpressionSectionLabel` to `QueryEditor/utils.ts`, which builds the label via i18n interpolation (`{{type}} Expression`) rather than concatenating a translated word onto a raw type.
* `ContentHeader` and `StackedItem` both call the new helper. `StackedItem` previously used `typeConfig[...].getLabel()`, which returns the lowercase sentence-fragment form intended for strings like "New expression" and delete confirmations.
* Replaced the now-unused `query-editor-next.header.expression` key with `query-editor-next.labels.expression-title`.

## Risks

Low. The change is limited to the expression label in the query editor header and stacked view; the single-edit header renders exactly the same text as before. The helper is named `getExpressionSectionLabel` to avoid colliding with the existing `getExpressionLabel` in `app/features/expressions/types.ts` that alerting uses.

## Demo

N/A

## Testing Instructions

* Open panel edit with the new query editor, add a SQL expression, and confirm the header reads `Sql Expression`.
* Enter stacked view and confirm the expression section title also reads `Sql Expression` rather than `expression`, matching the `Transformation` section's formatting.

## Reviewer Checklist

- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable

Close grafana/grafana#129996