### PR TITLE
fix(xorm): strip monotonic clock reading in formatColTime to prevent time parse failure with non-UTC TZ

### DIFF
--- a/pkg/util/xorm/engine.go
+++ b/pkg/util/xorm/engine.go
@@ -724,6 +724,17 @@ func (engine *Engine) formatColTime(col *core.Column, t time.Time) (v any) {
 		return ""
 	}
 
+	// Strip the monotonic clock reading before formatting.
+	// time.Now() includes a monotonic clock reading (e.g. m=+6.696806080).
+	// When serialized to a database column (especially text-based storage like
+	// SQLite), this produces strings like:
+	//   "2026-08-05 12:14:36.34069982 +0330 +0330 m=+6.696806080"
+	// which the str2Time parser cannot parse back because the format
+	// "2006-01-02 15:04:05.9999999 Z07:00" only matches the first offset.
+	// Truncate(0) strips the monotonic clock without changing the time value.
+	// See https://github.com/grafana/grafana/issues/130124
+	t = t.Truncate(0)
+
 	if col.TimeZone != nil {
 		return engine.formatTime(col.SQLType.Name, t.In(col.TimeZone))
 	}


### PR DESCRIPTION
Fixes #130124

## Problem

When a Grafana container has its timezone set to a non-UTC offset (e.g., `TZ=Asia/Tehran`, offset +0330), the internal KV store fails to parse timestamps, causing the error:

```
kv get: unsupported time format 2026-08-05 12:14:36.34069982 +0330 +0330 m=+6.696806080: parsing time "2026-08-05 12:14:36.34069982 +0330 +0330 m=+6.696806080" as "2006-01-02 15:04:05.9999999 Z07:00": cannot parse "+0330 +0330 m=+6.696806080" as "Z07:00"
```

## Root Cause

`time.Now()` includes a monotonic clock reading (e.g., `m=+6.696806080`). When the `time.Time` value is serialized to a database column via xorm's `formatColTime`, the resulting string contains this monotonic suffix. With a non-UTC timezone offset, the serialized format becomes:

```
2026-08-05 12:14:36.34069982 +0330 +0330 m=+6.696806080
```

The `str2Time` parser's format `2006-01-02 15:04:05.9999999 Z07:00` matches the first `+0330` offset but cannot parse the remaining `+0330 m=+6.696806080`.

## Fix

Strip the monotonic clock reading with `t.Truncate(0)` before formatting the time value. Per Go docs, `Truncate(0)` returns the time unchanged but strips the monotonic clock reading — it is a no-op on the actual time value. This is done at the common entry point `formatColTime` so all column types benefit.

## Verification

- Without the fix: set `TZ=Asia/Tehran`, restart Grafana → `unsupported time format` error
- With the fix: the monotonic clock is stripped before serialization, producing a clean format that `str2Time` can parse
- No behavioral change when container timezone is UTC (the monotonic suffix is still present but matches the format differently)