### PR TITLE
test: Better E2E dashboard import helper

### DIFF
--- a/e2e-playwright/dashboard-new-layouts/dashboard-group-panels.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboard-group-panels.spec.ts
@@ -1,17 +1,6 @@
-import { type Page } from 'playwright-core';
-
 import { test, expect, type E2ESelectorGroups, type DashboardPage } from '@grafana/plugin-e2e';
 
-import testV2Dashboard from '../dashboards/TestV2Dashboard.json';
-
-import {
-  groupIntoRow,
-  groupIntoTab,
-  saveDashboard,
-  selectRow,
-  stripMetadataNameFromImportJson,
-  toggleRow,
-} from './utils';
+import { groupIntoRow, groupIntoTab, importTestDashboard, saveDashboard, selectRow, toggleRow } from './utils';
 
 test.use({
   featureToggles: {
@@ -32,18 +21,6 @@ test.describe(
     tag: ['@dashboards'],
   },
   () => {
-    async function importTestDashboard(page: Page, selectors: E2ESelectorGroups, title: string) {
-      await page.goto(selectors.pages.ImportDashboard.url);
-      await page
-        .getByTestId(selectors.components.DashboardImportPage.textarea)
-        .fill(stripMetadataNameFromImportJson(JSON.stringify(testV2Dashboard)));
-      await page.getByTestId(selectors.components.DashboardImportPage.submit).click();
-      await page.getByTestId(selectors.components.ImportDashboardForm.name).fill(title);
-      await page.getByTestId(selectors.components.DataSourcePicker.inputV2).click();
-      await page.locator('div[data-testid^="data-testid data source card"]').first().click();
-      await page.getByTestId(selectors.components.ImportDashboardForm.submit).click();
-    }
-
     async function ungroupPanels(dashboardPage: DashboardPage, selectors: E2ESelectorGroups) {
       await dashboardPage.getByGrafanaSelector(selectors.components.CanvasGridAddActions.ungroup).click();
     }

--- a/e2e-playwright/dashboard-new-layouts/dashboard-repeats-row-layout.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboard-repeats-row-layout.spec.ts
@@ -43,7 +43,7 @@ test.describe(
       const sidebar = new Sidebar({ page, dashboardPage, selectors, components });
       const rows = new Rows({ page, dashboardPage, selectors, components });
 
-      await importTestDashboard(page, selectors, `Row layout repeats - add repeats - ${Date.now()}`);
+      await importTestDashboard(page, selectors, 'Row layout repeats - add repeats');
 
       await controls.enterEditMode();
 
@@ -70,7 +70,7 @@ test.describe(
       await importTestDashboard(
         page,
         selectors,
-        `Rows layout repeats - update on variable change - ${Date.now()}`,
+        'Rows layout repeats - update on variable change',
         JSON.stringify(V2DashWithRowRepeats)
       );
 
@@ -94,7 +94,7 @@ test.describe(
       await importTestDashboard(
         page,
         selectors,
-        `Rows layout repeats - update through sidebar - ${Date.now()}`,
+        'Rows layout repeats - update through sidebar',
         JSON.stringify(V2DashWithRowRepeats)
       );
 
@@ -122,14 +122,14 @@ test.describe(
       await importTestDashboard(
         page,
         selectors,
-        `Row layout repeats - update repeats after panel change - ${Date.now()}`,
+        'Row layout repeats - update repeats after panel change',
         JSON.stringify(V2DashWithRowRepeats)
       );
 
       await controls.enterEditMode();
 
       await panels.selectByTitle('single panel row 1');
-      await sidebar.panelOptions.setTitle(`${getEditedName('single panel row $c4')}`);
+      await sidebar.panelOptions.setTitle(getEditedName('single panel row $c4'));
 
       // close first row to load the second row
       await rows.toggle(`${REPEAT_TITLE_BASE}1`);
@@ -157,7 +157,7 @@ test.describe(
       await importTestDashboard(
         page,
         selectors,
-        `Row layout repeats - update repeats after panel change in editor - ${Date.now()}`,
+        'Row layout repeats - update repeats after panel change in editor',
         JSON.stringify(V2DashWithRowRepeats)
       );
 
@@ -204,7 +204,7 @@ test.describe(
       await importTestDashboard(
         page,
         selectors,
-        `Row layout repeats - hide canvas add action in repeats - ${Date.now()}`,
+        'Row layout repeats - hide canvas add action in repeats',
         JSON.stringify(V2DashWithRowRepeats)
       );
 
@@ -226,7 +226,7 @@ test.describe(
       await importTestDashboard(
         page,
         selectors,
-        `Row layout repeats - view panels in repeated rows - ${Date.now()}`,
+        'Row layout repeats - view panels in repeated rows',
         JSON.stringify(V2DashWithRowRepeats)
       );
 
@@ -273,7 +273,7 @@ test.describe(
       await importTestDashboard(
         page,
         selectors,
-        `Row layout repeats - view embedded panels in repeated rows - ${Date.now()}`,
+        'Row layout repeats - view embedded panels in repeated rows',
         JSON.stringify(V2DashWithRowRepeats)
       );
 
@@ -311,7 +311,7 @@ test.describe(
       await importTestDashboard(
         page,
         selectors,
-        `Row layout repeats - remove row repeats - ${Date.now()}`,
+        'Row layout repeats - remove row repeats',
         JSON.stringify(V2DashWithRowRepeats)
       );
 
@@ -349,7 +349,7 @@ test.describe(
       await importTestDashboard(
         page,
         selectors,
-        `Row layout repeats - add tabs in repeated rows - ${Date.now()}`,
+        'Row layout repeats - add tabs in repeated rows',
         JSON.stringify(V2DashWithRowRepeats)
       );
 
@@ -358,9 +358,9 @@ test.describe(
       // add a tab in first row
       await canvas.groupPanels('tab', rows.getContent(`${REPEAT_TITLE_BASE}1`));
 
-      await sidebar.tabOptions.setTitle(`tab-row-$c4`);
+      await sidebar.tabOptions.setTitle('tab-row-$c4');
 
-      await expect(tabs.getTitle(`tab-row-1`)).toBeVisible();
+      await expect(tabs.getTitle('tab-row-1')).toBeVisible();
 
       await saveDashboard(dashboardPage, page, selectors);
       await page.reload();
@@ -378,7 +378,7 @@ test.describe(
       await importTestDashboard(
         page,
         selectors,
-        `Row layout repeats - add repeat tabs in repeated rows - ${Date.now()}`,
+        'Row layout repeats - add repeat tabs in repeated rows',
         JSON.stringify(V2DashWithRowRepeats)
       );
 
@@ -387,7 +387,7 @@ test.describe(
       // add a tab in first row
       await canvas.groupPanels('tab', rows.getContent(`${REPEAT_TITLE_BASE}1`));
 
-      await sidebar.tabOptions.setTitle(`tab-$c1-row-$c4`);
+      await sidebar.tabOptions.setTitle('tab-$c1-row-$c4');
 
       await sidebar.tabOptions.repeatOptions.repeatByVariable('c1');
 
@@ -424,7 +424,7 @@ test.describe(
       await importTestDashboard(
         page,
         selectors,
-        `Row layout repeats - move repeated rows - ${Date.now()}`,
+        'Row layout repeats - move repeated rows',
         JSON.stringify(dashboardWithCollapsedRows),
         // there are no panels to show, since all rows are collapsed
         { checkPanelsVisible: false }

--- a/e2e-playwright/dashboard-new-layouts/dashboard-url-syncing.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboard-url-syncing.spec.ts
@@ -1,7 +1,7 @@
 import { selectors } from '@grafana/e2e-selectors';
 import { test, expect } from '@grafana/plugin-e2e';
 
-import testV2Dashboard from '../dashboards/V2DashboardWithTabsForSlugTest.json';
+import v2DashboardWithTabsForSlug from '../dashboards/V2DashboardWithTabsForSlugTest.json';
 
 import { Rows, Tabs } from './page-objects';
 import { importTestDashboard } from './utils';
@@ -98,7 +98,7 @@ test.describe(
     test.beforeAll(async ({ browser, baseURL }) => {
       const page = await browser.newPage({ baseURL });
       try {
-        await importTestDashboard(page, selectors, 'url-sync-tabs-test', JSON.stringify(testV2Dashboard));
+        await importTestDashboard(page, selectors, 'url-sync-tabs-test', JSON.stringify(v2DashboardWithTabsForSlug));
         const match = page.url().match(/\/d\/([^/?]+)/);
         dashboardUid = match![1];
       } finally {

--- a/e2e-playwright/dashboard-new-layouts/dashboards-conditional-rendering.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-conditional-rendering.spec.ts
@@ -279,7 +279,7 @@ async function importDashboardWithTabs(
   components: Components,
   title: string
 ) {
-  await importTestDashboard(page, selectors, `${title} - ${Date.now()}`, JSON.stringify(V2DashboardWithTabs), {
+  await importTestDashboard(page, selectors, title, JSON.stringify(V2DashboardWithTabs), {
     requiresDataSourceSelection: false,
   });
 

--- a/e2e-playwright/dashboard-new-layouts/dashboards-repeats-tabs-layout.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-repeats-tabs-layout.spec.ts
@@ -40,7 +40,7 @@ test.describe(
       const sidebar = new Sidebar({ page, dashboardPage, selectors, components });
       const tabs = new Tabs({ page, dashboardPage, selectors, components });
 
-      await importTestDashboard(page, selectors, `Tabs layout repeats - add repeats - ${Date.now()}`);
+      await importTestDashboard(page, selectors, 'Tabs layout repeats - add repeats');
 
       await controls.enterEditMode();
 
@@ -67,7 +67,7 @@ test.describe(
       await importTestDashboard(
         page,
         selectors,
-        `Tabs layout repeats - update on variable change - ${Date.now()}`,
+        'Tabs layout repeats - update on variable change',
         JSON.stringify(V2DashWithTabRepeats)
       );
 
@@ -90,7 +90,7 @@ test.describe(
       await importTestDashboard(
         page,
         selectors,
-        `Tabs layout repeats - update through sidebar - ${Date.now()}`,
+        'Tabs layout repeats - update through sidebar',
         JSON.stringify(V2DashWithTabRepeats)
       );
 
@@ -118,7 +118,7 @@ test.describe(
       await importTestDashboard(
         page,
         selectors,
-        `Tabs layout repeats - update repeats after panel change - ${Date.now()}`,
+        'Tabs layout repeats - update repeats after panel change',
         JSON.stringify(V2DashWithTabRepeats)
       );
 
@@ -152,7 +152,7 @@ test.describe(
       await importTestDashboard(
         page,
         selectors,
-        `Tabs layout repeats - update repeats after panel change in editor - ${Date.now()}`,
+        'Tabs layout repeats - update repeats after panel change in editor',
         JSON.stringify(V2DashWithTabRepeats)
       );
 
@@ -167,7 +167,7 @@ test.describe(
       await verifyChanges(dashboardPage, page, selectors, 'New edited panel');
 
       // verify panel title change in panel editor UI
-      await expect(panels.getPanel(`New edited panel`)).toBeVisible();
+      await expect(panels.getPanel('New edited panel')).toBeVisible();
 
       await controls.clickBackToDashboard();
       await expect(canvas.getContainer()).toBeVisible(); // verifying that dashboard loaded
@@ -195,7 +195,7 @@ test.describe(
       await importTestDashboard(
         page,
         selectors,
-        `Tabs layout repeats - hide canvas add action in repeats - ${Date.now()}`,
+        'Tabs layout repeats - hide canvas add action in repeats',
         JSON.stringify(V2DashWithTabRepeats)
       );
 
@@ -214,7 +214,7 @@ test.describe(
       await importTestDashboard(
         page,
         selectors,
-        `Tabs layout repeats - move repeated tabs - ${Date.now()}`,
+        'Tabs layout repeats - move repeated tabs',
         JSON.stringify(V2DashWithTabRepeats)
       );
       await controls.enterEditMode();
@@ -251,7 +251,7 @@ test.describe(
       await importTestDashboard(
         page,
         selectors,
-        `Tabs layout repeats - can load into repeated tab - ${Date.now()}`,
+        'Tabs layout repeats - can load into repeated tab',
         JSON.stringify(V2DashWithTabRepeats)
       );
 
@@ -275,7 +275,7 @@ test.describe(
       await importTestDashboard(
         page,
         selectors,
-        `Tabs layout repeats - view panels in repeated tabs - ${Date.now()}`,
+        'Tabs layout repeats - view panels in repeated tabs',
         JSON.stringify(V2DashWithTabRepeats)
       );
 
@@ -327,7 +327,7 @@ test.describe(
       await importTestDashboard(
         page,
         selectors,
-        `Tabs layout repeats - view embedded panels in repeated tabs - ${Date.now()}`,
+        'Tabs layout repeats - view embedded panels in repeated tabs',
         JSON.stringify(V2DashWithTabRepeats)
       );
 
@@ -367,7 +367,7 @@ test.describe(
       await importTestDashboard(
         page,
         selectors,
-        `Tabs layout repeats - remove repeats - ${Date.now()}`,
+        'Tabs layout repeats - remove repeats',
         JSON.stringify(V2DashWithTabRepeats)
       );
 

--- a/e2e-playwright/dashboard-new-layouts/utils.ts
+++ b/e2e-playwright/dashboard-new-layouts/utils.ts
@@ -179,40 +179,42 @@ export async function importTestDashboard(
   dashInput?: string,
   options: ImportTestDashboardOptions = {}
 ): Promise<string> {
-  options = { checkPanelsVisible: true, requiresDataSourceSelection: true, ...options };
+  return test.step(`Import test dashboard "${title}"`, async () => {
+    options = { checkPanelsVisible: true, requiresDataSourceSelection: true, ...options };
 
-  await page.goto(selectors.pages.ImportDashboard.url);
+    await page.goto(selectors.pages.ImportDashboard.url);
 
-  const importJson = stripMetadataNameFromImportJson(dashInput || JSON.stringify(testV2Dashboard));
-  await page.getByTestId(selectors.components.DashboardImportPage.textarea).fill(importJson);
-  await page.getByTestId(selectors.components.DashboardImportPage.submit).click();
+    const importJson = stripMetadataNameFromImportJson(dashInput || JSON.stringify(testV2Dashboard));
+    await page.getByTestId(selectors.components.DashboardImportPage.textarea).fill(importJson);
+    await page.getByTestId(selectors.components.DashboardImportPage.submit).click();
 
-  // we always append a timestamp so every import gets a unique title. Collisions happen on test retries
-  // and when parallel workers import dashboards sharing the same title (several specs reuse titles like "Paste tab")
-  // a collision does not fail the test (the import overwrites the existing dashboard),
-  // but Playwright traces show a validation error in the UI and tests may run against a stale dashboard
-  const uniqueTitle = `${title} [${Date.now().toString(36)}]`;
-  await page.getByTestId(selectors.components.ImportDashboardForm.name).fill(uniqueTitle);
+    // we always append a timestamp so every import gets a unique title. Collisions happen on test retries
+    // and when parallel workers import dashboards sharing the same title (several specs reuse titles like "Paste tab")
+    // a collision does not fail the test (the import overwrites the existing dashboard),
+    // but Playwright traces show a validation error in the UI and tests may run against a stale dashboard
+    const uniqueTitle = `${title} [${Date.now().toString(36)}]`;
+    await page.getByTestId(selectors.components.ImportDashboardForm.name).fill(uniqueTitle);
 
-  if (options.requiresDataSourceSelection) {
-    await page.getByTestId(selectors.components.DataSourcePicker.inputV2).click();
-    await page.locator('div[data-testid^="data-testid data source card"]').first().click();
-  }
+    if (options.requiresDataSourceSelection) {
+      await page.getByTestId(selectors.components.DataSourcePicker.inputV2).click();
+      await page.locator('div[data-testid^="data-testid data source card"]').first().click();
+    }
 
-  await page.getByTestId(selectors.components.ImportDashboardForm.submit).click();
+    await page.getByTestId(selectors.components.ImportDashboardForm.submit).click();
 
-  const undockMenuButton = page.locator('[aria-label="Undock menu"]');
-  const undockMenuVisible = await undockMenuButton.isVisible();
-  if (undockMenuVisible) {
-    await undockMenuButton.click();
-  }
+    const undockMenuButton = page.locator('[aria-label="Undock menu"]');
+    const undockMenuVisible = await undockMenuButton.isVisible();
+    if (undockMenuVisible) {
+      await undockMenuButton.click();
+    }
 
-  if (options.checkPanelsVisible) {
-    // wait for the 1st panel to render
-    await expect(page.locator('[data-testid="uplot-main-div"]').first()).toBeVisible();
-  }
+    if (options.checkPanelsVisible) {
+      // wait for the 1st panel to render
+      await expect(page.locator('[data-testid="uplot-main-div"]').first()).toBeVisible();
+    }
 
-  return uniqueTitle;
+    return uniqueTitle;
+  });
 }
 
 export async function goToEmbeddedPanel(page: Page) {

--- a/e2e-playwright/dashboard-new-layouts/utils.ts
+++ b/e2e-playwright/dashboard-new-layouts/utils.ts
@@ -155,7 +155,7 @@ interface ImportTestDashboardOptions {
   requiresDataSourceSelection?: boolean;
 }
 
-export function stripMetadataNameFromImportJson(input: string): string {
+function stripMetadataNameFromImportJson(input: string): string {
   // Keep fixture JSON intact, but remove a fixed resource name at import time so
   // each test creates an isolated dashboard via generateName in parallel runs.
   try {
@@ -178,26 +178,41 @@ export async function importTestDashboard(
   title: string,
   dashInput?: string,
   options: ImportTestDashboardOptions = {}
-) {
+): Promise<string> {
   options = { checkPanelsVisible: true, requiresDataSourceSelection: true, ...options };
-  const importJson = stripMetadataNameFromImportJson(dashInput || JSON.stringify(testV2Dashboard));
+
   await page.goto(selectors.pages.ImportDashboard.url);
+
+  const importJson = stripMetadataNameFromImportJson(dashInput || JSON.stringify(testV2Dashboard));
   await page.getByTestId(selectors.components.DashboardImportPage.textarea).fill(importJson);
   await page.getByTestId(selectors.components.DashboardImportPage.submit).click();
-  await page.getByTestId(selectors.components.ImportDashboardForm.name).fill(title);
+
+  // we always append a timestamp so every import gets a unique title. Collisions happen on test retries
+  // and when parallel workers import dashboards sharing the same title (several specs reuse titles like "Paste tab")
+  // a collision does not fail the test (the import overwrites the existing dashboard),
+  // but Playwright traces show a validation error in the UI and tests may run against a stale dashboard
+  const uniqueTitle = `${title} [${Date.now().toString(36)}]`;
+  await page.getByTestId(selectors.components.ImportDashboardForm.name).fill(uniqueTitle);
+
   if (options.requiresDataSourceSelection) {
     await page.getByTestId(selectors.components.DataSourcePicker.inputV2).click();
     await page.locator('div[data-testid^="data-testid data source card"]').first().click();
   }
+
   await page.getByTestId(selectors.components.ImportDashboardForm.submit).click();
+
   const undockMenuButton = page.locator('[aria-label="Undock menu"]');
   const undockMenuVisible = await undockMenuButton.isVisible();
   if (undockMenuVisible) {
-    undockMenuButton.click();
+    await undockMenuButton.click();
   }
+
   if (options.checkPanelsVisible) {
+    // wait for the 1st panel to render
     await expect(page.locator('[data-testid="uplot-main-div"]').first()).toBeVisible();
   }
+
+  return uniqueTitle;
 }
 
 export async function goToEmbeddedPanel(page: Page) {

--- a/e2e-playwright/dashboard-new-layouts/utils.ts
+++ b/e2e-playwright/dashboard-new-layouts/utils.ts
@@ -192,7 +192,7 @@ export async function importTestDashboard(
     // and when parallel workers import dashboards sharing the same title (several specs reuse titles like "Paste tab")
     // a collision does not fail the test (the import overwrites the existing dashboard),
     // but Playwright traces show a validation error in the UI and tests may run against a stale dashboard
-    const uniqueTitle = `${title} [${Date.now().toString(36)}]`;
+    const uniqueTitle = `${title} [${Date.now().toString(36)}-${test.info().workerIndex}]`;
     await page.getByTestId(selectors.components.ImportDashboardForm.name).fill(uniqueTitle);
 
     if (options.requiresDataSourceSelection) {

--- a/e2e-playwright/dashboards-suite/dashboard-tabs-drag-drop.spec.ts
+++ b/e2e-playwright/dashboards-suite/dashboard-tabs-drag-drop.spec.ts
@@ -52,7 +52,7 @@ test.describe('Dashboard Tabs Drag and Drop', { tag: ['@dashboards'] }, () => {
   });
 
   test('drag a tab to a different tabs manager (in a different row)', async ({ dashboardPage, selectors, page }) => {
-    await importTestDashboard(page, selectors, 'Drag tab within manager', JSON.stringify(v2DashboardWithTabs), {
+    await importTestDashboard(page, selectors, 'Drag tab to a different manager', JSON.stringify(v2DashboardWithTabs), {
       checkPanelsVisible: false,
       requiresDataSourceSelection: false,
     });


### PR DESCRIPTION
## Goal

Clean up E2E dashboard tests by consolidating the dashboard import logic into the shared `importTestDashboard` helper.

## Key changes

- The helper now appends a unique suffix (timestamp + worker index) to the dashboard title itself, so the `- ${Date.now()}` suffix repeated in every spec is gone. This prevents title collisions on test retries, which silently overwrite the existing dashboard and pollute Playwright traces with a UI validation error.
- Also removes the duplicated local helper in `dashboard-group-panels.spec.ts`, fixes a missing `await` on the undock-menu click, and fixes a copy-pasted test title in `dashboard-tabs-drag-drop.spec.ts`.

## How to test

```bash
yarn e2e:playwright --project dashboard-new-layouts --repeat-each=2
```
- Repeat-each run: the same test importing twice must not trip the "name already exists" validation, and each import must create a distinct dashboard.
- Forced retry: temporarily break an assertion and run with `--retries=1`; the retry trace should show no import-form validation error.
- Parallel duplicate titles: run `dashboard-duplicate-panel.spec.ts` and `dashboard-group-panels.spec.ts` together with more than one worker (both import "Paste tab").
- `dashboard-url-syncing.spec.ts`: its `beforeAll` import now gets a timestamped title; all serial tests must still resolve the dashboard via the extracted UID.
```