### PR TITLE
Search: add the per-resource trash endpoint

### DIFF
--- a/pkg/registry/apis/search/handler.go
+++ b/pkg/registry/apis/search/handler.go
@@ -14,6 +14,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/endpoints/request"
 
 	searchv0 "github.com/grafana/grafana/pkg/apis/search/v0alpha1"
@@ -63,8 +64,49 @@ func NewHandler(client resourcepb.ResourceIndexClient, provider resource.SearchF
 
 // SearchFor returns the POST handler for the search endpoint of one kind.
 func (h *Handler) SearchFor(kind kindRef) http.HandlerFunc {
+	return h.handle(kind, "search.v1.search", searchv0.KindSearchQuery,
+		func(r *http.Request, namespace string) (*resourcepb.ResourceSearchRequest, field.ErrorList, error) {
+			var q searchv0.SearchQuery
+			if err := decodeBody(r, &q); err != nil {
+				return nil, nil, err
+			}
+			req, ferrs := TranslateSearchQuery(&q, kind.gvr(), namespace, h.provider)
+			return req, ferrs, nil
+		},
+		func(res *resourcepb.ResourceSearchResponse, limit int64) (any, error) {
+			return searchResults(res, kind, limit)
+		},
+	)
+}
+
+// TrashFor returns the POST handler for the trash endpoint of one kind.
+func (h *Handler) TrashFor(kind kindRef) http.HandlerFunc {
+	return h.handle(kind, "search.v1.trash", searchv0.KindTrashQuery,
+		func(r *http.Request, namespace string) (*resourcepb.ResourceSearchRequest, field.ErrorList, error) {
+			var q searchv0.TrashQuery
+			if err := decodeBody(r, &q); err != nil {
+				return nil, nil, err
+			}
+			req, ferrs := TranslateTrashQuery(&q, kind.gvr(), namespace)
+			return req, ferrs, nil
+		},
+		func(res *resourcepb.ResourceSearchResponse, limit int64) (any, error) {
+			return trashResults(res, kind, limit)
+		},
+	)
+}
+
+// handle is the request flow both endpoints share. Only the body type and the
+// response envelope differ, which is what translate and respond supply.
+func (h *Handler) handle(
+	kind kindRef,
+	spanName string,
+	queryKind string,
+	translate func(*http.Request, string) (*resourcepb.ResourceSearchRequest, field.ErrorList, error),
+	respond func(*resourcepb.ResourceSearchResponse, int64) (any, error),
+) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		ctx, span := h.tracer.Start(r.Context(), "search.v1.search", trace.WithAttributes(
+		ctx, span := h.tracer.Start(r.Context(), spanName, trace.WithAttributes(
 			attribute.String("search.group", kind.group),
 			attribute.String("search.version", kind.version),
 			attribute.String("search.resource", kind.resource),
@@ -77,16 +119,14 @@ func (h *Handler) SearchFor(kind kindRef) http.HandlerFunc {
 			return
 		}
 
-		var q searchv0.SearchQuery
-		if err := decodeBody(r, &q); err != nil {
+		req, ferrs, err := translate(r, namespace)
+		if err != nil {
 			errhttp.Write(ctx, err, w)
 			return
 		}
-
-		req, ferrs := TranslateSearchQuery(&q, kind.gvr(), namespace, h.provider)
 		if len(ferrs) > 0 {
 			errhttp.Write(ctx, apierrors.NewInvalid(
-				schema.GroupKind{Group: searchv0.GROUP, Kind: searchv0.KindSearchQuery}, "", ferrs), w)
+				schema.GroupKind{Group: searchv0.GROUP, Kind: queryKind}, "", ferrs), w)
 			return
 		}
 
@@ -101,7 +141,7 @@ func (h *Handler) SearchFor(kind kindRef) http.HandlerFunc {
 			return
 		}
 
-		out, err := searchResults(res, kind, req.Limit)
+		out, err := respond(res, req.Limit)
 		if err != nil {
 			errhttp.Write(ctx, err, w)
 			return

--- a/pkg/registry/apis/search/openapi_schemas.go
+++ b/pkg/registry/apis/search/openapi_schemas.go
@@ -16,6 +16,8 @@ const (
 	envelopePkg         = "github.com/grafana/grafana/pkg/apis/search/v0alpha1."
 	searchQueryGoName   = envelopePkg + searchv0.KindSearchQuery
 	searchResultsGoName = envelopePkg + searchv0.KindSearchResults
+	trashQueryGoName    = envelopePkg + searchv0.KindTrashQuery
+	trashResultsGoName  = envelopePkg + searchv0.KindTrashResults
 )
 
 // componentPrefix is where an OpenAPI v3 document keeps its schemas.

--- a/pkg/registry/apis/search/response.go
+++ b/pkg/registry/apis/search/response.go
@@ -32,6 +32,25 @@ func searchResults(res *resourcepb.ResourceSearchResponse, kind kindRef, limit i
 	return out, nil
 }
 
+// trashResults maps a backend search response into the trash envelope. No facets:
+// trash never requests any, so the backend never returns any.
+func trashResults(res *resourcepb.ResourceSearchResponse, kind kindRef, limit int64) (*searchv0.TrashResults, error) {
+	items, err := resultItems(res.GetResults(), kind)
+	if err != nil {
+		return nil, err
+	}
+
+	return &searchv0.TrashResults{
+		TypeMeta: metaForKind(searchv0.KindTrashResults),
+		Metadata: searchv0.ResultsMetadata{
+			TotalHits:         res.GetTotalHits(),
+			TotalHitsRelation: totalHitsRelation(res.GetTotalHitsExact()),
+			Continue:          continueToken(res.GetResults(), limit, res.GetTotalHitsExact()),
+		},
+		Items: items,
+	}, nil
+}
+
 func totalHitsRelation(exact bool) searchv0.TotalHitsRelation {
 	if exact {
 		return searchv0.TotalHitsEqual

--- a/pkg/registry/apis/search/route.go
+++ b/pkg/registry/apis/search/route.go
@@ -12,13 +12,21 @@ import (
 
 // ConfigSection and ConfigKey name the ini setting that turns these endpoints
 // on. The endpoints are off by default while the API is being built out.
+//
+// Trash has its own key rather than sharing ConfigKey. It authorizes on a
+// different rule -- folder admin, or whoever deleted the object -- that has not been
+// reviewed yet, and a deployment may well turn search on for live search alone.
 const (
-	ConfigSection = "grafana-apiserver"
-	ConfigKey     = "enable_search_api"
+	ConfigSection  = "grafana-apiserver"
+	ConfigKey      = "enable_search_api"
+	ConfigKeyTrash = "enable_trash_api"
 )
 
-// Aliased so the authorization chain and the route cannot drift apart.
-const searchPathSegment = searchv0.SearchPathSegment
+// Aliased so the authorization chain and the routes cannot drift apart.
+const (
+	searchPathSegment = searchv0.SearchPathSegment
+	trashPathSegment  = searchv0.TrashPathSegment
+)
 
 // Route is an endpoint to mount, described in terms the caller's apiserver
 // wiring can consume. Deliberately not Grafana's builder.APIRouteHandler: the
@@ -50,6 +58,20 @@ func (h *Handler) SearchRoute(group, version, resourceName, kindName string) Rou
 	}
 }
 
+// TrashRoute returns the namespaced route for a kind's trash endpoint, mounted at
+// .../namespaces/{namespace}/{resource}/trash.
+//
+// POST for the same reasons as SearchRoute.
+func (h *Handler) TrashRoute(group, version, resourceName, kindName string) Route {
+	kind := kindRef{group: group, version: version, resource: resourceName, kind: kindName}
+	return Route{
+		Path:    resourceName + "/" + trashPathSegment,
+		Spec:    trashRouteSpec(kindName, version),
+		Handler: h.TrashFor(kind),
+		Schemas: envelopeSchemas(trashQueryGoName, trashResultsGoName),
+	}
+}
+
 // searchOperationID names the operation for OpenAPI. The version is part of the
 // name because the endpoint is mounted on every served version, and operation
 // IDs have to stay unique once the per-version specs are merged. It starts with
@@ -57,6 +79,10 @@ func (h *Handler) SearchRoute(group, version, resourceName, kindName string) Rou
 // it does not create.
 func searchOperationID(kindName, version string) string {
 	return "list" + kindName + "Search" + capitalize(version)
+}
+
+func trashOperationID(kindName, version string) string {
+	return "list" + kindName + "Trash" + capitalize(version)
 }
 
 func capitalize(s string) string {
@@ -67,12 +93,48 @@ func capitalize(s string) string {
 }
 
 func searchRouteSpec(kindName, version string) *spec3.PathProps {
+	return routeSpec(routeSpecArgs{
+		operationID:  searchOperationID(kindName, version),
+		description:  "Search " + kindName + " resources in a namespace.",
+		requestKind:  searchv0.KindSearchQuery,
+		requestGo:    searchQueryGoName,
+		responseKind: searchv0.KindSearchResults,
+		responseGo:   searchResultsGoName,
+	})
+}
+
+func trashRouteSpec(kindName, version string) *spec3.PathProps {
+	return routeSpec(routeSpecArgs{
+		operationID:  trashOperationID(kindName, version),
+		description:  "List deleted " + kindName + " resources in a namespace.",
+		requestKind:  searchv0.KindTrashQuery,
+		requestGo:    trashQueryGoName,
+		responseKind: searchv0.KindTrashResults,
+		responseGo:   trashResultsGoName,
+	})
+}
+
+// routeSpecArgs is what differs between the two endpoints. Go names are separate
+// from kind names because the schema components are keyed by the Go name, while
+// the descriptions read better with the kind name.
+type routeSpecArgs struct {
+	operationID  string
+	description  string
+	requestKind  string
+	requestGo    string
+	responseKind string
+	responseGo   string
+}
+
+// routeSpec builds what both endpoints have in common: a namespaced POST taking a
+// query envelope and returning a results envelope.
+func routeSpec(a routeSpecArgs) *spec3.PathProps {
 	return &spec3.PathProps{
 		Post: &spec3.Operation{
 			OperationProps: spec3.OperationProps{
 				Tags:        []string{"Search"},
-				OperationId: searchOperationID(kindName, version),
-				Description: "Search " + kindName + " resources in a namespace.",
+				OperationId: a.operationID,
+				Description: a.description,
 				Parameters: []*spec3.Parameter{
 					{
 						ParameterProps: spec3.ParameterProps{
@@ -88,8 +150,8 @@ func searchRouteSpec(kindName, version string) *spec3.PathProps {
 				RequestBody: &spec3.RequestBody{
 					RequestBodyProps: spec3.RequestBodyProps{
 						Required:    true,
-						Description: "A " + searchv0.KindSearchQuery + " describing what to match, sort and return.",
-						Content:     jsonContent(searchQueryGoName),
+						Description: "A " + a.requestKind + " describing what to match, sort and return.",
+						Content:     jsonContent(a.requestGo),
 					},
 				},
 				Responses: &spec3.Responses{
@@ -97,8 +159,8 @@ func searchRouteSpec(kindName, version string) *spec3.PathProps {
 						StatusCodeResponses: map[int]*spec3.Response{
 							200: {
 								ResponseProps: spec3.ResponseProps{
-									Description: "A " + searchv0.KindSearchResults + " envelope.",
-									Content:     jsonContent(searchResultsGoName),
+									Description: "A " + a.responseKind + " envelope.",
+									Content:     jsonContent(a.responseGo),
 								},
 							},
 						},

--- a/pkg/registry/apis/search/route_dispatch_test.go
+++ b/pkg/registry/apis/search/route_dispatch_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// The search endpoint sits at .../{resource}/search, the same shape as an
-// object path, so it could shadow the standard routes or be shadowed by them.
-// This dispatches through the same router the apiserver installs to show which
-// handler each request actually reaches.
+// The search and trash endpoints are served at .../{resource}/search and
+// .../{resource}/trash, which look like object paths, so they could shadow the
+// standard routes or be shadowed by them. This dispatches through the router the
+// apiserver installs, to show which handler each request actually reaches.
 func TestSearchRouteDoesNotShadowStandardRoutes(t *testing.T) {
 	const root = "/apis/dashboard.grafana.app/v0alpha1"
 
@@ -35,8 +35,9 @@ func TestSearchRouteDoesNotShadowStandardRoutes(t *testing.T) {
 	ws.Route(ws.POST("/namespaces/{namespace}/dashboards").To(record("create")))
 	// The legacy dashboard search route.
 	ws.Route(ws.GET("/namespaces/{namespace}/search").To(record("legacy-search")))
-	// The route under test, mounted the same way SearchRoute mounts it.
+	// The routes under test, mounted the same way SearchRoute and TrashRoute do.
 	ws.Route(ws.POST("/namespaces/{namespace}/dashboards/" + searchPathSegment).To(record("search")))
+	ws.Route(ws.POST("/namespaces/{namespace}/dashboards/" + trashPathSegment).To(record("trash")))
 	container.Add(ws)
 
 	for _, tc := range []struct {
@@ -46,11 +47,16 @@ func TestSearchRouteDoesNotShadowStandardRoutes(t *testing.T) {
 		handler string
 	}{
 		{"search endpoint", http.MethodPost, "/dashboards/search", "search"},
-		// A dashboard may legitimately be named "search"; every non-POST verb
-		// must still reach the object routes.
+		{"trash endpoint", http.MethodPost, "/dashboards/trash", "trash"},
+		// A dashboard may legitimately be named "search" or "trash"; every non-POST
+		// verb must still reach the object routes.
 		{"read a dashboard named search", http.MethodGet, "/dashboards/search", "get-object"},
 		{"replace a dashboard named search", http.MethodPut, "/dashboards/search", "replace-object"},
 		{"delete a dashboard named search", http.MethodDelete, "/dashboards/search", "delete-object"},
+		{"read a dashboard named trash", http.MethodGet, "/dashboards/trash", "get-object"},
+		{"replace a dashboard named trash", http.MethodPut, "/dashboards/trash", "replace-object"},
+		{"delete a dashboard named trash", http.MethodDelete, "/dashboards/trash", "delete-object"},
+		{"subresource of a dashboard named trash", http.MethodGet, "/dashboards/trash/dto", "subresource"},
 
 		{"read another dashboard", http.MethodGet, "/dashboards/my-dash", "get-object"},
 		{"subresource", http.MethodGet, "/dashboards/my-dash/dto", "subresource"},

--- a/pkg/registry/apis/search/route_test.go
+++ b/pkg/registry/apis/search/route_test.go
@@ -25,23 +25,38 @@ func TestSearchRoute(t *testing.T) {
 	assert.Equal(t, "listDashboardSearchV0alpha1", r.Spec.Post.OperationId)
 }
 
-func TestSearchOperationID(t *testing.T) {
+func TestTrashRoute(t *testing.T) {
+	h := NewHandler(&fakeIndexClient{resp: emptyResponse()}, testProvider(), noop.NewTracerProvider().Tracer(""))
+	r := h.TrashRoute("dashboard.grafana.app", "v0alpha1", "dashboards", "Dashboard")
+
+	assert.Equal(t, "dashboards/trash", r.Path)
+	require.NotNil(t, r.Handler)
+
+	require.NotNil(t, r.Spec)
+	require.NotNil(t, r.Spec.Post, "trash is a POST, so no other method should be described")
+	assert.Nil(t, r.Spec.Get)
+	assert.Equal(t, "listDashboardTrashV0alpha1", r.Spec.Post.OperationId)
+}
+
+func TestOperationIDs(t *testing.T) {
 	versions := []string{"v0alpha1", "v1", "v1beta1", "v2alpha1", "v2beta1"}
 
-	// The endpoint is mounted on every served version, so the IDs have to stay
-	// distinct once the per-version specs are merged.
+	// Both endpoints are mounted on every served version, so the IDs have to stay
+	// distinct across endpoints as well as versions once the specs are merged.
 	seen := map[string]bool{}
 	for _, v := range versions {
-		id := searchOperationID("Dashboard", v)
-		require.False(t, seen[id], "duplicate operation ID %q", id)
-		seen[id] = true
+		for _, id := range []string{searchOperationID("Dashboard", v), trashOperationID("Dashboard", v)} {
+			require.False(t, seen[id], "duplicate operation ID %q", id)
+			seen[id] = true
 
-		// Starting with a Kubernetes verb stops the route builder prefixing
-		// "create" onto what is really a read.
-		assert.True(t, strings.HasPrefix(id, "list"), "got %q", id)
+			// Starting with a Kubernetes verb stops the route builder prefixing
+			// "create" onto what is really a read.
+			assert.True(t, strings.HasPrefix(id, "list"), "got %q", id)
+		}
 	}
 
 	assert.Equal(t, "listDashboardSearchV0alpha1", searchOperationID("Dashboard", "v0alpha1"))
+	assert.Equal(t, "listDashboardTrashV0alpha1", trashOperationID("Dashboard", "v0alpha1"))
 }
 
 // An unresolved $ref renders as an empty model rather than erroring, so every
@@ -65,10 +80,37 @@ func TestSearchRoute_EveryRefResolves(t *testing.T) {
 	assert.Contains(t, r.Schemas, pkg+"WhereNode")
 	assert.Contains(t, r.Schemas, pkg+"TextPredicate")
 
-	// Trash belongs to an endpoint that does not exist yet.
+	// Each route publishes only what it references, so the trash envelopes belong to
+	// the trash route alone.
 	assert.NotContains(t, r.Schemas, pkg+"TrashQuery")
 
 	// Nothing anywhere in the published set points outside it.
+	for name, schema := range r.Schemas {
+		for _, ref := range collectRefs(&schema) {
+			assert.Contains(t, r.Schemas, ref, "%s references %s, which is not published", name, ref)
+		}
+	}
+}
+
+func TestTrashRoute_EveryRefResolves(t *testing.T) {
+	r := NewHandler(&fakeIndexClient{resp: emptyResponse()}, testProvider(), noop.NewTracerProvider().Tracer("")).
+		TrashRoute("dashboard.grafana.app", "v1", "dashboards", "Dashboard")
+
+	require.NotEmpty(t, r.Schemas, "the route must publish the components it references")
+
+	const pkg = "com.github.grafana.grafana.pkg.apis.search.v0alpha1."
+	reqRef := r.Spec.Post.RequestBody.Content["application/json"].Schema.Ref.String()
+	resRef := r.Spec.Post.Responses.StatusCodeResponses[200].Content["application/json"].Schema.Ref.String()
+	assert.Equal(t, "#/components/schemas/"+pkg+"TrashQuery", reqRef)
+	assert.Equal(t, "#/components/schemas/"+pkg+"TrashResults", resRef)
+	assert.Contains(t, r.Schemas, pkg+"TrashQuery")
+	assert.Contains(t, r.Schemas, pkg+"TrashResults")
+
+	// A TrashQuery has no labelSelector or facets, so it must not drag in the
+	// components only those reach.
+	assert.NotContains(t, r.Schemas, pkg+"SearchQuery")
+	assert.NotContains(t, r.Schemas, pkg+"FacetTerm")
+
 	for name, schema := range r.Schemas {
 		for _, ref := range collectRefs(&schema) {
 			assert.Contains(t, r.Schemas, ref, "%s references %s, which is not published", name, ref)

--- a/pkg/registry/apis/search/trash_handler_test.go
+++ b/pkg/registry/apis/search/trash_handler_test.go
@@ -1,0 +1,151 @@
+package search
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+	"k8s.io/apiserver/pkg/endpoints/request"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	searchv0 "github.com/grafana/grafana/pkg/apis/search/v0alpha1"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+)
+
+func doTrashRequest(t *testing.T, h *Handler, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodPost, "/trash", strings.NewReader(body))
+	ctx := identity.WithRequester(r.Context(), &identity.StaticRequester{Namespace: "default"})
+	ctx = request.WithNamespace(ctx, "default")
+	w := httptest.NewRecorder()
+	h.TrashFor(testKind)(w, r.WithContext(ctx))
+	return w
+}
+
+func trashBody(inner string) string {
+	return `{
+		"apiVersion": "` + searchv0.APIVERSION + `",
+		"kind": "` + searchv0.KindTrashQuery + `"` + inner + `
+	}`
+}
+
+func TestTrashHandler_RequestsDeletedResources(t *testing.T) {
+	client := &fakeIndexClient{resp: emptyResponse()}
+	h := NewHandler(client, testProvider(), noop.NewTracerProvider().Tracer(""))
+
+	w := doTrashRequest(t, h, trashBody(`, "limit": 25`))
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	require.NotNil(t, client.got)
+	assert.True(t, client.got.IsDeleted, "the backend must be told to search trash")
+	assert.Equal(t, "default", client.got.Options.Key.Namespace)
+	assert.Equal(t, testKind.group, client.got.Options.Key.Group)
+	assert.Equal(t, testKind.resource, client.got.Options.Key.Resource)
+	assert.Equal(t, int64(25), client.got.Limit)
+
+	// Federating trash is refused by the backend, so the endpoint must not ask.
+	assert.Empty(t, client.got.Federated)
+
+	var out searchv0.TrashResults
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &out))
+	assert.Equal(t, searchv0.KindTrashResults, out.Kind)
+	assert.Equal(t, searchv0.APIVERSION, out.APIVersion)
+}
+
+// So the default view reads as "most recently deleted first".
+func TestTrashHandler_DefaultsToNewestDeletionFirst(t *testing.T) {
+	client := &fakeIndexClient{resp: emptyResponse()}
+	h := NewHandler(client, testProvider(), noop.NewTracerProvider().Tracer(""))
+
+	w := doTrashRequest(t, h, trashBody(``))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	require.Len(t, client.got.SortBy, 1)
+	assert.Equal(t, resource.SEARCH_FIELD_DELETION_TIME, client.got.SortBy[0].Field)
+	assert.True(t, client.got.SortBy[0].Desc)
+}
+
+// deleted_rv identifies the version to restore, so a narrower field list must not
+// drop it.
+func TestTrashHandler_AlwaysReturnsTheDeletedResourceVersion(t *testing.T) {
+	client := &fakeIndexClient{resp: emptyResponse()}
+	h := NewHandler(client, testProvider(), noop.NewTracerProvider().Tracer(""))
+
+	w := doTrashRequest(t, h, trashBody(`, "fields": ["title"]`))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	assert.Contains(t, client.got.Fields, resource.SEARCH_FIELD_DELETED_RV)
+}
+
+func TestTrashHandler_RejectsBadRequests(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"wrong envelope kind", `{"apiVersion": "` + searchv0.APIVERSION + `", "kind": "` + searchv0.KindSearchQuery + `"}`},
+		{"malformed json", `{"kind": `},
+		{"empty body", ``},
+		{"unknown top-level field", trashBody(`, "labelSelector": {}`)},
+		{"field outside the trash set", trashBody(`, "fields": ["panel_type"]`)},
+		{"sort on a field outside the trash set", trashBody(`, "sort": [{"field": "panel_type"}]`)},
+		{"negative limit", trashBody(`, "limit": -1`)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &fakeIndexClient{resp: emptyResponse()}
+			h := NewHandler(client, testProvider(), noop.NewTracerProvider().Tracer(""))
+
+			w := doTrashRequest(t, h, tc.body)
+
+			assert.GreaterOrEqual(t, w.Code, 400, w.Body.String())
+			assert.Less(t, w.Code, 500, w.Body.String())
+			assert.Nil(t, client.got, "a rejected request must not reach the backend")
+		})
+	}
+}
+
+// The backend reports failures in the payload, so a nil transport error is not enough.
+func TestTrashHandler_PropagatesBackendErrorResult(t *testing.T) {
+	client := &fakeIndexClient{resp: &resourcepb.ResourceSearchResponse{
+		Error: &resourcepb.ErrorResult{Code: http.StatusBadRequest, Message: "nope"},
+	}}
+	h := NewHandler(client, testProvider(), noop.NewTracerProvider().Tracer(""))
+
+	w := doTrashRequest(t, h, trashBody(``))
+
+	assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+}
+
+func TestTrashHandler_RequiresARealNamespace(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		namespace string
+	}{
+		{"missing", ""},
+		{"wildcard", wildcardNamespace},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &fakeIndexClient{resp: emptyResponse()}
+			h := NewHandler(client, testProvider(), noop.NewTracerProvider().Tracer(""))
+
+			r := httptest.NewRequest(http.MethodPost, "/trash", strings.NewReader(trashBody(``)))
+			ctx := identity.WithRequester(r.Context(), &identity.StaticRequester{Namespace: "default"})
+			if tc.namespace != "" {
+				ctx = request.WithNamespace(ctx, tc.namespace)
+			}
+			w := httptest.NewRecorder()
+			h.TrashFor(testKind)(w, r.WithContext(ctx))
+
+			assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+			assert.Nil(t, client.got)
+		})
+	}
+}

--- a/pkg/services/apiserver/options/extra.go
+++ b/pkg/services/apiserver/options/extra.go
@@ -27,6 +27,12 @@ type ExtraOptions struct {
 	// Temporary, while the per-resource search endpoints are being built out; it
 	// goes away once kinds opt in through their manifest.
 	EnableSearchAPI bool
+
+	// EnableTrashAPI is the flag equivalent of [grafana-apiserver]
+	// enable_trash_api. Separate from EnableSearchAPI because trash authorizes on a
+	// different rule that has not been reviewed yet, so enabling search must not
+	// expose it.
+	EnableTrashAPI bool
 }
 
 func NewExtraOptions() *ExtraOptions {
@@ -44,6 +50,8 @@ func (o *ExtraOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&o.Verbosity, "verbosity", o.Verbosity, "Verbosity")
 	fs.BoolVar(&o.EnableSearchAPI, "grafana-apiserver-enable-search-api", o.EnableSearchAPI,
 		"Serve the per-resource search endpoints")
+	fs.BoolVar(&o.EnableTrashAPI, "grafana-apiserver-enable-trash-api", o.EnableTrashAPI,
+		"Serve the per-resource trash endpoints")
 }
 
 func (o *ExtraOptions) Validate() []error {

--- a/pkg/services/apiserver/searchroutes/searchroutes.go
+++ b/pkg/services/apiserver/searchroutes/searchroutes.go
@@ -35,22 +35,26 @@ type groupResource struct {
 	resource string
 }
 
-// Build returns the search routes to mount, or nil when the endpoint is off or
-// there is no client to serve it with.
+// Build returns the search and trash routes to mount, or nil when both are off or
+// there is no client to serve them with.
+//
+// The two are switched separately because trash authorizes on a different rule
+// that has not been reviewed yet. See searchapi.ConfigKeyTrash.
 //
 // builders and installers are the two ways a kind reaches the apiserver; a route
 // is only mounted on a group version one of them actually serves.
 func Build(
-	enabled bool,
+	searchEnabled bool,
+	trashEnabled bool,
 	tracer tracing.Tracer,
 	index resourcepb.ResourceIndexClient,
 	builders []builder.APIGroupBuilder,
 	installers []appsdkapiserver.AppInstaller,
 ) []builder.GroupVersionRoutes {
-	// Whether the endpoint is on is read by the caller, because the two servers
-	// that mount it are configured differently: one from an ini file, one from
+	// Whether an endpoint is on is read by the caller, because the two servers
+	// that mount them are configured differently: one from an ini file, one from
 	// flags.
-	if !enabled || index == nil {
+	if (!searchEnabled && !trashEnabled) || index == nil {
 		return nil
 	}
 
@@ -82,8 +86,14 @@ func Build(
 				if !allowed[groupResource{group: gv.Group, resource: resourceName}] {
 					continue
 				}
-				byGroupVersion[gv] = append(byGroupVersion[gv],
-					handler.SearchRoute(gv.Group, gv.Version, resourceName, kind.Kind))
+				if searchEnabled {
+					byGroupVersion[gv] = append(byGroupVersion[gv],
+						handler.SearchRoute(gv.Group, gv.Version, resourceName, kind.Kind))
+				}
+				if trashEnabled {
+					byGroupVersion[gv] = append(byGroupVersion[gv],
+						handler.TrashRoute(gv.Group, gv.Version, resourceName, kind.Kind))
+				}
 			}
 		}
 	}

--- a/pkg/services/apiserver/searchroutes/searchroutes_test.go
+++ b/pkg/services/apiserver/searchroutes/searchroutes_test.go
@@ -47,9 +47,43 @@ func paths(routes []builder.GroupVersionRoutes) map[string][]string {
 func TestBuild_NothingMountedWhenOffOrUnusable(t *testing.T) {
 	b := []builder.APIGroupBuilder{&fakeBuilder{gvs: []schema.GroupVersion{{Group: "dashboard.grafana.app", Version: "v1"}}}}
 
-	assert.Nil(t, Build(false, nil, fakeClient{}, b, nil), "off")
+	assert.Nil(t, Build(false, false, nil, fakeClient{}, b, nil), "both off")
 	// A server without a unified storage client has nothing to search.
-	assert.Nil(t, Build(true, nil, nil, b, nil), "no client")
+	assert.Nil(t, Build(true, false, nil, nil, b, nil), "no client")
+	assert.Nil(t, Build(false, true, nil, nil, b, nil), "no client, trash on")
+}
+
+// Trash authorizes on a rule that has not been reviewed yet, so turning search on
+// must not expose it.
+func TestBuild_SearchAndTrashAreIndependent(t *testing.T) {
+	newBuilders := func() []builder.APIGroupBuilder {
+		return []builder.APIGroupBuilder{&fakeBuilder{gvs: []schema.GroupVersion{
+			{Group: "dashboard.grafana.app", Version: "v1"},
+		}}}
+	}
+	const gv = "dashboard.grafana.app/v1"
+
+	t.Run("search only", func(t *testing.T) {
+		got := paths(Build(true, false, nil, fakeClient{}, newBuilders(), nil))
+		assert.Equal(t, []string{"dashboards/search"}, got[gv])
+	})
+
+	t.Run("trash only", func(t *testing.T) {
+		got := paths(Build(false, true, nil, fakeClient{}, newBuilders(), nil))
+		assert.Equal(t, []string{"dashboards/trash"}, got[gv])
+	})
+
+	t.Run("both", func(t *testing.T) {
+		got := paths(Build(true, true, nil, fakeClient{}, newBuilders(), nil))
+		assert.ElementsMatch(t, []string{"dashboards/search", "dashboards/trash"}, got[gv])
+	})
+}
+
+// Trash must not reach a kind that search cannot.
+func TestBuild_TrashRespectsTheAllowlist(t *testing.T) {
+	b := &fakeBuilder{gvs: []schema.GroupVersion{{Group: "playlist.grafana.app", Version: "v0alpha1"}}}
+
+	assert.Empty(t, paths(Build(true, true, nil, fakeClient{}, []builder.APIGroupBuilder{b}, nil)))
 }
 
 func TestBuild_MountsAllowedKinds(t *testing.T) {
@@ -58,7 +92,7 @@ func TestBuild_MountsAllowedKinds(t *testing.T) {
 		{Group: "folder.grafana.app", Version: "v1"},
 	}}
 
-	got := paths(Build(true, nil, fakeClient{}, []builder.APIGroupBuilder{b}, nil))
+	got := paths(Build(true, false, nil, fakeClient{}, []builder.APIGroupBuilder{b}, nil))
 
 	assert.Equal(t, []string{"dashboards/search"}, got["dashboard.grafana.app/v1"])
 	assert.Equal(t, []string{"folders/search"}, got["folder.grafana.app/v1"])
@@ -69,7 +103,7 @@ func TestBuild_MountsAllowedKinds(t *testing.T) {
 func TestBuild_SkipsGroupVersionsNotServed(t *testing.T) {
 	b := &fakeBuilder{gvs: []schema.GroupVersion{{Group: "dashboard.grafana.app", Version: "v1"}}}
 
-	got := paths(Build(true, nil, fakeClient{}, []builder.APIGroupBuilder{b}, nil))
+	got := paths(Build(true, false, nil, fakeClient{}, []builder.APIGroupBuilder{b}, nil))
 
 	assert.Contains(t, got, "dashboard.grafana.app/v1")
 	assert.NotContains(t, got, "dashboard.grafana.app/v2", "v2 is a served version, but not served by this builder")
@@ -84,7 +118,7 @@ func TestBuild_SkipsKindsNotAllowed(t *testing.T) {
 	}
 	b := &fakeBuilder{gvs: notAllowed}
 
-	assert.Empty(t, paths(Build(true, nil, fakeClient{}, []builder.APIGroupBuilder{b}, nil)))
+	assert.Empty(t, paths(Build(true, false, nil, fakeClient{}, []builder.APIGroupBuilder{b}, nil)))
 }
 
 // Every served version of an allowed kind gets the endpoint, so a client can use
@@ -103,7 +137,7 @@ func TestBuild_MountsEveryServedVersion(t *testing.T) {
 	}
 	require.NotEmpty(t, dashboardGVs)
 
-	got := paths(Build(true, nil, fakeClient{},
+	got := paths(Build(true, false, nil, fakeClient{},
 		[]builder.APIGroupBuilder{&fakeBuilder{gvs: dashboardGVs}}, nil))
 
 	assert.Len(t, got, len(dashboardGVs))

--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -408,8 +408,10 @@ func (s *service) start(ctx context.Context) error {
 
 	// Built once and used twice: the routes have to reach both the OpenAPI spec
 	// and the served WebServices, or the endpoint works but is undiscoverable.
-	searchAPIEnabled := s.cfg.SectionWithEnvOverrides(searchapi.ConfigSection).Key(searchapi.ConfigKey).MustBool(false)
-	searchRoutes := searchroutes.Build(searchAPIEnabled, s.tracing, s.unified, builders, s.appInstallers)
+	apiserverSection := s.cfg.SectionWithEnvOverrides(searchapi.ConfigSection)
+	searchAPIEnabled := apiserverSection.Key(searchapi.ConfigKey).MustBool(false)
+	trashAPIEnabled := apiserverSection.Key(searchapi.ConfigKeyTrash).MustBool(false)
+	searchRoutes := searchroutes.Build(searchAPIEnabled, trashAPIEnabled, s.tracing, s.unified, builders, s.appInstallers)
 
 	// Add OpenAPI specs for each group+version (existing builders)
 	err = builder.SetupConfig(


### PR DESCRIPTION
`POST .../namespaces/{ns}/{resource}/trash` lists a namespace's deleted resources, alongside the existing search endpoint. The query and result envelopes, the path segment and the translation already existed but were unreachable; this mounts them.

The endpoint is off by default behind its own `enable_trash_api` key rather than `enable_search_api`. Trash authorizes on a different rule from live search — folder admin, or whoever deleted the object — and that rule has not been reviewed yet, so turning search on must not expose it as a side effect.

The rule itself is implemented in #130481; this is the endpoint that reaches it. Enabling the key is only meaningful once both are in.

`SearchFor` and `TrashFor` now share the request flow, and the two OpenAPI specs share their common parts, since only the body type and the envelopes differ.

A dashboard may legitimately be named `trash`, so the dispatch test covers the standard object verbs on that path too.
