### PR TITLE
Home: Update getting started guides on home

### DIFF
--- a/public/app/features/home/Overview/useGuides.test.ts
+++ b/public/app/features/home/Overview/useGuides.test.ts
@@ -87,31 +87,30 @@ describe('useGuides', () => {
     await waitFor(() => expect(result.current).toBeDefined());
   });
 
-  it('keeps non-plugin guides visible when no app plugins are installed', async () => {
-    const { result } = renderHook(() => useGuides());
-
-    await waitFor(() => expect(result.current).toBeDefined());
-
-    expect(result.current?.map((guide) => guide.title)).toEqual(['Monitor infrastructure']);
-  });
-
   it('filters plugin guides when canAccessPluginPage denies the route', async () => {
-    setInstalledPlugins(['grafana-app-observability-app']);
+    setInstalledPlugins(['grafana-app-observability-app', 'grafana-synthetic-monitoring-app']);
     setPluginSettingsById({
       'grafana-app-observability-app': pluginSettings('grafana-app-observability-app', true),
+      'grafana-synthetic-monitoring-app': pluginSettings('grafana-synthetic-monitoring-app', true),
     });
     mockCanAccessPluginPage.mockImplementation((_settings, pluginPagePath) => {
-      return pluginPagePath !== '/a/grafana-app-observability-app/landing';
+      return pluginPagePath === '/a/grafana-app-observability-app/landing';
     });
 
-    const { result } = renderHook(() => useGuides());
-
+    const result = renderHook(() => useGuides()).result;
     await waitFor(() => expect(result.current).toBeDefined());
 
-    expect(result.current?.map((guide) => guide.title)).toEqual(['Monitor infrastructure']);
+    const ids = result.current?.map((guide) => guide.id) ?? [];
+    expect(ids).toContain('app-monitoring');
+    expect(ids).not.toContain('website-monitoring');
+
     expect(mockCanAccessPluginPage).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'grafana-app-observability-app' }),
       '/a/grafana-app-observability-app/landing'
+    );
+    expect(mockCanAccessPluginPage).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'grafana-synthetic-monitoring-app' }),
+      '/a/grafana-synthetic-monitoring-app/checks/new/api-endpoint'
     );
   });
 
@@ -122,10 +121,9 @@ describe('useGuides', () => {
     });
 
     const { result } = renderHook(() => useGuides());
-
     await waitFor(() => expect(result.current).toBeDefined());
 
-    expect(result.current?.map((guide) => guide.title)).toEqual(['Monitor infrastructure']);
+    expect(result.current?.map((guide) => guide.id)).toEqual([]);
     expect(mockCanAccessPluginPage).not.toHaveBeenCalled();
     expect(hasRoleSpy).toHaveBeenCalledWith('Admin');
   });
@@ -141,17 +139,16 @@ describe('useGuides', () => {
     });
 
     const { result } = renderHook(() => useGuides());
-
     await waitFor(() => expect(result.current).toBeDefined());
 
-    const titles = result.current?.map((guide) => guide.title) ?? [];
-    expect(titles).toContain('Monitor infrastructure');
-    expect(titles).toContain('Observe cloud services');
-    expect(titles).toContain('Visualize existing data');
-    expect(titles).toContain('Prometheus metrics');
-    expect(titles).toContain('OpenTelemetry');
-    expect(titles).toContain('Hosted telemetry data');
-    expect(titles).not.toContain('Logs');
+    const ids = result.current?.map((guide) => guide.id) ?? [];
+    expect(ids).toContain('infra-monitoring');
+    expect(ids).toContain('cloud-monitoring');
+    expect(ids).toContain('visualize-data');
+    expect(ids).toContain('prometheus-metrics');
+    expect(ids).toContain('opentelemetry');
+    expect(ids).toContain('hosted-data');
+    expect(ids).not.toContain('logs');
     expect(mockCanAccessPluginPage).toHaveBeenCalledWith(
       expect.objectContaining({ id: SETUPGUIDE_PLUGIN_ID }),
       '/a/grafana-setupguide-app/getting-started/logs-onboarding'
@@ -165,12 +162,10 @@ describe('useGuides', () => {
     });
 
     const { result } = renderHook(() => useGuides());
-
     await waitFor(() => expect(result.current).toBeDefined());
 
-    const titles = result.current?.map((guide) => guide.title) ?? [];
-    expect(titles).toContain('Monitor infrastructure');
-    expect(titles).toContain('Set up app monitoring');
-    expect(titles).not.toContain('Monitor website uptime and performance');
+    const ids = result.current?.map((guide) => guide.id) ?? [];
+    expect(ids).toContain('app-monitoring');
+    expect(ids).not.toContain('website-monitoring');
   });
 });

--- a/public/app/features/home/Overview/useGuides.ts
+++ b/public/app/features/home/Overview/useGuides.ts
@@ -33,22 +33,22 @@ export function useGuides() {
       },
       {
         id: 'infra-monitoring',
-        title: t('home.overview.get-started.cards.infra-monitoring.title', 'Monitor infrastructure'),
+        title: t('home.overview.get-started.cards.infra-monitoring.title', 'Monitor your OS'),
         description: t(
           'home.overview.get-started.cards.infra-monitoring.description',
-          'Monitor infra running on Linux, Kubernetes, cloud platforms, and more.'
+          'Collect operating system metrics for Linux, Windows, or macOS hosts.'
         ),
         icon: 'dashboard',
         color: theme.visualization.getColorByName('blue'),
         cta: t('home.overview.get-started.cards.infra-monitoring.cta', 'Start setup'),
-        href: '#',
+        href: '/a/grafana-setupguide-app/getting-started/quickstarts/os',
       },
       {
         id: 'database-monitoring',
         title: t('home.overview.get-started.cards.database-monitoring.title', 'Analyze database performance'),
         description: t(
           'home.overview.get-started.cards.database-monitoring.description',
-          'Query performance, connections, and storage for your data stores.'
+          'Gain insights into MySQL and PostgreSQL query performance and resource consumption.'
         ),
         icon: 'database',
         color: theme.visualization.getColorByName('purple'),
@@ -60,7 +60,7 @@ export function useGuides() {
         title: t('home.overview.get-started.cards.website-monitoring.title', 'Monitor website uptime and performance'),
         description: t(
           'home.overview.get-started.cards.website-monitoring.description',
-          'Test user experience under load and track availability over time.'
+          'Track the availability of your website and its performance from different locations.'
         ),
         icon: 'monitor',
         color: theme.visualization.getColorByName('green'),

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10950,7 +10950,7 @@
           },
           "database-monitoring": {
             "cta": "Start setup",
-            "description": "Query performance, connections, and storage for your data stores.",
+            "description": "Gain insights into MySQL and PostgreSQL query performance and resource consumption.",
             "title": "Analyze database performance"
           },
           "demo-data": {
@@ -10965,8 +10965,8 @@
           },
           "infra-monitoring": {
             "cta": "Start setup",
-            "description": "Monitor infra running on Linux, Kubernetes, cloud platforms, and more.",
-            "title": "Monitor infrastructure"
+            "description": "Collect operating system metrics for Linux, Windows, or macOS hosts.",
+            "title": "Monitor your OS"
           },
           "kubernetes": {
             "cta": "Start setup",
@@ -10995,7 +10995,7 @@
           },
           "website-monitoring": {
             "cta": "Start setup",
-            "description": "Test user experience under load and track availability over time.",
+            "description": "Track the availability of your website and its performance from different locations.",
             "title": "Monitor website uptime and performance"
           }
         },


### PR DESCRIPTION
**What is this feature?**

Updates the getting started guides on the homepage with their final links + copy.

**Why do we need this feature?**

Placeholder links + mis-matched copy before from #129765

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

cc #128653

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
