### PR TITLE
Search: authorize trash searches as folder admin or deleter

### DIFF
--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -1745,9 +1745,16 @@ func (s *server) listFromTrash(ctx context.Context, req *resourcepb.ListRequest)
 	)
 	maxPageBytes := s.maxPageSizeBytes
 
-	// Cache admin check results per folder to avoid redundant Check calls
-	// for items in the same folder.
-	folderAdminCache := make(map[string]bool)
+	// One authorizer per request: it caches folder-admin results, which must not
+	// outlive the request. The search path builds the same thing, so the two trash
+	// views cannot drift on who may see what.
+	authorizer := NewTrashAuthorizer(s.access, user, key, func(err error) {
+		s.degraded(ctx, "folder_admin_check", classifyAuthError(err), NamespacedResource{
+			Namespace: key.Namespace,
+			Group:     key.Group,
+			Resource:  key.Resource,
+		}, err)
+	})
 
 	rv, err := s.backend.ListHistory(ctx, req, func(iter ListIterator) error {
 		for iter.Next() {
@@ -1766,11 +1773,9 @@ func (s *server) listFromTrash(ctx context.Context, req *resourcepb.ListRequest)
 				continue
 			}
 
-			// Check if user is admin in this folder (cached) or the user who deleted the item.
-			if !s.checkFolderAdmin(ctx, user, iter.Folder(), key, folderAdminCache) {
-				if obj.GetUpdatedBy() != user.GetUID() {
-					continue
-				}
+			// The deletion marker records the deleting user as the last updater.
+			if !authorizer.Allowed(ctx, iter.Folder(), obj.GetUpdatedBy()) {
+				continue
 			}
 
 			item := &resourcepb.ResourceWrapper{
@@ -1819,33 +1824,6 @@ func (s *server) finalizeListResponse(ctx context.Context, rsp *resourcepb.ListR
 		s.storageMetrics.ListWithFieldSelectors.WithLabelValues(gr, "storage").Inc()
 	}
 	return rsp, nil
-}
-
-// checkFolderAdmin checks whether the user has admin permission (VerbSetPermissions) in the given
-// folder. Results are cached per folder to avoid redundant Check calls.
-func (s *server) checkFolderAdmin(ctx context.Context, user claims.AuthInfo, folder string, key *resourcepb.ResourceKey, cache map[string]bool) bool {
-	if isAdmin, ok := cache[folder]; ok {
-		return isAdmin
-	}
-	resp, err := s.access.Check(ctx, user, claims.CheckRequest{
-		Verb:      utils.VerbSetPermissions,
-		Group:     key.Group,
-		Resource:  key.Resource,
-		Namespace: key.Namespace,
-	}, folder)
-	if err != nil {
-		// The error is swallowed (user treated as non-admin), so without this
-		// the failure is invisible. Record it as a degraded operation, tagging
-		// whether authz was unavailable vs. a logical error.
-		s.degraded(ctx, "folder_admin_check", classifyAuthError(err), NamespacedResource{
-			Namespace: key.Namespace,
-			Group:     key.Group,
-			Resource:  key.Resource,
-		}, err)
-	}
-	isAdmin := err == nil && resp.Allowed
-	cache[folder] = isAdmin
-	return isAdmin
 }
 
 // parseTrashItem unmarshals the raw value into a GrafanaMetaAccessor.

--- a/pkg/storage/unified/resource/trash_authz.go
+++ b/pkg/storage/unified/resource/trash_authz.go
@@ -1,0 +1,86 @@
+package resource
+
+import (
+	"context"
+
+	claims "github.com/grafana/authlib/types"
+
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+)
+
+// TrashAuthorizer decides who may see a deleted object: whoever deleted it, or an
+// admin of the folder it was in.
+//
+// Not the read check live search applies. Read access to a folder is common, so
+// reusing it would disclose other people's deleted objects.
+//
+// One authorizer per request, because of the cache below.
+type TrashAuthorizer struct {
+	access claims.AccessClient
+	user   claims.AuthInfo
+
+	// Trash never federates, so one group and resource covers every candidate.
+	key *resourcepb.ResourceKey
+
+	// A UID only identifies someone within their own namespace.
+	namespaceMatches bool
+
+	// Cached because the check is a network call and a page of results usually
+	// spans far fewer folders than items. Must not outlive the request, or a
+	// permission change would never take effect.
+	folderAdmin map[string]bool
+
+	// The failure is swallowed, so report it or it is invisible.
+	onCheckError func(err error)
+}
+
+func NewTrashAuthorizer(
+	access claims.AccessClient,
+	user claims.AuthInfo,
+	key *resourcepb.ResourceKey,
+	onCheckError func(err error),
+) *TrashAuthorizer {
+	return &TrashAuthorizer{
+		access:           access,
+		user:             user,
+		key:              key,
+		namespaceMatches: claims.NamespaceMatches(user.GetNamespace(), key.Namespace),
+		folderAdmin:      map[string]bool{},
+		onCheckError:     onCheckError,
+	}
+}
+
+// Allowed reports whether the caller may see an object in folder deleted by
+// deletedBy.
+//
+// deletedBy is compared first because it needs no authorization call. The two
+// conditions are ORed, so the order affects only cost, not the answer.
+func (a *TrashAuthorizer) Allowed(ctx context.Context, folder, deletedBy string) bool {
+	if a.namespaceMatches && deletedBy != "" && deletedBy == a.user.GetUID() {
+		return true
+	}
+	return a.FolderAdmin(ctx, folder)
+}
+
+// FolderAdmin reports whether the caller administers folder.
+//
+// A kind with no folder is checked against the namespace instead, which is what
+// listFromTrash has always done.
+func (a *TrashAuthorizer) FolderAdmin(ctx context.Context, folder string) bool {
+	if isAdmin, ok := a.folderAdmin[folder]; ok {
+		return isAdmin
+	}
+	resp, err := a.access.Check(ctx, a.user, claims.CheckRequest{
+		Verb:      utils.VerbSetPermissions,
+		Group:     a.key.Group,
+		Resource:  a.key.Resource,
+		Namespace: a.key.Namespace,
+	}, folder)
+	if err != nil && a.onCheckError != nil {
+		a.onCheckError(err)
+	}
+	isAdmin := err == nil && resp.Allowed
+	a.folderAdmin[folder] = isAdmin
+	return isAdmin
+}

--- a/pkg/storage/unified/resource/trash_authz_test.go
+++ b/pkg/storage/unified/resource/trash_authz_test.go
@@ -1,0 +1,167 @@
+package resource
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	authlib "github.com/grafana/authlib/types"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+)
+
+func trashTestKey() *resourcepb.ResourceKey {
+	return &resourcepb.ResourceKey{
+		Namespace: "default",
+		Group:     "dashboard.grafana.app",
+		Resource:  "dashboards",
+	}
+}
+
+func trashTestUser(uid string) authlib.AuthInfo {
+	return &identity.StaticRequester{Type: authlib.TypeUser, UserUID: uid, Namespace: "default"}
+}
+
+// recordedCheck lets tests assert on the verb and scope, not just the answer.
+type recordedCheck struct {
+	verb   string
+	folder string
+}
+
+func newRecordingAuthorizer(
+	t *testing.T,
+	uid string,
+	allow func(folder string) bool,
+	err error,
+) (*TrashAuthorizer, *[]recordedCheck, *[]error) {
+	t.Helper()
+	var calls []recordedCheck
+	var reported []error
+	ac := &callbackAccessClient{fn: func(req authlib.CheckRequest, folder string) (authlib.CheckResponse, error) {
+		calls = append(calls, recordedCheck{verb: req.Verb, folder: folder})
+		if err != nil {
+			return authlib.CheckResponse{}, err
+		}
+		return authlib.CheckResponse{Allowed: allow(folder), Zookie: authlib.NoopZookie{}}, nil
+	}}
+	a := NewTrashAuthorizer(ac, trashTestUser(uid), trashTestKey(), func(e error) {
+		reported = append(reported, e)
+	})
+	return a, &calls, &reported
+}
+
+// Recognising the deleter is what keeps trash cheap, so it must cost no call.
+func TestTrashAuthorizer_DeleterIsAllowedWithoutAnyCheck(t *testing.T) {
+	a, calls, _ := newRecordingAuthorizer(t, "alice", func(string) bool { return false }, nil)
+
+	assert.True(t, a.Allowed(t.Context(), "folder-1", "user:alice"))
+	assert.Empty(t, *calls, "recognising the deleter must not call the access client")
+}
+
+func TestTrashAuthorizer_FolderAdminIsAllowed(t *testing.T) {
+	a, calls, _ := newRecordingAuthorizer(t, "carol", func(folder string) bool { return folder == "folder-1" }, nil)
+
+	assert.True(t, a.Allowed(t.Context(), "folder-1", "user:alice"))
+	assert.False(t, a.Allowed(t.Context(), "folder-2", "user:alice"))
+
+	require.Len(t, *calls, 2)
+	for _, c := range *calls {
+		assert.Equal(t, utils.VerbSetPermissions, c.verb, "folder admin is a set_permissions check")
+	}
+}
+
+// Read access to the folder must not be enough, which is the disclosure this rule
+// exists to prevent.
+func TestTrashAuthorizer_OtherUsersDeletionIsDenied(t *testing.T) {
+	a, _, _ := newRecordingAuthorizer(t, "bob", func(string) bool { return false }, nil)
+
+	assert.False(t, a.Allowed(t.Context(), "folder-1", "user:alice"))
+}
+
+// The same UID may belong to a different person in another namespace.
+func TestTrashAuthorizer_DeleterFromAnotherNamespaceIsDenied(t *testing.T) {
+	var calls []recordedCheck
+	ac := &callbackAccessClient{fn: func(req authlib.CheckRequest, folder string) (authlib.CheckResponse, error) {
+		calls = append(calls, recordedCheck{verb: req.Verb, folder: folder})
+		return authlib.CheckResponse{}, authlib.ErrNamespaceMismatch
+	}}
+	stranger := &identity.StaticRequester{Type: authlib.TypeUser, UserUID: "alice", Namespace: "other-namespace"}
+	a := NewTrashAuthorizer(ac, stranger, trashTestKey(), func(error) {})
+
+	require.Equal(t, "user:alice", stranger.GetUID(), "same UID, another namespace")
+	assert.False(t, a.Allowed(t.Context(), "folder-1", "user:alice"))
+	assert.Len(t, calls, 1, "it falls through to the folder check rather than short-circuiting")
+}
+
+// A wildcard identity is scoped to every namespace, so it still matches.
+func TestTrashAuthorizer_WildcardNamespaceMatches(t *testing.T) {
+	ac := &callbackAccessClient{fn: func(authlib.CheckRequest, string) (authlib.CheckResponse, error) {
+		return authlib.CheckResponse{Allowed: false, Zookie: authlib.NoopZookie{}}, nil
+	}}
+	wildcard := &identity.StaticRequester{Type: authlib.TypeUser, UserUID: "alice", Namespace: "*"}
+	a := NewTrashAuthorizer(ac, wildcard, trashTestKey(), func(error) {})
+
+	assert.True(t, a.Allowed(t.Context(), "folder-1", "user:alice"))
+}
+
+// Otherwise a missing deleter would match a caller with an empty UID.
+func TestTrashAuthorizer_EmptyDeletedByNeverMatches(t *testing.T) {
+	a, calls, _ := newRecordingAuthorizer(t, "", func(string) bool { return false }, nil)
+
+	assert.False(t, a.Allowed(t.Context(), "folder-1", ""))
+	assert.Len(t, *calls, 1, "it must fall through to the folder check, not short-circuit")
+}
+
+func TestTrashAuthorizer_CachesOneCheckPerFolder(t *testing.T) {
+	a, calls, _ := newRecordingAuthorizer(t, "carol", func(string) bool { return true }, nil)
+
+	for range 5 {
+		assert.True(t, a.Allowed(t.Context(), "folder-1", "user:alice"))
+	}
+	assert.True(t, a.Allowed(t.Context(), "folder-2", "user:alice"))
+
+	assert.Equal(t, []recordedCheck{
+		{verb: utils.VerbSetPermissions, folder: "folder-1"},
+		{verb: utils.VerbSetPermissions, folder: "folder-2"},
+	}, *calls)
+}
+
+// Denials need caching too, or a folder the caller does not administer costs a call
+// per object.
+func TestTrashAuthorizer_CachesDenials(t *testing.T) {
+	a, calls, _ := newRecordingAuthorizer(t, "bob", func(string) bool { return false }, nil)
+
+	for range 5 {
+		assert.False(t, a.Allowed(t.Context(), "folder-1", "user:alice"))
+	}
+	assert.Len(t, *calls, 1)
+}
+
+// The failure is swallowed, so without a report an authz outage would silently
+// empty everyone's trash.
+func TestTrashAuthorizer_ReportsCheckFailuresAndDenies(t *testing.T) {
+	boom := errors.New("authz unavailable")
+	a, _, reported := newRecordingAuthorizer(t, "carol", nil, boom)
+
+	assert.False(t, a.Allowed(t.Context(), "folder-1", "user:alice"))
+
+	require.Len(t, *reported, 1)
+	assert.ErrorIs(t, (*reported)[0], boom)
+}
+
+// Kinds outside the folder tree carry no folder, making the check namespace-wide.
+func TestTrashAuthorizer_FolderlessKindChecksTheWholeNamespace(t *testing.T) {
+	a, calls, _ := newRecordingAuthorizer(t, "carol", func(folder string) bool {
+		return folder == "" // granted namespace-wide
+	}, nil)
+
+	assert.True(t, a.Allowed(t.Context(), "", "user:alice"))
+
+	require.Len(t, *calls, 1)
+	assert.Equal(t, utils.VerbSetPermissions, (*calls)[0].verb)
+	assert.Empty(t, (*calls)[0].folder, "no folder means the check is not scoped to one")
+}

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"iter"
 	"math"
+	"net/http"
 	"os"
 	"path/filepath"
 	"slices"
@@ -2164,9 +2165,33 @@ func (b *bleveIndex) Search(
 	// TotalHitsExact=false.
 	postRank := b.postRankAuthzEnabled && access != nil
 
+	// A trash search replaces the read check with the trash rule on whichever authz
+	// path runs. Built once per request, because it caches folder-admin results.
+	var trashAuthz *resource.TrashAuthorizer
+	if req.IsDeleted && access != nil {
+		user, ok := authlib.AuthInfoFrom(ctx)
+		if !ok || user == nil {
+			// Falling through would apply the read check, which is more permissive.
+			response.Error = &resourcepb.ErrorResult{
+				Message: "no user found in context",
+				Code:    http.StatusUnauthorized,
+			}
+			return response, nil
+		}
+		trashAuthz = resource.NewTrashAuthorizer(access, user, &resourcepb.ResourceKey{
+			Namespace: b.key.Namespace,
+			Group:     b.key.Group,
+			Resource:  b.key.Resource,
+		}, func(err error) {
+			// Swallowed (the caller is treated as not an admin), so without this the
+			// failure would be invisible.
+			b.logger.FromContext(ctx).Error("trash folder admin check failed, treating user as not an admin", "error", err)
+		})
+	}
+
 	conversionStarts := time.Now()
 	// convert protobuf request to bleve request
-	searchrequest, e := b.toBleveSearchRequest(ctx, req, access, postRank)
+	searchrequest, e := b.toBleveSearchRequest(ctx, req, access, postRank, trashAuthz)
 	if e != nil {
 		response.Error = e
 		return response, nil
@@ -2191,7 +2216,7 @@ func (b *bleveIndex) Search(
 	}
 	if postRank && cursorLen > 0 && cursorLen != len(searchrequest.Sort) {
 		postRank = false
-		searchrequest, e = b.toBleveSearchRequest(ctx, req, access, postRank)
+		searchrequest, e = b.toBleveSearchRequest(ctx, req, access, postRank, trashAuthz)
 		if e != nil {
 			response.Error = e
 			return response, nil
@@ -2213,12 +2238,12 @@ func (b *bleveIndex) Search(
 	// from "fields returned to the caller" (selectFields).
 	selectFields := slices.Clone(searchrequest.Fields)
 	if postRank {
-		b.ensureAuthzFields(searchrequest)
+		b.ensureAuthzFields(searchrequest, trashAuthz != nil)
 	}
 	stats.AddRequestConversionTime(time.Since(conversionStarts))
 
 	if postRank {
-		return b.runPostFilterAuthz(ctx, access, req, index, searchrequest, selectFields, stats, response)
+		return b.runPostFilterAuthz(ctx, access, req, index, searchrequest, selectFields, stats, response, trashAuthz)
 	}
 
 	res, err := index.SearchInContext(ctx, searchrequest)
@@ -2334,7 +2359,7 @@ func (b *bleveIndex) getIndex(
 	return b.index, nil
 }
 
-func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.ResourceSearchRequest, access authlib.AccessClient, postRankAuthz bool) (*bleve.SearchRequest, *resourcepb.ErrorResult) {
+func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.ResourceSearchRequest, access authlib.AccessClient, postRankAuthz bool, trashAuthz *resource.TrashAuthorizer) (*bleve.SearchRequest, *resourcepb.ErrorResult) {
 	ctx, span := tracer.Start(ctx, "search.bleveIndex.toBleveSearchRequest") //nolint:staticcheck,ineffassign // SA4006: ctx intentionally kept so future code added to this function inherits the traced span
 	defer span.End()
 
@@ -2427,6 +2452,7 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 			namespace: b.key.Namespace,
 			group:     b.key.Group,
 			resources: b.authzResources(req),
+			trash:     trashAuthz,
 		})
 	}
 
@@ -3517,6 +3543,7 @@ type permissionScopedQuery struct {
 	namespace string
 	group     string
 	resources map[string]string // resource -> verb mapping
+	trash     *resource.TrashAuthorizer
 	log       log.Logger
 }
 
@@ -3525,6 +3552,8 @@ type permissionScopedQueryConfig struct {
 	namespace string
 	group     string
 	resources map[string]string // resource -> verb mapping
+	// Set for a trash search, nil for a live one.
+	trash *resource.TrashAuthorizer
 }
 
 func newPermissionScopedQuery(q query.Query, cfg permissionScopedQueryConfig) *permissionScopedQuery {
@@ -3534,6 +3563,7 @@ func newPermissionScopedQuery(q query.Query, cfg permissionScopedQueryConfig) *p
 		namespace: cfg.namespace,
 		group:     cfg.group,
 		resources: cfg.resources,
+		trash:     cfg.trash,
 		log:       log.New("search_permissions"),
 	}
 }
@@ -3544,12 +3574,19 @@ func (q *permissionScopedQuery) Searcher(ctx context.Context, i index.IndexReade
 		return nil, err
 	}
 
-	dvReader, err := i.DocValueReader([]string{"folder"})
+	// Both are doc values, so reading who deleted it costs no fetch.
+	dvFields := []string{resource.SEARCH_FIELD_FOLDER}
+	if q.trash != nil {
+		dvFields = append(dvFields, resource.SEARCH_FIELD_DELETED_BY)
+	}
+	dvReader, err := i.DocValueReader(dvFields)
 	if err != nil {
 		return nil, err
 	}
 
-	return newBatchAuthzSearcher(ctx, searcher, i, dvReader, q.access, q.namespace, q.group, q.resources, q.log.FromContext(ctx)), nil
+	s := newBatchAuthzSearcher(ctx, searcher, i, dvReader, q.access, q.namespace, q.group, q.resources, q.log.FromContext(ctx))
+	s.trash = q.trash
+	return s, nil
 }
 
 // docInfo holds document information for authorization
@@ -3561,6 +3598,8 @@ type docInfo struct {
 	name         string
 	folder       string
 	verb         string
+	// Only read on the trash path.
+	deletedBy string
 }
 
 // batchAuthzSearcher implements a batch-aware authorization filtering searcher
@@ -3575,6 +3614,9 @@ type batchAuthzSearcher struct {
 	group       string
 	resources   map[string]string // resource -> verb mapping
 	log         log.Logger
+
+	// Set for a trash search, nil for a live one.
+	trash *resource.TrashAuthorizer
 
 	// Traces the authz-filtered scan and records how many candidate documents
 	// were considered vs. how many survived authorization. Ended in Close.
@@ -3678,6 +3720,9 @@ func (s *batchAuthzSearcher) initPullIterator() {
 	// BatchCheck loop, so the authz phase is visible as a child of this
 	// searcher's span instead of an opaque gap.
 	authzIter := authz.FilterAuthorized(s.ctx, s.access, candidates, extractFn, authz.WithTracer(tracer))
+	if s.trash != nil {
+		authzIter = trashAuthorized(s.ctx, candidates, s.trash)
+	}
 
 	s.next, s.stop = iter.Pull2(func(yield func(docInfo, error) bool) {
 		for item, err := range authzIter {
@@ -3721,11 +3766,15 @@ func (s *batchAuthzSearcher) parseDocInfo(doc *search.DocumentMatch) (docInfo, b
 	resourceType := parts[2]
 	name := parts[3]
 
-	// Get folder from doc values
+	// Get folder (and, for trash, who deleted it) from doc values
 	folder := ""
+	deletedBy := ""
 	err = s.dvReader.VisitDocValues(doc.IndexInternalID, func(field string, value []byte) {
-		if field == "folder" {
+		switch field {
+		case resource.SEARCH_FIELD_FOLDER:
 			folder = string(value)
+		case resource.SEARCH_FIELD_DELETED_BY:
+			deletedBy = string(value)
 		}
 	})
 	if err != nil {
@@ -3748,6 +3797,7 @@ func (s *batchAuthzSearcher) parseDocInfo(doc *search.DocumentMatch) (docInfo, b
 		name:         name,
 		folder:       folder,
 		verb:         verb,
+		deletedBy:    deletedBy,
 	}, true
 }
 

--- a/pkg/storage/unified/search/bleve_postrank_authz.go
+++ b/pkg/storage/unified/search/bleve_postrank_authz.go
@@ -3,6 +3,7 @@ package search
 import (
 	"context"
 	"fmt"
+	"iter"
 	"slices"
 	"sort"
 	"strings"
@@ -147,11 +148,23 @@ func (b *bleveIndex) ensureSearchFields(searchrequest *bleve.SearchRequest, req 
 // extends the bleve load list only; it is NOT part of the response column list
 // (selectFields) — Search snapshots selectFields before calling this so the
 // caller's requested columns are returned unchanged.
-func (b *bleveIndex) ensureAuthzFields(searchrequest *bleve.SearchRequest) {
-	if !slices.Contains(searchrequest.Fields, resource.SEARCH_FIELD_FOLDER) &&
-		!slices.Contains(searchrequest.Fields, resource.SEARCH_FIELD_ALL_FIELDS) {
-		searchrequest.Fields = append(searchrequest.Fields, resource.SEARCH_FIELD_FOLDER)
+func (b *bleveIndex) ensureAuthzFields(searchrequest *bleve.SearchRequest, trash bool) {
+	for _, f := range authzLoadFields(trash) {
+		if !slices.Contains(searchrequest.Fields, f) &&
+			!slices.Contains(searchrequest.Fields, resource.SEARCH_FIELD_ALL_FIELDS) {
+			searchrequest.Fields = append(searchrequest.Fields, f)
+		}
 	}
+}
+
+// authzLoadFields are the stored fields the post-rank runner reads to authorize a
+// hit. Every place that narrows the load list has to keep all of them: dropping
+// deleted_by raises no error, it just stops the deleter seeing their own objects.
+func authzLoadFields(trash bool) []string {
+	if trash {
+		return []string{resource.SEARCH_FIELD_FOLDER, resource.SEARCH_FIELD_DELETED_BY}
+	}
+	return []string{resource.SEARCH_FIELD_FOLDER}
 }
 
 // authzResources builds the resource-type -> verb map used to authorize hits.
@@ -191,6 +204,10 @@ func parseHitDocInfo(doc *search.DocumentMatch, resources map[string]string) (do
 	if v, ok := doc.Fields[resource.SEARCH_FIELD_FOLDER].(string); ok {
 		folder = v
 	}
+	deletedBy := ""
+	if v, ok := doc.Fields[resource.SEARCH_FIELD_DELETED_BY].(string); ok {
+		deletedBy = v
+	}
 
 	return docInfo{
 		doc:          doc,
@@ -200,6 +217,7 @@ func parseHitDocInfo(doc *search.DocumentMatch, resources map[string]string) (do
 		name:         parts[3],
 		folder:       folder,
 		verb:         verb,
+		deletedBy:    deletedBy,
 	}, true
 }
 
@@ -226,6 +244,7 @@ func (b *bleveIndex) runPostFilterAuthz(
 	selectFields []string,
 	stats *resource.SearchStats,
 	response *resourcepb.ResourceSearchResponse,
+	trashAuthz *resource.TrashAuthorizer,
 ) (*resourcepb.ResourceSearchResponse, error) {
 	limit, offset := int(req.Limit), int(req.Offset)
 	ctx, span := tracer.Start(ctx, "search.postRankAuthz", trace.WithAttributes(
@@ -245,7 +264,7 @@ func (b *bleveIndex) runPostFilterAuthz(
 	countOnly := limit == 0 && !wantFacets
 
 	agg, facetAuthorized, facetExhausted, err := b.prepareFacetAggregation(
-		ctx, access, req, index, firstReq, resources, stats,
+		ctx, access, req, index, firstReq, resources, stats, trashAuthz,
 	)
 	if err != nil {
 		return nil, err
@@ -256,7 +275,7 @@ func (b *bleveIndex) runPostFilterAuthz(
 	case countOnly:
 		baseWindow = cfg.countWindowSize()
 		// No rows are returned, so load only what authorization reads.
-		firstReq.Fields = []string{resource.SEARCH_FIELD_FOLDER}
+		firstReq.Fields = authzLoadFields(trashAuthz != nil)
 		firstReq.Size = baseWindow
 	case wantFacets:
 		// Facets always use a separate scan starting at the top of the query.
@@ -325,7 +344,7 @@ func (b *bleveIndex) runPostFilterAuthz(
 		}
 
 		stop := false
-		for info, err := range authz.FilterAuthorized(ctx, access, candidateSeq, extractFn, authz.WithTracer(tracer)) {
+		for info, err := range authorizeHits(ctx, access, candidateSeq, extractFn, trashAuthz) {
 			if err != nil {
 				return nil, err
 			}
@@ -391,6 +410,22 @@ func (b *bleveIndex) runPostFilterAuthz(
 		authorized, exhausted, reverseSort, wantFacets, agg, stats)
 }
 
+// authorizeHits filters ranked hits by the trash rule when trashAuthz is set,
+// otherwise by the read check. Same shape either way, so the scan loops do not
+// need to know which is running.
+func authorizeHits(
+	ctx context.Context,
+	access authlib.AccessClient,
+	candidates iter.Seq[docInfo],
+	extractFn func(docInfo) authz.BatchCheckItem,
+	trashAuthz *resource.TrashAuthorizer,
+) iter.Seq2[docInfo, error] {
+	if trashAuthz != nil {
+		return trashAuthorized(ctx, candidates, trashAuthz)
+	}
+	return authz.FilterAuthorized(ctx, access, candidates, extractFn, authz.WithTracer(tracer))
+}
+
 func (b *bleveIndex) prepareFacetAggregation(
 	ctx context.Context,
 	access authlib.AccessClient,
@@ -399,6 +434,7 @@ func (b *bleveIndex) prepareFacetAggregation(
 	firstReq *bleve.SearchRequest,
 	resources map[string]string,
 	stats *resource.SearchStats,
+	trashAuthz *resource.TrashAuthorizer,
 ) (*facetAggregator, int64, bool, error) {
 	if len(req.Facet) == 0 {
 		return nil, 0, false, nil
@@ -415,7 +451,7 @@ func (b *bleveIndex) prepareFacetAggregation(
 		}
 	}
 	agg, authorized, exhausted, err := b.aggregateFacetsFromTop(
-		ctx, access, index, firstReq, resources, extractFn, req.Facet, stats,
+		ctx, access, index, firstReq, resources, extractFn, req.Facet, stats, trashAuthz,
 	)
 	return agg, authorized, exhausted, err
 }
@@ -424,8 +460,8 @@ func (b *bleveIndex) prepareFacetAggregation(
 // folder to authorize a hit and the stored facet fields to count its terms.
 // The response columns come from the page scan, so loading them here would
 // fetch stored data for up to FacetSampleSize hits that is never returned.
-func (b *bleveIndex) facetScanFields(facets map[string]*resourcepb.ResourceSearchRequest_Facet) []string {
-	fields := make([]string, 0, len(facets)+1)
+func (b *bleveIndex) facetScanFields(facets map[string]*resourcepb.ResourceSearchRequest_Facet, trash bool) []string {
+	fields := make([]string, 0, len(facets)+2)
 	for _, facet := range facets {
 		field := b.searchFields.storedFacetFields[facet.Field]
 		if field != "" && !slices.Contains(fields, field) {
@@ -433,7 +469,7 @@ func (b *bleveIndex) facetScanFields(facets map[string]*resourcepb.ResourceSearc
 		}
 	}
 	slices.Sort(fields)
-	return append(fields, resource.SEARCH_FIELD_FOLDER)
+	return append(fields, authzLoadFields(trash)...)
 }
 
 func (b *bleveIndex) aggregateFacetsFromTop(
@@ -445,6 +481,7 @@ func (b *bleveIndex) aggregateFacetsFromTop(
 	extractFn func(docInfo) authz.BatchCheckItem,
 	facets map[string]*resourcepb.ResourceSearchRequest_Facet,
 	stats *resource.SearchStats,
+	trashAuthz *resource.TrashAuthorizer,
 ) (*facetAggregator, int64, bool, error) {
 	agg := newFacetAggregator(facets, b.searchFields.storedFacetFields)
 	cfg := b.postRankAuthz
@@ -456,7 +493,7 @@ func (b *bleveIndex) aggregateFacetsFromTop(
 	initial.SearchAfter = nil
 	initial.SearchBefore = nil
 	initial.Size = cfg.facetWindowSize()
-	initial.Fields = b.facetScanFields(facets)
+	initial.Fields = b.facetScanFields(facets, trashAuthz != nil)
 	windowReq := &initial
 
 	var firstRes *bleve.SearchResult
@@ -486,7 +523,7 @@ func (b *bleveIndex) aggregateFacetsFromTop(
 				}
 			}
 		}
-		for info, err := range authz.FilterAuthorized(ctx, access, candidateSeq, extractFn, authz.WithTracer(tracer)) {
+		for info, err := range authorizeHits(ctx, access, candidateSeq, extractFn, trashAuthz) {
 			if err != nil {
 				return nil, 0, false, err
 			}

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -877,7 +877,7 @@ func TestBleveSearchRequestDefaultSortIncludesNameTieBreaker(t *testing.T) {
 		searchReq, errResult := idx.toBleveSearchRequest(t.Context(), &resourcepb.ResourceSearchRequest{
 			Options: &resourcepb.ListOptions{},
 			Limit:   10,
-		}, nil, false)
+		}, nil, false, nil)
 		require.Nil(t, errResult)
 		require.Len(t, searchReq.Sort, 2)
 
@@ -897,7 +897,7 @@ func TestBleveSearchRequestDefaultSortIncludesNameTieBreaker(t *testing.T) {
 			Options: &resourcepb.ListOptions{},
 			Limit:   10,
 			Query:   "grafana",
-		}, nil, false)
+		}, nil, false, nil)
 		require.Nil(t, errResult)
 		require.Len(t, searchReq.Sort, 2)
 		_, ok := searchReq.Sort[0].(*blevesearch.SortScore)
@@ -916,7 +916,7 @@ func TestBleveSearchRequestDefaultSortIncludesNameTieBreaker(t *testing.T) {
 			Facet: map[string]*resourcepb.ResourceSearchRequest_Facet{
 				"tagValues": {Field: resource.SEARCH_FIELD_TAGS, Limit: 10},
 			},
-		}, nil, false)
+		}, nil, false, nil)
 		require.Nil(t, errResult)
 		require.Contains(t, searchReq.Facets, "tagValues")
 		assert.Equal(t, resource.SEARCH_FIELD_TAGS, searchReq.Facets["tagValues"].Field)
@@ -929,7 +929,7 @@ func TestBleveSearchRequestDefaultSortIncludesNameTieBreaker(t *testing.T) {
 			Facet: map[string]*resourcepb.ResourceSearchRequest_Facet{
 				"region": {Field: "labels.region", Limit: 10},
 			},
-		}, nil, false)
+		}, nil, false, nil)
 		require.Nil(t, searchReq)
 		require.NotNil(t, errResult)
 		assert.Contains(t, errResult.Message, `field "labels.region" does not support faceting`)
@@ -945,7 +945,7 @@ func TestBleveSearchRequestDefaultSortIncludesNameTieBreaker(t *testing.T) {
 				Facet: map[string]*resourcepb.ResourceSearchRequest_Facet{
 					"tagValues": {Field: resource.SEARCH_FIELD_TAGS, Limit: -1},
 				},
-			}, nil, postRankAuthz)
+			}, nil, postRankAuthz, nil)
 			require.Nil(t, searchReq)
 			require.NotNil(t, errResult)
 			assert.Contains(t, errResult.Message, `facet "tagValues" has a negative limit`)

--- a/pkg/storage/unified/search/trash_authz.go
+++ b/pkg/storage/unified/search/trash_authz.go
@@ -1,0 +1,51 @@
+package search
+
+import (
+	"context"
+	"iter"
+
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+)
+
+// trashAuthorized filters candidates by the trash rule instead of the read check.
+// Shaped like authz.FilterAuthorized so it substitutes at the existing per-item
+// authorization hook rather than forking the read path.
+//
+// Unbatched on purpose: FilterAuthorized batches because the read check costs one
+// call per item, whereas the trash rule costs one per distinct folder and none for
+// objects the caller deleted.
+func trashAuthorized(
+	ctx context.Context,
+	candidates iter.Seq[docInfo],
+	authorizer *resource.TrashAuthorizer,
+) iter.Seq2[docInfo, error] {
+	return func(yield func(docInfo, error) bool) {
+		ctx, span := tracer.Start(ctx, "search.trashAuthorized")
+		defer span.End()
+
+		var considered, allowed int64
+		defer func() {
+			span.SetAttributes(
+				attribute.Int64("search.candidates", considered),
+				attribute.Int64("search.authorized", allowed),
+			)
+		}()
+
+		for info := range candidates {
+			considered++
+			if err := ctx.Err(); err != nil {
+				yield(docInfo{}, err)
+				return
+			}
+			if !authorizer.Allowed(ctx, info.folder, info.deletedBy) {
+				continue
+			}
+			allowed++
+			if !yield(info, nil) {
+				return
+			}
+		}
+	}
+}

--- a/pkg/storage/unified/search/trash_authz_test.go
+++ b/pkg/storage/unified/search/trash_authz_test.go
@@ -1,0 +1,418 @@
+package search_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	authlib "github.com/grafana/authlib/types"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	authzextv1 "github.com/grafana/grafana/pkg/services/authz/proto/v1"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+)
+
+// Trash authorizes on folder admin or deleter, not the read check. These tests exist
+// because reusing the read check would disclose other people's deleted objects to
+// anyone with read access to the folder, which for dashboards is most users.
+
+const (
+	trashAlice = "user:alice" // deleted things
+	trashBob   = "user:bob"   // can read the folder, is not an admin
+	trashCarol = "user:carol" // folder admin
+)
+
+// trashAccessClient answers the folder-admin and read checks separately. A stub that
+// ignored the verb could not tell the two rules apart, and so could not catch the
+// disclosure these tests guard against.
+type trashAccessClient struct {
+	adminFolders map[string]bool
+	readAll      bool
+
+	// Every folder checked, in order, including repeats, so tests can assert on the
+	// cache.
+	adminCheckFolders []string
+	// Counted so a test can show which rule ran.
+	readChecks int
+}
+
+func (c *trashAccessClient) Check(_ context.Context, _ authlib.AuthInfo, req authlib.CheckRequest, folder string) (authlib.CheckResponse, error) {
+	if req.Verb == utils.VerbSetPermissions {
+		c.adminCheckFolders = append(c.adminCheckFolders, folder)
+		return authlib.CheckResponse{Allowed: c.adminFolders[folder], Zookie: authlib.NoopZookie{}}, nil
+	}
+	c.readChecks++
+	return authlib.CheckResponse{Allowed: c.readAll, Zookie: authlib.NoopZookie{}}, nil
+}
+
+func (c *trashAccessClient) Compile(_ context.Context, _ authlib.AuthInfo, _ authlib.ListRequest) (authlib.ItemChecker, authlib.Zookie, error) {
+	return func(_, _ string) bool {
+		c.readChecks++
+		return c.readAll
+	}, authlib.NoopZookie{}, nil
+}
+
+func (c *trashAccessClient) BatchCheck(_ context.Context, _ authlib.AuthInfo, req authlib.BatchCheckRequest) (authlib.BatchCheckResponse, error) {
+	results := make(map[string]authlib.BatchCheckResult, len(req.Checks))
+	for _, item := range req.Checks {
+		c.readChecks++
+		results[item.CorrelationID] = authlib.BatchCheckResult{Allowed: c.readAll}
+	}
+	return authlib.BatchCheckResponse{Results: results}, nil
+}
+
+func (c *trashAccessClient) Read(context.Context, *authzextv1.ReadRequest) (*authzextv1.ReadResponse, error) {
+	return nil, nil
+}
+
+func (c *trashAccessClient) Write(context.Context, *authzextv1.WriteRequest) error { return nil }
+
+// adminCheckCount is how many set_permissions calls were made.
+func (c *trashAccessClient) adminCheckCount() int { return len(c.adminCheckFolders) }
+
+func trashDoc(name, folder, deletedBy string) *resource.BulkIndexItem {
+	return &resource.BulkIndexItem{
+		Action: resource.ActionIndex,
+		Doc: &resource.IndexableDocument{
+			RV:    1,
+			Name:  name,
+			Title: name,
+			Key: &resourcepb.ResourceKey{
+				Name:      name,
+				Namespace: "default",
+				Group:     "dashboard.grafana.app",
+				Resource:  "dashboards",
+			},
+			Folder:    folder,
+			IsDeleted: new(true),
+			DeletedBy: &deletedBy,
+		},
+	}
+}
+
+func liveDoc(name, folder string) *resource.BulkIndexItem {
+	d := trashDoc(name, folder, "")
+	d.Doc.IsDeleted = nil
+	d.Doc.DeletedBy = nil
+	return d
+}
+
+// trashIndexBuilders covers both authorization paths. Post-rank is intended to
+// become the default, so trash authz on only the in-searcher path would silently
+// revert to the read check when that happens.
+func trashIndexBuilders() []struct {
+	name  string
+	build func(t *testing.T) resource.ResourceIndex
+} {
+	return []struct {
+		name  string
+		build func(t *testing.T) resource.ResourceIndex
+	}{
+		{"in-searcher", func(t *testing.T) resource.ResourceIndex {
+			return newTestDashboardsIndex(t, threshold, 20, func(resource.ResourceIndex) (int64, error) { return 1, nil })
+		}},
+		{"post-rank", func(t *testing.T) resource.ResourceIndex {
+			return newTestDashboardsIndexPostRank(t, 20)
+		}},
+	}
+}
+
+func trashQueryFor(mutate func(*resourcepb.ResourceSearchRequest)) *resourcepb.ResourceSearchRequest {
+	q := &resourcepb.ResourceSearchRequest{
+		Options: &resourcepb.ListOptions{
+			Key: &resourcepb.ResourceKey{
+				Namespace: "default",
+				Group:     "dashboard.grafana.app",
+				Resource:  "dashboards",
+			},
+		},
+		Limit:     100,
+		IsDeleted: true,
+	}
+	if mutate != nil {
+		mutate(q)
+	}
+	return q
+}
+
+// runTrashSearch runs a search as the given user. uid is bare, so "alice" becomes the
+// "user:alice" that GetUID reports and deleted_by holds.
+func runTrashSearch(
+	t *testing.T,
+	index resource.ResourceIndex,
+	ac authlib.AccessClient,
+	uid string,
+	q *resourcepb.ResourceSearchRequest,
+) *resourcepb.ResourceSearchResponse {
+	t.Helper()
+	user := &identity.StaticRequester{Type: authlib.TypeUser, UserUID: uid, Namespace: "default"}
+	ctx := authlib.WithAuthInfo(context.Background(), user)
+	res, err := index.Search(ctx, ac, q, nil, nil)
+	require.NoError(t, err)
+	require.Nil(t, res.Error)
+	return res
+}
+
+func namesOf(res *resourcepb.ResourceSearchResponse) []string {
+	rows := res.Results.GetRows()
+	out := make([]string, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, row.Key.Name)
+	}
+	return out
+}
+
+// Bob can read the folder, so the live-search check would let him see this, but he
+// neither administers the folder nor deleted the object.
+func TestTrashAuthz_ReaderCannotSeeAnotherUsersDeletion(t *testing.T) {
+	for _, path := range trashIndexBuilders() {
+		t.Run(path.name, func(t *testing.T) {
+			index := path.build(t)
+			indexDocs(t, index, []*resource.BulkIndexItem{
+				trashDoc("alices-dash", "folder-1", trashAlice),
+			})
+
+			// Read access everywhere, admin nowhere.
+			ac := &trashAccessClient{readAll: true}
+			res := runTrashSearch(t, index, ac, "bob", trashQueryFor(nil))
+
+			assert.Empty(t, namesOf(res), "a folder reader must not see another user's deleted object")
+			assert.Equal(t, int64(0), res.TotalHits)
+		})
+	}
+}
+
+func TestTrashAuthz_FolderAdminSeesOtherUsersDeletions(t *testing.T) {
+	for _, path := range trashIndexBuilders() {
+		t.Run(path.name, func(t *testing.T) {
+			index := path.build(t)
+			indexDocs(t, index, []*resource.BulkIndexItem{
+				trashDoc("alices-dash", "folder-1", trashAlice),
+				trashDoc("elsewhere", "folder-2", trashAlice),
+			})
+
+			// Admin of folder-1 only, with no read access, so only the admin rule can
+			// grant this.
+			ac := &trashAccessClient{adminFolders: map[string]bool{"folder-1": true}}
+			res := runTrashSearch(t, index, ac, "carol", trashQueryFor(nil))
+
+			assert.Equal(t, []string{"alices-dash"}, namesOf(res))
+		})
+	}
+}
+
+func TestTrashAuthz_DeleterSeesTheirOwnDeletionWithoutBeingAdmin(t *testing.T) {
+	for _, path := range trashIndexBuilders() {
+		t.Run(path.name, func(t *testing.T) {
+			index := path.build(t)
+			indexDocs(t, index, []*resource.BulkIndexItem{
+				trashDoc("alices-dash", "folder-1", trashAlice),
+				trashDoc("bobs-dash", "folder-1", trashBob),
+			})
+
+			// Neither admin nor reader anywhere.
+			ac := &trashAccessClient{}
+			res := runTrashSearch(t, index, ac, "alice", trashQueryFor(nil))
+
+			assert.Equal(t, []string{"alices-dash"}, namesOf(res))
+
+			// The deleter half comes from the indexed field, so it costs no authz
+			// call at all. That is why deleted_by was indexed.
+			assert.Zero(t, ac.readChecks, "the read check must not be consulted for trash")
+		})
+	}
+}
+
+// A provisioned object is restored from its repository, never from trash.
+func TestTrashAuthz_ProvisionedObjectIsNeverVisible(t *testing.T) {
+	for _, path := range trashIndexBuilders() {
+		t.Run(path.name, func(t *testing.T) {
+			index := path.build(t)
+			provisioned := trashDoc("provisioned-dash", "folder-1", trashAlice)
+			provisioned.Doc.IsProvisioned = new(true)
+			indexDocs(t, index, []*resource.BulkIndexItem{provisioned})
+
+			for _, who := range []struct {
+				name string
+				uid  string
+				ac   *trashAccessClient
+			}{
+				{"deleter", "alice", &trashAccessClient{}},
+				{"folder admin", "carol", &trashAccessClient{adminFolders: map[string]bool{"folder-1": true}}},
+				{"reader", "bob", &trashAccessClient{readAll: true}},
+			} {
+				t.Run(who.name, func(t *testing.T) {
+					res := runTrashSearch(t, index, who.ac, who.uid, trashQueryFor(nil))
+					assert.Empty(t, namesOf(res))
+				})
+			}
+		})
+	}
+}
+
+// The check is a network call, so a page of 50 results across 50 folders would
+// otherwise cost 50 of them.
+func TestTrashAuthz_FolderAdminCheckIsCachedPerFolder(t *testing.T) {
+	for _, path := range trashIndexBuilders() {
+		t.Run(path.name, func(t *testing.T) {
+			index := path.build(t)
+			folders := []string{"folder-1", "folder-2"}
+			names := []string{"a", "b", "c", "d"}
+			docs := make([]*resource.BulkIndexItem, 0, len(folders)*len(names))
+			for _, folder := range folders {
+				for _, name := range names {
+					docs = append(docs, trashDoc(folder+"-"+name, folder, trashAlice))
+				}
+			}
+			indexDocs(t, index, docs)
+
+			ac := &trashAccessClient{adminFolders: map[string]bool{"folder-1": true, "folder-2": true}}
+			res := runTrashSearch(t, index, ac, "carol", trashQueryFor(nil))
+
+			require.Len(t, namesOf(res), 8)
+			assert.Equal(t, 2, ac.adminCheckCount(),
+				"one check per folder, not per item; got checks for %v", ac.adminCheckFolders)
+		})
+	}
+}
+
+// Live search must be untouched: the read check still decides.
+func TestTrashAuthz_LiveSearchIsUnchanged(t *testing.T) {
+	for _, path := range trashIndexBuilders() {
+		t.Run(path.name, func(t *testing.T) {
+			index := path.build(t)
+			indexDocs(t, index, []*resource.BulkIndexItem{
+				liveDoc("live-dash", "folder-1"),
+				trashDoc("deleted-dash", "folder-1", trashAlice),
+			})
+
+			t.Run("reader sees live results", func(t *testing.T) {
+				ac := &trashAccessClient{readAll: true}
+				q := trashQueryFor(nil)
+				q.IsDeleted = false
+
+				res := runTrashSearch(t, index, ac, "bob", q)
+
+				assert.Equal(t, []string{"live-dash"}, namesOf(res))
+				assert.Zero(t, ac.adminCheckCount(), "live search must not ask about folder admin")
+				assert.Positive(t, ac.readChecks, "live search must use the read check")
+			})
+
+			t.Run("read denied means no results", func(t *testing.T) {
+				ac := &trashAccessClient{readAll: false, adminFolders: map[string]bool{"folder-1": true}}
+				q := trashQueryFor(nil)
+				q.IsDeleted = false
+
+				res := runTrashSearch(t, index, ac, "carol", q)
+
+				assert.Empty(t, namesOf(res), "being a folder admin must not grant live read")
+			})
+		})
+	}
+}
+
+// Falling back to the read check would be more permissive, so the request is refused.
+func TestTrashAuthz_RefusesWhenThereIsNoUser(t *testing.T) {
+	index := newTestDashboardsIndex(t, threshold, 20, func(resource.ResourceIndex) (int64, error) { return 1, nil })
+	indexDocs(t, index, []*resource.BulkIndexItem{trashDoc("alices-dash", "folder-1", trashAlice)})
+
+	res, err := index.Search(context.Background(), &trashAccessClient{readAll: true}, trashQueryFor(nil), nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, res.Error)
+	assert.Equal(t, int32(401), res.Error.Code)
+}
+
+// The post-rank path narrows the bleve field list for count-only requests and for the
+// facet scan. Dropping deleted_by there raises no error: the deleter simply stops
+// seeing their own objects.
+func TestTrashAuthz_PostRankNarrowedFieldListsKeepDeletedBy(t *testing.T) {
+	withTags := func(item *resource.BulkIndexItem, tags ...string) *resource.BulkIndexItem {
+		item.Doc.Tags = tags
+		return item
+	}
+	build := func(t *testing.T) resource.ResourceIndex {
+		index := newTestDashboardsIndexPostRank(t, 20)
+		indexDocs(t, index, []*resource.BulkIndexItem{
+			withTags(trashDoc("alices-1", "folder-1", trashAlice), "shared"),
+			withTags(trashDoc("alices-2", "folder-1", trashAlice), "shared"),
+			withTags(trashDoc("bobs-1", "folder-1", trashBob), "shared"),
+		})
+		return index
+	}
+
+	t.Run("count-only request counts the deleter's own objects", func(t *testing.T) {
+		index := build(t)
+		q := trashQueryFor(func(q *resourcepb.ResourceSearchRequest) { q.Limit = 0 })
+
+		res := runTrashSearch(t, index, &trashAccessClient{}, "alice", q)
+
+		assert.Equal(t, int64(2), res.TotalHits)
+		assert.Empty(t, namesOf(res), "a count-only request returns no rows")
+	})
+
+	// A TrashQuery cannot request facets, so this is unreachable through /trash today.
+	// Covered because facetScanFields is shared, and a regression would surface only
+	// once trash gained facets.
+	t.Run("facet counts cover the deleter's own objects", func(t *testing.T) {
+		index := build(t)
+		q := trashQueryFor(func(q *resourcepb.ResourceSearchRequest) {
+			q.Facet = map[string]*resourcepb.ResourceSearchRequest_Facet{
+				"tags": {Field: resource.SEARCH_FIELD_TAGS, Limit: 10},
+			}
+		})
+
+		res := runTrashSearch(t, index, &trashAccessClient{}, "alice", q)
+
+		require.Contains(t, res.Facet, "tags")
+		terms := res.Facet["tags"].Terms
+		require.Len(t, terms, 1)
+		assert.Equal(t, "shared", terms[0].Term)
+		assert.Equal(t, int64(2), terms[0].Count, "only Alice's two deletions are hers to see")
+	})
+}
+
+// The rule has to apply on every window, not just the first.
+func TestTrashAuthz_AppliesOnEveryPage(t *testing.T) {
+	for _, path := range trashIndexBuilders() {
+		t.Run(path.name, func(t *testing.T) {
+			index := path.build(t)
+			const pairs = 10
+			docs := make([]*resource.BulkIndexItem, 0, pairs*2)
+			for i := range pairs {
+				suffix := string(rune('a' + i))
+				docs = append(docs, trashDoc(suffix+"-alice", "folder-1", trashAlice))
+				docs = append(docs, trashDoc(suffix+"-bob", "folder-1", trashBob))
+			}
+			indexDocs(t, index, docs)
+
+			var seen []string
+			var after []string
+			for page := 0; page < 20; page++ {
+				q := trashQueryFor(func(q *resourcepb.ResourceSearchRequest) {
+					q.Limit = 3
+					q.SearchAfter = after
+				})
+				res := runTrashSearch(t, index, &trashAccessClient{}, "alice", q)
+				rows := res.Results.GetRows()
+				if len(rows) == 0 {
+					break
+				}
+				seen = append(seen, namesOf(res)...)
+				after = rows[len(rows)-1].SortFields
+				require.NotEmpty(t, after)
+				if len(rows) < 3 {
+					break
+				}
+			}
+
+			require.Len(t, seen, 10, "every page must be filtered, and Alice owns 10 of the 20")
+			for _, name := range seen {
+				assert.Contains(t, name, "-alice", "Bob's deletions must never appear")
+			}
+		})
+	}
+}

--- a/pkg/storage/unified/testing/server.go
+++ b/pkg/storage/unified/testing/server.go
@@ -25,12 +25,14 @@ func RunStorageServerTest(t *testing.T, newBackend NewBackendFunc) {
 
 // func runTestIntegrationBackendHappyPath(t *testing.T, backend resource.StorageBackend, nsPrefix string) {
 func runTestResourcePermissionScenarios(t *testing.T, backend resource.StorageBackend, nsPrefix string) {
-	// Test user
+	// Test user. Carries the namespace its resources live in, because an identity
+	// with none matches nothing and is refused in production.
 	testUser := &identity.StaticRequester{
 		Type:           types.TypeUser,
 		Login:          "testuser",
 		UserID:         123,
 		UserUID:        "u123",
+		Namespace:      nsPrefix + "-ns1",
 		OrgRole:        identity.RoleAdmin,
 		IsGrafanaAdmin: true,
 	}
@@ -274,12 +276,18 @@ func runTestResourcePermissionScenarios(t *testing.T, backend resource.StorageBa
 
 // runTestListTrashAccessControl tests the access control logic for ListTrash
 func runTestListTrashAccessControl(t *testing.T, backend resource.StorageBackend, nsPrefix string) {
+	// The namespace the resources below live in. Both users carry it: an identity
+	// with no namespace matches nothing, not even another empty one, so it would be
+	// refused everywhere in production.
+	namespace := nsPrefix + "-trash-test"
+
 	// Create two different users
 	testUserA := &identity.StaticRequester{
 		Type:           types.TypeUser,
 		Login:          "testuserA",
 		UserID:         123,
 		UserUID:        "u123",
+		Namespace:      namespace,
 		OrgRole:        identity.RoleAdmin,
 		IsGrafanaAdmin: true, // admin user
 	}
@@ -289,6 +297,7 @@ func runTestListTrashAccessControl(t *testing.T, backend resource.StorageBackend
 		Login:          "testuserB",
 		UserID:         456,
 		UserUID:        "u456",
+		Namespace:      namespace,
 		OrgRole:        identity.RoleEditor,
 		IsGrafanaAdmin: false, // non-admin user
 	}
@@ -340,7 +349,7 @@ func runTestListTrashAccessControl(t *testing.T, backend resource.StorageBackend
 	key := &resourcepb.ResourceKey{
 		Group:     "playlist.grafana.app",
 		Resource:  "playlists",
-		Namespace: nsPrefix + "-trash-test",
+		Namespace: namespace,
 		Name:      "trash-test-playlist",
 	}
 
@@ -395,7 +404,7 @@ func runTestListTrashAccessControl(t *testing.T, backend resource.StorageBackend
 	keyB := &resourcepb.ResourceKey{
 		Group:     "playlist.grafana.app",
 		Resource:  "playlists",
-		Namespace: nsPrefix + "-trash-test",
+		Namespace: namespace,
 		Name:      "trash-test-playlist-b",
 	}
 
@@ -498,6 +507,11 @@ type mockAccessClient struct {
 }
 
 func (m *mockAccessClient) Check(ctx context.Context, user types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error) {
+	// The real client refuses a caller from another namespace before checking
+	// anything, so a fixture whose user has none would pass here and fail there.
+	if !types.NamespaceMatches(user.GetNamespace(), req.Namespace) {
+		return types.CheckResponse{}, types.ErrNamespaceMismatch
+	}
 	if m.checkFn != nil {
 		m.checkFn(req, folder)
 	}


### PR DESCRIPTION
Trash authorizes differently from live search: the caller sees a deleted object only if they administer its folder or deleted it themselves. The search path applied the ordinary read check regardless, which would have disclosed other people's deleted objects to anyone with read access to the folder.

The rule already existed in `listFromTrash`. It moves into `TrashAuthorizer`, which `listFromTrash` now delegates to, so the list and search paths cannot disagree about who may see what.

On the search path it replaces the read check at all three places per-item authorization happens, including the post-rank path. That one is included because it is intended to become the default, and covering only the other path would silently restore the read check when that happens.

No user-visible change: the search path this affects is not reachable yet, and the list path keeps the rule it already had.

One thing the rule will not take on trust: a UID only identifies someone within their own namespace, so a deleter match from another namespace is refused. The access client already applies this to the folder-admin check, but the deleter comparison never reached it. That also required giving the users in the shared storage-server test fixture a namespace, and making its mock access client enforce namespace matching the way the real one does — without that, fixtures pass where production would deny.

**Needs review — non-folder resources.** Kinds outside the folder tree have no folder, so the admin check is evaluated namespace-wide rather than per-folder. Trash for those kinds is "your own deletions, plus anyone holding `set_permissions` across the namespace" — inherited from `listFromTrash` rather than chosen. This PR doesn't change that, but it isn't hypothetical either: the list path already serves those kinds. The new `/trash` endpoint stays limited to dashboards and folders until it's settled.
