### PR TITLE
Provisioning: Grant default permissions to root-level dashboards

### DIFF
--- a/pkg/registry/apis/provisioning/resources/parser.go
+++ b/pkg/registry/apis/provisioning/resources/parser.go
@@ -24,6 +24,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/tracing"
+	foldermodel "github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/util"
 )
 
@@ -266,6 +267,13 @@ func (r *parser) Parse(ctx context.Context, info *repository.FileInfo) (parsed *
 	parsed.FolderScoped = supportsFolderAnnotation(r.clients.SupportedResources(), parsed.GVK)
 	if info.Path != "" && parsed.FolderScoped {
 		parsed.Meta.SetFolder(r.resolveFolderID(ctx, info))
+	}
+	// Dashboards inside a folder inherit access from it; root-level ones have nothing to inherit
+	// from, so they need their own default ACL or only admins can see them. apistore strips this
+	// annotation and runs its permission setter instead of persisting it.
+	if parsed.GVK.Group == dashboard.GROUP && parsed.GVK.Kind == "Dashboard" &&
+		foldermodel.IsRootFolderUID(parsed.Meta.GetFolder()) {
+		parsed.Meta.SetAnnotation(utils.AnnoKeyGrantPermissions, utils.AnnoGrantPermissionsDefault)
 	}
 
 	return parsed, nil

--- a/pkg/storage/unified/apistore/prepare.go
+++ b/pkg/storage/unified/apistore/prepare.go
@@ -299,10 +299,20 @@ func (s *Storage) prepareObjectForUpdate(ctx context.Context, updateObject runti
 		return v, fmt.Errorf("name mismatch between existing and updated object")
 	}
 
+	// A resource moved to the root has no parent folder left to inherit access from, so it needs
+	// its own default ACL or it becomes invisible to everyone but admins. Only service identities
+	// may trigger this: a user could otherwise gain admin on somebody else's resource just by
+	// moving it to the root. IsProvisioningServiceIdentity is also checked because multi-tenant
+	// provisioning is identified by token audience rather than by access-policy UID.
+	if !folder.IsRootFolderUID(previous.GetFolder()) && folder.IsRootFolderUID(obj.GetFolder()) &&
+		(identity.IsServiceIdentity(ctx) || identity.IsProvisioningServiceIdentity(info)) {
+		v.grantPermissions = obj.GetAnnotation(utils.AnnoKeyGrantPermissions)
+	}
+
 	obj.SetCreatedBy(previous.GetCreatedBy())
 	obj.SetCreationTimestamp(previous.GetCreationTimestamp())
 	obj.SetResourceVersion("")                           // removed from saved JSON because the RV is not yet calculated
-	obj.SetAnnotation(utils.AnnoKeyGrantPermissions, "") // Grant is ignored for update requests
+	obj.SetAnnotation(utils.AnnoKeyGrantPermissions, "") // Grant is otherwise ignored for update requests
 
 	// Make sure the deprecated internalID does not change
 	obj.SetDeprecatedInternalID(previous.GetDeprecatedInternalID()) // nolint:staticcheck

--- a/pkg/storage/unified/apistore/prepare_test.go
+++ b/pkg/storage/unified/apistore/prepare_test.go
@@ -716,6 +716,79 @@ func TestEnsureRepoManagedByParentFolder(t *testing.T) {
 	})
 }
 
+// audienceAuthInfo overrides the audience, which StaticRequester derives from the org ID and
+// therefore cannot express. Multi-tenant provisioning is identified this way rather than by UID.
+type audienceAuthInfo struct {
+	*identity.StaticRequester
+	uid      string
+	audience []string
+}
+
+func (a audienceAuthInfo) GetUID() string        { return a.uid }
+func (a audienceAuthInfo) GetAudience() []string { return a.audience }
+
+func TestPrepareObjectForUpdateGrantPermissions(t *testing.T) {
+	_ = dashv1.AddToScheme(rtscheme)
+	node, err := snowflake.NewNode(rand.Int64N(1024))
+	require.NoError(t, err)
+
+	provisioningCtx, _, err := identity.WithProvisioningIdentity(context.Background(), "default")
+	require.NoError(t, err)
+	userCtx := authlib.WithAuthInfo(context.Background(),
+		&identity.StaticRequester{UserID: 1, UserUID: "u1", Type: authlib.TypeUser},
+	)
+	multiTenantCtx := authlib.WithAuthInfo(context.Background(), audienceAuthInfo{
+		StaticRequester: &identity.StaticRequester{},
+		uid:             "access-policy:some-tenant-policy",
+		audience:        []string{"org:1", "provisioning.grafana.app"},
+	})
+
+	tests := []struct {
+		name      string
+		ctx       context.Context
+		oldFolder string
+		newFolder string
+		expected  string
+	}{
+		{"provisioning move to root grants", provisioningCtx, "folder-a", "", utils.AnnoGrantPermissionsDefault},
+		{"multi-tenant provisioning move to root grants", multiTenantCtx, "folder-a", "", utils.AnnoGrantPermissionsDefault},
+		{"user move to root does not grant", userCtx, "folder-a", "", ""},
+		{"provisioning move between root aliases does not grant", provisioningCtx, folder.GeneralFolderUID, "", ""},
+		{"provisioning move into a folder does not grant", provisioningCtx, "", "folder-a", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Storage{
+				gr:        dashv1.DashboardResourceInfo.GroupResource(),
+				codec:     apitesting.TestCodec(rtcodecs, dashv1.DashboardResourceInfo.GroupVersion()),
+				snowflake: node,
+				opts: StorageOptions{
+					Scheme:              rtscheme,
+					EnableFolderSupport: true,
+				},
+			}
+
+			oldDash := &dashv1.Dashboard{ObjectMeta: v1.ObjectMeta{Name: "dash"}}
+			oldMeta, err := utils.MetaAccessor(oldDash)
+			require.NoError(t, err)
+			oldMeta.SetFolder(tt.oldFolder)
+
+			newDash := oldDash.DeepCopy()
+			newMeta, err := utils.MetaAccessor(newDash)
+			require.NoError(t, err)
+			newMeta.SetFolder(tt.newFolder)
+			newMeta.SetAnnotation(utils.AnnoKeyGrantPermissions, utils.AnnoGrantPermissionsDefault)
+
+			stored, err := s.prepareObjectForUpdate(tt.ctx, newDash, oldDash)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, stored.grantPermissions)
+			require.Empty(t, newMeta.GetAnnotation(utils.AnnoKeyGrantPermissions),
+				"annotation must never be persisted")
+		})
+	}
+}
+
 func TestVerifyFolder(t *testing.T) {
 	_ = dashv1.AddToScheme(rtscheme)
 

--- a/pkg/storage/unified/apistore/store.go
+++ b/pkg/storage/unified/apistore/store.go
@@ -783,6 +783,11 @@ func (s *Storage) GuaranteedUpdate(
 			cleanupSafe, err := s.handleManagedResourceRouting(ctx, err, resourcepb.WatchEvent_MODIFIED, key, updatedObj, destination)
 			return s.cleanupSecretsAfterFailedPreparation(ctx, v, cleanupSafe, err)
 		}
+		v.permissionCreator, err = afterCreatePermissionCreator(ctx, req.Key, v.grantPermissions, updatedObj, s.opts.Permissions)
+		if err != nil {
+			// Nothing has been written yet, so clean up any inline secrets preparation created.
+			return v.finish(ctx, err, s.opts.SecureValues)
+		}
 
 		req.Value = v.raw.Bytes()
 		req.ResourceVersion = readResponse.ResourceVersion

--- a/pkg/tests/apis/provisioning/jobs/folderless_test.go
+++ b/pkg/tests/apis/provisioning/jobs/folderless_test.go
@@ -13,6 +13,7 @@ import (
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/tests/apis"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
 
@@ -61,6 +62,13 @@ func TestIntegrationProvisioning_FolderlessSyncPlacement(t *testing.T) {
 	require.Empty(t, rootDash.GetAnnotations()[utils.AnnoKeyFolder],
 		"root-level dashboard must have no parent folder")
 	require.Equal(t, repo, rootDash.GetAnnotations()[utils.AnnoKeyManagerIdentity])
+
+	viewerDashboards := helper.GetResourceClient(apis.ResourceClientArgs{
+		User: helper.Org1.Viewer,
+		GVR:  helper.DashboardsV1.Args.GVR,
+	})
+	_, err = viewerDashboards.Resource.Get(t.Context(), allPanelsUID, metav1.GetOptions{})
+	require.NoError(t, err, "Viewer should be able to read a root-level dashboard")
 
 	// Nested dashboard must live inside the top-level folder.
 	nestedDash, err := helper.DashboardsV1.Resource.Get(t.Context(), timelineUID, metav1.GetOptions{})
@@ -371,20 +379,52 @@ func TestIntegrationProvisioning_FolderlessFileMove(t *testing.T) {
 		SyncTarget: "folderless",
 		Workflows:  []string{"write"},
 		Copies: map[string]string{
-			"../testdata/all-panels.json": "dashboard.json",
+			"../testdata/all-panels.json": "team-y/dashboard.json",
 		},
 	})
 
 	helper.RequireRepoDashboardCount(t, repo, 1)
-	helper.RequireRepoFolderCount(t, repo, 0)
+	helper.RequireRepoFolderCount(t, repo, 1)
 
-	// Initially top-level: no parent folder.
+	// Initially in a top-level folder.
 	dash, err := helper.DashboardsV1.Resource.Get(t.Context(), allPanelsUID, metav1.GetOptions{})
 	require.NoError(t, err)
-	require.Empty(t, dash.GetAnnotations()[utils.AnnoKeyFolder], "dashboard should start at the top level")
+	require.NotEmpty(t, dash.GetAnnotations()[utils.AnnoKeyFolder], "dashboard should start in the subfolder")
+
+	// Move subdirectory -> root (reparent to the top level).
+	resp := helper.PostFilesRequest(t, repo, common.FilesPostOptions{
+		TargetPath:   "dashboard.json",
+		OriginalPath: "team-y/dashboard.json",
+		Message:      "move dashboard to the repository root",
+	})
+	_ = resp.Body.Close()
+	require.Equal(t, 200, resp.StatusCode, "move to root should succeed")
+
+	_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "dashboard.json")
+	require.NoError(t, err, "file should exist at the repository root")
+	_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "team-y", "dashboard.json")
+	require.Error(t, err, "file should no longer exist in the subdirectory")
+
+	// The dashboard is reparented to the top level and gains its own default permissions.
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		moved, err := helper.DashboardsV1.Resource.Get(t.Context(), allPanelsUID, metav1.GetOptions{})
+		if !assert.NoError(collect, err) {
+			return
+		}
+		assert.Empty(collect, moved.GetAnnotations()[utils.AnnoKeyFolder],
+			"dashboard should be parented to the root after the move")
+		assert.Equal(collect, repo, moved.GetAnnotations()[utils.AnnoKeyManagerIdentity])
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "dashboard should be reparented to the root")
+
+	viewerDashboards := helper.GetResourceClient(apis.ResourceClientArgs{
+		User: helper.Org1.Viewer,
+		GVR:  helper.DashboardsV1.Args.GVR,
+	})
+	_, err = viewerDashboards.Resource.Get(t.Context(), allPanelsUID, metav1.GetOptions{})
+	require.NoError(t, err, "Viewer should be able to read a dashboard moved to the repository root")
 
 	// Move root -> subdirectory (reparent into a top-level folder).
-	resp := helper.PostFilesRequest(t, repo, common.FilesPostOptions{
+	resp = helper.PostFilesRequest(t, repo, common.FilesPostOptions{
 		TargetPath:   "team-y/dashboard.json",
 		OriginalPath: "dashboard.json",
 		Message:      "move dashboard into a subfolder",
@@ -393,39 +433,14 @@ func TestIntegrationProvisioning_FolderlessFileMove(t *testing.T) {
 	require.Equal(t, 200, resp.StatusCode, "move into subfolder should succeed")
 
 	_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "team-y", "dashboard.json")
-	require.NoError(t, err, "file should exist at the new subdirectory path")
-	_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "dashboard.json")
-	require.Error(t, err, "file should no longer exist at the repo root")
-
-	// The dashboard is reparented into the (now top-level) subfolder.
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		moved, err := helper.DashboardsV1.Resource.Get(t.Context(), allPanelsUID, metav1.GetOptions{})
-		if !assert.NoError(collect, err) {
-			return
-		}
-		assert.NotEmpty(collect, moved.GetAnnotations()[utils.AnnoKeyFolder],
-			"dashboard should be parented to the subfolder after the move")
-		assert.Equal(collect, repo, moved.GetAnnotations()[utils.AnnoKeyManagerIdentity])
-	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "dashboard should be reparented into the subfolder")
-
-	// Move subdirectory -> root (reparent back to the top level).
-	resp = helper.PostFilesRequest(t, repo, common.FilesPostOptions{
-		TargetPath:   "dashboard.json",
-		OriginalPath: "team-y/dashboard.json",
-		Message:      "move dashboard back to the top level",
-	})
-	_ = resp.Body.Close()
-	require.Equal(t, 200, resp.StatusCode, "move back to root should succeed")
-
-	_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "dashboard.json")
-	require.NoError(t, err, "file should exist back at the repo root")
+	require.NoError(t, err, "file should exist in the subdirectory")
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		back, err := helper.DashboardsV1.Resource.Get(t.Context(), allPanelsUID, metav1.GetOptions{})
 		if !assert.NoError(collect, err) {
 			return
 		}
-		assert.Empty(collect, back.GetAnnotations()[utils.AnnoKeyFolder],
-			"dashboard should be back at the top level after moving to root")
-	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "dashboard should return to the top level")
+		assert.NotEmpty(collect, back.GetAnnotations()[utils.AnnoKeyFolder],
+			"dashboard should be parented to the subfolder after the move")
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "dashboard should return to the subfolder")
 }


### PR DESCRIPTION
**What is this feature?**

It's a fix so viewers can still access dashboards that use top-level provisioning

**Why do we need this feature?**

Now, viewers cannot see top level dashboards when they are synced using the folderless sync

**Who is this feature for?**

all

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
