### PR TITLE
Grafana UI: Allow resizing a splitter pane from zero

### DIFF
--- a/packages/grafana-ui/src/components/Splitter/useSplitter.test.tsx
+++ b/packages/grafana-ui/src/components/Splitter/useSplitter.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { useSplitter, type UseSplitterOptions } from './useSplitter';
+
+function Splitter(options: UseSplitterOptions) {
+  const { containerProps, primaryProps, secondaryProps, splitterProps } = useSplitter(options);
+
+  return (
+    <div {...containerProps}>
+      <div {...primaryProps} />
+      <div {...splitterProps} />
+      <div {...secondaryProps} />
+    </div>
+  );
+}
+
+describe('useSplitter', () => {
+  const CONTAINER = 1000;
+  const HANDLE = 16;
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // A pane can legitimately settle at zero. Starting the next gesture from that position must
+  // treat zero as a measured size, not as an uninitialized ref, or the divider gets stuck.
+  it('grows a zero-size primary pane on a new drag', () => {
+    const onResizing = jest.fn();
+    const { container } = render(<Splitter direction="column" initialSize={0} onResizing={onResizing} />);
+    const splitterContainer = container.firstElementChild!;
+    const primaryPane = splitterContainer.firstElementChild as HTMLElement;
+    const separator = screen.getByRole('separator');
+    separator.setPointerCapture = jest.fn();
+
+    // jsdom has no layout. The primary pane starts at zero, but can grow to fill the space when
+    // measureElement probes its maximum size during pointerdown.
+    jest.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function (this: Element) {
+      const height =
+        this === splitterContainer
+          ? CONTAINER
+          : this === primaryPane && primaryPane.style.flexGrow === '100'
+            ? CONTAINER - HANDLE
+            : 0;
+      return { width: 0, height } as DOMRect;
+    });
+
+    // jsdom does not implement PointerEvent, so dispatch mouse-shaped events under pointer names;
+    // React's pointer handlers still receive the coordinates used by the hook.
+    fireEvent(separator, new MouseEvent('pointerdown', { bubbles: true, clientY: 0 }));
+    fireEvent(separator, new MouseEvent('pointermove', { bubbles: true, clientY: 200 }));
+
+    expect(onResizing).toHaveBeenCalledWith(200 / (CONTAINER - HANDLE), 200, CONTAINER - HANDLE - 200);
+    expect(primaryPane).toHaveStyle({ flexGrow: `${200 / (CONTAINER - HANDLE)}` });
+  });
+});

--- a/packages/grafana-ui/src/components/Splitter/useSplitter.ts
+++ b/packages/grafana-ui/src/components/Splitter/useSplitter.ts
@@ -106,7 +106,7 @@ export function useSplitter(options: UseSplitterOptions) {
 
   const onUpdateSize = useCallback(
     (diff: number) => {
-      if (!containerSize.current || !primarySizeRef.current || !secondPaneRef.current) {
+      if (!containerSize.current || primarySizeRef.current === null || !secondPaneRef.current) {
         return;
       }
 


### PR DESCRIPTION
**What is this feature?**

Allows `useSplitter` to resize a primary pane after it reaches `0px`.

**Why do we need this feature?**

`onUpdateSize` treated a measured size of `0` as uninitialized. After fully collapsing the primary pane and releasing the pointer, subsequent drags were ignored.

**Who is this feature for?**

Users of split-pane layouts that allow the primary pane to collapse fully.

**Which issue(s) does this PR fix?**:

Fixes #130347

**Special notes for your reviewer:**

The regression test fails before the fix and passes after it. Manually reproduced on current `main` and verified with this change.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. (Not applicable.)
- [x] The docs and What's New are updated where needed. (Not applicable.)
