### PR TITLE
Tests: Opt-in all Grafana frontend codeowner teams to night frontend Bench code coverage metrics.

### DIFF
--- a/.github/workflows/report-frontend-coverage-to-bench.yaml
+++ b/.github/workflows/report-frontend-coverage-to-bench.yaml
@@ -14,10 +14,26 @@ jobs:
     outputs:
       opted-in-teams: >-
         [
+          "@grafana/access-squad",
+          "@grafana/alerting-squad",
+          "@grafana/app-o11y-visualizations",
+          "@grafana/dashboards-squad",
+          "@grafana/data-sources-plugins",
           "@grafana/datapro",
           "@grafana/dataviz-squad",
+          "@grafana/grafana-app-platform-squad",
+          "@grafana/grafana-backend-services-squad",
+          "@grafana/grafana-catalog",
+          "@grafana/grafana-datasources-core-services",
           "@grafana/grafana-frontend-navigation",
-          "@grafana/grafana-operator-experience-squad"
+          "@grafana/grafana-operator-experience-squad",
+          "@grafana/growth-engineering",
+          "@grafana/identity-access-team",
+          "@grafana/identity-squad",
+          "@grafana/observability-logs",
+          "@grafana/observability-metrics",
+          "@grafana/observability-traces-and-profiling",
+          "@grafana/sharing-squad"
         ]
     steps:
       - name: Define opted-in teams

--- a/.github/workflows/report-frontend-coverage-to-bench.yaml
+++ b/.github/workflows/report-frontend-coverage-to-bench.yaml
@@ -22,7 +22,6 @@ jobs:
           "@grafana/datapro",
           "@grafana/dataviz-squad",
           "@grafana/grafana-app-platform-squad",
-          "@grafana/grafana-backend-services-squad",
           "@grafana/grafana-catalog",
           "@grafana/grafana-datasources-core-services",
           "@grafana/grafana-frontend-navigation",


### PR DESCRIPTION
**What is this feature?**

This change opts the rest of the Grafana frontend teams from CODEOWNERS to nightly Bench unit test coverage metric reporting, so we can compare their coverage over time.

**Why do we need this feature?**

To compare unit test coverage over time, and compare coverage with other test tooling over time.

**Who is this feature for?**

Grafanista frontend engineers.