### PR TITLE
Alerting: Track Assistant investigation funnel from instance drawer

### DIFF
--- a/public/app/features/alerting/unified/triage/instance-details/StartInvestigationButton.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/StartInvestigationButton.tsx
@@ -94,6 +94,7 @@ export function StartInvestigationButton({
           href={view.href}
           target="_blank"
           rel="noopener noreferrer"
+          onClick={view.onOpenReport}
         >
           <Trans i18nKey="alerting.triage.instance-details-drawer.open-investigation">
             Open full investigation report
@@ -143,6 +144,7 @@ export function StartInvestigationButton({
             href={view.href}
             target="_blank"
             rel="noopener noreferrer"
+            onClick={view.onOpenReport}
           >
             <Trans i18nKey="alerting.triage.instance-details-drawer.open-failed-investigation">
               Open failed report
@@ -172,6 +174,7 @@ export function StartInvestigationButton({
             href={view.href}
             target="_blank"
             rel="noopener noreferrer"
+            onClick={view.onWatchLive}
           >
             <Trans i18nKey="alerting.triage.instance-details-drawer.investigation-watch-live">
               Watch live in assistant workspace
@@ -197,6 +200,7 @@ export function StartInvestigationButton({
             href={view.href}
             target="_blank"
             rel="noopener noreferrer"
+            onClick={view.onWatchLive}
           >
             <Trans i18nKey="alerting.triage.instance-details-drawer.investigation-watch-live">
               Watch live in assistant workspace

--- a/public/app/features/alerting/unified/triage/instance-details/assistantInvestigationTracking.ts
+++ b/public/app/features/alerting/unified/triage/instance-details/assistantInvestigationTracking.ts
@@ -3,7 +3,7 @@ import { reportInteraction } from '@grafana/runtime';
 import type { StartInvestigationViewModel } from './startInvestigationViewModel';
 
 /** Visible (non-hidden) UI statuses for the instance-drawer investigation control. */
-export type AssistantInvestigationUiStatus = Exclude<StartInvestigationViewModel['status'], 'hidden'>;
+type AssistantInvestigationUiStatus = Exclude<StartInvestigationViewModel['status'], 'hidden'>;
 
 type StartFromStatus = Extract<AssistantInvestigationUiStatus, 'idle' | 'startError' | 'reportFailed'>;
 type OpenReportFromStatus = Extract<AssistantInvestigationUiStatus, 'completed' | 'reportFailed'>;

--- a/public/app/features/alerting/unified/triage/instance-details/assistantInvestigationTracking.ts
+++ b/public/app/features/alerting/unified/triage/instance-details/assistantInvestigationTracking.ts
@@ -1,0 +1,53 @@
+import { reportInteraction } from '@grafana/runtime';
+
+import type { StartInvestigationViewModel } from './startInvestigationViewModel';
+
+/** Visible (non-hidden) UI statuses for the instance-drawer investigation control. */
+export type AssistantInvestigationUiStatus = Exclude<StartInvestigationViewModel['status'], 'hidden'>;
+
+type StartFromStatus = Extract<AssistantInvestigationUiStatus, 'idle' | 'startError' | 'reportFailed'>;
+type OpenReportFromStatus = Extract<AssistantInvestigationUiStatus, 'completed' | 'reportFailed'>;
+type WatchLiveFromStatus = Extract<AssistantInvestigationUiStatus, 'running' | 'pollError'>;
+type RetryFromStatus = Extract<AssistantInvestigationUiStatus, 'lookupError' | 'pollError'>;
+
+/** Fired once when the drawer investigation control becomes available (flags + plugin). */
+export function trackAssistantInvestigationImpression() {
+  reportInteraction('grafana_alerting_assistant_investigation_impression');
+}
+
+export function trackAssistantInvestigationStartClicked(payload: { from_status: StartFromStatus }) {
+  reportInteraction('grafana_alerting_assistant_investigation_start_clicked', payload);
+}
+
+export function trackAssistantInvestigationStartSucceeded(payload: {
+  from_status: StartFromStatus;
+  investigation_id: string;
+}) {
+  reportInteraction('grafana_alerting_assistant_investigation_start_succeeded', payload);
+}
+
+export function trackAssistantInvestigationStartFailed(payload: { from_status: StartFromStatus }) {
+  reportInteraction('grafana_alerting_assistant_investigation_start_failed', payload);
+}
+
+export function trackAssistantInvestigationOpenReport(payload: {
+  from_status: OpenReportFromStatus;
+  investigation_id: string;
+}) {
+  reportInteraction('grafana_alerting_assistant_investigation_open_report', payload);
+}
+
+export function trackAssistantInvestigationWatchLive(payload: {
+  from_status: WatchLiveFromStatus;
+  investigation_id: string;
+}) {
+  reportInteraction('grafana_alerting_assistant_investigation_watch_live', payload);
+}
+
+/** Recovery actions that are not a fresh start (lookup / poll only). */
+export function trackAssistantInvestigationRetry(payload: {
+  retry_type: 'lookup' | 'poll';
+  from_status: RetryFromStatus;
+}) {
+  reportInteraction('grafana_alerting_assistant_investigation_retry', payload);
+}

--- a/public/app/features/alerting/unified/triage/instance-details/startInvestigationViewModel.ts
+++ b/public/app/features/alerting/unified/triage/instance-details/startInvestigationViewModel.ts
@@ -1,0 +1,28 @@
+/**
+ * View model for {@link StartInvestigationButton}.
+ * The hook owns plugin/feature gating, request identity, RTK Query calls, and polling.
+ */
+export type StartInvestigationViewModel =
+  | { status: 'hidden' }
+  | { status: 'waitingIdentity' }
+  | { status: 'lookingUp' }
+  | { status: 'lookupError'; onRetry: () => void }
+  | { status: 'completed'; href: string; investigationId: string; onOpenReport: () => void }
+  | { status: 'starting' }
+  | { status: 'startError'; onStart: () => void }
+  | {
+      status: 'reportFailed';
+      href: string;
+      investigationId: string;
+      onStart: () => void;
+      onOpenReport: () => void;
+    }
+  | {
+      status: 'pollError';
+      href: string;
+      investigationId: string;
+      onRetry: () => void;
+      onWatchLive: () => void;
+    }
+  | { status: 'running'; href: string; investigationId: string; onWatchLive: () => void }
+  | { status: 'idle'; onStart: () => void };

--- a/public/app/features/alerting/unified/triage/instance-details/useStartInvestigation.ts
+++ b/public/app/features/alerting/unified/triage/instance-details/useStartInvestigation.ts
@@ -1,5 +1,5 @@
 import { skipToken } from '@reduxjs/toolkit/query';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { type Labels } from '@grafana/data';
 import { useDispatch } from 'app/types/store';
@@ -11,6 +11,15 @@ import { SupportedPlugin } from '../../types/pluginBridges';
 import { createAbsoluteUrl } from '../../utils/url';
 
 import {
+  trackAssistantInvestigationImpression,
+  trackAssistantInvestigationOpenReport,
+  trackAssistantInvestigationRetry,
+  trackAssistantInvestigationStartClicked,
+  trackAssistantInvestigationStartFailed,
+  trackAssistantInvestigationStartSucceeded,
+  trackAssistantInvestigationWatchLive,
+} from './assistantInvestigationTracking';
+import {
   ASSISTANT_INVESTIGATION_POLL_INTERVAL_MS,
   buildFromAlertRequest,
   getAssistantInvestigationUrl,
@@ -20,6 +29,7 @@ import {
   selectAssistantInvestigation,
   useManualAssistantInvestigationEnabled,
 } from './startInvestigationFromAlert';
+import type { StartInvestigationViewModel } from './startInvestigationViewModel';
 
 export interface UseStartInvestigationArgs {
   instanceLabels: Labels;
@@ -31,23 +41,6 @@ export interface UseStartInvestigationArgs {
   /** ISO timestamp when this firing episode ended; used when the alert is resolved. */
   alertEndsAt?: string;
 }
-
-/**
- * View model for {@link StartInvestigationButton}.
- * The hook owns plugin/feature gating, request identity, RTK Query calls, and polling.
- */
-export type StartInvestigationViewModel =
-  | { status: 'hidden' }
-  | { status: 'waitingIdentity' }
-  | { status: 'lookingUp' }
-  | { status: 'lookupError'; onRetry: () => void }
-  | { status: 'completed'; href: string }
-  | { status: 'starting' }
-  | { status: 'startError'; onStart: () => void }
-  | { status: 'reportFailed'; href: string; onStart: () => void }
-  | { status: 'pollError'; href: string; onRetry: () => void }
-  | { status: 'running'; href: string }
-  | { status: 'idle'; onStart: () => void };
 
 /**
  * Owns Assistant investigation state for a firing alert instance: lookup, start,
@@ -64,6 +57,7 @@ export function useStartInvestigation({
   const dispatch = useDispatch();
   const featureEnabled = useManualAssistantInvestigationEnabled();
   const { installed } = usePluginBridge(SupportedPlugin.Assistant);
+  const impressionTracked = useRef(false);
 
   // Wait for rule identity when the instance has no labels, otherwise early
   // Start/lookup can hash a different group key once the rule arrives.
@@ -189,10 +183,21 @@ export function useStartInvestigation({
     setShouldPoll(!isAssistantInvestigationTerminal(investigation?.state ?? 'pending'));
   }, [knownId, investigation?.state, isPollError]);
 
-  const onStart = () => {
+  useEffect(() => {
+    if (!featureEnabled || !installed || impressionTracked.current) {
+      return;
+    }
+    trackAssistantInvestigationImpression();
+    impressionTracked.current = true;
+  }, [featureEnabled, installed]);
+
+  const createOnStart = (fromStatus: 'idle' | 'startError' | 'reportFailed') => async () => {
     if (!requestBody) {
       return;
     }
+    // Retries from startError/reportFailed are still starts (from_status), not retry events.
+    trackAssistantInvestigationStartClicked({ from_status: fromStatus });
+
     // Prefer live state when known. When useInstanceAlertState returns null (loading /
     // missing datasource), fall back to history: a closed episode (endsAt, no open
     // startsAt) means resolved — otherwise we would omit endsAt for a resolved alert.
@@ -203,17 +208,26 @@ export function useStartInvestigation({
     // Prefer state-history resolve time; fall back to now so Assistant always gets
     // a non-zero endsAt for resolved alerts (required for downstream context).
     const endsAt = isResolved ? (alertEndsAt ?? new Date().toISOString()) : undefined;
-    startInvestigation({
-      ...requestBody,
-      name: rule?.title,
-      alerts: requestBody.alerts.map((alert) => ({
-        ...alert,
-        ...(alertStartsAt ? { startsAt: alertStartsAt } : {}),
-        ...(endsAt ? { endsAt } : {}),
-        status,
-        generatorURL,
-      })),
-    });
+
+    try {
+      const result = await startInvestigation({
+        ...requestBody,
+        name: rule?.title,
+        alerts: requestBody.alerts.map((alert) => ({
+          ...alert,
+          ...(alertStartsAt ? { startsAt: alertStartsAt } : {}),
+          ...(endsAt ? { endsAt } : {}),
+          status,
+          generatorURL,
+        })),
+      }).unwrap();
+      trackAssistantInvestigationStartSucceeded({
+        from_status: fromStatus,
+        investigation_id: result.id,
+      });
+    } catch {
+      trackAssistantInvestigationStartFailed({ from_status: fromStatus });
+    }
   };
 
   if (!featureEnabled || !installed) {
@@ -229,11 +243,26 @@ export function useStartInvestigation({
   }
 
   if (isLookupError && !investigation) {
-    return { status: 'lookupError', onRetry: () => refetchLookup() };
+    return {
+      status: 'lookupError',
+      onRetry: () => {
+        trackAssistantInvestigationRetry({ retry_type: 'lookup', from_status: 'lookupError' });
+        refetchLookup();
+      },
+    };
   }
 
   if (investigation && isAssistantInvestigationCompleted(investigation.state)) {
-    return { status: 'completed', href: getAssistantInvestigationUrl(investigation.id) };
+    return {
+      status: 'completed',
+      href: getAssistantInvestigationUrl(investigation.id),
+      investigationId: investigation.id,
+      onOpenReport: () =>
+        trackAssistantInvestigationOpenReport({
+          from_status: 'completed',
+          investigation_id: investigation.id,
+        }),
+    };
   }
 
   if (isStarting) {
@@ -246,25 +275,49 @@ export function useStartInvestigation({
     return {
       status: 'reportFailed',
       href: getAssistantInvestigationUrl(investigation.id),
-      onStart,
+      investigationId: investigation.id,
+      onStart: createOnStart('reportFailed'),
+      onOpenReport: () =>
+        trackAssistantInvestigationOpenReport({
+          from_status: 'reportFailed',
+          investigation_id: investigation.id,
+        }),
     };
   }
 
   if (isStartError) {
-    return { status: 'startError', onStart };
+    return { status: 'startError', onStart: createOnStart('startError') };
   }
 
   if (isPollError && knownId && !isAssistantInvestigationTerminal(investigation?.state)) {
     return {
       status: 'pollError',
       href: getAssistantInvestigationUrl(knownId),
-      onRetry: () => refetchPoll(),
+      investigationId: knownId,
+      onRetry: () => {
+        trackAssistantInvestigationRetry({ retry_type: 'poll', from_status: 'pollError' });
+        refetchPoll();
+      },
+      onWatchLive: () =>
+        trackAssistantInvestigationWatchLive({
+          from_status: 'pollError',
+          investigation_id: knownId,
+        }),
     };
   }
 
   if (investigation && !isAssistantInvestigationTerminal(investigation.state)) {
-    return { status: 'running', href: getAssistantInvestigationUrl(investigation.id) };
+    return {
+      status: 'running',
+      href: getAssistantInvestigationUrl(investigation.id),
+      investigationId: investigation.id,
+      onWatchLive: () =>
+        trackAssistantInvestigationWatchLive({
+          from_status: 'running',
+          investigation_id: investigation.id,
+        }),
+    };
   }
 
-  return { status: 'idle', onStart };
+  return { status: 'idle', onStart: createOnStart('idle') };
 }


### PR DESCRIPTION
## Summary
Adds `reportInteraction` funnel events for the triage instance-drawer "Start investigation" control so we can measure impression → start → success/fail → open report / watch live (and lookup/poll retries).
Tracking lives in the hook/view model; the button stays presentational. Start retries from error states only emit `start_*` with `from_status` (no separate `retry` for starts).

For POC: https://github.com/grafana/grafana/pull/128706 (behind `alerting.manualAssistantInvestigation` feature toggle)

### Events tracked
- `grafana_alerting_assistant_investigation_impression`
- `…_start_clicked` / `…_start_succeeded` / `…_start_failed` (`from_status`)
- `…_open_report` / `…_watch_live` (`from_status`, `investigation_id`)
- `…_retry` (`retry_type`: `lookup` | `poll`)