### PR TITLE
Notebooks: split the full-spec surface and fix element identity

### DIFF
--- a/public/app/features/dashboard-scene/mutation-api/commands/applyNotebookSpec.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/applyNotebookSpec.ts
@@ -1,0 +1,101 @@
+/**
+ * APPLY_NOTEBOOK_SPEC — replace the notebook with a complete v2beta1 `NotebookSpec`, the write half
+ * of the notebook full-spec surface (paired with GET_NOTEBOOK_SPEC). A caller reads the spec, edits
+ * the JSON, and applies the whole thing back instead of emitting a long sequence of granular
+ * ADD / UPDATE / MOVE / REMOVE commands.
+ *
+ * The spec is widened to the dashboard shape for the transformer, because the scene a notebook rides
+ * is dashboard-typed, and then rebuilt through the one rebuild-and-swap both resources share
+ * (`rebuildSceneFromSpec`). Being a full rebuild, it resets transient runtime state (in-flight
+ * queries, variable selections, scroll position).
+ *
+ * Three things a notebook needs that a dashboard apply does not, all of which look like details and
+ * are each a visible bug if dropped: it never enters dashboard edit mode, it carries `isEmbedded`
+ * across the rebuild, and it puts the document header back afterwards.
+ */
+
+import * as z from 'zod';
+
+import { type Spec as NotebookSpec } from '@grafana/schema/apis/notebook/v2beta1';
+
+import { notebookSpecToDashboardSpec, setNotebookDocumentHeader } from '../../serialization/notebookSpecTransform';
+import { transformSceneToNotebookSaveModel } from '../../serialization/transformSceneToNotebookSaveModel';
+import { validateNotebookSpec } from '../../v2schema/notebookSpecSchema';
+
+import { rebuildSceneFromSpec } from './specRebuild';
+import { requiresNotebookEdit, type MutationCommand } from './types';
+
+const applyNotebookSpecPayloadSchema = z.object({
+  spec: z
+    .record(z.string(), z.unknown())
+    .describe('A complete notebook spec to apply (the same shape GET_NOTEBOOK_SPEC returns).'),
+  validate: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe('When true, validate the spec against the notebook schema and reject the mutation if it is invalid.'),
+});
+
+export type ApplyNotebookSpecPayload = z.infer<typeof applyNotebookSpecPayloadSchema>;
+
+export const applyNotebookSpecCommand: MutationCommand<ApplyNotebookSpecPayload> = {
+  name: 'APPLY_NOTEBOOK_SPEC',
+  description:
+    'Replace the notebook with a complete v2beta1 NotebookSpec: settings, elements (markdown, code, ' +
+    'panel and library panel cells) and the ordered NotebookLayout that places them. The scene is ' +
+    'rebuilt from the spec.',
+
+  payloadSchema: applyNotebookSpecPayloadSchema,
+  permission: requiresNotebookEdit,
+  readOnly: false,
+
+  handler: async (payload, context) => {
+    const { scene } = context;
+    try {
+      // Opt-in validation: reject before mutating and hand back field-scoped messages the caller can
+      // self-correct on. The notebook check also covers referential integrity, which zod alone
+      // cannot express — a cell pointing at a missing element is structurally valid and renders as a
+      // silently absent cell.
+      let notebookSpec: NotebookSpec;
+      if (payload.validate) {
+        const result = validateNotebookSpec(payload.spec);
+        if (!result.success || !result.data) {
+          return { success: false, error: `Validation failed: ${result.errors.join(', ')}`, changes: [] };
+        }
+        // Apply the PARSED spec: the schema normalizes Go's `null` slices to `[]`,
+        // `elements: null` to `{}`, and fills CUE `*` defaults, so the scene is rebuilt from the
+        // same shape validation saw.
+        notebookSpec = result.data;
+      } else {
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- unvalidated path: caller-supplied spec is checked by the transform
+        notebookSpec = payload.spec as unknown as NotebookSpec;
+      }
+
+      // A notebook has no dashboard edit mode to enter — deliberately no enterEditModeIfNeeded.
+      rebuildSceneFromSpec(scene, notebookSpecToDashboardSpec(notebookSpec), {
+        isEmbedded: scene.state.meta.isEmbedded,
+      });
+      // The rebuild replaces the layout manager, which holds the document header on its own state,
+      // so restore it from the spec that was just applied.
+      setNotebookDocumentHeader(scene.state.body, notebookSpec.title, notebookSpec.tags);
+
+      // Echo the re-serialized spec so the caller sees the post-apply element names without a
+      // follow-up read. Best effort: a serialization failure still reports success, since the write
+      // itself already landed.
+      let appliedNotebook: NotebookSpec | undefined;
+      try {
+        appliedNotebook = transformSceneToNotebookSaveModel(scene);
+      } catch {
+        appliedNotebook = undefined;
+      }
+
+      return { success: true, data: { applied: true, spec: appliedNotebook, resource: 'notebook' }, changes: [] };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+        changes: [],
+      };
+    }
+  },
+};

--- a/public/app/features/dashboard-scene/mutation-api/commands/applySpec.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/applySpec.ts
@@ -124,7 +124,10 @@ type MutationContextScene = {
       key?: string;
     };
   };
-  serializer: { getK8SMetadata: () => Partial<ObjectMeta> | undefined };
+  serializer: {
+    getK8SMetadata: () => Partial<ObjectMeta> | undefined;
+    initializeElementMapping: (spec: DashboardV2Spec) => void;
+  };
   setState: (state: unknown) => void;
 };
 
@@ -136,6 +139,14 @@ type MutationContextScene = {
  * flags the caller owns rather than the save model — the notebook page sets `isEmbedded` after
  * loading, and a rebuild would otherwise drop it and reveal the dashboard edit chrome on a page
  * that is meant to be read-only to hand editing.
+ *
+ * The element map has to be reseeded by hand afterwards. `transformSaveModelSchemaV2ToScene` seeds
+ * the map of the scene it builds, but only that scene's *state* is cloned over and the serializer
+ * hangs off the scene object, so the live map would keep what load put there. It then resolves every
+ * element the applied spec added to `panel-<id>` and stores that, leaving the layout referencing a
+ * name the elements no longer use. `initializeElementMapping` clears before it seeds, so the reseed
+ * also undoes any wrong entry an earlier read cached. Deliberately not `setInitialSaveModel`, which
+ * would additionally reset the unsaved-changes baseline and change how dashboards detect dirty state.
  */
 function rebuildSceneFromSpec(
   scene: MutationContextScene,
@@ -149,6 +160,10 @@ function rebuildSceneFromSpec(
   // `scene`) survive the swap.
   const newState = sceneUtils.cloneSceneObjectState(rebuilt.state, { key: scene.state.key });
   scene.setState(preserveMeta ? { ...newState, meta: { ...newState.meta, ...preserveMeta } } : newState);
+
+  // Safe on a dashboard still served as v1: its serializer reads `panels`, finds none on a v2 spec,
+  // and is left with an empty map, which regenerates the same `panel-<id>` keys it seeds on load.
+  scene.serializer.initializeElementMapping(spec);
 }
 
 export const applySpecCommand: MutationCommand<ApplySpecPayload> = {
@@ -237,8 +252,8 @@ export const applySpecCommand: MutationCommand<ApplySpecPayload> = {
       const spec = validatedSpec ?? (payload.spec as unknown as DashboardV2Spec);
       rebuildSceneFromSpec(mutationScene, spec);
 
-      // Return the re-serialized spec so the caller gets the rekeyed element
-      // names (rebuild rekeys to `panel-<id>`) without a follow-up GET_SPEC.
+      // Return the re-serialized spec so the caller can see what landed without a follow-up
+      // GET_SPEC. Element names it chose come back unchanged, since the rebuild reseeds the map.
       // Best effort: a serialization failure still reports success.
       let appliedSpec: DashboardV2Spec | undefined;
       try {

--- a/public/app/features/dashboard-scene/mutation-api/commands/applySpec.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/applySpec.ts
@@ -29,12 +29,12 @@ import { dashboardAPIVersionResolver } from 'app/features/dashboard/api/Dashboar
 import { type DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
 
 import {
-  dashboardSpecToNotebookSpec,
   isNotebookScene,
   notebookSpecToDashboardSpec,
   setNotebookDocumentHeader,
 } from '../../serialization/notebookSpecTransform';
 import { transformSaveModelSchemaV2ToScene } from '../../serialization/transformSaveModelSchemaV2ToScene';
+import { transformSceneToNotebookSaveModel } from '../../serialization/transformSceneToNotebookSaveModel';
 import { transformSceneToSaveModelSchemaV2 } from '../../serialization/transformSceneToSaveModelSchemaV2';
 import { dashboardV2SpecSchema } from '../../v2schema/dashboardV2Schema';
 import { validateNotebookSpec } from '../../v2schema/notebookSpecSchema';
@@ -219,7 +219,7 @@ export const applySpecCommand: MutationCommand<ApplySpecPayload> = {
         // the write itself already landed.
         let appliedNotebook: NotebookSpec | undefined;
         try {
-          appliedNotebook = dashboardSpecToNotebookSpec(transformSceneToSaveModelSchemaV2(scene));
+          appliedNotebook = transformSceneToNotebookSaveModel(scene);
         } catch {
           appliedNotebook = undefined;
         }

--- a/public/app/features/dashboard-scene/mutation-api/commands/applySpec.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/applySpec.ts
@@ -10,30 +10,22 @@
  * resets transient runtime state (in-flight queries, variable selections,
  * scroll position).
  *
- * The command is resource-polymorphic, mirroring GET_SPEC: on a dashboard scene
- * the payload is a v2 `DashboardSpec`, on a notebook scene a v2beta1
- * `NotebookSpec`. The notebook path widens the spec to the dashboard shape for
- * the transformer, validates against the notebook schema rather than the
- * dashboard one, and skips dashboard edit mode — a notebook has no dashboard
- * edit chrome to enter, and entering it would mount the edit pane over a page
- * that is deliberately read-only to hand editing.
+ * A notebook is accepted too, by forwarding to APPLY_NOTEBOOK_SPEC. That is
+ * compatibility rather than design: the assistant plugin is released on its own
+ * schedule and looks for this command by name when it decides whether a page can
+ * be edited at all, so refusing a notebook here would break notebook pages for
+ * every plugin version already out there.
  */
 
 import * as z from 'zod';
 
 import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
-import { type Spec as NotebookSpec } from '@grafana/schema/apis/notebook/v2beta1';
 
-import {
-  isNotebookScene,
-  notebookSpecToDashboardSpec,
-  setNotebookDocumentHeader,
-} from '../../serialization/notebookSpecTransform';
-import { transformSceneToNotebookSaveModel } from '../../serialization/transformSceneToNotebookSaveModel';
+import { isNotebookScene } from '../../serialization/notebookSpecTransform';
 import { transformSceneToSaveModelSchemaV2 } from '../../serialization/transformSceneToSaveModelSchemaV2';
 import { dashboardV2SpecSchema } from '../../v2schema/dashboardV2Schema';
-import { validateNotebookSpec } from '../../v2schema/notebookSpecSchema';
 
+import { applyNotebookSpecCommand } from './applyNotebookSpec';
 import { rebuildSceneFromSpec } from './specRebuild';
 import { enterEditModeIfNeeded, requiresSpecWrite, type MutationCommand } from './types';
 
@@ -53,10 +45,10 @@ export type ApplySpecPayload = z.infer<typeof applySpecPayloadSchema>;
 export const applySpecCommand: MutationCommand<ApplySpecPayload> = {
   name: 'APPLY_SPEC',
   description:
-    'Replace the document with a complete spec. On a dashboard this is a v2 DashboardSpec ' +
-    '(settings, variables, annotations, panels, and nested rows/tabs layout); on a notebook a ' +
-    'v2beta1 NotebookSpec (settings, elements including markdown/code cells, and the ordered ' +
-    'NotebookLayout). The scene is rebuilt from the spec.',
+    'Replace the dashboard with a complete v2 DashboardSpec: settings, variables, annotations, ' +
+    'panels and the nested rows/tabs layout. The scene is rebuilt from the spec. Also accepted on ' +
+    'a notebook, where the payload is a v2beta1 NotebookSpec and APPLY_NOTEBOOK_SPEC is the ' +
+    'command to prefer.',
 
   payloadSchema: applySpecPayloadSchema,
   // Rebuilds the layout tree, so a dashboard gates on the same toggle as the layout commands;
@@ -67,45 +59,10 @@ export const applySpecCommand: MutationCommand<ApplySpecPayload> = {
   handler: async (payload, context) => {
     const { scene } = context;
     try {
+      // Compatibility forward, see the docstring for why it cannot simply refuse. This branch goes
+      // when no released assistant plugin version still asks for APPLY_SPEC on a notebook page.
       if (isNotebookScene(scene)) {
-        // Opt-in validation, same contract as the dashboard path below: reject before mutating
-        // and hand back field-scoped messages the caller can self-correct on. The notebook check
-        // also covers referential integrity, which zod alone cannot express — a cell pointing at
-        // a missing element is structurally valid and renders as a silently absent cell.
-        let notebookSpec: NotebookSpec;
-        if (payload.validate) {
-          const result = validateNotebookSpec(payload.spec);
-          if (!result.success || !result.data) {
-            return { success: false, error: `Validation failed: ${result.errors.join(', ')}`, changes: [] };
-          }
-          // Apply the PARSED spec: the schema normalizes Go's `null` slices to `[]`,
-          // `elements: null` to `{}`, and fills CUE `*` defaults, so the scene is rebuilt from
-          // the same shape validation saw.
-          notebookSpec = result.data;
-        } else {
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- unvalidated path: caller-supplied spec is checked by the transform
-          notebookSpec = payload.spec as unknown as NotebookSpec;
-        }
-
-        // A notebook has no dashboard edit mode to enter — deliberately no enterEditModeIfNeeded.
-        rebuildSceneFromSpec(scene, notebookSpecToDashboardSpec(notebookSpec), {
-          isEmbedded: scene.state.meta.isEmbedded,
-        });
-        // The rebuild replaces the layout manager, which holds the document header on its own
-        // state, so restore it from the spec that was just applied.
-        setNotebookDocumentHeader(scene.state.body, notebookSpec.title, notebookSpec.tags);
-
-        // Echo the re-serialized spec so the caller sees the post-apply element names without a
-        // follow-up GET_SPEC. Best effort: a serialization failure still reports success, since
-        // the write itself already landed.
-        let appliedNotebook: NotebookSpec | undefined;
-        try {
-          appliedNotebook = transformSceneToNotebookSaveModel(scene);
-        } catch {
-          appliedNotebook = undefined;
-        }
-
-        return { success: true, data: { applied: true, spec: appliedNotebook, resource: 'notebook' }, changes: [] };
+        return applyNotebookSpecCommand.handler(payload, context);
       }
 
       // Opt-in structural validation (default off to avoid breaking existing

--- a/public/app/features/dashboard-scene/mutation-api/commands/applySpec.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/applySpec.ts
@@ -21,24 +21,20 @@
 
 import * as z from 'zod';
 
-import { sceneUtils } from '@grafana/scenes';
 import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { type Spec as NotebookSpec } from '@grafana/schema/apis/notebook/v2beta1';
-import { type ObjectMeta } from 'app/features/apiserver/types';
-import { dashboardAPIVersionResolver } from 'app/features/dashboard/api/DashboardAPIVersionResolver';
-import { type DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
 
 import {
   isNotebookScene,
   notebookSpecToDashboardSpec,
   setNotebookDocumentHeader,
 } from '../../serialization/notebookSpecTransform';
-import { transformSaveModelSchemaV2ToScene } from '../../serialization/transformSaveModelSchemaV2ToScene';
 import { transformSceneToNotebookSaveModel } from '../../serialization/transformSceneToNotebookSaveModel';
 import { transformSceneToSaveModelSchemaV2 } from '../../serialization/transformSceneToSaveModelSchemaV2';
 import { dashboardV2SpecSchema } from '../../v2schema/dashboardV2Schema';
 import { validateNotebookSpec } from '../../v2schema/notebookSpecSchema';
 
+import { rebuildSceneFromSpec } from './specRebuild';
 import { enterEditModeIfNeeded, requiresSpecWrite, type MutationCommand } from './types';
 
 const applySpecPayloadSchema = z.object({
@@ -53,118 +49,6 @@ const applySpecPayloadSchema = z.object({
 });
 
 export type ApplySpecPayload = z.infer<typeof applySpecPayloadSchema>;
-
-/**
- * Wrap a bare spec in the access/metadata envelope `transformSaveModelSchemaV2ToScene`
- * expects, reusing the live scene's metadata + access so identity and
- * permissions survive the rebuild.
- */
-function dtoFromScene(scene: MutationContextScene, spec: DashboardV2Spec): DashboardWithAccessInfo<DashboardV2Spec> {
-  const meta = scene.state.meta;
-  return {
-    kind: 'DashboardWithAccessInfo',
-    metadata: resolveMetadata(scene),
-    access: {
-      canEdit: meta.canEdit !== false,
-      canSave: meta.canSave !== false,
-      canShare: meta.canShare !== false,
-      canStar: meta.canStar !== false,
-      canDelete: meta.canDelete !== false,
-      canAdmin: meta.canAdmin !== false,
-      slug: meta.slug,
-      url: meta.url,
-    },
-    // Whichever v2 version the backend serves (stable v2 or v2beta1). It is
-    // stamped onto the scene, so a wrong literal would mislabel it on save.
-    apiVersion: dashboardAPIVersionResolver.getV2(),
-    spec,
-  };
-}
-
-/**
- * `transformSaveModelSchemaV2ToScene` reads `metadata.name`/`generation`/
- * `creationTimestamp` unguarded, which throws on a brand-new / unsaved dashboard
- * whose serializer metadata is absent or partial. Guarantee a populated
- * envelope, preferring whatever the scene already has.
- */
-function resolveMetadata(scene: MutationContextScene): DashboardWithAccessInfo<DashboardV2Spec>['metadata'] {
-  const existing = scene.serializer.getK8SMetadata() ?? {};
-  const meta = scene.state.meta;
-  const uid =
-    (typeof existing.name === 'string' && existing.name) ||
-    (typeof meta.uid === 'string' && meta.uid) ||
-    (typeof meta.key === 'string' && meta.key) ||
-    'new-dashboard';
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- assemble the metadata envelope
-  return {
-    ...existing,
-    name: uid,
-    generation: typeof existing.generation === 'number' ? existing.generation : 1,
-    creationTimestamp:
-      typeof existing.creationTimestamp === 'string' ? existing.creationTimestamp : new Date().toISOString(),
-    annotations: existing.annotations ?? {},
-  } as DashboardWithAccessInfo<DashboardV2Spec>['metadata'];
-}
-
-// Minimal structural type for the bits of DashboardScene this command touches,
-// kept local to avoid a circular import.
-type MutationContextScene = {
-  state: {
-    key?: string;
-    meta: Record<string, unknown> & {
-      canEdit?: boolean;
-      canSave?: boolean;
-      canShare?: boolean;
-      canStar?: boolean;
-      canDelete?: boolean;
-      canAdmin?: boolean;
-      isEmbedded?: boolean;
-      slug?: string;
-      url?: string;
-      key?: string;
-    };
-  };
-  serializer: {
-    getK8SMetadata: () => Partial<ObjectMeta> | undefined;
-    initializeElementMapping: (spec: DashboardV2Spec) => void;
-  };
-  setState: (state: unknown) => void;
-};
-
-/**
- * Rebuild the scene from a dashboard-shaped spec and swap it in place.
- *
- * Shared by both resources: the notebook path widens its spec to this shape first, so there is
- * exactly one rebuild-and-swap and the two cannot drift. `preserveMeta` carries forward the meta
- * flags the caller owns rather than the save model — the notebook page sets `isEmbedded` after
- * loading, and a rebuild would otherwise drop it and reveal the dashboard edit chrome on a page
- * that is meant to be read-only to hand editing.
- *
- * The element map has to be reseeded by hand afterwards. `transformSaveModelSchemaV2ToScene` seeds
- * the map of the scene it builds, but only that scene's *state* is cloned over and the serializer
- * hangs off the scene object, so the live map would keep what load put there. It then resolves every
- * element the applied spec added to `panel-<id>` and stores that, leaving the layout referencing a
- * name the elements no longer use. `initializeElementMapping` clears before it seeds, so the reseed
- * also undoes any wrong entry an earlier read cached. Deliberately not `setInitialSaveModel`, which
- * would additionally reset the unsaved-changes baseline and change how dashboards detect dirty state.
- */
-function rebuildSceneFromSpec(
-  scene: MutationContextScene,
-  spec: DashboardV2Spec,
-  preserveMeta?: Record<string, unknown>
-): void {
-  const dto = dtoFromScene(scene, spec);
-  const rebuilt = transformSaveModelSchemaV2ToScene(dto);
-
-  // Reuse the live key so existing references (incl. the mutation client's
-  // `scene`) survive the swap.
-  const newState = sceneUtils.cloneSceneObjectState(rebuilt.state, { key: scene.state.key });
-  scene.setState(preserveMeta ? { ...newState, meta: { ...newState.meta, ...preserveMeta } } : newState);
-
-  // Safe on a dashboard still served as v1: its serializer reads `panels`, finds none on a v2 spec,
-  // and is left with an empty map, which regenerates the same `panel-<id>` keys it seeds on load.
-  scene.serializer.initializeElementMapping(spec);
-}
 
 export const applySpecCommand: MutationCommand<ApplySpecPayload> = {
   name: 'APPLY_SPEC',
@@ -183,9 +67,6 @@ export const applySpecCommand: MutationCommand<ApplySpecPayload> = {
   handler: async (payload, context) => {
     const { scene } = context;
     try {
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- narrow DashboardScene to the fields this command reads
-      const mutationScene = scene as unknown as MutationContextScene;
-
       if (isNotebookScene(scene)) {
         // Opt-in validation, same contract as the dashboard path below: reject before mutating
         // and hand back field-scoped messages the caller can self-correct on. The notebook check
@@ -207,7 +88,7 @@ export const applySpecCommand: MutationCommand<ApplySpecPayload> = {
         }
 
         // A notebook has no dashboard edit mode to enter — deliberately no enterEditModeIfNeeded.
-        rebuildSceneFromSpec(mutationScene, notebookSpecToDashboardSpec(notebookSpec), {
+        rebuildSceneFromSpec(scene, notebookSpecToDashboardSpec(notebookSpec), {
           isEmbedded: scene.state.meta.isEmbedded,
         });
         // The rebuild replaces the layout manager, which holds the document header on its own
@@ -250,7 +131,7 @@ export const applySpecCommand: MutationCommand<ApplySpecPayload> = {
 
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- unvalidated path: caller-supplied spec is checked by the transform
       const spec = validatedSpec ?? (payload.spec as unknown as DashboardV2Spec);
-      rebuildSceneFromSpec(mutationScene, spec);
+      rebuildSceneFromSpec(scene, spec);
 
       // Return the re-serialized spec so the caller can see what landed without a follow-up
       // GET_SPEC. Element names it chose come back unchanged, since the rebuild reseeds the map.

--- a/public/app/features/dashboard-scene/mutation-api/commands/commands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/commands.test.ts
@@ -60,6 +60,7 @@ describe('Command consistency', () => {
       'ENTER_EDIT_MODE',
       'GET_DASHBOARD_INFO',
       'GET_LAYOUT',
+      'GET_NOTEBOOK_SPEC',
       'GET_SPEC',
       'LIST_ANNOTATIONS',
       'LIST_PANELS',

--- a/public/app/features/dashboard-scene/mutation-api/commands/commands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/commands.test.ts
@@ -56,6 +56,7 @@ describe('Command consistency', () => {
       'ADD_ROW',
       'ADD_TAB',
       'ADD_VARIABLE',
+      'APPLY_NOTEBOOK_SPEC',
       'APPLY_SPEC',
       'ENTER_EDIT_MODE',
       'GET_DASHBOARD_INFO',

--- a/public/app/features/dashboard-scene/mutation-api/commands/commands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/commands.test.ts
@@ -48,6 +48,21 @@ describe('Command consistency', () => {
     }
   });
 
+  // Not decoration: the client reads readOnly to decide whether to forceRender after a command and
+  // whether to deep-clone the payload. A write marked read-only would apply a spec and never repaint.
+  it('marks the full-spec reads read-only and the writes not', () => {
+    const readOnlyByName = Object.fromEntries(
+      ALL_COMMANDS.filter((cmd) => cmd.name.includes('SPEC')).map((cmd) => [cmd.name, cmd.readOnly ?? false])
+    );
+
+    expect(readOnlyByName).toEqual({
+      GET_SPEC: true,
+      GET_NOTEBOOK_SPEC: true,
+      APPLY_SPEC: false,
+      APPLY_NOTEBOOK_SPEC: false,
+    });
+  });
+
   it('registers the expected set of commands', () => {
     const names = ALL_COMMANDS.map((cmd) => cmd.name).sort();
     expect(names).toEqual([

--- a/public/app/features/dashboard-scene/mutation-api/commands/dashboardSpecCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/dashboardSpecCommands.test.ts
@@ -1,0 +1,214 @@
+/**
+ * The dashboard half of the full-spec surface, driven end to end: a real scene built from a v2 spec,
+ * the real GET_SPEC / APPLY_SPEC handlers, the real serializer.
+ *
+ * It exists because the element-identity fix changes dashboard behaviour on purpose. An element name
+ * the caller chose used to be rekeyed to `panel-<id>` by the rebuild, and now survives, so that has
+ * to be pinned somewhere a dashboard reviewer will look rather than only in the notebook suite.
+ */
+
+import {
+  defaultPanelKind,
+  type PanelKind,
+  type Spec as DashboardV2Spec,
+} from '@grafana/schema/apis/dashboard.grafana.app/v2';
+import { type DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
+
+import { type DashboardScene } from '../../scene/DashboardScene';
+import { transformSaveModelSchemaV2ToScene } from '../../serialization/transformSaveModelSchemaV2ToScene';
+
+import { applySpecCommand } from './applySpec';
+import { getSpecCommand } from './getSpec';
+import { type MutationContext } from './types';
+
+// Entering edit mode starts the change tracker, which spawns a real web worker. jsdom has none, and
+// the global worker mock covers other features only.
+jest.mock('../../saving/createDetectChangesWorker', () => ({
+  createWorker: () => ({ postMessage: jest.fn(), terminate: jest.fn(), onmessage: null }),
+}));
+
+function panelElement(id: number, title: string): PanelKind {
+  const panel = defaultPanelKind();
+  return {
+    ...panel,
+    spec: {
+      ...panel.spec,
+      id,
+      title,
+      data: {
+        ...panel.spec.data,
+        spec: {
+          ...panel.spec.data.spec,
+          queries: [
+            {
+              kind: 'PanelQuery',
+              spec: {
+                refId: 'A',
+                hidden: false,
+                query: { kind: 'DataQuery', group: 'prometheus', version: 'v0', spec: { expr: 'up' } },
+              },
+            },
+          ],
+        },
+      },
+      vizConfig: { ...panel.spec.vizConfig, group: 'timeseries', version: '1.0.0' },
+    },
+  };
+}
+
+function gridItem(name: string, y: number) {
+  return {
+    kind: 'GridLayoutItem',
+    spec: { x: 0, y, width: 12, height: 8, element: { kind: 'ElementReference', name } },
+  };
+}
+
+/**
+ * The loaded panel is named `latency-panel`, not `panel-1`: the canonical name is what hides an
+ * element-identity problem, so a fixture using it would pass either way.
+ */
+function makeDashboardSpec(overrides: Partial<DashboardV2Spec> = {}): DashboardV2Spec {
+  const spec = {
+    title: 'Checkout latency',
+    description: '',
+    cursorSync: 'Off',
+    liveNow: false,
+    preload: false,
+    editable: true,
+    tags: [],
+    links: [],
+    annotations: [],
+    variables: [],
+    timeSettings: {
+      from: 'now-6h',
+      to: 'now',
+      autoRefresh: '',
+      autoRefreshIntervals: ['5s', '1m'],
+      hideTimepicker: false,
+      fiscalYearStartMonth: 0,
+      timezone: 'browser',
+    },
+    elements: { 'latency-panel': panelElement(1, 'p99 latency') },
+    layout: { kind: 'GridLayout', spec: { items: [gridItem('latency-panel', 0)] } },
+    ...overrides,
+  };
+
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- hand-built fixture matching the generated spec
+  return spec as unknown as DashboardV2Spec;
+}
+
+function buildDashboardScene(spec: DashboardV2Spec): DashboardScene {
+  const dto = {
+    kind: 'DashboardWithAccessInfo',
+    apiVersion: 'dashboard.grafana.app/v2beta1',
+    metadata: { name: 'dash-1', generation: 1, creationTimestamp: '2026-08-03T00:00:00Z', annotations: {} },
+    access: { canEdit: true, canSave: true, canShare: true, canStar: true, canDelete: true, canAdmin: true },
+    spec,
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal resource envelope for the test
+  } as unknown as DashboardWithAccessInfo<DashboardV2Spec>;
+
+  // Deliberately not activated, matching the notebook suite: the full-spec commands serialize from
+  // scene state, and activating starts the annotation data layer and the dashboard macro.
+  return transformSaveModelSchemaV2ToScene(dto);
+}
+
+function contextFor(scene: DashboardScene): MutationContext {
+  return { scene };
+}
+
+async function getSpec(scene: DashboardScene, validate = false) {
+  return getSpecCommand.handler({ validate }, contextFor(scene));
+}
+
+async function applySpec(scene: DashboardScene, spec: unknown, validate = false) {
+  return applySpecCommand.handler({ spec: spec as Record<string, unknown>, validate }, contextFor(scene));
+}
+
+function specOf(result: Awaited<ReturnType<typeof getSpec>>): DashboardV2Spec {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- handler data is untyped by the MutationResult contract
+  return (result.data as { spec: DashboardV2Spec }).spec;
+}
+
+function referencedNames(spec: DashboardV2Spec): string[] {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the fixture is a grid layout throughout
+  const items = (spec.layout as { spec: { items: Array<{ spec: { element: { name: string } } }> } }).spec.items;
+  return items.map((item) => item.spec.element.name);
+}
+
+/** Layout references with no element to resolve to: the shape a lost panel takes in a spec. */
+function danglingReferences(spec: DashboardV2Spec): string[] {
+  return referencedNames(spec).filter((name) => !spec.elements[name]);
+}
+
+/** A snapshot of the unsaved-changes baseline, which the reseed must leave alone. */
+function baselineOf(scene: DashboardScene): unknown {
+  return JSON.parse(JSON.stringify(scene.serializer.initialSaveModel ?? null));
+}
+
+describe('GET_SPEC on a dashboard', () => {
+  it('keeps the element name the dashboard was loaded with', async () => {
+    const spec = specOf(await getSpec(buildDashboardScene(makeDashboardSpec())));
+
+    expect(Object.keys(spec.elements)).toEqual(['latency-panel']);
+    expect(danglingReferences(spec)).toEqual([]);
+  });
+});
+
+describe('APPLY_SPEC on a dashboard', () => {
+  it('keeps the element name of a panel added by the caller', async () => {
+    const scene = buildDashboardScene(makeDashboardSpec());
+    const added = makeDashboardSpec({
+      elements: {
+        'latency-panel': panelElement(1, 'p99 latency'),
+        'errors-panel': panelElement(2, '5xx rate'),
+      },
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- hand-built grid layout
+      layout: {
+        kind: 'GridLayout',
+        spec: { items: [gridItem('latency-panel', 0), gridItem('errors-panel', 8)] },
+      } as unknown as DashboardV2Spec['layout'],
+    });
+
+    expect((await applySpec(scene, added)).success).toBe(true);
+    const spec = specOf(await getSpec(scene));
+
+    expect(Object.keys(spec.elements).sort()).toEqual(['errors-panel', 'latency-panel']);
+    expect(spec.elements['errors-panel'].spec.id).toBe(2);
+    expect(danglingReferences(spec)).toEqual([]);
+  });
+
+  it('keeps a newly added panel when the spec it read back is applied again', async () => {
+    const scene = buildDashboardScene(makeDashboardSpec());
+    const added = makeDashboardSpec({
+      elements: {
+        'latency-panel': panelElement(1, 'p99 latency'),
+        'errors-panel': panelElement(2, '5xx rate'),
+      },
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- hand-built grid layout
+      layout: {
+        kind: 'GridLayout',
+        spec: { items: [gridItem('latency-panel', 0), gridItem('errors-panel', 8)] },
+      } as unknown as DashboardV2Spec['layout'],
+    });
+
+    await applySpec(scene, added);
+    const readBack = specOf(await getSpec(scene));
+
+    expect((await applySpec(scene, readBack)).success).toBe(true);
+    const spec = specOf(await getSpec(scene));
+
+    expect(Object.keys(spec.elements).sort()).toEqual(['errors-panel', 'latency-panel']);
+    expect(danglingReferences(spec)).toEqual([]);
+  });
+
+  // The reseed uses initializeElementMapping rather than setInitialSaveModel precisely so the
+  // baseline the unsaved-changes diff compares against does not move.
+  it('leaves the unsaved-changes baseline untouched', async () => {
+    const scene = buildDashboardScene(makeDashboardSpec());
+    const before = baselineOf(scene);
+
+    await applySpec(scene, makeDashboardSpec({ title: 'Renamed' }));
+
+    expect(baselineOf(scene)).toEqual(before);
+  });
+});

--- a/public/app/features/dashboard-scene/mutation-api/commands/getNotebookSpec.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/getNotebookSpec.ts
@@ -1,0 +1,65 @@
+/**
+ * GET_NOTEBOOK_SPEC — return the whole notebook as a single v2beta1 `NotebookSpec`, the read half of
+ * the notebook full-spec surface (paired with APPLY_NOTEBOOK_SPEC).
+ *
+ * One command, one spec. `GET_SPEC` also answers on a notebook, but it answers with whichever spec
+ * the scene happens to render, so it cannot be described without naming two schemas and a rule for
+ * choosing between them. This command exists so a caller that knows it is looking at a notebook can
+ * say so, and so the notebook read survives the v2 `DashboardSpec` being retired.
+ */
+
+import * as z from 'zod';
+
+import { transformSceneToNotebookSaveModel } from '../../serialization/transformSceneToNotebookSaveModel';
+import { validateNotebookSpec } from '../../v2schema/notebookSpecSchema';
+
+import { requiresNotebookResource, type MutationCommand } from './types';
+
+const getNotebookSpecPayloadSchema = z
+  .object({
+    validate: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe('When true, validate the serialized spec against the notebook schema and fail if it is invalid.'),
+  })
+  .strict();
+
+export type GetNotebookSpecPayload = z.infer<typeof getNotebookSpecPayloadSchema>;
+
+export const getNotebookSpecCommand: MutationCommand<GetNotebookSpecPayload> = {
+  name: 'GET_NOTEBOOK_SPEC',
+  description:
+    'Return the entire notebook as one v2beta1 NotebookSpec JSON object: settings, elements ' +
+    '(markdown, code, panel and library panel cells) and the ordered NotebookLayout that places them.',
+
+  payloadSchema: getNotebookSpecPayloadSchema,
+  permission: requiresNotebookResource,
+  readOnly: true,
+
+  handler: async (payload, context) => {
+    const { scene } = context;
+    try {
+      const notebook = transformSceneToNotebookSaveModel(scene);
+
+      // Opt-in structural + referential validation (default off to avoid breaking reads).
+      // Worth requesting on a notebook: a read that comes back with dangling cell references means
+      // the scene lost elements on the way out, which is precisely what this used to do silently
+      // for markdown and code cells.
+      if (payload.validate) {
+        const result = validateNotebookSpec(notebook);
+        if (!result.success) {
+          return { success: false, error: `Validation failed: ${result.errors.join(', ')}`, changes: [] };
+        }
+      }
+
+      return { success: true, data: { spec: notebook, resource: 'notebook' }, changes: [] };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+        changes: [],
+      };
+    }
+  },
+};

--- a/public/app/features/dashboard-scene/mutation-api/commands/getSpec.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/getSpec.ts
@@ -6,16 +6,15 @@
  *
  * The command is resource-polymorphic: on a dashboard scene it returns a v2
  * `DashboardSpec`, on a notebook scene a v2beta1 `NotebookSpec`, reported via
- * `resource`. The scene serializer is dashboard-typed and always emits the full
- * dashboard shape, so a notebook is projected back down to its own fields before
- * it leaves here — a caller that echoed the dashboard shape back through
- * APPLY_SPEC would be writing `variables`, `annotations` and `cursorSync` into a
- * resource that has no such fields.
+ * `resource`. A notebook goes out through `transformSceneToNotebookSaveModel`,
+ * which is where the projection back down to the notebook's own fields lives and
+ * why it is needed.
  */
 
 import * as z from 'zod';
 
-import { dashboardSpecToNotebookSpec, isNotebookScene } from '../../serialization/notebookSpecTransform';
+import { isNotebookScene } from '../../serialization/notebookSpecTransform';
+import { transformSceneToNotebookSaveModel } from '../../serialization/transformSceneToNotebookSaveModel';
 import { transformSceneToSaveModelSchemaV2 } from '../../serialization/transformSceneToSaveModelSchemaV2';
 import { dashboardV2SpecSchema } from '../../v2schema/dashboardV2Schema';
 import { validateNotebookSpec } from '../../v2schema/notebookSpecSchema';
@@ -47,10 +46,8 @@ export const getSpecCommand: MutationCommand<GetSpecPayload> = {
   handler: async (payload, context) => {
     const { scene } = context;
     try {
-      const spec = transformSceneToSaveModelSchemaV2(scene);
-
       if (isNotebookScene(scene)) {
-        const notebook = dashboardSpecToNotebookSpec(spec);
+        const notebook = transformSceneToNotebookSaveModel(scene);
 
         // Opt-in structural + referential validation (default off to avoid breaking reads).
         // Worth requesting on a notebook: a read that comes back with dangling cell references
@@ -65,6 +62,8 @@ export const getSpecCommand: MutationCommand<GetSpecPayload> = {
 
         return { success: true, data: { spec: notebook, resource: 'notebook' }, changes: [] };
       }
+
+      const spec = transformSceneToSaveModelSchemaV2(scene);
 
       // Opt-in structural validation (default off to avoid breaking reads).
       if (payload.validate) {

--- a/public/app/features/dashboard-scene/mutation-api/commands/getSpec.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/getSpec.ts
@@ -1,24 +1,23 @@
 /**
- * GET_SPEC — return the whole document as a single spec, the read half of the
- * full-spec surface (paired with APPLY_SPEC). A thin wrapper over
+ * GET_SPEC — return the whole dashboard as a single v2 `DashboardSpec`, the read
+ * half of the full-spec surface (paired with APPLY_SPEC). A thin wrapper over
  * `transformSceneToSaveModelSchemaV2`, so it always reflects the canonical save
  * model.
  *
- * The command is resource-polymorphic: on a dashboard scene it returns a v2
- * `DashboardSpec`, on a notebook scene a v2beta1 `NotebookSpec`, reported via
- * `resource`. A notebook goes out through `transformSceneToNotebookSaveModel`,
- * which is where the projection back down to the notebook's own fields lives and
- * why it is needed.
+ * A notebook is answered too, by forwarding to GET_NOTEBOOK_SPEC. That is
+ * compatibility rather than design: the assistant plugin is released on its own
+ * schedule and looks for this command by name when it decides whether a page can
+ * be read at all, so refusing a notebook here would break notebook pages for
+ * every plugin version already out there.
  */
 
 import * as z from 'zod';
 
 import { isNotebookScene } from '../../serialization/notebookSpecTransform';
-import { transformSceneToNotebookSaveModel } from '../../serialization/transformSceneToNotebookSaveModel';
 import { transformSceneToSaveModelSchemaV2 } from '../../serialization/transformSceneToSaveModelSchemaV2';
 import { dashboardV2SpecSchema } from '../../v2schema/dashboardV2Schema';
-import { validateNotebookSpec } from '../../v2schema/notebookSpecSchema';
 
+import { getNotebookSpecCommand } from './getNotebookSpec';
 import { readOnly, type MutationCommand } from './types';
 
 const getSpecPayloadSchema = z
@@ -36,8 +35,10 @@ export type GetSpecPayload = z.infer<typeof getSpecPayloadSchema>;
 export const getSpecCommand: MutationCommand<GetSpecPayload> = {
   name: 'GET_SPEC',
   description:
-    'Return the entire document as one spec JSON object: a v2 DashboardSpec on a dashboard, ' +
-    'a v2beta1 NotebookSpec on a notebook. The response reports which one in `resource`.',
+    'Return the entire dashboard as one v2 DashboardSpec JSON object: settings, variables, ' +
+    'annotations, panels and the nested rows/tabs layout. Also accepted on a notebook, where it ' +
+    'returns a v2beta1 NotebookSpec and GET_NOTEBOOK_SPEC is the command to prefer. The response ' +
+    'reports which one it returned in `resource`.',
 
   payloadSchema: getSpecPayloadSchema,
   permission: readOnly,
@@ -46,21 +47,10 @@ export const getSpecCommand: MutationCommand<GetSpecPayload> = {
   handler: async (payload, context) => {
     const { scene } = context;
     try {
+      // Compatibility forward, see the docstring for why it cannot simply refuse. This branch goes
+      // when no released assistant plugin version still asks for GET_SPEC on a notebook page.
       if (isNotebookScene(scene)) {
-        const notebook = transformSceneToNotebookSaveModel(scene);
-
-        // Opt-in structural + referential validation (default off to avoid breaking reads).
-        // Worth requesting on a notebook: a read that comes back with dangling cell references
-        // means the scene lost elements on the way out, which is precisely what this command
-        // used to do silently for markdown and code cells.
-        if (payload.validate) {
-          const result = validateNotebookSpec(notebook);
-          if (!result.success) {
-            return { success: false, error: `Validation failed: ${result.errors.join(', ')}`, changes: [] };
-          }
-        }
-
-        return { success: true, data: { spec: notebook, resource: 'notebook' }, changes: [] };
+        return getNotebookSpecCommand.handler(payload, context);
       }
 
       const spec = transformSceneToSaveModelSchemaV2(scene);

--- a/public/app/features/dashboard-scene/mutation-api/commands/notebookSpecCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/notebookSpecCommands.test.ts
@@ -21,6 +21,7 @@ import { AccessControlAction } from 'app/types/accessControl';
 import { type DashboardScene } from '../../scene/DashboardScene';
 import { setNotebookDocumentHeader } from '../../serialization/notebookSpecTransform';
 import { transformSaveModelSchemaV2ToScene } from '../../serialization/transformSaveModelSchemaV2ToScene';
+import { DashboardMutationClient } from '../DashboardMutationClient';
 
 import { applyNotebookSpecCommand } from './applyNotebookSpec';
 import { applySpecCommand } from './applySpec';
@@ -197,6 +198,13 @@ function specOf(result: Awaited<ReturnType<typeof getSpec>>): NotebookSpec {
 function echoedSpecOf(result: Awaited<ReturnType<typeof applySpec>>): NotebookSpec {
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- handler data is untyped by the MutationResult contract
   return (result.data as { spec: NotebookSpec }).spec;
+}
+
+/** The document header, which the notebook layout manager holds on its own state. */
+function headerOf(scene: DashboardScene): { title?: string; tags?: string[] } {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the header lives on the layout manager, not the scene
+  const body = scene.state.body as unknown as { state: { title?: string; tags?: string[] } };
+  return { title: body.state.title, tags: body.state.tags };
 }
 
 function referencedNames(spec: NotebookSpec): string[] {
@@ -734,5 +742,82 @@ describe('APPLY_NOTEBOOK_SPEC permission', () => {
     const result = applyNotebookSpecCommand.permission(dashboardScene);
     expect(result.allowed).toBe(false);
     expect(result.allowed === false && result.error).toContain('notebooks only');
+  });
+});
+
+/**
+ * The compatibility promise: on a notebook, the dashboard commands do exactly what the notebook
+ * commands do. GET_SPEC and APPLY_SPEC forward, so these cases are near-tautological today, and that
+ * is the point rather than a weakness. They are what fails the day someone edits that branch, which
+ * is the only warning that an assistant version already released has stopped working.
+ *
+ * Do not replace them with a check that the forward was called. A forward that runs and returns the
+ * wrong thing is the failure worth catching, and only the caller-visible result shows it.
+ */
+describe('the dashboard spec commands on a notebook', () => {
+  it('GET_SPEC returns exactly what GET_NOTEBOOK_SPEC returns', async () => {
+    const scene = buildNotebookScene(makeNotebookSpecWithPanel());
+
+    // The whole result, not just the spec, so `resource` and `success` are covered too.
+    expect(await getSpec(scene, true)).toEqual(await getNotebookSpec(scene, true));
+  });
+
+  it('both write commands echo the same spec', async () => {
+    const viaDashboardCommand = buildNotebookScene(makeNotebookSpecWithPanel());
+    const viaNotebookCommand = buildNotebookScene(makeNotebookSpecWithPanel());
+    const edit = (current: NotebookSpec) => ({
+      ...current,
+      title: 'Renamed',
+      elements: { ...current.elements, finding: markdown('Deploy at 14:00 lines up with the spike.') },
+      layout: {
+        kind: 'NotebookLayout',
+        spec: { cells: [...current.layout.spec.cells, cell('finding', 'assistant')] },
+      },
+    });
+
+    const echoedByDashboardCommand = echoedSpecOf(
+      await applySpec(viaDashboardCommand, edit(specOf(await getSpec(viaDashboardCommand))), true)
+    );
+    const echoedByNotebookCommand = echoedSpecOf(
+      await applyNotebookSpec(viaNotebookCommand, edit(specOf(await getNotebookSpec(viaNotebookCommand))), true)
+    );
+
+    expect(echoedByDashboardCommand).toEqual(echoedByNotebookCommand);
+  });
+
+  it('both write commands leave the scene in the same state', async () => {
+    const viaDashboardCommand = buildNotebookScene(makeNotebookSpecWithPanel());
+    const viaNotebookCommand = buildNotebookScene(makeNotebookSpecWithPanel());
+    const renamed = (current: NotebookSpec) => ({ ...current, title: 'Renamed', tags: ['resolved'] });
+
+    await applySpec(viaDashboardCommand, renamed(specOf(await getSpec(viaDashboardCommand))), true);
+    await applyNotebookSpec(viaNotebookCommand, renamed(specOf(await getNotebookSpec(viaNotebookCommand))), true);
+
+    expect(specOf(await getNotebookSpec(viaDashboardCommand))).toEqual(
+      specOf(await getNotebookSpec(viaNotebookCommand))
+    );
+
+    // The header is a second copy of title and tags, held by the layout manager and not read back
+    // through the spec, so comparing specs alone would miss a missing restore.
+    expect(headerOf(viaDashboardCommand)).toEqual(headerOf(viaNotebookCommand));
+    expect(headerOf(viaDashboardCommand)).toEqual({ title: 'Renamed', tags: ['resolved'] });
+
+    // The two the rebuild is most likely to get wrong.
+    expect(viaDashboardCommand.state.meta.isEmbedded).toBe(viaNotebookCommand.state.meta.isEmbedded);
+    expect(viaDashboardCommand.state.isEditing).toBeFalsy();
+    expect(viaNotebookCommand.state.isEditing).toBeFalsy();
+  });
+
+  // Looks like testing the obvious, and is not. The assistant plugin decides whether a page can be
+  // read or edited by looking for GET_SPEC and APPLY_SPEC in this list by name, and reports the
+  // notebook as an unsupported surface if either is missing. Registration is deliberately not
+  // filtered by resource; this case is what stops that filter being added back as a tidy-up.
+  // The list is not scene-dependent today, so what this asserts is the decision, not a behaviour.
+  it('still advertises the dashboard pair alongside the notebook pair', () => {
+    const client = new DashboardMutationClient(buildNotebookScene(makeNotebookSpec()));
+
+    expect(client.getAvailableCommands()).toEqual(
+      expect.arrayContaining(['GET_SPEC', 'APPLY_SPEC', 'GET_NOTEBOOK_SPEC', 'APPLY_NOTEBOOK_SPEC'])
+    );
   });
 });

--- a/public/app/features/dashboard-scene/mutation-api/commands/notebookSpecCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/notebookSpecCommands.test.ts
@@ -7,7 +7,13 @@
  */
 
 import { config } from '@grafana/runtime';
-import { type Spec as NotebookSpec } from '@grafana/schema/apis/notebook/v2beta1';
+import {
+  defaultLibraryPanelKind,
+  defaultPanelKind,
+  type LibraryPanelKind,
+  type PanelKind,
+  type Spec as NotebookSpec,
+} from '@grafana/schema/apis/notebook/v2beta1';
 import { contextSrv } from 'app/core/services/context_srv';
 import { buildNotebookEnvelope } from 'app/features/notebook/scene/buildNotebookEnvelope';
 import { AccessControlAction } from 'app/types/accessControl';
@@ -49,6 +55,43 @@ function cell(name: string, source: 'assistant' | 'user') {
   return { kind: 'NotebookLayoutItem', spec: { element: { kind: 'ElementReference', name }, source } };
 }
 
+// Panel elements are built from the generated defaults rather than hand-written: the serializer
+// reads more of a panel than any one test asserts on, so a partial fixture would only carry the
+// fields I thought of and would go stale as the schema grows.
+function panelElement(id: number, title: string): PanelKind {
+  const panel = defaultPanelKind();
+  return {
+    ...panel,
+    spec: {
+      ...panel.spec,
+      id,
+      title,
+      data: {
+        ...panel.spec.data,
+        spec: {
+          ...panel.spec.data.spec,
+          queries: [
+            {
+              kind: 'PanelQuery',
+              spec: {
+                refId: 'A',
+                hidden: false,
+                query: { kind: 'DataQuery', group: 'prometheus', version: 'v0', spec: { expr: 'up' } },
+              },
+            },
+          ],
+        },
+      },
+      vizConfig: { ...panel.spec.vizConfig, group: 'timeseries', version: '1.0.0' },
+    },
+  };
+}
+
+function libraryPanelElement(id: number, title: string, uid: string, name: string): LibraryPanelKind {
+  const libraryPanel = defaultLibraryPanelKind();
+  return { ...libraryPanel, spec: { ...libraryPanel.spec, id, title, libraryPanel: { uid, name } } };
+}
+
 function makeNotebookSpec(overrides: Record<string, unknown> = {}): NotebookSpec {
   const spec = {
     title: 'Checkout latency investigation',
@@ -65,6 +108,41 @@ function makeNotebookSpec(overrides: Record<string, unknown> = {}): NotebookSpec
 
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- hand-built fixture matching the generated spec
   return spec as unknown as NotebookSpec;
+}
+
+/**
+ * A notebook with a panel cell among the narrative ones.
+ *
+ * Kept separate from `makeNotebookSpec` because the cases above assert on the exact element set.
+ * The panel's element name is deliberately not `panel-<id>`: the canonical name is what hides the
+ * element-identity problem these cases are about, which is also why the dogfood seed avoids it.
+ */
+function makeNotebookSpecWithPanel(): NotebookSpec {
+  return makeNotebookSpec({
+    elements: {
+      intro: markdown('## What we know\n\np99 jumped at 14:02.'),
+      'latency-panel': panelElement(1, 'p99 latency'),
+      repro: code('promql', 'histogram_quantile(0.99, rate(http_request_duration_seconds_bucket[5m]))'),
+    },
+    layout: {
+      kind: 'NotebookLayout',
+      spec: { cells: [cell('intro', 'user'), cell('latency-panel', 'assistant'), cell('repro', 'assistant')] },
+    },
+  });
+}
+
+/** Separate from the panel fixture so a library panel failure cannot be mistaken for a panel one. */
+function makeNotebookSpecWithLibraryPanel(): NotebookSpec {
+  return makeNotebookSpec({
+    elements: {
+      intro: markdown('## What we know\n\np99 jumped at 14:02.'),
+      'saved-view': libraryPanelElement(2, 'Checkout overview', 'lib-uid-1', 'Checkout overview'),
+    },
+    layout: {
+      kind: 'NotebookLayout',
+      spec: { cells: [cell('intro', 'user'), cell('saved-view', 'user')] },
+    },
+  });
 }
 
 /** Build a notebook scene exactly as NotebookScenePageStateManager does. */
@@ -103,6 +181,27 @@ async function applySpec(scene: DashboardScene, spec: unknown, validate = false)
 function specOf(result: Awaited<ReturnType<typeof getSpec>>): NotebookSpec {
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- handler data is untyped by the MutationResult contract
   return (result.data as { spec: NotebookSpec }).spec;
+}
+
+/** The notebook spec APPLY_SPEC echoes back, which is what a caller feeds into its next write. */
+function echoedSpecOf(result: Awaited<ReturnType<typeof applySpec>>): NotebookSpec {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- handler data is untyped by the MutationResult contract
+  return (result.data as { spec: NotebookSpec }).spec;
+}
+
+function referencedNames(spec: NotebookSpec): string[] {
+  return spec.layout.spec.cells.map((c) => c.spec.element.name);
+}
+
+/** Cell references with no element to resolve to: the shape a lost cell takes in a spec. */
+function danglingReferences(spec: NotebookSpec): string[] {
+  return referencedNames(spec).filter((name) => !spec.elements[name]);
+}
+
+/** The panel id an element carries, or undefined for a narrative cell. */
+function panelIdOf(spec: NotebookSpec, name: string): number | undefined {
+  const element = spec.elements[name];
+  return element && 'id' in element.spec ? element.spec.id : undefined;
 }
 
 beforeEach(() => {
@@ -298,6 +397,114 @@ describe('APPLY_SPEC on a notebook', () => {
       expect(result.success).toBe(true);
       expect(specOf(await getSpec(scene)).layout.spec.cells).toHaveLength(2);
     });
+  });
+});
+
+/**
+ * Panel cells, which the rest of this suite has none of.
+ *
+ * "Add a chart to my notebook" is the main use case for the surface, and it crosses a seam the
+ * narrative cases never touch: a cell's reference is written from the layout manager's own
+ * `elementName`, while the matching element key is derived from the serializer's element map. The
+ * two agree for whatever was loaded and can disagree for anything added afterwards.
+ */
+describe('panel cells', () => {
+  it('keeps the element name of a panel the notebook was loaded with', async () => {
+    const spec = specOf(await getSpec(buildNotebookScene(makeNotebookSpecWithPanel())));
+
+    expect(Object.keys(spec.elements).sort()).toEqual(['intro', 'latency-panel', 'repro']);
+    expect(panelIdOf(spec, 'latency-panel')).toBe(1);
+    expect(danglingReferences(spec)).toEqual([]);
+  });
+
+  it('keeps the element name of a panel added through APPLY_SPEC', async () => {
+    const scene = buildNotebookScene(makeNotebookSpecWithPanel());
+    const current = specOf(await getSpec(scene));
+
+    const result = await applySpec(
+      scene,
+      {
+        ...current,
+        elements: { ...current.elements, 'errors-panel': panelElement(3, '5xx rate') },
+        layout: {
+          kind: 'NotebookLayout',
+          spec: { cells: [...current.layout.spec.cells, cell('errors-panel', 'assistant')] },
+        },
+      },
+      true
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.success).toBe(true);
+
+    const echoed = echoedSpecOf(result);
+    expect(Object.keys(echoed.elements).sort()).toEqual(['errors-panel', 'intro', 'latency-panel', 'repro']);
+    expect(danglingReferences(echoed)).toEqual([]);
+  });
+
+  it('reads back a notebook that still validates after a panel is added', async () => {
+    const scene = buildNotebookScene(makeNotebookSpecWithPanel());
+    const current = specOf(await getSpec(scene));
+
+    await applySpec(
+      scene,
+      {
+        ...current,
+        elements: { ...current.elements, 'errors-panel': panelElement(3, '5xx rate') },
+        layout: {
+          kind: 'NotebookLayout',
+          spec: { cells: [...current.layout.spec.cells, cell('errors-panel', 'assistant')] },
+        },
+      },
+      true
+    );
+
+    const result = await getSpec(scene, true);
+
+    expect(result.error).toBeUndefined();
+    expect(result.success).toBe(true);
+  });
+
+  // The round trip a caller actually performs: read, edit, apply, then apply what came back.
+  it('keeps a newly added panel when the echoed spec is applied again', async () => {
+    const scene = buildNotebookScene(makeNotebookSpecWithPanel());
+    const current = specOf(await getSpec(scene));
+
+    const applied = await applySpec(scene, {
+      ...current,
+      elements: { ...current.elements, 'errors-panel': panelElement(3, '5xx rate') },
+      layout: {
+        kind: 'NotebookLayout',
+        spec: { cells: [...current.layout.spec.cells, cell('errors-panel', 'assistant')] },
+      },
+    });
+
+    await applySpec(scene, echoedSpecOf(applied));
+
+    const after = specOf(await getSpec(scene));
+    expect(referencedNames(after)).toEqual(['intro', 'latency-panel', 'repro', 'errors-panel']);
+    expect(danglingReferences(after)).toEqual([]);
+  });
+
+  it('does not drift when the same spec is applied twice', async () => {
+    const scene = buildNotebookScene(makeNotebookSpecWithPanel());
+    const current = specOf(await getSpec(scene));
+
+    await applySpec(scene, current);
+    const afterFirst = specOf(await getSpec(scene));
+
+    await applySpec(scene, afterFirst);
+    const afterSecond = specOf(await getSpec(scene));
+
+    expect(afterSecond).toEqual(afterFirst);
+  });
+
+  it('keeps the element name of a library panel cell', async () => {
+    const spec = specOf(await getSpec(buildNotebookScene(makeNotebookSpecWithLibraryPanel())));
+
+    expect(Object.keys(spec.elements).sort()).toEqual(['intro', 'saved-view']);
+    expect(panelIdOf(spec, 'saved-view')).toBe(2);
+    expect(danglingReferences(spec)).toEqual([]);
   });
 });
 

--- a/public/app/features/dashboard-scene/mutation-api/commands/notebookSpecCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/notebookSpecCommands.test.ts
@@ -22,6 +22,7 @@ import { type DashboardScene } from '../../scene/DashboardScene';
 import { setNotebookDocumentHeader } from '../../serialization/notebookSpecTransform';
 import { transformSaveModelSchemaV2ToScene } from '../../serialization/transformSaveModelSchemaV2ToScene';
 
+import { applyNotebookSpecCommand } from './applyNotebookSpec';
 import { applySpecCommand } from './applySpec';
 import { getNotebookSpecCommand } from './getNotebookSpec';
 import { getSpecCommand } from './getSpec';
@@ -180,6 +181,10 @@ async function applySpec(scene: DashboardScene, spec: unknown, validate = false)
 
 async function getNotebookSpec(scene: DashboardScene, validate = false) {
   return getNotebookSpecCommand.handler({ validate }, contextFor(scene));
+}
+
+async function applyNotebookSpec(scene: DashboardScene, spec: unknown, validate = false) {
+  return applyNotebookSpecCommand.handler({ spec: spec as Record<string, unknown>, validate }, contextFor(scene));
 }
 
 /** The notebook spec carried by a GET_SPEC result. */
@@ -618,5 +623,116 @@ describe('GET_NOTEBOOK_SPEC permission', () => {
     const result = getNotebookSpecCommand.permission(scene);
     expect(result.allowed).toBe(false);
     expect(result.allowed === false && result.error).toContain('dashboard.notebooks');
+  });
+});
+
+describe('APPLY_NOTEBOOK_SPEC', () => {
+  it('writes a cell the paired read command then returns', async () => {
+    const scene = buildNotebookScene(makeNotebookSpec());
+    const current = specOf(await getNotebookSpec(scene));
+
+    const applied = await applyNotebookSpec(
+      scene,
+      {
+        ...current,
+        elements: { ...current.elements, finding: markdown('The spike correlates with a deploy at 14:00.') },
+        layout: {
+          kind: 'NotebookLayout',
+          spec: { cells: [...current.layout.spec.cells, cell('finding', 'assistant')] },
+        },
+      },
+      true
+    );
+
+    expect(applied.error).toBeUndefined();
+    expect(applied.success).toBe(true);
+
+    const after = specOf(await getNotebookSpec(scene));
+    expect(referencedNames(after)).toEqual(['intro', 'repro', 'finding']);
+    expect(after.elements.finding).toEqual(markdown('The spike correlates with a deploy at 14:00.'));
+  });
+
+  it('echoes the applied notebook spec so the caller needs no follow-up read', async () => {
+    const scene = buildNotebookScene(makeNotebookSpec());
+    const current = specOf(await getNotebookSpec(scene));
+
+    const echoed = echoedSpecOf(await applyNotebookSpec(scene, { ...current, title: 'Renamed' }));
+
+    expect(echoed.title).toBe('Renamed');
+    expect(Object.keys(echoed).sort()).toEqual(['description', 'elements', 'layout', 'tags', 'timeSettings', 'title']);
+  });
+
+  it('keeps the page read-only to hand editing after the rebuild', async () => {
+    const scene = buildNotebookScene(makeNotebookSpec());
+    const current = specOf(await getNotebookSpec(scene));
+
+    await applyNotebookSpec(scene, current);
+
+    // The rebuild replaces scene state wholesale; isEmbedded is set by the notebook page, not by
+    // the save model, so it has to be carried across or the dashboard edit chrome reappears.
+    expect(scene.state.meta.isEmbedded).toBe(true);
+    expect(scene.canEditDashboard()).toBe(false);
+  });
+
+  it('does not enter dashboard edit mode', async () => {
+    const scene = buildNotebookScene(makeNotebookSpec());
+    const onEnterEditMode = jest.spyOn(scene, 'onEnterEditMode');
+    const current = specOf(await getNotebookSpec(scene));
+
+    await applyNotebookSpec(scene, current);
+
+    expect(onEnterEditMode).not.toHaveBeenCalled();
+    expect(scene.state.isEditing).toBeFalsy();
+  });
+
+  it('restores the document header the rebuild would otherwise blank', async () => {
+    const scene = buildNotebookScene(makeNotebookSpec());
+    const current = specOf(await getNotebookSpec(scene));
+
+    await applyNotebookSpec(scene, { ...current, title: 'Renamed', tags: ['resolved'] });
+
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the notebook layout manager holds the header on its own state
+    const body = scene.state.body as unknown as { state: { title?: string; tags?: string[] } };
+    expect(body.state.title).toBe('Renamed');
+    expect(body.state.tags).toEqual(['resolved']);
+  });
+
+  it('rejects a cell that references a missing element, without mutating', async () => {
+    const scene = buildNotebookScene(makeNotebookSpec());
+    const current = specOf(await getNotebookSpec(scene));
+
+    const result = await applyNotebookSpec(
+      scene,
+      {
+        ...current,
+        layout: {
+          kind: 'NotebookLayout',
+          spec: { cells: [...current.layout.spec.cells, cell('ghost', 'assistant')] },
+        },
+      },
+      true
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('no element named "ghost"');
+    expect(specOf(await getNotebookSpec(scene)).layout.spec.cells).toHaveLength(2);
+  });
+});
+
+describe('APPLY_NOTEBOOK_SPEC permission', () => {
+  it('allows a write to an embedded notebook, which the dashboard rule would refuse', () => {
+    const scene = buildNotebookScene(makeNotebookSpec());
+
+    expect(scene.canEditDashboard()).toBe(false);
+    expect(applyNotebookSpecCommand.permission(scene)).toEqual({ allowed: true });
+  });
+
+  it('refuses a dashboard', () => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- only the layout descriptor is read
+    const dashboardScene = { state: { body: { descriptor: { id: 'GridLayout' } } } } as unknown as DashboardScene;
+
+    const result = applyNotebookSpecCommand.permission(dashboardScene);
+    expect(result.allowed).toBe(false);
+    expect(result.allowed === false && result.error).toContain('notebooks only');
   });
 });

--- a/public/app/features/dashboard-scene/mutation-api/commands/notebookSpecCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/notebookSpecCommands.test.ts
@@ -569,6 +569,20 @@ describe('APPLY_SPEC permission', () => {
     expect(applySpecCommand.permission(scene).allowed).toBe(false);
   });
 
+  // The delegation in feature 7 depends entirely on this: the permission check runs before the
+  // handler, so if the dashboard rule judged a notebook, it would refuse and the forward would never
+  // be reached. Turning the dashboard toggle off and still getting an allow is the only way to show
+  // requiresSpecWrite really routed this scene to the notebook rule.
+  it('judges a notebook by the notebook rule even with dashboardNewLayouts off', () => {
+    const dashboardNewLayouts = config.featureToggles.dashboardNewLayouts;
+    config.featureToggles.dashboardNewLayouts = false;
+    const scene = buildNotebookScene(makeNotebookSpec());
+
+    expect(applySpecCommand.permission(scene)).toEqual({ allowed: true });
+
+    config.featureToggles.dashboardNewLayouts = dashboardNewLayouts;
+  });
+
   it('still applies the dashboard rule to a dashboard', () => {
     const dashboardNewLayouts = config.featureToggles.dashboardNewLayouts;
     config.featureToggles.dashboardNewLayouts = false;
@@ -631,6 +645,17 @@ describe('GET_NOTEBOOK_SPEC permission', () => {
     const result = getNotebookSpecCommand.permission(scene);
     expect(result.allowed).toBe(false);
     expect(result.allowed === false && result.error).toContain('dashboard.notebooks');
+  });
+
+  // Allowed on purpose, and the opposite of the write rule. A snapshot is not readable-or-not, it is
+  // editable-or-not: no other read command gates on it, GET_SPEC included, so refusing here would
+  // invent a restriction the surface does not have.
+  it('allows a read of a notebook snapshot', () => {
+    const scene = buildNotebookScene(makeNotebookSpec());
+    scene.setState({ meta: { ...scene.state.meta, isSnapshot: true } });
+
+    expect(getNotebookSpecCommand.permission(scene)).toEqual({ allowed: true });
+    expect(applyNotebookSpecCommand.permission(scene).allowed).toBe(false);
   });
 });
 
@@ -742,6 +767,35 @@ describe('APPLY_NOTEBOOK_SPEC permission', () => {
     const result = applyNotebookSpecCommand.permission(dashboardScene);
     expect(result.allowed).toBe(false);
     expect(result.allowed === false && result.error).toContain('notebooks only');
+  });
+
+  it('refuses when the notebooks feature flag is off', () => {
+    notebooksFlagEnabled = false;
+    const scene = buildNotebookScene(makeNotebookSpec());
+
+    const result = applyNotebookSpecCommand.permission(scene);
+    expect(result.allowed).toBe(false);
+    expect(result.allowed === false && result.error).toContain('dashboard.notebooks');
+  });
+
+  it('refuses on a notebook snapshot', () => {
+    const scene = buildNotebookScene(makeNotebookSpec());
+    scene.setState({ meta: { ...scene.state.meta, isSnapshot: true } });
+
+    const result = applyNotebookSpecCommand.permission(scene);
+    expect(result.allowed).toBe(false);
+    expect(result.allowed === false && result.error).toContain('snapshot');
+  });
+
+  it('refuses when the user cannot write dashboards', () => {
+    jest
+      .spyOn(contextSrv, 'hasPermission')
+      .mockImplementation((action) => action !== AccessControlAction.DashboardsWrite);
+    const scene = buildNotebookScene(makeNotebookSpec());
+
+    const result = applyNotebookSpecCommand.permission(scene);
+    expect(result.allowed).toBe(false);
+    expect(result.allowed === false && result.error).toContain('insufficient permissions');
   });
 });
 

--- a/public/app/features/dashboard-scene/mutation-api/commands/notebookSpecCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/notebookSpecCommands.test.ts
@@ -1,7 +1,7 @@
 /**
  * End-to-end cover for the full-spec surface on a notebook: a real notebook scene, built the way
- * the notebook page builds one, driven through the real GET_SPEC / APPLY_SPEC handlers and the
- * real serializer. Deliberately unmocked — the bugs this replaces were all in the seams between
+ * the notebook page builds one, driven through the real command handlers and the real serializer,
+ * both the notebook pair and the dashboard commands that still answer on a notebook. Deliberately unmocked — the bugs this replaces were all in the seams between
  * those pieces (elements derived from viz panels only, a dashboard-shaped spec handed back for a
  * notebook resource, a permission rule that refused every notebook write).
  */
@@ -23,6 +23,7 @@ import { setNotebookDocumentHeader } from '../../serialization/notebookSpecTrans
 import { transformSaveModelSchemaV2ToScene } from '../../serialization/transformSaveModelSchemaV2ToScene';
 
 import { applySpecCommand } from './applySpec';
+import { getNotebookSpecCommand } from './getNotebookSpec';
 import { getSpecCommand } from './getSpec';
 import { type MutationContext } from './types';
 
@@ -175,6 +176,10 @@ async function getSpec(scene: DashboardScene, validate = false) {
 
 async function applySpec(scene: DashboardScene, spec: unknown, validate = false) {
   return applySpecCommand.handler({ spec: spec as Record<string, unknown>, validate }, contextFor(scene));
+}
+
+async function getNotebookSpec(scene: DashboardScene, validate = false) {
+  return getNotebookSpecCommand.handler({ validate }, contextFor(scene));
 }
 
 /** The notebook spec carried by a GET_SPEC result. */
@@ -566,5 +571,52 @@ describe('APPLY_SPEC permission', () => {
     expect(result.allowed === false && result.error).toContain('dashboardNewLayouts');
 
     config.featureToggles.dashboardNewLayouts = dashboardNewLayouts;
+  });
+});
+
+describe('GET_NOTEBOOK_SPEC', () => {
+  it('returns the notebook, with the element names it was loaded under', async () => {
+    const spec = specOf(await getNotebookSpec(buildNotebookScene(makeNotebookSpecWithPanel())));
+
+    expect(Object.keys(spec).sort()).toEqual(['description', 'elements', 'layout', 'tags', 'timeSettings', 'title']);
+    expect(Object.keys(spec.elements).sort()).toEqual(['intro', 'latency-panel', 'repro']);
+    expect(panelIdOf(spec, 'latency-panel')).toBe(1);
+    expect(danglingReferences(spec)).toEqual([]);
+  });
+
+  it('passes notebook validation when asked to validate', async () => {
+    const result = await getNotebookSpec(buildNotebookScene(makeNotebookSpecWithPanel()), true);
+
+    expect(result.success).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+});
+
+describe('GET_NOTEBOOK_SPEC permission', () => {
+  // Reading a notebook needs its own rule rather than the unconditional one GET_SPEC uses, because
+  // the command promises a notebook spec and a dashboard cannot produce one.
+  it('allows a read of an embedded notebook', () => {
+    const scene = buildNotebookScene(makeNotebookSpec());
+
+    expect(scene.canEditDashboard()).toBe(false);
+    expect(getNotebookSpecCommand.permission(scene)).toEqual({ allowed: true });
+  });
+
+  it('refuses a dashboard', () => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- only the layout descriptor is read
+    const dashboardScene = { state: { body: { descriptor: { id: 'GridLayout' } } } } as unknown as DashboardScene;
+
+    const result = getNotebookSpecCommand.permission(dashboardScene);
+    expect(result.allowed).toBe(false);
+    expect(result.allowed === false && result.error).toContain('notebooks only');
+  });
+
+  it('refuses when the notebooks feature flag is off', () => {
+    notebooksFlagEnabled = false;
+    const scene = buildNotebookScene(makeNotebookSpec());
+
+    const result = getNotebookSpecCommand.permission(scene);
+    expect(result.allowed).toBe(false);
+    expect(result.allowed === false && result.error).toContain('dashboard.notebooks');
   });
 });

--- a/public/app/features/dashboard-scene/mutation-api/commands/registry.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/registry.ts
@@ -14,6 +14,7 @@ import { applySpecCommand } from './applySpec';
 import { enterEditModeCommand } from './enterEditMode';
 import { getDashboardInfoCommand } from './getDashboardInfo';
 import { getLayoutCommand } from './getLayout';
+import { getNotebookSpecCommand } from './getNotebookSpec';
 import { getSpecCommand } from './getSpec';
 import { listAnnotationsCommand } from './listAnnotations';
 import { listPanelsCommand } from './listPanels';
@@ -65,6 +66,7 @@ export const ALL_COMMANDS: Array<MutationCommand<any>> = [
   updateDashboardSettingsCommand,
   getSpecCommand,
   applySpecCommand,
+  getNotebookSpecCommand,
 ];
 
 /** Lookup command by name (case-insensitive). */

--- a/public/app/features/dashboard-scene/mutation-api/commands/registry.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/registry.ts
@@ -10,6 +10,7 @@ import { addPanelCommand } from './addPanel';
 import { addRowCommand } from './addRow';
 import { addTabCommand } from './addTab';
 import { addVariableCommand } from './addVariable';
+import { applyNotebookSpecCommand } from './applyNotebookSpec';
 import { applySpecCommand } from './applySpec';
 import { enterEditModeCommand } from './enterEditMode';
 import { getDashboardInfoCommand } from './getDashboardInfo';
@@ -67,6 +68,7 @@ export const ALL_COMMANDS: Array<MutationCommand<any>> = [
   getSpecCommand,
   applySpecCommand,
   getNotebookSpecCommand,
+  applyNotebookSpecCommand,
 ];
 
 /** Lookup command by name (case-insensitive). */

--- a/public/app/features/dashboard-scene/mutation-api/commands/specRebuild.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/specRebuild.ts
@@ -1,0 +1,129 @@
+/**
+ * The rebuild-and-swap shared by the full-spec write commands.
+ *
+ * Its own module because both resources go through it. The notebook widens its spec to the dashboard
+ * shape before calling, rather than having a rebuild of its own, so there is exactly one place where
+ * a document is replaced and the two cannot drift.
+ */
+
+import { sceneUtils } from '@grafana/scenes';
+import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
+import { type ObjectMeta } from 'app/features/apiserver/types';
+import { dashboardAPIVersionResolver } from 'app/features/dashboard/api/DashboardAPIVersionResolver';
+import { type DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
+
+import type { DashboardScene } from '../../scene/DashboardScene';
+import { transformSaveModelSchemaV2ToScene } from '../../serialization/transformSaveModelSchemaV2ToScene';
+
+// The parts of DashboardScene a rebuild actually touches. Naming them keeps the module honest about
+// its reach, and is what lets a caller's test drive this with a small stub instead of a real scene.
+type RebuildTargetScene = {
+  state: {
+    key?: string;
+    meta: Record<string, unknown> & {
+      canEdit?: boolean;
+      canSave?: boolean;
+      canShare?: boolean;
+      canStar?: boolean;
+      canDelete?: boolean;
+      canAdmin?: boolean;
+      isEmbedded?: boolean;
+      slug?: string;
+      url?: string;
+      key?: string;
+    };
+  };
+  serializer: {
+    getK8SMetadata: () => Partial<ObjectMeta> | undefined;
+    initializeElementMapping: (spec: DashboardV2Spec) => void;
+  };
+  setState: (state: unknown) => void;
+};
+
+/**
+ * Wrap a bare spec in the access/metadata envelope `transformSaveModelSchemaV2ToScene`
+ * expects, reusing the live scene's metadata + access so identity and
+ * permissions survive the rebuild.
+ */
+function dtoFromScene(scene: RebuildTargetScene, spec: DashboardV2Spec): DashboardWithAccessInfo<DashboardV2Spec> {
+  const meta = scene.state.meta;
+  return {
+    kind: 'DashboardWithAccessInfo',
+    metadata: resolveMetadata(scene),
+    access: {
+      canEdit: meta.canEdit !== false,
+      canSave: meta.canSave !== false,
+      canShare: meta.canShare !== false,
+      canStar: meta.canStar !== false,
+      canDelete: meta.canDelete !== false,
+      canAdmin: meta.canAdmin !== false,
+      slug: meta.slug,
+      url: meta.url,
+    },
+    // Whichever v2 version the backend serves (stable v2 or v2beta1). It is
+    // stamped onto the scene, so a wrong literal would mislabel it on save.
+    apiVersion: dashboardAPIVersionResolver.getV2(),
+    spec,
+  };
+}
+
+/**
+ * `transformSaveModelSchemaV2ToScene` reads `metadata.name`/`generation`/
+ * `creationTimestamp` unguarded, which throws on a brand-new / unsaved dashboard
+ * whose serializer metadata is absent or partial. Guarantee a populated
+ * envelope, preferring whatever the scene already has.
+ */
+function resolveMetadata(scene: RebuildTargetScene): DashboardWithAccessInfo<DashboardV2Spec>['metadata'] {
+  const existing = scene.serializer.getK8SMetadata() ?? {};
+  const meta = scene.state.meta;
+  const uid =
+    (typeof existing.name === 'string' && existing.name) ||
+    (typeof meta.uid === 'string' && meta.uid) ||
+    (typeof meta.key === 'string' && meta.key) ||
+    'new-dashboard';
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- assemble the metadata envelope
+  return {
+    ...existing,
+    name: uid,
+    generation: typeof existing.generation === 'number' ? existing.generation : 1,
+    creationTimestamp:
+      typeof existing.creationTimestamp === 'string' ? existing.creationTimestamp : new Date().toISOString(),
+    annotations: existing.annotations ?? {},
+  } as DashboardWithAccessInfo<DashboardV2Spec>['metadata'];
+}
+
+/**
+ * Rebuild the scene from a dashboard-shaped spec and swap it in place.
+ *
+ * `preserveMeta` carries forward the meta flags the caller owns rather than the save model — the
+ * notebook page sets `isEmbedded` after loading, and a rebuild would otherwise drop it and reveal the
+ * dashboard edit chrome on a page that is meant to be read-only to hand editing.
+ *
+ * The element map has to be reseeded by hand afterwards. `transformSaveModelSchemaV2ToScene` seeds
+ * the map of the scene it builds, but only that scene's *state* is cloned over and the serializer
+ * hangs off the scene object, so the live map would keep what load put there. It then resolves every
+ * element the applied spec added to `panel-<id>` and stores that, leaving the layout referencing a
+ * name the elements no longer use. `initializeElementMapping` clears before it seeds, so the reseed
+ * also undoes any wrong entry an earlier read cached. Deliberately not `setInitialSaveModel`, which
+ * would additionally reset the unsaved-changes baseline and change how dashboards detect dirty state.
+ */
+export function rebuildSceneFromSpec(
+  dashboardScene: DashboardScene,
+  spec: DashboardV2Spec,
+  preserveMeta?: Record<string, unknown>
+): void {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- narrow DashboardScene to the fields a rebuild reads
+  const scene = dashboardScene as unknown as RebuildTargetScene;
+
+  const dto = dtoFromScene(scene, spec);
+  const rebuilt = transformSaveModelSchemaV2ToScene(dto);
+
+  // Reuse the live key so existing references (incl. the mutation client's
+  // `scene`) survive the swap.
+  const newState = sceneUtils.cloneSceneObjectState(rebuilt.state, { key: scene.state.key });
+  scene.setState(preserveMeta ? { ...newState, meta: { ...newState.meta, ...preserveMeta } } : newState);
+
+  // Safe on a dashboard still served as v1: its serializer reads `panels`, finds none on a v2 spec,
+  // and is left with an empty map, which regenerates the same `panel-<id>` keys it seeds on load.
+  scene.serializer.initializeElementMapping(spec);
+}

--- a/public/app/features/dashboard-scene/mutation-api/commands/specValidation.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/specValidation.test.ts
@@ -61,6 +61,7 @@ function makeSceneContext(): MutationContext {
     activateSidebar: jest.fn(),
     serializer: {
       getK8SMetadata: () => ({ name: 'dash-uid', generation: 1, creationTimestamp: '2026-01-01T00:00:00Z' }),
+      initializeElementMapping: jest.fn(),
     },
     setState: jest.fn(),
   };

--- a/public/app/features/dashboard-scene/mutation-api/commands/types.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/types.ts
@@ -94,6 +94,23 @@ export function requiresNewDashboardLayoutsReadOnly(_scene: DashboardScene): Per
 }
 
 /**
+ * Requires the scene to be a notebook, on an instance where notebooks are enabled. The rule for the
+ * read-only half of the notebook surface, and the base the edit rule builds on.
+ */
+export function requiresNotebookResource(scene: DashboardScene): PermissionCheckResult {
+  if (!getFeatureFlagClient().getBooleanValue(FlagKeys.DashboardNotebooks, false)) {
+    return {
+      allowed: false,
+      error: 'Notebooks are not enabled on this instance (feature flag dashboard.notebooks).',
+    };
+  }
+  if (!isNotebookScene(scene)) {
+    return { allowed: false, error: 'This command applies to notebooks only: the open document is a dashboard.' };
+  }
+  return { allowed: true };
+}
+
+/**
  * Requires notebook editing to be possible: the resource must be enabled and the user must be
  * able to write dashboards.
  *
@@ -109,11 +126,9 @@ export function requiresNewDashboardLayoutsReadOnly(_scene: DashboardScene): Per
  * action is the right long-term answer and is tracked with the resource's permission model.
  */
 function requiresNotebookEdit(scene: DashboardScene): PermissionCheckResult {
-  if (!getFeatureFlagClient().getBooleanValue(FlagKeys.DashboardNotebooks, false)) {
-    return {
-      allowed: false,
-      error: 'Notebooks are not enabled on this instance (feature flag dashboard.notebooks).',
-    };
+  const resource = requiresNotebookResource(scene);
+  if (!resource.allowed) {
+    return resource;
   }
   if (scene.state.meta.isSnapshot) {
     return { allowed: false, error: 'Cannot edit notebook: it is a snapshot.' };

--- a/public/app/features/dashboard-scene/mutation-api/commands/types.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/types.ts
@@ -125,7 +125,7 @@ export function requiresNotebookResource(scene: DashboardScene): PermissionCheck
  * blast radius of the coarseness is a scene the user could not save anyway. A notebook-scoped
  * action is the right long-term answer and is tracked with the resource's permission model.
  */
-function requiresNotebookEdit(scene: DashboardScene): PermissionCheckResult {
+export function requiresNotebookEdit(scene: DashboardScene): PermissionCheckResult {
   const resource = requiresNotebookResource(scene);
   if (!resource.allowed) {
     return resource;

--- a/public/app/features/dashboard-scene/scene/layout-notebook/NotebookLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-notebook/NotebookLayoutManager.tsx
@@ -37,7 +37,7 @@ interface NotebookLayoutManagerState extends SceneObjectState {
 
 export class NotebookLayoutManager
   extends SceneObjectBase<NotebookLayoutManagerState>
-  implements DashboardLayoutManager<{}, NotebookLayoutKind, CellKind>
+  implements DashboardLayoutManager<{}, NotebookLayoutKind>
 {
   public static Component = NotebookLayoutManagerRenderer;
   public readonly isDashboardLayoutManager = true;
@@ -80,9 +80,12 @@ export class NotebookLayoutManager
     return this.state.cells.map((cell) => cell.state.body).filter((body): body is VizPanel => body !== undefined);
   }
 
-  // Narrative cells are exactly the elements getVizPanels() cannot report. Without this the
-  // serializer builds `elements` from viz panels alone and every markdown/code cell disappears
-  // while `layout.spec.cells` still references it — a spec with dangling ElementReferences.
+  // Narrative cells are exactly the elements getVizPanels() cannot report, so the notebook
+  // serializer asks for them separately and merges the two. Without them a spec carries
+  // `layout.spec.cells` entries pointing at elements that are not there.
+  //
+  // Notebook-specific on purpose: the dashboard layout contract knows nothing about this, because a
+  // dashboard has no elements that are not panels.
   public getNonPanelElements(): Record<string, CellKind> {
     const elements: Record<string, CellKind> = {};
     for (const cell of this.state.cells) {

--- a/public/app/features/dashboard-scene/scene/types/DashboardLayoutManager.ts
+++ b/public/app/features/dashboard-scene/scene/types/DashboardLayoutManager.ts
@@ -1,8 +1,5 @@
 import { type SceneObject, type VizPanel } from '@grafana/scenes';
-import {
-  type Element as DashboardElement,
-  type Spec as DashboardV2Spec,
-} from '@grafana/schema/apis/dashboard.grafana.app/v2';
+import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { type OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 
 import { type PanelIdGenerator } from '../../utils/dashboardSceneGraph';
@@ -14,18 +11,17 @@ import { type LayoutRegistryItem } from './LayoutRegistryItem';
  * different kinds are held together: the notebook layout serializes a kind outside the dashboard
  * layout union, so it does not fit the plain DashboardLayoutManager.
  *
- * serialize() and getNonPanelElements() are not type-checked through this alias. Narrow to the
- * concrete manager first (e.g. `body instanceof NotebookLayoutManager`) if you need a specific kind.
+ * serialize() is not type-checked through this alias. Narrow to the concrete manager first
+ * (e.g. `body instanceof NotebookLayoutManager`) if you need a specific kind.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- erases only the serialize()/element kinds so sibling layout managers fit
-export type AnyDashboardLayoutManager = DashboardLayoutManager<{}, any, any>;
+export type AnyDashboardLayoutManager = DashboardLayoutManager<{}, any>;
 
 /**
  * A scene object that usually wraps an underlying layout
  * Dealing with all the state management and editing of the layout
  */
-export interface DashboardLayoutManager<S = {}, TLayout = DashboardV2Spec['layout'], TElement = DashboardElement>
-  extends SceneObject {
+export interface DashboardLayoutManager<S = {}, TLayout = DashboardV2Spec['layout']> extends SceneObject {
   /** Marks it as a DashboardLayoutManager */
   isDashboardLayoutManager: true;
 
@@ -61,19 +57,6 @@ export interface DashboardLayoutManager<S = {}, TLayout = DashboardV2Spec['layou
    * Gets all the viz panels in the layout
    */
   getVizPanels(): VizPanel[];
-
-  /**
-   * Elements this layout references that are NOT viz panels, keyed by element name.
-   *
-   * The v2 serializer derives the spec's `elements` map from {@link getVizPanels}, which is
-   * complete for every dashboard layout. A sibling layout whose elements include non-panel
-   * kinds — the notebook's markdown/code cells — must contribute them here, or they are
-   * dropped on serialize while the layout keeps referencing them by name.
-   *
-   * TElement defaults to the dashboard element union; a sibling layout narrows it to its own
-   * element kind (the notebook to `CellKind`) the same way it narrows TLayout.
-   */
-  getNonPanelElements?(): Record<string, TElement>;
 
   /**
    * Notify the layout manager that the edit mode has changed

--- a/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.test.ts
+++ b/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.test.ts
@@ -1306,6 +1306,29 @@ describe('DashboardSceneSerializer', () => {
         // Should return default panel key for non-existent panel
         expect(serializer.getElementIdForPanel(3)).toBe('panel-3');
       });
+
+      // A library panel is returned by getVizPanels() like any other panel, so its element name has
+      // to be in the map. While it was not, serialization rekeyed it to panel-<id> and the layout
+      // kept referencing the name it was saved under, leaving the reference pointing at nothing.
+      it('should map a library panel element under its own name', () => {
+        serializer.initializeElementMapping({
+          ...saveModel,
+          elements: {
+            ...saveModel.elements,
+            'saved-view': {
+              kind: 'LibraryPanel',
+              spec: {
+                id: 3,
+                title: 'Checkout overview',
+                libraryPanel: { uid: 'lib-uid-1', name: 'Checkout overview' },
+              },
+            },
+          },
+        });
+
+        expect(serializer.getElementPanelMapping().get('saved-view')).toBe(3);
+        expect(serializer.getElementIdForPanel(3)).toBe('saved-view');
+      });
     });
   });
 

--- a/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.ts
@@ -319,7 +319,10 @@ export class V2DashboardSerializer
     const elementKeys = Object.keys(saveModel.elements);
     elementKeys.forEach((key) => {
       const elementPanel = saveModel.elements[key];
-      if (elementPanel.kind === 'Panel') {
+      // Library panels belong here too: they are returned by `getVizPanels()`, so their element key
+      // is derived through the same lookup, and leaving them out meant serialization rekeyed them to
+      // `panel-<id>` while the layout kept referencing the name they were saved under.
+      if (elementPanel.kind === 'Panel' || elementPanel.kind === 'LibraryPanel') {
         this.elementPanelMap.set(key, elementPanel.spec.id);
       }
     });

--- a/public/app/features/dashboard-scene/serialization/notebookSpecTransform.ts
+++ b/public/app/features/dashboard-scene/serialization/notebookSpecTransform.ts
@@ -156,18 +156,28 @@ export function notebookSpecToDashboardSpec(notebook: NotebookSpec): DashboardV2
  * `description` is dropped when empty: it is optional on a notebook, and the widening above
  * substitutes '' for absent, so an empty string round-trips back to absent.
  */
+/**
+ * Downgrade panel transformations in an elements map back to the notebook's v2beta1 wire shape.
+ *
+ * `normalizeTransformation` runs first so the downgrade is total: it is a no-op on the v2 shape the
+ * serializer emits, and idempotent if a spec somehow already carries the v2beta1 shape.
+ *
+ * Exported so the notebook serializer, which builds its elements itself, applies the same downgrade
+ * as the spec-to-spec projection instead of a second copy of it.
+ */
+export function downgradeElementsToNotebookWire(elements: Record<string, unknown>): Record<string, unknown> {
+  return mapPanelTransformations(elements, (transformation) =>
+    toWireTransformation(normalizeTransformation(transformation), NOTEBOOK_WIRE_VERSION)
+  );
+}
+
 export function dashboardSpecToNotebookSpec(spec: DashboardV2Spec): NotebookSpec {
   const notebook = {
     title: spec.title,
     ...(spec.description ? { description: spec.description } : {}),
     tags: spec.tags,
     timeSettings: spec.timeSettings,
-    // Downgrade panel transformations back to the notebook's v2beta1 wire shape.
-    // normalizeTransformation first so the downgrade is total: it is a no-op on the v2 shape the
-    // serializer emits, and idempotent if a spec somehow already carries the v2beta1 shape.
-    elements: mapPanelTransformations(spec.elements, (transformation) =>
-      toWireTransformation(normalizeTransformation(transformation), NOTEBOOK_WIRE_VERSION)
-    ),
+    elements: downgradeElementsToNotebookWire(spec.elements),
     layout: spec.layout,
   };
 
@@ -183,6 +193,7 @@ export function dashboardSpecToNotebookSpec(spec: DashboardV2Spec): NotebookSpec
 type NotebookLayoutLike = {
   descriptor: { id: string };
   setState: (state: { title?: string; tags?: string[] }) => void;
+  getNonPanelElements: () => Record<string, unknown>;
 };
 
 function hasNotebookDescriptor(body: unknown): body is NotebookLayoutLike {
@@ -204,6 +215,17 @@ function hasNotebookDescriptor(body: unknown): body is NotebookLayoutLike {
  * are reached before a handler has touched the scene, and answering "not a notebook" is the safe
  * reading — it routes to the dashboard rules the caller had before notebooks existed.
  */
+/**
+ * The notebook's narrative cells: the elements a notebook references that are not viz panels.
+ *
+ * Asked of the notebook layout directly rather than through a hook on the dashboard layout contract,
+ * which is what keeps the dashboard serializer free of any notebook knowledge. Anything that is not a
+ * notebook layout has none, and returning `{}` for it is what the optional hook resolved to before.
+ */
+export function getNotebookCellElements(body: unknown): Record<string, unknown> {
+  return hasNotebookDescriptor(body) ? body.getNonPanelElements() : {};
+}
+
 export function isNotebookScene(scene: { state?: { body?: unknown } } | undefined): boolean {
   return hasNotebookDescriptor(scene?.state?.body);
 }

--- a/public/app/features/dashboard-scene/serialization/transformSceneToNotebookSaveModel.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToNotebookSaveModel.test.ts
@@ -1,0 +1,143 @@
+import { defaultPanelKind, type PanelKind, type Spec as NotebookSpec } from '@grafana/schema/apis/notebook/v2beta1';
+import { buildNotebookEnvelope } from 'app/features/notebook/scene/buildNotebookEnvelope';
+
+import { type DashboardScene } from '../scene/DashboardScene';
+
+import { dashboardSpecToNotebookSpec } from './notebookSpecTransform';
+import { transformSaveModelSchemaV2ToScene } from './transformSaveModelSchemaV2ToScene';
+import { transformSceneToNotebookSaveModel } from './transformSceneToNotebookSaveModel';
+import { transformSceneToSaveModelSchemaV2 } from './transformSceneToSaveModelSchemaV2';
+
+const timeSettings = {
+  from: 'now-6h',
+  to: 'now',
+  autoRefresh: '',
+  autoRefreshIntervals: ['5s', '1m'],
+  hideTimepicker: false,
+  fiscalYearStartMonth: 0,
+  timezone: 'browser',
+};
+
+/**
+ * A panel carrying a transformation in the notebook's v2beta1 wire shape (`kind` holds the
+ * transformation id and `spec.id` duplicates it), which is what the resource really stores.
+ */
+function panelWithTransformation(): PanelKind {
+  const panel = defaultPanelKind();
+  return {
+    ...panel,
+    spec: {
+      ...panel.spec,
+      id: 1,
+      title: 'p99 latency',
+      data: {
+        ...panel.spec.data,
+        spec: {
+          ...panel.spec.data.spec,
+          queries: [
+            {
+              kind: 'PanelQuery',
+              spec: {
+                refId: 'A',
+                hidden: false,
+                query: { kind: 'DataQuery', group: 'prometheus', version: 'v0', spec: { expr: 'up' } },
+              },
+            },
+          ],
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the v2beta1 wire shape, which is what a stored notebook carries
+          transformations: [
+            { kind: 'limit', spec: { id: 'limit', options: { limitField: 5 } } },
+          ] as unknown as (typeof panel.spec.data.spec)['transformations'],
+        },
+      },
+      vizConfig: { ...panel.spec.vizConfig, group: 'timeseries', version: '1.0.0' },
+    },
+  };
+}
+
+function makeNotebookSpec(): NotebookSpec {
+  const spec = {
+    title: 'Checkout latency investigation',
+    description: 'p99 spike on the payments path',
+    tags: ['incident'],
+    timeSettings,
+    elements: {
+      intro: { kind: 'Cell', spec: { content: { kind: 'Markdown', spec: { text: '## What we know' } } } },
+      'latency-panel': panelWithTransformation(),
+      repro: { kind: 'Cell', spec: { content: { kind: 'Code', spec: { language: 'promql', code: 'up' } } } },
+    },
+    layout: {
+      kind: 'NotebookLayout',
+      spec: {
+        cells: [
+          {
+            kind: 'NotebookLayoutItem',
+            spec: { element: { kind: 'ElementReference', name: 'intro' }, source: 'user' },
+          },
+          {
+            kind: 'NotebookLayoutItem',
+            spec: { element: { kind: 'ElementReference', name: 'latency-panel' }, source: 'assistant' },
+          },
+          {
+            kind: 'NotebookLayoutItem',
+            spec: { element: { kind: 'ElementReference', name: 'repro' }, source: 'assistant' },
+          },
+        ],
+      },
+    },
+  };
+
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- hand-built fixture matching the generated spec
+  return spec as unknown as NotebookSpec;
+}
+
+/** Built the way the notebook page builds one, and not activated, matching the command suites. */
+function buildNotebookScene(): DashboardScene {
+  const envelope = buildNotebookEnvelope({
+    apiVersion: 'notebook.grafana.app/v2beta1',
+    kind: 'Notebook',
+    metadata: { name: 'nb-1', generation: 1, creationTimestamp: '2026-08-03T00:00:00Z', annotations: {} },
+    spec: makeNotebookSpec(),
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal resource envelope for the test
+  } as unknown as Parameters<typeof buildNotebookEnvelope>[0]);
+
+  return transformSaveModelSchemaV2ToScene(envelope);
+}
+
+describe('transformSceneToNotebookSaveModel', () => {
+  // Step 1 is a wrapper, so this compares the new entry point against the two calls the commands
+  // used to make. It is nearly a tautology today on purpose: its job is to be the reference when
+  // step 2 replaces the body with a composition that no longer routes through the dashboard
+  // serializer. Do not delete it as redundant, it is the only thing pinning that swap.
+  it('returns exactly what the dashboard serializer plus the notebook projection returns', () => {
+    const scene = buildNotebookScene();
+
+    const reference = dashboardSpecToNotebookSpec(transformSceneToSaveModelSchemaV2(scene));
+
+    expect(transformSceneToNotebookSaveModel(scene)).toEqual(reference);
+  });
+
+  // The scene speaks the v2 stable transformation shape, the notebook resource stores the v2beta1
+  // one, so serializing has to downgrade on the way out. Asserted on shape rather than against the
+  // input panel, because the round trip through the scene fills in `disabled` and `filter`.
+  it('downgrades panel transformations back to the notebook wire shape', () => {
+    const spec = transformSceneToNotebookSaveModel(buildNotebookScene());
+
+    const panel = spec.elements['latency-panel'];
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- narrowing the element union to the panel the fixture put there
+    const transformations = (panel as PanelKind).spec.data.spec.transformations;
+
+    expect(transformations).toHaveLength(1);
+    expect(transformations[0].kind).toBe('limit');
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- v2beta1 duplicates the id inside spec
+    expect((transformations[0].spec as { id: string }).id).toBe('limit');
+  });
+
+  // The serializer emits the full dashboard shape, so anything it adds has to be dropped here rather
+  // than carried into a resource with no such fields.
+  it('carries the notebook fields and none of the dashboard ones', () => {
+    const spec = transformSceneToNotebookSaveModel(buildNotebookScene());
+
+    expect(Object.keys(spec).sort()).toEqual(['description', 'elements', 'layout', 'tags', 'timeSettings', 'title']);
+  });
+});

--- a/public/app/features/dashboard-scene/serialization/transformSceneToNotebookSaveModel.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToNotebookSaveModel.test.ts
@@ -3,10 +3,10 @@ import { buildNotebookEnvelope } from 'app/features/notebook/scene/buildNotebook
 
 import { type DashboardScene } from '../scene/DashboardScene';
 
-import { dashboardSpecToNotebookSpec } from './notebookSpecTransform';
+import { downgradeElementsToNotebookWire } from './notebookSpecTransform';
 import { transformSaveModelSchemaV2ToScene } from './transformSaveModelSchemaV2ToScene';
 import { transformSceneToNotebookSaveModel } from './transformSceneToNotebookSaveModel';
-import { transformSceneToSaveModelSchemaV2 } from './transformSceneToSaveModelSchemaV2';
+import { getElements } from './transformSceneToSaveModelSchemaV2';
 
 const timeSettings = {
   from: 'now-6h',
@@ -105,16 +105,43 @@ function buildNotebookScene(): DashboardScene {
 }
 
 describe('transformSceneToNotebookSaveModel', () => {
-  // Step 1 is a wrapper, so this compares the new entry point against the two calls the commands
-  // used to make. It is nearly a tautology today on purpose: its job is to be the reference when
-  // step 2 replaces the body with a composition that no longer routes through the dashboard
-  // serializer. Do not delete it as redundant, it is the only thing pinning that swap.
-  it('returns exactly what the dashboard serializer plus the notebook projection returns', () => {
+  // What replaced the equivalence check this file used to carry.
+  //
+  // That one compared the notebook spec against
+  // `dashboardSpecToNotebookSpec(transformSceneToSaveModelSchemaV2(scene))`, and it did its job: it
+  // passed at the exact moment the body stopped routing through the dashboard serializer, which is
+  // what made the swap safe. It could not survive the second half of the change, because the
+  // dashboard serializer deliberately stopped emitting narrative cells, so the reference side lost
+  // every markdown and code cell and no longer described a notebook.
+  //
+  // This is the invariant that outlives it, and the one that would actually catch a regression: the
+  // panel elements in a notebook spec are the ones the shared builder produced, not a second
+  // derivation. Two functions computing an element key that nothing forces to agree is the bug this
+  // whole change came from, so it is worth an assertion rather than a comment.
+  it('takes its panel elements from the shared element builder rather than deriving them again', () => {
     const scene = buildNotebookScene();
 
-    const reference = dashboardSpecToNotebookSpec(transformSceneToSaveModelSchemaV2(scene));
+    const spec = transformSceneToNotebookSaveModel(scene);
+    const shared = getElements(scene, scene.serializer.getDSReferencesMapping());
 
-    expect(transformSceneToNotebookSaveModel(scene)).toEqual(reference);
+    const panelNames = Object.keys(shared);
+    expect(panelNames).toEqual(['latency-panel']);
+    for (const name of panelNames) {
+      // Compared after the notebook's wire downgrade, which is the one transformation applied on top.
+      expect(spec.elements[name]).toEqual(downgradeElementsToNotebookWire(shared)[name]);
+    }
+  });
+
+  // The cells the shared builder cannot see. Together with the case above this says the elements map
+  // is exactly panels-from-the-shared-builder plus the notebook's own cells, and nothing else.
+  it('adds the narrative cells the shared element builder cannot see', () => {
+    const scene = buildNotebookScene();
+
+    const spec = transformSceneToNotebookSaveModel(scene);
+    const sharedPanelNames = Object.keys(getElements(scene, scene.serializer.getDSReferencesMapping()));
+    const cellNames = Object.keys(spec.elements).filter((name) => !sharedPanelNames.includes(name));
+
+    expect(cellNames.sort()).toEqual(['intro', 'repro']);
   });
 
   // The scene speaks the v2 stable transformation shape, the notebook resource stores the v2beta1

--- a/public/app/features/dashboard-scene/serialization/transformSceneToNotebookSaveModel.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToNotebookSaveModel.ts
@@ -1,0 +1,25 @@
+/**
+ * Serialize an open notebook scene into a `NotebookSpec`.
+ *
+ * Everything that reads a scene is dashboard-typed: the scene serializer always emits the full
+ * dashboard shape, so a notebook has to be projected back down to its own fields before it leaves.
+ * Without that, a caller echoing what it read straight back through a write would be sending
+ * `variables`, `annotations` and `cursorSync` into a resource that has no such fields.
+ *
+ * Step 1 of two, and the body is deliberately just the two calls the commands used to make
+ * themselves. What it buys today is a name and a single home for the operation. Step 2 replaces the
+ * body with a composition that builds a `NotebookSpec` directly instead of routing through the
+ * dashboard serializer, which is what lets the dashboard side stop knowing about notebooks. The
+ * equivalence test next to this file is what makes that swap safe, so it is not optional.
+ */
+
+import { type Spec as NotebookSpec } from '@grafana/schema/apis/notebook/v2beta1';
+
+import { type DashboardScene } from '../scene/DashboardScene';
+
+import { dashboardSpecToNotebookSpec } from './notebookSpecTransform';
+import { transformSceneToSaveModelSchemaV2 } from './transformSceneToSaveModelSchemaV2';
+
+export function transformSceneToNotebookSaveModel(scene: DashboardScene): NotebookSpec {
+  return dashboardSpecToNotebookSpec(transformSceneToSaveModelSchemaV2(scene));
+}

--- a/public/app/features/dashboard-scene/serialization/transformSceneToNotebookSaveModel.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToNotebookSaveModel.ts
@@ -1,25 +1,41 @@
 /**
  * Serialize an open notebook scene into a `NotebookSpec`.
  *
- * Everything that reads a scene is dashboard-typed: the scene serializer always emits the full
- * dashboard shape, so a notebook has to be projected back down to its own fields before it leaves.
- * Without that, a caller echoing what it read straight back through a write would be sending
- * `variables`, `annotations` and `cursorSync` into a resource that has no such fields.
+ * Built field by field rather than by serializing a dashboard and projecting the result down. The
+ * projection worked, but it meant the dashboard serializer had to know that some layouts own elements
+ * it cannot see, which is a notebook concern living in dashboard code.
  *
- * Step 1 of two, and the body is deliberately just the two calls the commands used to make
- * themselves. What it buys today is a name and a single home for the operation. Step 2 replaces the
- * body with a composition that builds a `NotebookSpec` directly instead of routing through the
- * dashboard serializer, which is what lets the dashboard side stop knowing about notebooks. The
- * equivalence test next to this file is what makes that swap safe, so it is not optional.
+ * What is shared is shared by calling it, not by copying it. Panel elements and their identifiers come
+ * from the dashboard serializer's own `getElements`, and `timeSettings` from its `buildTimeSettings`.
+ * Deriving either again here is the failure this whole change came from: two functions computing an
+ * element key that nothing forces to agree.
+ *
+ * What is the notebook's own: its narrative cells, its layout, and the v2beta1 downgrade of panel
+ * transformations, which the resource is still served on.
  */
 
 import { type Spec as NotebookSpec } from '@grafana/schema/apis/notebook/v2beta1';
 
 import { type DashboardScene } from '../scene/DashboardScene';
 
-import { dashboardSpecToNotebookSpec } from './notebookSpecTransform';
-import { transformSceneToSaveModelSchemaV2 } from './transformSceneToSaveModelSchemaV2';
+import { downgradeElementsToNotebookWire, getNotebookCellElements } from './notebookSpecTransform';
+import { buildTimeSettings, getElements } from './transformSceneToSaveModelSchemaV2';
 
 export function transformSceneToNotebookSaveModel(scene: DashboardScene): NotebookSpec {
-  return dashboardSpecToNotebookSpec(transformSceneToSaveModelSchemaV2(scene));
+  const sceneState = scene.state;
+
+  const notebook = {
+    title: sceneState.title,
+    ...(sceneState.description ? { description: sceneState.description } : {}),
+    tags: sceneState.tags,
+    timeSettings: buildTimeSettings(scene),
+    elements: downgradeElementsToNotebookWire({
+      ...getNotebookCellElements(sceneState.body),
+      ...getElements(scene, scene.serializer.getDSReferencesMapping()),
+    }),
+    layout: sceneState.body.serialize(),
+  };
+
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- elements/layout are the notebook's sibling kinds, built by the dashboard-typed serializer
+  return notebook as unknown as NotebookSpec;
 }

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -230,28 +230,19 @@ export function getElements(scene: DashboardScene, dsReferencesMapping?: DSRefer
     panels.push(...getRepeatedSectionPanelsForSnapshot(scene));
   }
 
-  // A sibling layout can own elements that are not viz panels — the notebook's markdown and
-  // code cells. They cannot come from `panels`, so the layout contributes them directly;
-  // without this they vanish here while `layout` keeps referencing them by name. Dashboard
-  // layouts do not implement the hook, so this is an empty spread for all of them.
-  const nonPanelElements: Record<string, Element> = scene.state.body.getNonPanelElements?.() ?? {};
+  return panels.reduce<Record<string, Element>>((elements, vizPanel) => {
+    const element = vizPanelToSchemaV2(vizPanel, dsReferencesMapping, isSnapshot);
 
-  return panels.reduce<Record<string, Element>>(
-    (elements, vizPanel) => {
-      const element = vizPanelToSchemaV2(vizPanel, dsReferencesMapping, isSnapshot);
+    // Snapshot layout expands repeaters into explicit panels and references clones by a disambiguated key
+    // (panel clones by their own `key`, panels inside a repeated row clone additionally prefixed with the
+    // enclosing clone's key). Non-clone panels keep their stable element identifier.
+    const elementKey = isSnapshot
+      ? dashboardSceneGraph.getSnapshotElementIdentifierForVizPanel(vizPanel)
+      : dashboardSceneGraph.getElementIdentifierForVizPanel(vizPanel);
 
-      // Snapshot layout expands repeaters into explicit panels and references clones by a disambiguated key
-      // (panel clones by their own `key`, panels inside a repeated row clone additionally prefixed with the
-      // enclosing clone's key). Non-clone panels keep their stable element identifier.
-      const elementKey = isSnapshot
-        ? dashboardSceneGraph.getSnapshotElementIdentifierForVizPanel(vizPanel)
-        : dashboardSceneGraph.getElementIdentifierForVizPanel(vizPanel);
-
-      elements[elementKey] = element;
-      return elements;
-    },
-    { ...nonPanelElements }
-  );
+    elements[elementKey] = element;
+    return elements;
+  }, {});
 }
 
 // A repeated row/tab clone: duck-typed (rather than importing RowItem/TabItem, which would create a circular

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -84,14 +84,8 @@ type DeepPartial<T> = T extends object
  */
 export function transformSceneToSaveModelSchemaV2(scene: DashboardScene, isSnapshot = false): DashboardV2Spec {
   const sceneDash = scene.state;
-  const timeRange = sceneDash.$timeRange!.state;
-
-  const controlsState = sceneDash.controls?.state;
-  const refreshPicker = controlsState?.refreshPicker;
 
   const dsReferencesMapping = scene.serializer.getDSReferencesMapping();
-
-  const timeSettingsDefaults = defaultTimeSettingsSpec();
 
   let preferences: Preferences | undefined = undefined;
 
@@ -135,18 +129,7 @@ export function transformSceneToSaveModelSchemaV2(scene: DashboardScene, isSnaps
     // EOF dashboard settings
 
     // time settings
-    timeSettings: {
-      timezone: timeRange.timeZone || timeSettingsDefaults.timezone,
-      from: timeRange.from,
-      to: timeRange.to,
-      autoRefresh: refreshPicker?.state.refresh || timeSettingsDefaults.autoRefresh,
-      autoRefreshIntervals: refreshPicker?.state.intervals || timeSettingsDefaults.autoRefreshIntervals,
-      hideTimepicker: controlsState?.hideTimeControls || timeSettingsDefaults.hideTimepicker,
-      weekStart: timeRange.weekStart,
-      fiscalYearStartMonth: timeRange.fiscalYearStartMonth,
-      nowDelay: timeRange.UNSAFE_nowDelay,
-      quickRanges: controlsState?.timePicker.state.quickRanges,
-    },
+    timeSettings: buildTimeSettings(scene),
     // EOF time settings
 
     // variables
@@ -202,7 +185,41 @@ function getLiveNow(state: DashboardSceneState) {
   return Boolean(liveNow);
 }
 
-function getElements(scene: DashboardScene, dsReferencesMapping?: DSReferencesMapping, isSnapshot = false) {
+/**
+ * The document's time settings, read off the scene's time range and time controls.
+ *
+ * Exported because a sibling resource whose spec carries the same `timeSettings` block builds it from
+ * here rather than repeating it. Two functions deriving time settings that nothing forces to agree is
+ * how they drift.
+ */
+export function buildTimeSettings(scene: DashboardScene): DeepPartial<DashboardV2Spec>['timeSettings'] {
+  const timeRange = scene.state.$timeRange!.state;
+  const controlsState = scene.state.controls?.state;
+  const refreshPicker = controlsState?.refreshPicker;
+  const timeSettingsDefaults = defaultTimeSettingsSpec();
+
+  return {
+    timezone: timeRange.timeZone || timeSettingsDefaults.timezone,
+    from: timeRange.from,
+    to: timeRange.to,
+    autoRefresh: refreshPicker?.state.refresh || timeSettingsDefaults.autoRefresh,
+    autoRefreshIntervals: refreshPicker?.state.intervals || timeSettingsDefaults.autoRefreshIntervals,
+    hideTimepicker: controlsState?.hideTimeControls || timeSettingsDefaults.hideTimepicker,
+    weekStart: timeRange.weekStart,
+    fiscalYearStartMonth: timeRange.fiscalYearStartMonth,
+    nowDelay: timeRange.UNSAFE_nowDelay,
+    quickRanges: controlsState?.timePicker.state.quickRanges,
+  };
+}
+
+/**
+ * The spec's `elements` map, built from the layout's viz panels.
+ *
+ * Exported for the notebook serializer, which needs exactly these elements plus its own narrative
+ * cells. It calls this rather than deriving panels or their element identifiers again: two functions
+ * computing an element key that nothing forces to agree is the bug class this whole change came from.
+ */
+export function getElements(scene: DashboardScene, dsReferencesMapping?: DSReferencesMapping, isSnapshot = false) {
   const panels = scene.state.body.getVizPanels() ?? [];
 
   // For snapshot serialization we must also include repeated panel clones (panel repeaters store clones in state,

--- a/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.tsx
+++ b/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.tsx
@@ -107,11 +107,10 @@ function findV1PanelSaveModel(panels: unknown, id: number): unknown {
 //
 // The v2 branch depends on an ordering invariant: getSaveModel() (called just before this) keys every
 // element through the same serializer.getElementIdForPanel(id) that this lookup uses, so the id we
-// resolve here always matches a key serialization just produced. This is why library panels and
-// repeat clones both resolve even though initializeElementMapping seeds the map only from kind:'Panel'
-// elements: getSaveModel visits every panel first and, for any id not already mapped, getElementIdForPanel
-// generates and stores a "panel-<id>" key — which this lookup then finds. Keep getSaveModel ahead of
-// this call or the v2 mapping may be empty.
+// resolve here always matches a key serialization just produced. This is why repeat clones resolve even
+// though initializeElementMapping never seeds them: getSaveModel visits every panel first and, for any id
+// not already mapped, getElementIdForPanel generates and stores a "panel-<id>" key — which this lookup
+// then finds. Keep getSaveModel ahead of this call or the v2 mapping may be empty.
 function findPanelSaveModel(dashboardModel: unknown, panel: VizPanel, dashboard: DashboardScene): unknown {
   if (!isRecord(dashboardModel)) {
     return undefined;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Built on top https://github.com/grafana/grafana/pull/129936. Picks up my three review comments on#129936 plus a bug we found pairing.

**The bug.** A panel cell not named `panel-<id>` loses its element on serialize, so the cell silently disappears. Two causes: the element map was not reseeded after a spec rebuild, and it only ever mapped `kind: 'Panel'`, so library panel cells broke on plain load and read.

* **Your call, and the only thing I need from you.** Fixing it changes dashboards too: element names a caller chose now survive `APPLY_SPEC`, and library panel names survive serialization. Both look right to me. 

**The split.** Notebooks get `GET_NOTEBOOK_SPEC` and `APPLY_NOTEBOOK_SPEC`, each naming one spec. `GET_SPEC` and `APPLY_SPEC` keep working on a notebook by forwarding to them, because the assistant plugin ships separately and looks for those two names to decide if a page is editable. 

**Open**

- The resource check still keys off the layout (`body.descriptor.id === 'NotebookLayout'`) rather than the loaded resource, so we infer identity from what is rendering, is there a better way to do this?


<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
