### PR TITLE
Build: Add rspack build config for decoupled plugins

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -92,6 +92,10 @@ module.exports = {
   watchPlugins: ['jest-watch-typeahead/filename', 'jest-watch-typeahead/testname'],
   testPathIgnorePatterns: [
     '/node_modules/',
+    // This package is ESM-only (import.meta, @rspack/core), which Jest's
+    // CommonJS runtime cannot load. Its tests run under vitest instead —
+    // see `yarn test:rspack`.
+    '<rootDir>/packages/grafana-plugin-configs/',
     // Decoupled plugins run their own tests so ignoring them here.
     '<rootDir>/public/app/plugins/datasource/azuremonitor',
     '<rootDir>/public/app/plugins/datasource/cloudwatch',

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -139,6 +139,12 @@ const config: KnipConfig = {
     'packages/grafana-plugin-configs': {
       // this package contains shared code that isn't immediately used by the package
       webpack: false,
+      // knip's rspack plugin globs `rspack.config*` — which also matches the
+      // config's test file — and executes them without the arguments the
+      // plugin build passes in
+      rspack: false,
+      // the fixture plugin is only ever referenced by path from the config tests
+      ignore: ['__fixtures__/**'],
       ignoreDependencies: ['.*'],
     },
   },

--- a/packages/grafana-plugin-configs/__fixtures__/test-plugin/CHANGELOG.md
+++ b/packages/grafana-plugin-configs/__fixtures__/test-plugin/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+Fixture for `rspack.config.test.ts`. Not a real plugin.

--- a/packages/grafana-plugin-configs/__fixtures__/test-plugin/README.md
+++ b/packages/grafana-plugin-configs/__fixtures__/test-plugin/README.md
@@ -1,0 +1,3 @@
+# Test fixture plugin
+
+Fixture for `rspack.config.test.ts`. Not a real plugin.

--- a/packages/grafana-plugin-configs/__fixtures__/test-plugin/module.ts
+++ b/packages/grafana-plugin-configs/__fixtures__/test-plugin/module.ts
@@ -1,0 +1,11 @@
+/* fixture-source-comment: minification must remove this */
+// @ts-expect-error -- a plain UMD file with no types, deliberately untyped
+import umdDep from './umdDep.js';
+
+export function greet(name: string): string {
+  console.log('log call: pure_funcs must drop this');
+  console.info('info call: pure_funcs must drop this');
+  console.warn('warn call: pure_funcs must keep this');
+  console.error('error call: pure_funcs must keep this');
+  return `hello ${name} ${umdDep.marker}`;
+}

--- a/packages/grafana-plugin-configs/__fixtures__/test-plugin/package.json
+++ b/packages/grafana-plugin-configs/__fixtures__/test-plugin/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@grafana-plugins/test-fixture-plugin",
+  "private": true,
+  "version": "1.2.3"
+}

--- a/packages/grafana-plugin-configs/__fixtures__/test-plugin/plugin.json
+++ b/packages/grafana-plugin-configs/__fixtures__/test-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "type": "datasource",
+  "name": "Test Plugin",
+  "id": "grafana-testfixture-datasource",
+  "info": {
+    "version": "%VERSION%",
+    "updated": "%TODAY%"
+  }
+}

--- a/packages/grafana-plugin-configs/__fixtures__/test-plugin/umdDep.js
+++ b/packages/grafana-plugin-configs/__fixtures__/test-plugin/umdDep.js
@@ -1,0 +1,15 @@
+/*! @license fixture-license-notice: must be extracted to a sidecar */
+// A UMD-wrapped dependency, standing in for the real ones plugins bundle.
+// Whether its `define.amd` branch is resolved at build time or left for the
+// runtime depends on the config's `amd` option.
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define([], factory);
+  } else if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+  } else {
+    root.umdDep = factory();
+  }
+})(globalThis, function () {
+  return { marker: 'umd-dep-payload' };
+});

--- a/packages/grafana-plugin-configs/package.json
+++ b/packages/grafana-plugin-configs/package.json
@@ -10,6 +10,7 @@
   "type": "module",
   "devDependencies": {
     "@grafana/tsconfig": "^2.0.0",
+    "@rspack/core": "^2.1.7",
     "@swc/core": "1.13.3",
     "@swc/helpers": "^0.5.0",
     "@swc/jest": "^0.2.26",
@@ -18,6 +19,7 @@
     "@types/webpack-bundle-analyzer": "^4.7.0",
     "copy-webpack-plugin": "^14.0.0",
     "eslint": "9.32.0",
+    "eslint-rspack-plugin": "^5.0.1",
     "eslint-webpack-plugin": "5.0.2",
     "fork-ts-checker-webpack-plugin": "9.1.0",
     "identity-obj-proxy": "^3.0.0",
@@ -26,7 +28,9 @@
     "jest-environment-jsdom": "29.7.0",
     "replace-in-file-webpack-plugin": "1.0.6",
     "swc-loader": "0.2.6",
+    "ts-checker-rspack-plugin": "^1.5.1",
     "typescript": "6.0.2",
+    "vitest": "^4.1.10",
     "webpack": "^5.105.0",
     "webpack-bundle-analyzer": "^4.10.2",
     "webpack-virtual-modules": "^0.6.2"

--- a/packages/grafana-plugin-configs/rspack.config.test.ts
+++ b/packages/grafana-plugin-configs/rspack.config.test.ts
@@ -1,0 +1,88 @@
+import { type Configuration } from '@rspack/core';
+import fs from 'node:fs';
+import path from 'node:path';
+import ReplaceInFileWebpackPlugin from 'replace-in-file-webpack-plugin';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { compile, readAssets } from '../../scripts/rspack/plugins/testUtils.ts';
+
+import config, { type Env } from './rspack.config.ts';
+
+const FIXTURE_DIR = path.join(import.meta.dirname, '__fixtures__', 'test-plugin');
+const ROOT_LICENSE = path.resolve(import.meta.dirname, '../../LICENSE');
+const OUTPUT_PATH = '/dist';
+const BANNER = '/* [create-plugin] version: 5.22.0 */';
+
+async function createConfig(env: Env): Promise<Configuration> {
+  const pluginConfig = await config(env, FIXTURE_DIR);
+
+  return {
+    ...pluginConfig,
+    // The config derives `context` and `output.path` from process.cwd() because
+    // each plugin runs its own build from its own directory. Point them at the
+    // fixture instead of the repo root, and drop `clean` so the compilation
+    // never touches the real output directory.
+    context: FIXTURE_DIR,
+    output: { ...pluginConfig.output, path: OUTPUT_PATH, clean: false },
+    // ReplaceInFileWebpackPlugin rewrites the emitted files on the real
+    // filesystem, which an in-memory output filesystem never produces.
+    plugins: pluginConfig.plugins?.filter((plugin) => !(plugin instanceof ReplaceInFileWebpackPlugin)),
+  };
+}
+
+describe('plugin rspack config', () => {
+  // The config sets no `target`, so rspack resolves one from .browserslistrc.
+  // Vitest sets NODE_ENV=test and .browserslistrc has no [test] section, which
+  // resolves to an empty browser list and fails the compilation.
+  beforeAll(() => {
+    vi.stubEnv('BROWSERSLIST_ENV', 'production');
+  });
+
+  afterAll(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('emits the repo-root LICENSE byte-for-byte for plugins without their own', async () => {
+    const { outputFs } = await compile(await createConfig({ production: true }));
+    const assets = readAssets(outputFs, OUTPUT_PATH);
+
+    expect(assets['LICENSE']).toBe(fs.readFileSync(ROOT_LICENSE, 'utf-8'));
+  });
+
+  it('keeps the create-plugin banner after minification', async () => {
+    const { outputFs } = await compile(await createConfig({ production: true }));
+    const assets = readAssets(outputFs, OUTPUT_PATH);
+
+    expect(assets['module.js']).toContain(BANNER);
+    // Proves minification actually ran, so the banner survived it rather than
+    // the minimizer having been skipped.
+    expect(assets['module.js']).not.toContain('fixture-source-comment');
+  });
+
+  it('extracts third-party license notices into a sidecar instead of dropping them', async () => {
+    const { outputFs } = await compile(await createConfig({ production: true }));
+    const assets = readAssets(outputFs, OUTPUT_PATH);
+
+    expect(assets['module.js.LICENSE.txt']).toContain('fixture-license-notice');
+    expect(assets['module.js']).not.toContain('fixture-license-notice');
+  });
+
+  it('resolves the define.amd branch of bundled UMD deps at build time', async () => {
+    const { outputFs } = await compile(await createConfig({ production: true }));
+    const assets = readAssets(outputFs, OUTPUT_PATH);
+
+    // Without `amd`, the check is left in the bundle and evaluated at load
+    // time — where the global `define` SystemJS installs makes it truthy, so
+    // the dep registers with SystemJS, exports nothing, and the plugin throws.
+    expect(assets['module.js']).not.toContain('define.amd');
+    expect(assets['module.js']).toContain('umd-dep-payload');
+  });
+
+  it('drops console.log and console.info but keeps warn and error', async () => {
+    const { outputFs } = await compile(await createConfig({ production: true }));
+    const assets = readAssets(outputFs, OUTPUT_PATH);
+
+    expect(assets['module.js']).not.toContain('pure_funcs must drop this');
+    expect(assets['module.js']).toContain('pure_funcs must keep this');
+  });
+});

--- a/packages/grafana-plugin-configs/rspack.config.ts
+++ b/packages/grafana-plugin-configs/rspack.config.ts
@@ -50,7 +50,7 @@ class BuildModeRspackPlugin {
 // watch rebuild (it was ~16s on 2.1.1). Emitting the file directly avoids the
 // scan. Plugins that ship their own LICENSE copy it normally — that `from`
 // resolves inside the plugin directory.
-export class EmitLicenseRspackPlugin {
+class EmitLicenseRspackPlugin {
   apply(compiler: Compiler) {
     const licensePath = path.resolve(import.meta.dirname, '../../LICENSE');
     compiler.hooks.compilation.tap('EmitLicenseRspackPlugin', (compilation) => {

--- a/packages/grafana-plugin-configs/rspack.config.ts
+++ b/packages/grafana-plugin-configs/rspack.config.ts
@@ -1,0 +1,369 @@
+import rspack, { type Configuration, type Compiler } from '@rspack/core';
+import ESLintPlugin from 'eslint-rspack-plugin';
+import fs from 'fs';
+import path from 'path';
+import ReplaceInFileWebpackPlugin from 'replace-in-file-webpack-plugin';
+import { TsCheckerRspackPlugin } from 'ts-checker-rspack-plugin';
+import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
+
+import { DIST_DIR } from './constants.ts';
+import { getPackageJson, getPluginJson, getEntries, hasLicense } from './utils.ts';
+
+// CopyRspackPlugin has no `filter` option (unlike copy-webpack-plugin), so the
+// equivalent of the webpack config's `skipFiles` filter is expressed as glob
+// ignores instead.
+const copyIgnore = ['**/dist/**', '**/tsconfig.json', '**/package.json', '**/project.json'];
+
+class BuildModeRspackPlugin {
+  apply(compiler: Compiler) {
+    compiler.hooks.compilation.tap('BuildModeRspackPlugin', (compilation) => {
+      compilation.hooks.processAssets.tap(
+        {
+          name: 'BuildModeRspackPlugin',
+          stage: rspack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS,
+        },
+        async () => {
+          const assets = compilation.getAssets();
+          for (const asset of assets) {
+            if (asset.name.endsWith('plugin.json')) {
+              const pluginJsonString = asset.source.source().toString();
+              const pluginJsonWithBuildMode = JSON.stringify(
+                {
+                  ...JSON.parse(pluginJsonString),
+                  buildMode: compilation.options.mode,
+                },
+                null,
+                4
+              );
+              compilation.updateAsset(asset.name, new rspack.sources.RawSource(pluginJsonWithBuildMode));
+            }
+          }
+        }
+      );
+    });
+  }
+}
+
+// CopyRspackPlugin recursively scans the *parent directory* of a single-file
+// `from`, so a pattern for the repo-root LICENSE walks the whole monorepo. On
+// @rspack/core 2.1.7 that measures ~3.9s per plugin build, repeated on every
+// watch rebuild (it was ~16s on 2.1.1). Emitting the file directly avoids the
+// scan. Plugins that ship their own LICENSE copy it normally — that `from`
+// resolves inside the plugin directory.
+export class EmitLicenseRspackPlugin {
+  apply(compiler: Compiler) {
+    const licensePath = path.resolve(import.meta.dirname, '../../LICENSE');
+    compiler.hooks.compilation.tap('EmitLicenseRspackPlugin', (compilation) => {
+      compilation.hooks.processAssets.tap(
+        {
+          name: 'EmitLicenseRspackPlugin',
+          stage: rspack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS,
+        },
+        () => {
+          if (!compilation.getAsset('LICENSE')) {
+            compilation.emitAsset('LICENSE', new rspack.sources.RawSource(fs.readFileSync(licensePath, 'utf-8')));
+          }
+        }
+      );
+    });
+  }
+}
+
+export type Env = {
+  [key: string]: true | string | Env;
+};
+
+const config = async (env: Env, pluginDir = process.cwd()): Promise<Configuration> => {
+  const pluginJson = getPluginJson(pluginDir);
+  // Inject module. rspack ships a native equivalent of webpack-virtual-modules
+  // with the same constructor shape.
+  const virtualPublicPath = new rspack.experiments.VirtualModulesPlugin({
+    'node_modules/grafana-public-path.js': `
+  import amdMetaModule from 'amd-module';
+
+  __webpack_public_path__ =
+    amdMetaModule && amdMetaModule.uri
+      ? amdMetaModule.uri.slice(0, amdMetaModule.uri.lastIndexOf('/') + 1)
+      : 'public/plugins/${pluginJson.id}/';
+  `,
+  });
+
+  const baseConfig: Configuration = {
+    // No `cache` block: rspack's persistent cache is still experimental
+    // (`experiments.cache`) and the cold builds are fast enough without it.
+
+    // rspack only resolves the `define.amd` branch of a UMD wrapper at build
+    // time when AMD support is on. Without this, the check is left in the
+    // bundle and evaluated at load time, where the global `define` SystemJS
+    // installs makes it truthy: the dep registers with SystemJS, exports
+    // nothing, and the plugin throws.
+    amd: {},
+
+    context: process.cwd(),
+
+    devtool: env.production ? 'source-map' : 'eval-source-map',
+
+    entry: await getEntries(pluginDir),
+
+    externals: [
+      // Required for dynamic publicPath resolution
+      { 'amd-module': 'module' },
+      'lodash',
+      'jquery',
+      'moment',
+      'slate',
+      'emotion',
+      '@emotion/react',
+      '@emotion/css',
+      'prismjs',
+      'slate-plain-serializer',
+      '@grafana/slate-react',
+      'react',
+      'react/jsx-runtime',
+      'react/jsx-dev-runtime',
+      'react-dom',
+      'react-redux',
+      'redux',
+      'rxjs',
+      'rxjs/operators',
+      'react-router',
+      'd3',
+      /^@grafana\/ui/i,
+      /^@grafana\/runtime/i,
+      /^@grafana\/data/i,
+
+      // Mark legacy SDK imports as external if their name starts with the "grafana/" prefix
+      ({ request }, callback) => {
+        const prefix = 'grafana/';
+        const hasPrefix = (request?: string) => request?.indexOf(prefix) === 0;
+        const stripPrefix = (request?: string) => request?.substr(prefix.length);
+
+        if (hasPrefix(request)) {
+          return callback(undefined, stripPrefix(request));
+        }
+
+        callback();
+      },
+    ],
+
+    mode: env.production ? 'production' : 'development',
+
+    module: {
+      rules: [
+        // This must come first in the rules array otherwise it breaks sourcemaps.
+        {
+          test: /module\.tsx?$/,
+          use: [
+            {
+              loader: 'imports-loader',
+              options: {
+                imports: `side-effects grafana-public-path`,
+              },
+            },
+          ],
+        },
+        {
+          exclude: /(node_modules)/,
+          test: /\.[tj]sx?$/,
+          use: {
+            loader: 'builtin:swc-loader',
+            options: {
+              jsc: {
+                baseUrl: path.resolve(import.meta.dirname),
+                target: 'es2015',
+                loose: false,
+                parser: {
+                  syntax: 'typescript',
+                  tsx: true,
+                  decorators: false,
+                  dynamicImport: true,
+                },
+                transform: {
+                  react: {
+                    runtime: 'automatic',
+                  },
+                },
+              },
+            },
+          },
+        },
+        {
+          test: /\.css$/,
+          use: ['style-loader', 'css-loader'],
+        },
+        {
+          test: /\.s[ac]ss$/,
+          use: ['style-loader', 'css-loader', 'sass-loader'],
+        },
+        {
+          test: /\.(png|jpe?g|gif|svg)$/,
+          type: 'asset/resource',
+          generator: {
+            // Keep publicPath relative for host.com/grafana/ deployments
+            publicPath: `public/plugins/${pluginJson.id}/img/`,
+            outputPath: 'img/',
+            filename: Boolean(env.production) ? '[hash][ext]' : '[name][ext]',
+          },
+        },
+        {
+          test: /\.(woff|woff2|eot|ttf|otf)(\?v=\d+\.\d+\.\d+)?$/,
+          type: 'asset/resource',
+          generator: {
+            // Keep publicPath relative for host.com/grafana/ deployments
+            publicPath: `public/plugins/${pluginJson.id}/fonts/`,
+            outputPath: 'fonts/',
+            filename: Boolean(env.production) ? '[hash][ext]' : '[name][ext]',
+          },
+        },
+      ],
+    },
+
+    output: {
+      clean: {
+        keep: new RegExp(`(.*?_(amd64|arm(64)?)(.exe)?|go_plugin_build_manifest)`),
+      },
+      filename: '[name].js',
+      library: {
+        type: 'amd',
+      },
+      path: path.resolve(process.cwd(), DIST_DIR),
+      publicPath: `public/plugins/${pluginJson.id}/`,
+      uniqueName: pluginJson.id,
+    },
+
+    optimization: {
+      minimize: Boolean(env.production),
+      minimizer: [
+        new rspack.SwcJsMinimizerRspackPlugin({
+          // TerserPlugin extracts third-party @license banners into a
+          // <asset>.LICENSE.txt sidecar by default; rspack's minimizer does
+          // not, and `format.comments: false` below would otherwise drop those
+          // notices from the shipped bundle entirely.
+          extractComments: true,
+          minimizerOptions: {
+            format: {
+              // swc's `comments` only takes false | 'some' | 'all' — there is
+              // no terser-style predicate to keep the [create-plugin] banner,
+              // so all comments are dropped here and the banner is re-added
+              // after minification by the BannerPlugin below.
+              comments: false,
+            },
+            compress: {
+              // swc's `drop_console` is boolean-only and would drop warn and
+              // error too. pure_funcs matches terser's
+              // `drop_console: ['log', 'info']`.
+              pure_funcs: ['console.log', 'console.info'],
+            },
+          },
+        }),
+      ],
+    },
+
+    plugins: [
+      virtualPublicPath,
+      // Insert create plugin version information into the bundle so Grafana will load from cdn with script tags.
+      new rspack.BannerPlugin({
+        banner: '/* [create-plugin] version: 5.22.0 */',
+        raw: true,
+        entryOnly: true,
+        // Run after the minimizer (PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE) so the
+        // banner survives `format.comments: false`.
+        stage: rspack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE + 1,
+      }),
+      new rspack.CopyRspackPlugin({
+        patterns: [
+          // To `compiler.options.output`
+          { from: 'README.md', to: '.', force: true },
+          { from: 'plugin.json', to: '.' },
+          // Plugins without their own LICENSE get the repo-root Grafana
+          // LICENSE from EmitLicenseRspackPlugin instead of a copy pattern.
+          ...(hasLicense(pluginDir) ? [{ from: 'LICENSE', to: '.' }] : []),
+          { from: 'CHANGELOG.md', to: '.', force: true },
+          { from: '**/*.json', to: '.', globOptions: { ignore: copyIgnore } }, // TODO<Add an error for checking the basic structure of the repo>
+          { from: '**/*.svg', to: '.', noErrorOnMissing: true, globOptions: { ignore: copyIgnore } }, // Optional
+          { from: '**/*.png', to: '.', noErrorOnMissing: true, globOptions: { ignore: copyIgnore } }, // Optional
+          { from: '**/*.html', to: '.', noErrorOnMissing: true, globOptions: { ignore: copyIgnore } }, // Optional
+          { from: 'img/**/*', to: '.', noErrorOnMissing: true, globOptions: { ignore: copyIgnore } }, // Optional
+          { from: 'libs/**/*', to: '.', noErrorOnMissing: true, globOptions: { ignore: copyIgnore } }, // Optional
+          { from: 'schema/**/*', to: '.', noErrorOnMissing: true, globOptions: { ignore: copyIgnore } }, // Optional
+          { from: 'static/**/*', to: '.', noErrorOnMissing: true, globOptions: { ignore: copyIgnore } }, // Optional
+        ],
+      }),
+      // Replace certain template-variables in the README and plugin.json
+      new ReplaceInFileWebpackPlugin([
+        {
+          dir: path.resolve(DIST_DIR),
+          files: ['plugin.json', 'README.md'],
+          rules: [
+            {
+              search: /\%VERSION\%/g,
+              replace: env.commit
+                ? `${getPackageJson(pluginDir).version}-${env.commit}`
+                : getPackageJson(pluginDir).version,
+            },
+            {
+              search: /\%TODAY\%/g,
+              replace: new Date().toISOString().substring(0, 10),
+            },
+            {
+              search: /\%PLUGIN_ID\%/g,
+              replace: pluginJson.id,
+            },
+          ],
+        },
+      ]),
+      // Add buildMode to plugin.json
+      new BuildModeRspackPlugin(),
+      ...(hasLicense(pluginDir) ? [] : [new EmitLicenseRspackPlugin()]),
+      ...(env.development
+        ? [
+            new TsCheckerRspackPlugin({
+              async: true,
+              issue: {
+                include: [{ file: '**/*.{ts,tsx}' }],
+              },
+              typescript: { configFile: path.join(process.cwd(), 'tsconfig.json') },
+            }),
+            new ESLintPlugin({
+              extensions: ['.ts', '.tsx'],
+              lintDirtyModulesOnly: true, // don't lint on start, only lint changed files
+              cacheLocation: path.resolve(
+                import.meta.dirname,
+                '../../node_modules/.cache/eslint-rspack-plugin',
+                path.basename(process.cwd()),
+                '.eslintcache'
+              ),
+              configType: 'flat',
+              // eslint-rspack-plugin 5.x dropped `failOnError`; downgrading
+              // errors to warnings is the equivalent of `failOnError: false`.
+              severity: {
+                error: 'warning',
+              },
+            }),
+          ]
+        : []),
+    ],
+
+    resolve: {
+      extensions: ['.ts', '.tsx', '.js', '.jsx'],
+      conditionNames: ['@grafana-app/source', '...'],
+      // webpack's `resolve.unsafeCache` has no rspack equivalent; rspack caches
+      // resolution natively.
+    },
+
+    stats: 'minimal',
+
+    watchOptions: {
+      ignored: ['**/node_modules', '**/dist', '**/.yarn'],
+    },
+  };
+
+  if (env.stats) {
+    baseConfig.stats = 'normal';
+    baseConfig.plugins?.push(new BundleAnalyzerPlugin());
+  }
+
+  return baseConfig;
+};
+
+export default config;

--- a/scripts/rspack/vitest.config.ts
+++ b/scripts/rspack/vitest.config.ts
@@ -1,11 +1,13 @@
+import path from 'node:path';
 import { defineConfig } from 'vitest/config';
 
 // Vitest runs these tests instead of Jest because @rspack/core 2.x is ESM-only,
-// which Jest's CommonJS runtime cannot load in-process.
+// which Jest's CommonJS runtime cannot load in-process. Rooted at the repo so
+// the same project covers every rspack config, wherever it lives.
 export default defineConfig({
-  root: import.meta.dirname,
+  root: path.resolve(import.meta.dirname, '../..'),
   test: {
     environment: 'node',
-    include: ['plugins/**/*.test.ts'],
+    include: ['scripts/rspack/plugins/**/*.test.ts', 'packages/grafana-plugin-configs/**/*.test.ts'],
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2701,6 +2701,7 @@ __metadata:
   resolution: "@grafana/plugin-configs@workspace:packages/grafana-plugin-configs"
   dependencies:
     "@grafana/tsconfig": "npm:^2.0.0"
+    "@rspack/core": "npm:^2.1.7"
     "@swc/core": "npm:1.13.3"
     "@swc/helpers": "npm:^0.5.0"
     "@swc/jest": "npm:^0.2.26"
@@ -2709,6 +2710,7 @@ __metadata:
     "@types/webpack-bundle-analyzer": "npm:^4.7.0"
     copy-webpack-plugin: "npm:^14.0.0"
     eslint: "npm:9.32.0"
+    eslint-rspack-plugin: "npm:^5.0.1"
     eslint-webpack-plugin: "npm:5.0.2"
     fork-ts-checker-webpack-plugin: "npm:9.1.0"
     identity-obj-proxy: "npm:^3.0.0"
@@ -2719,7 +2721,9 @@ __metadata:
     replace-in-file-webpack-plugin: "npm:1.0.6"
     swc-loader: "npm:0.2.6"
     terser-webpack-plugin: "npm:^5.4.0"
+    ts-checker-rspack-plugin: "npm:^1.5.1"
     typescript: "npm:6.0.2"
+    vitest: "npm:^4.1.10"
     webpack: "npm:^5.105.0"
     webpack-bundle-analyzer: "npm:^4.10.2"
     webpack-virtual-modules: "npm:^0.6.2"
@@ -5013,6 +5017,247 @@ __metadata:
   version: 7.1.3
   resolution: "@jsdevtools/ono@npm:7.1.3"
   checksum: 10/d4a036ccb9d2b21b7e4cec077c59a5a83fad58adacbce89e7e6b77a703050481ff5b6d813aef7f5ff0a8347a85a0eedf599e2e6bb5784a971a93e53e43b10157
+  languageName: node
+  linkType: hard
+
+"@jsonjoy.com/base64@npm:17.67.0":
+  version: 17.67.0
+  resolution: "@jsonjoy.com/base64@npm:17.67.0"
+  peerDependencies:
+    tslib: 2
+  checksum: 10/ae44b0c4c83ecc5c0ee1911706a665e18e89d64a2b705cc458d7f6fc3c3c7db0e621261e978d02b74ded6a9fe1aafc8e708eb8a133e794a92bb033c50a0c4ccd
+  languageName: node
+  linkType: hard
+
+"@jsonjoy.com/base64@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@jsonjoy.com/base64@npm:1.1.2"
+  peerDependencies:
+    tslib: 2
+  checksum: 10/d76bb58eff841c090d9bf69a073611ffa73c40a664ccbcea689f65961f57d7b24051269d06b437e4f6204285d6ba92f50f587c5e95c5f9e4f10b36a2ed4cd0c8
+  languageName: node
+  linkType: hard
+
+"@jsonjoy.com/buffers@npm:17.67.0, @jsonjoy.com/buffers@npm:^17.65.0":
+  version: 17.67.0
+  resolution: "@jsonjoy.com/buffers@npm:17.67.0"
+  peerDependencies:
+    tslib: 2
+  checksum: 10/6c8f6c4c73ec4ddab538a88be0bf72d8a934752755d43b0289fbe19ce9fa6123f082d1cd5ae179495e121a2f50267d26d36641f6dadedd8d5d2a2f980426e8ff
+  languageName: node
+  linkType: hard
+
+"@jsonjoy.com/buffers@npm:^1.0.0, @jsonjoy.com/buffers@npm:^1.2.0":
+  version: 1.2.1
+  resolution: "@jsonjoy.com/buffers@npm:1.2.1"
+  peerDependencies:
+    tslib: 2
+  checksum: 10/8ef4784d05c0fb4d0f27a1f78f5b0ae1f3b537d237f978d10be0b88f59a534ae44db2a4bde28eee0eb461ede31dc194aab5927ac001ed2b764629fa43ae9b60b
+  languageName: node
+  linkType: hard
+
+"@jsonjoy.com/codegen@npm:17.67.0":
+  version: 17.67.0
+  resolution: "@jsonjoy.com/codegen@npm:17.67.0"
+  peerDependencies:
+    tslib: 2
+  checksum: 10/e2462836c708999d045c4a15099f12e721089a3731f0ad33da210559a52ed763b8bddbec3c181857341984ef12ea355290609f37f0dc6f8de1545c028090adf5
+  languageName: node
+  linkType: hard
+
+"@jsonjoy.com/codegen@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@jsonjoy.com/codegen@npm:1.0.0"
+  peerDependencies:
+    tslib: 2
+  checksum: 10/a0afb03d2af4fbc1377c547e507f5db99a25f515d8c4b6b2cef1ff28145ac59fff12b6e1f41f9734cb62ea5619e7f9be1acd0908305d6f4176898ee534ee9a64
+  languageName: node
+  linkType: hard
+
+"@jsonjoy.com/fs-core@npm:4.68.0":
+  version: 4.68.0
+  resolution: "@jsonjoy.com/fs-core@npm:4.68.0"
+  dependencies:
+    "@jsonjoy.com/fs-node-builtins": "npm:4.68.0"
+    "@jsonjoy.com/fs-node-utils": "npm:4.68.0"
+    thingies: "npm:^2.5.0"
+  peerDependencies:
+    tslib: 2
+  checksum: 10/2b18850af71bc2f68c0b2fefa40be869d8a3338d29899304efcae0f77a4dcb8acb56604423e60ea4102ff3ab76999f897f19ff92cb4dc00d64c5030d2d781e32
+  languageName: node
+  linkType: hard
+
+"@jsonjoy.com/fs-fsa@npm:4.68.0":
+  version: 4.68.0
+  resolution: "@jsonjoy.com/fs-fsa@npm:4.68.0"
+  dependencies:
+    "@jsonjoy.com/fs-core": "npm:4.68.0"
+    "@jsonjoy.com/fs-node-builtins": "npm:4.68.0"
+    "@jsonjoy.com/fs-node-utils": "npm:4.68.0"
+    thingies: "npm:^2.5.0"
+  peerDependencies:
+    tslib: 2
+  checksum: 10/0a6fbb1006a96562280f039d38e70fbdad6677c26c971b75d93f37818d56b54ee42d077050c20790385adbf2f0b27f8abd5ef1961158697f0f996dd6616ab0d1
+  languageName: node
+  linkType: hard
+
+"@jsonjoy.com/fs-node-builtins@npm:4.68.0":
+  version: 4.68.0
+  resolution: "@jsonjoy.com/fs-node-builtins@npm:4.68.0"
+  peerDependencies:
+    tslib: 2
+  checksum: 10/8753159724f0329d2ec09110b0e72df2ae3efa4840787be7d2df1121b84f6bbd283c25a344c62b9f12a36b54f9d4237acb7a28b16e989024e7eee75565697aeb
+  languageName: node
+  linkType: hard
+
+"@jsonjoy.com/fs-node-to-fsa@npm:4.68.0":
+  version: 4.68.0
+  resolution: "@jsonjoy.com/fs-node-to-fsa@npm:4.68.0"
+  dependencies:
+    "@jsonjoy.com/fs-fsa": "npm:4.68.0"
+    "@jsonjoy.com/fs-node-builtins": "npm:4.68.0"
+    "@jsonjoy.com/fs-node-utils": "npm:4.68.0"
+  peerDependencies:
+    tslib: 2
+  checksum: 10/1d99dc04e261400cc905888c04fc361c5ebd878d7dd31d69075b1f063376512abc822b0bdc98b8121493e86f2b5942b58cc451893f43d6599f5e5e6b87aa912d
+  languageName: node
+  linkType: hard
+
+"@jsonjoy.com/fs-node-utils@npm:4.68.0":
+  version: 4.68.0
+  resolution: "@jsonjoy.com/fs-node-utils@npm:4.68.0"
+  dependencies:
+    "@jsonjoy.com/fs-node-builtins": "npm:4.68.0"
+    glob-to-regex.js: "npm:^1.0.1"
+  peerDependencies:
+    tslib: 2
+  checksum: 10/2e8eb066060eda98ccacb07b5106407f8f61ca78b4a57b7d9911c1f5be17b5e3669bd75bdd2a0595016fb153e6087c56dd82651349ed35e7ab928dd645b31b17
+  languageName: node
+  linkType: hard
+
+"@jsonjoy.com/fs-node@npm:4.68.0":
+  version: 4.68.0
+  resolution: "@jsonjoy.com/fs-node@npm:4.68.0"
+  dependencies:
+    "@jsonjoy.com/fs-core": "npm:4.68.0"
+    "@jsonjoy.com/fs-node-builtins": "npm:4.68.0"
+    "@jsonjoy.com/fs-node-utils": "npm:4.68.0"
+    "@jsonjoy.com/fs-print": "npm:4.68.0"
+    "@jsonjoy.com/fs-snapshot": "npm:4.68.0"
+    glob-to-regex.js: "npm:^1.0.0"
+    thingies: "npm:^2.5.0"
+  peerDependencies:
+    tslib: 2
+  checksum: 10/322bb02720c9e80b9f00ab5a3f2c9590572873c8047964810c7c1d9a1fc64d5add59eb1f787fcd567ca8104f1759f326be4b885c75dbd90cc9c459988a7014c3
+  languageName: node
+  linkType: hard
+
+"@jsonjoy.com/fs-print@npm:4.68.0":
+  version: 4.68.0
+  resolution: "@jsonjoy.com/fs-print@npm:4.68.0"
+  dependencies:
+    "@jsonjoy.com/fs-node-utils": "npm:4.68.0"
+    tree-dump: "npm:^1.1.0"
+  peerDependencies:
+    tslib: 2
+  checksum: 10/e6def4cfc80b599d52c40ecb08d5ad5915c960ea92ad5e4deb0daeb1509c0360f9da95dcc4d998020bacc4195c9fce4b137445a004eeeeb971369aa09b65b41e
+  languageName: node
+  linkType: hard
+
+"@jsonjoy.com/fs-snapshot@npm:4.68.0":
+  version: 4.68.0
+  resolution: "@jsonjoy.com/fs-snapshot@npm:4.68.0"
+  dependencies:
+    "@jsonjoy.com/buffers": "npm:^17.65.0"
+    "@jsonjoy.com/fs-node-utils": "npm:4.68.0"
+    "@jsonjoy.com/json-pack": "npm:^17.65.0"
+    "@jsonjoy.com/util": "npm:^17.65.0"
+  peerDependencies:
+    tslib: 2
+  checksum: 10/abd270e72dd0b7b9991a27e35718f0d109e47c94957db85523d04606e03763b28ba3a4bb6bdd6f6fa1e408ecadbf87184b5a85a554b3a033ed3c1591ba215761
+  languageName: node
+  linkType: hard
+
+"@jsonjoy.com/json-pack@npm:^1.11.0":
+  version: 1.21.0
+  resolution: "@jsonjoy.com/json-pack@npm:1.21.0"
+  dependencies:
+    "@jsonjoy.com/base64": "npm:^1.1.2"
+    "@jsonjoy.com/buffers": "npm:^1.2.0"
+    "@jsonjoy.com/codegen": "npm:^1.0.0"
+    "@jsonjoy.com/json-pointer": "npm:^1.0.2"
+    "@jsonjoy.com/util": "npm:^1.9.0"
+    hyperdyperid: "npm:^1.2.0"
+    thingies: "npm:^2.5.0"
+    tree-dump: "npm:^1.1.0"
+  peerDependencies:
+    tslib: 2
+  checksum: 10/138b7eb8c96e6e435b0218c8f2eb5554e4eb49198a8718673a65e81da53b4617553ffa7124b51d6ea00fdfb868d6ff8b5ad6365e8336380ca7025f04d0412ee7
+  languageName: node
+  linkType: hard
+
+"@jsonjoy.com/json-pack@npm:^17.65.0":
+  version: 17.67.0
+  resolution: "@jsonjoy.com/json-pack@npm:17.67.0"
+  dependencies:
+    "@jsonjoy.com/base64": "npm:17.67.0"
+    "@jsonjoy.com/buffers": "npm:17.67.0"
+    "@jsonjoy.com/codegen": "npm:17.67.0"
+    "@jsonjoy.com/json-pointer": "npm:17.67.0"
+    "@jsonjoy.com/util": "npm:17.67.0"
+    hyperdyperid: "npm:^1.2.0"
+    thingies: "npm:^2.5.0"
+    tree-dump: "npm:^1.1.0"
+  peerDependencies:
+    tslib: 2
+  checksum: 10/9ff4403862e49433fe607175e90af749d64902640d63919ba559e5748d1a3db60d7366cc3b84dcc4a57ad478540e5eecb22fed80766e293482a0ab8e583b1b0b
+  languageName: node
+  linkType: hard
+
+"@jsonjoy.com/json-pointer@npm:17.67.0":
+  version: 17.67.0
+  resolution: "@jsonjoy.com/json-pointer@npm:17.67.0"
+  dependencies:
+    "@jsonjoy.com/util": "npm:17.67.0"
+  peerDependencies:
+    tslib: 2
+  checksum: 10/5a27c6b5b1276d357cfc3e8a05112d6305ccd17bf672190f25dfac2f4108ced170e784451d64728f60f93305c0007e3f832ddd175b8a47f3eb652cbabcec31ad
+  languageName: node
+  linkType: hard
+
+"@jsonjoy.com/json-pointer@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@jsonjoy.com/json-pointer@npm:1.0.2"
+  dependencies:
+    "@jsonjoy.com/codegen": "npm:^1.0.0"
+    "@jsonjoy.com/util": "npm:^1.9.0"
+  peerDependencies:
+    tslib: 2
+  checksum: 10/f22baeb3abc8ace2d8902d06ec297343431d4486dcf399aaaffd26ace7e62e194fe0efb4b7880e45b3b7939224ee838d3213448ef654fc8a61c91a76fe994d94
+  languageName: node
+  linkType: hard
+
+"@jsonjoy.com/util@npm:17.67.0, @jsonjoy.com/util@npm:^17.65.0":
+  version: 17.67.0
+  resolution: "@jsonjoy.com/util@npm:17.67.0"
+  dependencies:
+    "@jsonjoy.com/buffers": "npm:17.67.0"
+    "@jsonjoy.com/codegen": "npm:17.67.0"
+  peerDependencies:
+    tslib: 2
+  checksum: 10/b0facf65c3190d6ed1ada7e5b7679d80fa5da73bfbd02f2bb2f3af1c28c0d854b6ee2350824313b7ba82c0e5191da94903b4af61255bc232dbb7feedd2f31e0c
+  languageName: node
+  linkType: hard
+
+"@jsonjoy.com/util@npm:^1.9.0":
+  version: 1.9.0
+  resolution: "@jsonjoy.com/util@npm:1.9.0"
+  dependencies:
+    "@jsonjoy.com/buffers": "npm:^1.0.0"
+    "@jsonjoy.com/codegen": "npm:^1.0.0"
+  peerDependencies:
+    tslib: 2
+  checksum: 10/1a6e5301d725a7161b93ff707eb1a954bf4552a2fa96eee9a960d3ae3ed5f993d18b56dcff29e98036341a5968c5d1b2dfe21f76695390e7f0d89b81f24c85e0
   languageName: node
   linkType: hard
 
@@ -8192,6 +8437,13 @@ __metadata:
     "@swc/helpers":
       optional: true
   checksum: 10/84526df889fa2813cfa7dfbed71b713c47c2010b1f55da26db698a87ea11f3f433a931ec29616ff300cb63d0ea27cbe7d2b40df64abf45f9b1a484b59c94ca1a
+  languageName: node
+  linkType: hard
+
+"@rspack/lite-tapable@npm:^1.1.2":
+  version: 1.1.5
+  resolution: "@rspack/lite-tapable@npm:1.1.5"
+  checksum: 10/e74775fd2d9355175168cde752467bb9906bb5deb850f11e65535effa7d775230fa2f9583587a36b360ba0bea45e841d785858f61ea31d2c2bf36fe9ab6c27b1
   languageName: node
   linkType: hard
 
@@ -13064,7 +13316,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"anymatch@npm:^3.0.3, anymatch@npm:^3.1.1, anymatch@npm:^3.1.3":
+"anymatch@npm:^3.0.3, anymatch@npm:^3.1.1, anymatch@npm:^3.1.3, anymatch@npm:~3.1.2":
   version: 3.1.3
   resolution: "anymatch@npm:3.1.3"
   dependencies:
@@ -13700,6 +13952,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"binary-extensions@npm:^2.0.0":
+  version: 2.3.0
+  resolution: "binary-extensions@npm:2.3.0"
+  checksum: 10/bcad01494e8a9283abf18c1b967af65ee79b0c6a9e6fcfafebfe91dbe6e0fc7272bafb73389e198b310516ae04f7ad17d79aacf6cb4c0d5d5202a7e2e52c7d98
+  languageName: node
+  linkType: hard
+
 "bintrees@npm:1.0.2":
   version: 1.0.2
   resolution: "bintrees@npm:1.0.2"
@@ -13796,7 +14055,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"braces@npm:^3.0.3":
+"braces@npm:^3.0.3, braces@npm:~3.0.2":
   version: 3.0.3
   resolution: "braces@npm:3.0.3"
   dependencies:
@@ -14219,6 +14478,25 @@ __metadata:
   version: 1.7.3
   resolution: "cheminfo-types@npm:1.7.3"
   checksum: 10/238918de274b8cb7e92eed50e11396c71dd48d3f3196335e4b4b53f1ab12bb0b217a22a5b8d12ce35f7b256147f2953b9506e4f6e48a0dc9eda1df0625fd3e5c
+  languageName: node
+  linkType: hard
+
+"chokidar@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "chokidar@npm:3.6.0"
+  dependencies:
+    anymatch: "npm:~3.1.2"
+    braces: "npm:~3.0.2"
+    fsevents: "npm:~2.3.2"
+    glob-parent: "npm:~5.1.2"
+    is-binary-path: "npm:~2.1.0"
+    is-glob: "npm:~4.0.1"
+    normalize-path: "npm:~3.0.0"
+    readdirp: "npm:~3.6.0"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  checksum: 10/c327fb07704443f8d15f7b4a7ce93b2f0bc0e6cea07ec28a7570aa22cd51fcf0379df589403976ea956c369f25aa82d84561947e227cd925902e1751371658df
   languageName: node
   linkType: hard
 
@@ -17800,6 +18078,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-rspack-plugin@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "eslint-rspack-plugin@npm:5.0.1"
+  dependencies:
+    micromatch: "npm:^4.0.8"
+    normalize-path: "npm:^3.0.0"
+    tinyglobby: "npm:^0.2.15"
+  peerDependencies:
+    "@rspack/core": ^1.0.8 || ^2.0.0
+    eslint: ^9.0.0 || ^10.0.0
+  peerDependenciesMeta:
+    "@rspack/core":
+      optional: true
+  checksum: 10/bd9995555b1f100be4d7db3843901f5819c6a38d8ef4545fe2d75bc7765a0d95622086d78f649e2a4a62a1a8c3f5e835ff737f7c1444c33dea33fc95282c570d
+  languageName: node
+  linkType: hard
+
 "eslint-scope@npm:5.1.1, eslint-scope@npm:^5.1.1":
   version: 5.1.1
   resolution: "eslint-scope@npm:5.1.1"
@@ -19289,12 +19584,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob-parent@npm:^5.1.2":
+"glob-parent@npm:^5.1.2, glob-parent@npm:~5.1.2":
   version: 5.1.2
   resolution: "glob-parent@npm:5.1.2"
   dependencies:
     is-glob: "npm:^4.0.1"
   checksum: 10/32cd106ce8c0d83731966d31517adb766d02c3812de49c30cfe0675c7c0ae6630c11214c54a5ae67aca882cf738d27fd7768f21aa19118b9245950554be07247
+  languageName: node
+  linkType: hard
+
+"glob-to-regex.js@npm:^1.0.0, glob-to-regex.js@npm:^1.0.1":
+  version: 1.2.0
+  resolution: "glob-to-regex.js@npm:1.2.0"
+  peerDependencies:
+    tslib: 2
+  checksum: 10/13034e642db479d75448bdd9f37de7451bef2879c394bfe3f8df6588e0479893e94059eaee77cdf50dce675607fb2395c132dcca0c9a559a6192e89b2ad0f134
   languageName: node
   linkType: hard
 
@@ -20414,6 +20718,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hyperdyperid@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "hyperdyperid@npm:1.2.0"
+  checksum: 10/64abb5568ff17aa08ac0175ae55e46e22831c5552be98acdd1692081db0209f36fff58b31432017b4e1772c178962676a2cc3c54e4d5d7f020d7710cec7ad7a6
+  languageName: node
+  linkType: hard
+
 "hyphenate-style-name@npm:^1.0.3":
   version: 1.0.4
   resolution: "hyphenate-style-name@npm:1.0.4"
@@ -20937,6 +21248,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-binary-path@npm:~2.1.0":
+  version: 2.1.0
+  resolution: "is-binary-path@npm:2.1.0"
+  dependencies:
+    binary-extensions: "npm:^2.0.0"
+  checksum: 10/078e51b4f956c2c5fd2b26bb2672c3ccf7e1faff38e0ebdba45612265f4e3d9fc3127a1fa8370bbf09eab61339203c3d3b7af5662cbf8be4030f8fac37745b0e
+  languageName: node
+  linkType: hard
+
 "is-boolean-object@npm:^1.2.1":
   version: 1.2.1
   resolution: "is-boolean-object@npm:1.2.1"
@@ -21068,7 +21388,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-glob@npm:^4.0.0, is-glob@npm:^4.0.1, is-glob@npm:^4.0.3":
+"is-glob@npm:^4.0.0, is-glob@npm:^4.0.1, is-glob@npm:^4.0.3, is-glob@npm:~4.0.1":
   version: 4.0.3
   resolution: "is-glob@npm:4.0.3"
   dependencies:
@@ -24508,6 +24828,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"memfs@npm:^4.64.0":
+  version: 4.68.0
+  resolution: "memfs@npm:4.68.0"
+  dependencies:
+    "@jsonjoy.com/fs-core": "npm:4.68.0"
+    "@jsonjoy.com/fs-fsa": "npm:4.68.0"
+    "@jsonjoy.com/fs-node": "npm:4.68.0"
+    "@jsonjoy.com/fs-node-builtins": "npm:4.68.0"
+    "@jsonjoy.com/fs-node-to-fsa": "npm:4.68.0"
+    "@jsonjoy.com/fs-node-utils": "npm:4.68.0"
+    "@jsonjoy.com/fs-print": "npm:4.68.0"
+    "@jsonjoy.com/fs-snapshot": "npm:4.68.0"
+    "@jsonjoy.com/json-pack": "npm:^1.11.0"
+    "@jsonjoy.com/util": "npm:^1.9.0"
+    glob-to-regex.js: "npm:^1.0.1"
+    thingies: "npm:^2.5.0"
+    tree-dump: "npm:^1.0.3"
+    tslib: "npm:^2.0.0"
+  checksum: 10/dcf6f297951041a6aa3b6c6995003c4cd40bb751b45a14583ae721c557cde8e3b23fde00c8bfd9e8389bfbf46a7ecce209e6b3b2da136ef11af3f549283c703d
+  languageName: node
+  linkType: hard
+
 "memoize-one@npm:6.0.0, memoize-one@npm:^6.0.0":
   version: 6.0.0
   resolution: "memoize-one@npm:6.0.0"
@@ -25898,7 +26240,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"normalize-path@npm:^3.0.0":
+"normalize-path@npm:^3.0.0, normalize-path@npm:~3.0.0":
   version: 3.0.0
   resolution: "normalize-path@npm:3.0.0"
   checksum: 10/88eeb4da891e10b1318c4b2476b6e2ecbeb5ff97d946815ffea7794c31a89017c70d7f34b3c2ebf23ef4e9fc9fb99f7dffe36da22011b5b5c6ffa34f4873ec20
@@ -27447,7 +27789,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.0.4, picomatch@npm:^2.2.3, picomatch@npm:^2.3.1":
+"picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.2.3, picomatch@npm:^2.3.1":
   version: 2.3.2
   resolution: "picomatch@npm:2.3.2"
   checksum: 10/b788ef8148a2415b9dec12f0bb350ae6a5830f8f1950e472abc2f5225494debf7d1b75eb031df0ceaea9e8ec3e7bad599e8dbf3c60d61b42be429ba41bff4426
@@ -29614,6 +29956,15 @@ __metadata:
   version: 5.0.0
   resolution: "readdirp@npm:5.0.0"
   checksum: 10/a17a591b51d8b912083660df159e8bd17305dc1a9ef27c869c818bd95ff59e3a6496f97e91e724ef433e789d559d24e39496ea1698822eb5719606dc9c1a923d
+  languageName: node
+  linkType: hard
+
+"readdirp@npm:~3.6.0":
+  version: 3.6.0
+  resolution: "readdirp@npm:3.6.0"
+  dependencies:
+    picomatch: "npm:^2.2.1"
+  checksum: 10/196b30ef6ccf9b6e18c4e1724b7334f72a093d011a99f3b5920470f0b3406a51770867b3e1ae9711f227ef7a7065982f6ee2ce316746b2cb42c88efe44297fe7
   languageName: node
   linkType: hard
 
@@ -32617,6 +32968,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"thingies@npm:^2.5.0":
+  version: 2.6.1
+  resolution: "thingies@npm:2.6.1"
+  peerDependencies:
+    tslib: ^2
+  checksum: 10/23fd7ec0ae386d9aa3e5fa69bf6d4d4a2e0305723c2aeef848f5513e845bb463b0f697727b53f31029e7cf949f12a413bf4a0ea5705dde3daa0c1feaa712822e
+  languageName: node
+  linkType: hard
+
 "throttle-debounce@npm:^3.0.1":
   version: 3.0.1
   resolution: "throttle-debounce@npm:3.0.1"
@@ -32872,6 +33232,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tree-dump@npm:^1.0.3, tree-dump@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "tree-dump@npm:1.1.0"
+  peerDependencies:
+    tslib: 2
+  checksum: 10/2c20118d2671996aa6f1ba1310cef1404fb525bde5d989ab542013f62b23a3633c0f0b32cbd516ee6205051ec21912b2470dabca006d19c9eba0740b567e2b60
+  languageName: node
+  linkType: hard
+
 "tree-kill@npm:^1.2.2":
   version: 1.2.2
   resolution: "tree-kill@npm:1.2.2"
@@ -32953,6 +33322,27 @@ __metadata:
   peerDependencies:
     typescript: ">=4.8.4"
   checksum: 10/d5f1936f5618c6ab6942a97b78802217540ced00e7501862ae1f578d9a3aa189fc06050e64cb8951d21f7088e5fd35f53d2bf0d0370a883861c7b05e993ebc44
+  languageName: node
+  linkType: hard
+
+"ts-checker-rspack-plugin@npm:^1.5.1":
+  version: 1.6.0
+  resolution: "ts-checker-rspack-plugin@npm:1.6.0"
+  dependencies:
+    "@rspack/lite-tapable": "npm:^1.1.2"
+    chokidar: "npm:^3.6.0"
+    memfs: "npm:^4.64.0"
+    picocolors: "npm:^1.1.1"
+  peerDependencies:
+    "@rspack/core": ^1.0.0 || ^2.0.0
+    "@typescript/native-preview": ^7.0.0-0
+    typescript: ">=3.8.0"
+  peerDependenciesMeta:
+    "@rspack/core":
+      optional: true
+    "@typescript/native-preview":
+      optional: true
+  checksum: 10/8616d2f1748310299ee9b497f20253c2ad236e060b25ddbd4afdc329a9116136ee52821c648677bcd81da9df5e1c07052a0298cac0deb05bfdfdf3f7f68f3216
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What is this feature?**

Adds `packages/grafana-plugin-configs/rspack.config.ts`, mirroring `webpack.config.ts` beside it. Nothing imports it — it lands inert. Flipping plugins over is a follow-up.

**Why do we need this feature?**

Step toward the rspack migration. Landing the config separately keeps the plugin switchover diff reviewable.

**Who is this feature for?**

Grafana frontend contributors.

**Which issue(s) does this PR fix?**:

Part of #129731 (epic #128309)

**Special notes for your reviewer:**

Scope: four decoupled plugin workspaces exist on main (azuremonitor, cloudwatch, grafana-testdata-datasource, graphite), not the ten in the issue.

Load-bearing lines, each commented and covered by a test that fails without it:
- `amd: {}` — without it the UMD `define.amd` check survives into the bundle, SystemJS's global `define` makes it truthy, and the plugin exports nothing.
- `EmitLicenseRspackPlugin` over a `CopyRspackPlugin` LICENSE entry — a single-file `from` makes the copy plugin scan the parent directory. Re-measured on @rspack/core 2.1.7: 3.9s vs 88ms for a local file (was ~16s on 2.1.1). Still worth the workaround.
- `BannerPlugin` `stage: OPTIMIZE_SIZE + 1` — swc has no comment predicate, so the banner is injected after minification.
- `compress.pure_funcs` over `drop_console` — swc's is boolean-only and would strip `warn`/`error`.
- `extractComments: true` — **not in the original spike.** TerserPlugin extracts `@license` banners to a `.LICENSE.txt` sidecar; rspack's minimizer doesn't, and `format.comments: false` then dropped them. azuremonitor was losing React's MIT notice.

Verified against real plugins (driven directly, nothing wired):

| plugin | webpack | rspack | assets |
|---|---|---|---|
| graphite | 125KiB | 121KiB | identical |
| grafana-testdata-datasource | 242KiB | 239KiB | identical |
| cloudwatch | 317KiB | 307KiB | identical |
| azuremonitor | 441KiB | 425KiB | chunk id only |

Dev mode: both plugins load, 911 TS errors — same count as webpack.

Not covered by tests: nx `build`/`dev` targets and watch rebuilds.

`%VERSION%` substitution **is implemented** — `ReplaceInFileWebpackPlugin` is wired exactly as in `webpack.config.ts`, including the build-date and plugin-id replacements. It is not test-covered because it writes to the real filesystem after emit, so the probes filter it out.

Tests extend the existing `test:rspack` vitest project. Jest can't load this package (ESM), so `jest.config.js` ignores it — measured as excluding exactly one file, 2246 → 2245 collected.

`yarn.lock` grows ~400 lines: `@rspack/core`, `eslint-rspack-plugin`, `ts-checker-rspack-plugin` (config imports both), `vitest` (lint requires it declared). All already resolve from root. Costs one e2e cache invalidation. `@rspack/cli` deliberately deferred to the follow-up.

`yarn plugin:build` and `yarn build` unchanged.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

