### PR TITLE
TraceView: Fix transparent background on event popover title

### DIFF
--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/AccordionLogs.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/AccordionLogs.tsx
@@ -39,6 +39,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       display: 'flex',
       alignItems: 'center',
       background: autoColor(theme, '#f0f0f0'),
+      padding: theme.spacing(0.5, 1),
     }),
     AccordionLogsContent: css({
       label: 'AccordionLogsContent',

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/AccordionLogs.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/AccordionLogs.tsx
@@ -38,6 +38,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       color: 'inherit',
       display: 'flex',
       alignItems: 'center',
+      background: autoColor(theme, '#f0f0f0'),
     }),
     AccordionLogsContent: css({
       label: 'AccordionLogsContent',


### PR DESCRIPTION
## What this PR does

The events popover in the Trace View (shown when hovering a span event marker) had a title row ("Events") with no background set, while the events list right below it had an opaque background. This made the title show whatever was behind the floating popover (the trace timeline), mismatched against the solid row underneath.

This adds the same background to the title row so the whole popover has one uniform, opaque backing.

## Which issue(s) this PR fixes

Fixes #110220

## Special notes for your reviewer

Single-line CSS change, no new imports. Verified:
- Existing unit tests pass unchanged (`AccordionLogs.test.tsx`)
- Manually confirmed in a local dev build: hovering a span event (TestData DB "Trace" scenario) now shows a popover with a uniform background across the title and content