### PR TITLE
ShortURL: Add admin permissions to k8s api endpoints

### DIFF
--- a/apps/shorturl/pkg/app/authorizer.go
+++ b/apps/shorturl/pkg/app/authorizer.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"k8s.io/apiserver/pkg/authorization/authorizer"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 )
 
 func GetAuthorizer() authorizer.Authorizer {
@@ -14,7 +16,34 @@ func GetAuthorizer() authorizer.Authorizer {
 			return authorizer.DecisionNoOpinion, "", nil
 		}
 
-		// Any authenticated user can access the API
-		return authorizer.DecisionAllow, "", nil
+		user, err := identity.GetRequester(ctx)
+		if err != nil {
+			return authorizer.DecisionDeny, "valid user is required", err
+		}
+
+		switch attr.GetVerb() {
+		// Creating and reading (including resolving a short URL via the goto
+		// redirect) stays available to any authenticated user, including org
+		// role None, matching the traditional /api/short-urls behaviour.
+		case "create", "get":
+			return authorizer.DecisionAllow, "", nil
+		case "update", "patch":
+			// lastSeenAt lives in the status subresource and is bumped whenever
+			// a short URL is resolved, so it is part of the read flow and must
+			// stay available to any authenticated user. Updating the short URL
+			// resource itself (e.g. its path) remains editor+.
+			if attr.GetSubresource() == "status" {
+				return authorizer.DecisionAllow, "", nil
+			}
+		}
+
+		// Every other operation (list, watch, delete, deletecollection, and
+		// updating the short URL resource itself) is restricted to admins:
+		// listing exposes every short URL in the org and the mutating verbs can
+		// change or remove short URLs owned by other users.
+		if user.GetOrgRole() == identity.RoleAdmin {
+			return authorizer.DecisionAllow, "", nil
+		}
+		return authorizer.DecisionDeny, "admin role is required", nil
 	})
 }

--- a/apps/shorturl/pkg/app/authorizer_test.go
+++ b/apps/shorturl/pkg/app/authorizer_test.go
@@ -1,0 +1,126 @@
+package app
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+)
+
+func TestGetAuthorizer(t *testing.T) {
+	auth := GetAuthorizer()
+
+	newContext := func(role identity.RoleType) context.Context {
+		return identity.WithRequester(context.Background(), &identity.StaticRequester{OrgRole: role})
+	}
+
+	allRoles := []identity.RoleType{identity.RoleNone, identity.RoleViewer, identity.RoleEditor, identity.RoleAdmin}
+
+	t.Run("non-resource requests get no opinion", func(t *testing.T) {
+		decision, _, err := auth.Authorize(context.Background(), authorizer.AttributesRecord{
+			ResourceRequest: false,
+		})
+		require.NoError(t, err)
+		require.Equal(t, authorizer.DecisionNoOpinion, decision)
+	})
+
+	t.Run("missing requester is denied", func(t *testing.T) {
+		decision, _, err := auth.Authorize(context.Background(), authorizer.AttributesRecord{
+			ResourceRequest: true,
+			Verb:            "list",
+		})
+		require.Error(t, err)
+		require.Equal(t, authorizer.DecisionDeny, decision)
+	})
+
+	// create and get (read) are available to any authenticated user, including
+	// org role None, preserving the legacy /api/short-urls and goto-redirect
+	// behaviour.
+	for _, verb := range []string{"create", "get"} {
+		t.Run(verb+" is allowed for any authenticated user", func(t *testing.T) {
+			for _, role := range allRoles {
+				decision, _, err := auth.Authorize(newContext(role), authorizer.AttributesRecord{
+					ResourceRequest: true,
+					Verb:            verb,
+				})
+				require.NoError(t, err)
+				require.Equal(t, authorizer.DecisionAllow, decision, "role %s should be allowed to %s", role, verb)
+			}
+		})
+	}
+
+	// Updating the status subresource (lastSeenAt) is part of the read flow and
+	// must be available to any authenticated user, including org role None.
+	for _, verb := range []string{"update", "patch"} {
+		t.Run(verb+" of the status subresource is allowed for any authenticated user", func(t *testing.T) {
+			for _, role := range allRoles {
+				decision, _, err := auth.Authorize(newContext(role), authorizer.AttributesRecord{
+					ResourceRequest: true,
+					Verb:            verb,
+					Subresource:     "status",
+				})
+				require.NoError(t, err)
+				require.Equal(t, authorizer.DecisionAllow, decision, "role %s should be allowed to %s status", role, verb)
+			}
+		})
+	}
+
+	// list/watch, delete and updates to the resource itself are restricted to
+	// admins.
+	restrictedCases := []struct {
+		verb        string
+		subresource string
+	}{
+		{"list", ""},
+		{"watch", ""},
+		{"delete", ""},
+		{"deletecollection", ""},
+		{"update", ""},
+		{"patch", ""},
+	}
+	for _, tc := range restrictedCases {
+		name := tc.verb
+		if tc.subresource != "" {
+			name += "/" + tc.subresource
+		}
+		t.Run(name+" is denied for None, Viewer and Editor", func(t *testing.T) {
+			for _, role := range []identity.RoleType{identity.RoleNone, identity.RoleViewer, identity.RoleEditor} {
+				decision, _, err := auth.Authorize(newContext(role), authorizer.AttributesRecord{
+					ResourceRequest: true,
+					Verb:            tc.verb,
+					Subresource:     tc.subresource,
+				})
+				require.NoError(t, err)
+				require.Equal(t, authorizer.DecisionDeny, decision, "role %s should not be allowed to %s", role, name)
+			}
+		})
+
+		t.Run(name+" is allowed for Admin", func(t *testing.T) {
+			decision, _, err := auth.Authorize(newContext(identity.RoleAdmin), authorizer.AttributesRecord{
+				ResourceRequest: true,
+				Verb:            tc.verb,
+				Subresource:     tc.subresource,
+			})
+			require.NoError(t, err)
+			require.Equal(t, authorizer.DecisionAllow, decision, "admin should be allowed to %s", name)
+		})
+	}
+
+	t.Run("service identity may list and delete (stale URL cleanup)", func(t *testing.T) {
+		// The background cleanup job lists and deletes stale short URLs via the
+		// k8s API using a service identity (org role Admin), which must keep
+		// working.
+		ctx, _ := identity.WithServiceIdentity(context.Background(), 1)
+		for _, verb := range []string{"list", "delete"} {
+			decision, _, err := auth.Authorize(ctx, authorizer.AttributesRecord{
+				ResourceRequest: true,
+				Verb:            verb,
+			})
+			require.NoError(t, err)
+			require.Equal(t, authorizer.DecisionAllow, decision)
+		}
+	})
+}

--- a/pkg/tests/apis/shorturl/shorturl_test.go
+++ b/pkg/tests/apis/shorturl/shorturl_test.go
@@ -182,9 +182,8 @@ func doDualWriteTests(t *testing.T, helper *apis.K8sTestHelper, mode grafanarest
 		// Verify cross-API consistency
 		getFromBothAPIs(t, helper, client, uid)
 
-		// Clean up
-		err = client.Resource.Delete(context.Background(), uid, metav1.DeleteOptions{})
-		require.NoError(t, err)
+		// Clean up (delete is admin-only)
+		deleteAsAdmin(t, helper, uid)
 	})
 
 	t.Run("K8s API -> Legacy API visibility", func(t *testing.T) {
@@ -217,9 +216,8 @@ func doDualWriteTests(t *testing.T, helper *apis.K8sTestHelper, mode grafanarest
 		// Verify cross-API consistency
 		getFromBothAPIs(t, helper, client, uid)
 
-		// Clean up
-		err := client.Resource.Delete(context.Background(), uid, metav1.DeleteOptions{})
-		require.NoError(t, err)
+		// Clean up (delete is admin-only)
+		deleteAsAdmin(t, helper, uid)
 	})
 
 	t.Run("Redirect functionality", func(t *testing.T) {
@@ -260,9 +258,8 @@ func doDualWriteTests(t *testing.T, helper *apis.K8sTestHelper, mode grafanarest
 			require.Greater(t, lastSeenAt, int64(1), "lastSeenAt should be greater than 1 after redirect")
 		}, time.Second*15, time.Millisecond*150, "lastSeenAt not changed after 15s")
 
-		// Clean up
-		err := client.Resource.Delete(context.Background(), uid, metav1.DeleteOptions{})
-		require.NoError(t, err)
+		// Clean up (delete is admin-only)
+		deleteAsAdmin(t, helper, uid)
 	})
 }
 
@@ -308,9 +305,8 @@ func doUnifiedOnlyTests(t *testing.T, helper *apis.K8sTestHelper) {
 		// In unified-only mode, legacy API should not see the resource
 		assert.Nil(t, legacyResponse.Result)
 
-		// Clean up
-		err = client.Resource.Delete(context.Background(), uid, metav1.DeleteOptions{})
-		require.NoError(t, err)
+		// Clean up (delete is admin-only)
+		deleteAsAdmin(t, helper, uid)
 	})
 
 	t.Run("K8s API validation - invalid paths", func(t *testing.T) {
@@ -397,9 +393,8 @@ func doUnifiedOnlyTests(t *testing.T, helper *apis.K8sTestHelper) {
 				if response.Result != nil {
 					uid := response.Result.GetName()
 
-					// Clean up
-					err := client.Resource.Delete(context.Background(), uid, metav1.DeleteOptions{})
-					assert.NoError(t, err, "Cleanup should succeed")
+					// Clean up (delete is admin-only)
+					deleteAsAdmin(t, helper, uid)
 				}
 			})
 		}
@@ -430,10 +425,21 @@ func doUnifiedOnlyTests(t *testing.T, helper *apis.K8sTestHelper) {
 		}, (*any)(nil))
 		assert.Equal(t, 302, redirectResponse.Response.StatusCode)
 
-		// Clean up
-		err := client.Resource.Delete(context.Background(), uid, metav1.DeleteOptions{})
-		require.NoError(t, err)
+		// Clean up (delete is admin-only)
+		deleteAsAdmin(t, helper, uid)
 	})
+}
+
+// deleteAsAdmin removes a short URL using an org admin. ShortURL deletion is
+// restricted to admins, so tests that create resources as a lower-privileged
+// user must clean up through an admin client.
+func deleteAsAdmin(t *testing.T, helper *apis.K8sTestHelper, uid string) {
+	t.Helper()
+	adminClient := helper.GetResourceClient(apis.ResourceClientArgs{
+		User: helper.Org1.Admin,
+		GVR:  gvr,
+	})
+	require.NoError(t, adminClient.Resource.Delete(context.Background(), uid, metav1.DeleteOptions{}))
 }
 
 // Helper function to check if shortURL K8s APIs are available


### PR DESCRIPTION
**What is this feature?**
Refines the ShortURL Kubernetes API (shorturl.grafana.app) authorizer to align permissions with the resource's intended access model:

- create and get (including /goto redirect resolution) remain available to any authenticated user, matching the legacy /api/short-urls behavior.
- update/patch on the status subresource (the lastSeenAt bump on redirect) stays available to any authenticated user, as it's part of the read flow.
- list, watch, delete, deletecollection, and update/patch on the resource itself now require an admin role.

The stale-URL cleanup job runs under a service identity (admin) and is unaffected. Integration tests updated to clean up via a deleteAsAdmin helper, since delete is now admin-scoped.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
