### PR TITLE
fix(gitsync): use signer identity as commit author when configured

### DIFF
--- a/apps/provisioning/pkg/repository/git/repository.go
+++ b/apps/provisioning/pkg/repository/git/repository.go
@@ -968,7 +968,7 @@ func (r *gitRepository) ensureBranchExists(ctx context.Context, branchName strin
 // falling back to default Grafana signature. The committer is overridden by
 // spec.commit.signerName/Email when set; that identity must match the signing
 // key for providers to mark commits as Verified. The author is overridden by
-// the signer identity when spec.commit.signerIsAuthor is true.
+// the signer identity when configured.
 func (r *gitRepository) createSignature(ctx context.Context) (nanogit.Author, nanogit.Committer) {
 	author := nanogit.Author{
 		Name:  "Grafana",
@@ -997,10 +997,14 @@ func (r *gitRepository) createSignature(ctx context.Context) (nanogit.Author, na
 	if commit := r.config.Spec.Commit; commit != nil && (commit.SignerName != "" || commit.SignerEmail != "") {
 		committer.Name = cmp.Or(commit.SignerName, "Grafana")
 		committer.Email = cmp.Or(commit.SignerEmail, "noreply@grafana.com")
-		if commit.SignerIsAuthor {
-			author.Name = committer.Name
-			author.Email = committer.Email
-		}
+		// The signer identity is the user's real identity. When a signer
+		// name/email is configured for commit signing, use it for the author
+		// as well so that the commit author reflects the user instead of the
+		// hardcoded "Grafana <noreply@grafana.com>" default. Git providers with
+		// pre-receive hooks that validate the commit author (e.g. GitLab org
+		// membership) otherwise reject the push.
+		author.Name = committer.Name
+		author.Email = committer.Email
 	}
 
 	return author, committer

--- a/apps/provisioning/pkg/repository/git/repository.go
+++ b/apps/provisioning/pkg/repository/git/repository.go
@@ -968,7 +968,7 @@ func (r *gitRepository) ensureBranchExists(ctx context.Context, branchName strin
 // falling back to default Grafana signature. The committer is overridden by
 // spec.commit.signerName/Email when set; that identity must match the signing
 // key for providers to mark commits as Verified. The author is overridden by
-// the signer identity when configured.
+// the signer identity when configured and no context author override is set.
 func (r *gitRepository) createSignature(ctx context.Context) (nanogit.Author, nanogit.Committer) {
 	author := nanogit.Author{
 		Name:  "Grafana",
@@ -977,7 +977,9 @@ func (r *gitRepository) createSignature(ctx context.Context) (nanogit.Author, na
 	}
 
 	// Use signature from context if available
+	contextAuthorProvided := false
 	if sig := repository.GetAuthorSignature(ctx); sig != nil {
+		contextAuthorProvided = true
 		if sig.Name != "" {
 			author.Name = sig.Name
 		}
@@ -997,14 +999,17 @@ func (r *gitRepository) createSignature(ctx context.Context) (nanogit.Author, na
 	if commit := r.config.Spec.Commit; commit != nil && (commit.SignerName != "" || commit.SignerEmail != "") {
 		committer.Name = cmp.Or(commit.SignerName, "Grafana")
 		committer.Email = cmp.Or(commit.SignerEmail, "noreply@grafana.com")
-		// The signer identity is the user's real identity. When a signer
-		// name/email is configured for commit signing, use it for the author
-		// as well so that the commit author reflects the user instead of the
-		// hardcoded "Grafana <noreply@grafana.com>" default. Git providers with
-		// pre-receive hooks that validate the commit author (e.g. GitLab org
-		// membership) otherwise reject the push.
-		author.Name = committer.Name
-		author.Email = committer.Email
+		// When a signer name/email is configured for commit signing, use it
+		// for the author as well so that the commit author reflects the user
+		// instead of the hardcoded "Grafana <noreply@grafana.com>" default.
+		// Git providers with pre-receive hooks that validate the commit author
+		// (e.g. GitLab org membership) otherwise reject the push.
+		// A context-based author override (set by the API caller) takes
+		// precedence and is not overwritten.
+		if !contextAuthorProvided {
+			author.Name = committer.Name
+			author.Email = committer.Email
+		}
 	}
 
 	return author, committer

--- a/apps/provisioning/pkg/repository/git/repository_test.go
+++ b/apps/provisioning/pkg/repository/git/repository_test.go
@@ -2190,7 +2190,7 @@ func TestGitRepository_createSignature(t *testing.T) {
 		require.True(t, committer.Time.Before(after.Add(time.Second)))
 	})
 
-	t.Run("should set committer from spec while author stays default", func(t *testing.T) {
+	t.Run("should set author and committer from signer identity when configured", func(t *testing.T) {
 		repo := &gitRepository{
 			config: &provisioning.Repository{
 				Spec: provisioning.RepositorySpec{
@@ -2205,13 +2205,13 @@ func TestGitRepository_createSignature(t *testing.T) {
 
 		author, committer := repo.createSignature(context.Background())
 
-		require.Equal(t, "Grafana", author.Name)
-		require.Equal(t, "noreply@grafana.com", author.Email)
+		require.Equal(t, "Bot Signer", author.Name)
+		require.Equal(t, "signer@example.com", author.Email)
 		require.Equal(t, "Bot Signer", committer.Name)
 		require.Equal(t, "signer@example.com", committer.Email)
 	})
 
-	t.Run("should default committer email when only signer name is set", func(t *testing.T) {
+	t.Run("should default author and committer email when only signer name is set", func(t *testing.T) {
 		repo := &gitRepository{
 			config: &provisioning.Repository{
 				Spec: provisioning.RepositorySpec{
@@ -2223,7 +2223,7 @@ func TestGitRepository_createSignature(t *testing.T) {
 
 		author, committer := repo.createSignature(context.Background())
 
-		require.Equal(t, "Grafana", author.Name)
+		require.Equal(t, "Bot Signer", author.Name)
 		require.Equal(t, "Bot Signer", committer.Name)
 		require.Equal(t, "noreply@grafana.com", committer.Email)
 	})


### PR DESCRIPTION
### Description

Fix a bug where the Git commit author is hardcoded to "Grafana <noreply@grafana.com>" even when a signer name/email is configured for commit signing. Git providers with pre-receive hooks that validate the commit author (e.g. GitLab org membership) reject the push because the author does not match the signing identity.

### Problem

When a user configures SSH commit signing with a custom signer name and email, the `createSignature` function updates only the **committer** to the signer identity, while the **author** remains the hardcoded default "Grafana <noreply@grafana.com>". The `signerIsAuthor` option exists but is opt-in, and users are often unaware of it.

In `apps/provisioning/pkg/repository/git/repository.go`:

```go
committer := nanogit.Committer(author)
if commit := r.config.Spec.Commit; commit != nil && (commit.SignerName != "" || commit.SignerEmail != "") {
    committer.Name = cmp.Or(commit.SignerName, "Grafana")
    committer.Email = cmp.Or(commit.SignerEmail, "noreply@grafana.com")
    if commit.SignerIsAuthor {
        author.Name = committer.Name
        author.Email = committer.Email
    }
}
```

### Fix

When a signer name/email is configured, the author now also uses the signer identity. A context-based author override (set by the API caller) still takes precedence and is not overwritten.

```go
if !contextAuthorProvided {
    author.Name = committer.Name
    author.Email = committer.Email
}
```

Context-based author overrides (`repository.WithAuthorSignature`) continue to work as before — they take precedence over the signer identity.

### Verification

- Updated `TestGitRepository_createSignature` test cases to reflect the new behaviour
- The "should keep committer independent from a context author override" test still passes (context author takes precedence)

Fixes #129908