### PR TITLE
[release-13.1.4] SQLite: Parse legacy persisted time values

### DIFF
--- a/pkg/util/xorm/session_convert.go
+++ b/pkg/util/xorm/session_convert.go
@@ -52,6 +52,19 @@ func (session *Session) str2Time(col *core.Column, data string) (outTime time.Ti
 			x, err = time.ParseInLocation("2006-01-02 15:04:05.9999999 Z07:00", sdata, parseLoc)
 			//session.engine.logger.Debugf("time(3) key[%v]: %+v | sdata: [%v]\n", col.FieldName, x, sdata)
 		}
+		if err != nil {
+			legacyTime := sdata
+			if monotonicClock := strings.Index(legacyTime, " m="); monotonicClock >= 0 {
+				legacyTime = legacyTime[:monotonicClock]
+			}
+			x, err = time.ParseInLocation("2006-01-02 15:04:05.999999999 -0700 MST", legacyTime, parseLoc)
+			if err != nil {
+				parts := strings.Fields(legacyTime)
+				if len(parts) == 4 && parts[2] == parts[3] {
+					x, err = time.ParseInLocation("2006-01-02 15:04:05.999999999 -0700", strings.Join(parts[:3], " "), parseLoc)
+				}
+			}
+		}
 	} else if len(sdata) == 19 && strings.Contains(sdata, "-") {
 		x, err = time.ParseInLocation("2006-01-02 15:04:05", sdata, parseLoc)
 		//session.engine.logger.Debugf("time(4) key[%v]: %+v | sdata: [%v]\n", col.FieldName, x, sdata)

--- a/pkg/util/xorm/xorm_test.go
+++ b/pkg/util/xorm/xorm_test.go
@@ -3,10 +3,33 @@ package xorm
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	_ "github.com/grafana/grafana/pkg/util/sqlite"
+	"github.com/grafana/grafana/pkg/util/xorm/core"
 	"github.com/stretchr/testify/require"
 )
+
+func TestStr2TimeParsesLegacySQLiteTimestamp(t *testing.T) {
+	eng, err := NewEngine("sqlite3", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, eng.Close()) })
+
+	session := eng.NewSession()
+	t.Cleanup(session.Close)
+
+	want := time.Date(2026, time.July, 26, 8, 17, 47, 112233638, time.UTC)
+	for _, timestamp := range []string{
+		"2026-07-26 11:47:47.112233638 +0330 +0330 m=+84630.747193824",
+		"2026-07-26 11:47:47.112233638 +0330 +0330",
+	} {
+		t.Run(timestamp, func(t *testing.T) {
+			got, err := session.str2Time(&core.Column{SQLType: core.SQLType{Name: core.DateTime}}, timestamp)
+			require.NoError(t, err)
+			require.True(t, got.Equal(want), "got %s, want %s", got, want)
+		})
+	}
+}
 
 func TestBasicOperationsWithSqlite(t *testing.T) {
 	eng, err := NewEngine("sqlite3", ":memory:")


### PR DESCRIPTION
Backports https://github.com/grafana/grafana/pull/129923 to `release-13.1.4`.

The original fix was contributed by @maithilijoshi20. It allows Grafana to read malformed SQLite timestamps already persisted by affected Grafana 13.1 versions.

The automated backport was skipped because the original PR came from an external fork, so this PR applies the merged change manually.