### PR TITLE
DO NOT MERGE: IAM: Feat: PoC

### DIFF
--- a/apps/folder/pkg/apis/folder/v1/types.go
+++ b/apps/folder/pkg/apis/folder/v1/types.go
@@ -42,6 +42,27 @@ type FolderInfo struct {
 
 	// This folder does not resolve
 	Detached bool `json:"detached,omitempty"`
+
+	// CanView reports whether the requester can read this folder itself. False for a
+	// Detached (ghost) ancestor: its name is shown as inert path context (Phase 1.5,
+	// see identity-access-team#2285 §4.5), never as something the caller can actually
+	// open or list the children of.
+	CanView bool `json:"canView,omitempty"`
+
+	// CanEdit reports whether the requester can edit this folder. Always false for a
+	// Detached ancestor. Conservative placeholder for non-detached ancestors too --
+	// unlike CanView, this is not derived from a real permission check yet.
+	CanEdit bool `json:"canEdit,omitempty"`
+
+	// CanAdmin reports whether the requester can administer this folder's permissions.
+	// Always false for a Detached ancestor. Conservative placeholder for non-detached
+	// ancestors too -- unlike CanView, this is not derived from a real permission check yet.
+	CanAdmin bool `json:"canAdmin,omitempty"`
+
+	// CanDelete reports whether the requester can delete this folder. Always false for
+	// a Detached ancestor. Conservative placeholder for non-detached ancestors too --
+	// unlike CanView, this is not derived from a real permission check yet.
+	CanDelete bool `json:"canDelete,omitempty"`
 }
 
 func (FolderInfo) OpenAPIModelName() string {

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1410,4 +1410,9 @@ export interface FeatureToggles {
   * @default false
   */
   cujTracking?: boolean;
+  /**
+  * Show a folder's full ancestor path, including the names of ancestors the signed-in user has no access to, as inert non-browsable context. Gates the relaxed real-tree-placement criterion so items with a resolvable-but-inaccessible ancestor chain render in their real position instead of falling through to Shared with me; leaves Shared with me itself, and every other partial-access scenario, unchanged when off.
+  * @default false
+  */
+  ['authz.folderPathVisibility']?: boolean;
 }

--- a/pkg/registry/apis/dashboard/search.go
+++ b/pkg/registry/apis/dashboard/search.go
@@ -1189,14 +1189,91 @@ func (s *SearchHandler) getDashboardsUIDsSharedWithUser(ctx context.Context, use
 		foldersWithAccess = append(foldersWithAccess, fold.Key.Name)
 	}
 
+	// Phase 1.5 (identity-access-team#2285 §4.5 / #2310): behind the toggle, an item whose
+	// inaccessible parent's own ancestor chain still resolves (privileged, title-only read, see
+	// #2309) renders in its real tree position instead of falling through to Shared with me.
+	// Toggle off, this is a no-op and the loop below is byte-for-byte the pre-Phase-1.5 check.
+	pathVisibilityEnabled := s.features.IsEnabledGlobally(featuremgmt.FlagAuthzFolderPathVisibility)
+	resolvable := make(map[string]bool)
+
 	// add to sharedDashboards dashboards user has access to, but does NOT have access to it's parent folder.
 	// Root-parented dashboards (reported as "" or "general") have no parent folder, so skip both sentinels.
 	for _, dash := range dashboardResult.Results.Rows {
 		dashboardUid := dash.Key.Name
 		folderUid := string(dash.Cells[folderUidIdx])
-		if !foldermodel.IsRootFolderUID(folderUid) && !slices.Contains(foldersWithAccess, folderUid) {
-			sharedDashboards = append(sharedDashboards, dashboardUid)
+		if foldermodel.IsRootFolderUID(folderUid) || slices.Contains(foldersWithAccess, folderUid) {
+			continue
 		}
+
+		if pathVisibilityEnabled {
+			resolves, ok := resolvable[folderUid]
+			if !ok {
+				resolves = s.resolveAncestorChainNames(ctx, user, folderKey, folderUid)
+				resolvable[folderUid] = resolves
+			}
+			if resolves {
+				// Real position, with ghost ancestors (#2311), instead of Shared with me.
+				continue
+			}
+		}
+
+		sharedDashboards = append(sharedDashboards, dashboardUid)
 	}
 	return sharedDashboards, nil
+}
+
+// maxAncestorChainDepth bounds resolveAncestorChainNames against a corrupt or cyclic ancestor
+// chain; it mirrors the kind of depth guard newParentsGetter's maxDepth provides for the /parents
+// walk, but generously, since this is just a resolvability probe (no response body to bound).
+const maxAncestorChainDepth = 64
+
+// resolveAncestorChainNames reports whether every ancestor of folderUID, up to the root, can be
+// resolved via a privileged, title-only lookup (see identity-access-team#2309) -- even if user
+// (from the real ctx) can't actually read some of them. It intentionally returns only a bool: the
+// one thing this decides is the Shared-with-me placement carve-out below, never anything that
+// itself needs to expose a title or other ancestor detail to the caller.
+func (s *SearchHandler) resolveAncestorChainNames(ctx context.Context, user identity.Requester, folderKey *resourcepb.ResourceKey, folderUID string) bool {
+	svcCtx := identity.WithServiceIdentityContext(ctx, user.GetOrgID())
+
+	seen := make(map[string]bool, maxAncestorChainDepth)
+	current := folderUID
+	for depth := 0; depth < maxAncestorChainDepth; depth++ {
+		if foldermodel.IsRootFolderUID(current) {
+			return true
+		}
+		if seen[current] {
+			return false // cyclic reference -- never resolvable
+		}
+		seen[current] = true
+
+		req := &resourcepb.ResourceSearchRequest{
+			Fields: []string{"folder"},
+			Limit:  1,
+			Options: &resourcepb.ListOptions{
+				Key: folderKey,
+				Fields: []*resourcepb.Requirement{{
+					Key:      "name",
+					Operator: "in",
+					Values:   []string{current},
+				}},
+			},
+		}
+		resp, err := s.client.Search(svcCtx, req)
+		if err != nil || resp.Results == nil || len(resp.Results.Rows) == 0 {
+			return false
+		}
+
+		folderColIdx := -1
+		for i, col := range resp.Results.Columns {
+			if col.Name == "folder" {
+				folderColIdx = i
+			}
+		}
+		if folderColIdx == -1 {
+			return false
+		}
+
+		current = string(resp.Results.Rows[0].Cells[folderColIdx])
+	}
+	return false
 }

--- a/pkg/registry/apis/dashboard/search_test.go
+++ b/pkg/registry/apis/dashboard/search_test.go
@@ -685,6 +685,270 @@ func TestSearchHandlerSharedDashboards(t *testing.T) {
 		assert.Equal(t, len(mockResponse3.Results.Rows), len(p.Hits))
 	})
 
+	t.Run("phase 1.5: toggle on, item with a resolvable-but-inaccessible ancestor chain is excluded from Shared with me", func(t *testing.T) {
+		// dashboardSearchRequest: one dashboard the user can read directly, parented under a
+		// folder the user has no access to at all (not even folders.self:read).
+		mockResponse1 := &resourcepb.ResourceSearchResponse{
+			Results: &resourcepb.ResourceTable{
+				Columns: []*resourcepb.ResourceTableColumnDefinition{{Name: "folder"}},
+				Rows: []*resourcepb.ResourceTableRow{
+					{
+						Key:   &resourcepb.ResourceKey{Name: "dashboardinprivatefolder", Resource: "dashboard"},
+						Cells: [][]byte{[]byte("privatefolder")},
+					},
+				},
+			},
+		}
+
+		// folderSearchRequest: privatefolder is not among the folders the user can fully read.
+		mockResponse2 := &resourcepb.ResourceSearchResponse{
+			Results: &resourcepb.ResourceTable{
+				Columns: []*resourcepb.ResourceTableColumnDefinition{{Name: "folder"}},
+				Rows:    []*resourcepb.ResourceTableRow{},
+			},
+		}
+
+		// resolveAncestorChainNames' privileged lookup of privatefolder itself: it resolves,
+		// and its own parent is the root -- so the whole chain is resolvable.
+		mockResponse3 := &resourcepb.ResourceSearchResponse{
+			Results: &resourcepb.ResourceTable{
+				Columns: []*resourcepb.ResourceTableColumnDefinition{{Name: "folder"}},
+				Rows: []*resourcepb.ResourceTableRow{
+					{
+						Key:   &resourcepb.ResourceKey{Name: "privatefolder", Resource: "folder"},
+						Cells: [][]byte{[]byte("")},
+					},
+				},
+			},
+		}
+
+		mockClient := &MockClient{
+			MockResponses: []*resourcepb.ResourceSearchResponse{mockResponse1, mockResponse2, mockResponse3},
+		}
+
+		features := featuremgmt.WithFeatures(featuremgmt.FlagAuthzFolderPathVisibility)
+		searchHandler := SearchHandler{
+			log:      log.New("test", "test"),
+			client:   mockClient,
+			tracer:   tracing.NewNoopTracerService(),
+			features: features,
+		}
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/search?folder=sharedwithme", nil)
+		req.Header.Add("content-type", "application/json")
+		allPermissions := make(map[int64]map[string][]string)
+		permissions := make(map[string][]string)
+		permissions[dashboards.ActionDashboardsRead] = []string{"dashboards:uid:dashboardinprivatefolder"}
+		allPermissions[1] = permissions
+		req = req.WithContext(identity.WithRequester(req.Context(), &user.SignedInUser{Namespace: "test", OrgID: 1, Permissions: allPermissions}))
+
+		searchHandler.DoSearch(rr, req)
+
+		// call1 = dashboardSearchRequest, call2 = folderSearchRequest (both inside
+		// getDashboardsUIDsSharedWithUser), call3 = resolveAncestorChainNames' privileged lookup
+		// of privatefolder. It resolves, so the item is excluded, sharedDashboards ends up empty,
+		// and the handler short-circuits to an empty result -- no further "final display" search.
+		assert.Equal(t, 3, mockClient.CallCount)
+
+		resp := rr.Result()
+		defer func() {
+			if err := resp.Body.Close(); err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		p := &v0alpha1.SearchResults{}
+		err := json.NewDecoder(resp.Body).Decode(p)
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(p.Hits))
+	})
+
+	t.Run("phase 1.5: toggle off, an item with a resolvable-but-inaccessible ancestor still falls through to Shared with me unchanged", func(t *testing.T) {
+		// Identical setup to the toggle-on case above, but with the toggle off: behavior must be
+		// byte-for-byte the pre-Phase-1.5 fallback.
+		mockResponse1 := &resourcepb.ResourceSearchResponse{
+			Results: &resourcepb.ResourceTable{
+				Columns: []*resourcepb.ResourceTableColumnDefinition{{Name: "folder"}},
+				Rows: []*resourcepb.ResourceTableRow{
+					{
+						Key:   &resourcepb.ResourceKey{Name: "dashboardinprivatefolder", Resource: "dashboard"},
+						Cells: [][]byte{[]byte("privatefolder")},
+					},
+				},
+			},
+		}
+		mockResponse2 := &resourcepb.ResourceSearchResponse{
+			Results: &resourcepb.ResourceTable{
+				Columns: []*resourcepb.ResourceTableColumnDefinition{{Name: "folder"}},
+				Rows:    []*resourcepb.ResourceTableRow{},
+			},
+		}
+
+		// Final display search using the narrowed "names" filter (sharedDashboards, unchanged
+		// from today) -- this is the pre-Phase-1.5 path, so unlike the toggle-on case above there
+		// is no ancestor-resolution call, and this third call still happens.
+		mockResponse3 := &resourcepb.ResourceSearchResponse{
+			Results: &resourcepb.ResourceTable{
+				Columns: []*resourcepb.ResourceTableColumnDefinition{{Name: "folder"}},
+				Rows: []*resourcepb.ResourceTableRow{
+					{
+						Key:   &resourcepb.ResourceKey{Name: "dashboardinprivatefolder", Resource: "dashboard"},
+						Cells: [][]byte{[]byte("privatefolder")},
+					},
+				},
+			},
+		}
+
+		mockClient := &MockClient{
+			MockResponses: []*resourcepb.ResourceSearchResponse{mockResponse1, mockResponse2, mockResponse3},
+		}
+
+		features := featuremgmt.WithFeatures() // toggle off
+		searchHandler := SearchHandler{
+			log:      log.New("test", "test"),
+			client:   mockClient,
+			tracer:   tracing.NewNoopTracerService(),
+			features: features,
+		}
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/search?folder=sharedwithme", nil)
+		req.Header.Add("content-type", "application/json")
+		allPermissions := make(map[int64]map[string][]string)
+		permissions := make(map[string][]string)
+		permissions[dashboards.ActionDashboardsRead] = []string{"dashboards:uid:dashboardinprivatefolder"}
+		allPermissions[1] = permissions
+		req = req.WithContext(identity.WithRequester(req.Context(), &user.SignedInUser{Namespace: "test", OrgID: 1, Permissions: allPermissions}))
+
+		searchHandler.DoSearch(rr, req)
+
+		// call1 = dashboardSearchRequest, call2 = folderSearchRequest (both inside
+		// getDashboardsUIDsSharedWithUser, no ancestor-resolution call since the toggle is off),
+		// call3 = final display search for the (still non-empty) sharedDashboards list.
+		assert.Equal(t, 3, mockClient.CallCount)
+
+		resp := rr.Result()
+		defer func() {
+			if err := resp.Body.Close(); err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		p := &v0alpha1.SearchResults{}
+		err := json.NewDecoder(resp.Body).Decode(p)
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(p.Hits))
+	})
+
+	t.Run("phase 1.5 guardrail: a resolvable item is never duplicated into Shared with me alongside a genuinely unresolvable one", func(t *testing.T) {
+		// dashboardSearchRequest: one dashboard whose ancestor chain will resolve, one whose
+		// won't (e.g. the ancestor itself was deleted/corrupted).
+		mockResponse1 := &resourcepb.ResourceSearchResponse{
+			Results: &resourcepb.ResourceTable{
+				Columns: []*resourcepb.ResourceTableColumnDefinition{{Name: "folder"}},
+				Rows: []*resourcepb.ResourceTableRow{
+					{
+						Key:   &resourcepb.ResourceKey{Name: "dashboardresolvable", Resource: "dashboard"},
+						Cells: [][]byte{[]byte("resolvablefolder")},
+					},
+					{
+						Key:   &resourcepb.ResourceKey{Name: "dashboardunresolvable", Resource: "dashboard"},
+						Cells: [][]byte{[]byte("deadfolder")},
+					},
+				},
+			},
+		}
+
+		// folderSearchRequest: neither folder is directly accessible.
+		mockResponse2 := &resourcepb.ResourceSearchResponse{
+			Results: &resourcepb.ResourceTable{
+				Columns: []*resourcepb.ResourceTableColumnDefinition{{Name: "folder"}},
+				Rows:    []*resourcepb.ResourceTableRow{},
+			},
+		}
+
+		// resolveAncestorChainNames("resolvablefolder"): resolves, parented at root.
+		mockResponse3 := &resourcepb.ResourceSearchResponse{
+			Results: &resourcepb.ResourceTable{
+				Columns: []*resourcepb.ResourceTableColumnDefinition{{Name: "folder"}},
+				Rows: []*resourcepb.ResourceTableRow{
+					{
+						Key:   &resourcepb.ResourceKey{Name: "resolvablefolder", Resource: "folder"},
+						Cells: [][]byte{[]byte("")},
+					},
+				},
+			},
+		}
+
+		// resolveAncestorChainNames("deadfolder"): no rows back -- doesn't resolve at all.
+		mockResponse4 := &resourcepb.ResourceSearchResponse{
+			Results: &resourcepb.ResourceTable{
+				Columns: []*resourcepb.ResourceTableColumnDefinition{{Name: "folder"}},
+				Rows:    []*resourcepb.ResourceTableRow{},
+			},
+		}
+
+		// Final display search for the (still non-empty) sharedDashboards list -- only the
+		// unresolvable dashboard should ever be requested here.
+		mockResponse5 := &resourcepb.ResourceSearchResponse{
+			Results: &resourcepb.ResourceTable{
+				Columns: []*resourcepb.ResourceTableColumnDefinition{{Name: "folder"}},
+				Rows: []*resourcepb.ResourceTableRow{
+					{
+						Key:   &resourcepb.ResourceKey{Name: "dashboardunresolvable", Resource: "dashboard"},
+						Cells: [][]byte{[]byte("deadfolder")},
+					},
+				},
+			},
+		}
+
+		mockClient := &MockClient{
+			MockResponses: []*resourcepb.ResourceSearchResponse{mockResponse1, mockResponse2, mockResponse3, mockResponse4, mockResponse5},
+		}
+
+		features := featuremgmt.WithFeatures(featuremgmt.FlagAuthzFolderPathVisibility)
+		searchHandler := SearchHandler{
+			log:      log.New("test", "test"),
+			client:   mockClient,
+			tracer:   tracing.NewNoopTracerService(),
+			features: features,
+		}
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/search?folder=sharedwithme", nil)
+		req.Header.Add("content-type", "application/json")
+		allPermissions := make(map[int64]map[string][]string)
+		permissions := make(map[string][]string)
+		permissions[dashboards.ActionDashboardsRead] = []string{"dashboards:uid:dashboardresolvable", "dashboards:uid:dashboardunresolvable"}
+		allPermissions[1] = permissions
+		req = req.WithContext(identity.WithRequester(req.Context(), &user.SignedInUser{Namespace: "test", OrgID: 1, Permissions: allPermissions}))
+
+		searchHandler.DoSearch(rr, req)
+
+		// call1+call2 (getDashboardsUIDsSharedWithUser's own lookups) + call3+call4 (one
+		// resolveAncestorChainNames probe per distinct folder) + call5 (final display search).
+		assert.Equal(t, 5, mockClient.CallCount)
+		thirdCall := mockClient.MockCalls[2]
+		assert.Equal(t, []string{"resolvablefolder"}, thirdCall.Options.Fields[0].Values)
+		fourthCall := mockClient.MockCalls[3]
+		assert.Equal(t, []string{"deadfolder"}, fourthCall.Options.Fields[0].Values)
+		// The final display search must only ever have been narrowed to the unresolvable item --
+		// the resolvable one is never (also) folded into Shared with me.
+		fifthCall := mockClient.MockCalls[4]
+		assert.Equal(t, []string{"dashboardunresolvable"}, fifthCall.Options.Fields[1].Values)
+
+		resp := rr.Result()
+		defer func() {
+			if err := resp.Body.Close(); err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		p := &v0alpha1.SearchResults{}
+		err := json.NewDecoder(resp.Body).Decode(p)
+		require.NoError(t, err)
+		require.Len(t, p.Hits, 1)
+		assert.Equal(t, "dashboardunresolvable", p.Hits[0].Name)
+	})
+
 	t.Run("should compute shared dashboards based on requested edit permission", func(t *testing.T) {
 		// dashboardSearchRequest
 		mockResponse1 := &resourcepb.ResourceSearchResponse{

--- a/pkg/registry/apis/folders/parents.go
+++ b/pkg/registry/apis/folders/parents.go
@@ -9,13 +9,20 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 
 	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	folderLegacy "github.com/grafana/grafana/pkg/services/folder"
 )
 
 type parentsGetter = func(ctx context.Context, folder *folders.Folder) (*folders.FolderInfoList, error)
 
-func newParentsGetter(getter rest.Getter, maxDepth int) parentsGetter {
+// newParentsGetter builds the ancestor-chain walker used by the /parents subresource (and by
+// folder-move validation). pathVisibilityEnabled gates Phase 1.5 (#2285 §4.5, behind
+// featuremgmt.FlagAuthzFolderPathVisibility): off, this is byte-for-byte the pre-Phase-1.5 walk --
+// it stops at the first ancestor the caller can't access. On, it keeps walking to the root,
+// resolving inaccessible ancestors' names via a privileged, title-only read (see
+// getAncestorTitleOnly below) instead of giving up.
+func newParentsGetter(getter rest.Getter, maxDepth int, pathVisibilityEnabled bool) parentsGetter {
 	return func(ctx context.Context, folder *folders.Folder) (*folders.FolderInfoList, error) {
 		info := &folders.FolderInfoList{
 			Items: []folders.FolderInfo{},
@@ -23,8 +30,9 @@ func newParentsGetter(getter rest.Getter, maxDepth int) parentsGetter {
 		id := folder.Name
 		if id == folderLegacy.GeneralFolderUID || id == folderLegacy.SharedWithMeFolderUID {
 			info.Items = []folders.FolderInfo{{
-				Name:  folder.Name,
-				Title: folder.Spec.Title,
+				Name:    folder.Name,
+				Title:   folder.Spec.Title,
+				CanView: true,
 			}}
 			return info, nil
 		}
@@ -32,13 +40,24 @@ func newParentsGetter(getter rest.Getter, maxDepth int) parentsGetter {
 		found := make(map[string]bool)
 		found[folder.Name] = true
 		var err error
+		// detached tracks whether the *current* folder was itself resolved via the privileged
+		// title-only read (i.e. the caller can't actually access it) so the item built for it
+		// below is correctly flagged as inert/non-browsable context, not a real, navigable node.
+		detached := false
 
 		for folder != nil {
 			meta, _ := utils.MetaAccessor(folder)
 			item := folders.FolderInfo{
-				Name:   folder.Name,
-				Title:  folder.Spec.Title,
-				Parent: meta.GetFolder(),
+				Name:     folder.Name,
+				Title:    folder.Spec.Title,
+				Parent:   meta.GetFolder(),
+				Detached: detached,
+				// CanView mirrors Detached: a ghost node (see getAncestorTitleOnly) was never
+				// actually authorized for this caller, so it must never claim viewability.
+				// CanEdit/CanAdmin/CanDelete are left at their false default for every item here
+				// (see the doc comment on FolderInfo) -- accurately computing them would need
+				// accessClient plumbed into this walk, which is out of scope for Phase 1.5.
+				CanView: !detached,
 			}
 			if folder.Spec.Description != nil {
 				item.Description = *folder.Spec.Description
@@ -54,12 +73,36 @@ func newParentsGetter(getter rest.Getter, maxDepth int) parentsGetter {
 
 			obj, e2 := getter.Get(ctx, item.Parent, &metav1.GetOptions{})
 			if e2 != nil {
-				info.Items = append(info.Items, folders.FolderInfo{
-					Name:        item.Parent,
-					Detached:    true,
-					Description: e2.Error(),
-				})
-				break
+				if !pathVisibilityEnabled {
+					info.Items = append(info.Items, folders.FolderInfo{
+						Name:        item.Parent,
+						Detached:    true,
+						Description: e2.Error(),
+					})
+					break
+				}
+
+				// Behind the toggle: the caller can't fully access this ancestor, but its name
+				// alone is not sensitive information for path-display purposes (epic #2285 §4.5)
+				// -- resolve it via the privileged, title-only read instead of stopping the whole
+				// walk here. Keep trying the normal, authorized getter.Get at every further
+				// level: an ancestor higher up the chain may still be genuinely accessible (e.g.
+				// self-read on the root, an inaccessible team folder below it) and must render as
+				// a real node, not an inert one, if so.
+				ghostFolder, gerr := getAncestorTitleOnly(ctx, getter, item.Parent)
+				if gerr != nil {
+					info.Items = append(info.Items, folders.FolderInfo{
+						Name:        item.Parent,
+						Detached:    true,
+						Description: gerr.Error(),
+					})
+					break
+				}
+
+				found[ghostFolder.Name] = true
+				folder = ghostFolder
+				detached = true
+				continue
 			}
 
 			parentFolder, ok := obj.(*folders.Folder)
@@ -74,10 +117,52 @@ func newParentsGetter(getter rest.Getter, maxDepth int) parentsGetter {
 
 			found[parentFolder.Name] = true
 			folder = parentFolder
+			detached = false
 		}
 
 		// Start from the root
 		slices.Reverse(info.Items)
 		return info, err
 	}
+}
+
+// getAncestorTitleOnly resolves {uid, title, parent, description} for a single ancestor folder
+// using a service identity, bypassing the normal per-object folders:read/can_get_self check. This
+// is the one deliberate trust boundary Phase 1.5 introduces (epic #2285 §4.5 / issue #2309): a
+// folder's bare name is treated as inert path-display context, never as equivalent to real read
+// access. Callers must only ever use the returned object to keep the ancestor walk above going
+// one more level -- it must never be serialized back to the client as-is, and it must never carry
+// anything beyond the four fields a *folders.Folder needs for that walk (no permissions, no
+// content, no children).
+func getAncestorTitleOnly(ctx context.Context, getter rest.Getter, uid string) (*folders.Folder, error) {
+	requester, err := identity.GetRequester(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	svcCtx := identity.WithServiceIdentityContext(ctx, requester.GetOrgID())
+	obj, err := getter.Get(svcCtx, uid, &metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	full, ok := obj.(*folders.Folder)
+	if !ok {
+		return nil, fmt.Errorf("expected folder, found: %T", obj)
+	}
+
+	ghost := &folders.Folder{
+		ObjectMeta: metav1.ObjectMeta{Name: full.Name},
+		Spec:       folders.FolderSpec{Title: full.Spec.Title},
+	}
+	if full.Spec.Description != nil {
+		desc := *full.Spec.Description
+		ghost.Spec.Description = &desc
+	}
+
+	fullMeta, _ := utils.MetaAccessor(full)
+	ghostMeta, _ := utils.MetaAccessor(ghost)
+	ghostMeta.SetFolder(fullMeta.GetFolder())
+
+	return ghost, nil
 }

--- a/pkg/registry/apis/folders/parents_test.go
+++ b/pkg/registry/apis/folders/parents_test.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 )
@@ -25,11 +27,12 @@ func TestParents(t *testing.T) {
 			name   string
 			folder string
 		}
-		getter      map[string]*folders.Folder
-		setupFn     func(*grafanarest.MockStorage) // called after the getter is registered
-		expected    *folders.FolderInfoList
-		expectedErr string
-		maxDepth    int // defaults to 5 unless set
+		getter         map[string]*folders.Folder
+		setupFn        func(*grafanarest.MockStorage) // called after the getter is registered
+		expected       *folders.FolderInfoList
+		expectedErr    string
+		maxDepth       int  // defaults to 5 unless set
+		pathVisibility bool // Phase 1.5 toggle (featuremgmt.FlagAuthzFolderPathVisibility); defaults to off, matching pre-Phase-1.5 behavior
 	}{
 		{
 			name: "no parents",
@@ -37,7 +40,7 @@ func TestParents(t *testing.T) {
 				name: "test",
 			},
 			expected: &folders.FolderInfoList{Items: []folders.FolderInfo{
-				{Name: "test"},
+				{Name: "test", CanView: true},
 			}},
 		},
 		{
@@ -47,8 +50,8 @@ func TestParents(t *testing.T) {
 				folder: "parent",
 			},
 			expected: &folders.FolderInfoList{Items: []folders.FolderInfo{
-				{Name: "test", Parent: "parent"},
-				{Name: "parent"},
+				{Name: "test", Parent: "parent", CanView: true},
+				{Name: "parent", CanView: true},
 			}},
 		},
 		{
@@ -58,7 +61,7 @@ func TestParents(t *testing.T) {
 			},
 			getter: map[string]*folders.Folder{},
 			expected: &folders.FolderInfoList{Items: []folders.FolderInfo{
-				{Name: "general"},
+				{Name: "general", CanView: true},
 			}},
 		},
 		{
@@ -73,7 +76,7 @@ func TestParents(t *testing.T) {
 					nothing, fmt.Errorf("custom error message"))
 			},
 			expected: &folders.FolderInfoList{Items: []folders.FolderInfo{
-				{Name: "test", Parent: "parent"},
+				{Name: "test", Parent: "parent", CanView: true},
 				{Name: "parent", Detached: true, Description: "custom error message"},
 			}},
 		},
@@ -89,7 +92,7 @@ func TestParents(t *testing.T) {
 					nil).Once()
 			},
 			expected: &folders.FolderInfoList{Items: []folders.FolderInfo{
-				{Name: "test", Parent: "parent"},
+				{Name: "test", Parent: "parent", CanView: true},
 				{Name: "parent", Detached: true, Description: "expected folder, found: *unstructured.Unstructured"},
 			}},
 		},
@@ -148,7 +151,7 @@ func TestParents(t *testing.T) {
 				maxDepth = 5
 			}
 
-			getter := newParentsGetter(m, maxDepth)
+			getter := newParentsGetter(m, maxDepth, tt.pathVisibility)
 			parents, err := getter(context.TODO(), &folders.Folder{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: tt.request.name,
@@ -166,4 +169,167 @@ func TestParents(t *testing.T) {
 			}
 		})
 	}
+}
+
+// isServiceIdentityCtx and isRealUserCtx are testify mock.MatchedBy predicates that distinguish
+// the privileged, title-only ancestor read (#2309) from the normal, per-caller-authorized Get --
+// this is the actual behavior under test, not just an artifact of the mock setup, so matching on
+// it (rather than on call order) keeps the tests honest about which path fired.
+func isServiceIdentityCtx(ctx context.Context) bool { return identity.IsServiceIdentity(ctx) }
+func isRealUserCtx(ctx context.Context) bool        { return !identity.IsServiceIdentity(ctx) }
+
+// TestParents_PathVisibility covers Phase 1.5 (#2285 §4.5): with FlagAuthzFolderPathVisibility on,
+// an inaccessible ancestor's name should still resolve (as an inert, Detached node) instead of
+// stopping the whole walk, and a genuinely accessible ancestor further up the chain must still
+// render as a real node -- the walk must not permanently downgrade to "ghost mode" the moment it
+// hits one inaccessible ancestor.
+func TestParents_PathVisibility(t *testing.T) {
+	ctx := identity.WithRequester(context.Background(), &identity.StaticRequester{OrgID: 1})
+
+	newFolder := func(name, parent, title string) *folders.Folder {
+		return &folders.Folder{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        name,
+				Annotations: map[string]string{utils.AnnoKeyFolder: parent},
+			},
+			Spec: folders.FolderSpec{Title: title},
+		}
+	}
+
+	t.Run("inaccessible ancestor resolves via privileged read, accessible ancestor above it still renders as real", func(t *testing.T) {
+		// tree: sharedRoot (root-parented, accessible) -> teamBlue (inaccessible) -> mySubfolder (the requested folder)
+		sharedRoot := newFolder("sharedRoot", "", "Shared root")
+		teamBlue := newFolder("teamBlue", "sharedRoot", "Team Blue")
+
+		m := grafanarest.NewMockStorage(t)
+		// The caller cannot access teamBlue through the normal, authorized path.
+		m.On("Get", mock.MatchedBy(isRealUserCtx), "teamBlue", &metav1.GetOptions{}).
+			Return(nil, fmt.Errorf("access denied")).Once()
+		// The privileged, title-only read can still resolve its name.
+		m.On("Get", mock.MatchedBy(isServiceIdentityCtx), "teamBlue", &metav1.GetOptions{}).
+			Return(teamBlue, nil).Once()
+		// sharedRoot is genuinely accessible -- the walk must keep trying the real, authorized
+		// path at every level, not stay in ghost mode once it's used it once.
+		m.On("Get", mock.MatchedBy(isRealUserCtx), "sharedRoot", &metav1.GetOptions{}).
+			Return(sharedRoot, nil).Once()
+
+		getter := newParentsGetter(m, 5, true)
+		result, err := getter(ctx, newFolder("mySubfolder", "teamBlue", "My subfolder"))
+		require.NoError(t, err)
+		require.Equal(t, []folders.FolderInfo{
+			{Name: "sharedRoot", Title: "Shared root", CanView: true},
+			{Name: "teamBlue", Title: "Team Blue", Parent: "sharedRoot", Detached: true},
+			{Name: "mySubfolder", Title: "My subfolder", Parent: "teamBlue", CanView: true},
+		}, result.Items)
+	})
+
+	t.Run("multiple consecutive inaccessible ancestors all resolve, not just the nearest one", func(t *testing.T) {
+		// tree: root (root-parented, inaccessible) -> teamBlue (inaccessible) -> mySubfolder
+		root := newFolder("root", "", "Org root")
+		teamBlue := newFolder("teamBlue", "root", "Team Blue")
+
+		m := grafanarest.NewMockStorage(t)
+		m.On("Get", mock.MatchedBy(isRealUserCtx), "teamBlue", &metav1.GetOptions{}).
+			Return(nil, fmt.Errorf("access denied")).Once()
+		m.On("Get", mock.MatchedBy(isServiceIdentityCtx), "teamBlue", &metav1.GetOptions{}).
+			Return(teamBlue, nil).Once()
+		m.On("Get", mock.MatchedBy(isRealUserCtx), "root", &metav1.GetOptions{}).
+			Return(nil, fmt.Errorf("access denied")).Once()
+		m.On("Get", mock.MatchedBy(isServiceIdentityCtx), "root", &metav1.GetOptions{}).
+			Return(root, nil).Once()
+
+		getter := newParentsGetter(m, 5, true)
+		result, err := getter(ctx, newFolder("mySubfolder", "teamBlue", "My subfolder"))
+		require.NoError(t, err)
+		require.Equal(t, []folders.FolderInfo{
+			{Name: "root", Title: "Org root", Detached: true},
+			{Name: "teamBlue", Title: "Team Blue", Parent: "root", Detached: true},
+			{Name: "mySubfolder", Title: "My subfolder", Parent: "teamBlue", CanView: true},
+		}, result.Items)
+	})
+
+	t.Run("privileged read also failing falls back to the same detached placeholder as toggle-off", func(t *testing.T) {
+		m := grafanarest.NewMockStorage(t)
+		m.On("Get", mock.MatchedBy(isRealUserCtx), "teamBlue", &metav1.GetOptions{}).
+			Return(nil, fmt.Errorf("access denied")).Once()
+		m.On("Get", mock.MatchedBy(isServiceIdentityCtx), "teamBlue", &metav1.GetOptions{}).
+			Return(nil, fmt.Errorf("not found")).Once()
+
+		getter := newParentsGetter(m, 5, true)
+		result, err := getter(ctx, newFolder("mySubfolder", "teamBlue", "My subfolder"))
+		require.NoError(t, err)
+		require.Equal(t, []folders.FolderInfo{
+			{Name: "teamBlue", Detached: true, Description: "not found"},
+			{Name: "mySubfolder", Title: "My subfolder", Parent: "teamBlue", CanView: true},
+		}, result.Items)
+	})
+
+	t.Run("guardrail: the privileged read never returns anything beyond uid/title/parent/description", func(t *testing.T) {
+		desc := "a description"
+		teamBlue := newFolder("teamBlue", "sharedRoot", "Team Blue")
+		teamBlue.Spec.Description = &desc
+		// Deliberately pollute the source object with fields getAncestorTitleOnly must never
+		// carry over -- labels, extra annotations, finalizers, a resource version. If any of
+		// these leaked through, this test would catch it via the exact-equality check below.
+		teamBlue.Labels = map[string]string{"secret-label": "must-not-leak"}
+		teamBlue.Annotations["unrelated-annotation"] = "must-not-leak"
+		teamBlue.Finalizers = []string{"must-not-leak"}
+		teamBlue.ResourceVersion = "12345"
+
+		m := grafanarest.NewMockStorage(t)
+		m.On("Get", mock.MatchedBy(isServiceIdentityCtx), "teamBlue", &metav1.GetOptions{}).Return(teamBlue, nil).Once()
+
+		ghost, err := getAncestorTitleOnly(ctx, m, "teamBlue")
+		require.NoError(t, err)
+
+		expected := &folders.Folder{
+			ObjectMeta: metav1.ObjectMeta{Name: "teamBlue"},
+			Spec:       folders.FolderSpec{Title: "Team Blue", Description: &desc},
+		}
+		expectedMeta, _ := utils.MetaAccessor(expected)
+		expectedMeta.SetFolder("sharedRoot")
+		require.Equal(t, expected, ghost)
+	})
+
+	t.Run("guardrail: siblings of a ghost ancestor never appear in the resolved path", func(t *testing.T) {
+		// tree: sharedRoot -> {teamBlue (inaccessible, on the path), teamRed (an unrelated sibling)}
+		sharedRoot := newFolder("sharedRoot", "", "Shared root")
+		teamBlue := newFolder("teamBlue", "sharedRoot", "Team Blue")
+
+		m := grafanarest.NewMockStorage(t)
+		m.On("Get", mock.MatchedBy(isRealUserCtx), "teamBlue", &metav1.GetOptions{}).
+			Return(nil, fmt.Errorf("access denied")).Once()
+		m.On("Get", mock.MatchedBy(isServiceIdentityCtx), "teamBlue", &metav1.GetOptions{}).
+			Return(teamBlue, nil).Once()
+		m.On("Get", mock.MatchedBy(isRealUserCtx), "sharedRoot", &metav1.GetOptions{}).
+			Return(sharedRoot, nil).Once()
+		// No expectation is registered for "teamRed" at all -- if the walk ever asked about it
+		// (real or privileged path), the mock would fail this test outright for an unexpected
+		// call, which is exactly the guarantee this test wants: the walk only ever resolves the
+		// one ancestor chain it was asked about, never a folder's other children.
+
+		getter := newParentsGetter(m, 5, true)
+		result, err := getter(ctx, newFolder("mySubfolder", "teamBlue", "My subfolder"))
+		require.NoError(t, err)
+		require.Len(t, result.Items, 3)
+		for _, item := range result.Items {
+			require.NotEqual(t, "teamRed", item.Name)
+		}
+	})
+
+	t.Run("cyclic reference through a ghost ancestor is still detected", func(t *testing.T) {
+		// teamBlue (inaccessible, ghost) claims mySubfolder as its own parent -- a cycle.
+		teamBlue := newFolder("teamBlue", "mySubfolder", "Team Blue")
+
+		m := grafanarest.NewMockStorage(t)
+		m.On("Get", mock.MatchedBy(isRealUserCtx), "teamBlue", &metav1.GetOptions{}).
+			Return(nil, fmt.Errorf("access denied")).Maybe()
+		m.On("Get", mock.MatchedBy(isServiceIdentityCtx), "teamBlue", &metav1.GetOptions{}).
+			Return(teamBlue, nil).Maybe()
+
+		getter := newParentsGetter(m, 5, true)
+		_, err := getter(ctx, newFolder("mySubfolder", "teamBlue", "My subfolder"))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "cyclic folder references found")
+	})
 }

--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -61,8 +61,9 @@ type FolderAPIBuilder struct {
 	maxNestedFolderDepth int
 
 	// Flags
-	useZanzana          bool // features.IsEnabledGlobally(featuremgmt.FlagZanzana)
-	permissionsOnCreate bool // cfg.RBAC.PermissionsOnCreation("folder")
+	useZanzana           bool // features.IsEnabledGlobally(featuremgmt.FlagZanzana)
+	permissionsOnCreate  bool // cfg.RBAC.PermissionsOnCreation("folder")
+	folderPathVisibility bool // features.IsEnabledGlobally(featuremgmt.FlagAuthzFolderPathVisibility)
 
 	// Legacy services -- these will not exist in the MT environment
 	resourcePermissionsSvc *dynamic.NamespaceableResourceInterface
@@ -128,6 +129,7 @@ func RegisterAPIService(cfg *setting.Cfg,
 		accessClient:         accessClient,
 		permissionsOnCreate:  cfg.RBAC.PermissionsOnCreation("folder"),
 		useZanzana:           features.IsEnabledGlobally(featuremgmt.FlagZanzana), //nolint:staticcheck
+		folderPathVisibility: features.IsEnabledGlobally(featuremgmt.FlagAuthzFolderPathVisibility),
 		searcher:             unified,
 		permissionStore:      NewZanzanaPermissionStore(zanzanaClient),
 		maxNestedFolderDepth: cfg.MaxNestedFolderDepth,
@@ -158,6 +160,7 @@ func NewAPIService(ac authlib.AccessClient, searcher resource.ResourceClient, fe
 		dashboardSvc:           dashboardSvc, // injected so cascade delete can remove dashboards in MT
 		maxNestedFolderDepth:   maxNestedFolderDepth,
 		useZanzana:             features.IsEnabledGlobally(featuremgmt.FlagZanzana), //nolint:staticcheck
+		folderPathVisibility:   features.IsEnabledGlobally(featuremgmt.FlagAuthzFolderPathVisibility),
 	}
 }
 
@@ -258,7 +261,7 @@ func (b *FolderAPIBuilder) storageForVersion(
 	storage := map[string]rest.Storage{}
 	storage[folders.StoragePath()] = b.storage
 
-	b.parents = newParentsGetter(b.storage, b.maxNestedFolderDepth) // used for validation
+	b.parents = newParentsGetter(b.storage, b.maxNestedFolderDepth, b.folderPathVisibility) // used for validation
 	storage[folders.StoragePath("parents")] = &subParentsREST{
 		getter:  b.storage,
 		parents: b.parents,

--- a/pkg/registry/apis/folders/register_test.go
+++ b/pkg/registry/apis/folders/register_test.go
@@ -143,7 +143,7 @@ func TestFolderAPIBuilder_Validate_Create(t *testing.T) {
 
 			b := &FolderAPIBuilder{
 				storage:              us,
-				parents:              newParentsGetter(us, 2),
+				parents:              newParentsGetter(us, 2, false),
 				maxNestedFolderDepth: setting.NewCfg().MaxNestedFolderDepth,
 			}
 
@@ -503,7 +503,7 @@ func TestFolderAPIBuilder_Validate_Update(t *testing.T) {
 			b := &FolderAPIBuilder{
 				storage:  us,
 				searcher: sm,
-				parents:  newParentsGetter(us, setting.NewCfg().MaxNestedFolderDepth),
+				parents:  newParentsGetter(us, setting.NewCfg().MaxNestedFolderDepth, false),
 			}
 
 			err := b.Validate(context.Background(), admission.NewAttributesRecord(
@@ -595,7 +595,7 @@ func TestFolderAPIBuilder_Mutate_Create(t *testing.T) {
 			b := &FolderAPIBuilder{
 				storage:  us,
 				searcher: sm,
-				parents:  newParentsGetter(us, setting.NewCfg().MaxNestedFolderDepth),
+				parents:  newParentsGetter(us, setting.NewCfg().MaxNestedFolderDepth, false),
 			}
 			admAttr := admission.NewAttributesRecord(
 				tt.input,
@@ -699,7 +699,7 @@ func TestFolderAPIBuilder_Mutate_Update(t *testing.T) {
 	b := &FolderAPIBuilder{
 		storage:  us,
 		searcher: sm,
-		parents:  newParentsGetter(us, setting.NewCfg().MaxNestedFolderDepth),
+		parents:  newParentsGetter(us, setting.NewCfg().MaxNestedFolderDepth, false),
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/registry/apis/folders/sub_access_test.go
+++ b/pkg/registry/apis/folders/sub_access_test.go
@@ -201,6 +201,67 @@ func TestSubAccessREST_getAccessInfo(t *testing.T) {
 	}
 }
 
+// TestSubAccessREST_getAccessInfo_folderSelfReadGrant is a spike observation for
+// identity-access-team#2285, Phase 1, open question raised for #2295: what does /access report
+// for a folder the caller can only self-read (folders.self:read), and is it misleading?
+//
+// checkAccess only ever probes the folder object itself (get/create/update/delete/setperms on
+// THIS folder, see folderTierChecks) -- it never probes whether dashboards/alerts/library panels
+// in the folder are actually readable. This test's "allowed" map is not hypothetical: it is
+// exactly the real BatchCheck result for a get_self-only grant, proven independently and
+// end-to-end in pkg/services/authz/zanzana/server/server_check_folder_self_test.go
+// (TestIntegrationServerCheck_FolderSelfRead) --
+//   - "get_self grants get on the folder itself" -> the get probe here is allowed
+//   - "get_self does NOT recurse to a child folder" -> create/update/delete/setperms would all
+//     be denied too, since none of those relations include get_self
+//   - "get_self does NOT leak read on a dashboard directly inside the folder" -> a real
+//     dashboards:read check against this same folder would be denied, even though...
+//
+// ...the tier resolution below reports Viewer, and Viewer's AccessControl bundle includes
+// "dashboards:read" (and alert.rules:read, library.panels:read, alert.silences:read). A frontend
+// trusting AccessControl would show "you can view dashboards here" for a folder whose contents
+// the user cannot actually see. That gap -- not the OpenFGA layer, which behaves correctly -- is
+// what #2295 needs to close: either compute a distinct tier for self-only access, or stop
+// deriving AccessControl from the tier for folders where the grant is self-only.
+func TestSubAccessREST_getAccessInfo_folderSelfReadGrant(t *testing.T) {
+	f := &folders.Folder{}
+	meta, err := utils.MetaAccessor(f)
+	require.NoError(t, err)
+	meta.SetName("self-only-folder")
+	store := grafanarest.NewMockStorage(t)
+	store.On("Get", mock.Anything, "self-only-folder", &metav1.GetOptions{}).Return(f, nil)
+
+	ac := &subAccessMockClient{
+		batchCheckFunc: func(_ context.Context, _ authlib.AuthInfo, req authlib.BatchCheckRequest) (authlib.BatchCheckResponse, error) {
+			results := make(map[string]authlib.BatchCheckResult, len(req.Checks))
+			for _, item := range req.Checks {
+				// The only real signal a get_self grant produces: the folder-object get probe
+				// is allowed, every other folder-object probe is denied.
+				results[item.CorrelationID] = authlib.BatchCheckResult{Allowed: item.Verb == utils.VerbGet}
+			}
+			return authlib.BatchCheckResponse{Results: results}, nil
+		},
+	}
+
+	r := &subAccessREST{getter: store, accessClient: ac}
+	ctx := request.WithNamespace(context.Background(), "default")
+	ctx = identity.WithRequester(ctx, &user.SignedInUser{UserID: 1, OrgID: 1})
+
+	got, err := r.getAccessInfo(ctx, "self-only-folder")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	require.False(t, got.CanAdmin)
+	require.False(t, got.CanEdit)
+	require.False(t, got.CanSave)
+	require.False(t, got.CanDelete)
+	require.Equal(t, actionsForTier(tierViewer), got.AccessControl,
+		"a self-only grant currently resolves to the full Viewer bundle, including dashboards:read -- "+
+			"this is the misleading-UI gap #2295 needs to close, not a regression introduced here")
+	require.True(t, got.AccessControl["dashboards:read"],
+		"AccessControl claims dashboard read access that the real Zanzana check denies for a self-only grant")
+}
+
 func TestSubAccessREST_getAccessInfo_virtualFolders(t *testing.T) {
 	t.Run("root/general folder runs real access checks against the general scope without a Get", func(t *testing.T) {
 		// "general" and the legacy empty UID must both resolve to the general scope.

--- a/pkg/registry/apis/folders/validate_test.go
+++ b/pkg/registry/apis/folders/validate_test.go
@@ -478,7 +478,7 @@ func TestValidateCreate(t *testing.T) {
 				mockStorage.On("Get", mock.Anything, name, &metav1.GetOptions{}).Return(f, nil).Maybe()
 			}
 
-			getter := newParentsGetter(mockStorage, maxDepth)
+			getter := newParentsGetter(mockStorage, maxDepth, false)
 
 			err := validateOnCreate(ctx, tt.folder, getter, maxDepth)
 

--- a/pkg/services/accesscontrol/ossaccesscontrol/folder.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/folder.go
@@ -91,8 +91,35 @@ func FolderFixedRoleRegistrations(wildcardSeed bool) []accesscontrol.RoleRegistr
 	return []accesscontrol.RoleRegistration{viewer, editor, admin}
 }
 
+// FolderSelfReadRoleRegistration registers folders.self:read for permission validation without
+// granting it to any built-in role. It exists purely so the permission registry knows the action
+// and its valid scope prefix (folders:uid:): DeclareFixedRoles only calls RegisterPermission for
+// actions that appear in a *declared* fixed role's permission list, and folders.self:read is
+// deliberately excluded from FolderViewActions/FolderEditActions/FolderAdminActions -- bundling it
+// there would grant it to every Viewer by default, defeating the point of a self-only,
+// individually assignable action. The only supported way a user gets this action is an explicit
+// custom-role assignment naming a specific folder (identity-access-team#2285, Phase 1).
+//
+// Without this registration, enterprise custom-role validation (ValidateProvidedPermissions, when
+// cfg.RBAC.PermissionValidationEnabled) rejects folders.self:read as an unknown action -- see
+// permreg.TestPermissionRegistry_FolderSelfReadRegistrationGap for the empirical demonstration.
+func FolderSelfReadRoleRegistration() accesscontrol.RoleRegistration {
+	return accesscontrol.RoleRegistration{
+		Role: accesscontrol.RoleDTO{
+			Name:        "fixed:folders:self-reader",
+			DisplayName: "Folder self-reader (internal)",
+			Description: "Registers folders.self:read for custom-role permission validation. Not granted to any basic role.",
+			Group:       "Folders",
+			Permissions: accesscontrol.PermissionsForActions([]string{folder.ActionFoldersReadSelf}, folder.ScopeFoldersAll),
+			Hidden:      true,
+		},
+		Grants: []string{},
+	}
+}
+
 func registerFolderRoles(cfg *setting.Cfg, _ featuremgmt.FeatureToggles, service accesscontrol.Service) error {
-	return service.DeclareFixedRoles(FolderFixedRoleRegistrations(cfg.RBAC.PermissionsWildcardSeed("folder"))...)
+	registrations := append(FolderFixedRoleRegistrations(cfg.RBAC.PermissionsWildcardSeed("folder")), FolderSelfReadRoleRegistration())
+	return service.DeclareFixedRoles(registrations...)
 }
 
 // FolderPermissionsRoleRegistrations returns the templated reader/writer fixed

--- a/pkg/services/accesscontrol/ossaccesscontrol/folder_self_test.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/folder_self_test.go
@@ -1,0 +1,51 @@
+package ossaccesscontrol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/permreg"
+	"github.com/grafana/grafana/pkg/services/folder"
+)
+
+// TestFolderSelfReadRoleRegistration is a spike test for identity-access-team#2285, Phase 1.
+// It verifies the production registration data (not a copy of it) satisfies the two properties
+// the design depends on:
+//  1. folders.self:read is never bundled into a role actually granted to a built-in org role
+//     (Viewer/Editor/Admin/Grafana Admin) -- it must only ever be reachable via an explicit
+//     custom-role assignment.
+//  2. Declaring it (mirroring what Service.DeclareFixedRoles does: validate + RegisterPermission)
+//     is enough to make folders.self:read a recognised action for custom-role validation.
+func TestFolderSelfReadRoleRegistration(t *testing.T) {
+	reg := FolderSelfReadRoleRegistration()
+
+	t.Run("is a well-formed fixed role", func(t *testing.T) {
+		require.NoError(t, accesscontrol.ValidateFixedRole(reg.Role))
+		require.NoError(t, accesscontrol.ValidateBuiltInRoles(reg.Grants))
+	})
+
+	t.Run("is not granted to any built-in role", func(t *testing.T) {
+		assert.Empty(t, reg.Grants, "folders.self:read must only be reachable via an explicit custom-role assignment, never a default grant")
+	})
+
+	t.Run("folders.self:read is not bundled into any of the Viewer/Editor/Admin action sets", func(t *testing.T) {
+		assert.NotContains(t, FolderViewActions, folder.ActionFoldersReadSelf)
+		assert.NotContains(t, FolderEditActions, folder.ActionFoldersReadSelf)
+		assert.NotContains(t, FolderAdminActions, folder.ActionFoldersReadSelf)
+	})
+
+	t.Run("declaring it registers folders.self:read for custom-role validation", func(t *testing.T) {
+		pr := permreg.ProvidePermissionRegistry()
+		for _, p := range reg.Role.Permissions {
+			require.NoError(t, pr.RegisterPermission(p.Action, p.Scope))
+		}
+
+		assert.NoError(t, pr.IsPermissionValid(folder.ActionFoldersReadSelf, "folders:uid:AABBCC"))
+		// Scope must still be tied to a specific folder, not left completely unchecked -- a
+		// mistyped action name should not silently validate.
+		assert.Error(t, pr.IsPermissionValid("folders.self:write", "folders:uid:AABBCC"))
+	})
+}

--- a/pkg/services/accesscontrol/permreg/permreg_folder_self_test.go
+++ b/pkg/services/accesscontrol/permreg/permreg_folder_self_test.go
@@ -1,0 +1,50 @@
+package permreg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPermissionRegistry_FolderSelfReadRegistrationGap is a spike test for the
+// folders.self:read design (identity-access-team#2285, Phase 1, open question #3: "does the role
+// write path accept the new action end to end?").
+//
+// folders.self:read is deliberately NOT part of FolderViewActions/FolderEditActions/
+// FolderAdminActions (see pkg/services/accesscontrol/ossaccesscontrol/folder.go) -- bundling it
+// there would grant it to every Viewer by default, which defeats the point of a self-only,
+// individually-assignable action. But DeclareFixedRoles only calls RegisterPermission for
+// actions that appear in a *declared* fixed role's permission list. An action that is never
+// declared by any fixed role is never registered, so custom-role validation
+// (ValidateProvidedPermissions, enterprise-only, gated by cfg.RBAC.PermissionValidationEnabled)
+// rejects it with ErrUnknownAction.
+//
+// This demonstrates the gap empirically, and the minimal fix: registering the action (with its
+// scope prefix) via a role declaration that is never granted to any built-in role, so the
+// registry knows about it without bundling it into Viewer/Editor/Admin.
+func TestPermissionRegistry_FolderSelfReadRegistrationGap(t *testing.T) {
+	t.Run("unregistered folders.self:read is rejected as an unknown action", func(t *testing.T) {
+		pr := newPermissionRegistry()
+		// Simulates today's state: only the bundled folder actions get registered by
+		// DeclareFixedRoles; folders.self:read is not one of them.
+		require.NoError(t, pr.RegisterPermission("folders:read", "folders:uid:"))
+
+		err := pr.IsPermissionValid("folders.self:read", "folders:uid:AABBCC")
+		require.Error(t, err, "folders.self:read must be registered somewhere or custom-role creation will reject it")
+		assert.ErrorIs(t, err, ErrUnknownAction("folders.self:read"))
+	})
+
+	t.Run("registering folders.self:read directly (without granting it to any role) fixes validation", func(t *testing.T) {
+		pr := newPermissionRegistry()
+		require.NoError(t, pr.RegisterPermission("folders:read", "folders:uid:"))
+
+		// The fix: a RegisterPermission call for folders.self:read, e.g. via a hidden
+		// accesscontrol.RoleRegistration with Grants: []string{} (never assigned to Viewer/
+		// Editor/Admin/Grafana Admin), so the *only* way a user gets this action is an explicit
+		// custom-role assignment naming a specific folder.
+		require.NoError(t, pr.RegisterPermission("folders.self:read", "folders:uid:"))
+
+		assert.NoError(t, pr.IsPermissionValid("folders.self:read", "folders:uid:AABBCC"))
+	})
+}

--- a/pkg/services/authz/zanzana/common/translations.go
+++ b/pkg/services/authz/zanzana/common/translations.go
@@ -83,6 +83,7 @@ var resourceTranslations = map[string]resourceTranslation{
 		resource: folderResource,
 		mapping: map[string]actionMapping{
 			"folders:read":      newMapping(RelationGet, ""),
+			"folders.self:read": newMapping(RelationGetSelf, ""),
 			"folders:write":     newMapping(RelationUpdate, ""),
 			"folders:create":    newMapping(RelationCreate, ""),
 			"folders:delete":    newMapping(RelationDelete, ""),

--- a/pkg/services/authz/zanzana/common/tuple.go
+++ b/pkg/services/authz/zanzana/common/tuple.go
@@ -57,15 +57,17 @@ const (
 	RelationSetEdit  string = "edit"
 	RelationSetAdmin string = "admin"
 
-	RelationGet    string = "get"
-	RelationUpdate string = "update"
-	RelationCreate string = "create"
-	RelationDelete string = "delete"
+	RelationGet     string = "get"
+	RelationGetSelf string = "get_self"
+	RelationUpdate  string = "update"
+	RelationCreate  string = "create"
+	RelationDelete  string = "delete"
 
 	RelationGetPermissions string = "get_permissions"
 	RelationSetPermissions string = "set_permissions"
 
 	RelationCanGet            string = "can_get"
+	RelationCanGetSelf        string = "can_get_self"
 	RelationCanCreate         string = "can_create"
 	RelationCanUpdate         string = "can_update"
 	RelationCanDelete         string = "can_delete"
@@ -125,6 +127,7 @@ var RelationsSubresource = []string{
 var RelationsFolder = append(
 	RelationsSubresource,
 	RelationGet,
+	RelationGetSelf,
 	RelationUpdate,
 	RelationCreate,
 	RelationDelete,
@@ -186,7 +189,11 @@ var VerbMapping = map[string]string{
 
 // RelationToVerbMapping is mapping a zanzana relation to k8s verb.
 var RelationToVerbMapping = map[string]string{
-	RelationGet:            utils.VerbGet,
+	RelationGet: utils.VerbGet,
+	// get_self is a grant-time distinction only; reading a folder is still
+	// verb "get" at check time (get_self feeds can_get_self, see schema_folder.fga
+	// and FolderDirectPermissionRelation).
+	RelationGetSelf:        utils.VerbGet,
 	RelationCreate:         utils.VerbCreate,
 	RelationUpdate:         utils.VerbUpdate,
 	RelationDelete:         utils.VerbDelete,
@@ -195,6 +202,11 @@ var RelationToVerbMapping = map[string]string{
 }
 
 // FolderPermissionRelation returns the optimized folder relation for permission management.
+//
+// This is used both when checking the folder object itself AND when checking whether a resource
+// (e.g. a dashboard) inherits access from its containing folder. Deliberately does NOT include
+// get_self: a self-only grant on a folder must not let its contents (or subfolders) inherit read.
+// Use FolderDirectPermissionRelation instead for "is the folder itself accessible" checks.
 func FolderPermissionRelation(relation string) string {
 	switch relation {
 	case RelationGet:
@@ -212,6 +224,23 @@ func FolderPermissionRelation(relation string) string {
 	default:
 		return relation
 	}
+}
+
+// FolderDirectPermissionRelation returns the relation to use when checking (or listing) access to
+// a folder object itself, as opposed to a resource that inherits permissions from a folder. For
+// "get" this additionally includes get_self, so a self-only grant makes the folder itself visible
+// -- without granting anything that recurses to its subtree or lets its direct content inherit
+// read (that would defeat the point of a self-only grant; see identity-access-team#2285 open
+// question #2). Every other verb behaves the same as FolderPermissionRelation.
+//
+// Do NOT use this for the "does this resource inherit from its folder" branches (checkGeneric,
+// listGeneric, collectFolderPermissionChecks) -- those must keep using FolderPermissionRelation /
+// can_get so self-only grants cannot leak folder content.
+func FolderDirectPermissionRelation(relation string) string {
+	if relation == RelationGet {
+		return RelationCanGetSelf
+	}
+	return FolderPermissionRelation(relation)
 }
 
 // SubresourcePermissionRelation returns computed subresource relations that include escalation.

--- a/pkg/services/authz/zanzana/common/tuple_test.go
+++ b/pkg/services/authz/zanzana/common/tuple_test.go
@@ -165,3 +165,29 @@ func TestTranslateToResourceTuple(t *testing.T) {
 		})
 	}
 }
+
+// TestTranslateToResourceTuple_FolderSelfReadWildcardScope is a spike test for
+// identity-access-team#2285, open question #6 (wildcard-scope edge case). A wildcard scope
+// (folders:*) routes through the group_resource branch of TranslateToResourceTuple, which emits a
+// tuple with relation get_self on a group_resource:... object. This proves that translation step
+// alone succeeds and produces a tuple -- it does NOT prove the tuple is usable, because get_self
+// is deliberately not defined on the group_resource type (see schema_resource.fga): a
+// self-only grant is only meaningful for one specific folder, so a group-wide "all folders"
+// self-only grant is nonsensical by construction. Whether OpenFGA rejects writing this tuple is
+// verified separately at the server/reconciler integration level
+// (TestIntegrationReconciler_FolderSelfReadWildcardScopeRejected).
+func TestTranslateToResourceTuple_FolderSelfReadWildcardScope(t *testing.T) {
+	tuple, ok := TranslateToResourceTuple("user:1", "folders.self:read", "folders", "*")
+	require.True(t, ok, "translation itself does not reject a wildcard scope for folders.self:read")
+	require.EqualExportedValues(t, &openfgav1.TupleKey{
+		User:     "user:1",
+		Relation: RelationGetSelf,
+		Object:   "group_resource:folder.grafana.app/folders",
+	}, tuple)
+
+	// get_self must NOT be a valid relation on group_resource: it's deliberately absent from
+	// schema_resource.fga. If this assertion ever fails because someone added it, open question
+	// #6 needs to be re-examined (a wildcard self-only grant would then silently become a full
+	// tier grant across every folder).
+	require.NotContains(t, RelationsGroupResource, RelationGetSelf)
+}

--- a/pkg/services/authz/zanzana/schema/schema_folder.fga
+++ b/pkg/services/authz/zanzana/schema/schema_folder.fga
@@ -9,6 +9,9 @@ type folder
     define edit: [user, service-account, team#member, role#assignee] or edit from parent
     define view: [user, service-account, team#member, role#assignee] or view from parent
     define get: [user, service-account, team#member, role#assignee] or get from parent
+    # get_self is deliberately NOT "or get_self from parent": a self-only grant
+    # must not propagate to children, unlike every other relation here.
+    define get_self: [user, service-account, team#member, role#assignee]
     define create: [user, service-account, team#member, role#assignee] or create from parent
     define update: [user, service-account, team#member, role#assignee] or update from parent
     define delete: [user, service-account, team#member, role#assignee] or delete from parent
@@ -17,6 +20,11 @@ type folder
 
     # Computed actions
     define can_get: admin or edit or view or get
+    # can_get_self is ONLY for checking the folder object itself. It must never be used for
+    # resources that inherit permissions from a folder (dashboards, subresources) or for
+    # subfolder inheritance -- can_get (unchanged, no get_self) is what those paths use, and
+    # that is what keeps get_self from leaking folder content or subtree visibility.
+    define can_get_self: can_get or get_self
     define can_create: admin or edit or create
     define can_update: admin or edit or update
     define can_delete: admin or edit or delete

--- a/pkg/services/authz/zanzana/server/reconciler/translators_test.go
+++ b/pkg/services/authz/zanzana/server/reconciler/translators_test.go
@@ -698,6 +698,46 @@ func TestTranslateRoleToTuplesWithComposition(t *testing.T) {
 	})
 }
 
+// TestTranslateRoleToTuples_FolderSelfRead is a spike test for identity-access-team#2285, Phase 1,
+// open questions #3 (role write path) and #5 (reconciler rebuild survival).
+//
+//   - #3: a Role CRD carrying folders.self:read translates to a get_self tuple end to end,
+//     through the exact same TranslateRoleToTuples/RoleToTuples path production reconciliation
+//     uses, and that tuple is valid against the real compiled schema.
+//   - #5: TranslateRoleToTuples is a pure function of the Role spec (no hidden state), so
+//     translating it again -- exactly what a full reconciler rebuild does -- reproduces the
+//     identical tuple. There is no drift risk from a rebuild dropping or mutating a self-only
+//     grant.
+func TestTranslateRoleToTuples_FolderSelfRead(t *testing.T) {
+	ts := loadTypesystem(t)
+
+	role := &iamv0.Role{
+		ObjectMeta: metav1.ObjectMeta{Name: "folder-self-reader"},
+		Spec: iamv0.RoleSpec{
+			Permissions: []iamv0.RolespecPermission{
+				{Action: "folders.self:read", Scope: "folders:uid:AABBCC"},
+			},
+		},
+	}
+
+	tuples, err := TranslateRoleToTuples(toUnstructured(t, role), nil)
+	require.NoError(t, err)
+
+	require.ElementsMatch(t, tupleKeyStrings([]*openfgav1.TupleKey{
+		{User: "role:folder-self-reader#assignee", Relation: "get_self", Object: "folder:AABBCC"},
+	}), tupleKeyStrings(tuples))
+
+	for _, tuple := range tuples {
+		validateTupleAgainstSchema(t, ts, tuple)
+	}
+
+	// Rebuild survival: re-translating the same Role spec (what a full reconciler rebuild does)
+	// must reproduce the exact same tuple, not drop it or produce a different one.
+	rebuiltTuples, err := TranslateRoleToTuples(toUnstructured(t, role), nil)
+	require.NoError(t, err)
+	require.ElementsMatch(t, tupleKeyStrings(tuples), tupleKeyStrings(rebuiltTuples))
+}
+
 // TestTranslateRoleToTuples_RoleManagementPermissions verifies the reconciler
 // end-to-end (Role CRD → tuples) for the three legacy role-management actions:
 //

--- a/pkg/services/authz/zanzana/server/reconciler_folder_self_test.go
+++ b/pkg/services/authz/zanzana/server/reconciler_folder_self_test.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/authz/zanzana/common"
+	"github.com/grafana/grafana/pkg/util/testutil"
+)
+
+// TestIntegrationReconciler_FolderSelfReadWildcardScopeRejected is a spike test for
+// identity-access-team#2285, open question #6 (wildcard-scope edge case): "if someone grants
+// folders.self:read with scope folders:* instead of folders:uid:X, what happens?"
+//
+// common.TranslateToResourceTuple happily produces a get_self tuple on a group_resource object
+// (see common.TestTranslateToResourceTuple_FolderSelfReadWildcardScope) -- translation does not
+// reject it. This test proves the *next* layer down, the real compiled OpenFGA model, does: since
+// get_self is deliberately absent from schema_resource.fga's group_resource type, writing that
+// tuple is rejected by OpenFGA itself.
+//
+// Practical consequence for the reconciler: a Role with {action: folders.self:read,
+// scope: folders:*} will fail to reconcile its tuples (the write errors), rather than silently
+// granting nothing or silently granting everything. This is undesirable either way -- Phase 1
+// needs explicit validation that rejects folders.self:read + a wildcard/kind-level scope at
+// role-write time, with a clear error, instead of leaving it to fail this deep in the pipeline.
+func TestIntegrationReconciler_FolderSelfReadWildcardScopeRejected(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	srv := setupOpenFGAServer(t)
+
+	tuple, ok := common.TranslateToResourceTuple("user:wildcard-self", "folders.self:read", "folders", "*")
+	require.True(t, ok)
+	require.Equal(t, common.RelationGetSelf, tuple.Relation)
+	require.Equal(t, "group_resource:folder.grafana.app/folders", tuple.Object)
+
+	store, err := srv.getStoreInfo(context.Background(), namespace)
+	require.NoError(t, err)
+
+	_, err = srv.openFGAClient.Write(context.Background(), &openfgav1.WriteRequest{
+		StoreId:              store.ID,
+		AuthorizationModelId: store.ModelID,
+		Writes: &openfgav1.WriteRequestWrites{
+			TupleKeys: []*openfgav1.TupleKey{tuple},
+		},
+	})
+
+	assert.Error(t, err, "OpenFGA should reject a get_self tuple on group_resource:folder.grafana.app/folders, since get_self is not a relation defined on that type")
+}

--- a/pkg/services/authz/zanzana/server/server_batch_check.go
+++ b/pkg/services/authz/zanzana/server/server_batch_check.go
@@ -723,7 +723,9 @@ func (s *Server) resolveTypedItems(
 		if sample.resource.IsValidRelation(key.relation) {
 			listRelation := key.relation
 			if key.typ == common.TypeFolder {
-				listRelation = common.FolderPermissionRelation(key.relation)
+				// "Is the folder itself accessible" -- get_self-aware, see
+				// FolderDirectPermissionRelation doc comment.
+				listRelation = common.FolderDirectPermissionRelation(key.relation)
 			}
 			if err := s.collectAllowedObjects(ctx, allowed, &openfgav1.ListObjectsRequest{
 				StoreId:              store.ID,

--- a/pkg/services/authz/zanzana/server/server_check.go
+++ b/pkg/services/authz/zanzana/server/server_check.go
@@ -145,10 +145,13 @@ func (s *Server) checkTyped(ctx context.Context, subject, relation string, resou
 		return &authzv1.CheckResponse{Allowed: false}, nil
 	}
 
-	// Use optimized folder permission relations for permission management
+	// Use optimized folder permission relations for permission management. This is the
+	// "is the folder object itself accessible" path, so it uses FolderDirectPermissionRelation
+	// (get_self-aware) rather than FolderPermissionRelation (used by checkGeneric below for the
+	// "does this resource inherit from its folder" path, which must stay get_self-blind).
 	checkRelation := relation
 	if resource.Type() == common.TypeFolder {
-		checkRelation = common.FolderPermissionRelation(relation)
+		checkRelation = common.FolderDirectPermissionRelation(relation)
 	}
 
 	// Check if subject has direct access to resource

--- a/pkg/services/authz/zanzana/server/server_check_folder_self_test.go
+++ b/pkg/services/authz/zanzana/server/server_check_folder_self_test.go
@@ -1,0 +1,85 @@
+package server
+
+import (
+	"testing"
+
+	authzv1 "github.com/grafana/authlib/authz/proto/v1"
+	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/services/authz/zanzana/common"
+	"github.com/grafana/grafana/pkg/util/testutil"
+)
+
+// TestIntegrationServerCheck_FolderSelfRead is a spike test for the folders.self:read / get_self
+// design (identity-access-team#2285, Phase 1). It empirically verifies the two safety properties
+// the design relies on, rather than trusting the schema reasoning by inspection:
+//
+//  1. get_self does NOT recurse to child folders (unlike every other assignable folder relation,
+//     which all include "or <relation> from parent").
+//  2. get_self does NOT leak read on subresources (dashboards) placed directly in the folder.
+//     This resolves open question #2 in the epic as option (a): self-read is pure navigation,
+//     the folder's direct contents are not included.
+func TestIntegrationServerCheck_FolderSelfRead(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	srv := setupOpenFGAServer(t)
+
+	const (
+		parentFolder = "self-parent"
+		childFolder  = "self-child"
+		viewFolder   = "view-parent"
+	)
+
+	tuples := []*openfgav1.TupleKey{
+		// The grant under test: get_self directly on the parent folder only.
+		common.NewFolderTuple("user:self-only", common.RelationGetSelf, parentFolder),
+		// Parent/child relationship so recursion (or lack of it) can be observed.
+		common.NewFolderParentTuple(childFolder, parentFolder),
+		// Control: a real Viewer-tier grant on a separate folder, to contrast against get_self
+		// in the "sanity" case below.
+		common.NewFolderTuple("user:full-view", common.RelationSetView, viewFolder),
+	}
+	setupOpenFGADatabase(t, srv, tuples)
+
+	newReq := func(subject, verb, group, resource, subresource, folder, name string) *authzv1.CheckRequest {
+		return &authzv1.CheckRequest{
+			Namespace:   namespace,
+			Subject:     subject,
+			Verb:        verb,
+			Group:       group,
+			Resource:    resource,
+			Subresource: subresource,
+			Name:        name,
+			Folder:      folder,
+		}
+	}
+
+	t.Run("get_self grants get on the folder itself", func(t *testing.T) {
+		res, err := srv.Check(newContextWithNamespace(), newReq("user:self-only", utils.VerbGet, folderGroup, folderResource, "", "", parentFolder))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed(), "get_self on X should satisfy a get check on X")
+	})
+
+	t.Run("get_self does NOT recurse to a child folder", func(t *testing.T) {
+		res, err := srv.Check(newContextWithNamespace(), newReq("user:self-only", utils.VerbGet, folderGroup, folderResource, "", "", childFolder))
+		require.NoError(t, err)
+		assert.False(t, res.GetAllowed(), "get_self on X must not grant get on X's children")
+	})
+
+	t.Run("get_self does NOT leak read on a dashboard directly inside the folder", func(t *testing.T) {
+		res, err := srv.Check(newContextWithNamespace(), newReq("user:self-only", utils.VerbGet, dashboardGroup, dashboardResource, "", parentFolder, "dash-in-self-only-folder"))
+		require.NoError(t, err)
+		assert.False(t, res.GetAllowed(), "get_self must not expose the folder's direct contents (resolves open question #2 as option (a))")
+	})
+
+	t.Run("sanity: a real Viewer-tier grant (view relation) on a folder DOES expose direct content", func(t *testing.T) {
+		// Control case, using a separate folder so it doesn't interfere with the self-only assertions
+		// above: confirms the *contrast* with get_self is real, not an artifact of the test setup.
+		res, err := srv.Check(newContextWithNamespace(), newReq("user:full-view", utils.VerbGet, dashboardGroup, dashboardResource, "", viewFolder, "dash-in-view-folder"))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed(), "a real view-tier grant should expose direct content, unlike get_self")
+	})
+}

--- a/pkg/services/authz/zanzana/server/server_list.go
+++ b/pkg/services/authz/zanzana/server/server_list.go
@@ -124,10 +124,14 @@ func (s *Server) listTyped(ctx context.Context, subject, relation string, resour
 
 	// List all resources the subject has direct access to via the base relation.
 	if resource.IsValidRelation(relation) {
-		// Use optimized folder permission relations for permission management
+		// Use optimized folder permission relations for permission management. Folder-typed
+		// listing is the "which folders are themselves accessible" path, so it must use the
+		// get_self-aware relation (see FolderDirectPermissionRelation doc comment) -- unlike
+		// listGeneric below, which resolves folder-content inheritance and must stay
+		// get_self-blind.
 		listRelation := relation
 		if resource.Type() == common.TypeFolder {
-			listRelation = common.FolderPermissionRelation(relation)
+			listRelation = common.FolderDirectPermissionRelation(relation)
 		}
 
 		res, err := s.listObjects(ctx, &openfgav1.ListObjectsRequest{

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -3165,6 +3165,15 @@ var (
 			Expression:   "false",
 			Generate:     Generate{Go: true},
 		},
+		{
+			Name:         "authz.folderPathVisibility",
+			Description:  "Show a folder's full ancestor path, including the names of ancestors the signed-in user has no access to, as inert non-browsable context. Gates the relaxed real-tree-placement criterion so items with a resolvable-but-inaccessible ancestor chain render in their real position instead of falling through to Shared with me; leaves Shared with me itself, and every other partial-access scenario, unchanged when off.",
+			Stage:        FeatureStageExperimental,
+			Owner:        identityAccessTeam,
+			HideFromDocs: true,
+			Expression:   "false",
+			Generate:     Generate{Go: true},
+		},
 		// tl;dr: name your new flag `component.featureName`, specify Go and/or React generation targets, and use with OpenFeature!
 		//
 		// Adding a new feature flag? Be sure to check out the updated docs at /contribute/feature-toggles.md#Steps-to-adding-a-feature-toggle

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -3172,7 +3172,9 @@ var (
 			Owner:        identityAccessTeam,
 			HideFromDocs: true,
 			Expression:   "false",
-			Generate:     Generate{Go: true},
+			// LegacyFrontend: PoC needs config.featureToggles['authz.folderPathVisibility'] in
+			// browse-dashboards (identity-access-team#2285 §4.5, chunk 5 ghost-node injection).
+			Generate: Generate{Go: true, LegacyFrontend: true},
 		},
 		// tl;dr: name your new flag `component.featureName`, specify Go and/or React generation targets, and use with OpenFeature!
 		//

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -367,3 +367,4 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-06-24,authz.listFoldersViaSearch,experimental,@grafana/identity-access-team,false,false,false
 2026-06-24,libraryElements.folderTreeViaSearch,experimental,@grafana/identity-access-team,false,false,false
 2026-08-03,alerting.stateManagerRequireWarm,experimental,@grafana/alerting-squad,false,false,false
+2026-08-08,authz.folderPathVisibility,experimental,@grafana/identity-access-team,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -993,4 +993,8 @@ const (
 	// FlagAlertingStateManagerRequireWarm
 	// Hold back alert state writes until the state cache has been warmed. For rulers that warm asynchronously, such as the multi-tenant ruler.
 	FlagAlertingStateManagerRequireWarm = "alerting.stateManagerRequireWarm"
+
+	// FlagAuthzFolderPathVisibility
+	// Show a folder's full ancestor path, including the names of ancestors the signed-in user has no access to, as inert non-browsable context. Gates the relaxed real-tree-placement criterion so items with a resolvable-but-inaccessible ancestor chain render in their real position instead of falling through to Shared with me; leaves Shared with me itself, and every other partial-access scenario, unchanged when off.
+	FlagAuthzFolderPathVisibility = "authz.folderPathVisibility"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1135,6 +1135,20 @@
     },
     {
       "metadata": {
+        "name": "authz.folderPathVisibility",
+        "resourceVersion": "1786222559124",
+        "creationTimestamp": "2026-08-08T20:55:59Z"
+      },
+      "spec": {
+        "description": "Show a folder's full ancestor path, including the names of ancestors the signed-in user has no access to, as inert non-browsable context. Gates the relaxed real-tree-placement criterion so items with a resolvable-but-inaccessible ancestor chain render in their real position instead of falling through to Shared with me; leaves Shared with me itself, and every other partial-access scenario, unchanged when off.",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team",
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "authz.listFoldersViaSearch",
         "resourceVersion": "1782267268333",
         "creationTimestamp": "2026-06-24T02:14:28Z"

--- a/pkg/services/folder/access_control.go
+++ b/pkg/services/folder/access_control.go
@@ -17,6 +17,7 @@ const (
 
 	ActionFoldersCreate           = "folders:create"
 	ActionFoldersRead             = "folders:read"
+	ActionFoldersReadSelf         = "folders.self:read"
 	ActionFoldersWrite            = "folders:write"
 	ActionFoldersDelete           = "folders:delete"
 	ActionFoldersPermissionsRead  = "folders.permissions:read"

--- a/public/app/features/browse-dashboards/api/services.ts
+++ b/public/app/features/browse-dashboards/api/services.ts
@@ -1,3 +1,4 @@
+import { getAPINamespace } from '@grafana/api-clients';
 import { t } from '@grafana/i18n';
 import { config, getBackendSrv } from '@grafana/runtime';
 import { collectionsAPIv1alpha1 } from 'app/api/clients/collections/v1alpha1';
@@ -35,6 +36,153 @@ async function searchOldAPI(parentUID?: string, page = 1, pageSize = PAGE_SIZE) 
     page,
     limit: pageSize,
   });
+}
+
+// --- Phase 1.5 PoC: folder path visibility (identity-access-team#2285 §4.5) ---
+//
+// Items whose parent isn't accessible but whose full ancestor *name* chain resolves are placed
+// in their real tree position, with the inaccessible ancestors rendered as inert "ghost" nodes,
+// instead of falling through to Shared with me (excluded there by the backend when
+// authz.folderPathVisibility is on -- see pkg/registry/apis/dashboard/search.go). This module
+// never reads or writes anything under Shared with me; it only discovers candidates via the
+// legacy /api/search?folder=sharedwithme (unaffected by that backend exclusion, since it's a
+// separate implementation) purely as a signal for where to inject ghost ancestors at the root.
+//
+// Ghost ancestor UID -> its already-resolved real children, so that expanding a ghost node in
+// the tree serves these instead of hitting listFolders/listDashboards's normal search path,
+// which would come back empty (the caller has no access to the ghost itself).
+const ghostChildrenByUID = new Map<string, DashboardViewItem[]>();
+const ghostFolderUIDs = new Set<string>();
+
+export function isGhostAncestorFolder(uid: string): boolean {
+  return ghostFolderUIDs.has(uid);
+}
+
+function getGhostChildren(parentUID: string, kind: DashboardViewItem['kind']): DashboardViewItem[] {
+  return (ghostChildrenByUID.get(parentUID) ?? []).filter((item) => item.kind === kind);
+}
+
+interface RawOrphan {
+  uid: string;
+  title: string;
+  url?: string;
+  kind: 'folder' | 'dashboard';
+  // Immediate (real) parent UID, per the legacy search response -- the folder the item lives in
+  // that the caller can't directly read.
+  folderUid: string;
+}
+
+async function fetchRawOrphans(): Promise<RawOrphan[]> {
+  const rows = await getBackendSrv().get<
+    Array<{ uid: string; title: string; type: string; url?: string; folderUid?: string }>
+  >('/api/search', { folder: 'sharedwithme' });
+
+  return rows
+    .filter((row): row is typeof row & { folderUid: string } => Boolean(row.folderUid))
+    .map((row) => ({
+      uid: row.uid,
+      title: row.title,
+      url: row.url,
+      kind: row.type === 'dash-folder' ? ('folder' as const) : ('dashboard' as const),
+      folderUid: row.folderUid,
+    }));
+}
+
+interface FolderInfo {
+  name: string;
+  title: string;
+  parent?: string;
+  detached?: boolean;
+}
+
+async function getFolderParents(uid: string): Promise<FolderInfo[]> {
+  const namespace = getAPINamespace();
+  const resp = await getBackendSrv().get<{ items?: FolderInfo[] }>(
+    `/apis/folder.grafana.app/v1beta1/namespaces/${namespace}/folders/${uid}/parents`
+  );
+  return resp.items ?? [];
+}
+
+// Resolves the ancestor chain for every distinct orphan, builds the ghost + real nodes along the
+// way (deduped, since multiple orphans can share ancestors), and returns only the root-level ones
+// -- deeper levels are served later via getGhostChildren() as the tree expands.
+async function fetchGhostAncestorItems(): Promise<NestedFolderDTO[]> {
+  ghostChildrenByUID.clear();
+  ghostFolderUIDs.clear();
+
+  const orphans = await fetchRawOrphans();
+  if (orphans.length === 0) {
+    return [];
+  }
+
+  const nodesByUID = new Map<string, DashboardViewItem>();
+
+  // Folder-kind orphans are themselves directly accessible (that's exactly why they're orphans:
+  // the folder itself is readable, its parent isn't) -- /parents on the orphan's OWN uid works,
+  // and the endpoint does the privileged walk for anything inaccessible above it. Calling
+  // /parents on orphan.folderUid instead (the inaccessible parent) would 403, since that
+  // subresource still requires "get" on whatever uid is in the URL.
+  for (const orphan of orphans) {
+    if (orphan.kind !== 'folder' || nodesByUID.has(orphan.uid)) {
+      continue;
+    }
+
+    let chain: FolderInfo[];
+    try {
+      chain = await getFolderParents(orphan.uid);
+    } catch (error) {
+      // Can't resolve this chain (e.g. a genuine cycle, or the privileged read itself failed) --
+      // leave this orphan unplaced rather than guessing at a position for it.
+      console.error(`Failed to resolve ghost ancestor chain for ${orphan.uid}`, error);
+      continue;
+    }
+
+    let prevUID: string | undefined = undefined;
+    for (const node of chain) {
+      if (!nodesByUID.has(node.name)) {
+        const isGhost = Boolean(node.detached);
+        if (isGhost) {
+          ghostFolderUIDs.add(node.name);
+        }
+        nodesByUID.set(node.name, {
+          kind: 'folder',
+          uid: node.name,
+          title: node.title,
+          parentUID: prevUID,
+          url: isGhost ? undefined : getFolderURL(node.name),
+        });
+      }
+      prevUID = node.name;
+    }
+  }
+
+  // Dashboard-kind orphans have no /parents of their own (only folders do), and their immediate
+  // parent is by definition inaccessible to the caller directly -- so they can only be placed if
+  // a folder-kind sibling under that same parent already resolved it above.
+  for (const orphan of orphans) {
+    if (orphan.kind !== 'dashboard' || !nodesByUID.has(orphan.folderUid)) {
+      continue;
+    }
+    nodesByUID.set(orphan.uid, {
+      kind: 'dashboard',
+      uid: orphan.uid,
+      title: orphan.title,
+      parentUID: orphan.folderUid,
+      url: orphan.url,
+    });
+  }
+
+  for (const node of nodesByUID.values()) {
+    if (node.parentUID !== undefined) {
+      const siblings = ghostChildrenByUID.get(node.parentUID) ?? [];
+      siblings.push(node);
+      ghostChildrenByUID.set(node.parentUID, siblings);
+    }
+  }
+
+  return Array.from(nodesByUID.values())
+    .filter((node) => node.parentUID === undefined)
+    .map((node) => ({ uid: node.uid, title: node.title }));
 }
 
 const virtualFolderBase = {
@@ -108,6 +256,13 @@ export async function listFolders(
   page = 1,
   pageSize = PAGE_SIZE
 ): Promise<DashboardViewItem[]> {
+  // Ghost ancestors (Phase 1.5 PoC, see comment above fetchGhostAncestorItems) have no real
+  // backing folder object the caller can query -- serve their already-resolved children instead
+  // of hitting the search API, which would come back empty.
+  if (parentUID !== undefined && isGhostAncestorFolder(parentUID)) {
+    return getGhostChildren(parentUID, 'folder');
+  }
+
   let folders: NestedFolderDTO[] = [];
   if (contextSrv.hasPermission(AccessControlAction.FoldersRead)) {
     if (config.featureToggles.foldersAppPlatformAPI) {
@@ -117,8 +272,13 @@ export async function listFolders(
     }
   }
 
+  if (parentUID === undefined && page === 1 && config.featureToggles['authz.folderPathVisibility']) {
+    folders = folders.concat(await listSafeGhosts(fetchGhostAncestorItems));
+  }
+
   return folders.map(({ uid, title, managedBy }) => {
-    const noUrl = isSharedWithMe(uid) || isVirtualTeamFolder(uid) || isVirtualStarredFolder(uid);
+    const noUrl =
+      isSharedWithMe(uid) || isVirtualTeamFolder(uid) || isVirtualStarredFolder(uid) || isGhostAncestorFolder(uid);
     return {
       kind: 'folder',
       uid,
@@ -134,7 +294,20 @@ export async function listFolders(
   });
 }
 
+async function listSafeGhosts(load: () => Promise<NestedFolderDTO[]>): Promise<NestedFolderDTO[]> {
+  try {
+    return await load();
+  } catch (error) {
+    console.error('Failed to load ghost ancestor folders', error);
+    return [];
+  }
+}
+
 export async function listDashboards(parentUID?: string, page = 1, pageSize = PAGE_SIZE): Promise<DashboardViewItem[]> {
+  if (parentUID !== undefined && isGhostAncestorFolder(parentUID)) {
+    return getGhostChildren(parentUID, 'dashboard');
+  }
+
   const searcher = getGrafanaSearcher();
 
   const dashboardsResults = await searcher.search({


### PR DESCRIPTION
This is a PoC for EPIC: https://github.com/grafana/identity-access-team/issues/2285
It was tested on plaent scale: https://github.com/grafana/grafana-iam-planetscale-local-test-env/pull/21

It serves 2 goals:
- validate that the new approach could work 
- test it before implementing the chunks

**Special notes for your reviewer:**
- tested it locally with planetsace (see the cfg above)
- created a google1 user with None role
- created with admin few dash and folders: 
<img width="766" height="748" alt="image" src="https://github.com/user-attachments/assets/5619314d-6515-4dd3-a59b-69aeecdb1638" />
- gave google1 the permission only for (via curl)
```
curl -s -u admin:admin -X POST \
  -H "Content-Type: application/json" \
  -d '{
    "metadata": {"name": "self-read-kek"},
    "spec": {
      "title": "folder self-read PoC",
      "description": "folders.self:read on kek for identity-access-team#2285 testing",
      "group": "custom",
      "permissions": [
        {"action": "folders.self:read", "scope": "folders:uid:dfqxg203vlz40b"}
      ]
    }
  }' \
  "http://localhost:3001/apis/iam.grafana.app/v0alpha1/namespaces/default/roles"
```

```
curl -s -u admin:admin -X POST \
  -H "Content-Type: application/json" \
  -d '{
    "metadata": {"name": "user-bfudocs71y96ob"},
    "spec": {
      "subject": {"kind": "User", "name": "bfudocs71y96ob"},
      "roleRefs": [{"kind": "Role", "name": "self-read-kek"}]
    }
  }' \
  "http://localhost:3001/apis/iam.grafana.app/v0alpha1/namespaces/default/rolebindings"
```

```
# 3a. New Role for Kek Child
curl -s -u admin:admin -X POST \
  -H "Content-Type: application/json" \
  -d '{
    "metadata": {"name": "self-read-kek-child"},
    "spec": {
      "title": "folder self-read PoC - Kek Child",
      "description": "folders.self:read on Kek Child for identity-access-team#2285 testing",
      "group": "custom",
      "permissions": [
        {"action": "folders.self:read", "scope": "folders:uid:cfudmmb5r35z4b"}
      ]
    }
  }' \
  "http://localhost:3001/apis/iam.grafana.app/v0alpha1/namespaces/default/roles"

# 3b. Fetch current RoleBinding to get its resourceVersion (required for the update)
curl -s -u admin:admin \
  "http://localhost:3001/apis/iam.grafana.app/v0alpha1/namespaces/default/rolebindings/user-bfudocs71y96ob"

# 3c. PUT it back with both roleRefs (paste the resourceVersion from 3b)
curl -s -u admin:admin -X PUT \
  -H "Content-Type: application/json" \
  -d '{
    "metadata": {
      "name": "user-bfudocs71y96ob",
      "resourceVersion": "PASTE_RESOURCE_VERSION_HERE"
    },
    "spec": {
      "subject": {"kind": "User", "name": "bfudocs71y96ob"},
      "roleRefs": [
        {"kind": "Role", "name": "self-read-kek"},
        {"kind": "Role", "name": "self-read-kek-child"}
      ]
    }
  }' \
  "http://localhost:3001/apis/iam.grafana.app/v0alpha1/namespaces/default/rolebindings/user-bfudocs71y96ob"
```

```
# 3a. New Role for Kek Child
curl -s -u admin:admin -X POST \
  -H "Content-Type: application/json" \
  -d '{
    "metadata": {"name": "self-read-kek-child"},
    "spec": {
      "title": "folder self-read PoC - Kek Child",
      "description": "folders.self:read on Kek Child for identity-access-team#2285 testing",
      "group": "custom",
      "permissions": [
        {"action": "folders.self:read", "scope": "folders:uid:cfudmmb5r35z4b"}
      ]
    }
  }' \
  "http://localhost:3001/apis/iam.grafana.app/v0alpha1/namespaces/default/roles"

# 3b. Fetch current RoleBinding to get its resourceVersion (required for the update)
curl -s -u admin:admin \
  "http://localhost:3001/apis/iam.grafana.app/v0alpha1/namespaces/default/rolebindings/user-bfudocs71y96ob"

# 3c. PUT it back with both roleRefs (paste the resourceVersion from 3b)
curl -s -u admin:admin -X PUT \
  -H "Content-Type: application/json" \
  -d '{
    "metadata": {
      "name": "user-bfudocs71y96ob",
      "resourceVersion": "PASTE_RESOURCE_VERSION_HERE"
    },
    "spec": {
      "subject": {"kind": "User", "name": "bfudocs71y96ob"},
      "roleRefs": [
        {"kind": "Role", "name": "self-read-kek"},
        {"kind": "Role", "name": "self-read-kek-child"}
      ]
    }
  }' \
  "http://localhost:3001/apis/iam.grafana.app/v0alpha1/namespaces/default/rolebindings/user-bfudocs71y96ob"
```

- what the google1 is seesing: 
<img width="740" height="576" alt="image" src="https://github.com/user-attachments/assets/99daee42-2852-4b08-9916-0ccf3f02f24e" />


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
