### PR TITLE
Navigation: Highlight the current page in the pinned and starred sections

### DIFF
--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenu.test.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenu.test.tsx
@@ -424,6 +424,15 @@ describe('MegaMenu', () => {
         expect(current).toHaveLength(1);
       });
 
+      it('highlights the top-level Starred item on the starred dashboards page, not Dashboards', async () => {
+        renderMegaMenu({ initialRoute: '/dashboards?starred' });
+
+        const starred = await screen.findByRole('link', { name: 'Starred' });
+        expect(starred).toHaveAttribute('aria-current', 'page');
+        // The Dashboards section shares the /dashboards pathname but not the ?starred query.
+        expect(screen.getByRole('link', { name: 'Dashboards' })).not.toHaveAttribute('aria-current');
+      });
+
       it('makes Starred pinnable rather than hideable', async () => {
         const { user } = renderMegaMenu();
 

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenu.test.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenu.test.tsx
@@ -72,11 +72,13 @@ const renderMegaMenu = ({
   hiddenItemIds = [],
   bookmarkUrls = [],
   sectionOrder,
+  initialRoute,
 }: {
   navBarTree?: NavModelItem[];
   hiddenItemIds?: string[];
   bookmarkUrls?: string[];
   sectionOrder?: string[];
+  initialRoute?: string;
 } = {}) => {
   // Hidden state + section order are read from localStorage; pins come from preferences.
   window.localStorage.setItem(HIDDEN_ITEMS_STORAGE_KEY, JSON.stringify(hiddenItemIds));
@@ -85,7 +87,10 @@ const renderMegaMenu = ({
   }
   seedBookmarks(bookmarkUrls);
 
-  return render(<MegaMenu onClose={() => {}} />, { preloadedState: { navBarTree } });
+  return render(<MegaMenu onClose={() => {}} />, {
+    preloadedState: { navBarTree },
+    ...(initialRoute ? { historyOptions: { initialEntries: [initialRoute] } } : {}),
+  });
 };
 
 describe('MegaMenu', () => {
@@ -393,6 +398,30 @@ describe('MegaMenu', () => {
         const pinned = within(await screen.findByRole('list', { name: 'Pinned items' }));
         expect(await pinned.findByRole('link', { name: new RegExp(STARRED_DASHBOARD.name) })).toBeInTheDocument();
         expect(pinned.getByText('Starred')).toBeInTheDocument();
+      });
+
+      it('highlights a starred dashboard in the Starred section when viewing that dashboard', async () => {
+        // The current page's sectionNav points at the generic Dashboards section; the starred child is
+        // the only row carrying the dashboard url, matched via the location pathname.
+        renderMegaMenu({ initialRoute: STARRED_DASHBOARD.url });
+
+        // The Starred section auto-expands around its active child.
+        const starred = await screen.findByRole('link', { name: STARRED_DASHBOARD.name });
+        expect(starred).toHaveAttribute('aria-current', 'page');
+      });
+
+      it('highlights the pinned copy of the starred dashboard when Starred is pinned', async () => {
+        renderMegaMenu({ initialRoute: STARRED_DASHBOARD.url, bookmarkUrls: ['/dashboards?starred'] });
+
+        // The pinned breadcrumb for the current dashboard owns the highlight (pinned box wins).
+        const pinned = within(await screen.findByRole('list', { name: 'Pinned items' }));
+        expect(await pinned.findByRole('link', { name: new RegExp(STARRED_DASHBOARD.name) })).toHaveAttribute(
+          'aria-current',
+          'page'
+        );
+        // Exactly one row claims the current page — no double highlight with the nav copy.
+        const current = screen.getAllByRole('link').filter((link) => link.getAttribute('aria-current') === 'page');
+        expect(current).toHaveLength(1);
       });
 
       it('makes Starred pinnable rather than hideable', async () => {

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuPinnedItem.test.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuPinnedItem.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from 'test/test-utils';
 
-import { type NavModelItem } from '@grafana/data';
+import { createTheme, type NavModelItem } from '@grafana/data';
 
 import { MegaMenuPinnedItem } from './MegaMenuPinnedItem';
 import { type PinnedLine } from './utils';
@@ -18,21 +18,29 @@ const renderItem = (
 };
 
 describe('MegaMenuPinnedItem', () => {
-  it('does not claim aria-current when the active item is a different (nav) copy of the same route', () => {
-    // getActiveItem resolves the nav copy first, so a pinned item that's also in the nav receives an
-    // activeItem with the same url but a different reference. The nav row owns aria-current; marking
-    // it here too would put aria-current="page" on two links for the same route.
+  it('does not claim aria-current when the active item is a different copy of the same route', () => {
+    // aria-current is reference-based: a same-url but different-reference activeItem (e.g. the item
+    // resolved to a nav ancestor copy) must not put a second aria-current="page" on the route.
     renderItem({ text: 'Explore', url: '/explore', id: 'explore' });
 
     expect(screen.getByRole('link', { name: /Explore/ })).not.toHaveAttribute('aria-current');
   });
 
   it('claims aria-current when it is the canonical active item', () => {
-    // When the pinned copy itself is what getActiveItem returned (e.g. the item is hidden from the
-    // nav but still pinned), this is the only row for the route, so it owns aria-current.
+    // getActiveItem now resolves the pinned copy first, so when the current page is pinned this row is
+    // the canonical active item and owns aria-current (the nav copy, resolved by reference, does not).
     const item: NavModelItem = { text: 'Explore', url: '/explore', id: 'explore' };
     renderItem(item, item);
 
     expect(screen.getByRole('link', { name: /Explore/ })).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('highlights the row with the selected treatment whenever the current route matches', () => {
+    // The visual highlight is url-based, so the row reads as selected even when aria-current lands on a
+    // different copy — the pinned row shows the same active background the nav row uses.
+    renderItem({ text: 'Explore', url: '/explore', id: 'explore' });
+
+    const row = screen.getByRole('link', { name: /Explore/ }).closest('li')?.firstElementChild;
+    expect(row).toHaveStyle({ backgroundColor: createTheme().colors.action.selected });
   });
 });

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuPinnedItem.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuPinnedItem.tsx
@@ -42,10 +42,10 @@ export function MegaMenuPinnedItem({
   const { item, ancestors, icon } = line;
   const label = item.text;
 
-  // Highlight the row whenever it points at the current route, but only claim aria-current when this
-  // pinned copy is the canonical active item. getActiveItem resolves the nav copy first, so an item
-  // that's both pinned and still in the nav keeps aria-current on its nav row; without this guard
-  // both links would carry aria-current="page" for the same route.
+  // Highlight the row (nav-style selected treatment) whenever it points at the current route, but only
+  // claim aria-current when this pinned copy is the canonical active item. getActiveItem resolves the
+  // pinned copy first, so a pinned page's aria-current lands here and the nav row (reference equality)
+  // no longer claims it — keeping a single aria-current="page" for the route.
   const isActiveRoute = Boolean(item.url) && item.url === activeItem?.url;
   const isCurrentPage = item === activeItem;
   const nearestAncestor = ancestors.at(-1);
@@ -54,7 +54,7 @@ export function MegaMenuPinnedItem({
 
   return (
     <li ref={draggableProvided?.innerRef} className={styles.entry} {...draggableProvided?.draggableProps}>
-      <div className={styles.row}>
+      <div className={cx(styles.row, isActiveRoute && styles.rowActive)}>
         {draggableProvided && (
           // Every pinned row is draggable, so the handle owns the reserved column outright.
           <div
@@ -73,7 +73,7 @@ export function MegaMenuPinnedItem({
               item.onClick?.();
               onClick?.();
             }}
-            className={cx(styles.link, isActiveRoute && styles.active)}
+            className={styles.link}
             {...(isCurrentPage && { 'aria-current': 'page' })}
           >
             {/* The leading icon is the top-level parent section's icon, not the leaf's own. */}
@@ -122,6 +122,14 @@ const getStyles = (theme: GrafanaTheme2, visualRefreshEnabled: boolean) => ({
     minWidth: 0,
     '&:hover': {
       backgroundColor: theme.colors.action.hover,
+    },
+  }),
+  // Selected treatment matching the active nav row: accent tint under visual refresh, action.selected
+  // otherwise, with the label reading as selected rather than secondary.
+  rowActive: css({
+    backgroundColor: visualRefreshEnabled ? theme.colors.accent.transparent : theme.colors.action.selected,
+    'a, span': {
+      color: visualRefreshEnabled ? theme.colors.accent.text : theme.colors.text.primary,
     },
   }),
   link: css({
@@ -179,8 +187,5 @@ const getStyles = (theme: GrafanaTheme2, visualRefreshEnabled: boolean) => ({
   sep: css({
     color: theme.colors.text.disabled,
     flexShrink: 0,
-  }),
-  active: css({
-    color: theme.colors.text.primary,
   }),
 });

--- a/public/app/core/components/AppChrome/MegaMenu/hooks.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/hooks.ts
@@ -415,12 +415,13 @@ export const useNavCustomization = () => {
 
   // Resolve the active item, pinned box first so that a pinned copy (or a pinned Starred section's
   // child) wins over the nav row; reference equality then highlights whichever rendered row matches.
-  // Prefer a match on the current page's actual url — a starred dashboard/folder is the only leaf
-  // carrying that url, so this highlights it in the Starred section, where its sectionNav node (the
-  // generic parent section) never would. Fall back to the sectionNav-node match for everything else.
+  // Prefer a match on the current page's actual url (pathname + query) — a starred dashboard/folder is
+  // the only row carrying that url, and the Starred section's own `/dashboards?starred` link needs the
+  // query to win over Dashboards — so these highlight in the Starred section, where their sectionNav
+  // node (the generic parent section) never would. Fall back to the sectionNav-node match otherwise.
   const candidates = [...pinnedLeafItems, ...navItems];
   const activeItem =
-    findActivePageItem(candidates, location.pathname) ??
+    findActivePageItem(candidates, location.pathname + location.search) ??
     getActiveItem(candidates, state.sectionNav.node, location.pathname);
 
   // --- Edit session lifecycle ---

--- a/public/app/core/components/AppChrome/MegaMenu/hooks.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/hooks.ts
@@ -412,9 +412,10 @@ export const useNavCustomization = () => {
     }
   }
 
-  // Resolve the active item from the rendered nav first (the canonical copy), falling back to the
-  // pinned box. Reference equality then highlights whichever rendered row is the match.
-  const activeItem = getActiveItem([...navItems, ...pinnedLeafItems], state.sectionNav.node, location.pathname);
+  // Resolve the active item from the pinned box first so that, when the current page is pinned, the
+  // highlight and aria-current land on the pinned copy rather than the nav row. Non-pinned pages fall
+  // through to the nav copy. Reference equality then highlights whichever rendered row is the match.
+  const activeItem = getActiveItem([...pinnedLeafItems, ...navItems], state.sectionNav.node, location.pathname);
 
   // --- Edit session lifecycle ---
 

--- a/public/app/core/components/AppChrome/MegaMenu/hooks.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/hooks.ts
@@ -23,6 +23,7 @@ import { contextSrv } from '../../../services/context_srv';
 import { getNavExperimentPayload, reportNavExperimentViewOnce, setNavExperimentVariant } from './navExperiment';
 import {
   enrichWithInteractionTracking,
+  findActivePageItem,
   findByUrl,
   getActiveItem,
   getPinnedEntries,
@@ -412,10 +413,15 @@ export const useNavCustomization = () => {
     }
   }
 
-  // Resolve the active item from the pinned box first so that, when the current page is pinned, the
-  // highlight and aria-current land on the pinned copy rather than the nav row. Non-pinned pages fall
-  // through to the nav copy. Reference equality then highlights whichever rendered row is the match.
-  const activeItem = getActiveItem([...pinnedLeafItems, ...navItems], state.sectionNav.node, location.pathname);
+  // Resolve the active item, pinned box first so that a pinned copy (or a pinned Starred section's
+  // child) wins over the nav row; reference equality then highlights whichever rendered row matches.
+  // Prefer a match on the current page's actual url — a starred dashboard/folder is the only leaf
+  // carrying that url, so this highlights it in the Starred section, where its sectionNav node (the
+  // generic parent section) never would. Fall back to the sectionNav-node match for everything else.
+  const candidates = [...pinnedLeafItems, ...navItems];
+  const activeItem =
+    findActivePageItem(candidates, location.pathname) ??
+    getActiveItem(candidates, state.sectionNav.node, location.pathname);
 
   // --- Edit session lifecycle ---
 

--- a/public/app/core/components/AppChrome/MegaMenu/utils.test.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/utils.test.ts
@@ -284,6 +284,12 @@ describe('findActivePageItem', () => {
         { id: 'starred/def', text: 'A folder', url: '/dashboards/f/def/?orgId=1' },
       ],
     },
+    {
+      id: 'create',
+      text: 'Create',
+      url: '/create',
+      children: [{ id: 'dashboards/import', text: 'Import dashboard', url: '/dashboard/import', isCreateAction: true }],
+    },
   ];
 
   it('matches a starred dashboard by uid despite a slug on the pathname', () => {
@@ -303,6 +309,12 @@ describe('findActivePageItem', () => {
     // The query keeps /dashboards?starred distinct from /dashboards, so the Starred section — not
     // Dashboards — is returned.
     expect(findActivePageItem(tree, '/dashboards?starred')?.id).toBe('starred');
+  });
+
+  it('ignores create actions so the page falls back to its parent section (e.g. import → Dashboards)', () => {
+    // The Import create action carries /dashboard/import but is dropped from the rendered menu, so it
+    // must not claim the highlight — leaving the sectionNav fallback to resolve the page to Dashboards.
+    expect(findActivePageItem(tree, '/dashboard/import')).toBeUndefined();
   });
 
   it('returns undefined when nothing carries the current page url', () => {

--- a/public/app/core/components/AppChrome/MegaMenu/utils.test.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/utils.test.ts
@@ -7,6 +7,7 @@ import { ContextSrv, setContextSrv } from 'app/core/services/context_srv';
 import {
   getEnrichedHelpItem,
   getActiveItem,
+  findActivePageItem,
   findByUrl,
   getPinnedEntries,
   moveItem,
@@ -261,6 +262,45 @@ describe('findByUrl', () => {
 
   it('returns null if no item found', () => {
     expect(findByUrl(mockNavTree, '/no-item')).toBeNull();
+  });
+});
+
+describe('findActivePageItem', () => {
+  // A Starred section whose children carry the real page urls (a slug on the dashboard, an ?orgId on
+  // the folder) — the shapes the starred sync produces.
+  const tree: NavModelItem[] = [
+    {
+      id: 'dashboards',
+      text: 'Dashboards',
+      url: '/dashboards',
+      children: [{ id: 'dashboards/browse', text: 'Browse', url: '/dashboards' }],
+    },
+    {
+      id: 'starred',
+      text: 'Starred',
+      url: '/dashboards?starred',
+      children: [
+        { id: 'starred/abc', text: 'A dashboard', url: '/d/abc' },
+        { id: 'starred/def', text: 'A folder', url: '/dashboards/f/def/?orgId=1' },
+      ],
+    },
+  ];
+
+  it('matches a starred dashboard by uid despite a slug on the pathname', () => {
+    expect(findActivePageItem(tree, '/d/abc/my-slug')?.id).toBe('starred/abc');
+  });
+
+  it('matches a starred folder by uid despite a trailing slash and query param', () => {
+    expect(findActivePageItem(tree, '/dashboards/f/def/folder-slug')?.id).toBe('starred/def');
+  });
+
+  it('skips section headers (items with children) so the specific leaf is matched, not its parent', () => {
+    // Both the Dashboards section and its Browse child carry /dashboards; the leaf is returned.
+    expect(findActivePageItem(tree, '/dashboards')?.id).toBe('dashboards/browse');
+  });
+
+  it('returns undefined when no leaf carries the current page url', () => {
+    expect(findActivePageItem(tree, '/d/not-starred')).toBeUndefined();
   });
 });
 

--- a/public/app/core/components/AppChrome/MegaMenu/utils.test.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/utils.test.ts
@@ -294,12 +294,18 @@ describe('findActivePageItem', () => {
     expect(findActivePageItem(tree, '/dashboards/f/def/folder-slug')?.id).toBe('starred/def');
   });
 
-  it('skips section headers (items with children) so the specific leaf is matched, not its parent', () => {
-    // Both the Dashboards section and its Browse child carry /dashboards; the leaf is returned.
+  it('prefers a child over its parent section when both carry the url', () => {
+    // Both the Dashboards section and its Browse child carry /dashboards; the child is returned.
     expect(findActivePageItem(tree, '/dashboards')?.id).toBe('dashboards/browse');
   });
 
-  it('returns undefined when no leaf carries the current page url', () => {
+  it('matches a section on its own url when no child does (top-level Starred for ?starred)', () => {
+    // The query keeps /dashboards?starred distinct from /dashboards, so the Starred section — not
+    // Dashboards — is returned.
+    expect(findActivePageItem(tree, '/dashboards?starred')?.id).toBe('starred');
+  });
+
+  it('returns undefined when nothing carries the current page url', () => {
     expect(findActivePageItem(tree, '/d/not-starred')).toBeUndefined();
   });
 });

--- a/public/app/core/components/AppChrome/MegaMenu/utils.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/utils.ts
@@ -164,6 +164,10 @@ const toPageKey = (url?: string): string | undefined => {
  * url. Children are matched before their parent, so `/dashboards` resolves to the Browse child rather
  * than the Dashboards section, while a section still matches on its own url when no child does. Returns
  * the matched element by reference, so downstream reference-equality highlighting works.
+ *
+ * Create actions (e.g. "Import dashboard" → `/dashboard/import`) are skipped: they're dropped from the
+ * rendered menu, so matching one would claim the highlight for a row that isn't shown and suppress the
+ * sectionNav fallback (which correctly resolves such a page to its parent section, e.g. Dashboards).
  */
 export const findActivePageItem = (nodes: NavModelItem[], currentUrl: string): NavModelItem | undefined => {
   const target = toPageKey(currentUrl);
@@ -175,7 +179,7 @@ export const findActivePageItem = (nodes: NavModelItem[], currentUrl: string): N
     if (childMatch) {
       return childMatch;
     }
-    if (toPageKey(item.url) === target) {
+    if (!item.isCreateAction && toPageKey(item.url) === target) {
       return item;
     }
   }

--- a/public/app/core/components/AppChrome/MegaMenu/utils.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/utils.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-import { type NavModelItem } from '@grafana/data';
+import { locationUtil, type NavModelItem } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, reportInteraction } from '@grafana/runtime';
 import { MEGA_MENU_TOGGLE_ID } from 'app/core/constants';
@@ -135,6 +135,51 @@ export const getActiveItem = (
     return getActiveItem(navTree, parentItem);
   }
 
+  return undefined;
+};
+
+// Reduce a nav url or the browser pathname to a stable key for "is this the page I'm on?". Strips the
+// app sub-path, query string and trailing slash, and collapses dashboard/folder urls to their uid —
+// a starred entry's url carries a slug and/or `?orgId=` that the browser location does not.
+const toPageKey = (url?: string): string | undefined => {
+  if (!url) {
+    return undefined;
+  }
+  const path = locationUtil.stripBaseFromUrl(url).split('?')[0].replace(/\/+$/, '');
+  const [, first, second, third] = path.split('/');
+  if (first === 'd' && second) {
+    return `/d/${second}`;
+  }
+  if (first === 'dashboards' && second === 'f' && third) {
+    return `/dashboards/f/${third}`;
+  }
+  return path || '/';
+};
+
+/**
+ * Find the leaf nav item whose url is the page the user is currently on (by pathname). This is how a
+ * starred dashboard/folder highlights in the Starred section: its sectionNav node points at the
+ * generic parent section, but its own row is the only leaf carrying the page's url. Section headers
+ * (items with children) are skipped so the specific page — not its parent — is highlighted. Returns
+ * the matched element by reference, so downstream reference-equality highlighting works.
+ */
+export const findActivePageItem = (nodes: NavModelItem[], pathname: string): NavModelItem | undefined => {
+  const target = toPageKey(pathname);
+  if (!target) {
+    return undefined;
+  }
+  for (const item of nodes) {
+    if (!item.children?.length) {
+      if (toPageKey(item.url) === target) {
+        return item;
+      }
+      continue;
+    }
+    const found = findActivePageItem(item.children, pathname);
+    if (found) {
+      return found;
+    }
+  }
   return undefined;
 };
 

--- a/public/app/core/components/AppChrome/MegaMenu/utils.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/utils.ts
@@ -138,46 +138,45 @@ export const getActiveItem = (
   return undefined;
 };
 
-// Reduce a nav url or the browser pathname to a stable key for "is this the page I'm on?". Strips the
-// app sub-path, query string and trailing slash, and collapses dashboard/folder urls to their uid —
-// a starred entry's url carries a slug and/or `?orgId=` that the browser location does not.
+// Reduce a nav url or the browser url to a stable key for "is this the page I'm on?". Strips the app
+// sub-path and trailing slash, and collapses dashboard/folder urls to their uid (their entry carries a
+// slug and/or `?orgId=` the browser location does not). The query string is otherwise kept, so the
+// Starred section's `/dashboards?starred` stays distinct from the Dashboards section's `/dashboards`.
 const toPageKey = (url?: string): string | undefined => {
   if (!url) {
     return undefined;
   }
-  const path = locationUtil.stripBaseFromUrl(url).split('?')[0].replace(/\/+$/, '');
-  const [, first, second, third] = path.split('/');
+  const stripped = locationUtil.stripBaseFromUrl(url);
+  const [, first, second, third] = stripped.split('?')[0].split('/');
   if (first === 'd' && second) {
     return `/d/${second}`;
   }
   if (first === 'dashboards' && second === 'f' && third) {
     return `/dashboards/f/${third}`;
   }
-  return path || '/';
+  return stripped.replace(/\/+$/, '') || '/';
 };
 
 /**
- * Find the leaf nav item whose url is the page the user is currently on (by pathname). This is how a
- * starred dashboard/folder highlights in the Starred section: its sectionNav node points at the
- * generic parent section, but its own row is the only leaf carrying the page's url. Section headers
- * (items with children) are skipped so the specific page — not its parent — is highlighted. Returns
+ * Find the nav item whose url is the page the user is currently on. This is how a starred item
+ * highlights in the Starred section: the page's sectionNav node points at the generic parent section,
+ * but a starred row (or the Starred section's own `/dashboards?starred` link) is what carries the real
+ * url. Children are matched before their parent, so `/dashboards` resolves to the Browse child rather
+ * than the Dashboards section, while a section still matches on its own url when no child does. Returns
  * the matched element by reference, so downstream reference-equality highlighting works.
  */
-export const findActivePageItem = (nodes: NavModelItem[], pathname: string): NavModelItem | undefined => {
-  const target = toPageKey(pathname);
+export const findActivePageItem = (nodes: NavModelItem[], currentUrl: string): NavModelItem | undefined => {
+  const target = toPageKey(currentUrl);
   if (!target) {
     return undefined;
   }
   for (const item of nodes) {
-    if (!item.children?.length) {
-      if (toPageKey(item.url) === target) {
-        return item;
-      }
-      continue;
+    const childMatch = item.children?.length ? findActivePageItem(item.children, currentUrl) : undefined;
+    if (childMatch) {
+      return childMatch;
     }
-    const found = findActivePageItem(item.children, pathname);
-    if (found) {
-      return found;
+    if (toPageKey(item.url) === target) {
+      return item;
     }
   }
   return undefined;


### PR DESCRIPTION
## What

Makes the mega menu highlight the **current page in the Pinned / Starred sections** rather than (only) the main nav:

- **On a pinned page** → the highlight and `aria-current` move to the pinned copy in the Pinned box; the main-nav row is no longer highlighted. The active pinned row gets the same selected-row treatment the nav uses (accent tint under visual refresh, `action.selected` otherwise).
- **On a starred dashboard/folder** → it highlights in the **Starred section**. Its `sectionNav` node points at the generic parent section (`dashboards/browse`, `manage-folder`), so this matches on the page's real url instead. Works whether or not the Starred section is pinned.
- **On the starred dashboards page (`/dashboards?starred`)** → the top-level **Starred** item highlights, not Dashboards.

Mechanically: the active-item resolution now prefers a match on the current page's actual url (`pathname + query`) via a new `findActivePageItem`, before falling back to the existing `sectionNav`-node match. Candidates are pinned-first, so a pinned copy wins over the nav copy. `findActivePageItem` normalises dashboard/folder urls to their uid (their entry carries a slug and/or `?orgId=` the browser location doesn't) but keeps other query strings, so `/dashboards?starred` stays distinct from `/dashboards`; it prefers a child over its parent section, but a section still matches on its own url.

## Why

When you pin or star something you use often, the current-page highlight belonged on that shortcut in the Pinned/Starred section — but it always landed on the nav row (or, for starred pages, on the generic Dashboards section), so the shortcut you were actually using never lit up.

## Who is this for?

Anyone using the customisable mega menu (`grafana.customizableMegaMenu`). No behaviour change when the flag is off.
