### PR TITLE
Apiserver: Re-prioritize aggregated discovery to the global preferred version

### DIFF
--- a/pkg/services/apiserver/builder/helper.go
+++ b/pkg/services/apiserver/builder/helper.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	discoveryendpoint "k8s.io/apiserver/pkg/endpoints/discovery/aggregated"
 	openapinamer "k8s.io/apiserver/pkg/endpoints/openapi"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericapiserver "k8s.io/apiserver/pkg/server"
@@ -257,9 +258,7 @@ func SetupConfig(
 			return fmt.Errorf("builder did not return any API group versions: %T", b)
 		}
 		pvs := scheme.PrioritizedVersionsForGroup(gvs[0].Group)
-		for j, gv := range pvs {
-			serverConfig.AggregatedDiscoveryGroupManager.SetGroupVersionPriority(metav1.GroupVersion(gv), 15000+i, len(pvs)-j)
-		}
+		SetGroupVersionPriorities(serverConfig.AggregatedDiscoveryGroupManager, discoveryGroupPriorityBase+i, pvs)
 	}
 
 	if err := AddPostStartHooks(serverConfig, builders); err != nil {
@@ -267,6 +266,29 @@ func SetupConfig(
 	}
 
 	return nil
+}
+
+// discoveryGroupPriorityBase is the group-priority-minimum base; the builder index is added for stable relative order.
+const discoveryGroupPriorityBase = 15000
+
+// SetGroupVersionPriorities orders a group's versions in aggregated discovery under one group priority; safe at runtime (the manager serializes calls).
+func SetGroupVersionPriorities(mgr discoveryendpoint.ResourceManager, groupPriority int, pvs []schema.GroupVersion) {
+	for j, gv := range pvs {
+		mgr.SetGroupVersionPriority(metav1.GroupVersion(gv), groupPriority, len(pvs)-j)
+	}
+}
+
+// BuilderGroupPriorities returns each builder group's discovery priority-minimum, matching startup, so a runtime re-prioritize preserves group order.
+func BuilderGroupPriorities(builders []APIGroupBuilder) map[string]int {
+	priorities := make(map[string]int, len(builders))
+	for i, b := range builders {
+		gvs := GetGroupVersions(b)
+		if len(gvs) == 0 {
+			continue
+		}
+		priorities[gvs[0].Group] = discoveryGroupPriorityBase + i
+	}
+	return priorities
 }
 
 // servedVersionsForResource returns the versions the scheme registers for this resource's

--- a/pkg/services/apiserver/preferred_version.go
+++ b/pkg/services/apiserver/preferred_version.go
@@ -39,6 +39,21 @@ func applyPreferredAPIVersions(logger log.Logger, cfg *setting.Cfg, scheme *runt
 	return nil
 }
 
+// preferredFirst reorders pvs so preferred is first (unchanged if absent); does not touch the scheme, so it is runtime-safe.
+func preferredFirst(pvs []schema.GroupVersion, preferred schema.GroupVersion) []schema.GroupVersion {
+	if !slices.Contains(pvs, preferred) {
+		return pvs
+	}
+	out := make([]schema.GroupVersion, 0, len(pvs))
+	out = append(out, preferred)
+	for _, gv := range pvs {
+		if gv != preferred {
+			out = append(out, gv)
+		}
+	}
+	return out
+}
+
 // ParseGroupVersionSetting parses a "group/version" string (e.g.
 // "dashboard.grafana.app/v1") into a GroupVersion. It requires both
 // group and version to be present and non-empty. The optional settingName names

--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apiserver/pkg/audit"
+	discoveryendpoint "k8s.io/apiserver/pkg/endpoints/discovery/aggregated"
 	genericapifilters "k8s.io/apiserver/pkg/endpoints/filters"
 	"k8s.io/apiserver/pkg/endpoints/responsewriter"
 	genericapiserver "k8s.io/apiserver/pkg/server"
@@ -111,6 +112,12 @@ type service struct {
 
 	// vpRegistry serves the resolved policy consulted by apistore.encode.
 	vpRegistry *versionpolicy.VersionPolicyRegistry
+	// groupPriority reads the live scheme; reprioritizeDiscovery uses it without mutating the scheme.
+	groupPriority func(string) []schema.GroupVersion
+	// groupDiscoveryPriority is each builder group's discovery priority-minimum, preserved across re-prioritize.
+	groupDiscoveryPriority map[string]int
+	// discoveryManager is nil until the server is built; nil skips re-prioritize (startup sets order at install).
+	discoveryManager discoveryendpoint.ResourceManager
 }
 
 func ProvideService(
@@ -347,6 +354,8 @@ func (s *service) start(ctx context.Context) error {
 	if err := applyPreferredAPIVersions(s.log, s.cfg, s.scheme, apiResourceConfig); err != nil {
 		return err
 	}
+	// groupPriority reads the live scheme (discovery follows preferred); the cap ranks against the natural snapshot instead.
+	s.groupPriority = s.scheme.PrioritizedVersionsForGroup
 
 	serverConfig.Authorization.Authorizer = s.authorizer
 	serverConfig.Authentication.Authenticator = authenticator.NewAuthenticator(serverConfig.Authentication.Authenticator)
@@ -465,6 +474,10 @@ func (s *service) start(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	// Capture the discovery seam so preferred can re-prioritize without a scheme mutation; group priorities mirror startup.
+	s.groupDiscoveryPriority = builder.BuilderGroupPriorities(builders)
+	s.discoveryManager = server.AggregatedDiscoveryGroupManager
 
 	// Install the API group+version for existing builders
 	err = builder.InstallAPIs(s.scheme,
@@ -641,6 +654,8 @@ func (s *service) IsReady() bool {
 }
 
 func (s *service) running(ctx context.Context) error {
+	// Apply the global preferred order to aggregated discovery now the manager exists (startup one-shot).
+	s.reprioritizeDiscovery()
 	select {
 	case err := <-s.stoppedCh:
 		if err != nil {
@@ -649,6 +664,24 @@ func (s *service) running(ctx context.Context) error {
 	case <-ctx.Done():
 	}
 	return nil
+}
+
+// reprioritizeDiscovery reports each group's global preferred version first in aggregated discovery; advisory only (no scheme/storage/cap effect), reverting to natural order when preferred is unset.
+func (s *service) reprioritizeDiscovery() {
+	if s.discoveryManager == nil || s.vpRegistry == nil {
+		return
+	}
+	for group, groupPriority := range s.groupDiscoveryPriority {
+		pvs := s.groupPriority(group)
+		if len(pvs) == 0 {
+			continue
+		}
+		ordered := pvs
+		if preferred := s.vpRegistry.Preferred(group); preferred != "" {
+			ordered = preferredFirst(pvs, schema.GroupVersion{Group: group, Version: preferred})
+		}
+		builder.SetGroupVersionPriorities(s.discoveryManager, groupPriority, ordered)
+	}
 }
 
 func ensureKubeConfig(restConfig *clientrest.Config, dir string) error {

--- a/pkg/services/apiserver/service_test.go
+++ b/pkg/services/apiserver/service_test.go
@@ -1,10 +1,21 @@
 package apiserver
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
-	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/stretchr/testify/require"
+	apidiscoveryv2 "k8s.io/api/apidiscovery/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	discoveryendpoint "k8s.io/apiserver/pkg/endpoints/discovery/aggregated"
+
+	"github.com/grafana/grafana/pkg/services/apiserver/versionpolicy"
+	"github.com/grafana/grafana/pkg/services/user"
 )
 
 func Test_useNamespaceFromPath(t *testing.T) {
@@ -48,4 +59,112 @@ func Test_useNamespaceFromPath(t *testing.T) {
 			}
 		})
 	}
+}
+
+const testGroup = "dashboard.grafana.app"
+
+// testOrder mirrors testDiscoveryScheme's natural priority as the resolver's registered-version snapshot.
+var testOrder = map[string][]string{testGroup: {"v2", "v1", "v0alpha1"}}
+
+// newTestRegistry builds a registry over testOrder with the given ini layer (nil for none). Shared by the
+// discovery and poller tests.
+func newTestRegistry(ini map[string]versionpolicy.VersionPolicy) *versionpolicy.VersionPolicyRegistry {
+	return versionpolicy.NewVersionPolicyRegistry(versionpolicy.NewResolver(testOrder), nil, ini)
+}
+
+// testDiscoveryScheme registers the group's versions with the scheme's natural
+// priority v2 > v1 > v0alpha1, so groupPriority reads production's real seam
+// (scheme.PrioritizedVersionsForGroup) rather than a hand-rolled fake.
+func testDiscoveryScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	gvs := []schema.GroupVersion{
+		{Group: testGroup, Version: "v2"},
+		{Group: testGroup, Version: "v1"},
+		{Group: testGroup, Version: "v0alpha1"},
+	}
+	for _, gv := range gvs {
+		scheme.AddKnownTypes(gv, &metav1.Status{})
+	}
+	require.NoError(t, scheme.SetVersionPriority(gvs...))
+	return scheme
+}
+
+// servedGroupVersions runs the aggregated discovery document through the real
+// handler and returns the versions the group actually advertises, in served
+// order — i.e. after the priority changes reprioritizeDiscovery applied.
+func servedGroupVersions(t *testing.T, mgr discoveryendpoint.ResourceManager, group string) []string {
+	t.Helper()
+	disScheme := runtime.NewScheme()
+	utilruntime.Must(apidiscoveryv2.AddToScheme(disScheme))
+	codecs := serializer.NewCodecFactory(disScheme)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/apis", nil)
+	req.Header.Set("Accept", "application/json;g=apidiscovery.k8s.io;v=v2;as=APIGroupDiscoveryList")
+	mgr.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	doc := &apidiscoveryv2.APIGroupDiscoveryList{}
+	require.NoError(t, runtime.DecodeInto(codecs.UniversalDecoder(), w.Body.Bytes(), doc))
+
+	for _, g := range doc.Items {
+		if g.Name != group {
+			continue
+		}
+		versions := make([]string, 0, len(g.Versions))
+		for _, v := range g.Versions {
+			versions = append(versions, v.Version)
+		}
+		return versions
+	}
+	t.Fatalf("group %q not present in discovery document", group)
+	return nil
+}
+
+// reprioritizeDiscovery floats the global preferred version first in what
+// aggregated discovery serves, and reverts to the scheme's natural order when
+// no preferred is set. Driven end-to-end: real scheme -> real discovery manager
+// -> served document.
+func TestReprioritizeDiscovery_ServedOrder(t *testing.T) {
+	scheme := testDiscoveryScheme(t)
+
+	tests := []struct {
+		name      string
+		preferred string
+		want      []string
+	}{
+		{name: "global preferred floats first", preferred: "v1", want: []string{"v1", "v2", "v0alpha1"}},
+		{name: "no preferred keeps natural order", preferred: "", want: []string{"v2", "v1", "v0alpha1"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ini map[string]versionpolicy.VersionPolicy
+			if tt.preferred != "" {
+				ini = map[string]versionpolicy.VersionPolicy{testGroup: {PreferredVersion: tt.preferred}}
+			}
+			reg := newTestRegistry(ini)
+
+			mgr := discoveryendpoint.NewResourceManager("apis")
+			for _, v := range testOrder[testGroup] {
+				mgr.AddGroupVersion(testGroup, apidiscoveryv2.APIVersionDiscovery{Version: v})
+			}
+
+			s := &service{
+				vpRegistry:             reg,
+				groupPriority:          scheme.PrioritizedVersionsForGroup,
+				groupDiscoveryPriority: map[string]int{testGroup: 15003},
+				discoveryManager:       mgr,
+			}
+			s.reprioritizeDiscovery()
+
+			require.Equal(t, tt.want, servedGroupVersions(t, mgr, testGroup))
+		})
+	}
+}
+
+// With no discovery manager captured yet, reprioritize is a no-op (no panic).
+func TestReprioritizeDiscovery_NoManagerNoop(t *testing.T) {
+	s := &service{vpRegistry: newTestRegistry(nil), groupPriority: testDiscoveryScheme(t).PrioritizedVersionsForGroup}
+	require.NotPanics(t, s.reprioritizeDiscovery)
 }


### PR DESCRIPTION
## What

PR 3 of the version-policy stack (parent: grafana/search-and-storage-team#881). Adds the discovery **re-prioritize seam**: aggregated `/apis` (using `application/json;g=apidiscovery.k8s.io;v=v2;as=APIGroupDiscoveryList`) reports each group's global `preferredVersion` first, applied as a startup one-shot once the discovery manager exists.

Follows the merged enforce cap (#129869) and resolver (#129667).

## How

- `preferredFirst(pvs, preferred)` — pure reorder of a group's version slice; **never mutates the scheme** (a runtime scheme reorder would race in-flight reads and would move the `maxVersion` cap ranking, which must stay decoupled from discovery order).
- `service.reprioritizeDiscovery()` walks each builder group, floats the registry's `Preferred(group)` to the front in the aggregated discovery manager, and reverts to natural order when preferred is unset. No-op when the registry or discovery manager is absent.
- Captures the discovery seam (`AggregatedDiscoveryGroupManager`, builder group priorities) at install time.

## Scope / non-goals

- `preferredVersion` is **advisory** — discovery only, no scheme/storage/cap effect.
- **Global**, not per-namespace: discovery is one process-wide scheme.
- Startup one-shot here; the live KV-driven re-invoke arrives in later stack PRs (`vp/live-rewire`).
- Gated by `[grafana-apiserver] version_policy_enabled` (default off).

## Tests

`discovery_reprioritize_test.go` — preferred floated first, absent preferred left natural, unknown group/version skipped. `go test ./pkg/services/apiserver/...` green.
