### PR TITLE
DataPro (migration): Finish `explore/state/utils.ts`

### DIFF
--- a/public/app/features/explore/state/utils.test.ts
+++ b/public/app/features/explore/state/utils.test.ts
@@ -4,11 +4,10 @@ import * as exploreUtils from 'app/core/utils/explore';
 
 import { loadAndInitDatasource, getRange, fromURLRange, MAX_HISTORY_AUTOCOMPLETE_ITEMS } from './utils';
 
-const dataSourceMock = {
-  get: jest.fn(),
-};
-jest.mock('app/features/plugins/datasource_srv', () => ({
-  getDatasourceSrv: jest.fn(() => dataSourceMock),
+const mockGetDataSourceInstance = jest.fn();
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstance: (...args: unknown[]) => mockGetDataSourceInstance(...args),
 }));
 
 const mockLocalDataStorage = {
@@ -37,22 +36,22 @@ describe('loadAndInitDatasource', () => {
 
   it('falls back to default datasource if the provided one was not found', async () => {
     setLastUsedDatasourceUIDSpy = jest.spyOn(exploreUtils, 'setLastUsedDatasourceUID');
-    dataSourceMock.get.mockRejectedValueOnce(new Error('Datasource not found'));
-    dataSourceMock.get.mockResolvedValue(DEFAULT_DATASOURCE);
+    mockGetDataSourceInstance.mockRejectedValueOnce(new Error('Datasource not found'));
+    mockGetDataSourceInstance.mockResolvedValue(DEFAULT_DATASOURCE);
     mockLocalDataStorage.getRichHistory.mockResolvedValue({ total: 0, richHistory: [] });
 
     const { instance } = await loadAndInitDatasource(1, { uid: 'Unknown' });
 
-    expect(dataSourceMock.get).toBeCalledTimes(2);
-    expect(dataSourceMock.get).toHaveBeenCalledWith({ uid: 'Unknown' });
-    expect(dataSourceMock.get).toHaveBeenCalledWith();
+    expect(mockGetDataSourceInstance).toBeCalledTimes(2);
+    expect(mockGetDataSourceInstance).toHaveBeenCalledWith({ uid: 'Unknown' });
+    expect(mockGetDataSourceInstance).toHaveBeenCalledWith();
     expect(instance).toMatchObject(DEFAULT_DATASOURCE);
     expect(setLastUsedDatasourceUIDSpy).toHaveBeenCalledWith(1, DEFAULT_DATASOURCE.uid);
   });
 
   it('saves last loaded data source uid', async () => {
     setLastUsedDatasourceUIDSpy = jest.spyOn(exploreUtils, 'setLastUsedDatasourceUID');
-    dataSourceMock.get.mockResolvedValue(TEST_DATASOURCE);
+    mockGetDataSourceInstance.mockResolvedValue(TEST_DATASOURCE);
     mockLocalDataStorage.getRichHistory.mockResolvedValue({
       total: 0,
       richHistory: [],
@@ -60,8 +59,8 @@ describe('loadAndInitDatasource', () => {
 
     const { instance } = await loadAndInitDatasource(1, { uid: 'Test' });
 
-    expect(dataSourceMock.get).toHaveBeenCalledTimes(1);
-    expect(dataSourceMock.get).toHaveBeenCalledWith({ uid: 'Test' });
+    expect(mockGetDataSourceInstance).toHaveBeenCalledTimes(1);
+    expect(mockGetDataSourceInstance).toHaveBeenCalledWith({ uid: 'Test' });
     expect(getLocalRichHistoryStorage).toHaveBeenCalledTimes(1);
 
     expect(instance).toMatchObject(TEST_DATASOURCE);
@@ -70,7 +69,7 @@ describe('loadAndInitDatasource', () => {
 
   it('pulls history data and returns the history by query', async () => {
     setLastUsedDatasourceUIDSpy = jest.spyOn(exploreUtils, 'setLastUsedDatasourceUID');
-    dataSourceMock.get.mockResolvedValue(TEST_DATASOURCE);
+    mockGetDataSourceInstance.mockResolvedValue(TEST_DATASOURCE);
     mockLocalDataStorage.getRichHistory.mockResolvedValueOnce({
       total: 1,
       richHistory: [
@@ -93,7 +92,7 @@ describe('loadAndInitDatasource', () => {
 
   it('pulls history data and returns the history by query with Mixed results', async () => {
     setLastUsedDatasourceUIDSpy = jest.spyOn(exploreUtils, 'setLastUsedDatasourceUID');
-    dataSourceMock.get.mockResolvedValue(TEST_DATASOURCE);
+    mockGetDataSourceInstance.mockResolvedValue(TEST_DATASOURCE);
     mockLocalDataStorage.getRichHistory.mockResolvedValueOnce({
       total: 1,
       richHistory: [
@@ -138,7 +137,7 @@ describe('loadAndInitDatasource', () => {
     });
 
     setLastUsedDatasourceUIDSpy = jest.spyOn(exploreUtils, 'setLastUsedDatasourceUID');
-    dataSourceMock.get.mockResolvedValue(TEST_DATASOURCE);
+    mockGetDataSourceInstance.mockResolvedValue(TEST_DATASOURCE);
     mockLocalDataStorage.getRichHistory.mockResolvedValueOnce({
       total: 1,
       richHistory: [

--- a/public/app/features/explore/state/utils.ts
+++ b/public/app/features/explore/state/utils.ts
@@ -30,7 +30,6 @@ import { type ExploreItemState, type ExplorePanelData, type RichHistoryQuery } f
 import { type StoreState } from 'app/types/store';
 
 import { setLastUsedDatasourceUID } from '../../../core/utils/explore';
-import { getDatasourceSrv } from '../../plugins/datasource_srv';
 import { loadSupplementaryQueries } from '../utils/supplementaryQueries';
 
 import { DEFAULT_RANGE } from './constants';
@@ -106,12 +105,12 @@ export async function loadAndInitDatasource(
   let instance: DataSourceApi<DataQuery, DataSourceJsonData, {}>;
   try {
     // let datasource be a ref if we have the info, otherwise a name or uid will do for lookup
-    instance = await getDatasourceSrv().get(datasource);
+    instance = await getDataSourceInstance(datasource);
   } catch (error) {
     // Falling back to the default data source in case the provided data source was not found.
     // It may happen if last used data source or the data source provided in the URL has been
     // removed or it is not provisioned anymore.
-    instance = await getDatasourceSrv().get();
+    instance = await getDataSourceInstance();
   }
   if (instance.init) {
     try {


### PR DESCRIPTION
## Description

Finishes the async data source migration in `public/app/features/explore/state/utils.ts`.

#127511 migrated the single `getDataSourceSrv()` call from `@grafana/runtime` and left the two app-internal `getDatasourceSrv()` (lowercase `s`) calls in place, on the reading that the internal accessor was out of scope. That reading was wrong: the internal accessor returns the concrete `DatasourceSrv` implementing the deprecated interface, and the scope analysis in #127033 covers indirect reach-through explicitly. The file was partially migrated; this finishes it.

The file now has zero `DataSourceSrv` references.

## Changes

**`explore/state/utils.ts`** — both calls in `loadAndInitDatasource`:

- `await getDatasourceSrv().get(datasource)` → `await getDataSourceInstance(datasource)`
- `await getDatasourceSrv().get()` → `await getDataSourceInstance()` (default-datasource fallback)
- Dropped the now-unused `getDatasourceSrv` import. `getDataSourceInstance` was already imported for `getCorrelationsData`, so no new import was needed.

**`explore/state/utils.test.ts`** — rewired the module mock from `app/features/plugins/datasource_srv` to `@grafana/runtime/unstable`, following the pattern in `useDatasourcesFromTargets.test.ts` and `RichHistoryLocalStorage.test.ts`:

- `...jest.requireActual('@grafana/runtime/unstable')` keeps the rest of the export surface intact for transitive importers.
- The mock is referenced through an arrow wrapper so the identifier resolves at call time — naming it directly in the factory hits the TDZ, since Jest invokes the factory during the hoisted `./utils` import.
- The legacy mock is gone entirely; nothing else in the file needed it.

No other `getDataSourceSrv` call sites in Explore are touched — those belong to separate tickets.

## Risks

Low. Behaviour-preserving swap, verified rather than assumed:

- **Default resolution matches.** `getDataSourceInstance()` with no ref resolves through `lookupFromMaps` to `byUid[defaultName] ?? byName[defaultName]`, the same default the legacy `.get()` returned.
- **Still throws on not-found**, so the existing `try`/`catch` fallback to the default data source is unchanged.

One difference worth a reviewer's attention: `getDataSourceInstance` has its own internal legacy fallback — on failure it retries through `DataSourceSrv` before throwing. So the outer `catch` in `loadAndInitDatasource` now fires only when *both* paths fail, where previously it fired whenever legacy `.get()` failed. That narrows the default-datasource fallback rather than widening it, which is the safer direction. It does mean a genuinely-missing data source costs two lookups, and logs `FALLBACK_TO_LEGACY_INSTANCE_WARNING` if the new cache is cold while legacy resolves. That is intended transition behaviour of the new API, not introduced here.

## Demo

No user-visible change — internal accessor swap with identical resolution semantics. Nothing to screenshot.

## Testing Instructions

```
yarn jest --no-watch public/app/features/explore/state/utils.test.ts
```

A `FALLBACK_TO_LEGACY_INSTANCE_WARNING` in the output would mean the mock is wired to the wrong module. The output is clean.

To exercise the fallback path manually: open Explore with a removed or never-provisioned data source UID in the URL (`/explore?left={"datasource":"does-not-exist"}`) and confirm it lands on the default data source.

## Reviewer Checklist

- [ ] Both `loadAndInitDatasource` call sites use `getDataSourceInstance`; no `getDatasourceSrv` references remain in the file
- [ ] Test mocks `@grafana/runtime/unstable`, not `app/features/plugins/datasource_srv`
- [ ] No `FALLBACK_TO_LEGACY_INSTANCE_WARNING` in test output
- [ ] Fallback-to-default semantics preserved for a missing data source ref
- [ ] Change is scoped to `utils.ts` and `utils.test.ts`

---

Follow-up to #127511 · scope analysis #127033 · migration epic #125083 · DPRO-300
