### PR TITLE
Docs: PostgreSQL quarterly update (FY27 Q3)

### DIFF
--- a/docs/sources/datasources/postgres/_index.md
+++ b/docs/sources/datasources/postgres/_index.md
@@ -15,12 +15,12 @@ labels:
 menuTitle: PostgreSQL
 title: PostgreSQL data source
 weight: 1200
-review_date: 2026-05-04
+review_date: 2026-08-10
 ---
 
 # PostgreSQL data source
 
-Grafana includes a built-in PostgreSQL data source plugin, enabling you to query and visualize data from any PostgreSQL-compatible database. You don't need to install a plugin to add the PostgreSQL data source to your Grafana instance.
+Grafana ships with the PostgreSQL data source out of the box. It's preinstalled in Grafana OSS and Enterprise, so you don't need to install a plugin to add it. The data source is packaged as a standalone plugin that can update independently of Grafana releases.
 
 Grafana offers several configuration options for this data source as well as a visual and code-based query editor.
 
@@ -67,6 +67,8 @@ The following documents help you get started with the PostgreSQL data source:
 - [Configure the PostgreSQL data source](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/postgres/configure/) - Set up authentication and connect to PostgreSQL.
 - [PostgreSQL query editor](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/postgres/query-editor/) - Create and edit queries with time series, table, and EXPLAIN formats.
 - [Template variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/postgres/template-variables/) - Create dynamic dashboards with PostgreSQL variables.
+- [Annotations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/postgres/annotations/) - Overlay PostgreSQL events on your dashboard graphs.
+- [Alerting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/postgres/alerting/) - Create alerts based on PostgreSQL query results.
 - [Troubleshooting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/postgres/troubleshooting/) - Solve common configuration and query errors.
 
 ## Additional features
@@ -82,12 +84,36 @@ To see the PostgreSQL data source in action, explore the demo dashboard on Grafa
 
 {{< docs/play title="PostgreSQL Overview" url="https://play.grafana.org/d/ddvpgdhiwjvuod/postgresql-overview" >}}
 
+## Plugin updates
+
+Starting with Grafana v13.2, the PostgreSQL data source is a standalone plugin, preinstalled in both Grafana OSS and Enterprise. This enables more frequent updates independent of Grafana releases. Grafana automatically checks the plugin catalog and installs the latest version on each server restart.
+
+To adjust this behavior:
+
+- **Opt out of auto-updates:** Set `preinstall_auto_update` to `false` in your [configuration file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/).
+- **Update manually:** Update at any time from the **Administration > Plugins** page without restarting Grafana.
+
+The standalone plugin requires Grafana 12.3.0 or later. The PostgreSQL data source bundled with Grafana 13.1 and earlier continues to work as before. These versions are unaffected by the externalization.
+
+Users running Grafana 12.3.x through 13.1.x can install the standalone plugin from the plugin catalog if they want the latest features before upgrading to Grafana 13.2. To use the standalone plugin with Grafana 12.3.x through 13.1.x, add the following to your [configuration file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/):
+
+```ini
+[plugin.grafana-postgresql-datasource]
+as_external = true
+
+[plugins]
+; Install the latest version on startup:
+preinstall_sync = grafana-postgresql-datasource
+; Or install a specific version:
+; preinstall_sync = grafana-postgresql-datasource@<version>
+```
+
 ## Related data sources
 
 The following databases use the PostgreSQL wire protocol and may work with this data source:
 
-- [TimescaleDB](https://www.timescale.com/)—Enable the **TimescaleDB** toggle in the data source settings for `time_bucket` support.
+- [TimescaleDB](https://www.timescale.com/). Enable the **TimescaleDB** toggle in the data source settings for `time_bucket` support.
 - [CockroachDB](https://www.cockroachlabs.com/)
-- [Amazon Redshift](https://aws.amazon.com/redshift/)—Grafana also offers a dedicated [Amazon Redshift data source](https://grafana.com/grafana/plugins/grafana-redshift-datasource/) with additional features.
+- [Amazon Redshift](https://aws.amazon.com/redshift/). Grafana also offers a dedicated [Amazon Redshift data source](https://grafana.com/grafana/plugins/grafana-redshift-datasource/) with additional features.
 - [CrateDB](https://cratedb.com/)
 - [YugabyteDB](https://www.yugabyte.com/)

--- a/docs/sources/datasources/postgres/_index.md
+++ b/docs/sources/datasources/postgres/_index.md
@@ -20,9 +20,9 @@ review_date: 2026-08-10
 
 # PostgreSQL data source
 
-Grafana ships with the PostgreSQL data source out of the box. It's preinstalled in Grafana OSS and Enterprise, so you don't need to install a plugin to add it. The data source is packaged as a standalone plugin that can update independently of Grafana releases.
+Query and visualize data from any PostgreSQL-compatible database. Build dashboards with the visual query builder or raw SQL, explore tables in real time, overlay annotations, and create alerts from the same connection. The data source works with self-managed PostgreSQL and managed services such as Amazon RDS, Amazon Aurora, Azure Database for PostgreSQL, and Google Cloud SQL.
 
-Grafana offers several configuration options for this data source as well as a visual and code-based query editor.
+Grafana ships with the PostgreSQL data source out of the box. It's preinstalled in Grafana OSS and Enterprise, so you don't need to install a plugin to add it. The data source is packaged as a standalone plugin that can update independently of Grafana releases.
 
 ## Supported databases
 

--- a/docs/sources/datasources/postgres/alerting/index.md
+++ b/docs/sources/datasources/postgres/alerting/index.md
@@ -14,7 +14,7 @@ labels:
 menuTitle: Alerting
 title: PostgreSQL alerting
 weight: 500
-review_date: 2026-05-04
+review_date: 2026-08-10
 ---
 
 # PostgreSQL alerting

--- a/docs/sources/datasources/postgres/annotations/index.md
+++ b/docs/sources/datasources/postgres/annotations/index.md
@@ -13,7 +13,7 @@ labels:
 menuTitle: Annotations
 title: PostgreSQL annotations
 weight: 340
-review_date: 2026-05-04
+review_date: 2026-08-10
 ---
 
 # PostgreSQL annotations

--- a/docs/sources/datasources/postgres/configure/_index.md
+++ b/docs/sources/datasources/postgres/configure/_index.md
@@ -12,7 +12,7 @@ labels:
 menuTitle: Configure
 title: Configure the PostgreSQL data source
 weight: 10
-review_date: 2026-05-04
+review_date: 2026-08-10
 ---
 
 # Configure the PostgreSQL data source
@@ -23,11 +23,11 @@ This document explains how to configure the PostgreSQL data source and lists all
 
 - You need the `Organization administrator` role to configure the data source. You can also [configure it via YAML](#provision-the-data-source) using Grafana provisioning or [using Terraform](#configure-with-terraform).
 
-- Grafana includes a built-in PostgreSQL data source; no plugin installation is required.
+- Grafana ships with the PostgreSQL data source preinstalled in OSS and Enterprise. You don't need to install a plugin. For update options, refer to [Plugin updates](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/postgres/#plugin-updates).
 
 - Have your PostgreSQL security details ready (certificates and client keys, if using TLS/SSL).
 
-- Note your PostgreSQL version; you’ll be prompted for it during configuration.
+- Note your PostgreSQL version; you'll be prompted for it during configuration.
 
 {{< admonition type="note" >}}
 When adding a data source, the database user you specify should have only `SELECT` permissions on the relevant schemas and tables. Grafana does not validate the safety of queries, so users could run potentially harmful SQL (for example, `DROP TABLE`). Create a dedicated PostgreSQL user with restricted permissions to limit risk.
@@ -53,7 +53,7 @@ Complete the following steps to set up a new PostgreSQL data source:
 1. Select the **PostgreSQL data source**.
 1. Click **Add new data source** in the upper right.
 
-You are taken to the **Settings** tab where you will configure the data source.
+You are taken to the **Settings** tab where you configure the data source.
 
 ## PostgreSQL configuration options
 
@@ -69,7 +69,7 @@ Following is a list of PostgreSQL configuration options:
 {{< admonition type="note" >}}
 **Grafana Cloud users:** Grafana Cloud can't reach databases on `localhost`, `127.0.0.1`, or private IP ranges (`10.x`, `172.16.x`, `192.168.x`) directly. If your PostgreSQL instance isn't publicly accessible, you must set up [Private data source connect (PDC)](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/) to establish a secure tunnel between Grafana Cloud and your private network. If you experience intermittent connection drops with the Docker-based PDC agent, try switching to the binary-based agent instead.
 
-If your database is publicly accessible but protected by a firewall, you must allowlist the Grafana Cloud outbound IP addresses. Grafana Cloud doesn't provide per-stack static IP addresses—only service-level IP ranges. For the current list of outbound IP addresses, refer to [Allow Grafana Cloud IP addresses in a firewall](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/allow-grafana-cloud-ips/).
+If your database is publicly accessible but protected by a firewall, you must allowlist the Grafana Cloud outbound IP addresses. Grafana Cloud doesn't provide per-stack static IP addresses. It provides only service-level IP ranges. For the current list of outbound IP addresses, refer to [Allow Grafana Cloud IP addresses in a firewall](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/allow-grafana-cloud-ips/).
 {{< /admonition >}}
 
 | Setting       | Description                                                                                                                                                                                                                                                            |
@@ -153,7 +153,7 @@ These settings control how Grafana manages connections to your PostgreSQL server
 | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Private data source connect | _Only for Grafana Cloud users._ Private data source connect, or PDC, allows you to establish a private, secured connection between a Grafana Cloud instance, or stack, and data sources secured within a private network. Click the drop-down to locate the URL for PDC. For more information, refer to [Private data source connect (PDC)](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/). |
 
-Click **Manage private data source connect** to be taken to your PDC connection page, where you’ll find your PDC configuration details.
+Click **Manage private data source connect** to be taken to your PDC connection page, where you'll find your PDC configuration details.
 
 **Secure SOCKS proxy:**
 
@@ -183,6 +183,8 @@ This value must be formatted as a number followed by a valid time identifier:
 ## Provision the data source
 
 You can define and configure the data source in YAML files with [provisioning](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/provisioning/#data-sources). For more information about provisioning and available configuration options, refer to [Provision Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/provisioning/#datasources).
+
+The plugin ID is `grafana-postgresql-datasource`. Provisioning examples in this document use `type: postgres`, which remains a supported alias.
 
 ### Basic provisioning example
 

--- a/docs/sources/datasources/postgres/configure/_index.md
+++ b/docs/sources/datasources/postgres/configure/_index.md
@@ -207,7 +207,7 @@ datasources:
       maxIdleConns: 100
       maxIdleConnsAuto: true
       connMaxLifetime: 14400
-      postgresVersion: 903 # 903=9.3, 904=9.4, 905=9.5, 906=9.6, 1000=10
+      postgresVersion: 903 # 900=9.0 ... 906=9.6, 1000=10, 1100=11, 1200=12, 1300=13, 1400=14, 1500=15
       timescaledb: false
 ```
 
@@ -311,8 +311,9 @@ The following table lists all `jsonData` and `secureJsonData` fields supported w
 | `maxIdleConns`           | `jsonData`       | Maximum idle connections. Default: `100`.                                              |
 | `maxIdleConnsAuto`       | `jsonData`       | Set max idle to max open automatically. Default: `true`.                               |
 | `connMaxLifetime`        | `jsonData`       | Connection max lifetime in seconds. Default: `14400`.                                  |
-| `postgresVersion`        | `jsonData`       | Server version code: `903` (9.3), `904` (9.4), `905` (9.5), `906` (9.6), `1000` (10+). |
+| `postgresVersion`        | `jsonData`       | Server version code for the query builder. Examples: `900` (9.0), `903` (9.3), `1000` (10), `1100` (11), `1200` (12), `1300` (13), `1400` (14), `1500` (15). Grafana auto-detects this on save when possible. |
 | `timescaledb`            | `jsonData`       | Enable TimescaleDB support. Default: `false`.                                          |
+| `timeInterval`           | `jsonData`       | Lower limit for `$__interval` and `$__interval_ms`. Same format as **Min time interval** (for example, `1m`). |
 | `tlsConfigurationMethod` | `jsonData`       | TLS cert method: `file-path` or `file-content`.                                        |
 | `sslRootCertFile`        | `jsonData`       | Path to root CA certificate (when using `file-path` method).                           |
 | `sslCertFile`            | `jsonData`       | Path to client certificate (when using `file-path` method).                            |

--- a/docs/sources/datasources/postgres/configure/_index.md
+++ b/docs/sources/datasources/postgres/configure/_index.md
@@ -303,25 +303,25 @@ datasources:
 
 The following table lists all `jsonData` and `secureJsonData` fields supported when provisioning the PostgreSQL data source:
 
-| Field                    | Location         | Description                                                                            |
-| ------------------------ | ---------------- | -------------------------------------------------------------------------------------- |
-| `database`               | `jsonData`       | The database name.                                                                     |
-| `sslmode`                | `jsonData`       | TLS/SSL mode: `disable`, `require`, `verify-ca`, or `verify-full`.                     |
-| `maxOpenConns`           | `jsonData`       | Maximum open connections. Default: `100`.                                              |
-| `maxIdleConns`           | `jsonData`       | Maximum idle connections. Default: `100`.                                              |
-| `maxIdleConnsAuto`       | `jsonData`       | Set max idle to max open automatically. Default: `true`.                               |
-| `connMaxLifetime`        | `jsonData`       | Connection max lifetime in seconds. Default: `14400`.                                  |
+| Field                    | Location         | Description                                                                                                                                                                                                   |
+| ------------------------ | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `database`               | `jsonData`       | The database name.                                                                                                                                                                                            |
+| `sslmode`                | `jsonData`       | TLS/SSL mode: `disable`, `require`, `verify-ca`, or `verify-full`.                                                                                                                                            |
+| `maxOpenConns`           | `jsonData`       | Maximum open connections. Default: `100`.                                                                                                                                                                     |
+| `maxIdleConns`           | `jsonData`       | Maximum idle connections. Default: `100`.                                                                                                                                                                     |
+| `maxIdleConnsAuto`       | `jsonData`       | Set max idle to max open automatically. Default: `true`.                                                                                                                                                      |
+| `connMaxLifetime`        | `jsonData`       | Connection max lifetime in seconds. Default: `14400`.                                                                                                                                                         |
 | `postgresVersion`        | `jsonData`       | Server version code for the query builder. Examples: `900` (9.0), `903` (9.3), `1000` (10), `1100` (11), `1200` (12), `1300` (13), `1400` (14), `1500` (15). Grafana auto-detects this on save when possible. |
-| `timescaledb`            | `jsonData`       | Enable TimescaleDB support. Default: `false`.                                          |
-| `timeInterval`           | `jsonData`       | Lower limit for `$__interval` and `$__interval_ms`. Same format as **Min time interval** (for example, `1m`). |
-| `tlsConfigurationMethod` | `jsonData`       | TLS cert method: `file-path` or `file-content`.                                        |
-| `sslRootCertFile`        | `jsonData`       | Path to root CA certificate (when using `file-path` method).                           |
-| `sslCertFile`            | `jsonData`       | Path to client certificate (when using `file-path` method).                            |
-| `sslKeyFile`             | `jsonData`       | Path to client key (when using `file-path` method).                                    |
-| `password`               | `secureJsonData` | Database password.                                                                     |
-| `tlsCACert`              | `secureJsonData` | Root CA certificate content (when using `file-content` method).                        |
-| `tlsClientCert`          | `secureJsonData` | Client certificate content (when using `file-content` method).                         |
-| `tlsClientKey`           | `secureJsonData` | Client key content (when using `file-content` method).                                 |
+| `timescaledb`            | `jsonData`       | Enable TimescaleDB support. Default: `false`.                                                                                                                                                                 |
+| `timeInterval`           | `jsonData`       | Lower limit for `$__interval` and `$__interval_ms`. Same format as **Min time interval** (for example, `1m`).                                                                                                 |
+| `tlsConfigurationMethod` | `jsonData`       | TLS cert method: `file-path` or `file-content`.                                                                                                                                                               |
+| `sslRootCertFile`        | `jsonData`       | Path to root CA certificate (when using `file-path` method).                                                                                                                                                  |
+| `sslCertFile`            | `jsonData`       | Path to client certificate (when using `file-path` method).                                                                                                                                                   |
+| `sslKeyFile`             | `jsonData`       | Path to client key (when using `file-path` method).                                                                                                                                                           |
+| `password`               | `secureJsonData` | Database password.                                                                                                                                                                                            |
+| `tlsCACert`              | `secureJsonData` | Root CA certificate content (when using `file-content` method).                                                                                                                                               |
+| `tlsClientCert`          | `secureJsonData` | Client certificate content (when using `file-content` method).                                                                                                                                                |
+| `tlsClientKey`           | `secureJsonData` | Client key content (when using `file-content` method).                                                                                                                                                        |
 
 #### Troubleshoot provisioning issues
 

--- a/docs/sources/datasources/postgres/query-editor/_index.md
+++ b/docs/sources/datasources/postgres/query-editor/_index.md
@@ -12,17 +12,17 @@ labels:
 menuTitle: Query editor
 title: PostgreSQL query editor
 weight: 20
-review_date: 2026-05-04
+review_date: 2026-08-10
 ---
 
 # PostgreSQL query editor
 
 The PostgreSQL query editor lets you build and run queries against your data source. For general query editor and data transformation concepts, refer to [Query and transform data](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/query-transform-data/).
 
-You can open the PostgreSQL query editor from the [Explore page](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/explore/) or from a dashboard panel—click the ellipsis in the upper right of the panel and select **Edit**.
+You can open the PostgreSQL query editor from the [Explore page](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/explore/) or from a dashboard panel. Click the ellipsis in the upper right of the panel and select **Edit**.
 
 {{< admonition type="note" >}}
-A default database must be configured in the data source settings. If none is set, or it is removed, the data source will not run queries until a database is configured again.
+A default database must be configured in the data source settings. If none is set, or it is removed, the data source doesn't run queries until a database is configured again.
 {{< /admonition >}}
 
 ## PostgreSQL query editor components
@@ -33,7 +33,7 @@ Builder mode helps you build a query using a visual interface. Code mode allows 
 
 ### PostgreSQL Builder mode
 
-The following components will help you build a PostgreSQL query:
+The following components help you build a PostgreSQL query:
 
 - **Format** - Select the query result format from the drop-down. The default is **Table**. If you use the **Time series** format option, one of the columns must be `time`. Refer to [Time series queries](#time-series-queries) for more information.
 - **Table** - Select a table from the drop-down. Tables correspond to the chosen database.
@@ -62,7 +62,7 @@ If a table or column name is a reserved word or contains mixed case or special c
 Select **Table** or **Time Series** as the format. Click the **{}** in the bottom right to format the query. Click the **downward caret** to expand the Code mode editor. **CTRL/CMD + Return** serves as a keyboard shortcut to execute the query.
 
 {{< admonition type="warning" >}}
-Changes made to a query in Code mode will not transfer to Builder mode and will be discarded. You will be prompted to copy your code to the clipboard to save any changes.
+Changes made to a query in Code mode don't transfer to Builder mode and are discarded. You're prompted to copy your code to the clipboard to save any changes.
 {{< /admonition >}}
 
 ## Macros
@@ -115,8 +115,8 @@ You can set a lower bound for these variables with the **Min time interval** opt
 Keep the following behavior in mind when using macros:
 
 - **Comment stripping:** Grafana strips SQL comments (`--` line comments and `/* */` block comments) before expanding macros. Macros placed inside comments aren't expanded.
-- **TimescaleDB mode:** When the **TimescaleDB** toggle is enabled in the data source configuration, `$__timeGroup` and `$__timeGroupAlias` use PostgreSQL's `time_bucket()` function instead of `floor(extract(epoch ...))`.
-- **Trailing comma pattern:** A `$__timeGroup(...)` call followed immediately by a comma (`,`) is automatically treated as `$__timeGroupAlias(...)`, adding the `AS "time"` alias. This is a legacy convenience—use `$__timeGroupAlias` explicitly for clarity.
+- **TimescaleDB mode:** When the **TimescaleDB** toggle is enabled in the data source configuration, `$__timeGroup` and `$__timeGroupAlias` use the PostgreSQL `time_bucket()` function instead of `floor(extract(epoch ...))`.
+- **Trailing comma pattern:** A `$__timeGroup(...)` call followed immediately by a comma (`,`) is automatically treated as `$__timeGroupAlias(...)`, adding the `AS "time"` alias. This is a legacy convenience. Use `$__timeGroupAlias` explicitly for clarity.
 - **Inspect expanded SQL:** To view the final SQL after macro expansion, open the [Query inspector](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/query-transform-data/#query-inspector) in a panel and check the query that was sent to the database.
 
 ## Table queries
@@ -274,7 +274,7 @@ GROUP BY time, hostname
 ORDER BY time
 ```
 
-Based on the data frame result in the following example, the time series panel will generate two series named _value 10.0.1.1_ and _value 10.0.1.2_. To display the series names as _10.0.1.1_ and _10.0.1.2_, use the [Standard options definitions](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/configure-standard-options/#display-name) display value `${__field.labels.hostname}`.
+Based on the data frame result in the following example, the time series panel generates two series named _value 10.0.1.1_ and _value 10.0.1.2_. To display the series names as _10.0.1.1_ and _10.0.1.2_, use the [Standard options definitions](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/configure-standard-options/#display-name) display value `${__field.labels.hostname}`.
 
 Data frame result:
 

--- a/docs/sources/datasources/postgres/query-editor/_index.md
+++ b/docs/sources/datasources/postgres/query-editor/_index.md
@@ -213,6 +213,10 @@ The available fill modes are:
 
 For example, `$__timeGroupAlias("CreatedAt",'5m', 0)` groups data into 5-minute intervals and fills any gaps with `0`.
 
+{{< admonition type="note" >}}
+As of Grafana 13.0, fill mode in `$__timeGroup` and `$__unixEpochGroup` includes additional safeguards to prevent incorrect data points when the query returns no rows or the time range falls outside the data boundaries.
+{{< /admonition >}}
+
 ### Row limits
 
 Grafana applies a server-side row limit to query results to protect against excessive memory usage. If your query returns more rows than the limit, the result is truncated. To reduce the number of rows returned, narrow the dashboard time range, increase the `$__timeGroup` interval, or add a `LIMIT` clause to your query.

--- a/docs/sources/datasources/postgres/template-variables/index.md
+++ b/docs/sources/datasources/postgres/template-variables/index.md
@@ -16,7 +16,7 @@ labels:
 menuTitle: Template variables
 title: PostgreSQL template variables
 weight: 300
-review_date: 2026-05-04
+review_date: 2026-08-10
 ---
 
 # PostgreSQL template variables

--- a/docs/sources/datasources/postgres/troubleshooting/index.md
+++ b/docs/sources/datasources/postgres/troubleshooting/index.md
@@ -15,7 +15,7 @@ labels:
 menuTitle: Troubleshooting
 title: Troubleshoot PostgreSQL data source issues
 weight: 600
-review_date: 2026-05-04
+review_date: 2026-08-10
 ---
 
 # Troubleshoot PostgreSQL data source issues
@@ -45,13 +45,13 @@ The following errors occur when Grafana cannot establish or maintain a connectio
 
 **Error message:** `dial tcp: connect: connection refused`, `i/o timeout`, or `context deadline exceeded` when using Grafana Cloud with a database on a private network.
 
-**Cause:** Grafana Cloud runs in a hosted environment and can't directly reach databases on `localhost`, `127.0.0.1`, or private IP ranges (`10.x`, `172.16.x`, `192.168.x`). This is the most common issue when migrating from self-hosted Grafana to Grafana Cloud.
+**Cause:** Grafana Cloud runs in a hosted environment and can't directly reach databases on `localhost`, `127.0.0.1`, or private IP ranges (`10.x`, `172.16.x`, `192.168.x`). This is the most common issue when migrating from self-managed Grafana to Grafana Cloud.
 
 **Solution:**
 
 1. Set up [Private data source connect (PDC)](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/) to create a secure tunnel between Grafana Cloud and your private network.
 1. Install the PDC agent on a machine that has network access to your PostgreSQL instance.
-1. If you experience intermittent connection drops with the Docker-based PDC agent, try the binary-based agent instead—this has resolved stability issues in some environments.
+1. If you experience intermittent connection drops with the Docker-based PDC agent, try the binary-based agent instead. This has resolved stability issues in some environments.
 1. Update the **Host URL** in the data source settings to use the hostname as seen from the PDC agent's network (not `localhost`).
 
 ### Request timed out

--- a/docs/sources/datasources/postgres/troubleshooting/index.md
+++ b/docs/sources/datasources/postgres/troubleshooting/index.md
@@ -230,13 +230,13 @@ The following errors occur when there are issues with SQL syntax or query execut
 
 **Error message:** Unexpected syntax errors or truncated results when string values contain `--` (double dash).
 
-**Cause:** In Grafana versions before 13.1, the SQL comment-stripping parser didn't correctly handle `--` inside single-quoted strings. A query like `WHERE name = 'value--suffix'` would be truncated at the `--`, causing the rest of the query to be silently dropped. This also affected strings with consecutive hyphens (for example, `'10YDE-VE-------2'` would be truncated to `'10YDE-VE`).
+**Cause:** In older Grafana versions, the SQL comment-stripping parser didn't correctly handle `--` inside single-quoted strings. A query like `WHERE name = 'value--suffix'` would be truncated at the `--`, causing the rest of the query to be silently dropped. This also affected strings with consecutive hyphens (for example, `'10YDE-VE-------2'` would be truncated to `'10YDE-VE`).
 
-This was fixed in Grafana 13.1 with a quote-aware comment-stripping parser (PR #121772). The fix also handles PostgreSQL dollar-quoted strings (`$$...$$`).
+This was fixed with a quote-aware comment-stripping parser (PR #121772). The fix also handles PostgreSQL dollar-quoted strings (`$$...$$`). It is available in Grafana 13.1 and later, Grafana 13.0.2 and later, and these 12.x patch releases: 12.1.11, 12.2.9, 12.3.7, and 12.4.3.
 
 **Solution:**
 
-1. Upgrade to Grafana 13.1 or later, which includes the fix.
+1. Upgrade to a Grafana release that includes the fix (13.1+, 13.0.2+, or one of the 12.x patch releases listed above).
 1. If you can't upgrade immediately, work around the issue by using PostgreSQL string concatenation to avoid literal `--` in your queries:
 
    ```sql


### PR DESCRIPTION
FY27 Q3 quarterly documentation update for the PostgreSQL data source, aligned with data source documentation conventions. Content was cross-referenced against the last core plugin snapshot before externalization (plugin.json, config version codes, shared SQL defaults) and CHANGELOG entries for accuracy. Config and query editor UI source of truth now lives in the standalone plugin repo after [#128782](https://github.com/grafana/grafana/pull/128782).

_index.md: Rewrote intro for capabilities and managed services, documented preinstalled standalone packaging, added Plugin updates section for Grafana 13.2 (auto-update, opt-out, as_external / preinstall_sync for 12.3.x–13.1.x), expanded Get started with Annotations and Alerting, fixed em dashes in Related data sources, updated review_date

configure/_index.md: Updated preinstall wording with Plugin updates link, noted plugin ID grafana-postgresql-datasource and postgres alias, corrected postgresVersion codes through 15, added timeInterval to provisioning reference, present-tense and style fixes, updated review_date

query-editor/_index.md: Present-tense cleanup, added Grafana 13.0 fill-mode safeguards note, product-possessive and em dash fixes, updated review_date

template-variables/index.md: Updated review_date

annotations/index.md: Updated review_date

alerting/index.md: Updated review_date

troubleshooting/index.md: Corrected comment-strip fix version floor (13.1+, 13.0.2+, and listed 12.x patches), replaced self-hosted with self-managed, style fixes, updated review_date

Technical accuracy verified against:

Pre-removal plugin.json (features, grafanaDependency >=12.3.0, aliasIDs)
pkg/setting/setting_plugins.go (default preinstall)
Pre-removal ConfigurationEditor.tsx (postgresVersion codes 900–1500)
packages/grafana-sql / conf/defaults.ini (SQL options including timeInterval, connection defaults)
CHANGELOG / backport commits for #121772 and fill safeguards #121327

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
