### PR TITLE
Gauge: clamp out-of-range values for RadialGauge arcs

### DIFF
--- a/packages/grafana-ui/src/components/RadialGauge/RadialGauge.story.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/RadialGauge.story.tsx
@@ -289,6 +289,37 @@ export const Examples: StoryFn<StoryProps> = (args) => {
           neutral={0}
         />
       </Stack>
+      <div>
+        Overflow with neutral <em>(range -5 to 5, neutral = 0, value = 10 / -10 — #130075)</em>
+      </div>
+      <Stack direction={'row'} gap={3}>
+        <RadialGaugeExample
+          min={-5}
+          max={5}
+          value={10}
+          colorScheme={FieldColorModeId.Thresholds}
+          gradient
+          shape="gauge"
+          glowCenter={true}
+          roundedBars={false}
+          barWidthFactor={0.7}
+          neutral={0}
+          showScaleLabels
+        />
+        <RadialGaugeExample
+          min={-5}
+          max={5}
+          value={-10}
+          colorScheme={FieldColorModeId.Thresholds}
+          gradient
+          shape="gauge"
+          glowCenter={true}
+          roundedBars={false}
+          barWidthFactor={0.7}
+          neutral={0}
+          showScaleLabels
+        />
+      </Stack>
     </Stack>
   );
 };

--- a/packages/grafana-ui/src/components/RadialGauge/utils.test.ts
+++ b/packages/grafana-ui/src/components/RadialGauge/utils.test.ts
@@ -334,6 +334,27 @@ describe('RadialGauge utils', () => {
       expect(result.startValueAngle).toBe(0);
       expect(result.endValueAngle).toBe(90);
     });
+
+    // Regression: https://github.com/grafana/grafana/issues/130075
+    // With a neutral point, values outside [min, max] must still produce arcs that fit the gauge.
+    it('should clamp overflow above max when neutral is set', () => {
+      const fieldDisplay = createFieldDisplay(10, -5, 5);
+      const result = getValueAngleForValue(fieldDisplay, 0, 360, 0);
+
+      expect(result.startValueAngle).toBe(180); // neutral at 0
+      expect(result.endValueAngle).toBe(180); // fill to max only
+      expect(result.startValueAngle + result.endValueAngle).toBeLessThanOrEqual(result.angleRange);
+    });
+
+    it('should clamp overflow below min when neutral is set', () => {
+      const fieldDisplay = createFieldDisplay(-10, -5, 5);
+      const result = getValueAngleForValue(fieldDisplay, 0, 360, 0);
+
+      expect(result.startValueAngle).toBe(0); // clamped value at min
+      expect(result.endValueAngle).toBe(180); // fill from min to neutral
+      expect(result.startValueAngle + result.endValueAngle).toBeLessThanOrEqual(result.angleRange);
+      expect(result.startValueAngle).toBeGreaterThanOrEqual(0);
+    });
   });
 
   describe('drawRadialArcPath', () => {

--- a/packages/grafana-ui/src/components/RadialGauge/utils.test.ts
+++ b/packages/grafana-ui/src/components/RadialGauge/utils.test.ts
@@ -355,6 +355,24 @@ describe('RadialGauge utils', () => {
       expect(result.startValueAngle + result.endValueAngle).toBeLessThanOrEqual(result.angleRange);
       expect(result.startValueAngle).toBeGreaterThanOrEqual(0);
     });
+
+    // When min === max and both are negative, getFieldConfigMinMax inverts the range.
+    // Clamping must use ordered bounds so a constant series still maps to mid-scale.
+    it('should keep mid-scale arc when min equals max and both are negative', () => {
+      const fieldDisplay = createFieldDisplay(-10, -10, -10);
+      const result = getValueAngleForValue(fieldDisplay, 0, 360);
+
+      expect(result.startValueAngle).toBe(0);
+      expect(result.endValueAngle).toBe(180);
+    });
+
+    it('should keep mid-scale arc with neutral when min equals max and both are negative', () => {
+      const fieldDisplay = createFieldDisplay(-10, -10, -10);
+      const result = getValueAngleForValue(fieldDisplay, 0, 360, -10);
+
+      expect(result.startValueAngle).toBe(180);
+      expect(result.endValueAngle).toBe(0);
+    });
   });
 
   describe('drawRadialArcPath', () => {

--- a/packages/grafana-ui/src/components/RadialGauge/utils.test.ts
+++ b/packages/grafana-ui/src/components/RadialGauge/utils.test.ts
@@ -335,7 +335,7 @@ describe('RadialGauge utils', () => {
       expect(result.endValueAngle).toBe(90);
     });
 
-    // Regression: https://github.com/grafana/grafana/issues/130075
+    // Regression for #130075
     // With a neutral point, values outside [min, max] must still produce arcs that fit the gauge.
     it('should clamp overflow above max when neutral is set', () => {
       const fieldDisplay = createFieldDisplay(10, -5, 5);
@@ -343,7 +343,6 @@ describe('RadialGauge utils', () => {
 
       expect(result.startValueAngle).toBe(180); // neutral at 0
       expect(result.endValueAngle).toBe(180); // fill to max only
-      expect(result.startValueAngle + result.endValueAngle).toBeLessThanOrEqual(result.angleRange);
     });
 
     it('should clamp overflow below min when neutral is set', () => {
@@ -352,8 +351,6 @@ describe('RadialGauge utils', () => {
 
       expect(result.startValueAngle).toBe(0); // clamped value at min
       expect(result.endValueAngle).toBe(180); // fill from min to neutral
-      expect(result.startValueAngle + result.endValueAngle).toBeLessThanOrEqual(result.angleRange);
-      expect(result.startValueAngle).toBeGreaterThanOrEqual(0);
     });
 
     // When min === max and both are negative, getFieldConfigMinMax inverts the range.

--- a/packages/grafana-ui/src/components/RadialGauge/utils.ts
+++ b/packages/grafana-ui/src/components/RadialGauge/utils.ts
@@ -60,10 +60,13 @@ export function getValueAngleForValue(
 ) {
   const angleRange = (360 % (startAngle === 0 ? 1 : startAngle)) + endAngle;
   const [min, max] = getFieldConfigMinMax(fieldDisplay);
+  // getFieldConfigMinMax can invert bounds when min === max < 0; order before clamping.
+  const low = Math.min(min, max);
+  const high = Math.max(min, max);
 
-  // Clamp arc geometry to [min, max]. Center text still uses the real value;
+  // Clamp arc geometry to [low, high]. Center text still uses the real value;
   // without this, overflow with a neutral point can produce invalid SVG arcs (#130075).
-  const value = Math.min(Math.max(fieldDisplay.display.numeric, min), max);
+  const value = Math.min(Math.max(fieldDisplay.display.numeric, low), high);
 
   const valueAngle = getValuePercentageForValue(fieldDisplay, value) * angleRange;
 
@@ -71,7 +74,7 @@ export function getValueAngleForValue(
 
   let startValueAngle = 0;
   if (typeof neutral === 'number') {
-    const clampedNeutral = Math.min(Math.max(min, neutral), max);
+    const clampedNeutral = Math.min(Math.max(neutral, low), high);
     const neutralAngle = getValuePercentageForValue(fieldDisplay, clampedNeutral) * angleRange;
     if (neutralAngle <= valueAngle) {
       startValueAngle = neutralAngle;

--- a/packages/grafana-ui/src/components/RadialGauge/utils.ts
+++ b/packages/grafana-ui/src/components/RadialGauge/utils.ts
@@ -59,7 +59,11 @@ export function getValueAngleForValue(
   neutral?: number
 ) {
   const angleRange = (360 % (startAngle === 0 ? 1 : startAngle)) + endAngle;
-  const value = fieldDisplay.display.numeric;
+  const [min, max] = getFieldConfigMinMax(fieldDisplay);
+
+  // Clamp arc geometry to [min, max]. Center text still uses the real value;
+  // without this, overflow with a neutral point can produce invalid SVG arcs (#130075).
+  const value = Math.min(Math.max(fieldDisplay.display.numeric, min), max);
 
   const valueAngle = getValuePercentageForValue(fieldDisplay, value) * angleRange;
 
@@ -67,7 +71,6 @@ export function getValueAngleForValue(
 
   let startValueAngle = 0;
   if (typeof neutral === 'number') {
-    const [min, max] = getFieldConfigMinMax(fieldDisplay);
     const clampedNeutral = Math.min(Math.max(min, neutral), max);
     const neutralAngle = getValuePercentageForValue(fieldDisplay, clampedNeutral) * angleRange;
     if (neutralAngle <= valueAngle) {


### PR DESCRIPTION
## Summary
- Clamp the value used for RadialGauge arc geometry to `[min, max]` so overflow with a neutral point cannot produce invalid/negative SVG arcs.
- Center text still shows the actual (unclamped) value, matching Grafana 12 behavior.
- Add regression tests and a Storybook example for the reported min=-5 / max=5 / neutral=0 cases.

Fixes #130075

## Test plan
- [x] `yarn jest packages/grafana-ui/src/components/RadialGauge/utils.test.ts` (41 passed)
- [x] Storybook: RadialGauge → Examples → Overflow with neutral
- [ ] Manual (optional): Gauge panel, min=-5, max=5, neutral=0, values 10 and -10 — bar fills to ends, center shows real value, no broken arc