### PR TITLE
Notebooks: add RBAC mapper entry so notebooks are authorized when Unified Storage enforcement is enabled

### DIFF
--- a/pkg/services/authz/rbac/mapper.go
+++ b/pkg/services/authz/rbac/mapper.go
@@ -174,6 +174,28 @@ func newDashboardTranslation() translation {
 	return dashTranslation
 }
 
+// newNotebookTranslation authorizes notebooks during the private preview by reusing dashboard
+// RBAC, but only on the action axis: notebooks map to dashboard ACTIONS (dashboards:read/write/…)
+// and the folder action sets, so any existing dashboard/folder/basic-role grant already covers
+// them and no new roles are needed to ship the preview.
+//
+// The object SCOPE is deliberately kept in the notebook's own namespace (notebooks:uid:) rather
+// than dashboards:uid:, because a notebook is not a dashboard: its UID must not live in the
+// dashboards scope tree, and dashboard per-object grants must not bleed into notebook access or
+// listing (buildItemList keys the allowed-item set off this prefix). Nothing grants notebooks:uid:
+// scopes yet — per-notebook sharing isn't offered in the preview — so access is folder-scoped.
+//
+// After the private preview notebooks should move to full, first-class RBAC: dedicated
+// notebooks:* actions and notebook roles (view/edit/admin), wired into the folder action sets so
+// folder grants keep covering them, plus a notebook resource-permissions service for per-notebook
+// sharing. The notebooks:uid: scope chosen here is what makes that a clean, additive change (no
+// scope migration): swap the action mapping to notebooks:* and the scope is already correct.
+func newNotebookTranslation() translation {
+	t := newDashboardTranslation()
+	t.resource = "notebooks"
+	return t
+}
+
 // newFolderTranslation creates a translation for folders and also maps the actions to action sets
 func newFolderTranslation() translation {
 	folderTranslation := newResourceTranslation("folders", "uid", true, nil)
@@ -418,6 +440,7 @@ func NewMapperRegistry() MapperRegistry {
 		},
 		"dashboard.grafana.app": {
 			"dashboards":    newDashboardTranslation(),
+			"notebooks":     newNotebookTranslation(),
 			"librarypanels": newResourceTranslation("library.panels", "uid", true, nil),
 			// Annotations subresource for dashboards
 			// Uses dashboard scope (dashboards:uid:...) but annotation actions

--- a/pkg/services/authz/rbac/mapper.go
+++ b/pkg/services/authz/rbac/mapper.go
@@ -193,6 +193,11 @@ func newDashboardTranslation() translation {
 func newNotebookTranslation() translation {
 	t := newDashboardTranslation()
 	t.resource = "notebooks"
+	// Notebooks expose no permissions subresource in the preview, so drop the inherited
+	// dashboards.permissions:* verbs rather than let a notebook permissions request resolve
+	// onto dashboard permission actions.
+	delete(t.verbMapping, utils.VerbGetPermissions)
+	delete(t.verbMapping, utils.VerbSetPermissions)
 	return t
 }
 

--- a/pkg/services/authz/rbac/mapper_test.go
+++ b/pkg/services/authz/rbac/mapper_test.go
@@ -354,6 +354,34 @@ func TestMapper_AnnotationSubresource_ActionSets(t *testing.T) {
 	}
 }
 
+// TestMapperRegistry_Notebooks verifies notebooks reuse dashboard actions and folder
+// action sets (so existing dashboard/folder grants cover them for the private preview)
+// while keeping their own notebooks:uid: object scope, so notebook identities never live
+// in the dashboards scope tree.
+func TestMapperRegistry_Notebooks(t *testing.T) {
+	reg := NewMapperRegistry()
+
+	mapping, ok := reg.Get("dashboard.grafana.app", "notebooks", "")
+	require.True(t, ok)
+	require.NotNil(t, mapping)
+
+	// Reuses dashboard actions so existing dashboard/basic-role grants apply.
+	action, ok := mapping.Action(utils.VerbGet)
+	require.True(t, ok)
+	assert.Equal(t, "dashboards:read", action)
+	action, ok = mapping.Action(utils.VerbUpdate)
+	require.True(t, ok)
+	assert.Equal(t, "dashboards:write", action)
+
+	// Folder action sets make folder permissions grant notebook access.
+	assert.Contains(t, mapping.ActionSets(utils.VerbGet), "folders:view")
+	assert.True(t, mapping.HasFolderSupport())
+
+	// Object scope stays in the notebook's own namespace, never dashboards:uid:.
+	assert.Equal(t, "notebooks:uid:", mapping.Prefix())
+	assert.Equal(t, "notebooks:uid:nb1", mapping.Scope("nb1"))
+}
+
 func TestMapperRegistry_Settings(t *testing.T) {
 	reg := NewMapperRegistry()
 

--- a/pkg/services/authz/rbac/mapper_test.go
+++ b/pkg/services/authz/rbac/mapper_test.go
@@ -365,16 +365,26 @@ func TestMapperRegistry_Notebooks(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, mapping)
 
-	// Reuses dashboard actions so existing dashboard/basic-role grants apply.
-	action, ok := mapping.Action(utils.VerbGet)
-	require.True(t, ok)
-	assert.Equal(t, "dashboards:read", action)
-	action, ok = mapping.Action(utils.VerbUpdate)
-	require.True(t, ok)
-	assert.Equal(t, "dashboards:write", action)
+	// Reuses dashboard actions across every verb so existing dashboard/basic-role grants apply.
+	for verb, want := range map[string]string{
+		utils.VerbGet:              "dashboards:read",
+		utils.VerbList:             "dashboards:read",
+		utils.VerbWatch:            "dashboards:read",
+		utils.VerbCreate:           "dashboards:create",
+		utils.VerbUpdate:           "dashboards:write",
+		utils.VerbPatch:            "dashboards:write",
+		utils.VerbDelete:           "dashboards:delete",
+		utils.VerbDeleteCollection: "dashboards:delete",
+	} {
+		action, ok := mapping.Action(verb)
+		require.True(t, ok, "verb %q should map to an action", verb)
+		assert.Equal(t, want, action, "verb %q", verb)
+	}
 
-	// Folder action sets make folder permissions grant notebook access.
+	// Read verbs are satisfied by the folder view sets; create only by the folder edit/admin
+	// sets (so editors, not viewers, can create).
 	assert.Contains(t, mapping.ActionSets(utils.VerbGet), "folders:view")
+	assert.ElementsMatch(t, []string{"folders:edit", "folders:admin"}, mapping.ActionSets(utils.VerbCreate))
 	assert.True(t, mapping.HasFolderSupport())
 
 	// Object scope stays in the notebook's own namespace, never dashboards:uid:.

--- a/pkg/services/authz/rbac/service_test.go
+++ b/pkg/services/authz/rbac/service_test.go
@@ -421,6 +421,74 @@ func TestService_checkPermission(t *testing.T) {
 			expected: true,
 		},
 		{
+			name: "should allow reading a notebook via a folder permission",
+			permissions: []accesscontrol.Permission{
+				{
+					Scope:      "folders:uid:parent",
+					Kind:       "folders",
+					Attribute:  "uid",
+					Identifier: "parent",
+				},
+			},
+			folders: []store.Folder{
+				{UID: "parent"},
+				{UID: "child", ParentUID: new("parent")},
+			},
+			check: checkRequest{
+				Action:       "dashboards:read",
+				Group:        "dashboard.grafana.app",
+				Resource:     "notebooks",
+				Name:         "some_notebook",
+				ParentFolder: "child",
+			},
+			expected: true,
+		},
+		{
+			name: "should deny reading a notebook when the folder permission is on an unrelated folder",
+			permissions: []accesscontrol.Permission{
+				{
+					Scope:      "folders:uid:other",
+					Kind:       "folders",
+					Attribute:  "uid",
+					Identifier: "other",
+				},
+			},
+			folders: []store.Folder{
+				{UID: "parent"},
+				{UID: "child", ParentUID: new("parent")},
+				{UID: "other"},
+			},
+			check: checkRequest{
+				Action:       "dashboards:read",
+				Group:        "dashboard.grafana.app",
+				Resource:     "notebooks",
+				Name:         "some_notebook",
+				ParentFolder: "child",
+			},
+			expected: false,
+		},
+		{
+			// A per-object dashboard grant must not authorize a same-named notebook: notebooks
+			// keep their own notebooks:uid: scope, so dashboard object grants never bleed in.
+			name: "should deny a notebook when only a same-named dashboard object grant exists",
+			permissions: []accesscontrol.Permission{
+				{
+					Action:     "dashboards:read",
+					Scope:      "dashboards:uid:nb1",
+					Kind:       "dashboards",
+					Attribute:  "uid",
+					Identifier: "nb1",
+				},
+			},
+			check: checkRequest{
+				Action:   "dashboards:read",
+				Group:    "dashboard.grafana.app",
+				Resource: "notebooks",
+				Name:     "nb1",
+			},
+			expected: false,
+		},
+		{
 			name: "should allow querying a datasource",
 			permissions: []accesscontrol.Permission{
 				{

--- a/pkg/services/authz/rbac/service_test.go
+++ b/pkg/services/authz/rbac/service_test.go
@@ -424,6 +424,7 @@ func TestService_checkPermission(t *testing.T) {
 			name: "should allow reading a notebook via a folder permission",
 			permissions: []accesscontrol.Permission{
 				{
+					Action:     "dashboards:read",
 					Scope:      "folders:uid:parent",
 					Kind:       "folders",
 					Attribute:  "uid",
@@ -447,6 +448,7 @@ func TestService_checkPermission(t *testing.T) {
 			name: "should deny reading a notebook when the folder permission is on an unrelated folder",
 			permissions: []accesscontrol.Permission{
 				{
+					Action:     "dashboards:read",
 					Scope:      "folders:uid:other",
 					Kind:       "folders",
 					Attribute:  "uid",


### PR DESCRIPTION
## What

Adds a `pkg/services/authz/rbac/mapper.go` entry for `dashboard.grafana.app/notebooks` so notebook requests resolve to a real RBAC decision instead of the K8s-native fallback.

Notebooks reuse dashboard authorization **on the action axis only**:
- **Actions**: notebook verbs map to dashboard actions (`dashboards:read`/`write`/…) and the folder action sets — so existing dashboard/folder/basic-role grants already cover notebooks and no new roles are needed for the private preview.
- **Scope**: kept in the notebook's own namespace (`notebooks:uid:`), *not* `dashboards:uid:`.

## Why

Unified Storage authorization is moving from an allowlist (opt-in, most resources fail-open) to an exemption list (opt-out, everything enforced unless exempt). Notebooks are a **new** resource, so they're enforced from day one once the gate flips. With no mapper entry, notebooks fall to the K8s-native fallback, which generates `dashboard.grafana.app/notebooks:*` actions that nobody holds → **notebooks denied for everyone**. This entry makes notebooks inherit dashboard/folder permissions instead, matching their design ("a dashboard with narrative content", folder-scoped, sharing dashboard RBAC).

## Why the scope is `notebooks:uid:` and not `dashboards:uid:`

A notebook is not a dashboard — its UID must not live in the dashboards scope tree. This isn't cosmetic: `buildItemList` keys the allowed-item set off the scope prefix, so a `dashboards:uid:` prefix would let a user's **dashboard** per-object grants bleed into **notebook** list results (a UID-collision leak). Namespacing the scope to `notebooks:uid:` prevents that. Folder access (`checkInheritedPermissions`, `folders:uid:`) and org-wide wildcard grants don't use the object scope, so they're unaffected. In the preview nothing grants `notebooks:uid:` scopes (no per-notebook sharing), so access is folder-scoped only.

## Follow-up (post private preview)

This is intentionally scoped as an additive, migration-free step. Full first-class notebook RBAC — dedicated `notebooks:*` actions and notebook roles (view/edit/admin) wired into the folder action sets, plus a notebook resource-permissions service for per-notebook sharing — becomes a clean change later: swap the action mapping to `notebooks:*`; the scope is already correct, and no `notebooks:*` grant rows exist to migrate.

## Testing

- `TestMapperRegistry_Notebooks`: notebooks resolve to `dashboards:read` action, include the `folders:view` action set, support folders, and scope to `notebooks:uid:`.
- `TestService_checkPermission` cases: a folder View grant allows GET/LIST of a notebook in that folder; an unrelated-folder grant denies it; a same-named **dashboard** object grant does **not** authorize a notebook (no scope bleed).
- Verified manually end-to-end against a dev server with `authz_exemption_enabled=true`: a Viewer is denied a notebook in a folder they can't see, and allowed once granted View on the folder.

## Not included / out of scope

- No changes to the enforcement gate (`pkg/storage/unified/resource/access.go`) or exemption list — enforcement rollout is owned by the Search & Storage squad.
- No changes to the API-level authorizer (`newNotebookAuthorizer`) — it remains the feature-flag/service gate; per-object authorization lives in Unified Storage.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
