### PR TITLE
fix(annotations): use index-based access to avoid annotation_tag ID zero bug in AddMany

### DIFF
--- a/pkg/services/annotations/annotationsimpl/xorm_store.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store.go
@@ -155,12 +155,12 @@ func (r *xormRepositoryImpl) AddMany(ctx context.Context, items []annotations.It
 			return err
 		}
 
-		for i, item := range hasTags {
+		for i := range hasTags {
+			item := &hasTags[i]
 			if _, err := sess.Table("annotation").Insert(item); err != nil {
 				return err
 			}
-			itemWithID := &hasTags[i]
-			if err := r.ensureTags(ctx, itemWithID.ID, itemWithID.Tags); err != nil {
+			if err := r.ensureTags(ctx, item.ID, item.Tags); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Fixes #130459

## Bug
In `AddMany`, annotations with tags are inserted via a `for i, item := range hasTags` range loop.
`item` is a copy, so when `Insert` sets the generated annotation ID on the struct, it only sets it on the copy — not on `hasTags[i]`. Then `ensureTags(ctx, hasTags[i].ID, ...)` passes `annotationID = 0` because the original slice element was never updated.

This causes `annotation_tag` rows to be created with `annotation_id = 0`, creating orphaned rows that accumulate over time.

## Fix
Use index-based access (`for i := range hasTags`) with a pointer to the slice element, ensuring `Insert` writes the generated ID back to the correct location before `ensureTags` reads it.