### PR TITLE
Analytics: Fix stacked JSDoc breaking analytics-report

### DIFF
--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/analytics/types.ts
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/analytics/types.ts
@@ -120,8 +120,10 @@ export interface MappingFormCompletedProperties extends EventProperty {
 export interface EntryPointClickedProperties extends EventProperty {
   /** The specific entry point (button, link, etc.) the user interacted with. */
   entryPoint: SourceEntryPoint;
-  /** The category of content accessible through this entry point. */
-  /** @deprecated Use contentKinds instead. */
+  /**
+   * The category of content accessible through this entry point.
+   * @deprecated Use contentKinds instead.
+   */
   contentKind: ContentKind | undefined;
   /** The categories of content accessible through this entry point. */
   contentKinds: ContentKind[];


### PR DESCRIPTION
## Summary

`yarn analytics-report` crashed while parsing event definitions. The `contentKind` property in `public/app/features/dashboard/dashgrid/DashboardLibrary/analytics/types.ts` had two stacked JSDoc blocks (a description block plus a separate `@deprecated` block). The analytics parser (`getMetadataFromJSDocs` in `scripts/cli/analytics/typeResolution.mts`) treats stacked JSDoc as an invalid event definition and throws.

This merges them into a single JSDoc block, preserving the `@deprecated` tag.

## Error before the fix

```
Error: Expected only one JSDoc comment
    at getMetadataFromJSDocs (scripts/cli/analytics/typeResolution.mts:76:11)
    at scripts/cli/analytics/eventParser.mts:205:29
    at Array.map (<anonymous>)
    at describeObjectParameters (scripts/cli/analytics/eventParser.mts:191:37)
    at resolveEventProperties (scripts/cli/analytics/eventParser.mts:168:12)
    at parseEventFromCall (scripts/cli/analytics/eventParser.mts:91:25)
    at scripts/cli/analytics/eventParser.mts:42:21
    at Array.map (<anonymous>)
    at parseEventsFromFile (scripts/cli/analytics/eventParser.mts:36:6)
    at findAllEvents (scripts/cli/analytics/findAllEvents.mts:18:20)
```

## Testing

`yarn analytics-report` now runs to completion and generates the full report.
