### PR TITLE
Dashboards: Keep a library panel's element name through serialization

### DIFF
--- a/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.test.ts
+++ b/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.test.ts
@@ -1298,6 +1298,29 @@ describe('DashboardSceneSerializer', () => {
         expect(serializer.getPanelIdForElement('non-existent')).toBeUndefined();
       });
 
+      // A library panel is returned by getVizPanels() like any other panel, so its element name has
+      // to be in the map. While it was not, serialization rekeyed it to panel-<id> instead of the name
+      // the dashboard was saved under.
+      it('should map a library panel element under its own name', () => {
+        serializer.initializeElementMapping({
+          ...saveModel,
+          elements: {
+            ...saveModel.elements,
+            'saved-view': {
+              kind: 'LibraryPanel',
+              spec: {
+                id: 3,
+                title: 'Checkout overview',
+                libraryPanel: { uid: 'lib-uid-1', name: 'Checkout overview' },
+              },
+            },
+          },
+        });
+
+        expect(serializer.getElementPanelMapping().get('saved-view')).toBe(3);
+        expect(serializer.getElementIdForPanel(3)).toBe('saved-view');
+      });
+
       it('should get element id for panel correctly', () => {
         serializer.initializeElementMapping(saveModel);
 

--- a/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.ts
@@ -319,7 +319,10 @@ export class V2DashboardSerializer
     const elementKeys = Object.keys(saveModel.elements);
     elementKeys.forEach((key) => {
       const elementPanel = saveModel.elements[key];
-      if (elementPanel.kind === 'Panel') {
+      // Library panels belong here too: they are returned by `getVizPanels()`, so their element key is
+      // derived through the same lookup, and leaving them out meant serialization rekeyed them to
+      // `panel-<id>` instead of the name the dashboard was saved under.
+      if (elementPanel.kind === 'Panel' || elementPanel.kind === 'LibraryPanel') {
         this.elementPanelMap.set(key, elementPanel.spec.id);
       }
     });

--- a/public/app/features/dashboard-scene/serialization/libraryPanelElementName.test.ts
+++ b/public/app/features/dashboard-scene/serialization/libraryPanelElementName.test.ts
@@ -1,0 +1,94 @@
+/**
+ * A library panel keeps the element name its dashboard was saved under, end to end: v2 spec into a
+ * scene, back out through the real serializer.
+ *
+ * The unit cover for this is `initializeElementMapping` in DashboardSceneSerializer.test.ts. This is
+ * the round trip, because the map is only interesting for what serialization does with it, and the
+ * failure was silent: a dashboard saved with `elements: { 'saved-view': ... }` came back with
+ * `panel-<id>` instead, so the persisted key changed under a user who only opened and saved.
+ */
+
+import {
+  type Spec as DashboardV2Spec,
+  defaultSpec as defaultDashboardV2Spec,
+  defaultLibraryPanelKind,
+  defaultPanelSpec,
+} from '@grafana/schema/apis/dashboard.grafana.app/v2';
+import { type DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
+
+import { transformSaveModelSchemaV2ToScene } from './transformSaveModelSchemaV2ToScene';
+import { transformSceneToSaveModelSchemaV2 } from './transformSceneToSaveModelSchemaV2';
+
+/** Element names are deliberately not `panel-<id>`: the canonical name is what hides this bug. */
+function dashboardWithLibraryPanel(): DashboardV2Spec {
+  return {
+    ...defaultDashboardV2Spec(),
+    title: 'Checkout latency',
+    elements: {
+      'latency-panel': { kind: 'Panel', spec: { ...defaultPanelSpec(), id: 1, title: 'p99 latency' } },
+      'saved-view': {
+        ...defaultLibraryPanelKind(),
+        spec: {
+          ...defaultLibraryPanelKind().spec,
+          id: 2,
+          title: 'Checkout overview',
+          libraryPanel: { uid: 'lib-uid-1', name: 'Checkout overview' },
+        },
+      },
+    },
+    layout: {
+      kind: 'GridLayout',
+      spec: {
+        items: [
+          {
+            kind: 'GridLayoutItem',
+            spec: { x: 0, y: 0, width: 12, height: 8, element: { kind: 'ElementReference', name: 'latency-panel' } },
+          },
+          {
+            kind: 'GridLayoutItem',
+            spec: { x: 0, y: 8, width: 12, height: 8, element: { kind: 'ElementReference', name: 'saved-view' } },
+          },
+        ],
+      },
+    },
+  };
+}
+
+function sceneFrom(spec: DashboardV2Spec) {
+  const dto = {
+    kind: 'DashboardWithAccessInfo',
+    apiVersion: 'dashboard.grafana.app/v2beta1',
+    metadata: { name: 'dash-1', generation: 1, creationTimestamp: '2026-08-05T00:00:00Z', annotations: {} },
+    access: { canEdit: true, canSave: true, canShare: true, canStar: true, canDelete: true, canAdmin: true },
+    spec,
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal resource envelope for the test
+  } as unknown as DashboardWithAccessInfo<DashboardV2Spec>;
+
+  // Deliberately not activated: serialization reads scene state, and activating would start the
+  // library panel fetch and the annotation data layer, neither of which this is about.
+  return transformSaveModelSchemaV2ToScene(dto);
+}
+
+function layoutReferences(spec: DashboardV2Spec): string[] {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the fixture is a grid layout
+  const items = (spec.layout as { spec: { items: Array<{ spec: { element: { name: string } } }> } }).spec.items;
+  return items.map((item) => item.spec.element.name);
+}
+
+describe('library panel element names', () => {
+  it('survive a scene round trip', () => {
+    const serialized = transformSceneToSaveModelSchemaV2(sceneFrom(dashboardWithLibraryPanel()));
+
+    expect(Object.keys(serialized.elements).sort()).toEqual(['latency-panel', 'saved-view']);
+    expect(serialized.elements['saved-view'].kind).toBe('LibraryPanel');
+  });
+
+  it('leave no layout reference pointing at a missing element', () => {
+    const serialized = transformSceneToSaveModelSchemaV2(sceneFrom(dashboardWithLibraryPanel()));
+
+    expect(layoutReferences(serialized)).toEqual(['latency-panel', 'saved-view']);
+    for (const name of layoutReferences(serialized)) {
+      expect(serialized.elements[name]).toBeDefined();
+    }
+  });
+});

--- a/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.tsx
+++ b/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.tsx
@@ -107,11 +107,10 @@ function findV1PanelSaveModel(panels: unknown, id: number): unknown {
 //
 // The v2 branch depends on an ordering invariant: getSaveModel() (called just before this) keys every
 // element through the same serializer.getElementIdForPanel(id) that this lookup uses, so the id we
-// resolve here always matches a key serialization just produced. This is why library panels and
-// repeat clones both resolve even though initializeElementMapping seeds the map only from kind:'Panel'
-// elements: getSaveModel visits every panel first and, for any id not already mapped, getElementIdForPanel
-// generates and stores a "panel-<id>" key — which this lookup then finds. Keep getSaveModel ahead of
-// this call or the v2 mapping may be empty.
+// resolve here always matches a key serialization just produced. This is why repeat clones resolve even
+// though initializeElementMapping never seeds them: getSaveModel visits every panel first and, for any id
+// not already mapped, getElementIdForPanel generates and stores a "panel-<id>" key — which this lookup
+// then finds. Keep getSaveModel ahead of this call or the v2 mapping may be empty.
 function findPanelSaveModel(dashboardModel: unknown, panel: VizPanel, dashboard: DashboardScene): unknown {
   if (!isRecord(dashboardModel)) {
     return undefined;


### PR DESCRIPTION
## What

A dashboard saved with a library panel under an element name of its own, for example `elements: { 'saved-view': ... }`, came back from serialization keyed `panel-<id>`. Opening and saving was enough: nothing about the panel changed, but the persisted element key did.

`V2DashboardSerializer.initializeElementMapping` only mapped `kind: 'Panel'`. A library panel is returned by `getVizPanels()` like any other panel, so serialization looks its element name up in that map, misses, and falls back to the canonical `panel-<id>`.

One line, plus the tests that hold it.

## Why it looked harmless

The layout reference is derived from the same lookup (`getElementIdentifierForVizPanel`), so on a miss both the element key and the reference to it renamed together. The dashboard kept rendering, which is why nobody saw this.

It stops being harmless as soon as something addresses elements by name rather than by reading them back: the Mutation API's full-spec commands, or a layout that writes its own references. In grafana/grafana#129936 a notebook does exactly that and the panel disappeared, which is how this was found.

## Which issue(s) does this PR fix?

Split out of #129936 so the dashboard-affecting half is reviewed and changelogged on its own. Nothing in this PR touches notebooks.

## Tests

- `DashboardSceneSerializer.test.ts`: the map now carries a library panel element under its own name.
- `libraryPanelElementName.test.ts`: the round trip, v2 spec into a scene and back out, asserting the element key survives and no layout reference is left pointing at a missing element. Fails on `main` without the fix.

`yarn jest public/app/features/dashboard-scene/serialization`.

Please check that:
- [ ] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
