### PR TITLE
Alert: Announce buttonContent buttons by their visible label

### DIFF
--- a/packages/grafana-ui/src/components/Alert/Alert.test.tsx
+++ b/packages/grafana-ui/src/components/Alert/Alert.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { Button } from '../Button/Button';
+import { Icon } from '../Icon/Icon';
 
 import { Alert } from './Alert';
 
@@ -72,10 +73,15 @@ describe('Alert', () => {
   });
 
   describe('backward compatibility', () => {
-    it('renders buttonContent with onRemove as before', () => {
+    it('names the button after its visible text when buttonContent is a string', () => {
       render(<Alert title="Test" buttonContent="Go back" onRemove={jest.fn()} />);
+      expect(screen.getByRole('button', { name: 'Go back' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /close alert/i })).not.toBeInTheDocument();
+    });
+
+    it('keeps the close label when buttonContent is not a string', () => {
+      render(<Alert title="Test" buttonContent={<Icon name="question-circle" />} onRemove={jest.fn()} />);
       expect(screen.getByRole('button', { name: /close alert/i })).toBeInTheDocument();
-      expect(screen.getByText('Go back')).toBeInTheDocument();
     });
 
     it('renders dismiss X icon when only onRemove is set', () => {

--- a/packages/grafana-ui/src/components/Alert/Alert.tsx
+++ b/packages/grafana-ui/src/components/Alert/Alert.tsx
@@ -95,7 +95,12 @@ export const Alert = React.forwardRef<HTMLDivElement, Props>(
             <Stack alignItems="center" wrap="wrap">
               {action}
               {onRemove && buttonContent && (
-                <Button aria-label={closeLabel} variant="secondary" onClick={onRemove} type="button">
+                <Button
+                  aria-label={typeof buttonContent === 'string' ? undefined : closeLabel}
+                  variant="secondary"
+                  onClick={onRemove}
+                  type="button"
+                >
                   {buttonContent}
                 </Button>
               )}


### PR DESCRIPTION
**What is this feature?**

Skips the hardcoded "Close alert" aria-label when `buttonContent` is a string so the button's visible text is also its accessible name. Non-string content and the icon-only dismiss keep the "Close alert" label, implementing the first suggested approach from the original issue.

**Why do we need this feature?**

The accessible name didn't contain the visible label (WCAG 2.5.3) so screen readers announced the wrong action as described fully in #129954.

**Who is this feature for?**

Screen reader and speech input users

**Which issue(s) does this PR fix?**:

Fixes #129954

**Special notes for your reviewer:**

The existing test pinned the old behaviour and it now asserts the visible-text name. This fixes the string call sites from the issue however, `ImportOverview` and `PreviewBannerViewPR` pass React nodes which I can migrate to this PR here or in a follow up PR if desired.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
