### PR TITLE
Alerting: Strip empty-name labels/annotations when converting state to alert

### DIFF
--- a/pkg/services/ngalert/state/compat.go
+++ b/pkg/services/ngalert/state/compat.go
@@ -40,6 +40,21 @@ func StateToPostableAlert(transition StateTransition, appURL *url.URL) *models.P
 	nL := alertState.Labels.Copy()
 	nA := data.Labels(alertState.Annotations).Copy()
 
+	// Drop labels and annotations with an empty name or empty value. An empty name makes the
+	// Alertmanager reject the alert ("invalid label set: invalid name"); an empty value is
+	// equivalent to the label being absent. The namespace UID label is kept here - it is
+	// propagated into an annotation below.
+	for k, v := range nL {
+		if len(k) == 0 || len(v) == 0 {
+			delete(nL, k)
+		}
+	}
+	for k, v := range nA {
+		if len(k) == 0 || len(v) == 0 {
+			delete(nA, k)
+		}
+	}
+
 	// encode the values as JSON where it will be expanded later
 	if len(alertState.Values) > 0 {
 		if b, err := json.Marshal(alertState.Values); err == nil {

--- a/pkg/services/ngalert/state/compat_test.go
+++ b/pkg/services/ngalert/state/compat_test.go
@@ -199,6 +199,20 @@ func Test_StateToPostableAlert(t *testing.T) {
 				})
 			})
 
+			t.Run("should strip labels and annotations with an empty name or value", func(t *testing.T) {
+				alertState := randomTransition(eval.Normal, tc.state)
+				alertState.Labels[""] = "empty-name-label"
+				alertState.Labels["empty-value-label"] = ""
+				alertState.Annotations = randomMapOfStrings()
+				alertState.Annotations[""] = "empty-name-annotation"
+				alertState.Annotations["empty-value-annotation"] = ""
+				result := StateToPostableAlert(alertState, appURL)
+				require.NotContains(t, result.Labels, "")
+				require.NotContains(t, result.Labels, "empty-value-label")
+				require.NotContains(t, result.Annotations, "")
+				require.NotContains(t, result.Annotations, "empty-value-annotation")
+			})
+
 			switch tc.state {
 			case eval.NoData:
 				t.Run("should keep existing labels and change name", func(t *testing.T) {


### PR DESCRIPTION
`StateToPostableAlert` converts an alert rule's state into a `PostableAlert`. A label or annotation with an **empty name** makes the Alertmanager reject the alert (`invalid label set: invalid name`); an **empty value** is equivalent to the label being absent. This strips both when the alert is built.

The namespace UID label is preserved here — it is propagated into an annotation a few lines below.

Complements #130171, which does the same in the remote Alertmanager sender (`PutAlerts`); this handles it at the state→alert boundary.

### Testing
Extended `Test_StateToPostableAlert` to cover empty-name and empty-value labels/annotations (Normal/Alerting/Pending/NoData/Error). Full `state` package passes.
