### PR TITLE
Transformations: Respect dateFormat when converting string fields to time

### DIFF
--- a/packages/grafana-data/src/datetime/parser.test.ts
+++ b/packages/grafana-data/src/datetime/parser.test.ts
@@ -60,5 +60,28 @@ describe('dateTimeParse', () => {
       expect(result.valueOf().toString()).not.toBe('NaN');
       expect(result.valueOf()).toBe(1772496000000);
     });
+
+    it('should still recover when a caller passes an unrelated format', () => {
+      // TimePickerWithHistory parses stored epoch ms values with an explicit fullDate format.
+      const result = dateTimeParse(EPOCH_MS, { timeZone: 'utc', format: 'YYYY-MM-DD HH:mm:ss' });
+      expect(result.valueOf()).toBe(1772496000000);
+    });
+  });
+
+  describe('all-digit values with a digit-based format (issue #130484)', () => {
+    it('should parse Unix seconds with the X format rather than as epoch ms', () => {
+      const result = dateTimeParse('1728397800', { timeZone: 'utc', format: 'X' });
+      expect(result.valueOf()).toBe(1728397800000);
+    });
+
+    it('should parse Unix milliseconds with the x format', () => {
+      const result = dateTimeParse('1728397800000', { timeZone: 'utc', format: 'x' });
+      expect(result.valueOf()).toBe(1728397800000);
+    });
+
+    it('should parse compact dates with the YYYYMMDD format', () => {
+      const result = dateTimeParse('20241008', { timeZone: 'utc', format: 'YYYYMMDD' });
+      expect(result.toISOString()).toBe('2024-10-08T00:00:00.000Z');
+    });
   });
 });

--- a/packages/grafana-data/src/datetime/parser.ts
+++ b/packages/grafana-data/src/datetime/parser.ts
@@ -62,14 +62,6 @@ const parseString = (value: string, options?: DateTimeOptionsWhenParsing): DateT
     return parsed || dateTime();
   }
 
-  // Epoch millisecond strings (e.g. "1704067200000" from URL params like ?from=1704067200000)
-  // must not be parsed through the date format — moment("1704067200000", "YYYY-MM-DD HH:mm:ss")
-  // produces an invalid DateTime whose valueOf() === NaN, which propagates to $__from/$__to
-  // scoped variables and causes literal "NaN" to appear in SQL queries (issue #119445).
-  if (/^\d+$/.test(value)) {
-    return parseOthers(parseInt(value, 10), options);
-  }
-
   let timeZone = getTimeZone(options);
   let format = options?.format ?? systemDateFormats.fullDate;
   if (value.endsWith('Z')) {
@@ -80,6 +72,21 @@ const parseString = (value: string, options?: DateTimeOptionsWhenParsing): DateT
     timeZone = 'utc';
   }
 
+  const parsed = parseWithFormat(value, format, timeZone);
+
+  // An all-digit string that the format could not parse is an epoch millisecond value, e.g.
+  // "1704067200000" from a URL param like ?from=1704067200000 checked against the default
+  // "YYYY-MM-DD HH:mm:ss". Without this fallback moment returns an invalid DateTime whose
+  // valueOf() is NaN, which reaches $__from/$__to and emits a literal "NaN" in SQL (#119445).
+  // Formats that legitimately parse digits (X, x, YYYYMMDD) parse above and are left alone.
+  if (!parsed.isValid() && /^\d+$/.test(value)) {
+    return parseOthers(parseInt(value, 10), options);
+  }
+
+  return parsed;
+};
+
+const parseWithFormat = (value: string, format: string, timeZone: string): DateTime => {
   const zone = moment.tz.zone(timeZone);
 
   if (zone && zone.name) {

--- a/packages/grafana-data/src/transformations/transformers/convertFieldType.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/convertFieldType.test.ts
@@ -616,4 +616,52 @@ describe('fieldToTimeField', () => {
       values: [1728397800000, 1728397815000, 1728397830000],
     });
   });
+
+  it('should properly parse string Unix timestamps - in seconds', () => {
+    const stringTimeField: Field = {
+      config: {},
+      name: 'Unix second timestamps as strings',
+      type: FieldType.string,
+      values: ['1728397800', '1728397815', '1728397830'],
+    };
+
+    expect(fieldToTimeField(stringTimeField, 'X')).toEqual({
+      config: {},
+      name: 'Unix second timestamps as strings',
+      type: FieldType.time,
+      values: [1728397800000, 1728397815000, 1728397830000],
+    });
+  });
+
+  it('should properly parse string Unix timestamps - in milliseconds', () => {
+    const stringTimeField: Field = {
+      config: {},
+      name: 'Unix MS timestamps as strings',
+      type: FieldType.string,
+      values: ['1728397800000', '1728397815000', '1728397830000'],
+    };
+
+    expect(fieldToTimeField(stringTimeField, 'x')).toEqual({
+      config: {},
+      name: 'Unix MS timestamps as strings',
+      type: FieldType.time,
+      values: [1728397800000, 1728397815000, 1728397830000],
+    });
+  });
+
+  it('should honour an all-digit date format for string values', () => {
+    const stringTimeField: Field = {
+      config: {},
+      name: 'Compact dates',
+      type: FieldType.string,
+      values: ['20241008', '20241009'],
+    };
+
+    expect(fieldToTimeField(stringTimeField, 'YYYYMMDD')).toEqual({
+      config: {},
+      name: 'Compact dates',
+      type: FieldType.time,
+      values: [new Date(2024, 9, 8).valueOf(), new Date(2024, 9, 9).valueOf()],
+    });
+  });
 });


### PR DESCRIPTION
## Description

This PR fixes #130484. The `Convert field type` transformation ignored the `dateFormat` setting for string fields and read every all-digit string as epoch milliseconds. A string field set to `Time` with format `X` came out as January 1970.

The cause is the all-digit early return added to `parseString` in #122693. It runs before the format is read, so the format is dropped. This affects any digits-only format — `X`, `x`, `YYYYMMDD` — not just `X`.

Only `main` (`13.2.0-pre`) has the guard, so no release is affected and no backport is needed.

## Changes

- `parser.ts`: try the configured format first, and fall back to epoch milliseconds only when that parse comes back invalid. Formats that really do parse digits now succeed instead of being skipped, and unparseable epoch-ms strings are still caught.
- Moved the timezone-aware parse into a `parseWithFormat` helper to keep `parseString` readable.
- Added tests for `X`, `x`, and `YYYYMMDD` string inputs in `parser.test.ts` and `convertFieldType.test.ts`. The one existing `'X'` test used a number field, which is the path that still worked — that is why this slipped through.

## Risks

Low. The change makes the epoch-ms fallback apply in fewer cases, not more, and both tests from #122693 pass unchanged.

The old and new code differ only when the format can actually parse an all-digit string:

- Short values like `"20240115"` now read as dates instead of epoch ms. That is the fix.
- If someone sets `date_formats.full_date = X`, a 13-digit epoch-ms value would read as seconds. `full_date` is a display format, so this is not a real setting.

The 10- and 13-digit values the time picker produces behave the same either way.

## Demo

A table panel over a TestData `Raw Frames` query with an explicit **string** field of Unix second timestamps, and one `Convert field type` transformation set to `Time` with input format `X`.

### Before

<!-- drop before.mp4 here -->

Every value collapses into January 1970, because the string is read as epoch milliseconds and the `X` format is discarded.

### After

<!-- drop after.mp4 here -->

The same panel resolves to the correct timestamps.

| Input | Format | Before | After |
| --- | --- | --- | --- |
| `"1700000000"` | `X` | `1970-01-20` | `2023-11-14` |
| `"20240115"` | `YYYYMMDD` | `1970-01-01` | `2024-01-15` |

See the diffs in https://app.meticulous.ai/projects/grafana/grafana/test-runs/pbcGKDW8gCMj6F6wCpgRMjFdLD for examples.

## Testing Instructions

- Add a panel with a query returning a string field of Unix seconds, e.g. `"1700000000"` (TestData `CSV Content` works).
- Add a `Convert field type` transformation, set the destination type to `Time` and the date format to `X`.
- Check the timestamps land in 2023, not 1970.
- Repeat with `YYYYMMDD` and values like `20241008`.
- Check #119445 still works: pick an absolute time range so the URL has `?from=<epoch ms>`, and confirm a SQL datasource gets a real timestamp instead of `NaN`.

### What I ran

- The four regression tests fail on `main` and pass here.
- `grafana-data` datetime and transformations suites: 698 passed, 51 suites.
- Full `tsc --noEmit`: 0 errors. ESLint and Prettier clean.
