### PR TITLE
Table: remove table.refactorNested feature toggle

### DIFF
--- a/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
@@ -74,7 +74,6 @@ declare module "@openfeature/core" {
     | "assistant.fullscreenWorkspace"
     | "table.protoRowParser"
     | "grafana.queryVarEditorRedesign"
-    | "table.refactorNested"
     | "table.paginationPageSize"
     | "table.autoColumnWidths"
     | "dataviz.experimentalColorSchemes"

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -165,8 +165,6 @@ export const FlagKeys = {
   TablePaginationPageSize: "table.paginationPageSize",
   /** Enables a new internal parser for table panel which doesn't rely on constructing a dynamic function and works in more browser environments. */
   TableProtoRowParser: "table.protoRowParser",
-  /** Enables the refactored TableNG nested-table implementation */
-  TableRefactorNested: "table.refactorNested",
   /** Routes short URL requests from /api to the /apis endpoint in the frontend. Depends on kubernetesShortURLs */
   UseKubernetesShortURLsAPI: "useKubernetesShortURLsAPI",
 } as const;
@@ -1005,17 +1003,6 @@ export const useFlagTablePaginationPageSize = (options?: ReactFlagEvaluationOpti
  */
 export const useFlagTableProtoRowParser = (options?: ReactFlagEvaluationOptions): boolean => {
   return useFlag("table.protoRowParser", false, options).value;
-};
-
-/**
- * Enables the refactored TableNG nested-table implementation
- *
- * **Details:**
- * - flag key: `table.refactorNested`
- * - default value: `false`
- */
-export const useFlagTableRefactorNested = (options?: ReactFlagEvaluationOptions): boolean => {
-  return useFlag("table.refactorNested", false, options).value;
 };
 
 /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2966,15 +2966,6 @@ var (
 			Generate:    Generate{React: true},
 		},
 		{
-			Name:         "table.refactorNested",
-			Description:  "Enables the refactored TableNG nested-table implementation",
-			Stage:        FeatureStageExperimental,
-			Owner:        grafanaDatavizSquad,
-			HideFromDocs: true,
-			Expression:   "false",
-			Generate:     Generate{React: true},
-		},
-		{
 			Name:         "table.paginationPageSize",
 			Description:  "Enables configuring a fixed page size for paginated tables instead of deriving it from the panel height",
 			Stage:        FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -344,7 +344,6 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-06-19,splunk.useLegacyResultsApi,experimental,@grafana/data-sources-plugins,false,false,false
 2026-06-22,table.protoRowParser,experimental,@grafana/dataviz-squad,false,false,true
 2026-06-17,grafana.queryVarEditorRedesign,GA,@grafana/dashboards-squad,false,false,true
-2026-06-25,table.refactorNested,experimental,@grafana/dataviz-squad,false,false,true
 2026-07-29,table.paginationPageSize,experimental,@grafana/dataviz-squad,false,false,true
 2026-07-24,table.autoColumnWidths,experimental,@grafana/dataviz-squad,false,false,true
 2026-06-23,dataviz.experimentalColorSchemes,experimental,@grafana/dataviz-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -6139,7 +6139,8 @@
       "metadata": {
         "name": "table.refactorNested",
         "resourceVersion": "1782413661913",
-        "creationTimestamp": "2026-06-25T18:54:21Z"
+        "creationTimestamp": "2026-06-25T18:54:21Z",
+        "deletionTimestamp": "2026-08-11T20:20:39Z"
       },
       "spec": {
         "description": "Enables the refactored TableNG nested-table implementation",


### PR DESCRIPTION
## What is this feature toggle?

`table.refactorNested` gated the refactored TableNG nested-table implementation.

## Why should it be removed?

The refactor was made permanent in #129407, which removed the flag check from all call sites (deleted `LegacyTableNG.tsx`, promoted the refactored `TableDataGrid`/`TableFlat`/`TableNested` split to the only implementation). The toggle registration itself was left behind. This PR removes the now-unused registry entry and regenerates the derived toggle files (`toggles_gen.{go,csv,json}`, `openfeature.gen.ts`, `openfeature-types.gen.d.ts`) via `make gen-feature-toggles`.

No product code changes — the old/new code path decision already happened in #129407.

🤖 Generated with [Claude Code](https://claude.com/claude-code)