### PR TITLE
TableNG: resize + width cleanups

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/TableFlat.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableFlat.tsx
@@ -22,6 +22,7 @@ import {
   useScrollbarWidth,
   useSortedRows,
   useRowCompiler,
+  useTypographyCtx,
 } from './hooks';
 import { type ColumnBuildConfig, useColumnBuilderFromFields, useDataGridRows } from './render-hooks';
 import {
@@ -34,8 +35,6 @@ import {
 } from './types';
 import {
   calculateFooterHeight,
-  createTypographyContext,
-  extractPixelValue,
   getApplyToRowBgFn,
   getCellColorInlineStylesFactory,
   getCellLinks,
@@ -140,8 +139,7 @@ export function TableFlat(props: TableNGProps) {
 
   const gridRef = useRef<DataGridHandle>(null);
   const scrollbarWidth = useScrollbarWidth(gridRef, height);
-  // `width` may already be debounced by RefactoredTableNG. scrollbarWidth never is, so a scrollbar
-  // appearing/disappearing re-sizes columns immediately instead of lagging behind that debounce.
+  // A scrollbar appearing/disappearing changes how much room the columns have, so factor it out.
   const availableWidth = useMemo(() => width - scrollbarWidth, [width, scrollbarWidth]);
 
   const getCellColorInlineStyles = useMemo(() => getCellColorInlineStylesFactory(theme), [theme]);
@@ -151,15 +149,7 @@ export function TableFlat(props: TableNGProps) {
   );
   const getTextColorForBackground = useMemo(() => memoize(_getTextColorForBackground, { maxSize: 1000 }), []);
 
-  const typographyCtx = useMemo(
-    () =>
-      createTypographyContext(
-        theme.typography.fontSize,
-        theme.typography.fontFamily,
-        extractPixelValue(theme.typography.body.letterSpacing!) * theme.typography.fontSize
-      ),
-    [theme]
-  );
+  const typographyCtx = useTypographyCtx(theme);
 
   const frozenColumns = _frozenColumns;
 

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.safari.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.safari.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+
+import { applyFieldOverrides, createTheme, type DataFrame, FieldType, toDataFrame } from '@grafana/data';
+
+import { TableNG } from './TableNG';
+
+// Safari 26 has a rendering bug that TableNG works around by wrapping the table in a
+// `contain: strict` container (Safari26Wrapper). IS_SAFARI_26 is derived from the user agent at
+// module load, so we force it on here to exercise that path. Scoped to its own file so the override
+// doesn't leak into the main suite; getGridStyles keeps the real value via requireActual.
+jest.mock('./styles', () => {
+  const actual = jest.requireActual('./styles');
+  return { ...actual, IS_SAFARI_26: true };
+});
+
+const createBasicDataFrame = (): DataFrame =>
+  applyFieldOverrides({
+    data: [
+      toDataFrame({
+        name: 'TestData',
+        length: 1,
+        fields: [{ name: 'Column A', type: FieldType.string, values: ['A1'], config: { custom: {} } }],
+      }),
+    ],
+    fieldConfig: { defaults: {}, overrides: [] },
+    replaceVariables: (value) => value,
+    timeZone: 'utc',
+    theme: createTheme(),
+  })[0];
+
+describe('TableNG Safari 26 workaround', () => {
+  it('wraps the table in a contain:strict container without breaking rendering', () => {
+    const { container } = render(
+      <TableNG enableVirtualization={false} data={createBasicDataFrame()} width={800} height={600} />
+    );
+
+    // The grid renders inside an extra wrapper div rather than at the container root.
+    const grid = container.querySelector('[role="grid"]');
+    expect(grid).toBeInTheDocument();
+    expect(container.firstElementChild).not.toBe(grid);
+    expect(container.firstElementChild?.tagName).toBe('DIV');
+
+    // cell content still renders through the wrapper
+    expect(screen.getByText('A1')).toBeInTheDocument();
+  });
+});

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.test.tsx
@@ -1041,10 +1041,11 @@ describe('TableNG', () => {
       render(<TableNG enableVirtualization={false} data={createGeoDataFrame()} width={800} height={600} />);
 
       // A geo field sends TableNG down the Suspense/LazyOpenLayersProvider branch. Until the
-      // provider resolves, GeoCell has no formatGeometry and just stringifies the raw geometry;
-      // once it loads the cell renders the geometry as WKT (EPSG:3857 -> 4326). Waiting for that
-      // WKT proves the geo cell rendered through the lazily-loaded provider, not the fallback.
-      expect(await screen.findByText(/POINT\(-74\.0445 40\.6891/)).toBeInTheDocument();
+      // provider resolves, GeoCell has no formatGeometry and stringifies the raw geometry (a plain
+      // object); once it loads, the cell renders the geometry as WKT. Matching the WKT *shape*
+      // (rather than exact coordinates, which drift through the projection round-trip) proves the
+      // geo cell rendered through the lazily-loaded provider rather than the Suspense fallback.
+      expect(await screen.findByText(/^POINT\([^)]+\)$/)).toBeInTheDocument();
     });
   });
 

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Point } from 'ol/geom';
+import { fromLonLat } from 'ol/proj';
 
 import {
   applyFieldOverrides,
@@ -258,7 +259,12 @@ const createGeoDataFrame = (): DataFrame =>
       length: 1,
       fields: [
         { name: 'Label', type: FieldType.string, values: ['NYC'], config: { custom: {} } },
-        { name: 'Location', type: FieldType.geo, values: [new Point([-74.0445, 40.6892])], config: { custom: {} } },
+        {
+          name: 'Location',
+          type: FieldType.geo,
+          values: [new Point(fromLonLat([-74.0445, 40.6892]))],
+          config: { custom: {} },
+        },
       ],
     })
   );
@@ -1031,11 +1037,14 @@ describe('TableNG', () => {
   });
 
   describe('Geo cells', () => {
-    it('routes through the lazy OpenLayers provider when a geo cell is present', async () => {
+    it('renders the geo cell as WKT once the lazy OpenLayers provider loads', async () => {
       render(<TableNG enableVirtualization={false} data={createGeoDataFrame()} width={800} height={600} />);
-      // A geo field sends TableNG down the Suspense/LazyOpenLayersProvider branch rather than
-      // rendering the plain table directly; the non-geo column still renders while it loads.
-      expect(await screen.findByText('NYC')).toBeInTheDocument();
+
+      // A geo field sends TableNG down the Suspense/LazyOpenLayersProvider branch. Until the
+      // provider resolves, GeoCell has no formatGeometry and just stringifies the raw geometry;
+      // once it loads the cell renders the geometry as WKT (EPSG:3857 -> 4326). Waiting for that
+      // WKT proves the geo cell rendered through the lazily-loaded provider, not the fallback.
+      expect(await screen.findByText(/POINT\(-74\.0445 40\.6891/)).toBeInTheDocument();
     });
   });
 

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.test.tsx
@@ -18,7 +18,6 @@ import { type PanelContext, PanelContextProvider } from '../../PanelChrome';
 import { TableCellDisplayMode } from '../types';
 
 import { TableNG } from './TableNG';
-import { RESIZE_WIDTH_DEBOUNCE_MS } from './hooks';
 
 // Shared helpers for test data frame construction
 const withFieldOverrides = (frame: ReturnType<typeof toDataFrame>): DataFrame =>
@@ -2361,11 +2360,10 @@ describe('TableNG', () => {
     });
   });
 
-  describe('width debouncing', () => {
+  describe('column width on resize', () => {
     let origResizeObserver = global.ResizeObserver;
 
     beforeEach(() => {
-      jest.useFakeTimers();
       origResizeObserver = global.ResizeObserver;
       global.ResizeObserver = class ResizeObserver {
         observe() {}
@@ -2375,7 +2373,6 @@ describe('TableNG', () => {
     });
 
     afterEach(() => {
-      jest.useRealTimers();
       global.ResizeObserver = origResizeObserver;
     });
 
@@ -2410,19 +2407,16 @@ describe('TableNG', () => {
       expect(columnTemplate(container)).toBe('450px 450px');
     });
 
-    it('defers width changes until the resize settles when an auto-sized pill column is present', () => {
+    it('applies width changes immediately for an auto-sized pill column', () => {
       const data = frameWithFields([pillField(), valueField]);
       const { container, rerender } = renderAtWidth(data, 400);
       expect(columnTemplate(container)).toBe('200px 200px');
 
       rerender(<TableNG enableVirtualization={false} data={data} width={900} height={300} />);
-      expect(columnTemplate(container)).toBe('200px 200px');
-
-      act(() => jest.advanceTimersByTime(RESIZE_WIDTH_DEBOUNCE_MS));
       expect(columnTemplate(container)).toBe('450px 450px');
     });
 
-    it('defers width changes until the resize settles when an auto-sized column wraps its text', () => {
+    it('applies width changes immediately when an auto-sized column wraps its text', () => {
       const data = frameWithFields([
         {
           name: 'Name',
@@ -2436,16 +2430,13 @@ describe('TableNG', () => {
       expect(columnTemplate(container)).toBe('200px 200px');
 
       rerender(<TableNG enableVirtualization={false} data={data} width={900} height={300} />);
-      expect(columnTemplate(container)).toBe('200px 200px');
-
-      act(() => jest.advanceTimersByTime(RESIZE_WIDTH_DEBOUNCE_MS));
       expect(columnTemplate(container)).toBe('450px 450px');
     });
 
-    // Toggling width-sensitivity (here by turning on text wrapping) flips whether the debounce is active.
-    // The debounce wrapper stays mounted regardless, so the table must not remount — a remount would
-    // recreate the grid DOM node and wipe local state like filters, pagination, and column resize.
-    it('does not remount the table when width-sensitivity toggles', () => {
+    // Toggling text wrapping changes the field config but the same table component renders throughout,
+    // so it must not remount — a remount would recreate the grid DOM node and wipe local state like
+    // filters, pagination, and column resize.
+    it('does not remount the table when a width-sensitive config toggles', () => {
       const gridNode = (container: HTMLElement) => container.querySelector('[role="grid"], [role="treegrid"]');
 
       const insensitive = frameWithFields([
@@ -2473,7 +2464,7 @@ describe('TableNG', () => {
       expect(columnTemplate(container)).toBe('100px 800px');
     });
 
-    it('defers width changes when only a nested table has a width-sensitive column', () => {
+    it('applies width changes immediately when only a nested table has a width-sensitive column', () => {
       const nestedFrame = toDataFrame({
         name: 'Nested',
         fields: [pillField(), valueField],
@@ -2492,9 +2483,6 @@ describe('TableNG', () => {
       const initialTemplate = columnTemplate(container);
 
       rerender(<TableNG enableVirtualization={false} data={data} width={900} height={300} />);
-      expect(columnTemplate(container)).toBe(initialTemplate);
-
-      act(() => jest.advanceTimersByTime(RESIZE_WIDTH_DEBOUNCE_MS));
       expect(columnTemplate(container)).not.toBe(initialTemplate);
     });
   });

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.test.tsx
@@ -1,5 +1,6 @@
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { Point } from 'ol/geom';
 
 import {
   applyFieldOverrides,
@@ -246,6 +247,18 @@ const createTimeDataFrame = (): DataFrame =>
           config: { custom: {} },
         },
         { name: 'Value', type: FieldType.number, values: [1, 2, 3], config: { custom: {} } },
+      ],
+    })
+  );
+
+const createGeoDataFrame = (): DataFrame =>
+  withFieldOverrides(
+    toDataFrame({
+      name: 'GeoData',
+      length: 1,
+      fields: [
+        { name: 'Label', type: FieldType.string, values: ['NYC'], config: { custom: {} } },
+        { name: 'Location', type: FieldType.geo, values: [new Point([-74.0445, 40.6892])], config: { custom: {} } },
       ],
     })
   );
@@ -1014,6 +1027,15 @@ describe('TableNG', () => {
       );
 
       expect(container.querySelector('.table-ng-pagination')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Geo cells', () => {
+    it('routes through the lazy OpenLayers provider when a geo cell is present', async () => {
+      render(<TableNG enableVirtualization={false} data={createGeoDataFrame()} width={800} height={600} />);
+      // A geo field sends TableNG down the Suspense/LazyOpenLayersProvider branch rather than
+      // rendering the plain table directly; the non-geo column still renders while it loads.
+      expect(await screen.findByText('NYC')).toBeInTheDocument();
     });
   });
 

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -1,17 +1,15 @@
 import { css } from '@emotion/css';
 import { Suspense, useMemo } from 'react';
 
-import { type Field, FieldType } from '@grafana/data';
+import { FieldType } from '@grafana/data';
 
 import { useStyles2 } from '../../../themes/ThemeContext';
 import { hasGeoCell, LazyOpenLayersProvider } from '../geo';
 
 import { TableFlat } from './TableFlat';
 import { TableNested } from './TableNested';
-import { RESIZE_WIDTH_DEBOUNCE_MS, useDebouncedNumber } from './hooks';
 import { IS_SAFARI_26 } from './styles';
 import { type TableNGProps } from './types';
-import { getVisibleFields, shouldDebounceWidth } from './utils';
 
 // Safari 26 shipped with a bug that prevents the table from rendering correctly
 // unless it is wrapped in a container with `contain: strict`.
@@ -20,47 +18,16 @@ function Safari26Wrapper(props: { children: React.ReactNode }) {
   return <div className={className}>{props.children}</div>;
 }
 
-// The debounce costs a frame of staleness on every resize, so we only feed the debounced width to
-// layouts which are expensive to re-apply; everything else gets the live width. This wrapper is
-// always mounted (regardless of `enabled`) so toggling debounce — e.g. when wrap text or a cell type
-// changes field width-sensitivity — doesn't change the fiber tree and remount the table, which would
-// reset local state like filters, pagination, expanded rows, and column resize.
-function DebouncedWidth({
-  width,
-  enabled,
-  children,
-}: {
-  width: number;
-  enabled: boolean;
-  children: (width: number) => React.ReactNode;
-}) {
-  const debounced = useDebouncedNumber(width, RESIZE_WIDTH_DEBOUNCE_MS);
-  return <>{children(enabled ? debounced : width)}</>;
-}
-
 export function TableNG(props: TableNGProps) {
   const { data, width } = props;
 
   const nestedDataField = useMemo(() => data.fields.find((f) => f.type === FieldType.nestedFrames), [data.fields]);
   const tableHasGeoCell = useMemo(() => hasGeoCell(data), [data]);
 
-  const needsDebounce = useMemo(() => {
-    // nested grids size their auto columns off the same panel width, so either level can require it.
-    const nestedFields: Field[] = nestedDataField?.values[0]?.[0]?.fields ?? [];
-    return shouldDebounceWidth(getVisibleFields(data.fields)) || shouldDebounceWidth(getVisibleFields(nestedFields));
-  }, [data.fields, nestedDataField]);
-
-  const renderTable = (tableWidth: number) =>
-    nestedDataField ? (
-      <TableNested {...props} width={tableWidth} nestedFramesField={nestedDataField} />
-    ) : (
-      <TableFlat {...props} width={tableWidth} />
-    );
-
-  const inner = (
-    <DebouncedWidth width={width} enabled={needsDebounce}>
-      {renderTable}
-    </DebouncedWidth>
+  const inner = nestedDataField ? (
+    <TableNested {...props} width={width} nestedFramesField={nestedDataField} />
+  ) : (
+    <TableFlat {...props} width={width} />
   );
   const rendered = IS_SAFARI_26 ? <Safari26Wrapper>{inner}</Safari26Wrapper> : inner;
 

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNested.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNested.tsx
@@ -35,6 +35,7 @@ import {
   useRowHeight,
   useScrollbarWidth,
   useSortedRows,
+  useTypographyCtx,
 } from './hooks';
 import { type ColumnBuildConfig, useColumnBuilderFromFields, useDataGridRows } from './render-hooks';
 import { getGridStyles, IS_SAFARI_26 } from './styles';
@@ -49,8 +50,6 @@ import {
 } from './types';
 import {
   calculateFooterHeight,
-  createTypographyContext,
-  extractPixelValue,
   getApplyToRowBgFn,
   getCellColorInlineStylesFactory,
   getCellLinks,
@@ -195,8 +194,7 @@ export function TableNested(props: TableNGProps & { nestedFramesField: Field<Dat
   // nested tables don't support frozen columns; subtract expander column width
   const frozenColumns = 0;
   const numFrozenColsFullyInView = 0;
-  // `width` may already be debounced by RefactoredTableNG. scrollbarWidth never is, so a scrollbar
-  // appearing/disappearing re-sizes columns immediately instead of lagging behind that debounce.
+  // A scrollbar appearing/disappearing changes how much room the columns have, so factor it out.
   const availableWidth = useMemo(() => width - COLUMN.EXPANDER_WIDTH - scrollbarWidth, [width, scrollbarWidth]);
 
   const getCellColorInlineStyles = useMemo(() => getCellColorInlineStylesFactory(theme), [theme]);
@@ -206,15 +204,7 @@ export function TableNested(props: TableNGProps & { nestedFramesField: Field<Dat
   );
   const getTextColorForBackground = useMemo(() => memoize(_getTextColorForBackground, { maxSize: 1000 }), []);
 
-  const typographyCtx = useMemo(
-    () =>
-      createTypographyContext(
-        theme.typography.fontSize,
-        theme.typography.fontFamily,
-        extractPixelValue(theme.typography.body.letterSpacing!) * theme.typography.fontSize
-      ),
-    [theme]
-  );
+  const typographyCtx = useTypographyCtx(theme);
 
   // When a width override is removed from field config, the configured-width count drops. That
   // change to field.config.custom.width is a mutation on the existing field objects, so it doesn't

--- a/packages/grafana-ui/src/components/Table/TableNG/constants.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/constants.ts
@@ -19,3 +19,16 @@ export const TABLE = {
   BORDER_RIGHT: 1,
   SCROLLBAR_AFFORDANCE: 16,
 };
+
+/**
+ * Horizontal chrome around a cell's content: left + right padding plus the right border. Subtract
+ * from a column's pixel width to get its usable content width, or add to size a column to content.
+ */
+export const CELL_HORIZONTAL_CHROME = TABLE.CELL_PADDING * 2 + TABLE.BORDER_RIGHT;
+
+// Space a single header affordance icon (filter / sort / type) reserves next to the label. Sized to
+// the widest of them — the sort arrow, rendered at Icon size "lg" (18px) — plus the flex gap, so a
+// filterable or sorted column doesn't ellipsize its title once its icon appears.
+const HEADER_ICON_WIDTH = 18;
+const HEADER_ICON_GAP = 4;
+export const HEADER_ICON_SPACE = HEADER_ICON_WIDTH + HEADER_ICON_GAP;

--- a/packages/grafana-ui/src/components/Table/TableNG/hooks.test.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/hooks.test.ts
@@ -16,7 +16,6 @@ import {
   useNestedRows,
   useColWidths,
   useRowCompiler,
-  useDebouncedNumber,
 } from './hooks';
 import { type TableRow } from './types';
 import { applyFilter, createTypographyContext, compileFrameToRecords } from './utils';
@@ -24,34 +23,6 @@ import { applyFilter, createTypographyContext, compileFrameToRecords } from './u
 const emptyFilterResult = applyFilter([], {}, []);
 
 describe('TableNG hooks', () => {
-  describe('useDebouncedNumber', () => {
-    beforeEach(() => jest.useFakeTimers());
-    afterEach(() => jest.useRealTimers());
-
-    it('returns the initial value immediately, without waiting for the debounce', () => {
-      const { result } = renderHook(() => useDebouncedNumber(100, 120));
-      expect(result.current).toBe(100);
-    });
-
-    it('holds the previous value until changes settle, then emits only the final value', () => {
-      const { result, rerender } = renderHook(({ v }) => useDebouncedNumber(v, 120), {
-        initialProps: { v: 100 },
-      });
-
-      // rapid changes (a drag) — none should be reflected until the window elapses
-      rerender({ v: 150 });
-      rerender({ v: 220 });
-      rerender({ v: 315 });
-      expect(result.current).toBe(100);
-
-      act(() => jest.advanceTimersByTime(119));
-      expect(result.current).toBe(100); // still within the debounce window
-
-      act(() => jest.advanceTimersByTime(1));
-      expect(result.current).toBe(315); // only the last value lands, not the intermediate ones
-    });
-  });
-
   function setupData() {
     // Mock data for testing
     const fields: Field[] = [
@@ -719,7 +690,8 @@ describe('TableNG hooks', () => {
         });
       });
 
-      expect(heightFn).toHaveBeenCalledWith('Longer name that needs wrapping', 26, modifiedFields[0], -1, 22);
+      // colWidth 100 - chrome 13 - 3 icons (filter + sort + type) * 22 = 21, floor - 1 = 20.
+      expect(heightFn).toHaveBeenCalledWith('Longer name that needs wrapping', 20, modifiedFields[0], -1, 22);
     });
 
     it('does not throw if a field has been deleted but the colWidth has not yet been updated', () => {
@@ -1436,6 +1408,43 @@ describe('TableNG hooks', () => {
       expect(result.current.nestedFieldWidths).toEqual([100, 100]);
       expect(result.current.nestedColWidths.get('a')).toEqual({ type: 'resized', width: 100 });
       expect(result.current.nestedColWidths.get('b')).toEqual({ type: 'resized', width: 100 });
+    });
+
+    it('re-flows auto (unconfigured) column widths when the panel width changes', () => {
+      const fields: Field[] = ['a', 'b'].map((name) => ({ name, type: FieldType.string, config: {}, values: [] }));
+      const { result, rerender } = renderHook(
+        ({ availableWidth }: { availableWidth: number }) =>
+          useNestedColWidths({ nestedVisibleFields: fields, availableWidth }),
+        { initialProps: { availableWidth: 300 } }
+      );
+
+      const before = [...result.current.nestedFieldWidths];
+      rerender({ availableWidth: 600 });
+      const after = result.current.nestedFieldWidths;
+
+      // widening the panel widens the auto-sized nested columns (previously they stayed put until a
+      // structure change, so they ignored panel resize).
+      expect(after[0]).toBeGreaterThan(before[0]);
+      expect(after[1]).toBeGreaterThan(before[1]);
+    });
+
+    it('preserves a manual nested resize across a panel resize before it persists to config', () => {
+      const fields = makeFields(['a', 'b']); // configured width 100 each
+      const { result, rerender } = renderHook(
+        ({ availableWidth }: { availableWidth: number }) =>
+          useNestedColWidths({ nestedVisibleFields: fields, availableWidth }),
+        { initialProps: { availableWidth: 300 } }
+      );
+
+      // user drags column 'a' — local widths update immediately; config persists later on pointer-up.
+      act(() => {
+        result.current.handleNestedColumnWidthsChange(new Map([['a', { type: 'resized', width: 250 }]]));
+      });
+      expect(result.current.nestedFieldWidths[0]).toBe(250);
+
+      // a panel resize lands before the drag persists — it must not overwrite the in-progress resize.
+      rerender({ availableWidth: 600 });
+      expect(result.current.nestedFieldWidths[0]).toBe(250);
     });
 
     it('handleNestedColumnWidthsChange updates nestedFieldWidths and nestedColWidths', () => {

--- a/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
@@ -9,7 +9,6 @@ import {
   type CSSProperties,
   useEffect,
 } from 'react';
-import { useDebounce } from 'react-use';
 
 import {
   createDataFrame,
@@ -17,6 +16,7 @@ import {
   type Field,
   FieldType,
   formattedValueToString,
+  type GrafanaTheme2,
   reduceField,
   ReducerID,
 } from '@grafana/data';
@@ -31,7 +31,7 @@ import { type MatcherScope } from '@grafana/schema';
 
 import { type TableColumnResizeActionCallback } from '../types';
 
-import { TABLE } from './constants';
+import { CELL_HORIZONTAL_CHROME, HEADER_ICON_SPACE, TABLE } from './constants';
 import { IS_SAFARI_26 } from './styles';
 import {
   type FilterType,
@@ -54,6 +54,8 @@ import {
   buildCellHeightMeasurers,
   applyFilter,
   compileFrameToRecords,
+  createTypographyContext,
+  extractPixelValue,
 } from './utils';
 
 export function useFilteredRows(rows: TableRow[], fields: Field[], hasNestedFrames?: boolean) {
@@ -339,9 +341,6 @@ export const useNestedRows = (
   }, [hasNestedFrames, nestedFramesFieldName, rows, sortColumns, filter, frameToRecords, nestedData]);
 };
 
-const ICON_WIDTH = 16;
-const ICON_GAP = 4;
-
 interface UseHeaderHeightOptions {
   enabled: boolean;
   fields: Field[];
@@ -359,8 +358,6 @@ export function useHeaderHeight({
   typographyCtx,
   showTypeIcons = false,
 }: UseHeaderHeightOptions): number {
-  const perIconSpace = ICON_WIDTH + ICON_GAP;
-
   const measurers = useMemo(() => buildHeaderHeightMeasurers(fields, typographyCtx), [fields, typographyCtx]);
 
   const columnAvailableWidths = useMemo(
@@ -370,25 +367,25 @@ export function useHeaderHeight({
           return 0; // no width available for this column yet
         }
 
-        let width = c - 2 * TABLE.CELL_PADDING - TABLE.BORDER_RIGHT;
+        let width = c - CELL_HORIZONTAL_CHROME;
         const field = fields[idx];
 
         // filtering icon
         if (field.config?.custom?.filterable) {
-          width -= perIconSpace;
+          width -= HEADER_ICON_SPACE;
         }
         // sorting icon
         if (sortColumns.some((col) => col.columnKey === getDisplayName(field))) {
-          width -= perIconSpace;
+          width -= HEADER_ICON_SPACE;
         }
         // type icon
         if (showTypeIcons) {
-          width -= perIconSpace;
+          width -= HEADER_ICON_SPACE;
         }
         // sadly, the math for this is off by exactly 1 pixel. shrug.
         return Math.floor(width) - 1;
       }),
-    [fields, columnWidths, sortColumns, showTypeIcons, perIconSpace]
+    [fields, columnWidths, sortColumns, showTypeIcons]
   );
 
   const headerHeight = useMemo(() => {
@@ -425,7 +422,7 @@ interface UseRowHeightOptions {
   nestedFooterHeight?: number;
 }
 
-const getTrueColWidths = (cw: number[]): number[] => cw.map((c) => c - (2 * TABLE.CELL_PADDING + TABLE.BORDER_RIGHT));
+const getTrueColWidths = (cw: number[]): number[] => cw.map((c) => c - CELL_HORIZONTAL_CHROME);
 
 // TODO: maybe there's a way to decouple the nested rows from the top-level rows here.
 export function useRowHeight({
@@ -720,18 +717,20 @@ export function useScrollbarWidth(ref: RefObject<DataGridHandle | null>, height:
   return scrollbarWidth;
 }
 
-// How long to wait after the last width change before recomputing the width-driven layout.
-export const RESIZE_WIDTH_DEBOUNCE_MS = 100;
-
 /**
- * Trailing-debounces a numeric value. Used for width performance optimization.
+ * Builds the typography context the table uses to measure text (row heights, header heights). Shared
+ * by the flat and nested tables so the memoization lives in one place.
  */
-export function useDebouncedNumber(value: number, wait: number): number {
-  const [debounced, setDebounced] = useState(value);
-  // react-use's useDebounce handles the timer lifecycle (reset on change, clear on unmount); we wrap
-  // it in state so this returns the debounced value rather than exposing the callback plumbing.
-  useDebounce(() => setDebounced(value), wait, [value]);
-  return debounced;
+export function useTypographyCtx(theme: GrafanaTheme2): TypographyCtx {
+  return useMemo(
+    () =>
+      createTypographyContext(
+        theme.typography.fontSize,
+        theme.typography.fontFamily,
+        extractPixelValue(theme.typography.body.letterSpacing!) * theme.typography.fontSize
+      ),
+    [theme]
+  );
 }
 
 interface UseNestedColWidthsOptions {
@@ -761,26 +760,33 @@ export function useNestedColWidths({
   );
 
   const [nestedFieldWidths, setNestedFieldWidths] = useState(() => configuredWidths);
+  // Previous config-derived widths, so we can tell which columns actually changed upstream.
+  const prevConfiguredWidths = useRef(configuredWidths);
 
-  // on structureRev change, sync the widths from config and check whether we ought to dispatch an update.
+  // Re-sync from config-derived widths whenever they change — structure changes and, crucially,
+  // panel resize (availableWidth feeds configuredWidths), so nested columns re-flow to the new
+  // width (previously this only ran on structureRev, so nested columns ignored panel resize). We
+  // adopt a column's new width only when its config-derived width actually changed; a column that
+  // changed only locally (an in-progress manual drag, which persists to field config later on
+  // pointer-up) keeps its local width, so an interleaved resize doesn't clobber the drag.
   useEffect(() => {
-    const newWidths = computeColWidths(nestedVisibleFields, availableWidth);
-    let hasChanges = false;
-    if (nestedFieldWidths.length !== newWidths.length) {
-      // if we have fewer columns than the new widths, we have changes
-      hasChanges = true;
-    }
-    for (let i = 0; i < newWidths.length; i++) {
-      if (nestedFieldWidths[i] !== newWidths[i]) {
-        hasChanges = true;
-        break;
+    const prevConfigured = prevConfiguredWidths.current;
+    prevConfiguredWidths.current = configuredWidths;
+    setNestedFieldWidths((current) => {
+      if (current.length !== configuredWidths.length) {
+        return configuredWidths;
       }
-    }
-
-    if (hasChanges) {
-      setNestedFieldWidths(newWidths);
-    }
-  }, [structureRev]); // eslint-disable-line react-hooks/exhaustive-deps
+      let changed = false;
+      const next = current.map((width, i) => {
+        if (configuredWidths[i] !== prevConfigured[i]) {
+          changed = changed || width !== configuredWidths[i];
+          return configuredWidths[i];
+        }
+        return width;
+      });
+      return changed ? next : current;
+    });
+  }, [configuredWidths, structureRev]);
 
   // this is the representation that react-data-grid wants, which we derive from the source of truth (nestedFieldWidths) on every render
   const nestedColWidths = useMemo(

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
@@ -56,7 +56,6 @@ import {
   parseStyleJson,
   predicateByName,
   prepareSparklineValue,
-  shouldDebounceWidth,
   SINGLE_LINE_ESTIMATE_THRESHOLD,
 } from './utils';
 
@@ -1701,90 +1700,6 @@ describe('TableNG utils', () => {
           COLUMN.DEFAULT_WIDTH
         )
       ).toEqual([COLUMN.DEFAULT_WIDTH, COLUMN.DEFAULT_WIDTH]);
-    });
-  });
-
-  describe('shouldDebounceWidth', () => {
-    const field = (config: Field['config'], overrides: Partial<Field> = {}): Field => ({
-      name: 'A',
-      type: FieldType.string,
-      values: ['a'],
-      config,
-      ...overrides,
-    });
-
-    const cellField = (type: TableCellDisplayMode, extraCustom: Record<string, unknown> = {}) =>
-      field({ custom: { cellOptions: { type }, ...extraCustom } });
-
-    it.each([TableCellDisplayMode.Pill, TableCellDisplayMode.Sparkline, TableCellDisplayMode.Gauge])(
-      'debounces an auto-sized %s column',
-      (type) => {
-        expect(shouldDebounceWidth([cellField(type)])).toBe(true);
-      }
-    );
-
-    it.each([
-      TableCellDisplayMode.Auto,
-      TableCellDisplayMode.ColorText,
-      TableCellDisplayMode.ColorBackground,
-      TableCellDisplayMode.DataLinks,
-      TableCellDisplayMode.Markdown,
-      TableCellDisplayMode.JSONView,
-      TableCellDisplayMode.Image,
-    ])('does not debounce an auto-sized %s column', (type) => {
-      expect(shouldDebounceWidth([cellField(type)])).toBe(false);
-    });
-
-    it('debounces an auto cell which resolves to a sparkline', () => {
-      const frame = createDataFrame({
-        fields: [
-          { name: 'time', type: FieldType.time, values: [0, 1000] },
-          { name: 'value', type: FieldType.number, values: [1, 2] },
-        ],
-      });
-
-      expect(
-        shouldDebounceWidth([field({}, { type: FieldType.frame, values: [frame] })]) // cell type defaults to auto
-      ).toBe(true);
-    });
-
-    it('debounces an auto-sized column with wrapped text, whatever its cell type', () => {
-      expect(shouldDebounceWidth([cellField(TableCellDisplayMode.Auto, { wrapText: true })])).toBe(true);
-    });
-
-    it('does not debounce a wrapped-text column with a configured width', () => {
-      expect(shouldDebounceWidth([cellField(TableCellDisplayMode.Auto, { wrapText: true, width: 100 })])).toBe(false);
-    });
-
-    it('does not debounce when the width-sensitive column has a configured width', () => {
-      expect(shouldDebounceWidth([cellField(TableCellDisplayMode.Pill, { width: 100 })])).toBe(false);
-    });
-
-    it('does not debounce when only the plain columns are auto-sized', () => {
-      expect(
-        shouldDebounceWidth([
-          cellField(TableCellDisplayMode.Pill, { width: 100 }),
-          cellField(TableCellDisplayMode.Auto),
-        ])
-      ).toBe(false);
-    });
-
-    it('debounces when any auto-sized column is width-sensitive', () => {
-      expect(
-        shouldDebounceWidth([
-          cellField(TableCellDisplayMode.Auto, { width: 100 }),
-          cellField(TableCellDisplayMode.Auto),
-          cellField(TableCellDisplayMode.Gauge),
-        ])
-      ).toBe(true);
-    });
-
-    it('reads the migrated cell type from the legacy displayMode config', () => {
-      expect(shouldDebounceWidth([field({ custom: { displayMode: 'gradient-gauge' } })])).toBe(true);
-    });
-
-    it('does not debounce an empty field list', () => {
-      expect(shouldDebounceWidth([])).toBe(false);
     });
   });
 

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -1171,40 +1171,6 @@ export function computeColWidths(fields: Field[], availWidth: number) {
   );
 }
 
-// cells which have to re-measure or re-draw themselves when their column width changes. pills
-// re-wrap, sparklines and gauges re-render their viz against the new width. every other cell type
-// just re-flows text, which the browser handles without us recomputing anything.
-// the legacy basic/gradient/lcd gauge modes aren't listed: getCellOptions migrates them to Gauge.
-const WIDTH_SENSITIVE_CELL_TYPES = new Set<TableCellOptions['type']>([
-  TableCellDisplayMode.Pill,
-  TableCellDisplayMode.Sparkline,
-  TableCellDisplayMode.Gauge,
-]);
-
-/**
- * @internal
- * Whether panel width changes should be debounced before they drive the column layout. Debouncing
- * trades a moment of staleness for fewer layout passes, so it only pays off when applying a width
- * is actually expensive: some column has to be both auto-sized (a configured width doesn't move
- * with the panel) and width-sensitive - either a cell which redraws itself against the new width,
- * or wrapped text, which makes us re-measure every row height.
- */
-export function shouldDebounceWidth(fields: Field[]): boolean {
-  return fields.some((field) => {
-    if (field.config.custom?.width) {
-      return false;
-    }
-    if (shouldTextWrap(field)) {
-      return true;
-    }
-    const cellType = getCellOptions(field).type;
-    return WIDTH_SENSITIVE_CELL_TYPES.has(
-      // auto cells resolve to a sparkline when the field holds time series frames.
-      cellType === TableCellDisplayMode.Auto ? getAutoRendererDisplayMode(field) : cellType
-    );
-  });
-}
-
 export function buildNestedColumnWidthsMap(fields: Field[], widths: number[]): ColumnWidths {
   return new Map<string, ColumnWidth>(
     fields.map((field, idx) => [getDisplayName(field), { type: 'resized', width: widths[idx] }])


### PR DESCRIPTION
### What

A handful of TableNG width/resize improvements, split out of the larger content-aware auto column
widths PR (#129236) so they can be reviewed and land on their own. None of these depend on that
feature — they all operate on the existing (non-toggle) table paths:

- **Re-flow nested column widths on panel resize.** `useNestedColWidths` only re-synced widths from
  config on a data-structure change (`structureRev`), so nested-table columns ignored panel resizes
  entirely — widening the panel left them at their old widths. Re-sync whenever the config-derived
  widths change (which includes `availableWidth`), adopting a column's new width only when its
  config-derived width actually changed (via a `prevConfiguredWidths` ref) so an in-progress manual
  drag isn't clobbered by an interleaved resize.

- **Remove width debouncing.** A resize-perf trace showed the width math is negligible next to
  react-data-grid's synchronous re-render (which the debounce doesn't touch), so the debounce bought
  little while costing a frame of staleness on every resize. Drops `DebouncedWidth` /
  `useDebouncedNumber` / `RESIZE_WIDTH_DEBOUNCE_MS` / `shouldDebounceWidth` and feeds the live width
  straight to the table. Note: this partially reverts the earlier resize-perf debounce.

- **Extract shared constants.** Hoist `CELL_HORIZONTAL_CHROME` and the header-icon spacing into
  `constants.ts` and dedup the inline copies in `hooks.ts`. The header-icon reservation is sized to
  the widest affordance (the sort arrow, rendered at Icon size `lg` = 18px, up from 16) so a
  filterable/sorted column reserves enough room for its icon.

- **Extract `useTypographyCtx()`.** `TableFlat` and `TableNested` duplicated the same
  `createTypographyContext(...)` `useMemo`; move it into a shared hook.

### Why

These are general table cleanups that were riding along in #129236 and bloating its diff. Landing
them separately keeps that PR focused on the content-aware width logic.

### Testing

- Unit: `useNestedColWidths` re-flow + manual-resize-preservation, updated the `useHeaderHeight`
  available-width expectation for the icon-space bump, reworked the resize tests in `TableNG.test.tsx`
  to assert widths apply immediately (no debounce), and removed the `useDebouncedNumber` /
  `shouldDebounceWidth` suites. Full `TableNG` `hooks`/`utils`/`TableNG` suites pass; `eslint`/
  `prettier` clean.
- Manual: resize a table panel and confirm nested columns re-flow and a manual nested drag survives a
  resize; confirm width changes apply immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
