### PR TITLE
Chore: Unblock main (gauge e2e count)

### DIFF
--- a/e2e-playwright/panels-suite/gauge.spec.ts
+++ b/e2e-playwright/panels-suite/gauge.spec.ts
@@ -10,7 +10,7 @@ const NEW_GAUGES_DASHBOARD_UID = 'panel-tests-gauge-new';
 const OLD_TO_NEW_GAUGES_DASHBOARD_UID = 'panel-tests-old-gauge-to-new';
 
 const OLD_GAUGES_DASHBOARD_GAUGE_COUNT = 16;
-const NEW_GAUGE_DASHBOARD_GAUGE_COUNT = 37;
+const NEW_GAUGE_DASHBOARD_GAUGE_COUNT = 39;
 
 test.describe(
   'Gauge Panel',


### PR DESCRIPTION
`gauge.spec.ts` expects the wrong gauge count

#130154 added an "Overflow with neutral" row with two panels to `devenv/dev-dashboards/panel-gauge/gauge_tests_new.json` (30 → 32 elements) without updating the count the e2e spec asserts. Both new panels use `csv_metric_values` with a single value, so they render one gauge container each: 37 + 2 = 39.

Observed in https://github.com/grafana/grafana/actions/runs/31029035406/job/92386615281 — three attempts, each settling at 39 and holding for seven consecutive polls:

```
Expected: 37
Received: 39
  6 × locator resolved to 0 elements
  7 × locator resolved to 39 elements
```

This also fixes the `a11y` test in the same file, which was reported flaky. It asserts the same constant, and `toHaveCount` passes on any transient match — so 37 could pass while the count climbed to 39. Asserting the terminal value removes that race.

## Note

The hardcoded gauge count means any gdev gauge dashboard edit breaks that spec. Deriving it from the dashboard would be more robust, but that is a larger change than this unblock warrants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)