### PR TITLE
Provisioning: Allow overriding the Git Sync commit author

### DIFF
--- a/apps/provisioning/kinds/repository.cue
+++ b/apps/provisioning/kinds/repository.cue
@@ -121,6 +121,12 @@ repository: {
 					// Supports variables: {{action}}, {{resourceKind}}, {{resourceID}}, {{title}}.
 					// When empty, a built-in default is used (e.g. "Save dashboard: <title>").
 					singleResourceMessageTemplate?: string
+					// Name used as the commit author instead of the user who triggered
+					// the commit. Only valid when signingMethod is unset.
+					authorName?: string
+					// Email used as the commit author instead of the user who triggered
+					// the commit. Only valid when signingMethod is unset.
+					authorEmail?: string
 					// Name used as the commit signer. Required for the signing key's
 					// identity to match the commit, which providers need to mark commits
 					// as Verified. When empty, defaults to "Grafana".

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/types.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/types.go
@@ -376,6 +376,15 @@ type CommitOptions struct {
 	// When true, the Comment field in Save drawers is pre-filled from
 	// SingleResourceMessageTemplate and rendered read-only.
 	EnforceTemplate bool `json:"enforceTemplate,omitempty"`
+
+	// Name used as the commit author instead of the user who triggered the
+	// commit. Only valid when signingMethod is unset.
+	AuthorName string `json:"authorName,omitempty"`
+
+	// Email used as the commit author instead of the user who triggered the
+	// commit. Only valid when signingMethod is unset.
+	AuthorEmail string `json:"authorEmail,omitempty"`
+
 	// Name used as the commit signer. Required for the signing key's identity
 	// to match the commit, which providers need to mark commits as Verified. When
 	// empty, defaults to "Grafana".

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
@@ -240,6 +240,20 @@ func schema_pkg_apis_provisioning_v0alpha1_CommitOptions(ref common.ReferenceCal
 							Format:      "",
 						},
 					},
+					"authorName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name used as the commit author instead of the user who triggered the commit. Only valid when signingMethod is unset.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"authorEmail": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Email used as the commit author instead of the user who triggered the commit. Only valid when signingMethod is unset.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"signerName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Name used as the commit signer. Required for the signing key's identity to match the commit, which providers need to mark commits as Verified. When empty, defaults to \"Grafana\".",

--- a/apps/provisioning/pkg/generated/applyconfiguration/provisioning/v0alpha1/commitoptions.go
+++ b/apps/provisioning/pkg/generated/applyconfiguration/provisioning/v0alpha1/commitoptions.go
@@ -21,6 +21,12 @@ type CommitOptionsApplyConfiguration struct {
 	// When true, the Comment field in Save drawers is pre-filled from
 	// SingleResourceMessageTemplate and rendered read-only.
 	EnforceTemplate *bool `json:"enforceTemplate,omitempty"`
+	// Name used as the commit author instead of the user who triggered the
+	// commit. Only valid when signingMethod is unset.
+	AuthorName *string `json:"authorName,omitempty"`
+	// Email used as the commit author instead of the user who triggered the
+	// commit. Only valid when signingMethod is unset.
+	AuthorEmail *string `json:"authorEmail,omitempty"`
 	// Name used as the commit signer. Required for the signing key's identity
 	// to match the commit, which providers need to mark commits as Verified. When
 	// empty, defaults to "Grafana".
@@ -60,6 +66,22 @@ func (b *CommitOptionsApplyConfiguration) WithSingleResourceMessageTemplate(valu
 // If called multiple times, the EnforceTemplate field is set to the value of the last call.
 func (b *CommitOptionsApplyConfiguration) WithEnforceTemplate(value bool) *CommitOptionsApplyConfiguration {
 	b.EnforceTemplate = &value
+	return b
+}
+
+// WithAuthorName sets the AuthorName field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the AuthorName field is set to the value of the last call.
+func (b *CommitOptionsApplyConfiguration) WithAuthorName(value string) *CommitOptionsApplyConfiguration {
+	b.AuthorName = &value
+	return b
+}
+
+// WithAuthorEmail sets the AuthorEmail field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the AuthorEmail field is set to the value of the last call.
+func (b *CommitOptionsApplyConfiguration) WithAuthorEmail(value string) *CommitOptionsApplyConfiguration {
+	b.AuthorEmail = &value
 	return b
 }
 

--- a/apps/provisioning/pkg/repository/git/repository.go
+++ b/apps/provisioning/pkg/repository/git/repository.go
@@ -965,7 +965,8 @@ func (r *gitRepository) ensureBranchExists(ctx context.Context, branchName strin
 }
 
 // createSignature creates author and committer signatures using the context signature if available,
-// falling back to default Grafana signature. The committer is overridden by
+// falling back to default Grafana signature. The author is overridden by
+// spec.commit.authorName/Email when set. The committer is overridden by
 // spec.commit.signerName/Email when set; that identity must match the signing
 // key for providers to mark commits as Verified. The author is overridden by
 // the signer identity when spec.commit.signerIsAuthor is true.
@@ -991,6 +992,11 @@ func (r *gitRepository) createSignature(ctx context.Context) (nanogit.Author, na
 
 	if author.Time.IsZero() {
 		author.Time = time.Now()
+	}
+
+	if commit := r.config.Spec.Commit; commit != nil && (commit.AuthorName != "" || commit.AuthorEmail != "") {
+		author.Name = cmp.Or(commit.AuthorName, "Grafana")
+		author.Email = cmp.Or(commit.AuthorEmail, "noreply@grafana.com")
 	}
 
 	committer := nanogit.Committer(author)

--- a/apps/provisioning/pkg/repository/git/repository_test.go
+++ b/apps/provisioning/pkg/repository/git/repository_test.go
@@ -2252,6 +2252,76 @@ func TestGitRepository_createSignature(t *testing.T) {
 		require.Equal(t, "Bot Signer", committer.Name)
 		require.Equal(t, "signer@example.com", committer.Email)
 	})
+
+	t.Run("should override author and committer from spec", func(t *testing.T) {
+		repo := &gitRepository{
+			config: &provisioning.Repository{
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitHubRepositoryType,
+					Commit: &provisioning.CommitOptions{
+						AuthorName:  "Sync Bot",
+						AuthorEmail: "bot@example.com",
+					},
+				},
+			},
+		}
+		ctx := repository.WithAuthorSignature(context.Background(), repository.CommitSignature{
+			Name:  "John Doe",
+			Email: "john@example.com",
+		})
+
+		author, committer := repo.createSignature(ctx)
+
+		require.Equal(t, "Sync Bot", author.Name)
+		require.Equal(t, "bot@example.com", author.Email)
+		require.Equal(t, "Sync Bot", committer.Name)
+		require.Equal(t, "bot@example.com", committer.Email)
+	})
+
+	t.Run("should default author name when only author email is overridden", func(t *testing.T) {
+		repo := &gitRepository{
+			config: &provisioning.Repository{
+				Spec: provisioning.RepositorySpec{
+					Type:   provisioning.GitHubRepositoryType,
+					Commit: &provisioning.CommitOptions{AuthorEmail: "bot@example.com"},
+				},
+			},
+		}
+		ctx := repository.WithAuthorSignature(context.Background(), repository.CommitSignature{
+			Name:  "John Doe",
+			Email: "john@example.com",
+		})
+
+		author, committer := repo.createSignature(ctx)
+
+		require.Equal(t, "Grafana", author.Name)
+		require.Equal(t, "bot@example.com", author.Email)
+		require.Equal(t, "Grafana", committer.Name)
+		require.Equal(t, "bot@example.com", committer.Email)
+	})
+
+	t.Run("should keep the signer as committer when the author is overridden", func(t *testing.T) {
+		repo := &gitRepository{
+			config: &provisioning.Repository{
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitHubRepositoryType,
+					Commit: &provisioning.CommitOptions{
+						AuthorName:  "Sync Bot",
+						AuthorEmail: "bot@example.com",
+						SignerName:  "Bot Signer",
+						SignerEmail: "signer@example.com",
+					},
+				},
+			},
+		}
+
+		author, committer := repo.createSignature(context.Background())
+
+		require.Equal(t, "Sync Bot", author.Name)
+		require.Equal(t, "bot@example.com", author.Email)
+		require.Equal(t, "Bot Signer", committer.Name)
+		require.Equal(t, "signer@example.com", committer.Email)
+	})
 }
 
 func TestNewGitRepository(t *testing.T) {

--- a/apps/provisioning/pkg/repository/validator.go
+++ b/apps/provisioning/pkg/repository/validator.go
@@ -101,6 +101,7 @@ func (v *RepositoryValidator) Validate(ctx context.Context, cfg *provisioning.Re
 	}
 
 	list = append(list, validateWorkflowOptions(cfg)...)
+	list = append(list, validateCommitOptions(cfg)...)
 
 	for _, w := range cfg.Spec.Workflows {
 		switch w {
@@ -223,6 +224,44 @@ func validateWorkflowOptions(cfg *provisioning.Repository) field.ErrorList {
 		}
 	default:
 		// Hosting providers (github, githubEnterprise, bitbucket, gitlab) support all options.
+	}
+
+	return list
+}
+
+// validateCommitOptions keeps the two ways of setting a commit identity apart: the
+// signer identity only applies to signed commits, and the author override only
+// applies when commits are not signed.
+func validateCommitOptions(cfg *provisioning.Repository) field.ErrorList {
+	commit := cfg.Spec.Commit
+	if commit == nil {
+		return nil
+	}
+
+	path := field.NewPath("spec", "commit")
+	var list field.ErrorList
+
+	if commit.SigningMethod == "" {
+		const detail = "signer identity requires a signing method; use authorName/authorEmail to set the commit author without signing"
+		if commit.SignerName != "" {
+			list = append(list, field.Invalid(path.Child("signerName"), commit.SignerName, detail))
+		}
+		if commit.SignerEmail != "" {
+			list = append(list, field.Invalid(path.Child("signerEmail"), commit.SignerEmail, detail))
+		}
+		if commit.SignerIsAuthor {
+			list = append(list, field.Invalid(path.Child("signerIsAuthor"), commit.SignerIsAuthor, detail))
+		}
+
+		return list
+	}
+
+	const detail = "author override is not allowed when commit signing is enabled; use signerName/signerEmail with signerIsAuthor instead"
+	if commit.AuthorName != "" {
+		list = append(list, field.Invalid(path.Child("authorName"), commit.AuthorName, detail))
+	}
+	if commit.AuthorEmail != "" {
+		list = append(list, field.Invalid(path.Child("authorEmail"), commit.AuthorEmail, detail))
 	}
 
 	return list

--- a/apps/provisioning/pkg/repository/validator_test.go
+++ b/apps/provisioning/pkg/repository/validator_test.go
@@ -1146,3 +1146,72 @@ func TestAdmissionValidator_ValidatorError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "duplicate repository")
 }
+
+func TestValidateCommitOptions(t *testing.T) {
+	tests := []struct {
+		name         string
+		commit       *provisioning.CommitOptions
+		expectedErrs []string
+	}{
+		{
+			name:   "no commit options",
+			commit: nil,
+		},
+		{
+			name:   "author override without signing",
+			commit: &provisioning.CommitOptions{AuthorName: "Sync Bot", AuthorEmail: "bot@example.com"},
+		},
+		{
+			name:   "signing without author override",
+			commit: &provisioning.CommitOptions{SigningMethod: provisioning.SSHSigningMethod, SignerName: "Bot Signer"},
+		},
+		{
+			name: "signer without a signing method",
+			commit: &provisioning.CommitOptions{
+				SignerName:     "Bot Signer",
+				SignerEmail:    "signer@example.com",
+				SignerIsAuthor: true,
+			},
+			expectedErrs: []string{"spec.commit.signerName", "spec.commit.signerEmail", "spec.commit.signerIsAuthor"},
+		},
+		{
+			name:         "signer as author without a signing method",
+			commit:       &provisioning.CommitOptions{SignerIsAuthor: true},
+			expectedErrs: []string{"spec.commit.signerIsAuthor"},
+		},
+		{
+			name: "author override with signing",
+			commit: &provisioning.CommitOptions{
+				AuthorName:    "Sync Bot",
+				AuthorEmail:   "bot@example.com",
+				SigningMethod: provisioning.SSHSigningMethod,
+			},
+			expectedErrs: []string{"spec.commit.authorName", "spec.commit.authorEmail"},
+		},
+		{
+			name: "author email override with signing",
+			commit: &provisioning.CommitOptions{
+				AuthorEmail:   "bot@example.com",
+				SigningMethod: provisioning.SSHSigningMethod,
+			},
+			expectedErrs: []string{"spec.commit.authorEmail"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := validateCommitOptions(&provisioning.Repository{
+				Spec: provisioning.RepositorySpec{
+					Title:  "Test Repo",
+					Type:   provisioning.GitHubRepositoryType,
+					Commit: tt.commit,
+				},
+			})
+
+			require.Len(t, errs, len(tt.expectedErrs))
+			for i, expected := range tt.expectedErrs {
+				assert.Equal(t, expected, errs[i].Field)
+			}
+		})
+	}
+}

--- a/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
@@ -1854,6 +1854,10 @@ export type BranchOptions = {
   nameTemplate?: string;
 };
 export type CommitOptions = {
+  /** Email used as the commit author instead of the user who triggered the commit. Only valid when signingMethod is unset. */
+  authorEmail?: string;
+  /** Name used as the commit author instead of the user who triggered the commit. Only valid when signingMethod is unset. */
+  authorName?: string;
   /** When true, the Comment field in Save drawers is pre-filled from SingleResourceMessageTemplate and rendered read-only. */
   enforceTemplate?: boolean;
   /** Email used as the commit signer. Must match the signing key's identity and a verified email on the account where the matching public key is registered. When empty, defaults to "noreply@grafana.com". */

--- a/packages/grafana-openapi/src/apis/provisioning.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/provisioning.grafana.app-v0alpha1.json
@@ -3755,6 +3755,14 @@
       "CommitOptions": {
         "type": "object",
         "properties": {
+          "authorEmail": {
+            "description": "Email used as the commit author instead of the user who triggered the commit. Only valid when signingMethod is unset.",
+            "type": "string"
+          },
+          "authorName": {
+            "description": "Name used as the commit author instead of the user who triggered the commit. Only valid when signingMethod is unset.",
+            "type": "string"
+          },
           "enforceTemplate": {
             "description": "When true, the Comment field in Save drawers is pre-filled from SingleResourceMessageTemplate and rendered read-only.",
             "type": "boolean"

--- a/packages/grafana-openapi/src/apis/provisioning.grafana.app-v1beta1.json
+++ b/packages/grafana-openapi/src/apis/provisioning.grafana.app-v1beta1.json
@@ -3755,6 +3755,14 @@
       "CommitOptions": {
         "type": "object",
         "properties": {
+          "authorEmail": {
+            "description": "Email used as the commit author instead of the user who triggered the commit. Only valid when signingMethod is unset.",
+            "type": "string"
+          },
+          "authorName": {
+            "description": "Name used as the commit author instead of the user who triggered the commit. Only valid when signingMethod is unset.",
+            "type": "string"
+          },
           "enforceTemplate": {
             "description": "When true, the Comment field in Save drawers is pre-filled from SingleResourceMessageTemplate and rendered read-only.",
             "type": "boolean"

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
@@ -4084,6 +4084,14 @@
       "com.github.grafana.grafana.apps.provisioning.pkg.apis.provisioning.v0alpha1.CommitOptions": {
         "type": "object",
         "properties": {
+          "authorEmail": {
+            "description": "Email used as the commit author instead of the user who triggered the commit. Only valid when signingMethod is unset.",
+            "type": "string"
+          },
+          "authorName": {
+            "description": "Name used as the commit author instead of the user who triggered the commit. Only valid when signingMethod is unset.",
+            "type": "string"
+          },
           "enforceTemplate": {
             "description": "When true, the Comment field in Save drawers is pre-filled from SingleResourceMessageTemplate and rendered read-only.",
             "type": "boolean"

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v1beta1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v1beta1.json
@@ -4084,6 +4084,14 @@
       "com.github.grafana.grafana.apps.provisioning.pkg.apis.provisioning.v1beta1.CommitOptions": {
         "type": "object",
         "properties": {
+          "authorEmail": {
+            "description": "Email used as the commit author instead of the user who triggered the commit. Only valid when signingMethod is unset.",
+            "type": "string"
+          },
+          "authorName": {
+            "description": "Name used as the commit author instead of the user who triggered the commit. Only valid when signingMethod is unset.",
+            "type": "string"
+          },
           "enforceTemplate": {
             "description": "When true, the Comment field in Save drawers is pre-filled from SingleResourceMessageTemplate and rendered read-only.",
             "type": "boolean"


### PR DESCRIPTION
**What is this feature?**

Adds a commit author option to Git Sync repositories. When set, every commit Grafana writes is attributed to that identity instead of the user who made the change. It is only accepted when commit signing is off, since the signer identity already covers the author when signing is on.

The resulting behavior:

| Signing | Signer is Author | Author override | Author | Committer |
| - | - | - | --- | --- |
| ❌ | — | ❌ | User who made the change | — |
| ❌ | — | ✅ | Author override | Author override |
| ✅ | ❌ | — | User who made the change | Signer |
| ✅ | ✅ | — | Signer | Signer |

Verified against a live repository for all four cases: https://github.com/amalavet/ale-git-sync/pull/30/commits

**Why do we need this feature?**

Git providers can reject pushes based on the commit author: GitLab can require the author to be a member of the organization, and GitHub blocks pushes that would expose a private email address. Today the only way to control the author is to configure a signing key and identity, which these users do not otherwise need.

**Who is this feature for?**

Git Sync users whose provider enforces push rules on the commit author.

**Which issue(s) does this PR fix?**:

Fixes #129908

<sub>Description generated by Claude Code.</sub>
