### PR TITLE
[release-13.0.6] BarChart: Fix tooltip with circular dataframe field value

### DIFF
--- a/packages/grafana-ui/src/components/VizTooltip/utils.test.ts
+++ b/packages/grafana-ui/src/components/VizTooltip/utils.test.ts
@@ -463,5 +463,93 @@ describe('utils', () => {
       expect(result.text).toBe('[[1,2],[3,4]]');
       expect(result.numeric).toBeNaN();
     });
+
+    it('falls back and warns instead of throwing on an unserializable value', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const value: Record<string, unknown> = { spanID: '123' };
+      value.self = value;
+
+      const result = getTooltipDisplayValue(value, mockField);
+      expect(result.text).toBe('[object Object]');
+      expect(result.numeric).toBeNaN();
+      expect(warn).toHaveBeenCalledWith('Cannot render tooltip value', expect.objectContaining({ value }));
+
+      warn.mockRestore();
+    });
+  });
+
+  // repro for hovering a panel whose data carries sub-frames (Tempo traces with tableType: traces),
+  // where the frames are circular and used to crash the whole panel on JSON.stringify
+  describe('getFieldDisplayItems with frame-valued fields', () => {
+    // mirrors what applyFieldOverrides() produces: each field gets a __dataContext back-reference
+    // to the frame that owns it, so the frame cannot be serialized
+    const makeCircularFrame = (): DataFrame => {
+      const frame: DataFrame = {
+        name: 'spans',
+        length: 1,
+        fields: [{ name: 'spanID', type: FieldType.string, values: ['abc'], config: {} }],
+      };
+
+      frame.fields[0].state = {
+        scopedVars: {
+          __dataContext: { value: { data: [frame], frame, frameIndex: 0, field: frame.fields[0] } },
+        },
+      };
+
+      return frame;
+    };
+
+    // Tempo names this field "nested"; nestedFrames values are DataFrame[], frame values a single frame
+    const makeFrameValuedField = (type: FieldType.frame | FieldType.nestedFrames): Field => ({
+      name: 'nested',
+      type,
+      values: [type === FieldType.nestedFrames ? [makeCircularFrame()] : makeCircularFrame()],
+      config: {},
+    });
+
+    const xField: Field = {
+      name: 'traceService',
+      type: FieldType.string,
+      values: ['frontend'],
+      config: {},
+      display: (value: unknown) => ({ text: String(value), numeric: NaN }),
+    };
+
+    const durationField: Field = {
+      name: 'duration',
+      type: FieldType.number,
+      values: [42],
+      config: {},
+      display: (value: unknown) => ({ text: String(value), numeric: Number(value) }),
+    };
+
+    it.each([FieldType.nestedFrames, FieldType.frame] as const)('omits %s fields from series rows', (type) => {
+      const rows = getFieldDisplayItems(
+        [xField, durationField, makeFrameValuedField(type)],
+        xField,
+        [0, 0, 0],
+        null,
+        TooltipDisplayMode.Multi,
+        SortOrder.None
+      );
+
+      expect(rows.map((row) => row.label)).toEqual(['duration']);
+    });
+
+    it.each([FieldType.nestedFrames, FieldType.frame] as const)('omits %s fields from extraFields', (type) => {
+      const rows = getFieldDisplayItems(
+        [xField, durationField],
+        xField,
+        [0, 0],
+        null,
+        TooltipDisplayMode.Multi,
+        SortOrder.None,
+        undefined,
+        false,
+        [makeFrameValuedField(type)]
+      );
+
+      expect(rows.map((row) => row.label)).toEqual(['duration']);
+    });
   });
 });

--- a/packages/grafana-ui/src/components/VizTooltip/utils.test.ts
+++ b/packages/grafana-ui/src/components/VizTooltip/utils.test.ts
@@ -524,7 +524,7 @@ describe('utils', () => {
     };
 
     it.each([FieldType.nestedFrames, FieldType.frame] as const)('omits %s fields from series rows', (type) => {
-      const rows = getFieldDisplayItems(
+      const rows = getContentItems(
         [xField, durationField, makeFrameValuedField(type)],
         xField,
         [0, 0, 0],
@@ -537,7 +537,7 @@ describe('utils', () => {
     });
 
     it.each([FieldType.nestedFrames, FieldType.frame] as const)('omits %s fields from extraFields', (type) => {
-      const rows = getFieldDisplayItems(
+      const rows = getContentItems(
         [xField, durationField],
         xField,
         [0, 0],

--- a/packages/grafana-ui/src/components/VizTooltip/utils.ts
+++ b/packages/grafana-ui/src/components/VizTooltip/utils.ts
@@ -80,6 +80,24 @@ const numberCmp = (a: VizTooltipItem, b: VizTooltipItem) => a.numeric! - b.numer
 const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
 const stringCmp = (a: VizTooltipItem, b: VizTooltipItem) => collator.compare(`${a.value}`, `${b.value}`);
 
+/**
+ * Fields holding DataFrames (Tempo's nested spans, sparkline columns, expandable sub-tables) have
+ * no meaningful one-line representation, and `applyFieldOverrides` gives every frame a circular
+ * `__dataContext` back-reference to the field that owns it, so they cannot be serialized either.
+ */
+const isFrameValuedField = (field: Field) => field.type === FieldType.frame || field.type === FieldType.nestedFrames;
+
+// the catch only exists so an unserializable datasource value costs one row, not the whole panel
+const stringifyValue = (value: unknown): string => {
+  try {
+    return JSON.stringify(value);
+  } catch (error) {
+    // This path shouldn't be hittable
+    console.warn('Cannot render tooltip value', { error, value });
+    return String(value);
+  }
+};
+
 export const getTooltipDisplayValue = (
   value: unknown,
   field: Field
@@ -93,11 +111,11 @@ export const getTooltipDisplayValue = (
       return { text: '', numeric: NaN };
     }
 
-    return { text: JSON.stringify(value), numeric: NaN };
+    return { text: stringifyValue(value), numeric: NaN };
   }
 
   if (value && typeof value === 'object') {
-    return { text: JSON.stringify(value), numeric: NaN };
+    return { text: stringifyValue(value), numeric: NaN };
   }
 
   const display = field.display!(value); // super expensive :(
@@ -125,6 +143,7 @@ export const getContentItems = (
     if (
       field === xField ||
       field.type === FieldType.time ||
+      isFrameValuedField(field) ||
       !fieldFilter(field) ||
       field.config.custom?.hideFrom?.tooltip
     ) {
@@ -177,7 +196,7 @@ export const getContentItems = (
   }
 
   _restFields?.forEach((field) => {
-    if (!field.config.custom?.hideFrom?.tooltip) {
+    if (!field.config.custom?.hideFrom?.tooltip && !isFrameValuedField(field)) {
       const { colorIndicator, colorPlacement } = getIndicatorAndPlacement(field);
       const rawValue = field.values[dataIdxs[0]!];
       const display = getTooltipDisplayValue(rawValue, field);


### PR DESCRIPTION
Backport 64e18b7c978644cf98e447addb29add51c37386d from #130092

---

**What is this feature?**

Fixing barchart crash with datasource nested table frames ("traces" table format) 

**Why do we need this feature?**

To keep the tooltip rendering and the panel from crashing

Fixes #

**Special notes for your reviewer:**
Alternate approach of https://github.com/grafana/grafana/pull/130088

<img width="666" height="489" alt="image" src="https://github.com/user-attachments/assets/91af2d71-9001-4736-9da9-49d8d0d41efd" />

Introduced by https://github.com/grafana/grafana/pull/116631

[reproduction-2026-08-04 14_27_00.json.txt](https://github.com/user-attachments/files/30719038/debug-TraceQL.nested.field.repro-2026-08-04.14_27_00.json.txt)

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
