### PR TITLE
Search: publish schemas for the search endpoint

### DIFF
--- a/pkg/registry/apis/search/openapi_schemas.go
+++ b/pkg/registry/apis/search/openapi_schemas.go
@@ -1,0 +1,82 @@
+package search
+
+import (
+	"strings"
+
+	"k8s.io/kube-openapi/pkg/spec3"
+	"k8s.io/kube-openapi/pkg/util"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+
+	commonv0 "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
+	searchv0 "github.com/grafana/grafana/pkg/apis/search/v0alpha1"
+)
+
+// Go names, because that is how the generated definitions are keyed.
+const (
+	envelopePkg         = "github.com/grafana/grafana/pkg/apis/search/v0alpha1."
+	searchQueryGoName   = envelopePkg + searchv0.KindSearchQuery
+	searchResultsGoName = envelopePkg + searchv0.KindSearchResults
+)
+
+// componentPrefix is where an OpenAPI v3 document keeps its schemas.
+const componentPrefix = "#/components/schemas/"
+
+// friendly is the component name for a definition. Generated dependencies come in
+// two forms — Go import paths, and names already converted by OpenAPIModelName —
+// and converting an already-converted name reverses it twice.
+func friendly(name string) string {
+	if strings.Contains(name, "/") {
+		return util.ToRESTFriendlyName(name)
+	}
+	return name
+}
+
+func schemaRef(goName string) spec.Ref {
+	return spec.MustCreateRef(componentPrefix + friendly(goName))
+}
+
+// envelopeSchemas returns the components a route referencing roots needs, since
+// each group version's spec is self-contained.
+//
+// Dependencies are followed rather than listed so a new envelope field cannot
+// reference a component nobody publishes — which renders as an empty model with no
+// error. The common package is merged in because the envelope reaches types it
+// owns, and through them metav1.LabelSelector.
+func envelopeSchemas(roots ...string) map[string]spec.Schema {
+	defs := searchv0.GetOpenAPIDefinitions(schemaRef)
+	for name, def := range commonv0.GetOpenAPIDefinitions(schemaRef) {
+		defs[name] = def
+	}
+
+	out := map[string]spec.Schema{}
+	queue := append([]string{}, roots...)
+	for len(queue) > 0 {
+		name := queue[0]
+		queue = queue[1:]
+
+		if _, seen := out[friendly(name)]; seen {
+			continue
+		}
+		def, ok := defs[name]
+		if !ok {
+			continue
+		}
+		out[friendly(name)] = def.Schema
+		queue = append(queue, def.Dependencies...)
+	}
+
+	return out
+}
+
+// jsonContent describes a JSON body carrying the named Go type.
+func jsonContent(goName string) map[string]*spec3.MediaType {
+	return map[string]*spec3.MediaType{
+		"application/json": {
+			MediaTypeProps: spec3.MediaTypeProps{
+				Schema: &spec.Schema{
+					SchemaProps: spec.SchemaProps{Ref: schemaRef(goName)},
+				},
+			},
+		},
+	}
+}

--- a/pkg/registry/apis/search/route.go
+++ b/pkg/registry/apis/search/route.go
@@ -28,6 +28,10 @@ type Route struct {
 	Path    string
 	Spec    *spec3.PathProps
 	Handler http.HandlerFunc
+
+	// Schemas are the components Spec references. They travel with the route
+	// because the envelope types belong to a different group than the one serving.
+	Schemas map[string]spec.Schema
 }
 
 // SearchRoute returns the namespaced route for a kind's search endpoint,
@@ -42,6 +46,7 @@ func (h *Handler) SearchRoute(group, version, resourceName, kindName string) Rou
 		Path:    resourceName + "/" + searchPathSegment,
 		Spec:    searchRouteSpec(kindName, version),
 		Handler: h.SearchFor(kind),
+		Schemas: envelopeSchemas(searchQueryGoName, searchResultsGoName),
 	}
 }
 
@@ -84,9 +89,7 @@ func searchRouteSpec(kindName, version string) *spec3.PathProps {
 					RequestBodyProps: spec3.RequestBodyProps{
 						Required:    true,
 						Description: "A " + searchv0.KindSearchQuery + " describing what to match, sort and return.",
-						Content: map[string]*spec3.MediaType{
-							"application/json": {},
-						},
+						Content:     jsonContent(searchQueryGoName),
 					},
 				},
 				Responses: &spec3.Responses{
@@ -95,9 +98,7 @@ func searchRouteSpec(kindName, version string) *spec3.PathProps {
 							200: {
 								ResponseProps: spec3.ResponseProps{
 									Description: "A " + searchv0.KindSearchResults + " envelope.",
-									Content: map[string]*spec3.MediaType{
-										"application/json": {},
-									},
+									Content:     jsonContent(searchResultsGoName),
 								},
 							},
 						},

--- a/pkg/registry/apis/search/route_test.go
+++ b/pkg/registry/apis/search/route_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace/noop"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
 func TestSearchRoute(t *testing.T) {
@@ -41,4 +42,57 @@ func TestSearchOperationID(t *testing.T) {
 	}
 
 	assert.Equal(t, "listDashboardSearchV0alpha1", searchOperationID("Dashboard", "v0alpha1"))
+}
+
+// An unresolved $ref renders as an empty model rather than erroring, so every
+// reference in the published set has to resolve within it.
+func TestSearchRoute_EveryRefResolves(t *testing.T) {
+	r := NewHandler(&fakeIndexClient{resp: emptyResponse()}, testProvider(), noop.NewTracerProvider().Tracer("")).
+		SearchRoute("dashboard.grafana.app", "v1", "dashboards", "Dashboard")
+
+	require.NotEmpty(t, r.Schemas, "the route must publish the components it references")
+
+	const pkg = "com.github.grafana.grafana.pkg.apis.search.v0alpha1."
+	reqRef := r.Spec.Post.RequestBody.Content["application/json"].Schema.Ref.String()
+	resRef := r.Spec.Post.Responses.StatusCodeResponses[200].Content["application/json"].Schema.Ref.String()
+	assert.Equal(t, "#/components/schemas/"+pkg+"SearchQuery", reqRef)
+	assert.Equal(t, "#/components/schemas/"+pkg+"SearchResults", resRef)
+	assert.Contains(t, r.Schemas, pkg+"SearchQuery")
+	assert.Contains(t, r.Schemas, pkg+"SearchResults")
+
+	// Reached only through WhereNode, which contains itself: the walk followed
+	// dependencies and still terminated.
+	assert.Contains(t, r.Schemas, pkg+"WhereNode")
+	assert.Contains(t, r.Schemas, pkg+"TextPredicate")
+
+	// Trash belongs to an endpoint that does not exist yet.
+	assert.NotContains(t, r.Schemas, pkg+"TrashQuery")
+
+	// Nothing anywhere in the published set points outside it.
+	for name, schema := range r.Schemas {
+		for _, ref := range collectRefs(&schema) {
+			assert.Contains(t, r.Schemas, ref, "%s references %s, which is not published", name, ref)
+		}
+	}
+}
+
+// collectRefs returns the component names a schema references.
+func collectRefs(s *spec.Schema) []string {
+	if s == nil {
+		return nil
+	}
+	var out []string
+	if ref := s.Ref.String(); strings.HasPrefix(ref, "#/components/schemas/") {
+		out = append(out, strings.TrimPrefix(ref, "#/components/schemas/"))
+	}
+	for _, p := range s.Properties {
+		out = append(out, collectRefs(&p)...)
+	}
+	if s.Items != nil {
+		out = append(out, collectRefs(s.Items.Schema)...)
+	}
+	if s.AdditionalProperties != nil {
+		out = append(out, collectRefs(s.AdditionalProperties.Schema)...)
+	}
+	return out
 }

--- a/pkg/services/apiserver/builder/common.go
+++ b/pkg/services/apiserver/builder/common.go
@@ -16,6 +16,7 @@ import (
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/kube-openapi/pkg/common"
 	"k8s.io/kube-openapi/pkg/spec3"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 
 	"github.com/grafana/grafana/pkg/api/routing"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
@@ -109,6 +110,10 @@ type APIRouteHandler struct {
 	Path    string           // added to the appropriate level
 	Spec    *spec3.PathProps // Exposed in the open api service discovery
 	Handler http.HandlerFunc // when Level = resource, the resource will be available in context
+
+	// Schemas are components the Spec references. A route whose types belong to
+	// another group must bring them: each group version's spec is self-contained.
+	Schemas map[string]spec.Schema
 }
 
 // GroupVersionRoutes are routes the caller mounts itself, for an endpoint that

--- a/pkg/services/apiserver/builder/openapi.go
+++ b/pkg/services/apiserver/builder/openapi.go
@@ -70,11 +70,35 @@ func addRoutePaths(openAPISpec *spec3.OpenAPI, gv schema.GroupVersion, routes *A
 		openAPISpec.Paths.Paths["/apis/"+gv.String()+"/"+route.Path] = &spec3.Path{
 			PathProps: *route.Spec,
 		}
+		addRouteSchemas(openAPISpec, route)
 	}
 	for _, route := range routes.Namespace {
 		openAPISpec.Paths.Paths["/apis/"+gv.String()+"/namespaces/{namespace}/"+route.Path] = &spec3.Path{
 			PathProps: *route.Spec,
 		}
+		addRouteSchemas(openAPISpec, route)
+	}
+}
+
+// addRouteSchemas publishes the components a route's spec references. An
+// unresolved $ref renders as an empty model rather than erroring.
+func addRouteSchemas(openAPISpec *spec3.OpenAPI, route APIRouteHandler) {
+	if len(route.Schemas) == 0 {
+		return
+	}
+	if openAPISpec.Components == nil {
+		openAPISpec.Components = &spec3.Components{}
+	}
+	if openAPISpec.Components.Schemas == nil {
+		openAPISpec.Components.Schemas = map[string]*spec.Schema{}
+	}
+	for name, schema := range route.Schemas {
+		// First writer wins: routes in a group version share these types, and a
+		// kind's own definitions must not be clobbered.
+		if _, exists := openAPISpec.Components.Schemas[name]; exists {
+			continue
+		}
+		openAPISpec.Components.Schemas[name] = &schema
 	}
 }
 

--- a/pkg/services/apiserver/searchroutes/searchroutes.go
+++ b/pkg/services/apiserver/searchroutes/searchroutes.go
@@ -120,6 +120,7 @@ func toGroupVersionRoutes(byGroupVersion map[schema.GroupVersion][]searchapi.Rou
 				Path:    r.Path,
 				Spec:    r.Spec,
 				Handler: r.Handler,
+				Schemas: r.Schemas,
 			})
 		}
 		out = append(out, builder.GroupVersionRoutes{


### PR DESCRIPTION
Swagger UI failed to render the endpoint, throwing `TypeError: undefined is not an object (evaluating 'o.get("schema").toJS')`. The route declared `application/json` content with no schema, so the UI dereferenced nothing.

Referencing the envelope is not enough on its own: each group version's OpenAPI document is self-contained, and the envelope types live in `search.grafana.app` while the route is served from the kind's own group. An unresolved `$ref` renders as an empty model *without* erroring — harder to notice than the crash. So a route now carries the components its spec references, the shape app-sdk manifests already use.

Components are followed from the two roots rather than listed, so a new envelope field cannot reference something nobody publishes, and the walk terminates on `WhereNode`, which contains itself. Trash types are excluded until that endpoint exists. This holds for any kind added to the allowlist later, since the schemas travel with the route.

One trap for anything else publishing cross-group schemas: generated definitions name dependencies two ways — Go import paths, and names already converted by `OpenAPIModelName` — and converting an already-converted name reverses it twice. `TestSearchRoute_EveryRefResolves` covers it.

Verification needs a build containing this, so I will re-check the served spec and Swagger UI after merge. Epic: grafana/search-and-storage-team#869.