### PR TITLE
Dashboards: Keep the panel editor bound to the tree after a scene rebuild

### DIFF
--- a/public/app/features/dashboard-scene/mutation-api/commands/applySpec.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/applySpec.test.ts
@@ -182,6 +182,31 @@ describe('APPLY_SPEC with a panel open for editing', () => {
     expect(editorIsAttached(scene)).toBe(true);
   });
 
+  it('leaves a panel the user opened during the library-panel wait alone', async () => {
+    const scene = buildScene(makeSpec());
+    openPanelEdit(scene, 'panel-2');
+
+    await applySpec(scene, makeSpec());
+    expect(editedPanelKey(scene)).toBeUndefined();
+
+    // The pane is closed for the whole wait, so the user is free to open something else.
+    openPanelEdit(scene, 'panel-1');
+    getLibraryPanelBehavior(findVizPanelByKey(scene, 'panel-2')!)!.setState({ isLoaded: true });
+
+    expect(editedPanelKey(scene)).toBe('panel-1');
+  });
+
+  it('leaves the pane closed when the user exits edit mode during the library-panel wait', async () => {
+    const scene = buildScene(makeSpec());
+    openPanelEdit(scene, 'panel-2');
+
+    await applySpec(scene, makeSpec());
+    scene.exitEditMode({ skipConfirm: true });
+    getLibraryPanelBehavior(findVizPanelByKey(scene, 'panel-2')!)!.setState({ isLoaded: true });
+
+    expect(editedPanelKey(scene)).toBeUndefined();
+  });
+
   it('leaves the editor closed when none was open', async () => {
     const scene = buildScene(makeSpec());
 

--- a/public/app/features/dashboard-scene/mutation-api/commands/applySpec.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/applySpec.test.ts
@@ -1,0 +1,192 @@
+/**
+ * APPLY_SPEC while a panel is open for editing.
+ *
+ * The command rebuilds the scene from the spec and swaps the result in, and `setState` merges, so an
+ * editor opened before the swap survives it still driving a VizPanel the dashboard no longer
+ * contains. These drive the real command against a real scene rather than the re-attach on its own:
+ * the reported symptom is that an edit made after the swap is missing from what a read returns, so
+ * that is what is asserted.
+ */
+
+import { cloneDeep } from 'lodash';
+
+import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
+import { handyTestingSchema } from '@grafana/schema/apis/dashboard.grafana.app/v2/examples';
+import { type DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
+
+import { buildPanelEditScene } from '../../panel-edit/PanelEditor';
+import { type DashboardScene } from '../../scene/DashboardScene';
+import { transformSaveModelSchemaV2ToScene } from '../../serialization/transformSaveModelSchemaV2ToScene';
+import { findVizPanelByKey, getLibraryPanelBehavior } from '../../utils/utils';
+
+import { applySpecCommand } from './applySpec';
+import { getSpecCommand } from './getSpec';
+import { type MutationContext } from './types';
+
+// Entering edit mode starts the change tracker, which spawns a real web worker jsdom does not have.
+jest.mock('../../saving/createDetectChangesWorker', () => ({
+  createWorker: () => ({ postMessage: jest.fn(), terminate: jest.fn(), onmessage: null }),
+}));
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getDataSourceSrv: () => ({ getInstanceSettings: jest.fn() }),
+}));
+
+/**
+ * `handyTestingSchema` holds `panel-1` (a plain panel) and `panel-2` (a library panel). Its
+ * variables are dropped: they are irrelevant here and some are behind a feature toggle.
+ */
+function makeSpec(mutate?: (spec: DashboardV2Spec) => void): DashboardV2Spec {
+  const spec = cloneDeep(handyTestingSchema);
+  spec.variables = [];
+  mutate?.(spec);
+  return spec;
+}
+
+function withoutPanel1(spec: DashboardV2Spec) {
+  delete spec.elements['panel-1'];
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the fixture is a grid layout
+  const layout = spec.layout as { spec: { items: Array<{ spec: { element: { name: string } } }> } };
+  layout.spec.items = layout.spec.items.filter((item) => item.spec.element.name !== 'panel-1');
+}
+
+function buildScene(spec: DashboardV2Spec): DashboardScene {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal resource envelope for the test
+  const dto = {
+    kind: 'DashboardWithAccessInfo',
+    apiVersion: 'dashboard.grafana.app/v2beta1',
+    metadata: { name: 'dash-1', generation: 1, creationTimestamp: '2026-08-03T00:00:00Z', annotations: {} },
+    access: { canEdit: true, canSave: true, canShare: true, canStar: true, canDelete: true, canAdmin: true },
+    spec,
+  } as unknown as DashboardWithAccessInfo<DashboardV2Spec>;
+
+  return transformSaveModelSchemaV2ToScene(dto);
+}
+
+async function applySpec(scene: DashboardScene, spec: DashboardV2Spec) {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the payload schema takes an opaque record
+  const payload = { spec: spec as unknown as Record<string, unknown>, validate: false };
+  return applySpecCommand.handler(payload, { scene } satisfies MutationContext);
+}
+
+async function readSpec(scene: DashboardScene): Promise<DashboardV2Spec> {
+  const result = await getSpecCommand.handler({ validate: false }, { scene } satisfies MutationContext);
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- handler data is untyped by the MutationResult contract
+  return (result.data as { spec: DashboardV2Spec }).spec;
+}
+
+function openPanelEdit(scene: DashboardScene, key: string) {
+  const panel = findVizPanelByKey(scene, key)!;
+  scene.onEnterEditMode();
+  scene.setState({ editPanel: buildPanelEditScene(panel) });
+  return panel;
+}
+
+/**
+ * Assertions read these rather than the scene objects themselves: a failed `toBe` on a VizPanel
+ * sends the whole circular tree over jest's worker IPC and kills the run.
+ */
+function editedPanelKey(scene: DashboardScene) {
+  return scene.state.editPanel?.state.panelRef.resolve().state.key;
+}
+
+/** Whether the editor drives the object the dashboard currently holds, rather than a discarded one. */
+function editorIsAttached(scene: DashboardScene) {
+  const panel = scene.state.editPanel?.state.panelRef.resolve();
+  return panel !== undefined && panel === findVizPanelByKey(scene, panel.state.key!);
+}
+
+describe('APPLY_SPEC with a panel open for editing', () => {
+  it('re-binds the editor onto the panel in the rebuilt tree', async () => {
+    const scene = buildScene(makeSpec());
+    const beforeSwap = openPanelEdit(scene, 'panel-1');
+
+    expect((await applySpec(scene, makeSpec())).success).toBe(true);
+
+    expect(editedPanelKey(scene)).toBe('panel-1');
+    expect(scene.state.editPanel!.state.panelRef.resolve() === beforeSwap).toBe(false);
+    expect(editorIsAttached(scene)).toBe(true);
+  });
+
+  it('keeps an edit made through the editor after the rebuild visible to a read', async () => {
+    const scene = buildScene(makeSpec());
+    openPanelEdit(scene, 'panel-1');
+
+    await applySpec(scene, makeSpec());
+    scene.state.editPanel!.state.panelRef.resolve().setState({ title: 'Renamed by user' });
+
+    expect((await readSpec(scene)).elements['panel-1']).toMatchObject({ spec: { title: 'Renamed by user' } });
+  });
+
+  it('closes the editor when the applied spec no longer has the panel', async () => {
+    const scene = buildScene(makeSpec());
+    openPanelEdit(scene, 'panel-1');
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await applySpec(scene, makeSpec(withoutPanel1));
+
+    expect(editedPanelKey(scene)).toBeUndefined();
+    expect(findVizPanelByKey(scene, 'panel-1')).toBeNull();
+  });
+
+  it('waits for a library panel to load before re-opening the editor on it', async () => {
+    const scene = buildScene(makeSpec());
+    openPanelEdit(scene, 'panel-2');
+
+    await applySpec(scene, makeSpec());
+
+    // The rebuild resets library panels to unloaded; opening now would edit an empty shell.
+    const libPanel = getLibraryPanelBehavior(findVizPanelByKey(scene, 'panel-2')!)!;
+    expect(libPanel.state.isLoaded).toBeFalsy();
+    expect(editedPanelKey(scene)).toBeUndefined();
+
+    libPanel.setState({ isLoaded: true });
+    expect(editedPanelKey(scene)).toBe('panel-2');
+    expect(editorIsAttached(scene)).toBe(true);
+  });
+
+  it('recovers the pane when a second rebuild lands during the library-panel wait', async () => {
+    const scene = buildScene(makeSpec());
+    openPanelEdit(scene, 'panel-2');
+
+    await applySpec(scene, makeSpec());
+    const stale = getLibraryPanelBehavior(findVizPanelByKey(scene, 'panel-2')!)!;
+    // `editPanel` is unset for the whole wait, so this rebuild has no key to re-open from.
+    await applySpec(scene, makeSpec());
+    expect(editedPanelKey(scene)).toBeUndefined();
+
+    // The load the discarded tree started completes, and hands off to the live tree's own wait.
+    stale.setState({ isLoaded: true });
+    expect(editedPanelKey(scene)).toBeUndefined();
+
+    getLibraryPanelBehavior(findVizPanelByKey(scene, 'panel-2')!)!.setState({ isLoaded: true });
+    expect(editedPanelKey(scene)).toBe('panel-2');
+    expect(editorIsAttached(scene)).toBe(true);
+  });
+
+  it('recovers the pane when a rebuild races an in-flight `?editPanel=` wait', async () => {
+    const scene = buildScene(makeSpec());
+    scene.onEnterEditMode();
+
+    // Open panel edit the way the URL does, while the library panel is still loading.
+    const stale = getLibraryPanelBehavior(findVizPanelByKey(scene, 'panel-2')!)!;
+    scene.urlSync!.updateFromUrl({ editPanel: '2' });
+    expect(editedPanelKey(scene)).toBeUndefined();
+
+    await applySpec(scene, makeSpec());
+    stale.setState({ isLoaded: true });
+    getLibraryPanelBehavior(findVizPanelByKey(scene, 'panel-2')!)!.setState({ isLoaded: true });
+
+    expect(editedPanelKey(scene)).toBe('panel-2');
+    expect(editorIsAttached(scene)).toBe(true);
+  });
+
+  it('leaves the editor closed when none was open', async () => {
+    const scene = buildScene(makeSpec());
+
+    expect((await applySpec(scene, makeSpec())).success).toBe(true);
+
+    expect(editedPanelKey(scene)).toBeUndefined();
+  });
+});

--- a/public/app/features/dashboard-scene/mutation-api/commands/applySpec.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/applySpec.test.ts
@@ -207,6 +207,31 @@ describe('APPLY_SPEC with a panel open for editing', () => {
     expect(editedPanelKey(scene)).toBeUndefined();
   });
 
+  it('keeps `?editPanel=` in the URL while the library panel loads', async () => {
+    const scene = buildScene(makeSpec());
+    openPanelEdit(scene, 'panel-2');
+
+    await applySpec(scene, makeSpec());
+
+    // The pane is closed, but the dashboard is still editing that panel: a reload here has to come
+    // back to it, and a load that never completes must not lose it either.
+    expect(editedPanelKey(scene)).toBeUndefined();
+    expect(scene.urlSync!.getUrlState().editPanel).toBe('2');
+
+    getLibraryPanelBehavior(findVizPanelByKey(scene, 'panel-2')!)!.setState({ isLoaded: true });
+    expect(scene.urlSync!.getUrlState().editPanel).toBe('2');
+  });
+
+  it('drops `?editPanel=` when the applied spec no longer has the panel', async () => {
+    const scene = buildScene(makeSpec());
+    openPanelEdit(scene, 'panel-1');
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await applySpec(scene, makeSpec(withoutPanel1));
+
+    expect(scene.urlSync!.getUrlState().editPanel).toBeUndefined();
+  });
+
   it('leaves the editor closed when none was open', async () => {
     const scene = buildScene(makeSpec());
 

--- a/public/app/features/dashboard-scene/mutation-api/commands/applySpec.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/applySpec.ts
@@ -13,7 +13,7 @@
 
 import * as z from 'zod';
 
-import { sceneUtils } from '@grafana/scenes';
+import { sceneUtils, type SceneObjectUrlValues } from '@grafana/scenes';
 import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { type ObjectMeta } from 'app/features/apiserver/types';
 import { dashboardAPIVersionResolver } from 'app/features/dashboard/api/DashboardAPIVersionResolver';
@@ -110,6 +110,12 @@ type MutationContextScene = {
   setState: (state: unknown) => void;
 };
 
+// Same reason: the bits of DashboardSceneUrlSync the rebuild drives, without importing it.
+type DashboardUrlSync = {
+  retainEditPanelAcrossRebuild: (panelId: string) => void;
+  updateFromUrl: (values: SceneObjectUrlValues) => void;
+};
+
 export const applySpecCommand: MutationCommand<ApplySpecPayload> = {
   name: 'APPLY_SPEC',
   description:
@@ -162,10 +168,20 @@ export const applySpecCommand: MutationCommand<ApplySpecPayload> = {
       // waits for a library panel to load, and leaves the pane closed when the applied spec no
       // longer has the panel.
       const editPanelKey = scene.state.editPanel?.getUrlKey();
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- narrow the base handler to the dashboard's own, which owns the hold below
+      const urlSync = scene.urlSync as DashboardUrlSync | undefined;
+
+      if (editPanelKey) {
+        // Dropping the pane below writes `?editPanel=` out of the URL, and the re-open cannot
+        // always put it back in the same tick: a library panel has to load first. Hold the param
+        // so a reload during that window, or a load that never completes, still names the panel.
+        urlSync?.retainEditPanelAcrossRebuild(editPanelKey);
+      }
+
       scene.setState({ ...newState, editPanel: undefined });
 
       if (editPanelKey) {
-        scene.urlSync?.updateFromUrl({ editPanel: editPanelKey });
+        urlSync?.updateFromUrl({ editPanel: editPanelKey });
       }
 
       // Return the re-serialized spec so the caller gets the rekeyed element

--- a/public/app/features/dashboard-scene/mutation-api/commands/applySpec.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/applySpec.ts
@@ -155,7 +155,18 @@ export const applySpecCommand: MutationCommand<ApplySpecPayload> = {
       // Reuse the live key so existing references (incl. the mutation client's
       // `scene`) survive the swap.
       const newState = sceneUtils.cloneSceneObjectState(rebuilt.state, { key: scene.state.key });
-      scene.setState(newState);
+      // `setState` merges, so an open panel editor would survive the swap still driving the
+      // VizPanel and layout item of the tree we just discarded: edits made through it never reach
+      // the new tree, and so are absent from a save or a read. Drop it and re-open through url
+      // sync, the same path `?editPanel=` takes, which resolves the id against the current tree,
+      // waits for a library panel to load, and leaves the pane closed when the applied spec no
+      // longer has the panel.
+      const editPanelKey = scene.state.editPanel?.getUrlKey();
+      scene.setState({ ...newState, editPanel: undefined });
+
+      if (editPanelKey) {
+        scene.urlSync?.updateFromUrl({ editPanel: editPanelKey });
+      }
 
       // Return the re-serialized spec so the caller gets the rekeyed element
       // names (rebuild rekeys to `panel-<id>`) without a follow-up GET_SPEC.

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditor.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditor.test.ts
@@ -2,6 +2,7 @@ import { of } from 'rxjs';
 
 import { type DataQueryRequest, type DataSourceApi, LoadingState, type PanelPlugin, store } from '@grafana/data';
 import { getPanelPlugin } from '@grafana/data/test';
+import { config } from '@grafana/runtime';
 import {
   type CancelActivationHandler,
   CustomVariable,
@@ -213,6 +214,50 @@ describe('PanelEditor', () => {
       // Change back to already saved state
       panel.setState({ title: 'changed title' });
       expect(panelEditor.state.isDirty).toBe(false);
+    });
+  });
+
+  describe('When the scene is rebuilt underneath the editor', () => {
+    beforeAll(() => {
+      config.featureToggles.dashboardNewLayouts = true;
+    });
+
+    afterAll(() => {
+      config.featureToggles.dashboardNewLayouts = false;
+    });
+
+    /** Replace the layout tree wholesale, as APPLY_SPEC and the json/code editors do. */
+    function swapBody(dashboard: DashboardScene) {
+      dashboard.setState({
+        body: DefaultGridLayoutManager.fromVizPanels([new VizPanel({ key: 'panel-1', pluginId: 'text' })]),
+      });
+    }
+
+    it('Should not commit the panel edit onto the discarded layout item', async () => {
+      const { dashboard, panel } = await setup({});
+      const setPanelEditAction = jest.spyOn(dashboard.state.sidebar, 'setPanelEditAction');
+
+      panel.setState({ title: 'changed title' });
+      swapBody(dashboard);
+
+      deactivate!();
+      deactivate = undefined;
+
+      // The action's source would be the layout item of the discarded tree. It never activates
+      // again, and DashboardSidebar retries an inactive source on an unbounded setTimeout loop.
+      expect(setPanelEditAction).not.toHaveBeenCalled();
+    });
+
+    it('Should still commit when the editor is attached to the live tree', async () => {
+      const { dashboard, panel } = await setup({});
+      const setPanelEditAction = jest.spyOn(dashboard.state.sidebar, 'setPanelEditAction');
+
+      panel.setState({ title: 'changed title' });
+
+      deactivate!();
+      deactivate = undefined;
+
+      expect(setPanelEditAction).toHaveBeenCalled();
     });
   });
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
@@ -33,7 +33,12 @@ import { type DashboardLayoutItem, isDashboardLayoutItem } from '../scene/types/
 import { vizPanelToPanel } from '../serialization/transformSceneToSaveModel';
 import { DashboardEditActionEvent } from '../sidebar/events';
 import { SIDEBAR_COLLAPSED_KEY } from '../sidebar/shared';
-import { getDashboardSceneFor, getLibraryPanelBehavior, getPanelIdForVizPanel } from '../utils/utils';
+import {
+  findVizPanelByKey,
+  getDashboardSceneFor,
+  getLibraryPanelBehavior,
+  getPanelIdForVizPanel,
+} from '../utils/utils';
 
 import { DataProviderSharer } from './PanelDataPane/DataProviderSharer';
 import { type PanelDataPane } from './PanelDataPane/PanelDataPane';
@@ -135,6 +140,14 @@ export class PanelEditor extends SceneObjectBase<PanelEditorState> {
   private commitChanges() {
     if (!this.state.isDirty && !this._changesHaveBeenMade) {
       // Nothing to commit
+      return;
+    }
+
+    const panel = this.state.panelRef.resolve();
+    if (findVizPanelByKey(getDashboardSceneFor(this), panel.state.key) !== panel) {
+      // Our tree was replaced wholesale (APPLY_SPEC and the json/code editors rebuild the scene),
+      // so there is nothing to commit onto: the edit action below would be sourced from a layout
+      // item that never activates again, and the sidebar retries an inactive source forever.
       return;
     }
 

--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
@@ -1,4 +1,4 @@
-import { type SceneObjectUrlSyncHandler, type SceneObjectUrlValues, type VizPanel } from '@grafana/scenes';
+import { type SceneObjectUrlSyncHandler, type SceneObjectUrlValues } from '@grafana/scenes';
 
 import { buildPanelEditScene } from '../panel-edit/PanelEditor';
 import { createDashboardEditViewFor } from '../settings/createDashboardEditViewFor';
@@ -87,7 +87,7 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
 
       const libPanelBehavior = getLibraryPanelBehavior(panel);
       if (libPanelBehavior && !libPanelBehavior?.state.isLoaded) {
-        this._waitForLibPanelToLoadBeforeEnteringPanelEdit(panel, libPanelBehavior);
+        this._waitForLibPanelToLoadBeforeEnteringPanelEdit(values.editPanel, libPanelBehavior);
         return;
       }
 
@@ -123,14 +123,39 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
   /**
    * Temporary solution, with some refactoring of PanelEditor we can remove this
    */
-  private _waitForLibPanelToLoadBeforeEnteringPanelEdit(panel: VizPanel, libPanel: LibraryPanelBehavior) {
+  private _waitForLibPanelToLoadBeforeEnteringPanelEdit(panelId: string, libPanel: LibraryPanelBehavior) {
     const sub = libPanel.subscribeToState((state) => {
       if (state.isLoaded) {
-        this._scene.setState({
-          editPanel: buildPanelEditScene(panel, panel.state.pluginId === UNCONFIGURED_PANEL_PLUGIN_ID),
-        });
         sub.unsubscribe();
+        this._openPanelEditById(panelId);
       }
+    });
+  }
+
+  /**
+   * Open panel edit for an id resolved against the CURRENT tree.
+   *
+   * The wait above outlives the panel it was started for. A scene rebuild (APPLY_SPEC, the json and
+   * code editors) replaces the whole layout tree, and `state.editPanel` is unset for the duration of
+   * the wait, so nothing else can re-open the pane afterwards. Resolving the id again is what lets
+   * the wait survive that: opening the editor on the panel it captured would instead leave the pane
+   * driving a panel the dashboard no longer contains. If the panel it lands on is itself an unloaded
+   * library panel, it waits once more, on the behavior the live tree holds.
+   */
+  private _openPanelEditById(panelId: string) {
+    const panel = findEditPanel(this._scene, panelId);
+    if (!panel) {
+      return;
+    }
+
+    const libPanelBehavior = getLibraryPanelBehavior(panel);
+    if (libPanelBehavior && !libPanelBehavior.state.isLoaded) {
+      this._waitForLibPanelToLoadBeforeEnteringPanelEdit(panelId, libPanelBehavior);
+      return;
+    }
+
+    this._scene.setState({
+      editPanel: buildPanelEditScene(panel, panel.state.pluginId === UNCONFIGURED_PANEL_PLUGIN_ID),
     });
   }
 }

--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
@@ -1,3 +1,5 @@
+import { type Unsubscribable } from 'rxjs';
+
 import { type SceneObjectUrlSyncHandler, type SceneObjectUrlValues } from '@grafana/scenes';
 
 import { buildPanelEditScene } from '../panel-edit/PanelEditor';
@@ -12,6 +14,16 @@ import { DefaultGridLayoutManager } from './layout-default/DefaultGridLayoutMana
 import { type DashboardSceneState } from './types/dashboard';
 
 export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
+  /**
+   * Panel id of an editor that is open as far as the URL is concerned but has no pane yet: the id
+   * resolved to an unloaded library panel, or a rebuild dropped the pane before re-resolving it.
+   * `state.editPanel` is unset for that whole window, so without the hold the state change that
+   * closes the pane writes `?editPanel=` out, and a reload before the re-open lands (or a library
+   * panel whose fetch fails) loses the editor for good.
+   */
+  private _heldEditPanelId?: string;
+  private _libPanelSub?: Unsubscribable;
+
   constructor(private _scene: DashboardScene) {}
 
   getKeys(): string[] {
@@ -25,9 +37,25 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
       autofitpanels: this.getAutoFitPanels(),
       viewPanel: state.viewPanel,
       editview: state.editview?.getUrlKey(),
-      editPanel: state.editPanel?.getUrlKey() || undefined,
+      // The hold only stands while the dashboard is still editing. Leaving edit mode clears the
+      // param through its own navigation, and reporting the held id here would put it back.
+      editPanel: state.editPanel?.getUrlKey() || (state.isEditing ? this._heldEditPanelId : undefined),
       shareView: state.shareView,
     };
+  }
+
+  /**
+   * Hold `?editPanel=` in the URL across a scene rebuild, for a caller that is about to drop the
+   * pane and re-resolve the id against the tree it swaps in.
+   */
+  public retainEditPanelAcrossRebuild(panelId: string) {
+    this._heldEditPanelId = panelId;
+  }
+
+  private _releaseEditPanel() {
+    this._libPanelSub?.unsubscribe();
+    this._libPanelSub = undefined;
+    this._heldEditPanelId = undefined;
   }
 
   private getAutoFitPanels(): string | undefined {
@@ -72,6 +100,13 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
 
       if (!panel) {
         console.warn(`Panel ${values.editPanel} not found`);
+        // A rebuild that dropped the panel: release the hold and force the state change that
+        // writes `?editPanel=` out, or the URL keeps naming a panel the tree does not have.
+        const wasHeld = this._heldEditPanelId !== undefined;
+        this._releaseEditPanel();
+        if (wasHeld) {
+          this._scene.setState({ editPanel: undefined });
+        }
         return;
       }
 
@@ -91,9 +126,15 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
         return;
       }
 
+      this._releaseEditPanel();
       update.editPanel = buildPanelEditScene(panel, panel.state.pluginId === UNCONFIGURED_PANEL_PLUGIN_ID);
-    } else if (editPanel && values.editPanel === null) {
-      update.editPanel = undefined;
+    } else if (values.editPanel === null) {
+      // Closing the pane supersedes a re-open still waiting on a library panel.
+      this._releaseEditPanel();
+
+      if (editPanel) {
+        update.editPanel = undefined;
+      }
     }
 
     if (typeof values.shareView === 'string') {
@@ -124,12 +165,21 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
    * Temporary solution, with some refactoring of PanelEditor we can remove this
    */
   private _waitForLibPanelToLoadBeforeEnteringPanelEdit(panelId: string, libPanel: LibraryPanelBehavior) {
+    this._libPanelSub?.unsubscribe();
+    this._heldEditPanelId = panelId;
+
     const sub = libPanel.subscribeToState((state) => {
       if (state.isLoaded) {
         sub.unsubscribe();
+        if (this._libPanelSub === sub) {
+          this._libPanelSub = undefined;
+          this._heldEditPanelId = undefined;
+        }
         this._openPanelEditById(panelId);
       }
     });
+
+    this._libPanelSub = sub;
   }
 
   /**
@@ -147,6 +197,7 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
     // intent: leaving edit mode, or opening a different panel, would be silently undone by
     // re-opening on the id this wait captured.
     if (!this._scene.state.isEditing || this._scene.state.editPanel) {
+      this._releaseEditPanel();
       return;
     }
 

--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
@@ -143,6 +143,13 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
    * library panel, it waits once more, on the behavior the live tree holds.
    */
   private _openPanelEditById(panelId: string) {
+    // The pane is closed for the whole wait, so anything the user does meanwhile is the newer
+    // intent: leaving edit mode, or opening a different panel, would be silently undone by
+    // re-opening on the id this wait captured.
+    if (!this._scene.state.isEditing || this._scene.state.editPanel) {
+      return;
+    }
+
     const panel = findEditPanel(this._scene, panelId);
     if (!panel) {
       return;


### PR DESCRIPTION
**What is this feature?**

`APPLY_SPEC` rebuilds the scene from a spec and swaps the result in with `scene.setState(newState)`. `setState` merges, so an open `editPanel` survives the swap still driving the `VizPanel` and layout item of the tree that was just discarded.

This drops the editor as part of the swap and re-opens it through url sync, the path `?editPanel=` already takes:

```ts
const editPanelKey = scene.state.editPanel?.getUrlKey();

if (editPanelKey) {
  urlSync?.retainEditPanelAcrossRebuild(editPanelKey);
}

scene.setState({ ...newState, editPanel: undefined });

if (editPanelKey) {
  urlSync?.updateFromUrl({ editPanel: editPanelKey });
}
```

`DashboardSceneUrlSync.updateFromUrl` is already the canonical "open the editor for panel N against the current tree" entry point, and it is public via `scene.urlSync`. It resolves the id with `findEditPanel`, carries the `UNCONFIGURED_PANEL_PLUGIN_ID` flag, waits for a library panel to load, and leaves the pane closed when the applied spec no longer has the panel. None of that needs to be re-derived.

Four guards make the swap safe:

| Guard | Why |
| --- | --- |
| `PanelEditor.commitChanges` returns early when its tree has been replaced | The undo entry it stashes is sourced from the editor's layout item. After a rebuild that item never activates again, and `DashboardSidebar.performPanelEditAction` retries an inactive source on a `setTimeout` loop with no bound. |
| A pending library-panel wait resolves its id against the current tree when it fires | The wait is held by the url sync handler, which outlives the tree. A rebuild during the load would otherwise open the editor on the discarded panel. |
| That wait stops when the intent changes | The pane is closed for the whole wait. A user who leaves edit mode or opens a different panel meanwhile would have that action silently undone when the load resolves. |
| `?editPanel=` is held in the URL for the duration of the wait | `state.editPanel` is unset while the library panel loads, so the state change that closes the pane would write the param out. A reload during that window, or a fetch that never completes, would lose the editor for good. |

**Why do we need this feature?**

With a panel open for editing, any `APPLY_SPEC` leaves the pane detached from the dashboard. Observed on `main`:

- the panel preview goes blank
- the options fields stop holding input: keystrokes land on the orphaned panel and are reverted on the next re-render
- anything that does land is invisible to `transformSceneToSaveModelSchemaV2`, so it is absent from a save or a read, and is overwritten by the next write

Reproduction:

1. Open a dashboard and open a panel for editing (`?editPanel=1`)
2. Change the panel title in the editor. `GET_SPEC` returns the new title, as expected
3. Run any `APPLY_SPEC` against the dashboard (for example, ask Grafana Assistant to edit a panel)
4. Change the title in the editor again. The pane no longer works, and `GET_SPEC` still returns the value from step 2

Step 4 is the user-visible bug: the edit appears to be accepted and then silently disappears.

**Who is this feature for?**

Anyone editing a panel while something writes the whole dashboard spec. Today that is users working with Grafana Assistant, which uses `APPLY_SPEC` for every dashboard change.

**Special notes for your reviewer:**

Tests: `applySpec.test.ts` drives the real command against a real scene and asserts the reported symptom, that an edit made after the swap is present in what a read returns. Verified red without the source change: 11 of the new cases fail with the three source files reverted to `main`.

Assertions deliberately compare panel keys and booleans rather than scene objects. A failed `toBe` on a `VizPanel` sends the whole circular tree over jest's worker IPC and kills the run rather than reporting a failure.

Behaviour change worth a second opinion: the re-opened editor takes a fresh original-state snapshot, so panel-edit **Discard** reverts to the post-rebuild state rather than to the state when the pane was first opened, and the dirty flag resets. That seems right given the dashboard underneath has been replaced.

Holding `?editPanel=` across the swap also means the param never changes value, so the rebuild no longer writes the URL twice in one tick.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
