### PR TITLE
Text: Fix stray closing brace when completing a variable after `${`

### DIFF
--- a/public/app/plugins/panel/text/v2/editor/variableCompletion.test.ts
+++ b/public/app/plugins/panel/text/v2/editor/variableCompletion.test.ts
@@ -11,9 +11,12 @@ const suggestions: VariableSuggestion[] = [
   { value: '__data.fields["Value"]', label: 'Value', origin: VariableOrigin.Fields },
 ];
 
-function complete(doc: string, explicit = false) {
+/** `docWithCursor` marks the cursor with `|`; without one it sits at the end. */
+function complete(docWithCursor: string, explicit = false) {
+  const pos = docWithCursor.indexOf('|');
+  const doc = docWithCursor.replace('|', '');
   const source = variableCompletion(suggestions);
-  const context = new CompletionContext(EditorState.create({ doc }), doc.length, explicit);
+  const context = new CompletionContext(EditorState.create({ doc }), pos === -1 ? doc.length : pos, explicit);
   return source(context);
 }
 
@@ -28,6 +31,19 @@ describe('variableCompletion', () => {
     const result = complete('${myV');
     expect(result?.from).toBe(0);
     expect(result?.options.map((o) => o.label)).toEqual(['${myVar}']);
+  });
+
+  it('swallows the closing brace `closeBrackets` inserted, so accepting leaves no stray `}`', () => {
+    // `${` auto-closes to `${}`, and the option carries its own brace.
+    expect(complete('${|}')).toMatchObject({ from: 0, to: 3 });
+    expect(complete('${myV|}')).toMatchObject({ from: 0, to: 6 });
+    // The cursor may also sit inside a reference that is already written out.
+    expect(complete('${my|Var} tail')).toMatchObject({ from: 0, to: 8 });
+  });
+
+  it('replaces only up to the cursor when the reference has no brace to close', () => {
+    expect(complete('$myV|}')).toMatchObject({ from: 0, to: 4 });
+    expect(complete('${myVar|')).toMatchObject({ from: 0, to: 7 });
   });
 
   it('matches on the suggestion label as well as the value', () => {

--- a/public/app/plugins/panel/text/v2/editor/variableCompletion.ts
+++ b/public/app/plugins/panel/text/v2/editor/variableCompletion.ts
@@ -7,6 +7,9 @@ import {
 
 // A variable being typed at the cursor: `$`, an optional brace, and the name so far.
 const TRIGGER_PATTERN = /\$\{?[\w.]*$/;
+// The rest of a braced reference the cursor sits inside: any name left to the
+// right, then the closing brace.
+const BRACED_TAIL_PATTERN = /^[\w.]*\}/;
 
 const toCompletion = (suggestion: VariableSuggestion): CodeMirrorCompletion => ({
   label: `\${${suggestion.value}}`,
@@ -15,11 +18,25 @@ const toCompletion = (suggestion: VariableSuggestion): CodeMirrorCompletion => (
   type: 'variable',
 });
 
+/** End of the range an option replaces: the cursor, or the end of a braced reference around it. */
+function braceAwareTo(context: CodeMirrorCompletionContext, trigger: string): number {
+  if (!trigger.startsWith('${')) {
+    return context.pos;
+  }
+  const line = context.state.doc.lineAt(context.pos);
+  const tail = context.state.sliceDoc(context.pos, line.to).match(BRACED_TAIL_PATTERN);
+  return tail ? context.pos + tail[0].length : context.pos;
+}
+
 /**
  * Autocompletion source for template and field variables, triggered by `$`.
  *
  * Options insert a full `${...}` reference, so the replaced range starts at the
  * `$`. That `${` prefix would defeat CodeMirror's own matching, hence `filter: false`.
+ *
+ * The range also runs past the closing brace of a reference the cursor is inside,
+ * because the option carries its own. Typing `${` leaves `${|}` once `closeBrackets`
+ * has matched the brace, and that `}` would otherwise be left behind.
  */
 export function variableCompletion(
   suggestions: VariableSuggestion[]
@@ -35,6 +52,6 @@ export function variableCompletion(
       ? suggestions.filter((s) => s.value.toLowerCase().includes(typed) || s.label.toLowerCase().includes(typed))
       : suggestions;
 
-    return { from: word.from, options: matches.map(toCompletion), filter: false };
+    return { from: word.from, to: braceAwareTo(context, word.text), options: matches.map(toCompletion), filter: false };
   };
 }


### PR DESCRIPTION
Targets `adela/text_v2_vars_autocomplete` so it can be merged straight into #129994.

Fixes the extra `}` reported in https://github.com/grafana/grafana/pull/129994#discussion_r3708017374 and confirmed in https://github.com/grafana/grafana/pull/129994#discussion_r3713531046.

## The problem

Completion options insert a full `${...}` reference, so the replaced range starts at the `$` — but it ended at the cursor. CodeMirror's `closeBrackets` auto-inserts the closing brace as soon as `${` is typed, so the document is already `${|}`. The brace the option carries is then added on top of the one that is already there:

| typed | accepted | before | after |
| --- | --- | --- | --- |
| `$` | `${myVar}` | `${myVar}` | `${myVar}` |
| `${` | `${myVar}` | `${myVar}}` ❌ | `${myVar}` ✅ |

## The fix

`braceAwareTo()` extends the replaced range over the rest of a braced reference the cursor sits inside — the auto-inserted brace, and any name to the right of the cursor. It is scoped to the current line, and only applies when the trigger opened with `${`, so a lone `$` still replaces up to the cursor only.

This also fixes a case the bot did not mention: putting the cursor inside a reference that is already written out (`${my|Var}`) previously left `Var}` behind.

## Why not disable `closeBrackets`

The bot suggested following the sibling CodeMirror inputs, which turn `closeBrackets` off. Those (`InlineInput`, `QueryInput`) are single-line query fields. This is a full editor whose Code mode edits Go, JSON, SQL and TypeScript, where bracket auto-closing is worth keeping — so the fix belongs in the completion range instead.

## Verification

Driven through real CodeMirror state (`insertBracket` + `insertCompletionText` with the markdown language), both `hi $` and `hi ${` now complete to `hi ${myVar}`.

Unit tests cover the braced, unbraced and cursor-inside-a-reference cases. The test helper now takes a `|` cursor marker, since it previously pinned the cursor to the end of the document and could not express text after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
