### PR TITLE
Chore: add CI check for breaking protobuf changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1367,6 +1367,7 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/release-verify-packages.yml @grafana/grafana-operator-experience-squad
 /.github/workflows/cleanup-branches.yml @grafana/grafana-backend-services-squad
 /.github/workflows/publish-artifact.yml @grafana/grafana-backend-services-squad
+/.github/workflows/proto-breaking-changes.yml @grafana/grafana-backend-services-squad
 /.github/actions/changelog @zserge
 /.github/workflows/check-frontend-test-coverage.yml @grafana/dataviz-squad
 /.github/workflows/report-frontend-coverage-to-bench.yaml @grafana/dataviz-squad

--- a/.github/workflows/proto-breaking-changes.yml
+++ b/.github/workflows/proto-breaking-changes.yml
@@ -1,0 +1,63 @@
+# Fails a PR that breaks backwards compatibility of a protobuf module.
+name: Protobuf breaking changes
+
+on:
+  pull_request:
+    paths:
+      - 'pkg/registry/apps/annotation/proto/**'
+      - '.github/workflows/proto-breaking-changes.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  breaking:
+    name: ${{ matrix.module }}
+    runs-on: ubuntu-arm64-small
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        module:
+          # To enforce compatibility for another buf module, add its path here
+          # and to the `paths:` filter above. The breaking-change policy itself
+          # lives in each module's buf.yaml under `breaking.use`.
+          - pkg/registry/apps/annotation/proto
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+          fetch-depth: 0 # buf compares against history, so the full log is required
+          filter: blob:none
+
+      - name: Export merge base tree
+        id: base
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          MODULE: ${{ matrix.module }}
+        run: |
+          git fetch --no-tags --filter=blob:none origin "$BASE_REF"
+          base_sha="$(git merge-base HEAD FETCH_HEAD)"
+          dir="$RUNNER_TEMP/buf-base"
+          mkdir -p "$dir"
+          # The checkout above is a partial clone, so it can't act as a git remote for
+          # buf to read the base ref's tree from directly. Exporting just the module's
+          # tree to a plain directory sidesteps that and only fetches the blobs it needs.
+          git archive "$base_sha" -- "$MODULE" | tar -x -C "$dir"
+          echo "dir=$dir" >> "$GITHUB_OUTPUT"
+
+      - uses: bufbuild/buf-action@8c6a16e16f12ba20b6470afa9c2ba9b5ba8c97c3 # v1.5.0
+        with:
+          version: 1.65.0
+          input: ${{ matrix.module }}
+          breaking: true # The action bundles several other buf commands, but we only need breaking for this workflow.
+          breaking_against: ${{ steps.base.outputs.dir }}/${{ matrix.module }}
+          lint: false
+          format: false
+          push: false
+          archive: false
+          pr_comment: false

--- a/.policy.yml
+++ b/.policy.yml
@@ -40,6 +40,7 @@ policy:
             - Workflow .github/workflows/pr-test-integration-pgvector.yml succeeded or skipped
             - Workflow .github/workflows/pr-test-integration.yml succeeded or skipped
             - Workflow .github/workflows/pr-unified-storage-compatibility.yml succeeded or skipped
+            - Workflow .github/workflows/proto-breaking-changes.yml succeeded or skipped
             - Workflow .github/workflows/reject-gh-secrets.yml succeeded or skipped
             - Workflow .github/workflows/run-schema-v2-e2e.yml succeeded or skipped
             - Workflow .github/workflows/shellcheck.yml succeeded or skipped
@@ -653,6 +654,23 @@ approval_rules:
             - success
           workflows:
             - .github/workflows/pr-unified-storage-compatibility.yml
+  - name: Workflow .github/workflows/proto-breaking-changes.yml succeeded or skipped
+    if:
+      changed_files:
+        paths:
+          - ^pkg\/registry\/apps\/annotation\/proto\/(?:(?:[^/]*(?:/|$))*)$
+          - ^\.github\/workflows\/proto-breaking-changes\.yml$
+      file_not_deleted:
+        paths:
+          - ^\.github\/workflows\/proto-breaking-changes\.yml$
+    requires:
+      conditions:
+        has_workflow_result:
+          conclusions:
+            - skipped
+            - success
+          workflows:
+            - .github/workflows/proto-breaking-changes.yml
   - name: Workflow .github/workflows/reject-gh-secrets.yml succeeded or skipped
     if:
       file_not_deleted:

--- a/Makefile
+++ b/Makefile
@@ -787,6 +787,11 @@ protobuf: ## Compile protobuf definitions
 	buf generate pkg/services/ngalert/store/proto/v1 --template pkg/services/ngalert/store/proto/v1/buf.gen.yaml
 	buf generate pkg/registry/apps/annotation/proto --template pkg/registry/apps/annotation/proto/buf.gen.yaml
 
+.PHONY: protobuf-breaking
+protobuf-breaking: ## Check protobuf definitions for breaking changes against main
+	bash scripts/protobuf-check.sh
+	buf breaking pkg/registry/apps/annotation/proto --against '.git#branch=main,subdir=pkg/registry/apps/annotation/proto'
+
 .PHONY: clean
 clean: ## Clean up intermediate build artifacts.
 	@echo "cleaning"


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR adds a `protobuf-breaking` Makefile utility to check that protobuf schema changes are backwards compatible. It leverages the `buf` CLI's [`breaking` command](https://buf.build/docs/reference/cli/buf/breaking/). Our dev environment [already uses the `buf` CLI for protobuf generation](https://github.com/grafana/grafana/blob/70867d75381f39d855e6bf9ce7fc163bc88b90c3/Makefile#L779-L788), so this feels like the natural fit for checking for breaking changes too.

This PR also adds a check to CI that will fail if a PR makes breaking changes to the specified protobuf schemas (right now just the annotation store schema is configured). The goal being to ensure backwards compatibility of both the protobuf wire format and generated Go code. It leverages https://github.com/bufbuild/buf-action to run the `buf` CLI. 

This initial iteration will just check for breaking changes against `main`, but will likely follow this up to ensure compatibility against released versions (e.g. N-1/2 versions or something along those lines).

**Why do we need this feature?**

Helps to ensure backwards compatibility of both the protobuf wire format and generated Go code to ensure we maintain our side of the contract.

**Who is this feature for?**



**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Part of https://github.com/grafana/grafana-org/issues/965

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
