### PR TITLE
TablePanel: Support row-based sparkline colors

### DIFF
--- a/docs/sources/visualizations/panels-visualizations/visualizations/table/index.md
+++ b/docs/sources/visualizations/panels-visualizations/visualizations/table/index.md
@@ -404,6 +404,7 @@ This cell type shows values rendered as a sparkline.
 To show sparklines on data with multiple time series, use the [Time series to table transformation](ref:time-series-to-table-transformation) to process it into a format the table can show.
 
 You can color sparklines using thresholds by setting the field's color scheme to **From thresholds (by value)** in the [standard color scheme options](ref:color-scheme), using an override, and setting **Gradient mode** to **Scheme**. When thresholds are defined, the sparkline automatically reflects threshold levels along the line.
+You can also set **Sparkline color mode** to **By field value** and select a **Sparkline color field** to derive each row's sparkline color from another field in the same row. Rows with the same source value use the same palette color.
 
 ![Table using sparkline cell type](/media/docs/grafana/panels-visualizations/screenshot-table-as-sparkline-v11.3.png)
 
@@ -414,6 +415,8 @@ For more detailed information about all of the sparkline styling options (except
 | Option              | Description                                                                |
 | ------------------- | --------------------------------------------------------------------------------------------- |
 | Hide value          | Toggle the switch on or off to display or hide the cell value on the sparkline. |
+| Sparkline color mode | Choose whether the sparkline uses the configured **Field color** or derives a palette color **By field value** from another field in the same row. |
+| Sparkline color field | Select the field used to assign row-based sparkline colors when **Sparkline color mode** is set to **By field value**. |
 | Style               | Choose whether to display your time-series data as **Lines**, **Bars**, or **Points**. You can use overrides to combine multiple styles in the same graph. |
 | Line interpolation  | How the graph interpolates the series line. Choose from:<ul><li>**Linear** - Points are joined by straight lines.</li><li>**Smooth** - Points are joined by curved lines that smooths transitions between points.</li><li>**Step before** - The line is displayed as steps between points. Points are rendered at the end of the step.</li><li>**Step after** - The line is displayed as steps between points. Points are rendered at the beginning of the step.</li></ul> |
 | Line width          | The thickness of the series lines or the outline for bars using the **Line width** slider. |

--- a/packages/grafana-schema/src/common/common.gen.ts
+++ b/packages/grafana-schema/src/common/common.gen.ts
@@ -849,8 +849,15 @@ export interface TableBarGaugeCellOptions {
 /**
  * Sparkline cell options
  */
+export enum TableSparklineColorMode {
+  Field = 'field',
+  ByFieldValue = 'byFieldValue',
+}
+
 export interface TableSparklineCellOptions extends GraphFieldConfig {
   hideValue?: boolean;
+  sparklineColorField?: string;
+  sparklineColorMode?: TableSparklineColorMode;
   type: TableCellDisplayMode.Sparkline;
 }
 

--- a/packages/grafana-schema/src/common/table.cue
+++ b/packages/grafana-schema/src/common/table.cue
@@ -59,10 +59,14 @@ TableBarGaugeCellOptions: {
 } @cuetsy(kind="interface")
 
 // Sparkline cell options
+TableSparklineColorMode: "field" | "byFieldValue" @cuetsy(kind="enum",memberNames="Field|ByFieldValue")
+
 TableSparklineCellOptions: {
 	GraphFieldConfig
-	type:       TableCellDisplayMode & "sparkline"
-	hideValue?: bool
+	type:                 TableCellDisplayMode & "sparkline"
+	hideValue?:           bool
+	sparklineColorMode?:  TableSparklineColorMode
+	sparklineColorField?: string
 } @cuetsy(kind="interface")
 
 // Colored background cell options

--- a/packages/grafana-ui/src/components/Table/Cells/SparklineCell.tsx
+++ b/packages/grafana-ui/src/components/Table/Cells/SparklineCell.tsx
@@ -19,6 +19,7 @@ import {
   type TableSparklineCellOptions,
   TableCellDisplayMode,
   VisibilityMode,
+  TableSparklineColorMode,
 } from '@grafana/schema';
 
 import { useTheme2 } from '../../../themes/ThemeContext';
@@ -26,6 +27,7 @@ import { measureText } from '../../../utils/measureText';
 import { FormattedValueDisplay } from '../../FormattedValueDisplay/FormattedValueDisplay';
 import { Sparkline } from '../../Sparkline/Sparkline';
 import { getAlignmentFactor, getCellOptions } from '../cellUtils';
+import { getSparklineColor } from '../sparklineColor';
 import { type TableCellProps } from '../types';
 
 export const defaultSparklineCellConfig: TableSparklineCellOptions = {
@@ -39,6 +41,7 @@ export const defaultSparklineCellConfig: TableSparklineCellOptions = {
   barAlignment: BarAlignment.Center,
   showPoints: VisibilityMode.Never,
   hideValue: false,
+  sparklineColorMode: TableSparklineColorMode.Field,
 };
 
 export const SparklineCell = (props: TableCellProps) => {
@@ -77,7 +80,7 @@ export const SparklineCell = (props: TableCellProps) => {
   const cellOptions = getTableSparklineCellOptions(field);
 
   const config: FieldConfig<GraphFieldConfig> = {
-    color: field.config.color,
+    color: getSparklineColor(field, cell.row.index, props.frame, cellOptions, tableStyles.theme),
     thresholds: field.config.thresholds,
     custom: {
       ...defaultSparklineCellConfig,

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/SparklineCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/SparklineCell.tsx
@@ -12,12 +12,14 @@ import {
   LineInterpolation,
   type TableSparklineCellOptions,
   TableCellDisplayMode,
+  TableSparklineColorMode,
   VisibilityMode,
 } from '@grafana/schema';
 
 import { measureText } from '../../../../utils/measureText';
 import { FormattedValueDisplay } from '../../../FormattedValueDisplay/FormattedValueDisplay';
 import { Sparkline } from '../../../Sparkline/Sparkline';
+import { getSparklineColor } from '../../sparklineColor';
 import { MaybeWrapWithLink } from '../components/MaybeWrapWithLink';
 import { isTableCellStylesKeyEqual } from '../styles';
 import { type SparklineCellProps, type TableCellStyles } from '../types';
@@ -34,10 +36,11 @@ const defaultSparklineCellConfig: TableSparklineCellOptions = {
   barAlignment: BarAlignment.Center,
   showPoints: VisibilityMode.Never,
   hideValue: false,
+  sparklineColorMode: TableSparklineColorMode.Field,
 };
 
 export const SparklineCell = (props: SparklineCellProps) => {
-  const { field, value, theme, timeRange, rowIdx, width } = props;
+  const { field, frame, value, theme, timeRange, rowIdx, width } = props;
   const sparkline = prepareSparklineValue(value, field);
 
   if (!sparkline) {
@@ -71,7 +74,7 @@ export const SparklineCell = (props: SparklineCellProps) => {
   const cellOptions = getTableSparklineCellOptions(field);
 
   const config: FieldConfig<GraphFieldConfig> = {
-    color: field.config.color,
+    color: getSparklineColor(field, rowIdx, frame, cellOptions, theme),
     thresholds: field.config.thresholds,
     custom: {
       ...defaultSparklineCellConfig,

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/renderers.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/renderers.tsx
@@ -105,6 +105,7 @@ const CELL_REGISTRY: Record<TableCellOptions['type'], CellRegistryEntry> = {
         <SparklineCell
           value={props.value}
           field={props.field}
+          frame={props.frame}
           timeRange={props.timeRange}
           rowIdx={props.rowIdx}
           theme={props.theme}

--- a/packages/grafana-ui/src/components/Table/TableNG/types.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/types.ts
@@ -199,6 +199,7 @@ export interface RowExpanderNGProps {
 
 export interface SparklineCellProps {
   field: Field;
+  frame?: DataFrame;
   rowIdx: number;
   theme: GrafanaTheme2;
   timeRange?: TimeRange;

--- a/packages/grafana-ui/src/components/Table/sparklineColor.test.ts
+++ b/packages/grafana-ui/src/components/Table/sparklineColor.test.ts
@@ -1,0 +1,136 @@
+import { createTheme, FieldType, toDataFrame, type FieldColor } from '@grafana/data';
+import { FieldColorModeId, TableCellDisplayMode, TableSparklineColorMode } from '@grafana/schema';
+
+import { getSparklineColor } from './sparklineColor';
+
+describe('getSparklineColor', () => {
+  const theme = createTheme();
+  const fieldColor: FieldColor = { mode: FieldColorModeId.Fixed, fixedColor: 'blue' };
+
+  const frame = toDataFrame({
+    fields: [
+      { name: 'service', type: FieldType.string, values: ['api', 'db', 'api', null] },
+      {
+        name: 'trend',
+        type: FieldType.number,
+        values: [1, 2, 3, 4],
+        config: {
+          color: fieldColor,
+        },
+      },
+    ],
+  });
+
+  const sparklineField = frame.fields[1];
+
+  it('uses the field color in the default color mode', () => {
+    expect(
+      getSparklineColor(
+        sparklineField,
+        0,
+        frame,
+        { type: TableCellDisplayMode.Sparkline, sparklineColorMode: TableSparklineColorMode.Field },
+        theme
+      )
+    ).toBe(fieldColor);
+  });
+
+  it('uses the same palette color for rows with the same source field value', () => {
+    const first = getSparklineColor(
+      sparklineField,
+      0,
+      frame,
+      {
+        type: TableCellDisplayMode.Sparkline,
+        sparklineColorMode: TableSparklineColorMode.ByFieldValue,
+        sparklineColorField: 'service',
+      },
+      theme
+    );
+    const third = getSparklineColor(
+      sparklineField,
+      2,
+      frame,
+      {
+        type: TableCellDisplayMode.Sparkline,
+        sparklineColorMode: TableSparklineColorMode.ByFieldValue,
+        sparklineColorField: 'service',
+      },
+      theme
+    );
+
+    expect(first).toEqual(third);
+  });
+
+  it('usually uses different palette colors for different source field values', () => {
+    const first = getSparklineColor(
+      sparklineField,
+      0,
+      frame,
+      {
+        type: TableCellDisplayMode.Sparkline,
+        sparklineColorMode: TableSparklineColorMode.ByFieldValue,
+        sparklineColorField: 'service',
+      },
+      theme
+    );
+    const second = getSparklineColor(
+      sparklineField,
+      1,
+      frame,
+      {
+        type: TableCellDisplayMode.Sparkline,
+        sparklineColorMode: TableSparklineColorMode.ByFieldValue,
+        sparklineColorField: 'service',
+      },
+      theme
+    );
+
+    expect(first).not.toEqual(second);
+  });
+
+  it('falls back to the field color when the source field is missing', () => {
+    expect(
+      getSparklineColor(
+        sparklineField,
+        0,
+        frame,
+        {
+          type: TableCellDisplayMode.Sparkline,
+          sparklineColorMode: TableSparklineColorMode.ByFieldValue,
+          sparklineColorField: 'missing',
+        },
+        theme
+      )
+    ).toBe(fieldColor);
+  });
+
+  it('falls back to the field color when the source field value is null or undefined', () => {
+    expect(
+      getSparklineColor(
+        sparklineField,
+        3,
+        frame,
+        {
+          type: TableCellDisplayMode.Sparkline,
+          sparklineColorMode: TableSparklineColorMode.ByFieldValue,
+          sparklineColorField: 'service',
+        },
+        theme
+      )
+    ).toBe(fieldColor);
+    expect(
+      getSparklineColor(
+        sparklineField,
+        99,
+        frame,
+        {
+          type: TableCellDisplayMode.Sparkline,
+          sparklineColorMode: TableSparklineColorMode.ByFieldValue,
+          sparklineColorField: 'service',
+        },
+        theme
+      )
+    ).toBe(fieldColor);
+  });
+});

--- a/packages/grafana-ui/src/components/Table/sparklineColor.ts
+++ b/packages/grafana-ui/src/components/Table/sparklineColor.ts
@@ -1,0 +1,70 @@
+import { type DataFrame, type Field, type FieldColor, type GrafanaTheme2, getColorByStringHash } from '@grafana/data';
+import { FieldColorModeId, TableSparklineColorMode, type TableSparklineCellOptions } from '@grafana/schema';
+
+export function getSparklineColor(
+  field: Field,
+  rowIndex: number,
+  frame: DataFrame | undefined,
+  cellOptions: TableSparklineCellOptions,
+  theme: GrafanaTheme2
+): FieldColor | undefined {
+  if (cellOptions.sparklineColorMode !== TableSparklineColorMode.ByFieldValue) {
+    return field.config.color;
+  }
+
+  const key = getRowBasedSparklineColorKey(frame, rowIndex, cellOptions.sparklineColorField);
+  if (key === undefined) {
+    return field.config.color;
+  }
+
+  const paletteColor = getColorByStringHash(theme.visualization.palette, key);
+  return {
+    mode: FieldColorModeId.Fixed,
+    fixedColor: theme.visualization.getColorByName(paletteColor),
+  };
+}
+
+export function getRowBasedSparklineColorKey(
+  frame: DataFrame | undefined,
+  rowIndex: number,
+  sourceFieldName: string | undefined
+): string | undefined {
+  if (!frame || !sourceFieldName) {
+    return undefined;
+  }
+
+  const sourceField = frame.fields.find(
+    (field) => field.name === sourceFieldName || field.state?.displayName === sourceFieldName
+  );
+  const sourceValue = sourceField?.values[rowIndex];
+
+  if (sourceValue == null) {
+    return undefined;
+  }
+
+  if (sourceValue instanceof Date) {
+    return sourceValue.toISOString();
+  }
+
+  switch (typeof sourceValue) {
+    case 'string':
+      return sourceValue;
+    case 'number':
+    case 'boolean':
+    case 'bigint':
+      return String(sourceValue);
+    case 'object':
+      return stringifyObjectValue(sourceValue);
+    default:
+      return undefined;
+  }
+}
+
+function stringifyObjectValue(value: object): string | undefined {
+  try {
+    const result = JSON.stringify(value);
+    return result === undefined ? undefined : result;
+  } catch {
+    return undefined;
+  }
+}

--- a/public/app/plugins/panel/table/TableCellOptionEditor.tsx
+++ b/public/app/plugins/panel/table/TableCellOptionEditor.tsx
@@ -1,6 +1,7 @@
 import { merge } from 'lodash';
 import { useState } from 'react';
 
+import { type StandardEditorContext } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { type TableCellOptions } from '@grafana/schema';
 import { Combobox, type ComboboxOption, Field, Stack, TableCellDisplayMode } from '@grafana/ui';
@@ -10,22 +11,25 @@ import { ColorBackgroundCellOptionsEditor } from './cells/ColorBackgroundCellOpt
 import { ImageCellOptionsEditor } from './cells/ImageCellOptionsEditor';
 import { MarkdownCellOptionsEditor } from './cells/MarkdownCellOptionsEditor';
 import { SparklineCellOptionsEditor } from './cells/SparklineCellOptionsEditor';
+import { type Options } from './panelcfg.gen';
 
 // The props that any cell type editor are expected
 // to handle. In this case the generic type should
 // be a discriminated interface of TableCellOptions
 export interface TableCellEditorProps<T> {
   cellOptions: T;
+  context?: StandardEditorContext<Options>;
   onChange: (value: T) => void;
 }
 
 interface Props {
   value: TableCellOptions;
   onChange: (v: TableCellOptions) => void;
+  context?: StandardEditorContext<Options>;
   id?: string;
 }
 
-export const TableCellOptionEditor = ({ value, onChange, id }: Props) => {
+export const TableCellOptionEditor = ({ value, onChange, context, id }: Props) => {
   const cellType = value.type;
   const cellDisplayModeOptions: Array<ComboboxOption<TableCellOptions['type']>> = [
     { value: TableCellDisplayMode.Auto, label: t('table.cell-types.auto', 'Auto') },
@@ -85,7 +89,7 @@ export const TableCellOptionEditor = ({ value, onChange, id }: Props) => {
         <ColorBackgroundCellOptionsEditor cellOptions={value} onChange={onCellOptionsChange} />
       )}
       {cellType === TableCellDisplayMode.Sparkline && (
-        <SparklineCellOptionsEditor cellOptions={value} onChange={onCellOptionsChange} />
+        <SparklineCellOptionsEditor cellOptions={value} context={context} onChange={onCellOptionsChange} />
       )}
       {cellType === TableCellDisplayMode.Image && (
         <ImageCellOptionsEditor cellOptions={value} onChange={onCellOptionsChange} />

--- a/public/app/plugins/panel/table/cells/SparklineCellOptionsEditor.test.tsx
+++ b/public/app/plugins/panel/table/cells/SparklineCellOptionsEditor.test.tsx
@@ -1,8 +1,13 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { standardEditorsRegistry } from '@grafana/data';
-import { GraphDrawStyle, TableCellDisplayMode, type TableSparklineCellOptions } from '@grafana/schema';
+import { FieldType, standardEditorsRegistry, toDataFrame } from '@grafana/data';
+import {
+  GraphDrawStyle,
+  TableCellDisplayMode,
+  TableSparklineColorMode,
+  type TableSparklineCellOptions,
+} from '@grafana/schema';
 import { mockComboboxRect } from '@grafana/test-utils';
 import { getAllOptionEditors } from 'app/core/components/OptionsUI/registry';
 
@@ -25,9 +30,64 @@ function setup(cellOptions: Partial<TableSparklineCellOptions> = {}) {
 }
 
 describe('SparklineCellOptionsEditor', () => {
+  const context = {
+    data: [
+      toDataFrame({
+        fields: [
+          { name: 'service', type: FieldType.string, values: ['api'] },
+          { name: 'trend', type: FieldType.number, values: [1] },
+        ],
+      }),
+    ],
+    options: { frameIndex: 0, showHeader: true },
+  };
+
   it('renders the "Hide value" control it adds on top of the graph config', () => {
     setup();
     expect(screen.getByLabelText('Hide value')).toBeInTheDocument();
+  });
+
+  it('renders the sparkline color mode control', () => {
+    setup();
+    expect(screen.getByText('Sparkline color mode')).toBeInTheDocument();
+    expect(screen.getByText('Field color')).toBeInTheDocument();
+    expect(screen.getByText('By field value')).toBeInTheDocument();
+  });
+
+  it('shows the sparkline color field picker when coloring by field value', () => {
+    render(
+      <SparklineCellOptionsEditor
+        cellOptions={{
+          type: TableCellDisplayMode.Sparkline,
+          sparklineColorMode: TableSparklineColorMode.ByFieldValue,
+        }}
+        context={context}
+        onChange={jest.fn()}
+      />
+    );
+    expect(screen.getByText('Sparkline color field')).toBeInTheDocument();
+  });
+
+  it('clears the sparkline color field with an empty value', async () => {
+    const onChange = jest.fn();
+    render(
+      <SparklineCellOptionsEditor
+        cellOptions={{
+          type: TableCellDisplayMode.Sparkline,
+          sparklineColorMode: TableSparklineColorMode.ByFieldValue,
+          sparklineColorField: 'service',
+        }}
+        context={context}
+        onChange={onChange}
+      />
+    );
+
+    await userEvent.click(screen.getByTitle('Clear value'));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sparklineColorField: '',
+      })
+    );
   });
 
   it('forwards a changed option while preserving the existing cell options', async () => {

--- a/public/app/plugins/panel/table/cells/SparklineCellOptionsEditor.tsx
+++ b/public/app/plugins/panel/table/cells/SparklineCellOptionsEditor.tsx
@@ -2,9 +2,10 @@ import { css } from '@emotion/css';
 import { useId, useMemo } from 'react';
 
 import { createFieldConfigRegistry, type SetFieldConfigOptionsArgs } from '@grafana/data';
-import { type GraphFieldConfig, type TableSparklineCellOptions } from '@grafana/schema';
-import { Field, useStyles2 } from '@grafana/ui';
-import { defaultSparklineCellConfig } from '@grafana/ui/internal';
+import { t } from '@grafana/i18n';
+import { type GraphFieldConfig, TableSparklineColorMode, type TableSparklineCellOptions } from '@grafana/schema';
+import { Field, RadioButtonGroup, useStyles2 } from '@grafana/ui';
+import { defaultSparklineCellConfig, FieldNamePicker } from '@grafana/ui/internal';
 
 import { getGraphFieldConfig } from '../../timeseries/config';
 import { type TableCellEditorProps } from '../TableCellOptionEditor';
@@ -40,7 +41,7 @@ function getChartCellConfig(cfg: GraphFieldConfig): SetFieldConfigOptionsArgs<Gr
 }
 
 export const SparklineCellOptionsEditor = (props: TableCellEditorProps<TableSparklineCellOptions>) => {
-  const { cellOptions, onChange } = props;
+  const { cellOptions, context, onChange } = props;
 
   const registry = useMemo(() => {
     const config = getChartCellConfig(defaultSparklineCellConfig);
@@ -50,11 +51,57 @@ export const SparklineCellOptionsEditor = (props: TableCellEditorProps<TableSpar
   const style = useStyles2(getStyles);
 
   const values = { ...defaultSparklineCellConfig, ...cellOptions };
+  const editorContext = context ?? { data: [] };
+  const selectedFrame =
+    editorContext.options?.frameIndex != null ? editorContext.data[editorContext.options.frameIndex] : undefined;
+  const fieldPickerContext = selectedFrame ? { ...editorContext, data: [selectedFrame] } : editorContext;
 
   const htmlIdBase = useId();
 
   return (
     <>
+      <Field
+        noMargin
+        label={t('table.sparkline-cell-options.color-mode-label', 'Sparkline color mode')}
+        className={style.field}
+      >
+        <RadioButtonGroup
+          id={`${htmlIdBase}sparklineColorMode`}
+          options={[
+            {
+              label: t('table.sparkline-cell-options.color-mode-field', 'Field color'),
+              value: TableSparklineColorMode.Field,
+            },
+            {
+              label: t('table.sparkline-cell-options.color-mode-by-field-value', 'By field value'),
+              value: TableSparklineColorMode.ByFieldValue,
+            },
+          ]}
+          value={values.sparklineColorMode ?? TableSparklineColorMode.Field}
+          onChange={(value) => onChange({ ...cellOptions, sparklineColorMode: value })}
+        />
+      </Field>
+      {(values.sparklineColorMode ?? TableSparklineColorMode.Field) === TableSparklineColorMode.ByFieldValue && (
+        <Field
+          noMargin
+          label={t('table.sparkline-cell-options.color-field-label', 'Sparkline color field')}
+          className={style.field}
+        >
+          <FieldNamePicker
+            id={`${htmlIdBase}sparklineColorField`}
+            value={values.sparklineColorField ?? ''}
+            onChange={(value) => onChange({ ...cellOptions, sparklineColorField: value ?? '' })}
+            context={fieldPickerContext}
+            item={{
+              id: 'sparklineColorField',
+              name: t('table.sparkline-cell-options.color-field-label', 'Sparkline color field'),
+              settings: {
+                isClearable: true,
+              },
+            }}
+          />
+        </Field>
+      )}
       {registry.list(optionIds.map((id) => `custom.${id}`)).map((item) => {
         if (item.showIf && !item.showIf(values)) {
           return null;


### PR DESCRIPTION
**What is this feature?**

Adds an optional row-aware color mode for Table panel sparkline cells.

When **Sparkline color mode** is set to **By field value**, the sparkline color is derived from another field in the same row. The selected row value is converted to a stable string key and mapped deterministically to Grafana's theme visualization palette.

Default behavior is unchanged. Existing dashboards continue to use the sparkline field color unless the new mode is explicitly enabled.

**Why do we need this feature?**

Table panels can show multiple sparkline cells in the same sparkline column, but today those sparklines all use the field/column color. That makes it hard to visually distinguish row categories, especially in tables or nested tables where each row represents a different group, region, service, status, or similar dimension.

This option lets users keep sparkline colors consistent by another field's row value.

**Who is this feature for?**

Users building Table panels with sparkline cells who want row-level category coloring, such as coloring trends by service, region, status, source, or collector type.

**Which issue(s) does this PR fix?**:

N/A

**Screenshots**

Before:

Sparklines all the same color

<img width="1107" height="796" alt="Screenshot 2026-08-11 at 20 31 44" src="https://github.com/user-attachments/assets/2ae82deb-4095-4833-8337-5040962fa6ab" />

After:

With **Sparkline color mode** set to **By field value** and **Sparkline color field** set to `region`, each row derives its sparkline color from the row's `region` value.

<img width="1088" height="837" alt="Screenshot 2026-08-11 at 20 32 02" src="https://github.com/user-attachments/assets/b1c93731-15c0-4cc1-9f2b-9a3af1434235" />

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] The docs are updated.
- [x] Default behavior is unchanged unless the new sparkline color mode is explicitly enabled.
- [ ] If this is a notable improvement, it should be considered for What's New.

Testing:
- `yarn jest packages/grafana-ui/src/components/Table/sparklineColor.test.ts public/app/plugins/panel/table/cells/SparklineCellOptionsEditor.test.tsx --runInBand`
- `yarn eslint` on changed TypeScript/TSX files
- `yarn prettier --check` on changed files
- `yarn tsc --noEmit --pretty false`