### PR TITLE
fix(navtree): label Assistant nav as AI

### DIFF
--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -591,7 +591,7 @@ func (s *ServiceImpl) readNavigationSettings() {
 		"grafana-labelmanagement-app":      {SectionID: navtree.NavIDAlertsAndIncidents, SortWeight: 5, Text: "Label management"},
 		"grafana-incident-app":             {SectionID: navtree.NavIDAlertsAndIncidents, SortWeight: 6, Text: "Incident"},
 		"grafana-oncall-app":               {SectionID: navtree.NavIDAlertsAndIncidents, SortWeight: 7, Text: "OnCall"},
-		"grafana-assistant-app":            {SectionID: navtree.NavIDRoot, SortWeight: navtree.WeightAssistant, Text: "Assistant", SubTitle: "AI-powered assistant for Grafana", Icon: "ai-sparkle"},
+		"grafana-assistant-app":            {SectionID: navtree.NavIDRoot, SortWeight: navtree.WeightAssistant, Text: "AI", SubTitle: "AI-powered assistant for Grafana", Icon: "ai-sparkle"},
 		"grafana-ml-app":                   {SectionID: navtree.NavIDRoot, SortWeight: navtree.WeightAIAndML, Text: "Machine Learning", SubTitle: "Explore AI and machine learning features", Icon: "gf-ml-alt"},
 		"grafana-cloud-link-app":           {SectionID: navtree.NavIDCfgPlugins, SortWeight: 3},
 		"grafana-adaptive-metrics-app":     {SectionID: navtree.NavIDAdaptiveTelemetry, SortWeight: 1},

--- a/pkg/services/navtree/navtreeimpl/applinks_test.go
+++ b/pkg/services/navtree/navtreeimpl/applinks_test.go
@@ -902,6 +902,14 @@ func TestAddAppLinksAccessControl(t *testing.T) {
 	})
 }
 
+func TestReadNavigationSettingsAssistantLabel(t *testing.T) {
+	service := ServiceImpl{cfg: setting.NewCfg()}
+
+	service.readNavigationSettings()
+
+	require.Equal(t, "AI", service.navigationAppConfig[assistantAppID].Text)
+}
+
 func TestProcessAssistantAppPlugin(t *testing.T) {
 	httpReq, _ := http.NewRequest(http.MethodGet, "", nil)
 	reqCtx := &contextmodel.ReqContext{


### PR DESCRIPTION
## What

Renames the Grafana Assistant app top-level navigation label to `AI` and adds a regression test.

## Why

The app now contains multiple AI surfaces, so the top-level menu label should match the product navigation.
"Workspaces" will be renamed into "Assistant" once this change is in place.

## Testing

- `mise exec -- go test ./pkg/services/navtree/navtreeimpl -run 'Test(ReadNavigationSettingsAssistantLabel|ProcessAssistantAppPlugin)' -count=1`