### PR TITLE
DataPro (migration): Migrate `explore/SignalExplorer/SignalExplorer.tsx`

### DIFF
--- a/public/app/features/explore/ContentOutline/ContentOutline.test.tsx
+++ b/public/app/features/explore/ContentOutline/ContentOutline.test.tsx
@@ -1,8 +1,8 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { type DataSourceInstanceSettings, type TimeRange, store } from '@grafana/data';
-import { type DataSourceSrv, setDataSourceSrv } from '@grafana/runtime';
+import { type DataSourceInstanceSettings, type DataSourcePluginMeta, type TimeRange, store } from '@grafana/data';
+import { initDataSourceInstanceSettings, setDatasourcePluginMetas } from '@grafana/runtime/internal';
 import { type DataQuery } from '@grafana/schema';
 
 import { ContentOutline } from './ContentOutline';
@@ -22,23 +22,26 @@ const scrollerMock = document.createElement('div');
 
 const unregisterMock = jest.fn();
 
+const promMeta = { id: 'prometheus', info: { logos: { small: 'prometheus.svg' } } } as unknown as DataSourcePluginMeta;
+
 const promSettings = {
   uid: 'prom-uid',
   type: 'prometheus',
   name: 'gdev-prometheus',
-  meta: { id: 'prometheus', info: { logos: { small: 'prometheus.svg' } } },
+  meta: promMeta,
 } as unknown as DataSourceInstanceSettings;
 
 const timeRange = { raw: { from: 'now-1h', to: 'now' }, from: {}, to: {} } as unknown as TimeRange;
 
-const setup = (mergeSingleChild = false, showSignalExplorer = false, queries: DataQuery[] = []) => {
+const setup = async (mergeSingleChild = false, showSignalExplorer = false, queries: DataQuery[] = []) => {
   HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
 
   scrollerMock.scroll = jest.fn();
 
-  setDataSourceSrv({
-    getInstanceSettings: () => promSettings,
-  } as unknown as DataSourceSrv);
+  // SignalExplorer resolves a card's datasource and logo through the async datasource APIs, so
+  // both of the caches behind them are seeded rather than the legacy `DataSourceSrv`.
+  initDataSourceInstanceSettings({ 'gdev-prometheus': promSettings }, 'gdev-prometheus');
+  setDatasourcePluginMetas({ prometheus: promMeta });
 
   // Mock useContentOutlineContext with custom outlineItems
   const mockUseContentOutlineContext = require('./ContentOutlineContext').useContentOutlineContext;
@@ -90,7 +93,7 @@ const setup = (mergeSingleChild = false, showSignalExplorer = false, queries: Da
     unregister: unregisterMock,
   });
 
-  return render(
+  const rendered = render(
     <ContentOutline
       scroller={scrollerMock}
       panelId="content-outline-container-1"
@@ -99,11 +102,20 @@ const setup = (mergeSingleChild = false, showSignalExplorer = false, queries: Da
       timeRange={timeRange}
     />
   );
+
+  // The explorer's datasource hooks resolve a few promise turns after the first paint, so settle
+  // them here: their state updates stay inside act() and the cards carry resolved names.
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  return rendered;
 };
 
 describe('<ContentOutline />', () => {
   it('toggles content on button click', async () => {
-    setup();
+    await setup();
     let showContentOutlineButton = screen.getByRole('button', { name: 'Collapse outline' });
     expect(showContentOutlineButton).toBeInTheDocument();
 
@@ -117,7 +129,7 @@ describe('<ContentOutline />', () => {
   });
 
   it('scrolls into view on content button click', async () => {
-    setup();
+    await setup();
     const itemButtons = screen.getAllByRole('button', { name: /Item [0-9]+/ });
 
     for (const button of itemButtons) {
@@ -128,7 +140,7 @@ describe('<ContentOutline />', () => {
   });
 
   it('doesnt merge a single child item when mergeSingleChild is false', async () => {
-    setup();
+    await setup();
     const expandSectionChevrons = screen.getAllByRole('button', { name: 'Content outline item collapse button' });
     await userEvent.click(expandSectionChevrons[0]);
 
@@ -136,15 +148,15 @@ describe('<ContentOutline />', () => {
     expect(child).toBeInTheDocument();
   });
 
-  it('merges a single child item when mergeSingleChild is true', () => {
-    setup(true);
+  it('merges a single child item when mergeSingleChild is true', async () => {
+    await setup(true);
     const child = screen.queryByRole('button', { name: 'Item 1-1' });
 
     expect(child).not.toBeInTheDocument();
   });
 
   it('displays multiple children', async () => {
-    setup();
+    await setup();
     const expandSectionChevrons = screen.getAllByRole('button', { name: 'Content outline item collapse button' });
     await userEvent.click(expandSectionChevrons[1]);
 
@@ -155,7 +167,7 @@ describe('<ContentOutline />', () => {
   });
 
   it('if item has multiple children, it displays multiple children even when mergeSingleChild is true', async () => {
-    setup(true);
+    await setup(true);
     const expandSectionChevrons = screen.getAllByRole('button', { name: 'Content outline item collapse button' });
     // since first item has only one child, we will have only one chevron
     await userEvent.click(expandSectionChevrons[0]);
@@ -167,7 +179,7 @@ describe('<ContentOutline />', () => {
   });
 
   it('collapse button has same aria-controls as the section content', async () => {
-    setup();
+    await setup();
     const expandSectionChevrons = screen.getAllByRole('button', { name: 'Content outline item collapse button' });
     // chevron for the second item
     const button = expandSectionChevrons[1];
@@ -178,7 +190,7 @@ describe('<ContentOutline />', () => {
   });
 
   it('deletes item on delete button click', async () => {
-    setup();
+    await setup();
     const expandSectionChevrons = screen.getAllByRole('button', { name: 'Content outline item collapse button' });
     // chevron for the second item
     const button = expandSectionChevrons[1];
@@ -191,7 +203,7 @@ describe('<ContentOutline />', () => {
 
   it('should retrieve the last expanded state from local storage', async () => {
     const getBoolMock = jest.spyOn(store, 'getBool').mockReturnValue(false);
-    setup();
+    await setup();
     const collapseContentOutlineButton = screen.queryByRole('button', { name: 'Collapse outline' });
     const expandContentOutlineButton = screen.queryByRole('button', { name: 'Expand outline' });
     expect(collapseContentOutlineButton).not.toBeInTheDocument();
@@ -207,23 +219,23 @@ describe('<ContentOutline />', () => {
       useBooleanFlagValueMock.mockImplementation((_: string, defaultValue: boolean) => defaultValue);
     });
 
-    it('hides the header title and the query cards by default (feature toggle off)', () => {
-      setup(false, false, promQueries);
+    it('hides the header title and the query cards by default (feature toggle off)', async () => {
+      await setup(false, false, promQueries);
       expect(screen.queryByText('Outline')).not.toBeInTheDocument();
       expect(screen.queryByText('Datasource explorer')).not.toBeInTheDocument();
       expect(screen.queryByTestId('signal-card-A')).not.toBeInTheDocument();
     });
 
-    it('does not render the query cards or header title when the feature toggle is disabled', () => {
+    it('does not render the query cards or header title when the feature toggle is disabled', async () => {
       useBooleanFlagValueMock.mockReturnValue(false);
-      setup(false, true, promQueries);
+      await setup(false, true, promQueries);
       expect(screen.queryByTestId('signal-card-A')).not.toBeInTheDocument();
       expect(screen.queryByText('Outline')).not.toBeInTheDocument();
     });
 
-    it('renders a query card and the "Datasource explorer" title when the toggle is enabled and Prometheus is selected', () => {
+    it('renders a query card and the "Datasource explorer" title when the toggle is enabled and Prometheus is selected', async () => {
       useBooleanFlagValueMock.mockReturnValue(true);
-      setup(false, true, promQueries);
+      await setup(false, true, promQueries);
       expect(screen.getByText('Datasource explorer')).toBeInTheDocument();
       expect(screen.getByTestId('signal-card-A')).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Jump to query A (gdev-prometheus)' })).toBeInTheDocument();
@@ -231,7 +243,7 @@ describe('<ContentOutline />', () => {
 
     it('renders the metrics explorer once a Prometheus card is expanded', async () => {
       useBooleanFlagValueMock.mockReturnValue(true);
-      setup(false, true, promQueries);
+      await setup(false, true, promQueries);
       expect(screen.queryByPlaceholderText('Search metrics')).not.toBeInTheDocument();
 
       await userEvent.click(screen.getByRole('button', { name: 'Expand datasource explorer for query A' }));
@@ -243,7 +255,7 @@ describe('<ContentOutline />', () => {
 
     it('hides the explorer when the outline is collapsed', async () => {
       useBooleanFlagValueMock.mockReturnValue(true);
-      setup(false, true, promQueries);
+      await setup(false, true, promQueries);
       expect(screen.getByTestId('signal-card-A')).toBeInTheDocument();
 
       await userEvent.click(screen.getByRole('button', { name: 'Collapse outline' }));
@@ -255,9 +267,9 @@ describe('<ContentOutline />', () => {
       expect(screen.getByRole('button', { name: 'Expand outline' })).toBeInTheDocument();
     });
 
-    it('does not render the query cards or header title when the toggle is enabled but Prometheus is not selected', () => {
+    it('does not render the query cards or header title when the toggle is enabled but Prometheus is not selected', async () => {
       useBooleanFlagValueMock.mockReturnValue(true);
-      setup(false, false, promQueries);
+      await setup(false, false, promQueries);
       expect(screen.queryByTestId('signal-card-A')).not.toBeInTheDocument();
       expect(screen.queryByText('Datasource explorer')).not.toBeInTheDocument();
       expect(screen.queryByText('Outline')).not.toBeInTheDocument();

--- a/public/app/features/explore/SignalExplorer/SignalExplorer.test.tsx
+++ b/public/app/features/explore/SignalExplorer/SignalExplorer.test.tsx
@@ -1,8 +1,13 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { type DataSourceApi, type DataSourceInstanceSettings, type TimeRange } from '@grafana/data';
-import { type DataSourceSrv, setDataSourceSrv } from '@grafana/runtime';
+import {
+  type DataSourceApi,
+  type DataSourceInstanceSettings,
+  type DataSourcePluginMeta,
+  type TimeRange,
+} from '@grafana/data';
+import { initDataSourceInstanceSettings, setDatasourcePluginMetas } from '@grafana/runtime/internal';
 import { type DataQuery } from '@grafana/schema';
 
 import { type ContentOutlineItemContextProps } from '../ContentOutline/ContentOutlineContext';
@@ -13,17 +18,31 @@ jest.mock('../ContentOutline/ContentOutlineContext', () => ({
   useContentOutlineContext: jest.fn(),
 }));
 
-const makeSettings = (uid: string, type: string, name: string) =>
+const makeMeta = (id: string) =>
   ({
-    uid,
-    type,
-    name,
-    meta: { id: type, info: { logos: { small: `${type}.svg` } } },
-  }) as unknown as DataSourceInstanceSettings;
+    id,
+    name: id,
+    type: 'datasource',
+    info: { logos: { small: `${id}.svg`, large: `${id}.svg` } },
+  }) as unknown as DataSourcePluginMeta;
 
+const makeSettings = (uid: string, type: string, name: string) =>
+  ({ uid, type, name, meta: makeMeta(type) }) as unknown as DataSourceInstanceSettings;
+
+// The component resolves a card's datasource from the instance list and its logo from the
+// datasource plugin metas, so both of the real caches behind those hooks are seeded here. No
+// legacy `DataSourceSrv` is registered: the new APIs' fallback to it stays inert, so a seeding
+// gap surfaces as an unresolved card instead of being papered over by legacy resolution.
 const datasources: Record<string, DataSourceInstanceSettings> = {
-  'prom-uid': makeSettings('prom-uid', 'prometheus', 'gdev-prometheus'),
-  'loki-uid': makeSettings('loki-uid', 'loki', 'gdev-loki'),
+  'gdev-prometheus': makeSettings('prom-uid', 'prometheus', 'gdev-prometheus'),
+  'gdev-loki': makeSettings('loki-uid', 'loki', 'gdev-loki'),
+  'gdev-amp': makeSettings('amp-uid', 'grafana-amazonprometheus-datasource', 'gdev-amp'),
+};
+
+const pluginMetas: Record<string, DataSourcePluginMeta> = {
+  prometheus: makeMeta('prometheus'),
+  loki: makeMeta('loki'),
+  'grafana-amazonprometheus-datasource': makeMeta('grafana-amazonprometheus-datasource'),
 };
 
 const scrollerMock = document.createElement('div');
@@ -43,15 +62,14 @@ const explorer = (queries: DataQuery[], paneDatasource?: DataSourceApi) => (
   />
 );
 
-const setup = (queries: DataQuery[], paneDatasource?: DataSourceApi) => {
-  scrollerMock.scroll = jest.fn();
+const seedDataSources = () => {
+  initDataSourceInstanceSettings(datasources, 'gdev-prometheus');
+  setDatasourcePluginMetas(pluginMetas);
+};
 
-  setDataSourceSrv({
-    getInstanceSettings(ref?: string | { uid?: string }) {
-      const uid = typeof ref === 'string' ? ref : ref?.uid;
-      return uid ? datasources[uid] : undefined;
-    },
-  } as unknown as DataSourceSrv);
+const setup = async (queries: DataQuery[], paneDatasource?: DataSourceApi) => {
+  scrollerMock.scroll = jest.fn();
+  seedDataSources();
 
   // Query rows register themselves as children of the Queries outline item.
   const queryChildren: ContentOutlineItemContextProps[] = queries.map((query) => ({
@@ -81,28 +99,37 @@ const setup = (queries: DataQuery[], paneDatasource?: DataSourceApi) => {
     ],
   });
 
+  const rendered = render(explorer(queries, paneDatasource));
+
+  // Both datasource hooks resolve a few promise turns after the first paint. Settling them here
+  // keeps those state updates inside act() and means the assertions below see resolved cards.
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
   return {
     user: userEvent.setup(),
-    ...render(explorer(queries, paneDatasource)),
+    ...rendered,
   };
 };
 
 describe('<SignalExplorer />', () => {
-  it('renders the header with the injected toggle button', () => {
-    setup([]);
+  it('renders the header with the injected toggle button', async () => {
+    await setup([]);
 
     expect(screen.getByText('Datasource explorer')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Collapse outline' })).toBeInTheDocument();
   });
 
-  it('renders an empty state when there are no queries', () => {
-    setup([]);
+  it('renders an empty state when there are no queries', async () => {
+    await setup([]);
 
     expect(screen.getByText('Add a query to browse its datasource.')).toBeInTheDocument();
   });
 
-  it('renders one card per query, labelled with its own datasource in a Mixed pane', () => {
-    setup([
+  it('renders one card per query, labelled with its own datasource in a Mixed pane', async () => {
+    await setup([
       { refId: 'A', datasource: { uid: 'prom-uid', type: 'prometheus' } },
       { refId: 'B', datasource: { uid: 'loki-uid', type: 'loki' } },
     ]);
@@ -113,15 +140,38 @@ describe('<SignalExplorer />', () => {
     expect(screen.getByRole('button', { name: 'Jump to query B (gdev-loki)' })).toBeInTheDocument();
   });
 
-  it('falls back to the pane datasource for queries without their own ref', () => {
-    setup([{ refId: 'A' }], { uid: 'prom-uid', type: 'prometheus' } as DataSourceApi);
+  it('resolves a query that names its datasource instead of carrying its uid', async () => {
+    await setup([{ refId: 'A', datasource: { uid: 'gdev-loki', type: 'loki' } }]);
+
+    // The name, not the 'loki' type the label falls back to when the ref resolves to nothing.
+    expect(screen.getByRole('button', { name: 'Jump to query A (gdev-loki)' })).toBeInTheDocument();
+  });
+
+  it('labels a card with its datasource type until the datasource list resolves', async () => {
+    seedDataSources();
+    render(explorer([{ refId: 'A', datasource: { uid: 'prom-uid', type: 'prometheus' } }]));
+
+    // The list is async, so the first paint only has the ref's own fields to label the card with.
+    expect(screen.getByRole('button', { name: 'Jump to query A (prometheus)' })).toBeInTheDocument();
+
+    expect(await screen.findByRole('button', { name: 'Jump to query A (gdev-prometheus)' })).toBeInTheDocument();
+  });
+
+  it('takes a card logo from the plugin meta of the datasource type', async () => {
+    await setup([{ refId: 'A', datasource: { uid: 'loki-uid', type: 'loki' } }]);
+
+    expect(screen.getByTestId('signal-card-A').querySelector('img')).toHaveAttribute('src', 'loki.svg');
+  });
+
+  it('falls back to the pane datasource for queries without their own ref', async () => {
+    await setup([{ refId: 'A' }], { uid: 'prom-uid', type: 'prometheus' } as DataSourceApi);
 
     expect(screen.getByRole('button', { name: 'Jump to query A (gdev-prometheus)' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Expand datasource explorer for query A' })).toBeInTheDocument();
   });
 
-  it('only makes Prometheus cards expandable', () => {
-    setup([
+  it('only makes Prometheus cards expandable', async () => {
+    await setup([
       { refId: 'A', datasource: { uid: 'prom-uid', type: 'prometheus' } },
       { refId: 'B', datasource: { uid: 'loki-uid', type: 'loki' } },
     ]);
@@ -130,14 +180,14 @@ describe('<SignalExplorer />', () => {
     expect(screen.queryByRole('button', { name: 'Expand datasource explorer for query B' })).not.toBeInTheDocument();
   });
 
-  it('treats Prometheus flavors as expandable', () => {
-    setup([{ refId: 'A', datasource: { uid: 'amp-uid', type: 'grafana-amazonprometheus-datasource' } }]);
+  it('treats Prometheus flavors as expandable', async () => {
+    await setup([{ refId: 'A', datasource: { uid: 'amp-uid', type: 'grafana-amazonprometheus-datasource' } }]);
 
     expect(screen.getByRole('button', { name: 'Expand datasource explorer for query A' })).toBeInTheDocument();
   });
 
   it('reveals the metrics explorer when a Prometheus card is expanded', async () => {
-    const { user } = setup([{ refId: 'A', datasource: { uid: 'prom-uid', type: 'prometheus' } }]);
+    const { user } = await setup([{ refId: 'A', datasource: { uid: 'prom-uid', type: 'prometheus' } }]);
     expect(screen.queryByPlaceholderText('Search metrics')).not.toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'Expand datasource explorer for query A' }));
@@ -146,7 +196,7 @@ describe('<SignalExplorer />', () => {
   });
 
   it('collapses a card again without affecting the others', async () => {
-    const { user } = setup([
+    const { user } = await setup([
       { refId: 'A', datasource: { uid: 'prom-uid', type: 'prometheus' } },
       { refId: 'B', datasource: { uid: 'prom-uid', type: 'prometheus' } },
     ]);
@@ -163,7 +213,7 @@ describe('<SignalExplorer />', () => {
   });
 
   it('keeps multiple cards expanded independently', async () => {
-    const { user } = setup([
+    const { user } = await setup([
       { refId: 'A', datasource: { uid: 'prom-uid', type: 'prometheus' } },
       { refId: 'B', datasource: { uid: 'prom-uid', type: 'prometheus' } },
     ]);
@@ -175,8 +225,8 @@ describe('<SignalExplorer />', () => {
     expect(screen.getAllByRole('button', { expanded: true })).toHaveLength(2);
   });
 
-  it('relabels a card when its query switches datasource', () => {
-    const { rerender } = setup([{ refId: 'A', datasource: { uid: 'prom-uid', type: 'prometheus' } }]);
+  it('relabels a card when its query switches datasource', async () => {
+    const { rerender } = await setup([{ refId: 'A', datasource: { uid: 'prom-uid', type: 'prometheus' } }]);
     expect(screen.getByRole('button', { name: 'Expand datasource explorer for query A' })).toBeInTheDocument();
 
     rerender(explorer([{ refId: 'A', datasource: { uid: 'loki-uid', type: 'loki' } }]));
@@ -186,7 +236,7 @@ describe('<SignalExplorer />', () => {
   });
 
   it('keeps an expanded card intact while its query is being edited', async () => {
-    const { user, rerender } = setup([promQuery('A')]);
+    const { user, rerender } = await setup([promQuery('A')]);
 
     await user.click(screen.getByRole('button', { name: 'Expand datasource explorer for query A' }));
     await user.type(screen.getByPlaceholderText('Search metrics'), 'node_cpu');
@@ -201,7 +251,7 @@ describe('<SignalExplorer />', () => {
   });
 
   it('scrolls to the query row when a card is clicked', async () => {
-    const { user } = setup([{ refId: 'A', datasource: { uid: 'loki-uid', type: 'loki' } }]);
+    const { user } = await setup([{ refId: 'A', datasource: { uid: 'loki-uid', type: 'loki' } }]);
 
     await user.click(screen.getByRole('button', { name: /^Jump to query A/ }));
 
@@ -209,7 +259,7 @@ describe('<SignalExplorer />', () => {
   });
 
   it('forgets a deleted query, so a new one reusing its refId is not already expanded', async () => {
-    const { user, rerender } = setup([promQuery('A'), promQuery('B')]);
+    const { user, rerender } = await setup([promQuery('A'), promQuery('B')]);
 
     await user.click(screen.getByRole('button', { name: 'Expand datasource explorer for query B' }));
     expect(screen.getByPlaceholderText('Search metrics')).toBeInTheDocument();
@@ -223,7 +273,7 @@ describe('<SignalExplorer />', () => {
   });
 
   it('forgets an expanded card when its query moves to a datasource with no explorer', async () => {
-    const { user, rerender } = setup([promQuery('A')]);
+    const { user, rerender } = await setup([promQuery('A')]);
 
     await user.click(screen.getByRole('button', { name: 'Expand datasource explorer for query A' }));
 
@@ -235,7 +285,7 @@ describe('<SignalExplorer />', () => {
   });
 
   it('keeps the remaining cards expanded when another query is deleted', async () => {
-    const { user, rerender } = setup([promQuery('A'), promQuery('B'), promQuery('C')]);
+    const { user, rerender } = await setup([promQuery('A'), promQuery('B'), promQuery('C')]);
 
     await user.click(screen.getByRole('button', { name: 'Expand datasource explorer for query A' }));
     await user.click(screen.getByRole('button', { name: 'Expand datasource explorer for query C' }));
@@ -248,7 +298,7 @@ describe('<SignalExplorer />', () => {
   it('does nothing when a card has no query row to scroll to', async () => {
     // The outline mock only registers rows for the queries passed to setup, so a card
     // added afterwards has nothing to scroll to.
-    const { user, rerender } = setup([]);
+    const { user, rerender } = await setup([]);
     rerender(explorer([{ refId: 'Z', datasource: { uid: 'loki-uid', type: 'loki' } }]));
 
     await user.click(screen.getByRole('button', { name: /^Jump to query Z/ }));
@@ -257,7 +307,7 @@ describe('<SignalExplorer />', () => {
   });
 
   it('expanding a card does not also jump to its query, since the chevron does not bubble', async () => {
-    const { user } = setup([{ refId: 'A', datasource: { uid: 'prom-uid', type: 'prometheus' } }]);
+    const { user } = await setup([{ refId: 'A', datasource: { uid: 'prom-uid', type: 'prometheus' } }]);
 
     await user.click(screen.getByRole('button', { name: 'Expand datasource explorer for query A' }));
 

--- a/public/app/features/explore/SignalExplorer/SignalExplorer.tsx
+++ b/public/app/features/explore/SignalExplorer/SignalExplorer.tsx
@@ -3,7 +3,8 @@ import { type ReactNode, useEffect, useMemo, useState } from 'react';
 
 import { type DataSourceApi, type GrafanaTheme2, type TimeRange } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { useDatasourcePluginMetas } from '@grafana/runtime/internal';
+import { useDataSourceInstanceList } from '@grafana/runtime/unstable';
 import { type DataQuery } from '@grafana/schema';
 import { ScrollContainer, useStyles2 } from '@grafana/ui';
 
@@ -54,27 +55,52 @@ export function SignalExplorer({ queries, paneDatasource, timeRange, scroller, t
   const { outlineItems } = useContentOutlineContext() ?? { outlineItems: [] };
   const [expandedRefIds, setExpandedRefIds] = useState<Set<string>>(new Set());
 
+  // The whole list once, rather than a lookup per ref: a card's datasource is resolved inside the
+  // memo below, and one hook per query would break the rules of hooks as queries come and go.
+  // `all` because a query can target any datasource, whatever capabilities its plugin reports, and
+  // `mixed` so a Mixed pane's own datasource resolves for a query that carries no ref of its own.
+  const { items: dataSourceItems } = useDataSourceInstanceList({ all: true, mixed: true });
+  // Logos come from the plugin metas keyed by type, not from the resolved instance, so a ref that
+  // matches no instance still shows its plugin's logo alongside the type it names.
+  const { value: pluginMetas } = useDatasourcePluginMetas();
+
+  const logosByType = useMemo(() => {
+    const logos = new Map<string, string | undefined>();
+
+    for (const meta of pluginMetas ?? []) {
+      logos.set(meta.id, meta.info.logos.small);
+      // A datasource instance's type can be the old id of a renamed plugin.
+      for (const aliasId of meta.aliasIDs ?? []) {
+        logos.set(aliasId, meta.info.logos.small);
+      }
+    }
+
+    return logos;
+  }, [pluginMetas]);
+
   const cards: CardDescriptor[] = useMemo(() => {
     const paneRef = paneDatasource?.uid ? { uid: paneDatasource.uid, type: paneDatasource.type } : undefined;
 
     return queries.map((query) => {
       const ref = query.datasource ?? paneRef;
-      const settings = ref ? getDataSourceSrv().getInstanceSettings(ref) : undefined;
-      const type = settings?.type ?? ref?.type;
+      // Matched on name as well as uid: a ref can name its datasource rather than carry its uid,
+      // and the settings lookup this replaced resolved either form.
+      const item = ref?.uid ? dataSourceItems.find((ds) => ds.uid === ref.uid || ds.name === ref.uid) : undefined;
+      const type = item?.type ?? ref?.type;
 
       return {
         refId: query.refId,
-        datasourceName: settings?.name ?? type ?? t('explore.signal-explorer.unknown-datasource', 'Unknown datasource'),
-        datasourceLogo: settings?.meta.info.logos.small,
+        datasourceName: item?.name ?? type ?? t('explore.signal-explorer.unknown-datasource', 'Unknown datasource'),
+        datasourceLogo: type ? logosByType.get(type) : undefined,
         // Prometheus is currently the only datasource with an explorer to open.
         isExpandable: isPrometheusType(type),
-        // The settings uid rather than the ref's: a ref naming a datasource by name resolves to the
+        // The resolved uid rather than the ref's: a ref naming a datasource by name resolves to the
         // uid here, and the uid is what the metric cache keys its entries on.
-        dsUid: settings?.uid ?? ref?.uid,
+        dsUid: item?.uid ?? ref?.uid,
         dsType: type,
       };
     });
-  }, [queries, paneDatasource]);
+  }, [queries, paneDatasource, dataSourceItems, logosByType]);
 
   // A card's expanded state has to go away with the card's ability to expand:
   // - a deleted query, because Explore hands out the lowest unused refId when a query is


### PR DESCRIPTION
## Description

`SignalExplorer` resolved each card's datasource with `getDataSourceSrv().getInstanceSettings()` inside the `useMemo` that maps over the pane's queries. This replaces that synchronous call with the async datasource APIs.

Part of the migration tracked in #127033 (and its parent #125083). This file landed in #129608, after #127033 was first closed, so it wasn't on the original list — it was added when the issue was reopened. Resolves DPRO-302, which unblocks the path-scoped ESLint guard (last remaining item on the Tooling section of #127033).

## Changes

- Identity fields (`name`, `type`, `uid`) come from a single `useDataSourceInstanceList({ all: true, mixed: true })` call, looked up per ref inside the existing memo. `all` because a query can target any datasource whatever capabilities its plugin reports; `mixed` so a Mixed pane's own datasource still resolves for a query that carries no ref of its own.
- `meta.info.logos.small` comes from a single `useDatasourcePluginMetas()` call, indexed by plugin type (including `aliasIDs`, matching what the singular hook does internally). This follows the "use meta APIs where only plugin metadata is needed" guidance in #125083 — the card reads `meta.*` and nothing from `jsonData`/`url`.
- Neither `useDataSourceInstanceSettings` nor `useDatasourcePluginMeta` (singular) is called per card: both take one ref/id, so calling them inside the map would be N hooks for N queries.
- The per-ref lookup matches on **uid or name**, because a ref can name its datasource rather than carry its uid and `getInstanceSettings` resolved either form. `dsUid` still prefers the resolved uid — the metric cache keys its entries on it.
- `SignalExplorer.test.tsx` seeds the real caches behind the new APIs (`initDataSourceInstanceSettings`, `setDatasourcePluginMetas`) instead of stubbing `DataSourceSrv`, and registers no legacy `DataSourceSrv` at all, so a seeding gap surfaces as an unresolved card rather than being papered over by legacy resolution. New cases cover name-based ref resolution, the logo coming from plugin meta, and the labelling across the loading window.
- `ContentOutline.test.tsx` gets the same reseeding: it renders `SignalExplorer`, so it failed on both the synchronous name assertion and an act warning until its datasource seeding moved to the async APIs.

## Risks

Frontend only, one component, behind the Signal Explorer feature toggle.

- **First paint labels a card with its ref's `type`** until the list resolves (one promise turn against an in-memory cache). Deliberate, and pinned by a test. Because the fallback chain is `resolved name → ref type → "Unknown datasource"`, a typed ref never shows "Unknown datasource"; `isExpandable` and `dsUid` come off the ref, so no chevron pop-in and no metrics-list remount. A skeleton would trade a briefly-imprecise label for briefly-no label.
- **Name-based refs** pass the name as `dsUid` for that first paint, so the metric catalog caches one entry under the name before re-keying on the resolved uid. Extra cache entry, same data.
- **Runtime datasources** are deliberately excluded from `getDataSourceInstanceList`, where legacy `getInstanceSettings` resolved them. Such a card would show its type instead of its name; `dsUid` still passes through so the metrics list works. Not reachable through Explore's datasource picker.
- **`$var` datasource refs** are not interpolated by the new API family (documented on `useDataSourceInstanceSettings`). Same limitation as the rest of the migrated code; Explore refs are concrete.
- A ref carrying a `type` but no `uid` no longer resolves to that type's default instance (legacy did this via `findByType`). Explore always sets `uid` on `query.datasource`, and the pane ref is only built when `paneDatasource.uid` exists.

## Demo

No visual change — this is a behaviour-preserving refactor of how the existing cards resolve their datasource. The sidebar renders the same instance names and plugin logos as before, with the first-paint labelling described under Risks.

## Testing Instructions

1. `yarn jest public/app/features/explore/SignalExplorer public/app/features/explore/ContentOutline`
2. In Explore with the Signal Explorer toggle on, open the Datasource explorer sidebar in a Mixed pane holding a Prometheus and a Loki query. Each card shows its own instance name and plugin logo; only Prometheus cards expand.
3. Switch a query's datasource and confirm the card relabels and collapses.
4. Check the console for `FALLBACK_TO_LEGACY_*` warnings — there should be none.

## Reviewer Checklist

- [ ] No `getDataSourceSrv` usage left in the file
- [ ] Each hook is called once, never inside `queries.map`
- [ ] Ref lookup matches uid **and** name
- [ ] `dsUid` still prefers the resolved uid (the metric cache keys on it)
- [ ] `loading` (plugin meta hooks) vs `isLoading` (datasource hooks) used correctly
- [ ] Tests seed the async APIs; no legacy `DataSourceSrv` stub left behind
