### PR TITLE
fix: migration index rebuild retry mechanism changed based on distributor usage

### DIFF
--- a/pkg/storage/unified/migrations/migrator.go
+++ b/pkg/storage/unified/migrations/migrator.go
@@ -247,13 +247,17 @@ func (m *unifiedMigration) RebuildIndexes(ctx context.Context, opts RebuildIndex
 		boff.Wait()
 	}
 
-	err := boff.ErrCause()
-	if ctx.Err() != nil {
-		logger.Error("context ended while rebuilding indexes", "error", err, "lastError", lastErr, "attempts", boff.NumRetries())
-		return err
+	if lastErr == nil {
+		lastErr = fmt.Errorf("unknown error rebuilding indexes after %d attempts", boff.NumRetries())
 	}
 
-	logger.Error("failed to rebuild indexes after retries", "error", err, "lastError", lastErr, "attempts", boff.NumRetries())
+	err := fmt.Errorf("%w: last rebuild error: %w", boff.ErrCause(), lastErr)
+	if ctx.Err() != nil {
+		logger.Error("context ended while rebuilding indexes", "error", err, "attempts", boff.NumRetries())
+	} else {
+		logger.Error("failed to rebuild indexes after retries", "error", err, "attempts", boff.NumRetries())
+	}
+
 	return err
 }
 

--- a/pkg/storage/unified/migrations/migrator.go
+++ b/pkg/storage/unified/migrations/migrator.go
@@ -247,15 +247,14 @@ func (m *unifiedMigration) RebuildIndexes(ctx context.Context, opts RebuildIndex
 		boff.Wait()
 	}
 
-	cause := boff.ErrCause()
-	if lastErr == nil {
-		lastErr = cause
-	}
-	if lastErr != nil {
-		logger.Error("failed to rebuild indexes after retries", "error", lastErr, "cause", cause, "attempts", boff.NumRetries())
+	err := boff.ErrCause()
+	if ctx.Err() != nil {
+		logger.Error("context ended while rebuilding indexes", "error", err, "lastError", lastErr, "attempts", boff.NumRetries())
+		return err
 	}
 
-	return lastErr
+	logger.Error("failed to rebuild indexes after retries", "error", err, "lastError", lastErr, "attempts", boff.NumRetries())
+	return err
 }
 
 func (m *unifiedMigration) rebuildIndexes(ctx context.Context, opts RebuildIndexOptions) error {

--- a/pkg/storage/unified/migrations/migrator.go
+++ b/pkg/storage/unified/migrations/migrator.go
@@ -36,6 +36,15 @@ type unifiedMigration struct {
 	client         resource.ResourceClient
 	log            log.Logger
 	registry       *MigrationRegistry
+	rebuildBackoff *backoff.Config
+}
+
+type Option func(*unifiedMigration)
+
+func WithRebuildBackoff(cfg backoff.Config) Option {
+	return func(m *unifiedMigration) {
+		m.rebuildBackoff = &cfg
+	}
 }
 
 // streamProvider abstracts the different ways to create a bulk process stream
@@ -69,11 +78,20 @@ func ProvideUnifiedMigrator(
 	client resource.ResourceClient,
 	registry *MigrationRegistry,
 ) UnifiedMigrator {
+	return NewUnifiedMigrator(client, registry)
+}
+
+func NewUnifiedMigrator(
+	client resource.ResourceClient,
+	registry *MigrationRegistry,
+	opts ...Option,
+) UnifiedMigrator {
 	return newUnifiedMigrator(
 		&resourceClientStreamProvider{client: client},
 		client,
 		log.New("storage.unified.migrator"),
 		registry,
+		opts...,
 	)
 }
 
@@ -82,13 +100,18 @@ func newUnifiedMigrator(
 	client resource.ResourceClient,
 	log log.Logger,
 	registry *MigrationRegistry,
+	opts ...Option,
 ) UnifiedMigrator {
-	return &unifiedMigration{
+	m := &unifiedMigration{
 		streamProvider: streamProvider,
 		client:         client,
 		log:            log,
 		registry:       registry,
 	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
 }
 
 func (m *unifiedMigration) Migrate(ctx context.Context, opts MigrateOptions) (*resourcepb.BulkResponse, error) {
@@ -179,34 +202,60 @@ type RebuildIndexOptions struct {
 	MigrationFinishedAt time.Time
 }
 
-func (m *unifiedMigration) RebuildIndexes(ctx context.Context, opts RebuildIndexOptions) error {
-	m.log.Info("start rebuilding index for resources", "namespace", opts.NamespaceInfo.Value, "orgId", opts.NamespaceInfo.OrgID, "resources", opts.Resources)
-	defer m.log.Info("finished rebuilding index for resources", "namespace", opts.NamespaceInfo.Value, "orgId", opts.NamespaceInfo.OrgID, "resources", opts.Resources)
-
-	boff := backoff.New(ctx, backoff.Config{
+var (
+	singleInstanceRebuildBackoff = backoff.Config{
 		MinBackoff: 500 * time.Millisecond,
 		MaxBackoff: 3 * time.Second,
 		MaxRetries: 5,
-	})
+	}
+
+	distributorRebuildBackoff = backoff.Config{
+		MinBackoff: 5 * time.Second,
+		MaxBackoff: 30 * time.Second,
+		MaxRetries: 10,
+	}
+)
+
+func (m *unifiedMigration) backoffConfig(opts RebuildIndexOptions) backoff.Config {
+	switch {
+	case m.rebuildBackoff != nil:
+		return *m.rebuildBackoff
+	case opts.UsingDistributor:
+		return distributorRebuildBackoff
+	default:
+		return singleInstanceRebuildBackoff
+	}
+}
+
+func (m *unifiedMigration) RebuildIndexes(ctx context.Context, opts RebuildIndexOptions) error {
+	logger := m.log.New("namespace", opts.NamespaceInfo.Value, "orgId", opts.NamespaceInfo.OrgID, "resources", opts.Resources)
+	logger.Info("start rebuilding index for resources")
+
+	cfg := m.backoffConfig(opts)
+	boff := backoff.New(ctx, cfg)
 
 	var lastErr error
 	for boff.Ongoing() {
 		err := m.rebuildIndexes(ctx, opts)
 		if err == nil {
+			logger.Info("finished rebuilding index for resources", "attempts", boff.NumRetries()+1)
 			return nil
 		}
 
 		lastErr = err
-		m.log.Error("retrying rebuild indexes", "namespace", opts.NamespaceInfo.Value, "orgId", opts.NamespaceInfo.OrgID, "error", err, "attempt", boff.NumRetries())
+		logger.Error("retrying rebuild indexes", "error", err, "attempt", boff.NumRetries()+1, "maxAttempts", cfg.MaxRetries)
 		boff.Wait()
 	}
 
-	if err := boff.ErrCause(); err != nil {
-		m.log.Error("failed to rebuild indexes after retries", "namespace", opts.NamespaceInfo.Value, "orgId", opts.NamespaceInfo.OrgID, "error", lastErr)
-		return lastErr
+	cause := boff.ErrCause()
+	if lastErr == nil {
+		lastErr = cause
+	}
+	if lastErr != nil {
+		logger.Error("failed to rebuild indexes after retries", "error", lastErr, "cause", cause, "attempts", boff.NumRetries())
 	}
 
-	return nil
+	return lastErr
 }
 
 func (m *unifiedMigration) rebuildIndexes(ctx context.Context, opts RebuildIndexOptions) error {

--- a/pkg/storage/unified/migrations/migrator_test.go
+++ b/pkg/storage/unified/migrations/migrator_test.go
@@ -743,6 +743,72 @@ func TestUnifiedMigration_RebuildIndexes_RetrySuccess(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestUnifiedMigration_RebuildIndexes_ContextCanceledDuringBackoff(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	mockClient := resource.NewMockResourceClient(t)
+	mockClient.EXPECT().
+		RebuildIndexes(mock.Anything, mock.Anything).
+		RunAndReturn(func(context.Context, *resourcepb.RebuildIndexesRequest, ...grpc.CallOption) (*resourcepb.RebuildIndexesResponse, error) {
+			cancel()
+			return nil, fmt.Errorf("temporary failure")
+		}).
+		Once()
+
+	registry := migrations.NewMigrationRegistry()
+	registry.Register(dashboard.FoldersDashboardsMigration(dashboardmigrator.ProvideFoldersDashboardsMigrator(nil)))
+	migrator := migrations.NewUnifiedMigrator(
+		mockClient,
+		registry,
+		migrations.WithRebuildBackoff(backoff.Config{
+			MinBackoff: time.Minute,
+			MaxBackoff: time.Minute,
+			MaxRetries: 5,
+		}),
+	)
+
+	err := migrator.RebuildIndexes(ctx, migrations.RebuildIndexOptions{
+		NamespaceInfo:       authlib.NamespaceInfo{OrgID: 1, Value: "stack-123"},
+		Resources:           []schema.GroupResource{{Group: "dashboard.grafana.app", Resource: "dashboards"}},
+		MigrationFinishedAt: time.Now(),
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.NotContains(t, err.Error(), "temporary failure")
+}
+
+func TestUnifiedMigration_RebuildIndexes_ContextDeadlineExceeded(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	t.Cleanup(cancel)
+
+	mockClient := resource.NewMockResourceClient(t)
+	mockClient.EXPECT().
+		RebuildIndexes(mock.Anything, mock.Anything).
+		Return(nil, fmt.Errorf("temporary failure")).
+		Maybe()
+
+	registry := migrations.NewMigrationRegistry()
+	registry.Register(dashboard.FoldersDashboardsMigration(dashboardmigrator.ProvideFoldersDashboardsMigrator(nil)))
+	migrator := migrations.NewUnifiedMigrator(
+		mockClient,
+		registry,
+		migrations.WithRebuildBackoff(backoff.Config{
+			MinBackoff: 5 * time.Millisecond,
+			MaxBackoff: 10 * time.Millisecond,
+			MaxRetries: 0,
+		}),
+	)
+
+	err := migrator.RebuildIndexes(ctx, migrations.RebuildIndexOptions{
+		NamespaceInfo:       authlib.NamespaceInfo{OrgID: 1, Value: "stack-123"},
+		Resources:           []schema.GroupResource{{Group: "dashboard.grafana.app", Resource: "dashboards"}},
+		MigrationFinishedAt: time.Now(),
+	})
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
 func TestUnifiedMigration_RebuildIndexes_UsingDistributor(t *testing.T) {
 	migrationFinishedAt := time.Now()
 

--- a/pkg/storage/unified/migrations/migrator_test.go
+++ b/pkg/storage/unified/migrations/migrator_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	authlib "github.com/grafana/authlib/types"
+	"github.com/grafana/dskit/backoff"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/infra/db"
 	dashboard "github.com/grafana/grafana/pkg/registry/apis/dashboard"
@@ -355,6 +356,12 @@ const (
 	snapshotsID            = "snapshots migration"
 )
 
+var fastRebuildBackoff = backoff.Config{
+	MinBackoff: time.Millisecond,
+	MaxBackoff: 2 * time.Millisecond,
+	MaxRetries: 5,
+}
+
 var migrationIDsToDefault = map[string]bool{
 	playlistsID:            true,
 	foldersAndDashboardsID: true, // Auto-migrated when resource count is below threshold
@@ -652,9 +659,10 @@ func TestUnifiedMigration_RebuildIndexes(t *testing.T) {
 			registry.Register(dashboard.FoldersDashboardsMigration(dashboardmigrator.ProvideFoldersDashboardsMigrator(nil)))
 			registry.Register(playlist.PlaylistMigration(playlistmigrator.ProvidePlaylistMigrator(nil)))
 			registry.Register(shorturl.ShortURLMigration(shorturlmigrator.ProvideShortURLMigrator(nil)))
-			migrator := migrations.ProvideUnifiedMigrator(
+			migrator := migrations.NewUnifiedMigrator(
 				mockClient,
 				registry,
+				migrations.WithRebuildBackoff(fastRebuildBackoff),
 			)
 
 			// Create test data
@@ -708,9 +716,10 @@ func TestUnifiedMigration_RebuildIndexes_RetrySuccess(t *testing.T) {
 	registry.Register(dashboard.FoldersDashboardsMigration(dashboardmigrator.ProvideFoldersDashboardsMigrator(nil)))
 	registry.Register(playlist.PlaylistMigration(playlistmigrator.ProvidePlaylistMigrator(nil)))
 	registry.Register(shorturl.ShortURLMigration(shorturlmigrator.ProvideShortURLMigrator(nil)))
-	migrator := migrations.ProvideUnifiedMigrator(
+	migrator := migrations.NewUnifiedMigrator(
 		mockClient,
 		registry,
+		migrations.WithRebuildBackoff(fastRebuildBackoff),
 	)
 
 	// Create test data
@@ -896,9 +905,10 @@ func TestUnifiedMigration_RebuildIndexes_UsingDistributor(t *testing.T) {
 			registry.Register(dashboard.FoldersDashboardsMigration(dashboardmigrator.ProvideFoldersDashboardsMigrator(nil)))
 			registry.Register(playlist.PlaylistMigration(playlistmigrator.ProvidePlaylistMigrator(nil)))
 			registry.Register(shorturl.ShortURLMigration(shorturlmigrator.ProvideShortURLMigrator(nil)))
-			migrator := migrations.ProvideUnifiedMigrator(
+			migrator := migrations.NewUnifiedMigrator(
 				mockClient,
 				registry,
+				migrations.WithRebuildBackoff(fastRebuildBackoff),
 			)
 
 			// Create test data
@@ -968,9 +978,10 @@ func TestUnifiedMigration_RebuildIndexes_UsingDistributor_RetrySuccess(t *testin
 	registry.Register(dashboard.FoldersDashboardsMigration(dashboardmigrator.ProvideFoldersDashboardsMigrator(nil)))
 	registry.Register(playlist.PlaylistMigration(playlistmigrator.ProvidePlaylistMigrator(nil)))
 	registry.Register(shorturl.ShortURLMigration(shorturlmigrator.ProvideShortURLMigrator(nil)))
-	migrator := migrations.ProvideUnifiedMigrator(
+	migrator := migrations.NewUnifiedMigrator(
 		mockClient,
 		registry,
+		migrations.WithRebuildBackoff(fastRebuildBackoff),
 	)
 
 	// Create test data

--- a/pkg/storage/unified/migrations/migrator_test.go
+++ b/pkg/storage/unified/migrations/migrator_test.go
@@ -775,7 +775,7 @@ func TestUnifiedMigration_RebuildIndexes_ContextCanceledDuringBackoff(t *testing
 	})
 
 	require.ErrorIs(t, err, context.Canceled)
-	require.NotContains(t, err.Error(), "temporary failure")
+	require.ErrorContains(t, err, "temporary failure")
 }
 
 func TestUnifiedMigration_RebuildIndexes_ContextDeadlineExceeded(t *testing.T) {


### PR DESCRIPTION
- `RebuildIndexes` retried with a single policy (500ms–3s, 5 attempts). That's fine for a single instance, but with the distributor a rebuild has to fan out to every storage instance and report a fresh build time for each, so the old window gave up before the slower instances could finish.
- Split the retry policy in two: single-instance keeps 500ms–3s / 5 attempts; distributor gets 5s–30s / 10 attempts.
Retry policy is overridable at construction via NewUnifiedMigrator(client, registry, WithRebuildBackoff(cfg)), so tests don't sleep through real backoff.
- Fixed `RebuildIndexes` returning nil when the context was already canceled on entry, it now returns the backoff cause instead of reporting a rebuild that never ran as successful.
- Logging: attempt/maxAttempts on each retry, attempt count on success and failure, repeated namespace/orgId fields hoisted into a child logger, and the "finished" line no longer fires on failure.


Ticket: https://github.com/grafana/search-and-storage-team/issues/835