### PR TITLE
Unified Storage: Fix vector backfiller error handling

### DIFF
--- a/pkg/storage/unified/search/embed/backfill/backfill_test.go
+++ b/pkg/storage/unified/search/embed/backfill/backfill_test.go
@@ -592,7 +592,8 @@ func TestIsPermanentItemError(t *testing.T) {
 	}{
 		{"pq data exception", &pq.Error{Code: "22021"}, true},
 		{"wrapped pq data exception", fmt.Errorf("upsert: %w", &pq.Error{Code: "22021"}), true},
-		{"pq constraint violation", &pq.Error{Code: "23505"}, true},
+		// Class 23 stays retryable: a missing partition is 23514 check_violation.
+		{"pq check violation", &pq.Error{Code: "23514"}, false},
 		{"pq connection failure", &pq.Error{Code: "08006"}, false},
 		{"pq insufficient resources", &pq.Error{Code: "53100"}, false},
 		// Provider rejections stay retryable: misconfig produces the same codes.

--- a/pkg/storage/unified/search/embed/backfill/backfill_test.go
+++ b/pkg/storage/unified/search/embed/backfill/backfill_test.go
@@ -574,8 +574,7 @@ func TestRunBackfillJob_PendingDeleteLabel_RunsBeforeStatsLookup(t *testing.T) {
 	assert.Equal(t, 0, stats.calls, "pending-delete skip must come before stats lookup")
 }
 
-// azureAPIError builds an openai.Error with Request/Response populated —
-// its Error() method dereferences both, as the SDK always sets them.
+// azureAPIError populates Request/Response because Error() dereferences both.
 func azureAPIError(status int) *openai.Error {
 	req, _ := http.NewRequest(http.MethodPost, "https://example.test/embeddings", nil)
 	return &openai.Error{
@@ -596,9 +595,7 @@ func TestIsPermanentItemError(t *testing.T) {
 		{"pq constraint violation", &pq.Error{Code: "23505"}, true},
 		{"pq connection failure", &pq.Error{Code: "08006"}, false},
 		{"pq insufficient resources", &pq.Error{Code: "53100"}, false},
-		// Provider rejections stay retryable: the same codes fire for
-		// request-wide misconfig (bad model/deployment), where skipping
-		// would silently drain the whole job.
+		// Provider rejections stay retryable: misconfig produces the same codes.
 		{"grpc invalid argument", grpcstatus.Error(grpccodes.InvalidArgument, "bad input"), false},
 		{"bedrock validation", &smithy.GenericAPIError{Code: "ValidationException", Message: "bad input"}, false},
 		{"azure bad request", azureAPIError(http.StatusBadRequest), false},
@@ -671,8 +668,6 @@ func TestRunBackfillJob_EmbedProviderError_FailsJob(t *testing.T) {
 	vec := newFakeVector()
 	vec.jobs = []vector.BackfillJob{{ID: 1, Model: "test-model", StoppingRV: 100}}
 
-	// Even a provider "validation" rejection must fail the job — the same
-	// code fires for misconfig, and skipping would drain every item.
 	emb := newFakeEmbedder(&fakeText{dim: 4, err: grpcstatus.Error(grpccodes.InvalidArgument, "input rejected")})
 	b, err := NewVectorBackfiller(Options{
 		Storage:       storage,

--- a/pkg/storage/unified/search/embed/backfill/backfill_test.go
+++ b/pkg/storage/unified/search/embed/backfill/backfill_test.go
@@ -3,15 +3,22 @@ package backfill
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net/http"
 	"testing"
 	"time"
 
+	"github.com/aws/smithy-go"
 	"github.com/grafana/grafana/apps/provisioning/pkg/controller"
+	"github.com/lib/pq"
+	"github.com/openai/openai-go/v3"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
@@ -565,4 +572,120 @@ func TestRunBackfillJob_PendingDeleteLabel_RunsBeforeStatsLookup(t *testing.T) {
 
 	assert.Empty(t, vec.upserts)
 	assert.Equal(t, 0, stats.calls, "pending-delete skip must come before stats lookup")
+}
+
+// azureAPIError builds an openai.Error with Request/Response populated —
+// its Error() method dereferences both, as the SDK always sets them.
+func azureAPIError(status int) *openai.Error {
+	req, _ := http.NewRequest(http.MethodPost, "https://example.test/embeddings", nil)
+	return &openai.Error{
+		StatusCode: status,
+		Request:    req,
+		Response:   &http.Response{StatusCode: status},
+	}
+}
+
+func TestIsPermanentItemError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"pq data exception", &pq.Error{Code: "22021"}, true},
+		{"wrapped pq data exception", fmt.Errorf("upsert: %w", &pq.Error{Code: "22021"}), true},
+		{"pq constraint violation", &pq.Error{Code: "23505"}, true},
+		{"pq connection failure", &pq.Error{Code: "08006"}, false},
+		{"pq insufficient resources", &pq.Error{Code: "53100"}, false},
+		{"grpc invalid argument", grpcstatus.Error(grpccodes.InvalidArgument, "bad input"), true},
+		{"grpc out of range", grpcstatus.Error(grpccodes.OutOfRange, "too long"), true},
+		{"grpc resource exhausted", grpcstatus.Error(grpccodes.ResourceExhausted, "quota"), false},
+		{"bedrock validation", &smithy.GenericAPIError{Code: "ValidationException", Message: "bad input"}, true},
+		{"wrapped bedrock validation", fmt.Errorf("bedrock: invoke: %w", &smithy.GenericAPIError{Code: "ValidationException"}), true},
+		{"bedrock throttling", &smithy.GenericAPIError{Code: "ThrottlingException"}, false},
+		{"azure bad request", azureAPIError(http.StatusBadRequest), true},
+		{"azure payload too large", azureAPIError(http.StatusRequestEntityTooLarge), true},
+		{"azure rate limited", azureAPIError(http.StatusTooManyRequests), false},
+		{"wrapped grpc invalid argument", fmt.Errorf("embed batch: %w", grpcstatus.Error(grpccodes.InvalidArgument, "bad input")), true},
+		{"grpc unavailable", grpcstatus.Error(grpccodes.Unavailable, "down"), false},
+		{"plain error", errors.New("connection refused"), false},
+		{"context canceled", context.Canceled, false},
+		{"context deadline", context.DeadlineExceeded, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isPermanentItemError(tc.err))
+		})
+	}
+}
+
+func TestRunBackfillJob_CorruptResource_SkippedNotFatal(t *testing.T) {
+	storage := newFakeStorage()
+	storage.listItems = []listItem{
+		// Truncated JSON: extract fails deterministically.
+		{Namespace: "ns", Name: "poison", RV: 50, Value: []byte(`{"uid":"poison","panels":[`)},
+		makeListItem("ns", "good", 60),
+	}
+
+	vec := newFakeVector()
+	vec.jobs = []vector.BackfillJob{{ID: 1, Model: "test-model", StoppingRV: 100}}
+
+	o := newBackfiller(t, storage, vec)
+	o.runBackfill(context.Background())
+
+	require.Len(t, vec.upserts, 1, "corrupt item skipped, good item embedded")
+	assert.Equal(t, "good", vec.upserts[0][0].UID)
+	assert.Empty(t, vec.errorMarks, "permanent errors must not fail the job")
+	assert.Equal(t, []int64{1}, vec.completedJobIDs)
+}
+
+func TestRunBackfillJob_PermanentUpsertError_SkipsItem(t *testing.T) {
+	storage := newFakeStorage()
+	storage.listItems = []listItem{makeListItem("ns", "dash-a", 50)}
+
+	vec := newFakeVector()
+	vec.upsertErr = &pq.Error{Code: "22021"}
+	vec.jobs = []vector.BackfillJob{{ID: 1, Model: "test-model", StoppingRV: 100}}
+
+	o := newBackfiller(t, storage, vec)
+	o.runBackfill(context.Background())
+
+	assert.Empty(t, vec.errorMarks)
+	assert.Equal(t, []int64{1}, vec.completedJobIDs)
+}
+
+func TestRunBackfillJob_RetryableUpsertError_FailsJob(t *testing.T) {
+	storage := newFakeStorage()
+	storage.listItems = []listItem{makeListItem("ns", "dash-a", 50)}
+
+	vec := newFakeVector()
+	vec.upsertErr = errors.New("connection refused")
+	vec.jobs = []vector.BackfillJob{{ID: 1, Model: "test-model", StoppingRV: 100}}
+
+	o := newBackfiller(t, storage, vec)
+	o.runBackfill(context.Background())
+
+	require.Len(t, vec.errorMarks, 1, "retryable errors keep failing the job for the next tick")
+	assert.Empty(t, vec.completedJobIDs)
+}
+
+func TestRunBackfillJob_PermanentEmbedError_SkipsItem(t *testing.T) {
+	storage := newFakeStorage()
+	storage.listItems = []listItem{makeListItem("ns", "dash-a", 50)}
+
+	vec := newFakeVector()
+	vec.jobs = []vector.BackfillJob{{ID: 1, Model: "test-model", StoppingRV: 100}}
+
+	emb := newFakeEmbedder(&fakeText{dim: 4, err: grpcstatus.Error(grpccodes.InvalidArgument, "input rejected")})
+	b, err := NewVectorBackfiller(Options{
+		Storage:       storage,
+		VectorBackend: vec,
+		BatchEmbedder: embedder.NewBatchEmbedder(*emb),
+		Builders:      []embed.Builder{dashboard.New()},
+	})
+	require.NoError(t, err)
+	b.runBackfill(context.Background())
+
+	assert.Empty(t, vec.upserts)
+	assert.Empty(t, vec.errorMarks)
+	assert.Equal(t, []int64{1}, vec.completedJobIDs)
 }

--- a/pkg/storage/unified/search/embed/backfill/backfill_test.go
+++ b/pkg/storage/unified/search/embed/backfill/backfill_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/aws/smithy-go"
 	"github.com/grafana/grafana/apps/provisioning/pkg/controller"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/lib/pq"
 	"github.com/openai/openai-go/v3"
 	"github.com/prometheus/client_golang/prometheus"
@@ -592,6 +593,8 @@ func TestIsPermanentItemError(t *testing.T) {
 	}{
 		{"pq data exception", &pq.Error{Code: "22021"}, true},
 		{"wrapped pq data exception", fmt.Errorf("upsert: %w", &pq.Error{Code: "22021"}), true},
+		{"pgx data exception", &pgconn.PgError{Code: "22021"}, true},
+		{"pgx check violation", &pgconn.PgError{Code: "23514"}, false},
 		// Class 23 stays retryable: a missing partition is 23514 check_violation.
 		{"pq check violation", &pq.Error{Code: "23514"}, false},
 		{"pq connection failure", &pq.Error{Code: "08006"}, false},

--- a/pkg/storage/unified/search/embed/backfill/backfill_test.go
+++ b/pkg/storage/unified/search/embed/backfill/backfill_test.go
@@ -596,16 +596,12 @@ func TestIsPermanentItemError(t *testing.T) {
 		{"pq constraint violation", &pq.Error{Code: "23505"}, true},
 		{"pq connection failure", &pq.Error{Code: "08006"}, false},
 		{"pq insufficient resources", &pq.Error{Code: "53100"}, false},
-		{"grpc invalid argument", grpcstatus.Error(grpccodes.InvalidArgument, "bad input"), true},
-		{"grpc out of range", grpcstatus.Error(grpccodes.OutOfRange, "too long"), true},
-		{"grpc resource exhausted", grpcstatus.Error(grpccodes.ResourceExhausted, "quota"), false},
-		{"bedrock validation", &smithy.GenericAPIError{Code: "ValidationException", Message: "bad input"}, true},
-		{"wrapped bedrock validation", fmt.Errorf("bedrock: invoke: %w", &smithy.GenericAPIError{Code: "ValidationException"}), true},
-		{"bedrock throttling", &smithy.GenericAPIError{Code: "ThrottlingException"}, false},
-		{"azure bad request", azureAPIError(http.StatusBadRequest), true},
-		{"azure payload too large", azureAPIError(http.StatusRequestEntityTooLarge), true},
-		{"azure rate limited", azureAPIError(http.StatusTooManyRequests), false},
-		{"wrapped grpc invalid argument", fmt.Errorf("embed batch: %w", grpcstatus.Error(grpccodes.InvalidArgument, "bad input")), true},
+		// Provider rejections stay retryable: the same codes fire for
+		// request-wide misconfig (bad model/deployment), where skipping
+		// would silently drain the whole job.
+		{"grpc invalid argument", grpcstatus.Error(grpccodes.InvalidArgument, "bad input"), false},
+		{"bedrock validation", &smithy.GenericAPIError{Code: "ValidationException", Message: "bad input"}, false},
+		{"azure bad request", azureAPIError(http.StatusBadRequest), false},
 		{"grpc unavailable", grpcstatus.Error(grpccodes.Unavailable, "down"), false},
 		{"plain error", errors.New("connection refused"), false},
 		{"context canceled", context.Canceled, false},
@@ -668,13 +664,15 @@ func TestRunBackfillJob_RetryableUpsertError_FailsJob(t *testing.T) {
 	assert.Empty(t, vec.completedJobIDs)
 }
 
-func TestRunBackfillJob_PermanentEmbedError_SkipsItem(t *testing.T) {
+func TestRunBackfillJob_EmbedProviderError_FailsJob(t *testing.T) {
 	storage := newFakeStorage()
 	storage.listItems = []listItem{makeListItem("ns", "dash-a", 50)}
 
 	vec := newFakeVector()
 	vec.jobs = []vector.BackfillJob{{ID: 1, Model: "test-model", StoppingRV: 100}}
 
+	// Even a provider "validation" rejection must fail the job — the same
+	// code fires for misconfig, and skipping would drain every item.
 	emb := newFakeEmbedder(&fakeText{dim: 4, err: grpcstatus.Error(grpccodes.InvalidArgument, "input rejected")})
 	b, err := NewVectorBackfiller(Options{
 		Storage:       storage,
@@ -686,6 +684,6 @@ func TestRunBackfillJob_PermanentEmbedError_SkipsItem(t *testing.T) {
 	b.runBackfill(context.Background())
 
 	assert.Empty(t, vec.upserts)
-	assert.Empty(t, vec.errorMarks)
-	assert.Equal(t, []int64{1}, vec.completedJobIDs)
+	require.Len(t, vec.errorMarks, 1)
+	assert.Empty(t, vec.completedJobIDs)
 }

--- a/pkg/storage/unified/search/embed/backfill/backfiller.go
+++ b/pkg/storage/unified/search/embed/backfill/backfiller.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/lib/pq"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -307,10 +309,14 @@ func isPermanentItemError(err error) bool {
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return false
 	}
+	// SQLSTATE class 22 = data exception, e.g. NUL byte in text. Class 23
+	// is excluded: missing partitions surface as 23514 check_violation.
+	var pgxErr *pgconn.PgError
+	if errors.As(err, &pgxErr) {
+		return strings.HasPrefix(pgxErr.Code, "22")
+	}
 	var pqErr *pq.Error
 	if errors.As(err, &pqErr) {
-		// SQLSTATE class 22 = data exception, e.g. NUL byte in text. Class 23
-		// is excluded: missing partitions surface as 23514 check_violation.
 		return pqErr.Code.Class() == "22"
 	}
 	return false

--- a/pkg/storage/unified/search/embed/backfill/backfiller.go
+++ b/pkg/storage/unified/search/embed/backfill/backfiller.go
@@ -2,9 +2,20 @@ package backfill
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"sort"
 	"time"
+
+	"github.com/aws/smithy-go"
+	"github.com/lib/pq"
+	"github.com/openai/openai-go/v3"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/metrics/metricutil"
@@ -14,9 +25,6 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/search/embed"
 	"github.com/grafana/grafana/pkg/storage/unified/search/embed/embedder"
 	"github.com/grafana/grafana/pkg/storage/unified/search/vector"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
 )
 
 var tracer = otel.Tracer("github.com/grafana/grafana/pkg/storage/unified/search/embed/backfill")
@@ -297,6 +305,56 @@ func (b *VectorBackfiller) runBackfillPage(ctx context.Context, job vector.Backf
 	return nextToken, nil
 }
 
+// isPermanentItemError reports whether an item-level failure is a
+// deterministic function of the item's content rather than a transient
+// infra fault. Unknown errors default to retryable so outages keep the
+// job's fail-and-retry semantics instead of silently dropping items.
+func isPermanentItemError(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	var pqErr *pq.Error
+	if errors.As(err, &pqErr) {
+		// SQLSTATE class 22 (data exception, e.g. NUL byte in text) and
+		// class 23 (constraint violation) are decided by the row itself;
+		// all other classes stay retryable.
+		class := pqErr.Code.Class()
+		return class == "22" || class == "23"
+	}
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		// Bedrock (aws-sdk-go-v2): ValidationException means the model
+		// rejected the request contents. Throttling, model timeouts, and
+		// 5xx arrive as other exception types and stay retryable.
+		return apiErr.ErrorCode() == "ValidationException"
+	}
+	var oaiErr *openai.Error
+	if errors.As(err, &oaiErr) {
+		// Azure (openai-go): 400/413/422 from the embeddings endpoint
+		// means the input was rejected (malformed, too large). 429 and
+		// 5xx stay retryable.
+		return oaiErr.StatusCode == http.StatusBadRequest ||
+			oaiErr.StatusCode == http.StatusRequestEntityTooLarge ||
+			oaiErr.StatusCode == http.StatusUnprocessableEntity
+	}
+	if s, ok := grpcstatus.FromError(err); ok {
+		// Vertex (cloud.google.com/go/aiplatform) speaks gRPC and
+		// rejects an item's content with InvalidArgument or OutOfRange —
+		// e.g. text over the model's token limit or input the model
+		// refuses to process. Quota and availability failures surface as
+		// ResourceExhausted or Unavailable and stay retryable.
+		return s.Code() == grpccodes.InvalidArgument || s.Code() == grpccodes.OutOfRange
+	}
+	return false
+}
+
+// skipPermanentItem logs an item whose failure no retry can fix; callers
+// skip the item so one poison resource cannot wedge the job forever.
+func (b *VectorBackfiller) skipPermanentItem(stage, namespace, group, res, name string, err error) {
+	b.log.Error("backfill: permanent error; skipping item",
+		"stage", stage, "namespace", namespace, "group", group, "resource", res, "name", name, "err", err)
+}
+
 // processBackfillItem runs the per-resource pipeline: skip if RV>stopping_rv
 // or already embedded, else extract → embed → upsert.
 func (b *VectorBackfiller) processBackfillItem(ctx context.Context, job vector.BackfillJob, builder embed.Builder, iter resource.ListIterator) (retErr error) {
@@ -368,7 +426,11 @@ func (b *VectorBackfiller) processBackfillItem(ctx context.Context, job vector.B
 
 	items, err := builder.Extract(ctx, key, iter.Value())
 	if err != nil {
-		return fmt.Errorf("extract %s/%s: %w", namespace, name, err)
+		// Extract is a pure function of the stored bytes, so any failure
+		// (e.g. corrupt dashboard JSON) is permanent by definition.
+		b.skipPermanentItem("extract", namespace, group, res, name, err)
+		statusLabel = "skipped_permanent_error"
+		return nil
 	}
 	if resCap := builder.MaxItemsPerResource(); resCap > 0 && len(items) > resCap {
 		items = items[:resCap]
@@ -382,10 +444,20 @@ func (b *VectorBackfiller) processBackfillItem(ctx context.Context, job vector.B
 
 	vectors, err := b.batchEmbedder.Embed(ctx, namespace, res, rv, items)
 	if err != nil {
+		if isPermanentItemError(err) {
+			b.skipPermanentItem("embed", namespace, group, res, name, err)
+			statusLabel = "skipped_permanent_error"
+			return nil
+		}
 		return fmt.Errorf("embed %s/%s: %w", namespace, name, err)
 	}
 
 	if err := b.vectorBackend.Upsert(ctx, vectors); err != nil {
+		if isPermanentItemError(err) {
+			b.skipPermanentItem("upsert", namespace, group, res, name, err)
+			statusLabel = "skipped_permanent_error"
+			return nil
+		}
 		return fmt.Errorf("upsert %s/%s: %w", namespace, name, err)
 	}
 	return nil

--- a/pkg/storage/unified/search/embed/backfill/backfiller.go
+++ b/pkg/storage/unified/search/embed/backfill/backfiller.go
@@ -309,9 +309,9 @@ func isPermanentItemError(err error) bool {
 	}
 	var pqErr *pq.Error
 	if errors.As(err, &pqErr) {
-		// SQLSTATE class 22 = data exception (e.g. NUL byte), 23 = constraint violation.
-		class := pqErr.Code.Class()
-		return class == "22" || class == "23"
+		// SQLSTATE class 22 = data exception, e.g. NUL byte in text. Class 23
+		// is excluded: missing partitions surface as 23514 check_violation.
+		return pqErr.Code.Class() == "22"
 	}
 	return false
 }

--- a/pkg/storage/unified/search/embed/backfill/backfiller.go
+++ b/pkg/storage/unified/search/embed/backfill/backfiller.go
@@ -4,18 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 	"sort"
 	"time"
 
-	"github.com/aws/smithy-go"
 	"github.com/lib/pq"
-	"github.com/openai/openai-go/v3"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	grpccodes "google.golang.org/grpc/codes"
-	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/metrics/metricutil"
@@ -307,8 +302,13 @@ func (b *VectorBackfiller) runBackfillPage(ctx context.Context, job vector.Backf
 
 // isPermanentItemError reports whether an item-level failure is a
 // deterministic function of the item's content rather than a transient
-// infra fault. Unknown errors default to retryable so outages keep the
-// job's fail-and-retry semantics instead of silently dropping items.
+// infra fault. Only Postgres data/constraint errors qualify: embedding
+// provider rejections (Bedrock ValidationException, Azure 400, Vertex
+// InvalidArgument) are deliberately excluded because the same codes fire
+// for request-wide misconfiguration (bad model, deployment, endpoint) —
+// skipping on those would drain every item and complete the job with
+// nothing embedded. Unknown errors default to retryable for the same
+// reason.
 func isPermanentItemError(err error) bool {
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return false
@@ -321,37 +321,15 @@ func isPermanentItemError(err error) bool {
 		class := pqErr.Code.Class()
 		return class == "22" || class == "23"
 	}
-	var apiErr smithy.APIError
-	if errors.As(err, &apiErr) {
-		// Bedrock (aws-sdk-go-v2): ValidationException means the model
-		// rejected the request contents. Throttling, model timeouts, and
-		// 5xx arrive as other exception types and stay retryable.
-		return apiErr.ErrorCode() == "ValidationException"
-	}
-	var oaiErr *openai.Error
-	if errors.As(err, &oaiErr) {
-		// Azure (openai-go): 400/413/422 from the embeddings endpoint
-		// means the input was rejected (malformed, too large). 429 and
-		// 5xx stay retryable.
-		return oaiErr.StatusCode == http.StatusBadRequest ||
-			oaiErr.StatusCode == http.StatusRequestEntityTooLarge ||
-			oaiErr.StatusCode == http.StatusUnprocessableEntity
-	}
-	if s, ok := grpcstatus.FromError(err); ok {
-		// Vertex (cloud.google.com/go/aiplatform) speaks gRPC and
-		// rejects an item's content with InvalidArgument or OutOfRange —
-		// e.g. text over the model's token limit or input the model
-		// refuses to process. Quota and availability failures surface as
-		// ResourceExhausted or Unavailable and stay retryable.
-		return s.Code() == grpccodes.InvalidArgument || s.Code() == grpccodes.OutOfRange
-	}
 	return false
 }
 
 // skipPermanentItem logs an item whose failure no retry can fix; callers
 // skip the item so one poison resource cannot wedge the job forever.
+// Warn, not Error: the skip is expected, handled behavior; the
+// skipped_permanent_error metric status is the alerting signal.
 func (b *VectorBackfiller) skipPermanentItem(stage, namespace, group, res, name string, err error) {
-	b.log.Error("backfill: permanent error; skipping item",
+	b.log.Warn("backfill: permanent error; skipping item",
 		"stage", stage, "namespace", namespace, "group", group, "resource", res, "name", name, "err", err)
 }
 
@@ -444,11 +422,9 @@ func (b *VectorBackfiller) processBackfillItem(ctx context.Context, job vector.B
 
 	vectors, err := b.batchEmbedder.Embed(ctx, namespace, res, rv, items)
 	if err != nil {
-		if isPermanentItemError(err) {
-			b.skipPermanentItem("embed", namespace, group, res, name, err)
-			statusLabel = "skipped_permanent_error"
-			return nil
-		}
+		// Provider errors are never classified permanent (see
+		// isPermanentItemError), so embed failures always fail the job
+		// and retry on the next tick.
 		return fmt.Errorf("embed %s/%s: %w", namespace, name, err)
 	}
 

--- a/pkg/storage/unified/search/embed/backfill/backfiller.go
+++ b/pkg/storage/unified/search/embed/backfill/backfiller.go
@@ -300,34 +300,23 @@ func (b *VectorBackfiller) runBackfillPage(ctx context.Context, job vector.Backf
 	return nextToken, nil
 }
 
-// isPermanentItemError reports whether an item-level failure is a
-// deterministic function of the item's content rather than a transient
-// infra fault. Only Postgres data/constraint errors qualify: embedding
-// provider rejections (Bedrock ValidationException, Azure 400, Vertex
-// InvalidArgument) are deliberately excluded because the same codes fire
-// for request-wide misconfiguration (bad model, deployment, endpoint) —
-// skipping on those would drain every item and complete the job with
-// nothing embedded. Unknown errors default to retryable for the same
-// reason.
+// isPermanentItemError reports whether the item's own content caused the
+// failure, so retrying can never succeed. Provider rejections stay retryable
+// because misconfig produces the same codes.
 func isPermanentItemError(err error) bool {
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return false
 	}
 	var pqErr *pq.Error
 	if errors.As(err, &pqErr) {
-		// SQLSTATE class 22 (data exception, e.g. NUL byte in text) and
-		// class 23 (constraint violation) are decided by the row itself;
-		// all other classes stay retryable.
+		// SQLSTATE class 22 = data exception (e.g. NUL byte), 23 = constraint violation.
 		class := pqErr.Code.Class()
 		return class == "22" || class == "23"
 	}
 	return false
 }
 
-// skipPermanentItem logs an item whose failure no retry can fix; callers
-// skip the item so one poison resource cannot wedge the job forever.
-// Warn, not Error: the skip is expected, handled behavior; the
-// skipped_permanent_error metric status is the alerting signal.
+// skipPermanentItem logs an unfixable item being skipped so it can't wedge the job.
 func (b *VectorBackfiller) skipPermanentItem(stage, namespace, group, res, name string, err error) {
 	b.log.Warn("backfill: permanent error; skipping item",
 		"stage", stage, "namespace", namespace, "group", group, "resource", res, "name", name, "err", err)
@@ -404,8 +393,7 @@ func (b *VectorBackfiller) processBackfillItem(ctx context.Context, job vector.B
 
 	items, err := builder.Extract(ctx, key, iter.Value())
 	if err != nil {
-		// Extract is a pure function of the stored bytes, so any failure
-		// (e.g. corrupt dashboard JSON) is permanent by definition.
+		// Extract is deterministic over stored bytes; failures are permanent.
 		b.skipPermanentItem("extract", namespace, group, res, name, err)
 		statusLabel = "skipped_permanent_error"
 		return nil
@@ -422,9 +410,6 @@ func (b *VectorBackfiller) processBackfillItem(ctx context.Context, job vector.B
 
 	vectors, err := b.batchEmbedder.Embed(ctx, namespace, res, rv, items)
 	if err != nil {
-		// Provider errors are never classified permanent (see
-		// isPermanentItemError), so embed failures always fail the job
-		// and retry on the next tick.
 		return fmt.Errorf("embed %s/%s: %w", namespace, name, err)
 	}
 


### PR DESCRIPTION
This adds better error handling to the vector backfiller so a failing resource wont block the backfill job forever. Two thing now get their errors skipped in the backfilling:

1. **Extract failures** — unconditional, at the call site (backfiller.go). Extract is a pure function of stored bytes; corrupt dashboard JSON (invalid character '?' in string escape code) can't be fixed by retrying.

2. **Postgres class 22 errors** (data exception) — the value itself is unstorable:
- 22021 invalid byte sequence (NUL byte — both prod wedges)
- 22001 string too long
- 22003 numeric out of range
- 22P02 invalid text representation
- ~30 more in the class, all "this value can never go in this column"