### PR TITLE
fix(signing): extend signing key expiration by 1 month

### DIFF
--- a/pkg/services/signingkeys/signingkeysimpl/service.go
+++ b/pkg/services/signingkeys/signingkeysimpl/service.go
@@ -117,7 +117,7 @@ func (s *Service) buildJWKS(ctx context.Context, keys []signingkeys.SigningKey) 
 
 // GetOrCreatePrivateKey returns the private key with the specified key ID. If the key does not exist, it will be
 // created with the specified algorithm.
-// The key will be automatically rotated at the beginning of each month. The previous key will be kept for 30 days.
+// The key will be automatically rotated at the beginning of each month.
 func (s *Service) GetOrCreatePrivateKey(ctx context.Context,
 	keyPrefix string, alg jose.SignatureAlgorithm) (string, crypto.Signer, error) {
 	if alg != jose.ES256 {

--- a/pkg/services/signingkeys/signingkeysimpl/service.go
+++ b/pkg/services/signingkeys/signingkeysimpl/service.go
@@ -117,8 +117,7 @@ func (s *Service) buildJWKS(ctx context.Context, keys []signingkeys.SigningKey) 
 
 // GetOrCreatePrivateKey returns the private key with the specified key ID. If the key does not exist, it will be
 // created with the specified algorithm.
-// The key will be automatically rotated at the beginning of each month. The previous key is kept
-// until the start of the month after next.
+// The key will be automatically rotated at the beginning of each month. The previous key will be kept for 30 days.
 func (s *Service) GetOrCreatePrivateKey(ctx context.Context,
 	keyPrefix string, alg jose.SignatureAlgorithm) (string, crypto.Signer, error) {
 	if alg != jose.ES256 {
@@ -180,7 +179,7 @@ func (s *Service) addPrivateKey(ctx context.Context, keyID string, alg jose.Sign
 	}
 
 	now := time.Now()
-	expiry := keyExpiry(now)
+	expiry := now.Add(30 * 24 * time.Hour)
 	key, err := s.store.Add(ctx, &signingkeys.SigningKey{
 		KeyID:      keyID,
 		PrivateKey: string(encoded),
@@ -277,11 +276,6 @@ func (s *Service) decodePrivateKey(ctx context.Context, privateKey string) (cryp
 func keyMonthScopedID(keyPrefix string, alg jose.SignatureAlgorithm) string {
 	keyID := keyPrefix + "-" + time.Now().UTC().Format("2006-01") + "-" + strings.ToLower(string(alg))
 	return keyID
-}
-
-func keyExpiry(now time.Time) time.Time {
-	utc := now.UTC()
-	return time.Date(utc.Year(), utc.Month()+2, 1, 0, 0, 0, 0, time.UTC)
 }
 
 func (s *Service) registerAPIEndpoints(router routing.RouteRegister) {

--- a/pkg/services/signingkeys/signingkeysimpl/service.go
+++ b/pkg/services/signingkeys/signingkeysimpl/service.go
@@ -178,8 +178,10 @@ func (s *Service) addPrivateKey(ctx context.Context, keyID string, alg jose.Sign
 		return nil, err
 	}
 
+	// Set expiration to a bit over a month to account for things like
+	// 31-day months or longer-lived tokens.
 	now := time.Now()
-	expiry := now.Add(30 * 24 * time.Hour)
+	expiry := now.Add(33 * 24 * time.Hour)
 	key, err := s.store.Add(ctx, &signingkeys.SigningKey{
 		KeyID:      keyID,
 		PrivateKey: string(encoded),

--- a/pkg/services/signingkeys/signingkeysimpl/service.go
+++ b/pkg/services/signingkeys/signingkeysimpl/service.go
@@ -117,7 +117,8 @@ func (s *Service) buildJWKS(ctx context.Context, keys []signingkeys.SigningKey) 
 
 // GetOrCreatePrivateKey returns the private key with the specified key ID. If the key does not exist, it will be
 // created with the specified algorithm.
-// The key will be automatically rotated at the beginning of each month. The previous key will be kept for 30 days.
+// The key will be automatically rotated at the beginning of each month. The previous key is kept
+// until the start of the month after next.
 func (s *Service) GetOrCreatePrivateKey(ctx context.Context,
 	keyPrefix string, alg jose.SignatureAlgorithm) (string, crypto.Signer, error) {
 	if alg != jose.ES256 {
@@ -179,7 +180,7 @@ func (s *Service) addPrivateKey(ctx context.Context, keyID string, alg jose.Sign
 	}
 
 	now := time.Now()
-	expiry := now.Add(30 * 24 * time.Hour)
+	expiry := keyExpiry(now)
 	key, err := s.store.Add(ctx, &signingkeys.SigningKey{
 		KeyID:      keyID,
 		PrivateKey: string(encoded),
@@ -276,6 +277,11 @@ func (s *Service) decodePrivateKey(ctx context.Context, privateKey string) (cryp
 func keyMonthScopedID(keyPrefix string, alg jose.SignatureAlgorithm) string {
 	keyID := keyPrefix + "-" + time.Now().UTC().Format("2006-01") + "-" + strings.ToLower(string(alg))
 	return keyID
+}
+
+func keyExpiry(now time.Time) time.Time {
+	utc := now.UTC()
+	return time.Date(utc.Year(), utc.Month()+2, 1, 0, 0, 0, 0, time.UTC)
 }
 
 func (s *Service) registerAPIEndpoints(router routing.RouteRegister) {

--- a/pkg/services/signingkeys/signingkeysimpl/service_test.go
+++ b/pkg/services/signingkeys/signingkeysimpl/service_test.go
@@ -129,6 +129,62 @@ func TestEmbeddedKeyService_GetOrCreatePrivateKey(t *testing.T) {
 	require.Len(t, cacheStorage.Storage, 1)
 }
 
+func TestKeyExpiry(t *testing.T) {
+	testCases := []struct {
+		name string
+		now  time.Time
+		want time.Time
+	}{
+		{
+			name: "created at the start of a 31 day month",
+			now:  time.Date(2026, 7, 1, 0, 0, 3, 0, time.UTC),
+			want: time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "created at the start of a 30 day month",
+			now:  time.Date(2026, 6, 1, 0, 0, 3, 0, time.UTC),
+			want: time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "created at the start of a 28 day month",
+			now:  time.Date(2026, 2, 1, 0, 0, 3, 0, time.UTC),
+			want: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "created on a leap day",
+			now:  time.Date(2028, 2, 29, 23, 59, 59, 0, time.UTC),
+			want: time.Date(2028, 4, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "created mid month",
+			now:  time.Date(2026, 10, 14, 12, 30, 0, 0, time.UTC),
+			want: time.Date(2026, 12, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "rolls over the year",
+			now:  time.Date(2026, 12, 3, 0, 0, 0, 0, time.UTC),
+			want: time.Date(2027, 2, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "uses the UTC month regardless of the local zone",
+			now:  time.Date(2026, 4, 1, 1, 0, 0, 0, time.FixedZone("UTC+13", 13*60*60)),
+			want: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			expiry := keyExpiry(tc.now)
+			assert.Equal(t, tc.want, expiry)
+
+			utc := tc.now.UTC()
+			lastInstantOfKeyIDMonth := time.Date(utc.Year(), utc.Month()+1, 1, 0, 0, 0, 0, time.UTC)
+			assert.True(t, expiry.After(lastInstantOfKeyIDMonth),
+				"key expires at %s, before its key ID stops being used at %s", expiry, lastInstantOfKeyIDMonth)
+		})
+	}
+}
+
 func TestExposeJWKS(t *testing.T) {
 	// create a new service instance
 	mockStore := signingkeystore.NewFakeStore()

--- a/pkg/services/signingkeys/signingkeysimpl/service_test.go
+++ b/pkg/services/signingkeys/signingkeysimpl/service_test.go
@@ -129,62 +129,6 @@ func TestEmbeddedKeyService_GetOrCreatePrivateKey(t *testing.T) {
 	require.Len(t, cacheStorage.Storage, 1)
 }
 
-func TestKeyExpiry(t *testing.T) {
-	testCases := []struct {
-		name string
-		now  time.Time
-		want time.Time
-	}{
-		{
-			name: "created at the start of a 31 day month",
-			now:  time.Date(2026, 7, 1, 0, 0, 3, 0, time.UTC),
-			want: time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC),
-		},
-		{
-			name: "created at the start of a 30 day month",
-			now:  time.Date(2026, 6, 1, 0, 0, 3, 0, time.UTC),
-			want: time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
-		},
-		{
-			name: "created at the start of a 28 day month",
-			now:  time.Date(2026, 2, 1, 0, 0, 3, 0, time.UTC),
-			want: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
-		},
-		{
-			name: "created on a leap day",
-			now:  time.Date(2028, 2, 29, 23, 59, 59, 0, time.UTC),
-			want: time.Date(2028, 4, 1, 0, 0, 0, 0, time.UTC),
-		},
-		{
-			name: "created mid month",
-			now:  time.Date(2026, 10, 14, 12, 30, 0, 0, time.UTC),
-			want: time.Date(2026, 12, 1, 0, 0, 0, 0, time.UTC),
-		},
-		{
-			name: "rolls over the year",
-			now:  time.Date(2026, 12, 3, 0, 0, 0, 0, time.UTC),
-			want: time.Date(2027, 2, 1, 0, 0, 0, 0, time.UTC),
-		},
-		{
-			name: "uses the UTC month regardless of the local zone",
-			now:  time.Date(2026, 4, 1, 1, 0, 0, 0, time.FixedZone("UTC+13", 13*60*60)),
-			want: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			expiry := keyExpiry(tc.now)
-			assert.Equal(t, tc.want, expiry)
-
-			utc := tc.now.UTC()
-			lastInstantOfKeyIDMonth := time.Date(utc.Year(), utc.Month()+1, 1, 0, 0, 0, 0, time.UTC)
-			assert.True(t, expiry.After(lastInstantOfKeyIDMonth),
-				"key expires at %s, before its key ID stops being used at %s", expiry, lastInstantOfKeyIDMonth)
-		})
-	}
-}
-
 func TestExposeJWKS(t *testing.T) {
 	// create a new service instance
 	mockStore := signingkeystore.NewFakeStore()


### PR DESCRIPTION
It makes signing keys live for 2-3 days past the end of the month. A new key is created every month, so the old key will remain valid for a few more days after the creation of a new key. This solves 31-day month, leap days, etc. issues when verifying tokens.

Just to be clear, this makes keys able to verify tokens for a bit past a month, but we still create a new key each month and stop signing tokens with the old key after 1 month of its creation.