### PR TITLE
FS: Add preview assets override for frontend PR previews

### DIFF
--- a/pkg/api/webassets/webassets.go
+++ b/pkg/api/webassets/webassets.go
@@ -62,7 +62,7 @@ func GetWebAssets(ctx context.Context, buildDir string, cfg *setting.Cfg, licens
 
 	cdn := "" // "https://grafana-assets.grafana.net/grafana/10.3.0-64123/"
 	if cdn != "" {
-		result, err = readWebAssetsFromCDN(ctx, buildDir, cdn)
+		result, err = ReadWebAssetsFromCDN(ctx, buildDir, cdn)
 	}
 
 	assetsFilename := "assets-manifest.json"
@@ -100,7 +100,7 @@ func ReadWebAssetsFromFile(manifestpath string) (*dtos.EntryPointAssets, error) 
 	return readWebAssets(f)
 }
 
-func readWebAssetsFromCDN(ctx context.Context, buildDir string, baseURL string) (*dtos.EntryPointAssets, error) {
+func ReadWebAssetsFromCDN(ctx context.Context, buildDir string, baseURL string) (*dtos.EntryPointAssets, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"public/"+buildDir+"/assets-manifest.json", nil)
 	if err != nil {
 		return nil, err
@@ -112,7 +112,12 @@ func readWebAssetsFromCDN(ctx context.Context, buildDir string, baseURL string) 
 	defer func() {
 		_ = response.Body.Close()
 	}()
-	dto, err := readWebAssets(response.Body)
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code %d fetching assets-manifest.json from %s", response.StatusCode, baseURL)
+	}
+	// Limit the response body size to guard against oversized responses
+	const maxManifestSize = 10 * 1024 * 1024
+	dto, err := readWebAssets(io.LimitReader(response.Body, maxManifestSize))
 	if err == nil {
 		dto.SetContentDeliveryURL(baseURL)
 	}

--- a/pkg/api/webassets/webassets.go
+++ b/pkg/api/webassets/webassets.go
@@ -115,7 +115,6 @@ func ReadWebAssetsFromCDN(ctx context.Context, buildDir string, baseURL string) 
 	if response.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("unexpected status code %d fetching assets-manifest.json from %s", response.StatusCode, baseURL)
 	}
-	// Limit the response body size to guard against oversized responses
 	const maxManifestSize = 10 * 1024 * 1024
 	dto, err := readWebAssets(io.LimitReader(response.Body, maxManifestSize))
 	if err == nil {

--- a/pkg/api/webassets/webassets_test.go
+++ b/pkg/api/webassets/webassets_test.go
@@ -78,7 +78,7 @@ func TestReadWebassets(t *testing.T) {
 func TestReadWebassetsFromCDN(t *testing.T) {
 	t.Skip()
 
-	assets, err := readWebAssetsFromCDN(context.Background(), "build", "https://grafana-assets.grafana.net/grafana/10.3.0-64123/")
+	assets, err := ReadWebAssetsFromCDN(context.Background(), "build", "https://grafana-assets.grafana.net/grafana/10.3.0-64123/")
 	require.NoError(t, err)
 
 	dto, err := json.MarshalIndent(assets, "", "  ")

--- a/pkg/services/frontend/frontend_service.go
+++ b/pkg/services/frontend/frontend_service.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/grafana/pkg/middleware/requestmeta"
 	"github.com/grafana/grafana/pkg/plugins/pluginscdn"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	fswebassets "github.com/grafana/grafana/pkg/services/frontend/webassets"
 	"github.com/grafana/grafana/pkg/services/hooks"
 	"github.com/grafana/grafana/pkg/services/licensing"
 	"github.com/grafana/grafana/pkg/services/publicdashboards"
@@ -57,9 +58,11 @@ type frontendService struct {
 	tracer       trace.Tracer
 	license      licensing.Licensing
 
-	index           *IndexProvider
-	settingsService settingservice.Service // nil if not configured
-	pluginsCDN      *pluginscdn.Service
+	index                *IndexProvider
+	previewCfg           fswebassets.PreviewAssetsConfig
+	previewAssetsHandler *previewAssetsHandler
+	settingsService      settingservice.Service // nil if not configured
+	pluginsCDN           *pluginscdn.Service
 
 	// baggageEvalContextKeys are the W3C baggage member keys copied into the
 	// per-request OpenFeature evaluation context.
@@ -69,7 +72,9 @@ type frontendService struct {
 func ProvideFrontendService(cfg *setting.Cfg, features featuremgmt.FeatureToggles, promGatherer prometheus.Gatherer, promRegister prometheus.Registerer, license licensing.Licensing, hooksService *hooks.HooksService) (*frontendService, error) {
 	logger := log.New("frontend-service")
 
-	index, err := NewIndexProvider(cfg, license, hooksService)
+	previewCfg := fswebassets.ReadPreviewAssetsConfig(cfg)
+
+	index, err := NewIndexProvider(cfg, license, hooksService, previewCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -89,16 +94,18 @@ func ProvideFrontendService(cfg *setting.Cfg, features featuremgmt.FeatureToggle
 	}
 
 	s := &frontendService{
-		cfg:             cfg,
-		features:        features,
-		log:             logger,
-		promGatherer:    promGatherer,
-		promRegister:    promRegister,
-		tracer:          tracer,
-		license:         license,
-		index:           index,
-		settingsService: settingsService,
-		pluginsCDN:      pluginsCDN,
+		cfg:                  cfg,
+		features:             features,
+		log:                  logger,
+		promGatherer:         promGatherer,
+		promRegister:         promRegister,
+		tracer:               tracer,
+		license:              license,
+		index:                index,
+		previewCfg:           previewCfg,
+		previewAssetsHandler: newPreviewAssetsHandler(cfg, previewCfg),
+		settingsService:      settingsService,
+		pluginsCDN:           pluginsCDN,
 
 		baggageEvalContextKeys: readBaggageEvalContextKeys(cfg),
 	}
@@ -198,6 +205,12 @@ func (s *frontendService) registerRoutes(m *web.Mux) {
 	// GET because all POST requests are passed to the backend, even though POST is more correct. The frontend
 	// uses cache busting to ensure requests aren't cached.
 	s.routeGet(m, "/-/fe-boot-error", s.handleBootError)
+
+	// Preview assets opt-in flow. When the feature is disabled (the default)
+	// the route is not registered at all.
+	if s.previewCfg.Active() {
+		s.routeGet(m, previewAssetsPath, s.previewAssetsHandler.handleGet)
+	}
 
 	s.routeGet(m, "/public-dashboards/:accessToken",
 		publicdashboards.SetPublicDashboardAccessToken,

--- a/pkg/services/frontend/frontend_service.go
+++ b/pkg/services/frontend/frontend_service.go
@@ -206,8 +206,7 @@ func (s *frontendService) registerRoutes(m *web.Mux) {
 	// uses cache busting to ensure requests aren't cached.
 	s.routeGet(m, "/-/fe-boot-error", s.handleBootError)
 
-	// Preview assets opt-in flow. When the feature is disabled (the default)
-	// the route is not registered at all.
+	// Preview assets opt-in flow; not registered when the feature is disabled.
 	if s.previewCfg.Active() {
 		s.routeGet(m, previewAssetsPath, s.previewAssetsHandler.handleGet)
 	}

--- a/pkg/services/frontend/frontend_service.go
+++ b/pkg/services/frontend/frontend_service.go
@@ -206,7 +206,7 @@ func (s *frontendService) registerRoutes(m *web.Mux) {
 	// uses cache busting to ensure requests aren't cached.
 	s.routeGet(m, "/-/fe-boot-error", s.handleBootError)
 
-	// Preview assets opt-in flow; not registered when the feature is disabled.
+	// Preview assets MUST NOT be configured unless explicitly enabled.
 	if s.previewCfg.Active() {
 		s.routeGet(m, previewAssetsPath, s.previewAssetsHandler.handleGet)
 	}

--- a/pkg/services/frontend/frontend_service.go
+++ b/pkg/services/frontend/frontend_service.go
@@ -206,8 +206,8 @@ func (s *frontendService) registerRoutes(m *web.Mux) {
 	// uses cache busting to ensure requests aren't cached.
 	s.routeGet(m, "/-/fe-boot-error", s.handleBootError)
 
-	// Preview assets MUST NOT be configured unless explicitly enabled.
-	if s.previewCfg.Active() {
+	// Preview assets MUST NOT be reachable unless explicitly configured.
+	if s.previewCfg.Configured() {
 		s.routeGet(m, previewAssetsPath, s.previewAssetsHandler.handleGet)
 	}
 

--- a/pkg/services/frontend/index.go
+++ b/pkg/services/frontend/index.go
@@ -229,17 +229,15 @@ func (p *IndexProvider) HandleRequest(writer http.ResponseWriter, request *http.
 // resolveAssets returns the preview build's assets when a valid preview cookie is
 // present, falling back to the default assets so a stale cookie can't break the page.
 func (p *IndexProvider) resolveAssets(ctx context.Context, req *http.Request) (dtos.EntryPointAssets, string, error) {
-	if p.previewCfg.Active() {
-		if cookie, err := req.Cookie(previewAssetsCookieName); err == nil && cookie.Value != "" {
-			// Second lock: the cookie only takes effect on stacks that opted in.
-			if namespace, _ := k8srequest.NamespaceFrom(ctx); p.previewCfg.NamespaceAllowed(namespace) {
-				assets, err := fswebassets.GetPreviewWebAssets(ctx, p.previewCfg, cookie.Value)
-				if err == nil {
-					p.log.Info("resolved preview assets", "folder", cookie.Value)
-					return assets, cookie.Value, nil
-				}
-				p.log.Warn("unable to load preview assets, falling back to default assets", "folder", cookie.Value, "err", err)
+	if cookie, err := req.Cookie(previewAssetsCookieName); err == nil && cookie.Value != "" {
+		// The cookie only takes effect on stacks that have opted in.
+		if p.previewCfg.Active(k8srequest.NamespaceValue(ctx)) {
+			assets, err := fswebassets.GetPreviewWebAssets(ctx, p.previewCfg, cookie.Value)
+			if err == nil {
+				p.log.Info("resolved preview assets", "folder", cookie.Value)
+				return assets, cookie.Value, nil
 			}
+			p.log.Warn("unable to load preview assets, falling back to default assets", "folder", cookie.Value, "err", err)
 		}
 	}
 

--- a/pkg/services/frontend/index.go
+++ b/pkg/services/frontend/index.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"syscall"
 
+	k8srequest "k8s.io/apiserver/pkg/endpoints/request"
+
 	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
@@ -226,15 +228,18 @@ func (p *IndexProvider) HandleRequest(writer http.ResponseWriter, request *http.
 
 // resolveAssets returns the preview build's assets when a valid preview cookie is
 // present, falling back to the default assets so a stale cookie can't break the page.
-func (p *IndexProvider) resolveAssets(ctx context.Context, request *http.Request) (dtos.EntryPointAssets, string, error) {
+func (p *IndexProvider) resolveAssets(ctx context.Context, req *http.Request) (dtos.EntryPointAssets, string, error) {
 	if p.previewCfg.Active() {
-		if cookie, err := request.Cookie(previewAssetsCookieName); err == nil && cookie.Value != "" {
-			assets, err := fswebassets.GetPreviewWebAssets(ctx, p.previewCfg, cookie.Value)
-			if err == nil {
-				p.log.Info("resolved preview assets", "folder", cookie.Value)
-				return assets, cookie.Value, nil
+		if cookie, err := req.Cookie(previewAssetsCookieName); err == nil && cookie.Value != "" {
+			// Second lock: the cookie only takes effect on stacks that opted in.
+			if namespace, _ := k8srequest.NamespaceFrom(ctx); p.previewCfg.NamespaceAllowed(namespace) {
+				assets, err := fswebassets.GetPreviewWebAssets(ctx, p.previewCfg, cookie.Value)
+				if err == nil {
+					p.log.Info("resolved preview assets", "folder", cookie.Value)
+					return assets, cookie.Value, nil
+				}
+				p.log.Warn("unable to load preview assets, falling back to default assets", "folder", cookie.Value, "err", err)
 			}
-			p.log.Warn("unable to load preview assets, falling back to default assets", "folder", cookie.Value, "err", err)
 		}
 	}
 

--- a/pkg/services/frontend/index.go
+++ b/pkg/services/frontend/index.go
@@ -229,9 +229,9 @@ func (p *IndexProvider) HandleRequest(writer http.ResponseWriter, request *http.
 // resolveAssets returns the preview build's assets when a valid preview cookie is
 // present, falling back to the default assets so a stale cookie can't break the page.
 func (p *IndexProvider) resolveAssets(ctx context.Context, req *http.Request) (dtos.EntryPointAssets, string, error) {
-	if cookie, err := req.Cookie(previewAssetsCookieName); err == nil && cookie.Value != "" {
-		// The cookie only takes effect on stacks that have opted in.
-		if p.previewCfg.Active(k8srequest.NamespaceValue(ctx)) {
+	// The cookie only takes effect on stacks that have opted in.
+	if p.previewCfg.Active(k8srequest.NamespaceValue(ctx)) {
+		if cookie, err := req.Cookie(previewAssetsCookieName); err == nil && cookie.Value != "" {
 			assets, err := fswebassets.GetPreviewWebAssets(ctx, p.previewCfg, cookie.Value)
 			if err == nil {
 				p.log.Info("resolved preview assets", "folder", cookie.Value)

--- a/pkg/services/frontend/index.go
+++ b/pkg/services/frontend/index.go
@@ -48,8 +48,7 @@ type IndexViewData struct {
 	Assets      dtos.EntryPointAssets // Includes CDN info
 	DefaultUser dtos.CurrentUser
 
-	// PreviewAssetsFolder is set to the preview folder name when the assets
-	// above were loaded from a preview build (see preview_assets.go).
+	// Set when Assets come from a preview build (see preview_assets.go).
 	PreviewAssetsFolder string
 
 	// Nonce is a cryptographic identifier for use with Content Security Policy.
@@ -225,12 +224,8 @@ func (p *IndexProvider) HandleRequest(writer http.ResponseWriter, request *http.
 	}
 }
 
-// resolveAssets returns the entrypoint assets for the request. When the
-// preview assets feature is enabled and the request carries a valid preview
-// cookie, the assets come from the preview build and the returned folder is
-// non-empty. If the preview build cannot be loaded, we fall back to the
-// default assets rather than failing the request, so a stale cookie can never
-// take a browser session down with it.
+// resolveAssets returns the preview build's assets when a valid preview cookie is
+// present, falling back to the default assets so a stale cookie can't break the page.
 func (p *IndexProvider) resolveAssets(ctx context.Context, request *http.Request) (dtos.EntryPointAssets, string, error) {
 	if p.previewCfg.Active() {
 		if cookie, err := request.Cookie(previewAssetsCookieName); err == nil && cookie.Value != "" {

--- a/pkg/services/frontend/index.go
+++ b/pkg/services/frontend/index.go
@@ -1,6 +1,7 @@
 package frontend
 
 import (
+	"context"
 	"embed"
 	"encoding/hex"
 	"errors"
@@ -30,6 +31,7 @@ type IndexProvider struct {
 	config       *setting.Cfg
 	license      licensing.Licensing
 	bootScript   template.JS
+	previewCfg   fswebassets.PreviewAssetsConfig
 }
 
 type IndexViewData struct {
@@ -45,6 +47,10 @@ type IndexViewData struct {
 
 	Assets      dtos.EntryPointAssets // Includes CDN info
 	DefaultUser dtos.CurrentUser
+
+	// PreviewAssetsFolder is set to the preview folder name when the assets
+	// above were loaded from a preview build (see preview_assets.go).
+	PreviewAssetsFolder string
 
 	// Nonce is a cryptographic identifier for use with Content Security Policy.
 	Nonce string
@@ -79,14 +85,14 @@ type IndexViewData struct {
 
 // Templates setup.
 var (
-	//go:embed *.html
+	//go:embed index.html
 	templatesFS embed.FS
 
 	// templates
-	htmlTemplates = template.Must(template.New("html").Delims("[[", "]]").ParseFS(templatesFS, `*.html`))
+	htmlTemplates = template.Must(template.New("html").Delims("[[", "]]").ParseFS(templatesFS, `index.html`))
 )
 
-func NewIndexProvider(cfg *setting.Cfg, license licensing.Licensing, hooksService *hooks.HooksService) (*IndexProvider, error) {
+func NewIndexProvider(cfg *setting.Cfg, license licensing.Licensing, hooksService *hooks.HooksService, previewCfg fswebassets.PreviewAssetsConfig) (*IndexProvider, error) {
 	t := htmlTemplates.Lookup("index.html")
 	if t == nil {
 		return nil, fmt.Errorf("missing index template")
@@ -108,6 +114,7 @@ func NewIndexProvider(cfg *setting.Cfg, license licensing.Licensing, hooksServic
 		hooksService: hooksService,
 		config:       cfg,
 		license:      license,
+		previewCfg:   previewCfg,
 		//nolint:gosec
 		bootScript: template.JS(bootScriptRaw),
 	}, nil
@@ -129,7 +136,7 @@ func (p *IndexProvider) HandleRequest(writer http.ResponseWriter, request *http.
 		return
 	}
 
-	assetsManifest, err := fswebassets.GetWebAssets(ctx, p.config, p.license)
+	assetsManifest, previewFolder, err := p.resolveAssets(ctx, request)
 	if err != nil {
 		p.log.Error("unable to get web assets", "err", err)
 		http.Error(writer, "Internal Server Error", http.StatusInternalServerError)
@@ -157,6 +164,7 @@ func (p *IndexProvider) HandleRequest(writer http.ResponseWriter, request *http.
 		AppSubUrl:                             p.config.AppSubURL,
 		IsDevelopmentEnv:                      p.config.Env == setting.Dev,
 		Assets:                                assetsManifest,
+		PreviewAssetsFolder:                   previewFolder,
 		DefaultUser:                           dtos.CurrentUser{},
 		Nonce:                                 reqCtx.RequestNonce,
 		PublicDashboardAccessToken:            reqCtx.PublicDashboardAccessToken,
@@ -215,6 +223,28 @@ func (p *IndexProvider) HandleRequest(writer http.ResponseWriter, request *http.
 		}
 		panic(fmt.Sprintf("Error rendering index\n %s", err.Error()))
 	}
+}
+
+// resolveAssets returns the entrypoint assets for the request. When the
+// preview assets feature is enabled and the request carries a valid preview
+// cookie, the assets come from the preview build and the returned folder is
+// non-empty. If the preview build cannot be loaded, we fall back to the
+// default assets rather than failing the request, so a stale cookie can never
+// take a browser session down with it.
+func (p *IndexProvider) resolveAssets(ctx context.Context, request *http.Request) (dtos.EntryPointAssets, string, error) {
+	if p.previewCfg.Active() {
+		if cookie, err := request.Cookie(previewAssetsCookieName); err == nil && cookie.Value != "" {
+			assets, err := fswebassets.GetPreviewWebAssets(ctx, p.previewCfg, cookie.Value)
+			if err == nil {
+				p.log.Info("resolved preview assets", "folder", cookie.Value)
+				return assets, cookie.Value, nil
+			}
+			p.log.Error("unable to load preview assets, falling back to default assets", "folder", cookie.Value, "err", err)
+		}
+	}
+
+	assets, err := fswebassets.GetWebAssets(ctx, p.config, p.license)
+	return assets, "", err
 }
 
 func (p *IndexProvider) runIndexDataHooks(reqCtx *contextmodel.ReqContext, data *IndexViewData) {

--- a/pkg/services/frontend/index.go
+++ b/pkg/services/frontend/index.go
@@ -239,7 +239,7 @@ func (p *IndexProvider) resolveAssets(ctx context.Context, request *http.Request
 				p.log.Info("resolved preview assets", "folder", cookie.Value)
 				return assets, cookie.Value, nil
 			}
-			p.log.Error("unable to load preview assets, falling back to default assets", "folder", cookie.Value, "err", err)
+			p.log.Warn("unable to load preview assets, falling back to default assets", "folder", cookie.Value, "err", err)
 		}
 	}
 

--- a/pkg/services/frontend/index.html
+++ b/pkg/services/frontend/index.html
@@ -218,6 +218,11 @@
         window.__grafanaOFREPRootUrlEnabled = true;
       [[end]]
 
+      [[if .PreviewAssetsFolder]]
+        // Set when the assets on this page come from a PR preview build
+        window.__grafanaPreviewAssets = '[[.PreviewAssetsFolder]]';
+      [[end]]
+
       window.__grafanaLegacyAPIMode = [[.LegacyAPIMode]];
       window.__grafanaPublicDashboardAccessToken = [[.PublicDashboardAccessToken]];
 

--- a/pkg/services/frontend/index_test.go
+++ b/pkg/services/frontend/index_test.go
@@ -112,7 +112,7 @@ func TestFrontendService_WebAssets(t *testing.T) {
 		mux := setupPreviewTestMux(t, bucket.URL+"/")
 		previewURL := bucket.URL + "/" + folder + "/"
 
-		req := httptest.NewRequest("GET", "/", nil)
+		req := newPreviewRequest("/")
 		req.AddCookie(&http.Cookie{Name: previewAssetsCookieName, Value: folder})
 		recorder := httptest.NewRecorder()
 		mux.ServeHTTP(recorder, req)
@@ -135,8 +135,25 @@ func TestFrontendService_WebAssets(t *testing.T) {
 		t.Cleanup(bucket.Close)
 		mux := setupPreviewTestMux(t, bucket.URL+"/")
 
-		req := httptest.NewRequest("GET", "/", nil)
+		req := newPreviewRequest("/")
 		req.AddCookie(&http.Cookie{Name: previewAssetsCookieName, Value: "pr_grafana_does_not_exist"})
+		recorder := httptest.NewRecorder()
+		mux.ServeHTTP(recorder, req)
+
+		assert.Equal(t, 200, recorder.Code)
+		body := recorder.Body.String()
+		assert.Contains(t, body, "src=\"public/build/runtime.js\"")
+		assert.NotContains(t, body, "window.__grafanaPreviewAssets")
+	})
+
+	t.Run("should ignore the preview cookie for a namespace that has not opted in", func(t *testing.T) {
+		const folder = "pr_grafana_123456"
+		bucket := newPreviewBucketServer(t, folder)
+		mux := setupPreviewTestMux(t, bucket.URL+"/")
+
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("baggage", "namespace=stacks-other")
+		req.AddCookie(&http.Cookie{Name: previewAssetsCookieName, Value: folder})
 		recorder := httptest.NewRecorder()
 		mux.ServeHTTP(recorder, req)
 

--- a/pkg/services/frontend/index_test.go
+++ b/pkg/services/frontend/index_test.go
@@ -1,6 +1,7 @@
 package frontend
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -103,5 +104,70 @@ func TestFrontendService_WebAssets(t *testing.T) {
 		body := recorder.Body.String()
 		assert.Contains(t, body, "src=\"public/build/runtime.js\" type=\"text/javascript\"")
 		assert.Contains(t, body, "src=\"public/build/app.js\" type=\"text/javascript\"")
+	})
+
+	t.Run("should serve preview assets when the preview cookie is set", func(t *testing.T) {
+		const folder = "pr_grafana_123456"
+		bucket := newPreviewBucketServer(t, folder)
+		mux := setupPreviewTestMux(t, bucket.URL+"/")
+		previewURL := bucket.URL + "/" + folder + "/"
+
+		req := httptest.NewRequest("GET", "/", nil)
+		req.AddCookie(&http.Cookie{Name: previewAssetsCookieName, Value: folder})
+		recorder := httptest.NewRecorder()
+		mux.ServeHTTP(recorder, req)
+
+		assert.Equal(t, 200, recorder.Code)
+		body := recorder.Body.String()
+
+		// Asset URLs should point at the preview build
+		assert.Contains(t, body, previewURL+"public/build/runtime.preview.js")
+		assert.Contains(t, body, previewURL+"public/build/app.preview.js")
+		assert.NotContains(t, body, "src=\"public/build/runtime.js\"")
+		assert.NotContains(t, body, "src=\"public/build/app.js\"")
+
+		// The page should flag that preview assets are active
+		assert.Contains(t, body, "window.__grafanaPreviewAssets = '"+folder+"'")
+	})
+
+	t.Run("should fall back to default assets when the preview build cannot be loaded", func(t *testing.T) {
+		bucket := httptest.NewServer(http.NotFoundHandler())
+		t.Cleanup(bucket.Close)
+		mux := setupPreviewTestMux(t, bucket.URL+"/")
+
+		req := httptest.NewRequest("GET", "/", nil)
+		req.AddCookie(&http.Cookie{Name: previewAssetsCookieName, Value: "pr_grafana_does_not_exist"})
+		recorder := httptest.NewRecorder()
+		mux.ServeHTTP(recorder, req)
+
+		assert.Equal(t, 200, recorder.Code)
+		body := recorder.Body.String()
+		assert.Contains(t, body, "src=\"public/build/runtime.js\"")
+		assert.NotContains(t, body, "window.__grafanaPreviewAssets")
+	})
+
+	t.Run("should ignore the preview cookie when the feature is disabled", func(t *testing.T) {
+		publicDir := setupTestWebAssets(t)
+		cfg := &setting.Cfg{
+			Raw:            ini.Empty(),
+			HTTPPort:       "3000",
+			StaticRootPath: publicDir,
+			Env:            setting.Dev,
+		}
+		service := createTestService(t, cfg)
+
+		mux := web.New()
+		service.addMiddlewares(mux)
+		service.registerRoutes(mux)
+
+		req := httptest.NewRequest("GET", "/", nil)
+		req.AddCookie(&http.Cookie{Name: previewAssetsCookieName, Value: "pr_grafana_123456"})
+		recorder := httptest.NewRecorder()
+		mux.ServeHTTP(recorder, req)
+
+		assert.Equal(t, 200, recorder.Code)
+		body := recorder.Body.String()
+		assert.Contains(t, body, "src=\"public/build/runtime.js\"")
+		assert.NotContains(t, body, "window.__grafanaPreviewAssets")
 	})
 }

--- a/pkg/services/frontend/preview_assets.go
+++ b/pkg/services/frontend/preview_assets.go
@@ -127,6 +127,7 @@ func (h *previewAssetsHandler) renderConfirmationPage(w http.ResponseWriter, log
 		return
 	}
 
+	// #nosec G124 nosemgrep: go.lang.security.audit.net.cookie-missing-secure.cookie-missing-secure -- Secure follows [security] cookie_secure, like all Grafana cookies (see pkg/middleware/cookies)
 	http.SetCookie(w, &http.Cookie{
 		Name:     previewCSRFCookieName,
 		Value:    csrfToken,
@@ -160,6 +161,7 @@ func (h *previewAssetsHandler) renderConfirmationPage(w http.ResponseWriter, log
 }
 
 func (h *previewAssetsHandler) clearCSRFCookie(w http.ResponseWriter) {
+	// #nosec G124 nosemgrep: go.lang.security.audit.net.cookie-missing-secure.cookie-missing-secure -- Secure follows [security] cookie_secure, like all Grafana cookies (see pkg/middleware/cookies)
 	http.SetCookie(w, &http.Cookie{
 		Name:     previewCSRFCookieName,
 		Value:    "",
@@ -172,6 +174,7 @@ func (h *previewAssetsHandler) clearCSRFCookie(w http.ResponseWriter) {
 }
 
 func (h *previewAssetsHandler) setCookie(w http.ResponseWriter, name, value string, maxAge int) {
+	// #nosec G124 nosemgrep: go.lang.security.audit.net.cookie-missing-secure.cookie-missing-secure -- Secure follows [security] cookie_secure, like all Grafana cookies (see pkg/middleware/cookies)
 	http.SetCookie(w, &http.Cookie{
 		Name:     name,
 		Value:    value,

--- a/pkg/services/frontend/preview_assets.go
+++ b/pkg/services/frontend/preview_assets.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"time"
 
+	"k8s.io/apiserver/pkg/endpoints/request"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
 	fswebassets "github.com/grafana/grafana/pkg/services/frontend/webassets"
@@ -53,6 +55,14 @@ func newPreviewAssetsHandler(cfg *setting.Cfg, previewCfg fswebassets.PreviewAss
 func (h *previewAssetsHandler) handleGet(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	logger := contexthandler.FromContext(ctx).Logger
+
+	// Stacks that haven't opted in see an unknown route.
+	namespace, _ := request.NamespaceFrom(ctx)
+	if !h.previewCfg.NamespaceAllowed(namespace) {
+		logger.Debug("preview assets requested by a namespace that has not opted in", "namespace", namespace)
+		http.NotFound(w, r)
+		return
+	}
 
 	query := r.URL.Query()
 

--- a/pkg/services/frontend/preview_assets.go
+++ b/pkg/services/frontend/preview_assets.go
@@ -128,7 +128,8 @@ func (h *previewAssetsHandler) renderConfirmationPage(w http.ResponseWriter, log
 	}
 
 	// Secure follows [security] cookie_secure, like all Grafana cookies (see pkg/middleware/cookies).
-	// #nosec G124 nosemgrep: go.lang.security.audit.net.cookie-missing-secure.cookie-missing-secure
+	// #nosec G124
+	// nosemgrep: go.lang.security.audit.net.cookie-missing-secure.cookie-missing-secure
 	http.SetCookie(w, &http.Cookie{
 		Name:     previewCSRFCookieName,
 		Value:    csrfToken,
@@ -162,7 +163,8 @@ func (h *previewAssetsHandler) renderConfirmationPage(w http.ResponseWriter, log
 
 func (h *previewAssetsHandler) clearCSRFCookie(w http.ResponseWriter) {
 	// Secure follows [security] cookie_secure, like all Grafana cookies (see pkg/middleware/cookies).
-	// #nosec G124 nosemgrep: go.lang.security.audit.net.cookie-missing-secure.cookie-missing-secure
+	// #nosec G124
+	// nosemgrep: go.lang.security.audit.net.cookie-missing-secure.cookie-missing-secure
 	http.SetCookie(w, &http.Cookie{
 		Name:     previewCSRFCookieName,
 		Value:    "",
@@ -176,7 +178,8 @@ func (h *previewAssetsHandler) clearCSRFCookie(w http.ResponseWriter) {
 
 func (h *previewAssetsHandler) setCookie(w http.ResponseWriter, name, value string, maxAge int) {
 	// Secure follows [security] cookie_secure, like all Grafana cookies (see pkg/middleware/cookies).
-	// #nosec G124 nosemgrep: go.lang.security.audit.net.cookie-missing-secure.cookie-missing-secure
+	// #nosec G124
+	// nosemgrep: go.lang.security.audit.net.cookie-missing-secure.cookie-missing-secure
 	http.SetCookie(w, &http.Cookie{
 		Name:     name,
 		Value:    value,

--- a/pkg/services/frontend/preview_assets.go
+++ b/pkg/services/frontend/preview_assets.go
@@ -18,9 +18,7 @@ import (
 const (
 	previewAssetsPath = "/-/set-preview-assets"
 
-	// previewAssetsCookieName stores only the preview folder name, never a URL.
-	// The full asset URL is always constructed server-side from the configured
-	// base URL.
+	// Stores only the folder name; asset URLs are always built server-side.
 	previewAssetsCookieName = "grafana_preview_assets"
 	previewCSRFCookieName   = "grafana_preview_assets_csrf"
 
@@ -51,13 +49,7 @@ func newPreviewAssetsHandler(cfg *setting.Cfg, previewCfg fswebassets.PreviewAss
 }
 
 // handleGet serves the whole opt-in flow. The frontend service only receives
-// GET requests (everything else is routed to the backend), so the confirmation
-// step is also a GET, protected by a CSRF token transmitted as a query
-// parameter and validated against a short-lived cookie:
-//
-//	GET ?assets=<folder>                  confirmation page, sets CSRF cookie
-//	GET ?assets=<folder>&confirm=<token>  sets the preview cookie, redirects to /
-//	GET ?clear=1                          removes the preview cookie, redirects to /
+// GETs, so the confirm step is a CSRF-token-guarded GET rather than a POST.
 func (h *previewAssetsHandler) handleGet(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	logger := contexthandler.FromContext(ctx).Logger
@@ -109,8 +101,7 @@ func (h *previewAssetsHandler) handleGet(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// The CSRF token is single-use: clear it together with setting the
-	// preview cookie.
+	// The CSRF token is single-use: clear it together with setting the preview cookie.
 	h.clearCSRFCookie(w)
 	h.setCookie(w, previewAssetsCookieName, folder, int(previewCookieMaxAge.Seconds()))
 
@@ -141,8 +132,7 @@ func (h *previewAssetsHandler) renderConfirmationPage(w http.ResponseWriter, log
 
 	w.Header().Set("Content-Type", "text/html; charset=UTF-8")
 	w.Header().Set("Cache-Control", "no-store")
-	// The confirmation token travels in the query string; make sure it never
-	// leaks through the Referer header.
+	// The confirmation token travels in the query string; keep it out of Referer.
 	w.Header().Set("Referrer-Policy", "no-referrer")
 
 	err = previewAssetsConfirmTemplate.Execute(w, struct {

--- a/pkg/services/frontend/preview_assets.go
+++ b/pkg/services/frontend/preview_assets.go
@@ -127,7 +127,8 @@ func (h *previewAssetsHandler) renderConfirmationPage(w http.ResponseWriter, log
 		return
 	}
 
-	// #nosec G124 nosemgrep: go.lang.security.audit.net.cookie-missing-secure.cookie-missing-secure -- Secure follows [security] cookie_secure, like all Grafana cookies (see pkg/middleware/cookies)
+	// Secure follows [security] cookie_secure, like all Grafana cookies (see pkg/middleware/cookies).
+	// #nosec G124 nosemgrep: go.lang.security.audit.net.cookie-missing-secure.cookie-missing-secure
 	http.SetCookie(w, &http.Cookie{
 		Name:     previewCSRFCookieName,
 		Value:    csrfToken,
@@ -161,7 +162,8 @@ func (h *previewAssetsHandler) renderConfirmationPage(w http.ResponseWriter, log
 }
 
 func (h *previewAssetsHandler) clearCSRFCookie(w http.ResponseWriter) {
-	// #nosec G124 nosemgrep: go.lang.security.audit.net.cookie-missing-secure.cookie-missing-secure -- Secure follows [security] cookie_secure, like all Grafana cookies (see pkg/middleware/cookies)
+	// Secure follows [security] cookie_secure, like all Grafana cookies (see pkg/middleware/cookies).
+	// #nosec G124 nosemgrep: go.lang.security.audit.net.cookie-missing-secure.cookie-missing-secure
 	http.SetCookie(w, &http.Cookie{
 		Name:     previewCSRFCookieName,
 		Value:    "",
@@ -174,7 +176,8 @@ func (h *previewAssetsHandler) clearCSRFCookie(w http.ResponseWriter) {
 }
 
 func (h *previewAssetsHandler) setCookie(w http.ResponseWriter, name, value string, maxAge int) {
-	// #nosec G124 nosemgrep: go.lang.security.audit.net.cookie-missing-secure.cookie-missing-secure -- Secure follows [security] cookie_secure, like all Grafana cookies (see pkg/middleware/cookies)
+	// Secure follows [security] cookie_secure, like all Grafana cookies (see pkg/middleware/cookies).
+	// #nosec G124 nosemgrep: go.lang.security.audit.net.cookie-missing-secure.cookie-missing-secure
 	http.SetCookie(w, &http.Cookie{
 		Name:     name,
 		Value:    value,

--- a/pkg/services/frontend/preview_assets.go
+++ b/pkg/services/frontend/preview_assets.go
@@ -101,7 +101,6 @@ func (h *previewAssetsHandler) handleGet(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// The CSRF token is single-use: clear it together with setting the preview cookie.
 	h.clearCSRFCookie(w)
 	h.setCookie(w, previewAssetsCookieName, folder, int(previewCookieMaxAge.Seconds()))
 

--- a/pkg/services/frontend/preview_assets.go
+++ b/pkg/services/frontend/preview_assets.go
@@ -1,0 +1,192 @@
+package frontend
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"embed"
+	"encoding/hex"
+	"html/template"
+	"net/http"
+	"time"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/contexthandler"
+	fswebassets "github.com/grafana/grafana/pkg/services/frontend/webassets"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+const (
+	previewAssetsPath = "/-/set-preview-assets"
+
+	// previewAssetsCookieName stores only the preview folder name, never a URL.
+	// The full asset URL is always constructed server-side from the configured
+	// base URL.
+	previewAssetsCookieName = "grafana_preview_assets"
+	previewCSRFCookieName   = "grafana_preview_assets_csrf"
+
+	csrfTokenLength     = 32
+	csrfCookieMaxAge    = 10 * time.Minute
+	previewCookieMaxAge = 24 * time.Hour
+)
+
+var (
+	//go:embed preview_assets_confirm.html
+	previewAssetsTemplateFS embed.FS
+
+	// Parsed with the default {{ }} delimiters; kept separate from the index
+	// template set which uses [[ ]].
+	previewAssetsConfirmTemplate = template.Must(template.ParseFS(previewAssetsTemplateFS, "preview_assets_confirm.html"))
+)
+
+type previewAssetsHandler struct {
+	previewCfg   fswebassets.PreviewAssetsConfig
+	cookieSecure bool
+}
+
+func newPreviewAssetsHandler(cfg *setting.Cfg, previewCfg fswebassets.PreviewAssetsConfig) *previewAssetsHandler {
+	return &previewAssetsHandler{
+		previewCfg:   previewCfg,
+		cookieSecure: cfg.CookieSecure,
+	}
+}
+
+// handleGet serves the whole opt-in flow. The frontend service only receives
+// GET requests (everything else is routed to the backend), so the confirmation
+// step is also a GET, protected by a CSRF token transmitted as a query
+// parameter and validated against a short-lived cookie:
+//
+//	GET ?assets=<folder>                  confirmation page, sets CSRF cookie
+//	GET ?assets=<folder>&confirm=<token>  sets the preview cookie, redirects to /
+//	GET ?clear=1                          removes the preview cookie, redirects to /
+func (h *previewAssetsHandler) handleGet(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	logger := contexthandler.FromContext(ctx).Logger
+
+	query := r.URL.Query()
+
+	if query.Get("clear") != "" {
+		h.setCookie(w, previewAssetsCookieName, "", -1)
+		logger.Info("preview assets cookie cleared")
+		http.Redirect(w, r, "/", http.StatusSeeOther)
+		return
+	}
+
+	folder := query.Get("assets")
+	if folder == "" {
+		http.Error(w, "missing 'assets' query parameter", http.StatusBadRequest)
+		return
+	}
+
+	assetsURL, err := fswebassets.ResolvePreviewAssetsURL(h.previewCfg.BaseURL, folder)
+	if err != nil {
+		logger.Warn("rejected preview assets folder", "folder", folder, "reason", err)
+		http.Error(w, "invalid 'assets' query parameter", http.StatusBadRequest)
+		return
+	}
+
+	confirmToken := query.Get("confirm")
+	if confirmToken == "" {
+		h.renderConfirmationPage(w, logger, folder, assetsURL)
+		return
+	}
+
+	csrfCookie, err := r.Cookie(previewCSRFCookieName)
+	if err != nil || csrfCookie.Value == "" {
+		http.Error(w, "missing or expired confirmation token, go back and try again", http.StatusForbidden)
+		return
+	}
+	if subtle.ConstantTimeCompare([]byte(csrfCookie.Value), []byte(confirmToken)) != 1 {
+		logger.Warn("preview assets confirmation token mismatch", "folder", folder)
+		http.Error(w, "invalid confirmation token, go back and try again", http.StatusForbidden)
+		return
+	}
+
+	// Check the preview build actually exists before committing the browser to
+	// it for 24 hours.
+	if _, err := fswebassets.GetPreviewWebAssets(ctx, h.previewCfg, folder); err != nil {
+		logger.Warn("preview assets manifest could not be loaded", "folder", folder, "err", err)
+		http.Error(w, "preview assets could not be loaded - check the deploy exists and has finished uploading", http.StatusBadGateway)
+		return
+	}
+
+	// The CSRF token is single-use: clear it together with setting the
+	// preview cookie.
+	h.clearCSRFCookie(w)
+	h.setCookie(w, previewAssetsCookieName, folder, int(previewCookieMaxAge.Seconds()))
+
+	logger.Info("preview assets cookie set", "folder", folder, "url", assetsURL)
+
+	http.Redirect(w, r, "/", http.StatusSeeOther)
+}
+
+func (h *previewAssetsHandler) renderConfirmationPage(w http.ResponseWriter, logger log.Logger, folder, assetsURL string) {
+	csrfToken, err := generateCSRFToken()
+	if err != nil {
+		logger.Error("failed to generate CSRF token", "err", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	http.SetCookie(w, &http.Cookie{
+		Name:     previewCSRFCookieName,
+		Value:    csrfToken,
+		Path:     previewAssetsPath,
+		MaxAge:   int(csrfCookieMaxAge.Seconds()),
+		HttpOnly: true,
+		Secure:   h.cookieSecure,
+		SameSite: http.SameSiteStrictMode,
+	})
+
+	w.Header().Set("Content-Type", "text/html; charset=UTF-8")
+	w.Header().Set("Cache-Control", "no-store")
+	// The confirmation token travels in the query string; make sure it never
+	// leaks through the Referer header.
+	w.Header().Set("Referrer-Policy", "no-referrer")
+
+	err = previewAssetsConfirmTemplate.Execute(w, struct {
+		Folder    string
+		AssetsURL string
+		CSRFToken string
+		Duration  string
+	}{
+		Folder:    folder,
+		AssetsURL: assetsURL,
+		CSRFToken: csrfToken,
+		Duration:  "24 hours",
+	})
+	if err != nil {
+		logger.Error("failed to render preview assets confirmation page", "err", err)
+	}
+}
+
+func (h *previewAssetsHandler) clearCSRFCookie(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     previewCSRFCookieName,
+		Value:    "",
+		Path:     previewAssetsPath,
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   h.cookieSecure,
+		SameSite: http.SameSiteStrictMode,
+	})
+}
+
+func (h *previewAssetsHandler) setCookie(w http.ResponseWriter, name, value string, maxAge int) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     name,
+		Value:    value,
+		Path:     "/",
+		MaxAge:   maxAge,
+		HttpOnly: true,
+		Secure:   h.cookieSecure,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+func generateCSRFToken() (string, error) {
+	bytes := make([]byte, csrfTokenLength)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(bytes), nil
+}

--- a/pkg/services/frontend/preview_assets.go
+++ b/pkg/services/frontend/preview_assets.go
@@ -57,8 +57,8 @@ func (h *previewAssetsHandler) handleGet(w http.ResponseWriter, r *http.Request)
 	logger := contexthandler.FromContext(ctx).Logger
 
 	// Stacks that haven't opted in see an unknown route.
-	namespace, _ := request.NamespaceFrom(ctx)
-	if !h.previewCfg.NamespaceAllowed(namespace) {
+	namespace := request.NamespaceValue(ctx)
+	if !h.previewCfg.Active(namespace) {
 		logger.Debug("preview assets requested by a namespace that has not opted in", "namespace", namespace)
 		http.NotFound(w, r)
 		return

--- a/pkg/services/frontend/preview_assets_confirm.html
+++ b/pkg/services/frontend/preview_assets_confirm.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <meta name="referrer" content="no-referrer" />
+    <title>Load preview assets</title>
+    <!-- This page is fully self-contained: all styles are embedded so it never
+         loads external assets, regardless of which asset bundle is active. -->
+    <style>
+      :root {
+        --bg: #f4f5f5;
+        --surface: #ffffff;
+        --border: rgba(36, 41, 46, 0.12);
+        --text: rgb(36, 41, 46);
+        --text-secondary: rgba(36, 41, 46, 0.75);
+        --code-bg: rgba(36, 41, 46, 0.07);
+        --warning-bg: rgba(245, 95, 62, 0.08);
+        --warning-border: rgba(245, 95, 62, 0.5);
+        --primary: #f55f3e;
+        --primary-hover: #d94e30;
+        --secondary-bg: rgba(36, 41, 46, 0.08);
+        --secondary-hover: rgba(36, 41, 46, 0.15);
+      }
+
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #111217;
+          --surface: #181b1f;
+          --border: rgba(204, 204, 220, 0.15);
+          --text: rgb(204, 204, 220);
+          --text-secondary: rgba(204, 204, 220, 0.65);
+          --code-bg: rgba(204, 204, 220, 0.07);
+          --warning-bg: rgba(245, 95, 62, 0.1);
+          --warning-border: rgba(245, 95, 62, 0.5);
+          --secondary-bg: rgba(204, 204, 220, 0.1);
+          --secondary-hover: rgba(204, 204, 220, 0.16);
+        }
+      }
+
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial,
+          sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        min-height: 100dvh;
+        margin: 0;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.5;
+      }
+
+      main {
+        max-width: 600px;
+        margin: 1rem;
+        padding: 2rem;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        background: var(--surface);
+      }
+
+      h1 {
+        font-size: 1.25rem;
+        margin: 0 0 1rem;
+      }
+
+      p {
+        margin: 0 0 0.75rem;
+        color: var(--text-secondary);
+      }
+
+      .url {
+        word-break: break-all;
+        background: var(--code-bg);
+        padding: 0.5rem 0.75rem;
+        border-radius: 4px;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        font-size: 0.8125rem;
+        margin-bottom: 0.75rem;
+      }
+
+      .warning {
+        padding: 0.75rem;
+        background: var(--warning-bg);
+        border: 1px solid var(--warning-border);
+        border-radius: 4px;
+        font-size: 0.8125rem;
+      }
+
+      .actions {
+        margin-top: 1.5rem;
+        display: flex;
+        gap: 0.75rem;
+        align-items: center;
+      }
+
+      button,
+      .cancel {
+        display: inline-block;
+        padding: 0.5rem 1rem;
+        border-radius: 4px;
+        border: none;
+        cursor: pointer;
+        font-size: 0.875rem;
+        font-family: inherit;
+        text-decoration: none;
+        line-height: 1.5;
+      }
+
+      button {
+        background: var(--primary);
+        color: #fff;
+      }
+
+      button:hover {
+        background: var(--primary-hover);
+      }
+
+      .cancel {
+        background: var(--secondary-bg);
+        color: var(--text);
+      }
+
+      .cancel:hover {
+        background: var(--secondary-hover);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Load preview assets?</h1>
+      <p>
+        You are about to load the frontend assets from the preview build
+        <strong>{{.Folder}}</strong>:
+      </p>
+      <div class="url">{{.AssetsURL}}</div>
+      <div class="warning">
+        This replaces the Grafana frontend in this browser with unreviewed, unreleased code for
+        {{.Duration}}. Only continue if you trust the pull request these assets were built from.
+        You can undo this at any time by visiting
+        <code>/-/set-preview-assets?clear=1</code>.
+      </div>
+      <form method="GET" action="/-/set-preview-assets">
+        <input type="hidden" name="assets" value="{{.Folder}}" />
+        <input type="hidden" name="confirm" value="{{.CSRFToken}}" />
+        <div class="actions">
+          <button type="submit">Load preview assets</button>
+          <a class="cancel" href="/">Cancel</a>
+        </div>
+      </form>
+    </main>
+  </body>
+</html>

--- a/pkg/services/frontend/preview_assets_confirm.html
+++ b/pkg/services/frontend/preview_assets_confirm.html
@@ -5,8 +5,6 @@
     <meta name="viewport" content="width=device-width" />
     <meta name="referrer" content="no-referrer" />
     <title>Load preview assets</title>
-    <!-- This page is fully self-contained: all styles are embedded so it never
-         loads external assets, regardless of which asset bundle is active. -->
     <style>
       :root {
         --bg: #f4f5f5;

--- a/pkg/services/frontend/preview_assets_test.go
+++ b/pkg/services/frontend/preview_assets_test.go
@@ -15,6 +15,9 @@ import (
 	"github.com/grafana/grafana/pkg/web"
 )
 
+// previewTestNamespace is allowlisted in setupPreviewTestMux.
+const previewTestNamespace = "stacks-123456"
+
 // previewTestManifest is served by the mock bucket server in preview assets tests.
 const previewTestManifest = `{
 	"entrypoints": {
@@ -52,6 +55,7 @@ func setupPreviewTestMux(t *testing.T, previewBaseURL string) *web.Mux {
 	raw := ini.Empty()
 	raw.Section("frontend_service").Key("preview_assets_enabled").SetValue("true")
 	raw.Section("frontend_service").Key("preview_assets_base_url").SetValue(previewBaseURL)
+	raw.Section("frontend_service").Key("preview_assets_allowed_namespaces").SetValue(previewTestNamespace)
 
 	cfg := &setting.Cfg{
 		Raw:            raw,
@@ -65,6 +69,14 @@ func setupPreviewTestMux(t *testing.T, previewBaseURL string) *web.Mux {
 	service.addMiddlewares(mux)
 	service.registerRoutes(mux)
 	return mux
+}
+
+// newPreviewRequest makes a request from a namespace that has opted in to
+// preview assets.
+func newPreviewRequest(target string) *http.Request {
+	req := httptest.NewRequest("GET", target, nil)
+	req.Header.Set("baggage", "namespace="+previewTestNamespace)
+	return req
 }
 
 func getCookie(t *testing.T, resp *http.Response, name string) *http.Cookie {
@@ -91,7 +103,7 @@ func TestPreviewAssets_RouteNotRegisteredWhenDisabled(t *testing.T) {
 	service.addMiddlewares(mux)
 	service.registerRoutes(mux)
 
-	req := httptest.NewRequest("GET", "/-/set-preview-assets?assets=pr_grafana_123", nil)
+	req := newPreviewRequest("/-/set-preview-assets?assets=pr_grafana_123")
 	recorder := httptest.NewRecorder()
 	mux.ServeHTTP(recorder, req)
 
@@ -106,7 +118,7 @@ func TestPreviewAssets_ConfirmationPage(t *testing.T) {
 	mux := setupPreviewTestMux(t, "https://storage.example.com/bucket/")
 
 	t.Run("should render confirmation page with resolved URL and CSRF cookie", func(t *testing.T) {
-		req := httptest.NewRequest("GET", "/-/set-preview-assets?assets=pr_grafana_123456", nil)
+		req := newPreviewRequest("/-/set-preview-assets?assets=pr_grafana_123456")
 		recorder := httptest.NewRecorder()
 		mux.ServeHTTP(recorder, req)
 
@@ -126,7 +138,7 @@ func TestPreviewAssets_ConfirmationPage(t *testing.T) {
 	})
 
 	t.Run("should reject missing assets parameter", func(t *testing.T) {
-		req := httptest.NewRequest("GET", "/-/set-preview-assets", nil)
+		req := newPreviewRequest("/-/set-preview-assets")
 		recorder := httptest.NewRecorder()
 		mux.ServeHTTP(recorder, req)
 
@@ -135,7 +147,7 @@ func TestPreviewAssets_ConfirmationPage(t *testing.T) {
 
 	t.Run("should reject invalid folder names", func(t *testing.T) {
 		for _, folder := range []string{"../etc/passwd", "foo bar", "a?b=c", "<script>", "foo/bar", "foo.bar"} {
-			req := httptest.NewRequest("GET", "/-/set-preview-assets?assets="+url.QueryEscape(folder), nil)
+			req := newPreviewRequest("/-/set-preview-assets?assets=" + url.QueryEscape(folder))
 			recorder := httptest.NewRecorder()
 			mux.ServeHTTP(recorder, req)
 
@@ -158,7 +170,7 @@ func TestPreviewAssets_Confirm(t *testing.T) {
 		mux := setupPreviewTestMux(t, bucket.URL+"/")
 
 		// Fetch the confirmation page to obtain a CSRF token
-		req := httptest.NewRequest("GET", "/-/set-preview-assets?assets="+folder, nil)
+		req := newPreviewRequest("/-/set-preview-assets?assets=" + folder)
 		recorder := httptest.NewRecorder()
 		mux.ServeHTTP(recorder, req)
 		require.Equal(t, 200, recorder.Code)
@@ -171,7 +183,7 @@ func TestPreviewAssets_Confirm(t *testing.T) {
 	t.Run("should set the preview cookie for a valid confirmation", func(t *testing.T) {
 		mux, token := setup(t)
 
-		req := httptest.NewRequest("GET", confirmURL(token), nil)
+		req := newPreviewRequest(confirmURL(token))
 		req.AddCookie(&http.Cookie{Name: previewCSRFCookieName, Value: token})
 		recorder := httptest.NewRecorder()
 		mux.ServeHTTP(recorder, req)
@@ -194,7 +206,7 @@ func TestPreviewAssets_Confirm(t *testing.T) {
 	t.Run("should reject a confirmation without the CSRF cookie", func(t *testing.T) {
 		mux, token := setup(t)
 
-		req := httptest.NewRequest("GET", confirmURL(token), nil)
+		req := newPreviewRequest(confirmURL(token))
 		recorder := httptest.NewRecorder()
 		mux.ServeHTTP(recorder, req)
 
@@ -205,7 +217,7 @@ func TestPreviewAssets_Confirm(t *testing.T) {
 	t.Run("should reject a mismatched confirmation token", func(t *testing.T) {
 		mux, token := setup(t)
 
-		req := httptest.NewRequest("GET", confirmURL("not-the-right-token"), nil)
+		req := newPreviewRequest(confirmURL("not-the-right-token"))
 		req.AddCookie(&http.Cookie{Name: previewCSRFCookieName, Value: token})
 		recorder := httptest.NewRecorder()
 		mux.ServeHTTP(recorder, req)
@@ -220,13 +232,13 @@ func TestPreviewAssets_Confirm(t *testing.T) {
 		t.Cleanup(bucket.Close)
 		mux := setupPreviewTestMux(t, bucket.URL+"/")
 
-		req := httptest.NewRequest("GET", "/-/set-preview-assets?assets="+folder, nil)
+		req := newPreviewRequest("/-/set-preview-assets?assets=" + folder)
 		recorder := httptest.NewRecorder()
 		mux.ServeHTTP(recorder, req)
 		require.Equal(t, 200, recorder.Code)
 		token := getCookie(t, recorder.Result(), previewCSRFCookieName).Value
 
-		req = httptest.NewRequest("GET", confirmURL(token), nil)
+		req = newPreviewRequest(confirmURL(token))
 		req.AddCookie(&http.Cookie{Name: previewCSRFCookieName, Value: token})
 		recorder = httptest.NewRecorder()
 		mux.ServeHTTP(recorder, req)
@@ -239,7 +251,7 @@ func TestPreviewAssets_Confirm(t *testing.T) {
 func TestPreviewAssets_Clear(t *testing.T) {
 	mux := setupPreviewTestMux(t, "https://storage.example.com/bucket/")
 
-	req := httptest.NewRequest("GET", "/-/set-preview-assets?clear=1", nil)
+	req := newPreviewRequest("/-/set-preview-assets?clear=1")
 	req.AddCookie(&http.Cookie{Name: previewAssetsCookieName, Value: "pr_grafana_123456"})
 	recorder := httptest.NewRecorder()
 	mux.ServeHTTP(recorder, req)
@@ -251,4 +263,27 @@ func TestPreviewAssets_Clear(t *testing.T) {
 	require.NotNil(t, previewCookie)
 	assert.Equal(t, "", previewCookie.Value)
 	assert.Equal(t, -1, previewCookie.MaxAge)
+}
+
+func TestPreviewAssets_NamespaceLock(t *testing.T) {
+	mux := setupPreviewTestMux(t, "https://storage.example.com/bucket/")
+
+	t.Run("should 404 for a namespace that has not opted in", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/-/set-preview-assets?assets=pr_grafana_123456", nil)
+		req.Header.Set("baggage", "namespace=stacks-other")
+		recorder := httptest.NewRecorder()
+		mux.ServeHTTP(recorder, req)
+
+		assert.Equal(t, 404, recorder.Code)
+		assert.Nil(t, getCookie(t, recorder.Result(), previewCSRFCookieName))
+	})
+
+	t.Run("should 404 for a request without a namespace", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/-/set-preview-assets?assets=pr_grafana_123456", nil)
+		recorder := httptest.NewRecorder()
+		mux.ServeHTTP(recorder, req)
+
+		assert.Equal(t, 404, recorder.Code)
+		assert.Nil(t, getCookie(t, recorder.Result(), previewCSRFCookieName))
+	})
 }

--- a/pkg/services/frontend/preview_assets_test.go
+++ b/pkg/services/frontend/preview_assets_test.go
@@ -1,0 +1,254 @@
+package frontend
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/ini.v1"
+
+	fswebassets "github.com/grafana/grafana/pkg/services/frontend/webassets"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/web"
+)
+
+// previewTestManifest is served by the mock bucket server in preview assets tests.
+const previewTestManifest = `{
+	"entrypoints": {
+		"app": {
+			"assets": {
+				"js": ["public/build/runtime.preview.js", "public/build/app.preview.js"],
+				"css": ["public/build/grafana.app.preview.css"]
+			}
+		},
+		"dark": { "assets": { "css": ["public/build/grafana.dark.preview.css"] } },
+		"light": { "assets": { "css": ["public/build/grafana.light.preview.css"] } }
+	}
+}`
+
+// newPreviewBucketServer returns a server that serves previewTestManifest for
+// the given folder, mimicking the GCS bucket layout the CI workflow uploads.
+func newPreviewBucketServer(t *testing.T, folder string) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/"+folder+"/public/build/assets-manifest.json" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(previewTestManifest))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func setupPreviewTestMux(t *testing.T, previewBaseURL string) *web.Mux {
+	t.Helper()
+	fswebassets.ResetPreviewAssetsCache()
+
+	raw := ini.Empty()
+	raw.Section("frontend_service").Key("preview_assets_enabled").SetValue("true")
+	raw.Section("frontend_service").Key("preview_assets_base_url").SetValue(previewBaseURL)
+
+	cfg := &setting.Cfg{
+		Raw:            raw,
+		HTTPPort:       "3000",
+		StaticRootPath: setupTestWebAssets(t),
+		Env:            setting.Dev,
+	}
+	service := createTestService(t, cfg)
+
+	mux := web.New()
+	service.addMiddlewares(mux)
+	service.registerRoutes(mux)
+	return mux
+}
+
+func getCookie(t *testing.T, resp *http.Response, name string) *http.Cookie {
+	t.Helper()
+	for _, c := range resp.Cookies() {
+		if c.Name == name {
+			return c
+		}
+	}
+	return nil
+}
+
+func TestPreviewAssets_RouteNotRegisteredWhenDisabled(t *testing.T) {
+	publicDir := setupTestWebAssets(t)
+	cfg := &setting.Cfg{
+		Raw:            ini.Empty(),
+		HTTPPort:       "3000",
+		StaticRootPath: publicDir,
+		Env:            setting.Dev,
+	}
+	service := createTestService(t, cfg)
+
+	mux := web.New()
+	service.addMiddlewares(mux)
+	service.registerRoutes(mux)
+
+	req := httptest.NewRequest("GET", "/-/set-preview-assets?assets=pr_grafana_123", nil)
+	recorder := httptest.NewRecorder()
+	mux.ServeHTTP(recorder, req)
+
+	// The route should not exist, so the request falls through to the index
+	// wildcard and renders the app.
+	assert.Equal(t, 200, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), "<div id=\"reactRoot\"></div>")
+	assert.NotContains(t, recorder.Body.String(), "Load preview assets")
+}
+
+func TestPreviewAssets_ConfirmationPage(t *testing.T) {
+	mux := setupPreviewTestMux(t, "https://storage.example.com/bucket/")
+
+	t.Run("should render confirmation page with resolved URL and CSRF cookie", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/-/set-preview-assets?assets=pr_grafana_123456", nil)
+		recorder := httptest.NewRecorder()
+		mux.ServeHTTP(recorder, req)
+
+		assert.Equal(t, 200, recorder.Code)
+		body := recorder.Body.String()
+		assert.Contains(t, body, "pr_grafana_123456")
+		assert.Contains(t, body, "https://storage.example.com/bucket/pr_grafana_123456/")
+		assert.Contains(t, body, `name="confirm"`)
+		assert.Equal(t, "no-referrer", recorder.Header().Get("Referrer-Policy"))
+		assert.Contains(t, recorder.Header().Get("Cache-Control"), "no-store")
+
+		csrfCookie := getCookie(t, recorder.Result(), previewCSRFCookieName)
+		require.NotNil(t, csrfCookie, "CSRF cookie should be set")
+		assert.True(t, csrfCookie.HttpOnly)
+		assert.Equal(t, previewAssetsPath, csrfCookie.Path)
+		assert.Contains(t, body, csrfCookie.Value, "page should embed the CSRF token")
+	})
+
+	t.Run("should reject missing assets parameter", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/-/set-preview-assets", nil)
+		recorder := httptest.NewRecorder()
+		mux.ServeHTTP(recorder, req)
+
+		assert.Equal(t, 400, recorder.Code)
+	})
+
+	t.Run("should reject invalid folder names", func(t *testing.T) {
+		for _, folder := range []string{"../etc/passwd", "foo bar", "a?b=c", "<script>", "foo/bar", "foo.bar"} {
+			req := httptest.NewRequest("GET", "/-/set-preview-assets?assets="+url.QueryEscape(folder), nil)
+			recorder := httptest.NewRecorder()
+			mux.ServeHTTP(recorder, req)
+
+			assert.Equal(t, 400, recorder.Code, "should reject folder: %s", folder)
+			// Error responses must never echo the input back
+			assert.NotContains(t, recorder.Body.String(), folder)
+		}
+	})
+}
+
+func TestPreviewAssets_Confirm(t *testing.T) {
+	const folder = "pr_grafana_123456"
+
+	confirmURL := func(token string) string {
+		return "/-/set-preview-assets?assets=" + folder + "&confirm=" + url.QueryEscape(token)
+	}
+
+	setup := func(t *testing.T) (*web.Mux, string) {
+		bucket := newPreviewBucketServer(t, folder)
+		mux := setupPreviewTestMux(t, bucket.URL+"/")
+
+		// Fetch the confirmation page to obtain a CSRF token
+		req := httptest.NewRequest("GET", "/-/set-preview-assets?assets="+folder, nil)
+		recorder := httptest.NewRecorder()
+		mux.ServeHTTP(recorder, req)
+		require.Equal(t, 200, recorder.Code)
+
+		csrfCookie := getCookie(t, recorder.Result(), previewCSRFCookieName)
+		require.NotNil(t, csrfCookie)
+		return mux, csrfCookie.Value
+	}
+
+	t.Run("should set the preview cookie for a valid confirmation", func(t *testing.T) {
+		mux, token := setup(t)
+
+		req := httptest.NewRequest("GET", confirmURL(token), nil)
+		req.AddCookie(&http.Cookie{Name: previewCSRFCookieName, Value: token})
+		recorder := httptest.NewRecorder()
+		mux.ServeHTTP(recorder, req)
+
+		assert.Equal(t, 303, recorder.Code)
+		assert.Equal(t, "/", recorder.Header().Get("Location"))
+
+		previewCookie := getCookie(t, recorder.Result(), previewAssetsCookieName)
+		require.NotNil(t, previewCookie, "preview cookie should be set")
+		assert.Equal(t, folder, previewCookie.Value, "cookie should store only the folder name")
+		assert.True(t, previewCookie.HttpOnly)
+		assert.Equal(t, "/", previewCookie.Path)
+		assert.Equal(t, int(previewCookieMaxAge.Seconds()), previewCookie.MaxAge, "cookie should expire after 24 hours")
+
+		csrfCookie := getCookie(t, recorder.Result(), previewCSRFCookieName)
+		require.NotNil(t, csrfCookie)
+		assert.Equal(t, -1, csrfCookie.MaxAge, "CSRF cookie should be cleared")
+	})
+
+	t.Run("should reject a confirmation without the CSRF cookie", func(t *testing.T) {
+		mux, token := setup(t)
+
+		req := httptest.NewRequest("GET", confirmURL(token), nil)
+		recorder := httptest.NewRecorder()
+		mux.ServeHTTP(recorder, req)
+
+		assert.Equal(t, 403, recorder.Code)
+		assert.Nil(t, getCookie(t, recorder.Result(), previewAssetsCookieName))
+	})
+
+	t.Run("should reject a mismatched confirmation token", func(t *testing.T) {
+		mux, token := setup(t)
+
+		req := httptest.NewRequest("GET", confirmURL("not-the-right-token"), nil)
+		req.AddCookie(&http.Cookie{Name: previewCSRFCookieName, Value: token})
+		recorder := httptest.NewRecorder()
+		mux.ServeHTTP(recorder, req)
+
+		assert.Equal(t, 403, recorder.Code)
+		assert.Nil(t, getCookie(t, recorder.Result(), previewAssetsCookieName))
+	})
+
+	t.Run("should not set the cookie when the preview build does not exist", func(t *testing.T) {
+		// Bucket server that 404s everything
+		bucket := httptest.NewServer(http.NotFoundHandler())
+		t.Cleanup(bucket.Close)
+		mux := setupPreviewTestMux(t, bucket.URL+"/")
+
+		req := httptest.NewRequest("GET", "/-/set-preview-assets?assets="+folder, nil)
+		recorder := httptest.NewRecorder()
+		mux.ServeHTTP(recorder, req)
+		require.Equal(t, 200, recorder.Code)
+		token := getCookie(t, recorder.Result(), previewCSRFCookieName).Value
+
+		req = httptest.NewRequest("GET", confirmURL(token), nil)
+		req.AddCookie(&http.Cookie{Name: previewCSRFCookieName, Value: token})
+		recorder = httptest.NewRecorder()
+		mux.ServeHTTP(recorder, req)
+
+		assert.Equal(t, 502, recorder.Code)
+		assert.Nil(t, getCookie(t, recorder.Result(), previewAssetsCookieName))
+	})
+}
+
+func TestPreviewAssets_Clear(t *testing.T) {
+	mux := setupPreviewTestMux(t, "https://storage.example.com/bucket/")
+
+	req := httptest.NewRequest("GET", "/-/set-preview-assets?clear=1", nil)
+	req.AddCookie(&http.Cookie{Name: previewAssetsCookieName, Value: "pr_grafana_123456"})
+	recorder := httptest.NewRecorder()
+	mux.ServeHTTP(recorder, req)
+
+	assert.Equal(t, 303, recorder.Code)
+	assert.Equal(t, "/", recorder.Header().Get("Location"))
+
+	previewCookie := getCookie(t, recorder.Result(), previewAssetsCookieName)
+	require.NotNil(t, previewCookie)
+	assert.Equal(t, "", previewCookie.Value)
+	assert.Equal(t, -1, previewCookie.MaxAge)
+}

--- a/pkg/services/frontend/preview_assets_test.go
+++ b/pkg/services/frontend/preview_assets_test.go
@@ -53,7 +53,6 @@ func setupPreviewTestMux(t *testing.T, previewBaseURL string) *web.Mux {
 	fswebassets.ResetPreviewAssetsCache()
 
 	raw := ini.Empty()
-	raw.Section("frontend_service").Key("preview_assets_enabled").SetValue("true")
 	raw.Section("frontend_service").Key("preview_assets_base_url").SetValue(previewBaseURL)
 	raw.Section("frontend_service").Key("preview_assets_allowed_namespaces").SetValue(previewTestNamespace)
 

--- a/pkg/services/frontend/webassets/preview.go
+++ b/pkg/services/frontend/webassets/preview.go
@@ -15,52 +15,37 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-// validPreviewAssetsFolder matches deploy IDs created by the deploy-frontend-preview
-// CI workflow, e.g. pr_grafana_123456. Deliberately strict so a folder name can
-// never introduce new path segments or URL metacharacters.
+// Deploy IDs like pr_grafana_123456. Deliberately strict so a folder can never
+// introduce path segments or URL metacharacters.
 var validPreviewAssetsFolder = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
 
 const (
 	maxPreviewAssetsFolderLength = 128
 
-	// previewCacheTTL keeps remote manifest fetches off the hot path while still
-	// picking up re-deploys of the same preview folder quickly. Failed lookups
-	// are cached for the same period: the preview cookie lives for 24 hours and
-	// its folder can vanish from the bucket, so without negative caching every
-	// page load would pay a blocking remote roundtrip just to fall back to the
-	// default assets.
+	// Applies to failures too: without negative caching, every page load with a
+	// stale preview cookie would pay a blocking remote fetch.
 	previewCacheTTL = 30 * time.Second
 
-	// previewFetchTimeout bounds the manifest fetch: the shared HTTP client
-	// (webassets.ReadWebAssetsFromCDN) sets no timeout of its own, and the
-	// fetch runs detached from the caller's context (see GetPreviewWebAssets).
+	// The shared HTTP client has no timeout of its own, and the fetch runs
+	// detached from the caller's context.
 	previewFetchTimeout = 10 * time.Second
 )
 
-// PreviewAssetsConfig configures serving frontend assets from a preview build
-// uploaded by CI instead of the release assets. This is a development-only
-// feature: it must never be enabled in production because it serves
-// non-released JavaScript to the browser.
+// PreviewAssetsConfig configures serving frontend assets from a CI-uploaded
+// preview build instead of the release assets. Never enable in production.
 type PreviewAssetsConfig struct {
-	// Enabled turns the preview assets feature on. When false (the default)
-	// the preview routes are not registered and cookies are ignored.
 	Enabled bool
 
-	// BaseURL is the only origin preview assets can be loaded from. A per-user
-	// folder name is appended to it server-side, so requests can never point
-	// the service at an arbitrary origin.
+	// The only origin previews can load from; folder names are appended server-side.
 	BaseURL string
 }
 
-// Active returns true only when the feature is both enabled and has a base URL
-// to resolve preview folders against.
 func (c PreviewAssetsConfig) Active() bool {
 	return c.Enabled && c.BaseURL != ""
 }
 
-// ReadPreviewAssetsConfig reads the preview assets configuration. It is
-// startup-time, cluster-wide configuration and deliberately cannot be
-// overridden per tenant via the settings service.
+// ReadPreviewAssetsConfig reads startup-time, cluster-wide configuration;
+// deliberately not overridable per tenant via the settings service.
 func ReadPreviewAssetsConfig(cfg *setting.Cfg) PreviewAssetsConfig {
 	sec := cfg.SectionWithEnvOverrides("frontend_service")
 	return PreviewAssetsConfig{
@@ -69,9 +54,7 @@ func ReadPreviewAssetsConfig(cfg *setting.Cfg) PreviewAssetsConfig {
 	}
 }
 
-// ResolvePreviewAssetsURL builds the full assets URL for a preview folder,
-// validating the folder name so the result always stays under the configured
-// base URL.
+// ResolvePreviewAssetsURL validates the folder name and roots the URL under baseURL.
 func ResolvePreviewAssetsURL(baseURL string, folder string) (string, error) {
 	if baseURL == "" {
 		return "", fmt.Errorf("preview assets base URL is not configured")
@@ -106,9 +89,7 @@ var (
 	previewCacheMu sync.Mutex
 	previewCache   = map[string]cachedPreviewAssets{}
 
-	// previewFlights collapses concurrent fetches of the same assets URL into
-	// one remote request, so a slow bucket response costs a single connection
-	// and concurrent misses cannot race each other's cache writes.
+	// Collapses concurrent fetches of the same assets URL into one remote request.
 	previewFlights singleflight.Group
 )
 
@@ -119,10 +100,8 @@ func ResetPreviewAssetsCache() {
 	previewCacheMu.Unlock()
 }
 
-// GetPreviewWebAssets fetches the assets manifest for a preview folder and
-// returns entrypoints with all asset URLs rooted at the preview location.
-// Results, including fetch failures, are cached for previewCacheTTL, and
-// concurrent callers for the same URL share a single remote fetch.
+// GetPreviewWebAssets fetches the assets manifest for a preview folder, with all
+// asset URLs rooted at the preview location.
 func GetPreviewWebAssets(ctx context.Context, preview PreviewAssetsConfig, folder string) (dtos.EntryPointAssets, error) {
 	if !preview.Active() {
 		return dtos.EntryPointAssets{}, fmt.Errorf("preview assets are not enabled")
@@ -138,17 +117,14 @@ func GetPreviewWebAssets(ctx context.Context, preview PreviewAssetsConfig, folde
 	}
 
 	ch := previewFlights.DoChan(assetsURL, func() (any, error) {
-		// Re-check under the flight: a previous flight may have populated the
-		// cache while we waited for the singleflight slot.
+		// A previous flight may have filled the cache while we waited for the slot.
 		if cached, ok := getCachedPreviewAssets(assetsURL); ok {
 			return cached, nil
 		}
 
 		logger.Info("fetching preview assets manifest", "url", assetsURL)
-		// Detach from the caller's context so one caller disconnecting doesn't
-		// cache a context error for every request in the next TTL window; the
-		// explicit timeout bounds the fetch because the shared HTTP client
-		// doesn't.
+		// Detached so one caller disconnecting doesn't cache a context error for
+		// every request in the next TTL window.
 		fetchCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), previewFetchTimeout)
 		defer cancel()
 
@@ -166,8 +142,7 @@ func GetPreviewWebAssets(ctx context.Context, preview PreviewAssetsConfig, folde
 		return entry, nil
 	})
 
-	// Wait on this caller's own context so a cancelled request returns promptly
-	// while the shared fetch continues for the other waiters.
+	// A cancelled request returns promptly; the shared fetch continues for others.
 	select {
 	case <-ctx.Done():
 		return dtos.EntryPointAssets{}, ctx.Err()
@@ -180,8 +155,7 @@ func GetPreviewWebAssets(ctx context.Context, preview PreviewAssetsConfig, folde
 	}
 }
 
-// getCachedPreviewAssets returns the live cache entry for assetsURL, evicting
-// expired entries first.
+// getCachedPreviewAssets returns the live entry, evicting expired entries first.
 func getCachedPreviewAssets(assetsURL string) (cachedPreviewAssets, bool) {
 	previewCacheMu.Lock()
 	defer previewCacheMu.Unlock()

--- a/pkg/services/frontend/webassets/preview.go
+++ b/pkg/services/frontend/webassets/preview.go
@@ -31,16 +31,14 @@ const (
 // preview build instead of the release assets.
 // Should NEVER be enabled in production.
 type PreviewAssetsConfig struct {
-	Enabled bool
 	BaseURL string
 
-	// Second lock: even with the feature enabled, only these namespaces serve
-	// preview assets. Empty means no namespace is allowed.
+	// Only these namespaces serve preview assets; empty disables the feature.
 	AllowedNamespaces []string
 }
 
 func (c PreviewAssetsConfig) Active() bool {
-	return c.Enabled && c.BaseURL != ""
+	return c.BaseURL != "" && len(c.AllowedNamespaces) > 0
 }
 
 // NamespaceAllowed reports whether a stack has opted in. Fails closed: requests
@@ -54,7 +52,6 @@ func (c PreviewAssetsConfig) NamespaceAllowed(namespace string) bool {
 func ReadPreviewAssetsConfig(cfg *setting.Cfg) PreviewAssetsConfig {
 	sec := cfg.SectionWithEnvOverrides("frontend_service")
 	return PreviewAssetsConfig{
-		Enabled:           sec.Key("preview_assets_enabled").MustBool(false),
 		BaseURL:           sec.Key("preview_assets_base_url").String(),
 		AllowedNamespaces: util.SplitString(sec.Key("preview_assets_allowed_namespaces").String()),
 	}
@@ -110,7 +107,7 @@ func ResetPreviewAssetsCache() {
 // asset URLs rooted at the preview location.
 func GetPreviewWebAssets(ctx context.Context, preview PreviewAssetsConfig, folder string) (dtos.EntryPointAssets, error) {
 	if !preview.Active() {
-		return dtos.EntryPointAssets{}, fmt.Errorf("preview assets are not enabled")
+		return dtos.EntryPointAssets{}, fmt.Errorf("preview assets are not configured")
 	}
 
 	assetsURL, err := ResolvePreviewAssetsURL(preview.BaseURL, folder)

--- a/pkg/services/frontend/webassets/preview.go
+++ b/pkg/services/frontend/webassets/preview.go
@@ -1,0 +1,142 @@
+package fswebassets
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/grafana/grafana/pkg/api/dtos"
+	"github.com/grafana/grafana/pkg/api/webassets"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+// validPreviewAssetsFolder matches deploy IDs created by the deploy-frontend-preview
+// CI workflow, e.g. pr_grafana_123456. Deliberately strict so a folder name can
+// never introduce new path segments or URL metacharacters.
+var validPreviewAssetsFolder = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
+
+const (
+	maxPreviewAssetsFolderLength = 128
+
+	// previewCacheTTL keeps remote manifest fetches off the hot path while still
+	// picking up re-deploys of the same preview folder quickly.
+	previewCacheTTL = 30 * time.Second
+)
+
+// PreviewAssetsConfig configures serving frontend assets from a preview build
+// uploaded by CI instead of the release assets. This is a development-only
+// feature: it must never be enabled in production because it serves
+// non-released JavaScript to the browser.
+type PreviewAssetsConfig struct {
+	// Enabled turns the preview assets feature on. When false (the default)
+	// the preview routes are not registered and cookies are ignored.
+	Enabled bool
+
+	// BaseURL is the only origin preview assets can be loaded from. A per-user
+	// folder name is appended to it server-side, so requests can never point
+	// the service at an arbitrary origin.
+	BaseURL string
+}
+
+// Active returns true only when the feature is both enabled and has a base URL
+// to resolve preview folders against.
+func (c PreviewAssetsConfig) Active() bool {
+	return c.Enabled && c.BaseURL != ""
+}
+
+// ReadPreviewAssetsConfig reads the preview assets configuration. It is
+// startup-time, cluster-wide configuration and deliberately cannot be
+// overridden per tenant via the settings service.
+func ReadPreviewAssetsConfig(cfg *setting.Cfg) PreviewAssetsConfig {
+	sec := cfg.SectionWithEnvOverrides("frontend_service")
+	return PreviewAssetsConfig{
+		Enabled: sec.Key("preview_assets_enabled").MustBool(false),
+		BaseURL: sec.Key("preview_assets_base_url").String(),
+	}
+}
+
+// ResolvePreviewAssetsURL builds the full assets URL for a preview folder,
+// validating the folder name so the result always stays under the configured
+// base URL.
+func ResolvePreviewAssetsURL(baseURL string, folder string) (string, error) {
+	if baseURL == "" {
+		return "", fmt.Errorf("preview assets base URL is not configured")
+	}
+
+	if folder == "" {
+		return "", fmt.Errorf("preview assets folder is empty")
+	}
+
+	if len(folder) > maxPreviewAssetsFolderLength {
+		return "", fmt.Errorf("preview assets folder exceeds maximum length")
+	}
+
+	if !validPreviewAssetsFolder.MatchString(folder) {
+		return "", fmt.Errorf("preview assets folder contains invalid characters")
+	}
+
+	base := baseURL
+	if !strings.HasSuffix(base, "/") {
+		base += "/"
+	}
+	return base + folder + "/", nil
+}
+
+type cachedPreviewAssets struct {
+	assets    dtos.EntryPointAssets
+	fetchedAt time.Time
+}
+
+var (
+	previewCacheMu sync.Mutex
+	previewCache   = map[string]cachedPreviewAssets{}
+)
+
+// ResetPreviewAssetsCache clears the preview manifest cache. Exported for tests.
+func ResetPreviewAssetsCache() {
+	previewCacheMu.Lock()
+	previewCache = map[string]cachedPreviewAssets{}
+	previewCacheMu.Unlock()
+}
+
+// GetPreviewWebAssets fetches the assets manifest for a preview folder and
+// returns entrypoints with all asset URLs rooted at the preview location.
+func GetPreviewWebAssets(ctx context.Context, preview PreviewAssetsConfig, folder string) (dtos.EntryPointAssets, error) {
+	if !preview.Active() {
+		return dtos.EntryPointAssets{}, fmt.Errorf("preview assets are not enabled")
+	}
+
+	assetsURL, err := ResolvePreviewAssetsURL(preview.BaseURL, folder)
+	if err != nil {
+		return dtos.EntryPointAssets{}, err
+	}
+
+	previewCacheMu.Lock()
+	defer previewCacheMu.Unlock()
+
+	for key, cached := range previewCache {
+		if time.Since(cached.fetchedAt) >= previewCacheTTL {
+			delete(previewCache, key)
+		}
+	}
+
+	if cached, ok := previewCache[assetsURL]; ok {
+		return cached.assets, nil
+	}
+
+	logger.Info("fetching preview assets manifest", "url", assetsURL)
+	result, err := webassets.ReadWebAssetsFromCDN(ctx, "build", assetsURL)
+	if err != nil {
+		return dtos.EntryPointAssets{}, err
+	}
+
+	previewCache[assetsURL] = cachedPreviewAssets{
+		assets:    *result,
+		fetchedAt: time.Now(),
+	}
+
+	return *result, nil
+}

--- a/pkg/services/frontend/webassets/preview.go
+++ b/pkg/services/frontend/webassets/preview.go
@@ -6,9 +6,9 @@ import (
 	"regexp"
 	"slices"
 	"strings"
-	"sync"
 	"time"
 
+	"github.com/hashicorp/golang-lru/v2/expirable"
 	"golang.org/x/sync/singleflight"
 
 	"github.com/grafana/grafana/pkg/api/dtos"
@@ -24,6 +24,7 @@ var validPreviewAssetsFolder = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
 const (
 	maxPreviewAssetsFolderLength = 128
 	previewCacheTTL              = 30 * time.Second
+	previewCacheSize             = 64
 	previewFetchTimeout          = 10 * time.Second
 )
 
@@ -85,14 +86,14 @@ func ResolvePreviewAssetsURL(baseURL string, folder string) (string, error) {
 }
 
 type cachedPreviewAssets struct {
-	assets    dtos.EntryPointAssets
-	err       error
-	fetchedAt time.Time
+	assets dtos.EntryPointAssets
+	err    error
 }
 
 var (
-	previewCacheMu sync.Mutex
-	previewCache   = map[string]cachedPreviewAssets{}
+	// Bounded so unauthenticated requests carrying arbitrary cookie values can't
+	// grow the cache without limit.
+	previewCache = expirable.NewLRU[string, cachedPreviewAssets](previewCacheSize, nil, previewCacheTTL)
 
 	// Collapses concurrent fetches of the same assets URL into one remote request.
 	previewFlights singleflight.Group
@@ -100,9 +101,7 @@ var (
 
 // Clears the cache, exported just for tests.
 func ResetPreviewAssetsCache() {
-	previewCacheMu.Lock()
-	previewCache = map[string]cachedPreviewAssets{}
-	previewCacheMu.Unlock()
+	previewCache.Purge()
 }
 
 // GetPreviewWebAssets fetches the assets manifest for a preview folder, with all
@@ -117,13 +116,13 @@ func GetPreviewWebAssets(ctx context.Context, preview PreviewAssetsConfig, folde
 		return dtos.EntryPointAssets{}, err
 	}
 
-	if cached, ok := getCachedPreviewAssets(assetsURL); ok {
+	if cached, ok := previewCache.Get(assetsURL); ok {
 		return cached.assets, cached.err
 	}
 
 	ch := previewFlights.DoChan(assetsURL, func() (any, error) {
 		// A previous flight may have filled the cache while we waited for the slot.
-		if cached, ok := getCachedPreviewAssets(assetsURL); ok {
+		if cached, ok := previewCache.Get(assetsURL); ok {
 			return cached, nil
 		}
 
@@ -135,14 +134,12 @@ func GetPreviewWebAssets(ctx context.Context, preview PreviewAssetsConfig, folde
 
 		result, err := webassets.ReadWebAssetsFromCDN(fetchCtx, "build", assetsURL)
 
-		entry := cachedPreviewAssets{err: err, fetchedAt: time.Now()}
+		entry := cachedPreviewAssets{err: err}
 		if err == nil {
 			entry.assets = *result
 		}
 
-		previewCacheMu.Lock()
-		previewCache[assetsURL] = entry
-		previewCacheMu.Unlock()
+		previewCache.Add(assetsURL, entry)
 
 		return entry, nil
 	})
@@ -158,19 +155,4 @@ func GetPreviewWebAssets(ctx context.Context, preview PreviewAssetsConfig, folde
 		entry := flight.Val.(cachedPreviewAssets)
 		return entry.assets, entry.err
 	}
-}
-
-// getCachedPreviewAssets returns the live entry, evicting expired entries first.
-func getCachedPreviewAssets(assetsURL string) (cachedPreviewAssets, bool) {
-	previewCacheMu.Lock()
-	defer previewCacheMu.Unlock()
-
-	for key, cached := range previewCache {
-		if time.Since(cached.fetchedAt) >= previewCacheTTL {
-			delete(previewCache, key)
-		}
-	}
-
-	cached, ok := previewCache[assetsURL]
-	return cached, ok
 }

--- a/pkg/services/frontend/webassets/preview.go
+++ b/pkg/services/frontend/webassets/preview.go
@@ -21,22 +21,15 @@ var validPreviewAssetsFolder = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
 
 const (
 	maxPreviewAssetsFolderLength = 128
-
-	// Applies to failures too: without negative caching, every page load with a
-	// stale preview cookie would pay a blocking remote fetch.
-	previewCacheTTL = 30 * time.Second
-
-	// The shared HTTP client has no timeout of its own, and the fetch runs
-	// detached from the caller's context.
-	previewFetchTimeout = 10 * time.Second
+	previewCacheTTL              = 30 * time.Second
+	previewFetchTimeout          = 10 * time.Second
 )
 
 // PreviewAssetsConfig configures serving frontend assets from a CI-uploaded
-// preview build instead of the release assets. Never enable in production.
+// preview build instead of the release assets.
+// Should NEVER be enabled in production.
 type PreviewAssetsConfig struct {
 	Enabled bool
-
-	// The only origin previews can load from; folder names are appended server-side.
 	BaseURL string
 }
 
@@ -93,7 +86,7 @@ var (
 	previewFlights singleflight.Group
 )
 
-// ResetPreviewAssetsCache clears the preview manifest cache. Exported for tests.
+// Clears the cache, exported just for tests.
 func ResetPreviewAssetsCache() {
 	previewCacheMu.Lock()
 	previewCache = map[string]cachedPreviewAssets{}

--- a/pkg/services/frontend/webassets/preview.go
+++ b/pkg/services/frontend/webassets/preview.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/sync/singleflight"
+
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/webassets"
 	"github.com/grafana/grafana/pkg/setting"
@@ -22,8 +24,17 @@ const (
 	maxPreviewAssetsFolderLength = 128
 
 	// previewCacheTTL keeps remote manifest fetches off the hot path while still
-	// picking up re-deploys of the same preview folder quickly.
+	// picking up re-deploys of the same preview folder quickly. Failed lookups
+	// are cached for the same period: the preview cookie lives for 24 hours and
+	// its folder can vanish from the bucket, so without negative caching every
+	// page load would pay a blocking remote roundtrip just to fall back to the
+	// default assets.
 	previewCacheTTL = 30 * time.Second
+
+	// previewFetchTimeout bounds the manifest fetch: the shared HTTP client
+	// (webassets.ReadWebAssetsFromCDN) sets no timeout of its own, and the
+	// fetch runs detached from the caller's context (see GetPreviewWebAssets).
+	previewFetchTimeout = 10 * time.Second
 )
 
 // PreviewAssetsConfig configures serving frontend assets from a preview build
@@ -87,12 +98,18 @@ func ResolvePreviewAssetsURL(baseURL string, folder string) (string, error) {
 
 type cachedPreviewAssets struct {
 	assets    dtos.EntryPointAssets
+	err       error
 	fetchedAt time.Time
 }
 
 var (
 	previewCacheMu sync.Mutex
 	previewCache   = map[string]cachedPreviewAssets{}
+
+	// previewFlights collapses concurrent fetches of the same assets URL into
+	// one remote request, so a slow bucket response costs a single connection
+	// and concurrent misses cannot race each other's cache writes.
+	previewFlights singleflight.Group
 )
 
 // ResetPreviewAssetsCache clears the preview manifest cache. Exported for tests.
@@ -104,6 +121,8 @@ func ResetPreviewAssetsCache() {
 
 // GetPreviewWebAssets fetches the assets manifest for a preview folder and
 // returns entrypoints with all asset URLs rooted at the preview location.
+// Results, including fetch failures, are cached for previewCacheTTL, and
+// concurrent callers for the same URL share a single remote fetch.
 func GetPreviewWebAssets(ctx context.Context, preview PreviewAssetsConfig, folder string) (dtos.EntryPointAssets, error) {
 	if !preview.Active() {
 		return dtos.EntryPointAssets{}, fmt.Errorf("preview assets are not enabled")
@@ -114,6 +133,56 @@ func GetPreviewWebAssets(ctx context.Context, preview PreviewAssetsConfig, folde
 		return dtos.EntryPointAssets{}, err
 	}
 
+	if cached, ok := getCachedPreviewAssets(assetsURL); ok {
+		return cached.assets, cached.err
+	}
+
+	ch := previewFlights.DoChan(assetsURL, func() (any, error) {
+		// Re-check under the flight: a previous flight may have populated the
+		// cache while we waited for the singleflight slot.
+		if cached, ok := getCachedPreviewAssets(assetsURL); ok {
+			return cached, nil
+		}
+
+		logger.Info("fetching preview assets manifest", "url", assetsURL)
+		// Detach from the caller's context so one caller disconnecting doesn't
+		// cache a context error for every request in the next TTL window; the
+		// explicit timeout bounds the fetch because the shared HTTP client
+		// doesn't.
+		fetchCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), previewFetchTimeout)
+		defer cancel()
+
+		result, err := webassets.ReadWebAssetsFromCDN(fetchCtx, "build", assetsURL)
+
+		entry := cachedPreviewAssets{err: err, fetchedAt: time.Now()}
+		if err == nil {
+			entry.assets = *result
+		}
+
+		previewCacheMu.Lock()
+		previewCache[assetsURL] = entry
+		previewCacheMu.Unlock()
+
+		return entry, nil
+	})
+
+	// Wait on this caller's own context so a cancelled request returns promptly
+	// while the shared fetch continues for the other waiters.
+	select {
+	case <-ctx.Done():
+		return dtos.EntryPointAssets{}, ctx.Err()
+	case flight := <-ch:
+		if flight.Err != nil {
+			return dtos.EntryPointAssets{}, flight.Err
+		}
+		entry := flight.Val.(cachedPreviewAssets)
+		return entry.assets, entry.err
+	}
+}
+
+// getCachedPreviewAssets returns the live cache entry for assetsURL, evicting
+// expired entries first.
+func getCachedPreviewAssets(assetsURL string) (cachedPreviewAssets, bool) {
 	previewCacheMu.Lock()
 	defer previewCacheMu.Unlock()
 
@@ -123,20 +192,6 @@ func GetPreviewWebAssets(ctx context.Context, preview PreviewAssetsConfig, folde
 		}
 	}
 
-	if cached, ok := previewCache[assetsURL]; ok {
-		return cached.assets, nil
-	}
-
-	logger.Info("fetching preview assets manifest", "url", assetsURL)
-	result, err := webassets.ReadWebAssetsFromCDN(ctx, "build", assetsURL)
-	if err != nil {
-		return dtos.EntryPointAssets{}, err
-	}
-
-	previewCache[assetsURL] = cachedPreviewAssets{
-		assets:    *result,
-		fetchedAt: time.Now(),
-	}
-
-	return *result, nil
+	cached, ok := previewCache[assetsURL]
+	return cached, ok
 }

--- a/pkg/services/frontend/webassets/preview.go
+++ b/pkg/services/frontend/webassets/preview.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/webassets"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 // Deploy IDs like pr_grafana_123456. Deliberately strict so a folder can never
@@ -31,10 +33,20 @@ const (
 type PreviewAssetsConfig struct {
 	Enabled bool
 	BaseURL string
+
+	// Second lock: even with the feature enabled, only these namespaces serve
+	// preview assets. Empty means no namespace is allowed.
+	AllowedNamespaces []string
 }
 
 func (c PreviewAssetsConfig) Active() bool {
 	return c.Enabled && c.BaseURL != ""
+}
+
+// NamespaceAllowed reports whether a stack has opted in. Fails closed: requests
+// without a namespace never see preview assets.
+func (c PreviewAssetsConfig) NamespaceAllowed(namespace string) bool {
+	return namespace != "" && slices.Contains(c.AllowedNamespaces, namespace)
 }
 
 // ReadPreviewAssetsConfig reads startup-time, cluster-wide configuration;
@@ -42,8 +54,9 @@ func (c PreviewAssetsConfig) Active() bool {
 func ReadPreviewAssetsConfig(cfg *setting.Cfg) PreviewAssetsConfig {
 	sec := cfg.SectionWithEnvOverrides("frontend_service")
 	return PreviewAssetsConfig{
-		Enabled: sec.Key("preview_assets_enabled").MustBool(false),
-		BaseURL: sec.Key("preview_assets_base_url").String(),
+		Enabled:           sec.Key("preview_assets_enabled").MustBool(false),
+		BaseURL:           sec.Key("preview_assets_base_url").String(),
+		AllowedNamespaces: util.SplitString(sec.Key("preview_assets_allowed_namespaces").String()),
 	}
 }
 

--- a/pkg/services/frontend/webassets/preview.go
+++ b/pkg/services/frontend/webassets/preview.go
@@ -37,14 +37,16 @@ type PreviewAssetsConfig struct {
 	AllowedNamespaces []string
 }
 
-func (c PreviewAssetsConfig) Active() bool {
+// Configured reports whether the cluster serves preview assets at all.
+// Per-request access also requires an opted-in namespace: see Active.
+func (c PreviewAssetsConfig) Configured() bool {
 	return c.BaseURL != "" && len(c.AllowedNamespaces) > 0
 }
 
-// NamespaceAllowed reports whether a stack has opted in. Fails closed: requests
-// without a namespace never see preview assets.
-func (c PreviewAssetsConfig) NamespaceAllowed(namespace string) bool {
-	return namespace != "" && slices.Contains(c.AllowedNamespaces, namespace)
+// Active reports whether preview assets are available to the request's
+// namespace. Fails closed: requests without a namespace never see previews.
+func (c PreviewAssetsConfig) Active(namespace string) bool {
+	return c.Configured() && namespace != "" && slices.Contains(c.AllowedNamespaces, namespace)
 }
 
 // ReadPreviewAssetsConfig reads startup-time, cluster-wide configuration;
@@ -106,7 +108,7 @@ func ResetPreviewAssetsCache() {
 // GetPreviewWebAssets fetches the assets manifest for a preview folder, with all
 // asset URLs rooted at the preview location.
 func GetPreviewWebAssets(ctx context.Context, preview PreviewAssetsConfig, folder string) (dtos.EntryPointAssets, error) {
-	if !preview.Active() {
+	if !preview.Configured() {
 		return dtos.EntryPointAssets{}, fmt.Errorf("preview assets are not configured")
 	}
 

--- a/pkg/services/frontend/webassets/preview_test.go
+++ b/pkg/services/frontend/webassets/preview_test.go
@@ -205,20 +205,24 @@ func TestGetPreviewWebAssets(t *testing.T) {
 	})
 }
 
-func TestNamespaceAllowed(t *testing.T) {
+func TestActive(t *testing.T) {
 	cfg := fswebassets.PreviewAssetsConfig{
 		BaseURL:           "https://storage.example.com/bucket/",
 		AllowedNamespaces: []string{"stacks-123", "stacks-456"},
 	}
 
-	assert.True(t, cfg.NamespaceAllowed("stacks-123"))
-	assert.True(t, cfg.NamespaceAllowed("stacks-456"))
-	assert.False(t, cfg.NamespaceAllowed("stacks-789"))
-	assert.False(t, cfg.NamespaceAllowed(""), "requests without a namespace must fail closed")
+	assert.True(t, cfg.Active("stacks-123"))
+	assert.True(t, cfg.Active("stacks-456"))
+	assert.False(t, cfg.Active("stacks-789"))
+	assert.False(t, cfg.Active(""), "requests without a namespace must fail closed")
 
 	empty := fswebassets.PreviewAssetsConfig{BaseURL: "https://storage.example.com/"}
-	assert.False(t, empty.NamespaceAllowed("stacks-123"), "an empty allowlist must not allow any namespace")
-	assert.False(t, empty.Active(), "an empty allowlist must disable the feature entirely")
+	assert.False(t, empty.Active("stacks-123"), "an empty allowlist must not allow any namespace")
+	assert.False(t, empty.Configured(), "an empty allowlist must disable the feature entirely")
+
+	noURL := fswebassets.PreviewAssetsConfig{AllowedNamespaces: []string{"stacks-123"}}
+	assert.False(t, noURL.Active("stacks-123"), "a missing base URL must disable the feature entirely")
+	assert.False(t, noURL.Configured())
 }
 
 func TestReadPreviewAssetsConfig(t *testing.T) {
@@ -228,7 +232,8 @@ func TestReadPreviewAssetsConfig(t *testing.T) {
 	sec.Key("preview_assets_allowed_namespaces").SetValue("stacks-123, stacks-456")
 
 	cfg := fswebassets.ReadPreviewAssetsConfig(&setting.Cfg{Raw: raw})
-	assert.True(t, cfg.Active())
+	assert.True(t, cfg.Configured())
+	assert.True(t, cfg.Active("stacks-123"))
 	assert.Equal(t, "https://storage.example.com/bucket/", cfg.BaseURL)
 	assert.Equal(t, []string{"stacks-123", "stacks-456"}, cfg.AllowedNamespaces)
 }

--- a/pkg/services/frontend/webassets/preview_test.go
+++ b/pkg/services/frontend/webassets/preview_test.go
@@ -5,8 +5,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -125,5 +127,78 @@ func TestGetPreviewWebAssets(t *testing.T) {
 
 		_, err := fswebassets.GetPreviewWebAssets(context.Background(), preview, "pr_grafana_999")
 		assert.Error(t, err)
+	})
+
+	t.Run("should cache manifest fetch errors between requests", func(t *testing.T) {
+		fswebassets.ResetPreviewAssetsCache()
+		var requests atomic.Int64
+		server := newBucketServer(t, "pr_grafana_42", &requests)
+		preview := fswebassets.PreviewAssetsConfig{Enabled: true, BaseURL: server.URL + "/"}
+
+		for range 3 {
+			_, err := fswebassets.GetPreviewWebAssets(context.Background(), preview, "pr_grafana_999")
+			require.Error(t, err)
+		}
+
+		assert.Equal(t, int64(1), requests.Load(), "a failing manifest lookup should only hit the bucket once within the cache TTL")
+	})
+
+	t.Run("should coalesce concurrent fetches into one request", func(t *testing.T) {
+		fswebassets.ResetPreviewAssetsCache()
+		var requests atomic.Int64
+		release := make(chan struct{})
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requests.Add(1)
+			<-release
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(previewManifest))
+		}))
+		t.Cleanup(server.Close)
+		preview := fswebassets.PreviewAssetsConfig{Enabled: true, BaseURL: server.URL + "/"}
+
+		var wg sync.WaitGroup
+		for range 5 {
+			wg.Go(func() {
+				_, err := fswebassets.GetPreviewWebAssets(context.Background(), preview, "pr_grafana_42")
+				assert.NoError(t, err)
+			})
+		}
+		close(release)
+		wg.Wait()
+
+		assert.Equal(t, int64(1), requests.Load(), "concurrent callers should share one fetch")
+	})
+
+	t.Run("should not fail other callers when one caller is cancelled", func(t *testing.T) {
+		fswebassets.ResetPreviewAssetsCache()
+		var requests atomic.Int64
+		release := make(chan struct{})
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requests.Add(1)
+			<-release
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(previewManifest))
+		}))
+		t.Cleanup(server.Close)
+		preview := fswebassets.PreviewAssetsConfig{Enabled: true, BaseURL: server.URL + "/"}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		leaderErr := make(chan error, 1)
+		go func() {
+			_, err := fswebassets.GetPreviewWebAssets(ctx, preview, "pr_grafana_42")
+			leaderErr <- err
+		}()
+
+		// Wait until the leader's fetch is in flight, then cancel the leader.
+		require.Eventually(t, func() bool { return requests.Load() == 1 }, time.Second, 10*time.Millisecond)
+		cancel()
+		require.ErrorIs(t, <-leaderErr, context.Canceled)
+
+		// The detached fetch must still complete and serve a later caller.
+		close(release)
+		_, err := fswebassets.GetPreviewWebAssets(context.Background(), preview, "pr_grafana_42")
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), requests.Load(), "the cancelled caller's fetch should be reused, not retried")
 	})
 }

--- a/pkg/services/frontend/webassets/preview_test.go
+++ b/pkg/services/frontend/webassets/preview_test.go
@@ -89,7 +89,7 @@ func TestGetPreviewWebAssets(t *testing.T) {
 	t.Run("should fetch the manifest and prefix all asset URLs", func(t *testing.T) {
 		fswebassets.ResetPreviewAssetsCache()
 		server := newBucketServer(t, "pr_grafana_42", nil)
-		preview := fswebassets.PreviewAssetsConfig{Enabled: true, BaseURL: server.URL + "/"}
+		preview := fswebassets.PreviewAssetsConfig{BaseURL: server.URL + "/", AllowedNamespaces: []string{"stacks-123"}}
 
 		assets, err := fswebassets.GetPreviewWebAssets(context.Background(), preview, "pr_grafana_42")
 		require.NoError(t, err)
@@ -106,7 +106,7 @@ func TestGetPreviewWebAssets(t *testing.T) {
 		fswebassets.ResetPreviewAssetsCache()
 		var requests atomic.Int64
 		server := newBucketServer(t, "pr_grafana_42", &requests)
-		preview := fswebassets.PreviewAssetsConfig{Enabled: true, BaseURL: server.URL + "/"}
+		preview := fswebassets.PreviewAssetsConfig{BaseURL: server.URL + "/", AllowedNamespaces: []string{"stacks-123"}}
 
 		for range 3 {
 			_, err := fswebassets.GetPreviewWebAssets(context.Background(), preview, "pr_grafana_42")
@@ -116,7 +116,7 @@ func TestGetPreviewWebAssets(t *testing.T) {
 		assert.Equal(t, int64(1), requests.Load(), "manifest should only be fetched once within the cache TTL")
 	})
 
-	t.Run("should error when the feature is not enabled", func(t *testing.T) {
+	t.Run("should error when the feature is not configured", func(t *testing.T) {
 		fswebassets.ResetPreviewAssetsCache()
 		_, err := fswebassets.GetPreviewWebAssets(context.Background(), fswebassets.PreviewAssetsConfig{}, "pr_grafana_42")
 		assert.Error(t, err)
@@ -125,7 +125,7 @@ func TestGetPreviewWebAssets(t *testing.T) {
 	t.Run("should error when the manifest does not exist", func(t *testing.T) {
 		fswebassets.ResetPreviewAssetsCache()
 		server := newBucketServer(t, "pr_grafana_42", nil)
-		preview := fswebassets.PreviewAssetsConfig{Enabled: true, BaseURL: server.URL + "/"}
+		preview := fswebassets.PreviewAssetsConfig{BaseURL: server.URL + "/", AllowedNamespaces: []string{"stacks-123"}}
 
 		_, err := fswebassets.GetPreviewWebAssets(context.Background(), preview, "pr_grafana_999")
 		assert.Error(t, err)
@@ -135,7 +135,7 @@ func TestGetPreviewWebAssets(t *testing.T) {
 		fswebassets.ResetPreviewAssetsCache()
 		var requests atomic.Int64
 		server := newBucketServer(t, "pr_grafana_42", &requests)
-		preview := fswebassets.PreviewAssetsConfig{Enabled: true, BaseURL: server.URL + "/"}
+		preview := fswebassets.PreviewAssetsConfig{BaseURL: server.URL + "/", AllowedNamespaces: []string{"stacks-123"}}
 
 		for range 3 {
 			_, err := fswebassets.GetPreviewWebAssets(context.Background(), preview, "pr_grafana_999")
@@ -156,7 +156,7 @@ func TestGetPreviewWebAssets(t *testing.T) {
 			_, _ = w.Write([]byte(previewManifest))
 		}))
 		t.Cleanup(server.Close)
-		preview := fswebassets.PreviewAssetsConfig{Enabled: true, BaseURL: server.URL + "/"}
+		preview := fswebassets.PreviewAssetsConfig{BaseURL: server.URL + "/", AllowedNamespaces: []string{"stacks-123"}}
 
 		var wg sync.WaitGroup
 		for range 5 {
@@ -182,7 +182,7 @@ func TestGetPreviewWebAssets(t *testing.T) {
 			_, _ = w.Write([]byte(previewManifest))
 		}))
 		t.Cleanup(server.Close)
-		preview := fswebassets.PreviewAssetsConfig{Enabled: true, BaseURL: server.URL + "/"}
+		preview := fswebassets.PreviewAssetsConfig{BaseURL: server.URL + "/", AllowedNamespaces: []string{"stacks-123"}}
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -207,7 +207,6 @@ func TestGetPreviewWebAssets(t *testing.T) {
 
 func TestNamespaceAllowed(t *testing.T) {
 	cfg := fswebassets.PreviewAssetsConfig{
-		Enabled:           true,
 		BaseURL:           "https://storage.example.com/bucket/",
 		AllowedNamespaces: []string{"stacks-123", "stacks-456"},
 	}
@@ -217,19 +216,19 @@ func TestNamespaceAllowed(t *testing.T) {
 	assert.False(t, cfg.NamespaceAllowed("stacks-789"))
 	assert.False(t, cfg.NamespaceAllowed(""), "requests without a namespace must fail closed")
 
-	empty := fswebassets.PreviewAssetsConfig{Enabled: true, BaseURL: "https://storage.example.com/"}
+	empty := fswebassets.PreviewAssetsConfig{BaseURL: "https://storage.example.com/"}
 	assert.False(t, empty.NamespaceAllowed("stacks-123"), "an empty allowlist must not allow any namespace")
+	assert.False(t, empty.Active(), "an empty allowlist must disable the feature entirely")
 }
 
 func TestReadPreviewAssetsConfig(t *testing.T) {
 	raw := ini.Empty()
 	sec := raw.Section("frontend_service")
-	sec.Key("preview_assets_enabled").SetValue("true")
 	sec.Key("preview_assets_base_url").SetValue("https://storage.example.com/bucket/")
 	sec.Key("preview_assets_allowed_namespaces").SetValue("stacks-123, stacks-456")
 
 	cfg := fswebassets.ReadPreviewAssetsConfig(&setting.Cfg{Raw: raw})
-	assert.True(t, cfg.Enabled)
+	assert.True(t, cfg.Active())
 	assert.Equal(t, "https://storage.example.com/bucket/", cfg.BaseURL)
 	assert.Equal(t, []string{"stacks-123", "stacks-456"}, cfg.AllowedNamespaces)
 }

--- a/pkg/services/frontend/webassets/preview_test.go
+++ b/pkg/services/frontend/webassets/preview_test.go
@@ -1,0 +1,129 @@
+package fswebassets_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	fswebassets "github.com/grafana/grafana/pkg/services/frontend/webassets"
+)
+
+func TestResolvePreviewAssetsURL(t *testing.T) {
+	t.Run("should build the URL from the base URL and folder", func(t *testing.T) {
+		url, err := fswebassets.ResolvePreviewAssetsURL("https://storage.example.com/bucket/", "pr_grafana_123456")
+		require.NoError(t, err)
+		assert.Equal(t, "https://storage.example.com/bucket/pr_grafana_123456/", url)
+	})
+
+	t.Run("should add a trailing slash to the base URL when missing", func(t *testing.T) {
+		url, err := fswebassets.ResolvePreviewAssetsURL("https://storage.example.com/bucket", "pr_grafana_123456")
+		require.NoError(t, err)
+		assert.Equal(t, "https://storage.example.com/bucket/pr_grafana_123456/", url)
+	})
+
+	t.Run("should reject invalid folders", func(t *testing.T) {
+		invalid := []string{
+			"",
+			"../otherfolder",
+			"foo/bar",
+			"foo bar",
+			"foo.bar",
+			"https://evil.example.com",
+			"foo?bar=baz",
+			"foo#bar",
+			strings.Repeat("a", 129),
+		}
+		for _, folder := range invalid {
+			_, err := fswebassets.ResolvePreviewAssetsURL("https://storage.example.com/bucket/", folder)
+			assert.Error(t, err, "should reject folder: %q", folder)
+		}
+	})
+
+	t.Run("should reject an empty base URL", func(t *testing.T) {
+		_, err := fswebassets.ResolvePreviewAssetsURL("", "pr_grafana_123456")
+		assert.Error(t, err)
+	})
+}
+
+const previewManifest = `{
+	"entrypoints": {
+		"app": {
+			"assets": {
+				"js": ["public/build/runtime.preview.js", "public/build/app.preview.js"],
+				"css": ["public/build/grafana.app.preview.css"]
+			}
+		},
+		"dark": { "assets": { "css": ["public/build/grafana.dark.preview.css"] } },
+		"light": { "assets": { "css": ["public/build/grafana.light.preview.css"] } }
+	}
+}`
+
+func TestGetPreviewWebAssets(t *testing.T) {
+	newBucketServer := func(t *testing.T, folder string, requests *atomic.Int64) *httptest.Server {
+		t.Helper()
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if requests != nil {
+				requests.Add(1)
+			}
+			if r.URL.Path == "/"+folder+"/public/build/assets-manifest.json" {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(previewManifest))
+				return
+			}
+			http.NotFound(w, r)
+		}))
+		t.Cleanup(server.Close)
+		return server
+	}
+
+	t.Run("should fetch the manifest and prefix all asset URLs", func(t *testing.T) {
+		fswebassets.ResetPreviewAssetsCache()
+		server := newBucketServer(t, "pr_grafana_42", nil)
+		preview := fswebassets.PreviewAssetsConfig{Enabled: true, BaseURL: server.URL + "/"}
+
+		assets, err := fswebassets.GetPreviewWebAssets(context.Background(), preview, "pr_grafana_42")
+		require.NoError(t, err)
+
+		previewURL := server.URL + "/pr_grafana_42/"
+		assert.Equal(t, previewURL, assets.ContentDeliveryURL)
+		assert.Equal(t, previewURL+"public/build/runtime.preview.js", assets.JSFiles[0].FilePath)
+		assert.Equal(t, previewURL+"public/build/app.preview.js", assets.JSFiles[1].FilePath)
+		assert.Equal(t, previewURL+"public/build/grafana.dark.preview.css", assets.Dark)
+		assert.Equal(t, previewURL+"public/build/grafana.light.preview.css", assets.Light)
+	})
+
+	t.Run("should cache the manifest between requests", func(t *testing.T) {
+		fswebassets.ResetPreviewAssetsCache()
+		var requests atomic.Int64
+		server := newBucketServer(t, "pr_grafana_42", &requests)
+		preview := fswebassets.PreviewAssetsConfig{Enabled: true, BaseURL: server.URL + "/"}
+
+		for range 3 {
+			_, err := fswebassets.GetPreviewWebAssets(context.Background(), preview, "pr_grafana_42")
+			require.NoError(t, err)
+		}
+
+		assert.Equal(t, int64(1), requests.Load(), "manifest should only be fetched once within the cache TTL")
+	})
+
+	t.Run("should error when the feature is not enabled", func(t *testing.T) {
+		fswebassets.ResetPreviewAssetsCache()
+		_, err := fswebassets.GetPreviewWebAssets(context.Background(), fswebassets.PreviewAssetsConfig{}, "pr_grafana_42")
+		assert.Error(t, err)
+	})
+
+	t.Run("should error when the manifest does not exist", func(t *testing.T) {
+		fswebassets.ResetPreviewAssetsCache()
+		server := newBucketServer(t, "pr_grafana_42", nil)
+		preview := fswebassets.PreviewAssetsConfig{Enabled: true, BaseURL: server.URL + "/"}
+
+		_, err := fswebassets.GetPreviewWebAssets(context.Background(), preview, "pr_grafana_999")
+		assert.Error(t, err)
+	})
+}

--- a/pkg/services/frontend/webassets/preview_test.go
+++ b/pkg/services/frontend/webassets/preview_test.go
@@ -12,8 +12,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/ini.v1"
 
 	fswebassets "github.com/grafana/grafana/pkg/services/frontend/webassets"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 func TestResolvePreviewAssetsURL(t *testing.T) {
@@ -201,4 +203,33 @@ func TestGetPreviewWebAssets(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, int64(1), requests.Load(), "the cancelled caller's fetch should be reused, not retried")
 	})
+}
+
+func TestNamespaceAllowed(t *testing.T) {
+	cfg := fswebassets.PreviewAssetsConfig{
+		Enabled:           true,
+		BaseURL:           "https://storage.example.com/bucket/",
+		AllowedNamespaces: []string{"stacks-123", "stacks-456"},
+	}
+
+	assert.True(t, cfg.NamespaceAllowed("stacks-123"))
+	assert.True(t, cfg.NamespaceAllowed("stacks-456"))
+	assert.False(t, cfg.NamespaceAllowed("stacks-789"))
+	assert.False(t, cfg.NamespaceAllowed(""), "requests without a namespace must fail closed")
+
+	empty := fswebassets.PreviewAssetsConfig{Enabled: true, BaseURL: "https://storage.example.com/"}
+	assert.False(t, empty.NamespaceAllowed("stacks-123"), "an empty allowlist must not allow any namespace")
+}
+
+func TestReadPreviewAssetsConfig(t *testing.T) {
+	raw := ini.Empty()
+	sec := raw.Section("frontend_service")
+	sec.Key("preview_assets_enabled").SetValue("true")
+	sec.Key("preview_assets_base_url").SetValue("https://storage.example.com/bucket/")
+	sec.Key("preview_assets_allowed_namespaces").SetValue("stacks-123, stacks-456")
+
+	cfg := fswebassets.ReadPreviewAssetsConfig(&setting.Cfg{Raw: raw})
+	assert.True(t, cfg.Enabled)
+	assert.Equal(t, "https://storage.example.com/bucket/", cfg.BaseURL)
+	assert.Equal(t, []string{"stacks-123", "stacks-456"}, cfg.AllowedNamespaces)
 }


### PR DESCRIPTION
Adds an opt-in preview assets override to the multi-tenant frontend service, so a browser session can load the frontend from a PR preview build instead of the release assets.

**How it works**

- New config: `[frontend_service] preview_assets_base_url` and `preview_assets_allowed_namespaces` (startup-time, cluster-wide; not overridable per tenant). The feature is active only when both are set; by default no routes are registered and cookies are ignored.
- `GET /-/set-preview-assets?assets=<folder>` serves a confirmation page explaining what will happen; confirming sets a 24h cookie holding only the folder name. `?clear=1` removes it. The frontend service only receives GETs, so the confirm step is a GET protected by a single-use CSRF token in a short-lived cookie.
- When the cookie is present, index rendering fetches `<base URL>/<folder>/public/build/assets-manifest.json` and serves the page with those assets, exposing `window.__grafanaPreviewAssets` for the notice in the follow-up PR. If the manifest can't be loaded the page falls back to the release assets, so a stale cookie can never take a session down.

**Safety properties**

- Individual tenants must be opted into this with the `preview_assets_allowed_namespaces` config
- Folder names are validated against `^[a-zA-Z0-9_]+$` (max 128 chars) and the asset URL is always constructed server-side under the configured base URL, so requests can never point the service at an arbitrary origin.
- Manifest lookups run outside the cache lock with a 10s timeout, results (including failures) are cached for 30s, and concurrent fetches for the same URL are collapsed via singleflight.

Part of a stack: this PR is the backend, followed by the deploy workflow and the in-app notice.

See design doc for more info: https://docs.google.com/document/d/1fwfoCOxXSDd5nGYVAR2ZsioBBgSRs1CxjdVXpCbwUI8/edit