### PR TITLE
unified-search: refuse indexes needing features this instance cannot read

### DIFF
--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -102,17 +102,20 @@ type BulkIndexRequest struct {
 }
 
 type IndexBuildInfo struct {
-	BuildTime        time.Time       // Timestamp when the index was built. This value doesn't change on subsequent index updates.
-	BuildVersion     *semver.Version // Grafana version used when originally building the index. This value doesn't change on subsequent index updates.
-	SelectableFields []string        // List of selectable fields used when index was built.
-	SearchFieldsHash string          // Hash captured at build time over the SearchFieldDefinition slices registered for (group, resource), across all versions. Empty when no SearchFieldsProvider was in use.
-	Features         []IndexFeature  // Index features the index was built with. Empty on indexes built before index features existed.
+	BuildTime          time.Time       // Timestamp when the index was built. This value doesn't change on subsequent index updates.
+	BuildVersion       *semver.Version // Grafana version used when originally building the index. This value doesn't change on subsequent index updates.
+	SelectableFields   []string        // List of selectable fields used when index was built.
+	SearchFieldsHash   string          // Hash captured at build time over the SearchFieldDefinition slices registered for (group, resource), across all versions. Empty when no SearchFieldsProvider was in use.
+	Features           []IndexFeature  // Index features the index was built with. Empty on indexes built before index features existed.
+	ReaderRequirements []IndexFeature  // Features a reader must understand before using this index. Empty on indexes built before requirements were recorded.
 }
 
-// IndexFeature names a mapping change an older index cannot satisfy. Only for
-// changes no declared search field describes, such as an internal marker: a
-// declared field already moves IndexAffectingHash. Choosing wrong is silent — no
-// rebuild, missing data, no error.
+// IndexFeature names something about an index the search fields hash does not
+// capture: an internal marker no field declares, a storage choice a declaration
+// does not describe, or fields kept out of the hash on purpose (see
+// TrashSearchFieldDefinitions). Changes the hash covers already force a rebuild.
+// Making such a change without adding a feature for it is silent: nothing
+// rebuilds, and older indexes keep serving without the mapping.
 type IndexFeature string
 
 // IndexFeatureTrashFields means the index maps TrashSearchFieldDefinitions. An
@@ -145,11 +148,31 @@ func TrashIndexFeatures() []IndexFeature {
 }
 
 // currentIndexFeatures is recorded in every index this binary builds.
+//
+// A feature that changes which documents the index holds, not just how they are
+// mapped, belongs in readerRequiredFeatures too, and must not be enabled here
+// until that check has shipped for longer than the compatibility window —
+// instances without the check ignore the requirement and read the index anyway.
 var currentIndexFeatures = []IndexFeature{
 	IndexFeatureDeletedMarker,
 	IndexFeatureStoredFacets,
 	IndexFeatureTrashFields,
 }
+
+// knownIndexFeatures is every feature this binary can read. A feature belongs here
+// from the release that implements its reading side, even if nothing builds indexes
+// with it yet. Only ever grows.
+var knownIndexFeatures = []IndexFeature{
+	IndexFeatureDeletedMarker,
+	IndexFeatureStoredFacets,
+	IndexFeatureTrashFields,
+}
+
+// readerRequiredFeatures name features an instance must understand before using an
+// index that has them. Empty today. A mapping alone is not enough to add one:
+// deleted documents are only kept when a config option says so, so a requirement
+// declared from the mapping would make older instances refuse safe indexes.
+var readerRequiredFeatures = []IndexFeature{}
 
 // requiredIndexFeatures is the subset an index must already have to be used. An
 // index without one of these features is rebuilt before it serves anything, even
@@ -189,6 +212,26 @@ func MissingIndexFeatures(buildInfo IndexBuildInfo, requiredFeatures []IndexFeat
 		}
 	}
 	return missing
+}
+
+// IndexReaderRequirements returns the requirements an index built by this binary
+// declares.
+func IndexReaderRequirements() []IndexFeature {
+	return slices.Sorted(slices.Values(readerRequiredFeatures))
+}
+
+// UnknownIndexRequirements returns declared requirements this binary does not
+// recognise; a non-empty result means the index must not be used. Matching on known
+// names rather than required ones is what lets an instance refuse a feature added
+// after it shipped.
+func UnknownIndexRequirements(requirements []IndexFeature) []IndexFeature {
+	var unknown []IndexFeature
+	for _, feature := range requirements {
+		if !slices.Contains(knownIndexFeatures, feature) {
+			unknown = append(unknown, feature)
+		}
+	}
+	return unknown
 }
 
 type ResourceIndex interface {

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -674,6 +674,32 @@ func TestRequiredIndexFeaturesAreCurrent(t *testing.T) {
 	}
 }
 
+// Anything this binary builds with, it must also know how to read, or it would
+// refuse its own indexes.
+func TestKnownIndexFeaturesCoverCurrent(t *testing.T) {
+	for _, current := range CurrentIndexFeatures() {
+		require.Contains(t, knownIndexFeatures, current)
+	}
+}
+
+// Declaring a requirement this binary cannot read would reject every index it
+// builds.
+func TestReaderRequiredFeaturesAreKnown(t *testing.T) {
+	for _, required := range readerRequiredFeatures {
+		require.Contains(t, knownIndexFeatures, required)
+	}
+	require.Empty(t, UnknownIndexRequirements(IndexReaderRequirements()))
+}
+
+func TestUnknownIndexRequirements(t *testing.T) {
+	// An index built before requirements were recorded.
+	require.Empty(t, UnknownIndexRequirements(nil))
+
+	// Refused by name, so an older instance needs no knowledge of the feature.
+	require.Equal(t, []IndexFeature{"feature-from-the-future"},
+		UnknownIndexRequirements([]IndexFeature{IndexFeatureDeletedMarker, "feature-from-the-future"}))
+}
+
 // TestRequiredIndexFeaturesStoredFacets covers the gating that keeps the stored
 // facet mapping from rebuilding indexes where post-rank authorization is off.
 func TestRequiredIndexFeaturesStoredFacets(t *testing.T) {

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -656,11 +656,12 @@ func newBleveIndex(path string, mapper mapping.IndexMapping, buildTime time.Time
 	}
 
 	bi := buildInfo{
-		BuildTime:        buildTime.Unix(),
-		BuildVersion:     buildVersion,
-		SelectableFields: selectableFields,
-		SearchFieldsHash: searchFieldsHash,
-		Features:         resource.CurrentIndexFeatures(),
+		BuildTime:          buildTime.Unix(),
+		BuildVersion:       buildVersion,
+		SelectableFields:   selectableFields,
+		SearchFieldsHash:   searchFieldsHash,
+		Features:           resource.CurrentIndexFeatures(),
+		ReaderRequirements: resource.IndexReaderRequirements(),
 	}
 
 	biBytes, err := json.Marshal(bi)
@@ -694,6 +695,10 @@ type buildInfo struct {
 	// Index features the index was built with. Absent on indexes built before
 	// index features existed.
 	Features []resource.IndexFeature `json:"features,omitempty"`
+
+	// Features a reader must understand before using this index. One this binary
+	// does not recognise means the index may hold documents it would misread.
+	ReaderRequirements []resource.IndexFeature `json:"reader_requirements,omitempty"`
 }
 
 type buildIndexSource int
@@ -1079,7 +1084,6 @@ func (b *bleveBackend) tryReuseFileIndex(resourceDir string, lastImportTime time
 	bi, err := getBuildInfo(idx)
 	if err != nil {
 		logger.Warn("failed to get build info from existing index", "error", err)
-		return idx, name, rv, nil
 	}
 
 	indexBuildTime := time.Time{}
@@ -1091,7 +1095,13 @@ func (b *bleveBackend) tryReuseFileIndex(resourceDir string, lastImportTime time
 	// scan replaces it shortly after. Only an index that would answer incorrectly
 	// is rejected. An index with no build time counts as older than any import.
 	reason := ""
-	if missing := resource.MissingIndexFeatures(bi.resourceBuildInfo(), b.requiredFeatures); len(missing) > 0 {
+	if err != nil {
+		// Without build info there is no way to tell whether this index declares a
+		// requirement this binary cannot meet, so it is not safe to serve.
+		reason = fmt.Sprintf("build info could not be read: %v", err)
+	} else if unknown := resource.UnknownIndexRequirements(bi.ReaderRequirements); len(unknown) > 0 {
+		reason = fmt.Sprintf("index requires features this instance does not understand %v", unknown)
+	} else if missing := resource.MissingIndexFeatures(bi.resourceBuildInfo(), b.requiredFeatures); len(missing) > 0 {
 		reason = fmt.Sprintf("index is missing required features %v", missing)
 	} else if !lastImportTime.IsZero() && indexBuildTime.Before(lastImportTime) {
 		reason = "index was built before the last import"
@@ -1960,11 +1970,12 @@ func (bi buildInfo) resourceBuildInfo() resource.IndexBuildInfo {
 	}
 
 	return resource.IndexBuildInfo{
-		BuildTime:        bt,
-		BuildVersion:     bv,
-		SelectableFields: bi.SelectableFields,
-		SearchFieldsHash: bi.SearchFieldsHash,
-		Features:         bi.Features,
+		BuildTime:          bt,
+		BuildVersion:       bv,
+		SelectableFields:   bi.SelectableFields,
+		SearchFieldsHash:   bi.SearchFieldsHash,
+		Features:           bi.Features,
+		ReaderRequirements: bi.ReaderRequirements,
 	}
 }
 

--- a/pkg/storage/unified/search/bleve_snapshot.go
+++ b/pkg/storage/unified/search/bleve_snapshot.go
@@ -324,12 +324,23 @@ func (b *bleveBackend) pickBestSnapshot(all map[ulid.ULID]*IndexMeta, notOlderTh
 	minVersion := b.opts.Snapshot.MinBuildVersion
 	running := b.runningBuildVersion
 
-	var droppedAge, droppedUnparseable, droppedFormatUnsupported int
+	var droppedAge, droppedUnparseable, droppedFormatUnsupported, droppedUnknownRequirements int
 	candidates := make([]snapshotCandidate, 0, len(all))
 	for k, m := range all {
 		// Hard filter: age.
 		if !notOlderThan.IsZero() && m.UploadTimestamp.Before(notOlderThan) {
 			droppedAge++
+			continue
+		}
+		// Hard filter: needs a feature this instance cannot read. Dropped here rather
+		// than after download so an older snapshot can be used instead.
+		if unknown := resource.UnknownIndexRequirements(m.ReaderRequirements); len(unknown) > 0 {
+			droppedUnknownRequirements++
+			logger.Debug("index snapshot candidate dropped: unknown reader requirements",
+				"key", k.String(),
+				"unknown_requirements", unknown,
+				"version", m.BuildVersion,
+			)
 			continue
 		}
 		if !isSnapshotIndexFormatUnknownOrSupported(m.IndexFormat, b.maxSupportedIndexFormat) {
@@ -371,7 +382,7 @@ func (b *bleveBackend) pickBestSnapshot(all map[ulid.ULID]*IndexMeta, notOlderTh
 	}
 
 	if len(candidates) == 0 {
-		logger.Debug("no index snapshot candidates", "total", len(all), "dropped_age", droppedAge, "dropped_unparseable", droppedUnparseable, "dropped_format_unsupported", droppedFormatUnsupported, "max_supported_format", b.maxSupportedIndexFormat)
+		logger.Debug("no index snapshot candidates", "total", len(all), "dropped_age", droppedAge, "dropped_unparseable", droppedUnparseable, "dropped_format_unsupported", droppedFormatUnsupported, "dropped_unknown_requirements", droppedUnknownRequirements, "max_supported_format", b.maxSupportedIndexFormat)
 		return snapshotCandidate{}, false
 	}
 
@@ -420,9 +431,9 @@ func snapshotTier(v, minVersion, running *semver.Version) int {
 // on success.
 //
 // Snapshot selection accepts an older Grafana version (see snapshotTier), so
-// this is where a snapshot that would answer incorrectly gets rejected. That
-// costs a download first; recording index features in the snapshot metadata
-// would let selection skip such a snapshot instead. Follow-up.
+// this is where a snapshot that would answer incorrectly gets rejected. Selection
+// already skips manifests declaring requirements we do not understand; this covers
+// snapshots uploaded before that field existed.
 func (b *bleveBackend) validateDownloadedIndex(idx bleve.Index) (int64, error) {
 	rv, err := getRV(idx)
 	if err != nil {
@@ -434,6 +445,9 @@ func (b *bleveBackend) validateDownloadedIndex(idx bleve.Index) (int64, error) {
 	bi, err := getBuildInfo(idx)
 	if err != nil {
 		return 0, fmt.Errorf("reading build info: %w", err)
+	}
+	if unknown := resource.UnknownIndexRequirements(bi.ReaderRequirements); len(unknown) > 0 {
+		return 0, fmt.Errorf("snapshot requires index features this instance does not understand %v", unknown)
 	}
 	if missing := resource.MissingIndexFeatures(bi.resourceBuildInfo(), b.requiredFeatures); len(missing) > 0 {
 		return 0, fmt.Errorf("snapshot is missing required index features %v", missing)

--- a/pkg/storage/unified/search/bleve_snapshot_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_test.go
@@ -42,8 +42,9 @@ func writeFakeSnapshot(dir string, meta *IndexMeta) error {
 		return err
 	}
 	bi, err := json.Marshal(buildInfo{
-		BuildTime:    meta.UploadTimestamp.Unix(),
-		BuildVersion: meta.BuildVersion,
+		BuildTime:          meta.UploadTimestamp.Unix(),
+		BuildVersion:       meta.BuildVersion,
+		ReaderRequirements: meta.ReaderRequirements,
 	})
 	if err != nil {
 		return err
@@ -163,6 +164,38 @@ func TestPickBestSnapshot(t *testing.T) {
 		all := map[ulid.ULID]*IndexMeta{makeULID(t, now): snap("not-a-version", 100, time.Minute)}
 		_, ok := newBackend(minV).pickBestSnapshot(all, cutoff(24*time.Hour), log.New("bleve-snapshot-test"))
 		assert.False(t, ok)
+	})
+
+	requiring := func(ver string, rv int64, age time.Duration, requirements ...resource.IndexFeature) *IndexMeta {
+		m := snap(ver, rv, age)
+		m.ReaderRequirements = requirements
+		return m
+	}
+
+	t.Run("dropped for unknown reader requirements", func(t *testing.T) {
+		all := map[ulid.ULID]*IndexMeta{makeULID(t, now): requiring("11.5.0", 100, time.Minute, "feature-from-the-future")}
+		_, ok := newBackend(minV).pickBestSnapshot(all, cutoff(24*time.Hour), log.New("bleve-snapshot-test"))
+		assert.False(t, ok)
+	})
+
+	t.Run("requirements this instance understands are accepted", func(t *testing.T) {
+		key := makeULID(t, now)
+		all := map[ulid.ULID]*IndexMeta{key: requiring("11.5.0", 100, time.Minute, resource.IndexFeatureDeletedMarker)}
+		c, ok := newBackend(minV).pickBestSnapshot(all, cutoff(24*time.Hour), log.New("bleve-snapshot-test"))
+		require.True(t, ok)
+		assert.Equal(t, key, c.key)
+	})
+
+	// Without the filter the newer one wins as tier 2 and its documents are misread.
+	t.Run("falls back to an older snapshot when the newest needs an unknown feature", func(t *testing.T) {
+		compatible := makeULID(t, now.Add(-30*time.Second))
+		all := map[ulid.ULID]*IndexMeta{
+			compatible:       snap("11.5.0", 100, time.Minute),
+			makeULID(t, now): requiring("12.0.0", 999, time.Minute, "feature-from-the-future"),
+		}
+		c, ok := newBackend(minV).pickBestSnapshot(all, cutoff(24*time.Hour), log.New("bleve-snapshot-test"))
+		require.True(t, ok)
+		assert.Equal(t, compatible, c.key)
 	})
 
 	t.Run("tier 0 preferred over 1 and 2", func(t *testing.T) {

--- a/pkg/storage/unified/search/bleve_snapshot_upload.go
+++ b/pkg/storage/unified/search/bleve_snapshot_upload.go
@@ -172,6 +172,7 @@ func (b *bleveBackend) snapshotCopyAndUpload(ctx context.Context, key resource.N
 	meta := IndexMeta{
 		BuildVersion:          bi.BuildVersion,
 		IndexFormat:           indexFormat,
+		ReaderRequirements:    bi.ReaderRequirements,
 		LatestResourceVersion: rv,
 		DocCount:              docCount,
 	}

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -1257,6 +1257,81 @@ func TestValidateDownloadedIndexChecksRequiredFeatures(t *testing.T) {
 		require.ErrorContains(t, err, "missing required index features [alpha]")
 	})
 }
+
+// A local index whose build info cannot be read is discarded: there is no way to
+// tell whether it declares a requirement this binary cannot meet.
+func TestReuseFileIndexRejectsUnreadableBuildInfo(t *testing.T) {
+	newIndexOnDisk := func(t *testing.T, rawBuildInfo []byte) string {
+		t.Helper()
+		resourceDir := t.TempDir()
+		idx, err := newBleveIndex(filepath.Join(resourceDir, "index-dir"), bleve.NewIndexMapping(), time.Now(), buildVersion, nil, "")
+		require.NoError(t, err)
+		require.NoError(t, setRV(idx, 42))
+		if rawBuildInfo != nil {
+			require.NoError(t, idx.SetInternal([]byte(internalBuildInfoKey), rawBuildInfo))
+		}
+		require.NoError(t, idx.Close())
+		return resourceDir
+	}
+
+	logger := log.New("bleve-test")
+
+	t.Run("reused when build info is readable", func(t *testing.T) {
+		backend, _ := setupBleveBackend(t, withRootDir(t.TempDir()))
+		idx, _, rv, err := backend.tryReuseFileIndex(newIndexOnDisk(t, nil), time.Time{}, logger)
+		require.NoError(t, err)
+		require.NotNil(t, idx)
+		require.Equal(t, int64(42), rv)
+		require.NoError(t, idx.Close())
+	})
+
+	t.Run("discarded when build info cannot be parsed", func(t *testing.T) {
+		backend, _ := setupBleveBackend(t, withRootDir(t.TempDir()))
+		idx, _, _, err := backend.tryReuseFileIndex(newIndexOnDisk(t, []byte("{not json")), time.Time{}, logger)
+		require.NoError(t, err)
+		require.Nil(t, idx)
+	})
+}
+
+// Stands in for an index written by a newer binary.
+func newIndexDeclaringRequirements(t *testing.T, requirements ...resource.IndexFeature) bleve.Index {
+	t.Helper()
+	idx, err := newBleveIndex("", bleve.NewIndexMapping(), time.Now(), buildVersion, nil, "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = idx.Close() })
+	require.NoError(t, setRV(idx, 42))
+
+	bi, err := getBuildInfo(idx)
+	require.NoError(t, err)
+	bi.ReaderRequirements = requirements
+	raw, err := json.Marshal(bi)
+	require.NoError(t, err)
+	require.NoError(t, idx.SetInternal([]byte(internalBuildInfoKey), raw))
+	return idx
+}
+
+// Backstops selection, which can only check snapshots whose manifest carries the
+// requirements.
+func TestValidateDownloadedIndexChecksReaderRequirements(t *testing.T) {
+	backend, _ := setupBleveBackend(t, withRootDir(t.TempDir()))
+
+	t.Run("rejected for a requirement this binary does not know", func(t *testing.T) {
+		_, err := backend.validateDownloadedIndex(newIndexDeclaringRequirements(t, "feature-from-the-future"))
+		require.ErrorContains(t, err, "does not understand [feature-from-the-future]")
+	})
+
+	t.Run("accepted when every requirement is understood", func(t *testing.T) {
+		rv, err := backend.validateDownloadedIndex(newIndexDeclaringRequirements(t, resource.IndexFeatureDeletedMarker))
+		require.NoError(t, err)
+		require.Equal(t, int64(42), rv)
+	})
+
+	t.Run("accepted when none are declared", func(t *testing.T) {
+		rv, err := backend.validateDownloadedIndex(newIndexDeclaringRequirements(t))
+		require.NoError(t, err)
+		require.Equal(t, int64(42), rv)
+	})
+}
 func TestMemoryBleveIndexCanBeCopiedToFilesystem(t *testing.T) {
 	mapper, err := GetBleveMappings(nil, "", "", nil)
 	require.NoError(t, err)

--- a/pkg/storage/unified/search/remote_index_store.go
+++ b/pkg/storage/unified/search/remote_index_store.go
@@ -90,6 +90,10 @@ type IndexMeta struct {
 	// IndexFormat identifies the Bleve segment format that wrote this snapshot
 	// (for example, "zap/16"). Empty on legacy snapshots means "unknown, assume compatible".
 	IndexFormat string `json:"index_format,omitempty"`
+	// ReaderRequirements are the features an instance must understand before using
+	// this snapshot. Selection skips a snapshot declaring one it does not recognise.
+	// Empty on snapshots uploaded before this field existed.
+	ReaderRequirements []resource.IndexFeature `json:"reader_requirements,omitempty"`
 	// LatestResourceVersion is the latest resource version included in the index.
 	LatestResourceVersion int64 `json:"latest_resource_version"`
 	// DocCount is the number of documents in the index at upload time. Recorded


### PR DESCRIPTION
An index records which features it was built with, and an instance checks that an index has the features it needs. That protects a new instance from an old index, but not the reverse — an instance can't require a feature whose name it has never heard of. Snapshot selection takes a newer snapshot as a last resort, so this is reachable.

Indexes and snapshots now also record which features a reader must understand, and an instance refuses any naming a feature it doesn't recognise — which is what lets it protect itself against a feature added after it shipped. The check runs during snapshot selection, so an unusable candidate is skipped in favour of an older readable snapshot instead of a rebuild, and again after download and on local index reuse. An index whose build metadata can't be read is now discarded too.

No feature is declared as a requirement yet. Whether an index holds documents a reader could misread depends on what was written to it, not on its mapping: deleted documents are only kept when a config option says so, and that decision isn't recorded. Declaring a requirement from the mapping would make older instances refuse indexes that were safe for them.

What ships here is the check itself. It protects nothing retroactively, since instances without it ignore the declaration — so a feature that changes what an index holds can only be enabled by default once this has been released for longer than the version compatibility window. That rule is recorded next to the feature list.

Also corrects the `IndexFeature` doc: it claimed a feature is only for changes no declared search field describes, but trash fields and stored facets are both declared and neither is captured by the search fields hash.

Part of https://github.com/grafana/search-and-storage-team/issues/895
