### PR TITLE
SQLite: enable WAL mode by default to reduce lock contention

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -279,6 +279,7 @@ cache_mode = private
 # WAL mode significantly reduces "database is locked" errors under concurrent load.
 # Set to false if your database file resides on a network-mounted volume (NFS, EFS, CIFS),
 # as SQLite WAL requires file locking that most network filesystems do not support reliably.
+# When false, Grafana sets journal_mode=DELETE so a DB previously opened with WAL is reverted.
 wal = true
 
 # For "mysql" and "postgres". Lock the database for the migrations, default is true.

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -275,8 +275,11 @@ path = grafana.db
 # For "sqlite3" only. cache mode setting used for connecting to the database
 cache_mode = private
 
-# For "sqlite3" only. Enable/disable Write-Ahead Logging, https://sqlite.org/wal.html. Default is false.
-wal = false
+# For "sqlite3" only. Enable/disable Write-Ahead Logging, https://sqlite.org/wal.html. Default is true.
+# WAL mode significantly reduces "database is locked" errors under concurrent load.
+# Set to false if your database file resides on a network-mounted volume (NFS, EFS, CIFS),
+# as SQLite WAL requires file locking that most network filesystems do not support reliably.
+wal = true
 
 # For "mysql" and "postgres". Lock the database for the migrations, default is true.
 migration_locking = true

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -188,8 +188,11 @@
 # For "sqlite3" only. cache mode setting used for connecting to the database. (private, shared)
 ;cache_mode = private
 
-# For "sqlite3" only. Enable/disable Write-Ahead Logging, https://sqlite.org/wal.html. Default is false.
-;wal = false
+# For "sqlite3" only. Enable/disable Write-Ahead Logging, https://sqlite.org/wal.html. Default is true.
+# WAL mode significantly reduces "database is locked" errors under concurrent load.
+# Set to false if your database file resides on a network-mounted volume (NFS, EFS, CIFS),
+# as SQLite WAL requires file locking that most network filesystems do not support reliably.
+;wal = true
 
 # For "mysql" and "postgres" only. Lock the database for the migrations, default is true.
 ;migration_locking = true

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -192,6 +192,7 @@
 # WAL mode significantly reduces "database is locked" errors under concurrent load.
 # Set to false if your database file resides on a network-mounted volume (NFS, EFS, CIFS),
 # as SQLite WAL requires file locking that most network filesystems do not support reliably.
+# When false, Grafana sets journal_mode=DELETE so a DB previously opened with WAL is reverted.
 ;wal = true
 
 # For "mysql" and "postgres" only. Lock the database for the migrations, default is true.

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -473,7 +473,9 @@ Defaults to `private`.
 
 #### `wal`
 
-For "sqlite3" only. Setting to enable/disable [Write-Ahead Logging](https://sqlite.org/wal.html). The default value is `false` (disabled).
+For "sqlite3" only. Setting to enable/disable [Write-Ahead Logging](https://sqlite.org/wal.html). The default value is `true` (enabled).
+
+WAL mode significantly reduces "database is locked" errors under concurrent load. Set to `false` if your SQLite database file resides on a network-mounted volume (NFS, EFS, CIFS), as WAL requires file locking that most network filesystems do not support reliably.
 
 #### `query_retries`
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -475,7 +475,7 @@ Defaults to `private`.
 
 For "sqlite3" only. Setting to enable/disable [Write-Ahead Logging](https://sqlite.org/wal.html). The default value is `true` (enabled).
 
-WAL mode significantly reduces "database is locked" errors under concurrent load. Set to `false` if your SQLite database file resides on a network-mounted volume (NFS, EFS, CIFS), as WAL requires file locking that most network filesystems do not support reliably.
+WAL mode significantly reduces "database is locked" errors under concurrent load. Set to `false` if your SQLite database file resides on a network-mounted volume (NFS, EFS, CIFS), as WAL requires file locking that most network filesystems do not support reliably. When set to `false`, Grafana explicitly sets `journal_mode=DELETE` so a database that was previously opened with WAL is reverted (SQLite otherwise persists WAL mode on the database file).
 
 #### `query_retries`
 

--- a/pkg/services/sqlstore/database_config.go
+++ b/pkg/services/sqlstore/database_config.go
@@ -117,7 +117,7 @@ func (dbCfg *DatabaseConfig) readConfig(cfg *setting.Cfg) error {
 	dbCfg.IsolationLevel = sec.Key("isolation_level").String()
 
 	dbCfg.CacheMode = sec.Key("cache_mode").MustString("private")
-	dbCfg.WALEnabled = sec.Key("wal").MustBool(false)
+	dbCfg.WALEnabled = sec.Key("wal").MustBool(true)
 	dbCfg.SkipMigrations = sec.Key("skip_migrations").MustBool()
 	dbCfg.EnsureDefaultOrgAndUser = sec.Key("ensure_default_org_and_user").MustBool(true)
 	dbCfg.MigrationLock = sec.Key("migration_locking").MustBool(true)

--- a/pkg/services/sqlstore/database_config.go
+++ b/pkg/services/sqlstore/database_config.go
@@ -202,8 +202,12 @@ func (dbCfg *DatabaseConfig) buildConnectionString(cfg *setting.Cfg, features fe
 
 		cnnstr = fmt.Sprintf("file:%s?cache=%s&mode=rwc", dbCfg.Path, dbCfg.CacheMode)
 
+		// Always set journal_mode explicitly. SQLite persists WAL on the DB file, so
+		// omitting the pragma when wal=false would leave an upgraded DB stuck in WAL.
 		if dbCfg.WALEnabled {
 			cnnstr += "&_journal_mode=WAL"
+		} else {
+			cnnstr += "&_journal_mode=DELETE"
 		}
 
 		cnnstr += buildExtraConnectionString('&', dbCfg.UrlQueryParams)

--- a/pkg/services/sqlstore/database_config_test.go
+++ b/pkg/services/sqlstore/database_config_test.go
@@ -3,6 +3,7 @@ package sqlstore
 import (
 	"errors"
 	"net/url"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -213,4 +214,60 @@ func TestBuildConnectionStringPostgres(t *testing.T) {
 			assert.Equal(t, tc.expectedConnStr, tc.dbCfg.ConnectionString)
 		})
 	}
+}
+
+func TestSQLiteWALDefault(t *testing.T) {
+	t.Run("WAL is enabled by default when not explicitly configured", func(t *testing.T) {
+		// nolint:staticcheck
+		cfg := setting.NewCfgWithFeatures(featuremgmt.WithFeatures().IsEnabledGlobally)
+		sec, err := cfg.Raw.NewSection("database")
+		require.NoError(t, err)
+		_, err = sec.NewKey("type", migrator.SQLite)
+		require.NoError(t, err)
+
+		dbCfg := &DatabaseConfig{}
+		require.NoError(t, dbCfg.readConfig(cfg))
+
+		assert.True(t, dbCfg.WALEnabled, "WAL should be enabled by default for SQLite")
+	})
+
+	t.Run("WAL can be explicitly disabled", func(t *testing.T) {
+		// nolint:staticcheck
+		cfg := setting.NewCfgWithFeatures(featuremgmt.WithFeatures().IsEnabledGlobally)
+		sec, err := cfg.Raw.NewSection("database")
+		require.NoError(t, err)
+		_, err = sec.NewKey("type", migrator.SQLite)
+		require.NoError(t, err)
+		_, err = sec.NewKey("wal", "false")
+		require.NoError(t, err)
+
+		dbCfg := &DatabaseConfig{}
+		require.NoError(t, dbCfg.readConfig(cfg))
+
+		assert.False(t, dbCfg.WALEnabled, "WAL should be disabled when explicitly set to false")
+	})
+
+	t.Run("WAL enabled adds journal_mode to SQLite connection string", func(t *testing.T) {
+		dbCfg := &DatabaseConfig{
+			Type:       migrator.SQLite,
+			Path:       filepath.Join(t.TempDir(), "grafana_test.db"),
+			WALEnabled: true,
+			CacheMode:  "private",
+		}
+		cfg := &setting.Cfg{}
+		require.NoError(t, dbCfg.buildConnectionString(cfg, nil))
+		assert.Contains(t, dbCfg.ConnectionString, "_journal_mode=WAL")
+	})
+
+	t.Run("WAL disabled omits journal_mode from SQLite connection string", func(t *testing.T) {
+		dbCfg := &DatabaseConfig{
+			Type:       migrator.SQLite,
+			Path:       filepath.Join(t.TempDir(), "grafana_test.db"),
+			WALEnabled: false,
+			CacheMode:  "private",
+		}
+		cfg := &setting.Cfg{}
+		require.NoError(t, dbCfg.buildConnectionString(cfg, nil))
+		assert.NotContains(t, dbCfg.ConnectionString, "_journal_mode=WAL")
+	})
 }

--- a/pkg/services/sqlstore/database_config_test.go
+++ b/pkg/services/sqlstore/database_config_test.go
@@ -259,7 +259,7 @@ func TestSQLiteWALDefault(t *testing.T) {
 		assert.Contains(t, dbCfg.ConnectionString, "_journal_mode=WAL")
 	})
 
-	t.Run("WAL disabled omits journal_mode from SQLite connection string", func(t *testing.T) {
+	t.Run("WAL disabled sets journal_mode DELETE to revert persisted WAL", func(t *testing.T) {
 		dbCfg := &DatabaseConfig{
 			Type:       migrator.SQLite,
 			Path:       filepath.Join(t.TempDir(), "grafana_test.db"),
@@ -269,5 +269,6 @@ func TestSQLiteWALDefault(t *testing.T) {
 		cfg := &setting.Cfg{}
 		require.NoError(t, dbCfg.buildConnectionString(cfg, nil))
 		assert.NotContains(t, dbCfg.ConnectionString, "_journal_mode=WAL")
+		assert.Contains(t, dbCfg.ConnectionString, "_journal_mode=DELETE")
 	})
 }


### PR DESCRIPTION
## Summary
- Enable SQLite Write-Ahead Logging (`wal = true`) by default in `defaults.ini`, `sample.ini`, and `database_config.go` (`MustBool(true)`).
- Document the NFS/EFS/CIFS caveat so operators on network-mounted volumes can disable WAL when needed.
- Add unit tests covering the new default, explicit disable, and connection-string journal mode behavior.

Fixes #65115

## Test plan
- [x] `go test ./pkg/services/sqlstore/ -run 'TestSQLiteWALDefault|TestBuildConnectionStringPostgres|TestIntegrationSQLConnectionString' -count=1`
- [ ] Fresh SQLite install without `wal` in grafana.ini starts with WAL enabled (connection string includes `_journal_mode=WAL`)
- [ ] Setting `wal = false` still disables WAL
- [ ] Docs/`sample.ini`/`defaults.ini` all say default is true


