### PR TITLE
fix: sanitize X-Dashboard-Title and X-Panel-Title header values to ASCII per RFC 7230 [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -380,6 +380,27 @@ describe('DataSourceWithBackend', () => {
     `);
   });
 
+  test('sanitizes non-ASCII characters in dashboard and panel title headers', async () => {
+    const { mock, ds } = createMockDatasource();
+    await firstValueFrom(
+      ds.query({
+        maxDataPoints: 10,
+        intervalMs: 5000,
+        targets: [{ refId: 'A' }],
+        dashboardUID: 'dashA',
+        dashboardTitle: 'Cotações Diárias 2026',
+        panelId: 123,
+        panelName: 'Painel de Vendas 🚀',
+        range: getDefaultTimeRange(),
+      } as DataQueryRequest)
+    );
+
+    const args = mock.calls[0][0];
+    expect(args.headers?.['X-Dashboard-Title']).toBe('Cotaes Dirias 2026');
+    expect(args.headers?.['X-Panel-Title']).toBe('Painel de Vendas ');
+    expect(args.headers?.['X-Dashboard-Title']).toBe(args.headers?.['X-Dashboard-Title'].replace(/[^\x20-\x7E]/g, ''));
+  });
+
   test('correctly creates expression queries', async () => {
     const { mock, ds } = createMockDatasource();
     await firstValueFrom(

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -75,6 +75,18 @@ enum PluginRequestHeaders {
 }
 
 /**
+ * HTTP header field values must consist only of printable ASCII characters
+ * (RFC 7230, section 3.2.6). Dashboard and panel titles may contain arbitrary
+ * Unicode (e.g. accented text), which browsers serialize as raw high-ASCII
+ * bytes in custom headers and strict WAFs/proxies reject. Strip everything
+ * outside the printable ASCII range so the request passes compliance checks.
+ */
+function sanitizeHeaderValue(value: string): string {
+  return value.replace(/[^\x20-\x7E]/g, '');
+}
+
+
+/**
  * Describes the details in the payload returned when checking the health of a data source
  * plugin.
  *
@@ -269,13 +281,13 @@ class DataSourceWithBackend<
     if (request.dashboardUID) {
       headers[PluginRequestHeaders.DashboardUID] = request.dashboardUID;
       if (request.dashboardTitle) {
-        headers[PluginRequestHeaders.DashboardTitle] = request.dashboardTitle;
+        headers[PluginRequestHeaders.DashboardTitle] = sanitizeHeaderValue(request.dashboardTitle);
       }
       if (request.panelId) {
         headers[PluginRequestHeaders.PanelID] = `${request.panelId}`;
       }
       if (request.panelName) {
-        headers[PluginRequestHeaders.PanelTitle] = request.panelName;
+        headers[PluginRequestHeaders.PanelTitle] = sanitizeHeaderValue(request.panelName);
       }
     }
     if (request.panelPluginId) {


### PR DESCRIPTION
## What

Strip non-ASCII characters from the `X-Dashboard-Title` and `X-Panel-Title` header values before they are sent on the wire, so that dashboard and panel titles containing accented or non-ASCII characters (e.g. Portuguese `Cotações`, emoji) do not trigger HTTP compliance violations in strict WAFs and reverse proxies that enforce RFC 7230.

The request headers are set by the frontend; the /api/ds/query backend receives them raw. When a title contains non-ASCII characters, the browser's Fetch/XHR header serialization coerces each character to a single byte in the 0x80-0xFF range (Latin-1/Windows-1252 style "ByteString" coercion), producing header values with raw high-ASCII bytes on the wire. Strict HTTP-compliant infrastructure (WAFs, reverse proxies) enforcing RFC 7230 header field-value rules rejects these.

## Changes

1. **`DataSourceWithBackend.ts`** — Added a `sanitizeHeaderValue()` helper that strips all characters outside the printable ASCII range (`\\x20-\\x7E`). Applied it to both `X-Dashboard-Title` and `X-Panel-Title` header values.

2. **`DataSourceWithBackend.test.ts`** — Added a test case verifying that non-ASCII characters are stripped from both title headers.

## Related issue

Fixes #130448

## References

- [RFC 7230, Section 3.2.6](https://httpwg.org/specs/rfc7230.html#field.value)
- Original contextual-headers implementation: #60301
