### PR TITLE
fix(users): handle error when user login is updated to an already used one

### DIFF
--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -289,6 +289,9 @@ func (hs *HTTPServer) handleUpdateUser(ctx context.Context, cmd user.UpdateUserC
 		if errors.Is(err, user.ErrCaseInsensitive) {
 			return response.Error(http.StatusConflict, "Update would result in user login conflict", err)
 		}
+		if errors.Is(err, user.ErrUserAlreadyExists) {
+			return response.Error(http.StatusConflict, "Login or email is already in use", err)
+		}
 		return response.ErrOrFallback(http.StatusInternalServerError, "Failed to update user", err)
 	}
 

--- a/pkg/api/user_test.go
+++ b/pkg/api/user_test.go
@@ -651,6 +651,21 @@ func TestIntegrationHTTPServer_UpdateUser(t *testing.T) {
 			assert.Equal(t, 403, sc.resp.Code)
 		},
 	}, hs)
+
+	hs.userService = &usertest.FakeUserService{ExpectedError: user.ErrUserAlreadyExists}
+
+	updateUserScenario(t, updateUserContext{
+		desc:         "Should return 409 when the login or email is taken by another user",
+		url:          "/api/users/1",
+		routePattern: "/api/users/:id",
+		cmd:          updateUserCommand,
+		fn: func(sc *scenarioContext) {
+			sc.authInfoService.ExpectedError = user.ErrUserNotFound
+
+			sc.fakeReqWithParams("PUT", sc.url, map[string]string{"id": "1"}).exec()
+			assert.Equal(t, http.StatusConflict, sc.resp.Code)
+		},
+	}, hs)
 }
 
 func setupUpdateEmailTests(t *testing.T, cfg *setting.Cfg) (*user.User, *HTTPServer, *notifications.NotificationServiceMock) {

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -272,7 +272,7 @@ func (ss *sqlStore) Update(ctx context.Context, cmd *user.UpdateUserCommand) err
 		})
 
 		if _, err := q.Update(&usr); err != nil {
-			return err
+			return handleSQLError(ss.dialect, err)
 		}
 
 		if cmd.IsGrafanaAdmin != nil && !*cmd.IsGrafanaAdmin {

--- a/pkg/services/user/userimpl/store_test.go
+++ b/pkg/services/user/userimpl/store_test.go
@@ -1024,6 +1024,46 @@ func TestIntegrationUserUpdate(t *testing.T) {
 		require.Equal(t, "loginuser3", result.Login)
 		require.Equal(t, "user3@test.com", result.Email)
 	})
+
+	t.Run("Testing DB - update to a login taken by another user conflicts", func(t *testing.T) {
+		err := userStore.Update(context.Background(), &user.UpdateUserCommand{
+			Login:  "loginUSER0",
+			Email:  "USER1@test.com",
+			UserID: users[1].ID,
+		})
+		require.ErrorIs(t, err, user.ErrUserAlreadyExists)
+
+		result, err := userStore.GetByID(context.Background(), users[1].ID)
+		require.NoError(t, err)
+		require.Equal(t, "loginuser1", result.Login)
+	})
+
+	t.Run("Testing DB - update to an email taken by another user conflicts", func(t *testing.T) {
+		err := userStore.Update(context.Background(), &user.UpdateUserCommand{
+			Login:  "loginUSER1",
+			Email:  "USER0@test.com",
+			UserID: users[1].ID,
+		})
+		require.ErrorIs(t, err, user.ErrUserAlreadyExists)
+
+		result, err := userStore.GetByID(context.Background(), users[1].ID)
+		require.NoError(t, err)
+		require.Equal(t, "user1@test.com", result.Email)
+	})
+
+	t.Run("Testing DB - update keeping the user's own login and email succeeds", func(t *testing.T) {
+		err := userStore.Update(context.Background(), &user.UpdateUserCommand{
+			Login:  "loginUSER1",
+			Email:  "USER1@test.com",
+			Name:   "Renamed",
+			UserID: users[1].ID,
+		})
+		require.NoError(t, err)
+
+		result, err := userStore.GetByID(context.Background(), users[1].ID)
+		require.NoError(t, err)
+		require.Equal(t, "Renamed", result.Name)
+	})
 }
 
 func createFiveTestUsers(t *testing.T, svc user.Service, fn func(i int) *user.CreateUserCommand) []*user.User {


### PR DESCRIPTION
Fixes bug where a 500 is returned when a user has its login or email updated to one that's already in use.

It does so by using the existing `handleSQLError()` helper: https://github.com/grafana/grafana/blob/caef03cc03af5476d2c3ebc6ab3b986dc4ad9e42/pkg/services/user/userimpl/store.go#L599-L604