### PR TITLE
Provisioning: Keep sync step when instance has resources

### DIFF
--- a/public/app/features/provisioning/Wizard/ProvisioningWizard.test.tsx
+++ b/public/app/features/provisioning/Wizard/ProvisioningWizard.test.tsx
@@ -285,6 +285,32 @@ describe('ProvisioningWizard', () => {
       const nextButton = screen.getByRole('button', { name: /Choose additional settings/i });
       expect(nextButton).toBeInTheDocument();
     });
+
+    it('should keep the sync step when instance resources exist and the repository is empty', async () => {
+      // Resources to migrate with an empty remote — folder/folderless must not skip
+      // the synchronize step (otherwise the migrate option is never shown).
+      server.use(
+        http.get(`${BASE}/stats`, () =>
+          HttpResponse.json({
+            instance: [{ group: 'dashboard.grafana.app', resource: 'dashboards', count: 2 }],
+          })
+        ),
+        http.get(`${BASE}/repositories/:name/files/`, () => HttpResponse.json({ items: [] }))
+      );
+
+      const { user } = setup(<ProvisioningWizard type="github" />);
+
+      await fillConnectionForm(user, 'github', {
+        token: 'test-token',
+        url: 'https://github.com/test/repo',
+      });
+
+      await user.click(screen.getByRole('button', { name: /Choose what to synchronize/i }));
+
+      expect(await screen.findByRole('heading', { name: /3\. Choose what to synchronize/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Synchronize with external storage/i })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Choose additional settings/i })).not.toBeInTheDocument();
+    });
   });
 
   describe('Error Handling', () => {

--- a/public/app/features/provisioning/Wizard/hooks/useResourceStats.test.ts
+++ b/public/app/features/provisioning/Wizard/hooks/useResourceStats.test.ts
@@ -134,5 +134,30 @@ describe('useResourceStats', () => {
 
       expect(result.current.shouldSkipSync).toBe(true);
     });
+
+    it('does not skip sync for folder target when instance resources exist', () => {
+      mockStats({ instance: [{ group: 'dashboard.grafana.app', resource: 'dashboards', count: 3 }] });
+
+      const { result } = renderHook(() => useResourceStats('repo', 'folder', false, { isHealthy: true }));
+
+      expect(result.current.resourceCount).toBe(3);
+      expect(result.current.fileCount).toBe(0);
+      expect(result.current.shouldSkipSync).toBe(false);
+    });
+
+    it('does not skip sync for folderless (root level) when instance resources exist', () => {
+      mockStats({ instance: [{ group: 'dashboard.grafana.app', resource: 'dashboards', count: 2 }] });
+
+      const { result } = renderHook(() => useResourceStats('repo', 'folderless', false, { isHealthy: true }));
+
+      expect(result.current.shouldSkipSync).toBe(false);
+      expect(result.current.requiresMigration).toBe(false);
+    });
+
+    it('skips sync for folderless only when both resources and files are empty', () => {
+      const { result } = renderHook(() => useResourceStats('repo', 'folderless', false, { isHealthy: true }));
+
+      expect(result.current.shouldSkipSync).toBe(true);
+    });
   });
 });

--- a/public/app/features/provisioning/Wizard/hooks/useResourceStats.test.ts
+++ b/public/app/features/provisioning/Wizard/hooks/useResourceStats.test.ts
@@ -129,35 +129,26 @@ describe('useResourceStats', () => {
       expect(optOut.result.current.requiresMigration).toBe(false);
     });
 
-    it('skips sync when a folder target has no resources and no files', () => {
-      const { result } = renderHook(() => useResourceStats('repo', 'folder', false, { isHealthy: true }));
+    it.each(['folder', 'folderless'] as const)(
+      'skips sync for %s target when there are no resources and no files',
+      (target) => {
+        const { result } = renderHook(() => useResourceStats('repo', target, false, { isHealthy: true }));
 
-      expect(result.current.shouldSkipSync).toBe(true);
-    });
+        expect(result.current.shouldSkipSync).toBe(true);
+      }
+    );
 
-    it('does not skip sync for folder target when instance resources exist', () => {
-      mockStats({ instance: [{ group: 'dashboard.grafana.app', resource: 'dashboards', count: 3 }] });
+    it.each(['folder', 'folderless'] as const)(
+      'does not skip sync for %s target when instance resources exist',
+      (target) => {
+        mockStats({ instance: [{ group: 'dashboard.grafana.app', resource: 'dashboards', count: 2 }] });
 
-      const { result } = renderHook(() => useResourceStats('repo', 'folder', false, { isHealthy: true }));
+        const { result } = renderHook(() => useResourceStats('repo', target, false, { isHealthy: true }));
 
-      expect(result.current.resourceCount).toBe(3);
-      expect(result.current.fileCount).toBe(0);
-      expect(result.current.shouldSkipSync).toBe(false);
-    });
-
-    it('does not skip sync for folderless (root level) when instance resources exist', () => {
-      mockStats({ instance: [{ group: 'dashboard.grafana.app', resource: 'dashboards', count: 2 }] });
-
-      const { result } = renderHook(() => useResourceStats('repo', 'folderless', false, { isHealthy: true }));
-
-      expect(result.current.shouldSkipSync).toBe(false);
-      expect(result.current.requiresMigration).toBe(false);
-    });
-
-    it('skips sync for folderless only when both resources and files are empty', () => {
-      const { result } = renderHook(() => useResourceStats('repo', 'folderless', false, { isHealthy: true }));
-
-      expect(result.current.shouldSkipSync).toBe(true);
-    });
+        expect(result.current.shouldSkipSync).toBe(false);
+        // Folder and folderless only migrate when the user opts in.
+        expect(result.current.requiresMigration).toBe(false);
+      }
+    );
   });
 });

--- a/public/app/features/provisioning/Wizard/hooks/useResourceStats.ts
+++ b/public/app/features/provisioning/Wizard/hooks/useResourceStats.ts
@@ -119,8 +119,11 @@ export function useResourceStats(
   // For instance sync: migrate if there are resources (checkbox is disabled and always true)
   // For folder and folderless sync: only migrate if user explicitly opts in via checkbox
   const requiresMigration = syncTarget === 'instance' ? resourceCount > 0 : (migrateResources ?? false);
-  const shouldSkipSync =
-    (resourceCount === 0 || syncTarget === 'folder' || syncTarget === 'folderless') && fileCount === 0;
+  // Only skip the synchronize step when there is nothing to pull and nothing that
+  // could be migrated. Folder and folderless targets used to skip whenever the
+  // repository had no files, which hid the migrate option for empty repos even
+  // when the Grafana instance still had resources (issue #128917).
+  const shouldSkipSync = resourceCount === 0 && fileCount === 0;
 
   // Format display strings
   const resourceCountDisplay =


### PR DESCRIPTION
**What is this feature?**

This change fixes the Git Sync onboarding wizard so step 4 (Synchronize with external storage) is no longer skipped when the remote repository is empty but the Grafana instance still has resources. Folder and folderless (root level) targets previously skipped that step whenever the remote had zero files, which blocked migrating existing dashboards.

**Why do we need this feature?**

Users who connect a new empty GitHub repository with GitHub App auth and choose root level (folderless) or folder sync never reached the synchronize step. The next button jumped straight to additional settings, so they could not start migration of existing dashboards.

**Who is this feature for?**

Grafana users setting up Git Sync who already have dashboards or other resources in the instance and want to migrate them into an empty repository.

**Which issue(s) does this PR fix?**:

Fixes #128917

**Special notes for your reviewer:**

The skip condition is now empty remote files AND zero instance resources. Folder and folderless no longer force a skip based only on an empty remote. Unit tests cover folder, folderless, and the wizard next button label.

Please check that:
* [x] It works as expected from a user's perspective.
* [ ] If this is a pre GA feature, it is behind a feature toggle.
* [ ] The docs are updated, and if this is a notable improvement, it is added to our What's New doc.

Signed-off-by: Siddhartha Singh <siddharthagithub0007@gmail.com>
