### PR TITLE
Home: Update home background for visual refresh

### DIFF
--- a/packages/grafana-data/src/themes/createComponents.ts
+++ b/packages/grafana-data/src/themes/createComponents.ts
@@ -4,7 +4,7 @@ import * as z from 'zod';
 import { type ThemeColors } from './createColors';
 import type { Radii } from './createShape';
 import type { ThemeSpacingTokens } from './createSpacing';
-import { resolvePaletteRefs } from './palette_new';
+import { palette, resolvePaletteRefs } from './palette_new';
 import { type DeepRequired } from './types';
 
 interface MenuComponentTokens {
@@ -121,6 +121,17 @@ export const ThemeComponentsInputSchema = z
     tag: z.object({
       colors: z.array(z.object({ background: z.string(), text: z.string() })).optional(),
     }),
+    home: z.object({
+      background: z
+        .object({
+          base: z.string(),
+          fade: z.string(),
+          highlight: z.string(),
+          right: z.string(),
+          left: z.string(),
+        })
+        .optional(),
+    }),
   })
   .partial();
 
@@ -207,6 +218,15 @@ export function createComponents(colors: ThemeColors, componentsInput: ThemeComp
     },
     tag: {
       colors: DEFAULT_TAG_COLORS,
+    },
+    home: {
+      background: {
+        base: colors.background.page,
+        fade: colors.mode === 'dark' ? palette.violet950 : palette.violet100,
+        highlight: colors.mode === 'dark' ? palette.violet900 : palette.violet200,
+        right: colors.mode === 'dark' ? palette.orange900 : palette.orange200,
+        left: colors.mode === 'dark' ? palette.blue900 : palette.blue200,
+      },
     },
   };
 

--- a/packages/grafana-data/src/themes/createComponents.ts
+++ b/packages/grafana-data/src/themes/createComponents.ts
@@ -4,7 +4,7 @@ import * as z from 'zod';
 import { type ThemeColors } from './createColors';
 import type { Radii } from './createShape';
 import type { ThemeSpacingTokens } from './createSpacing';
-import { palette, resolvePaletteRefs } from './palette_new';
+import { resolvePaletteRefs } from './palette_new';
 import { type DeepRequired } from './types';
 
 interface MenuComponentTokens {
@@ -124,7 +124,6 @@ export const ThemeComponentsInputSchema = z
     home: z.object({
       background: z
         .object({
-          base: z.string().optional(),
           fade: z.string().optional(),
           highlight: z.string().optional(),
           right: z.string().optional(),
@@ -221,11 +220,19 @@ export function createComponents(colors: ThemeColors, componentsInput: ThemeComp
     },
     home: {
       background: {
-        base: colors.background.page,
-        fade: colors.mode === 'dark' ? palette.violet900 : palette.violet100,
-        highlight: colors.mode === 'dark' ? palette.violet800 : palette.violet200,
-        right: colors.mode === 'dark' ? palette.orange800 : palette.orange200,
-        left: colors.mode === 'dark' ? palette.blue800 : palette.blue200,
+        fade:
+          colors.mode === 'dark'
+            ? 'hsl(from #3a364c h calc(s * 1.5) calc(l * 1.1))'
+            : 'hsl(from #dedfee h calc(s * 1.05) calc(l * 0.9))',
+        highlight: 'transparent',
+        right:
+          colors.mode === 'dark'
+            ? 'hsl(from #722323 h calc(s * 1.1) calc(l * 0.9) / 80%)'
+            : 'hsl(from #ff9a9a h s l / 80%)',
+        left:
+          colors.mode === 'dark'
+            ? 'hsl(from #1b416d h calc(s * 0.9) calc(l * 0.9) / 60%)'
+            : 'hsl(from #a6e3df h s l / 60%)',
       },
     },
   };

--- a/packages/grafana-data/src/themes/createComponents.ts
+++ b/packages/grafana-data/src/themes/createComponents.ts
@@ -124,11 +124,11 @@ export const ThemeComponentsInputSchema = z
     home: z.object({
       background: z
         .object({
-          base: z.string(),
-          fade: z.string(),
-          highlight: z.string(),
-          right: z.string(),
-          left: z.string(),
+          base: z.string().optional(),
+          fade: z.string().optional(),
+          highlight: z.string().optional(),
+          right: z.string().optional(),
+          left: z.string().optional(),
         })
         .optional(),
     }),

--- a/packages/grafana-data/src/themes/createComponents.ts
+++ b/packages/grafana-data/src/themes/createComponents.ts
@@ -222,10 +222,10 @@ export function createComponents(colors: ThemeColors, componentsInput: ThemeComp
     home: {
       background: {
         base: colors.background.page,
-        fade: colors.mode === 'dark' ? palette.violet950 : palette.violet100,
-        highlight: colors.mode === 'dark' ? palette.violet900 : palette.violet200,
-        right: colors.mode === 'dark' ? palette.orange900 : palette.orange200,
-        left: colors.mode === 'dark' ? palette.blue900 : palette.blue200,
+        fade: colors.mode === 'dark' ? palette.violet900 : palette.violet100,
+        highlight: colors.mode === 'dark' ? palette.violet800 : palette.violet200,
+        right: colors.mode === 'dark' ? palette.orange800 : palette.orange200,
+        left: colors.mode === 'dark' ? palette.blue800 : palette.blue200,
       },
     },
   };

--- a/packages/grafana-data/src/themes/schema.generated.json
+++ b/packages/grafana-data/src/themes/schema.generated.json
@@ -1186,6 +1186,40 @@
             }
           },
           "additionalProperties": false
+        },
+        "home": {
+          "type": "object",
+          "properties": {
+            "background": {
+              "type": "object",
+              "properties": {
+                "base": {
+                  "type": "string"
+                },
+                "fade": {
+                  "type": "string"
+                },
+                "highlight": {
+                  "type": "string"
+                },
+                "right": {
+                  "type": "string"
+                },
+                "left": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "base",
+                "fade",
+                "highlight",
+                "right",
+                "left"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false

--- a/packages/grafana-data/src/themes/schema.generated.json
+++ b/packages/grafana-data/src/themes/schema.generated.json
@@ -1193,9 +1193,6 @@
             "background": {
               "type": "object",
               "properties": {
-                "base": {
-                  "type": "string"
-                },
                 "fade": {
                   "type": "string"
                 },

--- a/packages/grafana-data/src/themes/schema.generated.json
+++ b/packages/grafana-data/src/themes/schema.generated.json
@@ -1209,13 +1209,6 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "base",
-                "fade",
-                "highlight",
-                "right",
-                "left"
-              ],
               "additionalProperties": false
             }
           },

--- a/packages/grafana-data/src/themes/themeDefinitions/visual_refresh_dark.json
+++ b/packages/grafana-data/src/themes/themeDefinitions/visual_refresh_dark.json
@@ -139,6 +139,14 @@
         { "background": "palette.lavender800", "text": "palette.lavender200" },
         { "background": "palette.rose800", "text": "palette.rose200" }
       ]
+    },
+    "home": {
+      "background": {
+        "fade": "palette.violet900",
+        "highlight": "palette.violet800",
+        "right": "palette.orange800",
+        "left": "palette.blue800"
+      }
     }
   }
 }

--- a/packages/grafana-data/src/themes/themeDefinitions/visual_refresh_light.json
+++ b/packages/grafana-data/src/themes/themeDefinitions/visual_refresh_light.json
@@ -135,6 +135,14 @@
     },
     "input": {
       "background": "palette.white"
+    },
+    "home": {
+      "background": {
+        "fade": "palette.violet100",
+        "highlight": "palette.violet200",
+        "right": "palette.orange200",
+        "left": "palette.blue200"
+      }
     }
   },
   "shape": {

--- a/public/app/core/components/Page/Page.tsx
+++ b/public/app/core/components/Page/Page.tsx
@@ -129,7 +129,7 @@ const getStyles = (theme: GrafanaTheme2, visualRefreshEnabled: boolean) => {
     }),
     wrapperGradient: css({
       label: 'page-wrapper-gradient',
-      background: `url('data:image/svg+xml;utf8,${encodeURIComponent(getGradientBackgroundForTheme(theme))}') center center / cover no-repeat`,
+      background: `url('data:image/svg+xml;utf8,${encodeURIComponent(getGradientBackgroundForTheme(theme, visualRefreshEnabled))}') center center / cover no-repeat`,
     }),
     pageContent: css({
       label: 'page-content',
@@ -177,9 +177,40 @@ function getDefaultBackgroundForLayout(layout: PageLayoutType, visualRefreshEnab
   return visualRefreshEnabled ? 'primary' : 'canvas';
 }
 
-function getGradientBackgroundForTheme(theme: GrafanaTheme2) {
+function getGradientBackgroundForTheme(theme: GrafanaTheme2, visualRefreshEnabled: boolean) {
   // Use an inline SVG as a background to avoid flashing of the background when loading a page
   // Use an inline SVG rather than a CSS gradient due to the complexity of the gradients being used
+
+  if (visualRefreshEnabled) {
+    return `
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 3840 2160">
+  <rect width="3840" height="2160" fill="${theme.colors.background.page}" />
+  <rect width="3840" height="2160" fill="url(#full)" fill-opacity="0.5"/>
+  <rect width="3840" height="2160" fill="url(#highlight)" fill-opacity="0.25"/>
+  <rect width="3840" height="2160" fill="url(#right)" fill-opacity="0.20"/>
+  <rect width="3840" height="2160" fill="url(#left)" fill-opacity="0.25"/>
+  <defs>
+    <linearGradient id="full" x1="1920" x2="1920" y1="0" y2="2160" gradientUnits="userSpaceOnUse">
+      <stop stop-color="${theme.colors.tertiary.background}"/>
+      <stop offset="1" stop-color="${theme.colors.tertiary.background}" stop-opacity="0.5"/>
+    </linearGradient>
+    <radialGradient id="highlight" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1920 2160) rotate(90) scale(684.5 3891.29)">
+      <stop stop-color="${theme.colors.tertiary.backgroundEmphasis}"/>
+      <stop offset="1" stop-color="${theme.colors.tertiary.backgroundEmphasis}" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="right" x1="3728.97" y1="41.797" x2="2775.64" y2="1368.31" gradientUnits="userSpaceOnUse">
+      <stop stop-color="${theme.colors.accent.backgroundEmphasis}"/>
+      <stop offset="1" stop-color="${theme.colors.accent.backgroundEmphasis}" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="left" x1="-18.9569" y1="14.831" x2="884.72" y2="850.544" gradientUnits="userSpaceOnUse">
+      <stop stop-color="${theme.colors.info.backgroundEmphasis}"/>
+      <stop offset="1" stop-color="${theme.colors.info.backgroundEmphasis}" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+</svg>
+`;
+  }
+
   return theme.isDark
     ? `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 2322 1181"><path fill="url(#a)" d="M0 0h2322v1181H0z"/><path fill="url(#b)" fill-opacity=".25" d="M0 0h2322v1181H0z"/><path fill="url(#c)" fill-opacity=".2" d="M0 0h2322v1181H0z"/><path fill="#1b1b2c" fill-opacity=".4" d="M0 0h2322v1181H0z"/><defs><linearGradient id="a" x1="472.424" x2="335.969" y1="1181" y2="-57.275" gradientUnits="userSpaceOnUse"><stop stop-color="#1a1626"/><stop offset="1" stop-color="#3a364c"/></linearGradient><linearGradient id="b" x1="2254.86" x2="1752.33" y1="22.853" y2="796.185" gradientUnits="userSpaceOnUse"><stop stop-color="#722323"/><stop offset="1" stop-color="#722323" stop-opacity="0"/></linearGradient><linearGradient id="c" x1="-11.463" x2="484.016" y1="8.109" y2="514.871" gradientUnits="userSpaceOnUse"><stop stop-color="#1b6d68"/><stop offset="1" stop-color="#1b416d" stop-opacity="0"/></linearGradient></defs></svg>`
     : `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 2322 1181"><path fill="url(#a)" d="M0 0h2322v1181H0z"/><path fill="url(#b)" d="M0 0h2322v1181H0z"/><path fill="url(#c)" fill-opacity=".18" d="M0 0h2322v1181H0z"/><path fill="url(#d)" fill-opacity=".18" d="M0 0h2322v1181H0z"/><defs><linearGradient id="a" x1="472.424" x2="335.969" y1="1181" y2="-57.275" gradientUnits="userSpaceOnUse"><stop stop-color="#cbcee9"/><stop offset=".745" stop-color="#f4f2fb"/></linearGradient><linearGradient id="b" x1="862" x2="762.5" y1="1209.5" y2="12" gradientUnits="userSpaceOnUse"><stop stop-color="#e3e3ec"/><stop offset="1" stop-color="#dedfee"/></linearGradient><linearGradient id="c" x1="2268.5" x2="1749.44" y1="53.5" y2="797.834" gradientUnits="userSpaceOnUse"><stop stop-color="#ff9a9a"/><stop offset="1" stop-color="#ddc8eb" stop-opacity="0"/></linearGradient><linearGradient id="d" x1="-11.463" x2="655.435" y1="8.109" y2="772.366" gradientUnits="userSpaceOnUse"><stop stop-color="#a6e3df"/><stop offset="1" stop-color="#b6e1ee" stop-opacity="0"/></linearGradient></defs></svg>`;

--- a/public/app/core/components/Page/Page.tsx
+++ b/public/app/core/components/Page/Page.tsx
@@ -129,7 +129,7 @@ const getStyles = (theme: GrafanaTheme2, visualRefreshEnabled: boolean) => {
     }),
     wrapperGradient: css({
       label: 'page-wrapper-gradient',
-      background: `url('data:image/svg+xml;utf8,${encodeURIComponent(getGradientBackgroundForTheme(theme, visualRefreshEnabled))}') center center / cover no-repeat`,
+      background: `url('data:image/svg+xml;utf8,${encodeURIComponent(getGradientBackgroundForTheme(theme))}') center center / cover no-repeat`,
     }),
     pageContent: css({
       label: 'page-content',
@@ -177,14 +177,12 @@ function getDefaultBackgroundForLayout(layout: PageLayoutType, visualRefreshEnab
   return visualRefreshEnabled ? 'primary' : 'canvas';
 }
 
-function getGradientBackgroundForTheme(theme: GrafanaTheme2, visualRefreshEnabled: boolean) {
+function getGradientBackgroundForTheme(theme: GrafanaTheme2) {
   // Use an inline SVG as a background to avoid flashing of the background when loading a page
   // Use an inline SVG rather than a CSS gradient due to the complexity of the gradients being used
-
-  if (visualRefreshEnabled) {
-    return `
+  return `
 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 3840 2160">
-  <rect width="3840" height="2160" fill="${theme.components.home.background.base}" />
+  <rect width="3840" height="2160" fill="${theme.colors.background.page}" />
   <rect width="3840" height="2160" fill="url(#fade)" fill-opacity="0.5"/>
   <rect width="3840" height="2160" fill="url(#highlight)" fill-opacity="0.25"/>
   <rect width="3840" height="2160" fill="url(#right)" fill-opacity="0.20"/>
@@ -209,9 +207,4 @@ function getGradientBackgroundForTheme(theme: GrafanaTheme2, visualRefreshEnable
   </defs>
 </svg>
 `;
-  }
-
-  return theme.isDark
-    ? `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 2322 1181"><path fill="url(#a)" d="M0 0h2322v1181H0z"/><path fill="url(#b)" fill-opacity=".25" d="M0 0h2322v1181H0z"/><path fill="url(#c)" fill-opacity=".2" d="M0 0h2322v1181H0z"/><path fill="#1b1b2c" fill-opacity=".4" d="M0 0h2322v1181H0z"/><defs><linearGradient id="a" x1="472.424" x2="335.969" y1="1181" y2="-57.275" gradientUnits="userSpaceOnUse"><stop stop-color="#1a1626"/><stop offset="1" stop-color="#3a364c"/></linearGradient><linearGradient id="b" x1="2254.86" x2="1752.33" y1="22.853" y2="796.185" gradientUnits="userSpaceOnUse"><stop stop-color="#722323"/><stop offset="1" stop-color="#722323" stop-opacity="0"/></linearGradient><linearGradient id="c" x1="-11.463" x2="484.016" y1="8.109" y2="514.871" gradientUnits="userSpaceOnUse"><stop stop-color="#1b6d68"/><stop offset="1" stop-color="#1b416d" stop-opacity="0"/></linearGradient></defs></svg>`
-    : `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 2322 1181"><path fill="url(#a)" d="M0 0h2322v1181H0z"/><path fill="url(#b)" d="M0 0h2322v1181H0z"/><path fill="url(#c)" fill-opacity=".18" d="M0 0h2322v1181H0z"/><path fill="url(#d)" fill-opacity=".18" d="M0 0h2322v1181H0z"/><defs><linearGradient id="a" x1="472.424" x2="335.969" y1="1181" y2="-57.275" gradientUnits="userSpaceOnUse"><stop stop-color="#cbcee9"/><stop offset=".745" stop-color="#f4f2fb"/></linearGradient><linearGradient id="b" x1="862" x2="762.5" y1="1209.5" y2="12" gradientUnits="userSpaceOnUse"><stop stop-color="#e3e3ec"/><stop offset="1" stop-color="#dedfee"/></linearGradient><linearGradient id="c" x1="2268.5" x2="1749.44" y1="53.5" y2="797.834" gradientUnits="userSpaceOnUse"><stop stop-color="#ff9a9a"/><stop offset="1" stop-color="#ddc8eb" stop-opacity="0"/></linearGradient><linearGradient id="d" x1="-11.463" x2="655.435" y1="8.109" y2="772.366" gradientUnits="userSpaceOnUse"><stop stop-color="#a6e3df"/><stop offset="1" stop-color="#b6e1ee" stop-opacity="0"/></linearGradient></defs></svg>`;
 }

--- a/public/app/core/components/Page/Page.tsx
+++ b/public/app/core/components/Page/Page.tsx
@@ -184,27 +184,27 @@ function getGradientBackgroundForTheme(theme: GrafanaTheme2, visualRefreshEnable
   if (visualRefreshEnabled) {
     return `
 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 3840 2160">
-  <rect width="3840" height="2160" fill="${theme.colors.background.page}" />
-  <rect width="3840" height="2160" fill="url(#full)" fill-opacity="0.5"/>
+  <rect width="3840" height="2160" fill="${theme.components.home.background.base}" />
+  <rect width="3840" height="2160" fill="url(#fade)" fill-opacity="0.5"/>
   <rect width="3840" height="2160" fill="url(#highlight)" fill-opacity="0.25"/>
   <rect width="3840" height="2160" fill="url(#right)" fill-opacity="0.20"/>
   <rect width="3840" height="2160" fill="url(#left)" fill-opacity="0.25"/>
   <defs>
-    <linearGradient id="full" x1="1920" x2="1920" y1="0" y2="2160" gradientUnits="userSpaceOnUse">
-      <stop stop-color="${theme.colors.tertiary.background}"/>
-      <stop offset="1" stop-color="${theme.colors.tertiary.background}" stop-opacity="0.5"/>
+    <linearGradient id="fade" x1="1920" x2="1920" y1="0" y2="2160" gradientUnits="userSpaceOnUse">
+      <stop stop-color="${theme.components.home.background.fade}"/>
+      <stop offset="1" stop-color="${theme.components.home.background.fade}" stop-opacity="0.5"/>
     </linearGradient>
     <radialGradient id="highlight" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1920 2160) rotate(90) scale(684.5 3891.29)">
-      <stop stop-color="${theme.colors.tertiary.backgroundEmphasis}"/>
-      <stop offset="1" stop-color="${theme.colors.tertiary.backgroundEmphasis}" stop-opacity="0"/>
+      <stop stop-color="${theme.components.home.background.highlight}"/>
+      <stop offset="1" stop-color="${theme.components.home.background.highlight}" stop-opacity="0"/>
     </radialGradient>
     <linearGradient id="right" x1="3728.97" y1="41.797" x2="2775.64" y2="1368.31" gradientUnits="userSpaceOnUse">
-      <stop stop-color="${theme.colors.accent.backgroundEmphasis}"/>
-      <stop offset="1" stop-color="${theme.colors.accent.backgroundEmphasis}" stop-opacity="0"/>
+      <stop stop-color="${theme.components.home.background.right}"/>
+      <stop offset="1" stop-color="${theme.components.home.background.right}" stop-opacity="0"/>
     </linearGradient>
     <linearGradient id="left" x1="-18.9569" y1="14.831" x2="884.72" y2="850.544" gradientUnits="userSpaceOnUse">
-      <stop stop-color="${theme.colors.info.backgroundEmphasis}"/>
-      <stop offset="1" stop-color="${theme.colors.info.backgroundEmphasis}" stop-opacity="0"/>
+      <stop stop-color="${theme.components.home.background.left}"/>
+      <stop offset="1" stop-color="${theme.components.home.background.left}" stop-opacity="0"/>
     </linearGradient>
   </defs>
 </svg>


### PR DESCRIPTION
**What is this feature?**

Refresh:

| Before | After |
|-|-|
| <img width="1905" height="1178" alt="image" src="https://github.com/user-attachments/assets/bc8baf35-0b4b-456e-93e8-e39634f019a3" /> | <img width="1905" height="1178" alt="image" src="https://github.com/user-attachments/assets/0f383c1e-e61a-4bec-8d3c-37b4c29ac096" /> |
| <img width="1905" height="1178" alt="image" src="https://github.com/user-attachments/assets/f59e3e01-2c10-4f08-94d4-fae0ba4db41a" /> | <img width="1905" height="1178" alt="image" src="https://github.com/user-attachments/assets/a4c1d3f2-15a3-450c-9ed0-ba330be431cc" /> |

Default:

| Before | After |
|-|-|
| <img width="1905" height="1172" alt="image" src="https://github.com/user-attachments/assets/4cdbc22c-2855-40c2-b4d6-8b8a557eeebf" /> | <img width="1905" height="1172" alt="image" src="https://github.com/user-attachments/assets/6932f794-b33c-4e35-bd52-34ac26eccc66" />
| <img width="1905" height="1172" alt="image" src="https://github.com/user-attachments/assets/2cda80fa-529b-46a8-9ddc-46ee51c07c07" /> | <img width="1905" height="1172" alt="image" src="https://github.com/user-attachments/assets/a14eb9ff-4e15-4731-b6ea-5cd5f8a4440c" /> |

**Why do we need this feature?**

Darkens (or lightens) the background and updates it to use theme tokens for the colors within it, aligning it better to the visual refresh.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
