### PR TITLE
Build: Quote profiling address so make run works in native Windows

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,6 +1,6 @@
 [build]
 bin = "./bin/grafana-air"
-args_bin = ["server", "-profile", "-profile-addr=127.0.0.1", "-profile-port=6000", "-profile-block-rate=1", "-profile-mutex-rate=5", "-packaging=dev", "cfg:app_mode=development"]
+args_bin = ["server", "-profile", "-profile-addr='127.0.0.1'", "-profile-port=6000", "-profile-block-rate=1", "-profile-mutex-rate=5", "-packaging=dev", "cfg:app_mode=development"]
 cmd = "make CGO_ENABLED=0 SOURCE_DATE_EPOCH=1767222000 GO_BUILD_DEV=1 build-air"
 exclude_regex = ["_test.go", "_gen.go"]
 exclude_unchanged = true


### PR DESCRIPTION
**What is this feature?**

Single quotes the `profile-addr` value in `.air.toml` so PowerShell processes it as expected

**Why do we need this feature?**

On native Windows, when you execute `make run` the build and migrations run successfully, but the server doesn't start. As air joins the `args_bin` array into a single string as they are, when passed to PowerShell it ends up with a parameter `-profile-addr=127.0.0.1`. PowerShell cuts it at the first dot, and then keeps the rest as another argument, mangling the rest, effectively ending up with `-profile-addr=127`. 

When the server starts pprof, it attempts to bind to the address `127`, stopping the start-up process.

**Who is this feature for?**

Any developer who wants to build and run from source grafana in Windows

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/130355

**Special notes for your reviewer**:

- Tested sucessfully in Windows 11 using both PowerShell versions. 
- Tested in Linux via Docker with the quoted value.  