### PR TITLE
Navigation: Add a Database configurations section under Administration

### DIFF
--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -55,6 +55,7 @@ const (
 	NavIDCfgGeneral           = "cfg/general"
 	NavIDCfgPlugins           = "cfg/plugins"
 	NavIDCfgAccess            = "cfg/access"
+	NavIDCfgDatabases         = "cfg/databases"
 	NavIDBookmarks            = "bookmarks"
 )
 

--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -347,6 +347,22 @@ func (s *ServiceImpl) addPluginToSection(c *contextmodel.ReqContext, treeRoot *n
 				Img:   s.cfg.AppSubURL + plugin.Info.Logos.Large,
 				IsNew: true,
 			})
+		case navtree.NavIDCfgDatabases:
+			// Unlike the other sections here this one is nested under Administration, so it can
+			// only be created once that node exists.
+			cfgNode := treeRoot.FindById(navtree.NavIDCfg)
+			if cfgNode == nil {
+				s.log.Error("Administration nav node not found", "pluginId", plugin.ID, "navId", sectionID)
+				break
+			}
+			cfgNode.Children = append(cfgNode.Children, &navtree.NavLink{
+				Text:     "Database configurations",
+				Id:       navtree.NavIDCfgDatabases,
+				SubTitle: "Configure the databases that store your logs, metrics, and traces",
+				Icon:     "shield",
+				Children: sectionChildren,
+				Url:      s.cfg.AppSubURL + "/admin/databases",
+			})
 		default:
 			s.log.Error("Plugin app nav id not found", "pluginId", plugin.ID, "navId", sectionID)
 		}
@@ -394,6 +410,8 @@ func (s *ServiceImpl) readNavigationSettings() {
 		"grafana-assistant-app":            {SectionID: navtree.NavIDRoot, SortWeight: navtree.WeightAssistant, Text: "Assistant", SubTitle: "AI-powered assistant for Grafana", Icon: "ai-sparkle"},
 		"grafana-ml-app":                   {SectionID: navtree.NavIDRoot, SortWeight: navtree.WeightAIAndML, Text: "Machine Learning", SubTitle: "Explore AI and machine learning features", Icon: "gf-ml-alt"},
 		"grafana-cloud-link-app":           {SectionID: navtree.NavIDCfgPlugins, SortWeight: 3},
+		"grafana-dbcfg-app":                {SectionID: navtree.NavIDCfgDatabases, SortWeight: 1},
+		"grafana-dbselfserve-app":          {SectionID: navtree.NavIDCfgDatabases, SortWeight: 2},
 		"grafana-adaptive-metrics-app":     {SectionID: navtree.NavIDAdaptiveTelemetry, SortWeight: 1},
 		"grafana-adaptivelogs-app":         {SectionID: navtree.NavIDAdaptiveTelemetry, SortWeight: 2},
 		"grafana-adaptivetraces-app":       {SectionID: navtree.NavIDAdaptiveTelemetry, SortWeight: 3},

--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -410,8 +410,6 @@ func (s *ServiceImpl) readNavigationSettings() {
 		"grafana-assistant-app":            {SectionID: navtree.NavIDRoot, SortWeight: navtree.WeightAssistant, Text: "Assistant", SubTitle: "AI-powered assistant for Grafana", Icon: "ai-sparkle"},
 		"grafana-ml-app":                   {SectionID: navtree.NavIDRoot, SortWeight: navtree.WeightAIAndML, Text: "Machine Learning", SubTitle: "Explore AI and machine learning features", Icon: "gf-ml-alt"},
 		"grafana-cloud-link-app":           {SectionID: navtree.NavIDCfgPlugins, SortWeight: 3},
-		"grafana-dbcfg-app":                {SectionID: navtree.NavIDCfgDatabases, SortWeight: 1},
-		"grafana-dbselfserve-app":          {SectionID: navtree.NavIDCfgDatabases, SortWeight: 2},
 		"grafana-adaptive-metrics-app":     {SectionID: navtree.NavIDAdaptiveTelemetry, SortWeight: 1},
 		"grafana-adaptivelogs-app":         {SectionID: navtree.NavIDAdaptiveTelemetry, SortWeight: 2},
 		"grafana-adaptivetraces-app":       {SectionID: navtree.NavIDAdaptiveTelemetry, SortWeight: 3},

--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -358,7 +358,7 @@ func (s *ServiceImpl) addPluginToSection(c *contextmodel.ReqContext, treeRoot *n
 			cfgNode.Children = append(cfgNode.Children, &navtree.NavLink{
 				Text:     "Database configurations",
 				Id:       navtree.NavIDCfgDatabases,
-				SubTitle: "Configure the databases that store your logs, metrics, and traces",
+				SubTitle: "Manage settings for your observability databases",
 				Icon:     "shield",
 				Children: sectionChildren,
 				Url:      s.cfg.AppSubURL + "/admin/databases",

--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -348,8 +348,7 @@ func (s *ServiceImpl) addPluginToSection(c *contextmodel.ReqContext, treeRoot *n
 				IsNew: true,
 			})
 		case navtree.NavIDCfgDatabases:
-			// Unlike the other sections here this one is nested under Administration, so it can
-			// only be created once that node exists.
+			// Nests under Administration rather than the tree root, unlike the cases above.
 			cfgNode := treeRoot.FindById(navtree.NavIDCfg)
 			if cfgNode == nil {
 				s.log.Error("Administration nav node not found", "pluginId", plugin.ID, "navId", sectionID)
@@ -410,6 +409,8 @@ func (s *ServiceImpl) readNavigationSettings() {
 		"grafana-assistant-app":            {SectionID: navtree.NavIDRoot, SortWeight: navtree.WeightAssistant, Text: "Assistant", SubTitle: "AI-powered assistant for Grafana", Icon: "ai-sparkle"},
 		"grafana-ml-app":                   {SectionID: navtree.NavIDRoot, SortWeight: navtree.WeightAIAndML, Text: "Machine Learning", SubTitle: "Explore AI and machine learning features", Icon: "gf-ml-alt"},
 		"grafana-cloud-link-app":           {SectionID: navtree.NavIDCfgPlugins, SortWeight: 3},
+		"grafana-dbcfg-app":                {SectionID: navtree.NavIDCfgDatabases, SortWeight: 1},
+		"grafana-dbselfserve-app":          {SectionID: navtree.NavIDCfgDatabases, SortWeight: 2},
 		"grafana-adaptive-metrics-app":     {SectionID: navtree.NavIDAdaptiveTelemetry, SortWeight: 1},
 		"grafana-adaptivelogs-app":         {SectionID: navtree.NavIDAdaptiveTelemetry, SortWeight: 2},
 		"grafana-adaptivetraces-app":       {SectionID: navtree.NavIDAdaptiveTelemetry, SortWeight: 3},

--- a/pkg/services/navtree/navtreeimpl/applinks_test.go
+++ b/pkg/services/navtree/navtreeimpl/applinks_test.go
@@ -534,6 +534,8 @@ func TestReadingNavigationSettings(t *testing.T) {
 		service.readNavigationSettings()
 
 		require.Equal(t, "observability", service.navigationAppConfig["grafana-k8s-app"].SectionID)
+		require.Equal(t, navtree.NavIDCfgDatabases, service.navigationAppConfig["grafana-dbcfg-app"].SectionID)
+		require.Equal(t, navtree.NavIDCfgDatabases, service.navigationAppConfig["grafana-dbselfserve-app"].SectionID)
 	})
 
 	t.Run("Can add additional overrides via ini system", func(t *testing.T) {

--- a/pkg/services/navtree/navtreeimpl/applinks_test.go
+++ b/pkg/services/navtree/navtreeimpl/applinks_test.go
@@ -204,6 +204,7 @@ func TestAddAppLinks(t *testing.T) {
 		require.Equal(t, "plugin-page-test-app3", appsNode.Children[1].Id)
 	})
 
+	// This can be done by using `[navigation.app_sections]` in the INI config
 	t.Run("Should group apps configured for the databases nav id under Administration", func(t *testing.T) {
 		service.navigationAppConfig = map[string]NavigationAppConfig{
 			"test-app1": {SectionID: navtree.NavIDCfgDatabases, SortWeight: 1},

--- a/pkg/services/navtree/navtreeimpl/applinks_test.go
+++ b/pkg/services/navtree/navtreeimpl/applinks_test.go
@@ -204,6 +204,54 @@ func TestAddAppLinks(t *testing.T) {
 		require.Equal(t, "plugin-page-test-app3", appsNode.Children[1].Id)
 	})
 
+	t.Run("Should group apps configured for the databases nav id under Administration", func(t *testing.T) {
+		service.navigationAppConfig = map[string]NavigationAppConfig{
+			"test-app1": {SectionID: navtree.NavIDCfgDatabases, SortWeight: 1},
+			"test-app2": {SectionID: navtree.NavIDCfgDatabases, SortWeight: 2},
+		}
+
+		treeRoot := navtree.NavTreeRoot{}
+		treeRoot.AddSection(&navtree.NavLink{
+			Id: navtree.NavIDCfg,
+		})
+
+		err := service.addAppLinks(&treeRoot, reqCtx)
+		require.NoError(t, err)
+
+		databasesNode := treeRoot.FindById(navtree.NavIDCfgDatabases)
+		require.NotNil(t, databasesNode)
+		require.Equal(t, "Database configurations", databasesNode.Text)
+		require.Equal(t, "/admin/databases", databasesNode.Url)
+
+		// The section is created by the first app and reused by the second
+		require.Len(t, databasesNode.Children, 2)
+		require.Equal(t, "plugin-page-test-app1", databasesNode.Children[0].Id)
+		require.Equal(t, "plugin-page-test-app2", databasesNode.Children[1].Id)
+
+		adminNode := treeRoot.FindById(navtree.NavIDCfg)
+		require.Len(t, adminNode.Children, 1)
+		require.Equal(t, navtree.NavIDCfgDatabases, adminNode.Children[0].Id)
+
+		appsNode := treeRoot.FindById(navtree.NavIDApps)
+		require.NotNil(t, appsNode)
+		require.Len(t, appsNode.Children, 1)
+		require.Equal(t, "plugin-page-test-app3", appsNode.Children[0].Id)
+	})
+
+	t.Run("Should not add the databases section if no plugin wants to live there", func(t *testing.T) {
+		service.navigationAppConfig = map[string]NavigationAppConfig{}
+
+		treeRoot := navtree.NavTreeRoot{}
+		treeRoot.AddSection(&navtree.NavLink{
+			Id: navtree.NavIDCfg,
+		})
+
+		err := service.addAppLinks(&treeRoot, reqCtx)
+		require.NoError(t, err)
+
+		require.Nil(t, treeRoot.FindById(navtree.NavIDCfgDatabases))
+	})
+
 	t.Run("Should only add an 'Observability' section if a plugin exists that wants to live there", func(t *testing.T) {
 		service.navigationAppConfig = map[string]NavigationAppConfig{}
 

--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -99,6 +99,8 @@ export function getNavTitle(navId: string | undefined) {
       return t('nav.config-plugins.title', 'Plugins and data');
     case 'cfg/access':
       return t('nav.config-access.title', 'Users and access');
+    case 'cfg/databases':
+      return t('nav.config-databases.title', 'Database configurations');
     case 'datasources':
       return t('nav.datasources.title', 'Data sources');
     case 'authentication':
@@ -298,6 +300,8 @@ export function getNavSubTitle(navId: string | undefined) {
       return t('nav.config-plugins.subtitle', 'Install plugins and define the relationships between data');
     case 'cfg/access':
       return t('nav.config-access.subtitle', 'Configure access for individual users, teams, and service accounts');
+    case 'cfg/databases':
+      return t('nav.config-databases.subtitle', 'Configure the databases that store your logs, metrics, and traces');
     case 'apps':
       return t('nav.apps.subtitle', 'App plugins that extend the Grafana experience');
     case 'monitoring':

--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -301,7 +301,7 @@ export function getNavSubTitle(navId: string | undefined) {
     case 'cfg/access':
       return t('nav.config-access.subtitle', 'Configure access for individual users, teams, and service accounts');
     case 'cfg/databases':
-      return t('nav.config-databases.subtitle', 'Configure the databases that store your logs, metrics, and traces');
+      return t('nav.config-databases.subtitle', 'Manage settings for your observability databases');
     case 'apps':
       return t('nav.apps.subtitle', 'App plugins that extend the Grafana experience');
     case 'monitoring':

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -245,6 +245,10 @@ export function getAppRoutes(): RouteDescriptor[] {
       component: () => <NavLandingPage navId="cfg/access" />,
     },
     {
+      path: '/admin/databases',
+      component: () => <NavLandingPage navId="cfg/databases" />,
+    },
+    {
       path: '/org',
       component: SafeDynamicImport(
         () => import(/* webpackChunkName: "OrgDetailsPage" */ '../features/org/OrgDetailsPage')

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11959,7 +11959,8 @@
       "title": "Users and access"
     },
     "config-databases": {
-      "subtitle": "Configure the databases that store your logs, metrics, and traces",
+    "config-databases": {
+      "subtitle": "Manage settings for your observability databases",
       "title": "Database configurations"
     },
     "config-general": {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11958,6 +11958,10 @@
       "subtitle": "Configure access for individual users, teams, and service accounts",
       "title": "Users and access"
     },
+    "config-databases": {
+      "subtitle": "Configure the databases that store your logs, metrics, and traces",
+      "title": "Database configurations"
+    },
     "config-general": {
       "subtitle": "Manage default preferences and settings across Grafana",
       "title": "General"

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11959,7 +11959,6 @@
       "title": "Users and access"
     },
     "config-databases": {
-    "config-databases": {
       "subtitle": "Manage settings for your observability databases",
       "title": "Database configurations"
     },


### PR DESCRIPTION
## What

Adds a `cfg/databases` navigation section — **Administration → Database configurations** — and puts the two database configuration apps in it, so they sit under one node rather than side by side directly under Administration.

```
Administration
└── Database configurations
    ├── Logs configuration     (grafana-dbcfg-app)
    └── Traces configuration   (grafana-dbselfserve-app)
```

## Shape

The section is created lazily in `addPluginToSection`, by whichever assigned app is processed first, and reused by the rest — so it is absent wherever neither plugin is installed, and needs no pruning pass. Unlike the other cases in that switch it nests under Administration rather than the tree root, so it looks up `cfg` first.

The placement lives in `readNavigationSettings` alongside the other Cloud app entries rather than in per-stack config. That keeps the id out of the hands of Grafana versions that predate this change: an `app_sections` value naming an unknown section drops the app's nav link entirely, whereas with no entry at all those stacks simply fall back to "More apps".

`/admin/databases` renders the usual `NavLandingPage`, matching the sibling `cfg/*` sections.

## Note on depth

The mega menu renders three levels (`MAX_DEPTH = 2` in `MegaMenuItem`), so pages belonging to an app inside this section do not appear in the menu. They keep their nav index entry, breadcrumbs and in-page section nav.

## Tests

`TestAddAppLinks` covers the grouping (section created once, assigned apps as children in weight order, apps kept out of "More apps") and the absence of the section when no plugin claims it. `TestReadingNavigationSettings` covers the two default assignments.

Also verified end to end against a local instance with both plugins installed and no `[navigation.app_sections]` config.

## Why `no-check-mt-service-compatibility`

The frontend and backend halves are compatible in either deployment order, so the version skew this check guards against does not apply.

- **Frontend first:** nothing emits the `cfg/databases` nav id, so the section does not exist, the route is unreachable from the menu, and navigating to `/admin/databases` directly renders the standard "Page not found" page.
- **Backend first:** the section only appears once a plugin is assigned to it in config. Its label comes from the backend `Text`, which `getNavTitle` falls back to, and the group header falls through to `PageNotFound` until the route exists.

Splitting would produce two PRs of three files each with no compatibility benefit.

## Coverage check

`Coverage - @grafana/grafana-frontend-navigation` reports -0.02% lines, -0.01% statements, -0.02% functions. Asking the codeowners to accept that rather than paper over it.

The check passes only on `prPct >= mainPct`, measured across every file the team owns, so a couple of uncovered lines register as a fraction of a percent. This diff adds exactly three frontend code sites, none of which any test reaches:

- two `return t('nav.config-databases.…')` arms in the `navBarItem-translations.ts` switch — lines and statements;
- one `component: () => <NavLandingPage navId="cfg/databases" />` route entry — a new uncovered function.

None of it is logic. A unit test over the translation arms would assert that the switch returns the string the switch defines, and the route's function is only reachable by rendering it — there is no render test for `routes.tsx`, and every sibling landing-page route carries the same uncovered arrow. The one defect these could hold is a mistyped nav id, which is caught by the nav rendering rather than by a unit test repeating the literal.

## Local testing

<img width="329" height="467" alt="image" src="https://github.com/user-attachments/assets/e897bebe-39ad-420d-a004-3b50918ea3c3" />

<img width="717" height="358" alt="image" src="https://github.com/user-attachments/assets/ace8ce8d-e460-4366-b076-85fd066806af" />