### PR TITLE
fix(home): fall back to unified HomePage when prefs probe fails

### DIFF
--- a/public/app/features/home/HomeRoute.test.tsx
+++ b/public/app/features/home/HomeRoute.test.tsx
@@ -2,6 +2,7 @@ import { http, HttpResponse } from 'msw';
 import { type ComponentProps } from 'react';
 import { render, screen, waitFor } from 'test/test-utils';
 
+import { useMergedPreferencesQuery } from '@grafana/api-clients/rtkq/preferences/v1';
 import { locationService, setBackendSrv, setPluginComponentsHook } from '@grafana/runtime';
 import { MERGED_PREFS_URL } from '@grafana/test-utils/handlers';
 import server, { setupMockServer } from '@grafana/test-utils/server';
@@ -28,10 +29,23 @@ jest.mock('./analytics/main', () => ({
 
 jest.mock('app/plugins/panel/news/useNewsFeed');
 
+// Call through by default so MSW-backed tests keep working; override only for the
+// cached-data-after-error case that is hard to reproduce via the network layer.
+jest.mock('@grafana/api-clients/rtkq/preferences/v1', () => {
+  const actual = jest.requireActual('@grafana/api-clients/rtkq/preferences/v1');
+  return {
+    ...actual,
+    useMergedPreferencesQuery: jest.fn(actual.useMergedPreferencesQuery),
+  };
+});
+
 setBackendSrv(backendSrv);
 setupMockServer();
 
 const useNewsFeedMock = jest.mocked(useNewsFeed);
+const useMergedPreferencesQueryMock = jest.mocked(useMergedPreferencesQuery);
+const actualUseMergedPreferencesQuery = jest.requireActual('@grafana/api-clients/rtkq/preferences/v1')
+  .useMergedPreferencesQuery as typeof useMergedPreferencesQuery;
 
 describe('HomeRoute', () => {
   let probeCallCount = 0;
@@ -47,6 +61,7 @@ describe('HomeRoute', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    useMergedPreferencesQueryMock.mockImplementation(actualUseMergedPreferencesQuery);
     probeCallCount = 0;
     setPluginComponentsHook(() => ({ components: [], isLoading: false }));
     useNewsFeedMock.mockReturnValue({
@@ -118,6 +133,20 @@ describe('HomeRoute', () => {
 
     expect(await screen.findByText(/Welcome to Grafana/i)).toBeInTheDocument();
     expect(jest.mocked(homepageViewed)).toHaveBeenCalledTimes(1);
+  });
+
+  it('prefs error with cached homeDashboardUID → still renders dashboard proxy', async () => {
+    // Simulate RTK Query keeping previous data after a failed refetch.
+    useMergedPreferencesQueryMock.mockReturnValue({
+      data: { metadata: {}, spec: { homeDashboardUID: 'abc' } },
+      isLoading: false,
+      isError: true,
+    } as ReturnType<typeof useMergedPreferencesQuery>);
+
+    render(<HomeRoute {...props} />);
+
+    expect(await screen.findByTestId('dashboard-page-proxy-stub')).toBeInTheDocument();
+    expect(jest.mocked(homepageViewed)).not.toHaveBeenCalled();
   });
 
   it('homeURL present → calls locationService.replace', async () => {

--- a/public/app/features/home/HomeRoute.test.tsx
+++ b/public/app/features/home/HomeRoute.test.tsx
@@ -107,7 +107,7 @@ describe('HomeRoute', () => {
     expect(jest.mocked(homepageViewed)).not.toHaveBeenCalled();
   });
 
-  it('merged endpoint returns 500 → renders dashboard proxy', async () => {
+  it('merged endpoint returns 500 → renders HomePage', async () => {
     server.use(
       http.get(MERGED_PREFS_URL, () => {
         return HttpResponse.json({ message: 'boom' }, { status: 500 });
@@ -116,8 +116,8 @@ describe('HomeRoute', () => {
 
     render(<HomeRoute {...props} />);
 
-    expect(await screen.findByTestId('dashboard-page-proxy-stub')).toBeInTheDocument();
-    expect(jest.mocked(homepageViewed)).not.toHaveBeenCalled();
+    expect(await screen.findByText(/Welcome to Grafana/i)).toBeInTheDocument();
+    expect(jest.mocked(homepageViewed)).toHaveBeenCalledTimes(1);
   });
 
   it('homeURL present → calls locationService.replace', async () => {

--- a/public/app/features/home/HomeRoute.test.tsx
+++ b/public/app/features/home/HomeRoute.test.tsx
@@ -141,7 +141,8 @@ describe('HomeRoute', () => {
       data: { metadata: {}, spec: { homeDashboardUID: 'abc' } },
       isLoading: false,
       isError: true,
-    } as ReturnType<typeof useMergedPreferencesQuery>);
+      refetch: jest.fn(),
+    } as unknown as ReturnType<typeof useMergedPreferencesQuery>);
 
     render(<HomeRoute {...props} />);
 

--- a/public/app/features/home/HomeRoute.tsx
+++ b/public/app/features/home/HomeRoute.tsx
@@ -40,7 +40,6 @@ function HomeRouteInner(props: DashboardPageProxyProps) {
   }
 
   // Empty/absent UID, or prefs probe failed with no UID available → unified homepage
-  // (bundled home.json is no longer the default).
   return <HomePage />;
 }
 

--- a/public/app/features/home/HomeRoute.tsx
+++ b/public/app/features/home/HomeRoute.tsx
@@ -34,9 +34,9 @@ function HomeRouteInner(props: DashboardPageProxyProps) {
   }
 
   // Probe failed: we cannot tell whether a home dashboard is configured.
-  // Fall back to the dashboard proxy so existing on-prem setups still work.
+  // Fall back to the unified homepage (bundled home.json is no longer the default).
   if (isError || !data) {
-    return <DashboardPageProxy {...props} />;
+    return <HomePage />;
   }
 
   if (homeDashboardUID) {

--- a/public/app/features/home/HomeRoute.tsx
+++ b/public/app/features/home/HomeRoute.tsx
@@ -14,7 +14,7 @@ const DashboardPageProxy = lazy(
 const HomePage = lazy(() => import(/* webpackChunkName: "HomePage" */ './HomePage'));
 
 function HomeRouteInner(props: DashboardPageProxyProps) {
-  const { data, isLoading, isError } = useMergedPreferencesQuery();
+  const { data, isLoading } = useMergedPreferencesQuery();
   const redirectUri = data?.spec?.homeURL;
   const homeDashboardUID = data?.spec?.homeDashboardUID;
   // homeDashboardUID takes precedence over homeURL
@@ -33,16 +33,14 @@ function HomeRouteInner(props: DashboardPageProxyProps) {
     return <PageLoader />;
   }
 
-  // Probe failed: we cannot tell whether a home dashboard is configured.
-  // Fall back to the unified homepage (bundled home.json is no longer the default).
-  if (isError || !data) {
-    return <HomePage />;
-  }
-
+  // Prefer a known home dashboard UID (including cached data after a failed refetch)
+  // over the error fallback so a transient prefs failure does not replace a configured home.
   if (homeDashboardUID) {
     return <DashboardPageProxy {...props} />;
   }
 
+  // Empty/absent UID, or prefs probe failed with no UID available → unified homepage
+  // (bundled home.json is no longer the default).
   return <HomePage />;
 }
 


### PR DESCRIPTION
## Summary
- When the merged preferences probe fails, render the unified `HomePage` instead of `DashboardPageProxy`.
- Prefer a known/cached `homeDashboardUID` over the error fallback so a transient prefs refetch failure does not replace a configured home dashboard.
- Unblocks safe removal of bundled `home.json` / welcome+gettingstarted panels (#130273).

## Stack
1. **This PR** → `main`
2. Backend removal: #130538
3. Panel deletion: #130539

## Test plan
- [x] `yarn jest public/app/features/home/HomeRoute.test.tsx --watchAll=false`
- [x] Prefs 500 with no cached UID lands on unified homepage
- [x] Prefs error with cached `homeDashboardUID` still uses dashboard proxy
- [x] `homeDashboardUID` / `default-home-dashboard` still use dashboard proxy

Part of #130273 (1/3)