### PR TITLE
GrafanaUI: Update react-inlinesvg to 4.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -385,7 +385,7 @@
     "react-highlight-words": "0.21.0",
     "react-hook-form": "^7.49.2",
     "react-i18next": "^17.0.9",
-    "react-inlinesvg": "4.3.0",
+    "react-inlinesvg": "^4.5.0",
     "react-loading-skeleton": "3.5.0",
     "react-moveable": "0.56.0",
     "react-redux": "9.2.0",

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -120,7 +120,7 @@
     "react-dropzone": "^14.3.8",
     "react-highlight-words": "^0.21.0",
     "react-hook-form": "^7.49.2",
-    "react-inlinesvg": "^4.3.0",
+    "react-inlinesvg": "^4.5.0",
     "react-loading-skeleton": "^3.5.0",
     "react-router-dom": "^5.3.4",
     "react-router-dom-v5-compat": "^6.26.1",

--- a/packages/grafana-ui/src/components/EmptyState/EmptyState.tsx
+++ b/packages/grafana-ui/src/components/EmptyState/EmptyState.tsx
@@ -84,7 +84,6 @@ function getDefaultImageForVariant(variant: Props['variant']) {
       return <GrotNotFound width={300} />;
     }
     case 'completed': {
-      // @ts-expect-error react-inlinesvg@4.3.0 return type includes bigint, which isn't in @types/react@18's ReactNode. Remove when we update @types/react.
       return <SVG src={GrotCompleted} width={300} />;
     }
     default: {

--- a/packages/grafana-ui/src/components/EmptyState/GrotCTA/GrotCTA.tsx
+++ b/packages/grafana-ui/src/components/EmptyState/GrotCTA/GrotCTA.tsx
@@ -16,7 +16,6 @@ export interface Props {
 export const GrotCTA = ({ width = 'auto', height }: Props) => {
   const styles = useStyles2(getStyles);
 
-  // @ts-expect-error react-inlinesvg@4.3.0 return type includes bigint, which isn't in @types/react@18's ReactNode. Remove when we update @types/react.
   return <SVG src={grotCTASvg} className={styles.svg} height={height} width={width} />;
 };
 

--- a/packages/grafana-ui/src/components/EmptyState/GrotNotFound/GrotNotFound.tsx
+++ b/packages/grafana-ui/src/components/EmptyState/GrotNotFound/GrotNotFound.tsx
@@ -52,7 +52,6 @@ export const GrotNotFound = ({ width = 'auto', height }: Props) => {
     };
   }, []);
 
-  // @ts-expect-error react-inlinesvg@4.3.0 return type includes bigint, which isn't in @types/react@18's ReactNode. Remove when we update @types/react.
   return <SVG innerRef={svgRef} src={notFoundSvg} className={styles.svg} height={height} width={width} />;
 };
 

--- a/packages/grafana-ui/src/components/Icon/Icon.tsx
+++ b/packages/grafana-ui/src/components/Icon/Icon.tsx
@@ -117,7 +117,6 @@ export const Icon = memo(
       );
 
       return (
-        // @ts-expect-error react-inlinesvg@4.3.0 return type includes bigint, which isn't in @types/react@18's ReactNode. Remove when we update @types/react.
         <SVG
           data-testid={`icon-${iconName}`}
           aria-hidden={

--- a/packages/grafana-ui/src/components/Spinner/Spinner.tsx
+++ b/packages/grafana-ui/src/components/Spinner/Spinner.tsx
@@ -65,7 +65,6 @@ export const Spinner = ({
           className
         )}
       >
-        {/* @ts-expect-error react-inlinesvg@4.3.0 return type includes bigint, which isn't in @types/react@18's ReactNode. Remove when we update @types/react. */}
         <SVG
           src={svgPath}
           width={size}

--- a/public/app/core/components/SVG/SanitizedSVG.tsx
+++ b/public/app/core/components/SVG/SanitizedSVG.tsx
@@ -8,7 +8,6 @@ type SanitizedSVGProps = Props & { cleanStyle?: boolean };
 
 export const SanitizedSVG = (props: SanitizedSVGProps) => {
   const { cleanStyle, ...inlineSvgProps } = props;
-  // @ts-expect-error react-inlinesvg@4.3.0 return type includes bigint, which isn't in @types/react@18's ReactNode. Remove when we update @types/react.
   return <SVG {...inlineSvgProps} cacheRequests={true} preProcessor={cleanStyle ? getCleanSVGAndStyle : getCleanSVG} />;
 };
 

--- a/public/app/features/alerting/unified/home/GettingStarted.tsx
+++ b/public/app/features/alerting/unified/home/GettingStarted.tsx
@@ -49,7 +49,6 @@ export default function GettingStarted() {
           </ul>
           <div className={styles.svgContainer}>
             <Stack justifyContent={'center'}>
-              {/* @ts-expect-error react-inlinesvg@4.3.0 return type includes bigint, which isn't in @types/react@18's ReactNode. Remove when we update @types/react. */}
               <SVG src={atAGlanceImage} width={undefined} height={undefined} />
             </Stack>
           </div>

--- a/public/app/features/dashboard-scene/sidebar/add-new/AddNewPane.tsx
+++ b/public/app/features/dashboard-scene/sidebar/add-new/AddNewPane.tsx
@@ -82,7 +82,6 @@ function AddNewPaneRenderer({ model }: SceneComponentProps<AddNewPane>) {
                           }}
                           aria-label={t('dashboard.sidebar.add.new-panel.title', 'Panel')}
                         >
-                          {/* @ts-expect-error react-inlinesvg@4.3.0 return type includes bigint, which isn't in @types/react@18's ReactNode. Remove when we update @types/react. */}
                           <SVG
                             title={t('dashboard.sidebar.add.new-panel.button', 'Add new panel button')}
                             src={addPanelSvg}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3245,7 +3245,7 @@ __metadata:
     react-element-to-jsx-string: "npm:^17.0.1"
     react-highlight-words: "npm:^0.21.0"
     react-hook-form: "npm:^7.49.2"
-    react-inlinesvg: "npm:^4.3.0"
+    react-inlinesvg: "npm:^4.5.0"
     react-loading-skeleton: "npm:^3.5.0"
     react-router-dom: "npm:^5.3.4"
     react-router-dom-v5-compat: "npm:^6.26.1"
@@ -19739,7 +19739,7 @@ __metadata:
     react-highlight-words: "npm:0.21.0"
     react-hook-form: "npm:^7.49.2"
     react-i18next: "npm:^17.0.9"
-    react-inlinesvg: "npm:4.3.0"
+    react-inlinesvg: "npm:^4.5.0"
     react-loading-skeleton: "npm:3.5.0"
     react-moveable: "npm:0.56.0"
     react-redux: "npm:9.2.0"
@@ -28975,14 +28975,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-inlinesvg@npm:4.3.0, react-inlinesvg@npm:^4.3.0":
-  version: 4.3.0
-  resolution: "react-inlinesvg@npm:4.3.0"
+"react-inlinesvg@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "react-inlinesvg@npm:4.5.0"
   dependencies:
     react-from-dom: "npm:^0.7.5"
   peerDependencies:
     react: 16.8 - 19
-  checksum: 10/8272c86abfabb8c341f69c8ce874878fc40af930a961e63431ba6b014b42a89f0ed6d3141854733a8dc5780891bf1d285e3423517f64fc2f2d787a6d902c0ccd
+  checksum: 10/656cb769c302393b1dbb80790a0ab6d6648beeacb0e48c89831e17de14c200d4397d72c1e2dcb8874df70379c0df3f4f51b4d6627d8a30736e1a0ec940e7609a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Icons can render as permanently empty `<svg>` elements when their first fetch is aborted by a component unmount. This is easily visible with the flame graph controls (expand/collapse groups, text align), which remount during initial layout (the Single→Split pane transition) while the icon SVGs are still in flight from the assets CDN.

<img width="484" height="126" alt="image" src="https://github.com/user-attachments/assets/7c107ef2-43a6-4f88-8e82-2e10a6fe6833" />


The aborted request poisons react-inlinesvg's shared cache, so every subsequent mount of that icon renders an empty placeholder and never retries. Since failed icons also never reach the persistent icon cache, the breakage repeats on every page load.

The regression came with react-inlinesvg 4.3.0 (#122943), which added an AbortController that cancels icon fetches on unmount: concurrent cache waiters for the same URL were left with empty content and no retry when the owning request aborted mid-flight. Fixed upstream in 4.4.0 ("Fix concurrent cache waiters silently failing on in-flight errors", https://github.com/gilbarbara/react-inlinesvg/pull/250).

Reproduced in Explore with a Pyroscope flame graph by adding ~400ms of latency to icon fetches; with this bump the same scenario renders all icons.

<img width="359" height="129" alt="image" src="https://github.com/user-attachments/assets/5f7948a2-6411-460c-8282-fb8289956044" />

Notes:
- Removes `@ts-expect-error` directives made unused by the explicit `InlineSVG` return type added in 4.4.1.
- Affects 13.1.0+ only (12.3.x ships react-inlinesvg 4.2.0, which has no abort-on-unmount); worth backporting to the affected release branches.