### PR TITLE
chore: improve logs for Loki client

### DIFF
--- a/pkg/components/loki/lokihttp/client.go
+++ b/pkg/components/loki/lokihttp/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 	"sync"
 	"time"
@@ -310,7 +311,7 @@ func (c *client) sendBatch(tenantID string, batch *batch) {
 			break
 		}
 
-		c.logger.Warn("error sending batch, will retry", "status", status, "error", err)
+		c.logger.Warn("error sending batch, will retry", "status", status, "error", sendErrorCause(err))
 		c.metrics.batchRetries.WithLabelValues(c.cfg.URL.Host).Inc()
 		backoff.Wait()
 
@@ -325,6 +326,16 @@ func (c *client) sendBatch(tenantID string, batch *batch) {
 		c.metrics.droppedBytes.WithLabelValues(c.cfg.URL.Host).Add(bufBytes)
 		c.metrics.droppedEntries.WithLabelValues(c.cfg.URL.Host).Add(float64(entriesCount))
 	}
+}
+
+// sendErrorCause unwraps *url.Error so log lines carry the failure cause
+// without repeating the full request URL; the target host is already part of
+// the logger context.
+func sendErrorCause(err error) error {
+	if urlErr, ok := errors.AsType[*url.Error](err); ok {
+		return urlErr.Err
+	}
+	return err
 }
 
 func (c *client) send(ctx context.Context, tenantID string, buf []byte) (int, error) {

--- a/pkg/components/loki/lokihttp/client_test.go
+++ b/pkg/components/loki/lokihttp/client_test.go
@@ -1,0 +1,50 @@
+package lokihttp
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSendErrorCause(t *testing.T) {
+	t.Run("nil error stays nil", func(t *testing.T) {
+		require.NoError(t, sendErrorCause(nil))
+	})
+
+	t.Run("non-url error is returned as is", func(t *testing.T) {
+		err := errors.New("server returned HTTP status 429 Too Many Requests (429): rate limited")
+		require.Equal(t, err, sendErrorCause(err))
+	})
+
+	t.Run("drops the request url from a transport error", func(t *testing.T) {
+		err := &url.Error{
+			Op:  "Post",
+			URL: "https://12345:token@logs.example.net/loki/api/v1/push",
+			Err: errors.New("dial tcp: no such host"),
+		}
+		cause := sendErrorCause(err)
+		require.EqualError(t, cause, "dial tcp: no such host")
+	})
+
+	t.Run("drops the request url from a request build error", func(t *testing.T) {
+		_, err := http.NewRequest("POST", "https://12345:token@logs.example.net/loki/api/v1/push\x7f", nil)
+		require.Error(t, err)
+
+		cause := sendErrorCause(err)
+		require.Error(t, cause)
+		require.NotContains(t, cause.Error(), "logs.example.net")
+	})
+
+	t.Run("unwraps a wrapped url error", func(t *testing.T) {
+		inner := &url.Error{
+			Op:  "Post",
+			URL: "https://logs.example.net/loki/api/v1/push",
+			Err: errors.New("context deadline exceeded"),
+		}
+		cause := sendErrorCause(errors.Join(inner))
+		require.EqualError(t, cause, "context deadline exceeded")
+	})
+}


### PR DESCRIPTION
## What this PR does

Fixing Loki client retry/error logs (`pkg/components/loki/lokihttp/client.go`) to avoid logging the raw error returned by the HTTP client by unwrapping the error. 

## Testing

Added `client_test.go` 