### PR TITLE
[release-12.4.9] Dashboards: Fix importing V1 dashboards with multiple same-type datasources

### DIFF
--- a/public/app/features/manage-dashboards/import/utils/inputs.test.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.test.ts
@@ -457,6 +457,140 @@ describe('applyV1Inputs', () => {
     expect(dsVariable.current?.value).toBe('ds-uid');
   });
 
+  it('keeps selections independent for multiple inputs of the same plugin type', () => {
+    const dashboard = {
+      title: 'two prom inputs',
+      uid: 'old',
+      schemaVersion: 41,
+      panels: [
+        {
+          datasource: { type: 'prometheus', uid: '${DS_PROM_A}' },
+          targets: [{ datasource: { type: 'prometheus', uid: '${DS_PROM_A}' }, expr: 'up', refId: 'A' }],
+        },
+        {
+          datasource: { type: 'prometheus', uid: '${DS_PROM_B}' },
+          targets: [{ datasource: { type: 'prometheus', uid: '${DS_PROM_B}' }, expr: 'up', refId: 'A' }],
+        },
+      ],
+    } as unknown as Dashboard;
+
+    const inputs: DashboardInputs = {
+      dataSources: [
+        {
+          name: 'DS_PROM_A',
+          label: 'Prometheus A',
+          description: '',
+          info: '',
+          value: '',
+          type: InputType.DataSource,
+          pluginId: 'prometheus',
+        },
+        {
+          name: 'DS_PROM_B',
+          label: 'Prometheus B',
+          description: '',
+          info: '',
+          value: '',
+          type: InputType.DataSource,
+          pluginId: 'prometheus',
+        },
+      ],
+      constants: [],
+      libraryPanels: [],
+    };
+
+    const form: ImportDashboardDTO = {
+      title: 'two prom inputs',
+      uid: 'new-uid',
+      gnetId: '',
+      constants: [],
+      dataSources: [
+        { uid: 'prom-a', type: 'prometheus', name: 'Prom A' } as DataSourceInstanceSettings,
+        { uid: 'prom-b', type: 'prometheus', name: 'Prom B' } as DataSourceInstanceSettings,
+      ],
+      elements: [],
+      folder: { uid: 'folder' },
+    };
+
+    const result = applyV1Inputs(dashboard, inputs, form);
+
+    expect(result.panels?.[0].datasource?.uid).toBe('prom-a');
+    expect(result.panels?.[1].datasource?.uid).toBe('prom-b');
+
+    const panelA = result.panels?.[0] as PanelWithTargets;
+    const panelB = result.panels?.[1] as PanelWithTargets;
+    expect(panelA.targets?.[0].datasource?.uid).toBe('prom-a');
+    expect(panelB.targets?.[0].datasource?.uid).toBe('prom-b');
+  });
+
+  it('falls back to matching by plugin type when selections are not index-aligned', () => {
+    // interpolateV1Dashboard dedupes selections per plugin type, so the selections
+    // array can be shorter than the inputs array.
+    const dashboard = {
+      title: 'dedup selections',
+      uid: 'old',
+      schemaVersion: 41,
+      panels: [
+        {
+          datasource: { type: 'loki', uid: '${DS_LOKI}' },
+          targets: [],
+        },
+      ],
+    } as unknown as Dashboard;
+
+    const inputs: DashboardInputs = {
+      dataSources: [
+        {
+          name: 'DS_PROM_A',
+          label: 'Prometheus A',
+          description: '',
+          info: '',
+          value: '',
+          type: InputType.DataSource,
+          pluginId: 'prometheus',
+        },
+        {
+          name: 'DS_PROM_B',
+          label: 'Prometheus B',
+          description: '',
+          info: '',
+          value: '',
+          type: InputType.DataSource,
+          pluginId: 'prometheus',
+        },
+        {
+          name: 'DS_LOKI',
+          label: 'Loki',
+          description: '',
+          info: '',
+          value: '',
+          type: InputType.DataSource,
+          pluginId: 'loki',
+        },
+      ],
+      constants: [],
+      libraryPanels: [],
+    };
+
+    // Only one selection per plugin type; DS_LOKI (index 2) has no entry at its index.
+    const form: ImportDashboardDTO = {
+      title: 'dedup selections',
+      uid: 'new-uid',
+      gnetId: '',
+      constants: [],
+      dataSources: [
+        { uid: 'prom-a', type: 'prometheus', name: 'Prom A' } as DataSourceInstanceSettings,
+        { uid: 'loki-1', type: 'loki', name: 'Loki' } as DataSourceInstanceSettings,
+      ],
+      elements: [],
+      folder: { uid: 'folder' },
+    };
+
+    const result = applyV1Inputs(dashboard, inputs, form);
+
+    expect(result.panels?.[0].datasource?.uid).toBe('loki-1');
+  });
+
   it('replaces constant variable query, current, and options with user-provided values', () => {
     const dashboard = {
       title: 'old',

--- a/public/app/features/manage-dashboards/import/utils/inputs.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.ts
@@ -560,9 +560,19 @@ function checkUserInputMatch(
   userDsInputs: DataSourceInstanceSettings[]
 ) {
   const dsName = templateizedUid.replace(/\$\{(.*)\}/, '$1');
-  const input = datasourceInputs?.find((ds) => ds.name === dsName);
-  const userInput = input && userDsInputs.find((ds) => ds.type === input.pluginId);
-  return userInput;
+  const inputIndex = datasourceInputs?.findIndex((ds) => ds.name === dsName) ?? -1;
+  if (inputIndex < 0) {
+    return undefined;
+  }
+
+  const input = datasourceInputs[inputIndex];
+
+  const selectionByIndex = userDsInputs[inputIndex];
+  if (selectionByIndex?.type === input.pluginId) {
+    return selectionByIndex;
+  }
+
+  return userDsInputs.find((ds) => ds.type === input.pluginId);
 }
 
 function processAnnotation(


### PR DESCRIPTION
Backport 895a1f44e56c759a9ae08abfa799686d67282f42 from #130382

---

**What is this feature?**

Fixes the classic (v1) dashboard import so that multiple datasource inputs of the same plugin type each keep their own user selection.

**Why do we need this feature?**

When a dashboard's `__inputs` section contains multiple datasources sharing the same plugin type (i.e. `DS_PROM_A` and `DS_PROM_B`), the form shows two distinct inputs but replaces all occurrences with the first pick.

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

Fixes #128809

**Special notes for your reviewer:**

Steps to reproduce:
1. Import the following dashboard:
```json
{
  "__inputs": [
    { "name": "DS_PROM_A", "label": "Prometheus A", "description": "", "type": "datasource", "pluginId": "prometheus", "pluginName": "Prometheus" },
    { "name": "DS_PROM_B", "label": "Prometheus B", "description": "", "type": "datasource", "pluginId": "prometheus", "pluginName": "Prometheus" }
  ],
  "title": "Repro: two prometheus inputs",
  "schemaVersion": 41,
  "panels": [
    {
      "id": 1,
      "type": "timeseries",
      "title": "Panel 1",
      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
      "datasource": { "type": "prometheus", "uid": "${DS_PROM_A}" },
      "targets": [{ "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM_A}" }, "expr": "up" }]
    },
    {
      "id": 2,
      "type": "timeseries",
      "title": "Panel 2",
      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
      "datasource": { "type": "prometheus", "uid": "${DS_PROM_B}" },
      "targets": [{ "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM_B}" }, "expr": "up" }]
    }
  ]
}
```
2. Select two distinct datasources in the form.
3. Observe Panel 1 and Panel 2 having the same datasource.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
