### PR TITLE
[WIP] TimeComparison: Line Style POC

### DIFF
--- a/packages/grafana-data/src/dataframe/utils.test.ts
+++ b/packages/grafana-data/src/dataframe/utils.test.ts
@@ -182,18 +182,22 @@ describe('alignTimeRangeCompareData', () => {
 
     expect(second.fields[0].values).toEqual(first.fields[0].values);
     expect(second.fields[0].config).toEqual(first.fields[0].config);
-    expect(second.fields).toHaveLength(2);
+    // time field + shadow backing + dashed foreground for the single value field
+    expect(second.fields).toHaveLength(3);
   });
 
   // #126189 acceptance criteria — "compare is dashed, current is solid".
   // The compare frame is the only one passed through alignTimeRangeCompareData; the current-period frame
   // never gets a lineStyle, so leaving the current frame's config untouched is what keeps it solid.
   // Assert on the returned frame — alignTimeRangeCompareData is non-mutating (#128796).
-  describe('dashed styling for comparison series (#126189)', () => {
+  //
+  // Each graphable value field is expanded into two series: a solid "shadow" backing (index N) drawn
+  // behind, and the dash-dot-dash foreground (index N+1) in the series color drawn on top.
+  describe('shadow + dashed styling for comparison series (#126189)', () => {
     const DASH_LINE_STYLE = { fill: 'dash', dash: [1, 5, 4, 5] };
 
     it.each([FieldType.number, FieldType.boolean, FieldType.enum])(
-      'applies the dashed lineStyle to %s value fields',
+      'expands %s value fields into a solid shadow backing followed by a dashed foreground',
       (fieldType) => {
         const frame = toDataFrame({
           fields: [
@@ -204,7 +208,23 @@ describe('alignTimeRangeCompareData', () => {
 
         const result = alignTimeRangeCompareData(frame, ONE_DAY_MS, createTheme());
 
-        expect(result.fields[1].config.custom?.lineStyle).toEqual(DASH_LINE_STYLE);
+        // time + shadow + dashed
+        expect(result.fields).toHaveLength(3);
+
+        // shadow glow: solid, wide, faded, its own line color, hidden from legend/tooltip
+        const shadow = result.fields[1];
+        expect(shadow.config.custom?.lineStyle).toEqual({ fill: 'solid' });
+        expect(shadow.config.custom?.lineWidth).toBe(2); // default 1 + 1
+        expect(typeof shadow.config.custom?.lineColor).toBe('string');
+        expect(shadow.config.custom?.fillOpacity).toBe(0);
+        expect(shadow.config.custom?.showPoints).toBe('never');
+        expect(shadow.config.custom?.hideFrom).toEqual({ legend: true, tooltip: true, viz: false });
+
+        // dashed foreground keeps the series color (no explicit lineColor override)
+        const foreground = result.fields[2];
+        expect(foreground.config.custom?.lineStyle).toEqual(DASH_LINE_STYLE);
+        expect(foreground.config.custom?.lineColor).toBeUndefined();
+        expect(foreground.config.custom?.hideFrom).toBeUndefined();
       }
     );
 
@@ -221,7 +241,7 @@ describe('alignTimeRangeCompareData', () => {
       expect(result.fields[0].config.custom?.lineStyle).toBeUndefined();
     });
 
-    it('does not add a lineStyle to string fields', () => {
+    it('does not expand or style string fields', () => {
       const frame = toDataFrame({
         fields: [
           { name: 'time', type: FieldType.time, values: [1000, 2000] },
@@ -232,11 +252,50 @@ describe('alignTimeRangeCompareData', () => {
 
       const result = alignTimeRangeCompareData(frame, ONE_DAY_MS, createTheme());
 
+      // time + string (untouched) + shadow + dashed
+      expect(result.fields).toHaveLength(4);
       expect(result.fields[1].config.custom?.lineStyle).toBeUndefined();
-      expect(result.fields[2].config.custom?.lineStyle).toEqual(DASH_LINE_STYLE);
+      expect(result.fields[2].config.custom?.lineStyle).toEqual({ fill: 'solid' });
+      expect(result.fields[3].config.custom?.lineStyle).toEqual(DASH_LINE_STYLE);
     });
 
-    it('preserves an existing lineStyle-adjacent custom config while adding the dash', () => {
+    it('groups every shadow ahead of every foreground for multi-series frames', () => {
+      // Shadows must all render before foregrounds so a later series' wider shadow never paints over
+      // an earlier series' dashed line.
+      const frame = toDataFrame({
+        fields: [
+          { name: 'time', type: FieldType.time, values: [1000, 2000] },
+          { name: 'a', type: FieldType.number, values: [10, 20] },
+          { name: 'b', type: FieldType.number, values: [30, 40] },
+        ],
+      });
+
+      const result = alignTimeRangeCompareData(frame, ONE_DAY_MS, createTheme());
+
+      // time + (shadow a, shadow b) + (dashed a, dashed b)
+      expect(result.fields).toHaveLength(5);
+      expect(result.fields[0].type).toBe(FieldType.time);
+      expect(result.fields[1].config.custom?.lineStyle).toEqual({ fill: 'solid' });
+      expect(result.fields[2].config.custom?.lineStyle).toEqual({ fill: 'solid' });
+      expect(result.fields[3].config.custom?.lineStyle).toEqual(DASH_LINE_STYLE);
+      expect(result.fields[4].config.custom?.lineStyle).toEqual(DASH_LINE_STYLE);
+    });
+
+    it('gives each expanded field its own state so the join can assign independent origins', () => {
+      const frame = toDataFrame({
+        fields: [
+          { name: 'time', type: FieldType.time, values: [1000, 2000] },
+          { name: 'value', type: FieldType.number, values: [10, 20] },
+        ],
+      });
+
+      const result = alignTimeRangeCompareData(frame, ONE_DAY_MS, createTheme());
+
+      // Shared state would let the join's in-place `state.origin` write bleed between the two series.
+      expect(result.fields[1].state).not.toBe(result.fields[2].state);
+    });
+
+    it('derives the shadow line width from an existing lineWidth and preserves it on the foreground', () => {
       const frame = toDataFrame({
         fields: [
           { name: 'time', type: FieldType.time, values: [1000, 2000] },
@@ -251,8 +310,13 @@ describe('alignTimeRangeCompareData', () => {
 
       const result = alignTimeRangeCompareData(frame, ONE_DAY_MS, createTheme());
 
-      expect(result.fields[1].config.custom?.lineWidth).toBe(2);
-      expect(result.fields[1].config.custom?.lineStyle).toEqual(DASH_LINE_STYLE);
+      // shadow glow is wider than the configured line width
+      expect(result.fields[1].config.custom?.lineWidth).toBe(3); // configured 2 + 1
+      expect(result.fields[1].config.custom?.lineStyle).toEqual({ fill: 'solid' });
+
+      // dashed foreground keeps the configured line width
+      expect(result.fields[2].config.custom?.lineWidth).toBe(2);
+      expect(result.fields[2].config.custom?.lineStyle).toEqual(DASH_LINE_STYLE);
     });
   });
 });

--- a/packages/grafana-data/src/dataframe/utils.ts
+++ b/packages/grafana-data/src/dataframe/utils.ts
@@ -1,3 +1,5 @@
+import { getFieldSeriesColor } from '../field/scale';
+import { alpha, darken, lighten } from '../themes/colorManipulator';
 import { type GrafanaTheme2 } from '../themes/types';
 import { type DataFrame, type Field, FieldType } from '../types/dataFrame';
 import { type TimeRange } from '../types/time';
@@ -126,8 +128,27 @@ export function addRow(dataFrame: DataFrame, row: Record<string, unknown> | unkn
   }
 }
 
+// Dash-dot-dash pattern for the foreground compare line.
+const COMPARE_DASH = [1, 5, 4, 5];
+
+// How much to lighten (light theme) / darken (dark theme) the series color to produce the
+// "shadow" backing line, so the compare series reads as a shadow of its current-period counterpart.
+const SHADOW_COLOR_AMOUNT = 0.3;
+
+// The shadow is drawn as a faded, translucent line just one step wider than the dashed foreground so
+// it reads as a subtle glow/halo hugging the pattern, while still preserving the peaks and valleys
+// that the dash pattern would otherwise leave in the gaps.
+const SHADOW_LINE_WIDTH_INCREASE = 1;
+const SHADOW_OPACITY = 0.35;
+
 /**
  * Aligns time range comparison data by adjusting timestamps and applying compare-specific styling.
+ *
+ * Each graphable field is expanded into two rendered series: a wide, faded, translucent "shadow"
+ * glow (a lightened/darkened shade of the series color) drawn behind, plus a dash-dot-dash line in
+ * the series color drawn on top. The glow keeps the shape continuous so peaks/valleys aren't lost in
+ * the dash gaps, while the shared color makes the relationship to the current-period series clear.
+ *
  * Returns a new DataFrame with new field objects rather than mutating the input - callers (e.g.
  * streaming/split-chunk query paths) may not own the frame or its fields, so mutating them in place
  * can corrupt state shared elsewhere (e.g. a datasource's response accumulator).
@@ -136,37 +157,80 @@ export function addRow(dataFrame: DataFrame, row: Record<string, unknown> | unkn
  * @param theme - The Grafana theme for color calculations
  */
 export function alignTimeRangeCompareData(series: DataFrame, diff: number, theme: GrafanaTheme2): DataFrame {
-  const fields = series.fields.map((field: Field): Field => {
+  const timeCompare = { diffMs: diff, isTimeShiftQuery: true };
+
+  // Non-graphable fields (time/string) keep their position; graphable fields are expanded into a
+  // shadow + dashed pair. All shadows are grouped ahead of all foregrounds so that, in multi-series
+  // frames, a later series' shadow can't paint over an earlier series' dashed line.
+  const passthrough: Field[] = [];
+  const shadows: Field[] = [];
+  const foregrounds: Field[] = [];
+
+  for (const field of series.fields) {
     // Align compare series time stamps with reference series
     const values =
       field.type === FieldType.time ? field.values.map((v: number) => (diff < 0 ? v - diff : v + diff)) : field.values;
 
-    const config = {
-      ...(field.config ?? {}),
-      custom: {
-        ...(field.config?.custom ?? {}),
-        timeCompare: {
-          diffMs: diff,
-          isTimeShiftQuery: true,
-        },
-      },
-    };
+    const isGraphable =
+      field.type === FieldType.number || field.type === FieldType.boolean || field.type === FieldType.enum;
 
-    // Apply visual styling for comparison series
-    if (field.type === FieldType.number || field.type === FieldType.boolean || field.type === FieldType.enum) {
-      config.custom = {
-        ...config.custom,
-        lineStyle: {
-          fill: 'dash',
-          dash: [1, 5, 4, 5],
+    if (!isGraphable) {
+      passthrough.push({
+        ...field,
+        values,
+        config: {
+          ...(field.config ?? {}),
+          custom: { ...(field.config?.custom ?? {}), timeCompare },
         },
-      };
+      });
+      continue;
     }
 
-    return { ...field, values, config };
-  });
+    const baseColor = getFieldSeriesColor(field, theme).color;
+    const shadowTint = theme.isDark ? darken(baseColor, SHADOW_COLOR_AMOUNT) : lighten(baseColor, SHADOW_COLOR_AMOUNT);
+    const shadowColor = alpha(shadowTint, SHADOW_OPACITY);
+    const baseLineWidth = field.config?.custom?.lineWidth ?? 1;
 
-  return { ...series, fields };
+    // Shadow glow: wide, faded, translucent line drawn behind the dashed line so peaks/valleys survive
+    // the dash gaps. Hidden from the legend and tooltip so it doesn't duplicate the compare entry.
+    // Each expanded field needs its own `state`: the join step mutates `state.origin` in place, so a
+    // shared reference would make the shadow and dashed series resolve to the same origin field.
+    shadows.push({
+      ...field,
+      values,
+      state: { ...field.state },
+      config: {
+        ...(field.config ?? {}),
+        custom: {
+          ...(field.config?.custom ?? {}),
+          timeCompare,
+          lineColor: shadowColor,
+          lineWidth: baseLineWidth + SHADOW_LINE_WIDTH_INCREASE,
+          lineStyle: { fill: 'solid' },
+          fillOpacity: 0,
+          showPoints: 'never',
+          hideFrom: { legend: true, tooltip: true, viz: false },
+        },
+      },
+    });
+
+    // Dash-dot-dash foreground in the series color, drawn on top of the shadow.
+    foregrounds.push({
+      ...field,
+      values,
+      state: { ...field.state },
+      config: {
+        ...(field.config ?? {}),
+        custom: {
+          ...(field.config?.custom ?? {}),
+          timeCompare,
+          lineStyle: { fill: 'dash', dash: [...COMPARE_DASH] },
+        },
+      },
+    });
+  }
+
+  return { ...series, fields: [...passthrough, ...shadows, ...foregrounds] };
 }
 
 /**

--- a/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
@@ -70,19 +70,12 @@ export const TimeSeriesPanel = ({
   const { frames, compareDiffMs } = useMemo(() => {
     let frames = prepareGraphableFields(data.series, theme, timeRange);
     if (frames != null) {
-      let compareDiffMs: number[] = [0];
       // Held separately from `frames` below: TS won't retain the null-check narrowing of `frames`
       // inside the .map callback once `frames` itself gets reassigned in this scope.
       const originalFrames = frames;
 
       frames = originalFrames.map((frame: DataFrame) => {
         const diffMs = frame.meta?.timeCompare?.diffMs ?? 0;
-
-        frame.fields.forEach((field) => {
-          if (field.type !== FieldType.time) {
-            compareDiffMs.push(diffMs);
-          }
-        });
 
         if (diffMs !== 0) {
           // Check if the compared frame needs time alignment
@@ -95,6 +88,18 @@ export const TimeSeriesPanel = ({
         }
 
         return frame;
+      });
+
+      // Built after alignment: alignTimeRangeCompareData expands each compare field into a shadow +
+      // dashed series, so the per-series diff must be indexed against the final field layout.
+      const compareDiffMs: number[] = [0];
+      frames.forEach((frame) => {
+        const diffMs = frame.meta?.timeCompare?.diffMs ?? 0;
+        frame.fields.forEach((field) => {
+          if (field.type !== FieldType.time) {
+            compareDiffMs.push(diffMs);
+          }
+        });
       });
 
       return { frames, compareDiffMs };


### PR DESCRIPTION
Just a POC to explore another possible line styling approach for time comparison.

Adds a shadow background behind a unique dash styling that isn't possible from the user options.

<img width="2318" height="682" alt="image (1)" src="https://github.com/user-attachments/assets/5e195ed7-af76-4a19-aab2-bb24e5276757" />



Related to https://github.com/grafana/grafana/issues/126187