### PR TITLE
Dashboard: Add stable dashboard body capture target

### DIFF
--- a/public/app/features/dashboard-scene/sidebar/DashboardSidebarSplitter.test.tsx
+++ b/public/app/features/dashboard-scene/sidebar/DashboardSidebarSplitter.test.tsx
@@ -71,6 +71,7 @@ describe('DashboardSidebarSplitter', () => {
 
     const scrollContainer = screen.getByTestId(selectors.components.DashboardSidebarSplitter.bodyContainer);
     expect(scrollContainer).toHaveAttribute('tabindex', '0');
+    expect(scrollContainer).toHaveAttribute('data-dashboard-body');
   });
 });
 

--- a/public/app/features/dashboard-scene/sidebar/DashboardSidebarSplitter.tsx
+++ b/public/app/features/dashboard-scene/sidebar/DashboardSidebarSplitter.tsx
@@ -132,6 +132,7 @@ function DashboardSidebarSplitterNewLayouts({ dashboard, isEditing, body, contro
         <div
           className={cx(styles.bodyWrapper, styles.bodyWrapperKiosk)}
           data-testid={selectors.components.DashboardSidebarSplitter.primaryBody}
+          data-dashboard-body
         >
           <NativeScrollbar onSetScrollRef={dashboard.onSetScrollRef}>{body}</NativeScrollbar>
         </div>
@@ -149,6 +150,7 @@ function DashboardSidebarSplitterNewLayouts({ dashboard, isEditing, body, contro
           ref={onBodyRef}
           onPointerDown={onClearSelection}
           data-testid={selectors.components.DashboardSidebarSplitter.bodyContainer}
+          data-dashboard-body
           // The dashboard scrolls inside this element rather than the document body, so make it
           // focusable; without this, arrow/page keys can't scroll the dashboard once it's focused.
           // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex


### PR DESCRIPTION
**What is this feature?**

Adds a stable `data-dashboard-body` attribute to the dashboard body containers.

**Why do we need this feature?**

The experimental dashboard-template preview capture in grafana-enterprise needs a production-owned target instead of deprecated E2E selectors or layout-specific CSS classes. This keeps the capture target stable across dashboard layouts and kiosk mode.

Related enterprise PR: https://github.com/grafana/grafana-enterprise/pull/12846

**Who is this feature for?**

Users of the experimental dashboard templates feature.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

- [x] It works as expected from a user perspective.
- [x] The consuming feature is pre-GA and behind `grafana.customDashboardTemplates`.
- [x] No documentation change is needed for this internal DOM marker.

Tested with `DashboardSidebarSplitter.test.tsx`.
