### PR TITLE
Frontend: restrict usage of getDataSourceSrv

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2168,6 +2168,11 @@
       "count": 1
     }
   },
+  "public/app/features/explore/TraceView/createSpanLink.test.ts": {
+    "@grafana/no-get-data-source-srv": {
+      "count": 1
+    }
+  },
   "public/app/features/explore/TraceView/createSpanLink.tsx": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 2
@@ -3237,16 +3242,6 @@
     },
     "@typescript-eslint/no-explicit-any": {
       "count": 6
-    }
-  },
-  "public/app/plugins/panel/traces/TracesPanel.test.tsx": {
-    "@grafana/no-get-data-source-srv": {
-      "count": 1
-    }
-  },
-  "public/app/plugins/panel/traces/TracesPanel.tsx": {
-    "@grafana/no-get-data-source-srv": {
-      "count": 1
     }
   },
   "public/app/plugins/panel/xychart/SeriesEditor.tsx": {

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -308,7 +308,7 @@
     }
   },
   "packages/grafana-o11y-ds-frontend/src/TraceToProfiles/TraceToProfilesSettings.tsx": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     },
     "react-hooks/exhaustive-deps": {
@@ -800,11 +800,6 @@
       "count": 2
     }
   },
-  "public/app/core/components/NestedFolderPicker/useFoldersQuery.test.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "public/app/core/components/OptionsUI/NumberInput.tsx": {
     "@grafana/require-no-margin": {
       "count": 1
@@ -1118,10 +1113,10 @@
     }
   },
   "public/app/features/alerting/unified/components/rule-editor/ExpressionEditor.tsx": {
-    "@typescript-eslint/consistent-type-assertions": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     },
-    "no-restricted-imports": {
+    "@typescript-eslint/consistent-type-assertions": {
       "count": 1
     }
   },
@@ -1136,18 +1131,18 @@
     }
   },
   "public/app/features/alerting/unified/components/rule-editor/PreviewRule.tsx": {
-    "@typescript-eslint/no-explicit-any": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     },
-    "no-restricted-imports": {
+    "@typescript-eslint/no-explicit-any": {
       "count": 1
     }
   },
   "public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx": {
-    "@typescript-eslint/consistent-type-assertions": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     },
-    "no-restricted-imports": {
+    "@typescript-eslint/consistent-type-assertions": {
       "count": 1
     },
     "react-prefer-function-component/react-prefer-function-component": {
@@ -1155,7 +1150,7 @@
     }
   },
   "public/app/features/alerting/unified/components/rule-editor/RecordingRuleEditor.tsx": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
@@ -1185,27 +1180,27 @@
     }
   },
   "public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
   "public/app/features/alerting/unified/components/rule-viewer/tabs/QueryAndCondition.test.tsx": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
   "public/app/features/alerting/unified/components/rules/Filter/useRuleFilterAutocomplete.ts": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
   "public/app/features/alerting/unified/components/rules/MultipleDataSourcePicker.tsx": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
   "public/app/features/alerting/unified/components/rules/RuleDetailsDataSources.tsx": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
@@ -1243,12 +1238,12 @@
     }
   },
   "public/app/features/alerting/unified/home/Insights.tsx": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
   "public/app/features/alerting/unified/hooks/useAlertQueriesStatus.ts": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
@@ -1268,10 +1263,10 @@
     }
   },
   "public/app/features/alerting/unified/hooks/useFilteredRules.ts": {
-    "@typescript-eslint/consistent-type-assertions": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     },
-    "no-restricted-imports": {
+    "@typescript-eslint/consistent-type-assertions": {
       "count": 1
     }
   },
@@ -1291,42 +1286,32 @@
     }
   },
   "public/app/features/alerting/unified/rule-editor/formDefaults.test.ts": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
   "public/app/features/alerting/unified/rule-editor/formDefaults.ts": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "public/app/features/alerting/unified/rule-list/filter/useSavedSearches.test.tsx": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
   "public/app/features/alerting/unified/state/AlertingQueryRunner.ts": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "public/app/features/alerting/unified/triage/hooks/useTriageSavedSearches.test.tsx": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
   "public/app/features/alerting/unified/triage/scene/tagKeysProviders.test.ts": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
   "public/app/features/alerting/unified/triage/scene/tagKeysProviders.ts": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
   "public/app/features/alerting/unified/triage/scene/useLabelsBreakdown.ts": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
@@ -1341,7 +1326,7 @@
     }
   },
   "public/app/features/alerting/unified/utils/datasource.ts": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
@@ -1367,7 +1352,7 @@
     }
   },
   "public/app/features/alerting/unified/utils/rule-form.ts": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
@@ -1393,7 +1378,7 @@
     }
   },
   "public/app/features/annotations/utils/savedQueryUtils.ts": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
@@ -1451,7 +1436,7 @@
     }
   },
   "public/app/features/dashboard-prompt/datasources.ts": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
@@ -1479,27 +1464,27 @@
     }
   },
   "public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
   "public/app/features/dashboard-scene/panel-edit/PanelDataPane/EmptyTransformationsMessage.test.tsx": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
   "public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
   "public/app/features/dashboard-scene/panel-edit/PanelDataPane/utils.test.ts": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
   "public/app/features/dashboard-scene/panel-edit/PanelDataPane/utils.ts": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
@@ -1509,12 +1494,12 @@
     }
   },
   "public/app/features/dashboard-scene/scene/DashboardDataLayerSet.tsx": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
   "public/app/features/dashboard-scene/scene/DashboardScene.tsx": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
@@ -1529,14 +1514,14 @@
     }
   },
   "public/app/features/dashboard-scene/scene/export/exporters.ts": {
+    "@grafana/no-get-data-source-srv": {
+      "count": 1
+    },
     "@typescript-eslint/consistent-type-assertions": {
       "count": 3
     },
     "@typescript-eslint/no-explicit-any": {
       "count": 7
-    },
-    "no-restricted-imports": {
-      "count": 1
     }
   },
   "public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItemEditor.tsx": {
@@ -1576,12 +1561,12 @@
     }
   },
   "public/app/features/dashboard-scene/scene/panel-actions/PanelGroupByAction/PanelGroupByAction.tsx": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
   "public/app/features/dashboard-scene/scene/setDashboardPanelContext.ts": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
@@ -1591,7 +1576,7 @@
     }
   },
   "public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
@@ -1609,7 +1594,7 @@
     }
   },
   "public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
@@ -1619,7 +1604,7 @@
     }
   },
   "public/app/features/dashboard-scene/settings/AnnotationsEditView.tsx": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
@@ -1629,7 +1614,7 @@
     }
   },
   "public/app/features/dashboard-scene/settings/ProvisionedControlsSection.tsx": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
@@ -1639,17 +1624,17 @@
     }
   },
   "public/app/features/dashboard-scene/settings/annotations/AnnotationQueryOptions.tsx": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
   "public/app/features/dashboard-scene/settings/annotations/AnnotationSettingsEdit.tsx": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
   "public/app/features/dashboard-scene/settings/annotations/AnnotationSettingsList.tsx": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
@@ -1658,13 +1643,8 @@
       "count": 4
     }
   },
-  "public/app/features/dashboard-scene/settings/variables/VariablesUnknownTable.test.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "public/app/features/dashboard-scene/settings/variables/components/QueryVariableForm.tsx": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     },
     "react-hooks/exhaustive-deps": {
@@ -1685,12 +1665,12 @@
     }
   },
   "public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.tsx": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
   "public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.tsx": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     },
     "react-hooks/exhaustive-deps": {
@@ -1698,12 +1678,12 @@
     }
   },
   "public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/QueryVariableEditor.tsx": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
   "public/app/features/dashboard-scene/settings/variables/utils.ts": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
@@ -1766,42 +1746,42 @@
     }
   },
   "public/app/features/dashboard-scene/utils/dashboardControls.test.ts": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
   "public/app/features/dashboard-scene/utils/dashboardControls.ts": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
   "public/app/features/dashboard-scene/utils/drilldownUtils.test.ts": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
   "public/app/features/dashboard-scene/utils/drilldownUtils.ts": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
   "public/app/features/dashboard-scene/utils/getVizSuggestionForQuery.test.ts": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
   "public/app/features/dashboard-scene/utils/getVizSuggestionForQuery.ts": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
   "public/app/features/dashboard-scene/utils/utils.ts": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
   "public/app/features/dashboard-scene/utils/variables.ts": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
@@ -1816,14 +1796,14 @@
     }
   },
   "public/app/features/dashboard/components/DashExportModal/DashboardExporter.ts": {
+    "@grafana/no-get-data-source-srv": {
+      "count": 1
+    },
     "@typescript-eslint/consistent-type-assertions": {
       "count": 3
     },
     "@typescript-eslint/no-explicit-any": {
       "count": 7
-    },
-    "no-restricted-imports": {
-      "count": 1
     }
   },
   "public/app/features/dashboard/components/GenAI/hooks.ts": {
@@ -1837,12 +1817,12 @@
     }
   },
   "public/app/features/dashboard/components/Inspector/hooks.test.ts": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
   "public/app/features/dashboard/components/Inspector/hooks.ts": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
@@ -1940,7 +1920,7 @@
     }
   },
   "public/app/features/dashboard/containers/NewDashboardWithDS.tsx": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
@@ -1950,7 +1930,7 @@
     }
   },
   "public/app/features/dashboard/dashgrid/DashboardLibrary/utils/communityDashboardHelpers.test.ts": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
@@ -1965,14 +1945,14 @@
     }
   },
   "public/app/features/dashboard/state/DashboardMigrator.ts": {
+    "@grafana/no-get-data-source-srv": {
+      "count": 1
+    },
     "@typescript-eslint/consistent-type-assertions": {
       "count": 2
     },
     "@typescript-eslint/no-explicit-any": {
       "count": 13
-    },
-    "no-restricted-imports": {
-      "count": 1
     }
   },
   "public/app/features/dashboard/state/DashboardModel.repeat.test.ts": {
@@ -2021,11 +2001,6 @@
       "count": 1
     }
   },
-  "public/app/features/dashboard/utils/tracking.test.ts": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "public/app/features/datasources/components/ButtonRow.tsx": {
     "@grafana/no-gf-form": {
       "count": 1
@@ -2042,7 +2017,7 @@
     }
   },
   "public/app/features/datasources/hooks.ts": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
@@ -2199,10 +2174,10 @@
     }
   },
   "public/app/features/explore/spec/helper/setup.tsx": {
-    "@typescript-eslint/no-explicit-any": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     },
-    "no-restricted-imports": {
+    "@typescript-eslint/no-explicit-any": {
       "count": 1
     }
   },
@@ -2220,7 +2195,7 @@
     }
   },
   "public/app/features/explore/utils/supplementaryQueries_legacy.test.ts": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
@@ -2292,12 +2267,12 @@
     }
   },
   "public/app/features/logs/components/panel/LogLineMenu.test.tsx": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
   "public/app/features/manage-dashboards/import/utils/inputs.ts": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
@@ -2390,18 +2365,13 @@
     }
   },
   "public/app/features/plugins/datasource_srv.ts": {
+    "@grafana/no-get-data-source-srv": {
+      "count": 1
+    },
     "@typescript-eslint/consistent-type-assertions": {
       "count": 3
     },
     "@typescript-eslint/no-explicit-any": {
-      "count": 1
-    },
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "public/app/features/plugins/loader/sharedDependencies.ts": {
-    "no-restricted-imports": {
       "count": 1
     }
   },
@@ -2431,14 +2401,14 @@
     }
   },
   "public/app/features/query/components/QueryEditorRow.tsx": {
+    "@grafana/no-get-data-source-srv": {
+      "count": 1
+    },
     "@grafana/no-gf-form": {
       "count": 1
     },
     "@typescript-eslint/consistent-type-assertions": {
       "count": 3
-    },
-    "no-restricted-imports": {
-      "count": 1
     },
     "react-hooks/rules-of-hooks": {
       "count": 1
@@ -2448,7 +2418,7 @@
     }
   },
   "public/app/features/query/components/QueryEditorRows.tsx": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     },
     "react-prefer-function-component/react-prefer-function-component": {
@@ -2456,7 +2426,7 @@
     }
   },
   "public/app/features/query/components/QueryGroup.tsx": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     },
     "react-prefer-function-component/react-prefer-function-component": {
@@ -2469,7 +2439,7 @@
     }
   },
   "public/app/features/query/state/DashboardQueryRunner/AnnotationsWorker.ts": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
@@ -2544,14 +2514,14 @@
     }
   },
   "public/app/features/templating/template_srv.ts": {
+    "@grafana/no-get-data-source-srv": {
+      "count": 1
+    },
     "@typescript-eslint/consistent-type-assertions": {
       "count": 3
     },
     "@typescript-eslint/no-explicit-any": {
       "count": 9
-    },
-    "no-restricted-imports": {
-      "count": 1
     }
   },
   "public/app/features/transformers/FilterByValueTransformer/ValueMatchers/types.ts": {
@@ -2703,11 +2673,6 @@
       "count": 2
     }
   },
-  "public/app/features/variables/inspect/VariablesUnknownTable.test.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "public/app/features/variables/inspect/utils.ts": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 2
@@ -2745,11 +2710,11 @@
     }
   },
   "public/app/features/variables/query/actions.ts": {
+    "@grafana/no-get-data-source-srv": {
+      "count": 1
+    },
     "@typescript-eslint/no-explicit-any": {
       "count": 3
-    },
-    "no-restricted-imports": {
-      "count": 1
     }
   },
   "public/app/features/variables/query/operators.ts": {
@@ -2782,11 +2747,6 @@
       "count": 1
     }
   },
-  "public/app/features/variables/state/actions.test.ts": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "public/app/features/variables/state/actions.ts": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 6
@@ -2795,11 +2755,6 @@
   "public/app/features/variables/state/keyedVariablesReducer.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
-    }
-  },
-  "public/app/features/variables/state/onTimeRangeUpdated.test.ts": {
-    "no-restricted-imports": {
-      "count": 1
     }
   },
   "public/app/features/variables/state/sharedReducer.ts": {
@@ -2872,7 +2827,7 @@
     }
   },
   "public/app/plugins/datasource/azuremonitor/module.ts": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
@@ -2887,11 +2842,11 @@
     }
   },
   "public/app/plugins/datasource/cloudwatch/components/ConfigEditor/ConfigEditor.tsx": {
+    "@grafana/no-get-data-source-srv": {
+      "count": 1
+    },
     "@grafana/require-no-margin": {
       "count": 3
-    },
-    "no-restricted-imports": {
-      "count": 1
     }
   },
   "public/app/plugins/datasource/cloudwatch/components/ConfigEditor/SecureSocksProxySettingsNewStyling.tsx": {
@@ -2900,18 +2855,13 @@
     }
   },
   "public/app/plugins/datasource/cloudwatch/components/ConfigEditor/XrayLinkConfig.tsx": {
+    "@grafana/no-get-data-source-srv": {
+      "count": 1
+    },
     "@grafana/no-gf-form": {
       "count": 1
     },
     "@grafana/require-no-margin": {
-      "count": 1
-    },
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/MetricsQueryEditor.test.tsx": {
-    "no-restricted-imports": {
       "count": 1
     }
   },
@@ -2931,11 +2881,11 @@
     }
   },
   "public/app/plugins/datasource/cloudwatch/utils/datalinks.ts": {
+    "@grafana/no-get-data-source-srv": {
+      "count": 1
+    },
     "@typescript-eslint/consistent-type-assertions": {
       "count": 2
-    },
-    "no-restricted-imports": {
-      "count": 1
     }
   },
   "public/app/plugins/datasource/dashboard/DashboardQueryEditor.tsx": {
@@ -2994,11 +2944,11 @@
     }
   },
   "public/app/plugins/datasource/grafana/components/QueryEditor.tsx": {
+    "@grafana/no-get-data-source-srv": {
+      "count": 1
+    },
     "@typescript-eslint/consistent-type-assertions": {
       "count": 2
-    },
-    "no-restricted-imports": {
-      "count": 1
     }
   },
   "public/app/plugins/datasource/grafana/components/TimeRegionEditor.tsx": {
@@ -3084,7 +3034,7 @@
     }
   },
   "public/app/plugins/datasource/mixed/MixedDataSource.ts": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
@@ -3232,7 +3182,7 @@
     }
   },
   "public/app/plugins/panel/logstable/LogsTableDetails.test.tsx": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
@@ -3290,12 +3240,12 @@
     }
   },
   "public/app/plugins/panel/traces/TracesPanel.test.tsx": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
   "public/app/plugins/panel/traces/TracesPanel.tsx": {
-    "no-restricted-imports": {
+    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -308,6 +308,9 @@
     }
   },
   "packages/grafana-o11y-ds-frontend/src/TraceToProfiles/TraceToProfilesSettings.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    },
     "react-hooks/exhaustive-deps": {
       "count": 1
     }
@@ -797,6 +800,11 @@
       "count": 2
     }
   },
+  "public/app/core/components/NestedFolderPicker/useFoldersQuery.test.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "public/app/core/components/OptionsUI/NumberInput.tsx": {
     "@grafana/require-no-margin": {
       "count": 1
@@ -1112,6 +1120,9 @@
   "public/app/features/alerting/unified/components/rule-editor/ExpressionEditor.tsx": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "public/app/features/alerting/unified/components/rule-editor/FolderSelector.tsx": {
@@ -1127,13 +1138,24 @@
   "public/app/features/alerting/unified/components/rule-editor/PreviewRule.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1
     },
+    "no-restricted-imports": {
+      "count": 1
+    },
     "react-prefer-function-component/react-prefer-function-component": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/components/rule-editor/RecordingRuleEditor.tsx": {
+    "no-restricted-imports": {
       "count": 1
     }
   },
@@ -1159,6 +1181,31 @@
   },
   "public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/CloudDataSourceSelector.tsx": {
     "@grafana/require-no-margin": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/components/rule-viewer/tabs/QueryAndCondition.test.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/components/rules/Filter/useRuleFilterAutocomplete.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/components/rules/MultipleDataSourcePicker.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/components/rules/RuleDetailsDataSources.tsx": {
+    "no-restricted-imports": {
       "count": 1
     }
   },
@@ -1195,6 +1242,16 @@
       "count": 5
     }
   },
+  "public/app/features/alerting/unified/home/Insights.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/hooks/useAlertQueriesStatus.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "public/app/features/alerting/unified/hooks/useAlertmanagerConfig.ts": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1
@@ -1213,6 +1270,9 @@
   "public/app/features/alerting/unified/hooks/useFilteredRules.ts": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "public/app/features/alerting/unified/hooks/useGenericSavedSearches.ts": {
@@ -1230,6 +1290,46 @@
       "count": 1
     }
   },
+  "public/app/features/alerting/unified/rule-editor/formDefaults.test.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/rule-editor/formDefaults.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/rule-list/filter/useSavedSearches.test.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/state/AlertingQueryRunner.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/triage/hooks/useTriageSavedSearches.test.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/triage/scene/tagKeysProviders.test.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/triage/scene/tagKeysProviders.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/triage/scene/useLabelsBreakdown.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "public/app/features/alerting/unified/types/alerting.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 3
@@ -1237,6 +1337,11 @@
   },
   "public/app/features/alerting/unified/types/receiver-form.ts": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/utils/datasource.ts": {
+    "no-restricted-imports": {
       "count": 1
     }
   },
@@ -1261,6 +1366,11 @@
       "count": 2
     }
   },
+  "public/app/features/alerting/unified/utils/rule-form.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "public/app/features/alerting/unified/utils/rules.ts": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 3
@@ -1280,6 +1390,11 @@
     },
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    }
+  },
+  "public/app/features/annotations/utils/savedQueryUtils.ts": {
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "public/app/features/auth-config/FieldRenderer.tsx": {
@@ -1335,6 +1450,11 @@
       "count": 2
     }
   },
+  "public/app/features/dashboard-prompt/datasources.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "public/app/features/dashboard-scene/addToDashboard/AddToDashboardForm.tsx": {
     "@grafana/require-no-margin": {
       "count": 2
@@ -1358,8 +1478,43 @@
       "count": 1
     }
   },
+  "public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/panel-edit/PanelDataPane/EmptyTransformationsMessage.test.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/panel-edit/PanelDataPane/utils.test.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/panel-edit/PanelDataPane/utils.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "public/app/features/dashboard-scene/saving/SaveDashboardForm.tsx": {
     "@grafana/require-no-margin": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/scene/DashboardDataLayerSet.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/scene/DashboardScene.tsx": {
+    "no-restricted-imports": {
       "count": 1
     }
   },
@@ -1379,6 +1534,9 @@
     },
     "@typescript-eslint/no-explicit-any": {
       "count": 7
+    },
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItemEditor.tsx": {
@@ -1417,8 +1575,23 @@
       "count": 1
     }
   },
+  "public/app/features/dashboard-scene/scene/panel-actions/PanelGroupByAction/PanelGroupByAction.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/scene/setDashboardPanelContext.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "public/app/features/dashboard-scene/serialization/buildNewDashboardSaveModel.ts": {
     "@typescript-eslint/consistent-type-assertions": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts": {
+    "no-restricted-imports": {
       "count": 1
     }
   },
@@ -1435,8 +1608,18 @@
       "count": 1
     }
   },
+  "public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "public/app/features/dashboard-scene/serialization/transformToV1TypesUtils.ts": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/settings/AnnotationsEditView.tsx": {
+    "no-restricted-imports": {
       "count": 1
     }
   },
@@ -1445,9 +1628,29 @@
       "count": 1
     }
   },
+  "public/app/features/dashboard-scene/settings/ProvisionedControlsSection.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "public/app/features/dashboard-scene/settings/TimePickerSettings.tsx": {
     "@grafana/require-no-margin": {
       "count": 5
+    }
+  },
+  "public/app/features/dashboard-scene/settings/annotations/AnnotationQueryOptions.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/settings/annotations/AnnotationSettingsEdit.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/settings/annotations/AnnotationSettingsList.tsx": {
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "public/app/features/dashboard-scene/settings/variables/VariableEditableElement.tsx": {
@@ -1455,7 +1658,15 @@
       "count": 4
     }
   },
+  "public/app/features/dashboard-scene/settings/variables/VariablesUnknownTable.test.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "public/app/features/dashboard-scene/settings/variables/components/QueryVariableForm.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    },
     "react-hooks/exhaustive-deps": {
       "count": 1
     }
@@ -1473,8 +1684,26 @@
       "count": 1
     }
   },
+  "public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    },
     "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/QueryVariableEditor.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/settings/variables/utils.ts": {
+    "no-restricted-imports": {
       "count": 1
     }
   },
@@ -1536,6 +1765,46 @@
       "count": 1
     }
   },
+  "public/app/features/dashboard-scene/utils/dashboardControls.test.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/utils/dashboardControls.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/utils/drilldownUtils.test.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/utils/drilldownUtils.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/utils/getVizSuggestionForQuery.test.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/utils/getVizSuggestionForQuery.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/utils/utils.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/utils/variables.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "public/app/features/dashboard/api/ResponseTransformers.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
@@ -1552,6 +1821,9 @@
     },
     "@typescript-eslint/no-explicit-any": {
       "count": 7
+    },
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "public/app/features/dashboard/components/GenAI/hooks.ts": {
@@ -1562,6 +1834,16 @@
   "public/app/features/dashboard/components/HelpWizard/HelpWizard.tsx": {
     "@grafana/require-no-margin": {
       "count": 3
+    }
+  },
+  "public/app/features/dashboard/components/Inspector/hooks.test.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard/components/Inspector/hooks.ts": {
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "public/app/features/dashboard/components/PanelEditor/DynamicConfigValueEditor.tsx": {
@@ -1657,9 +1939,19 @@
       "count": 1
     }
   },
+  "public/app/features/dashboard/containers/NewDashboardWithDS.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "public/app/features/dashboard/dashgrid/DashboardLibrary/CompatibilityBadge.tsx": {
     "@grafana/no-plain-links": {
       "count": 2
+    }
+  },
+  "public/app/features/dashboard/dashgrid/DashboardLibrary/utils/communityDashboardHelpers.test.ts": {
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "public/app/features/dashboard/dashgrid/SeriesVisibilityConfigFactory.ts": {
@@ -1678,6 +1970,9 @@
     },
     "@typescript-eslint/no-explicit-any": {
       "count": 13
+    },
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "public/app/features/dashboard/state/DashboardModel.repeat.test.ts": {
@@ -1726,6 +2021,11 @@
       "count": 1
     }
   },
+  "public/app/features/dashboard/utils/tracking.test.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "public/app/features/datasources/components/ButtonRow.tsx": {
     "@grafana/no-gf-form": {
       "count": 1
@@ -1738,6 +2038,11 @@
   },
   "public/app/features/datasources/components/EditDataSourceActions.test.tsx": {
     "@grafana/no-plain-links": {
+      "count": 1
+    }
+  },
+  "public/app/features/datasources/hooks.ts": {
+    "no-restricted-imports": {
       "count": 1
     }
   },
@@ -1896,6 +2201,9 @@
   "public/app/features/explore/spec/helper/setup.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "public/app/features/explore/state/time.test.ts": {
@@ -1909,6 +2217,11 @@
     },
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    }
+  },
+  "public/app/features/explore/utils/supplementaryQueries_legacy.test.ts": {
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "public/app/features/expressions/ExpressionDatasource.ts": {
@@ -1975,6 +2288,16 @@
   },
   "public/app/features/live/centrifuge/channel.ts": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    }
+  },
+  "public/app/features/logs/components/panel/LogLineMenu.test.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "public/app/features/manage-dashboards/import/utils/inputs.ts": {
+    "no-restricted-imports": {
       "count": 1
     }
   },
@@ -2072,6 +2395,14 @@
     },
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "public/app/features/plugins/loader/sharedDependencies.ts": {
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "public/app/features/plugins/sandbox/distortions.ts": {
@@ -2106,6 +2437,9 @@
     "@typescript-eslint/consistent-type-assertions": {
       "count": 3
     },
+    "no-restricted-imports": {
+      "count": 1
+    },
     "react-hooks/rules-of-hooks": {
       "count": 1
     },
@@ -2114,17 +2448,28 @@
     }
   },
   "public/app/features/query/components/QueryEditorRows.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    },
     "react-prefer-function-component/react-prefer-function-component": {
       "count": 1
     }
   },
   "public/app/features/query/components/QueryGroup.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    },
     "react-prefer-function-component/react-prefer-function-component": {
       "count": 1
     }
   },
   "public/app/features/query/state/DashboardQueryRunner/AnnotationsQueryRunner.ts": {
     "@typescript-eslint/consistent-type-assertions": {
+      "count": 1
+    }
+  },
+  "public/app/features/query/state/DashboardQueryRunner/AnnotationsWorker.ts": {
+    "no-restricted-imports": {
       "count": 1
     }
   },
@@ -2204,6 +2549,9 @@
     },
     "@typescript-eslint/no-explicit-any": {
       "count": 9
+    },
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "public/app/features/transformers/FilterByValueTransformer/ValueMatchers/types.ts": {
@@ -2355,6 +2703,11 @@
       "count": 2
     }
   },
+  "public/app/features/variables/inspect/VariablesUnknownTable.test.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "public/app/features/variables/inspect/utils.ts": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 2
@@ -2394,6 +2747,9 @@
   "public/app/features/variables/query/actions.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 3
+    },
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "public/app/features/variables/query/operators.ts": {
@@ -2426,6 +2782,11 @@
       "count": 1
     }
   },
+  "public/app/features/variables/state/actions.test.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "public/app/features/variables/state/actions.ts": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 6
@@ -2434,6 +2795,11 @@
   "public/app/features/variables/state/keyedVariablesReducer.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    }
+  },
+  "public/app/features/variables/state/onTimeRangeUpdated.test.ts": {
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "public/app/features/variables/state/sharedReducer.ts": {
@@ -2505,6 +2871,11 @@
       "count": 7
     }
   },
+  "public/app/plugins/datasource/azuremonitor/module.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "public/app/plugins/datasource/azuremonitor/utils/common.ts": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1
@@ -2518,6 +2889,9 @@
   "public/app/plugins/datasource/cloudwatch/components/ConfigEditor/ConfigEditor.tsx": {
     "@grafana/require-no-margin": {
       "count": 3
+    },
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "public/app/plugins/datasource/cloudwatch/components/ConfigEditor/SecureSocksProxySettingsNewStyling.tsx": {
@@ -2530,6 +2904,14 @@
       "count": 1
     },
     "@grafana/require-no-margin": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/MetricsQueryEditor.test.tsx": {
+    "no-restricted-imports": {
       "count": 1
     }
   },
@@ -2551,6 +2933,9 @@
   "public/app/plugins/datasource/cloudwatch/utils/datalinks.ts": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 2
+    },
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "public/app/plugins/datasource/dashboard/DashboardQueryEditor.tsx": {
@@ -2611,6 +2996,9 @@
   "public/app/plugins/datasource/grafana/components/QueryEditor.tsx": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 2
+    },
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "public/app/plugins/datasource/grafana/components/TimeRegionEditor.tsx": {
@@ -2692,6 +3080,11 @@
   },
   "public/app/plugins/datasource/graphite/utils.ts": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    }
+  },
+  "public/app/plugins/datasource/mixed/MixedDataSource.ts": {
+    "no-restricted-imports": {
       "count": 1
     }
   },
@@ -2838,6 +3231,11 @@
       "count": 1
     }
   },
+  "public/app/plugins/panel/logstable/LogsTableDetails.test.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "public/app/plugins/panel/nodeGraph/Edge.tsx": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1
@@ -2889,6 +3287,16 @@
     },
     "@typescript-eslint/no-explicit-any": {
       "count": 6
+    }
+  },
+  "public/app/plugins/panel/traces/TracesPanel.test.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "public/app/plugins/panel/traces/TracesPanel.tsx": {
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "public/app/plugins/panel/xychart/SeriesEditor.tsx": {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -74,12 +74,6 @@ const baseImportConfig = {
       importNames: ['useObservable'],
       message: 'react-use is being phased out. Import useObservable from @grafana/data/unstable instead.',
     },
-    {
-      name: '@grafana/runtime',
-      importNames: ['getDataSourceSrv'],
-      message:
-        'getDataSourceSrv is being phased out in Grafana core. Use the async data source APIs from @grafana/runtime/unstable instead (getDataSourceInstance, getDataSourceInstanceSettings, getDataSourceInstanceList). See the migration guide in issue #125083.',
-    },
   ],
 };
 
@@ -184,6 +178,7 @@ module.exports = [
       '@grafana/zod-import-namespace': 'error',
       '@grafana/no-direct-date-fns': 'error',
       '@grafana/no-direct-create-monitoring-logger': 'error',
+      '@grafana/no-get-data-source-srv': 'error',
       'react-prefer-function-component/react-prefer-function-component': ['error', { allowJsxUtilityClass: true }],
       'react/prop-types': 'off',
       // need to ignore emotion's `css` prop, see https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unknown-property.md#rule-options

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -74,6 +74,12 @@ const baseImportConfig = {
       importNames: ['useObservable'],
       message: 'react-use is being phased out. Import useObservable from @grafana/data/unstable instead.',
     },
+    {
+      name: '@grafana/runtime',
+      importNames: ['getDataSourceSrv'],
+      message:
+        'getDataSourceSrv is being phased out in Grafana core. Use the async data source APIs from @grafana/runtime/unstable instead (getDataSourceInstance, getDataSourceInstanceSettings, getDataSourceInstanceList). See the migration guide in issue #125083.',
+    },
   ],
 };
 

--- a/packages/grafana-eslint-rules/rules/no-restricted-syntax.cjs
+++ b/packages/grafana-eslint-rules/rules/no-restricted-syntax.cjs
@@ -71,5 +71,14 @@ module.exports = createNoRestrictedSyntax(
     ].join(', '),
     message:
       "Zod imports must use exactly `import * as z from 'zod'` or `import type * as z from 'zod'`. Imports from zod subpaths are not allowed.",
+  },
+  {
+    name: 'no-get-data-source-srv',
+    selector: [
+      'ImportDeclaration[source.value="@grafana/runtime"] > ImportSpecifier[imported.name="getDataSourceSrv"]',
+      'Program:has(ImportDeclaration[source.value="@grafana/runtime"] > ImportDefaultSpecifier, ImportDeclaration[source.value="@grafana/runtime"] > ImportNamespaceSpecifier) MemberExpression[property.name="getDataSourceSrv"]',
+    ].join(', '),
+    message:
+      'getDataSourceSrv is being phased out in Grafana core. Use the async data source APIs from @grafana/runtime/unstable instead (getDataSourceInstance, getDataSourceInstanceSettings, getDataSourceInstanceList). See the migration guide https://github.com/grafana/grafana/issues/125083.',
   }
 );

--- a/packages/grafana-runtime/src/services/dataSourceSrv.ts
+++ b/packages/grafana-runtime/src/services/dataSourceSrv.ts
@@ -20,24 +20,16 @@ export interface DataSourceSrv {
    * Returns the requested dataSource. If it cannot be found it rejects the promise.
    * @param ref - The datasource identifier, it can be a name, UID or DataSourceRef (an object with UID),
    * @param scopedVars - variables used to interpolate a templated passed as name.
-   *
-   * @deprecated Use `getDataSourceInstance` or `useDataSourceInstance` from `@grafana/runtime/unstable` instead.
    */
   get(ref?: DataSourceRef | string | null, scopedVars?: ScopedVars): Promise<DataSourceApi>;
 
   /**
    * Get a list of data sources
-   *
-   * @deprecated For Grafana core and internal plugins: use `getDataSourceInstanceList` or
-   *   `useDataSourceInstanceList` from `@grafana/runtime/unstable` instead.
-   *   External plugin authors: no stable replacement is available yet.
    */
   getList(filters?: GetDataSourceListFilters): DataSourceInstanceSettings[];
 
   /**
    * Get settings and plugin metadata by name or uid
-   *
-   * @deprecated Use `getDataSourceInstanceSettings` or `useDataSourceInstanceSettings` from `@grafana/runtime/unstable` instead.
    */
   getInstanceSettings(
     ref?: DataSourceRef | string | null,
@@ -46,15 +38,11 @@ export interface DataSourceSrv {
 
   /**
    * Reloads the DataSourceSrv
-   *
-   * @deprecated Use `reloadDataSourceInstanceSettings` from `@grafana/runtime/unstable` instead.
    */
   reload(): Promise<void>;
 
   /**
    * Registers a runtime data source. Make sure your data source uid is unique.
-   *
-   * @deprecated Use `registerRuntimeDataSourceInstance` from `@grafana/runtime/unstable` instead.
    */
   registerRuntimeDataSource(entry: RuntimeDataSourceRegistration): void;
 }
@@ -122,10 +110,6 @@ export function setDataSourceSrv(instance: DataSourceSrv) {
  * a datasource that is added as a plugin (both external and internal).
  *
  * @public
- * @deprecated Import the specific functions/hooks directly from `@grafana/runtime/unstable`
- *   (e.g. `getDataSourceInstanceSettings`, `getDataSourceInstance`,
- *   `getDataSourceInstanceList`, `useDataSourceInstanceList`).
- *   This singleton will be removed once all callers have migrated.
  */
 export function getDataSourceSrv(): DataSourceSrv {
   return singletonInstance;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Blocks against any new usage of getDatasourceSrv and suppresses all current usage, giving a stronger signal to devs in their IDEs (red ink!) that something needs fixing. Also removes the deprecation notices as the new apis are unstable and I'm not sure we want to signal to the plugin devs to shift to unstable apis.


### Before
<img width="2302" height="1024" alt="image" src="https://github.com/user-attachments/assets/9c256a72-1e34-4b93-bea4-3656837e4654" />


### After 
<img width="2244" height="558" alt="image" src="https://github.com/user-attachments/assets/6e4cbfbd-a53d-4c13-bf76-395e930965f8" />



**Why do we need this feature?**

We need to move to the new async apis for MT goodness.

**Who is this feature for?**

Everyone.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
