### PR TITLE
[release-12.4.9] Azure Monitor: fix migration for dimension filters

### DIFF
--- a/pkg/tsdb/azuremonitor/metrics/migrations.go
+++ b/pkg/tsdb/azuremonitor/metrics/migrations.go
@@ -3,15 +3,20 @@ package metrics
 import "github.com/grafana/grafana/pkg/tsdb/azuremonitor/kinds/dataquery"
 
 func MigrateDimensionFilters(filters []dataquery.AzureMetricDimension) []dataquery.AzureMetricDimension {
-	var newFilters []dataquery.AzureMetricDimension
+	newFilters := []dataquery.AzureMetricDimension{}
 	for _, filter := range filters {
+		// Drop filters without dimension
+		if filter.Dimension == nil {
+			continue
+		}
+
 		newFilter := filter
 		// Ignore the deprecation check as this is a migration
 		// nolint:staticcheck
 		newFilter.Filter = nil
-		// If there is no old field and the new field is specified - append as this is valid
+		// If there is no legacy filter field, there is nothing to migrate, append as-is
 		// nolint:staticcheck
-		if filter.Filter == nil && filter.Filters != nil {
+		if filter.Filter == nil {
 			newFilters = append(newFilters, newFilter)
 		} else {
 			// nolint:staticcheck

--- a/pkg/tsdb/azuremonitor/metrics/migrations_test.go
+++ b/pkg/tsdb/azuremonitor/metrics/migrations_test.go
@@ -47,6 +47,16 @@ func TestDimensionFiltersMigration(t *testing.T) {
 			dimensionFilters:         []dataquery.AzureMetricDimension{{Dimension: strPtr("testDimension"), Operator: strPtr("eq"), Filter: &additionalTestFilter, Filters: []string{testFilter}}},
 			expectedDimensionFilters: []dataquery.AzureMetricDimension{{Dimension: strPtr("testDimension"), Operator: strPtr("eq"), Filters: []string{testFilter, additionalTestFilter}}},
 		},
+		{
+			name:                     "will return empty filter unchanged",
+			dimensionFilters:         []dataquery.AzureMetricDimension{{Dimension: new("testDimension"), Operator: new("eq")}},
+			expectedDimensionFilters: []dataquery.AzureMetricDimension{{Dimension: new("testDimension"), Operator: new("eq")}},
+		},
+		{
+			name:                     "drops filters without dimension",
+			dimensionFilters:         []dataquery.AzureMetricDimension{{Operator: new("eq")}},
+			expectedDimensionFilters: []dataquery.AzureMetricDimension{},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Backport 9b0503462b776c30fc4ab053c1e6ab78448a13dd from #128786

---

## Changes

For Azure Monitor metrics queries, the migration for dimension filters is modified:

- filters with no legacy filter and no "new" filter (`{"dimension:":"Dimension", "operator":"eq"}`) now queries `Dimension eq '*'`, instead of panicking.
- filters with no dimension (`{"operator": "eq"}`) are dropped, instead of panicking.

## Why

This is a fix for a panic error that occurs when adding a Azure Monitor alert query with a dimension filter such as

```json
"dimensionFilters": [{
   "dimension": "xxx",
   "operator": "eq"
}]
```

(no `filters` array, no `filter` deprecated field).

When adding the unit test from this PR, tests fail with:

```
--- FAIL: TestDimensionFiltersMigration (0.00s)
    --- FAIL: TestDimensionFiltersMigration/will_return_empty_filter_unchanged (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xef657a]
```

The change in `pkg/tsdb/azuremonitor/metrics/migrations.go` fixes the failing test, by removing the possibility to have `filter.Filter == nil` in https://github.com/grafana/grafana/blob/4a28a330ea5ba749ec19696ca9afcf2078b3360e/pkg/tsdb/azuremonitor/metrics/migrations.go#L18

Note that the case where both `Filter` and `Filters` are nil is valid.

Another panic error was thrown for filters without dimension, such as `{"operator": "eq"}`.
