### PR TITLE
FrontendService: Remove frontendService.settingsSourceFilter feature toggle

### DIFF
--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2515,15 +2515,6 @@ var (
 			Expression:  "true",
 		},
 		{
-			Name:         "frontendService.settingsSourceFilter",
-			Description:  "Adds a label filter for source=us when fetching settings from the settings service in the frontend service",
-			Stage:        FeatureStageExperimental,
-			Owner:        grafanaFrontendPlatformSquad,
-			Expression:   "false",
-			HideFromDocs: true,
-			Generate:     Generate{Go: true},
-		},
-		{
 			Name:         "managedPluginsV2",
 			Description:  "Enables managed plugins v2 (expanded rollout, community plugin coverage)",
 			Stage:        FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -291,7 +291,6 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-05-22,alertingNotificationHistoryDetail,experimental,@grafana/alerting-squad,false,false,false
 2026-07-14,deletedFolderResourceCleanup,experimental,@grafana/search-and-storage,false,false,false
 2026-05-22,react19,GA,@grafana/grafana-frontend-platform,false,false,false
-2026-05-22,frontendService.settingsSourceFilter,experimental,@grafana/grafana-frontend-platform,false,false,false
 2026-05-22,managedPluginsV2,experimental,@grafana/grafana-catalog,false,false,false
 2026-05-22,rememberUserOrgForSso,GA,@grafana/identity-access-team,false,false,false
 2026-05-22,dsAbstractionApp,experimental,@grafana/grafana-datasources-core-services,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -834,10 +834,6 @@ const (
 	// Whether to use the new React 19 runtime
 	FlagReact19 = "react19"
 
-	// FlagFrontendServiceSettingsSourceFilter
-	// Adds a label filter for source=us when fetching settings from the settings service in the frontend service
-	FlagFrontendServiceSettingsSourceFilter = "frontendService.settingsSourceFilter"
-
 	// FlagManagedPluginsV2
 	// Enables managed plugins v2 (expanded rollout, community plugin coverage)
 	FlagManagedPluginsV2 = "managedPluginsV2"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2722,7 +2722,8 @@
       "metadata": {
         "name": "frontendService.settingsSourceFilter",
         "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "deletionTimestamp": "2026-08-06T11:53:39Z"
       },
       "spec": {
         "description": "Adds a label filter for source=us when fetching settings from the settings service in the frontend service",

--- a/pkg/services/frontend/request_config_middleware.go
+++ b/pkg/services/frontend/request_config_middleware.go
@@ -79,30 +79,16 @@ func RequestConfigMiddleware(cfg *setting.Cfg, license licensing.Licensing, sett
 
 				if ok && namespace != "" {
 					// Fetch tenant overrides for relevant sections only
-					sourceFilterEnabled, _ := ofClient.BooleanValue(ctx, featuremgmt.FlagFrontendServiceSettingsSourceFilter, false, openfeature.TransactionContext(ctx))
-
-					var sourceExpression metav1.LabelSelectorRequirement
-					if sourceFilterEnabled {
-						sourceExpression = metav1.LabelSelectorRequirement{
-							Key:      "source",
-							Operator: metav1.LabelSelectorOpIn,
-							Values:   []string{"us"},
-						}
-					} else {
-						// don't return values from defaults.ini as they conflict with the service's own defaults
-						sourceExpression = metav1.LabelSelectorRequirement{
-							Key:      "source",
-							Operator: metav1.LabelSelectorOpNotIn,
-							Values:   []string{"defaults"},
-						}
-					}
-
 					selector := metav1.LabelSelector{
 						MatchExpressions: []metav1.LabelSelectorRequirement{{
 							Key:      "section",
 							Operator: metav1.LabelSelectorOpIn,
 							Values:   []string{"security", "analytics"},
-						}, sourceExpression},
+						}, {
+							Key:      "source",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"us"},
+						}},
 					}
 
 					settings, err := settingsService.ListAsIni(ctx, selector)

--- a/pkg/services/frontend/request_config_middleware_test.go
+++ b/pkg/services/frontend/request_config_middleware_test.go
@@ -46,30 +46,6 @@ func setupTestContext(r *http.Request, namespace string) *http.Request {
 
 var openfeatureTestMutex sync.Mutex
 
-func enableSourceFilterToggle(t *testing.T) {
-	t.Helper()
-	openfeatureTestMutex.Lock()
-
-	sourceFilterFlag := memprovider.InMemoryFlag{
-		Key:            featuremgmt.FlagFrontendServiceSettingsSourceFilter,
-		DefaultVariant: "on",
-		Variants:       map[string]any{"on": true, "off": false},
-	}
-
-	provider, err := featuremgmt.CreateStaticProviderWithStandardFlags(map[string]memprovider.InMemoryFlag{
-		featuremgmt.FlagFrontendServiceSettingsSourceFilter: sourceFilterFlag,
-	})
-	require.NoError(t, err)
-
-	err = openfeature.SetProviderAndWait(provider)
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		_ = openfeature.SetProviderAndWait(openfeature.NoopProvider{})
-		openfeatureTestMutex.Unlock()
-	})
-}
-
 func enableReducedBootDataToggle(t *testing.T) {
 	t.Helper()
 	openfeatureTestMutex.Lock()
@@ -304,9 +280,7 @@ func TestRequestConfigMiddleware(t *testing.T) {
 		assert.False(t, mockSettingsService.called)
 	})
 
-	t.Run("should include source filter in selector when source filter toggle is enabled", func(t *testing.T) {
-		enableSourceFilterToggle(t)
-
+	t.Run("should include source filter in selector", func(t *testing.T) {
 		mockSettingsService := &mockSettingsService{
 			settings: []*settingservice.Setting{},
 		}
@@ -335,45 +309,11 @@ func TestRequestConfigMiddleware(t *testing.T) {
 		assert.Equal(t, http.StatusOK, recorder.Code)
 		assert.True(t, mockSettingsService.called)
 
-		// Verify the selector uses source=us filter (replacing the NotIn defaults filter)
 		require.Len(t, mockSettingsService.capturedSelector.MatchExpressions, 2)
 		sourceFilter := mockSettingsService.capturedSelector.MatchExpressions[1]
 		assert.Equal(t, "source", sourceFilter.Key)
 		assert.Equal(t, metav1.LabelSelectorOpIn, sourceFilter.Operator)
 		assert.Equal(t, []string{"us"}, sourceFilter.Values)
-	})
-
-	t.Run("should not include source filter in selector when source filter toggle is disabled", func(t *testing.T) {
-		mockSettingsService := &mockSettingsService{
-			settings: []*settingservice.Setting{},
-		}
-
-		license := &licensing.OSSLicensingService{}
-		cfg := &setting.Cfg{
-			Raw:      ini.Empty(),
-			HTTPPort: "1234",
-			AppURL:   "https://grafana.example.com",
-		}
-
-		middleware := RequestConfigMiddleware(cfg, license, mockSettingsService, nil)
-
-		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusOK)
-		})
-
-		handler := middleware(testHandler)
-
-		req := httptest.NewRequest("GET", "/", nil)
-		req = setupTestContext(req, "stacks-123")
-		recorder := httptest.NewRecorder()
-
-		handler.ServeHTTP(recorder, req)
-
-		assert.Equal(t, http.StatusOK, recorder.Code)
-		assert.True(t, mockSettingsService.called)
-
-		// Verify the selector does NOT include a source=us filter (only 2 expressions)
-		require.Len(t, mockSettingsService.capturedSelector.MatchExpressions, 2)
 	})
 
 	t.Run("populates full frontend settings and namespace when reduced boot data flag is enabled", func(t *testing.T) {


### PR DESCRIPTION
Removes the `frontendService.settingsSourceFilter` feature toggle. The `source In ["us"]` label filter is now the only behavior.

Before this change, the toggle selected one of two label filters when the middleware fetched tenant settings from the Settings Service:

- Toggle on: `source In ["us"]`
- Toggle off: `source NotIn ["defaults"]`

The middleware now always applies the `source In ["us"]` filter.

Other changes:

- The toggle definition is removed from the registry. The generated toggle files are updated with `make gen-feature-toggles`.
- The test for the toggle-off path is removed. The remaining test asserts that the selector always contains the filter.