### PR TITLE
fix(alerting): save interval/maxDataPoints on input change in Options tooltip (#111664)

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
@@ -230,7 +230,7 @@ export function MaxDataPointsOption({
 }) {
   const value = options.maxDataPoints ?? '';
 
-  const onMaxDataPointsBlur = (event: ChangeEvent<HTMLInputElement>) => {
+  const commitMaxDataPoints = (event: ChangeEvent<HTMLInputElement>) => {
     const maxDataPointsNumber = parseInt(event.target.value, 10);
 
     const maxDataPoints = isNaN(maxDataPointsNumber) || maxDataPointsNumber === 0 ? undefined : maxDataPointsNumber;
@@ -257,7 +257,8 @@ export function MaxDataPointsOption({
         width={10}
         placeholder={DEFAULT_MAX_DATA_POINTS.toString()}
         spellCheck={false}
-        onBlur={onMaxDataPointsBlur}
+        onChange={commitMaxDataPoints}
+        onBlur={commitMaxDataPoints}
         defaultValue={value}
       />
     </InlineField>
@@ -273,7 +274,7 @@ export function MinIntervalOption({
 }) {
   const value = options.minInterval ?? '';
 
-  const onMinIntervalBlur = (event: ChangeEvent<HTMLInputElement>) => {
+  const commitMinInterval = (event: ChangeEvent<HTMLInputElement>) => {
     const minInterval = event.target.value;
     if (minInterval !== value) {
       onChange({
@@ -299,7 +300,8 @@ export function MinIntervalOption({
         width={10}
         placeholder={DEFAULT_MIN_INTERVAL}
         spellCheck={false}
-        onBlur={onMinIntervalBlur}
+        onChange={commitMinInterval}
+        onBlur={commitMinInterval}
         defaultValue={value}
       />
     </InlineField>


### PR DESCRIPTION
## Description

Fix the interval and max data points values not being saved when the Options tooltip is closed by clicking outside it.

### Problem

When the Options tooltip on the alert creation/edit page is closed by clicking outside (not via the close button or blur), the `onBlur` event on the interval and max data points inputs does not fire. This is because the `Toggletip` component unmounts the DOM before the blur event can propagate.

Currently, both inputs use `defaultValue` (uncontrolled) with `onBlur` to commit changes. When the tooltip closes, the input is removed from the DOM and `onBlur` never fires, so the entered value is lost.

### Fix

Add an `onChange` handler alongside `onBlur` so the value is committed immediately on every keystroke. This ensures the value is already saved when the tooltip is closed, regardless of whether `onBlur` fires.

The `onBlur` handler is kept as a fallback for the normal case where the user tabs away from the input.

### How to test

1. Open any alert or create a new alert
2. Click "Options" next to the datasource selector
3. Set a value for "Interval" or "Max data points"
4. Click outside the tooltip to close it
5. Re-open the tooltip — the value should be saved

Fixes #111664