### PR TITLE
Provisioning: OAuth app connection follow-ups

### DIFF
--- a/apps/provisioning/pkg/connection/mutator.go
+++ b/apps/provisioning/pkg/connection/mutator.go
@@ -46,7 +46,7 @@ func (m *AdmissionMutator) Mutate(ctx context.Context, a admission.Attributes, o
 	}
 
 	if a.GetOperation() == admission.Update {
-		if old, ok := a.GetOldObject().(*provisioning.Connection); ok && oauthCredentialsChanged(c, old) {
+		if old, ok := a.GetOldObject().(*provisioning.Connection); ok && oauthAppChanged(c, old) {
 			c.Secure.Token = common.InlineSecureValue{Remove: true}
 		}
 	}
@@ -71,14 +71,18 @@ func CopySecureValues(new, old *provisioning.Connection) {
 	}
 }
 
-// oauthCredentialsChanged reports whether an update changes the OAuth app
-// credentials the stored token was minted with. The token is removed in that
+// oauthAppChanged reports whether an update changes the OAuth app the
+// stored token was minted by: its credentials or the provider it lives on
+// (type and, for self-hosted providers, URL). The token is removed in that
 // case: it belongs to the previous app and the user must authorize again.
-func oauthCredentialsChanged(new, old *provisioning.Connection) bool {
-	if new.Spec.OAuth == nil || old.Spec.OAuth == nil {
+func oauthAppChanged(new, old *provisioning.Connection) bool {
+	if new.Spec.OAuth == nil && old.Spec.OAuth == nil {
 		return false
 	}
-	if new.Spec.OAuth.ClientID != old.Spec.OAuth.ClientID {
+	if new.Spec.OAuth == nil || old.Spec.OAuth == nil {
+		return true
+	}
+	if new.Spec.Type != old.Spec.Type || new.Spec.URL != old.Spec.URL || new.Spec.OAuth.ClientID != old.Spec.OAuth.ClientID {
 		return true
 	}
 	return !new.Secure.ClientSecret.Create.IsZero() ||

--- a/apps/provisioning/pkg/connection/mutator_test.go
+++ b/apps/provisioning/pkg/connection/mutator_test.go
@@ -1,6 +1,7 @@
 package connection
 
 import (
+	"cmp"
 	"errors"
 	"testing"
 
@@ -126,11 +127,27 @@ func TestAdmissionMutator_Mutate(t *testing.T) {
 func TestAdmissionMutator_MutateUpdateOAuthToken(t *testing.T) {
 	tests := []struct {
 		name      string
+		newType   provisioning.ConnectionType
+		newURL    string
 		newOAuth  *provisioning.ConnectionOAuthConfig
 		newSecure provisioning.ConnectionSecure
 		oldOAuth  *provisioning.ConnectionOAuthConfig
 		wantToken common.InlineSecureValue
 	}{
+		{
+			name:      "removes token when connection type is changed",
+			newType:   provisioning.GitlabConnectionType,
+			newOAuth:  &provisioning.ConnectionOAuthConfig{ClientID: "same-client"},
+			oldOAuth:  &provisioning.ConnectionOAuthConfig{ClientID: "same-client"},
+			wantToken: common.InlineSecureValue{Remove: true},
+		},
+		{
+			name:      "removes token when connection URL is changed",
+			newURL:    "https://gitlab.example.com",
+			newOAuth:  &provisioning.ConnectionOAuthConfig{ClientID: "same-client"},
+			oldOAuth:  &provisioning.ConnectionOAuthConfig{ClientID: "same-client"},
+			wantToken: common.InlineSecureValue{Remove: true},
+		},
 		{
 			name:      "keeps token when oauth credentials are unchanged",
 			newOAuth:  &provisioning.ConnectionOAuthConfig{ClientID: "same-client"},
@@ -174,6 +191,16 @@ func TestAdmissionMutator_MutateUpdateOAuthToken(t *testing.T) {
 			name:      "keeps token when connection is not oauth",
 			wantToken: common.InlineSecureValue{},
 		},
+		{
+			name:      "removes token when connection switches away from oauth",
+			oldOAuth:  &provisioning.ConnectionOAuthConfig{ClientID: "old-client"},
+			wantToken: common.InlineSecureValue{Remove: true},
+		},
+		{
+			name:      "removes token when connection switches to oauth",
+			newOAuth:  &provisioning.ConnectionOAuthConfig{ClientID: "new-client"},
+			wantToken: common.InlineSecureValue{Remove: true},
+		},
 	}
 
 	for _, tt := range tests {
@@ -184,7 +211,8 @@ func TestAdmissionMutator_MutateUpdateOAuthToken(t *testing.T) {
 			obj := &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: provisioning.ConnectionSpec{
-					Type:  provisioning.GithubConnectionType,
+					Type:  cmp.Or(tt.newType, provisioning.GithubConnectionType),
+					URL:   tt.newURL,
 					OAuth: tt.newOAuth,
 				},
 				Secure: tt.newSecure,

--- a/apps/provisioning/pkg/connection/oauth/connection.go
+++ b/apps/provisioning/pkg/connection/oauth/connection.go
@@ -23,34 +23,30 @@ import (
 //go:generate mockery --name Provider --structname MockProvider --inpackage --filename provider_mock.go --with-expecter
 type Provider interface {
 	Endpoint() oauth2.Endpoint
-	ListRepositories(ctx context.Context, accessToken string) ([]provisioning.ExternalRepository, error)
+	ListRepositories(ctx context.Context) ([]provisioning.ExternalRepository, error)
 }
 
-type ConnectionSecrets struct {
-	ClientSecret common.RawSecureValue
-	Token        common.RawSecureValue
+type oauthConnection struct {
+	provider     Provider
+	repoType     provisioning.RepositoryType
+	clientID     string
+	clientSecret common.RawSecureValue
+	token        common.RawSecureValue
 }
 
-type Connection struct {
-	provider Provider
-	repoType provisioning.RepositoryType
-	clientID string
-	secrets  ConnectionSecrets
-}
-
-func NewConnection(provider Provider, repoType provisioning.RepositoryType, cfg provisioning.ConnectionOAuthConfig, secrets ConnectionSecrets) Connection {
-	return Connection{
-		provider: provider,
-		repoType: repoType,
-		clientID: cfg.ClientID,
-		secrets:  secrets,
+func newConnection(provider Provider, repoType provisioning.RepositoryType, cfg provisioning.ConnectionOAuthConfig, clientSecret, token common.RawSecureValue) *oauthConnection {
+	return &oauthConnection{
+		provider:     provider,
+		repoType:     repoType,
+		clientID:     cfg.ClientID,
+		clientSecret: clientSecret,
+		token:        token,
 	}
 }
 
 // Test validates that the stored access token works against the provider.
-func (c *Connection) Test(ctx context.Context) (*provisioning.TestResults, error) {
-	token, err := parseToken(c.secrets.Token)
-	if err != nil || token.AccessToken == "" {
+func (c *oauthConnection) Test(ctx context.Context) (*provisioning.TestResults, error) {
+	if token, err := parseToken(c.token); err != nil || token.AccessToken == "" {
 		return connection.FailedTestResults(
 			http.StatusUnauthorized,
 			[]provisioning.ErrorDetails{{
@@ -61,7 +57,7 @@ func (c *Connection) Test(ctx context.Context) (*provisioning.TestResults, error
 		), nil
 	}
 
-	if _, err := c.provider.ListRepositories(ctx, token.AccessToken); err != nil {
+	if _, err := c.ListRepositories(ctx); err != nil {
 		if errors.Is(err, connection.ErrAuthentication) {
 			return connection.FailedTestResults(
 				http.StatusUnauthorized,
@@ -87,7 +83,7 @@ func (c *Connection) Test(ctx context.Context) (*provisioning.TestResults, error
 // GenerateRepositoryToken returns an access token usable for git operations on
 // the given repository. OAuth app tokens are not repository scoped, so this is
 // the connection-level access token kept fresh by the connection controller.
-func (c *Connection) GenerateRepositoryToken(_ context.Context, repo *provisioning.Repository) (*connection.ExpirableSecureValue, error) {
+func (c *oauthConnection) GenerateRepositoryToken(_ context.Context, repo *provisioning.Repository) (*connection.ExpirableSecureValue, error) {
 	if repo == nil {
 		return nil, errors.New("a repository is required to generate a token")
 	}
@@ -95,7 +91,7 @@ func (c *Connection) GenerateRepositoryToken(_ context.Context, repo *provisioni
 		return nil, fmt.Errorf("repository type %q is not served by this connection (serves %q)", repo.Spec.Type, c.repoType)
 	}
 
-	token, err := parseToken(c.secrets.Token)
+	token, err := parseToken(c.token)
 	if err != nil || token.AccessToken == "" {
 		return nil, fmt.Errorf("connection access token not available: %w", connection.ErrAuthentication)
 	}
@@ -110,13 +106,13 @@ func (c *Connection) GenerateRepositoryToken(_ context.Context, repo *provisioni
 }
 
 // ListRepositories returns the list of repositories accessible through this connection.
-func (c *Connection) ListRepositories(ctx context.Context) ([]provisioning.ExternalRepository, error) {
-	token, err := parseToken(c.secrets.Token)
+func (c *oauthConnection) ListRepositories(ctx context.Context) ([]provisioning.ExternalRepository, error) {
+	token, err := parseToken(c.token)
 	if err != nil || token.AccessToken == "" {
 		return nil, fmt.Errorf("connection access token not available: %w", connection.ErrAuthentication)
 	}
 
-	return c.provider.ListRepositories(ctx, token.AccessToken)
+	return c.provider.ListRepositories(ctx)
 }
 
 // GenerateConnectionToken exchanges the stored refresh token for a new access
@@ -124,8 +120,8 @@ func (c *Connection) ListRepositories(ctx context.Context) ([]provisioning.Exter
 // (e.g. GitLab) return a new one, which is stored as part of the token; when
 // absent the stored refresh token remains valid and is kept.
 // Implements the connection.TokenConnection interface.
-func (c *Connection) GenerateConnectionToken(ctx context.Context) (common.RawSecureValue, error) {
-	stored, err := parseToken(c.secrets.Token)
+func (c *oauthConnection) GenerateConnectionToken(ctx context.Context) (common.RawSecureValue, error) {
+	stored, err := parseToken(c.token)
 	if err != nil {
 		return "", err
 	}
@@ -135,7 +131,7 @@ func (c *Connection) GenerateConnectionToken(ctx context.Context) (common.RawSec
 
 	cfg := oauth2.Config{
 		ClientID:     c.clientID,
-		ClientSecret: string(c.secrets.ClientSecret),
+		ClientSecret: string(c.clientSecret),
 		Endpoint:     c.provider.Endpoint(),
 	}
 
@@ -153,14 +149,14 @@ func (c *Connection) GenerateConnectionToken(ctx context.Context) (common.RawSec
 
 // ExchangeAuthorizationCode exchanges an OAuth authorization code for tokens.
 // Implements the connection.OAuthConnection interface.
-func (c *Connection) ExchangeAuthorizationCode(ctx context.Context, code, redirectURI string) (common.RawSecureValue, error) {
+func (c *oauthConnection) ExchangeAuthorizationCode(ctx context.Context, code, redirectURI string) (common.RawSecureValue, error) {
 	if code == "" {
 		return "", errors.New("an authorization code is required")
 	}
 
 	cfg := oauth2.Config{
 		ClientID:     c.clientID,
-		ClientSecret: string(c.secrets.ClientSecret),
+		ClientSecret: string(c.clientSecret),
 		Endpoint:     c.provider.Endpoint(),
 		RedirectURL:  redirectURI,
 	}
@@ -175,8 +171,8 @@ func (c *Connection) ExchangeAuthorizationCode(ctx context.Context, code, redire
 
 // ValidateToken checks the stored token. A missing expiry means the provider
 // issued a non-expiring access token (e.g. GitHub OAuth apps).
-func (c *Connection) ValidateToken() (expiresAt time.Time, err error) {
-	token, err := parseToken(c.secrets.Token)
+func (c *oauthConnection) ValidateToken() (expiresAt time.Time, err error) {
+	token, err := parseToken(c.token)
 	if err != nil {
 		return time.Time{}, err
 	}
@@ -215,7 +211,7 @@ func marshalToken(token *oauth2.Token) (common.RawSecureValue, error) {
 }
 
 var (
-	_ connection.Connection      = (*Connection)(nil)
-	_ connection.TokenConnection = (*Connection)(nil)
-	_ connection.OAuthConnection = (*Connection)(nil)
+	_ connection.Connection      = (*oauthConnection)(nil)
+	_ connection.TokenConnection = (*oauthConnection)(nil)
+	_ connection.OAuthConnection = (*oauthConnection)(nil)
 )

--- a/apps/provisioning/pkg/connection/oauth/connection_test.go
+++ b/apps/provisioning/pkg/connection/oauth/connection_test.go
@@ -1,4 +1,4 @@
-package oauth_test
+package oauth
 
 import (
 	"encoding/json"
@@ -16,7 +16,6 @@ import (
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/connection"
-	"github.com/grafana/grafana/apps/provisioning/pkg/connection/oauth"
 	common "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
 )
 
@@ -100,8 +99,8 @@ func TestConnection_Test(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			provider := newMockProvider(t, "")
-			provider.EXPECT().ListRepositories(mock.Anything, "access").Return(nil, tt.listErr).Maybe()
-			conn := oauth.NewConnection(provider, provisioning.GitLabRepositoryType, testOAuthConfig, oauth.ConnectionSecrets{Token: tt.token})
+			provider.EXPECT().ListRepositories(mock.Anything).Return(nil, tt.listErr).Maybe()
+			conn := newConnection(provider, provisioning.GitLabRepositoryType, testOAuthConfig, "", tt.token)
 
 			results, err := conn.Test(t.Context())
 			require.NoError(t, err)
@@ -164,7 +163,7 @@ func TestConnection_GenerateRepositoryToken(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			conn := oauth.NewConnection(newMockProvider(t, ""), provisioning.GitLabRepositoryType, testOAuthConfig, oauth.ConnectionSecrets{Token: tt.token})
+			conn := newConnection(newMockProvider(t, ""), provisioning.GitLabRepositoryType, testOAuthConfig, "", tt.token)
 
 			value, err := conn.GenerateRepositoryToken(t.Context(), tt.repo)
 			if tt.expectedErr != "" {
@@ -182,10 +181,9 @@ func TestConnection_ListRepositories(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		provider := newMockProvider(t, "")
-		provider.EXPECT().ListRepositories(mock.Anything, "access").Return(repos, nil)
-		conn := oauth.NewConnection(provider, provisioning.GitLabRepositoryType, testOAuthConfig, oauth.ConnectionSecrets{
-			Token: marshalTestToken(t, &oauth2.Token{AccessToken: "access"}),
-		})
+		provider.EXPECT().ListRepositories(mock.Anything).Return(repos, nil)
+		conn := newConnection(provider, provisioning.GitLabRepositoryType, testOAuthConfig, "",
+			marshalTestToken(t, &oauth2.Token{AccessToken: "access"}))
 
 		result, err := conn.ListRepositories(t.Context())
 		require.NoError(t, err)
@@ -193,7 +191,7 @@ func TestConnection_ListRepositories(t *testing.T) {
 	})
 
 	t.Run("failure - no token stored", func(t *testing.T) {
-		conn := oauth.NewConnection(newMockProvider(t, ""), provisioning.GitLabRepositoryType, testOAuthConfig, oauth.ConnectionSecrets{})
+		conn := newConnection(newMockProvider(t, ""), provisioning.GitLabRepositoryType, testOAuthConfig, "", "")
 
 		_, err := conn.ListRepositories(t.Context())
 		require.ErrorIs(t, err, connection.ErrAuthentication)
@@ -254,10 +252,7 @@ func TestConnection_GenerateConnectionToken(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			srv := newTokenServer(t, tt.responseCode, tt.response)
-			conn := oauth.NewConnection(newMockProvider(t, srv.URL), provisioning.GitLabRepositoryType, testOAuthConfig, oauth.ConnectionSecrets{
-				ClientSecret: "client-secret",
-				Token:        tt.token,
-			})
+			conn := newConnection(newMockProvider(t, srv.URL), provisioning.GitLabRepositoryType, testOAuthConfig, "client-secret", tt.token)
 
 			raw, err := conn.GenerateConnectionToken(t.Context())
 			if tt.expectedErr != "" {
@@ -304,9 +299,7 @@ func TestConnection_ExchangeAuthorizationCode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			srv := newTokenServer(t, tt.responseCode, tt.response)
-			conn := oauth.NewConnection(newMockProvider(t, srv.URL), provisioning.GitLabRepositoryType, testOAuthConfig, oauth.ConnectionSecrets{
-				ClientSecret: "client-secret",
-			})
+			conn := newConnection(newMockProvider(t, srv.URL), provisioning.GitLabRepositoryType, testOAuthConfig, "client-secret", "")
 
 			raw, err := conn.ExchangeAuthorizationCode(t.Context(), tt.code, "https://grafana.example/callback")
 			if tt.expectedErr != "" {
@@ -359,7 +352,7 @@ func TestConnection_ValidateToken(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			conn := oauth.NewConnection(newMockProvider(t, ""), provisioning.GitLabRepositoryType, testOAuthConfig, oauth.ConnectionSecrets{Token: tt.token})
+			conn := newConnection(newMockProvider(t, ""), provisioning.GitLabRepositoryType, testOAuthConfig, "", tt.token)
 
 			tokenExpiry, err := conn.ValidateToken()
 			if tt.expectedErr != "" {
@@ -374,8 +367,8 @@ func TestConnection_ValidateToken(t *testing.T) {
 
 var testOAuthConfig = provisioning.ConnectionOAuthConfig{ClientID: "client-id"}
 
-func newMockProvider(t *testing.T, tokenURL string) *oauth.MockProvider {
-	provider := oauth.NewMockProvider(t)
+func newMockProvider(t *testing.T, tokenURL string) *MockProvider {
+	provider := NewMockProvider(t)
 	provider.EXPECT().Endpoint().Return(oauth2.Endpoint{TokenURL: tokenURL}).Maybe()
 	return provider
 }

--- a/apps/provisioning/pkg/connection/oauth/extra.go
+++ b/apps/provisioning/pkg/connection/oauth/extra.go
@@ -12,8 +12,10 @@ import (
 )
 
 // NewProviderFunc constructs the provider-specific parts of an OAuth app
-// connection from the connection spec.
-type NewProviderFunc func(spec provisioning.ConnectionSpec) Provider
+// connection from the connection spec and the stored access token. The token
+// is empty until the user authorizes the OAuth application; the connection
+// never calls the provider's API in that state.
+type NewProviderFunc func(spec provisioning.ConnectionSpec, accessToken string) (Provider, error)
 
 // ValidateSpecFunc performs provider-specific spec validation. The shared
 // oauth section and secure values are validated by the extra itself. May be
@@ -66,13 +68,23 @@ func (e *extra) Build(ctx context.Context, conn *provisioning.Connection) (conne
 		return nil, fmt.Errorf("decrypt token: %w", err)
 	}
 
-	secrets := ConnectionSecrets{
-		ClientSecret: clientSecret,
-		Token:        token,
+	// An empty token means the OAuth app has not been authorized yet, which is a
+	// valid state for a connection to be built in.
+	accessToken := ""
+	if !token.IsZero() {
+		parsed, err := parseToken(token)
+		if err != nil {
+			return nil, fmt.Errorf("parse token: %w", err)
+		}
+		accessToken = parsed.AccessToken
 	}
 
-	c := NewConnection(e.newProvider(conn.Spec), e.repoType, *conn.Spec.OAuth, secrets)
-	return &c, nil
+	provider, err := e.newProvider(conn.Spec, accessToken)
+	if err != nil {
+		return nil, fmt.Errorf("build provider: %w", err)
+	}
+
+	return newConnection(provider, e.repoType, *conn.Spec.OAuth, clientSecret, token), nil
 }
 
 func (e *extra) Mutate(_ context.Context, _ runtime.Object) error {

--- a/apps/provisioning/pkg/connection/oauth/extra_test.go
+++ b/apps/provisioning/pkg/connection/oauth/extra_test.go
@@ -40,7 +40,7 @@ func TestExtra_Build(t *testing.T) {
 			},
 			setup: func(m *connection.MockSecureValues) {
 				m.EXPECT().ClientSecret(mock.Anything).Return("client-secret", nil)
-				m.EXPECT().Token(mock.Anything).Return("token", nil)
+				m.EXPECT().Token(mock.Anything).Return(common.RawSecureValue(`{"access_token":"token"}`), nil)
 			},
 		},
 		{
@@ -105,6 +105,81 @@ func TestExtra_Build(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, result)
 		})
+	}
+}
+
+func TestExtra_Build_PassesAccessToken(t *testing.T) {
+	tests := []struct {
+		name      string
+		token     common.RawSecureValue
+		wantToken string
+	}{
+		{name: "stored token is passed to the provider", token: common.RawSecureValue(`{"access_token":"stored-token"}`), wantToken: "stored-token"},
+		{name: "missing token builds provider with empty token", token: "", wantToken: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			secure := connection.NewMockSecureValues(t)
+			secure.EXPECT().ClientSecret(mock.Anything).Return("client-secret", nil)
+			secure.EXPECT().Token(mock.Anything).Return(tt.token, nil)
+
+			var gotToken string
+			e := oauth.NewExtra(
+				func(*provisioning.Connection) connection.SecureValues { return secure },
+				provisioning.GitlabConnectionType,
+				provisioning.GitLabRepositoryType,
+				func(_ provisioning.ConnectionSpec, accessToken string) (oauth.Provider, error) {
+					gotToken = accessToken
+					return oauth.NewMockProvider(t), nil
+				},
+				nil,
+			)
+
+			_, err := e.Build(t.Context(), newBuildTestConnection())
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantToken, gotToken)
+		})
+	}
+}
+
+func TestExtra_Build_InvalidToken(t *testing.T) {
+	secure := connection.NewMockSecureValues(t)
+	secure.EXPECT().ClientSecret(mock.Anything).Return("client-secret", nil)
+	secure.EXPECT().Token(mock.Anything).Return("not-a-token", nil)
+
+	e := newTestExtra(t, secure, nil)
+
+	_, err := e.Build(t.Context(), newBuildTestConnection())
+	require.EqualError(t, err, "parse token: stored token is not a valid token payload")
+}
+
+func TestExtra_Build_ProviderError(t *testing.T) {
+	secure := connection.NewMockSecureValues(t)
+	secure.EXPECT().ClientSecret(mock.Anything).Return("client-secret", nil)
+	secure.EXPECT().Token(mock.Anything).Return("", nil)
+
+	e := oauth.NewExtra(
+		func(*provisioning.Connection) connection.SecureValues { return secure },
+		provisioning.GitlabConnectionType,
+		provisioning.GitLabRepositoryType,
+		func(_ provisioning.ConnectionSpec, _ string) (oauth.Provider, error) {
+			return nil, errors.New("boom")
+		},
+		nil,
+	)
+
+	_, err := e.Build(t.Context(), newBuildTestConnection())
+	require.EqualError(t, err, "build provider: boom")
+}
+
+func newBuildTestConnection() *provisioning.Connection {
+	return &provisioning.Connection{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-connection"},
+		Spec: provisioning.ConnectionSpec{
+			Type:  provisioning.GitlabConnectionType,
+			OAuth: &provisioning.ConnectionOAuthConfig{ClientID: "client-id"},
+		},
 	}
 }
 
@@ -244,7 +319,9 @@ func newTestExtra(t *testing.T, secure *connection.MockSecureValues, validateSpe
 		func(*provisioning.Connection) connection.SecureValues { return secure },
 		provisioning.GitlabConnectionType,
 		provisioning.GitLabRepositoryType,
-		func(_ provisioning.ConnectionSpec) oauth.Provider { return oauth.NewMockProvider(t) },
+		func(_ provisioning.ConnectionSpec, _ string) (oauth.Provider, error) {
+			return oauth.NewMockProvider(t), nil
+		},
 		validateSpec,
 	)
 }

--- a/apps/provisioning/pkg/connection/oauth/provider_mock.go
+++ b/apps/provisioning/pkg/connection/oauth/provider_mock.go
@@ -68,9 +68,9 @@ func (_c *MockProvider_Endpoint_Call) RunAndReturn(run func() oauth2.Endpoint) *
 	return _c
 }
 
-// ListRepositories provides a mock function with given fields: ctx, accessToken
-func (_m *MockProvider) ListRepositories(ctx context.Context, accessToken string) ([]v0alpha1.ExternalRepository, error) {
-	ret := _m.Called(ctx, accessToken)
+// ListRepositories provides a mock function with given fields: ctx
+func (_m *MockProvider) ListRepositories(ctx context.Context) ([]v0alpha1.ExternalRepository, error) {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListRepositories")
@@ -78,19 +78,19 @@ func (_m *MockProvider) ListRepositories(ctx context.Context, accessToken string
 
 	var r0 []v0alpha1.ExternalRepository
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) ([]v0alpha1.ExternalRepository, error)); ok {
-		return rf(ctx, accessToken)
+	if rf, ok := ret.Get(0).(func(context.Context) ([]v0alpha1.ExternalRepository, error)); ok {
+		return rf(ctx)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) []v0alpha1.ExternalRepository); ok {
-		r0 = rf(ctx, accessToken)
+	if rf, ok := ret.Get(0).(func(context.Context) []v0alpha1.ExternalRepository); ok {
+		r0 = rf(ctx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]v0alpha1.ExternalRepository)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, accessToken)
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -105,14 +105,13 @@ type MockProvider_ListRepositories_Call struct {
 
 // ListRepositories is a helper method to define mock.On call
 //   - ctx context.Context
-//   - accessToken string
-func (_e *MockProvider_Expecter) ListRepositories(ctx interface{}, accessToken interface{}) *MockProvider_ListRepositories_Call {
-	return &MockProvider_ListRepositories_Call{Call: _e.mock.On("ListRepositories", ctx, accessToken)}
+func (_e *MockProvider_Expecter) ListRepositories(ctx interface{}) *MockProvider_ListRepositories_Call {
+	return &MockProvider_ListRepositories_Call{Call: _e.mock.On("ListRepositories", ctx)}
 }
 
-func (_c *MockProvider_ListRepositories_Call) Run(run func(ctx context.Context, accessToken string)) *MockProvider_ListRepositories_Call {
+func (_c *MockProvider_ListRepositories_Call) Run(run func(ctx context.Context)) *MockProvider_ListRepositories_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -122,7 +121,7 @@ func (_c *MockProvider_ListRepositories_Call) Return(_a0 []v0alpha1.ExternalRepo
 	return _c
 }
 
-func (_c *MockProvider_ListRepositories_Call) RunAndReturn(run func(context.Context, string) ([]v0alpha1.ExternalRepository, error)) *MockProvider_ListRepositories_Call {
+func (_c *MockProvider_ListRepositories_Call) RunAndReturn(run func(context.Context) ([]v0alpha1.ExternalRepository, error)) *MockProvider_ListRepositories_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
**What is this feature?**

Follow-ups to #129741:

- The stored authorization is now cleared whenever a connection is switched to a different provider, host, or OAuth app, so an old token is never sent anywhere it was not issued for.
- OAuth providers now receive the connection's access token when the connection is built, keeping token handling in one place.

| Commit | Addresses |
| --- | --- |
| a2cd10300 | [#129741 (comment)](https://github.com/grafana/grafana/pull/129741#discussion_r3727123891) |
| 414a737f2 | Supporting rework for grafana/grafana-enterprise#12983 |

**Why do we need this feature?**

Keeping an authorization across a provider or app change could replay it against a host it was not issued for.

**Special notes for your reviewer**:

Companion enterprise PR: grafana/grafana-enterprise#12983 (depends on this one).

---
*Description generated by Claude Code*
