### PR TITLE
DataPro (migration): Migrate `correlations/Forms/ConfigureCorrelationSourceForm.tsx`

### DIFF
--- a/public/app/features/correlations/Forms/ConfigureCorrelationSourceForm.test.tsx
+++ b/public/app/features/correlations/Forms/ConfigureCorrelationSourceForm.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+
+import { type DataSourceInstanceSettings } from '@grafana/data';
+import { setTemplateSrv } from '@grafana/runtime';
+import { useDataSourceInstanceSettings } from '@grafana/runtime/unstable';
+import { TemplateSrv } from 'app/features/templating/template_srv';
+
+import { ConfigureCorrelationSourceForm } from './ConfigureCorrelationSourceForm';
+import { type FormDTO } from './types';
+
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  useDataSourceInstanceSettings: jest.fn(),
+}));
+
+// The picker resolves the whole data source list through the srv singleton, which
+// is unrelated to the heading these tests cover.
+jest.mock('app/features/datasources/components/picker/DataSourcePicker', () => ({
+  DataSourcePicker: () => <div />,
+}));
+
+const useDataSourceInstanceSettingsMock = jest.mocked(useDataSourceInstanceSettings);
+
+const Wrapper = ({ children }: { children: ReactNode }) => {
+  const methods = useForm<FormDTO>({
+    defaultValues: { type: 'query', targetUID: 'target-uid', config: { target: {}, field: '' } },
+  });
+  return <FormProvider {...methods}>{children}</FormProvider>;
+};
+
+const renderForm = () =>
+  render(
+    <Wrapper>
+      <ConfigureCorrelationSourceForm />
+    </Wrapper>
+  );
+
+describe('ConfigureCorrelationSourceForm', () => {
+  beforeAll(() => {
+    // The form scans the target query for template variables on every render.
+    setTemplateSrv(new TemplateSrv());
+  });
+
+  afterEach(() => {
+    useDataSourceInstanceSettingsMock.mockReset();
+  });
+
+  it('names the target data source in the heading once it resolves', () => {
+    useDataSourceInstanceSettingsMock.mockReturnValue({
+      isLoading: false,
+      settings: { name: 'Loki' } as DataSourceInstanceSettings,
+    });
+
+    renderForm();
+
+    expect(useDataSourceInstanceSettingsMock).toHaveBeenCalledWith('target-uid');
+    expect(
+      screen.getByRole('group', { name: 'Configure the data source that will link to Loki (Step 3 of 3)' })
+    ).toBeInTheDocument();
+  });
+
+  it('omits the name from the heading while the target data source is loading', () => {
+    useDataSourceInstanceSettingsMock.mockReturnValue({ isLoading: true, settings: undefined });
+
+    renderForm();
+
+    expect(
+      screen.getByRole('group', { name: 'Configure the data source that will link to (Step 3 of 3)' })
+    ).toBeInTheDocument();
+  });
+
+  it('omits the name from the heading when the targetUID does not resolve', () => {
+    useDataSourceInstanceSettingsMock.mockReturnValue({ isLoading: false, settings: undefined });
+
+    renderForm();
+
+    expect(
+      screen.getByRole('group', { name: 'Configure the data source that will link to (Step 3 of 3)' })
+    ).toBeInTheDocument();
+  });
+});

--- a/public/app/features/correlations/Forms/ConfigureCorrelationSourceForm.tsx
+++ b/public/app/features/correlations/Forms/ConfigureCorrelationSourceForm.tsx
@@ -3,9 +3,9 @@ import { Controller, useFormContext } from 'react-hook-form';
 
 import { type DataSourceInstanceSettings, type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
+import { useDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { Card, Field, FieldSet, Input, Stack, useStyles2 } from '@grafana/ui';
 import { DataSourcePicker } from 'app/features/datasources/components/picker/DataSourcePicker';
-import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 
 import { getVariableUsageInfo } from '../../explore/utils/links';
 
@@ -65,9 +65,9 @@ export const ConfigureCorrelationSourceForm = () => {
   const variables = getVariableUsageInfo(currentTargetQuery, {}).variables.map(
     (variable) => variable.variableName + (variable.fieldPath ? `.${variable.fieldPath}` : '')
   );
-  const dataSourceName = getDatasourceSrv().getInstanceSettings(getValues('targetUID'))?.name;
+  const { settings: targetDataSource } = useDataSourceInstanceSettings(getValues('targetUID'));
 
-  const formText = getFormText(currentType, dataSourceName);
+  const formText = getFormText(currentType, targetDataSource?.name);
 
   function VariableList() {
     return (


### PR DESCRIPTION
## Description

`ConfigureCorrelationSourceForm` resolved the target data source name synchronously in its render body, using the app-internal `getDatasourceSrv()` from `app/features/plugins/datasource_srv`. That returns the concrete `DatasourceSrv`, which implements the deprecated `DataSourceSrv` interface, so it is in scope for the migration. This moves the call site to the async `useDataSourceInstanceSettings` hook from `@grafana/runtime/unstable`.

Part of the `getDataSourceSrv` migration (#125083). This is reopened scope from #127033, which treated the app-internal lowercase-s `getDatasourceSrv` as out of scope.

Fixes #130162

## Changes

- Replace `getDatasourceSrv().getInstanceSettings(getValues('targetUID'))?.name` with `useDataSourceInstanceSettings(getValues('targetUID'))`, reading `.name` off the returned settings.
- Remove the `app/features/plugins/datasource_srv` import.
- Add `ConfigureCorrelationSourceForm.test.tsx`. The component had no test file. It covers the step 3 heading in three states: target resolved, target still loading, and `targetUID` that does not resolve.

`getValues('targetUID')` stays as the hook argument. Switching to `watch()` would change when the form re-reads the field, so it is left alone here.

## Risks

Low. The name now resolves asynchronously, so the first render has no name and the heading falls back to its existing no-name form. `dataSourceName` was already optional and `getFormText` already handled its absence, so this path is not new code.

The no-name heading renders on every mount, not just when the uid fails to resolve, because the hook always starts in a loading state. Measured against a local instance with a `MutationObserver` on the legend:

| Legend text | t (ms) |
| --- | --- |
| `Configure the data source that will link to  (Step 3 of 3)` | 73801.7 |
| `Configure the data source that will link to gdev-graphite (Step 3 of 3)` | 73805.6 |

3.9 ms, which is inside a single frame at 60 Hz. It does not paint as a distinct visual state.

## Demo

Step 3 of the Add correlation wizard, with `gdev-graphite` selected as the target in step 2:

```
Configure the data source that will link to gdev-graphite (Step 3 of 3)
```

## Testing Instructions

1. Go to Administration > Plugins and data > Correlations.
2. Click Add correlation.
3. Step 1: enter a label, then Next.
4. Step 2: leave Type as Query, pick any target data source, then Next.
5. Step 3: the heading names the data source picked in step 2.

Unit tests:

```
yarn jest --no-watch public/app/features/correlations
```

The two page-level suites in that directory drive the wizard to step 3, so they exercise this component against the real hook rather than a mock.

## Reviewer Checklist

- [ ] Step 3 heading names the target data source selected in step 2.
- [ ] External-type correlations are unaffected. That heading does not interpolate a data source name.
- [ ] Editing an existing correlation shows the target name on step 3.
- [ ] No console warnings from the async resolution, in particular no legacy cache-miss fallback warning.
