### PR TITLE
Explore: realign query datasource UIDs on pane DS switch

### DIFF
--- a/public/app/features/explore/state/datasource.change.test.ts
+++ b/public/app/features/explore/state/datasource.change.test.ts
@@ -1,0 +1,139 @@
+import { of } from 'rxjs';
+
+import { type DataSourceApi, type DataSourceJsonData, type DataSourcePluginMeta } from '@grafana/data';
+import { type DataQuery, type DataSourceRef } from '@grafana/schema';
+import { configureStore } from 'app/store/configureStore';
+import { type StoreState, type ThunkDispatch } from 'app/types/store';
+
+import { changeDatasource } from './datasource';
+import { createDefaultInitialState } from './testHelpers';
+
+const promA: DataSourceApi = {
+  name: 'Prometheus A',
+  type: 'prometheus',
+  uid: 'prom-a',
+  meta: { id: 'prometheus' } as DataSourcePluginMeta,
+  getRef: () => ({ type: 'prometheus', uid: 'prom-a' }),
+  query: jest.fn().mockReturnValue(of({ data: [] })),
+  init: jest.fn(),
+} as unknown as DataSourceApi<DataQuery, DataSourceJsonData, {}>;
+
+const promB: DataSourceApi = {
+  name: 'Prometheus B',
+  type: 'prometheus',
+  uid: 'prom-b',
+  meta: { id: 'prometheus' } as DataSourcePluginMeta,
+  getRef: () => ({ type: 'prometheus', uid: 'prom-b' }),
+  query: jest.fn().mockReturnValue(of({ data: [] })),
+  init: jest.fn(),
+} as unknown as DataSourceApi<DataQuery, DataSourceJsonData, {}>;
+
+const datasources = [promA, promB];
+
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstance: (ref?: DataSourceRef | string) => {
+    if (!ref) {
+      return Promise.resolve(datasources[0]);
+    }
+    return Promise.resolve(
+      datasources.find((ds) => (typeof ref === 'string' ? ds.uid === ref : ds.uid === ref.uid)) || datasources[0]
+    );
+  },
+}));
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getTemplateSrv: () => ({
+    updateTimeRange: jest.fn(),
+  }),
+  getDataSourceSrv: () => ({
+    get: (ref?: DataSourceRef | string) => {
+      if (!ref) {
+        return datasources[0];
+      }
+      return datasources.find((ds) => (typeof ref === 'string' ? ds.uid === ref : ds.uid === ref.uid)) || datasources[0];
+    },
+  }),
+  reportInteraction: jest.fn(),
+}));
+
+jest.mock('app/features/correlations/utils', () => ({
+  getCorrelationsFromStorage: jest.fn().mockResolvedValue({ correlations: [] }),
+}));
+
+jest.mock('app/core/history/richHistoryStorageProvider', () => ({
+  getLocalRichHistoryStorage: () => ({
+    getRichHistory: jest.fn().mockResolvedValue({ richHistory: [] }),
+  }),
+}));
+
+jest.mock('app/features/dashboard/services/TimeSrv', () => ({
+  ...jest.requireActual('app/features/dashboard/services/TimeSrv'),
+  getTimeSrv: () => ({
+    init: jest.fn(),
+    timeRange: jest.fn().mockReturnValue({}),
+  }),
+}));
+
+describe('changeDatasource', () => {
+  const { defaultInitialState } = createDefaultInitialState();
+
+  it('updates query-level datasource UIDs when switching between same-type datasources', async () => {
+    const { dispatch, getState }: { dispatch: ThunkDispatch; getState: () => StoreState } = configureStore({
+      ...defaultInitialState,
+      explore: {
+        panes: {
+          left: {
+            ...defaultInitialState.explore.panes.left,
+            datasourceInstance: promA,
+            queries: [{ refId: 'A', expr: 'up', datasource: { type: 'prometheus', uid: 'prom-a' } }],
+            querySubscription: undefined,
+            isLive: false,
+          },
+        },
+      },
+    } as unknown as Partial<StoreState>);
+
+    await dispatch(
+      changeDatasource({
+        exploreId: 'left',
+        datasource: 'prom-b',
+        options: { importQueries: true },
+      })
+    );
+
+    const pane = getState().explore.panes.left!;
+    expect(pane.datasourceInstance?.uid).toBe('prom-b');
+    expect(pane.queries[0].datasource?.uid).toBe('prom-b');
+    expect(pane.queries[0].datasource?.type).toBe('prometheus');
+  });
+
+  it('realigns stale query UIDs even when importQueries is not requested', async () => {
+    const { dispatch, getState }: { dispatch: ThunkDispatch; getState: () => StoreState } = configureStore({
+      ...defaultInitialState,
+      explore: {
+        panes: {
+          left: {
+            ...defaultInitialState.explore.panes.left,
+            datasourceInstance: promA,
+            queries: [{ refId: 'A', expr: 'up', datasource: { type: 'prometheus', uid: 'prom-a' } }],
+            querySubscription: undefined,
+            isLive: false,
+          },
+        },
+      },
+    } as unknown as Partial<StoreState>);
+
+    await dispatch(
+      changeDatasource({
+        exploreId: 'left',
+        datasource: 'prom-b',
+      })
+    );
+
+    const pane = getState().explore.panes.left!;
+    expect(pane.datasourceInstance?.uid).toBe('prom-b');
+    expect(pane.queries[0].datasource?.uid).toBe('prom-b');
+  });
+});

--- a/public/app/features/explore/state/datasource.ts
+++ b/public/app/features/explore/state/datasource.ts
@@ -13,7 +13,7 @@ import { createAsyncThunk } from 'app/types/store';
 import { loadSupplementaryQueries } from '../utils/supplementaryQueries';
 
 import { saveCorrelationsAction } from './explorePane';
-import { importQueries, runQueries } from './query';
+import { alignQueriesToDatasource, importQueries, runQueries } from './query';
 import { changeRefreshInterval } from './time';
 import { createEmptyQueryResponse, loadAndInitDatasource } from './utils';
 
@@ -74,6 +74,11 @@ export const changeDatasource = createAsyncThunk(
     if (options?.importQueries) {
       await dispatch(importQueries(exploreId, queries, currentDataSourceInstance, instance));
     }
+
+    // runQueries prefers each query's embedded datasource over the pane instance.
+    // Always realign query-level UIDs after a pane datasource switch so requests
+    // (and the URL panes payload) cannot keep pointing at the previous datasource.
+    dispatch(alignQueriesToDatasource(exploreId, instance));
 
     if (getState().explore.panes[exploreId]!.isLive) {
       dispatch(changeRefreshInterval({ exploreId, refreshInterval: RefreshPicker.offOption.value }));

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -289,11 +289,28 @@ export function cancelQueries(exploreId: string): ThunkResult<void> {
   };
 }
 
-const addDatasourceToQueries = (datasource: DataSourceApi, queries: DataQuery[]) => {
+export const addDatasourceToQueries = (datasource: DataSourceApi, queries: DataQuery[]) => {
   const dataSourceRef = datasource.getRef();
   return queries.map((query: DataQuery) => {
     return { ...query, datasource: dataSourceRef };
   });
+};
+
+/**
+ * Ensures every query in the pane uses the given datasource ref.
+ * Needed because runQueries prefers query.datasource over the pane-level instance.
+ */
+export const alignQueriesToDatasource = (exploreId: string, datasource: DataSourceApi): ThunkResult<void> => {
+  return (dispatch, getState) => {
+    const queries = getState().explore.panes[exploreId]?.queries;
+    if (!queries?.length || datasource.meta?.mixed) {
+      return;
+    }
+    if (queries.every((query) => query.datasource?.uid === datasource.uid)) {
+      return;
+    }
+    dispatch(queriesImportedAction({ exploreId, queries: addDatasourceToQueries(datasource, queries) }));
+  };
 };
 
 const getImportableQueries = async (
@@ -381,8 +398,8 @@ export const importQueries = (
 ): ThunkResult<Promise<DataQuery[] | void>> => {
   return async (dispatch) => {
     if (!sourceDataSource) {
-      // explore not initialized
-      dispatch(queriesImportedAction({ exploreId, queries }));
+      // explore not initialized — still stamp the target datasource on queries
+      dispatch(queriesImportedAction({ exploreId, queries: addDatasourceToQueries(targetDataSource, queries) }));
       return;
     }
 


### PR DESCRIPTION
## Summary
- Switching the Explore pane datasource updated the pane-level DS but could leave each query's embedded `datasource.uid` pointing at the previous datasource.
- `runQueries` prefers `query.datasource` over the pane instance, so subsequent runs (and the URL `panes` payload) kept hitting the old UID.
- After `changeDatasource`, always realign query-level refs for non-mixed panes; also stamp the target DS when importing with a missing source instance.

Fixes #128269

## Test plan
- [x] `yarn jest --no-watch` on `datasource.change.test.ts`, `datasource.test.ts`, `query.test.ts`, `spec/datasourceState.test.tsx` (49 passed)
- [ ] Explore → Prometheus A → run query → switch pane picker to Prometheus B (same type) → run again → Network tab `x-datasource-uid` / query body uid match B
- [ ] URL `panes` JSON shows matching root `datasource` and `queries[].datasource.uid`

