### PR TITLE
Themes: Restore theme border colors

### DIFF
--- a/packages/grafana-data/src/themes/createColors.test.ts
+++ b/packages/grafana-data/src/themes/createColors.test.ts
@@ -14,24 +14,4 @@ describe('createColors', () => {
     });
     expect(palette.primary.main).toBe('#FF0000');
   });
-
-  it('Should use opaque border tokens', () => {
-    const darkPalette = createColors({ mode: 'dark' });
-    const lightPalette = createColors({ mode: 'light' });
-
-    // border tokens should not have transparency (fixes semi-transparent modal borders)
-    expect(darkPalette.border.weak).not.toContain('rgba');
-    expect(darkPalette.border.medium).not.toContain('rgba');
-    expect(darkPalette.border.strong).not.toContain('rgba');
-    expect(lightPalette.border.weak).not.toContain('rgba');
-    expect(lightPalette.border.medium).not.toContain('rgba');
-    expect(lightPalette.border.strong).not.toContain('rgba');
-
-    expect(darkPalette.border.weak).toBe('rgb(54, 57, 64)');
-    expect(darkPalette.border.medium).toBe('rgb(68, 70, 78)');
-    expect(darkPalette.border.strong).toBe('rgb(85, 87, 96)');
-    expect(lightPalette.border.weak).toBe('rgb(229, 229, 230)');
-    expect(lightPalette.border.medium).toBe('rgb(189, 191, 192)');
-    expect(lightPalette.border.strong).toBe('rgb(167, 169, 171)');
-  });
 });

--- a/packages/grafana-data/src/themes/createColors.ts
+++ b/packages/grafana-data/src/themes/createColors.ts
@@ -233,9 +233,9 @@ class LightColors implements ThemeColorsBase<Partial<ThemeRichColor>> {
   };
 
   border = {
-    weak: `rgb(229, 229, 230)`,
-    medium: `rgb(189, 191, 192)`,
-    strong: `rgb(167, 169, 171)`,
+    weak: `rgba(${this.blackBase}, 0.12)`,
+    medium: `rgba(${this.blackBase}, 0.3)`,
+    strong: `rgba(${this.blackBase}, 0.4)`,
   };
 
   secondary = {

--- a/packages/grafana-data/src/themes/createColors.ts
+++ b/packages/grafana-data/src/themes/createColors.ts
@@ -130,9 +130,9 @@ class DarkColors implements ThemeColorsBase<Partial<ThemeRichColor>> {
   whiteBase = '204, 204, 220';
 
   border = {
-    weak: `rgb(54, 57, 64)`,
-    medium: `rgb(68, 70, 78)`,
-    strong: `rgb(85, 87, 96)`,
+    weak: `rgba(${this.whiteBase}, 0.12)`,
+    medium: `rgba(${this.whiteBase}, 0.2)`,
+    strong: `rgba(${this.whiteBase}, 0.30)`,
   };
 
   text = {

--- a/public/sass/_variables.dark.generated.scss
+++ b/public/sass/_variables.dark.generated.scss
@@ -109,14 +109,14 @@ $btn-drag-image: '../img/grab_dark.svg';
 $input-bg: #111217;
 
 $input-color: rgb(204, 204, 220);
-$input-border-color: rgb(68, 70, 78);
+$input-border-color: rgba(204, 204, 220, 0.2);
 
 // Dropdowns
 // -------------------------
 $dropdownBackground: #181b1f;
-$dropdownBorder: rgb(54, 57, 64);
-$dropdownDividerTop: rgb(54, 57, 64);
-$dropdownDividerBottom: rgb(54, 57, 64);
+$dropdownBorder: rgba(204, 204, 220, 0.12);
+$dropdownDividerTop: rgba(204, 204, 220, 0.12);
+$dropdownDividerBottom: rgba(204, 204, 220, 0.12);
 
 $dropdownLinkColor: $link-color;
 $dropdownLinkColorHover: $white;
@@ -147,7 +147,7 @@ $tooltipColor: rgb(204, 204, 220);
 
 $popover-bg: #181b1f;
 $popover-color: rgb(204, 204, 220);
-$popover-border-color: rgb(54, 57, 64);
+$popover-border-color: rgba(204, 204, 220, 0.12);
 $popover-header-bg: #22252b;
 $popover-shadow: 0px 8px 24px rgb(1, 4, 9);
 

--- a/public/sass/_variables.light.generated.scss
+++ b/public/sass/_variables.light.generated.scss
@@ -109,14 +109,14 @@ $btn-drag-image: '../img/grab_light.svg';
 $input-bg: #ffffff;
 
 $input-color: rgba(36, 41, 46, 1);
-$input-border-color: rgb(189, 191, 192);
+$input-border-color: rgba(36, 41, 46, 0.3);
 
 // Dropdowns
 // -------------------------
 $dropdownBackground: #ffffff;
-$dropdownBorder: rgb(229, 229, 230);
-$dropdownDividerTop: rgb(229, 229, 230);
-$dropdownDividerBottom: rgb(229, 229, 230);
+$dropdownBorder: rgba(36, 41, 46, 0.12);
+$dropdownDividerTop: rgba(36, 41, 46, 0.12);
+$dropdownDividerBottom: rgba(36, 41, 46, 0.12);
 
 $dropdownLinkColor: $dark-2;
 $dropdownLinkColorHover: $link-color;
@@ -143,7 +143,7 @@ $tooltipColor: rgba(36, 41, 46, 1);
 
 $popover-bg: #ffffff;
 $popover-color: rgba(36, 41, 46, 1);
-$popover-border-color: rgb(229, 229, 230);
+$popover-border-color: rgba(36, 41, 46, 0.12);
 $popover-header-bg: #f4f5f5;
 $popover-shadow: 0px 13px 20px 1px rgba(24, 26, 27, 0.18);
 


### PR DESCRIPTION
Reverts https://github.com/grafana/grafana/pull/125797 

which looks to have been merged without much design discussion/impact. That change had a strong visual impact; the current dark themes and tokens are built around opacity-based colors, which make them work across different surfaces without being too strong. 

Just changing them like this requires a bigger rethink around surface and border colors, and possibly new border tokens. 

For edge case scenarios like borders on elements that cover an image (so far in 5 years of this there has only been an issue 2-3 times), we can solve it by a solid background that we place the card (element with border) on (with no spacing, just so the border does not bleed or overlap).

