### PR TITLE
Alerting: Serve folder lookups from the search index (metadata-only)

### DIFF
--- a/pkg/services/ngalert/provisioning/alert_rules.go
+++ b/pkg/services/ngalert/provisioning/alert_rules.go
@@ -260,6 +260,9 @@ func (service *AlertRuleService) ListAlertRules(ctx context.Context, user identi
 		fq := folder.GetFoldersQuery{
 			OrgID:        user.GetOrgID(),
 			SignedInUser: user,
+			// Only folder UID and per-folder access are used below; serve
+			// from the search index rather than a full-object folder list.
+			MetadataOnly: true,
 		}
 		folders, err := service.folderService.GetFolders(ctx, fq)
 		if err != nil {
@@ -1211,6 +1214,9 @@ func (service *AlertRuleService) GetAlertGroupsWithFolderFullpath(ctx context.Co
 		UIDs:         nil,
 		WithFullpath: true,
 		SignedInUser: user,
+		// Only Fullpath is read below; serve from the search index rather than a
+		// full-object folder list.
+		MetadataOnly: true,
 	}
 	for uid := range namespaces {
 		fq.UIDs = append(fq.UIDs, uid)

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -185,6 +185,9 @@ func (st DBstore) getFolderFullpaths(ctx context.Context, orgID int64, folderUID
 		UIDs:         folderUIDs,
 		WithFullpath: true,
 		SignedInUser: bgUser,
+		// Only Fullpath is read below; serve from the search index rather than a
+		// full-object folder list.
+		MetadataOnly: true,
 	})
 	if err != nil {
 		return nil, err
@@ -1640,6 +1643,9 @@ func (st DBstore) GetAlertRulesForScheduling(ctx context.Context, query *ngmodel
 					UIDs:         slices.Collect(maps.Keys(uids)),
 					WithFullpath: true,
 					SignedInUser: schedulerUser,
+					// Only Fullpath is read below; serve from the search index rather than a
+					// full-object folder list.
+					MetadataOnly: true,
 				})
 				if err != nil {
 					return fmt.Errorf("failed to fetch a list of folders that contain alert rules: %w", err)


### PR DESCRIPTION
## What
Route ngalert's folder lookups to the search index (`MetadataOnly: true`) instead of a full-object folder list. Affects the scheduler's `PopulateFolders`, `getFolderFullpaths`, and provisioning's `ListAlertRules` (non-admin) + `GetAlertGroupsWithFolderFullpath`.

## Why
After multi-tenant folder was enabled to all prod, the folder app-platform apiserver was OOM-killed and CPU spiked. Root cause: a LIST-folders storm — callers fetched every folder in the org as full objects (JSON-unmarshal + gzip) then used only the folder UID / fullpath. These ngalert paths (especially the scheduler tick with `PopulateFolders`) were top drivers.

Each site now reads only the metadata it actually consumes (`Fullpath`, UID) from the search index. Behavior-preserving: the metadata path carries these fields and applies the same RBAC visibility as the list path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)