### PR TITLE
fix: watch missed events

### DIFF
--- a/pkg/storage/unified/resource/broadcaster.go
+++ b/pkg/storage/unified/resource/broadcaster.go
@@ -11,7 +11,20 @@ import (
 )
 
 type Broadcaster[T any] interface {
-	Subscribe(ctx context.Context, name, resource string) (<-chan T, error)
+	// Subscribe registers a new listener and returns a channel that first
+	// replays cached events, then streams new ones as they arrive.
+	//
+	// sinceRV, if non-zero, is the resource version the caller already has
+	// history up to. It's used to check whether the replay cache has
+	// uninterrupted event history back to that point: the returned
+	// hasFullHistory channel receives a single value once that check has
+	// run. true means the cache (and therefore the returned event channel)
+	// covers sinceRV onward with no gaps; false means older events may have
+	// been evicted from the cache (or it never observed any), and the
+	// caller should backfill from durable storage before trusting the
+	// stream alone. Passing sinceRV == 0 skips the check and always reports
+	// true.
+	Subscribe(ctx context.Context, name, resource string, sinceRV int64) (ch <-chan T, hasFullHistory <-chan bool, err error)
 	Unsubscribe(<-chan T)
 }
 
@@ -54,12 +67,16 @@ func newBroadcasterMetrics(reg prometheus.Registerer) *BroadcasterMetrics {
 // when either ctx is cancelled or input is closed.
 //
 // eventResourceFn extracts a resource label for an event entering the broadcaster.
-func NewBroadcaster[T any](ctx context.Context, input <-chan T, metrics *BroadcasterMetrics, eventResourceFn func(T) string) Broadcaster[T] {
-	return newBroadcasterWithSizes[T](ctx, input, watchChanSize, defaultOverflowCap, metrics, eventResourceFn)
+// eventRVFn extracts the resource version of an event, used to determine
+// whether the replay cache has uninterrupted history back to a subscriber's
+// requested sinceRV; it may be nil if callers never pass a non-zero sinceRV
+// to Subscribe.
+func NewBroadcaster[T any](ctx context.Context, input <-chan T, metrics *BroadcasterMetrics, eventResourceFn func(T) string, eventRVFn func(T) int64) Broadcaster[T] {
+	return newBroadcasterWithSizes[T](ctx, input, watchChanSize, defaultOverflowCap, metrics, eventResourceFn, eventRVFn)
 }
 
 // newBroadcasterWithSizes creates a broadcaster with configurable buffer sizes for testing.
-func newBroadcasterWithSizes[T any](ctx context.Context, input <-chan T, subBufSize, ovfCap int, metrics *BroadcasterMetrics, eventResourceFn func(T) string) *broadcaster[T] {
+func newBroadcasterWithSizes[T any](ctx context.Context, input <-chan T, subBufSize, ovfCap int, metrics *BroadcasterMetrics, eventResourceFn func(T) string, eventRVFn func(T) int64) *broadcaster[T] {
 	if metrics == nil {
 		metrics = newBroadcasterMetrics(nil)
 	}
@@ -72,6 +89,7 @@ func newBroadcasterWithSizes[T any](ctx context.Context, input <-chan T, subBufS
 		terminated:      make(chan struct{}),
 		metrics:         metrics,
 		eventResourceFn: eventResourceFn,
+		eventRVFn:       eventRVFn,
 		watchBufSize:    subBufSize,
 		overflowCap:     ovfCap,
 	}
@@ -82,10 +100,12 @@ func newBroadcasterWithSizes[T any](ctx context.Context, input <-chan T, subBufS
 }
 
 type subscription[T any] struct {
-	name     string
-	resource string // metric label for subscriber-attributed metrics
-	ch       chan T
-	overflow []T // pending items when channel is full, nil when not overflowing
+	name      string
+	resource  string // metric label for subscriber-attributed metrics
+	sinceRV   int64
+	historyCh chan bool // buffered 1; see Broadcaster.Subscribe
+	ch        chan T
+	overflow  []T // pending items when channel is full, nil when not overflowing
 }
 
 type broadcaster[T any] struct {
@@ -102,6 +122,7 @@ type broadcaster[T any] struct {
 	subs            map[<-chan T]*subscription[T]
 	metrics         *BroadcasterMetrics
 	eventResourceFn func(T) string
+	eventRVFn       func(T) int64
 
 	// configuration
 
@@ -153,18 +174,24 @@ const (
 	overflowLogInterval = 10 * time.Second
 )
 
-func (b *broadcaster[T]) Subscribe(ctx context.Context, name, resource string) (<-chan T, error) {
-	sub := &subscription[T]{name: name, resource: resource, ch: make(chan T, b.watchBufSize)}
+func (b *broadcaster[T]) Subscribe(ctx context.Context, name, resource string, sinceRV int64) (<-chan T, <-chan bool, error) {
+	sub := &subscription[T]{
+		name:      name,
+		resource:  resource,
+		sinceRV:   sinceRV,
+		historyCh: make(chan bool, 1),
+		ch:        make(chan T, b.watchBufSize),
+	}
 
 	select {
 	case <-ctx.Done(): // client canceled
 		b.metrics.SubscriptionsTotal.WithLabelValues(resource, subscriptionResultCtxCanceled).Inc()
-		return nil, ctx.Err()
+		return nil, nil, ctx.Err()
 	case <-b.terminated: // no more data
 		b.metrics.SubscriptionsTotal.WithLabelValues(resource, subscriptionResultTerminated).Inc()
-		return nil, io.EOF
+		return nil, nil, io.EOF
 	case b.subscribe <- sub: // success submitting subscription
-		return sub.ch, nil
+		return sub.ch, sub.historyCh, nil
 	}
 }
 
@@ -220,6 +247,18 @@ func (b *broadcaster[T]) stream(input <-chan T) {
 	}()
 
 	addSubscriber := func(sub *subscription[T]) {
+		hasFullHistory := true
+		if sub.sinceRV > 0 {
+			if oldest, ok := b.cache.oldest(); ok && b.eventRVFn != nil {
+				hasFullHistory = b.eventRVFn(oldest) <= sub.sinceRV
+			} else {
+				// Empty cache, or no way to inspect it: can't vouch for
+				// anything before now.
+				hasFullHistory = false
+			}
+		}
+		sub.historyCh <- hasFullHistory
+
 		// send initial batch of cached items
 		if !b.cache.readInto(sub.ch) {
 			b.metrics.SubscriptionsTotal.WithLabelValues(sub.resource, subscriptionResultReplayFailed).Inc()
@@ -337,6 +376,16 @@ func newRingBuffer[T any](size int) ringBuffer[T] {
 	return ringBuffer[T]{
 		buf: make([]T, size),
 	}
+}
+
+// oldest returns the oldest cached item and true, or the zero value and
+// false if the cache is empty.
+func (r *ringBuffer[T]) oldest() (T, bool) {
+	if r.len == 0 {
+		var zero T
+		return zero, false
+	}
+	return r.buf[r.zero], true
 }
 
 func (r *ringBuffer[T]) add(item T) {

--- a/pkg/storage/unified/resource/broadcaster_test.go
+++ b/pkg/storage/unified/resource/broadcaster_test.go
@@ -41,10 +41,17 @@ func TestRingBuffer(t *testing.T) {
 	require.True(t, c.readInto(dst))
 	require.Empty(t, drainChan(dst))
 
+	_, ok := c.oldest()
+	require.False(t, ok, "oldest on an empty buffer reports no item")
+
 	c.add(1)
 	dst = make(chan int, 10)
 	require.True(t, c.readInto(dst))
 	require.Equal(t, []int{1}, drainChan(dst))
+
+	oldest, ok := c.oldest()
+	require.True(t, ok)
+	require.Equal(t, 1, oldest)
 
 	for i := 2; i <= 6; i++ {
 		c.add(i)
@@ -73,6 +80,11 @@ func TestRingBuffer(t *testing.T) {
 	// destination too small — returns false
 	small := make(chan int, 1)
 	require.False(t, c.readInto(small))
+
+	// two evictions happened above: oldest is now 4 (see comment at line 71).
+	oldest, ok = c.oldest()
+	require.True(t, ok)
+	require.Equal(t, 4, oldest)
 }
 
 func TestBroadcaster(t *testing.T) {
@@ -90,9 +102,9 @@ func TestBroadcaster(t *testing.T) {
 		close(ch)
 	})
 
-	b := NewBroadcaster(ctx, ch, metrics, nil)
+	b := NewBroadcaster(ctx, ch, metrics, nil, nil)
 
-	sub, err := b.Subscribe(ctx, "test", "test")
+	sub, _, err := b.Subscribe(ctx, "test", "test", 0)
 	require.NoError(t, err)
 
 	for _, expected := range input {
@@ -112,6 +124,56 @@ func TestBroadcaster(t *testing.T) {
 	requireMetricValue(t, metrics.UnsubscriptionsTotal.WithLabelValues("test", unsubscriptionReasonShutdown), 1)
 }
 
+// TestBroadcasterHasFullHistory exercises the hasFullHistory signal Subscribe
+// reports: whether the replay cache has uninterrupted history back to a
+// requested sinceRV, or whether the caller must backfill from durable
+// storage because older events were evicted (or never observed).
+func TestBroadcasterHasFullHistory(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := make(chan int)
+	t.Cleanup(func() { close(ch) })
+
+	// Subscriber buffer must exceed the cache size for readInto to succeed.
+	const subBuf = defaultCacheSize + 100
+	b := newBroadcasterWithSizes(ctx, ch, subBuf, defaultOverflowCap, nil, nil, func(v int) int64 { return int64(v) })
+
+	// Push past the cache's capacity so the oldest items are evicted: the
+	// cache ends up holding values [51, 550].
+	for i := 1; i <= defaultCacheSize+50; i++ {
+		ch <- i
+	}
+
+	t.Run("sinceRV within cached history reports full history", func(t *testing.T) {
+		_, historyCh, err := b.Subscribe(ctx, "sub1", "test", 51)
+		require.NoError(t, err)
+		require.True(t, <-historyCh)
+	})
+
+	t.Run("sinceRV older than the oldest cached item reports a gap", func(t *testing.T) {
+		_, historyCh, err := b.Subscribe(ctx, "sub2", "test", 50)
+		require.NoError(t, err)
+		require.False(t, <-historyCh)
+	})
+
+	t.Run("sinceRV == 0 always reports full history", func(t *testing.T) {
+		_, historyCh, err := b.Subscribe(ctx, "sub3", "test", 0)
+		require.NoError(t, err)
+		require.True(t, <-historyCh)
+	})
+
+	t.Run("non-zero sinceRV against an empty cache reports a gap", func(t *testing.T) {
+		emptyCh := make(chan int)
+		t.Cleanup(func() { close(emptyCh) })
+		empty := newBroadcasterWithSizes(ctx, emptyCh, subBuf, defaultOverflowCap, nil, nil, func(v int) int64 { return int64(v) })
+
+		_, historyCh, err := empty.Subscribe(ctx, "sub4", "test", 1)
+		require.NoError(t, err)
+		require.False(t, <-historyCh)
+	})
+}
+
 func TestBroadcasterUnsubscribe(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -121,14 +183,14 @@ func TestBroadcasterUnsubscribe(t *testing.T) {
 	reg := prometheus.NewPedanticRegistry()
 	metrics := newBroadcasterMetrics(reg)
 
-	b := NewBroadcaster(ctx, ch, metrics, nil)
+	b := NewBroadcaster(ctx, ch, metrics, nil, nil)
 
 	// subscribe three, then unsubscribe all
-	sub1, err := b.Subscribe(ctx, "sub1", "test")
+	sub1, _, err := b.Subscribe(ctx, "sub1", "test", 0)
 	require.NoError(t, err)
-	sub2, err := b.Subscribe(ctx, "sub2", "test")
+	sub2, _, err := b.Subscribe(ctx, "sub2", "test", 0)
 	require.NoError(t, err)
-	sub3, err := b.Subscribe(ctx, "sub3", "test")
+	sub3, _, err := b.Subscribe(ctx, "sub3", "test", 0)
 	require.NoError(t, err)
 
 	b.Unsubscribe(sub1)
@@ -144,7 +206,7 @@ func TestBroadcasterUnsubscribe(t *testing.T) {
 	require.False(t, ok)
 
 	// broadcaster should still work — new subscriber receives data
-	sub4, err := b.Subscribe(ctx, "sub4", "test")
+	sub4, _, err := b.Subscribe(ctx, "sub4", "test", 0)
 	require.NoError(t, err)
 
 	ch <- 42
@@ -166,13 +228,13 @@ func TestBroadcasterSlowConsumerDeadlock(t *testing.T) {
 	// Use small overflow cap so slow consumers get disconnected quickly.
 	const subBuf = 10
 	const ovfCap = 20
-	b := newBroadcasterWithSizes(ctx, ch, subBuf, ovfCap, nil, nil)
+	b := newBroadcasterWithSizes(ctx, ch, subBuf, ovfCap, nil, nil, nil)
 
 	// Create 101 subscribers that never read — enough to exceed the
 	// internal unsubscribe channel buffer and exercise bulk disconnect.
 	const numSubs = internalChanSize + 1
 	for i := 0; i < numSubs; i++ {
-		_, err := b.Subscribe(ctx, "test", "test")
+		_, _, err := b.Subscribe(ctx, "test", "test", 0)
 		require.NoError(t, err)
 	}
 
@@ -204,9 +266,9 @@ func TestBroadcasterOverflowSpoolsInsteadOfDisconnecting(t *testing.T) {
 
 	const subBuf = 10
 	const ovfCap = 100
-	b := newBroadcasterWithSizes(ctx, ch, subBuf, ovfCap, nil, nil)
+	b := newBroadcasterWithSizes(ctx, ch, subBuf, ovfCap, nil, nil, nil)
 
-	sub, err := b.Subscribe(ctx, "test", "test")
+	sub, _, err := b.Subscribe(ctx, "test", "test", 0)
 	require.NoError(t, err)
 
 	// Send more items than the subscriber buffer can hold.
@@ -241,9 +303,9 @@ func TestBroadcasterDisconnectsOnOverflowCapExceeded(t *testing.T) {
 
 	const subBuf = 10
 	const ovfCap = 20
-	b := newBroadcasterWithSizes(ctx, ch, subBuf, ovfCap, metrics, nil)
+	b := newBroadcasterWithSizes(ctx, ch, subBuf, ovfCap, metrics, nil, nil)
 
-	sub, err := b.Subscribe(ctx, "test", "test")
+	sub, _, err := b.Subscribe(ctx, "test", "test", 0)
 	require.NoError(t, err)
 
 	// Send enough items to fill buffer + exceed overflow cap.
@@ -293,7 +355,7 @@ func TestBroadcasterReadIntoDoesNotFillChannel(t *testing.T) {
 	// so readInto should leave headroom.
 	const subBuf = defaultCacheSize + 100
 	const ovfCap = 1000
-	b := newBroadcasterWithSizes(ctx, ch, subBuf, ovfCap, nil, nil)
+	b := newBroadcasterWithSizes(ctx, ch, subBuf, ovfCap, nil, nil, nil)
 
 	// Fill the cache to capacity by sending items through the input channel
 	// (no subscribers yet, so items only go to cache).
@@ -302,7 +364,7 @@ func TestBroadcasterReadIntoDoesNotFillChannel(t *testing.T) {
 	}
 
 	// Subscribe — readInto sends all cached items into the subscriber channel.
-	sub, err := b.Subscribe(ctx, "test", "test")
+	sub, _, err := b.Subscribe(ctx, "test", "test", 0)
 	require.NoError(t, err)
 
 	// Read one cached item to confirm the subscription is active.
@@ -342,9 +404,9 @@ func TestBroadcasterOverflowMemoryReleasedWhenCaughtUp(t *testing.T) {
 
 	const subBuf = 10
 	const ovfCap = 100
-	b := newBroadcasterWithSizes(ctx, ch, subBuf, ovfCap, metrics, nil)
+	b := newBroadcasterWithSizes(ctx, ch, subBuf, ovfCap, metrics, nil, nil)
 
-	sub, err := b.Subscribe(ctx, "test", "test")
+	sub, _, err := b.Subscribe(ctx, "test", "test", 0)
 	require.NoError(t, err)
 
 	// Send more items than the channel buffer can hold, causing overflow.
@@ -403,7 +465,7 @@ func TestBroadcasterMetricsSubscribeFailures(t *testing.T) {
 			watchBufSize: watchChanSize,
 		}
 
-		_, err := b.Subscribe(subCtx, "sub1", "test")
+		_, _, err := b.Subscribe(subCtx, "sub1", "test", 0)
 		require.Error(t, err)
 		requireMetricValue(t, metrics.SubscriptionsTotal.WithLabelValues("test", subscriptionResultCtxCanceled), 1)
 	})
@@ -414,11 +476,11 @@ func TestBroadcasterMetricsSubscribeFailures(t *testing.T) {
 
 		ctx := context.Background()
 		input := make(chan int)
-		b := newBroadcasterWithSizes(ctx, input, watchChanSize, defaultOverflowCap, metrics, nil)
+		b := newBroadcasterWithSizes(ctx, input, watchChanSize, defaultOverflowCap, metrics, nil, nil)
 		close(input)
 
 		require.Eventually(t, func() bool {
-			_, err := b.Subscribe(ctx, "sub1", "test")
+			_, _, err := b.Subscribe(ctx, "sub1", "test", 0)
 			return errors.Is(err, io.EOF)
 		}, time.Second, 10*time.Millisecond)
 		requireMetricValue(t, metrics.SubscriptionsTotal.WithLabelValues("test", subscriptionResultTerminated), 1)

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -1756,7 +1756,7 @@ func (s *server) listFromTrash(ctx context.Context, req *resourcepb.ListRequest)
 			}
 
 			// Parse item metadata — needed for both provisioned and authorization checks.
-			obj, err := parseTrashItem(iter.Value())
+			obj, err := parseMetaAccessor(iter.Value())
 			if err != nil {
 				continue
 			}
@@ -1848,8 +1848,8 @@ func (s *server) checkFolderAdmin(ctx context.Context, user claims.AuthInfo, fol
 	return isAdmin
 }
 
-// parseTrashItem unmarshals the raw value into a GrafanaMetaAccessor.
-func parseTrashItem(value []byte) (utils.GrafanaMetaAccessor, error) {
+// parseMetaAccessor unmarshals the raw value into a GrafanaMetaAccessor.
+func parseMetaAccessor(value []byte) (utils.GrafanaMetaAccessor, error) {
 	partial := &metav1.PartialObjectMetadata{}
 	if err := json.Unmarshal(value, partial); err != nil {
 		return nil, err
@@ -1896,6 +1896,11 @@ func (s *server) initWatcher() error {
 			return ""
 		}
 		return e.Key.Resource
+	}, func(e *WrittenEvent) int64 {
+		if e == nil {
+			return 0
+		}
+		return e.ResourceVersion
 	})
 	return nil
 }
@@ -1943,10 +1948,21 @@ func (s *server) Watch(req *resourcepb.WatchRequest, srv resourcepb.ResourceStor
 		return apierrors.NewUnauthorized("not allowed to list anything") // ?? or a single error?
 	}
 
+	// If the client supplies an explicit `since`, resumeRV records it so we can
+	// ask the broadcaster whether its replay cache has uninterrupted history
+	// back to that point. The cache only holds a bounded number of recent
+	// events, so a client that reconnects slowly — or a burst of writes while
+	// it was disconnected — can push events the client hasn't seen yet out of
+	// the cache before it resubscribes. When that happens we backfill the gap
+	// from durable storage below instead of silently skipping those events.
+	var resumeRV int64
+	if !req.SendInitialEvents && req.Since != 0 {
+		resumeRV = req.Since
+	}
+
 	// Start listening -- this will buffer any changes that happen while we backfill.
 	// If events are generated faster than we can process them, then some events will be dropped.
-	// TODO: Think of a way to allow the client to catch up.
-	stream, err := s.broadcaster.Subscribe(ctx, fmt.Sprintf("%s/%s/%s", key.Group, key.Resource, key.Namespace), key.Resource)
+	stream, hasFullHistory, err := s.broadcaster.Subscribe(ctx, fmt.Sprintf("%s/%s/%s", key.Group, key.Resource, key.Namespace), key.Resource, resumeRV)
 	if err != nil {
 		return err
 	}
@@ -2056,6 +2072,28 @@ func (s *server) Watch(req *resourcepb.WatchRequest, srv resourcepb.ResourceStor
 		since = req.Since
 	}
 
+	if resumeRV > 0 {
+		select {
+		case ok := <-hasFullHistory:
+			if !ok {
+				// The broadcaster's replay cache doesn't cover resumeRV onward
+				// without gaps (it may have evicted older events, or never
+				// observed any). List the missing range directly from durable
+				// storage so we don't silently skip events the client hasn't
+				// seen yet.
+				latestRV, err := s.backfillWatchGap(ctx, srv, req, checker, resumeRV, &lastEmittedRV)
+				if err != nil {
+					return err
+				}
+				if latestRV > since {
+					since = latestRV
+				}
+			}
+		case <-ctx.Done():
+			return nil
+		}
+	}
+
 	// Set up periodic bookmark ticker when the client opted in.
 	var bookmarkC <-chan time.Time
 	if req.AllowWatchBookmarks && s.bookmarkFrequency > 0 {
@@ -2131,6 +2169,71 @@ func (s *server) Watch(req *resourcepb.WatchRequest, srv resourcepb.ResourceStor
 			}
 		}
 	}
+}
+
+// backfillWatchGap replays events in (resumeRV, latestRV] straight from
+// durable storage, for the case where the broadcaster's in-memory replay
+// cache doesn't have uninterrupted history back to resumeRV (e.g. the cache
+// evicted older events during a burst of writes while the client was
+// disconnected, or never observed any events at all). It returns the
+// resource version storage has now been fully scanned up to; the caller
+// should resume filtering the live/cached stream from there rather than
+// resumeRV, to avoid re-delivering what was just backfilled.
+//
+// Because ListModifiedSince only returns the latest change per resource
+// name within the scanned range, backfilled events carry no "previous
+// object" — the client treats them as if it's seeing the resource for the
+// first time, which is the correct behaviour for a resource it never
+// observed a prior state for.
+//
+// A failure while listing (for example a backend that doesn't implement
+// ListModifiedSince, such as the legacy-SQL-backed IAM resources) is logged
+// and treated as "nothing more to backfill": the caller falls back to
+// resumeRV, i.e. exactly the pre-backfill behaviour. A failure sending to
+// the client, on the other hand, means the client is gone and is returned
+// so Watch can shut the stream down like it does everywhere else.
+func (s *server) backfillWatchGap(ctx context.Context, srv resourcepb.ResourceStore_WatchServer, req *resourcepb.WatchRequest, checker claims.ItemChecker, resumeRV int64, lastEmittedRV *int64) (int64, error) {
+	key := req.Options.Key
+	latestRV, seq := s.backend.ListModifiedSince(ctx, NamespacedResource{
+		Group:     key.Group,
+		Resource:  key.Resource,
+		Namespace: key.Namespace,
+	}, resumeRV, nil)
+
+	for res, err := range seq {
+		if err != nil {
+			s.log.Warn("watch: failed to backfill gap in replay cache from storage, resuming from cache only", "err", err)
+			return resumeRV, nil
+		}
+		if res.ResourceVersion <= resumeRV || !matchesQueryKey(key, &res.Key) {
+			continue
+		}
+
+		var folder string
+		if obj, err := parseMetaAccessor(res.Value); err == nil {
+			folder = obj.GetFolder()
+		}
+		if !checker(res.Key.Name, folder) {
+			continue
+		}
+
+		value := res.Value
+		if res.Action == resourcepb.WatchEvent_DELETED {
+			value = []byte{}
+		}
+		if err := srv.Send(&resourcepb.WatchEvent{
+			Type: res.Action,
+			Resource: &resourcepb.WatchEvent_Resource{
+				Value:   value,
+				Version: res.ResourceVersion,
+			},
+		}); err != nil {
+			return 0, err
+		}
+		*lastEmittedRV = res.ResourceVersion
+	}
+
+	return latestRV, nil
 }
 
 func (s *server) Search(ctx context.Context, req *resourcepb.ResourceSearchRequest) (*resourcepb.ResourceSearchResponse, error) {

--- a/pkg/storage/unified/resource/server_test.go
+++ b/pkg/storage/unified/resource/server_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"iter"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -1414,6 +1415,10 @@ type watchTestServerOpts struct {
 	BookmarkFrequency time.Duration
 	StorageMetrics    *StorageMetrics
 	AccessClient      authlib.AccessClient
+	// WrapBackend, if set, wraps the real KV backend before it's handed to
+	// the server — e.g. to make a specific call fail without disturbing the
+	// rest of the backend's behaviour.
+	WrapBackend func(StorageBackend) StorageBackend
 }
 
 func newWatchTestServer(t *testing.T, opts watchTestServerOpts) *server {
@@ -1430,8 +1435,13 @@ func newWatchTestServer(t *testing.T, opts watchTestServerOpts) *server {
 	})
 	require.NoError(t, err)
 
+	var backend StorageBackend = store
+	if opts.WrapBackend != nil {
+		backend = opts.WrapBackend(backend)
+	}
+
 	srv, err := NewResourceServer(ResourceServerOptions{
-		Backend:           store,
+		Backend:           backend,
 		BookmarkFrequency: opts.BookmarkFrequency,
 		StorageMetrics:    opts.StorageMetrics,
 		AccessClient:      opts.AccessClient,
@@ -1450,6 +1460,13 @@ var playlistCounter int
 // createTestPlaylist creates a playlist resource with a unique auto-generated
 // name. ctx must already carry auth info.
 func createTestPlaylist(ctx context.Context, srv *server) error {
+	_, err := createTestPlaylistRV(ctx, srv)
+	return err
+}
+
+// createTestPlaylistRV is like createTestPlaylist but also returns the
+// resource version the create was assigned.
+func createTestPlaylistRV(ctx context.Context, srv *server) (int64, error) {
 	playlistCounter++
 	name := fmt.Sprintf("playlist-%d", playlistCounter)
 	value := []byte(`{
@@ -1474,12 +1491,12 @@ func createTestPlaylist(ctx context.Context, srv *server) error {
 	}
 	created, err := srv.Create(ctx, &resourcepb.CreateRequest{Key: key, Value: value})
 	if err != nil {
-		return err
+		return 0, err
 	}
 	if created.Error != nil {
-		return fmt.Errorf("creating playlist %q: %v", name, created.Error)
+		return 0, fmt.Errorf("creating playlist %q: %v", name, created.Error)
 	}
-	return nil
+	return created.ResourceVersion, nil
 }
 
 func TestPeriodicBookmarks(t *testing.T) {
@@ -1857,6 +1874,161 @@ drain:
 	}
 	require.Len(t, added, 1)
 	require.Contains(t, string(added[0].Resource.Value), `"name":"`+allowedName+`"`)
+}
+
+// TestWatchBackfillsGapWhenReplayCacheEvicted is a regression test for the
+// broadcaster's bounded replay cache silently dropping events. The cache
+// only holds the most recent defaultCacheSize written events; if a burst of
+// writes pushes the cache past that bound before a client resumes a watch
+// from an older `Since`, naively replaying only the cache would skip
+// everything older than the cache's oldest surviving entry. The server must
+// detect that gap and backfill the missing range from durable storage.
+func TestWatchBackfillsGapWhenReplayCacheEvicted(t *testing.T) {
+	testUser := newWatchTestUser()
+	reg := prometheus.NewPedanticRegistry()
+	metrics := ProvideStorageMetrics(reg)
+	srv := newWatchTestServer(t, watchTestServerOpts{StorageMetrics: metrics})
+	ctx := authlib.WithAuthInfo(t.Context(), testUser)
+
+	// The watch below resumes just after this RV — everything created from
+	// here on must reach the client.
+	resumeRV, err := createTestPlaylistRV(ctx, srv)
+	require.NoError(t, err)
+
+	// Create enough additional resources that the broadcaster's replay cache
+	// (bounded to defaultCacheSize entries) no longer covers resumeRV.
+	const burst = defaultCacheSize + 10
+	for i := 0; i < burst; i++ {
+		require.NoError(t, createTestPlaylist(ctx, srv))
+	}
+
+	// Wait until the broadcaster has actually absorbed every create into its
+	// (bounded) cache before subscribing. Otherwise some of the burst may
+	// still be in flight and get delivered live instead of via the replay
+	// cache, which wouldn't exercise the eviction this test targets.
+	requireMetricEventually(t, metrics.Broadcaster.EventsReceivedTotal.WithLabelValues(watchTestResource), float64(1+burst))
+
+	watchCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	mock := newMockWatchServer(watchCtx)
+
+	var eg errgroup.Group
+	eg.Go(func() error {
+		return srv.Watch(&resourcepb.WatchRequest{
+			Options: &resourcepb.ListOptions{
+				Key: &resourcepb.ResourceKey{Group: watchTestGroup, Resource: watchTestResource},
+			},
+			Since: resumeRV,
+		}, mock)
+	})
+
+	added := 0
+	deadline := time.After(5 * time.Second)
+drain:
+	for added < burst {
+		select {
+		case evt := <-mock.events:
+			if evt.Type == resourcepb.WatchEvent_ADDED {
+				require.Greater(t, evt.Resource.Version, resumeRV,
+					"backfilled/replayed events must be newer than the requested Since")
+				added++
+			}
+		case <-deadline:
+			break drain
+		}
+	}
+
+	cancel()
+	require.NoError(t, eg.Wait())
+
+	require.Equal(t, burst, added, "every event after Since should be delivered exactly once, even once evicted from the replay cache")
+}
+
+// listModifiedSinceFailingBackend wraps a StorageBackend and makes
+// ListModifiedSince always fail, simulating a backend that doesn't support
+// it (e.g. the legacy-SQL-backed IAM resources).
+type listModifiedSinceFailingBackend struct {
+	StorageBackend
+}
+
+func (b *listModifiedSinceFailingBackend) ListModifiedSince(context.Context, NamespacedResource, int64, *time.Time) (int64, iter.Seq2[*ModifiedResource, error]) {
+	return 0, func(yield func(*ModifiedResource, error) bool) {
+		yield(nil, errors.New("list modified since not supported by this backend"))
+	}
+}
+
+// Stop forwards to the embedded backend's Stop, if it has one. Without this,
+// the type assertion server.Stop uses to find a stoppable backend fails
+// against the wrapper type, and the real backend (with its background
+// pruner/GC goroutines) never gets told to shut down.
+func (b *listModifiedSinceFailingBackend) Stop(ctx context.Context) error {
+	if stopper, ok := b.StorageBackend.(ResourceServerStopper); ok {
+		return stopper.Stop(ctx)
+	}
+	return nil
+}
+
+// TestWatchGapBackfillDegradesGracefullyWhenUnsupported verifies that Watch
+// doesn't fail the whole stream when the storage backend can't backfill a
+// replay-cache gap. It should fall back to whatever the replay cache and
+// live stream provide — i.e. the same behaviour as before the backfill was
+// added — rather than erroring the watch out from under the client.
+func TestWatchGapBackfillDegradesGracefullyWhenUnsupported(t *testing.T) {
+	testUser := newWatchTestUser()
+	reg := prometheus.NewPedanticRegistry()
+	metrics := ProvideStorageMetrics(reg)
+	srv := newWatchTestServer(t, watchTestServerOpts{
+		StorageMetrics: metrics,
+		WrapBackend: func(b StorageBackend) StorageBackend {
+			return &listModifiedSinceFailingBackend{StorageBackend: b}
+		},
+	})
+	ctx := authlib.WithAuthInfo(t.Context(), testUser)
+
+	resumeRV, err := createTestPlaylistRV(ctx, srv)
+	require.NoError(t, err)
+
+	// Force the same replay-cache gap as TestWatchBackfillsGapWhenReplayCacheEvicted.
+	const burst = defaultCacheSize + 10
+	for i := 0; i < burst; i++ {
+		require.NoError(t, createTestPlaylist(ctx, srv))
+	}
+	requireMetricEventually(t, metrics.Broadcaster.EventsReceivedTotal.WithLabelValues(watchTestResource), float64(1+burst))
+
+	watchCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	mock := newMockWatchServer(watchCtx)
+
+	var eg errgroup.Group
+	eg.Go(func() error {
+		return srv.Watch(&resourcepb.WatchRequest{
+			Options: &resourcepb.ListOptions{
+				Key: &resourcepb.ResourceKey{Group: watchTestGroup, Resource: watchTestResource},
+			},
+			Since: resumeRV,
+		}, mock)
+	})
+
+	// The backend can't backfill, so only the cache's bounded window of
+	// events arrives — the same imperfect-but-non-fatal outcome as before
+	// this feature existed.
+	added := 0
+	deadline := time.After(2 * time.Second)
+drain:
+	for {
+		select {
+		case evt := <-mock.events:
+			if evt.Type == resourcepb.WatchEvent_ADDED {
+				added++
+			}
+		case <-deadline:
+			break drain
+		}
+	}
+
+	cancel()
+	require.NoError(t, eg.Wait(), "Watch must not fail just because gap backfill isn't supported")
+	require.Equal(t, defaultCacheSize, added)
 }
 
 // callbackAccessClient is a test helper whose Check behavior can be swapped between calls.

--- a/pkg/storage/unified/search/embed/reconciler/fakes_test.go
+++ b/pkg/storage/unified/search/embed/reconciler/fakes_test.go
@@ -458,14 +458,16 @@ func newFakeBroadcaster() *fakeBroadcaster {
 	return &fakeBroadcaster{ch: make(chan *resource.WrittenEvent, 16)}
 }
 
-func (b *fakeBroadcaster) Subscribe(_ context.Context, _, _ string) (<-chan *resource.WrittenEvent, error) {
+func (b *fakeBroadcaster) Subscribe(_ context.Context, _, _ string, _ int64) (<-chan *resource.WrittenEvent, <-chan bool, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.subscribeCalls++
 	if b.subscribeErr != nil {
-		return nil, b.subscribeErr
+		return nil, nil, b.subscribeErr
 	}
-	return b.ch, nil
+	historyCh := make(chan bool, 1)
+	historyCh <- true
+	return b.ch, historyCh, nil
 }
 
 func (b *fakeBroadcaster) Unsubscribe(ch <-chan *resource.WrittenEvent) {

--- a/pkg/storage/unified/search/embed/reconciler/reconciler.go
+++ b/pkg/storage/unified/search/embed/reconciler/reconciler.go
@@ -239,7 +239,7 @@ func (s *Reconciler) Run(ctx context.Context) error {
 	// startupReconcile snapshot and the subscription join can't slip through;
 	// the broadcaster's replay buffer covers the brief overlap.
 	if s.broadcaster != nil {
-		ch, err := s.broadcaster.Subscribe(ctx, "embeddings-reconciler", "embeddings-reconciler")
+		ch, _, err := s.broadcaster.Subscribe(ctx, "embeddings-reconciler", "embeddings-reconciler", 0)
 		if err != nil {
 			s.log.Error("reconciler: subscribe to write events", "err", err)
 		} else if ch != nil {


### PR DESCRIPTION

`server.go`'s `Watch` subscribes to the broadcaster, which unconditionally replays its ring-buffer cache (last `defaultCacheSize`=500 written events) into every new subscriber, then the watch loop just numerically filters `event.ResourceVersion > since`. If a client resumes with an explicit `Since` older than the cache's oldest surviving entry — evicted by a burst of >500 writes while disconnected, or the cache is simply empty (fresh broadcaster, e.g. after restart) — the missing events are dropped with **no signal**, not even the dead `WatchEvent_ERROR` path. This is the exact TODO that was sitting next to the `Subscribe` call ("Think of a way to allow the client to catch up").
