### PR TITLE
Notebooks: List Page - Backend Work

### DIFF
--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -17,6 +17,7 @@ const (
 	WeightDashboard
 	WeightExplore
 	WeightDrilldown
+	WeightNotebooks
 	WeightAssistant
 	WeightSigil
 	WeightAlerting
@@ -43,6 +44,7 @@ const (
 	NavIDDashboards           = "dashboards/browse"
 	NavIDExplore              = "explore"
 	NavIDDrilldown            = "drilldown"
+	NavIDNotebooks            = "notebooks"
 	NavIDAdaptiveTelemetry    = "adaptive-telemetry"
 	NavIDCfg                  = "cfg" // NavIDCfg is the id for org configuration navigation node
 	NavIDAlertsAndIncidents   = "alerts-and-incidents"

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -331,7 +331,7 @@ func (s *ServiceImpl) buildNotebooksNavLink(c *contextmodel.ReqContext) *navtree
 	return &navtree.NavLink{
 		Text:       "Notebooks",
 		Id:         navtree.NavIDNotebooks,
-		SubTitle:   "Investigation notebooks created from workspaces, dashboards, alerts, and incidents",
+		SubTitle:   "Investigation notebooks created from workspaces, dashboards, alerts, and incidents.",
 		Icon:       "book",
 		SortWeight: navtree.WeightNotebooks,
 		Url:        s.cfg.AppSubURL + "/notebooks",

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -148,6 +148,10 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 		})
 	}
 
+	if notebooksSection := s.buildNotebooksNavLink(c); notebooksSection != nil {
+		treeRoot.AddSection(notebooksSection)
+	}
+
 	if s.cfg.ProfileEnabled && c.IsSignedIn {
 		treeRoot.AddSection(s.getProfileNode(c))
 	}
@@ -299,6 +303,38 @@ func (s *ServiceImpl) getProfileNode(c *contextmodel.ReqContext) *navtree.NavLin
 		SortWeight: navtree.WeightProfile,
 		Children:   children,
 		RoundIcon:  true,
+	}
+}
+
+// buildNotebooksNavLink returns the top-level Notebooks section, or nil when the feature is off
+// or the user cannot read dashboards. Notebooks reuse dashboard RBAC actions, so an unscoped
+// dashboards:read is what grants access to the list page; the apiserver then filters the list
+// down to the notebooks the user may actually see.
+func (s *ServiceImpl) buildNotebooksNavLink(c *contextmodel.ReqContext) *navtree.NavLink {
+	if !c.IsSignedIn {
+		return nil
+	}
+
+	if !ac.HasAccess(s.accessControl, c)(ac.EvalPermission(dashboards.ActionDashboardsRead)) {
+		return nil
+	}
+
+	if !openfeature.NewDefaultClient().Boolean(
+		c.Req.Context(),
+		featuremgmt.FlagDashboardNotebooks,
+		false,
+		openfeature.TransactionContext(c.Req.Context()),
+	) {
+		return nil
+	}
+
+	return &navtree.NavLink{
+		Text:       "Notebooks",
+		Id:         navtree.NavIDNotebooks,
+		SubTitle:   "Investigation notebooks created from workspaces, dashboards, alerts, and incidents",
+		Icon:       "book",
+		SortWeight: navtree.WeightNotebooks,
+		Url:        s.cfg.AppSubURL + "/notebooks",
 	}
 }
 

--- a/pkg/services/navtree/navtreeimpl/navtree_test.go
+++ b/pkg/services/navtree/navtreeimpl/navtree_test.go
@@ -2,12 +2,16 @@ package navtreeimpl
 
 import (
 	"net/http"
+	"sync"
 	"testing"
 
+	"github.com/open-feature/go-sdk/openfeature"
+	"github.com/open-feature/go-sdk/openfeature/memprovider"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/authn/authntest"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
@@ -122,5 +126,73 @@ func TestBuildDashboardNavLinks(t *testing.T) {
 		navLinks := service.buildDashboardNavLinks(reqCtx)
 
 		require.False(t, hasPlaylistLink(navLinks), "expected unauthenticated user to not see the Playlists nav link")
+	})
+}
+
+// openfeatureTestMutex serializes tests that swap the global OpenFeature provider.
+var openfeatureTestMutex sync.Mutex
+
+func setOpenFeatureFlags(t *testing.T, flags map[string]bool) {
+	t.Helper()
+	openfeatureTestMutex.Lock()
+
+	inMem := make(map[string]memprovider.InMemoryFlag, len(flags))
+	for name, value := range flags {
+		inMem[name] = setting.NewInMemoryFlag(name, value)
+	}
+	provider, err := featuremgmt.CreateStaticProviderWithStandardFlags(inMem)
+	require.NoError(t, err)
+	require.NoError(t, openfeature.SetProviderAndWait(provider))
+
+	t.Cleanup(func() {
+		_ = openfeature.SetProviderAndWait(openfeature.NoopProvider{})
+		openfeatureTestMutex.Unlock()
+	})
+}
+
+func TestBuildNotebooksNavLink(t *testing.T) {
+	newService := func(canReadDashboards bool) *ServiceImpl {
+		return &ServiceImpl{
+			cfg:           setting.NewCfg(),
+			accessControl: actest.FakeAccessControl{ExpectedEvaluate: canReadDashboards},
+			features:      featuremgmt.WithFeatures(),
+		}
+	}
+
+	newReqCtx := func(isSignedIn bool) *contextmodel.ReqContext {
+		httpReq, _ := http.NewRequest(http.MethodGet, "", nil)
+		return &contextmodel.ReqContext{
+			SignedInUser: &user.SignedInUser{OrgRole: org.RoleViewer},
+			IsSignedIn:   isSignedIn,
+			Context:      &web.Context{Req: httpReq},
+		}
+	}
+
+	t.Run("Should show Notebooks for a signed-in user with dashboard read access when the flag is on", func(t *testing.T) {
+		setOpenFeatureFlags(t, map[string]bool{featuremgmt.FlagDashboardNotebooks: true})
+
+		link := newService(true).buildNotebooksNavLink(newReqCtx(true))
+
+		require.NotNil(t, link)
+		require.Equal(t, navtree.NavIDNotebooks, link.Id)
+		require.Equal(t, "/notebooks", link.Url)
+	})
+
+	t.Run("Should not show Notebooks when the flag is off", func(t *testing.T) {
+		setOpenFeatureFlags(t, map[string]bool{featuremgmt.FlagDashboardNotebooks: false})
+
+		require.Nil(t, newService(true).buildNotebooksNavLink(newReqCtx(true)))
+	})
+
+	t.Run("Should not show Notebooks without dashboard read access", func(t *testing.T) {
+		setOpenFeatureFlags(t, map[string]bool{featuremgmt.FlagDashboardNotebooks: true})
+
+		require.Nil(t, newService(false).buildNotebooksNavLink(newReqCtx(true)))
+	})
+
+	t.Run("Should not show Notebooks for an unauthenticated user", func(t *testing.T) {
+		setOpenFeatureFlags(t, map[string]bool{featuremgmt.FlagDashboardNotebooks: true})
+
+		require.Nil(t, newService(true).buildNotebooksNavLink(newReqCtx(false)))
 	})
 }

--- a/pkg/services/navtree/navtreeimpl/navtree_test.go
+++ b/pkg/services/navtree/navtreeimpl/navtree_test.go
@@ -135,6 +135,12 @@ var openfeatureTestMutex sync.Mutex
 func setOpenFeatureFlags(t *testing.T, flags map[string]bool) {
 	t.Helper()
 	openfeatureTestMutex.Lock()
+	// Registered before anything that can FailNow, so a failed assertion below cannot leave the
+	// mutex locked and deadlock the rest of the package.
+	t.Cleanup(func() {
+		_ = openfeature.SetProviderAndWait(openfeature.NoopProvider{})
+		openfeatureTestMutex.Unlock()
+	})
 
 	inMem := make(map[string]memprovider.InMemoryFlag, len(flags))
 	for name, value := range flags {
@@ -143,11 +149,6 @@ func setOpenFeatureFlags(t *testing.T, flags map[string]bool) {
 	provider, err := featuremgmt.CreateStaticProviderWithStandardFlags(inMem)
 	require.NoError(t, err)
 	require.NoError(t, openfeature.SetProviderAndWait(provider))
-
-	t.Cleanup(func() {
-		_ = openfeature.SetProviderAndWait(openfeature.NoopProvider{})
-		openfeatureTestMutex.Unlock()
-	})
 }
 
 func TestBuildNotebooksNavLink(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

> [!IMPORTANT]
> Goes in together with #130444 (frontend). This PR adds the nav entry; that one adds the `/notebooks` page it links to. Merging this one alone leaves a nav item whose route 404s — both are behind the same feature toggle, so there's no user impact either way.

**What is this feature?**

Adds a top-level **Notebooks** section to the nav tree, linking to `/notebooks`.

The section renders only when both are true:

- the `dashboard.notebooks` feature toggle is on (evaluated per request via OpenFeature)
- the user has `dashboards:read` on any scope

Notebooks reuse dashboard RBAC actions, so existing dashboard and folder grants already cover them and no new roles are needed. This is the same gate the "Starred" section uses, and it matches what the apiserver enforces for the `notebooks` resource.

**Why do we need this feature?**

Notebooks have no entry point in the UI today — the only route is `/notebook/:uid`, which you can reach only if you already know the UID. This makes them discoverable.

**Who is this feature for?**

Grafana users with dashboard access, once notebooks are enabled.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes grafana/grafana-enterprise#12981

**Special notes for your reviewer:**

- `WeightNotebooks` is inserted before `WeightAssistant`, which shifts the constants after it. Nothing references those weights numerically, so this is safe.
- The gating lives in `buildNotebooksNavLink`, which returns `nil` rather than being inlined in `GetNavTree`, so it can be unit tested directly (flag off / no `dashboards:read` / not signed in / all good).

Please check that:
- [ ] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
