### PR TITLE
Revert "FeatureToggles: Remove kubernetesQueryCaching and querycaching.redirectToK8SApi feature toggles"

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -209,6 +209,11 @@ export interface FeatureToggles {
   */
   kubernetesLogsDrilldown?: boolean;
   /**
+  * Adds support for Kubernetes querycaching
+  * @default false
+  */
+  kubernetesQueryCaching?: boolean;
+  /**
   * Register legacy datasource apis that use the numeric id
   * @default false
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -462,6 +462,15 @@ var (
 			Generate:        Generate{LegacyGo: true, LegacyFrontend: true},
 		},
 		{
+			Name:            "kubernetesQueryCaching",
+			Description:     "Adds support for Kubernetes querycaching",
+			Stage:           FeatureStageExperimental,
+			Owner:           grafanaOperatorExperienceSquad,
+			RequiresRestart: true,
+			Expression:      "false",
+			Generate:        Generate{LegacyGo: true, LegacyFrontend: true},
+		},
+		{
 			Name:            "datasources.queryTypes",
 			Description:     "Load Query types from spec.{version}.query.{yaml|json}",
 			Stage:           FeatureStageExperimental,
@@ -2701,6 +2710,14 @@ var (
 			Expression:      "false",
 			RequiresRestart: true,
 			Generate:        Generate{LegacyGo: true, LegacyFrontend: true},
+		},
+		{
+			Name:        "querycaching.redirectToK8SApi",
+			Description: "Redirect caching service cache config reads from legacy storage to K8s API",
+			Stage:       FeatureStageExperimental,
+			Owner:       grafanaOperatorExperienceSquad,
+			Expression:  "false",
+			Generate:    Generate{Go: true},
 		},
 		{
 			Name:        "querycaching.enableConnectionsClient",

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -51,6 +51,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2025-08-29,useKubernetesShortURLsAPI,GA,@grafana/sharing-squad,false,false,true
 2025-08-29,kubernetesCorrelations,experimental,@grafana/datapro,false,true,false
 2025-10-16,kubernetesLogsDrilldown,experimental,@grafana/observability-logs,false,true,false
+2025-10-20,kubernetesQueryCaching,experimental,@grafana/grafana-operator-experience-squad,false,true,false
 2026-05-22,datasources.queryTypes,experimental,@grafana/grafana-app-platform-squad,false,true,false
 2026-05-22,datasources.loadOpenAPI,experimental,@grafana/grafana-app-platform-squad,false,true,false
 2026-05-22,datasources.chunkedQueryStreaming,experimental,@grafana/grafana-datasources-core-services,false,false,false
@@ -313,6 +314,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-05-22,tracesDrilldownTimeSeeker,experimental,@grafana/observability-traces-and-profiling,false,false,true
 2026-05-22,enableColorblindSafePanelOptions,experimental,@grafana/dataviz-squad,false,false,true
 2026-05-22,cacheConfigUnifiedStorageMigration,experimental,@grafana/grafana-operator-experience-squad,false,true,false
+2026-05-22,querycaching.redirectToK8SApi,experimental,@grafana/grafana-operator-experience-squad,false,false,false
 2026-05-22,querycaching.enableConnectionsClient,experimental,@grafana/grafana-operator-experience-squad,false,false,false
 2026-05-22,querycaching.useInQueryService,experimental,@grafana/grafana-operator-experience-squad,false,false,false
 2026-05-22,influxDBConfigValidation,experimental,@grafana/data-sources-plugins,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -159,6 +159,10 @@ const (
 	// Adds support for Kubernetes logs drilldown
 	FlagKubernetesLogsDrilldown = "kubernetesLogsDrilldown"
 
+	// FlagKubernetesQueryCaching
+	// Adds support for Kubernetes querycaching
+	FlagKubernetesQueryCaching = "kubernetesQueryCaching"
+
 	// FlagDatasourcesQueryTypes
 	// Load Query types from spec.{version}.query.{yaml|json}
 	FlagDatasourcesQueryTypes = "datasources.queryTypes"
@@ -877,6 +881,10 @@ const (
 	// FlagCacheConfigUnifiedStorageMigration
 	// Enables cache configs data migration to unified storage
 	FlagCacheConfigUnifiedStorageMigration = "cacheConfigUnifiedStorageMigration"
+
+	// FlagQuerycachingRedirectToK8SApi
+	// Redirect caching service cache config reads from legacy storage to K8s API
+	FlagQuerycachingRedirectToK8SApi = "querycaching.redirectToK8SApi"
 
 	// FlagQuerycachingEnableConnectionsClient
 	// Use connections client instead of storage to resolve datasource plugin ID in query caching

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -3843,8 +3843,7 @@
       "metadata": {
         "name": "kubernetesQueryCaching",
         "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-10-20T16:11:25Z",
-        "deletionTimestamp": "2026-08-04T08:36:41Z"
+        "creationTimestamp": "2025-10-20T16:11:25Z"
       },
       "spec": {
         "description": "Adds support for Kubernetes querycaching",
@@ -5295,8 +5294,7 @@
       "metadata": {
         "name": "querycaching.redirectToK8SApi",
         "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z",
-        "deletionTimestamp": "2026-08-04T08:36:41Z"
+        "creationTimestamp": "2026-05-22T09:03:04Z"
       },
       "spec": {
         "description": "Redirect caching service cache config reads from legacy storage to K8s API",

--- a/pkg/storage/unified/migrations/testcases/querycacheconfigs.go
+++ b/pkg/storage/unified/migrations/testcases/querycacheconfigs.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	authlib "github.com/grafana/authlib/types"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/grafana/grafana/pkg/tests/apis"
 )
@@ -26,7 +27,7 @@ func (tc *queryCacheConfigsTestCase) Name() string {
 }
 
 func (tc *queryCacheConfigsTestCase) FeatureToggles() []string {
-	return []string{}
+	return []string{featuremgmt.FlagKubernetesQueryCaching}
 }
 
 func (tc *queryCacheConfigsTestCase) RenameTables() []string {


### PR DESCRIPTION
## Summary

Reverts #130026, restoring the `kubernetesQueryCaching` and `querycaching.redirectToK8SApi` feature toggle definitions (and the querycacheconfigs migration testcase's toggle reference). Companion to the enterprise revert of the querycaching flag cleanup (grafana/grafana-enterprise PR on the same branch name), which restores the code that reads these toggles.

## Merge order

1. **This PR first** — it only adds constants back, safe against current enterprise main
2. Then the enterprise revert PR (its restored code references these constants)

The matching branch name pins the two PRs' CI to each other while both are open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)