### PR TITLE
Auditing: Document the resource name field and [auditing]snapshot_timeout setting

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/enterprise-configuration/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/enterprise-configuration/index.md
@@ -237,7 +237,7 @@ Set to false to only log requests with 2xx, 3xx, 401, 403, 500 responses.
 
 Maximum response body (in bytes) to be recorded. May help reducing the memory footprint caused by auditing.
 
-### snapshot_timeout
+### `snapshot_timeout`
 
 Grafana uses `snapshot_timeout` as a cooperative deadline when resolving resource names before serving a request that may delete resources. Grafana currently uses this setting for `DELETE /api/admin/users/{id}`. Because the backing store must honor context cancellation, the value isn't a strict upper bound on request latency. Use a duration such as `500ms` or `2s`. If you configure zero or a negative duration, Grafana logs a warning and uses the default of `500ms`.
 

--- a/docs/sources/setup-grafana/configure-grafana/enterprise-configuration/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/enterprise-configuration/index.md
@@ -237,6 +237,10 @@ Set to false to only log requests with 2xx, 3xx, 401, 403, 500 responses.
 
 Maximum response body (in bytes) to be recorded. May help reducing the memory footprint caused by auditing.
 
+### snapshot_timeout
+
+Grafana uses `snapshot_timeout` as a cooperative deadline when resolving resource names before serving a request that may delete resources. Grafana currently uses this setting for `DELETE /api/admin/users/:id`. Because the backing store must honor context cancellation, the value isn't a strict upper bound on request latency. Use a duration such as `500ms` or `2s`. If you configure zero or a negative duration, Grafana logs a warning and uses the default of `500ms`.
+
 ## [auditing.logs.file]
 
 ### path

--- a/docs/sources/setup-grafana/configure-grafana/enterprise-configuration/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/enterprise-configuration/index.md
@@ -239,7 +239,7 @@ Maximum response body (in bytes) to be recorded. May help reducing the memory fo
 
 ### snapshot_timeout
 
-Grafana uses `snapshot_timeout` as a cooperative deadline when resolving resource names before serving a request that may delete resources. Grafana currently uses this setting for `DELETE /api/admin/users/:id`. Because the backing store must honor context cancellation, the value isn't a strict upper bound on request latency. Use a duration such as `500ms` or `2s`. If you configure zero or a negative duration, Grafana logs a warning and uses the default of `500ms`.
+Grafana uses `snapshot_timeout` as a cooperative deadline when resolving resource names before serving a request that may delete resources. Grafana currently uses this setting for `DELETE /api/admin/users/{id}`. Because the backing store must honor context cancellation, the value isn't a strict upper bound on request latency. Use a duration such as `500ms` or `2s`. If you configure zero or a negative duration, Grafana logs a warning and uses the default of `500ms`.
 
 ## [auditing.logs.file]
 

--- a/docs/sources/setup-grafana/configure-security/audit-grafana.md
+++ b/docs/sources/setup-grafana/configure-security/audit-grafana.md
@@ -372,7 +372,7 @@ By default, dashboard content doesn't appear in audit logs because it can signif
 
 Data source query request and response bodies are also excluded by default. Enabling `log_datasource_query_request_body` or `log_datasource_query_response_body` significantly increases log volume and may expose sensitive data such as query parameters, credentials, or personally identifiable information.
 
-Before Grafana serves `DELETE /api/admin/users/:id`, it tries to capture the user's display name, or login when the display name is empty, so the audit log can retain it after a successful deletion. The `snapshot_timeout` option sets a cooperative context deadline for this lookup. The user store must honor context cancellation, so the setting isn't a strict upper bound on request latency. If the lookup fails or observes an expired deadline, Grafana continues to process the request. If the deletion succeeds, the audit log omits `resources[x].name`.
+Before Grafana serves `DELETE /api/admin/users/{id}`, it tries to capture the user's display name, or login when the display name is empty, so the audit log can retain it after a successful deletion. The `snapshot_timeout` option sets a cooperative context deadline for this lookup. The user store must honor context cancellation, so the setting isn't a strict upper bound on request latency. If the lookup fails or observes an expired deadline, Grafana continues to process the request. If the deletion succeeds, the audit log omits `resources[x].name`.
 
 ```ini
 [auditing]

--- a/docs/sources/setup-grafana/configure-security/audit-grafana.md
+++ b/docs/sources/setup-grafana/configure-security/audit-grafana.md
@@ -61,8 +61,10 @@ Audit logs contain the following fields. The fields followed by **\*** are alway
 | `result.failureMessage` | string  | HTTP error message.                                                                                                                                                                                                      |
 | `result.body`           | string  | Response body. Filled with `<non-marshalable format>` when it isn't a valid JSON.                                                                                                                                        |
 | `resources`             | array   | Information about the resources that the request action affected. This field can be null for non-resource actions such as `login` or `logout`.                                                                           |
-| `resources[x].id`\*     | number  | ID of the resource.                                                                                                                                                                                                      |
+| `resources[x].id`       | number  | ID of the resource, when available.                                                                                                                                                                                      |
 | `resources[x].type`\*   | string  | The type of the resource that was logged: `alert`, `alert-notification`, `annotation`, `api-key`, `auth-token`, `dashboard`, `datasource`, `folder`, `org`, `panel`, `playlist`, `report`, `team`, `user`, or `version`. |
+| `resources[x].uid`      | string  | UID of the resource, when available.                                                                                                                                                                                     |
+| `resources[x].name`     | string  | Name of the resource, when available. Grafana currently populates this field for `user` resources.                                                                                                                       |
 | `requestUri`\*          | string  | Request URI.                                                                                                                                                                                                             |
 | `ipAddress`\*           | string  | IP address that the request was made from.                                                                                                                                                                               |
 | `userAgent`\*           | string  | Agent through which the request was made.                                                                                                                                                                                |
@@ -70,13 +72,14 @@ Audit logs contain the following fields. The fields followed by **\*** are alway
 | `additionalData`        | object  | Additional information that can be provided about the request.                                                                                                                                                           |
 
 The `additionalData` field can contain the following information:
-| Field name | Action | Description |
-| ---------- | ------ | ----------- |
-| `loginUsername` | `login` | Login used in the Grafana authentication form. |
-| `extUserInfo` | `login` | User information provided by the external system that was used to log in. |
-| `authTokenCount` | `login` | Number of active authentication tokens for the user that logged in. |
-| `terminationReason` | `logout` | The reason why the user logged out, such as a manual logout or a token expiring. |
-| `billing_role` | `billing-information` | The billing role associated with the billing information being sent. |
+
+| Field name          | Action                | Description                                                                      |
+| ------------------- | --------------------- | -------------------------------------------------------------------------------- |
+| `loginUsername`     | `login`               | Login used in the Grafana authentication form.                                   |
+| `extUserInfo`       | `login`               | User information provided by the external system that was used to log in.        |
+| `authTokenCount`    | `login`               | Number of active authentication tokens for the user that logged in.              |
+| `terminationReason` | `logout`              | The reason why the user logged out, such as a manual logout or a token expiring. |
+| `billing_role`      | `billing-information` | The billing role associated with the billing information being sent.             |
 
 ### Identify recorded actions
 
@@ -369,6 +372,8 @@ By default, dashboard content doesn't appear in audit logs because it can signif
 
 Data source query request and response bodies are also excluded by default. Enabling `log_datasource_query_request_body` or `log_datasource_query_response_body` significantly increases log volume and may expose sensitive data such as query parameters, credentials, or personally identifiable information.
 
+Before Grafana serves `DELETE /api/admin/users/:id`, it tries to capture the user's display name, or login when the display name is empty, so the audit log can retain it after a successful deletion. The `snapshot_timeout` option sets a cooperative context deadline for this lookup. The user store must honor context cancellation, so the setting isn't a strict upper bound on request latency. If the lookup fails or observes an expired deadline, Grafana continues to process the request. If the deletion succeeds, the audit log omits `resources[x].name`.
+
 ```ini
 [auditing]
 # Enable the auditing feature
@@ -389,6 +394,10 @@ log_all_status_codes = false
 # Maximum response body (in bytes) to be audited; 500KiB by default.
 # May help reducing the memory footprint caused by auditing.
 max_response_size_bytes = 512000
+# Timeout for resolving resource names before Grafana serves a request that
+# may delete resources. Uses duration format, for example, 500ms or 2s.
+# The default is 500ms.
+snapshot_timeout = 500ms
 ```
 
 Each exporter has its own configuration fields.


### PR DESCRIPTION
Follows up on the admin user-deletion audit enrichment (implementation companion, Grafana Labs internal: grafana/grafana-enterprise#12941) with the promised OSS documentation:

- `resources[x].name` — added to the audit log fields table, plus a paragraph in the configuration section covering the pre-deletion lookup and its failure behavior (if the lookup fails and the deletion succeeds, the entry omits the name).
- `resources[x].uid` — added to the fields table; already emitted but undocumented. The `resources[x].id` row also loses its always-present star — the field is omitted when absent.
- `[auditing]snapshot_timeout` — added to the sample ini block and the enterprise configuration reference (cooperative deadline, duration format; zero or negative values log a warning and fall back to `500ms`).

Docs only; no code changes. The adjacent `additionalData` table in the audit page picks up a formatting-only Prettier realignment.

---

This PR follows up on a customer request from Grafana's Voice of Customer (VoC) program (internal ref IDEASVOC-I-10349). It was prepared with AI assistance as part of an internal VoC→PR pilot and human-reviewed before submission; I'm the accountable author and will handle review feedback.
