### PR TITLE
 OpenFeature: Derive proxy namespace from eval context for wildcard c…

### DIFF
--- a/pkg/registry/apis/ofrep/http_routes.go
+++ b/pkg/registry/apis/ofrep/http_routes.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/validation"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/apiserver/builder"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
@@ -155,34 +156,42 @@ func (b *APIBuilder) validateNamespaceIfPresent(r *http.Request, evalCtx evalCon
 	_, span := tracing.Start(r.Context(), "ofrep.validateNamespaceIfPresent")
 	defer span.End()
 
-	if evalCtx.namespace == "" {
-		// No namespace in eval context -- nothing to validate
-		span.SetAttributes(attribute.Bool("validation.success", true))
-		return "", true
+	authNamespace := ""
+	if user, ok := types.AuthInfoFrom(r.Context()); ok {
+		authNamespace = user.GetNamespace()
 	}
 
-	user, ok := types.AuthInfoFrom(r.Context())
-	if !ok {
-		// No auth info -- can't validate, but that's fine; unauthed requests are
-		// gated on public flags by the caller
-		span.SetAttributes(attribute.Bool("validation.success", true))
-		return "", true
-	}
-
-	authNamespace := user.GetNamespace()
-	if authNamespace == "" {
-		// Unauthenticated user has no namespace -- skip validation
-		span.SetAttributes(attribute.Bool("validation.success", true))
-		return "", true
-	}
-
+	resolvedNamespace := resolveTargetNamespace(authNamespace, evalCtx.namespace)
 	span.SetAttributes(
 		attribute.String("auth_namespace", authNamespace),
 		attribute.String("eval_ctx_namespace", evalCtx.namespace),
 	)
 
+	// Nothing to check: caller claimed no target namespace, or we have no
+	// concrete identity to validate against (unauthed request -- gated on
+	// public flags elsewhere).
+	if evalCtx.namespace == "" || authNamespace == "" {
+		span.SetAttributes(attribute.Bool("validation.success", true))
+		return resolvedNamespace, true
+	}
+
 	// Wildcard auth namespace grants cluster-wide access — valid for any specific namespace.
 	valid := evalCtx.namespace == authNamespace || authNamespace == "*"
 	span.SetAttributes(attribute.Bool("validation.success", valid))
-	return authNamespace, valid
+	return resolvedNamespace, valid
+}
+
+// resolveTargetNamespace picks the namespace MTFF uses in the User-Agent when
+// proxying downstream. A concrete authNamespace wins; otherwise (empty, or
+// wildcard "*" for callers acting across tenants) fall back to the per-request
+// namespace from the eval context body, so calls don't all collapse into one
+// shared bucket.
+func resolveTargetNamespace(authNamespace, evalCtxNamespace string) string {
+	if authNamespace != "" && authNamespace != "*" {
+		return authNamespace
+	}
+	if evalCtxNamespace != "" && len(validation.IsValidNamespace(evalCtxNamespace)) == 0 {
+		return evalCtxNamespace
+	}
+	return authNamespace
 }

--- a/pkg/registry/apis/ofrep/http_routes_test.go
+++ b/pkg/registry/apis/ofrep/http_routes_test.go
@@ -28,65 +28,82 @@ func TestAPIBuilder_ValidateNamespaceIfPresent(t *testing.T) {
 	b := &APIBuilder{logger: logger}
 
 	tests := []struct {
-		name          string
-		authNamespace string
-		requestBody   string
-		noAuthInfo    bool
-		expectedValid bool
+		name              string
+		authNamespace     string
+		requestBody       string
+		noAuthInfo        bool
+		expectedValid     bool
+		expectedNamespace string
 	}{
 		{
-			name:          "no namespace in eval context - always valid",
-			authNamespace: "stacks-1",
-			requestBody:   `{"context":{}}`,
-			expectedValid: true,
+			name:              "no namespace in eval context - always valid",
+			authNamespace:     "stacks-1",
+			requestBody:       `{"context":{}}`,
+			expectedValid:     true,
+			expectedNamespace: "stacks-1",
 		},
 		{
-			name:          "no context object at all - always valid",
-			authNamespace: "stacks-1",
-			requestBody:   `{}`,
-			expectedValid: true,
+			name:              "no context object at all - always valid",
+			authNamespace:     "stacks-1",
+			requestBody:       `{}`,
+			expectedValid:     true,
+			expectedNamespace: "stacks-1",
 		},
 		{
-			name:          "namespace matches auth namespace - valid",
-			authNamespace: "stacks-1",
-			requestBody:   `{"context":{"namespace":"stacks-1"}}`,
-			expectedValid: true,
+			name:              "namespace matches auth namespace - valid",
+			authNamespace:     "stacks-1",
+			requestBody:       `{"context":{"namespace":"stacks-1"}}`,
+			expectedValid:     true,
+			expectedNamespace: "stacks-1",
 		},
 		{
-			name:          "namespace does not match auth namespace - invalid",
-			authNamespace: "stacks-1",
-			requestBody:   `{"context":{"namespace":"stacks-99"}}`,
-			expectedValid: false,
+			name:              "namespace does not match auth namespace - invalid, resolves to auth namespace",
+			authNamespace:     "stacks-1",
+			requestBody:       `{"context":{"namespace":"stacks-99"}}`,
+			expectedValid:     false,
+			expectedNamespace: "stacks-1",
 		},
 		{
-			name:          "unauthenticated with namespace in eval context - valid",
-			authNamespace: "",
-			requestBody:   `{"context":{"namespace":"stacks-1"}}`,
-			expectedValid: true,
+			name:              "unauthenticated with namespace in eval context - valid, resolves to eval ctx namespace",
+			authNamespace:     "",
+			requestBody:       `{"context":{"namespace":"stacks-1"}}`,
+			expectedValid:     true,
+			expectedNamespace: "stacks-1",
 		},
 		{
-			name:          "unauthenticated with no namespace - valid",
-			authNamespace: "",
-			requestBody:   `{"context":{}}`,
-			expectedValid: true,
+			name:              "unauthenticated with no namespace - valid, resolves to empty",
+			authNamespace:     "",
+			requestBody:       `{"context":{}}`,
+			expectedValid:     true,
+			expectedNamespace: "",
 		},
 		{
-			name:          "no auth info at all - valid (public flag gating handles unauthed)",
-			requestBody:   `{"context":{"namespace":"stacks-1"}}`,
-			noAuthInfo:    true,
-			expectedValid: true,
+			name:              "no auth info at all - valid (public flag gating handles unauthed), resolves to eval ctx namespace",
+			requestBody:       `{"context":{"namespace":"stacks-1"}}`,
+			noAuthInfo:        true,
+			expectedValid:     true,
+			expectedNamespace: "stacks-1",
 		},
 		{
-			name:          "wildcard auth namespace - valid for any specific namespace",
-			authNamespace: "*",
-			requestBody:   `{"context":{"namespace":"stacks-1"}}`,
-			expectedValid: true,
+			name:              "wildcard auth namespace - valid for any specific namespace, resolves to eval ctx namespace",
+			authNamespace:     "*",
+			requestBody:       `{"context":{"namespace":"stacks-1"}}`,
+			expectedValid:     true,
+			expectedNamespace: "stacks-1",
 		},
 		{
-			name:          "empty body - always valid",
-			authNamespace: "stacks-1",
-			requestBody:   ``,
-			expectedValid: true,
+			name:              "wildcard auth namespace with header-unsafe eval ctx namespace - falls back to wildcard",
+			authNamespace:     "*",
+			requestBody:       `{"context":{"namespace":"stacks-1\r\nX-Injected: evil"}}`,
+			expectedValid:     true,
+			expectedNamespace: "*",
+		},
+		{
+			name:              "empty body - always valid",
+			authNamespace:     "stacks-1",
+			requestBody:       ``,
+			expectedValid:     true,
+			expectedNamespace: "stacks-1",
 		},
 	}
 
@@ -109,8 +126,9 @@ func TestAPIBuilder_ValidateNamespaceIfPresent(t *testing.T) {
 			evalCtx, err := b.readEvalContext(httptest.NewRecorder(), req)
 			require.NoError(t, err)
 
-			_, valid := b.validateNamespaceIfPresent(req, evalCtx)
+			namespace, valid := b.validateNamespaceIfPresent(req, evalCtx)
 			assert.Equal(t, tt.expectedValid, valid)
+			assert.Equal(t, tt.expectedNamespace, namespace)
 
 			// Body must still be readable after readEvalContext
 			body, err := io.ReadAll(req.Body)


### PR DESCRIPTION
Follow-up to https://github.com/grafana/grafana/pull/124993 

MTFF builds the outbound User-Agent from the caller's own auth namespace. Multi-tenant callers auth as wildcard ("*") so all  their traffic across every tenant collapsed into one shared `features-grafana-app/*` bucket.                                                  
This PR changes it to fall back to the per-request namespace from the eval context body when the caller has no concrete tenant identity.
