### PR TITLE
Dashboards: Serve shared-dashboard folder check from the search index

### DIFF
--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -1422,11 +1422,14 @@ func (dr *DashboardServiceImpl) filterUserSharedDashboards(ctx context.Context, 
 	}
 
 	// GetFolders return only folders available to user. So we can use is to check access.
+	// Only UID is read below; serve from the search index rather than a
+	// full-object folder list.
 	userDashFolders, err := dr.folderService.GetFolders(ctx, folder.GetFoldersQuery{
 		UIDs:         folderUIDs,
 		OrgID:        user.GetOrgID(),
 		OrderByTitle: true,
 		SignedInUser: user,
+		MetadataOnly: true,
 	})
 	if err != nil {
 		return nil, folder.ErrInternal.Errorf("failed to fetch parent folders from store: %w", err)


### PR DESCRIPTION
## What
Route `filterUserSharedDashboards`' folder-access lookup to the search index (`MetadataOnly: true`) instead of a full-object folder list.

## Why
Part of reducing load on the multi-tenant folder app-platform apiserver (OOM/CPU after MT folder was enabled to all prod). This runs on the dashboard "shared with me" search path and uses only the returned folder UID set to decide access.

## Review note (access-sensitive)
A shared dashboard is hidden from "shared with me" only if the user has parent-folder access. This now relies on the search index applying the **same RBAC visibility** as the list path (`getFoldersMetadata`). Please verify "shared with me" behavior — a folder wrongly present/absent in the index result would over/under-filter what the user sees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)