### PR TITLE
fix(assistant): Fix panel editor losing changes after the dashboard is rebuilt

### DIFF
--- a/public/app/features/dashboard-scene/mutation-api/commands/applySpec.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/applySpec.ts
@@ -157,6 +157,9 @@ export const applySpecCommand: MutationCommand<ApplySpecPayload> = {
       const newState = sceneUtils.cloneSceneObjectState(rebuilt.state, { key: scene.state.key });
       scene.setState(newState);
 
+      // setState merges, so an open editor would keep pointing at the discarded tree.
+      scene.reattachPanelEditor();
+
       // Return the re-serialized spec so the caller gets the rekeyed element
       // names (rebuild rekeys to `panel-<id>`) without a follow-up GET_SPEC.
       // Best effort: a serialization failure still reports success.

--- a/public/app/features/dashboard-scene/mutation-api/commands/specValidation.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/specValidation.test.ts
@@ -63,6 +63,7 @@ function makeSceneContext(): MutationContext {
       getK8SMetadata: () => ({ name: 'dash-uid', generation: 1, creationTimestamp: '2026-01-01T00:00:00Z' }),
     },
     setState: jest.fn(),
+    reattachPanelEditor: jest.fn(),
   };
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- structural stub of the DashboardScene surface this command reads
   return { scene: scene as unknown as DashboardScene } satisfies MutationContext;
@@ -74,6 +75,7 @@ describe('APPLY_SPEC validate flag', () => {
   afterEach(() => {
     mockTransformSaveModelSchemaV2ToScene.mockReset();
     mockTransformSceneToSaveModelSchemaV2.mockReset();
+    jest.mocked(sceneContext.scene.reattachPanelEditor).mockClear();
   });
 
   it('defaults `validate` to false in the payload schema (non-breaking)', () => {
@@ -108,6 +110,7 @@ describe('APPLY_SPEC validate flag', () => {
     const result = await applySpecCommand.handler({ spec: specWithNulls, validate: true }, sceneContext);
 
     expect(result.success).toBe(true);
+    expect(sceneContext.scene.reattachPanelEditor).toHaveBeenCalled();
     const dto = mockTransformSaveModelSchemaV2ToScene.mock.calls[0][0];
     expect(dto.spec.tags).toEqual([]);
     expect(dto.spec.annotations).toEqual([]);
@@ -119,6 +122,7 @@ describe('APPLY_SPEC validate flag', () => {
     mockTransformSaveModelSchemaV2ToScene.mockReturnValue({ state: {} });
     const result = await applySpecCommand.handler({ spec: validSpec, validate: false }, sceneContext);
     expect(result.success).toBe(true);
+    expect(sceneContext.scene.reattachPanelEditor).toHaveBeenCalled();
     const dto = mockTransformSaveModelSchemaV2ToScene.mock.calls[0][0];
     expect(dto.spec).toBe(validSpec);
   });

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
@@ -77,6 +77,7 @@ export class PanelEditor extends SceneObjectBase<PanelEditorState> {
   private _originalSaveModel!: Panel;
   private _changesHaveBeenMade = false;
   private _tableViewPanelActivationAdded = false;
+  private _skipPendingCommit = false;
 
   public constructor(state: PanelEditorState) {
     super(state);
@@ -132,7 +133,22 @@ export class PanelEditor extends SceneObjectBase<PanelEditorState> {
     };
   }
 
+  /**
+   * Drop the pending panel-edit undo entry instead of committing it on deactivate.
+   *
+   * Used when this editor is being replaced because the layout tree it captured
+   * has been discarded: the entry's source is that dead layout item, which never
+   * activates again, so the sidebar would retry it forever.
+   */
+  public skipPendingCommit() {
+    this._skipPendingCommit = true;
+  }
+
   private commitChanges() {
+    if (this._skipPendingCommit) {
+      return;
+    }
+
     if (!this.state.isDirty && !this._changesHaveBeenMade) {
       // Nothing to commit
       return;
@@ -427,6 +443,38 @@ export class PanelEditor extends SceneObjectBase<PanelEditorState> {
     // This is to notify UrlSyncManager that a new object has been added to scene that requires url sync
     this.publishEvent(new NewSceneObjectAddedEvent(dataPane), true);
   };
+}
+
+export interface PendingPanelEdit {
+  /** The editor, when it could be built right away. */
+  editor?: PanelEditor;
+  /** Abandons the wait. Only set when the editor was deferred. */
+  cancel?: () => void;
+}
+
+/**
+ * Open panel edit for `panel`, deferring while a library panel is still loading
+ * — it is an empty shell until then, so the editor must not open on it.
+ *
+ * Shared by the URL sync and by the re-attach after a scene rebuild, so both get
+ * the library-panel wait and the unconfigured-panel flag.
+ */
+export function openPanelEditFor(panel: VizPanel, onReady: (editor: PanelEditor) => void): PendingPanelEdit {
+  const build = () => buildPanelEditScene(panel, panel.state.pluginId === UNCONFIGURED_PANEL_PLUGIN_ID);
+  const libPanel = getLibraryPanelBehavior(panel);
+
+  if (!libPanel || libPanel.state.isLoaded) {
+    return { editor: build() };
+  }
+
+  const sub = libPanel.subscribeToState((state) => {
+    if (state.isLoaded) {
+      sub.unsubscribe();
+      onReady(build());
+    }
+  });
+
+  return { cancel: () => sub.unsubscribe() };
 }
 
 export function buildPanelEditScene(panel: VizPanel, isNewPanel = false): PanelEditor {

--- a/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
@@ -3494,6 +3494,53 @@ function createV2DashboardWithTransformations(transformationIds: string[]): Dash
   };
 }
 
+describe('reattachPanelEditor', () => {
+  /** Replace `body` wholesale with an equivalent tree, as APPLY_SPEC's rebuild-and-swap does. */
+  function swapBody(scene: DashboardScene, panelKeys: string[]) {
+    scene.setState({
+      body: new DefaultGridLayoutManager({
+        grid: new SceneGridLayout({
+          children: panelKeys.map(
+            (key, index) =>
+              new DashboardGridItem({
+                key: `griditem-rebuilt-${index}`,
+                x: 0,
+                body: new VizPanel({ title: 'Panel A', key, pluginId: 'table' }),
+              })
+          ),
+        }),
+      }),
+    });
+  }
+
+  it('re-binds the editor onto the panel in the replaced layout tree', () => {
+    const scene = buildTestScene();
+    scene.onEnterEditMode();
+    scene.setState({ editPanel: buildPanelEditScene(findVizPanelByKey(scene, 'panel-1')!) });
+
+    swapBody(scene, ['panel-1']);
+    const rebuilt = findVizPanelByKey(scene, 'panel-1')!;
+    expect(scene.state.editPanel!.state.panelRef.resolve()).not.toBe(rebuilt);
+
+    scene.reattachPanelEditor();
+
+    expect(scene.state.editPanel!.state.panelRef.resolve()).toBe(rebuilt);
+    scene.state.editPanel!.state.panelRef.resolve().setState({ title: 'Renamed by user' });
+    expect(rebuilt.state.title).toBe('Renamed by user');
+  });
+
+  it('closes the editor when the new tree no longer has its panel', () => {
+    const scene = buildTestScene();
+    scene.onEnterEditMode();
+    scene.setState({ editPanel: buildPanelEditScene(findVizPanelByKey(scene, 'panel-1')!) });
+
+    swapBody(scene, ['panel-9']);
+    scene.reattachPanelEditor();
+
+    expect(scene.state.editPanel).toBeUndefined();
+  });
+});
+
 function buildTestScene(overrides?: Partial<DashboardSceneState>) {
   const scene = new DashboardScene({
     title: 'hello',

--- a/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
@@ -22,6 +22,7 @@ import {
   SceneDataTransformer,
   LocalValueVariable,
   MultiValueVariable,
+  type SceneObject,
 } from '@grafana/scenes';
 import { type Dashboard, DashboardCursorSync, type LibraryPanel } from '@grafana/schema';
 import { type Spec as DashboardV2Spec, type VariableKind } from '@grafana/schema/apis/dashboard.grafana.app/v2';
@@ -46,6 +47,7 @@ import { buildPanelEditScene } from '../panel-edit/PanelEditor';
 import { SaveDashboardDrawer } from '../saving/SaveDashboardDrawer';
 import { createWorker } from '../saving/createDetectChangesWorker';
 import { buildGridItemForPanel, transformSaveModelToScene } from '../serialization/transformSaveModelToScene';
+import { transformSceneToSaveModelSchemaV2 } from '../serialization/transformSceneToSaveModelSchemaV2';
 import * as DashboardTemplateExtensionModule from '../settings/enterprise-components/DashboardTemplateExtension';
 import { getCloneKey } from '../utils/clone';
 import { dashboardSceneGraph } from '../utils/dashboardSceneGraph';
@@ -3496,47 +3498,86 @@ function createV2DashboardWithTransformations(transformationIds: string[]): Dash
 
 describe('reattachPanelEditor', () => {
   /** Replace `body` wholesale with an equivalent tree, as APPLY_SPEC's rebuild-and-swap does. */
-  function swapBody(scene: DashboardScene, panelKeys: string[]) {
+  function swapBody(scene: DashboardScene, key: string, behaviors: SceneObject[] = []) {
     scene.setState({
-      body: new DefaultGridLayoutManager({
-        grid: new SceneGridLayout({
-          children: panelKeys.map(
-            (key, index) =>
-              new DashboardGridItem({
-                key: `griditem-rebuilt-${index}`,
-                x: 0,
-                body: new VizPanel({ title: 'Panel A', key, pluginId: 'table' }),
-              })
-          ),
-        }),
-      }),
+      body: DefaultGridLayoutManager.fromVizPanels([
+        new VizPanel({ title: 'Panel A', key, pluginId: 'table', $behaviors: behaviors }),
+      ]),
     });
+  }
+
+  function openEditorOnPanel1(scene: DashboardScene) {
+    const editPanel = buildPanelEditScene(findVizPanelByKey(scene, 'panel-1')!);
+    scene.setState({ editPanel });
+    return editPanel;
   }
 
   it('re-binds the editor onto the panel in the replaced layout tree', () => {
     const scene = buildTestScene();
     scene.onEnterEditMode();
-    scene.setState({ editPanel: buildPanelEditScene(findVizPanelByKey(scene, 'panel-1')!) });
+    openEditorOnPanel1(scene);
 
-    swapBody(scene, ['panel-1']);
-    const rebuilt = findVizPanelByKey(scene, 'panel-1')!;
-    expect(scene.state.editPanel!.state.panelRef.resolve()).not.toBe(rebuilt);
-
+    swapBody(scene, 'panel-1');
     scene.reattachPanelEditor();
 
-    expect(scene.state.editPanel!.state.panelRef.resolve()).toBe(rebuilt);
+    // The bug was that edits made through the editor never reached serialization.
     scene.state.editPanel!.state.panelRef.resolve().setState({ title: 'Renamed by user' });
-    expect(rebuilt.state.title).toBe('Renamed by user');
+    expect(transformSceneToSaveModelSchemaV2(scene).elements['panel-1']).toMatchObject({
+      spec: { title: 'Renamed by user' },
+    });
   });
 
   it('closes the editor when the new tree no longer has its panel', () => {
     const scene = buildTestScene();
     scene.onEnterEditMode();
-    scene.setState({ editPanel: buildPanelEditScene(findVizPanelByKey(scene, 'panel-1')!) });
+    openEditorOnPanel1(scene);
 
-    swapBody(scene, ['panel-9']);
+    swapBody(scene, 'panel-9');
     scene.reattachPanelEditor();
 
+    expect(scene.state.editPanel).toBeUndefined();
+  });
+
+  it("drops the outgoing editor's pending undo entry, which is sourced from the discarded tree", () => {
+    const scene = buildTestScene();
+    scene.onEnterEditMode();
+    const skip = jest.spyOn(openEditorOnPanel1(scene), 'skipPendingCommit');
+
+    swapBody(scene, 'panel-1');
+    scene.reattachPanelEditor();
+
+    expect(skip).toHaveBeenCalled();
+  });
+
+  it('waits for a library panel to load before opening the editor on it', () => {
+    const scene = buildTestScene();
+    scene.onEnterEditMode();
+    openEditorOnPanel1(scene);
+
+    // The rebuild resets library panels to unloaded.
+    const libPanel = new LibraryPanelBehavior({ isLoaded: false, uid: 'lib-uid', name: 'lib' });
+    swapBody(scene, 'panel-1', [libPanel]);
+    scene.reattachPanelEditor();
+    expect(scene.state.editPanel).toBeUndefined();
+
+    libPanel.setState({ isLoaded: true });
+    expect(scene.state.editPanel!.state.panelRef.resolve().state.key).toBe('panel-1');
+  });
+
+  it('abandons a pending library-panel wait when the scene is rebuilt again', () => {
+    const scene = buildTestScene();
+    scene.onEnterEditMode();
+    openEditorOnPanel1(scene);
+
+    const stale = new LibraryPanelBehavior({ isLoaded: false, uid: 'lib-uid', name: 'lib' });
+    swapBody(scene, 'panel-1', [stale]);
+    scene.reattachPanelEditor();
+
+    swapBody(scene, 'panel-1');
+    scene.reattachPanelEditor();
+
+    // The superseded wait must not reopen the editor on the panel it captured.
+    stale.setState({ isLoaded: true });
     expect(scene.state.editPanel).toBeUndefined();
   });
 });

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -63,7 +63,7 @@ import {
   ManagerKind,
   type ResourceForCreate,
 } from '../../apiserver/types';
-import { buildPanelEditScene } from '../panel-edit/PanelEditor';
+import { openPanelEditFor } from '../panel-edit/PanelEditor';
 import { DashboardSceneChangeTracker } from '../saving/DashboardSceneChangeTracker';
 import { SaveDashboardDrawer } from '../saving/SaveDashboardDrawer';
 import { type DashboardChangeInfo } from '../saving/shared';
@@ -115,7 +115,6 @@ import { createMutationClient } from './DashboardMutationClientSetter';
 import { DashboardSceneRenderer } from './DashboardSceneRenderer';
 import { DashboardSceneUrlSync } from './DashboardSceneUrlSync';
 import { LibraryPanelBehavior } from './LibraryPanelBehavior';
-import { UNCONFIGURED_PANEL_PLUGIN_ID } from './UnconfiguredPanel';
 import { setupKeyboardShortcuts } from './keyboardShortcuts';
 import { AutoGridItem } from './layout-auto-grid/AutoGridItem';
 import { DashboardGridItem } from './layout-default/DashboardGridItem';
@@ -169,6 +168,8 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
    * Handles url sync
    */
   protected _urlSync = new DashboardSceneUrlSync(this);
+  /** Cancels a panel-edit re-attach still waiting on a library panel to load. */
+  private _pendingPanelEdit?: () => void;
   /**
    * Get notified when variables change
    */
@@ -614,39 +615,31 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
     return this._initialState !== undefined;
   }
 
-  /**
-   * Re-bind an open panel editor onto the CURRENT layout tree.
-   *
-   * `PanelEditor` captures both the `VizPanel` it edits and that panel's layout
-   * item when it is constructed. Anything that replaces `state.body` wholesale
-   * — today that is APPLY_SPEC's rebuild-and-swap — therefore leaves the editor
-   * driving objects that are no longer reachable from the scene. The pane keeps
-   * rendering and accepting input, but nothing the user changes there reaches
-   * `transformSceneToSaveModel*`, so their edit is invisible to a save or a read
-   * and is silently reverted by the next wholesale write.
-   *
-   * Rebuilding the editor against the new panel is the smallest correct fix: it
-   * re-runs the same path the URL sync uses, so the pane resumes with a valid
-   * layout-item parent. A panel the new tree no longer contains has no editor to
-   * rebuild, so the pane is closed instead.
-   *
-   * `viewPanel` and `inspectPanelKey` need no equivalent — they hold panel KEYS
-   * and are resolved against the current scene on use.
-   */
+  // Re-bind an open panel editor onto the CURRENT layout tree.
   public reattachPanelEditor() {
+    // Always first: a wait left over from an earlier rebuild would reopen the
+    // editor on a panel that is no longer in the tree. It cannot be resumed here
+    // because the pane was closed while waiting, so a rebuild abandons it.
+    this._pendingPanelEdit?.();
+    this._pendingPanelEdit = undefined;
+
     const { editPanel } = this.state;
     if (!editPanel) {
       return;
     }
 
-    // Same find+open path as DashboardSceneUrlSync so cancel/discard semantics
-    // for unconfigured panels survive the rebuild.
+    // The outgoing editor's deactivate would stash an undo entry sourced from the
+    // discarded layout item, which never activates again and would be retried
+    // forever. The rebuild supersedes it anyway.
+    editPanel.skipPendingCommit();
+
     const panel = findEditPanel(this, editPanel.getUrlKey());
-    this.setState({
-      editPanel: panel
-        ? buildPanelEditScene(panel, panel.state.pluginId === UNCONFIGURED_PANEL_PLUGIN_ID)
-        : undefined,
-    });
+    const pending = panel ? openPanelEditFor(panel, (rebuilt) => this.setState({ editPanel: rebuilt })) : {};
+    this._pendingPanelEdit = pending.cancel;
+
+    // `undefined` while a library panel loads, so the pane closes rather than
+    // rendering over an empty shell.
+    this.setState({ editPanel: pending.editor });
   }
 
   /**

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -63,6 +63,7 @@ import {
   ManagerKind,
   type ResourceForCreate,
 } from '../../apiserver/types';
+import { buildPanelEditScene } from '../panel-edit/PanelEditor';
 import { DashboardSceneChangeTracker } from '../saving/DashboardSceneChangeTracker';
 import { SaveDashboardDrawer } from '../saving/SaveDashboardDrawer';
 import { type DashboardChangeInfo } from '../saving/shared';
@@ -98,6 +99,7 @@ import {
 } from '../utils/predefinedVariableDenyList';
 import { fetchPredefinedVariables, isPredefinedOrigin } from '../utils/predefinedVariables';
 import {
+  findEditPanel,
   getClosestVizPanel,
   getDashboardSceneFor,
   getDefaultVizPanel,
@@ -113,6 +115,7 @@ import { createMutationClient } from './DashboardMutationClientSetter';
 import { DashboardSceneRenderer } from './DashboardSceneRenderer';
 import { DashboardSceneUrlSync } from './DashboardSceneUrlSync';
 import { LibraryPanelBehavior } from './LibraryPanelBehavior';
+import { UNCONFIGURED_PANEL_PLUGIN_ID } from './UnconfiguredPanel';
 import { setupKeyboardShortcuts } from './keyboardShortcuts';
 import { AutoGridItem } from './layout-auto-grid/AutoGridItem';
 import { DashboardGridItem } from './layout-default/DashboardGridItem';
@@ -609,6 +612,41 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
 
   public canDiscard() {
     return this._initialState !== undefined;
+  }
+
+  /**
+   * Re-bind an open panel editor onto the CURRENT layout tree.
+   *
+   * `PanelEditor` captures both the `VizPanel` it edits and that panel's layout
+   * item when it is constructed. Anything that replaces `state.body` wholesale
+   * — today that is APPLY_SPEC's rebuild-and-swap — therefore leaves the editor
+   * driving objects that are no longer reachable from the scene. The pane keeps
+   * rendering and accepting input, but nothing the user changes there reaches
+   * `transformSceneToSaveModel*`, so their edit is invisible to a save or a read
+   * and is silently reverted by the next wholesale write.
+   *
+   * Rebuilding the editor against the new panel is the smallest correct fix: it
+   * re-runs the same path the URL sync uses, so the pane resumes with a valid
+   * layout-item parent. A panel the new tree no longer contains has no editor to
+   * rebuild, so the pane is closed instead.
+   *
+   * `viewPanel` and `inspectPanelKey` need no equivalent — they hold panel KEYS
+   * and are resolved against the current scene on use.
+   */
+  public reattachPanelEditor() {
+    const { editPanel } = this.state;
+    if (!editPanel) {
+      return;
+    }
+
+    // Same find+open path as DashboardSceneUrlSync so cancel/discard semantics
+    // for unconfigured panels survive the rebuild.
+    const panel = findEditPanel(this, editPanel.getUrlKey());
+    this.setState({
+      editPanel: panel
+        ? buildPanelEditScene(panel, panel.state.pluginId === UNCONFIGURED_PANEL_PLUGIN_ID)
+        : undefined,
+    });
   }
 
   /**

--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
@@ -1,13 +1,11 @@
-import { type SceneObjectUrlSyncHandler, type SceneObjectUrlValues, type VizPanel } from '@grafana/scenes';
+import { type SceneObjectUrlSyncHandler, type SceneObjectUrlValues } from '@grafana/scenes';
 
-import { buildPanelEditScene } from '../panel-edit/PanelEditor';
+import { openPanelEditFor } from '../panel-edit/PanelEditor';
 import { createDashboardEditViewFor } from '../settings/createDashboardEditViewFor';
 import { ShareDrawer } from '../sharing/ShareDrawer/ShareDrawer';
-import { findEditPanel, getLibraryPanelBehavior } from '../utils/utils';
+import { findEditPanel } from '../utils/utils';
 
 import { type DashboardScene } from './DashboardScene';
-import { type LibraryPanelBehavior } from './LibraryPanelBehavior';
-import { UNCONFIGURED_PANEL_PLUGIN_ID } from './UnconfiguredPanel';
 import { DefaultGridLayoutManager } from './layout-default/DefaultGridLayoutManager';
 import { type DashboardSceneState } from './types/dashboard';
 
@@ -85,13 +83,13 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
         this._scene.onEnterEditMode();
       }
 
-      const libPanelBehavior = getLibraryPanelBehavior(panel);
-      if (libPanelBehavior && !libPanelBehavior?.state.isLoaded) {
-        this._waitForLibPanelToLoadBeforeEnteringPanelEdit(panel, libPanelBehavior);
+      const { editor } = openPanelEditFor(panel, (editPanel) => this._scene.setState({ editPanel }));
+      if (!editor) {
+        // Waiting on a library panel; the editor opens once it has loaded.
         return;
       }
 
-      update.editPanel = buildPanelEditScene(panel, panel.state.pluginId === UNCONFIGURED_PANEL_PLUGIN_ID);
+      update.editPanel = editor;
     } else if (editPanel && values.editPanel === null) {
       update.editPanel = undefined;
     }
@@ -118,19 +116,5 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
     if (Object.keys(update).length > 0) {
       this._scene.setState(update);
     }
-  }
-
-  /**
-   * Temporary solution, with some refactoring of PanelEditor we can remove this
-   */
-  private _waitForLibPanelToLoadBeforeEnteringPanelEdit(panel: VizPanel, libPanel: LibraryPanelBehavior) {
-    const sub = libPanel.subscribeToState((state) => {
-      if (state.isLoaded) {
-        this._scene.setState({
-          editPanel: buildPanelEditScene(panel, panel.state.pluginId === UNCONFIGURED_PANEL_PLUGIN_ID),
-        });
-        sub.unsubscribe();
-      }
-    });
   }
 }


### PR DESCRIPTION
Before: 

https://github.com/user-attachments/assets/14524c48-a9a8-453d-802f-d57bdc228a80

After:

https://github.com/user-attachments/assets/c21ebe06-b8a3-48d0-a31f-13fa56cff381

**What is this feature?**

Re-binds an open panel editor onto the current layout tree after the dashboard scene has been replaced wholesale.

`PanelEditor` captures both the `VizPanel` it edits and that panel's layout item when it is constructed. `APPLY_SPEC` rebuilds the scene from a spec and swaps the result in with `scene.setState(newState)` — and because `setState` merges, the existing `editPanel` survives, still driving objects that are no longer reachable from `state.body`.

`DashboardScene.reattachPanelEditor()` finds the panel by id in the new tree and rebuilds the editor against it, mirroring what `DashboardSceneUrlSync` does when opening panel edit from the URL:

- the same `findEditPanel` lookup, and the `isNewPanel` flag for unconfigured panels, so cancel/discard semantics survive
- the same wait for a library panel to finish loading — the rebuild resets library panels to unloaded, and opening the editor on one before it loads would edit an empty shell. That wait is now a shared `openPanelEditWhenLibraryPanelLoads` helper used by both call sites
- if the applied spec no longer contains the panel, the editor is closed instead. Clearing the state also clears the `editPanel` URL param, since `getUrlState` derives it from state

The outgoing editor's pending undo entry is dropped via a new `PanelEditor.skipPendingCommit()`. On deactivate, `commitChanges()` stashes a `DashboardEditActionEvent` on the sidebar whose `source` is the editor's layout item — after a rebuild that item belongs to the discarded tree and never activates again, and `DashboardSidebar.performPanelEditAction` retries an inactive source on a `setTimeout` loop with no bound. The rebuild supersedes that entry anyway.

**Why do we need this feature?**

With a panel open for editing, any `APPLY_SPEC` leaves the pane detached from the dashboard. Observed on `main`:

- the panel preview goes blank
- the options fields stop holding input — keystrokes land on the orphaned panel and are reverted on the next re-render
- anything that does land is invisible to `transformSceneToSaveModelSchemaV2`, so it is absent from a save or a read, and is overwritten by the next write

Reproduction:

1. Open a dashboard and open a panel for editing (`?editPanel=1`)
2. Change the panel title in the editor — `GET_SPEC` returns the new title, as expected
3. Run any `APPLY_SPEC` against the dashboard (for example, ask Grafana Assistant to edit a panel)
4. Change the title in the editor again — the pane no longer works, and `GET_SPEC` still returns the value from step 2

Step 4 is the user-visible bug: your edit appears to be accepted and then silently disappears.

**Who is this feature for?**

Anyone editing a panel while something writes the whole dashboard spec. Today that is users working with Grafana Assistant, which uses `APPLY_SPEC` for every dashboard change — it is the reported path. The fix is at the scene level rather than in the command, so any future caller that replaces the layout tree gets the same behaviour.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

- The rebuilt editor takes a fresh original-state snapshot, so panel-edit **Discard** now reverts to the post-rebuild state rather than to the state when the pane was first opened, and the editor's dirty flag resets. That seems right given the dashboard underneath has been replaced, but it is a behaviour change worth a second opinion.
- Two other places perform the same clone-and-swap — `settings/JsonModelEditView.tsx` and `sidebar/codePaneUtils.ts`. I have not confirmed whether the panel editor can be open in those flows; if it can, they should call `reattachPanelEditor()` too.
- `viewPanel` and `inspectPanelKey` need no equivalent: they hold panel keys and are resolved against the current scene on use.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
