### PR TITLE
[release-12.4.9] Azure Monitor: stop TraceExemplar attaching portal links to every field

### DIFF
--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
@@ -547,7 +547,7 @@ func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, query *A
 }
 
 func addDataLinksToFields(query *AzureLogAnalyticsQuery, azurePortalBaseUrl string, frame *data.Frame, dsInfo types.DatasourceInfo, queryUrl string) error {
-	if query.QueryType == dataquery.AzureQueryTypeAzureTraces {
+	if query.QueryType == dataquery.AzureQueryTypeAzureTraces || query.QueryType == dataquery.AzureQueryTypeTraceExemplar {
 		err := addTraceDataLinksToFields(query, azurePortalBaseUrl, frame, dsInfo)
 		if err != nil {
 			return err
@@ -577,9 +577,19 @@ func addTraceDataLinksToFields(query *AzureLogAnalyticsQuery, azurePortalBaseUrl
 		return err
 	}
 
-	if len(queryJSONModel.AzureTraces.Resources) == 0 {
+	if queryJSONModel.AzureTraces == nil {
+		queryJSONModel.AzureTraces = &dataquery.AzureTracesQuery{}
+	}
+
+	// Prefer resolved query resources (e.g. TraceExemplar correlation results) over the raw JSON payload.
+	resources := query.Resources
+	if len(resources) == 0 {
+		resources = queryJSONModel.AzureTraces.Resources
+	}
+	if len(resources) == 0 {
 		return fmt.Errorf("no resources specified for Azure traces data link")
 	}
+	queryJSONModel.AzureTraces.Resources = resources
 
 	traceIdVariable := "${__data.fields.traceID}"
 	resultFormat := dataquery.ResultFormatTrace
@@ -589,34 +599,45 @@ func addTraceDataLinksToFields(query *AzureLogAnalyticsQuery, azurePortalBaseUrl
 		queryJSONModel.AzureTraces.OperationId = &traceIdVariable
 	}
 
+	// Explore links from TraceExemplar should open as Azure Traces queries.
+	azureTracesQueryType := string(dataquery.AzureQueryTypeAzureTraces)
+	queryJSONModel.QueryType = &azureTracesQueryType
+
 	logsQueryType := string(dataquery.AzureQueryTypeLogAnalytics)
 	logsJSONModel := dataquery.AzureMonitorQuery{
 		QueryType: &logsQueryType,
 		AzureLogAnalytics: &dataquery.AzureLogsQuery{
 			Query:     &query.TraceLogsExploreQuery,
-			Resources: []string{queryJSONModel.AzureTraces.Resources[0]},
+			Resources: []string{resources[0]},
 		},
 	}
 
 	if query.ResultFormat == dataquery.ResultFormatTable {
+		exploreTraceModel := queryJSONModel
+		exploreTrace := *queryJSONModel.AzureTraces
+		exploreTrace.Query = &query.TraceExploreQuery
+		exploreTraceModel.AzureTraces = &exploreTrace
 		AddCustomDataLink(*frame, data.DataLink{
 			Title: "Explore Trace: ${__data.fields.traceID}",
 			URL:   "",
 			Internal: &data.InternalDataLink{
 				DatasourceUID:  dsInfo.DatasourceUID,
 				DatasourceName: dsInfo.DatasourceName,
-				Query:          queryJSONModel,
+				Query:          exploreTraceModel,
 			},
 		}, MultiField)
 
-		queryJSONModel.AzureTraces.Query = &query.TraceParentExploreQuery
+		exploreParentModel := queryJSONModel
+		exploreParent := *queryJSONModel.AzureTraces
+		exploreParent.Query = &query.TraceParentExploreQuery
+		exploreParentModel.AzureTraces = &exploreParent
 		AddCustomDataLink(*frame, data.DataLink{
 			Title: "Explore Parent Span: ${__data.fields.parentSpanID}",
 			URL:   "",
 			Internal: &data.InternalDataLink{
 				DatasourceUID:  dsInfo.DatasourceUID,
 				DatasourceName: dsInfo.DatasourceName,
-				Query:          queryJSONModel,
+				Query:          exploreParentModel,
 			},
 		}, MultiField)
 

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource_test.go
@@ -899,3 +899,122 @@ func TestAddTraceDataLinksToFields_EmptyResources(t *testing.T) {
 		})
 	}
 }
+
+func TestAddDataLinksToFields_TraceExemplar(t *testing.T) {
+	dsInfo := types.DatasourceInfo{
+		DatasourceUID:  "azure-monitor",
+		DatasourceName: "Azure Monitor",
+		Services: map[string]types.DatasourceService{
+			"Azure Monitor": {},
+		},
+	}
+
+	jsonResource := "/subscriptions/sub"
+	resolvedResource := "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Insights/components/app"
+	traceExploreQuery := "union isfuzzy=true AppTraces | where operation_Id == TraceId"
+	parentExploreQuery := "union isfuzzy=true AppTraces | where operation_Id == TraceId | where id == ParentId"
+	logsExploreQuery := "union isfuzzy=true AppTraces | where operation_Id == TraceId | project *"
+
+	newExemplarQuery := func(resultFormat dataquery.ResultFormat) *AzureLogAnalyticsQuery {
+		queryJSON := fmt.Sprintf(`{
+			"queryType": "traceql",
+			"azureTraces": {
+				"resources": [%q],
+				"resultFormat": %q,
+				"operationId": "trace-id"
+			}
+		}`, jsonResource, resultFormat)
+		return &AzureLogAnalyticsQuery{
+			JSON:                    []byte(queryJSON),
+			QueryType:               dataquery.AzureQueryTypeTraceExemplar,
+			ResultFormat:            resultFormat,
+			Resources:               []string{resolvedResource},
+			TraceExploreQuery:       traceExploreQuery,
+			TraceParentExploreQuery: parentExploreQuery,
+			TraceLogsExploreQuery:   logsExploreQuery,
+		}
+	}
+
+	newTraceFrame := func() *data.Frame {
+		return data.NewFrame("trace",
+			data.NewField("traceID", nil, []string{"trace-id"}),
+			data.NewField("spanID", nil, []string{"span-id"}),
+			data.NewField("operationName", nil, []string{"GET /"}),
+			data.NewField("serviceName", nil, []string{"frontend"}),
+			data.NewField("duration", nil, []float64{1.2}),
+		)
+	}
+
+	t.Run("trace format does not attach portal query links to every field", func(t *testing.T) {
+		frame := newTraceFrame()
+		err := addDataLinksToFields(newExemplarQuery(dataquery.ResultFormatTrace), "https://portal.azure.com", frame, dsInfo, "https://portal.azure.com/query")
+		require.NoError(t, err)
+
+		require.Equal(t, 0, countFieldLinksByTitle(frame, "View query in Azure Portal"))
+		require.Equal(t, 1, countFieldLinksByTitle(frame, "Explore Trace Logs"))
+	})
+
+	// Also covers the table-format regression where Explore Trace / Explore Parent Span shared one
+	// AzureTraces pointer, so setting TraceParentExploreQuery overwrote the explore-trace payload.
+	t.Run("explore links use Azure Traces query type and resolved resources", func(t *testing.T) {
+		frame := newTraceFrame()
+		err := addDataLinksToFields(newExemplarQuery(dataquery.ResultFormatTable), "https://portal.azure.com", frame, dsInfo, "https://portal.azure.com/query")
+		require.NoError(t, err)
+
+		exploreTrace := findInternalAzureQueryByLinkTitle(t, frame, "Explore Trace: ${__data.fields.traceID}")
+		require.NotNil(t, exploreTrace.QueryType)
+		require.Equal(t, string(dataquery.AzureQueryTypeAzureTraces), *exploreTrace.QueryType)
+		require.NotNil(t, exploreTrace.AzureTraces)
+		require.Equal(t, []string{resolvedResource}, exploreTrace.AzureTraces.Resources)
+		require.NotNil(t, exploreTrace.AzureTraces.Query)
+		require.Equal(t, traceExploreQuery, *exploreTrace.AzureTraces.Query)
+
+		exploreParent := findInternalAzureQueryByLinkTitle(t, frame, "Explore Parent Span: ${__data.fields.parentSpanID}")
+		require.NotNil(t, exploreParent.QueryType)
+		require.Equal(t, string(dataquery.AzureQueryTypeAzureTraces), *exploreParent.QueryType)
+		require.NotNil(t, exploreParent.AzureTraces)
+		require.Equal(t, []string{resolvedResource}, exploreParent.AzureTraces.Resources)
+		require.NotNil(t, exploreParent.AzureTraces.Query)
+		require.Equal(t, parentExploreQuery, *exploreParent.AzureTraces.Query)
+
+		exploreLogs := findInternalAzureQueryByLinkTitle(t, frame, "Explore Trace Logs")
+		require.NotNil(t, exploreLogs.QueryType)
+		require.Equal(t, string(dataquery.AzureQueryTypeLogAnalytics), *exploreLogs.QueryType)
+		require.NotNil(t, exploreLogs.AzureLogAnalytics)
+		require.Equal(t, []string{resolvedResource}, exploreLogs.AzureLogAnalytics.Resources)
+	})
+}
+
+func countFieldLinksByTitle(frame *data.Frame, title string) int {
+	count := 0
+	for _, field := range frame.Fields {
+		if field.Config == nil {
+			continue
+		}
+		for _, link := range field.Config.Links {
+			if link.Title == title {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func findInternalAzureQueryByLinkTitle(t *testing.T, frame *data.Frame, title string) dataquery.AzureMonitorQuery {
+	t.Helper()
+	for _, field := range frame.Fields {
+		if field.Config == nil {
+			continue
+		}
+		for _, link := range field.Config.Links {
+			if link.Title != title || link.Internal == nil {
+				continue
+			}
+			query, ok := link.Internal.Query.(dataquery.AzureMonitorQuery)
+			require.True(t, ok, "expected AzureMonitorQuery on link %q", title)
+			return query
+		}
+	}
+	require.FailNow(t, "link not found", "title %q", title)
+	return dataquery.AzureMonitorQuery{}
+}


### PR DESCRIPTION
Backport 0e268d50bf14d48e3327602e440feb6049d5c777 from #129612

---

## Summary
- Route `TraceExemplar` (`traceql`) responses through the same data-link path as Azure Traces instead of multi-field `AddConfigLinks`
- Prevents duplicate **"View query in Azure Portal"** links when opening traces via Prometheus exemplars ([#128810](https://github.com/grafana/grafana/issues/128810))
- Prefer resolved `query.Resources` for explore links; nil-safe `AzureTraces`; explore links from exemplars use Azure Traces query type
- Also fix table-format **"Explore Trace"** / **"Explore Parent Span"** links sharing one `AzureTraces` pointer — mutating the parent-span query previously overwrote the explore-trace link payload. Each link now gets its own copy.

**Behavior note:** Exemplars use `ResultFormatTrace`. On that path, Azure Traces does not attach an Azure Portal deep link — it attaches a single internal **"Explore Trace Logs"** link (Grafana Explore). After this fix, exemplar-opened traces match that same behavior (one Grafana explore link), rather than N copies of "View query in Azure Portal". That matches the working direct App Insights / Azure Traces path described in the issue and presumably we prefer to make internal grafana queries when we can.

Related frontend defensive dedupe: #129595

## Test plan
- [x] `go test ./pkg/tsdb/azuremonitor/loganalytics/ -run TestAddDataLinksToFields_TraceExemplar` (includes regression coverage that Explore Trace / Explore Parent Span keep distinct query payloads)
- [x] With `azureMonitorPrometheusExemplars` enabled: open a trace from a Prometheus exemplar into Azure Monitor and confirm a single "Explore Trace Logs" link (not N duplicates of "View query in Azure Portal")
- [ ] Direct Azure Traces query still gets expected explore / portal links for table and trace formats

This is reproducible with the `[managed_data_source] - Azure Managed Prometheus (Tailscale)` datasource and [this](https://datasourcedev.grafana-dev.net/goto/s2mb4w?orgId=stacks-5285) is what the reproduction query looks like in cloud. Click one of the little exemplar stars, and it brings up a azure monitor logs query. If you click one of the logs you'll see links that used to look like this:
<img width="614" height="419" alt="Screenshot 2026-07-31 at 2 04 06 PM" src="https://github.com/user-attachments/assets/20c20d0f-60a9-4e7f-9551-2ddf6faa6ff8" />
and now looks like this:
<img width="624" height="185" alt="Screenshot 2026-08-03 at 9 16 34 AM" src="https://github.com/user-attachments/assets/77697127-32a9-4d4f-a410-a20582081bca" />
