### PR TITLE
SSO: ride the SSOSetting kind on the dual-writer

### DIFF
--- a/pkg/registry/apis/iam/models.go
+++ b/pkg/registry/apis/iam/models.go
@@ -55,7 +55,6 @@ type IdentityAccessManagementAPIBuilder struct {
 	externalGroupReconciler    legacy.ExternalGroupReconciler
 	teamBindingLegacyStore     *teambinding.LegacyBindingStore
 	ssoLegacyStore             *sso.LegacyStore
-	ssoUseMTSettings           bool
 	roleApiInstaller           RoleApiInstaller
 	globalRoleApiInstaller     GlobalRoleApiInstaller
 	teamLBACApiInstaller       TeamLBACApiInstaller

--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -128,12 +128,11 @@ func RegisterAPIService(
 	}
 
 	// Mode lever for the SSO settings migration: any configured storage mode
-	// above 0 hands the SSOSetting kind to the MT-Settings store.
-	ssoUseMTSettings := false
+	// above 0 builds the MT-Settings client so the SSOSetting kind can ride the
+	// dual-writer; the storage mode then routes reads and writes between stores.
 	var ssoSettingsClient settingsvc.Service
 	if cfg != nil {
 		if resCfg, ok := cfg.UnifiedStorage[legacyiamv0.SSOSettingResourceInfo.GroupResource().String()]; ok && resCfg.DualWriterMode > grafanarest.Mode0 {
-			ssoUseMTSettings = true
 			c, err := sso.NewSettingsClient(cfg)
 			if err != nil {
 				log.New("iam.apis").Error("failed to build MT-Settings client for SSOSetting store", "error", err)
@@ -150,7 +149,6 @@ func RegisterAPIService(
 		externalGroupReconciler:           externalGroupReconciler,
 		teamBindingLegacyStore:            teambinding.NewLegacyBindingStore(store, tracing),
 		ssoLegacyStore:                    sso.NewLegacyStore(ssoService, tracing),
-		ssoUseMTSettings:                  ssoUseMTSettings,
 		ssoSettingsClient:                 ssoSettingsClient,
 		roleApiInstaller:                  roleApiInstaller,
 		globalRoleApiInstaller:            globalRoleApiInstaller,
@@ -450,15 +448,19 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *ge
 	// SSO settings apis
 	if enableSsoSettingsApi && b.ssoLegacyStore != nil {
 		ssoResource := legacyiamv0.SSOSettingResourceInfo
-		// The [unified_storage.ssosettings.iam.grafana.app] storage mode decides
-		// which store serves the kind: mode 0 (default) keeps the legacy store;
-		// any higher mode engages the MT-Settings store.
-		if b.ssoUseMTSettings {
-			var writer settingsvc.Writer
-			if b.ssoSettingsClient != nil {
-				writer, _ = b.ssoSettingsClient.(settingsvc.Writer)
+		// When the MT-Settings client is configured, the SSOSetting kind rides the
+		// standard dual-writer (legacy + MT-Settings), which routes reads and writes
+		// by the [unified_storage.ssosettings.iam.grafana.app] storage mode. Without
+		// it (e.g. on-prem, or when the builder is unavailable) the legacy store
+		// serves alone.
+		if b.ssoSettingsClient != nil && opts.DualWriteBuilder != nil {
+			writer, _ := b.ssoSettingsClient.(settingsvc.Writer)
+			mtStore := sso.NewMTSettingsStore(b.ssoSettingsClient, writer)
+			dw, err := opts.DualWriteBuilder(ssoResource.GroupResource(), b.ssoLegacyStore, mtStore)
+			if err != nil {
+				return err
 			}
-			storage[ssoResource.StoragePath()] = sso.NewMTSettingsStore(b.ssoSettingsClient, writer)
+			storage[ssoResource.StoragePath()] = dw
 		} else {
 			storage[ssoResource.StoragePath()] = b.ssoLegacyStore
 		}

--- a/pkg/registry/apis/iam/sso/store.go
+++ b/pkg/registry/apis/iam/sso/store.go
@@ -26,6 +26,7 @@ var (
 	_ rest.Scoper               = (*LegacyStore)(nil)
 	_ rest.Getter               = (*LegacyStore)(nil)
 	_ rest.Lister               = (*LegacyStore)(nil)
+	_ rest.Creater              = (*LegacyStore)(nil)
 	_ rest.Updater              = (*LegacyStore)(nil)
 	_ rest.SingularNameProvider = (*LegacyStore)(nil)
 	_ rest.GracefulDeleter      = (*LegacyStore)(nil)
@@ -108,6 +109,32 @@ func (s *LegacyStore) Get(ctx context.Context, name string, options *metav1.GetO
 
 	object := mapToObject(ns.Value, setting)
 	return &object, nil
+}
+
+// Create implements rest.Creater. SSO settings are upsert-by-provider, so it
+// delegates to the same Upsert as Update; it exists so the kind can ride the
+// dual-writer composite, which requires rest.CreaterUpdater.
+func (s *LegacyStore) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, _ *metav1.CreateOptions) (runtime.Object, error) {
+	ctx, span := s.tracer.Start(ctx, "sso.Create")
+	defer span.End()
+
+	ident, err := identity.GetRequester(ctx)
+	if err != nil {
+		return nil, err
+	}
+	setting, ok := obj.(*iamv0.SSOSetting)
+	if !ok {
+		return nil, errors.New("expected ssosetting on create")
+	}
+	if createValidation != nil {
+		if err := createValidation(ctx, obj); err != nil {
+			return nil, err
+		}
+	}
+	if err := s.service.Upsert(ctx, mapToModel(setting), ident); err != nil {
+		return nil, err
+	}
+	return s.Get(ctx, setting.Name, nil)
 }
 
 // Update implements rest.Updater.

--- a/pkg/registry/apis/iam/sso/store_test.go
+++ b/pkg/registry/apis/iam/sso/store_test.go
@@ -1,0 +1,127 @@
+package sso
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	iamv0 "github.com/grafana/grafana/pkg/apis/iam/v0alpha1"
+	"github.com/grafana/grafana/pkg/services/ssosettings"
+	ssomodels "github.com/grafana/grafana/pkg/services/ssosettings/models"
+)
+
+// fakeSSOService embeds Service so only the methods Create exercises need bodies.
+// GetForProviderWithRedactedSecrets reads back whatever Upsert stored, so the
+// happy path observes its own write.
+type fakeSSOService struct {
+	ssosettings.Service
+	upserted  *ssomodels.SSOSettings // last model handed to Upsert
+	upsertErr error
+}
+
+func (f *fakeSSOService) Upsert(_ context.Context, s *ssomodels.SSOSettings, _ identity.Requester) error {
+	if f.upsertErr != nil {
+		return f.upsertErr
+	}
+	f.upserted = s
+	return nil
+}
+
+func (f *fakeSSOService) GetForProviderWithRedactedSecrets(_ context.Context, _ string) (*ssomodels.SSOSettings, error) {
+	if f.upserted == nil {
+		return nil, ssosettings.ErrNotFound
+	}
+	return f.upserted, nil
+}
+
+func reqCtx() context.Context {
+	return identity.WithRequester(context.Background(), &identity.StaticRequester{})
+}
+
+func TestLegacyStore_Create(t *testing.T) {
+	tests := []struct {
+		name   string
+		svc    *fakeSSOService
+		op     func(s *LegacyStore) (runtime.Object, error)
+		assert func(t *testing.T, sso *iamv0.SSOSetting, err error, svc *fakeSSOService)
+	}{
+		{
+			name: "upserts the provider and returns the stored object",
+			svc:  &fakeSSOService{},
+			op: func(s *LegacyStore) (runtime.Object, error) {
+				return s.Create(reqCtx(), ssoObj("azuread", map[string]any{"enabled": "true"}), nil, &metav1.CreateOptions{})
+			},
+			assert: func(t *testing.T, sso *iamv0.SSOSetting, err error, svc *fakeSSOService) {
+				require.NoError(t, err)
+				require.NotNil(t, sso)
+				assert.Equal(t, "azuread", sso.Name)
+				assert.Equal(t, map[string]any{"enabled": "true"}, sso.Spec.Settings.Object)
+				require.NotNil(t, svc.upserted)
+				assert.Equal(t, "azuread", svc.upserted.Provider)
+			},
+		},
+		{
+			name: "fails without an identity and does not upsert",
+			svc:  &fakeSSOService{},
+			op: func(s *LegacyStore) (runtime.Object, error) {
+				return s.Create(context.Background(), ssoObj("azuread", map[string]any{"enabled": "true"}), nil, &metav1.CreateOptions{})
+			},
+			assert: func(t *testing.T, sso *iamv0.SSOSetting, err error, svc *fakeSSOService) {
+				require.Error(t, err)
+				assert.Nil(t, sso)
+				assert.Nil(t, svc.upserted)
+			},
+		},
+		{
+			name: "rejects a non-SSOSetting object",
+			svc:  &fakeSSOService{},
+			op: func(s *LegacyStore) (runtime.Object, error) {
+				return s.Create(reqCtx(), &iamv0.SSOSettingList{}, nil, &metav1.CreateOptions{})
+			},
+			assert: func(t *testing.T, sso *iamv0.SSOSetting, err error, svc *fakeSSOService) {
+				require.Error(t, err)
+				assert.Nil(t, sso)
+				assert.Nil(t, svc.upserted)
+			},
+		},
+		{
+			name: "surfaces a validation failure before upserting",
+			svc:  &fakeSSOService{},
+			op: func(s *LegacyStore) (runtime.Object, error) {
+				deny := func(context.Context, runtime.Object) error { return errors.New("denied") }
+				return s.Create(reqCtx(), ssoObj("azuread", map[string]any{"enabled": "true"}), deny, &metav1.CreateOptions{})
+			},
+			assert: func(t *testing.T, sso *iamv0.SSOSetting, err error, svc *fakeSSOService) {
+				require.Error(t, err)
+				assert.Nil(t, sso)
+				assert.Nil(t, svc.upserted)
+			},
+		},
+		{
+			name: "propagates an upsert error",
+			svc:  &fakeSSOService{upsertErr: errors.New("boom")},
+			op: func(s *LegacyStore) (runtime.Object, error) {
+				return s.Create(reqCtx(), ssoObj("azuread", map[string]any{"enabled": "true"}), nil, &metav1.CreateOptions{})
+			},
+			assert: func(t *testing.T, sso *iamv0.SSOSetting, err error, _ *fakeSSOService) {
+				require.Error(t, err)
+				assert.Nil(t, sso)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			obj, err := tc.op(NewLegacyStore(tc.svc, noop.NewTracerProvider().Tracer("test")))
+			sso, _ := obj.(*iamv0.SSOSetting) // may be nil; each assert decides what "valid" means
+			tc.assert(t, sso, err, tc.svc)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Rides the `SSOSetting` kind (`iam.grafana.app`) on the standard dual-writer: the legacy store and the MT-Settings store are composed via `DualWriteBuilder`, routed by the `[unified_storage.ssosettings.iam.grafana.app]` storage mode — write-both, read-flip at Mode3, legacy-drop at Mode4.

- Adds `Create` to the SSO `LegacyStore` so it satisfies `rest.CreaterUpdater`. SSO is upsert-by-provider, so it delegates to the same `Upsert` as `Update`.
- Replaces the interim either/or store selection with the dual-writer; the legacy store still serves alone on-prem (no MT-Settings client).

## Test plan

`go test ./pkg/registry/apis/iam/...`

Fixes grafana/identity-access-team#2288