### PR TITLE
SQL Expressions: Restore datasource display names

### DIFF
--- a/public/app/features/expressions/ExpressionDatasource.test.ts
+++ b/public/app/features/expressions/ExpressionDatasource.test.ts
@@ -1,6 +1,14 @@
 import { of, lastValueFrom } from 'rxjs';
 
-import { dateTime, type DataQueryRequest, type DataSourceInstanceSettings } from '@grafana/data';
+import {
+  dateTime,
+  type DataFrame,
+  type DataQueryRequest,
+  type DataSourceInstanceSettings,
+  FieldType,
+  getFieldDisplayName,
+  toDataFrame,
+} from '@grafana/data';
 import { DataSourceWithBackend } from '@grafana/runtime';
 import { backendSrv } from 'app/core/services/backend_srv';
 
@@ -122,6 +130,80 @@ describe('ExpressionDatasourceApi', () => {
           targets: [expect.objectContaining({ expression: '$A + $B' })],
         })
       );
+    });
+
+    it('restores a SQL expression display name without changing source query frames', async () => {
+      const ds = new ExpressionDatasourceApi({} as DataSourceInstanceSettings);
+      const query: ExpressionQuery = {
+        type: ExpressionQueryType.sql,
+        refId: 'B',
+        expression: 'SELECT * FROM A',
+        datasource: { uid: '__expr__', type: '__expr__' },
+      };
+      const sourceFrame = toDataFrame({
+        refId: 'A',
+        fields: [
+          { name: '__value__', type: FieldType.number, values: [1] },
+          { name: '__display_name__', type: FieldType.string, values: ['source'] },
+        ],
+      });
+      const sqlFrame = toDataFrame({
+        refId: 'B',
+        fields: [
+          { name: 'time', type: FieldType.time, values: [1, 2] },
+          { name: '__value__', type: FieldType.number, config: { unit: 'short' }, values: [10, 20] },
+          { name: '__display_name__', type: FieldType.string, values: ['x', 'x'] },
+        ],
+      });
+
+      mockGetDatasource.mockResolvedValue({});
+      jest.spyOn(DataSourceWithBackend.prototype, 'query').mockReturnValue(of({ data: [sourceFrame, sqlFrame] }));
+
+      const response = await lastValueFrom(ds.query(buildRequest(query, {})));
+
+      expect(response.data[0]).toBe(sourceFrame);
+      const resultFrame = response.data[1] as DataFrame;
+      expect(resultFrame).not.toBe(sqlFrame);
+      expect(resultFrame.fields[1].config).toEqual({ unit: 'short', displayNameFromDS: 'x' });
+      expect(getFieldDisplayName(resultFrame.fields[1], resultFrame, [resultFrame])).toBe('x');
+      expect(sqlFrame.fields[1].config).toEqual({ unit: 'short' });
+    });
+
+    it('does not restore an ambiguous SQL expression display name', async () => {
+      const ds = new ExpressionDatasourceApi({} as DataSourceInstanceSettings);
+      const query: ExpressionQuery = {
+        type: ExpressionQueryType.sql,
+        refId: 'B',
+        expression: 'SELECT * FROM A',
+        datasource: { uid: '__expr__', type: '__expr__' },
+      };
+      const differentNames = toDataFrame({
+        refId: 'B',
+        fields: [
+          { name: '__value__', type: FieldType.number, values: [1, 2] },
+          { name: '__display_name__', type: FieldType.string, values: ['A', 'B'] },
+        ],
+      });
+      const multipleValues = toDataFrame({
+        refId: 'B',
+        fields: [
+          { name: '__value__', type: FieldType.number, values: [1] },
+          { name: 'other', type: FieldType.number, values: [2] },
+          { name: '__display_name__', type: FieldType.string, values: ['A'] },
+        ],
+      });
+
+      mockGetDatasource.mockResolvedValue({});
+      jest
+        .spyOn(DataSourceWithBackend.prototype, 'query')
+        .mockReturnValue(of({ data: [differentNames, multipleValues] }));
+
+      const response = await lastValueFrom(ds.query(buildRequest(query, {})));
+
+      expect(response.data[0]).toBe(differentNames);
+      expect(response.data[1]).toBe(multipleValues);
+      expect(differentNames.fields[0].config.displayNameFromDS).toBeUndefined();
+      expect(multipleValues.fields[0].config.displayNameFromDS).toBeUndefined();
     });
   });
 });

--- a/public/app/features/expressions/ExpressionDatasource.test.ts
+++ b/public/app/features/expressions/ExpressionDatasource.test.ts
@@ -208,7 +208,36 @@ describe('ExpressionDatasourceApi', () => {
       expect(frame.fields[0].config.displayNameFromDS).toBeUndefined();
     });
 
-    it('does not restore an ambiguous SQL expression display name', async () => {
+    it('restores the reserved value field when other numeric fields are present', async () => {
+      const ds = new ExpressionDatasourceApi({} as DataSourceInstanceSettings);
+      const query: ExpressionQuery = {
+        type: ExpressionQueryType.sql,
+        refId: 'B',
+        expression: 'SELECT * FROM A',
+        datasource: { uid: '__expr__', type: '__expr__' },
+      };
+      const frame = toDataFrame({
+        refId: 'B',
+        fields: [
+          { name: '__value__', type: FieldType.number, values: [1] },
+          { name: 'other', type: FieldType.number, values: [2] },
+          { name: '__display_name__', type: FieldType.string, values: ['A'] },
+        ],
+      });
+
+      mockGetDatasource.mockResolvedValue({});
+      jest.spyOn(DataSourceWithBackend.prototype, 'query').mockReturnValue(of({ data: [frame] }));
+
+      const response = await lastValueFrom(ds.query(buildRequest(query, {})));
+
+      const resultFrame = response.data[0] as DataFrame;
+      expect(resultFrame).not.toBe(frame);
+      expect(resultFrame.fields[0].config.displayNameFromDS).toBe('A');
+      expect(resultFrame.fields[1].config.displayNameFromDS).toBeUndefined();
+      expect(frame.fields[0].config.displayNameFromDS).toBeUndefined();
+    });
+
+    it('does not restore an ambiguous SQL expression display name or a frame without a value field', async () => {
       const ds = new ExpressionDatasourceApi({} as DataSourceInstanceSettings);
       const query: ExpressionQuery = {
         type: ExpressionQueryType.sql,
@@ -223,11 +252,10 @@ describe('ExpressionDatasourceApi', () => {
           { name: '__display_name__', type: FieldType.string, values: ['A', 'B'] },
         ],
       });
-      const multipleValues = toDataFrame({
+      const missingValue = toDataFrame({
         refId: 'B',
         fields: [
-          { name: '__value__', type: FieldType.number, values: [1] },
-          { name: 'other', type: FieldType.number, values: [2] },
+          { name: 'n', type: FieldType.number, values: [1] },
           { name: '__display_name__', type: FieldType.string, values: ['A'] },
         ],
       });
@@ -235,14 +263,14 @@ describe('ExpressionDatasourceApi', () => {
       mockGetDatasource.mockResolvedValue({});
       jest
         .spyOn(DataSourceWithBackend.prototype, 'query')
-        .mockReturnValue(of({ data: [differentNames, multipleValues] }));
+        .mockReturnValue(of({ data: [differentNames, missingValue] }));
 
       const response = await lastValueFrom(ds.query(buildRequest(query, {})));
 
       expect(response.data[0]).toBe(differentNames);
-      expect(response.data[1]).toBe(multipleValues);
+      expect(response.data[1]).toBe(missingValue);
       expect(differentNames.fields[0].config.displayNameFromDS).toBeUndefined();
-      expect(multipleValues.fields[0].config.displayNameFromDS).toBeUndefined();
+      expect(missingValue.fields[0].config.displayNameFromDS).toBeUndefined();
     });
   });
 });

--- a/public/app/features/expressions/ExpressionDatasource.test.ts
+++ b/public/app/features/expressions/ExpressionDatasource.test.ts
@@ -3,6 +3,7 @@ import { of, lastValueFrom } from 'rxjs';
 import {
   dateTime,
   type DataFrame,
+  type DataFrameType,
   type DataQueryRequest,
   type DataSourceInstanceSettings,
   FieldType,
@@ -57,7 +58,7 @@ describe('ExpressionDatasourceApi', () => {
 
   describe('query datasource scoping', () => {
     const buildRequest = (
-      query: ExpressionQuery,
+      query: ExpressionQuery | ExpressionQuery[],
       scopedVars: Record<string, { value: string; text: string }>
     ): DataQueryRequest<ExpressionQuery> =>
       ({
@@ -69,7 +70,7 @@ describe('ExpressionDatasourceApi', () => {
           to: dateTime('2026-01-01T01:00:00Z'),
           raw: { from: 'now-1h', to: 'now' },
         },
-        targets: [query],
+        targets: Array.isArray(query) ? query : [query],
         scopedVars,
         filters: [],
         interval: '1m',
@@ -132,9 +133,13 @@ describe('ExpressionDatasourceApi', () => {
       );
     });
 
-    it('restores a SQL expression display name without changing source query frames', async () => {
+    it('restores display names for a SQL expression and its converted source frame', async () => {
       const ds = new ExpressionDatasourceApi({} as DataSourceInstanceSettings);
-      const query: ExpressionQuery = {
+      const sourceQuery = {
+        refId: 'A',
+        datasource: { uid: 'prometheus', type: 'prometheus' },
+      } as ExpressionQuery;
+      const sqlQuery: ExpressionQuery = {
         type: ExpressionQueryType.sql,
         refId: 'B',
         expression: 'SELECT * FROM A',
@@ -142,6 +147,7 @@ describe('ExpressionDatasourceApi', () => {
       };
       const sourceFrame = toDataFrame({
         refId: 'A',
+        meta: { type: 'timeseries-full-long' as DataFrameType },
         fields: [
           { name: '__value__', type: FieldType.number, values: [1] },
           { name: '__display_name__', type: FieldType.string, values: ['source'] },
@@ -155,18 +161,51 @@ describe('ExpressionDatasourceApi', () => {
           { name: '__display_name__', type: FieldType.string, values: ['x', 'x'] },
         ],
       });
+      const staleState = { displayName: 'stale' };
+      sqlFrame.fields[1].state = staleState;
 
       mockGetDatasource.mockResolvedValue({});
       jest.spyOn(DataSourceWithBackend.prototype, 'query').mockReturnValue(of({ data: [sourceFrame, sqlFrame] }));
 
-      const response = await lastValueFrom(ds.query(buildRequest(query, {})));
+      const response = await lastValueFrom(ds.query(buildRequest([sourceQuery, sqlQuery], {})));
 
-      expect(response.data[0]).toBe(sourceFrame);
+      const sourceResultFrame = response.data[0] as DataFrame;
+      expect(sourceResultFrame).not.toBe(sourceFrame);
+      expect(sourceResultFrame.fields[0].config.displayNameFromDS).toBe('source');
+      expect(getFieldDisplayName(sourceResultFrame.fields[0], sourceResultFrame, [sourceResultFrame])).toBe('source');
+      expect(sourceFrame.fields[0].config.displayNameFromDS).toBeUndefined();
       const resultFrame = response.data[1] as DataFrame;
       expect(resultFrame).not.toBe(sqlFrame);
       expect(resultFrame.fields[1].config).toEqual({ unit: 'short', displayNameFromDS: 'x' });
+      expect(resultFrame.fields[1].state).toBeNull();
       expect(getFieldDisplayName(resultFrame.fields[1], resultFrame, [resultFrame])).toBe('x');
       expect(sqlFrame.fields[1].config).toEqual({ unit: 'short' });
+      expect(sqlFrame.fields[1].state).toBe(staleState);
+    });
+
+    it('does not treat a datasource SQL query as a SQL expression', async () => {
+      const ds = new ExpressionDatasourceApi({} as DataSourceInstanceSettings);
+      const query = {
+        type: ExpressionQueryType.sql,
+        refId: 'A',
+        datasource: { uid: 'mysql', type: 'mysql' },
+      } as ExpressionQuery;
+      const frame = toDataFrame({
+        refId: 'A',
+        meta: { type: 'timeseries-full-long' as DataFrameType },
+        fields: [
+          { name: '__value__', type: FieldType.number, values: [30] },
+          { name: '__display_name__', type: FieldType.string, values: ['third-party'] },
+        ],
+      });
+
+      mockGetDatasource.mockResolvedValue({});
+      jest.spyOn(DataSourceWithBackend.prototype, 'query').mockReturnValue(of({ data: [frame] }));
+
+      const response = await lastValueFrom(ds.query(buildRequest(query, {})));
+
+      expect(response.data[0]).toBe(frame);
+      expect(frame.fields[0].config.displayNameFromDS).toBeUndefined();
     });
 
     it('does not restore an ambiguous SQL expression display name', async () => {

--- a/public/app/features/expressions/ExpressionDatasource.ts
+++ b/public/app/features/expressions/ExpressionDatasource.ts
@@ -19,6 +19,7 @@ import {
   type FetchResponse,
   getBackendSrv,
   getTemplateSrv,
+  isExpressionReference,
   toDataQueryResponse,
 } from '@grafana/runtime';
 import { ExpressionDatasourceRef } from '@grafana/runtime/internal';
@@ -30,6 +31,8 @@ import { ExpressionQueryEditor } from './ExpressionQueryEditor';
 import { ExpressionDatasourceUID, type ExpressionQuery, ExpressionQueryType } from './types';
 
 const SQL_DISPLAY_NAME_FIELD = '__display_name__';
+// Source frames consumed by SQL expressions are returned with these internal full-long conversion types.
+const SQL_FULL_LONG_FRAME_TYPES = new Set(['numeric-full-long', 'timeseries-full-long']);
 
 function restoreSQLDisplayName(frame: DataFrame): DataFrame {
   const displayFields = frame.fields.filter((field) => field.name === SQL_DISPLAY_NAME_FIELD);
@@ -60,16 +63,24 @@ function restoreSQLDisplayName(frame: DataFrame): DataFrame {
 
 function restoreSQLDisplayNames(response: DataQueryResponse, queries: ExpressionQuery[]): DataQueryResponse {
   const sqlRefIds = new Set(
-    queries.filter((query) => query.type === ExpressionQueryType.sql).map((query) => query.refId)
+    queries
+      .filter((query) => isExpressionReference(query.datasource) && query.type === ExpressionQueryType.sql)
+      .map((query) => query.refId)
   );
   if (sqlRefIds.size === 0) {
     return response;
   }
 
+  const queryRefIds = new Set(queries.map((query) => query.refId));
   return {
     ...response,
     data: response.data.map((frame) =>
-      isDataFrame(frame) && frame.refId && sqlRefIds.has(frame.refId) ? restoreSQLDisplayName(frame) : frame
+      isDataFrame(frame) &&
+      frame.refId &&
+      (sqlRefIds.has(frame.refId) ||
+        (queryRefIds.has(frame.refId) && SQL_FULL_LONG_FRAME_TYPES.has(frame.meta?.type ?? '')))
+        ? restoreSQLDisplayName(frame)
+        : frame
     ),
   };
 }

--- a/public/app/features/expressions/ExpressionDatasource.ts
+++ b/public/app/features/expressions/ExpressionDatasource.ts
@@ -31,16 +31,19 @@ import { ExpressionQueryEditor } from './ExpressionQueryEditor';
 import { ExpressionDatasourceUID, type ExpressionQuery, ExpressionQueryType } from './types';
 
 const SQL_DISPLAY_NAME_FIELD = '__display_name__';
+const SQL_VALUE_FIELD = '__value__';
 // Source frames consumed by SQL expressions are returned with these internal full-long conversion types.
 const SQL_FULL_LONG_FRAME_TYPES = new Set(['numeric-full-long', 'timeseries-full-long']);
 
 function restoreSQLDisplayName(frame: DataFrame): DataFrame {
   const displayFields = frame.fields.filter((field) => field.name === SQL_DISPLAY_NAME_FIELD);
-  const valueFields = frame.fields.filter((field) => field.type === FieldType.number);
+  const valueFields = frame.fields.filter((field) => field.name === SQL_VALUE_FIELD && field.type === FieldType.number);
   if (displayFields.length !== 1 || valueFields.length !== 1) {
     return frame;
   }
 
+  // A field-level display name can only describe one series. Multi-series full-long frames interleave
+  // names per row and need to be partitioned into separate series before their aliases can be restored.
   const displayName = displayFields[0].values[0];
   if (
     typeof displayName !== 'string' ||

--- a/public/app/features/expressions/ExpressionDatasource.ts
+++ b/public/app/features/expressions/ExpressionDatasource.ts
@@ -6,6 +6,8 @@ import {
   type DataQueryResponse,
   type DataSourceInstanceSettings,
   type DataSourcePluginMeta,
+  FieldType,
+  isDataFrame,
   PluginType,
   type ScopedVars,
   type TimeRange,
@@ -26,6 +28,51 @@ import icnDatasourceSvg from 'img/icn-datasource.svg';
 
 import { ExpressionQueryEditor } from './ExpressionQueryEditor';
 import { ExpressionDatasourceUID, type ExpressionQuery, ExpressionQueryType } from './types';
+
+const SQL_DISPLAY_NAME_FIELD = '__display_name__';
+
+function restoreSQLDisplayName(frame: DataFrame): DataFrame {
+  const displayFields = frame.fields.filter((field) => field.name === SQL_DISPLAY_NAME_FIELD);
+  const valueFields = frame.fields.filter((field) => field.type === FieldType.number);
+  if (displayFields.length !== 1 || valueFields.length !== 1) {
+    return frame;
+  }
+
+  const displayName = displayFields[0].values[0];
+  if (
+    typeof displayName !== 'string' ||
+    displayName.length === 0 ||
+    !displayFields[0].values.every((value) => value === displayName)
+  ) {
+    return frame;
+  }
+
+  const valueField = valueFields[0];
+  return {
+    ...frame,
+    fields: frame.fields.map((field) =>
+      field === valueField
+        ? { ...field, config: { ...field.config, displayNameFromDS: displayName }, state: null }
+        : field
+    ),
+  };
+}
+
+function restoreSQLDisplayNames(response: DataQueryResponse, queries: ExpressionQuery[]): DataQueryResponse {
+  const sqlRefIds = new Set(
+    queries.filter((query) => query.type === ExpressionQueryType.sql).map((query) => query.refId)
+  );
+  if (sqlRefIds.size === 0) {
+    return response;
+  }
+
+  return {
+    ...response,
+    data: response.data.map((frame) =>
+      isDataFrame(frame) && frame.refId && sqlRefIds.has(frame.refId) ? restoreSQLDisplayName(frame) : frame
+    ),
+  };
+}
 
 /**
  * This is a singleton instance that just pretends to be a DataSource
@@ -60,7 +107,11 @@ export class ExpressionDatasourceApi extends DataSourceWithBackend<ExpressionQue
     });
 
     let sub = from(Promise.all(targets));
-    return sub.pipe(mergeMap((t) => super.query({ ...request, targets: t })));
+    return sub.pipe(
+      mergeMap((queries) =>
+        super.query({ ...request, targets: queries }).pipe(map((response) => restoreSQLDisplayNames(response, queries)))
+      )
+    );
   }
 
   newQuery(query?: Partial<ExpressionQuery>): ExpressionQuery {


### PR DESCRIPTION
## Related Issue
Fixes DPRO-84

## Description
Restore SQL expression display names for eligible result frames so datasource aliases appear in panels.

## Changes
* Restore a consistent `__display_name__` alias onto the reserved `__value__` field for SQL expression results and converted source frames.
* Restrict normalization to SQL expressions and preserve original frames through immutable copies.
* Add unit coverage for source frames, cached display names, unrelated datasource SQL queries, extra numeric columns, and ambiguous aliases.

## Risks
Alias restoration is limited to single-series frames with one consistent display name. Multi-series full-long frames contain distinct names per row and require partitioning into separate series, which is outside this change.

## Demo
Not applicable.

## Testing Instructions
* Run `yarn jest --no-watch public/app/features/expressions/ExpressionDatasource.test.ts`.

## Reviewer Checklist
- [x] Tests are added where applicable
- [x] Issue is linked to PR
- [ ] Code pulled and tested
- [x] Code is meaningfully improved if applicable
