### PR TITLE
DataPro: Seed data source tests through the async APIs

### DIFF
--- a/packages/grafana-runtime/src/internal/index.ts
+++ b/packages/grafana-runtime/src/internal/index.ts
@@ -80,4 +80,11 @@ export { invalidatePluginSettingsCache } from '../services/pluginSettings/invali
 
 export { initDataSourceInstanceSettings, syncDataSourceInstanceSettings } from '../services/dataSource/settings';
 export { setDataSourcePluginImporter } from '../services/dataSource/dataSource';
+// Exported so test helpers can assert a suite never resolved through the legacy fallback.
+// Delete along with the fallbacks themselves once `DataSourceSrv` is gone.
+export {
+  FALLBACK_TO_LEGACY_INSTANCE_WARNING,
+  FALLBACK_TO_LEGACY_LIST_WARNING,
+  FALLBACK_TO_LEGACY_SETTINGS_WARNING,
+} from '../services/dataSource/constants';
 export { setExpressionDataSourceInstance } from '../services/dataSource/expressionDs';

--- a/public/app/features/correlations/CorrelationsPageAppPlatform.test.tsx
+++ b/public/app/features/correlations/CorrelationsPageAppPlatform.test.tsx
@@ -2,12 +2,13 @@ import { render, waitFor, screen, within, type Matcher, getByRole } from '@testi
 import userEvent from '@testing-library/user-event';
 import { openMenu } from 'react-select-event';
 import { TestProvider } from 'test/helpers/TestProvider';
+import { seedDataSources, watchDataSourceFallbacks } from 'test/helpers/seedDataSources';
 import { MockDataSourceApi } from 'test/mocks/datasource_srv';
 import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
 
+import { type DataSourceInstanceSettings } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { type DataSourceSrv, type reportInteraction, setAppEvents, setDataSourceSrv, config } from '@grafana/runtime';
-import { type DataSourceRef } from '@grafana/schema';
+import { type reportInteraction, setAppEvents, config } from '@grafana/runtime';
 import { mockBoundingClientRect } from '@grafana/test-utils';
 import { appEvents } from 'app/core/app_events';
 import { type createSuccessNotification } from 'app/core/copy/appNotification';
@@ -25,7 +26,6 @@ import {
 } from './__mocks__/correlations.scenario';
 import { prePopulateCorrelations, setupMockCorrelations } from './__mocks__/fixtures';
 import { setupCorrelationsMswServer } from './__mocks__/server';
-import { MockDataSourceSrv } from './__mocks__/useCorrelations.mocks';
 
 const server = setupCorrelationsMswServer();
 
@@ -34,29 +34,31 @@ const originalFeatureToggles = config.featureToggles;
 // Set app events up, otherwise plugin modules will fail to load
 setAppEvents(appEvents);
 
-const renderWithContext = async (datasources: ConstructorParameters<typeof MockDataSourceSrv>[0] = {}) => {
+// The fallback's warning is inert in public/app suites, so green plus a quiet console proves
+// nothing. Spy on the logger instead and fail if a lookup resolved through the legacy service.
+let dataSourceFallbacks: ReturnType<typeof watchDataSourceFallbacks> | undefined;
+
+afterEach(() => {
+  const fallbacks = dataSourceFallbacks;
+  dataSourceFallbacks = undefined;
+  fallbacks?.expectNoFallbacks(['instance', 'settings', 'list']);
+});
+
+const renderWithContext = async (datasources: Record<string, DataSourceInstanceSettings> = {}) => {
   const grafanaContext = getGrafanaContextMock();
-  const dsServer = new MockDataSourceSrv(datasources) as unknown as DataSourceSrv;
-  dsServer.get = (name: string) => {
-    const dsApi = new MockDataSourceApi(name);
-    // Mock the QueryEditor component
-    dsApi.components = {
-      QueryEditor: () => <>{name} query editor</>,
-    };
-    return Promise.resolve(dsApi);
-  };
 
-  // the getInstanceSettings in MockDataSourceSrv finds by string only, not ref, so we build it out here
-  dsServer.getInstanceSettings = (ref: DataSourceRef | string) => {
-    const lookupName = typeof ref === 'string' ? ref : ref?.uid;
-    if (lookupName === undefined) {
-      return undefined;
-    } else {
-      return datasources[lookupName];
-    }
-  };
-
-  setDataSourceSrv(dsServer);
+  seedDataSources(
+    Object.values(datasources).map((settings) => {
+      const dsApi = new MockDataSourceApi(settings);
+      // Mock the QueryEditor component
+      dsApi.components = {
+        QueryEditor: () => <>{settings.name} query editor</>,
+      };
+      return { settings, api: dsApi };
+    }),
+    { legacySrv: 'mock' }
+  );
+  dataSourceFallbacks = watchDataSourceFallbacks();
 
   // the new render method doesn't seem to offer custom queries for now, so we can't change over yet
   const renderResult = render(
@@ -151,21 +153,6 @@ jest.mock('@grafana/runtime', () => {
     reportInteraction: (...args: Parameters<typeof reportInteraction>) => {
       mocks.reportInteraction(...args);
     },
-  };
-});
-
-// Delegate the new async datasource APIs to the legacy srv configured per-test via setDataSourceSrv,
-// so the cache-miss legacy fallback (which logs a warning that fails on console) is never hit.
-jest.mock('@grafana/runtime/unstable', () => {
-  const actualRuntime = jest.requireActual('@grafana/runtime');
-  const actualUnstable = jest.requireActual('@grafana/runtime/unstable');
-
-  return {
-    ...actualUnstable,
-    getDataSourceInstanceSettings: (ref: Parameters<typeof actualUnstable.getDataSourceInstanceSettings>[0]) =>
-      Promise.resolve(actualRuntime.getDataSourceSrv().getInstanceSettings(ref)),
-    getDataSourceInstance: (ref: Parameters<typeof actualUnstable.getDataSourceInstance>[0]) =>
-      actualRuntime.getDataSourceSrv().get(ref),
   };
 });
 

--- a/public/app/features/correlations/CorrelationsPageLegacy.test.tsx
+++ b/public/app/features/correlations/CorrelationsPageLegacy.test.tsx
@@ -4,19 +4,13 @@ import { merge, uniqueId } from 'lodash';
 import { openMenu } from 'react-select-event';
 import { Observable } from 'rxjs';
 import { TestProvider } from 'test/helpers/TestProvider';
+import { seedDataSources, watchDataSourceFallbacks } from 'test/helpers/seedDataSources';
 import { MockDataSourceApi } from 'test/mocks/datasource_srv';
 import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
 
-import { SupportedTransformationType } from '@grafana/data';
+import { type DataSourceInstanceSettings, SupportedTransformationType } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import {
-  type BackendSrv,
-  type BackendSrvRequest,
-  type DataSourceSrv,
-  type reportInteraction,
-  setAppEvents,
-  setDataSourceSrv,
-} from '@grafana/runtime';
+import { type BackendSrv, type BackendSrvRequest, type reportInteraction, setAppEvents } from '@grafana/runtime';
 import { mockBoundingClientRect } from '@grafana/test-utils';
 import { appEvents } from 'app/core/app_events';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -31,15 +25,24 @@ import {
   createFetchCorrelationsResponse,
   createRemoveCorrelationResponse,
   createUpdateCorrelationResponse,
-  MockDataSourceSrv,
 } from './__mocks__/useCorrelations.mocks';
 import { type Correlation, type CreateCorrelationParams, type OmitUnion } from './types';
 
 // Set app events up, otherwise plugin modules will fail to load
 setAppEvents(appEvents);
 
+// The fallback's warning is inert in public/app suites, so green plus a quiet console proves
+// nothing. Spy on the logger instead and fail if a lookup resolved through the legacy service.
+let dataSourceFallbacks: ReturnType<typeof watchDataSourceFallbacks> | undefined;
+
+afterEach(() => {
+  const fallbacks = dataSourceFallbacks;
+  dataSourceFallbacks = undefined;
+  fallbacks?.expectNoFallbacks(['instance', 'settings', 'list']);
+});
+
 const renderWithContext = async (
-  datasources: ConstructorParameters<typeof MockDataSourceSrv>[0] = {},
+  datasources: Record<string, DataSourceInstanceSettings> = {},
   correlations: Correlation[] = []
 ) => {
   const backend = {
@@ -99,17 +102,18 @@ const renderWithContext = async (
     },
   } as unknown as BackendSrv;
   const grafanaContext = getGrafanaContextMock({ backend });
-  const dsServer = new MockDataSourceSrv(datasources) as unknown as DataSourceSrv;
-  dsServer.get = (name: string) => {
-    const dsApi = new MockDataSourceApi(name);
-    // Mock the QueryEditor component
-    dsApi.components = {
-      QueryEditor: () => <>{name} query editor</>,
-    };
-    return Promise.resolve(dsApi);
-  };
-
-  setDataSourceSrv(dsServer);
+  seedDataSources(
+    Object.values(datasources).map((settings) => {
+      const dsApi = new MockDataSourceApi(settings);
+      // Mock the QueryEditor component
+      dsApi.components = {
+        QueryEditor: () => <>{settings.name} query editor</>,
+      };
+      return { settings, api: dsApi };
+    }),
+    { legacySrv: 'mock' }
+  );
+  dataSourceFallbacks = watchDataSourceFallbacks();
 
   const renderResult = render(
     <TestProvider store={configureStore({})} grafanaContext={grafanaContext}>
@@ -202,21 +206,6 @@ jest.mock('@grafana/runtime', () => {
     reportInteraction: (...args: Parameters<typeof reportInteraction>) => {
       mocks.reportInteraction(...args);
     },
-  };
-});
-
-// Delegate the new async datasource APIs to the legacy srv configured per-test via setDataSourceSrv,
-// so the cache-miss legacy fallback (which logs a warning that fails on console) is never hit.
-jest.mock('@grafana/runtime/unstable', () => {
-  const actualRuntime = jest.requireActual('@grafana/runtime');
-  const actualUnstable = jest.requireActual('@grafana/runtime/unstable');
-
-  return {
-    ...actualUnstable,
-    getDataSourceInstanceSettings: (ref: Parameters<typeof actualUnstable.getDataSourceInstanceSettings>[0]) =>
-      Promise.resolve(actualRuntime.getDataSourceSrv().getInstanceSettings(ref)),
-    getDataSourceInstance: (ref: Parameters<typeof actualUnstable.getDataSourceInstance>[0]) =>
-      actualRuntime.getDataSourceSrv().get(ref),
   };
 });
 

--- a/public/app/features/explore/QueryRows.test.tsx
+++ b/public/app/features/explore/QueryRows.test.tsx
@@ -1,10 +1,9 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
+import { seedDataSources, watchDataSourceFallbacks } from 'test/helpers/seedDataSources';
 
 import { type DataSourceApi, type DataSourceInstanceSettings } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { type DataSourceSrv, setDataSourceSrv } from '@grafana/runtime';
-import { initDataSourceInstanceSettings } from '@grafana/runtime/internal';
 import { type DataQuery } from '@grafana/schema';
 import { configureStore } from 'app/store/configureStore';
 import { type ExploreState } from 'app/types/explore';
@@ -20,62 +19,62 @@ jest.mock('@grafana/runtime', () => ({
   reportInteraction: () => null,
 }));
 
+// The fallback's warning is inert in public/app suites, so green plus a quiet console proves
+// nothing. Spy on the logger instead and fail if a lookup resolved through the legacy service.
+let dataSourceFallbacks: ReturnType<typeof watchDataSourceFallbacks> | undefined;
+
+afterEach(() => {
+  const fallbacks = dataSourceFallbacks;
+  dataSourceFallbacks = undefined;
+  fallbacks?.expectNoFallbacks(['instance', 'settings', 'list']);
+});
+
 function setup(queries: DataQuery[], { resolveDatasource = true } = {}) {
-  const defaultDs = {
-    name: 'newDs',
-    uid: 'newDs-uid',
-    meta: { id: 'newDs' },
-    components: {
-      QueryEditor: () => 'newDs query editor',
+  const fixtures = [
+    {
+      settings: {
+        name: 'newDs',
+        uid: 'newDs-uid',
+        type: 'newDs',
+        isDefault: true,
+        meta: { id: 'newDs', mixed: false },
+      } as DataSourceInstanceSettings,
+      api: {
+        name: 'newDs',
+        uid: 'newDs-uid',
+        meta: { id: 'newDs' },
+        components: {
+          QueryEditor: () => 'newDs query editor',
+        },
+      } as unknown as DataSourceApi,
     },
-  } as unknown as DataSourceApi;
+    {
+      settings: {
+        name: 'someDs',
+        uid: 'someDs-uid',
+        type: 'someDs',
+        meta: { id: 'someDs', mixed: false },
+      } as DataSourceInstanceSettings,
+      api: {
+        name: 'someDs',
+        uid: 'someDs-uid',
+        meta: { id: 'someDs' },
+        components: {
+          QueryEditor: () => 'someDs query editor',
+        },
+      } as unknown as DataSourceApi,
+    },
+  ];
 
-  const datasources: Record<string, DataSourceApi> = {
-    'newDs-uid': defaultDs,
-    'someDs-uid': {
-      name: 'someDs',
-      uid: 'someDs-uid',
-      meta: { id: 'someDs' },
-      components: {
-        QueryEditor: () => 'someDs query editor',
-      },
-    } as unknown as DataSourceApi,
-  };
+  // QueryRows resolves its group settings through the new async datasource API; QueryEditorRow
+  // still loads the plugin through the legacy service. Seeding both from one fixture set keeps
+  // them consistent, and clears the instance cache so re-seeding per test is not a no-op.
+  seedDataSources(fixtures, { legacySrv: 'mock' });
+  dataSourceFallbacks = watchDataSourceFallbacks();
 
-  // QueryRows resolves its group settings through the new async datasource API, which reads
-  // the in-memory instance-settings cache. Seed it so the lookup never falls back to legacy.
-  const dsSettings: Record<string, DataSourceInstanceSettings> = {
-    'newDs-uid': {
-      name: 'newDs',
-      uid: 'newDs-uid',
-      type: 'newDs',
-      isDefault: true,
-      meta: { id: 'newDs', mixed: false },
-    } as DataSourceInstanceSettings,
-    'someDs-uid': {
-      name: 'someDs',
-      uid: 'someDs-uid',
-      type: 'someDs',
-      meta: { id: 'someDs', mixed: false },
-    } as DataSourceInstanceSettings,
-  };
-  initDataSourceInstanceSettings(dsSettings, 'newDs');
-
-  // QueryEditorRow still loads the plugin through the legacy service, so it stays seeded
-  // until that call site is migrated. getInstanceSettings deliberately has no default-datasource
-  // fallback: that keeps the new API's own default resolution under test instead of masking a
-  // cache miss behind the legacy path.
-  setDataSourceSrv({
-    getList() {
-      return Object.values(datasources).map((d) => ({ name: d.name }));
-    },
-    getInstanceSettings(uid: string) {
-      return dsSettings[uid];
-    },
-    get(uid?: string) {
-      return Promise.resolve(uid ? datasources[uid] || defaultDs : defaultDs);
-    },
-  } as unknown as DataSourceSrv);
+  const datasources: Record<string, DataSourceApi> = Object.fromEntries(
+    fixtures.map((fixture) => [fixture.settings.uid, fixture.api])
+  );
 
   const leftState = makeExplorePaneState();
   const initialState: ExploreState = {

--- a/public/app/features/explore/spec/helper/setup.tsx
+++ b/public/app/features/explore/spec/helper/setup.tsx
@@ -10,6 +10,11 @@ import { Provider } from 'react-redux';
 // eslint-disable-next-line no-restricted-imports
 import { Route, Router } from 'react-router-dom';
 import { of } from 'rxjs';
+import {
+  type DataSourceFallbackWatcher,
+  seedDataSources,
+  watchDataSourceFallbacks,
+} from 'test/helpers/seedDataSources';
 import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
 
 import {
@@ -32,7 +37,6 @@ import {
   setLocationService,
   setPluginLinksHook,
 } from '@grafana/runtime';
-import { type DataSourceRef } from '@grafana/schema';
 import { getTestFeatureFlagClient, setTestFlags } from '@grafana/test-utils/unstable';
 import { AppChrome } from 'app/core/components/AppChrome/AppChrome';
 import { GrafanaContext } from 'app/core/context/GrafanaContext';
@@ -76,6 +80,19 @@ type SetupOptions = {
 type TearDownOptions = {
   clearLocalStorage?: boolean;
 };
+
+// Every suite that seeds through this helper gets the check: the fallback logs a warning, but
+// that warning is inert here because nothing initialises the loggers registry in public/app
+// tests, so jest-fail-on-console never sees it and a legacy-only lookup passes green.
+let dataSourceFallbacks: DataSourceFallbackWatcher | undefined;
+
+afterEach(() => {
+  const fallbacks = dataSourceFallbacks;
+  dataSourceFallbacks = undefined;
+  // Every kind, not just instance resolution: these suites resolve settings and lists through the
+  // new APIs too, so there is nothing to concede.
+  fallbacks?.expectNoFallbacks(['instance', 'settings', 'list']);
+});
 
 export function setupExplore(options?: SetupOptions): {
   datasources: { [uid: string]: DataSourceApi };
@@ -126,42 +143,21 @@ export function setupExplore(options?: SetupOptions): {
   const defaultDatasources: DatasourceSetup[] = [
     makeDatasourceSetup(),
     makeDatasourceSetup({ name: 'elastic', id: 2 }),
-    makeDatasourceSetup({ name: MIXED_DATASOURCE_NAME, uid: MIXED_DATASOURCE_NAME, id: 999 }),
+    // pluginId 'mixed' keeps the list APIs treating this as the built-in mixed data source:
+    // excluded from the base list and appended only when a caller asks for it.
+    makeDatasourceSetup({ name: MIXED_DATASOURCE_NAME, uid: MIXED_DATASOURCE_NAME, id: 999, pluginId: 'mixed' }),
   ];
 
   const dsSettings = options?.datasources || defaultDatasources;
 
   const previousDataSourceSrv = getDataSourceSrv();
 
-  setDataSourceSrv({
-    registerRuntimeDataSource: jest.fn(),
-    getList(): DataSourceInstanceSettings[] {
-      return dsSettings.map((d) => d.settings);
-    },
-    getInstanceSettings(ref?: DataSourceRef) {
-      const allSettings = dsSettings.map((d) => d.settings);
-      return allSettings.find((x) => x.name === ref || x.uid === ref || x.uid === ref?.uid) || allSettings[0];
-    },
-    get(datasource?: string | DataSourceRef | null): Promise<DataSourceApi> {
-      let ds: DataSourceApi | undefined;
-      if (!datasource) {
-        ds = dsSettings[0]?.api;
-      } else {
-        ds = dsSettings.find((ds) =>
-          typeof datasource === 'string'
-            ? ds.api.name === datasource || ds.api.uid === datasource
-            : ds.api.uid === datasource?.uid
-        )?.api;
-      }
-
-      if (ds) {
-        return Promise.resolve(ds);
-      }
-
-      return Promise.reject();
-    },
-    reload: jest.fn().mockResolvedValue(undefined),
-  });
+  // Seeds the async data source APIs and the legacy service from the same fixtures. Seeding only
+  // the legacy service would route every migrated call site Explore reaches through the legacy
+  // fallback, so the specs would assert legacy semantics whatever the new path does. The legacy
+  // service stays until the call sites Explore renders are all migrated; drop it for 'none' then.
+  seedDataSources(dsSettings, { legacySrv: 'mock' });
+  dataSourceFallbacks = watchDataSourceFallbacks();
 
   const previousEchoSrv = getEchoSrv();
   setEchoSrv(new Echo());
@@ -255,7 +251,8 @@ export function makeDatasourceSetup({
   name = 'loki',
   id = 1,
   uid: uidOverride,
-}: { name?: string; id?: number; uid?: string } = {}): DatasourceSetup {
+  pluginId,
+}: { name?: string; id?: number; uid?: string; pluginId?: string } = {}): DatasourceSetup {
   const uid = uidOverride || `${name}-uid`;
   const type = 'logs';
 
@@ -274,11 +271,15 @@ export function makeDatasourceSetup({
         large: '',
       },
     },
-    id: id.toString(),
+    id: pluginId ?? id.toString(),
     module: 'loki',
     name,
     type: PluginType.datasource,
     baseUrl: '',
+    // Both list APIs drop data sources that declare no queryable capability unless asked for
+    // `all`, so without these the picker and rich history come back empty.
+    metrics: true,
+    logs: true,
   };
   return {
     settings: {

--- a/public/test/helpers/seedDataSources.test.ts
+++ b/public/test/helpers/seedDataSources.test.ts
@@ -1,0 +1,94 @@
+import { type DataSourceApi, type DataSourceInstanceSettings, type DataSourcePluginMeta } from '@grafana/data';
+import { getDataSourceSrv, setDataSourceSrv, type DataSourceSrv } from '@grafana/runtime';
+import { getDataSourceInstance, getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
+
+import { seedDataSources, watchDataSourceFallbacks } from './seedDataSources';
+
+function makeFixture(name: string, uid: string, api?: Partial<DataSourceApi>) {
+  const meta = { id: name, name, type: 'datasource', module: '', baseUrl: '', logs: true } as DataSourcePluginMeta;
+  const settings = { uid, name, type: 'logs', meta, access: 'proxy', jsonData: {}, readOnly: false };
+
+  return {
+    settings: settings as DataSourceInstanceSettings,
+    api: { uid, name, components: {}, ...api } as DataSourceApi,
+  };
+}
+
+describe('seedDataSources', () => {
+  it('resolves an instance through the async API rather than the legacy fallback', async () => {
+    const loki = makeFixture('loki', 'loki-uid', { query: jest.fn() });
+    seedDataSources([loki], { legacySrv: 'mock' });
+    const fallbacks = watchDataSourceFallbacks();
+
+    await expect(getDataSourceInstance('loki-uid')).resolves.toBe(loki.api);
+    await expect(getDataSourceInstanceSettings('loki-uid')).resolves.toBe(loki.settings);
+    expect(() => fallbacks.expectNoFallbacks(['instance', 'settings', 'list'])).not.toThrow();
+  });
+
+  it('resolves the same instance through the legacy service', async () => {
+    const loki = makeFixture('loki', 'loki-uid');
+    seedDataSources([loki], { legacySrv: 'mock' });
+
+    await expect(getDataSourceSrv().get('loki-uid')).resolves.toBe(loki.api);
+    await expect(getDataSourceSrv().get({ uid: 'loki-uid' })).resolves.toBe(loki.api);
+    expect(getDataSourceSrv().getInstanceSettings('loki')).toBe(loki.settings);
+  });
+
+  it('keeps the fixture components on the constructed instance', async () => {
+    const components = { QueryEditor: () => null };
+    const loki = makeFixture('loki', 'loki-uid', { components });
+    seedDataSources([loki], { legacySrv: 'mock' });
+
+    const instance = await getDataSourceInstance('loki-uid');
+    expect(instance.components).toBe(components);
+  });
+
+  it('resolves the default data source for an empty ref', async () => {
+    const loki = makeFixture('loki', 'loki-uid');
+    const elastic = makeFixture('elastic', 'elastic-uid');
+    elastic.settings.isDefault = true;
+    seedDataSources([loki, elastic], { legacySrv: 'mock' });
+
+    await expect(getDataSourceInstance()).resolves.toBe(elastic.api);
+    await expect(getDataSourceSrv().get()).resolves.toBe(elastic.api);
+  });
+
+  it('hands back the instance from the latest seeding, not a cached one', async () => {
+    seedDataSources([makeFixture('loki', 'loki-uid')], { legacySrv: 'mock' });
+    await getDataSourceInstance('loki-uid');
+
+    const reseeded = makeFixture('loki', 'loki-uid');
+    seedDataSources([reseeded], { legacySrv: 'mock' });
+
+    await expect(getDataSourceInstance('loki-uid')).resolves.toBe(reseeded.api);
+  });
+
+  it('fails a lookup instead of falling back when no legacy service is seeded', async () => {
+    seedDataSources([makeFixture('loki', 'loki-uid')], { legacySrv: 'none' });
+    const fallbacks = watchDataSourceFallbacks();
+
+    await expect(getDataSourceInstance('missing-uid')).rejects.toThrow();
+    expect(() => fallbacks.expectNoFallbacks(['instance', 'settings', 'list'])).not.toThrow();
+  });
+});
+
+describe('watchDataSourceFallbacks', () => {
+  it('reports a lookup that only the legacy service could resolve', async () => {
+    const loki = makeFixture('loki', 'loki-uid');
+    const legacyOnly: DataSourceSrv = {
+      get: () => Promise.resolve(loki.api!),
+      getInstanceSettings: () => loki.settings,
+      getList: () => [loki.settings],
+      reload: jest.fn(),
+      registerRuntimeDataSource: jest.fn(),
+    };
+    // Nothing in the new registries, everything in the legacy service: the shape this util exists
+    // to remove.
+    seedDataSources([], { legacySrv: 'none' });
+    setDataSourceSrv(legacyOnly);
+    const fallbacks = watchDataSourceFallbacks();
+
+    await expect(getDataSourceInstance('loki-uid')).resolves.toBe(loki.api);
+    expect(() => fallbacks.expectNoFallbacks()).toThrow(/legacy DataSourceSrv fallback/);
+  });
+});

--- a/public/test/helpers/seedDataSources.ts
+++ b/public/test/helpers/seedDataSources.ts
@@ -1,0 +1,199 @@
+import { keyBy } from 'lodash';
+
+import {
+  type DataSourceApi,
+  type DataSourceInstanceSettings,
+  type DataSourcePluginMeta,
+  type DataSourceRef,
+} from '@grafana/data';
+import { type DataSourceSrv, setDataSourceSrv } from '@grafana/runtime';
+import {
+  FALLBACK_TO_LEGACY_INSTANCE_WARNING,
+  FALLBACK_TO_LEGACY_LIST_WARNING,
+  FALLBACK_TO_LEGACY_SETTINGS_WARNING,
+  setDataSourcePluginImporter,
+  syncDataSourceInstanceSettings,
+} from '@grafana/runtime/internal';
+import { mockLogger } from '@grafana/test-utils/unstable';
+
+/**
+ * A data source to seed. Pass `api` when the test resolves an instance (`getDataSourceInstance`,
+ * `useDataSourceInstance`, or the legacy `getDataSourceSrv().get`) — it is the object those calls
+ * return. Settings alone are enough for lookups and lists.
+ */
+interface DataSourceFixture {
+  settings: DataSourceInstanceSettings;
+  api?: DataSourceApi;
+}
+
+type SeedableDataSource = DataSourceInstanceSettings | DataSourceFixture;
+
+/** The subset of a data source plugin the instance loader reads. */
+interface TestDataSourcePlugin {
+  DataSourceClass: new (settings: DataSourceInstanceSettings) => DataSourceApi;
+  components: unknown;
+}
+
+interface SeedDataSourcesOptions {
+  /**
+   * How to seed the legacy `DataSourceSrv`. Required with no default: whether a test still needs
+   * the legacy service is the decision this util exists to make deliberate, and it is the option
+   * that goes away when `DataSourceSrv` does.
+   *
+   * - `'none'` — no service at all, so the legacy fallback is inert and a lookup the new
+   *   registries miss fails loudly. What a test wants once everything it reaches is migrated.
+   * - `'mock'` — a minimal service backed by the same fixtures, for the call sites a test reaches
+   *   that are not migrated yet.
+   */
+  legacySrv: 'mock' | 'none';
+}
+
+/**
+ * Seed data sources for a test through both the async data source APIs and the legacy
+ * `DataSourceSrv`, from one set of fixtures.
+ *
+ * Seeding only the legacy service makes migrated call sites resolve through the legacy fallback,
+ * so the test asserts the old semantics no matter what the new path does. Use
+ * {@link watchDataSourceFallbacks} to prove a suite never took that route.
+ */
+export function seedDataSources(dataSources: SeedableDataSource[], options: SeedDataSourcesOptions): void {
+  const fixtures = dataSources.map(toFixture);
+  const settings = keyBy(
+    fixtures.map((fixture) => fixture.settings),
+    (dsSettings) => dsSettings.name
+  );
+  const defaultDataSourceName =
+    fixtures.find((fixture) => fixture.settings.isDefault)?.settings.name ?? fixtures[0]?.settings.name ?? '';
+
+  // syncDataSourceInstanceSettings rather than initDataSourceInstanceSettings: it also clears the
+  // constructed-instance cache. Suites re-seed per test, and a cached instance built from the
+  // previous test's fixtures would otherwise be handed back for a uid this call just rebuilt.
+  syncDataSourceInstanceSettings({ datasources: settings, defaultDatasource: defaultDataSourceName });
+  setDataSourcePluginImporter(
+    // The importer type is internal to @grafana/runtime; fixtures only need to supply what the
+    // loader reads off the plugin.
+    createFixtureImporter(fixtures) as unknown as Parameters<typeof setDataSourcePluginImporter>[0]
+  );
+
+  setDataSourceSrv(
+    options.legacySrv === 'none'
+      ? (undefined as unknown as DataSourceSrv)
+      : createLegacyDataSourceSrvMock(fixtures, defaultDataSourceName)
+  );
+}
+
+function toFixture(dataSource: SeedableDataSource): DataSourceFixture {
+  return 'settings' in dataSource ? dataSource : { settings: dataSource };
+}
+
+function createFixtureImporter(fixtures: DataSourceFixture[]) {
+  // Keyed on the meta object rather than meta.id: fixtures routinely share a plugin id, and the
+  // loader passes back the very meta object the settings carry, so identity is both unique and
+  // available. meta.id is the fallback for settings whose meta was cloned.
+  const byMeta = new Map<DataSourcePluginMeta, DataSourceFixture>();
+  const byPluginId = new Map<string, DataSourceFixture>();
+
+  for (const fixture of fixtures) {
+    byMeta.set(fixture.settings.meta, fixture);
+    if (!byPluginId.has(fixture.settings.meta.id)) {
+      byPluginId.set(fixture.settings.meta.id, fixture);
+    }
+  }
+
+  return async (meta: DataSourcePluginMeta): Promise<TestDataSourcePlugin> => {
+    const api = (byMeta.get(meta) ?? byPluginId.get(meta.id))?.api;
+    if (!api) {
+      throw new Error(
+        `seedDataSources: no api fixture for data source plugin "${meta.id}". Seed it as { settings, api }.`
+      );
+    }
+    // `new` on a function returning an object yields that object, so the instance is the fixture
+    // api itself and the handles a test holds (e.g. query mocks) stay live. components is returned
+    // because the loader overwrites instance.components with whatever the plugin supplies.
+    return {
+      DataSourceClass: function () {
+        return api;
+      } as unknown as TestDataSourcePlugin['DataSourceClass'],
+      components: api.components ?? {},
+    };
+  };
+}
+
+/**
+ * Minimal legacy service for the call sites a test reaches that are not migrated yet. It resolves
+ * by uid or name and falls back to the default data source for an empty ref. getList ignores its
+ * filters — the async list API applies the real ones.
+ */
+function createLegacyDataSourceSrvMock(fixtures: DataSourceFixture[], defaultDataSourceName: string): DataSourceSrv {
+  const byUid = keyBy(fixtures, (fixture) => fixture.settings.uid);
+  const byName = keyBy(fixtures, (fixture) => fixture.settings.name);
+
+  const find = (ref?: DataSourceRef | string | null): DataSourceFixture | undefined => {
+    const nameOrUid = typeof ref === 'string' ? ref : ref?.uid;
+    if (!nameOrUid || nameOrUid === 'default') {
+      return byUid[defaultDataSourceName] ?? byName[defaultDataSourceName];
+    }
+    return byUid[nameOrUid] ?? byName[nameOrUid];
+  };
+
+  return {
+    get(ref) {
+      const fixture = find(ref);
+      if (!fixture?.api) {
+        return Promise.reject(new Error(`Datasource ${JSON.stringify(ref)} was not found`));
+      }
+      return Promise.resolve(fixture.api);
+    },
+    getInstanceSettings(ref) {
+      return find(ref)?.settings;
+    },
+    getList() {
+      return fixtures.map((fixture) => fixture.settings);
+    },
+    reload: jest.fn().mockResolvedValue(undefined),
+    registerRuntimeDataSource: jest.fn(),
+  };
+}
+
+const DATA_SOURCE_LOGGER_SOURCE = 'grafana/runtime.plugins.datasource';
+
+const FALLBACK_WARNINGS = {
+  instance: FALLBACK_TO_LEGACY_INSTANCE_WARNING,
+  settings: FALLBACK_TO_LEGACY_SETTINGS_WARNING,
+  list: FALLBACK_TO_LEGACY_LIST_WARNING,
+} as const;
+
+type DataSourceFallbackKind = keyof typeof FALLBACK_WARNINGS;
+
+export interface DataSourceFallbackWatcher {
+  /** Throws if any of the given kinds of fallback happened. Instance resolution by default. */
+  expectNoFallbacks(kinds?: DataSourceFallbackKind[]): void;
+}
+
+/**
+ * Watch for data source lookups that resolved through the legacy `DataSourceSrv` fallback.
+ *
+ * The fallback logs a warning, but that warning is inert in `public/app` suites: nothing calls
+ * `initializeLoggersRegistry` there, so it never reaches the console and jest-fail-on-console
+ * never sees it. Absence of console output proves nothing — register this spy logger instead.
+ */
+export function watchDataSourceFallbacks(): DataSourceFallbackWatcher {
+  const logger = mockLogger(DATA_SOURCE_LOGGER_SOURCE);
+
+  return {
+    expectNoFallbacks(kinds = ['instance']) {
+      const messages: string[] = kinds.map((kind) => FALLBACK_WARNINGS[kind]);
+      const fallbacks = jest
+        .mocked(logger.logWarning)
+        .mock.calls.map(([message]) => message)
+        .filter((message) => messages.includes(message));
+
+      if (fallbacks.length > 0) {
+        throw new Error(
+          `Data sources resolved through the legacy DataSourceSrv fallback, so this test asserts legacy semantics. ` +
+            `Seed the async APIs too (seedDataSources).\n${fallbacks.map((message) => `  - ${message}`).join('\n')}`
+        );
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Description

Tests that seed data sources only via `setDataSourceSrv` resolve migrated call sites through the<br>legacy fallback, so they assert legacy semantics whatever the new async path does. The fallback<br>logs a warning, but nothing calls `initializeLoggersRegistry()` outside `app.ts`, so<br>`jest-fail-on-console` never sees it. This is the shape that let the template-variable identity bug<br>reach main (grafana/grafana#127578 -> revert [#127870](<https://github.com/grafana/grafana/issues/127870>) -> fix [#128035](<https://github.com/grafana/grafana/issues/128035>)).

Measured with a spy logger on `grafana/runtime.plugins.datasource`:

<!-- linear:table-colwidths:266,266,266 -->
|  | main | this PR |
| -- | -- | -- |
| Explore tests resolving through the fallback | **18 of 86** | 0 |
| Correlations page tests | **9** | 0 |

130 instance, 172 settings and 17 list resolutions per run came back from `DataSourceSrv`. The<br>same probe across all 198 DataPro-owned frontend suites found no others.

## Changes

* `seedDataSources()` (`public/test/helpers/seedDataSources.ts`) seeds the async data source<br>APIs and the legacy `DataSourceSrv` from one fixture set. `legacySrv` is required — `'none'` or<br>`'mock'` — so the seeding target is never implicit, and it is the part that disappears with<br>`DataSourceSrv`.
* `watchDataSourceFallbacks()` registers a spy logger and fails the test if a lookup resolved<br>through the fallback. It needs the three `FALLBACK_TO_LEGACY_*` constants, now exported from<br>`@grafana/runtime/internal` — the only change outside DataPro-owned files.
* `explore/spec/helper/setup.tsx` (eight suites), `QueryRows.test.tsx` and both<br>**Correlations page tests** seed through the util and assert no fallback, per test. Correlations<br>also drops a `jest.mock('@grafana/runtime/unstable')` block that delegated the new APIs back to a<br>hand-built `MockDataSourceSrv`.
* **Explore fixtures** declare `metrics`/`logs` in plugin meta and give the mixed data source<br>plugin id `mixed`; without that the list APIs correctly drop every fixture.

grafana/grafana#130200 called for `@grafana/test-utils`, but every consumer is in `public/app` and that<br>package's jest project cannot load `@grafana/runtime` — which seeding its registries requires.

## Risks

* The guard is a module-scope `afterEach`, so importing a helper opts the suite in. Deliberate,<br>but a future legacy-only seeding there fails rather than passing quietly.
* `tearDown()` restores the previous legacy service but leaves the new registries seeded. Latent —<br>every test re-seeds — and clearing mid-teardown risks failing pending async work during unmount.
* `seedDataSources` uses `syncDataSourceInstanceSettings`, which also clears the instance cache.<br>Otherwise a re-seeded uid hands back the previous test's instance and its `query` mock silently<br>stops working. Unit tested.

## Demo

n/a — test infrastructure.

## Testing Instructions

```
yarn jest --no-watch public/app/features/explore public/app/features/correlations public/test/helpers
yarn lint && yarn typecheck
```

179 suites / 1577 tests green. To watch the guard fire, drop the `metrics`/`logs` flags from<br>`makeDatasourceSetup` — `queryHistory.test.tsx` then fails on a legacy list fallback.

## Not included

Alerting's `testSetup/datasources.ts`. All 298 Alerting suites pass with zero fallbacks under<br>legacy-only seeding, so it reaches no migrated call site today.

## Reviewer Checklist

- [ ] @grafana/grafana-frontend-platform — the three `FALLBACK_TO_LEGACY_*` exports on<br>    `grafana-runtime`'s internal surface.
- [ ] `legacySrv` required rather than defaulted.
- [ ] Teardown asymmetry: leave as-is, or clear the new registries too?

Closes grafana/grafana#130200. Part of grafana/grafana#127033. Related: [#125083](<https://github.com/grafana/grafana/issues/125083>).