### PR TITLE
Home: Add header actions overview bar for alerts + incidents

### DIFF
--- a/public/app/core/components/Page/PageHeader.tsx
+++ b/public/app/core/components/Page/PageHeader.tsx
@@ -26,7 +26,7 @@ export function PageHeader({ navItem, renderTitle, actions, info, subTitle, onEd
 
   return (
     <div className={styles.pageHeader}>
-      <div className={styles.topRow}>
+      <div className={styles.titleSubtitleContainer}>
         <div className={styles.titleInfoContainer}>
           <div className={styles.title}>
             {navItem.img && <img className={styles.img} src={navItem.img} alt={`logo for ${navItem.text}`} />}
@@ -45,22 +45,15 @@ export function PageHeader({ navItem, renderTitle, actions, info, subTitle, onEd
           </div>
           {info && <PageInfo info={info} />}
         </div>
-        <div className={styles.actions}>{actions}</div>
+        {sub && <div className={styles.subTitle}>{sub}</div>}
       </div>
-      {sub && <div className={styles.subTitle}>{sub}</div>}
+      <div className={styles.actions}>{actions}</div>
     </div>
   );
 }
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {
-    topRow: css({
-      alignItems: 'flex-start',
-      display: 'flex',
-      flexDirection: 'row',
-      flexWrap: 'wrap',
-      gap: theme.spacing(1, 3),
-    }),
     title: css({
       display: 'flex',
       flexDirection: 'row',
@@ -76,10 +69,16 @@ const getStyles = (theme: GrafanaTheme2) => {
       flexDirection: 'row',
       gap: theme.spacing(1),
     }),
+    titleSubtitleContainer: css({
+      display: 'flex',
+      label: 'title-subtitle-container',
+      flexDirection: 'column',
+      flex: 1,
+      gap: theme.spacing(1),
+    }),
     titleInfoContainer: css({
       display: 'flex',
       label: 'title-info-container',
-      flex: 1,
       flexWrap: 'wrap',
       gap: theme.spacing(1, 4),
       justifyContent: 'space-between',
@@ -89,8 +88,9 @@ const getStyles = (theme: GrafanaTheme2) => {
     pageHeader: css({
       label: 'page-header',
       display: 'flex',
-      flexDirection: 'column',
-      gap: theme.spacing(1),
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      gap: theme.spacing(1, 3),
       marginBottom: theme.spacing(2),
     }),
     subTitle: css({

--- a/public/app/features/home/AlertsIncidents/AlertIncidentTabs.test.tsx
+++ b/public/app/features/home/AlertsIncidents/AlertIncidentTabs.test.tsx
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from 'msw';
-import { useState } from 'react';
+import { useState, type Ref } from 'react';
 import { act, render, screen, waitFor } from 'test/test-utils';
 
 import { PluginIncludeType, type PluginMeta } from '@grafana/data';
@@ -21,7 +21,12 @@ import { SupportedPlugin } from 'app/features/alerting/unified/types/pluginBridg
 import { AlertState, type AlertmanagerAlert } from 'app/plugins/datasource/alertmanager/types';
 import { AccessControlAction } from 'app/types/accessControl';
 
-import { AlertIncidentTabs } from './AlertIncidentTabs';
+import {
+  ALERTS_TAB_ID,
+  AlertIncidentTabs,
+  INCIDENTS_TAB_ID,
+  type AlertIncidentSwitchHandle,
+} from './AlertIncidentTabs';
 import { useFiringAlerts } from './useFiringAlerts';
 import { useIncidents } from './useIncidents';
 
@@ -170,11 +175,19 @@ afterEach(async () => {
   invalidateCachedPromisesCache();
 });
 
-function AlertIncidentTabsWithData() {
+function AlertIncidentTabsWithData({ switchRef }: { switchRef?: Ref<AlertIncidentSwitchHandle> } = {}) {
   const [team, setTeam] = useState<string | undefined>();
   const alertsData = useFiringAlerts(team);
   const incidentsData = useIncidents();
-  return <AlertIncidentTabs alertsData={alertsData} incidentsData={incidentsData} team={team} setTeam={setTeam} />;
+  return (
+    <AlertIncidentTabs
+      alertsData={alertsData}
+      incidentsData={incidentsData}
+      team={team}
+      setTeam={setTeam}
+      switchRef={switchRef}
+    />
+  );
 }
 
 describe('AlertIncidentTabs', () => {
@@ -277,6 +290,85 @@ describe('AlertIncidentTabs', () => {
 
     expect(await screen.findByText('Database outage')).toBeInTheDocument();
     expect(screen.queryByText('CPU Critical')).not.toBeInTheDocument();
+  });
+
+  it('switchRef handle switches tabs imperatively', async () => {
+    mockAlerts([makeAlert({ labels: { alertname: 'CPU Critical', severity: 'critical' } })]);
+    mockIrmPlugin();
+    mockIncidents([activeIncident]);
+    let handle: AlertIncidentSwitchHandle | null = null;
+
+    render(
+      <AlertIncidentTabsWithData
+        switchRef={(instance) => {
+          handle = instance;
+        }}
+      />
+    );
+
+    expect(await screen.findByText('CPU Critical')).toBeInTheDocument();
+    expect(handle).not.toBeNull();
+
+    await act(async () => {
+      handle?.switch(INCIDENTS_TAB_ID, false);
+    });
+
+    expect(await screen.findByText('Database outage')).toBeInTheDocument();
+    expect(screen.queryByText('CPU Critical')).not.toBeInTheDocument();
+
+    await act(async () => {
+      handle?.switch(ALERTS_TAB_ID, false);
+    });
+
+    expect(await screen.findByText('CPU Critical')).toBeInTheDocument();
+    expect(screen.queryByText('Database outage')).not.toBeInTheDocument();
+  });
+
+  it('switchRef handle scrolls by default and skips scrolling when requested', async () => {
+    mockAlerts([makeAlert({ labels: { alertname: 'CPU Critical', severity: 'critical' } })]);
+    mockIrmPlugin();
+    mockIncidents([activeIncident]);
+    let handle: AlertIncidentSwitchHandle | null = null;
+    const scrollIntoView = jest.fn();
+    const originalScrollIntoView = Element.prototype.scrollIntoView;
+
+    Object.defineProperty(Element.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: scrollIntoView,
+    });
+
+    try {
+      render(
+        <AlertIncidentTabsWithData
+          switchRef={(instance) => {
+            handle = instance;
+          }}
+        />
+      );
+
+      expect(await screen.findByText('CPU Critical')).toBeInTheDocument();
+
+      await act(async () => {
+        handle?.switch(INCIDENTS_TAB_ID);
+      });
+
+      expect(await screen.findByText('Database outage')).toBeInTheDocument();
+      expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
+
+      scrollIntoView.mockClear();
+
+      await act(async () => {
+        handle?.switch(ALERTS_TAB_ID, false);
+      });
+
+      expect(await screen.findByText('CPU Critical')).toBeInTheDocument();
+      expect(scrollIntoView).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(Element.prototype, 'scrollIntoView', {
+        configurable: true,
+        value: originalScrollIntoView,
+      });
+    }
   });
 
   it('shows the incidents footer actions when the user can declare and access incidents', async () => {

--- a/public/app/features/home/AlertsIncidents/AlertIncidentTabs.test.tsx
+++ b/public/app/features/home/AlertsIncidents/AlertIncidentTabs.test.tsx
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from 'msw';
+import { useState } from 'react';
 import { act, render, screen, waitFor } from 'test/test-utils';
 
 import { PluginIncludeType, type PluginMeta } from '@grafana/data';
@@ -21,6 +22,8 @@ import { AlertState, type AlertmanagerAlert } from 'app/plugins/datasource/alert
 import { AccessControlAction } from 'app/types/accessControl';
 
 import { AlertIncidentTabs } from './AlertIncidentTabs';
+import { useFiringAlerts } from './useFiringAlerts';
+import { useIncidents } from './useIncidents';
 
 jest.mock('../analytics/main', () => ({
   ctaClicked: jest.fn(),
@@ -167,11 +170,18 @@ afterEach(async () => {
   invalidateCachedPromisesCache();
 });
 
+function AlertIncidentTabsWithData() {
+  const [team, setTeam] = useState<string | undefined>();
+  const alertsData = useFiringAlerts(team);
+  const incidentsData = useIncidents();
+  return <AlertIncidentTabs alertsData={alertsData} incidentsData={incidentsData} team={team} setTeam={setTeam} />;
+}
+
 describe('AlertIncidentTabs', () => {
   it('renders nothing when the user lacks AlertingInstanceRead permission', async () => {
     jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(false);
 
-    const { container } = render(<AlertIncidentTabs />);
+    const { container } = render(<AlertIncidentTabsWithData />);
     // the plugin bridge settles asynchronously, so let it before asserting nothing appeared
     await waitFor(() => expect(container).toBeEmptyDOMElement());
   });
@@ -179,7 +189,7 @@ describe('AlertIncidentTabs', () => {
   it('renders a single Firing alerts heading and tab when permitted', async () => {
     mockAlerts([makeAlert({ labels: { alertname: 'CPU Critical', severity: 'critical' } })]);
 
-    render(<AlertIncidentTabs />);
+    render(<AlertIncidentTabsWithData />);
 
     // Wait for the alert to load so the card content is rendered.
     expect(await screen.findByText('CPU Critical')).toBeInTheDocument();
@@ -197,7 +207,7 @@ describe('AlertIncidentTabs', () => {
       makeAlert({ labels: { alertname: 'Memory High', severity: 'high' } }),
     ]);
 
-    render(<AlertIncidentTabs />);
+    render(<AlertIncidentTabsWithData />);
 
     // Counter is undefined while loading, so wait until it reflects the loaded count.
     const tab = await screen.findByRole('tab', { name: /firing alerts/i });
@@ -215,7 +225,7 @@ describe('AlertIncidentTabs', () => {
     }));
     mockIncidents(fullPage, { hasMore: true });
 
-    render(<AlertIncidentTabs />);
+    render(<AlertIncidentTabsWithData />);
 
     const tab = await screen.findByRole('tab', { name: /incidents/i });
     await waitFor(() => expect(tab).toHaveTextContent(`${ACTIVE_INCIDENTS_QUERY_LIMIT}+`));
@@ -232,7 +242,7 @@ describe('AlertIncidentTabs', () => {
     }));
     mockIncidents(fullPage, { hasMore: false });
 
-    render(<AlertIncidentTabs />);
+    render(<AlertIncidentTabsWithData />);
 
     const tab = await screen.findByRole('tab', { name: /incidents/i });
     await waitFor(() => expect(tab).toHaveTextContent(String(ACTIVE_INCIDENTS_QUERY_LIMIT)));
@@ -244,7 +254,7 @@ describe('AlertIncidentTabs', () => {
     mockIrmPlugin();
     mockIncidents([activeIncident]);
 
-    render(<AlertIncidentTabs />);
+    render(<AlertIncidentTabsWithData />);
 
     expect(await screen.findByText('Database outage')).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /incidents/i })).toHaveAttribute('aria-selected', 'true');
@@ -257,7 +267,7 @@ describe('AlertIncidentTabs', () => {
     mockIrmPlugin();
     mockIncidents([activeIncident]);
 
-    const { user } = render(<AlertIncidentTabs />);
+    const { user } = render(<AlertIncidentTabsWithData />);
 
     // Alerts tab is active by default.
     expect(await screen.findByText('CPU Critical')).toBeInTheDocument();
@@ -275,7 +285,7 @@ describe('AlertIncidentTabs', () => {
     mockIrmPlugin({ includes: [] });
     mockIncidents([activeIncident]);
 
-    render(<AlertIncidentTabs />);
+    render(<AlertIncidentTabsWithData />);
 
     expect(await screen.findByText('Database outage')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /declare an incident/i })).toBeInTheDocument();
@@ -302,7 +312,7 @@ describe('AlertIncidentTabs', () => {
     });
     mockIncidents([activeIncident]);
 
-    render(<AlertIncidentTabs />);
+    render(<AlertIncidentTabsWithData />);
 
     expect(await screen.findByText('Database outage')).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: /declare an incident/i })).not.toBeInTheDocument();
@@ -316,7 +326,7 @@ describe('AlertIncidentTabs', () => {
       mockIrmPlugin();
       mockIncidents([activeIncident]);
 
-      const { user } = render(<AlertIncidentTabs />);
+      const { user } = render(<AlertIncidentTabsWithData />);
 
       expect(await screen.findByText('CPU Critical')).toBeInTheDocument();
       expect(await screen.findByRole('combobox', { name: /filter alerts by team/i })).toBeInTheDocument();
@@ -339,7 +349,7 @@ describe('AlertIncidentTabs', () => {
       mockTeamLabelValues(['Team A', 'Team B', 'Team C']);
       const requests = mockAlerts([makeAlert({ labels: { alertname: 'CPU Critical', severity: 'critical' } })]);
 
-      const { user } = render(<AlertIncidentTabs />);
+      const { user } = render(<AlertIncidentTabsWithData />);
 
       // Initial request is filtered to the user's own teams, matched tolerantly
       // ((?i) + separator gaps) since the free-form `team` label usually carries
@@ -378,7 +388,7 @@ describe('AlertIncidentTabs', () => {
         })
       );
 
-      const { user } = render(<AlertIncidentTabs />);
+      const { user } = render(<AlertIncidentTabsWithData />);
 
       expect(await screen.findByText('CPU Critical')).toBeInTheDocument();
       const combobox = await screen.findByRole('combobox', { name: /filter alerts by team/i });
@@ -417,7 +427,7 @@ describe('AlertIncidentTabs', () => {
         })
       );
 
-      const { user } = render(<AlertIncidentTabs />);
+      const { user } = render(<AlertIncidentTabsWithData />);
 
       expect(await screen.findByText('CPU Critical')).toBeInTheDocument();
       const combobox = await screen.findByRole('combobox', { name: /filter alerts by team/i });
@@ -452,7 +462,7 @@ describe('AlertIncidentTabs', () => {
         })
       );
 
-      const { user } = render(<AlertIncidentTabs />);
+      const { user } = render(<AlertIncidentTabsWithData />);
 
       expect(await screen.findByText('CPU Critical')).toBeInTheDocument();
       await user.click(await screen.findByRole('combobox', { name: /filter alerts by team/i }));
@@ -468,7 +478,7 @@ describe('AlertIncidentTabs', () => {
       mockTeamLabelValues(['Team A', 'Team C']);
       const requests = mockAlerts([makeAlert({ labels: { alertname: 'CPU Critical', severity: 'critical' } })]);
 
-      const { user } = render(<AlertIncidentTabs />);
+      const { user } = render(<AlertIncidentTabsWithData />);
 
       const ownTeamsFilter = `team=~"(?i)${wireTolerantPattern('Team', 'A')}"`;
 
@@ -512,7 +522,7 @@ describe('AlertIncidentTabs', () => {
         })
       );
 
-      const { user } = render(<AlertIncidentTabs />);
+      const { user } = render(<AlertIncidentTabsWithData />);
 
       expect(await screen.findByText('CPU Critical')).toBeInTheDocument();
       expect(screen.queryByTestId('summary-card-skeleton')).not.toBeInTheDocument();
@@ -535,7 +545,7 @@ describe('AlertIncidentTabs', () => {
       mockTeamLabelValues(['Team A', 'Team C']);
       const requests = mockAlerts([makeAlert({ labels: { alertname: 'CPU Critical', severity: 'critical' } })]);
 
-      const { user } = render(<AlertIncidentTabs />);
+      const { user } = render(<AlertIncidentTabsWithData />);
 
       expect(await screen.findByText('CPU Critical')).toBeInTheDocument();
       const combobox = await screen.findByRole('combobox', { name: /filter alerts by team/i });
@@ -566,7 +576,7 @@ describe('AlertIncidentTabs', () => {
         })
       );
 
-      const { user } = render(<AlertIncidentTabs />);
+      const { user } = render(<AlertIncidentTabsWithData />);
 
       expect(await screen.findByText('CPU Critical')).toBeInTheDocument();
       await user.click(await screen.findByRole('combobox', { name: /filter alerts by team/i }));
@@ -581,7 +591,7 @@ describe('AlertIncidentTabs', () => {
       mockTeamLabelValues(['Team Alpha', 'Team Beta', 'Zebra Squad']);
       mockAlerts([makeAlert({ labels: { alertname: 'CPU Critical', severity: 'critical' } })]);
 
-      const { user } = render(<AlertIncidentTabs />);
+      const { user } = render(<AlertIncidentTabsWithData />);
 
       expect(await screen.findByText('CPU Critical')).toBeInTheDocument();
       const combobox = await screen.findByRole('combobox', { name: /filter alerts by team/i });
@@ -612,7 +622,7 @@ describe('AlertIncidentTabs', () => {
       mockTeamLabelValues(['Team A']);
       mockAlerts([makeAlert({ labels: { alertname: 'CPU Critical', severity: 'critical' } })]);
 
-      render(<AlertIncidentTabs />);
+      render(<AlertIncidentTabsWithData />);
 
       expect(await screen.findByText('CPU Critical')).toBeInTheDocument();
       expect(screen.queryByRole('combobox', { name: /filter alerts by team/i })).not.toBeInTheDocument();
@@ -623,7 +633,7 @@ describe('AlertIncidentTabs', () => {
       // No alerts carry the selected team label, so the team-scoped empty copy shows.
       const requests = mockAlerts([]);
 
-      const { user } = render(<AlertIncidentTabs />);
+      const { user } = render(<AlertIncidentTabsWithData />);
 
       await user.click(await screen.findByRole('combobox', { name: /filter alerts by team/i }));
       await user.click(await screen.findByRole('option', { name: 'platform-monitoring' }));

--- a/public/app/features/home/AlertsIncidents/AlertIncidentTabs.tsx
+++ b/public/app/features/home/AlertsIncidents/AlertIncidentTabs.tsx
@@ -3,8 +3,6 @@ import { useImperativeHandle, useRef, useState, type Ref } from 'react';
 import { t } from '@grafana/i18n';
 import { Box, ScrollContainer, Stack, Tab, TabContent, TabsBar, Text } from '@grafana/ui';
 import { ACTIVE_INCIDENTS_QUERY_LIMIT } from 'app/features/alerting/unified/api/incidentsApi';
-import { usePluginBridge } from 'app/features/alerting/unified/hooks/usePluginBridge';
-import { SupportedPlugin } from 'app/features/alerting/unified/types/pluginBridges';
 
 import { DASHBOARD_TABS_SCROLL_HEIGHT_REDESIGN } from '../DashboardTabs/types';
 import { HomeSection } from '../HomeSection';
@@ -12,11 +10,11 @@ import { tabChanged } from '../analytics/main';
 
 import { CreateAndViewAlertsButtons } from './CreateAndViewAlertsButtons';
 import { DeclareAndViewIncidentsButtons } from './DeclareAndViewIncidentsButtons';
-import { FiringAlertsCardView } from './FiringAlertsCard';
-import { IncidentsCardView } from './IncidentsCard';
+import { FiringAlertsCard } from './FiringAlertsCard';
+import { IncidentsCard } from './IncidentsCard';
 import { TeamFilterCombobox } from './TeamFilterCombobox';
-import { canViewFiringAlerts, useFiringAlerts } from './useFiringAlerts';
-import { useIncidents } from './useIncidents';
+import { type FiringAlertsData } from './useFiringAlerts';
+import { type IncidentsData } from './useIncidents';
 
 export const ALERTS_TAB_ID = 'firing-alerts' as const;
 export const INCIDENTS_TAB_ID = 'incidents' as const;
@@ -26,36 +24,24 @@ export type AlertIncidentSwitchHandle = {
   switch: (tab: TabId, scroll?: boolean) => void;
 };
 
-export function AlertIncidentTabs({ switchRef }: { switchRef?: Ref<AlertIncidentSwitchHandle> }) {
-  const { installed, loading } = usePluginBridge(SupportedPlugin.Irm);
-  const canViewIncidents = Boolean(installed && !loading);
-  const canViewAlerts = canViewFiringAlerts();
-
-  // Hide the tabs if neither alerts nor incidents are available
-  if (!canViewAlerts && !canViewIncidents) {
-    return null;
-  }
-
-  return (
-    <AlertIncidentTabsInner canViewAlerts={canViewAlerts} canViewIncidents={canViewIncidents} switchRef={switchRef} />
-  );
-}
-
-function AlertIncidentTabsInner({
-  canViewAlerts,
-  canViewIncidents,
+export function AlertIncidentTabs({
+  alertsData,
+  incidentsData,
+  team,
+  setTeam,
   switchRef,
 }: {
-  canViewAlerts: boolean;
-  canViewIncidents: boolean;
+  alertsData: FiringAlertsData;
+  incidentsData: IncidentsData;
+  team: string | undefined;
+  setTeam: (team: string | undefined) => void;
   switchRef?: Ref<AlertIncidentSwitchHandle>;
 }) {
+  const canViewIncidents = !!incidentsData.enabled;
+  const canViewAlerts = alertsData.enabled;
+
   // Default to alerts tab if alerts are available, otherwise default to incidents tab
   const [activeTab, setActiveTab] = useState<TabId>(canViewAlerts ? ALERTS_TAB_ID : INCIDENTS_TAB_ID);
-  // Kept across tab switches so returning to the Alerts tab restores the filter.
-  const [selectedTeam, setSelectedTeam] = useState<string | undefined>();
-  const alertsData = useFiringAlerts(selectedTeam);
-  const incidentsData = useIncidents();
   const { count, hasAlerts, hasTeams, loading, canCreate, newRuleHref, viewAllHref, error } = alertsData;
   const {
     loading: incidentsLoading,
@@ -66,6 +52,7 @@ function AlertIncidentTabsInner({
     canDeclare: incidentsCanDeclare,
     canAccess: incidentsCanAccess,
   } = incidentsData;
+
   const isAlertActionsVisible = canViewAlerts && !loading && !error && activeTab === ALERTS_TAB_ID;
   const isIncidentsActionsVisible =
     canViewIncidents && !incidentsLoading && !incidentsError && activeTab === INCIDENTS_TAB_ID;
@@ -79,6 +66,11 @@ function AlertIncidentTabsInner({
       }
     },
   }));
+
+  // Hide the tabs if neither alerts nor incidents are available
+  if (!canViewAlerts && !canViewIncidents) {
+    return null;
+  }
 
   const title =
     canViewAlerts && canViewIncidents
@@ -112,6 +104,7 @@ function AlertIncidentTabsInner({
         ]
       : []),
   ];
+
   return (
     <Stack direction="column" gap={1} minWidth={0} ref={containerRef}>
       <Stack justifyContent="space-between" alignItems="center" minHeight={4}>
@@ -122,7 +115,7 @@ function AlertIncidentTabsInner({
           // Hidden rather than unmounted on the Incidents tab, so the combobox keeps
           // its fetched team values instead of refetching them on every tab switch.
           <div hidden={activeTab !== ALERTS_TAB_ID}>
-            <TeamFilterCombobox selectedTeam={selectedTeam} onChange={setSelectedTeam} userHasTeams={hasTeams} />
+            <TeamFilterCombobox selectedTeam={team} onChange={setTeam} userHasTeams={hasTeams} />
           </div>
         )}
       </Stack>
@@ -149,8 +142,8 @@ function AlertIncidentTabsInner({
             maxHeight={`${DASHBOARD_TABS_SCROLL_HEIGHT_REDESIGN}px`}
             minHeight={`${DASHBOARD_TABS_SCROLL_HEIGHT_REDESIGN}px`}
           >
-            {activeTab === ALERTS_TAB_ID && <FiringAlertsCardView data={alertsData} hideFooterActions />}
-            {activeTab === INCIDENTS_TAB_ID && <IncidentsCardView data={incidentsData} hideFooterActions />}
+            {activeTab === ALERTS_TAB_ID && <FiringAlertsCard data={alertsData} hideFooterActions />}
+            {activeTab === INCIDENTS_TAB_ID && <IncidentsCard data={incidentsData} hideFooterActions />}
           </ScrollContainer>
 
           <Box padding={1} paddingTop={1.5}>

--- a/public/app/features/home/AlertsIncidents/AlertIncidentTabs.tsx
+++ b/public/app/features/home/AlertsIncidents/AlertIncidentTabs.tsx
@@ -58,14 +58,18 @@ export function AlertIncidentTabs({
     canViewIncidents && !incidentsLoading && !incidentsError && activeTab === INCIDENTS_TAB_ID;
 
   const containerRef = useRef<HTMLDivElement>(null);
-  useImperativeHandle(switchRef, () => ({
-    switch: (tab: TabId, scroll = true) => {
-      setActiveTab(tab);
-      if (scroll) {
-        containerRef.current?.scrollIntoView({ behavior: 'smooth' });
-      }
-    },
-  }));
+  useImperativeHandle(
+    switchRef,
+    () => ({
+      switch: (tab: TabId, scroll = true) => {
+        setActiveTab(tab);
+        if (scroll) {
+          containerRef.current?.scrollIntoView({ behavior: 'smooth' });
+        }
+      },
+    }),
+    []
+  );
 
   // Hide the tabs if neither alerts nor incidents are available
   if (!canViewAlerts && !canViewIncidents) {

--- a/public/app/features/home/AlertsIncidents/AlertIncidentTabs.tsx
+++ b/public/app/features/home/AlertsIncidents/AlertIncidentTabs.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useImperativeHandle, useRef, useState, type Ref } from 'react';
 
 import { t } from '@grafana/i18n';
 import { Box, ScrollContainer, Stack, Tab, TabContent, TabsBar, Text } from '@grafana/ui';
@@ -18,10 +18,15 @@ import { TeamFilterCombobox } from './TeamFilterCombobox';
 import { canViewFiringAlerts, useFiringAlerts } from './useFiringAlerts';
 import { useIncidents } from './useIncidents';
 
-const ALERTS_TAB_ID = 'firing-alerts';
-const INCIDENTS_TAB_ID = 'incidents';
+export const ALERTS_TAB_ID = 'firing-alerts' as const;
+export const INCIDENTS_TAB_ID = 'incidents' as const;
 
-export function AlertIncidentTabs() {
+type TabId = typeof ALERTS_TAB_ID | typeof INCIDENTS_TAB_ID;
+export type AlertIncidentSwitchHandle = {
+  switch: (tab: TabId, scroll?: boolean) => void;
+};
+
+export function AlertIncidentTabs({ switchRef }: { switchRef?: Ref<AlertIncidentSwitchHandle> }) {
   const { installed, loading } = usePluginBridge(SupportedPlugin.Irm);
   const canViewIncidents = Boolean(installed && !loading);
   const canViewAlerts = canViewFiringAlerts();
@@ -31,18 +36,22 @@ export function AlertIncidentTabs() {
     return null;
   }
 
-  return <AlertIncidentTabsInner canViewAlerts={canViewAlerts} canViewIncidents={canViewIncidents} />;
+  return (
+    <AlertIncidentTabsInner canViewAlerts={canViewAlerts} canViewIncidents={canViewIncidents} switchRef={switchRef} />
+  );
 }
 
 function AlertIncidentTabsInner({
   canViewAlerts,
   canViewIncidents,
+  switchRef,
 }: {
   canViewAlerts: boolean;
   canViewIncidents: boolean;
+  switchRef?: Ref<AlertIncidentSwitchHandle>;
 }) {
   // Default to alerts tab if alerts are available, otherwise default to incidents tab
-  const [activeTab, setActiveTab] = useState(canViewAlerts ? ALERTS_TAB_ID : INCIDENTS_TAB_ID);
+  const [activeTab, setActiveTab] = useState<TabId>(canViewAlerts ? ALERTS_TAB_ID : INCIDENTS_TAB_ID);
   // Kept across tab switches so returning to the Alerts tab restores the filter.
   const [selectedTeam, setSelectedTeam] = useState<string | undefined>();
   const alertsData = useFiringAlerts(selectedTeam);
@@ -60,6 +69,16 @@ function AlertIncidentTabsInner({
   const isAlertActionsVisible = canViewAlerts && !loading && !error && activeTab === ALERTS_TAB_ID;
   const isIncidentsActionsVisible =
     canViewIncidents && !incidentsLoading && !incidentsError && activeTab === INCIDENTS_TAB_ID;
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  useImperativeHandle(switchRef, () => ({
+    switch: (tab: TabId, scroll = true) => {
+      setActiveTab(tab);
+      if (scroll) {
+        containerRef.current?.scrollIntoView({ behavior: 'smooth' });
+      }
+    },
+  }));
 
   const title =
     canViewAlerts && canViewIncidents
@@ -94,7 +113,7 @@ function AlertIncidentTabsInner({
       : []),
   ];
   return (
-    <Stack direction="column" gap={1} minWidth={0}>
+    <Stack direction="column" gap={1} minWidth={0} ref={containerRef}>
       <Stack justifyContent="space-between" alignItems="center" minHeight={4}>
         <Text element="h2" variant="h5">
           {title}

--- a/public/app/features/home/AlertsIncidents/FiringAlertsCard.test.tsx
+++ b/public/app/features/home/AlertsIncidents/FiringAlertsCard.test.tsx
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from 'msw';
-import { render, screen } from 'test/test-utils';
+import { render, screen, waitFor } from 'test/test-utils';
 
 import { config, setBackendSrv, setPluginComponentsHook } from '@grafana/runtime';
 import server, { setupMockServer } from '@grafana/test-utils/server';
@@ -13,6 +13,7 @@ import { ctaClicked } from '../analytics/main';
 
 import { FiringAlertsCard } from './FiringAlertsCard';
 import { HOME_CARD_MAX_ITEMS } from './constants';
+import { useFiringAlerts } from './useFiringAlerts';
 
 jest.mock('../analytics/main', () => ({
   ctaClicked: jest.fn(),
@@ -73,19 +74,24 @@ afterEach(() => {
   config.appSubUrl = '';
 });
 
+function FiringAlertsCardWithData() {
+  const data = useFiringAlerts();
+  return data.enabled ? <FiringAlertsCard data={data} /> : null;
+}
+
 describe('FiringAlertsCard', () => {
-  it('renders null when user lacks AlertingInstanceRead permission', () => {
+  it('renders null when user lacks AlertingInstanceRead permission', async () => {
     jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(false);
 
-    const { container } = render(<FiringAlertsCard />);
-    expect(container).toBeEmptyDOMElement();
+    const { container } = render(<FiringAlertsCardWithData />);
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
   });
 
   it('renders alerts sorted by severity', async () => {
     mockTeams([]);
     mockAlerts([warningAlert, criticalAlert, highAlert]);
 
-    render(<FiringAlertsCard />);
+    render(<FiringAlertsCardWithData />);
 
     expect(await screen.findByText('CPU Critical')).toBeInTheDocument();
 
@@ -101,7 +107,7 @@ describe('FiringAlertsCard', () => {
     mockTeams([]);
     mockAlerts([criticalAlert, highAlert]);
 
-    render(<FiringAlertsCard />);
+    render(<FiringAlertsCardWithData />);
 
     expect(await screen.findByText('CPU Critical')).toBeInTheDocument();
 
@@ -117,7 +123,7 @@ describe('FiringAlertsCard', () => {
     mockTeams([]);
     mockAlerts([linkedAlert]);
 
-    render(<FiringAlertsCard />);
+    render(<FiringAlertsCardWithData />);
 
     expect(await screen.findByRole('link', { name: /^Linked alert/ })).toHaveAttribute(
       'href',
@@ -129,7 +135,7 @@ describe('FiringAlertsCard', () => {
     mockTeams([]);
     mockAlerts([critAliasAlert, sev2Alert]);
 
-    render(<FiringAlertsCard />);
+    render(<FiringAlertsCardWithData />);
 
     expect(await screen.findByText('Crit Alias')).toBeInTheDocument();
 
@@ -143,7 +149,7 @@ describe('FiringAlertsCard', () => {
     mockTeams([]);
     mockAlerts([noSeverityAlert]);
 
-    render(<FiringAlertsCard />);
+    render(<FiringAlertsCardWithData />);
 
     expect(await screen.findByText('No Severity')).toBeInTheDocument();
     expect(await screen.findByText('Unknown')).toBeInTheDocument();
@@ -164,7 +170,7 @@ describe('FiringAlertsCard', () => {
       })
     );
 
-    render(<FiringAlertsCard />);
+    render(<FiringAlertsCardWithData />);
 
     expect(await screen.findByText('CPU Critical')).toBeInTheDocument();
 
@@ -188,7 +194,7 @@ describe('FiringAlertsCard', () => {
       })
     );
 
-    render(<FiringAlertsCard />);
+    render(<FiringAlertsCardWithData />);
 
     expect(await screen.findByText('CPU Critical')).toBeInTheDocument();
 
@@ -203,7 +209,7 @@ describe('FiringAlertsCard', () => {
     mockTeams([{ name: 'empty-team' }]);
     mockAlerts([]);
 
-    render(<FiringAlertsCard />);
+    render(<FiringAlertsCardWithData />);
 
     expect(await screen.findByText('No firing alerts for your teams.')).toBeInTheDocument();
 
@@ -214,7 +220,7 @@ describe('FiringAlertsCard', () => {
     mockTeams([]);
     mockAlerts([]);
 
-    render(<FiringAlertsCard />);
+    render(<FiringAlertsCardWithData />);
 
     expect(await screen.findByText('You have no firing alerts.')).toBeInTheDocument();
   });
@@ -231,7 +237,7 @@ describe('FiringAlertsCard', () => {
     );
     mockAlerts(many);
 
-    render(<FiringAlertsCard />);
+    render(<FiringAlertsCardWithData />);
 
     expect(await screen.findByText('Alert 0')).toBeInTheDocument();
     // Render is capped even though one more alert is firing...
@@ -250,7 +256,7 @@ describe('FiringAlertsCard', () => {
     mockTeams([]);
     mockAlerts([criticalAlert]);
 
-    render(<FiringAlertsCard />);
+    render(<FiringAlertsCardWithData />);
 
     expect(await screen.findByRole('link', { name: /create an alert rule/i })).toHaveAttribute(
       'href',
@@ -269,7 +275,7 @@ describe('FiringAlertsCard', () => {
     mockTeams([]);
     mockAlerts([]);
 
-    render(<FiringAlertsCard />);
+    render(<FiringAlertsCardWithData />);
 
     expect(await screen.findByRole('link', { name: /create an alert rule/i })).toHaveAttribute(
       'href',
@@ -283,7 +289,7 @@ describe('FiringAlertsCard', () => {
     mockTeams([]);
     mockAlerts([criticalAlert]);
 
-    render(<FiringAlertsCard />);
+    render(<FiringAlertsCardWithData />);
 
     expect(await screen.findByText('CPU Critical')).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: /create an alert rule/i })).not.toBeInTheDocument();
@@ -300,7 +306,7 @@ describe('FiringAlertsCard', () => {
     mockTeams([]);
     mockAlerts([criticalAlert]);
 
-    render(<FiringAlertsCard />);
+    render(<FiringAlertsCardWithData />);
 
     expect(await screen.findByRole('link', { name: /create an alert rule/i })).toHaveAttribute(
       'href',
@@ -323,7 +329,7 @@ describe('FiringAlertsCard', () => {
     mockTeams([]);
     mockAlerts([]);
 
-    render(<FiringAlertsCard />);
+    render(<FiringAlertsCardWithData />);
 
     expect(await screen.findByRole('link', { name: /create an alert rule/i })).toHaveAttribute(
       'href',
@@ -356,7 +362,7 @@ describe('FiringAlertsCard', () => {
       mockTeams([]);
       mockAlerts([linkedAlert]);
 
-      const { user } = render(<FiringAlertsCard />);
+      const { user } = render(<FiringAlertsCardWithData />);
 
       await user.click(await screen.findByRole('link', { name: /^Linked alert/ }));
 
@@ -377,7 +383,7 @@ describe('FiringAlertsCard', () => {
       mockTeams([]);
       mockAlerts([]);
 
-      const { user } = render(<FiringAlertsCard />);
+      const { user } = render(<FiringAlertsCardWithData />);
 
       await user.click(await screen.findByRole('link', { name: /create an alert rule/i }));
 
@@ -398,7 +404,7 @@ describe('FiringAlertsCard', () => {
       mockTeams([]);
       mockAlerts([criticalAlert]);
 
-      const { user } = render(<FiringAlertsCard />);
+      const { user } = render(<FiringAlertsCardWithData />);
 
       await user.click(await screen.findByRole('link', { name: /create an alert rule/i }));
       expect(jest.mocked(ctaClicked)).toHaveBeenCalledWith({
@@ -419,7 +425,7 @@ describe('FiringAlertsCard', () => {
       mockTeams([]);
       mockAlerts([]);
 
-      const { user } = render(<FiringAlertsCard />);
+      const { user } = render(<FiringAlertsCardWithData />);
 
       await user.click(await screen.findByRole('link', { name: /view all alert rules/i }));
 

--- a/public/app/features/home/AlertsIncidents/FiringAlertsCard.tsx
+++ b/public/app/features/home/AlertsIncidents/FiringAlertsCard.tsx
@@ -12,7 +12,7 @@ import { ctaClicked } from '../analytics/main';
 import { CreateAndViewAlertsButtons } from './CreateAndViewAlertsButtons';
 import { SummaryCard, SummaryCardAge, SummaryCardPrefix } from './SummaryCard';
 import { severityLevelColor } from './severity';
-import { canViewFiringAlerts, useFiringAlerts, type FiringAlertsData } from './useFiringAlerts';
+import { type FiringAlertsData } from './useFiringAlerts';
 
 /** Extract the path (with query string) from an absolute generatorURL, falling back to the raw value. */
 function alertDetailHref(alert: AlertmanagerAlert) {
@@ -65,25 +65,8 @@ function emptyMessage(selectedTeam: string | undefined, hasTeams: boolean): stri
   return t('home.firing-alerts-card.empty', 'You have no firing alerts.');
 }
 
-export function FiringAlertsCard() {
-  if (!canViewFiringAlerts()) {
-    return null;
-  }
-
-  return <FiringAlertsCardInner />;
-}
-
-/**
- * Inner component avoids calling hooks conditionally —
- * the permission gate is in the parent wrapper.
- */
-function FiringAlertsCardInner() {
-  const data = useFiringAlerts();
-  return <FiringAlertsCardView data={data} />;
-}
-
 /** Render-only card body; data comes from useFiringAlerts so callers control where the hook runs. */
-export function FiringAlertsCardView({
+export function FiringAlertsCard({
   data,
   hideFooterActions = false,
 }: {

--- a/public/app/features/home/AlertsIncidents/IncidentsCard.test.tsx
+++ b/public/app/features/home/AlertsIncidents/IncidentsCard.test.tsx
@@ -16,6 +16,7 @@ import { configureStore } from 'app/store/configureStore';
 import { ctaClicked } from '../analytics/main';
 
 import { IncidentsCard } from './IncidentsCard';
+import { useIncidents } from './useIncidents';
 
 jest.mock('app/features/alerting/unified/hooks/usePluginBridge', () => ({
   ...jest.requireActual('app/features/alerting/unified/hooks/usePluginBridge'),
@@ -72,11 +73,16 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
+function IncidentsCardWithData() {
+  const data = useIncidents();
+  return <IncidentsCard data={data} />;
+}
+
 describe('IncidentsCard', () => {
   it('lists active incidents with severity, count badge, and detail links', async () => {
     mockIncidents(activeIncidents);
 
-    render(<IncidentsCard />);
+    render(<IncidentsCardWithData />);
 
     expect(await screen.findByText('Database outage')).toBeInTheDocument();
     expect(screen.getByText('Elevated latency')).toBeInTheDocument();
@@ -102,7 +108,7 @@ describe('IncidentsCard', () => {
   it('shows the declare CTA in the empty state', async () => {
     mockIncidents([]);
 
-    render(<IncidentsCard />);
+    render(<IncidentsCardWithData />);
 
     expect(await screen.findByRole('link', { name: /declare an incident/i })).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: 'Database outage' })).not.toBeInTheDocument();
@@ -111,7 +117,7 @@ describe('IncidentsCard', () => {
   it('treats a 404 (org not onboarded) as the empty state, not an error', async () => {
     server.use(http.post(QUERY_PREVIEWS_PATH, () => new HttpResponse(null, { status: 404 })));
 
-    render(<IncidentsCard />);
+    render(<IncidentsCardWithData />);
 
     expect(await screen.findByRole('link', { name: /declare an incident/i })).toBeInTheDocument();
     expect(screen.queryByText('Could not load active incidents')).not.toBeInTheDocument();
@@ -120,7 +126,7 @@ describe('IncidentsCard', () => {
   it('shows a retryable error for genuine failures (5xx)', async () => {
     server.use(http.post(QUERY_PREVIEWS_PATH, () => new HttpResponse(null, { status: 500 })));
 
-    render(<IncidentsCard />);
+    render(<IncidentsCardWithData />);
 
     expect(await screen.findByText('Could not load active incidents')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
@@ -146,7 +152,7 @@ describe('IncidentsCard', () => {
     });
     mockIncidents(activeIncidents);
 
-    render(<IncidentsCard />);
+    render(<IncidentsCardWithData />);
 
     expect(await screen.findByText('Database outage')).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: 'Database outage' })).not.toBeInTheDocument();
@@ -162,7 +168,7 @@ describe('IncidentsCard', () => {
     }));
     mockIncidents(many, { hasMore: true });
 
-    render(<IncidentsCard />);
+    render(<IncidentsCardWithData />);
 
     expect(await screen.findByText(`${ACTIVE_INCIDENTS_QUERY_LIMIT}+`)).toBeInTheDocument();
   });
@@ -176,7 +182,7 @@ describe('IncidentsCard', () => {
     }));
     mockIncidents(many, { hasMore: false });
 
-    render(<IncidentsCard />);
+    render(<IncidentsCardWithData />);
 
     expect(await screen.findByText(String(ACTIVE_INCIDENTS_QUERY_LIMIT))).toBeInTheDocument();
     expect(screen.queryByText(`${ACTIVE_INCIDENTS_QUERY_LIMIT}+`)).not.toBeInTheDocument();
@@ -191,7 +197,7 @@ describe('IncidentsCard', () => {
     }));
     mockIncidents(many);
 
-    render(<IncidentsCard />);
+    render(<IncidentsCardWithData />);
 
     expect(await screen.findByText('Incident 0')).toBeInTheDocument();
     expect(screen.getAllByRole('listitem')).toHaveLength(8);
@@ -200,7 +206,7 @@ describe('IncidentsCard', () => {
   it('shows a Declare CTA in the empty state when the user can declare', async () => {
     mockIncidents([]);
 
-    render(<IncidentsCard />);
+    render(<IncidentsCardWithData />);
 
     expect(await screen.findByRole('link', { name: /declare an incident/i })).toHaveAttribute(
       'href',
@@ -228,7 +234,7 @@ describe('IncidentsCard', () => {
     });
     mockIncidents([]);
 
-    render(<IncidentsCard />);
+    render(<IncidentsCardWithData />);
 
     expect(await screen.findByText('No active incidents.')).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: /declare an incident/i })).not.toBeInTheDocument();
@@ -250,7 +256,7 @@ describe('IncidentsCard', () => {
       },
     ]);
 
-    render(<IncidentsCard />);
+    render(<IncidentsCardWithData />);
 
     expect(await screen.findByText('Warning but newer')).toBeInTheDocument();
 
@@ -263,7 +269,7 @@ describe('IncidentsCard', () => {
     const store = configureStore();
     mockIncidents([]);
 
-    const { unmount } = render(<IncidentsCard />, { store });
+    const { unmount } = render(<IncidentsCardWithData />, { store });
     // The declare CTA only renders once the first query resolves as empty (not while loading).
     expect(await screen.findByRole('link', { name: /declare an incident/i })).toBeInTheDocument();
 
@@ -271,7 +277,7 @@ describe('IncidentsCard', () => {
 
     // Incident declared out-of-band in the IRM plugin; user returns to Home (card remounts).
     mockIncidents([activeIncidents[0]]);
-    render(<IncidentsCard />, { store });
+    render(<IncidentsCardWithData />, { store });
 
     // refetchOnMountOrArgChange forces a refetch on remount; without it the stale empty
     // cache would persist and this assertion would time out.
@@ -293,7 +299,7 @@ describe('IncidentsCard', () => {
     it('tracks incident_detail when an incident title link is clicked', async () => {
       mockIncidents(activeIncidents);
 
-      const { user } = render(<IncidentsCard />);
+      const { user } = render(<IncidentsCardWithData />);
 
       await user.click(await screen.findByRole('link', { name: 'Database outage' }));
 
@@ -307,7 +313,7 @@ describe('IncidentsCard', () => {
     it('tracks declare_incident from the empty-state CTA', async () => {
       mockIncidents([]);
 
-      const { user } = render(<IncidentsCard />);
+      const { user } = render(<IncidentsCardWithData />);
 
       await user.click(await screen.findByRole('link', { name: /declare an incident/i }));
 
@@ -321,7 +327,7 @@ describe('IncidentsCard', () => {
     it('tracks declare_incident from the footer when incidents exist', async () => {
       mockIncidents(activeIncidents);
 
-      const { user } = render(<IncidentsCard />);
+      const { user } = render(<IncidentsCardWithData />);
 
       await user.click(await screen.findByRole('link', { name: /declare an incident/i }));
 
@@ -335,7 +341,7 @@ describe('IncidentsCard', () => {
     it('tracks view_all_incidents from the footer', async () => {
       mockIncidents(activeIncidents);
 
-      const { user } = render(<IncidentsCard />);
+      const { user } = render(<IncidentsCardWithData />);
 
       await user.click(await screen.findByRole('link', { name: /view all incidents/i }));
 

--- a/public/app/features/home/AlertsIncidents/IncidentsCard.tsx
+++ b/public/app/features/home/AlertsIncidents/IncidentsCard.tsx
@@ -12,15 +12,10 @@ import { ctaClicked } from '../analytics/main';
 import { DeclareAndViewIncidentsButtons } from './DeclareAndViewIncidentsButtons';
 import { SummaryCard, SummaryCardAge, SummaryCardPrefix } from './SummaryCard';
 import { severityLevelColor } from './severity';
-import { useIncidents, type IncidentsData } from './useIncidents';
-
-export function IncidentsCard() {
-  const data = useIncidents();
-  return <IncidentsCardView data={data} />;
-}
+import { type IncidentsData } from './useIncidents';
 
 /** Render-only card body; data comes from useIncidents so callers control where the hook runs. */
-export function IncidentsCardView({
+export function IncidentsCard({
   data,
   hideFooterActions = false,
 }: {

--- a/public/app/features/home/AlertsIncidents/useFiringAlerts.ts
+++ b/public/app/features/home/AlertsIncidents/useFiringAlerts.ts
@@ -163,6 +163,7 @@ export function useFiringAlerts(selectedTeam?: string) {
     hasTeams,
     // Echoed back so the card can scope its empty message to the filtered team.
     selectedTeam,
+    enabled,
     loading,
     error,
     refetch,

--- a/public/app/features/home/AlertsIncidents/useIncidents.ts
+++ b/public/app/features/home/AlertsIncidents/useIncidents.ts
@@ -63,6 +63,7 @@ export function useIncidents() {
     count,
     hasMore,
     hasIncidents,
+    enabled: pluginLoading ? undefined : !!installed,
     loading,
     error: loadError,
     refetch,

--- a/public/app/features/home/HeaderActions.test.tsx
+++ b/public/app/features/home/HeaderActions.test.tsx
@@ -1,0 +1,240 @@
+import { http, HttpResponse } from 'msw';
+import { type RefObject } from 'react';
+import { render, screen, waitFor, within } from 'test/test-utils';
+
+import { setBackendSrv, setPluginComponentsHook } from '@grafana/runtime';
+import { invalidateCachedPromisesCache } from '@grafana/runtime/internal';
+import server, { setupMockServer } from '@grafana/test-utils/server';
+import { backendSrv } from 'app/core/services/backend_srv';
+import { contextSrv } from 'app/core/services/context_srv';
+import { ACTIVE_INCIDENTS_QUERY_LIMIT, type IncidentPreview } from 'app/features/alerting/unified/api/incidentsApi';
+import {
+  installAppPluginMeta,
+  pluginMeta,
+  uninstallAppPluginMeta,
+} from 'app/features/alerting/unified/testSetup/plugins';
+import { SupportedPlugin } from 'app/features/alerting/unified/types/pluginBridges';
+import { AlertState, type AlertmanagerAlert } from 'app/plugins/datasource/alertmanager/types';
+import { AccessControlAction } from 'app/types/accessControl';
+
+import { ALERTS_TAB_ID, INCIDENTS_TAB_ID, type AlertIncidentSwitchHandle } from './AlertsIncidents/AlertIncidentTabs';
+import { useFiringAlerts } from './AlertsIncidents/useFiringAlerts';
+import { useIncidents } from './AlertsIncidents/useIncidents';
+import { HeaderActions } from './HeaderActions';
+import { ctaClicked } from './analytics/main';
+
+jest.mock('./analytics/main', () => ({
+  ctaClicked: jest.fn(),
+  tabChanged: jest.fn(),
+  clearHistoryClicked: jest.fn(),
+  homepageViewed: jest.fn(),
+}));
+
+setBackendSrv(backendSrv);
+setupMockServer();
+
+function makeAlert(overrides: Partial<AlertmanagerAlert> & { labels: AlertmanagerAlert['labels'] }): AlertmanagerAlert {
+  return {
+    startsAt: new Date(Date.now() - 60_000).toISOString(),
+    updatedAt: new Date().toISOString(),
+    endsAt: '0001-01-01T00:00:00Z',
+    fingerprint: Math.random().toString(36).slice(2),
+    receivers: [{ name: 'default' }],
+    status: { state: AlertState.Active, silencedBy: [], inhibitedBy: [] },
+    annotations: {},
+    ...overrides,
+    labels: { alertname: 'test', ...overrides.labels },
+  };
+}
+
+function mockAlerts(alerts: AlertmanagerAlert[]) {
+  server.use(http.get('/api/alertmanager/:datasourceUid/api/v2/alerts', () => HttpResponse.json(alerts)));
+}
+
+function mockNoIrmPlugin() {
+  uninstallAppPluginMeta(SupportedPlugin.Irm);
+  server.use(http.get('/api/plugins/:pluginId/settings', () => HttpResponse.json({ enabled: false })));
+}
+
+function mockIrmPlugin() {
+  installAppPluginMeta(pluginMeta[SupportedPlugin.Irm]);
+  server.use(
+    http.get(`/api/plugins/${SupportedPlugin.Irm}/settings`, () =>
+      HttpResponse.json({ ...pluginMeta[SupportedPlugin.Irm], includes: [] })
+    )
+  );
+}
+
+function mockIncidents(incidents: IncidentPreview[], { hasMore = false } = {}) {
+  server.use(
+    http.post('/api/plugins/:pluginId/resources/api/v1/IncidentsService.QueryIncidentPreviews', () =>
+      HttpResponse.json({ incidentPreviews: incidents, cursor: { hasMore, nextValue: hasMore ? 'next' : '' } })
+    )
+  );
+}
+
+const noopRef = { current: null } satisfies RefObject<AlertIncidentSwitchHandle | null>;
+
+function HeaderActionsWithData({
+  switchRef = noopRef,
+}: {
+  switchRef?: RefObject<AlertIncidentSwitchHandle | null>;
+} = {}) {
+  const alertsData = useFiringAlerts();
+  const incidentsData = useIncidents();
+  return <HeaderActions alertsData={alertsData} incidentsData={incidentsData} alertIncidentRef={switchRef} />;
+}
+
+beforeEach(() => {
+  setPluginComponentsHook(() => ({ components: [], isLoading: false }));
+  jest
+    .spyOn(contextSrv, 'hasPermission')
+    .mockImplementation((action: string) => action === AccessControlAction.AlertingInstanceRead);
+  server.use(http.get('/api/user/teams', () => HttpResponse.json([])));
+  mockAlerts([]);
+  mockNoIrmPlugin();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  invalidateCachedPromisesCache();
+});
+
+describe('HeaderActions', () => {
+  it('renders nothing when the user lacks alerting permission and IRM is not installed', async () => {
+    jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(false);
+
+    const { container } = render(<HeaderActionsWithData />);
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
+  });
+
+  it('renders the firing alerts button when the user has alerting permission', async () => {
+    render(<HeaderActionsWithData />);
+    expect(await screen.findByRole('button', { name: /firing alerts/i })).toBeInTheDocument();
+  });
+
+  it('shows "All clear" on the firing alerts button when there are no alerts', async () => {
+    render(<HeaderActionsWithData />);
+    const button = await screen.findByRole('button', { name: /firing alerts/i });
+    await waitFor(() => expect(within(button).getByText('All clear')).toBeInTheDocument());
+  });
+
+  it('shows the total alert count on the firing alerts button', async () => {
+    mockAlerts([
+      makeAlert({ labels: { alertname: 'CPU Critical', severity: 'critical' } }),
+      makeAlert({ labels: { alertname: 'Memory High', severity: 'high' } }),
+      makeAlert({ labels: { alertname: 'Disk Warning', severity: 'warning' } }),
+    ]);
+
+    render(<HeaderActionsWithData />);
+
+    const button = await screen.findByRole('button', { name: /firing alerts/i });
+    await waitFor(() => expect(within(button).getByText('3')).toBeInTheDocument());
+  });
+
+  it('shows critical and high severity counts alongside SeverityBars', async () => {
+    mockAlerts([
+      makeAlert({ labels: { alertname: 'CPU Critical', severity: 'critical' } }),
+      makeAlert({ labels: { alertname: 'Memory High', severity: 'high' } }),
+    ]);
+
+    render(<HeaderActionsWithData />);
+
+    const button = await screen.findByRole('button', { name: /firing alerts/i });
+    await waitFor(() => {
+      // Total count
+      expect(within(button).getByText('2')).toBeInTheDocument();
+      // One count per severity level (critical=1, high=1)
+      expect(within(button).getAllByText('1')).toHaveLength(2);
+    });
+  });
+
+  it('does not render the incidents button when IRM is not installed', async () => {
+    render(<HeaderActionsWithData />);
+
+    await screen.findByRole('button', { name: /firing alerts/i });
+    // IRM plugin bridge settles asynchronously; give it time before asserting absence
+    await waitFor(() => expect(screen.queryByRole('button', { name: /active incidents/i })).not.toBeInTheDocument());
+  });
+
+  it('renders the incidents button when IRM is installed', async () => {
+    mockIrmPlugin();
+    mockIncidents([]);
+
+    render(<HeaderActionsWithData />);
+
+    expect(await screen.findByRole('button', { name: /active incidents/i })).toBeInTheDocument();
+  });
+
+  it('shows "All clear" on the incidents button when there are no active incidents', async () => {
+    mockIrmPlugin();
+    mockIncidents([]);
+
+    render(<HeaderActionsWithData />);
+
+    const button = await screen.findByRole('button', { name: /active incidents/i });
+    await waitFor(() => expect(within(button).getByText('All clear')).toBeInTheDocument());
+  });
+
+  it('shows the active incident count on the incidents button', async () => {
+    mockIrmPlugin();
+    mockIncidents([
+      { incidentID: '1', title: 'Database outage', severityLabel: 'Critical', createdTime: '2024-01-02T10:00:00Z' },
+      { incidentID: '2', title: 'Elevated latency', severityLabel: 'High', createdTime: '2024-01-01T09:00:00Z' },
+    ]);
+
+    render(<HeaderActionsWithData />);
+
+    const button = await screen.findByRole('button', { name: /active incidents/i });
+    await waitFor(() => expect(within(button).getByText('2')).toBeInTheDocument());
+  });
+
+  it("shows 'N+' on the incidents button when the server reports more incidents beyond the query limit", async () => {
+    jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(false);
+    mockIrmPlugin();
+    mockIncidents(
+      Array.from({ length: ACTIVE_INCIDENTS_QUERY_LIMIT }, (_, i) => ({
+        incidentID: String(i),
+        title: `Incident ${i}`,
+        severityLabel: 'Critical',
+        createdTime: '2024-01-02T10:00:00Z',
+      })),
+      { hasMore: true }
+    );
+
+    render(<HeaderActionsWithData />);
+
+    const button = await screen.findByRole('button', { name: /active incidents/i });
+    await waitFor(() => expect(within(button).getByText(`${ACTIVE_INCIDENTS_QUERY_LIMIT}+`)).toBeInTheDocument());
+  });
+
+  it('clicking the firing alerts button switches to the alerts tab', async () => {
+    const switchFn = jest.fn();
+
+    const { user } = render(<HeaderActionsWithData switchRef={{ current: { switch: switchFn } }} />);
+
+    await user.click(await screen.findByRole('button', { name: /firing alerts/i }));
+    expect(switchFn).toHaveBeenCalledWith(ALERTS_TAB_ID);
+    expect(ctaClicked).toHaveBeenCalledWith({
+      surface: 'header',
+      action: 'view_alerts',
+      placement: 'pill',
+    });
+  });
+
+  it('clicking the incidents button switches to the incidents tab', async () => {
+    mockIrmPlugin();
+    mockIncidents([]);
+    const switchFn = jest.fn();
+
+    const { user } = render(<HeaderActionsWithData switchRef={{ current: { switch: switchFn } }} />);
+
+    await user.click(await screen.findByRole('button', { name: /active incidents/i }));
+    expect(switchFn).toHaveBeenCalledWith(INCIDENTS_TAB_ID);
+    expect(ctaClicked).toHaveBeenCalledWith({
+      surface: 'header',
+      action: 'view_incidents',
+      placement: 'pill',
+    });
+  });
+});

--- a/public/app/features/home/HeaderActions.tsx
+++ b/public/app/features/home/HeaderActions.tsx
@@ -3,7 +3,7 @@ import { type RefObject } from 'react';
 
 import { locale, type GrafanaTheme2 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
-import { Button, ButtonGroup, Stack, Text, useStyles2 } from '@grafana/ui';
+import { Button, ButtonGroup, Icon, Stack, Text, useStyles2 } from '@grafana/ui';
 import { SeverityBars } from 'app/features/alerting/unified/triage/scene/filters/SeverityBars';
 
 import { ALERTS_TAB_ID, INCIDENTS_TAB_ID, type AlertIncidentSwitchHandle } from './AlertsIncidents/AlertIncidentTabs';
@@ -22,7 +22,7 @@ export function HeaderActions({
 }) {
   const styles = useStyles2(getStyles);
 
-  const canViewIncidents = !!incidentsData.enabled && !incidentsData.loading;
+  const canViewIncidents = !!incidentsData.enabled;
   const canViewAlerts = alertsData.enabled;
 
   // Hide the overview if neither alerts nor incidents are available
@@ -32,7 +32,7 @@ export function HeaderActions({
 
   return (
     <ButtonGroup className={styles.group}>
-      {canViewAlerts && (
+      {canViewAlerts && !alertsData.error && (
         <Button
           variant="secondary"
           tooltip={t('home.header-actions.firing-alerts', 'Firing alerts')}
@@ -50,7 +50,9 @@ export function HeaderActions({
           }}
         >
           <Stack direction="row" alignItems="center" gap={1}>
-            {alertsData.count === 0 ? (
+            {alertsData.loading ? (
+              <Icon name="spinner" />
+            ) : alertsData.count === 0 ? (
               <Text variant="bodySmall" color="secondary">
                 <Trans i18nKey="home.header-actions.no-firing-alerts">All clear</Trans>
               </Text>
@@ -81,7 +83,7 @@ export function HeaderActions({
         </Button>
       )}
 
-      {canViewIncidents && (
+      {canViewIncidents && !incidentsData.error && (
         <Button
           variant="secondary"
           tooltip={t('home.header-actions.active-incidents', 'Active incidents')}
@@ -99,7 +101,9 @@ export function HeaderActions({
           }}
         >
           <Stack direction="row" alignItems="center" gap={1}>
-            {incidentsData.count === 0 ? (
+            {incidentsData.loading ? (
+              <Icon name="spinner" />
+            ) : incidentsData.count === 0 ? (
               <Text variant="bodySmall" color="secondary">
                 <Trans i18nKey="home.header-actions.no-active-incidents">All clear</Trans>
               </Text>

--- a/public/app/features/home/HeaderActions.tsx
+++ b/public/app/features/home/HeaderActions.tsx
@@ -1,10 +1,15 @@
+import { css } from '@emotion/css';
+
+import { type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { Button, ButtonGroup, Stack, Text } from '@grafana/ui';
+import { Button, ButtonGroup, Stack, Text, useStyles2 } from '@grafana/ui';
 import { SeverityBars } from 'app/features/alerting/unified/triage/scene/filters/SeverityBars';
 
 export function HeaderActions() {
+  const styles = useStyles2(getStyles);
+
   return (
-    <ButtonGroup>
+    <ButtonGroup className={styles.group}>
       <Button
         variant="secondary"
         tooltip={t('home.header-actions.firing-alerts', 'Firing alerts')}
@@ -39,3 +44,9 @@ export function HeaderActions() {
     </ButtonGroup>
   );
 }
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  group: css({
+    marginTop: 'auto',
+  }),
+});

--- a/public/app/features/home/HeaderActions.tsx
+++ b/public/app/features/home/HeaderActions.tsx
@@ -1,70 +1,118 @@
 import { css } from '@emotion/css';
 import { type RefObject } from 'react';
 
-import { type GrafanaTheme2 } from '@grafana/data';
-import { t } from '@grafana/i18n';
+import { locale, type GrafanaTheme2 } from '@grafana/data';
+import { t, Trans } from '@grafana/i18n';
 import { Button, ButtonGroup, Stack, Text, useStyles2 } from '@grafana/ui';
 import { SeverityBars } from 'app/features/alerting/unified/triage/scene/filters/SeverityBars';
 
 import { ALERTS_TAB_ID, INCIDENTS_TAB_ID, type AlertIncidentSwitchHandle } from './AlertsIncidents/AlertIncidentTabs';
+import { type FiringAlertsData } from './AlertsIncidents/useFiringAlerts';
+import { type IncidentsData } from './AlertsIncidents/useIncidents';
 import { ctaClicked } from './analytics/main';
 
-export function HeaderActions({ alertIncidentRef }: { alertIncidentRef: RefObject<AlertIncidentSwitchHandle | null> }) {
+export function HeaderActions({
+  alertsData,
+  incidentsData,
+  alertIncidentRef,
+}: {
+  alertsData: FiringAlertsData;
+  incidentsData: IncidentsData;
+  alertIncidentRef: RefObject<AlertIncidentSwitchHandle | null>;
+}) {
   const styles = useStyles2(getStyles);
+
+  const canViewIncidents = !!incidentsData.enabled && !incidentsData.loading;
+  const canViewAlerts = alertsData.enabled;
+
+  // Hide the overview if neither alerts nor incidents are available
+  if (!canViewAlerts && !canViewIncidents) {
+    return null;
+  }
 
   return (
     <ButtonGroup className={styles.group}>
-      <Button
-        variant="secondary"
-        tooltip={t('home.header-actions.firing-alerts', 'Firing alerts')}
-        aria-label={t('home.header-actions.firing-alerts', 'Firing alerts')}
-        icon="bell"
-        onClick={() => {
-          if (alertIncidentRef.current) {
-            alertIncidentRef.current.switch(ALERTS_TAB_ID);
-            ctaClicked({
-              surface: 'header',
-              action: 'view_alerts',
-              placement: 'pill',
-            });
-          }
-        }}
-      >
-        <Stack direction="row" alignItems="center" gap={1}>
-          <Text>{58}</Text>
+      {canViewAlerts && (
+        <Button
+          variant="secondary"
+          tooltip={t('home.header-actions.firing-alerts', 'Firing alerts')}
+          aria-label={t('home.header-actions.firing-alerts', 'Firing alerts')}
+          icon="bell"
+          onClick={() => {
+            if (alertIncidentRef.current) {
+              alertIncidentRef.current.switch(ALERTS_TAB_ID);
+              ctaClicked({
+                surface: 'header',
+                action: 'view_alerts',
+                placement: 'pill',
+              });
+            }
+          }}
+        >
+          <Stack direction="row" alignItems="center" gap={1}>
+            {alertsData.count === 0 ? (
+              <Text variant="bodySmall" color="secondary">
+                <Trans i18nKey="home.header-actions.no-firing-alerts">All clear</Trans>
+              </Text>
+            ) : (
+              <>
+                <Text>{locale(alertsData.count, 0).text}</Text>
 
-          <Stack direction="row" alignItems="center" gap={0.5}>
-            <SeverityBars level="critical" />
-            <Text>{11}</Text>
+                {alertsData.criticalCount > 0 && (
+                  <Stack direction="row" alignItems="center" gap={0.5}>
+                    <SeverityBars level="critical" />
+                    <Text variant="bodySmall" color="secondary">
+                      {locale(alertsData.criticalCount, 0).text}
+                    </Text>
+                  </Stack>
+                )}
+
+                {alertsData.highCount > 0 && (
+                  <Stack direction="row" alignItems="center" gap={0.5}>
+                    <SeverityBars level="major" />
+                    <Text variant="bodySmall" color="secondary">
+                      {locale(alertsData.highCount, 0).text}
+                    </Text>
+                  </Stack>
+                )}
+              </>
+            )}
           </Stack>
+        </Button>
+      )}
 
-          <Stack direction="row" alignItems="center" gap={0.5}>
-            <SeverityBars level="major" />
-            <Text>{47}</Text>
+      {canViewIncidents && (
+        <Button
+          variant="secondary"
+          tooltip={t('home.header-actions.active-incidents', 'Active incidents')}
+          aria-label={t('home.header-actions.active-incidents', 'Active incidents')}
+          icon="fire"
+          onClick={() => {
+            if (alertIncidentRef.current) {
+              alertIncidentRef.current.switch(INCIDENTS_TAB_ID);
+              ctaClicked({
+                surface: 'header',
+                action: 'view_incidents',
+                placement: 'pill',
+              });
+            }
+          }}
+        >
+          <Stack direction="row" alignItems="center" gap={1}>
+            {incidentsData.count === 0 ? (
+              <Text variant="bodySmall" color="secondary">
+                <Trans i18nKey="home.header-actions.no-active-incidents">All clear</Trans>
+              </Text>
+            ) : (
+              <Text>
+                {incidentsData.hasMore
+                  ? `${locale(incidentsData.count, 0).text}+`
+                  : locale(incidentsData.count, 0).text}
+              </Text>
+            )}
           </Stack>
-        </Stack>
-      </Button>
-
-      <Button
-        variant="secondary"
-        tooltip={t('home.header-actions.active-incidents', 'Active incidents')}
-        aria-label={t('home.header-actions.active-incidents', 'Active incidents')}
-        icon="fire"
-        onClick={() => {
-          if (alertIncidentRef.current) {
-            alertIncidentRef.current.switch(INCIDENTS_TAB_ID);
-            ctaClicked({
-              surface: 'header',
-              action: 'view_incidents',
-              placement: 'pill',
-            });
-          }
-        }}
-      >
-        <Stack direction="row" alignItems="center" gap={1}>
-          <Text>{50}+</Text>
-        </Stack>
-      </Button>
+        </Button>
+      )}
     </ButtonGroup>
   );
 }

--- a/public/app/features/home/HeaderActions.tsx
+++ b/public/app/features/home/HeaderActions.tsx
@@ -1,11 +1,15 @@
 import { css } from '@emotion/css';
+import { type RefObject } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Button, ButtonGroup, Stack, Text, useStyles2 } from '@grafana/ui';
 import { SeverityBars } from 'app/features/alerting/unified/triage/scene/filters/SeverityBars';
 
-export function HeaderActions() {
+import { ALERTS_TAB_ID, INCIDENTS_TAB_ID, type AlertIncidentSwitchHandle } from './AlertsIncidents/AlertIncidentTabs';
+import { ctaClicked } from './analytics/main';
+
+export function HeaderActions({ alertIncidentRef }: { alertIncidentRef: RefObject<AlertIncidentSwitchHandle | null> }) {
   const styles = useStyles2(getStyles);
 
   return (
@@ -15,6 +19,16 @@ export function HeaderActions() {
         tooltip={t('home.header-actions.firing-alerts', 'Firing alerts')}
         aria-label={t('home.header-actions.firing-alerts', 'Firing alerts')}
         icon="bell"
+        onClick={() => {
+          if (alertIncidentRef.current) {
+            alertIncidentRef.current.switch(ALERTS_TAB_ID);
+            ctaClicked({
+              surface: 'header',
+              action: 'view_alerts',
+              placement: 'pill',
+            });
+          }
+        }}
       >
         <Stack direction="row" alignItems="center" gap={1}>
           <Text>{58}</Text>
@@ -36,6 +50,16 @@ export function HeaderActions() {
         tooltip={t('home.header-actions.active-incidents', 'Active incidents')}
         aria-label={t('home.header-actions.active-incidents', 'Active incidents')}
         icon="fire"
+        onClick={() => {
+          if (alertIncidentRef.current) {
+            alertIncidentRef.current.switch(INCIDENTS_TAB_ID);
+            ctaClicked({
+              surface: 'header',
+              action: 'view_incidents',
+              placement: 'pill',
+            });
+          }
+        }}
       >
         <Stack direction="row" alignItems="center" gap={1}>
           <Text>{50}+</Text>

--- a/public/app/features/home/HeaderActions.tsx
+++ b/public/app/features/home/HeaderActions.tsx
@@ -1,0 +1,41 @@
+import { t } from '@grafana/i18n';
+import { Button, ButtonGroup, Stack, Text } from '@grafana/ui';
+import { SeverityBars } from 'app/features/alerting/unified/triage/scene/filters/SeverityBars';
+
+export function HeaderActions() {
+  return (
+    <ButtonGroup>
+      <Button
+        variant="secondary"
+        tooltip={t('home.header-actions.firing-alerts', 'Firing alerts')}
+        aria-label={t('home.header-actions.firing-alerts', 'Firing alerts')}
+        icon="bell"
+      >
+        <Stack direction="row" alignItems="center" gap={1}>
+          <Text>{58}</Text>
+
+          <Stack direction="row" alignItems="center" gap={0.5}>
+            <SeverityBars level="critical" />
+            <Text>{11}</Text>
+          </Stack>
+
+          <Stack direction="row" alignItems="center" gap={0.5}>
+            <SeverityBars level="major" />
+            <Text>{47}</Text>
+          </Stack>
+        </Stack>
+      </Button>
+
+      <Button
+        variant="secondary"
+        tooltip={t('home.header-actions.active-incidents', 'Active incidents')}
+        aria-label={t('home.header-actions.active-incidents', 'Active incidents')}
+        icon="fire"
+      >
+        <Stack direction="row" alignItems="center" gap={1}>
+          <Text>{50}+</Text>
+        </Stack>
+      </Button>
+    </ButtonGroup>
+  );
+}

--- a/public/app/features/home/HomePage.tsx
+++ b/public/app/features/home/HomePage.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { Suspense, useCallback, useEffect, useRef } from 'react';
+import { Suspense, useCallback, useEffect, useRef, useState } from 'react';
 
 import { PageLayoutType, PluginExtensionPoints } from '@grafana/data';
 import { GrafanaEdition } from '@grafana/data/internal';
@@ -11,14 +11,12 @@ import { Page } from 'app/core/components/Page/Page';
 import { ASSISTANT_PLUGIN_ID, SETUPGUIDE_PLUGIN_ID } from 'app/core/constants';
 import { isOnPrem } from 'app/core/utils/isOnPrem';
 
-import { usePluginBridge } from '../alerting/unified/hooks/usePluginBridge';
-import { SupportedPlugin } from '../alerting/unified/types/pluginBridges';
-
 import { AlertIncidentTabs, type AlertIncidentSwitchHandle } from './AlertsIncidents/AlertIncidentTabs';
 import { FiringAlertsCard } from './AlertsIncidents/FiringAlertsCard';
 import { IncidentsCard } from './AlertsIncidents/IncidentsCard';
 import { NewsCard } from './AlertsIncidents/NewsCard';
-import { canViewFiringAlerts } from './AlertsIncidents/useFiringAlerts';
+import { useFiringAlerts } from './AlertsIncidents/useFiringAlerts';
+import { useIncidents } from './AlertsIncidents/useIncidents';
 import { DashboardTabs } from './DashboardTabs/DashboardTabs';
 import { type HomepageTabExtensionProps } from './DashboardTabs/types';
 import { HeaderActions } from './HeaderActions';
@@ -71,11 +69,13 @@ export default function HomePage() {
     extensionPointId: PluginExtensionPoints.HomepageTabs,
   });
 
+  const [team, setTeam] = useState<string>();
+  const alertsData = useFiringAlerts(team);
+  const incidentsData = useIncidents();
   const alertIncidentRef = useRef<AlertIncidentSwitchHandle | null>(null);
-  const irm = usePluginBridge(SupportedPlugin.Irm);
 
   const isWaitingForTabs = !redesignEnabled && isLoadingTabs;
-  const isWaitingForIRM = !redesignEnabled && irm.loading;
+  const isWaitingForIRM = !redesignEnabled && incidentsData.enabled === undefined;
   const isLoadingExtensions = isLoadingAssistant || isLoadingExtra || isWaitingForTabs || isWaitingForIRM;
 
   // The impression counts a rendered homepage, never a skeleton: the tracker mounts inside
@@ -107,8 +107,8 @@ export default function HomePage() {
       ),
   });
   const showExtra = extraContent !== null;
-  const showAlertsCard = canViewFiringAlerts();
-  const showIRMNewsCard = irm.loading || irm.installed || config.newsFeedEnabled;
+  const showAlertsCard = alertsData.enabled;
+  const showIRMNewsCard = incidentsData.enabled === undefined || incidentsData.enabled || config.newsFeedEnabled;
   const skeleton = (
     <HomePageSkeleton
       showAlertsCard={showAlertsCard}
@@ -156,7 +156,13 @@ export default function HomePage() {
                   <Grid gap={2} columns={{ xs: 1, md: 2 }}>
                     {/* Skip the HomepageTabs extension point for the redesign UI */}
                     <DashboardTabs extensionComponents={[]} />
-                    <AlertIncidentTabs switchRef={alertIncidentRef} />
+                    <AlertIncidentTabs
+                      alertsData={alertsData}
+                      incidentsData={incidentsData}
+                      team={team}
+                      setTeam={setTeam}
+                      switchRef={alertIncidentRef}
+                    />
                   </Grid>
                 </>
               ) : (
@@ -173,8 +179,12 @@ export default function HomePage() {
                   </HomeSection>
 
                   <Grid gap={2} columns={{ xs: 1, md: 2 }}>
-                    <FiringAlertsCard />
-                    {irm.installed ? <IncidentsCard /> : config.newsFeedEnabled && <NewsCard />}
+                    {alertsData.enabled && <FiringAlertsCard data={alertsData} />}
+                    {incidentsData.enabled ? (
+                      <IncidentsCard data={incidentsData} />
+                    ) : (
+                      config.newsFeedEnabled && <NewsCard />
+                    )}
                   </Grid>
                 </>
               )}

--- a/public/app/features/home/HomePage.tsx
+++ b/public/app/features/home/HomePage.tsx
@@ -126,7 +126,11 @@ export default function HomePage() {
         subTitle: t('home.home-page.placeholder', 'Welcome to {{edition}}.', { edition: getEdition() }),
         hideFromBreadcrumbs: true,
       }}
-      actions={redesignEnabled ? <HeaderActions alertIncidentRef={alertIncidentRef} /> : undefined}
+      actions={
+        redesignEnabled ? (
+          <HeaderActions alertsData={alertsData} incidentsData={incidentsData} alertIncidentRef={alertIncidentRef} />
+        ) : undefined
+      }
       layout={PageLayoutType.Home}
     >
       <Page.Contents>

--- a/public/app/features/home/HomePage.tsx
+++ b/public/app/features/home/HomePage.tsx
@@ -21,6 +21,7 @@ import { NewsCard } from './AlertsIncidents/NewsCard';
 import { canViewFiringAlerts } from './AlertsIncidents/useFiringAlerts';
 import { DashboardTabs } from './DashboardTabs/DashboardTabs';
 import { type HomepageTabExtensionProps } from './DashboardTabs/types';
+import { HeaderActions } from './HeaderActions';
 import { HomePageSkeleton } from './HomePageSkeleton';
 import { HomeSection } from './HomeSection';
 import { Overview } from './Overview/Overview';
@@ -124,6 +125,7 @@ export default function HomePage() {
         subTitle: t('home.home-page.placeholder', 'Welcome to {{edition}}.', { edition: getEdition() }),
         hideFromBreadcrumbs: true,
       }}
+      actions={redesignEnabled ? <HeaderActions /> : undefined}
       layout={PageLayoutType.Home}
     >
       <Page.Contents>

--- a/public/app/features/home/HomePage.tsx
+++ b/public/app/features/home/HomePage.tsx
@@ -14,7 +14,7 @@ import { isOnPrem } from 'app/core/utils/isOnPrem';
 import { usePluginBridge } from '../alerting/unified/hooks/usePluginBridge';
 import { SupportedPlugin } from '../alerting/unified/types/pluginBridges';
 
-import { AlertIncidentTabs } from './AlertsIncidents/AlertIncidentTabs';
+import { AlertIncidentTabs, type AlertIncidentSwitchHandle } from './AlertsIncidents/AlertIncidentTabs';
 import { FiringAlertsCard } from './AlertsIncidents/FiringAlertsCard';
 import { IncidentsCard } from './AlertsIncidents/IncidentsCard';
 import { NewsCard } from './AlertsIncidents/NewsCard';
@@ -71,6 +71,7 @@ export default function HomePage() {
     extensionPointId: PluginExtensionPoints.HomepageTabs,
   });
 
+  const alertIncidentRef = useRef<AlertIncidentSwitchHandle | null>(null);
   const irm = usePluginBridge(SupportedPlugin.Irm);
 
   const isWaitingForTabs = !redesignEnabled && isLoadingTabs;
@@ -125,7 +126,7 @@ export default function HomePage() {
         subTitle: t('home.home-page.placeholder', 'Welcome to {{edition}}.', { edition: getEdition() }),
         hideFromBreadcrumbs: true,
       }}
-      actions={redesignEnabled ? <HeaderActions /> : undefined}
+      actions={redesignEnabled ? <HeaderActions alertIncidentRef={alertIncidentRef} /> : undefined}
       layout={PageLayoutType.Home}
     >
       <Page.Contents>
@@ -155,7 +156,7 @@ export default function HomePage() {
                   <Grid gap={2} columns={{ xs: 1, md: 2 }}>
                     {/* Skip the HomepageTabs extension point for the redesign UI */}
                     <DashboardTabs extensionComponents={[]} />
-                    <AlertIncidentTabs />
+                    <AlertIncidentTabs switchRef={alertIncidentRef} />
                   </Grid>
                 </>
               ) : (

--- a/public/app/features/home/analytics/types.ts
+++ b/public/app/features/home/analytics/types.ts
@@ -120,4 +120,10 @@ export type CtaClicked = Satisfies<
           solution: string;
         }
     ))
+  | ({
+      surface: 'header';
+    } & {
+      action: 'view_alerts' | 'view_incidents';
+      placement: 'pill';
+    })
 >;

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10975,6 +10975,10 @@
       "view-all": "View all firing alerts",
       "view-rules": "View all alert rules"
     },
+    "header-actions": {
+      "active-incidents": "Active incidents",
+      "firing-alerts": "Firing alerts"
+    },
     "home-page": {
       "edition": {
         "cloud": "Grafana Cloud",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10977,7 +10977,9 @@
     },
     "header-actions": {
       "active-incidents": "Active incidents",
-      "firing-alerts": "Firing alerts"
+      "firing-alerts": "Firing alerts",
+      "no-active-incidents": "All clear",
+      "no-firing-alerts": "All clear"
     },
     "home-page": {
       "edition": {


### PR DESCRIPTION
**What is this feature?**

Introduces two actions buttons in the home header, showing a quick overview of the active alerts + incidents. Clicking on either scrolls the user down to the relevant tab.

**Why do we need this feature?**

Allow folks to more quickly get a quick overview of the state of their stack when at the top of the homepage.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

Fixes #129716

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
