### PR TITLE
Docs: TestData quarterly update (FY27 Q3)

### DIFF
--- a/docs/sources/datasources/testdata/_index.md
+++ b/docs/sources/datasources/testdata/_index.md
@@ -23,7 +23,7 @@ review_date: '2026-08-11'
 
 # TestData data source
 
-Grafana ships with a built-in TestData data source that generates simulated time-series, log, trace, and other data for any [panel](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/). You can use it to verify dashboard functionality, test visualizations, prototype alerting rules, and reproduce issues without connecting to an external data source.
+Every dashboard starts with data, and the TestData data source gives you data instantly. TestData is bundled with Grafana, so it's ready to use out of the box with no installation required. It generates simulated time series, logs, traces, and more for any [panel](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/), with no external connection required. Use it to prototype dashboards, put visualizations through their paces with tricky edge cases, experiment with alert rules, and reproduce issues in a way that others can replicate.
 
 ## Supported features
 

--- a/docs/sources/datasources/testdata/_index.md
+++ b/docs/sources/datasources/testdata/_index.md
@@ -18,7 +18,7 @@ labels:
 menuTitle: TestData
 title: TestData data source
 weight: 1500
-review_date: '2026-04-08'
+review_date: '2026-08-11'
 ---
 
 # TestData data source
@@ -39,7 +39,7 @@ Grafana ships with a built-in TestData data source that generates simulated time
 The following pages help you set up and use the TestData data source:
 
 - [Configure the TestData data source](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/testdata/configure/) for setup and provisioning instructions.
-- [TestData query editor](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/testdata/query-editor/) for a reference of all 30 available scenarios and their options.
+- [TestData query editor](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/testdata/query-editor/) for a reference of all 33 available scenarios and their options.
 - [TestData alerting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/testdata/alerting/) for prototyping and testing alert rules with simulated data.
 - [TestData template variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/testdata/template-variables/) for using TestData with dashboard variables.
 - [Troubleshoot TestData](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/testdata/troubleshooting/) for solutions to common issues.

--- a/docs/sources/datasources/testdata/_index.md
+++ b/docs/sources/datasources/testdata/_index.md
@@ -42,6 +42,7 @@ The following pages help you set up and use the TestData data source:
 - [TestData query editor](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/testdata/query-editor/) for a reference of all 33 available scenarios and their options.
 - [TestData alerting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/testdata/alerting/) for prototyping and testing alert rules with simulated data.
 - [TestData template variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/testdata/template-variables/) for using TestData with dashboard variables.
+- [TestData annotations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/testdata/annotations/) for generating simulated annotation events.
 - [Troubleshoot TestData](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/testdata/troubleshooting/) for solutions to common issues.
 
 ## Additional features

--- a/docs/sources/datasources/testdata/alerting/index.md
+++ b/docs/sources/datasources/testdata/alerting/index.md
@@ -15,7 +15,7 @@ labels:
 menuTitle: Alerting
 title: TestData alerting
 weight: 400
-review_date: '2026-04-08'
+review_date: '2026-08-11'
 ---
 
 # TestData alerting
@@ -39,6 +39,7 @@ TestData scenarios that return time-series data work with alert rule conditions.
 | **Predictable CSV Wave**     | Custom repeating waveforms. Test complex threshold patterns with precise control.              |
 | **Random Walk (with error)** | Returns both data and an error. Test how alerts handle partial failures.                       |
 | **Error with source**        | Returns a plugin or downstream error. Test alert evaluation error handling.                    |
+| **Flaky Query**              | Returns errors intermittently. Test how alerts handle a data source that fails part of the time. |
 | **No Data Points**           | Returns empty results. Test no-data alert conditions.                                          |
 | **Slow Query**               | Introduces a configurable delay. Test alert evaluation timeouts.                               |
 
@@ -116,10 +117,14 @@ Select the **No Data Points** scenario. The backend returns an empty result, whi
 
 Select **Error with source** and choose the error type:
 
-- **Plugin** — simulates a failure in the plugin itself. The alert enters an error state.
-- **Downstream** — simulates a failure in the data source or network. The alert enters an error state with a downstream classification.
+- **Plugin**: Simulates a failure in the plugin itself. The alert enters an error state.
+- **Downstream**: Simulates a failure in the data source or network. The alert enters an error state with a downstream classification.
 
 You can also use **Random Walk (with error)**, which returns valid data alongside an error, to test how the alerting engine handles partial failures.
+
+### Intermittent errors
+
+Select **Flaky Query** to simulate a data source that fails part of the time. Set the **Error rate** to control how often requests fail, and use **Status code** and **Error source** to shape the error. Use this to verify how an alert rule behaves when evaluations succeed and fail across consecutive intervals, and how the **No data and error handling** settings respond to intermittent failures.
 
 ### Timeouts
 

--- a/docs/sources/datasources/testdata/alerting/index.md
+++ b/docs/sources/datasources/testdata/alerting/index.md
@@ -31,17 +31,17 @@ The TestData data source supports [Grafana Alerting](https://grafana.com/docs/gr
 
 TestData scenarios that return time-series data work with alert rule conditions. Choose a scenario based on the behavior you want to test.
 
-| Scenario                     | Alerting use case                                                                              |
-| ---------------------------- | ---------------------------------------------------------------------------------------------- |
-| **Predictable Pulse**        | Deterministic on/off pattern. Produces repeatable alert firing and resolving on a fixed cycle. |
-| **Random Walk**              | Non-deterministic time series. Useful for quick prototyping and load testing alert evaluation. |
-| **CSV Metric Values**        | Controlled, fixed values. Test exact threshold boundaries.                                     |
-| **Predictable CSV Wave**     | Custom repeating waveforms. Test complex threshold patterns with precise control.              |
-| **Random Walk (with error)** | Returns both data and an error. Test how alerts handle partial failures.                       |
-| **Error with source**        | Returns a plugin or downstream error. Test alert evaluation error handling.                    |
+| Scenario                     | Alerting use case                                                                                |
+| ---------------------------- | ------------------------------------------------------------------------------------------------ |
+| **Predictable Pulse**        | Deterministic on/off pattern. Produces repeatable alert firing and resolving on a fixed cycle.   |
+| **Random Walk**              | Non-deterministic time series. Useful for quick prototyping and load testing alert evaluation.   |
+| **CSV Metric Values**        | Controlled, fixed values. Test exact threshold boundaries.                                       |
+| **Predictable CSV Wave**     | Custom repeating waveforms. Test complex threshold patterns with precise control.                |
+| **Random Walk (with error)** | Returns both data and an error. Test how alerts handle partial failures.                         |
+| **Error with source**        | Returns a plugin or downstream error. Test alert evaluation error handling.                      |
 | **Flaky Query**              | Returns errors intermittently. Test how alerts handle a data source that fails part of the time. |
-| **No Data Points**           | Returns empty results. Test no-data alert conditions.                                          |
-| **Slow Query**               | Introduces a configurable delay. Test alert evaluation timeouts.                               |
+| **No Data Points**           | Returns empty results. Test no-data alert conditions.                                            |
+| **Slow Query**               | Introduces a configurable delay. Test alert evaluation timeouts.                                 |
 
 Scenarios that produce logs, traces, or streaming data aren't suitable for threshold-based alert conditions.
 

--- a/docs/sources/datasources/testdata/annotations/index.md
+++ b/docs/sources/datasources/testdata/annotations/index.md
@@ -1,0 +1,61 @@
+---
+description: Use annotations with the TestData data source to generate simulated annotation events for testing dashboards.
+keywords:
+  - grafana
+  - testdata
+  - annotations
+  - events
+  - testing
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
+menuTitle: Annotations
+title: TestData annotations
+weight: 350
+review_date: '2026-08-11'
+---
+
+# TestData annotations
+
+The TestData data source can generate simulated [annotation](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/build-dashboards/annotate-visualizations/) events. Use it to test how dashboards and panels render annotation markers and overlays without connecting to an external source. The generated events are created in the browser and aren't persisted.
+
+## Before you begin
+
+- [Configure the TestData data source](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/testdata/configure/).
+- Familiarize yourself with [annotations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/build-dashboards/annotate-visualizations/) in Grafana.
+
+## Add an annotation query
+
+To add a dashboard annotation query that uses TestData:
+
+1. Navigate to the dashboard you want to update and click **Edit**.
+1. Click **Settings**.
+1. Select the **Annotations** tab.
+1. Click **Add annotation query**.
+1. Enter a name for the annotation.
+1. Select the **TestData** data source.
+1. Set the **Count** field to the number of events you want to generate. Default: `10`.
+1. Click **Save dashboard**.
+
+TestData distributes the generated events evenly across the current dashboard time range. Each event includes sample text with a link and the tags `text` and `server`.
+
+## Use the Annotations scenario in a panel
+
+You can also generate annotation data as a panel query using the **Annotations** scenario. This returns annotation-shaped data frames directly to the panel instead of registering a dashboard-wide annotation query.
+
+To use the Annotations scenario:
+
+1. Add or edit a panel and select the **TestData** data source.
+1. Choose the **Annotations** scenario from the **Scenario** drop-down.
+1. Set the **Count** field to the number of events you want to generate. Default: `10`.
+1. Click **Run queries**.
+
+For a reference of all TestData scenarios, refer to the [TestData query editor](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/testdata/query-editor/).
+
+## Limitations
+
+- **Events are synthetic.** TestData generates fixed sample text and tags. You can't customize the event content.
+- **Events aren't persisted.** The data source builds events in the browser each time the query runs. TestData doesn't store annotations or query an external source.
+- **Not evaluated by the alerting engine.** The Annotations scenario runs in the browser, so it can't be used with [Grafana Alerting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/testdata/alerting/) or in any context that requires server-side evaluation.

--- a/docs/sources/datasources/testdata/annotations/index.md
+++ b/docs/sources/datasources/testdata/annotations/index.md
@@ -54,6 +54,29 @@ To use the Annotations scenario:
 
 For a reference of all TestData scenarios, refer to the [TestData query editor](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/testdata/query-editor/).
 
+## Example: Overlay annotations on a time series panel
+
+This example creates a time series panel with simulated data, then adds a TestData annotation query so you can verify how the panel renders annotation markers.
+
+1. Navigate to the dashboard you want to update and click **Edit**.
+1. Click the **Add** icon and select **Visualization**.
+1. Select the **TestData** data source.
+1. Choose the **Random Walk** scenario from the **Scenario** drop-down.
+1. Click **Run queries** to render the time series.
+1. Click **Back to dashboard**, then click **Settings**.
+1. Select the **Annotations** tab.
+1. Click **Add annotation query**.
+1. Enter a name for the annotation, for example `Test events`.
+1. Select the **TestData** data source.
+1. Set the **Count** field to `5`.
+1. Click **Save dashboard**.
+
+Grafana draws five vertical annotation markers evenly across the time range on the time series panel. Hover over a marker to see the sample text and tags. Adjust the **Count** field to change how many markers appear.
+
+{{< admonition type="tip" >}}
+To test how a panel handles crowded overlays, increase the **Count** field to a high value, such as `100`. This produces many closely spaced markers, which is useful for checking marker rendering and tooltip behavior at high density.
+{{< /admonition >}}
+
 ## Limitations
 
 - **Events are synthetic.** TestData generates fixed sample text and tags. You can't customize the event content.

--- a/docs/sources/datasources/testdata/configure/index.md
+++ b/docs/sources/datasources/testdata/configure/index.md
@@ -16,7 +16,7 @@ labels:
 menuTitle: Configure
 title: Configure the TestData data source
 weight: 100
-review_date: '2026-04-08'
+review_date: '2026-08-11'
 ---
 
 # Configure the TestData data source
@@ -92,7 +92,7 @@ For all available configuration options, refer to the [Grafana provider data sou
 
 After configuring your TestData data source, you can:
 
-- [Write queries](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/testdata/query-editor/) using the 30 available scenarios to generate simulated data.
+- [Write queries](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/testdata/query-editor/) using the 33 available scenarios to generate simulated data.
 - [Use template variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/testdata/template-variables/) to create dynamic, reusable dashboards.
 - [Set up alerting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/testdata/alerting/) to prototype and test alert rules with simulated data.
 - [Troubleshoot issues](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/testdata/troubleshooting/) if you encounter problems with your data source.

--- a/docs/sources/datasources/testdata/configure/index.md
+++ b/docs/sources/datasources/testdata/configure/index.md
@@ -60,7 +60,7 @@ If the test fails, refer to [Troubleshoot TestData](https://grafana.com/docs/gra
 
 ## Provision the data source
 
-You can define and configure the data source in YAML files as part of Grafana's provisioning system. For more information about provisioning, refer to [Provisioning data sources](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/provisioning/#data-sources).
+You can define and configure the data source in YAML files as part of the Grafana provisioning system. For more information about provisioning, refer to [Provisioning data sources](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/provisioning/#data-sources).
 
 TestData doesn't require any `jsonData` or `secureJsonData` fields.
 

--- a/docs/sources/datasources/testdata/query-editor/index.md
+++ b/docs/sources/datasources/testdata/query-editor/index.md
@@ -268,7 +268,7 @@ Generates simulated distributed trace data.
 
 Generates synthetic annotation data points. These annotations are created entirely in the browser and are useful for testing how panels display annotation markers and overlays. They don't query an external source or persist data.
 
-For more information about annotations in Grafana, refer to [Annotate visualizations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/build-dashboards/annotate-visualizations/).
+For more information about using annotations with TestData, refer to [TestData annotations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/testdata/annotations/). For more information about annotations in Grafana, refer to [Annotate visualizations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/build-dashboards/annotate-visualizations/).
 
 | Field     | Description                                       |
 | --------- | ------------------------------------------------- |

--- a/docs/sources/datasources/testdata/query-editor/index.md
+++ b/docs/sources/datasources/testdata/query-editor/index.md
@@ -72,7 +72,7 @@ The scenarios are organized into the following categories. Use the table below t
 | [Flaky Query](#flaky-query)                                         | Error testing         | Intermittent errors with configurable rate.        |
 | [Errors and notices](#errors-and-notices)                           | Error testing         | Series with info, warning, and error notices.      |
 | [No Data Points](#no-data-points)                                   | Error testing         | Empty result with no data.                         |
-| [Data Points Outside Range](#datapoints-outside-range)              | Error testing         | Data point outside the visible time range.         |
+| [Data Points Outside Range](#data-points-outside-range)             | Error testing         | Data point outside the visible time range.         |
 | [Slow Query](#slow-query)                                           | Error testing         | Configurable delay before returning data.          |
 | [Query Metadata](#query-metadata)                                   | Metadata              | Returns query context metadata.                    |
 
@@ -391,7 +391,7 @@ Returns a random walk series with one query-result notice of each severity (info
 
 Returns an empty result with no data points. Use this to test how panels display when there's no data.
 
-### Data points Outside Range
+### Data Points Outside Range
 
 Returns a single data point with a timestamp one hour before the query time range. Use this to test how panels handle data outside the visible range.
 

--- a/docs/sources/datasources/testdata/query-editor/index.md
+++ b/docs/sources/datasources/testdata/query-editor/index.md
@@ -286,12 +286,12 @@ Generates heatmap data with linearly distributed bucket boundaries (0, 10, 20, 3
 
 Generates only exemplars, the diamond markers a panel draws on top of a series, and no series of its own. Add a second query in the same panel, such as Random Walk, to give the exemplars a series to annotate. Values and timestamps are seeded from the dashboard time range, so the same range always returns the same exemplars.
 
-| Field           | Description                                                                                                       |
-| --------------- | ----------------------------------------------------------------------------------------------------------------- |
-| **Count**       | Number of exemplars to generate.                                                                                  |
-| **Min**         | Minimum value for the exemplars. When empty, the range is derived from a reference random walk over the same time range, padded by 10%. |
-| **Max**         | Maximum value for the exemplars. When empty, the range is derived as described for **Min**.                       |
-| **Labels**      | Exemplar labels shown in the tooltip. Each label defines a **Name**, a **Length**, and an optional **Link**.      |
+| Field      | Description                                                                                                                             |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| **Count**  | Number of exemplars to generate.                                                                                                        |
+| **Min**    | Minimum value for the exemplars. When empty, the range is derived from a reference random walk over the same time range, padded by 10%. |
+| **Max**    | Maximum value for the exemplars. When empty, the range is derived as described for **Min**.                                             |
+| **Labels** | Exemplar labels shown in the tooltip. Each label defines a **Name**, a **Length**, and an optional **Link**.                            |
 
 To keep the exemplars aligned with a sibling series, pin **Min** and **Max**, or give the sibling query an explicit start value and spread. The legend filter matches on exemplar labels, so hiding a series in the legend also hides its markers.
 
@@ -374,14 +374,14 @@ Use this to test how Grafana differentiates between plugin errors and downstream
 
 Returns errors intermittently based on a configurable error rate, with optional delays. Use this to test how panels, alert rules, and error handling behave when a data source fails part of the time.
 
-| Field                | Description                                                                                                   |
-| -------------------- | ------------------------------------------------------------------------------------------------------------- |
-| **Error rate**       | Percentage of requests that return an error. Default: `50`.                                                   |
-| **Status code**      | HTTP status code returned with the error. Default: `400`.                                                     |
-| **Error source**     | Source of the error: `Plugin` (plugin error) or `Downstream` (downstream service error).                      |
-| **Query delay**      | Base delay applied to each request in Go duration syntax, for example `1s` or `500ms`. Default: `5s`.         |
-| **Delay variability**| Randomizes the query delay by plus or minus this percentage. For example, `100` on a `1s` delay sleeps between 0 and 2 seconds. |
-| **Error message**    | Message returned with the error. Default: `Flaky query error`.                                                |
+| Field                 | Description                                                                                                                     |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| **Error rate**        | Percentage of requests that return an error. Default: `50`.                                                                     |
+| **Status code**       | HTTP status code returned with the error. Default: `400`.                                                                       |
+| **Error source**      | Source of the error: `Plugin` (plugin error) or `Downstream` (downstream service error).                                        |
+| **Query delay**       | Base delay applied to each request in Go duration syntax, for example `1s` or `500ms`. Default: `5s`.                           |
+| **Delay variability** | Randomizes the query delay by plus or minus this percentage. For example, `100` on a `1s` delay sleeps between 0 and 2 seconds. |
+| **Error message**     | Message returned with the error. Default: `Flaky query error`.                                                                  |
 
 ### Errors and notices
 

--- a/docs/sources/datasources/testdata/query-editor/index.md
+++ b/docs/sources/datasources/testdata/query-editor/index.md
@@ -15,12 +15,12 @@ labels:
 menuTitle: Query editor
 title: TestData query editor
 weight: 200
-review_date: '2026-04-08'
+review_date: '2026-08-11'
 ---
 
 # TestData query editor
 
-Instead of a traditional query language, the TestData data source uses **scenarios** to generate simulated data. Each scenario produces a different type of data suited for testing specific visualizations, behaviors, or edge cases. TestData includes 30 scenarios covering time series, logs, traces, graphs, streaming, and error simulation.
+Instead of a traditional query language, the TestData data source uses **scenarios** to generate simulated data. Each scenario produces a different type of data suited for testing specific visualizations, behaviors, or edge cases. TestData includes 33 scenarios covering time series, logs, traces, graphs, streaming, and error simulation.
 
 Use scenarios to:
 
@@ -33,7 +33,7 @@ Use scenarios to:
 To build a query, select a scenario from the **Scenario** drop-down. The query editor updates to show fields specific to that scenario. Click **Run queries** or use the keyboard shortcut to execute.
 
 {{< admonition type="note" >}}
-Some scenarios run entirely in the browser (Streaming Client, Grafana Live, Grafana API, Steps, No Data Points). These scenarios don't send queries to the backend, which means they can't be used with [Grafana Alerting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/testdata/alerting/) or in any context that requires server-side evaluation.
+Some scenarios run entirely in the browser: Streaming Client, Grafana Live, Grafana API, Steps, Annotations, Node Graph, Flame Graph, Trace, and Raw Frames. These scenarios don't send queries to the backend, which means they can't be used with [Grafana Alerting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/testdata/alerting/) or in any context that requires server-side evaluation.
 {{< /admonition >}}
 
 ## Scenario reference
@@ -63,11 +63,14 @@ The scenarios are organized into the following categories. Use the table below t
 | [Annotations](#annotations)                                         | Visualization testing | Annotation data points.                            |
 | [Exponential heatmap bucket data](#exponential-heatmap-bucket-data) | Visualization testing | Heatmap data with exponential buckets.             |
 | [Linear heatmap bucket data](#linear-heatmap-bucket-data)           | Visualization testing | Heatmap data with linear buckets.                  |
+| [Exemplars](#exemplars)                                             | Visualization testing | Exemplar markers to overlay on a sibling series.   |
 | [Streaming Client](#streaming-client)                               | Streaming             | Browser-side streaming (signal, logs, traces).     |
 | [Grafana Live](#grafana-live)                                       | Streaming             | Server-side streaming via live channels.           |
 | [Grafana API](#grafana-api)                                         | Data retrieval        | Fetch data from internal Grafana endpoints.        |
 | [Conditional Error](#conditional-error)                             | Error testing         | Configurable error or CSV data.                    |
 | [Error with source](#error-with-source)                             | Error testing         | Error with plugin or downstream classification.    |
+| [Flaky Query](#flaky-query)                                         | Error testing         | Intermittent errors with configurable rate.        |
+| [Errors and notices](#errors-and-notices)                           | Error testing         | Series with info, warning, and error notices.      |
 | [No Data Points](#no-data-points)                                   | Error testing         | Empty result with no data.                         |
 | [Data Points Outside Range](#datapoints-outside-range)              | Error testing         | Data point outside the visible time range.         |
 | [Slow Query](#slow-query)                                           | Error testing         | Configurable delay before returning data.          |
@@ -279,6 +282,19 @@ Generates heatmap data with exponentially distributed bucket boundaries (1, 2, 4
 
 Generates heatmap data with linearly distributed bucket boundaries (0, 10, 20, 30, ...). Use this to test heatmap panels with linear distributions.
 
+### Exemplars
+
+Generates only exemplars, the diamond markers a panel draws on top of a series, and no series of its own. Add a second query in the same panel, such as Random Walk, to give the exemplars a series to annotate. Values and timestamps are seeded from the dashboard time range, so the same range always returns the same exemplars.
+
+| Field           | Description                                                                                                       |
+| --------------- | ----------------------------------------------------------------------------------------------------------------- |
+| **Count**       | Number of exemplars to generate.                                                                                  |
+| **Min**         | Minimum value for the exemplars. When empty, the range is derived from a reference random walk over the same time range, padded by 10%. |
+| **Max**         | Maximum value for the exemplars. When empty, the range is derived as described for **Min**.                       |
+| **Labels**      | Exemplar labels shown in the tooltip. Each label defines a **Name**, a **Length**, and an optional **Link**.      |
+
+To keep the exemplars aligned with a sibling series, pin **Min** and **Max**, or give the sibling query an explicit start value and spread. The legend filter matches on exemplar labels, so hiding a series in the legend also hides its markers.
+
 ## Streaming scenarios
 
 These scenarios produce real-time streaming data. Data updates continuously in the browser without requiring manual query execution.
@@ -353,6 +369,23 @@ Returns an error with a configurable source classification.
 | **Error source** | Source of the error: `Plugin` (plugin error) or `Downstream` (downstream service error). |
 
 Use this to test how Grafana differentiates between plugin errors and downstream errors in alerting and error handling.
+
+### Flaky Query
+
+Returns errors intermittently based on a configurable error rate, with optional delays. Use this to test how panels, alert rules, and error handling behave when a data source fails part of the time.
+
+| Field                | Description                                                                                                   |
+| -------------------- | ------------------------------------------------------------------------------------------------------------- |
+| **Error rate**       | Percentage of requests that return an error. Default: `50`.                                                   |
+| **Status code**      | HTTP status code returned with the error. Default: `400`.                                                     |
+| **Error source**     | Source of the error: `Plugin` (plugin error) or `Downstream` (downstream service error).                      |
+| **Query delay**      | Base delay applied to each request in Go duration syntax, for example `1s` or `500ms`. Default: `5s`.         |
+| **Delay variability**| Randomizes the query delay by plus or minus this percentage. For example, `100` on a `1s` delay sleeps between 0 and 2 seconds. |
+| **Error message**    | Message returned with the error. Default: `Flaky query error`.                                                |
+
+### Errors and notices
+
+Returns a random walk series with one query-result notice of each severity (info, warning, and error) attached to the frame metadata. Use this to preview how a panel displays query errors and notices.
 
 ### No Data Points
 

--- a/docs/sources/datasources/testdata/template-variables/index.md
+++ b/docs/sources/datasources/testdata/template-variables/index.md
@@ -14,7 +14,7 @@ labels:
 menuTitle: Template variables
 title: TestData template variables
 weight: 300
-review_date: '2026-04-08'
+review_date: '2026-08-11'
 ---
 
 # TestData template variables

--- a/docs/sources/datasources/testdata/troubleshooting/index.md
+++ b/docs/sources/datasources/testdata/troubleshooting/index.md
@@ -17,7 +17,7 @@ labels:
 menuTitle: Troubleshooting
 title: Troubleshoot TestData data source issues
 weight: 500
-review_date: '2026-04-08'
+review_date: '2026-08-11'
 ---
 
 # Troubleshoot TestData data source issues
@@ -222,7 +222,7 @@ These errors occur when using TestData with [Grafana Alerting](https://grafana.c
 
 **Solutions:**
 
-1. Verify you're using a backend-evaluated scenario. Browser-only scenarios (Streaming Client, Grafana Live, Grafana API, Steps, No Data Points) return empty results when evaluated by the alerting engine. Use a backend scenario like Random Walk or Predictable Pulse instead.
+1. Verify you're using a backend-evaluated scenario. Browser-only scenarios (Streaming Client, Grafana Live, Grafana API, Steps, Annotations, Node Graph, Flame Graph, Trace, and Raw Frames) return empty results when evaluated by the alerting engine. Use a backend scenario like Random Walk or Predictable Pulse instead.
 1. Confirm the scenario is returning time-series data. Scenarios that produce logs (Logs), traces (Trace), graphs (Node Graph, Flame Graph), or tables (Table Static) can't be used as alert conditions.
 1. Check that the **String Input** field isn't empty for scenarios that require it (for example, CSV Metric Values).
 

--- a/docs/sources/datasources/testdata/troubleshooting/index.md
+++ b/docs/sources/datasources/testdata/troubleshooting/index.md
@@ -53,11 +53,11 @@ These errors occur when running TestData scenarios.
 
 **Possible causes and solutions:**
 
-| Cause                                       | Solution                                                                                                                                             |
-| ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| No series query in the panel                | Exemplars returns only markers and no series of its own. Add a second query, such as Random Walk, for the exemplars to annotate.                     |
-| Series hidden in the legend                 | The legend filter matches on exemplar labels, so hiding a series in the legend also hides its markers. Show the series to restore the markers.       |
-| Markers fall outside the panel value range  | With **Min** and **Max** empty, the value range is derived from a reference random walk and markers can land off-panel. Set **Min** and **Max** explicitly, or align them with the sibling series. |
+| Cause                                      | Solution                                                                                                                                                                                           |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| No series query in the panel               | Exemplars returns only markers and no series of its own. Add a second query, such as Random Walk, for the exemplars to annotate.                                                                   |
+| Series hidden in the legend                | The legend filter matches on exemplar labels, so hiding a series in the legend also hides its markers. Show the series to restore the markers.                                                     |
+| Markers fall outside the panel value range | With **Min** and **Max** empty, the value range is derived from a reference random walk and markers can land off-panel. Set **Min** and **Max** explicitly, or align them with the sibling series. |
 
 ### Wrong data type for the visualization
 

--- a/docs/sources/datasources/testdata/troubleshooting/index.md
+++ b/docs/sources/datasources/testdata/troubleshooting/index.md
@@ -44,40 +44,20 @@ These errors occur when running TestData scenarios.
 | Empty String Input for CSV scenarios | CSV Metric Values and CSV Content require input data. Add comma-separated values or CSV content.                               |
 | Time range doesn't contain data      | Some scenarios generate data relative to the query time range. Expand the dashboard time range.                                |
 
-### Unexpected error from Conditional Error
+### Exemplars don't appear
 
 **Symptoms:**
 
-- Query returns a server error or panic message.
-- Error appears immediately when running the query.
+- The Exemplars scenario runs without error but no diamond markers appear on the panel.
+- Markers disappear when you interact with the legend.
 
-**Solutions:**
+**Possible causes and solutions:**
 
-1. The Conditional Error scenario triggers a server panic when the **String Input** field is empty. This is the intended behavior for error testing.
-1. To return data instead of an error, populate the **String Input** field with comma-separated values (for example, `1,20,90,30,5,0`).
-1. To change the error type, use the **Error type** drop-down to select between Server panic, Frontend exception, and Frontend observable.
-
-### Error with source returns an error
-
-The Error with source scenario intentionally returns errors for testing how Grafana handles different error sources. This isn't a misconfiguration.
-
-- **Plugin** error source simulates an error originating from the plugin itself.
-- **Downstream** error source simulates an error from a downstream service.
-
-Use this scenario to test alerting rules, error displays, and error handling in custom panels.
-
-### Slow Query appears stuck
-
-**Symptoms:**
-
-- Query runs for an extended period.
-- Panel shows a loading spinner indefinitely.
-
-**Solutions:**
-
-1. Check the **String Input** field, which controls the delay duration. The default is `5s`.
-1. Reduce the value to a shorter duration (for example, `1s` or `500ms`).
-1. The field accepts Go duration syntax: `5s` (seconds), `1m` (minutes), `500ms` (milliseconds).
+| Cause                                       | Solution                                                                                                                                             |
+| ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| No series query in the panel                | Exemplars returns only markers and no series of its own. Add a second query, such as Random Walk, for the exemplars to annotate.                     |
+| Series hidden in the legend                 | The legend filter matches on exemplar labels, so hiding a series in the legend also hides its markers. Show the series to restore the markers.       |
+| Markers fall outside the panel value range  | With **Min** and **Max** empty, the value range is derived from a reference random walk and markers can land off-panel. Set **Min** and **Max** explicitly, or align them with the sibling series. |
 
 ### Wrong data type for the visualization
 
@@ -104,6 +84,51 @@ Use this scenario to test alerting rules, error displays, and error handling in 
 1. Predictable Pulse aligns timestamps to the step interval based on absolute time from the epoch, not from the start of the time range. This means the pattern starts at the same point regardless of when you load the dashboard.
 1. Verify the cycle duration matches your intent: the full cycle is `Step * (On Count + Off Count)` seconds.
 1. Check that **On Value** and **Off Value** are set correctly. The defaults are `2` and `1`, not `1` and `0`.
+
+### Slow Query appears stuck
+
+**Symptoms:**
+
+- Query runs for an extended period.
+- Panel shows a loading spinner indefinitely.
+
+**Solutions:**
+
+1. Check the **String Input** field, which controls the delay duration. The default is `5s`.
+1. Reduce the value to a shorter duration (for example, `1s` or `500ms`).
+1. The field accepts Go duration syntax: `5s` (seconds), `1m` (minutes), `500ms` (milliseconds).
+
+### Unexpected error from Conditional Error
+
+**Symptoms:**
+
+- Query returns a server error or panic message.
+- Error appears immediately when running the query.
+
+**Solutions:**
+
+1. The Conditional Error scenario triggers a server panic when the **String Input** field is empty. This is the intended behavior for error testing.
+1. To return data instead of an error, populate the **String Input** field with comma-separated values (for example, `1,20,90,30,5,0`).
+1. To change the error type, use the **Error type** drop-down to select between Server panic, Frontend exception, and Frontend observable.
+
+### Error with source returns an error
+
+The Error with source scenario intentionally returns errors for testing how Grafana handles different error sources. This isn't a misconfiguration.
+
+- **Plugin** error source simulates an error originating from the plugin itself.
+- **Downstream** error source simulates an error from a downstream service.
+
+Use this scenario to test alerting rules, error displays, and error handling in custom panels.
+
+### Flaky Query returns errors intermittently
+
+The Flaky Query scenario returns errors for a configurable percentage of requests. Intermittent errors are the intended behavior, not a misconfiguration.
+
+**Solutions:**
+
+1. Adjust the **Error rate** field to control how often requests fail. Set it to `0` for no errors or `100` to fail every request.
+1. Use the **Status code** and **Error source** fields to shape the returned error.
+1. If you're using Flaky Query with an alert rule, be aware that intermittent failures can flip the rule between states across evaluations. For alerting behavior, refer to [TestData alerting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/testdata/alerting/).
 
 ## CSV and data input errors
 


### PR DESCRIPTION
Quarterly documentation update (FY27 Q3) for the TestData data source. Refreshes all pages for accuracy, adds a new annotations page, and reconciles the scenario reference against the plugin source code. All content was cross-referenced against the Go backend and TypeScript frontend for accuracy.
## Changes
**_index.md:**
Rewrote the intro to be more engaging and to state that TestData is bundled with Grafana, corrected the scenario count from 30 to 33, added a link to the new annotations page in "Get started", refreshed review_date
**configure/index.md:**
Corrected the scenario count from 30 to 33, removed a product possessive to satisfy Vale, refreshed review_date
**query-editor/index.md:**
Corrected the scenario count from 30 to 33, documented three new scenarios (Exemplars, Flaky Query, Errors and notices) in the reference table and as full subsections, corrected the browser-only admonition (removed No Data Points, added the scenarios that actually run in the browser), fixed a broken in-page anchor and scenario-name inconsistency for Data Points Outside Range, cross-linked the Annotations scenario to the new annotations page, refreshed review_date
**alerting/index.md:**
Added Flaky Query to the alerting scenario table and a new "Intermittent errors" subsection, converted em-dash list intros to colon style, refreshed review_date
**template-variables/index.md:**
Refreshed review_date (content verified accurate)
**troubleshooting/index.md:**
Added troubleshooting entries for Exemplars ("don't appear") and Flaky Query, reordered the "Query errors" section into a clearer flow (missing/wrong output, then behavior/performance, then intentional-error scenarios), corrected the browser-only scenario list in the alerting section, refreshed review_date
**annotations/index.md (new):**
Overview of TestData's annotation support, steps to add a dashboard annotation query, using the Annotations scenario in a panel, a worked example overlaying annotations on a time series panel with a density-testing tip, and limitations
**Technical accuracy verified against:**
- `pkg/tsdb/grafana-testdata-datasource/scenarios.go` (scenario registry: 33 scenarios, names, new Exemplars/Flaky Query/Errors and notices)
- `public/app/plugins/datasource/grafana-testdata-datasource/datasource.ts` (query routing: browser-only vs backend scenarios, native annotation support)
- `public/app/plugins/datasource/grafana-testdata-datasource/components/FlakyQueryEditor.tsx` (Flaky Query fields)
- `public/app/plugins/datasource/grafana-testdata-datasource/plugin.json` (supported features, grafanaDependency, plugin ID)
A couple of notes:



**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
