### PR TITLE
I18n: Fail extraction when the extractor reports an error

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1125,6 +1125,7 @@ scripts/verify-pkg-stig.sh @grafana/grafana-backend-services-squad
 /scripts/validate-npm-packages.sh @grafana/grafana-backend-services-squad @grafana/grafana-frontend-platform
 /scripts/ci-frontend-metrics.sh @grafana/grafana-frontend-platform @grafana/grafana-frontend-platform
 /scripts/cli/ @grafana/grafana-frontend-platform
+/scripts/tests/i18nExtractGuard.test.ts @grafana/grafana-frontend-platform
 /scripts/clean-git-or-error.sh @grafana/grafana-as-code
 /scripts/grafana-server/ @grafana/grafana-frontend-platform
 /scripts/check-frontend-dev.sh @grafana/grafana-frontend-platform

--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,11 @@ generate-openapi: openapi3-gen
 	yarn workspace @grafana/openapi process-specs
 
 ##@ Internationalisation
+# i18next-cli exits 0 after dropping a key that has a nesting conflict, so every extraction
+# pass runs through this guard to turn a dropped key into a build failure. Absolute path so
+# it also resolves for the Enterprise pass, which runs from a subdirectory.
+I18N_EXTRACT_GUARD = node $(CURDIR)/scripts/cli/runI18nExtract.mjs
+
 .PHONY: i18n-extract-enterprise
 ENTERPRISE_FE_EXT_FILE = public/app/extensions/index.ts
 ifeq ("$(wildcard $(ENTERPRISE_FE_EXT_FILE))","") ## if enterprise is not enabled
@@ -179,17 +184,17 @@ i18n-extract-enterprise:
 else
 i18n-extract-enterprise:
 	@echo "Extracting i18n strings for Enterprise"
-	cd public/locales/enterprise && LANG=en_US.UTF-8 yarn run i18next-cli extract --sync-primary
+	cd public/locales/enterprise && LANG=en_US.UTF-8 $(I18N_EXTRACT_GUARD) yarn run i18next-cli extract --sync-primary
 endif
 
 .PHONY: i18n-extract
 i18n-extract: i18n-extract-enterprise
 	@echo "Extracting i18n strings for OSS"
-	LANG=en_US.UTF-8 yarn run i18next-cli extract --sync-primary
+	LANG=en_US.UTF-8 $(I18N_EXTRACT_GUARD) yarn run i18next-cli extract --sync-primary
 	@echo "Extracting i18n strings for packages"
-	LANG=en_US.UTF-8 yarn run packages:i18n-extract
+	LANG=en_US.UTF-8 $(I18N_EXTRACT_GUARD) yarn run packages:i18n-extract
 	@echo "Extracting i18n strings for plugins"
-	LANG=en_US.UTF-8 yarn run plugin:i18n-extract
+	LANG=en_US.UTF-8 $(I18N_EXTRACT_GUARD) yarn run plugin:i18n-extract
 
 ##@ Building
 .PHONY: gen-cue

--- a/scripts/cli/runI18nExtract.mjs
+++ b/scripts/cli/runI18nExtract.mjs
@@ -1,0 +1,106 @@
+/// @ts-check
+
+import { spawn } from 'child_process';
+
+// Runs an i18n extraction pass and fails the build if the extractor reported an error.
+//
+// i18next-cli logs extraction errors — a nesting conflict that drops a key, a <Trans> child that
+// won't match at runtime — and still exits 0. A dropped key never reaches the catalog, so
+// extraction produces no diff either and the i18n-verify job passes while the string goes missing
+// at runtime. The i18next-parser setup this replaced failed the build via `failOnWarnings: true`,
+// dropped in #112512 with no equivalent: no i18next-cli option makes these fatal, because
+// `warnOnConflicts` only covers duplicate keys with differing default values.
+//
+// This is a stopgap. Matching output is the integration upstream points at — it prefixes these
+// messages with "Error:" so build tooling can treat them as fatal — but it is still a coupling to
+// their output format, so scripts/tests/i18nExtractGuard.test.ts exercises it against the real
+// extractor. Delete this in favour of a config option if i18next-cli ever grows one.
+
+const ERROR_LINE = /^[ \t]*Error:.*$/gm;
+
+// i18next-cli colours some output even when piped, and `FORCE_COLOR` makes that unconditional.
+// Strip escape sequences before matching so a coloured error can't slip past the anchor.
+const ANSI_ESCAPE = /\u001b\[[0-9;]*m/g;
+
+const [command, ...args] = process.argv.slice(2);
+
+if (!command) {
+  console.error('Usage: node scripts/cli/runI18nExtract.mjs <command> [...args]');
+  process.exit(1);
+}
+
+const commandLine = [command, ...args].join(' ');
+
+// Piping extraction into something that exits early (`| head`, quitting `less`) closes our
+// output mid-write. Ignore the EPIPE rather than dying with an unhandled error, which would
+// look like a fault in this guard.
+/** @param {NodeJS.ErrnoException} err */
+const ignoreEpipe = (err) => {
+  if (err.code !== 'EPIPE') {
+    throw err;
+  }
+};
+
+process.stdout.on('error', ignoreEpipe);
+process.stderr.on('error', ignoreEpipe);
+
+let output = '';
+let spawnFailed = false;
+
+const child = spawn(command, args, { stdio: ['inherit', 'pipe', 'pipe'] });
+
+// Stream through untouched so the extractor's own output still reaches the terminal, keeping a
+// copy to scan at the end — scanning per chunk would miss a message split across chunks.
+child.stdout?.on('data', (chunk) => {
+  output += chunk.toString();
+  process.stdout.write(chunk);
+});
+
+child.stderr?.on('data', (chunk) => {
+  output += chunk.toString();
+  process.stderr.write(chunk);
+});
+
+child.on('error', (err) => {
+  spawnFailed = true;
+  console.error(`Failed to run "${commandLine}": ${err.message}`);
+  process.exitCode = 1;
+});
+
+child.on('close', (code, signal) => {
+  // A failed spawn also emits 'close' with the errno as the code; keep the code set above.
+  if (spawnFailed) {
+    return;
+  }
+
+  // Never mask a real failure from the underlying command.
+  if (signal) {
+    console.error(`"${commandLine}" was terminated by signal ${signal}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (code !== 0) {
+    process.exitCode = code ?? 1;
+    return;
+  }
+
+  // Conflicts are reported once per locale, so dedupe.
+  const plainOutput = output.replace(ANSI_ESCAPE, '');
+  const errors = [...new Set(Array.from(plainOutput.match(ERROR_LINE) ?? [], (line) => line.trim()))];
+
+  if (errors.length === 0) {
+    return;
+  }
+
+  console.error(`\nExtraction reported ${errors.length} error(s) but exited 0:\n`);
+  for (const error of errors) {
+    console.error(`  ${error}`);
+  }
+  console.error(
+    `\nThese produce no catalog diff, so nothing else will catch them. Fix them at the source.\nCommand: ${commandLine}\n`
+  );
+
+  // Set exitCode rather than calling process.exit() so buffered output is flushed.
+  process.exitCode = 1;
+});

--- a/scripts/tests/i18nExtractGuard.test.ts
+++ b/scripts/tests/i18nExtractGuard.test.ts
@@ -1,0 +1,104 @@
+import { spawnSync } from 'child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+
+// `scripts/cli/runI18nExtract.mjs` detects extraction errors by matching i18next-cli's output,
+// because no config option makes them fatal. That makes it coupled to i18next-cli's output format,
+// so these tests run the real extractor over a fixture rather than testing the matching in
+// isolation. If an i18next-cli upgrade changes the format, this fails instead of the guard
+// silently going quiet — which is the whole failure mode being guarded against.
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const GUARD = path.join(REPO_ROOT, 'scripts', 'cli', 'runI18nExtract.mjs');
+const I18NEXT_CLI = path.join(REPO_ROOT, 'node_modules', '.bin', 'i18next-cli');
+
+const CONFIG = `export default {
+  locales: ['en-US'],
+  extract: {
+    input: ['src/**/*.{tsx,ts}'],
+    output: 'locales/{{language}}/{{namespace}}.json',
+    defaultNS: 'fixture',
+  },
+};
+`;
+
+const CONFLICTING_KEYS = `export const parent = () => t('fixture.conflict.parent', 'Parent');
+export const child = () => t('fixture.conflict.parent.child', 'Child');
+`;
+
+const CLEAN_KEYS = `export const ok = () => t('fixture.clean.label', 'Label');
+`;
+
+const fixtureDirs: string[] = [];
+
+/** Writes a throwaway extraction fixture and returns its directory. */
+function createFixture(source: string) {
+  // The fixture lives outside the repo so extraction can't write into tracked locale files.
+  // It therefore can't resolve `i18next-cli` for a `defineConfig` import — hence a plain object,
+  // which is all `defineConfig` returns anyway.
+  const dir = mkdtempSync(path.join(tmpdir(), 'i18n-extract-guard-'));
+  fixtureDirs.push(dir);
+  mkdirSync(path.join(dir, 'src'));
+  writeFileSync(path.join(dir, 'i18next.config.mjs'), CONFIG);
+  writeFileSync(path.join(dir, 'src', 'Keys.tsx'), source);
+  return dir;
+}
+
+function extract(cwd: string, { guarded }: { guarded: boolean }) {
+  const args = guarded ? [GUARD, 'node', I18NEXT_CLI, 'extract'] : [I18NEXT_CLI, 'extract'];
+  const result = spawnSync('node', args, { cwd, encoding: 'utf8' });
+  return { status: result.status, output: `${result.stdout}${result.stderr}` };
+}
+
+afterAll(() => {
+  for (const dir of fixtureDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('runI18nExtract guard', () => {
+  jest.setTimeout(60_000);
+
+  it('fails when a nesting conflict drops a key, naming both keys', () => {
+    const { status, output } = extract(createFixture(CONFLICTING_KEYS), { guarded: true });
+
+    expect(status).not.toBe(0);
+    expect(output).toContain('fixture.conflict.parent.child');
+    expect(output).toContain('fixture.conflict.parent');
+  });
+
+  it('passes when extraction reports no errors', () => {
+    const { status, output } = extract(createFixture(CLEAN_KEYS), { guarded: true });
+
+    expect(status).toBe(0);
+    expect(output).toContain('Extraction complete');
+  });
+
+  // Documents why the guard exists. If this starts failing, i18next-cli has made extraction
+  // errors fatal on its own and the guard can be removed.
+  it('is still needed, because i18next-cli exits 0 on a nesting conflict', () => {
+    const { status, output } = extract(createFixture(CONFLICTING_KEYS), { guarded: false });
+
+    expect(status).toBe(0);
+    expect(output).toContain('Nesting conflict');
+  });
+
+  it('does not mask a non-zero exit from the wrapped command', () => {
+    const result = spawnSync('node', [GUARD, 'node', '-e', 'process.exit(42)'], { encoding: 'utf8' });
+
+    expect(result.status).toBe(42);
+  });
+
+  it('detects errors even when i18next-cli colours its output', () => {
+    const emitColouredError = `const { styleText } = require('util');
+      console.error(styleText('red', 'Error: Nesting conflict: key "a.b.c" conflicts with existing key "a.b".'));`;
+    const result = spawnSync('node', [GUARD, 'node', '-e', emitColouredError], {
+      encoding: 'utf8',
+      env: { ...process.env, FORCE_COLOR: '1' },
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('conflicts with existing key');
+  });
+});


### PR DESCRIPTION
> [!IMPORTANT]
> Merge grafana/grafana-enterprise#12960 first — it clears 7 pre-existing extraction errors in
> enterprise. OSS CI is unaffected either way, but enterprise's `i18n-verify` syncs enterprise into
> OSS and runs this same `make i18n-extract`, so landing this first reddens every enterprise PR.

**What is this feature?**

Makes an i18n extraction error fail the build. All four passes in `make i18n-extract` (enterprise, OSS
root, both nx fan-outs) now run through `scripts/cli/runI18nExtract.mjs`, which streams the
extractor's output through and exits non-zero if it reported an error.

**Why do we need this feature?**

`i18next-cli` logs extraction errors and exits 0. A nesting conflict drops the key, so it never
reaches the catalog and extraction produces **no diff** — `i18n-verify` passes too, and nothing in CI
can catch it. That's how #129955 went unnoticed: 11 strings missing from the catalog, one key
rendering as an object for all users.

It's a regression. The i18next-parser → i18next-cli migration (#112512) dropped `failOnWarnings: true`
with no replacement, and the old parser exited 1 on exactly this input. `warnOnConflicts: 'error'`
isn't the lever — it only covers duplicate keys with differing default values. `--ci` doesn't help
either, since `hasErrors` never sees these. No equivalent option exists.

**Who is this feature for?**

Anyone adding translatable strings, and translators — a dropped key never gets translated.

**Which issue(s) does this PR fix?**:

Fixes #129947

**Special notes for your reviewer:**

Matching output is a coupling I'd rather avoid, but it's the integration upstream points at: they
prefix these messages `Error:` so build tooling can treat them as fatal. The alternatives are worse.
`runExtractor` takes a custom logger, but config loading isn't exported, so that means reimplementing
TS config resolution and the CLI's flags against unexported internals. A plugin's `onEnd` only sees
extracted keys, so it would re-derive upstream's conflict logic and still miss the `<Trans>` class.

So it's labelled a stopgap in-code, and `scripts/tests/i18nExtractGuard.test.ts` pins the format by
running the real extractor over a fixture — if an upgrade changes the output, that test fails instead
of the guard going quiet. One test asserts the raw CLI still exits 0, so we'll know if upstream fixes
this and the guard can go.

Verified with a deliberate conflict in each of `public/app/`, `packages/grafana-sql` (nx),
`azuremonitor` (nx) and enterprise: all exit non-zero naming both keys, and clean runs exit 0 with no
catalog diff. The nx cases matter — both fan-outs report `Successfully ran target` and exit 0, so
wrapping only the OSS pass would have been theatre. Real failures still surface unchanged (42 → 42,
ENOENT and SIGTERM → 1).

Not addressed: the three `e2e-playwright/test-plugins/*` define `i18n-extract` scripts that no pass
reaches, so they are never extracted at all. Separate gap.
