### PR TITLE
fix: skip os.ExpandEnv on already-expanded provisioning values

### DIFF
--- a/pkg/services/provisioning/values/values.go
+++ b/pkg/services/provisioning/values/values.go
@@ -290,7 +290,15 @@ func interpolateIfaceValue(val string) (interface{}, string, error) {
 	if err != nil {
 		return val, val, fmt.Errorf("failed to interpolate value '%s': %w", val, err)
 	}
-	expandedEnv := os.ExpandEnv(expanded)
+	var expandedEnv string
+	if expanded != val {
+		// ExpandVar resolved a ${VAR}, $__env{}, or $__file{} reference.
+		// The expanded value may contain literal '$' characters (e.g., a
+		// password from a file). Skip os.ExpandEnv to avoid corrupting them.
+		expandedEnv = expanded
+	} else {
+		expandedEnv = os.ExpandEnv(expanded)
+	}
 	if expandedEnv != val {
 		// If the value is an environment variable, consider it may not be a string
 		intV, err := strconv.ParseInt(expandedEnv, 10, 64)
@@ -320,8 +328,14 @@ func interpolateValue(val string) (string, string, error) {
 		if err != nil {
 			return val, val, fmt.Errorf("failed to interpolate value '%s': %w", val, err)
 		}
-		v = expanded
-		interpolated[i] = os.ExpandEnv(v)
+		if expanded != v {
+			// ExpandVar resolved a ${VAR}, $__env{}, or $__file{} reference.
+			// The expanded value may contain literal '$' characters (e.g., a
+			// password from a file). Skip os.ExpandEnv to avoid corrupting them.
+			interpolated[i] = expanded
+		} else {
+			interpolated[i] = os.ExpandEnv(expanded)
+		}
 	}
 	return strings.Join(interpolated, "$"), val, nil
 }


### PR DESCRIPTION
## Description

Closes #130055

### Problem

When a datasource is provisioned with a secret delivered through the **file provider** (`$__file{}`) or the **env provider** (`$__env{}`), any `$` inside the resolved secret is treated as an environment-variable reference by `os.ExpandEnv` and stripped. The credential that reaches the datasource is silently truncated, so authentication fails.

Root cause: in `interpolateValue` and `interpolateIfaceValue`, `setting.ExpandVar` is called first (resolves `$__file{}`, `$__env{}`, `${VAR}`), then `os.ExpandEnv` is called on the result. When `ExpandVar` resolves `$__file{/path}` to a file content like `Pa$sw0rd`, the subsequent `os.ExpandEnv` interprets `$sw0rd` as an env reference and drops it — yielding only `Pa`.

### Fix

Check if `ExpandVar` changed the value. If it did (meaning it resolved a `${VAR}`, `$__env{}`, or `$__file{}` reference), skip `os.ExpandEnv` — the expanded value may contain literal `$` characters (e.g., a password from a file). If `ExpandVar` did not change the value, `os.ExpandEnv` is still needed to handle bare `$VAR` (unbraced) references.

### Behavior comparison

| Delivery in `secureJsonData` | Resolved by | Before fix | After fix |
| --- | --- | --- | --- |
| `$MY_PASS` (bare env) | `os.ExpandEnv` | `os.ExpandEnv` works | `os.ExpandEnv` works (unchanged) |
| `${MY_PASS}` (braced) | `ExpandVar` → `os.ExpandEnv` | `$` in secret truncated | `$` in secret preserved |
| `$__env{MY_PASS}` | `ExpandVar` → `os.ExpandEnv` | `$` in secret truncated | `$` in secret preserved |
| `$__file{/path}` | `ExpandVar` (reads file) → `os.ExpandEnv` | `$` in secret truncated | `$` in secret preserved |