### PR TITLE
Grafana UI: Share one variable completion source, and fix a doubled brace in data links

### DIFF
--- a/packages/grafana-ui/src/components/CodeMirror/InlineInput.mdx
+++ b/packages/grafana-ui/src/components/CodeMirror/InlineInput.mdx
@@ -25,6 +25,37 @@ that edit `${...}` variable expressions.
 />
 ```
 
+### Suggesting variables
+
+Build the source with `createVariableCompletionSource` rather than by hand. It
+owns the `$` trigger, the filtering and — importantly — the range an option
+replaces, so accepting a suggestion next to a closing brace cannot leave a stray
+`}` behind.
+
+```tsx
+const completionSources = useMemo(() => [createVariableCompletionSource(suggestions)], [suggestions]);
+```
+
+Inside a URL, where `=` also opens the popup and variables need query encoding:
+
+```tsx
+createVariableCompletionSource(suggestions, {
+  separators: ['='],
+  getInsertText: (suggestion) => `\${${suggestion.value}:queryparam}`,
+});
+```
+
+If a source has to offer variables alongside other kinds of completion, the
+factory does not fit — a range on the result would apply to every option. Build
+the options yourself and reach for `applyVariableReference` on the variable ones:
+
+```tsx
+options: [
+  ...variables.map((name) => ({ label: name, apply: applyVariableReference(`\${${name}}`), type: 'variable' })),
+  ...fields.map((name) => ({ label: name, type: 'property' })),
+];
+```
+
 ### Accessibility
 
 The editable element is a `contenteditable`, so it cannot be associated with a

--- a/packages/grafana-ui/src/components/CodeMirror/InlineInput.story.tsx
+++ b/packages/grafana-ui/src/components/CodeMirror/InlineInput.story.tsx
@@ -2,30 +2,24 @@ import type { Meta, StoryFn } from '@storybook/react';
 import { useEffect, useState } from 'react';
 import { action } from 'storybook/actions';
 
+import { VariableOrigin, type VariableSuggestion } from '@grafana/data';
+
 import { Field } from '../Forms/Field';
 
 import { CodeMirrorInlineInput } from './InlineInput';
 import mdx from './InlineInput.mdx';
-import type { CodeMirrorCompletionSource } from './types';
+import { createVariableCompletionSource } from './variableCompletion';
 
-// A trivial completion source that suggests a couple of `${...}` variables when
-// the user types `$`.
-const variableCompletionSource: CodeMirrorCompletionSource = (context) => {
-  const word = context.matchBefore(/\$\{?[\w.]*$/);
-  if (!word && !context.explicit) {
-    return null;
-  }
+const suggestions: VariableSuggestion[] = [
+  { value: '__series.name', label: '__series.name', origin: VariableOrigin.Series },
+  { value: '__field.name', label: '__field.name', origin: VariableOrigin.Field },
+  { value: '__value.raw', label: '__value.raw', origin: VariableOrigin.Value },
+];
 
-  return {
-    from: word ? word.from : context.pos,
-    filter: false,
-    options: [
-      { label: '__series.name', apply: '${__series.name}', type: 'variable' },
-      { label: '__field.name', apply: '${__field.name}', type: 'variable' },
-      { label: '__value.raw', apply: '${__value.raw}', type: 'variable' },
-    ],
-  };
-};
+// Suggests `${...}` variables when the user types `$`. The factory owns the
+// trigger, the filtering and the replaced range, so accepting an option can't
+// leave a stray brace behind.
+const variableCompletionSource = createVariableCompletionSource(suggestions);
 
 const meta: Meta<typeof CodeMirrorInlineInput> = {
   title: 'Inputs/CodeMirrorInlineInput',
@@ -83,7 +77,9 @@ LongValue.args = {
 
 export const WithVariableCompletions = Controlled.bind({});
 WithVariableCompletions.args = {
-  value: 'https://example.com/d/abc?var=',
+  // Carries a complete reference, so the mid-reference case is reachable: put
+  // the caret inside `${__value.raw}` and accept an option.
+  value: 'https://example.com/d/abc?var=${__value.raw}',
   placeholder: 'http://your-grafana.com/d/000000010/annotations',
   completionSources: [variableCompletionSource],
 };

--- a/packages/grafana-ui/src/components/CodeMirror/variableCompletion.test.ts
+++ b/packages/grafana-ui/src/components/CodeMirror/variableCompletion.test.ts
@@ -1,0 +1,232 @@
+import { CompletionContext, type CompletionResult } from '@codemirror/autocomplete';
+import { EditorState } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+
+import { DataLinkBuiltInVars, VariableOrigin, type VariableSuggestion } from '@grafana/data';
+
+import { applyVariableReference, createVariableCompletionSource } from './variableCompletion';
+
+const suggestions: VariableSuggestion[] = [
+  { value: 'myVar', label: 'myVar', documentation: 'Custom variable', origin: VariableOrigin.Template },
+  { value: DataLinkBuiltInVars.fieldName, label: '__field.name', origin: VariableOrigin.Field },
+  { value: '__data.fields["Value"]', label: 'Value', origin: VariableOrigin.Fields },
+];
+
+type VariableSourceOptions = Parameters<typeof createVariableCompletionSource>[1];
+
+const URL_MODE: VariableSourceOptions = {
+  separators: ['='],
+  getInsertText: (s) => `\${${s.value}:queryparam}`,
+};
+
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  document.body.removeChild(container);
+});
+
+/** `docWithCursor` marks the cursor with `|`; without one it sits at the end. */
+function parse(docWithCursor: string) {
+  const cursor = docWithCursor.indexOf('|');
+  const doc = docWithCursor.replace('|', '');
+  return { doc, pos: cursor === -1 ? doc.length : cursor };
+}
+
+function complete(docWithCursor: string, options?: VariableSourceOptions) {
+  const { doc, pos } = parse(docWithCursor);
+  const source = createVariableCompletionSource(suggestions, options);
+  return source(new CompletionContext(EditorState.create({ doc }), pos, false));
+}
+
+function completeExplicit(docWithCursor: string, options?: VariableSourceOptions) {
+  const { doc, pos } = parse(docWithCursor);
+  const source = createVariableCompletionSource(suggestions, options);
+  return source(new CompletionContext(EditorState.create({ doc }), pos, true));
+}
+
+/** Runs an option's `apply` against a real editor and returns the resulting document. */
+function applyOption(docWithCursor: string, result: CompletionResult, label: string): string {
+  const { doc, pos } = parse(docWithCursor);
+  const view = new EditorView({ state: EditorState.create({ doc }), parent: container });
+  const option = result.options.find((o) => o.label === label);
+  if (!option || typeof option.apply !== 'function') {
+    throw new Error(`no applicable option labelled ${label}`);
+  }
+
+  option.apply(view, option, result.from, result.to ?? pos);
+  const next = view.state.doc.toString();
+  view.destroy();
+  return next;
+}
+
+/** Accepts the first option of an implicitly triggered completion. */
+function completeAndApply(docWithCursor: string, label: string, options?: VariableSourceOptions): string {
+  const result = complete(docWithCursor, options);
+  if (!result) {
+    throw new Error(`no completion offered for ${docWithCursor}`);
+  }
+  return applyOption(docWithCursor, result, label);
+}
+
+describe('createVariableCompletionSource', () => {
+  describe('triggering', () => {
+    it('offers every variable once `$` is typed', () => {
+      const result = complete('# Title\n$');
+      expect(result?.from).toBe(8);
+      expect(result?.options.map((o) => o.label)).toEqual(['myVar', '__field.name', 'Value']);
+    });
+
+    it('replaces the whole reference being typed, including the brace', () => {
+      expect(complete('${myV')?.from).toBe(0);
+      expect(complete('${myV')?.options.map((o) => o.label)).toEqual(['myVar']);
+    });
+
+    it('matches on the suggestion value as well as the label', () => {
+      // `__data.fields["Value"]` is the value; `Value` is the label.
+      expect(complete('$__data')?.options.map((o) => o.label)).toEqual(['Value']);
+      expect(complete('$Value')?.options.map((o) => o.label)).toEqual(['Value']);
+    });
+
+    it('stays closed outside a reference', () => {
+      expect(complete('some text')).toBeNull();
+    });
+
+    it('shows everything on an explicit request outside a reference, inserting at the cursor', () => {
+      const result = completeExplicit('some text ');
+      expect(result?.from).toBe(10);
+      expect(result?.options).toHaveLength(3);
+    });
+
+    it('shows everything on an explicit request after a trigger, still anchored at the `$`', () => {
+      const result = completeExplicit('$myV');
+      expect(result?.from).toBe(0);
+      expect(result?.options).toHaveLength(3);
+    });
+
+    it('offers nothing at all when there are no suggestions', () => {
+      const source = createVariableCompletionSource([]);
+      expect(source(new CompletionContext(EditorState.create({ doc: '$' }), 1, true))).toBeNull();
+    });
+  });
+
+  describe('option metadata', () => {
+    it('defaults to the suggestion label with its origin as the detail', () => {
+      const options = complete('$')?.options ?? [];
+      expect(options[0]).toMatchObject({ label: 'myVar', detail: VariableOrigin.Template, type: 'variable' });
+      expect(options[0].info).toBe('Custom variable');
+    });
+
+    it('takes label and detail from `toDisplay` when given', () => {
+      const options =
+        complete('$', {
+          toDisplay: (s) => ({
+            label: `\${${s.value}}`,
+            detail: s.value === s.label ? s.origin : `${s.label} / ${s.origin}`,
+          }),
+        })?.options ?? [];
+
+      expect(options[0]).toMatchObject({ label: '${myVar}', detail: VariableOrigin.Template });
+      expect(options[2]).toMatchObject({
+        label: '${__data.fields["Value"]}',
+        detail: `Value / ${VariableOrigin.Fields}`,
+      });
+    });
+  });
+
+  describe('separators', () => {
+    it('does not trigger on a separator that was not configured', () => {
+      expect(complete('url?param=')).toBeNull();
+    });
+
+    it('opens after a configured separator and preserves it', () => {
+      const result = complete('url?param=', URL_MODE);
+      expect(result?.from).toBe(10);
+      expect(applyOption('url?param=', result!, 'myVar')).toBe('url?param=${myVar:queryparam}');
+    });
+
+    it('preserves the separator once a filter prefix has been typed', () => {
+      const result = complete('url?param=myV', URL_MODE);
+      expect(result?.from).toBe(10);
+      expect(applyOption('url?param=myV', result!, 'myVar')).toBe('url?param=${myVar:queryparam}');
+    });
+
+    it('still anchors at the `$` when one is typed after the separator', () => {
+      // The end-anchored match lands on the `$`, never on the `=`.
+      const result = complete('url?param=$myV', URL_MODE);
+      expect(result?.from).toBe(10);
+      expect(applyOption('url?param=$myV', result!, 'myVar')).toBe('url?param=${myVar:queryparam}');
+    });
+  });
+
+  describe('getInsertText', () => {
+    it('inserts a plain `${value}` by default', () => {
+      expect(completeAndApply('$myV', 'myVar')).toBe('${myVar}');
+    });
+
+    it('inserts whatever `getInsertText` returns', () => {
+      expect(completeAndApply('$myV', 'myVar', URL_MODE)).toBe('${myVar:queryparam}');
+    });
+  });
+});
+
+describe('applying an option next to a closing brace', () => {
+  it('consumes the brace `closeBrackets` inserted, rather than doubling it', () => {
+    // Typing `${` in an editor with bracket closing leaves the document as `${|}`.
+    expect(completeAndApply('${|}', 'myVar')).toBe('${myVar}');
+  });
+
+  it('replaces the whole reference when the cursor sits inside a complete one', () => {
+    expect(completeAndApply('?x=${my|Var} tail', 'myVar')).toBe('?x=${myVar} tail');
+  });
+
+  it('replaces a reference that carries a format suffix', () => {
+    expect(completeAndApply('?x=${my|Var:queryparam}', 'myVar', URL_MODE)).toBe('?x=${myVar:queryparam}');
+  });
+
+  it('leaves a closing brace alone when the reference being typed has no opening one', () => {
+    // The `}` belongs to something else — the option brings its own pair.
+    expect(completeAndApply('?x=$my|} tail', 'myVar')).toBe('?x=${myVar}} tail');
+  });
+
+  it('leaves a closing brace alone after a separator', () => {
+    expect(completeAndApply('url?param=my|} tail', 'myVar', URL_MODE)).toBe('url?param=${myVar:queryparam}} tail');
+  });
+
+  it('does not reach a closing brace on a later line', () => {
+    expect(completeAndApply('${my|\nbar}', 'myVar')).toBe('${myVar}\nbar}');
+  });
+
+  it('does not reach past the end of an unclosed reference', () => {
+    expect(completeAndApply('?x=${my|', 'myVar')).toBe('?x=${myVar}');
+  });
+
+  it('inserts without consuming anything on an explicit request outside a reference', () => {
+    const result = completeExplicit('?x=| tail');
+    expect(applyOption('?x=| tail', result!, 'myVar')).toBe('?x=${myVar} tail');
+  });
+
+  // Known gap: the tail of a bracketed accessor is not a name, so it is left
+  // behind. Widening the pattern enough to cover it would also swallow prose in
+  // a Markdown document, so this is deliberate.
+  it('leaves a bracketed accessor tail behind', () => {
+    expect(completeAndApply('?x=${__data.fi|elds["Value"]}', 'Value')).toBe(
+      '?x=${__data.fields["Value"]}elds["Value"]}'
+    );
+  });
+});
+
+describe('applyVariableReference', () => {
+  it('is usable on its own, for a source mixing variables with other option kinds', () => {
+    const view = new EditorView({ state: EditorState.create({ doc: '?x=${my}' }), parent: container });
+
+    applyVariableReference('${myVar}')(view, { label: 'myVar' }, 3, 6);
+
+    expect(view.state.doc.toString()).toBe('?x=${myVar}');
+    view.destroy();
+  });
+});

--- a/packages/grafana-ui/src/components/CodeMirror/variableCompletion.ts
+++ b/packages/grafana-ui/src/components/CodeMirror/variableCompletion.ts
@@ -1,0 +1,132 @@
+import { insertCompletionText } from '@codemirror/autocomplete';
+import { type EditorState } from '@codemirror/state';
+
+import { type VariableSuggestion } from '@grafana/data';
+
+import { type CodeMirrorCompletion, type CodeMirrorCompletionContext, type CodeMirrorCompletionResult } from './types';
+
+// The rest of a braced reference the cursor sits inside: the remainder of the
+// name, an optional `:format` suffix, then the closing brace.
+const BRACED_TAIL_PATTERN = /^[\w.:]*\}/;
+
+/** How a suggestion is presented in the completion list. */
+export interface VariableCompletionDisplay {
+  label: string;
+  detail?: string;
+}
+
+export interface VariableCompletionOptions {
+  /**
+   * Characters besides `$` that open the popup. They are separators rather than
+   * part of the reference, so they are preserved: the replaced range starts
+   * after them. `['=']` for a URL query string.
+   */
+  separators?: string[];
+  /**
+   * Text inserted when an option is accepted. Defaults to `${value}`. Override
+   * to add a format suffix, for example `${value:queryparam}` inside a URL.
+   */
+  getInsertText?: (suggestion: VariableSuggestion) => string;
+  /**
+   * Label and detail shown in the list. Defaults to the suggestion's own label
+   * with its origin as the detail.
+   */
+  toDisplay?: (suggestion: VariableSuggestion) => VariableCompletionDisplay;
+}
+
+type CompletionApply = NonNullable<Exclude<CodeMirrorCompletion['apply'], string>>;
+
+function escapeForCharClass(char: string): string {
+  return char.replace(/[\\\]^-]/g, '\\$&');
+}
+
+/** `$`, or one of the separators, then an optional brace and the name so far. */
+function buildTriggerPattern(separators: string[]): RegExp {
+  return new RegExp(`[$${separators.map(escapeForCharClass).join('')}]\\{?[\\w.]*$`);
+}
+
+function referenceEnd(state: EditorState, from: number, to: number): number {
+  // Only a range that already opened a brace may close one. An unbraced `$name`
+  // supplies both braces itself, so a `}` further along the line is not ours.
+  if (!state.sliceDoc(from, to).startsWith('${')) {
+    return to;
+  }
+
+  const line = state.doc.lineAt(to);
+  const tail = state.sliceDoc(to, line.to).match(BRACED_TAIL_PATTERN);
+  return tail ? to + tail[0].length : to;
+}
+
+/**
+ * `Completion.apply` for an option that inserts a whole `${...}` reference.
+ *
+ * The option carries its own closing brace, so a `}` already to the right of the
+ * cursor has to be part of the replaced range. Two ways one gets there:
+ * - `closeBrackets`, on in CodeMirror's default basic setup, inserts `}` the
+ *   moment `{` is typed, leaving the document as `${|}`.
+ * - The cursor sits inside a reference that is already complete: `${my|Var}`.
+ *
+ * Prefer {@link createVariableCompletionSource}. Reach for this directly only
+ * when a source has to emit variable options alongside other kinds, where a
+ * range on the result would apply to every option.
+ */
+export function applyVariableReference(text: string): CompletionApply {
+  return (view, _completion, from, to) => {
+    view.dispatch(insertCompletionText(view.state, text, from, referenceEnd(view.state, from, to)));
+  };
+}
+
+/**
+ * Autocompletion source for Grafana variables, triggered by `$`.
+ *
+ * Options insert a full `${...}` reference, so the replaced range starts at the
+ * `$`. That `${` prefix would defeat CodeMirror's own label matching, so
+ * suggestions are filtered here instead and the result sets `filter: false`.
+ */
+export function createVariableCompletionSource(
+  suggestions: VariableSuggestion[],
+  options: VariableCompletionOptions = {}
+): (context: CodeMirrorCompletionContext) => CodeMirrorCompletionResult | null {
+  const {
+    separators = [],
+    getInsertText = (suggestion: VariableSuggestion) => `\${${suggestion.value}}`,
+    toDisplay = (suggestion: VariableSuggestion) => ({ label: suggestion.label, detail: suggestion.origin }),
+  } = options;
+  const triggerPattern = buildTriggerPattern(separators);
+
+  const toCompletion = (suggestion: VariableSuggestion): CodeMirrorCompletion => ({
+    ...toDisplay(suggestion),
+    info: suggestion.documentation,
+    apply: applyVariableReference(getInsertText(suggestion)),
+    type: 'variable',
+  });
+
+  return (context: CodeMirrorCompletionContext): CodeMirrorCompletionResult | null => {
+    if (suggestions.length === 0) {
+      return null;
+    }
+
+    const word = context.matchBefore(triggerPattern);
+
+    // Outside a reference, only an explicit request (Ctrl+Space) responds, by
+    // inserting a fresh reference at the cursor.
+    if (!word) {
+      return context.explicit ? { from: context.pos, options: suggestions.map(toCompletion), filter: false } : null;
+    }
+
+    // A separator is preserved, so the range starts after it. A `$` is part of
+    // the reference and is replaced, which is what stops an explicit request
+    // after a typed `$` from producing `$${...}`.
+    const from = separators.includes(word.text.charAt(0)) ? word.from + 1 : word.from;
+    const typed = word.text.slice(1).replace(/^\{/, '').toLowerCase();
+
+    // An explicit request shows every variable; implicit triggering filters by
+    // the name typed so far.
+    const matches =
+      context.explicit || !typed
+        ? suggestions
+        : suggestions.filter((s) => s.value.toLowerCase().includes(typed) || s.label.toLowerCase().includes(typed));
+
+    return { from, options: matches.map(toCompletion), filter: false };
+  };
+}

--- a/packages/grafana-ui/src/components/DataLinks/codemirrorUtils.test.ts
+++ b/packages/grafana-ui/src/components/DataLinks/codemirrorUtils.test.ts
@@ -1,10 +1,15 @@
-import { type CompletionContext } from '@codemirror/autocomplete';
+import { CompletionContext, type CompletionResult } from '@codemirror/autocomplete';
 import { EditorState, type Extension } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
 
 import { createTheme, DataLinkBuiltInVars, VariableOrigin, type VariableSuggestion } from '@grafana/data';
 
-import { createDataLinkHighlighter, createDataLinkTheme, dataLinkAutocompletion } from './codemirrorUtils';
+import {
+  createDataLinkHighlighter,
+  createDataLinkTheme,
+  dataLinkAutocompletion,
+  type DataLinkInterpolationMode,
+} from './codemirrorUtils';
 
 const mockSuggestions: VariableSuggestion[] = [
   {
@@ -51,23 +56,7 @@ describe('codemirrorUtils', () => {
   }
 
   function createMockContext(text: string, pos: number, explicit = false): CompletionContext {
-    const state = EditorState.create({ doc: text });
-    return {
-      state,
-      pos,
-      explicit,
-      matchBefore: (regex: RegExp) => {
-        const before = text.slice(0, pos);
-        const match = before.match(regex);
-        if (!match) {
-          return null;
-        }
-        const from = pos - match[0].length;
-        return { from, to: pos, text: match[0] };
-      },
-      aborted: false,
-      addEventListener: jest.fn(),
-    } as unknown as CompletionContext;
+    return new CompletionContext(EditorState.create({ doc: text }), pos, explicit);
   }
 
   // The text content of every `.cm-variable` decoration the highlighter rendered.
@@ -115,151 +104,83 @@ describe('codemirrorUtils', () => {
     });
   });
 
+  // Triggering, filtering and option metadata are `createVariableCompletionSource`'s
+  // behaviour and are covered by its own tests. What is data-link-specific, and
+  // tested here, is which separator and which encoding each mode wires up.
   describe('dataLinkAutocompletion', () => {
-    describe('explicit completion', () => {
-      it('shows all suggestions on explicit trigger', () => {
-        const result = dataLinkAutocompletion(mockSuggestions)(createMockContext('', 0, true));
-        expect(result).not.toBeNull();
-        expect(result?.options).toHaveLength(4);
-        expect(result?.from).toBe(0);
+    function applyOption(doc: string, pos: number, result: CompletionResult, label: string): string {
+      const view = createEditor(doc, []);
+      const option = result.options.find((o) => o.label === label);
+      if (!option || typeof option.apply !== 'function') {
+        throw new Error(`no applicable option labelled ${label}`);
+      }
+
+      option.apply(view, option, result.from, result.to ?? pos);
+      return view.state.doc.toString();
+    }
+
+    function complete(doc: string, mode?: DataLinkInterpolationMode, explicit = false) {
+      const source = dataLinkAutocompletion(mockSuggestions, mode ? { mode } : {});
+      const result = source(createMockContext(doc, doc.length, explicit));
+      if (!result) {
+        throw new Error(`no completion offered for ${doc}`);
+      }
+      return result;
+    }
+
+    function completeAndApply(doc: string, label: string, mode?: DataLinkInterpolationMode): string {
+      return applyOption(doc, doc.length, complete(doc, mode), label);
+    }
+
+    describe("mode: 'url'", () => {
+      it('encodes a template variable for a query string', () => {
+        expect(completeAndApply('url?p=$myV', 'myVar')).toBe('url?p=${myVar:queryparam}');
       });
 
-      it('formats series variable correctly (no queryparam)', () => {
-        const result = dataLinkAutocompletion(mockSuggestions)(createMockContext('', 0, true));
-        const opt = result?.options.find((o) => o.label === '__series.name');
-        expect(opt?.apply).toBe('${__series.name}');
+      it('leaves built-in variables unencoded', () => {
+        expect(completeAndApply('url?p=$ser', '__series.name')).toBe('url?p=${__series.name}');
+        expect(completeAndApply('url?p=$all', '__all_variables')).toBe('url?p=${__all_variables}');
       });
 
-      it('formats template variable with queryparam', () => {
-        const result = dataLinkAutocompletion(mockSuggestions)(createMockContext('', 0, true));
-        const opt = result?.options.find((o) => o.label === 'myVar');
-        expect(opt?.apply).toBe('${myVar:queryparam}');
+      it('opens after the query-param separator and preserves it', () => {
+        expect(completeAndApply('url?param=', 'myVar')).toBe('url?param=${myVar:queryparam}');
       });
 
-      it('formats includeVars without queryparam', () => {
-        const result = dataLinkAutocompletion(mockSuggestions)(createMockContext('', 0, true));
-        const opt = result?.options.find((o) => o.label === '__all_variables');
-        expect(opt?.apply).toBe('${__all_variables}');
+      it('preserves the separator once a filter prefix has been typed', () => {
+        // Regression: `=fo` once had `from` at the `=`, swallowing it on apply.
+        expect(completeAndApply('url?param=myV', 'myVar')).toBe('url?param=${myVar:queryparam}');
       });
 
-      it('returns null when no suggestions', () => {
-        expect(dataLinkAutocompletion([])(createMockContext('', 0, true))).toBeNull();
-      });
+      it('replaces a reference the cursor sits inside rather than doubling its brace', () => {
+        const doc = 'url?p=${myVar:queryparam}';
+        const pos = 'url?p=${myV'.length;
+        const result = dataLinkAutocompletion(mockSuggestions)(createMockContext(doc, pos));
 
-      it('anchors at a typed $ so an explicit request does not produce `$${...}`', () => {
-        // Ctrl+Space with a `$` already typed must replace the `$`, not insert
-        // after it. `from` at the `$` means applying `${var}` yields `${var}`.
-        const result = dataLinkAutocompletion(mockSuggestions)(createMockContext('url?p=$', 7, true));
-        expect(result?.from).toBe(6); // index of `$`
-      });
-
-      it('preserves a typed = on an explicit request (from points after =)', () => {
-        const result = dataLinkAutocompletion(mockSuggestions)(createMockContext('url?param=', 10, true));
-        expect(result?.from).toBe(10); // after `=`, so the separator is not replaced
-      });
-
-      it('still shows every suggestion on an explicit request after a trigger', () => {
-        const result = dataLinkAutocompletion(mockSuggestions)(createMockContext('$ser', 4, true));
-        expect(result?.options).toHaveLength(4); // explicit ignores the typed filter
-      });
-    });
-
-    describe('trigger on $ character', () => {
-      it('shows completions after $', () => {
-        const result = dataLinkAutocompletion(mockSuggestions)(createMockContext('$', 1, false));
-        expect(result).not.toBeNull();
-        expect(result?.options).toHaveLength(4);
-      });
-
-      it('replaces the $ when applying (does not duplicate it)', () => {
-        // from must point at the `$` so applying `${var}` replaces it rather than
-        // producing `$${var}`.
-        const result = dataLinkAutocompletion(mockSuggestions)(createMockContext('url?p=$', 7, false));
-        expect(result?.from).toBe(6); // index of `$`
-      });
-
-      it('shows completions after ${', () => {
-        const result = dataLinkAutocompletion(mockSuggestions)(createMockContext('${', 2, false));
-        expect(result).not.toBeNull();
-      });
-
-      it('filters by the variable name typed after ${', () => {
-        const result = dataLinkAutocompletion(mockSuggestions)(createMockContext('${ser', 5, false));
-        expect(result).not.toBeNull();
-        expect(result?.options.map((o) => o.label)).toEqual(['__series.name']);
-      });
-
-      it('does not show completions without trigger', () => {
-        const result = dataLinkAutocompletion(mockSuggestions)(createMockContext('test', 4, false));
-        expect(result).toBeNull();
-      });
-    });
-
-    describe('trigger on = character', () => {
-      it('shows completions after =', () => {
-        const result = dataLinkAutocompletion(mockSuggestions)(createMockContext('url?param=', 10, false));
-        expect(result).not.toBeNull();
-        expect(result?.options).toHaveLength(4);
-      });
-
-      it('preserves the = when applying (from points after =)', () => {
-        // The `=` is a separator, not part of the variable. Applying must keep it:
-        // `?param=` + `${var}`, never swallowing the `=`.
-        const result = dataLinkAutocompletion(mockSuggestions)(createMockContext('url?param=', 10, false));
-        expect(result?.from).toBe(10); // position after `=`, so `=` is not replaced
-      });
-
-      it('preserves the = when a filter prefix has been typed (=fo)', () => {
-        // Regression: previously `=fo` had from at the `=`, swallowing it on apply.
-        const result = dataLinkAutocompletion(mockSuggestions)(createMockContext('url?param=fo', 12, false));
-        expect(result?.from).toBe(10); // after `=`; only the `fo` prefix is replaced
+        expect(applyOption(doc, pos, result!, 'myVar')).toBe('url?p=${myVar:queryparam}');
       });
     });
 
     describe("mode: 'text'", () => {
-      it('does not trigger on = (= is not a separator in plain text)', () => {
-        const result = dataLinkAutocompletion(mockSuggestions, { mode: 'text' })(createMockContext('param=', 6, false));
-        expect(result).toBeNull();
+      it('does not treat = as a separator', () => {
+        expect(dataLinkAutocompletion(mockSuggestions, { mode: 'text' })(createMockContext('param=', 6))).toBeNull();
       });
 
-      it('triggers on $', () => {
-        const result = dataLinkAutocompletion(mockSuggestions, { mode: 'text' })(createMockContext('$', 1, false));
-        expect(result).not.toBeNull();
-        expect(result?.options).toHaveLength(4);
-        expect(result?.from).toBe(0);
+      it('inserts a plain ${var} with no query encoding', () => {
+        expect(completeAndApply('$myV', 'myVar', 'text')).toBe('${myVar}');
+        expect(completeAndApply('$ser', '__series.name', 'text')).toBe('${__series.name}');
       });
 
-      it('formats a template variable as plain ${var} (no queryparam)', () => {
-        const result = dataLinkAutocompletion(mockSuggestions, { mode: 'text' })(createMockContext('', 0, true));
-        const opt = result?.options.find((o) => o.label === 'myVar');
-        expect(opt?.apply).toBe('${myVar}');
-      });
+      it('replaces a reference the cursor sits inside rather than doubling its brace', () => {
+        const doc = 'title ${myVar} tail';
+        const pos = 'title ${myV'.length;
+        const result = dataLinkAutocompletion(mockSuggestions, { mode: 'text' })(createMockContext(doc, pos));
 
-      it('formats a series variable as plain ${var}', () => {
-        const result = dataLinkAutocompletion(mockSuggestions, { mode: 'text' })(createMockContext('', 0, true));
-        const opt = result?.options.find((o) => o.label === '__series.name');
-        expect(opt?.apply).toBe('${__series.name}');
+        expect(applyOption(doc, pos, result!, 'myVar')).toBe('title ${myVar} tail');
       });
     });
 
-    describe('option metadata', () => {
-      it('includes detail (origin) for all options', () => {
-        const result = dataLinkAutocompletion(mockSuggestions)(createMockContext('$', 1, false));
-        result?.options.forEach((opt) => expect(opt.detail).toBeDefined());
-      });
-
-      it('includes documentation info for all options', () => {
-        const result = dataLinkAutocompletion(mockSuggestions)(createMockContext('$', 1, false));
-        result?.options.forEach((opt) => {
-          expect(opt.info).toBeDefined();
-          expect(typeof opt.info).toBe('string');
-        });
-      });
-
-      it('sets type to variable for all options', () => {
-        const result = dataLinkAutocompletion(mockSuggestions)(createMockContext('$', 1, false));
-        result?.options.forEach((opt) => expect(opt.type).toBe('variable'));
-      });
+    it('offers nothing when there are no suggestions', () => {
+      expect(dataLinkAutocompletion([])(createMockContext('$', 1, true))).toBeNull();
     });
   });
 });

--- a/packages/grafana-ui/src/components/DataLinks/codemirrorUtils.ts
+++ b/packages/grafana-ui/src/components/DataLinks/codemirrorUtils.ts
@@ -1,22 +1,15 @@
-import { type Completion, type CompletionContext, type CompletionResult } from '@codemirror/autocomplete';
 import { type Extension } from '@codemirror/state';
 import { Decoration, type DecorationSet, EditorView, ViewPlugin, type ViewUpdate } from '@codemirror/view';
 
 import { DataLinkBuiltInVars, type GrafanaTheme2, VariableOrigin, type VariableSuggestion } from '@grafana/data';
 
+import { type CodeMirrorCompletionContext, type CodeMirrorCompletionResult } from '../CodeMirror/types';
+import { createVariableCompletionSource } from '../CodeMirror/variableCompletion';
+
 // Matches a complete `${...}` variable reference anywhere in the document.
 const VARIABLE_PATTERN = /\$\{[^}]+\}/g;
 
 export type DataLinkInterpolationMode = 'url' | 'text';
-
-// Matches a variable being typed at the cursor: a trigger, an optional opening
-// brace, and the variable name typed so far.
-// - URL mode also treats `=` as a trigger: it's the query-param separator
-//   (`?key=`), so suggestions should open after it (the `=` itself is not part
-//   of the variable).
-// - Text mode (e.g. a link title) has no query params, so only `$` triggers.
-const URL_TRIGGER_PATTERN = /[$=]\{?[\w.]*$/;
-const TEXT_TRIGGER_PATTERN = /\$\{?[\w.]*$/;
 
 const VARIABLE_CLASS = 'cm-variable';
 
@@ -85,73 +78,23 @@ function getApplyText(suggestion: VariableSuggestion, mode: DataLinkInterpolatio
   return `\${${suggestion.value}:queryparam}`;
 }
 
-function createCompletionOption(suggestion: VariableSuggestion, mode: DataLinkInterpolationMode): Completion {
-  return {
-    label: suggestion.label,
-    detail: suggestion.origin,
-    info: suggestion.documentation ?? '',
-    apply: getApplyText(suggestion, mode),
-    type: 'variable',
-  };
-}
-
 /**
- * Autocompletion source for data link variables. Triggered by `$` — and, in `'url'` mode, also by `=` (the query-param separator) — or explicitly via Ctrl+Space.
+ * Autocompletion source for data link variables, triggered by `$` — and, in
+ * `'url'` mode, also by `=`, the query-param separator (`?key=`), which is
+ * preserved rather than replaced.
  *
- * The applied text is always a full `${...}` reference, so the replaced range
- * must start at the right place:
- * - `$`/`${` triggers are part of the variable syntax → replace from the `$`.
- * - `=` is a separator → replace from *after* the `=`, preserving it. (The old
- *   implementation replaced from the `=`, swallowing it for inputs like `=fo`.)
- *
- * Filtering is done here against the typed name (`filter: false`) so the `${`
- * prefix in the replaced range doesn't defeat CodeMirror's label matching.
- *
- * Pass `{ mode: 'text' }` for plain-text fields (e.g. a link title): `=` no
+ * Pass `{ mode: 'text' }` for plain-text fields such as a link title: `=` no
  * longer triggers and template variables are formatted as `${var}` without the
  * URL-only `:queryparam` encoding.
  */
 export function dataLinkAutocompletion(
   suggestions: VariableSuggestion[],
   options: { mode?: DataLinkInterpolationMode } = {}
-): (context: CompletionContext) => CompletionResult | null {
+): (context: CodeMirrorCompletionContext) => CodeMirrorCompletionResult | null {
   const { mode = 'url' } = options;
-  const triggerPattern = mode === 'url' ? URL_TRIGGER_PATTERN : TEXT_TRIGGER_PATTERN;
 
-  return (context: CompletionContext): CompletionResult | null => {
-    if (suggestions.length === 0) {
-      return null;
-    }
-
-    const word = context.matchBefore(triggerPattern);
-
-    // Outside a trigger, only respond when completion was explicitly requested
-    // (Ctrl+Space): insert a fresh `${...}` at the cursor.
-    if (!word) {
-      return context.explicit
-        ? { from: context.pos, options: suggestions.map((s) => createCompletionOption(s, mode)), filter: false }
-        : null;
-    }
-
-    const triggerChar = word.text.charAt(0);
-    // The variable name typed so far, after stripping the trigger and brace.
-    const typed = word.text.replace(/^[$=]\{?/, '');
-    // `=` is preserved (replace after it); `$`/`${` is replaced (it's re-inserted).
-    // Anchoring at the trigger (rather than the cursor) is what stops an explicit
-    // request after a typed `$` from producing `$${...}`.
-    const from = triggerChar === '=' ? word.from + 1 : word.from;
-
-    // An explicit request (Ctrl+Space) shows every variable; implicit triggering
-    // filters by the name typed so far.
-    const matches =
-      context.explicit || !typed
-        ? suggestions
-        : suggestions.filter((s) => s.label.toLowerCase().includes(typed.toLowerCase()));
-
-    return {
-      from,
-      options: matches.map((s) => createCompletionOption(s, mode)),
-      filter: false,
-    };
-  };
+  return createVariableCompletionSource(suggestions, {
+    separators: mode === 'url' ? ['='] : [],
+    getInsertText: (suggestion) => getApplyText(suggestion, mode),
+  });
 }

--- a/packages/grafana-ui/src/unstable.ts
+++ b/packages/grafana-ui/src/unstable.ts
@@ -14,6 +14,8 @@ export * from './utils/skeleton';
 export { CodeMirrorEditor } from './components/CodeMirror/CodeEditorLazy';
 export { signatureHelp } from './components/CodeMirror/signatureHelp';
 export type { SignatureHelpOptions } from './components/CodeMirror/signatureHelp';
+export { applyVariableReference, createVariableCompletionSource } from './components/CodeMirror/variableCompletion';
+export type { VariableCompletionDisplay, VariableCompletionOptions } from './components/CodeMirror/variableCompletion';
 export type {
   CodeMirrorBasicSetup,
   CodeMirrorCompletion,

--- a/public/app/plugins/panel/text/v2/TextNGPanel.editorLoading.test.tsx
+++ b/public/app/plugins/panel/text/v2/TextNGPanel.editorLoading.test.tsx
@@ -12,6 +12,9 @@ import { createProps, renderPanel } from './test-utils';
 // Stub the lazy CodeMirror bundle used by the inline editor.
 jest.mock('@grafana/ui/unstable', () => ({
   __esModule: true,
+  // The stubbed editor never runs completions; the source itself is covered by
+  // editor/variableCompletion.test.ts.
+  createVariableCompletionSource: () => () => null,
   CodeMirrorEditor: ({ value, 'aria-label': ariaLabel }: { value: string; 'aria-label'?: string }) => (
     <textarea aria-label={ariaLabel} value={value} readOnly />
   ),

--- a/public/app/plugins/panel/text/v2/TextNGPanel.test.tsx
+++ b/public/app/plugins/panel/text/v2/TextNGPanel.test.tsx
@@ -12,6 +12,9 @@ import { createProps, renderPanel } from './test-utils';
 // Stub the lazy CodeMirror bundle used by the inline editor and the read-only code view.
 jest.mock('@grafana/ui/unstable', () => ({
   __esModule: true,
+  // The stubbed editor never runs completions; the source itself is covered by
+  // editor/variableCompletion.test.ts.
+  createVariableCompletionSource: () => () => null,
   CodeMirrorEditor: ({
     value,
     basicSetup,

--- a/public/app/plugins/panel/text/v2/editor/TextNGEditor.test.tsx
+++ b/public/app/plugins/panel/text/v2/editor/TextNGEditor.test.tsx
@@ -14,6 +14,9 @@ import { FORMAT_TOOLBAR_TEST_ID } from './TextNGFormatToolbar';
 // stub it with a plain textarea so these tests stay fast and deterministic.
 jest.mock('@grafana/ui/unstable', () => ({
   __esModule: true,
+  // The stubbed editor never runs completions; the source itself is covered by
+  // variableCompletion.test.ts.
+  createVariableCompletionSource: () => () => null,
   CodeMirrorEditor: ({
     value,
     onChange,

--- a/public/app/plugins/panel/text/v2/editor/variableCompletion.test.ts
+++ b/public/app/plugins/panel/text/v2/editor/variableCompletion.test.ts
@@ -1,5 +1,6 @@
 import { CompletionContext } from '@codemirror/autocomplete';
 import { EditorState } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
 
 import { VariableOrigin, type VariableSuggestion } from '@grafana/data';
 
@@ -11,37 +12,51 @@ const suggestions: VariableSuggestion[] = [
   { value: '__data.fields["Value"]', label: 'Value', origin: VariableOrigin.Fields },
 ];
 
-function complete(doc: string, explicit = false) {
+/** `docWithCursor` marks the cursor with `|`; without one it sits at the end. */
+function complete(docWithCursor: string, explicit = false) {
+  const cursor = docWithCursor.indexOf('|');
+  const doc = docWithCursor.replace('|', '');
+  const pos = cursor === -1 ? doc.length : cursor;
   const source = variableCompletion(suggestions);
-  const context = new CompletionContext(EditorState.create({ doc }), doc.length, explicit);
-  return source(context);
+
+  return { doc, pos, result: source(new CompletionContext(EditorState.create({ doc }), pos, explicit)) };
 }
 
+function completeAndApply(docWithCursor: string, label: string) {
+  const { doc, pos, result } = complete(docWithCursor);
+  const option = result?.options.find((o) => o.label === label);
+  if (!option || typeof option.apply !== 'function') {
+    throw new Error(`no applicable option labelled ${label}`);
+  }
+
+  const view = new EditorView({ state: EditorState.create({ doc }) });
+  option.apply(view, option, result!.from, result!.to ?? pos);
+  const next = view.state.doc.toString();
+  view.destroy();
+  return next;
+}
+
+// Triggering and filtering come from `createVariableCompletionSource` and are
+// covered by its tests. This source only customises how options are presented.
 describe('variableCompletion', () => {
-  it('offers every variable once `$` is typed', () => {
-    const result = complete('# Title\n$');
+  it('labels options with the reference they insert', () => {
+    const { result } = complete('# Title\n$');
     expect(result?.from).toBe(8);
     expect(result?.options.map((o) => o.label)).toEqual(['${myVar}', '${__field.name}', '${__data.fields["Value"]}']);
   });
 
-  it('replaces the whole reference being typed, including the brace', () => {
-    const result = complete('${myV');
-    expect(result?.from).toBe(0);
-    expect(result?.options.map((o) => o.label)).toEqual(['${myVar}']);
-  });
-
-  it('matches on the suggestion label as well as the value', () => {
-    expect(complete('$Value')?.options.map((o) => o.label)).toEqual(['${__data.fields["Value"]}']);
-  });
-
   it('describes the origin, and the label when it differs from the value', () => {
-    const options = complete('$')?.options ?? [];
+    const options = complete('$').result?.options ?? [];
     expect(options[0]).toMatchObject({ detail: VariableOrigin.Template, info: 'Custom variable' });
     expect(options[2]).toMatchObject({ detail: `Value / ${VariableOrigin.Fields}` });
   });
 
-  it('stays closed outside a variable reference, even when explicitly requested', () => {
-    expect(complete('some text')).toBeNull();
-    expect(complete('some text ', true)).toBeNull();
+  it('inserts the reference it advertises', () => {
+    expect(completeAndApply('# Title\n$myV', '${myVar}')).toBe('# Title\n${myVar}');
+  });
+
+  it('does not double the brace `closeBrackets` inserted', () => {
+    // The editor leaves bracket closing on, so typing `${` gives `${|}`.
+    expect(completeAndApply('${|}', '${myVar}')).toBe('${myVar}');
   });
 });

--- a/public/app/plugins/panel/text/v2/editor/variableCompletion.ts
+++ b/public/app/plugins/panel/text/v2/editor/variableCompletion.ts
@@ -1,40 +1,23 @@
 import { type VariableSuggestion } from '@grafana/data';
 import {
-  type CodeMirrorCompletion,
   type CodeMirrorCompletionContext,
   type CodeMirrorCompletionResult,
+  createVariableCompletionSource,
 } from '@grafana/ui/unstable';
-
-// A variable being typed at the cursor: `$`, an optional brace, and the name so far.
-const TRIGGER_PATTERN = /\$\{?[\w.]*$/;
-
-const toCompletion = (suggestion: VariableSuggestion): CodeMirrorCompletion => ({
-  label: `\${${suggestion.value}}`,
-  detail: suggestion.value === suggestion.label ? suggestion.origin : `${suggestion.label} / ${suggestion.origin}`,
-  info: suggestion.documentation,
-  type: 'variable',
-});
 
 /**
  * Autocompletion source for template and field variables, triggered by `$`.
  *
- * Options insert a full `${...}` reference, so the replaced range starts at the
- * `$`. That `${` prefix would defeat CodeMirror's own matching, hence `filter: false`.
+ * Options are labelled with the reference they insert rather than with the bare
+ * variable name, so the list shows exactly what will land in the document.
  */
 export function variableCompletion(
   suggestions: VariableSuggestion[]
 ): (context: CodeMirrorCompletionContext) => CodeMirrorCompletionResult | null {
-  return (context) => {
-    const word = context.matchBefore(TRIGGER_PATTERN);
-    if (!word) {
-      return null;
-    }
-
-    const typed = word.text.replace(/^\$\{?/, '').toLowerCase();
-    const matches = typed
-      ? suggestions.filter((s) => s.value.toLowerCase().includes(typed) || s.label.toLowerCase().includes(typed))
-      : suggestions;
-
-    return { from: word.from, options: matches.map(toCompletion), filter: false };
-  };
+  return createVariableCompletionSource(suggestions, {
+    toDisplay: (suggestion) => ({
+      label: `\${${suggestion.value}}`,
+      detail: suggestion.value === suggestion.label ? suggestion.origin : `${suggestion.label} / ${suggestion.origin}`,
+    }),
+  });
 }


### PR DESCRIPTION
Follows up on the stray-brace bug [Bugbot found](https://github.com/grafana/grafana/pull/129994#discussion_r3708017374) in #129994, which @adela-almasan [confirmed with a video](https://github.com/grafana/grafana/pull/129994#discussion_r3713531046). I sent a fix as #130068, but that targeted the feature branch and was closed when this one merged instead — so the bug is still on `main`, and this replaces it with something broader.

## The bug

A completion option inserts a whole `${myVar}`, carrying its own closing brace. But the replaced range ended at the cursor, so any `}` already to the right of it survived and doubled up. Two ways to get one there:

| | before | after |
| --- | --- | --- |
| Type `${` in the Text panel, accept | `${myVar}}` ❌ | `${myVar}` ✅ |
| Caret inside `?x=${myV\|ar:queryparam}` in a data link, accept | `${myVar:queryparam}ar:queryparam}` ❌ | `${myVar:queryparam}` ✅ |

The first is the reported one: CodeMirror's `closeBrackets` inserts `}` the instant `{` is typed, so the document is already `${|}`. The second I found while sweeping for other instances — same defect, different route in.

## Why this is bigger than a two-line fix

I checked every CodeMirror editor and completion source in the repo. There were two `${…}` sources, and they were the same algorithm written twice — which is exactly why the same bug had to be found and fixed in each separately. Data links was also correct only by accident: `InlineInput` happens to set `closeBrackets: false`, so it never hit the first route. Text v2 leaves it on, so it did.

So rather than patch both, there is now one implementation.

`createVariableCompletionSource` owns the `$` trigger, the filtering and the replaced range. Three options cover everything the real call sites differ on:

```ts
createVariableCompletionSource(suggestions, {
  separators: ['='],                                    // a trigger that is preserved, not replaced
  getInsertText: (s) => `\${${s.value}:queryparam}`,    // a format suffix
  toDisplay: (s) => ({ label: `\${${s.value}}` }),      // how the option is labelled
});
```

Both call sites are now wrappers over it — `dataLinkAutocompletion` is six lines, and the Text panel's is seven and only sets `toDisplay`, to keep its `${…}` labels.

`applyVariableReference` is exported too, as the underlying `Completion.apply`. It is the escape hatch for a source that has to emit variable options alongside other kinds, where a range on the *result* would wrongly apply to every option — the shape the Text panel's completion is heading towards.

Correctness no longer depends on the host editor's `closeBrackets` setting, which is the part that matters: an integrator adding variable completion shouldn't have to know how the editor they're dropping into is configured.

## Behaviour changes

Two, both from unifying rather than from the fix:

- Data links suggestions now match on their value as well as their label. Strictly more forgiving.
- Ctrl+Space outside a reference in the Text panel now offers every variable and inserts one at the cursor, where it previously did nothing. This is what data links already did.

## Known gap, deliberate

A reference whose tail is not a name — `${__data.fi|elds["Value"]}` — is still left behind. Widening the pattern enough to cover it also swallows prose in a Markdown document, so it's asserted explicitly in the tests with a comment, rather than left to surprise someone later.

Separately, Ctrl+Space with the caret at `${myVar:que|ryparam}` still misbehaves: `matchBefore` returns null there, so the range starts at the cursor. Fixing that needs a brace-aware *start* as well, which is a different change — but it's now one place to fix instead of two.

## Testing

25 new tests for the shared source, asserting on the resulting document rather than on index arithmetic. The data-links suite keeps what's specific to it and drops what's now covered upstream; its hand-rolled `CompletionContext` stand-in is replaced with the real class. 334 tests pass across the three affected areas, plus typecheck, eslint and prettier.

Not yet eyeballed in a browser — worth a look at the Text panel's option list in particular, since `toDisplay` is what preserves its current presentation.

## Out of scope

The Text panel **v1** editor has the same bug on the Monaco path (`Monaco/suggestions.ts` — Monaco's markdown and html configs both auto-close `{`, and the replacement range never runs past the closing brace). Not touched here; happy to follow up if it's worth it given v2 is coming.

Please check that:

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
