### PR TITLE
FeatureControl: Show by default with a notice when preview assets are active

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -984,6 +984,7 @@ playwright.storybook.config.ts @grafana/grafana-frontend-platform
 /public/app/core/utils/urlToken.ts @grafana/identity-access-team
 /public/app/core/utils/version.ts @grafana/data-sources-plugins
 /public/app/core/utils/roles.ts @grafana/identity-access-team
+/public/app/core/utils/previewAssets* @grafana/grafana-frontend-platform
 /public/app/dev-utils.ts @grafana/grafana-frontend-platform
 
 /public/app/features/AGENTS.md @grafana/dataviz-squad

--- a/.github/workflows/deploy-frontend-preview.yml
+++ b/.github/workflows/deploy-frontend-preview.yml
@@ -257,7 +257,8 @@ jobs:
 
             ✅ The preview for commit ${{ needs.check.outputs.head-sha }} is live: **[open the preview](${{ steps.preview-url.outputs.url }})**.
 
-            Each new push to this PR builds and deploys the preview again automatically.
+            - Each new push to this PR builds and deploys the preview again automatically.
+            - Share the above link for others to preview it in their browsers too.
 
   comment-failure:
     name: Comment that the deploy failed

--- a/pkg/services/frontend/preview_assets.go
+++ b/pkg/services/frontend/preview_assets.go
@@ -149,12 +149,10 @@ func (h *previewAssetsHandler) renderConfirmationPage(w http.ResponseWriter, log
 		Folder    string
 		AssetsURL string
 		CSRFToken string
-		Duration  string
 	}{
 		Folder:    folder,
 		AssetsURL: assetsURL,
 		CSRFToken: csrfToken,
-		Duration:  "24 hours",
 	})
 	if err != nil {
 		logger.Error("failed to render preview assets confirmation page", "err", err)

--- a/pkg/services/frontend/preview_assets_confirm.html
+++ b/pkg/services/frontend/preview_assets_confirm.html
@@ -13,10 +13,8 @@
         --text: rgb(36, 41, 46);
         --text-secondary: rgba(36, 41, 46, 0.75);
         --code-bg: rgba(36, 41, 46, 0.07);
-        --warning-bg: rgba(245, 95, 62, 0.08);
-        --warning-border: rgba(245, 95, 62, 0.5);
-        --primary: #f55f3e;
-        --primary-hover: #d94e30;
+        --primary: #1b855e;
+        --primary-hover: #0a764e;
         --secondary-bg: rgba(36, 41, 46, 0.08);
         --secondary-hover: rgba(36, 41, 46, 0.15);
       }
@@ -29,8 +27,6 @@
           --text: rgb(204, 204, 220);
           --text-secondary: rgba(204, 204, 220, 0.65);
           --code-bg: rgba(204, 204, 220, 0.07);
-          --warning-bg: rgba(245, 95, 62, 0.1);
-          --warning-border: rgba(245, 95, 62, 0.5);
           --secondary-bg: rgba(204, 204, 220, 0.1);
           --secondary-hover: rgba(204, 204, 220, 0.16);
         }
@@ -78,11 +74,7 @@
         margin-bottom: 0.75rem;
       }
 
-      .warning {
-        padding: 0.75rem;
-        background: var(--warning-bg);
-        border: 1px solid var(--warning-border);
-        border-radius: 4px;
+      .description {
         font-size: 0.8125rem;
       }
 
@@ -128,16 +120,11 @@
   <body>
     <main>
       <h1>Load preview assets?</h1>
-      <p>
-        You are about to load the frontend assets from the preview build
-        <strong>{{.Folder}}</strong>:
-      </p>
+      <p>Load the frontend preview from <strong>{{.Folder}}</strong>:</p>
       <div class="url">{{.AssetsURL}}</div>
-      <div class="warning">
-        This replaces the Grafana frontend in this browser with unreviewed, unreleased code for
-        {{.Duration}}. Only continue if you trust the pull request these assets were built from.
-        You can undo this at any time by visiting
-        <code>/-/set-preview-assets?clear=1</code>.
+      <div class="description">
+        This sets a cookie in your browser to enable the preview. Share this page’s URL
+        with others so they can preview it in their browsers too.
       </div>
       <form method="GET" action="/-/set-preview-assets">
         <input type="hidden" name="assets" value="{{.Folder}}" />

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlags.test.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlags.test.tsx
@@ -31,6 +31,7 @@ describe('FeatureControlFlags', () => {
     jest.clearAllMocks();
     window.localStorage.clear();
     getLocalStorageProvider().clearFlags();
+    delete window.__grafanaPreviewAssets;
   });
 
   it('renders flags from local storage', async () => {
@@ -54,5 +55,21 @@ describe('FeatureControlFlags', () => {
     expect(setIsOpen).toHaveBeenCalledWith(false);
     expect(setIsAccessible).toHaveBeenCalledWith(false);
     expect(window.localStorage.getItem(getStorageKey('alpha'))).toBe('true');
+  });
+
+  it('does not show the preview assets message by default', () => {
+    renderComponent();
+
+    expect(screen.queryByText('Frontend preview active')).not.toBeInTheDocument();
+  });
+
+  it('shows the preview assets message when preview assets are active', () => {
+    window.__grafanaPreviewAssets = 'pr_grafana_123456';
+
+    renderComponent();
+
+    expect(screen.getByText('Frontend preview active')).toBeInTheDocument();
+    expect(screen.getByText('pr_grafana_123456')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Stop preview/ })).toBeInTheDocument();
   });
 });

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlags.test.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlags.test.tsx
@@ -68,8 +68,23 @@ describe('FeatureControlFlags', () => {
 
     renderComponent();
 
-    expect(screen.getByText('Frontend preview active')).toBeInTheDocument();
-    expect(screen.getByText('pr_grafana_123456')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Stop preview/ })).toBeInTheDocument();
+    const previewStatus = screen.getByRole('status');
+    expect(previewStatus).toHaveTextContent('Frontend preview active');
+    expect(previewStatus).toHaveTextContent('Build pr_grafana_123456 live for just you.');
+    expect(screen.getByRole('button', { name: 'Stop preview' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Copy share link' })).toBeInTheDocument();
+  });
+
+  it('copies a link that enables the active preview assets', async () => {
+    Object.defineProperty(window, 'isSecureContext', { value: true, configurable: true });
+    const user = userEvent.setup();
+    window.__grafanaPreviewAssets = 'pr_grafana_123456';
+
+    renderComponent();
+    await user.click(screen.getByRole('button', { name: 'Copy share link' }));
+
+    expect(await navigator.clipboard.readText()).toBe(
+      `${window.location.origin}/-/set-preview-assets?assets=pr_grafana_123456`
+    );
   });
 });

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlags.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlags.tsx
@@ -5,7 +5,8 @@ import { useEffect, useState } from 'react';
 import type { GrafanaTheme2 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { getLocalStorageProvider } from '@grafana/runtime/internal';
-import { Card, Dropdown, Icon, IconButton, Menu, MenuItem, Stack, Text, useStyles2 } from '@grafana/ui';
+import { Alert, Button, Card, Dropdown, Icon, IconButton, Menu, MenuItem, Stack, Text, useStyles2 } from '@grafana/ui';
+import { getPreviewAssetsFolder } from 'app/core/utils/previewAssets';
 
 import { FeatureControlFlag, type FeatureControlFlagProps } from './FeatureControlFlag';
 import { useFeatureControlContext } from './FeatureControlProvider';
@@ -18,6 +19,7 @@ export const FeatureControlFlags = () => {
   const { setIsOpen, setIsAccessible } = useFeatureControlContext();
   const [flags, setFlags] = useState<Flag[]>([]);
   const styles = useStyles2(getStyles);
+  const previewAssetsFolder = getPreviewAssetsFolder();
 
   useEffect(() => {
     const loadFlags = () => {
@@ -81,6 +83,30 @@ export const FeatureControlFlags = () => {
         </Trans>
       </Text>
 
+      {previewAssetsFolder && (
+        <Alert
+          severity="info"
+          title={t('feature-control.preview-assets.title', 'Frontend preview active')}
+          action={
+            <Button
+              size="sm"
+              variant="secondary"
+              // Must be a full page load so the request reaches the frontend
+              // service instead of the SPA router
+              onClick={() => window.location.assign('/-/set-preview-assets?clear=1')}
+            >
+              {t('feature-control.preview-assets.stop', 'Stop preview')}
+            </Button>
+          }
+          className={styles.previewAlert}
+        >
+          <Trans i18nKey="feature-control.preview-assets.body" values={{ folder: previewAssetsFolder }}>
+            This session is using frontend assets from the preview build <code>{'{{ folder }}'}</code> instead of the
+            released frontend.
+          </Trans>
+        </Alert>
+      )}
+
       <div className={styles.list}>
         {flags.map((flag) => (
           <FeatureControlFlag key={flag.key} flag={flag} />
@@ -102,6 +128,9 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   menu: css({
     marginLeft: 'auto',
+  }),
+  previewAlert: css({
+    marginBottom: 0,
   }),
   list: css({
     display: 'flex',

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlags.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlags.tsx
@@ -5,11 +5,12 @@ import { useEffect, useState } from 'react';
 import type { GrafanaTheme2 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { getLocalStorageProvider } from '@grafana/runtime/internal';
-import { Alert, Button, Card, Dropdown, Icon, IconButton, Menu, MenuItem, Stack, Text, useStyles2 } from '@grafana/ui';
+import { Card, Dropdown, Icon, IconButton, Menu, MenuItem, Stack, Text, useStyles2 } from '@grafana/ui';
 import { getPreviewAssetsFolder } from 'app/core/utils/previewAssets';
 
 import { FeatureControlFlag, type FeatureControlFlagProps } from './FeatureControlFlag';
 import { useFeatureControlContext } from './FeatureControlProvider';
+import { PreviewAssetsMessage } from './PreviewAssetsMessage';
 
 const compare = new Intl.Collator('en', { sensitivity: 'base', numeric: true }).compare;
 
@@ -83,29 +84,7 @@ export const FeatureControlFlags = () => {
         </Trans>
       </Text>
 
-      {previewAssetsFolder && (
-        <Alert
-          severity="info"
-          title={t('feature-control.preview-assets.title', 'Frontend preview active')}
-          action={
-            <Button
-              size="sm"
-              variant="secondary"
-              // Must be a full page load so the request reaches the frontend
-              // service instead of the SPA router
-              onClick={() => window.location.assign('/-/set-preview-assets?clear=1')}
-            >
-              {t('feature-control.preview-assets.stop', 'Stop preview')}
-            </Button>
-          }
-          className={styles.previewAlert}
-        >
-          <Trans i18nKey="feature-control.preview-assets.body" values={{ folder: previewAssetsFolder }}>
-            This session is using frontend assets from the preview build <code>{'{{ folder }}'}</code> instead of the
-            released frontend.
-          </Trans>
-        </Alert>
-      )}
+      {previewAssetsFolder && <PreviewAssetsMessage previewAssetsFolder={previewAssetsFolder} />}
 
       <div className={styles.list}>
         {flags.map((flag) => (
@@ -128,9 +107,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   menu: css({
     marginLeft: 'auto',
-  }),
-  previewAlert: css({
-    marginBottom: 0,
   }),
   list: css({
     display: 'flex',

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlProvider.test.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlProvider.test.tsx
@@ -25,6 +25,7 @@ describe('FeatureControlProvider', () => {
     jest.clearAllMocks();
 
     window.localStorage.clear();
+    delete window.__grafanaPreviewAssets;
     locationServiceMock.getSearchObject.mockReturnValue({});
     locationServiceMock.getLocationObservable.mockReturnValue({
       subscribe: jest.fn().mockReturnValue({
@@ -87,6 +88,22 @@ describe('FeatureControlProvider', () => {
 
     expectState({ isAccessible: true, isOpen: true });
     expectStorage({ isAccessible: 'true', isOpen: 'true' });
+  });
+
+  it('should default to accessible and open when preview assets are active', () => {
+    window.__grafanaPreviewAssets = 'pr_grafana_123456';
+    renderProvider();
+
+    expectState({ isAccessible: true, isOpen: true });
+  });
+
+  it('should respect a stored dismissal when preview assets are active', () => {
+    window.__grafanaPreviewAssets = 'pr_grafana_123456';
+    window.localStorage.setItem(STORAGE_KEYS.accessible, 'false');
+    window.localStorage.setItem(STORAGE_KEYS.open, 'false');
+    renderProvider();
+
+    expectState({ isAccessible: false, isOpen: false });
   });
 
   it('should update accessibility and open state', async () => {

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlProvider.test.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlProvider.test.tsx
@@ -43,6 +43,14 @@ describe('FeatureControlProvider', () => {
         <div data-testid="is-open">{isOpen.toString()}</div>
         <button onClick={() => setIsAccessible(true)}>Enable accessibility</button>
         <button onClick={() => setIsOpen(true)}>Open feature control</button>
+        <button
+          onClick={() => {
+            setIsAccessible(false);
+            setIsOpen(false);
+          }}
+        >
+          Dismiss feature control
+        </button>
       </div>
     );
   };
@@ -97,13 +105,24 @@ describe('FeatureControlProvider', () => {
     expectState({ isAccessible: true, isOpen: true });
   });
 
-  it('should respect a stored dismissal when preview assets are active', () => {
+  it('should override a stored dismissal on the first page load when preview assets are active', () => {
     window.__grafanaPreviewAssets = 'pr_grafana_123456';
     window.localStorage.setItem(STORAGE_KEYS.accessible, 'false');
     window.localStorage.setItem(STORAGE_KEYS.open, 'false');
     renderProvider();
 
+    expectState({ isAccessible: true, isOpen: true });
+    expectStorage({ isAccessible: 'false', isOpen: 'false' });
+  });
+
+  it('should allow feature control to be dismissed during a preview session', async () => {
+    window.__grafanaPreviewAssets = 'pr_grafana_123456';
+    renderProvider();
+
+    await userEvent.click(screen.getByText('Dismiss feature control'));
+
     expectState({ isAccessible: false, isOpen: false });
+    expectStorage({ isAccessible: 'false', isOpen: 'false' });
   });
 
   it('should update accessibility and open state', async () => {

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlProvider.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlProvider.tsx
@@ -2,6 +2,7 @@ import { createContext, type ReactNode, useContext, useEffect, useMemo } from 'r
 
 import { locationService } from '@grafana/runtime';
 import { useStoredBoolean } from 'app/core/hooks/useStored';
+import { getPreviewAssetsFolder } from 'app/core/utils/previewAssets';
 
 const FEATURE_CONTROL_ACCESSIBLE_LOCAL_STORAGE_KEY = 'grafana.feature-control.accessible';
 const FEATURE_CONTROL_OPEN_LOCAL_STORAGE_KEY = 'grafana.feature-control.open';
@@ -25,8 +26,15 @@ export const FeatureControlContext = createContext<FeatureControlContextType>({
 export const useFeatureControlContext = () => useContext(FeatureControlContext);
 
 export const FeatureControlContextProvider = ({ children }: { children: ReactNode }) => {
-  const [isAccessible, setIsAccessible] = useStoredBoolean(FEATURE_CONTROL_ACCESSIBLE_LOCAL_STORAGE_KEY, false);
-  const [isOpen, setIsOpen] = useStoredBoolean(FEATURE_CONTROL_OPEN_LOCAL_STORAGE_KEY, false);
+  // When this session runs frontend assets from a PR preview build, the UI is
+  // shown by default so the preview is clearly signposted. Stored values (e.g.
+  // an explicit dismissal) still take precedence.
+  const previewAssetsActive = Boolean(getPreviewAssetsFolder());
+  const [isAccessible, setIsAccessible] = useStoredBoolean(
+    FEATURE_CONTROL_ACCESSIBLE_LOCAL_STORAGE_KEY,
+    previewAssetsActive
+  );
+  const [isOpen, setIsOpen] = useStoredBoolean(FEATURE_CONTROL_OPEN_LOCAL_STORAGE_KEY, previewAssetsActive);
 
   useEffect(() => {
     const syncForcedState = () => {

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlProvider.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, type ReactNode, useContext, useEffect, useMemo } from 'react';
+import { createContext, type ReactNode, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
 import { locationService } from '@grafana/runtime';
 import { useStoredBoolean } from 'app/core/hooks/useStored';
@@ -26,15 +26,33 @@ export const FeatureControlContext = createContext<FeatureControlContextType>({
 export const useFeatureControlContext = () => useContext(FeatureControlContext);
 
 export const FeatureControlContextProvider = ({ children }: { children: ReactNode }) => {
-  // When this session runs frontend assets from a PR preview build, the UI is
-  // shown by default so the preview is clearly signposted. Stored values (e.g.
-  // an explicit dismissal) still take precedence.
   const previewAssetsActive = Boolean(getPreviewAssetsFolder());
-  const [isAccessible, setIsAccessible] = useStoredBoolean(
+  const [storedIsAccessible, setStoredIsAccessible] = useStoredBoolean(
     FEATURE_CONTROL_ACCESSIBLE_LOCAL_STORAGE_KEY,
     previewAssetsActive
   );
-  const [isOpen, setIsOpen] = useStoredBoolean(FEATURE_CONTROL_OPEN_LOCAL_STORAGE_KEY, previewAssetsActive);
+  const [storedIsOpen, setStoredIsOpen] = useStoredBoolean(FEATURE_CONTROL_OPEN_LOCAL_STORAGE_KEY, previewAssetsActive);
+
+  // Ignore persisted dismissals on the first render of a preview session, but
+  // clear the override when the user changes either value during that session.
+  const [forceAccessible, setForceAccessible] = useState(previewAssetsActive);
+  const [forceOpen, setForceOpen] = useState(previewAssetsActive);
+  const isAccessible = forceAccessible || storedIsAccessible;
+  const isOpen = forceOpen || storedIsOpen;
+  const setIsAccessible = useCallback(
+    (value: boolean) => {
+      setForceAccessible(false);
+      setStoredIsAccessible(value);
+    },
+    [setStoredIsAccessible]
+  );
+  const setIsOpen = useCallback(
+    (value: boolean) => {
+      setForceOpen(false);
+      setStoredIsOpen(value);
+    },
+    [setStoredIsOpen]
+  );
 
   useEffect(() => {
     const syncForcedState = () => {

--- a/public/app/core/components/AppChrome/FeatureControl/PreviewAssetsMessage.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/PreviewAssetsMessage.tsx
@@ -1,0 +1,75 @@
+/* eslint-disable @grafana/i18n/no-untranslated-strings */
+import { css } from '@emotion/css';
+
+import type { GrafanaTheme2 } from '@grafana/data';
+import { Button, ClipboardButton, Icon, Stack, Text, useStyles2 } from '@grafana/ui';
+
+interface PreviewAssetsMessageProps {
+  previewAssetsFolder: string;
+}
+
+export const PreviewAssetsMessage = ({ previewAssetsFolder }: PreviewAssetsMessageProps) => {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <div className={styles.previewStatus} role="status">
+      <Icon name="info-circle" className={styles.previewIcon} />
+      <div className={styles.previewText}>
+        <Text variant="bodySmall" weight="medium">
+          Frontend preview active
+        </Text>
+        <Text variant="bodySmall" color="secondary">
+          Build <span className={styles.code}>{previewAssetsFolder}</span> live for just you.
+        </Text>
+      </div>
+
+      <Stack direction="column" gap={1} alignItems="flex-end">
+        <Button
+          size="sm"
+          variant="secondary"
+          // Must be a full page load so the request reaches the frontend service instead of the SPA router
+          onClick={() => window.location.assign('/-/set-preview-assets?clear=1')}
+        >
+          Stop preview
+        </Button>
+        <ClipboardButton
+          size="sm"
+          variant="secondary"
+          getText={() => {
+            const url = new URL('/-/set-preview-assets', window.location.origin);
+            url.searchParams.set('assets', previewAssetsFolder);
+            return url.href;
+          }}
+        >
+          Copy share link
+        </ClipboardButton>
+      </Stack>
+    </div>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    previewStatus: css({
+      display: 'grid',
+      gridTemplateColumns: 'auto minmax(0, 1fr) auto',
+      gap: theme.spacing(1),
+      alignItems: 'center',
+      padding: theme.spacing(1),
+      backgroundColor: theme.colors.background.secondary,
+      borderLeft: `3px solid ${theme.colors.info.border}`,
+      borderRadius: theme.shape.radius.default,
+    }),
+    previewIcon: css({
+      color: theme.colors.info.text,
+    }),
+    previewText: css({
+      display: 'flex',
+      flexDirection: 'column',
+      minWidth: 0,
+    }),
+    code: css({
+      fontFamily: theme.typography.fontFamilyMonospace,
+    }),
+  };
+};

--- a/public/app/core/utils/previewAssets.ts
+++ b/public/app/core/utils/previewAssets.ts
@@ -1,0 +1,11 @@
+/**
+ * Returns the preview build folder name (e.g. `pr_grafana_123456`) when this
+ * session is serving frontend assets from a PR preview build, or undefined
+ * when the release assets are in use.
+ *
+ * The value is injected into index.html by the frontend service when the
+ * preview assets cookie is set - see pkg/services/frontend/preview_assets.go.
+ */
+export function getPreviewAssetsFolder(): string | undefined {
+  return window.__grafanaPreviewAssets || undefined;
+}

--- a/public/app/types/window.d.ts
+++ b/public/app/types/window.d.ts
@@ -47,6 +47,12 @@ export declare global {
 
     /** Selects the Luxon-backed implementation before the application bundle loads. */
     __grafanaUseLuxon?: boolean;
+
+    /**
+     * Set by the frontend service to the preview folder name when this page is
+     * serving frontend assets from a PR preview build instead of the release assets.
+     */
+    __grafanaPreviewAssets?: string;
   }
 
   // Augment DOMParser to accept TrustedType sanitised content

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9254,11 +9254,6 @@
     "flag-value": "Flag value",
     "menu": "Open menu",
     "new-flag": "new-flag-override",
-    "preview-assets": {
-      "body": "This session is using frontend assets from the preview build <1>{{ folder }}</1> instead of the released frontend.",
-      "stop": "Stop preview",
-      "title": "Frontend preview active"
-    },
     "save-flag": "Save",
     "title": "Feature control"
   },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9254,6 +9254,11 @@
     "flag-value": "Flag value",
     "menu": "Open menu",
     "new-flag": "new-flag-override",
+    "preview-assets": {
+      "body": "This session is using frontend assets from the preview build <1>{{ folder }}</1> instead of the released frontend.",
+      "stop": "Stop preview",
+      "title": "Frontend preview active"
+    },
     "save-flag": "Save",
     "title": "Feature control"
   },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9201,6 +9201,11 @@
     "flag-value": "Flag value",
     "menu": "Open menu",
     "new-flag": "new-flag-override",
+    "preview-assets": {
+      "body": "This session is using frontend assets from the preview build <1>{{ folder }}</1> instead of the released frontend.",
+      "stop": "Stop preview",
+      "title": "Frontend preview active"
+    },
     "save-flag": "Save",
     "title": "Feature control"
   },


### PR DESCRIPTION

- When a Frontend Preview is active, forces open Feature Control with a disclaimer about the preview, and `Copy share link` button

<img width="474" height="350" alt="Screenshot 2026-08-20 at 12 14 24 pm" src="https://github.com/user-attachments/assets/aecefa61-80af-46af-8943-977df72ac526" />

- Tweaks the preview consent screen to be less intimidating, and more informative

<img width="802" height="390" alt="Screenshot 2026-08-20 at 12 12 02 pm" src="https://github.com/user-attachments/assets/07e9242b-4694-4338-a88d-9c87f9985610" />

- Updates the PR comment to include sharing instructions



See design doc for more info: https://docs.google.com/document/d/1fwfoCOxXSDd5nGYVAR2ZsioBBgSRs1CxjdVXpCbwUI8/edit