### PR TITLE
Snapshots: Fix deletekey cross-org issue

### DIFF
--- a/pkg/registry/apis/dashboard/snapshot/snapshot_legacy_store.go
+++ b/pkg/registry/apis/dashboard/snapshot/snapshot_legacy_store.go
@@ -62,6 +62,18 @@ func (s *SnapshotLegacyStore) Delete(ctx context.Context, name string, deleteVal
 		return nil, false, err
 	}
 
+	// Snapshots are org-scoped, but lookups by key are global. Reject deletes that
+	// target a snapshot owned by a different org than the caller's namespace, and
+	// return NotFound (rather than a distinct error) so the endpoint does not become
+	// a cross-org existence oracle.
+	ns, err := request.NamespaceInfoFrom(ctx, true)
+	if err != nil {
+		return nil, false, err
+	}
+	if snap.OrgID != ns.OrgID {
+		return nil, false, s.ResourceInfo.NewNotFound(name)
+	}
+
 	// Delete the external one first. The stored ExternalDeleteURL may have an outdated
 	// path format (e.g. created with externalSnapshotsK8SAPIPush in the opposite
 	// state), so each branch extracts the host and rebuilds the URL with the
@@ -101,6 +113,16 @@ func (s *SnapshotLegacyStore) List(ctx context.Context, options *internalversion
 				DeleteKey: deleteKey,
 			})
 			if err != nil {
+				return &dashV0.SnapshotList{}, nil
+			}
+			// Lookups by deleteKey are global; scope the result to the caller's org so
+			// this branch (used by the delete-by-key route) cannot resolve a snapshot
+			// owned by another org.
+			ns, err := request.NamespaceInfoFrom(ctx, true)
+			if err != nil {
+				return nil, err
+			}
+			if snap.OrgID != ns.OrgID {
 				return &dashV0.SnapshotList{}, nil
 			}
 			return &dashV0.SnapshotList{

--- a/pkg/registry/apis/dashboard/snapshot/snapshot_legacy_store_test.go
+++ b/pkg/registry/apis/dashboard/snapshot/snapshot_legacy_store_test.go
@@ -11,12 +11,24 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	k8srequest "k8s.io/apiserver/pkg/endpoints/request"
 
+	authlib "github.com/grafana/authlib/types"
 	dashV0 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
+	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/services/dashboardsnapshots"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 )
+
+// ctxForOrg returns a context whose namespace resolves to the given org, mirroring
+// how the apiserver sets the namespace before reaching the store.
+func ctxForOrg(orgID int64) context.Context {
+	return k8srequest.WithNamespace(context.Background(), authlib.OrgNamespaceFormatter(orgID))
+}
 
 func setExternalSnapshotsK8SAPIPushToggle(t *testing.T, enabled bool) {
 	t.Helper()
@@ -48,6 +60,7 @@ func TestSnapshotLegacyStore_Delete_External(t *testing.T) {
 			Return(&dashboardsnapshots.DashboardSnapshot{
 				Key:               "snap-1",
 				DeleteKey:         deleteKey,
+				OrgID:             1,
 				External:          true,
 				ExternalDeleteURL: externalDeleteURL,
 			}, nil)
@@ -76,7 +89,7 @@ func TestSnapshotLegacyStore_Delete_External(t *testing.T) {
 		// the URL from the domain + deleteKey rather than using it as-is.
 		store := makeStore(t, server.URL+"/apis/dashboard.grafana.app/v0alpha1/namespaces/default/snapshots/delete/"+deleteKey)
 
-		_, _, err := store.Delete(context.Background(), "snap-1", nil, &metav1.DeleteOptions{})
+		_, _, err := store.Delete(ctxForOrg(1), "snap-1", nil, &metav1.DeleteOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, receivedReq)
 		assert.Equal(t, http.MethodDelete, receivedReq.Method)
@@ -96,7 +109,7 @@ func TestSnapshotLegacyStore_Delete_External(t *testing.T) {
 
 		store := makeStore(t, server.URL+"/api/snapshots-delete/"+deleteKey)
 
-		_, _, err := store.Delete(context.Background(), "snap-1", nil, &metav1.DeleteOptions{})
+		_, _, err := store.Delete(ctxForOrg(1), "snap-1", nil, &metav1.DeleteOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, receivedReq)
 		assert.Equal(t, http.MethodGet, receivedReq.Method)
@@ -118,7 +131,7 @@ func TestSnapshotLegacyStore_Delete_External(t *testing.T) {
 		// extract just the domain and rebuild the new k8s path.
 		store := makeStore(t, server.URL+"/api/snapshots-delete/"+deleteKey)
 
-		_, _, err := store.Delete(context.Background(), "snap-1", nil, &metav1.DeleteOptions{})
+		_, _, err := store.Delete(ctxForOrg(1), "snap-1", nil, &metav1.DeleteOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, receivedReq)
 		assert.Equal(t, http.MethodDelete, receivedReq.Method)
@@ -130,7 +143,82 @@ func TestSnapshotLegacyStore_Delete_External(t *testing.T) {
 
 		store := makeStore(t, "not-a-url")
 
-		_, _, err := store.Delete(context.Background(), "snap-1", nil, &metav1.DeleteOptions{})
+		_, _, err := store.Delete(ctxForOrg(1), "snap-1", nil, &metav1.DeleteOptions{})
 		require.Error(t, err)
+	})
+}
+
+// Snapshots are org-scoped but the store looks them up by global key. A caller in
+// one org must not be able to delete a snapshot owned by another org.
+func TestSnapshotLegacyStore_Delete_CrossOrg(t *testing.T) {
+	mockService := dashboardsnapshots.NewMockService(t)
+	mockService.On("GetDashboardSnapshot", mock.Anything, mock.Anything).
+		Return(&dashboardsnapshots.DashboardSnapshot{
+			Key:       "snap-1",
+			DeleteKey: "abc123",
+			OrgID:     1,
+		}, nil)
+	// The delete must never be reached for a cross-org target.
+	mockService.On("DeleteDashboardSnapshot", mock.Anything, mock.Anything).
+		Return(nil).
+		Run(func(mock.Arguments) { t.Fatal("DeleteDashboardSnapshot should not be called for a cross-org snapshot") }).
+		Maybe()
+
+	store := &SnapshotLegacyStore{
+		ResourceInfo: dashV0.SnapshotResourceInfo,
+		Service:      mockService,
+	}
+
+	// Caller is in org 2, snapshot belongs to org 1.
+	_, deleted, err := store.Delete(ctxForOrg(2), "snap-1", nil, &metav1.DeleteOptions{})
+	require.Error(t, err)
+	assert.True(t, apierrors.IsNotFound(err), "expected NotFound, got %v", err)
+	assert.False(t, deleted)
+}
+
+func TestSnapshotLegacyStore_List_DeleteKey(t *testing.T) {
+	const deleteKey = "abc123"
+
+	makeStore := func(t *testing.T) *SnapshotLegacyStore {
+		mockService := dashboardsnapshots.NewMockService(t)
+		mockService.On("GetDashboardSnapshot", mock.Anything, &dashboardsnapshots.GetDashboardSnapshotQuery{DeleteKey: deleteKey}).
+			Return(&dashboardsnapshots.DashboardSnapshot{
+				Key:       "snap-1",
+				DeleteKey: deleteKey,
+				OrgID:     1,
+				Dashboard: simplejson.New(),
+			}, nil)
+		return &SnapshotLegacyStore{
+			ResourceInfo: dashV0.SnapshotResourceInfo,
+			Service:      mockService,
+			Namespacer:   authlib.OrgNamespaceFormatter,
+		}
+	}
+
+	listByDeleteKey := func(ctx context.Context, store *SnapshotLegacyStore) (*dashV0.SnapshotList, error) {
+		obj, err := store.List(ctx, &internalversion.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector("spec.deleteKey", deleteKey),
+		})
+		if err != nil {
+			return nil, err
+		}
+		list, ok := obj.(*dashV0.SnapshotList)
+		require.True(t, ok)
+		return list, nil
+	}
+
+	t.Run("returns the snapshot for a same-org caller", func(t *testing.T) {
+		store := makeStore(t)
+		list, err := listByDeleteKey(ctxForOrg(1), store)
+		require.NoError(t, err)
+		require.Len(t, list.Items, 1)
+		assert.Equal(t, "snap-1", list.Items[0].Name)
+	})
+
+	t.Run("returns an empty list for a cross-org caller", func(t *testing.T) {
+		store := makeStore(t)
+		list, err := listByDeleteKey(ctxForOrg(2), store)
+		require.NoError(t, err)
+		assert.Empty(t, list.Items)
 	})
 }

--- a/pkg/registry/apis/dashboard/snapshot/sub_deletekey.go
+++ b/pkg/registry/apis/dashboard/snapshot/sub_deletekey.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"net/http"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
 
 	dashv0 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
+	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 )
 
 // deleteKeyREST exposes the plaintext deleteKey via a dedicated subresource
@@ -62,6 +64,19 @@ func (r *deleteKeyREST) Connect(ctx context.Context, name string, opts runtime.O
 	snap, ok := obj.(*dashv0.Snapshot)
 	if !ok {
 		return nil, fmt.Errorf("expected Snapshot, got %T", obj)
+	}
+
+	// Snapshots are org-scoped, but lookups by key are global. The store stamps the
+	// snapshot's namespace from its owning org, so reject requests that resolve a
+	// snapshot owned by a different org than the caller's namespace — otherwise the
+	// caller could read another org's secret deleteKey using only the public key.
+	// Return NotFound so the endpoint does not leak cross-org existence.
+	ns, err := request.NamespaceInfoFrom(ctx, true)
+	if err != nil {
+		return nil, err
+	}
+	if snap.Namespace != ns.Value {
+		return nil, apierrors.NewNotFound(dashv0.SnapshotResourceInfo.GroupResource(), name)
 	}
 
 	deleteKey := ""

--- a/pkg/registry/apis/dashboard/snapshot/sub_deletekey_test.go
+++ b/pkg/registry/apis/dashboard/snapshot/sub_deletekey_test.go
@@ -61,7 +61,7 @@ func TestDeleteKeyREST_Connect_SameOrg(t *testing.T) {
 	require.True(t, ok, "expected DashboardSnapshotWithDeleteKey, got %T", responder.obj)
 	assert.Equal(t, "secret-delete-key", result.DeleteKey)
 	// The embedded spec must not carry the deleteKey.
-	assert.Nil(t, result.Snapshot.Spec.DeleteKey)
+	assert.Nil(t, result.Spec.DeleteKey)
 }
 
 func TestDeleteKeyREST_Connect_CrossOrg(t *testing.T) {

--- a/pkg/registry/apis/dashboard/snapshot/sub_deletekey_test.go
+++ b/pkg/registry/apis/dashboard/snapshot/sub_deletekey_test.go
@@ -1,0 +1,77 @@
+package snapshot
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	authlib "github.com/grafana/authlib/types"
+	dashv0 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/services/dashboardsnapshots"
+)
+
+// capturingResponder records the object/error passed by the subresource handler.
+type capturingResponder struct {
+	obj runtime.Object
+	err error
+}
+
+func (r *capturingResponder) Object(_ int, obj runtime.Object) { r.obj = obj }
+func (r *capturingResponder) Error(err error)                  { r.err = err }
+
+func newDeleteKeyREST(t *testing.T) *deleteKeyREST {
+	t.Helper()
+	mockService := dashboardsnapshots.NewMockService(t)
+	mockService.On("GetDashboardSnapshot", mock.Anything, mock.Anything).
+		Return(&dashboardsnapshots.DashboardSnapshot{
+			Key:       "snap-1",
+			DeleteKey: "secret-delete-key",
+			OrgID:     1,
+			Dashboard: simplejson.New(),
+		}, nil)
+
+	store := &SnapshotLegacyStore{
+		ResourceInfo: dashv0.SnapshotResourceInfo,
+		Service:      mockService,
+		Namespacer:   authlib.OrgNamespaceFormatter,
+	}
+	return &deleteKeyREST{getter: store}
+}
+
+func TestDeleteKeyREST_Connect_SameOrg(t *testing.T) {
+	r := newDeleteKeyREST(t)
+	responder := &capturingResponder{}
+
+	// Caller in org 1, snapshot owned by org 1.
+	handler, err := r.Connect(ctxForOrg(1), "snap-1", nil, responder)
+	require.NoError(t, err)
+	require.NotNil(t, handler)
+
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+	require.NoError(t, responder.err)
+
+	result, ok := responder.obj.(*dashv0.DashboardSnapshotWithDeleteKey)
+	require.True(t, ok, "expected DashboardSnapshotWithDeleteKey, got %T", responder.obj)
+	assert.Equal(t, "secret-delete-key", result.DeleteKey)
+	// The embedded spec must not carry the deleteKey.
+	assert.Nil(t, result.Snapshot.Spec.DeleteKey)
+}
+
+func TestDeleteKeyREST_Connect_CrossOrg(t *testing.T) {
+	r := newDeleteKeyREST(t)
+	responder := &capturingResponder{}
+
+	// Caller in org 2, snapshot owned by org 1: must not leak the deleteKey.
+	handler, err := r.Connect(ctxForOrg(2), "snap-1", nil, responder)
+	require.Error(t, err)
+	assert.True(t, apierrors.IsNotFound(err), "expected NotFound, got %v", err)
+	assert.Nil(t, handler)
+	assert.Nil(t, responder.obj)
+}


### PR DESCRIPTION
**What is this feature?**

Fixes a cross-organization access-control gap in dashboard snapshots exposed through the `dashboard.grafana.app/v0alpha1` apiserver.

Snapshots are organization-scoped, but the apiserver resolved them by their global key while ignoring the request namespace (namespace == org), and the authorizer only verified that the caller held the snapshot RBAC action in their own org — not that the target snapshot belonged to that org. As a result, an authenticated user with the snapshot delete permission in one org, holding only the *public* share key of a snapshot in another org, could:

- read that snapshot's secret `deleteKey` via the `deletekey` subresource, and
- delete that snapshot outright via the apiserver `DELETE`, without ever possessing the `deleteKey`.

This change scopes the privileged snapshot lookups to the caller's org and returns `NotFound` on a mismatch (rather than a distinct error, so the endpoints don't become a cross-org existence oracle):

- `SnapshotLegacyStore.Delete` — reject a delete whose target snapshot is owned by a different org.
- `SnapshotLegacyStore.List` `spec.deleteKey` field-selector branch — return an empty result for a cross-org lookup (used by the delete-by-key route).
- `deletekey` subresource — reject the request before exposing the `deleteKey` when the snapshot's namespace doesn't match the caller's.

The deliberately public read paths are left untouched so snapshot sharing keeps working: the plain snapshot `GET` (which already strips the `deleteKey`) and the `dashboard` subresource remain viewable by key, matching the documented "anyone with the link" behavior.

**Why do we need this feature?**

It closes a broken-access-control issue that crossed the organization boundary Grafana enforces everywhere else for snapshots (the legacy REST `DeleteDashboardSnapshot` already rejects cross-org deletes, and the apiserver `List` is already org-scoped). Reading another org's `deleteKey` defeated the guarantee that the `deleteKey` is known only to the snapshot's creator.

**Who is this feature for?**

Operators of any Grafana instance with more than one organization.

**Special notes for your reviewer:**

- Backend-only change; no API shape changes.
- Not behind a feature toggle — this is a security fix to existing behavior, not a new feature.
- No docs changes: the fix aligns behavior with the already-documented org scoping and `deleteKey` guarantees.
- Regression tests added: cross-org `Delete` returns `NotFound` and never calls the underlying delete; the `deletekey` subresource returns `NotFound` cross-org and the `deleteKey` same-org; the `spec.deleteKey` list branch returns an empty list cross-org and the item same-org.
- Verified end-to-end against a local multi-org instance: with the fix, a cross-org `deletekey` read and a cross-org `DELETE` both return 404 (no `deleteKey` leak, snapshot preserved), while the same request from the owning org still succeeds and public snapshot viewing is unaffected.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle. (N/A — security fix)
- [x] The docs are updated, and if this is a notable improvement, it's added to What's New. (N/A — no behavior/docs surface changes)
