### PR TITLE
Docs: Jaeger quarterly update (FY27 Q3)

### DIFF
--- a/docs/sources/datasources/jaeger/_index.md
+++ b/docs/sources/datasources/jaeger/_index.md
@@ -16,12 +16,14 @@ labels:
 menuTitle: Jaeger
 title: Jaeger data source
 weight: 800
-review_date: 2026-03-03
+review_date: 2026-08-11
 ---
 
 # Jaeger data source
 
-Grafana ships with built-in support for [Jaeger](https://www.jaegertracing.io/), an open source, end-to-end distributed tracing system. Use the Jaeger data source to query and visualize traces, explore service dependencies, and correlate traces with logs and metrics.
+[Jaeger](https://www.jaegertracing.io/) is an open source, end-to-end distributed tracing system. Use the Jaeger data source to query and visualize traces, explore service dependencies, and correlate traces with logs and metrics.
+
+Grafana ships with the Jaeger data source preinstalled in both Grafana OSS and Enterprise, so there's nothing to install. It's packaged as a standalone plugin that updates independently of Grafana releases. For more information, refer to [Plugin updates](#plugin-updates).
 
 ## Supported features
 
@@ -40,6 +42,30 @@ The following documents help you set up and use the Jaeger data source:
 - [Configure the Jaeger data source](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/jaeger/configure/)
 - [Jaeger query editor](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/jaeger/query-editor/)
 - [Troubleshoot Jaeger data source issues](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/jaeger/troubleshooting/)
+
+## Plugin updates
+
+Starting with Grafana v13.2, the Jaeger data source is a standalone plugin, preinstalled in both Grafana OSS and Enterprise. This lets the data source receive updates independently of Grafana releases. Grafana automatically checks the plugin catalog and installs the latest version on each server restart.
+
+To adjust this behavior:
+
+- **Opt out of auto-updates:** Set `preinstall_auto_update` to `false` in your [configuration file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/).
+- **Update manually:** Update at any time from the **Administration > Plugins** page without restarting Grafana.
+
+The standalone plugin requires Grafana 12.3.0 or later. The Jaeger data source bundled with Grafana 12.2 and earlier continues to work as before. These versions are unaffected by the change.
+
+If you run Grafana 12.3.x through 13.1.x, you can install the standalone plugin from the plugin catalog to get the latest features before you upgrade to Grafana 13.2. To use the standalone plugin with these versions, add the following to your [configuration file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/):
+
+```ini
+[plugin.jaeger]
+as_external = true
+
+[plugins]
+; Install the latest version on startup:
+preinstall_sync = jaeger
+; Or install a specific version:
+; preinstall_sync = jaeger@<version>
+```
 
 ## Additional features
 

--- a/docs/sources/datasources/jaeger/configure/index.md
+++ b/docs/sources/datasources/jaeger/configure/index.md
@@ -16,7 +16,7 @@ labels:
 menuTitle: Configure
 title: Configure the Jaeger data source
 weight: 100
-review_date: 2026-03-03
+review_date: 2026-08-11
 ---
 
 # Configure the Jaeger data source

--- a/docs/sources/datasources/jaeger/query-editor/index.md
+++ b/docs/sources/datasources/jaeger/query-editor/index.md
@@ -16,7 +16,7 @@ labels:
 menuTitle: Query editor
 title: Jaeger query editor
 weight: 200
-review_date: 2026-03-03
+review_date: 2026-08-11
 ---
 
 # Jaeger query editor
@@ -149,7 +149,7 @@ The JSON file must follow the Jaeger trace format with a `data` array containing
 }
 ```
 
-## Query data via gRPC endpoint (public preview)
+## Query data via gRPC endpoint (experimental)
 
 Jaeger offers an alternative method for querying data that uses their gRPC service over HTTP. For detailed information about the API and setup requirements, refer to the [Jaeger API documentation](https://www.jaegertracing.io/docs/2.12/architecture/apis/#query-json-over-http).
 
@@ -159,7 +159,7 @@ The following queries are supported through the gRPC endpoint:
 - Operation search
 - Trace ID search
 
-To enable gRPC querying for Jaeger within Grafana, enable the `jaegerEnableGrpcEndpoint` feature flag. Grafana Cloud customers should contact support to request access and provide feedback on this feature.
+To enable gRPC querying for Jaeger within Grafana, enable the `jaegerEnableGrpcEndpoint` feature flag. This feature is experimental. Grafana Cloud customers should contact support to request access and provide feedback on this feature.
 
 ## Use template variables
 

--- a/docs/sources/datasources/jaeger/troubleshooting/index.md
+++ b/docs/sources/datasources/jaeger/troubleshooting/index.md
@@ -16,7 +16,7 @@ labels:
 menuTitle: Troubleshooting
 title: Troubleshoot Jaeger data source issues
 weight: 500
-review_date: 2026-03-03
+review_date: 2026-08-11
 ---
 
 # Troubleshoot Jaeger data source issues
@@ -196,7 +196,7 @@ These errors occur when using the gRPC query endpoint.
 
 **Solutions:**
 
-1. Verify the `jaegerEnableGrpcEndpoint` feature flag is enabled in Grafana. This feature is in public preview.
+1. Verify the `jaegerEnableGrpcEndpoint` feature flag is enabled in Grafana. This feature is experimental.
 1. Grafana Cloud customers should contact support to request access.
 1. Note that search and dependency graph queries currently use the REST endpoint even when the feature flag is enabled. Only service search, operation search, and trace ID queries use gRPC.
 


### PR DESCRIPTION
Quarterly documentation update for the Jaeger data source. The main change reflects Jaeger's move out of core: as of Grafana 13.2 it ships as a preinstalled standalone plugin rather than a built-in core data source. Content was cross-referenced against the external grafana/grafana-jaeger-datasource plugin source for accuracy.

_index.md: Reworded intro to drop "built-in support" phrasing, clarified Grafana still ships Jaeger preinstalled in OSS and Enterprise, added a "Plugin updates" section (auto-update on restart, preinstall_auto_update opt-out, manual updates via Administration > Plugins, minimum Grafana 12.3.0, and as_external/preinstall_sync opt-in for Grafana 12.3.x–13.1.x), updated review_date

configure/index.md: Updated review_date, config options verified accurate against ConfigEditor source

query-editor/index.md: Corrected gRPC endpoint feature stage from "public preview" to "experimental" to match the feature toggle registry, updated review_date

troubleshooting/index.md: Corrected gRPC feature stage wording from "public preview" to "experimental", updated review_date

Technical accuracy verified against:

grafana/grafana-jaeger-datasource src/plugin.json (supported features, grafanaDependency >=12.3.0-0)
src/configuration/ConfigEditor.tsx (connection, auth, trace-to-logs/metrics, Node graph, Span bar, Trace ID time params)
src/components/QueryEditor.tsx, src/types.ts (query types and search fields)
pkg/jaeger/querydata.go, pkg/jaeger/callresource.go (gRPC vs REST routing per query type)
pkg/services/featuremgmt/registry.go (jaegerEnableGrpcEndpoint stage: experimental)


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
