### PR TITLE
Docs: InfluxDB quarterly update (FY27 Q3)

### DIFF
--- a/docs/sources/datasources/influxdb/_index.md
+++ b/docs/sources/datasources/influxdb/_index.md
@@ -20,14 +20,16 @@ labels:
 menuTitle: InfluxDB
 title: InfluxDB data source
 weight: 700
-review_date: 2026-05-01
+review_date: 2026-08-04
 ---
 
 # InfluxDB data source
 
 {{< docs/shared lookup="influxdb/intro.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
-Grafana includes a built-in InfluxDB data source plugin, enabling you to query and visualize data from InfluxDB without installing additional plugins. Grafana offers multiple configuration options for this data source, including a choice of three query languages (SQL, InfluxQL, and Flux). SQL and InfluxQL provide both visual builder and code editing modes, while Flux provides a code editor only.
+Grafana ships with the InfluxDB data source out of the box. The data source is preinstalled in both Grafana OSS and Grafana Enterprise, so there's nothing for you to install. It's packaged as a standalone plugin that Grafana can update independently of Grafana releases. For details, refer to [Plugin updates](#plugin-updates).
+
+Grafana offers multiple configuration options for this data source, including a choice of three query languages (SQL, InfluxQL, and Flux). SQL and InfluxQL provide both visual builder and code editing modes, while Flux provides a code editor only.
 
 ## Supported versions
 
@@ -72,7 +74,27 @@ After configuring the data source, you can:
 
 ## Plugin updates
 
-Always ensure that your plugin version is up-to-date so you have access to all current features and improvements. Navigate to **Plugins and data** > **Plugins** to check for updates. Grafana recommends upgrading to the latest Grafana version, and this applies to plugins as well.
+Starting with Grafana v13.2, the InfluxDB data source is a standalone plugin, preinstalled in both Grafana OSS and Enterprise. This enables more frequent updates independent of Grafana releases. Grafana automatically checks the plugin catalog and installs the latest version on each server restart.
+
+To adjust this behavior:
+
+- **Opt out of auto-updates:** Set `preinstall_auto_update` to `false` in your [configuration file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/).
+- **Update manually:** Update at any time from the **Administration > Plugins** page without restarting Grafana.
+
+The standalone plugin requires Grafana 12.3.0 or later. The InfluxDB data source bundled with Grafana 13.1 and earlier continues to work as before. Those versions are unaffected by this change.
+
+Users running Grafana 12.3.x through 13.1.x can install the standalone plugin from the plugin catalog if they want the latest features before upgrading to Grafana 13.2. To use the standalone plugin with these versions, add the following to your [configuration file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/):
+
+```ini
+[plugin.influxdb]
+as_external = true
+
+[plugins]
+; Install the latest version on startup:
+preinstall_sync = influxdb
+; Or install a specific version:
+; preinstall_sync = influxdb@<version>
+```
 
 {{< admonition type="note" >}}
 Plugins are automatically updated in Grafana Cloud.

--- a/docs/sources/datasources/influxdb/_index.md
+++ b/docs/sources/datasources/influxdb/_index.md
@@ -83,6 +83,10 @@ To adjust this behavior:
 
 The standalone plugin requires Grafana 12.3.0 or later. The InfluxDB data source bundled with Grafana 13.1 and earlier continues to work as before. Those versions are unaffected by this change.
 
+{{< admonition type="caution" >}}
+Grafana recommends running plugin version 13.1.0 or later. Earlier versions could write API tokens to Grafana server logs in plain text at default log levels. If you've run an earlier version, treat your server logs as sensitive and rotate any tokens that may have been exposed.
+{{< /admonition >}}
+
 Users running Grafana 12.3.x through 13.1.x can install the standalone plugin from the plugin catalog if they want the latest features before upgrading to Grafana 13.2. To use the standalone plugin with these versions, add the following to your [configuration file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/):
 
 ```ini
@@ -96,8 +100,10 @@ preinstall_sync = influxdb
 ; preinstall_sync = influxdb@<version>
 ```
 
+On self-managed Grafana, you control the plugin version. To roll back after a problematic update, pin a known-good version with `preinstall_sync = influxdb@<version>` and restart Grafana, or install a specific version from the **Administration > Plugins** page.
+
 {{< admonition type="note" >}}
-Plugins are automatically updated in Grafana Cloud.
+In Grafana Cloud, plugin updates are managed automatically. You can't pin the plugin to a specific version or roll back to a previous one yourself. If a plugin update causes problems with your dashboards or queries, contact Grafana Support.
 {{< /admonition >}}
 
 ## Related resources

--- a/docs/sources/datasources/influxdb/alerting/index.md
+++ b/docs/sources/datasources/influxdb/alerting/index.md
@@ -16,7 +16,7 @@ labels:
 menuTitle: Alerting
 title: InfluxDB alerting
 weight: 550
-review_date: 2026-05-01
+review_date: 2026-08-04
 ---
 
 # InfluxDB alerting

--- a/docs/sources/datasources/influxdb/alerting/index.md
+++ b/docs/sources/datasources/influxdb/alerting/index.md
@@ -125,6 +125,19 @@ Complex queries with many nested functions or large result sets may timeout or f
 - Using appropriate aggregation intervals
 - Adding filters to limit the data scanned
 
+## Handle transient errors and timeouts
+
+Brief InfluxDB latency spikes or network interruptions can cause alert rule evaluations to fail. By default, a failed evaluation moves the rule into an error state, which can trigger a large number of spurious notifications at once even though your data is healthy.
+
+To make alert rules resilient to transient errors:
+
+1. In the alert rule settings, expand **Configure no data and error handling** and set **Alert state if execution error or timeout** to **Keep Last State**. The rule keeps its previous state through brief evaluation failures instead of firing an error alert.
+1. Set a **Pending period** so the alert condition must be met for a sustained period across multiple evaluations before the alert fires.
+1. If evaluations fail because queries run out of time, increase the data source timeout. Refer to [Advanced HTTP settings](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/influxdb/configure/#advanced-http-settings) for details.
+1. Simplify or narrow alert queries so they complete well within the timeout. Refer to [Query complexity](#query-complexity) for guidance.
+
+For more information about error state handling, refer to [No data and error handling](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/create-grafana-managed-rule/#configure-no-data-and-error-handling).
+
 ## Best practices
 
 Follow these best practices when creating InfluxDB alerts:

--- a/docs/sources/datasources/influxdb/annotations/index.md
+++ b/docs/sources/datasources/influxdb/annotations/index.md
@@ -16,7 +16,7 @@ labels:
 menuTitle: Annotations
 title: InfluxDB annotations
 weight: 500
-review_date: 2026-05-01
+review_date: 2026-08-04
 ---
 
 # InfluxDB annotations

--- a/docs/sources/datasources/influxdb/configure/_index.md
+++ b/docs/sources/datasources/influxdb/configure/_index.md
@@ -23,7 +23,7 @@ labels:
 menuTitle: Configure
 title: Configure the InfluxDB data source
 weight: 300
-review_date: 2026-05-01
+review_date: 2026-08-04
 ---
 
 # Configure the InfluxDB data source

--- a/docs/sources/datasources/influxdb/configure/_index.md
+++ b/docs/sources/datasources/influxdb/configure/_index.md
@@ -47,6 +47,8 @@ If you're new to InfluxDB, these terms are used throughout the configuration:
 
 To configure the InfluxDB data source, you must have the `Administrator` role.
 
+Grafana and Grafana Cloud don't provide a hosted InfluxDB service. The data source connects to an InfluxDB instance that you run and manage yourself, or to one of InfluxData's cloud products. You must have a running InfluxDB instance before you configure the data source.
+
 InfluxData provides three query languages:
 
 - **SQL** - Standard SQL query language for InfluxDB 3.x and newer cloud products (Cloud Serverless, Cloud Dedicated, Clustered). InfluxData recommends SQL for new deployments. It supports JOINs, subqueries, and standard SQL functions. Refer to [InfluxDB SQL reference](https://docs.influxdata.com/influxdb/cloud-serverless/reference/sql/) for the full list of supported statements, operators, and functions.
@@ -68,6 +70,10 @@ Complete the following steps to set up a new InfluxDB data source:
 1. Type `InfluxDB` in the search bar.
 1. Select the **InfluxDB** data source.
 1. Click **Add new data source** in the upper right.
+
+{{< admonition type="note" >}}
+Complete the required connection settings and click **Save & test** before you rename the data source. If you rename a new data source before saving it, Grafana validates the entire configuration and returns an error because the **URL** field is still empty.
+{{< /admonition >}}
 
 Grafana opens the **Settings** tab where you configure the data source. A sidebar on the left displays navigation links to each configuration section:
 
@@ -124,7 +130,7 @@ Refer to [Manage DBRP Mappings](https://docs.influxdata.com/influxdb/cloud/query
 Toggle **Advanced HTTP Settings** to expand optional settings for more control over your data source.
 
 - **Allowed cookies** - Defines which cookies are forwarded to the data source. All other cookies are deleted by default.
-- **Timeout** - Set an HTTP request timeout in seconds.
+- **Timeout** - Sets the HTTP request timeout in seconds. If you don't set a value, Grafana uses the `timeout` setting in the `dataproxy` section of the [configuration file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#dataproxy), which defaults to `30` seconds. Increase this value if complex queries or large result sets fail with timeout errors such as `context deadline exceeded`. Alert rule evaluations use the same timeout, so increasing it also gives alert queries more time to complete.
 
 **Custom HTTP headers**
 
@@ -214,6 +220,12 @@ Toggle **Advanced Database Settings** to expand optional settings that give you 
 _For Grafana Cloud only._ Private data source connect (PDC) allows you to establish a private, secured connection between a Grafana Cloud instance and data sources secured within a private network. For more information, refer to [Private data source connect (PDC)](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/).
 
 Click **Manage private data source connect** to go to your PDC connection page, where you'll find your PDC configuration details.
+
+{{< admonition type="caution" >}}
+When you use PDC, don't set the InfluxDB URL to `127.0.0.1` or `localhost`. PDC tunnels traffic through a SOCKS proxy, which can't resolve loopback addresses. Use the machine's LAN IP address or a hostname that's resolvable from the network where the PDC agent runs. Refer to [PDC connection fails with "no such host"](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/influxdb/troubleshooting/#pdc-connection-fails-with-no-such-host) for more information.
+{{< /admonition >}}
+
+PDC agent deployment, proxy configuration, and network and token management are covered in the PDC documentation, not here. Refer to [Configure PDC](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/configure-pdc/) for setup and [Troubleshoot PDC issues](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/troubleshooting/) for agent errors, log interpretation, and failure modes.
 
 ### Save and test
 

--- a/docs/sources/datasources/influxdb/query-editor/index.md
+++ b/docs/sources/datasources/influxdb/query-editor/index.md
@@ -19,14 +19,14 @@ labels:
 title: InfluxDB query editor
 menuTitle: Query editor
 weight: 400
-review_date: 2026-05-01
+review_date: 2026-08-04
 ---
 
 # InfluxDB query editor
 
 The InfluxDB query editor helps you build and run queries against your InfluxDB data source. You can access it from the [Explore page](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/explore/) or from any dashboard panel by clicking the ellipsis in the upper right of the panel and selecting **Edit**.
 
-The editor supports three query languages — SQL, InfluxQL, and Flux — each with its own editing experience and macro system. SQL and InfluxQL provide both a visual builder mode and a code editing mode, while Flux provides a code editor only. You can also use the query editor to retrieve [log data](#query-logs).
+The editor supports three query languages: SQL, InfluxQL, and Flux. Each has its own editing experience and macro system. SQL and InfluxQL provide both a visual builder mode and a code editing mode, while Flux provides a code editor only. You can also use the query editor to retrieve [log data](#query-logs).
 
 For general information about Grafana query editors, refer to [Query and transform data](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/query-transform-data/).
 
@@ -277,7 +277,7 @@ To view the interpolated version of a query with the Query inspector, refer to [
 
 You can query and display log data from InfluxDB in [Explore](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/explore/) and in the dashboard [Logs panel](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/logs/).
 
-**InfluxQL:** Select an InfluxDB data source in the query editor. Under the **Select measurement field** next to the **FROM** section, choose a measurement containing your log data, then choose the appropriate fields that will display the log message. Add any additional filters by clicking the **+ sign** next to the **WHERE** field. Set **FORMAT AS** to **Logs**.
+**InfluxQL:** Select an InfluxDB data source in the query editor. Under the **Select measurement field** next to the **FROM** section, choose a measurement containing your log data, then choose the appropriate fields that display the log message. Add any additional filters by clicking the **+ sign** next to the **WHERE** field. Set **FORMAT AS** to **Logs**.
 
 **SQL:** Write a SQL query that returns a timestamp column and a text column containing the log message. Set the **Format** to **Table**. For example:
 

--- a/docs/sources/datasources/influxdb/template-variables/index.md
+++ b/docs/sources/datasources/influxdb/template-variables/index.md
@@ -19,7 +19,7 @@ labels:
 menuTitle: Template variables
 title: InfluxDB template variables
 weight: 450
-review_date: 2026-05-01
+review_date: 2026-08-04
 ---
 
 # InfluxDB template variables

--- a/docs/sources/datasources/influxdb/template-variables/index.md
+++ b/docs/sources/datasources/influxdb/template-variables/index.md
@@ -42,6 +42,20 @@ For general information about variables, refer to [Variables](https://grafana.co
 | Data source   | Yes                 |
 | Ad-hoc filter | Yes (InfluxQL only) |
 
+To switch a dashboard between InfluxDB instances, use a data source variable. Don't use a query variable that returns data source names as a workaround. Query-based workarounds can break after Grafana upgrades because they depend on internal identifiers. Refer to [Add a data source variable](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/add-template-variables/#add-a-data-source-variable) for details.
+
+## Where you can use variables
+
+Variable support differs by query editor and mode:
+
+| Editor                 | Variable support                                                                                          |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------- |
+| InfluxQL visual editor | Drop-downs include your template variables alongside values from your database.                            |
+| InfluxQL raw mode      | Full support.                                                                                              |
+| SQL builder mode       | Drop-downs list only tables and columns from your database. Switch to code mode to use variables.          |
+| SQL code mode          | Full support. Press Ctrl+Space to show variable suggestions.                                               |
+| Flux code editor       | Full support.                                                                                              |
+
 ## Create a query variable
 
 By adding a query template variable, you can write an InfluxDB metadata exploration query. These queries return results such as measurement names, key names, and key values.
@@ -97,6 +111,27 @@ You can list columns in a specific table:
 SHOW COLUMNS FROM cpu
 ```
 
+## Scope variables to the dashboard time range
+
+By default, metadata queries such as `SHOW TAG VALUES` return values from the entire retention period, not just the dashboard time range. If a host or sensor stopped reporting long ago, its values still appear in the variable drop-down as long as they exist within retention.
+
+To limit variable results to the dashboard time range:
+
+1. Include a time condition in the variable query. Variable queries interpolate the same time macros as regular queries: `$timeFilter` for InfluxQL, `$__timeFilter(<column>)` for SQL, and `v.timeRangeStart` and `v.timeRangeStop` for Flux.
+1. Set the variable's **Refresh** option to **On time range change** so the values update when the dashboard time range changes.
+
+**InfluxQL example:**
+
+```sql
+SHOW TAG VALUES WITH KEY = "hostname" WHERE $timeFilter
+```
+
+**SQL example:**
+
+```sql
+SELECT DISTINCT hostname FROM cpu WHERE $__timeFilter(time)
+```
+
 ## Chain or nest variables
 
 You can create nested variables, sometimes called [chained variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/add-template-variables/#chained-variables).
@@ -149,7 +184,13 @@ SELECT mean("value") FROM "logins" WHERE "hostname" =~ /^$host$/ AND $timeFilter
 SELECT mean("value") FROM "logins" WHERE "hostname" =~ /^${host}$/ AND $timeFilter GROUP BY time($__interval), "hostname"
 ```
 
-When you enable the **Multi-value** or **Include all value** options with InfluxQL, Grafana converts the labels from plain text to a regular expression-compatible string, so you must use `=~` instead of `=`.
+When you enable the **Multi-value** or **Include all value** options with InfluxQL, Grafana converts the labels from plain text to a regular expression-compatible string, so you must use `=~` instead of `=` and wrap the variable in a regular expression such as `/^$host$/`.
+
+For example, if `$host` is a multi-value variable and you select `server1` and `server2`, Grafana joins the values with `|`, wraps them in parentheses, and escapes any special characters. The interpolated query looks like this:
+
+```sql
+SELECT mean("value") FROM "logins" WHERE "hostname" =~ /^(server1|server2)$/ AND $timeFilter GROUP BY time($__interval), "hostname"
+```
 
 **SQL examples:**
 
@@ -162,6 +203,16 @@ SELECT $__dateBin(time), mean(usage_system) FROM cpu WHERE $__timeFilter(time) A
 ```
 
 When you enable the **Multi-value** option with SQL, use the `IN` operator instead of `=` to match multiple values.
+
+### Prevent unwanted value escaping
+
+When you use a variable inside a regular expression, or when the variable is multi-value, Grafana escapes special characters in the values so the query remains valid. If you need the literal, unmodified value instead, use the `raw` format option:
+
+```sql
+SELECT mean("value") FROM "requests" WHERE "path" = '${path:raw}' AND $timeFilter GROUP BY time($__interval)
+```
+
+This is useful for custom variables whose values intentionally contain characters that Grafana would otherwise escape. For all available format options, refer to [Advanced variable format options](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/variable-syntax/#advanced-variable-format-options).
 
 ### Templated dashboard example
 

--- a/docs/sources/datasources/influxdb/template-variables/index.md
+++ b/docs/sources/datasources/influxdb/template-variables/index.md
@@ -48,13 +48,13 @@ To switch a dashboard between InfluxDB instances, use a data source variable. Do
 
 Variable support differs by query editor and mode:
 
-| Editor                 | Variable support                                                                                          |
-| ---------------------- | ---------------------------------------------------------------------------------------------------------- |
-| InfluxQL visual editor | Drop-downs include your template variables alongside values from your database.                            |
-| InfluxQL raw mode      | Full support.                                                                                              |
-| SQL builder mode       | Drop-downs list only tables and columns from your database. Switch to code mode to use variables.          |
-| SQL code mode          | Full support. Press Ctrl+Space to show variable suggestions.                                               |
-| Flux code editor       | Full support.                                                                                              |
+| Editor                 | Variable support                                                                                  |
+| ---------------------- | ------------------------------------------------------------------------------------------------- |
+| InfluxQL visual editor | Drop-downs include your template variables alongside values from your database.                   |
+| InfluxQL raw mode      | Full support.                                                                                     |
+| SQL builder mode       | Drop-downs list only tables and columns from your database. Switch to code mode to use variables. |
+| SQL code mode          | Full support. Press Ctrl+Space to show variable suggestions.                                      |
+| Flux code editor       | Full support.                                                                                     |
 
 ## Create a query variable
 

--- a/docs/sources/datasources/influxdb/troubleshooting/index.md
+++ b/docs/sources/datasources/influxdb/troubleshooting/index.md
@@ -73,6 +73,35 @@ The following errors occur when Grafana can't establish or maintain a connection
 1. Verify the hostname is resolvable from the network where the PDC agent is running.
 1. If the error appeared suddenly without configuration changes, check the [Grafana Cloud status page](https://status.grafana.com/) for active incidents.
 
+### PDC connection stops working after certificate renewal fails
+
+**Symptoms:**
+
+- A previously working PDC-connected data source stops working
+- The PDC agent logs show errors renewing or signing the SSH certificate
+- Queries fail with SOCKS proxy connection errors
+
+**Cause:** The PDC agent uses a Grafana Cloud API token to periodically renew its SSH certificate. If the token is incorrect, has expired, or has been deleted, certificate renewal fails and the connection stops working when the current certificate expires.
+
+**Solution:**
+
+1. Check the PDC agent logs for authentication or certificate signing errors.
+1. Verify the API token in the PDC agent configuration is valid. If the token has expired or been deleted, generate a new one from your PDC connection page in Grafana Cloud and update the agent configuration.
+1. Restart the PDC agent after updating the token.
+1. Refer to [Troubleshoot PDC issues](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/troubleshooting/) for agent error codes, log interpretation, and token management guidance.
+
+### TLS certificate errors
+
+**Error message:** `x509: certificate signed by unknown authority` or similar TLS verification errors
+
+**Cause:** InfluxDB presents a TLS certificate that isn't signed by a certificate authority (CA) that the Grafana server trusts. This is common with self-signed certificates and internal corporate certificate authorities. TLS verification applies end to end, so this error also occurs when you connect through PDC.
+
+**Solution:**
+
+1. The InfluxDB data source supports TLS configuration for each data source instance. In the data source settings, expand **Auth and TLS/SSL Settings**, enable **CA cert**, and paste your CA certificate. Refer to [Auth and TLS/SSL settings](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/influxdb/configure/#auth-and-tlsssl-settings) for details.
+1. If your InfluxDB server requires client certificates, enable **TLS client auth** and provide the server name, client certificate, and client key.
+1. As a last resort, you can enable **Skip TLS verify** to bypass certificate validation. Grafana doesn't recommend this for production use because it disables protection against man-in-the-middle attacks.
+
 ### Request timed out
 
 **Error message:** `context deadline exceeded` or `request timeout` or `dial tcp <IP>:<port>: i/o timeout`
@@ -96,10 +125,11 @@ The following errors occur when there are issues with authentication credentials
 
 **Error message:** "401 Unauthorized" or "authorization failed"
 
-**Cause:** The authentication credentials are invalid or missing.
+**Cause:** The authentication credentials are invalid or missing. Transient network issues can also surface as authentication errors even when your credentials are valid.
 
 **Solution:**
 
+1. If the error is intermittent or appeared without a configuration change, wait a few minutes and retry **Save & test** to rule out a transient network issue before rotating credentials.
 1. Verify that the token or password is correct in the data source configuration.
 1. For Flux and SQL, ensure the token has not expired.
 1. For InfluxQL with InfluxDB 2.x, verify the token is set as an `Authorization` header with the value `Token <your-token>`.
@@ -201,7 +231,7 @@ Each query language uses a different API endpoint. If you select the wrong langu
 - `net::ERR_ABORTED` on proxy requests
 - The InfluxDB plugin attempts direct browser-to-InfluxDB connections
 
-**Cause:** You're running an outdated version of Grafana. Browser access mode was removed in Grafana 9.2.0, and older versions may attempt direct browser connections that violate CSP policies.
+**Cause:** You're running an outdated version of Grafana. Browser access mode was removed in Grafana 9.2.0, and older versions may attempt direct browser connections that violate CSP policies. Current versions of the data source support only server (proxy) access, where the Grafana server sends all queries to InfluxDB and the browser never connects to InfluxDB directly.
 
 **Solution:**
 
@@ -461,6 +491,47 @@ If you need the same query in both a dashboard panel and an alert rule, maintain
 1. Check that the alert evaluation time range contains data. Alerts use a fixed time range, not the dashboard's time picker.
 1. Verify the data source connection is working by clicking **Save & test** in the data source settings.
 
+## Template variable errors
+
+The following issues occur when using template variables with InfluxDB queries.
+
+### Variable drop-down shows stale or historical values
+
+**Cause:** Metadata queries such as `SHOW TAG VALUES` return values from the entire retention period, not just the dashboard time range. Hosts or sensors that stopped reporting long ago still appear in the drop-down.
+
+**Solution:**
+
+1. Add a time condition to the variable query, such as `WHERE $timeFilter` for InfluxQL or `WHERE $__timeFilter(time)` for SQL.
+1. Set the variable's **Refresh** option to **On time range change**.
+1. Refer to [Scope variables to the dashboard time range](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/influxdb/template-variables/#scope-variables-to-the-dashboard-time-range) for examples.
+
+### Multi-select variable breaks the query
+
+**Cause:** When a variable has the **Multi-value** or **Include all value** option enabled, Grafana interpolates the selected values as a regular expression group, such as `(server1|server2)`. Queries that compare with `=` or that don't wrap the variable in a regular expression fail or return no data.
+
+**Solution:**
+
+1. For InfluxQL, use the `=~` operator and wrap the variable in a regular expression: `"hostname" =~ /^$host$/`.
+1. For SQL, use the `IN` operator: `host IN ($host)`.
+1. Refer to [Choose a variable syntax](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/influxdb/template-variables/#choose-a-variable-syntax) for working examples.
+
+### Variable values are escaped unexpectedly
+
+**Cause:** Grafana escapes special characters in variable values when the variable is multi-value or used inside a regular expression. Custom variable values that intentionally contain special characters, such as paths or expressions, arrive at InfluxDB modified.
+
+**Solution:**
+
+Use the `raw` format option, such as `${path:raw}`, to interpolate the literal value without escaping. Refer to [Prevent unwanted value escaping](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/influxdb/template-variables/#prevent-unwanted-value-escaping) for details.
+
+### Variable drop-down contains a blank or duplicate entry
+
+**Cause:** The variable query returns duplicate values. Grafana deduplicates results, but depending on the plugin version, duplicates can surface as a blank entry in the drop-down.
+
+**Solution:**
+
+1. Update the variable query to return unique values. For SQL, use `SELECT DISTINCT`. For InfluxQL, `SHOW` metadata queries already return unique values, so check for duplicates across retention policies.
+1. Alternatively, use the variable's **Regex** option to filter the results.
+
 ## Other common issues
 
 The following issues don't produce specific error messages but are commonly encountered during day-to-day use.
@@ -472,12 +543,13 @@ The following issues don't produce specific error messages but are commonly enco
 - Dashboard panels display "data source \<UID\> was not found"
 - Manually re-running queries in the panel editor works after you select the data source again
 
-**Cause:** Dashboard panels reference an old or deleted data source UID. This happens when a data source is deleted and recreated, since the new data source gets a different UID.
+**Cause:** Dashboard panels reference an old or deleted data source UID. This happens when a data source is deleted and recreated, since the new data source gets a different UID. Dashboard schema migrations can also leave panels with invalid data source references, so verify your panels after a dashboard is migrated to a new schema version.
 
 **Solution:**
 
-1. Edit each affected panel and reselect the correct InfluxDB data source from the data source drop-down.
-1. Click **Apply** to save each panel.
+1. Find the current UID of your InfluxDB data source. Navigate to **Connections** > **Data sources**, open the data source, and copy the UID from the page URL.
+1. To find every stale reference at once, open the dashboard's JSON model from the dashboard settings and search for the UID shown in the panel error message.
+1. Fix the references by editing each affected panel and selecting the correct InfluxDB data source from the drop-down again, or by replacing the stale UID in the JSON model and saving the dashboard.
 1. To avoid this issue, update existing data sources instead of deleting and recreating them.
 
 ### 404 Not Found when sending Telegraf metrics to Grafana Cloud
@@ -505,6 +577,40 @@ The following issues don't produce specific error messages but are commonly enco
 1. For SQL, verify the `$__timeFilter(time)` macro is included so the query uses the dashboard time range.
 1. For InfluxQL, verify the retention policy contains data for the selected time range.
 
+### Numeric values stored as strings display a blank panel
+
+**Symptoms:**
+
+- Time series panels show no data even though the query returns results
+- Values appear in the table view but can't be graphed
+
+**Cause:** InfluxDB sets a field's data type when the field is first written. If numeric values were written as strings, for example quoted in line protocol, InfluxDB returns them as strings and Grafana can't graph them. This is a data issue in InfluxDB, not in Grafana.
+
+**Solution:**
+
+1. As a workaround, add the [Convert field type](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/query-transform-data/transform-data/#convert-field-type) transformation to the panel and convert the field to **Number**.
+1. To fix the root cause, correct the data type at write time. InfluxDB can't change the type of an existing field, so you may need to write the data to a new field or measurement.
+1. In older Grafana versions, the **Convert field type** transformation converted null values to zeros. Current versions preserve null values. If you see nulls displayed as zeros after conversion, upgrade Grafana.
+
+### Panel values differ between view and edit mode
+
+**Cause:** Grafana calculates the query interval (`$__interval`) from the time range and the maximum number of data points, which is based on the panel's width. A panel rendered in edit mode has a different width than in the dashboard view, so queries that group by `time($__interval)` can aggregate into different bucket sizes and display different values. Both results are correct. They're aggregated at different resolutions.
+
+**Solution:**
+
+1. To make values consistent, set a fixed **Min interval** or **Max data points** value in the panel's query options.
+1. Alternatively, use an explicit interval in the query, such as `GROUP BY time(1m)` instead of `GROUP BY time($__interval)`.
+
+### Legend or tooltip colors don't match the series
+
+**Cause:** The query returns multiple series with the same name. This commonly happens when a query doesn't group by the tags that differentiate series, or when an alias hides the distinguishing information. Grafana assigns colors and tooltip values by series name, so duplicate names cause the legend and hover tooltip to display mismatched colors or values.
+
+**Solution:**
+
+1. Group by the tags that make each series unique, such as `GROUP BY "hostname"`.
+1. Use alias patterns such as `$tag_hostname` in the **ALIAS** field so each series has a unique display name. Refer to [Alias patterns](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/influxdb/query-editor/#alias-patterns) for details.
+1. Use the panel inspector to confirm each returned series has a distinct name.
+
 ### Slow query performance
 
 **Cause:** Queries take a long time to execute.
@@ -519,6 +625,23 @@ The following issues don't produce specific error messages but are commonly enco
 1. For Flux, use `aggregateWindow()` to downsample data before visualization.
 1. Consider using continuous queries or tasks to pre-aggregate data.
 
+### InfluxDB receives a high volume of queries from Grafana
+
+**Symptoms:**
+
+- Unexpected query load on your InfluxDB server
+- You're unsure whether the traffic originates from Grafana
+
+**Cause:** Every panel on a dashboard sends its queries to InfluxDB each time the dashboard refreshes. Query volume scales with the number of panels, the number of queries per panel, the refresh interval, and the number of people viewing the dashboard at the same time. For example, a dashboard with 20 panels refreshing every 10 seconds generates at least 120 queries per minute for each viewer.
+
+**Solution:**
+
+1. Increase the dashboard refresh interval or turn off auto-refresh where it isn't needed.
+1. Reduce the number of panels and queries per dashboard.
+1. Increase the **Min time interval** setting to reduce the resolution of each query.
+1. In Grafana Enterprise and Grafana Cloud, enable [query caching](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/data-source-management/#query-and-resource-caching) so identical queries within the cache window are served from cache instead of hitting InfluxDB.
+1. To confirm whether traffic originates from your Grafana Cloud instance, compare the source IP addresses against the [Grafana Cloud allowlist](https://grafana.com/docs/grafana-cloud/platform/security-and-account-management/security-and-access/allow-list/).
+
 ### Data appears delayed or missing recent points
 
 **Cause:** The visualization doesn't show the most recent data.
@@ -531,6 +654,10 @@ The following issues don't produce specific error messages but are commonly enco
 1. Check for clock synchronization issues between Grafana and InfluxDB.
 
 ## Enable debug logging
+
+{{< admonition type="caution" >}}
+InfluxDB plugin versions earlier than 13.1.0 could write API tokens to Grafana server logs in plain text at default log levels. Before troubleshooting with logs, upgrade to plugin version 13.1.0 or later. Treat log files as sensitive, and rotate any tokens that may have been exposed.
+{{< /admonition >}}
 
 To capture detailed error information for troubleshooting:
 

--- a/docs/sources/datasources/influxdb/troubleshooting/index.md
+++ b/docs/sources/datasources/influxdb/troubleshooting/index.md
@@ -18,7 +18,7 @@ labels:
 menuTitle: Troubleshooting
 title: Troubleshoot InfluxDB data source issues
 weight: 700
-review_date: 2026-05-01
+review_date: 2026-08-04
 ---
 
 # Troubleshoot InfluxDB data source issues
@@ -551,10 +551,11 @@ If you've tried the solutions in this guide and still encounter issues:
 
 1. Check the [InfluxDB documentation](https://docs.influxdata.com/) for API-specific guidance.
 1. Review the [Grafana community forums](https://community.grafana.com/) for similar issues.
-1. Review [InfluxDB data source issues on GitHub](https://github.com/grafana/grafana/issues?q=is%3Aissue+influxdb) for known bugs.
+1. Review [InfluxDB data source issues on GitHub](https://github.com/grafana/grafana-influxdb-datasource/issues) for known bugs.
 1. Contact Grafana Support if you're an Enterprise, Cloud Pro, or Cloud Contracted user.
 1. When reporting issues, include:
    - Grafana version
+   - InfluxDB data source plugin version, found on the **Administration > Plugins** page
    - InfluxDB version and product (OSS, Cloud, Enterprise)
    - Query language (Flux, InfluxQL, or SQL)
    - Error messages (redact sensitive information)


### PR DESCRIPTION
Quarterly review of the InfluxDB data source documentation. The headline change is documenting the plugin's externalization from core Grafana (removed in [#129602](https://github.com/grafana/grafana/pull/129602), landing in Grafana 13.2) as a standalone preinstalled plugin. 

Also folds in troubleshooting and configuration content driven by a Zendesk ticket review covering seven support categories. Content was verified against the standalone plugin source code in [grafana/grafana-influxdb-datasource](https://github.com/grafana/grafana-influxdb-datasource) and core Grafana where applicable. `review_date` updated on all seven pages.

**_index.md:**
Reworded "built-in plugin" intro to reflect the standalone preinstalled plugin model, replaced the generic "Plugin updates" section with the externalization pattern (auto-update on restart, `preinstall_auto_update` opt-out, Grafana 12.3.0 minimum, `as_external`/`preinstall_sync` opt-in snippet for 12.3.x–13.1.x), added security note recommending plugin 13.1.0+ (earlier versions could log API tokens in plain text), added self-managed version pinning/rollback guidance and a Grafana Cloud managed-updates admonition (no self-service rollback)

**configure/_index.md:**
Added note that Grafana Cloud doesn't provide hosted InfluxDB, added save-before-rename validation note, expanded Timeout documentation (30-second `dataproxy` default, when to increase, alerting impact), added PDC loopback-address caution, added pointers to the PDC configure and troubleshooting docs for agent, proxy, network, and token topics

**query-editor/index.md:**
Minor style fixes 

**template-variables/index.md:**
Added data source variable guidance (use the dedicated type, not query workarounds), added "Where you can use variables" editor support table, added "Scope variables to the dashboard time range" section with `$timeFilter`/`$__timeFilter` examples, added multi-select interpolation example showing the generated regex group, added "Prevent unwanted value escaping" section with `${var:raw}`

**annotations/index.md:**
Review date update only

**alerting/index.md:**
Added "Handle transient errors and timeouts" section (Keep Last State error handling, pending period, data source timeout, query simplification) to address alert storms from transient failures

**troubleshooting/index.md:**
Added PDC certificate renewal failure entry, added TLS certificate errors entry (corporate CA via per-instance CA cert configuration), added security caution to debug logging section (token logging before plugin 13.1.0), added "Template variable errors" section (stale values outside time range, multi-select breakage, unexpected escaping, blank/duplicate entries), added high query volume entry with Grafana Cloud allowlist link, added blank-panels-from-string-values entry (Convert field type workaround), added view-vs-edit-mode value discrepancy entry (`$__interval` and panel width), added duplicate series names legend/tooltip entry, expanded stale data source UID entry with JSON model bulk-fix steps and post-migration verification note, strengthened 401 entry with transient-error retry guidance, clarified server (proxy) access in the CSP entry, pointed GitHub issues link at the standalone plugin repo, added plugin version to issue-reporting details

**Technical accuracy verified against:**
- `grafana/grafana-influxdb-datasource` catalog entry (version 13.1.1, `grafanaDependency >=12.3.0`)
- `src/variables.ts`, `src/datasource.ts` (`$timeFilter` support in variable queries, multi-value regex interpolation, variable query range handling, result deduplication)
- `src/components/editor/config-v2/UrlAndAuthenticationSection.tsx`, `pkg/influxdb/flux/flux.go`, `pkg/influxdb/fsql/fsql.go` (URL validation on save/rename, `missing URL from datasource configuration`)
- `src/components/editor/query/influxql/visual/VisualInfluxQLEditor.tsx`, `fsql/FSQLEditor.tsx` (variable support per editor mode)
- `conf/defaults.ini` (`dataproxy.timeout = 30` default)
- `pkg/setting/setting_plugins.go` (`influxdb` in default preinstalled plugins)
- `packages/grafana-data/.../convertFieldType.ts` (null preservation in Convert field type)
- Alerting UI labels in `public/app/features/alerting/unified` (Keep Last State, error handling)
Note: the config and query editor source of truth now lives in the external plugin repo, so future code verification for this data source happens there. PDC agent proxy setup, network/token lifecycle, and access policy cascade-delete doc requests from the ticket review were routed to the PDC documentation rather than duplicated here.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
