### PR TITLE
fix(ssosettings): fall back to config-file providers when DB List fails

### DIFF
--- a/pkg/services/ssosettings/ssosettingsimpl/service.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service.go
@@ -220,13 +220,21 @@ func (s *Service) List(ctx context.Context) ([]*models.SSOSettings, error) {
 	storedSettings, err := s.store.List(ctx)
 
 	if err != nil {
-		return nil, err
+		// If the DB store is unavailable, log the error and continue with
+		// only the fallback (config-file / MT-Settings) sources so that
+		// providers configured via grafana.ini or env vars still appear
+		// on the login page.
+		s.logger.Warn("Failed to list SSO settings from DB, falling back to system settings", "error", err)
+		storedSettings = nil
 	}
 
 	for _, provider := range s.providersList {
 		fallbackSettings, servedByMT, err := s.loadSettingsUsingFallbackStrategy(ctx, provider)
 		if err != nil {
-			return nil, err
+			// If a single provider's fallback strategy fails, log the
+			// error and skip it rather than failing the entire list.
+			s.logger.Warn("Failed to load fallback settings for provider", "provider", provider, "error", err)
+			continue
 		}
 
 		// Mode 4+: MT-Settings is the sole read source, the DB is ignored.


### PR DESCRIPTION
## What

When the `sso_setting` table is empty or the DB store is unavailable, the `List()` method previously returned a hard error, causing the `SocialService` to create an empty `socialMap` at startup. The login page then found no enabled OAuth providers and hid the "Sign in with GitHub" (and other OAuth-provider) buttons — even when the provider was correctly configured in `grafana.ini` or env vars.

## Root Cause

Grafana has two parallel systems for managing OAuth provider configuration:

1. **Legacy file-based config** — `grafana.ini` (or env-var equivalent like `GF_AUTH_GITHUB_*`) populated at startup.
2. **SSO Settings service** — a database-backed registry (`pkg/services/ssosettings/`) that the Authentication page in the UI writes to.

The `SocialService.ProvideService()` calls `ssoSettings.List()` at startup to populate its `socialMap`. If `List()` fails — for example because the DB store returns an error, or a single provider's fallback strategy errors out — the entire `socialMap` stays empty, and the login page never renders the OAuth provider buttons.

## Fix

Two changes to `List()` in `pkg/services/ssosettings/ssosettingsimpl/service.go`:

1. **DB store error → graceful fallback**: If `s.store.List()` fails, log the error and continue with an empty set of DB settings. The fallback (config-file / MT-Settings) sources are still consulted, so providers configured via `grafana.ini` or env vars appear on the login page.
2. **Single provider failure → skip, don't abort**: If a specific provider's fallback strategy fails, log the error and skip that provider rather than failing the entire `List()` call. This prevents one misconfigured provider from hiding all others.

## Testing

- Verified via `gofmt` — no formatting issues
- Existing SSO Settings tests cover the normal-path merge behavior; the fix only changes error-handling paths
- Manual trace: when `s.store.List()` returns an error, the code now logs a warning and continues with `storedSettings = nil`; the fallback strategies are then consulted for each provider

Fixes #119181