### PR TITLE
fix: accept string datasource ref in DashboardV2DataQueryKindDatasource UnmarshalJSON

### DIFF
--- a/apps/dashboard/pkg/apis/dashboard/v2/dashboard_spec_gen.go
+++ b/apps/dashboard/pkg/apis/dashboard/v2/dashboard_spec_gen.go
@@ -2615,6 +2615,42 @@ func (DashboardV2DataQueryKindDatasource) OpenAPIModelName() string {
 	return "com.github.grafana.grafana.apps.dashboard.pkg.apis.dashboard.v2.DashboardV2DataQueryKindDatasource"
 }
 
+// UnmarshalJSON implements a custom JSON unmarshalling logic to decode `DashboardV2DataQueryKindDatasource` from JSON.
+// It accepts both a string (datasource name) and an object with a "name" field.
+// This is needed because some exported dashboards have the datasource reference as a plain string,
+// while the generated schema expects {"name": "..."}.
+func (resource *DashboardV2DataQueryKindDatasource) UnmarshalJSON(raw []byte) error {
+	if raw == nil {
+		return nil
+	}
+
+	var errList []error
+
+	// Try object form: {"name": "datasource-uid"}
+	var obj struct {
+		Name *string `json:"name,omitempty"`
+	}
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		errList = append(errList, err)
+	} else {
+		if obj.Name != nil {
+			resource.Name = obj.Name
+		}
+		return nil
+	}
+
+	// Try string form: "datasource-uid"
+	var str string
+	if err := json.Unmarshal(raw, &str); err != nil {
+		errList = append(errList, err)
+	} else {
+		resource.Name = &str
+		return nil
+	}
+
+	return errors.Join(errList...)
+}
+
 // +k8s:openapi-gen=true
 type DashboardV2FieldConfigSourceOverrides struct {
 	// Describes config override rules created when interacting with Grafana.


### PR DESCRIPTION
## What

The `DashboardV2DataQueryKindDatasource` type only supports the object form `{"name": "..."}` for the datasource field in queries. When provisioning a dashboard where the datasource reference is a plain string (e.g. `"datasource": "ElasticSearch_index-reference"`), the JSON unmarshaler fails with:

> json: cannot unmarshal string into Go struct field DashboardSpec.spec.elements.spec.data.spec.queries.spec.query.datasource of type v2.DashboardV2DataQueryKindDatasource

## Fix

Add a custom `UnmarshalJSON` to `DashboardV2DataQueryKindDatasource` that accepts both forms:

1. **String** (e.g. `"MetricsCentral_fs-tickets"`) → sets `Name` to the string value
2. **Object** (e.g. `{"name": "MetricsCentral_fs-tickets"}`) → sets `Name` from the field

This follows the same pattern used by existing custom unmarshalers in the file (e.g. `DashboardStringOrFloat64`, `DashboardStringOrArrayOfString`).

## Verification

- `gofmt -e` passes (syntax valid)
- Unit tests pass for all input forms: string, object, null, empty, and invalid inputs
- Full integration test verifies the datasource is correctly parsed in the `DashboardPanelQuerySpec` → `DashboardDataQueryKind` chain

## Related issue

Closes #128167