### PR TITLE
Dashboards: Deprecate scripted dashboards and disable them by default

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -299,6 +299,12 @@ export interface FeatureToggles {
   */
   dashboardNewLayouts?: boolean;
   /**
+  * Disables legacy scripted dashboards, which are deprecated and will be removed in Grafana 14. Set to false to temporarily restore them.
+  * @deprecated
+  * @default true
+  */
+  disableScriptedDashboards?: boolean;
+  /**
   * Enables undo/redo in dynamic dashboards
   * @default false
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -644,6 +644,14 @@ var (
 			Expression:  "true",
 		},
 		{
+			Name:        "disableScriptedDashboards",
+			Description: "Disables legacy scripted dashboards, which are deprecated and will be removed in Grafana 14. Set to false to temporarily restore them.",
+			Stage:       FeatureStageDeprecated,
+			Generate:    Generate{LegacyFrontend: true},
+			Owner:       grafanaDashboardsSquad,
+			Expression:  "true", // enabled by default: scripted dashboards are disabled
+		},
+		{
 			Name:        "dashboard.notebooks",
 			Description: "Enable notebooks, a resource in the dashboard API group for mixing text cells, code cells, and visualization panels",
 			Stage:       FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -72,6 +72,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2023-10-30,alertmanagerRemotePrimary,experimental,@grafana/alerting-squad,false,false,false
 2023-10-31,annotationPermissionUpdate,GA,@grafana/identity-access-team,false,false,false
 2024-10-23,dashboardNewLayouts,GA,@grafana/dashboards-squad,false,false,true
+2026-08-05,disableScriptedDashboards,deprecated,@grafana/dashboards-squad,false,false,true
 2026-07-08,dashboard.notebooks,experimental,@grafana/sharing-squad,false,false,false
 2025-08-29,dashboardUndoRedo,experimental,@grafana/dashboards-squad,false,false,true
 2025-11-21,perPanelNonApplicableDrilldowns,experimental,@grafana/dashboards-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2212,6 +2212,20 @@
     },
     {
       "metadata": {
+        "name": "disableScriptedDashboards",
+        "resourceVersion": "1785944490040",
+        "creationTimestamp": "2026-08-05T15:41:30Z"
+      },
+      "spec": {
+        "description": "Disables legacy scripted dashboards, which are deprecated and will be removed in Grafana 14. Set to false to temporarily restore them.",
+        "stage": "deprecated",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true,
+        "expression": "true"
+      }
+    },
+    {
+      "metadata": {
         "name": "drilldownRecommendations",
         "resourceVersion": "1779440584464",
         "creationTimestamp": "2025-12-17T12:52:59Z",

--- a/public/app/features/dashboard-scene/components/ScriptedDashboardDeprecationBanner.tsx
+++ b/public/app/features/dashboard-scene/components/ScriptedDashboardDeprecationBanner.tsx
@@ -5,8 +5,6 @@ import { Alert, Box, TextLink } from '@grafana/ui';
 import { SCRIPTED_DASHBOARDS_DEPRECATION_URL } from 'app/features/dashboard/services/DashboardLoaderSrv';
 
 interface ScriptedDashboardDeprecationBannerProps {
-  // Whether the current dashboard is a scripted dashboard. Derived from the route type rather than
-  // dashboard meta, because `fromScript` is dropped by the v2 response transformer.
   isScripted: boolean;
 }
 

--- a/public/app/features/dashboard-scene/components/ScriptedDashboardDeprecationBanner.tsx
+++ b/public/app/features/dashboard-scene/components/ScriptedDashboardDeprecationBanner.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+
+import { Trans, t } from '@grafana/i18n';
+import { Alert, Box, TextLink } from '@grafana/ui';
+import { SCRIPTED_DASHBOARDS_DEPRECATION_URL } from 'app/features/dashboard/services/DashboardLoaderSrv';
+
+interface ScriptedDashboardDeprecationBannerProps {
+  // Whether the current dashboard is a scripted dashboard. Derived from the route type rather than
+  // dashboard meta, because `fromScript` is dropped by the v2 response transformer.
+  isScripted: boolean;
+}
+
+export function ScriptedDashboardDeprecationBanner({ isScripted }: ScriptedDashboardDeprecationBannerProps) {
+  const [dismissed, setDismissed] = useState(false);
+
+  if (!isScripted || dismissed) {
+    return null;
+  }
+
+  return (
+    <Box paddingX={2} paddingTop={2}>
+      <Alert
+        severity="warning"
+        title={t('dashboard-scene.scripted-dashboard-deprecation-banner.title', 'Scripted dashboards are deprecated')}
+        style={{ flex: 0 }}
+        onRemove={() => setDismissed(true)}
+      >
+        <Trans i18nKey="dashboard-scene.scripted-dashboard-deprecation-banner.body">
+          This feature will be removed in Grafana 14.{' '}
+          <TextLink href={SCRIPTED_DASHBOARDS_DEPRECATION_URL} external>
+            Read the deprecation notice
+          </TextLink>
+          .
+        </Trans>
+      </Alert>
+    </Box>
+  );
+}

--- a/public/app/features/dashboard-scene/components/ScriptedDashboardsDisabledPage.tsx
+++ b/public/app/features/dashboard-scene/components/ScriptedDashboardsDisabledPage.tsx
@@ -9,7 +9,7 @@ export function ScriptedDashboardsDisabledPage() {
 
   return (
     <Page navId="dashboards/browse" layout={PageLayoutType.Canvas} pageNav={{ text: title }}>
-      <Box paddingY={4} display="flex" direction="column" alignItems="center">
+      <Box display="flex" direction="column" alignItems="center">
         <Alert severity="info" title={title}>
           <Trans i18nKey="dashboard-scene.scripted-dashboards-disabled.body">
             Scripted dashboards are deprecated and will be removed in Grafana 14.{' '}

--- a/public/app/features/dashboard-scene/components/ScriptedDashboardsDisabledPage.tsx
+++ b/public/app/features/dashboard-scene/components/ScriptedDashboardsDisabledPage.tsx
@@ -1,0 +1,26 @@
+import { PageLayoutType } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { Alert, Box, TextLink } from '@grafana/ui';
+import { Page } from 'app/core/components/Page/Page';
+import { SCRIPTED_DASHBOARDS_DEPRECATION_URL } from 'app/features/dashboard/services/DashboardLoaderSrv';
+
+export function ScriptedDashboardsDisabledPage() {
+  const title = t('dashboard-scene.scripted-dashboards-disabled.title', 'Scripted dashboards are disabled');
+
+  return (
+    <Page navId="dashboards/browse" layout={PageLayoutType.Canvas} pageNav={{ text: title }}>
+      <Box paddingY={4} display="flex" direction="column" alignItems="center">
+        <Alert severity="info" title={title}>
+          <Trans i18nKey="dashboard-scene.scripted-dashboards-disabled.body">
+            Scripted dashboards are deprecated and will be removed in Grafana 14.{' '}
+            <TextLink href={SCRIPTED_DASHBOARDS_DEPRECATION_URL} external>
+              Read the deprecation notice
+            </TextLink>
+            . To temporarily restore them, set the <code>disableScriptedDashboards</code> feature toggle to{' '}
+            <code>false</code>.
+          </Trans>
+        </Alert>
+      </Box>
+    </Page>
+  );
+}

--- a/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
@@ -20,6 +20,7 @@ import {
 } from 'app/features/dashboard/containers/types';
 import { TemplateDashboardModal } from 'app/features/dashboard/dashgrid/DashboardLibrary/TemplateDashboardModal';
 import { useTemplateDashboardsAvailability } from 'app/features/dashboard/dashgrid/DashboardLibrary/hooks/useTemplateDashboardsAvailability';
+import { SCRIPTED_DASHBOARDS_DISABLED_MESSAGE_ID } from 'app/features/dashboard/services/DashboardLoaderSrv';
 import { getDashboardSceneProfiler } from 'app/features/dashboard/services/DashboardProfiler';
 import { DashboardPreviewBanner } from 'app/features/provisioning/components/Dashboards/DashboardPreviewBanner';
 import { OrphanedDashboardBanner } from 'app/features/provisioning/components/Dashboards/OrphanedDashboardBanner';
@@ -29,6 +30,8 @@ import { DashboardConversionWarningBanner } from '../components/DashboardConvers
 import { DashboardTemplateEditBanner } from '../components/DashboardTemplateEditBanner';
 import { DashboardTemplateSavedBanner } from '../components/DashboardTemplateSavedBanner';
 import { DashboardTemplateUseBanner } from '../components/DashboardTemplateUseBanner';
+import { ScriptedDashboardDeprecationBanner } from '../components/ScriptedDashboardDeprecationBanner';
+import { ScriptedDashboardsDisabledPage } from '../components/ScriptedDashboardsDisabledPage';
 import { SuggestedDashboardsBanner } from '../components/SuggestedDashboardsBanner';
 import { DashboardPrompt } from '../saving/DashboardPrompt';
 import { preserveDashboardSceneStateInLocalStorage } from '../utils/dashboardSessionState';
@@ -121,6 +124,10 @@ export function DashboardScenePage({ route, queryParams, location }: Props) {
   }, [route, slug, type, uid]);
 
   if (!dashboard) {
+    if (loadError?.messageId === SCRIPTED_DASHBOARDS_DISABLED_MESSAGE_ID) {
+      return <ScriptedDashboardsDisabledPage />;
+    }
+
     return loadError ? (
       <DashboardPageError
         error={loadError}
@@ -152,6 +159,7 @@ export function DashboardScenePage({ route, queryParams, location }: Props) {
     <UrlSyncContextProvider scene={dashboard} updateUrlOnInit={true} createBrowserHistorySteps={true}>
       <DashboardPreviewBanner queryParams={queryParams} route={route.routeName} slug={slug} path={path} />
       <DashboardConversionWarningBanner dashboard={dashboard} />
+      <ScriptedDashboardDeprecationBanner isScripted={type === 'script'} />
       <OrphanedDashboardBanner dashboard={dashboard} />
       <SuggestedDashboardsBanner route={route.routeName} dashboard={dashboard} />
       <DashboardTemplateSavedBanner />

--- a/public/app/features/dashboard/services/DashboardLoaderSrv.ts
+++ b/public/app/features/dashboard/services/DashboardLoaderSrv.ts
@@ -1,5 +1,5 @@
 import { AppEvents, dateMath, type UrlQueryMap, type UrlQueryValue } from '@grafana/data';
-import { getBackendSrv, isFetchError, locationService } from '@grafana/runtime';
+import { config, getBackendSrv, isFetchError, locationService } from '@grafana/runtime';
 import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { backendSrv } from 'app/core/services/backend_srv';
 import impressionSrv from 'app/core/services/impression_srv';
@@ -16,6 +16,9 @@ import { getDashboardSrv } from './DashboardSrv';
 import { getDashboardSnapshotSrv } from './SnapshotSrv';
 
 type ScriptedDashboardExecution = { data: DashboardDataDTO };
+
+export const SCRIPTED_DASHBOARDS_DEPRECATION_URL = 'https://github.com/grafana/grafana/issues/24059';
+export const SCRIPTED_DASHBOARDS_DISABLED_MESSAGE_ID = 'scripted-dashboards-disabled';
 
 // Scripted dashboards are arbitrary user code, so nothing has validated what they return.
 // Accept any object and let the rest of the loading pipeline deal with the details.
@@ -43,6 +46,20 @@ abstract class DashboardLoaderSrvBase<T> implements DashboardLoaderSrvLike<T> {
   abstract loadSnapshot(slug: string): Promise<T>;
 
   protected loadScriptedDashboard(file: string): Promise<DashboardDTO> {
+    // Scripted dashboards are deprecated and disabled by default (feature toggle enabled). Admins can
+    // set `disableScriptedDashboards` to false to temporarily restore them until they are removed in Grafana 14.
+    if (config.featureToggles.disableScriptedDashboards) {
+      // Reject with a plain object (not an Error) so the messageId propagates through
+      // getMessageIdFromError and the scene page can render a dedicated notice with a link.
+      return Promise.reject({
+        status: 410,
+        messageId: SCRIPTED_DASHBOARDS_DISABLED_MESSAGE_ID,
+        message:
+          'Scripted dashboards are deprecated and have been disabled. They will be removed in Grafana 14. ' +
+          'To temporarily restore them, set the "disableScriptedDashboards" feature toggle to false.',
+      });
+    }
+
     const url = 'public/dashboards/' + file.replace(/\.(?!js)/, '/') + '?' + new Date().getTime();
 
     return getBackendSrv()

--- a/public/app/features/dashboard/services/DashboardLoaderSrv.ts
+++ b/public/app/features/dashboard/services/DashboardLoaderSrv.ts
@@ -46,11 +46,7 @@ abstract class DashboardLoaderSrvBase<T> implements DashboardLoaderSrvLike<T> {
   abstract loadSnapshot(slug: string): Promise<T>;
 
   protected loadScriptedDashboard(file: string): Promise<DashboardDTO> {
-    // Scripted dashboards are deprecated and disabled by default (feature toggle enabled). Admins can
-    // set `disableScriptedDashboards` to false to temporarily restore them until they are removed in Grafana 14.
     if (config.featureToggles.disableScriptedDashboards) {
-      // Reject with a plain object (not an Error) so the messageId propagates through
-      // getMessageIdFromError and the scene page can render a dedicated notice with a link.
       return Promise.reject({
         status: 410,
         messageId: SCRIPTED_DASHBOARDS_DISABLED_MESSAGE_ID,

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -7588,6 +7588,14 @@
       "new-alert-rule": "New alert rule",
       "title-no-alerting-capable-query-found": "No alerting capable query found"
     },
+    "scripted-dashboard-deprecation-banner": {
+      "body": "This feature will be removed in Grafana 14. <2>Read the deprecation notice</2>.",
+      "title": "Scripted dashboards are deprecated"
+    },
+    "scripted-dashboards-disabled": {
+      "body": "Scripted dashboards are deprecated and will be removed in Grafana 14. <2>Read the deprecation notice</2>. To temporarily restore them, set the <4>disableScriptedDashboards</4> feature toggle to <7>false</7>.",
+      "title": "Scripted dashboards are disabled"
+    },
     "section-placement": {
       "top-row": "Top of row",
       "top-tab": "Top of tab"


### PR DESCRIPTION
**What is this feature?**

Begins the removal of legacy scripted dashboards which have been deprecated since Grafana v7.0.
- Adds a `disableScriptedDashboards` feature toggle (stage: deprecated), **enabled by default**.
- When disabled, scripted dashboards still render but display a dismissible warning banner that the feature will be removed in Grafana 14.

scripted dashboards enabled:
<img width="1374" height="550" alt="image" src="https://github.com/user-attachments/assets/deca8222-144a-4a0e-9682-a57db30524d1" />

disabled

<img width="1388" height="636" alt="image" src="https://github.com/user-attachments/assets/d2b75b07-06dc-4189-8ed2-57ecc2998959" />

