### PR TITLE
Alerting: Fix alert rule detail showing "Inhibited" when nothing is inhibited

### DIFF
--- a/public/app/features/alerting/unified/api/alertmanagerApi.ts
+++ b/public/app/features/alerting/unified/api/alertmanagerApi.ts
@@ -42,10 +42,27 @@ export interface GrafanaAlertingConfigurationStatusResponse {
   numExternalAlertmanagers: number;
 }
 
+/**
+ * The state options are exclusions, not a selector: each one decides whether alerts in that state
+ * are *included*, and they all default to true. So `{ inhibited: true }` selects nothing on its own,
+ * and any state you don't exclude still comes back — notably "unprocessed" alerts, which have no
+ * marker entry yet and are therefore neither active, silenced nor inhibited. Check the alert's own
+ * `status` if you need to know which state it is actually in.
+ */
 interface AlertmanagerAlertsFilter {
+  /** Include active alerts (default: true when omitted) */
   active?: boolean;
+  /** Include silenced alerts (default: true when omitted). An alert can be both silenced and inhibited. */
   silenced?: boolean;
+  /** Include inhibited alerts (default: true when omitted) */
   inhibited?: boolean;
+  /**
+   * Include unprocessed alerts (default: true when omitted).
+   *
+   * Only honoured by external Alertmanager datasources, whose query string is proxied verbatim. The
+   * Grafana Alertmanager ignores it: neither the built-in handler nor the remote Alertmanager client
+   * reads or forwards this param, so unprocessed alerts are always returned there.
+   */
   unprocessed?: boolean;
   matchers?: Matcher[];
 }
@@ -85,7 +102,6 @@ export const alertmanagerApi = alertingApi.injectEndpoints({
       { amSourceName: string; filter?: AlertmanagerAlertsFilter; showErrorAlert?: boolean }
     >({
       query: ({ amSourceName, filter, showErrorAlert = true }) => {
-        // TODO Add support for active, silenced, inhibited, unprocessed filters
         const filterMatchers = filter?.matchers
           ?.filter((matcher) => matcher.name && matcher.value)
           .map((matcher) => {

--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.test.tsx
@@ -448,6 +448,20 @@ describe('RuleViewer', () => {
       expect(screen.queryByText('Inhibited')).not.toBeInTheDocument();
     });
 
+    it('should not show "Inhibited" for unprocessed instances of the rule', async () => {
+      setAlertmanagerAlertsHandler([
+        mockAlertmanagerAlert({
+          labels: { __alert_rule_uid__: grafanaRulerRule.grafana_alert.uid, alertname: 'Test alert' },
+          status: { state: AlertState.Unprocessed, silencedBy: [], inhibitedBy: [] },
+        }),
+      ]);
+
+      await renderRuleViewer(mockRule, mockRuleIdentifier);
+
+      await screen.findByText('Test alert');
+      expect(screen.queryByText('Inhibited')).not.toBeInTheDocument();
+    });
+
     it('should not show a stale "Inhibited" badge while re-fetching after the rule is no longer inhibited', async () => {
       // Seed the cache: the rule currently has an inhibited instance, so the badge shows.
       setAlertmanagerAlertsHandler([

--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.test.tsx
@@ -411,6 +411,15 @@ describe('RuleViewer', () => {
       ]);
     });
 
+    /**
+     * The badge only appears once the Alertmanager query resolves, so checking for its absence
+     * straight after render could pass before the response is even delivered. Waiting out the
+     * findBy timeout gives the badge every chance to show up first.
+     */
+    const expectNoInhibitedBadge = async () => {
+      await expect(screen.findByText('Inhibited')).rejects.toThrow();
+    };
+
     it('should show "Inhibited" state in the title when the rule has inhibited instances', async () => {
       setAlertmanagerAlertsHandler([
         mockAlertmanagerAlert({
@@ -429,9 +438,7 @@ describe('RuleViewer', () => {
 
       await renderRuleViewer(mockRule, mockRuleIdentifier);
 
-      // wait for the page to settle
-      await screen.findByText('Test alert');
-      expect(screen.queryByText('Inhibited')).not.toBeInTheDocument();
+      await expectNoInhibitedBadge();
     });
 
     it('should not show "Inhibited" when inhibited alerts belong to a different rule', async () => {
@@ -444,8 +451,7 @@ describe('RuleViewer', () => {
 
       await renderRuleViewer(mockRule, mockRuleIdentifier);
 
-      await screen.findByText('Test alert');
-      expect(screen.queryByText('Inhibited')).not.toBeInTheDocument();
+      await expectNoInhibitedBadge();
     });
 
     it('should not show "Inhibited" for unprocessed instances of the rule', async () => {
@@ -458,8 +464,7 @@ describe('RuleViewer', () => {
 
       await renderRuleViewer(mockRule, mockRuleIdentifier);
 
-      await screen.findByText('Test alert');
-      expect(screen.queryByText('Inhibited')).not.toBeInTheDocument();
+      await expectNoInhibitedBadge();
     });
 
     it('should not show a stale "Inhibited" badge while re-fetching after the rule is no longer inhibited', async () => {

--- a/public/app/features/alerting/unified/hooks/useHasInhibitedInstances.test.tsx
+++ b/public/app/features/alerting/unified/hooks/useHasInhibitedInstances.test.tsx
@@ -64,6 +64,23 @@ describe('useHasInhibitedInstances', () => {
     expect(result.current.hasInhibitedInstances).toBe(false);
   });
 
+  it('should return false for unprocessed alerts matching the rule UID', async () => {
+    setAlertmanagerAlertsHandler([
+      mockAlertmanagerAlert({
+        labels: { __alert_rule_uid__: TEST_RULE_UID, alertname: 'TestAlert' },
+        status: { state: AlertState.Unprocessed, silencedBy: [], inhibitedBy: [] },
+      }),
+    ]);
+
+    const { result } = renderHook(() => useHasInhibitedInstances(TEST_RULE_UID), { wrapper: wrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.hasInhibitedInstances).toBe(false);
+  });
+
   it('should return isLoading true initially', () => {
     const { result } = renderHook(() => useHasInhibitedInstances(TEST_RULE_UID), { wrapper: wrapper() });
 

--- a/public/app/features/alerting/unified/hooks/useHasInhibitedInstances.test.tsx
+++ b/public/app/features/alerting/unified/hooks/useHasInhibitedInstances.test.tsx
@@ -81,7 +81,7 @@ describe('useHasInhibitedInstances', () => {
     expect(result.current.hasInhibitedInstances).toBe(false);
   });
 
-  it('should not ask the API to exclude silenced alerts', async () => {
+  const captureAlertsRequests = async () => {
     const { http, HttpResponse } = await import('msw');
     const { default: mswServer } = await import('@grafana/test-utils/server');
 
@@ -93,6 +93,12 @@ describe('useHasInhibitedInstances', () => {
       })
     );
 
+    return requestedUrls;
+  };
+
+  it('should scope the request to the rule and not exclude silenced alerts', async () => {
+    const requestedUrls = await captureAlertsRequests();
+
     renderHook(() => useHasInhibitedInstances(TEST_RULE_UID), { wrapper: wrapper() });
 
     await waitFor(() => {
@@ -100,10 +106,24 @@ describe('useHasInhibitedInstances', () => {
     });
 
     const params = new URL(requestedUrls[0]).searchParams;
+    // scoping to the rule keeps the response small, rather than every suppressed alert in the org
+    expect(params.getAll('filter')).toEqual([`__alert_rule_uid__="${TEST_RULE_UID}"`]);
     // an alert can be both silenced and inhibited, so excluding silenced alerts would hide it
     expect(params.has('silenced')).toBe(false);
     expect(params.get('active')).toBe('false');
     expect(params.get('inhibited')).toBe('true');
+  });
+
+  it('should not request anything when ruleUid is undefined', async () => {
+    const requestedUrls = await captureAlertsRequests();
+
+    const { result } = renderHook(() => useHasInhibitedInstances(undefined), { wrapper: wrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(requestedUrls).toHaveLength(0);
   });
 
   it('should return false for alerts that are only silenced', async () => {

--- a/public/app/features/alerting/unified/hooks/useHasInhibitedInstances.test.tsx
+++ b/public/app/features/alerting/unified/hooks/useHasInhibitedInstances.test.tsx
@@ -81,6 +81,86 @@ describe('useHasInhibitedInstances', () => {
     expect(result.current.hasInhibitedInstances).toBe(false);
   });
 
+  it('should not ask the API to exclude silenced alerts', async () => {
+    const { http, HttpResponse } = await import('msw');
+    const { default: mswServer } = await import('@grafana/test-utils/server');
+
+    const requestedUrls: string[] = [];
+    mswServer.use(
+      http.get('/api/alertmanager/:datasourceUid/api/v2/alerts', ({ request }) => {
+        requestedUrls.push(request.url);
+        return HttpResponse.json([]);
+      })
+    );
+
+    renderHook(() => useHasInhibitedInstances(TEST_RULE_UID), { wrapper: wrapper() });
+
+    await waitFor(() => {
+      expect(requestedUrls).toHaveLength(1);
+    });
+
+    const params = new URL(requestedUrls[0]).searchParams;
+    // an alert can be both silenced and inhibited, so excluding silenced alerts would hide it
+    expect(params.has('silenced')).toBe(false);
+    expect(params.get('active')).toBe('false');
+    expect(params.get('inhibited')).toBe('true');
+  });
+
+  it('should return false for alerts that are only silenced', async () => {
+    setAlertmanagerAlertsHandler([
+      mockAlertmanagerAlert({
+        labels: { __alert_rule_uid__: TEST_RULE_UID, alertname: 'TestAlert' },
+        status: { state: AlertState.Suppressed, silencedBy: ['silence-id'], inhibitedBy: [] },
+      }),
+    ]);
+
+    const { result } = renderHook(() => useHasInhibitedInstances(TEST_RULE_UID), { wrapper: wrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.hasInhibitedInstances).toBe(false);
+  });
+
+  it('should return true for alerts that are both silenced and inhibited', async () => {
+    setAlertmanagerAlertsHandler([
+      mockAlertmanagerAlert({
+        labels: { __alert_rule_uid__: TEST_RULE_UID, alertname: 'TestAlert' },
+        status: { state: AlertState.Suppressed, silencedBy: ['silence-id'], inhibitedBy: ['source-fingerprint'] },
+      }),
+    ]);
+
+    const { result } = renderHook(() => useHasInhibitedInstances(TEST_RULE_UID), { wrapper: wrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.hasInhibitedInstances).toBe(true);
+  });
+
+  it('should return true when the rule has both unprocessed and inhibited instances', async () => {
+    setAlertmanagerAlertsHandler([
+      mockAlertmanagerAlert({
+        labels: { __alert_rule_uid__: TEST_RULE_UID, alertname: 'Unprocessed instance' },
+        status: { state: AlertState.Unprocessed, silencedBy: [], inhibitedBy: [] },
+      }),
+      mockAlertmanagerAlert({
+        labels: { __alert_rule_uid__: TEST_RULE_UID, alertname: 'Inhibited instance' },
+        status: { state: AlertState.Suppressed, silencedBy: [], inhibitedBy: ['source-fingerprint'] },
+      }),
+    ]);
+
+    const { result } = renderHook(() => useHasInhibitedInstances(TEST_RULE_UID), { wrapper: wrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.hasInhibitedInstances).toBe(true);
+  });
+
   it('should return isLoading true initially', () => {
     const { result } = renderHook(() => useHasInhibitedInstances(TEST_RULE_UID), { wrapper: wrapper() });
 

--- a/public/app/features/alerting/unified/hooks/useHasInhibitedInstances.ts
+++ b/public/app/features/alerting/unified/hooks/useHasInhibitedInstances.ts
@@ -4,16 +4,17 @@ import { useInhibitedAlerts } from './useInhibitedAlerts';
  * Checks whether any firing instances of a given Grafana-managed alert rule
  * are currently being inhibited by the Grafana Alertmanager.
  *
- * Uses the shared useInhibitedAlerts cache (one request for the full inhibited list)
- * and matches client-side via the __alert_rule_uid__ label, which the backend
- * unconditionally stamps on every Grafana-managed alert instance.
+ * The request is already scoped to the rule by its __alert_rule_uid__ label, which the backend
+ * unconditionally stamps on every Grafana-managed alert instance. The same label is checked here
+ * too, so a matcher an Alertmanager implementation happens to ignore can't turn another rule's
+ * inhibition into this rule's.
  */
 export function useHasInhibitedInstances(ruleUid: string | undefined): {
   hasInhibitedInstances: boolean;
   isLoading: boolean;
   isFetching: boolean;
 } {
-  const { inhibitedAlerts, isLoading, isFetching } = useInhibitedAlerts();
+  const { inhibitedAlerts, isLoading, isFetching } = useInhibitedAlerts(ruleUid);
 
   const hasInhibitedInstances =
     ruleUid !== undefined && inhibitedAlerts.some((alert) => alert.labels.__alert_rule_uid__ === ruleUid);

--- a/public/app/features/alerting/unified/hooks/useInhibitedAlerts.ts
+++ b/public/app/features/alerting/unified/hooks/useInhibitedAlerts.ts
@@ -6,14 +6,16 @@ import { alertmanagerApi } from '../api/alertmanagerApi';
 import { GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
 
 /**
- * Fetches the full list of currently inhibited alerts from the Grafana Alertmanager.
+ * Fetches the alerts of a single Grafana-managed rule that the Grafana Alertmanager is currently
+ * inhibiting, matched on the `__alert_rule_uid__` label the backend stamps on every instance.
  *
- * The request is intentionally not scoped to a single rule, so the result is shared via
- * RTK Query's cache across all consumers, avoiding per-rule network requests.
+ * Scoping the request to one rule keeps the response small: without a matcher the Alertmanager
+ * returns every suppressed alert in the org, which can be a lot of silenced alerts to download and
+ * parse for what callers use as a per-rule signal.
  *
- * Only runs for the Grafana-managed alertmanager.
+ * Skipped entirely when no rule UID is given.
  */
-export function useInhibitedAlerts(): {
+export function useInhibitedAlerts(ruleUid: string | undefined): {
   inhibitedAlerts: AlertmanagerAlert[];
   isLoading: boolean;
   isFetching: boolean;
@@ -21,12 +23,16 @@ export function useInhibitedAlerts(): {
   const { data, isLoading, isFetching } = alertmanagerApi.useGetAlertmanagerAlertsQuery(
     {
       amSourceName: GRAFANA_RULES_SOURCE_NAME,
-      // `silenced` is deliberately left out: an alert can be both silenced and inhibited, and
-      // passing `silenced: false` would make the API drop it before we see it.
-      filter: { inhibited: true, active: false },
+      filter: {
+        inhibited: true,
+        active: false,
+        // `silenced` is deliberately left out: an alert can be both silenced and inhibited, and
+        // passing `silenced: false` would make the API drop it before we see it.
+        matchers: [{ name: '__alert_rule_uid__', value: ruleUid ?? '', isRegex: false, isEqual: true }],
+      },
       showErrorAlert: false,
     },
-    { skip: false }
+    { skip: !ruleUid }
   );
 
   // The state params above only bound the response, they don't select inhibited alerts (see

--- a/public/app/features/alerting/unified/hooks/useInhibitedAlerts.ts
+++ b/public/app/features/alerting/unified/hooks/useInhibitedAlerts.ts
@@ -29,9 +29,9 @@ export function useInhibitedAlerts(): {
     { skip: false }
   );
 
-  // The state params tell the API which states to drop, they don't select inhibited alerts. Nothing
-  // excludes "unprocessed" alerts (those with no marker entry yet), so they come back too. Only a
-  // non-empty inhibitedBy means inhibited, which makes the params above an optimisation, not a filter.
+  // The state params above only bound the response, they don't select inhibited alerts (see
+  // AlertmanagerAlertsFilter): unprocessed alerts come back too, so a non-empty inhibitedBy is
+  // what actually decides.
   const inhibitedAlerts = useMemo(() => (data ?? []).filter((alert) => alert.status.inhibitedBy.length > 0), [data]);
 
   return {

--- a/public/app/features/alerting/unified/hooks/useInhibitedAlerts.ts
+++ b/public/app/features/alerting/unified/hooks/useInhibitedAlerts.ts
@@ -8,8 +8,8 @@ import { GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
 /**
  * Fetches the full list of currently inhibited alerts from the Grafana Alertmanager.
  *
- * This is intentionally unfiltered so the result is shared via RTK Query's cache
- * across all consumers, avoiding per-rule network requests.
+ * The request is intentionally not scoped to a single rule, so the result is shared via
+ * RTK Query's cache across all consumers, avoiding per-rule network requests.
  *
  * Only runs for the Grafana-managed alertmanager.
  */

--- a/public/app/features/alerting/unified/hooks/useInhibitedAlerts.ts
+++ b/public/app/features/alerting/unified/hooks/useInhibitedAlerts.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { type AlertmanagerAlert } from 'app/plugins/datasource/alertmanager/types';
 
 import { alertmanagerApi } from '../api/alertmanagerApi';
@@ -25,8 +27,13 @@ export function useInhibitedAlerts(): {
     { skip: false }
   );
 
+  // The Alertmanager state filters are exclusions, not a selector: the API drops alerts that are
+  // active or silenced, but "unprocessed" alerts (no marker entry yet) match neither and come back
+  // too. Only alerts with a non-empty inhibitedBy are actually inhibited.
+  const inhibitedAlerts = useMemo(() => (data ?? []).filter((alert) => alert.status.inhibitedBy.length > 0), [data]);
+
   return {
-    inhibitedAlerts: data ?? [],
+    inhibitedAlerts,
     isLoading,
     isFetching,
   };

--- a/public/app/features/alerting/unified/hooks/useInhibitedAlerts.ts
+++ b/public/app/features/alerting/unified/hooks/useInhibitedAlerts.ts
@@ -21,15 +21,17 @@ export function useInhibitedAlerts(): {
   const { data, isLoading, isFetching } = alertmanagerApi.useGetAlertmanagerAlertsQuery(
     {
       amSourceName: GRAFANA_RULES_SOURCE_NAME,
-      filter: { inhibited: true, active: false, silenced: false },
+      // `silenced` is deliberately left out: an alert can be both silenced and inhibited, and
+      // passing `silenced: false` would make the API drop it before we see it.
+      filter: { inhibited: true, active: false },
       showErrorAlert: false,
     },
     { skip: false }
   );
 
-  // The Alertmanager state filters are exclusions, not a selector: the API drops alerts that are
-  // active or silenced, but "unprocessed" alerts (no marker entry yet) match neither and come back
-  // too. Only alerts with a non-empty inhibitedBy are actually inhibited.
+  // The state params tell the API which states to drop, they don't select inhibited alerts. Nothing
+  // excludes "unprocessed" alerts (those with no marker entry yet), so they come back too. Only a
+  // non-empty inhibitedBy means inhibited, which makes the params above an optimisation, not a filter.
   const inhibitedAlerts = useMemo(() => (data ?? []).filter((alert) => alert.status.inhibitedBy.length > 0), [data]);
 
   return {


### PR DESCRIPTION
**What is this feature?**

Fixes the rule detail page rendering an "Inhibited" state for Grafana-managed alert rules that have no inhibited instances, and hardens the query behind it.

- Only alerts with a non-empty `status.inhibitedBy` count as inhibited. Previously every alert the query returned was treated as inhibited, without inspecting its status.
- Stop passing `silenced: false`. An alert can be both silenced and inhibited, and excluding silenced alerts dropped those server-side, where no client check can recover them.
- Scope the request with an `__alert_rule_uid__` matcher, and skip it entirely when there is no rule UID (recording and datasource-managed rules).
- Document the state options on `AlertmanagerAlertsFilter`, including that `unprocessed` is a no-op against the Grafana Alertmanager.

**Why do we need this feature?**

The Alertmanager `/api/v2/alerts` state options are exclusions, not a selector: each one decides whether alerts in that state are *included*, and they all default to true. So `{ inhibited: true, active: false, silenced: false }` does not mean "inhibited alerts" — it means "everything that is neither active nor silenced". Alerts in the `unprocessed` state (no marker entry yet, e.g. before the dispatcher's first group flush, or after an Alertmanager restart) are excluded by none of those options and came back in the response.

Nothing filters `unprocessed` out afterwards: Grafana's handler doesn't accept the `unprocessed` param (`api_alertmanager.go` reads only active/silenced/inhibited) and the remote Alertmanager client forwards only those three. So on stacks using the remote Alertmanager, any rule with an unprocessed instance rendered as "Inhibited", replacing its real state (Firing, Normal, ...).

Observed payload from an affected rule:

```json
{
  "labels": { "__alert_rule_uid__": "...", "alertname": "..." },
  "status": { "state": "unprocessed", "silencedBy": [], "inhibitedBy": [] }
}
```

Not inhibited by anything, yet the badge said otherwise.

**Who is this feature for?**

Anyone viewing Grafana-managed alert rules, particularly on stacks backed by the remote Alertmanager, where the wrong state is most visible.

**Which issue(s) does this PR fix?**:

N/A — reported directly, no tracking issue.

**Special notes for your reviewer:**

Frontend only. The bug can't be reproduced against a local Grafana: the built-in Alertmanager marks alert status on the read path, so it never returns `unprocessed`. To see it by hand, override the `api/v2/alerts` response in DevTools with a `"state": "unprocessed"` alert carrying the rule's UID — on main the title reads "Inhibited", with this PR it reads the rule's real state.

Test coverage added for: unprocessed instances, silenced-only, silenced-and-inhibited, mixed unprocessed/inhibited, the shape of the outgoing request, and no request when there is no rule UID. Each was verified to fail without its corresponding change.

The absence assertions in `RuleViewer.test.tsx` were rewritten — they previously checked `queryByText` immediately after the rule name appeared, which could pass before the Alertmanager response was delivered. They only caught this regression because the fetch won the race.
