### PR TITLE
Docs: MySQL quarterly update (FY27 Q3)

### DIFF
--- a/docs/sources/datasources/mysql/_index.md
+++ b/docs/sources/datasources/mysql/_index.md
@@ -16,12 +16,14 @@ labels:
 menuTitle: MySQL
 title: MySQL data source
 weight: 1000
-review_date: 2026-05-11
+review_date: 2026-08-10
 ---
 
 # MySQL data source
 
-Grafana ships with built-in support for MySQL.
+Grafana ships with the MySQL data source out of the box. It's preinstalled in both Grafana OSS and Grafana Enterprise, so there's nothing for you to install.
+Starting with Grafana 13.2, the data source is packaged as a standalone plugin that can be updated independently of Grafana releases. Refer to [Plugin updates](#plugin-updates) for details.
+
 You can query and visualize data from MySQL-compatible databases like [MariaDB](https://mariadb.org/) or [Percona Server](https://www.percona.com/).
 
 Use this data source to create dashboards, explore SQL data, and monitor MySQL-based workloads in real time.
@@ -64,6 +66,30 @@ The following documentation helps you get started with the MySQL data source:
 - [MySQL annotations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/mysql/annotations/)
 - [MySQL alerting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/mysql/alerting/)
 - [Troubleshoot MySQL data source issues](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/mysql/troubleshooting/)
+
+## Plugin updates
+
+Starting with Grafana 13.2, the MySQL data source is a standalone plugin, preinstalled in both Grafana OSS and Grafana Enterprise. This enables more frequent updates independent of Grafana releases. Grafana automatically checks the plugin catalog and installs the latest version on each server restart.
+
+To adjust this behavior:
+
+- **Opt out of auto-updates:** Set `preinstall_auto_update` to `false` in your [configuration file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/).
+- **Update manually:** Update at any time from the **Administration > Plugins** page without restarting Grafana.
+
+The standalone plugin requires Grafana 12.3.0 or later. The MySQL data source bundled with Grafana 13.1 and earlier continues to work as before. These versions are unaffected by the change.
+
+Users running Grafana 12.3.x through 13.1.x can install the standalone plugin from the plugin catalog if they want the latest features before upgrading to Grafana 13.2. To use the standalone plugin with Grafana 12.3.x through 13.1.x, add the following to your [configuration file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/):
+
+```ini
+[plugin.mysql]
+as_external = true
+
+[plugins]
+; Install the latest version on startup:
+preinstall_sync = mysql
+; Or install a specific version:
+; preinstall_sync = mysql@<version>
+```
 
 ## Additional resources
 

--- a/docs/sources/datasources/mysql/_index.md
+++ b/docs/sources/datasources/mysql/_index.md
@@ -21,12 +21,10 @@ review_date: 2026-08-10
 
 # MySQL data source
 
-Grafana ships with the MySQL data source out of the box. It's preinstalled in both Grafana OSS and Grafana Enterprise, so there's nothing for you to install.
-Starting with Grafana 13.2, the data source is packaged as a standalone plugin that can be updated independently of Grafana releases. Refer to [Plugin updates](#plugin-updates) for details.
+The MySQL data source lets you query and visualize data from MySQL and MySQL-compatible databases like [MariaDB](https://mariadb.org/) or [Percona Server](https://www.percona.com/).
+Use it to create dashboards, explore SQL data, and monitor MySQL-based workloads in real time.
 
-You can query and visualize data from MySQL-compatible databases like [MariaDB](https://mariadb.org/) or [Percona Server](https://www.percona.com/).
-
-Use this data source to create dashboards, explore SQL data, and monitor MySQL-based workloads in real time.
+The data source ships with Grafana out of the box. It's preinstalled in both Grafana OSS and Grafana Enterprise, so there's nothing for you to install. Starting with Grafana 13.2, it's packaged as a standalone plugin that updates independently of Grafana releases. Refer to [Plugin updates](#plugin-updates) for details.
 
 Watch the following video to learn more about using the Grafana MySQL data source plugin: {{< youtube id="p_RDHfHS-P8">}}
 

--- a/docs/sources/datasources/mysql/_index.md
+++ b/docs/sources/datasources/mysql/_index.md
@@ -35,7 +35,7 @@ Watch the following video to learn more about using the Grafana MySQL data sourc
 This data source supports the following MySQL-compatible databases:
 
 - MySQL 5.7 and newer
-- MariaDB 10.2 and newer
+- MariaDB 10.5 and newer
 - Percona Server 5.7 and newer
 - Amazon Aurora MySQL
 - Azure Database for MySQL

--- a/docs/sources/datasources/mysql/alerting/index.md
+++ b/docs/sources/datasources/mysql/alerting/index.md
@@ -13,7 +13,7 @@ labels:
 menuTitle: Alerting
 title: MySQL alerting
 weight: 350
-review_date: 2026-05-11
+review_date: 2026-08-10
 ---
 
 # MySQL alerting

--- a/docs/sources/datasources/mysql/annotations/index.md
+++ b/docs/sources/datasources/mysql/annotations/index.md
@@ -13,7 +13,7 @@ labels:
 menuTitle: Annotations
 title: MySQL annotations
 weight: 340
-review_date: 2026-05-11
+review_date: 2026-08-10
 ---
 
 # MySQL annotations

--- a/docs/sources/datasources/mysql/configure/_index.md
+++ b/docs/sources/datasources/mysql/configure/_index.md
@@ -28,7 +28,7 @@ Before configuring the MySQL data source, ensure you have the following:
 
 - **Grafana permissions:** You must have the Organization administrator role to configure data sources. Organization administrators can also [configure the data source via YAML](#provision-the-data-source) with the Grafana provisioning system.
 
-- **A running MySQL instance:** MySQL 5.7 or newer, MariaDB 10.2 or newer, or a compatible MySQL-based database such as Percona Server.
+- **A running MySQL instance:** MySQL 5.7 or newer, MariaDB 10.5 or newer, or a compatible MySQL-based database such as Percona Server.
 
 - **Network access:** Grafana must be able to reach your MySQL server. The default port is `3306`.
 

--- a/docs/sources/datasources/mysql/configure/_index.md
+++ b/docs/sources/datasources/mysql/configure/_index.md
@@ -15,7 +15,7 @@ labels:
 menuTitle: Configure
 title: Configure the MySQL data source
 weight: 10
-review_date: 2026-05-11
+review_date: 2026-08-10
 ---
 
 # Configure the MySQL data source
@@ -37,7 +37,7 @@ Before configuring the MySQL data source, ensure you have the following:
 - **Security certificates:** If using encrypted connections, gather any necessary TLS/SSL certificates.
 
 {{< admonition type="note" >}}
-Grafana ships with a built-in MySQL data source plugin. No additional installation is required.
+The MySQL data source plugin is preinstalled in Grafana, so no additional installation is required. As of Grafana 13.2, it's packaged as a standalone plugin that updates independently of Grafana releases. Refer to [Plugin updates](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/mysql/#plugin-updates) for details.
 {{< /admonition >}}
 
 {{< admonition type="tip" >}}
@@ -66,7 +66,7 @@ To add the MySQL data source complete the following steps:
 1. Select the **MySQL data source** option.
 1. Click **Add new data source** in the upper right.
 
-You are taken to the **Settings** tab where you will configure the data source.
+You are taken to the **Settings** tab where you configure the data source.
 
 ## MySQL configuration options
 
@@ -78,7 +78,7 @@ Following is a list of MySQL configuration options:
 
 **Connection:**
 
-- **Host URL** - Enter the IP address/hostname and optional port of your MySQL instance. If the port is omitted the default `3306` port will be used.
+- **Host URL** - Enter the IP address/hostname and optional port of your MySQL instance. If the port is omitted, Grafana uses the default `3306` port.
 - **Database** - Enter the name of your MySQL database.
 
 **Authentication:**
@@ -98,7 +98,7 @@ The following are additional MySQL settings.
 
 **MySQL options:**
 
-- **Session Timezone** - Specifies the timezone used in the database session, such as `Europe/Berlin` or `+02:00`. Required if the timezone of the database (or the host of the database) is set to something other than UTC. Set this to `+00:00` so Grafana can handle times properly. Set the value used in the session with `SET time_zone='...'`. If you leave this field empty, the timezone will not be updated. For more information, refer to [MySQL Server Time Zone Support](https://dev.mysql.com/doc/en/time-zone-support.html).
+- **Session Timezone** - Specifies the timezone used in the database session, such as `Europe/Berlin` or `+02:00`. Required if the timezone of the database (or the host of the database) is set to something other than UTC. Set this to `+00:00` so Grafana can handle times properly. Set the value used in the session with `SET time_zone='...'`. If you leave this field empty, the timezone isn't updated. For more information, refer to [MySQL Server Time Zone Support](https://dev.mysql.com/doc/en/time-zone-support.html).
 - **Min time interval** - Defines a lower limit for the [`$__interval`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/add-template-variables/#__interval) and [`$__interval_ms`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/add-template-variables/#__interval_ms) variables. Grafana recommends aligning this setting with the data write frequency. For example, set it to `1m` if your data is written every minute. Refer to [Min time interval](#min-time-interval) for format examples.
 
 **Connection limits:**

--- a/docs/sources/datasources/mysql/query-editor/_index.md
+++ b/docs/sources/datasources/mysql/query-editor/_index.md
@@ -12,7 +12,7 @@ labels:
 menuTitle: Query editor
 title: MySQL query editor
 weight: 30
-review_date: 2026-05-11
+review_date: 2026-08-10
 ---
 
 # MySQL query editor
@@ -22,7 +22,7 @@ Grafana’s query editors are unique for each data source. For general informati
 The MySQL query editor is located on the [Explore page](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/explore/). You can also access the MySQL query editor from a dashboard panel. Click the ellipsis in the upper right of the panel and select **Edit**.
 
 {{< admonition type="note" >}}
-If a default database is configured in the **Data Source Configuration page**, or via a provisioning configuration file, users will be restricted to querying only that pre-configured database.
+If a default database is configured in the **Data Source Configuration page**, or via a provisioning configuration file, users are restricted to querying only that pre-configured database.
 {{< /admonition >}}
 
 ## MySQL query editor components
@@ -32,12 +32,12 @@ The MySQL query editor has two modes: **Builder** and **Code**.
 Builder mode helps you build a query using a visual interface. Code mode allows for advanced querying and offers support for complex SQL query writing.
 
 {{< admonition type="note" >}}
-If your table or database name contains a reserved word or a [prohibited character](https://dev.mysql.com/doc/en/identifiers.html) the editor will put quotes around the name. For example, the name `table-name` will be quoted with backticks - `` `table-name` ``.
+If your table or database name contains a reserved word or a [prohibited character](https://dev.mysql.com/doc/en/identifiers.html) the editor puts quotes around the name. For example, the name `table-name` is quoted with backticks - `` `table-name` ``.
 {{< /admonition >}}
 
 ## MySQL Builder mode
 
-The following components will help you build a MySQL query:
+The following components help you build a MySQL query:
 
 - **Format** - Select a format response from the drop-down for the MySQL query. The default is **Table**. If you use the **Time series** format option, one of the columns must be `time`.
 
@@ -51,7 +51,7 @@ The following components will help you build a MySQL query:
   - **Alias** - _Optional_ Add an alias from the drop-down. You can also add your own alias by typing it in the box and clicking **Enter**. Remove an alias by clicking the **X**.
 
 - **Filter** - Toggle to add filters.
-  - **Filter by column value** - _Optional_ If you toggle **Filter** you can add a column to filter by from the drop-down. To filter on more columns, click the **+ sign** to the right of the condition drop-down. You can choose a variety of operators from the drop-down next to the condition. When multiple filters are added you can add an `AND` operator to display all true conditions or an `OR` operator to display any true conditions. Use the second drop-down to choose a filter. To remove a filter, click the `X` button next to that filter's drop-down. After selecting a date type column, you can choose **Macros** from the operators list and select `timeFilter` which will add the `$\_\_timeFilter` macro to the query with the selected date column.
+  - **Filter by column value** - _Optional_ If you toggle **Filter** you can add a column to filter by from the drop-down. To filter on more columns, click the **+ sign** to the right of the condition drop-down. You can choose a variety of operators from the drop-down next to the condition. When multiple filters are added you can add an `AND` operator to display all true conditions or an `OR` operator to display any true conditions. Use the second drop-down to choose a filter. To remove a filter, click the `X` button next to that filter's drop-down. After selecting a date type column, you can choose **Macros** from the operators list and select `timeFilter`, which adds the `$\_\_timeFilter` macro to the query with the selected date column.
 
 - **Group** - Toggle to add **Group by column**.
   - **Group by column** - Select a column to filter by from the drop-down. Click the **+ sign** to filter by multiple columns. Click the **X** to remove a filter.
@@ -69,7 +69,7 @@ To create advanced queries, switch to **Code mode** by clicking **Code** in the 
 Select **Table** or **Time Series** as the format. Click the **{}** in the bottom right to format the query. Click the **downward caret** to expand the Code mode editor. **CTRL/CMD + Return** serves as a keyboard shortcut to execute the query.
 
 {{< admonition type="warning" >}}
-Changes made to a query in Code mode will not transfer to Builder mode and will be discarded. You will be prompted to copy your code to the clipboard to save any changes.
+Changes made to a query in Code mode don't transfer to Builder mode and are discarded. Grafana prompts you to copy your code to the clipboard to save any changes.
 {{< /admonition >}}
 
 ## Macros
@@ -89,8 +89,6 @@ You can add macros to your queries to simplify the syntax and enable dynamic ele
 | `$__timeGroup(dateColumn,'5m', previous)`             | Same as the `$__timeGroup(dateColumn,'5m', previous)` macro, but uses the previous value in the series as the fill value. If no previous value exists,`NULL` will be used. **This applies only to time series queries.**                       |
 | `$__timeGroupAlias(dateColumn,'5m')`                  | Replaces the value identical to $\_\_timeGroup but with an added column alias.                                                                                                                                                                 |
 | `$__unixEpochFilter(dateColumn)`                      | Replaces the value by a time range filter using the specified column name with times represented as a UNIX timestamp. Example: _dateColumn > 1494410783 AND dateColumn < 1494497183_                                                           |
-| `$__unixEpochFrom()`                                  | Replaces the value with the start of the currently active time selection as a UNIX timestamp. Example: _1494410783_                                                                                                                            |
-| `$__unixEpochTo()`                                    | Replaces the value with the end of the currently active time selection as UNIX timestamp. Example: _1494497183_                                                                                                                                |
 | `$__unixEpochNanoFilter(dateColumn)`                  | Replaces the value with a time range filter using the specified column name with time represented as a nanosecond timestamp. Example: _dateColumn > 1494410783152415214 AND dateColumn < 1494497183142514872_                                  |
 | `$__unixEpochNanoFrom()`                              | Replaces the value with the start of the currently active time selection as nanosecond timestamp. Example: _1494410783152415214_                                                                                                               |
 | `$__unixEpochNanoTo()`                                | Replaces the value with the end of the currently active time selection as nanosecond timestamp. Example: _1494497183142514872_                                                                                                                 |
@@ -103,7 +101,7 @@ As of Grafana 13.0, fill resampling in `$__timeGroup` and `$__unixEpochGroup` in
 
 ## Table SQL queries
 
-If the **Format** option is set to **Table**, you can execute virtually any type of SQL query. The Table panel will automatically display the resulting columns and rows from your query.
+If the **Format** option is set to **Table**, you can execute virtually any type of SQL query. The Table panel automatically displays the resulting columns and rows from your query.
 
 You can change or customize the name of a Table panel column by using the SQL keyword `AS` syntax.
 

--- a/docs/sources/datasources/mysql/template-variables/index.md
+++ b/docs/sources/datasources/mysql/template-variables/index.md
@@ -14,7 +14,7 @@ labels:
 menuTitle: Template variables
 title: MySQL template variables
 weight: 300
-review_date: 2026-05-11
+review_date: 2026-08-10
 ---
 
 # MySQL template variables

--- a/docs/sources/datasources/mysql/troubleshooting/index.md
+++ b/docs/sources/datasources/mysql/troubleshooting/index.md
@@ -15,7 +15,7 @@ labels:
 menuTitle: Troubleshooting
 title: Troubleshoot MySQL data source issues
 weight: 400
-review_date: 2026-05-11
+review_date: 2026-08-10
 ---
 
 # Troubleshoot MySQL data source issues
@@ -432,6 +432,7 @@ If you continue to experience issues after following this troubleshooting guide:
 When reporting issues, include:
 
 - Grafana version
+- MySQL data source plugin version, found on the **Administration > Plugins** page. The plugin updates independently of Grafana releases.
 - MySQL version
 - Error messages (redact sensitive information)
 - Steps to reproduce


### PR DESCRIPTION
Quarterly documentation update (FY27 Q3) for the MySQL data source. The main change documents the plugin's externalization from core Grafana: as of Grafana 13.2, MySQL ships as a preinstalled standalone plugin ([grafana/grafana-mysql-datasource](https://github.com/grafana/grafana-mysql-datasource)) that updates independently of Grafana releases. Content was cross-referenced against the external plugin source code and the Go MySQL driver for accuracy.

_index.md: Rewrote intro to lead with data source capabilities and reflect the preinstalled standalone plugin model, added "Plugin updates" section (auto-update behavior, preinstall_auto_update opt-out, manual updates, as_external/preinstall_sync opt-in for Grafana 12.3.x–13.1.x), updated MariaDB support to 10.5 and newer, refreshed review date

configure/_index.md: Replaced "built-in plugin" note with preinstalled standalone plugin wording linking to Plugin updates, updated MariaDB prerequisite to 10.5 or newer, converted future-tense phrasing to present tense, refreshed review date

query-editor/_index.md: Removed $__unixEpochFrom() and $__unixEpochTo() from the macro table (never implemented by the MySQL backend; queries using them fail with an "unknown macro" error), converted future-tense phrasing to present tense, refreshed review date

template-variables/index.md: Content verified against source, refreshed review date

annotations/index.md: Content verified against source, refreshed review date

alerting/index.md: Content verified against source, refreshed review date

troubleshooting/index.md: Added MySQL data source plugin version to the issue-reporting checklist since the plugin now versions independently of Grafana, refreshed review date

Technical accuracy verified against:

pkg/setting/setting_plugins.go (MySQL in defaultPreinstallPlugins)
grafana/grafana PR #129439 (core plugin removal, ships in Grafana 13.2)
Grafana plugin catalog API for mysql (plugin version 13.0.2, grafanaDependency >=12.3.0)
grafana-mysql-datasource pkg/mysql/macros.go (supported macros)
go-sql-driver/mysql v1.10.0 README (supported database versions)

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
