### PR TITLE
Alerting: send hysteresis loaded dimensions as a plain array

### DIFF
--- a/pkg/expr/hysteresis.go
+++ b/pkg/expr/hysteresis.go
@@ -102,10 +102,13 @@ func NewHysteresisCommand(refID string, referenceVar string, loadCondition Thres
 	}, nil
 }
 
-// FingerprintsFromFrame converts data.Frame to Fingerprints.
+// fingerprintsFromFrame converts data.Frame to Fingerprints.
 // The input data frame must have a single field of uint64 type.
 // Returns error if the input data frame has invalid format
-func FingerprintsFromFrame(frame *data.Frame) (Fingerprints, error) {
+//
+// Deprecated: only for reading the deprecated loadedDimensions field. Fingerprints now travel as a
+// plain array, which needs no conversion.
+func fingerprintsFromFrame(frame *data.Frame) (Fingerprints, error) {
 	frameType, frameVersion := frame.TypeInfo("")
 	if frameType != "fingerprints" {
 		return nil, fmt.Errorf("invalid format of loaded dimensions frame: expected frame type 'fingerprints'")
@@ -136,8 +139,11 @@ func FingerprintsFromFrame(frame *data.Frame) (Fingerprints, error) {
 	return result, nil
 }
 
-// FingerprintsToFrame converts Fingerprints to data.Frame.
-func FingerprintsToFrame(fingerprints Fingerprints) *data.Frame {
+// fingerprintsToFrame converts Fingerprints to data.Frame.
+//
+// Deprecated: only for writing the deprecated loadedDimensions field. See
+// SetLoadedFingerprintsToHysteresisCommand.
+func fingerprintsToFrame(fingerprints Fingerprints) *data.Frame {
 	fp := make([]uint64, 0, len(fingerprints))
 	for fingerprint := range fingerprints {
 		fp = append(fp, uint64(fingerprint))

--- a/pkg/expr/hysteresis.go
+++ b/pkg/expr/hysteresis.go
@@ -105,9 +105,6 @@ func NewHysteresisCommand(refID string, referenceVar string, loadCondition Thres
 // fingerprintsFromFrame converts data.Frame to Fingerprints.
 // The input data frame must have a single field of uint64 type.
 // Returns error if the input data frame has invalid format
-//
-// Deprecated: only for reading the deprecated loadedDimensions field. Fingerprints now travel as a
-// plain array, which needs no conversion.
 func fingerprintsFromFrame(frame *data.Frame) (Fingerprints, error) {
 	frameType, frameVersion := frame.TypeInfo("")
 	if frameType != "fingerprints" {
@@ -140,9 +137,6 @@ func fingerprintsFromFrame(frame *data.Frame) (Fingerprints, error) {
 }
 
 // fingerprintsToFrame converts Fingerprints to data.Frame.
-//
-// Deprecated: only for writing the deprecated loadedDimensions field. See
-// SetLoadedFingerprintsToHysteresisCommand.
 func fingerprintsToFrame(fingerprints Fingerprints) *data.Frame {
 	fp := make([]uint64, 0, len(fingerprints))
 	for fingerprint := range fingerprints {

--- a/pkg/expr/hysteresis_test.go
+++ b/pkg/expr/hysteresis_test.go
@@ -175,7 +175,7 @@ func TestLoadedDimensionsFromFrame(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			result, err := FingerprintsFromFrame(testCase.frame)
+			result, err := fingerprintsFromFrame(testCase.frame)
 			if testCase.expectedError {
 				require.Error(t, err)
 			} else {
@@ -212,8 +212,8 @@ func TestFingerprintsToFrame(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			frame := FingerprintsToFrame(testCase.input)
-			actual, err := FingerprintsFromFrame(frame)
+			frame := fingerprintsToFrame(testCase.input)
+			actual, err := fingerprintsFromFrame(frame)
 			require.NoError(t, err)
 			require.EqualValues(t, testCase.expected, actual)
 		})

--- a/pkg/expr/query.types.json
+++ b/pkg/expr/query.types.json
@@ -297,7 +297,7 @@
     {
       "metadata": {
         "name": "threshold",
-        "resourceVersion": "1786389239949",
+        "resourceVersion": "1786465221559",
         "creationTimestamp": "2024-02-21T22:09:26Z"
       },
       "spec": {
@@ -350,10 +350,7 @@
                     "type": "object"
                   },
                   "loadedDimensions": {
-                    "additionalProperties": true,
-                    "description": "Deprecated: use LoadedFingerprints. Read only when LoadedFingerprints is absent.",
-                    "type": "object",
-                    "x-grafana-type": "data.DataFrame"
+                    "description": "Deprecated: use LoadedFingerprints. Kept raw and decoded only when LoadedFingerprints is\nabsent, so an optional frame parsing error would not break everything"
                   },
                   "loadedFingerprints": {
                     "description": "Fingerprints of the series that are already firing. Supersedes LoadedDimensions",

--- a/pkg/expr/query.types.json
+++ b/pkg/expr/query.types.json
@@ -297,7 +297,7 @@
     {
       "metadata": {
         "name": "threshold",
-        "resourceVersion": "1709915973363",
+        "resourceVersion": "1786389239949",
         "creationTimestamp": "2024-02-21T22:09:26Z"
       },
       "spec": {
@@ -351,8 +351,16 @@
                   },
                   "loadedDimensions": {
                     "additionalProperties": true,
+                    "description": "Deprecated: use LoadedFingerprints. Read only when LoadedFingerprints is absent.",
                     "type": "object",
                     "x-grafana-type": "data.DataFrame"
+                  },
+                  "loadedFingerprints": {
+                    "description": "Fingerprints of the series that are already firing. Supersedes LoadedDimensions",
+                    "items": {
+                      "type": "integer"
+                    },
+                    "type": "array"
                   },
                   "unloadEvaluator": {
                     "additionalProperties": false,

--- a/pkg/expr/query.types.json
+++ b/pkg/expr/query.types.json
@@ -297,7 +297,7 @@
     {
       "metadata": {
         "name": "threshold",
-        "resourceVersion": "1786465221559",
+        "resourceVersion": "1786466011231",
         "creationTimestamp": "2024-02-21T22:09:26Z"
       },
       "spec": {
@@ -353,9 +353,9 @@
                     "description": "Deprecated: use LoadedFingerprints. Kept raw and decoded only when LoadedFingerprints is\nabsent, so an optional frame parsing error would not break everything"
                   },
                   "loadedFingerprints": {
-                    "description": "Fingerprints of the series that are already firing. Supersedes LoadedDimensions",
+                    "description": "Fingerprints of the series that are already firing, encoded as decimal strings to preserve their full uint64 precision through untyped JSON decoding. Supersedes LoadedDimensions",
                     "items": {
-                      "type": "integer"
+                      "type": "string"
                     },
                     "type": "array"
                   },

--- a/pkg/expr/threshold.go
+++ b/pkg/expr/threshold.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+
 	"github.com/grafana/grafana/pkg/expr/mathexp"
 	"github.com/grafana/grafana/pkg/expr/metrics"
 	"github.com/grafana/grafana/pkg/infra/tracing"
@@ -155,8 +156,14 @@ func UnmarshalThresholdCommand(rn *rawNode) (Command, error) {
 		}
 		unloading.Invert = true
 		var d Fingerprints
-		if firstCondition.LoadedDimensions != nil {
-			d, err = FingerprintsFromFrame(firstCondition.LoadedDimensions)
+		switch {
+		case firstCondition.LoadedFingerprints != nil:
+			d = make(Fingerprints, len(firstCondition.LoadedFingerprints))
+			for _, fp := range firstCondition.LoadedFingerprints {
+				d[data.Fingerprint(fp)] = struct{}{}
+			}
+		case firstCondition.LoadedDimensions != nil:
+			d, err = fingerprintsFromFrame(firstCondition.LoadedDimensions)
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse loaded dimensions: %w", err)
 			}
@@ -235,9 +242,14 @@ type ThresholdCommandConfig struct {
 }
 
 type ThresholdConditionJSON struct {
-	Evaluator        ConditionEvalJSON  `json:"evaluator"`
-	UnloadEvaluator  *ConditionEvalJSON `json:"unloadEvaluator,omitempty"`
-	LoadedDimensions *data.Frame        `json:"loadedDimensions,omitempty"`
+	Evaluator       ConditionEvalJSON  `json:"evaluator"`
+	UnloadEvaluator *ConditionEvalJSON `json:"unloadEvaluator,omitempty"`
+
+	// Fingerprints of the series that are already firing. Supersedes LoadedDimensions
+	LoadedFingerprints []uint64 `json:"loadedFingerprints,omitempty"`
+
+	// Deprecated: use LoadedFingerprints. Read only when LoadedFingerprints is absent.
+	LoadedDimensions *data.Frame `json:"loadedDimensions,omitempty"`
 }
 
 // IsHysteresisExpression returns true if the raw model describes a hysteresis command:
@@ -252,7 +264,8 @@ func IsHysteresisExpression(query map[string]any) bool {
 	return c != nil
 }
 
-// SetLoadedDimensionsToHysteresisCommand mutates the input map and sets field "conditions[0].loadedMetrics" with the data frame created from the provided fingerprints.
+// SetLoadedDimensionsToHysteresisCommand mutates the input map and sets field
+// "conditions[0].loadedFingerprints" to the provided fingerprints.
 func SetLoadedDimensionsToHysteresisCommand(query map[string]any, fingerprints Fingerprints) error {
 	condition, err := getConditionForHysteresisCommand(query)
 	if err != nil {
@@ -261,7 +274,23 @@ func SetLoadedDimensionsToHysteresisCommand(query map[string]any, fingerprints F
 	if condition == nil {
 		return errors.New("not a hysteresis command")
 	}
-	fr := FingerprintsToFrame(fingerprints)
+	fp := make([]uint64, 0, len(fingerprints))
+	for fingerprint := range fingerprints {
+		fp = append(fp, uint64(fingerprint))
+	}
+	condition["loadedFingerprints"] = fp
+	return nil
+}
+
+func setLoadedDimensionsToHysteresisCommandAsFrame(query map[string]any, fingerprints Fingerprints) error {
+	condition, err := getConditionForHysteresisCommand(query)
+	if err != nil {
+		return err
+	}
+	if condition == nil {
+		return errors.New("not a hysteresis command")
+	}
+	fr := fingerprintsToFrame(fingerprints)
 	condition["loadedDimensions"] = fr
 	return nil
 }

--- a/pkg/expr/threshold.go
+++ b/pkg/expr/threshold.go
@@ -1,6 +1,7 @@
 package expr
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -293,31 +294,24 @@ func SetLoadedDimensionsToHysteresisCommand(query map[string]any, fingerprints F
 }
 
 func decodeLoadedDimensionsFrame(raw json.RawMessage) (*data.Frame, error) {
+	schemaIndex := bytes.Index(raw, []byte(`"schema"`))
+	dataIndex := bytes.Index(raw, []byte(`"data"`))
+	if schemaIndex >= 0 && dataIndex >= 0 && dataIndex < schemaIndex {
+		// this is the last resort of fixing the frame. It's a temporary dirty hack to workaround shuffling of json keys
+		// by the querier pipeline until it's switched to loadedFingerprints array
+		reordered, ok := schemaBeforeData(raw)
+		if ok {
+			raw = reordered
+		}
+	}
 	frame := &data.Frame{}
-	err := frame.UnmarshalJSON(raw)
-	if err == nil {
-		return frame, nil
-	}
-	// check if the error is due to malformed key order.
-	// See: https://github.com/grafana/grafana-plugin-sdk-go/blob/cc0b49b8370162cf7f321ed3b323a403c3308546/data/frame_json.go#L299-L301
-	if !strings.Contains(err.Error(), "malformed key order") {
+	if err := frame.UnmarshalJSON(raw); err != nil {
 		return nil, err
 	}
-
-	reordered, ok := schemaBeforeData(raw)
-	if !ok {
-		return nil, err
-	}
-	retried := &data.Frame{}
-	if retryErr := retried.UnmarshalJSON(reordered); retryErr != nil {
-		return nil, retryErr
-	}
-	return retried, nil
+	return frame, nil
 }
 
 func schemaBeforeData(frame json.RawMessage) (json.RawMessage, bool) {
-	// this is the last resort of fixing the frame. It's a temporary dirty hack to workaround shuffling of json keys
-	// by the querier pipeline until it's switched to loadedFingerprints array
 	var parts struct {
 		Schema json.RawMessage `json:"schema"`
 		Data   json.RawMessage `json:"data"`

--- a/pkg/expr/threshold.go
+++ b/pkg/expr/threshold.go
@@ -156,14 +156,18 @@ func UnmarshalThresholdCommand(rn *rawNode) (Command, error) {
 		}
 		unloading.Invert = true
 		var d Fingerprints
-		switch {
-		case firstCondition.LoadedFingerprints != nil:
+		if firstCondition.LoadedFingerprints != nil {
 			d = make(Fingerprints, len(firstCondition.LoadedFingerprints))
 			for _, fp := range firstCondition.LoadedFingerprints {
 				d[data.Fingerprint(fp)] = struct{}{}
 			}
-		case firstCondition.LoadedDimensions != nil:
-			d, err = fingerprintsFromFrame(firstCondition.LoadedDimensions)
+		} else if len(firstCondition.LoadedDimensions) > 0 && string(firstCondition.LoadedDimensions) != "null" {
+			// TODO yuri: This is a temporary workaround. Delete it once everything is switched to loadedFingerprints field
+			frame, err := decodeLoadedDimensionsFrame(firstCondition.LoadedDimensions)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse loaded dimensions: %w", err)
+			}
+			d, err = fingerprintsFromFrame(frame)
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse loaded dimensions: %w", err)
 			}
@@ -248,8 +252,9 @@ type ThresholdConditionJSON struct {
 	// Fingerprints of the series that are already firing. Supersedes LoadedDimensions
 	LoadedFingerprints []uint64 `json:"loadedFingerprints,omitempty"`
 
-	// Deprecated: use LoadedFingerprints. Read only when LoadedFingerprints is absent.
-	LoadedDimensions *data.Frame `json:"loadedDimensions,omitempty"`
+	// Deprecated: use LoadedFingerprints. Kept raw and decoded only when LoadedFingerprints is
+	// absent, so an optional frame parsing error would not break everything
+	LoadedDimensions json.RawMessage `json:"loadedDimensions,omitempty"`
 }
 
 // IsHysteresisExpression returns true if the raw model describes a hysteresis command:
@@ -282,7 +287,53 @@ func SetLoadedDimensionsToHysteresisCommand(query map[string]any, fingerprints F
 	return nil
 }
 
-func setLoadedDimensionsToHysteresisCommandAsFrame(query map[string]any, fingerprints Fingerprints) error {
+func decodeLoadedDimensionsFrame(raw json.RawMessage) (*data.Frame, error) {
+	frame := &data.Frame{}
+	err := frame.UnmarshalJSON(raw)
+	if err == nil {
+		return frame, nil
+	}
+	// check if the error is due to malformed key order.
+	// See: https://github.com/grafana/grafana-plugin-sdk-go/blob/cc0b49b8370162cf7f321ed3b323a403c3308546/data/frame_json.go#L299-L301
+	if !strings.Contains(err.Error(), "malformed key order") {
+		return nil, err
+	}
+
+	reordered, ok := schemaBeforeData(raw)
+	if !ok {
+		return nil, err
+	}
+	retried := &data.Frame{}
+	if retryErr := retried.UnmarshalJSON(reordered); retryErr != nil {
+		return nil, retryErr
+	}
+	return retried, nil
+}
+
+func schemaBeforeData(frame json.RawMessage) (json.RawMessage, bool) {
+	// this is the last resort of fixing the frame. It's a temporary dirty hack to workaround shuffling of json keys
+	// by the querier pipeline until it's switched to loadedFingerprints array
+	var parts struct {
+		Schema json.RawMessage `json:"schema"`
+		Data   json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(frame, &parts); err != nil || parts.Schema == nil || parts.Data == nil {
+		return nil, false
+	}
+	out := make([]byte, 0, len(frame))
+	out = append(out, `{"schema":`...)
+	out = append(out, parts.Schema...)
+	out = append(out, `,"data":`...)
+	out = append(out, parts.Data...)
+	return append(out, '}'), true
+}
+
+// SetLoadedDimensionsToHysteresisCommandAsFrame mutates the input map and sets field
+// "conditions[0].loadedDimensions" with the data frame created from the provided fingerprints.
+//
+// Deprecated: use SetLoadedDimensionsToHysteresisCommand. Only for writing alongside it, so that a
+// reader that predates loadedFingerprints still finds something it understands.
+func SetLoadedDimensionsToHysteresisCommandAsFrame(query map[string]any, fingerprints Fingerprints) error {
 	condition, err := getConditionForHysteresisCommand(query)
 	if err != nil {
 		return err
@@ -290,8 +341,7 @@ func setLoadedDimensionsToHysteresisCommandAsFrame(query map[string]any, fingerp
 	if condition == nil {
 		return errors.New("not a hysteresis command")
 	}
-	fr := fingerprintsToFrame(fingerprints)
-	condition["loadedDimensions"] = fr
+	condition["loadedDimensions"] = fingerprintsToFrame(fingerprints)
 	return nil
 }
 

--- a/pkg/expr/threshold.go
+++ b/pkg/expr/threshold.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -158,7 +159,11 @@ func UnmarshalThresholdCommand(rn *rawNode) (Command, error) {
 		var d Fingerprints
 		if firstCondition.LoadedFingerprints != nil {
 			d = make(Fingerprints, len(firstCondition.LoadedFingerprints))
-			for _, fp := range firstCondition.LoadedFingerprints {
+			for _, value := range firstCondition.LoadedFingerprints {
+				fp, err := strconv.ParseUint(value, 10, 64)
+				if err != nil {
+					return nil, fmt.Errorf("failed to parse loaded fingerprint %q: %w", value, err)
+				}
 				d[data.Fingerprint(fp)] = struct{}{}
 			}
 		} else if len(firstCondition.LoadedDimensions) > 0 && string(firstCondition.LoadedDimensions) != "null" {
@@ -249,8 +254,8 @@ type ThresholdConditionJSON struct {
 	Evaluator       ConditionEvalJSON  `json:"evaluator"`
 	UnloadEvaluator *ConditionEvalJSON `json:"unloadEvaluator,omitempty"`
 
-	// Fingerprints of the series that are already firing. Supersedes LoadedDimensions
-	LoadedFingerprints []uint64 `json:"loadedFingerprints,omitempty"`
+	// Fingerprints of the series that are already firing, encoded as decimal strings to preserve their full uint64 precision through untyped JSON decoding. Supersedes LoadedDimensions
+	LoadedFingerprints []string `json:"loadedFingerprints,omitempty"`
 
 	// Deprecated: use LoadedFingerprints. Kept raw and decoded only when LoadedFingerprints is
 	// absent, so an optional frame parsing error would not break everything
@@ -279,9 +284,9 @@ func SetLoadedDimensionsToHysteresisCommand(query map[string]any, fingerprints F
 	if condition == nil {
 		return errors.New("not a hysteresis command")
 	}
-	fp := make([]uint64, 0, len(fingerprints))
+	fp := make([]string, 0, len(fingerprints))
 	for fingerprint := range fingerprints {
-		fp = append(fp, uint64(fingerprint))
+		fp = append(fp, strconv.FormatUint(uint64(fingerprint), 10))
 	}
 	condition["loadedFingerprints"] = fp
 	return nil

--- a/pkg/expr/threshold_test.go
+++ b/pkg/expr/threshold_test.go
@@ -318,7 +318,7 @@ func TestUnmarshalThresholdCommand(t *testing.T) {
 				        ],
 				        "type": "lt"
 				      },
-				      "loadedFingerprints": [18446744073709551615,2,3,4,5]
+				      "loadedFingerprints": ["18446744073709551615","2","3","4","5"]
 				    }
 				  ]
 				}`,
@@ -554,12 +554,9 @@ func TestSetLoadedDimensionsToHysteresisCommand(t *testing.T) {
 func TestLoadedFingerprintsEncoding(t *testing.T) {
 	const model = `{ "type": "threshold", "conditions": [{ "evaluator": { "params": [5], "type": "gt" }, "unloadEvaluator" : {"params": [2], "type": "lt"}}], "expression": "A" }`
 
-	// The point of the array encoding. A query reaches the expression service through callers that
-	// re-serialise it via simplejson, which sorts object keys on the way out — the ordering the frame
-	// encoding cannot survive. Note this says nothing about integer precision: that holds because
-	// simplejson decodes with UseNumber, and a decoder that reads JSON numbers into float64 instead
-	// would mangle a fingerprint above 2^53 in either encoding, frame included.
-	t.Run("survives the simplejson round-trip that sorts keys", func(t *testing.T) {
+	// A query reaches the expression service through callers that re-serialise it via simplejson,
+	// which sorts object keys on the way out — the ordering the frame encoding cannot survive.
+	t.Run("survives JSON round-trips", func(t *testing.T) {
 		query := map[string]any{}
 		require.NoError(t, json.Unmarshal([]byte(model), &query))
 		fingerprints := Fingerprints{math.MaxUint64: {}, 2: {}, 3: {}}
@@ -570,6 +567,11 @@ func TestLoadedFingerprintsEncoding(t *testing.T) {
 		sj, err := simplejson.NewJson(raw)
 		require.NoError(t, err)
 		raw, err = sj.MarshalJSON()
+		require.NoError(t, err)
+
+		var generic map[string]any
+		require.NoError(t, json.Unmarshal(raw, &generic))
+		raw, err = json.Marshal(generic)
 		require.NoError(t, err)
 
 		cmd, err := UnmarshalThresholdCommand(&rawNode{RefID: "B", QueryRaw: raw})
@@ -584,7 +586,7 @@ func TestLoadedFingerprintsEncoding(t *testing.T) {
 		require.NoError(t, SetLoadedDimensionsToHysteresisCommandAsFrame(query, Fingerprints{2: {}, 3: {}}))
 
 		condition := query["conditions"].([]any)[0].(map[string]any)
-		require.ElementsMatch(t, []uint64{2, 3}, condition["loadedFingerprints"])
+		require.ElementsMatch(t, []string{"2", "3"}, condition["loadedFingerprints"])
 		require.NotNil(t, condition["loadedDimensions"], "the frame is still written for readers that predate loadedFingerprints")
 	})
 

--- a/pkg/expr/threshold_test.go
+++ b/pkg/expr/threshold_test.go
@@ -265,9 +265,7 @@ func TestUnmarshalThresholdCommand(t *testing.T) {
 		},
 		{
 			// A caller that re-serialises the query through a map sorts the keys, which puts "data" ahead
-			// of "schema" — an order the frame decoder cannot read in its single pass. Decoding retries
-			// with the keys put back in order, so this still parses. Guards the error-string match in
-			// decodeLoadedDimensionsFrame: if the SDK rewords it, this case fails.
+			// of "schema" — an order the frame decoder cannot read in its single pass.
 			description: "frame loaded dimensions ordered data first are reordered and read",
 			query: `{
 				  "conditions": [

--- a/pkg/expr/threshold_test.go
+++ b/pkg/expr/threshold_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/expr/mathexp"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 )
@@ -261,6 +263,70 @@ func TestUnmarshalThresholdCommand(t *testing.T) {
 				require.EqualValues(t, []uint64{2, 3, 4, 5, 18446744073709551615}, actual)
 			},
 		},
+		{
+			// The frame encoding cannot survive a caller that re-serialises the query through a map:
+			// sorting the keys puts "data" ahead of "schema", and the frame decoder needs the schema
+			// first. Documented rather than worked around — such callers should send the array below.
+			description: "frame loaded dimensions ordered data first are rejected",
+			query: `{
+				  "conditions": [
+				    {
+				      "evaluator": {
+				        "params": [
+				          100
+				        ],
+				        "type": "gt"
+				      },
+				      "loadedDimensions": {"data":{"values":[[18446744073709551615,2,3,4,5]]},"schema":{"fields":[{"name":"fingerprints","type":"number","typeInfo":{"frame":"uint64"}}],"meta":{"type":"fingerprints","typeVersion":[1,0]},"name":"test"}},
+				      "unloadEvaluator": {
+				        "params": [
+				          31
+				        ],
+				        "type": "lt"
+				      }
+				    }
+				  ],
+				  "expression": "B"
+				}`,
+			shouldError:   true,
+			expectedError: "malformed key order or frame without schema",
+		},
+		{
+			description: "unmarshal as hysteresis command from loadedFingerprints",
+			query: `{
+				  "expression": "B",
+				  "conditions": [
+				    {
+				      "evaluator": {
+				        "params": [
+				          100
+				        ],
+				        "type": "gt"
+				      },
+				      "unloadEvaluator": {
+				        "params": [
+				          31
+				        ],
+				        "type": "lt"
+				      },
+				      "loadedFingerprints": [18446744073709551615,2,3,4,5]
+				    }
+				  ]
+				}`,
+			assert: func(t *testing.T, c Command) {
+				require.IsType(t, &HysteresisCommand{}, c)
+				cmd := c.(*HysteresisCommand)
+				actual := make([]uint64, 0, len(cmd.LoadedDimensions))
+				for fingerprint := range cmd.LoadedDimensions {
+					actual = append(actual, uint64(fingerprint))
+				}
+				sort.Slice(actual, func(i, j int) bool {
+					return actual[i] < actual[j]
+				})
+
+				require.EqualValues(t, []uint64{2, 3, 4, 5, 18446744073709551615}, actual)
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -473,6 +539,46 @@ func TestSetLoadedDimensionsToHysteresisCommand(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, fingerprints, cmd.(*HysteresisCommand).LoadedDimensions)
+	})
+}
+
+func TestLoadedFingerprintsEncoding(t *testing.T) {
+	const model = `{ "type": "threshold", "conditions": [{ "evaluator": { "params": [5], "type": "gt" }, "unloadEvaluator" : {"params": [2], "type": "lt"}}], "expression": "A" }`
+
+	// The point of the array encoding. A query reaches the expression service through callers that
+	// re-serialise it via simplejson, which sorts object keys on the way out — the ordering the frame
+	// encoding cannot survive. Note this says nothing about integer precision: that holds because
+	// simplejson decodes with UseNumber, and a decoder that reads JSON numbers into float64 instead
+	// would mangle a fingerprint above 2^53 in either encoding, frame included.
+	t.Run("survives the simplejson round-trip that sorts keys", func(t *testing.T) {
+		query := map[string]any{}
+		require.NoError(t, json.Unmarshal([]byte(model), &query))
+		fingerprints := Fingerprints{math.MaxUint64: {}, 2: {}, 3: {}}
+		require.NoError(t, SetLoadedDimensionsToHysteresisCommand(query, fingerprints))
+
+		raw, err := json.Marshal(query)
+		require.NoError(t, err)
+		sj, err := simplejson.NewJson(raw)
+		require.NoError(t, err)
+		raw, err = sj.MarshalJSON()
+		require.NoError(t, err)
+
+		cmd, err := UnmarshalThresholdCommand(&rawNode{RefID: "B", QueryRaw: raw})
+		require.NoError(t, err)
+		require.Equal(t, fingerprints, cmd.(*HysteresisCommand).LoadedDimensions)
+	})
+
+	t.Run("takes precedence over the deprecated frame", func(t *testing.T) {
+		query := map[string]any{}
+		require.NoError(t, json.Unmarshal([]byte(model), &query))
+		require.NoError(t, setLoadedDimensionsToHysteresisCommandAsFrame(query, Fingerprints{2: {}, 3: {}}))
+		require.NoError(t, SetLoadedDimensionsToHysteresisCommand(query, Fingerprints{7: {}}))
+
+		raw, err := json.Marshal(query)
+		require.NoError(t, err)
+		cmd, err := UnmarshalThresholdCommand(&rawNode{RefID: "B", QueryRaw: raw})
+		require.NoError(t, err)
+		require.Equal(t, Fingerprints{7: {}}, cmd.(*HysteresisCommand).LoadedDimensions)
 	})
 }
 

--- a/pkg/expr/threshold_test.go
+++ b/pkg/expr/threshold_test.go
@@ -264,10 +264,11 @@ func TestUnmarshalThresholdCommand(t *testing.T) {
 			},
 		},
 		{
-			// The frame encoding cannot survive a caller that re-serialises the query through a map:
-			// sorting the keys puts "data" ahead of "schema", and the frame decoder needs the schema
-			// first. Documented rather than worked around — such callers should send the array below.
-			description: "frame loaded dimensions ordered data first are rejected",
+			// A caller that re-serialises the query through a map sorts the keys, which puts "data" ahead
+			// of "schema" — an order the frame decoder cannot read in its single pass. Decoding retries
+			// with the keys put back in order, so this still parses. Guards the error-string match in
+			// decodeLoadedDimensionsFrame: if the SDK rewords it, this case fails.
+			description: "frame loaded dimensions ordered data first are reordered and read",
 			query: `{
 				  "conditions": [
 				    {
@@ -288,8 +289,16 @@ func TestUnmarshalThresholdCommand(t *testing.T) {
 				  ],
 				  "expression": "B"
 				}`,
-			shouldError:   true,
-			expectedError: "malformed key order or frame without schema",
+			assert: func(t *testing.T, c Command) {
+				require.IsType(t, &HysteresisCommand{}, c)
+				cmd := c.(*HysteresisCommand)
+				actual := make([]uint64, 0, len(cmd.LoadedDimensions))
+				for fingerprint := range cmd.LoadedDimensions {
+					actual = append(actual, uint64(fingerprint))
+				}
+				slices.Sort(actual)
+				require.EqualValues(t, []uint64{2, 3, 4, 5, 18446744073709551615}, actual)
+			},
 		},
 		{
 			description: "unmarshal as hysteresis command from loadedFingerprints",
@@ -568,17 +577,37 @@ func TestLoadedFingerprintsEncoding(t *testing.T) {
 		require.Equal(t, fingerprints, cmd.(*HysteresisCommand).LoadedDimensions)
 	})
 
-	t.Run("takes precedence over the deprecated frame", func(t *testing.T) {
+	t.Run("writes both encodings", func(t *testing.T) {
 		query := map[string]any{}
 		require.NoError(t, json.Unmarshal([]byte(model), &query))
-		require.NoError(t, setLoadedDimensionsToHysteresisCommandAsFrame(query, Fingerprints{2: {}, 3: {}}))
-		require.NoError(t, SetLoadedDimensionsToHysteresisCommand(query, Fingerprints{7: {}}))
+		require.NoError(t, SetLoadedDimensionsToHysteresisCommand(query, Fingerprints{2: {}, 3: {}}))
+		require.NoError(t, SetLoadedDimensionsToHysteresisCommandAsFrame(query, Fingerprints{2: {}, 3: {}}))
+
+		condition := query["conditions"].([]any)[0].(map[string]any)
+		require.ElementsMatch(t, []uint64{2, 3}, condition["loadedFingerprints"])
+		require.NotNil(t, condition["loadedDimensions"], "the frame is still written for readers that predate loadedFingerprints")
+	})
+
+	// When both encodings are present the array wins, so a stale or mangled frame beside it cannot
+	// change the outcome. Distinct fingerprints in each, otherwise the assertion cannot tell them apart.
+	t.Run("array takes precedence over the frame beside it", func(t *testing.T) {
+		query := map[string]any{}
+		require.NoError(t, json.Unmarshal([]byte(model), &query))
+		require.NoError(t, SetLoadedDimensionsToHysteresisCommandAsFrame(query, Fingerprints{7: {}}))
+		require.NoError(t, SetLoadedDimensionsToHysteresisCommand(query, Fingerprints{2: {}, 3: {}}))
 
 		raw, err := json.Marshal(query)
 		require.NoError(t, err)
+		// simplejson sorts object keys, which puts the frame's "data" ahead of its "schema".
+		sj, err := simplejson.NewJson(raw)
+		require.NoError(t, err)
+		raw, err = sj.MarshalJSON()
+		require.NoError(t, err)
+		require.Regexp(t, `"loadedDimensions":\{"data"`, string(raw), "frame must be reordered for this test to mean anything")
+
 		cmd, err := UnmarshalThresholdCommand(&rawNode{RefID: "B", QueryRaw: raw})
 		require.NoError(t, err)
-		require.Equal(t, Fingerprints{7: {}}, cmd.(*HysteresisCommand).LoadedDimensions)
+		require.Equal(t, Fingerprints{2: {}, 3: {}}, cmd.(*HysteresisCommand).LoadedDimensions)
 	})
 }
 

--- a/pkg/services/ngalert/models/alert_query_test.go
+++ b/pkg/services/ngalert/models/alert_query_test.go
@@ -258,9 +258,9 @@ func TestAlertQuery(t *testing.T) {
 				t.Run("can patch the command with loaded metrics", func(t *testing.T) {
 					require.NoError(t, tc.alertQuery.PatchHysteresisExpression(map[data.Fingerprint]struct{}{1: {}, 2: {}, 3: {}}))
 					condition := tc.alertQuery.modelProps["conditions"].([]any)[0].(map[string]any)
-					fingerprints, ok := condition["loadedFingerprints"].([]uint64)
+					fingerprints, ok := condition["loadedFingerprints"].([]string)
 					require.True(t, ok)
-					require.ElementsMatch(t, []uint64{1, 2, 3}, fingerprints)
+					require.ElementsMatch(t, []string{"1", "2", "3"}, fingerprints)
 
 					// The fingerprints have to reach the marshalled model, not just modelProps.
 					blob, err := tc.alertQuery.GetModel()

--- a/pkg/services/ngalert/models/alert_query_test.go
+++ b/pkg/services/ngalert/models/alert_query_test.go
@@ -257,11 +257,15 @@ func TestAlertQuery(t *testing.T) {
 			if tc.expectedIsHysteresis {
 				t.Run("can patch the command with loaded metrics", func(t *testing.T) {
 					require.NoError(t, tc.alertQuery.PatchHysteresisExpression(map[data.Fingerprint]struct{}{1: {}, 2: {}, 3: {}}))
-					data, ok := tc.alertQuery.modelProps["conditions"].([]any)[0].(map[string]any)["loadedDimensions"]
+					condition := tc.alertQuery.modelProps["conditions"].([]any)[0].(map[string]any)
+					fingerprints, ok := condition["loadedFingerprints"].([]uint64)
 					require.True(t, ok)
-					require.NotNil(t, data)
-					_, err := tc.alertQuery.GetModel()
+					require.ElementsMatch(t, []uint64{1, 2, 3}, fingerprints)
+
+					// The fingerprints have to reach the marshalled model, not just modelProps.
+					blob, err := tc.alertQuery.GetModel()
 					require.NoError(t, err)
+					require.Contains(t, string(blob), `"loadedFingerprints"`)
 				})
 			}
 		})


### PR DESCRIPTION
This PR introduces a new way to propagate fingerprints for loaded dimensions to hysteresis expression. 
1. It introduces a new field `loadedFingerprints` of type []string. This is done to avoid losing precision during potential re-marshaling in the query execution pipeline (because json represent values as float64 by default and big numbers can lose precision)
2. Deprecates the old way but keep it for backward compatibility. In the case of both fields is specified, it will read `loadedFingerprints` and fallback only if it's empty or undefined. 
3. Changes how the field `loadedDimensions` is parsed. Now the type is RawMessage and parsing happens only in the fallback path. The unmarshalling logic of data.Frame is very picky about the order of the fields in JSON, which can be broken during the re-marshaling process in the querier workflow. To work around this, the PR adds a check and fixes the payload before parsing. This is a temporary solution before the code path is removed completely. 