### PR TITLE
Provisioning: Document Bitbucket delete-webhook permission

### DIFF
--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/_index.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/_index.md
@@ -150,12 +150,6 @@ If you want to configure Git Sync for Bitbucket, you need a Bitbucket API token 
 - **Pull requests**: Read and write permission
 - **Webhooks**: Read, write, and delete permission
 
-{{< admonition type="note" >}}
-
-Unlike GitHub, Bitbucket uses granular API token scopes that separate webhook read, write, and delete. Git Sync removes the repository's webhook when you delete or reconnect the repository, so the token must include the delete-webhook scope. Without it, removal fails with a `permission denied` error on the delete-webhook call.
-
-{{< /admonition >}}
-
 Return to Grafana and fill in the following fields:
 
 1. Paste the token into the **API Token** text box.

--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/_index.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/_index.md
@@ -148,7 +148,13 @@ If you want to configure Git Sync for Bitbucket, you need a Bitbucket API token 
 
 - **Repositories**: Read and write permission
 - **Pull requests**: Read and write permission
-- **Webhooks**: Read and write permission
+- **Webhooks**: Read, write, and delete permission
+
+{{< admonition type="note" >}}
+
+Unlike GitHub, Bitbucket uses granular API token scopes that separate webhook read, write, and delete. Git Sync removes the repository's webhook when you delete or reconnect the repository, so the token must include the delete-webhook scope. Without it, removal fails with a `permission denied` error on the delete-webhook call.
+
+{{< /admonition >}}
 
 Return to Grafana and fill in the following fields:
 

--- a/public/app/features/provisioning/Shared/TokenPermissionsInfo.test.tsx
+++ b/public/app/features/provisioning/Shared/TokenPermissionsInfo.test.tsx
@@ -17,4 +17,11 @@ describe('TokenPermissionsInfo', () => {
     expect(await screen.findByText(/Repository/)).toBeInTheDocument();
     expect(screen.queryByText(/Administration/)).not.toBeInTheDocument();
   });
+
+  it('lists the Webhooks: Read, write, and delete permission for Bitbucket', async () => {
+    render(<TokenPermissionsInfo type="bitbucket" />);
+
+    const row = await screen.findByText(/Webhooks/);
+    expect(row).toHaveTextContent('Webhooks: Read, write, and delete');
+  });
 });

--- a/public/app/features/provisioning/Shared/TokenPermissionsInfo.tsx
+++ b/public/app/features/provisioning/Shared/TokenPermissionsInfo.tsx
@@ -123,7 +123,7 @@ function getPermissionsForProvider(type: InstructionAvailability): Permission[] 
         },
         {
           name: t('provisioning.bitbucket.permissions.webhooks-label', 'Webhooks'),
-          access: t('provisioning.bitbucket.permissions.webhooks-read-write', 'Read and write'),
+          access: t('provisioning.bitbucket.permissions.webhooks-read-write-delete', 'Read, write, and delete'),
         },
       ];
     default:

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13422,7 +13422,7 @@
         "repository-label": "Repositories",
         "repository-read-write-admin": "Read, and write",
         "webhooks-label": "Webhooks",
-        "webhooks-read-write": "Read and write"
+        "webhooks-read-write-delete": "Read, write, and delete"
       },
       "pr-workflow-description": "Allows users to choose whether to open a pull request when saving changes. If the repository does not allow direct changes to the main branch, a pull request may still be required.",
       "pr-workflow-label": "Enable pull request option when saving",


### PR DESCRIPTION
## What this PR does

Bitbucket uses granular Atlassian API token scopes that separate webhook **read**, **write**, and **delete** — unlike GitHub, whose coarse `Webhooks: Read and write` permission already implies delete. Git Sync deletes the repository's webhook when the repository is deleted or reconnected, so the token must include the delete-webhook scope. Without it, the cleanup finalizer fails with:

```
remove finalizers: execute deletion hooks: delete webhook: permission denied
```

This PR updates the docs and the frontend token-permissions info to state that the Bitbucket token's Webhooks scope must include **delete**.

## Changes

- **Docs** — `git-sync-setup/_index.md`: Bitbucket Webhooks bullet now reads `Read, write, and delete permission`, plus a note explaining why delete is required.
- **Frontend** — `TokenPermissionsInfo.tsx`: Bitbucket Webhooks access now `Read, write, and delete` (new i18n key `webhooks-read-write-delete`). One shared component, so both the connect wizard and the config/edit form update.
- **i18n** — `en-US/grafana.json` regenerated via `make i18n-extract`.
- **Test** — added a Bitbucket assertion in `TokenPermissionsInfo.test.tsx`.

GitHub / GitLab wording is unchanged.

## Out of scope

Backend enforcement of the delete-webhook scope on Bitbucket PATs (as done for GitHub) — separate backend PR.

## Related

fixes grafana/git-ui-sync-project#1317

🤖 Generated with [Claude Code](https://claude.com/claude-code)