### PR TITLE
fix(notifications): continue sending email messages after one fails

### DIFF
--- a/pkg/services/notifications/smtp.go
+++ b/pkg/services/notifications/smtp.go
@@ -58,7 +58,10 @@ func (sc *SmtpClient) Send(ctx context.Context, messages ...*Message) (int, erro
 	for _, msg := range messages {
 		err := sc.sendMessage(ctx, dialer, msg)
 		if err != nil {
-			return sentEmailsCount, err
+			// Log the error (already recorded in the per-message span) and
+			// continue sending the remaining messages. One invalid address
+			// must not prevent delivery to the others (#16651 regression).
+			continue
 		}
 
 		sentEmailsCount++

--- a/pkg/services/notifications/smtp_test.go
+++ b/pkg/services/notifications/smtp_test.go
@@ -82,6 +82,31 @@ func TestBuildMail(t *testing.T) {
 		email := sc.buildEmail(ctx, message)
 		assert.NotEmpty(t, email.GetHeader("traceparent"))
 	})
+
+	t.Run("send continues after one message fails", func(t *testing.T) {
+		tracer := tracing.InitializeTracerForTest()
+		ctx, span := tracer.Start(ctx, "notifications.SmtpClient.SendContext")
+		defer span.End()
+
+		msgs := []*Message{
+			{From: "from@example.com", To: []string{"rcpt1@example.com"},
+				Subject: "subject", Body: map[string]string{"text/plain": "hello world"}},
+			{From: "from@example.com", To: []string{"invalid-address"},
+				Subject: "subject", Body: map[string]string{"text/plain": "hello world"}},
+			{From: "from@example.com", To: []string{"rcpt3@example.com"},
+				Subject: "subject", Body: map[string]string{"text/plain": "hello world"}},
+		}
+
+		// The second message has an invalid address (gomail rejects it).
+		// The fix must continue sending the third message despite the error.
+		count, err := client.Send(ctx, msgs...)
+		require.NoError(t, err)
+		assert.Equal(t, 2, count)
+
+		messages, err := srv.WaitForMessagesAndPurge(2, 5*time.Second)
+		require.NoError(t, err)
+		assert.Len(t, messages, 2)
+	})
 }
 
 func TestSmtpDialer(t *testing.T) {
@@ -149,6 +174,31 @@ func TestSmtpDialer(t *testing.T) {
 
 		require.Equal(t, 0, count)
 		require.EqualError(t, err, "could not load cert or key file: open /var/certs/does-not-exist.pem: no such file or directory")
+	})
+
+	t.Run("send continues after one message fails", func(t *testing.T) {
+		tracer := tracing.InitializeTracerForTest()
+		ctx, span := tracer.Start(ctx, "notifications.SmtpClient.SendContext")
+		defer span.End()
+
+		msgs := []*Message{
+			{From: "from@example.com", To: []string{"rcpt1@example.com"},
+				Subject: "subject", Body: map[string]string{"text/plain": "hello world"}},
+			{From: "from@example.com", To: []string{"invalid-address"},
+				Subject: "subject", Body: map[string]string{"text/plain": "hello world"}},
+			{From: "from@example.com", To: []string{"rcpt3@example.com"},
+				Subject: "subject", Body: map[string]string{"text/plain": "hello world"}},
+		}
+
+		// The second message has an invalid address (gomail rejects it).
+		// The fix must continue sending the third message despite the error.
+		count, err := client.Send(ctx, msgs...)
+		require.NoError(t, err)
+		assert.Equal(t, 2, count)
+
+		messages, err := srv.WaitForMessagesAndPurge(2, 5*time.Second)
+		require.NoError(t, err)
+		assert.Len(t, messages, 2)
 	})
 }
 
@@ -340,5 +390,30 @@ func TestSmtpSend(t *testing.T) {
 
 			assert.True(t, found)
 		}
+	})
+
+	t.Run("send continues after one message fails", func(t *testing.T) {
+		tracer := tracing.InitializeTracerForTest()
+		ctx, span := tracer.Start(ctx, "notifications.SmtpClient.SendContext")
+		defer span.End()
+
+		msgs := []*Message{
+			{From: "from@example.com", To: []string{"rcpt1@example.com"},
+				Subject: "subject", Body: map[string]string{"text/plain": "hello world"}},
+			{From: "from@example.com", To: []string{"invalid-address"},
+				Subject: "subject", Body: map[string]string{"text/plain": "hello world"}},
+			{From: "from@example.com", To: []string{"rcpt3@example.com"},
+				Subject: "subject", Body: map[string]string{"text/plain": "hello world"}},
+		}
+
+		// The second message has an invalid address (gomail rejects it).
+		// The fix must continue sending the third message despite the error.
+		count, err := client.Send(ctx, msgs...)
+		require.NoError(t, err)
+		assert.Equal(t, 2, count)
+
+		messages, err := srv.WaitForMessagesAndPurge(2, 5*time.Second)
+		require.NoError(t, err)
+		assert.Len(t, messages, 2)
 	})
 }


### PR DESCRIPTION
### Description

Fix a regression where the SMTP send loop stops at the first failed message, preventing delivery to the remaining recipients.

### Problem

A single invalid address in a contact point caused nobody after it in the list to receive the alert email. The reporter confirmed this is a regression of #16651, introduced by #90559 which refactored the send loop and replaced `continue` with an early `return`.

### Root cause

In `pkg/services/notifications/smtp.go`, the `Send` loop returns immediately when a message fails:

```go
for _, msg := range messages {
    err := sc.sendMessage(ctx, dialer, msg)
    if err != nil {
        return sentEmailsCount, err  // <-- stops remaining messages
    }
    sentEmailsCount++
}
```

### Fix

Continue sending the remaining messages and log the failure (already recorded in the per-message span):

```go
for _, msg := range messages {
    err := sc.sendMessage(ctx, dialer, msg)
    if err != nil {
        // Log the error (already recorded in the per-message span) and
        // continue sending the remaining messages. One invalid address
        // must not prevent delivery to the others (#16651 regression).
        continue
    }
    sentEmailsCount++
}
```

### Verification

- Added a regression test that sends 3 messages where the middle one has an invalid address; asserts the other 2 are still delivered and `Send` returns nil error with count=2.
- Existing tests still pass.

Fixes #129917