### PR TITLE
Alerting: Make the data source help icon a keyboard-accessible link

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
@@ -127,7 +127,17 @@ export const QueryWrapper = ({
             </Trans>
           }
         >
-          <Icon name="info-circle" onClick={() => window.open(DOCS_URL_DATA_SOURCE_ALERTING, '_blank')} />
+          <a
+            href={DOCS_URL_DATA_SOURCE_ALERTING}
+            target="_blank"
+            rel="noreferrer"
+            aria-label={t(
+              'alerting.selecting-data-source-tooltip.aria-label-data-source-support',
+              'Read about data source support for alerting'
+            )}
+          >
+            <Icon name="info-circle" />
+          </a>
         </Tooltip>
       </div>
     );

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3263,6 +3263,7 @@
       "title-type": "Type"
     },
     "selecting-data-source-tooltip": {
+      "aria-label-data-source-support": "Read about data source support for alerting",
       "tooltip-content": "Not finding the data source you want? Some data sources are not supported for alerting. Click on the icon for more information."
     },
     "settings": {


### PR DESCRIPTION
**What is this feature?**

The info icon next to the data source picker in the alert rule query editor is now a link to the data source alerting documentation, instead of an `<svg>` carrying an `onClick` handler.

**Why do we need this feature?**

The tooltip on that icon tells the user to "click on the icon for more information". `Tooltip` clones its child with `tabIndex: 0`, so the icon could be reached with the keyboard — but an `<svg>` has no native activation, so Enter and Space did nothing and the documentation was reachable with a pointer only (WCAG 2.1.1 Keyboard, level A). The focusable element also had no role and no accessible name, so it was announced as a focusable graphic with no indication that it leads anywhere (WCAG 4.1.2 Name, Role, Value, level A).

An anchor around the icon brings native keyboard activation, a link role, an accessible name of its own, and the focus outline that the global styles already apply to anchors on `:focus-visible`. `rel="noreferrer"` additionally drops the `opener` reference that `window.open(url, '_blank')` keeps, unlike a rendered link.

**Who is this feature for?**

Keyboard and screen reader users creating or editing alert rules.

**Which issue(s) does this PR fix?**:

No linked issue.

**Special notes for your reviewer:**

The appearance is unchanged: the global anchor styles resolve to `text.primary` with no underline, which is how the icon rendered before.

`TextLink` was not used here — it requires text children and appends a second icon when `external` is set, both of which would change the row. The plain anchor matches the neighbouring `DashboardAnnotationField` and `NeedHelpInfo` in the same directory.

#129900 currently touches the same file, but a different part of it (the query option fields); this change only touches `SelectingDataSourceTooltip`.

Please check that:
- [x] It works as expected from a user's perspective.
