### PR TITLE
Folder: Serve available-folders lookup from the search index (metadata-only)

### DIFF
--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -197,6 +197,9 @@ func (s *Service) getAvailableNonRootFolders(ctx context.Context, q *folder.GetC
 		SignedInUser:     q.SignedInUser,
 		OrderByTitle:     true,
 		WithFullpathUIDs: true,
+		// Only UID/ParentUID/FullpathUIDs are used below; serve from the search
+		// index rather than a full-object folder list.
+		MetadataOnly: true,
 	})
 	if err != nil {
 		return nil, folder.ErrInternal.Errorf("failed to fetch subfolders: %w", err)


### PR DESCRIPTION
## What
Route `getAvailableNonRootFolders` to the search index (`MetadataOnly: true`) instead of a full-object folder list.

## Why
Part of reducing load on the multi-tenant folder app-platform apiserver (OOM/CPU after MT folder was enabled to all prod). This per-request path reads only `UID`/`ParentUID`/`FullpathUIDs`, all carried by the metadata path, so behavior is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)