### PR TITLE
Access Control: Fix registry race

### DIFF
--- a/pkg/services/accesscontrol/permreg/permreg.go
+++ b/pkg/services/accesscontrol/permreg/permreg.go
@@ -1,7 +1,9 @@
 package permreg
 
 import (
+	"maps"
 	"strings"
+	"sync"
 
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -65,7 +67,8 @@ type PrefixSet map[string]bool
 var _ PermissionRegistry = &permissionRegistry{}
 
 type permissionRegistry struct {
-	actionScopePrefixes map[string]PrefixSet // TODO use thread safe map
+	mu                  sync.RWMutex
+	actionScopePrefixes map[string]PrefixSet
 	kindScopePrefix     map[string]string
 	logger              log.Logger
 }
@@ -120,27 +123,30 @@ func (pr *permissionRegistry) RegisterPluginScope(scope string) {
 
 	scopeParts := strings.Split(scope, ":")
 	kind := scopeParts[0]
-
-	// If the scope is already registered, return
-	if _, found := pr.kindScopePrefix[kind]; found {
-		return
-	}
-
-	// If the scope contains an attribute part, register the kind and attribute
+	scopePrefix := kind + ":"
 	if len(scopeParts) > 2 {
-		attr := scopeParts[1]
-		pr.kindScopePrefix[kind] = kind + ":" + attr + ":"
-		pr.logger.Debug("registered scope prefix", "kind", kind, "scope_prefix", kind+":"+attr+":")
-		return
+		scopePrefix = kind + ":" + scopeParts[1] + ":"
 	}
 
-	pr.logger.Debug("registered scope prefix", "kind", kind, "scope_prefix", kind+":")
-	pr.kindScopePrefix[kind] = kind + ":"
+	pr.mu.Lock()
+	if _, found := pr.kindScopePrefix[kind]; found {
+		pr.mu.Unlock()
+		return
+	}
+	pr.kindScopePrefix[kind] = scopePrefix
+	pr.mu.Unlock()
+
+	pr.logger.Debug("registered scope prefix", "kind", kind, "scope_prefix", scopePrefix)
 }
 
 func (pr *permissionRegistry) RegisterPermission(action, scope string) error {
-	if _, ok := pr.actionScopePrefixes[action]; !ok {
-		pr.actionScopePrefixes[action] = PrefixSet{}
+	pr.mu.Lock()
+	defer pr.mu.Unlock()
+
+	validScopePrefixes, ok := pr.actionScopePrefixes[action]
+	if !ok {
+		validScopePrefixes = PrefixSet{}
+		pr.actionScopePrefixes[action] = validScopePrefixes
 	}
 
 	if scope == "" {
@@ -156,11 +162,14 @@ func (pr *permissionRegistry) RegisterPermission(action, scope string) error {
 	}
 
 	// Add a new entry in case the scope is not empty
-	pr.actionScopePrefixes[action][scopePrefix] = true
+	validScopePrefixes[scopePrefix] = true
 	return nil
 }
 
 func (pr *permissionRegistry) IsPermissionValid(action, scope string) error {
+	pr.mu.RLock()
+	defer pr.mu.RUnlock()
+
 	validScopePrefixes, ok := pr.actionScopePrefixes[action]
 	if !ok {
 		return ErrUnknownAction(action)
@@ -199,6 +208,9 @@ func isScopeValid(scope string, validScopePrefixes PrefixSet) bool {
 }
 
 func (pr *permissionRegistry) GetScopePrefixes(action string) (PrefixSet, bool) {
+	pr.mu.RLock()
+	defer pr.mu.RUnlock()
+
 	set, ok := pr.actionScopePrefixes[action]
-	return set, ok
+	return maps.Clone(set), ok
 }

--- a/pkg/services/accesscontrol/permreg/permreg.go
+++ b/pkg/services/accesscontrol/permreg/permreg.go
@@ -125,7 +125,8 @@ func (pr *permissionRegistry) RegisterPluginScope(scope string) {
 	kind := scopeParts[0]
 	scopePrefix := kind + ":"
 	if len(scopeParts) > 2 {
-		scopePrefix = kind + ":" + scopeParts[1] + ":"
+		attr := scopeParts[1]
+		scopePrefix = kind + ":" + attr + ":"
 	}
 
 	pr.mu.Lock()

--- a/pkg/services/accesscontrol/permreg/permreg_test.go
+++ b/pkg/services/accesscontrol/permreg/permreg_test.go
@@ -1,6 +1,8 @@
 package permreg
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -242,6 +244,81 @@ func Test_permissionRegistry_GetScopePrefixes(t *testing.T) {
 				require.Equal(t, v, tt.want[k])
 			}
 		})
+	}
+}
+
+func Test_permissionRegistry_GetScopePrefixesReturnsCopy(t *testing.T) {
+	pr := newPermissionRegistry()
+	require.NoError(t, pr.RegisterPermission("folders:read", "folders:uid:"))
+
+	prefixes, ok := pr.GetScopePrefixes("folders:read")
+	require.True(t, ok)
+	prefixes["dashboards:uid:"] = true
+	delete(prefixes, "folders:uid:")
+
+	prefixes, ok = pr.GetScopePrefixes("folders:read")
+	require.True(t, ok)
+	require.Equal(t, PrefixSet{"folders:uid:": true}, prefixes)
+}
+
+func Test_permissionRegistry_ConcurrentPluginAndFixedRoleRegistration(t *testing.T) {
+	pr := newPermissionRegistry()
+
+	const (
+		workers    = 32
+		iterations = 100
+	)
+	start := make(chan struct{})
+	errs := make(chan error, workers*iterations*2)
+	var wg sync.WaitGroup
+
+	for worker := range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+
+			for iteration := range iterations {
+				if worker%2 != 0 {
+					action := fmt.Sprintf("fixed-role-%d:read", iteration%8)
+					if err := pr.RegisterPermission(action, ""); err != nil {
+						errs <- err
+						continue
+					}
+					if err := pr.IsPermissionValid(action, ""); err != nil {
+						errs <- err
+					}
+					if _, ok := pr.GetScopePrefixes(action); !ok {
+						errs <- fmt.Errorf("scope prefixes not found for %s", action)
+					}
+					continue
+				}
+
+				kind := fmt.Sprintf("plugin-%d", iteration%8)
+				scope := kind + ":uid:value"
+				action := kind + ":read"
+
+				pr.RegisterPluginScope(scope)
+				if err := pr.RegisterPermission(action, scope); err != nil {
+					errs <- err
+					continue
+				}
+				if err := pr.IsPermissionValid(action, scope); err != nil {
+					errs <- err
+				}
+				if _, ok := pr.GetScopePrefixes(action); !ok {
+					errs <- fmt.Errorf("scope prefixes not found for %s", action)
+				}
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err)
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This makes the permission registry safe for concurrent role registration.

**Why do we need this feature?**

The IAM role sync and plugin loader can register permissions concurrently at startup, causing fatal concurrent map writes crashes and pod restarts.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
