### PR TITLE
CI: Deploy frontend previews for frontend-only PRs via /deploy-to-fs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1354,6 +1354,8 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/i18n-verify.yml @grafana/grafana-frontend-platform
 /.github/workflows/deploy-storybook.yml @grafana/grafana-frontend-platform
 /.github/workflows/deploy-storybook-preview.yml @grafana/grafana-frontend-platform
+/.github/workflows/deploy-frontend-preview.yml @grafana/grafana-frontend-platform
+/.github/actions/frontend-preview-check @grafana/grafana-frontend-platform
 /.github/workflows/scripts/publish-frontend-metrics.mts @grafana/grafana-frontend-platform
 /.github/workflows/pr-go-workspace-check.yml @grafana/grafana-app-platform-squad
 /.github/workflows/pr-dependabot-update-go-workspace.yml @grafana/grafana-app-platform-squad

--- a/.github/actions/frontend-preview-check/action.yml
+++ b/.github/actions/frontend-preview-check/action.yml
@@ -2,8 +2,7 @@ name: Frontend preview check
 description: >-
   Determines whether a pull request is eligible for a frontend preview deploy:
   not from a fork, and only changing frontend code. Used by the
-  deploy-frontend-preview and ephemeral instances workflows to decide between
-  deploying a frontend preview or a full ephemeral instance.
+  deploy-frontend-preview workflow.
 
 inputs:
   pr-number:

--- a/.github/actions/frontend-preview-check/action.yml
+++ b/.github/actions/frontend-preview-check/action.yml
@@ -1,0 +1,81 @@
+name: Frontend preview check
+description: >-
+  Determines whether a pull request is eligible for a frontend preview deploy:
+  not from a fork, and only changing frontend code. Used by the
+  deploy-frontend-preview and ephemeral instances workflows to decide between
+  deploying a frontend preview or a full ephemeral instance.
+
+inputs:
+  pr-number:
+    description: Pull request number to inspect
+    required: true
+  token:
+    description: GitHub token used to read the pull request
+    required: true
+
+outputs:
+  should-deploy:
+    description: >-
+      'true' when the PR is eligible for a frontend preview deploy: not from a
+      fork, and every changed file is frontend code
+    value: ${{ steps.check.outputs.should-deploy }}
+  head-sha:
+    description: Head commit SHA of the pull request
+    value: ${{ steps.check.outputs.head-sha }}
+
+runs:
+  using: composite
+  steps:
+    - name: Check pull request files
+      id: check
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+        REPO: ${{ github.repository }}
+      run: |
+        set -euo pipefail
+
+        pr=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")
+
+        head_sha=$(jq -r '.head.sha' <<< "$pr")
+        head_repo=$(jq -r '.head.repo.full_name // ""' <<< "$pr")
+
+        is_fork=true
+        if [ "$head_repo" = "$REPO" ]; then
+          is_fork=false
+        fi
+
+        files=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')
+
+        # A PR is frontend-only when every changed file matches this allowlist.
+        # Keep it conservative: anything not listed (backend code, config,
+        # schemas, CI, docs tooling, ...) makes the PR ineligible.
+        frontend_only=true
+        if [ -z "$files" ]; then
+          frontend_only=false
+        fi
+
+        while IFS= read -r file; do
+          case "$file" in
+            public/* | packages/* | e2e-playwright/* | scripts/webpack/*) ;;
+            package.json | yarn.lock | .yarnrc.yml | nx.json | tsconfig.json) ;;
+            *)
+              echo "Not frontend-only, found: ${file}"
+              frontend_only=false
+              break
+              ;;
+          esac
+        done <<< "$files"
+
+        should_deploy=false
+        if [ "$frontend_only" = "true" ] && [ "$is_fork" = "false" ]; then
+          should_deploy=true
+        fi
+
+        {
+          echo "should-deploy=${should_deploy}"
+          echo "head-sha=${head_sha}"
+        } >> "$GITHUB_OUTPUT"
+
+        echo "PR #${PR_NUMBER}: should-deploy=${should_deploy} (frontend-only=${frontend_only}, is-fork=${is_fork}), head-sha=${head_sha}"

--- a/.github/workflows/deploy-frontend-preview.yml
+++ b/.github/workflows/deploy-frontend-preview.yml
@@ -1,0 +1,237 @@
+name: Deploy frontend preview
+
+# Builds the frontend of a pull request and uploads it to the preview assets
+# bucket, so it can be loaded in the shared preview Grafana instance via
+# /-/set-preview-assets (see pkg/services/frontend/preview_assets.go).
+#
+# Opt in by commenting `/deploy-to-hg` on a PR that only changes frontend
+# code - the same command that deploys an ephemeral instance for PRs with
+# backend changes. Once opted in (tracked with the deploy-frontend-preview
+# label), every push to the PR rebuilds and redeploys the preview.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request:
+    types: [synchronize]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  check:
+    name: Check PR is eligible
+    # Deploys are restricted to org members commenting /deploy-to-hg on
+    # non-fork PRs. Pushes to a PR that has already opted in (has the label)
+    # redeploy automatically.
+    if: |
+      github.repository == 'grafana/grafana' &&
+      (
+        (github.event_name == 'issue_comment' &&
+          github.event.issue.pull_request &&
+          startsWith(github.event.comment.body, '/deploy-to-hg') &&
+          (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER')) ||
+        (github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.fork == false &&
+          contains(github.event.pull_request.labels.*.name, 'deploy-frontend-preview'))
+      )
+    runs-on: ubuntu-arm64-small
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      should-deploy: ${{ steps.check.outputs.should-deploy }}
+      pr-number: ${{ steps.pr.outputs.number }}
+      head-sha: ${{ steps.check.outputs.head-sha }}
+    steps:
+      # Checkout the default branch (not the PR merge ref) so the local
+      # actions used by this job always run trusted code
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Get PR number
+        id: pr
+        env:
+          PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+        run: echo "number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+
+      - name: Check PR is eligible for a frontend preview
+        id: check
+        uses: ./.github/actions/frontend-preview-check
+        with:
+          pr-number: ${{ steps.pr.outputs.number }}
+          token: ${{ github.token }}
+
+  label:
+    name: Label PR for future deploys
+    # The label records the opt-in so pushes to the PR redeploy the preview
+    # without another comment.
+    needs: check
+    if: github.event_name == 'issue_comment' && needs.check.outputs.should-deploy == 'true'
+    runs-on: ubuntu-arm64-small
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Add label and acknowledge comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ needs.check.outputs.pr-number }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          gh api "repos/${REPO}/issues/${PR_NUMBER}/labels" -f "labels[]=deploy-frontend-preview"
+          gh api "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" -f content=rocket
+
+  comment-building:
+    name: Comment that the build started
+    needs: check
+    if: needs.check.outputs.should-deploy == 'true'
+    runs-on: ubuntu-arm64-small
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment that the build started
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: frontend-preview
+          number: ${{ needs.check.outputs.pr-number }}
+          GITHUB_TOKEN: ${{ github.token }}
+          message: |
+            ### Frontend preview
+
+            ⏳ The preview build for commit ${{ needs.check.outputs.head-sha }} is in progress.
+
+  build:
+    name: Build frontend
+    needs: check
+    if: needs.check.outputs.should-deploy == 'true'
+    runs-on: ubuntu-x64-large
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout PR code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.check.outputs.head-sha }}
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node
+
+      - name: Install dependencies
+        uses: ./.github/actions/yarn-install
+
+      - name: Build frontend
+        run: yarn build
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
+        with:
+          name: frontend-preview-build
+          path: public/build
+          retention-days: 1
+
+  deploy:
+    name: Deploy preview assets
+    # Uploads from a separate job so the OIDC-enabled step never runs
+    # alongside code built from the PR.
+    needs: [check, build]
+    runs-on: ubuntu-arm64-small
+    permissions:
+      contents: read
+      id-token: write # required for push-to-gcs
+      pull-requests: write # to update the status comment
+    env:
+      BUCKET_NAME: grafana-frontend-preview-dev
+      PREVIEW_STACK_URL: https://frontendpreview.grafana-dev.net
+    # The environment surfaces the preview URL on the PR
+    environment:
+      name: "frontend-preview-pr-${{ needs.check.outputs.pr-number }}"
+      url: ${{ steps.preview-url.outputs.url }}
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: frontend-preview-build
+          path: public/build
+
+      # The deploy name is the folder users put in the preview assets cookie.
+      # It must match the backend's validation: alphanumeric and underscores
+      # only. It is stable across pushes so an already-set cookie picks up new
+      # builds of the same PR.
+      - name: Create deploy name
+        id: deploy-name
+        env:
+          PR_NUMBER: ${{ needs.check.outputs.pr-number }}
+        run: echo "deploy-name=pr_grafana_${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload assets
+        uses: grafana/shared-workflows/actions/push-to-gcs@main
+        with:
+          environment: dev
+          bucket: ${{ env.BUCKET_NAME }}
+          # Assets live under <deploy-name>/public/build/ to match the layout
+          # the assets manifest and CDN paths expect
+          bucket_path: ${{ steps.deploy-name.outputs.deploy-name }}/public/build
+          path: public/build
+          service_account: github-gf-frontend-preview-dev@grafanalabs-workload-identity.iam.gserviceaccount.com
+          parent: false
+
+      - name: Set preview URL
+        id: preview-url
+        env:
+          DEPLOY_NAME: ${{ steps.deploy-name.outputs.deploy-name }}
+        run: |
+          echo "url=${PREVIEW_STACK_URL}/-/set-preview-assets?assets=${DEPLOY_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Write summary
+        env:
+          DEPLOY_NAME: ${{ steps.deploy-name.outputs.deploy-name }}
+          HEAD_SHA: ${{ needs.check.outputs.head-sha }}
+          PREVIEW_URL: ${{ steps.preview-url.outputs.url }}
+        run: |
+          {
+            echo "## Frontend preview deployed 🚀"
+            echo ""
+            echo "- Deploy name: \`${DEPLOY_NAME}\` (commit ${HEAD_SHA})"
+            echo "- Load it at: ${PREVIEW_URL}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Update comment to say the preview is live
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: frontend-preview
+          number: ${{ needs.check.outputs.pr-number }}
+          GITHUB_TOKEN: ${{ github.token }}
+          message: |
+            ### Frontend preview
+
+            ✅ The preview for commit ${{ needs.check.outputs.head-sha }} is live: **[open the preview](${{ steps.preview-url.outputs.url }})**.
+
+            Each new push to this PR builds and deploys the preview again automatically.
+
+  comment-failure:
+    name: Comment that the deploy failed
+    needs: [check, build, deploy]
+    if: failure() && needs.check.outputs.should-deploy == 'true'
+    runs-on: ubuntu-arm64-small
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Update comment to say the deploy failed
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: frontend-preview
+          number: ${{ needs.check.outputs.pr-number }}
+          GITHUB_TOKEN: ${{ github.token }}
+          message: |
+            ### Frontend preview
+
+            ❌ The preview deploy for commit ${{ needs.check.outputs.head-sha }} failed. See the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).

--- a/.github/workflows/deploy-frontend-preview.yml
+++ b/.github/workflows/deploy-frontend-preview.yml
@@ -1,12 +1,8 @@
 name: Deploy frontend preview
 
-# Builds the frontend of a pull request and uploads it to the preview assets
-# bucket, so it can be loaded in the shared preview Grafana instance via
-# /-/set-preview-assets (see pkg/services/frontend/preview_assets.go).
-#
-# Opt in by commenting `/deploy-to-fs` on a PR that only changes frontend
-# code. Once opted in (tracked with the deploy-frontend-preview label), every
-# push to the PR rebuilds and redeploys the preview.
+# Triggered by commenting /deploy-to-fs, builds the frontend of the pull
+# request and uploads it to the preview assets bucket, to use with the new
+# frontend PR preview feature
 #
 # NOTE: the `/deploy-to-fs` command is temporary, while we test this
 # mechanism. The plan is to later fold it into `/deploy-to-hg`: that command
@@ -18,11 +14,6 @@ on:
     types: [created]
   pull_request:
     types: [synchronize]
-
-# Concurrency is scoped to the build and deploy jobs rather than the workflow:
-# every created comment on a PR spawns a run of this workflow, and a
-# workflow-level group is joined before job-level `if`s are evaluated, so an
-# unrelated comment could cancel an in-flight build or deploy.
 
 permissions: {}
 
@@ -189,12 +180,7 @@ jobs:
           PR_NUMBER: ${{ needs.check.outputs.pr-number }}
         run: echo "deploy-name=pr_grafana_${PR_NUMBER}" >> "$GITHUB_OUTPUT"
 
-      # The manifest is the pointer to a build: every file it references is
-      # content-hashed and uploads never delete existing objects, so uploading
-      # chunks first and the manifest last means the preview backend (which
-      # fetches only the manifest) always sees a complete build, even if this
-      # run dies mid-upload. Files within one push-to-gcs call upload in
-      # parallel with no ordering guarantee, hence two calls.
+      # Upload the assets manifest last to help make uploads more atomic.
       - name: Stage manifests to upload last
         run: |
           mkdir -p preview-manifest

--- a/.github/workflows/deploy-frontend-preview.yml
+++ b/.github/workflows/deploy-frontend-preview.yml
@@ -4,10 +4,14 @@ name: Deploy frontend preview
 # bucket, so it can be loaded in the shared preview Grafana instance via
 # /-/set-preview-assets (see pkg/services/frontend/preview_assets.go).
 #
-# Opt in by commenting `/deploy-to-hg` on a PR that only changes frontend
-# code - the same command that deploys an ephemeral instance for PRs with
-# backend changes. Once opted in (tracked with the deploy-frontend-preview
-# label), every push to the PR rebuilds and redeploys the preview.
+# Opt in by commenting `/deploy-to-fs` on a PR that only changes frontend
+# code. Once opted in (tracked with the deploy-frontend-preview label), every
+# push to the PR rebuilds and redeploys the preview.
+#
+# NOTE: the `/deploy-to-fs` command is temporary, while we test this
+# mechanism. The plan is to later fold it into `/deploy-to-hg`: that command
+# will deploy a frontend preview for frontend-only PRs, and an ephemeral
+# instance for everything else.
 
 on:
   issue_comment:
@@ -24,7 +28,7 @@ permissions: {}
 jobs:
   check:
     name: Check PR is eligible
-    # Deploys are restricted to org members commenting /deploy-to-hg on
+    # Deploys are restricted to org members commenting /deploy-to-fs on
     # non-fork PRs. Pushes to a PR that has already opted in (has the label)
     # redeploy automatically.
     if: |
@@ -32,7 +36,7 @@ jobs:
       (
         (github.event_name == 'issue_comment' &&
           github.event.issue.pull_request &&
-          startsWith(github.event.comment.body, '/deploy-to-hg') &&
+          startsWith(github.event.comment.body, '/deploy-to-fs') &&
           (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER')) ||
         (github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.fork == false &&

--- a/.github/workflows/deploy-frontend-preview.yml
+++ b/.github/workflows/deploy-frontend-preview.yml
@@ -19,9 +19,10 @@ on:
   pull_request:
     types: [synchronize]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number }}
-  cancel-in-progress: true
+# Concurrency is scoped to the build and deploy jobs rather than the workflow:
+# every created comment on a PR spawns a run of this workflow, and a
+# workflow-level group is joined before job-level `if`s are evaluated, so an
+# unrelated comment could cancel an in-flight build or deploy.
 
 permissions: {}
 
@@ -117,6 +118,12 @@ jobs:
     needs: check
     if: needs.check.outputs.should-deploy == 'true'
     runs-on: ubuntu-x64-large
+    # Only runs that passed the check gate reach this job, so unrelated
+    # comments never join the group. A newer push cancels a stale in-flight
+    # build, which has no external side effects.
+    concurrency:
+      group: ${{ github.workflow }}-build-${{ needs.check.outputs.pr-number }}
+      cancel-in-progress: true
     permissions:
       contents: read
     steps:
@@ -148,6 +155,12 @@ jobs:
     # alongside code built from the PR.
     needs: [check, build]
     runs-on: ubuntu-arm64-small
+    # Never cancel an in-flight upload. Newer deploys queue behind it; GitHub
+    # keeps only the newest pending job in the group, so the last push always
+    # deploys last.
+    concurrency:
+      group: ${{ github.workflow }}-deploy-${{ needs.check.outputs.pr-number }}
+      cancel-in-progress: false
     permissions:
       contents: read
       id-token: write # required for push-to-gcs
@@ -176,7 +189,18 @@ jobs:
           PR_NUMBER: ${{ needs.check.outputs.pr-number }}
         run: echo "deploy-name=pr_grafana_${PR_NUMBER}" >> "$GITHUB_OUTPUT"
 
-      - name: Upload assets
+      # The manifest is the pointer to a build: every file it references is
+      # content-hashed and uploads never delete existing objects, so uploading
+      # chunks first and the manifest last means the preview backend (which
+      # fetches only the manifest) always sees a complete build, even if this
+      # run dies mid-upload. Files within one push-to-gcs call upload in
+      # parallel with no ordering guarantee, hence two calls.
+      - name: Stage manifests to upload last
+        run: |
+          mkdir -p preview-manifest
+          mv public/build/assets-manifest*.json preview-manifest/
+
+      - name: Upload assets (manifests excluded)
         uses: grafana/shared-workflows/actions/push-to-gcs@main
         with:
           environment: dev
@@ -185,6 +209,16 @@ jobs:
           # the assets manifest and CDN paths expect
           bucket_path: ${{ steps.deploy-name.outputs.deploy-name }}/public/build
           path: public/build
+          service_account: github-gf-frontend-preview-dev@grafanalabs-workload-identity.iam.gserviceaccount.com
+          parent: false
+
+      - name: Upload manifests to switch the preview to this build
+        uses: grafana/shared-workflows/actions/push-to-gcs@main
+        with:
+          environment: dev
+          bucket: ${{ env.BUCKET_NAME }}
+          bucket_path: ${{ steps.deploy-name.outputs.deploy-name }}/public/build
+          path: preview-manifest
           service_account: github-gf-frontend-preview-dev@grafanalabs-workload-identity.iam.gserviceaccount.com
           parent: false
 
@@ -239,3 +273,27 @@ jobs:
             ### Frontend preview
 
             ❌ The preview deploy for commit ${{ needs.check.outputs.head-sha }} failed. See the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+
+  comment-cancelled:
+    name: Comment that the deploy was cancelled
+    needs: [check, build, deploy]
+    # failure() does not match cancelled jobs, so without this a cancelled run
+    # would leave the sticky comment saying the build is in progress forever.
+    if: |
+      always() && needs.check.outputs.should-deploy == 'true' &&
+      !contains(needs.*.result, 'failure') &&
+      contains(needs.*.result, 'cancelled')
+    runs-on: ubuntu-arm64-small
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Update comment to say the deploy was cancelled
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: frontend-preview
+          number: ${{ needs.check.outputs.pr-number }}
+          GITHUB_TOKEN: ${{ github.token }}
+          message: |
+            ### Frontend preview
+
+            ⚠️ The preview deploy for commit ${{ needs.check.outputs.head-sha }} was cancelled ([workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})). If a newer push superseded it, that run will update this comment when it finishes. Any previously deployed preview is still live.

--- a/.github/workflows/ephemeral-instances-pr-comment.yml
+++ b/.github/workflows/ephemeral-instances-pr-comment.yml
@@ -9,45 +9,11 @@ on:
 permissions: {}
 
 jobs:
-  # PRs that only change frontend code get a frontend preview deploy (see
-  # deploy-frontend-preview.yml) instead of a full ephemeral instance.
-  check-frontend-preview:
-    name: Check for frontend preview eligibility
-    if: |
-      github.repository_owner == 'grafana' &&
-      github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request &&
-      startsWith(github.event.comment.body, '/deploy-to-hg') &&
-      (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER')
-    runs-on: ubuntu-arm64-small
-    permissions:
-      contents: read
-      pull-requests: read
-    outputs:
-      should-deploy: ${{ steps.check.outputs.should-deploy }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-
-      - name: Check PR is eligible for a frontend preview
-        id: check
-        uses: ./.github/actions/frontend-preview-check
-        with:
-          pr-number: ${{ github.event.issue.number }}
-          token: ${{ github.token }}
-
   handle-ephemeral-instances:
-    needs: check-frontend-preview
-    # !cancelled() lets this run when check-frontend-preview is skipped (the
-    # pull_request closed teardown path); its outputs are then empty, which is
-    # treated as not getting a frontend preview.
     if: |
-      !cancelled() &&
       github.repository_owner == 'grafana' &&
       (
-        (github.event.issue.pull_request && startsWith(github.event.comment.body, '/deploy-to-hg') && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') && needs.check-frontend-preview.outputs.should-deploy != 'true') ||
+        (github.event.issue.pull_request && startsWith(github.event.comment.body, '/deploy-to-hg') && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER')) ||
         github.event.action == 'closed'
       )
     runs-on: ubuntu-arm64-small

--- a/.github/workflows/ephemeral-instances-pr-comment.yml
+++ b/.github/workflows/ephemeral-instances-pr-comment.yml
@@ -9,11 +9,45 @@ on:
 permissions: {}
 
 jobs:
-  handle-ephemeral-instances:
+  # PRs that only change frontend code get a frontend preview deploy (see
+  # deploy-frontend-preview.yml) instead of a full ephemeral instance.
+  check-frontend-preview:
+    name: Check for frontend preview eligibility
     if: |
       github.repository_owner == 'grafana' &&
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/deploy-to-hg') &&
+      (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER')
+    runs-on: ubuntu-arm64-small
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      should-deploy: ${{ steps.check.outputs.should-deploy }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Check PR is eligible for a frontend preview
+        id: check
+        uses: ./.github/actions/frontend-preview-check
+        with:
+          pr-number: ${{ github.event.issue.number }}
+          token: ${{ github.token }}
+
+  handle-ephemeral-instances:
+    needs: check-frontend-preview
+    # !cancelled() lets this run when check-frontend-preview is skipped (the
+    # pull_request closed teardown path); its outputs are then empty, which is
+    # treated as not getting a frontend preview.
+    if: |
+      !cancelled() &&
+      github.repository_owner == 'grafana' &&
       (
-        (github.event.issue.pull_request && startsWith(github.event.comment.body, '/deploy-to-hg') && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER')) ||
+        (github.event.issue.pull_request && startsWith(github.event.comment.body, '/deploy-to-hg') && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') && needs.check-frontend-preview.outputs.should-deploy != 'true') ||
         github.event.action == 'closed'
       )
     runs-on: ubuntu-arm64-small

--- a/.policy.yml
+++ b/.policy.yml
@@ -14,6 +14,7 @@ policy:
             - Workflow .github/workflows/build-go-matrix.yml succeeded or skipped
             - Workflow .github/workflows/check-frontend-test-coverage.yml succeeded or skipped
             - Workflow .github/workflows/codeowners-validator.yml succeeded or skipped
+            - Workflow .github/workflows/deploy-frontend-preview.yml succeeded or skipped
             - Workflow .github/workflows/deploy-pr-preview.yml succeeded or skipped
             - Workflow .github/workflows/deploy-storybook-preview.yml succeeded or skipped
             - Workflow .github/workflows/detect-breaking-changes-levitate.yml succeeded or skipped
@@ -185,6 +186,19 @@ approval_rules:
             - success
           workflows:
             - .github/workflows/create-security-patch-from-security-mirror.yml
+  - name: Workflow .github/workflows/deploy-frontend-preview.yml succeeded or skipped
+    if:
+      file_not_deleted:
+        paths:
+          - ^\.github\/workflows\/deploy-frontend-preview\.yml$
+    requires:
+      conditions:
+        has_workflow_result:
+          conclusions:
+            - skipped
+            - success
+          workflows:
+            - .github/workflows/deploy-frontend-preview.yml
   - name: Workflow .github/workflows/deploy-pr-preview.yml succeeded or skipped
     if:
       changed_files:

--- a/.policy.yml
+++ b/.policy.yml
@@ -14,7 +14,6 @@ policy:
             - Workflow .github/workflows/build-go-matrix.yml succeeded or skipped
             - Workflow .github/workflows/check-frontend-test-coverage.yml succeeded or skipped
             - Workflow .github/workflows/codeowners-validator.yml succeeded or skipped
-            - Workflow .github/workflows/deploy-frontend-preview.yml succeeded or skipped
             - Workflow .github/workflows/deploy-pr-preview.yml succeeded or skipped
             - Workflow .github/workflows/deploy-storybook-preview.yml succeeded or skipped
             - Workflow .github/workflows/detect-breaking-changes-levitate.yml succeeded or skipped

--- a/Makefile
+++ b/Makefile
@@ -842,6 +842,8 @@ GENERATE_POLICY_BOT_CONFIG_SHA := sha256:d05ff5c7d4247da155c85f8c6f1f9f7c6d013d1
 		.
 # We don't want the patch workflow to be run. This is exclusively useful for the security-mirror. It won't work in OSS.
 	sed -i.bak '/- Workflow \.github\/workflows\/create-security-patch-from-security-mirror/d' .policy.yml; rm -f .policy.yml.bak
+# The frontend preview deploy is opt-in and only triggers on `synchronize`, so a PR opened without a further push never produces a run for policy-bot to find.
+	sed -i.bak '/- Workflow \.github\/workflows\/deploy-frontend-preview/d' .policy.yml; rm -f .policy.yml.bak
 # Make govulncheck non-blocking - accept failure so it doesn't prevent merge
 	sed -i.bak '/name: Workflow \.github\/workflows\/govulncheck\.yml/,/workflows:/{s/- success/- success\n            - failure/;}' .policy.yml; rm -f .policy.yml.bak
 # Make check-frontend-test-coverage non-blocking - accept failure so it doesn't prevent merge


### PR DESCRIPTION
Adds a workflow that builds a PR's frontend and uploads it to the preview assets bucket, so it can be loaded in the shared preview instance via `/-/set-preview-assets` (see the PR below this one in the stack).

**How it works**

- Org members opt a PR in by commenting `/deploy-to-fs`. Eligibility is checked by a new `frontend-preview-check` action (non-fork, frontend-only changes). The opt-in is recorded with the `deploy-frontend-preview` label so every subsequent push redeploys automatically.
- Assets upload to `grafana-frontend-preview-dev` under `pr_grafana_<number>/public/build/`. The deploy name is stable across pushes so an already-set cookie picks up new builds.
- A sticky PR comment tracks build progress and links the preview.

**Deploy safety**

- Build and deploy are separate jobs so the OIDC-enabled upload step never runs alongside code built from the PR.
- Manifests upload last: every other file is content-hashed and uploads never delete, so the preview backend (which fetches only the manifest) always sees a complete build even if a run dies mid-upload.
- Concurrency is scoped per job rather than per workflow so unrelated PR comments can't cancel an in-flight build; deploys queue rather than cancel.

The `/deploy-to-fs` command is temporary while this mechanism is tested; the plan is to fold it into `/deploy-to-hg`.

See design doc for more info: https://docs.google.com/document/d/1fwfoCOxXSDd5nGYVAR2ZsioBBgSRs1CxjdVXpCbwUI8/edit