### PR TITLE
SQLite: Enable WAL by default where the filesystem supports it

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -275,8 +275,11 @@ path = grafana.db
 # For "sqlite3" only. cache mode setting used for connecting to the database
 cache_mode = private
 
-# For "sqlite3" only. Enable/disable Write-Ahead Logging, https://sqlite.org/wal.html. Default is false.
-wal = false
+# For "sqlite3" only. Enable/disable Write-Ahead Logging, https://sqlite.org/wal.html. Default is auto.
+# WAL requires all processes using the database to share a small amount of memory, so it does not
+# work over a network filesystem such as NFS, EFS or SMB. With "auto", Grafana enables WAL only
+# where the database is on storage local to this host.
+wal = auto
 
 # For "mysql" and "postgres". Lock the database for the migrations, default is true.
 migration_locking = true

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -188,8 +188,11 @@
 # For "sqlite3" only. cache mode setting used for connecting to the database. (private, shared)
 ;cache_mode = private
 
-# For "sqlite3" only. Enable/disable Write-Ahead Logging, https://sqlite.org/wal.html. Default is false.
-;wal = false
+# For "sqlite3" only. Enable/disable Write-Ahead Logging, https://sqlite.org/wal.html. Default is auto.
+# WAL requires all processes using the database to share a small amount of memory, so it does not
+# work over a network filesystem such as NFS, EFS or SMB. With "auto", Grafana enables WAL only
+# where the database is on storage local to this host.
+;wal = auto
 
 # For "mysql" and "postgres" only. Lock the database for the migrations, default is true.
 ;migration_locking = true

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -483,7 +483,7 @@ Supported values:
 - **`true`**: Grafana always enables WAL. Use this when you know the database file is on storage that only one Grafana instance uses, even if Grafana doesn't recognize the filesystem.
 - **`false`**: Grafana disables WAL. This also reverts a database that already uses WAL, because SQLite stores the journal mode in the database file.
 
-Grafana detects the storage on Linux and Windows. On other operating systems, `auto` assumes local storage and enables WAL.
+Grafana detects the storage on Linux, macOS and Windows. On other operating systems, `auto` leaves WAL off, so set `wal` to `true` if you know the database is on local storage.
 
 #### `query_retries`
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -473,7 +473,17 @@ Defaults to `private`.
 
 #### `wal`
 
-For "sqlite3" only. Setting to enable/disable [Write-Ahead Logging](https://sqlite.org/wal.html). The default value is `false` (disabled).
+For "sqlite3" only. Controls [Write-Ahead Logging](https://sqlite.org/wal.html) (WAL). The default value is `auto`.
+
+As the SQLite documentation puts it, all processes using a database must be on the same host computer, and WAL doesn't work over a network filesystem, because WAL requires all processes to share a small amount of memory and processes on separate host machines can't share memory with each other. Enabling WAL on a network mount such as NFS, Amazon EFS or SMB can stop Grafana from starting or corrupt the database.
+
+Supported values:
+
+- **`auto`**: Grafana enables WAL only when the database file is on storage local to the host. When Grafana doesn't enable WAL, it logs the storage it detected and reverts a database that already uses WAL.
+- **`true`**: Grafana always enables WAL. Use this when you know the database file is on storage that only one Grafana instance uses, even if Grafana doesn't recognize the filesystem.
+- **`false`**: Grafana disables WAL. This also reverts a database that already uses WAL, because SQLite stores the journal mode in the database file.
+
+Grafana detects the storage on Linux and Windows. On other operating systems, `auto` assumes local storage and enables WAL.
 
 #### `query_retries`
 

--- a/go.mod
+++ b/go.mod
@@ -675,7 +675,7 @@ require (
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/exp v0.0.0-20260709172345-9ea1abe57597 // indirect
 	golang.org/x/mod v0.38.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
+	golang.org/x/sys v0.47.0
 	golang.org/x/telemetry v0.0.0-20260708182218-49f421fb7959 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/tools v0.48.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -206,6 +206,7 @@ require (
 	golang.org/x/net v0.57.0 // @grafana/data-sources-plugins
 	golang.org/x/oauth2 v0.36.0 // @grafana/identity-access-team
 	golang.org/x/sync v0.22.0 // @grafana/alerting-backend
+	golang.org/x/sys v0.47.0 // @grafana/grafana-search-and-storage
 	golang.org/x/text v0.40.0 // @grafana/grafana-backend-group
 	golang.org/x/time v0.15.0 // @grafana/grafana-backend-group
 	gonum.org/v1/gonum v0.17.0 // @grafana/data-sources-plugins
@@ -675,7 +676,6 @@ require (
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/exp v0.0.0-20260709172345-9ea1abe57597 // indirect
 	golang.org/x/mod v0.38.0 // indirect
-	golang.org/x/sys v0.47.0
 	golang.org/x/telemetry v0.0.0-20260708182218-49f421fb7959 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/tools v0.48.0 // indirect

--- a/pkg/services/sqlstore/database_config.go
+++ b/pkg/services/sqlstore/database_config.go
@@ -119,18 +119,16 @@ func (dbCfg *DatabaseConfig) readConfig(cfg *setting.Cfg) error {
 
 	dbCfg.CacheMode = sec.Key("cache_mode").MustString("private")
 	// auto needs the resolved database path, so it is decided in buildConnectionString.
-	walRaw := strings.TrimSpace(sec.Key("wal").String())
-	switch {
-	case walRaw == "" || strings.EqualFold(walRaw, walAutoValue):
-		dbCfg.wal = walAuto
-	default:
+	dbCfg.wal = walAuto
+	if walRaw := strings.TrimSpace(sec.Key("wal").String()); walRaw != "" && !strings.EqualFold(walRaw, walAutoValue) {
 		enabled, err := sec.Key("wal").Bool()
-		if err != nil {
-			return fmt.Errorf("invalid value %q for [database] wal, expected auto, true or false", walRaw)
-		}
-		dbCfg.wal = walOff
-		if enabled {
+		switch {
+		case err != nil:
+			walLogger.Warn("Ignoring invalid value for [database] wal, expected auto, true or false", "value", walRaw)
+		case enabled:
 			dbCfg.wal = walOn
+		default:
+			dbCfg.wal = walOff
 		}
 	}
 

--- a/pkg/services/sqlstore/database_config.go
+++ b/pkg/services/sqlstore/database_config.go
@@ -37,6 +37,7 @@ type DatabaseConfig struct {
 	ConnMaxLifetime             int
 	CacheMode                   string
 	WALEnabled                  bool
+	wal                         walSetting
 	UrlQueryParams              map[string][]string
 	SkipMigrations              bool
 	EnsureDefaultOrgAndUser     bool
@@ -117,7 +118,22 @@ func (dbCfg *DatabaseConfig) readConfig(cfg *setting.Cfg) error {
 	dbCfg.IsolationLevel = sec.Key("isolation_level").String()
 
 	dbCfg.CacheMode = sec.Key("cache_mode").MustString("private")
-	dbCfg.WALEnabled = sec.Key("wal").MustBool(false)
+	// auto needs the resolved database path, so it is decided in buildConnectionString.
+	walRaw := strings.TrimSpace(sec.Key("wal").String())
+	switch {
+	case walRaw == "" || strings.EqualFold(walRaw, walAutoValue):
+		dbCfg.wal = walAuto
+	default:
+		enabled, err := sec.Key("wal").Bool()
+		if err != nil {
+			return fmt.Errorf("invalid value %q for [database] wal, expected auto, true or false", walRaw)
+		}
+		dbCfg.wal = walOff
+		if enabled {
+			dbCfg.wal = walOn
+		}
+	}
+
 	dbCfg.SkipMigrations = sec.Key("skip_migrations").MustBool()
 	dbCfg.EnsureDefaultOrgAndUser = sec.Key("ensure_default_org_and_user").MustBool(true)
 	dbCfg.MigrationLock = sec.Key("migration_locking").MustBool(true)
@@ -202,8 +218,15 @@ func (dbCfg *DatabaseConfig) buildConnectionString(cfg *setting.Cfg, features fe
 
 		cnnstr = fmt.Sprintf("file:%s?cache=%s&mode=rwc", dbCfg.Path, dbCfg.CacheMode)
 
+		fsName, fsSupportsWAL := filesystemSupportsWAL(walFilesystemPath(dbCfg.Path))
+		dbCfg.WALEnabled = resolveWAL(dbCfg.wal, fsName, fsSupportsWAL)
+
+		// SQLite stores the journal mode in the database file, so a database converted to
+		// WAL earlier stays in WAL unless we set it back.
 		if dbCfg.WALEnabled {
 			cnnstr += "&_journal_mode=WAL"
+		} else {
+			cnnstr += "&_journal_mode=DELETE"
 		}
 
 		cnnstr += buildExtraConnectionString('&', dbCfg.UrlQueryParams)

--- a/pkg/services/sqlstore/database_config_test.go
+++ b/pkg/services/sqlstore/database_config_test.go
@@ -3,6 +3,7 @@ package sqlstore
 import (
 	"errors"
 	"net/url"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -211,6 +212,76 @@ func TestBuildConnectionStringPostgres(t *testing.T) {
 			err := tc.dbCfg.buildConnectionString(&setting.Cfg{}, nil)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedConnStr, tc.dbCfg.ConnectionString)
+		})
+	}
+}
+
+func TestReadConfigWAL(t *testing.T) {
+	testCases := []struct {
+		value    string
+		expected walSetting
+		expErr   bool
+	}{
+		{value: "auto", expected: walAuto},
+		{value: "AUTO", expected: walAuto},
+		{value: "", expected: walAuto},
+		{value: "true", expected: walOn},
+		{value: "1", expected: walOn},
+		{value: "on", expected: walOn},
+		{value: "yes", expected: walOn},
+		{value: "false", expected: walOff},
+		{value: "0", expected: walOff},
+		{value: "off", expected: walOff},
+		{value: "no", expected: walOff},
+		{value: "sometimes", expErr: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run("wal = "+tc.value, func(t *testing.T) {
+			// nolint:staticcheck
+			cfg := setting.NewCfgWithFeatures(featuremgmt.WithFeatures().IsEnabledGlobally)
+			sec, err := cfg.Raw.NewSection("database")
+			require.NoError(t, err)
+			_, err = sec.NewKey("type", migrator.SQLite)
+			require.NoError(t, err)
+			_, err = sec.NewKey("wal", tc.value)
+			require.NoError(t, err)
+
+			dbCfg := &DatabaseConfig{}
+			err = dbCfg.readConfig(cfg)
+			if tc.expErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, dbCfg.wal)
+		})
+	}
+}
+
+func TestBuildConnectionStringSQLiteJournalMode(t *testing.T) {
+	testCases := []struct {
+		name        string
+		wal         walSetting
+		expJournal  string
+		expWALValue bool
+	}{
+		{name: "WAL enabled", wal: walOn, expJournal: "_journal_mode=WAL", expWALValue: true},
+		{name: "WAL disabled reverts a converted database", wal: walOff, expJournal: "_journal_mode=DELETE", expWALValue: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dbCfg := &DatabaseConfig{
+				Type:      migrator.SQLite,
+				Path:      filepath.Join(t.TempDir(), "grafana.db"),
+				CacheMode: "private",
+				wal:       tc.wal,
+			}
+
+			require.NoError(t, dbCfg.buildConnectionString(&setting.Cfg{}, nil))
+			assert.Contains(t, dbCfg.ConnectionString, tc.expJournal)
+			assert.Equal(t, tc.expWALValue, dbCfg.WALEnabled)
 		})
 	}
 }

--- a/pkg/services/sqlstore/database_config_test.go
+++ b/pkg/services/sqlstore/database_config_test.go
@@ -220,7 +220,6 @@ func TestReadConfigWAL(t *testing.T) {
 	testCases := []struct {
 		value    string
 		expected walSetting
-		expErr   bool
 	}{
 		{value: "auto", expected: walAuto},
 		{value: "AUTO", expected: walAuto},
@@ -233,7 +232,7 @@ func TestReadConfigWAL(t *testing.T) {
 		{value: "0", expected: walOff},
 		{value: "off", expected: walOff},
 		{value: "no", expected: walOff},
-		{value: "sometimes", expErr: true},
+		{value: "sometimes", expected: walAuto},
 	}
 
 	for _, tc := range testCases {
@@ -248,13 +247,8 @@ func TestReadConfigWAL(t *testing.T) {
 			require.NoError(t, err)
 
 			dbCfg := &DatabaseConfig{}
-			err = dbCfg.readConfig(cfg)
-			if tc.expErr {
-				require.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
-			assert.Equal(t, tc.expected, dbCfg.wal)
+			require.NoError(t, dbCfg.readConfig(cfg))
+			assert.Equal(t, tc.expected, dbCfg.wal, "an unusable value falls back to auto rather than failing startup")
 		})
 	}
 }

--- a/pkg/services/sqlstore/wal.go
+++ b/pkg/services/sqlstore/wal.go
@@ -57,8 +57,7 @@ func resolveWAL(setting walSetting, fsName string, fsSupportsWAL bool) bool {
 		return true
 	default:
 		if !fsSupportsWAL {
-			walLogger.Warn("Not enabling SQLite WAL mode because the filesystem holding the database may not support it. "+
-				"Set [database] wal = true to enable it anyway",
+			walLogger.Warn("Not enabling SQLite WAL mode because the filesystem holding the database may not support it",
 				"filesystem", fsName)
 			return false
 		}

--- a/pkg/services/sqlstore/wal.go
+++ b/pkg/services/sqlstore/wal.go
@@ -1,0 +1,68 @@
+package sqlstore
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+)
+
+// walSetting is the parsed form of the [database] wal option.
+type walSetting int
+
+const (
+	// walAuto turns WAL on only where the filesystem is known to support it.
+	walAuto walSetting = iota
+	walOn
+	walOff
+)
+
+const walAutoValue = "auto"
+
+var walLogger = log.New("sqlstore.wal")
+
+// walFilesystemPath returns the path whose filesystem decides whether WAL is used.
+func walFilesystemPath(dbPath string) string {
+	// An existing database is inspected directly, and statfs follows symlinks.
+	if _, err := os.Stat(dbPath); err == nil {
+		return dbPath
+	}
+
+	// A database that does not exist yet can still be a link to storage elsewhere,
+	// which is where SQLite will create it.
+	if target, err := os.Readlink(dbPath); err == nil {
+		if !filepath.IsAbs(target) {
+			target = filepath.Join(filepath.Dir(dbPath), target)
+		}
+		return filepath.Dir(target)
+	}
+
+	return filepath.Dir(dbPath)
+}
+
+// resolveWAL decides whether SQLite runs in WAL mode.
+//
+// WAL requires all processes using the database to share a small amount of memory, so
+// it does not work over a network filesystem. We cannot ask a path whether it can
+// provide that, so auto only turns WAL on where it is known to hold.
+func resolveWAL(setting walSetting, fsName string, fsSupportsWAL bool) bool {
+	switch setting {
+	case walOff:
+		return false
+	case walOn:
+		if !fsSupportsWAL {
+			walLogger.Warn("SQLite WAL mode is enabled on a filesystem where it may fail or corrupt the database",
+				"filesystem", fsName)
+		}
+		return true
+	default:
+		if !fsSupportsWAL {
+			walLogger.Warn("Not enabling SQLite WAL mode because the filesystem holding the database may not support it. "+
+				"Set [database] wal = true to enable it anyway",
+				"filesystem", fsName)
+			return false
+		}
+		walLogger.Debug("Enabling SQLite WAL mode", "filesystem", fsName)
+		return true
+	}
+}

--- a/pkg/services/sqlstore/wal_bsd.go
+++ b/pkg/services/sqlstore/wal_bsd.go
@@ -1,0 +1,28 @@
+//go:build darwin || freebsd
+
+package sqlstore
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// Filesystems local to this host, which is what WAL's shared memory needs. statfs
+// names them, so network mounts report nfs or smbfs and are left out.
+var walFilesystems = map[string]bool{
+	"apfs":  true,
+	"hfs":   true,
+	"ufs":   true,
+	"zfs":   true,
+	"tmpfs": true,
+}
+
+func filesystemSupportsWAL(path string) (string, bool) {
+	// Statfs follows symlinks, so this reports the filesystem holding the target.
+	var stat unix.Statfs_t
+	if err := unix.Statfs(path, &stat); err != nil {
+		return "unknown", false
+	}
+
+	name := unix.ByteSliceToString(stat.Fstypename[:])
+	return name, walFilesystems[name]
+}

--- a/pkg/services/sqlstore/wal_linux.go
+++ b/pkg/services/sqlstore/wal_linux.go
@@ -1,0 +1,57 @@
+package sqlstore
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+// x/sys has no constant for ZFS.
+const zfsSuperMagic = 0x2fc12fc1
+
+// Filesystems local to this host, which is what WAL's shared memory needs. The key is
+// uint32 because statfs reports the type as a signed 32 bit integer on 32 bit
+// architectures, where magics above 0x7fffffff would read as negative.
+var walFilesystems = map[uint32]string{
+	unix.EXT4_SUPER_MAGIC:  "ext2/3/4",
+	unix.XFS_SUPER_MAGIC:   "xfs",
+	unix.BTRFS_SUPER_MAGIC: "btrfs",
+	unix.F2FS_SUPER_MAGIC:  "f2fs",
+	unix.TMPFS_MAGIC:       "tmpfs",
+	// Safe because the database is created in the writable upper layer.
+	unix.OVERLAYFS_SUPER_MAGIC: "overlayfs",
+	zfsSuperMagic:              "zfs",
+}
+
+func filesystemSupportsWAL(path string) (string, bool) {
+	// Statfs follows symlinks, so this reports the filesystem holding the target.
+	var stat unix.Statfs_t
+	if err := unix.Statfs(path, &stat); err != nil {
+		return "unknown", false
+	}
+
+	return walFilesystem(uint32(stat.Type))
+}
+
+// Named only so the log line says which filesystem was detected rather than a magic
+// number. WAL stays off on all of them.
+var namedFilesystems = map[uint32]string{
+	unix.NFS_SUPER_MAGIC:  "nfs",
+	unix.CIFS_SUPER_MAGIC: "cifs",
+	unix.SMB_SUPER_MAGIC:  "smb",
+	unix.SMB2_SUPER_MAGIC: "smb2",
+	unix.FUSE_SUPER_MAGIC: "fuse",
+	unix.CEPH_SUPER_MAGIC: "ceph",
+}
+
+func walFilesystem(fsType uint32) (string, bool) {
+	if name, ok := walFilesystems[fsType]; ok {
+		return name, true
+	}
+
+	if name, ok := namedFilesystems[fsType]; ok {
+		return name, false
+	}
+
+	return fmt.Sprintf("0x%x", fsType), false
+}

--- a/pkg/services/sqlstore/wal_linux_test.go
+++ b/pkg/services/sqlstore/wal_linux_test.go
@@ -1,0 +1,49 @@
+package sqlstore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
+)
+
+func TestWALFilesystem(t *testing.T) {
+	tests := []struct {
+		fsType    uint32
+		name      string
+		supported bool
+	}{
+		{fsType: unix.EXT4_SUPER_MAGIC, name: "ext2/3/4", supported: true},
+		{fsType: unix.TMPFS_MAGIC, name: "tmpfs", supported: true},
+		{fsType: unix.OVERLAYFS_SUPER_MAGIC, name: "overlayfs", supported: true},
+		{fsType: unix.BTRFS_SUPER_MAGIC, name: "btrfs", supported: true},
+		{fsType: zfsSuperMagic, name: "zfs", supported: true},
+		{fsType: unix.NFS_SUPER_MAGIC, name: "nfs", supported: false},
+		{fsType: unix.CIFS_SUPER_MAGIC, name: "cifs", supported: false},
+		{fsType: unix.SMB2_SUPER_MAGIC, name: "smb2", supported: false},
+		{fsType: unix.FUSE_SUPER_MAGIC, name: "fuse", supported: false},
+		{fsType: unix.CEPH_SUPER_MAGIC, name: "ceph", supported: false},
+		{fsType: 0xdeadbeef, name: "0xdeadbeef", supported: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			name, supported := walFilesystem(tc.fsType)
+			assert.Equal(t, tc.name, name)
+			assert.Equal(t, tc.supported, supported)
+		})
+	}
+}
+
+func TestFilesystemSupportsWALProcfs(t *testing.T) {
+	// procfs stands in for any filesystem missing from the allow list.
+	name, supported := filesystemSupportsWAL("/proc")
+	assert.False(t, supported)
+	assert.Equal(t, "0x9fa0", name)
+}
+
+func TestFilesystemSupportsWALMissingPath(t *testing.T) {
+	name, supported := filesystemSupportsWAL("/does/not/exist")
+	assert.False(t, supported)
+	assert.Equal(t, "unknown", name)
+}

--- a/pkg/services/sqlstore/wal_other.go
+++ b/pkg/services/sqlstore/wal_other.go
@@ -1,0 +1,9 @@
+//go:build !linux && !windows
+
+package sqlstore
+
+// Assume local storage: the remaining platforms are almost always developer machines
+// with the database on a local disk.
+func filesystemSupportsWAL(_ string) (string, bool) {
+	return "unknown", true
+}

--- a/pkg/services/sqlstore/wal_other.go
+++ b/pkg/services/sqlstore/wal_other.go
@@ -1,9 +1,9 @@
-//go:build !linux && !windows
+//go:build !linux && !windows && !darwin && !freebsd
 
 package sqlstore
 
-// Assume local storage: the remaining platforms are almost always developer machines
-// with the database on a local disk.
+// Without a way to tell local storage from a network mount, leave WAL off unless the
+// operator asks for it.
 func filesystemSupportsWAL(_ string) (string, bool) {
-	return "unknown", true
+	return "unknown", false
 }

--- a/pkg/services/sqlstore/wal_test.go
+++ b/pkg/services/sqlstore/wal_test.go
@@ -66,7 +66,6 @@ func TestWALFilesystemPath(t *testing.T) {
 
 		assert.Equal(t, filepath.Join(dir, "elsewhere"), walFilesystemPath(link))
 	})
-
 }
 
 func TestFilesystemSupportsWAL(t *testing.T) {

--- a/pkg/services/sqlstore/wal_test.go
+++ b/pkg/services/sqlstore/wal_test.go
@@ -1,0 +1,117 @@
+package sqlstore
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func TestResolveWAL(t *testing.T) {
+	tests := []struct {
+		name          string
+		setting       walSetting
+		fsSupportsWAL bool
+		expected      bool
+	}{
+		{name: "auto enables WAL on a supported filesystem", setting: walAuto, fsSupportsWAL: true, expected: true},
+		{name: "auto leaves WAL off on an unsupported filesystem", setting: walAuto, fsSupportsWAL: false, expected: false},
+		{name: "true enables WAL on a supported filesystem", setting: walOn, fsSupportsWAL: true, expected: true},
+		{name: "true enables WAL even on an unsupported filesystem", setting: walOn, fsSupportsWAL: false, expected: true},
+		{name: "false leaves WAL off on a supported filesystem", setting: walOff, fsSupportsWAL: true, expected: false},
+		{name: "false leaves WAL off on an unsupported filesystem", setting: walOff, fsSupportsWAL: false, expected: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, resolveWAL(tc.setting, "testfs", tc.fsSupportsWAL))
+		})
+	}
+}
+
+func TestWALFilesystemPath(t *testing.T) {
+	t.Run("a database that does not exist yet is judged by its directory", func(t *testing.T) {
+		dir := t.TempDir()
+		assert.Equal(t, dir, walFilesystemPath(filepath.Join(dir, "grafana.db")))
+	})
+
+	t.Run("an existing database is inspected directly", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "grafana.db")
+		require.NoError(t, os.WriteFile(path, nil, 0o600))
+		assert.Equal(t, path, walFilesystemPath(path))
+	})
+
+	t.Run("a symlink to a database that does not exist yet is judged by its target", func(t *testing.T) {
+		dir := t.TempDir()
+		target := filepath.Join(dir, "elsewhere", "grafana.db")
+		require.NoError(t, os.MkdirAll(filepath.Dir(target), 0o750))
+		link := filepath.Join(dir, "grafana.db")
+		require.NoError(t, os.Symlink(target, link))
+
+		assert.Equal(t, filepath.Dir(target), walFilesystemPath(link))
+	})
+
+	t.Run("relative symlinks resolve against the link directory", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "elsewhere"), 0o750))
+		link := filepath.Join(dir, "grafana.db")
+		require.NoError(t, os.Symlink(filepath.Join("elsewhere", "grafana.db"), link))
+
+		assert.Equal(t, filepath.Join(dir, "elsewhere"), walFilesystemPath(link))
+	})
+
+}
+
+func TestFilesystemSupportsWAL(t *testing.T) {
+	// The result depends on the filesystem the tests run on, so only check that the
+	// filesystem is always named, since the name ends up in a log line.
+	name, _ := filesystemSupportsWAL(t.TempDir())
+	assert.NotEmpty(t, name)
+}
+
+// A database converted to WAL keeps that mode in its file, so it has to be reverted
+// when it ends up somewhere WAL does not work, for example after a move to a network
+// mount.
+func TestWALDatabaseIsRevertedWhenWALIsOff(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "grafana.db")
+
+	walCfg := &DatabaseConfig{Type: migrator.SQLite, Path: path, CacheMode: "private", wal: walOn}
+	require.NoError(t, walCfg.buildConnectionString(&setting.Cfg{}, nil))
+
+	walDB, err := sql.Open("sqlite3", walCfg.ConnectionString)
+	require.NoError(t, err)
+	_, err = walDB.Exec("CREATE TABLE t (a int)")
+	require.NoError(t, err)
+	_, err = walDB.Exec("INSERT INTO t VALUES (42)")
+	require.NoError(t, err)
+	require.Equal(t, "wal", journalMode(t, walDB))
+	require.NoError(t, walDB.Close())
+
+	offCfg := &DatabaseConfig{Type: migrator.SQLite, Path: path, CacheMode: "private", wal: walOff}
+	require.NoError(t, offCfg.buildConnectionString(&setting.Cfg{}, nil))
+
+	offDB, err := sql.Open("sqlite3", offCfg.ConnectionString)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, offDB.Close()) }()
+
+	assert.Equal(t, "delete", journalMode(t, offDB))
+
+	var value int
+	require.NoError(t, offDB.QueryRow("SELECT a FROM t").Scan(&value))
+	assert.Equal(t, 42, value, "reverting the journal mode keeps the data")
+}
+
+func journalMode(t *testing.T, db *sql.DB) string {
+	t.Helper()
+
+	var mode string
+	require.NoError(t, db.QueryRow("PRAGMA journal_mode").Scan(&mode))
+	return mode
+}

--- a/pkg/services/sqlstore/wal_windows.go
+++ b/pkg/services/sqlstore/wal_windows.go
@@ -1,0 +1,59 @@
+package sqlstore
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"golang.org/x/sys/windows"
+)
+
+var driveTypeNames = map[uint32]string{
+	windows.DRIVE_UNKNOWN:     "unknown drive",
+	windows.DRIVE_NO_ROOT_DIR: "invalid drive",
+	windows.DRIVE_REMOVABLE:   "removable drive",
+	windows.DRIVE_FIXED:       "fixed drive",
+	windows.DRIVE_REMOTE:      "network drive",
+	windows.DRIVE_CDROM:       "CD-ROM drive",
+	windows.DRIVE_RAMDISK:     "RAM disk",
+}
+
+// Drives local to this computer, which is what WAL's shared memory needs. Mapped
+// network drives and UNC paths report DRIVE_REMOTE and are left out.
+var walDriveTypes = map[uint32]bool{
+	windows.DRIVE_FIXED:   true,
+	windows.DRIVE_RAMDISK: true,
+}
+
+func filesystemSupportsWAL(path string) (string, bool) {
+	driveType, err := driveTypeOf(path)
+	if err != nil {
+		return "unknown", false
+	}
+
+	name, ok := driveTypeNames[driveType]
+	if !ok {
+		name = fmt.Sprintf("drive type %d", driveType)
+	}
+
+	return name, walDriveTypes[driveType]
+}
+
+func driveTypeOf(name string) (uint32, error) {
+	abs, err := filepath.Abs(name)
+	if err != nil {
+		return 0, err
+	}
+
+	path, err := windows.UTF16PtrFromString(abs)
+	if err != nil {
+		return 0, err
+	}
+
+	// GetDriveType needs the root of the volume, not the directory itself.
+	root := make([]uint16, windows.MAX_PATH+1)
+	if err := windows.GetVolumePathName(path, &root[0], uint32(len(root))); err != nil {
+		return 0, err
+	}
+
+	return windows.GetDriveType(&root[0]), nil
+}


### PR DESCRIPTION

Write-Ahead Logging reduces "database is locked" errors. It has not been the default because WAL requires all processes using the database to share a small amount of memory, so it does not work over a network filesystem such as NFS, Amazon EFS or SMB, where enabling it can break Grafana or corrupt the database.

The `wal` setting now takes a third value, which becomes the default:

- `auto` (new default): enable WAL only when the database is on storage local to the host, otherwise leave it off and log a warning naming the detected filesystem. Detection uses `statfs` on Linux and macOS and the drive type on Windows; other platforms leave WAL off.
- `true`: always enable WAL, warning if the storage is not recognised.
- `false`: disable WAL, and revert a database converted to WAL earlier.

The last point is a fix on its own: SQLite records the journal mode in the database file, so `wal = false` previously left a converted database in WAL, which is why several people on the issue reported that reverting the setting did not help.

Detection uses a list of known-good local filesystems rather than a list of risky ones, because a missing entry then only costs an installation today's behaviour instead of breaking an upgrade.

Existing values keep working, `1`, `0`, `on`, `off`, `yes`, `no` and `GF_DATABASE_WAL` included.

## Does it help?

Measured with the connection strings this PR produces, on the modernc driver, using the pool settings from `defaults.ini` (`busy_timeout` 7500 ms, `max_idle_conn = 2`, unlimited open connections). Readers do single-row `SELECT`s, writers commit one-row `UPDATE` transactions, three seconds per configuration.

```
mode     readers  writers    reads/s   writes/s     read p99    write p99
DELETE         4        1       1110       1979      33.309ms      1.368ms
WAL            4        1     144725      15649         366us        191us
DELETE        16        1       3303       3223     103.554ms      1.444ms
WAL           16        1     100120       9999       2.739ms        906us
DELETE        64        1       3887       1858     528.901ms      1.476ms
WAL           64        1     129668       3192       6.849ms      3.193ms
DELETE         0        8          -       2455             -      2.511ms
WAL            0        8          -      14636             -         61us
```

Reads are 30 to 100 times faster and read p99 falls from hundreds of milliseconds to single digits, because readers no longer wait behind the writer's exclusive lock. Writes are 2 to 6 times faster, since a WAL commit appends to one file instead of creating and deleting a journal per transaction.

Note what did not happen: no `database is locked` errors in either mode. The busy timeout is already 7500 ms, so contention shows up as latency rather than errors, and the reports on #65115 are the tail of that same distribution, when a wait outlasts the timeout or a caller cannot wait. WAL removes the waiting; the errors are a symptom of it.

Numbers are from macOS 26.5 on arm64 with a local SSD, a single process and a two-column table, so the ratios are indicative rather than absolute.

## What this does not fix

- Writes stay serialised. One writer at a time, WAL or not. The last two rows above show the ceiling moving, not disappearing, so an instance that needs concurrent writers still wants Postgres or MySQL.
- Backups change. WAL adds `-wal` and `-shm` files, and recent commits can sit in the `-wal` file until a checkpoint, so copying `grafana.db` on its own can miss data that was already committed. File-level backups of a running instance need every file, or `VACUUM INTO`.
- It stays unsafe on shared storage, which is why the default is `auto` rather than `true`.

<details>
<summary>Benchmark harness</summary>

Drop this in `pkg/services/sqlstore` and run `go test ./pkg/services/sqlstore/ -run TestWALBenchmark -v`.

```go
package sqlstore

import (
	"database/sql"
	"fmt"
	"math/rand"
	"path/filepath"
	"sort"
	"sync"
	"sync/atomic"
	"testing"
	"time"

	"github.com/stretchr/testify/require"

	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
	"github.com/grafana/grafana/pkg/setting"
	"github.com/grafana/grafana/pkg/util/sqlite"
)

const (
	benchDuration = 3 * time.Second
	benchRows     = 1000
)

type benchResult struct {
	mode      string
	readers   int
	writers   int
	reads     int64
	writes    int64
	readErrs  int64
	writeErrs int64
	readP99   time.Duration
	writeP99  time.Duration
}

func openBenchDB(t *testing.T, wal walSetting) *sql.DB {
	t.Helper()

	cfg := &DatabaseConfig{
		Type:      migrator.SQLite,
		Path:      filepath.Join(t.TempDir(), "grafana.db"),
		CacheMode: "private",
		wal:       wal,
	}
	require.NoError(t, cfg.buildConnectionString(&setting.Cfg{}, nil))

	db, err := sql.Open("sqlite3", cfg.ConnectionString)
	require.NoError(t, err)

	// Same pool shape as Grafana's defaults: unlimited open connections, 2 idle.
	db.SetMaxOpenConns(0)
	db.SetMaxIdleConns(2)

	_, err = db.Exec("CREATE TABLE bench (id INTEGER PRIMARY KEY, value INTEGER NOT NULL)")
	require.NoError(t, err)
	for i := range benchRows {
		_, err = db.Exec("INSERT INTO bench (id, value) VALUES (?, ?)", i, i)
		require.NoError(t, err)
	}

	var mode string
	require.NoError(t, db.QueryRow("PRAGMA journal_mode").Scan(&mode))
	t.Logf("journal_mode=%s", mode)

	return db
}

func percentile(all []time.Duration, p float64) time.Duration {
	if len(all) == 0 {
		return 0
	}
	sort.Slice(all, func(i, j int) bool { return all[i] < all[j] })
	idx := int(float64(len(all)) * p)
	if idx >= len(all) {
		idx = len(all) - 1
	}
	return all[idx]
}

func runBench(t *testing.T, wal walSetting, mode string, readers, writers int) benchResult {
	t.Helper()

	db := openBenchDB(t, wal)
	defer db.Close()

	res := benchResult{mode: mode, readers: readers, writers: writers}
	deadline := time.Now().Add(benchDuration)

	var (
		mu         sync.Mutex
		readTimes  []time.Duration
		writeTimes []time.Duration
		wg         sync.WaitGroup
	)

	for range readers {
		wg.Go(func() {
			rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
			var local []time.Duration
			for time.Now().Before(deadline) {
				start := time.Now()
				var value int
				err := db.QueryRow("SELECT value FROM bench WHERE id = ?", rnd.Intn(benchRows)).Scan(&value)
				local = append(local, time.Since(start))
				if err != nil {
					atomic.AddInt64(&res.readErrs, 1)
					if !sqlite.IsBusyOrLocked(err) {
						t.Errorf("unexpected read error: %v", err)
						return
					}
					continue
				}
				atomic.AddInt64(&res.reads, 1)
			}
			mu.Lock()
			readTimes = append(readTimes, local...)
			mu.Unlock()
		})
	}

	// Writers commit small transactions, as Grafana's background jobs do.
	for range writers {
		wg.Go(func() {
			rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
			var local []time.Duration
			for time.Now().Before(deadline) {
				start := time.Now()
				err := func() error {
					tx, err := db.Begin()
					if err != nil {
						return err
					}
					if _, err := tx.Exec("UPDATE bench SET value = value + 1 WHERE id = ?", rnd.Intn(benchRows)); err != nil {
						_ = tx.Rollback()
						return err
					}
					return tx.Commit()
				}()
				local = append(local, time.Since(start))
				if err != nil {
					atomic.AddInt64(&res.writeErrs, 1)
					if !sqlite.IsBusyOrLocked(err) {
						t.Errorf("unexpected write error: %v", err)
						return
					}
					continue
				}
				atomic.AddInt64(&res.writes, 1)
			}
			mu.Lock()
			writeTimes = append(writeTimes, local...)
			mu.Unlock()
		})
	}

	wg.Wait()

	res.readP99 = percentile(readTimes, 0.99)
	res.writeP99 = percentile(writeTimes, 0.99)
	return res
}

func TestWALBenchmark(t *testing.T) {
	var results []benchResult

	for _, readers := range []int{4, 16, 64} {
		results = append(results,
			runBench(t, walOff, "DELETE", readers, 1),
			runBench(t, walOn, "WAL", readers, 1),
		)
	}

	// Write saturated: no readers, several writers competing for the single writer slot.
	results = append(results,
		runBench(t, walOff, "DELETE", 0, 8),
		runBench(t, walOn, "WAL", 0, 8),
	)

	fmt.Printf("\n%-8s %8s %8s %10s %10s %10s %10s %12s %12s\n",
		"mode", "readers", "writers", "reads/s", "writes/s", "readErrs", "writeErrs", "read p99", "write p99")
	for _, r := range results {
		fmt.Printf("%-8s %8d %8d %10.0f %10.0f %10d %10d %12s %12s\n",
			r.mode, r.readers, r.writers,
			float64(r.reads)/benchDuration.Seconds(),
			float64(r.writes)/benchDuration.Seconds(),
			r.readErrs, r.writeErrs,
			r.readP99.Round(time.Microsecond), r.writeP99.Round(time.Microsecond))
	}
}
```

</details>

Fixes #65115
