### PR TITLE
Add Prometheus metrics to the search manifest watcher

### DIFF
--- a/pkg/storage/unified/resource/manifest_watcher.go
+++ b/pkg/storage/unified/resource/manifest_watcher.go
@@ -15,6 +15,8 @@ import (
 	"github.com/grafana/dskit/services"
 
 	authnlib "github.com/grafana/authlib/authn"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -103,6 +105,7 @@ type ManifestWatcher struct {
 	client       dynamic.Interface
 	pollInterval time.Duration
 	onChange     func([]app.Manifest)
+	metrics      *manifestWatcherMetrics
 
 	// byName is the current snapshot, keyed by apiserver object name. The name key
 	// lets a poll keep a known manifest when the same object later fails to
@@ -110,6 +113,36 @@ type ManifestWatcher struct {
 	mu       sync.RWMutex
 	byName   map[string]app.Manifest
 	lastHash string
+}
+
+// manifestWatcherMetrics are the watcher's Prometheus metrics. Built with a nil
+// registerer in tests, which promauto treats as a no-op.
+type manifestWatcherMetrics struct {
+	polls       *prometheus.CounterVec
+	reloads     prometheus.Counter
+	manifests   prometheus.Gauge
+	lastSuccess prometheus.Gauge
+}
+
+func newManifestWatcherMetrics(reg prometheus.Registerer) *manifestWatcherMetrics {
+	return &manifestWatcherMetrics{
+		polls: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "search_manifest_watcher_polls_total",
+			Help: "Manifest watcher poll cycles by result (success, empty, error).",
+		}, []string{"result"}),
+		reloads: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "search_manifest_watcher_reloads_total",
+			Help: "Times the manifest watcher published a changed manifest set.",
+		}),
+		manifests: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Name: "search_manifest_watcher_manifests",
+			Help: "Number of manifests in the current watcher snapshot.",
+		}),
+		lastSuccess: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Name: "search_manifest_watcher_last_success_timestamp_seconds",
+			Help: "Unix time of the last successful manifest watcher poll (list succeeded).",
+		}),
+	}
 }
 
 // newManifestRESTConfig builds a rest.Config that authenticates to the
@@ -156,7 +189,7 @@ func manifestAuthWrapper(exchanger authnlib.TokenExchanger) transport.WrapperFun
 // NewManifestWatcher creates a ManifestWatcher as a dskit service. The initial
 // poll runs in the starting state, so anything that waits for Running observes a
 // populated snapshot. onChange may be nil.
-func NewManifestWatcher(cfg ManifestWatcherConfig, onChange func([]app.Manifest)) (*ManifestWatcher, error) {
+func NewManifestWatcher(cfg ManifestWatcherConfig, reg prometheus.Registerer, onChange func([]app.Manifest)) (*ManifestWatcher, error) {
 	restCfg, err := newManifestRESTConfig(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("building manifest REST config: %w", err)
@@ -173,6 +206,7 @@ func NewManifestWatcher(cfg ManifestWatcherConfig, onChange func([]app.Manifest)
 	}
 
 	w := newManifestWatcher(client, interval, onChange, cfg.Log)
+	w.metrics = newManifestWatcherMetrics(reg)
 	w.Service = services.NewBasicService(w.starting, w.running, nil)
 	return w, nil
 }
@@ -188,6 +222,7 @@ func newManifestWatcher(client dynamic.Interface, pollInterval time.Duration, on
 		client:       client,
 		pollInterval: pollInterval,
 		onChange:     onChange,
+		metrics:      newManifestWatcherMetrics(nil),
 	}
 }
 
@@ -233,13 +268,17 @@ func (w *ManifestWatcher) runPollCycle(ctx context.Context) {
 
 	result, err := w.list(ctx, prev)
 	if err != nil {
+		w.metrics.polls.WithLabelValues("error").Inc()
 		w.log.Error("manifest watcher poll cycle: list failed, keeping previous set", "error", err)
 		return
 	}
+	w.metrics.lastSuccess.SetToCurrentTime()
 	if len(result) == 0 {
+		w.metrics.polls.WithLabelValues("empty").Inc()
 		w.log.Warn("manifest watcher poll cycle: zero manifests, keeping previous set")
 		return
 	}
+	w.metrics.polls.WithLabelValues("success").Inc()
 
 	manifests := sortedManifests(result)
 	hash, err := hashManifests(manifests)
@@ -260,9 +299,12 @@ func (w *ManifestWatcher) runPollCycle(ctx context.Context) {
 	}
 	w.mu.Unlock()
 
+	w.metrics.manifests.Set(float64(len(result)))
+
 	if !changed {
 		return
 	}
+	w.metrics.reloads.Inc()
 	w.log.Info("manifest watcher published new manifest set", "manifests", len(manifests))
 	if w.onChange != nil {
 		w.onChange(manifests)

--- a/pkg/storage/unified/resource/manifest_watcher_test.go
+++ b/pkg/storage/unified/resource/manifest_watcher_test.go
@@ -10,6 +10,9 @@ import (
 	"time"
 
 	authn "github.com/grafana/authlib/authn"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
 	"github.com/grafana/grafana-app-sdk/app"
 	"github.com/grafana/grafana/pkg/clientauth"
 	"github.com/grafana/grafana/pkg/setting"
@@ -173,6 +176,34 @@ func TestManifestWatcher_EmptyListKeepsPreviousSet(t *testing.T) {
 	})
 	w.runPollCycle(t.Context())
 	require.Len(t, w.Manifests(), 1)
+}
+
+func TestManifestWatcher_RecordsMetrics(t *testing.T) {
+	client := fakeManifestClient(
+		testAppManifestObj("m-dashboards", "dashboards", "dashboard.grafana.app", "Dashboard", "title"),
+	)
+	w := newManifestWatcher(client, 0, nil, nil)
+	w.metrics = newManifestWatcherMetrics(prometheus.NewPedanticRegistry())
+
+	// First poll: one successful poll, one reload, one manifest, a fresh timestamp.
+	w.runPollCycle(t.Context())
+	require.Equal(t, float64(1), testutil.ToFloat64(w.metrics.polls.WithLabelValues("success")))
+	require.Equal(t, float64(1), testutil.ToFloat64(w.metrics.reloads))
+	require.Equal(t, float64(1), testutil.ToFloat64(w.metrics.manifests))
+	require.Positive(t, testutil.ToFloat64(w.metrics.lastSuccess))
+
+	// Unchanged data: another successful poll, but no new reload.
+	w.runPollCycle(t.Context())
+	require.Equal(t, float64(2), testutil.ToFloat64(w.metrics.polls.WithLabelValues("success")))
+	require.Equal(t, float64(1), testutil.ToFloat64(w.metrics.reloads))
+
+	// A list failure increments the error label and leaves reloads untouched.
+	client.PrependReactor("list", "appmanifests", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("apiserver down")
+	})
+	w.runPollCycle(t.Context())
+	require.Equal(t, float64(1), testutil.ToFloat64(w.metrics.polls.WithLabelValues("error")))
+	require.Equal(t, float64(1), testutil.ToFloat64(w.metrics.reloads))
 }
 
 func TestManifestWatcher_PicksUpChangesOnNextPoll(t *testing.T) {

--- a/pkg/storage/unified/sql/service.go
+++ b/pkg/storage/unified/sql/service.go
@@ -413,7 +413,7 @@ func (s *service) registerServer(provider grpcserver.Provider) error {
 	// its initial poll completes before the index is built.
 	if registry := searchOptions.SearchFields; registry != nil {
 		if mwCfg := resource.NewManifestWatcherConfig(s.cfg); mwCfg != nil {
-			watcher, err := resource.NewManifestWatcher(*mwCfg, func(live []appsdk.Manifest) {
+			watcher, err := resource.NewManifestWatcher(*mwCfg, s.reg, func(live []appsdk.Manifest) {
 				if err := resource.ApplyManifests(registry, resource.AppManifests(), live); err != nil {
 					s.log.Error("manifest reload failed, keeping current search fields", "error", err)
 					return


### PR DESCRIPTION
The search manifest watcher previously only surfaced its activity through logs. This adds four Prometheus metrics so it can be observed and alerted on: poll cycles by result (search_manifest_watcher_polls_total), the number of times a changed manifest set was published (search_manifest_watcher_reloads_total), the current snapshot size (search_manifest_watcher_manifests), and the timestamp of the last successful poll (search_manifest_watcher_last_success_timestamp_seconds).

The metrics are additive and the reload logic is unchanged; in tests the watcher builds them with a no-op registerer. The watcher is still dormant unless configured, so nothing is emitted by default.

Part of grafana/search-and-storage-team#827.
