### PR TITLE
fix(unified-storage): use raw snowflake RV for legacy-compat CAS comparison in DELETE/UPDATE

### DIFF
--- a/pkg/storage/unified/resource/data/sqlkv_delete_legacy_resource.sql
+++ b/pkg/storage/unified/resource/data/sqlkv_delete_legacy_resource.sql
@@ -3,4 +3,4 @@ WHERE {{ .Ident "group" }} = {{ .Arg .Group }}
 AND {{ .Ident "resource" }} = {{ .Arg .Resource }}
 AND {{ .Ident "namespace" }} = {{ .Arg .Namespace }}
 AND {{ .Ident "name" }} = {{ .Arg .Name }}
-AND {{ .Ident "resource_version" }} = {{ .Arg .PreviousRV }};
+AND {{ .Ident "resource_version" }} = {{ .Arg .CurrentRV }};

--- a/pkg/storage/unified/resource/data/sqlkv_update_legacy_resource.sql
+++ b/pkg/storage/unified/resource/data/sqlkv_update_legacy_resource.sql
@@ -10,4 +10,4 @@ WHERE {{ .Ident "group" }} = {{ .Arg .Group }}
 AND {{ .Ident "resource" }} = {{ .Arg .Resource }}
 AND {{ .Ident "namespace" }} = {{ .Arg .Namespace }}
 AND {{ .Ident "name" }} = {{ .Arg .Name }}
-AND {{ .Ident "resource_version" }} = {{ .Arg .PreviousRV }};
+AND {{ .Ident "resource_version" }} = {{ .Arg .CurrentRV }};

--- a/pkg/storage/unified/resource/datastore.go
+++ b/pkg/storage/unified/resource/datastore.go
@@ -976,6 +976,13 @@ type sqlKVLegacySaveRequest struct {
 	Action     int64
 	Folder     string
 	PreviousRV int64
+	// CurrentRV is the resource_version currently stored in the `resource`
+	// table, used for the optimistic-lock (CAS) comparison in the UPDATE/DELETE
+	// WHERE clause. It must be kept in the same encoding as the stored value
+	// (the raw snowflake RV), unlike PreviousRV which is normalized to the
+	// microsecond form used by the legacy SQL backend's previous_resource_version
+	// column.
+	CurrentRV int64
 }
 
 func (req sqlKVLegacySaveRequest) Validate() error {
@@ -1088,6 +1095,7 @@ func (d *dataStore) applyBackwardsCompatibleChanges(ctx context.Context, tx db.T
 			Action:      action,
 			Folder:      key.Folder,
 			PreviousRV:  previousRV,
+			CurrentRV:   event.PreviousRV,
 		})
 
 		if err != nil {
@@ -1107,6 +1115,7 @@ func (d *dataStore) applyBackwardsCompatibleChanges(ctx context.Context, tx db.T
 			Namespace:   key.Namespace,
 			Name:        key.Name,
 			PreviousRV:  previousRV,
+			CurrentRV:   event.PreviousRV,
 		})
 
 		if err != nil {


### PR DESCRIPTION
## What this PR does

Fixes dashboards being undeletable/unrenamable with HTTP 409 `Operation cannot be fulfilled on dashboards.dashboard.grafana.app: requested RV does not match current RV` on instances using the SQL-backed unified storage in backwards-compatibility mode (SQLite/Postgres/MySQL).

## Root cause

The `resource` table stores the **raw snowflake `resource_version`** (copied from `resource_history`). The legacy backwards-compatibility layer in `applyBackwardsCompatibleChanges` normalizes `event.PreviousRV` from snowflake to a microsecond timestamp (`RVFromSnowflake`) for the `previous_resource_version` column — but the **DELETE and UPDATE SQL templates used that same converted value in the optimistic-lock WHERE clause**, comparing it against the stored snowflake `resource_version`.

The two encodings occupy disjoint numeric ranges (snowflake ≈ 2.9e17–2.5e18 vs microsecond ≈ 1.4e15–1.9e15), so the comparison never matched. `RowsAffected()` returned 0, `checkLegacyCASConflict` reported a conflict, and the API returned 409.

This affects any dashboard whose `resource` row carries a snowflake-scale RV (e.g. resources written during a 12.x → 13.x migration). Folders/playlists/etc. use microsecond-scale RVs so the conversion is a no-op, which is why only dashboards were hit.

## Fix

Add a `CurrentRV` field to `sqlKVLegacySaveRequest` that carries the **raw snowflake `event.PreviousRV`** for the WHERE-clause CAS comparison, while keeping `PreviousRV` (microsecond) for the `previous_resource_version` column writes in the UPDATE template.

- `datastore.go`: populate `CurrentRV: event.PreviousRV` in both the `DataActionUpdated` and `DataActionDeleted` paths.
- `sqlkv_delete_legacy_resource.sql`: compare `resource_version = CurrentRV`.
- `sqlkv_update_legacy_resource.sql`: compare `resource_version = CurrentRV` in the WHERE clause; keep `previous_resource_version = PreviousRV` (microsecond) in the SET clause.

## Verification

Confirmed against the reporter's diagnosis: the failing comparison is converted-`PreviousRV` vs unconverted stored value (stored `1778015392097997869` → converted `1778015392097997`). After this change the CAS comparison uses the raw snowflake value on both sides, so DELETE/UPDATE match the stored row and RowsAffected=1.

Closes #130334