### PR TITLE
TraceView: hide empty Resource attributes section

### DIFF
--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.test.tsx
@@ -272,6 +272,26 @@ describe('<SpanDetail>', () => {
     expect(props.processToggle).toHaveBeenLastCalledWith(span.spanID);
   });
 
+  it('hides Resource attributes when process.tags is empty', () => {
+    const spanWithoutResourceAttributes = {
+      ...span,
+      process: {
+        ...span.process,
+        tags: [],
+      },
+    };
+
+    render(
+      <SpanDetail
+        {...(props as unknown as SpanDetailProps)}
+        span={spanWithoutResourceAttributes}
+      />
+    );
+
+    expect(screen.queryByText('Resource attributes')).not.toBeInTheDocument();
+    expect(screen.getByRole('switch', { name: /Span attributes/ })).toBeInTheDocument();
+  });
+
   it('renders the logs', async () => {
     render(<SpanDetail {...(props as unknown as SpanDetailProps)} />);
     await userEvent.click(screen.getByRole('switch', { name: /Events/ }));

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
@@ -485,7 +485,7 @@ export default function SpanDetail(props: SpanDetailProps) {
     />
   );
 
-  if (process.tags) {
+  if (process.tags?.length) {
     listOfContentCards.push(
       <AccordionCategorizedKeyValues
         data={process.tags}


### PR DESCRIPTION
## Summary
- Hide the **Resource attributes** accordion in span detail when `process.tags` is empty
- `process.tags` is always an array (`transform.ts`), so the old truthy guard always rendered an inert empty header
- Matches sibling length checks for logs/warnings; adds a unit test for the empty case

Fixes #130422

## Test plan
- [x] `yarn jest --no-watch public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.test.tsx`
- [ ] Open a trace whose frames omit `serviceTags` (or send `[]`) and confirm Resource attributes is gone
- [ ] Open a Tempo/Jaeger trace with resource attributes and confirm the section still appears and expands


