### PR TITLE
Fix user teams pagination

### DIFF
--- a/apps/iam/go.mod
+++ b/apps/iam/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/grafana/grafana v0.0.0-00010101000000-000000000000
 	github.com/grafana/grafana-app-sdk v0.56.6
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0
+	github.com/stretchr/testify v1.11.1
 	k8s.io/apimachinery v0.36.2
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a
 )
@@ -103,7 +104,6 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect
-	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.44.0 // indirect

--- a/apps/iam/kinds/user.cue
+++ b/apps/iam/kinds/user.cue
@@ -78,6 +78,12 @@ userv0alpha1: userKind & {
 		"/teams": {
 			"GET": {
 				name: "getUserTeams"
+				request: {
+					query: {
+						limit:    int64 | *0
+						continue: string | *""
+					}
+				}
 				response: {
 					#UserTeam: {
 						user:       string

--- a/apps/iam/pkg/apis/iam/v0alpha1/user_client.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/user_client.go
@@ -7,6 +7,7 @@ import (
 )
 
 func (c *UserClient) GetUserTeamsAll(ctx context.Context, identifier resource.Identifier, request GetUserTeamsRequest) (*GetUserTeamsResponse, error) {
+	request.Params.Continue = ""
 	response, err := c.GetUserTeams(ctx, identifier, request)
 	if err != nil {
 		return nil, err

--- a/apps/iam/pkg/apis/iam/v0alpha1/user_client.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/user_client.go
@@ -1,0 +1,27 @@
+package v0alpha1
+
+import (
+	"context"
+
+	"github.com/grafana/grafana-app-sdk/resource"
+)
+
+func (c *UserClient) GetUserTeamsAll(ctx context.Context, identifier resource.Identifier, request GetUserTeamsRequest) (*GetUserTeamsResponse, error) {
+	response, err := c.GetUserTeams(ctx, identifier, request)
+	if err != nil {
+		return nil, err
+	}
+
+	for response.Continue != "" {
+		request.Params.Continue = response.Continue
+		page, err := c.GetUserTeams(ctx, identifier, request)
+		if err != nil {
+			return nil, err
+		}
+		response.Items = append(response.Items, page.Items...)
+		response.Continue = page.Continue
+		response.ResourceVersion = page.ResourceVersion
+	}
+
+	return response, nil
+}

--- a/apps/iam/pkg/apis/iam/v0alpha1/user_client_gen.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/user_client_gen.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/grafana/grafana-app-sdk/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -102,13 +103,18 @@ func (c *UserClient) Delete(ctx context.Context, identifier resource.Identifier,
 }
 
 type GetUserTeamsRequest struct {
+	Params  GetUserTeamsRequestParams
 	Headers http.Header
 }
 
 func (c *UserClient) GetUserTeams(ctx context.Context, identifier resource.Identifier, request GetUserTeamsRequest) (*GetUserTeamsResponse, error) {
+	params := url.Values{}
+	params.Set("continue", fmt.Sprintf("%v", request.Params.Continue))
+	params.Set("limit", fmt.Sprintf("%v", request.Params.Limit))
 	resp, err := c.client.SubresourceRequest(ctx, identifier, resource.CustomRouteRequestOptions{
 		Path:    "/teams",
 		Verb:    "GET",
+		Query:   params,
 		Headers: request.Headers,
 	})
 	if err != nil {

--- a/apps/iam/pkg/apis/iam/v0alpha1/user_client_test.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/user_client_test.go
@@ -1,0 +1,125 @@
+package v0alpha1
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana-app-sdk/resource"
+)
+
+type recordingResourceClient struct {
+	resource.Client
+	requests  []resource.CustomRouteRequestOptions
+	responses [][]byte
+	errors    []error
+	onRequest func(context.Context, int)
+}
+
+func (c *recordingResourceClient) SubresourceRequest(ctx context.Context, _ resource.Identifier, request resource.CustomRouteRequestOptions) ([]byte, error) {
+	c.requests = append(c.requests, request)
+	if c.onRequest != nil {
+		c.onRequest(ctx, len(c.requests))
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if len(c.errors) > 0 {
+		err := c.errors[0]
+		c.errors = c.errors[1:]
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(c.responses) > 0 {
+		response := c.responses[0]
+		c.responses = c.responses[1:]
+		return response, nil
+	}
+	return []byte(`{}`), nil
+}
+
+func TestUserClientGetUserTeamsEncodesPaginationParameters(t *testing.T) {
+	transport := &recordingResourceClient{}
+	client := NewUserClient(transport)
+
+	_, err := client.GetUserTeams(context.Background(), resource.Identifier{Namespace: "org-1", Name: "user-1"}, GetUserTeamsRequest{
+		Params: GetUserTeamsRequestParams{
+			Limit:    25,
+			Continue: "next+/=",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "continue=next%2B%2F%3D&limit=25", transport.requests[0].Query.Encode())
+}
+
+func TestUserClientGetUserTeamsAllReturnsOnePage(t *testing.T) {
+	transport := &recordingResourceClient{responses: [][]byte{
+		[]byte(`{"items":[{"user":"user-1","team":"team-1","permission":"Member","external":false}]}`),
+	}}
+	client := NewUserClient(transport)
+
+	response, err := client.GetUserTeamsAll(context.Background(), resource.Identifier{Namespace: "org-1", Name: "user-1"}, GetUserTeamsRequest{})
+	require.NoError(t, err)
+	require.Len(t, response.Items, 1)
+	require.Equal(t, "team-1", response.Items[0].Team)
+}
+
+func TestUserClientGetUserTeamsAllCombinesMultiplePages(t *testing.T) {
+	transport := &recordingResourceClient{responses: [][]byte{
+		[]byte(`{"metadata":{"continue":"next+/="},"items":[{"user":"user-1","team":"team-1"}]}`),
+		[]byte(`{"metadata":{"resourceVersion":"2"},"items":[{"user":"user-1","team":"team-2"}]}`),
+	}}
+	client := NewUserClient(transport)
+
+	response, err := client.GetUserTeamsAll(context.Background(), resource.Identifier{Namespace: "org-1", Name: "user-1"}, GetUserTeamsRequest{
+		Params: GetUserTeamsRequestParams{Limit: 1},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []GetUserTeamsUserTeam{{User: "user-1", Team: "team-1"}, {User: "user-1", Team: "team-2"}}, response.Items)
+	require.Empty(t, response.Continue)
+	require.Equal(t, "2", response.ResourceVersion)
+	require.Equal(t, "continue=&limit=1", transport.requests[0].Query.Encode())
+	require.Equal(t, "continue=next%2B%2F%3D&limit=1", transport.requests[1].Query.Encode())
+}
+
+func TestUserClientGetUserTeamsAllReturnsEmptyResult(t *testing.T) {
+	transport := &recordingResourceClient{responses: [][]byte{[]byte(`{"items":[]}`)}}
+	client := NewUserClient(transport)
+
+	response, err := client.GetUserTeamsAll(context.Background(), resource.Identifier{Namespace: "org-1", Name: "user-1"}, GetUserTeamsRequest{})
+	require.NoError(t, err)
+	require.Empty(t, response.Items)
+}
+
+func TestUserClientGetUserTeamsAllReturnsLaterPageError(t *testing.T) {
+	wantErr := errors.New("second page failed")
+	transport := &recordingResourceClient{
+		responses: [][]byte{[]byte(`{"metadata":{"continue":"next"},"items":[{"user":"user-1","team":"team-1"}]}`)},
+		errors:    []error{nil, wantErr},
+	}
+	client := NewUserClient(transport)
+
+	response, err := client.GetUserTeamsAll(context.Background(), resource.Identifier{Namespace: "org-1", Name: "user-1"}, GetUserTeamsRequest{})
+	require.ErrorIs(t, err, wantErr)
+	require.Nil(t, response)
+}
+
+func TestUserClientGetUserTeamsAllReturnsLaterPageCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	transport := &recordingResourceClient{
+		responses: [][]byte{[]byte(`{"metadata":{"continue":"next"},"items":[{"user":"user-1","team":"team-1"}]}`)},
+		onRequest: func(_ context.Context, call int) {
+			if call == 2 {
+				cancel()
+			}
+		},
+	}
+	client := NewUserClient(transport)
+
+	response, err := client.GetUserTeamsAll(ctx, resource.Identifier{Namespace: "org-1", Name: "user-1"}, GetUserTeamsRequest{})
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, response)
+}

--- a/apps/iam/pkg/apis/iam/v0alpha1/user_client_test.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/user_client_test.go
@@ -85,6 +85,17 @@ func TestUserClientGetUserTeamsAllCombinesMultiplePages(t *testing.T) {
 	require.Equal(t, "continue=next%2B%2F%3D&limit=1", transport.requests[1].Query.Encode())
 }
 
+func TestUserClientGetUserTeamsAllStartsFromFirstPage(t *testing.T) {
+	transport := &recordingResourceClient{responses: [][]byte{[]byte(`{"items":[]}`)}}
+	client := NewUserClient(transport)
+
+	_, err := client.GetUserTeamsAll(context.Background(), resource.Identifier{Namespace: "org-1", Name: "user-1"}, GetUserTeamsRequest{
+		Params: GetUserTeamsRequestParams{Limit: 25, Continue: "caller-token"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "continue=&limit=25", transport.requests[0].Query.Encode())
+}
+
 func TestUserClientGetUserTeamsAllReturnsEmptyResult(t *testing.T) {
 	transport := &recordingResourceClient{responses: [][]byte{[]byte(`{"items":[]}`)}}
 	client := NewUserClient(transport)

--- a/apps/iam/pkg/apis/iam/v0alpha1/user_getuserteams_request_params_object_gen.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/user_getuserteams_request_params_object_gen.go
@@ -1,0 +1,37 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v0alpha1
+
+import (
+	"github.com/grafana/grafana-app-sdk/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type GetUserTeamsRequestParamsObject struct {
+	metav1.TypeMeta           `json:",inline"`
+	GetUserTeamsRequestParams `json:",inline"`
+}
+
+func NewGetUserTeamsRequestParamsObject() *GetUserTeamsRequestParamsObject {
+	return &GetUserTeamsRequestParamsObject{}
+}
+
+func (o *GetUserTeamsRequestParamsObject) DeepCopyObject() runtime.Object {
+	dst := NewGetUserTeamsRequestParamsObject()
+	o.DeepCopyInto(dst)
+	return dst
+}
+
+func (o *GetUserTeamsRequestParamsObject) DeepCopyInto(dst *GetUserTeamsRequestParamsObject) {
+	dst.TypeMeta.APIVersion = o.TypeMeta.APIVersion
+	dst.TypeMeta.Kind = o.TypeMeta.Kind
+	dstGetUserTeamsRequestParams := GetUserTeamsRequestParams{}
+	_ = resource.CopyObjectInto(&dstGetUserTeamsRequestParams, &o.GetUserTeamsRequestParams)
+}
+
+func (GetUserTeamsRequestParamsObject) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.iam.pkg.apis.iam.v0alpha1.GetUserTeamsRequestParamsObject"
+}
+
+var _ runtime.Object = NewGetUserTeamsRequestParamsObject()

--- a/apps/iam/pkg/apis/iam/v0alpha1/user_getuserteams_request_params_types_gen.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/user_getuserteams_request_params_types_gen.go
@@ -1,0 +1,21 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v0alpha1
+
+type GetUserTeamsRequestParams struct {
+	Limit    int64  `json:"limit"`
+	Continue string `json:"continue"`
+}
+
+// NewGetUserTeamsRequestParams creates a new GetUserTeamsRequestParams object.
+func NewGetUserTeamsRequestParams() *GetUserTeamsRequestParams {
+	return &GetUserTeamsRequestParams{
+		Limit:    0,
+		Continue: "",
+	}
+}
+
+// OpenAPIModelName returns the OpenAPI model name for GetUserTeamsRequestParams.
+func (GetUserTeamsRequestParams) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.iam.pkg.apis.iam.v0alpha1.GetUserTeamsRequestParams"
+}

--- a/apps/iam/pkg/apis/iam_manifest.go
+++ b/apps/iam/pkg/apis/iam_manifest.go
@@ -126,6 +126,35 @@ var appManifestData = app.ManifestData{
 
 									OperationId: "getUserTeams",
 
+									Parameters: []*spec3.Parameter{
+
+										{
+											ParameterProps: spec3.ParameterProps{
+												Name:     "continue",
+												In:       "query",
+												Required: true,
+												Schema: &spec.Schema{
+													SchemaProps: spec.SchemaProps{
+														Type: []string{"string"},
+													},
+												},
+											},
+										},
+
+										{
+											ParameterProps: spec3.ParameterProps{
+												Name:     "limit",
+												In:       "query",
+												Required: true,
+												Schema: &spec.Schema{
+													SchemaProps: spec.SchemaProps{
+														Type: []string{"integer"},
+													},
+												},
+											},
+										},
+									},
+
 									Responses: &spec3.Responses{
 										ResponsesProps: spec3.ResponsesProps{
 											Default: &spec3.Response{
@@ -1524,6 +1553,7 @@ func ManifestCustomRouteResponsesAssociator(kind, version, path, verb string) (g
 }
 
 var customRouteToGoParamsType = map[string]runtime.Object{
+	"v0alpha1|User|teams|GET": &v0alpha1.GetUserTeamsRequestParamsObject{},
 
 	"v0alpha1|ServiceAccount|tokens|GET": &v0alpha1.ListServiceAccountTokensRequestParamsObject{},
 }

--- a/pkg/services/team/teamk8s/team.go
+++ b/pkg/services/team/teamk8s/team.go
@@ -219,7 +219,7 @@ func (s *TeamK8sService) listUserTeams(ctx context.Context, namespace, userUID s
 	svcCtx := identity.WithServiceIdentityForSingleNamespaceContext(ctx, namespace)
 
 	// Propagate every error (including 404) so teamimpl falls back to legacy when the subresource is gated off.
-	resp, err := client.GetUserTeams(svcCtx, sdkresource.Identifier{Namespace: namespace, Name: userUID}, iamv0alpha1.GetUserTeamsRequest{})
+	resp, err := client.GetUserTeamsAll(svcCtx, sdkresource.Identifier{Namespace: namespace, Name: userUID}, iamv0alpha1.GetUserTeamsRequest{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/team/teamk8s/team_test.go
+++ b/pkg/services/team/teamk8s/team_test.go
@@ -1351,6 +1351,30 @@ func userTeamsResponse(rows []iamv0alpha1.GetUserTeamsUserTeam) iamv0alpha1.GetU
 	}
 }
 
+func TestTeamK8sService_ListUserTeamsReturnsAllPages(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		response := userTeamsResponse([]iamv0alpha1.GetUserTeamsUserTeam{{User: "user-1", Team: "team-1"}})
+		if r.URL.Query().Get("continue") == "next+/=" {
+			response.Items[0].Team = "team-2"
+		} else {
+			response.Continue = "next+/="
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(response))
+	}))
+	defer server.Close()
+
+	provider := &mockDirectRestConfigProvider{restConfig: &clientrest.Config{Host: server.URL}}
+	service := NewTeamK8sService(log.NewNopLogger(), setting.NewCfg(), provider, tracing.InitializeTracerForTest())
+
+	rows, err := service.listUserTeams(contextWithReqContext(), "org-1", "user-1")
+	require.NoError(t, err)
+	require.Equal(t, []iamv0alpha1.GetUserTeamsUserTeam{
+		{User: "user-1", Team: "team-1"},
+		{User: "user-1", Team: "team-2"},
+	}, rows)
+}
+
 func TestTeamK8sService_GetTeamsByUser(t *testing.T) {
 	tests := []struct {
 		name                   string


### PR DESCRIPTION
## What changed

- add `limit` and `continue` query parameters to the generated IAM `GetUserTeams` client
- add a continuation-aware `GetUserTeamsAll` helper
- update the Kubernetes team service to retrieve every page
- add generated request parameter types and pagination coverage

## Why

The user teams subresource is paginated, but its generated client did not expose or send pagination parameters. Callers therefore returned only the first page and silently omitted memberships beyond the default 500-item limit.

## Validation

- IAM generated-client unit tests
- Team Kubernetes service tests
- IAM user-teams integration tests
- OpenAPI generation and integration checks
- API client generation
- backend build
- binary-level manual regression using the same 501-team database:
  - pre-fix caller returned 500 teams
  - fixed caller returned 501 unique teams
