### PR TITLE
fix(alerting): keep original RuleUID in recovery versions to avoid duplicate key on delete

### DIFF
--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -84,7 +84,6 @@ func (st DBstore) DeleteAlertRulesByUID(ctx context.Context, orgID int64, user *
 			for idx := range versions {
 				version := &versions[idx]
 				version.ID = 0
-				version.RuleUID = ""
 				version.Created = TimeNow()
 				version.CreatedBy = nil
 				if user != nil {

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -753,12 +753,12 @@ func TestIntegration_DeleteAlertRulesByUID(t *testing.T) {
 
 		_ = sqlStore.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
 			var versions []alertRuleVersion
-			err = sess.Table(alertRuleVersion{}).Where(`rule_uid = ''`).In("rule_guid", guids).Find(&versions)
+			err = sess.Table(alertRuleVersion{}).In("rule_guid", guids).Find(&versions)
 			require.NoError(t, err)
 			require.Len(t, versions, len(rules)) // should be one version per GUID
 
 			for _, version := range versions {
-				assert.Equal(t, "", version.RuleUID)
+				require.NotEmpty(t, version.RuleUID)
 				assert.Equal(t, "test", *version.CreatedBy)
 				// Remove the GUID from guids
 				for i, guid := range guids {


### PR DESCRIPTION
Fixes #130138

## Problem

When deleting alert rules with the `AlertRuleRestore` feature flag enabled, the recovery version's `RuleUID` was cleared to empty string (`version.RuleUID = ""`). This caused a unique constraint violation on `UQE_alert_rule_version_rule_org_id_rule_uid_version` when multiple rules with the same version number were deleted simultaneously, because the key `(org_id, '''', version)` was duplicated.

Error from user:
```
failed to delete rule group: failed to persist deleted rule for recovery:
pq: duplicate key value violates unique constraint "UQE_alert_rule_version_rule_org_id_rule_uid_version" (23505)
```

## Fix

Keep the original `RuleUID` in recovery versions. The `RuleUID` is a stable identifier that does not need to be cleared for recovery purposes. This ensures uniqueness even on databases with the 3-column unique constraint `(rule_org_id, rule_uid, version)`.

## Verification

- [x] Code compiles
- [x] Existing tests updated to expect non-empty RuleUID
- [x] Manual code review confirms the fix resolves the constraint violation