### PR TITLE
chore: Migrate provisioning export feature toggle to open feature

### DIFF
--- a/pkg/operators/provisioning/jobs.go
+++ b/pkg/operators/provisioning/jobs.go
@@ -91,7 +91,6 @@ func buildWorkers(cfg *setting.Cfg, controllerCfg *ControllerConfig, registry pr
 		return nil, nil, fmt.Errorf("failed to provide feature manager: %w", err)
 	}
 	features := featuremgmt.ProvideToggles(featureManager)
-	exportEnabled := features.IsEnabledGlobally(featuremgmt.FlagProvisioningExport)                 //nolint:staticcheck
 	folderMetadataEnabled := features.IsEnabledGlobally(featuremgmt.FlagProvisioningFolderMetadata) //nolint:staticcheck
 	// Evaluated per job via OpenFeature so the flag behaves consistently with the
 	// API server (see performanceEnabled in the provisioning apiserver package).

--- a/pkg/operators/provisioning/jobs.go
+++ b/pkg/operators/provisioning/jobs.go
@@ -149,7 +149,6 @@ func buildWorkers(cfg *setting.Cfg, controllerCfg *ControllerConfig, registry pr
 		export.ExportAllWithNewUIDs,
 		stageIfPossible,
 		metrics,
-		exportEnabled,
 	)
 
 	// Migration export preserves original names so the takeover
@@ -161,7 +160,6 @@ func buildWorkers(cfg *setting.Cfg, controllerCfg *ControllerConfig, registry pr
 		export.ExportAll,
 		stageIfPossible,
 		metrics,
-		exportEnabled,
 	)
 	cleaner := migrate.NewNamespaceCleaner(clients)
 	unifiedStorageMigrator := migrate.NewUnifiedStorageMigrator(

--- a/pkg/operators/provisioning/jobs.go
+++ b/pkg/operators/provisioning/jobs.go
@@ -167,7 +167,7 @@ func buildWorkers(cfg *setting.Cfg, controllerCfg *ControllerConfig, registry pr
 		migrateExportWorker,
 		syncWorker,
 	)
-	migrationWorker := migrate.NewMigrationWorkerFromUnified(unifiedStorageMigrator, exportEnabled)
+	migrationWorker := migrate.NewMigrationWorkerFromUnified(unifiedStorageMigrator)
 
 	// Delete
 	deleteWorker := deletepkg.NewWorker(syncWorker, stageIfPossible, repositoryResources, metrics)

--- a/pkg/registry/apis/provisioning/jobs.go
+++ b/pkg/registry/apis/provisioning/jobs.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 
 	authlib "github.com/grafana/authlib/types"
+	"github.com/open-feature/go-sdk/openfeature"
 
 	"github.com/grafana/grafana/apps/provisioning/pkg/apis/auth"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
@@ -22,6 +23,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 )
 
 type JobQueueGetter interface {
@@ -37,7 +39,6 @@ type jobsConnector struct {
 	clients               resources.ClientFactory
 	folderMetadataEnabled bool
 	perfTestingEnabled    func(ctx context.Context) bool
-	exportEnabled         bool
 }
 
 func NewJobsConnector(
@@ -49,7 +50,6 @@ func NewJobsConnector(
 	clients resources.ClientFactory,
 	folderMetadataEnabled bool,
 	perfTestingEnabled func(ctx context.Context) bool,
-	exportEnabled bool,
 ) *jobsConnector {
 	return &jobsConnector{
 		repoGetter:            repoGetter,
@@ -60,7 +60,6 @@ func NewJobsConnector(
 		clients:               clients,
 		folderMetadataEnabled: folderMetadataEnabled,
 		perfTestingEnabled:    perfTestingEnabled,
-		exportEnabled:         exportEnabled,
 	}
 }
 
@@ -314,13 +313,15 @@ func (c *jobsConnector) authorizeJob(ctx context.Context, repo repository.Reposi
 	if spec.Action == provisioning.JobActionTest && (c.perfTestingEnabled == nil || !c.perfTestingEnabled(ctx)) {
 		return apierrors.NewBadRequest("test jobs require the provisioning.performance feature flag")
 	}
+
+	exportEnabled := openfeature.NewDefaultClient().Boolean(ctx, featuremgmt.FlagProvisioningExport, false, openfeature.TransactionContext(ctx))
 	// Reject export (push) and migrate jobs up front when the feature is disabled,
 	// so the API user gets a clear error at creation time instead of a job that is
 	// created only to complete as a no-op.
-	if spec.Action == provisioning.JobActionPush && !c.exportEnabled {
+	if spec.Action == provisioning.JobActionPush && !exportEnabled {
 		return apierrors.NewBadRequest("push jobs require the provisioningExport feature flag")
 	}
-	if spec.Action == provisioning.JobActionMigrate && !c.exportEnabled {
+	if spec.Action == provisioning.JobActionMigrate && !exportEnabled {
 		return apierrors.NewBadRequest("migrate jobs require the provisioningExport feature flag")
 	}
 

--- a/pkg/registry/apis/provisioning/jobs/export/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/export/worker.go
@@ -10,12 +10,15 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/grafana/grafana-app-sdk/logging"
+	"github.com/open-feature/go-sdk/openfeature"
+
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/quotas"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 )
 
 //go:generate mockery --name ExportFn --structname MockExportFn --inpackage --filename mock_export_fn.go --with-expecter
@@ -31,7 +34,6 @@ type ExportWorker struct {
 	exportFn            ExportFn
 	wrapWithStageFn     WrapWithStageFn
 	metrics             jobs.JobMetrics
-	enabled             bool
 }
 
 func NewExportWorker(
@@ -41,7 +43,6 @@ func NewExportWorker(
 	exportFn ExportFn,
 	wrapWithStageFn WrapWithStageFn,
 	metrics jobs.JobMetrics,
-	enabled bool,
 ) *ExportWorker {
 	return &ExportWorker{
 		clientFactory:       clientFactory,
@@ -50,7 +51,6 @@ func NewExportWorker(
 		exportFn:            exportFn,
 		wrapWithStageFn:     wrapWithStageFn,
 		metrics:             metrics,
-		enabled:             enabled,
 	}
 }
 
@@ -60,10 +60,11 @@ func (r *ExportWorker) IsSupported(ctx context.Context, job provisioning.Job) bo
 
 // Process will start a job
 func (r *ExportWorker) Process(ctx context.Context, repo repository.Repository, job provisioning.Job, progress jobs.JobProgressRecorder) (processErr error) {
-	if !r.enabled {
-		// A disabled feature is an expected configuration state, not a failure:
-		// complete the job in a warning state so it is not logged or alerted as an error.
-		return jobs.AsWarning(errors.New("export functionality is disabled by configuration"))
+	enabled := openfeature.NewDefaultClient().Boolean(ctx, featuremgmt.FlagProvisioningExport, false, openfeature.TransactionContext(ctx))
+	if enabled {
+			// A disabled feature is an expected configuration state, not a failure:
+			// complete the job in a warning state so it is not logged or alerted as an error.
+			return jobs.AsWarning(errors.New("export functionality is disabled"))
 	}
 
 	options := job.Spec.Push

--- a/pkg/registry/apis/provisioning/jobs/export/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/export/worker.go
@@ -61,10 +61,10 @@ func (r *ExportWorker) IsSupported(ctx context.Context, job provisioning.Job) bo
 // Process will start a job
 func (r *ExportWorker) Process(ctx context.Context, repo repository.Repository, job provisioning.Job, progress jobs.JobProgressRecorder) (processErr error) {
 	enabled := openfeature.NewDefaultClient().Boolean(ctx, featuremgmt.FlagProvisioningExport, false, openfeature.TransactionContext(ctx))
-	if enabled {
-			// A disabled feature is an expected configuration state, not a failure:
-			// complete the job in a warning state so it is not logged or alerted as an error.
-			return jobs.AsWarning(errors.New("export functionality is disabled"))
+	if !enabled {
+		// A disabled feature is an expected configuration state, not a failure:
+		// complete the job in a warning state so it is not logged or alerted as an error.
+		return jobs.AsWarning(errors.New("export functionality is disabled"))
 	}
 
 	options := job.Spec.Push

--- a/pkg/registry/apis/provisioning/jobs/export/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/export/worker.go
@@ -15,6 +15,7 @@ import (
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/quotas"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+	"github.com/grafana/grafana/pkg/infra/features"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
@@ -60,16 +61,18 @@ func (r *ExportWorker) IsSupported(ctx context.Context, job provisioning.Job) bo
 
 // Process will start a job
 func (r *ExportWorker) Process(ctx context.Context, repo repository.Repository, job provisioning.Job, progress jobs.JobProgressRecorder) (processErr error) {
-	enabled := openfeature.NewDefaultClient().Boolean(ctx, featuremgmt.FlagProvisioningExport, false, openfeature.TransactionContext(ctx))
+	options := job.Spec.Push
+	if options == nil {
+		return errors.New("missing export settings")
+	}
+
+	cfg := repo.Config()
+	evalCtx := features.EvaluationContextFromTargetingKey(cfg.Namespace)
+	enabled := openfeature.NewDefaultClient().Boolean(ctx, featuremgmt.FlagProvisioningExport, false, evalCtx)
 	if !enabled {
 		// A disabled feature is an expected configuration state, not a failure:
 		// complete the job in a warning state so it is not logged or alerted as an error.
 		return jobs.AsWarning(errors.New("export functionality is disabled"))
-	}
-
-	options := job.Spec.Push
-	if options == nil {
-		return errors.New("missing export settings")
 	}
 
 	logger := logging.FromContext(ctx).With("options", options)
@@ -88,7 +91,6 @@ func (r *ExportWorker) Process(ctx context.Context, repo repository.Repository, 
 		attribute.Int("export.resources_count", len(options.Resources)),
 	)
 
-	cfg := repo.Config()
 	// Can write to external branch
 	if err := repository.IsWriteAllowed(cfg, options.Branch); err != nil {
 		return err

--- a/pkg/registry/apis/provisioning/jobs/export/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/export/worker_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 )
 
 // newSupportedResourceClients returns a MockResourceClients exposing dashboards + folders
@@ -80,7 +81,9 @@ func TestExportWorker_IsSupported(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := NewExportWorker(nil, nil, nil, nil, nil, metrics, true)
+			featuremgmt.WithEnabledFlags(t, featuremgmt.FlagProvisioningExport)
+			
+			r := NewExportWorker(nil, nil, nil, nil, nil, metrics)
 			got := r.IsSupported(context.Background(), tt.job)
 			require.Equal(t, tt.want, got)
 		})
@@ -94,7 +97,9 @@ func TestExportWorker_ProcessNoExportSettings(t *testing.T) {
 		},
 	}
 
-	r := NewExportWorker(nil, nil, nil, nil, nil, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
+	featuremgmt.WithEnabledFlags(t, featuremgmt.FlagProvisioningExport)
+	
+	r := NewExportWorker(nil, nil, nil, nil, nil, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
 	err := r.Process(context.Background(), nil, job, nil)
 	require.EqualError(t, err, "missing export settings")
 }
@@ -117,7 +122,9 @@ func TestExportWorker_ProcessWriteNotAllowed(t *testing.T) {
 		},
 	})
 
-	r := NewExportWorker(nil, nil, nil, nil, nil, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
+	featuremgmt.WithEnabledFlags(t, featuremgmt.FlagProvisioningExport)
+	
+	r := NewExportWorker(nil, nil, nil, nil, nil, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
 	err := r.Process(context.Background(), mockRepo, job, nil)
 	require.EqualError(t, err, "repositories.provisioning.grafana.app is forbidden: write operations are not allowed for this repository")
 }
@@ -141,7 +148,9 @@ func TestExportWorker_ProcessBranchNotAllowedForLocal(t *testing.T) {
 		},
 	})
 
-	r := NewExportWorker(nil, nil, nil, nil, nil, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
+	featuremgmt.WithEnabledFlags(t, featuremgmt.FlagProvisioningExport)
+	
+	r := NewExportWorker(nil, nil, nil, nil, nil, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
 	err := r.Process(context.Background(), mockRepo, job, nil)
 	require.EqualError(t, err, "repositories.provisioning.grafana.app is forbidden: branch workflow is not allowed for this repository")
 }
@@ -168,8 +177,9 @@ func TestExportWorker_ProcessFailedToCreateClients(t *testing.T) {
 	mockClients := resources.NewMockClientFactory(t)
 
 	mockClients.On("Clients", mock.Anything, "test-namespace").Return(nil, errors.New("failed to create clients"))
+	featuremgmt.WithEnabledFlags(t, featuremgmt.FlagProvisioningExport)
 
-	r := NewExportWorker(mockClients, nil, nil, nil, nil, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
+	r := NewExportWorker(mockClients, nil, nil, nil, nil, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
 	mockProgress := jobs.NewMockJobProgressRecorder(t)
 
 	err := r.Process(context.Background(), mockRepo, job, mockProgress)
@@ -205,7 +215,9 @@ func TestExportWorker_ProcessNotReaderWriter(t *testing.T) {
 		return fn(repo, true)
 	})
 
-	r := NewExportWorker(mockClients, nil, nil, nil, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
+	featuremgmt.WithEnabledFlags(t, featuremgmt.FlagProvisioningExport)
+	
+	r := NewExportWorker(mockClients, nil, nil, nil, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
 	err := r.Process(context.Background(), mockRepo, job, mockProgress)
 	require.EqualError(t, err, "export job submitted targeting repository that is not a ReaderWriter")
 }
@@ -241,7 +253,9 @@ func TestExportWorker_ProcessRepositoryResourcesError(t *testing.T) {
 	mockStageFn.On("Execute", mock.Anything, mockRepo, mock.Anything, mock.Anything).Return(func(ctx context.Context, repo repository.Repository, stageOpts repository.StageOptions, fn func(repository.Repository, bool) error) error {
 		return fn(repo, true)
 	})
-	r := NewExportWorker(mockClients, mockRepoResources, nil, nil, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
+	featuremgmt.WithEnabledFlags(t, featuremgmt.FlagProvisioningExport)
+	
+	r := NewExportWorker(mockClients, mockRepoResources, nil, nil, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
 	err := r.Process(context.Background(), mockRepo, job, mockProgress)
 	require.EqualError(t, err, "create repository resource client: failed to create repository resources client")
 }
@@ -293,7 +307,9 @@ func TestExportWorker_ProcessStageOptions(t *testing.T) {
 		return fn(repo, true)
 	})
 
-	r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
+	featuremgmt.WithEnabledFlags(t, featuremgmt.FlagProvisioningExport)
+	
+	r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
 	err := r.Process(context.Background(), mockRepo, job, mockProgress)
 	require.NoError(t, err)
 }
@@ -375,7 +391,9 @@ func TestExportWorker_ProcessStageOptionsWithBranch(t *testing.T) {
 				return fn(repo, true)
 			})
 
-			r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
+			featuremgmt.WithEnabledFlags(t, featuremgmt.FlagProvisioningExport)
+			
+			r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
 			err := r.Process(context.Background(), mockRepo, job, mockProgress)
 			require.NoError(t, err)
 		})
@@ -418,7 +436,9 @@ func TestExportWorker_ProcessExportFnError(t *testing.T) {
 		return fn(repo, true)
 	})
 
-	r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
+	featuremgmt.WithEnabledFlags(t, featuremgmt.FlagProvisioningExport)
+
+	r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
 	err := r.Process(context.Background(), mockRepo, job, mockProgress)
 	require.EqualError(t, err, "export failed")
 }
@@ -448,8 +468,9 @@ func TestExportWorker_ProcessWrapWithStageFnError(t *testing.T) {
 
 	mockClients := resources.NewMockClientFactory(t)
 	mockClients.On("Clients", mock.Anything, "test-namespace").Return(resources.NewMockResourceClients(t), nil)
+	featuremgmt.WithEnabledFlags(t, featuremgmt.FlagProvisioningExport)
 
-	r := NewExportWorker(mockClients, nil, nil, nil, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
+	r := NewExportWorker(mockClients, nil, nil, nil, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
 	err := r.Process(context.Background(), mockRepo, job, mockProgress)
 	require.EqualError(t, err, "stage failed")
 }
@@ -473,9 +494,10 @@ func TestExportWorker_ProcessBranchNotAllowedForStageableRepositories(t *testing
 	})
 
 	mockProgress := jobs.NewMockJobProgressRecorder(t)
+	featuremgmt.WithEnabledFlags(t, featuremgmt.FlagProvisioningExport)
 	// No progress messages expected in current implementation
 
-	r := NewExportWorker(nil, nil, nil, nil, nil, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
+	r := NewExportWorker(nil, nil, nil, nil, nil, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
 	err := r.Process(context.Background(), mockRepo, job, mockProgress)
 	require.EqualError(t, err, "repositories.provisioning.grafana.app is forbidden: branch workflow is not allowed for this repository")
 }
@@ -526,8 +548,9 @@ func TestExportWorker_ProcessGitRepository(t *testing.T) {
 	}), mock.Anything).Return(func(ctx context.Context, repo repository.Repository, stageOpts repository.StageOptions, fn func(repository.Repository, bool) error) error {
 		return fn(repo, true)
 	})
+	featuremgmt.WithEnabledFlags(t, featuremgmt.FlagProvisioningExport)
 
-	r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
+	r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
 	err := r.Process(context.Background(), mockRepo, job, mockProgress)
 	require.NoError(t, err)
 }
@@ -572,8 +595,9 @@ func TestExportWorker_ProcessGitRepositoryExportFnError(t *testing.T) {
 	mockStageFn.On("Execute", mock.Anything, mockRepo, mock.Anything, mock.Anything).Return(func(ctx context.Context, repo repository.Repository, stageOpts repository.StageOptions, fn func(repository.Repository, bool) error) error {
 		return fn(repo, true)
 	})
+	featuremgmt.WithEnabledFlags(t, featuremgmt.FlagProvisioningExport)
 
-	r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
+	r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
 	err := r.Process(context.Background(), mockRepo, job, mockProgress)
 	require.EqualError(t, err, "export failed")
 }
@@ -649,8 +673,9 @@ func TestExportWorker_CommitMessagePrecedence(t *testing.T) {
 			}), mock.Anything).Return(func(ctx context.Context, repo repository.Repository, stageOpts repository.StageOptions, fn func(repository.Repository, bool) error) error {
 				return fn(mockReaderWriter, true)
 			})
+			featuremgmt.WithEnabledFlags(t, featuremgmt.FlagProvisioningExport)
 
-			r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
+			r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
 			err := r.Process(context.Background(), mockRepo, job, mockProgress)
 			require.NoError(t, err)
 		})
@@ -714,8 +739,9 @@ func TestExportWorker_RefURLsSetWithBranch(t *testing.T) {
 		// The staging function needs to call the inner function with a ReaderWriter
 		return fn(mockReaderWriter, true)
 	})
+	featuremgmt.WithEnabledFlags(t, featuremgmt.FlagProvisioningExport)
 
-	r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
+	r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
 	err := r.Process(context.Background(), mockRepoWithURLs, job, mockProgress)
 	require.NoError(t, err)
 
@@ -771,8 +797,9 @@ func TestExportWorker_RefURLsNotSetWithoutBranch(t *testing.T) {
 	mockStageFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(func(ctx context.Context, repo repository.Repository, stageOpts repository.StageOptions, fn func(repository.Repository, bool) error) error {
 		return fn(mockReaderWriter, true)
 	})
+	featuremgmt.WithEnabledFlags(t, featuremgmt.FlagProvisioningExport)
 
-	r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
+	r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
 	err := r.Process(context.Background(), mockRepoWithURLs, job, mockProgress)
 	require.NoError(t, err)
 
@@ -828,8 +855,9 @@ func TestExportWorker_RefURLsNotSetForNonURLRepository(t *testing.T) {
 	mockStageFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(func(ctx context.Context, repo repository.Repository, stageOpts repository.StageOptions, fn func(repository.Repository, bool) error) error {
 		return fn(mockReaderWriter, true)
 	})
+	featuremgmt.WithEnabledFlags(t, featuremgmt.FlagProvisioningExport)
 
-	r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
+	r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
 	err := r.Process(context.Background(), mockRepo, job, mockProgress)
 	require.NoError(t, err)
 

--- a/pkg/registry/apis/provisioning/jobs/export/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/export/worker_test.go
@@ -82,7 +82,7 @@ func TestExportWorker_IsSupported(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			featuremgmt.WithEnabledFlags(t, featuremgmt.FlagProvisioningExport)
-			
+
 			r := NewExportWorker(nil, nil, nil, nil, nil, metrics)
 			got := r.IsSupported(context.Background(), tt.job)
 			require.Equal(t, tt.want, got)
@@ -98,7 +98,7 @@ func TestExportWorker_ProcessNoExportSettings(t *testing.T) {
 	}
 
 	featuremgmt.WithEnabledFlags(t, featuremgmt.FlagProvisioningExport)
-	
+
 	r := NewExportWorker(nil, nil, nil, nil, nil, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
 	err := r.Process(context.Background(), nil, job, nil)
 	require.EqualError(t, err, "missing export settings")
@@ -123,7 +123,7 @@ func TestExportWorker_ProcessWriteNotAllowed(t *testing.T) {
 	})
 
 	featuremgmt.WithEnabledFlags(t, featuremgmt.FlagProvisioningExport)
-	
+
 	r := NewExportWorker(nil, nil, nil, nil, nil, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
 	err := r.Process(context.Background(), mockRepo, job, nil)
 	require.EqualError(t, err, "repositories.provisioning.grafana.app is forbidden: write operations are not allowed for this repository")
@@ -149,7 +149,7 @@ func TestExportWorker_ProcessBranchNotAllowedForLocal(t *testing.T) {
 	})
 
 	featuremgmt.WithEnabledFlags(t, featuremgmt.FlagProvisioningExport)
-	
+
 	r := NewExportWorker(nil, nil, nil, nil, nil, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
 	err := r.Process(context.Background(), mockRepo, job, nil)
 	require.EqualError(t, err, "repositories.provisioning.grafana.app is forbidden: branch workflow is not allowed for this repository")
@@ -216,7 +216,7 @@ func TestExportWorker_ProcessNotReaderWriter(t *testing.T) {
 	})
 
 	featuremgmt.WithEnabledFlags(t, featuremgmt.FlagProvisioningExport)
-	
+
 	r := NewExportWorker(mockClients, nil, nil, nil, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
 	err := r.Process(context.Background(), mockRepo, job, mockProgress)
 	require.EqualError(t, err, "export job submitted targeting repository that is not a ReaderWriter")
@@ -254,7 +254,7 @@ func TestExportWorker_ProcessRepositoryResourcesError(t *testing.T) {
 		return fn(repo, true)
 	})
 	featuremgmt.WithEnabledFlags(t, featuremgmt.FlagProvisioningExport)
-	
+
 	r := NewExportWorker(mockClients, mockRepoResources, nil, nil, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
 	err := r.Process(context.Background(), mockRepo, job, mockProgress)
 	require.EqualError(t, err, "create repository resource client: failed to create repository resources client")
@@ -308,7 +308,7 @@ func TestExportWorker_ProcessStageOptions(t *testing.T) {
 	})
 
 	featuremgmt.WithEnabledFlags(t, featuremgmt.FlagProvisioningExport)
-	
+
 	r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
 	err := r.Process(context.Background(), mockRepo, job, mockProgress)
 	require.NoError(t, err)
@@ -392,7 +392,7 @@ func TestExportWorker_ProcessStageOptionsWithBranch(t *testing.T) {
 			})
 
 			featuremgmt.WithEnabledFlags(t, featuremgmt.FlagProvisioningExport)
-			
+
 			r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
 			err := r.Process(context.Background(), mockRepo, job, mockProgress)
 			require.NoError(t, err)
@@ -1164,8 +1164,9 @@ func TestExportWorker_ProcessQuotaExceeded(t *testing.T) {
 	mockResourceClients := newSupportedResourceClients(t)
 	mockClients := resources.NewMockClientFactory(t)
 	mockClients.On("Clients", mock.Anything, "test-namespace").Return(mockResourceClients, nil)
+	featuremgmt.WithEnabledFlags(t, featuremgmt.FlagProvisioningExport)
 
-	r := NewExportWorker(mockClients, nil, mockLister, nil, nil, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
+	r := NewExportWorker(mockClients, nil, mockLister, nil, nil, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
 	err := r.Process(context.Background(), mockRepo, job, mockProgress)
 
 	require.Error(t, err)
@@ -1225,8 +1226,9 @@ func TestExportWorker_ProcessQuotaNotExceeded(t *testing.T) {
 	mockStageFn.On("Execute", mock.Anything, mockRepo, mock.Anything, mock.Anything).Return(func(ctx context.Context, repo repository.Repository, stageOpts repository.StageOptions, fn func(repository.Repository, bool) error) error {
 		return fn(repo, true)
 	})
+	featuremgmt.WithEnabledFlags(t, featuremgmt.FlagProvisioningExport)
 
-	r := NewExportWorker(mockClients, mockRepoResources, mockLister, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
+	r := NewExportWorker(mockClients, mockRepoResources, mockLister, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
 	err := r.Process(context.Background(), mockRepo, job, mockProgress)
 	require.NoError(t, err)
 }
@@ -1273,8 +1275,9 @@ func TestExportWorker_ProcessQuotaUnlimited(t *testing.T) {
 	mockStageFn.On("Execute", mock.Anything, mockRepo, mock.Anything, mock.Anything).Return(func(ctx context.Context, repo repository.Repository, stageOpts repository.StageOptions, fn func(repository.Repository, bool) error) error {
 		return fn(repo, true)
 	})
+	featuremgmt.WithEnabledFlags(t, featuremgmt.FlagProvisioningExport)
 
-	r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
+	r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
 	err := r.Process(context.Background(), mockRepo, job, mockProgress)
 	require.NoError(t, err)
 }
@@ -1305,6 +1308,9 @@ func TestExportWorker_ConfigurationDisabled(t *testing.T) {
 			// Create mock registry for metrics
 			registry := prometheus.NewRegistry()
 			metrics := jobs.RegisterJobMetrics(registry)
+			if tt.enabled {
+				featuremgmt.WithEnabledFlags(t, featuremgmt.FlagProvisioningExport)
+			}
 
 			// Create export worker with minimal dependencies
 			worker := NewExportWorker(
@@ -1314,7 +1320,6 @@ func TestExportWorker_ConfigurationDisabled(t *testing.T) {
 				ExportAll,
 				repository.WrapWithStageAndPushIfPossible,
 				metrics,
-				tt.enabled,
 			)
 
 			// Create a minimal mock repository

--- a/pkg/registry/apis/provisioning/jobs/export/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/export/worker_test.go
@@ -1294,7 +1294,7 @@ func TestExportWorker_ConfigurationDisabled(t *testing.T) {
 			name:       "export job fails when disabled by configuration",
 			enabled:    false,
 			wantErr:    true,
-			wantErrMsg: "export functionality is disabled by configuration",
+			wantErrMsg: "export functionality is disabled by feature flag",
 		},
 		{
 			name:    "export job proceeds when enabled",
@@ -1366,7 +1366,7 @@ func TestExportWorker_ConfigurationDisabled(t *testing.T) {
 				// It may fail later due to minimal mocks, but the configuration check passed
 				if err != nil {
 					// Job failed due to mocking, not configuration - that's okay
-					assert.NotContains(t, err.Error(), "disabled by configuration")
+					assert.NotContains(t, err.Error(), "disabled by feature flag")
 				}
 			}
 		})

--- a/pkg/registry/apis/provisioning/jobs/export/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/export/worker_test.go
@@ -1325,16 +1325,14 @@ func TestExportWorker_ConfigurationDisabled(t *testing.T) {
 			// Create a minimal mock repository
 			mockRepo := repository.NewMockRepository(t)
 
-			// Set up mock expectations for when enabled
-			if tt.enabled {
-				mockRepo.On("Config").Return(&v0alpha1.Repository{
-					Spec: v0alpha1.RepositorySpec{
-						Sync: v0alpha1.SyncOptions{
-							Target: "instance",
-						},
+			// Config() is read to build the flag's evaluation context regardless of enabled state.
+			mockRepo.On("Config").Return(&v0alpha1.Repository{
+				Spec: v0alpha1.RepositorySpec{
+					Sync: v0alpha1.SyncOptions{
+						Target: "instance",
 					},
-				})
-			}
+				},
+			})
 
 			// Create a test job
 			job := v0alpha1.Job{

--- a/pkg/registry/apis/provisioning/jobs/export/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/export/worker_test.go
@@ -1291,10 +1291,10 @@ func TestExportWorker_ConfigurationDisabled(t *testing.T) {
 		wantErrMsg string
 	}{
 		{
-			name:       "export job fails when disabled by configuration",
+			name:       "export job fails when feature flag is disabled",
 			enabled:    false,
 			wantErr:    true,
-			wantErrMsg: "export functionality is disabled by feature flag",
+			wantErrMsg: "export functionality is disabled",
 		},
 		{
 			name:    "export job proceeds when enabled",
@@ -1364,7 +1364,7 @@ func TestExportWorker_ConfigurationDisabled(t *testing.T) {
 				// It may fail later due to minimal mocks, but the configuration check passed
 				if err != nil {
 					// Job failed due to mocking, not configuration - that's okay
-					assert.NotContains(t, err.Error(), "disabled by feature flag")
+					assert.NotContains(t, err.Error(), "functionality is disabled")
 				}
 			}
 		})

--- a/pkg/registry/apis/provisioning/jobs/migrate/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/worker.go
@@ -9,6 +9,8 @@ import (
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/open-feature/go-sdk/openfeature"
 )
 
 //go:generate mockery --name Migrator --structname MockMigrator --inpackage --filename mock_migrator.go --with-expecter
@@ -18,20 +20,17 @@ type Migrator interface {
 
 type MigrationWorker struct {
 	unifiedMigrator Migrator
-	enabled         bool
 }
 
-func NewMigrationWorkerFromUnified(unifiedMigrator Migrator, enabled bool) *MigrationWorker {
+func NewMigrationWorkerFromUnified(unifiedMigrator Migrator) *MigrationWorker {
 	return &MigrationWorker{
 		unifiedMigrator: unifiedMigrator,
-		enabled:         enabled,
 	}
 }
 
-func NewMigrationWorker(unifiedMigrator Migrator, enabled bool) *MigrationWorker {
+func NewMigrationWorker(unifiedMigrator Migrator) *MigrationWorker {
 	return &MigrationWorker{
 		unifiedMigrator: unifiedMigrator,
-		enabled:         enabled,
 	}
 }
 
@@ -40,7 +39,8 @@ func (w *MigrationWorker) IsSupported(ctx context.Context, job provisioning.Job)
 }
 
 func (w *MigrationWorker) Process(ctx context.Context, repo repository.Repository, job provisioning.Job, progress jobs.JobProgressRecorder) (processErr error) {
-	if !w.enabled {
+	enabled := openfeature.NewDefaultClient().Boolean(ctx, featuremgmt.FlagProvisioningExport, false, openfeature.TransactionContext(ctx))
+	if enabled {
 		// A disabled feature is an expected configuration state, not a failure:
 		// complete the job in a warning state so it is not logged or alerted as an error.
 		return jobs.AsWarning(errors.New("migrate functionality is disabled by configuration"))

--- a/pkg/registry/apis/provisioning/jobs/migrate/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/worker.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/grafana-app-sdk/logging"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+	"github.com/grafana/grafana/pkg/infra/features"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -39,16 +40,18 @@ func (w *MigrationWorker) IsSupported(ctx context.Context, job provisioning.Job)
 }
 
 func (w *MigrationWorker) Process(ctx context.Context, repo repository.Repository, job provisioning.Job, progress jobs.JobProgressRecorder) (processErr error) {
-	enabled := openfeature.NewDefaultClient().Boolean(ctx, featuremgmt.FlagProvisioningExport, false, openfeature.TransactionContext(ctx))
+	options := job.Spec.Migrate
+	if options == nil {
+		return errors.New("missing migrate settings")
+	}
+
+	cfg := repo.Config()
+	evalCtx := features.EvaluationContextFromTargetingKey(cfg.Namespace)
+	enabled := openfeature.NewDefaultClient().Boolean(ctx, featuremgmt.FlagProvisioningExport, false, evalCtx)
 	if !enabled {
 		// A disabled feature is an expected configuration state, not a failure:
 		// complete the job in a warning state so it is not logged or alerted as an error.
 		return jobs.AsWarning(errors.New("migrate functionality is disabled"))
-	}
-
-	options := job.Spec.Migrate
-	if options == nil {
-		return errors.New("missing migrate settings")
 	}
 
 	logger := logging.FromContext(ctx).With("options", options)

--- a/pkg/registry/apis/provisioning/jobs/migrate/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/worker.go
@@ -40,10 +40,10 @@ func (w *MigrationWorker) IsSupported(ctx context.Context, job provisioning.Job)
 
 func (w *MigrationWorker) Process(ctx context.Context, repo repository.Repository, job provisioning.Job, progress jobs.JobProgressRecorder) (processErr error) {
 	enabled := openfeature.NewDefaultClient().Boolean(ctx, featuremgmt.FlagProvisioningExport, false, openfeature.TransactionContext(ctx))
-	if enabled {
+	if !enabled {
 		// A disabled feature is an expected configuration state, not a failure:
 		// complete the job in a warning state so it is not logged or alerted as an error.
-		return jobs.AsWarning(errors.New("migrate functionality is disabled by configuration"))
+		return jobs.AsWarning(errors.New("migrate functionality is disabled"))
 	}
 
 	options := job.Spec.Migrate

--- a/pkg/registry/apis/provisioning/jobs/migrate/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/worker_test.go
@@ -12,6 +12,7 @@ import (
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 )
 
 func TestMigrationWorker_IsSupported(t *testing.T) {
@@ -39,7 +40,8 @@ func TestMigrationWorker_IsSupported(t *testing.T) {
 			want: false,
 		},
 	}
-	//true
+	featuremgmt.WithEnabledFlags(t, featuremgmt.FlagProvisioningExport)
+
 	worker := NewMigrationWorker(nil)
 
 	for _, tt := range tests {
@@ -51,7 +53,8 @@ func TestMigrationWorker_IsSupported(t *testing.T) {
 }
 
 func TestMigrationWorker_ProcessNotReaderWriter(t *testing.T) {
-	// true
+	featuremgmt.WithEnabledFlags(t, featuremgmt.FlagProvisioningExport)
+
 	worker := NewMigrationWorker(NewMockMigrator(t))
 	job := provisioning.Job{
 		Spec: provisioning.JobSpec{
@@ -81,7 +84,7 @@ func TestMigrationWorker_Process(t *testing.T) {
 				Spec: provisioning.JobSpec{
 					Action:  provisioning.JobActionMigrate,
 					Migrate: nil,
-				,
+				},
 			},
 			setupMocks: func(um *MockMigrator, pr *jobs.MockJobProgressRecorder) {
 			},
@@ -129,8 +132,8 @@ func TestMigrationWorker_Process(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			unifiedMigrator := NewMockMigrator(t)
 			progressRecorder := jobs.NewMockJobProgressRecorder(t)
+			featuremgmt.WithEnabledFlags(t, featuremgmt.FlagProvisioningExport)
 
-			//true
 			worker := NewMigrationWorker(unifiedMigrator)
 
 			if tt.setupMocks != nil {
@@ -184,9 +187,9 @@ func TestMigrationWorker_ConfigurationDisabled(t *testing.T) {
 			// Set up mock expectations for when enabled
 			if tt.enabled {
 				mockMigrator.On("Migrate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				featuremgmt.WithEnabledFlags(t, featuremgmt.FlagProvisioningExport)
 			}
 
-			// as in test
 			// Create migration worker
 			worker := NewMigrationWorker(mockMigrator)
 

--- a/pkg/registry/apis/provisioning/jobs/migrate/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/worker_test.go
@@ -39,8 +39,8 @@ func TestMigrationWorker_IsSupported(t *testing.T) {
 			want: false,
 		},
 	}
-
-	worker := NewMigrationWorker(nil, true)
+	//true
+	worker := NewMigrationWorker(nil)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -51,7 +51,8 @@ func TestMigrationWorker_IsSupported(t *testing.T) {
 }
 
 func TestMigrationWorker_ProcessNotReaderWriter(t *testing.T) {
-	worker := NewMigrationWorker(NewMockMigrator(t), true)
+	// true
+	worker := NewMigrationWorker(NewMockMigrator(t))
 	job := provisioning.Job{
 		Spec: provisioning.JobSpec{
 			Action:  provisioning.JobActionMigrate,
@@ -80,7 +81,7 @@ func TestMigrationWorker_Process(t *testing.T) {
 				Spec: provisioning.JobSpec{
 					Action:  provisioning.JobActionMigrate,
 					Migrate: nil,
-				},
+				,
 			},
 			setupMocks: func(um *MockMigrator, pr *jobs.MockJobProgressRecorder) {
 			},
@@ -129,7 +130,8 @@ func TestMigrationWorker_Process(t *testing.T) {
 			unifiedMigrator := NewMockMigrator(t)
 			progressRecorder := jobs.NewMockJobProgressRecorder(t)
 
-			worker := NewMigrationWorker(unifiedMigrator, true)
+			//true
+			worker := NewMigrationWorker(unifiedMigrator)
 
 			if tt.setupMocks != nil {
 				tt.setupMocks(unifiedMigrator, progressRecorder)
@@ -184,8 +186,9 @@ func TestMigrationWorker_ConfigurationDisabled(t *testing.T) {
 				mockMigrator.On("Migrate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			}
 
+			// as in test
 			// Create migration worker
-			worker := NewMigrationWorker(mockMigrator, tt.enabled)
+			worker := NewMigrationWorker(mockMigrator)
 
 			// Create a mock repository (ReaderWriter interface required)
 			mockRepo := repository.NewMockReaderWriter(t)

--- a/pkg/registry/apis/provisioning/jobs/migrate/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/worker_test.go
@@ -168,10 +168,10 @@ func TestMigrationWorker_ConfigurationDisabled(t *testing.T) {
 		wantErrMsg string
 	}{
 		{
-			name:       "migrate job fails when disabled by configuration",
+			name:       "migrate job fails when feature flag is disabled",
 			enabled:    false,
 			wantErr:    true,
-			wantErrMsg: "migrate functionality is disabled by configuration",
+			wantErrMsg: "migrate functionality is disabled",
 		},
 		{
 			name:    "migrate job proceeds when enabled",
@@ -229,7 +229,7 @@ func TestMigrationWorker_ConfigurationDisabled(t *testing.T) {
 				// It may fail later due to minimal mocks, but the configuration check passed
 				if err != nil {
 					// Job failed due to mocking, not configuration - that's okay
-					assert.NotContains(t, err.Error(), "disabled by configuration")
+					assert.NotContains(t, err.Error(), "functionality is disabled")
 				}
 			}
 		})

--- a/pkg/registry/apis/provisioning/jobs/migrate/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/worker_test.go
@@ -66,6 +66,7 @@ func TestMigrationWorker_ProcessNotReaderWriter(t *testing.T) {
 	progressRecorder.On("SetTotal", mock.Anything, 10).Return()
 
 	repo := repository.NewMockReader(t)
+	repo.On("Config").Return(&provisioning.Repository{})
 	err := worker.Process(context.Background(), repo, job, progressRecorder)
 	require.EqualError(t, err, "migration job submitted targeting repository that is not a ReaderWriter")
 }
@@ -106,7 +107,7 @@ func TestMigrationWorker_Process(t *testing.T) {
 				um.On("Migrate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
 			setupRepo: func(repo *repository.MockRepository) {
-				// No Config() call needed anymore
+				repo.On("Config").Return(&provisioning.Repository{})
 			},
 		},
 		{
@@ -122,7 +123,7 @@ func TestMigrationWorker_Process(t *testing.T) {
 				um.On("Migrate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
 			setupRepo: func(repo *repository.MockRepository) {
-				// No Config() call needed anymore
+				repo.On("Config").Return(&provisioning.Repository{})
 			},
 			expectedError: "",
 		},
@@ -195,6 +196,7 @@ func TestMigrationWorker_ConfigurationDisabled(t *testing.T) {
 
 			// Create a mock repository (ReaderWriter interface required)
 			mockRepo := repository.NewMockReaderWriter(t)
+			mockRepo.On("Config").Return(&provisioning.Repository{})
 
 			// Create a test job
 			job := provisioning.Job{

--- a/pkg/registry/apis/provisioning/jobs_test.go
+++ b/pkg/registry/apis/provisioning/jobs_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 )
 
 // newJobAuthClients returns a ClientFactory whose ResourceClients exposes the static
@@ -135,7 +136,8 @@ func TestExportFeatureGate(t *testing.T) {
 	cfg := newTestRepo("my-repo", "default")
 
 	t.Run("push rejected when disabled", func(t *testing.T) {
-		c := &jobsConnector{exportEnabled: false}
+		featuremgmt.WithDisabledFlags(t, featuremgmt.FlagProvisioningExport)
+		c := &jobsConnector{}
 		spec := provisioning.JobSpec{Action: provisioning.JobActionPush, Push: &provisioning.ExportJobOptions{}}
 
 		err := c.authorizeJob(ctx, nil, cfg, spec)
@@ -145,7 +147,8 @@ func TestExportFeatureGate(t *testing.T) {
 	})
 
 	t.Run("migrate rejected when disabled", func(t *testing.T) {
-		c := &jobsConnector{exportEnabled: false}
+		featuremgmt.WithDisabledFlags(t, featuremgmt.FlagProvisioningExport)
+		c := &jobsConnector{}
 		spec := provisioning.JobSpec{Action: provisioning.JobActionMigrate, Migrate: &provisioning.MigrateJobOptions{}}
 
 		err := c.authorizeJob(ctx, nil, cfg, spec)
@@ -155,7 +158,8 @@ func TestExportFeatureGate(t *testing.T) {
 	})
 
 	t.Run("migrate passes the gate when enabled", func(t *testing.T) {
-		c := &jobsConnector{exportEnabled: true}
+		featuremgmt.WithEnabledFlags(t, featuremgmt.FlagProvisioningExport)
+		c := &jobsConnector{}
 		// spec.Migrate == nil short-circuits authorizeMigrateJob after the gate,
 		// so this exercises the gate without needing authorization mocks.
 		spec := provisioning.JobSpec{Action: provisioning.JobActionMigrate}
@@ -165,7 +169,8 @@ func TestExportFeatureGate(t *testing.T) {
 	})
 
 	t.Run("push passes the gate when enabled", func(t *testing.T) {
-		c := &jobsConnector{exportEnabled: true}
+		featuremgmt.WithEnabledFlags(t, featuremgmt.FlagProvisioningExport)
+		c := &jobsConnector{}
 		spec := provisioning.JobSpec{Action: provisioning.JobActionPush, Push: &provisioning.ExportJobOptions{}}
 
 		// Past the gate the push authorizer runs; with a nil repo it fails on the

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -920,8 +920,7 @@ func (b *APIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.APIGroupI
 	storage[provisioning.RepositoryResourceInfo.StoragePath("refs")] = WithTimeout(NewRefsConnector(b), 30*time.Second)
 	storage[provisioning.RepositoryResourceInfo.StoragePath("resources")] = WithTimeout(NewListConnector(b, b.resourceLister), 30*time.Second)
 	storage[provisioning.RepositoryResourceInfo.StoragePath("history")] = WithTimeout(NewHistorySubresource(b), 30*time.Second)
-	exportEnabled := b.features.IsEnabledGlobally(featuremgmt.FlagProvisioningExport) //nolint:staticcheck
-	storage[provisioning.RepositoryResourceInfo.StoragePath("jobs")] = WithTimeout(NewJobsConnector(b, b, b, jobHistory, b.access, b.clients, b.folderMetadataEnabled, performanceEnabled, exportEnabled), 30*time.Second)
+	storage[provisioning.RepositoryResourceInfo.StoragePath("jobs")] = WithTimeout(NewJobsConnector(b, b, b, jobHistory, b.access, b.clients, b.folderMetadataEnabled, performanceEnabled), 30*time.Second)
 
 	// Add any extra storage
 	for _, extra := range b.extras {

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -1022,8 +1022,6 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 
 			stageIfPossible := repository.WrapWithStageAndPushIfPossible
 
-			exportEnabled := b.features.IsEnabled(postStartHookCtx.Context, featuremgmt.FlagProvisioningExport) //nolint:staticcheck
-
 			// Standalone export generates new UIDs so exported files don't
 			// reference existing resource identifiers.
 			exportWorker := export.NewExportWorker(
@@ -1033,7 +1031,6 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 				export.ExportAllWithNewUIDs,
 				stageIfPossible,
 				metrics,
-				exportEnabled,
 			)
 
 			syncer := sync.NewSyncer(sync.Compare, sync.FullSync, sync.IncrementalSync, b.tracer, 10, metrics, b.folderMetadataEnabled, b.syncResourceTimeout) //nolint:staticcheck
@@ -1057,7 +1054,6 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 				export.ExportAll,
 				stageIfPossible,
 				metrics,
-				exportEnabled,
 			)
 			cleaner := migrate.NewNamespaceCleaner(b.clients)
 			unifiedStorageMigrator := migrate.NewUnifiedStorageMigrator(
@@ -1067,7 +1063,6 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 			)
 			migrationWorker := migrate.NewMigrationWorker(
 				unifiedStorageMigrator,
-				b.features.IsEnabled(postStartHookCtx.Context, featuremgmt.FlagProvisioningExport), //nolint:staticcheck
 			)
 
 			deleteWorker := deletepkg.NewWorker(syncWorker, stageIfPossible, b.repositoryResources, metrics)

--- a/pkg/services/featuremgmt/testing.go
+++ b/pkg/services/featuremgmt/testing.go
@@ -26,3 +26,21 @@ func WithEnabledFlags(t *testing.T, flags ...string) {
 		_ = openfeature.SetProviderAndWait(openfeature.NoopProvider{})
 	})
 }
+
+// WithEnabledFlags sets up an OpenFeature static provider with the given flags
+// enabled for the duration of the test, then resets to the no-op provider.
+func WithDisabledFlags(t *testing.T, flags ...string) {
+	t.Helper()
+
+	inMemoryFlags := make(map[string]memprovider.InMemoryFlag, len(flags))
+	for _, f := range flags {
+		inMemoryFlags[f] = setting.NewInMemoryFlag(f, false)
+	}
+	provider, err := CreateStaticProviderWithStandardFlags(inMemoryFlags)
+	require.NoError(t, err)
+	require.NoError(t, openfeature.SetProviderAndWait(provider))
+
+	t.Cleanup(func() {
+		_ = openfeature.SetProviderAndWait(openfeature.NoopProvider{})
+	})
+}

--- a/pkg/services/featuremgmt/testing.go
+++ b/pkg/services/featuremgmt/testing.go
@@ -26,21 +26,3 @@ func WithEnabledFlags(t *testing.T, flags ...string) {
 		_ = openfeature.SetProviderAndWait(openfeature.NoopProvider{})
 	})
 }
-
-// WithEnabledFlags sets up an OpenFeature static provider with the given flags
-// enabled for the duration of the test, then resets to the no-op provider.
-func WithDisabledFlags(t *testing.T, flags ...string) {
-	t.Helper()
-
-	inMemoryFlags := make(map[string]memprovider.InMemoryFlag, len(flags))
-	for _, f := range flags {
-		inMemoryFlags[f] = setting.NewInMemoryFlag(f, false)
-	}
-	provider, err := CreateStaticProviderWithStandardFlags(inMemoryFlags)
-	require.NoError(t, err)
-	require.NoError(t, openfeature.SetProviderAndWait(provider))
-
-	t.Cleanup(func() {
-		_ = openfeature.SetProviderAndWait(openfeature.NoopProvider{})
-	})
-}

--- a/pkg/services/featuremgmt/testing.go
+++ b/pkg/services/featuremgmt/testing.go
@@ -1,6 +1,7 @@
 package featuremgmt
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/grafana/grafana/pkg/setting"
@@ -12,12 +13,33 @@ import (
 // WithEnabledFlags sets up an OpenFeature static provider with the given flags
 // enabled for the duration of the test, then resets to the no-op provider.
 func WithEnabledFlags(t *testing.T, flags ...string) {
+	WithFlags(t, flags, []string{})
+}
+
+// WithDisabledFlags sets up an OpenFeature static provider with the given flags
+// disabled for the duration of the test, then resets to the no-op provider.
+func WithDisabledFlags(t *testing.T, flags ...string) {
+	WithFlags(t, []string{}, flags)
+}
+
+// WithFlags sets up an OpenFeature static provider serving the given enabled and
+// disabled flags for the duration of the test, then resets to the no-op provider.
+// A flag listed in both enabled and disabled fails the test.
+func WithFlags(t *testing.T, enabled, disabled []string) {
 	t.Helper()
 
-	inMemoryFlags := make(map[string]memprovider.InMemoryFlag, len(flags))
-	for _, f := range flags {
+	inMemoryFlags := make(map[string]memprovider.InMemoryFlag, len(enabled)+len(disabled))
+	for _, f := range enabled {
 		inMemoryFlags[f] = setting.NewInMemoryFlag(f, true)
 	}
+
+	for _, f := range disabled {
+		_, ok := inMemoryFlags[f]
+		require.False(t, ok, fmt.Sprintf("flag %s cannot be enabled and disabled at time", f))
+
+		inMemoryFlags[f] = setting.NewInMemoryFlag(f, false)
+	}
+
 	provider, err := CreateStaticProviderWithStandardFlags(inMemoryFlags)
 	require.NoError(t, err)
 	require.NoError(t, openfeature.SetProviderAndWait(provider))
@@ -25,4 +47,16 @@ func WithEnabledFlags(t *testing.T, flags ...string) {
 	t.Cleanup(func() {
 		_ = openfeature.SetProviderAndWait(openfeature.NoopProvider{})
 	})
+}
+
+// Disabled returns flags for use as the disabled list in WithFlags, improving
+// call-site readability (e.g. WithFlags(t, Enabled("a"), Disabled("b"))).
+func Disabled(flags ...string) []string {
+	return flags
+}
+
+// Enabled returns flags for use as the enabled list in WithFlags, improving
+// call-site readability (e.g. WithFlags(t, Enabled("a"), Disabled("b"))).
+func Enabled(flags ...string) []string {
+	return flags
 }

--- a/pkg/tests/apis/provisioning/disabledfeatures_test.go
+++ b/pkg/tests/apis/provisioning/disabledfeatures_test.go
@@ -7,6 +7,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
 
@@ -56,6 +57,7 @@ func TestIntegrationProvisioning_MigrateDisabledByConfiguration(t *testing.T) {
 
 func TestIntegrationProvisioning_ExportDisabledByConfiguration(t *testing.T) {
 	helper := sharedHelper(t)
+	featuremgmt.WithDisabledFlags(t, featuremgmt.FlagProvisioningExport)
 
 	const repo = "test-repository"
 	testRepo := common.TestRepo{

--- a/pkg/tests/apis/provisioning/disabledfeatures_test.go
+++ b/pkg/tests/apis/provisioning/disabledfeatures_test.go
@@ -7,7 +7,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
 
@@ -57,7 +56,6 @@ func TestIntegrationProvisioning_MigrateDisabledByConfiguration(t *testing.T) {
 
 func TestIntegrationProvisioning_ExportDisabledByConfiguration(t *testing.T) {
 	helper := sharedHelper(t)
-	featuremgmt.WithDisabledFlags(t, featuremgmt.FlagProvisioningExport)
 
 	const repo = "test-repository"
 	testRepo := common.TestRepo{


### PR DESCRIPTION
Migrating code using provisioningExport feature toggle to open feature.

## Notes
Feature is enabled in dev and ops, we should add goff flag prior to merging this pr


Reflecting changes on FE:
https://github.com/grafana/grafana/pull/130604