### PR TITLE
CI: Fix code stats metrics job aborting on yarn outdated failures

### DIFF
--- a/scripts/ci-frontend-metrics.sh
+++ b/scripts/ci-frontend-metrics.sh
@@ -11,7 +11,8 @@ EMOTION_IMPORTS="$(grep -r -o -E --include="*.ts*" --exclude="*.test*" "\{.*css.
 TS_FILES="$(find public/app -type f -name "*.ts*" -not -name "*.test*" | wc -l)"
 DEPRECATED_DATA_SOURCE_SRV="$(grep -r -oE --include="*.ts*" --exclude="*.test.*" --exclude="*.spec.*" --exclude-dir={__mocks__,mocks,spec,node_modules,dist,compiled} "get(DataSource|Datasource)Srv\(\)" public/app packages | grep -cvE "packages/grafana-runtime/src/services/|public/app/features/plugins/datasource_srv" || true)"
 SCSS_FILES="$(find public packages -name '*.scss' -not -path '*/node_modules/*' | wc -l)"
-OUTDATED_DEPENDENCIES="$(yarn outdated --all | grep -oP '[[:digit:]]+ *(?= dependencies are out of date)')"
+OUTDATED_DEPENDENCIES="$(yarn outdated --all | grep -oP '[[:digit:]]+ *(?= dependencies are out of date)' || true)"
+TOTAL_OUTDATED_DEPENDENCIES="${OUTDATED_DEPENDENCIES:-0}"
 CIRCULAR_DEPENDENCIES="$(yarn lint:circular 2>&1 >/dev/null | sed -n 's/.*Found \([0-9]*\) circular.*/\1/p')"
 TOTAL_CIRCULAR_DEPENDENCIES="${CIRCULAR_DEPENDENCIES:-0}"
 
@@ -20,7 +21,7 @@ echo -e "Directives: $DIRECTIVES"
 echo -e "Controllers: $CONTROLLERS"
 echo -e "Legacy forms: $LEGACY_FORMS"
 echo -e "Barrel imports: $BARREL_IMPORTS"
-echo -e "Total outdated dependencies: $OUTDATED_DEPENDENCIES"
+echo -e "Total outdated dependencies: $TOTAL_OUTDATED_DEPENDENCIES"
 echo -e "ClassName in props: $CLASSNAME_PROP"
 echo -e "@emotion/css imports: $EMOTION_IMPORTS"
 echo -e "Total TS files: $TS_FILES"
@@ -72,7 +73,7 @@ echo "Metrics: {
   \"grafana.ci-code.directives\": \"${DIRECTIVES}\",
   \"grafana.ci-code.controllers\": \"${CONTROLLERS}\",
   \"grafana.ci-code.legacyForms\": \"${LEGACY_FORMS}\",
-  \"grafana.ci-code.dependencies.outdated\": \"${OUTDATED_DEPENDENCIES}\",
+  \"grafana.ci-code.dependencies.outdated\": \"${TOTAL_OUTDATED_DEPENDENCIES}\",
   \"grafana.ci-code.props.className\": \"${CLASSNAME_PROP}\",
   \"grafana.ci-code.imports.emotion\": \"${EMOTION_IMPORTS}\",
   \"grafana.ci-code.tsFiles\": \"${TS_FILES}\",


### PR DESCRIPTION
## Summary
- `scripts/ci-frontend-metrics.sh` computed `OUTDATED_DEPENDENCIES` via `yarn outdated --all | grep ...` with no fallback. When `yarn outdated` fails to print its usual summary line (e.g. a dependency's `latest` npm dist-tag is under quarantine), the grep finds no match, the pipeline exits non-zero, and `set -e` aborts the script before it reaches the final `Metrics: {...}` output.
- That left `publish-frontend-metrics.mts` reading empty stdin and throwing `Error: No metrics found`, failing the `Publish metrics` job in `pr-e2e-tests.yml` on every run since 2026-08-10 ~16:09 UTC.
- Guards `OUTDATED_DEPENDENCIES` the same way `CIRCULAR_DEPENDENCIES` already is (`|| true` + `${VAR:-0}` fallback), so a flaky/failing `yarn outdated` no longer takes down the whole metrics pipeline.

## Test plan
- [x] `bash -n scripts/ci-frontend-metrics.sh`
- [x] Simulated a failing `yarn outdated` locally and confirmed the script now falls through to `TOTAL_OUTDATED_DEPENDENCIES=0` instead of aborting
- [ ] CI: confirm `Publish metrics` job in `pr-e2e-tests.yml` passes on this branch