### PR TITLE
BarChart: Fix tooltip with circular dataframe field value

### DIFF
--- a/packages/grafana-ui/src/components/VizTooltip/narrowing.ts
+++ b/packages/grafana-ui/src/components/VizTooltip/narrowing.ts
@@ -1,0 +1,17 @@
+import { type Field, FieldType, isDataFrame } from '@grafana/data';
+
+/**
+ * Fields holding DataFrames (sparkline columns, expandable sub-tables) have no meaningful one-line
+ * representation, and `applyFieldOverrides` gives every frame a circular `__dataContext`
+ * back-reference to the field that owns it, so they cannot be serialized either.
+ *
+ * The declared type is checked first so these fields drop out before they can influence the
+ * `allNumeric` sort decision; {@link isFrameValue} then covers frames arriving under a type that
+ * doesn't advertise them (`other`, or untyped).
+ */
+export const isFrameValuedField = (field: Field) =>
+  field.type === FieldType.frame || field.type === FieldType.nestedFrames;
+
+// nestedFrames values are DataFrame[], frame values a single DataFrame. Only the first element is
+// inspected: the array is homogeneous by contract, and this runs against every hovered value.
+export const isFrameValue = (value: unknown) => isDataFrame(value) || (Array.isArray(value) && isDataFrame(value[0]));

--- a/packages/grafana-ui/src/components/VizTooltip/utils.test.ts
+++ b/packages/grafana-ui/src/components/VizTooltip/utils.test.ts
@@ -549,6 +549,130 @@ describe('utils', () => {
       expect(result.text).toBe('[[1,2],[3,4]]');
       expect(result.numeric).toBeNaN();
     });
+
+    it('falls back instead of throwing on an unserializable value', () => {
+      const value: Record<string, unknown> = { spanID: '123' };
+      value.self = value;
+
+      const result = getTooltipDisplayValue(value, mockField);
+      expect(result.text).toBe('[object Object]');
+      expect(result.numeric).toBeNaN();
+    });
+
+    it('keeps repeated sibling references, which are not cycles', () => {
+      const tag = { key: 'service', value: 'api' };
+
+      const result = getTooltipDisplayValue([tag, tag], mockField);
+      expect(result.text).toBe('[{"key":"service","value":"api"},{"key":"service","value":"api"}]');
+    });
+  });
+
+  // repro for panels hovering data that carries sub-frames (e.g. Tempo traces with tableType:
+  // traces), where the frames are circular and used to crash the whole panel on JSON.stringify
+  describe('getFieldDisplayItems with frame-valued fields', () => {
+    // mirrors what applyFieldOverrides() produces: each field gets a __dataContext back-reference
+    // to the frame that owns it, so the frame cannot be serialized
+    const makeCircularFrame = (): DataFrame => {
+      const frame: DataFrame = {
+        name: 'spans',
+        length: 1,
+        fields: [{ name: 'spanID', type: FieldType.string, values: ['abc'], config: {} }],
+      };
+
+      frame.fields[0].state = {
+        scopedVars: {
+          __dataContext: { value: { data: [frame], frame, frameIndex: 0, field: frame.fields[0] } },
+        },
+      };
+
+      return frame;
+    };
+
+    const makeFrameValuedField = (type: FieldType.frame | FieldType.nestedFrames): Field => ({
+      name: 'nested',
+      type,
+      // nestedFrames values are DataFrame[], frame values are a single DataFrame
+      values: [type === FieldType.nestedFrames ? [makeCircularFrame()] : makeCircularFrame()],
+      config: {},
+    });
+
+    const xField: Field = {
+      name: 'traceService',
+      type: FieldType.string,
+      values: ['frontend'],
+      config: {},
+      display: (value: unknown) => ({ text: String(value), numeric: NaN }),
+    };
+
+    const durationField: Field = {
+      name: 'duration',
+      type: FieldType.number,
+      values: [42],
+      config: {},
+      display: (value: unknown) => ({ text: String(value), numeric: Number(value) }),
+    };
+
+    it.each([FieldType.nestedFrames, FieldType.frame] as const)('omits %s fields from extraFields', (type) => {
+      const rows = getFieldDisplayItems(
+        [xField, durationField],
+        xField,
+        [0, 0],
+        null,
+        TooltipDisplayMode.Multi,
+        SortOrder.None,
+        undefined,
+        false,
+        [makeFrameValuedField(type)]
+      );
+
+      expect(rows.map((row) => row.label)).toEqual(['duration']);
+    });
+
+    it.each([FieldType.nestedFrames, FieldType.frame] as const)('omits %s fields from series rows', (type) => {
+      const rows = getFieldDisplayItems(
+        [xField, durationField, makeFrameValuedField(type)],
+        xField,
+        [0, 0, 0],
+        null,
+        TooltipDisplayMode.Multi,
+        SortOrder.None
+      );
+
+      expect(rows.map((row) => row.label)).toEqual(['duration']);
+    });
+
+    // datasources don't reliably tag these fields, so the value has to be checked too
+    it.each([FieldType.other, FieldType.string] as const)(
+      'omits frame values carried by a %s field',
+      (mislabelledType) => {
+        const mislabelled: Field = { ...makeFrameValuedField(FieldType.nestedFrames), type: mislabelledType };
+
+        expect(
+          getFieldDisplayItems(
+            [xField, durationField, mislabelled],
+            xField,
+            [0, 0, 0],
+            null,
+            TooltipDisplayMode.Multi,
+            SortOrder.None
+          ).map((row) => row.label)
+        ).toEqual(['duration']);
+
+        expect(
+          getFieldDisplayItems(
+            [xField, durationField],
+            xField,
+            [0, 0],
+            null,
+            TooltipDisplayMode.Multi,
+            SortOrder.None,
+            undefined,
+            false,
+            [mislabelled]
+          ).map((row) => row.label)
+        ).toEqual(['duration']);
+      }
+    );
   });
 
   describe('getColorIndicatorClass', () => {

--- a/packages/grafana-ui/src/components/VizTooltip/utils.ts
+++ b/packages/grafana-ui/src/components/VizTooltip/utils.ts
@@ -8,14 +8,15 @@ import {
 } from '@grafana/data';
 import { SortOrder, TooltipDisplayMode } from '@grafana/schema';
 
+import { type ColorIndicatorStyles } from './VizTooltipColorIndicator';
+import { isFrameValue, isFrameValuedField } from './narrowing';
+import { VizTooltipColorIndicator, VizTooltipColorPlacement, type VizTooltipItem } from './types';
+
 /** @alpha */
 export interface TooltipScrollableOptions {
   mode: TooltipDisplayMode;
   maxHeight?: number;
 }
-
-import { type ColorIndicatorStyles } from './VizTooltipColorIndicator';
-import { VizTooltipColorIndicator, VizTooltipColorPlacement, type VizTooltipItem } from './types';
 
 export const calculateTooltipPosition = (
   xPos = 0,
@@ -87,6 +88,16 @@ const numberCmp = (a: VizTooltipItem, b: VizTooltipItem) => a.numeric! - b.numer
 const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
 const stringCmp = (a: VizTooltipItem, b: VizTooltipItem) => collator.compare(`${a.value}`, `${b.value}`);
 
+// The catch exists so an unserializable value costs one row, not the whole panel.
+const stringifyValue = (value: unknown): string => {
+  try {
+    return JSON.stringify(value);
+  } catch (error) {
+    console.warn('Cannot render tooltip value', { error, value });
+    return String(value);
+  }
+};
+
 export const getTooltipDisplayValue = (
   value: unknown,
   field: Field
@@ -100,11 +111,11 @@ export const getTooltipDisplayValue = (
       return { text: '', numeric: NaN };
     }
 
-    return { text: JSON.stringify(value), numeric: NaN };
+    return { text: stringifyValue(value), numeric: NaN };
   }
 
   if (value && typeof value === 'object') {
-    return { text: JSON.stringify(value), numeric: NaN };
+    return { text: stringifyValue(value), numeric: NaN };
   }
 
   const display = field.display!(value); // super expensive :(
@@ -115,6 +126,9 @@ export const getTooltipDisplayValue = (
  * @alpha
  *
  * Builds the list of {@link VizTooltipItem} rows to display in a visualization tooltip.
+ *
+ * Fields whose values are DataFrames (`frame`, `nestedFrames`) are always excluded from both
+ * `fields` and `extraFields` — they have no meaningful single-value representation.
  *
  * @param fields - All fields in the aligned data frame (including the x/time field).
  * @param xField - The x-axis or time field; it is excluded from the output rows.
@@ -147,6 +161,7 @@ export const getFieldDisplayItems = (
     if (
       field === xField ||
       field.type === FieldType.time ||
+      isFrameValuedField(field) ||
       !fieldFilter(field) ||
       field.config.custom?.hideFrom?.tooltip
     ) {
@@ -171,7 +186,7 @@ export const getFieldDisplayItems = (
 
     const v = fields[i].values[dataIdx];
 
-    if ((v == null && field.config.noValue == null) || (hideZeros && v === 0)) {
+    if ((v == null && field.config.noValue == null) || (hideZeros && v === 0) || isFrameValue(v)) {
       continue;
     }
 
@@ -199,21 +214,28 @@ export const getFieldDisplayItems = (
   }
 
   extraFields?.forEach((field) => {
-    if (!field.config.custom?.hideFrom?.tooltip) {
-      const { colorIndicator, colorPlacement } = getIndicatorAndPlacement(field);
-      const rawValue = field.values[dataIdxs[0]!];
-      const display = getTooltipDisplayValue(rawValue, field);
-
-      rows.push({
-        label: field.state?.displayName ?? field.name,
-        value: display.text,
-        color: FALLBACK_COLOR,
-        colorIndicator,
-        colorPlacement,
-        lineStyle: field.config.custom?.lineStyle,
-        isHiddenFromViz: true,
-      });
+    if (field.config.custom?.hideFrom?.tooltip || isFrameValuedField(field)) {
+      return;
     }
+
+    const rawValue = field.values[dataIdxs[0]!];
+
+    if (isFrameValue(rawValue)) {
+      return;
+    }
+
+    const { colorIndicator, colorPlacement } = getIndicatorAndPlacement(field);
+    const display = getTooltipDisplayValue(rawValue, field);
+
+    rows.push({
+      label: field.state?.displayName ?? field.name,
+      value: display.text,
+      color: FALLBACK_COLOR,
+      colorIndicator,
+      colorPlacement,
+      lineStyle: field.config.custom?.lineStyle,
+      isHiddenFromViz: true,
+    });
   });
 
   if (sortOrder !== SortOrder.None && rows.length > 1) {


### PR DESCRIPTION
**What is this feature?**

Fixing barchart crash with tempo datasource nested table frames ("traces" table format) 

**Why do we need this feature?**

To keep the tooltip rendering and the panel from crashing

Fixes #

**Special notes for your reviewer:**
Alternate approach of https://github.com/grafana/grafana/pull/130092

<img width="666" height="489" alt="image" src="https://github.com/user-attachments/assets/91af2d71-9001-4736-9da9-49d8d0d41efd" />

Introduced by https://github.com/grafana/grafana/pull/116631

[reproduction-2026-08-04 14_27_00.json.txt](https://github.com/user-attachments/files/30719038/debug-TraceQL.nested.field.repro-2026-08-04.14_27_00.json.txt)

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
