### PR TITLE
Alerting: Improve capture matching performance

### DIFF
--- a/pkg/services/ngalert/eval/captures.go
+++ b/pkg/services/ngalert/eval/captures.go
@@ -1,0 +1,450 @@
+package eval
+
+import (
+	"cmp"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+
+	"github.com/grafana/grafana/pkg/expr/classic"
+)
+
+// capturesByRefID holds every captured number value of an evaluation, keyed by the
+// RefID that produced it and then by the fingerprint of the capture's own labels.
+type capturesByRefID = map[string]map[data.Fingerprint]NumberValueCapture
+
+// attachCaptureValues attaches to each condition frame the captures whose labels match
+// the labels of that frame. Labels match when they are equal, or when one set contains
+// the other.
+//
+// Equal labels have equal fingerprints, so an exact match is a map lookup. Any other
+// match has a different number of labels, so the capture is either a subset or a
+// superset of the frame. Both are found by hashing only the labels the two sides share,
+// so a frame costs one lookup per distinct label-name set instead of one comparison per
+// capture. Rules normally use one label-name set per RefID, so the whole call costs
+// frames plus captures rather than frames times captures.
+func attachCaptureValues(frames data.Frames, captures capturesByRefID) {
+	if len(frames) == 0 {
+		return
+	}
+	index := newCaptureIndex(captures)
+
+	var matched []NumberValueCapture
+	for _, frame := range frames {
+		// classic conditions already have metadata set and only have one value, there's no need to add anything in this case.
+		if frame.Meta != nil && frame.Meta.Custom != nil {
+			if _, ok := frame.Meta.Custom.([]classic.EvalMatch); ok {
+				continue // do not overwrite EvalMatch from classic condition.
+			}
+		}
+
+		frame.SetMeta(&data.FrameMeta{}) // overwrite metadata
+
+		if len(frame.Fields) != 1 {
+			continue
+		}
+		matched = index.match(frame.Fields[0].Labels, matched[:0])
+		if len(matched) > 0 {
+			frame.Meta.Custom = slices.Clone(matched)
+		}
+	}
+}
+
+// captureIndex finds the captures that match the labels of a condition frame.
+type captureIndex struct {
+	// refIDs is sorted, so every run attaches matches in the same order.
+	refIDs  []string
+	byRefID map[string]*refIDCaptures
+	// keys holds the label names of the frame being matched. match reuses it.
+	keys []string
+	// scratch holds the matches being sorted. sortMatches reuses it.
+	scratch []orderedCapture
+}
+
+func newCaptureIndex(captures capturesByRefID) *captureIndex {
+	index := &captureIndex{
+		refIDs:  make([]string, 0, len(captures)),
+		byRefID: make(map[string]*refIDCaptures, len(captures)),
+	}
+	for refID, byFingerprint := range captures {
+		index.refIDs = append(index.refIDs, refID)
+		index.byRefID[refID] = &refIDCaptures{byFingerprint: byFingerprint}
+	}
+	slices.Sort(index.refIDs)
+	return index
+}
+
+// match appends every capture that matches labels to dst, and returns dst.
+func (i *captureIndex) match(labels data.Labels, dst []NumberValueCapture) []NumberValueCapture {
+	keys := sortedLabelKeys(labels, i.keys[:0])
+	i.keys = keys
+
+	// The projection of a label set onto its own names is the fingerprint of that set.
+	// Every name is present, so the projection always exists.
+	fingerprint, _ := projectFingerprint(labels, keys)
+	keySet := keySetFingerprint(keys)
+
+	for _, refID := range i.refIDs {
+		captures := i.byRefID[refID]
+
+		// First look for a capture whose labels are an exact match.
+		if v, ok := captures.byFingerprint[fingerprint]; ok {
+			dst = append(dst, v)
+			continue
+		}
+
+		// Equal labels always have the same fingerprint, and the lookup above found none.
+		// No remaining capture of this RefID can have labels equal to those of the frame,
+		// so only subsets and supersets are left.
+		start := len(dst)
+		dst = captures.appendSubsets(labels, keys, dst)
+		dst = captures.appendSupersets(labels, keys, keySet, fingerprint, dst)
+		if len(dst)-start > 1 {
+			i.sortMatches(dst[start:])
+		}
+	}
+	return dst
+}
+
+// sortMatches puts the matches of one RefID in the order compareCaptures defines.
+func (i *captureIndex) sortMatches(matches []NumberValueCapture) {
+	// data.Labels.String sorts the label names and builds a string, so render the labels
+	// of every match once here instead of once per comparison.
+	i.scratch = i.scratch[:0]
+	for _, capture := range matches {
+		i.scratch = append(i.scratch, newOrderedCapture(capture))
+	}
+	slices.SortFunc(i.scratch, compareCaptures)
+	for j, ordered := range i.scratch {
+		matches[j] = ordered.capture
+	}
+}
+
+// maxCachedSupersetIndexes bounds how many superset indexes one RefID keeps. The
+// condition frames of one evaluation almost always use the same label names, so one
+// index per RefID is the normal case. Past the bound a frame scans the wider captures
+// instead of building an index, so the cache cannot grow with the number of frames.
+const maxCachedSupersetIndexes = 8
+
+// refIDCaptures holds the captures of one RefID.
+type refIDCaptures struct {
+	// byFingerprint holds every capture, keyed by the fingerprint of its own labels.
+	byFingerprint map[data.Fingerprint]NumberValueCapture
+
+	// groups holds the captures grouped by the label names they use, sorted by how many
+	// names each group uses. keySetGroups builds it on first use, because a frame that
+	// finds an exact match never reads it.
+	groups  []captureGroup
+	grouped bool
+
+	// supersetIndexes holds the indexes supersetIndex built, keyed by the fingerprint of
+	// the label names of the frame each index was built for.
+	supersetIndexes map[data.Fingerprint][]cachedSupersetIndex
+	cached          int
+}
+
+// captureGroup holds the captures of one RefID that use the same set of label names.
+type captureGroup struct {
+	// keys are the label names shared by every member, sorted in ascending order.
+	keys    []string
+	members []NumberValueCapture
+	// byFingerprint holds the members keyed by the fingerprint of their own labels. The
+	// index method builds it on first use.
+	byFingerprint map[data.Fingerprint]NumberValueCapture
+}
+
+// cachedSupersetIndex holds one index and the label names of the frame it was built for.
+type cachedSupersetIndex struct {
+	keys     []string
+	captures map[data.Fingerprint][]NumberValueCapture
+}
+
+// appendSubsets appends the captures whose labels are a strict subset of labels.
+//
+// A capture is a subset when the frame holds every label name the capture uses, with the
+// same values. Projecting the frame labels onto the label names of a group tests both at
+// once: the projection does not exist when a name is missing, and it equals the
+// fingerprint of the capture's own labels when the values agree.
+func (r *refIDCaptures) appendSubsets(labels data.Labels, keys []string, dst []NumberValueCapture) []NumberValueCapture {
+	// A group with as many label names as the frame is skipped: such a capture can only
+	// match when its labels are equal, which the exact lookup already ruled out.
+	narrower := r.narrowerGroups(len(keys))
+	for i := range narrower {
+		group := &narrower[i]
+		fingerprint, ok := projectFingerprint(labels, group.keys)
+		if !ok {
+			continue // the frame does not hold one of the label names of this group
+		}
+		v, ok := group.index()[fingerprint]
+		if !ok {
+			continue
+		}
+		// Fingerprints are 64 bit, so two different label sets can share one. Attaching a
+		// candidate that is not a real subset would put the value of an unrelated series
+		// into the evaluation string, so confirm it.
+		if !labels.Contains(v.Labels) {
+			continue
+		}
+		dst = append(dst, v)
+	}
+	return dst
+}
+
+// appendSupersets appends the captures whose labels are a strict superset of labels.
+// keys holds the label names of labels, keySet the fingerprint of those names, and
+// fingerprint the fingerprint of labels itself.
+func (r *refIDCaptures) appendSupersets(labels data.Labels, keys []string, keySet, fingerprint data.Fingerprint, dst []NumberValueCapture) []NumberValueCapture {
+	wider := r.widerGroups(len(keys))
+	if len(wider) == 0 {
+		return dst
+	}
+
+	index, ok := r.supersetIndex(wider, keys, keySet)
+	if !ok {
+		// The RefID already holds as many cached indexes as it may. Compare the labels of
+		// the wider captures instead of building an index only this frame would read. Both
+		// walk the wider captures once, and the comparison allocates nothing. match sorts
+		// the matches afterwards, so the order they are found in does not matter.
+		for i := range wider {
+			for _, v := range wider[i].members {
+				if v.Labels.Contains(labels) {
+					dst = append(dst, v)
+				}
+			}
+		}
+		return dst
+	}
+
+	for _, v := range index[fingerprint] {
+		// As in appendSubsets, confirm the candidate to rule out a shared fingerprint.
+		if !v.Labels.Contains(labels) {
+			continue
+		}
+		dst = append(dst, v)
+	}
+	return dst
+}
+
+// supersetIndex indexes the captures of wider, the groups that use more label names than
+// the frame. keys holds the label names of the frame. The index keys each capture by the
+// fingerprint of its labels projected onto those names, so a capture holds the labels of
+// the frame when that projection equals the fingerprint of the frame labels.
+//
+// One index is cached per set of frame label names. supersetIndex reports false once the
+// cache is full, because an index the cache cannot keep would serve a single frame.
+func (r *refIDCaptures) supersetIndex(wider []captureGroup, keys []string, keySet data.Fingerprint) (map[data.Fingerprint][]NumberValueCapture, bool) {
+	for _, cached := range r.supersetIndexes[keySet] {
+		// Two sets of label names can share a fingerprint, so compare the names.
+		if slices.Equal(cached.keys, keys) {
+			return cached.captures, true
+		}
+	}
+	if r.cached >= maxCachedSupersetIndexes {
+		return nil, false
+	}
+
+	index := make(map[data.Fingerprint][]NumberValueCapture)
+	for i := range wider {
+		for _, capture := range wider[i].members {
+			fingerprint, ok := projectFingerprint(capture.Labels, keys)
+			if !ok {
+				continue // the capture does not hold one of the label names of the frame
+			}
+			index[fingerprint] = append(index[fingerprint], capture)
+		}
+	}
+
+	if r.supersetIndexes == nil {
+		r.supersetIndexes = make(map[data.Fingerprint][]cachedSupersetIndex, 1)
+	}
+	r.supersetIndexes[keySet] = append(r.supersetIndexes[keySet], cachedSupersetIndex{
+		keys:     slices.Clone(keys),
+		captures: index,
+	})
+	r.cached++
+	return index, true
+}
+
+// narrowerGroups returns the groups whose captures use fewer than n label names, and
+// widerGroups those that use more than n. Groups are sorted by how many names they use,
+// so a frame finds both ends with a binary search instead of walking every group.
+func (r *refIDCaptures) narrowerGroups(n int) []captureGroup {
+	groups := r.keySetGroups()
+	return groups[:sort.Search(len(groups), func(i int) bool { return len(groups[i].keys) >= n })]
+}
+
+func (r *refIDCaptures) widerGroups(n int) []captureGroup {
+	groups := r.keySetGroups()
+	return groups[sort.Search(len(groups), func(i int) bool { return len(groups[i].keys) > n }):]
+}
+
+// keySetGroups groups the captures of the RefID by the set of label names they use, and
+// sorts the groups by how many names that is.
+func (r *refIDCaptures) keySetGroups() []captureGroup {
+	if r.grouped {
+		return r.groups
+	}
+	r.grouped = true
+
+	var (
+		buf      []string
+		byKeySet = make(map[data.Fingerprint][]int, 1)
+	)
+	for _, capture := range r.byFingerprint {
+		buf = sortedLabelKeys(capture.Labels, buf[:0])
+		keySet := keySetFingerprint(buf)
+
+		group := -1
+		for _, i := range byKeySet[keySet] {
+			// Two sets of label names can share a fingerprint, so compare the names.
+			if slices.Equal(r.groups[i].keys, buf) {
+				group = i
+				break
+			}
+		}
+		if group < 0 {
+			group = len(r.groups)
+			r.groups = append(r.groups, captureGroup{keys: slices.Clone(buf)})
+			byKeySet[keySet] = append(byKeySet[keySet], group)
+		}
+		r.groups[group].members = append(r.groups[group].members, capture)
+	}
+
+	slices.SortFunc(r.groups, func(a, b captureGroup) int {
+		if c := cmp.Compare(len(a.keys), len(b.keys)); c != 0 {
+			return c
+		}
+		return slices.Compare(a.keys, b.keys)
+	})
+
+	if len(r.groups) == 1 {
+		// Every capture uses the same label names, so the RefID is one group, and that
+		// group can reuse the map the captures already live in.
+		r.groups[0].byFingerprint = r.byFingerprint
+	}
+	return r.groups
+}
+
+// index returns the members of the group keyed by the fingerprint of their own labels.
+func (g *captureGroup) index() map[data.Fingerprint]NumberValueCapture {
+	if g.byFingerprint == nil {
+		g.byFingerprint = make(map[data.Fingerprint]NumberValueCapture, len(g.members))
+		for _, capture := range g.members {
+			g.byFingerprint[capture.Labels.Fingerprint()] = capture
+		}
+	}
+	return g.byFingerprint
+}
+
+// orderedCapture is a capture with its labels already rendered, so that sorting a list of
+// captures renders the labels of each of them once.
+type orderedCapture struct {
+	labels  string
+	capture NumberValueCapture
+}
+
+func newOrderedCapture(capture NumberValueCapture) orderedCapture {
+	return orderedCapture{labels: capture.Labels.String(), capture: capture}
+}
+
+// compareCaptures puts captures in a fixed order, so an evaluation attaches them in the
+// same order however the runtime walks the maps that hold them.
+//
+// Var comes first because extractEvalString sorts the attached captures by Var alone.
+// That sort is stable, so captures that share a Var keep the order this comparison gave
+// them. The string extractEvalString builds then stays the same between evaluations of
+// unchanged data, and so does the capture extractValues picks among those sharing a Var.
+func compareCaptures(a, b orderedCapture) int {
+	if c := strings.Compare(a.capture.Var, b.capture.Var); c != 0 {
+		return c
+	}
+	if c := strings.Compare(a.labels, b.labels); c != 0 {
+		return c
+	}
+	if c := strings.Compare(a.capture.Type, b.capture.Type); c != 0 {
+		return c
+	}
+	if a.capture.IsDatasourceNode != b.capture.IsDatasourceNode {
+		if a.capture.IsDatasourceNode {
+			return 1
+		}
+		return -1
+	}
+	switch {
+	case a.capture.Value == nil && b.capture.Value == nil:
+		return 0
+	case a.capture.Value == nil:
+		return -1
+	case b.capture.Value == nil:
+		return 1
+	}
+	return cmp.Compare(*a.capture.Value, *b.capture.Value)
+}
+
+// The constants below are the 64-bit FNV-1 parameters of hash/fnv, and the separator
+// that data.Labels.Fingerprint writes after every label name and value. They are
+// repeated here so that projectFingerprint can hash a label set without allocating a
+// hasher or a byte slice. TestProjectFingerprint fails if the SDK changes any of them.
+const (
+	fnv1Offset64    uint64 = 14695981039346656037
+	fnv1Prime64     uint64 = 1099511628211
+	labelsSeparator uint64 = 255 // an invalid utf-8 sequence, as used by the SDK
+)
+
+// projectFingerprint returns the fingerprint of labels restricted to keys. keys must be
+// sorted in ascending order and must not repeat. The result equals the fingerprint the
+// SDK calculates for a data.Labels holding only those keys, so a projection and a full
+// fingerprint of the same pairs compare equal.
+//
+// projectFingerprint reports false when labels does not hold one of the keys. A missing
+// key means the projection does not exist. Hashing the remaining keys instead would
+// match label sets that do not carry that key at all.
+//
+// Hashing here beats copying the projected pairs into a data.Labels and calling
+// Fingerprint on it: that measured about three times slower and allocates a map per
+// projection.
+func projectFingerprint(labels data.Labels, keys []string) (data.Fingerprint, bool) {
+	h := fnv1Offset64
+	for _, name := range keys {
+		value, ok := labels[name]
+		if !ok {
+			return 0, false
+		}
+		h = hashLabelPart(h, name)
+		h = hashLabelPart(h, value)
+	}
+	return data.Fingerprint(h), true
+}
+
+// keySetFingerprint returns a fingerprint of the label names in keys, which must be
+// sorted in ascending order. Unlike projectFingerprint it ignores label values, so it
+// identifies the shape of a label set rather than its contents.
+func keySetFingerprint(keys []string) data.Fingerprint {
+	h := fnv1Offset64
+	for _, name := range keys {
+		h = hashLabelPart(h, name)
+	}
+	return data.Fingerprint(h)
+}
+
+// hashLabelPart adds a label name or value, followed by the separator, to an FNV-1 hash.
+func hashLabelPart(h uint64, s string) uint64 {
+	for i := range len(s) {
+		h *= fnv1Prime64
+		h ^= uint64(s[i])
+	}
+	h *= fnv1Prime64
+	h ^= labelsSeparator
+	return h
+}
+
+// sortedLabelKeys appends the names of labels to buf and sorts them in ascending order.
+func sortedLabelKeys(labels data.Labels, buf []string) []string {
+	for name := range labels {
+		buf = append(buf, name)
+	}
+	slices.Sort(buf)
+	return buf
+}

--- a/pkg/services/ngalert/eval/captures_test.go
+++ b/pkg/services/ngalert/eval/captures_test.go
@@ -1,0 +1,898 @@
+package eval
+
+import (
+	"fmt"
+	"math/rand"
+	"reflect"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/expr/classic"
+)
+
+func TestAttachCaptureValues(t *testing.T) {
+	testCases := []struct {
+		name string
+		// frame is the condition frame that receives the captures.
+		frame *data.Frame
+		// captures are the captured values of every query and expression.
+		captures capturesByRefID
+		// expected is the multiset of captures attached to the frame, in the format of
+		// captureKey. A nil value means that Meta.Custom must stay nil.
+		expected []string
+	}{
+		{
+			name:  "exact match suppresses subset and superset matching",
+			frame: floatFrame("B", data.Labels{"cluster": "a", "pod": "p"}),
+			captures: capturesOf(
+				capture("A", data.Labels{"cluster": "a", "pod": "p"}, 1),
+				capture("A", data.Labels{"cluster": "a"}, 2),
+				capture("A", data.Labels{"cluster": "a", "pod": "p", "job": "j"}, 3),
+			),
+			expected: []string{captureKey(capture("A", data.Labels{"cluster": "a", "pod": "p"}, 1))},
+		},
+		{
+			name:  "capture labels are a strict subset",
+			frame: floatFrame("B", data.Labels{"cluster": "a", "pod": "p"}),
+			captures: capturesOf(
+				capture("A", data.Labels{"cluster": "a"}, 1),
+			),
+			expected: []string{captureKey(capture("A", data.Labels{"cluster": "a"}, 1))},
+		},
+		{
+			name:  "capture labels are a strict superset",
+			frame: floatFrame("B", data.Labels{"cluster": "a"}),
+			captures: capturesOf(
+				capture("A", data.Labels{"cluster": "a", "pod": "p"}, 1),
+			),
+			expected: []string{captureKey(capture("A", data.Labels{"cluster": "a", "pod": "p"}, 1))},
+		},
+		{
+			name:  "incomparable label sets do not match",
+			frame: floatFrame("B", data.Labels{"cluster": "a"}),
+			captures: capturesOf(
+				capture("A", data.Labels{"namespace": "b"}, 1),
+			),
+			expected: nil,
+		},
+		{
+			name:  "same keys with a different value do not match",
+			frame: floatFrame("B", data.Labels{"cluster": "a"}),
+			captures: capturesOf(
+				capture("A", data.Labels{"cluster": "b"}, 1),
+			),
+			expected: nil,
+		},
+		{
+			name:  "equally sized but different key sets do not match",
+			frame: floatFrame("B", data.Labels{"cluster": "a", "pod": "p"}),
+			captures: capturesOf(
+				capture("A", data.Labels{"cluster": "a", "job": "j"}, 1),
+			),
+			expected: nil,
+		},
+		{
+			name:  "capture with empty labels matches every frame",
+			frame: floatFrame("B", data.Labels{"cluster": "a"}),
+			captures: capturesOf(
+				capture("A", data.Labels{}, 1),
+			),
+			expected: []string{captureKey(capture("A", data.Labels{}, 1))},
+		},
+		{
+			name:  "empty frame labels match nonempty captures",
+			frame: floatFrame("B", data.Labels{}),
+			captures: capturesOf(
+				capture("A", data.Labels{"cluster": "a"}, 1),
+				capture("A", data.Labels{"cluster": "b", "pod": "p"}, 2),
+			),
+			expected: []string{
+				captureKey(capture("A", data.Labels{"cluster": "a"}, 1)),
+				captureKey(capture("A", data.Labels{"cluster": "b", "pod": "p"}, 2)),
+			},
+		},
+		{
+			name:  "multiple fallback captures of one refID all match",
+			frame: floatFrame("B", data.Labels{"cluster": "a", "pod": "p"}),
+			captures: capturesOf(
+				capture("A", data.Labels{"cluster": "a"}, 1),
+				capture("A", data.Labels{"pod": "p"}, 2),
+				capture("A", data.Labels{"cluster": "a", "pod": "p", "job": "j"}, 3),
+				capture("A", data.Labels{"cluster": "a", "pod": "p", "job": "k"}, 4),
+				capture("A", data.Labels{"cluster": "b"}, 5),
+			),
+			expected: []string{
+				captureKey(capture("A", data.Labels{"cluster": "a"}, 1)),
+				captureKey(capture("A", data.Labels{"pod": "p"}, 2)),
+				captureKey(capture("A", data.Labels{"cluster": "a", "pod": "p", "job": "j"}, 3)),
+				captureKey(capture("A", data.Labels{"cluster": "a", "pod": "p", "job": "k"}, 4)),
+			},
+		},
+		{
+			name:  "every refID contributes its own matches",
+			frame: floatFrame("C", data.Labels{"cluster": "a", "pod": "p"}),
+			captures: capturesOf(
+				capture("A", data.Labels{"cluster": "a", "pod": "p"}, 1),
+				capture("B", data.Labels{"cluster": "a"}, 2),
+				capture("C", data.Labels{"cluster": "a", "pod": "p", "job": "j"}, 3),
+			),
+			expected: []string{
+				captureKey(capture("A", data.Labels{"cluster": "a", "pod": "p"}, 1)),
+				captureKey(capture("B", data.Labels{"cluster": "a"}, 2)),
+				captureKey(capture("C", data.Labels{"cluster": "a", "pod": "p", "job": "j"}, 3)),
+			},
+		},
+		{
+			name:  "frames with more than one field are skipped",
+			frame: twoFieldFrame("B", data.Labels{"cluster": "a"}),
+			captures: capturesOf(
+				capture("A", data.Labels{"cluster": "a"}, 1),
+			),
+			expected: nil,
+		},
+		{
+			name:  "frames with no fields are skipped",
+			frame: &data.Frame{RefID: "B"},
+			captures: capturesOf(
+				capture("A", data.Labels{"cluster": "a"}, 1),
+			),
+			expected: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			attachCaptureValues(data.Frames{tc.frame}, tc.captures)
+
+			require.NotNil(t, tc.frame.Meta, "metadata must always be reset")
+			if tc.expected == nil {
+				require.Nil(t, tc.frame.Meta.Custom)
+				return
+			}
+			require.ElementsMatch(t, tc.expected, captureKeys(t, tc.frame))
+		})
+	}
+
+	t.Run("classic condition frames are untouched", func(t *testing.T) {
+		matches := []classic.EvalMatch{{Metric: "metric", Value: new(1.0), Labels: data.Labels{"cluster": "a"}}}
+		frame := floatFrame("B", data.Labels{"cluster": "a"})
+		frame.SetMeta(&data.FrameMeta{Custom: matches})
+
+		attachCaptureValues(data.Frames{frame}, capturesOf(capture("A", data.Labels{"cluster": "a"}, 1)))
+
+		require.Equal(t, matches, frame.Meta.Custom)
+	})
+}
+
+// TestAttachCaptureValuesMatchesReference compares the matcher with a copy of the loop it
+// replaced. It is the main guard for the change: extractEvalString renders every attached
+// capture, so the full set of matches of a frame shows up in the evaluation string of an
+// alert instance.
+func TestAttachCaptureValuesMatchesReference(t *testing.T) {
+	const cases = 300
+
+	rnd := rand.New(rand.NewSource(20260805))
+	frameCount, captureCount := 0, 0
+	unmatched, multiMatched := 0, 0
+
+	for i := range cases {
+		specs, captures := randomCaptureCase(rnd)
+		frameCount += len(specs)
+		for _, byFingerprint := range captures {
+			captureCount += len(byFingerprint)
+		}
+
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			want := buildFrames(specs)
+			referenceAttachCaptureValues(want, captures)
+
+			got := buildFrames(specs)
+			attachCaptureValues(got, captures)
+
+			require.Len(t, got, len(want))
+			for j := range want {
+				if _, ok := want[j].Meta.Custom.([]classic.EvalMatch); ok {
+					require.Equal(t, want[j].Meta.Custom, got[j].Meta.Custom, "frame %d: classic metadata must be kept", j)
+					continue
+				}
+				if want[j].Meta.Custom == nil {
+					unmatched++
+					require.Nil(t, got[j].Meta.Custom, "frame %d: %s", j, specs[j])
+					continue
+				}
+				expected := captureKeys(t, want[j])
+				if len(expected) > 1 {
+					multiMatched++
+				}
+				require.ElementsMatch(t, expected, captureKeys(t, got[j]), "frame %d: %s", j, specs[j])
+			}
+		})
+	}
+
+	// Keep the generator honest. Without these counts it could drift into cases that match
+	// nothing, or that always match exactly one capture.
+	require.Greater(t, frameCount, 8000)
+	require.Greater(t, captureCount, 20000)
+	require.Greater(t, unmatched, 800)
+	require.Greater(t, multiMatched, 7000)
+}
+
+// TestAttachCaptureValuesIsDeterministic checks that the attached captures do not depend
+// on the order in which the runtime walks the maps that hold them. Grafana builds the
+// evaluation string of an alert instance from those captures, writes it to annotation
+// history and sends it to Alertmanager, so it must not change while the data does not.
+func TestAttachCaptureValuesIsDeterministic(t *testing.T) {
+	frameLabels := data.Labels{"cluster": "a", "pod": "p"}
+	list := []NumberValueCapture{
+		// Subsets, supersets and captures that share a Var, so that several captures of
+		// one RefID match the frame and extractValues has to pick a winner.
+		capture("A", data.Labels{"cluster": "a"}, 1),
+		capture("A", data.Labels{"pod": "p"}, 2),
+		capture("A", data.Labels{"cluster": "a", "pod": "p", "job": "j"}, 3),
+		capture("A", data.Labels{"cluster": "a", "pod": "p", "job": "k"}, 4),
+		capture("A", data.Labels{"cluster": "a", "pod": "p", "job": "l"}, 5),
+		capture("A", data.Labels{"cluster": "a", "pod": "p", "job": "m"}, 6),
+		capture("A", data.Labels{"cluster": "a", "pod": "p", "zone": "z"}, 7),
+		capture("A", data.Labels{}, 8),
+		capture("A", data.Labels{"cluster": "b"}, 9),    // does not match
+		capture("A", data.Labels{"namespace": "n"}, 10), // does not match
+		capture("C", data.Labels{"cluster": "a", "pod": "p"}, 11),
+		capture("D", data.Labels{"cluster": "a", "pod": "p", "job": "j"}, 12),
+		capture("D", data.Labels{"cluster": "a", "pod": "p", "job": "k"}, 13),
+		capture("D", data.Labels{"cluster": "a"}, 14),
+		capture("D", data.Labels{"pod": "p"}, 15),
+		capture("D", data.Labels{}, 16),
+	}
+
+	rnd := rand.New(rand.NewSource(7))
+	var (
+		wantOrder  []string
+		wantString string
+		wantValues map[string]NumberValueCapture
+	)
+	for i := range 100 {
+		shuffled := slices.Clone(list)
+		rnd.Shuffle(len(shuffled), func(a, b int) { shuffled[a], shuffled[b] = shuffled[b], shuffled[a] })
+
+		frame := floatFrame("B", frameLabels)
+		attachCaptureValues(data.Frames{frame}, capturesOf(shuffled...))
+
+		order := orderedCaptureKeys(t, frame)
+		// extractEvalString sorts the captures in place, and extractValues reads them
+		// afterwards, exactly as evaluateExecutionResult does.
+		evalString, values := extractEvalString(frame), extractValues(frame)
+
+		if i == 0 {
+			wantOrder, wantString, wantValues = order, evalString, values
+			require.Len(t, wantOrder, 14, "every matching capture must be attached")
+			continue
+		}
+		require.Equal(t, wantOrder, order)
+		require.Equal(t, wantString, evalString)
+		require.Equal(t, wantValues, values)
+	}
+}
+
+// TestCaptureIndexRejectsCollidingCandidates checks the comparison that confirms a
+// candidate found through a projection fingerprint. Fingerprints are 64 bit, so two
+// unrelated label sets can share one and end up in the same place in the index.
+func TestCaptureIndexRejectsCollidingCandidates(t *testing.T) {
+	frameLabels := data.Labels{"cluster": "a", "pod": "p"}
+	keys := sortedLabelKeys(frameLabels, nil)
+	fingerprint, _ := projectFingerprint(frameLabels, keys)
+	keySet := keySetFingerprint(keys)
+
+	// subsetGroup puts one capture in the bucket a subset of frameLabels would land in,
+	// whatever its labels really are. That is what a collision looks like to appendSubsets.
+	subsetGroup := func(c NumberValueCapture) []captureGroup {
+		subsetKeys := []string{"cluster"}
+		projected, ok := projectFingerprint(frameLabels, subsetKeys)
+		require.True(t, ok)
+		return []captureGroup{{
+			keys:          subsetKeys,
+			members:       []NumberValueCapture{c},
+			byFingerprint: map[data.Fingerprint]NumberValueCapture{projected: c},
+		}}
+	}
+
+	supersetMatching := capture("A", data.Labels{"cluster": "a", "pod": "p", "job": "j"}, 1)
+	supersetColliding := capture("A", data.Labels{"cluster": "b", "pod": "q", "job": "j"}, 2)
+
+	testCases := []struct {
+		name string
+		// captures is the state the lookup reads.
+		captures *refIDCaptures
+		// lookup is appendSubsets or appendSupersets, called for frameLabels.
+		lookup func(*refIDCaptures) []NumberValueCapture
+		// want is the captures the lookup must return.
+		want []NumberValueCapture
+	}{
+		{
+			name: "subset candidate of another series is rejected",
+			captures: &refIDCaptures{
+				byFingerprint: map[data.Fingerprint]NumberValueCapture{},
+				grouped:       true,
+				groups:        subsetGroup(capture("A", data.Labels{"cluster": "b"}, 1)),
+			},
+			lookup: func(r *refIDCaptures) []NumberValueCapture {
+				return r.appendSubsets(frameLabels, keys, nil)
+			},
+			want: nil,
+		},
+		{
+			name: "subset candidate of the same series is returned",
+			captures: &refIDCaptures{
+				byFingerprint: map[data.Fingerprint]NumberValueCapture{},
+				grouped:       true,
+				groups:        subsetGroup(capture("A", data.Labels{"cluster": "a"}, 2)),
+			},
+			lookup: func(r *refIDCaptures) []NumberValueCapture {
+				return r.appendSubsets(frameLabels, keys, nil)
+			},
+			want: []NumberValueCapture{capture("A", data.Labels{"cluster": "a"}, 2)},
+		},
+		{
+			name: "superset candidates in one bucket are checked one by one",
+			captures: &refIDCaptures{
+				byFingerprint: map[data.Fingerprint]NumberValueCapture{},
+				grouped:       true,
+				groups: []captureGroup{{
+					keys:    []string{"cluster", "job", "pod"},
+					members: []NumberValueCapture{supersetMatching, supersetColliding},
+				}},
+				// Both candidates sit in the bucket of the frame's own fingerprint, which
+				// is what a collision between their projections would produce.
+				supersetIndexes: map[data.Fingerprint][]cachedSupersetIndex{keySet: {{
+					keys:     keys,
+					captures: map[data.Fingerprint][]NumberValueCapture{fingerprint: {supersetMatching, supersetColliding}},
+				}}},
+				cached: 1,
+			},
+			lookup: func(r *refIDCaptures) []NumberValueCapture {
+				return r.appendSupersets(frameLabels, keys, keySet, fingerprint, nil)
+			},
+			want: []NumberValueCapture{supersetMatching},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.lookup(tc.captures))
+		})
+	}
+}
+
+// TestCaptureGroupsByKeySet checks the grouping the fallback lookups are built on.
+func TestCaptureGroupsByKeySet(t *testing.T) {
+	captures := &refIDCaptures{byFingerprint: capturesOf(
+		capture("A", data.Labels{"cluster": "a"}, 1),
+		capture("A", data.Labels{"cluster": "b"}, 2),
+		capture("A", data.Labels{"cluster": "a", "pod": "p"}, 3),
+		capture("A", data.Labels{}, 4),
+	)["A"]}
+
+	groups := captures.keySetGroups()
+	require.Len(t, groups, 3)
+	require.True(t, slices.IsSortedFunc(groups, func(a, b captureGroup) int {
+		return len(a.keys) - len(b.keys)
+	}), "groups must be sorted by the number of label names they use")
+	require.Equal(t, groups[:2], captures.narrowerGroups(2))
+	require.Equal(t, groups[2:], captures.widerGroups(1))
+
+	byKeys := map[string]captureGroup{}
+	for _, group := range groups {
+		byKeys[strings.Join(group.keys, ",")] = group
+	}
+	for _, tc := range []struct {
+		keys    string
+		members int
+	}{
+		{keys: "", members: 1},
+		{keys: "cluster", members: 2},
+		{keys: "cluster,pod", members: 1},
+	} {
+		t.Run("group "+tc.keys, func(t *testing.T) {
+			require.Len(t, byKeys[tc.keys].members, tc.members)
+		})
+	}
+
+	// A single group reuses the map the captures already live in.
+	one := &refIDCaptures{byFingerprint: capturesOf(
+		capture("A", data.Labels{"cluster": "a"}, 1),
+		capture("A", data.Labels{"cluster": "b"}, 2),
+	)["A"]}
+	require.Len(t, one.keySetGroups(), 1)
+	require.Equal(t, one.byFingerprint, one.keySetGroups()[0].index())
+}
+
+// TestSupersetIndexCache checks that the index is reused for frames that share their
+// label names, and that the number of cached indexes stays bounded.
+func TestSupersetIndexCache(t *testing.T) {
+	captures := &refIDCaptures{byFingerprint: capturesOf(
+		capture("A", data.Labels{"cluster": "a", "pod": "p"}, 1),
+	)["A"]}
+
+	indexFor := func(names []string) (map[data.Fingerprint][]NumberValueCapture, bool) {
+		return captures.supersetIndex(captures.widerGroups(len(names)), names, keySetFingerprint(names))
+	}
+
+	keys := []string{"cluster"}
+	first, ok := indexFor(keys)
+	require.True(t, ok)
+	require.Len(t, first, 1)
+	// The second call for the same label names returns the same index.
+	second, ok := indexFor(keys)
+	require.True(t, ok)
+	require.Equal(t, reflect.ValueOf(first).Pointer(), reflect.ValueOf(second).Pointer())
+
+	// Captures with as many labels as the frame, or fewer, are not indexed at all.
+	require.Empty(t, captures.widerGroups(2))
+
+	for i := range maxCachedSupersetIndexes + 4 {
+		indexFor([]string{"cluster" + strconv.Itoa(i)})
+	}
+	require.Equal(t, maxCachedSupersetIndexes, captures.cached)
+
+	// Once the cache is full, a set of label names that is not in it gets no index and
+	// the caller compares labels instead.
+	_, ok = indexFor([]string{"pod"})
+	require.False(t, ok)
+	// Names that are already cached still get their index.
+	_, ok = indexFor(keys)
+	require.True(t, ok)
+
+	// match reuses one buffer for the label names of every frame, so the cache must copy
+	// them. An aliased entry would answer for whichever frame was matched last.
+	cached := captures.supersetIndexes[keySetFingerprint(keys)]
+	require.Len(t, cached, 1)
+	keys[0] = "overwritten"
+	require.Equal(t, []string{"cluster"}, cached[0].keys)
+}
+
+// TestAttachCaptureValuesBeyondSupersetIndexCache checks the fallback for frames whose
+// label names the cache has no room for. Those frames compare labels instead of building
+// an index, and must still get the same captures.
+func TestAttachCaptureValuesBeyondSupersetIndexCache(t *testing.T) {
+	const shapes = maxCachedSupersetIndexes + 5
+
+	specs := make([]frameSpec, 0, shapes)
+	list := make([]NumberValueCapture, 0, shapes)
+	for i := range shapes {
+		// Every frame uses its own label name, so every frame needs its own index, and
+		// every frame has one strict superset capture and one capture it cannot match.
+		name := "shape" + strconv.Itoa(i)
+		specs = append(specs, frameSpec{labels: data.Labels{name: "v"}, fields: 1})
+		list = append(list,
+			capture("A", data.Labels{name: "v", "pod": "p"}, float64(i)),
+			capture("A", data.Labels{name: "other", "pod": "p"}, float64(i)))
+	}
+	captures := capturesOf(list...)
+
+	want := buildFrames(specs)
+	referenceAttachCaptureValues(want, captures)
+
+	got := buildFrames(specs)
+	attachCaptureValues(got, captures)
+
+	for i := range want {
+		require.Equal(t, []string{captureKey(list[2*i])}, captureKeys(t, want[i]), "frame %d", i)
+		require.Equal(t, captureKeys(t, want[i]), captureKeys(t, got[i]), "frame %d", i)
+	}
+}
+
+func TestCompareCaptures(t *testing.T) {
+	ascending := []NumberValueCapture{
+		{Var: "A", Labels: data.Labels{"cluster": "a"}, Type: "reduce"},
+		{Var: "A", Labels: data.Labels{"cluster": "a"}, Type: "reduce", Value: new(1.0)},
+		{Var: "A", Labels: data.Labels{"cluster": "a"}, Type: "reduce", Value: new(2.0)},
+		{Var: "A", Labels: data.Labels{"cluster": "a"}, Type: "threshold"},
+		{Var: "A", Labels: data.Labels{"cluster": "a", "pod": "p"}, Type: "reduce"},
+		{Var: "A", Labels: data.Labels{"cluster": "b"}, Type: "reduce"},
+		{Var: "B", Labels: data.Labels{"cluster": "a"}, Type: "reduce"},
+	}
+	for i := range ascending {
+		a := newOrderedCapture(ascending[i])
+		require.Zero(t, compareCaptures(a, a), "%d must equal itself", i)
+		for j := i + 1; j < len(ascending); j++ {
+			b := newOrderedCapture(ascending[j])
+			require.Negative(t, compareCaptures(a, b), "%d must sort before %d", i, j)
+			require.Positive(t, compareCaptures(b, a), "%d must sort after %d", j, i)
+		}
+	}
+
+	// A capture of a query and a capture of an expression are told apart.
+	expression := newOrderedCapture(NumberValueCapture{Var: "A"})
+	query := newOrderedCapture(NumberValueCapture{Var: "A", IsDatasourceNode: true})
+	require.Negative(t, compareCaptures(expression, query))
+	require.Positive(t, compareCaptures(query, expression))
+}
+
+// TestProjectFingerprint pins the helper against the SDK. projectFingerprint repeats the
+// FNV-1 parameters and the byte layout of data.Labels.Fingerprint, so the two must agree
+// for a projection and a full fingerprint of the same pairs to be comparable.
+func TestProjectFingerprint(t *testing.T) {
+	labels := data.Labels{"a": "1", "b": "2", "c": "3"}
+
+	testCases := []struct {
+		name string
+		// labels the projection reads.
+		labels data.Labels
+		// keys the projection is restricted to, sorted in ascending order.
+		keys []string
+		// want holds the key/value pairs whose SDK fingerprint the projection must equal.
+		// It is only read when present is true.
+		want    data.Labels
+		present bool
+	}{
+		{
+			name:    "projection onto all keys equals the fingerprint of the label set",
+			labels:  labels,
+			keys:    []string{"a", "b", "c"},
+			want:    labels,
+			present: true,
+		},
+		{
+			name:    "projection onto a strict subset equals the fingerprint of that subset",
+			labels:  labels,
+			keys:    []string{"a", "c"},
+			want:    data.Labels{"a": "1", "c": "3"},
+			present: true,
+		},
+		{
+			name:    "projection onto no keys equals the fingerprint of empty labels",
+			labels:  labels,
+			keys:    nil,
+			want:    data.Labels{},
+			present: true,
+		},
+		{
+			name:    "empty labels project onto no keys",
+			labels:  data.Labels{},
+			keys:    nil,
+			want:    data.Labels{},
+			present: true,
+		},
+		{
+			name:    "a missing key is reported instead of hashing a shorter set",
+			labels:  data.Labels{"a": "1"},
+			keys:    []string{"a", "b"},
+			present: false,
+		},
+		{
+			name:    "empty labels report every key as missing",
+			labels:  data.Labels{},
+			keys:    []string{"a"},
+			present: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, present := projectFingerprint(tc.labels, tc.keys)
+			require.Equal(t, tc.present, present)
+			if !tc.present {
+				return
+			}
+			require.Equal(t, tc.want.Fingerprint(), got)
+		})
+	}
+
+	t.Run("projections agree with the SDK for random label sets", func(t *testing.T) {
+		rnd := rand.New(rand.NewSource(1))
+		names := []string{"cluster", "namespace", "pod", "job", "instance", "__name__", "", "ünïcode"}
+		for range 500 {
+			full := data.Labels{}
+			for _, i := range rnd.Perm(len(names))[:1+rnd.Intn(len(names)-1)] {
+				full[names[i]] = strconv.Itoa(rnd.Intn(10))
+			}
+			keys := sortedLabelKeys(full, nil)
+			keys = keys[:1+rnd.Intn(len(keys))]
+
+			projected := data.Labels{}
+			for _, name := range keys {
+				projected[name] = full[name]
+			}
+
+			got, present := projectFingerprint(full, keys)
+			require.True(t, present)
+			require.Equal(t, projected.Fingerprint(), got, "labels=%v keys=%v", full, keys)
+		}
+	})
+}
+
+func TestKeySetFingerprint(t *testing.T) {
+	testCases := []struct {
+		name  string
+		a, b  []string
+		equal bool
+	}{
+		{
+			name:  "the same names hash the same",
+			a:     []string{"a", "b"},
+			b:     []string{"a", "b"},
+			equal: true,
+		},
+		{
+			name: "different names hash differently",
+			a:    []string{"a", "b"},
+			b:    []string{"a", "c"},
+		},
+		{
+			// Names are separated, so a key set is not confused with a longer name.
+			name: "two names do not hash as their concatenation",
+			a:    []string{"a", "b"},
+			b:    []string{"ab"},
+		},
+		{
+			name: "a name is not dropped for being empty",
+			a:    []string{"a", ""},
+			b:    []string{"a"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.equal {
+				require.Equal(t, keySetFingerprint(tc.a), keySetFingerprint(tc.b))
+				return
+			}
+			require.NotEqual(t, keySetFingerprint(tc.a), keySetFingerprint(tc.b))
+		})
+	}
+}
+
+func TestSortedLabelKeys(t *testing.T) {
+	testCases := []struct {
+		name   string
+		labels data.Labels
+		// buf is the buffer to append to, as match reuses one across frames.
+		buf  []string
+		want []string
+	}{
+		{
+			name:   "names are sorted",
+			labels: data.Labels{"c": "3", "a": "1", "b": "2"},
+			want:   []string{"a", "b", "c"},
+		},
+		{
+			name:   "empty labels give no names",
+			labels: data.Labels{},
+			want:   nil,
+		},
+		{
+			name:   "a reused buffer keeps only the new names",
+			labels: data.Labels{"c": "3"},
+			buf:    []string{"a", "b"},
+			want:   []string{"c"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, sortedLabelKeys(tc.labels, tc.buf[:0]))
+		})
+	}
+}
+
+// referenceAttachCaptureValues is a copy of the capture matching loop as it was before
+// the projection index replaced it. Tests compare the two implementations.
+func referenceAttachCaptureValues(frames data.Frames, captures capturesByRefID) {
+	for _, frame := range frames {
+		if frame.Meta != nil && frame.Meta.Custom != nil {
+			if _, ok := frame.Meta.Custom.([]classic.EvalMatch); ok {
+				continue // do not overwrite EvalMatch from classic condition.
+			}
+		}
+
+		frame.SetMeta(&data.FrameMeta{}) // overwrite metadata
+
+		if len(frame.Fields) == 1 {
+			theseLabels := frame.Fields[0].Labels
+			fp := theseLabels.Fingerprint()
+
+			for _, fps := range captures {
+				// First look for a capture whose labels are an exact match
+				if v, ok := fps[fp]; ok {
+					if frame.Meta.Custom == nil {
+						frame.Meta.Custom = []NumberValueCapture{}
+					}
+					frame.Meta.Custom = append(frame.Meta.Custom.([]NumberValueCapture), v)
+				} else {
+					// If no exact match was found, look for captures whose labels are either subsets
+					// or supersets
+					for _, v := range fps {
+						// matching labels are equal labels, or when one set of labels includes the labels of the other.
+						if theseLabels.Equals(v.Labels) || theseLabels.Contains(v.Labels) || v.Labels.Contains(theseLabels) {
+							if frame.Meta.Custom == nil {
+								frame.Meta.Custom = []NumberValueCapture{}
+							}
+							frame.Meta.Custom = append(frame.Meta.Custom.([]NumberValueCapture), v)
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// frameSpec describes a condition frame so that the same frame can be built twice, once
+// for each implementation under comparison.
+type frameSpec struct {
+	labels data.Labels
+	// fields is the number of fields of the frame. Only frames with a single field take
+	// part in capture matching.
+	fields int
+	// classic marks a frame that already carries the metadata of a classic condition.
+	classic bool
+}
+
+func (s frameSpec) String() string {
+	return fmt.Sprintf("labels={%s} fields=%d classic=%t", s.labels, s.fields, s.classic)
+}
+
+func buildFrames(specs []frameSpec) data.Frames {
+	frames := make(data.Frames, 0, len(specs))
+	for _, spec := range specs {
+		var frame *data.Frame
+		switch spec.fields {
+		case 0:
+			frame = &data.Frame{RefID: "B"}
+		case 1:
+			frame = floatFrame("B", spec.labels)
+		default:
+			frame = twoFieldFrame("B", spec.labels)
+		}
+		if spec.classic {
+			frame.SetMeta(&data.FrameMeta{Custom: []classic.EvalMatch{{
+				Metric: "metric", Value: new(1.0), Labels: spec.labels,
+			}}})
+		}
+		frames = append(frames, frame)
+	}
+	return frames
+}
+
+// randomCaptureCase generates condition frames and captures that cover exact, subset,
+// superset, empty, incomparable and multiple matches, as well as classic frames and
+// frames of a shape that cannot hold captures.
+//
+// The alphabet is wide enough that two label sets can differ in a name, in a value, or in
+// both, and label sets range from empty to wider than any frame. Names that sort around
+// the same neighbourhood, and names that are a prefix of another, are in the list because
+// projectFingerprint hashes sorted names with a separator between them.
+func randomCaptureCase(rnd *rand.Rand) ([]frameSpec, capturesByRefID) {
+	keys := []string{
+		"cluster", "namespace", "pod", "job", "instance", "__name__",
+		"zone", "region", "", "pod_name", "po", "ünïcode",
+	}
+	values := []string{"a", "b", "c", "", "aa", "ünïcode"}
+
+	randomLabels := func(size int) data.Labels {
+		labels := make(data.Labels, size)
+		for _, i := range rnd.Perm(len(keys))[:size] {
+			labels[keys[i]] = values[rnd.Intn(len(values))]
+		}
+		return labels
+	}
+
+	specs := make([]frameSpec, 0, 40)
+	for range 20 + rnd.Intn(20) {
+		spec := frameSpec{labels: randomLabels(rnd.Intn(6)), fields: 1}
+		switch rnd.Intn(20) {
+		case 0:
+			spec.classic = true
+		case 1:
+			spec.fields = 2
+		case 2:
+			spec.fields = 0
+		}
+		specs = append(specs, spec)
+	}
+
+	captures := capturesByRefID{}
+	for _, refID := range []string{"A", "C", "D"} {
+		for range 20 + rnd.Intn(20) {
+			labels := randomLabels(rnd.Intn(8))
+			// Half of the captures start from the labels of a condition frame, so that
+			// exact, subset and superset matches all occur.
+			if len(specs) > 0 && rnd.Intn(2) == 0 {
+				labels = specs[rnd.Intn(len(specs))].labels.Copy()
+				switch rnd.Intn(5) {
+				case 0: // one name more
+					labels[keys[rnd.Intn(len(keys))]] = values[rnd.Intn(len(values))]
+				case 1: // one name fewer
+					for k := range labels {
+						delete(labels, k)
+						break
+					}
+				case 2: // the same names, one value changed
+					for k := range labels {
+						labels[k] = values[rnd.Intn(len(values))]
+						break
+					}
+				case 3: // one name swapped for another
+					for k := range labels {
+						delete(labels, k)
+						labels[keys[rnd.Intn(len(keys))]] = values[rnd.Intn(len(values))]
+						break
+					}
+				}
+			}
+			addCapture(captures, capture(refID, labels, rnd.Float64()))
+		}
+	}
+	return specs, captures
+}
+
+func floatFrame(refID string, labels data.Labels) *data.Frame {
+	return &data.Frame{
+		RefID:  refID,
+		Fields: data.Fields{data.NewField("Value", labels, []*float64{new(1.0)})},
+	}
+}
+
+func twoFieldFrame(refID string, labels data.Labels) *data.Frame {
+	frame := floatFrame(refID, labels)
+	frame.Fields = append(frame.Fields, data.NewField("Value2", labels, []*float64{new(2.0)}))
+	return frame
+}
+
+func capture(refID string, labels data.Labels, value float64) NumberValueCapture {
+	return NumberValueCapture{
+		Var:    refID,
+		Labels: labels,
+		Type:   "reduce",
+		Value:  &value,
+	}
+}
+
+func capturesOf(list ...NumberValueCapture) capturesByRefID {
+	captures := capturesByRefID{}
+	for _, c := range list {
+		addCapture(captures, c)
+	}
+	return captures
+}
+
+func addCapture(captures capturesByRefID, c NumberValueCapture) {
+	byFingerprint := captures[c.Var]
+	if byFingerprint == nil {
+		byFingerprint = map[data.Fingerprint]NumberValueCapture{}
+		captures[c.Var] = byFingerprint
+	}
+	byFingerprint[c.Labels.Fingerprint()] = c
+}
+
+// captureKey identifies a capture by everything a reader of Meta.Custom can observe.
+func captureKey(c NumberValueCapture) string {
+	value := "null"
+	if c.Value != nil {
+		value = strconv.FormatFloat(*c.Value, 'g', -1, 64)
+	}
+	return fmt.Sprintf("var=%s labels={%s} type=%s datasource=%t value=%s", c.Var, c.Labels, c.Type, c.IsDatasourceNode, value)
+}
+
+// orderedCaptureKeys returns the attached captures in the order they were attached in.
+func orderedCaptureKeys(t *testing.T, frame *data.Frame) []string {
+	t.Helper()
+	captures, ok := frame.Meta.Custom.([]NumberValueCapture)
+	require.True(t, ok, "frame metadata must hold captures, got %T", frame.Meta.Custom)
+	keys := make([]string, 0, len(captures))
+	for _, c := range captures {
+		keys = append(keys, captureKey(c))
+	}
+	return keys
+}
+
+func captureKeys(t *testing.T, frame *data.Frame) []string {
+	t.Helper()
+	keys := orderedCaptureKeys(t, frame)
+	sort.Strings(keys)
+	return keys
+}

--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/expr"
-	"github.com/grafana/grafana/pkg/expr/classic"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -568,43 +567,7 @@ func queryDataResponseToExecutionResults(c models.Condition, execResp *backend.Q
 	}
 
 	// add capture values as data frame metadata to each result (frame) that has matching labels.
-	for _, frame := range result.Condition {
-		// classic conditions already have metadata set and only have one value, there's no need to add anything in this case.
-		if frame.Meta != nil && frame.Meta.Custom != nil {
-			if _, ok := frame.Meta.Custom.([]classic.EvalMatch); ok {
-				continue // do not overwrite EvalMatch from classic condition.
-			}
-		}
-
-		frame.SetMeta(&data.FrameMeta{}) // overwrite metadata
-
-		if len(frame.Fields) == 1 {
-			theseLabels := frame.Fields[0].Labels
-			fp := theseLabels.Fingerprint()
-
-			for _, fps := range captures {
-				// First look for a capture whose labels are an exact match
-				if v, ok := fps[fp]; ok {
-					if frame.Meta.Custom == nil {
-						frame.Meta.Custom = []NumberValueCapture{}
-					}
-					frame.Meta.Custom = append(frame.Meta.Custom.([]NumberValueCapture), v)
-				} else {
-					// If no exact match was found, look for captures whose labels are either subsets
-					// or supersets
-					for _, v := range fps {
-						// matching labels are equal labels, or when one set of labels includes the labels of the other.
-						if theseLabels.Equals(v.Labels) || theseLabels.Contains(v.Labels) || v.Labels.Contains(theseLabels) {
-							if frame.Meta.Custom == nil {
-								frame.Meta.Custom = []NumberValueCapture{}
-							}
-							frame.Meta.Custom = append(frame.Meta.Custom.([]NumberValueCapture), v)
-						}
-					}
-				}
-			}
-		}
-	}
+	attachCaptureValues(result.Condition, captures)
 
 	return result
 }

--- a/pkg/services/ngalert/eval/eval_bench_test.go
+++ b/pkg/services/ngalert/eval/eval_bench_test.go
@@ -2,6 +2,7 @@ package eval
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"testing"
 	"time"
@@ -33,6 +34,46 @@ func BenchmarkEvaluate(b *testing.B) {
 	}
 }
 
+// BenchmarkCaptureMatching measures attaching captures to condition frames, the step
+// that dominates evaluation CPU when rules return many series.
+//
+// The exact case is the fast path: a capture and its condition frame have the same label
+// fingerprint. The superset and subset cases miss that lookup, so the matcher projects
+// labels onto the label names the two sides share. A binary math expression produces the
+// superset shape in practice, because its result takes the wider of its two operand
+// label sets.
+func BenchmarkCaptureMatching(b *testing.B) {
+	shapes := []struct {
+		name string
+		// extra is how many labels are added to the capture side, and drop says whether
+		// one of its labels is removed.
+		extra int
+		drop  bool
+	}{
+		{name: "exact"},
+		{name: "superset", extra: 1},
+		{name: "subset", drop: true},
+	}
+	for _, shape := range shapes {
+		for _, n := range []int{2000, 8000} {
+			b.Run(fmt.Sprintf("%s/%d", shape.name, n), func(b *testing.B) {
+				condition := models.Condition{Condition: "B", Data: []models.AlertQuery{
+					{RefID: "A", DatasourceUID: expr.DatasourceUID},
+					{RefID: "B", DatasourceUID: expr.DatasourceUID},
+				}}
+				var resp backend.QueryDataResponse
+				seedCaptureResponse(&resp, n, shape.extra, shape.drop)
+
+				b.ReportAllocs()
+				b.ResetTimer() // building the response above is not part of the measurement
+				for range b.N {
+					queryDataResponseToExecutionResults(condition, &resp)
+				}
+			})
+		}
+	}
+}
+
 func seedDataResponse(r *backend.QueryDataResponse, n int) {
 	resps := make(backend.Responses, n)
 	for i := 0; i < n; i++ {
@@ -54,5 +95,39 @@ func seedDataResponse(r *backend.QueryDataResponse, n int) {
 		})
 		resps["A"], resps["B"] = a, b
 	}
+	r.Responses = resps
+}
+
+// seedCaptureResponse builds n single value frames for refID A and n for refID B, the
+// condition. Every single value frame becomes a capture, so each condition frame finds
+// an exact match among the captures of B, then looks for the capture of A of the same
+// series. Adding or dropping a label on the A side changes its fingerprint, so that
+// second lookup misses and takes the fallback.
+func seedCaptureResponse(r *backend.QueryDataResponse, n, extra int, drop bool) {
+	resps := make(backend.Responses, 2)
+	a, b := resps["A"], resps["B"]
+	for i := range n {
+		conditionLabels := data.Labels{
+			"foo":      strconv.Itoa(i),
+			"bar":      strconv.Itoa(i + 1),
+			"instance": strconv.Itoa(i + 2),
+		}
+		captureLabels := conditionLabels.Copy()
+		for j := range extra {
+			captureLabels["extra"+strconv.Itoa(j)] = strconv.Itoa(i)
+		}
+		if drop {
+			delete(captureLabels, "instance")
+		}
+		a.Frames = append(a.Frames, &data.Frame{
+			RefID:  "A",
+			Fields: data.Fields{data.NewField("Value", captureLabels, []*float64{new(1.0)})},
+		})
+		b.Frames = append(b.Frames, &data.Frame{
+			RefID:  "B",
+			Fields: data.Fields{data.NewField("Value", conditionLabels, []*float64{new(1.0)})},
+		})
+	}
+	resps["A"], resps["B"] = a, b
 	r.Responses = resps
 }

--- a/pkg/services/ngalert/eval/extract_md.go
+++ b/pkg/services/ngalert/eval/extract_md.go
@@ -10,6 +10,9 @@ import (
 	"github.com/grafana/grafana/pkg/expr/classic"
 )
 
+// extractEvalString renders the captures, or the classic evaluation matches, attached to
+// a frame. The sort below is stable, so captures that share a Var keep the order
+// attachCaptureValues gave them. See compareCaptures for why that order matters.
 func extractEvalString(frame *data.Frame) (s string) {
 	if frame == nil {
 		return "empty frame"
@@ -46,7 +49,7 @@ func extractEvalString(frame *data.Frame) (s string) {
 
 	if captures, ok := frame.Meta.Custom.([]NumberValueCapture); ok {
 		// Sort captures in ascending order of "Var" so we can assert in tests
-		sort.Slice(captures, func(i, j int) bool {
+		sort.SliceStable(captures, func(i, j int) bool {
 			return captures[i].Var < captures[j].Var
 		})
 		sb := strings.Builder{}

--- a/pkg/services/ngalert/eval/extract_md_test.go
+++ b/pkg/services/ngalert/eval/extract_md_test.go
@@ -1,6 +1,7 @@
 package eval
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -52,6 +53,67 @@ func TestExtractEvalString(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
 			require.Equal(t, tc.outString, extractEvalString(tc.inFrame))
+		})
+	}
+}
+
+// TestExtractEvalStringKeepsOrderWithinVar checks that rendering keeps the order the
+// captures arrived in. attachCaptureValues sorts the captures of one RefID with
+// compareCaptures, and the sort by Var in extractEvalString must not undo that.
+//
+// Every case carries thirteen captures because sort.Slice and sort.SliceStable only
+// differ above twelve elements. Below that both run an insertion sort, which is stable.
+//
+// This is a separate test rather than another case of TestExtractEvalString because the
+// expected value here is an order, and spelling thirteen captures out as one rendered
+// string would hide which one moved.
+func TestExtractEvalStringKeepsOrderWithinVar(t *testing.T) {
+	testCases := []struct {
+		name string
+		// vars gives the Var of each capture. The value of a capture is its position
+		// here, so want can name the captures by the order they went in.
+		vars []string
+		want []float64
+	}{
+		{
+			name: "already grouped by Var",
+			vars: []string{"A", "A", "A", "A", "A", "A", "A", "A", "A", "A", "B", "B", "B"},
+			want: []float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
+		},
+		{
+			name: "interleaved Vars",
+			vars: []string{"B", "A", "A", "A", "A", "B", "A", "A", "A", "A", "B", "A", "A"},
+			want: []float64{1, 2, 3, 4, 6, 7, 8, 9, 11, 12, 0, 5, 10},
+		},
+		{
+			name: "Vars in reverse order",
+			vars: []string{"B", "B", "B", "B", "B", "B", "A", "A", "A", "A", "A", "A", "A"},
+			want: []float64{6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, 5},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			captures := make([]NumberValueCapture, 0, len(tc.vars))
+			for i, v := range tc.vars {
+				captures = append(captures, NumberValueCapture{
+					Var:    v,
+					Labels: data.Labels{"host": strconv.Itoa(i)},
+					Type:   "reduce",
+					Value:  new(float64(i)),
+				})
+			}
+
+			frame := newMetaFrame(captures, new(1.0))
+			extractEvalString(frame)
+
+			// extractEvalString sorts Meta.Custom in place, so the slice now holds the
+			// order the captures were rendered in.
+			var order []float64
+			for _, c := range frame.Meta.Custom.([]NumberValueCapture) {
+				order = append(order, *c.Value)
+			}
+			require.Equal(t, tc.want, order)
 		})
 	}
 }


### PR DESCRIPTION
**What is this feature?**

Attaching capture values to condition frames looked up captures by an exact label fingerprint. On a miss it scanned every capture of the RefID, so the cost was frames*captures.

Index the captures by their set of label names instead. A subset or superset match now hashes only the labels the two sets share, so a frame pays for the number of distinct label-name sets, not for the number of captures. Each candidate is still confirmed with a Contains comparison, because two label sets can share a fingerprint.

Matches are attached in sorted order, so the evaluation string stays the same between evaluations of unchanged data.

Benchmark at 8000 frames and 8000 captures: superset 3217 ms to 11.1 ms, subset 3500 ms to 8.9 ms. The exact-match path is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core alert evaluation metadata matching and ordering that feed evaluation strings and per-RefID values; behavior is heavily tested against the prior implementation but wrong matches would misrepresent firing context.
> 
> **Overview**
> Replaces the inline **frames × captures** scan in alert evaluation with a dedicated **`attachCaptureValues`** path that indexes captures by RefID and label fingerprints, then matches condition frames via exact lookup plus subset/superset resolution using projected label hashes (with **`Contains`** checks for fingerprint collisions).
> 
> **Determinism:** Matches per RefID are sorted with **`compareCaptures`**, and **`extractEvalString`** now uses **`sort.SliceStable`** so evaluation strings and **`extractValues`** winners stay stable across map iteration order (annotation history / Alertmanager text).
> 
> **Tests & benchmarks:** Extensive property tests against the old reference loop, collision/cache edge cases, and **`BenchmarkCaptureMatching`** for exact/subset/superset at 2k/8k series.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbf5a37a75a1f02362ab3c2fd0fb41eed27b9564. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->