### PR TITLE
fix: remove folders:create from HasEditPermissionInFolders check (#130090)

### DIFF
--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -147,7 +147,7 @@ func (hs *HTTPServer) setIndexViewData(c *contextmodel.ReqContext) (*dtos.IndexV
 	}
 
 	hasAccess := ac.HasAccess(hs.AccessControl, c)
-	hasEditPerm := hasAccess(ac.EvalAny(ac.EvalPermission(dashboards.ActionDashboardsCreate), ac.EvalPermission(folder.ActionFoldersCreate)))
+	hasEditPerm := hasAccess(ac.EvalPermission(dashboards.ActionDashboardsCreate))
 
 	data := dtos.IndexViewData{
 		User: &dtos.CurrentUser{


### PR DESCRIPTION
## What issue does this PR fix?

Closes #130090

## What does this PR do?

`HasEditPermissionInFolders` was computed as `dashboards:create` OR `folders:create`. Users with the "Folders Creator" role (`fixed:folders:creator`) have `folders:create` permission but NOT `dashboards:create` permission. This caused the frontend to show a "New Dashboard" button for these users, even though they cannot actually create dashboards.

**Fix**: Remove the `folders:create` check from `HasEditPermissionInFolders`. The field should only reflect whether the user has `dashboards:create` permission, since `folders:create` is about creating folders, not dashboards.

## Testing

- Users with "Folders Creator" role can still create folders
- Users with "Folders Creator" role no longer see the "New Dashboard" button
- Users with the Editor org role (who have both `dashboards:create` and `folders:create` through the Editor role) still see the "New Dashboard" button