### PR TITLE
Grafana Datasource: Remove deprecated getDataSourceSrv usage from QueryEditor

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2950,7 +2950,7 @@
       "count": 1
     },
     "@typescript-eslint/consistent-type-assertions": {
-      "count": 2
+      "count": 1
     }
   },
   "public/app/plugins/datasource/grafana/components/TimeRegionEditor.tsx": {

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2946,9 +2946,6 @@
     }
   },
   "public/app/plugins/datasource/grafana/components/QueryEditor.tsx": {
-    "@grafana/no-get-data-source-srv": {
-      "count": 1
-    },
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1
     }

--- a/public/app/plugins/datasource/grafana/components/QueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana/components/QueryEditor.tsx
@@ -8,7 +8,7 @@ import {
   type DataQueryRequest,
   type Field,
 } from '@grafana/data';
-import { config, getDataSourceSrv } from '@grafana/runtime';
+import { config } from '@grafana/runtime';
 import { InlineField, Select, Alert, Input, InlineFieldRow, Stack, InlineLabel } from '@grafana/ui';
 import { getManagedChannelInfo } from 'app/features/live/info';
 
@@ -45,7 +45,7 @@ interface ChannelInfo {
 }
 
 export const QueryEditor = memo(function QueryEditor(props: Props) {
-  const { onChange, onRunQuery } = props;
+  const { datasource, onChange, onRunQuery } = props;
   const [channelInfo, setChannelInfo] = useState<ChannelInfo>({ channels: [], channelFields: {} });
   const [folders, setFolders] = useState<Array<SelectableValue<string>>>();
 
@@ -66,25 +66,20 @@ export const QueryEditor = memo(function QueryEditor(props: Props) {
       targets: [{ queryType: GrafanaQueryType.List, refId: 'A' }],
     } as DataQueryRequest<GrafanaQuery>;
 
-    getDataSourceSrv()
-      .get('-- Grafana --')
-      .then((ds) => {
-        const gds = ds as GrafanaDatasource;
-        gds.query(listQuery).subscribe({
-          next: (rsp) => {
-            if (rsp.data.length) {
-              const names: Field = rsp.data[0].fields[0];
-              setFolders(
-                names.values.map((v) => ({
-                  value: v,
-                  label: v,
-                }))
-              );
-            }
-          },
-        });
-      });
-  }, []);
+    datasource.query(listQuery).subscribe({
+      next: (rsp) => {
+        if (rsp.data.length) {
+          const names: Field = rsp.data[0].fields[0];
+          setFolders(
+            names.values.map((v) => ({
+              value: v,
+              label: v,
+            }))
+          );
+        }
+      },
+    });
+  }, [datasource]);
 
   useEffect(() => {
     loadChannelInfo();


### PR DESCRIPTION
Part of #125083.

## What changed

The `QueryEditor` for the `-- Grafana --` data source called the deprecated `getDataSourceSrv().get('-- Grafana --')` API. This call loaded the folder list for the "List public files" query type.

The editor already receives the `GrafanaDatasource` instance as `props.datasource`. The folder query now uses this instance directly. This change removes the deprecated call, the async lookup, and the `as GrafanaDatasource` cast.

PR #128155 already migrated `datasource.ts`, so this PR makes no changes to that file.

## Verification

- Lint, unit tests, and `yarn typecheck` pass.
- Manual test in a browser against a local build:
  - Opened Explore with the `-- Grafana --` data source.
  - The Random Walk query returned data.
  - The "List public files" query type filled the Path dropdown with the folders `gazetteer`, `img`, and `maps`.
  - Selection of the `img` folder showed the correct file list.