### PR TITLE
fix(alerting): save options tooltip values on input change instead of onBlur [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
@@ -257,7 +257,7 @@ export function MaxDataPointsOption({
         width={10}
         placeholder={DEFAULT_MAX_DATA_POINTS.toString()}
         spellCheck={false}
-        onBlur={onMaxDataPointsBlur}
+        onChange={onMaxDataPointsBlur}
         defaultValue={value}
       />
     </InlineField>
@@ -299,7 +299,7 @@ export function MinIntervalOption({
         width={10}
         placeholder={DEFAULT_MIN_INTERVAL}
         spellCheck={false}
-        onBlur={onMinIntervalBlur}
+        onChange={onMinIntervalBlur}
         defaultValue={value}
       />
     </InlineField>


### PR DESCRIPTION
Fixes #111664

## What this PR does
The `MaxDataPointsOption` and `MinIntervalOption` components saved their values using the `onBlur` event handler. However, because these inputs live inside a `Toggletip`, when the user clicks outside the tooltip the tooltip unmounts its content **before** the `blur` event fires on the input. As a result, changed values for the **Interval** and **Max data points** were silently discarded.

## Fix
Switch both inputs from `onBlur` to `onChange` so the value is committed immediately on every input change, preventing data loss when the tooltip closes.

## Files changed
- `public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx`