### PR TITLE
SSO: back the SSOSetting kind with an MT-Settings store

### DIFF
--- a/pkg/registry/apis/iam/authorizer.go
+++ b/pkg/registry/apis/iam/authorizer.go
@@ -8,9 +8,9 @@ import (
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 
 	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
-	legacyiamv0 "github.com/grafana/grafana/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	legacyiamv0 "github.com/grafana/grafana/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/display"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/legacy"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"

--- a/pkg/registry/apis/iam/authorizer.go
+++ b/pkg/registry/apis/iam/authorizer.go
@@ -82,10 +82,14 @@ func newIAMAuthorizer(
 	// registered. Interim: allow authenticated identities; real settings:write
 	// RBAC is a follow-up (tracked with the SSO settings migration).
 	resourceAuthorizer[legacyiamv0.SSOSettingResourceInfo.GetName()] = authorizer.AuthorizerFunc(func(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
-		if _, ok := authlib.AuthInfoFrom(ctx); ok {
-			return authorizer.DecisionAllow, "", nil
+		requester, err := identity.GetRequester(ctx)
+		if err != nil || requester == nil {
+			return authorizer.DecisionDeny, "cannot access ssosettings without an identity", nil
 		}
-		return authorizer.DecisionDeny, "cannot access ssosettings without an identity", nil
+		if requester.IsIdentityType(authlib.TypeAnonymous) {
+			return authorizer.DecisionDeny, "anonymous identities cannot access ssosettings", nil
+		}
+		return authorizer.DecisionAllow, "", nil
 	})
 	resourceAuthorizer["searchUsers"] = serviceAuthorizer
 	resourceAuthorizer["searchTeams"] = serviceAuthorizer

--- a/pkg/registry/apis/iam/authorizer.go
+++ b/pkg/registry/apis/iam/authorizer.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 
 	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
+	legacyiamv0 "github.com/grafana/grafana/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/display"
@@ -77,6 +78,15 @@ func newIAMAuthorizer(
 	resourceAuthorizer[iamv0.ServiceAccountResourceInfo.GetName()] = newServiceAccountAuthorizer(accessClient)
 	resourceAuthorizer[iamv0.UserResourceInfo.GetName()] = newUserAuthorizer(accessClient)
 	resourceAuthorizer[iamv0.TeamResourceInfo.GetName()] = newTeamAuthorizer(accessClient)
+	// The SSOSetting kind had no k8s-API consumers, so no authorizer was ever
+	// registered. Interim: allow authenticated identities; real settings:write
+	// RBAC is a follow-up (tracked with the SSO settings migration).
+	resourceAuthorizer[legacyiamv0.SSOSettingResourceInfo.GetName()] = authorizer.AuthorizerFunc(func(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+		if _, ok := authlib.AuthInfoFrom(ctx); ok {
+			return authorizer.DecisionAllow, "", nil
+		}
+		return authorizer.DecisionDeny, "cannot access ssosettings without an identity", nil
+	})
 	resourceAuthorizer["searchUsers"] = serviceAuthorizer
 	resourceAuthorizer["searchTeams"] = serviceAuthorizer
 	// TODO: Implement fine-grained authorization for external group mapping search on the search level

--- a/pkg/registry/apis/iam/models.go
+++ b/pkg/registry/apis/iam/models.go
@@ -113,6 +113,10 @@ type IdentityAccessManagementAPIBuilder struct {
 
 	cfgProvider    configprovider.ConfigProvider
 	settingService settingsvc.Service
+	// ssoSettingsClient backs the SSOSetting kind's MTSettingsStore (reads +
+	// writes to setting.grafana.app). Built in RegisterAPIService when the
+	// kind's storage mode engages MT-Settings.
+	ssoSettingsClient settingsvc.Service
 
 	// ofClient evaluates the feature flags gating the IAM APIs. The default
 	// client resolves the globally-registered provider at evaluation time.

--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -130,9 +130,15 @@ func RegisterAPIService(
 	// Mode lever for the SSO settings migration: any configured storage mode
 	// above 0 hands the SSOSetting kind to the MT-Settings store.
 	ssoUseMTSettings := false
+	var ssoSettingsClient settingsvc.Service
 	if cfg != nil {
 		if resCfg, ok := cfg.UnifiedStorage[legacyiamv0.SSOSettingResourceInfo.GroupResource().String()]; ok && resCfg.DualWriterMode > grafanarest.Mode0 {
 			ssoUseMTSettings = true
+			c, err := sso.NewSettingsClient(cfg)
+			if err != nil {
+				log.New("iam.apis").Error("failed to build MT-Settings client for SSOSetting store", "error", err)
+			}
+			ssoSettingsClient = c
 		}
 	}
 
@@ -145,6 +151,7 @@ func RegisterAPIService(
 		teamBindingLegacyStore:            teambinding.NewLegacyBindingStore(store, tracing),
 		ssoLegacyStore:                    sso.NewLegacyStore(ssoService, tracing),
 		ssoUseMTSettings:                  ssoUseMTSettings,
+		ssoSettingsClient:                 ssoSettingsClient,
 		roleApiInstaller:                  roleApiInstaller,
 		globalRoleApiInstaller:            globalRoleApiInstaller,
 		teamLBACApiInstaller:              teamLBACApiInstaller,
@@ -443,14 +450,15 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *ge
 	// SSO settings apis
 	if enableSsoSettingsApi && b.ssoLegacyStore != nil {
 		ssoResource := legacyiamv0.SSOSettingResourceInfo
-		// The storage mode of [unified_storage.ssosettings.iam.grafana.app]
-		// decides which store serves the kind: at mode 0 (the default) the
-		// legacy store behaves as before; any higher mode engages the
-		// MT-Settings store, which fails loudly until it is implemented.
-		// The standard dual-writer cannot wrap this kind yet: it requires
-		// rest.CreaterUpdater and SSO settings are update-only.
+		// The [unified_storage.ssosettings.iam.grafana.app] storage mode decides
+		// which store serves the kind: mode 0 (default) keeps the legacy store;
+		// any higher mode engages the MT-Settings store.
 		if b.ssoUseMTSettings {
-			storage[ssoResource.StoragePath()] = sso.NewMTSettingsStore()
+			var writer settingsvc.Writer
+			if b.ssoSettingsClient != nil {
+				writer, _ = b.ssoSettingsClient.(settingsvc.Writer)
+			}
+			storage[ssoResource.StoragePath()] = sso.NewMTSettingsStore(b.ssoSettingsClient, writer)
 		} else {
 			storage[ssoResource.StoragePath()] = b.ssoLegacyStore
 		}

--- a/pkg/registry/apis/iam/sso/mtsettings_store.go
+++ b/pkg/registry/apis/iam/sso/mtsettings_store.go
@@ -2,13 +2,22 @@ package sso
 
 import (
 	"context"
+	"fmt"
+	"hash/fnv"
 	"net/http"
+	"sort"
+	"strconv"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
+
+	common "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
+	iamv0 "github.com/grafana/grafana/pkg/apis/iam/v0alpha1"
+	settingsvc "github.com/grafana/grafana/pkg/services/setting"
 )
 
 var (
@@ -16,19 +25,22 @@ var (
 	_ rest.Scoper               = (*MTSettingsStore)(nil)
 	_ rest.Getter               = (*MTSettingsStore)(nil)
 	_ rest.Lister               = (*MTSettingsStore)(nil)
+	_ rest.Creater              = (*MTSettingsStore)(nil)
 	_ rest.Updater              = (*MTSettingsStore)(nil)
 	_ rest.SingularNameProvider = (*MTSettingsStore)(nil)
 	_ rest.GracefulDeleter      = (*MTSettingsStore)(nil)
 )
 
-// MTSettingsStore is the MT-Settings-backed storage for the SSOSetting kind
-// and the "unified" side of the resource's dual-writer. At storage mode 0 the
-// dual-writer serves the legacy store and this one is never reached; at any
-// higher mode it fails loudly until the MT-Settings pipes are implemented.
-type MTSettingsStore struct{}
+// MTSettingsStore backs the SSOSetting kind with MT-Settings: a provider's blob
+// maps to per-key Setting rows under the auth.<provider> section. Source-layer
+// precedence and secret encrypt/decrypt are handled server-side.
+type MTSettingsStore struct {
+	reader settingsvc.Service
+	writer settingsvc.Writer
+}
 
-func NewMTSettingsStore() *MTSettingsStore {
-	return &MTSettingsStore{}
+func NewMTSettingsStore(reader settingsvc.Service, writer settingsvc.Writer) *MTSettingsStore {
+	return &MTSettingsStore{reader: reader, writer: writer}
 }
 
 // Destroy implements rest.Storage.
@@ -59,9 +71,51 @@ func (s *MTSettingsStore) ConvertToTable(ctx context.Context, object runtime.Obj
 	return resource.TableConverter().ConvertToTable(ctx, object, tableOptions)
 }
 
-// Get implements rest.Getter.
-func (s *MTSettingsStore) Get(_ context.Context, name string, _ *metav1.GetOptions) (runtime.Object, error) {
-	return nil, s.notImplemented("get", name)
+// Get reassembles the provider's SSOSetting from its (source-resolved) rows.
+func (s *MTSettingsStore) Get(ctx context.Context, name string, _ *metav1.GetOptions) (runtime.Object, error) {
+	if s.reader == nil {
+		return nil, s.notImplemented("get", name)
+	}
+	rows, err := s.reader.List(ctx, sectionSelector(name))
+	if err != nil {
+		return nil, apierrors.NewInternalError(err)
+	}
+	if len(rows) == 0 {
+		return nil, resource.NewNotFound(name)
+	}
+	return rowsToSSOSetting(ctx, name, rows), nil
+}
+
+// Create implements rest.Creater. It writes each key of the blob as a per-key
+// row under auth.<provider>. Secret classification/encryption is the settings
+// service mutator's job.
+func (s *MTSettingsStore) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, _ *metav1.CreateOptions) (runtime.Object, error) {
+	if s.writer == nil {
+		return nil, s.notImplemented("create", "")
+	}
+	ssoSetting, ok := obj.(*iamv0.SSOSetting)
+	if !ok {
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected an SSOSetting object, got %T", obj))
+	}
+	if createValidation != nil {
+		if err := createValidation(ctx, obj); err != nil {
+			return nil, err
+		}
+	}
+
+	section := sectionFor(ssoSetting.Name)
+	desired := ssoSetting.Spec.Settings.UnstructuredContent()
+	for key, val := range desired {
+		if err := s.writer.Upsert(ctx, &settingsvc.Setting{Section: section, Key: key, Value: valueToString(val)}); err != nil {
+			return nil, apierrors.NewInternalError(err)
+		}
+	}
+
+	out := ssoSetting.DeepCopy()
+	out.TypeMeta = ssoTypeMeta()
+	out.Namespace = genericapirequest.NamespaceValue(ctx)
+	out.ResourceVersion = coarseResourceVersion(desired)
+	return out, nil
 }
 
 // List implements rest.Lister.
@@ -69,17 +123,183 @@ func (s *MTSettingsStore) List(_ context.Context, _ *internalversion.ListOptions
 	return nil, s.notImplemented("list", "")
 }
 
-// Update implements rest.Updater.
-func (s *MTSettingsStore) Update(_ context.Context, name string, _ rest.UpdatedObjectInfo, _ rest.ValidateObjectFunc, _ rest.ValidateObjectUpdateFunc, _ bool, _ *metav1.UpdateOptions) (runtime.Object, bool, error) {
-	return nil, false, s.notImplemented("update", name)
+// Update implements rest.Updater with the desired-state reconcile: upsert every
+// desired key FIRST, then delete stale us-layer rows LAST, failing loud on any
+// error. Ordering guarantees a required value is never absent (worst case is a
+// recoverable duplicate), and re-applying the same blob converges. Validation
+// (e.g. "exactly one" mutually-exclusive variant) is enforced upstream, not here.
+func (s *MTSettingsStore) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, _ *metav1.UpdateOptions) (runtime.Object, bool, error) {
+	if s.reader == nil || s.writer == nil {
+		return nil, false, s.notImplemented("update", name)
+	}
+
+	var oldObj runtime.Object
+	current, err := s.Get(ctx, name, &metav1.GetOptions{})
+	switch {
+	case err == nil:
+		oldObj = current
+	case apierrors.IsNotFound(err) && !forceAllowCreate:
+		return nil, false, err
+	case apierrors.IsNotFound(err):
+		// create-on-update: oldObj stays nil
+	default:
+		return nil, false, err
+	}
+
+	newObj, err := objInfo.UpdatedObject(ctx, oldObj)
+	if err != nil {
+		return nil, false, err
+	}
+	ssoSetting, ok := newObj.(*iamv0.SSOSetting)
+	if !ok {
+		return nil, false, apierrors.NewBadRequest(fmt.Sprintf("expected an SSOSetting object, got %T", newObj))
+	}
+
+	created := oldObj == nil
+	if created {
+		if createValidation != nil {
+			if err := createValidation(ctx, newObj); err != nil {
+				return nil, false, err
+			}
+		}
+	} else if updateValidation != nil {
+		if err := updateValidation(ctx, newObj, oldObj); err != nil {
+			return nil, false, err
+		}
+	}
+
+	section := sectionFor(name)
+	desired := ssoSetting.Spec.Settings.UnstructuredContent()
+
+	// Upsert every desired key first — a required value is never removed before
+	// its replacement is durable.
+	for key, val := range desired {
+		if err := s.writer.Upsert(ctx, &settingsvc.Setting{Section: section, Key: key, Value: valueToString(val)}); err != nil {
+			return nil, false, apierrors.NewInternalError(err)
+		}
+	}
+
+	// Prune stale us-layer rows last: any us row whose key is not in the desired
+	// blob. defaults/hgapi layers are not ours to touch.
+	existing, err := s.reader.List(ctx, sectionSelector(name))
+	if err != nil {
+		return nil, false, apierrors.NewInternalError(err)
+	}
+	for _, row := range existing {
+		if row.Labels["source"] != "us" {
+			continue
+		}
+		if _, keep := desired[row.Key]; !keep {
+			if err := s.writer.Delete(ctx, section, row.Key); err != nil {
+				return nil, false, apierrors.NewInternalError(err)
+			}
+		}
+	}
+
+	out := ssoSetting.DeepCopy()
+	out.TypeMeta = ssoTypeMeta()
+	out.Namespace = genericapirequest.NamespaceValue(ctx)
+	out.ResourceVersion = coarseResourceVersion(desired)
+	return out, created, nil
 }
 
-// Delete implements rest.GracefulDeleter.
-func (s *MTSettingsStore) Delete(_ context.Context, name string, _ rest.ValidateObjectFunc, _ *metav1.DeleteOptions) (runtime.Object, bool, error) {
-	return nil, false, s.notImplemented("delete", name)
+// Delete implements rest.GracefulDeleter. It removes the provider's us-layer
+// rows (defaults/hgapi remain server-side); the provider then resolves to its
+// system defaults.
+func (s *MTSettingsStore) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, _ *metav1.DeleteOptions) (runtime.Object, bool, error) {
+	if s.reader == nil || s.writer == nil {
+		return nil, false, s.notImplemented("delete", name)
+	}
+	current, err := s.Get(ctx, name, &metav1.GetOptions{})
+	if err != nil {
+		return nil, false, err
+	}
+	if deleteValidation != nil {
+		if err := deleteValidation(ctx, current); err != nil {
+			return nil, false, err
+		}
+	}
+
+	rows, err := s.reader.List(ctx, sectionSelector(name))
+	if err != nil {
+		return nil, false, apierrors.NewInternalError(err)
+	}
+	section := sectionFor(name)
+	for _, row := range rows {
+		if row.Labels["source"] != "us" {
+			continue
+		}
+		if err := s.writer.Delete(ctx, section, row.Key); err != nil {
+			return nil, false, apierrors.NewInternalError(err)
+		}
+	}
+	return current, true, nil
 }
 
 func (s *MTSettingsStore) notImplemented(verb string, name string) error {
 	return apierrors.NewGenericServerResponse(http.StatusNotImplemented, verb, resource.GroupResource(), name,
 		"MT-Settings storage for SSO settings is not implemented yet", 0, false)
+}
+
+// sectionFor returns the settings section for a provider (e.g. saml -> auth.saml).
+func sectionFor(provider string) string { return "auth." + provider }
+
+func sectionSelector(provider string) metav1.LabelSelector {
+	return metav1.LabelSelector{MatchLabels: map[string]string{"section": sectionFor(provider)}}
+}
+
+func ssoTypeMeta() metav1.TypeMeta {
+	return metav1.TypeMeta{Kind: "SSOSetting", APIVersion: resource.GroupVersion().String()}
+}
+
+// rowsToSSOSetting assembles a provider's rows into an SSOSetting blob. The rows
+// are already source-resolved by the settings service; source=us on any row
+// means the provider carries an admin override (db), otherwise it is system.
+func rowsToSSOSetting(ctx context.Context, provider string, rows []*settingsvc.Setting) *iamv0.SSOSetting {
+	settings := make(map[string]any, len(rows))
+	source := iamv0.SourceSystem
+	for _, r := range rows {
+		settings[r.Key] = r.Value
+		if r.Labels["source"] == "us" {
+			source = iamv0.SourceDB
+		}
+	}
+	return &iamv0.SSOSetting{
+		TypeMeta: ssoTypeMeta(),
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            provider,
+			Namespace:       genericapirequest.NamespaceValue(ctx),
+			ResourceVersion: coarseResourceVersion(settings),
+		},
+		Spec: iamv0.SSOSettingSpec{
+			Source:   source,
+			Settings: common.Unstructured{Object: settings},
+		},
+	}
+}
+
+// coarseResourceVersion derives a content-hash resourceVersion. SSO settings use
+// last-write-wins (no strict multi-row concurrency), so this is for protocol
+// compliance and change detection, not conflict enforcement.
+func coarseResourceVersion(settings map[string]any) string {
+	keys := make([]string, 0, len(settings))
+	for k := range settings {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	h := fnv.New64a()
+	for _, k := range keys {
+		_, _ = fmt.Fprintf(h, "%s=%v\n", k, settings[k])
+	}
+	return strconv.FormatUint(h.Sum64(), 10)
+}
+
+func valueToString(v any) string {
+	if v == nil {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return fmt.Sprintf("%v", v)
 }

--- a/pkg/registry/apis/iam/sso/mtsettings_store.go
+++ b/pkg/registry/apis/iam/sso/mtsettings_store.go
@@ -90,7 +90,7 @@ func (s *MTSettingsStore) Get(ctx context.Context, name string, _ *metav1.GetOpt
 // row under auth.<provider>. Secret classification/encryption is the settings
 // service mutator's job.
 func (s *MTSettingsStore) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, _ *metav1.CreateOptions) (runtime.Object, error) {
-	if s.writer == nil {
+	if s.reader == nil || s.writer == nil {
 		return nil, s.notImplemented("create", "")
 	}
 	ssoSetting, ok := obj.(*iamv0.SSOSetting)
@@ -111,11 +111,9 @@ func (s *MTSettingsStore) Create(ctx context.Context, obj runtime.Object, create
 		}
 	}
 
-	out := ssoSetting.DeepCopy()
-	out.TypeMeta = ssoTypeMeta()
-	out.Namespace = genericapirequest.NamespaceValue(ctx)
-	out.ResourceVersion = coarseResourceVersion(desired)
-	return out, nil
+	// Re-read so the response is the stored projection, not an echo of the
+	// request (which omits default-layer keys and never sets Spec.Source).
+	return s.Get(ctx, ssoSetting.Name, &metav1.GetOptions{})
 }
 
 // List implements rest.Lister.
@@ -196,11 +194,8 @@ func (s *MTSettingsStore) Update(ctx context.Context, name string, objInfo rest.
 		}
 	}
 
-	out := ssoSetting.DeepCopy()
-	out.TypeMeta = ssoTypeMeta()
-	out.Namespace = genericapirequest.NamespaceValue(ctx)
-	out.ResourceVersion = coarseResourceVersion(desired)
-	return out, created, nil
+	updated, err := s.Get(ctx, name, &metav1.GetOptions{})
+	return updated, created, err
 }
 
 // Delete implements rest.GracefulDeleter. It removes the provider's us-layer
@@ -233,6 +228,10 @@ func (s *MTSettingsStore) Delete(ctx context.Context, name string, deleteValidat
 			return nil, false, apierrors.NewInternalError(err)
 		}
 	}
+	// NOTE: returns the pre-delete object. Removing the us override leaves any
+	// defaults/hgapi rows, so the provider does not truly vanish; the accurate
+	// post-delete semantics are mode-dependent (which store is read-authoritative)
+	// and are settled in the migration's later choreography stage.
 	return current, true, nil
 }
 

--- a/pkg/registry/apis/iam/sso/mtsettings_store_test.go
+++ b/pkg/registry/apis/iam/sso/mtsettings_store_test.go
@@ -18,35 +18,65 @@ import (
 	settingsvc "github.com/grafana/grafana/pkg/services/setting"
 )
 
-// fakeReader embeds Service so only List needs an implementation; the store
-// never exercises the other methods.
-type fakeReader struct {
+// fakeSettings is a stateful in-memory MT-Settings double implementing both the
+// reader (List) and writer (Upsert/Delete) surfaces. Writes mutate the us layer
+// and List returns it merged with the immutable seeded layers (defaults/hgapi),
+// so a re-read after a write observes that write — which the store's responses
+// now rely on.
+type fakeSettings struct {
 	settingsvc.Service
-	rows []*settingsvc.Setting
+	us       map[string]*settingsvc.Setting // section|key -> us row
+	seeded   []*settingsvc.Setting          // immutable non-us rows
+	upserts  map[string]string              // key -> value, for write assertions
+	sections map[string]string              // key -> section, for write assertions
+	deleted  []string                       // deleted keys, in call order
 }
 
-func (f *fakeReader) List(context.Context, metav1.LabelSelector) ([]*settingsvc.Setting, error) {
-	return f.rows, nil
+func newFakeSettings(seed []*settingsvc.Setting) *fakeSettings {
+	f := &fakeSettings{
+		us:       map[string]*settingsvc.Setting{},
+		upserts:  map[string]string{},
+		sections: map[string]string{},
+	}
+	for _, r := range seed {
+		if r.Labels["source"] == "us" {
+			f.us[r.Section+"|"+r.Key] = r
+		} else {
+			f.seeded = append(f.seeded, r)
+		}
+	}
+	return f
 }
 
-type fakeWriter struct {
-	upserts  map[string]string // key -> value
-	sections map[string]string // key -> section
-	deleted  []string          // deleted keys, in call order
+func (f *fakeSettings) List(_ context.Context, sel metav1.LabelSelector) ([]*settingsvc.Setting, error) {
+	section := sel.MatchLabels["section"]
+	var out []*settingsvc.Setting
+	for _, r := range f.seeded {
+		if r.Section == section {
+			out = append(out, r)
+		}
+	}
+	for _, r := range f.us {
+		if r.Section == section {
+			out = append(out, r)
+		}
+	}
+	return out, nil
 }
 
-func newFakeWriter() *fakeWriter {
-	return &fakeWriter{upserts: map[string]string{}, sections: map[string]string{}}
-}
-
-func (f *fakeWriter) Upsert(_ context.Context, s *settingsvc.Setting) error {
+func (f *fakeSettings) Upsert(_ context.Context, s *settingsvc.Setting) error {
 	f.upserts[s.Key] = s.Value
 	f.sections[s.Key] = s.Section
+	f.us[s.Section+"|"+s.Key] = &settingsvc.Setting{
+		Section: s.Section, Key: s.Key, Value: s.Value,
+		Labels: map[string]string{"source": "us"},
+	}
 	return nil
 }
 
-func (f *fakeWriter) Delete(_ context.Context, _, key string) error {
+func (f *fakeSettings) Delete(_ context.Context, section, key string) error {
 	f.deleted = append(f.deleted, key)
+	delete(f.us, section+"|"+key)
 	return nil
 }
 
@@ -72,15 +102,18 @@ func defaultRow(section, key, value string) *settingsvc.Setting {
 func TestMTSettingsStore(t *testing.T) {
 	tests := []struct {
 		name   string
-		rows   []*settingsvc.Setting // seeds the reader
+		rows   []*settingsvc.Setting // seeds the store
 		op     func(s *MTSettingsStore) (runtime.Object, bool, error)
-		assert func(t *testing.T, sso *iamv0.SSOSetting, ok bool, err error, w *fakeWriter)
+		assert func(t *testing.T, sso *iamv0.SSOSetting, ok bool, err error, f *fakeSettings)
 	}{
 		{
 			name: "Get assembles rows into a blob; source=db when a us row is present",
 			rows: []*settingsvc.Setting{usRow("auth.saml", "enabled", "true"), defaultRow("auth.saml", "name", "SAML")},
-			op:   func(s *MTSettingsStore) (runtime.Object, bool, error) { o, e := s.Get(nsCtx(), "saml", &metav1.GetOptions{}); return o, false, e },
-			assert: func(t *testing.T, sso *iamv0.SSOSetting, _ bool, err error, _ *fakeWriter) {
+			op: func(s *MTSettingsStore) (runtime.Object, bool, error) {
+				o, e := s.Get(nsCtx(), "saml", &metav1.GetOptions{})
+				return o, false, e
+			},
+			assert: func(t *testing.T, sso *iamv0.SSOSetting, _ bool, err error, _ *fakeSettings) {
 				require.NoError(t, err)
 				require.NotNil(t, sso)
 				assert.Equal(t, "saml", sso.Name)
@@ -92,8 +125,11 @@ func TestMTSettingsStore(t *testing.T) {
 		{
 			name: "Get returns source=system when no us row is present",
 			rows: []*settingsvc.Setting{defaultRow("auth.saml", "name", "SAML")},
-			op:   func(s *MTSettingsStore) (runtime.Object, bool, error) { o, e := s.Get(nsCtx(), "saml", &metav1.GetOptions{}); return o, false, e },
-			assert: func(t *testing.T, sso *iamv0.SSOSetting, _ bool, err error, _ *fakeWriter) {
+			op: func(s *MTSettingsStore) (runtime.Object, bool, error) {
+				o, e := s.Get(nsCtx(), "saml", &metav1.GetOptions{})
+				return o, false, e
+			},
+			assert: func(t *testing.T, sso *iamv0.SSOSetting, _ bool, err error, _ *fakeSettings) {
 				require.NoError(t, err)
 				require.NotNil(t, sso)
 				assert.Equal(t, iamv0.SourceSystem, sso.Spec.Source)
@@ -102,30 +138,37 @@ func TestMTSettingsStore(t *testing.T) {
 		{
 			name: "Get returns NotFound when the provider has no rows",
 			rows: nil,
-			op:   func(s *MTSettingsStore) (runtime.Object, bool, error) { o, e := s.Get(nsCtx(), "saml", &metav1.GetOptions{}); return o, false, e },
-			assert: func(t *testing.T, sso *iamv0.SSOSetting, _ bool, err error, _ *fakeWriter) {
+			op: func(s *MTSettingsStore) (runtime.Object, bool, error) {
+				o, e := s.Get(nsCtx(), "saml", &metav1.GetOptions{})
+				return o, false, e
+			},
+			assert: func(t *testing.T, sso *iamv0.SSOSetting, _ bool, err error, _ *fakeSettings) {
 				assert.True(t, apierrors.IsNotFound(err))
 				assert.Nil(t, sso)
 			},
 		},
 		{
-			name: "Create upserts every blob key under auth.<provider>",
-			rows: nil,
+			name: "Create upserts every blob key and returns the stored projection, not the request",
+			rows: []*settingsvc.Setting{defaultRow("auth.generic_oauth", "auto_login", "false")},
 			op: func(s *MTSettingsStore) (runtime.Object, bool, error) {
 				o, e := s.Create(nsCtx(), ssoObj("generic_oauth", map[string]any{"enabled": "true", "client_id": "abc"}), nil, &metav1.CreateOptions{})
 				return o, false, e
 			},
-			assert: func(t *testing.T, sso *iamv0.SSOSetting, _ bool, err error, w *fakeWriter) {
+			assert: func(t *testing.T, sso *iamv0.SSOSetting, _ bool, err error, f *fakeSettings) {
 				require.NoError(t, err)
 				require.NotNil(t, sso)
-				assert.Equal(t, map[string]string{"enabled": "true", "client_id": "abc"}, w.upserts)
-				assert.Equal(t, "auth.generic_oauth", w.sections["client_id"])
+				assert.Equal(t, map[string]string{"enabled": "true", "client_id": "abc"}, f.upserts)
+				assert.Equal(t, "auth.generic_oauth", f.sections["client_id"])
 				assert.Equal(t, "stacks-11", sso.Namespace)
 				assert.NotEmpty(t, sso.ResourceVersion)
+				// Projection, not echo: Spec.Source is resolved and the seeded
+				// default-layer key is merged in — neither is in the request.
+				assert.Equal(t, iamv0.SourceDB, sso.Spec.Source)
+				assert.Equal(t, map[string]any{"enabled": "true", "client_id": "abc", "auto_login": "false"}, sso.Spec.Settings.Object)
 			},
 		},
 		{
-			name: "Update upserts desired keys and prunes only stale unified-storage (us) rows",
+			name: "Update upserts desired keys, prunes only stale us rows, and returns the merged projection",
 			rows: []*settingsvc.Setting{
 				usRow("auth.saml", "enabled", "true"),   // kept (in desired)
 				usRow("auth.saml", "stale", "x"),        // pruned (us, not in desired)
@@ -136,13 +179,15 @@ func TestMTSettingsStore(t *testing.T) {
 					rest.DefaultUpdatedObjectInfo(ssoObj("saml", map[string]any{"enabled": "false", "new_key": "y"})),
 					nil, nil, false, &metav1.UpdateOptions{})
 			},
-			assert: func(t *testing.T, sso *iamv0.SSOSetting, created bool, err error, w *fakeWriter) {
+			assert: func(t *testing.T, sso *iamv0.SSOSetting, created bool, err error, f *fakeSettings) {
 				require.NoError(t, err)
 				require.NotNil(t, sso)
 				assert.False(t, created)
-				assert.Equal(t, map[string]string{"enabled": "false", "new_key": "y"}, w.upserts)
-				assert.Equal(t, []string{"stale"}, w.deleted)
+				assert.Equal(t, map[string]string{"enabled": "false", "new_key": "y"}, f.upserts)
+				assert.Equal(t, []string{"stale"}, f.deleted)
 				assert.Equal(t, "stacks-11", sso.Namespace)
+				assert.Equal(t, iamv0.SourceDB, sso.Spec.Source)
+				assert.Equal(t, map[string]any{"enabled": "false", "new_key": "y", "name": "SAML"}, sso.Spec.Settings.Object)
 			},
 		},
 		{
@@ -153,11 +198,12 @@ func TestMTSettingsStore(t *testing.T) {
 					rest.DefaultUpdatedObjectInfo(ssoObj("saml", map[string]any{"enabled": "true"})),
 					nil, nil, true, &metav1.UpdateOptions{})
 			},
-			assert: func(t *testing.T, sso *iamv0.SSOSetting, created bool, err error, w *fakeWriter) {
+			assert: func(t *testing.T, sso *iamv0.SSOSetting, created bool, err error, f *fakeSettings) {
 				require.NoError(t, err)
 				require.NotNil(t, sso)
 				assert.True(t, created)
-				assert.Equal(t, map[string]string{"enabled": "true"}, w.upserts)
+				assert.Equal(t, map[string]string{"enabled": "true"}, f.upserts)
+				assert.Equal(t, iamv0.SourceDB, sso.Spec.Source)
 			},
 		},
 		{
@@ -168,7 +214,7 @@ func TestMTSettingsStore(t *testing.T) {
 					rest.DefaultUpdatedObjectInfo(ssoObj("saml", map[string]any{"enabled": "true"})),
 					nil, nil, false, &metav1.UpdateOptions{})
 			},
-			assert: func(t *testing.T, sso *iamv0.SSOSetting, _ bool, err error, _ *fakeWriter) {
+			assert: func(t *testing.T, sso *iamv0.SSOSetting, _ bool, err error, _ *fakeSettings) {
 				assert.True(t, apierrors.IsNotFound(err))
 				assert.Nil(t, sso)
 			},
@@ -176,19 +222,24 @@ func TestMTSettingsStore(t *testing.T) {
 		{
 			name: "Delete removes only the unified-storage (us) rows",
 			rows: []*settingsvc.Setting{usRow("auth.saml", "enabled", "true"), defaultRow("auth.saml", "name", "SAML")},
-			op:   func(s *MTSettingsStore) (runtime.Object, bool, error) { return s.Delete(nsCtx(), "saml", nil, &metav1.DeleteOptions{}) },
-			assert: func(t *testing.T, sso *iamv0.SSOSetting, deleted bool, err error, w *fakeWriter) {
+			op: func(s *MTSettingsStore) (runtime.Object, bool, error) {
+				return s.Delete(nsCtx(), "saml", nil, &metav1.DeleteOptions{})
+			},
+			assert: func(t *testing.T, sso *iamv0.SSOSetting, deleted bool, err error, f *fakeSettings) {
 				require.NoError(t, err)
 				require.NotNil(t, sso)
 				assert.True(t, deleted)
-				assert.Equal(t, []string{"enabled"}, w.deleted)
+				assert.Equal(t, []string{"enabled"}, f.deleted)
 			},
 		},
 		{
 			name: "List is not implemented",
 			rows: nil,
-			op:   func(s *MTSettingsStore) (runtime.Object, bool, error) { o, e := s.List(nsCtx(), nil); return o, false, e },
-			assert: func(t *testing.T, sso *iamv0.SSOSetting, _ bool, err error, _ *fakeWriter) {
+			op: func(s *MTSettingsStore) (runtime.Object, bool, error) {
+				o, e := s.List(nsCtx(), nil)
+				return o, false, e
+			},
+			assert: func(t *testing.T, sso *iamv0.SSOSetting, _ bool, err error, _ *fakeSettings) {
 				require.Error(t, err)
 				status, ok := err.(apierrors.APIStatus)
 				require.True(t, ok)
@@ -200,10 +251,10 @@ func TestMTSettingsStore(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			w := newFakeWriter()
-			obj, ok, err := tc.op(NewMTSettingsStore(&fakeReader{rows: tc.rows}, w))
+			f := newFakeSettings(tc.rows)
+			obj, ok, err := tc.op(NewMTSettingsStore(f, f))
 			sso, _ := obj.(*iamv0.SSOSetting) // may be nil; each assert decides what "valid" means
-			tc.assert(t, sso, ok, err, w)
+			tc.assert(t, sso, ok, err, f)
 		})
 	}
 }

--- a/pkg/registry/apis/iam/sso/mtsettings_store_test.go
+++ b/pkg/registry/apis/iam/sso/mtsettings_store_test.go
@@ -1,0 +1,235 @@
+package sso
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
+
+	common "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
+	iamv0 "github.com/grafana/grafana/pkg/apis/iam/v0alpha1"
+	settingsvc "github.com/grafana/grafana/pkg/services/setting"
+)
+
+// fakeReader embeds Service so only List needs an implementation; the store
+// never exercises the other methods.
+type fakeReader struct {
+	settingsvc.Service
+	rows []*settingsvc.Setting
+}
+
+func (f *fakeReader) List(context.Context, metav1.LabelSelector) ([]*settingsvc.Setting, error) {
+	return f.rows, nil
+}
+
+type fakeWriter struct {
+	upserts  map[string]string // key -> value
+	sections map[string]string // key -> section
+	deleted  []string          // deleted keys, in call order
+}
+
+func newFakeWriter() *fakeWriter {
+	return &fakeWriter{upserts: map[string]string{}, sections: map[string]string{}}
+}
+
+func (f *fakeWriter) Upsert(_ context.Context, s *settingsvc.Setting) error {
+	f.upserts[s.Key] = s.Value
+	f.sections[s.Key] = s.Section
+	return nil
+}
+
+func (f *fakeWriter) Delete(_ context.Context, _, key string) error {
+	f.deleted = append(f.deleted, key)
+	return nil
+}
+
+func nsCtx() context.Context {
+	return genericapirequest.WithNamespace(context.Background(), "stacks-11")
+}
+
+func ssoObj(name string, settings map[string]any) *iamv0.SSOSetting {
+	return &iamv0.SSOSetting{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       iamv0.SSOSettingSpec{Settings: common.Unstructured{Object: settings}},
+	}
+}
+
+func usRow(section, key, value string) *settingsvc.Setting {
+	return &settingsvc.Setting{Section: section, Key: key, Value: value, Labels: map[string]string{"source": "us"}}
+}
+
+func defaultRow(section, key, value string) *settingsvc.Setting {
+	return &settingsvc.Setting{Section: section, Key: key, Value: value, Labels: map[string]string{"source": "defaults"}}
+}
+
+func TestMTSettingsStore(t *testing.T) {
+	tests := []struct {
+		name   string
+		rows   []*settingsvc.Setting // seeds the reader
+		op     func(s *MTSettingsStore) (runtime.Object, bool, error)
+		assert func(t *testing.T, sso *iamv0.SSOSetting, ok bool, err error, w *fakeWriter)
+	}{
+		{
+			name: "Get assembles rows into a blob; source=db when a us row is present",
+			rows: []*settingsvc.Setting{usRow("auth.saml", "enabled", "true"), defaultRow("auth.saml", "name", "SAML")},
+			op:   func(s *MTSettingsStore) (runtime.Object, bool, error) { o, e := s.Get(nsCtx(), "saml", &metav1.GetOptions{}); return o, false, e },
+			assert: func(t *testing.T, sso *iamv0.SSOSetting, _ bool, err error, _ *fakeWriter) {
+				require.NoError(t, err)
+				require.NotNil(t, sso)
+				assert.Equal(t, "saml", sso.Name)
+				assert.Equal(t, "stacks-11", sso.Namespace)
+				assert.Equal(t, iamv0.SourceDB, sso.Spec.Source)
+				assert.Equal(t, map[string]any{"enabled": "true", "name": "SAML"}, sso.Spec.Settings.Object)
+			},
+		},
+		{
+			name: "Get returns source=system when no us row is present",
+			rows: []*settingsvc.Setting{defaultRow("auth.saml", "name", "SAML")},
+			op:   func(s *MTSettingsStore) (runtime.Object, bool, error) { o, e := s.Get(nsCtx(), "saml", &metav1.GetOptions{}); return o, false, e },
+			assert: func(t *testing.T, sso *iamv0.SSOSetting, _ bool, err error, _ *fakeWriter) {
+				require.NoError(t, err)
+				require.NotNil(t, sso)
+				assert.Equal(t, iamv0.SourceSystem, sso.Spec.Source)
+			},
+		},
+		{
+			name: "Get returns NotFound when the provider has no rows",
+			rows: nil,
+			op:   func(s *MTSettingsStore) (runtime.Object, bool, error) { o, e := s.Get(nsCtx(), "saml", &metav1.GetOptions{}); return o, false, e },
+			assert: func(t *testing.T, sso *iamv0.SSOSetting, _ bool, err error, _ *fakeWriter) {
+				assert.True(t, apierrors.IsNotFound(err))
+				assert.Nil(t, sso)
+			},
+		},
+		{
+			name: "Create upserts every blob key under auth.<provider>",
+			rows: nil,
+			op: func(s *MTSettingsStore) (runtime.Object, bool, error) {
+				o, e := s.Create(nsCtx(), ssoObj("generic_oauth", map[string]any{"enabled": "true", "client_id": "abc"}), nil, &metav1.CreateOptions{})
+				return o, false, e
+			},
+			assert: func(t *testing.T, sso *iamv0.SSOSetting, _ bool, err error, w *fakeWriter) {
+				require.NoError(t, err)
+				require.NotNil(t, sso)
+				assert.Equal(t, map[string]string{"enabled": "true", "client_id": "abc"}, w.upserts)
+				assert.Equal(t, "auth.generic_oauth", w.sections["client_id"])
+				assert.Equal(t, "stacks-11", sso.Namespace)
+				assert.NotEmpty(t, sso.ResourceVersion)
+			},
+		},
+		{
+			name: "Update upserts desired keys and prunes only stale unified-storage (us) rows",
+			rows: []*settingsvc.Setting{
+				usRow("auth.saml", "enabled", "true"),   // kept (in desired)
+				usRow("auth.saml", "stale", "x"),        // pruned (us, not in desired)
+				defaultRow("auth.saml", "name", "SAML"), // never pruned (not us)
+			},
+			op: func(s *MTSettingsStore) (runtime.Object, bool, error) {
+				return s.Update(nsCtx(), "saml",
+					rest.DefaultUpdatedObjectInfo(ssoObj("saml", map[string]any{"enabled": "false", "new_key": "y"})),
+					nil, nil, false, &metav1.UpdateOptions{})
+			},
+			assert: func(t *testing.T, sso *iamv0.SSOSetting, created bool, err error, w *fakeWriter) {
+				require.NoError(t, err)
+				require.NotNil(t, sso)
+				assert.False(t, created)
+				assert.Equal(t, map[string]string{"enabled": "false", "new_key": "y"}, w.upserts)
+				assert.Equal(t, []string{"stale"}, w.deleted)
+				assert.Equal(t, "stacks-11", sso.Namespace)
+			},
+		},
+		{
+			name: "Update creates on update when absent and forceAllowCreate is set",
+			rows: nil,
+			op: func(s *MTSettingsStore) (runtime.Object, bool, error) {
+				return s.Update(nsCtx(), "saml",
+					rest.DefaultUpdatedObjectInfo(ssoObj("saml", map[string]any{"enabled": "true"})),
+					nil, nil, true, &metav1.UpdateOptions{})
+			},
+			assert: func(t *testing.T, sso *iamv0.SSOSetting, created bool, err error, w *fakeWriter) {
+				require.NoError(t, err)
+				require.NotNil(t, sso)
+				assert.True(t, created)
+				assert.Equal(t, map[string]string{"enabled": "true"}, w.upserts)
+			},
+		},
+		{
+			name: "Update returns NotFound when absent and forceAllowCreate is not set",
+			rows: nil,
+			op: func(s *MTSettingsStore) (runtime.Object, bool, error) {
+				return s.Update(nsCtx(), "saml",
+					rest.DefaultUpdatedObjectInfo(ssoObj("saml", map[string]any{"enabled": "true"})),
+					nil, nil, false, &metav1.UpdateOptions{})
+			},
+			assert: func(t *testing.T, sso *iamv0.SSOSetting, _ bool, err error, _ *fakeWriter) {
+				assert.True(t, apierrors.IsNotFound(err))
+				assert.Nil(t, sso)
+			},
+		},
+		{
+			name: "Delete removes only the unified-storage (us) rows",
+			rows: []*settingsvc.Setting{usRow("auth.saml", "enabled", "true"), defaultRow("auth.saml", "name", "SAML")},
+			op:   func(s *MTSettingsStore) (runtime.Object, bool, error) { return s.Delete(nsCtx(), "saml", nil, &metav1.DeleteOptions{}) },
+			assert: func(t *testing.T, sso *iamv0.SSOSetting, deleted bool, err error, w *fakeWriter) {
+				require.NoError(t, err)
+				require.NotNil(t, sso)
+				assert.True(t, deleted)
+				assert.Equal(t, []string{"enabled"}, w.deleted)
+			},
+		},
+		{
+			name: "List is not implemented",
+			rows: nil,
+			op:   func(s *MTSettingsStore) (runtime.Object, bool, error) { o, e := s.List(nsCtx(), nil); return o, false, e },
+			assert: func(t *testing.T, sso *iamv0.SSOSetting, _ bool, err error, _ *fakeWriter) {
+				require.Error(t, err)
+				status, ok := err.(apierrors.APIStatus)
+				require.True(t, ok)
+				assert.Equal(t, int32(http.StatusNotImplemented), status.Status().Code)
+				assert.Nil(t, sso)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := newFakeWriter()
+			obj, ok, err := tc.op(NewMTSettingsStore(&fakeReader{rows: tc.rows}, w))
+			sso, _ := obj.(*iamv0.SSOSetting) // may be nil; each assert decides what "valid" means
+			tc.assert(t, sso, ok, err, w)
+		})
+	}
+}
+
+func TestCoarseResourceVersion(t *testing.T) {
+	base := map[string]any{"a": "1", "b": "2"}
+	assert.Equal(t, coarseResourceVersion(base), coarseResourceVersion(map[string]any{"b": "2", "a": "1"}), "order-independent")
+	assert.NotEqual(t, coarseResourceVersion(base), coarseResourceVersion(map[string]any{"a": "1", "b": "3"}), "value change moves the version")
+}
+
+func TestValueToString(t *testing.T) {
+	tests := []struct {
+		in   any
+		want string
+	}{
+		{nil, ""},
+		{"hello", "hello"},
+		{true, "true"},
+		{42, "42"},
+	}
+	for _, tc := range tests {
+		assert.Equal(t, tc.want, valueToString(tc.in))
+	}
+}
+
+func TestSectionFor(t *testing.T) {
+	assert.Equal(t, "auth.saml", sectionFor("saml"))
+	assert.Equal(t, "auth.generic_oauth", sectionFor("generic_oauth"))
+}

--- a/pkg/registry/apis/iam/sso/settings_client.go
+++ b/pkg/registry/apis/iam/sso/settings_client.go
@@ -1,0 +1,50 @@
+package sso
+
+import (
+	"fmt"
+
+	"github.com/grafana/authlib/authn"
+	"k8s.io/client-go/rest"
+
+	settingsvc "github.com/grafana/grafana/pkg/services/setting"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+// NewSettingsClient builds the MT-Settings client backing the SSOSetting kind.
+// The returned Service also implements settingsvc.Writer (reads + writes). It
+// deliberately skips metric registration to avoid colliding with the
+// ssosettings read client.
+func NewSettingsClient(cfg *setting.Cfg) (settingsvc.Service, error) {
+	settingsSec := cfg.SectionWithEnvOverrides("settings_service")
+	url := settingsSec.Key("url").String()
+	if url == "" {
+		return nil, fmt.Errorf("settings_service.url is not configured")
+	}
+
+	grpcAuth := cfg.SectionWithEnvOverrides("grpc_client_authentication")
+	tokenClient, err := authn.NewTokenExchangeClient(authn.TokenExchangeConfig{
+		Token:            grpcAuth.Key("token").String(),
+		TokenExchangeURL: grpcAuth.Key("token_exchange_url").String(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create token exchange client: %w", err)
+	}
+
+	tlsSec := cfg.SectionWithEnvOverrides("tls_client_config")
+	svc, err := settingsvc.New(settingsvc.Config{
+		URL:                 url,
+		TokenExchangeClient: tokenClient,
+		TLSClientConfig: rest.TLSClientConfig{
+			Insecure: tlsSec.Key("insecure").MustBool(false),
+			CAFile:   tlsSec.Key("root_ca_file").String(),
+		},
+		ServiceName: "grafana-sso-settings-store",
+		// Disable read caching: the store's writes bypass this client's cache,
+		// so caching would serve stale reads right after a write.
+		CacheTTL: -1,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create settings client: %w", err)
+	}
+	return svc, nil
+}


### PR DESCRIPTION
## Summary

Backs the `SSOSetting` kind (`iam.grafana.app`) with an MT-Settings store: a provider's settings blob maps to per-key `Setting` rows under `auth.<provider>`. Implements Get / Create / Update / Delete; List returns 501 for now.

- Get: reassembles a provider's section rows into the blob (the settings apiserver pre-resolves source-layer precedence and decrypt-on-read). Values come back decrypted by the apiserver, without redaction — secret redaction on read is deferred to Stage 3.4 (dark in prod until a read-MT mode; reads are on legacy at mode 0).
- Create/Update: write each blob key via the write client; Update reconciles — upsert every desired key, then prune stale unified-storage rows. Both re-read after writing and return the reassembled projection (merged default-layer keys, resolved `Spec.Source`, content-hash `resourceVersion`) rather than echoing the request.
- Delete: removes the provider's unified-storage rows (defaults/hgapi remain server-side) and returns the pre-delete object; the accurate post-delete result is mode-dependent (which store is read-authoritative) and is settled in Stage 3.4.

Interim authorizer: the kind previously had no authorizer. This adds an interim one that allows any authenticated identity (denies anonymous). Real `settings:write` RBAC scoped to `auth.*` is a follow-up.

## Test plan

`go test ./pkg/registry/apis/iam/sso/`

Fixes grafana/identity-access-team#2287
