### PR TITLE
Dashboards: Add row linking and scrolling functionality

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -47,6 +47,7 @@ import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
 import { type DecoratedRevisionModel } from 'app/features/dashboard/types/revisionModels';
+import { scrollToRow } from 'app/features/dashboard-scene/scene/layout-rows/scrollToRow';
 import { dashboardWatcher } from 'app/features/live/dashboard/dashboardWatcher';
 import { type DashboardJson } from 'app/features/manage-dashboards/types';
 import { PROVISIONING_PREVIEW_URL } from 'app/features/provisioning/constants';
@@ -1411,6 +1412,12 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
     if (this._prevScrollPos !== undefined) {
       this._scrollRef?.scrollTo(0, this._prevScrollPos!);
     }
+  }
+
+  public scrollToRow(srow: string) {
+    locationService.partial({ srow: null });
+
+    scrollToRow(srow, this.state.body);
   }
 
   getSaveModel(): Dashboard | DashboardV2Spec {

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -1423,10 +1423,10 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
     }
   }
 
-  public scrollToRow(srow: string) {
-    locationService.partial({ srow: null }, true);
+  public scrollToRow(drow: string) {
+    locationService.partial({ drow: null }, true);
 
-    if (scrollToRow(srow, this.state.body)) {
+    if (scrollToRow(drow, this.state.body)) {
       this._pendingRowScroll = undefined;
       return;
     }
@@ -1435,7 +1435,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
     // repeat-local slugs only interpolate correctly) once the repeat variable resolves and
     // the repeater runs, which happens after url sync. The repeaters publish
     // NewSceneObjectAddedEvent when done, so keep the slug pending and retry on that event.
-    this._pendingRowScroll = srow;
+    this._pendingRowScroll = drow;
     this._pendingRowScrollSub ??= this.subscribeToEvent(NewSceneObjectAddedEvent, () => {
       if (this._pendingRowScroll && scrollToRow(this._pendingRowScroll, this.state.body)) {
         this._pendingRowScroll = undefined;

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -1415,7 +1415,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
   }
 
   public scrollToRow(srow: string) {
-    locationService.partial({ srow: null });
+    locationService.partial({ srow: null }, true);
 
     scrollToRow(srow, this.state.body);
   }

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -1,4 +1,5 @@
 import type * as H from 'history';
+import { type Unsubscribable } from 'rxjs';
 
 import {
   CoreApp,
@@ -28,6 +29,7 @@ import {
   type SceneVariable,
   type SceneVariableDependencyConfigLike,
   MultiValueVariable,
+  NewSceneObjectAddedEvent,
   type VizPanel,
 } from '@grafana/scenes';
 import { type Dashboard, type DashboardLink, type LibraryPanel } from '@grafana/schema';
@@ -193,6 +195,10 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
   private _scrollRef?: ScrollRefElement;
   private _prevScrollPos?: number;
 
+  /** Row slug path from the url that did not match any row yet (e.g. a repeated row not created yet) */
+  private _pendingRowScroll?: string;
+  private _pendingRowScrollSub?: Unsubscribable;
+
   /**
    * What initiated the current edit session, e.g. the assistant building a dashboard for the user
    */
@@ -284,6 +290,9 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
       this.deactivateSidebar();
       oldDashboardWrapper.destroy();
       dashboardWatcher.leave();
+      this._pendingRowScrollSub?.unsubscribe();
+      this._pendingRowScrollSub = undefined;
+      this._pendingRowScroll = undefined;
     };
   }
 
@@ -1417,7 +1426,21 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
   public scrollToRow(srow: string) {
     locationService.partial({ srow: null }, true);
 
-    scrollToRow(srow, this.state.body);
+    if (scrollToRow(srow, this.state.body)) {
+      this._pendingRowScroll = undefined;
+      return;
+    }
+
+    // The target row may not exist yet: repeated rows/tabs are only created (and their
+    // repeat-local slugs only interpolate correctly) once the repeat variable resolves and
+    // the repeater runs, which happens after url sync. The repeaters publish
+    // NewSceneObjectAddedEvent when done, so keep the slug pending and retry on that event.
+    this._pendingRowScroll = srow;
+    this._pendingRowScrollSub ??= this.subscribeToEvent(NewSceneObjectAddedEvent, () => {
+      if (this._pendingRowScroll && scrollToRow(this._pendingRowScroll, this.state.body)) {
+        this._pendingRowScroll = undefined;
+      }
+    });
   }
 
   getSaveModel(): Dashboard | DashboardV2Spec {

--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.test.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.test.ts
@@ -1,7 +1,10 @@
+import { locationService } from '@grafana/runtime';
 import { SceneQueryRunner, VizPanel } from '@grafana/scenes';
 
 import { DashboardScene } from './DashboardScene';
 import { DefaultGridLayoutManager } from './layout-default/DefaultGridLayoutManager';
+import { RowItem } from './layout-rows/RowItem';
+import { RowsLayoutManager } from './layout-rows/RowsLayoutManager';
 
 describe('DashboardSceneUrlSync', () => {
   describe('Given a standard scene', () => {
@@ -23,6 +26,111 @@ describe('DashboardSceneUrlSync', () => {
     });
   });
 
+  describe('Scroll to row', () => {
+    let scrollIntoViewSpy: jest.Mock;
+    let originalScrollIntoView: typeof HTMLElement.prototype.scrollIntoView;
+    let locationPartialSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      // jsdom doesn't implement scrollIntoView, so patch the prototype rather than spy on it.
+      originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+      scrollIntoViewSpy = jest.fn();
+      HTMLElement.prototype.scrollIntoView = scrollIntoViewSpy;
+      locationPartialSpy = jest.spyOn(locationService, 'partial').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+      locationPartialSpy.mockRestore();
+      document.body.innerHTML = '';
+    });
+
+    it('scrolls the matching row into view', () => {
+      const { scene, element } = buildTestSceneWithRow('Traces Instance Stats');
+
+      scene.urlSync?.updateFromUrl({ srow: 'Traces-Instance-Stats' });
+
+      expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
+      expect(scrollIntoViewSpy.mock.instances[0]).toBe(element);
+    });
+
+    it('expands a collapsed row', () => {
+      const { scene, row } = buildTestSceneWithRow('Traces Instance Stats', { collapse: true });
+
+      scene.urlSync?.updateFromUrl({ srow: 'Traces-Instance-Stats' });
+
+      expect(row.state.collapse).toBe(false);
+    });
+
+    it('clears parameter from the url after scrolling so it acts as a one-shot action', () => {
+      const { scene } = buildTestSceneWithRow('Traces Instance Stats');
+
+      scene.urlSync?.updateFromUrl({ srow: 'Traces-Instance-Stats' });
+
+      expect(locationPartialSpy).toHaveBeenCalledWith({ srow: null });
+    });
+
+    it('expands all collapsed ancestor rows of a nested row', () => {
+      const nestedRow = new RowItem({ title: 'Nested' });
+      const middleRow = new RowItem({
+        title: 'Middle',
+        collapse: true,
+        layout: new RowsLayoutManager({ rows: [nestedRow] }),
+      });
+      const outerRow = new RowItem({
+        title: 'Outer',
+        collapse: true,
+        layout: new RowsLayoutManager({ rows: [middleRow] }),
+      });
+      const scene = new DashboardScene({
+        title: 'hello',
+        uid: 'dash-1',
+        body: new RowsLayoutManager({ rows: [outerRow] }),
+      });
+
+      scene.urlSync?.updateFromUrl({ srow: 'Outer/Middle/Nested' });
+
+      expect(outerRow.state.collapse).toBe(false);
+      expect(middleRow.state.collapse).toBe(false);
+    });
+
+    it('scrolls the correct row when a nested row shares its slug with a top-level row', () => {
+      const nestedRow = new RowItem({ title: 'Row 1' });
+      const containerRow = new RowItem({ title: 'Row 2', layout: new RowsLayoutManager({ rows: [nestedRow] }) });
+      const topLevelRow = new RowItem({ title: 'Row 1' });
+      const scene = new DashboardScene({
+        title: 'hello',
+        uid: 'dash-1',
+        body: new RowsLayoutManager({ rows: [topLevelRow, containerRow] }),
+      });
+
+      const topLevelElement = document.createElement('div');
+      document.body.appendChild(topLevelElement);
+      topLevelRow.containerRef.current = topLevelElement;
+
+      const nestedElement = document.createElement('div');
+      document.body.appendChild(nestedElement);
+      nestedRow.containerRef.current = nestedElement;
+
+      scene.urlSync?.updateFromUrl({ srow: 'Row-2/Row-1' });
+      expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
+      expect(scrollIntoViewSpy.mock.instances[0]).toBe(nestedElement);
+
+      scene.urlSync?.updateFromUrl({ srow: 'Row-1' });
+      expect(scrollIntoViewSpy).toHaveBeenCalledTimes(2);
+      expect(scrollIntoViewSpy.mock.instances[1]).toBe(topLevelElement);
+    });
+
+    it('clears parameter but does not scroll when no row matches the slug', () => {
+      const { scene } = buildTestSceneWithRow('Traces Instance Stats');
+
+      scene.urlSync?.updateFromUrl({ srow: 'Does-Not-Exist' });
+
+      expect(scrollIntoViewSpy).not.toHaveBeenCalled();
+      expect(locationPartialSpy).toHaveBeenCalledWith({ srow: null });
+    });
+  });
+
   describe('entering edit mode', () => {
     it('it should be possible to go from the view panel view to the edit view when the dashboard is not in edit mdoe', () => {
       const scene = buildTestScene();
@@ -34,6 +142,22 @@ describe('DashboardSceneUrlSync', () => {
     });
   });
 });
+
+function buildTestSceneWithRow(title: string, { collapse }: { collapse?: boolean } = {}) {
+  const row = new RowItem({ title, collapse });
+  const scene = new DashboardScene({
+    title: 'hello',
+    uid: 'dash-1',
+    body: new RowsLayoutManager({ rows: [row] }),
+  });
+
+  // simulate the row being rendered
+  const element = document.createElement('div');
+  document.body.appendChild(element);
+  row.containerRef.current = element;
+
+  return { scene, row, element };
+}
 
 function buildTestScene() {
   const scene = new DashboardScene({

--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.test.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.test.ts
@@ -69,7 +69,8 @@ describe('DashboardSceneUrlSync', () => {
 
       scene.urlSync?.updateFromUrl({ srow: 'Traces-Instance-Stats' });
 
-      expect(locationPartialSpy).toHaveBeenCalledWith({ srow: null });
+      // replace: true so clearing srow does not push a history entry that Back would restore
+      expect(locationPartialSpy).toHaveBeenCalledWith({ srow: null }, true);
     });
 
     it('expands all collapsed ancestor rows of a nested row', () => {
@@ -177,7 +178,7 @@ describe('DashboardSceneUrlSync', () => {
       scene.urlSync?.updateFromUrl({ srow: 'Does-Not-Exist' });
 
       expect(scrollIntoViewSpy).not.toHaveBeenCalled();
-      expect(locationPartialSpy).toHaveBeenCalledWith({ srow: null });
+      expect(locationPartialSpy).toHaveBeenCalledWith({ srow: null }, true);
     });
   });
 

--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.test.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.test.ts
@@ -121,6 +121,34 @@ describe('DashboardSceneUrlSync', () => {
       expect(scrollIntoViewSpy.mock.instances[1]).toBe(topLevelElement);
     });
 
+    it('distinguishes a row titled with a slash from a nested row with the same path segments', () => {
+      const nestedRow = new RowItem({ title: 'Bar' });
+      const parentRow = new RowItem({ title: 'Foo', layout: new RowsLayoutManager({ rows: [nestedRow] }) });
+      const slashTitleRow = new RowItem({ title: 'Foo/Bar' });
+      const scene = new DashboardScene({
+        title: 'hello',
+        uid: 'dash-1',
+        body: new RowsLayoutManager({ rows: [slashTitleRow, parentRow] }),
+      });
+
+      const slashTitleElement = document.createElement('div');
+      document.body.appendChild(slashTitleElement);
+      slashTitleRow.containerRef.current = slashTitleElement;
+
+      const nestedElement = document.createElement('div');
+      document.body.appendChild(nestedElement);
+      nestedRow.containerRef.current = nestedElement;
+
+      // Encoded slash in the title segment must not match nested Foo/Bar path
+      scene.urlSync?.updateFromUrl({ srow: 'Foo%2FBar' });
+      expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
+      expect(scrollIntoViewSpy.mock.instances[0]).toBe(slashTitleElement);
+
+      scene.urlSync?.updateFromUrl({ srow: 'Foo/Bar' });
+      expect(scrollIntoViewSpy).toHaveBeenCalledTimes(2);
+      expect(scrollIntoViewSpy.mock.instances[1]).toBe(nestedElement);
+    });
+
     it('clears parameter but does not scroll when no row matches the slug', () => {
       const { scene } = buildTestSceneWithRow('Traces Instance Stats');
 

--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.test.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.test.ts
@@ -1,5 +1,5 @@
 import { locationService } from '@grafana/runtime';
-import { SceneQueryRunner, VizPanel } from '@grafana/scenes';
+import { NewSceneObjectAddedEvent, SceneQueryRunner, VizPanel } from '@grafana/scenes';
 
 import { DashboardScene } from './DashboardScene';
 import { DefaultGridLayoutManager } from './layout-default/DefaultGridLayoutManager';
@@ -179,6 +179,82 @@ describe('DashboardSceneUrlSync', () => {
 
       expect(scrollIntoViewSpy).not.toHaveBeenCalled();
       expect(locationPartialSpy).toHaveBeenCalledWith({ srow: null }, true);
+    });
+
+    it('matches a repeated row clone by its own slug, without the source row as a path segment', () => {
+      const sourceRow = new RowItem({ title: 'Web A' });
+      // Repeat clones live in the source row's repeatedRows state, so their scene graph
+      // parent is the source row even though they render as its siblings
+      const cloneRow = new RowItem({ title: 'Web B', repeatSourceKey: sourceRow.state.key });
+      sourceRow.setState({ repeatedRows: [cloneRow] });
+      const scene = new DashboardScene({
+        title: 'hello',
+        uid: 'dash-1',
+        body: new RowsLayoutManager({ rows: [sourceRow] }),
+      });
+
+      const cloneElement = document.createElement('div');
+      document.body.appendChild(cloneElement);
+      cloneRow.containerRef.current = cloneElement;
+
+      scene.urlSync?.updateFromUrl({ srow: 'Web-B' });
+
+      expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
+      expect(scrollIntoViewSpy.mock.instances[0]).toBe(cloneElement);
+    });
+
+    it('scrolls to a repeated row that is created after url sync, when the repeater announces it', () => {
+      const sourceRow = new RowItem({ title: 'Web A' });
+      const scene = new DashboardScene({
+        title: 'hello',
+        uid: 'dash-1',
+        body: new RowsLayoutManager({ rows: [sourceRow] }),
+      });
+
+      // On load the repeat variable has not resolved yet, so the clone does not exist
+      scene.urlSync?.updateFromUrl({ srow: 'Web-B' });
+      expect(scrollIntoViewSpy).not.toHaveBeenCalled();
+
+      // Simulate the repeater performing repeats: it creates the clones and publishes
+      // NewSceneObjectAddedEvent when done
+      const cloneRow = new RowItem({ title: 'Web B', repeatSourceKey: sourceRow.state.key });
+      sourceRow.setState({ repeatedRows: [cloneRow] });
+      const cloneElement = document.createElement('div');
+      document.body.appendChild(cloneElement);
+      cloneRow.containerRef.current = cloneElement;
+      sourceRow.publishEvent(new NewSceneObjectAddedEvent(sourceRow), true);
+
+      expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
+      expect(scrollIntoViewSpy.mock.instances[0]).toBe(cloneElement);
+
+      // The retry is one-shot: later additions must not scroll again
+      sourceRow.publishEvent(new NewSceneObjectAddedEvent(sourceRow), true);
+      expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('replaces a pending scroll target when a new srow arrives before the old one matched', () => {
+      const sourceRow = new RowItem({ title: 'Web A' });
+      const scene = new DashboardScene({
+        title: 'hello',
+        uid: 'dash-1',
+        body: new RowsLayoutManager({ rows: [sourceRow] }),
+      });
+
+      scene.urlSync?.updateFromUrl({ srow: 'Web-B' });
+      scene.urlSync?.updateFromUrl({ srow: 'Web-C' });
+
+      const cloneB = new RowItem({ title: 'Web B', repeatSourceKey: sourceRow.state.key });
+      const cloneC = new RowItem({ title: 'Web C', repeatSourceKey: sourceRow.state.key });
+      sourceRow.setState({ repeatedRows: [cloneB, cloneC] });
+      for (const clone of [cloneB, cloneC]) {
+        const element = document.createElement('div');
+        document.body.appendChild(element);
+        clone.containerRef.current = element;
+      }
+      sourceRow.publishEvent(new NewSceneObjectAddedEvent(sourceRow), true);
+
+      expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
+      expect(scrollIntoViewSpy.mock.instances[0]).toBe(cloneC.containerRef.current);
     });
   });
 

--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.test.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.test.ts
@@ -5,6 +5,8 @@ import { DashboardScene } from './DashboardScene';
 import { DefaultGridLayoutManager } from './layout-default/DefaultGridLayoutManager';
 import { RowItem } from './layout-rows/RowItem';
 import { RowsLayoutManager } from './layout-rows/RowsLayoutManager';
+import { TabItem } from './layout-tabs/TabItem';
+import { TabsLayoutManager } from './layout-tabs/TabsLayoutManager';
 
 describe('DashboardSceneUrlSync', () => {
   describe('Given a standard scene', () => {
@@ -92,6 +94,26 @@ describe('DashboardSceneUrlSync', () => {
 
       expect(outerRow.state.collapse).toBe(false);
       expect(middleRow.state.collapse).toBe(false);
+    });
+
+    it('switches to a non-active tab containing the target row', () => {
+      const targetRow = new RowItem({ title: 'Target row' });
+      const activeTab = new TabItem({ title: 'Active tab' });
+      const targetTab = new TabItem({
+        title: 'Target tab',
+        layout: new RowsLayoutManager({ rows: [targetRow] }),
+      });
+      const tabsLayout = new TabsLayoutManager({ tabs: [activeTab, targetTab] });
+      const scene = new DashboardScene({
+        title: 'hello',
+        uid: 'dash-1',
+        body: tabsLayout,
+      });
+      tabsLayout.setState({ currentTabSlug: activeTab.getSlug() });
+
+      scene.urlSync?.updateFromUrl({ srow: 'Target-tab/Target-row' });
+
+      expect(tabsLayout.getCurrentTab()).toBe(targetTab);
     });
 
     it('scrolls the correct row when a nested row shares its slug with a top-level row', () => {

--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.test.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.test.ts
@@ -50,7 +50,7 @@ describe('DashboardSceneUrlSync', () => {
     it('scrolls the matching row into view', () => {
       const { scene, element } = buildTestSceneWithRow('Traces Instance Stats');
 
-      scene.urlSync?.updateFromUrl({ srow: 'Traces-Instance-Stats' });
+      scene.urlSync?.updateFromUrl({ drow: 'Traces-Instance-Stats' });
 
       expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
       expect(scrollIntoViewSpy.mock.instances[0]).toBe(element);
@@ -59,7 +59,7 @@ describe('DashboardSceneUrlSync', () => {
     it('expands a collapsed row', () => {
       const { scene, row } = buildTestSceneWithRow('Traces Instance Stats', { collapse: true });
 
-      scene.urlSync?.updateFromUrl({ srow: 'Traces-Instance-Stats' });
+      scene.urlSync?.updateFromUrl({ drow: 'Traces-Instance-Stats' });
 
       expect(row.state.collapse).toBe(false);
     });
@@ -67,10 +67,10 @@ describe('DashboardSceneUrlSync', () => {
     it('clears parameter from the url after scrolling so it acts as a one-shot action', () => {
       const { scene } = buildTestSceneWithRow('Traces Instance Stats');
 
-      scene.urlSync?.updateFromUrl({ srow: 'Traces-Instance-Stats' });
+      scene.urlSync?.updateFromUrl({ drow: 'Traces-Instance-Stats' });
 
-      // replace: true so clearing srow does not push a history entry that Back would restore
-      expect(locationPartialSpy).toHaveBeenCalledWith({ srow: null }, true);
+      // replace: true so clearing drow does not push a history entry that Back would restore
+      expect(locationPartialSpy).toHaveBeenCalledWith({ drow: null }, true);
     });
 
     it('expands all collapsed ancestor rows of a nested row', () => {
@@ -91,7 +91,7 @@ describe('DashboardSceneUrlSync', () => {
         body: new RowsLayoutManager({ rows: [outerRow] }),
       });
 
-      scene.urlSync?.updateFromUrl({ srow: 'Outer/Middle/Nested' });
+      scene.urlSync?.updateFromUrl({ drow: 'Outer/Middle/Nested' });
 
       expect(outerRow.state.collapse).toBe(false);
       expect(middleRow.state.collapse).toBe(false);
@@ -112,7 +112,7 @@ describe('DashboardSceneUrlSync', () => {
       });
       tabsLayout.setState({ currentTabSlug: activeTab.getSlug() });
 
-      scene.urlSync?.updateFromUrl({ srow: 'Target-tab/Target-row' });
+      scene.urlSync?.updateFromUrl({ drow: 'Target-tab/Target-row' });
 
       expect(tabsLayout.getCurrentTab()).toBe(targetTab);
     });
@@ -135,11 +135,11 @@ describe('DashboardSceneUrlSync', () => {
       document.body.appendChild(nestedElement);
       nestedRow.containerRef.current = nestedElement;
 
-      scene.urlSync?.updateFromUrl({ srow: 'Row-2/Row-1' });
+      scene.urlSync?.updateFromUrl({ drow: 'Row-2/Row-1' });
       expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
       expect(scrollIntoViewSpy.mock.instances[0]).toBe(nestedElement);
 
-      scene.urlSync?.updateFromUrl({ srow: 'Row-1' });
+      scene.urlSync?.updateFromUrl({ drow: 'Row-1' });
       expect(scrollIntoViewSpy).toHaveBeenCalledTimes(2);
       expect(scrollIntoViewSpy.mock.instances[1]).toBe(topLevelElement);
     });
@@ -163,11 +163,11 @@ describe('DashboardSceneUrlSync', () => {
       nestedRow.containerRef.current = nestedElement;
 
       // Encoded slash in the title segment must not match nested Foo/Bar path
-      scene.urlSync?.updateFromUrl({ srow: 'Foo%2FBar' });
+      scene.urlSync?.updateFromUrl({ drow: 'Foo%2FBar' });
       expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
       expect(scrollIntoViewSpy.mock.instances[0]).toBe(slashTitleElement);
 
-      scene.urlSync?.updateFromUrl({ srow: 'Foo/Bar' });
+      scene.urlSync?.updateFromUrl({ drow: 'Foo/Bar' });
       expect(scrollIntoViewSpy).toHaveBeenCalledTimes(2);
       expect(scrollIntoViewSpy.mock.instances[1]).toBe(nestedElement);
     });
@@ -175,10 +175,10 @@ describe('DashboardSceneUrlSync', () => {
     it('clears parameter but does not scroll when no row matches the slug', () => {
       const { scene } = buildTestSceneWithRow('Traces Instance Stats');
 
-      scene.urlSync?.updateFromUrl({ srow: 'Does-Not-Exist' });
+      scene.urlSync?.updateFromUrl({ drow: 'Does-Not-Exist' });
 
       expect(scrollIntoViewSpy).not.toHaveBeenCalled();
-      expect(locationPartialSpy).toHaveBeenCalledWith({ srow: null }, true);
+      expect(locationPartialSpy).toHaveBeenCalledWith({ drow: null }, true);
     });
 
     it('matches a repeated row clone by its own slug, without the source row as a path segment', () => {
@@ -197,7 +197,7 @@ describe('DashboardSceneUrlSync', () => {
       document.body.appendChild(cloneElement);
       cloneRow.containerRef.current = cloneElement;
 
-      scene.urlSync?.updateFromUrl({ srow: 'Web-B' });
+      scene.urlSync?.updateFromUrl({ drow: 'Web-B' });
 
       expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
       expect(scrollIntoViewSpy.mock.instances[0]).toBe(cloneElement);
@@ -212,7 +212,7 @@ describe('DashboardSceneUrlSync', () => {
       });
 
       // On load the repeat variable has not resolved yet, so the clone does not exist
-      scene.urlSync?.updateFromUrl({ srow: 'Web-B' });
+      scene.urlSync?.updateFromUrl({ drow: 'Web-B' });
       expect(scrollIntoViewSpy).not.toHaveBeenCalled();
 
       // Simulate the repeater performing repeats: it creates the clones and publishes
@@ -232,7 +232,7 @@ describe('DashboardSceneUrlSync', () => {
       expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('replaces a pending scroll target when a new srow arrives before the old one matched', () => {
+    it('replaces a pending scroll target when a new drow arrives before the old one matched', () => {
       const sourceRow = new RowItem({ title: 'Web A' });
       const scene = new DashboardScene({
         title: 'hello',
@@ -240,8 +240,8 @@ describe('DashboardSceneUrlSync', () => {
         body: new RowsLayoutManager({ rows: [sourceRow] }),
       });
 
-      scene.urlSync?.updateFromUrl({ srow: 'Web-B' });
-      scene.urlSync?.updateFromUrl({ srow: 'Web-C' });
+      scene.urlSync?.updateFromUrl({ drow: 'Web-B' });
+      scene.urlSync?.updateFromUrl({ drow: 'Web-C' });
 
       const cloneB = new RowItem({ title: 'Web B', repeatSourceKey: sourceRow.state.key });
       const cloneC = new RowItem({ title: 'Web C', repeatSourceKey: sourceRow.state.key });

--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
@@ -27,7 +27,7 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
   constructor(private _scene: DashboardScene) {}
 
   getKeys(): string[] {
-    return ['inspect', 'viewPanel', 'editPanel', 'editview', 'autofitpanels', 'shareView', 'srow'];
+    return ['inspect', 'viewPanel', 'editPanel', 'editview', 'autofitpanels', 'shareView', 'drow'];
   }
 
   getUrlState(): SceneObjectUrlValues {
@@ -160,8 +160,8 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
       this._scene.setState(update);
     }
 
-    if (typeof values.srow === 'string') {
-      this._scene.scrollToRow(values.srow);
+    if (typeof values.drow === 'string') {
+      this._scene.scrollToRow(values.drow);
     }
   }
 

--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
@@ -27,7 +27,7 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
   constructor(private _scene: DashboardScene) {}
 
   getKeys(): string[] {
-    return ['inspect', 'viewPanel', 'editPanel', 'editview', 'autofitpanels', 'shareView'];
+    return ['inspect', 'viewPanel', 'editPanel', 'editview', 'autofitpanels', 'shareView', 'srow'];
   }
 
   getUrlState(): SceneObjectUrlValues {
@@ -158,6 +158,10 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
 
     if (Object.keys(update).length > 0) {
       this._scene.setState(update);
+    }
+
+    if (typeof values.srow === 'string') {
+      this._scene.scrollToRow(values.srow);
     }
   }
 

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
@@ -142,7 +142,7 @@ export class RowItem
   /** Returns an absolute url that scrolls this row into view when the dashboard is opened */
   public getUrl(): string {
     const urlWithRowParam = locationUtil.getUrlForPartial(locationService.getLocation(), {
-      srow: getRowSlugPath(this),
+      drow: getRowSlugPath(this),
     });
 
     return new URL(urlWithRowParam, window.location.origin).toString();

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import { store } from '@grafana/data';
+import { locationUtil, store } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config, logWarning } from '@grafana/runtime';
+import { config, locationService, logWarning } from '@grafana/runtime';
 import {
   NewSceneObjectAddedEvent,
   sceneGraph,
@@ -44,6 +44,7 @@ import { useSidebarOptions } from './RowItemEditor';
 import { RowItemRenderer } from './RowItemRenderer';
 import { RowItems } from './RowItems';
 import { RowsLayoutManager } from './RowsLayoutManager';
+import { getRowSlugPath } from './scrollToRow';
 
 export interface RowItemState extends SceneObjectState {
   layout: DashboardLayoutManager;
@@ -136,6 +137,15 @@ export class RowItem
           .filter((item): item is RowItem => item instanceof RowItem)
       : [];
     return getSlugForRowOrTab(this, siblings);
+  }
+
+  /** Returns an absolute url that scrolls this row into view when the dashboard is opened */
+  public getUrl(): string {
+    const urlWithRowParam = locationUtil.getUrlForPartial(locationService.getLocation(), {
+      srow: getRowSlugPath(this),
+    });
+
+    return new URL(urlWithRowParam, window.location.origin).toString();
   }
 
   public switchLayout(layout: DashboardLayoutManager, skipUndo?: boolean) {

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.test.tsx
@@ -51,4 +51,37 @@ describe('RowItemRenderer', () => {
     await userEvent.click(toggle);
     expect(toggle).toHaveAttribute('aria-expanded', 'true');
   });
+
+  it('copies a link to the row when the copy link button is clicked', async () => {
+    // ClipboardButton only uses the clipboard API in a secure context.
+    // userEvent.setup() (called by render) attaches a working clipboard stub we can read back.
+    Object.defineProperty(window, 'isSecureContext', { value: true, configurable: true });
+
+    renderRow({ title: 'My row' });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Copy link to row' }));
+
+    expect(await navigator.clipboard.readText()).toContain('srow=My-row');
+  });
+
+  it('copies a link with the full slug path for a nested row', async () => {
+    Object.defineProperty(window, 'isSecureContext', { value: true, configurable: true });
+
+    const nestedRow = new RowItem({ title: 'Row 1', layout: AutoGridLayoutManager.createEmpty() });
+    const outerRow = new RowItem({ title: 'Row 2', layout: new RowsLayoutManager({ rows: [nestedRow] }) });
+    const scene = new DashboardScene({
+      $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
+      body: new RowsLayoutManager({ rows: [outerRow] }),
+    });
+    render(<scene.Component model={scene} />);
+
+    const copyButtons = screen.getAllByRole('button', { name: 'Copy link to row' });
+    expect(copyButtons).toHaveLength(2);
+
+    // The outer row's header renders before the nested row's header
+    await userEvent.click(copyButtons[1]);
+
+    const copiedUrl = new URL(await navigator.clipboard.readText());
+    expect(copiedUrl.searchParams.get('srow')).toBe('Row-2/Row-1');
+  });
 });

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.test.tsx
@@ -10,7 +10,7 @@ import { AutoGridLayoutManager } from '../layout-auto-grid/AutoGridLayoutManager
 import { RowItem } from './RowItem';
 import { RowsLayoutManager } from './RowsLayoutManager';
 
-function renderRow({ collapse = false, title = 'My row' } = {}) {
+function renderRow({ collapse = false, title = 'My row', isEditing = false } = {}) {
   const row = new RowItem({
     key: 'row-1',
     title,
@@ -20,6 +20,7 @@ function renderRow({ collapse = false, title = 'My row' } = {}) {
   const scene = new DashboardScene({
     $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
     body: new RowsLayoutManager({ rows: [row] }),
+    isEditing,
   });
   render(<scene.Component model={scene} />);
   return { row };
@@ -62,6 +63,12 @@ describe('RowItemRenderer', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Copy link to row' }));
 
     expect(await navigator.clipboard.readText()).toContain('srow=My-row');
+  });
+
+  it('hides the copy link button while editing', () => {
+    renderRow({ isEditing: true });
+
+    expect(screen.queryByRole('button', { name: 'Copy link to row' })).not.toBeInTheDocument();
   });
 
   it('copies a link with the full slug path for a nested row', async () => {

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.test.tsx
@@ -84,4 +84,15 @@ describe('RowItemRenderer', () => {
     const copiedUrl = new URL(await navigator.clipboard.readText());
     expect(copiedUrl.searchParams.get('srow')).toBe('Row-2/Row-1');
   });
+
+  it('encodes slashes in row titles so they do not look like nested paths', async () => {
+    Object.defineProperty(window, 'isSecureContext', { value: true, configurable: true });
+
+    renderRow({ title: 'Foo/Bar' });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Copy link to row' }));
+
+    const copiedUrl = new URL(await navigator.clipboard.readText());
+    expect(copiedUrl.searchParams.get('srow')).toBe('Foo%2FBar');
+  });
 });

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.test.tsx
@@ -62,7 +62,7 @@ describe('RowItemRenderer', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'Copy link to row' }));
 
-    expect(await navigator.clipboard.readText()).toContain('srow=My-row');
+    expect(await navigator.clipboard.readText()).toContain('drow=My-row');
   });
 
   it('hides the copy link button while editing', () => {
@@ -89,7 +89,7 @@ describe('RowItemRenderer', () => {
     await userEvent.click(copyButtons[1]);
 
     const copiedUrl = new URL(await navigator.clipboard.readText());
-    expect(copiedUrl.searchParams.get('srow')).toBe('Row-2/Row-1');
+    expect(copiedUrl.searchParams.get('drow')).toBe('Row-2/Row-1');
   });
 
   it('encodes slashes in row titles so they do not look like nested paths', async () => {
@@ -100,6 +100,6 @@ describe('RowItemRenderer', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Copy link to row' }));
 
     const copiedUrl = new URL(await navigator.clipboard.readText());
-    expect(copiedUrl.searchParams.get('srow')).toBe('Foo%2FBar');
+    expect(copiedUrl.searchParams.get('drow')).toBe('Foo%2FBar');
   });
 });

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
@@ -6,7 +6,15 @@ import { type GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { type SceneComponentProps } from '@grafana/scenes';
-import { clearButtonStyles, Icon, Tooltip, useElementSelection, usePointerDistance, useStyles2 } from '@grafana/ui';
+import {
+  clearButtonStyles,
+  ClipboardButton,
+  Icon,
+  Tooltip,
+  useElementSelection,
+  usePointerDistance,
+  useStyles2,
+} from '@grafana/ui';
 
 import { useIsConditionallyHidden } from '../../conditional-rendering/hooks/useIsConditionallyHidden';
 import { useSoloPanelContext } from '../../solo/SoloPanelContext';
@@ -162,6 +170,16 @@ export function RowItemRenderer({ model }: SceneComponentProps<RowItem>) {
                 {!isEditing && titleElement}
               </button>
               {isEditing && titleElement}
+              <ClipboardButton
+                icon="link"
+                size="sm"
+                fill="text"
+                variant="secondary"
+                className={cx(styles.copyLinkButton, 'dashboard-row-header-copy-link')}
+                aria-label={t('dashboard.rows-layout.row.copy-link', 'Copy link to row')}
+                tooltip={t('dashboard.rows-layout.row.copy-link', 'Copy link to row')}
+                getText={() => model.getUrl()}
+              />
               {isEditing && layoutType && <LayoutModeIndicator layoutType={layoutType} className="layout-indicator" />}
               {isDraggable && <Icon name="draggabledots" className="dashboard-row-header-drag-handle" />}
             </div>
@@ -217,6 +235,17 @@ function getStyles(theme: GrafanaTheme2) {
       minWidth: 0,
       gap: theme.spacing(1),
     }),
+    copyLinkButton: css({
+      opacity: 0,
+
+      [theme.transitions.handleMotion('no-preference', 'reduce')]: {
+        transition: 'opacity 0.25s',
+      },
+
+      '&:focus-visible': {
+        opacity: 1,
+      },
+    }),
     rowTitle: css({
       display: 'flex',
       alignItems: 'center',
@@ -269,6 +298,11 @@ function getStyles(theme: GrafanaTheme2) {
       // Reveal this row's layout indicator when hovering or focusing anywhere on the row
       '&:hover > .dashboard-row-header .layout-indicator, &:focus-within > .dashboard-row-header .layout-indicator': {
         display: 'inline-block',
+      },
+      // Reveal this row's copy link button when hovering anywhere on the row
+      // (child selector so hovering an outer row does not reveal nested rows' buttons)
+      '&:hover > .dashboard-row-header .dashboard-row-header-copy-link': {
+        opacity: 1,
       },
     }),
     wrapperNotCollapsed: css({

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
@@ -170,16 +170,18 @@ export function RowItemRenderer({ model }: SceneComponentProps<RowItem>) {
                 {!isEditing && titleElement}
               </button>
               {isEditing && titleElement}
-              <ClipboardButton
-                icon="link"
-                size="sm"
-                fill="text"
-                variant="secondary"
-                className={cx(styles.copyLinkButton, 'dashboard-row-header-copy-link')}
-                aria-label={t('dashboard.rows-layout.row.copy-link', 'Copy link to row')}
-                tooltip={t('dashboard.rows-layout.row.copy-link', 'Copy link to row')}
-                getText={() => model.getUrl()}
-              />
+              {!isEditing && (
+                <ClipboardButton
+                  icon="link"
+                  size="sm"
+                  fill="text"
+                  variant="secondary"
+                  className={cx(styles.copyLinkButton, 'dashboard-row-header-copy-link')}
+                  aria-label={t('dashboard.rows-layout.row.copy-link', 'Copy link to row')}
+                  tooltip={t('dashboard.rows-layout.row.copy-link', 'Copy link to row')}
+                  getText={() => model.getUrl()}
+                />
+              )}
               {isEditing && layoutType && <LayoutModeIndicator layoutType={layoutType} className="layout-indicator" />}
               {isDraggable && <Icon name="draggabledots" className="dashboard-row-header-drag-handle" />}
             </div>

--- a/public/app/features/dashboard-scene/scene/layout-rows/scrollToRow.ts
+++ b/public/app/features/dashboard-scene/scene/layout-rows/scrollToRow.ts
@@ -1,0 +1,45 @@
+import { sceneGraph, type SceneObject } from '@grafana/scenes';
+
+import { type DashboardLayoutManager } from '../types/DashboardLayoutManager';
+import { isRowItem, isTabItem, type RowItemLike } from '../types/LayoutItemTypeGuards';
+
+/**
+ * Row slugs are only unique among siblings, so the url value is the row's slug prefixed
+ * with the slugs of all ancestor rows/tabs, e.g. `Row-2/Row-1` for a row nested in another row.
+ */
+export function getRowSlugPath(row: RowItemLike): string {
+  const segments = [row.getSlug()];
+
+  let ancestor = row.parent;
+  while (ancestor) {
+    if (isRowItem(ancestor) || isTabItem(ancestor)) {
+      segments.unshift(ancestor.getSlug());
+    }
+    ancestor = ancestor.parent;
+  }
+
+  return segments.join('/');
+}
+
+export function scrollToRow(srow: string, layout: DashboardLayoutManager) {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  const row = (sceneGraph.findAllObjects(layout, isRowItem) as RowItemLike[]).find(
+    (row) => getRowSlugPath(row) === srow
+  );
+
+  if (!row) {
+    return;
+  }
+
+  // The row might be nested inside collapsed rows - expand them all so it can render
+  let ancestor: SceneObject | undefined = row;
+  while (ancestor && ancestor !== layout) {
+    if (isRowItem(ancestor) && ancestor.getCollapsedState()) {
+      ancestor.setCollapsedState(false);
+    }
+
+    ancestor = ancestor.parent!;
+  }
+
+  row.scrollIntoView();
+}

--- a/public/app/features/dashboard-scene/scene/layout-rows/scrollToRow.ts
+++ b/public/app/features/dashboard-scene/scene/layout-rows/scrollToRow.ts
@@ -1,4 +1,4 @@
-import { sceneGraph, type SceneObject } from '@grafana/scenes';
+import { sceneGraph } from '@grafana/scenes';
 
 import { type DashboardLayoutManager } from '../types/DashboardLayoutManager';
 import { isRowItem, isTabItem, type RowItemLike } from '../types/LayoutItemTypeGuards';
@@ -34,14 +34,8 @@ export function scrollToRow(srow: string, layout: DashboardLayoutManager) {
     return;
   }
 
-  // The row might be nested inside collapsed rows - expand them all so it can render
-  let ancestor: SceneObject | undefined = row;
-  while (ancestor && ancestor !== layout) {
-    if (isRowItem(ancestor) && ancestor.getCollapsedState()) {
-      ancestor.setCollapsedState(false);
-    }
-
-    ancestor = ancestor.parent!;
+  if (row.getCollapsedState()) {
+    row.setCollapsedState(false);
   }
 
   row.scrollIntoView();

--- a/public/app/features/dashboard-scene/scene/layout-rows/scrollToRow.ts
+++ b/public/app/features/dashboard-scene/scene/layout-rows/scrollToRow.ts
@@ -6,6 +6,9 @@ import { isRowItem, isTabItem, type RowItemLike } from '../types/LayoutItemTypeG
 /**
  * Row slugs are only unique among siblings, so the url value is the row's slug prefixed
  * with the slugs of all ancestor rows/tabs, e.g. `Row-2/Row-1` for a row nested in another row.
+ *
+ * Each segment is encodeURIComponent'd so a title containing `/` (e.g. `Foo/Bar` → `Foo%2FBar`)
+ * cannot collide with a nested path (`Foo` + `Bar` → `Foo/Bar`).
  */
 export function getRowSlugPath(row: RowItemLike): string {
   const segments = [row.getSlug()];
@@ -18,7 +21,7 @@ export function getRowSlugPath(row: RowItemLike): string {
     ancestor = ancestor.parent;
   }
 
-  return segments.join('/');
+  return segments.map(encodeURIComponent).join('/');
 }
 
 export function scrollToRow(srow: string, layout: DashboardLayoutManager) {

--- a/public/app/features/dashboard-scene/scene/layout-rows/scrollToRow.ts
+++ b/public/app/features/dashboard-scene/scene/layout-rows/scrollToRow.ts
@@ -1,7 +1,13 @@
-import { sceneGraph } from '@grafana/scenes';
+import { sceneGraph, type SceneObject } from '@grafana/scenes';
 
 import { type DashboardLayoutManager } from '../types/DashboardLayoutManager';
 import { isRowItem, isTabItem, type RowItemLike } from '../types/LayoutItemTypeGuards';
+
+function getRepeatSourceKey(object: SceneObject): string | undefined {
+  return 'repeatSourceKey' in object.state && typeof object.state.repeatSourceKey === 'string'
+    ? object.state.repeatSourceKey
+    : undefined;
+}
 
 /**
  * Row slugs are only unique among siblings, so the url value is the row's slug prefixed
@@ -13,10 +19,19 @@ import { isRowItem, isTabItem, type RowItemLike } from '../types/LayoutItemTypeG
 export function getRowSlugPath(row: RowItemLike): string {
   const segments = [row.getSlug()];
 
+  let previous: SceneObject = row;
   let ancestor = row.parent;
   while (ancestor) {
     if (isRowItem(ancestor) || isTabItem(ancestor)) {
-      segments.unshift(ancestor.getSlug());
+      // Repeat clones are parented under their source row/tab in the scene graph
+      // (they live in its repeatedRows/repeatedTabs state), but they render as siblings
+      // of the source, so the source must not become a path segment.
+      const repeatSourceKey = getRepeatSourceKey(previous);
+      const ancestorIsRepeatSource = repeatSourceKey !== undefined && repeatSourceKey === ancestor.state.key;
+      if (!ancestorIsRepeatSource) {
+        segments.unshift(ancestor.getSlug());
+      }
+      previous = ancestor;
     }
     ancestor = ancestor.parent;
   }
@@ -24,14 +39,15 @@ export function getRowSlugPath(row: RowItemLike): string {
   return segments.map(encodeURIComponent).join('/');
 }
 
-export function scrollToRow(srow: string, layout: DashboardLayoutManager) {
+/** Returns whether a row matching the slug path was found */
+export function scrollToRow(srow: string, layout: DashboardLayoutManager): boolean {
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const row = (sceneGraph.findAllObjects(layout, isRowItem) as RowItemLike[]).find(
     (row) => getRowSlugPath(row) === srow
   );
 
   if (!row) {
-    return;
+    return false;
   }
 
   if (row.getCollapsedState()) {
@@ -39,4 +55,5 @@ export function scrollToRow(srow: string, layout: DashboardLayoutManager) {
   }
 
   row.scrollIntoView();
+  return true;
 }

--- a/public/app/features/dashboard-scene/scene/layout-rows/scrollToRow.ts
+++ b/public/app/features/dashboard-scene/scene/layout-rows/scrollToRow.ts
@@ -40,10 +40,10 @@ export function getRowSlugPath(row: RowItemLike): string {
 }
 
 /** Returns whether a row matching the slug path was found */
-export function scrollToRow(srow: string, layout: DashboardLayoutManager): boolean {
+export function scrollToRow(drow: string, layout: DashboardLayoutManager): boolean {
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const row = (sceneGraph.findAllObjects(layout, isRowItem) as RowItemLike[]).find(
-    (row) => getRowSlugPath(row) === srow
+    (row) => getRowSlugPath(row) === drow
   );
 
   if (!row) {

--- a/public/app/features/dashboard-scene/scene/types/LayoutItemTypeGuards.ts
+++ b/public/app/features/dashboard-scene/scene/types/LayoutItemTypeGuards.ts
@@ -2,10 +2,17 @@ import { type SceneObject } from '@grafana/scenes';
 
 export interface RowItemLike extends SceneObject {
   readonly dashboardLayoutItemType: 'row';
+
+  getSlug(): string;
+  scrollIntoView(): void;
+  getCollapsedState(): boolean;
+  setCollapsedState(collapsed: boolean): void;
 }
 
 export interface TabItemLike extends SceneObject {
   readonly dashboardLayoutItemType: 'tab';
+
+  getSlug(): string;
 }
 
 export function isRowItem(object: SceneObject): object is RowItemLike {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6047,6 +6047,7 @@
       "new-row-title": "New row",
       "row": {
         "collapse": "Collapse row {{title}}",
+        "copy-link": "Copy link to row",
         "expand": "Expand row {{title}}",
         "new": "New row",
         "repeat": {


### PR DESCRIPTION
This PR brings the "link to row" functionality to dashboards. It supports nesting and it works with nested tabs/rows as well.

Fixes #82827 