### PR TITLE
Diagnostics: record a truncation reason even when querydata.json still fits

### DIFF
--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -137,7 +137,11 @@ func (b *Bundler) Build(resp *backend.QueryDataResponse, harBuffer *harcapture.B
 			// only trace of the drop is the truncated/limitBytes/originalBytes fields inside
 			// querydata.json itself -- easy to miss next to an actual encode failure, which does get a
 			// querydata-error.txt. Record it the same way so either cause leaves a visible trail.
-			queryDataErr = errors.Join(queryDataErr, fmt.Errorf("querydata.json was truncated: response exceeded the %d-byte size limit", maxQueryDataArtifactBytes))
+			//
+			// "request and/or response" rather than naming one side: truncated can fire with no response
+			// at all (an oversized request on its own), so blaming "the response" unconditionally would
+			// contradict querydata.json's own responseOmitted/requestOmitted markers in that case.
+			queryDataErr = errors.Join(queryDataErr, fmt.Errorf("querydata.json was truncated: request and/or response exceeded the %d-byte size limit", maxQueryDataArtifactBytes))
 		}
 		if err != nil {
 			// A query-data artifact that cannot be fully JSON-encoded must not sink the whole bundle:
@@ -489,7 +493,12 @@ func (b *Bundler) BuildDashboard(dashboardJSON json.RawMessage, panels []Dashboa
 						// the other two QueryDataTruncated branches above, nothing else here would otherwise
 						// explain why. Without a message, QueryDataError stays empty and the manifest reads
 						// as if this panel's query data is complete.
-						queryDataErrs = append(queryDataErrs, fmt.Sprintf("querydata.json was truncated: response exceeded its %d-byte assigned budget", queryDataLimit))
+						//
+						// "request and/or response" rather than naming one side: truncated can fire with no
+						// response at all (an oversized request on its own), so blaming "the response"
+						// unconditionally would contradict querydata.json's own responseOmitted/requestOmitted
+						// markers in that case.
+						queryDataErrs = append(queryDataErrs, fmt.Sprintf("querydata.json was truncated: request and/or response exceeded its %d-byte assigned budget", queryDataLimit))
 					}
 				}
 			}

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -131,7 +131,14 @@ func (b *Bundler) Build(resp *backend.QueryDataResponse, harBuffer *harcapture.B
 		queryDataErr = fmt.Errorf("serialize query request: %w", queryRequestErr)
 	}
 	if resp != nil || len(queryRequestJSON) > 0 {
-		queryData, err := marshalQueryDataArtifact(queryRequestJSON, resp)
+		queryData, truncated, err := marshalQueryDataArtifactWithLimit(queryRequestJSON, resp, maxQueryDataArtifactBytes)
+		if truncated {
+			// A truncated artifact still encodes successfully (err stays nil below), so without this the
+			// only trace of the drop is the truncated/limitBytes/originalBytes fields inside
+			// querydata.json itself -- easy to miss next to an actual encode failure, which does get a
+			// querydata-error.txt. Record it the same way so either cause leaves a visible trail.
+			queryDataErr = errors.Join(queryDataErr, fmt.Errorf("querydata.json was truncated: response exceeded the %d-byte size limit", maxQueryDataArtifactBytes))
+		}
 		if err != nil {
 			// A query-data artifact that cannot be fully JSON-encoded must not sink the whole bundle:
 			// record the failure and still ship HAR and the other artifacts, mirroring how the dashboard
@@ -209,11 +216,6 @@ type queryDataFrameSummary struct {
 	RefID  string `json:"refId,omitempty"`
 	Rows   int    `json:"rows"`
 	Fields int    `json:"fields"`
-}
-
-func marshalQueryDataArtifact(request json.RawMessage, resp *backend.QueryDataResponse) ([]byte, error) {
-	data, _, err := marshalQueryDataArtifactWithLimit(request, resp, maxQueryDataArtifactBytes)
-	return data, err
 }
 
 // marshalQueryDataArtifactWithLimit returns the encoded querydata.json plus whether it had to drop
@@ -482,6 +484,13 @@ func (b *Bundler) BuildDashboard(dashboardJSON json.RawMessage, panels []Dashboa
 					entry.QueryDataBytes = len(queryData)
 					queryDataBytesRemaining -= len(queryData)
 					entry.QueryDataTruncated = truncated
+					if truncated {
+						// Encoded successfully within its budget, but only after dropping content -- unlike
+						// the other two QueryDataTruncated branches above, nothing else here would otherwise
+						// explain why. Without a message, QueryDataError stays empty and the manifest reads
+						// as if this panel's query data is complete.
+						queryDataErrs = append(queryDataErrs, fmt.Sprintf("querydata.json was truncated: response exceeded its %d-byte assigned budget", queryDataLimit))
+					}
 				}
 			}
 		}

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -137,6 +137,13 @@ func TestBundler_Build_boundsOversizedQueryData(t *testing.T) {
 	require.Contains(t, string(queryData), `"truncated": true`)
 	require.Contains(t, string(queryData), `"rows": 1`)
 	require.Contains(t, string(queryData), `"refId": "A"`)
+
+	// A truncated-but-successfully-encoded artifact still leaves a trail outside querydata.json
+	// itself: without this, a size-limit drop and a "nothing at all went wrong" bundle both come back
+	// with no querydata-error.txt, and a reader who doesn't dig into querydata.json's own fields would
+	// never know content was dropped.
+	require.Contains(t, files, "querydata-error.txt")
+	require.Contains(t, string(files["querydata-error.txt"]), "truncated")
 }
 
 func TestBundler_Build_boundsOversizedRequestWithoutResponse(t *testing.T) {
@@ -600,6 +607,27 @@ func TestBuildDashboard_boundsAggregateQueryData(t *testing.T) {
 	}
 	require.LessOrEqual(t, queryDataBytes, maxDashboardQueryDataBytes)
 	require.Contains(t, string(files["manifest.json"]), `"queryDataTruncated": true`)
+}
+
+// A panel whose own querydata.json needs internal truncation, but still fits comfortably inside the
+// remaining dashboard budget, took the one QueryDataTruncated branch in BuildDashboard that recorded no
+// queryDataError message -- unlike the other two (budget exhausted / artifact still over budget after
+// truncating). This pins that gap closed.
+func TestBuildDashboard_recordsQueryDataErrorWhenSinglePanelTruncatedWithinBudget(t *testing.T) {
+	frame := data.NewFrame("logs", data.NewField("line", nil, []string{strings.Repeat("x", maxQueryDataArtifactBytes)}))
+	panels := []DashboardPanel{{
+		ID:    1,
+		Title: "Logs",
+		Resp:  &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{frame}}}},
+	}}
+
+	blob, err := NewBundler(nil).BuildDashboard(nil, panels)
+	require.NoError(t, err)
+
+	files := readTarGz(t, blob)
+	require.Contains(t, string(files["manifest.json"]), `"queryDataTruncated": true`)
+	require.Contains(t, string(files["manifest.json"]), `"queryDataError"`)
+	require.Contains(t, string(files["manifest.json"]), "truncated")
 }
 
 // The whole-dashboard client posts the dashboard save model once instead of each panel's JSON, so


### PR DESCRIPTION
## Summary
- A response too large for the querydata.json size budget still encodes successfully once truncated (no error is returned), so the only trace of the drop was the `truncated`/`limitBytes`/`originalBytes` fields inside `querydata.json` itself.
- The single-panel path's `querydata-error.txt` and the dashboard path's `manifest.json` `queryDataError` were already populated for a request-serialize failure or an artifact still over budget after truncating, but not for this most common case (truncated, but fits) -- so it read as complete unless you opened `querydata.json` and checked its own fields.
- Folds a truncation note into the same `querydata-error.txt` / manifest entry either path already produces. No signature change on `Build`/`BuildDashboard`, no new signal -- purely closes a gap in an existing mechanism.

## Test plan
- [x] `go test ./pkg/services/diagnostics/...` passes, including two new tests pinning the gap closed (one per path)
- [x] `go vet ./pkg/services/diagnostics/... ./pkg/api/...` clean
- [x] Existing tests unchanged -- no call-site churn