### PR TITLE
fix: serve `GetUserVisibleNamespaces` from the search/bleve index (metadata-only)

### DIFF
--- a/pkg/services/folder/folderimpl/unifiedstore.go
+++ b/pkg/services/folder/folderimpl/unifiedstore.go
@@ -339,6 +339,13 @@ func (ss *FolderUnifiedStoreImpl) GetFolders(ctx context.Context, q folder.GetFo
 	ctx, span := ss.tracer.Start(ctx, tracePrefix+"GetFolders")
 	defer span.End()
 
+	// Serve metadata-only callers from the search index to avoid the serial
+	// full-object BatchGet that dominates LIST cost on large orgs. The index is
+	// RBAC filtered the same way as the storage list path.
+	if q.MetadataOnly {
+		return ss.getFoldersMetadata(ctx, q)
+	}
+
 	out, err := ss.list(ctx, q.OrgID, v1.ListOptions{})
 	if err != nil {
 		return nil, err
@@ -383,6 +390,89 @@ func (ss *FolderUnifiedStoreImpl) GetFolders(ctx context.Context, q folder.GetFo
 	// }
 
 	return hits, nil
+}
+
+// getFoldersMetadata serves GetFolders from the search index. It fetches
+// metadata for ALL readable folders (needed to resolve parent chains for the
+// full paths) then applies the UID filter client-side, mirroring the list
+// path's semantics without reading any full stored objects.
+func (ss *FolderUnifiedStoreImpl) getFoldersMetadata(ctx context.Context, q folder.GetFoldersFromStoreQuery) ([]*folder.Folder, error) {
+	ctx, span := ss.tracer.Start(ctx, tracePrefix+"getFoldersMetadata")
+	defer span.End()
+
+	refs, err := ss.searchAllFolders(ctx, q.OrgID)
+	if err != nil {
+		return nil, err
+	}
+
+	folders := make([]*folder.Folder, len(refs))
+	for i, ref := range refs {
+		folders[i] = &folder.Folder{
+			ID:        ref.ID, // nolint:staticcheck
+			OrgID:     q.OrgID,
+			UID:       ref.UID,
+			ParentUID: ref.ParentUID,
+			Title:     ref.Title,
+			ManagedBy: ref.ManagedBy,
+		}
+	}
+
+	filters := make(map[string]struct{}, len(q.UIDs))
+	for _, uid := range q.UIDs {
+		filters[uid] = struct{}{}
+	}
+
+	folderMap := make(map[string]*folder.Folder)
+	relations := make(map[string]string)
+	if q.WithFullpath || q.WithFullpathUIDs {
+		for _, f := range folders {
+			folderMap[f.UID] = f
+			relations[f.UID] = f.ParentUID
+		}
+	}
+
+	hits := make([]*folder.Folder, 0, len(folders))
+	for _, f := range folders {
+		if shouldSkipFolder(f, filters) {
+			continue
+		}
+
+		if (q.WithFullpath || q.WithFullpathUIDs) && f.Fullpath == "" {
+			if err := buildFolderFullPaths(f, relations, folderMap); err != nil {
+				return nil, err
+			}
+		}
+
+		hits = append(hits, f)
+	}
+
+	return hits, nil
+}
+
+// searchAllFolders returns metadata for every folder the caller can read,
+// paginating to exhaustion. No field requirements matches all folders; the
+// search backend applies RBAC, matching the list path's visibility.
+func (ss *FolderUnifiedStoreImpl) searchAllFolders(ctx context.Context, orgID int64) ([]*folder.FolderReference, error) {
+	ctx, span := ss.tracer.Start(ctx, tracePrefix+"searchAllFolders")
+	defer span.End()
+
+	var all []*folder.FolderReference
+	for offset := int64(0); ; {
+		req := &resourcepb.ResourceSearchRequest{
+			Options: &resourcepb.ListOptions{},
+			Limit:   searchPageSize,
+			Offset:  offset,
+		}
+		hits, raw, err := ss.doSearchPage(ctx, orgID, req)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, hits...)
+		if raw == 0 {
+			return all, nil
+		}
+		offset += int64(raw)
+	}
 }
 
 // searchChildren returns ALL direct children of any of the given parent UIDs

--- a/pkg/services/folder/folderimpl/unifiedstore_test.go
+++ b/pkg/services/folder/folderimpl/unifiedstore_test.go
@@ -1461,3 +1461,117 @@ func TestList(t *testing.T) {
 		})
 	}
 }
+
+// searchRow builds a single-hit row for the folder search index with the
+// title/folder columns getFoldersMetadata relies on.
+func searchRow(uid, title, parentUID string) *resourcepb.ResourceTableRow {
+	return &resourcepb.ResourceTableRow{
+		Key:   &resourcepb.ResourceKey{Name: uid, Resource: "folder"},
+		Cells: [][]byte{[]byte(title), []byte(parentUID)},
+	}
+}
+
+func TestGetFoldersMetadata(t *testing.T) {
+	tracer := noop.NewTracerProvider().Tracer("TestGetFoldersMetadata")
+	orgID := int64(1)
+	ctx := context.Background()
+
+	// A -> B -> C tree; getFoldersMetadata must build full paths from the search
+	// hits alone, never reading a full folder object (no List/BatchGet/Get).
+	newStore := func(t *testing.T) (*FolderUnifiedStoreImpl, *client.MockK8sHandler) {
+		mockCli := new(client.MockK8sHandler)
+		return &FolderUnifiedStoreImpl{
+			k8sclient:   mockCli,
+			userService: usertest.NewUserServiceFake(),
+			tracer:      tracer,
+			maxDepth:    8,
+		}, mockCli
+	}
+
+	searchResponse := &resourcepb.ResourceSearchResponse{
+		Results: &resourcepb.ResourceTable{
+			Columns: []*resourcepb.ResourceTableColumnDefinition{
+				{Name: resource.SEARCH_FIELD_TITLE, Type: resourcepb.ResourceTableColumnDefinition_STRING},
+				{Name: resource.SEARCH_FIELD_FOLDER, Type: resourcepb.ResourceTableColumnDefinition_STRING},
+			},
+			Rows: []*resourcepb.ResourceTableRow{
+				searchRow("a", "A", ""),
+				searchRow("b", "B", "a"),
+				searchRow("c", "C", "b"),
+			},
+		},
+		TotalHits: 3,
+	}
+
+	emptyResponse := &resourcepb.ResourceSearchResponse{
+		Results: &resourcepb.ResourceTable{
+			Columns: searchResponse.Results.Columns,
+		},
+	}
+
+	expectSearchAll := func(mockCli *client.MockK8sHandler) {
+		mockCli.On("Search", mock.Anything, orgID, &resourcepb.ResourceSearchRequest{
+			Options: &resourcepb.ListOptions{},
+			Limit:   searchPageSize,
+			Offset:  0,
+		}).Return(searchResponse, nil).Once()
+		// searchAllFolders pages until an empty page, so it issues a trailing
+		// Search past the last hit (offset = number of hits returned above).
+		mockCli.On("Search", mock.Anything, orgID, &resourcepb.ResourceSearchRequest{
+			Options: &resourcepb.ListOptions{},
+			Limit:   searchPageSize,
+			Offset:  int64(len(searchResponse.Results.Rows)),
+		}).Return(emptyResponse, nil).Once()
+	}
+
+	t.Run("builds full paths from the search index without reading full objects", func(t *testing.T) {
+		store, mockCli := newStore(t)
+		expectSearchAll(mockCli)
+
+		got, err := store.GetFolders(ctx, folder.GetFoldersFromStoreQuery{
+			GetFoldersQuery: folder.GetFoldersQuery{
+				OrgID:            orgID,
+				MetadataOnly:     true,
+				WithFullpath:     true,
+				WithFullpathUIDs: true,
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, got, 3)
+
+		byUID := map[string]*folder.Folder{}
+		for _, f := range got {
+			byUID[f.UID] = f
+		}
+		require.Equal(t, "A/B/C", byUID["c"].Fullpath)
+		require.Equal(t, "a/b/c", byUID["c"].FullpathUIDs)
+		require.Equal(t, "A/B", byUID["b"].Fullpath)
+		require.Equal(t, "A", byUID["a"].Fullpath)
+		require.Equal(t, orgID, byUID["a"].OrgID)
+
+		// The whole point of Option A: no full-object reads.
+		mockCli.AssertNotCalled(t, "List", mock.Anything, mock.Anything, mock.Anything)
+		mockCli.AssertNotCalled(t, "Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+		mockCli.AssertExpectations(t)
+	})
+
+	t.Run("UID filter returns only requested folders but full paths use all ancestors", func(t *testing.T) {
+		store, mockCli := newStore(t)
+		expectSearchAll(mockCli)
+
+		got, err := store.GetFolders(ctx, folder.GetFoldersFromStoreQuery{
+			GetFoldersQuery: folder.GetFoldersQuery{
+				OrgID:        orgID,
+				UIDs:         []string{"c"},
+				MetadataOnly: true,
+				WithFullpath: true,
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		require.Equal(t, "c", got[0].UID)
+		// Ancestors A and B aren't in the result set but are still resolved for the path.
+		require.Equal(t, "A/B/C", got[0].Fullpath)
+		mockCli.AssertExpectations(t)
+	})
+}

--- a/pkg/services/folder/model.go
+++ b/pkg/services/folder/model.go
@@ -268,6 +268,12 @@ type GetFoldersQuery struct {
 	WithFullpathUIDs bool
 	BatchSize        uint64
 
+	// MetadataOnly serves folders from the search index instead of reading each
+	// full stored object. Only UID, ID, OrgID, ParentUID, Title, ManagedBy and
+	// the full paths are populated. For callers that only need the folder
+	// tree/titles and want to avoid the linear full-object fetch on large orgs.
+	MetadataOnly bool
+
 	// Pagination options
 	Limit int64
 	Page  int64

--- a/pkg/services/ngalert/store/namespace.go
+++ b/pkg/services/ngalert/store/namespace.go
@@ -20,6 +20,7 @@ func (st DBstore) GetUserVisibleNamespaces(ctx context.Context, orgID int64, use
 		WithFullpath:     true,
 		WithFullpathUIDs: true,
 		SignedInUser:     user,
+		MetadataOnly:     true,
 	})
 	if err != nil {
 		return nil, err
@@ -34,7 +35,7 @@ func (st DBstore) GetUserVisibleNamespaces(ctx context.Context, orgID int64, use
 
 // GetNamespaceByUID is a handler for retrieving a namespace by its UID. Alerting rules follow a Grafana folder-like structure which we call namespaces.
 func (st DBstore) GetNamespaceByUID(ctx context.Context, uid string, orgID int64, user identity.Requester) (*folder.Folder, error) {
-	f, err := st.FolderService.GetFolders(ctx, folder.GetFoldersQuery{OrgID: orgID, UIDs: []string{uid}, WithFullpath: true, SignedInUser: user})
+	f, err := st.FolderService.GetFolders(ctx, folder.GetFoldersQuery{OrgID: orgID, UIDs: []string{uid}, WithFullpath: true, SignedInUser: user, MetadataOnly: true})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Patch https://github.com/grafana/grafana/pull/129065 into `slow`.