### PR TITLE
TraceView: Open span and resource attributes by default

### DIFF
--- a/public/app/features/explore/TraceView/TraceView.test.tsx
+++ b/public/app/features/explore/TraceView/TraceView.test.tsx
@@ -181,27 +181,27 @@ describe('TraceView', () => {
     await userEvent.click(firstSpan);
     // Resource attributes are open by default alongside span attributes
     expect(
-      screen.getAllByText('', { selector: 'div[data-testid="KeyValueTable"]' }).some((table) =>
-        table.innerHTML.includes('client-uuid-1')
-      )
+      screen
+        .getAllByText('', { selector: 'div[data-testid="KeyValueTable"]' })
+        .some((table) => table.innerHTML.includes('client-uuid-1'))
     ).toBe(true);
     await userEvent.click(firstSpan);
 
     const secondSpan = screen.getAllByText('', { selector: 'div[data-testid="span-view"]' })[1];
     await userEvent.click(secondSpan);
     expect(
-      screen.getAllByText('', { selector: 'div[data-testid="KeyValueTable"]' }).some((table) =>
-        table.innerHTML.includes('client-uuid-2')
-      )
+      screen
+        .getAllByText('', { selector: 'div[data-testid="KeyValueTable"]' })
+        .some((table) => table.innerHTML.includes('client-uuid-2'))
     ).toBe(true);
     await userEvent.click(secondSpan);
 
     const thirdSpan = screen.getAllByText('', { selector: 'div[data-testid="span-view"]' })[2];
     await userEvent.click(thirdSpan);
     expect(
-      screen.getAllByText('', { selector: 'div[data-testid="KeyValueTable"]' }).some((table) =>
-        table.innerHTML.includes('client-uuid-3')
-      )
+      screen
+        .getAllByText('', { selector: 'div[data-testid="KeyValueTable"]' })
+        .some((table) => table.innerHTML.includes('client-uuid-3'))
     ).toBe(true);
   });
 

--- a/public/app/features/explore/TraceView/TraceView.test.tsx
+++ b/public/app/features/explore/TraceView/TraceView.test.tsx
@@ -175,28 +175,34 @@ describe('TraceView', () => {
 
   it('correctly shows processes for each span', async () => {
     renderTraceView();
-    let table: HTMLElement;
     expect(screen.queryAllByText('', { selector: 'div[data-testid="span-view"]' }).length).toBe(3);
 
     const firstSpan = screen.getAllByText('', { selector: 'div[data-testid="span-view"]' })[0];
     await userEvent.click(firstSpan);
-    await userEvent.click(screen.getByText(/Resource/));
-    table = screen.getByText('', { selector: 'div[data-testid="KeyValueTable"]' });
-    expect(table.innerHTML).toContain('client-uuid-1');
+    // Resource attributes are open by default alongside span attributes
+    expect(
+      screen.getAllByText('', { selector: 'div[data-testid="KeyValueTable"]' }).some((table) =>
+        table.innerHTML.includes('client-uuid-1')
+      )
+    ).toBe(true);
     await userEvent.click(firstSpan);
 
     const secondSpan = screen.getAllByText('', { selector: 'div[data-testid="span-view"]' })[1];
     await userEvent.click(secondSpan);
-    await userEvent.click(screen.getByText(/Resource/));
-    table = screen.getByText('', { selector: 'div[data-testid="KeyValueTable"]' });
-    expect(table.innerHTML).toContain('client-uuid-2');
+    expect(
+      screen.getAllByText('', { selector: 'div[data-testid="KeyValueTable"]' }).some((table) =>
+        table.innerHTML.includes('client-uuid-2')
+      )
+    ).toBe(true);
     await userEvent.click(secondSpan);
 
     const thirdSpan = screen.getAllByText('', { selector: 'div[data-testid="span-view"]' })[2];
     await userEvent.click(thirdSpan);
-    await userEvent.click(screen.getByText(/Resource/));
-    table = screen.getByText('', { selector: 'div[data-testid="KeyValueTable"]' });
-    expect(table.innerHTML).toContain('client-uuid-3');
+    expect(
+      screen.getAllByText('', { selector: 'div[data-testid="KeyValueTable"]' }).some((table) =>
+        table.innerHTML.includes('client-uuid-3')
+      )
+    ).toBe(true);
   });
 
   it('resets detail view for new trace with the identical spanID', async () => {

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/AccordionCategorizedKeyValues.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/AccordionCategorizedKeyValues.tsx
@@ -159,6 +159,10 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
     summary: css({
       marginLeft: '0.7em',
+      flex: 1,
+      minWidth: 0,
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
     }),
     categories: css({
       padding: `0 ${categoryIndent}`,

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/DetailState.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/DetailState.tsx
@@ -40,8 +40,9 @@ export default class DetailState {
       logs,
       references,
     }: DetailState | Record<string, undefined> = oldState || {};
-    this.isTagsOpen = Boolean(isTagsOpen);
-    this.isProcessOpen = Boolean(isProcessOpen);
+    // Span and resource attributes are open by default when a detail panel is first opened.
+    this.isTagsOpen = oldState ? Boolean(isTagsOpen) : true;
+    this.isProcessOpen = oldState ? Boolean(isProcessOpen) : true;
     this.isSummaryAttributesOpen = Boolean(isSummaryAttributesOpen);
     this.isReferencesOpen = Boolean(isReferencesOpen);
     this.isWarningsOpen = Boolean(isWarningsOpen);

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.test.tsx
@@ -59,7 +59,8 @@ import SpanDetail, { getAbsoluteTime, type SpanDetailProps } from './index';
 describe('<SpanDetail>', () => {
   // use `transformTraceData` on a fake trace to get a fully processed span
   const span = transformTraceData(traceGenerator.trace({ numberOfSpans: 1 }))!.spans[0];
-  const detailState = new DetailState().toggleLogs().toggleProcess().toggleReferences().toggleTags();
+  // Span/resource attributes default open; only open the sections that start collapsed.
+  const detailState = new DetailState().toggleLogs().toggleReferences();
   const traceStartTime = 5;
   const topOfExploreViewRef = jest.fn();
   const request = {
@@ -389,8 +390,12 @@ describe('<SpanDetail>', () => {
         { key: 'aggregation.span_count', value: '3' },
       ],
     };
-    // All accordions collapsed so each renders its abbreviated key preview.
-    const summaryTagsProps = { ...props, span: summarySpanWithTags, detailState: new DetailState() };
+    // Collapse span/resource attributes (open by default) so each accordion renders its abbreviated key preview.
+    const summaryTagsProps = {
+      ...props,
+      span: summarySpanWithTags,
+      detailState: new DetailState().toggleTags().toggleProcess(),
+    };
 
     beforeEach(() => {
       jest.mocked(formatDuration).mockImplementation((duration: number) => `${duration}us`);

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.test.tsx
@@ -14,14 +14,6 @@
 
 jest.mock('../../utils/date');
 
-// Controls the measured container width so the two-column layout decision is
-// deterministic in tests (real measurement needs layout jsdom doesn't do).
-let mockMeasuredWidth = 0;
-jest.mock('react-use/lib/useMeasure', () => ({
-  __esModule: true,
-  default: () => [jest.fn(), { width: mockMeasuredWidth }],
-}));
-
 // SpanDetailLinkButtons resolves data source settings via an async hook; return a
 // synchronous value so rendering doesn't trigger an un-acted state update in tests.
 jest.mock('@grafana/runtime/unstable', () => ({
@@ -187,7 +179,6 @@ describe('<SpanDetail>', () => {
   ];
 
   beforeEach(() => {
-    mockMeasuredWidth = 0;
     jest.mocked(formatDuration).mockReset();
     props.tagsToggle.mockReset();
     props.processToggle.mockReset();
@@ -214,18 +205,9 @@ describe('<SpanDetail>', () => {
     expect(() => render(<SpanDetail {...(props as unknown as SpanDetailProps)} />)).not.toThrow();
   });
 
-  describe('attribute card layout', () => {
-    it('uses two columns when the container is wider than 1000px', () => {
-      mockMeasuredWidth = 1200;
-      render(<SpanDetail {...(props as unknown as SpanDetailProps)} />);
-      expect(screen.getAllByTestId('span-detail-cards-column')).toHaveLength(2);
-    });
-
-    it('uses a single column when the container is 1000px or narrower', () => {
-      mockMeasuredWidth = 800;
-      render(<SpanDetail {...(props as unknown as SpanDetailProps)} />);
-      expect(screen.getAllByTestId('span-detail-cards-column')).toHaveLength(1);
-    });
+  it('renders attribute cards', () => {
+    render(<SpanDetail {...(props as unknown as SpanDetailProps)} />);
+    expect(screen.getByTestId('span-detail-cards-column')).toBeInTheDocument();
   });
 
   it('shows the operation name', () => {

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
@@ -15,7 +15,6 @@
 import { css, cx } from '@emotion/css';
 import { SpanStatusCode } from '@opentelemetry/api';
 import React, { useCallback, useMemo } from 'react';
-import useMeasure from 'react-use/lib/useMeasure';
 
 import {
   type CoreApp,
@@ -137,6 +136,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       borderRadius: theme.shape.radius.md,
       margin: '6px',
       padding: '5px',
+      minWidth: 0,
     }),
     header: css({
       label: 'SpanDetailHeader',
@@ -150,6 +150,16 @@ const getStyles = (theme: GrafanaTheme2) => {
     content: css({
       label: 'SpanDetailContent',
       fontSize: theme.typography.bodySmall.fontSize,
+    }),
+    cards: css({
+      label: 'SpanDetailCards',
+      display: 'grid',
+      gridTemplateColumns: 'minmax(0, 1fr)',
+      alignItems: 'start',
+      // Side-by-side when the span detail container is wide enough; otherwise stack.
+      [theme.breakpoints.container.up(1000)]: {
+        gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 1fr)',
+      },
     }),
     listWrapper: css({
       label: 'SpanDetailListWrapper',
@@ -165,6 +175,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       label: 'SpanDetailComponent',
       display: 'flex',
       flexDirection: 'column', // On bigger screens display attributes below service name
+      containerType: 'inline-size',
     }),
     serviceNameAndLinks: css({
       label: 'ServiceNameAndLinks',
@@ -236,7 +247,6 @@ const getStyles = (theme: GrafanaTheme2) => {
       letterSpacing: '0.25px',
       margin: '0.5em 0 -0.75em',
       textAlign: 'right',
-      clear: 'both',
     }),
     debugLabel: css({
       label: 'debugLabel',
@@ -397,8 +407,6 @@ export default function SpanDetail(props: SpanDetailProps) {
         ]
       : []),
   ];
-
-  const [mainContainerRef, { width: mainContainerWidth }] = useMeasure<HTMLDivElement>();
 
   const styles = useStyles2(getStyles);
   const theme = useTheme2();
@@ -588,7 +596,7 @@ export default function SpanDetail(props: SpanDetailProps) {
   }
 
   return (
-    <div data-testid="span-detail-component" ref={mainContainerRef} className={styles.spanDetailComponent}>
+    <div data-testid="span-detail-component" className={styles.spanDetailComponent}>
       <div className={styles.header}>
         <div className={styles.serviceNameAndLinks}>
           <h6 className={styles.operationName} title={operationName}>
@@ -628,7 +636,7 @@ export default function SpanDetail(props: SpanDetailProps) {
         </div>
       </div>
       <div className={styles.content}>
-        <CardsContainer listOfContentCards={listOfContentCards} containerWidth={mainContainerWidth} />
+        <CardsContainer listOfContentCards={listOfContentCards} />
 
         <small className={styles.debugInfo}>
           {/* TODO: fix keyboard a11y */}
@@ -665,45 +673,11 @@ export const getAbsoluteTime = (startTime: number, timeZone: TimeZone) => {
   return ` (${absoluteTime})`;
 };
 
-const CardsContainer = ({
-  listOfContentCards,
-  containerWidth,
-}: {
-  listOfContentCards: React.ReactNode[];
-  containerWidth: number;
-}) => {
+const CardsContainer = ({ listOfContentCards }: { listOfContentCards: React.ReactNode[] }) => {
   const styles = useStyles2(getStyles);
 
-  const useTwoColumns = containerWidth > 1000;
-
-  if (useTwoColumns) {
-    return (
-      <>
-        <div data-testid="span-detail-cards-column" className={css({ float: 'left', width: '50%' })}>
-          {listOfContentCards.map((card, index) =>
-            index % 2 === 0 ? (
-              <div className={styles.card} key={index}>
-                {card}
-              </div>
-            ) : null
-          )}
-        </div>
-
-        <div data-testid="span-detail-cards-column" className={css({ float: 'right', width: '50%' })}>
-          {listOfContentCards.map((card, index) =>
-            index % 2 === 1 ? (
-              <div className={styles.card} key={index}>
-                {card}
-              </div>
-            ) : null
-          )}
-        </div>
-      </>
-    );
-  }
-
   return (
-    <div data-testid="span-detail-cards-column" className={css({ clear: 'both', width: '100%' })}>
+    <div data-testid="span-detail-cards-column" className={styles.cards}>
       {listOfContentCards.map((card, index) => (
         <div className={styles.card} key={index}>
           {card}

--- a/public/app/features/explore/TraceView/useDetailState.test.ts
+++ b/public/app/features/explore/TraceView/useDetailState.test.ts
@@ -48,17 +48,16 @@ describe('useDetailState', () => {
     expect(result.current.detailStates.get('span1')?.references.isOpen).toBe(true);
   });
 
-  it('toggles processes', async () => {
+  it('opens process and tags by default, and toggles them closed', async () => {
     const { result } = renderHook(() => useDetailState(sampleFrame));
     act(() => result.current.toggleDetail('span1'));
-    act(() => result.current.detailProcessToggle('span1'));
     expect(result.current.detailStates.get('span1')?.isProcessOpen).toBe(true);
-  });
-
-  it('toggles tags', async () => {
-    const { result } = renderHook(() => useDetailState(sampleFrame));
-    act(() => result.current.toggleDetail('span1'));
-    act(() => result.current.detailTagsToggle('span1'));
     expect(result.current.detailStates.get('span1')?.isTagsOpen).toBe(true);
+
+    act(() => result.current.detailProcessToggle('span1'));
+    expect(result.current.detailStates.get('span1')?.isProcessOpen).toBe(false);
+
+    act(() => result.current.detailTagsToggle('span1'));
+    expect(result.current.detailStates.get('span1')?.isTagsOpen).toBe(false);
   });
 });


### PR DESCRIPTION
**What is this feature?**

TraceView: Open span and resource attributes by default.

**Why do we need this feature?**

When expanding a span in Trace View, Span attributes and Resource attributes now start expanded so attribute details are visible immediately. Other detail sections (logs, warnings, etc.) remain collapsed until toggled.

**Who is this feature for?**

TraceView users.