### PR TITLE
Apiserver: Add KV reader for the version policy

### DIFF
--- a/pkg/cmd/grafana-cli/commands/resource_db_migrate_test.go
+++ b/pkg/cmd/grafana-cli/commands/resource_db_migrate_test.go
@@ -26,6 +26,7 @@ var kvTables = []string{
 	"search_snapshot_data",
 	"resource_stats_daily",
 	"resource_stats_aggregates",
+	"resource_version_policy",
 }
 
 func TestIntegrationResourceDbMigrate(t *testing.T) {

--- a/pkg/services/apiserver/versionpolicy/kv_reader.go
+++ b/pkg/services/apiserver/versionpolicy/kv_reader.go
@@ -1,0 +1,75 @@
+package versionpolicy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+
+	"github.com/grafana/grafana/pkg/storage/unified/resource/kv"
+)
+
+const readBatchSize = 50
+
+// KVReader reads the operator-set runtime layer from KV, one entry per group. A nil reader or store
+// reads as no layer, so the registry falls back to ini.
+type KVReader struct {
+	store kv.KV
+}
+
+func NewKVReader(store kv.KV) *KVReader {
+	return &KVReader{store: store}
+}
+
+// Read loads the per-group runtime layer. An error is returned rather than partially applied, so the
+// caller keeps its last-known layer.
+func (r *KVReader) Read(ctx context.Context) (map[string]VersionPolicy, error) {
+	if r == nil || r.store == nil {
+		return nil, nil
+	}
+
+	var keys []string
+	for key, err := range r.store.Keys(ctx, kv.VersionPolicySection, kv.ListOptions{}) {
+		if err != nil {
+			return nil, err
+		}
+		keys = append(keys, key)
+	}
+	if len(keys) == 0 {
+		return map[string]VersionPolicy{}, nil
+	}
+
+	layer := make(map[string]VersionPolicy, len(keys))
+	for batch := range slices.Chunk(keys, readBatchSize) {
+		for kve, err := range r.store.BatchGet(ctx, kv.VersionPolicySection, batch) {
+			if err != nil {
+				return nil, err
+			}
+			var p VersionPolicy
+			dec := json.NewDecoder(kve.Value)
+			dec.DisallowUnknownFields()
+			decodeErr := dec.Decode(&p)
+			_ = kve.Value.Close()
+			if decodeErr != nil {
+				return nil, fmt.Errorf("version policy: decoding KV value for group %q: %w", kve.Key, decodeErr)
+			}
+			if err := validatePolicy(p); err != nil {
+				return nil, fmt.Errorf("version policy: invalid entry for group %q: %w", kve.Key, err)
+			}
+			layer[kve.Key] = p
+		}
+	}
+	return layer, nil
+}
+
+func validatePolicy(p VersionPolicy) error {
+	for _, v := range []string{p.PreferredVersion, p.MaxAllowedVersion} {
+		if v == "" {
+			continue
+		}
+		if _, ok := capRank(v); !ok {
+			return fmt.Errorf("unparseable version %q", v)
+		}
+	}
+	return nil
+}

--- a/pkg/services/apiserver/versionpolicy/kv_reader_test.go
+++ b/pkg/services/apiserver/versionpolicy/kv_reader_test.go
@@ -1,0 +1,103 @@
+package versionpolicy
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/dgraph-io/badger/v4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/storage/unified/resource/kv"
+)
+
+func seedKV(t *testing.T) kv.KV {
+	t.Helper()
+	db, err := badger.Open(badger.DefaultOptions("").WithInMemory(true).WithLogger(nil))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return kv.NewBadgerKV(db)
+}
+
+func save(t *testing.T, store kv.KV, key, value string) {
+	t.Helper()
+	w, err := store.Save(t.Context(), kv.VersionPolicySection, key)
+	require.NoError(t, err)
+	_, err = w.Write([]byte(value))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+}
+
+func TestKVReader_Read(t *testing.T) {
+	t.Run("nil store yields no layer", func(t *testing.T) {
+		layer, err := NewKVReader(nil).Read(t.Context())
+		require.NoError(t, err)
+		require.Nil(t, layer)
+	})
+
+	t.Run("empty section yields empty layer", func(t *testing.T) {
+		layer, err := NewKVReader(seedKV(t)).Read(t.Context())
+		require.NoError(t, err)
+		require.Empty(t, layer)
+	})
+
+	t.Run("reads one entry per group", func(t *testing.T) {
+		store := seedKV(t)
+		save(t, store, "dashboard.grafana.app", `{"preferredVersion":"v1beta1","maxAllowedVersion":"v1"}`)
+		save(t, store, "folder.grafana.app", `{"preferredVersion":"v0alpha1"}`)
+
+		layer, err := NewKVReader(store).Read(t.Context())
+		require.NoError(t, err)
+		require.Equal(t, VersionPolicy{PreferredVersion: "v1beta1", MaxAllowedVersion: "v1"}, layer["dashboard.grafana.app"])
+		require.Equal(t, VersionPolicy{PreferredVersion: "v0alpha1"}, layer["folder.grafana.app"])
+		require.Len(t, layer, 2)
+	})
+
+	t.Run("reads across BatchGet chunk boundaries", func(t *testing.T) {
+		store := seedKV(t)
+		const n = readBatchSize*2 + 3 // more than one batch, non-multiple
+		for i := 0; i < n; i++ {
+			save(t, store, fmt.Sprintf("g%03d.grafana.app", i), `{"maxAllowedVersion":"v1"}`)
+		}
+
+		layer, err := NewKVReader(store).Read(t.Context())
+		require.NoError(t, err)
+		require.Len(t, layer, n, "every group returned across chunks, none dropped or duplicated")
+	})
+
+	t.Run("malformed value errors, so the caller keeps its last-known layer", func(t *testing.T) {
+		store := seedKV(t)
+		save(t, store, "dashboard.grafana.app", `{"maxAllowedVersion":"v1"}`)
+		save(t, store, "bad.grafana.app", `{not json`)
+
+		layer, err := NewKVReader(store).Read(t.Context())
+		require.Error(t, err, "a malformed value must fail the read, not silently drop the group and lift its cap")
+		require.Nil(t, layer)
+	})
+
+	t.Run("unknown field errors instead of silently dropping the ceiling", func(t *testing.T) {
+		store := seedKV(t)
+		save(t, store, "dashboard.grafana.app", `{"maxAllowdVersion":"v1"}`) // typo'd key would otherwise decode to an empty policy
+
+		layer, err := NewKVReader(store).Read(t.Context())
+		require.Error(t, err)
+		require.Nil(t, layer)
+	})
+
+	t.Run("unparseable version value errors", func(t *testing.T) {
+		store := seedKV(t)
+		save(t, store, "dashboard.grafana.app", `{"maxAllowedVersion":"v1typo"}`)
+
+		layer, err := NewKVReader(store).Read(t.Context())
+		require.Error(t, err)
+		require.Nil(t, layer)
+	})
+
+	t.Run("valid prerelease versions pass validation", func(t *testing.T) {
+		store := seedKV(t)
+		save(t, store, "dashboard.grafana.app", `{"preferredVersion":"v0alpha1","maxAllowedVersion":"v1beta1"}`)
+
+		layer, err := NewKVReader(store).Read(t.Context())
+		require.NoError(t, err)
+		require.Equal(t, VersionPolicy{PreferredVersion: "v0alpha1", MaxAllowedVersion: "v1beta1"}, layer["dashboard.grafana.app"])
+	})
+}

--- a/pkg/services/apiserver/versionpolicy/registry.go
+++ b/pkg/services/apiserver/versionpolicy/registry.go
@@ -11,9 +11,9 @@ import (
 
 type VersionPolicy struct {
 	// advisory: affects discovery only, never storage
-	PreferredVersion string
+	PreferredVersion string `json:"preferredVersion,omitempty"`
 	// persist ceiling: writes whose version outranks it are rejected
-	MaxAllowedVersion string
+	MaxAllowedVersion string `json:"maxAllowedVersion,omitempty"`
 }
 
 // VersionPolicyRegistry serves the resolved global policy. base holds the static layers

--- a/pkg/storage/unified/resource/kv/sqlkv.go
+++ b/pkg/storage/unified/resource/kv/sqlkv.go
@@ -32,6 +32,7 @@ const (
 	StatsDailySection             = "stats/daily"
 	StatsAggregatesSection        = "stats/aggregates"
 	NATSPeersSection              = "nats/peers"
+	VersionPolicySection          = "apiserver/versionpolicy"
 )
 
 // validSaveSections is the set of sections accepted by SqlKV.Save.
@@ -46,6 +47,7 @@ var validSaveSections = map[string]bool{
 	StatsDailySection:             true,
 	StatsAggregatesSection:        true,
 	NATSPeersSection:              true,
+	VersionPolicySection:          true,
 }
 
 var _ KV = &SqlKV{}
@@ -133,6 +135,8 @@ func (k *SqlKV) getQueryBuilder(section string) (*queryBuilder, error) {
 		tableName = "resource_stats_aggregates"
 	case NATSPeersSection:
 		tableName = "nats_discovery_peers"
+	case VersionPolicySection:
+		tableName = "resource_version_policy"
 	default:
 		return nil, fmt.Errorf("invalid section: %s", section)
 	}

--- a/pkg/storage/unified/sql/db/migrations/resource_mig.go
+++ b/pkg/storage/unified/sql/db/migrations/resource_mig.go
@@ -297,6 +297,17 @@ func initResourceTables(mg *migrator.Migrator) string {
 	mg.AddMigration("create table "+resource_stats_aggregates_table.Name, migrator.NewAddTableMigration(resource_stats_aggregates_table))
 	mg.AddMigration("Change key_path collation of resource_stats_aggregates in postgres", migrator.NewRawSQLMigration("").Postgres(`ALTER TABLE resource_stats_aggregates ALTER COLUMN key_path TYPE VARCHAR(2048) COLLATE "C";`))
 
+	// Table backing the apiserver/versionpolicy KV section: operator-set global API version policy per group.
+	resource_version_policy_table := migrator.Table{
+		Name: "resource_version_policy",
+		Columns: []*migrator.Column{
+			{Name: "key_path", Type: migrator.DB_NVarchar, Length: 2048, Nullable: false, IsPrimaryKey: true, IsLatin: true},
+			{Name: "value", Type: migrator.DB_Text, Nullable: false},
+		},
+	}
+	mg.AddMigration("create table "+resource_version_policy_table.Name, migrator.NewAddTableMigration(resource_version_policy_table))
+	mg.AddMigration("Change key_path collation of resource_version_policy in postgres", migrator.NewRawSQLMigration("").Postgres(`ALTER TABLE resource_version_policy ALTER COLUMN key_path TYPE VARCHAR(2048) COLLATE "C";`))
+
 	return marker
 }
 


### PR DESCRIPTION
## What

Runtime (live) layer of the version-policy feature (parent grafana/search-and-storage-team#881). `versionpolicy.KVReader` reads the per-cluster policy — advisory `preferredVersion` + `maxVersion` cap per group — from a KV store via the backend-agnostic `kv.KV` interface. Sits above the compiled-default and ini layers in the resolver.

Builds on the merged resolver (#129667), enforce cap (#129869), and discovery re-prioritize (#130117).

## How

- `KVReader` (`kv_reader.go`) owns the `kv.KV` store; its `Read` method scans the `apiserver/versionpolicy` KV section (one entry per group, keyed by group name) in bounded batches. A nil reader or store reads as no layer (ini-only). Any error (store or malformed value) is returned rather than partially applied, so the caller (poller) keeps its last-known layer instead of dropping a cap.
- Named a reader with `Read` — not a resolver — to avoid overloading `Resolver.Resolve`, which already means merging policy layers.
- `kv.VersionPolicySection` joins the section registry in `sqlkv.go` (`validSaveSections` + `resource_version_policy` table mapping); the migration creates the table. Served by SqlKV, badger/file, and the remote KV gRPC service.

Scope: supports SqlKV (KV over SQL); the legacy SQL resource-storage backend is separate and out of scope.

## Tests

`KVReader.Read` against badger: reads, chunk-boundary crossing, malformed/unknown-field/unparseable-version errors, empty section, nil store.