### PR TITLE
Transformations: Include tags in PanelEditNext search

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/useTransformationSearchAndFilter.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/useTransformationSearchAndFilter.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
 
-import { standardTransformersRegistry, TransformerCategory } from '@grafana/data';
+import { DataTransformerID, standardTransformersRegistry, TransformerCategory } from '@grafana/data';
 import { getStandardTransformers } from 'app/features/transformers/standardTransformers';
 
 import { useTransformationSearchAndFilter } from './useTransformationSearchAndFilter';
@@ -63,6 +63,14 @@ describe('useTransformationSearchAndFilter', () => {
       act(() => result.current.setSearch('zzzznonexistent12345'));
 
       expect(result.current.filteredTransformations).toHaveLength(0);
+    });
+
+    it('finds transformations by tag', () => {
+      const { result } = renderHook(() => useTransformationSearchAndFilter(mockOnSelect));
+
+      act(() => result.current.setSearch('pivot'));
+
+      expect(result.current.filteredTransformations.map(({ id }) => id)).toContain(DataTransformerID.transpose);
     });
 
     it('clears filter when search is cleared', () => {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/useTransformationSearchAndFilter.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/useTransformationSearchAndFilter.ts
@@ -41,7 +41,10 @@ export function useTransformationSearchAndFilter(
     if (search) {
       const lower = search.toLowerCase();
       result = result.filter(
-        ({ name, description }) => name.toLowerCase().includes(lower) || description?.toLowerCase().includes(lower)
+        ({ name, description, tags }) =>
+          name.toLowerCase().includes(lower) ||
+          description?.toLowerCase().includes(lower) ||
+          Array.from(tags ?? []).some((tag) => tag.toLowerCase().includes(lower))
       );
     }
 


### PR DESCRIPTION
## Related Issue
Fixes #129966, Fixes DPRO-293

## Description
PanelEditNext transformation search only matched transformation names and descriptions, unlike the classic experience. Include transformation tags in the search so familiar terms such as "pivot" return the Transpose transformation.

## Changes
* Include transformation tags in PanelEditNext's case-insensitive transformation search.
* Add focused regression coverage proving a tag-only search for "pivot" returns Transpose.

## Risks
The change is limited to transformation picker filtering and preserves existing name, description, and category matching behavior.

## Demo
<img width="800" height="427" alt="CleanShot 2026-08-11 at 17 03 22" src="https://github.com/user-attachments/assets/6ef179e1-9a05-4474-a57e-4041a312edd8" />

## Testing Instructions
1. Open a dashboard and edit a panel using the new panel edit experience.
2. Open the **Transformations** section and select **Add transformation**.
3. Enter `pivot` in the transformation search.
4. Verify that **Transpose** appears in the results.
5. Clear the search, enter `organize`, and verify that existing name-based search still returns **Organize fields by name**.
6. Select **Transpose** and verify that the transformation is added successfully.

## Reviewer Checklist
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable