### PR TITLE
Alerting: Stop reading the legacy [alerting] configuration section

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1191,18 +1191,7 @@ func (cfg *Cfg) readAnnotationSettings() error {
 	}
 
 	alertingAnnotations := cfg.Raw.Section("unified_alerting.state_history.annotations")
-	if alertingAnnotations.Key("max_age").Value() == "" && section.Key("max_annotations_to_keep").Value() == "" {
-		// Although this section is not documented anymore, we decided to keep it to avoid potential data-loss when user upgrades Grafana and does not change the setting.
-		// TODO delete some time after Grafana 11.
-		alertingSection := cfg.Raw.Section("alerting")
-		cleanup := newAnnotationCleanupSettings(alertingSection, "max_annotation_age")
-		if cleanup.MaxCount > 0 || cleanup.MaxAge > 0 {
-			cfg.Logger.Warn("settings 'max_annotations_to_keep' and 'max_annotation_age' in section [alerting] are deprecated. Please use settings 'max_annotations_to_keep' and 'max_age' in section [unified_alerting.state_history.annotations]")
-		}
-		cfg.AlertingAnnotationCleanupSetting = cleanup
-	} else {
-		cfg.AlertingAnnotationCleanupSetting = newAnnotationCleanupSettings(alertingAnnotations, "max_age")
-	}
+	cfg.AlertingAnnotationCleanupSetting = newAnnotationCleanupSettings(alertingAnnotations, "max_age")
 
 	cfg.DashboardAnnotationCleanupSettings = newAnnotationCleanupSettings(dashboardAnnotation, "max_age")
 	cfg.APIAnnotationCleanupSettings = newAnnotationCleanupSettings(apiIAnnotation, "max_age")
@@ -1681,10 +1670,6 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 		if len(kv) == 2 {
 			cfg.ReportingStaticContext[strings.TrimSpace("_static_context_"+kv[0])] = strings.TrimSpace(kv[1])
 		}
-	}
-
-	if err := cfg.readAlertingSettings(iniFile); err != nil {
-		return err
 	}
 
 	explore := iniFile.Section("explore")
@@ -2268,17 +2253,6 @@ func (cfg *Cfg) readRenderingSettings(iniFile *ini.File) {
 	cfg.ImagesDir = filepath.Join(cfg.DataPath, "png")
 	cfg.CSVsDir = filepath.Join(cfg.DataPath, "csv")
 	cfg.PDFsDir = filepath.Join(cfg.DataPath, "pdf")
-}
-
-func (cfg *Cfg) readAlertingSettings(iniFile *ini.File) error {
-	// This check is kept to prevent users that upgrade to Grafana 11 with the legacy alerting enabled. This should prevent them from accidentally upgrading without migration to Unified Alerting.
-	alerting := iniFile.Section("alerting")
-	enabled, err := alerting.Key("enabled").Bool()
-	if err == nil && enabled {
-		cfg.Logger.Error("Option '[alerting].enabled' cannot be true. Legacy Alerting is removed. It is no longer deployed, enhanced, or supported. Delete '[alerting].enabled' and use '[unified_alerting].enabled' to enable Grafana Alerting. For more information, refer to the documentation on upgrading to Grafana Alerting (https://grafana.com/docs/grafana/v10.4/alerting/set-up/migrating-alerts)")
-		return fmt.Errorf("invalid setting [alerting].enabled")
-	}
-	return nil
 }
 
 func readSnapshotsSettings(cfg *Cfg, iniFile *ini.File) error {

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -579,42 +579,6 @@ func TestGetCDNPathWithAlphaVersion(t *testing.T) {
 	require.Equal(t, "http://cdn.grafana.com/grafana/v7.5.0-alpha.11124/", actual)
 }
 
-func TestAlertingEnabled(t *testing.T) {
-	t.Run("fail if legacy alerting enabled", func(t *testing.T) {
-		f := ini.Empty()
-		cfg := NewCfg()
-
-		alertingSec, err := f.NewSection("alerting")
-		require.NoError(t, err)
-		_, err = alertingSec.NewKey("enabled", "true")
-		require.NoError(t, err)
-
-		require.Error(t, cfg.readAlertingSettings(f))
-	})
-
-	t.Run("do nothing if it is disabled", func(t *testing.T) {
-		f := ini.Empty()
-		cfg := NewCfg()
-
-		alertingSec, err := f.NewSection("alerting")
-		require.NoError(t, err)
-		_, err = alertingSec.NewKey("enabled", "false")
-		require.NoError(t, err)
-		require.NoError(t, cfg.readAlertingSettings(f))
-	})
-
-	t.Run("do nothing if it invalid", func(t *testing.T) {
-		f := ini.Empty()
-		cfg := NewCfg()
-
-		alertingSec, err := f.NewSection("alerting")
-		require.NoError(t, err)
-		_, err = alertingSec.NewKey("enabled", "test")
-		require.NoError(t, err)
-		require.NoError(t, cfg.readAlertingSettings(f))
-	})
-}
-
 func TestRedactedValue(t *testing.T) {
 	testCases := []struct {
 		desc     string

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -50,7 +50,6 @@ const (
 	schedulerDefaultInitialRetryDelay       = 1 * time.Second
 	schedulerDefaultMaxRetryDelay           = 4 * time.Second
 	schedulerDefaultRandomizationFactor     = 0.1
-	schedulerDefaultLegacyMinInterval       = 1
 	screenshotsDefaultCapture               = false
 	screenshotsDefaultCaptureTimeout        = 10 * time.Second
 	screenshotsMaxCaptureTimeout            = 30 * time.Second
@@ -378,26 +377,12 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 	// TODO load from ini file
 	uaCfg.DefaultConfiguration = alertmanagerDefaultConfiguration
 
-	alerting := iniFile.Section("alerting")
+	uaCfg.ExecuteAlerts = ua.Key("execute_alerts").MustBool(schedulerDefaultExecuteAlerts)
 
-	uaExecuteAlerts := ua.Key("execute_alerts").MustBool(schedulerDefaultExecuteAlerts)
-	if uaExecuteAlerts { // unified option equals the default (true)
-		legacyExecuteAlerts := alerting.Key("execute_alerts").MustBool(schedulerDefaultExecuteAlerts)
-		if !legacyExecuteAlerts {
-			cfg.Logger.Warn("falling back to legacy setting of 'execute_alerts'; please use the configuration option in the `unified_alerting` section if Grafana 8 alerts are enabled.")
-		}
-		uaExecuteAlerts = legacyExecuteAlerts
-	}
-	uaCfg.ExecuteAlerts = uaExecuteAlerts
-
-	// if the unified alerting options equal the defaults, apply the respective legacy one
 	uaEvaluationTimeout, err := gtime.ParseDuration(valueAsString(ua, "evaluation_timeout", evaluatorDefaultEvaluationTimeout.String()))
-	if err != nil || uaEvaluationTimeout == evaluatorDefaultEvaluationTimeout { // unified option is invalid duration or equals the default
-		legaceEvaluationTimeout := time.Duration(alerting.Key("evaluation_timeout_seconds").MustInt64(int64(evaluatorDefaultEvaluationTimeout.Seconds()))) * time.Second
-		if legaceEvaluationTimeout != evaluatorDefaultEvaluationTimeout {
-			cfg.Logger.Warn("falling back to legacy setting of 'evaluation_timeout_seconds'; please use the configuration option in the `unified_alerting` section if Grafana 8 alerts are enabled.")
-		}
-		uaEvaluationTimeout = legaceEvaluationTimeout
+	if err != nil {
+		cfg.Logger.Warn("failed to parse setting 'evaluation_timeout' as duration, falling back to the default value", "error", err, "default", evaluatorDefaultEvaluationTimeout)
+		uaEvaluationTimeout = evaluatorDefaultEvaluationTimeout
 	}
 	uaCfg.EvaluationTimeout = uaEvaluationTimeout
 
@@ -452,16 +437,9 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 	}
 
 	uaMinInterval, err := gtime.ParseDuration(valueAsString(ua, "min_interval", uaCfg.BaseInterval.String()))
-	if err != nil || uaMinInterval == uaCfg.BaseInterval { // unified option is invalid duration or equals the default
-		// if the legacy option is invalid, fallback to 10 (unified alerting min interval default)
-		legacyMinInterval := time.Duration(alerting.Key("min_interval_seconds").MustInt64(int64(uaCfg.BaseInterval.Seconds()))) * time.Second
-		if legacyMinInterval > uaCfg.BaseInterval {
-			cfg.Logger.Warn("falling back to legacy setting of 'min_interval_seconds'; please use the configuration option in the `unified_alerting` section if Grafana 8 alerts are enabled.")
-			uaMinInterval = legacyMinInterval
-		} else {
-			// if legacy interval is smaller than the base interval, adjust it to the base interval
-			uaMinInterval = uaCfg.BaseInterval
-		}
+	if err != nil {
+		cfg.Logger.Warn("failed to parse setting 'min_interval' as duration, falling back to the base interval", "error", err, "default", uaCfg.BaseInterval)
+		uaMinInterval = uaCfg.BaseInterval
 	}
 
 	if uaMinInterval < uaCfg.BaseInterval {

--- a/pkg/setting/setting_unified_alerting_test.go
+++ b/pkg/setting/setting_unified_alerting_test.go
@@ -84,23 +84,16 @@ func TestUnifiedAlertingSettings(t *testing.T) {
 	testCases := []struct {
 		desc                   string
 		unifiedAlertingOptions map[string]string
-		alertingOptions        map[string]string
 		verifyCfg              func(*testing.T, Cfg)
 	}{
 		{
-			desc: "when the unified options do not equal the defaults, it should not apply the legacy ones",
+			desc: "when the unified options are set, it should read them",
 			unifiedAlertingOptions: map[string]string{
 				"admin_config_poll_interval": "120s",
 				"max_attempts":               "6",
 				"min_interval":               "60s",
 				"execute_alerts":             "false",
 				"evaluation_timeout":         "90s",
-			},
-			alertingOptions: map[string]string{
-				"max_attempts":               strconv.FormatInt(schedulerDefaultMaxAttempts, 10),
-				"min_interval_seconds":       strconv.FormatInt(schedulerDefaultLegacyMinInterval, 10),
-				"execute_alerts":             strconv.FormatBool(schedulerDefaultExecuteAlerts),
-				"evaluation_timeout_seconds": strconv.FormatInt(int64(evaluatorDefaultEvaluationTimeout.Seconds()), 10),
 			},
 			verifyCfg: func(t *testing.T, cfg Cfg) {
 				require.Equal(t, 120*time.Second, cfg.UnifiedAlerting.AdminConfigPollInterval)
@@ -113,45 +106,12 @@ func TestUnifiedAlertingSettings(t *testing.T) {
 			},
 		},
 		{
-			desc: "when the unified options equal the defaults, it should apply the legacy ones",
+			desc: "when the unified options are not set, apply the defaults",
 			unifiedAlertingOptions: map[string]string{
 				"admin_config_poll_interval": "120s",
-				"min_interval":               SchedulerBaseInterval.String(),
-				"execute_alerts":             strconv.FormatBool(schedulerDefaultExecuteAlerts),
-				"evaluation_timeout":         evaluatorDefaultEvaluationTimeout.String(),
-			},
-			alertingOptions: map[string]string{
-				"max_attempts":               "1", // Note: Ignored, setting does not exist.
-				"min_interval_seconds":       "120",
-				"execute_alerts":             "true",
-				"evaluation_timeout_seconds": "160",
 			},
 			verifyCfg: func(t *testing.T, cfg Cfg) {
 				require.Equal(t, 120*time.Second, cfg.UnifiedAlerting.AdminConfigPollInterval)
-				require.Equal(t, int64(3), cfg.UnifiedAlerting.MaxAttempts)
-				require.Equal(t, 120*time.Second, cfg.UnifiedAlerting.MinInterval)
-				require.Equal(t, true, cfg.UnifiedAlerting.ExecuteAlerts)
-				require.Equal(t, 160*time.Second, cfg.UnifiedAlerting.EvaluationTimeout)
-				require.Equal(t, SchedulerBaseInterval, cfg.UnifiedAlerting.BaseInterval)
-				require.Equal(t, 120*time.Second, cfg.UnifiedAlerting.DefaultRuleEvaluationInterval)
-			},
-		},
-		{
-			desc: "when both unified and legacy options are invalid, apply the defaults",
-			unifiedAlertingOptions: map[string]string{
-				"max_attempts":        "invalid",
-				"min_interval":        "invalid",
-				"execute_alerts":      "invalid",
-				"evaluation_timeouts": "invalid",
-			},
-			alertingOptions: map[string]string{
-				"max_attempts":               "invalid",
-				"min_interval_seconds":       "invalid",
-				"execute_alerts":             "invalid",
-				"evaluation_timeout_seconds": "invalid",
-			},
-			verifyCfg: func(t *testing.T, cfg Cfg) {
-				require.Equal(t, alertmanagerDefaultConfigPollInterval, cfg.UnifiedAlerting.AdminConfigPollInterval)
 				require.Equal(t, int64(schedulerDefaultMaxAttempts), cfg.UnifiedAlerting.MaxAttempts)
 				require.Equal(t, SchedulerBaseInterval, cfg.UnifiedAlerting.MinInterval)
 				require.Equal(t, schedulerDefaultExecuteAlerts, cfg.UnifiedAlerting.ExecuteAlerts)
@@ -161,27 +121,21 @@ func TestUnifiedAlertingSettings(t *testing.T) {
 			},
 		},
 		{
-			desc: "when unified alerting options are invalid, apply legacy options",
+			desc: "when the unified options are invalid, apply the defaults",
 			unifiedAlertingOptions: map[string]string{
 				"max_attempts":       "invalid",
 				"min_interval":       "invalid",
 				"execute_alerts":     "invalid",
 				"evaluation_timeout": "invalid",
 			},
-			alertingOptions: map[string]string{
-				"max_attempts":               "1", // Note: Ignored, setting does not exist.
-				"min_interval_seconds":       "120",
-				"execute_alerts":             "false",
-				"evaluation_timeout_seconds": "160",
-			},
 			verifyCfg: func(t *testing.T, cfg Cfg) {
 				require.Equal(t, alertmanagerDefaultConfigPollInterval, cfg.UnifiedAlerting.AdminConfigPollInterval)
-				require.Equal(t, int64(3), cfg.UnifiedAlerting.MaxAttempts)
-				require.Equal(t, 120*time.Second, cfg.UnifiedAlerting.MinInterval)
-				require.Equal(t, false, cfg.UnifiedAlerting.ExecuteAlerts)
-				require.Equal(t, 160*time.Second, cfg.UnifiedAlerting.EvaluationTimeout)
+				require.Equal(t, int64(schedulerDefaultMaxAttempts), cfg.UnifiedAlerting.MaxAttempts)
+				require.Equal(t, SchedulerBaseInterval, cfg.UnifiedAlerting.MinInterval)
+				require.Equal(t, schedulerDefaultExecuteAlerts, cfg.UnifiedAlerting.ExecuteAlerts)
+				require.Equal(t, evaluatorDefaultEvaluationTimeout, cfg.UnifiedAlerting.EvaluationTimeout)
 				require.Equal(t, SchedulerBaseInterval, cfg.UnifiedAlerting.BaseInterval)
-				require.Equal(t, 120*time.Second, cfg.UnifiedAlerting.DefaultRuleEvaluationInterval)
+				require.Equal(t, DefaultRuleEvaluationInterval, cfg.UnifiedAlerting.DefaultRuleEvaluationInterval)
 			},
 		},
 	}
@@ -195,12 +149,6 @@ func TestUnifiedAlertingSettings(t *testing.T) {
 			require.NoError(t, err)
 			for k, v := range tc.unifiedAlertingOptions {
 				_, err = unifiedAlertingSec.NewKey(k, v)
-				require.NoError(t, err)
-			}
-			alertingSec, err := f.NewSection("alerting")
-			require.NoError(t, err)
-			for k, v := range tc.alertingOptions {
-				_, err = alertingSec.NewKey(k, v)
 				require.NoError(t, err)
 			}
 			err = cfg.ReadUnifiedAlertingSettings(f)
@@ -221,10 +169,9 @@ func TestMinInterval(t *testing.T) {
 	}
 
 	testCases := []struct {
-		desc              string
-		minInterval       *time.Duration
-		legacyMinInterval *time.Duration
-		verifyCfg         func(*testing.T, *Cfg, error)
+		desc        string
+		minInterval *time.Duration
+		verifyCfg   func(*testing.T, *Cfg, error)
 	}{
 		{
 			desc:        "should fail if min interval is less than base interval",
@@ -250,34 +197,12 @@ func TestMinInterval(t *testing.T) {
 			},
 		},
 		{
-			desc:              "should fail if fallback to legacy min interval and it is not multiple of base interval",
-			legacyMinInterval: randPredicate(func(dur time.Duration) bool { return dur > SchedulerBaseInterval && dur%SchedulerBaseInterval != 0 }),
-			verifyCfg: func(t *testing.T, cfg *Cfg, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "min_interval")
-			},
-		},
-		{
-			desc:              "should not fail if fallback to legacy min interval it is multiple of base interval",
-			legacyMinInterval: randPredicate(func(dur time.Duration) bool { return dur >= SchedulerBaseInterval && dur%SchedulerBaseInterval == 0 }),
-			verifyCfg: func(t *testing.T, cfg *Cfg, err error) {
-				require.NoError(t, err)
-			},
-		},
-		{
 			desc: "should adjust DefaultRuleEvaluationInterval to min interval if it is greater",
 			minInterval: randPredicate(func(dur time.Duration) bool {
 				return dur%SchedulerBaseInterval == 0 && dur > DefaultRuleEvaluationInterval
 			}),
 			verifyCfg: func(t *testing.T, cfg *Cfg, err error) {
 				require.Equal(t, cfg.UnifiedAlerting.MinInterval, cfg.UnifiedAlerting.DefaultRuleEvaluationInterval)
-			},
-		},
-		{
-			desc:              "should fallback to the default if legacy interval is less than base",
-			legacyMinInterval: randPredicate(func(dur time.Duration) bool { return dur < SchedulerBaseInterval }),
-			verifyCfg: func(t *testing.T, cfg *Cfg, err error) {
-				require.Equal(t, SchedulerBaseInterval, cfg.UnifiedAlerting.MinInterval)
 			},
 		},
 	}
@@ -289,12 +214,6 @@ func TestMinInterval(t *testing.T) {
 				section, err := f.NewSection("unified_alerting")
 				require.NoError(t, err)
 				_, err = section.NewKey("min_interval", testCase.minInterval.String())
-				require.NoError(t, err)
-			}
-			if testCase.legacyMinInterval != nil {
-				alertingSec, err := f.NewSection("alerting")
-				require.NoError(t, err)
-				_, err = alertingSec.NewKey("min_interval_seconds", strconv.Itoa(int(testCase.legacyMinInterval.Seconds())))
 				require.NoError(t, err)
 			}
 			cfg := NewCfg()

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -431,13 +431,6 @@ func createGrafDir(t *testing.T, tmpDir string, opts GrafanaOpts) (string, strin
 	_, err = anonSect.NewKey("enabled", "true")
 	require.NoError(t, err)
 
-	alertingSect, err := cfg.NewSection("alerting")
-	require.NoError(t, err)
-	_, err = alertingSect.NewKey("notification_timeout_seconds", "1")
-	require.NoError(t, err)
-	_, err = alertingSect.NewKey("max_attempts", "3")
-	require.NoError(t, err)
-
 	if opts.EnableRecordingRules {
 		recordingRulesSect, err := cfg.NewSection("recording_rules")
 		require.NoError(t, err)

--- a/pkg/tsdb/cloudwatch/models/settings.go
+++ b/pkg/tsdb/cloudwatch/models/settings.go
@@ -38,7 +38,7 @@ func LoadCloudWatchSettings(ctx context.Context, config backend.DataSourceInstan
 	}
 
 	// logs timeout default is 30 minutes, the same as timeout in frontend logs query
-	// note: for alerting queries, the context will be cancelled before that unless evaluation_timeout_seconds in defaults.ini is increased (default: 30s)
+	// note: for alerting queries, the context will be cancelled before that unless [unified_alerting].evaluation_timeout in defaults.ini is increased (default: 30s)
 	if instance.LogsTimeout.Duration == 0 {
 		instance.LogsTimeout = Duration{30 * time.Minute}
 	}


### PR DESCRIPTION
## What is this feature?

Removes every remaining reader of the legacy `[alerting]` configuration section. Legacy alerting was removed in Grafana 11, but four readers survived:

- `readAlertingSettings` — the guard that refused to start when `[alerting].enabled = true`.
- `[alerting].execute_alerts`, `evaluation_timeout_seconds`, `min_interval_seconds` — fallbacks applied when the `[unified_alerting]` counterpart was unset, invalid, or happened to equal its default.
- `[alerting].max_annotation_age`, `max_annotations_to_keep` — fallbacks for alert annotation cleanup, carrying a `TODO delete some time after Grafana 11`.
- Test scaffolding in `testinfra` that wrote `[alerting]` keys nothing reads.

Also updates a stale comment in the CloudWatch datasource that pointed at `evaluation_timeout_seconds`. `conf/*.ini` and the docs were already free of the section.

Dropping the fallback simplifies two resolution paths: an explicit `[unified_alerting]` `evaluation_timeout` / `min_interval` is now always honored (previously a value equal to the default was treated as unset so the legacy setting won), and an unparsable value logs a warning and uses the default, consistent with the neighbouring `initial_retry_delay` / `max_retry_delay` settings.

The open question this PR settles: is the `[alerting].enabled` guard still earning the confusion it prevents? It exists so someone upgrading from pre-11 gets a hard error instead of silently losing alerting. Two majors later, the trade-off looks inverted — the check keeps a dead section alive in the config surface, and anyone who has reached 13.x has long since migrated.

## Why do we need this feature?

The `[alerting]` section has been undocumented and non-functional for two major versions. Keeping partial readers around means the config surface still implies these settings do something.

## Special notes for your reviewer

Verified with `go build ./pkg/...`, `go test ./pkg/setting/... ./pkg/registry/apps/annotation/... ./pkg/services/cleanup/... ./pkg/tsdb/cloudwatch/models/...`, and `golangci-lint` on the touched packages.

# Release notice breaking change

Grafana no longer reads anything from the legacy `[alerting]` configuration section. The section was left over from legacy alerting, removed in Grafana 11, and the remaining keys only acted as fallbacks for their Unified Alerting equivalents. If any of them are still set, they are now ignored — the corresponding `[unified_alerting]` setting (or its default) applies instead.

Settings that are no longer read:

| Legacy setting | Replacement | Behavior if you still rely on the legacy setting |
| --- | --- | --- |
| `[alerting].enabled` | `[unified_alerting].enabled` | Setting it to `true` no longer stops Grafana from starting with an error; it is silently ignored. |
| `[alerting].execute_alerts` | `[unified_alerting].execute_alerts` | `false` no longer disables rule evaluation. Evaluation runs (default `true`) unless `[unified_alerting].execute_alerts = false`. |
| `[alerting].evaluation_timeout_seconds` | `[unified_alerting].evaluation_timeout` | Falls back to the default `30s` instead of the legacy value. |
| `[alerting].min_interval_seconds` | `[unified_alerting].min_interval` | Falls back to the default `10s` instead of the legacy value, so rules may be allowed to evaluate more frequently than before. |
| `[alerting].max_annotation_age` | `[unified_alerting.state_history.annotations].max_age` | Falls back to the default `0` — alert annotations are kept forever instead of being cleaned up. |
| `[alerting].max_annotations_to_keep` | `[unified_alerting.state_history.annotations].max_annotations_to_keep` | Falls back to the default `0` — all alert annotations are kept. |

Two related changes to how `[unified_alerting]` values are resolved, since the legacy fallback is gone:

- An explicit `[unified_alerting].evaluation_timeout` or `min_interval` is now always honored, even when it equals the default. Previously a value equal to the default was treated as "unset" and the legacy setting won.
- An unparsable `evaluation_timeout` or `min_interval` now logs a warning and uses the default, instead of reading the legacy setting.

Before upgrading, move any values you still keep in `[alerting]` to the `[unified_alerting]` equivalents listed above, then delete the section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Blocked by grafana/alerting-squad#1960 — audit which cloud tenants still set the legacy `[alerting]` keys before this merges.

