### PR TITLE
PanelEditNext: Responsive styling for add buttons when query stack is narrow

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/AddCardButton.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/AddCardButton.tsx
@@ -205,8 +205,8 @@ function getStyles(theme: GrafanaTheme2, alwaysVisible: boolean) {
       height: theme.spacing(2.5),
       borderRadius: theme.shape.radius.sm,
       border: 'none',
-      background: theme.colors.primary.main,
-      color: theme.colors.primary.contrastText,
+      background: theme.colors.secondary.main,
+      color: theme.colors.secondary.contrastText,
       cursor: 'pointer',
       padding: 0,
       // Never let the row's flex layout shrink this below its own content — the section title
@@ -235,7 +235,7 @@ function getStyles(theme: GrafanaTheme2, alwaysVisible: boolean) {
       }),
 
       '&:hover': {
-        background: theme.colors.primary.shade,
+        background: theme.colors.secondary.shade,
       },
 
       '&:active': {
@@ -243,7 +243,7 @@ function getStyles(theme: GrafanaTheme2, alwaysVisible: boolean) {
       },
 
       '&:focus-visible': {
-        outline: `2px solid ${theme.colors.primary.border}`,
+        outline: `2px solid ${theme.colors.secondary.border}`,
         outlineOffset: '2px',
         ...(!alwaysVisible && {
           opacity: 1,

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/AddCardButton.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/AddCardButton.tsx
@@ -209,6 +209,9 @@ function getStyles(theme: GrafanaTheme2, alwaysVisible: boolean) {
       color: theme.colors.primary.contrastText,
       cursor: 'pointer',
       padding: 0,
+      // Never let the row's flex layout shrink this below its own content — the section title
+      // wraps to make room instead.
+      flexShrink: 0,
       willChange: 'transform',
       transform: alwaysVisible ? 'translateZ(0)' : 'translateY(-50%) translateZ(0)',
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/AddCardButton.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/AddCardButton.tsx
@@ -243,7 +243,9 @@ function getStyles(theme: GrafanaTheme2, alwaysVisible: boolean) {
       },
 
       '&:focus-visible': {
-        outline: `2px solid ${theme.colors.secondary.border}`,
+        // Intentionally not theme.colors.secondary.border — that token is a faint decorative
+        // border for the solid fill and is nearly invisible as a focus ring against it.
+        outline: `2px solid ${theme.colors.primary.border}`,
         outlineOffset: '2px',
         ...(!alwaysVisible && {
           opacity: 1,

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/CollapsableSection.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/CollapsableSection.tsx
@@ -28,7 +28,7 @@ export const CollapsableSection = ({ label, isOpen, onToggle, headerAction, chil
           aria-controls={contentId}
         >
           <Icon name={isOpen ? 'angle-down' : 'angle-right'} />
-          <Text color="primary" variant="bodySmall" weight="light">
+          <Text color="primary" variant="bodySmall" weight="light" truncate title={label}>
             {label}
           </Text>
         </button>
@@ -60,10 +60,9 @@ const getStyles = (theme: GrafanaTheme2) => ({
     gap: theme.spacing(1),
     cursor: 'pointer',
     borderRadius: theme.shape.radius.sm,
-    // Lets the label wrap (even mid-word for single-word labels like "Transformations") instead
-    // of overflowing the header row and pushing the add button out of view.
+    // Lets the label truncate instead of overflowing the header row and pushing the add button
+    // out of view.
     minWidth: 0,
-    overflowWrap: 'anywhere',
     '&:focus-visible': getFocusStyles(theme),
   }),
 });

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/CollapsableSection.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/CollapsableSection.tsx
@@ -60,6 +60,10 @@ const getStyles = (theme: GrafanaTheme2) => ({
     gap: theme.spacing(1),
     cursor: 'pointer',
     borderRadius: theme.shape.radius.sm,
+    // Lets the label wrap (even mid-word for single-word labels like "Transformations") instead
+    // of overflowing the header row and pushing the add button out of view.
+    minWidth: 0,
+    overflowWrap: 'anywhere',
     '&:focus-visible': getFocusStyles(theme),
   }),
 });


### PR DESCRIPTION
## Description
This PR closes #130449. It fixes a responsive layout bug in `PanelEditNext`'s query/transformation sidebar where the `+ Add` button on the `Transformations` section header gets clipped when the sidebar is narrow, and switches the add buttons from the `primary` to `secondary` button variant.

## Changes
- `CollapsableSection`: let the section title truncate with an ellipsis (`Text truncate`, `min-width: 0` on the toggle button) instead of overflowing the header row. `Transformations` is a single word with no space to wrap on, so at narrow widths it previously hit its min-content floor and overflowed the row, and the `Sidebar`'s `overflow-x: hidden` scroll container silently clipped the add button. A native `title` attribute preserves access to the full label on hover, since `Text`'s styled tooltip only wraps non-`span` elements and this label has to stay `span` (button content must be phrasing content).
- `AddCardButton`: add `flexShrink: 0` so the button itself is never compressed — the section title truncates first to make room.
- `AddCardButton`: switch background/hover colors from `theme.colors.primary` to `theme.colors.secondary`. The `:focus-visible` outline stays on `theme.colors.primary.border` rather than following suit — `secondary.border` is a faint decorative token meant for the solid fill's edge and is nearly invisible as a focus ring against it (caught by [Cursor Bugbot](https://github.com/grafana/grafana/pull/130500#pullrequestreview-4907474932) on an earlier revision).

## Risks
None identified. Pure CSS/style change scoped to `PanelEditNext`'s query/transformation sidebar, behind the `queryEditorNext` feature flag.

## Demo
### Before
See #130449 for the original repro screenshots — the `Transformations` add button gets clipped as the sidebar narrows.

### After

<!-- dpro311-after-narrow-v2.png: sidebar at its 200px minimum width — both labels truncate with an ellipsis, add buttons fully visible in the new secondary color -->

When the sidebar is very narrow, both labels truncate with an ellipsis, add buttons fully visible in the new secondary color:

<img width="230" height="110" alt="query stack narrow after" src="https://github.com/user-attachments/assets/47ea8c76-aff7-4aee-b179-02d684dd2cd1" />

<!-- dpro311-after-wide-v2.png: wider sidebar — full labels, same secondary-colored buttons -->

When the sidebar is wider, we get full labels and same secondary-colored buttons:

<img width="345" height="110" alt="query stack wide after" src="https://github.com/user-attachments/assets/7869e056-182a-4f21-8de7-ac570aec05c4" />

<!-- dpro311-focus-ring-visible.png: keyboard focus on the "Queries & Expressions" add button — outline ring is clearly visible against the secondary fill -->

When expanded, the outline ring is clearly visible against the secondary fill:

<img width="230" height="180" alt="query stack expanded narrow after" src="https://github.com/user-attachments/assets/6fa46fb9-efa3-4e3a-8fc7-e5fa0b852e02" />

## Testing Instructions
- Enable the `queryEditorNext` feature toggle.
- Open any dashboard panel in edit mode.
- Add a transformation so both the `Queries & Expressions` and `Transformations` sections are visible.
- Drag the sidebar splitter to its narrowest width and confirm the `+ Add` buttons remain fully visible, truncate their labels with an ellipsis, and are styled as secondary (gray, not teal).
- Tab to an add button and confirm the focus ring is clearly visible.

## Reviewer Checklist
Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.
