### PR TITLE
Datasources: Fix config page not showing PDC on new datasource configs

### DIFF
--- a/public/app/features/datasources/api.test.ts
+++ b/public/app/features/datasources/api.test.ts
@@ -100,6 +100,30 @@ describe('Datasources / API', () => {
       };
       expect(convertK8sDatasourceSettingsToLegacyDatasourceSettings(dsK8sSettings)).toEqual(dsLegacySettings);
     });
+
+    it('should default jsonData to an empty object when the apiserver omits it', () => {
+      const dsK8sSettings: DataSourceSettingsK8s = {
+        kind: 'DataSource',
+        metadata: {
+          name: 'fortytwo',
+          namespace: 'default',
+          resourceVersion: '2',
+          labels: { 'grafana.app/deprecatedInternalID': '42' },
+        },
+        spec: {
+          access: 'all areas',
+          title: 'slartybartfast',
+          url: 'example.com',
+          basicAuth: false,
+          basicAuthUser: '',
+          user: '',
+          database: '',
+        },
+        apiVersion: 'marvin.datasource.grafana.app/v0alpha1',
+      };
+
+      expect(convertK8sDatasourceSettingsToLegacyDatasourceSettings(dsK8sSettings).jsonData).toEqual({});
+    });
   });
 
   describe('deleteDataSource()', () => {

--- a/public/app/features/datasources/api.ts
+++ b/public/app/features/datasources/api.ts
@@ -30,7 +30,9 @@ export interface K8sMetadata {
 
 export interface DatasourceInstanceK8sSpec {
   access: string;
-  jsonData: DataSourceJsonData;
+  // Omitted by the apiserver when empty (`json:"jsonData,omitzero"`), so it is not
+  // guaranteed to be present on responses.
+  jsonData?: DataSourceJsonData;
   title: string;
   url: string;
   user: string;
@@ -103,7 +105,7 @@ export const convertLegacyDatasourceSettingsToK8sDatasourceSettings = (
   };
   let k8sSpec: DatasourceInstanceK8sSpec = {
     access: dsSettings.access,
-    jsonData: dsSettings.jsonData,
+    jsonData: dsSettings.jsonData ?? {},
     title: dsSettings.name,
     url: dsSettings.url,
     basicAuth: dsSettings.basicAuth,
@@ -158,7 +160,9 @@ export const convertK8sDatasourceSettingsToLegacyDatasourceSettings = (
     basicAuth: dsK8sSettings.spec.basicAuth,
     basicAuthUser: dsK8sSettings.spec.basicAuthUser,
     isDefault: dsK8sSettings.spec.isDefault ? true : false,
-    jsonData: dsK8sSettings.spec.jsonData,
+    // DataSourceSettings.jsonData is non-optional and consumers (e.g. the
+    // grafana/datasources/config extension point) dereference it without guarding.
+    jsonData: dsK8sSettings.spec.jsonData ?? {},
     secureJsonFields: {},
     readOnly: dsK8sSettings.spec.readOnly ? dsK8sSettings.spec.readOnly : false,
     withCredentials: false,


### PR DESCRIPTION
**What is this feature?**

Defaults `jsonData` to `{}` when converting a datasource from the app platform (k8s) shape to the legacy `DataSourceSettings` shape.

The apiserver declares the field as `json:"jsonData,omitzero"` ([pkg/apis/datasource/v0alpha1/datasource.go](https://github.com/grafana/grafana/blob/main/pkg/apis/datasource/v0alpha1/datasource.go)) and the converter skips setting it when empty ([pkg/registry/apis/datasource/converter/converter.go](https://github.com/grafana/grafana/blob/main/pkg/registry/apis/datasource/converter/converter.go)), so `spec.jsonData` is absent — not `null`, not `{}` — for any datasource with no jsonData. `convertK8sDatasourceSettingsToLegacyDatasourceSettings` passed it straight through, producing a `DataSourceSettings` whose `jsonData` was `undefined` despite the type declaring it non-optional.

Three changes:
- `jsonData: dsK8sSettings.spec.jsonData ?? {}` on the k8s → legacy read path (the bug).
- The same guard on the legacy → k8s write path, matching the one already in `convertLegacyDatasourceSettingsPartialToK8sDatasourceSettings`.
- `DatasourceInstanceK8sSpec.jsonData` marked optional, so the type matches the wire contract and TypeScript catches the next unguarded deref.

**Why do we need this feature?**

When creating a new datasource, `EditDataSource` hands that object to the `grafana/datasources/config` extension point as `context.dataSource`, and consumers such as the pdc app rely on it. For example, `grafana-pdc-app` calls `useState(context.dataSource.jsonData.connMaxLifetime)`, which throws:

```
TypeError: Cannot read properties of undefined (reading 'connMaxLifetime')
Extension "grafana-pdc-app/PDC Datasource Config" failed to load.
```

The extension error boundary catches it, so the entire PDC config section silently fails to render on the datasource config page which means we can't set a pdc network on any new/unsaved datasource config pages. 


**Who is this feature for?**

Anyone opening a datasource config page who wants to set up a pdc configuration and is unable to 

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)