### PR TITLE
Diagnostics: raise querydata.json size limits

### DIFF
--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -31,6 +31,13 @@ type Bundler struct {
 // their uncompressed JSON bounded independently so adding querydata.json cannot multiply a large
 // panel/dashboard archive without an explicit truncation marker.
 //
+// This bound is unrelated to the plugin<->core gRPC message size limit that constrains
+// grafana-plugin-sdk-go's own HAR capture caps (backend/harcapture.maxCapturedTotalBytes): by the
+// time marshalQueryDataArtifact runs, resp has already crossed that boundary (or, for an in-process
+// core datasource, never crossed it at all). What these bound instead is the size of the downloaded
+// bundle and the transient memory json.MarshalIndent allocates for the full artifact before the
+// length check below runs -- a response near the cap still costs a full-size allocation once.
+//
 // Declared as vars, not consts, solely so tests can shrink them (see diagnostics_test.go) instead of
 // each allocating a payload at the real multi-hundred-MiB scale.
 var (

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -31,8 +31,8 @@ type Bundler struct {
 // their uncompressed JSON bounded independently so adding querydata.json cannot multiply a large
 // panel/dashboard archive without an explicit truncation marker.
 const (
-	maxQueryDataArtifactBytes  = 1 << 30
-	maxDashboardQueryDataBytes = 1536 << 20 // 1.5 GiB; 4 GiB would overflow a 32-bit int
+	maxQueryDataArtifactBytes  = 1 << 30    // 1 GiB
+	maxDashboardQueryDataBytes = 1536 << 20 // 1.5 GiB
 	// minQueryDataArtifactBytes is the smallest budget worth attempting: below it not even a truncated
 	// artifact (version + omission markers) fits, so the panel's query data is skipped up front.
 	minQueryDataArtifactBytes = 256

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -17,6 +17,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 
 	"github.com/grafana/grafana/pkg/infra/httpclient/harcapture"
 )
@@ -36,7 +37,8 @@ type Bundler struct {
 // time marshalQueryDataArtifact runs, resp has already crossed that boundary (or, for an in-process
 // core datasource, never crossed it at all). What these bound instead is the size of the downloaded
 // bundle and the transient memory json.MarshalIndent allocates for the full artifact before the
-// length check below runs -- a response near the cap still costs a full-size allocation once.
+// length check below runs -- estimateResponseBytes skips that allocation for the clearest oversized
+// cases, but a response it can't rule out cheaply still costs a full-size allocation once.
 //
 // Declared as vars, not consts, solely so tests can shrink them (see diagnostics_test.go) instead of
 // each allocating a payload at the real multi-hundred-MiB scale.
@@ -232,9 +234,25 @@ func marshalQueryDataArtifact(request json.RawMessage, resp *backend.QueryDataRe
 func marshalQueryDataArtifactWithLimit(request json.RawMessage, resp *backend.QueryDataResponse, maxBytes int) ([]byte, bool, error) {
 	artifact := queryDataArtifact{Version: queryDataArtifactVersion, Request: request}
 	if resp != nil {
+		filtered := queryDataResponseWithoutCaptureFrames(resp)
+
+		// estimateResponseBytes only ever undercounts (see its doc comment), so a response it already
+		// calls oversized cannot possibly fit once encoded -- skip straight to the same truncated shape
+		// the full-size check below would produce anyway, without paying for the encode.
+		if estimateResponseBytes(filtered) > maxBytes {
+			out, err := fitQueryDataArtifact(queryDataArtifact{
+				Version:         queryDataArtifactVersion,
+				ResponseSummary: summarizeQueryDataResponse(resp),
+				Truncated:       true,
+				LimitBytes:      maxBytes,
+				ResponseOmitted: true,
+			}, request, maxBytes)
+			return out, true, err
+		}
+
 		// The SDK encoder returns a complete byte slice. The artifact/archive is bounded below, but
 		// serializing an oversized response can still temporarily allocate its full JSON size.
-		responseJSON, err := queryDataResponseWithoutCaptureFrames(resp).MarshalJSON()
+		responseJSON, err := filtered.MarshalJSON()
 		if err != nil {
 			// A response that cannot be encoded (e.g. an unserializable value in a frame's Meta.Custom)
 			// usually still has a serializable request beside it. Degrade to the same request + summary
@@ -651,6 +669,69 @@ func queryDataResponseWithoutCaptureFrames(resp *backend.QueryDataResponse) *bac
 		}
 	}
 	return filtered
+}
+
+// estimateResponseBytes is a fast lower bound on resp's JSON-encoded size, used to skip the real
+// encode (marshalQueryDataArtifactWithLimit) for the clearest oversized cases. It sums only the raw
+// bytes string/JSON field values and response errors already hold in memory -- what actually drives
+// an oversized response -- plus a 1-byte floor per value of any other type, with no allowance for
+// JSON structure (separators, braces, field/schema names). It therefore never overestimates: a
+// response this calls oversized truly is, but one it doesn't catch can still turn out oversized once
+// actually encoded.
+func estimateResponseBytes(resp *backend.QueryDataResponse) int {
+	if resp == nil {
+		return 0
+	}
+	total := 0
+	for _, response := range resp.Responses {
+		if response.Error != nil {
+			total += len(response.Error.Error())
+		}
+		for _, frame := range response.Frames {
+			if frame == nil {
+				continue
+			}
+			for _, field := range frame.Fields {
+				total += estimateFieldBytes(field)
+			}
+		}
+	}
+	return total
+}
+
+// estimateFieldBytes is the per-field half of estimateResponseBytes.
+func estimateFieldBytes(field *data.Field) int {
+	n := field.Len()
+	switch field.Type() {
+	case data.FieldTypeString, data.FieldTypeNullableString:
+		total := 0
+		for i := 0; i < n; i++ {
+			switch v := field.At(i).(type) {
+			case string:
+				total += len(v)
+			case *string:
+				if v != nil {
+					total += len(*v)
+				}
+			}
+		}
+		return total
+	case data.FieldTypeJSON, data.FieldTypeNullableJSON:
+		total := 0
+		for i := 0; i < n; i++ {
+			switch v := field.At(i).(type) {
+			case json.RawMessage:
+				total += len(v)
+			case *json.RawMessage:
+				if v != nil {
+					total += len(*v)
+				}
+			}
+		}
+		return total
+	default:
+		return n
+	}
 }
 
 // forEachHARFrameCustom calls fn with the Custom map of every frame across all synthetic capture

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -31,8 +31,8 @@ type Bundler struct {
 // their uncompressed JSON bounded independently so adding querydata.json cannot multiply a large
 // panel/dashboard archive without an explicit truncation marker.
 const (
-	maxQueryDataArtifactBytes  = 8 << 20
-	maxDashboardQueryDataBytes = 32 << 20
+	maxQueryDataArtifactBytes  = 1 << 30
+	maxDashboardQueryDataBytes = 1536 << 20 // 1.5 GiB; 4 GiB would overflow a 32-bit int
 	// minQueryDataArtifactBytes is the smallest budget worth attempting: below it not even a truncated
 	// artifact (version + omission markers) fits, so the panel's query data is skipped up front.
 	minQueryDataArtifactBytes = 256

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -716,7 +716,7 @@ func estimateFieldBytes(field *data.Field) int {
 			}
 		}
 		return total
-	case data.FieldTypeJSON, data.FieldTypeNullableJSON:
+	case data.FieldTypeJSON, data.FieldTypeNullableJSON: //nolint:staticcheck
 		total := 0
 		for i := 0; i < n; i++ {
 			switch v := field.At(i).(type) {

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -30,13 +30,17 @@ type Bundler struct {
 // Query responses can contain substantially more data than the diagnostic traffic itself. Keep
 // their uncompressed JSON bounded independently so adding querydata.json cannot multiply a large
 // panel/dashboard archive without an explicit truncation marker.
-const (
+//
+// Declared as vars, not consts, solely so tests can shrink them (see diagnostics_test.go) instead of
+// each allocating a payload at the real multi-hundred-MiB scale.
+var (
 	maxQueryDataArtifactBytes  = 1 << 30    // 1 GiB
 	maxDashboardQueryDataBytes = 1536 << 20 // 1.5 GiB
-	// minQueryDataArtifactBytes is the smallest budget worth attempting: below it not even a truncated
-	// artifact (version + omission markers) fits, so the panel's query data is skipped up front.
-	minQueryDataArtifactBytes = 256
 )
+
+// minQueryDataArtifactBytes is the smallest budget worth attempting: below it not even a truncated
+// artifact (version + omission markers) fits, so the panel's query data is skipped up front.
+const minQueryDataArtifactBytes = 256
 
 // queryDataArtifactVersion is the schema version stamped into every querydata.json (including its
 // truncated fallbacks) so a reader can tell how to interpret the artifact.

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -926,6 +926,50 @@ func TestMarshalQueryDataArtifactWithLimit_reportsTruncation(t *testing.T) {
 	require.False(t, truncated, "a response that fits must report truncated=false")
 }
 
+// TestMarshalQueryDataArtifactWithLimit_skipsEncodeForClearlyOversizedResponse proves the early-skip
+// path in marshalQueryDataArtifactWithLimit: a response whose lower-bound estimate alone already
+// exceeds maxBytes must never reach the full MarshalJSON/MarshalIndent encode, so OriginalBytes (which
+// only the full encode can populate) stays unset.
+func TestMarshalQueryDataArtifactWithLimit_skipsEncodeForClearlyOversizedResponse(t *testing.T) {
+	const limit = 4096
+	frame := data.NewFrame("logs", data.NewField("line", nil, []string{strings.Repeat("x", limit+1)}))
+	resp := &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{frame}}}}
+	require.Greater(t, estimateResponseBytes(resp), limit, "sanity: the estimate itself must already exceed the limit")
+
+	out, truncated, err := marshalQueryDataArtifactWithLimit(nil, resp, limit)
+	require.NoError(t, err)
+	require.True(t, truncated)
+
+	var art queryDataArtifact
+	require.NoError(t, json.Unmarshal(out, &art))
+	require.True(t, art.ResponseOmitted)
+	require.Zero(t, art.OriginalBytes, "the early-skip path never ran the full encode, so there is nothing to report")
+	require.Contains(t, art.ResponseSummary, "A")
+}
+
+// TestMarshalQueryDataArtifactWithLimit_fullEncodeStillMeasuredWhenEstimateMisses covers the
+// complementary case: a response whose per-value byte estimate stays low (many small numeric fields,
+// each field's own JSON schema/structure overhead is not counted by estimateResponseBytes) but whose
+// real encoded size is still over budget. The full encode must still run and OriginalBytes must still
+// be populated -- the estimate is a fast pre-filter, not a replacement for the real check.
+func TestMarshalQueryDataArtifactWithLimit_fullEncodeStillMeasuredWhenEstimateMisses(t *testing.T) {
+	const limit = 200
+	frames := make(data.Frames, 0, 20)
+	for i := 0; i < 20; i++ {
+		frames = append(frames, data.NewFrame("f", data.NewField("v", nil, []float64{42})))
+	}
+	resp := &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: frames}}}
+	require.LessOrEqual(t, estimateResponseBytes(resp), limit, "sanity: the cheap estimate must not itself exceed the limit")
+
+	out, truncated, err := marshalQueryDataArtifactWithLimit(nil, resp, limit)
+	require.NoError(t, err)
+	require.True(t, truncated, "sanity: the real encoded size must exceed the limit despite the low estimate")
+
+	var art queryDataArtifact
+	require.NoError(t, json.Unmarshal(out, &art))
+	require.Positive(t, art.OriginalBytes, "the full encode ran and its measured size must be recorded")
+}
+
 func TestMarshalQueryDataArtifactWithLimit_truncationTiers(t *testing.T) {
 	// A request large enough that neither the full artifact nor the (request + summary) tier fits,
 	// forcing the ladder past tier 1.
@@ -965,7 +1009,11 @@ func TestMarshalQueryDataArtifactWithLimit_truncationTiers(t *testing.T) {
 		require.Empty(t, art.Request)
 		require.Empty(t, art.ResponseSummary, "tier 3 drops even the per-refID summary")
 		require.Equal(t, 300, art.LimitBytes)
-		require.Positive(t, art.OriginalBytes)
+		// The 4096-byte error text alone clears estimateResponseBytes's lower bound past maxBytes, so
+		// this response is caught before the full encode ever runs -- OriginalBytes has nothing to
+		// report. TestMarshalQueryDataArtifactWithLimit_fullEncodeStillMeasuredWhenEstimateMisses covers
+		// the case where the full encode does run and OriginalBytes is populated.
+		require.Zero(t, art.OriginalBytes)
 	})
 
 	// The two omission markers are how a reader tells "this was dropped to fit the cap" from "this was

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -21,6 +21,18 @@ import (
 	"github.com/grafana/grafana/pkg/infra/httpclient/harcapture"
 )
 
+// shrinkQueryDataLimits lowers the package's query-data size budgets for the duration of the calling
+// test, restored on cleanup, so a test proving truncation happens at the budget doesn't have to
+// allocate a payload at the real (multi-hundred-MiB) production scale to cross it.
+func shrinkQueryDataLimits(t *testing.T, artifactBytes, dashboardBytes int) {
+	t.Helper()
+	prevArtifact, prevDashboard := maxQueryDataArtifactBytes, maxDashboardQueryDataBytes
+	maxQueryDataArtifactBytes, maxDashboardQueryDataBytes = artifactBytes, dashboardBytes
+	t.Cleanup(func() {
+		maxQueryDataArtifactBytes, maxDashboardQueryDataBytes = prevArtifact, prevDashboard
+	})
+}
+
 func TestBundler_Build(t *testing.T) {
 	// No HAR captured (empty buffer, nil response) -> traffic.har omitted; only panel.json present.
 	blob, err := NewBundler(nil).Build(nil, &harcapture.Buffer{}, json.RawMessage(`{"id":1}`), nil, nil, nil, nil)
@@ -123,6 +135,7 @@ func TestBundler_Build_excludesCaptureFramesFromQueryData(t *testing.T) {
 }
 
 func TestBundler_Build_boundsOversizedQueryData(t *testing.T) {
+	shrinkQueryDataLimits(t, 4096, 16384)
 	frame := data.NewFrame("logs", data.NewField("line", nil, []string{strings.Repeat("x", maxQueryDataArtifactBytes)}))
 	resp := &backend.QueryDataResponse{Responses: backend.Responses{
 		"A": {Frames: data.Frames{frame}},
@@ -140,6 +153,7 @@ func TestBundler_Build_boundsOversizedQueryData(t *testing.T) {
 }
 
 func TestBundler_Build_boundsOversizedRequestWithoutResponse(t *testing.T) {
+	shrinkQueryDataLimits(t, 4096, 16384)
 	// An oversized request with no response must truncate without claiming a response was omitted.
 	request := json.RawMessage(`{"expr":"` + strings.Repeat("x", maxQueryDataArtifactBytes) + `"}`)
 
@@ -576,6 +590,7 @@ func TestBuildDashboard_recordsQueryDataPerPanel(t *testing.T) {
 }
 
 func TestBuildDashboard_boundsAggregateQueryData(t *testing.T) {
+	shrinkQueryDataLimits(t, 64<<10, 128<<10)
 	panels := make([]DashboardPanel, 0, 5)
 	for i := 1; i <= 5; i++ {
 		frame := data.NewFrame("logs", data.NewField("line", nil, []string{strings.Repeat("x", maxQueryDataArtifactBytes-4096)}))
@@ -895,17 +910,18 @@ func TestTruncateDiagnosticString(t *testing.T) {
 }
 
 func TestMarshalQueryDataArtifactWithLimit_reportsTruncation(t *testing.T) {
-	frame := data.NewFrame("logs", data.NewField("line", nil, []string{strings.Repeat("x", maxQueryDataArtifactBytes)}))
+	const limit = 4096
+	frame := data.NewFrame("logs", data.NewField("line", nil, []string{strings.Repeat("x", limit)}))
 	resp := &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{frame}}}}
 
-	_, truncated, err := marshalQueryDataArtifactWithLimit(nil, resp, maxQueryDataArtifactBytes)
+	_, truncated, err := marshalQueryDataArtifactWithLimit(nil, resp, limit)
 	require.NoError(t, err)
 	require.True(t, truncated, "an oversized response must report truncated=true")
 
 	small := &backend.QueryDataResponse{Responses: backend.Responses{
 		"A": {Frames: data.Frames{data.NewFrame("cpu", data.NewField("value", nil, []float64{42}))}},
 	}}
-	_, truncated, err = marshalQueryDataArtifactWithLimit(nil, small, maxQueryDataArtifactBytes)
+	_, truncated, err = marshalQueryDataArtifactWithLimit(nil, small, limit)
 	require.NoError(t, err)
 	require.False(t, truncated, "a response that fits must report truncated=false")
 }


### PR DESCRIPTION
## Summary
- Raises the on-demand diagnostics `querydata.json` size caps: per-panel `maxQueryDataArtifactBytes` 8 MiB -> 1 GiB, dashboard-wide `maxDashboardQueryDataBytes` 32 MiB -> 1.5 GiB.
- These caps are independent of grafana-plugin-sdk-go#1622's HAR capture caps: by the time `marshalQueryDataArtifact` runs, the response has already crossed the plugin<->core gRPC boundary (or never crossed it, for an in-process core datasource), so the gRPC send-limit math that bounds the SDK's `maxCapturedTotalBytes` doesn't apply here. What actually bounds this artifact is the downloaded bundle's size and the transient memory `json.MarshalIndent` allocates for the full artifact before the length check runs — see the updated doc comment in `diagnostics.go`.