### PR TITLE
[release-13.1.4] SQLite: configure a stable modernc time format by default

### DIFF
--- a/pkg/util/sqlite/sqlite_nocgo.go
+++ b/pkg/util/sqlite/sqlite_nocgo.go
@@ -54,18 +54,22 @@ var dsnMapping = map[string]string{
 }
 
 func convertSQLite3URL(dsn string) (string, error) {
-	pos := strings.IndexRune(dsn, '?')
-	if pos < 1 {
-		return dsn, nil // no parameters to convert
+	newDSN := dsn
+	var params url.Values
+	if pos := strings.IndexRune(dsn, '?'); pos >= 1 {
+		var err error
+		if params, err = url.ParseQuery(dsn[pos+1:]); err != nil {
+			return "", err
+		}
+		newDSN = dsn[:pos]
 	}
-	params, err := url.ParseQuery(dsn[pos+1:])
-	if err != nil {
-		return "", err
-	}
-	newDSN := dsn[:pos]
 
 	q := url.Values{}
 	q.Add("_pragma", "busy_timeout(7500)") // Default of mattn/go-sqlite3 is 5s but we increase it to 7.5s to try and avoid busy errors.
+	// Without this, modernc serializes time.Time values with time.Time.String(), which Go documents as a
+	// debugging representation. That can embed a monotonic reading or a duplicated zone offset, producing
+	// values that don't round-trip. A user-supplied _time_format below overrides this default.
+	q.Set("_time_format", "sqlite")
 
 	for key, values := range params {
 		if alias, ok := dsnAlias[strings.ToLower(key)]; ok {

--- a/pkg/util/sqlite/sqlite_nocgo_test.go
+++ b/pkg/util/sqlite/sqlite_nocgo_test.go
@@ -1,0 +1,106 @@
+package sqlite
+
+import (
+	"database/sql"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestStableTimeFormat verifies that a time.Time passed directly to Exec is stored in a stable
+// format, without a monotonic reading or a duplicated zone offset (see issue #129518).
+func TestStableTimeFormat(t *testing.T) {
+	// A location with a numeric zone name is what triggered the duplicated-offset representation.
+	loc := time.FixedZone("+0330", 3*3600+30*60)
+
+	for _, dsn := range []string{
+		"file:" + filepath.Join(t.TempDir(), "test.db") + "?_journal_mode=WAL",
+		"file:" + filepath.Join(t.TempDir(), "noparams.db"),
+	} {
+		t.Run(dsn, func(t *testing.T) {
+			db, err := sql.Open("sqlite3", dsn)
+			if err != nil {
+				t.Fatalf("open SQLite database: %v", err)
+			}
+			t.Cleanup(func() {
+				if err := db.Close(); err != nil {
+					t.Errorf("close SQLite database: %v", err)
+				}
+			})
+
+			if _, err := db.ExecContext(t.Context(), "CREATE TABLE t (ts TEXT)"); err != nil {
+				t.Fatalf("create table: %v", err)
+			}
+
+			now := time.Now().In(loc)
+			if _, err := db.ExecContext(t.Context(), "INSERT INTO t (ts) VALUES (?)", now); err != nil {
+				t.Fatalf("insert time: %v", err)
+			}
+
+			var stored string
+			if err := db.QueryRowContext(t.Context(), "SELECT ts FROM t").Scan(&stored); err != nil {
+				t.Fatalf("select time: %v", err)
+			}
+
+			if strings.Contains(stored, "m=") {
+				t.Errorf("stored time contains monotonic reading: %q", stored)
+			}
+			if strings.Count(stored, "+0330") > 1 {
+				t.Errorf("stored time contains duplicated zone offset: %q", stored)
+			}
+
+			parsed, err := time.Parse("2006-01-02 15:04:05.999999999-07:00", stored)
+			if err != nil {
+				t.Fatalf("parse stored time %q: %v", stored, err)
+			}
+			if !parsed.Equal(now) {
+				t.Errorf("stored time %q does not match original %q", parsed, now)
+			}
+		})
+	}
+}
+
+func TestConvertSQLite3URL_TimeFormat(t *testing.T) {
+	testCases := []struct {
+		name string
+		dsn  string
+		want string
+	}{
+		{
+			name: "default is applied when absent",
+			dsn:  "file:test.db?_journal_mode=WAL",
+			want: "sqlite",
+		},
+		{
+			name: "default is applied without params",
+			dsn:  "file:test.db",
+			want: "sqlite",
+		},
+		{
+			name: "user configuration takes precedence",
+			dsn:  "file:test.db?_time_format=datetime",
+			want: "datetime",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			converted, err := convertSQLite3URL(tc.dsn)
+			if err != nil {
+				t.Fatalf("convertSQLite3URL: %v", err)
+			}
+			pos := strings.IndexRune(converted, '?')
+			if pos < 0 {
+				t.Fatalf("converted DSN has no query params: %q", converted)
+			}
+			q, err := url.ParseQuery(converted[pos+1:])
+			if err != nil {
+				t.Fatalf("parse converted query: %v", err)
+			}
+			if got := q.Get("_time_format"); got != tc.want {
+				t.Errorf("unexpected _time_format: got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Backports https://github.com/grafana/grafana/pull/129530 to `release-13.1.4`.

Configures a stable modernc SQLite time format to prevent malformed KV timestamps in numeric-offset time zones.