### PR TITLE
docs(graph): alpha graph frames meta proposal

### DIFF
--- a/packages/grafana-data/src/types/data.ts
+++ b/packages/grafana-data/src/types/data.ts
@@ -32,6 +32,13 @@ export const preferredVisualizationTypes = [
 export type PreferredVisualisationType = (typeof preferredVisualizationTypes)[number];
 
 /**
+ * @alpha - experimental
+ * Explicit frame level mappings for graph edges keys
+ * Must be valid field names (not display names)
+ */
+export type GraphMeta = { sourceKey?: string; targetKey?: string };
+
+/**
  * Should be kept in sync with https://github.com/grafana/grafana-plugin-sdk-go/blob/main/data/frame_meta.go
  * @public
  */
@@ -45,7 +52,7 @@ export interface QueryResultMeta {
   typeVersion?: [number, number];
 
   /** DatasSource Specific Values */
-  custom?: Record<string, any>;
+  custom?: Record<string, any> & GraphMeta;
 
   /** Stats */
   stats?: QueryResultMetaStat[];

--- a/packages/grafana-data/src/types/dataFrameTypes.ts
+++ b/packages/grafana-data/src/types/dataFrameTypes.ts
@@ -44,4 +44,33 @@ export enum DataFrameType {
    *  xMin, xMax, count
    */
   Histogram = 'histogram',
+
+  /**
+   * Legacy graph frame edges
+   */
+  GraphEdgesLong = 'graph-edges-long',
+  /**
+   * Legacy graph frame nodes
+   */
+  GraphNodesLong = 'graph-nodes-long',
+  /**
+   * @alpha - experimental
+   * Proposed graph frame edges
+   */
+  GraphEdgesWide = 'graph-edges-wide',
+  /**
+   * @alpha - experimental
+   * Proposed graph frame nodes
+   */
+  GraphNodesWide = 'graph-nodes-wide',
+  /**
+   * @alpha - experimental
+   * Proposed mulit-frame graph nodes
+   */
+  GraphNodesMulti = 'graph-nodes-multi',
+  /**
+   * @alpha - experimental
+   * Proposed multi-frame graph edges
+   */
+  GraphEdgesMulti = 'graph-edges-multi',
 }


### PR DESCRIPTION
**What is this feature?**

Alpha proposal for graph frame meta

**Why do we need this feature?**

To move towards public data plane spec for graph-wide and graph-multi as long-term replacement for graph-long which does not support field overrides.

**Who is this feature for?**

The future

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
