### PR TITLE
Logs Table: Fix data export by passing the raw table frame

### DIFF
--- a/public/app/plugins/panel/logstable/LogsTable.test.tsx
+++ b/public/app/plugins/panel/logstable/LogsTable.test.tsx
@@ -20,6 +20,7 @@ import { mockTransformationsRegistry, organizeFieldsTransformer } from '@grafana
 import { defaultTableOptions } from '@grafana/schema';
 import { PanelContextProvider, type PanelContext } from '@grafana/ui';
 import { LOGS_DATAPLANE_BODY_NAME, LOGS_DATAPLANE_TIMESTAMP_NAME } from 'app/features/logs/logsFrame';
+import { DownloadFormat, downloadLogs } from 'app/features/logs/utils';
 import { extractFieldsTransformer } from 'app/features/transformers/extractFields/extractFields';
 import { configureStore } from 'app/store/configureStore';
 
@@ -29,6 +30,11 @@ import { LogsTable } from './LogsTable';
 import { type Options } from './options/types';
 import { defaultOptions } from './panelcfg.gen';
 import { getPanelData } from './testsUtils';
+
+jest.mock('app/features/logs/utils', () => ({
+  ...jest.requireActual('app/features/logs/utils'),
+  downloadLogs: jest.fn(),
+}));
 
 const fieldConfig: FieldConfigSource = {
   defaults: {},
@@ -199,6 +205,37 @@ describe('LogsTable', () => {
           order: LogsSortOrder.Ascending,
         })
       );
+    });
+
+    it('downloads from the raw frame when displayed fields exclude the log body', async () => {
+      // Regression: organizeFields removes body from data.series for display. Download must use the
+      // raw frame — dataFrameToLogsModel needs body — or the export is empty.
+      const downloadLogsMock = jest.mocked(downloadLogs);
+      downloadLogsMock.mockClear();
+
+      const { container } = setUp(undefined, {
+        showControls: true,
+        allowDownload: true,
+        displayedFields: [LOGS_DATAPLANE_TIMESTAMP_NAME, 'level'],
+      });
+
+      await waitFor(() => expect(screen.getByLabelText('Download logs')).toBeInTheDocument());
+
+      const headers = container.querySelectorAll('[role="columnheader"]');
+      expect(Array.from(headers).map((h) => h.textContent)).toEqual(['timestamp', 'level']);
+
+      await userEvent.click(screen.getByLabelText('Download logs'));
+      await userEvent.click(await screen.findByText('json'));
+
+      expect(downloadLogsMock).toHaveBeenCalledTimes(1);
+      expect(downloadLogsMock).toHaveBeenCalledWith(DownloadFormat.Json, expect.any(Array), expect.anything(), [
+        LOGS_DATAPLANE_TIMESTAMP_NAME,
+        'level',
+      ]);
+
+      const rows = downloadLogsMock.mock.calls[0][1];
+      expect(rows.map((row) => row.entry)).toEqual(['log 1', 'log 2']);
+      expect(rows[0].dataFrame.fields.some((field) => field.name === LOGS_DATAPLANE_BODY_NAME)).toBe(true);
     });
   });
 

--- a/public/app/plugins/panel/logstable/LogsTable.tsx
+++ b/public/app/plugins/panel/logstable/LogsTable.tsx
@@ -345,6 +345,7 @@ export const LogsTable = ({
             onChangeTimeRange={onChangeTimeRange}
             onWrapTextClick={handleWrapTextClick}
             logOptionsStorageKey={SETTING_KEY_ROOT}
+            rawDataFrame={rawTableFrame}
           />
 
           <LogsTableDetails

--- a/public/app/plugins/panel/logstable/TableNGWrap.tsx
+++ b/public/app/plugins/panel/logstable/TableNGWrap.tsx
@@ -1,7 +1,14 @@
 import { css } from '@emotion/css';
 import { useCallback, useState } from 'react';
 
-import { type GrafanaTheme2, LogSortOrderChangeEvent, LogsSortOrder, type PanelProps, store } from '@grafana/data';
+import {
+  type DataFrame,
+  type GrafanaTheme2,
+  LogSortOrderChangeEvent,
+  LogsSortOrder,
+  type PanelProps,
+  store,
+} from '@grafana/data';
 import { getAppEvents } from '@grafana/runtime';
 import { usePanelContext, useStyles2 } from '@grafana/ui';
 import { TableNG } from '@grafana/ui/unstable';
@@ -28,6 +35,7 @@ interface Props extends Omit<PanelProps<Options>, 'timeRange'> {
   logOptionsStorageKey: string;
   containerElement: HTMLDivElement;
   onWrapTextClick: () => void;
+  rawDataFrame: DataFrame | null;
 }
 
 export function TableNGWrap({
@@ -44,6 +52,7 @@ export function TableNGWrap({
   logOptionsStorageKey,
   containerElement,
   onWrapTextClick,
+  rawDataFrame,
 }: Props) {
   useCacheFieldDisplayNames(data.series);
 
@@ -76,11 +85,14 @@ export function TableNGWrap({
 
   const downloadLogs = useCallback(
     (format: DownloadFormat) => {
+      if (!rawDataFrame) {
+        return;
+      }
       // converting to logsModel is a lot of unnecessary compute, but since this is only called on user action it should work as a short-term solution
-      const { meta, rows } = dataFrameToLogsModel(data.series);
+      const { meta, rows } = dataFrameToLogsModel([rawDataFrame]);
       download(format, rows, meta, options.displayedFields);
     },
-    [data.series, options.displayedFields]
+    [options.displayedFields, rawDataFrame]
   );
 
   return (


### PR DESCRIPTION
By passing the transformed frame we were missing required information by logsModel to properly generate rows for export.
Now passing the raw table frame.

Fixes https://github.com/grafana/grafana/issues/130157

### How to reproduce

With the new logs table:
- Query logs
- Select one field from the list on the left, uncheck everything else.
- Expected result: the files should not be empty and should respect the fields on display.