### PR TITLE
Analytics Framework: Add check to prevent users to use more than a JSDoc comments

### DIFF
--- a/packages/grafana-eslint-rules/README.md
+++ b/packages/grafana-eslint-rules/README.md
@@ -323,6 +323,23 @@ interface LoadedProperties extends EventProperty {
 }
 ```
 
+- **`stackedJSDocComment`** — Each event and interface property must be documented with a single JSDoc block. TypeScript allows stacking several blocks on one declaration, and the analytics report concatenates them into one description, which is rarely what the author intended. Merge the text, and move tags such as `@owner` into the same block.
+
+```ts
+// Bad ❌
+interface LoadedProperties extends EventProperty {
+  /** Total number of items visible in the library. */
+  /** Only counts the ones rendered at load time. */
+  numberOfItems: number;
+}
+
+// Good ✅
+interface LoadedProperties extends EventProperty {
+  /** Total number of items visible in the library, counting only the ones rendered at load time. */
+  numberOfItems: number;
+}
+```
+
 ### `no-direct-create-monitoring-logger`
 
 Disallow direct named imports of `createMonitoringLogger` from `@grafana/runtime`. New loggers must be registered in `packages/grafana-runtime/src/services/logging/loggers.ts` and retrieved via `getLogger` from `@grafana/runtime/unstable`.

--- a/packages/grafana-eslint-rules/rules/define-feature-events.cjs
+++ b/packages/grafana-eslint-rules/rules/define-feature-events.cjs
@@ -148,14 +148,13 @@ const defineFeatureEventsRule = createRule({
             (e) => e.expression.type === AST_NODE_TYPES.Identifier && e.expression.name === 'EventProperty'
           ) ?? false;
 
-        const numberOfComments = context.sourceCode.getCommentsBefore(node).length;
-
         if (!extendsEventProperty) {
           context.report({ node, messageId: 'interfaceMustExtend' });
           return;
         }
 
         for (const member of node.body.body) {
+          const numberOfComments = context.sourceCode.getCommentsBefore(member).length;
           if (numberOfComments === 0) {
             context.report({ node: member, messageId: 'missingPropertyComment' });
           }

--- a/packages/grafana-eslint-rules/rules/define-feature-events.cjs
+++ b/packages/grafana-eslint-rules/rules/define-feature-events.cjs
@@ -112,14 +112,18 @@ const defineFeatureEventsRule = createRule({
           }
 
           for (const prop of init.properties) {
+            const numberOfComments = context.sourceCode.getCommentsBefore(prop).length;
             if (prop.type !== AST_NODE_TYPES.Property) {
               continue;
             }
             if (!propertyValueCallsFactory(prop.value)) {
               continue;
             }
-            if (context.sourceCode.getCommentsBefore(prop).length === 0) {
+            if (numberOfComments === 0) {
               context.report({ node: prop, messageId: 'missingEventComment' });
+            }
+            if (numberOfComments >= 2) {
+              context.report({ node: prop, messageId: 'stackedJSDocComment' });
             }
           }
           return;
@@ -144,14 +148,19 @@ const defineFeatureEventsRule = createRule({
             (e) => e.expression.type === AST_NODE_TYPES.Identifier && e.expression.name === 'EventProperty'
           ) ?? false;
 
+        const numberOfComments = context.sourceCode.getCommentsBefore(node).length;
+
         if (!extendsEventProperty) {
           context.report({ node, messageId: 'interfaceMustExtend' });
           return;
         }
 
         for (const member of node.body.body) {
-          if (context.sourceCode.getCommentsBefore(member).length === 0) {
+          if (numberOfComments === 0) {
             context.report({ node: member, messageId: 'missingPropertyComment' });
+          }
+          if (numberOfComments >= 2) {
+            context.report({ node: member, messageId: 'stackedJSDocComment' });
           }
         }
       },
@@ -170,6 +179,7 @@ const defineFeatureEventsRule = createRule({
       missingEventComment: 'Each event must have a JSDoc comment describing when it fires or its purpose.',
       interfaceMustExtend: 'Event property interfaces must extend `EventProperty` from `@grafana/runtime/internal`.',
       missingPropertyComment: 'Each interface property must have a JSDoc comment describing what it captures.',
+      stackedJSDocComment: 'Each interface property or event must just have one JSDoc comment describing it',
     },
     schema: [],
   },

--- a/packages/grafana-eslint-rules/rules/define-feature-events.cjs
+++ b/packages/grafana-eslint-rules/rules/define-feature-events.cjs
@@ -31,6 +31,21 @@ const defineFeatureEventsRule = createRule({
       return false;
     }
 
+    // Counts only the JSDoc blocks
+    /** @param {import('@typescript-eslint/utils').TSESTree.Node} node */
+    function countJsDocsBefore(node) {
+      const previousToken = context.sourceCode.getTokenBefore(node, { includeComments: false });
+
+      return context.sourceCode
+        .getCommentsBefore(node)
+        .filter(
+          (comment) =>
+            comment.type === 'Block' &&
+            comment.value.startsWith('*') &&
+            (!previousToken || comment.loc.start.line > previousToken.loc.end.line)
+        ).length;
+    }
+
     // Also handles arrow-wrapper variant: (props: X) => factory<X>('event')({ ...props })
     /** @param {import('@typescript-eslint/utils').TSESTree.Node} valueNode */
     function propertyValueCallsFactory(valueNode) {
@@ -112,17 +127,16 @@ const defineFeatureEventsRule = createRule({
           }
 
           for (const prop of init.properties) {
-            const numberOfComments = context.sourceCode.getCommentsBefore(prop).length;
             if (prop.type !== AST_NODE_TYPES.Property) {
               continue;
             }
             if (!propertyValueCallsFactory(prop.value)) {
               continue;
             }
-            if (numberOfComments === 0) {
+            const numberOfJsDocs = countJsDocsBefore(prop);
+            if (numberOfJsDocs === 0) {
               context.report({ node: prop, messageId: 'missingEventComment' });
-            }
-            if (numberOfComments >= 2) {
+            } else if (numberOfJsDocs >= 2) {
               context.report({ node: prop, messageId: 'stackedJSDocComment' });
             }
           }
@@ -131,8 +145,11 @@ const defineFeatureEventsRule = createRule({
 
         // Pattern (b) — individual export
         if (callsFactoryVariable(init)) {
-          if (context.sourceCode.getCommentsBefore(node).length === 0) {
+          const numberOfJsDocs = countJsDocsBefore(node);
+          if (numberOfJsDocs === 0) {
             context.report({ node: decl.declarations[0].id, messageId: 'missingEventComment' });
+          } else if (numberOfJsDocs >= 2) {
+            context.report({ node: decl.declarations[0].id, messageId: 'stackedJSDocComment' });
           }
         }
       },
@@ -154,11 +171,10 @@ const defineFeatureEventsRule = createRule({
         }
 
         for (const member of node.body.body) {
-          const numberOfComments = context.sourceCode.getCommentsBefore(member).length;
-          if (numberOfComments === 0) {
+          const numberOfJsDocs = countJsDocsBefore(member);
+          if (numberOfJsDocs === 0) {
             context.report({ node: member, messageId: 'missingPropertyComment' });
-          }
-          if (numberOfComments >= 2) {
+          } else if (numberOfJsDocs >= 2) {
             context.report({ node: member, messageId: 'stackedJSDocComment' });
           }
         }

--- a/packages/grafana-eslint-rules/tests/define-feature-events.test.js
+++ b/packages/grafana-eslint-rules/tests/define-feature-events.test.js
@@ -53,6 +53,61 @@ ruleTester.run('define-feature-events', defineFeatureEventsRule, {
     {
       code: `export const foo = { bar: someOtherFn('x') };`,
     },
+    // Individually exported event with a description
+    {
+      code: `
+        ${DEFINE_EVENTS_IMPORT}
+        const createEvent = defineFeatureEvents('grafana', 'homepage');
+        /** Fires once when the homepage first renders. */
+        export const homepageViewed = createEvent('viewed');
+      `,
+    },
+    // A line comment above a single JSDoc block is not a second description
+    {
+      code: `
+        ${EVENT_PROPERTY_IMPORT}
+        interface LoadedProps extends EventProperty {
+          // TODO: rename this property
+          /** Total number of items visible at load time. */
+          numberOfItems: number;
+        }
+      `,
+    },
+    // Neither is an eslint directive
+    {
+      code: `
+        ${DEFINE_EVENTS_IMPORT}
+        const createEvent = defineFeatureEvents('grafana', 'dashboard_library');
+        export const MyInteractions = {
+          // eslint-disable-next-line no-console
+          /** Fires when loaded. */
+          loaded: createEvent('loaded'),
+        };
+      `,
+    },
+    // Nor a plain block comment, which carries no description for the report
+    {
+      code: `
+        ${EVENT_PROPERTY_IMPORT}
+        interface LoadedProps extends EventProperty {
+          /* internal note */
+          /** Total number of items visible at load time. */
+          numberOfItems: number;
+        }
+      `,
+    },
+    // A JSDoc trailing the previous property belongs to that property, not to the next one
+    {
+      code: `
+        ${EVENT_PROPERTY_IMPORT}
+        interface LoadedProps extends EventProperty {
+          /** Identifier of the library. */
+          libraryId: string; /** trailing note */
+          /** Total number of items visible at load time. */
+          numberOfItems: number;
+        }
+      `,
+    },
   ],
 
   invalid: [
@@ -90,6 +145,99 @@ ruleTester.run('define-feature-events', defineFeatureEventsRule, {
       code: `
         ${EVENT_PROPERTY_IMPORT}
         interface LoadedProps extends EventProperty {
+          numberOfItems: number;
+        }
+      `,
+      errors: [{ messageId: 'missingPropertyComment' }],
+    },
+    // Individually exported event with no description
+    {
+      code: `
+        ${DEFINE_EVENTS_IMPORT}
+        const createEvent = defineFeatureEvents('grafana', 'homepage');
+        export const homepageViewed = createEvent('viewed');
+      `,
+      errors: [{ messageId: 'missingEventComment' }],
+    },
+    // Stacked JSDoc on an event in a grouped object
+    {
+      code: `
+        ${DEFINE_EVENTS_IMPORT}
+        const createEvent = defineFeatureEvents('grafana', 'dashboard_library');
+        export const MyInteractions = {
+          /** Fires when loaded. */
+          /** Only once the items are visible. */
+          loaded: createEvent('loaded'),
+        };
+      `,
+      errors: [{ messageId: 'stackedJSDocComment' }],
+    },
+    // Stacked JSDoc on an individually exported event
+    {
+      code: `
+        ${DEFINE_EVENTS_IMPORT}
+        const createEvent = defineFeatureEvents('grafana', 'homepage');
+        /** Fires once when the homepage first renders. */
+        /** Never while a loading skeleton is showing. */
+        export const homepageViewed = createEvent('viewed');
+      `,
+      errors: [{ messageId: 'stackedJSDocComment' }],
+    },
+    // Stacked JSDoc on an interface property
+    {
+      code: `
+        ${EVENT_PROPERTY_IMPORT}
+        interface LoadedProps extends EventProperty {
+          /** Total number of items. */
+          /** Counted at load time. */
+          numberOfItems: number;
+        }
+      `,
+      errors: [{ messageId: 'stackedJSDocComment' }],
+    },
+    // Three blocks are reported once, not once per extra block
+    {
+      code: `
+        ${EVENT_PROPERTY_IMPORT}
+        interface LoadedProps extends EventProperty {
+          /** One. */
+          /** Two. */
+          /** Three. */
+          numberOfItems: number;
+        }
+      `,
+      errors: [{ messageId: 'stackedJSDocComment' }],
+    },
+    // Several line comments are still no description, so this is missing rather than stacked
+    {
+      code: `
+        ${EVENT_PROPERTY_IMPORT}
+        interface LoadedProps extends EventProperty {
+          // first note
+          // second note
+          numberOfItems: number;
+        }
+      `,
+      errors: [{ messageId: 'missingPropertyComment' }],
+    },
+    // A single line comment does not satisfy the requirement either
+    {
+      code: `
+        ${EVENT_PROPERTY_IMPORT}
+        interface LoadedProps extends EventProperty {
+          // TODO: document this
+          numberOfItems: number;
+        }
+      `,
+      errors: [{ messageId: 'missingPropertyComment' }],
+    },
+    // A JSDoc trailing the previous property does not document the next one
+    {
+      code: `
+        ${EVENT_PROPERTY_IMPORT}
+        interface LoadedProps extends EventProperty {
+          /** Identifier of the library. */
+          libraryId: string; /** trailing note */
           numberOfItems: number;
         }
       `,

--- a/packages/grafana-eslint-rules/tests/define-feature-events.test.js
+++ b/packages/grafana-eslint-rules/tests/define-feature-events.test.js
@@ -1,3 +1,4 @@
+import * as tsParser from '@typescript-eslint/parser';
 import { RuleTester } from 'eslint';
 
 import defineFeatureEventsRule from '../rules/define-feature-events.cjs';
@@ -6,7 +7,8 @@ RuleTester.setDefaultConfig({
   languageOptions: {
     ecmaVersion: 2020,
     sourceType: 'module',
-    parser: require('@typescript-eslint/parser'),
+    // Imported rather than required: this package is an ES module, so `require` is not defined here.
+    parser: tsParser,
   },
 });
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Adds `stackedJSDocComment` check to prevent users from using more than a JSDoc 

**Why do we need this feature?**
To prevent issues like https://github.com/grafana/grafana/pull/130363, where the report crashed while parsing event definitions.

**Who is this feature for?**
Everyone using `Analytics Framework`

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
