### PR TITLE
Notebooks: Added sharing button at top / toolbar

### DIFF
--- a/public/app/features/notebook/pages/NotebookScenePage.tsx
+++ b/public/app/features/notebook/pages/NotebookScenePage.tsx
@@ -14,6 +14,8 @@ import { type DashboardControls } from 'app/features/dashboard-scene/scene/Dashb
 import { type DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
 import { DashboardRoutes } from 'app/types/dashboard';
 
+import { NotebookToolbar } from '../toolbar/NotebookToolbar';
+
 import { getNotebookScenePageStateManager } from './NotebookScenePageStateManager';
 
 // Fetch a notebook, wrap it into the scene envelope, hand it to the existing transformer
@@ -59,12 +61,12 @@ export function NotebookScenePage() {
   // A notebook with the time picker hidden has no time state to reflect in the URL, so skip URL
   // sync entirely (same as the public dashboard page).
   if (notebookScene.state.controls?.state.hideTimeControls) {
-    return <NotebookDocument scene={notebookScene} />;
+    return <NotebookDocument scene={notebookScene} uid={uid} />;
   }
 
   return (
     <UrlSyncContextProvider scene={notebookScene} updateUrlOnInit={true} createBrowserHistorySteps={true}>
-      <NotebookDocument scene={notebookScene} />
+      <NotebookDocument scene={notebookScene} uid={uid} />
     </UrlSyncContextProvider>
   );
 }
@@ -73,7 +75,7 @@ export function NotebookScenePage() {
 // Page instead of DashboardScene.Component — that keeps the dashboard toolbar, sidebar
 // and outline sidebar out. The scene is activated so panels still run their queries and
 // resolve the shared time range; the title stays via the page breadcrumb (pageNav).
-function NotebookDocument({ scene }: { scene: DashboardScene }) {
+function NotebookDocument({ scene, uid }: { scene: DashboardScene; uid?: string }) {
   const { body, controls, title } = scene.useState();
 
   useEffect(() => scene.activate(), [scene]);
@@ -83,6 +85,7 @@ function NotebookDocument({ scene }: { scene: DashboardScene }) {
 
   return (
     <Page navId="notebooks" pageNav={pageNav} layout={PageLayoutType.Custom}>
+      {uid && <NotebookToolbar uid={uid} />}
       {/* ScopesVariable (and other UNSAFE_renderAsHidden vars) must mount so query runners aren't blocked forever on dependsOnScopes — same as SoloPanelPage. */}
       {renderHiddenVariables(scene)}
       {controls && <NotebookControls controls={controls} />}

--- a/public/app/features/notebook/toolbar/NotebookToolbar.test.tsx
+++ b/public/app/features/notebook/toolbar/NotebookToolbar.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from 'test/test-utils';
+
+import { config } from '@grafana/runtime';
+
+import { NotebookToolbar } from './NotebookToolbar';
+
+describe('NotebookToolbar', () => {
+  const originalAppUrl = config.appUrl;
+  const originalIsSecureContext = window.isSecureContext;
+
+  beforeEach(() => {
+    // Outside a secure context ClipboardButton falls back to document.execCommand, which jsdom
+    // does not implement — the copy would fail silently and never reach the clipboard stub.
+    Object.assign(window, { isSecureContext: true });
+    config.appUrl = 'https://host/';
+  });
+
+  afterEach(() => {
+    Object.assign(window, { isSecureContext: originalIsSecureContext });
+    config.appUrl = originalAppUrl;
+  });
+
+  it('copies an absolute link to the notebook, not the in-app path', async () => {
+    const { user } = render(<NotebookToolbar uid="nb1" />);
+
+    await user.click(screen.getByRole('button', { name: 'Copy link' }));
+
+    // The origin is the point: a copied '/notebooks/nb1' would be useless pasted into an email.
+    // notebookShareUrl's sub-path and orgId handling is covered by urls.test.ts.
+    expect(await navigator.clipboard.readText()).toBe('https://host/notebooks/nb1');
+  });
+
+  it('confirms the copy, so the single click does not look like it did nothing', async () => {
+    const { user } = render(<NotebookToolbar uid="nb1" />);
+
+    await user.click(screen.getByRole('button', { name: 'Copy link' }));
+
+    expect(await screen.findByText('Copied')).toBeInTheDocument();
+  });
+});

--- a/public/app/features/notebook/toolbar/NotebookToolbar.test.tsx
+++ b/public/app/features/notebook/toolbar/NotebookToolbar.test.tsx
@@ -1,10 +1,12 @@
+import { createMemoryHistory } from 'history';
 import { render, screen } from 'test/test-utils';
 
-import { config } from '@grafana/runtime';
+import { HistoryWrapper, config, locationService, setLocationService } from '@grafana/runtime';
 
 import { NotebookToolbar } from './NotebookToolbar';
 
 describe('NotebookToolbar', () => {
+  const originalLocationService = locationService;
   const originalAppUrl = config.appUrl;
   const originalIsSecureContext = window.isSecureContext;
 
@@ -17,21 +19,40 @@ describe('NotebookToolbar', () => {
 
   afterEach(() => {
     Object.assign(window, { isSecureContext: originalIsSecureContext });
+    setLocationService(originalLocationService);
     config.appUrl = originalAppUrl;
   });
 
+  /**
+   * Renders, then installs a location service that carries an orgId, so the copied link has the
+   * shape it has in production.
+   *
+   * The order matters: the test wrapper builds its own HistoryWrapper and calls setLocationService
+   * while rendering, so anything installed beforehand is discarded. notebookShareUrl reads the
+   * service when the button is clicked, not at render, so setting it afterwards is enough.
+   */
+  function setup() {
+    const rendered = render(<NotebookToolbar uid="nb1" />);
+
+    const history = new HistoryWrapper(createMemoryHistory({ initialEntries: ['/'] }));
+    history.setOrgIdGetter(() => 3);
+    setLocationService(history);
+
+    return rendered;
+  }
+
   it('copies an absolute link to the notebook, not the in-app path', async () => {
-    const { user } = render(<NotebookToolbar uid="nb1" />);
+    const { user } = setup();
 
     await user.click(screen.getByRole('button', { name: 'Copy link' }));
 
-    // The origin is the point: a copied '/notebooks/nb1' would be useless pasted into an email.
-    // notebookShareUrl's sub-path and orgId handling is covered by urls.test.ts.
-    expect(await navigator.clipboard.readText()).toBe('https://host/notebooks/nb1');
+    // Both halves matter for a pasted link: the origin, or it is useless outside the app, and the
+    // orgId, or it opens whichever org the reader happens to be in.
+    expect(await navigator.clipboard.readText()).toBe('https://host/notebooks/nb1?orgId=3');
   });
 
   it('confirms the copy, so the single click does not look like it did nothing', async () => {
-    const { user } = render(<NotebookToolbar uid="nb1" />);
+    const { user } = setup();
 
     await user.click(screen.getByRole('button', { name: 'Copy link' }));
 

--- a/public/app/features/notebook/toolbar/NotebookToolbar.tsx
+++ b/public/app/features/notebook/toolbar/NotebookToolbar.tsx
@@ -1,0 +1,33 @@
+import { css } from '@emotion/css';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { ClipboardButton, useStyles2 } from '@grafana/ui';
+
+import { notebookShareUrl } from '../urls';
+
+/**
+ * The notebook view's header bar.
+ */
+export function NotebookToolbar({ uid }: { uid: string }) {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <div className={styles.toolbar}>
+      <ClipboardButton variant="secondary" size="sm" icon="link" getText={() => notebookShareUrl(uid)}>
+        {t('notebooks.view.copy-link', 'Copy link')}
+      </ClipboardButton>
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  toolbar: css({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    gap: theme.spacing(1),
+    padding: theme.spacing(1, 2),
+    borderBottom: `1px solid ${theme.colors.border.weak}`,
+  }),
+});

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12792,6 +12792,9 @@
         "updated": "Updated"
       },
       "unknown-author": "Anonymous"
+    },
+    "view": {
+      "copy-link": "Copy link"
     }
   },
   "notifications": {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds a header bar to the notebook view page, with a one-click **Copy link** button as its first action.

The button copies an absolute URL to the notebook — same behaviour, and the same `notebookShareUrl` helper, as the row action on the list page.

**Why do we need this feature?**

You can copy a link to a notebook from the list page, but not from inside the notebook you're actually reading. This also establishes the bar that the rest of the notebook actions (lock, assistant, export, overflow menu) will land in.

**Who is this feature for?**

Grafana users with dashboard access, once notebooks are enabled.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes grafana/grafana-enterprise#12995

**Special notes for your reviewer:**

- The share URL helper already existed from the list page work, so nothing was extracted or duplicated — both entry points call `notebookShareUrl`.
- The bar renders inside the page rather than via `AppChromeUpdate`. The chrome toolbar row is `background.primary` while a `PageLayoutType.Custom` page is `canvas`, so putting it in the chrome left a visible seam above the document. In-page it shares the document's background, which also matches the design.
- `ClipboardButton` handles the "Copied" confirmation itself, so there's no notification dispatch here.
<img width="204" height="105" alt="Screenshot 2026-08-11 at 4 32 14 PM" src="https://github.com/user-attachments/assets/6c73c5dd-cbb7-4d1c-9940-3b0ab950fe9d" />
