### PR TITLE
PanelChrome: give panel description info control an accessible name

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -191,7 +191,11 @@ export function PanelChrome({
   }
 
   const descriptionTitleItem = description && (
-    <PanelDescription description={description} className={dragClassCancel} />
+    <PanelDescription
+      description={description}
+      className={dragClassCancel}
+      title={typeof title === 'string' ? title : undefined}
+    />
   );
 
   const subtitleContent = subtitle && <PanelDescription description={subtitle} inSubHeader />;

--- a/packages/grafana-ui/src/components/PanelChrome/PanelDescription.test.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelDescription.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+
+import { PanelDescription } from './PanelDescription';
+
+describe('PanelDescription', () => {
+  it('exposes an accessible button name for the info control', () => {
+    render(<PanelDescription description="Panel help text" title="CPU usage" />);
+
+    expect(screen.getByRole('button', { name: 'More information about CPU usage' })).toBeInTheDocument();
+  });
+
+  it('falls back to a generic accessible name when title is missing', () => {
+    render(<PanelDescription description="Panel help text" />);
+
+    expect(screen.getByRole('button', { name: 'More information' })).toBeInTheDocument();
+  });
+
+  it('renders nothing when description is empty', () => {
+    const { container } = render(<PanelDescription description="" title="CPU usage" />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/packages/grafana-ui/src/components/PanelChrome/PanelDescription.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelDescription.tsx
@@ -2,6 +2,7 @@ import { css, cx } from '@emotion/css';
 import type { JSX } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
 
 import { useStyles2 } from '../../themes/ThemeContext';
 import { Icon } from '../Icon/Icon';
@@ -14,9 +15,11 @@ interface Props {
   description: string | (() => string);
   className?: string;
   inSubHeader?: boolean;
+  /** Panel title used for the accessible name of the info control */
+  title?: string;
 }
 
-export function PanelDescription({ description, className, inSubHeader }: Props) {
+export function PanelDescription({ description, className, inSubHeader, title }: Props) {
   const styles = useStyles2(getStyles);
 
   const getDescriptionContent = (): JSX.Element => {
@@ -38,9 +41,23 @@ export function PanelDescription({ description, className, inSubHeader }: Props)
     );
   }
 
+  const ariaLabel = title
+    ? t('grafana-ui.panel-chrome.aria-label-panel-description', 'More information about {{title}}', { title })
+    : t('grafana-ui.panel-chrome.aria-label-panel-description-fallback', 'More information');
+
   return description !== '' ? (
     <Tooltip interactive content={getDescriptionContent}>
-      <TitleItem className={cx(className, styles.description)}>
+      {/*
+        Tooltip must wrap the triggering element so it can set aria-describedby.
+        TitleItem with onClick renders a real button (accessible name + role).
+      */}
+      <TitleItem
+        className={cx(className, styles.description)}
+        aria-label={ariaLabel}
+        onClick={() => {
+          // No-op: opens via Tooltip focus/hover; onClick makes TitleItem a button.
+        }}
+      >
         <Icon name="info-circle" size="md" />
       </TitleItem>
     </Tooltip>

--- a/packages/grafana-ui/src/components/PanelChrome/TitleItem.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/TitleItem.tsx
@@ -45,6 +45,8 @@ export const TitleItem = forwardRef<TitleItemElement, TitleItemProps>(
           variant="secondary"
           fill="text"
           onClick={onClick}
+          title={title}
+          {...rest}
         >
           {children}
         </Button>


### PR DESCRIPTION
## Summary

Fixes the panel header "More info" control so screen readers get a proper **name** and **button** role instead of announcing a nameless group.

- Keep `Tooltip` wrapping the trigger so it can set `aria-describedby` (per prior investigation on #88013)
- Render `TitleItem` as a button and set an `aria-label` (`More information about {{title}}` when a string title is available)
- Forward aria/title props through `TitleItem`'s button path
- Add unit tests for the accessible name

Fixes #88013

## Test plan

- [x] `npx jest packages/grafana-ui/src/components/PanelChrome/PanelDescription.test.tsx --watchAll=false --ci`
- [ ] Manually: open a dashboard panel with a description, tab to the info icon, confirm Narrator/VoiceOver announces a button with "More information about …"
- [ ] Confirm focus/Enter still reveals the interactive description tooltip
- [ ] Confirm visual styling of the info control still matches neighboring title items