### PR TITLE
Docs: OpenTSDB quarterly update (FY27 Q3)

### DIFF
--- a/docs/sources/datasources/opentsdb/_index.md
+++ b/docs/sources/datasources/opentsdb/_index.md
@@ -18,12 +18,14 @@ labels:
 menuTitle: OpenTSDB
 title: OpenTSDB data source
 weight: 1100
-last_reviewed: 2026-01-28
+review_date: 2026-08-11
 ---
 
 # OpenTSDB data source
 
-Grafana ships with support for OpenTSDB, an open source time series database built on top of HBase. Use the OpenTSDB data source to visualize metrics, create alerts, and build dashboards from your time series data.
+OpenTSDB is an open source time series database built on top of HBase. Use the OpenTSDB data source to visualize metrics, create alerts, and build dashboards from your time series data.
+
+Grafana ships with OpenTSDB preinstalled in both Grafana OSS and Enterprise, so there's nothing for you to install. The data source is now packaged as a standalone plugin that updates independently of Grafana releases. For details, refer to [Plugin updates](#plugin-updates).
 
 ## Supported features
 
@@ -55,6 +57,30 @@ The following documents help you get started with the OpenTSDB data source:
 - [OpenTSDB query editor](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/opentsdb/query-editor/) - Create and edit queries with aggregation, downsampling, and filtering.
 - [Template variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/opentsdb/template-variables/) - Create dynamic dashboards with OpenTSDB variables.
 - [Troubleshooting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/opentsdb/troubleshooting/) - Solve common configuration and query errors.
+
+## Plugin updates
+
+Starting with Grafana v13.2, the OpenTSDB data source is a standalone plugin, preinstalled in both Grafana OSS and Enterprise. This enables more frequent updates independent of Grafana releases. Grafana automatically checks the plugin catalog and installs the latest version on each server restart.
+
+To adjust this behavior:
+
+- **Opt out of auto-updates:** Set `preinstall_auto_update` to `false` in your [configuration file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/).
+- **Update manually:** Update at any time from the **Administration > Plugins** page without restarting Grafana.
+
+The standalone plugin requires Grafana 12.3.0 or later. The OpenTSDB data source bundled with Grafana 12.2 and earlier continues to work as before. These versions are unaffected by the externalization.
+
+Users running Grafana 12.3.x through 13.1.x can install the standalone plugin from the plugin catalog if they want the latest features before upgrading to Grafana 13.2. To use the standalone plugin with these versions, add the following to your [configuration file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/):
+
+```ini
+[plugin.opentsdb]
+as_external = true
+
+[plugins]
+; Install the latest version on startup:
+preinstall_sync = opentsdb
+; Or install a specific version:
+; preinstall_sync = opentsdb@<version>
+```
 
 ## Additional features
 

--- a/docs/sources/datasources/opentsdb/alerting/index.md
+++ b/docs/sources/datasources/opentsdb/alerting/index.md
@@ -14,7 +14,7 @@ labels:
 menuTitle: Alerting
 title: OpenTSDB alerting
 weight: 400
-last_reviewed: 2026-01-28
+review_date: 2026-08-11
 ---
 
 # OpenTSDB alerting

--- a/docs/sources/datasources/opentsdb/annotations/index.md
+++ b/docs/sources/datasources/opentsdb/annotations/index.md
@@ -111,11 +111,11 @@ Mark incident start and resolution times:
 
 Track when configuration changes are applied:
 
-| Field                   | Value           |
-| ----------------------- | --------------- |
+| Field                   | Value                 |
+| ----------------------- | --------------------- |
 | Name                    | Configuration changes |
-| OpenTSDB metrics query  | `events.config` |
-| Show Global Annotations | disabled        |
+| OpenTSDB metrics query  | `events.config`       |
+| Show Global Annotations | disabled              |
 
 ### Correlate multiple event types
 

--- a/docs/sources/datasources/opentsdb/annotations/index.md
+++ b/docs/sources/datasources/opentsdb/annotations/index.md
@@ -13,7 +13,7 @@ labels:
 menuTitle: Annotations
 title: OpenTSDB annotations
 weight: 450
-last_reviewed: 2026-01-28
+review_date: 2026-08-11
 ---
 
 # OpenTSDB annotations

--- a/docs/sources/datasources/opentsdb/annotations/index.md
+++ b/docs/sources/datasources/opentsdb/annotations/index.md
@@ -87,7 +87,7 @@ This query retrieves annotations attached to the `deploy.myapp` metric, showing 
 
 ### Monitor infrastructure-wide events
 
-Capture system-wide events such as network changes or datacenter maintenance:
+Capture system-wide events such as network changes or data center maintenance:
 
 | Field                   | Value                   |
 | ----------------------- | ----------------------- |
@@ -113,7 +113,7 @@ Track when configuration changes are applied:
 
 | Field                   | Value           |
 | ----------------------- | --------------- |
-| Name                    | Config Changes  |
+| Name                    | Configuration changes |
 | OpenTSDB metrics query  | `events.config` |
 | Show Global Annotations | disabled        |
 

--- a/docs/sources/datasources/opentsdb/configure/index.md
+++ b/docs/sources/datasources/opentsdb/configure/index.md
@@ -80,11 +80,11 @@ Configure these settings based on your OpenTSDB server version and configuration
 
 The version setting enables different query features in Grafana:
 
-| Version   | Available features                                                                                                   |
-| --------- | -------------------------------------------------------------------------------------------------------------------- |
-| **<=2.1** | Basic queries with tags. Uses legacy tag-based filtering.                                                            |
-| **==2.2** | Adds filter support (`literal_or`, `wildcard`, `regexp`, and more). Filters replace tags for more flexible queries.  |
-| **==2.3** | Adds explicit tags support for rate calculations and additional filter types.                                        |
+| Version   | Available features                                                                                                           |
+| --------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| **<=2.1** | Basic queries with tags. Uses legacy tag-based filtering.                                                                    |
+| **==2.2** | Adds filter support (`literal_or`, `wildcard`, `regexp`, and more). Filters replace tags for more flexible queries.          |
+| **==2.3** | Adds explicit tags support for rate calculations and additional filter types.                                                |
 | **==2.4** | Adds fill policy support for downsampling (`none`, `null`, `zero`, `nan`). Enables `arrays=true` for alerting compatibility. |
 
 Select the version that matches your OpenTSDB server. If you're unsure, check your OpenTSDB version with the `/api/version` endpoint.

--- a/docs/sources/datasources/opentsdb/configure/index.md
+++ b/docs/sources/datasources/opentsdb/configure/index.md
@@ -83,9 +83,9 @@ The version setting enables different query features in Grafana:
 | Version   | Available features                                                                                                   |
 | --------- | -------------------------------------------------------------------------------------------------------------------- |
 | **<=2.1** | Basic queries with tags. Uses legacy tag-based filtering.                                                            |
-| **==2.2** | Adds filter support (literal_or, wildcard, regexp, and more). Filters replace tags for more flexible queries.        |
+| **==2.2** | Adds filter support (`literal_or`, `wildcard`, `regexp`, and more). Filters replace tags for more flexible queries.  |
 | **==2.3** | Adds explicit tags support for rate calculations and additional filter types.                                        |
-| **==2.4** | Adds fill policy support for downsampling (none, null, zero, nan). Enables `arrays=true` for alerting compatibility. |
+| **==2.4** | Adds fill policy support for downsampling (`none`, `null`, `zero`, `nan`). Enables `arrays=true` for alerting compatibility. |
 
 Select the version that matches your OpenTSDB server. If you're unsure, check your OpenTSDB version with the `/api/version` endpoint.
 

--- a/docs/sources/datasources/opentsdb/configure/index.md
+++ b/docs/sources/datasources/opentsdb/configure/index.md
@@ -14,7 +14,7 @@ labels:
 menuTitle: Configure
 title: Configure the OpenTSDB data source
 weight: 100
-last_reviewed: 2026-01-28
+review_date: 2026-08-11
 ---
 
 # Configure the OpenTSDB data source
@@ -88,6 +88,10 @@ The version setting enables different query features in Grafana:
 | **==2.4** | Adds fill policy support for downsampling (none, null, zero, nan). Enables `arrays=true` for alerting compatibility. |
 
 Select the version that matches your OpenTSDB server. If you're unsure, check your OpenTSDB version with the `/api/version` endpoint.
+
+## Secure SOCKS proxy
+
+The OpenTSDB data source supports connecting through a secure SOCKS5 proxy. Use this to reach an OpenTSDB server hosted in a different network than Grafana without exposing it to the public internet. You configure the proxy at the Grafana instance level. For setup instructions, refer to [Configure a data source SOCKS5 connection proxy](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/proxy/).
 
 ## Verify the connection
 

--- a/docs/sources/datasources/opentsdb/query-editor/index.md
+++ b/docs/sources/datasources/opentsdb/query-editor/index.md
@@ -312,7 +312,7 @@ This query sums HTTP request counts across all hosts matching `web-*` and groups
 
 This query calculates the rate of bytes received per second. The counter max is set to the 64-bit unsigned integer maximum to handle counter wraps correctly.
 
-### Using alias patterns
+### Use alias patterns
 
 | Field      | Value                       |
 | ---------- | --------------------------- |
@@ -323,7 +323,7 @@ This query calculates the rate of bytes received per second. The counter max is 
 
 This query uses the alias pattern to create readable legend labels like `webserver01 - Response Time`.
 
-### Downsampling with custom interval
+### Downsample with a custom interval
 
 | Field                 | Value               |
 | --------------------- | ------------------- |
@@ -333,7 +333,7 @@ This query uses the alias pattern to create readable legend labels like `webserv
 | Downsample Aggregator | `avg`               |
 | Fill                  | `zero`              |
 
-This query downsamples disk I/O data to 5-minute averages, filling gaps with zero values.
+This query reduces disk I/O data to 5-minute averages, filling gaps with zero values.
 
 ### Compare environments with filters
 

--- a/docs/sources/datasources/opentsdb/query-editor/index.md
+++ b/docs/sources/datasources/opentsdb/query-editor/index.md
@@ -17,7 +17,7 @@ labels:
 menuTitle: Query editor
 title: OpenTSDB query editor
 weight: 200
-last_reviewed: 2026-01-28
+review_date: 2026-08-11
 ---
 
 # OpenTSDB query editor
@@ -60,12 +60,12 @@ The alias field supports dynamic substitution using tag values. Use the pattern 
 
 Downsampling reduces the number of data points returned by aggregating values over time intervals. This improves query performance and reduces the amount of data transferred.
 
-| Field                    | Description                                                                                                              |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------ |
-| **Interval**             | The time interval for downsampling. Leave blank to use the automatic interval based on the panel's time range and width. |
-| **Aggregator**           | The aggregation function for downsampling. Default: `avg`.                                                               |
-| **Fill**                 | (Version 2.2+) The fill policy for missing data points. Default: `none`.                                                 |
-| **Disable downsampling** | Toggle to disable downsampling entirely. Use this when you need raw data points.                                         |
+| Field                    | Description                                                                                                                                            |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Down sample**          | The time interval for downsampling. Enter a value in the input next to the **Down sample** label, or leave it blank to use the automatic interval based on the panel's time range and width. |
+| **Aggregator**           | The aggregation function for downsampling. Default: `avg`.                                                                                             |
+| **Fill**                 | (Version 2.2+) The fill policy for missing data points. Default: `none`.                                                                              |
+| **Disable downsampling** | Toggle to disable downsampling entirely. Use this when you need raw data points.                                                                      |
 
 ### Interval format
 
@@ -193,7 +193,7 @@ When **Explicit tags** is enabled (version 2.3+), OpenTSDB only returns time ser
 
 ## Aggregators
 
-The aggregator function combines multiple time series into one. Grafana fetches the list of available aggregators from your OpenTSDB server, so you may see additional aggregators beyond those listed here.
+The aggregator function combines multiple time series into one. The data source includes a built-in default list (`avg`, `sum`, `min`, `max`, `dev`, `zimsum`, `mimmin`, and `mimmax`), then replaces it with the list fetched from your OpenTSDB server. As a result, you may see additional aggregators, such as `count`, beyond the built-in defaults.
 
 ### Common aggregators
 

--- a/docs/sources/datasources/opentsdb/query-editor/index.md
+++ b/docs/sources/datasources/opentsdb/query-editor/index.md
@@ -60,12 +60,12 @@ The alias field supports dynamic substitution using tag values. Use the pattern 
 
 Downsampling reduces the number of data points returned by aggregating values over time intervals. This improves query performance and reduces the amount of data transferred.
 
-| Field                    | Description                                                                                                                                            |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Field                    | Description                                                                                                                                                                                  |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Down sample**          | The time interval for downsampling. Enter a value in the input next to the **Down sample** label, or leave it blank to use the automatic interval based on the panel's time range and width. |
-| **Aggregator**           | The aggregation function for downsampling. Default: `avg`.                                                                                             |
-| **Fill**                 | (Version 2.2+) The fill policy for missing data points. Default: `none`.                                                                              |
-| **Disable downsampling** | Toggle to disable downsampling entirely. Use this when you need raw data points.                                                                      |
+| **Aggregator**           | The aggregation function for downsampling. Default: `avg`.                                                                                                                                   |
+| **Fill**                 | (Version 2.2+) The fill policy for missing data points. Default: `none`.                                                                                                                     |
+| **Disable downsampling** | Toggle to disable downsampling entirely. Use this when you need raw data points.                                                                                                             |
 
 ### Interval format
 

--- a/docs/sources/datasources/opentsdb/template-variables/index.md
+++ b/docs/sources/datasources/opentsdb/template-variables/index.md
@@ -20,7 +20,7 @@ review_date: 2026-08-11
 
 # OpenTSDB template variables
 
-Instead of hard-coding server, application, and sensor names in your metric queries, you can use template variables. Variables appear as drop-down menus at the top of the dashboard, making it easy to change the data being displayed without editing queries.
+Instead of hard-coding server, application, and sensor names in your metric queries, you can use template variables. Variables appear as drop-down menus at the top of the dashboard, so you can change the data being displayed without editing queries.
 
 For an introduction to template variables, refer to the [Variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/) documentation.
 
@@ -186,7 +186,7 @@ Variables can be used in these query editor fields:
 
 ## Multi-value variables
 
-When you enable **Multi-value** for a variable, users can select multiple values simultaneously. The OpenTSDB data source handles multi-value variables using pipe (`|`) separation, which is compatible with OpenTSDB's literal_or filter type.
+When you enable **Multi-value** for a variable, users can select multiple values simultaneously. The OpenTSDB data source handles multi-value variables using pipe (`|`) separation, which is compatible with OpenTSDB's `literal_or` filter type.
 
 ### Configure multi-value variables
 

--- a/docs/sources/datasources/opentsdb/template-variables/index.md
+++ b/docs/sources/datasources/opentsdb/template-variables/index.md
@@ -15,7 +15,7 @@ labels:
 menuTitle: Template variables
 title: OpenTSDB template variables
 weight: 300
-last_reviewed: 2026-01-28
+review_date: 2026-08-11
 ---
 
 # OpenTSDB template variables

--- a/docs/sources/datasources/opentsdb/troubleshooting/index.md
+++ b/docs/sources/datasources/opentsdb/troubleshooting/index.md
@@ -15,7 +15,7 @@ labels:
 menuTitle: Troubleshooting
 title: Troubleshoot OpenTSDB data source issues
 weight: 500
-last_reviewed: 2026-01-28
+review_date: 2026-08-11
 ---
 
 # Troubleshoot OpenTSDB data source issues

--- a/docs/sources/datasources/opentsdb/troubleshooting/index.md
+++ b/docs/sources/datasources/opentsdb/troubleshooting/index.md
@@ -149,7 +149,11 @@ These issues relate to slow queries or high resource usage.
 1. Check OpenTSDB and HBase performance metrics.
 1. Consider increasing OpenTSDB heap size if memory is constrained.
 
+<!-- vale Grafana.Headings = NO -->
+
 ### HBase performance issues
+
+<!-- vale Grafana.Headings = YES -->
 
 OpenTSDB relies on HBase for data storage. Performance problems in HBase directly affect OpenTSDB query performance.
 
@@ -157,7 +161,7 @@ OpenTSDB relies on HBase for data storage. Performance problems in HBase directl
 
 1. Monitor HBase region server health and compaction status.
 1. Ensure sufficient heap memory is allocated to HBase region servers.
-1. Check for region hotspots and rebalance if necessary.
+1. Check for region hot spots and redistribute regions if necessary.
 1. Refer to the [OpenTSDB troubleshooting guide](http://opentsdb.net/docs/build/html/user_guide/troubleshooting.html) for HBase-specific issues.
 
 ## Enable debug logging


### PR DESCRIPTION
Quarterly documentation update for the OpenTSDB data source (FY27 Q3). Documents OpenTSDB's move to a preinstalled standalone plugin, refreshes frontmatter to the current review_date standard, aligns query editor wording with the actual UI, and resolves outstanding Vale prose issues. All content was cross-referenced against the externalized plugin source (grafana/grafana-opentsdb-datasource) for accuracy.

_index.md: Reworded intro so it no longer implies OpenTSDB is bundled in the Grafana binary, added "Plugin updates" section (preinstalled in OSS and Enterprise starting Grafana 13.2, auto-update on restart, preinstall_auto_update opt-out, manual updates via Administration > Plugins, 12.3.0 minimum, and as_external/preinstall_sync opt-in snippet for Grafana 12.3.x–13.1.x), updated frontmatter to review_date

configure/index.md: Added "Secure SOCKS proxy" section with cross-link to the SOCKS5 proxy setup docs, backticked filter-type and fill-policy identifiers in the version-features table, updated frontmatter to review_date

query-editor/index.md: Aligned downsample field wording with the "Down sample" UI label and removed the nonexistent "Interval" field-label row, clarified that the aggregator list starts from built-in defaults then is replaced by the server /api/aggregators list (so extras like count appear), fixed gerund headings ("Use alias patterns", "Downsample with a custom interval"), updated frontmatter to review_date

alerting/index.md: Updated frontmatter to review_date

annotations/index.md: Corrected "datacenter" to "data center" and "Config Changes" to "Configuration changes", updated frontmatter to review_date

template-variables/index.md: Backticked the literal_or identifier, removed subjective "easy" wording from the intro, updated frontmatter to review_date

troubleshooting/index.md: Reworded "region hotspots and rebalance" to "region hot spots and redistribute regions", scoped a Grafana.Headings suppression around the HBase product-name heading, updated frontmatter to review_date

Technical accuracy verified against grafana/grafana-opentsdb-datasource:

src/plugin.json (grafanaDependency >=12.3.0, no bundled dashboards) and pkg/setting/setting_plugins.go in grafana/grafana (preinstall entry)
src/components/ConfigEditor.tsx, OpenTsdbDetails.tsx (config options, version/resolution/lookup-limit defaults, Secure SOCKS proxy support)
src/components/*.tsx query editor (field labels, defaults, version gating for Filters/Fill/Explicit tags)
src/datasource.ts (metricFindQuery template-variable functions and their suggest/lookup API mappings, annotation handling)
pkg/opentsdb/utils.go (arrays=true gated on OpenTSDB 2.4)

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
