### PR TITLE
Alerting: Strip empty-name labels before sending to remote Alertmanager

### DIFF
--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -579,10 +579,10 @@ func (am *Alertmanager) GetAlertGroups(ctx context.Context, active, silenced, in
 func (am *Alertmanager) PutAlerts(ctx context.Context, alerts apimodels.PostableAlerts) error {
 	for _, a := range alerts.PostableAlerts {
 		for k, v := range a.Labels {
-			// The Grafana Alertmanager skips empty and namespace UID labels.
+			// The Grafana Alertmanager skips empty-name, empty-value, and namespace UID labels.
 			// To get the same alert fingerprint we need to remove these labels too.
 			// https://github.com/grafana/alerting/blob/2dda1c67ec02625ac9fc8607157b3d5825d47919/notify/grafana_alertmanager.go#L722-L724
-			if len(v) == 0 || k == alertingModels.NamespaceUIDLabel {
+			if len(k) == 0 || len(v) == 0 || k == alertingModels.NamespaceUIDLabel {
 				delete(a.Labels, k)
 			}
 		}

--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -581,7 +581,7 @@ func (am *Alertmanager) PutAlerts(ctx context.Context, alerts apimodels.Postable
 		for k, v := range a.Labels {
 			// The Grafana Alertmanager skips empty-name, empty-value, and namespace UID labels.
 			// To get the same alert fingerprint we need to remove these labels too.
-			// https://github.com/grafana/alerting/blob/2dda1c67ec02625ac9fc8607157b3d5825d47919/notify/grafana_alertmanager.go#L722-L724
+			// https://github.com/grafana/alerting/blob/d7fe949135639051472a18db58b764467fa8859b/notify/grafana_alertmanager.go#L966-L968
 			if len(k) == 0 || len(v) == 0 || k == alertingModels.NamespaceUIDLabel {
 				delete(a.Labels, k)
 			}

--- a/pkg/services/ngalert/remote/alertmanager_test.go
+++ b/pkg/services/ngalert/remote/alertmanager_test.go
@@ -1473,9 +1473,9 @@ func TestIntegrationRemoteAlertmanagerAlerts(t *testing.T) {
 	// Let's create two active alerts and one expired one.
 	// UTF-8 label names should be preserved.
 	utf8LabelName := "test utf-8 label 😳"
-	alert1 := genAlert(true, map[string]string{utf8LabelName: "test_1", "empty": "", alertingModels.NamespaceUIDLabel: "test_1"})
-	alert2 := genAlert(true, map[string]string{utf8LabelName: "test_2", "empty": "", alertingModels.NamespaceUIDLabel: "test_2"})
-	alert3 := genAlert(false, map[string]string{utf8LabelName: "test_3", "empty": "", alertingModels.NamespaceUIDLabel: "test_3"})
+	alert1 := genAlert(true, map[string]string{utf8LabelName: "test_1", "empty": "", "": "empty_name", alertingModels.NamespaceUIDLabel: "test_1"})
+	alert2 := genAlert(true, map[string]string{utf8LabelName: "test_2", "empty": "", "": "empty_name", alertingModels.NamespaceUIDLabel: "test_2"})
+	alert3 := genAlert(false, map[string]string{utf8LabelName: "test_3", "empty": "", "": "empty_name", alertingModels.NamespaceUIDLabel: "test_3"})
 	postableAlerts := apimodels.PostableAlerts{
 		PostableAlerts: []amv2.PostableAlert{alert1, alert2, alert3},
 	}
@@ -1493,12 +1493,13 @@ func TestIntegrationRemoteAlertmanagerAlerts(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(alertGroups))
 
-	// Labels with empty values and the namespace UID label should be removed.
+	// Labels with empty names, empty values, and the namespace UID label should be removed.
 	// UTF-8 label names should remain unchanged.
 	for _, a := range alertGroups {
 		require.Len(t, a.Alerts, 2)
 		for _, a := range a.Alerts {
 			require.NotContains(t, a.Labels, "empty")
+			require.NotContains(t, a.Labels, "")
 			require.NotContains(t, a.Labels, alertingModels.NamespaceUIDLabel)
 			require.Contains(t, a.Labels, utf8LabelName)
 		}


### PR DESCRIPTION
When Grafana forwards alerts to a remote Alertmanager, it POSTs them to `/api/v2/alerts`, where the Alertmanager validates each alert. A label with an empty name (`""`) fails validation (`invalid label set: invalid name ""`, HTTP 400) and the whole request is rejected — dropping those alerts.

`PutAlerts` already strips empty-value and namespace-UID labels before sending (to keep alert fingerprints consistent). This extends that to also strip empty-name labels, matching grafana/alerting#648.
