### PR TITLE
Docs:  Elasticsearch quarterly update (FY27 Q3) 

### DIFF
--- a/docs/sources/datasources/elasticsearch/_index.md
+++ b/docs/sources/datasources/elasticsearch/_index.md
@@ -103,7 +103,7 @@ After you have configured the Elasticsearch data source, you can:
 - Use [Explore](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/explore/) to run user-written queries against your Elasticsearch data.
 - Configure and use [template variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/elasticsearch/template-variables/) for dynamic dashboards.
 - Add [Transformations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/query-transform-data/transform-data/) to process query results.
-- [Build dashboards](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/build-dashboards/) to visualize your Elasticsearch data.
+- [Build dashboards](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/) to visualize your Elasticsearch data.
 
 ## Related data sources
 

--- a/docs/sources/datasources/elasticsearch/_index.md
+++ b/docs/sources/datasources/elasticsearch/_index.md
@@ -108,4 +108,4 @@ After you have configured the Elasticsearch data source, you can:
 ## Related data sources
 
 - [OpenSearch](https://grafana.com/docs/plugins/grafana-opensearch-datasource/latest/) - For Amazon OpenSearch Service.
-- [Loki](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/loki/) - Grafana's log aggregation system.
+- [Loki](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/loki/) - The Grafana log aggregation system.

--- a/docs/sources/datasources/elasticsearch/_index.md
+++ b/docs/sources/datasources/elasticsearch/_index.md
@@ -16,11 +16,12 @@ labels:
 menuTitle: Elasticsearch
 title: Elasticsearch data source
 weight: 325
+review_date: 2026-08-10
 ---
 
 # Elasticsearch data source
 
-[Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/elasticsearch-intro.html) is a search and analytics engine used for a variety of use cases. The built-in Elasticsearch data source lets you query and visualize logs or metrics stored in Elasticsearch, and annotate graphs with log events.
+[Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/elasticsearch-intro.html) is a search and analytics engine used for a variety of use cases. Grafana ships with the Elasticsearch data source preinstalled, so you can query and visualize logs or metrics stored in Elasticsearch, and annotate graphs with log events, without installing a plugin. The data source is packaged as a standalone plugin that you can update independently of Grafana releases. Refer to [Plugin updates](#plugin-updates) for details.
 
 {{< admonition type="note" >}}
 If you use Amazon OpenSearch Service (the successor to Amazon Elasticsearch Service), use the [OpenSearch data source](https://grafana.com/docs/plugins/grafana-opensearch-datasource/latest/) instead.
@@ -32,9 +33,10 @@ The Elasticsearch data source supports:
 
 - **Metrics queries:** Aggregate and visualize numeric data using bucket and metric aggregations.
 - **Log queries:** Search, filter, and explore log data with Lucene query syntax.
+- **Raw DSL queries:** Write native Elasticsearch Query DSL in Code mode.
+- **ES|QL queries:** Query data using Elasticsearch's pipe-based query language.
 - **Annotations:** Overlay Elasticsearch events on your dashboard graphs.
 - **Alerting:** Create alerts based on Elasticsearch query results.
-- **ES|QL queries (experimental):** Query data using Elasticsearch's pipe-based query language.
 
 ## Before you begin
 
@@ -68,14 +70,18 @@ The following documentation helps you set up and use the Elasticsearch data sour
 
 ## Plugin updates
 
-Starting with Grafana v13.0, the Elasticsearch data source is a standalone plugin, pre-installed in both Grafana OSS and Enterprise. This enables more frequent updates independent of Grafana releases. Grafana automatically checks the plugin catalog and installs the latest version on each server restart.
+Starting with Grafana v13.0, the Elasticsearch data source is a standalone plugin, preinstalled in both Grafana OSS and Enterprise. This enables more frequent updates independent of Grafana releases. Grafana automatically checks the plugin catalog and installs the latest version on each server restart.
+
+{{< admonition type="note" >}}
+Plugins are automatically updated in Grafana Cloud.
+{{< /admonition >}}
 
 To adjust this behavior:
 
 - **Opt out of auto-updates:** Set `preinstall_auto_update` to `false` in your [configuration file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/).
-- **Update manually:** Update at any time from the **Administration > Plugins** page without restarting Grafana.
+- **Update manually:** Update at any time from **Plugins and data** > **Plugins** without restarting Grafana.
 
-The standalone plugin requires Grafana 12.2.0 or later. The Elasticsearch data source bundled with Grafana 12.1 and earlier continues to work as before — these versions are unaffected by the externalisation.
+The standalone plugin requires Grafana 12.2.0 or later. The Elasticsearch data source bundled with Grafana 12.1 and earlier continues to work as before. These versions are unaffected by the externalization.
 
 Users running Grafana 12.2.x through 12.4.x can install the standalone plugin from the plugin catalog if they want the latest features before upgrading to Grafana 13.0. To use the standalone plugin with Grafana 12.2.x through 12.4.x, add the following to your [configuration file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/):
 

--- a/docs/sources/datasources/elasticsearch/alerting/index.md
+++ b/docs/sources/datasources/elasticsearch/alerting/index.md
@@ -15,6 +15,7 @@ labels:
 menuTitle: Alerting
 title: Elasticsearch alerting
 weight: 550
+review_date: 2026-08-10
 ---
 
 # Elasticsearch alerting
@@ -44,12 +45,11 @@ Queries that return time series data allow Grafana to evaluate values over time 
 
 | Query type                     | Alerting support | Notes                                                       |
 | ------------------------------ | ---------------- | ----------------------------------------------------------- |
-| Metrics with Date histogram    | ✅ Full support  | Recommended for alerting                                    |
-| Metrics without Date histogram | ⚠️ Limited       | May not evaluate correctly over time                        |
-| Logs                           | ❌ Not supported | Use metrics queries instead                                 |
-| Raw data                       | ❌ Not supported | Use metrics queries instead                                 |
-| Raw document (deprecated)      | ❌ Not supported | Deprecated since Grafana v10.1. Use metrics queries instead |
-
+| Metrics with Date histogram    | Supported        | Recommended for alerting                                    |
+| Metrics without Date histogram | Limited          | May not evaluate correctly over time                        |
+| Logs                           | Not supported    | Use metrics queries instead                                 |
+| Raw data                       | Not supported    | Use metrics queries instead                                 |
+| Raw document (deprecated)      | Not supported    | Deprecated since Grafana v10.1. Use metrics queries instead |
 ## Create an alert rule
 
 To create an alert rule using Elasticsearch:

--- a/docs/sources/datasources/elasticsearch/alerting/index.md
+++ b/docs/sources/datasources/elasticsearch/alerting/index.md
@@ -50,6 +50,7 @@ Queries that return time series data allow Grafana to evaluate values over time 
 | Logs                           | Not supported    | Use metrics queries instead                                 |
 | Raw data                       | Not supported    | Use metrics queries instead                                 |
 | Raw document (deprecated)      | Not supported    | Deprecated since Grafana v10.1. Use metrics queries instead |
+
 ## Create an alert rule
 
 To create an alert rule using Elasticsearch:

--- a/docs/sources/datasources/elasticsearch/annotations/index.md
+++ b/docs/sources/datasources/elasticsearch/annotations/index.md
@@ -23,7 +23,7 @@ review_date: 2026-08-10
 Annotations overlay event data on your dashboard graphs, helping you correlate log events with metrics.
 You can use Elasticsearch as a data source for annotations to display events such as deployments, alerts, or other significant occurrences on your visualizations.
 
-For general information about annotations, refer to [Annotate visualizations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/build-dashboards/annotate-visualizations/).
+For general information about annotations, refer to [Annotate visualizations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/annotate-visualizations/).
 
 ## Before you begin
 

--- a/docs/sources/datasources/elasticsearch/annotations/index.md
+++ b/docs/sources/datasources/elasticsearch/annotations/index.md
@@ -15,6 +15,7 @@ labels:
 menuTitle: Annotations
 title: Elasticsearch annotations
 weight: 500
+review_date: 2026-08-10
 ---
 
 # Elasticsearch annotations

--- a/docs/sources/datasources/elasticsearch/configure/index.md
+++ b/docs/sources/datasources/elasticsearch/configure/index.md
@@ -23,7 +23,7 @@ review_date: 2026-08-10
 Grafana ships with the Elasticsearch data source preinstalled. You can create a variety of queries to visualize logs or metrics stored in Elasticsearch, and annotate graphs with log events stored in Elasticsearch. For details about updating the standalone plugin, refer to [Plugin updates](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/elasticsearch/#plugin-updates).
 
 For instructions on how to add a data source to Grafana, refer to the [administration documentation](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/data-source-management/).
-Administrators can also [configure the data source via YAML](#provision-the-data-source) with Grafana's provisioning system.
+Administrators can also [configure the data source via YAML](#provision-the-data-source) with the Grafana provisioning system.
 
 ## Before you begin
 
@@ -56,7 +56,7 @@ To add the Elasticsearch data source, complete the following steps:
 1. Click **Elasticsearch** under the **Data source** section.
 1. Click **Add new data source** in the upper right.
 
-You will be taken to the **Settings** tab where you will set up your Elasticsearch configuration.
+You are taken to the **Settings** tab where you set up your Elasticsearch configuration.
 
 ## Configuration options
 
@@ -98,11 +98,11 @@ For information about creating API keys, refer to the [Elasticsearch API keys do
 
 Amazon OpenSearch Service is the successor to Amazon Elasticsearch Service. For Amazon OpenSearch Service, use the [OpenSearch data source](https://grafana.com/docs/plugins/grafana-opensearch-datasource/latest/) instead of this Elasticsearch data source.
 
-If you still connect Grafana's Elasticsearch data source to a domain that requires AWS Signature Version 4 (AWS SigV4), for example a legacy Amazon Elasticsearch Service domain or another SigV4-protected OpenSearch-compatible endpoint, you must sign all requests with SigV4.
+If you still connect the Grafana Elasticsearch data source to a domain that requires AWS Signature Version 4 (AWS SigV4), for example a legacy Amazon Elasticsearch Service domain or another SigV4-protected OpenSearch-compatible endpoint, you must sign all requests with SigV4.
 
 For details on AWS SigV4, refer to the [AWS documentation](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html).
 
-To sign requests, enable SigV4 in Grafana's [configuration](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#sigv4_auth_enabled). After SigV4 is enabled, configure it on the Elasticsearch data source configuration page. For more information about AWS authentication options, refer to [AWS authentication](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/aws-cloudwatch/aws-authentication/).
+To sign requests, enable SigV4 in the Grafana [configuration](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#sigv4_auth_enabled). After SigV4 is enabled, configure it on the Elasticsearch data source configuration page. For more information about AWS authentication options, refer to [AWS authentication](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/aws-cloudwatch/aws-authentication/).
 
 {{< figure src="/static/img/docs/v73/elasticsearch-sigv4-config-editor.png" max-width="500px" class="docs-image--no-shadow" caption="SigV4 configuration for AWS-hosted Elasticsearch-compatible domains" >}}
 
@@ -196,13 +196,13 @@ Configure which fields the data source uses for log messages and log levels.
 
 ### Data links
 
-Data links create a link from a specified field that can be accessed in Explore's logs view. You can add multiple data links by clicking **+ Add**.
+Data links create a link from a specified field that can be accessed in the Explore logs view. You can add multiple data links by clicking **+ Add**.
 
 Each data link configuration consists of:
 
 - **Field** - Sets the name of the field used by the data link.
 
-- **URL/query** - Sets the full link URL if the link is external. If the link is internal, this input serves as a query for the target data source.<br/>In both cases, you can interpolate the value from the field with the `${__value.raw }` macro.
+- **URL/query** - Sets the full link URL if the link is external. If the link is internal, this input serves as a query for the target data source. In both cases, you can interpolate the value from the field with the `${__value.raw }` macro.
 
 - **URL Label** (Optional) - Sets a custom display label for the link. The link label defaults to the full external URL or name of the linked internal data source and is overridden by this setting.
 
@@ -216,13 +216,13 @@ If you use PDC with SigV4 (AWS Signature Version 4 Authentication), the PDC agen
 
 - **Private data source connect** - Click in the box to set the default PDC connection from the drop-down menu or create a new connection.
 
-Once you have configured your Elasticsearch data source options, click **Save & test** to test the connection. A successful connection displays the following message:
+After you have configured your Elasticsearch data source options, click **Save & test** to test the connection. A successful connection displays the following message:
 
 `Elasticsearch data source is healthy.`
 
 ## Provision the data source
 
-You can define and configure the data source in YAML files as part of Grafana's provisioning system.
+You can define and configure the data source in YAML files as part of the Grafana provisioning system.
 For more information about provisioning, and for available configuration options, refer to [Provisioning Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/provisioning/).
 
 {{< admonition type="note" >}}

--- a/docs/sources/datasources/elasticsearch/configure/index.md
+++ b/docs/sources/datasources/elasticsearch/configure/index.md
@@ -15,12 +15,12 @@ labels:
 menuTitle: Configure
 title: Configure the Elasticsearch data source
 weight: 200
+review_date: 2026-08-10
 ---
 
 # Configure the Elasticsearch data source
 
-Grafana ships with built-in support for Elasticsearch.
-You can create a variety of queries to visualize logs or metrics stored in Elasticsearch, and annotate graphs with log events stored in Elasticsearch.
+Grafana ships with the Elasticsearch data source preinstalled. You can create a variety of queries to visualize logs or metrics stored in Elasticsearch, and annotate graphs with log events stored in Elasticsearch. For details about updating the standalone plugin, refer to [Plugin updates](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/elasticsearch/#plugin-updates).
 
 For instructions on how to add a data source to Grafana, refer to the [administration documentation](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/data-source-management/).
 Administrators can also [configure the data source via YAML](#provision-the-data-source) with Grafana's provisioning system.
@@ -68,11 +68,13 @@ Configure the following basic settings for the Elasticsearch data source:
 
 ## Connection
 
+Set the HTTP endpoint Grafana uses to reach your Elasticsearch cluster.
+
 - **URL** - The URL of your Elasticsearch server, including the port. Examples: `http://localhost:9200`, `http://elasticsearch.example.com:9200`.
 
 ## Authentication
 
-Select an authentication method from the drop-down menu:
+Choose how Grafana authenticates to Elasticsearch. Select an authentication method from the drop-down menu:
 
 - **Basic authentication** - Enter the username and password for your Elasticsearch user.
 
@@ -92,20 +94,17 @@ To authenticate using an Elasticsearch API key, select **No authentication** and
 
 For information about creating API keys, refer to the [Elasticsearch API keys documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html).
 
-### Amazon Elasticsearch Service
+### Amazon OpenSearch Service and SigV4
 
-If you use Amazon Elasticsearch Service, you can use Grafana's Elasticsearch data source to visualize data from it.
+Amazon OpenSearch Service is the successor to Amazon Elasticsearch Service. For Amazon OpenSearch Service, use the [OpenSearch data source](https://grafana.com/docs/plugins/grafana-opensearch-datasource/latest/) instead of this Elasticsearch data source.
 
-If you use an AWS Identity and Access Management (IAM) policy to control access to your Amazon Elasticsearch Service domain, you must use AWS Signature Version 4 (AWS SigV4) to sign all requests to that domain.
+If you still connect Grafana's Elasticsearch data source to a domain that requires AWS Signature Version 4 (AWS SigV4), for example a legacy Amazon Elasticsearch Service domain or another SigV4-protected OpenSearch-compatible endpoint, you must sign all requests with SigV4.
 
 For details on AWS SigV4, refer to the [AWS documentation](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html).
 
-To sign requests to your Amazon Elasticsearch Service domain, you can enable SigV4 in Grafana's [configuration](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#sigv4_auth_enabled).
+To sign requests, enable SigV4 in Grafana's [configuration](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#sigv4_auth_enabled). After SigV4 is enabled, configure it on the Elasticsearch data source configuration page. For more information about AWS authentication options, refer to [AWS authentication](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/aws-cloudwatch/aws-authentication/).
 
-Once AWS SigV4 is enabled, you can configure it on the Elasticsearch data source configuration page.
-For more information about AWS authentication options, refer to [AWS authentication](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/aws-cloudwatch/aws-authentication/).
-
-{{< figure src="/static/img/docs/v73/elasticsearch-sigv4-config-editor.png" max-width="500px" class="docs-image--no-shadow" caption="SigV4 configuration for AWS Elasticsearch Service" >}}
+{{< figure src="/static/img/docs/v73/elasticsearch-sigv4-config-editor.png" max-width="500px" class="docs-image--no-shadow" caption="SigV4 configuration for AWS-hosted Elasticsearch-compatible domains" >}}
 
 ### TLS settings
 
@@ -145,6 +144,7 @@ The following settings are specific to the Elasticsearch data source.
   - **Wildcard patterns** - Use `*` to match multiple indices. Examples: `logs-*`, `metrics-*`, `filebeat-*`.
   - **Time patterns** - Use date placeholders for time-based indices. Wrap the fixed portion in square brackets. Examples: `[logstash-]YYYY.MM.DD`, `[metrics-]YYYY.MM`.
   - **Specific index** - Enter the exact index name. Example: `application-logs`.
+  - **Cross-cluster search** - Use the `cluster:index` pattern to query remote clusters configured in Elasticsearch. Example: `logs-cluster:logs-*`. Cross-cluster search is always available. No feature toggle is required.
 
 - **Pattern** - Select the matching pattern if you use a time pattern in your index name. Options include:
   - no pattern

--- a/docs/sources/datasources/elasticsearch/configure/index.md
+++ b/docs/sources/datasources/elasticsearch/configure/index.md
@@ -42,7 +42,7 @@ To configure the Elasticsearch data source, you need:
 
 When Elasticsearch security features are enabled, you must configure the following cluster privileges for the user or API key that Grafana uses to connect:
 
-- **monitor** - Necessary to retrieve the version information of the connected Elasticsearch instance.
+- **monitor** - Required for the connection health check. Grants access to the `_cluster/health` endpoint and retrieves the version information of the connected Elasticsearch instance.
 - **view_index_metadata** - Required for accessing mapping definitions of indices.
 - **read** - Grants the ability to perform search and retrieval operations on indices. This is essential for querying and extracting data from the cluster.
 

--- a/docs/sources/datasources/elasticsearch/query-editor/index.md
+++ b/docs/sources/datasources/elasticsearch/query-editor/index.md
@@ -89,12 +89,12 @@ Use the **+ sign** to the right to add multiple metrics to your query. Click on 
 - **Group by options** - Create multiple group by options when constructing your Elasticsearch query. Date histogram is the default option. The following options are available in the drop-down menu:
   - terms - refer to [Terms aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html).
   - filter - refer to [Filter aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-filter-aggregation.html).
-  - geo hash grid - refer to [Geohash grid aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-geohashgrid-aggregation.html).
+  - `geo hash grid` - refer to the [`geohash_grid` aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-geohashgrid-aggregation.html).
   - date histogram - for time series queries. Refer to [Date histogram aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html).
   - histogram - Depicts frequency distributions. Refer to [Histogram aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-histogram-aggregation.html).
   - nested (experimental) - Refer to [Nested aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-nested-aggregation.html).
 
-Each group by option will have a different subset of options to further narrow your query.
+Each group by option has a different subset of options to further narrow your query.
 
 The following options are specific to the **date histogram** bucket aggregation option.
 
@@ -108,7 +108,7 @@ The following options are specific to the **date histogram** bucket aggregation 
 Configure the following options for the **terms** bucket aggregation option:
 
 - **Order** - Sets the order of data. Options are `top` or `bottom.`
-- **Size** - Limits the number of documents, or size of the data set. You can set a custom number or `no limit`.
+- **Size** - Limits the number of documents, or size of the dataset. You can set a custom number or `no limit`.
 - **Min doc count** - The minimum amount of data to include in your query. The default is `0`.
 - **Order by** - Order terms by `term value`, `doc count` or `count`.
 - **Missing** - Defines how documents missing a value should be treated. Missing values are ignored by default, but they can be treated as if they had a value. Refer to [Missing value](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html#_missing_value_5) in the Elasticsearch documentation for more information.
@@ -118,9 +118,9 @@ Configure the following options for the **filters** bucket aggregation option:
 - **Query** - Specify the query to create a bucket of documents (data). Examples are `hostname:"hostname1"`, `product:"widget5"`. Use the \* wildcard to match any number of characters.
 - **Label** - Add a label or name to the bucket.
 
-Configure the following options for the **geo hash grid** bucket aggregation option:
+Configure the following options for the **`geo hash grid`** bucket aggregation option:
 
-- **Precision** - Specifies the number of characters of the geo hash.
+- **Precision** - Specifies the number of characters of the `geo hash`.
 
 Configure the following options for the **histogram** bucket aggregation option:
 
@@ -129,7 +129,7 @@ Configure the following options for the **histogram** bucket aggregation option:
 
 The **nested** group by option is currently experimental, you can select a field and then settings specific to that field.
 
-Click the **+ sign** to add multiple group by options. The data will grouped in order (first by, then by).
+Click the **+ sign** to add multiple group by options. The data is grouped in order (first by, then by).
 
 {{< figure src="/static/img/docs/elasticsearch/group-by-then-by-10.2.png" max-width="850px" class="docs-image--no-shadow" caption="Group by options" >}}
 
@@ -164,7 +164,7 @@ When in Code mode, you can write complete Elasticsearch query DSL in JSON format
 - **Syntax highlighting** for JSON
 - **Auto-formatting** - Click the **Format** button or press `Shift+Alt+F` to format your query
 - **Keyboard shortcuts** - Press `Ctrl+Enter` (or `Cmd+Enter` on Mac) to run the query
-- **Real-time validation** - Invalid JSON will be highlighted with error messages
+- **Real-time validation** - Invalid JSON is highlighted with error messages
 
 ### Time range handling
 
@@ -196,7 +196,7 @@ An example query applying dashboard time range using the `@timestamp` field:
 
 The raw query editor supports all query types:
 
-- **Metrics queries** are used to query time series data with aggregations. The query parser will automatically extract bucket and metric aggregations from your DSL and use them for response processing.
+- **Metrics queries** are used to query time series data with aggregations. The query parser automatically extracts bucket and metric aggregations from your DSL and uses them for response processing.
 - **Logs queries** are used to query log data.
 
 ## ES|QL query editor
@@ -262,12 +262,10 @@ FROM logs-*
 
 #### PromQL metrics queries
 
-When you select the **Metrics** query type, ES|QL also accepts PromQL source commands. Grafana processes the response as time series frames, the same way it does for ES|QL `STATS` queries:
+When you select the **Metrics** query type, ES|QL also accepts the `PROMQL` source command. Grafana processes the response as time series frames, the same way it does for ES|QL `STATS` queries. `PROMQL` must be the first command in the query (leading comments are allowed):
 
 ```esql
-FROM metrics-*
-| WHERE service.name == "api-gateway"
-| PROMQL "rate(http_requests_total[5m])"
+PROMQL index=metrics-* step=1m avg(metrics.system.cpu.logical.count)
 ```
 
 ### Learn more about ES|QL

--- a/docs/sources/datasources/elasticsearch/query-editor/index.md
+++ b/docs/sources/datasources/elasticsearch/query-editor/index.md
@@ -1,7 +1,6 @@
 ---
 aliases:
   - ../../data-sources/elasticsearch/query-editor/
-  - ../../data-sources/elasticsearch/template-variables/
 description: Guide for using the Elasticsearch data source's query editor
 keywords:
   - grafana
@@ -17,10 +16,10 @@ labels:
     - cloud
     - enterprise
     - oss
-    - data source
 menuTitle: Query editor
 title: Elasticsearch query editor
 weight: 300
+review_date: 2026-08-10
 ---
 
 # Elasticsearch query editor
@@ -50,6 +49,8 @@ Elasticsearch groups aggregations into three categories:
 
 There are two types of queries you can create with the Elasticsearch query builder. Each type is explained in detail below.
 
+Use the **Preserve query** toggle to keep your Lucene query when you switch between **Metrics**, **Logs**, **Raw Data**, and **Raw Document**. When the toggle is off (the default for new queries), switching query types clears the Lucene query. Grafana remembers your last Preserve query choice in the browser for new queries.
+
 ### Metrics query type
 
 Metrics queries aggregate data and produce calculations such as count, min, max, and more. Click the metric box to view options in the drop-down menu. The default is `count`.
@@ -67,6 +68,12 @@ Metrics queries aggregate data and produce calculations such as count, min, max,
   - unique count - refer to [Cardinality aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-cardinality-aggregation.html)
   - top metrics - refer to [Top metrics aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-top-metrics.html)
   - rate - refer to [Rate aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-rate-aggregation.html)
+
+- **Sibling bucket aggregations** - These metrics compute an outer statistic over a per-group inner statistic within each time bucket. For example, **Sum Bucket** with an inner **Max** produces a sum of maxima across hosts. The following options are available:
+  - Sum Bucket - refer to [Sum bucket aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-sum-bucket-aggregation.html)
+  - Max Bucket - refer to [Max bucket aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-max-bucket-aggregation.html)
+  - Min Bucket - refer to [Min bucket aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-min-bucket-aggregation.html)
+  - Average Bucket - refer to [Avg bucket aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-avg-bucket-aggregation.html)
 
 - **Pipeline aggregations** - Pipeline aggregations work on the output of other aggregations rather than on documents. The following pipeline aggregations are available:
   - moving function - Calculates a value based on a sliding window of aggregated values. Refer to [Moving function aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-movfn-aggregation.html).
@@ -132,11 +139,16 @@ Logs queries analyze Elasticsearch log data. You can configure the following opt
 
 - **Logs Options/Limit** - Limits the number of logs to analyze. The default is `500`.
 
+## Query options
+
+Open the **Options** section in the query editor to configure query-level settings:
+
+- **Limit** or **Size** - For Logs and Raw Data queries, sets the maximum number of documents to return. The default is `500`.
+- **Include runtime fields** - When enabled, runtime fields defined in the index mapping are included in the response. This option is available in Builder mode.
+
 ## Raw query editor
 
-{{< docs/experimental product="The raw query editor" featureFlag="elasticsearchRawDSLQuery" >}}
-
-The raw query editor allows you to write Elasticsearch queries using the native [Elasticsearch Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html).
+The raw query editor lets you write Elasticsearch queries using the native [Elasticsearch Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html).
 
 ### Switch between Builder and Code modes
 
@@ -189,11 +201,11 @@ The raw query editor supports all query types:
 
 ## ES|QL query editor
 
-{{< docs/experimental product="The ES|QL query editor" featureFlag="elasticsearchESQLQuery" >}}
-
-Introduced in Grafana v13.0, the ES|QL query editor lets you query Elasticsearch using [ES|QL (Elasticsearch Query Language)](https://www.elastic.co/docs/reference/query-languages/esql), a pipe-based query language. Unlike Lucene queries that rely on aggregation configuration in the builder UI, ES|QL lets you express filtering, aggregation, and transformation in a single query string.
+The ES|QL query editor lets you query Elasticsearch using [ES|QL (Elasticsearch Query Language)](https://www.elastic.co/docs/reference/query-languages/esql), a pipe-based query language. Unlike Lucene queries that rely on aggregation configuration in the builder UI, ES|QL lets you express filtering, aggregation, and transformation in a single query string.
 
 For an introduction to ES|QL syntax and concepts, refer to [Get started with ES|QL queries](https://www.elastic.co/docs/reference/query-languages/esql/esql-getting-started) in the Elasticsearch documentation.
+
+When an ES|QL query does not include a time filter, Grafana automatically adds a time range filter based on the dashboard or Explore time picker.
 
 ### Index selection
 
@@ -206,9 +218,9 @@ How the editor handles index selection depends on your data source configuration
 
 The ES|QL code editor provides:
 
-- **Code suggestions** -- Auto-complete for ES|QL commands and functions
-- **Error highlighting** -- Syntax errors are highlighted in the editor and error messages from Elasticsearch are displayed directly
-- **Syntax highlighting** -- ES|QL keywords, operators, and values are color-coded for readability
+- **Code suggestions** - Auto-complete for ES|QL commands and functions
+- **Error highlighting** - Syntax errors are highlighted in the editor and error messages from Elasticsearch are displayed directly
+- **Syntax highlighting** - ES|QL keywords, operators, and values are color-coded for readability
 
 ### Example queries
 
@@ -248,14 +260,24 @@ FROM logs-*
 | LIMIT 100
 ```
 
+#### PromQL metrics queries
+
+When you select the **Metrics** query type, ES|QL also accepts PromQL source commands. Grafana processes the response as time series frames, the same way it does for ES|QL `STATS` queries:
+
+```esql
+FROM metrics-*
+| WHERE service.name == "api-gateway"
+| PROMQL "rate(http_requests_total[5m])"
+```
+
 ### Learn more about ES|QL
 
 For more information about ES|QL syntax, commands, and functions, refer to the following Elasticsearch documentation:
 
-- [ES|QL reference](https://www.elastic.co/docs/reference/query-languages/esql) -- Overview of the ES|QL query language
-- [ES|QL commands](https://www.elastic.co/docs/reference/query-languages/esql/commands) -- Source and processing commands (`FROM`, `WHERE`, `STATS`, `EVAL`, `KEEP`, `SORT`, `LIMIT`, and more)
-- [ES|QL functions and operators](https://www.elastic.co/docs/reference/query-languages/esql/functions-operators) -- Aggregation, math, string, date, and other functions
-- [ES|QL syntax](https://www.elastic.co/docs/reference/query-languages/esql/esql-syntax) -- Identifiers, literals, operators, and special characters
+- [ES|QL reference](https://www.elastic.co/docs/reference/query-languages/esql) - Overview of the ES|QL query language
+- [ES|QL commands](https://www.elastic.co/docs/reference/query-languages/esql/commands) - Source and processing commands (`FROM`, `WHERE`, `STATS`, `EVAL`, `KEEP`, `SORT`, `LIMIT`, and more)
+- [ES|QL functions and operators](https://www.elastic.co/docs/reference/query-languages/esql/functions-operators) - Aggregation, math, string, date, and other functions
+- [ES|QL syntax](https://www.elastic.co/docs/reference/query-languages/esql/esql-syntax) - Identifiers, literals, operators, and special characters
 
 ## Use template variables
 

--- a/docs/sources/datasources/elasticsearch/template-variables/index.md
+++ b/docs/sources/datasources/elasticsearch/template-variables/index.md
@@ -25,7 +25,7 @@ Instead of hard-coding details such as server, application, and sensor names in 
 Grafana lists these variables in drop-down select boxes at the top of the dashboard to help you change the data displayed in your dashboard.
 Grafana refers to such variables as template variables.
 
-For an introduction to templating and template variables, refer to the [Templating](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/) and [Add and manage variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/add-template-variables/) documentation.
+For an introduction to templating and template variables, refer to the [Templating](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/variables/) and [Add and manage variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/variables/add-template-variables/) documentation.
 
 ## Use filters
 
@@ -53,7 +53,7 @@ The Elasticsearch data source supports two variable syntaxes for use in the **Qu
 - `[[varname]]`, such as `hostname:[[hostname]]`
 
 When the _Multi-value_ or _Include all value_ options are enabled, Grafana converts the labels from plain text to a Lucene-compatible condition.
-For details, refer to the [Multi-value variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/add-template-variables/#multi-value-variables) documentation.
+For details, refer to the [Multi-value variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/variables/add-template-variables/#multi-value-variables) documentation.
 
 ## Use variables in queries
 

--- a/docs/sources/datasources/elasticsearch/template-variables/index.md
+++ b/docs/sources/datasources/elasticsearch/template-variables/index.md
@@ -16,6 +16,7 @@ labels:
 menuTitle: Template variables
 title: Elasticsearch template variables
 weight: 400
+review_date: 2026-08-10
 ---
 
 # Elasticsearch template variables

--- a/docs/sources/datasources/elasticsearch/troubleshooting/index.md
+++ b/docs/sources/datasources/elasticsearch/troubleshooting/index.md
@@ -15,6 +15,7 @@ labels:
 menuTitle: Troubleshooting
 title: Troubleshoot issues with the Elasticsearch data source
 weight: 600
+review_date: 2026-08-10
 ---
 
 # Troubleshoot issues with the Elasticsearch data source
@@ -92,7 +93,7 @@ The following errors occur when there are issues with authentication credentials
 1. Verify the user has read access to the specified index.
 1. Check Elasticsearch security settings and role mappings.
 1. Ensure the user has permission to access the `_cluster/health` endpoint.
-1. If using AWS Elasticsearch Service with SigV4 authentication, verify the IAM policy grants the required permissions.
+1. If using SigV4 authentication with an AWS-hosted Elasticsearch-compatible domain, verify the IAM policy grants the required permissions.
 
 ## Cluster health errors
 
@@ -131,7 +132,7 @@ The following errors occur when there are issues with the configured index or in
 
 ### Index not found
 
-**Error message:** "Error validating index: index_not_found"
+**Error message:** "Error validating index: `index_not_found`"
 
 **Cause:** The specified index or index pattern does not match any existing indices.
 
@@ -168,9 +169,10 @@ The following errors occur when there are issues with query syntax or configurat
 **Solution:**
 
 1. Reduce the time range of your query.
-1. Increase the date histogram interval (for example, change from `10s` to `1m`).
+1. Increase the date histogram interval (for example, change from `10s` to `1m`). For nested aggregations with **Interval** set to `Auto`, newer plugin versions widen the auto interval when the query would exceed `max_buckets`.
 1. Add filters to reduce the number of documents being aggregated.
-1. Increase the `search.max_buckets` setting in Elasticsearch (requires cluster admin access).
+1. Increase the `search.max_buckets` setting in Elasticsearch (requires cluster administrator access).
+1. Update the Elasticsearch plugin if you are on an older version. Refer to [Plugin updates](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/elasticsearch/#plugin-updates).
 
 ### Required field missing
 
@@ -200,7 +202,7 @@ The following errors occur when there are Elasticsearch version compatibility is
 
 ### Unsupported Elasticsearch version
 
-**Error message:** "Support for Elasticsearch versions after their end-of-life (currently versions &lt; 7.16) was removed. Using unsupported version of Elasticsearch may lead to unexpected and incorrect results."
+**Error message:** "Support for Elasticsearch versions after their end-of-life (currently versions &lt; 7.17) was removed. Using unsupported version of Elasticsearch may lead to unexpected and incorrect results."
 
 **Cause:** The Elasticsearch version is no longer supported by the Grafana data source.
 
@@ -209,6 +211,18 @@ The following errors occur when there are Elasticsearch version compatibility is
 1. Upgrade Elasticsearch to a supported version (7.17+, 8.x, or 9.x).
 1. Refer to [Elastic Product End of Life Dates](https://www.elastic.co/support/eol) for version support information.
 1. Note that queries may still work, but Grafana does not guarantee functionality for unsupported versions.
+
+### Elastic Cloud Serverless health check returns 410 Gone
+
+**Error message:** Health check fails with status `410 Gone` when connecting to Elastic Cloud Serverless.
+
+**Cause:** An older version of the Elasticsearch plugin used a health-check request that Elastic Cloud Serverless no longer accepts.
+
+**Solution:**
+
+1. Update the Elasticsearch plugin to **12.8.0** or later. Refer to [Plugin updates](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/elasticsearch/#plugin-updates).
+1. Confirm `preinstall_auto_update` is enabled so Grafana installs the latest plugin on restart, or update manually from **Plugins and data** > **Plugins**.
+1. Click **Save & test** again after the plugin update.
 
 ## Other common issues
 
@@ -237,25 +251,18 @@ The following issues don't produce specific error messages but are commonly enco
 1. Check Elasticsearch cluster performance and resource utilization.
 1. Consider using index aliases or data streams for better query routing.
 
-### CORS errors in browser console
+### Browser access mode disabled
 
-**Cause:** Cross-Origin Resource Sharing (CORS) is blocking requests from the browser to Elasticsearch.
+**Error message:** Direct browser access is no longer available, or the data source fails when configured for browser access.
+
+**Cause:** Browser access mode was removed in Grafana 9.2.0. The Elasticsearch data source must use Server (proxy) access so the Grafana backend connects to Elasticsearch.
 
 **Solution:**
 
-1. Use Server (proxy) access mode instead of Browser access mode in the data source configuration.
-1. If Browser access is required, configure CORS settings in Elasticsearch:
-
-```yaml
-http.cors.enabled: true
-http.cors.allow-origin: '<your-grafana-url>'
-http.cors.allow-headers: 'Authorization, Content-Type'
-http.cors.allow-credentials: true
-```
-
-{{< admonition type="note" >}}
-Server (proxy) access mode is recommended for security and reliability.
-{{< /admonition >}}
+1. Open the data source configuration in Grafana.
+1. Ensure access mode is set to **Server** (proxy). Provisioned data sources should use `access: proxy`.
+1. Click **Save & test** to verify the connection.
+1. If you still see browser CORS errors, upgrade Grafana and the Elasticsearch plugin. Older configurations that attempted direct browser-to-Elasticsearch requests are no longer supported.
 
 ## Get additional help
 


### PR DESCRIPTION
Quarterly documentation update for the Elasticsearch data source, aligned with data source documentation conventions. Content was cross-referenced against the externalized plugin at [grafana/grafana-elasticsearch-datasource](https://github.com/grafana/grafana-elasticsearch-datasource) (catalog v12.8.0) for accuracy. Set review_date: 2026-08-10 on all seven pages.

_index.md: Reworded intro from "built-in" to preinstalled standalone plugin with a link to Plugin updates, removed "(experimental)" from ES|QL and added Raw DSL to Key capabilities, added the Grafana Cloud auto-update admonition to Plugin updates, changed the manual update path to Plugins and data > Plugins, fixed em dash and "externalisation" wording, normalized the Build dashboards link to the visualizations/dashboards/ path

configure/index.md: Replaced "ships with built-in support" with preinstalled-plugin wording, added intros under Connection and Authentication, reframed the Amazon Elasticsearch Service section as Amazon OpenSearch Service and SigV4 pointing to the OpenSearch data source while retaining SigV4 guidance, added a cross-cluster search (cluster:index) index-name bullet, style clean-up (present tense, "After" instead of "Once", removed table <br/>)

query-editor/index.md: Removed the elasticsearchRawDSLQuery and elasticsearchESQLQuery experimental shortcodes (toggles removed in plugin 12.7.0), documented the Sum/Max/Min/Average Bucket sibling aggregations, added the Preserve query toggle description, added a Query options section covering Include runtime fields, added a PROMQL metrics example and the automatic ES|QL time-range injection note, removed the invalid data source product label and stray template-variables alias, present-tense and word-list fixes

template-variables/index.md: Normalized Templating, Add and manage variables, and Multi-value variables links to the visualizations/dashboards/ path

annotations/index.md: Normalized the Annotate visualizations link to the visualizations/dashboards/ path

alerting/index.md: Replaced emoji compatibility cells with plain text (Supported / Limited / Not supported)

troubleshooting/index.md: Corrected the unsupported-version message from < 7.16 to < 7.17, added an Elastic Cloud Serverless health check returns 410 Gone entry (fixed in plugin 12.8.0), replaced the CORS/Browser section with an Browser access mode disabled entry directing to Server (proxy) access, updated AWS SigV4 wording, added an auto-interval note under Too many buckets

Technical accuracy verified against:

plugin.json catalog metadata (version 12.8.0, grafanaDependency >=12.2.0, preinstalled plugin ID elasticsearch)
CHANGELOG.md / release notes for 12.7.0–12.8.0 (toggle removals, sibling aggregations, Preserve query, Serverless 410 fix, cross-cluster search)
src/components/QueryEditor/MetricAggregationsEditor/utils.ts (sibling bucket labels)
src/components/QueryEditor/ElasticsearchQueryOptions.tsx (Include runtime fields option, Builder-mode only)
src/components/QueryEditor/preserveQueryPreference.ts (Preserve query default behavior)
pkg/elasticsearch/esql_response_processor.go (PROMQL source-command handling and example syntax)
pkg/setting/setting_plugins.go (preinstalled plugins list)

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
