### PR TITLE
Home: Show dashboard descriptions on homepage

### DIFF
--- a/public/app/plugins/panel/dashlist/DashList.tsx
+++ b/public/app/plugins/panel/dashlist/DashList.tsx
@@ -193,7 +193,6 @@ export function DashList(props: PanelProps<Options>) {
               layoutMode="list"
               onStarChange={handleStarChange}
               source="dashListView"
-              showDescription
             />
           </li>
         );

--- a/public/app/plugins/panel/dashlist/DashListItem.tsx
+++ b/public/app/plugins/panel/dashlist/DashListItem.tsx
@@ -19,9 +19,6 @@ interface Props {
   onStarChange?: (id: string, isStarred: boolean) => void;
   // Row density for list mode. 'compact' gives denser rows for the redesigned homepage
   density?: 'default' | 'compact';
-  // Show an info icon with the dashboard description in list mode, when one exists.
-  // Defaults to false so shared consumers (homepage tabs, recently viewed) are unchanged.
-  showDescription?: boolean;
 }
 export function DashListItem({
   dashboard,
@@ -33,7 +30,6 @@ export function DashListItem({
   onStarChange,
   source,
   density = 'default',
-  showDescription = false,
 }: Props) {
   const css = useStyles2(getStyles);
   const isCompact = density === 'compact';
@@ -67,7 +63,7 @@ export function DashListItem({
           href={url}
           onClick={onCardLinkClick}
           trailing={
-            showDescription && dashboard.description ? (
+            dashboard.description ? (
               <Stack gap={0.5} alignItems="center">
                 <DescriptionTooltip description={dashboard.description} />
                 {starButton}


### PR DESCRIPTION
**What is this feature?**

Following on from #130006, we're fine with these descriptions also showing on the homepage, which is the only other consumer of this component.

**Why do we need this feature?**

Consistently show descriptions of dashboards to customers via the DashList/DashListItem component.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
