### PR TITLE
Gauge: Add overflow-with-neutral example panels to gdev dashboard

### DIFF
--- a/devenv/dev-dashboards/panel-gauge/gauge_tests_new.json
+++ b/devenv/dev-dashboards/panel-gauge/gauge_tests_new.json
@@ -1378,6 +1378,184 @@
           }
         }
       },
+      "panel-43": {
+        "kind": "Panel",
+        "spec": {
+          "id": 43,
+          "title": "Overflow above max + neutral",
+          "description": "Regression: value (10) exceeds max with a neutral point. The arc must clamp to [min, max] while the center text keeps the real value.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "grafana-testdata-datasource",
+                      "version": "v0",
+                      "spec": {
+                        "alias": "1",
+                        "scenarioId": "csv_metric_values",
+                        "stringInput": "10"
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {
+                "maxDataPoints": 20
+              }
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "gauge",
+            "version": "13.0.0-pre",
+            "spec": {
+              "options": {
+                "barShape": "flat",
+                "barWidthFactor": 0.7,
+                "effects": {
+                  "barGlow": false,
+                  "centerGlow": true,
+                  "gradient": true
+                },
+                "neutral": 0,
+                "orientation": "auto",
+                "reduceOptions": {
+                  "calcs": ["lastNotNull"],
+                  "fields": "",
+                  "values": false
+                },
+                "segmentCount": 1,
+                "segmentSpacing": 0.3,
+                "shape": "gauge",
+                "showThresholdLabels": false,
+                "showThresholdMarkers": true,
+                "sparkline": false
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "min": -5,
+                  "max": 5,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": null,
+                        "color": "green"
+                      },
+                      {
+                        "value": 0,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-44": {
+        "kind": "Panel",
+        "spec": {
+          "id": 44,
+          "title": "Overflow below min + neutral",
+          "description": "Regression: value (-10) is below min with a neutral point. The arc must clamp to [min, max] while the center text keeps the real value.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "grafana-testdata-datasource",
+                      "version": "v0",
+                      "spec": {
+                        "alias": "1",
+                        "scenarioId": "csv_metric_values",
+                        "stringInput": "-10"
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {
+                "maxDataPoints": 20
+              }
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "gauge",
+            "version": "13.0.0-pre",
+            "spec": {
+              "options": {
+                "barShape": "flat",
+                "barWidthFactor": 0.7,
+                "effects": {
+                  "barGlow": false,
+                  "centerGlow": true,
+                  "gradient": true
+                },
+                "neutral": 0,
+                "orientation": "auto",
+                "reduceOptions": {
+                  "calcs": ["lastNotNull"],
+                  "fields": "",
+                  "values": false
+                },
+                "segmentCount": 1,
+                "segmentSpacing": 0.3,
+                "shape": "gauge",
+                "showThresholdLabels": false,
+                "showThresholdMarkers": true,
+                "sparkline": false
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "min": -5,
+                  "max": 5,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": null,
+                        "color": "green"
+                      },
+                      {
+                        "value": 0,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
       "panel-26": {
         "kind": "Panel",
         "spec": {
@@ -3113,6 +3291,46 @@
                         "element": {
                           "kind": "ElementReference",
                           "name": "panel-42"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "Overflow with neutral",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 4,
+                        "height": 6,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-43"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 4,
+                        "y": 0,
+                        "width": 4,
+                        "height": 6,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-44"
                         }
                       }
                     }


### PR DESCRIPTION
## Summary

Adds an **"Overflow with neutral"** row to the gauge (new) gdev dashboard (`devenv/dev-dashboards/panel-gauge/gauge_tests_new.json`), giving us a provisioned repro of the fix from #130082.

With a neutral point set, values outside `[min, max]` must clamp the arc geometry to the range while the center text still shows the real value. This mirrors the Storybook example added in that PR:

| Panel | Value | Range | neutral | Demonstrates |
|-------|-------|-------|---------|--------------|
| Overflow above max + neutral | `10` | -5 to 5 | 0 | arc clamps to max, center shows real value |
| Overflow below min + neutral | `-10` | -5 to 5 | 0 | arc clamps to min, center shows real value |

Both panels use `shape: gauge`, `barWidthFactor: 0.7`, center glow + gradient, and thresholds color mode — matching the story props.

## Golden checksums

No regeneration needed. The migration/conversion golden tests read the preserved **v1** corpus (`apps/dashboard/pkg/migration/testdata/v1_dev_dashboards`), which is intentionally decoupled from the v2 `devenv/dev-dashboards` set. Verified locally:

- `go test ./apps/dashboard/pkg/migration/...` -> all `ok`, no checksum drift
- `yarn prettier` -> unchanged

## Test plan

- [ ] Provision gdev dashboards, open **Panel tests - Gauge (new)**, check the **Overflow with neutral** row: both bars fill to the ends without a broken arc, and the center text reads `10` / `-10`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)