### PR TITLE
Alerting: unset datasource when constructing AdHocFiltersVariable

### DIFF
--- a/public/app/features/alerting/unified/triage/scene/TriageScene.test.tsx
+++ b/public/app/features/alerting/unified/triage/scene/TriageScene.test.tsx
@@ -1,0 +1,99 @@
+import { of } from 'rxjs';
+
+import { type DataSourceApi, type DataSourceRef, LoadingState } from '@grafana/data';
+import { config, type getDataSourceSrv, setDataSourceSrv, setRunRequest } from '@grafana/runtime';
+import {
+  type AdHocFiltersVariable,
+  EmbeddedScene,
+  SceneFlexItem,
+  SceneFlexLayout,
+  SceneQueryRunner,
+  SceneTimeRange,
+  SceneVariableSet,
+} from '@grafana/scenes';
+
+const DATASOURCE_UID = 'triage-prom-uid';
+
+// ../constants reads the UID from config at module load, so this has to happen before the dynamic
+// import of TriageScene below.
+config.unifiedAlerting = {
+  ...config.unifiedAlerting,
+  stateHistory: { ...config.unifiedAlerting?.stateHistory, prometheusTargetDatasourceUID: DATASOURCE_UID },
+};
+
+const runRequest = jest.fn().mockReturnValue(of({ state: LoadingState.Done, series: [], timeRange: {} }));
+const getDataSource = jest.fn(async (_ref?: DataSourceRef | string | null) => {
+  const datasource: Partial<DataSourceApi> = {
+    uid: DATASOURCE_UID,
+    getRef: () => ({ uid: DATASOURCE_UID }),
+    interval: '1m',
+  };
+  return datasource as DataSourceApi;
+});
+
+setRunRequest(runRequest);
+setDataSourceSrv({
+  get: getDataSource,
+  getInstanceSettings: () => ({ uid: DATASOURCE_UID }),
+} as unknown as ReturnType<typeof getDataSourceSrv>);
+
+/**
+ * Runs a query against DATASOURCE_UID inside a scene carrying the given filters variable, and returns
+ * the ad-hoc filters that ended up on the outgoing request.
+ */
+async function getRequestFiltersFor(variable: AdHocFiltersVariable) {
+  const queryRunner = new SceneQueryRunner({
+    datasource: { uid: DATASOURCE_UID },
+    queries: [{ refId: 'query', expr: 'asserts:error:ratio{asserts_env="production"}' }],
+  });
+
+  const scene = new EmbeddedScene({
+    $timeRange: new SceneTimeRange({ from: 'now-1h', to: 'now' }),
+    $variables: new SceneVariableSet({ variables: [variable] }),
+    body: new SceneFlexLayout({ children: [new SceneFlexItem({ body: queryRunner })] }),
+  });
+
+  scene.activate();
+  queryRunner.activate();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  return runRequest.mock.calls.at(-1)?.[1]?.filters;
+}
+
+async function getTriageFiltersVariable() {
+  const { triageScene } = await import('./TriageScene');
+  // Clone so activating the test scene does not disturb the real (module-level) triage scene.
+  const variable = triageScene.state.$variables?.getByName('filters')?.clone();
+  return variable as AdHocFiltersVariable;
+}
+
+describe('triage filters variable', () => {
+  beforeEach(() => {
+    runRequest.mockClear();
+    getDataSource.mockClear();
+  });
+
+  it('does not leak its filters into other queries in the scene', async () => {
+    // Regression test: the triage page builds its own PromQL label matchers, but scenes merges every
+    // ad-hoc filters variable it finds in a query runner's ancestry into DataQueryRequest.filters when
+    // the datasource UIDs match, without honouring applyMode: 'manual'. Prometheus then appends those
+    // matchers to the expression. That made the instance details drawer render "No data" for healthy
+    // firing instances, since filters like alertname are not labels on the rule's own query.
+    const variable = await getTriageFiltersVariable();
+    variable.setState({ filters: [{ key: 'alertname', operator: '=', value: 'AuthErrorRatioBreach' }] });
+
+    await expect(getRequestFiltersFor(variable)).resolves.toBeUndefined();
+  });
+
+  it('never resolves a datasource from its own (unset) ref', async () => {
+    // The variable has no datasource ref, so anything resolving one from it would silently fall back to
+    // the default datasource. The tag key/value providers pass the triage UID themselves instead.
+    const variable = await getTriageFiltersVariable();
+    await getRequestFiltersFor(variable);
+
+    const resolvedRefs = getDataSource.mock.calls.map(([ref]) => ref);
+    expect(resolvedRefs.length).toBeGreaterThan(0);
+    expect(resolvedRefs).not.toContain(null);
+    expect(resolvedRefs).not.toContain(undefined);
+  });
+});

--- a/public/app/features/alerting/unified/triage/scene/TriageScene.test.tsx
+++ b/public/app/features/alerting/unified/triage/scene/TriageScene.test.tsx
@@ -1,7 +1,7 @@
 import { of } from 'rxjs';
 
 import { type DataSourceApi, type DataSourceRef, LoadingState } from '@grafana/data';
-import { config, type getDataSourceSrv, setDataSourceSrv, setRunRequest } from '@grafana/runtime';
+import { type DataSourceSrv, config, setDataSourceSrv, setRunRequest } from '@grafana/runtime';
 import {
   type AdHocFiltersVariable,
   EmbeddedScene,
@@ -35,7 +35,7 @@ setRunRequest(runRequest);
 setDataSourceSrv({
   get: getDataSource,
   getInstanceSettings: () => ({ uid: DATASOURCE_UID }),
-} as unknown as ReturnType<typeof getDataSourceSrv>);
+} as unknown as DataSourceSrv);
 
 /**
  * Runs a query against DATASOURCE_UID inside a scene carrying the given filters variable, and returns

--- a/public/app/features/alerting/unified/triage/scene/TriageScene.tsx
+++ b/public/app/features/alerting/unified/triage/scene/TriageScene.tsx
@@ -14,8 +14,6 @@ import {
 import { EmbeddedSceneWithContext } from '@grafana/scenes-react';
 import { useTheme2 } from '@grafana/ui';
 
-import { DATASOURCE_UID } from '../constants';
-
 import { TriageSavedSearchesControl } from './TriageSavedSearchesControl';
 import { WorkbenchSceneObject } from './Workbench';
 import { prometheusExpressionBuilder } from './expressionBuilder';
@@ -47,10 +45,12 @@ export const triageScene = new EmbeddedSceneWithContext({
       new AdHocFiltersVariable({
         name: 'filters',
         label: 'Filters',
-        datasource: {
-          type: 'prometheus',
-          uid: DATASOURCE_UID,
-        },
+        // Deliberately unset. Scenes merges every ad-hoc filters variable it finds in a query runner's
+        // ancestry into `DataQueryRequest.filters` whenever the datasource UIDs match, ignoring applyMode,
+        // and Prometheus then appends those matchers to the query expression. That leaked these filters
+        // into the alert rule queries rendered by the instance details drawer, and double-applied them to
+        // the queries below. Nothing needs the ref: the tag providers resolve the datasource themselves.
+        datasource: null,
         applyMode: 'manual', // we will construct the label matchers for the PromQL queries ourselves
         allowCustomValue: true,
         useQueriesAsFilterForOptions: true,


### PR DESCRIPTION


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This fixes an issue where filters from the activity page were getting merged into the query despite us setting applyMode to manual

**Why do we need this feature?**

Without this the instance details page on the alert activity page can return no data for the query if the user has filters set on the activity page.

**Who is this feature for?**

Users of the Alert Activity page

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
