### PR TITLE
chore(e2e): fix 'recieved' typo in RequestsRecorder (received)

### DIFF
--- a/e2e-playwright/utils/RequestsRecorder.ts
+++ b/e2e-playwright/utils/RequestsRecorder.ts
@@ -73,7 +73,7 @@ export class RequestsRecorder {
   async #handleRequest(request: Request) {
     const type = request.resourceType();
 
-    // Once we've recieved a document response, create a list of requests that we'll count the responses of.
+    // Once we've received a document response, create a list of requests that we'll count the responses of.
     // We also want to count the document request itself.
     if (this.#documentUrl || type === 'document') {
       this.#currentRequests.add(request);
@@ -98,7 +98,7 @@ export class RequestsRecorder {
     // Record when a document response comes in so we can keep track of future requests
     if (type === 'document') {
       if (this.#documentUrl) {
-        console.warn('recieved additional document response', url);
+        console.warn('received additional document response', url);
       }
 
       this.#documentUrl = url;


### PR DESCRIPTION
### WHY

Two occurrences of `recieved` (typo for `received`) in `e2e-playwright/utils/RequestsRecorder.ts` — one in a comment, one in a `console.warn` message.

### WHAT

```diff
-// Once we've recieved a document response, ...
+// Once we've received a document response, ...
-console.warn('recieved additional document response', url);
+console.warn('received additional document response', url);
```

Trivial spelling fix; no logic change.