### PR TITLE
Docs: Prometheus quarterly update (FY27 Q3)

### DIFF
--- a/docs/sources/datasources/prometheus/_index.md
+++ b/docs/sources/datasources/prometheus/_index.md
@@ -53,6 +53,7 @@ After you configure the Prometheus data source, you can:
 - Use [Explore](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/explore/) to query data without building a dashboard
 - Add [transformations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/query-transform-data/transform-data/) to manipulate query results
 - Create [recorded queries](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/recorded-queries/) for pre-aggregated data
+- Save and reuse PromQL queries across dashboards, Explore, and annotations with [saved queries](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/query-transform-data/#saved-queries) (available in Grafana Enterprise and Grafana Cloud)
 - Build a wide variety of [visualizations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/)
 
 ## Cloud-managed Prometheus services
@@ -60,22 +61,22 @@ After you configure the Prometheus data source, you can:
 {{< admonition type="note" >}}
 In Grafana 13, the core Prometheus data source no longer supports SigV4 (AWS) or Azure AD authentication. These authentication methods have been migrated to dedicated plugins:
 
-- **Amazon Managed Service for Prometheus** — Use the [Amazon Managed Service for Prometheus data source](https://grafana.com/grafana/plugins/grafana-amazonprometheus-datasource/). For migration details, refer to [AWS authentication (deprecated)](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/configure/aws-authentication/).
-- **Azure Monitor Managed Service for Prometheus** — Use the [Azure Monitor Managed Service for Prometheus data source](https://grafana.com/grafana/plugins/grafana-azureprometheus-datasource/). For migration details, refer to [Azure authentication (deprecated)](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/configure/azure-authentication/).
+- **Amazon Managed Service for Prometheus:** Use the [Amazon Managed Service for Prometheus data source](https://grafana.com/grafana/plugins/grafana-amazonprometheus-datasource/). For migration details, refer to [AWS authentication (deprecated)](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/configure/aws-authentication/).
+- **Azure Monitor Managed Service for Prometheus:** Use the [Azure Monitor Managed Service for Prometheus data source](https://grafana.com/grafana/plugins/grafana-azureprometheus-datasource/). For migration details, refer to [Azure authentication (deprecated)](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/configure/azure-authentication/).
 
 Existing data sources using these methods are automatically migrated on startup.
 {{< /admonition >}}
 
 ## Plugin updates
 
-Starting with Grafana v13.2, the Prometheus data source is a standalone plugin, preinstalled in both Grafana OSS and Enterprise. This enables more frequent updates independent of Grafana releases. Grafana automatically checks the plugin catalog and installs the latest version on each server restart.
+Grafana still ships with the Prometheus data source out of the box. It's preinstalled in both Grafana OSS and Grafana Enterprise, so there's nothing for you to install. Starting with Grafana v13.2, it's packaged as a standalone plugin rather than built into the Grafana codebase, which means you can update the plugin as needed without waiting for a Grafana release. By default, Grafana checks the plugin catalog and installs the latest version on each server restart.
 
 To adjust this behavior:
 
 - **Opt out of auto-updates:** Set `preinstall_auto_update` to `false` in your [configuration file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/).
 - **Update manually:** Update at any time from the **Administration > Plugins** page without restarting Grafana.
 
-The standalone plugin requires Grafana 12.3.0 or later. The Prometheus data source bundled with Grafana 13.1 and earlier continues to work as before—those versions aren't affected by this change.
+The standalone plugin requires Grafana 12.3.0 or later. The Prometheus data source bundled with Grafana 13.1 and earlier continues to work as before, and those versions aren't affected by this change.
 
 Users running Grafana 12.3.x through 13.1.x can install the standalone plugin from the plugin catalog if they want the latest features before upgrading to Grafana 13.2. To use the standalone plugin with Grafana 12.3.x through 13.1.x, add the following to your [configuration file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/):
 

--- a/docs/sources/datasources/prometheus/_index.md
+++ b/docs/sources/datasources/prometheus/_index.md
@@ -15,14 +15,14 @@ labels:
 menuTitle: Prometheus
 title: Prometheus data source
 weight: 1300
-review_date: 2026-05-07
+review_date: 2026-08-04
 ---
 
 # Prometheus data source
 
 Prometheus is an open source monitoring system and time series database that scrapes and stores metrics used for monitoring and alerting.
 
-Grafana includes built-in support for Prometheus, so you don't need to install a plugin. Write queries using [PromQL](https://prometheus.io/docs/prometheus/latest/querying/basics/) in the query editor, or use [Metrics Drilldown](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/explore/simplified-exploration/metrics/) to explore metrics without writing queries. The Prometheus data source also works with other projects that implement the [Prometheus querying API](https://prometheus.io/docs/prometheus/latest/querying/api/), including [Grafana Mimir](/docs/mimir/latest/) and [Thanos](https://thanos.io/tip/components/query.md/).
+The Prometheus data source is preinstalled in Grafana, so you don't need to install it manually. Write queries using [PromQL](https://prometheus.io/docs/prometheus/latest/querying/basics/) in the query editor, or use [Metrics Drilldown](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/explore/simplified-exploration/metrics/) to explore metrics without writing queries. The Prometheus data source also works with other projects that implement the [Prometheus querying API](https://prometheus.io/docs/prometheus/latest/querying/api/), including [Grafana Mimir](https://grafana.com/docs/mimir/latest/) and [Thanos](https://thanos.io/tip/components/query.md/).
 
 ## Supported features
 
@@ -65,6 +65,30 @@ In Grafana 13, the core Prometheus data source no longer supports SigV4 (AWS) or
 
 Existing data sources using these methods are automatically migrated on startup.
 {{< /admonition >}}
+
+## Plugin updates
+
+Starting with Grafana v13.2, the Prometheus data source is a standalone plugin, preinstalled in both Grafana OSS and Enterprise. This enables more frequent updates independent of Grafana releases. Grafana automatically checks the plugin catalog and installs the latest version on each server restart.
+
+To adjust this behavior:
+
+- **Opt out of auto-updates:** Set `preinstall_auto_update` to `false` in your [configuration file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/).
+- **Update manually:** Update at any time from the **Administration > Plugins** page without restarting Grafana.
+
+The standalone plugin requires Grafana 12.3.0 or later. The Prometheus data source bundled with Grafana 13.1 and earlier continues to work as before—those versions aren't affected by this change.
+
+Users running Grafana 12.3.x through 13.1.x can install the standalone plugin from the plugin catalog if they want the latest features before upgrading to Grafana 13.2. To use the standalone plugin with Grafana 12.3.x through 13.1.x, add the following to your [configuration file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/):
+
+```ini
+[plugin.prometheus]
+as_external = true
+
+[plugins]
+; Install the latest version on startup:
+preinstall_sync = prometheus
+; Or install a specific version:
+; preinstall_sync = prometheus@<version>
+```
 
 ## Related resources
 

--- a/docs/sources/datasources/prometheus/alerting/index.md
+++ b/docs/sources/datasources/prometheus/alerting/index.md
@@ -74,9 +74,9 @@ The **pending period** determines how long a condition must be continuously true
 
 Choose evaluation intervals based on your use case:
 
-- **15s–30s** — Critical infrastructure alerts where fast detection matters.
-- **1m** — Standard monitoring alerts (recommended default).
-- **5m** — Non-urgent or noisy metrics where you want to reduce evaluation load.
+- **15s–30s:** Critical infrastructure alerts where fast detection matters.
+- **1m:** Standard monitoring alerts (recommended default).
+- **5m:** Non-urgent or noisy metrics where you want to reduce evaluation load.
 
 ## Example alert queries
 
@@ -137,7 +137,7 @@ up{job="myservice"}
 
 ### Alert when a metric disappears
 
-Use `absent()` to detect when a metric stops being scraped entirely — for example, when a service crashes and no longer reports metrics:
+Use `absent()` to detect when a metric stops being scraped entirely, for example, when a service crashes and no longer reports metrics:
 
 **Query A:**
 
@@ -157,19 +157,19 @@ absent_over_time(up{job="myservice"}[5m])
 
 Use multiple queries and expressions to alert only when multiple conditions are true simultaneously. This reduces noise by avoiding alerts during low-traffic periods.
 
-**Query A** — P95 latency:
+**Query A** (P95 latency):
 
 ```promql
 histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{job="api"}[$__rate_interval])) by (le))
 ```
 
-**Query B** — Request rate:
+**Query B** (request rate):
 
 ```promql
 sum(rate(http_requests_total{job="api"}[$__rate_interval]))
 ```
 
-**Expression C** — Math (both conditions must be true):
+**Expression C** (Math, where both conditions must be true):
 
 ```
 $A > 2 && $B > 100
@@ -183,9 +183,9 @@ $A > 2 && $B > 100
 
 ### When to use recording rules
 
-- **Dashboard panels that query the same expensive expression repeatedly** — pre-compute it once and query the result.
-- **Alert rules on complex expressions** — simplify the alert query by alerting on the pre-aggregated metric.
-- **High-cardinality aggregations** — reduce thousands of series to a handful of pre-computed series.
+- **Dashboard panels that query the same expensive expression repeatedly:** pre-compute it once and query the result.
+- **Alert rules on complex expressions:** simplify the alert query by alerting on the pre-aggregated metric.
+- **High-cardinality aggregations:** reduce thousands of series to a handful of pre-computed series.
 
 ### Set up Grafana-managed recording rules for Prometheus
 
@@ -204,7 +204,7 @@ $A > 2 && $B > 100
       ```
 
    1. Enter a metric name for the result (for example, `service:http_requests:rate5m`). Follow the Prometheus [recording rule naming convention](https://prometheus.io/docs/practices/rules/#naming-and-aggregation): `level:metric:operations`.
-   1. Select the **Target data source**—the Prometheus instance where results are written.
+   1. Select the **Target data source**, which is the Prometheus instance where results are written.
    1. Set the evaluation interval (for example, every 1 minute).
    1. Click **Save rule**.
 
@@ -216,7 +216,7 @@ $A > 2 && $B > 100
 
 ### Recording rules with PDC
 
-If your Prometheus instance is behind [Private data source connect (PDC)](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/configure/#private-data-source-connect), Grafana can write recording rule results through the PDC tunnel. No additional configuration is needed — PDC supports both reads and writes.
+If your Prometheus instance is behind [Private data source connect (PDC)](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/configure/#private-data-source-connect), Grafana can write recording rule results through the PDC tunnel. No additional configuration is needed, because PDC supports both reads and writes.
 
 ### Limitations
 
@@ -249,7 +249,7 @@ Complex queries with many nested functions or large result sets may timeout or f
 
 When using OAuth-authenticated Prometheus endpoints (Google Managed Prometheus, Azure Managed Prometheus), queries may succeed in Explore and dashboards but fail intermittently during alert evaluation. This happens because the alerting backend handles token refresh differently from the interactive query path.
 
-If you're using GCP, consider the **datasource-syncer** pattern — a sidecar process that refreshes OAuth tokens and updates the data source credentials on a schedule shorter than the token lifetime.
+If you're using GCP, consider the **datasource-syncer** pattern, a sidecar process that refreshes OAuth tokens and updates the data source credentials on a schedule shorter than the token lifetime.
 
 For detailed troubleshooting steps, refer to [OAuth token expiration errors](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/troubleshooting/#oauth-token-expiration-errors-gcp-and-azure).
 
@@ -259,15 +259,15 @@ Grafana can display Prometheus alerting rules but can't create or modify them th
 
 ## Configure alert state for execution errors
 
-By default, when a Grafana-managed alert rule encounters an execution error or timeout (such as a network blip, i/o timeout, or a transient 502 from Prometheus), the rule enters an **Error** state — which fires the alert. This can cause false alarms and spam on-call teams when the underlying issue is a brief connectivity interruption rather than a genuine threshold breach.
+By default, when a Grafana-managed alert rule encounters an execution error or timeout (such as a network blip, i/o timeout, or a transient 502 from Prometheus), the rule enters an **Error** state, which fires the alert. This can cause false alarms and spam on-call teams when the underlying issue is a brief connectivity interruption rather than a genuine threshold breach.
 
 To prevent false positives from transient errors, configure the **Alert state if execution error or timeout** setting on each alert rule:
 
 1. Open the alert rule for editing.
 1. In the alert conditions section, locate **Alert state if execution error or timeout**.
 1. Change the value from **Alerting** (default) to one of:
-   - **Keep Last State** — The alert retains its previous state (firing or normal) until a successful evaluation occurs. This is the recommended setting for most Prometheus alert rules.
-   - **OK** — The alert is set to normal during the error, preventing it from firing.
+   - **Keep Last State:** The alert retains its previous state (firing or normal) until a successful evaluation occurs. This is the recommended setting for most Prometheus alert rules.
+   - **OK:** The alert is set to normal during the error, preventing it from firing.
 1. Click **Save rule**.
 
 {{< admonition type="note" >}}

--- a/docs/sources/datasources/prometheus/alerting/index.md
+++ b/docs/sources/datasources/prometheus/alerting/index.md
@@ -14,7 +14,7 @@ labels:
 menuTitle: Alerting
 title: Prometheus alerting
 weight: 550
-review_date: 2026-05-07
+review_date: 2026-08-04
 ---
 
 # Prometheus alerting
@@ -191,7 +191,7 @@ $A > 2 && $B > 100
 
 1. **Enable the data source as a recording rules target:** In the Prometheus data source configuration, verify that **Allow as recording rules target** is toggled on (it's on by default). This allows Grafana to write recording rule results back to this instance.
 
-1. **Verify write access:** The Prometheus-compatible backend must support remote write. Grafana Cloud Metrics (Mimir) and self-hosted Mimir support this natively. Standard Prometheus requires the `--web.enable-remote-write-receiver` flag (Prometheus 2.33+).
+1. **Verify write access:** The Prometheus-compatible backend must support remote write. Grafana Cloud Metrics (Mimir) and self-managed Mimir support this natively. Standard Prometheus requires the `--web.enable-remote-write-receiver` flag (Prometheus 2.33+).
 
 1. **Create a recording rule:**
    1. Navigate to **Alerting** > **Alert rules**.
@@ -204,7 +204,7 @@ $A > 2 && $B > 100
       ```
 
    1. Enter a metric name for the result (for example, `service:http_requests:rate5m`). Follow the Prometheus [recording rule naming convention](https://prometheus.io/docs/practices/rules/#naming-and-aggregation): `level:metric:operations`.
-   1. Select the **Target data source** — the Prometheus instance where results will be written.
+   1. Select the **Target data source**—the Prometheus instance where results are written.
    1. Set the evaluation interval (for example, every 1 minute).
    1. Click **Save rule**.
 

--- a/docs/sources/datasources/prometheus/alerting/index.md
+++ b/docs/sources/datasources/prometheus/alerting/index.md
@@ -169,7 +169,7 @@ histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{job="api"
 sum(rate(http_requests_total{job="api"}[$__rate_interval]))
 ```
 
-**Expression C** (Math, where both conditions must be true):
+**Expression C** (Math, combining both conditions):
 
 ```
 $A > 2 && $B > 100
@@ -183,9 +183,9 @@ $A > 2 && $B > 100
 
 ### When to use recording rules
 
-- **Dashboard panels that query the same expensive expression repeatedly:** pre-compute it once and query the result.
-- **Alert rules on complex expressions:** simplify the alert query by alerting on the pre-aggregated metric.
-- **High-cardinality aggregations:** reduce thousands of series to a handful of pre-computed series.
+- **Dashboard panels that query the same expensive expression repeatedly:** Pre-compute it once and query the result.
+- **Alert rules on complex expressions:** Simplify the alert query by alerting on the pre-aggregated metric.
+- **High-cardinality aggregations:** Reduce thousands of series to a handful of pre-computed series.
 
 ### Set up Grafana-managed recording rules for Prometheus
 

--- a/docs/sources/datasources/prometheus/annotations/index.md
+++ b/docs/sources/datasources/prometheus/annotations/index.md
@@ -14,7 +14,7 @@ labels:
 menuTitle: Annotations
 title: Prometheus annotations
 weight: 500
-review_date: 2026-05-07
+review_date: 2026-08-04
 ---
 
 # Prometheus annotations
@@ -65,7 +65,7 @@ Prometheus annotations work differently from SQL-based annotations. Instead of q
 - If the query returns multiple time series, each series produces its own set of annotations.
 
 {{< admonition type="note" >}}
-Because every returned data point creates an annotation, queries that return continuous data (like `node_cpu_seconds_total`) will produce an annotation at every step interval, flooding your dashboard. Always use expressions that return data only at the moments you want annotated.
+Because every returned data point creates an annotation, queries that return continuous data (like `node_cpu_seconds_total`) produce an annotation at every step interval, flooding your dashboard. Always use expressions that return data only at the moments you want annotated.
 {{< /admonition >}}
 
 ## Field mappings

--- a/docs/sources/datasources/prometheus/annotations/index.md
+++ b/docs/sources/datasources/prometheus/annotations/index.md
@@ -60,7 +60,7 @@ To add a Prometheus annotation to your dashboard:
 Prometheus annotations work differently from SQL-based annotations. Instead of querying a table of events, you write a PromQL expression that returns time-series data. Grafana converts the query results into annotation events using these rules:
 
 - Grafana executes the PromQL query as a range query over the dashboard's time window.
-- **Every data point returned creates an annotation.** There is no automatic filtering of zero values — if you only want annotations at specific moments, your PromQL expression must filter the results (for example, using `> 0` or the `ALERTS` metric).
+- **Every data point returned creates an annotation.** There is no automatic filtering of zero values. If you only want annotations at specific moments, your PromQL expression must filter the results (for example, using `> 0` or the `ALERTS` metric).
 - Grafana uses the field mapping configuration to determine what text, title, and tags to display for each annotation.
 - If the query returns multiple time series, each series produces its own set of annotations.
 
@@ -96,8 +96,8 @@ ALERTS{alertstate="firing"}
 
 This creates an annotation at every step interval where an alert is firing. The `ALERTS` metric includes labels such as:
 
-- `alertname` — The name of the alerting rule
-- `alertstate` — Either `firing` or `pending`
+- `alertname`: The name of the alerting rule
+- `alertstate`: Either `firing` or `pending`
 - Any labels defined on the alerting rule
 
 To limit to specific alerts or severity levels:
@@ -141,7 +141,7 @@ node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes < 0.1
 ```
 
 {{< admonition type="note" >}}
-Comparison operators in PromQL act as filters — they only return data points where the condition is true. This means the expression above only returns data when memory is below 10%, and annotations only appear at those times. There's no need to add an outer `> 0` wrapper.
+Comparison operators in PromQL act as filters. They only return data points where the condition is true. This means the expression above only returns data when memory is below 10%, and annotations only appear at those times. There's no need to add an outer `> 0` wrapper.
 {{< /admonition >}}
 
 ### Scaling event annotations
@@ -181,9 +181,9 @@ If your build info metric uses a `version` label (for example, `build_info{versi
 
 The **Min step** setting controls how many data points the query returns, which directly affects how many annotations appear. A larger step means fewer annotations:
 
-- **Min step `1m`** — Up to one annotation per minute (good for short time ranges).
-- **Min step `5m`** — Up to one annotation per 5 minutes (good for day-range dashboards).
-- **Min step `1h`** — Up to one annotation per hour (good for week-range dashboards).
+- **Min step `1m`:** Up to one annotation per minute (good for short time ranges).
+- **Min step `5m`:** Up to one annotation per 5 minutes (good for day-range dashboards).
+- **Min step `1h`:** Up to one annotation per hour (good for week-range dashboards).
 
 If your dashboard shows too many annotation markers, increase the Min step or add more specific filters to your query.
 

--- a/docs/sources/datasources/prometheus/configure/_index.md
+++ b/docs/sources/datasources/prometheus/configure/_index.md
@@ -15,12 +15,12 @@ labels:
 menuTitle: Configure
 title: Configure the Prometheus data source
 weight: 200
-review_date: 2026-05-07
+review_date: 2026-08-04
 ---
 
 # Configure the Prometheus data source
 
-This document provides instructions for configuring the Prometheus data source and explains the available configuration options. Grafana includes built-in support for Prometheus, so you don't need to install a plugin. For general information on adding a data source to Grafana, refer to [Add a data source](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/#add-a-data-source).
+This document provides instructions for configuring the Prometheus data source and explains the available configuration options. The Prometheus data source is preinstalled in Grafana, so you don't need to install it manually. For general information on adding a data source to Grafana, refer to [Add a data source](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/#add-a-data-source).
 
 ## Before you begin
 
@@ -155,7 +155,7 @@ Pass along additional information and metadata about the request or response.
   Grafana uses this setting to determine which API endpoints and features to enable. For example, when set to Mimir, Grafana uses regular expression-optimized label queries that significantly improve autocomplete and variable loading performance for large metric sets.
 
 {{< admonition type="note" >}}
-Team-based Label-Based Access Control (LBAC) for the Prometheus data source requires the backend to be **Grafana Cloud Metrics (Mimir)** or **Grafana Enterprise Metrics (GEM)**. LBAC doesn't work with external Prometheus-compatible endpoints such as Google Managed Prometheus, self-hosted Prometheus, or Thanos, even if you enable the `teamHttpHeadersMimir` setting. The LBAC enforcement relies on Mimir-specific HTTP headers that other backends don't support.
+Team-based Label-Based Access Control (LBAC) for the Prometheus data source requires the backend to be **Grafana Cloud Metrics (Mimir)** or **Grafana Enterprise Metrics (GEM)**. LBAC doesn't work with external Prometheus-compatible endpoints such as Google Managed Prometheus, self-managed Prometheus, or Thanos, even if you enable the `teamHttpHeadersMimir` setting. The LBAC enforcement relies on Mimir-specific HTTP headers that other backends don't support.
 {{< /admonition >}}
 
 - **Cache level** - Sets the browser caching level for editor queries. Options: `Low`, `Medium`, `High`, or `None`. Higher cache settings are recommended for high-cardinality data sources.
@@ -201,7 +201,7 @@ If you use PDC with SigV4 (AWS Signature Version 4 Authentication), the PDC agen
 
 Click **Manage private data source connect networks** to view your PDC configuration details.
 
-For more information, refer to [Private data source connect (PDC)](/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/) and [Configure PDC](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/configure-pdc/#configure-grafana-private-data-source-connect-pdc).
+For more information, refer to [Private data source connect (PDC)](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/) and [Configure PDC](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/configure-pdc/#configure-grafana-private-data-source-connect-pdc).
 
 For troubleshooting PDC connectivity issues (DNS resolution, "host unreachable" errors, or parallel connection tuning), refer to [PDC connectivity errors](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/troubleshooting/#pdc-connectivity-errors).
 
@@ -330,7 +330,7 @@ azure_auth_enabled = true
 ```
 
 {{< admonition type="note" >}}
-If you are using Azure authentication, don't enable `Forward OAuth identity`. Both methods use the same HTTP authorization headers, and the OAuth token will override your Azure credentials.
+If you are using Azure authentication, don't enable `Forward OAuth identity`. Both methods use the same HTTP authorization headers, and the OAuth token overrides your Azure credentials.
 {{< /admonition >}}
 
 ## Troubleshooting

--- a/docs/sources/datasources/prometheus/configure/_index.md
+++ b/docs/sources/datasources/prometheus/configure/_index.md
@@ -88,9 +88,9 @@ Additional authentication methods (Azure AD, AWS SigV4) are available depending 
 Azure AD and SigV4 authentication on the core Prometheus data source are **deprecated** in Grafana 13. Existing data sources using these methods are automatically migrated to dedicated plugins on startup. For new setups, use the [Azure Monitor Managed Service for Prometheus](https://grafana.com/grafana/plugins/grafana-azureprometheus-datasource/) or [Amazon Managed Service for Prometheus](https://grafana.com/grafana/plugins/grafana-amazonprometheus-datasource/) plugins instead. For migration details, refer to [Azure authentication (deprecated)](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/configure/azure-authentication/) or [AWS authentication (deprecated)](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/configure/aws-authentication/).
 {{< /admonition >}}
 
-- **Azure AD authentication** - Available in Grafana Enterprise and self-managed instances where `azure_auth_enabled = true` is configured. On Grafana Cloud, this option requires a server-side feature flag that isn't enabled by default — contact [Grafana Support](https://grafana.com/profile/org#support) to request it be enabled for your stack. Refer to [Azure authentication settings](#azure-authentication-settings-deprecated) for configuration details.
+- **Azure AD authentication** - Available in Grafana Enterprise and self-managed instances where `azure_auth_enabled = true` is configured. On Grafana Cloud, this option requires a server-side feature flag that isn't enabled by default. Contact [Grafana Support](https://grafana.com/profile/org#support) to request it be enabled for your stack. Refer to [Azure authentication settings](#azure-authentication-settings-deprecated) for configuration details.
 
-- **AWS SigV4 authentication** - Available in self-managed Grafana instances where `sigv4_auth_enabled = true` is configured. On Grafana Cloud, this option isn't available by default — contact [Grafana Support](https://grafana.com/profile/org#support) to request it be enabled for your stack.
+- **AWS SigV4 authentication** - Available in self-managed Grafana instances where `sigv4_auth_enabled = true` is configured. On Grafana Cloud, this option isn't available by default. Contact [Grafana Support](https://grafana.com/profile/org#support) to request it be enabled for your stack.
 
 {{< admonition type="note" >}}
 If Azure AD or SigV4 options don't appear in the authentication drop-down, the required feature flag isn't enabled on your instance. For Grafana Cloud, submit a support request. For self-managed instances, update the Grafana configuration file.
@@ -167,7 +167,7 @@ Team-based Label-Based Access Control (LBAC) for the Prometheus data source requ
 
 - **Custom query parameters** - Add custom parameters to the Prometheus query URL for more control over query execution. Examples: `timeout`, `partial_response`, `dedup`, or `max_source_resolution`. Join multiple parameters with `&`.
 - **HTTP method** - Select either the `POST` or `GET` HTTP method to query your data source. `POST` is recommended and selected by default, as it supports larger queries. Select `GET` if your network restricts `POST` requests.
-- **Series limit** - Maximum number of returned series. The limit applies to all resources (metrics, labels, and values) for both endpoints (series and labels). Leave empty to use the default limit (40000). Set to `0` to disable the limit — this may cause performance issues.
+- **Series limit** - Maximum number of returned series. The limit applies to all resources (metrics, labels, and values) for both endpoints (series and labels). Leave empty to use the default limit (40000). Set to `0` to disable the limit, which may cause performance issues.
 - **Use series endpoint** - Toggle on to use the series endpoint (`/api/v1/series`) with the `match[]` parameter instead of the label values endpoint (`/api/v1/label/<label_name>/values`). The label values endpoint is generally more performant, but the series endpoint supports the `POST` method.
 
 ### Exemplars

--- a/docs/sources/datasources/prometheus/configure/aws-authentication.md
+++ b/docs/sources/datasources/prometheus/configure/aws-authentication.md
@@ -2,7 +2,7 @@
 aliases:
   - ../data-sources/prometheus/
   - ../features/datasources/prometheus/
-description: Migrating from Prometheus SigV4 authentication to the Amazon Managed Service for Prometheus data source
+description: Migrate from Prometheus SigV4 authentication to the Amazon Managed Service for Prometheus data source
 keywords:
   - grafana
   - prometheus
@@ -18,7 +18,7 @@ labels:
 menuTitle: AWS authentication (deprecated)
 title: Migrate from Prometheus SigV4 to Amazon Managed Service for Prometheus
 weight: 210
-review_date: 2026-05-07
+review_date: 2026-08-04
 ---
 
 # Migrate from Prometheus SigV4 to Amazon Managed Service for Prometheus
@@ -95,6 +95,8 @@ Replace `<ACCESS_KEY>` and `<SECRET_KEY>` with your AWS credentials.
 
 ## Troubleshoot migration issues
 
+The following sections cover common issues you may encounter during or after the migration and how to resolve them.
+
 ### Amazon Managed Service for Prometheus plugin not installed
 
 **Symptom:** Migration doesn't occur or the data source type is missing.
@@ -111,7 +113,7 @@ Replace `<ACCESS_KEY>` and `<SECRET_KEY>` with your AWS credentials.
 
 **Solution:**
 
-1. **Self-hosted Grafana:** Verify that `grafana-amazonprometheus-datasource` is included in `forward_settings_to_plugins` under the `[aws]` heading in your `.ini` configuration file.
+1. **Self-managed Grafana:** Verify that `grafana-amazonprometheus-datasource` is included in `forward_settings_to_plugins` under the `[aws]` heading in your `.ini` configuration file.
 1. **Grafana Cloud:** Contact [Grafana Support](https://grafana.com/profile/org#support).
 
 ### Rollback the migration

--- a/docs/sources/datasources/prometheus/configure/aws-authentication.md
+++ b/docs/sources/datasources/prometheus/configure/aws-authentication.md
@@ -48,9 +48,9 @@ To determine if your Prometheus data sources have been migrated:
 
 The banner displays one of the following messages:
 
-- **"Migration Notice"** — The data source has been migrated to the Amazon Managed Service for Prometheus plugin.
-- **"Deprecation Notice"** — The data source hasn't been migrated yet.
-- **No banner** — No migration is needed (the data source doesn't use SigV4).
+- **"Migration Notice":** The data source has been migrated to the Amazon Managed Service for Prometheus plugin.
+- **"Deprecation Notice":** The data source hasn't been migrated yet.
+- **No banner:** No migration is needed (the data source doesn't use SigV4).
 
 ## Configure the Amazon Managed Service for Prometheus data source
 
@@ -191,7 +191,7 @@ echo "$response_body" | jq -c '.[] | select(.jsonData["prometheus-type-migration
     read_only=$(echo "$data" | jq -r '.readOnly // false')
 
     if [[ "$read_only" == "true" ]]; then
-        log_message "$uid is readOnly — edit the type to 'prometheus' in the provisioning file instead."
+        log_message "$uid is readOnly; edit the type to 'prometheus' in the provisioning file instead."
         continue
     fi
 

--- a/docs/sources/datasources/prometheus/configure/azure-authentication.md
+++ b/docs/sources/datasources/prometheus/configure/azure-authentication.md
@@ -2,7 +2,7 @@
 aliases:
   - ../data-sources/prometheus/
   - ../features/datasources/prometheus/
-description: Migrating from Prometheus Azure AD authentication to the Azure Monitor Managed Service for Prometheus data source
+description: Migrate from Prometheus Azure AD authentication to the Azure Monitor Managed Service for Prometheus data source
 keywords:
   - grafana
   - prometheus
@@ -19,7 +19,7 @@ labels:
 menuTitle: Azure authentication (deprecated)
 title: Migrate from Prometheus Azure AD to Azure Monitor Managed Service for Prometheus
 weight: 200
-review_date: 2026-05-07
+review_date: 2026-08-04
 ---
 
 # Migrate from Prometheus Azure AD to Azure Monitor Managed Service for Prometheus
@@ -113,6 +113,8 @@ Replace `<CLIENT_ID>`, `<TENANT_ID>`, and `<CLIENT_SECRET>` with your Azure cred
 
 ## Troubleshoot migration issues
 
+The following sections cover common issues you may encounter during or after the migration and how to resolve them.
+
 ### Azure Monitor Managed Service for Prometheus plugin not installed
 
 **Symptom:** Migration doesn't occur or the data source type is missing.
@@ -129,7 +131,7 @@ Replace `<CLIENT_ID>`, `<TENANT_ID>`, and `<CLIENT_SECRET>` with your Azure cred
 
 **Solution:**
 
-1. **Self-hosted Grafana:** Verify that `grafana-azureprometheus-datasource` is included in `forward_settings_to_plugins` under the `[azure]` heading in your `.ini` configuration file.
+1. **Self-managed Grafana:** Verify that `grafana-azureprometheus-datasource` is included in `forward_settings_to_plugins` under the `[azure]` heading in your `.ini` configuration file.
 1. **Grafana Cloud:** Contact [Grafana Support](https://grafana.com/profile/org#support).
 
 ### Rollback the migration

--- a/docs/sources/datasources/prometheus/configure/azure-authentication.md
+++ b/docs/sources/datasources/prometheus/configure/azure-authentication.md
@@ -49,9 +49,9 @@ To determine if your Prometheus data sources have been migrated:
 
 The banner displays one of the following messages:
 
-- **"Migration Notice"** — The data source has been migrated to the Azure Monitor Managed Service for Prometheus plugin.
-- **"Deprecation Notice"** — The data source hasn't been migrated yet.
-- **No banner** — No migration is needed (the data source doesn't use Azure AD authentication).
+- **"Migration Notice":** The data source has been migrated to the Azure Monitor Managed Service for Prometheus plugin.
+- **"Deprecation Notice":** The data source hasn't been migrated yet.
+- **No banner:** No migration is needed (the data source doesn't use Azure AD authentication).
 
 ## Configure the Azure Monitor Managed Service for Prometheus data source
 
@@ -209,7 +209,7 @@ echo "$response_body" | jq -c '.[] | select(.jsonData["prometheus-type-migration
     read_only=$(echo "$data" | jq -r '.readOnly // false')
 
     if [[ "$read_only" == "true" ]]; then
-        log_message "$uid is readOnly — edit the type to 'prometheus' in the provisioning file instead."
+        log_message "$uid is readOnly; edit the type to 'prometheus' in the provisioning file instead."
         continue
     fi
 

--- a/docs/sources/datasources/prometheus/query-editor/_index.md
+++ b/docs/sources/datasources/prometheus/query-editor/_index.md
@@ -16,14 +16,14 @@ labels:
 menuTitle: Query editor
 title: Prometheus query editor
 weight: 300
-review_date: 2026-05-07
+review_date: 2026-08-04
 ---
 
 # Prometheus query editor
 
 The Prometheus query editor lets you write PromQL queries against your Prometheus-compatible data sources. It includes a visual query builder for constructing queries without writing PromQL, a code editor with autocomplete and syntax highlighting, and configurable output formats for different visualization types.
 
-You can access the query editor from the [Explore page](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/explore/) or from any dashboard panel by clicking the panel title and selecting **Edit**. For general documentation on querying data sources in Grafana, refer to [Query and transform data](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/query-transform-data/). For more information about PromQL, see [Querying Prometheus](http://prometheus.io/docs/querying/basics/).
+You can access the query editor from the [Explore page](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/explore/) or from any dashboard panel by clicking the panel title and selecting **Edit**. For general documentation on querying data sources in Grafana, refer to [Query and transform data](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/query-transform-data/). For more information about PromQL, refer to [Querying Prometheus](https://prometheus.io/docs/prometheus/latest/querying/basics/).
 
 The query editor has two modes:
 
@@ -78,7 +78,7 @@ Grafana adjusts the query time range to align with the dynamically calculated st
 
 ### Exemplars
 
-Toggle on to include exemplars in the graph. Exemplars link aggregated metric data to specific trace examples, letting you jump from a spike directly to a relevant trace. For more information, see [Introduction to exemplars](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/fundamentals/exemplars/).
+Toggle on to include exemplars in the graph. Exemplars link aggregated metric data to specific trace examples, letting you jump from a spike directly to a relevant trace. For more information, refer to [Introduction to exemplars](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/fundamentals/exemplars/).
 
 {{< admonition type="note" >}}
 Exemplars are not available with Instant query types.
@@ -152,7 +152,7 @@ The Metrics explorer (Builder mode) and [Metrics browser (Code mode)](#metrics-b
 
 ## Code mode
 
-**Code mode** is for experienced Prometheus users who prefer writing PromQL directly. For more information about PromQL, see [Querying Prometheus](http://prometheus.io/docs/querying/basics/).
+**Code mode** is for experienced Prometheus users who prefer writing PromQL directly. For more information about PromQL, refer to [Querying Prometheus](https://prometheus.io/docs/prometheus/latest/querying/basics/).
 
 {{< figure src="/static/img/docs/prometheus/code-mode.png" max-width="500px" class="docs-image--no-shadow" caption="Code mode" >}}
 

--- a/docs/sources/datasources/prometheus/query-editor/_index.md
+++ b/docs/sources/datasources/prometheus/query-editor/_index.md
@@ -27,8 +27,8 @@ You can access the query editor from the [Explore page](https://grafana.com/docs
 
 The query editor has two modes:
 
-- [Builder mode](#builder-mode) — Visual interface for constructing queries without writing PromQL directly.
-- [Code mode](#code-mode) — Text editor with autocomplete for writing PromQL directly.
+- [Builder mode](#builder-mode): Visual interface for constructing queries without writing PromQL directly.
+- [Code mode](#code-mode): Text editor with autocomplete for writing PromQL directly.
 
 Grafana synchronizes both modes, allowing you to switch between them. Grafana also displays a warning message if it detects an issue with the query while switching modes.
 
@@ -40,9 +40,9 @@ The following options are available in both Builder and Code modes. They control
 
 Controls the display name for time series in the panel legend.
 
-- **Auto** — Displays unique labels only, hiding labels that are common across all returned series. This produces cleaner legends when many series share the same labels.
-- **Verbose** — Displays all label names for every series.
-- **Custom** — Lets you define the legend using label templates. For example, `{{hostname}}` is replaced with the value of the `hostname` label. To switch to a different legend mode, clear the input and click outside the field.
+- **Auto:** Displays unique labels only, hiding labels that are common across all returned series. This produces cleaner legends when many series share the same labels.
+- **Verbose:** Displays all label names for every series.
+- **Custom:** Lets you define the legend using label templates. For example, `{{hostname}}` is replaced with the value of the `hostname` label. To switch to a different legend mode, clear the input and click outside the field.
 
 ### Min step
 
@@ -56,17 +56,17 @@ The time range of the query is aligned to the step size, which may adjust the ac
 
 Determines how query results are interpreted and displayed in a panel.
 
-- **Time series** — The default format. Returns data as time-indexed series suitable for graph panels.
-- **Table** — Displays data in a tabular format. Works only in a [Table panel](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/table/).
-- **Heatmap** — Displays histogram-type metrics in a [Heatmap panel](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/heatmap/) by converting cumulative histograms to regular ones and sorting the series by bucket boundary.
+- **Time series:** The default format. Returns data as time-indexed series suitable for graph panels.
+- **Table:** Displays data in a tabular format. Works only in a [Table panel](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/table/).
+- **Heatmap:** Displays histogram-type metrics in a [Heatmap panel](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/heatmap/) by converting cumulative histograms to regular ones and sorting the series by bucket boundary.
 
 ### Type
 
 Determines the query type.
 
-- **Both** — The default. Runs both a Range query and an Instant query and returns combined results.
-- **Range** — Returns a set of time series where each series includes multiple data points over the selected time range. Use this for graph visualizations (lines, bars, points, stacked).
-- **Instant** — Returns a single data point per series (the most recent value within the selected time range). Use this for stat panels, tables, or gauges. To visualize instant query results in a time series panel, add a field override with the `Transform` property set to `Constant`. For more information, refer to [Time Series Transform option](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/time-series/#transform).
+- **Both:** The default. Runs both a Range query and an Instant query and returns combined results.
+- **Range:** Returns a set of time series where each series includes multiple data points over the selected time range. Use this for graph visualizations (lines, bars, points, stacked).
+- **Instant:** Returns a single data point per series (the most recent value within the selected time range). Use this for stat panels, tables, or gauges. To visualize instant query results in a time series panel, add a field override with the `Transform` property set to `Constant`. For more information, refer to [Time Series Transform option](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/time-series/#transform).
 
 {{< admonition type="note" >}}
 Grafana adjusts the query time range to align with the dynamically calculated step interval. This ensures consistent metric visualization and supports Prometheus result caching. However, this alignment can cause minor visual differences, such as a slight gap at the graph's right edge or a shifted start time. For example, a `15s` step aligns timestamps to Unix times divisible by 15 seconds. A `1w` Min step aligns the range to the start of the week (Thursday at 00:00 UTC in Prometheus).
@@ -86,30 +86,30 @@ Exemplars are not available with Instant query types.
 
 Builder mode contains the following components:
 
-- **Kick start your query** — Click to view predefined operation patterns that help you quickly build queries with multiple operations:
+- **Kick start your query:** Click to view predefined operation patterns that help you quickly build queries with multiple operations:
   - Rate query starters
   - Histogram query starters
   - Binary query starters
 
   Click the arrow next to each to see the available options.
 
-- **Explain** — Toggle on to display a step-by-step explanation of all query components and operations.
+- **Explain:** Toggle on to display a step-by-step explanation of all query components and operations.
 
 ### Select a metric
 
-- **Metric** — Select a metric from the drop-down. The data source provides available metrics based on the selected time range. You can type to search and filter the list. Click the book icon to open [Metrics explorer](#metrics-explorer).
-- **Label filters** — Select labels and values to filter the metric. Use the `+` button to add filters and the `x` button to remove them. When a metric is selected, the data source requests available labels and their values from the server.
+- **Metric:** Select a metric from the drop-down. The data source provides available metrics based on the selected time range. You can type to search and filter the list. Click the book icon to open [Metrics explorer](#metrics-explorer).
+- **Label filters:** Select labels and values to filter the metric. Use the `+` button to add filters and the `x` button to remove them. When a metric is selected, the data source requests available labels and their values from the server.
 
 ### Add operations
 
 Click **+ Operations** to add operations to your query. The query editor groups operations into the following categories:
 
-- [Aggregations](https://prometheus.io/docs/prometheus/latest/querying/operators/#aggregation-operators) — `sum`, `avg`, `count`, `min`, `max`, etc.
-- [Range functions](https://prometheus.io/docs/prometheus/latest/querying/functions/#functions) — `rate`, `increase`, `irate`, `avg_over_time`, etc.
-- [Functions](https://prometheus.io/docs/prometheus/latest/querying/functions/#functions) — `abs`, `ceil`, `histogram_quantile`, etc.
-- [Binary operations](https://prometheus.io/docs/prometheus/latest/querying/operators/#binary-operators) — arithmetic and comparison operators.
-- [Trigonometric functions](https://prometheus.io/docs/prometheus/latest/querying/functions/#trigonometric-functions) — `acos`, `asin`, `atan`, etc.
-- Time functions — `time`, `timestamp`, `day_of_week`, etc.
+- [Aggregations](https://prometheus.io/docs/prometheus/latest/querying/operators/#aggregation-operators): `sum`, `avg`, `count`, `min`, `max`, etc.
+- [Range functions](https://prometheus.io/docs/prometheus/latest/querying/functions/#functions): `rate`, `increase`, `irate`, `avg_over_time`, etc.
+- [Functions](https://prometheus.io/docs/prometheus/latest/querying/functions/#functions): `abs`, `ceil`, `histogram_quantile`, etc.
+- [Binary operations](https://prometheus.io/docs/prometheus/latest/querying/operators/#binary-operators): arithmetic and comparison operators.
+- [Trigonometric functions](https://prometheus.io/docs/prometheus/latest/querying/functions/#trigonometric-functions): `acos`, `asin`, `atan`, etc.
+- Time functions: `time`, `timestamp`, `day_of_week`, etc.
 
 All operations display function parameters beneath the operation header. Some operations allow you to apply specific labels (for example, `by` or `without` clauses).
 
@@ -125,10 +125,10 @@ Click the book icon next to the metric selector to open the Metrics explorer. It
 
 The following options are available under **Additional Settings**:
 
-- **Include description in search** — Search by both name and description.
-- **Include results with no metadata** — Include metrics that lack type or description metadata.
-- **Disable text wrap** — Disable text wrapping for long metric names.
-- **Enable regex search** — Filter metric names by regular expression, which uses an additional API call.
+- **Include description in search:** Search by both name and description.
+- **Include results with no metadata:** Include metrics that lack type or description metadata.
+- **Disable text wrap:** Disable text wrapping for long metric names.
+- **Enable regex search:** Filter metric names by regular expression, which uses an additional API call.
 
 {{< admonition type="note" >}}
 The Metrics explorer (Builder mode) and [Metrics browser (Code mode)](#metrics-browser) are separate components. The Metrics explorer does not browse labels, but the Metrics browser can display all labels on a metric.
@@ -140,22 +140,22 @@ The Metrics explorer (Builder mode) and [Metrics browser (Code mode)](#metrics-b
 
 Code mode provides:
 
-- **Autocomplete** — Suggests metrics, labels, functions, aggregations, and keywords as you type. The drop-down includes documentation for suggested items where available.
-- **Syntax highlighting** — Color-codes PromQL syntax for readability.
-- **Metrics browser** — Click the arrow next to **Metrics browser** to open it.
+- **Autocomplete:** Suggests metrics, labels, functions, aggregations, and keywords as you type. The drop-down includes documentation for suggested items where available.
+- **Syntax highlighting:** Color-codes PromQL syntax for readability.
+- **Metrics browser:** Click the arrow next to **Metrics browser** to open it.
 
 ### Metrics browser
 
 The Metrics browser helps you build basic queries by exploring available metrics and labels.
 
-1. **Step 1** — Select a metric. The browser narrows available labels to those applicable to the metric.
-2. **Step 2** — Select one or more labels.
-3. **Step 3** — Select values for each label to tighten the query scope.
-4. **Step 4** — Choose an action:
-   - **Use query** — Insert the selector into the query editor.
-   - **Use as rate query** — Insert the selector wrapped in `rate(...[$__rate_interval])`.
-   - **Validate selector** — Verify the selector is valid and display the number of matching series.
-   - **Clear** — Reset your selections.
+1. **Step 1:** Select a metric. The browser narrows available labels to those applicable to the metric.
+2. **Step 2:** Select one or more labels.
+3. **Step 3:** Select values for each label to tighten the query scope.
+4. **Step 4:** Choose an action:
+   - **Use query:** Insert the selector into the query editor.
+   - **Use as rate query:** Insert the selector wrapped in `rate(...[$__rate_interval])`.
+   - **Validate selector:** Verify the selector is valid and display the number of matching series.
+   - **Clear:** Reset your selections.
 
 {{< admonition type="note" >}}
 If you don't remember the exact metric name, start by selecting a few labels to filter the list and narrow down your options.
@@ -230,19 +230,19 @@ Calculate average CPU usage percentage, grouped by instance:
 
 Use multiple queries and expressions to calculate derived values. In the query editor, add multiple queries (A, B) and a math expression (C):
 
-**Query A** — Total memory:
+**Query A** (total memory):
 
 ```promql
 node_memory_MemTotal_bytes
 ```
 
-**Query B** — Available memory:
+**Query B** (available memory):
 
 ```promql
 node_memory_MemAvailable_bytes
 ```
 
-**Expression C** — Percentage available (click **+ Expression** → **Math**):
+**Expression C** (percentage available, using **+ Expression** → **Math**):
 
 ```
 $B / $A * 100
@@ -273,26 +273,26 @@ The query inspector helps you debug queries that return unexpected results or no
 
 1. Click **Query inspector** in the panel edit view (below the query editor).
 1. Review the following tabs:
-   - **Query** — Shows the exact request sent to Prometheus, including the evaluated PromQL expression, time range, and step interval. Use this to verify that template variables resolved correctly.
-   - **Data** — Shows the raw response data. If empty, your query matched no series.
-   - **Stats** — Shows request timing and response size.
+   - **Query:** Shows the exact request sent to Prometheus, including the evaluated PromQL expression, time range, and step interval. Use this to verify that template variables resolved correctly.
+   - **Data:** Shows the raw response data. If empty, your query matched no series.
+   - **Stats:** Shows request timing and response size.
 
 Common debugging steps:
 
-1. **No data returned** — Check the Query tab to see if template variables resolved to empty values. Try the query directly in the Prometheus built-in expression browser (`/graph`) to rule out Grafana-specific issues.
-1. **Fewer series than expected** — Check that your label filters aren't too restrictive. Remove filters one at a time to isolate which filter is excluding data.
-1. **"Too many data points" or timeout** — Reduce the time range, increase the Min step, or add aggregations to reduce cardinality. Refer to [Query high-cardinality data](#query-high-cardinality-data).
+1. **No data returned:** Check the Query tab to see if template variables resolved to empty values. Try the query directly in the Prometheus built-in expression browser (`/graph`) to rule out Grafana-specific issues.
+1. **Fewer series than expected:** Check that your label filters aren't too restrictive. Remove filters one at a time to isolate which filter is excluding data.
+1. **"Too many data points" or timeout:** Reduce the time range, increase the Min step, or add aggregations to reduce cardinality. Refer to [Query high-cardinality data](#query-high-cardinality-data).
 
 ## Query high-cardinality data
 
 High-cardinality metrics (those with many unique label combinations) can cause queries to timeout or exceed memory limits when queried over long time ranges. Follow these practices to query high-cardinality data effectively:
 
-- **Aggregate first, then filter** — Use `sum()`, `avg()`, or `count()` to reduce the number of series before applying other operations. For example, `sum(rate(metric[5m])) by (service)` is far cheaper than querying all individual pod-level series.
-- **Use recording rules for repeated queries** — If a dashboard panel queries the same expensive expression on every load, create a [Prometheus recording rule](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/) to pre-compute the result.
-- **Scope with template variables** — Use dashboard [template variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/template-variables/) to select a specific `namespace`, `cluster`, or `job` rather than querying all labels at once.
-- **Increase Min step for overview panels** — For panels showing trends over days or weeks, set a higher **Min step** (for example, `5m` or `15m`) to reduce the number of data points requested.
-- **Set Max data points** — Use the **Max data points** query option to cap resolution for wide time ranges.
-- **Use Adaptive Metrics (Grafana Cloud)** — [Adaptive Metrics](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/reduce-costs/metrics-costs/control-metrics-usage-via-adaptive-metrics/) automatically reduces the cardinality of metrics that aren't queried at full resolution.
+- **Aggregate first, then filter:** Use `sum()`, `avg()`, or `count()` to reduce the number of series before applying other operations. For example, `sum(rate(metric[5m])) by (service)` is far cheaper than querying all individual pod-level series.
+- **Use recording rules for repeated queries:** If a dashboard panel queries the same expensive expression on every load, create a [Prometheus recording rule](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/) to pre-compute the result.
+- **Scope with template variables:** Use dashboard [template variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/template-variables/) to select a specific `namespace`, `cluster`, or `job` rather than querying all labels at once.
+- **Increase Min step for overview panels:** For panels showing trends over days or weeks, set a higher **Min step** (for example, `5m` or `15m`) to reduce the number of data points requested.
+- **Set Max data points:** Use the **Max data points** query option to cap resolution for wide time ranges.
+- **Use Adaptive Metrics (Grafana Cloud):** [Adaptive Metrics](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/reduce-costs/metrics-costs/control-metrics-usage-via-adaptive-metrics/) automatically reduces the cardinality of metrics that aren't queried at full resolution.
 
 If your queries hit memory or sample limits, refer to [Memory limit exceeded for high-cardinality queries](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/troubleshooting/#memory-limit-exceeded-for-high-cardinality-queries).
 
@@ -302,7 +302,7 @@ The following behaviors are frequently misinterpreted as bugs but are expected P
 
 ### `increase()` returns fractional values on integer counters
 
-`increase()` uses linear interpolation to estimate the increase over the specified time window. Because scrape timestamps rarely align exactly with the window boundaries, the result is interpolated — which produces fractional values even for integer counters.
+`increase()` uses linear interpolation to estimate the increase over the specified time window. Because scrape timestamps rarely align exactly with the window boundaries, the result is interpolated, which produces fractional values even for integer counters.
 
 This is expected. If you need integer results, wrap the expression in `ceil()` or `floor()`:
 
@@ -324,7 +324,7 @@ If you see this after a deployment or scaling event, verify your service discove
 
 ### Counter reset spikes after pod restarts
 
-When a monitored process restarts, its counters reset to zero. Prometheus handles this with counter reset detection — `rate()` and `increase()` account for resets and don't produce negative values. However, you may still see a brief spike at the reset point because the first scrape after a restart reports the full counter value accumulated since the restart.
+When a monitored process restarts, its counters reset to zero. Prometheus handles this with counter reset detection: `rate()` and `increase()` account for resets and don't produce negative values. However, you may still see a brief spike at the reset point because the first scrape after a restart reports the full counter value accumulated since the restart.
 
 To minimize the visual impact:
 
@@ -338,7 +338,7 @@ If adding a label filter doesn't reduce the result count, you may have high-card
 
 ## Related resources
 
-- [Template variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/template-variables/) — Use variables like `$namespace` or `$job` to create dynamic, reusable dashboards.
-- [Annotations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/annotations/) — Overlay Prometheus events on your panels.
-- [Alerting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/alerting/) — Create alert rules from your Prometheus queries.
-- [Troubleshooting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/troubleshooting/) — Resolve common query errors and performance issues.
+- [Template variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/template-variables/): Use variables like `$namespace` or `$job` to create dynamic, reusable dashboards.
+- [Annotations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/annotations/): Overlay Prometheus events on your panels.
+- [Alerting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/alerting/): Create alert rules from your Prometheus queries.
+- [Troubleshooting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/troubleshooting/): Resolve common query errors and performance issues.

--- a/docs/sources/datasources/prometheus/query-editor/_index.md
+++ b/docs/sources/datasources/prometheus/query-editor/_index.md
@@ -242,7 +242,7 @@ node_memory_MemTotal_bytes
 node_memory_MemAvailable_bytes
 ```
 
-**Expression C** (percentage available, using **+ Expression** → **Math**):
+**Expression C** (percentage available). To add it, click **+ Expression** and select **Math**:
 
 ```
 $B / $A * 100
@@ -287,7 +287,7 @@ Common debugging steps:
 
 High-cardinality metrics (those with many unique label combinations) can cause queries to timeout or exceed memory limits when queried over long time ranges. Follow these practices to query high-cardinality data effectively:
 
-- **Aggregate first, then filter:** Use `sum()`, `avg()`, or `count()` to reduce the number of series before applying other operations. For example, `sum(rate(metric[5m])) by (service)` is far cheaper than querying all individual pod-level series.
+- **Aggregate first, then filter:** Use `sum()`, `avg()`, or `count()` to reduce the number of series before applying other operations. For example, `sum(rate(metric[5m])) by (service)` is far cheaper than querying all individual Pod-level series.
 - **Use recording rules for repeated queries:** If a dashboard panel queries the same expensive expression on every load, create a [Prometheus recording rule](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/) to pre-compute the result.
 - **Scope with template variables:** Use dashboard [template variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/template-variables/) to select a specific `namespace`, `cluster`, or `job` rather than querying all labels at once.
 - **Increase Min step for overview panels:** For panels showing trends over days or weeks, set a higher **Min step** (for example, `5m` or `15m`) to reduce the number of data points requested.

--- a/docs/sources/datasources/prometheus/query-editor/_index.md
+++ b/docs/sources/datasources/prometheus/query-editor/_index.md
@@ -30,15 +30,11 @@ The query editor has two modes:
 - [Builder mode](#builder-mode) — Visual interface for constructing queries without writing PromQL directly.
 - [Code mode](#code-mode) — Text editor with autocomplete for writing PromQL directly.
 
-![Query editor mode](/media/docs/prometheus/builder-code-v11-mode.png)
-
 Grafana synchronizes both modes, allowing you to switch between them. Grafana also displays a warning message if it detects an issue with the query while switching modes.
 
 ## Query options
 
 The following options are available in both Builder and Code modes. They control how the query is executed and how results are displayed.
-
-{{< figure src="/static/img/docs/prometheus/options.png" max-width="500px" class="docs-image--no-shadow" caption="Query options" >}}
 
 ### Legend
 
@@ -99,18 +95,12 @@ Builder mode contains the following components:
 
 - **Explain** — Toggle on to display a step-by-step explanation of all query components and operations.
 
-{{< figure src="/static/img/docs/prometheus/explain-results.png" max-width="500px" class="docs-image--no-shadow" caption="Explain results" >}}
-
 ### Select a metric
-
-{{< figure src="/static/img/docs/prometheus/metrics-and-labels.png" max-width="500px" class="docs-image--no-shadow" caption="Metric and label filters" >}}
 
 - **Metric** — Select a metric from the drop-down. The data source provides available metrics based on the selected time range. You can type to search and filter the list. Click the book icon to open [Metrics explorer](#metrics-explorer).
 - **Label filters** — Select labels and values to filter the metric. Use the `+` button to add filters and the `x` button to remove them. When a metric is selected, the data source requests available labels and their values from the server.
 
 ### Add operations
-
-{{< figure src="/static/img/docs/prometheus/operations.png" max-width="500px" class="docs-image--no-shadow" caption="Operations" >}}
 
 Click **+ Operations** to add operations to your query. The query editor groups operations into the following categories:
 
@@ -123,19 +113,13 @@ Click **+ Operations** to add operations to your query. The query editor groups 
 
 All operations display function parameters beneath the operation header. Some operations allow you to apply specific labels (for example, `by` or `without` clauses).
 
-{{< figure src="/static/img/docs/prometheus/use-function-by-label-9-5.png" max-width="500px" class="docs-image--no-shadow" caption="Functions and labels" >}}
-
 If you add an operation in a way that would create an invalid query, the query editor automatically places it in the correct position to maintain a valid query structure.
 
 ### Hints
 
 The query editor can detect which operations are most appropriate for certain selected metrics. When it does, it displays a hint next to the **+ Operations** button. Click the hint to add the suggested operation.
 
-{{< figure src="/static/img/docs/prometheus/hint-example.png" max-width="500px" class="docs-image--no-shadow" caption="Hint" >}}
-
 ### Metrics explorer
-
-{{< figure src="/static/img/docs/prometheus/screenshot-grafana-prometheus-metrics-explorer-2.png" max-width="500px" class="docs-image--no-shadow" caption="Metrics explorer" >}}
 
 Click the book icon next to the metric selector to open the Metrics explorer. It displays all metrics in a paginated list showing the name, type, and description for each metric.
 
@@ -154,8 +138,6 @@ The Metrics explorer (Builder mode) and [Metrics browser (Code mode)](#metrics-b
 
 **Code mode** is for experienced Prometheus users who prefer writing PromQL directly. For more information about PromQL, refer to [Querying Prometheus](https://prometheus.io/docs/prometheus/latest/querying/basics/).
 
-{{< figure src="/static/img/docs/prometheus/code-mode.png" max-width="500px" class="docs-image--no-shadow" caption="Code mode" >}}
-
 Code mode provides:
 
 - **Autocomplete** — Suggests metrics, labels, functions, aggregations, and keywords as you type. The drop-down includes documentation for suggested items where available.
@@ -165,8 +147,6 @@ Code mode provides:
 ### Metrics browser
 
 The Metrics browser helps you build basic queries by exploring available metrics and labels.
-
-{{< figure alt="Prometheus query editor metrics browser" src="/media/docs/prometheus/Metrics-browser-V10-prom-query-editor.png" caption="Metrics browser" >}}
 
 1. **Step 1** — Select a metric. The browser narrows available labels to those applicable to the metric.
 2. **Step 2** — Select one or more labels.

--- a/docs/sources/datasources/prometheus/template-variables/_index.md
+++ b/docs/sources/datasources/prometheus/template-variables/_index.md
@@ -88,7 +88,7 @@ Set **Refresh** to `On time range change` so the top 5 instances update as you c
 - **Include All option:** Adds an "All" option that selects every value. Combined with multi-value, this generates a regular expression like `value1|value2|value3`.
 
 {{< admonition type="note" >}}
-When **Multi-value** or **Include All** is enabled, use `=~` (regular expression match) instead of `=` (exact match) in your queries, since the variable value becomes a regex pattern.
+When **Multi-value** or **Include All** is enabled, use `=~` (regular expression match) instead of `=` (exact match) in your queries, since the variable value becomes a regular expression pattern.
 {{< /admonition >}}
 
 **Example with multi-value:**

--- a/docs/sources/datasources/prometheus/template-variables/_index.md
+++ b/docs/sources/datasources/prometheus/template-variables/_index.md
@@ -17,7 +17,7 @@ labels:
 menuTitle: Template variables
 title: Prometheus template variables
 weight: 400
-review_date: 2026-05-07
+review_date: 2026-08-04
 ---
 
 # Prometheus template variables
@@ -39,7 +39,7 @@ Query variables query Prometheus to populate dropdown values. When creating a qu
 | **Series query**  | `metric`, `label`, or both              | Returns time series matching the specified metric and/or label selectors.       | Metric: `http_requests_total`, Label: `job="api"`                                       |
 | **Classic query** | query string                            | _Deprecated._ Legacy syntax using functions like `label_values(metric, label)`. | `label_values(http_requests_total, job)`                                                |
 
-For details on metric names, label names, and label values, refer to the [Prometheus data model](http://prometheus.io/docs/concepts/data_model/#metric-names-and-labels).
+For details on metric names, label names, and label values, refer to the [Prometheus data model](https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels).
 
 ### Query type examples
 
@@ -199,7 +199,13 @@ If **Multi-value** or **Include All** is enabled, the variable value becomes a r
 
 ## Filters variable
 
-Prometheus supports the [Filters](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/add-template-variables/#add-ad-hoc-filters) variable type (formerly called "ad hoc filters"), which lets dashboard viewers dynamically add label filters without editing queries.
+<!-- vale Grafana.WordList = NO -->
+<!-- vale Grafana.Spelling = NO -->
+
+Prometheus supports the [Filters](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/filter-group-by/) variable type (formerly called "ad hoc filters"), which lets dashboard viewers dynamically add label filters without editing queries.
+
+<!-- vale Grafana.Spelling = YES -->
+<!-- vale Grafana.WordList = YES -->
 
 {{< admonition type="note" >}}
 The **Filter and Group by** feature extends the Filters variable by adding grouping support for Prometheus and Loki data sources. For more information, refer to [Filter and Group by](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/filter-group-by/).

--- a/docs/sources/datasources/prometheus/template-variables/_index.md
+++ b/docs/sources/datasources/prometheus/template-variables/_index.md
@@ -43,7 +43,7 @@ For details on metric names, label names, and label values, refer to the [Promet
 
 ### Query type examples
 
-**Label values — Populate a dropdown with all jobs:**
+**Label values (populate a drop-down with all jobs):**
 
 1. Create a new variable with **Type: Query**.
 1. Select your Prometheus data source.
@@ -53,15 +53,15 @@ For details on metric names, label names, and label values, refer to the [Promet
 
 The variable dropdown now shows all unique `job` label values.
 
-**Label values — Filtered by metric:**
+**Label values (filtered by metric):**
 
 Set **Label** to `instance` and **Metric** to `node_cpu_seconds_total` to show only instances that report CPU metrics.
 
-**Metrics — Find available metrics by pattern:**
+**Metrics (find available metrics by pattern):**
 
 Set **Query type** to `Metrics` and enter `http_.*_total` in the **Metric** field to populate the dropdown with all HTTP counter metrics.
 
-**Query result — Dynamic top-N filtering:**
+**Query result (dynamic top-N filtering):**
 
 Set **Query type** to `Query result` and enter:
 
@@ -78,14 +78,14 @@ Set **Refresh** to `On time range change` so the top 5 instances update as you c
 | Option          | Description                                                                                                                                                                                                      |
 | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Data source** | The Prometheus data source to query.                                                                                                                                                                             |
-| **Regex**       | Optional regular expression to extract a portion of the returned values. Use capture groups — for example, `/.*instance="([^"]+)".*/` extracts the instance label value from a series string.                    |
+| **Regex**       | Optional regular expression to extract a portion of the returned values. Use capture groups. For example, `/.*instance="([^"]+)".*/` extracts the instance label value from a series string.                    |
 | **Sort**        | Sort order for dropdown values: `Disabled`, `Alphabetical (asc)`, `Alphabetical (desc)`, `Numerical (asc)`, `Numerical (desc)`, `Alphabetical (case-insensitive, asc)`, `Alphabetical (case-insensitive, desc)`. |
 | **Refresh**     | When to update values: `On dashboard load` or `On time range change`. Use `On time range change` for variables that depend on `$__range`.                                                                        |
 
 ### Selection options
 
-- **Multi-value** — Allows selecting multiple values at once. Grafana joins them with a pipe (`|`) for regular expression matching.
-- **Include All option** — Adds an "All" option that selects every value. Combined with multi-value, this generates a regular expression like `value1|value2|value3`.
+- **Multi-value:** Allows selecting multiple values at once. Grafana joins them with a pipe (`|`) for regular expression matching.
+- **Include All option:** Adds an "All" option that selects every value. Combined with multi-value, this generates a regular expression like `value1|value2|value3`.
 
 {{< admonition type="note" >}}
 When **Multi-value** or **Include All** is enabled, use `=~` (regular expression match) instead of `=` (exact match) in your queries, since the variable value becomes a regex pattern.
@@ -227,6 +227,6 @@ Filters are applied to all queries using the selected data source. You cannot se
 
 ## Related resources
 
-- [Query editor](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/query-editor/) — Use variables in PromQL queries.
-- [Annotations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/annotations/) — Use template variables in annotation queries.
-- [Troubleshooting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/troubleshooting/) — Resolve variable-related query issues.
+- [Query editor](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/query-editor/): Use variables in PromQL queries.
+- [Annotations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/annotations/): Use template variables in annotation queries.
+- [Troubleshooting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/troubleshooting/): Resolve variable-related query issues.

--- a/docs/sources/datasources/prometheus/template-variables/_index.md
+++ b/docs/sources/datasources/prometheus/template-variables/_index.md
@@ -78,7 +78,7 @@ Set **Refresh** to `On time range change` so the top 5 instances update as you c
 | Option          | Description                                                                                                                                                                                                      |
 | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Data source** | The Prometheus data source to query.                                                                                                                                                                             |
-| **Regex**       | Optional regular expression to extract a portion of the returned values. Use capture groups. For example, `/.*instance="([^"]+)".*/` extracts the instance label value from a series string.                    |
+| **Regex**       | Optional regular expression to extract a portion of the returned values. Use capture groups. For example, `/.*instance="([^"]+)".*/` extracts the instance label value from a series string.                     |
 | **Sort**        | Sort order for dropdown values: `Disabled`, `Alphabetical (asc)`, `Alphabetical (desc)`, `Numerical (asc)`, `Numerical (desc)`, `Alphabetical (case-insensitive, asc)`, `Alphabetical (case-insensitive, desc)`. |
 | **Refresh**     | When to update values: `On dashboard load` or `On time range change`. Use `On time range change` for variables that depend on `$__range`.                                                                        |
 

--- a/docs/sources/datasources/prometheus/template-variables/_index.md
+++ b/docs/sources/datasources/prometheus/template-variables/_index.md
@@ -179,7 +179,7 @@ For `$__rate_interval` to produce reliable results, the scrape interval must mat
 
 - **Recording rules with fixed intervals:** If you use `$__rate_interval` in a recording rule query, the interval depends on the evaluation context. For recording rules, use a fixed interval (for example, `[5m]`) rather than `$__rate_interval`.
 
-For troubleshooting `$__rate_interval` issues, refer to [`$__rate_interval` returns no data or incorrect values](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/troubleshooting/#rate_interval-returns-no-data-or-incorrect-values).
+For troubleshooting `$__rate_interval` issues, refer to [Rate interval returns no data or incorrect values](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/troubleshooting/#rate_interval-returns-no-data-or-incorrect-values).
 
 For additional background, refer to [$\_\_rate_interval for Prometheus rate queries that just work](https://grafana.com/blog/2020/09/28/new-in-grafana-7.2-__rate_interval-for-prometheus-rate-queries-that-just-work/).
 

--- a/docs/sources/datasources/prometheus/troubleshooting/index.md
+++ b/docs/sources/datasources/prometheus/troubleshooting/index.md
@@ -16,7 +16,7 @@ labels:
 menuTitle: Troubleshooting
 title: Troubleshoot Prometheus data source issues
 weight: 600
-review_date: 2026-05-07
+review_date: 2026-08-04
 ---
 
 # Troubleshoot Prometheus data source issues
@@ -109,7 +109,7 @@ The following errors occur when Grafana cannot establish or maintain a connectio
 PDC connectivity issues are almost always caused by networking on the customer side (DNS, firewall rules, routing), not by Grafana Cloud. The data source test passing doesn't guarantee sustained connectivity under load — it only verifies a single query succeeds.
 {{< /admonition >}}
 
-For general PDC setup and configuration, refer to [Private data source connect (PDC)](/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/) and [Configure PDC](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/configure-pdc/).
+For general PDC setup and configuration, refer to [Private data source connect (PDC)](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/) and [Configure PDC](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/configure-pdc/).
 
 ### Certificate verification failed
 
@@ -167,7 +167,7 @@ The following errors occur when there are issues with authentication credentials
 For Google Managed Prometheus (GMP):
 
 1. Use the **GCP datasource-syncer** pattern: run a sidecar process that refreshes OAuth tokens and updates the Grafana data source credentials on a schedule shorter than the token lifetime (typically every 45 minutes for a 60-minute token). This ensures the stored token is always valid when the alerting backend uses it.
-1. Alternatively, use the [Google Cloud Monitor data source](https://grafana.com/grafana/plugins/stackdriver/) with its built-in GCP credential management rather than pointing the core Prometheus data source at a GMP endpoint.
+1. Alternatively, use the [Google Cloud Monitor data source](https://grafana.com/grafana/plugins/stackdriver/) with its built-in GCP credential management rather than pointing the Prometheus data source at a GMP endpoint.
 1. If running on GKE with Workload Identity, ensure the Kubernetes service account token refresh is functioning and the projected token volume is mounted correctly.
 
 For Azure Managed Prometheus:
@@ -190,7 +190,7 @@ This token caching behavior is a known issue that has received code fixes in rec
 
 **Symptom:** You've enabled `teamHttpHeadersMimir` and configured Team LBAC rules, but users can still see all metrics regardless of their team assignments.
 
-**Cause:** Label-Based Access Control (LBAC) for the Prometheus data source only works when the backend is **Grafana Cloud Metrics (Mimir)** or **Grafana Enterprise Metrics (GEM)**. It doesn't work with Google Managed Prometheus, self-hosted Prometheus, Thanos, or other Prometheus-compatible endpoints. The LBAC enforcement relies on Mimir-specific HTTP headers (`X-Scope-OrgID` and team-scoped label matchers) that other backends ignore.
+**Cause:** Label-Based Access Control (LBAC) for the Prometheus data source only works when the backend is **Grafana Cloud Metrics (Mimir)** or **Grafana Enterprise Metrics (GEM)**. It doesn't work with Google Managed Prometheus, self-managed Prometheus, Thanos, or other Prometheus-compatible endpoints. The LBAC enforcement relies on Mimir-specific HTTP headers (`X-Scope-OrgID` and team-scoped label matchers) that other backends ignore.
 
 **Solution:**
 

--- a/docs/sources/datasources/prometheus/troubleshooting/index.md
+++ b/docs/sources/datasources/prometheus/troubleshooting/index.md
@@ -106,7 +106,7 @@ The following errors occur when Grafana cannot establish or maintain a connectio
 1. **Check for idle timeout issues.** If the connection drops after periods of inactivity, configure TCP keepalives on the host or add a keepalive setting to the PDC agent configuration.
 
 {{< admonition type="note" >}}
-PDC connectivity issues are almost always caused by networking on the customer side (DNS, firewall rules, routing), not by Grafana Cloud. The data source test passing doesn't guarantee sustained connectivity under load — it only verifies a single query succeeds.
+PDC connectivity issues are almost always caused by networking on the customer side (DNS, firewall rules, routing), not by Grafana Cloud. The data source test passing doesn't guarantee sustained connectivity under load. It only verifies a single query succeeds.
 {{< /admonition >}}
 
 For general PDC setup and configuration, refer to [Private data source connect (PDC)](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/) and [Configure PDC](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/configure-pdc/).
@@ -174,12 +174,12 @@ For Azure Managed Prometheus:
 
 1. Verify the Azure AD app registration's client secret hasn't expired.
 1. If using Managed Identity, ensure the Grafana instance's identity has the **Monitoring Data Reader** role on the Azure Monitor workspace.
-1. Check that **Forward OAuth identity** is not enabled alongside Azure AD authentication — both use the same HTTP authorization headers and conflict with each other.
+1. Check that **Forward OAuth identity** is not enabled alongside Azure AD authentication. Both use the same HTTP authorization headers and conflict with each other.
 
 General steps:
 
 1. Check the Grafana server logs for token refresh errors around the time alerts fail.
-1. Verify the data source test (**Save & test**) passes — this confirms current credentials are valid but doesn't guarantee the alerting backend has a fresh token.
+1. Verify the data source test (**Save & test**) passes. This confirms current credentials are valid but doesn't guarantee the alerting backend has a fresh token.
 1. If the issue persists, set **Alert state if execution error or timeout** to **Keep Last State** to prevent false alarms while investigating. Refer to [Configure alert state for execution errors](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/alerting/#configure-alert-state-for-execution-errors).
 
 {{< admonition type="note" >}}
@@ -352,7 +352,7 @@ The following errors occur when there are issues with PromQL syntax or query exe
 
 | Cause                                         | Solution                                                                                                                                              |
 | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `increase()` fractional values                | Expected behavior — Prometheus uses linear interpolation. Use `ceil()` or `floor()` if you need integers.                                             |
+| `increase()` fractional values                | Expected behavior. Prometheus uses linear interpolation. Use `ceil()` or `floor()` if you need integers.                                              |
 | `rate()` grows over time                      | Multiple instances write to the same series without unique labels. Ensure each target has unique `instance`/`pod` labels and aggregate with `sum by`. |
 | Counter reset spikes after pod restarts       | Use `$__rate_interval` or a longer range vector to smooth spikes. Investigate frequent restarts as the root cause.                                    |
 | Values differ between edit mode and dashboard | Panel width affects `$__interval` which affects `rate()` window calculations. Set a **Min step** on the query.                                        |
@@ -407,7 +407,7 @@ The following errors occur when the data source is not configured correctly.
 
 **Symptom:** Queries using `$__rate_interval` return no data, return different values in edit mode versus the dashboard, or produce unexpected gaps.
 
-**Cause:** `$__rate_interval` is calculated as `max($__interval + scrape_interval, 4 * scrape_interval)`. If any input to this formula is incorrect, the resulting window is wrong — either too small (no data) or inconsistent across contexts.
+**Cause:** `$__rate_interval` is calculated as `max($__interval + scrape_interval, 4 * scrape_interval)`. If any input to this formula is incorrect, the resulting window is wrong: either too small (no data) or inconsistent across contexts.
 
 **Common causes and solutions:**
 
@@ -421,7 +421,7 @@ The following errors occur when the data source is not configured correctly.
 **To debug the current value:**
 
 1. Open the query inspector in a panel (click the panel title, then **Inspect** > **Query**).
-1. Look at the expanded query sent to Prometheus — the actual interval value replacing `$__rate_interval` is visible in the request.
+1. Look at the expanded query sent to Prometheus. The actual interval value replacing `$__rate_interval` is visible in the request.
 1. Compare this value against your actual scrape interval. If it's smaller than your scrape interval, you need to configure the data source scrape interval or set a Min step.
 
 For detailed documentation on how `$__rate_interval` works and how to configure it, refer to [Use `$__rate_interval`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/template-variables/#use-__rate_interval).
@@ -459,7 +459,7 @@ The following issues affect query speed and data freshness.
 1. Verify the **Scrape interval** is configured correctly in the data source settings.
 1. Ensure Prometheus has finished scraping the target (there's a delay between the scrape interval and data availability).
 1. Check for clock synchronization issues between Grafana and Prometheus (use NTP).
-1. For `rate()` and similar functions, the most recent partial scrape interval won't have enough data points — this is expected.
+1. For `rate()` and similar functions, the most recent partial scrape interval won't have enough data points. This is expected.
 
 ### Exemplars not showing
 
@@ -510,7 +510,7 @@ The following issues occur when using Prometheus with Grafana Alerting.
 
 **Symptom:** Alert rules intermittently fire due to execution errors rather than genuine threshold breaches. On-call teams receive false positive notifications. Alert state history shows error states caused by transient backend issues (network blips, HTTP 502/500 responses, timeouts) rather than actual metric conditions being met.
 
-**Cause:** By default, when an alert rule encounters an execution error or timeout, Grafana sets the alert state to **Alerting** — which fires the alert. Transient connectivity issues between Grafana and Prometheus (i/o timeouts, deadline exceeded, brief outages) trigger this behavior even though the underlying metric hasn't crossed its threshold.
+**Cause:** By default, when an alert rule encounters an execution error or timeout, Grafana sets the alert state to **Alerting**, which fires the alert. Transient connectivity issues between Grafana and Prometheus (i/o timeouts, deadline exceeded, brief outages) trigger this behavior even though the underlying metric hasn't crossed its threshold.
 
 **Solution:**
 
@@ -524,8 +524,8 @@ This ensures the alert retains its previous state during transient errors and on
 
 1. Network stability between Grafana and Prometheus.
 1. Prometheus resource utilization (CPU, memory, disk I/O).
-1. The **Query timeout** setting in the data source configuration — increase it if complex queries regularly exceed the limit.
-1. Query complexity — simplify queries or use recording rules to pre-compute expensive expressions.
+1. The **Query timeout** setting in the data source configuration. Increase it if complex queries regularly exceed the limit.
+1. Query complexity. Simplify queries or use recording rules to pre-compute expensive expressions.
 
 For configuration details, refer to [Configure alert state for execution errors](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/alerting/#configure-alert-state-for-execution-errors).
 

--- a/docs/sources/datasources/prometheus/troubleshooting/index.md
+++ b/docs/sources/datasources/prometheus/troubleshooting/index.md
@@ -85,7 +85,7 @@ The following errors occur when Grafana cannot establish or maintain a connectio
 
 ### PDC connectivity errors
 
-**Error messages:** "host unreachable", "EOF", "network unreachable", "connection reset by peer", "dial tcp: lookup ... no such host"
+**Error messages:** `host unreachable`, `EOF`, `network unreachable`, `connection reset by peer`, `dial tcp: lookup ... no such host`
 
 **Symptom:** Prometheus queries fail intermittently or consistently when using Private data source connect (PDC) to reach a Prometheus instance behind a private network. The data source test may pass occasionally but queries fail under load.
 
@@ -103,7 +103,7 @@ The following errors occur when Grafana cannot establish or maintain a connectio
 
 1. **Check firewall rules.** Ensure the PDC agent's outbound SSH connection to Grafana Cloud isn't being interrupted by firewall rules, NAT gateways, or idle connection timeouts.
 1. **Verify the PDC agent is running and healthy.** Check agent logs for connection errors or restarts. The agent must maintain a persistent connection to Grafana Cloud.
-1. **Check for idle timeout issues.** If the connection drops after periods of inactivity, configure TCP keepalives on the host or add a keepalive setting to the PDC agent configuration.
+1. **Check for idle timeout issues.** If the connection drops after periods of inactivity, configure TCP keepalive on the host or add a `keepalive` setting to the PDC agent configuration.
 
 {{< admonition type="note" >}}
 PDC connectivity issues are almost always caused by networking on the customer side (DNS, firewall rules, routing), not by Grafana Cloud. The data source test passing doesn't guarantee sustained connectivity under load. It only verifies a single query succeeds.
@@ -231,7 +231,7 @@ The following errors occur when there are issues with PromQL syntax or query exe
 
 ### Query syntax error
 
-**Error message:** "parse error: unexpected character" or "bad_data: 1:X: parse error"
+**Error message:** `parse error: unexpected character` or `bad_data: 1:X: parse error`
 
 **Cause:** The PromQL query contains invalid syntax.
 
@@ -276,7 +276,7 @@ The following errors occur when there are issues with PromQL syntax or query exe
 
 ### Too many time series
 
-**Error message:** "exceeded maximum resolution of 11,000 points per timeseries" or "maximum number of series limit exceeded"
+**Error message:** `exceeded maximum resolution of 11,000 points per timeseries` or `maximum number of series limit exceeded`
 
 **Cause:** The query is returning more time series or data points than the configured limits allow.
 


### PR DESCRIPTION
FY27 Q3 quarterly update for the Prometheus data source documentation. The headline change documents the externalization of Prometheus from Grafana core into a standalone preinstalled plugin (Grafana 13.2); the rest is style hygiene, link fixes, and prose cleanup across all nine pages. Content was verified against the Grafana codebase, the plugin catalog, and the standalone plugin's changelog.

**_index.md:**
Added "Plugin updates" section covering the standalone plugin packaging in Grafana 13.2 (preinstalled in OSS and Enterprise, auto-update behavior, `preinstall_auto_update` opt-out, early opt-in snippet for Grafana 12.3.x–13.1.x), reworded "built-in support" to preinstalled, added saved queries (GA) to Additional features, fully qualified the Grafana Mimir link

**configure/_index.md:**
Reworded "built-in support" to preinstalled, replaced "self-hosted" with "self-managed", fixed future tense in the Azure/OAuth note, fully qualified the PDC link

**configure/aws-authentication.md:**
Added intro text under "Troubleshoot migration issues", replaced "Self-hosted" with "Self-managed", removed gerund from frontmatter description

**configure/azure-authentication.md:**
Same fixes as the AWS migration page (heading intro, self-managed, description gerund)

**query-editor/_index.md:**
Removed ten outdated v9.5/v10/v11 screenshots (fresh captures planned for next quarter), replaced "see" with "refer to" (3 occurrences), updated prometheus.io links to HTTPS and current URLs, clarified the multi-query expression example lead-in

**template-variables/_index.md:**
Fixed dead `#add-ad-hoc-filters` anchor to point to the Filter and group by page, updated prometheus.io link to HTTPS, added Vale suppression for the intentional historical name "ad hoc filters"

**annotations/index.md:**
Fixed future tense in annotation flooding guidance

**alerting/index.md:**
Replaced "self-hosted" with "self-managed", fixed future tense in recording rules steps, capitalized sentence-style bullet text

**troubleshooting/index.md:**
Replaced "self-hosted" with "self-managed", fully qualified the PDC link, removed stale "core Prometheus data source" phrasing

All files: bumped `review_date` to 2026-08-04 and removed em dashes doc-set-wide (converted bullet definitions to bold-plus-colon style, rephrased mid-sentence dashes). 

**Technical accuracy verified against:**
- `pkg/setting/setting_plugins.go` (Prometheus in the default preinstall list)
- grafana/grafana#129332 (core removal commit; confirmed not in any 13.1.x release tag, ships in 13.2)
- grafana.com plugin catalog API (standalone plugin v13.1.7, requires Grafana >= 12.3.0)
- `grafana/grafana-prometheus-datasource` CHANGELOG (no new user-facing features since the Q2 update)
- `pkg/services/featuremgmt/registry.go` (no new Prometheus-related feature toggles)


**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
