### PR TITLE
Chore: Expand ESLint + lefthook coverage to all JS-alike files

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,6 +17,8 @@ const grafanaConfig = require('@grafana/eslint-config/flat');
 const grafanaPlugin = require('@grafana/eslint-plugin');
 const grafanaI18nPlugin = require('@grafana/i18n/eslint-plugin');
 
+const jsTsFiles = '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}';
+
 const pluginsToTranslate = ['public/app/plugins/panel', 'public/app/plugins/datasource/azuremonitor'];
 
 const commonTestIgnores = [
@@ -147,7 +149,7 @@ module.exports = [
       // it also conflicts with the betterer eslint rules so disabled
       reportUnusedDisableDirectives: false,
     },
-    files: ['**/*.{ts,tsx,js}'],
+    files: [`**/${jsTsFiles}`],
     ignores: ['packages/grafana-ui/src/components/Forms/Legacy/**'],
     plugins: {
       '@emotion': emotionPlugin,
@@ -596,7 +598,7 @@ module.exports = [
 
   // Old betterer rules config:
   {
-    files: ['**/*.{js,jsx,ts,tsx}'],
+    files: [`**/${jsTsFiles}`],
     ignores: [
       // FIXME: Remove once all enterprise issues are fixed -
       // we don't have a suppressions file/approach for enterprise code yet
@@ -609,7 +611,7 @@ module.exports = [
     },
   },
   {
-    files: ['**/*.{js,jsx,ts,tsx}'],
+    files: [`**/${jsTsFiles}`],
     ignores: [
       ...commonTestIgnores,
       // FIXME: Remove once all enterprise issues are fixed -

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -11,9 +11,9 @@ pre-commit:
   parallel: true
   commands:
     frontend-lint:
-      glob: '*.{js,ts,tsx}'
+      glob: '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}'
       run: |
-        yarn eslint --ext .js,.tsx,.ts --cache --prune-suppressions --fix {staged_files} &&
+        yarn eslint --ext .js,.jsx,.ts,.tsx,.mjs,.cjs,.mts,.cts --cache --prune-suppressions --fix {staged_files} &&
         git add eslint-suppressions.json &&
         yarn prettier --write {staged_files}
       stage_fixed: true

--- a/packages/grafana-eslint-rules/index.cjs
+++ b/packages/grafana-eslint-rules/index.cjs
@@ -1,13 +1,13 @@
+const consistentStoryTitles = require('./rules/consistent-story-titles.cjs');
+const defineFeatureEvents = require('./rules/define-feature-events.cjs');
 const noAriaLabelSelectors = require('./rules/no-aria-label-e2e-selectors.cjs');
 const noBorderRadiusLiteral = require('./rules/no-border-radius-literal.cjs');
+const noInvalidCssProperties = require('./rules/no-invalid-css-properties.cjs');
+const noPluginExternalImportPaths = require('./rules/no-plugin-external-import-paths.cjs');
+const noRestrictedImgSrcs = require('./rules/no-restricted-img-srcs.cjs');
+const noRestrictedSyntaxRules = require('./rules/no-restricted-syntax.cjs');
 const noUnreducedMotion = require('./rules/no-unreduced-motion.cjs');
 const themeTokenUsage = require('./rules/theme-token-usage.cjs');
-const noRestrictedImgSrcs = require('./rules/no-restricted-img-srcs.cjs');
-const consistentStoryTitles = require('./rules/consistent-story-titles.cjs');
-const noPluginExternalImportPaths = require('./rules/no-plugin-external-import-paths.cjs');
-const noInvalidCssProperties = require('./rules/no-invalid-css-properties.cjs');
-const defineFeatureEvents = require('./rules/define-feature-events.cjs');
-const noRestrictedSyntaxRules = require('./rules/no-restricted-syntax.cjs');
 
 /** @type {import('eslint').Linter.Plugin} */
 module.exports = {

--- a/packages/grafana-eslint-rules/rules/import-utils.cjs
+++ b/packages/grafana-eslint-rules/rules/import-utils.cjs
@@ -73,6 +73,7 @@ const replaceWithPublicBuild = (fixer, node) => {
   const startingQuote = node.raw.startsWith('"') ? '"' : "'";
   return fixer.replaceText(
     node,
+    // eslint-disable-next-line @grafana/no-restricted-img-srcs -- logic that implements the rule itself
     `${startingQuote}${value.replace('public/img/', 'public/build/img/')}${startingQuote}`
   );
 };
@@ -82,6 +83,7 @@ const replaceWithPublicBuild = (fixer, node) => {
  */
 const isInvalidImageLocation = (value) => {
   return (
+    // eslint-disable-next-line @grafana/no-restricted-img-srcs -- logic that implements the rule itself
     value.startsWith('public/img/') ||
     (!value.startsWith('public/build/') &&
       !value.startsWith('public/plugins/') &&

--- a/packages/grafana-eslint-rules/rules/no-invalid-css-properties.cjs
+++ b/packages/grafana-eslint-rules/rules/no-invalid-css-properties.cjs
@@ -1,6 +1,6 @@
 const { ESLintUtils, AST_NODE_TYPES } = require('@typescript-eslint/utils');
-const { all: allCssProperties } = require('known-css-properties');
 const htmlTagsModule = require('html-tags');
+const { all: allCssProperties } = require('known-css-properties');
 
 const createRule = ESLintUtils.RuleCreator(
   (name) => `https://github.com/grafana/grafana/blob/main/packages/grafana-eslint-rules/README.md#${name}`

--- a/packages/grafana-eslint-rules/rules/no-restricted-img-srcs.cjs
+++ b/packages/grafana-eslint-rules/rules/no-restricted-img-srcs.cjs
@@ -1,9 +1,10 @@
 // @ts-check
 /** @typedef {import('@typescript-eslint/utils').TSESTree.Literal} Literal */
 /** @typedef {import('@typescript-eslint/utils').TSESTree.TemplateLiteral} TemplateLiteral */
-const { getImageImportFixers, replaceWithPublicBuild, isInvalidImageLocation } = require('./import-utils.cjs');
 
 const { ESLintUtils, AST_NODE_TYPES } = require('@typescript-eslint/utils');
+
+const { getImageImportFixers, replaceWithPublicBuild, isInvalidImageLocation } = require('./import-utils.cjs');
 
 const createRule = ESLintUtils.RuleCreator(
   (name) => `https://github.com/grafana/grafana/blob/main/packages/grafana-eslint-rules/README.md#${name}`
@@ -29,6 +30,7 @@ const imgSrcRule = createRule({
         const { value } = node;
 
         if (value && typeof value === 'string' && isInvalidImageLocation(value)) {
+          // eslint-disable-next-line @grafana/no-restricted-img-srcs -- logic that implements the rule itself
           const canUseBuildFolder = value.startsWith('public/img/');
           /**
            * @type {import('@typescript-eslint/utils/ts-eslint').SuggestionReportDescriptor<"publicImg" | "importImage" | "useBuildFolder">[]}

--- a/packages/grafana-eslint-rules/rules/no-restricted-syntax.cjs
+++ b/packages/grafana-eslint-rules/rules/no-restricted-syntax.cjs
@@ -33,9 +33,11 @@ module.exports = createNoRestrictedSyntax(
       'Using localeCompare() can cause performance issues when sorting large datasets. Consider using Intl.Collator for better performance when sorting arrays, or add an eslint-disable comment if sorting a small, known dataset.',
   },
   {
+    /* eslint-disable @grafana/no-gf-form -- logic that implements the rule itself */
     name: 'no-gf-form',
     selector: 'Literal[value=/gf-form/], TemplateElement[value.cooked=/gf-form/]',
     message: 'gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.',
+    /* eslint-enable @grafana/no-gf-form */
   },
   {
     name: 'no-config-apps',

--- a/packages/grafana-i18n/src/eslint/index.cjs
+++ b/packages/grafana-i18n/src/eslint/index.cjs
@@ -1,5 +1,5 @@
-const noUntranslatedStrings = require('./no-untranslated-strings/no-untranslated-strings.cjs');
 const noTranslationTopLevel = require('./no-translation-top-level/no-translation-top-level.cjs');
+const noUntranslatedStrings = require('./no-untranslated-strings/no-untranslated-strings.cjs');
 const tPluralDefaults = require('./t-plural-defaults/t-plural-defaults.cjs');
 const transPluralDefaults = require('./trans-plural-defaults/trans-plural-defaults.cjs');
 

--- a/packages/grafana-i18n/src/eslint/no-untranslated-strings/no-untranslated-strings.cjs
+++ b/packages/grafana-i18n/src/eslint/no-untranslated-strings/no-untranslated-strings.cjs
@@ -5,6 +5,8 @@
 /** @typedef {import('@typescript-eslint/utils/ts-eslint').RuleModule<'noUntranslatedStrings' | 'noUntranslatedStringsProp' | 'wrapWithTrans' | 'wrapWithT' | 'noUntranslatedStringsProperties', [{ forceFix: string[] , calleesToIgnore: string[], basePaths: string[], namespace?: string }]>} RuleDefinition */
 /** @typedef {import('@typescript-eslint/utils/ts-eslint').RuleContext<'noUntranslatedStrings' | 'noUntranslatedStringsProp' | 'wrapWithTrans' | 'wrapWithT' | 'noUntranslatedStringsProperties',  [{forceFix: string[], calleesToIgnore: string[], basePaths: string[], namespace?: string}]>} RuleContextWithOptions */
 
+const { ESLintUtils, AST_NODE_TYPES } = require('@typescript-eslint/utils');
+
 const {
   getNodeValue,
   getTFixers,
@@ -14,8 +16,6 @@ const {
   shouldBeFixed,
   isStringNonAlphanumeric,
 } = require('./translation-utils.cjs');
-
-const { ESLintUtils, AST_NODE_TYPES } = require('@typescript-eslint/utils');
 
 const createRule = ESLintUtils.RuleCreator(
   (name) => `https://github.com/grafana/grafana/blob/main/packages/grafana-i18n/src/eslint/README.md#${name}`

--- a/scripts/cli/analytics/codeowners.mts
+++ b/scripts/cli/analytics/codeowners.mts
@@ -1,5 +1,5 @@
-import path from 'path';
 import { OwnershipEngine } from 'github-codeowners/dist/lib/ownership/index.js';
+import path from 'path';
 
 const CODEOWNERS_PATH = path.resolve('.github/CODEOWNERS');
 

--- a/scripts/cli/analytics/eventParser.mts
+++ b/scripts/cli/analytics/eventParser.mts
@@ -1,5 +1,4 @@
 import path from 'path';
-
 import {
   Node,
   SyntaxKind,
@@ -11,11 +10,10 @@ import {
   type JSDoc,
 } from 'ts-morph';
 
-import type { EventData, EventNamespace, EventPropertySchema, JSDocMetadata } from './types.mts';
-
+import { resolveOwner } from './codeowners.mts';
 import { extractSilentFromOptions } from './findAllEvents.mts';
 import { getMetadataFromJSDocs, getJsDocsFromNode, resolveType } from './typeResolution.mts';
-import { resolveOwner } from './codeowners.mts';
+import type { EventData, EventNamespace, EventPropertySchema, JSDocMetadata } from './types.mts';
 
 /**
  * Finds all events declared in a file by locating calls to known factory functions

--- a/scripts/cli/analytics/findAllEvents.mts
+++ b/scripts/cli/analytics/findAllEvents.mts
@@ -1,9 +1,8 @@
 import { Node, SyntaxKind, type SourceFile } from 'ts-morph';
 
-import type { EventData, EventNamespace, EventPropertySchema } from './types.mts';
-
 import { parseEventsFromFile } from './eventParser.mts';
 import { getMetadataFromJSDocs, getJsDocsFromNode, resolveType } from './typeResolution.mts';
+import type { EventData, EventNamespace, EventPropertySchema } from './types.mts';
 
 export const findAllEvents = (files: SourceFile[], defineFeatureEventsPath: string): EventData[] => {
   const eventMap = new Map<string, EventData>();

--- a/scripts/cli/analytics/silent.test.mts
+++ b/scripts/cli/analytics/silent.test.mts
@@ -1,6 +1,5 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
-
 import { Project, type SourceFile } from 'ts-morph';
 
 import { findAllEvents } from './findAllEvents.mts';

--- a/scripts/cli/analytics/typeResolution.mts
+++ b/scripts/cli/analytics/typeResolution.mts
@@ -1,4 +1,5 @@
 import { Node, createWrappedNode, type JSDoc, type Node as TsMorphNode, type Type, type ts } from 'ts-morph';
+
 import type { JSDocMetadata } from './types.mts';
 
 /**

--- a/scripts/cli/eslint-stats-reporter.mjs
+++ b/scripts/cli/eslint-stats-reporter.mjs
@@ -1,4 +1,5 @@
 //@ts-check
+// eslint-disable-next-line lodash/import-scope -- lodash is a cjs module here
 import lodash from 'lodash';
 const { camelCase } = lodash;
 

--- a/scripts/codeowners-manifest/list-tests.mts
+++ b/scripts/codeowners-manifest/list-tests.mts
@@ -6,10 +6,10 @@
 // bodies are executed.
 //
 // Usage: node ./scripts/codeowners-manifest/list-tests.mts '@grafana/dataviz-squad'
-import cp from 'node:child_process';
-import path from 'node:path';
 
 import { parse } from 'jest-editor-support';
+import cp from 'node:child_process';
+import path from 'node:path';
 
 const JEST_BIN_PATH = 'node_modules/jest/bin/jest.js';
 const JEST_CONFIG_PATH = 'jest.config.codeowner.js';
@@ -69,6 +69,7 @@ let failed = 0;
 for (const file of files) {
   let root: ParsedNode;
   try {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- untyped return from parse()
     ({ root } = parse(file) as { root: ParsedNode });
   } catch (err) {
     failed++;


### PR DESCRIPTION
**What is this feature?**

Updates the globs used by ESLint + lefthook to include all JS-alike files, rather than just a subset.

**Why do we need this feature?**

Follow-on from #130205 + #130012, where a poorly formatted `.cjs` file landed, which lefthook did not format automatically locally.

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
