### PR TITLE
[PoC] Text: Markdown live preview 

### DIFF
--- a/packages/grafana-ui/src/components/CodeMirror/CodeEditor.story.tsx
+++ b/packages/grafana-ui/src/components/CodeMirror/CodeEditor.story.tsx
@@ -5,7 +5,6 @@ import { action } from 'storybook/actions';
 import { CodeEditor } from './CodeEditor';
 import mdx from './CodeEditor.mdx';
 import type { CodeMirrorCompletionSource, CodeMirrorEditorLanguage } from './types';
-import { useMarkdownLivePreview } from './useMarkdownLivePreview';
 
 const languageOptions: CodeMirrorEditorLanguage[] = [
   'go',
@@ -111,32 +110,6 @@ WithCompletions.args = {
   height: '240px',
   completionMode: 'override',
   completionSources: [keywordCompletionSource],
-};
-
-const storyVariables: Record<string, string> = {
-  '${cluster}': 'prod-eu-west-1',
-  $service: 'checkout-api',
-};
-
-const MarkdownLivePreviewEditor: StoryFn<typeof CodeEditor> = (args) => {
-  const extensions = useMarkdownLivePreview(true, (text: string) => storyVariables[text] ?? text);
-
-  return <ControlledEditor {...args} extensions={extensions} />;
-};
-
-export const MarkdownLivePreview = MarkdownLivePreviewEditor.bind({});
-MarkdownLivePreview.args = {
-  value: `# Rollback steps for \${cluster}
-
-Scale $service **down to zero**, then revert the config to \`v4.2\`.
-
-> Page the on-call SRE before step 3.
-
-See the [runbook](https://example.com/runbook) for the ~~old~~ current process.`,
-  language: 'markdown',
-  height: '320px',
-  lineWrapping: true,
-  basicSetup: { lineNumbers: false, foldGutter: false, highlightActiveLine: false },
 };
 
 export default meta;

--- a/packages/grafana-ui/src/components/CodeMirror/CodeEditor.story.tsx
+++ b/packages/grafana-ui/src/components/CodeMirror/CodeEditor.story.tsx
@@ -5,6 +5,7 @@ import { action } from 'storybook/actions';
 import { CodeEditor } from './CodeEditor';
 import mdx from './CodeEditor.mdx';
 import type { CodeMirrorCompletionSource, CodeMirrorEditorLanguage } from './types';
+import { useMarkdownLivePreview } from './useMarkdownLivePreview';
 
 const languageOptions: CodeMirrorEditorLanguage[] = [
   'go',
@@ -110,6 +111,32 @@ WithCompletions.args = {
   height: '240px',
   completionMode: 'override',
   completionSources: [keywordCompletionSource],
+};
+
+const storyVariables: Record<string, string> = {
+  '${cluster}': 'prod-eu-west-1',
+  $service: 'checkout-api',
+};
+
+const MarkdownLivePreviewEditor: StoryFn<typeof CodeEditor> = (args) => {
+  const extensions = useMarkdownLivePreview(true, (text: string) => storyVariables[text] ?? text);
+
+  return <ControlledEditor {...args} extensions={extensions} />;
+};
+
+export const MarkdownLivePreview = MarkdownLivePreviewEditor.bind({});
+MarkdownLivePreview.args = {
+  value: `# Rollback steps for \${cluster}
+
+Scale $service **down to zero**, then revert the config to \`v4.2\`.
+
+> Page the on-call SRE before step 3.
+
+See the [runbook](https://example.com/runbook) for the ~~old~~ current process.`,
+  language: 'markdown',
+  height: '320px',
+  lineWrapping: true,
+  basicSetup: { lineNumbers: false, foldGutter: false, highlightActiveLine: false },
 };
 
 export default meta;

--- a/packages/grafana-ui/src/components/CodeMirror/languageLoader.test.ts
+++ b/packages/grafana-ui/src/components/CodeMirror/languageLoader.test.ts
@@ -98,6 +98,29 @@ describe('loadLanguageExtension', () => {
     }
   );
 
+  // The toolbar inserts GFM tables and `- [ ] ` checklists, which strict
+  // CommonMark does not parse.
+  it.each([
+    ['Table', '| a | b |\n| - | - |\n| 1 | 2 |'],
+    ['Strikethrough', '~~gone~~'],
+    ['TaskMarker', '- [ ] todo'],
+  ])('parses the GFM %s node', async (nodeName, doc) => {
+    await jest.isolateModulesAsync(async () => {
+      const { loadLanguageExtension } = await import('./languageLoader');
+      const { ensureSyntaxTree } = await import('@codemirror/language');
+      const { EditorState } = await import('@codemirror/state');
+
+      const extension = await loadLanguageExtension('markdown');
+      const state = EditorState.create({ doc, extensions: extension ? [extension] : [] });
+      const tree = ensureSyntaxTree(state, state.doc.length);
+
+      const names: string[] = [];
+      tree?.iterate({ enter: (node) => void names.push(node.name) });
+
+      expect(names).toContain(nodeName);
+    });
+  });
+
   it('configures the typescript loader for TypeScript syntax', async () => {
     await jest.isolateModulesAsync(async () => {
       const { loadLanguageExtension } = await import('./languageLoader');

--- a/packages/grafana-ui/src/components/CodeMirror/languageLoader.ts
+++ b/packages/grafana-ui/src/components/CodeMirror/languageLoader.ts
@@ -13,8 +13,14 @@ const loadHtml = async (): Promise<CodeMirrorExtension> =>
 const loadJson = async (): Promise<CodeMirrorExtension> =>
   (await import(/* webpackChunkName: "codemirror-lang-json" */ '@codemirror/lang-json')).json();
 
-const loadMarkdown = async (): Promise<CodeMirrorExtension> =>
-  (await import(/* webpackChunkName: "codemirror-lang-markdown" */ '@codemirror/lang-markdown')).markdown();
+// `markdown()` defaults to strict CommonMark, which does not parse tables, task
+// lists or strikethrough. `markdownLanguage` is the GFM base, a superset.
+const loadMarkdown = async (): Promise<CodeMirrorExtension> => {
+  const { markdown, markdownLanguage } = await import(
+    /* webpackChunkName: "codemirror-lang-markdown" */ '@codemirror/lang-markdown'
+  );
+  return markdown({ base: markdownLanguage });
+};
 
 const loadTypescript = async (): Promise<CodeMirrorExtension> =>
   (await import(/* webpackChunkName: "codemirror-lang-javascript" */ '@codemirror/lang-javascript')).javascript({

--- a/packages/grafana-ui/src/components/CodeMirror/markdownLivePreview.test.ts
+++ b/packages/grafana-ui/src/components/CodeMirror/markdownLivePreview.test.ts
@@ -1,0 +1,233 @@
+import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
+import { ensureSyntaxTree } from '@codemirror/language';
+import { EditorState, type Extension } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+
+import { createTheme } from '@grafana/data';
+
+import { markdownLivePreview } from './markdownLivePreview';
+import { createCodeEditorTheme } from './theme';
+
+const theme = createTheme();
+
+let views: EditorView[] = [];
+
+/**
+ * jsdom reports a zero-height editor, which puts the viewport at roughly 100
+ * lines. Fixtures must stay well under that or only their top would be
+ * decorated, and the failures read as logic bugs.
+ */
+function createView(
+  doc: string,
+  selection?: { anchor: number; head?: number },
+  { before = [], interpolate }: { before?: Extension[]; interpolate?: (text: string) => string } = {}
+): EditorView {
+  const view = new EditorView({
+    parent: document.body,
+    state: EditorState.create({
+      doc,
+      selection,
+      extensions: [...before, markdown({ base: markdownLanguage }), markdownLivePreview(theme, interpolate)],
+    }),
+  });
+  views.push(view);
+
+  // The parse is lazy and budgeted, so the first tree is often empty. Forcing it
+  // and dispatching an empty transaction makes the plugin's rebuild deterministic.
+  ensureSyntaxTree(view.state, view.state.doc.length, 5000);
+  view.dispatch({});
+
+  return view;
+}
+
+/** What the user sees, with hidden markers removed. */
+const rendered = (view: EditorView) => view.contentDOM.textContent;
+
+afterEach(() => {
+  views.forEach((view) => view.destroy());
+  views = [];
+});
+
+describe('markdownLivePreview', () => {
+  it('leaves the document untouched', () => {
+    const doc = '# Title\n\nSome **bold** text.';
+    const view = createView(doc, { anchor: doc.length });
+
+    expect(view.state.doc.toString()).toBe(doc);
+  });
+
+  it('hides heading markers along with the space they leave behind', () => {
+    const view = createView('# Title\n\nbody', { anchor: 11 });
+
+    // Not ' Title' — HeaderMark covers the `#` only, so the separator has to go too.
+    expect(rendered(view)).toBe('Titlebody');
+  });
+
+  it.each([
+    ['bold', '**bold** tail', 'bold tail'],
+    ['italic', '*italic* tail', 'italic tail'],
+    ['strikethrough', '~~gone~~ tail', 'gone tail'],
+    ['inline code', '`code` tail', 'code tail'],
+    ['link', '[label](https://example.com) tail', 'label tail'],
+  ])('hides %s markers', (_name, doc, expected) => {
+    const view = createView(`x\n${doc}`, { anchor: 0 });
+
+    expect(rendered(view)).toBe(`x${expected}`);
+  });
+
+  it('reveals the markers on the line the cursor is on', () => {
+    const view = createView('# Title\n\nbody', { anchor: 11 });
+    expect(rendered(view)).toBe('Titlebody');
+
+    view.dispatch({ selection: { anchor: 3 } });
+
+    expect(rendered(view)).toBe('# Titlebody');
+  });
+
+  it('reveals every line a selection touches', () => {
+    // head lands at the end of line 2, so lines 1-2 reveal and line 3 stays hidden.
+    const view = createView('# One\n## Two\n### Three', { anchor: 0, head: 12 });
+
+    expect(rendered(view)).toBe('# One## TwoThree');
+  });
+
+  it('reveals only the cursor line when the selection is very large', () => {
+    const doc = Array.from({ length: 80 }, (_, i) => `# Heading ${i}`).join('\n');
+    const view = createView(doc, { anchor: 0, head: doc.length });
+
+    // Select-all would otherwise un-render the entire document at once.
+    expect(rendered(view)?.startsWith('Heading 0')).toBe(true);
+    expect(rendered(view)).toContain(`# Heading ${79}`);
+  });
+
+  it('leaves image syntax alone', () => {
+    const view = createView('x\n![alt text](https://e.com/a.png)', { anchor: 0 });
+
+    // Nothing renders the image yet, so hiding the markers would collapse it to
+    // bare alt text and the image would vanish without trace.
+    expect(rendered(view)).toBe('x![alt text](https://e.com/a.png)');
+  });
+
+  it('keeps a fenced code block’s fences visible', () => {
+    const view = createView('```js\nconst a = 1;\n```', { anchor: 0 });
+
+    expect(rendered(view)).toContain('```');
+  });
+
+  it('does not touch non-GFM markers that the renderer would show literally', () => {
+    const view = createView('x\nH~2~O and 2^10^', { anchor: 0 });
+
+    expect(rendered(view)).toBe('xH~2~O and 2^10^');
+  });
+
+  it('marks up heading lines for screen readers', () => {
+    const view = createView('## Title\n\nbody', { anchor: 12 });
+
+    const heading = view.contentDOM.querySelector('[role="heading"]');
+    expect(heading).not.toBeNull();
+    expect(heading?.getAttribute('aria-level')).toBe('2');
+    expect(heading?.classList.contains('cm-md-h2')).toBe(true);
+  });
+
+  it('does not rebuild decorations during an IME composition', () => {
+    const view = createView('# Title\n\nbody', { anchor: 11 });
+    expect(rendered(view)).toBe('Titlebody');
+
+    // Replacing DOM mid-composition aborts it in Chrome and Safari, so moving
+    // onto the heading must not reveal its marker until the composition ends.
+    Object.defineProperty(view, 'composing', { value: true, configurable: true });
+    view.dispatch({ selection: { anchor: 3 } });
+
+    expect(rendered(view)).toBe('Titlebody');
+  });
+
+  // The default code theme's syntax highlighting emits bare `.ͼtag` rules and is
+  // mounted after ours, so it would win any equal-specificity tie. Our own class
+  // names out-specify it instead.
+  describe('over the default code editor theme', () => {
+    // Same order CodeEditor uses: the Grafana theme first, ours last.
+    const createStyledView = (doc: string, selection: { anchor: number }) =>
+      createView(doc, selection, { before: [createCodeEditorTheme(theme)] });
+
+    it('sizes and colours headings as prose', () => {
+      const view = createStyledView('# Title\n\nbody', { anchor: 11 });
+      const heading = view.contentDOM.querySelector('.cm-md-h1')!;
+
+      const styles = getComputedStyle(heading);
+      expect(styles.fontSize).toBe(theme.typography.h1.fontSize);
+      // Not the highlight style's `colors.primary.text`.
+      expect(styles.color).toBe(theme.colors.text.primary);
+    });
+
+    it('sets the body font on the content', () => {
+      const view = createStyledView('# Title', { anchor: 0 });
+
+      expect(getComputedStyle(view.contentDOM).fontFamily).toBe(theme.typography.fontFamily);
+    });
+  });
+
+  describe('variables', () => {
+    const values: Record<string, string> = {
+      $datacenter: 'eu-west-1',
+      '${datacenter}': 'eu-west-1',
+      '${datacenter:csv}': 'eu-west-1,us-east-1',
+      '[[datacenter]]': 'eu-west-1',
+    };
+    const interpolate = (text: string) => values[text] ?? text;
+
+    const createVariableView = (doc: string, selection: { anchor: number }) =>
+      createView(doc, selection, { interpolate });
+
+    it.each(Object.keys(values))('renders the value of %s', (source) => {
+      const view = createVariableView(`x\nRegion: ${source}`, { anchor: 0 });
+
+      expect(rendered(view)).toBe(`xRegion: ${values[source]}`);
+      expect(view.state.doc.toString()).toBe(`x\nRegion: ${source}`);
+    });
+
+    it('reveals the reference on the line being edited', () => {
+      const view = createVariableView('x\nRegion: $datacenter', { anchor: 0 });
+      expect(rendered(view)).toBe('xRegion: eu-west-1');
+
+      view.dispatch({ selection: { anchor: 5 } });
+
+      expect(rendered(view)).toBe('xRegion: $datacenter');
+    });
+
+    it('leaves text that merely looks like a variable alone', () => {
+      const view = createVariableView('x\nIt cost $5 and $notAVariable', { anchor: 0 });
+
+      // Interpolating to itself means there is nothing to show.
+      expect(rendered(view)).toBe('xIt cost $5 and $notAVariable');
+    });
+
+    it('does not replace a variable inside a hidden link URL', () => {
+      const view = createVariableView('x\n[home](https://$datacenter.example.com)', { anchor: 0 });
+
+      // The URL is already hidden; two replacements over one range would collide.
+      expect(rendered(view)).toBe('xhome');
+    });
+
+    it('is inert to the browser so typing cannot land inside it', () => {
+      const view = createVariableView('x\nRegion: $datacenter', { anchor: 0 });
+
+      const widget = view.contentDOM.querySelector('.cm-md-variable');
+      expect(widget?.getAttribute('contenteditable')).toBe('false');
+      expect(widget?.getAttribute('title')).toBe('$datacenter');
+    });
+
+    it('leaves references as source when no interpolate is given', () => {
+      const view = createView('x\nRegion: $datacenter', { anchor: 0 });
+
+      expect(rendered(view)).toBe('xRegion: $datacenter');
+    });
+  });
+
+  it('copies the source, not the rendered text', () => {
+    const doc = '# Title';
+    const view = createView(doc, { anchor: doc.length });
+
+    // What CodeMirror puts on the clipboard is sliced straight from the doc.
+    expect(view.state.sliceDoc(0, doc.length)).toBe('# Title');
+  });
+});

--- a/packages/grafana-ui/src/components/CodeMirror/markdownLivePreview.ts
+++ b/packages/grafana-ui/src/components/CodeMirror/markdownLivePreview.ts
@@ -1,0 +1,393 @@
+import { syntaxTree } from '@codemirror/language';
+import { Prec, type EditorState, type Extension, type Line, type Range } from '@codemirror/state';
+import {
+  Decoration,
+  EditorView,
+  ViewPlugin,
+  WidgetType,
+  type DecorationSet,
+  type ViewUpdate,
+  type PluginValue,
+} from '@codemirror/view';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+
+/**
+ * Node names are matched as strings rather than against `@lezer/markdown`'s
+ * `Type` enum: that package is only a transitive dependency of `@grafana/ui`
+ * (`@codemirror/lang-markdown` owns it), and importing it here would also pull
+ * the lazily-chunked markdown grammar into the main bundle.
+ */
+
+/** Markers replaced with nothing while the cursor is off their line. */
+const HIDDEN_MARKS = new Set(['HeaderMark', 'EmphasisMark', 'StrikethroughMark', 'QuoteMark']);
+
+/**
+ * Markers hidden only inside this parent. A fenced block's ``` fence is a
+ * `CodeMark` too, and hiding it would leave a blank line where the block starts;
+ * an autolink's `URL` is the only text it has, so hiding it would leave nothing.
+ *
+ * Images are excluded throughout: nothing here renders one, so hiding `![…](…)`
+ * would collapse it to bare alt text and the image would silently disappear.
+ * Showing the source at least tells the author an image is there.
+ */
+const HIDDEN_MARK_PARENTS = new Map([
+  ['CodeMark', 'InlineCode'],
+  ['LinkMark', 'Link'],
+  ['LinkTitle', 'Link'],
+  ['URL', 'Link'],
+]);
+
+/** Block nodes that style every line they cover. */
+const LINE_CLASSES: Record<string, string> = {
+  ATXHeading1: 'cm-md-h1',
+  SetextHeading1: 'cm-md-h1',
+  ATXHeading2: 'cm-md-h2',
+  SetextHeading2: 'cm-md-h2',
+  ATXHeading3: 'cm-md-h3',
+  ATXHeading4: 'cm-md-h4',
+  ATXHeading5: 'cm-md-h5',
+  ATXHeading6: 'cm-md-h6',
+  Blockquote: 'cm-md-quote',
+  FencedCode: 'cm-md-code',
+  CodeBlock: 'cm-md-code',
+};
+
+const LINE_DECORATIONS: Record<string, Decoration> = Object.fromEntries(
+  Object.entries(LINE_CLASSES).map(([node, className]) => {
+    // The `#` markers are hidden from the DOM, and a `cm-line` div carries no
+    // semantics of its own, so the heading is announced from the line instead.
+    const level = /Heading(\d)$/.exec(node)?.[1];
+    return [
+      node,
+      Decoration.line(
+        level ? { class: className, attributes: { role: 'heading', 'aria-level': level } } : { class: className }
+      ),
+    ];
+  })
+);
+
+/**
+ * A select-all would otherwise un-render the whole document at once — a full
+ * reflow, and a flash of raw markdown. Past this many lines only the line the
+ * cursor sits on is revealed.
+ */
+const MAX_REVEALED_LINES = 50;
+
+const hidden = Decoration.replace({});
+
+/** Line numbers whose markers stay visible because a selection touches them. */
+function revealedLines(state: EditorState): Set<number> {
+  const lines = new Set<number>();
+
+  for (const range of state.selection.ranges) {
+    const first = state.doc.lineAt(range.from).number;
+    const last = state.doc.lineAt(range.to).number;
+
+    if (last - first > MAX_REVEALED_LINES) {
+      lines.add(state.doc.lineAt(range.head).number);
+      continue;
+    }
+
+    for (let line = first; line <= last; line++) {
+      lines.add(line);
+    }
+  }
+
+  return lines;
+}
+
+/** Identifies a revealed-line set, so caret motion within a line is not a change. */
+const revealedKey = (state: EditorState) => [...revealedLines(state)].join(',');
+
+/**
+ * `ATXHeading` writes `HeaderMark` over the `#` run alone and starts the inline
+ * content one character later, so the separating space belongs to no node. Left
+ * behind, every heading renders with a stray leading space.
+ */
+function markerEnd(state: EditorState, name: string, from: number, to: number): number {
+  if (name !== 'HeaderMark' && name !== 'QuoteMark') {
+    return to;
+  }
+
+  const lineEnd = state.doc.lineAt(from).to;
+  let end = to;
+  while (end < lineEnd && state.doc.sliceString(end, end + 1) === ' ') {
+    end++;
+  }
+  return end;
+}
+
+/**
+ * A template or field variable reference: `$name`, `${name}`, `${name:format}`
+ * or `[[name]]`. Deliberately loose — a match that interpolates to itself (`$5`
+ * in prose, an undefined variable) is discarded rather than filtered up front.
+ *
+ * `DataLinks/codemirrorUtils.ts` has a deliberately narrower `${…}`-only
+ * pattern for highlighting; the two are not meant to be unified.
+ */
+const VARIABLE_PATTERN = /\$\{[^}\s]+\}|\[\[[^\]\s]+\]\]|\$\w+/g;
+
+class VariableWidget extends WidgetType {
+  constructor(
+    private readonly source: string,
+    private readonly value: string
+  ) {
+    super();
+  }
+
+  // Without this every widget is rebuilt on every keystroke and cursor move.
+  eq(other: VariableWidget) {
+    return other.source === this.source && other.value === this.value;
+  }
+
+  toDOM() {
+    const span = document.createElement('span');
+    span.className = 'cm-md-variable';
+    span.textContent = this.value;
+    span.title = this.source;
+    // The widget lives inside contenteditable; without this the browser lets the
+    // user type into it and CodeMirror sees DOM it did not produce.
+    span.setAttribute('contenteditable', 'false');
+    return span;
+  }
+
+  // Let CodeMirror handle clicks so the caret can be placed next to the value.
+  ignoreEvent() {
+    return false;
+  }
+}
+
+interface Span {
+  from: number;
+  to: number;
+}
+
+const contains = (outer: Span, inner: Span) => outer.from <= inner.from && outer.to >= inner.to;
+const overlaps = (a: Span, b: Span) => a.from < b.to && a.to > b.from;
+
+interface VariableSpan extends Span {
+  source: string;
+  value: string;
+}
+
+/** Resolvable variable references on `line`. */
+function findVariables(line: Line, resolve: (text: string) => string): VariableSpan[] {
+  // Most prose lines hold neither, and the regex is by far the costlier check.
+  if (!line.text.includes('$') && !line.text.includes('[[')) {
+    return [];
+  }
+
+  const found: VariableSpan[] = [];
+
+  for (const match of line.text.matchAll(VARIABLE_PATTERN)) {
+    const source = match[0];
+    const value = resolve(source);
+
+    // Unchanged means it is not a variable at all, or has no value to show.
+    if (value !== source) {
+      const from = line.from + (match.index ?? 0);
+      found.push({ from, to: from + source.length, source, value });
+    }
+  }
+
+  return found;
+}
+
+function buildLivePreviewDecorations(view: EditorView, interpolate?: (text: string) => string): DecorationSet {
+  const { state } = view;
+  const tree = syntaxTree(state);
+  const revealed = revealedLines(state);
+  // Resolution walks the scene graph, and prose repeats references (and pays for
+  // near-misses like `$5`), so each distinct token is resolved once per build.
+  const resolved = new Map<string, string>();
+  const resolve = (source: string) => {
+    let value = resolved.get(source);
+    if (value === undefined) {
+      value = interpolate ? interpolate(source) : source;
+      resolved.set(source, value);
+    }
+    return value;
+  };
+  // Not a RangeSetBuilder: line decorations sit at line starts and interleave
+  // with marks found later in the tree walk, so positions do not arrive sorted.
+  const ranges: Array<Range<Decoration>> = [];
+  const decoratedLines = new Set<string>();
+  // Collected rather than emitted, because a variable reference can overlap a
+  // marker and only one of the two may claim the range.
+  const markers: Span[] = [];
+  const variables: VariableSpan[] = [];
+
+  for (const { from, to } of view.visibleRanges) {
+    tree.iterate({
+      from,
+      to,
+      enter: (node) => {
+        const lineDecoration = LINE_DECORATIONS[node.name];
+
+        if (lineDecoration) {
+          const first = state.doc.lineAt(node.from).number;
+          const last = state.doc.lineAt(Math.min(node.to, state.doc.length)).number;
+          for (let line = first; line <= last; line++) {
+            // Nested blockquotes cover the same lines twice.
+            const key = `${node.name}:${line}`;
+            if (!decoratedLines.has(key)) {
+              decoratedLines.add(key);
+              ranges.push(lineDecoration.range(state.doc.line(line).from));
+            }
+          }
+          return;
+        }
+
+        const requiredParent = HIDDEN_MARK_PARENTS.get(node.name);
+        const hideable = requiredParent ? node.node.parent?.name === requiredParent : HIDDEN_MARKS.has(node.name);
+        if (!hideable || revealed.has(state.doc.lineAt(node.from).number)) {
+          return;
+        }
+
+        const end = markerEnd(state, node.name, node.from, node.to);
+        if (end > node.from) {
+          markers.push({ from: node.from, to: end });
+        }
+      },
+    });
+
+    if (interpolate) {
+      const lastLine = state.doc.lineAt(to).number;
+      for (let number = state.doc.lineAt(from).number; number <= lastLine; number++) {
+        if (!revealed.has(number)) {
+          variables.push(...findVariables(state.doc.line(number), resolve));
+        }
+      }
+    }
+  }
+
+  // Interpolation runs before the markdown parser when the panel renders, so a
+  // variable owns its whole reference — `[[name]]` is a variable, not a link.
+  // A variable sitting *inside* a marker (a link URL) is the other way round.
+  const keptMarkers = markers.filter((marker) => !variables.some((variable) => contains(variable, marker)));
+  const keptVariables = variables.filter((variable) => !keptMarkers.some((marker) => overlaps(marker, variable)));
+
+  for (const marker of keptMarkers) {
+    ranges.push(hidden.range(marker.from, marker.to));
+  }
+  for (const { from, to, source, value } of keptVariables) {
+    ranges.push(Decoration.replace({ widget: new VariableWidget(source, value) }).range(from, to));
+  }
+
+  return Decoration.set(ranges, true);
+}
+
+function livePreviewPlugin(interpolate?: (text: string) => string) {
+  return ViewPlugin.fromClass(
+    class implements PluginValue {
+      decorations: DecorationSet;
+      private tree: ReturnType<typeof syntaxTree>;
+      private revealed: string;
+
+      constructor(view: EditorView) {
+        this.tree = syntaxTree(view.state);
+        this.revealed = revealedKey(view.state);
+        this.decorations = buildLivePreviewDecorations(view, interpolate);
+      }
+
+      update(update: ViewUpdate) {
+        // Replacing DOM inside an active composition aborts it in Chrome and Safari,
+        // which drops or duplicates characters for IME users. The composition's own
+        // final change triggers the rebuild instead.
+        if (update.view.composing) {
+          return;
+        }
+
+        // The parser advances the tree in a transaction that changes nothing else,
+        // so tree identity has to be part of the condition or the tail of a long
+        // document stays unstyled until the next edit. The selection only matters
+        // through the lines it reveals, so caret motion within a line is ignored.
+        const tree = syntaxTree(update.state);
+        const revealed = revealedKey(update.state);
+        const isStale = tree !== this.tree || revealed !== this.revealed || update.docChanged || update.viewportChanged;
+
+        if (isStale) {
+          this.tree = tree;
+          this.revealed = revealed;
+          this.decorations = buildLivePreviewDecorations(update.view, interpolate);
+        }
+      }
+    },
+    { decorations: (plugin) => plugin.decorations }
+  );
+}
+
+function livePreviewTheme(theme: GrafanaTheme2): Extension {
+  // Takes its weight from the variant so a heading matches the real element
+  // (see GlobalStyles/elements.ts); the margins there cannot apply to a line.
+  const heading = (level: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6') => {
+    const variant = theme.typography[level];
+    return {
+      fontSize: variant.fontSize,
+      lineHeight: `${variant.lineHeight}`,
+      fontWeight: `${variant.fontWeight}`,
+      color: theme.colors.text.primary,
+    };
+  };
+
+  return EditorView.theme({
+    // Prose, not code — but `padding` is deliberately left alone here, callers
+    // set it on `.cm-content`/`.cm-line` from outside the editor.
+    '.cm-content': {
+      fontFamily: theme.typography.fontFamily,
+      fontSize: theme.typography.body.fontSize,
+      lineHeight: `${theme.typography.body.lineHeight}`,
+    },
+    '.cm-md-h1': heading('h1'),
+    '.cm-md-h2': heading('h2'),
+    '.cm-md-h3': heading('h3'),
+    '.cm-md-h4': heading('h4'),
+    '.cm-md-h5': heading('h5'),
+    '.cm-md-h6': heading('h6'),
+    '.cm-md-quote': {
+      borderLeft: `3px solid ${theme.colors.border.strong}`,
+      color: theme.colors.text.secondary,
+      fontStyle: 'italic',
+    },
+    '.cm-md-code': {
+      fontFamily: theme.typography.fontFamilyMonospace,
+      fontSize: theme.typography.bodySmall.fontSize,
+      background: theme.colors.background.secondary,
+    },
+    // Marked as interpolated so a resolved value is not mistaken for typed text.
+    '.cm-md-variable': {
+      color: theme.colors.text.primary,
+      background: theme.colors.background.secondary,
+      borderBottom: `1px dotted ${theme.colors.border.strong}`,
+      borderRadius: theme.shape.radius.default,
+      padding: theme.spacing(0, 0.25),
+    },
+  });
+}
+
+/**
+ * Renders markdown formatting in place while the document stays markdown
+ * source: headings take heading sizes, emphasis and links render, and the
+ * syntax markers are hidden except on the line the cursor is on.
+ *
+ * Requires `language="markdown"`. The editor's value is never rewritten, so
+ * commands that edit the source — and copy, undo and paste — are unaffected.
+ *
+ * The returned extension must be memoized. `CodeEditor` compares the
+ * `extensions` array element-wise by identity, so a fresh call on every render
+ * reconfigures the whole editor and closes any open completion popup. Prefer
+ * {@link useMarkdownLivePreview}, which handles this.
+ *
+ * `interpolate` resolves a variable reference such as `${datacenter}` to its
+ * value, which is shown in place of the reference; it should return its input
+ * unchanged for anything that is not a variable. Values refresh on the next
+ * edit, selection change or scroll — not the instant a dashboard variable
+ * changes. Omit it to leave references as source.
+ */
+export function markdownLivePreview(theme: GrafanaTheme2, interpolate?: (text: string) => string): Extension {
+  // Only the theme is raised: our class selectors already out-specify the
+  // default syntax highlighting, and raising the plugin itself would nest our
+  // replacements outside the highlight spans.
+  return [livePreviewPlugin(interpolate), Prec.high(livePreviewTheme(theme))];
+}

--- a/packages/grafana-ui/src/components/CodeMirror/useMarkdownLivePreview.ts
+++ b/packages/grafana-ui/src/components/CodeMirror/useMarkdownLivePreview.ts
@@ -1,0 +1,30 @@
+import { useMemo } from 'react';
+
+import { useTheme2 } from '../../themes/ThemeContext';
+
+import { markdownLivePreview } from './markdownLivePreview';
+import { type CodeMirrorExtension } from './types';
+import { useStableCallback } from './useStableProps';
+
+/**
+ * Memoized {@link markdownLivePreview} extension, ready to pass to
+ * `CodeEditor`'s `extensions` prop.
+ *
+ * `CodeEditor` compares that array element-wise by identity, so an unmemoized
+ * extension reconfigures the editor on every keystroke — which discards
+ * extension state such as an open completion popup. `interpolate` may therefore
+ * be a fresh closure each render; it is held by reference and always called at
+ * its latest version.
+ */
+export function useMarkdownLivePreview(
+  enabled = true,
+  interpolate: (text: string) => string = (text) => text
+): CodeMirrorExtension[] {
+  const theme = useTheme2();
+  const stableInterpolate = useStableCallback(interpolate);
+
+  return useMemo(
+    () => (enabled ? [markdownLivePreview(theme, stableInterpolate)] : []),
+    [enabled, theme, stableInterpolate]
+  );
+}

--- a/packages/grafana-ui/src/unstable.ts
+++ b/packages/grafana-ui/src/unstable.ts
@@ -12,6 +12,8 @@
 export * from './utils/skeleton';
 
 export { CodeMirrorEditor } from './components/CodeMirror/CodeEditorLazy';
+export { markdownLivePreview } from './components/CodeMirror/markdownLivePreview';
+export { useMarkdownLivePreview } from './components/CodeMirror/useMarkdownLivePreview';
 export { signatureHelp } from './components/CodeMirror/signatureHelp';
 export type { SignatureHelpOptions } from './components/CodeMirror/signatureHelp';
 export type {

--- a/public/app/plugins/panel/text/v2/TextNGPanel.editorLoading.test.tsx
+++ b/public/app/plugins/panel/text/v2/TextNGPanel.editorLoading.test.tsx
@@ -12,6 +12,7 @@ import { createProps, renderPanel } from './test-utils';
 // Stub the lazy CodeMirror bundle used by the inline editor.
 jest.mock('@grafana/ui/unstable', () => ({
   __esModule: true,
+  useMarkdownLivePreview: () => [],
   CodeMirrorEditor: ({ value, 'aria-label': ariaLabel }: { value: string; 'aria-label'?: string }) => (
     <textarea aria-label={ariaLabel} value={value} readOnly />
   ),

--- a/public/app/plugins/panel/text/v2/TextNGPanel.test.tsx
+++ b/public/app/plugins/panel/text/v2/TextNGPanel.test.tsx
@@ -12,6 +12,7 @@ import { createProps, renderPanel } from './test-utils';
 // Stub the lazy CodeMirror bundle used by the inline editor and the read-only code view.
 jest.mock('@grafana/ui/unstable', () => ({
   __esModule: true,
+  useMarkdownLivePreview: () => [],
   CodeMirrorEditor: ({
     value,
     basicSetup,

--- a/public/app/plugins/panel/text/v2/editor/TextNGEditor.test.tsx
+++ b/public/app/plugins/panel/text/v2/editor/TextNGEditor.test.tsx
@@ -14,6 +14,7 @@ import { FORMAT_TOOLBAR_TEST_ID } from './TextNGFormatToolbar';
 // stub it with a plain textarea so these tests stay fast and deterministic.
 jest.mock('@grafana/ui/unstable', () => ({
   __esModule: true,
+  useMarkdownLivePreview: () => [],
   CodeMirrorEditor: ({
     value,
     onChange,
@@ -100,6 +101,8 @@ const setup = (
 
 const enterWriteMode = () => userEvent.click(screen.getByRole('radio', { name: 'Write' }));
 
+const enterPreviewMode = () => userEvent.click(screen.getByRole('radio', { name: 'Preview' }));
+
 const openModeMenu = () => userEvent.click(screen.getByRole('button', { name: /^Text mode/ }));
 
 const selectMode = async (name: string) => {
@@ -115,45 +118,74 @@ const selectLanguage = async (name: string) => {
 
 describe('TextNGEditor', () => {
   describe('default (view-first) state', () => {
-    it('lands on the rendered preview, not the editor', () => {
+    // Markdown renders its own formatting as you type, so there is nothing to
+    // land on a separate preview for.
+    it('lands in the editor for markdown', () => {
       setup('# Hello', TextMode.Markdown);
 
-      expect(screen.getByTestId(PREVIEW_TEST_ID).innerHTML).toContain('<h1');
+      expect(screen.getByRole('textbox')).toHaveValue('# Hello');
+      expect(screen.getByRole('radio', { name: 'Write' })).toBeChecked();
+      expect(screen.queryByTestId(PREVIEW_TEST_ID)).not.toBeInTheDocument();
+    });
+
+    it('lands on the rendered preview for other modes', () => {
+      setup('<p>Hello</p>', TextMode.HTML);
+
+      expect(screen.getByTestId(PREVIEW_TEST_ID).innerHTML).toContain('<p>');
       expect(screen.getByRole('radio', { name: 'Preview' })).toBeChecked();
       expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
     });
 
     it('opens straight into the editor when content is empty', () => {
-      setup('', TextMode.Markdown);
+      setup('', TextMode.HTML);
 
       expect(screen.getByRole('textbox')).toBeInTheDocument();
       expect(screen.getByRole('radio', { name: 'Write' })).toBeChecked();
     });
 
     it('reveals the editor after selecting Write', async () => {
-      setup('# Hello', TextMode.Markdown);
+      setup('<p>Hello</p>', TextMode.HTML);
 
       await enterWriteMode();
-      expect(screen.getByRole('textbox')).toHaveValue('# Hello');
+      expect(screen.getByRole('textbox')).toHaveValue('<p>Hello</p>');
       expect(screen.queryByTestId(PREVIEW_TEST_ID)).not.toBeInTheDocument();
     });
   });
 
   describe('views', () => {
-    it('shows only the rendered preview in Preview view', () => {
+    it('shows only the rendered preview in Preview view', async () => {
       setup('# Hello', TextMode.Markdown);
+
+      await userEvent.click(screen.getByRole('radio', { name: 'Preview' }));
 
       expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
       expect(screen.getByTestId(PREVIEW_TEST_ID).innerHTML).toContain('<h1');
     });
 
     it('shows editor and preview side by side in Split view', async () => {
-      setup('# Hello', TextMode.Markdown);
+      setup('<p>Hello</p>', TextMode.HTML);
 
       await userEvent.click(screen.getByRole('radio', { name: 'Split' }));
 
       expect(screen.getByRole('textbox')).toBeInTheDocument();
       expect(screen.getByTestId(PREVIEW_TEST_ID)).toBeInTheDocument();
+    });
+
+    it('offers no split in markdown, where the two panes would match', async () => {
+      setup('# Hello', TextMode.Markdown);
+
+      expect(screen.queryByRole('radio', { name: 'Split' })).not.toBeInTheDocument();
+      expect(screen.getByRole('radio', { name: 'Preview' })).toBeInTheDocument();
+    });
+
+    it('leaves split when switching into markdown', async () => {
+      setup('<p>Hello</p>', TextMode.HTML);
+      await userEvent.click(screen.getByRole('radio', { name: 'Split' }));
+
+      await selectMode('Markdown');
+
+      expect(screen.getByRole('radio', { name: 'Write' })).toBeChecked();
+      expect(screen.queryByRole('radio', { name: 'Split' })).not.toBeInTheDocument();
     });
 
     it('sanitizes script tags in the HTML mode preview', () => {
@@ -197,10 +229,10 @@ describe('TextNGEditor', () => {
       const replaceVariables = (value: string) => value.replace('$datacenter', 'A, B, C');
       setup('# Data center = $datacenter', TextMode.Markdown, jest.fn(), false, undefined, replaceVariables);
 
-      expect(screen.getByTestId(PREVIEW_TEST_ID)).toHaveTextContent('Data center = A, B, C');
-
-      await userEvent.click(screen.getByRole('radio', { name: 'Write' }));
       expect(screen.getByRole('textbox')).toHaveValue('# Data center = $datacenter');
+
+      await enterPreviewMode();
+      expect(screen.getByTestId(PREVIEW_TEST_ID)).toHaveTextContent('Data center = A, B, C');
     });
 
     it('forwards editor changes via a debounced onChange', async () => {
@@ -261,9 +293,11 @@ describe('TextNGEditor', () => {
       expect(onChange).not.toHaveBeenCalledWith({ content: 'updated' });
     });
 
-    it('interpolates with the json format when code language is json, regardless of mode', () => {
+    it('interpolates with the json format when code language is json, regardless of mode', async () => {
       const replaceVariables = jest.fn((value: string) => value);
       setup('# Hello', TextMode.Markdown, jest.fn(), false, CodeLanguage.Json, replaceVariables);
+
+      await enterPreviewMode();
 
       // Matches the panel render path, which keys the interpolation format off
       // code.language alone.
@@ -272,18 +306,17 @@ describe('TextNGEditor', () => {
   });
 
   describe('content that renders to nothing', () => {
-    // Deleting everything and pressing enter in Split view: markdown renders a
-    // lone newline to '', which the space fallback keeps DangerouslySetHtmlContent
-    // from throwing on.
+    // Deleting everything and previewing it: markdown renders a lone newline to
+    // '', which the space fallback keeps DangerouslySetHtmlContent from throwing on.
     it.each(['\n', '\n\n', '   \n  ', '<!-- just a comment -->'])(
       'renders the empty space fallback in the preview for %j',
       async (content) => {
         setup('# Hello', TextMode.Markdown);
-        await userEvent.click(screen.getByRole('radio', { name: 'Split' }));
 
         // fireEvent, because userEvent.type() does not reproduce a value that is
         // only whitespace. A throw here fails the test.
         fireEvent.change(screen.getByRole('textbox'), { target: { value: content } });
+        await enterPreviewMode();
 
         // Debounced preview settles from the '# Hello' <h1> to the space fallback.
         await waitFor(() => expect(screen.getByTestId(PREVIEW_TEST_ID).innerHTML.trim()).toBe(''));
@@ -292,11 +325,13 @@ describe('TextNGEditor', () => {
   });
 
   describe('preview updates', () => {
+    // Split is the only view where the preview updates while typing, and markdown
+    // does not offer it.
     it('re-renders the preview once typing settles', async () => {
-      setup('# Hello', TextMode.Markdown);
+      setup('<h1>Hello</h1>', TextMode.HTML);
       await userEvent.click(screen.getByRole('radio', { name: 'Split' }));
 
-      fireEvent.change(screen.getByRole('textbox'), { target: { value: '## Updated' } });
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: '<h2>Updated</h2>' } });
 
       // Still the old preview: the update is debounced.
       expect(screen.getByTestId(PREVIEW_TEST_ID).innerHTML).toContain('<h1');
@@ -316,8 +351,8 @@ describe('TextNGEditor', () => {
     it('shows externally replaced content immediately, e.g. after a discard', async () => {
       const { rerender } = render(
         <TextNGEditor
-          content="# Hello"
-          mode={TextMode.Markdown}
+          content="<h1>Hello</h1>"
+          mode={TextMode.HTML}
           showLineNumbers={false}
           replaceVariables={(value: string) => value}
           onChange={jest.fn()}
@@ -326,8 +361,8 @@ describe('TextNGEditor', () => {
 
       rerender(
         <TextNGEditor
-          content="## Reverted"
-          mode={TextMode.Markdown}
+          content="<h2>Reverted</h2>"
+          mode={TextMode.HTML}
           showLineNumbers={false}
           replaceVariables={(value: string) => value}
           onChange={jest.fn()}
@@ -347,15 +382,17 @@ describe('TextNGEditor', () => {
     });
 
     it('renders in Split view', async () => {
-      setup('hello', TextMode.Markdown);
+      setup('hello', TextMode.HTML);
 
       await userEvent.click(screen.getByRole('radio', { name: 'Split' }));
 
       expect(screen.getByTestId(FORMAT_TOOLBAR_TEST_ID)).toBeInTheDocument();
     });
 
-    it('is hidden in Preview view, where there is nothing to format', () => {
+    it('is hidden in Preview view, where there is nothing to format', async () => {
       setup('hello', TextMode.Markdown);
+
+      await enterPreviewMode();
 
       expect(screen.queryByTestId(FORMAT_TOOLBAR_TEST_ID)).not.toBeInTheDocument();
     });
@@ -391,6 +428,7 @@ describe('TextNGEditor', () => {
       const { onChange } = setup('# Hello', TextMode.Markdown);
 
       await selectMode('HTML');
+      await enterPreviewMode();
 
       expect(onChange).toHaveBeenCalledWith({ mode: TextMode.HTML, content: '# Hello' });
       // HTML mode does not turn '#' into a heading, it renders the text as-is.

--- a/public/app/plugins/panel/text/v2/editor/TextNGEditor.tsx
+++ b/public/app/plugins/panel/text/v2/editor/TextNGEditor.tsx
@@ -6,7 +6,7 @@ import { useDebounce } from 'react-use';
 import { type GrafanaTheme2, type InterpolateFunction, type VariableSuggestion } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Button, Dropdown, Icon, Menu, RadioButtonGroup, Stack, useStyles2, useTheme2 } from '@grafana/ui';
-import { CodeMirrorEditor, type CodeMirrorEditorLanguage } from '@grafana/ui/unstable';
+import { CodeMirrorEditor, useMarkdownLivePreview, type CodeMirrorEditorLanguage } from '@grafana/ui/unstable';
 import config from 'app/core/config';
 
 import { CodeLanguage, defaultCodeLanguage, TextMode } from '../../panelcfg.gen';
@@ -68,7 +68,22 @@ export function TextNGEditor({
 }: TextNGEditorProps) {
   const theme = useTheme2();
   const styles = useStyles2(getStyles);
-  const [view, setView] = useState<ViewMode>(() => (content.trim().length === 0 ? 'write' : 'preview'));
+  // Markdown renders its formatting as you type, so it opens in the editor and
+  // has no split — the two panes would show the same thing. Preview remains for
+  // what live preview cannot do: resolve variables and render tables.
+  const isMarkdown = mode === TextMode.Markdown;
+
+  const viewOptions = [
+    { label: t('textng.editor.view-preview', 'Preview'), value: 'preview' as const },
+    ...(isMarkdown ? [] : [{ label: t('textng.editor.view-split', 'Split'), value: 'split' as const }]),
+    { label: t('textng.editor.view-write', 'Write'), value: 'write' as const },
+  ];
+
+  const [selectedView, setView] = useState<ViewMode>(() =>
+    isMarkdown || content.trim().length === 0 ? 'write' : 'preview'
+  );
+  // Changing mode can retire the selected view, e.g. markdown has no split.
+  const view = viewOptions.some((option) => option.value === selectedView) ? selectedView : 'write';
 
   const [draft, setDraft] = useState(content);
   // a blur can fire before React re-renders with the new draft.
@@ -145,16 +160,22 @@ export function TextNGEditor({
 
   const completionSources = useMemo(() => [variableCompletion(suggestions ?? [])], [suggestions]);
 
-  const basicSetup = useMemo(
-    () => ({ lineNumbers: mode === TextMode.Code ? showLineNumbers : false }),
-    [mode, showLineNumbers]
-  );
+  // Markdown is edited as a document: formatting renders in place, the syntax
+  // markers only surface on the line being edited, and variables show their
+  // values — so the editor already reads the way the panel will.
+  const livePreviewExtensions = useMarkdownLivePreview(isMarkdown, (text) => replaceVariables(text, {}, format));
 
-  const viewOptions = [
-    { label: t('textng.editor.view-preview', 'Preview'), value: 'preview' as const },
-    { label: t('textng.editor.view-split', 'Split'), value: 'split' as const },
-    { label: t('textng.editor.view-write', 'Write'), value: 'write' as const },
-  ];
+  const basicSetup = useMemo(
+    () => ({
+      lineNumbers: mode === TextMode.Code ? showLineNumbers : false,
+      // Code chrome reads as a bug on a prose surface: an empty fold column, and
+      // a grey band behind whichever line happens to be revealed.
+      foldGutter: !isMarkdown,
+      highlightActiveLine: !isMarkdown,
+      highlightActiveLineGutter: !isMarkdown,
+    }),
+    [mode, showLineNumbers, isMarkdown]
+  );
 
   const modeLabels: Record<TextMode, string> = {
     [TextMode.Markdown]: t('textng.editor.mode-markdown', 'Markdown'),
@@ -248,6 +269,7 @@ export function TextNGEditor({
               onChange={handleDraftChange}
               language={editorLanguage}
               completionSources={completionSources}
+              extensions={livePreviewExtensions}
               lineWrapping
               basicSetup={basicSetup}
               height="100%"

--- a/public/app/plugins/panel/text/v2/editor/editorCommands.test.ts
+++ b/public/app/plugins/panel/text/v2/editor/editorCommands.test.ts
@@ -1,14 +1,22 @@
-import { EditorState } from '@codemirror/state';
+import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
+import { EditorState, type Extension } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
+
+import { createTheme } from '@grafana/data';
+import { markdownLivePreview } from '@grafana/ui/unstable';
 
 import { insertAtCursor, toggleLinePrefix, toggleOrderedList, toggleSurround } from './editorCommands';
 
 let views: EditorView[] = [];
 
-function createView(doc: string, selection?: { anchor: number; head?: number }): EditorView {
+function createView(
+  doc: string,
+  selection?: { anchor: number; head?: number },
+  extensions: Extension[] = []
+): EditorView {
   const view = new EditorView({
     parent: document.body,
-    state: EditorState.create({ doc, selection }),
+    state: EditorState.create({ doc, selection, extensions }),
   });
   views.push(view);
   return view;
@@ -364,5 +372,36 @@ describe('toggleOrderedList', () => {
     // Still between `ta` and `sk`.
     expect(view.state.doc.toString()).toBe('1. task');
     expect(view.state.selection.main.head).toBe(5);
+  });
+});
+
+// The toolbar edits markdown source, and live preview only decorates the view,
+// so every command must behave identically with it installed.
+describe('with markdown live preview installed', () => {
+  const createPreviewView = (doc: string, selection?: { anchor: number; head?: number }) =>
+    createView(doc, selection, [markdown({ base: markdownLanguage }), markdownLivePreview(createTheme())]);
+
+  it('wraps a selection whose markers are hidden', () => {
+    const view = createPreviewView('hello world', { anchor: 0, head: 5 });
+
+    toggleSurround(view, '**');
+
+    expect(view.state.doc.toString()).toBe('**hello** world');
+  });
+
+  it('unwraps a selection whose markers are hidden', () => {
+    const view = createPreviewView('**hello** world', { anchor: 2, head: 7 });
+
+    toggleSurround(view, '**');
+
+    expect(view.state.doc.toString()).toBe('hello world');
+  });
+
+  it('toggles a heading prefix off a rendered heading', () => {
+    const view = createPreviewView('# Title', { anchor: 4 });
+
+    toggleLinePrefix(view, '# ');
+
+    expect(view.state.doc.toString()).toBe('Title');
   });
 });


### PR DESCRIPTION
Markdown now renders its formatting as you type instead of showing raw source - the syntax markers are hidden except on the line the cursor is on. Template variables show their resolved value inline.                                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                   The document stays plain markdown at every moment - this is a CodeMirror view decoration, not a WYSIWYG document model - so the stored content, the format toolbar, copy, undo and `${var}` autocompletion are all unchanged.                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                                   
Because the editor now reads the way the panel renders, markdown opens in Write and no longer offers Split (both panes would show the same thing). Preview stays for what live preview can't do: tables, images, and sanitized output. HTML and Code modes are untouched.                                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                   
Also fixes the CodeMirror markdown mode to parse GFM (`markdownLanguage` instead of the CommonMark default). Tables, task lists and strikethrough previously got no highlighting at all, even though the toolbar inserts them and `marked` renders them with `gfm: true`. 

https://github.com/user-attachments/assets/b7c09867-73bb-4961-a73d-336f9b75544e



Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
