### PR TITLE
[release-13.0.6] SplashScreen: Disable feature toggle by default

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1723,7 +1723,7 @@ export interface FeatureToggles {
   frontendServiceSSOAutoLogin?: boolean;
   /**
   * Enables the splash screen modal for introducing new Grafana features on first session
-  * @default true
+  * @default false
   */
   splashScreen?: boolean;
   /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2739,7 +2739,7 @@ var (
 			Stage:        FeatureStagePublicPreview,
 			Owner:        grafanaFrontendPlatformSquad,
 			FrontendOnly: true,
-			Expression:   "true",
+			Expression:   "false",
 		},
 		{
 			Name:         "streamingForwardTeamHeadersTempo",

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -4859,10 +4859,10 @@
     {
       "metadata": {
         "name": "splashScreen",
-        "resourceVersion": "1775046571105",
+        "resourceVersion": "1785966920361",
         "creationTimestamp": "2026-03-25T17:59:16Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2026-04-01 12:29:31.105103 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2026-08-05 21:55:20.361587 +0000 UTC"
         }
       },
       "spec": {
@@ -4870,7 +4870,7 @@
         "stage": "preview",
         "codeowner": "@grafana/grafana-frontend-platform",
         "frontend": true,
-        "expression": "true"
+        "expression": "false"
       }
     },
     {


### PR DESCRIPTION
**What is this about?**
Changes the `splashScreen` feature toggle default expression from `true` to `false` on the 13.0.x release branch, and regenerates the derived files.


**Why do we need this?**
The splash screen modal is enabled by default on 13.0.x, so self-managed installs get it without opting in. It was enabled by default in #121647, then disabled again on `main` in #124756 — but that landed after the 13.0 release branch was cut, so the fix never reached 13.0.x. `main` and `release-13.1.x` are already at `false`; this brings 13.0.x in line.
This is a release-branch-only change, so there is no corresponding PR on `main` and nothing to backport.  

Fixes https://github.com/grafana/grafana/issues/127215
