### PR TITLE
Alerting: Treat null unloadEvaluator as a plain threshold

### DIFF
--- a/pkg/expr/threshold.go
+++ b/pkg/expr/threshold.go
@@ -294,8 +294,10 @@ func getConditionForHysteresisCommand(query map[string]any) (map[string]any, err
 	default:
 		return nil, errors.New("invalid threshold command: field \"condition\" expected to be an array of objects")
 	}
-	_, ok = condition["unloadEvaluator"]
-	if !ok {
+	// A null unloadEvaluator must be treated as absent: UnmarshalThresholdCommand decodes it to a nil
+	// pointer and builds a plain threshold, so detection here has to agree or we patch a command that
+	// never reads the loaded dimensions.
+	if u, ok := condition["unloadEvaluator"]; !ok || u == nil {
 		return nil, nil
 	}
 	return condition, nil

--- a/pkg/expr/threshold_test.go
+++ b/pkg/expr/threshold_test.go
@@ -396,6 +396,11 @@ func TestIsHysteresisExpression(t *testing.T) {
 			expected: false,
 		},
 		{
+			name:     "false if unloadEvaluator is null",
+			input:    json.RawMessage(`{ "type": "threshold", "conditions": [{ "unloadEvaluator" : null}] }`),
+			expected: false,
+		},
+		{
 			name:     "true type is threshold and a single condition has unloadEvaluator field",
 			input:    json.RawMessage(`{ "type": "threshold", "conditions": [{ "unloadEvaluator" : {}}] }`),
 			expected: true,


### PR DESCRIPTION
`IsHysteresisExpression` checked only whether the `conditions[0].unloadEvaluator` key existed, not whether it had a value. A `null` was reported as hysteresis, while `UnmarshalThresholdCommand` decodes `null` to a nil pointer and builds a plain `ThresholdCommand`. Evaluation then patched `loadedDimensions` into a command that never reads them.

The UI can't produce this — it clears the field with `undefined`, which `JSON.stringify` drops. Hand-written JSON via provisioning, the API, or Terraform can.

Now checks the value, not just the key.

An empty object (`"unloadEvaluator": {}`) is deliberately left alone: it still reports as hysteresis and fails at unmarshal with `expected threshold function to be one of [...]`. Rejecting it here instead would silently evaluate a half-configured rule as a plain threshold with no recovery behaviour — is a loud error the right call there?