### PR TITLE
Search: Fix free-text query dropping all-fields default to _score only

### DIFF
--- a/pkg/storage/unified/search/bleve_postrank_authz.go
+++ b/pkg/storage/unified/search/bleve_postrank_authz.go
@@ -132,7 +132,7 @@ func (c PostRankAuthzConfig) growWindow(base, nextWindow int) int {
 // request an explicit field set. The SEARCH_FIELD_ALL_FIELDS sentinel tells
 // hitsToTable to use the curated allFields column list.
 func (b *bleveIndex) ensureSearchFields(searchrequest *bleve.SearchRequest, req *resourcepb.ResourceSearchRequest) error {
-	if len(searchrequest.Fields) < 1 && req.Limit > 0 {
+	if len(req.Fields) < 1 && req.Limit > 0 {
 		f, err := b.index.Fields()
 		if err != nil {
 			return err

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -301,6 +301,31 @@ func TestCanSearchByTitle(t *testing.T) {
 		checkSearchQuery(t, index, newTestQuery("ash"), []string{"name2", "name3", "name1"})
 		checkSearchQuery(t, index, newTestQuery("ome"), []string{"name3"})
 	})
+
+	// A free-text query with no explicit response fields must still return the
+	// full all-fields column set. buildTextQuery appends the _score sentinel to
+	// the bleve field list, so the default-expansion check must key off the
+	// caller's original req.Fields — not the mutated bleve slice — or it sees a
+	// length of 1 and returns only the _score column.
+	t.Run("free-text query without explicit fields returns all-fields columns", func(t *testing.T) {
+		index := newTestDashboardsIndex(t, threshold, 2, noop)
+		indexDocumentsWithTitles(t, index, key, map[string]string{
+			"name1": "hello world",
+			"name2": "hello there",
+		})
+
+		q := newTestQuery("hello")
+		res, err := index.Search(context.Background(), nil, q, nil, nil)
+		require.NoError(t, err)
+
+		cols := make([]string, 0, len(res.Results.Columns))
+		for _, c := range res.Results.Columns {
+			cols = append(cols, c.Name)
+		}
+		require.Greater(t, len(cols), 1, "expected all-fields column set, got %v", cols)
+		require.Contains(t, cols, resource.SEARCH_FIELD_TITLE, "expected title column, got %v", cols)
+		require.NotContains(t, cols, resource.SEARCH_FIELD_SCORE, "all-fields default must not return the _score column")
+	})
 }
 
 // TestTitleNgramFieldSearch queries exclusively against the title_ngram field


### PR DESCRIPTION
**What is this feature?**

Fixes a bug where a free-text search query with no explicit response fields returned only the `_score` column instead of the full all-fields column set. `buildTextQuery` appends the `_score` sentinel to the bleve field list before `ensureSearchFields` runs, so the default-expansion check saw a length of 1 and skipped the all-fields expansion; the check now keys off the caller's original `req.Fields` instead of the already-mutated bleve slice.

**Why do we need this feature?**

Callers relying on the default (no `Fields` specified) free-text search got a single `_score` column back, breaking the documented all-fields default and forcing an explicit-field workaround.

**Who is this feature for?**

Consumers of unified storage search issuing free-text queries without an explicit field list.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Added a regression subtest in `bleve_search_test.go` that fails on the unpatched line (returns `[_score]` only) and passes with the fix; full `pkg/storage/unified/search` package is green (744 tests). Note `_score` is intentionally absent from the all-fields default — matching a no-fields non-text query.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.
