### PR TITLE
TraceView: Also show DB O11y promo if plugin is not activated

### DIFF
--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/pluginPromo/AttributePluginPromoTip.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/pluginPromo/AttributePluginPromoTip.test.tsx
@@ -2,9 +2,15 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { locationUtil } from '@grafana/data';
+import { reportInteraction } from '@grafana/runtime';
 
 import { AttributePluginPromoTip } from './AttributePluginPromoTip';
 import { type AttributePluginPromo } from './attributePluginPromos';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  reportInteraction: jest.fn(),
+}));
 
 const promo: AttributePluginPromo = {
   pluginId: 'grafana-dbo11y-app',
@@ -15,6 +21,10 @@ const promo: AttributePluginPromo = {
 };
 
 describe('AttributePluginPromoTip', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('renders children and shows promo content on click', async () => {
     const user = userEvent.setup();
     render(
@@ -33,5 +43,24 @@ describe('AttributePluginPromoTip', () => {
 
     const learnMore = screen.getByRole('link', { name: /learn more/i });
     expect(learnMore).toHaveAttribute('href', locationUtil.assureBaseUrl(`/plugins/${promo.pluginId}`));
+  });
+
+  it('reports interaction when the learn more link is clicked', async () => {
+    const user = userEvent.setup();
+    render(
+      <AttributePluginPromoTip promo={promo}>
+        <span>SELECT 1</span>
+      </AttributePluginPromoTip>
+    );
+
+    await user.click(screen.getByTestId('attribute-plugin-promo-trigger'));
+
+    const learnMore = await screen.findByRole('link', { name: /learn more/i });
+    learnMore.addEventListener('click', (event) => event.preventDefault());
+    await user.click(learnMore);
+
+    expect(reportInteraction).toHaveBeenCalledWith('grafana_traces_trace_view_attribute_plugin_promo_clicked', {
+      pluginId: 'grafana-dbo11y-app',
+    });
   });
 });

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/pluginPromo/AttributePluginPromoTip.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/pluginPromo/AttributePluginPromoTip.tsx
@@ -3,6 +3,7 @@ import { type PropsWithChildren } from 'react';
 
 import { type GrafanaTheme2, locationUtil } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
+import { reportInteraction } from '@grafana/runtime';
 import { Icon, LinkButton, Stack, Text, Toggletip, useStyles2 } from '@grafana/ui';
 
 import { type AttributePluginPromo } from './attributePluginPromos';
@@ -17,6 +18,12 @@ type Props = PropsWithChildren<{
 export function AttributePluginPromoTip({ promo, children }: Props) {
   const styles = useStyles2(getStyles);
   const catalogUrl = locationUtil.assureBaseUrl(`/plugins/${promo.pluginId}`);
+
+  const onLearnMoreClick = () => {
+    reportInteraction('grafana_traces_trace_view_attribute_plugin_promo_clicked', {
+      pluginId: promo.pluginId,
+    });
+  };
 
   return (
     <Toggletip
@@ -36,7 +43,7 @@ export function AttributePluginPromoTip({ promo, children }: Props) {
         </div>
       }
       footer={
-        <LinkButton href={catalogUrl} size="sm">
+        <LinkButton href={catalogUrl} size="sm" onClick={onLearnMoreClick}>
           <Trans i18nKey="explore.trace-view.attribute-plugin-promo.learn-more">Learn more</Trans>
         </LinkButton>
       }

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/pluginPromo/AttributePluginPromoTip.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/pluginPromo/AttributePluginPromoTip.tsx
@@ -12,7 +12,7 @@ type Props = PropsWithChildren<{
 }>;
 
 /**
- * Clickable attribute-value wrapper that promotes installing a related app plugin.
+ * Clickable attribute-value wrapper that promotes installing or activating a related app plugin.
  */
 export function AttributePluginPromoTip({ promo, children }: Props) {
   const styles = useStyles2(getStyles);

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/pluginPromo/attributePluginPromos.test.ts
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/pluginPromo/attributePluginPromos.test.ts
@@ -1,11 +1,16 @@
-import { renderHook } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 
-import { config } from '@grafana/runtime';
+import { config, isAppPluginEnabled } from '@grafana/runtime';
 import { useAppPluginMetas } from '@grafana/runtime/internal';
 
 import { isDatabaseAttribute } from '../attributeCategories';
 
 import { getAttributePluginPromos, useAttributePluginPromoGetter } from './attributePluginPromos';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  isAppPluginEnabled: jest.fn(),
+}));
 
 jest.mock('@grafana/runtime/internal', () => ({
   ...jest.requireActual('@grafana/runtime/internal'),
@@ -13,6 +18,7 @@ jest.mock('@grafana/runtime/internal', () => ({
 }));
 
 const mockUseAppPluginMetas = jest.mocked(useAppPluginMetas);
+const mockIsAppPluginEnabled = jest.mocked(isAppPluginEnabled);
 
 describe('getAttributePluginPromos', () => {
   const originalNamespace = config.namespace;
@@ -46,6 +52,7 @@ describe('useAttributePluginPromoGetter', () => {
 
   beforeEach(() => {
     config.namespace = 'stacks-12345';
+    mockIsAppPluginEnabled.mockResolvedValue(false);
   });
 
   afterEach(() => {
@@ -53,49 +60,80 @@ describe('useAttributePluginPromoGetter', () => {
     jest.clearAllMocks();
   });
 
-  it('returns no promo while plugin metas are loading', () => {
+  it('returns no promo while plugin metas are loading', async () => {
     mockUseAppPluginMetas.mockReturnValue({ loading: true, error: undefined, value: undefined });
 
     const { result } = renderHook(() => useAttributePluginPromoGetter());
 
-    expect(result.current('db.system')).toBeUndefined();
+    await waitFor(() => {
+      expect(result.current('db.system')).toBeUndefined();
+    });
+    expect(mockIsAppPluginEnabled).not.toHaveBeenCalled();
   });
 
-  it('returns no promo when plugin metas are unavailable', () => {
+  it('returns no promo when plugin metas are unavailable', async () => {
     mockUseAppPluginMetas.mockReturnValue({ loading: false, error: new Error('failed'), value: undefined });
 
     const { result } = renderHook(() => useAttributePluginPromoGetter());
 
-    expect(result.current('db.system')).toBeUndefined();
+    await waitFor(() => {
+      expect(result.current('db.system')).toBeUndefined();
+    });
+    expect(mockIsAppPluginEnabled).not.toHaveBeenCalled();
   });
 
-  it('returns a promo when the matching plugin is not installed', () => {
+  it('returns a promo when the matching plugin is not installed', async () => {
     mockUseAppPluginMetas.mockReturnValue({ loading: false, error: undefined, value: [] });
 
     const { result } = renderHook(() => useAttributePluginPromoGetter());
 
-    expect(result.current('db.system')?.pluginId).toBe('grafana-dbo11y-app');
+    await waitFor(() => {
+      expect(result.current('db.system')?.pluginId).toBe('grafana-dbo11y-app');
+    });
     expect(result.current('http.method')).toBeUndefined();
+    expect(mockIsAppPluginEnabled).not.toHaveBeenCalled();
   });
 
-  it('returns no promo when the matching plugin is installed', () => {
+  it('returns a promo when the matching plugin is installed but not activated', async () => {
     mockUseAppPluginMetas.mockReturnValue({
       loading: false,
       error: undefined,
       value: [{ id: 'grafana-dbo11y-app' } as never],
     });
+    mockIsAppPluginEnabled.mockResolvedValue(false);
 
     const { result } = renderHook(() => useAttributePluginPromoGetter());
 
+    await waitFor(() => {
+      expect(result.current('db.system')?.pluginId).toBe('grafana-dbo11y-app');
+    });
+    expect(mockIsAppPluginEnabled).toHaveBeenCalledWith('grafana-dbo11y-app');
+  });
+
+  it('returns no promo when the matching plugin is installed and activated', async () => {
+    mockUseAppPluginMetas.mockReturnValue({
+      loading: false,
+      error: undefined,
+      value: [{ id: 'grafana-dbo11y-app' } as never],
+    });
+    mockIsAppPluginEnabled.mockResolvedValue(true);
+
+    const { result } = renderHook(() => useAttributePluginPromoGetter());
+
+    await waitFor(() => {
+      expect(mockIsAppPluginEnabled).toHaveBeenCalledWith('grafana-dbo11y-app');
+    });
     expect(result.current('db.system')).toBeUndefined();
   });
 
-  it('returns no promo on on-prem', () => {
+  it('returns no promo on on-prem', async () => {
     config.namespace = 'default';
     mockUseAppPluginMetas.mockReturnValue({ loading: false, error: undefined, value: [] });
 
     const { result } = renderHook(() => useAttributePluginPromoGetter());
 
-    expect(result.current('db.system')).toBeUndefined();
+    await waitFor(() => {
+      expect(result.current('db.system')).toBeUndefined();
+    });
   });
 });

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/pluginPromo/attributePluginPromos.ts
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/pluginPromo/attributePluginPromos.ts
@@ -1,7 +1,9 @@
 import { useCallback, useMemo } from 'react';
+import { useAsync } from 'react-use';
 
 import { type IconName } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { isAppPluginEnabled } from '@grafana/runtime';
 import { useAppPluginMetas } from '@grafana/runtime/internal';
 import { isOnPrem } from 'app/core/utils/isOnPrem';
 
@@ -16,7 +18,8 @@ export type AttributePluginPromo = {
 };
 
 /**
- * Promos shown on attribute values when the related app plugin is not installed.
+ * Promos shown on attribute values when the related app plugin is not installed,
+ * or is installed but not activated (enabled).
  * Add new entries here as other apps (Knowledge Graph, App O11y, etc.) adopt this pattern.
  * Cloud-only: never shown on on-prem OSS or Enterprise (`isOnPrem()`).
  */
@@ -42,28 +45,46 @@ export function getAttributePluginPromos(): AttributePluginPromo[] {
 export type AttributePluginPromoGetter = (attributeKey: string) => AttributePluginPromo | undefined;
 
 /**
- * Returns a getter for attribute promos whose plugins are not installed.
+ * Returns a getter for attribute promos whose plugins are not installed or not activated.
  * Adding a promo only requires a new entry in {@link getAttributePluginPromos}.
- * Returns no promo while plugin metas are loading or unavailable, to avoid a flash for installed plugins.
+ * Returns no promo while status is loading or unavailable, to avoid a flash for activated plugins.
+ * Installed status comes from bootdata metas (no request); enabled is only fetched for installed apps
+ * to avoid 404s for plugins that aren't present.
  */
 export function useAttributePluginPromoGetter(): AttributePluginPromoGetter {
   const promos = useMemo(() => getAttributePluginPromos(), []);
-  const { loading, value: appMetas } = useAppPluginMetas();
+  const { loading: metasLoading, value: appMetas } = useAppPluginMetas();
 
-  const installedPluginIds = useMemo(() => {
-    if (loading || appMetas === undefined) {
+  const { value: inactivePluginIds } = useAsync(async () => {
+    if (metasLoading || appMetas === undefined) {
       return undefined;
     }
-    return new Set(appMetas.map((app) => app.id));
-  }, [appMetas, loading]);
+
+    const installedPluginIds = new Set(appMetas.map((app) => app.id));
+    const inactive = new Set<string>();
+
+    await Promise.all(
+      promos.map(async ({ pluginId }) => {
+        if (!installedPluginIds.has(pluginId)) {
+          inactive.add(pluginId);
+          return;
+        }
+        if (!(await isAppPluginEnabled(pluginId))) {
+          inactive.add(pluginId);
+        }
+      })
+    );
+
+    return inactive;
+  }, [appMetas, metasLoading, promos]);
 
   return useCallback(
     (attributeKey: string) => {
-      if (!installedPluginIds) {
+      if (!inactivePluginIds) {
         return undefined;
       }
-      return promos.find((promo) => !installedPluginIds.has(promo.pluginId) && promo.match(attributeKey));
+      return promos.find((promo) => inactivePluginIds.has(promo.pluginId) && promo.match(attributeKey));
     },
-    [installedPluginIds, promos]
+    [inactivePluginIds, promos]
   );
 }


### PR DESCRIPTION
**What is this feature?**

TraceView: Also show DB O11y promo if plugin is installed and not activated.

**Why do we need this feature?**

Follow up to https://github.com/grafana/grafana/pull/129552 with new rule.

Also adds feature tracking for clicks in the promo learn more button.

**Who is this feature for?**

TraceView users.
