### PR TITLE
Docs: Clarify Parca plugin deprecation and support end date

### DIFF
--- a/docs/sources/datasources/parca/_index.md
+++ b/docs/sources/datasources/parca/_index.md
@@ -23,7 +23,7 @@ review_date: 2026-04-10
 
 # Parca data source
 
-{{< admonition type="caution" >}}
+{{< admonition type="warning" >}}
 This plugin is deprecated and will only receive critical security updates. Support will end on January 2, 2027.
 {{< /admonition >}}
 

--- a/docs/sources/datasources/parca/_index.md
+++ b/docs/sources/datasources/parca/_index.md
@@ -24,8 +24,7 @@ review_date: 2026-04-10
 # Parca data source
 
 {{< admonition type="caution" >}}
-Starting January 2, 2027, the Parca data source plugin is deprecated.
-It will no longer receive updates after that date.
+This plugin is deprecated and will only receive critical security updates. Support will end on January 2, 2027.
 {{< /admonition >}}
 
 Parca is a continuous profiling database for analysis of CPU and memory usage, down to the line number and throughout time. Grafana ships with built-in support for Parca, so you can add it as a data source and start querying your profiles in [Explore](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/explore/).

--- a/docs/sources/datasources/parca/configure/index.md
+++ b/docs/sources/datasources/parca/configure/index.md
@@ -22,7 +22,7 @@ review_date: 2026-04-10
 
 # Configure the Parca data source
 
-{{< admonition type="caution" >}}
+{{< admonition type="warning" >}}
 This plugin is deprecated and will only receive critical security updates. Support will end on January 2, 2027.
 {{< /admonition >}}
 

--- a/docs/sources/datasources/parca/configure/index.md
+++ b/docs/sources/datasources/parca/configure/index.md
@@ -23,8 +23,7 @@ review_date: 2026-04-10
 # Configure the Parca data source
 
 {{< admonition type="caution" >}}
-Starting January 2, 2027, the Parca data source plugin is deprecated.
-It will no longer receive updates after that date.
+This plugin is deprecated and will only receive critical security updates. Support will end on January 2, 2027.
 {{< /admonition >}}
 
 This document explains how to configure the Parca data source in Grafana.

--- a/docs/sources/datasources/parca/query-editor/index.md
+++ b/docs/sources/datasources/parca/query-editor/index.md
@@ -21,8 +21,7 @@ review_date: 2026-04-10
 # Parca query editor
 
 {{< admonition type="caution" >}}
-Starting January 2, 2027, the Parca data source plugin is deprecated.
-It will no longer receive updates after that date.
+This plugin is deprecated and will only receive critical security updates. Support will end on January 2, 2027.
 {{< /admonition >}}
 
 This document explains how to use the Parca query editor to query and visualize continuous profiling data.

--- a/docs/sources/datasources/parca/query-editor/index.md
+++ b/docs/sources/datasources/parca/query-editor/index.md
@@ -20,7 +20,7 @@ review_date: 2026-04-10
 
 # Parca query editor
 
-{{< admonition type="caution" >}}
+{{< admonition type="warning" >}}
 This plugin is deprecated and will only receive critical security updates. Support will end on January 2, 2027.
 {{< /admonition >}}
 

--- a/docs/sources/datasources/parca/template-variables/index.md
+++ b/docs/sources/datasources/parca/template-variables/index.md
@@ -21,8 +21,7 @@ review_date: 2026-04-10
 # Parca template variables
 
 {{< admonition type="caution" >}}
-Starting January 2, 2027, the Parca data source plugin is deprecated.
-It will no longer receive updates after that date.
+This plugin is deprecated and will only receive critical security updates. Support will end on January 2, 2027.
 {{< /admonition >}}
 
 Instead of hard-coding label values in your profiling queries, you can use template variables to create dynamic, reusable dashboards. Variables appear as drop-down menus at the top of the dashboard, making it easy to switch between services, instances, or environments without editing queries.

--- a/docs/sources/datasources/parca/template-variables/index.md
+++ b/docs/sources/datasources/parca/template-variables/index.md
@@ -20,7 +20,7 @@ review_date: 2026-04-10
 
 # Parca template variables
 
-{{< admonition type="caution" >}}
+{{< admonition type="warning" >}}
 This plugin is deprecated and will only receive critical security updates. Support will end on January 2, 2027.
 {{< /admonition >}}
 

--- a/docs/sources/datasources/parca/troubleshooting/index.md
+++ b/docs/sources/datasources/parca/troubleshooting/index.md
@@ -20,8 +20,7 @@ review_date: 2026-04-10
 # Troubleshoot Parca data source issues
 
 {{< admonition type="caution" >}}
-Starting January 2, 2027, the Parca data source plugin is deprecated.
-It will no longer receive updates after that date.
+This plugin is deprecated and will only receive critical security updates. Support will end on January 2, 2027.
 {{< /admonition >}}
 
 This page provides solutions to common issues you might encounter when configuring or using the Parca data source. For configuration instructions, refer to [Configure the Parca data source](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/parca/configure/).

--- a/docs/sources/datasources/parca/troubleshooting/index.md
+++ b/docs/sources/datasources/parca/troubleshooting/index.md
@@ -19,7 +19,7 @@ review_date: 2026-04-10
 
 # Troubleshoot Parca data source issues
 
-{{< admonition type="caution" >}}
+{{< admonition type="warning" >}}
 This plugin is deprecated and will only receive critical security updates. Support will end on January 2, 2027.
 {{< /admonition >}}
 


### PR DESCRIPTION
**What is this feature?**

Change the caution notice to state that the plugin is deprecated now, receives only critical security updates, and support ends January 2, 2027.


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
