### PR TITLE
AuthN: propagate request context into auth and OAuth logs

### DIFF
--- a/pkg/login/social/connectors/azuread_oauth.go
+++ b/pkg/login/social/connectors/azuread_oauth.go
@@ -118,6 +118,7 @@ func NewAzureADProvider(info *social.OAuthInfo, cfg *setting.Cfg, orgRoleMapper 
 }
 
 func (s *SocialAzureAD) UserInfo(ctx context.Context, client *http.Client, token *oauth2.Token) (*social.BasicUserInfo, error) {
+	logger := s.log.FromContext(ctx)
 	s.reloadMutex.RLock()
 	defer s.reloadMutex.RUnlock()
 
@@ -146,7 +147,7 @@ func (s *SocialAzureAD) UserInfo(ctx context.Context, client *http.Client, token
 		return nil, fmt.Errorf("failed to extract groups: %w", err)
 	}
 
-	s.log.Debug("AzureAD OAuth: extracted groups", "email", email, "groups", fmt.Sprintf("%v", groups))
+	logger.Debug("AzureAD OAuth: extracted groups", "email", email, "groups", fmt.Sprintf("%v", groups))
 
 	userInfo := &social.BasicUserInfo{
 		Id:     claims.ID,
@@ -159,22 +160,22 @@ func (s *SocialAzureAD) UserInfo(ctx context.Context, client *http.Client, token
 	if !s.info.SkipOrgRoleSync {
 		directlyMappedRole, grafanaAdmin := s.extractRoleAndAdminOptional(claims)
 
-		s.log.Debug("AzureAD OAuth: extracted role", "email", email, "role", directlyMappedRole)
+		logger.Debug("AzureAD OAuth: extracted role", "email", email, "role", directlyMappedRole)
 
 		if s.info.AllowAssignGrafanaAdmin {
 			userInfo.IsGrafanaAdmin = &grafanaAdmin
 		}
 
-		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(s.orgMappingCfg, userInfo.Groups, directlyMappedRole)
+		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(ctx, s.orgMappingCfg, userInfo.Groups, directlyMappedRole)
 		if s.info.RoleAttributeStrict && len(userInfo.OrgRoles) == 0 {
 			return nil, errRoleAttributeStrictViolation.Errorf("could not evaluate any valid roles using IdP provided data")
 		}
 
-		s.log.Debug("AzureAD OAuth: mapped org roles", "email", email, "roles", fmt.Sprintf("%v", userInfo.OrgRoles))
+		logger.Debug("AzureAD OAuth: mapped org roles", "email", email, "roles", fmt.Sprintf("%v", userInfo.OrgRoles))
 	}
 
 	if s.info.AllowAssignGrafanaAdmin && s.info.SkipOrgRoleSync {
-		s.log.Debug("AllowAssignGrafanaAdmin and skipOrgRoleSync are both set, Grafana Admin role will not be synced, consider setting one or the other")
+		logger.Debug("AllowAssignGrafanaAdmin and skipOrgRoleSync are both set, Grafana Admin role will not be synced, consider setting one or the other")
 	}
 
 	if !s.isGroupMember(groups) {
@@ -210,7 +211,7 @@ func (s *SocialAzureAD) Exchange(ctx context.Context, code string, authOptions .
 	case social.ClientSecretPost:
 		// Default behavior for ClientSecretPost, no additional setup needed
 	default:
-		s.log.Debug("ClientAuthentication is not set. Using default client authentication method: none")
+		s.log.FromContext(ctx).Debug("ClientAuthentication is not set. Using default client authentication method: none")
 	}
 
 	// Default token exchange
@@ -266,13 +267,14 @@ type azureADManagedIdentityTokenSource struct {
 }
 
 func (s *azureADTokenSource) Token() (*oauth2.Token, error) {
-	s.log.Debug("Fetching Token with AzureAD Token Source and Workload Identity")
+	logger := s.log.FromContext(s.ctx)
+	logger.Debug("Fetching Token with AzureAD Token Source and Workload Identity")
 	if s.token.Valid() {
 		return s.token, nil
 	}
 
 	if s.token.RefreshToken == "" {
-		s.log.Warn("AzureADToken fetchToken failed: no refresh token available")
+		logger.Warn("AzureADToken fetchToken failed: no refresh token available")
 		return nil, fmt.Errorf("no refresh token available to refresh the access token")
 	}
 
@@ -293,18 +295,19 @@ func (s *azureADTokenSource) Token() (*oauth2.Token, error) {
 	if err != nil {
 		return nil, err
 	}
-	s.log.Debug("AzureADToken fetchToken completed", "expiry", token.Expiry)
+	logger.Debug("AzureADToken fetchToken completed", "expiry", token.Expiry)
 	return token, nil
 }
 
 func (s *azureADManagedIdentityTokenSource) Token() (*oauth2.Token, error) {
-	s.log.Debug("Fetching Token with AzureAD Token Source and Managed Identity")
+	logger := s.log.FromContext(s.ctx)
+	logger.Debug("Fetching Token with AzureAD Token Source and Managed Identity")
 	if s.token.Valid() {
 		return s.token, nil
 	}
 
 	if s.token.RefreshToken == "" {
-		s.log.Warn("AzureADManagedIdentityToken fetchToken failed: no refresh token available")
+		logger.Warn("AzureADManagedIdentityToken fetchToken failed: no refresh token available")
 		return nil, fmt.Errorf("no refresh token available to refresh the access token")
 	}
 
@@ -334,7 +337,7 @@ func (s *azureADManagedIdentityTokenSource) Token() (*oauth2.Token, error) {
 	if err != nil {
 		return nil, err
 	}
-	s.log.Debug("AzureADManagedIdentityToken fetchToken completed", "expiry", token.Expiry)
+	logger.Debug("AzureADManagedIdentityToken fetchToken completed", "expiry", token.Expiry)
 	return token, nil
 }
 
@@ -356,7 +359,7 @@ func fetchAzureADToken(ctx context.Context, log log.Logger, tokenURL string, par
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			log.Error("Failed to close response body", "error", err)
+			log.FromContext(ctx).Error("Failed to close response body", "error", err)
 		}
 	}()
 
@@ -366,7 +369,7 @@ func fetchAzureADToken(ctx context.Context, log log.Logger, tokenURL string, par
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		log.Error("oauth2: cannot fetch token", "status", resp.Status, "body", body)
+		log.FromContext(ctx).Error("oauth2: cannot fetch token", "status", resp.Status, "body", body)
 		return nil, fmt.Errorf("oauth2: cannot fetch token: %v", resp.Status)
 	}
 
@@ -479,6 +482,7 @@ func validateAllowedGroups(info *social.OAuthInfo, requester identity.Requester)
 }
 
 func (s *SocialAzureAD) validateClaims(ctx context.Context, client *http.Client, idTokenString string) (*azureClaims, error) {
+	logger := s.log.FromContext(ctx)
 	rawJSON, err := s.validateIDTokenSignatureWithURLs(ctx, client, idTokenString, s.getAzureJWKSURLs())
 	if err != nil {
 		return nil, fmt.Errorf("error validating id token signature: %w", err)
@@ -493,13 +497,13 @@ func (s *SocialAzureAD) validateClaims(ctx context.Context, client *http.Client,
 		return nil, &SocialError{"AzureAD OAuth: version 1.0 is not supported. Please ensure the auth_url and token_url are set to the v2.0 endpoints."}
 	}
 
-	s.log.Debug("Validating audience", "audience", claims.Audience, "client_id", s.ClientID)
+	logger.Debug("Validating audience", "audience", claims.Audience, "client_id", s.ClientID)
 	if claims.Audience != s.ClientID {
 		return nil, &SocialError{"AzureAD OAuth: audience mismatch"}
 	}
 
-	s.log.Debug("Validating tenant", "tenant", claims.TenantID, "allowed_tenants", s.allowedOrganizations)
-	if !s.isAllowedTenant(claims.TenantID) {
+	logger.Debug("Validating tenant", "tenant", claims.TenantID, "allowed_tenants", s.allowedOrganizations)
+	if !s.isAllowedTenant(logger, claims.TenantID) {
 		return nil, &SocialError{"AzureAD OAuth: tenant mismatch"}
 	}
 	return &claims, nil
@@ -623,8 +627,9 @@ type getAzureGroupResponse struct {
 //
 // See https://docs.microsoft.com/en-us/azure/active-directory/develop/id-tokens#groups-overage-claim
 func (s *SocialAzureAD) extractGroups(ctx context.Context, client *http.Client, claims *azureClaims, token *oauth2.Token) ([]string, error) {
+	logger := s.log.FromContext(ctx)
 	if !s.forceUseGraphAPI {
-		s.log.Debug("Checking the claim for groups")
+		logger.Debug("Checking the claim for groups")
 		if len(claims.Groups) > 0 {
 			return claims.Groups, nil
 		}
@@ -635,7 +640,7 @@ func (s *SocialAzureAD) extractGroups(ctx context.Context, client *http.Client, 
 	}
 
 	// Fallback to the Graph API
-	endpoint, errBuildGraphURI := s.groupsGraphAPIURL(claims, token)
+	endpoint, errBuildGraphURI := s.groupsGraphAPIURL(logger, claims, token)
 	if errBuildGraphURI != nil {
 		return nil, errBuildGraphURI
 	}
@@ -658,16 +663,16 @@ func (s *SocialAzureAD) extractGroups(ctx context.Context, client *http.Client, 
 
 	defer func() {
 		if err := res.Body.Close(); err != nil {
-			s.log.Warn("AzureAD OAuth: failed to close response body", "err", err)
+			logger.Warn("AzureAD OAuth: failed to close response body", "err", err)
 		}
 	}()
 
 	if res.StatusCode != http.StatusOK {
 		if res.StatusCode == http.StatusForbidden {
-			s.log.Warn("AzureAD OAuth: Token need GroupMember.Read.All permission to fetch all groups")
+			logger.Warn("AzureAD OAuth: Token need GroupMember.Read.All permission to fetch all groups")
 		} else {
 			body, _ := io.ReadAll(res.Body)
-			s.log.Warn("AzureAD OAuth: could not fetch user groups", "code", res.StatusCode, "body", string(body))
+			logger.Warn("AzureAD OAuth: could not fetch user groups", "code", res.StatusCode, "body", string(body))
 		}
 		return []string{}, nil
 	}
@@ -682,12 +687,12 @@ func (s *SocialAzureAD) extractGroups(ctx context.Context, client *http.Client, 
 
 // groupsGraphAPIURL retrieves the Microsoft Graph API URL to fetch user groups from the _claim_sources if present
 // otherwise it generates an handcrafted URL.
-func (s *SocialAzureAD) groupsGraphAPIURL(claims *azureClaims, token *oauth2.Token) (string, error) {
+func (s *SocialAzureAD) groupsGraphAPIURL(logger log.Logger, claims *azureClaims, token *oauth2.Token) (string, error) {
 	var endpoint string
 	// First check if an endpoint was specified in the claims
 	if claims.ClaimNames.Groups != "" {
 		endpoint = claims.ClaimSources[claims.ClaimNames.Groups].Endpoint
-		s.log.Debug(fmt.Sprintf("endpoint to fetch groups specified in the claims: %s", endpoint))
+		logger.Debug(fmt.Sprintf("endpoint to fetch groups specified in the claims: %s", endpoint))
 	}
 
 	// If no endpoint was specified or if the endpoints provided in _claim_source is pointing to the deprecated
@@ -710,7 +715,7 @@ func (s *SocialAzureAD) groupsGraphAPIURL(claims *azureClaims, token *oauth2.Tok
 		}
 
 		endpoint = fmt.Sprintf("https://graph.microsoft.com/v1.0/%s/users/%s/getMemberObjects", tenantID, claims.ID)
-		s.log.Debug(fmt.Sprintf("handcrafted endpoint to fetch groups: %s", endpoint))
+		logger.Debug(fmt.Sprintf("handcrafted endpoint to fetch groups: %s", endpoint))
 	}
 	return endpoint, nil
 }
@@ -728,9 +733,9 @@ func (s *SocialAzureAD) SupportBundleContent(bf *bytes.Buffer) error {
 	return s.getBaseSupportBundleContent(bf)
 }
 
-func (s *SocialAzureAD) isAllowedTenant(tenantID string) bool {
+func (s *SocialAzureAD) isAllowedTenant(logger log.Logger, tenantID string) bool {
 	if len(s.allowedOrganizations) == 0 {
-		s.log.Warn("No allowed organizations specified, all tenants are allowed. Configure allowed_organizations to restrict access")
+		logger.Warn("No allowed organizations specified, all tenants are allowed. Configure allowed_organizations to restrict access")
 		return true
 	}
 

--- a/pkg/login/social/connectors/common.go
+++ b/pkg/login/social/connectors/common.go
@@ -87,9 +87,11 @@ func (s *SocialBase) httpGet(ctx context.Context, client *http.Client, url strin
 		return nil, errDo
 	}
 
+	logger := s.log.FromContext(ctx)
+
 	defer func() {
 		if err := r.Body.Close(); err != nil {
-			s.log.Warn("Failed to close response body", "err", err)
+			logger.Warn("Failed to close response body", "err", err)
 		}
 	}()
 
@@ -104,7 +106,7 @@ func (s *SocialBase) httpGet(ctx context.Context, client *http.Client, url strin
 		return nil, fmt.Errorf("unsuccessful response status code %d: %s", r.StatusCode, string(response.Body))
 	}
 
-	s.log.Debug("HTTP GET", "url", url, "status", r.Status, "response_body", string(response.Body))
+	logger.Debug("HTTP GET", "url", url, "status", r.Status, "response_body", string(response.Body))
 
 	return response, nil
 }

--- a/pkg/login/social/connectors/generic_oauth.go
+++ b/pkg/login/social/connectors/generic_oauth.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/remotecache"
 	"github.com/grafana/grafana/pkg/login/social"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -226,19 +227,20 @@ func (info *UserInfoJson) String() string {
 }
 
 func (s *SocialGenericOAuth) UserInfo(ctx context.Context, client *http.Client, token *oauth2.Token) (*social.BasicUserInfo, error) {
+	logger := s.log.FromContext(ctx)
 	s.reloadMutex.RLock()
 	defer s.reloadMutex.RUnlock()
 
-	s.log.Debug("Getting user info")
+	logger.Debug("Getting user info")
 
 	// 1. Collect user info data from various sources
-	dataSources, err := s.collectUserInfoData(ctx, client, token)
+	dataSources, err := s.collectUserInfoData(ctx, client, token, logger)
 	if err != nil {
 		return nil, err
 	}
 
 	// 2. Build user info from collected data
-	userInfo, externalOrgs, err := s.buildUserInfo(dataSources)
+	userInfo, externalOrgs, err := s.buildUserInfo(logger, dataSources)
 	if err != nil {
 		return nil, err
 	}
@@ -255,12 +257,12 @@ func (s *SocialGenericOAuth) UserInfo(ctx context.Context, client *http.Client, 
 		return nil, err
 	}
 
-	s.log.Debug("User info result", "result", userInfo)
+	logger.Debug("User info result", "result", userInfo)
 	return userInfo, nil
 }
 
 // collectUserInfoData gathers user information from ID token, API, and access token
-func (s *SocialGenericOAuth) collectUserInfoData(ctx context.Context, client *http.Client, token *oauth2.Token) ([]*UserInfoJson, error) {
+func (s *SocialGenericOAuth) collectUserInfoData(ctx context.Context, client *http.Client, token *oauth2.Token, logger log.Logger) ([]*UserInfoJson, error) {
 	dataSources := make([]*UserInfoJson, 0, 3)
 
 	idTokenData, err := s.extractFromIDToken(ctx, token)
@@ -273,7 +275,7 @@ func (s *SocialGenericOAuth) collectUserInfoData(ctx context.Context, client *ht
 	if apiData := s.extractFromAPI(ctx, client); apiData != nil {
 		dataSources = append(dataSources, apiData)
 	}
-	if accessTokenData := s.extractFromAccessToken(token); accessTokenData != nil {
+	if accessTokenData := s.extractFromAccessToken(logger, token); accessTokenData != nil {
 		dataSources = append(dataSources, accessTokenData)
 	}
 
@@ -281,53 +283,53 @@ func (s *SocialGenericOAuth) collectUserInfoData(ctx context.Context, client *ht
 }
 
 // buildUserInfo constructs BasicUserInfo from collected data sources
-func (s *SocialGenericOAuth) buildUserInfo(dataSources []*UserInfoJson) (*social.BasicUserInfo, []string, error) {
+func (s *SocialGenericOAuth) buildUserInfo(logger log.Logger, dataSources []*UserInfoJson) (*social.BasicUserInfo, []string, error) {
 	userInfo := &social.BasicUserInfo{}
 	var externalOrgs []string
 
 	for _, data := range dataSources {
-		s.log.Debug("Processing external user info", "source", data.source, "data", data)
+		logger.Debug("Processing external user info", "source", data.source, "data", data)
 
-		s.extractBasicUserFields(userInfo, data)
+		s.extractBasicUserFields(logger, userInfo, data)
 
-		if err := s.extractRoleAndOrgs(userInfo, &externalOrgs, data); err != nil {
+		if err := s.extractRoleAndOrgs(logger, userInfo, &externalOrgs, data); err != nil {
 			return nil, nil, err
 		}
 
-		s.extractUserGroups(userInfo, data)
+		s.extractUserGroups(logger, userInfo, data)
 	}
 
 	return userInfo, externalOrgs, nil
 }
 
 // extractBasicUserFields extracts basic user fields (ID, Name, Login, Email) from data
-func (s *SocialGenericOAuth) extractBasicUserFields(userInfo *social.BasicUserInfo, data *UserInfoJson) {
+func (s *SocialGenericOAuth) extractBasicUserFields(logger log.Logger, userInfo *social.BasicUserInfo, data *UserInfoJson) {
 	if userInfo.Id == "" {
 		userInfo.Id = data.Sub
 	}
 
 	if userInfo.Name == "" {
-		userInfo.Name = s.extractUserName(data)
+		userInfo.Name = s.extractUserName(logger, data)
 	}
 
 	if userInfo.Login == "" {
-		userInfo.Login = s.extractLogin(data)
+		userInfo.Login = s.extractLogin(logger, data)
 	}
 
 	if userInfo.Email == "" {
-		userInfo.Email = s.extractEmail(data)
+		userInfo.Email = s.extractEmail(logger, data)
 		if userInfo.Email != "" {
-			s.log.Debug("Set user info email from extracted email", "email", userInfo.Email)
+			logger.Debug("Set user info email from extracted email", "email", userInfo.Email)
 		}
 	}
 }
 
 // extractRoleAndOrgs extracts role and organization information from data
-func (s *SocialGenericOAuth) extractRoleAndOrgs(userInfo *social.BasicUserInfo, externalOrgs *[]string, data *UserInfoJson) error {
+func (s *SocialGenericOAuth) extractRoleAndOrgs(logger log.Logger, userInfo *social.BasicUserInfo, externalOrgs *[]string, data *UserInfoJson) error {
 	if userInfo.Role == "" && !s.info.SkipOrgRoleSync {
 		role, grafanaAdmin, err := s.extractRoleAndAdminOptional(data.rawJSON, []string{})
 		if err != nil {
-			s.log.Warn("Failed to extract role", "err", err)
+			logger.Warn("Failed to extract role", "err", err)
 		} else {
 			userInfo.Role = role
 			if s.info.AllowAssignGrafanaAdmin {
@@ -339,7 +341,7 @@ func (s *SocialGenericOAuth) extractRoleAndOrgs(userInfo *social.BasicUserInfo, 
 	if len(*externalOrgs) == 0 && !s.info.SkipOrgRoleSync {
 		orgs, err := s.extractOrgs(data.rawJSON)
 		if err != nil {
-			s.log.Warn("Failed to extract orgs", "err", err)
+			logger.Warn("Failed to extract orgs", "err", err)
 			return err
 		}
 		*externalOrgs = orgs
@@ -349,13 +351,13 @@ func (s *SocialGenericOAuth) extractRoleAndOrgs(userInfo *social.BasicUserInfo, 
 }
 
 // extractUserGroups extracts group information from data
-func (s *SocialGenericOAuth) extractUserGroups(userInfo *social.BasicUserInfo, data *UserInfoJson) {
+func (s *SocialGenericOAuth) extractUserGroups(logger log.Logger, userInfo *social.BasicUserInfo, data *UserInfoJson) {
 	if len(userInfo.Groups) == 0 {
 		groups, err := s.extractGroups(data)
 		if err != nil {
-			s.log.Warn("Failed to extract groups", "err", err)
+			logger.Warn("Failed to extract groups", "err", err)
 		} else if len(groups) > 0 {
-			s.log.Debug("Setting user info groups from extracted groups")
+			logger.Debug("Setting user info groups from extracted groups")
 			userInfo.Groups = groups
 		}
 	}
@@ -363,15 +365,16 @@ func (s *SocialGenericOAuth) extractUserGroups(userInfo *social.BasicUserInfo, d
 
 // postProcessUserInfo handles post-processing of user info (org roles, private email, etc.)
 func (s *SocialGenericOAuth) postProcessUserInfo(ctx context.Context, client *http.Client, userInfo *social.BasicUserInfo, externalOrgs []string) error {
+	logger := s.log.FromContext(ctx)
 	if !s.info.SkipOrgRoleSync {
-		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(s.orgMappingCfg, externalOrgs, userInfo.Role)
+		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(ctx, s.orgMappingCfg, externalOrgs, userInfo.Role)
 		if s.info.RoleAttributeStrict && len(userInfo.OrgRoles) == 0 {
 			return errRoleAttributeStrictViolation.Errorf("could not evaluate any valid roles using IdP provided data")
 		}
 	}
 
 	if s.info.AllowAssignGrafanaAdmin && s.info.SkipOrgRoleSync {
-		s.log.Debug("AllowAssignGrafanaAdmin and skipOrgRoleSync are both set, Grafana Admin role will not be synced, consider setting one or the other")
+		logger.Debug("AllowAssignGrafanaAdmin and skipOrgRoleSync are both set, Grafana Admin role will not be synced, consider setting one or the other")
 	}
 
 	if s.canFetchPrivateEmail(userInfo) {
@@ -380,11 +383,11 @@ func (s *SocialGenericOAuth) postProcessUserInfo(ctx context.Context, client *ht
 			return err
 		}
 		userInfo.Email = email
-		s.log.Debug("Setting email from fetched private email", "email", userInfo.Email)
+		logger.Debug("Setting email from fetched private email", "email", userInfo.Email)
 	}
 
 	if userInfo.Login == "" {
-		s.log.Debug("Defaulting to using email for user info login", "email", userInfo.Email)
+		logger.Debug("Defaulting to using email for user info login", "email", userInfo.Email)
 		userInfo.Login = userInfo.Email
 	}
 
@@ -413,23 +416,24 @@ func (s *SocialGenericOAuth) canFetchPrivateEmail(userinfo *social.BasicUserInfo
 }
 
 func (s *SocialGenericOAuth) extractFromIDToken(ctx context.Context, token *oauth2.Token) (*UserInfoJson, error) {
-	s.log.Debug("Extracting user info from OAuth ID token")
+	logger := s.log.FromContext(ctx)
+	logger.Debug("Extracting user info from OAuth ID token")
 
 	idTokenAttribute := "id_token"
 	if s.idTokenAttributeName != "" {
 		idTokenAttribute = s.idTokenAttributeName
-		s.log.Debug("Using custom id_token attribute name", "attribute_name", idTokenAttribute)
+		logger.Debug("Using custom id_token attribute name", "attribute_name", idTokenAttribute)
 	}
 
 	idToken := token.Extra(idTokenAttribute)
 	if idToken == nil {
-		s.log.Debug("No id_token found", "token", fmt.Sprintf("%+v", token))
+		logger.Debug("No id_token found", "token", fmt.Sprintf("%+v", token))
 		return nil, nil
 	}
 
 	idTokenString, ok := idToken.(string)
 	if !ok {
-		s.log.Warn("ID token is not a string", "token", fmt.Sprintf("%+v", token))
+		logger.Warn("ID token is not a string", "token", fmt.Sprintf("%+v", token))
 		return nil, nil
 	}
 
@@ -441,70 +445,71 @@ func (s *SocialGenericOAuth) extractFromIDToken(ctx context.Context, token *oaut
 		// create a dedicated client for the JWKS retrieval, without a token source
 		rawJSON, err = s.validateIDTokenSignature(ctx, http.DefaultClient, idTokenString, s.info.JwkSetURL)
 		if err != nil {
-			s.log.Warn("Error validating ID token signature", "error", err)
+			logger.Warn("Error validating ID token signature", "error", err)
 			return nil, err
 		}
 	} else {
 		// Otherwise, just extract the payload without signature validation
 		rawJSON, err = s.retrieveRawJWTPayload(idTokenString)
 		if err != nil {
-			s.log.Warn("Error retrieving id_token payload", "error", err, "token", fmt.Sprintf("%+v", token))
+			logger.Warn("Error retrieving id_token payload", "error", err, "token", fmt.Sprintf("%+v", token))
 			return nil, nil
 		}
 	}
 
-	return s.parseUserInfoFromJSON(rawJSON, "id_token"), nil
+	return s.parseUserInfoFromJSON(logger, rawJSON, "id_token"), nil
 }
 
-func (s *SocialGenericOAuth) extractFromAccessToken(token *oauth2.Token) *UserInfoJson {
-	s.log.Debug("Extracting user info from OAuth access token")
+func (s *SocialGenericOAuth) extractFromAccessToken(logger log.Logger, token *oauth2.Token) *UserInfoJson {
+	logger.Debug("Extracting user info from OAuth access token")
 
 	accessToken := token.AccessToken
 	if accessToken == "" {
-		s.log.Debug("No access token found")
+		logger.Debug("No access token found")
 		return nil
 	}
 
 	rawJSON, err := s.retrieveRawJWTPayload(accessToken)
 	if err != nil {
-		s.log.Warn("Error retrieving access token payload", "error", err)
+		logger.Warn("Error retrieving access token payload", "error", err)
 		return nil
 	}
 
-	return s.parseUserInfoFromJSON(rawJSON, "access_token")
+	return s.parseUserInfoFromJSON(logger, rawJSON, "access_token")
 }
 
 // parseUserInfoFromJSON is a helper method to parse UserInfoJson from raw JSON and source
-func (s *SocialGenericOAuth) parseUserInfoFromJSON(rawJSON []byte, source string) *UserInfoJson {
+func (s *SocialGenericOAuth) parseUserInfoFromJSON(logger log.Logger, rawJSON []byte, source string) *UserInfoJson {
 	var data UserInfoJson
 	if err := json.Unmarshal(rawJSON, &data); err != nil {
-		s.log.Error("Error decoding user info JSON", "raw_json", string(rawJSON), "error", err, "source", source)
+		logger.Error("Error decoding user info JSON", "raw_json", string(rawJSON), "error", err, "source", source)
 		return nil
 	}
 
 	data.rawJSON = rawJSON
 	data.source = source
-	s.log.Debug("Parsed user info from JSON", "raw_json", string(rawJSON), "data", data.String(), "source", source)
+	logger.Debug("Parsed user info from JSON", "raw_json", string(rawJSON), "data", data.String(), "source", source)
 	return &data
 }
 
 func (s *SocialGenericOAuth) extractFromAPI(ctx context.Context, client *http.Client) *UserInfoJson {
-	s.log.Debug("Getting user info from API")
+	logger := s.log.FromContext(ctx)
+	logger.Debug("Getting user info from API")
 	if s.info.ApiUrl == "" {
-		s.log.Debug("No api url configured")
+		logger.Debug("No api url configured")
 		return nil
 	}
 
 	rawUserInfoResponse, err := s.httpGet(ctx, client, s.info.ApiUrl)
 	if err != nil {
-		s.log.Debug("Error getting user info from API", "url", s.info.ApiUrl, "error", err)
+		logger.Debug("Error getting user info from API", "url", s.info.ApiUrl, "error", err)
 		return nil
 	}
 
-	return s.parseUserInfoFromJSON(rawUserInfoResponse.Body, "API")
+	return s.parseUserInfoFromJSON(logger, rawUserInfoResponse.Body, "API")
 }
 
-func (s *SocialGenericOAuth) extractEmail(data *UserInfoJson) string {
+func (s *SocialGenericOAuth) extractEmail(logger log.Logger, data *UserInfoJson) string {
 	if data.Email != "" {
 		return data.Email
 	}
@@ -512,7 +517,7 @@ func (s *SocialGenericOAuth) extractEmail(data *UserInfoJson) string {
 	if s.emailAttributePath != "" {
 		email, err := util.SearchJSONForStringAttr(s.emailAttributePath, data.rawJSON)
 		if err != nil {
-			s.log.Error("Failed to search JSON for attribute", "error", err)
+			logger.Error("Failed to search JSON for attribute", "error", err)
 		} else if email != "" {
 			return email
 		}
@@ -528,23 +533,23 @@ func (s *SocialGenericOAuth) extractEmail(data *UserInfoJson) string {
 		if emailErr == nil {
 			return emailAddr.Address
 		}
-		s.log.Debug("Failed to parse e-mail address", "error", emailErr.Error())
+		logger.Debug("Failed to parse e-mail address", "error", emailErr.Error())
 	}
 
 	return ""
 }
 
-func (s *SocialGenericOAuth) extractLogin(data *UserInfoJson) string {
+func (s *SocialGenericOAuth) extractLogin(logger log.Logger, data *UserInfoJson) string {
 	if data.Login != "" {
-		s.log.Debug("Setting user info login from login field", "login", data.Login)
+		logger.Debug("Setting user info login from login field", "login", data.Login)
 		return data.Login
 	}
 
 	if s.loginAttributePath != "" {
-		s.log.Debug("Searching for login among JSON", "loginAttributePath", s.loginAttributePath)
+		logger.Debug("Searching for login among JSON", "loginAttributePath", s.loginAttributePath)
 		login, err := util.SearchJSONForStringAttr(s.loginAttributePath, data.rawJSON)
 		if err != nil {
-			s.log.Error("Failed to search JSON for login attribute", "error", err)
+			logger.Error("Failed to search JSON for login attribute", "error", err)
 		}
 
 		if login != "" {
@@ -553,35 +558,35 @@ func (s *SocialGenericOAuth) extractLogin(data *UserInfoJson) string {
 	}
 
 	if data.Username != "" {
-		s.log.Debug("Setting user info login from username field", "username", data.Username)
+		logger.Debug("Setting user info login from username field", "username", data.Username)
 		return data.Username
 	}
 
 	return ""
 }
 
-func (s *SocialGenericOAuth) extractUserName(data *UserInfoJson) string {
+func (s *SocialGenericOAuth) extractUserName(logger log.Logger, data *UserInfoJson) string {
 	if s.nameAttributePath != "" {
 		name, err := util.SearchJSONForStringAttr(s.nameAttributePath, data.rawJSON)
 		if err != nil {
-			s.log.Error("Failed to search JSON for attribute", "error", err)
+			logger.Error("Failed to search JSON for attribute", "error", err)
 		} else if name != "" {
-			s.log.Debug("Setting user info name from nameAttributePath", "nameAttributePath", s.nameAttributePath)
+			logger.Debug("Setting user info name from nameAttributePath", "nameAttributePath", s.nameAttributePath)
 			return name
 		}
 	}
 
 	if data.Name != "" {
-		s.log.Debug("Setting user info name from name field")
+		logger.Debug("Setting user info name from name field")
 		return data.Name
 	}
 
 	if data.DisplayName != "" {
-		s.log.Debug("Setting user info name from display name field")
+		logger.Debug("Setting user info name from display name field")
 		return data.DisplayName
 	}
 
-	s.log.Debug("Unable to find user info name")
+	logger.Debug("Unable to find user info name")
 	return ""
 }
 
@@ -594,6 +599,7 @@ func (s *SocialGenericOAuth) extractGroups(data *UserInfoJson) ([]string, error)
 }
 
 func (s *SocialGenericOAuth) fetchPrivateEmail(ctx context.Context, client *http.Client) (string, error) {
+	logger := s.log.FromContext(ctx)
 	type Record struct {
 		Email       string `json:"email"`
 		Primary     bool   `json:"primary"`
@@ -604,7 +610,7 @@ func (s *SocialGenericOAuth) fetchPrivateEmail(ctx context.Context, client *http
 
 	response, err := s.httpGet(ctx, client, s.info.ApiUrl+"/emails")
 	if err != nil {
-		s.log.Error("Error getting email address", "url", s.info.ApiUrl+"/emails", "error", err)
+		logger.Error("Error getting email address", "url", s.info.ApiUrl+"/emails", "error", err)
 		return "", fmt.Errorf("%v: %w", "Error getting email address", err)
 	}
 
@@ -618,14 +624,14 @@ func (s *SocialGenericOAuth) fetchPrivateEmail(ctx context.Context, client *http
 
 		err = json.Unmarshal(response.Body, &data)
 		if err != nil {
-			s.log.Error("Error decoding email addresses response", "raw_json", string(response.Body), "error", err)
+			logger.Error("Error decoding email addresses response", "raw_json", string(response.Body), "error", err)
 			return "", fmt.Errorf("%v: %w", "Error decoding email addresses response", err)
 		}
 
 		records = data.Values
 	}
 
-	s.log.Debug("Received email addresses", "emails", records)
+	logger.Debug("Received email addresses", "emails", records)
 
 	var email = ""
 	for _, record := range records {
@@ -635,7 +641,7 @@ func (s *SocialGenericOAuth) fetchPrivateEmail(ctx context.Context, client *http
 		}
 	}
 
-	s.log.Debug("Using email address", "email", email)
+	logger.Debug("Using email address", "email", email)
 
 	return email, nil
 }
@@ -651,13 +657,14 @@ func (s *SocialGenericOAuth) fetchTeamMemberships(ctx context.Context, client *h
 	}
 
 	if err == nil {
-		s.log.Debug("Received team memberships", "ids", ids)
+		s.log.FromContext(ctx).Debug("Received team memberships", "ids", ids)
 	}
 
 	return ids, err
 }
 
 func (s *SocialGenericOAuth) fetchTeamMembershipsFromDeprecatedTeamsUrl(ctx context.Context, client *http.Client) ([]string, error) {
+	logger := s.log.FromContext(ctx)
 	var ids []string
 
 	type Record struct {
@@ -666,7 +673,7 @@ func (s *SocialGenericOAuth) fetchTeamMembershipsFromDeprecatedTeamsUrl(ctx cont
 
 	response, err := s.httpGet(ctx, client, s.info.ApiUrl+"/teams")
 	if err != nil {
-		s.log.Error("Error getting team memberships", "url", s.info.ApiUrl+"/teams", "error", err)
+		logger.Error("Error getting team memberships", "url", s.info.ApiUrl+"/teams", "error", err)
 		return []string{}, err
 	}
 
@@ -674,7 +681,7 @@ func (s *SocialGenericOAuth) fetchTeamMembershipsFromDeprecatedTeamsUrl(ctx cont
 
 	err = json.Unmarshal(response.Body, &records)
 	if err != nil {
-		s.log.Error("Error decoding team memberships response", "raw_json", string(response.Body), "error", err)
+		logger.Error("Error decoding team memberships response", "raw_json", string(response.Body), "error", err)
 		return []string{}, err
 	}
 
@@ -693,7 +700,7 @@ func (s *SocialGenericOAuth) fetchTeamMembershipsFromTeamsUrl(ctx context.Contex
 
 	response, err := s.httpGet(ctx, client, s.teamsUrl)
 	if err != nil {
-		s.log.Error("Error getting team memberships", "url", s.teamsUrl, "error", err)
+		s.log.FromContext(ctx).Error("Error getting team memberships", "url", s.teamsUrl, "error", err)
 		return nil, err
 	}
 
@@ -701,13 +708,14 @@ func (s *SocialGenericOAuth) fetchTeamMembershipsFromTeamsUrl(ctx context.Contex
 }
 
 func (s *SocialGenericOAuth) fetchOrganizations(ctx context.Context, client *http.Client) ([]string, bool) {
+	logger := s.log.FromContext(ctx)
 	type Record struct {
 		Login string `json:"login"`
 	}
 
 	response, err := s.httpGet(ctx, client, s.info.ApiUrl+"/orgs")
 	if err != nil {
-		s.log.Error("Error getting organizations", "url", s.info.ApiUrl+"/orgs", "error", err)
+		logger.Error("Error getting organizations", "url", s.info.ApiUrl+"/orgs", "error", err)
 		return nil, false
 	}
 
@@ -715,7 +723,7 @@ func (s *SocialGenericOAuth) fetchOrganizations(ctx context.Context, client *htt
 
 	err = json.Unmarshal(response.Body, &records)
 	if err != nil {
-		s.log.Error("Error decoding organization response", "response", string(response.Body), "error", err)
+		logger.Error("Error decoding organization response", "response", string(response.Body), "error", err)
 		return nil, false
 	}
 
@@ -724,7 +732,7 @@ func (s *SocialGenericOAuth) fetchOrganizations(ctx context.Context, client *htt
 		logins[i] = record.Login
 	}
 
-	s.log.Debug("Received organizations", "logins", logins)
+	logger.Debug("Received organizations", "logins", logins)
 
 	return logins, true
 }

--- a/pkg/login/social/connectors/github_oauth.go
+++ b/pkg/login/social/connectors/github_oauth.go
@@ -304,6 +304,7 @@ func (s *SocialGithub) fetchOrganizations(ctx context.Context, client *http.Clie
 }
 
 func (s *SocialGithub) UserInfo(ctx context.Context, client *http.Client, token *oauth2.Token) (*social.BasicUserInfo, error) {
+	logger := s.log.FromContext(ctx)
 	s.reloadMutex.RLock()
 	defer s.reloadMutex.RUnlock()
 
@@ -337,7 +338,7 @@ func (s *SocialGithub) UserInfo(ctx context.Context, client *http.Client, token 
 	}
 
 	if s.info.AllowAssignGrafanaAdmin && s.info.SkipOrgRoleSync {
-		s.log.Debug("AllowAssignGrafanaAdmin and skipOrgRoleSync are both set, Grafana Admin role will not be synced, consider setting one or the other")
+		logger.Debug("AllowAssignGrafanaAdmin and skipOrgRoleSync are both set, Grafana Admin role will not be synced, consider setting one or the other")
 	}
 
 	var directlyMappedRole org.RoleType
@@ -346,14 +347,14 @@ func (s *SocialGithub) UserInfo(ctx context.Context, client *http.Client, token 
 		var grafanaAdmin bool
 		directlyMappedRole, grafanaAdmin, err = s.extractRoleAndAdminOptional(response.Body, userInfo.Groups)
 		if err != nil {
-			s.log.Warn("Failed to extract role", "err", err)
+			logger.Warn("Failed to extract role", "err", err)
 		}
 
 		if s.info.AllowAssignGrafanaAdmin {
 			userInfo.IsGrafanaAdmin = &grafanaAdmin
 		}
 
-		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(s.orgMappingCfg, userInfo.Groups, directlyMappedRole)
+		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(ctx, s.orgMappingCfg, userInfo.Groups, directlyMappedRole)
 		if s.info.RoleAttributeStrict && len(userInfo.OrgRoles) == 0 {
 			return nil, errRoleAttributeStrictViolation.Errorf("could not evaluate any valid roles using IdP provided data")
 		}

--- a/pkg/login/social/connectors/gitlab_oauth.go
+++ b/pkg/login/social/connectors/gitlab_oauth.go
@@ -120,19 +120,20 @@ func (s *SocialGitlab) getGroups(ctx context.Context, client *http.Client) []str
 
 // getGroupsPage returns groups and link to the next page if response is paginated
 func (s *SocialGitlab) getGroupsPage(ctx context.Context, client *http.Client, nextPage int) ([]string, *int) {
+	logger := s.log.FromContext(ctx)
 	type Group struct {
 		FullPath string `json:"full_path"`
 	}
 
 	groupURL, err := url.JoinPath(s.info.ApiUrl, "/groups")
 	if err != nil {
-		s.log.Error("Error joining GitLab API URL", "err", err)
+		logger.Error("Error joining GitLab API URL", "err", err)
 		return nil, nil
 	}
 
 	parsedUrl, err := url.Parse(groupURL)
 	if err != nil {
-		s.log.Error("Error parsing GitLab API URL", "err", err)
+		logger.Error("Error parsing GitLab API URL", "err", err)
 		return nil, nil
 	}
 
@@ -144,7 +145,7 @@ func (s *SocialGitlab) getGroupsPage(ctx context.Context, client *http.Client, n
 
 	response, err := s.httpGet(ctx, client, parsedUrl.String())
 	if err != nil {
-		s.log.Error("Error getting groups from GitLab API", "err", err)
+		logger.Error("Error getting groups from GitLab API", "err", err)
 		return nil, nil
 	}
 
@@ -153,7 +154,7 @@ func (s *SocialGitlab) getGroupsPage(ctx context.Context, client *http.Client, n
 	if respSizeString != "" {
 		foundSize, err := strconv.Atoi(respSizeString)
 		if err != nil {
-			s.log.Warn("Error parsing X-Total header from GitLab API", "err", err)
+			logger.Warn("Error parsing X-Total header from GitLab API", "err", err)
 		} else {
 			respSize = foundSize
 		}
@@ -161,7 +162,7 @@ func (s *SocialGitlab) getGroupsPage(ctx context.Context, client *http.Client, n
 
 	groups := make([]Group, 0, respSize)
 	if err := json.Unmarshal(response.Body, &groups); err != nil {
-		s.log.Error("Error parsing JSON from GitLab API", "err", err)
+		logger.Error("Error parsing JSON from GitLab API", "err", err)
 		return nil, nil
 	}
 
@@ -175,7 +176,7 @@ func (s *SocialGitlab) getGroupsPage(ctx context.Context, client *http.Client, n
 	if nextString != "" {
 		foundNext, err := strconv.Atoi(nextString)
 		if err != nil {
-			s.log.Warn("Error parsing X-Next-Page header from GitLab API", "err", err)
+			logger.Warn("Error parsing X-Next-Page header from GitLab API", "err", err)
 		} else {
 			next = &foundNext
 		}
@@ -185,6 +186,7 @@ func (s *SocialGitlab) getGroupsPage(ctx context.Context, client *http.Client, n
 }
 
 func (s *SocialGitlab) UserInfo(ctx context.Context, client *http.Client, token *oauth2.Token) (*social.BasicUserInfo, error) {
+	logger := s.log.FromContext(ctx)
 	s.reloadMutex.RLock()
 	defer s.reloadMutex.RUnlock()
 
@@ -211,20 +213,20 @@ func (s *SocialGitlab) UserInfo(ctx context.Context, client *http.Client, token 
 	}
 
 	if s.info.AllowAssignGrafanaAdmin && s.info.SkipOrgRoleSync {
-		s.log.Debug("AllowAssignGrafanaAdmin and skipOrgRoleSync are both set, Grafana Admin role will not be synced, consider setting one or the other")
+		logger.Debug("AllowAssignGrafanaAdmin and skipOrgRoleSync are both set, Grafana Admin role will not be synced, consider setting one or the other")
 	}
 
 	if !s.info.SkipOrgRoleSync {
 		directlyMappedRole, grafanaAdmin, err := s.extractRoleAndAdminOptional(data.raw, userInfo.Groups)
 		if err != nil {
-			s.log.Warn("Failed to extract role", "err", err)
+			logger.Warn("Failed to extract role", "err", err)
 		}
 
 		if s.info.AllowAssignGrafanaAdmin {
 			userInfo.IsGrafanaAdmin = &grafanaAdmin
 		}
 
-		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(s.orgMappingCfg, userInfo.Groups, directlyMappedRole)
+		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(ctx, s.orgMappingCfg, userInfo.Groups, directlyMappedRole)
 		if s.info.RoleAttributeStrict && len(userInfo.OrgRoles) == 0 {
 			return nil, errRoleAttributeStrictViolation.Errorf("could not evaluate any valid roles using IdP provided data")
 		}
@@ -267,24 +269,25 @@ func (s *SocialGitlab) extractFromAPI(ctx context.Context, client *http.Client, 
 	}
 
 	if s.cfg.Env == setting.Dev {
-		s.log.Debug("Resolved ID", "data", fmt.Sprintf("%+v", idData))
+		s.log.FromContext(ctx).Debug("Resolved ID", "data", fmt.Sprintf("%+v", idData))
 	}
 
 	return idData, nil
 }
 
 func (s *SocialGitlab) extractFromToken(ctx context.Context, client *http.Client, token *oauth2.Token) (*userData, error) {
-	s.log.Debug("Extracting user info from OAuth token")
+	logger := s.log.FromContext(ctx)
+	logger.Debug("Extracting user info from OAuth token")
 
 	idToken := token.Extra("id_token")
 	if idToken == nil {
-		s.log.Debug("No id_token found, defaulting to API access", "token", token)
+		logger.Debug("No id_token found, defaulting to API access", "token", token)
 		return nil, nil
 	}
 
 	idTokenString, ok := idToken.(string)
 	if !ok {
-		s.log.Warn("ID token is not a string", "token", fmt.Sprintf("%+v", idToken))
+		logger.Warn("ID token is not a string", "token", fmt.Sprintf("%+v", idToken))
 		return nil, nil
 	}
 
@@ -295,22 +298,22 @@ func (s *SocialGitlab) extractFromToken(ctx context.Context, client *http.Client
 	if s.info.ValidateIDToken && s.info.JwkSetURL != "" {
 		rawJSON, err = s.validateIDTokenSignature(ctx, http.DefaultClient, idTokenString, s.info.JwkSetURL)
 		if err != nil {
-			s.log.Warn("Error validating ID token signature", "error", err)
+			logger.Warn("Error validating ID token signature", "error", err)
 			return nil, err
 		}
 	} else {
 		// Otherwise, just extract the payload without signature validation
 		rawJSON, err = s.retrieveRawJWTPayload(idTokenString)
 		if err != nil {
-			s.log.Warn("Error retrieving id_token", "error", err, "token", fmt.Sprintf("%+v", idToken))
+			logger.Warn("Error retrieving id_token", "error", err, "token", fmt.Sprintf("%+v", idToken))
 			return nil, nil
 		}
 	}
 
-	s.log.Debug("Received id_token", "raw_json", string(rawJSON))
+	logger.Debug("Received id_token", "raw_json", string(rawJSON))
 	var data userData
 	if err := json.Unmarshal(rawJSON, &data); err != nil {
-		s.log.Warn("Error decoding id_token JSON", "raw_json", string(rawJSON), "error", err)
+		logger.Warn("Error decoding id_token JSON", "raw_json", string(rawJSON), "error", err)
 		return nil, nil
 	}
 
@@ -321,16 +324,16 @@ func (s *SocialGitlab) extractFromToken(ctx context.Context, client *http.Client
 
 	userInfo, err := s.retrieveUserInfo(ctx, client)
 	if err != nil {
-		s.log.Warn("Error retrieving groups from userinfo. Using only token provided groups", "error", err)
+		logger.Warn("Error retrieving groups from userinfo. Using only token provided groups", "error", err)
 	} else {
-		s.log.Debug("Retrieved groups from userinfo", "sub", userInfo.Sub,
+		logger.Debug("Retrieved groups from userinfo", "sub", userInfo.Sub,
 			"original_groups", data.Groups, "groups", userInfo.Groups)
 		data.Groups = userInfo.Groups
 	}
 
 	data.raw = rawJSON
 
-	s.log.Debug("Resolved user data", "data", fmt.Sprintf("%+v", data))
+	logger.Debug("Resolved user data", "data", fmt.Sprintf("%+v", data))
 	return &data, nil
 }
 

--- a/pkg/login/social/connectors/google_oauth.go
+++ b/pkg/login/social/connectors/google_oauth.go
@@ -119,6 +119,7 @@ func (s *SocialGoogle) Reload(ctx context.Context, settings ssoModels.SSOSetting
 }
 
 func (s *SocialGoogle) UserInfo(ctx context.Context, client *http.Client, token *oauth2.Token) (*social.BasicUserInfo, error) {
+	logger := s.log.FromContext(ctx)
 	s.reloadMutex.RLock()
 	defer s.reloadMutex.RUnlock()
 
@@ -149,7 +150,7 @@ func (s *SocialGoogle) UserInfo(ctx context.Context, client *http.Client, token 
 
 	groups, errPage := s.retrieveGroups(ctx, client, data)
 	if errPage != nil {
-		s.log.Warn("Error retrieving groups", "error", errPage)
+		logger.Warn("Error retrieving groups", "error", errPage)
 	}
 
 	if !s.isGroupMember(groups) {
@@ -165,26 +166,26 @@ func (s *SocialGoogle) UserInfo(ctx context.Context, client *http.Client, token 
 	}
 
 	if s.info.AllowAssignGrafanaAdmin && s.info.SkipOrgRoleSync {
-		s.log.Debug("AllowAssignGrafanaAdmin and skipOrgRoleSync are both set, Grafana Admin role will not be synced, consider setting one or the other")
+		logger.Debug("AllowAssignGrafanaAdmin and skipOrgRoleSync are both set, Grafana Admin role will not be synced, consider setting one or the other")
 	}
 
 	if !s.info.SkipOrgRoleSync {
 		directlyMappedRole, grafanaAdmin, err := s.extractRoleAndAdminOptional(data.rawJSON, userInfo.Groups)
 		if err != nil {
-			s.log.Warn("Failed to extract role", "err", err)
+			logger.Warn("Failed to extract role", "err", err)
 		}
 
 		if s.info.AllowAssignGrafanaAdmin {
 			userInfo.IsGrafanaAdmin = &grafanaAdmin
 		}
 
-		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(s.orgMappingCfg, userInfo.Groups, directlyMappedRole)
+		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(ctx, s.orgMappingCfg, userInfo.Groups, directlyMappedRole)
 		if s.info.RoleAttributeStrict && len(userInfo.OrgRoles) == 0 {
 			return nil, errRoleAttributeStrictViolation.Errorf("could not evaluate any valid roles using IdP provided data")
 		}
 	}
 
-	s.log.Debug("Resolved user info", "data", fmt.Sprintf("%+v", userInfo))
+	logger.Debug("Resolved user info", "data", fmt.Sprintf("%+v", userInfo))
 
 	return userInfo, nil
 }
@@ -244,17 +245,18 @@ func (s *SocialGoogle) AuthCodeURL(state string, opts ...oauth2.AuthCodeOption) 
 }
 
 func (s *SocialGoogle) extractFromToken(ctx context.Context, _ *http.Client, token *oauth2.Token) (*googleUserData, error) {
-	s.log.Debug("Extracting user info from OAuth token")
+	logger := s.log.FromContext(ctx)
+	logger.Debug("Extracting user info from OAuth token")
 
 	idToken := token.Extra("id_token")
 	if idToken == nil {
-		s.log.Debug("No id_token found, defaulting to API access", "token", token)
+		logger.Debug("No id_token found, defaulting to API access", "token", token)
 		return nil, nil
 	}
 
 	idTokenString, ok := idToken.(string)
 	if !ok {
-		s.log.Warn("ID token is not a string", "token", fmt.Sprintf("%+v", idToken))
+		logger.Warn("ID token is not a string", "token", fmt.Sprintf("%+v", idToken))
 		return nil, nil
 	}
 
@@ -265,20 +267,20 @@ func (s *SocialGoogle) extractFromToken(ctx context.Context, _ *http.Client, tok
 	if s.info.ValidateIDToken && s.info.JwkSetURL != "" {
 		rawJSON, err = s.validateIDTokenSignature(ctx, http.DefaultClient, idTokenString, s.info.JwkSetURL)
 		if err != nil {
-			s.log.Warn("Error validating ID token signature", "error", err)
+			logger.Warn("Error validating ID token signature", "error", err)
 			return nil, err
 		}
 	} else {
 		// Otherwise, just extract the payload without signature validation
 		rawJSON, err = s.retrieveRawJWTPayload(idTokenString)
 		if err != nil {
-			s.log.Warn("Error retrieving id_token", "error", err, "token", fmt.Sprintf("%+v", idToken))
+			logger.Warn("Error retrieving id_token", "error", err, "token", fmt.Sprintf("%+v", idToken))
 			return nil, nil
 		}
 	}
 
 	if s.cfg.Env == setting.Dev {
-		s.log.Debug("Received id_token", "raw_json", string(rawJSON))
+		logger.Debug("Received id_token", "raw_json", string(rawJSON))
 	}
 
 	var data googleUserData
@@ -303,7 +305,7 @@ type googleGroupResp struct {
 }
 
 func (s *SocialGoogle) retrieveGroups(ctx context.Context, client *http.Client, userData *googleUserData) ([]string, error) {
-	s.log.Debug("Retrieving groups", "scopes", s.Scopes)
+	s.log.FromContext(ctx).Debug("Retrieving groups", "scopes", s.Scopes)
 	if !slices.Contains(s.Scopes, googleIAMScope) {
 		return nil, nil
 	}
@@ -335,7 +337,7 @@ func (s *SocialGoogle) getGroupsPage(ctx context.Context, client *http.Client, u
 		url = fmt.Sprintf("%s&pageToken=%s", url, nextPageToken)
 	}
 
-	s.log.Debug("Retrieving groups", "url", url)
+	s.log.FromContext(ctx).Debug("Retrieving groups", "url", url)
 	resp, err := s.httpGet(ctx, client, url)
 	if err != nil {
 		return nil, fmt.Errorf("error getting groups: %s", err)

--- a/pkg/login/social/connectors/grafana_com_oauth.go
+++ b/pkg/login/social/connectors/grafana_com_oauth.go
@@ -163,7 +163,7 @@ func (s *SocialGrafanaCom) UserInfo(ctx context.Context, client *http.Client, _ 
 	}
 
 	if !s.info.SkipOrgRoleSync {
-		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(NewMappingConfiguration(map[string]map[int64]org.RoleType{}, false), nil, identity.RoleType(data.Role))
+		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(ctx, NewMappingConfiguration(map[string]map[int64]org.RoleType{}, false), nil, identity.RoleType(data.Role))
 	}
 
 	if !s.isOrganizationMember(data.Orgs) {

--- a/pkg/login/social/connectors/okta_oauth.go
+++ b/pkg/login/social/connectors/okta_oauth.go
@@ -115,6 +115,7 @@ func (claims *OktaClaims) extractEmail() string {
 }
 
 func (s *SocialOkta) UserInfo(ctx context.Context, client *http.Client, token *oauth2.Token) (*social.BasicUserInfo, error) {
+	logger := s.log.FromContext(ctx)
 	s.reloadMutex.RLock()
 	defer s.reloadMutex.RUnlock()
 
@@ -181,7 +182,7 @@ func (s *SocialOkta) UserInfo(ctx context.Context, client *http.Client, token *o
 	if !s.info.SkipOrgRoleSync {
 		directlyMappedRole, grafanaAdmin, err := s.extractRoleAndAdminOptional(data.rawJSON, groups)
 		if err != nil {
-			s.log.Warn("Failed to extract role", "err", err)
+			logger.Warn("Failed to extract role", "err", err)
 		}
 
 		if s.info.AllowAssignGrafanaAdmin {
@@ -190,39 +191,40 @@ func (s *SocialOkta) UserInfo(ctx context.Context, client *http.Client, token *o
 
 		externalOrgs, err := s.extractOrgs(data.rawJSON)
 		if err != nil {
-			s.log.Warn("Failed to extract orgs", "err", err)
+			logger.Warn("Failed to extract orgs", "err", err)
 			return nil, err
 		}
 
-		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(s.orgMappingCfg, externalOrgs, directlyMappedRole)
+		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(ctx, s.orgMappingCfg, externalOrgs, directlyMappedRole)
 		if s.info.RoleAttributeStrict && len(userInfo.OrgRoles) == 0 {
 			return nil, errRoleAttributeStrictViolation.Errorf("could not evaluate any valid roles using IdP provided data")
 		}
 	}
 
 	if s.info.AllowAssignGrafanaAdmin && s.info.SkipOrgRoleSync {
-		s.log.Debug("AllowAssignGrafanaAdmin and skipOrgRoleSync are both set, Grafana Admin role will not be synced, consider setting one or the other")
+		logger.Debug("AllowAssignGrafanaAdmin and skipOrgRoleSync are both set, Grafana Admin role will not be synced, consider setting one or the other")
 	}
 
 	return userInfo, nil
 }
 
 func (s *SocialOkta) extractAPI(ctx context.Context, data *OktaUserInfoJson, client *http.Client) error {
+	logger := s.log.FromContext(ctx)
 	rawUserInfoResponse, err := s.httpGet(ctx, client, s.info.ApiUrl)
 	if err != nil {
-		s.log.Debug("Error getting user info response", "url", s.info.ApiUrl, "error", err)
+		logger.Debug("Error getting user info response", "url", s.info.ApiUrl, "error", err)
 		return fmt.Errorf("error getting user info response: %w", err)
 	}
 	data.rawJSON = rawUserInfoResponse.Body
 
 	err = json.Unmarshal(data.rawJSON, data)
 	if err != nil {
-		s.log.Debug("Error decoding user info response", "raw_json", data.rawJSON, "error", err)
+		logger.Debug("Error decoding user info response", "raw_json", data.rawJSON, "error", err)
 		data.rawJSON = []byte{}
 		return fmt.Errorf("error decoding user info response: %w", err)
 	}
 
-	s.log.Debug("Received user info response", "raw_json", string(data.rawJSON), "data", data)
+	logger.Debug("Received user info response", "raw_json", string(data.rawJSON), "data", data)
 	return nil
 }
 

--- a/pkg/login/social/connectors/org_role_mapper.go
+++ b/pkg/login/social/connectors/org_role_mapper.go
@@ -50,32 +50,35 @@ func ProvideOrgRoleMapper(cfg *setting.Cfg, orgService org.Service) *OrgRoleMapp
 //
 // directlyMappedRole: role that is directly mapped to the user (ex: through `role_attribute_path`)
 func (m *OrgRoleMapper) MapOrgRoles(
+	ctx context.Context,
 	mappingCfg MappingConfiguration,
 	externalOrgs []string,
 	directlyMappedRole org.RoleType,
 ) map[int64]org.RoleType {
+	logger := m.logger.FromContext(ctx)
+
 	if len(mappingCfg.orgMapping) == 0 {
 		// Org mapping is not configured
-		return m.getDefaultOrgMapping(mappingCfg.strictRoleMapping, directlyMappedRole)
+		return m.getDefaultOrgMapping(ctx, mappingCfg.strictRoleMapping, directlyMappedRole)
 	}
 
 	userOrgRoles := getMappedOrgRoles(externalOrgs, mappingCfg.orgMapping)
 
-	if err := m.handleGlobalOrgMapping(userOrgRoles); err != nil {
+	if err := m.handleGlobalOrgMapping(ctx, userOrgRoles); err != nil {
 		// Cannot map global org roles, return nil (prevent resetting asignments)
 		return nil
 	}
 
 	if len(userOrgRoles) == 0 {
-		return m.getDefaultOrgMapping(mappingCfg.strictRoleMapping, directlyMappedRole)
+		return m.getDefaultOrgMapping(ctx, mappingCfg.strictRoleMapping, directlyMappedRole)
 	}
 
 	if directlyMappedRole == "" {
-		m.logger.Debug("No direct role mapping found")
+		logger.Debug("No direct role mapping found")
 		return userOrgRoles
 	}
 
-	m.logger.Debug("Direct role mapping found", "role", directlyMappedRole)
+	logger.Debug("Direct role mapping found", "role", directlyMappedRole)
 
 	// Merge roles from org mapping `org_mapping` with role from direct mapping
 	for orgID, role := range userOrgRoles {
@@ -85,9 +88,9 @@ func (m *OrgRoleMapper) MapOrgRoles(
 	return userOrgRoles
 }
 
-func (m *OrgRoleMapper) getDefaultOrgMapping(strictRoleMapping bool, directlyMappedRole org.RoleType) map[int64]org.RoleType {
+func (m *OrgRoleMapper) getDefaultOrgMapping(ctx context.Context, strictRoleMapping bool, directlyMappedRole org.RoleType) map[int64]org.RoleType {
 	if strictRoleMapping && !directlyMappedRole.IsValid() {
-		m.logger.Debug("Prevent default org role mapping, role attribute strict requested")
+		m.logger.FromContext(ctx).Debug("Prevent default org role mapping, role attribute strict requested")
 		return nil
 	}
 	orgRoles := make(map[int64]org.RoleType, 0)
@@ -102,7 +105,7 @@ func (m *OrgRoleMapper) getDefaultOrgMapping(strictRoleMapping bool, directlyMap
 	return orgRoles
 }
 
-func (m *OrgRoleMapper) handleGlobalOrgMapping(orgRoles map[int64]org.RoleType) error {
+func (m *OrgRoleMapper) handleGlobalOrgMapping(ctx context.Context, orgRoles map[int64]org.RoleType) error {
 	// No global role mapping => return
 	globalRole, ok := orgRoles[mapperMatchAllOrgID]
 	if !ok {
@@ -113,7 +116,7 @@ func (m *OrgRoleMapper) handleGlobalOrgMapping(orgRoles map[int64]org.RoleType) 
 	if err != nil {
 		// Prevent resetting assignments
 		clear(orgRoles)
-		m.logger.Warn("error fetching all orgs, removing org mapping to prevent org sync")
+		m.logger.FromContext(ctx).Warn("error fetching all orgs, removing org mapping to prevent org sync")
 		return err
 	}
 
@@ -137,7 +140,7 @@ func (m *OrgRoleMapper) ParseOrgMappingSettings(ctx context.Context, mappings []
 	for _, v := range mappings {
 		kv := splitOrgMapping(v)
 		if !isValidOrgMappingFormat(kv) {
-			m.logger.Error("Skipping org mapping due to invalid format.", "mapping", fmt.Sprintf("%v", v))
+			m.logger.FromContext(ctx).Error("Skipping org mapping due to invalid format.", "mapping", fmt.Sprintf("%v", v))
 			if roleStrict {
 				// Return empty mapping if the mapping format is invalied and roleStrict is enabled
 				return NewMappingConfiguration(map[string]map[int64]org.RoleType{}, roleStrict)
@@ -147,7 +150,7 @@ func (m *OrgRoleMapper) ParseOrgMappingSettings(ctx context.Context, mappings []
 
 		orgID, err := m.getOrgIDForInternalMapping(ctx, kv[1])
 		if err != nil {
-			m.logger.Warn("Could not fetch OrgID. Skipping.", "err", err, "mapping", fmt.Sprintf("%v", v), "org", kv[1])
+			m.logger.FromContext(ctx).Warn("Could not fetch OrgID. Skipping.", "err", err, "mapping", fmt.Sprintf("%v", v), "org", kv[1])
 			if roleStrict {
 				// Return empty mapping if at least one org name cannot be resolved when roleStrict is enabled
 				return NewMappingConfiguration(map[string]map[int64]org.RoleType{}, roleStrict)
@@ -157,7 +160,7 @@ func (m *OrgRoleMapper) ParseOrgMappingSettings(ctx context.Context, mappings []
 
 		if roleStrict && (len(kv) < 3 || !org.RoleType(kv[2]).IsValid()) {
 			// Return empty mapping if at least one org mapping is invalid (missing role, invalid role)
-			m.logger.Warn("Skipping org mapping due to missing or invalid role in mapping when roleStrict is enabled.", "mapping", fmt.Sprintf("%v", v))
+			m.logger.FromContext(ctx).Warn("Skipping org mapping due to missing or invalid role in mapping when roleStrict is enabled.", "mapping", fmt.Sprintf("%v", v))
 			return NewMappingConfiguration(map[string]map[int64]org.RoleType{}, roleStrict)
 		}
 
@@ -187,7 +190,7 @@ func (m *OrgRoleMapper) getOrgIDForInternalMapping(ctx context.Context, orgIdCfg
 
 		if getErr != nil {
 			// skip in case of error
-			m.logger.Warn("Could not fetch organization. Skipping.", "err", err, "org", orgIdCfg)
+			m.logger.FromContext(ctx).Warn("Could not fetch organization. Skipping.", "err", err, "org", orgIdCfg)
 			return 0, getErr
 		}
 		orgID = int(res.ID)

--- a/pkg/login/social/connectors/org_role_mapper_test.go
+++ b/pkg/login/social/connectors/org_role_mapper_test.go
@@ -218,7 +218,7 @@ func TestOrgRoleMapper_MapOrgRoles(t *testing.T) {
 				}
 			}
 			mappingCfg := mapper.ParseOrgMappingSettings(context.Background(), tc.orgMappingSettings, tc.strictRoleMapping)
-			actual := mapper.MapOrgRoles(mappingCfg, tc.externalOrgs, tc.directlyMappedRole)
+			actual := mapper.MapOrgRoles(context.Background(), mappingCfg, tc.externalOrgs, tc.directlyMappedRole)
 
 			assert.EqualValues(t, tc.expected, actual)
 		})
@@ -233,7 +233,7 @@ func TestOrgRoleMapper_MapOrgRoles_ReturnsDefaultOnNilMapping(t *testing.T) {
 	cfg.AutoAssignOrgRole = string(org.RoleViewer)
 	mapper := ProvideOrgRoleMapper(cfg, orgService)
 
-	actual := mapper.MapOrgRoles(NewMappingConfiguration(map[string]map[int64]org.RoleType{}, false), []string{"First"}, org.RoleNone)
+	actual := mapper.MapOrgRoles(context.Background(), NewMappingConfiguration(map[string]map[int64]org.RoleType{}, false), []string{"First"}, org.RoleNone)
 
 	assert.EqualValues(t, map[int64]org.RoleType{2: org.RoleNone}, actual)
 }

--- a/pkg/login/social/connectors/social_base.go
+++ b/pkg/login/social/connectors/social_base.go
@@ -299,6 +299,7 @@ func (s *SocialBase) getJWKSCacheKeyForURL(jwkSetURL string) string {
 
 // retrieveJWKSFromCache retrieves JWKS from cache by cache key.
 func (s *SocialBase) retrieveJWKSFromCache(ctx context.Context, cacheKey string) (*keySetJWKS, time.Duration, error) {
+	logger := s.log.FromContext(ctx)
 	if s.cache == nil {
 		return &keySetJWKS{}, 0, nil
 	}
@@ -306,16 +307,17 @@ func (s *SocialBase) retrieveJWKSFromCache(ctx context.Context, cacheKey string)
 	if val, err := s.cache.Get(ctx, cacheKey); err == nil {
 		var jwks keySetJWKS
 		err := json.Unmarshal(val, &jwks)
-		s.log.Debug("Retrieved cached key set", "cacheKey", cacheKey)
+		logger.Debug("Retrieved cached key set", "cacheKey", cacheKey)
 		return &jwks, 0, err
 	}
-	s.log.Debug("Keyset not found in cache")
+	logger.Debug("Keyset not found in cache")
 
 	return &keySetJWKS{}, 0, nil
 }
 
 // cacheJWKS caches the JWKS under the given cache key.
 func (s *SocialBase) cacheJWKS(ctx context.Context, cacheKey string, jwks *keySetJWKS, cacheExpiration time.Duration) error {
+	logger := s.log.FromContext(ctx)
 	if s.cache == nil {
 		return nil
 	}
@@ -326,7 +328,7 @@ func (s *SocialBase) cacheJWKS(ctx context.Context, cacheKey string, jwks *keySe
 	}
 
 	if err := s.cache.Set(ctx, cacheKey, jsonBuf.Bytes(), cacheExpiration); err != nil {
-		s.log.Warn("Failed to cache key set", "err", err)
+		logger.Warn("Failed to cache key set", "err", err)
 	}
 
 	return nil
@@ -361,6 +363,7 @@ func getCacheExpiration(header string) time.Duration {
 
 // retrieveJWKSFromURL retrieves JWKS from the configured URL
 func (s *SocialBase) retrieveJWKSFromURL(ctx context.Context, client *http.Client, jwkSetURL string) (*keySetJWKS, time.Duration, error) {
+	logger := s.log.FromContext(ctx)
 	if jwkSetURL == "" {
 		return nil, 0, fmt.Errorf("JWK Set URL is not configured")
 	}
@@ -377,7 +380,7 @@ func (s *SocialBase) retrieveJWKSFromURL(ctx context.Context, client *http.Clien
 	}
 
 	cacheExpiration := getCacheExpiration(resp.Headers.Get("cache-control"))
-	s.log.Debug("Retrieved key set from URL", "url", jwkSetURL, "cacheExpiration", cacheExpiration)
+	logger.Debug("Retrieved key set from URL", "url", jwkSetURL, "cacheExpiration", cacheExpiration)
 
 	return &jwks, cacheExpiration, nil
 }
@@ -386,6 +389,7 @@ func (s *SocialBase) retrieveJWKSFromURL(ctx context.Context, client *http.Clien
 // For each URL, the cache is checked first (keyed by hash of URL), then the URL is fetched if needed.
 // Tries each URL in order until a key verifies the signature.
 func (s *SocialBase) validateIDTokenSignatureWithURLs(ctx context.Context, client *http.Client, idTokenString string, jwkSetURLs []string) ([]byte, error) {
+	logger := s.log.FromContext(ctx)
 	parsedToken, err := jwt.ParseSigned(idTokenString, []jose.SignatureAlgorithm{
 		jose.EdDSA, jose.HS256, jose.HS384, jose.HS512,
 		jose.RS256, jose.RS384, jose.RS512,
@@ -411,27 +415,27 @@ func (s *SocialBase) validateIDTokenSignatureWithURLs(ctx context.Context, clien
 		// Try cache first for this URL
 		keyset, expiry, err := s.retrieveJWKSFromCache(ctx, cacheKey)
 		if err != nil {
-			s.log.Warn("Error retrieving JWKS from cache", "url", jwkSetURL, "error", err)
+			logger.Warn("Error retrieving JWKS from cache", "url", jwkSetURL, "error", err)
 		}
 		// If cache miss or empty, fetch from URL
 		if keyset == nil || len(keyset.Keys) == 0 {
 			keyset, expiry, err = s.retrieveJWKSFromURL(ctx, client, jwkSetURL)
 			if err != nil {
-				s.log.Warn("Error retrieving JWKS from URL", "url", jwkSetURL, "error", err)
+				logger.Warn("Error retrieving JWKS from URL", "url", jwkSetURL, "error", err)
 				continue
 			}
 		}
 
 		keys := keyset.Key(keyID)
 		for _, key := range keys {
-			s.log.Debug("Trying to verify token with key", "kid", key.KeyID)
+			logger.Debug("Trying to verify token with key", "kid", key.KeyID)
 			var claims map[string]any
 			if err := parsedToken.Claims(key, &claims); err == nil {
 				// Successfully verified, cache the keyset if we got it from URL (expiry > 0)
 				if expiry != 0 {
-					s.log.Debug("Caching key set", "kid", key.KeyID, "expiry", expiry)
+					logger.Debug("Caching key set", "kid", key.KeyID, "expiry", expiry)
 					if err := s.cacheJWKS(ctx, cacheKey, keyset, expiry); err != nil {
-						s.log.Warn("Failed to cache key set", "err", err)
+						logger.Warn("Failed to cache key set", "err", err)
 					}
 				}
 
@@ -441,7 +445,7 @@ func (s *SocialBase) validateIDTokenSignatureWithURLs(ctx context.Context, clien
 				}
 				return rawJSON, nil
 			}
-			s.log.Debug("Failed to verify token with key", "kid", key.KeyID, "err", err)
+			logger.Debug("Failed to verify token with key", "kid", key.KeyID, "err", err)
 		}
 	}
 

--- a/pkg/services/authn/authnimpl/sync/user_sync.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync.go
@@ -427,7 +427,7 @@ func (s *UserSync) SyncLastSeenHook(ctx context.Context, id *authn.Identity, r *
 	_, _, _ = s.lastSeenSF.Do(fmt.Sprintf("%d-%d", id.GetOrgID(), userID), func() (interface{}, error) {
 		err := s.userService.UpdateLastSeenAt(goCtx, &user.UpdateUserLastSeenAtCommand{UserID: userID, OrgID: id.GetOrgID()})
 		if err != nil && !errors.Is(err, user.ErrLastSeenUpToDate) {
-			s.log.Error("Failed to update last_seen_at", "err", err, "userId", userID)
+			s.log.FromContext(goCtx).Error("Failed to update last_seen_at", "err", err, "userId", userID)
 		}
 		return nil, nil
 	})

--- a/pkg/services/authn/authnserver/service.go
+++ b/pkg/services/authn/authnserver/service.go
@@ -59,13 +59,14 @@ func (s *Service) Authenticate(ctx context.Context, req *authnv1.AuthenticateReq
 	defer span.End()
 
 	if req == nil || req.Namespace == "" {
-		s.log.Error("Authenticate request error", "error", errExpectedNamespace)
+		s.log.FromContext(ctx).Error("Authenticate request error", "error", errExpectedNamespace)
 		return &authnv1.AuthenticateResponse{
 			Code: authnv1.AuthenticateCode_AUTHENTICATE_CODE_FAILED,
 		}, errExpectedNamespace
 	}
 
 	ctx = request.WithNamespace(ctx, req.Namespace)
+	ctx = log.WithContextualAttributes(ctx, []any{"namespace", req.Namespace})
 	span.SetAttributes(attribute.String("authn.namespace", req.Namespace))
 
 	grpclog.AddFields(ctx, grpclog.Fields{"authn.headers", headerNames(req.GetHttpHeaders())})
@@ -79,7 +80,7 @@ func (s *Service) Authenticate(ctx context.Context, req *authnv1.AuthenticateReq
 
 		resp, err := c.Authenticate(ctx, req)
 		if err != nil {
-			s.log.Error("Client authentication error", "client", c.Name(), "error", err)
+			s.log.FromContext(ctx).Error("Client authentication error", "client", c.Name(), "error", err)
 			grpclog.AddFields(ctx, grpclog.Fields{"authn.client", c.Name(), "authn.namespace", req.GetNamespace()})
 			return nil, err
 		}

--- a/pkg/services/authn/authnserver/service_test.go
+++ b/pkg/services/authn/authnserver/service_test.go
@@ -13,6 +13,7 @@ import (
 
 	authnv1 "github.com/grafana/authlib/authn/proto/v1"
 
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 )
 
@@ -222,11 +223,13 @@ func TestAuthenticate(t *testing.T) {
 		gotTestNS, ok := request.NamespaceFrom(client.gotTestCtx)
 		require.True(t, ok, "namespace must be set on Test ctx")
 		assert.Equal(t, "stacks-1234", gotTestNS)
+		assert.Equal(t, []any{"namespace", "stacks-1234"}, log.FromContext(client.gotTestCtx))
 
 		require.NotNil(t, client.gotAuthCtx)
 		gotAuthNS, ok := request.NamespaceFrom(client.gotAuthCtx)
 		require.True(t, ok, "namespace must be set on Authenticate ctx")
 		assert.Equal(t, "stacks-1234", gotAuthNS)
+		assert.Equal(t, []any{"namespace", "stacks-1234"}, log.FromContext(client.gotAuthCtx))
 	})
 
 	t.Run("all clients decline via NOT_HANDLED returns NOT_HANDLED", func(t *testing.T) {

--- a/pkg/services/authn/clients/api_key.go
+++ b/pkg/services/authn/clients/api_key.go
@@ -163,24 +163,24 @@ func (s *APIKey) Hook(ctx context.Context, identity *authn.Identity, r *authn.Re
 		return nil
 	}
 
-	go func(keyID string) {
+	go func(keyID string, logger log.Logger) {
 		defer func() {
 			if err := recover(); err != nil {
-				s.log.Error("Panic during user last seen sync", "err", err)
+				logger.Error("Panic during user last seen sync", "err", err)
 			}
 		}()
 
 		id, err := strconv.ParseInt(keyID, 10, 64)
 		if err != nil {
-			s.log.Warn("Invalid api key id", "id", keyID, "err", err)
+			logger.Warn("Invalid api key id", "id", keyID, "err", err)
 			return
 		}
 
 		if err := s.apiKeyService.UpdateAPIKeyLastUsedDate(context.Background(), id); err != nil {
-			s.log.Warn("Failed to update last used date for api key", "id", keyID, "err", err)
+			logger.Warn("Failed to update last used date for api key", "id", keyID, "err", err)
 			return
 		}
-	}(r.GetMeta(metaKeyID))
+	}(r.GetMeta(metaKeyID), s.log.FromContext(ctx))
 
 	return nil
 }

--- a/pkg/services/authn/clients/jwt.go
+++ b/pkg/services/authn/clients/jwt.go
@@ -129,11 +129,11 @@ func (s *JWT) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identi
 
 		externalOrgs, err := s.extractOrgs(claims)
 		if err != nil {
-			s.log.Warn("Failed to extract orgs", "err", err)
+			s.log.FromContext(ctx).Warn("Failed to extract orgs", "err", err)
 			return nil, err
 		}
 
-		id.OrgRoles = s.orgRoleMapper.MapOrgRoles(s.orgMappingCfg, externalOrgs, role)
+		id.OrgRoles = s.orgRoleMapper.MapOrgRoles(ctx, s.orgMappingCfg, externalOrgs, role)
 		if s.cfg.JWTAuth.RoleAttributeStrict && len(id.OrgRoles) == 0 {
 			return nil, errJWTInvalidRole.Errorf("could not evaluate any valid roles using IdP provided data")
 		}

--- a/pkg/services/login/authinfoimpl/service.go
+++ b/pkg/services/login/authinfoimpl/service.go
@@ -46,9 +46,11 @@ func (s *Service) GetAuthInfo(ctx context.Context, query *login.GetAuthInfoQuery
 		return nil, user.ErrUserNotFound
 	}
 
+	logger := s.logger.FromContext(ctx)
+
 	authInfo, err := s.getAuthInfoFromCache(ctx, query)
 	if err != nil && !errors.Is(err, remotecache.ErrCacheItemNotFound) {
-		s.logger.Warn("failed to retrieve auth info from cache", "error", err)
+		logger.Warn("failed to retrieve auth info from cache", "error", err)
 	} else if authInfo != nil {
 		return authInfo, nil
 	}
@@ -60,9 +62,9 @@ func (s *Service) GetAuthInfo(ctx context.Context, query *login.GetAuthInfoQuery
 
 	err = s.setAuthInfoInCache(ctx, query, authInfo)
 	if err != nil {
-		s.logger.Warn("failed to set auth info in cache", "error", err)
+		logger.Warn("failed to set auth info in cache", "error", err)
 	} else {
-		s.logger.Debug("auth info set in cache", "cacheKey", generateCacheKey(query))
+		logger.Debug("auth info set in cache", "cacheKey", generateCacheKey(query))
 	}
 
 	return authInfo, nil
@@ -125,7 +127,7 @@ func (s *Service) getAuthInfoFromCache(ctx context.Context, query *login.GetAuth
 		return nil, err
 	}
 
-	s.logger.Debug("auth info retrieved from cache", "cacheKey", cacheKey)
+	s.logger.FromContext(ctx).Debug("auth info retrieved from cache", "cacheKey", cacheKey)
 
 	return info, nil
 }
@@ -184,20 +186,22 @@ func (s *Service) DeleteUserAuthInfo(ctx context.Context, userID int64) error {
 		UserId: userID,
 	}))
 	if err != nil {
-		s.logger.Error("failed to delete auth info from cache", "error", err)
+		s.logger.FromContext(ctx).Error("failed to delete auth info from cache", "error", err)
 	}
 
 	return nil
 }
 
 func (s *Service) deleteUserAuthInfoInCache(ctx context.Context, query *login.GetAuthInfoQuery) {
+	logger := s.logger.FromContext(ctx)
+
 	if query.AuthId != "" {
 		err := s.remoteCache.Delete(ctx, generateCacheKey(&login.GetAuthInfoQuery{
 			AuthModule: query.AuthModule,
 			AuthId:     query.AuthId,
 		}))
 		if err != nil {
-			s.logger.Warn("failed to delete auth info from cache", "error", err)
+			logger.Warn("failed to delete auth info from cache", "error", err)
 		}
 	}
 
@@ -207,7 +211,7 @@ func (s *Service) deleteUserAuthInfoInCache(ctx context.Context, query *login.Ge
 				UserId: query.UserId,
 			}))
 		if errN != nil {
-			s.logger.Warn("failed to delete user auth info from cache", "error", errN)
+			logger.Warn("failed to delete user auth info from cache", "error", errN)
 		}
 
 		errA := s.remoteCache.Delete(ctx, generateCacheKey(
@@ -216,7 +220,7 @@ func (s *Service) deleteUserAuthInfoInCache(ctx context.Context, query *login.Ge
 				AuthModule: query.AuthModule,
 			}))
 		if errA != nil {
-			s.logger.Warn("failed to delete user module auth info from cache", "error", errA)
+			logger.Warn("failed to delete user module auth info from cache", "error", errA)
 		}
 	}
 }

--- a/pkg/services/login/authinfoimpl/store.go
+++ b/pkg/services/login/authinfoimpl/store.go
@@ -271,7 +271,7 @@ func (s *Store) UpdateAuthInfo(ctx context.Context, cmd *login.UpdateAuthInfoCom
 			Where("user_id = ? AND auth_module = ?", cmd.UserId, cmd.AuthModule).
 			Update(authUser)
 
-		s.logger.Debug("Updated user_auth", "user_id", cmd.UserId, "auth_id", cmd.AuthId, "auth_module", cmd.AuthModule, "rows", upd)
+		s.logger.FromContext(ctx).Debug("Updated user_auth", "user_id", cmd.UserId, "auth_id", cmd.AuthId, "auth_module", cmd.AuthModule, "rows", upd)
 
 		// Clean up duplicated entries
 		if upd > 1 {


### PR DESCRIPTION
## Summary
- Have `authnserver` attach the request namespace as a contextual log attribute so downstream `FromContext` loggers include it.
- Use `FromContext` for authinfo cache/store logs and for async api-key / last-seen hooks that previously logged without request context.
- Propagate contextual logging through social OAuth connectors (including threading `ctx` into `MapOrgRoles`).

## Why
Auth and OAuth login paths emit a lot of shared-library debug/info logs. When those skip `FromContext`, they lose request-scoped fields that are already on the context (such as `traceID`, and namespace when a caller has set contextual attributes). Wiring `FromContext` through these call sites keeps request logs correlatable without requiring every log line to pass those fields explicitly.


Made with [Cursor](https://cursor.com)