### PR TITLE
Dashboard: Preserve custom metadata when restoring a dashboard version

### DIFF
--- a/public/app/features/dashboard/api/v1.test.ts
+++ b/public/app/features/dashboard/api/v1.test.ts
@@ -4,6 +4,7 @@ import { backendSrv } from 'app/core/services/backend_srv';
 import {
   AnnoKeyFolder,
   AnnoKeyGrantPermissions,
+  AnnoKeyIgnorePredefinedVariables,
   AnnoKeyManagerAllowsEdits,
   AnnoKeyManagerKind,
   AnnoKeyMessage,
@@ -642,6 +643,52 @@ describe('v1 dashboard API', () => {
           metadata: expect.objectContaining({
             annotations: expect.objectContaining({
               [AnnoKeyFolder]: 'current-folder',
+            }),
+          }),
+        }),
+        expect.anything()
+      );
+    });
+
+    it('should preserve custom labels and annotations from the current dashboard', async () => {
+      // History list: version 3 without any custom metadata
+      mockGet.mockResolvedValueOnce({
+        metadata: { resourceVersion: '1' },
+        items: [
+          {
+            ...mockDashboardDto,
+            metadata: {
+              ...mockDashboardDto.metadata,
+              generation: 3,
+              annotations: { [AnnoKeyFolder]: 'old-folder' },
+            },
+          },
+        ],
+      });
+
+      // Current dashboard carries user-authored metadata
+      mockGet.mockResolvedValueOnce({
+        ...mockDashboardDto,
+        metadata: {
+          ...mockDashboardDto.metadata,
+          labels: { 'example.com/team': 'observability' },
+          annotations: {
+            [AnnoKeyFolder]: 'current-folder',
+            [AnnoKeyIgnorePredefinedVariables]: 'true',
+          },
+        },
+      });
+
+      const api = new K8sDashboardAPI();
+      await api.restoreDashboardVersion('dash-uid', 3);
+
+      expect(mockPut).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            labels: expect.objectContaining({ 'example.com/team': 'observability' }),
+            annotations: expect.objectContaining({
+              [AnnoKeyIgnorePredefinedVariables]: 'true',
             }),
           }),
         }),

--- a/public/app/features/dashboard/api/v1.ts
+++ b/public/app/features/dashboard/api/v1.ts
@@ -299,7 +299,9 @@ export class K8sDashboardAPI implements DashboardAPI<DashboardDTO, Dashboard> {
         ...historicalVersion.spec,
         uid,
       },
+      // carry over the current metadata so custom labels/annotations are not wiped by the update
       k8s: {
+        ...currentDashboard.metadata,
         name: uid,
       },
       message: `Restored from version ${version}`,

--- a/public/app/features/dashboard/api/v2.test.ts
+++ b/public/app/features/dashboard/api/v2.test.ts
@@ -8,6 +8,7 @@ import {
   AnnoKeyFolderTitle,
   AnnoKeyFolderUrl,
   AnnoKeyGrantPermissions,
+  AnnoKeyIgnorePredefinedVariables,
   AnnoKeyMessage,
   AnnoKeySavedFromUI,
   DeprecatedInternalId,
@@ -580,6 +581,52 @@ describe('v2 dashboard API', () => {
           metadata: expect.objectContaining({
             annotations: expect.objectContaining({
               [AnnoKeyFolder]: 'current-folder',
+            }),
+          }),
+        }),
+        expect.anything()
+      );
+    });
+
+    it('should preserve custom labels and annotations from the current dashboard', async () => {
+      // History list: version 3 without any custom metadata
+      mockGet.mockResolvedValueOnce({
+        metadata: { resourceVersion: '1' },
+        items: [
+          {
+            ...mockDashboardDto,
+            metadata: {
+              ...mockDashboardDto.metadata,
+              generation: 3,
+              annotations: { [AnnoKeyFolder]: 'old-folder' },
+            },
+          },
+        ],
+      });
+
+      // Current dashboard carries user-authored metadata
+      mockGet.mockResolvedValueOnce({
+        ...mockDashboardDto,
+        metadata: {
+          ...mockDashboardDto.metadata,
+          labels: { 'example.com/team': 'observability' },
+          annotations: {
+            [AnnoKeyFolder]: 'current-folder',
+            [AnnoKeyIgnorePredefinedVariables]: 'true',
+          },
+        },
+      });
+
+      const api = new K8sDashboardV2API();
+      await api.restoreDashboardVersion('dash-uid', 3);
+
+      expect(mockPut).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            labels: expect.objectContaining({ 'example.com/team': 'observability' }),
+            annotations: expect.objectContaining({
+              [AnnoKeyIgnorePredefinedVariables]: 'true',
             }),
           }),
         }),

--- a/public/app/features/dashboard/api/v2.ts
+++ b/public/app/features/dashboard/api/v2.ts
@@ -245,7 +245,9 @@ export class K8sDashboardV2API
     ]);
     return await this.saveDashboard({
       dashboard: historicalVersion.spec,
+      // carry over the current metadata so custom labels/annotations are not wiped by the update
       k8s: {
+        ...currentDashboard.metadata,
         name: uid,
       },
       message: `Restored from version ${version}`,


### PR DESCRIPTION
## What is this feature?

Fixes `restoreDashboardVersion` (v1 and v2 dashboard APIs) wiping custom `metadata.labels` and `metadata.annotations`.

## Why do we need this feature?

Unified storage updates follow Kubernetes PUT semantics — metadata is replaced, not merged. The restore path already fetched the current dashboard to preserve its folder, but sent only `k8s: {name: uid}`, so restoring any version silently dropped all other custom metadata (e.g. the user-toggled `grafana.app/ignorePredefinedVariables` annotation).

The fix carries the current dashboard's metadata into the save payload. `saveDashboard` already strips server-managed fields (`resourceVersion`, `DeprecatedInternalId`) and curates the message/folder annotations, so restore now behaves like the regular save flow.

## Who is this feature for?

Anyone restoring a dashboard version whose dashboard carries custom labels or annotations.

## Which issue(s) does this PR fix?

## Special notes for your reviewer:

Tests were written first and failed prior to the fix: restore now preserves a custom label and the `ignorePredefinedVariables` annotation in both v1 and v2 API tests.