### PR TITLE
fix: quote -profile-addr in .air.toml to prevent PowerShell splitting IP on Windows (#130355)

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,6 +1,6 @@
 [build]
 bin = "./bin/grafana-air"
-args_bin = ["server", "-profile", "-profile-addr=127.0.0.1", "-profile-port=6000", "-profile-block-rate=1", "-profile-mutex-rate=5", "-packaging=dev", "cfg:app_mode=development"]
+args_bin = ["server", "-profile", "-profile-addr=\"127.0.0.1\"", "-profile-port=6000", "-profile-block-rate=1", "-profile-mutex-rate=5", "-packaging=dev", "cfg:app_mode=development"]
 cmd = "make CGO_ENABLED=0 SOURCE_DATE_EPOCH=1767222000 GO_BUILD_DEV=1 build-air"
 exclude_regex = ["_test.go", "_gen.go"]
 exclude_unchanged = true


### PR DESCRIPTION
## What

On Windows 11, running `make run` (which uses `air`) fails with a panic:

```
diagnostics: pprof profiling enabled addr 127 port 6060 blockProfileRate 1 mutexProfileRate 0
panic: listen tcp: lookup 127: no such host
```

## Root Cause

`air` on Windows passes the full command string to `powershell -NoProfile -NonInteractive -Command ...` (see [`runner/util_windows.go`](https://github.com/air-verse/air/blob/main/runner/util_windows.go)). PowerShell's native command argument passing mangles the IP address `127.0.0.1` at the dots, resulting in the binary receiving only `-profile-addr=127`.

## Fix

Wrap `127.0.0.1` in quotes in the `.air.toml` `args_bin` array so PowerShell preserves the full IP address as a single token.

- On Unix: `/bin/sh -c` strips the quotes, no change in behavior.
- On Windows: quotes prevent PowerShell from splitting at the dots.

## Related Issue

Fixes #130355