### PR TITLE
fix(cuevalidator): create fresh CUE context per validation to prevent OOM

### DIFF
--- a/apps/dashboard/pkg/apis/dashboard/cuevalidator/validator.go
+++ b/apps/dashboard/pkg/apis/dashboard/cuevalidator/validator.go
@@ -8,43 +8,29 @@ import (
 	cuejson "cuelang.org/go/encoding/json"
 )
 
-const (
-	// maxValidations limits how many validations can use the same context before it's recreated.
-	// This prevents unbounded memory growth while still allowing schema reuse for performance.
-	// After this many validations, the context is discarded and a new one is created.
-	maxValidations = 100
-)
-
-// Validator provides thread-safe CUE schema validation with periodic context recreation.
+// Validator provides thread-safe CUE schema validation.
 //
 // CUE is not safe for concurrent use: https://github.com/cue-lang/cue/discussions/1205#discussioncomment-1189238
 // This validator uses a mutex to protect concurrent access to the underlying CUE validation.
 //
-// To prevent memory leaks from CUE's internal caching, we reuse a context for up to maxValidations
-// validations, then recreate it. This balances performance (schema reuse) with memory safety
-// (periodic garbage collection of cached values).
-//
-// See https://github.com/grafana/grafana/issues/114344#issuecomment-3605562491 for details
-// about the memory leak issue and this fix.
+// Validation is performed in a fresh CUE context on every call. CUE contexts
+// accumulate internal state (adept.Vertex graphs and caches) that are never
+// released while the context is alive, so a long-lived context leaks memory at
+// steady write rates (see https://github.com/grafana/grafana/issues/114344 and
+// https://github.com/grafana/grafana/issues/130336). Creating a context per
+// validation — and recompiling the (immutable) schema into it — makes the whole
+// validation graph garbage-collectable as soon as Validate returns.
 type Validator struct {
-	schemaSource    string
-	schemaPath      cue.Path
-	mu              sync.Mutex
-	ctx             *cue.Context
-	compiledSchema  cue.Value
-	validationCount int
+	schemaSource string
+	schemaPath   cue.Path
+	mu           sync.Mutex
 }
 
 // NewValidatorFromSource creates a new validator from a schema source string and path.
-// This prevents memory leaks by periodically recreating the CUE context after maxValidations uses.
 func NewValidatorFromSource(schemaSource string, schemaPath cue.Path) *Validator {
-	cueCtx := cuecontext.New()
-	compiledSchema := cueCtx.CompileString(schemaSource).LookupPath(schemaPath)
 	return &Validator{
-		schemaSource:   schemaSource,
-		schemaPath:     schemaPath,
-		ctx:            cueCtx,
-		compiledSchema: compiledSchema,
+		schemaSource: schemaSource,
+		schemaPath:   schemaPath,
 	}
 }
 
@@ -52,17 +38,13 @@ func (v *Validator) Validate(data []byte) error {
 	v.mu.Lock()
 	defer v.mu.Unlock()
 
-	// Increment validation count
-	v.validationCount++
-
-	// If we've reached the maximum number of validations, recreate the context
-	if v.validationCount >= maxValidations {
-		// Recreate context to allow GC to reclaim cached values
-		v.ctx = cuecontext.New()
-		v.compiledSchema = v.ctx.CompileString(v.schemaSource).LookupPath(v.schemaPath)
-		v.validationCount = 0
-	}
-
-	// Validate using the current compiled schema
-	return cuejson.Validate(data, v.compiledSchema)
+	// Use a fresh context per validation. CUE contexts hold references to every
+	// value compiled into them, keeping validation-time allocations reachable
+	// from the garbage collector. A per-call context has no such long-lived
+	// references, so the whole validation graph is collected once the call
+	// returns. The context itself is cheap to create; the embedded schema source
+	// is recompiled into it, which is the only per-call cost.
+	ctx := cuecontext.New()
+	compiledSchema := ctx.CompileString(v.schemaSource).LookupPath(v.schemaPath)
+	return cuejson.Validate(data, compiledSchema)
 }

--- a/apps/dashboard/pkg/apis/dashboard/v0alpha1/validation.go
+++ b/apps/dashboard/pkg/apis/dashboard/v0alpha1/validation.go
@@ -82,9 +82,8 @@ var schemaSource string
 
 func getValidator() *cuevalidator.Validator {
 	getSchemaOnce.Do(func() {
-		// The validator uses periodic context recreation to prevent memory leaks.
-		// The context is reused for up to 100 validations, then recreated to allow
-		// garbage collection of cached values while maintaining good performance.
+		// The validator creates a fresh CUE context per validation to prevent
+		// memory leaks from CUE's internal caches.
 		validator = cuevalidator.NewValidatorFromSource(
 			schemaSource,
 			cue.ParsePath("lineage.schemas[0].schema.spec"),

--- a/apps/dashboard/pkg/apis/dashboard/v1/validation.go
+++ b/apps/dashboard/pkg/apis/dashboard/v1/validation.go
@@ -83,9 +83,8 @@ var schemaSource string
 
 func getValidator() *cuevalidator.Validator {
 	getSchemaOnce.Do(func() {
-		// The validator uses periodic context recreation to prevent memory leaks.
-		// The context is reused for up to 100 validations, then recreated to allow
-		// garbage collection of cached values while maintaining good performance.
+		// The validator creates a fresh CUE context per validation to prevent
+		// memory leaks from CUE's internal caches.
 		validator = cuevalidator.NewValidatorFromSource(
 			schemaSource,
 			cue.ParsePath("lineage.schemas[0].schema.spec"),

--- a/apps/dashboard/pkg/apis/dashboard/v2/validation.go
+++ b/apps/dashboard/pkg/apis/dashboard/v2/validation.go
@@ -132,9 +132,8 @@ var schemaSource string
 
 func getValidator() *cuevalidator.Validator {
 	getSchemaOnce.Do(func() {
-		// The validator uses periodic context recreation to prevent memory leaks.
-		// The context is reused for up to 100 validations, then recreated to allow
-		// garbage collection of cached values while maintaining good performance.
+		// The validator creates a fresh CUE context per validation to prevent
+		// memory leaks from CUE's internal caches.
 		validator = cuevalidator.NewValidatorFromSource(
 			schemaSource,
 			cue.ParsePath("DashboardSpec"),

--- a/apps/dashboard/pkg/apis/dashboard/v2alpha1/validation.go
+++ b/apps/dashboard/pkg/apis/dashboard/v2alpha1/validation.go
@@ -132,9 +132,8 @@ var schemaSource string
 
 func getValidator() *cuevalidator.Validator {
 	getSchemaOnce.Do(func() {
-		// The validator uses periodic context recreation to prevent memory leaks.
-		// The context is reused for up to 100 validations, then recreated to allow
-		// garbage collection of cached values while maintaining good performance.
+		// The validator creates a fresh CUE context per validation to prevent
+		// memory leaks from CUE's internal caches.
 		validator = cuevalidator.NewValidatorFromSource(
 			schemaSource,
 			cue.ParsePath("DashboardSpec"),

--- a/apps/dashboard/pkg/apis/dashboard/v2beta1/validation.go
+++ b/apps/dashboard/pkg/apis/dashboard/v2beta1/validation.go
@@ -132,9 +132,8 @@ var schemaSource string
 
 func getValidator() *cuevalidator.Validator {
 	getSchemaOnce.Do(func() {
-		// The validator uses periodic context recreation to prevent memory leaks.
-		// The context is reused for up to 100 validations, then recreated to allow
-		// garbage collection of cached values while maintaining good performance.
+		// The validator creates a fresh CUE context per validation to prevent
+		// memory leaks from CUE's internal caches.
 		validator = cuevalidator.NewValidatorFromSource(
 			schemaSource,
 			cue.ParsePath("DashboardSpec"),


### PR DESCRIPTION
## Description

Fixes #130336

**Problem**: A long-lived `cue.Context` accumulates compiled values internally (adt.Vertex graphs and caches) that are never released while the context is alive. At low-but-steady write rates the count-based recycling (every 100 validations) can take hours to trigger, allowing memory to grow until the pod is OOMKilled every ~5 hours.

**Fix**: Create a fresh `cue.Context` per `Validate` call and recompile the (immutable) schema into it. The whole validation graph is then garbage-collectable as soon as the call returns.

**Performance**: The context itself is cheap to create; the embedded schema source string is recompiled per call, which is the only overhead. If profiling shows this is too slow, a `sync.Pool` of contexts with a per-context write barrier can be introduced later (see discussion on #130336).

**Changes**:
- `apps/dashboard/pkg/apis/dashboard/cuevalidator/validator.go` — remove `maxValidations`, persistent `ctx`, and `compiledSchema` fields; create context per validation
- 5 caller `validation.go` files — update stale comments about "periodic context recreation"