### PR TITLE
SSO: add Upsert/Delete write surface to service client

### DIFF
--- a/pkg/services/setting/service.go
+++ b/pkg/services/setting/service.go
@@ -566,8 +566,9 @@ func getRestClient(config Config, log logging.Logger, m clientMetrics) (*rest.RE
 
 	userAgent := fmt.Sprintf("settings-client %s (%s)", apiVersion, resolveServiceName(config))
 
-	// Add a default scheme to handle K8s API error responses
+	// Register meta types so error responses (Status) decode with their details.
 	scheme := runtime.NewScheme()
+	metav1.AddToGroupVersion(scheme, schema.GroupVersion{Group: "", Version: "v1"})
 
 	// Create the rate limiter explicitly so we can wrap it with instrumentation
 	rateLimiter := &instrumentedRateLimiter{

--- a/pkg/services/setting/service_test.go
+++ b/pkg/services/setting/service_test.go
@@ -219,7 +219,7 @@ func TestRemoteSettingService_List(t *testing.T) {
 
 		require.Error(t, err)
 		assert.Nil(t, result)
-		assert.Contains(t, err.Error(), "could not find the requested resource")
+		assert.Contains(t, err.Error(), "not found")
 	})
 
 	t.Run("should handle 500 internal server error", func(t *testing.T) {
@@ -247,7 +247,8 @@ func TestRemoteSettingService_List(t *testing.T) {
 
 		require.Error(t, err)
 		assert.Nil(t, result)
-		assert.Contains(t, err.Error(), "error on the server")
+		// Now decodes the server's Status message instead of a generic one.
+		assert.Contains(t, err.Error(), "database connection failed")
 	})
 
 	t.Run("should handle connection errors", func(t *testing.T) {

--- a/pkg/services/setting/writer.go
+++ b/pkg/services/setting/writer.go
@@ -3,10 +3,11 @@ package setting
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/endpoints/request"
 )
 
@@ -25,21 +26,9 @@ func (s *remoteSettingService) Upsert(ctx context.Context, setting *Setting) err
 	if !ok || namespace == "" {
 		return fmt.Errorf("missing namespace in context")
 	}
-	name := settingResourceName(setting.Section, setting.Key)
 
-	body, err := json.Marshal(map[string]any{
-		"apiVersion": settingGroupVersion.String(),
-		"kind":       "Setting",
-		"metadata": map[string]any{
-			"name":      name,
-			"namespace": namespace,
-		},
-		"spec": map[string]any{
-			"section": setting.Section,
-			"key":     setting.Key,
-			"value":   setting.Value,
-		},
-	})
+	// No name on create: the apiserver derives it from section/key.
+	createBody, err := settingBody("", namespace, setting)
 	if err != nil {
 		return err
 	}
@@ -49,7 +38,7 @@ func (s *remoteSettingService) Upsert(ctx context.Context, setting *Setting) err
 	createErr := s.restClient.Post().
 		Resource(resource).
 		Namespace(namespace).
-		Body(body).
+		Body(createBody).
 		Do(ctx).Error()
 	if createErr == nil {
 		return nil
@@ -58,11 +47,20 @@ func (s *remoteSettingService) Upsert(ctx context.Context, setting *Setting) err
 		return fmt.Errorf("upsert (create) setting %s/%s: %w", setting.Section, setting.Key, createErr)
 	}
 
+	// Server-assigned name; read it from the conflict.
+	name := nameFromStatus(createErr)
+	if name == "" {
+		return fmt.Errorf("upsert (update) setting %s/%s: conflict did not carry a resource name: %w", setting.Section, setting.Key, createErr)
+	}
+	updateBody, err := settingBody(name, namespace, setting)
+	if err != nil {
+		return err
+	}
 	if err := s.restClient.Put().
 		Resource(resource).
 		Namespace(namespace).
 		Name(name).
-		Body(body).
+		Body(updateBody).
 		Do(ctx).Error(); err != nil {
 		return fmt.Errorf("upsert (update) setting %s/%s: %w", setting.Section, setting.Key, err)
 	}
@@ -74,24 +72,51 @@ func (s *remoteSettingService) Delete(ctx context.Context, section, key string) 
 	if !ok || namespace == "" {
 		return fmt.Errorf("missing namespace in context")
 	}
-	name := settingResourceName(section, key)
 
+	// Server-assigned names, so delete by (section, key) labels (idempotent).
+	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
+		MatchLabels: map[string]string{"section": section, "key": key},
+	})
+	if err != nil {
+		return fmt.Errorf("delete setting %s/%s: %w", section, key, err)
+	}
 	if err := s.restClient.Delete().
 		Resource(resource).
 		Namespace(namespace).
-		Name(name).
-		Do(ctx).Error(); err != nil && !apierrors.IsNotFound(err) {
+		Param("labelSelector", selector.String()).
+		Do(ctx).Error(); err != nil {
 		return fmt.Errorf("delete setting %s/%s: %w", section, key, err)
 	}
 	return nil
 }
 
-// settingResourceName maps a section/key pair to a deterministic, RFC1123-safe
-// resource name, e.g. (auth.saml, certificate_url) -> "auth.saml--certificate-url".
-// Underscores are not valid in K8s names, so they collapse to dashes.
-func settingResourceName(section, key string) string {
-	sanitize := func(s string) string {
-		return strings.ToLower(strings.ReplaceAll(s, "_", "-"))
+// settingBody marshals a Setting; an empty name becomes generateName so the
+// apiserver assigns one.
+func settingBody(name, namespace string, setting *Setting) ([]byte, error) {
+	metadata := map[string]any{"namespace": namespace}
+	if name != "" {
+		metadata["name"] = name
+	} else {
+		metadata["generateName"] = "true"
 	}
-	return sanitize(section) + "--" + sanitize(key)
+	return json.Marshal(map[string]any{
+		"apiVersion": settingGroupVersion.String(),
+		"kind":       "Setting",
+		"metadata":   metadata,
+		"spec": map[string]any{
+			"section": setting.Section,
+			"key":     setting.Key,
+			"value":   setting.Value,
+		},
+	})
+}
+
+func nameFromStatus(err error) string {
+	var status apierrors.APIStatus
+	if errors.As(err, &status) {
+		if d := status.Status().Details; d != nil {
+			return d.Name
+		}
+	}
+	return ""
 }

--- a/pkg/services/setting/writer.go
+++ b/pkg/services/setting/writer.go
@@ -1,0 +1,97 @@
+package setting
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apiserver/pkg/endpoints/request"
+)
+
+// Writer is the write surface of the settings service, scoped to the caller's
+// namespace (from ctx). It writes the "us" (override) layer only.
+type Writer interface {
+	Upsert(ctx context.Context, s *Setting) error
+	// Delete is a no-op when the row is missing, so prune stays idempotent.
+	Delete(ctx context.Context, section, key string) error
+}
+
+var _ Writer = (*remoteSettingService)(nil)
+
+func (s *remoteSettingService) Upsert(ctx context.Context, setting *Setting) error {
+	namespace, ok := request.NamespaceFrom(ctx)
+	if !ok || namespace == "" {
+		return fmt.Errorf("missing namespace in context")
+	}
+	name := settingResourceName(setting.Section, setting.Key)
+
+	body, err := json.Marshal(map[string]any{
+		"apiVersion": settingGroupVersion.String(),
+		"kind":       "Setting",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": namespace,
+		},
+		"spec": map[string]any{
+			"section": setting.Section,
+			"key":     setting.Key,
+			"value":   setting.Value,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	// POST create, then PUT on conflict: the apiserver has no server-side apply,
+	// and its PUT is last-write-wins (no resourceVersion needed).
+	createErr := s.restClient.Post().
+		Resource(resource).
+		Namespace(namespace).
+		Body(body).
+		Do(ctx).Error()
+	if createErr == nil {
+		return nil
+	}
+	if !apierrors.IsAlreadyExists(createErr) {
+		return fmt.Errorf("upsert (create) setting %s/%s: %w", setting.Section, setting.Key, createErr)
+	}
+
+	if err := s.restClient.Put().
+		Resource(resource).
+		Namespace(namespace).
+		Name(name).
+		Body(body).
+		Do(ctx).Error(); err != nil {
+		return fmt.Errorf("upsert (update) setting %s/%s: %w", setting.Section, setting.Key, err)
+	}
+	return nil
+}
+
+func (s *remoteSettingService) Delete(ctx context.Context, section, key string) error {
+	namespace, ok := request.NamespaceFrom(ctx)
+	if !ok || namespace == "" {
+		return fmt.Errorf("missing namespace in context")
+	}
+	name := settingResourceName(section, key)
+
+	if err := s.restClient.Delete().
+		Resource(resource).
+		Namespace(namespace).
+		Name(name).
+		Do(ctx).Error(); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete setting %s/%s: %w", section, key, err)
+	}
+	return nil
+}
+
+// settingResourceName maps a section/key pair to a deterministic, RFC1123-safe
+// resource name, e.g. (auth.saml, certificate_url) -> "auth.saml--certificate-url".
+// Underscores are not valid in K8s names, so they collapse to dashes.
+func settingResourceName(section, key string) string {
+	sanitize := func(s string) string {
+		return strings.ToLower(strings.ReplaceAll(s, "_", "-"))
+	}
+	return sanitize(section) + "--" + sanitize(key)
+}

--- a/pkg/services/setting/writer_test.go
+++ b/pkg/services/setting/writer_test.go
@@ -1,0 +1,141 @@
+package setting
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apiserver/pkg/endpoints/request"
+)
+
+func TestRemoteSettingService_writes(t *testing.T) {
+	ctx := request.WithNamespace(context.Background(), "stacks-11")
+	setting := &Setting{Section: "auth.generic_oauth", Key: "client_id", Value: "abc"}
+	upsert := func(w Writer) error { return w.Upsert(ctx, setting) }
+	del := func(w Writer) error { return w.Delete(ctx, "auth.generic_oauth", "client_id") }
+
+	tests := []struct {
+		name        string
+		op          func(w Writer) error
+		handler     func(methods *[]string) http.HandlerFunc
+		wantErr     assert.ErrorAssertionFunc
+		wantMethods []string
+	}{
+		{
+			name:    "upsert creates via POST when the row is absent",
+			op:      upsert,
+			wantErr: assert.NoError,
+			handler: func(methods *[]string) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					*methods = append(*methods, r.Method)
+					w.WriteHeader(http.StatusCreated)
+				}
+			},
+			wantMethods: []string{http.MethodPost},
+		},
+		{
+			name:    "upsert falls back to PUT on 409 conflict",
+			op:      upsert,
+			wantErr: assert.NoError,
+			handler: func(methods *[]string) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					*methods = append(*methods, r.Method)
+					w.Header().Set("Content-Type", "application/json")
+					if r.Method == http.MethodPost {
+						w.WriteHeader(http.StatusConflict)
+						_, _ = w.Write([]byte(`{"kind":"Status","apiVersion":"v1","status":"Failure","reason":"AlreadyExists","code":409}`))
+						return
+					}
+					w.WriteHeader(http.StatusOK) // PUT wins
+				}
+			},
+			wantMethods: []string{http.MethodPost, http.MethodPut},
+		},
+		{
+			name:    "upsert aborts (no PUT) on a non-conflict POST error",
+			op:      upsert,
+			wantErr: assert.Error,
+			handler: func(methods *[]string) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					*methods = append(*methods, r.Method)
+					w.WriteHeader(http.StatusInternalServerError)
+				}
+			},
+			wantMethods: []string{http.MethodPost},
+		},
+		{
+			name:    "delete removes an existing row",
+			op:      del,
+			wantErr: assert.NoError,
+			handler: func(methods *[]string) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					*methods = append(*methods, r.Method)
+					w.WriteHeader(http.StatusOK)
+				}
+			},
+			wantMethods: []string{http.MethodDelete},
+		},
+		{
+			name:    "delete is a no-op when the row is missing (404)",
+			op:      del,
+			wantErr: assert.NoError,
+			handler: func(methods *[]string) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					*methods = append(*methods, r.Method)
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusNotFound)
+					_, _ = w.Write([]byte(`{"kind":"Status","apiVersion":"v1","status":"Failure","reason":"NotFound","code":404}`))
+				}
+			},
+			wantMethods: []string{http.MethodDelete},
+		},
+		{
+			name:    "delete surfaces non-NotFound errors",
+			op:      del,
+			wantErr: assert.Error,
+			handler: func(methods *[]string) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					*methods = append(*methods, r.Method)
+					w.WriteHeader(http.StatusInternalServerError)
+				}
+			},
+			wantMethods: []string{http.MethodDelete},
+		},
+		{
+			name:    "upsert errors when the context carries no namespace",
+			op:      func(w Writer) error { return w.Upsert(context.Background(), setting) },
+			wantErr: assert.Error,
+			handler: func(methods *[]string) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) { *methods = append(*methods, r.Method) }
+			},
+			wantMethods: nil, // guarded before any request
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var methods []string
+			srv := httptest.NewServer(tc.handler(&methods))
+			defer srv.Close()
+
+			err := tc.op(newTestClient(t, srv.URL, 500).(Writer))
+			tc.wantErr(t, err)
+			assert.Equal(t, tc.wantMethods, methods)
+		})
+	}
+}
+
+func TestSettingResourceName(t *testing.T) {
+	tests := []struct {
+		section, key, want string
+	}{
+		{"auth.generic_oauth", "client_id", "auth.generic-oauth--client-id"},
+		{"auth.saml", "certificate_url", "auth.saml--certificate-url"},
+		{"AUTH.LDAP", "Bind_Password", "auth.ldap--bind-password"},
+	}
+	for _, tc := range tests {
+		assert.Equal(t, tc.want, settingResourceName(tc.section, tc.key))
+	}
+}

--- a/pkg/services/setting/writer_test.go
+++ b/pkg/services/setting/writer_test.go
@@ -4,11 +4,34 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apiserver/pkg/endpoints/request"
 )
+
+const testName = "auth.generic-oauth--client-id" // server-assigned resource name
+
+// conflictStatus writes an AlreadyExists; a non-empty name goes in details.
+func conflictStatus(w http.ResponseWriter, name string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusConflict)
+	body := `{"kind":"Status","apiVersion":"v1","status":"Failure","reason":"AlreadyExists","code":409`
+	if name != "" {
+		body += `,"details":{"name":"` + name + `"}`
+	}
+	_, _ = w.Write([]byte(body + `}`))
+}
+
+func anyContains(ss []string, sub string) bool {
+	for _, s := range ss {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}
 
 func TestRemoteSettingService_writes(t *testing.T) {
 	ctx := request.WithNamespace(context.Background(), "stacks-11")
@@ -17,35 +40,36 @@ func TestRemoteSettingService_writes(t *testing.T) {
 	del := func(w Writer) error { return w.Delete(ctx, "auth.generic_oauth", "client_id") }
 
 	tests := []struct {
-		name        string
-		op          func(w Writer) error
-		handler     func(methods *[]string) http.HandlerFunc
-		wantErr     assert.ErrorAssertionFunc
-		wantMethods []string
+		name          string
+		op            func(w Writer) error
+		handler       func(reqs *[]string) http.HandlerFunc
+		wantErr       assert.ErrorAssertionFunc
+		wantMethods   []string
+		wantNamePath  bool   // a request must target testName (the PUT)
+		wantURISubstr string // a request URI must contain this (delete label selector)
 	}{
 		{
 			name:    "upsert creates via POST when the row is absent",
 			op:      upsert,
 			wantErr: assert.NoError,
-			handler: func(methods *[]string) http.HandlerFunc {
+			handler: func(reqs *[]string) http.HandlerFunc {
 				return func(w http.ResponseWriter, r *http.Request) {
-					*methods = append(*methods, r.Method)
+					*reqs = append(*reqs, r.Method+" "+r.URL.RequestURI())
 					w.WriteHeader(http.StatusCreated)
 				}
 			},
 			wantMethods: []string{http.MethodPost},
 		},
 		{
-			name:    "upsert falls back to PUT on 409 conflict",
-			op:      upsert,
-			wantErr: assert.NoError,
-			handler: func(methods *[]string) http.HandlerFunc {
+			name:         "upsert reads the name from the conflict error, then PUTs to it",
+			op:           upsert,
+			wantErr:      assert.NoError,
+			wantNamePath: true,
+			handler: func(reqs *[]string) http.HandlerFunc {
 				return func(w http.ResponseWriter, r *http.Request) {
-					*methods = append(*methods, r.Method)
-					w.Header().Set("Content-Type", "application/json")
+					*reqs = append(*reqs, r.Method+" "+r.URL.RequestURI())
 					if r.Method == http.MethodPost {
-						w.WriteHeader(http.StatusConflict)
-						_, _ = w.Write([]byte(`{"kind":"Status","apiVersion":"v1","status":"Failure","reason":"AlreadyExists","code":409}`))
+						conflictStatus(w, testName)
 						return
 					}
 					w.WriteHeader(http.StatusOK) // PUT wins
@@ -54,50 +78,49 @@ func TestRemoteSettingService_writes(t *testing.T) {
 			wantMethods: []string{http.MethodPost, http.MethodPut},
 		},
 		{
+			name:    "upsert errors when the conflict carries no resource name",
+			op:      upsert,
+			wantErr: assert.Error,
+			handler: func(reqs *[]string) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					*reqs = append(*reqs, r.Method+" "+r.URL.RequestURI())
+					conflictStatus(w, "")
+				}
+			},
+			wantMethods: []string{http.MethodPost},
+		},
+		{
 			name:    "upsert aborts (no PUT) on a non-conflict POST error",
 			op:      upsert,
 			wantErr: assert.Error,
-			handler: func(methods *[]string) http.HandlerFunc {
+			handler: func(reqs *[]string) http.HandlerFunc {
 				return func(w http.ResponseWriter, r *http.Request) {
-					*methods = append(*methods, r.Method)
+					*reqs = append(*reqs, r.Method+" "+r.URL.RequestURI())
 					w.WriteHeader(http.StatusInternalServerError)
 				}
 			},
 			wantMethods: []string{http.MethodPost},
 		},
 		{
-			name:    "delete removes an existing row",
-			op:      del,
-			wantErr: assert.NoError,
-			handler: func(methods *[]string) http.HandlerFunc {
+			name:          "delete issues a collection delete by (section,key) labels",
+			op:            del,
+			wantErr:       assert.NoError,
+			wantURISubstr: "auth.generic_oauth",
+			handler: func(reqs *[]string) http.HandlerFunc {
 				return func(w http.ResponseWriter, r *http.Request) {
-					*methods = append(*methods, r.Method)
+					*reqs = append(*reqs, r.Method+" "+r.URL.RequestURI())
 					w.WriteHeader(http.StatusOK)
 				}
 			},
 			wantMethods: []string{http.MethodDelete},
 		},
 		{
-			name:    "delete is a no-op when the row is missing (404)",
-			op:      del,
-			wantErr: assert.NoError,
-			handler: func(methods *[]string) http.HandlerFunc {
-				return func(w http.ResponseWriter, r *http.Request) {
-					*methods = append(*methods, r.Method)
-					w.Header().Set("Content-Type", "application/json")
-					w.WriteHeader(http.StatusNotFound)
-					_, _ = w.Write([]byte(`{"kind":"Status","apiVersion":"v1","status":"Failure","reason":"NotFound","code":404}`))
-				}
-			},
-			wantMethods: []string{http.MethodDelete},
-		},
-		{
-			name:    "delete surfaces non-NotFound errors",
+			name:    "delete surfaces an error",
 			op:      del,
 			wantErr: assert.Error,
-			handler: func(methods *[]string) http.HandlerFunc {
+			handler: func(reqs *[]string) http.HandlerFunc {
 				return func(w http.ResponseWriter, r *http.Request) {
-					*methods = append(*methods, r.Method)
+					*reqs = append(*reqs, r.Method+" "+r.URL.RequestURI())
 					w.WriteHeader(http.StatusInternalServerError)
 				}
 			},
@@ -107,8 +130,8 @@ func TestRemoteSettingService_writes(t *testing.T) {
 			name:    "upsert errors when the context carries no namespace",
 			op:      func(w Writer) error { return w.Upsert(context.Background(), setting) },
 			wantErr: assert.Error,
-			handler: func(methods *[]string) http.HandlerFunc {
-				return func(w http.ResponseWriter, r *http.Request) { *methods = append(*methods, r.Method) }
+			handler: func(reqs *[]string) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) { *reqs = append(*reqs, r.Method) }
 			},
 			wantMethods: nil, // guarded before any request
 		},
@@ -116,26 +139,25 @@ func TestRemoteSettingService_writes(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			var methods []string
-			srv := httptest.NewServer(tc.handler(&methods))
+			var reqs []string
+			srv := httptest.NewServer(tc.handler(&reqs))
 			defer srv.Close()
 
 			err := tc.op(newTestClient(t, srv.URL, 500).(Writer))
 			tc.wantErr(t, err)
-			assert.Equal(t, tc.wantMethods, methods)
-		})
-	}
-}
 
-func TestSettingResourceName(t *testing.T) {
-	tests := []struct {
-		section, key, want string
-	}{
-		{"auth.generic_oauth", "client_id", "auth.generic-oauth--client-id"},
-		{"auth.saml", "certificate_url", "auth.saml--certificate-url"},
-		{"AUTH.LDAP", "Bind_Password", "auth.ldap--bind-password"},
-	}
-	for _, tc := range tests {
-		assert.Equal(t, tc.want, settingResourceName(tc.section, tc.key))
+			var methods []string
+			for _, r := range reqs {
+				methods = append(methods, strings.SplitN(r, " ", 2)[0])
+			}
+			assert.Equal(t, tc.wantMethods, methods)
+
+			if tc.wantNamePath {
+				assert.Truef(t, anyContains(reqs, "/"+testName), "expected a request targeting %q; got %v", testName, reqs)
+			}
+			if tc.wantURISubstr != "" {
+				assert.Truef(t, anyContains(reqs, tc.wantURISubstr), "expected a request URI containing %q; got %v", tc.wantURISubstr, reqs)
+			}
+		})
 	}
 }

--- a/pkg/services/setting/writer_test.go
+++ b/pkg/services/setting/writer_test.go
@@ -133,7 +133,7 @@ func TestRemoteSettingService_writes(t *testing.T) {
 			handler: func(reqs *[]string) http.HandlerFunc {
 				return func(w http.ResponseWriter, r *http.Request) { *reqs = append(*reqs, r.Method) }
 			},
-			wantMethods: nil, // guarded before any request
+			wantMethods: []string{}, // guarded before any request
 		},
 	}
 
@@ -146,7 +146,7 @@ func TestRemoteSettingService_writes(t *testing.T) {
 			err := tc.op(newTestClient(t, srv.URL, 500).(Writer))
 			tc.wantErr(t, err)
 
-			var methods []string
+			methods := make([]string, 0, len(reqs))
 			for _, r := range reqs {
 				methods = append(methods, strings.SplitN(r, " ", 2)[0])
 			}


### PR DESCRIPTION
## Summary

Adds a write surface (`Upsert`/`Delete`) to the settings service client in `pkg/services/setting`. The client today only reads (`List`/`ListAsIni`); this lets it write individual `Setting` rows, scoped to the caller's namespace.

This is the base of a stack for the SSO settings → MT-Settings migration — the `SSOSetting` app-platform store (next PR) consumes this client to persist provider config. On its own the client isn't wired to a caller yet.

- `Upsert(ctx, *Setting)` — POST to create, PUT on conflict. The settings apiserver has no server-side-apply and its PUT is last-write-wins (no resourceVersion). The resource name is server-owned: create sends `generateName`, and the update reads the assigned name from the conflict error (consistent with the settings apiserver's other clients). Client-side `<section>--<key>` derivation was dropped per settings-squad review — section/key can yield RFC1123-invalid names.
- `Delete(ctx, section, key)` — collection delete by `(section, key)` labels; idempotent (no-op when the row is absent).
- Registers `metav1` meta types in the client scheme so API error responses decode with their details (required to read the conflict's assigned name). Side effect: the reader now surfaces the server's error message instead of a generic one (two reader-test assertions updated).
- Secret values ride the apiserver's existing encrypt-on-write mutator — nothing added here.

## Test plan

`go test ./pkg/services/setting/` — `writer_test.go` table-drives Upsert (clean create, conflict→reads name from error→PUT, conflict-without-name aborts, non-conflict abort, namespace guard) and Delete (collection delete by labels, error surfaced). All pass.

Fixes grafana/identity-access-team#2286
