### PR TITLE
Explore: Fix logs table downloads

### DIFF
--- a/public/app/features/logs/utils.test.ts
+++ b/public/app/features/logs/utils.test.ts
@@ -467,6 +467,19 @@ describe('logRowsToReadableJson', () => {
       },
     ]);
   });
+
+  it('should include picked dataframe fields', () => {
+    const result = logRowsToReadableJson([testRow2], ['timestamp', 'body', 'foo2']);
+
+    expect(result).toEqual([
+      {
+        date: '1970-01-01T00:00:00.010Z',
+        line: 'test entry',
+        timestamp: '123456789',
+        fields: { timestamp: '1', body: 'test entry', foo2: 'bar2' },
+      },
+    ]);
+  });
 });
 
 describe('mergeLogsVolumeDataFrames', () => {
@@ -752,6 +765,31 @@ describe('downloadLogs', () => {
         })
       );
     });
+
+    it('Downloads selected dataframe fields in text format', async () => {
+      const textLogs = [
+        createLogRow({
+          timeEpochMs: 100,
+          entry: 'test entry',
+          labels: { label: 'value' },
+          dataFrame: toDataFrame({
+            refId: 'A',
+            fields: [
+              { name: 'timestamp', type: FieldType.time, values: [100] },
+              { name: 'body', type: FieldType.string, values: ['test entry'] },
+              { name: 'labels', type: FieldType.other, values: [{ label: 'value' }] },
+            ],
+          }),
+          rowIndex: 0,
+        }),
+      ];
+
+      await downloadLogs(DownloadFormat.Text, textLogs, [], ['timestamp', 'body']);
+
+      const blob = jest.mocked(saveAs).mock.calls[0][0];
+      const text = typeof blob === 'string' ? blob : await blob.text();
+      expect(text).toContain('100\t1970-01-01T00:00:00.100Z\t100 test entry\n');
+    });
   });
 
   describe('CSV format', () => {
@@ -818,6 +856,35 @@ describe('downloadLogs', () => {
       const lineField = exportedFrame.fields.find((f) => f.name === 'body');
       expect(lineField).toBeDefined();
       expect(lineField?.values).toContain('test entry');
+    });
+
+    it('includes selected dataframe fields', async () => {
+      const csvLogs = [
+        createLogRow({
+          timeEpochMs: 100,
+          entry: 'test entry',
+          labels: { label: 'value' },
+          dataFrame: toDataFrame({
+            refId: 'A',
+            fields: [
+              { name: 'timestamp', type: FieldType.time, values: [100] },
+              { name: 'body', type: FieldType.string, values: ['test entry'] },
+              { name: 'labels', type: FieldType.other, values: [{ label: 'value' }] },
+            ],
+            meta: {
+              type: DataFrameType.LogLines,
+            },
+          }),
+          rowIndex: 0,
+        }),
+      ];
+
+      await downloadLogs(DownloadFormat.CSV, csvLogs, [], ['timestamp', 'body']);
+
+      expect(downloadDataFrameAsCsv).toHaveBeenCalledTimes(1);
+      const exportedFrame = jest.mocked(downloadDataFrameAsCsv).mock.calls[0][0];
+      expect(exportedFrame.fields.map((field) => field.name)).toEqual(['Date', 'timestamp', 'body']);
+      expect(exportedFrame.fields.find((field) => field.name === 'body')?.values).toContain('test entry');
     });
   });
 });

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -34,6 +34,7 @@ import {
 import { t } from '@grafana/i18n';
 import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 import { getConfig } from 'app/core/config';
+import { safeStringifyValue } from 'app/core/utils/explore';
 
 import { getLogsExtractFields } from '../explore/Logs/LogsTable';
 import { downloadDataFrameAsCsv, downloadLogsModelAsTxt } from '../inspector/utils/download';
@@ -191,20 +192,7 @@ export const escapeUnescapedString = (string: string) =>
 
 export function logRowsToReadableJson(logs: LogRowModel[], pickFields: string[] = []) {
   return logs.map((log) => {
-    const fields = getDataframeFields(log).reduce<Record<string, string>>((acc, field) => {
-      const key = field.keys[0];
-      acc[key] = field.values[0];
-      return acc;
-    }, {});
-
-    let logFields = {
-      ...fields,
-      ...log.labels,
-    };
-
-    if (pickFields.length) {
-      logFields = Object.fromEntries(Object.entries(logFields).filter(([key]) => pickFields.includes(key)));
-    }
+    const logFields = getFieldsForLogRowDownload(log, pickFields);
 
     return {
       line: log.entry,
@@ -213,6 +201,38 @@ export function logRowsToReadableJson(logs: LogRowModel[], pickFields: string[] 
       fields: logFields,
     };
   });
+}
+
+function getFieldsForLogRowDownload(log: LogRowModel, pickFields: string[] = []) {
+  if (!pickFields.length) {
+    return {
+      ...getDataframeFields(log).reduce<Record<string, string>>((acc, field) => {
+        const key = field.keys[0];
+        acc[key] = field.values[0];
+        return acc;
+      }, {}),
+      ...log.labels,
+    };
+  }
+
+  const dataframeFields = log.dataFrame.fields.reduce<Record<string, string>>((acc, field) => {
+    const value = field.values[log.rowIndex];
+    if (value == null) {
+      return acc;
+    }
+
+    acc[field.name] =
+      typeof value === 'string' || typeof value === 'number' ? value.toString() : safeStringifyValue(value);
+    return acc;
+  }, {});
+
+  const logFields: Record<string, string> = {
+    ...dataframeFields,
+    ...log.labels,
+    [LOG_LINE_BODY_FIELD_NAME]: log.entry,
+  };
+
+  return Object.fromEntries(Object.entries(logFields).filter(([key]) => pickFields.includes(key)));
 }
 
 /**
@@ -516,13 +536,12 @@ export const downloadLogs = async (
 ) => {
   switch (format) {
     case DownloadFormat.Text:
-      const shouldInjectLogLineBodyField = fields.length > 0 && fields.includes(LOG_LINE_BODY_FIELD_NAME);
-      const rowsForDownload = shouldInjectLogLineBodyField
+      const rowsForDownload = fields.length
         ? logRows.map((row) => ({
             ...row,
             labels: {
               ...row.labels,
-              [LOG_LINE_BODY_FIELD_NAME]: row.entry,
+              ...getFieldsForLogRowDownload(row, fields),
             },
           }))
         : logRows;

--- a/public/app/plugins/panel/logstable/LogsTable.test.tsx
+++ b/public/app/plugins/panel/logstable/LogsTable.test.tsx
@@ -20,6 +20,7 @@ import { mockTransformationsRegistry, organizeFieldsTransformer } from '@grafana
 import { defaultTableOptions } from '@grafana/schema';
 import { PanelContextProvider, type PanelContext } from '@grafana/ui';
 import { LOGS_DATAPLANE_BODY_NAME, LOGS_DATAPLANE_TIMESTAMP_NAME } from 'app/features/logs/logsFrame';
+import { DownloadFormat, downloadLogs } from 'app/features/logs/utils';
 import { extractFieldsTransformer } from 'app/features/transformers/extractFields/extractFields';
 import { configureStore } from 'app/store/configureStore';
 
@@ -68,6 +69,11 @@ jest.mock('@grafana/runtime', () => ({
     links: [],
     isLoading: false,
   }),
+}));
+
+jest.mock('app/features/logs/utils', () => ({
+  ...jest.requireActual('app/features/logs/utils'),
+  downloadLogs: jest.fn(),
 }));
 
 const setUp = (
@@ -198,6 +204,28 @@ describe('LogsTable', () => {
         new LogSortOrderChangeEvent({
           order: LogsSortOrder.Ascending,
         })
+      );
+    });
+
+    it('downloads the raw log rows from Explore table view', async () => {
+      jest.mocked(downloadLogs).mockClear();
+      setUp(undefined, { showControls: true }, CoreApp.Explore);
+      await waitFor(() => expect(screen.getByLabelText('Download')).toBeInTheDocument());
+
+      await userEvent.click(screen.getByLabelText('Download'));
+      await userEvent.click(await screen.findByText('json'));
+
+      expect(downloadLogs).toHaveBeenCalledTimes(1);
+      expect(downloadLogs).toHaveBeenCalledWith(
+        DownloadFormat.Json,
+        expect.arrayContaining([
+          expect.objectContaining({
+            entry: 'log 1',
+            labels: expect.objectContaining({ level: 'info' }),
+          }),
+        ]),
+        [],
+        []
       );
     });
   });

--- a/public/app/plugins/panel/logstable/LogsTable.tsx
+++ b/public/app/plugins/panel/logstable/LogsTable.tsx
@@ -345,6 +345,7 @@ export const LogsTable = ({
             onChangeTimeRange={onChangeTimeRange}
             onWrapTextClick={handleWrapTextClick}
             logOptionsStorageKey={SETTING_KEY_ROOT}
+            downloadSeries={data.series}
           />
 
           <LogsTableDetails

--- a/public/app/plugins/panel/logstable/TableNGWrap.tsx
+++ b/public/app/plugins/panel/logstable/TableNGWrap.tsx
@@ -1,7 +1,14 @@
 import { css } from '@emotion/css';
 import { useCallback, useState } from 'react';
 
-import { type GrafanaTheme2, LogSortOrderChangeEvent, LogsSortOrder, type PanelProps, store } from '@grafana/data';
+import {
+  type DataFrame,
+  type GrafanaTheme2,
+  LogSortOrderChangeEvent,
+  LogsSortOrder,
+  type PanelProps,
+  store,
+} from '@grafana/data';
 import { getAppEvents } from '@grafana/runtime';
 import { usePanelContext, useStyles2 } from '@grafana/ui';
 import { TableNG } from '@grafana/ui/unstable';
@@ -28,6 +35,7 @@ interface Props extends Omit<PanelProps<Options>, 'timeRange'> {
   logOptionsStorageKey: string;
   containerElement: HTMLDivElement;
   onWrapTextClick: () => void;
+  downloadSeries?: DataFrame[];
 }
 
 export function TableNGWrap({
@@ -44,6 +52,7 @@ export function TableNGWrap({
   logOptionsStorageKey,
   containerElement,
   onWrapTextClick,
+  downloadSeries = data.series,
 }: Props) {
   useCacheFieldDisplayNames(data.series);
 
@@ -77,10 +86,10 @@ export function TableNGWrap({
   const downloadLogs = useCallback(
     (format: DownloadFormat) => {
       // converting to logsModel is a lot of unnecessary compute, but since this is only called on user action it should work as a short-term solution
-      const { meta, rows } = dataFrameToLogsModel(data.series);
+      const { meta, rows } = dataFrameToLogsModel(downloadSeries);
       download(format, rows, meta, options.displayedFields);
     },
-    [data.series, options.displayedFields]
+    [downloadSeries, options.displayedFields]
   );
 
   return (


### PR DESCRIPTION
**What is this feature?**

Fixes Explore Logs table-view downloads so the download control exports the raw log rows instead of the transformed table frame, and keeps selected dataframe fields populated in txt/json/csv exports.

**Why do we need this feature?**

The table visualisation can transform/organize the frame for rendering. Reusing that transformed frame for downloads causes empty txt/json files and broken CSV output for the same Loki result set that downloads correctly from the Logs view.

**Who is this feature for?**

Explore Logs users downloading table-view Loki log results.

**Which issue(s) does this PR fix?**:

Fixes #130157

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] Tests were added for the raw-row download path and selected dataframe-field txt/json/csv exports.

Verification run locally:
- `CI=1 yarn jest public/app/features/logs/utils.test.ts public/app/plugins/panel/logstable/LogsTable.test.tsx --runInBand --notify=false`
- `yarn eslint public/app/features/logs/utils.ts public/app/features/logs/utils.test.ts public/app/plugins/panel/logstable/LogsTable.tsx public/app/plugins/panel/logstable/TableNGWrap.tsx public/app/plugins/panel/logstable/LogsTable.test.tsx`
