### PR TITLE
Sparkline: Fix flat sparklines for values below 1e-6

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -595,7 +595,7 @@ i18next.config.ts @grafana/grafana-frontend-platform
 /packages/grafana-data/src/utils/matchPluginId* @grafana/grafana-catalog
 /packages/grafana-data/src/utils/namedColorsPalette* @grafana/grafana-frontend-platform
 /packages/grafana-data/src/utils/nodeGraph.ts @grafana/observability-traces-and-profiling
-/packages/grafana-data/src/utils/numbers.ts @grafana/dataviz-squad
+/packages/grafana-data/src/utils/numbers* @grafana/dataviz-squad
 /packages/grafana-data/src/utils/object.ts @grafana/grafana-frontend-platform
 /packages/grafana-data/src/utils/OptionsUIBuilders.ts @grafana/dashboards-squad
 /packages/grafana-data/src/utils/Registry* @grafana/grafana-frontend-platform

--- a/packages/grafana-data/src/utils/numbers.test.ts
+++ b/packages/grafana-data/src/utils/numbers.test.ts
@@ -1,0 +1,49 @@
+import { guessDecimals, roundDecimals } from './numbers';
+
+describe('roundDecimals', () => {
+  it('returns integers untouched', () => {
+    expect(roundDecimals(10)).toBe(10);
+    expect(roundDecimals(-10, 4)).toBe(-10);
+  });
+
+  it('rounds half away from zero, symmetrically', () => {
+    expect(roundDecimals(2.5)).toBe(3);
+    expect(roundDecimals(-2.5)).toBe(-3);
+    expect(roundDecimals(0.5)).toBe(1);
+    expect(roundDecimals(-0.5)).toBe(-1);
+  });
+
+  it('rounds to the requested number of decimals', () => {
+    expect(roundDecimals(0.125, 2)).toBe(0.13);
+    expect(roundDecimals(-0.125, 2)).toBe(-0.13);
+    expect(roundDecimals(2.675, 2)).toBe(2.68);
+  });
+});
+
+describe('guessDecimals', () => {
+  it('counts decimal places', () => {
+    expect(guessDecimals(10)).toBe(0);
+    expect(guessDecimals(0.125)).toBe(3);
+    expect(guessDecimals(-0.25)).toBe(2);
+    expect(guessDecimals(371.5)).toBe(1);
+  });
+
+  it('counts decimal places for values stringified in exponential notation', () => {
+    // JavaScript switches to exponential below 1e-6, so these do not contain a
+    // '.' followed by the decimal expansion.
+    expect(guessDecimals(1e-7)).toBe(7);
+    expect(guessDecimals(1.5e-7)).toBe(8);
+    expect(guessDecimals(5e-324)).toBe(324);
+  });
+
+  it('reports no decimals for large values in exponential notation', () => {
+    expect(guessDecimals(1e21)).toBe(0);
+    expect(guessDecimals(1.5e21)).toBe(0);
+  });
+
+  it('is continuous across the notation boundary', () => {
+    // 1e-6 stringifies as '0.000001', 1e-7 as '1e-7'.
+    expect(guessDecimals(0.000001)).toBe(6);
+    expect(guessDecimals(1e-7)).toBe(7);
+  });
+});

--- a/packages/grafana-data/src/utils/numbers.test.ts
+++ b/packages/grafana-data/src/utils/numbers.test.ts
@@ -33,7 +33,19 @@ describe('guessDecimals', () => {
     // '.' followed by the decimal expansion.
     expect(guessDecimals(1e-7)).toBe(7);
     expect(guessDecimals(1.5e-7)).toBe(8);
-    expect(guessDecimals(5e-324)).toBe(324);
+    expect(guessDecimals(1e-30)).toBe(30);
+    expect(guessDecimals(1e-100)).toBe(100);
+  });
+
+  it('reports no decimals below the 100 fraction digit ceiling', () => {
+    // maximumFractionDigits cannot exceed 100 per spec, so smaller magnitudes
+    // format to '0'. Well below anything a panel plots.
+    expect(guessDecimals(1e-101)).toBe(0);
+  });
+
+  it('does not let locale grouping separators inflate the count', () => {
+    expect(guessDecimals(1234.5)).toBe(1);
+    expect(guessDecimals(1234567.25)).toBe(2);
   });
 
   it('reports no decimals for large values in exponential notation', () => {

--- a/packages/grafana-data/src/utils/numbers.ts
+++ b/packages/grafana-data/src/utils/numbers.ts
@@ -25,5 +25,16 @@ export function roundDecimals(val: number, dec = 0) {
  * bad  for arbitrary floats:     371.499999999999 -> 12
  */
 export function guessDecimals(num: number) {
-  return (('' + num).split('.')[1] || '').length;
+  const str = '' + num;
+
+  // Below 1e-6 (and at or above 1e21) JavaScript stringifies to exponential
+  // notation, where splitting on '.' counts the exponent's characters instead
+  // of decimal places: 1.5e-7 would otherwise report 4.
+  const expIndex = str.indexOf('e');
+  if (expIndex > -1) {
+    const mantissaDecimals = (str.slice(0, expIndex).split('.')[1] || '').length;
+    return Math.max(0, mantissaDecimals - Number(str.slice(expIndex + 1)));
+  }
+
+  return (str.split('.')[1] || '').length;
 }

--- a/packages/grafana-data/src/utils/numbers.ts
+++ b/packages/grafana-data/src/utils/numbers.ts
@@ -25,16 +25,5 @@ export function roundDecimals(val: number, dec = 0) {
  * bad  for arbitrary floats:     371.499999999999 -> 12
  */
 export function guessDecimals(num: number) {
-  const str = '' + num;
-
-  // Below 1e-6 (and at or above 1e21) JavaScript stringifies to exponential
-  // notation, where splitting on '.' counts the exponent's characters instead
-  // of decimal places: 1.5e-7 would otherwise report 4.
-  const expIndex = str.indexOf('e');
-  if (expIndex > -1) {
-    const mantissaDecimals = (str.slice(0, expIndex).split('.')[1] || '').length;
-    return Math.max(0, mantissaDecimals - Number(str.slice(expIndex + 1)));
-  }
-
-  return (str.split('.')[1] || '').length;
+  return (('' + num).split('.')[1] || '').length;
 }

--- a/packages/grafana-data/src/utils/numbers.ts
+++ b/packages/grafana-data/src/utils/numbers.ts
@@ -25,5 +25,18 @@ export function roundDecimals(val: number, dec = 0) {
  * bad  for arbitrary floats:     371.499999999999 -> 12
  */
 export function guessDecimals(num: number) {
-  return (('' + num).split('.')[1] || '').length;
+  const str = '' + num;
+  const eIdx = str.indexOf('e');
+
+  // JavaScript stringifies numbers below 1e-6 and at or above 1e21 in
+  // exponential notation, where the digits after the '.' are the mantissa's
+  // and not the decimal expansion, so splitting on '.' counts the wrong thing
+  // (1e-7 has no '.' at all and came back as 0 decimals).
+  if (eIdx > -1) {
+    const exp = Number(str.slice(eIdx + 1));
+    const mantissaDecimals = (str.slice(0, eIdx).split('.')[1] || '').length;
+    return Math.max(0, mantissaDecimals - exp);
+  }
+
+  return (str.split('.')[1] || '').length;
 }

--- a/packages/grafana-data/src/utils/numbers.ts
+++ b/packages/grafana-data/src/utils/numbers.ts
@@ -15,6 +15,25 @@ export function roundDecimals(val: number, dec = 0) {
   return Math.round(n) / p;
 }
 
+// Counts decimals without JavaScript's exponential notation getting in the way:
+// below 1e-6 (and at or above 1e21) `'' + num` yields something like '1.5e-7',
+// where splitting on '.' counts the exponent's characters rather than decimal
+// places. Built once and reused rather than per call.
+//
+// The locale is pinned because the decimal separator is locale dependent, and
+// this reads the result rather than displaying it: 'de-DE' formats 0.125 as
+// '0,125', which would count as no decimals at all. Grouping is off for the
+// same reason, so 1234.5 stays '1234.5' instead of '1,234.5'.
+//
+// 100 is the largest maximumFractionDigits the spec allows (anything higher
+// throws a RangeError), so values below ~1e-100 format to '0' and report no
+// decimals. That matches the behaviour before this function handled
+// exponential notation at all, and is far below any real panel data.
+const decimalCounter = new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 100,
+  useGrouping: false,
+});
+
 /**
  * Tries to guess number of decimals needed to format a number
  *
@@ -25,18 +44,5 @@ export function roundDecimals(val: number, dec = 0) {
  * bad  for arbitrary floats:     371.499999999999 -> 12
  */
 export function guessDecimals(num: number) {
-  const str = '' + num;
-  const eIdx = str.indexOf('e');
-
-  // JavaScript stringifies numbers below 1e-6 and at or above 1e21 in
-  // exponential notation, where the digits after the '.' are the mantissa's
-  // and not the decimal expansion, so splitting on '.' counts the wrong thing
-  // (1e-7 has no '.' at all and came back as 0 decimals).
-  if (eIdx > -1) {
-    const exp = Number(str.slice(eIdx + 1));
-    const mantissaDecimals = (str.slice(0, eIdx).split('.')[1] || '').length;
-    return Math.max(0, mantissaDecimals - exp);
-  }
-
-  return (str.split('.')[1] || '').length;
+  return (decimalCounter.format(num).split('.')[1] || '').length;
 }

--- a/packages/grafana-ui/src/components/Sparkline/utils.test.ts
+++ b/packages/grafana-ui/src/components/Sparkline/utils.test.ts
@@ -128,6 +128,16 @@ describe('Get y range', () => {
     config: {},
     state: { range: { min: 0.0053, max: 0.0094, delta: 0.0041 } },
   };
+  // Below 1e-6 JavaScript stringifies to exponential notation. A single-digit
+  // mantissa such as 1e-7 has no '.' at all, so guessDecimals used to return 0,
+  // both ends rounded to 0, and the range collapsed to [0, 1].
+  const subMicroYField: Field = {
+    name: 'y',
+    values: [1e-7, 2e-7, 3e-7, 2e-7, 1e-7],
+    type: FieldType.number,
+    config: {},
+    state: { range: { min: 1e-7, max: 3e-7, delta: 2e-7 } },
+  };
   const xField: Field = {
     name: 'x',
     values: [1000, 2000, 3000, 4000, 5000],
@@ -194,6 +204,11 @@ describe('Get y range', () => {
       description: 'decimal values which are not close to equal should not be rounded out',
       field: decimalsNotCloseYField,
       expected: [0.0053, 0.0094],
+    },
+    {
+      description: 'values below 1e-6, which stringify to exponential notation',
+      field: subMicroYField,
+      expected: [1e-7, 3e-7],
     },
   ])(`should return correct range for $description`, ({ field, expected }) => {
     const actual = getYRange(getAlignedFrame(field));


### PR DESCRIPTION
**What is this feature?**

A fix, not a feature. `guessDecimals` in `packages/grafana-data/src/utils/numbers.ts` counted decimal places by splitting the stringified number on `.`. JavaScript switches to exponential notation below `1e-6` and at or above `1e21`, so for those values it was counting the characters of the exponent instead:

| input | `'' + num` | before | after |
|---|---|---|---|
| `1e-7` | `"1e-7"` | 0 | 7 |
| `1.5e-7` | `"1.5e-7"` | 4 | 8 |
| `1.5e21` | `"1.5e+21"` | 5 | 0 |

The fix reads the count off the exponent when the string carries one. Plain decimal input takes the same path as before, and the boundary stays continuous, since `1e-6` stringifies as `"0.000001"` and still reports 6.

**Why do we need this feature?**

`Sparkline/utils.ts` uses it to pick the rounding precision for the sparkline's own range, with no magnitude guard:

```ts
const decimals = field.config.decimals ?? Math.max(guessDecimals(min), guessDecimals(max));

// call roundDecimals to mirror what is going to eventually happen in uplot
let roundedMin = roundDecimals(min, decimals);
let roundedMax = roundDecimals(max, decimals);
```

For a series below `1e-6` this produced `decimals = 0`, so both ends of the range rounded to zero and the sparkline was drawn against a collapsed range:

```
min 1e-7,  max 5e-7   ->  decimals=0  ->  rounded 0 .. 0
min 0.001, max 0.005  ->  decimals=3  ->  rounded 0.001 .. 0.005   (control)
```

Small-magnitude series are not exotic in practice: error rates, ratios and sub-microsecond durations all land there. No `field.config.decimals` override is needed to hit it, since that is only the fallback.

`UPlotAxisBuilder.ts:168` calls it as `guessDecimals(roundDecimals(tickIncr, 6))`. The `6` there already caps the magnitude, so that path degraded to 0 decimals rather than a nonsense count, but it shares the root cause and also benefits.

**Who is this feature for?**

Anyone with a panel showing a sparkline over values below `1e-6`.

**Which issue(s) does this PR fix?**:

Fixes #130409

**Special notes for your reviewer:**

`numbers.ts` had no test file, so this adds one covering both exported functions. Three of the seven cases fail against `main`:

```
Expected: 7   Received: 0     (1e-7)
Expected: 0   Received: 5     (1.5e21)
Expected: 7   Received: 0     (5e-324 / boundary)
```

I also ran the suites for the three consumers of `guessDecimals` to check nothing downstream shifted: `uPlot`, `Sparkline` and `calculateHeatmap`, 19 suites / 232 tests / 28 snapshots, all passing. `tsc`, `eslint` and `prettier --check` are clean.

One judgement call worth flagging: I fixed this at the source rather than guarding each caller, since `guessDecimals` is exported from `@grafana/data` and any caller can be handed a small number. If you would rather keep the helper naive and guard in `Sparkline`, I am happy to redo it that way.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle. Not applicable, this is a bug fix.
- [ ] The docs are updated. Not applicable, no user-facing configuration changes.
