### PR TITLE
DataPro (migration): Migrate `explore/hooks/useStateSync`

### DIFF
--- a/public/app/features/explore/hooks/useStateSync/index.test.tsx
+++ b/public/app/features/explore/hooks/useStateSync/index.test.tsx
@@ -5,8 +5,14 @@ import { type ReactNode } from 'react';
 import { TestProvider } from 'test/helpers/TestProvider';
 import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
 
-import { type DataQuery, type DataSourceApi, type UrlQueryMap } from '@grafana/data';
-import { HistoryWrapper, setDataSourceSrv, type DataSourceSrv } from '@grafana/runtime';
+import {
+  type DataQuery,
+  type DataSourceApi,
+  type DataSourceRef,
+  type ScopedVars,
+  type UrlQueryMap,
+} from '@grafana/data';
+import { HistoryWrapper } from '@grafana/runtime';
 import { setLastUsedDatasourceUID } from 'app/core/utils/explore';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
 import { configureStore } from 'app/store/configureStore';
@@ -31,7 +37,21 @@ jest.mock('rxjs', () => ({
     }),
 }));
 
-function defaultDsGetter(datasources: Array<ReturnType<typeof makeDatasourceSetup>>): DataSourceSrv['get'] {
+type DatasourceGetter = (ref?: DataSourceRef | string | null, scopedVars?: ScopedVars) => Promise<DataSourceApi>;
+
+// setup() seeds this per test. The mock factory below is hoisted above the datasources it
+// serves and runs on import, so the delegation has to stay lazy — reading the getter eagerly
+// would hit the temporal dead zone.
+const currentDatasourceGetter: { get: DatasourceGetter } = {
+  get: () => Promise.reject(new Error('datasources have not been seeded')),
+};
+
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstance: (...args: Parameters<DatasourceGetter>) => currentDatasourceGetter.get(...args),
+}));
+
+function defaultDsGetter(datasources: Array<ReturnType<typeof makeDatasourceSetup>>): DatasourceGetter {
   return (datasource) => {
     let ds;
     if (!datasource) {
@@ -54,7 +74,7 @@ function defaultDsGetter(datasources: Array<ReturnType<typeof makeDatasourceSetu
 
 interface SetupParams {
   queryParams?: UrlQueryMap;
-  datasourceGetter?: (datasources: Array<ReturnType<typeof makeDatasourceSetup>>) => DataSourceSrv['get'];
+  datasourceGetter?: (datasources: Array<ReturnType<typeof makeDatasourceSetup>>) => DatasourceGetter;
 }
 function setup({ queryParams = {}, datasourceGetter = defaultDsGetter }: SetupParams) {
   const history = createMemoryHistory({
@@ -69,13 +89,7 @@ function setup({ queryParams = {}, datasourceGetter = defaultDsGetter }: SetupPa
     makeDatasourceSetup({ name: MIXED_DATASOURCE_NAME, uid: MIXED_DATASOURCE_NAME, id: 999 }),
   ];
 
-  setDataSourceSrv({
-    registerRuntimeDataSource: jest.fn(),
-    get: datasourceGetter(datasources),
-    getInstanceSettings: jest.fn(),
-    getList: jest.fn(),
-    reload: jest.fn(),
-  });
+  currentDatasourceGetter.get = datasourceGetter(datasources);
 
   const store = configureStore({
     user: {
@@ -150,7 +164,7 @@ describe('useStateSync', () => {
         }),
         schemaVersion: 1,
       },
-      datasourceGetter: (datasources: Array<ReturnType<typeof makeDatasourceSetup>>): DataSourceSrv['get'] => {
+      datasourceGetter: (datasources: Array<ReturnType<typeof makeDatasourceSetup>>): DatasourceGetter => {
         return (datasource) => {
           let ds: DataSourceApi | undefined;
           if (!datasource) {

--- a/public/app/features/explore/hooks/useStateSync/internal.utils.test.ts
+++ b/public/app/features/explore/hooks/useStateSync/internal.utils.test.ts
@@ -1,0 +1,365 @@
+import {
+  CoreApp,
+  DataSourceApi,
+  type DataSourceInstanceSettings,
+  type DataSourcePluginMeta,
+  type ExploreUrlState,
+} from '@grafana/data';
+import { setDataSourceSrv, setTemplateSrv, type DataSourceSrv, type TemplateSrv } from '@grafana/runtime';
+import { initDataSourceInstanceSettings, setDataSourcePluginImporter } from '@grafana/runtime/internal';
+import { type DataQuery, type DataSourceRef } from '@grafana/schema';
+import { setLastUsedDatasourceUID } from 'app/core/utils/explore';
+import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
+
+import { DEFAULT_RANGE } from '../../state/constants';
+
+import {
+  getDefaultQuery,
+  getPaneDatasource,
+  getQueryFilter,
+  isMixedDatasource,
+  removeQueriesWithInvalidDatasource,
+  urlDiff,
+} from './internal.utils';
+
+function makeSettings(
+  uid: string,
+  name: string,
+  type: string,
+  opts: { isDefault?: boolean } = {}
+): DataSourceInstanceSettings {
+  return {
+    id: 1,
+    uid,
+    name,
+    type,
+    access: 'direct',
+    jsonData: {},
+    readOnly: false,
+    isDefault: opts.isDefault ?? false,
+    meta: {
+      id: type,
+      name: type,
+      type: 'datasource',
+      module: '',
+      baseUrl: '',
+      metrics: true,
+      info: {
+        author: { name: '' },
+        description: '',
+        links: [],
+        logos: { small: '', large: '' },
+        screenshots: [],
+        updated: '',
+        version: '',
+      },
+    } as unknown as DataSourcePluginMeta,
+  } as DataSourceInstanceSettings;
+}
+
+interface TestQuery extends DataQuery {
+  expr?: string;
+}
+
+const DEFAULT_DS_NAME = 'default datasource';
+const dsSettings: Record<string, DataSourceInstanceSettings> = {
+  default: makeSettings('default-uid', DEFAULT_DS_NAME, 'test-db', { isDefault: true }),
+  loki: makeSettings('loki-uid', 'loki', 'logs'),
+  elastic: makeSettings('elastic-uid', 'elastic', 'elasticsearch'),
+  mixed: makeSettings('mixed-uid', MIXED_DATASOURCE_NAME, 'mixed'),
+  withDefaultQuery: makeSettings('with-default-query-uid', 'withDefaultQuery', 'with-default-query'),
+};
+
+// Deriving identity from the settings the loader passes to the constructor — the identity a real
+// plugin instance carries. A `$var` ref that interpolates to a concrete uid must therefore produce
+// an instance whose uid/getRef() is the concrete uid, never the literal "${var}".
+class TestDataSource extends DataSourceApi<TestQuery> {
+  query() {
+    return Promise.resolve({ data: [] });
+  }
+  testDatasource() {
+    return Promise.resolve({ status: 'success', message: '' });
+  }
+}
+
+// Same, but exposes a plugin-supplied default query so getDefaultQuery has something to merge.
+class DefaultQueryDataSource extends TestDataSource {
+  getDefaultQuery(app: CoreApp): Partial<TestQuery> {
+    return { expr: `default for ${app}` };
+  }
+}
+
+// Legacy Explore URLs can carry a query's `datasource` as a bare string — by uid, by name, or as a
+// template variable. The schema type only allows a DataSourceRef, but getQueryFilter and
+// removeQueriesWithInvalidDatasource both handle the string form on purpose, so it needs covering.
+const legacyStringDs = (ref: string) => ref as unknown as DataSourceRef;
+
+const ORG_ID = 1;
+
+// The class is chosen from the plugin meta rather than per seed() call: constructed instances stay
+// cached for the lifetime of the module, so re-seeding a different class for a uid that an earlier
+// test already loaded would have no effect.
+function seed({ defaultName = DEFAULT_DS_NAME } = {}) {
+  initDataSourceInstanceSettings(dsSettings, defaultName);
+  setDataSourcePluginImporter(
+    jest.fn().mockImplementation((meta: DataSourcePluginMeta) =>
+      Promise.resolve({
+        DataSourceClass: meta.id === 'with-default-query' ? DefaultQueryDataSource : TestDataSource,
+        components: {},
+      })
+    )
+  );
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  seed();
+  // Interpolate the datasource variable to a concrete uid, mirroring dashboard interpolation.
+  setTemplateSrv({
+    getVariables: () => [],
+    replace: (target?: string) => (target === '${datasource}' ? 'loki-uid' : (target ?? '')),
+  } as unknown as TemplateSrv);
+  // No legacy srv: the new-API fallback stays inert, so a resolution miss surfaces as a failure
+  // instead of silently delegating to legacy semantics.
+  setDataSourceSrv(undefined as unknown as DataSourceSrv);
+});
+
+afterAll(() => {
+  window.localStorage.clear();
+});
+
+describe('urlDiff', () => {
+  const urlState = (overrides: Partial<ExploreUrlState> = {}): ExploreUrlState => ({
+    datasource: 'loki-uid',
+    queries: [{ refId: 'A' }],
+    range: { from: 'now-1h', to: 'now' },
+    ...overrides,
+  });
+
+  it('reports nothing changed for equal states', () => {
+    expect(urlDiff(urlState(), urlState())).toEqual({
+      datasource: false,
+      queries: false,
+      range: false,
+      panelsState: false,
+    });
+  });
+
+  it('reports each field that changed', () => {
+    expect(urlDiff(urlState(), urlState({ datasource: 'elastic-uid' })).datasource).toBe(true);
+    expect(urlDiff(urlState(), urlState({ queries: [{ refId: 'B' }] })).queries).toBe(true);
+    expect(urlDiff(urlState(), urlState({ range: { from: 'now-6h', to: 'now' } })).range).toBe(true);
+    expect(urlDiff(urlState(), urlState({ panelsState: { trace: { spanId: '1' } } })).panelsState).toBe(true);
+  });
+
+  it('treats a missing range as the default range', () => {
+    expect(urlDiff(urlState({ range: undefined }), urlState({ range: DEFAULT_RANGE })).range).toBe(false);
+  });
+
+  it('reports everything changed when one state is undefined', () => {
+    // A range that is deliberately not DEFAULT_RANGE, which the missing old state stands in for.
+    const current = urlState({ range: { from: 'now-90d', to: 'now-89d' } });
+
+    expect(urlDiff(undefined, current)).toEqual({
+      datasource: true,
+      queries: true,
+      range: true,
+      panelsState: false,
+    });
+  });
+});
+
+describe('getPaneDatasource', () => {
+  it('uses the root datasource when it resolves', async () => {
+    const result = await getPaneDatasource('elastic-uid', [], ORG_ID);
+
+    expect(result?.uid).toBe('elastic-uid');
+  });
+
+  it('resolves the root datasource by name as well as uid', async () => {
+    const result = await getPaneDatasource('elastic', [], ORG_ID);
+
+    expect(result?.uid).toBe('elastic-uid');
+  });
+
+  it('falls through to the queries when the root datasource is unavailable', async () => {
+    const result = await getPaneDatasource('UNKNOWN-UID', [{ refId: 'A', datasource: { uid: 'loki-uid' } }], ORG_ID);
+
+    expect(result?.uid).toBe('loki-uid');
+  });
+
+  it('returns the mixed datasource when the queries span multiple valid datasources', async () => {
+    const result = await getPaneDatasource(
+      null,
+      [
+        { refId: 'A', datasource: { uid: 'loki-uid' } },
+        { refId: 'B', datasource: { uid: 'elastic-uid' } },
+      ],
+      ORG_ID
+    );
+
+    expect(result?.name).toBe(MIXED_DATASOURCE_NAME);
+  });
+
+  it("returns the single valid query datasource, ignoring the ones that don't resolve", async () => {
+    const result = await getPaneDatasource(
+      null,
+      [
+        { refId: 'A', datasource: { uid: 'loki-uid' } },
+        { refId: 'B', datasource: { uid: 'UNKNOWN-UID' } },
+      ],
+      ORG_ID
+    );
+
+    expect(result?.uid).toBe('loki-uid');
+  });
+
+  it('falls back to the last used datasource when nothing else is specified', async () => {
+    setLastUsedDatasourceUID(ORG_ID, 'elastic-uid');
+
+    const result = await getPaneDatasource(null, [], ORG_ID);
+
+    expect(result?.uid).toBe('elastic-uid');
+  });
+
+  it('falls back to the default datasource when the last used one no longer exists', async () => {
+    setLastUsedDatasourceUID(ORG_ID, 'removed-uid');
+
+    const result = await getPaneDatasource(null, [], ORG_ID);
+
+    expect(result?.uid).toBe('default-uid');
+  });
+
+  it('resolves to undefined when nothing resolves and there is no default datasource', async () => {
+    seed({ defaultName: 'no such datasource' });
+
+    const result = await getPaneDatasource(
+      'UNKNOWN-UID',
+      [{ refId: 'A', datasource: legacyStringDs('ALSO-UNKNOWN') }],
+      ORG_ID
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  // The parity gap behind the revert of the first migration attempt: Explore's `panes` URL param
+  // can carry a `$var`, and the pane instance must come out with the concrete identity.
+  describe('template variable refs', () => {
+    it('resolves a $var root datasource to the concrete instance', async () => {
+      const result = await getPaneDatasource('${datasource}', [], ORG_ID);
+
+      expect(result?.uid).toBe('loki-uid');
+      expect(result?.name).toBe('loki');
+      expect(result?.getRef()).toEqual({ type: 'logs', uid: 'loki-uid' });
+    });
+
+    it('resolves a $var arriving inside a ref object', async () => {
+      const result = await getPaneDatasource({ uid: '${datasource}', type: '' }, [], ORG_ID);
+
+      expect(result?.uid).toBe('loki-uid');
+      expect(result?.getRef()).toEqual({ type: 'logs', uid: 'loki-uid' });
+    });
+
+    it('resolves a $var carried on a query datasource', async () => {
+      const result = await getPaneDatasource(
+        null,
+        [{ refId: 'A', datasource: legacyStringDs('${datasource}') }],
+        ORG_ID
+      );
+
+      expect(result?.uid).toBe('loki-uid');
+      expect(result?.getRef()).toEqual({ type: 'logs', uid: 'loki-uid' });
+    });
+
+    it('falls back to the default datasource when the $var does not interpolate', async () => {
+      const result = await getPaneDatasource('${unknown}', [], ORG_ID);
+
+      expect(result?.uid).toBe('default-uid');
+    });
+  });
+});
+
+describe('getDefaultQuery', () => {
+  it('builds a query with refId A and the datasource ref', async () => {
+    const ds = await getPaneDatasource('loki-uid', [], ORG_ID);
+
+    expect(getDefaultQuery(ds!)).toEqual({ refId: 'A', datasource: { type: 'logs', uid: 'loki-uid' } });
+  });
+
+  it("merges the datasource's own default query for Explore", async () => {
+    const ds = await getPaneDatasource('with-default-query-uid', [], ORG_ID);
+
+    expect(getDefaultQuery(ds!)).toEqual({
+      refId: 'A',
+      datasource: { type: 'with-default-query', uid: 'with-default-query-uid' },
+      expr: `default for ${CoreApp.Explore}`,
+    });
+  });
+});
+
+describe('isMixedDatasource', () => {
+  it('is true only for the mixed datasource', async () => {
+    const mixed = await getPaneDatasource('mixed-uid', [], ORG_ID);
+    const loki = await getPaneDatasource('loki-uid', [], ORG_ID);
+
+    expect(isMixedDatasource(mixed!)).toBe(true);
+    expect(isMixedDatasource(loki!)).toBe(false);
+  });
+});
+
+describe('getQueryFilter', () => {
+  it('keeps only queries that name a datasource when the root is mixed', async () => {
+    const mixed = await getPaneDatasource('mixed-uid', [], ORG_ID);
+    const queries: DataQuery[] = [{ refId: 'A' }, { refId: 'B', datasource: { uid: 'loki-uid' } }];
+
+    expect(queries.filter(getQueryFilter(mixed))).toEqual([queries[1]]);
+  });
+
+  it('keeps queries matching the root datasource by ref, uid or name, and those with no datasource', async () => {
+    const loki = await getPaneDatasource('loki-uid', [], ORG_ID);
+    const queries: DataQuery[] = [
+      { refId: 'A' },
+      { refId: 'B', datasource: { uid: 'loki-uid' } },
+      { refId: 'C', datasource: legacyStringDs('loki-uid') },
+      { refId: 'D', datasource: legacyStringDs('loki') },
+      { refId: 'E', datasource: { uid: 'elastic-uid' } },
+      { refId: 'F', datasource: legacyStringDs('elastic-uid') },
+    ];
+
+    expect(queries.filter(getQueryFilter(loki)).map((q) => q.refId)).toEqual(['A', 'B', 'C', 'D']);
+  });
+
+  it('keeps only queries with no datasource when there is no root datasource', () => {
+    const queries: DataQuery[] = [{ refId: 'A' }, { refId: 'B', datasource: { uid: 'loki-uid' } }];
+
+    expect(queries.filter(getQueryFilter(undefined)).map((q) => q.refId)).toEqual(['A']);
+  });
+});
+
+describe('removeQueriesWithInvalidDatasource', () => {
+  it('drops the queries whose datasource does not resolve', async () => {
+    const queries: DataQuery[] = [
+      { refId: 'A', datasource: { uid: 'loki-uid' } },
+      { refId: 'B', datasource: { uid: 'UNKNOWN-UID' } },
+      { refId: 'C', datasource: legacyStringDs('elastic-uid') },
+    ];
+
+    const result = await removeQueriesWithInvalidDatasource(queries);
+
+    expect(result.map((q) => q.refId)).toEqual(['A', 'C']);
+  });
+
+  it('keeps a query whose datasource is a template variable', async () => {
+    const queries: DataQuery[] = [{ refId: 'A', datasource: legacyStringDs('${datasource}') }];
+
+    const result = await removeQueriesWithInvalidDatasource(queries);
+
+    expect(result.map((q) => q.refId)).toEqual(['A']);
+  });
+
+  it('keeps queries with no datasource, which inherit the pane one', async () => {
+    const result = await removeQueriesWithInvalidDatasource([{ refId: 'A' }]);
+
+    expect(result.map((q) => q.refId)).toEqual(['A']);
+  });
+});

--- a/public/app/features/explore/hooks/useStateSync/internal.utils.ts
+++ b/public/app/features/explore/hooks/useStateSync/internal.utils.ts
@@ -1,9 +1,9 @@
 import { isEqual } from 'lodash';
 
 import { CoreApp, type DataSourceApi, type ExploreUrlState, isTruthy } from '@grafana/data';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { type DataQuery, type DataSourceRef } from '@grafana/schema';
 import { getLastUsedDatasourceUID } from 'app/core/utils/explore';
-import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
 
 import { DEFAULT_RANGE } from '../../state/constants';
@@ -59,7 +59,7 @@ export async function getPaneDatasource(
   // If there's a root datasource, use it unless it's unavailable
   if (rootDatasource) {
     try {
-      return await getDatasourceSrv().get(rootDatasource);
+      return await getDataSourceInstance(rootDatasource);
     } catch (_) {}
   }
 
@@ -75,28 +75,27 @@ export async function getPaneDatasource(
 
   try {
     if (queriesDatasources.length >= 1) {
-      const datasources = (await Promise.allSettled(queriesDatasources.map((ds) => getDatasourceSrv().get(ds)))).filter(
+      const datasources = (await Promise.allSettled(queriesDatasources.map((ds) => getDataSourceInstance(ds)))).filter(
         isFulfilled
       );
 
       // if queries have multiple (valid) datasources, we return the mixed datasource
       if (datasources.length > 1) {
-        return await getDatasourceSrv().get(MIXED_DATASOURCE_NAME);
+        return await getDataSourceInstance(MIXED_DATASOURCE_NAME);
       }
 
       // otherwise we return the first datasource.
       if (datasources.length === 1) {
-        return await getDatasourceSrv().get(queriesDatasources[0]);
+        return await getDataSourceInstance(queriesDatasources[0]);
       }
     }
   } catch (_) {}
 
   // If none of the queries specify a valid datasource, we use the last used one
   return (
-    getDatasourceSrv()
-      .get(getLastUsedDatasourceUID(orgId))
+    getDataSourceInstance(getLastUsedDatasourceUID(orgId))
       // Or the default one
-      .catch(() => getDatasourceSrv().get())
+      .catch(() => getDataSourceInstance())
       .catch(() => undefined)
   );
 }
@@ -133,12 +132,10 @@ export function getQueryFilter(datasource?: DataSourceApi) {
 export async function removeQueriesWithInvalidDatasource(queries: DataQuery[]) {
   const results = await Promise.allSettled(
     queries.map((query) => {
-      return getDatasourceSrv()
-        .get(query.datasource)
-        .then((ds) => ({
-          query,
-          ds,
-        }));
+      return getDataSourceInstance(query.datasource).then((ds) => ({
+        query,
+        ds,
+      }));
     })
   );
 

--- a/public/app/features/explore/hooks/useStateSync/synchronizer/init.ts
+++ b/public/app/features/explore/hooks/useStateSync/synchronizer/init.ts
@@ -3,12 +3,12 @@ import { type MutableRefObject } from 'react';
 
 import { EventBusSrv } from '@grafana/data';
 import { type LocationService } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { type DataQuery } from '@grafana/schema';
 import { initializeExplore } from 'app/features/explore/state/explorePane';
 import { clearPanes, syncTimesAction } from 'app/features/explore/state/main';
 import { fromURLRange } from 'app/features/explore/state/utils';
 import { withUniqueRefIds } from 'app/features/explore/utils/queries';
-import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 import { type ThunkDispatch } from 'app/types/store';
 
 import { getUrlStateFromPaneState } from '../external.utils';
@@ -55,10 +55,10 @@ export function initializeFromURL(
                       ? identity<DataQuery>
                       : (query) => ({ ...query, datasource: paneDatasource.getRef() })
                   )
-              : getDatasourceSrv()
-                  // otherwise we get a default query from the pane datasource or from the default datasource if the pane datasource is mixed
-                  .get(isMixedDatasource(paneDatasource) ? undefined : paneDatasource.getRef())
-                  .then((ds) => [getDefaultQuery(ds)])
+              : // otherwise we get a default query from the pane datasource or from the default datasource if the pane datasource is mixed
+                getDataSourceInstance(isMixedDatasource(paneDatasource) ? undefined : paneDatasource.getRef()).then(
+                  (ds) => [getDefaultQuery(ds)]
+                )
             : []
         ).then(async (queries) => {
           // we remove queries that have an invalid datasources
@@ -67,7 +67,7 @@ export function initializeFromURL(
           if (!validQueries.length && paneDatasource) {
             // and in case there's no query left we add a default one.
             validQueries = [
-              getDefaultQuery(isMixedDatasource(paneDatasource) ? await getDatasourceSrv().get() : paneDatasource),
+              getDefaultQuery(isMixedDatasource(paneDatasource) ? await getDataSourceInstance() : paneDatasource),
             ];
           }
 


### PR DESCRIPTION
## Description

Part of the `getDataSourceSrv` migration (#125083). Reopened scope from #127033: that pass only
covered `getDataSourceSrv()` from `@grafana/runtime`, but the app-internal `getDatasourceSrv()`
from `app/features/plugins/datasource_srv` returns the concrete `DatasourceSrv` that implements
the same deprecated, sync bootData-backed interface, so it is in scope too.

This moves the last two `useStateSync` call sites onto `getDataSourceInstance` from
`@grafana/runtime/unstable`. All 8 calls were already `async` or inside a promise chain, so each
is a drop-in swap. No behaviour change intended.

Fixes DPRO-298.

## Changes

- `explore/hooks/useStateSync/internal.utils.ts` — 6 calls in `getPaneDatasource` and
  `removeQueriesWithInvalidDatasource`. The `.catch(() => getDataSourceInstance())` default
  fallback keeps working: no-arg resolves the default data source, same as the legacy accessor.
- `explore/hooks/useStateSync/synchronizer/init.ts` — 2 calls for default-query resolution.
- Both `getDatasourceSrv` imports removed.
- `index.test.tsx` — `setDataSourceSrv` seeding replaced. It no longer feeds the migrated code, and
  letting the new API miss its cache would fall back to legacy and log
  `FALLBACK_TO_LEGACY_INSTANCE_WARNING` (a jest-fail-on-console failure). The datasources are built
  per test inside `setup()`, so the test now holds one getter ref that `setup()` seeds and a single
  `jest.mock('@grafana/runtime/unstable')` factory delegates to lazily — the factory is hoisted
  above the datasources it serves and runs on import, so an eager read would hit the temporal dead
  zone. One ref-keyed mock also covers `loadAndInitDatasource`, which this test reaches
  transitively through `initializeExplore` (migrated in #130173). Each test's `datasourceGetter`
  override is unchanged, and no `mockImplementationOnce` per call site is needed.

- New `internal.utils.test.ts` — `internal.utils.ts` had no direct unit test. 25 cases across
  `urlDiff`, `getPaneDatasource`, `getDefaultQuery`, `isMixedDatasource`, `getQueryFilter` and
  `removeQueriesWithInvalidDatasource`. It seeds the *real* new-API caches
  (`initDataSourceInstanceSettings` + `setDataSourcePluginImporter`) and sets **no** legacy srv, so
  the fallback is inert and any resolution miss fails instead of silently reasserting legacy
  semantics. Includes the `$var` cases below.

## Risks

**Template-variable refs.** `getPaneDatasource` resolves refs from the Explore URL `panes` param,
which can carry a `$var`. This is the parity gap that caused the #127578 revert (#127870), fixed
upstream by #128035. Now covered by `internal.utils.test.ts` against the real (unmocked) new API,
with a `templateSrv` that interpolates `${datasource}` → `loki-uid`:

| Ref from the URL | Result |
| --- | --- |
| `'${datasource}'` (string) | concrete instance — `uid: 'loki-uid'`, `name: 'loki'`, `getRef()` → `{ type: 'logs', uid: 'loki-uid' }` |
| `{ uid: '${datasource}', type: '' }` (ref object) | same concrete instance |
| `$var` on a query datasource, no root datasource | same concrete instance |
| `'${unknown}'` (does not interpolate) | falls through to the default data source |

No case leaks the literal `${...}` into the instance identity. Verified these assertions have teeth
by temporarily reverting the #128035 `rawRef` re-resolution: three of them fail with
`uid: "${datasource}"`, the exact symptom behind #127870.

**Branch is rebased on #130173.** `initializeExplore` reaches `loadAndInitDatasource`
(`explore/state/utils.ts`), which that PR moved onto the async API. This branch needs it: with
`loadAndInitDatasource` still on the legacy accessor, dropping `setDataSourceSrv` from the test
fails 19 specs. Rebased, the single `unstable` mock covers both paths and the legacy seeding is
gone entirely.

**The 6 `explore/spec/` suites still resolve these call sites through the legacy fallback.**
`spec/helper/setup.tsx` seeds only `setDataSourceSrv`, so the new API misses its cache and falls
back. It is silent — the loggers registry is only initialised in `app.ts`, so jest-fail-on-console
never sees the warning — and it predates this PR, since the gap is at the seeding level and applies
equally to #130173's `loadAndInitDatasource` on main today. Not fixed here because `setup.tsx` is
shared surface: tracked as DPRO-306, which covers all 27 test files and 2 helpers with one shared
seeding util. This PR does not rely on those suites for new-path confidence —
`internal.utils.test.ts` covers it directly with the fallback inert.

## Demo

No user-visible change — a same-behaviour swap of the data source accessor. Nothing to show.

## Testing Instructions

```bash
yarn jest --no-watch public/app/features/explore/hooks/useStateSync
yarn jest --no-watch public/app/features/explore/hooks/useExplorePageTitle.test.tsx
# whole feature, since spec/ reaches these files through ExplorePage
yarn jest --no-watch public/app/features/explore
```

Then in the app: open Explore, confirm a pane initialises from a URL with a root `datasource`,
with per-query datasources (mixed), with an unknown datasource (falls back to last-used, then
default), and split view with two panes.

## Reviewer Checklist

- [ ] All 8 call sites swapped, both `getDatasourceSrv` imports gone.
- [ ] The `unstable` mock is seeded once per test and covers every reachable call site, so no
      `FALLBACK_TO_LEGACY_INSTANCE_WARNING` is logged.
- [ ] `$var` spot-check above is convincing for the `panes` param.
- [ ] Needs #130173 in `main` — do not merge before it (already rebased on it).
