### PR TITLE
Runtime: Resolve expression refs by uid and mid-string variable refs in async datasource APIs

### DIFF
--- a/packages/grafana-runtime/src/services/dataSource/dataSource.test.ts
+++ b/packages/grafana-runtime/src/services/dataSource/dataSource.test.ts
@@ -213,6 +213,23 @@ describe('plugin', () => {
       expect(result).toBe(instance);
     });
 
+    it('resolves a template variable that is not at the start of the ref', async () => {
+      const settings = ds();
+      initDataSourceInstanceSettings({ [settings.name]: settings }, settings.name);
+      setTemplateSrv({
+        getVariables: () => [],
+        replace: (v?: string) => (v === 'logs-${stage}-loki' ? settings.name : (v ?? '')),
+      } as unknown as TemplateSrv);
+
+      const instance = Object.create(DataSourceApi.prototype) as DataSourceApi;
+      setDataSourcePluginImporter(
+        jest.fn().mockResolvedValue({ DataSourceClass: jest.fn().mockReturnValue(instance), components: {} })
+      );
+
+      const result = await getDataSourceInstance('logs-${stage}-loki');
+      expect(result).toBe(instance);
+    });
+
     describe('reference resolution parity with DatasourceSrv.get', () => {
       // Two test-db sources, Bravo is the default.
       const seedAlphaBravo = () => {
@@ -540,6 +557,18 @@ describe('plugin', () => {
 
       const result = await getDataSourceInstance({ type: '__expr__', uid: '__expr__' });
       expect(result).toBe(expr);
+    });
+
+    it('resolves a DataSourceRef with the expression uid but no type', async () => {
+      initDataSourceInstanceSettings({}, '');
+      const expr = registerExpression();
+      const mockImport = jest.fn();
+      setDataSourcePluginImporter(mockImport);
+
+      const result = await getDataSourceInstance({ uid: '__expr__' });
+
+      expect(result).toBe(expr);
+      expect(mockImport).not.toHaveBeenCalled();
     });
 
     it('survives a reload (state is in expressionDs module, independent of the plugin cache)', async () => {

--- a/packages/grafana-runtime/src/services/dataSource/dataSource.ts
+++ b/packages/grafana-runtime/src/services/dataSource/dataSource.ts
@@ -8,7 +8,7 @@ import { FALLBACK_TO_LEGACY_INSTANCE_WARNING } from './constants';
 import { getExpressionDataSourceInstance } from './expressionDs';
 import { describeRef, logDataSourceInstanceError, logDataSourceWarning } from './logging';
 import { getCachedPlugin, setCachedPlugin, setRuntimePlugin } from './pluginCache';
-import { getDataSourceInstanceSettings, getNameOrUid, upsertRuntimeDataSourceInstanceSettings } from './settings';
+import { getDataSourceInstanceSettings, upsertRuntimeDataSourceInstanceSettings } from './settings';
 import { type ImportDataSourcePluginFn } from './types';
 
 let importDataSourcePlugin: ImportDataSourcePluginFn | undefined;
@@ -37,10 +37,7 @@ export async function getDataSourceInstance(
   ref?: DataSourceRef | string | null,
   scopedVars?: ScopedVars
 ): Promise<DataSourceApi> {
-  // Check the uid as well as the full ref: dashboards exist with refs like
-  // `{uid: '__expr__'}` that carry no type, which the legacy DataSourceSrv
-  // recognises as expression refs by uid alone.
-  if (isExpressionReference(ref) || isExpressionReference(getNameOrUid(ref))) {
+  if (isExpressionReference(ref)) {
     const expressionDs = getExpressionDataSourceInstance();
     if (!expressionDs) {
       throw new Error(

--- a/packages/grafana-runtime/src/services/dataSource/dataSource.ts
+++ b/packages/grafana-runtime/src/services/dataSource/dataSource.ts
@@ -8,7 +8,7 @@ import { FALLBACK_TO_LEGACY_INSTANCE_WARNING } from './constants';
 import { getExpressionDataSourceInstance } from './expressionDs';
 import { describeRef, logDataSourceInstanceError, logDataSourceWarning } from './logging';
 import { getCachedPlugin, setCachedPlugin, setRuntimePlugin } from './pluginCache';
-import { getDataSourceInstanceSettings, upsertRuntimeDataSourceInstanceSettings } from './settings';
+import { getDataSourceInstanceSettings, getNameOrUid, upsertRuntimeDataSourceInstanceSettings } from './settings';
 import { type ImportDataSourcePluginFn } from './types';
 
 let importDataSourcePlugin: ImportDataSourcePluginFn | undefined;
@@ -37,7 +37,10 @@ export async function getDataSourceInstance(
   ref?: DataSourceRef | string | null,
   scopedVars?: ScopedVars
 ): Promise<DataSourceApi> {
-  if (isExpressionReference(ref)) {
+  // Check the uid as well as the full ref: dashboards exist with refs like
+  // `{uid: '__expr__'}` that carry no type, which the legacy DataSourceSrv
+  // recognises as expression refs by uid alone.
+  if (isExpressionReference(ref) || isExpressionReference(getNameOrUid(ref))) {
     const expressionDs = getExpressionDataSourceInstance();
     if (!expressionDs) {
       throw new Error(

--- a/packages/grafana-runtime/src/services/dataSource/settings.test.ts
+++ b/packages/grafana-runtime/src/services/dataSource/settings.test.ts
@@ -305,6 +305,19 @@ describe('instanceSettings', () => {
         setTemplateSrv(templateSrv);
       });
 
+      it('resolves a name that contains $ but is not a variable through the plain lookup', async () => {
+        // The shared templateSrv mock returns unknown values unchanged, so
+        // interpolation is a no-op and the lookup must fall through. The variable
+        // wrapper would carry the ref string as uid and a rawRef; the genuine
+        // settings carry neither.
+        const dollar = ds({ id: 9, uid: 'uid-dollar', name: 'cost$db' });
+        initDataSourceInstanceSettings({ ...fixtures, [dollar.name]: dollar }, 'Bravo');
+
+        const result = await getDataSourceInstanceSettings('cost$db');
+        expect(result?.uid).toBe('uid-dollar');
+        expect(result?.rawRef).toBeUndefined();
+      });
+
       it('interpolates a variable that is not at the start of the ref', async () => {
         setTemplateSrv({
           ...templateSrv,

--- a/packages/grafana-runtime/src/services/dataSource/settings.test.ts
+++ b/packages/grafana-runtime/src/services/dataSource/settings.test.ts
@@ -264,6 +264,13 @@ describe('instanceSettings', () => {
         const result = await getDataSourceInstanceSettings({ type: '-100' });
         expect(result?.uid).toBe('__expr__');
       });
+
+      it('resolves a DataSourceRef with the expression uid but no type', async () => {
+        initDataSourceInstanceSettings(fixtures, 'Bravo');
+        setExpressionDataSourceInstance(expressionInstance(fixtures.Expression));
+        const result = await getDataSourceInstanceSettings({ uid: '__expr__' });
+        expect(result?.uid).toBe('__expr__');
+      });
     });
 
     describe('template variables', () => {
@@ -293,6 +300,20 @@ describe('instanceSettings', () => {
         initDataSourceInstanceSettings(fixtures, 'Bravo');
 
         const result = await getDataSourceInstanceSettings('${multi}');
+        expect(result?.rawRef).toEqual({ type: 'test-db', uid: 'uid-alpha' });
+
+        setTemplateSrv(templateSrv);
+      });
+
+      it('interpolates a variable that is not at the start of the ref', async () => {
+        setTemplateSrv({
+          ...templateSrv,
+          replace: (value?: string) => (value === 'logs-${stage}-loki' ? 'Alpha' : (value ?? '')),
+        } as unknown as TemplateSrv);
+        initDataSourceInstanceSettings(fixtures, 'Bravo');
+
+        const result = await getDataSourceInstanceSettings('logs-${stage}-loki');
+        expect(result?.uid).toBe('logs-${stage}-loki');
         expect(result?.rawRef).toEqual({ type: 'test-db', uid: 'uid-alpha' });
 
         setTemplateSrv(templateSrv);

--- a/packages/grafana-runtime/src/services/dataSource/settings.ts
+++ b/packages/grafana-runtime/src/services/dataSource/settings.ts
@@ -241,11 +241,14 @@ function lookupFromMaps(
   ref: DataSourceRef | string | null | undefined,
   scopedVars: ScopedVars | undefined
 ): DataSourceInstanceSettings | undefined {
-  if (isExpressionReference(ref)) {
+  const nameOrUid = getNameOrUid(ref);
+
+  // Check the uid as well as the full ref: dashboards exist with refs like
+  // `{uid: '__expr__'}` that carry no type, which the legacy DataSourceSrv
+  // recognises as expression refs by uid alone.
+  if (isExpressionReference(ref) || isExpressionReference(nameOrUid)) {
     return getExpressionDataSourceSettings();
   }
-
-  const nameOrUid = getNameOrUid(ref);
 
   if (nameOrUid == null || nameOrUid === 'default') {
     if (isDataSourceRef(ref) && ref.type) {
@@ -257,20 +260,25 @@ function lookupFromMaps(
     return byUid[defaultName] ?? byName[defaultName];
   }
 
-  // Template variable reference — interpolate and preserve the raw ref.
-  if (nameOrUid[0] === '$') {
+  // Template variable reference — interpolate and preserve the raw ref. The variable can
+  // sit anywhere in the string (e.g. `logs-${stage}-loki`), not only at the start; legacy
+  // DataSourceSrv.get() interpolates unconditionally. When interpolation changes nothing
+  // (a datasource name that merely contains `$`), fall through to the plain lookup.
+  if (nameOrUid.includes('$')) {
     const interpolated = getTemplateSrv().replace(nameOrUid, scopedVars, variableInterpolation);
-    const resolved = interpolated === 'default' ? byName[defaultName] : (byUid[interpolated] ?? byName[interpolated]);
-    if (!resolved) {
-      return undefined;
+    if (interpolated !== nameOrUid) {
+      const resolved = interpolated === 'default' ? byName[defaultName] : (byUid[interpolated] ?? byName[interpolated]);
+      if (!resolved) {
+        return undefined;
+      }
+      return {
+        ...resolved,
+        isDefault: false,
+        name: nameOrUid,
+        uid: nameOrUid,
+        rawRef: { type: resolved.type, uid: resolved.uid },
+      };
     }
-    return {
-      ...resolved,
-      isDefault: false,
-      name: nameOrUid,
-      uid: nameOrUid,
-      rawRef: { type: resolved.type, uid: resolved.uid },
-    };
   }
 
   return byUid[nameOrUid] ?? byName[nameOrUid] ?? byId[nameOrUid];
@@ -388,7 +396,10 @@ function applyFilters(filters: GetDataSourceListFilters = {}): DataSourceInstanc
   return results;
 }
 
-function getNameOrUid(ref: DataSourceRef | string | null | undefined): string | undefined {
+/**
+ * @internal
+ */
+export function getNameOrUid(ref: DataSourceRef | string | null | undefined): string | undefined {
   if (ref == null) {
     return undefined;
   }

--- a/packages/grafana-runtime/src/services/dataSource/settings.ts
+++ b/packages/grafana-runtime/src/services/dataSource/settings.ts
@@ -241,14 +241,11 @@ function lookupFromMaps(
   ref: DataSourceRef | string | null | undefined,
   scopedVars: ScopedVars | undefined
 ): DataSourceInstanceSettings | undefined {
-  const nameOrUid = getNameOrUid(ref);
-
-  // Check the uid as well as the full ref: dashboards exist with refs like
-  // `{uid: '__expr__'}` that carry no type, which the legacy DataSourceSrv
-  // recognises as expression refs by uid alone.
-  if (isExpressionReference(ref) || isExpressionReference(nameOrUid)) {
+  if (isExpressionReference(ref)) {
     return getExpressionDataSourceSettings();
   }
+
+  const nameOrUid = getNameOrUid(ref);
 
   if (nameOrUid == null || nameOrUid === 'default') {
     if (isDataSourceRef(ref) && ref.type) {
@@ -396,10 +393,7 @@ function applyFilters(filters: GetDataSourceListFilters = {}): DataSourceInstanc
   return results;
 }
 
-/**
- * @internal
- */
-export function getNameOrUid(ref: DataSourceRef | string | null | undefined): string | undefined {
+function getNameOrUid(ref: DataSourceRef | string | null | undefined): string | undefined {
   if (ref == null) {
     return undefined;
   }

--- a/packages/grafana-runtime/src/utils/expressionRef.test.ts
+++ b/packages/grafana-runtime/src/utils/expressionRef.test.ts
@@ -7,6 +7,9 @@ describe('isExpressionReference', () => {
     expect(isExpressionReference('Expression')).toBeTruthy(); // Name
     expect(isExpressionReference({ type: '__expr__' })).toBeTruthy();
     expect(isExpressionReference({ type: '-100' })).toBeTruthy();
+    expect(isExpressionReference({ uid: '__expr__' })).toBeTruthy(); // Uid only, no type
+    expect(isExpressionReference({ uid: '-100' })).toBeTruthy();
+    expect(isExpressionReference({ type: 'prometheus', uid: 'abc' })).toBeFalsy();
     expect(isExpressionReference(null)).toBeFalsy();
     expect(isExpressionReference(undefined)).toBeFalsy();
   });

--- a/packages/grafana-runtime/src/utils/expressionRef.ts
+++ b/packages/grafana-runtime/src/utils/expressionRef.ts
@@ -16,6 +16,16 @@ export function isExpressionReference(ref?: DataSourceRef | string | null): bool
   if (!ref) {
     return false;
   }
-  const v = typeof ref === 'string' ? ref : ref.type;
-  return v === ExpressionDatasourceRef.type || v === ExpressionDatasourceRef.name || v === '-100'; // -100 was a legacy accident that should be removed
+  if (typeof ref === 'string') {
+    return isExpressionValue(ref);
+  }
+  // Check the uid as well as the type: dashboards exist with refs like `{uid: '__expr__'}`
+  // that carry no type, which the legacy DataSourceSrv resolves by uid alone.
+  return isExpressionValue(ref.type) || isExpressionValue(ref.uid);
+}
+
+function isExpressionValue(value: string | undefined): boolean {
+  return (
+    value === ExpressionDatasourceRef.type || value === ExpressionDatasourceRef.name || value === '-100' // -100 was a legacy accident that should be removed
+  );
 }


### PR DESCRIPTION
**What is this feature?**

Fixes the two remaining divergences between the async datasource APIs and the legacy `DataSourceSrv`, found via the fallback-warning logs in Faro (prod telemetry, ~75 fallbacks/day):

- Refs like `{uid: '__expr__'}` with no `type` were not recognised as expression refs. `isExpressionReference` checks `ref.type` on object refs, while the legacy service also matches the uid. The new path now checks both. This was 88% of the fallback volume.
- Datasource names with a template variable in the middle (e.g. `logs-${stage}-loki`) were only interpolated when the ref started with `$`. The legacy `get()` interpolates unconditionally, so the new path now interpolates any ref containing `$`, falling through to the plain lookup when interpolation changes nothing.

**Why do we need this feature?**

These were the last sources of "falling back to legacy DataSourceSrv" warnings in prod, blocking the DataSourceSrv burndown.

**Which issue(s) does this PR fix?**:

**Special notes for your reviewer:**

The equal counts of the settings and instance fallback warnings in the telemetry come from a single `getDataSourceInstance` call for an `{uid: '__expr__'}` ref emitting both, so both should drop to zero together.