### PR TITLE
Unified Storage: Tenant deleter still delete instance when gcom returns 404

### DIFF
--- a/pkg/services/gcom/gcom.go
+++ b/pkg/services/gcom/gcom.go
@@ -16,6 +16,8 @@ const LogPrefix = "gcom.service"
 
 var ErrTokenNotFound = errors.New("gcom: token not found")
 
+var ErrInstanceNotFound = errors.New("gcom: instance not found")
+
 type Service interface {
 	GetInstanceByID(ctx context.Context, requestID string, instanceID string) (Instance, error)
 	GetPlugins(ctx context.Context, requestID string) (map[string]Plugin, error)
@@ -83,6 +85,10 @@ func (client *GcomClient) GetInstanceByID(ctx context.Context, requestID string,
 			client.log.Error("closing http response body", "err", err.Error())
 		}
 	}()
+
+	if response.StatusCode == http.StatusNotFound {
+		return Instance{}, fmt.Errorf("instance id=%s: %w", instanceID, ErrInstanceNotFound)
+	}
 
 	if response.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(response.Body)

--- a/pkg/services/gcom/gcom.go
+++ b/pkg/services/gcom/gcom.go
@@ -87,6 +87,8 @@ func (client *GcomClient) GetInstanceByID(ctx context.Context, requestID string,
 	}()
 
 	if response.StatusCode == http.StatusNotFound {
+		// Drain the body so the keep-alive connection can be reused.
+		_, _ = io.Copy(io.Discard, response.Body)
 		return Instance{}, fmt.Errorf("instance id=%s: %w", instanceID, ErrInstanceNotFound)
 	}
 

--- a/pkg/storage/unified/resource/tenant_deleter.go
+++ b/pkg/storage/unified/resource/tenant_deleter.go
@@ -2,6 +2,7 @@ package resource
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand/v2"
 	"net/http"
@@ -25,7 +26,7 @@ type TenantDeleterConfig struct {
 	Interval time.Duration
 	Log      log.Logger
 	// Gcom, when non-nil, is used to confirm the stack is removed in GCOM before local
-	// tenant data is deleted: GetInstanceByID returns Instance with Status "deleted".
+	// tenant data is deleted: GetInstanceByID returns Instance with Status "deleted" or 404.
 	Gcom gcom.Service
 }
 
@@ -172,8 +173,8 @@ func (td *TenantDeleter) runDeletionPass(ctx context.Context) {
 	}
 }
 
-// gcomAllowsTenantDeletion returns true when GCOM returns 200 with Status "deleted" for the given
-// tenant name. Otherwise it returns false and logs.
+// gcomAllowsTenantDeletion returns true when GCOM returns 200 with Status "deleted" or 404 for
+// the given tenant name. Otherwise it returns false and logs.
 func (td *TenantDeleter) gcomAllowsTenantDeletion(ctx context.Context, tenantName string) bool {
 	ctx, span := tracer.Start(ctx, "resource.TenantDeleter.gcomAllowsTenantDeletion", trace.WithAttributes(
 		attribute.String("tenant", tenantName),
@@ -202,6 +203,14 @@ func (td *TenantDeleter) gcomAllowsTenantDeletion(ctx context.Context, tenantNam
 	span.SetAttributes(attribute.Int64("gcom_request_duration_ms", gcomDuration.Milliseconds()))
 
 	if err != nil {
+		// A 404 means the stack no longer exists in GCOM, which is as good as
+		// Status "deleted" — proceed with local data deletion.
+		if errors.Is(err, gcom.ErrInstanceNotFound) {
+			td.log.Info("stack not found in GCOM; proceeding with local data deletion",
+				"tenant", tenantName, "gcom_instance_id", instanceID)
+			span.SetAttributes(attribute.String("gcom_status", "not_found"))
+			return true
+		}
 		td.log.Error("GCOM instance check failed; skipping local data deletion",
 			"tenant", tenantName, "gcom_instance_id", instanceID, "err", err,
 			"gcom_request_duration_ms", gcomDuration.Milliseconds())

--- a/pkg/storage/unified/resource/tenant_deleter_test.go
+++ b/pkg/storage/unified/resource/tenant_deleter_test.go
@@ -717,6 +717,46 @@ func TestRunDeletionPass_AllowsWhenGcomReturnsDeletedStatus(t *testing.T) {
 	assert.NotEmpty(t, record.DeletedAt, "DeletedAt should be set after successful deletion")
 }
 
+// TestRunDeletionPass_AllowsWhenGcomReturns404 verifies local deletion proceeds when
+// GCOM no longer knows the instance (404).
+func TestRunDeletionPass_AllowsWhenGcomReturns404(t *testing.T) {
+	kv := setupBadgerKV(t)
+	ds := newDataStore(kv, nil)
+	pds := newPendingDeleteStore(kv)
+	td := NewTenantDeleter(ds, pds, TenantDeleterConfig{
+		DryRun:   false,
+		Interval: time.Hour,
+		Log:      log.NewNopLogger(),
+		Gcom: &testGcomVerifier{
+			getInstance: func(_ context.Context, _, instanceID string) (gcom.Instance, error) {
+				require.Equal(t, "1", instanceID)
+				return gcom.Instance{}, fmt.Errorf("instance id=%s: %w", instanceID, gcom.ErrInstanceNotFound)
+			},
+		},
+	}, nil)
+
+	saveTestResource(t, ds, testStacksNS1, "apps", "dashboards", "dash1", 100, nil)
+	require.NoError(t, pds.Upsert(t.Context(), testStacksNS1, PendingDeleteRecord{DeleteAfter: pastTime()}))
+
+	td.runDeletionPass(t.Context())
+
+	listKey := ListRequestKey{Group: "apps", Resource: "dashboards", Namespace: testStacksNS1}
+	prefix := listKey.Prefix()
+	var count int
+	for _, err := range ds.kv.Keys(t.Context(), dataSection, ListOptions{
+		StartKey: prefix,
+		EndKey:   PrefixRangeEnd(prefix),
+	}) {
+		require.NoError(t, err)
+		count++
+	}
+	assert.Equal(t, 0, count, "resources should be deleted when GCOM returns 404")
+
+	record, err := pds.Get(t.Context(), testStacksNS1)
+	require.NoError(t, err)
+	assert.NotEmpty(t, record.DeletedAt, "DeletedAt should be set after successful deletion")
+}
+
 // TestRunDeletionPass_SkipsWhenGcomInstanceStillExists verifies that local data is
 // not removed while GCOM still returns the stack instance.
 func TestRunDeletionPass_SkipsWhenGcomInstanceStillExists(t *testing.T) {


### PR DESCRIPTION
Tenant deleter was throwing errors when deleting instances when the gcom check returned a 404. If its a 404 it means it was already hard deleted in gcom.