### PR TITLE
fix: use RuleGUID instead of empty string for deleted alert rule versions to avoid duplicate key violation [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -84,7 +84,7 @@ func (st DBstore) DeleteAlertRulesByUID(ctx context.Context, orgID int64, user *
 			for idx := range versions {
 				version := &versions[idx]
 				version.ID = 0
-				version.RuleUID = ""
+				version.RuleUID = version.RuleGUID
 				version.Created = TimeNow()
 				version.CreatedBy = nil
 				if user != nil {
@@ -330,7 +330,7 @@ func (st DBstore) ListDeletedRules(ctx context.Context, orgID int64) ([]*ngmodel
 	alertRules := make([]*ngmodels.AlertRule, 0)
 	err := st.SQLStore.WithDbSession(ctx, func(sess *db.Session) error {
 		// take only the latest versions of each rule by GUID
-		rows, err := sess.Table(alertRuleVersion{}).Where("rule_org_id = ? AND rule_uid = ''", orgID).Desc("created", "id").Rows(alertRuleVersion{})
+		rows, err := sess.Table(alertRuleVersion{}).Where("rule_org_id = ? AND rule_uid = rule_guid", orgID).Desc("created", "id").Rows(alertRuleVersion{})
 		if err != nil {
 			return err
 		}
@@ -2060,7 +2060,7 @@ func (st DBstore) CleanUpDeletedAlertRules(ctx context.Context) (int64, error) {
 	err := st.SQLStore.WithTransactionalDbSession(ctx, func(sess *sqlstore.DBSession) error {
 		expire := TimeNow().Add(-st.Cfg.DeletedRuleRetention)
 		st.Logger.Debug("Permanently remove expired deleted rules", "deletedBefore", expire)
-		result, err := sess.Exec("DELETE FROM alert_rule_version WHERE rule_uid='' AND created <= ?", expire)
+		result, err := sess.Exec("DELETE FROM alert_rule_version WHERE rule_uid = rule_guid AND created <= ?", expire)
 		if err != nil {
 			return err
 		}
@@ -2088,7 +2088,7 @@ func (st DBstore) DeleteRuleFromTrashByGUID(ctx context.Context, orgID int64, ru
 	affectedRows := int64(-1)
 	err := st.SQLStore.WithTransactionalDbSession(ctx, func(sess *sqlstore.DBSession) error {
 		st.Logger.FromContext(ctx).Debug("Deleting a deleted rule by GUID", "ruleGUID", ruleGUID)
-		result, err := sess.Exec("DELETE FROM alert_rule_version WHERE rule_uid='' AND rule_org_id = ? AND rule_guid = ? ", orgID, ruleGUID)
+		result, err := sess.Exec("DELETE FROM alert_rule_version WHERE rule_uid = rule_guid AND rule_org_id = ? AND rule_guid = ? ", orgID, ruleGUID)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Description

Fixes #130138

When deleting a newly-created alert rule, the `DeleteAlertRulesByUID` function sets `RuleUID = ""` on the deleted version record to mark it as deleted for recovery purposes. However, this causes a PostgreSQL unique constraint violation (`UQE_alert_rule_version_rule_org_id_rule_uid_version`) when multiple rules share the same version number, because the `(org_id, "", version)` combination is no longer unique.

### Root Cause

In `DeleteAlertRulesByUID` at `pkg/services/ngalert/store/alert_rule.go`:
- Line 87: `version.RuleUID = ""` clears the RuleUID to mark the record as deleted
- The unique constraint `UQE_alert_rule_version_rule_org_id_rule_uid_version` is on `(rule_org_id, rule_uid, version)`
- When multiple rules with the same version are deleted, the BulkInsert tries to insert multiple records with `(org_id, "", version)`, causing a duplicate key violation

### Fix

Instead of clearing `RuleUID` to empty string, use the `RuleGUID` (which is a UUID unique per rule) as the `RuleUID` for deleted records. This ensures uniqueness of the `(org_id, rule_uid, version)` constraint while still allowing the `ListDeletedRules`, `CleanUpDeletedAlertRules`, and `DeleteRuleFromTrashByGUID` functions to find deleted records by checking `rule_uid = rule_guid`.

### Changes

1. **`DeleteAlertRulesByUID`**: Changed `version.RuleUID = ""` to `version.RuleUID = version.RuleGUID`
2. **`ListDeletedRules`**: Updated query to use `rule_uid = rule_guid` instead of `rule_uid = ''`
3. **`CleanUpDeletedAlertRules`**: Updated query to use `rule_uid = rule_guid` instead of `rule_uid = ''`
4. **`DeleteRuleFromTrashByGUID`**: Updated query to use `rule_uid = rule_guid` instead of `rule_uid = ''`