### PR TITLE
Datasources: allow plugins to customize health check follow-up

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -610,7 +610,7 @@ export interface TestDataSourceResponse {
   status: string;
   message: string;
   error?: Error;
-  details?: { message?: string; verboseMessage?: string };
+  details?: Record<string, unknown>;
 }
 
 export enum DataQueryErrorType {

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -723,6 +723,40 @@ describe('DataSourceWithBackend', () => {
     });
   });
 
+  describe('testDatasource', () => {
+    test('preserves health details on success so plugins can customize follow-up', async () => {
+      const response: HealthCheckResult = {
+        status: HealthStatus.OK,
+        message: 'Data source is working',
+        details: { followUpMessage: 'Custom next step' },
+      };
+      const { ds } = createMockDatasource();
+      mockDatasourceRequest.mockResolvedValueOnce({ data: response } as FetchResponse);
+
+      await expect(ds.testDatasource()).resolves.toEqual({
+        status: 'success',
+        message: 'Data source is working',
+        details: { followUpMessage: 'Custom next step' },
+      });
+    });
+
+    test('preserves empty followUpMessage so plugins can suppress the default follow-up', async () => {
+      const response: HealthCheckResult = {
+        status: HealthStatus.OK,
+        message: 'Data source is working',
+        details: { followUpMessage: '' },
+      };
+      const { ds } = createMockDatasource();
+      mockDatasourceRequest.mockResolvedValueOnce({ data: response } as FetchResponse);
+
+      await expect(ds.testDatasource()).resolves.toEqual({
+        status: 'success',
+        message: 'Data source is working',
+        details: { followUpMessage: '' },
+      });
+    });
+  });
+
   test('check that queries can skip the query cache', async () => {
     const { mock, ds } = createMockDatasource();
     await firstValueFrom(

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -80,6 +80,9 @@ enum PluginRequestHeaders {
  *
  * If the 'message' key exists, this will be displayed in the error message in DataSourceSettingsPage
  * If the 'verboseMessage' key exists, this will be displayed in the expandable details in the error message in DataSourceSettingsPage
+ * If the 'followUpMessage' key exists (string), it replaces the default success follow-up
+ * ("Next, you can start to visualize data...") on DataSourceSettingsPage. An empty string
+ * suppresses that default follow-up without showing replacement text.
  *
  * @public
  */

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -501,6 +501,7 @@ class DataSourceWithBackend<
         return {
           status: 'success',
           message: res.message,
+          details: res.details,
         };
       }
 

--- a/public/app/features/datasources/components/DataSourceTestingStatus.test.tsx
+++ b/public/app/features/datasources/components/DataSourceTestingStatus.test.tsx
@@ -594,5 +594,46 @@ describe('<DataSourceTestingStatus />', () => {
       expect(screen.getByLabelText('Create a dashboard')).toBeInTheDocument();
       expect(screen.getByLabelText('Explore data')).toBeInTheDocument();
     });
+
+    it('should render custom followUpMessage instead of default links when provided', () => {
+      render(
+        <MemoryRouter>
+          <DataSourceTestingStatus
+            {...successWithDetails({
+              testingStatus: {
+                status: 'success',
+                message: 'Data source is working',
+                details: { message: 'All good', followUpMessage: 'Check our docs for next steps.' },
+              },
+            })}
+          />
+        </MemoryRouter>
+      );
+
+      expect(screen.getByText('Check our docs for next steps.')).toBeInTheDocument();
+      expect(screen.queryByLabelText('Create a dashboard')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Explore data')).not.toBeInTheDocument();
+    });
+
+    it('should suppress default follow-up links when followUpMessage is an empty string', () => {
+      render(
+        <MemoryRouter>
+          <DataSourceTestingStatus
+            {...successWithDetails({
+              testingStatus: {
+                status: 'success',
+                message: 'Data source is working',
+                details: { message: 'All good', followUpMessage: '' },
+              },
+            })}
+          />
+        </MemoryRouter>
+      );
+
+      expect(screen.getByText('All good')).toBeInTheDocument();
+      expect(screen.queryByLabelText('Create a dashboard')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Explore data')).not.toBeInTheDocument();
+      expect(screen.queryByText(/Next, you can start to visualize data/)).not.toBeInTheDocument();
+    });
   });
 });

--- a/public/app/features/datasources/components/DataSourceTestingStatus.tsx
+++ b/public/app/features/datasources/components/DataSourceTestingStatus.tsx
@@ -43,6 +43,12 @@ interface AlertMessageProps extends HTMLAttributes<HTMLDivElement> {
   onSuggestedDashboardsClick?: () => void;
   onDashboardLinkClicked: () => void;
   extensionLinks?: PluginExtensionLink[];
+  /**
+   * Optional custom follow-up from the plugin health check (`details.followUpMessage`).
+   * When a string is set, replaces the default "Next, you can start to visualize data..." text.
+   * An empty string suppresses the default follow-up entirely.
+   */
+  followUpMessage?: string;
 }
 
 const getStyles = (theme: GrafanaTheme2, hasTitle: boolean) => {
@@ -72,12 +78,20 @@ const AlertSuccessMessage = ({
   hasDashboards,
   onSuggestedDashboardsClick,
   onDashboardLinkClicked,
+  followUpMessage,
 }: AlertMessageProps) => {
   const theme = useTheme2();
 
   const hasTitle = Boolean(title);
   const styles = getStyles(theme, hasTitle);
   const canExploreDataSources = contextSrv.hasAccessToExplore();
+
+  if (followUpMessage !== undefined) {
+    if (!followUpMessage) {
+      return null;
+    }
+    return <div className={styles.content}>{followUpMessage}</div>;
+  }
 
   return (
     <div className={styles.content}>
@@ -209,6 +223,10 @@ export function DataSourceTestingStatus({ testingStatus, exploreUrl, dataSource 
   const detailsMessage = testingStatus?.details?.message;
   const detailsVerboseMessage = testingStatus?.details?.verboseMessage;
   const errorDetailsLink = testingStatus?.details?.errorDetailsLink;
+  const followUpMessage =
+    typeof testingStatus?.details?.followUpMessage === 'string'
+      ? testingStatus.details.followUpMessage
+      : undefined;
   const onDashboardLinkClicked = () => {
     trackCreateDashboardClicked({
       grafana_version: config.buildInfo.version,
@@ -270,7 +288,15 @@ export function DataSourceTestingStatus({ testingStatus, exploreUrl, dataSource 
             <>
               {detailsMessage ? <>{String(detailsMessage)}</> : null}
               {severity === 'success' ? (
-                config.featureToggles.suggestedDashboards ? (
+                followUpMessage !== undefined ? (
+                  <AlertSuccessMessage
+                    title={message ?? ''}
+                    exploreUrl={exploreUrl}
+                    dataSourceId={dataSource.uid}
+                    onDashboardLinkClicked={onDashboardLinkClicked}
+                    followUpMessage={followUpMessage}
+                  />
+                ) : config.featureToggles.suggestedDashboards ? (
                   <SuggestedDashboardsLoader
                     datasourceUid={dataSource.uid}
                     sourceEntryPoint={SOURCE_ENTRY_POINTS.DATASOURCE_PAGE_SUCCESS_BANNER}


### PR DESCRIPTION
**What is this feature?**

Allows data source plugins to customize or suppress the hardcoded success follow-up message ("Next, you can start to visualize data by building a dashboard...") after a health check.

Plugins can return `followUpMessage` in health check `details` / `JSONDetails`:
- A non-empty string replaces the default dashboard/Explore next-steps text
- An empty string suppresses the default follow-up entirely
- Omitting the field keeps the existing behavior

**Why do we need this feature?**

Some data sources need extra setup after a successful connection (e.g. building a data model) before dashboards/Explore are useful. The default follow-up is misleading in those cases, and plugins currently cannot override or hide it.

**Who is this feature for?**

Data source plugin authors and end users of plugins that require post-connection setup.

**Which issue(s) does this PR fix?**:

Fixes #118379

**Special notes for your reviewer:**

Uses the existing flexible `details` payload (`HealthCheckResultDetails` / `JSONDetails`), so no plugin SDK or proto changes are required. Example for backend plugins:

```go
return &backend.CheckHealthResult{
    Status:  backend.HealthStatusOk,
    Message: "Successfully connected",
    JSONDetails: []byte(`{"followUpMessage":"Next, build your data model in the Data Model tab."}`),
}
```

**Tests**

- `yarn jest public/app/features/datasources/components/DataSourceTestingStatus.test.tsx --watchAll=false`

