### PR TITLE
Variables: show required markers on edit form fields

### DIFF
--- a/public/app/features/dashboard-scene/settings/variables/VariableEditableElement.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableEditableElement.tsx
@@ -289,6 +289,7 @@ function VariableNameInput({ variable, autoFocus }: { variable: SceneVariable; a
         invalid={!!nameError}
         error={nameError}
         noMargin={false}
+        required
       >
         <Input
           id={id}

--- a/public/app/features/dashboard-scene/settings/variables/components/CustomVariableForm.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/CustomVariableForm.tsx
@@ -53,7 +53,7 @@ export function CustomVariableForm({
       <VariableTextAreaField
         // we don't use a controlled component so we make sure the textarea content is cleared when changing format by providing a key
         key={valuesFormat}
-        name=""
+        name={t('dashboard-scene.custom-variable-form.name-values', 'Values')}
         placeholder={
           valuesFormat === 'json'
             ? // eslint-disable-next-line @grafana/i18n/no-untranslated-strings

--- a/public/app/features/dashboard-scene/settings/variables/components/QueryEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/QueryEditor.tsx
@@ -1,10 +1,10 @@
 import { useMemo } from 'react';
 
 import { type DataSourceApi, LoadingState, type TimeRange } from '@grafana/data';
-import { Trans } from '@grafana/i18n';
+import { t } from '@grafana/i18n';
 import { getTemplateSrv } from '@grafana/runtime';
 import { type QueryVariable } from '@grafana/scenes';
-import { Text, Box } from '@grafana/ui';
+import { Box, Field } from '@grafana/ui';
 import { isLegacyQueryEditor, isQueryEditor } from 'app/features/variables/guard';
 import { type VariableQueryEditorType } from 'app/features/variables/types';
 
@@ -43,20 +43,15 @@ export function QueryEditor({
 
   if (VariableQueryEditor && isLegacyQueryEditor(VariableQueryEditor, datasource)) {
     return (
-      <Box marginBottom={2}>
-        <Text variant="bodySmall" weight="medium">
-          <Trans i18nKey="dashboard-scene.query-editor.query">Query</Trans>
-        </Text>
-        <Box marginTop={0.25}>
-          <VariableQueryEditor
-            key={datasource.uid}
-            datasource={datasource}
-            query={queryWithDefaults}
-            templateSrv={getTemplateSrv()}
-            onChange={onLegacyQueryChange}
-          />
-        </Box>
-      </Box>
+      <Field label={t('dashboard-scene.query-editor.query', 'Query')} required>
+        <VariableQueryEditor
+          key={datasource.uid}
+          datasource={datasource}
+          query={queryWithDefaults}
+          templateSrv={getTemplateSrv()}
+          onChange={onLegacyQueryChange}
+        />
+      </Field>
     );
   }
 

--- a/public/app/features/dashboard-scene/settings/variables/components/QueryVariableForm.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/QueryVariableForm.tsx
@@ -129,6 +129,7 @@ export function QueryVariableEditorForm({
       <Field
         label={t('dashboard-scene.query-variable-editor-form.label-data-source', 'Data source')}
         htmlFor="data-source-picker"
+        required
       >
         <DataSourcePicker current={datasourceRef} onChange={datasourceChangeHandler} variables={true} width={30} />
       </Field>

--- a/public/app/features/dashboard-scene/settings/variables/components/VariableTextAreaField.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/VariableTextAreaField.tsx
@@ -38,7 +38,7 @@ export function VariableTextAreaField({
   const id = useId();
 
   return (
-    <Field label={name} description={description} htmlFor={id} noMargin={noMargin}>
+    <Field label={name} description={description} htmlFor={id} noMargin={noMargin} required={required}>
       <TextArea
         id={id}
         rows={2}

--- a/public/app/features/dashboard-scene/settings/variables/components/VariableTextField.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/VariableTextField.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+
+import { VariableTextField } from './VariableTextField';
+
+describe('VariableTextField', () => {
+  it('marks required fields with an asterisk on the label', () => {
+    render(<VariableTextField name="Name" required defaultValue="" />);
+
+    expect(screen.getByText('Name *')).toBeInTheDocument();
+  });
+
+  it('does not mark optional fields as required', () => {
+    render(<VariableTextField name="Label" defaultValue="" />);
+
+    expect(screen.getByText('Label')).toBeInTheDocument();
+    expect(screen.queryByText('Label *')).not.toBeInTheDocument();
+  });
+});

--- a/public/app/features/dashboard-scene/settings/variables/components/VariableTextField.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/VariableTextField.tsx
@@ -40,7 +40,7 @@ export function VariableTextField({
   const id = useId(name);
 
   return (
-    <Field label={name} description={description} invalid={invalid} error={error} htmlFor={id}>
+    <Field label={name} description={description} invalid={invalid} error={error} htmlFor={id} required={required}>
       <Input
         type="text"
         id={id}

--- a/public/app/features/dashboard-scene/settings/variables/editors/CustomVariableEditor/ModalEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/CustomVariableEditor/ModalEditor.tsx
@@ -5,7 +5,7 @@ import { type CustomVariableModel } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
 import { CustomVariable } from '@grafana/scenes';
-import { Button, FieldValidationMessage, Modal, Stack, TextArea } from '@grafana/ui';
+import { Button, Field, FieldValidationMessage, Modal, Stack, TextArea } from '@grafana/ui';
 import { dashboardEditActions } from 'app/features/dashboard-scene/sidebar/shared';
 
 import { ValuesFormatSelector } from '../../components/CustomVariableForm';
@@ -39,22 +39,24 @@ export function ModalEditor(props: ModalEditorProps) {
       <Stack direction="column" gap={2}>
         <ValuesFormatSelector valuesFormat={valuesFormat} onValuesFormatChange={onValuesFormatChange} />
         <div>
-          <TextArea
-            id={valuesFormat}
-            key={valuesFormat}
-            rows={4}
-            defaultValue={query}
-            onChange={onQueryChange}
-            placeholder={
-              valuesFormat === 'json'
-                ? // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
-                  '[{ "text":"text1", "value":"val1", "propA":"a1", "propB":"b1" },\n{ "text":"text2", "value":"val2", "propA":"a2", "propB":"b2" }]'
-                : // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
-                  '1, 10, mykey : myvalue, myvalue, escaped\,value'
-            }
-            required
-            data-testid={selectors.pages.Dashboard.Settings.Variables.Edit.CustomVariable.customValueInput}
-          />
+          <Field label={t('dashboard-scene.custom-variable-form.name-values', 'Values')} required>
+            <TextArea
+              id={valuesFormat}
+              key={valuesFormat}
+              rows={4}
+              defaultValue={query}
+              onChange={onQueryChange}
+              placeholder={
+                valuesFormat === 'json'
+                  ? // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
+                    '[{ "text":"text1", "value":"val1", "propA":"a1", "propB":"b1" },\n{ "text":"text2", "value":"val2", "propA":"a2", "propB":"b2" }]'
+                  : // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
+                    '1, 10, mykey : myvalue, myvalue, escaped\,value'
+              }
+              required
+              data-testid={selectors.pages.Dashboard.Settings.Variables.Edit.CustomVariable.customValueInput}
+            />
+          </Field>
           {queryValidationError && <FieldValidationMessage>{queryValidationError.message}</FieldValidationMessage>}
         </div>
         <div>

--- a/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/QueryVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/QueryVariableEditor.tsx
@@ -217,6 +217,7 @@ export function Editor({ variable, hideRefresh, hideStaticOptions, hidePreview }
         label={t('dashboard-scene.query-variable-editor-form.label-target-data-source', 'Target data source')}
         htmlFor="data-source-picker"
         noMargin
+        required
       >
         <DataSourcePicker current={datasourceRef} onChange={onDataSourceChange} variables={true} width={30} />
       </Field>


### PR DESCRIPTION
## Summary
- Template variable edit forms had `required` on inputs but not on `Field`, so the visual required asterisk never appeared (WCAG 3.3.2 / MAS 258655).
- Pass `required` through `VariableTextField` / `VariableTextAreaField`, Name (sidebar), Query, Data source, and Custom Values labels.
- Add unit coverage for the Name field asterisk.

Fixes #73397

## Test plan
- [x] `yarn jest --no-watch` on `VariableTextField`, `CustomVariableForm`, `QueryVariableForm`, `ModalEditor`, `VariableEditableElement`
- [ ] Dashboard → Settings → Variables → New: confirm **Name *** shows an asterisk
- [ ] Query variable: confirm **Data source *** and **Query *** (legacy query editor path)
- [ ] Custom variable: confirm **Values ***

