### PR TITLE
Docs: Zipkin quarterly update (FY27 Q3)

### DIFF
--- a/docs/sources/datasources/zipkin/_index.md
+++ b/docs/sources/datasources/zipkin/_index.md
@@ -17,17 +17,16 @@ labels:
 menuTitle: Zipkin
 title: Zipkin data source
 weight: 1600
-review_date: 2026-04-08
+review_date: 2026-08-11
 ---
 
 # Zipkin data source
 
-Grafana ships with built-in support for [Zipkin](https://zipkin.io/), an open source distributed tracing system.
-The Zipkin data source lets you query and visualize traces collected by Zipkin directly in Grafana, helping you identify latency bottlenecks, trace requests across microservices, and understand dependencies between services.
+When a request slows to a crawl or fails somewhere deep in your microservices, [Zipkin](https://zipkin.io/) shows you exactly where. Zipkin is an open source distributed tracing system that follows a request as it hops from service to service, so you can pinpoint the bottleneck instead of guessing.
 
-{{< admonition type="note" >}}
-This plugin requires Grafana version 12.3.0 or later.
-{{< /admonition >}}
+The Zipkin data source brings those traces straight into Grafana. Query and visualize them alongside your logs and metrics to find latency bottlenecks, follow requests across services, and map the dependencies between them. Grafana ships with the data source preinstalled, so you can start exploring traces right away.
+
+As of Grafana 13.2, Zipkin is packaged as a standalone plugin so it can receive updates independently of Grafana releases. For details, refer to [Plugin updates](#plugin-updates).
 
 ## Supported features
 
@@ -60,10 +59,30 @@ After configuring the data source, you can:
 
 ## Plugin updates
 
-Always ensure that your plugin version is up-to-date so you have access to all current features and improvements. Navigate to **Plugins and data** > **Plugins** to check for updates. Grafana recommends upgrading to the latest Grafana version, and this applies to plugins as well.
+Starting with Grafana v13.2, the Zipkin data source is a standalone plugin, preinstalled in both Grafana OSS and Enterprise. This enables more frequent updates independent of Grafana releases. Grafana automatically checks the plugin catalog and installs the latest version on each server restart.
+
+To adjust this behavior:
+
+- **Opt out of auto-updates:** Set `preinstall_auto_update` to `false` in your [configuration file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/).
+- **Update manually:** Update at any time from the **Administration > Plugins** page without restarting Grafana.
+
+The standalone plugin requires Grafana 12.3.0 or later. The Zipkin data source bundled with Grafana 13.1 and earlier continues to work as before. These versions are unaffected by the externalization.
+
+Users running Grafana 12.3.x through 13.1.x can install the standalone plugin from the plugin catalog if they want the latest features before upgrading to Grafana 13.2. To use the standalone plugin with these versions, add the following to your [configuration file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/):
+
+```ini
+[plugin.zipkin]
+as_external = true
+
+[plugins]
+; Install the latest version on startup:
+preinstall_sync = zipkin
+; Or install a specific version:
+; preinstall_sync = zipkin@<version>
+```
 
 {{< admonition type="note" >}}
-Plugins are automatically updated in Grafana Cloud.
+On Grafana Cloud, the Zipkin plugin is managed by Grafana and updates automatically.
 {{< /admonition >}}
 
 ## Related resources

--- a/docs/sources/datasources/zipkin/configure/index.md
+++ b/docs/sources/datasources/zipkin/configure/index.md
@@ -17,7 +17,7 @@ labels:
 menuTitle: Configure
 title: Configure the Zipkin data source
 weight: 100
-review_date: 2026-04-08
+review_date: 2026-08-11
 ---
 
 # Configure the Zipkin data source

--- a/docs/sources/datasources/zipkin/query-editor/index.md
+++ b/docs/sources/datasources/zipkin/query-editor/index.md
@@ -16,7 +16,7 @@ labels:
 menuTitle: Query editor
 title: Zipkin query editor
 weight: 200
-review_date: 2026-04-08
+review_date: 2026-08-11
 ---
 
 # Zipkin query editor

--- a/docs/sources/datasources/zipkin/template-variables/index.md
+++ b/docs/sources/datasources/zipkin/template-variables/index.md
@@ -14,7 +14,7 @@ labels:
 menuTitle: Template variables
 title: Zipkin template variables
 weight: 300
-review_date: 2026-04-08
+review_date: 2026-08-11
 ---
 
 # Zipkin template variables

--- a/docs/sources/datasources/zipkin/troubleshooting/index.md
+++ b/docs/sources/datasources/zipkin/troubleshooting/index.md
@@ -14,7 +14,7 @@ labels:
 menuTitle: Troubleshooting
 title: Troubleshoot Zipkin data source issues
 weight: 400
-review_date: 2026-04-08
+review_date: 2026-08-11
 ---
 
 # Troubleshoot Zipkin data source issues


### PR DESCRIPTION
Quarterly documentation review for the Zipkin data source (FY27 Q3), aligned with data source documentation conventions. The main change reflects Zipkin's move from a core, built-in data source to a standalone, preinstalled plugin. All content was cross-referenced against the externalized plugin source in grafana/grafana-zipkin-datasource for accuracy.

**_index.md:**
Rewrote the intro to be more engaging and to clarify that Grafana still ships Zipkin preinstalled, now as a standalone plugin; reworked the "Plugin updates" section to the externalized-preinstalled pattern (auto-update on restart, `preinstall_auto_update = false` opt-out, manual updates via Administration > Plugins, minimum Grafana 12.3.0, and the `as_external = true` / `preinstall_sync = zipkin` opt-in for Grafana 12.3.x–13.1.x); removed the redundant standalone version note; updated `review_date`

**configure/index.md:**
Verified auth methods, trace-to-logs and trace-to-metrics settings, span bar and node graph options, and provisioning/Terraform examples against source; no content drift; updated `review_date`

**query-editor/index.md:**
Verified query types, Traces cascader flow, JSON upload, and span filters against source; updated `review_date`

**template-variables/index.md:**
Verified supported variable types and steps; updated `review_date`

**troubleshooting/index.md:**
Verified user-journey ordering and confirmed every quoted error message and the Save & test success message against source; updated `review_date`

Technical accuracy verified against grafana/grafana-zipkin-datasource:
- `src/plugin.json` (feature flags: tracing yes; alerting/annotations/logs no; `grafanaDependency >=12.3.0`)
- `src/ConfigEditor.tsx` (auth, trace-to-logs/metrics, node graph, span bar, secure SOCKS proxy, advanced HTTP settings)
- `src/QueryField.tsx`, `src/types.ts` (query types `traceID`/`upload`, Traces cascader, Import trace, Shift+Enter placeholder, trace label format)
- `pkg/zipkin/client.go`, `handler_callresource.go`, `handler_querydata.go`, `zipkin.go` (API endpoints `/api/v2/services|spans|traces|trace/{id}`, exact error strings, "Data source is working" health-check message)
- `CHANGELOG.md` (latest version 12.4.5; no new doc-worthy features or breaking changes since the previous review)

## Test plan

- Ran Vale on `docs/sources/datasources/zipkin/` — 0 errors, 0 new warnings
- Markdown/IDE lint clean on all five modified files
- Confirmed all cross-references use fully qualified `https://grafana.com/docs/...` URLs (no relative or `.md` links) and the in-page `#plugin-updates` anchor resolves
- Verified rendered output in the docs preview: headings, admonitions, and code blocks display correctly
- Cross-checked all technical claims against the plugin source (see list above)

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
