### PR TITLE
E2E: Skip flaky gauge tests

### DIFF
--- a/e2e-playwright/panels-suite/gauge.spec.ts
+++ b/e2e-playwright/panels-suite/gauge.spec.ts
@@ -18,7 +18,7 @@ test.describe(
     tag: ['@panels', '@gauge'],
   },
   () => {
-    test('a11y', { tag: ['@a11y'] }, async ({ scanForA11yViolations, selectors, gotoDashboardPage }) => {
+    test.skip('a11y', { tag: ['@a11y'] }, async ({ scanForA11yViolations, selectors, gotoDashboardPage }) => {
       const dashboardPage = await gotoDashboardPage({ uid: NEW_GAUGES_DASHBOARD_UID });
       await expect(
         dashboardPage.getByGrafanaSelector(selectors.components.Panels.Visualization.Gauge.Container)
@@ -42,7 +42,8 @@ test.describe(
       await expect(errorInfo).toBeHidden();
     });
 
-    test('renders new gauge panels', async ({ gotoDashboardPage, selectors }) => {
+    // heavy flake aug 3 - aug 6
+    test.skip('renders new gauge panels', async ({ gotoDashboardPage, selectors }) => {
       // open Panel Tests - Gauge
       const dashboardPage = await gotoDashboardPage({ uid: NEW_GAUGES_DASHBOARD_UID });
 


### PR DESCRIPTION
Skip flaky gauge tests: https://github.com/grafana/grafana/actions/runs/31029507818/job/92388398433

Verified that both tests flake (heavily) locally as well. Skipping to unblock main while we follow-up with fix. 

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
