### PR TITLE
ApiKeys: wire legacy database provider

### DIFF
--- a/pkg/server/bootstrap/wire/wire_gen.go
+++ b/pkg/server/bootstrap/wire/wire_gen.go
@@ -408,7 +408,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts server.Options, apiO
 	if err != nil {
 		return nil, err
 	}
-	apikeyService, err := apikeyimpl.ProvideService(sqlStore, cfg, quotaService)
+	apikeyService, err := apikeyimpl.ProvideService(legacyDatabaseProvider, cfg, quotaService)
 	if err != nil {
 		return nil, err
 	}
@@ -1158,7 +1158,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	if err != nil {
 		return nil, err
 	}
-	apikeyService, err := apikeyimpl.ProvideService(sqlStore, cfg, quotaService)
+	apikeyService, err := apikeyimpl.ProvideService(legacyDatabaseProvider, cfg, quotaService)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/apikey/apikeyimpl/apikey.go
+++ b/pkg/services/apikey/apikeyimpl/apikey.go
@@ -3,19 +3,19 @@ package apikeyimpl
 import (
 	"context"
 
-	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/apikey"
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
 )
 
 type Service struct {
 	store store
 }
 
-func ProvideService(db db.DB, cfg *setting.Cfg, quotaService quota.Service) (apikey.Service, error) {
+func ProvideService(sql legacysql.LegacyDatabaseProvider, cfg *setting.Cfg, quotaService quota.Service) (apikey.Service, error) {
 	s := &Service{
-		store: &sqlStore{db: db},
+		store: &sqlStore{sql: sql},
 	}
 	defaultLimits, err := readQuotaConfig(cfg)
 	if err != nil {

--- a/pkg/services/apikey/apikeyimpl/queries/count_api_keys.sql
+++ b/pkg/services/apikey/apikeyimpl/queries/count_api_keys.sql
@@ -1,0 +1,5 @@
+SELECT COUNT(*) AS count
+FROM {{ .Ident .APIKeyTable }}
+{{- if .OrgID }}
+WHERE org_id = {{ .Arg .OrgID }}
+{{- end }}

--- a/pkg/services/apikey/apikeyimpl/templates.go
+++ b/pkg/services/apikey/apikeyimpl/templates.go
@@ -1,0 +1,23 @@
+package apikeyimpl
+
+import (
+	"embed"
+	"fmt"
+	"text/template"
+)
+
+var (
+	//go:embed queries/*.sql
+	sqlTemplatesFS embed.FS
+
+	sqlTemplates = template.Must(template.New("sql").ParseFS(sqlTemplatesFS, "queries/*.sql"))
+)
+
+func mustTemplate(filename string) *template.Template {
+	if tmpl := sqlTemplates.Lookup(filename); tmpl != nil {
+		return tmpl
+	}
+	panic(fmt.Sprintf("template file not found: %s", filename))
+}
+
+var countAPIKeysTemplate = mustTemplate("count_api_keys.sql")

--- a/pkg/services/apikey/apikeyimpl/templates_test.go
+++ b/pkg/services/apikey/apikeyimpl/templates_test.go
@@ -1,0 +1,37 @@
+package apikeyimpl
+
+import (
+	"testing"
+	"text/template"
+
+	"github.com/grafana/grafana/pkg/storage/legacysql"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate/mocks"
+)
+
+func TestTemplates(t *testing.T) {
+	dbHelper := &legacysql.LegacyDatabaseHelper{
+		Table: func(name string) string {
+			return "test_schema." + name
+		},
+	}
+
+	countQuery := func(orgID int64) sqltemplate.SQLTemplate {
+		return &countAPIKeysQuery{
+			SQLTemplate: mocks.NewTestingSQLTemplate(),
+			APIKeyTable: dbHelper.Table("api_key"),
+			OrgID:       orgID,
+		}
+	}
+
+	mocks.CheckQuerySnapshots(t, mocks.TemplateTestSetup{
+		RootDir:        "testdata",
+		SQLTemplatesFS: sqlTemplatesFS,
+		Templates: map[*template.Template][]mocks.TemplateTestCase{
+			countAPIKeysTemplate: {
+				{Name: "global", Data: countQuery(0)},
+				{Name: "org", Data: countQuery(7)},
+			},
+		},
+	})
+}

--- a/pkg/services/apikey/apikeyimpl/testdata/mysql--count_api_keys-global.sql
+++ b/pkg/services/apikey/apikeyimpl/testdata/mysql--count_api_keys-global.sql
@@ -1,0 +1,2 @@
+SELECT COUNT(*) AS count
+FROM `test_schema`.`api_key`

--- a/pkg/services/apikey/apikeyimpl/testdata/mysql--count_api_keys-org.sql
+++ b/pkg/services/apikey/apikeyimpl/testdata/mysql--count_api_keys-org.sql
@@ -1,0 +1,3 @@
+SELECT COUNT(*) AS count
+FROM `test_schema`.`api_key`
+WHERE org_id = 7

--- a/pkg/services/apikey/apikeyimpl/testdata/postgres--count_api_keys-global.sql
+++ b/pkg/services/apikey/apikeyimpl/testdata/postgres--count_api_keys-global.sql
@@ -1,0 +1,2 @@
+SELECT COUNT(*) AS count
+FROM "test_schema"."api_key"

--- a/pkg/services/apikey/apikeyimpl/testdata/postgres--count_api_keys-org.sql
+++ b/pkg/services/apikey/apikeyimpl/testdata/postgres--count_api_keys-org.sql
@@ -1,0 +1,3 @@
+SELECT COUNT(*) AS count
+FROM "test_schema"."api_key"
+WHERE org_id = 7

--- a/pkg/services/apikey/apikeyimpl/testdata/sqlite--count_api_keys-global.sql
+++ b/pkg/services/apikey/apikeyimpl/testdata/sqlite--count_api_keys-global.sql
@@ -1,0 +1,2 @@
+SELECT COUNT(*) AS count
+FROM "test_schema"."api_key"

--- a/pkg/services/apikey/apikeyimpl/testdata/sqlite--count_api_keys-org.sql
+++ b/pkg/services/apikey/apikeyimpl/testdata/sqlite--count_api_keys-org.sql
@@ -1,0 +1,3 @@
+SELECT COUNT(*) AS count
+FROM "test_schema"."api_key"
+WHERE org_id = 7

--- a/pkg/services/apikey/apikeyimpl/xorm_store.go
+++ b/pkg/services/apikey/apikeyimpl/xorm_store.go
@@ -10,15 +10,11 @@ import (
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/storage/legacysql"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
 )
 
 type sqlStore struct {
 	sql legacysql.LegacyDatabaseProvider
-}
-
-// quoteTable resolves a table name and quotes it for use in raw SQL.
-func quoteTable(dbHelper *legacysql.LegacyDatabaseHelper, name string) string {
-	return dbHelper.DB.Quote(dbHelper.Table(name))
 }
 
 // timeNow makes it possible to test usage of time
@@ -145,6 +141,38 @@ func (ss *sqlStore) UpdateAPIKeyLastUsedDate(ctx context.Context, tokenID int64)
 	})
 }
 
+type countAPIKeysQuery struct {
+	sqltemplate.SQLTemplate
+	APIKeyTable string
+	OrgID       int64
+}
+
+func (q countAPIKeysQuery) Validate() error { return nil }
+
+func countAPIKeys(dbHelper *legacysql.LegacyDatabaseHelper, sess *sqlstore.DBSession, scope quota.Scope, orgID int64, u *quota.Map) error {
+	query := countAPIKeysQuery{
+		SQLTemplate: sqltemplate.New(dbHelper.DialectForDriver()),
+		APIKeyTable: dbHelper.Table("api_key"),
+		OrgID:       orgID,
+	}
+	rawSQL, err := sqltemplate.Execute(countAPIKeysTemplate, query)
+	if err != nil {
+		return err
+	}
+
+	r := struct{ Count int64 }{}
+	if _, err := sess.SQL(rawSQL, query.GetArgs()...).Get(&r); err != nil {
+		return err
+	}
+
+	tag, err := quota.NewTag(apikey.QuotaTargetSrv, apikey.QuotaTarget, scope)
+	if err != nil {
+		return err
+	}
+	u.Set(tag, r.Count)
+	return nil
+}
+
 func (ss *sqlStore) Count(ctx context.Context, scopeParams *quota.ScopeParameters) (*quota.Map, error) {
 	dbHelper, err := ss.sql(ctx)
 	if err != nil {
@@ -152,44 +180,14 @@ func (ss *sqlStore) Count(ctx context.Context, scopeParams *quota.ScopeParameter
 	}
 
 	u := &quota.Map{}
-	type result struct {
-		Count int64
-	}
-
-	r := result{}
-	if err := dbHelper.DB.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
-		rawSQL := "SELECT COUNT(*) AS count FROM " + quoteTable(dbHelper, "api_key")
-		if _, err := sess.SQL(rawSQL).Get(&r); err != nil {
+	err = dbHelper.DB.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
+		if err := countAPIKeys(dbHelper, sess, quota.GlobalScope, 0, u); err != nil {
 			return err
 		}
+		if scopeParams != nil && scopeParams.OrgID != 0 {
+			return countAPIKeys(dbHelper, sess, quota.OrgScope, scopeParams.OrgID, u)
+		}
 		return nil
-	}); err != nil {
-		return u, err
-	} else {
-		tag, err := quota.NewTag(apikey.QuotaTargetSrv, apikey.QuotaTarget, quota.GlobalScope)
-		if err != nil {
-			return nil, err
-		}
-		u.Set(tag, r.Count)
-	}
-
-	if scopeParams != nil && scopeParams.OrgID != 0 {
-		if err := dbHelper.DB.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
-			rawSQL := "SELECT COUNT(*) AS count FROM " + quoteTable(dbHelper, "api_key") + " WHERE org_id = ?"
-			if _, err := sess.SQL(rawSQL, scopeParams.OrgID).Get(&r); err != nil {
-				return err
-			}
-			return nil
-		}); err != nil {
-			return u, err
-		} else {
-			tag, err := quota.NewTag(apikey.QuotaTargetSrv, apikey.QuotaTarget, quota.OrgScope)
-			if err != nil {
-				return nil, err
-			}
-			u.Set(tag, r.Count)
-		}
-	}
-
-	return u, nil
+	})
+	return u, err
 }

--- a/pkg/services/apikey/apikeyimpl/xorm_store.go
+++ b/pkg/services/apikey/apikeyimpl/xorm_store.go
@@ -9,19 +9,31 @@ import (
 	"github.com/grafana/grafana/pkg/services/apikey"
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
 )
 
 type sqlStore struct {
-	db db.DB
+	sql legacysql.LegacyDatabaseProvider
+}
+
+// quoteTable resolves a table name and quotes it for use in raw SQL.
+func quoteTable(dbHelper *legacysql.LegacyDatabaseHelper, name string) string {
+	return dbHelper.DB.Quote(dbHelper.Table(name))
 }
 
 // timeNow makes it possible to test usage of time
 var timeNow = time.Now
 
 func (ss *sqlStore) GetAllAPIKeys(ctx context.Context, orgID int64) ([]*apikey.APIKey, error) {
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
+
 	result := make([]*apikey.APIKey, 0)
-	err := ss.db.WithDbSession(ctx, func(dbSession *db.Session) error {
-		sess := dbSession.Where("service_account_id IS NULL").Asc("name")
+	err = dbHelper.DB.WithDbSession(ctx, func(dbSession *db.Session) error {
+		sess := dbSession.Table(dbHelper.Table("api_key")).
+			Where("service_account_id IS NULL").Asc("name")
 		if orgID != -1 {
 			sess = sess.Where("org_id=?", orgID)
 		}
@@ -31,9 +43,14 @@ func (ss *sqlStore) GetAllAPIKeys(ctx context.Context, orgID int64) ([]*apikey.A
 }
 
 func (ss *sqlStore) AddAPIKey(ctx context.Context, cmd *apikey.AddCommand) (res *apikey.APIKey, err error) {
-	err = ss.db.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	err = dbHelper.DB.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
 		key := apikey.APIKey{OrgID: cmd.OrgID, Name: cmd.Name}
-		exists, _ := sess.Get(&key)
+		exists, _ := sess.Table(dbHelper.Table("api_key")).Get(&key)
 		if exists {
 			return apikey.ErrDuplicate
 		}
@@ -60,7 +77,7 @@ func (ss *sqlStore) AddAPIKey(ctx context.Context, cmd *apikey.AddCommand) (res 
 			IsRevoked:        &isRevoked,
 		}
 
-		if _, err := sess.Insert(&t); err != nil {
+		if _, err := sess.Table(dbHelper.Table("api_key")).Insert(&t); err != nil {
 			return fmt.Errorf("%s: %w", "failed to insert token", err)
 		}
 		res = &t
@@ -70,9 +87,15 @@ func (ss *sqlStore) AddAPIKey(ctx context.Context, cmd *apikey.AddCommand) (res 
 }
 
 func (ss *sqlStore) GetApiKeyByName(ctx context.Context, query *apikey.GetByNameQuery) (res *apikey.APIKey, err error) {
-	err = ss.db.WithDbSession(ctx, func(sess *db.Session) error {
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
 		var key apikey.APIKey
-		has, err := sess.Where("org_id=? AND name=?", query.OrgID, query.KeyName).Get(&key)
+		has, err := sess.Table(dbHelper.Table("api_key")).
+			Where("org_id=? AND name=?", query.OrgID, query.KeyName).Get(&key)
 
 		if err != nil {
 			return err
@@ -87,9 +110,15 @@ func (ss *sqlStore) GetApiKeyByName(ctx context.Context, query *apikey.GetByName
 }
 
 func (ss *sqlStore) GetAPIKeyByHash(ctx context.Context, hash string) (*apikey.APIKey, error) {
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
+
 	var key apikey.APIKey
-	err := ss.db.WithDbSession(ctx, func(sess *db.Session) error {
-		has, err := sess.Table("api_key").Where(fmt.Sprintf("%s = ?", ss.db.GetDialect().Quote("key")), hash).Get(&key)
+	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
+		has, err := sess.Table(dbHelper.Table("api_key")).
+			Where(fmt.Sprintf("%s = ?", dbHelper.DB.GetDialect().Quote("key")), hash).Get(&key)
 		if err != nil {
 			return err
 		} else if !has {
@@ -101,9 +130,14 @@ func (ss *sqlStore) GetAPIKeyByHash(ctx context.Context, hash string) (*apikey.A
 }
 
 func (ss *sqlStore) UpdateAPIKeyLastUsedDate(ctx context.Context, tokenID int64) error {
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return fmt.Errorf("get legacy DB: %w", err)
+	}
+
 	now := timeNow()
-	return ss.db.WithDbSession(ctx, func(sess *db.Session) error {
-		if _, err := sess.Table("api_key").ID(tokenID).Cols("last_used_at").Update(&apikey.APIKey{LastUsedAt: &now}); err != nil {
+	return dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
+		if _, err := sess.Table(dbHelper.Table("api_key")).ID(tokenID).Cols("last_used_at").Update(&apikey.APIKey{LastUsedAt: &now}); err != nil {
 			return err
 		}
 
@@ -112,14 +146,19 @@ func (ss *sqlStore) UpdateAPIKeyLastUsedDate(ctx context.Context, tokenID int64)
 }
 
 func (ss *sqlStore) Count(ctx context.Context, scopeParams *quota.ScopeParameters) (*quota.Map, error) {
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
+
 	u := &quota.Map{}
 	type result struct {
 		Count int64
 	}
 
 	r := result{}
-	if err := ss.db.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
-		rawSQL := "SELECT COUNT(*) AS count FROM api_key"
+	if err := dbHelper.DB.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
+		rawSQL := "SELECT COUNT(*) AS count FROM " + quoteTable(dbHelper, "api_key")
 		if _, err := sess.SQL(rawSQL).Get(&r); err != nil {
 			return err
 		}
@@ -135,8 +174,8 @@ func (ss *sqlStore) Count(ctx context.Context, scopeParams *quota.ScopeParameter
 	}
 
 	if scopeParams != nil && scopeParams.OrgID != 0 {
-		if err := ss.db.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
-			rawSQL := "SELECT COUNT(*) AS count FROM api_key WHERE org_id = ?"
+		if err := dbHelper.DB.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
+			rawSQL := "SELECT COUNT(*) AS count FROM " + quoteTable(dbHelper, "api_key") + " WHERE org_id = ?"
 			if _, err := sess.SQL(rawSQL, scopeParams.OrgID).Get(&r); err != nil {
 				return err
 			}

--- a/pkg/services/apikey/apikeyimpl/xorm_store_test.go
+++ b/pkg/services/apikey/apikeyimpl/xorm_store_test.go
@@ -1,16 +1,122 @@
 package apikeyimpl
 
 import (
+	"context"
+	"regexp"
+	"sync"
 	"testing"
 
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/infra/db/dbtest"
+	"github.com/grafana/grafana/pkg/services/quota"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/util/testutil"
+	"github.com/grafana/grafana/pkg/util/xorm"
+	"github.com/grafana/grafana/pkg/util/xorm/core"
 )
 
 func TestIntegrationXORMApiKeyDataAccess(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	testIntegrationApiKeyDataAccess(t, func(ss db.DB) store {
-		return &sqlStore{db: ss}
+		return &sqlStore{sql: legacysql.NewDatabaseProvider(ss)}
 	})
+}
+
+var registerAPIKeySQLMockXormDriverOnce sync.Once
+
+type apiKeySQLMockXormDriver struct{}
+
+func (apiKeySQLMockXormDriver) Parse(string, string) (*core.Uri, error) {
+	return &core.Uri{DbType: core.SQLITE}, nil
+}
+
+type sqlmockAPIKeyDB struct {
+	dbtest.FakeDB
+	engine *xorm.Engine
+}
+
+func (d *sqlmockAPIKeyDB) WithDbSession(_ context.Context, callback sqlstore.DBTransactionFunc) error {
+	return d.withSession(callback)
+}
+
+func (d *sqlmockAPIKeyDB) WithTransactionalDbSession(_ context.Context, callback sqlstore.DBTransactionFunc) error {
+	return d.withSession(callback)
+}
+
+func (d *sqlmockAPIKeyDB) withSession(callback sqlstore.DBTransactionFunc) error {
+	sess := &sqlstore.DBSession{Session: d.engine.NewSession()}
+	defer sess.Close()
+	return callback(sess)
+}
+
+func (d *sqlmockAPIKeyDB) GetDBType() core.DbType {
+	return core.SQLITE
+}
+
+func (d *sqlmockAPIKeyDB) GetDialect() migrator.Dialect {
+	return migrator.NewSQLite3Dialect()
+}
+
+func (d *sqlmockAPIKeyDB) Quote(value string) string {
+	return d.engine.Quote(value)
+}
+
+func TestStoreUsesProviderTables(t *testing.T) {
+	registerAPIKeySQLMockXormDriverOnce.Do(func() {
+		if core.QueryDriver("sqlmock") == nil {
+			core.RegisterDriver("sqlmock", apiKeySQLMockXormDriver{})
+		}
+	})
+
+	dsn := "apikeyimpl-store"
+	mockDB, mock, err := sqlmock.NewWithDSN(dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mockDB.Close() })
+
+	engine, err := xorm.NewEngine("sqlmock", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = engine.Close() })
+
+	legacyDB := &sqlmockAPIKeyDB{engine: engine}
+	type contextKey struct{}
+	ctx := context.WithValue(context.Background(), contextKey{}, "provider context")
+	calls := 0
+	provider := func(gotCtx context.Context) (*legacysql.LegacyDatabaseHelper, error) {
+		require.Equal(t, "provider context", gotCtx.Value(contextKey{}))
+		calls++
+		return &legacysql.LegacyDatabaseHelper{
+			DB: legacyDB,
+			Table: func(name string) string {
+				return "test_schema." + name
+			},
+		}, nil
+	}
+	store := &sqlStore{sql: provider}
+
+	mock.ExpectQuery(regexp.QuoteMeta("FROM `test_schema`.`api_key`")).
+		WithArgs("hash").
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(7)))
+	_, err = store.GetAPIKeyByHash(ctx, "hash")
+	require.NoError(t, err)
+
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE `test_schema`.`api_key` SET")).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	require.NoError(t, store.UpdateAPIKeyLastUsedDate(ctx, 7))
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) AS count FROM `test_schema`.`api_key`")).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(3)))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) AS count FROM `test_schema`.`api_key` WHERE org_id = ?")).
+		WithArgs(int64(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(2)))
+	_, err = store.Count(ctx, &quota.ScopeParameters{OrgID: 1})
+	require.NoError(t, err)
+
+	require.Equal(t, 3, calls)
+	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/pkg/services/apikey/apikeyimpl/xorm_store_test.go
+++ b/pkg/services/apikey/apikeyimpl/xorm_store_test.go
@@ -109,9 +109,11 @@ func TestStoreUsesProviderTables(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	require.NoError(t, store.UpdateAPIKeyLastUsedDate(ctx, 7))
 
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) AS count FROM `test_schema`.`api_key`")).
+	// The count template renders with sqltemplate's dialect quoting (double
+	// quotes on the sqlite-flavored mock), unlike the xorm-built queries above.
+	mock.ExpectQuery(regexp.QuoteMeta(`FROM "test_schema"."api_key"`)).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(3)))
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) AS count FROM `test_schema`.`api_key` WHERE org_id = ?")).
+	mock.ExpectQuery(regexp.QuoteMeta(`WHERE org_id = ?`)).
 		WithArgs(int64(1)).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(2)))
 	_, err = store.Count(ctx, &quota.ScopeParameters{OrgID: 1})

--- a/pkg/services/authn/clients/api_key.go
+++ b/pkg/services/authn/clients/api_key.go
@@ -156,12 +156,16 @@ func (s *APIKey) Priority() uint {
 }
 
 func (s *APIKey) Hook(ctx context.Context, identity *authn.Identity, r *authn.Request) error {
-	ctx, span := s.tracer.Start(ctx, "authn.apikey.Hook") //nolint:ineffassign,staticcheck
+	ctx, span := s.tracer.Start(ctx, "authn.apikey.Hook")
 	defer span.End()
 
 	if r.GetMeta(metaKeySkipLastUsed) != "" {
 		return nil
 	}
+
+	// Detach the write from the request deadline but keep context values, so
+	// stores that resolve their database from the context keep working.
+	updateCtx := context.WithoutCancel(ctx)
 
 	go func(keyID string, logger log.Logger) {
 		defer func() {
@@ -176,7 +180,7 @@ func (s *APIKey) Hook(ctx context.Context, identity *authn.Identity, r *authn.Re
 			return
 		}
 
-		if err := s.apiKeyService.UpdateAPIKeyLastUsedDate(context.Background(), id); err != nil {
+		if err := s.apiKeyService.UpdateAPIKeyLastUsedDate(updateCtx, id); err != nil {
 			logger.Warn("Failed to update last used date for api key", "id", keyID, "err", err)
 			return
 		}

--- a/pkg/services/authn/clients/api_key_test.go
+++ b/pkg/services/authn/clients/api_key_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -177,6 +178,57 @@ func TestAPIKey_Test(t *testing.T) {
 			assert.Equal(t, tt.expected, c.Test(context.Background(), tt.req))
 		})
 	}
+}
+
+type capturingAPIKeyService struct {
+	apikeytest.Service
+	calls chan context.Context
+}
+
+func (s *capturingAPIKeyService) UpdateAPIKeyLastUsedDate(ctx context.Context, tokenID int64) error {
+	s.calls <- ctx
+	return nil
+}
+
+func TestAPIKey_Hook(t *testing.T) {
+	type ctxKey struct{}
+
+	t.Run("last used update should survive request cancellation but keep context values", func(t *testing.T) {
+		service := &capturingAPIKeyService{calls: make(chan context.Context, 1)}
+		c := ProvideAPIKey(service, tracing.InitializeTracerForTest())
+
+		ctx, cancel := context.WithCancel(context.WithValue(context.Background(), ctxKey{}, "tenant"))
+		req := &authn.Request{}
+		req.SetMeta(metaKeyID, "7")
+
+		assert.NoError(t, c.Hook(ctx, &authn.Identity{}, req))
+		cancel() // the request ends before the detached write runs
+
+		select {
+		case got := <-service.calls:
+			assert.Equal(t, "tenant", got.Value(ctxKey{}))
+			assert.NoError(t, got.Err())
+		case <-time.After(time.Second):
+			t.Fatal("expected UpdateAPIKeyLastUsedDate to be called")
+		}
+	})
+
+	t.Run("should skip last used update when the skip meta is set", func(t *testing.T) {
+		service := &capturingAPIKeyService{calls: make(chan context.Context, 1)}
+		c := ProvideAPIKey(service, tracing.InitializeTracerForTest())
+
+		req := &authn.Request{}
+		req.SetMeta(metaKeyID, "7")
+		req.SetMeta(metaKeySkipLastUsed, "true")
+
+		assert.NoError(t, c.Hook(context.Background(), &authn.Identity{}, req))
+
+		select {
+		case <-service.calls:
+			t.Fatal("expected UpdateAPIKeyLastUsedDate not to be called")
+		default:
+		}
+	})
 }
 
 func genApiKey() (string, string) {

--- a/pkg/services/authn/clients/api_key_test.go
+++ b/pkg/services/authn/clients/api_key_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apiserver/pkg/endpoints/request"
 
 	claims "github.com/grafana/authlib/types"
 	"github.com/grafana/grafana/pkg/components/satokengen"
@@ -191,13 +192,11 @@ func (s *capturingAPIKeyService) UpdateAPIKeyLastUsedDate(ctx context.Context, t
 }
 
 func TestAPIKey_Hook(t *testing.T) {
-	type ctxKey struct{}
-
 	t.Run("last used update should survive request cancellation but keep context values", func(t *testing.T) {
 		service := &capturingAPIKeyService{calls: make(chan context.Context, 1)}
 		c := ProvideAPIKey(service, tracing.InitializeTracerForTest())
 
-		ctx, cancel := context.WithCancel(context.WithValue(context.Background(), ctxKey{}, "tenant"))
+		ctx, cancel := context.WithCancel(request.WithNamespace(context.Background(), "stacks-11"))
 		req := &authn.Request{}
 		req.SetMeta(metaKeyID, "7")
 
@@ -206,7 +205,9 @@ func TestAPIKey_Hook(t *testing.T) {
 
 		select {
 		case got := <-service.calls:
-			assert.Equal(t, "tenant", got.Value(ctxKey{}))
+			ns, ok := request.NamespaceFrom(got)
+			assert.True(t, ok)
+			assert.Equal(t, "stacks-11", ns)
 			assert.NoError(t, got.Err())
 		case <-time.After(time.Second):
 			t.Fatal("expected UpdateAPIKeyLastUsedDate to be called")

--- a/pkg/services/quota/quotaimpl/quota_test.go
+++ b/pkg/services/quota/quotaimpl/quota_test.go
@@ -499,7 +499,7 @@ func setupEnv(t *testing.T, sqlStore db.DB, cfg *setting.Cfg, b bus.Bus, quotaSe
 	cfgProvider, err := configprovider.ProvideService(cfg)
 	require.NoError(t, err)
 	tracer := tracing.InitializeTracerForTest()
-	_, err = apikeyimpl.ProvideService(sqlStore, cfg, quotaService)
+	_, err = apikeyimpl.ProvideService(legacysql.NewDatabaseProvider(sqlStore), cfg, quotaService)
 	require.NoError(t, err)
 	_, err = authimpl.ProvideUserAuthTokenService(t.Context(), legacysql.NewDatabaseProvider(sqlStore), nil, quotaService, fakes.NewFakeSecretsService(), cfgProvider, tracing.InitializeTracerForTest(), featuremgmt.WithFeatures())
 	require.NoError(t, err)

--- a/pkg/services/serviceaccounts/database/store_test.go
+++ b/pkg/services/serviceaccounts/database/store_test.go
@@ -246,7 +246,7 @@ func setupTestDatabase(t *testing.T) (db.DB, *ServiceAccountsStoreImpl) {
 	t.Helper()
 	db, cfg := db.InitTestDBWithCfg(t)
 	quotaService := quotatest.New(false, nil)
-	apiKeyService, err := apikeyimpl.ProvideService(db, cfg, quotaService)
+	apiKeyService, err := apikeyimpl.ProvideService(legacysql.NewDatabaseProvider(db), cfg, quotaService)
 	require.NoError(t, err)
 	kvStore := kvstore.ProvideService(db)
 	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(db), cfg, quotaService)

--- a/pkg/services/serviceaccounts/tests/common.go
+++ b/pkg/services/serviceaccounts/tests/common.go
@@ -92,7 +92,7 @@ func SetupApiKey(t *testing.T, store db.DB, cfg *setting.Cfg, testKey TestApiKey
 	}
 
 	quotaService := quotatest.New(false, nil)
-	apiKeyService, err := apikeyimpl.ProvideService(store, cfg, quotaService)
+	apiKeyService, err := apikeyimpl.ProvideService(legacysql.NewDatabaseProvider(store), cfg, quotaService)
 	require.NoError(t, err)
 	key, err := apiKeyService.AddAPIKey(context.Background(), addKeyCmd)
 	require.NoError(t, err)


### PR DESCRIPTION
## What changed

- `apikeyimpl.ProvideService` now accepts a `LegacyDatabaseProvider`. Each store operation resolves the database helper from its operation context and qualifies all XORM and raw SQL table accesses.
- `APIKey.Hook` detaches the async last-used write with `context.WithoutCancel` instead of `context.Background()`, so the write outlives the request deadline without losing the request's context values. New tests pin both the detachment and the value retention.
- The two raw `COUNT(*)` usage queries render through embedded SQL templates (`sqltemplate`), with per-dialect snapshot tests.
- Server wiring and fixed-database callers use `legacysql.NewDatabaseProvider`.

## Why

The API key service sits on the service account token validation path, which remains in the session-auth dependency graph. Its cached instance must resolve table names from each request context instead of retaining a database whose default schema was selected at construction.

The `Hook` change follows from the same requirement: a fire-and-forget write built on `context.Background()` would discard the very context the store now resolves its database from.

This prepares the store for the session-auth path; the fluent XORM queries are left as-is.