### PR TITLE
TraceView: Fix overlapping content in span event popover

### DIFF
--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/AccordionKeyValues.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/AccordionKeyValues.tsx
@@ -45,6 +45,8 @@ const getStyles = (theme: GrafanaTheme2) => {
     headerLabel: css({
       width: '120px',
       display: 'inline-block',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
     }),
     headerEmpty: css({
       label: 'headerEmpty',


### PR DESCRIPTION
## What this PR does

`AccordionKeyValues`'s `headerLabel` style is a fixed-width (120px) inline-block with no overflow handling of its own. When the label text (e.g. an event name) is longer than 120px, it renders past the box and visually overlaps the `KeyValuesSummary` content shown next to it in the span event popover.

This adds `overflow: hidden` and `text-overflow: ellipsis` to `headerLabel` so long labels truncate instead of overlapping adjacent content.

## Which issue(s) this PR fixes

Fixes #110221

## Special notes for your reviewer

Two-line CSS change, no new imports. `headerLabel` is shared across all `AccordionKeyValues` call sites, so this truncation behavior applies uniformly. Existing unit tests pass unchanged (`AccordionKeyValues.test.tsx`, assertions are on DOM text/roles, not layout).