### PR TITLE
Alerting: Revert a staged import configuration

### DIFF
--- a/public/app/features/alerting/unified/api/convertToGMAApi.ts
+++ b/public/app/features/alerting/unified/api/convertToGMAApi.ts
@@ -6,10 +6,6 @@ import { alertingApi } from './alertingApi';
 
 export const convertToGMAApi = alertingApi.injectEndpoints({
   endpoints: (build) => ({
-    /**
-     * Convert Prometheus/Mimir rules to Grafana-managed alert rules
-     * POST /api/convert/prometheus/config/v1/rules
-     */
     convertToGMA: build.mutation<
       void,
       {
@@ -48,25 +44,17 @@ export const convertToGMAApi = alertingApi.injectEndpoints({
       }),
     }),
 
-    /**
-     * Import Alertmanager config (contact points, policies, templates, time intervals) to Grafana.
-     * POST /api/convert/api/v1/alerts
-     *
-     * Supports force-replace via X-Grafana-Alerting-Config-Force-Replace header
-     * to overwrite an existing config with a different identifier.
-     */
+    /** Stage an Alertmanager config (contact points, policies, templates, time intervals) in Grafana. */
     convertAlertmanagerConfig: build.mutation<
       ConvertAlertmanagerResponse,
       {
-        /** Alertmanager config as JSON string or YAML string */
         alertmanagerConfig: string;
-        /** Template files map */
         templateFiles?: Record<string, string>;
-        /** Configuration identifier - used as the extra config name (e.g., "prometheus-prod") */
+        /** Names the staged extra config, and the managed policy tree it produces (e.g. "prometheus-prod"). */
         configIdentifier: string;
-        /** If true, forcibly replace existing configuration regardless of identifier */
+        /** Overwrite an existing staged config even when its identifier differs. */
         forceReplace?: boolean;
-        /** If true, merge the imported config into the main Grafana config as editable resources */
+        /** Merge straight into the live config as editable resources instead of only staging. */
         promote?: boolean;
       }
     >({
@@ -78,33 +66,28 @@ export const convertToGMAApi = alertingApi.injectEndpoints({
           template_files: templateFiles,
         },
         headers: {
-          // The config identifier is the name of the extra configuration (policy tree name)
           'X-Grafana-Alerting-Config-Identifier': configIdentifier,
           ...(forceReplace ? { 'X-Grafana-Alerting-Config-Force-Replace': 'true' } : {}),
           ...(promote ? { 'X-Grafana-Alerting-Promote': 'true' } : {}),
         },
       }),
+      // Importing writes into the AM config (staged imports land on its extra_config), so the config
+      // query has to refetch — otherwise the Import tab the wizard redirects to renders its cached,
+      // pre-import config and shows the empty state instead of the freshly staged one.
+      invalidatesTags: ['AlertmanagerConfiguration'],
     }),
 
     /**
-     * Dry-run validation for Alertmanager config import.
-     * Uses the same endpoint as the real import but with the X-Grafana-Alerting-Dry-Run header.
-     * Validates the config, checks for conflicts, and returns info about resources that would be renamed
-     * without actually saving anything.
-     *
-     * POST /api/convert/api/v1/alerts (with X-Grafana-Alerting-Dry-Run: true)
-     * Returns 200 OK on success (vs 202 Accepted for real imports)
+     * Validate an Alertmanager config without saving it, reporting conflicts and resources that would be
+     * renamed. Same endpoint as the real import, distinguished only by the dry-run header.
      */
     dryRunAlertmanagerConfig: build.mutation<
       ConvertAlertmanagerResponse,
       {
-        /** Alertmanager config as JSON string or YAML string */
         alertmanagerConfig: string;
-        /** Template files map */
         templateFiles?: Record<string, string>;
-        /** Configuration identifier - used as the extra config name */
         configIdentifier: string;
-        /** If true, validate the merge into the main config (and the caller's permissions) */
+        /** Also validate the merge into the live config, and the caller's permissions for it. */
         promote?: boolean;
       }
     >({
@@ -126,6 +109,19 @@ export const convertToGMAApi = alertingApi.injectEndpoints({
           ...(promote ? { 'X-Grafana-Alerting-Promote': 'true' } : {}),
         },
       }),
+    }),
+
+    /** Discard a staged Alertmanager config. The live Grafana Alertmanager config is not affected. */
+    deleteStagedAlertmanagerConfig: build.mutation<void, { configIdentifier: string }>({
+      query: ({ configIdentifier }) => ({
+        url: `/api/convert/api/v1/alerts`,
+        method: 'DELETE',
+        headers: {
+          'X-Grafana-Alerting-Config-Identifier': configIdentifier,
+        },
+      }),
+      // The staged config lives inside the AM config, so refetching it removes the staged card.
+      invalidatesTags: ['AlertmanagerConfiguration'],
     }),
   }),
 });

--- a/public/app/features/alerting/unified/components/settings/AutoSyncConfiguration.test.tsx
+++ b/public/app/features/alerting/unified/components/settings/AutoSyncConfiguration.test.tsx
@@ -82,6 +82,8 @@ const edgeUi = {
   orphanWarning: byText(/is not available\. Disable sync or restore the datasource to continue/i),
   noDatasourcesMessage: byText(/no mimir or cortex datasources available/i),
   addMimirDatasourceLink: byRole('link', { name: /add mimir datasource/i }),
+  stagedConflictWarning: byText(/currently occupies that slot/i),
+  stagedConflictActiveTitle: byText(/auto-sync is not running/i),
 };
 
 describe('AutoSyncConfiguration — basic states (cases 1–3)', () => {
@@ -216,5 +218,52 @@ describe('AutoSyncConfiguration — edge-case states (cases 5–8)', () => {
     expect(ui.disableSyncButton.get()).toBeInTheDocument();
     // Save stays visible in orphan-uid so the admin can recover by picking a real datasource.
     expect(ui.saveButton.get()).toBeInTheDocument();
+  });
+});
+
+describe('AutoSyncConfiguration — staged configuration conflict', () => {
+  it('blocks enabling sync and explains why while a manual import is staged', async () => {
+    setupAdminConfigGet(server, { alertmanagersChoice: AlertmanagerChoice.Internal });
+    setupDatasourcesEndpoint(server, [MIMIR_DS_PAYLOAD]);
+    registerMimirDataSources();
+
+    render(<AutoSyncConfiguration stagedConfigIdentifier="prometheus-prod" />);
+
+    expect(await ui.notConfiguredBadge.find()).toBeInTheDocument();
+    expect(edgeUi.stagedConflictWarning.get()).toBeInTheDocument();
+    expect(ui.saveButton.get()).toBeDisabled();
+  });
+
+  it('reports that sync is not running when a foreign import outlives an enabled sync', async () => {
+    setupAdminConfigGet(server, {
+      alertmanagersChoice: AlertmanagerChoice.Internal,
+      external_alertmanager_uid: MIMIR_DS_UID,
+    });
+    setupDatasourcesEndpoint(server, [MIMIR_DS_PAYLOAD]);
+    registerMimirDataSources();
+
+    render(<AutoSyncConfiguration stagedConfigIdentifier="prometheus-prod" />);
+
+    expect(await edgeUi.stagedConflictActiveTitle.find()).toBeInTheDocument();
+    // Disabling must stay reachable — never trap the user in the broken state.
+    expect(ui.disableSyncButton.get()).toBeEnabled();
+  });
+
+  // Disabling sync leaves the staged config behind, so re-enabling the same datasource must not be blocked
+  // by the config the syncer itself wrote — it will simply overwrite its own entry.
+  it('allows re-enabling the datasource whose UID matches the staged identifier', async () => {
+    setupStatefulAdminConfig(server, postState);
+    setupDatasourcesEndpoint(server, [MIMIR_DS_PAYLOAD]);
+    registerMimirDataSources();
+
+    const { user } = render(<AutoSyncConfiguration stagedConfigIdentifier={MIMIR_DS_UID} />);
+
+    expect(await ui.notConfiguredBadge.find()).toBeInTheDocument();
+
+    await user.click(ui.picker.get());
+    await user.click(await screen.findByText(MIMIR_DS_NAME));
+
+    await waitFor(() => expect(ui.saveButton.get()).toBeEnabled());
+    expect(edgeUi.stagedConflictWarning.query()).not.toBeInTheDocument();
   });
 });

--- a/public/app/features/alerting/unified/components/settings/AutoSyncConfiguration.tsx
+++ b/public/app/features/alerting/unified/components/settings/AutoSyncConfiguration.tsx
@@ -8,7 +8,12 @@ import { Alert, Button, Card, ConfirmModal, Field, LinkButton, Select, Stack, To
 import { AutoSyncStatusBadge } from './AutoSyncStatusBadge';
 import { hasConfiguredUid, isOperatorManaged, useAutoSyncConfiguration } from './useAutoSyncConfiguration';
 
-export function AutoSyncConfiguration() {
+interface AutoSyncConfigurationProps {
+  /** Identifier of the staged import occupying the shared `extra_config` slot, if there is one. */
+  stagedConfigIdentifier?: string;
+}
+
+export function AutoSyncConfiguration({ stagedConfigIdentifier }: AutoSyncConfigurationProps) {
   const styles = useStyles2(getStyles);
   const { state, mimirCortexDatasources, selectedUid, setSelectedUid, save, disableSync, isPending, isLoading } =
     useAutoSyncConfiguration();
@@ -29,11 +34,23 @@ export function AutoSyncConfiguration() {
   const showDisableSync = state.kind === 'configured' || state.kind === 'orphan-uid';
   const showSave = state.kind === 'unconfigured' || state.kind === 'orphan-uid';
   const savedUid = hasConfiguredUid(state) ? state.uid : '';
-  const saveDisabled = !selectedUid || selectedUid === savedUid;
-  const saveDisabledTooltip = t(
-    'alerting.settings.auto-sync.save-disabled-no-selection',
-    'Select a Mimir or Cortex Alertmanager datasource to enable saving.'
-  );
+
+  // The syncer writes to the same single extra_config slot, keyed by datasource UID, and saves without
+  // replacing — so a foreign identifier parked there makes every sync tick fail server-side. An identifier
+  // matching the saved or selected UID is the syncer's own config, which it simply overwrites.
+  const conflictingStagedConfig =
+    Boolean(stagedConfigIdentifier) && stagedConfigIdentifier !== savedUid && stagedConfigIdentifier !== selectedUid;
+
+  const saveDisabled = !selectedUid || selectedUid === savedUid || conflictingStagedConfig;
+  const saveDisabledTooltip = conflictingStagedConfig
+    ? t(
+        'alerting.settings.auto-sync.save-disabled-staged-config',
+        'Revert the staged configuration before enabling auto-sync.'
+      )
+    : t(
+        'alerting.settings.auto-sync.save-disabled-no-selection',
+        'Select a Mimir or Cortex Alertmanager datasource to enable saving.'
+      );
 
   const handleDisableConfirm = async () => {
     setShowDisableConfirm(false);
@@ -83,6 +100,27 @@ export function AutoSyncConfiguration() {
               </Trans>
             </Alert>
           )}
+          {conflictingStagedConfig && (
+            <Alert
+              severity={savedUid ? 'error' : 'warning'}
+              title={
+                savedUid
+                  ? t('alerting.settings.auto-sync.staged-conflict-active-title', 'Auto-sync is not running')
+                  : t(
+                      'alerting.settings.auto-sync.staged-conflict-title',
+                      'Auto-sync is unavailable while a configuration is staged'
+                    )
+              }
+            >
+              <Trans
+                i18nKey="alerting.settings.auto-sync.staged-conflict-body"
+                values={{ identifier: stagedConfigIdentifier }}
+              >
+                Grafana holds one imported configuration at a time, and {'{{identifier}}'} currently occupies that slot.
+                Revert it below to free auto-sync.
+              </Trans>
+            </Alert>
+          )}
           <div className={styles.formRow}>
             <Field
               noMargin
@@ -112,6 +150,8 @@ export function AutoSyncConfiguration() {
                   aria-label={t('alerting.settings.auto-sync.picker-label', 'Datasource')}
                   options={options}
                   value={selectedUid || null}
+                  // Stays selectable during a staged-config conflict: picking the datasource whose UID
+                  // matches the staged identifier is one of the ways out of it.
                   onChange={(option) => option?.value && setSelectedUid(option.value)}
                   disabled={operatorManaged || isLoading}
                   isLoading={isLoading}

--- a/public/app/features/alerting/unified/hooks/useIsAutoSyncActive.test.ts
+++ b/public/app/features/alerting/unified/hooks/useIsAutoSyncActive.test.ts
@@ -1,0 +1,100 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { getWrapper, testWithFeatureToggles } from 'test/test-utils';
+
+import { type Config } from '@grafana/api-clients/rtkq/notifications.alerting/v0alpha1';
+import { AccessControlAction } from 'app/types/accessControl';
+
+import { setupMswServer } from '../mockApi';
+import { grantUserPermissions } from '../mocks';
+import { setupAutoSyncConfig } from '../mocks/server/handlers/k8s/config.k8s';
+
+import { resolveEffectiveSyncUid, useIsAutoSyncActive } from './useIsAutoSyncActive';
+
+const INI_UID = 'ini-mimir-uid';
+const SPEC_UID = 'spec-mimir-uid';
+
+function buildConfig(spec: Config['spec'], status: Config['status']): Config {
+  return {
+    apiVersion: 'notifications.alerting.grafana.app/v0alpha1',
+    kind: 'Config',
+    metadata: { name: 'default' },
+    spec,
+    status,
+  };
+}
+
+const notConfiguredCondition = {
+  type: 'ExternalAlertmanagerSynced',
+  status: 'Unknown',
+  reason: 'NotConfigured',
+  lastTransitionTime: '2026-01-01T00:00:00Z',
+} as const;
+
+describe('resolveEffectiveSyncUid', () => {
+  it('returns the spec UID when only spec is set', () => {
+    const config = buildConfig({ externalAlertmanagerSync: { datasourceUid: SPEC_UID } }, {});
+
+    expect(resolveEffectiveSyncUid(config)).toBe(SPEC_UID);
+  });
+
+  it('returns the ini UID from status, which never reaches spec', () => {
+    const config = buildConfig({}, { externalAlertmanagerSync: { datasourceUid: INI_UID, origin: 'ini' } });
+
+    expect(resolveEffectiveSyncUid(config)).toBe(INI_UID);
+  });
+
+  it('ignores an ini UID once the syncer reports NotConfigured', () => {
+    // The syncer keeps externalAlertmanagerSync as last-attempt context after sync stops, so the
+    // condition is the only thing that releases a stale ini reading.
+    const config = buildConfig(
+      {},
+      {
+        externalAlertmanagerSync: { datasourceUid: INI_UID, origin: 'ini' },
+        conditions: [notConfiguredCondition],
+      }
+    );
+
+    expect(resolveEffectiveSyncUid(config)).toBeUndefined();
+  });
+
+  it('prefers the ini UID over spec, matching the backend resolution order', () => {
+    const config = buildConfig(
+      { externalAlertmanagerSync: { datasourceUid: SPEC_UID } },
+      { externalAlertmanagerSync: { datasourceUid: INI_UID, origin: 'ini' } }
+    );
+
+    expect(resolveEffectiveSyncUid(config)).toBe(INI_UID);
+  });
+
+  it('ignores an api-origin status, which lags spec', () => {
+    const config = buildConfig({}, { externalAlertmanagerSync: { datasourceUid: SPEC_UID, origin: 'api' } });
+
+    expect(resolveEffectiveSyncUid(config)).toBeUndefined();
+  });
+
+  it('returns undefined when the Config is unreadable', () => {
+    expect(resolveEffectiveSyncUid(undefined)).toBeUndefined();
+  });
+});
+
+describe('useIsAutoSyncActive', () => {
+  const server = setupMswServer();
+
+  testWithFeatureToggles({ enable: ['alerting.syncExternalAlertmanager'] });
+
+  beforeEach(() => {
+    grantUserPermissions([AccessControlAction.ActionAlertingNotificationsConfigRead]);
+  });
+
+  it('reports an ini-configured sync as active, using its datasource UID', async () => {
+    setupAutoSyncConfig(server, { statusUid: INI_UID, statusOrigin: 'ini' });
+
+    const wrapper = getWrapper({ renderWithRouter: false });
+    const { result } = renderHook(() => useIsAutoSyncActive(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isActive).toBe(true);
+    });
+    expect(result.current.datasourceUid).toBe(INI_UID);
+  });
+});

--- a/public/app/features/alerting/unified/hooks/useIsAutoSyncActive.ts
+++ b/public/app/features/alerting/unified/hooks/useIsAutoSyncActive.ts
@@ -1,6 +1,6 @@
 import { skipToken } from '@reduxjs/toolkit/query';
 
-import { useGetConfigQuery } from '@grafana/api-clients/rtkq/notifications.alerting/v0alpha1';
+import { type Config, useGetConfigQuery } from '@grafana/api-clients/rtkq/notifications.alerting/v0alpha1';
 import { config } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction } from 'app/types/accessControl';
@@ -9,28 +9,58 @@ import { AccessControlAction } from 'app/types/accessControl';
 // ConfigSingletonName).
 const CONFIG_SINGLETON_NAME = 'default';
 
+// Mirrors the syncer's condition contract (conditionTypeExternalAlertmanagerSynced and
+// conditionReasonNotConfigured in pkg/services/ngalert/notifier/external_am_syncer.go). The generated
+// client types both fields as plain strings, so nothing links these to the backend at compile time.
+const SYNCED_CONDITION_TYPE = 'ExternalAlertmanagerSynced';
+const REASON_NOT_CONFIGURED = 'NotConfigured';
+
 interface AutoSyncState {
   isActive: boolean;
+  /** Datasource the org syncs from. Undefined while loading, when sync is off, or when the Config is unreadable. */
+  datasourceUid?: string;
   isLoading: boolean;
+}
+
+/**
+ * The datasource UID the sync worker will actually use, resolved the way the backend does in
+ * resolveExternalAMUIDForOrg: the operator ini override first, then the per-org spec.
+ *
+ * Status is ignored at the "api" origin because it holds the last sync attempt and lags — it stays
+ * populated after sync is disabled and restarted, so it reports active when it isn't. The ini
+ * override (unified_alerting.external_alertmanager_uid) is the exception: it never reaches spec, so
+ * status is the only place it surfaces. A stale ini reading is released by the
+ * ExternalAlertmanagerSynced/NotConfigured condition, which the syncer writes on the first tick after
+ * sync stops (every alertmanager_config_poll_interval, default 1 minute) while deliberately keeping
+ * externalAlertmanagerSync as last-attempt context.
+ *
+ * Residual gap: before the syncer's first tick status is empty, so an ini-configured sync is
+ * invisible here. IsExternalAMSyncConfiguredForOrg on the convert endpoint stays the real guard.
+ */
+export function resolveEffectiveSyncUid(orgConfig?: Config): string | undefined {
+  const lastAttempt = orgConfig?.status?.externalAlertmanagerSync;
+  const syncTurnedOff = orgConfig?.status?.conditions?.some(
+    (condition) => condition.type === SYNCED_CONDITION_TYPE && condition.reason === REASON_NOT_CONFIGURED
+  );
+
+  if (lastAttempt?.origin === 'ini' && !syncTurnedOff && lastAttempt.datasourceUid) {
+    return lastAttempt.datasourceUid;
+  }
+  return orgConfig?.spec?.externalAlertmanagerSync?.datasourceUid;
 }
 
 // Reports whether external (Mimir/Cortex) Alertmanager sync is actively running for the org.
 //
-// Sourced from spec.externalAlertmanagerSync on the per-org Config resource
-// (notifications.alerting.grafana.app). We read spec (the desired configuration), not status: status
-// holds the last sync attempt and lags — it stays populated after sync is disabled + restarted, so it
-// reports active when it isn't. Gated on the ActionAlertingNotificationsConfigRead permission so
-// non-admins who legitimately hold it are also blocked while sync is active. Fail-open: while loading
-// or on a 404/403 (resource absent or no read access) data is undefined, so isActive is false; when
-// the query is skipped (flag off or no read access) isLoading is also false.
-//
-// Known gap: spec does not reflect an ini-configured sync (unified_alerting.external_alertmanager_uid),
-// which surfaces only in status with origin='ini'. The backend convert endpoint's
-// IsExternalAMSyncConfiguredForOrg check is the real safety net; covering the ini case in the frontend
-// would require exposing the setting through frontend settings (a separate backend change).
+// Sourced from the per-org Config resource (notifications.alerting.grafana.app); see
+// resolveEffectiveSyncUid for how spec and status combine. Gated on the
+// ActionAlertingNotificationsConfigRead permission so non-admins who legitimately hold it are also
+// blocked while sync is active. Fail-open: while loading or on a 404/403 (resource absent or no read
+// access) data is undefined, so isActive is false; when the query is skipped (flag off or no read
+// access) isLoading is also false.
 export function useIsAutoSyncActive(): AutoSyncState {
   const flagOn = config.featureToggles['alerting.syncExternalAlertmanager'] === true;
   const canReadConfig = contextSrv.hasPermission(AccessControlAction.ActionAlertingNotificationsConfigRead);
   const { data, isLoading } = useGetConfigQuery(flagOn && canReadConfig ? { name: CONFIG_SINGLETON_NAME } : skipToken);
-  return { isActive: Boolean(data?.spec?.externalAlertmanagerSync?.datasourceUid), isLoading };
+  const datasourceUid = resolveEffectiveSyncUid(data);
+  return { isActive: Boolean(datasourceUid), datasourceUid, isLoading };
 }

--- a/public/app/features/alerting/unified/hooks/useSingleFlight.ts
+++ b/public/app/features/alerting/unified/hooks/useSingleFlight.ts
@@ -1,0 +1,26 @@
+import { useRef } from 'react';
+
+/**
+ * Wraps an async action so a second invocation is dropped while the first is still running.
+ *
+ * Needed for `ConfirmModal`, which submits through react-hook-form: `handleSubmit` awaits validation
+ * before invoking the callback, so `onConfirm` runs a microtask after the click handler returns — by
+ * which point a second click is already queued. A state-based guard cannot catch this (including
+ * `ConfirmModal`'s own in-flight lock), because it has not re-rendered the button as disabled yet.
+ */
+export function useSingleFlight(action: () => Promise<void>) {
+  const inFlightRef = useRef(false);
+
+  return async () => {
+    if (inFlightRef.current) {
+      return;
+    }
+    inFlightRef.current = true;
+
+    try {
+      await action();
+    } finally {
+      inFlightRef.current = false;
+    }
+  };
+}

--- a/public/app/features/alerting/unified/mocks/server/handlers/k8s/config.k8s.ts
+++ b/public/app/features/alerting/unified/mocks/server/handlers/k8s/config.k8s.ts
@@ -1,7 +1,12 @@
 import { HttpResponse, http } from 'msw';
 import { type SetupServer } from 'msw/node';
 
-import { API_GROUP, API_VERSION, type Config } from '@grafana/api-clients/rtkq/notifications.alerting/v0alpha1';
+import {
+  API_GROUP,
+  API_VERSION,
+  type Config,
+  type ConfigStatus,
+} from '@grafana/api-clients/rtkq/notifications.alerting/v0alpha1';
 
 // Config is the one notifications resource that only exists in v0alpha1, so this route is built from
 // that version's own constants rather than the shared ALERTING_API_SERVER_BASE_URL, which points at v1beta1.
@@ -15,19 +20,49 @@ interface AutoSyncConfigOptions {
   specUid?: string;
   /**
    * UID on status.externalAlertmanagerSync — the last sync attempt, which can lag spec.
-   * `useIsAutoSyncActive` does NOT read this; set it (with specUid omitted) to simulate a stale
-   * status that must not be treated as an active sync.
+   * `useIsAutoSyncActive` does NOT read this at the default `api` origin; set it (with specUid
+   * omitted) to simulate a stale status that must not be treated as an active sync.
    */
   statusUid?: string;
+  /**
+   * Which source supplied `statusUid` on the last run. `ini` is the operator override, which never
+   * reaches spec, so status is the only place it surfaces.
+   */
+  statusOrigin?: 'api' | 'ini';
+  /**
+   * Reason on the ExternalAlertmanagerSynced condition. `NotConfigured` is how the syncer reports
+   * that sync stopped while keeping externalAlertmanagerSync as last-attempt context.
+   */
+  syncedReason?: 'SyncSucceeded' | 'MergeCommitted' | 'NotConfigured';
 }
 
-function buildConfig(name: string, { specUid, statusUid }: AutoSyncConfigOptions = {}): Config {
+function buildStatus({ statusUid, statusOrigin = 'api', syncedReason }: AutoSyncConfigOptions): ConfigStatus {
+  const status: ConfigStatus = {};
+
+  if (statusUid) {
+    status.externalAlertmanagerSync = { datasourceUid: statusUid, origin: statusOrigin };
+  }
+  if (syncedReason) {
+    status.conditions = [
+      {
+        type: 'ExternalAlertmanagerSynced',
+        // The syncer only reports Unknown for NotConfigured; the other reasons ride a successful tick.
+        status: syncedReason === 'NotConfigured' ? 'Unknown' : 'True',
+        reason: syncedReason,
+        lastTransitionTime: '2026-01-01T00:00:00Z',
+      },
+    ];
+  }
+  return status;
+}
+
+function buildConfig(name: string, options: AutoSyncConfigOptions = {}): Config {
   return {
     apiVersion: `${API_GROUP}/${API_VERSION}`,
     kind: 'Config',
     metadata: { name },
-    spec: specUid ? { externalAlertmanagerSync: { datasourceUid: specUid } } : {},
-    status: statusUid ? { externalAlertmanagerSync: { datasourceUid: statusUid, origin: 'api' } } : {},
+    spec: options.specUid ? { externalAlertmanagerSync: { datasourceUid: options.specUid } } : {},
+    status: buildStatus(options),
   };
 }
 
@@ -40,7 +75,8 @@ const configHandler = (options: AutoSyncConfigOptions = {}, onRequest?: () => vo
 /**
  * Override the Config GET to drive external Alertmanager auto-sync state. Pass `specUid` to
  * simulate an active sync (what `useIsAutoSyncActive` reads); omit it for an inactive, empty Config.
- * Pass `statusUid` alone to simulate a stale status that must not count as active.
+ * Pass `statusUid` alone to simulate a stale status that must not count as active, or with
+ * `statusOrigin: 'ini'` to simulate the operator override that only ever surfaces in status.
  *
  * Returns a `requestSpy` that fires on every GET, so a test can assert the query was — or, when a
  * permission gate should short-circuit it, was not — made.

--- a/public/app/features/alerting/unified/settings/import/ImportSettingsPage.test.tsx
+++ b/public/app/features/alerting/unified/settings/import/ImportSettingsPage.test.tsx
@@ -1,14 +1,20 @@
-import { render, testWithFeatureToggles } from 'test/test-utils';
+import { HttpResponse, http } from 'msw';
+import { act, render, testWithFeatureToggles, waitFor } from 'test/test-utils';
 import { byRole, byText } from 'testing-library-selector';
 
+import { type AlertManagerCortexConfig } from 'app/plugins/datasource/alertmanager/types';
+import { configureStore } from 'app/store/configureStore';
 import { AccessControlAction } from 'app/types/accessControl';
 
+import { convertToGMAApi } from '../../api/convertToGMAApi';
 import { setupGrafanaManagedServer } from '../../components/settings/mocks/server';
 import { setupMswServer } from '../../mockApi';
 import { grantUserPermissions, grantUserRole } from '../../mocks';
+import { setupAutoSyncConfig } from '../../mocks/server/handlers/k8s/config.k8s';
 import { setupDataSources } from '../../testSetup/datasources';
 
 import ImportSettingsPage from './ImportSettingsPage';
+import { type StagedExtraConfig } from './stagedConfig';
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
@@ -17,12 +23,46 @@ jest.mock('@grafana/runtime', () => ({
 
 const server = setupMswServer();
 
+const AM_CONFIG_URL = '/api/alertmanager/:name/config/api/v1/alerts';
+const CONVERT_URL = '/api/convert/api/v1/alerts';
+const CONFIG_SINGLETON_URL = '/apis/notifications.alerting.grafana.app/v0alpha1/namespaces/:namespace/configs/:name';
+
+const stagedAlertmanagerConfig = 'route:\n  receiver: default\nreceivers:\n  - name: default\n';
+
+const stagedConfig: StagedExtraConfig = {
+  identifier: 'prometheus-prod',
+  alertmanager_config: stagedAlertmanagerConfig,
+  template_files: {},
+};
+
+const SYNC_DATASOURCE_UID = 'mimir-ds-uid';
+
+/** A staged config the syncer owns: the backend keys its own extra_config by the datasource UID. */
+const syncOwnedConfig: StagedExtraConfig = { ...stagedConfig, identifier: SYNC_DATASOURCE_UID };
+
 const ui = {
+  loading: byText(/loading imported configurations/i),
   autoSyncCard: byRole('region', { name: /auto-sync configuration/i }),
   emptyState: byText(/no configuration imported yet/i),
   importCta: byRole('link', { name: /import alertmanager configuration/i }),
   learnMoreLink: byRole('link', { name: /learn more about importing configurations/i }),
+  stagedConfigHeading: byRole('heading', { name: 'prometheus-prod' }),
+  syncedConfigHeading: byRole('heading', { name: SYNC_DATASOURCE_UID }),
+  revertButton: byRole('button', { name: /^revert$/i }),
+  syncedBadge: byText(/synced · read-only/i),
 };
+
+function serveStagedConfig(staged: StagedExtraConfig) {
+  server.use(
+    http.get(AM_CONFIG_URL, () =>
+      HttpResponse.json<AlertManagerCortexConfig>({
+        alertmanager_config: {},
+        template_files: {},
+        extra_config: [staged],
+      })
+    )
+  );
+}
 
 describe('Import settings tab', () => {
   beforeEach(() => {
@@ -41,6 +81,43 @@ describe('Import settings tab', () => {
     expect(ui.learnMoreLink.get()).toBeInTheDocument();
   });
 
+  it('shows a configuration staged after it was already rendered as empty', async () => {
+    let isStaged = false;
+    server.use(
+      // The staged config is carried on extra_config, so it only appears once an import has staged it.
+      http.get(AM_CONFIG_URL, () =>
+        HttpResponse.json<AlertManagerCortexConfig>({
+          alertmanager_config: {},
+          template_files: {},
+          extra_config: isStaged ? [stagedConfig] : undefined,
+        })
+      ),
+      http.post(CONVERT_URL, () => {
+        isStaged = true;
+        return HttpResponse.json({ status: 'success' });
+      })
+    );
+
+    const store = configureStore();
+    render(<ImportSettingsPage />, { store });
+
+    // The pre-import config is now cached — this is the cache the wizard's redirect lands back on.
+    expect(await ui.emptyState.find()).toBeInTheDocument();
+
+    // Stage a config the way the wizard does. Driven through the store rather than the UI because the
+    // wizard that triggers this mutation lives on another page.
+    await store.dispatch(
+      convertToGMAApi.endpoints.convertAlertmanagerConfig.initiate({
+        alertmanagerConfig: stagedAlertmanagerConfig,
+        configIdentifier: stagedConfig.identifier,
+        forceReplace: true,
+      })
+    );
+
+    expect(await ui.stagedConfigHeading.find()).toBeInTheDocument();
+    expect(ui.emptyState.query()).not.toBeInTheDocument();
+  });
+
   it('does not render the relocated auto-sync card when the sync flag is off', async () => {
     render(<ImportSettingsPage />);
 
@@ -55,6 +132,100 @@ describe('Import settings tab', () => {
       render(<ImportSettingsPage />);
 
       expect(await ui.autoSyncCard.find()).toBeInTheDocument();
+    });
+
+    describe('sync ownership of the staged card', () => {
+      beforeEach(() => {
+        // Ownership is read from the Config singleton, which needs the scoped config:get permission.
+        grantUserPermissions([
+          AccessControlAction.AlertingNotificationsRead,
+          AccessControlAction.ActionAlertingNotificationsConfigRead,
+        ]);
+      });
+
+      it('marks the staged card as synced when its identifier matches the synced datasource', async () => {
+        serveStagedConfig(syncOwnedConfig);
+        setupAutoSyncConfig(server, { specUid: SYNC_DATASOURCE_UID });
+
+        render(<ImportSettingsPage />);
+
+        expect(await ui.syncedConfigHeading.find()).toBeInTheDocument();
+        expect(ui.syncedBadge.get()).toBeInTheDocument();
+        expect(ui.revertButton.query()).not.toBeInTheDocument();
+      });
+
+      // The operator ini override (unified_alerting.external_alertmanager_uid) never reaches spec, so
+      // ownership has to be read off status or the card offers a Revert the next tick would undo.
+      it('marks the staged card as synced when an ini-configured sync owns it', async () => {
+        serveStagedConfig(syncOwnedConfig);
+        setupAutoSyncConfig(server, { statusUid: SYNC_DATASOURCE_UID, statusOrigin: 'ini' });
+
+        render(<ImportSettingsPage />);
+
+        expect(await ui.syncedConfigHeading.find()).toBeInTheDocument();
+        expect(ui.syncedBadge.get()).toBeInTheDocument();
+        expect(ui.revertButton.query()).not.toBeInTheDocument();
+      });
+
+      it('keeps revert available for a manual import while sync runs against another datasource', async () => {
+        serveStagedConfig(stagedConfig);
+        setupAutoSyncConfig(server, { specUid: SYNC_DATASOURCE_UID });
+
+        render(<ImportSettingsPage />);
+
+        expect(await ui.stagedConfigHeading.find()).toBeInTheDocument();
+        expect(ui.revertButton.get()).toBeInTheDocument();
+      });
+
+      // Ownership resolves independently of the Alertmanager config, so the card must wait for it —
+      // otherwise an unresolved query reads as "not sync-managed" and offers a Revert that the next
+      // sync tick would immediately undo.
+      it('does not offer revert before sync ownership is known', async () => {
+        const amConfigServed = jest.fn();
+        let resolveOwnership = () => {};
+        const ownershipResolved = new Promise<void>((resolve) => {
+          resolveOwnership = resolve;
+        });
+
+        server.use(
+          http.get(AM_CONFIG_URL, () => {
+            amConfigServed();
+            return HttpResponse.json<AlertManagerCortexConfig>({
+              alertmanager_config: {},
+              template_files: {},
+              extra_config: [syncOwnedConfig],
+            });
+          }),
+          http.get(CONFIG_SINGLETON_URL, async () => {
+            await ownershipResolved;
+            return HttpResponse.json({
+              apiVersion: 'notifications.alerting.grafana.app/v0alpha1',
+              kind: 'Config',
+              metadata: { name: 'default' },
+              spec: { externalAlertmanagerSync: { datasourceUid: SYNC_DATASOURCE_UID } },
+            });
+          })
+        );
+
+        render(<ImportSettingsPage />);
+
+        // Let the Alertmanager config land while ownership is still in flight — the window in which the
+        // card would otherwise render as a plain staged import.
+        await waitFor(() => expect(amConfigServed).toHaveBeenCalled());
+        await act(async () => {
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+
+        expect(ui.loading.get()).toBeInTheDocument();
+        expect(ui.revertButton.query()).not.toBeInTheDocument();
+        expect(ui.syncedConfigHeading.query()).not.toBeInTheDocument();
+
+        resolveOwnership();
+
+        expect(await ui.syncedConfigHeading.find()).toBeInTheDocument();
+        expect(ui.revertButton.query()).not.toBeInTheDocument();
+      });
     });
   });
 });

--- a/public/app/features/alerting/unified/settings/import/ImportSettingsPage.tsx
+++ b/public/app/features/alerting/unified/settings/import/ImportSettingsPage.tsx
@@ -8,7 +8,7 @@ import { logError } from '../../Analytics';
 import { AlertingPageWrapper } from '../../components/AlertingPageWrapper';
 import { WithReturnButton } from '../../components/WithReturnButton';
 import { AutoSyncConfiguration } from '../../components/settings/AutoSyncConfiguration';
-import { useAlertmanagerConfig } from '../../hooks/useAlertmanagerConfig';
+import { useIsAutoSyncActive } from '../../hooks/useIsAutoSyncActive';
 import { AlertmanagerProvider } from '../../state/AlertmanagerContext';
 import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
 import { DOCS_URL_ALERTING_MIGRATION } from '../../utils/docs';
@@ -17,7 +17,8 @@ import { withPageErrorBoundary } from '../../withPageErrorBoundary';
 import { useSettingsPageNav } from '../navigation';
 
 import { StagedConfiguration } from './StagedConfiguration';
-import { isStagedExtraConfig } from './stagedConfig';
+import { getStagedConfigPermissions } from './stagedConfigPermissions';
+import { useStagedConfig } from './useStagedConfig';
 
 const IMPORT_WIZARD_URL = '/alerting/import-to-gma';
 
@@ -49,27 +50,31 @@ function ImportSettingsPage() {
 
 function ImportSettingsContent() {
   const isAutoSyncEnabled = config.featureToggles['alerting.syncExternalAlertmanager'];
+  const { stagedConfig } = useStagedConfig();
 
   return (
     <Stack direction="column" gap={2}>
-      {isAutoSyncEnabled && <AutoSyncConfiguration />}
+      {isAutoSyncEnabled && <AutoSyncConfiguration stagedConfigIdentifier={stagedConfig?.identifier} />}
       <StagedConfigurationSection />
     </Stack>
   );
 }
 
 function StagedConfigurationSection() {
-  const { data, isLoading, isError, error, refetch } = useAlertmanagerConfig(GRAFANA_RULES_SOURCE_NAME);
+  const { canRevert } = getStagedConfigPermissions();
+  const { stagedConfig, liveConfig, isLoading, isError, error, refetch } = useStagedConfig();
+  const { datasourceUid: autoSyncUid, isLoading: isLoadingAutoSync } = useIsAutoSyncActive();
+
+  // The syncer addresses its own staged config by the datasource UID, so a matching identifier means this
+  // staged config is auto-sync's output rather than a manual import.
+  const isSyncManaged = Boolean(autoSyncUid) && stagedConfig?.identifier === autoSyncUid;
+  const isLoadingCard = isLoading || isLoadingAutoSync;
 
   useEffect(() => {
     if (isError) {
       logError(new Error(stringifyErrorLike(error)));
     }
   }, [isError, error]);
-
-  // A user can have at most one staged configuration at a time
-  const rawStagedConfig: unknown = data?.extra_config?.[0];
-  const stagedConfig = isStagedExtraConfig(rawStagedConfig) ? rawStagedConfig : undefined;
 
   return (
     <Stack direction="column" gap={1}>
@@ -83,7 +88,7 @@ function StagedConfigurationSection() {
         </Trans>
       </Text>
 
-      {isLoading && (
+      {isLoadingCard && (
         <LoadingPlaceholder text={t('alerting.settings.import.loading', 'Loading imported configurations…')} />
       )}
 
@@ -103,7 +108,7 @@ function StagedConfigurationSection() {
         </Alert>
       )}
 
-      {!isLoading && !isError && !stagedConfig && (
+      {!isLoadingCard && !isError && !stagedConfig && (
         <EmptyState
           variant="call-to-action"
           message={t('alerting.settings.import.empty-title', 'No configuration imported yet')}
@@ -123,8 +128,13 @@ function StagedConfigurationSection() {
         </EmptyState>
       )}
 
-      {!isLoading && !isError && stagedConfig && (
-        <StagedConfiguration stagedConfig={stagedConfig} liveConfig={data?.alertmanager_config} />
+      {!isLoadingCard && !isError && stagedConfig && (
+        <StagedConfiguration
+          stagedConfig={stagedConfig}
+          canRevert={canRevert}
+          isSyncManaged={isSyncManaged}
+          liveConfig={liveConfig}
+        />
       )}
     </Stack>
   );

--- a/public/app/features/alerting/unified/settings/import/RevertConfirmModal.test.tsx
+++ b/public/app/features/alerting/unified/settings/import/RevertConfirmModal.test.tsx
@@ -1,0 +1,74 @@
+import { HttpResponse, http } from 'msw';
+import { act, render, waitFor } from 'test/test-utils';
+import { byRole, byText } from 'testing-library-selector';
+
+import { setupMswServer } from '../../mockApi';
+
+import { RevertConfirmModal } from './RevertConfirmModal';
+
+const server = setupMswServer();
+
+const stagedConfig = {
+  identifier: 'config-min',
+  alertmanager_config: 'route:\n  receiver: default\nreceivers:\n  - name: default\n',
+  template_files: {},
+};
+
+const DELETE_URL = '/api/convert/api/v1/alerts';
+
+const ui = {
+  body: byText(/removes the staged copy/i),
+  reassureLive: byText(/live alertmanager config is not affected/i),
+  reassurePromoted: byText(/already promoted stays in place/i),
+  reassureReimport: byText(/import this configuration again/i),
+  confirm: byRole('button', { name: /^revert$/i }),
+};
+
+describe('RevertConfirmModal', () => {
+  it('shows reassuring copy and reverts the staged config on confirm', async () => {
+    let deletedIdentifier: string | null = null;
+    server.use(
+      http.delete(DELETE_URL, ({ request }) => {
+        deletedIdentifier = request.headers.get('X-Grafana-Alerting-Config-Identifier');
+        return new HttpResponse(null, { status: 202 });
+      })
+    );
+
+    const onDismiss = jest.fn();
+    const { user } = render(<RevertConfirmModal stagedConfig={stagedConfig} onDismiss={onDismiss} />);
+
+    expect(ui.body.get()).toBeInTheDocument();
+    expect(ui.reassureLive.get()).toBeInTheDocument();
+    expect(ui.reassurePromoted.get()).toBeInTheDocument();
+    expect(ui.reassureReimport.get()).toBeInTheDocument();
+
+    await user.click(ui.confirm.get());
+
+    await waitFor(() => expect(onDismiss).toHaveBeenCalled());
+    expect(deletedIdentifier).toBe('config-min');
+  });
+
+  it('reverts only once when the user submits the confirm button twice', async () => {
+    let deleteCount = 0;
+
+    server.use(
+      http.delete(DELETE_URL, () => {
+        deleteCount++;
+        return new HttpResponse(null, { status: 202 });
+      })
+    );
+
+    const onDismiss = jest.fn();
+    render(<RevertConfirmModal stagedConfig={stagedConfig} onDismiss={onDismiss} />);
+
+    // Both clicks must land before React re-renders the button as disabled; userEvent would flush
+    // between them and miss the race. See useSingleFlight for why the two submits overlap at all.
+    await act(async () => {
+      ui.confirm.get().click();
+      ui.confirm.get().click();
+    });
+
+    await waitFor(() => expect(onDismiss).toHaveBeenCalled());
+    expect(deleteCount).toBe(1);
+  });
+});

--- a/public/app/features/alerting/unified/settings/import/RevertConfirmModal.tsx
+++ b/public/app/features/alerting/unified/settings/import/RevertConfirmModal.tsx
@@ -1,0 +1,98 @@
+import { css } from '@emotion/css';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { ConfirmModal, Icon, Stack, Text, useStyles2 } from '@grafana/ui';
+import { useAppNotification } from 'app/core/copy/appNotification';
+
+import { logError } from '../../Analytics';
+import { convertToGMAApi } from '../../api/convertToGMAApi';
+import { useSingleFlight } from '../../hooks/useSingleFlight';
+import { stringifyErrorLike } from '../../utils/misc';
+
+import { type StagedExtraConfig } from './stagedConfig';
+
+interface Props {
+  stagedConfig: StagedExtraConfig;
+  onDismiss: () => void;
+}
+
+function ReassuranceRow({ children }: { children: NonNullable<React.ReactNode> }) {
+  const styles = useStyles2(getStyles);
+  return (
+    <Stack direction="row" gap={1} alignItems="flex-start">
+      <Icon name="check-circle" className={styles.checkIcon} />
+      <Text color="secondary">{children}</Text>
+    </Stack>
+  );
+}
+
+/**
+ * Confirmation modal for reverting (discarding) a staged Alertmanager config. Reassuring by design:
+ * the live config is untouched and the config can be re-imported later, so the confirm is neutral
+ * rather than destructive.
+ */
+export function RevertConfirmModal({ stagedConfig, onDismiss }: Props) {
+  const notifyApp = useAppNotification();
+  const [deleteStaged, { isLoading }] = convertToGMAApi.useDeleteStagedAlertmanagerConfigMutation();
+
+  // A second DELETE would 404 and show a failure toast for a revert that actually succeeded.
+  const onConfirm = useSingleFlight(async () => {
+    try {
+      await deleteStaged({ configIdentifier: stagedConfig.identifier }).unwrap();
+      notifyApp.success(t('alerting.settings.import.revert.success', 'Staged configuration reverted'));
+      onDismiss();
+    } catch (err) {
+      logError(new Error(stringifyErrorLike(err)));
+      notifyApp.error(
+        t('alerting.settings.import.revert.error-title', 'Failed to revert configuration'),
+        stringifyErrorLike(err)
+      );
+    }
+  });
+
+  return (
+    <ConfirmModal
+      isOpen
+      title={t('alerting.settings.import.revert.title', 'Revert this staged configuration?')}
+      confirmText={t('alerting.settings.import.revert.confirm', 'Revert')}
+      confirmVariant="secondary"
+      onConfirm={onConfirm}
+      // Prevent dismissing mid-revert so the mutation can't be interrupted.
+      onDismiss={isLoading ? () => {} : onDismiss}
+      body={
+        <Stack direction="column" gap={2}>
+          <Text>
+            <Trans i18nKey="alerting.settings.import.revert.body">
+              This removes the staged copy of the imported configuration from Grafana.
+            </Trans>
+          </Text>
+          <Stack direction="column" gap={1}>
+            <ReassuranceRow>
+              <Trans i18nKey="alerting.settings.import.revert.reassure-live">
+                Your live Alertmanager config is not affected.
+              </Trans>
+            </ReassuranceRow>
+            <ReassuranceRow>
+              <Trans i18nKey="alerting.settings.import.revert.reassure-promoted">
+                Anything you already promoted stays in place.
+              </Trans>
+            </ReassuranceRow>
+            <ReassuranceRow>
+              <Trans i18nKey="alerting.settings.import.revert.reassure-reimport">
+                You can import this configuration again at any time.
+              </Trans>
+            </ReassuranceRow>
+          </Stack>
+        </Stack>
+      }
+    />
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  checkIcon: css({
+    color: theme.colors.success.text,
+    marginTop: theme.spacing(0.25),
+  }),
+});

--- a/public/app/features/alerting/unified/settings/import/StagedConfiguration.test.tsx
+++ b/public/app/features/alerting/unified/settings/import/StagedConfiguration.test.tsx
@@ -60,12 +60,17 @@ const ui = {
   notificationPoliciesSection: byRole('button', { name: /notification polic/i }),
   notificationPoliciesContent: byRole('region', { name: /notification polic/i }),
   expandAll: byRole('button', { name: /expand all/i }),
+  syncedBadge: byText(/synced · read-only/i),
+  syncManagedNote: byText(/kept up to date by auto-sync/i),
   parseError: byText(/couldn't read the staged configuration/i),
+  revertButton: byRole('button', { name: /^revert$/i }),
+  revertModalTitle: byRole('heading', { name: /revert this staged configuration/i }),
+  noPermissionTooltip: byText(/don't have permission to modify/i),
 };
 
 describe('StagedConfiguration', () => {
   it('renders the identifier, staged badge and resource sections', () => {
-    render(<StagedConfiguration stagedConfig={stagedConfig} />);
+    render(<StagedConfiguration stagedConfig={stagedConfig} canRevert />);
 
     expect(ui.heading.get()).toBeInTheDocument();
     expect(ui.badge.get()).toBeInTheDocument();
@@ -73,7 +78,7 @@ describe('StagedConfiguration', () => {
   });
 
   it('expands a section to reveal resource names', async () => {
-    const { user } = render(<StagedConfiguration stagedConfig={stagedConfig} />);
+    const { user } = render(<StagedConfiguration stagedConfig={stagedConfig} canRevert />);
 
     await user.click(ui.contactPointsSection.get());
 
@@ -82,7 +87,7 @@ describe('StagedConfiguration', () => {
   });
 
   it('reveals every section when Expand all is clicked', async () => {
-    const { user } = render(<StagedConfiguration stagedConfig={stagedConfig} />);
+    const { user } = render(<StagedConfiguration stagedConfig={stagedConfig} canRevert />);
 
     await user.click(ui.expandAll.get());
 
@@ -91,7 +96,7 @@ describe('StagedConfiguration', () => {
   });
 
   it('links each resource to its detail/list page', async () => {
-    const { user } = render(<StagedConfiguration stagedConfig={stagedConfig} />);
+    const { user } = render(<StagedConfiguration stagedConfig={stagedConfig} canRevert />);
 
     await user.click(ui.expandAll.get());
 
@@ -127,6 +132,7 @@ describe('StagedConfiguration', () => {
     const { user } = render(
       <StagedConfiguration
         stagedConfig={stagedConfig}
+        canRevert
         liveConfig={{ receivers: [{ name: 'default' }], time_intervals: [{ name: 'weekends', time_intervals: [] }] }}
       />
     );
@@ -148,7 +154,7 @@ describe('StagedConfiguration', () => {
   });
 
   it('shows inhibition rule details inline (no link)', async () => {
-    const { user } = render(<StagedConfiguration stagedConfig={stagedConfig} />);
+    const { user } = render(<StagedConfiguration stagedConfig={stagedConfig} canRevert />);
 
     await user.click(ui.expandAll.get());
 
@@ -156,7 +162,7 @@ describe('StagedConfiguration', () => {
   });
 
   it('presents the import as a single routing tree named after the identifier', async () => {
-    const { user } = render(<StagedConfiguration stagedConfig={nestedPoliciesConfig} />);
+    const { user } = render(<StagedConfiguration stagedConfig={nestedPoliciesConfig} canRevert />);
 
     // One import contributes one routing tree, so the section count is 1 regardless of the tree's size.
     expect(within(ui.notificationPoliciesSection.get()).getByText('1')).toBeInTheDocument();
@@ -171,7 +177,7 @@ describe('StagedConfiguration', () => {
   });
 
   it('does not label the imported root as the default policy', async () => {
-    const { user } = render(<StagedConfiguration stagedConfig={stagedConfig} />);
+    const { user } = render(<StagedConfiguration stagedConfig={stagedConfig} canRevert />);
 
     await user.click(ui.notificationPoliciesSection.get());
 
@@ -180,8 +186,51 @@ describe('StagedConfiguration', () => {
   });
 
   it('shows an error when the configuration cannot be parsed', () => {
-    render(<StagedConfiguration stagedConfig={{ identifier: 'broken', alertmanager_config: 'foo: [bar' }} />);
+    render(<StagedConfiguration stagedConfig={{ identifier: 'broken', alertmanager_config: 'foo: [bar' }} canRevert />);
 
     expect(ui.parseError.get()).toBeInTheDocument();
+  });
+
+  describe('revert action', () => {
+    it('enables revert when the user can delete the import', () => {
+      render(<StagedConfiguration stagedConfig={stagedConfig} canRevert />);
+
+      expect(ui.revertButton.get()).toBeEnabled();
+    });
+
+    it('disables revert with an explanatory tooltip when the user cannot', async () => {
+      const { user } = render(<StagedConfiguration stagedConfig={stagedConfig} canRevert={false} />);
+
+      // A button with a tooltip renders aria-disabled (wrapped so the tooltip still shows on hover)
+      // rather than the native disabled attribute.
+      expect(ui.revertButton.get()).toHaveAttribute('aria-disabled', 'true');
+
+      await user.hover(ui.revertButton.get());
+      expect(await ui.noPermissionTooltip.find()).toBeInTheDocument();
+    });
+
+    it('opens the revert modal from the header action', async () => {
+      const { user } = render(<StagedConfiguration stagedConfig={stagedConfig} canRevert />);
+
+      await user.click(ui.revertButton.get());
+
+      expect(await ui.revertModalTitle.find()).toBeInTheDocument();
+    });
+  });
+
+  describe('when the staged config belongs to auto-sync', () => {
+    it('hides revert and explains why', () => {
+      render(<StagedConfiguration stagedConfig={stagedConfig} canRevert isSyncManaged />);
+
+      expect(ui.revertButton.query()).not.toBeInTheDocument();
+      expect(ui.syncManagedNote.get()).toBeInTheDocument();
+    });
+
+    it('marks the card as synced rather than staged', () => {
+      render(<StagedConfiguration stagedConfig={stagedConfig} canRevert isSyncManaged />);
+
+      expect(ui.syncedBadge.get()).toBeInTheDocument();
+      expect(ui.badge.query()).not.toBeInTheDocument();
+    });
   });
 });

--- a/public/app/features/alerting/unified/settings/import/StagedConfiguration.tsx
+++ b/public/app/features/alerting/unified/settings/import/StagedConfiguration.tsx
@@ -11,6 +11,7 @@ import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
 import { makeEditContactPointLink, makeEditTimeIntervalLink } from '../../utils/misc';
 import { createRelativeUrl } from '../../utils/url';
 
+import { RevertConfirmModal } from './RevertConfirmModal';
 import {
   type StagedExtraConfig,
   encodeRouteMatchersQuery,
@@ -65,6 +66,10 @@ interface AccordionSection {
 
 interface Props {
   stagedConfig: StagedExtraConfig;
+  /** Whether the current user can discard the staged configuration. */
+  canRevert: boolean;
+  /** Written by the external Alertmanager sync, so reverting it would only be undone by the next tick. */
+  isSyncManaged?: boolean;
   /**
    * The live Grafana Alertmanager config the staged one is merged against. Needed to work out which staged
    * resources the backend renames on a name collision, so their View links address the staged copy.
@@ -72,8 +77,13 @@ interface Props {
   liveConfig?: AlertmanagerConfig;
 }
 
-export function StagedConfiguration({ stagedConfig, liveConfig }: Props) {
+export function StagedConfiguration({ stagedConfig, canRevert, isSyncManaged, liveConfig }: Props) {
   const styles = useStyles2(getStyles);
+  const [showRevertModal, setShowRevertModal] = useState(false);
+  const noPermissionTooltip = t(
+    'alerting.settings.import.no-write-permission',
+    "You don't have permission to modify the imported configuration."
+  );
   const config = parseStagedAlertmanagerConfig(stagedConfig.alertmanager_config);
 
   if (!config) {
@@ -215,17 +225,47 @@ export function StagedConfiguration({ stagedConfig, liveConfig }: Props) {
 
   return (
     <div className={styles.card}>
-      <Stack direction="row" alignItems="center" gap={1}>
-        <Text element="h3" variant="h5">
-          {stagedConfig.identifier}
-        </Text>
-        <Badge
-          color="blue"
-          icon="cloud-upload"
-          text={t('alerting.settings.import.staged-badge', 'Staged · read-only')}
-        />
+      <Stack direction="row" alignItems="center" justifyContent="space-between" gap={1} wrap="wrap">
+        <Stack direction="row" alignItems="center" gap={1}>
+          <Text element="h3" variant="h5">
+            {stagedConfig.identifier}
+          </Text>
+          {isSyncManaged ? (
+            <Badge color="green" icon="sync" text={t('alerting.settings.import.synced-badge', 'Synced · read-only')} />
+          ) : (
+            <Badge
+              color="blue"
+              icon="cloud-upload"
+              text={t('alerting.settings.import.staged-badge', 'Staged · read-only')}
+            />
+          )}
+        </Stack>
+        {!isSyncManaged && (
+          <Button
+            variant="secondary"
+            disabled={!canRevert}
+            tooltip={canRevert ? undefined : noPermissionTooltip}
+            onClick={() => setShowRevertModal(true)}
+          >
+            <Trans i18nKey="alerting.settings.import.revert-button">Revert</Trans>
+          </Button>
+        )}
       </Stack>
+
+      {isSyncManaged && (
+        <Text variant="bodySmall" color="secondary">
+          <Trans i18nKey="alerting.settings.import.sync-managed-description">
+            This configuration is kept up to date by auto-sync, so it can&apos;t be reverted — disable auto-sync to
+            remove it.
+          </Trans>
+        </Text>
+      )}
+
       <ResourceAccordion sections={sections} />
+
+      {showRevertModal && (
+        <RevertConfirmModal stagedConfig={stagedConfig} onDismiss={() => setShowRevertModal(false)} />
+      )}
     </div>
   );
 }

--- a/public/app/features/alerting/unified/settings/import/stagedConfigPermissions.ts
+++ b/public/app/features/alerting/unified/settings/import/stagedConfigPermissions.ts
@@ -1,0 +1,21 @@
+import { contextSrv } from 'app/core/services/context_srv';
+import { AccessControlAction } from 'app/types/accessControl';
+
+const ALERTMANAGER_IMPORTS_DELETE = 'notifications.alerting.grafana.app/alertmanagerimports:delete';
+
+export interface StagedConfigPermissions {
+  canRevert: boolean;
+}
+
+/**
+ * Whether the current user may revert a staged import. Drives only the button's disabled state:
+ * `contextSrv` can't evaluate resource scopes, so a user scoped to a different import still sees an enabled
+ * button and gets a 403. The backend remains authoritative.
+ */
+export function getStagedConfigPermissions(): StagedConfigPermissions {
+  const hasLegacyWrite = contextSrv.hasPermission(AccessControlAction.AlertingNotificationsWrite);
+
+  return {
+    canRevert: hasLegacyWrite || contextSrv.hasPermission(ALERTMANAGER_IMPORTS_DELETE),
+  };
+}

--- a/public/app/features/alerting/unified/settings/import/useStagedConfig.ts
+++ b/public/app/features/alerting/unified/settings/import/useStagedConfig.ts
@@ -1,0 +1,20 @@
+import { useAlertmanagerConfig } from '../../hooks/useAlertmanagerConfig';
+import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
+
+import { type StagedExtraConfig, isStagedExtraConfig } from './stagedConfig';
+
+/**
+ * The staged Alertmanager import, read off the Grafana Alertmanager config it is carried on. Safe to call
+ * from several components — they share one RTK Query cache entry.
+ */
+export function useStagedConfig() {
+  const { data, ...rest } = useAlertmanagerConfig(GRAFANA_RULES_SOURCE_NAME);
+
+  // A user can have at most one staged configuration at a time
+  const rawStagedConfig: unknown = data?.extra_config?.[0];
+  const stagedConfig: StagedExtraConfig | undefined = isStagedExtraConfig(rawStagedConfig)
+    ? rawStagedConfig
+    : undefined;
+
+  return { ...rest, stagedConfig, liveConfig: data?.alertmanager_config };
+}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3282,8 +3282,12 @@
         "picker-label": "Datasource",
         "picker-placeholder": "Select a Mimir or Cortex Alertmanager datasource…",
         "save-disabled-no-selection": "Select a Mimir or Cortex Alertmanager datasource to enable saving.",
+        "save-disabled-staged-config": "Revert the staged configuration before enabling auto-sync.",
         "save-error": "Failed to save Mimir Alertmanager auto-sync",
         "save-success": "Mimir Alertmanager auto-sync enabled",
+        "staged-conflict-active-title": "Auto-sync is not running",
+        "staged-conflict-body": "Grafana holds one imported configuration at a time, and {{identifier}} currently occupies that slot. Revert it below to free auto-sync.",
+        "staged-conflict-title": "Auto-sync is unavailable while a configuration is staged",
         "title": "Auto-sync configuration"
       },
       "import": {
@@ -3300,11 +3304,23 @@
         "inhibition-equal": "equal: {{labels}}",
         "loading": "Loading imported configurations…",
         "no-matchers": "(no matchers)",
+        "no-write-permission": "You don't have permission to modify the imported configuration.",
         "parse-error-body": "The imported Alertmanager configuration could not be parsed.",
         "parse-error-title": "Couldn't read the staged configuration",
         "policy-tree-routes_one": "{{count}} route",
         "policy-tree-routes_other": "{{count}} routes",
         "resources": "Resources",
+        "revert": {
+          "body": "This removes the staged copy of the imported configuration from Grafana.",
+          "confirm": "Revert",
+          "error-title": "Failed to revert configuration",
+          "reassure-live": "Your live Alertmanager config is not affected.",
+          "reassure-promoted": "Anything you already promoted stays in place.",
+          "reassure-reimport": "You can import this configuration again at any time.",
+          "success": "Staged configuration reverted",
+          "title": "Revert this staged configuration?"
+        },
+        "revert-button": "Revert",
         "section": {
           "contact-points": "Contact points",
           "inhibition-rules": "Inhibition rules",
@@ -3315,6 +3331,8 @@
         "staged-badge": "Staged · read-only",
         "staged-description": "A read-only, reversible copy of an imported Alertmanager config. Promote it to merge into your live config, or revert to remove it.",
         "staged-title": "Staged configuration",
+        "sync-managed-description": "This configuration is kept up to date by auto-sync, so it can't be reverted — disable auto-sync to remove it.",
+        "synced-badge": "Synced · read-only",
         "view": "View"
       },
       "tabs": {


### PR DESCRIPTION
**What is this feature?**

Adds a **Revert** action to the staged configuration card on Alerting → Settings → Import, so a staged
Alertmanager import can be discarded from the UI. Reverting removes the staged copy and leaves the live
Grafana Alertmanager configuration untouched — the confirm modal says so explicitly, since this is a
recoverable action rather than a destructive one.

*(video)*

Along with it, the settings tab learns who owns the staged config:

- `useIsAutoSyncActive` now resolves the datasource UID the sync worker will actually use, the way the
  backend does in `resolveExternalAMUIDForOrg`: the operator ini override first, then the per-org spec.
  Previously it read `spec` alone, so a sync configured through
  `unified_alerting.external_alertmanager_uid` was invisible to the frontend. A stale ini reading is
  released by the `ExternalAlertmanagerSynced` / `NotConfigured` condition the syncer writes once sync
  stops.
- When the staged config is auto-sync's own output, the card is badged **Synced · read-only** and Revert
  is hidden — reverting it would only be undone by the next sync tick. The card explains that instead.
- Enabling auto-sync is blocked, with an explanation, while a staged config from a *different* source
  occupies the slot. Grafana holds one `extra_config` at a time, keyed by datasource UID, and the syncer
  saves without replacing — so a foreign identifier parked there makes every sync tick fail server-side,
  visible only in a status condition and a metric.
- Importing now invalidates the Alertmanager configuration query, so the Import tab renders the freshly
  staged config instead of its cached pre-import view.

**Why do we need this feature?**

Today the only way to discard a staged import is an API call, or running the import wizard a second time
to overwrite it. A user who imported the wrong configuration is stuck looking at it.

**Who is this feature for?**

Alerting users migrating from an external Alertmanager.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/alerting-squad/issues/1863

**Special notes for your reviewer:**

First of two PRs split out of #129243, which had grown to 26 files. This one is revert-only; the
**Promote** action follows in a stacked PR on top of this branch. Two consequences worth knowing while
reading:

- `stagedConfigPermissions.ts` gates only `canRevert` here and grows a `canPromote` half in the next PR.
  They are gated separately because the backend authorizes them independently — revert accepts the scoped
  `alertmanagerimports:delete`, so one coarse `notifications:write` check would make that scoped
  permission useless in the UI.
- The auto-sync conflict copy says "Revert the staged configuration…" in this PR and becomes "Promote or
  revert…" in the next one, once there is a Promote button to point at.

`getStagedConfigPermissions` drives only the button's disabled state. `contextSrv` can't evaluate
resource scopes, so a user scoped to a different import still sees an enabled button and gets a 403 —
the backend stays authoritative.

One residual gap is documented in `resolveEffectiveSyncUid`: before the syncer's first tick, status is
empty, so an ini-configured sync is still invisible to the frontend. `IsExternalAMSyncConfiguredForOrg`
on the convert endpoint remains the real guard.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
