### PR TITLE
DataPro (migration): Finish `explore/state/query.ts`

### DIFF
--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -36,7 +36,6 @@ import {
 } from 'app/core/utils/explore';
 import { getShiftedTimeRange } from 'app/core/utils/timePicker';
 import { getCorrelationsFromStorage } from 'app/features/correlations/utils';
-import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 import { getFiscalYearStartMonth, getTimeZone } from 'app/features/profile/state/selectors';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
 import {
@@ -488,7 +487,7 @@ async function handleHistory(
       if (query.datasource?.uid === datasource.uid) {
         return filterQuery(datasource, query);
       } else {
-        const queryDS = await getDatasourceSrv().get(query.datasource);
+        const queryDS = await getDataSourceInstance(query.datasource);
         return filterQuery(queryDS, query);
       }
     })


### PR DESCRIPTION
## Description

Finishes the async `DataSource` migration in `public/app/features/explore/state/query.ts`.

#127510 migrated the four `getDataSourceSrv()` call sites from `@grafana/runtime`, but left the app-internal `getDatasourceSrv()` (lowercase `s`) from `app/features/plugins/datasource_srv`. That accessor returns the concrete `DatasourceSrv` implementing the deprecated interface — the same sync bootData-backed path — so it was still in scope. This migrates the last call site and the file is now fully off `DataSourceSrv`.

## Changes

- `handleHistory`: `await getDatasourceSrv().get(query.datasource)` → `await getDataSourceInstance(query.datasource)`.
- Drop the now-unused `getDatasourceSrv` import. `getDataSourceInstance` was already imported for the file's other call sites, so no new import was needed.

One file, 1 insertion / 2 deletions. No test changes: `query.test.ts` already carries the `@grafana/runtime/unstable` mock added by #127510, and its resolution logic matches the `datasource_srv` mock it replaces.

## Risks

Low. Drop-in swap, already awaited, identical return type (`Promise<DataSourceApi>`).

Two behaviours worth noting, both verified as unchanged:

- **Undefined refs.** The `else` branch is reached whenever `query.datasource?.uid !== datasource.uid`, which includes `query.datasource` being undefined. Legacy `.get(undefined)` returns the default datasource; `getDataSourceInstance(undefined)` resolves to the same default via `settings.ts`.
- **Failure handling.** On failure `getDataSourceInstance` falls back to the legacy `DataSourceSrv` and logs a warning, so resolution behaviour is a superset of the old path rather than a narrowing.

## Demo

No user-visible change — internal refactor.

## Testing Instructions

```
yarn jest --no-watch public/app/features/explore/state/query.test.ts
```

44 tests pass. The full explore suite was also run: 168 suites / 1481 tests green, including `spec/queryHistory.test.tsx`, which drives query history end to end and covers the changed branch.

Note that explore tests mock `@grafana/runtime/unstable`, so the real `getDataSourceInstance` implementation is stubbed here. That path is covered directly in `packages/grafana-runtime/src/services/dataSource/dataSource.test.ts`, consistent with how the earlier call sites in this file were validated.

## Reviewer Checklist

- [ ] No remaining `DataSourceSrv` imports in `query.ts` (`app/features/plugins/datasource_srv` or `@grafana/runtime`).
- [ ] The `handleHistory` mixed-datasource branch behaves the same for both a differing-uid ref and an undefined ref.
- [ ] Agree the mocked-only coverage is acceptable, matching the precedent set by #127510.

---

Part of #125083. Reopened scope from #127033. Closes #130158.

DPRO-299
