### PR TITLE
Plugins: Add helpers to compare plugin IDs across renames

### DIFF
--- a/pkg/services/pluginsintegration/pluginstore/canonical.go
+++ b/pkg/services/pluginsintegration/pluginstore/canonical.go
@@ -1,0 +1,32 @@
+package pluginstore
+
+import "context"
+
+// CanonicalPluginID resolves a plugin ID or one of its aliasIDs to the plugin's canonical ID.
+//
+// Plugin renames are expressed as aliasIDs (e.g. the Pyroscope data source plugin is
+// "grafana-pyroscope-datasource" and keeps "phlare" as an alias), and identifiers recorded
+// before a rename are never rewritten. Callers that compare a recorded identifier against a
+// current one therefore need to normalize both sides first.
+//
+// Identifiers the store cannot resolve are returned unchanged, so callers keep working for
+// plugins that are not installed.
+func CanonicalPluginID(ctx context.Context, store Store, idOrAlias string) string {
+	if store == nil || idOrAlias == "" {
+		return idOrAlias
+	}
+	if p, ok := store.Plugin(ctx, idOrAlias); ok && p.ID != "" {
+		return p.ID
+	}
+	return idOrAlias
+}
+
+// SamePlugin reports whether two plugin identifiers refer to the same plugin, treating a
+// canonical ID and any of its aliasIDs as equal. Identifiers the store cannot resolve only
+// match themselves.
+func SamePlugin(ctx context.Context, store Store, a, b string) bool {
+	if a == b {
+		return true
+	}
+	return CanonicalPluginID(ctx, store, a) == CanonicalPluginID(ctx, store, b)
+}

--- a/pkg/services/pluginsintegration/pluginstore/canonical_test.go
+++ b/pkg/services/pluginsintegration/pluginstore/canonical_test.go
@@ -1,0 +1,100 @@
+package pluginstore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/plugins"
+)
+
+func testStoreWithAliases() *FakePluginStore {
+	return NewFakePluginStore(
+		Plugin{JSONData: plugins.JSONData{ID: "grafana-pyroscope-datasource", AliasIDs: []string{"phlare"}}},
+		Plugin{JSONData: plugins.JSONData{ID: "grafana-testdata-datasource", AliasIDs: []string{"testdata"}}},
+		Plugin{JSONData: plugins.JSONData{ID: "loki"}},
+	)
+}
+
+func TestCanonicalPluginID(t *testing.T) {
+	store := testStoreWithAliases()
+
+	tests := []struct {
+		name      string
+		store     Store
+		idOrAlias string
+		expected  string
+	}{
+		{name: "alias resolves to canonical ID", store: store, idOrAlias: "phlare", expected: "grafana-pyroscope-datasource"},
+		{name: "canonical ID is returned unchanged", store: store, idOrAlias: "grafana-pyroscope-datasource", expected: "grafana-pyroscope-datasource"},
+		{name: "plugin without aliases is returned unchanged", store: store, idOrAlias: "loki", expected: "loki"},
+		{name: "unknown ID is returned unchanged", store: store, idOrAlias: "does-not-exist", expected: "does-not-exist"},
+		{name: "empty ID is returned unchanged", store: store, idOrAlias: "", expected: ""},
+		{name: "nil store returns input unchanged", store: nil, idOrAlias: "phlare", expected: "phlare"},
+		{name: "empty store returns input unchanged", store: NewFakePluginStore(), idOrAlias: "phlare", expected: "phlare"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, CanonicalPluginID(context.Background(), tt.store, tt.idOrAlias))
+		})
+	}
+}
+
+func TestSamePlugin(t *testing.T) {
+	store := testStoreWithAliases()
+
+	tests := []struct {
+		name     string
+		store    Store
+		a        string
+		b        string
+		expected bool
+	}{
+		{name: "identical IDs", store: store, a: "loki", b: "loki", expected: true},
+		{name: "alias and canonical ID", store: store, a: "phlare", b: "grafana-pyroscope-datasource", expected: true},
+		{name: "canonical ID and alias", store: store, a: "grafana-pyroscope-datasource", b: "phlare", expected: true},
+		{name: "second plugin's alias and canonical ID", store: store, a: "testdata", b: "grafana-testdata-datasource", expected: true},
+		{name: "aliases of different plugins", store: store, a: "phlare", b: "testdata", expected: false},
+		{name: "unrelated plugins", store: store, a: "phlare", b: "loki", expected: false},
+		{name: "unknown ID only matches itself", store: store, a: "loki", b: "does-not-exist", expected: false},
+		{name: "nil store still matches identical IDs", store: nil, a: "phlare", b: "phlare", expected: true},
+		{name: "nil store cannot resolve aliases", store: nil, a: "phlare", b: "grafana-pyroscope-datasource", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, SamePlugin(context.Background(), tt.store, tt.a, tt.b))
+		})
+	}
+}
+
+// The real registry indexes every plugin ID before any aliasID, so a plugin that is still
+// installed under an ID another plugin claims as an alias must win the lookup. The fake has to
+// behave the same way or tests covering renamed plugins pass for the wrong reason.
+func TestFakePluginStore_PrefersIDsOverAliases(t *testing.T) {
+	store := NewFakePluginStore(
+		Plugin{JSONData: plugins.JSONData{ID: "grafana-pyroscope-datasource", AliasIDs: []string{"phlare"}}},
+		Plugin{JSONData: plugins.JSONData{ID: "phlare"}},
+	)
+
+	p, exists := store.Plugin(context.Background(), "phlare")
+	require.True(t, exists)
+	require.Equal(t, "phlare", p.ID)
+
+	p, exists = store.Plugin(context.Background(), "grafana-pyroscope-datasource")
+	require.True(t, exists)
+	require.Equal(t, "grafana-pyroscope-datasource", p.ID)
+}
+
+func TestFakePluginStore_ResolvesAliases(t *testing.T) {
+	store := testStoreWithAliases()
+
+	p, exists := store.Plugin(context.Background(), "phlare")
+	require.True(t, exists)
+	require.Equal(t, "grafana-pyroscope-datasource", p.ID)
+
+	_, exists = store.Plugin(context.Background(), "does-not-exist")
+	require.False(t, exists)
+}

--- a/pkg/services/pluginsintegration/pluginstore/fake.go
+++ b/pkg/services/pluginsintegration/pluginstore/fake.go
@@ -2,6 +2,7 @@ package pluginstore
 
 import (
 	"context"
+	"slices"
 
 	"github.com/grafana/grafana/pkg/plugins"
 )
@@ -17,8 +18,16 @@ func NewFakePluginStore(ps ...Plugin) *FakePluginStore {
 }
 
 func (pr *FakePluginStore) Plugin(_ context.Context, pluginID string) (Plugin, bool) {
+	// Match the real registry: every plugin ID is considered before any aliasID, so a plugin
+	// that is still installed under an ID another plugin claims as an alias wins.
 	for _, v := range pr.PluginList {
 		if v.ID == pluginID {
+			return v, true
+		}
+	}
+
+	for _, v := range pr.PluginList {
+		if slices.Contains(v.AliasIDs, pluginID) {
 			return v, true
 		}
 	}


### PR DESCRIPTION
**Alternative to #130087**, prerequisite for https://github.com/grafana/grafana-enterprise/pull/12954.

## Why

A plugin rename only adds an `aliasIDs` entry — it never rewrites identifiers already recorded elsewhere. A data source row provisioned when the Pyroscope plugin was called `phlare` still stores `phlare`, while callers send the plugin's current ID `grafana-pyroscope-datasource`. Anything comparing a recorded plugin identifier against a current one as strings therefore breaks after a rename.

That is the escalation: data source permissions rejected `grafanacloud-profiles` with `400 datasourcePermissions.invalidUID` because `ds_type` (canonical) didn't string-match the row's type (alias).

The alias-resolving logic already exists in three places that each rolled their own — `Service.ListConnections`, `Service.GetDataSourcesByType`, `converter.AsDataSource` — so this adds a shared home rather than a fourth copy.

## What

- `pluginstore.CanonicalPluginID(ctx, store, idOrAlias)` — resolves an ID or alias to the plugin's canonical ID; unresolvable input returned unchanged, so callers keep working for plugins that aren't installed.
- `pluginstore.SamePlugin(ctx, store, a, b)` — do two identifiers refer to the same plugin, treating a canonical ID and any of its aliases as equal.
- `FakePluginStore.Plugin` now resolves `aliasIDs`, checking **every plugin ID before any alias** so it matches the real registry (`registry.InMemory.plugin` consults the `store` map fully before the `alias` map). Without the two-pass ordering the fake returns the wrong plugin for exactly the renamed-plugin case these helpers exist for:

  ```go
  store := pluginstore.NewFakePluginStore(
      pluginstore.Plugin{JSONData: plugins.JSONData{ID: "grafana-pyroscope-datasource", AliasIDs: []string{"phlare"}}},
      pluginstore.Plugin{JSONData: plugins.JSONData{ID: "phlare"}},
  )
  store.Plugin(ctx, "phlare")   // single-pass: grafana-pyroscope-datasource (wrong) / real registry: phlare
  ```

## How it differs from #130087

That PR makes the same fake alias-aware, single-pass, and puts the canonicalization helper in the enterprise repo. This one fixes the lookup ordering and keeps the helper in OSS so the enterprise side is a one-liner and there's a single definition of "same plugin" to maintain.

## Testing

`TestCanonicalPluginID`, `TestSamePlugin`, `TestFakePluginStore_PrefersIDsOverAliases`, `TestFakePluginStore_ResolvesAliases`.

Ran all 20 packages that construct a `FakePluginStore` — `pkg/api`, `pkg/expr`, `pkg/middleware`, `pkg/services/datasources/service`, `pkg/services/query`, `pkg/services/ngalert/eval`, etc. — all pass. The newly-resolving lookups only reach `validateSettings`, which no-ops on empty `APIVersion`.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

<sub>Docs/What's New: n/a — internal helpers and a test fake, no user-facing surface. The user-visible fix is in the enterprise PR.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
