### PR TITLE
Explore Logs: log line highlight color lighten in dark, update deprecated pinned color

### DIFF
--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -551,11 +551,13 @@ export const getStyles = (
     logLineBody: maxContrast,
   };
 
-  const hoverColor = tinycolor(theme.colors.background.canvas).darken(11).toRgbString();
-  const pinnedColor = tinycolor(theme.colors.info.transparent).setAlpha(0.25).toString();
-  const detailsColor = tinycolor(theme.colors.background.canvas)
-    .darken(theme.isDark ? 2 : 5)
-    .toRgbString();
+  const hoverColor = theme.isDark
+    ? tinycolor(theme.colors.background.canvas).lighten(11).toRgbString()
+    : tinycolor(theme.colors.background.canvas).darken(11).toRgbString();
+  const pinnedColor = tinycolor(theme.colors.info.background).setAlpha(0.25).toString();
+  const detailsColor = theme.isDark
+    ? tinycolor(theme.colors.background.canvas).lighten(11).toRgbString()
+    : tinycolor(theme.colors.background.canvas).darken(5).toRgbString();
 
   return {
     logLine: css({


### PR DESCRIPTION
## What is this feature?

Fixes the log line highlight colors in the logs panel, which were nearly black in dark themes.

- `hoverColor` and `detailsColor` were derived by darkening `theme.colors.background.canvas`. In dark themes the canvas is already near-black (`#111217`), so darkening produced an almost pure-black highlight that was hard to distinguish. Both now lighten in dark themes instead, matching the feel of standard row hover elsewhere in Grafana (e.g. the dashboard list). Light theme hover is unchanged.
- `pinnedColor` now uses `theme.colors.info.background` instead of the deprecated `theme.colors.info.transparent` (identical resolved value, no visual change).

## Why do we need this feature?

In dark themes, hovering or selecting a log line made it *darker* than its surroundings instead of highlighting it.

## Who is this feature for?

Anyone reading logs in the logs panel or Explore in a dark theme.

## Test 🧪 

🤖 Generated with [Claude Code](https://claude.com/claude-code)