### PR TITLE
DataPro: Guard against new `DataSourceSrv` imports

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -594,6 +594,63 @@ module.exports = [
     },
   },
 
+  {
+    // DataPro finished migrating off the deprecated synchronous DataSourceSrv, so guard the
+    // paths we own against new imports creeping back in.
+    name: 'grafana/datapro-no-datasource-srv',
+    files: [
+      'public/app/features/explore/**/*.{ts,tsx,js,jsx}',
+      'public/app/features/correlations/**/*.{ts,tsx,js,jsx}',
+      'public/app/features/expressions/**/*.{ts,tsx,js,jsx}',
+      'public/app/features/transformers/**/*.{ts,tsx,js,jsx}',
+      'public/app/features/loki-helpers/**/*.{ts,tsx,js,jsx}',
+      'public/app/features/dashboard-scene/panel-edit/PanelEditNext/**/*.{ts,tsx,js,jsx}',
+      'public/app/features/dashboard/components/TransformationsEditor/**/*.{ts,tsx,js,jsx}',
+      'public/app/core/history/**/*.{ts,tsx,js,jsx}',
+      'public/app/core/utils/explore*.{ts,tsx,js,jsx}',
+      'public/app/core/utils/richHistory*.{ts,tsx,js,jsx}',
+      'public/app/core/components/SplitPaneWrapper/**/*.{ts,tsx,js,jsx}',
+      'public/app/core/crash/**/*.{ts,tsx,js,jsx}',
+    ],
+    ignores: [
+      // Owned by @grafana/observability-traces-and-profiling and still mid-migration.
+      'public/app/features/explore/TraceView/**',
+      // Deliberate holdout: reads the current srv so teardown can restore it. Needed until
+      // DataSourceSrv itself is deleted.
+      'public/app/features/explore/spec/helper/setup.tsx',
+      'public/app/features/explore/utils/supplementaryQueries_legacy.test.ts',
+      // Constructs a real DatasourceSrv to back a jest mock; legacy test seeding.
+      'public/app/core/history/RichHistoryLocalStorage.test.ts',
+    ],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        withBaseRestrictedImportsConfig({
+          patterns: [
+            {
+              // Duplicated because this block overrides the previous grafana/no-extensions-imports
+              group: ['app/extensions', 'app/extensions/*'],
+              message: 'Importing from app/extensions is not allowed',
+            },
+            {
+              group: ['@grafana/runtime'],
+              importNames: ['getDataSourceSrv'],
+              message:
+                'getDataSourceSrv is deprecated. Use the async APIs from @grafana/runtime/unstable instead: getDataSourceInstance, getDataSourceInstanceSettings, getDataSourceInstanceList, or the use* hooks. See grafana/grafana#125083.',
+            },
+            {
+              // getDatasourceSrv returns the concrete DatasourceSrv, which implements the same
+              // deprecated interface, so the app-internal module is restricted in full.
+              group: ['app/features/plugins/datasource_srv', '**/plugins/datasource_srv'],
+              message:
+                'app/features/plugins/datasource_srv is the deprecated synchronous DataSourceSrv. Use the async APIs from @grafana/runtime/unstable instead: getDataSourceInstance, getDataSourceInstanceSettings, getDataSourceInstanceList, or the use* hooks. See grafana/grafana#125083.',
+            },
+          ],
+        }),
+      ],
+    },
+  },
+
   // Old betterer rules config:
   {
     files: ['**/*.{js,jsx,ts,tsx}'],


### PR DESCRIPTION
## Description

DataPro finished migrating off the deprecated synchronous `DataSourceSrv` (#125083), but nothing stopped it returning: #129608 added a new `getDataSourceSrv()` import nine days after the migration was declared complete. That is the case this rule prevents.

It also covers the app-internal `getDatasourceSrv` (lowercase `s`) from `app/features/plugins/datasource_srv`, which returns the same deprecated interface. That was never obvious as in-scope, which is how six files were missed in the first pass.

Closes the last checkbox on #127033. Fixes DPRO-304.

## Changes

One `files`-scoped block in `eslint.config.js` over DataPro's CODEOWNERS paths, using `withBaseRestrictedImportsConfig` like its neighbours. Tests are in scope. It restricts:

- `@grafana/runtime` / `importNames: ['getDataSourceSrv']`, pointing at the async APIs in `@grafana/runtime/unstable`.
- `app/features/plugins/datasource_srv` in full, including relative forms.

`setDataSourceSrv` is deliberately not restricted — test seeding uses it, including `seedDataSources` from #130219.

Exempted: `explore/TraceView/**` (@grafana/observability-traces-and-profiling, mid-migration under #127037), `explore/spec/helper/setup.tsx` (teardown save/restore; permanent until `DataSourceSrv` is deleted), `explore/utils/supplementaryQueries_legacy.test.ts`, and `core/history/RichHistoryLocalStorage.test.ts`.

Around 20 remaining hits are `getDataSourceSrv: () => ...` properties inside `jest.mock` factories. `no-restricted-imports` sees imports only, so it cannot catch those; a custom AST rule is out of scope here.

## Risks

Low — lint-only, no source files touched. Two reviewer calls:

1. **The `RichHistoryLocalStorage.test.ts` exemption is my judgment, not from DPRO-304's audit**, which searched only the two function names and missed that this file imports the `DatasourceSrv` class to `new` one up. Narrowing to `importNames: ['getDatasourceSrv']` would need no exemption, but leaves `new DatasourceSrv()` legal in DataPro paths forever. Happy to flip it.
2. **I duplicated the `app/extensions` restriction.** `grafana/no-extensions-imports` scopes to `public/**`, and flat config replaces rule options wholesale, so this block would otherwise have silently dropped that guard for DataPro files.

## Demo

```
public/app/features/explore/Explore.tsx
  1:10  error  'getDataSourceSrv' import from '@grafana/runtime' is restricted from being
  used by a pattern. getDataSourceSrv is deprecated. Use the async APIs from
  @grafana/runtime/unstable instead: getDataSourceInstance, getDataSourceInstanceSettings,
  getDataSourceInstanceList, or the use* hooks. See grafana/grafana#125083
  no-restricted-imports
```

## Testing Instructions

`yarn lint` is clean on this branch.

1. Add `import { getDataSourceSrv } from '@grafana/runtime';` to a file under `public/app/features/explore/` (outside `TraceView/`), run `yarn eslint` on it, confirm the error above, revert.
2. Repeat with `import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';`.
3. `import { setDataSourceSrv } from '@grafana/runtime';` should **not** error.
4. `yarn eslint --print-config public/app/core/utils/explore.ts | grep "deprecated synchronous"` should match; the same against `explore/TraceView/TraceView.tsx` should not.

I verified all twelve globs resolve, all five exempted files are exempt, and that `test/mocks/datasource_srv` is not caught.

## Reviewer Checklist

- [ ] Scoped paths match DataPro's CODEOWNERS entries.
- [ ] The four exemptions are justified, in particular `RichHistoryLocalStorage.test.ts`.
- [ ] Restricting the internal module in full, not by `importNames`, is the right call.
- [ ] `setDataSourceSrv` staying unrestricted leaves no gap you care about.
- [ ] Messages are useful to someone hitting this cold.
