### PR TITLE
Home: Split CTA Click event into explicit union

### DIFF
--- a/public/app/features/home/AlertsIncidents/NewsCard.test.tsx
+++ b/public/app/features/home/AlertsIncidents/NewsCard.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from 'test/test-utils';
+
+import { DataFrameView } from '@grafana/data';
+import { type Feed } from 'app/plugins/panel/news/types';
+import { useNewsFeed } from 'app/plugins/panel/news/useNewsFeed';
+import { feedToDataFrame } from 'app/plugins/panel/news/utils';
+
+import { ctaClicked } from '../analytics/main';
+
+import { NewsCard } from './NewsCard';
+
+jest.mock('app/plugins/panel/news/useNewsFeed');
+jest.mock('../analytics/main', () => ({
+  ctaClicked: jest.fn(),
+}));
+
+const mockUseNewsFeed = jest.mocked(useNewsFeed);
+
+type FeedState = ReturnType<typeof useNewsFeed>['state'];
+
+const stubFeed: Feed = {
+  items: [
+    { title: 'Post One', link: 'https://example.com/1', pubDate: '2024-01-01', content: 'Content one' },
+    { title: 'Post Two', link: 'https://example.com/2', pubDate: '2024-01-02', content: 'Content two' },
+  ],
+};
+
+function makeFeedValue(): NonNullable<FeedState['value']> {
+  return new DataFrameView(feedToDataFrame(stubFeed));
+}
+
+function setFeedState(state: Partial<FeedState>, getNews = jest.fn()) {
+  mockUseNewsFeed.mockReturnValue({
+    state: { loading: false, error: undefined, value: undefined, ...state } as FeedState,
+    getNews,
+  });
+}
+
+describe('NewsCard', () => {
+  beforeEach(() => {
+    setFeedState({ value: makeFeedValue() });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('fires the news_detail cta event when a news item is clicked', async () => {
+    const { user } = render(<NewsCard />);
+
+    await user.click(screen.getByRole('link', { name: 'Post One' }));
+
+    expect(ctaClicked).toHaveBeenCalledWith({
+      surface: 'news_card',
+      action: 'news_detail',
+      placement: 'list',
+    });
+  });
+
+  it('fires the read_more_news cta event when the footer link is clicked', async () => {
+    const { user } = render(<NewsCard />);
+
+    await user.click(screen.getByRole('link', { name: 'Read more from the Grafana Labs blog' }));
+
+    expect(ctaClicked).toHaveBeenCalledWith({
+      surface: 'news_card',
+      action: 'read_more_news',
+      placement: 'footer',
+    });
+  });
+});

--- a/public/app/features/home/AlertsIncidents/NewsCard.tsx
+++ b/public/app/features/home/AlertsIncidents/NewsCard.tsx
@@ -33,7 +33,17 @@ export function NewsCard() {
       emptyMessage={t('home.news-card.empty', 'No recent blog posts.')}
       items={Array.from({ length: state.value?.length ?? 0 }, (_, i) => i)}
       getItemKey={(index) => state.value?.get(index)?.link ?? String(index)}
-      renderItem={(index) => state.value && <News showImage data={state.value} index={index} className={styles.post} />}
+      renderItem={(index) =>
+        state.value && (
+          <News
+            showImage
+            data={state.value}
+            index={index}
+            className={styles.post}
+            onClick={() => ctaClicked({ surface: 'news_card', action: 'news_detail', placement: 'list' })}
+          />
+        )
+      }
       footer={
         !!state.value?.length && (
           <FooterActions>

--- a/public/app/features/home/analytics/types.ts
+++ b/public/app/features/home/analytics/types.ts
@@ -57,11 +57,18 @@ export type CtaClicked = Satisfies<
           placement: 'footer';
         }
     ))
-  | {
+  | ({
       surface: 'news_card';
-      action: 'read_more_news';
-      placement: 'footer';
-    }
+    } & (
+      | {
+          action: 'news_detail';
+          placement: 'list';
+        }
+      | {
+          action: 'read_more_news';
+          placement: 'footer';
+        }
+    ))
   | {
       surface: 'recent_tab';
       action: 'create_dashboard' | 'browse_dashboards';

--- a/public/app/features/home/analytics/types.ts
+++ b/public/app/features/home/analytics/types.ts
@@ -10,54 +10,70 @@ export interface ClearHistoryClicked extends EventProperty {
   dashboard_count: number;
 }
 
-export interface CtaClicked extends EventProperty {
+interface CtaClickedBase extends EventProperty {
   /** Which homepage widget fired the CTA. */
-  surface:
-    | 'alerts_card'
-    | 'incidents_card'
-    | 'news_card'
-    | 'recent_tab'
-    | 'recommendations'
-    | 'existing_solution'
-    | 'no_data_card'
-    | 'overview';
-  /** What the user asked for. Which values are valid depends on the surface (not compiler-enforced). */
-  action:
-    | 'alert_detail'
-    | 'create_rule'
-    | 'view_all_alerts'
-    | 'view_all_rules'
-    | 'incident_detail'
-    | 'declare_incident'
-    | 'view_all_incidents'
-    | 'read_more_news'
-    | 'create_dashboard'
-    | 'browse_dashboards'
-    | 'enable'
-    | 'setup'
-    | 'open_solution'
-    | 'view_alerts'
-    | 'switch_solution'
-    | 'connect_data_source'
-    | 'open_guide'
-    | 'change_overview_filter';
-  /**
-   * Where on the widget the control lives. 'list' | 'empty_state' | 'footer' apply to the
-   * alerts/incidents cards and the recent tab; 'card' | 'pill' apply to recommendations and
-   * the no-data card; the existing-solution card uses 'card'.
-   */
-  placement: 'list' | 'empty_state' | 'footer' | 'card' | 'pill' | 'menu';
-  /** Stable id of the recommendation whose Enable CTA was clicked (surface 'recommendations' only). */
-  recommendation_id?: string;
-  /**
-   * Matrix base-row id driving the current card selection (surface 'recommendations' only);
-   * values are the BaseRow union in solutionsMatrix.ts.
-   */
-  starting_state?: string;
-  /**
-   * Stable id of the solution whose control was clicked (surfaces 'existing_solution' and
-   * 'no_data_card'). Also valid for surface 'recommendations', where it carries the solution
-   * view active when the card/pill was clicked.
-   */
+  surface: string;
+  /** What the user asked for. */
+  action: string;
+  /** Where on the widget the control lives. */
+  placement: string;
+  /** Stable id of the solution whose control was clicked. */
   solution?: string;
 }
+
+type Satisfies<Constraint, Target extends Constraint> = Target;
+
+export type CtaClicked = Satisfies<
+  CtaClickedBase,
+  | {
+      surface: 'alerts_card';
+      action: 'alert_detail' | 'create_rule' | 'view_all_alerts' | 'view_all_rules';
+      placement: 'list' | 'empty_state' | 'footer';
+    }
+  | {
+      surface: 'incidents_card';
+      action: 'incident_detail' | 'declare_incident' | 'view_all_incidents';
+      placement: 'list' | 'empty_state' | 'footer';
+    }
+  | {
+      surface: 'news_card';
+      action: 'read_more_news';
+      placement: 'footer';
+    }
+  | {
+      surface: 'recent_tab';
+      action: 'create_dashboard' | 'browse_dashboards';
+      placement: 'empty_state';
+    }
+  | {
+      surface: 'recommendations';
+      action: 'enable' | 'setup';
+      placement: 'card' | 'pill';
+      /** Stable id of the recommendation whose Enable CTA was clicked. */
+      recommendation_id: string;
+      /**
+       * Matrix base-row id driving the current card selection;
+       * values are the BaseRow union in solutionsMatrix.ts.
+       */
+      starting_state: string;
+      solution?: string;
+    }
+  | {
+      surface: 'existing_solution';
+      action: 'switch_solution' | 'view_alerts' | 'open_solution';
+      placement: 'card';
+      solution: string;
+    }
+  | {
+      surface: 'no_data_card';
+      action: 'open_solution' | 'connect_data_source';
+      placement: 'pill' | 'card';
+      solution?: string;
+    }
+  | {
+      surface: 'overview';
+      action: 'change_overview_filter' | 'open_guide';
+      placement: 'menu' | 'card';
+      solution: string;
+    }
+>;

--- a/public/app/features/home/analytics/types.ts
+++ b/public/app/features/home/analytics/types.ts
@@ -25,16 +25,38 @@ type Satisfies<Constraint, Target extends Constraint> = Target;
 
 export type CtaClicked = Satisfies<
   CtaClickedBase,
-  | {
+  | ({
       surface: 'alerts_card';
-      action: 'alert_detail' | 'create_rule' | 'view_all_alerts' | 'view_all_rules';
-      placement: 'list' | 'empty_state' | 'footer';
-    }
-  | {
+    } & (
+      | {
+          action: 'alert_detail';
+          placement: 'list';
+        }
+      | {
+          action: 'create_rule';
+          placement: 'empty_state' | 'footer';
+        }
+      | {
+          action: 'view_all_alerts' | 'view_all_rules';
+          placement: 'footer';
+        }
+    ))
+  | ({
       surface: 'incidents_card';
-      action: 'incident_detail' | 'declare_incident' | 'view_all_incidents';
-      placement: 'list' | 'empty_state' | 'footer';
-    }
+    } & (
+      | {
+          action: 'incident_detail';
+          placement: 'list';
+        }
+      | {
+          action: 'declare_incident';
+          placement: 'empty_state' | 'footer';
+        }
+      | {
+          action: 'view_all_incidents';
+          placement: 'footer';
+        }
+    ))
   | {
       surface: 'news_card';
       action: 'read_more_news';
@@ -64,16 +86,31 @@ export type CtaClicked = Satisfies<
       placement: 'card';
       solution: string;
     }
-  | {
+  | ({
       surface: 'no_data_card';
-      action: 'open_solution' | 'connect_data_source';
-      placement: 'pill' | 'card';
-      solution?: string;
-    }
-  | {
+    } & (
+      | {
+          action: 'open_solution';
+          placement: 'pill';
+          solution: string;
+        }
+      | {
+          action: 'connect_data_source';
+          placement: 'card';
+        }
+    ))
+  | ({
       surface: 'overview';
-      action: 'change_overview_filter' | 'open_guide';
-      placement: 'menu' | 'card';
-      solution: string;
-    }
+    } & (
+      | {
+          action: 'change_overview_filter';
+          placement: 'menu';
+          solution: string;
+        }
+      | {
+          action: 'open_guide';
+          placement: 'card';
+          solution: string;
+        }
+    ))
 >;

--- a/public/app/plugins/panel/news/component/News.tsx
+++ b/public/app/plugins/panel/news/component/News.tsx
@@ -11,12 +11,13 @@ import { type NewsItem } from '../types';
 
 interface NewsItemProps {
   showImage?: boolean;
+  onClick?: () => void;
   index: number;
   data: DataFrameView<NewsItem>;
   className?: string;
 }
 
-function NewsComponent({ showImage, data, index, className }: NewsItemProps) {
+function NewsComponent({ showImage, onClick, data, index, className }: NewsItemProps) {
   const titleId = useId();
   const visualRefreshEnabled = useFlagGrafanaVisualDesignRefresh();
   const styles = useStyles2(getStyles, visualRefreshEnabled);
@@ -32,6 +33,7 @@ function NewsComponent({ showImage, data, index, className }: NewsItemProps) {
           rel="noopener noreferrer"
           className={styles.socialImage}
           aria-hidden
+          onClick={onClick}
         >
           <img src={newsItem.ogImage} alt={newsItem.title} />
         </a>
@@ -42,7 +44,7 @@ function NewsComponent({ showImage, data, index, className }: NewsItemProps) {
         </time>
 
         <h1 className={styles.title} id={titleId}>
-          <TextLink href={textUtil.sanitizeUrl(newsItem.link)} external inline={false}>
+          <TextLink href={textUtil.sanitizeUrl(newsItem.link)} external inline={false} onClick={onClick}>
             {newsItem.title}
           </TextLink>
         </h1>


### PR DESCRIPTION
**What is this feature?**

Splits the CTA Click event type into a complex, but explicit, union.

**Why do we need this feature?**

To make it far easier to understand what combinations of the properties defined on the event are valid and may fire.

**Who is this feature for?**

Developers,

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
