### PR TITLE
CI: Add scripts/rspack to frontend path filters and e2e cache key

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -89,7 +89,7 @@ jobs:
         uses: actions/cache@v5  # zizmor: ignore[cache-poisoning] key derived only from hashFiles of tracked source
         id: cache
         with:
-          key: "e2e-build-frontend-v2-${{ runner.os }}-${{ hashFiles('yarn.lock', 'package.json', 'packages/**', 'public/**', 'scripts/webpack/**', '!**/*.test.ts', '!**/*.test.tsx', 'tsconfig.json', '.browserslistrc', 'nx.json', 'project.json', '.nvmrc') }}"
+          key: "e2e-build-frontend-v2-${{ runner.os }}-${{ hashFiles('yarn.lock', 'package.json', 'packages/**', 'public/**', 'scripts/webpack/**', 'scripts/rspack/**', '!**/*.test.ts', '!**/*.test.tsx', 'tsconfig.json', '.browserslistrc', 'nx.json', 'project.json', '.nvmrc') }}"
           path: |
             public/build
             public/build-swagger

--- a/.github/workflows/pr-endpoint-feature-toggle.yml
+++ b/.github/workflows/pr-endpoint-feature-toggle.yml
@@ -38,6 +38,7 @@ jobs:
               - '!packages/**/*.gen.ts'
               - '!packages/grafana-openapi/**'
               - 'scripts/webpack/**'
+              - 'scripts/rspack/**'
               - '.eslintrc*'
               - '.prettierrc*'
               - '.stylelintrc*'

--- a/.github/workflows/pr-mt-service-compatibility.yml
+++ b/.github/workflows/pr-mt-service-compatibility.yml
@@ -37,6 +37,7 @@ jobs:
               - 'public/**'
               - 'packages/**'
               - 'scripts/webpack/**'
+              - 'scripts/rspack/**'
               - '.eslintrc*'
               - '.prettierrc*'
               - '.stylelintrc*'


### PR DESCRIPTION
**What is this feature?**

Adds `scripts/rspack/**` alongside the existing `scripts/webpack/**` in three workflows:

- `pr-e2e-tests.yml` — frontend build cache key.
- `pr-endpoint-feature-toggle.yml` — `frontend_strict` path filter.
- `pr-mt-service-compatibility.yml` — same.

**Why do we need this feature?**

`scripts/rspack/` has existed since #129968, but these workflows never matched it, so rspack config changes silently skipped the frontend jobs.

**Who is this feature for?**

Frontend contributors and anyone working on the rspack migration.

**Which issue(s) does this PR fix?**:

None — this PR doesn't close an issue. It's part of the rspack migration epic #128309 and a prerequisite for #129728.

<!-- Deliberately no "Fixes" keyword: there is no issue for this change, and linking the epic that way would auto-close it on merge. -->

**Special notes for your reviewer:**

The two path filters take effect immediately. The e2e cache key is pre-positioning — `make build-js` still runs webpack, so no stale bundle is possible today. Merging cold-starts the e2e frontend cache once, since the key hash changes.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

