### PR TITLE
Plugins: Report react-router v5 usage from the shared dependency

### DIFF
--- a/public/app/features/plugins/loader/sharedDependencies.ts
+++ b/public/app/features/plugins/loader/sharedDependencies.ts
@@ -25,6 +25,8 @@ import * as flatten from 'app/core/utils/flatten';
 import kbn from 'app/core/utils/kbn';
 import * as ticks from 'app/core/utils/ticks';
 
+import { withV5UsageTelemetry } from './v5RouterTelemetry';
+
 // Help the 6.4 to 6.5 migration
 // The base classes were moved from @grafana/ui to @grafana/data
 // This exposes the same classes on both import paths
@@ -123,7 +125,12 @@ export const sharedDependenciesMap = {
   // just exposing "react-router-dom-v5-compat".
   //
   // (This means that we are exposing two versions of the same package).
-  'react-router-dom': () => import('react-router-dom'),
+  //
+  // The v5 exports that v6 removes are wrapped, so that a plugin which calls one
+  // is reported before the upgrade removes it. Calls to a hook carry the plugin
+  // id. Calls to a component do not, because React renders a component from its
+  // own work loop, after the frames of the plugin have returned.
+  'react-router-dom': () => import('react-router-dom').then(withV5UsageTelemetry),
   'react-router': () => import('react-router-dom-v5-compat'),
   redux: () => import('redux'),
   rxjs: () => import('rxjs'),

--- a/public/app/features/plugins/loader/sharedDependencies.ts
+++ b/public/app/features/plugins/loader/sharedDependencies.ts
@@ -126,10 +126,9 @@ export const sharedDependenciesMap = {
   //
   // (This means that we are exposing two versions of the same package).
   //
-  // The v5 exports that v6 removes are wrapped, so that a plugin which calls one
-  // is reported before the upgrade removes it. Calls to a hook carry the plugin
-  // id. Calls to a component do not, because React renders a component from its
-  // own work loop, after the frames of the plugin have returned.
+  // The v5 exports that v6 removes are wrapped, so that a plugin which calls one is reported before we attempt to upgrade
+  // this dependency. Calls to a hook will include the plugin id. Calls to a component do not, because React renders a component
+  // from its own work loop, after the frames of the plugin have returned.
   'react-router-dom': () => import('react-router-dom').then((module) => withV5UsageTelemetry(module)),
   'react-router': () => import('react-router-dom-v5-compat'),
   redux: () => import('redux'),

--- a/public/app/features/plugins/loader/sharedDependencies.ts
+++ b/public/app/features/plugins/loader/sharedDependencies.ts
@@ -130,7 +130,7 @@ export const sharedDependenciesMap = {
   // is reported before the upgrade removes it. Calls to a hook carry the plugin
   // id. Calls to a component do not, because React renders a component from its
   // own work loop, after the frames of the plugin have returned.
-  'react-router-dom': () => import('react-router-dom').then(withV5UsageTelemetry),
+  'react-router-dom': () => import('react-router-dom').then((module) => withV5UsageTelemetry(module)),
   'react-router': () => import('react-router-dom-v5-compat'),
   redux: () => import('redux'),
   rxjs: () => import('rxjs'),

--- a/public/app/features/plugins/loader/v5RouterTelemetry.test.ts
+++ b/public/app/features/plugins/loader/v5RouterTelemetry.test.ts
@@ -1,4 +1,7 @@
-import { getPluginIdFromStack } from './v5RouterTelemetry';
+import { type MonitoringLogger } from '@grafana/runtime';
+import { mockLogger } from '@grafana/test-utils/unstable';
+
+import { getPluginIdFromStack, reportV5Usage } from './v5RouterTelemetry';
 
 // Chrome-shaped frames. The parser is deliberately format-agnostic, so one
 // browser's shape is enough to cover the common case.
@@ -61,5 +64,60 @@ describe('getPluginIdFromStack', () => {
 
   it('returns undefined when there is no stack', () => {
     expect(getPluginIdFromStack(undefined)).toBeUndefined();
+  });
+});
+
+function pluginStack(pluginId: string) {
+  return chromeStack(`MyPage (http://localhost:3000/public/plugins/${pluginId}/module.js:2:3)`);
+}
+
+// The dedupe set lives at module scope and has no reset hook, because production
+// code should not carry one. Each test therefore uses its own plugin id.
+describe('reportV5Usage', () => {
+  let logger: MonitoringLogger;
+
+  beforeEach(() => {
+    logger = mockLogger('features.plugins');
+  });
+
+  it('reports the plugin id and the export name', () => {
+    reportV5Usage('useHistory', pluginStack('reports-once-app'));
+
+    expect(logger.logWarning).toHaveBeenCalledTimes(1);
+    const [, context] = jest.mocked(logger.logWarning).mock.calls[0];
+    expect(context).toMatchObject({ pluginId: 'reports-once-app', exportName: 'useHistory' });
+  });
+
+  it('reports the same plugin and export only once', () => {
+    reportV5Usage('useHistory', pluginStack('deduped-app'));
+    reportV5Usage('useHistory', pluginStack('deduped-app'));
+    reportV5Usage('useHistory', pluginStack('deduped-app'));
+
+    expect(logger.logWarning).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports the same export again for a different plugin', () => {
+    reportV5Usage('useHistory', pluginStack('first-app'));
+    reportV5Usage('useHistory', pluginStack('second-app'));
+
+    expect(logger.logWarning).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports a different export again for the same plugin', () => {
+    reportV5Usage('useHistory', pluginStack('two-exports-app'));
+    reportV5Usage('Redirect', pluginStack('two-exports-app'));
+
+    expect(logger.logWarning).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports the stack when it cannot find a plugin', () => {
+    const stack = chromeStack('RoutesWrapper (http://localhost:3000/public/build/app.js:1:1)');
+
+    reportV5Usage('withRouter', stack);
+
+    expect(logger.logWarning).toHaveBeenCalledTimes(1);
+    const [, context] = jest.mocked(logger.logWarning).mock.calls[0];
+    expect(context).toMatchObject({ exportName: 'withRouter', stack });
+    expect(context).not.toHaveProperty('pluginId');
   });
 });

--- a/public/app/features/plugins/loader/v5RouterTelemetry.test.ts
+++ b/public/app/features/plugins/loader/v5RouterTelemetry.test.ts
@@ -1,0 +1,65 @@
+import { getPluginIdFromStack } from './v5RouterTelemetry';
+
+// Chrome-shaped frames. The parser is deliberately format-agnostic, so one
+// browser's shape is enough to cover the common case.
+function chromeStack(...frames: string[]) {
+  return ['Error', ...frames.map((frame) => `    at ${frame}`)].join('\n');
+}
+
+describe('getPluginIdFromStack', () => {
+  it('reads the plugin id from a locally served bundle', () => {
+    const stack = chromeStack(
+      'reportV5Usage (http://localhost:3000/public/build/runtime.js:1:1)',
+      'MyPage (http://localhost:3000/public/plugins/grafana-assistant-app/module.js:2:3)'
+    );
+
+    expect(getPluginIdFromStack(stack)).toBe('grafana-assistant-app');
+  });
+
+  it('reads the plugin id from a CDN hosted bundle', () => {
+    const stack = chromeStack(
+      'reportV5Usage (http://localhost:3000/public/build/runtime.js:1:1)',
+      'MyPage (https://cdn.example.com/my-plugin/0.3.3/public/plugins/my-plugin/module.js:2:3)'
+    );
+
+    expect(getPluginIdFromStack(stack)).toBe('my-plugin');
+  });
+
+  it('reads the plugin id when Grafana is served from a sub path', () => {
+    const stack = chromeStack('MyPage (http://localhost:3000/grafana/public/plugins/my-plugin/module.js:2:3)');
+
+    expect(getPluginIdFromStack(stack)).toBe('my-plugin');
+  });
+
+  it('reads the plugin id from a lazy chunk inside the plugin', () => {
+    const stack = chromeStack('MyPage (http://localhost:3000/public/plugins/my-plugin/chunks/482.js:2:3)');
+
+    expect(getPluginIdFromStack(stack)).toBe('my-plugin');
+  });
+
+  it('takes the first plugin frame, which is the nearest caller', () => {
+    const stack = chromeStack(
+      'reportV5Usage (http://localhost:3000/public/build/runtime.js:1:1)',
+      'MyPage (http://localhost:3000/public/plugins/inner-plugin/module.js:2:3)',
+      'Host (http://localhost:3000/public/plugins/outer-plugin/module.js:4:5)'
+    );
+
+    expect(getPluginIdFromStack(stack)).toBe('inner-plugin');
+  });
+
+  it('reads Firefox shaped frames', () => {
+    const stack = ['MyPage@http://localhost:3000/public/plugins/my-plugin/module.js:2:3'].join('\n');
+
+    expect(getPluginIdFromStack(stack)).toBe('my-plugin');
+  });
+
+  it('returns undefined when no frame belongs to a plugin', () => {
+    const stack = chromeStack('RoutesWrapper (http://localhost:3000/public/build/app.js:1:1)');
+
+    expect(getPluginIdFromStack(stack)).toBeUndefined();
+  });
+
+  it('returns undefined when there is no stack', () => {
+    expect(getPluginIdFromStack(undefined)).toBeUndefined();
+  });
+});

--- a/public/app/features/plugins/loader/v5RouterTelemetry.test.ts
+++ b/public/app/features/plugins/loader/v5RouterTelemetry.test.ts
@@ -1,7 +1,7 @@
 import { type MonitoringLogger } from '@grafana/runtime';
 import { mockLogger } from '@grafana/test-utils/unstable';
 
-import { getPluginIdFromStack, reportV5Usage } from './v5RouterTelemetry';
+import { getPluginIdFromStack, reportV5Usage, withV5UsageTelemetry } from './v5RouterTelemetry';
 
 // Chrome-shaped frames. The parser is deliberately format-agnostic, so one
 // browser's shape is enough to cover the common case.
@@ -119,5 +119,60 @@ describe('reportV5Usage', () => {
     const [, context] = jest.mocked(logger.logWarning).mock.calls[0];
     expect(context).toMatchObject({ exportName: 'withRouter', stack });
     expect(context).not.toHaveProperty('pluginId');
+  });
+});
+
+function fakeRouterModule() {
+  return {
+    useHistory: jest.fn((..._args: unknown[]) => 'history-value'),
+    useRouteMatch: jest.fn((..._args: unknown[]) => 'match-value'),
+    withRouter: jest.fn((..._args: unknown[]) => 'wrapped-component'),
+    // v6 keeps this one, so it must pass through untouched.
+    useLocation: jest.fn((..._args: unknown[]) => 'location-value'),
+  };
+}
+
+describe('withV5UsageTelemetry function exports', () => {
+  let logger: MonitoringLogger;
+
+  beforeEach(() => {
+    logger = mockLogger('features.plugins');
+  });
+
+  it.each(['useHistory', 'useRouteMatch', 'withRouter'] as const)('returns what %s returns', (exportName) => {
+    const module = fakeRouterModule();
+    const wrapped = withV5UsageTelemetry(module);
+
+    expect(wrapped[exportName]()).toBe(module[exportName]());
+  });
+
+  it.each(['useHistory', 'useRouteMatch', 'withRouter'] as const)('passes arguments to %s', (exportName) => {
+    const module = fakeRouterModule();
+    const wrapped = withV5UsageTelemetry(module);
+
+    wrapped[exportName]('first', 'second');
+
+    expect(module[exportName]).toHaveBeenCalledWith('first', 'second');
+  });
+
+  it('reports repeated calls from one place only once', () => {
+    const wrapped = withV5UsageTelemetry(fakeRouterModule());
+
+    for (let i = 0; i < 3; i++) {
+      wrapped.useHistory();
+    }
+
+    expect(logger.logWarning).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves exports that v6 keeps untouched', () => {
+    const module = fakeRouterModule();
+    const wrapped = withV5UsageTelemetry(module);
+
+    expect(wrapped.useLocation).toBe(module.useLocation);
+
+    wrapped.useLocation();
+
+    expect(logger.logWarning).not.toHaveBeenCalled();
   });
 });

--- a/public/app/features/plugins/loader/v5RouterTelemetry.test.tsx
+++ b/public/app/features/plugins/loader/v5RouterTelemetry.test.tsx
@@ -1,7 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import * as reactRouterDom from 'react-router-dom';
+import { MemoryRouter, Route, Switch as RealSwitch } from 'react-router-dom';
+
 import { type MonitoringLogger } from '@grafana/runtime';
 import { mockLogger } from '@grafana/test-utils/unstable';
 
 import { getPluginIdFromStack, reportV5Usage, withV5UsageTelemetry } from './v5RouterTelemetry';
+
+// The component tests wrap the real module, because the point of them is the
+// interaction between a wrapped component and react-router's own matching.
+const routerModule = { ...reactRouterDom };
 
 // Chrome-shaped frames. The parser is deliberately format-agnostic, so one
 // browser's shape is enough to cover the common case.
@@ -139,6 +147,19 @@ describe('withV5UsageTelemetry function exports', () => {
     logger = mockLogger('features.plugins');
   });
 
+  // Must come first in this block. An unattributed report is keyed on the export
+  // name alone, so once another test in this file has called `useHistory` through
+  // a wrapper, later calls are correctly suppressed for the rest of the run.
+  it('reports the call, and repeats from one place only once', () => {
+    const wrapped = withV5UsageTelemetry(fakeRouterModule());
+
+    for (let i = 0; i < 3; i++) {
+      wrapped.useHistory();
+    }
+
+    expect(logger.logWarning).toHaveBeenCalledTimes(1);
+  });
+
   it.each(['useHistory', 'useRouteMatch', 'withRouter'] as const)('returns what %s returns', (exportName) => {
     const module = fakeRouterModule();
     const wrapped = withV5UsageTelemetry(module);
@@ -155,16 +176,6 @@ describe('withV5UsageTelemetry function exports', () => {
     expect(module[exportName]).toHaveBeenCalledWith('first', 'second');
   });
 
-  it('reports repeated calls from one place only once', () => {
-    const wrapped = withV5UsageTelemetry(fakeRouterModule());
-
-    for (let i = 0; i < 3; i++) {
-      wrapped.useHistory();
-    }
-
-    expect(logger.logWarning).toHaveBeenCalledTimes(1);
-  });
-
   it('leaves exports that v6 keeps untouched', () => {
     const module = fakeRouterModule();
     const wrapped = withV5UsageTelemetry(module);
@@ -174,5 +185,67 @@ describe('withV5UsageTelemetry function exports', () => {
     wrapped.useLocation();
 
     expect(logger.logWarning).not.toHaveBeenCalled();
+  });
+});
+
+describe('withV5UsageTelemetry component exports', () => {
+  let logger: MonitoringLogger;
+
+  beforeEach(() => {
+    logger = mockLogger('features.plugins');
+  });
+
+  it('renders the real Switch and reports it', () => {
+    const { Switch, Route } = withV5UsageTelemetry({ ...routerModule });
+
+    render(
+      <MemoryRouter initialEntries={['/second']}>
+        <Switch>
+          <Route path="/first">first page</Route>
+          <Route path="/second">second page</Route>
+        </Switch>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('second page')).toBeInTheDocument();
+    expect(logger.logWarning).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the real Prompt and reports it', () => {
+    const { Prompt } = withV5UsageTelemetry({ ...routerModule });
+
+    render(
+      <MemoryRouter>
+        <Prompt when={false} message="unsaved" />
+      </MemoryRouter>
+    );
+
+    expect(logger.logWarning).toHaveBeenCalledTimes(1);
+  });
+
+  // The wrapper changes the element type that `Switch` sees. v5 `Switch` matches
+  // on `child.props.path || child.props.from` rather than on the child type, so a
+  // forwarding wrapper stays transparent to it. This test is what proves that.
+  it('keeps a wrapped Redirect matchable by a real Switch', () => {
+    const { Redirect } = withV5UsageTelemetry({ ...routerModule });
+
+    render(
+      <MemoryRouter initialEntries={['/old']}>
+        <RealSwitch>
+          <Redirect from="/old" to="/new" />
+          <Route path="/new">new page</Route>
+        </RealSwitch>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('new page')).toBeInTheDocument();
+    expect(logger.logWarning).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves components that v6 keeps untouched', () => {
+    const wrapped = withV5UsageTelemetry({ ...routerModule });
+
+    expect(wrapped.Route).toBe(routerModule.Route);
+    expect(wrapped.Link).toBe(routerModule.Link);
   });
 });

--- a/public/app/features/plugins/loader/v5RouterTelemetry.test.tsx
+++ b/public/app/features/plugins/loader/v5RouterTelemetry.test.tsx
@@ -251,21 +251,18 @@ describe('withV5UsageTelemetry component exports', () => {
 });
 
 describe('withV5UsageTelemetry module shape', () => {
-  it('carries over the interop flags that a spread would drop', () => {
+  it('carries over __esModule, which a spread would drop', () => {
     const module = { useLocation: () => 'location' };
     Object.defineProperty(module, '__esModule', { value: true, enumerable: false });
-    Object.defineProperty(module, Symbol.toStringTag, { value: 'Module', enumerable: false });
 
     const wrapped = withV5UsageTelemetry(module);
 
     expect(Object.getOwnPropertyDescriptor(wrapped, '__esModule')).toMatchObject({ value: true });
-    expect(Object.getOwnPropertyDescriptor(wrapped, Symbol.toStringTag)).toMatchObject({ value: 'Module' });
   });
 
-  it('leaves the flags off when the module has none', () => {
+  it('leaves __esModule off when the module has none', () => {
     const wrapped = withV5UsageTelemetry({ useLocation: () => 'location' });
 
     expect('__esModule' in wrapped).toBe(false);
-    expect(Symbol.toStringTag in wrapped).toBe(false);
   });
 });

--- a/public/app/features/plugins/loader/v5RouterTelemetry.test.tsx
+++ b/public/app/features/plugins/loader/v5RouterTelemetry.test.tsx
@@ -249,3 +249,23 @@ describe('withV5UsageTelemetry component exports', () => {
     expect(wrapped.Link).toBe(routerModule.Link);
   });
 });
+
+describe('withV5UsageTelemetry module shape', () => {
+  it('carries over the interop flags that a spread would drop', () => {
+    const module = { useLocation: () => 'location' };
+    Object.defineProperty(module, '__esModule', { value: true, enumerable: false });
+    Object.defineProperty(module, Symbol.toStringTag, { value: 'Module', enumerable: false });
+
+    const wrapped = withV5UsageTelemetry(module);
+
+    expect(Object.getOwnPropertyDescriptor(wrapped, '__esModule')).toMatchObject({ value: true });
+    expect(Object.getOwnPropertyDescriptor(wrapped, Symbol.toStringTag)).toMatchObject({ value: 'Module' });
+  });
+
+  it('leaves the flags off when the module has none', () => {
+    const wrapped = withV5UsageTelemetry({ useLocation: () => 'location' });
+
+    expect('__esModule' in wrapped).toBe(false);
+    expect(Symbol.toStringTag in wrapped).toBe(false);
+  });
+});

--- a/public/app/features/plugins/loader/v5RouterTelemetry.test.tsx
+++ b/public/app/features/plugins/loader/v5RouterTelemetry.test.tsx
@@ -147,7 +147,7 @@ describe('withV5UsageTelemetry function exports', () => {
     logger = mockLogger('features.plugins');
   });
 
-  // Must come first in this block. An unattributed report is keyed on the export
+  // Must come first in this block. A report with no plugin id is keyed on the export
   // name alone, so once another test in this file has called `useHistory` through
   // a wrapper, later calls are correctly suppressed for the rest of the run.
   it('reports the call, and repeats from one place only once', () => {

--- a/public/app/features/plugins/loader/v5RouterTelemetry.ts
+++ b/public/app/features/plugins/loader/v5RouterTelemetry.ts
@@ -1,3 +1,5 @@
+import { createElement, type ComponentType } from 'react';
+
 import { getLogger } from '@grafana/runtime/unstable';
 
 // Plugin bundles are served from `public/plugins/<id>/`, both locally and from the
@@ -12,6 +14,7 @@ const reported = new Set<string>();
 // Exports that react-router v6 removes. Plugins that call these break at the
 // upgrade, so these are the ones worth counting.
 const V5_ONLY_FUNCTIONS = ['useHistory', 'useRouteMatch', 'withRouter'] as const;
+const V5_ONLY_COMPONENTS = ['Switch', 'Redirect', 'Prompt'] as const;
 
 /**
  * Reads the plugin id out of a captured stack.
@@ -44,7 +47,10 @@ export function getPluginIdFromStack(stack: string | undefined): string | undefi
  */
 export function reportV5Usage(exportName: string, stack: string | undefined = new Error().stack): void {
   const pluginId = getPluginIdFromStack(stack);
-  const key = `${pluginId ?? stack}:${exportName}`;
+  // Without a plugin the key holds the export name alone. Keying on the stack
+  // would let one export report many times, because React builds a different
+  // stack on each render.
+  const key = pluginId ? `${pluginId}:${exportName}` : `unattributed:${exportName}`;
 
   if (reported.has(key)) {
     return;
@@ -71,6 +77,22 @@ function reportingFunction(exportName: string, original: UnknownFunction): Unkno
   };
 }
 
+type UnknownProps = Record<string, unknown>;
+
+function isComponent(value: unknown): value is ComponentType<UnknownProps> {
+  return typeof value === 'function';
+}
+
+// The report happens during render rather than in an effect, so that a component
+// which throws still reports. The dedupe keeps repeat renders quiet.
+function reportingComponent(exportName: string, Original: ComponentType<UnknownProps>): UnknownFunction {
+  return function ReportingWrapper(props: UnknownProps) {
+    reportV5Usage(exportName);
+
+    return createElement(Original, props);
+  };
+}
+
 /**
  * Returns the react-router-dom module with its v5-only exports wrapped, so that
  * a plugin calling one of them is reported.
@@ -88,6 +110,14 @@ export function withV5UsageTelemetry<T extends Record<string, unknown>>(module: 
 
     if (isFunction(original)) {
       wrappers[exportName] = reportingFunction(exportName, original);
+    }
+  }
+
+  for (const exportName of V5_ONLY_COMPONENTS) {
+    const original = module[exportName];
+
+    if (isComponent(original)) {
+      wrappers[exportName] = reportingComponent(exportName, original);
     }
   }
 

--- a/public/app/features/plugins/loader/v5RouterTelemetry.ts
+++ b/public/app/features/plugins/loader/v5RouterTelemetry.ts
@@ -2,18 +2,20 @@ import { createElement, type ComponentType } from 'react';
 
 import { getLogger } from '@grafana/runtime/unstable';
 
-// Plugin bundles are served from `public/plugins/<id>/` regardless of host (CDN, filesystem).
+import { isReactComponent } from '../extensions/validators';
+
+// Plugin bundles are served with `public/plugins/<id>/` regardless of host (CDN, filesystem).
 const PLUGIN_BUNDLE_PATH = /\/public\/plugins\/([^/]+)\//;
-
 const reported = new Set<string>();
-
 // React-router v5 APIs that are removed in v6.
 const V5_ONLY_FUNCTIONS = ['useHistory', 'useRouteMatch', 'withRouter'] as const;
 const V5_ONLY_COMPONENTS = ['Switch', 'Redirect', 'Prompt'] as const;
 
+type UnknownFunction = (...args: never[]) => unknown;
+type UnknownProps = Record<string, unknown>;
+
 /**
- * Returns the react-router-dom module with the "v6 removed" exports wrapped so
- * we can report when a plugin uses them.
+ * Returns the react-router-dom module with the v5 APIs wrapped in functions that report usage to Faro.
  */
 export function withV5UsageTelemetry<T extends Record<string, unknown>>(module: T): T {
   const wrappers: Record<string, UnknownFunction> = {};
@@ -29,15 +31,15 @@ export function withV5UsageTelemetry<T extends Record<string, unknown>>(module: 
   for (const exportName of V5_ONLY_COMPONENTS) {
     const original = module[exportName];
 
-    if (isComponent(original)) {
+    if (isReactComponent(original)) {
       wrappers[exportName] = reportingComponent(exportName, original);
     }
   }
 
   const wrapped = { ...module, ...wrappers };
 
-  // Webpack defines `__esModule` as non-enumerable, causing the spread to drop it.
-  // SystemJS relies on it to determine whether to use the default export, so we need to preserve it.
+  // Webpack defines `__esModule` as non-enumerable, which makes the spread drop it,
+  // but SystemJS relies on it to determine whether to use the default export.
   const esModule = Object.getOwnPropertyDescriptor(module, '__esModule');
 
   if (esModule) {
@@ -47,9 +49,6 @@ export function withV5UsageTelemetry<T extends Record<string, unknown>>(module: 
   return wrapped;
 }
 
-/**
- * Reads the plugin id from a captured stack.
- */
 export function getPluginIdFromStack(stack: string | undefined): string | undefined {
   if (!stack) {
     return undefined;
@@ -59,21 +58,11 @@ export function getPluginIdFromStack(stack: string | undefined): string | undefi
 }
 
 /**
- * Reports that a plugin used an export that react-router v6 removes.
- *
- * Faro does not collect a stack trace for a warning, so the caller cannot be
- * identified after the fact. This captures one here instead, while the plugin
- * that made the call is still on the stack.
- *
  * Reports once per plugin and export. When the plugin cannot be identified the
- * event still goes out, with the stack attached, because an unattributed signal
- * is more useful than none.
+ * event still reports but without the plugin id.
  */
-export function reportV5Usage(exportName: string, stack: string | undefined = new Error().stack): void {
+export function reportV5Usage(exportName: string, stack?: string): void {
   const pluginId = getPluginIdFromStack(stack);
-  // Without a plugin the key holds the export name alone. Keying on the stack
-  // would let one export report many times, because React builds a different
-  // stack on each render.
   const key = pluginId ? `${pluginId}:${exportName}` : `unattributed:${exportName}`;
 
   if (reported.has(key)) {
@@ -87,31 +76,19 @@ export function reportV5Usage(exportName: string, stack: string | undefined = ne
   );
 }
 
-type UnknownFunction = (...args: never[]) => unknown;
-
 function isFunction(value: unknown): value is UnknownFunction {
   return typeof value === 'function';
 }
 
 function reportingFunction(exportName: string, original: UnknownFunction): UnknownFunction {
   return function reportingWrapper(...args) {
-    reportV5Usage(exportName);
+    reportV5Usage(exportName, new Error().stack);
 
     return original(...args);
   };
 }
 
-type UnknownProps = Record<string, unknown>;
-
-function isComponent(value: unknown): value is ComponentType<UnknownProps> {
-  return typeof value === 'function';
-}
-
-// The report happens during render rather than in an effect, so that a component
-// which throws still reports. The dedupe keeps repeat renders quiet.
-//
-// React calls this from its own work loop, after the plugin's call has returned,
-// so the captured stack holds no plugin id. Hooks keep theirs. See reportV5Usage.
+// Components are called by React, so the plugin that rendered it is not on the stack.
 function reportingComponent(exportName: string, Original: ComponentType<UnknownProps>): UnknownFunction {
   return function ReportingWrapper(props: UnknownProps) {
     reportV5Usage(exportName);

--- a/public/app/features/plugins/loader/v5RouterTelemetry.ts
+++ b/public/app/features/plugins/loader/v5RouterTelemetry.ts
@@ -1,7 +1,13 @@
+import { getLogger } from '@grafana/runtime/unstable';
+
 // Plugin bundles are served from `public/plugins/<id>/`, both locally and from the
 // CDN. transformPluginSourceForCDN keeps that segment in CDN URLs, so one marker
 // covers both. See public/app/features/plugins/cdn/utils.ts.
 const PLUGIN_BUNDLE_PATH = /\/public\/plugins\/([^/]+)\//;
+
+// One entry per plugin and export. A single latched flag would hide a second
+// plugin that reaches the same export.
+const reported = new Set<string>();
 
 /**
  * Reads the plugin id out of a captured stack.
@@ -19,4 +25,30 @@ export function getPluginIdFromStack(stack: string | undefined): string | undefi
   }
 
   return stack.match(PLUGIN_BUNDLE_PATH)?.[1];
+}
+
+/**
+ * Reports that a plugin used an export that react-router v6 removes.
+ *
+ * Faro does not collect a stack for a warning, so the caller cannot be
+ * identified after the fact. The stack is captured here instead, in the frame
+ * of the plugin that made the call.
+ *
+ * Reports once per plugin and export. When the plugin cannot be identified the
+ * event still goes out, with the stack attached, because an unattributed signal
+ * is more useful than none.
+ */
+export function reportV5Usage(exportName: string, stack: string | undefined = new Error().stack): void {
+  const pluginId = getPluginIdFromStack(stack);
+  const key = `${pluginId ?? stack}:${exportName}`;
+
+  if (reported.has(key)) {
+    return;
+  }
+  reported.add(key);
+
+  getLogger('features.plugins').logWarning(
+    'Plugin used a react-router-dom export that v6 removes',
+    pluginId ? { pluginId, exportName } : { exportName, stack: stack ?? 'unavailable' }
+  );
 }

--- a/public/app/features/plugins/loader/v5RouterTelemetry.ts
+++ b/public/app/features/plugins/loader/v5RouterTelemetry.ts
@@ -9,6 +9,10 @@ const PLUGIN_BUNDLE_PATH = /\/public\/plugins\/([^/]+)\//;
 // plugin that reaches the same export.
 const reported = new Set<string>();
 
+// Exports that react-router v6 removes. Plugins that call these break at the
+// upgrade, so these are the ones worth counting.
+const V5_ONLY_FUNCTIONS = ['useHistory', 'useRouteMatch', 'withRouter'] as const;
+
 /**
  * Reads the plugin id out of a captured stack.
  *
@@ -51,4 +55,41 @@ export function reportV5Usage(exportName: string, stack: string | undefined = ne
     'Plugin used a react-router-dom export that v6 removes',
     pluginId ? { pluginId, exportName } : { exportName, stack: stack ?? 'unavailable' }
   );
+}
+
+type UnknownFunction = (...args: never[]) => unknown;
+
+function isFunction(value: unknown): value is UnknownFunction {
+  return typeof value === 'function';
+}
+
+function reportingFunction(exportName: string, original: UnknownFunction): UnknownFunction {
+  return function reportingWrapper(...args) {
+    reportV5Usage(exportName);
+
+    return original(...args);
+  };
+}
+
+/**
+ * Returns the react-router-dom module with its v5-only exports wrapped, so that
+ * a plugin calling one of them is reported.
+ *
+ * The wrappers replace the exports rather than watching reads of them. SystemJS
+ * copies the values out of this object once, when it registers the shared
+ * dependency, so a getter or a Proxy would fire at load and never again. A
+ * wrapper survives, because the value that SystemJS copies is the wrapper.
+ */
+export function withV5UsageTelemetry<T extends Record<string, unknown>>(module: T): T {
+  const wrappers: Record<string, UnknownFunction> = {};
+
+  for (const exportName of V5_ONLY_FUNCTIONS) {
+    const original = module[exportName];
+
+    if (isFunction(original)) {
+      wrappers[exportName] = reportingFunction(exportName, original);
+    }
+  }
+
+  return { ...module, ...wrappers };
 }

--- a/public/app/features/plugins/loader/v5RouterTelemetry.ts
+++ b/public/app/features/plugins/loader/v5RouterTelemetry.ts
@@ -121,5 +121,22 @@ export function withV5UsageTelemetry<T extends Record<string, unknown>>(module: 
     }
   }
 
-  return { ...module, ...wrappers };
+  const wrapped = { ...module, ...wrappers };
+
+  // A spread copies enumerable properties only, and webpack marks the interop
+  // flags of a module namespace as non-enumerable. Carry them over by hand.
+  // SystemJS reads `__esModule` when it registers a shared dependency, and it
+  // keeps an object whose tag is 'Module' instead of copying it.
+  copyHiddenProperty(module, wrapped, '__esModule');
+  copyHiddenProperty(module, wrapped, Symbol.toStringTag);
+
+  return wrapped;
+}
+
+function copyHiddenProperty(source: object, target: object, key: string | symbol): void {
+  const descriptor = Object.getOwnPropertyDescriptor(source, key);
+
+  if (descriptor) {
+    Object.defineProperty(target, key, descriptor);
+  }
 }

--- a/public/app/features/plugins/loader/v5RouterTelemetry.ts
+++ b/public/app/features/plugins/loader/v5RouterTelemetry.ts
@@ -36,23 +36,19 @@ export function withV5UsageTelemetry<T extends Record<string, unknown>>(module: 
 
   const wrapped = { ...module, ...wrappers };
 
-  // A spread copies enumerable properties only, and webpack marks `__esModule`
-  // as non-enumerable. SystemJS reads it when it registers a shared dependency
-  // and puts it on the namespace it hands to plugins, so carry it over by hand.
-  copyHiddenProperty(module, wrapped, '__esModule');
+  // Webpack defines `__esModule` as non-enumerable, causing the spread to drop it.
+  // SystemJS relies on it to determine whether to use the default export, so we need to preserve it.
+  const esModule = Object.getOwnPropertyDescriptor(module, '__esModule');
+
+  if (esModule) {
+    Object.defineProperty(wrapped, '__esModule', esModule);
+  }
 
   return wrapped;
 }
 
 /**
- * Reads the plugin id out of a captured stack.
- *
- * The shared dependency is a singleton, so a caller cannot be identified from
- * anything the loader holds. The wrapper captures its own stack instead, which
- * runs in the frame of the plugin that called it.
- *
- * Frame formats differ between browsers, so this matches on the bundle path
- * rather than on frame syntax. The first match is the nearest caller.
+ * Reads the plugin id from a captured stack.
  */
 export function getPluginIdFromStack(stack: string | undefined): string | undefined {
   if (!stack) {
@@ -65,9 +61,9 @@ export function getPluginIdFromStack(stack: string | undefined): string | undefi
 /**
  * Reports that a plugin used an export that react-router v6 removes.
  *
- * Faro does not collect a stack for a warning, so the caller cannot be
- * identified after the fact. The stack is captured here instead, in the frame
- * of the plugin that made the call.
+ * Faro does not collect a stack trace for a warning, so the caller cannot be
+ * identified after the fact. This captures one here instead, while the plugin
+ * that made the call is still on the stack.
  *
  * Reports once per plugin and export. When the plugin cannot be identified the
  * event still goes out, with the stack attached, because an unattributed signal
@@ -113,18 +109,13 @@ function isComponent(value: unknown): value is ComponentType<UnknownProps> {
 
 // The report happens during render rather than in an effect, so that a component
 // which throws still reports. The dedupe keeps repeat renders quiet.
+//
+// React calls this from its own work loop, after the plugin's call has returned,
+// so the captured stack holds no plugin id. Hooks keep theirs. See reportV5Usage.
 function reportingComponent(exportName: string, Original: ComponentType<UnknownProps>): UnknownFunction {
   return function ReportingWrapper(props: UnknownProps) {
     reportV5Usage(exportName);
 
     return createElement(Original, props);
   };
-}
-
-function copyHiddenProperty(source: object, target: object, key: string | symbol): void {
-  const descriptor = Object.getOwnPropertyDescriptor(source, key);
-
-  if (descriptor) {
-    Object.defineProperty(target, key, descriptor);
-  }
 }

--- a/public/app/features/plugins/loader/v5RouterTelemetry.ts
+++ b/public/app/features/plugins/loader/v5RouterTelemetry.ts
@@ -2,19 +2,47 @@ import { createElement, type ComponentType } from 'react';
 
 import { getLogger } from '@grafana/runtime/unstable';
 
-// Plugin bundles are served from `public/plugins/<id>/`, both locally and from the
-// CDN. transformPluginSourceForCDN keeps that segment in CDN URLs, so one marker
-// covers both. See public/app/features/plugins/cdn/utils.ts.
+// Plugin bundles are served from `public/plugins/<id>/` regardless of host (CDN, filesystem).
 const PLUGIN_BUNDLE_PATH = /\/public\/plugins\/([^/]+)\//;
 
-// One entry per plugin and export. A single latched flag would hide a second
-// plugin that reaches the same export.
 const reported = new Set<string>();
 
-// Exports that react-router v6 removes. Plugins that call these break at the
-// upgrade, so these are the ones worth counting.
+// React-router v5 APIs that are removed in v6.
 const V5_ONLY_FUNCTIONS = ['useHistory', 'useRouteMatch', 'withRouter'] as const;
 const V5_ONLY_COMPONENTS = ['Switch', 'Redirect', 'Prompt'] as const;
+
+/**
+ * Returns the react-router-dom module with the "v6 removed" exports wrapped so
+ * we can report when a plugin uses them.
+ */
+export function withV5UsageTelemetry<T extends Record<string, unknown>>(module: T): T {
+  const wrappers: Record<string, UnknownFunction> = {};
+
+  for (const exportName of V5_ONLY_FUNCTIONS) {
+    const original = module[exportName];
+
+    if (isFunction(original)) {
+      wrappers[exportName] = reportingFunction(exportName, original);
+    }
+  }
+
+  for (const exportName of V5_ONLY_COMPONENTS) {
+    const original = module[exportName];
+
+    if (isComponent(original)) {
+      wrappers[exportName] = reportingComponent(exportName, original);
+    }
+  }
+
+  const wrapped = { ...module, ...wrappers };
+
+  // A spread copies enumerable properties only, and webpack marks `__esModule`
+  // as non-enumerable. SystemJS reads it when it registers a shared dependency
+  // and puts it on the namespace it hands to plugins, so carry it over by hand.
+  copyHiddenProperty(module, wrapped, '__esModule');
+
+  return wrapped;
+}
 
 /**
  * Reads the plugin id out of a captured stack.
@@ -91,46 +119,6 @@ function reportingComponent(exportName: string, Original: ComponentType<UnknownP
 
     return createElement(Original, props);
   };
-}
-
-/**
- * Returns the react-router-dom module with its v5-only exports wrapped, so that
- * a plugin calling one of them is reported.
- *
- * The wrappers replace the exports rather than watching reads of them. SystemJS
- * copies the values out of this object once, when it registers the shared
- * dependency, so a getter or a Proxy would fire at load and never again. A
- * wrapper survives, because the value that SystemJS copies is the wrapper.
- */
-export function withV5UsageTelemetry<T extends Record<string, unknown>>(module: T): T {
-  const wrappers: Record<string, UnknownFunction> = {};
-
-  for (const exportName of V5_ONLY_FUNCTIONS) {
-    const original = module[exportName];
-
-    if (isFunction(original)) {
-      wrappers[exportName] = reportingFunction(exportName, original);
-    }
-  }
-
-  for (const exportName of V5_ONLY_COMPONENTS) {
-    const original = module[exportName];
-
-    if (isComponent(original)) {
-      wrappers[exportName] = reportingComponent(exportName, original);
-    }
-  }
-
-  const wrapped = { ...module, ...wrappers };
-
-  // A spread copies enumerable properties only, and webpack marks the interop
-  // flags of a module namespace as non-enumerable. Carry them over by hand.
-  // SystemJS reads `__esModule` when it registers a shared dependency, and it
-  // keeps an object whose tag is 'Module' instead of copying it.
-  copyHiddenProperty(module, wrapped, '__esModule');
-  copyHiddenProperty(module, wrapped, Symbol.toStringTag);
-
-  return wrapped;
 }
 
 function copyHiddenProperty(source: object, target: object, key: string | symbol): void {

--- a/public/app/features/plugins/loader/v5RouterTelemetry.ts
+++ b/public/app/features/plugins/loader/v5RouterTelemetry.ts
@@ -1,0 +1,22 @@
+// Plugin bundles are served from `public/plugins/<id>/`, both locally and from the
+// CDN. transformPluginSourceForCDN keeps that segment in CDN URLs, so one marker
+// covers both. See public/app/features/plugins/cdn/utils.ts.
+const PLUGIN_BUNDLE_PATH = /\/public\/plugins\/([^/]+)\//;
+
+/**
+ * Reads the plugin id out of a captured stack.
+ *
+ * The shared dependency is a singleton, so a caller cannot be identified from
+ * anything the loader holds. The wrapper captures its own stack instead, which
+ * runs in the frame of the plugin that called it.
+ *
+ * Frame formats differ between browsers, so this matches on the bundle path
+ * rather than on frame syntax. The first match is the nearest caller.
+ */
+export function getPluginIdFromStack(stack: string | undefined): string | undefined {
+  if (!stack) {
+    return undefined;
+  }
+
+  return stack.match(PLUGIN_BUNDLE_PATH)?.[1];
+}

--- a/public/app/features/plugins/loader/v5RouterTelemetry.ts
+++ b/public/app/features/plugins/loader/v5RouterTelemetry.ts
@@ -63,7 +63,7 @@ export function getPluginIdFromStack(stack: string | undefined): string | undefi
  */
 export function reportV5Usage(exportName: string, stack?: string): void {
   const pluginId = getPluginIdFromStack(stack);
-  const key = pluginId ? `${pluginId}:${exportName}` : `unattributed:${exportName}`;
+  const key = pluginId ? `${pluginId}:${exportName}` : `unknownPluginId:${exportName}`;
 
   if (reported.has(key)) {
     return;
@@ -80,6 +80,7 @@ function isFunction(value: unknown): value is UnknownFunction {
   return typeof value === 'function';
 }
 
+// Functions are called by the plugin, so the plugin is on the stack.
 function reportingFunction(exportName: string, original: UnknownFunction): UnknownFunction {
   return function reportingWrapper(...args) {
     reportV5Usage(exportName, new Error().stack);


### PR DESCRIPTION
**What is this feature?**

Wraps the react router v5-only exports of the `react-router-dom` shared dependency, so that a plugin which calls one is reported through Faro. The exports that are removed in v6 are `Switch`, `Redirect`, `Prompt`, `useHistory`, `useRouteMatch` and `withRouter`. As each wrapper reports and then returns the real export there should be no change to plugin behaviour. Each plugin and export reports once.

**Why do we need this feature?**

To better understand which plugins might break for our users in prod before we attempt to finish the migration of react-router from v5 to v6.

**Who is this feature for?**

Grafana engineers

**Which issue(s) does this PR fix?**:

Fixes #130467

**Special notes for your reviewer:**

- Only the hooks and `withRouter` can pass on a plugin id. Due to how React renders a component `Switch`, `Redirect` and `Prompt` report with no plugin id.
- We have the e2e plugin `frontend-sandbox-app-test` which uses the v5 api which should assert the module wrapping doesn't break plugins.
