### PR TITLE
E2E selectors: Add a test id for the TabbedContainer close button

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -991,6 +991,13 @@ export const versionedComponents = {
     },
     active: { [MIN_GRAFANA_VERSION]: () => '[class*="-activeTabStyle"]' },
   },
+  TabbedContainer: {
+    // Shared by every TabbedContainer, so scope it to the surrounding container
+    // (for example pages.Explore.QueryHistory.container) to address one panel's close button.
+    closeButton: {
+      '13.2.0': 'data-testid tabbed-container-close-button',
+    },
+  },
   RefreshPicker: {
     runButtonV2: {
       [MIN_GRAFANA_VERSION]: 'data-testid RefreshPicker run button',

--- a/packages/grafana-e2e-selectors/src/selectors/pages.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/pages.ts
@@ -1189,6 +1189,11 @@ export const versionedPages = {
         '11.1.0': 'data-testid QueryHistory',
       },
     },
+    QueryInspector: {
+      container: {
+        '13.2.0': 'data-testid explore query inspector',
+      },
+    },
   },
   SoloPanel: {
     url: {

--- a/packages/grafana-ui/src/components/TabbedContainer/TabbedContainer.tsx
+++ b/packages/grafana-ui/src/components/TabbedContainer/TabbedContainer.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import * as React from 'react';
 
 import { type SelectableValue, type GrafanaTheme2 } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 
 import { IconButton } from '../../components/IconButton/IconButton';
 import { Tab } from '../../components/Tabs/Tab';
@@ -49,7 +50,13 @@ export function TabbedContainer({ tabs, defaultTab, closeIconTooltip, onClose, t
           />
         ))}
         <Box grow={1} display="flex" justifyContent="flex-end" paddingRight={1}>
-          <IconButton size="lg" onClick={onClose} name="times" tooltip={closeIconTooltip ?? 'Close'} />
+          <IconButton
+            size="lg"
+            onClick={onClose}
+            name="times"
+            tooltip={closeIconTooltip ?? 'Close'}
+            data-testid={selectors.components.TabbedContainer.closeButton}
+          />
         </Box>
       </TabsBar>
       <ScrollContainer>

--- a/public/app/features/explore/ExploreQueryInspector.tsx
+++ b/public/app/features/explore/ExploreQueryInspector.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { connect, type ConnectedProps } from 'react-redux';
 
 import { CoreApp, type GrafanaTheme2, LoadingState } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
 import { defaultTimeZone, type TimeZone } from '@grafana/schema';
@@ -106,7 +107,12 @@ export function ExploreQueryInspector(props: Props) {
   }
   return (
     <ExploreDrawer>
-      <TabbedContainer tabs={tabs} onClose={onClose} closeIconTooltip="Close query inspector" />
+      <TabbedContainer
+        tabs={tabs}
+        onClose={onClose}
+        closeIconTooltip="Close query inspector"
+        testId={selectors.pages.Explore.QueryInspector.container}
+      />
     </ExploreDrawer>
   );
 }


### PR DESCRIPTION
## What this does

Adds `components.TabbedContainer.closeButton` and wires it onto the close `IconButton` in `TabbedContainer`, plus a `testId` for Explore's query inspector container.

## Why

`TabbedContainer`'s close button carries **no test id**. The only handle on it is `closeIconTooltip`, which lands on the button as an `aria-label` — and two of the three call sites pass a translated string:

| Call site | Close label | Localized? |
| --- | --- | --- |
| `RichHistory.tsx` | `t('explore.rich-history.close-tooltip', 'Close query history')` | **yes** |
| `ExploreQueryInspector.tsx` | `"Close query inspector"` | no — hardcoded English |

So in a non-English Grafana the query history close button is unaddressable, and the inspector's only works by accident of an untranslated string.

`Tab.title` doesn't help either — it's `(title) => \`data-testid Tab ${title}\``, keyed on the **translated** label, so tab test ids shift with locale too.

This came out of driving Explore end to end with a Pathfinder guide, the same exercise behind #128794 and #129669. The guide needs a "now close the panel again" step, and today the only way to write it without depending on translated text is to reach for the icon's own test id:

```css
[data-testid='data-testid QueryHistory'] button:has(svg[data-testid='icon-times'])
```

That works, but it pins the button's internal icon markup rather than the control itself.

## Scope

`TabbedContainer` has exactly two consumers — Explore's query history and query inspector — so one selector covers both, and the blast radius is those two panels.

The inspector's `TabbedContainer` was also the only one not passing `testId`, so its container couldn't be scoped at all. It now uses `pages.Explore.QueryInspector.container`, mirroring the existing `pages.Explore.QueryHistory.container`.

## Not in here

`ExploreQueryInspector`'s hardcoded `closeIconTooltip="Close query inspector"` is an untranslated user-facing string. Left alone to keep this change to selectors — happy to fix it here or in a follow-up.

## Verified

- `yarn jest packages/grafana-e2e-selectors` — passes
- `yarn jest packages/grafana-ui/src/components/TabbedContainer` — 5/5 pass
- `tsc --noEmit` on `packages/grafana-e2e-selectors` — clean
- Both close buttons confirmed live on Grafana 13.2.0, each resolving to exactly one element when its panel is open and zero when closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)