### PR TITLE
Alerting: Refactor time intervals as top-level resource with UID

### DIFF
--- a/pkg/registry/apps/alerting/notifications/timeinterval/conversions.go
+++ b/pkg/registry/apps/alerting/notifications/timeinterval/conversions.go
@@ -3,6 +3,7 @@ package timeinterval
 import (
 	"encoding/json"
 
+	"github.com/prometheus/alertmanager/timeinterval"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
@@ -10,51 +11,57 @@ import (
 	model "github.com/grafana/grafana/apps/alerting/notifications/pkg/apis/alertingnotifications/v1beta1"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	gapiutil "github.com/grafana/grafana/pkg/services/apiserver/utils"
-	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 )
 
-func ConvertToK8sResources(orgID int64, intervals []definitions.MuteTimeInterval, namespacer request.NamespaceMapper, selector fields.Selector) (*model.TimeIntervalList, error) {
-	data, err := json.Marshal(intervals)
-	if err != nil {
-		return nil, err
-	}
-	var specs []model.TimeIntervalSpec
-	err = json.Unmarshal(data, &specs)
-	if err != nil {
-		return nil, err
-	}
+func ConvertToK8sResources(orgID int64, intervals []v1.TimeInterval, namespacer request.NamespaceMapper, selector fields.Selector) (*model.TimeIntervalList, error) {
 	result := &model.TimeIntervalList{}
 
-	for idx := range specs {
-		interval := intervals[idx]
-		spec := specs[idx]
-		item := buildTimeInterval(orgID, interval, spec, namespacer)
-		if selector != nil && !selector.Empty() && !selector.Matches(model.TimeIntervalSelectableFields(&item)) {
+	for _, interval := range intervals {
+		item, err := ConvertToK8sResource(orgID, interval, namespacer)
+		if err != nil {
+			return nil, err
+		}
+
+		if selector != nil && !selector.Empty() && !selector.Matches(model.TimeIntervalSelectableFields(item)) {
 			continue
 		}
-		result.Items = append(result.Items, item)
+		result.Items = append(result.Items, *item)
 	}
 	return result, nil
 }
 
-func ConvertToK8sResource(orgID int64, interval definitions.MuteTimeInterval, namespacer request.NamespaceMapper) (*model.TimeInterval, error) {
-	data, err := json.Marshal(interval)
+func ConvertToK8sResource(orgID int64, interval v1.TimeInterval, namespacer request.NamespaceMapper) (*model.TimeInterval, error) {
+	timeIntervals, err := convertToSpec(interval.TimeIntervals)
 	if err != nil {
 		return nil, err
 	}
-	spec := model.TimeIntervalSpec{}
-	err = json.Unmarshal(data, &spec)
-	if err != nil {
-		return nil, err
+	spec := model.TimeIntervalSpec{
+		Name:          interval.Title,
+		TimeIntervals: timeIntervals,
 	}
 	result := buildTimeInterval(orgID, interval, spec, namespacer)
-	result.UID = gapiutil.CalculateClusterWideUID(&result)
 	return &result, nil
 }
 
-func buildTimeInterval(orgID int64, interval definitions.MuteTimeInterval, spec model.TimeIntervalSpec, namespacer request.NamespaceMapper) model.TimeInterval {
+// convertToSpec converts the domain time intervals into the generated API types.
+// The JSON representation of timeinterval.TimeInterval matches model.TimeIntervalInterval,
+// so we round-trip through JSON instead of mapping each field by hand.
+func convertToSpec(intervals []timeinterval.TimeInterval) ([]model.TimeIntervalInterval, error) {
+	data, err := json.Marshal(intervals)
+	if err != nil {
+		return nil, err
+	}
+	var result []model.TimeIntervalInterval
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func buildTimeInterval(orgID int64, interval v1.TimeInterval, spec model.TimeIntervalSpec, namespacer request.NamespaceMapper) model.TimeInterval {
 	i := model.TimeInterval{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: kind.GroupVersionKind().GroupVersion().String(),
@@ -62,7 +69,7 @@ func buildTimeInterval(orgID int64, interval definitions.MuteTimeInterval, spec 
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			UID:             types.UID(interval.UID), // TODO This is needed to make PATCH work
-			Name:            interval.UID,            // TODO replace to stable UID when we switch to normal storage
+			Name:            string(interval.UID),
 			Namespace:       namespacer(orgID),
 			ResourceVersion: interval.Version,
 		},
@@ -71,33 +78,43 @@ func buildTimeInterval(orgID int64, interval definitions.MuteTimeInterval, spec 
 	i.SetProvenanceStatus(string(interval.Provenance))
 	i.UID = gapiutil.CalculateClusterWideUID(&i)
 
-	i.SetCanUse(ngmodels.Provenance(interval.Provenance) != ngmodels.ProvenanceConvertedPrometheus)
+	i.SetCanUse(interval.Provenance != ngmodels.ProvenanceConvertedPrometheus)
 
 	return i
 }
 
-func convertToDomainModel(interval *model.TimeInterval) (definitions.MuteTimeInterval, error) {
-	b, err := json.Marshal(interval.Spec)
+func convertToDomainModel(interval *model.TimeInterval) (v1.TimeInterval, error) {
+	timeIntervals, err := convertFromSpec(interval.Spec.TimeIntervals)
 	if err != nil {
-		return definitions.MuteTimeInterval{}, err
+		return v1.TimeInterval{}, provisioning.MakeErrTimeIntervalInvalid(err)
 	}
-	result := definitions.MuteTimeInterval{}
-	err = json.Unmarshal(b, &result)
-	if err != nil {
-		return definitions.MuteTimeInterval{}, provisioning.MakeErrTimeIntervalInvalid(err)
-	}
-	result.Version = interval.ResourceVersion
-	result.UID = interval.Name
 
 	prov, err := ngmodels.ProvenanceFromString(interval.GetProvenanceStatus())
 	if err != nil {
-		return definitions.MuteTimeInterval{}, provisioning.MakeErrTimeIntervalInvalid(err)
+		return v1.TimeInterval{}, provisioning.MakeErrTimeIntervalInvalid(err)
 	}
-	result.Provenance = definitions.Provenance(prov)
 
-	err = result.Validate()
+	return v1.TimeInterval{
+		ResourceMetadata: v1.ResourceMetadata{
+			UID:        v1.ResourceUID(interval.Name),
+			Version:    interval.ResourceVersion,
+			Provenance: prov,
+		},
+		Title:         interval.Spec.Name,
+		TimeIntervals: timeIntervals,
+	}, nil
+}
+
+// convertFromSpec is the inverse of convertToSpec, converting the generated API types
+// back into the domain time intervals via JSON round-trip.
+func convertFromSpec(intervals []model.TimeIntervalInterval) ([]timeinterval.TimeInterval, error) {
+	data, err := json.Marshal(intervals)
 	if err != nil {
-		return definitions.MuteTimeInterval{}, provisioning.MakeErrTimeIntervalInvalid(err)
+		return nil, err
+	}
+	var result []timeinterval.TimeInterval
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, err
 	}
 	return result, nil
 }

--- a/pkg/registry/apps/alerting/notifications/timeinterval/legacy_storage.go
+++ b/pkg/registry/apps/alerting/notifications/timeinterval/legacy_storage.go
@@ -13,8 +13,8 @@ import (
 	model "github.com/grafana/grafana/apps/alerting/notifications/pkg/apis/alertingnotifications/v1beta1"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
-	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
 )
 
 var (
@@ -22,10 +22,10 @@ var (
 )
 
 type TimeIntervalService interface {
-	GetMuteTimings(ctx context.Context, orgID int64) ([]definitions.MuteTimeInterval, error)
-	CreateMuteTiming(ctx context.Context, mt definitions.MuteTimeInterval, orgID int64) (definitions.MuteTimeInterval, error)
-	UpdateMuteTiming(ctx context.Context, mt definitions.MuteTimeInterval, orgID int64) (definitions.MuteTimeInterval, error)
-	DeleteMuteTiming(ctx context.Context, nameOrUid string, orgID int64, provenance definitions.Provenance, version string) error
+	GetMuteTimings(ctx context.Context, orgID int64) ([]v1.TimeInterval, error)
+	CreateMuteTiming(ctx context.Context, mt v1.TimeInterval, orgID int64) (v1.TimeInterval, error)
+	UpdateMuteTiming(ctx context.Context, mt v1.TimeInterval, orgID int64) (v1.TimeInterval, error)
+	DeleteMuteTiming(ctx context.Context, nameOrUid string, orgID int64, provenance ngmodels.Provenance, version string) error
 }
 
 type legacyStorage struct {
@@ -82,7 +82,7 @@ func (s *legacyStorage) Get(ctx context.Context, uid string, _ *metav1.GetOption
 	}
 
 	for _, mt := range timings {
-		if mt.UID == uid {
+		if mt.UID == v1.ResourceUID(uid) {
 			return ConvertToK8sResource(info.OrgID, mt, s.namespacer)
 		}
 	}
@@ -156,10 +156,6 @@ func (s *legacyStorage) Update(ctx context.Context,
 		return old, false, err
 	}
 
-	if p.Name != interval.UID {
-		return nil, false, errors.NewBadRequest("title of cannot be changed. Consider creating a new resource.")
-	}
-
 	updated, err := s.service.UpdateMuteTiming(ctx, interval, info.OrgID)
 	if err != nil {
 		return nil, false, err
@@ -197,8 +193,8 @@ func (s *legacyStorage) Delete(ctx context.Context, uid string, deleteValidation
 	if err != nil {
 		return nil, false, errors.NewBadRequest(err.Error())
 	}
-	err = s.service.DeleteMuteTiming(ctx, p.Name, info.OrgID, definitions.Provenance(prov), version) // TODO add support for dry-run option
-	return old, false, err                                                                           // false - will be deleted async
+	err = s.service.DeleteMuteTiming(ctx, p.Name, info.OrgID, prov, version) // TODO add support for dry-run option
+	return old, false, err                                                   // false - will be deleted async
 }
 
 func (s *legacyStorage) DeleteCollection(context.Context, rest.ValidateObjectFunc, *metav1.DeleteOptions, *internalversion.ListOptions) (runtime.Object, error) {

--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts.go
@@ -37,9 +37,9 @@ func (s *Service) getAlertMuteTimings(ctx context.Context, signedInUser *user.Si
 
 	for _, muteTiming := range muteTimings {
 		muteTimeIntervals = append(muteTimeIntervals, muteTimeInterval{
-			UID: muteTiming.UID,
+			UID: string(muteTiming.UID),
 			MuteTimeInterval: config.MuteTimeInterval{
-				Name:          muteTiming.Name,
+				Name:          muteTiming.Title,
 				TimeIntervals: muteTiming.TimeIntervals,
 			},
 		})

--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts_test.go
@@ -51,7 +51,7 @@ func TestGetAlertMuteTimings(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, muteTimeIntervals)
 		require.Len(t, muteTimeIntervals, 1)
-		require.Equal(t, createdMuteTiming.Name, muteTimeIntervals[0].Name)
+		require.Equal(t, createdMuteTiming.Title, muteTimeIntervals[0].Name)
 	})
 }
 
@@ -153,12 +153,12 @@ func TestGetNotificationPolicies(t *testing.T) {
 		}}
 
 		muteTiming := createMuteTiming(t, ctx, s, user)
-		require.NotEmpty(t, muteTiming.Name)
+		require.NotEmpty(t, muteTiming.Title)
 
 		contactPoints := createContactPoints(t, ctx, s, user)
 		require.GreaterOrEqual(t, len(contactPoints), 1)
 
-		updateNotificationPolicyTree(t, ctx, s, user, contactPoints[0].Name, muteTiming.Name)
+		updateNotificationPolicyTree(t, ctx, s, user, contactPoints[0].Name, muteTiming.Title)
 
 		notificationPolicies, err := s.getNotificationPolicies(ctx, user)
 		require.NoError(t, err)
@@ -296,7 +296,7 @@ func TestGetAlertRuleGroups(t *testing.T) {
 	})
 }
 
-func createMuteTiming(t *testing.T, ctx context.Context, service *Service, user *user.SignedInUser) definitions.MuteTimeInterval {
+func createMuteTiming(t *testing.T, ctx context.Context, service *Service, user *user.SignedInUser) v1.TimeInterval {
 	t.Helper()
 
 	muteTiming := `{
@@ -316,7 +316,8 @@ func createMuteTiming(t *testing.T, ctx context.Context, service *Service, user 
 	var mt definitions.MuteTimeInterval
 	require.NoError(t, json.Unmarshal([]byte(muteTiming), &mt))
 
-	createdTiming, err := service.ngAlert.Api.MuteTimings.CreateMuteTiming(ctx, mt, user.GetOrgID())
+	interval := v1.NewTimeInterval(mt.Name, mt.TimeIntervals, models.ProvenanceNone)
+	createdTiming, err := service.ngAlert.Api.MuteTimings.CreateMuteTiming(ctx, interval, user.GetOrgID())
 	require.NoError(t, err)
 
 	return createdTiming

--- a/pkg/services/ngalert/api/api_alertmanager_test.go
+++ b/pkg/services/ngalert/api/api_alertmanager_test.go
@@ -192,7 +192,7 @@ func TestAlertmanagerAutogenConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		cOpt := []cmp.Option{
-			cmpopts.IgnoreUnexported(apimodels.PostableUserConfig{}, apimodels.Route{}, labels.Matcher{}),
+			cmpopts.IgnoreUnexported(apimodels.PostableUserConfig{}, apimodels.Route{}, labels.Matcher{}, time.Location{}),
 			cmpopts.IgnoreFields(apimodels.PostableGrafanaReceiver{}, "UID", "Settings"),
 		}
 		if !cmp.Equal(test, exp, cOpt...) {
@@ -467,7 +467,20 @@ var validConfig = `{
 					"addresses": "<example@example.com>"
 				}
 			}]
-		}]
+		}],
+		"time_intervals": [
+			{
+				"name": "test_interval",
+				"time_intervals": [{
+					"times": [{"start_time": "12:12","end_time": "23:23"}],
+					"weekdays": ["monday","wednesday","friday","sunday"],
+					"days_of_month": ["10:20","25:-1"],
+					"months": ["1:6","10:12"],
+					"years": ["2022:2054"],
+					"location": "America/Montreal"
+				}]
+			}
+		]
 	}
 }
 `
@@ -504,7 +517,20 @@ var validConfigWithoutAutogen = `{
 					"addresses": "<other@example.com>"
 				}
 			}]
-		}]
+		}],
+		"time_intervals": [
+			{
+				"name": "test_interval",
+				"time_intervals": [{
+					"times": [{"start_time": "12:12","end_time": "23:23"}],
+					"weekdays": ["monday","wednesday","friday","sunday"],
+					"days_of_month": ["10:20","25:-1"],
+					"months": ["1:6","10:12"],
+					"years": ["2022:2054"],
+					"location": "America/Montreal"
+				}]
+			}
+		]
 	}
 }
 `
@@ -555,7 +581,20 @@ var validConfigWithAutogen = `{
 					"addresses": "<other@example.com>"
 				}
 			}]
-		}]
+		}],
+		"time_intervals": [
+			{
+				"name": "test_interval",
+				"time_intervals": [{
+					"times": [{"start_time": "12:12","end_time": "23:23"}],
+					"weekdays": ["monday","wednesday","friday","sunday"],
+					"days_of_month": ["10:20","25:-1"],
+					"months": ["1:6","10:12"],
+					"years": ["2022:2054"],
+					"location": "America/Montreal"
+				}]
+			}
+		]
 	}
 }
 `

--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -64,11 +64,11 @@ type NotificationPolicyService interface {
 }
 
 type MuteTimingService interface {
-	GetMuteTimings(ctx context.Context, orgID int64) ([]definitions.MuteTimeInterval, error)
-	GetMuteTimingByName(ctx context.Context, name string, orgID int64) (definitions.MuteTimeInterval, error)
-	CreateMuteTiming(ctx context.Context, mt definitions.MuteTimeInterval, orgID int64) (definitions.MuteTimeInterval, error)
-	UpdateMuteTiming(ctx context.Context, mt definitions.MuteTimeInterval, orgID int64) (definitions.MuteTimeInterval, error)
-	DeleteMuteTiming(ctx context.Context, name string, orgID int64, provenance definitions.Provenance, version string) error
+	GetMuteTimings(ctx context.Context, orgID int64) ([]v1.TimeInterval, error)
+	GetMuteTimingByName(ctx context.Context, name string, orgID int64) (v1.TimeInterval, error)
+	CreateMuteTiming(ctx context.Context, mt v1.TimeInterval, orgID int64) (v1.TimeInterval, error)
+	UpdateMuteTiming(ctx context.Context, mt v1.TimeInterval, orgID int64) (v1.TimeInterval, error)
+	DeleteMuteTiming(ctx context.Context, nameOrUid string, orgID int64, provenance alerting_models.Provenance, version string) error
 }
 
 type AlertRuleService interface {
@@ -131,7 +131,7 @@ func (srv *ProvisioningSrv) RouteGetPolicyTreeExport(c *contextmodel.ReqContext)
 
 func (srv *ProvisioningSrv) RoutePutPolicyTree(c *contextmodel.ReqContext, tree definitions.Route) response.Response {
 	provenance := determineProvenance(c)
-	_, _, err := srv.policies.UpdatePolicyTree(c.Req.Context(), c.GetOrgID(), tree, alerting_models.Provenance(provenance), "")
+	_, _, err := srv.policies.UpdatePolicyTree(c.Req.Context(), c.GetOrgID(), tree, provenance, "")
 	if errors.Is(err, store.ErrNoAlertmanagerConfiguration) {
 		return ErrResp(http.StatusNotFound, err, "")
 	}
@@ -147,7 +147,7 @@ func (srv *ProvisioningSrv) RoutePutPolicyTree(c *contextmodel.ReqContext, tree 
 
 func (srv *ProvisioningSrv) RouteResetPolicyTree(c *contextmodel.ReqContext) response.Response {
 	provenance := determineProvenance(c)
-	tree, err := srv.policies.ResetPolicyTree(c.Req.Context(), c.GetOrgID(), alerting_models.Provenance(provenance))
+	tree, err := srv.policies.ResetPolicyTree(c.Req.Context(), c.GetOrgID(), provenance)
 	if err != nil {
 		return response.ErrOrFallback(http.StatusInternalServerError, "failed to reset notification policy tree", err)
 	}
@@ -188,7 +188,7 @@ func (srv *ProvisioningSrv) RouteGetContactPointsExport(c *contextmodel.ReqConte
 
 func (srv *ProvisioningSrv) RoutePostContactPoint(c *contextmodel.ReqContext, cp definitions.EmbeddedContactPoint) response.Response {
 	provenance := determineProvenance(c)
-	contactPoint, err := srv.contactPointService.CreateContactPoint(c.Req.Context(), c.GetOrgID(), c.SignedInUser, cp, alerting_models.Provenance(provenance))
+	contactPoint, err := srv.contactPointService.CreateContactPoint(c.Req.Context(), c.GetOrgID(), c.SignedInUser, cp, provenance)
 	if errors.Is(err, provisioning.ErrValidation) {
 		return ErrResp(http.StatusBadRequest, err, "")
 	}
@@ -201,7 +201,7 @@ func (srv *ProvisioningSrv) RoutePostContactPoint(c *contextmodel.ReqContext, cp
 func (srv *ProvisioningSrv) RoutePutContactPoint(c *contextmodel.ReqContext, cp definitions.EmbeddedContactPoint, UID string) response.Response {
 	cp.UID = UID
 	provenance := determineProvenance(c)
-	err := srv.contactPointService.UpdateContactPoint(c.Req.Context(), c.GetOrgID(), c.SignedInUser, cp, alerting_models.Provenance(provenance))
+	err := srv.contactPointService.UpdateContactPoint(c.Req.Context(), c.GetOrgID(), c.SignedInUser, cp, provenance)
 	if errors.Is(err, provisioning.ErrValidation) {
 		return ErrResp(http.StatusBadRequest, err, "")
 	}
@@ -244,7 +244,7 @@ func (srv *ProvisioningSrv) RoutePutTemplate(c *contextmodel.ReqContext, body de
 		Content: body.Template,
 		Kind:    v1.TemplateKindGrafana,
 		ResourceMetadata: v1.ResourceMetadata{
-			Provenance: alerting_models.Provenance(determineProvenance(c)),
+			Provenance: determineProvenance(c),
 			Version:    body.ResourceVersion,
 		},
 	}
@@ -257,7 +257,7 @@ func (srv *ProvisioningSrv) RoutePutTemplate(c *contextmodel.ReqContext, body de
 
 func (srv *ProvisioningSrv) RouteDeleteTemplate(c *contextmodel.ReqContext, nameOrUid string) response.Response {
 	version := c.Query("version")
-	err := srv.templates.DeleteTemplate(c.Req.Context(), c.GetOrgID(), nameOrUid, alerting_models.Provenance(determineProvenance(c)), version)
+	err := srv.templates.DeleteTemplate(c.Req.Context(), c.GetOrgID(), nameOrUid, determineProvenance(c), version)
 	if err != nil {
 		return response.ErrOrFallback(http.StatusInternalServerError, "", err)
 	}
@@ -269,7 +269,7 @@ func (srv *ProvisioningSrv) RouteGetMuteTiming(c *contextmodel.ReqContext, name 
 	if err != nil {
 		return response.ErrOrFallback(http.StatusInternalServerError, "failed to get mute timing by name", err)
 	}
-	return response.JSON(http.StatusOK, timing)
+	return response.JSON(http.StatusOK, ModelToMuteTimeInterval(timing))
 }
 
 func (srv *ProvisioningSrv) RouteGetMuteTimingExport(c *contextmodel.ReqContext, name string) response.Response {
@@ -278,8 +278,8 @@ func (srv *ProvisioningSrv) RouteGetMuteTimingExport(c *contextmodel.ReqContext,
 		return response.ErrOrFallback(http.StatusInternalServerError, "failed to get mute timings", err)
 	}
 	for _, timing := range timings {
-		if name == timing.Name {
-			e := AlertingFileExportFromMuteTimings(c.GetOrgID(), []definitions.MuteTimeInterval{timing})
+		if name == timing.Title {
+			e := AlertingFileExportFromMuteTimings(c.GetOrgID(), []definitions.MuteTimeInterval{ModelToMuteTimeInterval(timing)})
 			return exportResponse(c, e)
 		}
 	}
@@ -291,7 +291,7 @@ func (srv *ProvisioningSrv) RouteGetMuteTimings(c *contextmodel.ReqContext) resp
 	if err != nil {
 		return response.ErrOrFallback(http.StatusInternalServerError, "failed to get mute timings", err)
 	}
-	return response.JSON(http.StatusOK, timings)
+	return response.JSON(http.StatusOK, ModelToMuteTimeIntervals(timings))
 }
 
 func (srv *ProvisioningSrv) RouteGetMuteTimingsExport(c *contextmodel.ReqContext) response.Response {
@@ -299,17 +299,18 @@ func (srv *ProvisioningSrv) RouteGetMuteTimingsExport(c *contextmodel.ReqContext
 	if err != nil {
 		return response.ErrOrFallback(http.StatusInternalServerError, "failed to get mute timings", err)
 	}
-	e := AlertingFileExportFromMuteTimings(c.GetOrgID(), timings)
+	e := AlertingFileExportFromMuteTimings(c.GetOrgID(), ModelToMuteTimeIntervals(timings))
 	return exportResponse(c, e)
 }
 
 func (srv *ProvisioningSrv) RoutePostMuteTiming(c *contextmodel.ReqContext, mt definitions.MuteTimeInterval) response.Response {
-	mt.Provenance = determineProvenance(c)
-	created, err := srv.muteTimings.CreateMuteTiming(c.Req.Context(), mt, c.GetOrgID())
+	ti := MuteTimeIntervalToModel(mt)
+	ti.Provenance = determineProvenance(c)
+	created, err := srv.muteTimings.CreateMuteTiming(c.Req.Context(), ti, c.GetOrgID())
 	if err != nil {
 		return response.ErrOrFallback(http.StatusInternalServerError, "failed to create mute timing", err)
 	}
-	return response.JSON(http.StatusCreated, created)
+	return response.JSON(http.StatusCreated, ModelToMuteTimeInterval(created))
 }
 
 func (srv *ProvisioningSrv) RoutePutMuteTiming(c *contextmodel.ReqContext, mt definitions.MuteTimeInterval, name string) response.Response {
@@ -321,12 +322,13 @@ func (srv *ProvisioningSrv) RoutePutMuteTiming(c *contextmodel.ReqContext, mt de
 	if mt.Name != name {
 		mt.UID = name
 	}
-	mt.Provenance = determineProvenance(c)
-	updated, err := srv.muteTimings.UpdateMuteTiming(c.Req.Context(), mt, c.GetOrgID())
+	ti := MuteTimeIntervalToModel(mt)
+	ti.Provenance = determineProvenance(c)
+	updated, err := srv.muteTimings.UpdateMuteTiming(c.Req.Context(), ti, c.GetOrgID())
 	if err != nil {
 		return response.ErrOrFallback(http.StatusInternalServerError, "failed to update mute timing", err)
 	}
-	return response.JSON(http.StatusAccepted, updated)
+	return response.JSON(http.StatusAccepted, ModelToMuteTimeInterval(updated))
 }
 
 func (srv *ProvisioningSrv) RouteDeleteMuteTiming(c *contextmodel.ReqContext, name string) response.Response {
@@ -546,11 +548,11 @@ func (srv *ProvisioningSrv) RouteDeleteAlertRuleGroup(c *contextmodel.ReqContext
 	return response.JSON(http.StatusNoContent, "")
 }
 
-func determineProvenance(ctx *contextmodel.ReqContext) definitions.Provenance {
+func determineProvenance(ctx *contextmodel.ReqContext) alerting_models.Provenance {
 	if _, disabled := ctx.Req.Header[disableProvenanceHeaderName]; disabled {
-		return definitions.Provenance(alerting_models.ProvenanceNone)
+		return alerting_models.ProvenanceNone
 	}
-	return definitions.Provenance(alerting_models.ProvenanceAPI)
+	return alerting_models.ProvenanceAPI
 }
 
 func determineManagerProperties(ctx *contextmodel.ReqContext) utils.ManagerProperties {

--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -2208,34 +2208,16 @@ func TestApiGetSnapshots(t *testing.T) {
 			Location: &timeinterval.Location{Location: location},
 		}
 	}
-	cfg.AlertmanagerConfig.TimeIntervals = append(cfg.AlertmanagerConfig.TimeIntervals,
-		v1.TimeInterval{
-			Name: "MuteTimeIntervalA",
-			TimeIntervals: []timeinterval.TimeInterval{
-				timeIntervalExample(),
-			},
-		},
-		v1.TimeInterval{
-			Name: "MuteTimeIntervalB",
-			TimeIntervals: []timeinterval.TimeInterval{
-				timeIntervalExample(),
-			},
-		},
-	)
-	cfg.AlertmanagerConfig.TimeIntervals = append(cfg.AlertmanagerConfig.TimeIntervals,
-		v1.TimeInterval{
-			Name: "TimeIntervalA",
-			TimeIntervals: []timeinterval.TimeInterval{
-				timeIntervalExample(),
-			},
-		},
-		v1.TimeInterval{
-			Name: "TimeIntervalB",
-			TimeIntervals: []timeinterval.TimeInterval{
-				timeIntervalExample(),
-			},
-		},
-	)
+	// Add to the intervals already present in the base config (referenced by routes) rather than
+	// replacing the map, otherwise the route references become dangling and validation fails.
+	for _, interval := range []v1.TimeInterval{
+		v1.NewTimeInterval("MuteTimeIntervalA", []timeinterval.TimeInterval{timeIntervalExample()}, models.ProvenanceNone),
+		v1.NewTimeInterval("MuteTimeIntervalB", []timeinterval.TimeInterval{timeIntervalExample()}, models.ProvenanceNone),
+		v1.NewTimeInterval("TimeIntervalA", []timeinterval.TimeInterval{timeIntervalExample()}, models.ProvenanceNone),
+		v1.NewTimeInterval("TimeIntervalB", []timeinterval.TimeInterval{timeIntervalExample()}, models.ProvenanceNone),
+	} {
+		cfg.TimeIntervals[interval.UID] = interval
+	}
 
 	amConfig, err := legacy_storage.SerializeAlertmanagerConfig(*cfg)
 	require.NoError(t, err)

--- a/pkg/services/ngalert/api/compat_mute_timings.go
+++ b/pkg/services/ngalert/api/compat_mute_timings.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	amconfig "github.com/prometheus/alertmanager/config"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
+)
+
+func ModelToMuteTimeIntervals(intervals []v1.TimeInterval) []definitions.MuteTimeInterval {
+	out := make([]definitions.MuteTimeInterval, 0, len(intervals))
+	for _, interval := range intervals {
+		out = append(out, ModelToMuteTimeInterval(interval))
+	}
+	return out
+}
+
+func ModelToMuteTimeInterval(interval v1.TimeInterval) definitions.MuteTimeInterval {
+	return definitions.MuteTimeInterval{
+		UID: string(interval.UID),
+		MuteTimeInterval: amconfig.MuteTimeInterval{
+			Name:          interval.Title,
+			TimeIntervals: interval.TimeIntervals,
+		},
+		Version:    interval.Version,
+		Provenance: definitions.Provenance(interval.Provenance),
+	}
+}
+
+func MuteTimeIntervalToModel(mt definitions.MuteTimeInterval) v1.TimeInterval {
+	return v1.TimeInterval{
+		ResourceMetadata: v1.ResourceMetadata{
+			UID:        v1.ResourceUID(mt.UID),
+			Version:    mt.Version,
+			Provenance: models.Provenance(mt.Provenance),
+		},
+		Title:         mt.Name,
+		TimeIntervals: mt.TimeIntervals,
+	}
+}

--- a/pkg/services/ngalert/api/compat_mute_timings_test.go
+++ b/pkg/services/ngalert/api/compat_mute_timings_test.go
@@ -1,0 +1,81 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	amconfig "github.com/prometheus/alertmanager/config"
+	"github.com/prometheus/alertmanager/timeinterval"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+)
+
+// fullTimeIntervals returns a fully-populated set of time intervals exercising every field so
+// the round-trip tests fail if any nested field is dropped.
+func fullTimeIntervals() []timeinterval.TimeInterval {
+	return []timeinterval.TimeInterval{
+		{
+			Times: []timeinterval.TimeRange{
+				{StartMinute: 10, EndMinute: 20},
+				{StartMinute: 50, EndMinute: 60},
+			},
+			Weekdays: []timeinterval.WeekdayRange{
+				{InclusiveRange: timeinterval.InclusiveRange{Begin: 1, End: 2}},
+				{InclusiveRange: timeinterval.InclusiveRange{Begin: 5, End: 6}},
+			},
+			DaysOfMonth: []timeinterval.DayOfMonthRange{
+				{InclusiveRange: timeinterval.InclusiveRange{Begin: 1, End: 10}},
+				{InclusiveRange: timeinterval.InclusiveRange{Begin: 20, End: 25}},
+			},
+			Months: []timeinterval.MonthRange{
+				{InclusiveRange: timeinterval.InclusiveRange{Begin: 1, End: 3}},
+			},
+			Years: []timeinterval.YearRange{
+				{InclusiveRange: timeinterval.InclusiveRange{Begin: 2020, End: 2022}},
+			},
+			Location: &timeinterval.Location{Location: time.UTC},
+		},
+	}
+}
+
+func TestMuteTimeIntervalModelRoundTrip(t *testing.T) {
+	t.Run("roundtrip is lossless", func(t *testing.T) {
+		cases := []struct {
+			name string
+			in   definitions.MuteTimeInterval
+		}{
+			{
+				name: "fully populated",
+				in: definitions.MuteTimeInterval{
+					UID: "some-stable-uid",
+					MuteTimeInterval: amconfig.MuteTimeInterval{
+						Name:          "my-interval",
+						TimeIntervals: fullTimeIntervals(),
+					},
+					Version:    "v-12345",
+					Provenance: definitions.Provenance(models.ProvenanceAPI),
+				},
+			},
+			{
+				name: "zero value",
+				in:   definitions.MuteTimeInterval{},
+			},
+			{
+				name: "nil time intervals",
+				in: definitions.MuteTimeInterval{
+					MuteTimeInterval: amconfig.MuteTimeInterval{Name: "empty-interval"},
+					Provenance:       definitions.Provenance(models.ProvenanceFile),
+				},
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				out := ModelToMuteTimeInterval(MuteTimeIntervalToModel(tc.in))
+				require.Equal(t, tc.in, out)
+			})
+		}
+	})
+}

--- a/pkg/services/ngalert/api/test-data/policy-exports/testing.go
+++ b/pkg/services/ngalert/api/test-data/policy-exports/testing.go
@@ -38,15 +38,6 @@ var Config = func() *v1.AMConfigV1 {
 		AlertmanagerConfig: v1.PostableApiAlertingConfig{
 			Config: v1.Config{
 				Route: Legacy(),
-				// Add time interval references to help tests avoid validation errors.
-				TimeIntervals: []v1.TimeInterval{
-					{Name: "interval"},
-					{Name: "active"},
-					{Name: "Some interval"},
-					{Name: "A provisioned interval"},
-					{Name: "Some interval override"},
-					{Name: "A provisioned interval override"},
-				},
 			},
 			// Add receiver references to help tests avoid validation errors.
 			Receivers: []*v1.PostableApiReceiver{
@@ -57,6 +48,15 @@ var Config = func() *v1.AMConfigV1 {
 				{Name: "provisioned-contact-point"},
 				{Name: "nested-receiver"},
 			},
+		},
+		// Add time interval references to help tests avoid validation errors.
+		TimeIntervals: map[v1.ResourceUID]v1.TimeInterval{
+			v1.TimeIntervalUID("interval"):                        {Title: "interval"},
+			v1.TimeIntervalUID("active"):                          {Title: "active"},
+			v1.TimeIntervalUID("Some interval"):                   {Title: "Some interval"},
+			v1.TimeIntervalUID("A provisioned interval"):          {Title: "A provisioned interval"},
+			v1.TimeIntervalUID("Some interval override"):          {Title: "Some interval override"},
+			v1.TimeIntervalUID("A provisioned interval override"): {Title: "A provisioned interval override"},
 		},
 		ManagedRoutes: map[string]*v1.Route{
 			"empty":            Empty(),

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_mute_timings.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_mute_timings.go
@@ -136,14 +136,6 @@ type MuteTimeInterval struct {
 	Provenance              Provenance `json:"provenance,omitempty"`
 }
 
-func (mt *MuteTimeInterval) ResourceType() string {
-	return "muteTimeInterval"
-}
-
-func (mt *MuteTimeInterval) ResourceID() string {
-	return mt.Name
-}
-
 type MuteTimeIntervalExport struct {
 	OrgID                   int64 `json:"orgId" yaml:"orgId"`
 	config.MuteTimeInterval `json:",inline" yaml:",inline"`

--- a/pkg/services/ngalert/notifier/alertmanager_config.go
+++ b/pkg/services/ngalert/notifier/alertmanager_config.go
@@ -291,7 +291,7 @@ func (moa *MultiOrgAlertmanager) gettableUserConfigFromAMConfigString(ctx contex
 	result := definitions.GettableUserConfig{
 		TemplateFiles: v1.TemplatesToTemplateFiles(cfg.Templates),
 		AlertmanagerConfig: definitions.GettableApiAlertingConfig{
-			Config: PostableApiAlertingConfigToAPI(alertmanagerConfig).Config,
+			Config: PostableApiAlertingConfigToAPI(alertmanagerConfig, cfg.SortedTimeIntervals()).Config,
 		},
 		ExtraConfigs: ExtraConfigsToAPI(cfg.ExtraConfigs),
 	}
@@ -557,8 +557,7 @@ func (moa *MultiOrgAlertmanager) mergeProvenance(ctx context.Context, config def
 		config.TemplateFileProvenances[key] = definitions.Provenance(provenance)
 	}
 
-	mt := definitions.MuteTimeInterval{}
-	mtProvs, err := moa.ProvStore.GetProvenances(ctx, org, mt.ResourceType())
+	mtProvs, err := moa.ProvStore.GetProvenances(ctx, org, (&v1.TimeInterval{}).ResourceType())
 	if err != nil {
 		return definitions.GettableUserConfig{}, nil
 	}

--- a/pkg/services/ngalert/notifier/autogen_alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/autogen_alertmanager_test.go
@@ -31,16 +31,17 @@ func TestAddAutogenConfig(t *testing.T) {
 					Route: rootRoute(),
 				},
 			},
+			TimeIntervals: map[v1.ResourceUID]v1.TimeInterval{},
 		}
+
 		for _, receiver := range receivers {
 			cfg.AlertmanagerConfig.Receivers = append(cfg.AlertmanagerConfig.Receivers, &v1.PostableApiReceiver{
 				Name: receiver,
 			})
 		}
 		for _, muteInterval := range muteIntervals {
-			cfg.AlertmanagerConfig.TimeIntervals = append(cfg.AlertmanagerConfig.TimeIntervals, v1.TimeInterval{
-				Name: muteInterval,
-			})
+			ti := v1.NewTimeInterval(muteInterval, nil, models.ProvenanceNone)
+			cfg.TimeIntervals[ti.UID] = ti
 		}
 		return cfg
 	}

--- a/pkg/services/ngalert/notifier/compat.go
+++ b/pkg/services/ngalert/notifier/compat.go
@@ -75,7 +75,7 @@ func PostableAPIConfigToNotificationsConfiguration(
 	return alertingNotify.NotificationsConfiguration{
 		RoutingTree:   RouteToAPI(cfg.AlertmanagerConfig.Route),
 		InhibitRules:  append(inhibitionRules, cfg.AlertmanagerConfig.InhibitRules...),
-		TimeIntervals: ModelToTimeIntervals(cfg.AlertmanagerConfig.TimeIntervals),
+		TimeIntervals: ModelToTimeIntervals(cfg.SortedTimeIntervals()),
 		Templates:     ModelToTemplateDefinitions(cfg.SortedTemplates()), // templates are already merged.
 		Receivers:     receivers,
 		Limits:        limits,
@@ -113,7 +113,7 @@ func ModelToTimeIntervals(in []v1.TimeInterval) []alertingNotify.TimeInterval {
 	out := make([]alertingNotify.TimeInterval, 0, len(in))
 	for _, t := range in {
 		out = append(out, config.TimeInterval{
-			Name:          t.Name,
+			Name:          t.Title,
 			TimeIntervals: t.TimeIntervals,
 		})
 	}

--- a/pkg/services/ngalert/notifier/compat_test.go
+++ b/pkg/services/ngalert/notifier/compat_test.go
@@ -14,7 +14,7 @@ func TestModelToTimeIntervals(t *testing.T) {
 	weekdayRange := timeinterval.WeekdayRange{InclusiveRange: timeinterval.InclusiveRange{Begin: 1, End: 5}}
 
 	ti := func(name string, intervals ...timeinterval.TimeInterval) v1.TimeInterval {
-		return v1.TimeInterval{Name: name, TimeIntervals: intervals}
+		return v1.TimeInterval{Title: name, TimeIntervals: intervals}
 	}
 	want := func(name string, intervals ...timeinterval.TimeInterval) config.TimeInterval {
 		return config.TimeInterval{Name: name, TimeIntervals: intervals}
@@ -30,18 +30,16 @@ func TestModelToTimeIntervals(t *testing.T) {
 			expected: []config.TimeInterval{},
 		},
 		{
-			name:     "time intervals",
+			name:     "multiple time intervals",
 			in:       []v1.TimeInterval{ti("ti-1"), ti("ti-2")},
 			expected: []config.TimeInterval{want("ti-1"), want("ti-2")},
 		},
 		{
-			name: "preserves TimeIntervals payload and order",
+			name: "preserves TimeIntervals payload",
 			in: []v1.TimeInterval{
-				{Name: "mti-1", TimeIntervals: []timeinterval.TimeInterval{{Weekdays: []timeinterval.WeekdayRange{weekdayRange}}}},
-				{Name: "ti-1", TimeIntervals: []timeinterval.TimeInterval{{Weekdays: []timeinterval.WeekdayRange{weekdayRange}}}},
+				{Title: "ti-1", TimeIntervals: []timeinterval.TimeInterval{{Weekdays: []timeinterval.WeekdayRange{weekdayRange}}}},
 			},
 			expected: []config.TimeInterval{
-				{Name: "mti-1", TimeIntervals: []timeinterval.TimeInterval{{Weekdays: []timeinterval.WeekdayRange{weekdayRange}}}},
 				{Name: "ti-1", TimeIntervals: []timeinterval.TimeInterval{{Weekdays: []timeinterval.WeekdayRange{weekdayRange}}}},
 			},
 		},

--- a/pkg/services/ngalert/notifier/legacy_storage/imported.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/imported.go
@@ -77,22 +77,19 @@ func (e ImportedConfigRevision) GetTimeIntervals() ([]v1.TimeInterval, error) {
 
 	// Merge to get the renames map (only renamed if name collision occurs)
 	timeIntervals, _, added := merge.TimeIntervals(
-		e.rev.Config.AlertmanagerConfig.TimeIntervals,
+		e.rev.Config.TimeIntervals,
 		imported,
 		e.identifier,
 	)
 
-	importedTitles := make(map[string]struct{}, len(added))
-	for _, title := range added {
-		importedTitles[title] = struct{}{}
-	}
-
-	// Filter to imported intervals
 	result := make([]v1.TimeInterval, 0, len(added))
-	for _, ti := range timeIntervals {
-		if _, ok := importedTitles[ti.Name]; !ok {
+	for _, uid := range added {
+		ti, ok := timeIntervals[uid]
+		if !ok {
 			continue
 		}
+
+		ti.Provenance = models.ProvenanceConvertedPrometheus
 		result = append(result, ti)
 	}
 
@@ -123,7 +120,7 @@ func (e ImportedConfigRevision) GetManagedRoute() (*ManagedRoute, error) {
 
 	route := e.importedConfig.ToGrafanaRoute()
 
-	renamed := merge.DeduplicateResources(e.rev.Config.AlertmanagerConfig, *e.importedConfig, e.identifier)
+	renamed := merge.DeduplicateResources(*e.rev.Config, *e.importedConfig, e.identifier)
 
 	merge.RenameResourceUsagesInRoutes([]*v1.Route{route}, renamed)
 

--- a/pkg/services/ngalert/notifier/legacy_storage/receivers_test.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/receivers_test.go
@@ -488,10 +488,6 @@ func getConfigRevisionForTest(opts ...opt) *ConfigRevision {
 			AlertmanagerConfig: v1.PostableApiAlertingConfig{
 				Config: v1.Config{
 					Route: &v1.Route{Receiver: "receiver1"},
-					TimeIntervals: []v1.TimeInterval{
-						{Name: "time-interval-1"},
-						{Name: "mute-interval-1"},
-					},
 				},
 				Receivers: []*v1.PostableApiReceiver{
 					{
@@ -525,6 +521,10 @@ func getConfigRevisionForTest(opts ...opt) *ConfigRevision {
 						},
 					},
 				},
+			},
+			TimeIntervals: map[v1.ResourceUID]v1.TimeInterval{
+				v1.TimeIntervalUID("time-interval-1"): {Title: "time-interval-1"},
+				v1.TimeIntervalUID("mute-interval-1"): {Title: "mute-interval-1"},
 			},
 			ManagedRoutes: map[string]*v1.Route{
 				"named_route": {Receiver: "receiver1"},

--- a/pkg/services/ngalert/notifier/legacy_storage/routes.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/routes.go
@@ -301,8 +301,8 @@ func (rev *ConfigRevision) validateReceiverReferences(route v1.Route) error {
 
 func (rev *ConfigRevision) validateTimeIntervalReferences(route v1.Route) error {
 	timeIntervals := map[string]struct{}{}
-	for _, mt := range rev.Config.AlertmanagerConfig.TimeIntervals {
-		timeIntervals[mt.Name] = struct{}{}
+	for _, ti := range rev.Config.TimeIntervals {
+		timeIntervals[ti.Title] = struct{}{}
 	}
 	return route.ValidateTimeIntervals(timeIntervals)
 }

--- a/pkg/services/ngalert/notifier/legacy_storage/time_intervals.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/time_intervals.go
@@ -1,0 +1,33 @@
+package legacy_storage
+
+import (
+	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
+)
+
+func (rev *ConfigRevision) GetTimeIntervalWithTitle(title string) (v1.TimeInterval, bool) {
+	for _, ti := range rev.Config.TimeIntervals {
+		if ti.Title == title {
+			return ti, true
+		}
+	}
+	return v1.TimeInterval{}, false
+}
+
+func (rev *ConfigRevision) SetTimeInterval(ti v1.TimeInterval) v1.TimeInterval {
+	if rev.Config.TimeIntervals == nil {
+		rev.Config.TimeIntervals = make(map[v1.ResourceUID]v1.TimeInterval)
+	}
+	// The UID is derived from the title, so always key by the title's UID rather than trusting
+	// the caller's value. On rename the caller passes the old UID (to locate the existing entry);
+	// recomputing here ensures the renamed interval is stored under its new UID instead of
+	// overwriting and then being deleted under the old one.
+	ti.UID = v1.TimeIntervalUID(ti.Title)
+	// Ensure Version is set.
+	ti.Version = v1.TimeIntervalFingerprint(ti)
+	rev.Config.TimeIntervals[ti.UID] = ti
+	return ti
+}
+
+func (rev *ConfigRevision) DeleteTimeInterval(uid v1.ResourceUID) {
+	delete(rev.Config.TimeIntervals, uid)
+}

--- a/pkg/services/ngalert/notifier/legacy_storage/v1/compat.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/v1/compat.go
@@ -33,6 +33,7 @@ func ToModel(in *definitions.PostableUserConfig) *AMConfigV1 {
 	return &AMConfigV1{
 		Templates:          templates,
 		InhibitionRules:    InhibitionRulesToModel(in.ManagedInhibitionRules),
+		TimeIntervals:      TimeIntervalsToModel(in.AlertmanagerConfig.MuteTimeIntervals, in.AlertmanagerConfig.TimeIntervals),
 		AlertmanagerConfig: PostableApiAlertingConfigToModel(in.AlertmanagerConfig),
 		ExtraConfigs:       ExtraConfigsToModel(in.ExtraConfigs),
 		ManagedRoutes:      ManagedRoutesToModel(in.ManagedRoutes),
@@ -42,29 +43,30 @@ func ToModel(in *definitions.PostableUserConfig) *AMConfigV1 {
 func PostableApiAlertingConfigToModel(in definition.PostableApiAlertingConfig) PostableApiAlertingConfig {
 	return PostableApiAlertingConfig{
 		Config: Config{
-			Global:        in.Global,
-			Route:         RouteToModel(in.Route),
-			InhibitRules:  slices.Clone(in.InhibitRules),
-			Templates:     slices.Clone(in.Templates),
-			TimeIntervals: TimeIntervalsToModel(in.MuteTimeIntervals, in.TimeIntervals),
+			Global:       in.Global,
+			Route:        RouteToModel(in.Route),
+			InhibitRules: slices.Clone(in.InhibitRules),
+			Templates:    slices.Clone(in.Templates),
 		},
 		Receivers: ReceiversToModel(in.Receivers),
 	}
 }
 
-func TimeIntervalsToModel(muteIntervals []config.MuteTimeInterval, timeIntervals []config.TimeInterval) []TimeInterval {
+func TimeIntervalsToModel(muteIntervals []config.MuteTimeInterval, timeIntervals []config.TimeInterval) map[ResourceUID]TimeInterval {
 	if muteIntervals == nil && timeIntervals == nil {
 		return nil
 	}
-	// Fold mute time intervals into time intervals, mute first. A name cannot appear in both lists
-	// because Config rejects duplicates across them at unmarshal time, so the order only needs to be
-	// stable; mute-first matches what the config was previously flattened to when applied.
-	out := make([]TimeInterval, 0, len(muteIntervals)+len(timeIntervals))
+	// Fold the deprecated mute time intervals into time intervals. Merging both lists under one set
+	// of UIDs is safe because Config rejects duplicate names across them at unmarshal time, so no
+	// definition can silently overwrite another here.
+	out := make(map[ResourceUID]TimeInterval, len(muteIntervals)+len(timeIntervals))
 	for _, interval := range muteIntervals {
-		out = append(out, TimeInterval(interval))
+		ti := NewTimeInterval(interval.Name, interval.TimeIntervals, models.ProvenanceNone)
+		out[ti.UID] = ti
 	}
 	for _, interval := range timeIntervals {
-		out = append(out, TimeInterval(interval))
+		ti := NewTimeInterval(interval.Name, interval.TimeIntervals, models.ProvenanceNone)
+		out[ti.UID] = ti
 	}
 	return out
 }
@@ -208,7 +210,7 @@ func ToDBModel(in *AMConfigV1) (*AMConfigDB, error) {
 	}
 	dbModel := AMConfigDB{
 		ManagedTemplates:   TemplatesToManagedTemplates(in.Templates),
-		AlertmanagerConfig: PostableApiAlertingConfigToDB(in.AlertmanagerConfig),
+		AlertmanagerConfig: PostableApiAlertingConfigToDB(in.AlertmanagerConfig, in.SortedTimeIntervals()),
 		ExtraConfigs:       ExtraConfigsToDB(in.ExtraConfigs),
 		ManagedRoutes:      ManagedRoutesToDB(in.ManagedRoutes),
 	}
@@ -223,27 +225,29 @@ func ToDBModel(in *AMConfigV1) (*AMConfigDB, error) {
 	return &dbModel, errors.Join(errs...)
 }
 
-func PostableApiAlertingConfigToDB(in PostableApiAlertingConfig) definition.PostableApiAlertingConfig {
+func PostableApiAlertingConfigToDB(in PostableApiAlertingConfig, timeIntervals []TimeInterval) definition.PostableApiAlertingConfig {
 	return definition.PostableApiAlertingConfig{
 		Config: definition.Config{
-			Global:        in.Global,
-			Route:         RouteToDB(in.Route),
-			InhibitRules:  slices.Clone(in.InhibitRules),
-			Templates:     slices.Clone(in.Templates),
-			TimeIntervals: TimeIntervalsToDB(in.TimeIntervals),
+			Global:       in.Global,
+			Route:        RouteToDB(in.Route),
+			InhibitRules: slices.Clone(in.InhibitRules),
+			Templates:    slices.Clone(in.Templates),
+			// This conversion can be lossy since we don't track whether the TimeInterval came from MuteTimeInterval or TimeInterval.
+			TimeIntervals: TimeIntervalsToDB(timeIntervals),
 		},
 		Receivers: ReceiversToDB(in.Receivers),
 	}
 }
 
 func TimeIntervalsToDB(in []TimeInterval) []config.TimeInterval {
-	if in == nil {
+	// Keep the DB model free of an empty time_intervals array when there are none.
+	if len(in) == 0 {
 		return nil
 	}
 	out := make([]config.TimeInterval, 0, len(in))
 	for _, interval := range in {
 		out = append(out, config.TimeInterval{
-			Name:          interval.Name,
+			Name:          interval.Title,
 			TimeIntervals: interval.TimeIntervals,
 		})
 	}

--- a/pkg/services/ngalert/notifier/legacy_storage/v1/compat_test.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/v1/compat_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -244,13 +245,14 @@ inhibit_rules:
 	require.NotNil(t, convertedDB)
 
 	// The round-trip is lossless except that deprecated mute_time_intervals are folded into
-	// time_intervals (mute first) by design, so build the expectation from the same fold.
-	folderIntervals := make([]config.TimeInterval, 0, len(originalDB.AlertmanagerConfig.MuteTimeIntervals)+len(originalDB.AlertmanagerConfig.TimeIntervals))
+	// time_intervals (sorted by name) by design, so build the expectation from the same fold.
 	for _, mt := range originalDB.AlertmanagerConfig.MuteTimeIntervals {
-		folderIntervals = append(folderIntervals, config.TimeInterval(mt))
+		originalDB.AlertmanagerConfig.TimeIntervals = append(originalDB.AlertmanagerConfig.TimeIntervals, config.TimeInterval(mt))
 	}
-	originalDB.AlertmanagerConfig.TimeIntervals = append(folderIntervals, originalDB.AlertmanagerConfig.TimeIntervals...)
 	originalDB.AlertmanagerConfig.MuteTimeIntervals = nil
+	slices.SortFunc(originalDB.AlertmanagerConfig.TimeIntervals, func(a, b config.TimeInterval) int {
+		return strings.Compare(a.Name, b.Name)
+	})
 
 	diff := cmp.Diff(originalDB, convertedDB, cmpopts.IgnoreUnexported(AMConfigDB{}, definition.Route{}, labels.Matcher{}))
 	if diff != "" {

--- a/pkg/services/ngalert/notifier/legacy_storage/v1/model.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/v1/model.go
@@ -11,7 +11,6 @@ import (
 	"github.com/grafana/alerting/definition/compat"
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/pkg/labels"
-	"github.com/prometheus/alertmanager/timeinterval"
 	"github.com/prometheus/common/model"
 	"go.yaml.in/yaml/v3"
 
@@ -23,8 +22,10 @@ type AMConfigDB = definitions.PostableUserConfig // TODO: Define type explicitly
 
 // AMConfigV1 is an exact structural copy of PostableUserConfig without json tags.
 type AMConfigV1 struct {
-	Templates          map[ResourceUID]TemplateGroup
-	InhibitionRules    map[ResourceUID]InhibitionRule
+	Templates       map[ResourceUID]TemplateGroup
+	InhibitionRules map[ResourceUID]InhibitionRule
+	TimeIntervals   map[ResourceUID]TimeInterval
+
 	AlertmanagerConfig PostableApiAlertingConfig
 	ExtraConfigs       []ExtraConfiguration
 	ManagedRoutes      ManagedRoutes
@@ -63,6 +64,11 @@ func (c *AMConfigV1) Validate() error {
 		}
 	}
 	for _, r := range c.InhibitionRules {
+		if err := r.Validate(); err != nil {
+			return err
+		}
+	}
+	for _, r := range c.TimeIntervals {
 		if err := r.Validate(); err != nil {
 			return err
 		}
@@ -120,7 +126,14 @@ func (c *ExtraAlertmanagerConfig) ToGrafanaRoute() *Route {
 
 // ToGrafanaTimeIntervals converts the imported time intervals to Grafana's type.
 func (c *ExtraAlertmanagerConfig) ToGrafanaTimeIntervals() []TimeInterval {
-	return TimeIntervalsToModel(c.MuteTimeIntervals, c.TimeIntervals)
+	out := make([]TimeInterval, 0, len(c.MuteTimeIntervals)+len(c.TimeIntervals))
+	for _, interval := range c.MuteTimeIntervals {
+		out = append(out, NewTimeInterval(interval.Name, interval.TimeIntervals, models.ProvenanceNone))
+	}
+	for _, interval := range c.TimeIntervals {
+		out = append(out, NewTimeInterval(interval.Name, interval.TimeIntervals, models.ProvenanceNone))
+	}
+	return out
 }
 
 // ReceiverNameStubs returns the imported receivers as Grafana receivers populated with only
@@ -274,8 +287,6 @@ func (c *PostableApiAlertingConfig) GetReceivers() []*PostableApiReceiver {
 	return c.Receivers
 }
 
-func (c *PostableApiAlertingConfig) GetTimeIntervals() []TimeInterval { return c.TimeIntervals }
-
 func (c *PostableApiAlertingConfig) GetRoute() *Route {
 	return c.Route
 }
@@ -329,12 +340,7 @@ type Config struct {
 	Global       *config.GlobalConfig
 	Route        *Route
 	InhibitRules []config.InhibitRule
-
-	// TimeIntervals holds both the deprecated mute_time_intervals and time_intervals stored in the
-	// database, folded into one list with the mute intervals first. The split is not preserved: on
-	// save everything is written back as time_intervals.
-	TimeIntervals []TimeInterval
-	Templates     []string
+	Templates    []string
 }
 
 type ObjectMatchers labels.Matchers
@@ -498,19 +504,6 @@ func (r *Route) ResourceID() string {
 }
 
 type Provenance string
-
-type TimeInterval struct {
-	Name          string
-	TimeIntervals []timeinterval.TimeInterval
-}
-
-func (mt *TimeInterval) ResourceType() string {
-	return "muteTimeInterval" // Intentionally kept as-is for backwards compatibility.
-}
-
-func (mt *TimeInterval) ResourceID() string {
-	return mt.Name
-}
 
 type PostableApiReceiver struct {
 	Name                    string

--- a/pkg/services/ngalert/notifier/legacy_storage/v1/model_test.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/v1/model_test.go
@@ -150,8 +150,8 @@ func TestExtraAlertmanagerConfig_ToGrafanaTimeIntervals(t *testing.T) {
 
 	times := c.ToGrafanaTimeIntervals()
 	require.Len(t, times, 2)
-	assert.Equal(t, "weekends", times[0].Name)
-	assert.Equal(t, "business-hours", times[1].Name)
+	assert.Equal(t, "weekends", times[0].Title)
+	assert.Equal(t, "business-hours", times[1].Title)
 }
 
 func TestExtraAlertmanagerConfig_ReceiverNameStubs(t *testing.T) {

--- a/pkg/services/ngalert/notifier/legacy_storage/v1/time_interval.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/v1/time_interval.go
@@ -1,0 +1,131 @@
+package v1
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"slices"
+	"strings"
+	"unsafe"
+
+	"github.com/prometheus/alertmanager/timeinterval"
+	"go.yaml.in/yaml/v3"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+)
+
+type TimeInterval struct {
+	ResourceMetadata
+
+	Title         string
+	TimeIntervals []timeinterval.TimeInterval // TODO: Replace with local types.
+}
+
+func (mt *TimeInterval) ResourceType() string {
+	return "muteTimeInterval" // Intentionally kept as-is for backwards compatibility.
+}
+
+func (mt *TimeInterval) ResourceID() string {
+	return mt.Title
+}
+
+func (mt *TimeInterval) Validate() error {
+	if mt.Title == "" {
+		return errors.New("missing name in time interval")
+	}
+
+	// For now, we rely on the upstream validation in marshallers, but we should eventually create local types and move
+	// the logic to explicit Validate() methods.
+	s, err := yaml.Marshal(mt.TimeIntervals)
+	if err != nil {
+		return err
+	}
+	if err = yaml.Unmarshal(s, &(mt.TimeIntervals)); err != nil {
+		return err
+	}
+	return nil
+}
+
+// SortedTimeIntervals returns time intervals ordered by title.
+func (c *AMConfigV1) SortedTimeIntervals() []TimeInterval {
+	res := make([]TimeInterval, 0, len(c.TimeIntervals))
+	for _, t := range c.TimeIntervals {
+		res = append(res, t)
+	}
+
+	return slices.SortedFunc(slices.Values(res), func(a TimeInterval, b TimeInterval) int {
+		return strings.Compare(a.Title, b.Title)
+	})
+}
+
+func NewTimeInterval(name string, intervals []timeinterval.TimeInterval, provenance models.Provenance) TimeInterval {
+	ti := TimeInterval{
+		ResourceMetadata: ResourceMetadata{
+			UID:        TimeIntervalUID(name),
+			Provenance: provenance,
+		},
+		Title:         name,
+		TimeIntervals: slices.Clone(intervals),
+	}
+	ti.Version = TimeIntervalFingerprint(ti)
+	return ti
+}
+
+func TimeIntervalUID(name string) ResourceUID {
+	return ResourceUID(models.NameToUid(name))
+}
+
+func TimeIntervalFingerprint(interval TimeInterval) string {
+	sum := fnv.New64()
+
+	writeBytes := func(b []byte) {
+		_, _ = sum.Write(b)
+		// add a byte sequence that cannot happen in UTF-8 strings.
+		_, _ = sum.Write([]byte{255})
+	}
+	writeString := func(s string) {
+		if len(s) == 0 {
+			writeBytes(nil)
+			return
+		}
+		// avoid allocation when converting string to byte slice
+		writeBytes(unsafe.Slice(unsafe.StringData(s), len(s))) // #nosec G103 nosemgrep: go.lang.security.audit.unsafe.use-of-unsafe-block
+	}
+	// this temp slice is used to convert ints to bytes.
+	tmp := make([]byte, 8)
+	writeInt := func(u int) {
+		binary.LittleEndian.PutUint64(tmp, uint64(u))
+		writeBytes(tmp)
+	}
+
+	writeRange := func(r timeinterval.InclusiveRange) {
+		writeInt(r.Begin)
+		writeInt(r.End)
+	}
+
+	// fields that determine the rule state
+	writeString(interval.Title)
+	for _, ti := range interval.TimeIntervals {
+		for _, time := range ti.Times {
+			writeInt(time.StartMinute)
+			writeInt(time.EndMinute)
+		}
+		for _, itm := range ti.Months {
+			writeRange(itm.InclusiveRange)
+		}
+		for _, itm := range ti.DaysOfMonth {
+			writeRange(itm.InclusiveRange)
+		}
+		for _, itm := range ti.Weekdays {
+			writeRange(itm.InclusiveRange)
+		}
+		for _, itm := range ti.Years {
+			writeRange(itm.InclusiveRange)
+		}
+		if ti.Location != nil {
+			writeString(ti.Location.String())
+		}
+	}
+	return fmt.Sprintf("%016x", sum.Sum64())
+}

--- a/pkg/services/ngalert/notifier/legacy_storage/v1/time_interval_test.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/v1/time_interval_test.go
@@ -1,0 +1,371 @@
+package v1
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/prometheus/alertmanager/timeinterval"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+)
+
+func inclusive(begin, end int) timeinterval.InclusiveRange {
+	return timeinterval.InclusiveRange{Begin: begin, End: end}
+}
+
+func TestTimeInterval_Validate(t *testing.T) {
+	utc, err := time.LoadLocation("UTC")
+	require.NoError(t, err)
+
+	tt := []struct {
+		name      string
+		interval  TimeInterval
+		expErrMsg string
+	}{
+		{
+			name: "valid interval passes",
+			interval: TimeInterval{
+				Title: "business-hours",
+				TimeIntervals: []timeinterval.TimeInterval{
+					{
+						Times:       []timeinterval.TimeRange{{StartMinute: 540, EndMinute: 1020}},
+						Weekdays:    []timeinterval.WeekdayRange{{InclusiveRange: inclusive(1, 5)}},
+						DaysOfMonth: []timeinterval.DayOfMonthRange{{InclusiveRange: inclusive(1, 15)}},
+						Months:      []timeinterval.MonthRange{{InclusiveRange: inclusive(1, 6)}},
+						Years:       []timeinterval.YearRange{{InclusiveRange: inclusive(2024, 2025)}},
+						Location:    &timeinterval.Location{Location: utc},
+					},
+				},
+			},
+		},
+		{
+			name:     "interval without any time intervals passes",
+			interval: TimeInterval{Title: "empty"},
+		},
+		{
+			name: "interval with an empty time interval passes",
+			interval: TimeInterval{
+				Title:         "empty-element",
+				TimeIntervals: []timeinterval.TimeInterval{{}},
+			},
+		},
+		{
+			name: "negative days of month are allowed",
+			interval: TimeInterval{
+				Title: "end-of-month",
+				TimeIntervals: []timeinterval.TimeInterval{
+					{DaysOfMonth: []timeinterval.DayOfMonthRange{{InclusiveRange: inclusive(-3, -1)}}},
+				},
+			},
+		},
+		{
+			name: "end minute at end of day is allowed",
+			interval: TimeInterval{
+				Title: "until-midnight",
+				TimeIntervals: []timeinterval.TimeInterval{
+					{Times: []timeinterval.TimeRange{{StartMinute: 1020, EndMinute: 1440}}},
+				},
+			},
+		},
+		{
+			name:      "fails when title is empty",
+			interval:  TimeInterval{Title: ""},
+			expErrMsg: "missing name in time interval",
+		},
+		{
+			name: "fails when start time is not before end time",
+			interval: TimeInterval{
+				Title: "inverted-times",
+				TimeIntervals: []timeinterval.TimeInterval{
+					{Times: []timeinterval.TimeRange{{StartMinute: 1020, EndMinute: 540}}},
+				},
+			},
+			expErrMsg: "start time cannot be equal or greater than end time",
+		},
+		{
+			name: "fails when time range is zero valued",
+			interval: TimeInterval{
+				Title: "zero-times",
+				TimeIntervals: []timeinterval.TimeInterval{
+					{Times: []timeinterval.TimeRange{{}}},
+				},
+			},
+			expErrMsg: "start time cannot be equal or greater than end time",
+		},
+		{
+			name: "fails when end minute is beyond the end of the day",
+			interval: TimeInterval{
+				Title: "overflowing-times",
+				TimeIntervals: []timeinterval.TimeInterval{
+					{Times: []timeinterval.TimeRange{{StartMinute: 540, EndMinute: 1500}}},
+				},
+			},
+			expErrMsg: "couldn't parse timestamp 25:00, invalid format",
+		},
+		{
+			name: "fails when weekday is out of range",
+			interval: TimeInterval{
+				Title: "invalid-weekday",
+				TimeIntervals: []timeinterval.TimeInterval{
+					{Weekdays: []timeinterval.WeekdayRange{{InclusiveRange: inclusive(1, 9)}}},
+				},
+			},
+			expErrMsg: "unable to convert 9 into weekday string",
+		},
+		{
+			name: "fails when weekday range is inverted",
+			interval: TimeInterval{
+				Title: "inverted-weekdays",
+				TimeIntervals: []timeinterval.TimeInterval{
+					{Weekdays: []timeinterval.WeekdayRange{{InclusiveRange: inclusive(5, 1)}}},
+				},
+			},
+			expErrMsg: "start day cannot be before end day",
+		},
+		{
+			name: "fails when day of month is out of range",
+			interval: TimeInterval{
+				Title: "invalid-day-of-month",
+				TimeIntervals: []timeinterval.TimeInterval{
+					{DaysOfMonth: []timeinterval.DayOfMonthRange{{InclusiveRange: inclusive(1, 32)}}},
+				},
+			},
+			expErrMsg: "32 is not a valid day of the month: out of range",
+		},
+		{
+			name: "fails when day of month has negative start but positive end",
+			interval: TimeInterval{
+				Title: "mixed-day-of-month",
+				TimeIntervals: []timeinterval.TimeInterval{
+					{DaysOfMonth: []timeinterval.DayOfMonthRange{{InclusiveRange: inclusive(-5, 5)}}},
+				},
+			},
+			expErrMsg: "end day must be negative if start day is negative",
+		},
+		{
+			name: "allows when day of month has positive start but negative end",
+			interval: TimeInterval{
+				Title: "mixed-day-of-month",
+				TimeIntervals: []timeinterval.TimeInterval{
+					{DaysOfMonth: []timeinterval.DayOfMonthRange{{InclusiveRange: inclusive(5, -5)}}},
+				},
+			},
+			expErrMsg: "",
+		},
+		{
+			name: "fails when month range is inverted",
+			interval: TimeInterval{
+				Title: "inverted-months",
+				TimeIntervals: []timeinterval.TimeInterval{
+					{Months: []timeinterval.MonthRange{{InclusiveRange: inclusive(6, 1)}}},
+				},
+			},
+			expErrMsg: "end month january is before start month june",
+		},
+		{
+			name: "fails when year range is inverted",
+			interval: TimeInterval{
+				Title: "inverted-years",
+				TimeIntervals: []timeinterval.TimeInterval{
+					{Years: []timeinterval.YearRange{{InclusiveRange: inclusive(2025, 2024)}}},
+				},
+			},
+			expErrMsg: "end year 2024 is before start year 2025",
+		},
+		{
+			name: "fails when location is set but empty",
+			interval: TimeInterval{
+				Title: "empty-location",
+				TimeIntervals: []timeinterval.TimeInterval{
+					{Location: &timeinterval.Location{}},
+				},
+			},
+			expErrMsg: "unable to convert nil location into string",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			gotErr := tc.interval.Validate()
+			if tc.expErrMsg != "" {
+				require.Error(t, gotErr)
+				require.ErrorContains(t, gotErr, tc.expErrMsg)
+			} else {
+				require.NoError(t, gotErr)
+			}
+		})
+	}
+
+	t.Run("validation is idempotent", func(t *testing.T) {
+		interval := TimeInterval{
+			Title: "test",
+			TimeIntervals: []timeinterval.TimeInterval{
+				{
+					Times:    []timeinterval.TimeRange{{StartMinute: 0, EndMinute: 1440}},
+					Weekdays: []timeinterval.WeekdayRange{{InclusiveRange: inclusive(3, 3)}},
+					Location: &timeinterval.Location{Location: utc},
+				},
+			},
+		}
+
+		require.NoError(t, interval.Validate())
+		first := TimeIntervalFingerprint(interval)
+		require.NoError(t, interval.Validate())
+		assert.Equal(t, first, TimeIntervalFingerprint(interval))
+	})
+}
+
+func TestTimeIntervalFingerprint(t *testing.T) {
+	baseInterval := func() TimeInterval {
+		return TimeInterval{
+			ResourceMetadata: ResourceMetadata{
+				UID:        TimeIntervalUID("business-hours"),
+				Version:    "some-version",
+				Provenance: models.ProvenanceAPI,
+			},
+			Title: "business-hours",
+			TimeIntervals: []timeinterval.TimeInterval{
+				{
+					Times:       []timeinterval.TimeRange{{StartMinute: 540, EndMinute: 1020}},
+					Weekdays:    []timeinterval.WeekdayRange{{InclusiveRange: inclusive(1, 5)}},
+					DaysOfMonth: []timeinterval.DayOfMonthRange{{InclusiveRange: inclusive(1, 15)}},
+					Months:      []timeinterval.MonthRange{{InclusiveRange: inclusive(1, 6)}},
+					Years:       []timeinterval.YearRange{{InclusiveRange: inclusive(2024, 2025)}},
+					Location:    &timeinterval.Location{Location: time.UTC},
+				},
+			},
+		}
+	}
+
+	t.Run("stable across code changes", func(t *testing.T) {
+		// If this is a valid fingerprint generation change, update the expected value.
+		assert.Equal(t, "07f0771de266d6d4", TimeIntervalFingerprint(baseInterval()))
+	})
+
+	t.Run("stable across equal values", func(t *testing.T) {
+		assert.Equal(t, TimeIntervalFingerprint(baseInterval()), TimeIntervalFingerprint(baseInterval()))
+	})
+
+	t.Run("stable for empty interval", func(t *testing.T) {
+		assert.Equal(t, TimeIntervalFingerprint(TimeInterval{}), TimeIntervalFingerprint(TimeInterval{}))
+	})
+
+	t.Run("nil and empty time intervals are equal", func(t *testing.T) {
+		nilIntervals := TimeInterval{Title: "test"}
+		emptyIntervals := TimeInterval{Title: "test", TimeIntervals: []timeinterval.TimeInterval{}}
+		assert.Equal(t, TimeIntervalFingerprint(nilIntervals), TimeIntervalFingerprint(emptyIntervals))
+	})
+
+	t.Run("stable across metadata modification", func(t *testing.T) {
+		fingerprint := TimeIntervalFingerprint(baseInterval())
+
+		metadataType := reflect.TypeOf(ResourceMetadata{})
+		otherMetadata := reflect.ValueOf(ResourceMetadata{
+			UID:        "some-other-uid",
+			Version:    "some-other-version",
+			Provenance: models.ProvenanceFile,
+		})
+		for i := 0; i < metadataType.NumField(); i++ {
+			field := metadataType.Field(i).Name
+			cp := baseInterval()
+
+			vf := reflect.ValueOf(&cp.ResourceMetadata).Elem().Field(i)
+			other := otherMetadata.Field(i)
+			require.NotEqualf(t, other.Interface(), vf.Interface(),
+				"ResourceMetadata field %s is the same as the original, test does not ensure stability across the field", field)
+			vf.Set(other)
+
+			assert.Equalf(t, fingerprint, TimeIntervalFingerprint(cp),
+				"ResourceMetadata field %s should not be part of the fingerprint", field)
+		}
+	})
+
+	t.Run("unstable across title modification", func(t *testing.T) {
+		cp := baseInterval()
+		cp.Title = "after-hours"
+		assert.NotEqual(t, TimeIntervalFingerprint(baseInterval()), TimeIntervalFingerprint(cp))
+	})
+
+	t.Run("unstable across time interval field modification", func(t *testing.T) {
+		fingerprint := TimeIntervalFingerprint(baseInterval())
+
+		other := timeinterval.TimeInterval{
+			Times:       []timeinterval.TimeRange{{StartMinute: 0, EndMinute: 300}},
+			Weekdays:    []timeinterval.WeekdayRange{{InclusiveRange: inclusive(6, 6)}},
+			DaysOfMonth: []timeinterval.DayOfMonthRange{{InclusiveRange: inclusive(20, 25)}},
+			Months:      []timeinterval.MonthRange{{InclusiveRange: inclusive(9, 12)}},
+			Years:       []timeinterval.YearRange{{InclusiveRange: inclusive(2030, 2031)}},
+			Location:    &timeinterval.Location{Location: time.FixedZone("Test/Zone", 3600)},
+		}
+		otherValue := reflect.ValueOf(other)
+
+		intervalType := reflect.TypeOf(timeinterval.TimeInterval{})
+		for i := 0; i < intervalType.NumField(); i++ {
+			field := intervalType.Field(i).Name
+			cp := baseInterval()
+
+			vf := reflect.ValueOf(&cp.TimeIntervals[0]).Elem().Field(i)
+			otherField := otherValue.Field(i)
+			require.NotEqualf(t, otherField.Interface(), vf.Interface(),
+				"TimeInterval field %s is the same as the original, test does not ensure instability across the field", field)
+			vf.Set(otherField)
+
+			assert.NotEqualf(t, fingerprint, TimeIntervalFingerprint(cp),
+				"TimeInterval field %s does not seem to be used in the fingerprint", field)
+		}
+	})
+
+	t.Run("unstable across cleared location", func(t *testing.T) {
+		cp := baseInterval()
+		cp.TimeIntervals[0].Location = nil
+		assert.NotEqual(t, TimeIntervalFingerprint(baseInterval()), TimeIntervalFingerprint(cp))
+	})
+
+	t.Run("unstable across added time interval", func(t *testing.T) {
+		cp := baseInterval()
+		cp.TimeIntervals = append(cp.TimeIntervals, timeinterval.TimeInterval{
+			Times: []timeinterval.TimeRange{{StartMinute: 0, EndMinute: 60}},
+		})
+		assert.NotEqual(t, TimeIntervalFingerprint(baseInterval()), TimeIntervalFingerprint(cp))
+	})
+
+	t.Run("unstable across reordered time intervals", func(t *testing.T) {
+		first := TimeInterval{
+			Title: "test",
+			TimeIntervals: []timeinterval.TimeInterval{
+				{Times: []timeinterval.TimeRange{{StartMinute: 0, EndMinute: 60}}},
+				{Months: []timeinterval.MonthRange{{InclusiveRange: inclusive(1, 2)}}},
+			},
+		}
+		second := TimeInterval{
+			Title:         "test",
+			TimeIntervals: []timeinterval.TimeInterval{first.TimeIntervals[1], first.TimeIntervals[0]},
+		}
+		assert.NotEqual(t, TimeIntervalFingerprint(first), TimeIntervalFingerprint(second))
+	})
+
+	t.Run("unstable across reordered times within a time interval", func(t *testing.T) {
+		first := TimeInterval{
+			Title: "test",
+			TimeIntervals: []timeinterval.TimeInterval{
+				{Times: []timeinterval.TimeRange{{StartMinute: 0, EndMinute: 60}, {StartMinute: 600, EndMinute: 660}}},
+			},
+		}
+		second := TimeInterval{
+			Title: "test",
+			TimeIntervals: []timeinterval.TimeInterval{
+				{Times: []timeinterval.TimeRange{{StartMinute: 600, EndMinute: 660}, {StartMinute: 0, EndMinute: 60}}},
+			},
+		}
+		assert.NotEqual(t, TimeIntervalFingerprint(first), TimeIntervalFingerprint(second))
+	})
+
+	t.Run("matches the version set by NewTimeInterval", func(t *testing.T) {
+		base := baseInterval()
+		created := NewTimeInterval(base.Title, base.TimeIntervals, models.ProvenanceNone)
+		assert.Equal(t, TimeIntervalFingerprint(base), created.Version)
+	})
+}

--- a/pkg/services/ngalert/notifier/merge/merge.go
+++ b/pkg/services/ngalert/notifier/merge/merge.go
@@ -140,11 +140,17 @@ func MergeExtraConfig(_ context.Context, cfg *v1.AMConfigV1) (v1.AMConfigV1, Mer
 	}
 	mergedReceivers, renamedReceivers, addedReceivers := Receivers(cfg.AlertmanagerConfig.Receivers, importedReceivers, mimirCfg.Identifier)
 
-	mergedTimeIntervals, renamedTimeIntervals, addedTimeIntervals := TimeIntervals(
-		cfg.AlertmanagerConfig.TimeIntervals,
+	mergedTimeIntervals, renamedTimeIntervals, addedTimeIntervalUIDs := TimeIntervals(
+		cfg.TimeIntervals,
 		mcfg.ToGrafanaTimeIntervals(),
 		mimirCfg.Identifier,
 	)
+	addedTimeIntervals := make([]string, 0, len(addedTimeIntervalUIDs))
+	for _, uid := range addedTimeIntervalUIDs {
+		if interval, ok := mergedTimeIntervals[uid]; ok {
+			addedTimeIntervals = append(addedTimeIntervals, interval.Title)
+		}
+	}
 
 	managedRoutes := make(v1.ManagedRoutes, len(cfg.ManagedRoutes)+1)
 	{
@@ -175,16 +181,16 @@ func MergeExtraConfig(_ context.Context, cfg *v1.AMConfigV1) (v1.AMConfigV1, Mer
 			Templates:    templates,
 			AlertmanagerConfig: v1.PostableApiAlertingConfig{
 				Config: v1.Config{
-					Global:        nil, // Grafana does not use global. The Global settings are set to the respective integrations at parse time.
-					Route:         cfg.AlertmanagerConfig.Route,
-					InhibitRules:  cfg.AlertmanagerConfig.InhibitRules,
-					TimeIntervals: mergedTimeIntervals,
-					Templates:     nil, // Grafana does not use this.
+					Global:       nil, // Grafana does not use global. The Global settings are set to the respective integrations at parse time.
+					Route:        cfg.AlertmanagerConfig.Route,
+					InhibitRules: cfg.AlertmanagerConfig.InhibitRules,
+					Templates:    nil, // Grafana does not use this.
 				},
 				Receivers: mergedReceivers,
 			},
 			ManagedRoutes:   managedRoutes,
 			InhibitionRules: managedInhibitionRules,
+			TimeIntervals:   mergedTimeIntervals,
 		}, MergeResult{
 			RenameResources:      RenameResources{Receivers: renamedReceivers, TimeIntervals: renamedTimeIntervals, Templates: renamedTemplates},
 			AddedRoute:           mimirCfg.Identifier,
@@ -197,8 +203,8 @@ func MergeExtraConfig(_ context.Context, cfg *v1.AMConfigV1) (v1.AMConfigV1, Mer
 
 // DeduplicateResources merges existing and incoming resources (receivers and time intervals) and ensures unique names by
 // appending a suffix derived from identifier. Returns renamed resources for tracking adjustments made.
-func DeduplicateResources(a v1.PostableApiAlertingConfig, b v1.ExtraAlertmanagerConfig, identifier string) RenameResources {
-	_, renamedReceivers, _ := Receivers(a.Receivers, b.ReceiverNameStubs(), identifier)
+func DeduplicateResources(a v1.AMConfigV1, b v1.ExtraAlertmanagerConfig, identifier string) RenameResources {
+	_, renamedReceivers, _ := Receivers(a.AlertmanagerConfig.Receivers, b.ReceiverNameStubs(), identifier)
 	_, renamedTimeIntervals, _ := TimeIntervals(
 		a.TimeIntervals,
 		b.ToGrafanaTimeIntervals(),
@@ -211,42 +217,43 @@ func DeduplicateResources(a v1.PostableApiAlertingConfig, b v1.ExtraAlertmanager
 // suffix derived from identifier. It returns a merged list of time intervals, a map of renamed interval names for
 // tracking adjustments made, and the final names of the incoming intervals (post-rename) in their original order.
 func TimeIntervals(
-	existing []v1.TimeInterval,
+	existing map[v1.ResourceUID]v1.TimeInterval,
 	incoming []v1.TimeInterval,
 	identifier string,
-) ([]v1.TimeInterval, map[string]string, []string) {
+) (map[v1.ResourceUID]v1.TimeInterval, map[string]string, []v1.ResourceUID) {
 	dedupSuffix := getDedupSuffix(identifier)
 	usedNames := createIndexTimeIntervals(existing, incoming)
-	result := make([]v1.TimeInterval, 0, len(existing)+len(incoming))
-	result = append(result, existing...)
+	result := make(map[v1.ResourceUID]v1.TimeInterval, len(existing)+len(incoming))
+	maps.Copy(result, existing)
 	renames := make(map[string]string)
-	added := make([]string, 0, len(incoming))
+	added := make([]v1.ResourceUID, 0, len(incoming))
 	for idx, interval := range incoming {
-		curName := interval.Name
+		curName := interval.Title
 		if i, ok := usedNames[curName]; ok && i != idx { // if the name is already used by another interval, append a suffix.
 			newName := getUniqueName(curName, dedupSuffix, usedNames)
 			renames[curName] = newName
 			usedNames[newName] = idx
-			interval.Name = newName
+			// Rebuild rather than assigning the title so UID and Version are recomputed from the new name.
+			interval = v1.NewTimeInterval(newName, interval.TimeIntervals, interval.Provenance)
 		}
-		added = append(added, interval.Name)
-		result = append(result, interval)
+		added = append(added, interval.UID)
+		result[interval.UID] = interval
 	}
 	return result, renames, added
 }
 
 func createIndexTimeIntervals(
-	existing []v1.TimeInterval,
+	existing map[v1.ResourceUID]v1.TimeInterval,
 	incoming []v1.TimeInterval,
 ) map[string]int {
 	// usedNames is a map of existing interval names where value is the index of the interval that holds the name in the incoming list.
 	usedNames := make(map[string]int, len(existing)+len(incoming))
 	for _, r := range existing {
-		usedNames[r.Name] = -1
+		usedNames[r.Title] = -1
 	}
 	for idx, r := range incoming {
-		if _, ok := usedNames[r.Name]; !ok {
-			usedNames[r.Name] = idx
+		if _, ok := usedNames[r.Title]; !ok {
+			usedNames[r.Title] = idx
 		}
 	}
 	return usedNames

--- a/pkg/services/ngalert/notifier/merge/merge_test.go
+++ b/pkg/services/ngalert/notifier/merge/merge_test.go
@@ -157,9 +157,14 @@ func TestReceivers(t *testing.T) {
 
 func TestTimeIntervals(t *testing.T) {
 	ti := func(name string) v1.TimeInterval {
-		return v1.TimeInterval{
-			Name: name,
+		return v1.NewTimeInterval(name, nil, models.ProvenanceNone)
+	}
+	toMap := func(intervals ...v1.TimeInterval) map[v1.ResourceUID]v1.TimeInterval {
+		m := make(map[v1.ResourceUID]v1.TimeInterval, len(intervals))
+		for _, interval := range intervals {
+			m[interval.UID] = interval
 		}
+		return m
 	}
 
 	identifier := "dupe"
@@ -171,9 +176,9 @@ func TestTimeIntervals(t *testing.T) {
 		name            string
 		existing        []v1.TimeInterval
 		incoming        []v1.TimeInterval
-		expected        []v1.TimeInterval
+		expected        map[v1.ResourceUID]v1.TimeInterval
 		expectedRenames map[string]string
-		expectedAdded   []string
+		expectedAdded   []v1.ResourceUID
 	}{
 		{
 			name: "should append copies of incoming to existing time intervals",
@@ -185,14 +190,17 @@ func TestTimeIntervals(t *testing.T) {
 				ti("mti3"),
 				ti("ti4"),
 			},
-			expected: []v1.TimeInterval{
+			expected: toMap(
 				ti("mti1"),
 				ti("ti2"),
 				ti("mti3"),
 				ti("ti4"),
-			},
+			),
 			expectedRenames: map[string]string{},
-			expectedAdded:   []string{"mti3", "ti4"},
+			expectedAdded: []v1.ResourceUID{
+				v1.TimeIntervalUID("mti3"),
+				v1.TimeIntervalUID("ti4"),
+			},
 		},
 		{
 			name: "should rename incoming if there is existing",
@@ -204,17 +212,20 @@ func TestTimeIntervals(t *testing.T) {
 				ti("ti2"),
 				ti("mti1"),
 			},
-			expected: []v1.TimeInterval{
+			expected: toMap(
 				ti("mti1"),
 				ti("ti2"),
-				ti("ti2" + suffix),
-				ti("mti1" + suffix),
-			},
+				ti("ti2"+suffix),
+				ti("mti1"+suffix),
+			),
 			expectedRenames: map[string]string{
 				"ti2":  "ti2" + suffix,
 				"mti1": "mti1" + suffix,
 			},
-			expectedAdded: []string{"ti2" + suffix, "mti1" + suffix},
+			expectedAdded: []v1.ResourceUID{
+				v1.TimeIntervalUID("ti2" + suffix),
+				v1.TimeIntervalUID("mti1" + suffix),
+			},
 		},
 		{
 			name: "should rename incoming if there is existing after dedup",
@@ -226,17 +237,20 @@ func TestTimeIntervals(t *testing.T) {
 				ti("ti1"),
 				ti("ti1" + suffix),
 			},
-			expected: []v1.TimeInterval{
+			expected: toMap(
 				ti("ti1"),
-				ti("ti1" + suffix),
-				ti("ti1" + suffix + "_01"),
-				ti("ti1" + suffix + suffix),
-			},
+				ti("ti1"+suffix),
+				ti("ti1"+suffix+"_01"),
+				ti("ti1"+suffix+suffix),
+			),
 			expectedRenames: map[string]string{
 				"ti1" + suffix: "ti1" + suffix + suffix,
 				"ti1":          "ti1" + suffix + "_01",
 			},
-			expectedAdded: []string{"ti1" + suffix + "_01", "ti1" + suffix + suffix},
+			expectedAdded: []v1.ResourceUID{
+				v1.TimeIntervalUID("ti1" + suffix + "_01"),
+				v1.TimeIntervalUID("ti1" + suffix + suffix),
+			},
 		},
 		{
 			name: "should rename dupe among incoming",
@@ -247,15 +261,18 @@ func TestTimeIntervals(t *testing.T) {
 				ti("ti2"),
 				ti("ti2"),
 			},
-			expected: []v1.TimeInterval{
+			expected: toMap(
 				ti("ti2"),
-				ti("ti2" + suffix),
-				ti("ti2" + suffix + "_01"),
-			},
+				ti("ti2"+suffix),
+				ti("ti2"+suffix+"_01"),
+			),
 			expectedRenames: map[string]string{
 				"ti2": "ti2" + suffix + "_01",
 			},
-			expectedAdded: []string{"ti2" + suffix, "ti2" + suffix + "_01"},
+			expectedAdded: []v1.ResourceUID{
+				v1.TimeIntervalUID("ti2" + suffix),
+				v1.TimeIntervalUID("ti2" + suffix + "_01"),
+			},
 		},
 		{
 			name: "should ensure uniqueness across existing and incoming",
@@ -268,30 +285,34 @@ func TestTimeIntervals(t *testing.T) {
 				ti("ti1"),
 				ti("ti2"),
 			},
-			expected: []v1.TimeInterval{
+			expected: toMap(
 				ti("ti1"),
-				ti("ti1" + suffix),
-				ti("ti1" + suffix + "_01"),
-				ti("ti1" + suffix + "_02"),
+				ti("ti1"+suffix),
+				ti("ti1"+suffix+"_01"),
+				ti("ti1"+suffix+"_02"),
 				ti("ti2"),
-			},
+			),
 			expectedRenames: map[string]string{
 				"ti1": "ti1" + suffix + "_02",
 			},
-			expectedAdded: []string{"ti1" + suffix + "_01", "ti1" + suffix + "_02", "ti2"},
+			expectedAdded: []v1.ResourceUID{
+				v1.TimeIntervalUID("ti1" + suffix + "_01"),
+				v1.TimeIntervalUID("ti1" + suffix + "_02"),
+				v1.TimeIntervalUID("ti2"),
+			},
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			var existingNames, incomingNames []string
 			for _, r := range tc.existing {
-				existingNames = append(existingNames, r.Name)
+				existingNames = append(existingNames, r.Title)
 			}
 			for _, r := range tc.incoming {
-				incomingNames = append(incomingNames, r.Name)
+				incomingNames = append(incomingNames, r.Title)
 			}
 
-			actualTimeIntervals, actualRenames, actualAdded := TimeIntervals(tc.existing, tc.incoming, identifier)
+			actualTimeIntervals, actualRenames, actualAdded := TimeIntervals(toMap(tc.existing...), tc.incoming, identifier)
 			assert.Equal(t, tc.expected, actualTimeIntervals)
 			assert.EqualValues(t, tc.expectedRenames, actualRenames)
 			assert.Equal(t, tc.expectedAdded, actualAdded)
@@ -299,12 +320,12 @@ func TestTimeIntervals(t *testing.T) {
 			// check that existing and incoming lists are not changed
 			var names []string
 			for _, r := range tc.existing {
-				names = append(names, r.Name)
+				names = append(names, r.Title)
 			}
 			assert.Equal(t, existingNames, names)
 			names = nil
 			for _, r := range tc.incoming {
-				names = append(names, r.Name)
+				names = append(names, r.Title)
 			}
 			assert.Equal(t, incomingNames, names)
 		})

--- a/pkg/services/ngalert/notifier/merge/testdata/merged_config.json
+++ b/pkg/services/ngalert/notifier/merge/testdata/merged_config.json
@@ -65,17 +65,6 @@
         ]
       },
       {
-        "name": "ti-1",
-        "time_intervals": [
-          {
-            "weekdays": [
-              "saturday",
-              "sunday"
-            ]
-          }
-        ]
-      },
-      {
         "name": "mti-2",
         "time_intervals": [
           {
@@ -84,6 +73,17 @@
                 "start_time": "00:00",
                 "end_time": "12:00"
               }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "ti-1",
+        "time_intervals": [
+          {
+            "weekdays": [
+              "saturday",
+              "sunday"
             ]
           }
         ]

--- a/pkg/services/ngalert/notifier/merge/testdata/merged_no_intervals.json
+++ b/pkg/services/ngalert/notifier/merge/testdata/merged_no_intervals.json
@@ -65,17 +65,6 @@
         ]
       },
       {
-        "name": "ti-1",
-        "time_intervals": [
-          {
-            "weekdays": [
-              "saturday",
-              "sunday"
-            ]
-          }
-        ]
-      },
-      {
         "name": "mti-2",
         "time_intervals": [
           {
@@ -84,6 +73,17 @@
                 "start_time": "00:00",
                 "end_time": "12:00"
               }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "ti-1",
+        "time_intervals": [
+          {
+            "weekdays": [
+              "saturday",
+              "sunday"
             ]
           }
         ]

--- a/pkg/services/ngalert/notifier/merge/testdata/merged_renamed_intervals.json
+++ b/pkg/services/ngalert/notifier/merge/testdata/merged_renamed_intervals.json
@@ -65,6 +65,10 @@
         ]
       },
       {
+        "name": "mti-1_mimir-12345",
+        "time_intervals": null
+      },
+      {
         "name": "ti-1",
         "time_intervals": [
           {
@@ -92,10 +96,6 @@
             ]
           }
         ]
-      },
-      {
-        "name": "mti-1_mimir-12345",
-        "time_intervals": null
       }
     ],
     "receivers": [

--- a/pkg/services/ngalert/notifier/merge/testdata/merged_renamed_receiver.json
+++ b/pkg/services/ngalert/notifier/merge/testdata/merged_renamed_receiver.json
@@ -65,17 +65,6 @@
         ]
       },
       {
-        "name": "ti-1",
-        "time_intervals": [
-          {
-            "weekdays": [
-              "saturday",
-              "sunday"
-            ]
-          }
-        ]
-      },
-      {
         "name": "mti-2",
         "time_intervals": [
           {
@@ -84,6 +73,17 @@
                 "start_time": "00:00",
                 "end_time": "12:00"
               }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "ti-1",
+        "time_intervals": [
+          {
+            "weekdays": [
+              "saturday",
+              "sunday"
             ]
           }
         ]

--- a/pkg/services/ngalert/notifier/merge/testdata/merged_suffixed_receiver.json
+++ b/pkg/services/ngalert/notifier/merge/testdata/merged_suffixed_receiver.json
@@ -65,17 +65,6 @@
         ]
       },
       {
-        "name": "ti-1",
-        "time_intervals": [
-          {
-            "weekdays": [
-              "saturday",
-              "sunday"
-            ]
-          }
-        ]
-      },
-      {
         "name": "mti-2",
         "time_intervals": [
           {
@@ -84,6 +73,17 @@
                 "start_time": "00:00",
                 "end_time": "12:00"
               }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "ti-1",
+        "time_intervals": [
+          {
+            "weekdays": [
+              "saturday",
+              "sunday"
             ]
           }
         ]

--- a/pkg/services/ngalert/notifier/validation.go
+++ b/pkg/services/ngalert/notifier/validation.go
@@ -69,8 +69,8 @@ func newStaticContactPointValidator(am *v1.AMConfigV1) staticContactPointValidat
 	}
 
 	availableTimeIntervals := make(map[string]struct{})
-	for _, interval := range am.AlertmanagerConfig.TimeIntervals {
-		availableTimeIntervals[interval.Name] = struct{}{}
+	for _, interval := range am.TimeIntervals {
+		availableTimeIntervals[interval.Title] = struct{}{}
 	}
 
 	return staticContactPointValidator{

--- a/pkg/services/ngalert/provisioning/errors.go
+++ b/pkg/services/ngalert/provisioning/errors.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
-	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
 )
@@ -141,8 +140,8 @@ func makeErrTemplateOrigin(t v1.TemplateGroup, action string) error {
 	return ErrTemplateOrigin.Build(errutil.TemplateData{Public: map[string]interface{}{"Action": action, "Name": t.Title}})
 }
 
-func makeErrMuteTimeIntervalOrigin(mt definitions.MuteTimeInterval, action string) error {
+func makeErrMuteTimeIntervalOrigin(mt v1.TimeInterval, action string) error {
 	return ErrTimeIntervalOrigin.Build(errutil.TemplateData{
-		Public: map[string]interface{}{"Action": action, "Name": mt.Name},
+		Public: map[string]interface{}{"Action": action, "Name": mt.Title},
 	})
 }

--- a/pkg/services/ngalert/provisioning/mute_timings.go
+++ b/pkg/services/ngalert/provisioning/mute_timings.go
@@ -2,20 +2,11 @@ package provisioning
 
 import (
 	"context"
-	"encoding/binary"
-	"errors"
-	"fmt"
-	"hash/fnv"
 	"maps"
 	"slices"
 	"strings"
-	"unsafe"
-
-	"github.com/prometheus/alertmanager/config"
-	"github.com/prometheus/alertmanager/timeinterval"
 
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
 	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
@@ -72,189 +63,163 @@ func (svc *MuteTimingService) WithIncludeImported() *MuteTimingService {
 }
 
 // GetMuteTimings returns a slice of all mute timings within the specified org.
-func (svc *MuteTimingService) GetMuteTimings(ctx context.Context, orgID int64) ([]definitions.MuteTimeInterval, error) {
+func (svc *MuteTimingService) GetMuteTimings(ctx context.Context, orgID int64) ([]v1.TimeInterval, error) {
 	rev, err := svc.configStore.Get(ctx, orgID)
 	if err != nil {
 		return nil, err
 	}
 
-	grafanaIntervals := getGrafanaTimeIntervals(rev)
-	importedIntervals := svc.getImportedTimeIntervals(rev)
-
-	if len(grafanaIntervals)+len(importedIntervals) == 0 {
-		return []definitions.MuteTimeInterval{}, nil
-	}
-
-	provenances, err := svc.provenanceStore.GetProvenances(ctx, orgID, (&definitions.MuteTimeInterval{}).ResourceType())
-	if err != nil {
+	if err := svc.assignTimeIntervalProvenance(ctx, orgID, rev); err != nil {
 		return nil, err
 	}
 
-	result := make([]definitions.MuteTimeInterval, 0, len(grafanaIntervals))
+	grafanaIntervals := rev.Config.TimeIntervals
+	importedIntervals := svc.getImportedTimeIntervals(rev)
+
+	if len(grafanaIntervals)+len(importedIntervals) == 0 {
+		return []v1.TimeInterval{}, nil
+	}
+
+	result := make([]v1.TimeInterval, 0, len(grafanaIntervals)+len(importedIntervals))
 	for _, interval := range grafanaIntervals {
-		prov, ok := provenances[(&definitions.MuteTimeInterval{MuteTimeInterval: config.MuteTimeInterval(interval)}).ResourceID()]
-		if !ok {
-			prov = models.ProvenanceNone
-		}
-
-		result = append(result, newMuteTimingInterval(interval, definitions.Provenance(prov)))
+		result = append(result, interval)
 	}
 
-	for _, interval := range importedIntervals {
-		result = append(result, newMuteTimingInterval(interval, definitions.Provenance(models.ProvenanceConvertedPrometheus)))
-	}
+	result = append(result, importedIntervals...)
 
-	slices.SortFunc(result, func(a, b definitions.MuteTimeInterval) int {
-		return strings.Compare(a.Name, b.Name)
+	slices.SortFunc(result, func(a, b v1.TimeInterval) int {
+		return strings.Compare(a.Title, b.Title)
 	})
 
 	return result, nil
 }
 
 // GetMuteTimingByUID returns a mute timing by UID
-func (svc *MuteTimingService) GetMuteTimingByUID(ctx context.Context, uid string, orgID int64) (definitions.MuteTimeInterval, error) {
+func (svc *MuteTimingService) GetMuteTimingByUID(ctx context.Context, uid v1.ResourceUID, orgID int64) (v1.TimeInterval, error) {
 	revision, err := svc.configStore.Get(ctx, orgID)
 	if err != nil {
-		return definitions.MuteTimeInterval{}, err
+		return v1.TimeInterval{}, err
 	}
 
-	result, found, err := svc.getMuteTimingByUID(ctx, revision, orgID, uid)
-	if err != nil {
-		return definitions.MuteTimeInterval{}, err
+	if err := svc.assignTimeIntervalProvenance(ctx, orgID, revision); err != nil {
+		return v1.TimeInterval{}, err
 	}
-	if found {
+
+	if result, found := svc.getMuteTimingByUID(revision, uid); found {
 		return result, nil
 	}
 
-	return definitions.MuteTimeInterval{}, ErrTimeIntervalNotFound.Errorf("")
+	return v1.TimeInterval{}, ErrTimeIntervalNotFound.Errorf("")
 }
 
 // GetMuteTimingByName returns a mute timing by name.
-func (svc *MuteTimingService) GetMuteTimingByName(ctx context.Context, name string, orgID int64) (definitions.MuteTimeInterval, error) {
+func (svc *MuteTimingService) GetMuteTimingByName(ctx context.Context, name string, orgID int64) (v1.TimeInterval, error) {
 	revision, err := svc.configStore.Get(ctx, orgID)
 	if err != nil {
-		return definitions.MuteTimeInterval{}, err
+		return v1.TimeInterval{}, err
 	}
 
-	mti, found, err := svc.getMuteTimingByName(ctx, revision, orgID, name)
-	if err != nil {
-		return definitions.MuteTimeInterval{}, err
-	} else if !found {
-		return definitions.MuteTimeInterval{}, ErrTimeIntervalNotFound.Errorf("")
+	if err := svc.assignTimeIntervalProvenance(ctx, orgID, revision); err != nil {
+		return v1.TimeInterval{}, err
 	}
 
-	return mti, nil
-}
-
-// getMuteTiming is a helper that tries to get a mute timing by name first, then UID if not found by name.
-func (svc *MuteTimingService) getMuteTiming(ctx context.Context, revision *legacy_storage.ConfigRevision, nameOrUID string, orgID int64) (definitions.MuteTimeInterval, error) {
-	result, found, err := svc.getMuteTimingByName(ctx, revision, orgID, nameOrUID)
-	if err != nil {
-		return definitions.MuteTimeInterval{}, err
-	}
-	if found {
-		return result, nil
+	if mti, found := revision.GetTimeIntervalWithTitle(name); found {
+		return mti, nil
 	}
 
-	result, found, err = svc.getMuteTimingByUID(ctx, revision, orgID, nameOrUID)
-	if err != nil {
-		return definitions.MuteTimeInterval{}, err
-	}
-	if found {
-		return result, nil
-	}
-
-	return definitions.MuteTimeInterval{}, ErrTimeIntervalNotFound.Errorf("")
+	return v1.TimeInterval{}, ErrTimeIntervalNotFound.Errorf("")
 }
 
 // CreateMuteTiming adds a new mute timing within the specified org. The created mute timing is returned.
-func (svc *MuteTimingService) CreateMuteTiming(ctx context.Context, mt definitions.MuteTimeInterval, orgID int64) (definitions.MuteTimeInterval, error) {
+func (svc *MuteTimingService) CreateMuteTiming(ctx context.Context, mt v1.TimeInterval, orgID int64) (v1.TimeInterval, error) {
 	if err := mt.Validate(); err != nil {
-		return definitions.MuteTimeInterval{}, MakeErrTimeIntervalInvalid(err)
+		return v1.TimeInterval{}, MakeErrTimeIntervalInvalid(err)
 	}
 
-	if err := svc.validator(ctx, models.ProvenanceNone, models.Provenance(mt.Provenance)); err != nil {
-		return definitions.MuteTimeInterval{}, err
+	if err := svc.validator(ctx, models.ProvenanceNone, mt.Provenance); err != nil {
+		return v1.TimeInterval{}, err
 	}
 
 	revision, err := svc.configStore.Get(ctx, orgID)
 	if err != nil {
-		return definitions.MuteTimeInterval{}, err
+		return v1.TimeInterval{}, err
 	}
 
-	if grafanaTimeIntervalExists(revision, mt.Name) {
-		return definitions.MuteTimeInterval{}, ErrTimeIntervalExists.Errorf("")
+	if _, ok := revision.GetTimeIntervalWithTitle(mt.Title); ok {
+		return v1.TimeInterval{}, ErrTimeIntervalExists.Errorf("")
 	}
 
-	revision.Config.AlertmanagerConfig.TimeIntervals = append(revision.Config.AlertmanagerConfig.TimeIntervals, v1.TimeInterval(mt.MuteTimeInterval))
+	created := revision.SetTimeInterval(mt)
 
 	err = svc.xact.InTransaction(ctx, func(ctx context.Context) error {
 		if err := svc.configStore.Save(ctx, revision, orgID); err != nil {
 			return err
 		}
-		return svc.provenanceStore.SetProvenance(ctx, &mt, orgID, models.Provenance(mt.Provenance))
+		return svc.provenanceStore.SetProvenance(ctx, &created, orgID, created.Provenance)
 	})
 	if err != nil {
-		return definitions.MuteTimeInterval{}, err
+		return v1.TimeInterval{}, err
 	}
 
-	return newMuteTimingInterval(v1.TimeInterval(mt.MuteTimeInterval), mt.Provenance), nil
+	return created, nil
 }
 
 // UpdateMuteTiming replaces an existing mute timing within the specified org. The replaced mute timing is returned. If the mute timing does not exist, ErrMuteTimingsNotFound is returned.
-func (svc *MuteTimingService) UpdateMuteTiming(ctx context.Context, mt definitions.MuteTimeInterval, orgID int64) (definitions.MuteTimeInterval, error) {
+func (svc *MuteTimingService) UpdateMuteTiming(ctx context.Context, mt v1.TimeInterval, orgID int64) (v1.TimeInterval, error) {
 	if err := mt.Validate(); err != nil {
-		return definitions.MuteTimeInterval{}, MakeErrTimeIntervalInvalid(err)
+		return v1.TimeInterval{}, MakeErrTimeIntervalInvalid(err)
 	}
 
 	revision, err := svc.configStore.Get(ctx, orgID)
 	if err != nil {
-		return definitions.MuteTimeInterval{}, err
+		return v1.TimeInterval{}, err
+	}
+
+	if err := svc.assignTimeIntervalProvenance(ctx, orgID, revision); err != nil {
+		return v1.TimeInterval{}, err
 	}
 
 	var found bool
-	var existing definitions.MuteTimeInterval
+	var existing v1.TimeInterval
 	if mt.UID != "" {
-		existing, found, err = svc.getMuteTimingByUID(ctx, revision, orgID, mt.UID)
+		existing, found = svc.getMuteTimingByUID(revision, mt.UID)
 	} else {
-		existing, found, err = svc.getMuteTimingByName(ctx, revision, orgID, mt.Name)
+		// This case supports the legacy provisioning API when a request is made with only a Title and no UID.
+		existing, found = revision.GetTimeIntervalWithTitle(mt.Title)
 	}
-	if err != nil {
-		return definitions.MuteTimeInterval{}, err
-	} else if !found {
-		return definitions.MuteTimeInterval{}, ErrTimeIntervalNotFound.Errorf("")
+	if !found {
+		return v1.TimeInterval{}, ErrTimeIntervalNotFound.Errorf("")
 	}
 
-	if existing.Name != mt.Name { // if mute timing is renamed, check if this name is already taken
-		if grafanaTimeIntervalExists(revision, mt.Name) {
-			return definitions.MuteTimeInterval{}, ErrTimeIntervalExists.Errorf("")
+	if existing.Title != mt.Title { // if mute timing is renamed, check if this name is already taken
+		if _, ok := revision.GetTimeIntervalWithTitle(mt.Title); ok {
+			return v1.TimeInterval{}, ErrTimeIntervalExists.Errorf("")
 		}
 	}
 
-	if existing.Provenance == definitions.Provenance(models.ProvenanceConvertedPrometheus) {
-		return definitions.MuteTimeInterval{}, makeErrMuteTimeIntervalOrigin(existing, "update")
+	if existing.Provenance == models.ProvenanceConvertedPrometheus {
+		return v1.TimeInterval{}, makeErrMuteTimeIntervalOrigin(existing, "update")
 	}
 
 	// check that provenance is not changed in an invalid way
-	if err := svc.validator(ctx, models.Provenance(existing.Provenance), models.Provenance(mt.Provenance)); err != nil {
-		return definitions.MuteTimeInterval{}, err
+	if err := svc.validator(ctx, existing.Provenance, mt.Provenance); err != nil {
+		return v1.TimeInterval{}, err
 	}
-
-	existingInterval := v1.TimeInterval(existing.MuteTimeInterval)
 
 	// check optimistic concurrency
-	if err = svc.checkOptimisticConcurrency(existingInterval, models.Provenance(mt.Provenance), mt.Version, "update"); err != nil {
-		return definitions.MuteTimeInterval{}, err
+	if err = svc.checkOptimisticConcurrency(existing, mt.Provenance, mt.Version, "update"); err != nil {
+		return v1.TimeInterval{}, err
 	}
+
+	updated := revision.SetTimeInterval(mt)
 
 	// TODO add diff and noop detection
 	err = svc.xact.InTransaction(ctx, func(ctx context.Context) error {
 		// if the name of the time interval changed
-		if existingInterval.Name != mt.Name {
-			deleteTimeInterval(revision, existingInterval)
-			revision.Config.AlertmanagerConfig.TimeIntervals = append(revision.Config.AlertmanagerConfig.TimeIntervals, v1.TimeInterval(mt.MuteTimeInterval))
+		if existing.Title != updated.Title {
+			revision.DeleteTimeInterval(existing.UID)
 
-			err = svc.renameTimeIntervalInDependentResources(ctx, orgID, revision, existingInterval.Name, mt.Name, models.Provenance(mt.Provenance))
+			err = svc.renameTimeIntervalInDependentResources(ctx, orgID, revision, existing.Title, updated.Title, updated.Provenance)
 			if err != nil {
 				return err
 			}
@@ -263,111 +228,91 @@ func (svc *MuteTimingService) UpdateMuteTiming(ctx context.Context, mt definitio
 			if err != nil {
 				return err
 			}
-		} else {
-			updateTimeInterval(revision, v1.TimeInterval(mt.MuteTimeInterval))
 		}
 		if err := svc.configStore.Save(ctx, revision, orgID); err != nil {
 			return err
 		}
-		return svc.provenanceStore.SetProvenance(ctx, &mt, orgID, models.Provenance(mt.Provenance))
+		return svc.provenanceStore.SetProvenance(ctx, &updated, orgID, updated.Provenance)
 	})
 	if err != nil {
-		return definitions.MuteTimeInterval{}, err
+		return v1.TimeInterval{}, err
 	}
 
-	return newMuteTimingInterval(v1.TimeInterval(mt.MuteTimeInterval), mt.Provenance), nil
+	return updated, nil
 }
 
 // DeleteMuteTiming deletes the mute timing with the given name in the given org. If the mute timing does not exist, no error is returned.
-func (svc *MuteTimingService) DeleteMuteTiming(ctx context.Context, nameOrUID string, orgID int64, provenance definitions.Provenance, version string) error {
+func (svc *MuteTimingService) DeleteMuteTiming(ctx context.Context, nameOrUID string, orgID int64, provenance models.Provenance, version string) error {
 	revision, err := svc.configStore.Get(ctx, orgID)
 	if err != nil {
 		return err
 	}
 
-	existing, err := svc.getMuteTiming(ctx, revision, nameOrUID, orgID)
-	if err != nil && !errors.Is(err, ErrTimeIntervalNotFound) {
+	if err := svc.assignTimeIntervalProvenance(ctx, orgID, revision); err != nil {
 		return err
-	} else if errors.Is(err, ErrTimeIntervalNotFound) {
-		return nil
+	}
+
+	// First attempt to find by Name and then by UID.
+	existing, found := revision.GetTimeIntervalWithTitle(nameOrUID)
+	if !found {
+		existing, found = svc.getMuteTimingByUID(revision, v1.ResourceUID(nameOrUID))
+		if !found {
+			return nil
+		}
 	}
 
 	// Block deletes of imported intervals
-	if existing.Provenance == definitions.Provenance(models.ProvenanceConvertedPrometheus) {
+	if existing.Provenance == models.ProvenanceConvertedPrometheus {
 		return makeErrMuteTimeIntervalOrigin(existing, "delete")
 	}
 
-	existingInterval := v1.TimeInterval(existing.MuteTimeInterval)
-
-	if err := svc.validator(ctx, models.Provenance(existing.Provenance), models.Provenance(provenance)); err != nil {
+	if err := svc.validator(ctx, existing.Provenance, provenance); err != nil {
 		return err
 	}
 
-	if revision.TimeIntervalUsedByRoutes(existing.Name) {
-		ns, _ := svc.ruleNotificationsStore.ListContactPointRoutings(ctx, models.ListContactPointRoutingsQuery{OrgID: orgID, TimeIntervalName: existing.Name})
+	if revision.TimeIntervalUsedByRoutes(existing.Title) {
+		ns, _ := svc.ruleNotificationsStore.ListContactPointRoutings(ctx, models.ListContactPointRoutingsQuery{OrgID: orgID, TimeIntervalName: existing.Title})
 		// ignore error here because it's not important
-		return MakeErrTimeIntervalInUse(existing.Name, true, slices.Collect(maps.Keys(ns)))
+		return MakeErrTimeIntervalInUse(existing.Title, true, slices.Collect(maps.Keys(ns)))
 	}
 
-	if err = svc.checkOptimisticConcurrency(existingInterval, models.Provenance(provenance), version, "delete"); err != nil {
+	if err = svc.checkOptimisticConcurrency(existing, provenance, version, "delete"); err != nil {
 		return err
 	}
-	deleteTimeInterval(revision, existingInterval)
+	revision.DeleteTimeInterval(existing.UID)
 
 	return svc.xact.InTransaction(ctx, func(ctx context.Context) error {
-		keys, err := svc.ruleNotificationsStore.ListContactPointRoutings(ctx, models.ListContactPointRoutingsQuery{OrgID: orgID, TimeIntervalName: existing.Name})
+		keys, err := svc.ruleNotificationsStore.ListContactPointRoutings(ctx, models.ListContactPointRoutingsQuery{OrgID: orgID, TimeIntervalName: existing.Title})
 		if err != nil {
 			return err
 		}
 		if len(keys) > 0 {
-			return MakeErrTimeIntervalInUse(existing.Name, false, slices.Collect(maps.Keys(keys)))
+			return MakeErrTimeIntervalInUse(existing.Title, false, slices.Collect(maps.Keys(keys)))
 		}
 
 		if err := svc.configStore.Save(ctx, revision, orgID); err != nil {
 			return err
 		}
-		return svc.provenanceStore.DeleteProvenance(ctx, &existingInterval, orgID)
+		return svc.provenanceStore.DeleteProvenance(ctx, &existing, orgID)
 	})
 }
 
-func (svc *MuteTimingService) getMuteTimingByName(ctx context.Context, revision *legacy_storage.ConfigRevision, orgID int64, name string) (definitions.MuteTimeInterval, bool, error) {
-	grafanaIntervals := getGrafanaTimeIntervals(revision)
-	if idx := slices.IndexFunc(grafanaIntervals, findByName(name)); idx != -1 {
-		interval := grafanaIntervals[idx]
-
-		prov, err := svc.provenanceStore.GetProvenance(ctx, &definitions.MuteTimeInterval{UID: legacy_storage.NameToUid(interval.Name), MuteTimeInterval: config.MuteTimeInterval(interval)}, orgID)
-		if err != nil {
-			return definitions.MuteTimeInterval{}, false, err
-		}
-
-		return newMuteTimingInterval(interval, definitions.Provenance(prov)), true, nil
-	}
-
-	return definitions.MuteTimeInterval{}, false, nil
-}
-
-func (svc *MuteTimingService) getMuteTimingByUID(ctx context.Context, revision *legacy_storage.ConfigRevision, orgID int64, uid string) (definitions.MuteTimeInterval, bool, error) {
-	grafanaIntervals := getGrafanaTimeIntervals(revision)
-	if idx := slices.IndexFunc(grafanaIntervals, findByUID(uid)); idx != -1 {
-		interval := grafanaIntervals[idx]
-
-		prov, err := svc.provenanceStore.GetProvenance(ctx, &definitions.MuteTimeInterval{UID: legacy_storage.NameToUid(interval.Name), MuteTimeInterval: config.MuteTimeInterval(interval)}, orgID)
-		if err != nil {
-			return definitions.MuteTimeInterval{}, false, err
-		}
-
-		return newMuteTimingInterval(interval, definitions.Provenance(prov)), true, nil
+// getMuteTimingByUID returns a mute timing by UID. Return time intervals from both the current and imported config
+// if the interval is not found in the current revision.
+func (svc *MuteTimingService) getMuteTimingByUID(revision *legacy_storage.ConfigRevision, uid v1.ResourceUID) (v1.TimeInterval, bool) {
+	if ti, ok := revision.Config.TimeIntervals[uid]; ok {
+		return ti, true
 	}
 
 	if importedIntervals := svc.getImportedTimeIntervals(revision); len(importedIntervals) > 0 {
-		if idx := slices.IndexFunc(importedIntervals, findByUID(uid)); idx != -1 {
-			interval := importedIntervals[idx]
-
-			return newMuteTimingInterval(interval, definitions.Provenance(models.ProvenanceConvertedPrometheus)), true, nil
+		for _, ti := range importedIntervals {
+			if ti.UID == uid {
+				return ti, true
+			}
 		}
 	}
 
-	return definitions.MuteTimeInterval{}, false, nil
+	return v1.TimeInterval{}, false
 }
 
 func (svc *MuteTimingService) getImportedTimeIntervals(rev *legacy_storage.ConfigRevision) []v1.TimeInterval {
@@ -390,106 +335,37 @@ func (svc *MuteTimingService) getImportedTimeIntervals(rev *legacy_storage.Confi
 	return intervals
 }
 
-func findByName(name string) func(v1.TimeInterval) bool {
-	return func(interval v1.TimeInterval) bool {
-		return interval.Name == name
-	}
-}
-
-func findByUID(uid string) func(v1.TimeInterval) bool {
-	return func(interval v1.TimeInterval) bool {
-		return legacy_storage.NameToUid(interval.Name) == uid
-	}
-}
-
-func getGrafanaTimeIntervals(rev *legacy_storage.ConfigRevision) []v1.TimeInterval {
-	return rev.Config.AlertmanagerConfig.TimeIntervals
-}
-
-func grafanaTimeIntervalExists(rev *legacy_storage.ConfigRevision, name string) bool {
-	grafanaIntervals := getGrafanaTimeIntervals(rev)
-	return slices.IndexFunc(grafanaIntervals, findByName(name)) != -1
-}
-
-func updateTimeInterval(rev *legacy_storage.ConfigRevision, interval v1.TimeInterval) {
-	for idx := range rev.Config.AlertmanagerConfig.TimeIntervals {
-		if rev.Config.AlertmanagerConfig.TimeIntervals[idx].Name == interval.Name {
-			rev.Config.AlertmanagerConfig.TimeIntervals[idx] = interval
-			return
-		}
-	}
-}
-
-func deleteTimeInterval(rev *legacy_storage.ConfigRevision, interval v1.TimeInterval) {
-	rev.Config.AlertmanagerConfig.TimeIntervals = slices.DeleteFunc(rev.Config.AlertmanagerConfig.TimeIntervals, findByName(interval.Name))
-}
-
-func calculateMuteTimeIntervalFingerprint(interval v1.TimeInterval) string {
-	sum := fnv.New64()
-
-	writeBytes := func(b []byte) {
-		_, _ = sum.Write(b)
-		// add a byte sequence that cannot happen in UTF-8 strings.
-		_, _ = sum.Write([]byte{255})
-	}
-	writeString := func(s string) {
-		if len(s) == 0 {
-			writeBytes(nil)
-			return
-		}
-		// #nosec G103
-		// avoid allocation when converting string to byte slice
-		writeBytes(unsafe.Slice(unsafe.StringData(s), len(s)))
-	}
-	// this temp slice is used to convert ints to bytes.
-	tmp := make([]byte, 8)
-	writeInt := func(u int) {
-		binary.LittleEndian.PutUint64(tmp, uint64(u))
-		writeBytes(tmp)
+func (svc *MuteTimingService) assignTimeIntervalProvenance(ctx context.Context, orgID int64, rev *legacy_storage.ConfigRevision) error {
+	if len(rev.Config.TimeIntervals) == 0 {
+		return nil
 	}
 
-	writeRange := func(r timeinterval.InclusiveRange) {
-		writeInt(r.Begin)
-		writeInt(r.End)
+	provenances, err := svc.provenanceStore.GetProvenances(ctx, orgID, (&v1.TimeInterval{}).ResourceType())
+	if err != nil {
+		return err
 	}
 
-	// fields that determine the rule state
-	writeString(interval.Name)
-	for _, ti := range interval.TimeIntervals {
-		for _, time := range ti.Times {
-			writeInt(time.StartMinute)
-			writeInt(time.EndMinute)
+	for uid, interval := range rev.Config.TimeIntervals {
+		prov, ok := provenances[interval.ResourceID()]
+		if !ok {
+			prov = models.ProvenanceNone
 		}
-		for _, itm := range ti.Months {
-			writeRange(itm.InclusiveRange)
-		}
-		for _, itm := range ti.DaysOfMonth {
-			writeRange(itm.InclusiveRange)
-		}
-		for _, itm := range ti.Weekdays {
-			writeRange(itm.InclusiveRange)
-		}
-		for _, itm := range ti.Years {
-			writeRange(itm.InclusiveRange)
-		}
-		if ti.Location != nil {
-			writeString(ti.Location.String())
-		}
+		interval.Provenance = prov
+		rev.Config.TimeIntervals[uid] = interval
 	}
-	return fmt.Sprintf("%016x", sum.Sum64())
+	return nil
 }
 
 func (svc *MuteTimingService) checkOptimisticConcurrency(current v1.TimeInterval, provenance models.Provenance, desiredVersion string, action string) error {
 	if desiredVersion == "" {
 		if provenance != models.ProvenanceFile {
 			// if version is not specified and it's not a file provisioning, emit a log message to reflect that optimistic concurrency is disabled for this request
-			svc.log.Debug("ignoring optimistic concurrency check because version was not provided", "timeInterval", current.Name, "operation", action)
+			svc.log.Debug("ignoring optimistic concurrency check because version was not provided", "timeInterval", current.Title, "operation", action)
 		}
 		return nil
 	}
-	currentVersion := calculateMuteTimeIntervalFingerprint(current)
-	if currentVersion != desiredVersion {
-		return ErrVersionConflict.Errorf("provided version %s of time interval %s does not match current version %s", desiredVersion, current.Name, currentVersion)
+	if current.Version != desiredVersion {
+		return ErrVersionConflict.Errorf("provided version %s of time interval %s does not match current version %s", desiredVersion, current.Title, current.Version)
 	}
 	return nil
 }
@@ -524,13 +400,4 @@ func (svc *MuteTimingService) renameTimeIntervalInDependentResources(ctx context
 		svc.log.FromContext(ctx).Info("Updated rules and routes that use renamed time interval", "oldName", oldName, "newName", newName, "rules", len(affected), "routes", updatedRouteCnt)
 	}
 	return nil
-}
-
-func newMuteTimingInterval(interval v1.TimeInterval, provenance definitions.Provenance) definitions.MuteTimeInterval {
-	return definitions.MuteTimeInterval{
-		UID:              legacy_storage.NameToUid(interval.Name),
-		MuteTimeInterval: config.MuteTimeInterval(interval),
-		Version:          calculateMuteTimeIntervalFingerprint(interval),
-		Provenance:       provenance,
-	}
 }

--- a/pkg/services/ngalert/provisioning/mute_timings_test.go
+++ b/pkg/services/ngalert/provisioning/mute_timings_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"slices"
 	"testing"
 
 	"github.com/prometheus/alertmanager/timeinterval"
@@ -14,7 +13,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
 	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
@@ -25,23 +23,10 @@ func TestGetMuteTimings(t *testing.T) {
 	orgID := int64(1)
 	revision := &legacy_storage.ConfigRevision{
 		Config: &v1.AMConfigV1{
-			AlertmanagerConfig: v1.PostableApiAlertingConfig{
-				Config: v1.Config{
-					TimeIntervals: []v1.TimeInterval{
-						{
-							Name:          "Test1",
-							TimeIntervals: nil,
-						},
-						{
-							Name:          "Test2",
-							TimeIntervals: nil,
-						},
-						{
-							Name:          "Test3",
-							TimeIntervals: nil,
-						},
-					},
-				},
+			TimeIntervals: map[v1.ResourceUID]v1.TimeInterval{
+				v1.TimeIntervalUID("Test1"): v1.NewTimeInterval("Test1", nil, models.ProvenanceNone),
+				v1.TimeIntervalUID("Test2"): v1.NewTimeInterval("Test2", nil, models.ProvenanceNone),
+				v1.TimeIntervalUID("Test3"): v1.NewTimeInterval("Test3", nil, models.ProvenanceNone),
 			},
 		},
 	}
@@ -62,27 +47,27 @@ func TestGetMuteTimings(t *testing.T) {
 		result, err := sut.GetMuteTimings(context.Background(), 1)
 
 		require.NoError(t, err)
-		require.Len(t, result, len(revision.Config.AlertmanagerConfig.TimeIntervals))
-		require.Equal(t, "Test1", result[0].Name)
+		require.Len(t, result, len(revision.Config.TimeIntervals))
+		require.Equal(t, "Test1", result[0].Title)
 		require.EqualValues(t, provenances["Test1"], result[0].Provenance)
 		require.NotEmpty(t, result[0].Version)
-		require.Equal(t, legacy_storage.NameToUid(result[0].Name), result[0].UID)
+		require.Equal(t, v1.TimeIntervalUID(result[0].Title), result[0].UID)
 
-		require.Equal(t, "Test2", result[1].Name)
+		require.Equal(t, "Test2", result[1].Title)
 		require.EqualValues(t, provenances["Test2"], result[1].Provenance)
 		require.NotEmpty(t, result[1].Version)
-		require.Equal(t, legacy_storage.NameToUid(result[1].Name), result[1].UID)
+		require.Equal(t, v1.TimeIntervalUID(result[1].Title), result[1].UID)
 
-		require.Equal(t, "Test3", result[2].Name)
+		require.Equal(t, "Test3", result[2].Title)
 		require.EqualValues(t, "", result[2].Provenance)
 		require.NotEmpty(t, result[2].Version)
-		require.Equal(t, legacy_storage.NameToUid(result[2].Name), result[2].UID)
+		require.Equal(t, v1.TimeIntervalUID(result[2].Title), result[2].UID)
 
 		require.Len(t, store.Calls, 1)
 		require.Equal(t, "Get", store.Calls[0].Method)
 		require.Equal(t, orgID, store.Calls[0].Args[1])
 
-		prov.AssertCalled(t, "GetProvenances", mock.Anything, orgID, (&definitions.MuteTimeInterval{}).ResourceType())
+		prov.AssertCalled(t, "GetProvenances", mock.Anything, orgID, (&v1.TimeInterval{}).ResourceType())
 	})
 
 	t.Run("service returns empty list when config file contains no mute timings", func(t *testing.T) {
@@ -126,10 +111,10 @@ func TestGetMuteTimings(t *testing.T) {
 
 	t.Run("with imported intervals", func(t *testing.T) {
 		grafanaIntervals := []v1.TimeInterval{
-			{Name: "grafana-interval"},
+			{Title: "grafana-interval"},
 		}
 		importedIntervals := []v1.TimeInterval{
-			{Name: "imported-interval"},
+			{Title: "imported-interval"},
 		}
 		revision := createConfigWithImportedIntervals(grafanaIntervals, importedIntervals)
 
@@ -148,7 +133,7 @@ func TestGetMuteTimings(t *testing.T) {
 
 			require.NoError(t, err)
 			require.Len(t, result, 1)
-			require.Equal(t, "grafana-interval", result[0].Name)
+			require.Equal(t, "grafana-interval", result[0].Title)
 			require.EqualValues(t, models.ProvenanceAPI, result[0].Provenance)
 		})
 
@@ -167,10 +152,10 @@ func TestGetMuteTimings(t *testing.T) {
 			require.Len(t, result, 2)
 
 			// Find Grafana interval
-			var grafanaInterval *definitions.MuteTimeInterval
-			var importedInterval *definitions.MuteTimeInterval
+			var grafanaInterval *v1.TimeInterval
+			var importedInterval *v1.TimeInterval
 			for i := range result {
-				switch name := result[i].Name; name {
+				switch name := result[i].Title; name {
 				case "grafana-interval":
 					grafanaInterval = &result[i]
 				case "imported-interval":
@@ -182,14 +167,14 @@ func TestGetMuteTimings(t *testing.T) {
 			require.NotNil(t, importedInterval, "Imported interval not found")
 
 			// Verify Grafana interval
-			require.Equal(t, "grafana-interval", grafanaInterval.Name)
+			require.Equal(t, "grafana-interval", grafanaInterval.Title)
 			require.EqualValues(t, models.ProvenanceAPI, grafanaInterval.Provenance)
-			require.Equal(t, legacy_storage.NameToUid(grafanaInterval.Name), grafanaInterval.UID)
+			require.Equal(t, v1.TimeIntervalUID(grafanaInterval.Title), grafanaInterval.UID)
 
 			// Verify imported interval
-			require.Equal(t, "imported-interval", importedInterval.Name)
+			require.Equal(t, "imported-interval", importedInterval.Title)
 			require.EqualValues(t, models.ProvenanceConvertedPrometheus, importedInterval.Provenance)
-			require.Equal(t, legacy_storage.NameToUid(importedInterval.Name), importedInterval.UID)
+			require.Equal(t, v1.TimeIntervalUID(importedInterval.Title), importedInterval.UID)
 		})
 
 		t.Run("handles empty ExtraConfigs", func(t *testing.T) {
@@ -206,7 +191,7 @@ func TestGetMuteTimings(t *testing.T) {
 
 			require.NoError(t, err)
 			require.Len(t, result, 1)
-			require.Equal(t, "grafana-interval", result[0].Name)
+			require.Equal(t, "grafana-interval", result[0].Title)
 		})
 	})
 }
@@ -215,19 +200,9 @@ func TestGetMuteTimingByName(t *testing.T) {
 	orgID := int64(1)
 	revision := &legacy_storage.ConfigRevision{
 		Config: &v1.AMConfigV1{
-			AlertmanagerConfig: v1.PostableApiAlertingConfig{
-				Config: v1.Config{
-					TimeIntervals: []v1.TimeInterval{
-						{
-							Name:          "Test1",
-							TimeIntervals: nil,
-						},
-						{
-							Name:          "Test2",
-							TimeIntervals: nil,
-						},
-					},
-				},
+			TimeIntervals: map[v1.ResourceUID]v1.TimeInterval{
+				v1.TimeIntervalUID("Test1"): v1.NewTimeInterval("Test1", nil, models.ProvenanceNone),
+				v1.TimeIntervalUID("Test2"): v1.NewTimeInterval("Test2", nil, models.ProvenanceNone),
 			},
 		},
 	}
@@ -237,30 +212,29 @@ func TestGetMuteTimingByName(t *testing.T) {
 		store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {
 			return revision, nil
 		}
-		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceAPI, nil)
+		prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{"Test1": models.ProvenanceAPI}, nil)
 
 		result, err := sut.GetMuteTimingByName(context.Background(), "Test1", orgID)
 
 		require.NoError(t, err)
 
-		require.Equal(t, "Test1", result.Name)
+		require.Equal(t, "Test1", result.Title)
 		require.EqualValues(t, models.ProvenanceAPI, result.Provenance)
-		require.Equal(t, legacy_storage.NameToUid(result.Name), result.UID)
+		require.Equal(t, v1.TimeIntervalUID(result.Title), result.UID)
 		require.NotEmpty(t, result.Version)
 
 		require.Len(t, store.Calls, 1)
 		require.Equal(t, "Get", store.Calls[0].Method)
 		require.Equal(t, orgID, store.Calls[0].Args[1])
 
-		prov.AssertCalled(t, "GetProvenance", mock.Anything, mock.MatchedBy(func(mt *definitions.MuteTimeInterval) bool {
-			return mt.Name == result.Name
-		}), orgID)
+		prov.AssertCalled(t, "GetProvenances", mock.Anything, orgID, (&v1.TimeInterval{}).ResourceType())
 
 		t.Run("service returns ErrTimeIntervalNotFound if no mute timing by name", func(t *testing.T) {
-			sut, store, _ := createMuteTimingSvcSut()
+			sut, store, prov := createMuteTimingSvcSut()
 			store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {
 				return revision, nil
 			}
+			prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{}, nil)
 
 			_, err := sut.GetMuteTimingByName(context.Background(), "Test123", orgID)
 
@@ -286,7 +260,7 @@ func TestGetMuteTimingByName(t *testing.T) {
 					return revision, nil
 				}
 				expected := fmt.Errorf("failed")
-				prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return("", expected)
+				prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(nil, expected)
 
 				_, err := sut.GetMuteTimingByName(context.Background(), "Test1", orgID)
 
@@ -300,19 +274,9 @@ func TestGetMuteTimingByUID(t *testing.T) {
 	orgID := int64(1)
 	revision := &legacy_storage.ConfigRevision{
 		Config: &v1.AMConfigV1{
-			AlertmanagerConfig: v1.PostableApiAlertingConfig{
-				Config: v1.Config{
-					TimeIntervals: []v1.TimeInterval{
-						{
-							Name:          "Test1",
-							TimeIntervals: nil,
-						},
-						{
-							Name:          "Test2",
-							TimeIntervals: nil,
-						},
-					},
-				},
+			TimeIntervals: map[v1.ResourceUID]v1.TimeInterval{
+				v1.TimeIntervalUID("Test1"): v1.NewTimeInterval("Test1", nil, models.ProvenanceNone),
+				v1.TimeIntervalUID("Test2"): v1.NewTimeInterval("Test2", nil, models.ProvenanceNone),
 			},
 		},
 	}
@@ -322,12 +286,14 @@ func TestGetMuteTimingByUID(t *testing.T) {
 		store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {
 			return revision, nil
 		}
-		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceAPI, nil)
-		result, err := sut.GetMuteTimingByUID(context.Background(), legacy_storage.NameToUid("Test1"), orgID)
+		prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{"Test1": models.ProvenanceAPI}, nil)
+		result, err := sut.GetMuteTimingByUID(context.Background(), v1.TimeIntervalUID("Test1"), orgID)
 
 		require.NoError(t, err)
 
-		require.Equal(t, result, result)
+		require.Equal(t, "Test1", result.Title)
+		require.Equal(t, v1.TimeIntervalUID("Test1"), result.UID)
+		require.EqualValues(t, models.ProvenanceAPI, result.Provenance)
 	})
 
 	t.Run("service returns ErrTimeIntervalNotFound if no mute timings", func(t *testing.T) {
@@ -349,7 +315,7 @@ func TestGetMuteTimingByUID(t *testing.T) {
 				return nil, expected
 			}
 
-			_, err := sut.GetMuteTimingByUID(context.Background(), legacy_storage.NameToUid("Test1"), orgID)
+			_, err := sut.GetMuteTimingByUID(context.Background(), v1.TimeIntervalUID("Test1"), orgID)
 
 			require.ErrorIs(t, err, expected)
 		})
@@ -360,9 +326,9 @@ func TestGetMuteTimingByUID(t *testing.T) {
 				return revision, nil
 			}
 			expected := fmt.Errorf("failed")
-			prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return("", expected)
+			prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(nil, expected)
 
-			_, err := sut.GetMuteTimingByUID(context.Background(), legacy_storage.NameToUid("Test1"), orgID)
+			_, err := sut.GetMuteTimingByUID(context.Background(), v1.TimeIntervalUID("Test1"), orgID)
 
 			require.ErrorIs(t, err, expected)
 		})
@@ -375,24 +341,22 @@ func TestCreateMuteTimings(t *testing.T) {
 	initialConfig := func() *v1.AMConfigV1 {
 		return &v1.AMConfigV1{
 			Templates: nil,
-			AlertmanagerConfig: v1.PostableApiAlertingConfig{
-				Config: v1.Config{
-					TimeIntervals: []v1.TimeInterval{
-						{
-							Name: "TEST",
-						},
-						{
-							Name: "TEST2",
-						},
-					},
+			TimeIntervals: map[v1.ResourceUID]v1.TimeInterval{
+				v1.TimeIntervalUID("TEST"): {
+					ResourceMetadata: v1.ResourceMetadata{UID: v1.TimeIntervalUID("TEST")},
+					Title:            "TEST",
 				},
-				Receivers: nil,
+				v1.TimeIntervalUID("TEST2"): {
+					ResourceMetadata: v1.ResourceMetadata{UID: v1.TimeIntervalUID("TEST2")},
+					Title:            "TEST2",
+				},
 			},
 		}
 	}
 
-	expected := definitions.AmMuteTimeInterval{
-		Name: "Test",
+	expected := v1.TimeInterval{
+		ResourceMetadata: v1.ResourceMetadata{UID: v1.TimeIntervalUID("Test")},
+		Title:            "Test",
 		TimeIntervals: []timeinterval.TimeInterval{
 			{
 				Times: []timeinterval.TimeRange{
@@ -404,18 +368,17 @@ func TestCreateMuteTimings(t *testing.T) {
 		},
 	}
 	expectedProvenance := models.ProvenanceAPI
-	timing := definitions.MuteTimeInterval{
-		MuteTimeInterval: expected,
-		Provenance:       definitions.Provenance(expectedProvenance),
+	timing := v1.TimeInterval{
+		ResourceMetadata: v1.ResourceMetadata{UID: v1.TimeIntervalUID("Test"), Provenance: expectedProvenance},
+		Title:            expected.Title,
+		TimeIntervals:    expected.TimeIntervals,
 	}
 
 	t.Run("returns ErrTimeIntervalInvalid if mute timings fail validation", func(t *testing.T) {
 		sut, _, _ := createMuteTimingSvcSut()
-		timing := definitions.MuteTimeInterval{
-			MuteTimeInterval: definitions.AmMuteTimeInterval{
-				Name: "",
-			},
-			Provenance: definitions.Provenance(models.ProvenanceFile),
+		timing := v1.TimeInterval{
+			ResourceMetadata: v1.ResourceMetadata{Provenance: models.ProvenanceFile},
+			Title:            "",
 		}
 
 		_, err := sut.CreateMuteTiming(context.Background(), timing, orgID)
@@ -424,27 +387,22 @@ func TestCreateMuteTimings(t *testing.T) {
 	})
 
 	t.Run("returns ErrTimeIntervalExists if mute timing with the name exists", func(t *testing.T) {
-		sut, store, prov := createMuteTimingSvcSut()
+		sut, store, _ := createMuteTimingSvcSut()
 		store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {
 			return &legacy_storage.ConfigRevision{Config: initialConfig()}, nil
 		}
-		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceNone, nil)
 
-		existing := initialConfig().AlertmanagerConfig.TimeIntervals[0]
-		timing := definitions.MuteTimeInterval{
-			MuteTimeInterval: definitions.AmMuteTimeInterval(existing),
-			Provenance:       definitions.Provenance(models.ProvenanceFile),
-		}
+		existing := initialConfig().TimeIntervals[v1.TimeIntervalUID("TEST")]
+		existing.Provenance = models.ProvenanceFile
+		timing := existing
 
 		_, err := sut.CreateMuteTiming(context.Background(), timing, orgID)
 
 		require.Truef(t, ErrTimeIntervalExists.Is(err), "expected ErrTimeIntervalExists but got %s", err)
 
-		existing = initialConfig().AlertmanagerConfig.TimeIntervals[1]
-		timing = definitions.MuteTimeInterval{
-			MuteTimeInterval: definitions.AmMuteTimeInterval(existing),
-			Provenance:       definitions.Provenance(models.ProvenanceFile),
-		}
+		existing = initialConfig().TimeIntervals[v1.TimeIntervalUID("TEST2")]
+		existing.Provenance = models.ProvenanceFile
+		timing = existing
 
 		_, err = sut.CreateMuteTiming(context.Background(), timing, orgID)
 
@@ -469,9 +427,10 @@ func TestCreateMuteTimings(t *testing.T) {
 		result, err := sut.CreateMuteTiming(context.Background(), timing, orgID)
 		require.NoError(t, err)
 
-		require.EqualValues(t, expected, result.MuteTimeInterval)
+		require.EqualValues(t, expected.Title, result.Title)
+		require.EqualValues(t, expected.TimeIntervals, result.TimeIntervals)
 		require.EqualValues(t, expectedProvenance, result.Provenance)
-		require.Equal(t, legacy_storage.NameToUid(expected.Name), result.UID)
+		require.Equal(t, v1.TimeIntervalUID(expected.Title), result.UID)
 		require.NotEmpty(t, result.Version)
 
 		require.Len(t, store.Calls, 2)
@@ -482,10 +441,16 @@ func TestCreateMuteTimings(t *testing.T) {
 		require.Equal(t, orgID, store.Calls[1].Args[2])
 		revision := store.Calls[1].Args[1].(*legacy_storage.ConfigRevision)
 
-		expectedTimings := append(initialConfig().AlertmanagerConfig.TimeIntervals, v1.TimeInterval(expected))
-		require.EqualValues(t, expectedTimings, revision.Config.AlertmanagerConfig.TimeIntervals)
+		stored, ok := revision.Config.TimeIntervals[v1.TimeIntervalUID(expected.Title)]
+		require.True(t, ok, "created interval should be stored")
+		require.Equal(t, expected.Title, stored.Title)
+		require.EqualValues(t, expected.TimeIntervals, stored.TimeIntervals)
+		// Existing intervals are preserved.
+		require.Contains(t, revision.Config.TimeIntervals, v1.TimeIntervalUID("TEST"))
+		require.Contains(t, revision.Config.TimeIntervals, v1.TimeIntervalUID("TEST2"))
+		require.Len(t, revision.Config.TimeIntervals, 3)
 
-		prov.AssertCalled(t, "SetProvenance", mock.Anything, &timing, orgID, expectedProvenance)
+		prov.AssertCalled(t, "SetProvenance", mock.Anything, &result, orgID, expectedProvenance)
 	})
 
 	t.Run("propagates errors", func(t *testing.T) {
@@ -547,24 +512,23 @@ func TestUpdateMuteTimings(t *testing.T) {
 	orgID := int64(1)
 
 	original := v1.TimeInterval{
-		Name: "Test",
+		ResourceMetadata: v1.ResourceMetadata{UID: v1.TimeIntervalUID("Test")},
+		Title:            "Test",
 	}
-	originalVersion := calculateMuteTimeIntervalFingerprint(original)
+	originalVersion := v1.TimeIntervalFingerprint(original)
 	initialConfig := func() *v1.AMConfigV1 {
 		return &v1.AMConfigV1{
 			Templates: nil,
+			TimeIntervals: map[v1.ResourceUID]v1.TimeInterval{
+				v1.TimeIntervalUID("Test"):  v1.NewTimeInterval("Test", nil, models.ProvenanceNone),
+				v1.TimeIntervalUID("Test2"): v1.NewTimeInterval("Test2", nil, models.ProvenanceNone),
+			},
 			AlertmanagerConfig: v1.PostableApiAlertingConfig{
 				Config: v1.Config{
-					TimeIntervals: []v1.TimeInterval{
-						original,
-						{
-							Name: "Test2",
-						},
-					},
 					Route: &v1.Route{
 						Routes: []*v1.Route{
 							{
-								MuteTimeIntervals: []string{original.Name},
+								MuteTimeIntervals: []string{original.Title},
 							},
 						},
 					},
@@ -575,7 +539,8 @@ func TestUpdateMuteTimings(t *testing.T) {
 	}
 
 	expected := v1.TimeInterval{
-		Name: "Test",
+		ResourceMetadata: v1.ResourceMetadata{UID: v1.TimeIntervalUID("Test")},
+		Title:            "Test",
 		TimeIntervals: []timeinterval.TimeInterval{
 			{
 				Times: []timeinterval.TimeRange{
@@ -587,21 +552,19 @@ func TestUpdateMuteTimings(t *testing.T) {
 		},
 	}
 	expectedProvenance := models.ProvenanceAPI
-	expectedVersion := calculateMuteTimeIntervalFingerprint(expected)
-	expectedUID := legacy_storage.NameToUid(expected.Name)
-	timing := definitions.MuteTimeInterval{
-		MuteTimeInterval: definitions.AmMuteTimeInterval(expected),
-		Version:          originalVersion,
-		Provenance:       definitions.Provenance(expectedProvenance),
+	expectedVersion := v1.TimeIntervalFingerprint(expected)
+	expectedUID := v1.TimeIntervalUID(expected.Title)
+	timing := v1.TimeInterval{
+		ResourceMetadata: v1.ResourceMetadata{UID: v1.TimeIntervalUID(expected.Title), Version: originalVersion, Provenance: expectedProvenance},
+		Title:            expected.Title,
+		TimeIntervals:    expected.TimeIntervals,
 	}
 
 	t.Run("rejects mute timings that fail validation", func(t *testing.T) {
 		sut, _, _ := createMuteTimingSvcSut()
-		timing := definitions.MuteTimeInterval{
-			MuteTimeInterval: definitions.AmMuteTimeInterval{
-				Name: "",
-			},
-			Provenance: definitions.Provenance(models.ProvenanceFile),
+		timing := v1.TimeInterval{
+			ResourceMetadata: v1.ResourceMetadata{Provenance: models.ProvenanceFile},
+			Title:            "",
 		}
 
 		_, err := sut.UpdateMuteTiming(context.Background(), timing, orgID)
@@ -618,12 +581,10 @@ func TestUpdateMuteTimings(t *testing.T) {
 		sut.validator = func(_ context.Context, from, to models.Provenance) error {
 			return expectedErr
 		}
-		timing := definitions.MuteTimeInterval{
-			MuteTimeInterval: definitions.AmMuteTimeInterval(expected),
-			Provenance:       definitions.Provenance(models.ProvenanceFile),
-		}
+		timing := expected
+		timing.Provenance = models.ProvenanceFile
 
-		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(expectedProvenance, nil)
+		prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{expected.Title: expectedProvenance}, nil)
 
 		_, err := sut.UpdateMuteTiming(context.Background(), timing, orgID)
 
@@ -638,24 +599,21 @@ func TestUpdateMuteTimings(t *testing.T) {
 		sut.validator = func(_ context.Context, from, to models.Provenance) error {
 			return nil
 		}
-		timing := definitions.MuteTimeInterval{
-			UID: legacy_storage.NameToUid("Test2"),
-			MuteTimeInterval: definitions.AmMuteTimeInterval{
-				Name: "Test",
-				TimeIntervals: []timeinterval.TimeInterval{
-					{
-						Times: []timeinterval.TimeRange{
-							{
-								StartMinute: 10, EndMinute: 60,
-							},
+		timing := v1.TimeInterval{
+			ResourceMetadata: v1.ResourceMetadata{UID: v1.TimeIntervalUID("Test2"), Provenance: expectedProvenance},
+			Title:            "Test",
+			TimeIntervals: []timeinterval.TimeInterval{
+				{
+					Times: []timeinterval.TimeRange{
+						{
+							StartMinute: 10, EndMinute: 60,
 						},
 					},
 				},
 			},
-			Provenance: definitions.Provenance(expectedProvenance),
 		}
 
-		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(expectedProvenance, nil)
+		prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{}, nil)
 
 		_, err := sut.UpdateMuteTiming(context.Background(), timing, orgID)
 		require.ErrorIs(t, err, ErrTimeIntervalExists)
@@ -667,13 +625,11 @@ func TestUpdateMuteTimings(t *testing.T) {
 			return &legacy_storage.ConfigRevision{Config: initialConfig()}, nil
 		}
 
-		timing := definitions.MuteTimeInterval{
-			MuteTimeInterval: definitions.AmMuteTimeInterval(expected),
-			Version:          "some_random_version",
-			Provenance:       definitions.Provenance(expectedProvenance),
-		}
+		timing := expected
+		timing.Version = "some_random_version"
+		timing.Provenance = expectedProvenance
 
-		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(expectedProvenance, nil)
+		prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{expected.Title: expectedProvenance}, nil)
 
 		_, err := sut.UpdateMuteTiming(context.Background(), timing, orgID)
 
@@ -685,14 +641,12 @@ func TestUpdateMuteTimings(t *testing.T) {
 		store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {
 			return &legacy_storage.ConfigRevision{Config: initialConfig()}, nil
 		}
-		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(expectedProvenance, nil)
+		prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{expected.Title: expectedProvenance}, nil)
 
 		t.Run("when UID is specified", func(t *testing.T) {
-			timing := definitions.MuteTimeInterval{
-				UID:              "not-found",
-				MuteTimeInterval: definitions.AmMuteTimeInterval(expected),
-				Provenance:       definitions.Provenance(expectedProvenance),
-			}
+			timing := expected
+			timing.UID = "not-found"
+			timing.Provenance = expectedProvenance
 
 			_, err := sut.UpdateMuteTiming(context.Background(), timing, orgID)
 
@@ -700,11 +654,9 @@ func TestUpdateMuteTimings(t *testing.T) {
 		})
 
 		t.Run("when only Name is specified", func(t *testing.T) {
-			timing := definitions.MuteTimeInterval{
-				MuteTimeInterval: definitions.AmMuteTimeInterval{
-					Name: "not-found",
-				},
-				Provenance: definitions.Provenance(expectedProvenance),
+			timing := v1.TimeInterval{
+				ResourceMetadata: v1.ResourceMetadata{Provenance: expectedProvenance},
+				Title:            "not-found",
 			}
 
 			_, err := sut.UpdateMuteTiming(context.Background(), timing, orgID)
@@ -722,7 +674,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 			assertInTransaction(t, ctx)
 			return nil
 		}
-		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(expectedProvenance, nil)
+		prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{expected.Title: expectedProvenance}, nil)
 		prov.EXPECT().SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
 			func(ctx context.Context, _ models.Provisionable, _ int64, _ models.Provenance) error {
 				assertInTransaction(t, ctx)
@@ -732,10 +684,11 @@ func TestUpdateMuteTimings(t *testing.T) {
 		result, err := sut.UpdateMuteTiming(context.Background(), timing, orgID)
 		require.NoError(t, err)
 
-		require.EqualValues(t, expected, result.MuteTimeInterval)
+		require.EqualValues(t, expected.Title, result.Title)
+		require.EqualValues(t, expected.TimeIntervals, result.TimeIntervals)
 		require.EqualValues(t, expectedProvenance, result.Provenance)
 		require.EqualValues(t, expectedVersion, result.Version)
-		require.Equal(t, legacy_storage.NameToUid(result.Name), result.UID)
+		require.Equal(t, v1.TimeIntervalUID(result.Title), result.UID)
 
 		require.Len(t, store.Calls, 2)
 		require.Equal(t, "Get", store.Calls[0].Method)
@@ -745,35 +698,36 @@ func TestUpdateMuteTimings(t *testing.T) {
 		require.Equal(t, orgID, store.Calls[1].Args[2])
 		revision := store.Calls[1].Args[1].(*legacy_storage.ConfigRevision)
 
-		require.EqualValues(t, []v1.TimeInterval{expected, {Name: "Test2"}}, revision.Config.AlertmanagerConfig.TimeIntervals)
+		stored, ok := revision.Config.TimeIntervals[v1.TimeIntervalUID(expected.Title)]
+		require.True(t, ok)
+		require.Equal(t, expected.Title, stored.Title)
+		require.EqualValues(t, expected.TimeIntervals, stored.TimeIntervals)
 
-		prov.AssertCalled(t, "SetProvenance", mock.Anything, &timing, orgID, expectedProvenance)
+		prov.AssertCalled(t, "SetProvenance", mock.Anything, mock.MatchedBy(func(m *v1.TimeInterval) bool { return m.Title == timing.Title }), orgID, expectedProvenance)
 
 		t.Run("bypass optimistic concurrency check if version is empty", func(t *testing.T) {
 			store.Calls = nil
-			timing := definitions.MuteTimeInterval{
-				MuteTimeInterval: definitions.AmMuteTimeInterval{
-					Name: expected.Name,
-					TimeIntervals: []timeinterval.TimeInterval{
-						{Months: []timeinterval.MonthRange{
-							{
-								InclusiveRange: timeinterval.InclusiveRange{
-									Begin: 1,
-									End:   10,
-								},
+			timing := v1.TimeInterval{
+				ResourceMetadata: v1.ResourceMetadata{UID: v1.TimeIntervalUID(expected.Title), Provenance: expectedProvenance},
+				Title:            expected.Title,
+				TimeIntervals: []timeinterval.TimeInterval{
+					{Months: []timeinterval.MonthRange{
+						{
+							InclusiveRange: timeinterval.InclusiveRange{
+								Begin: 1,
+								End:   10,
 							},
 						}},
 					},
 				},
-				Version:    "",
-				Provenance: definitions.Provenance(expectedProvenance),
 			}
-			expectedVersion := calculateMuteTimeIntervalFingerprint(v1.TimeInterval(timing.MuteTimeInterval))
+			expectedVersion := v1.TimeIntervalFingerprint(timing)
 
 			result, err := sut.UpdateMuteTiming(context.Background(), timing, orgID)
 			require.NoError(t, err)
 
-			require.EqualValues(t, timing.MuteTimeInterval, result.MuteTimeInterval)
+			require.EqualValues(t, timing.Title, result.Title)
+			require.EqualValues(t, timing.TimeIntervals, result.TimeIntervals)
 			require.Equal(t, expectedVersion, result.Version)
 			require.EqualValues(t, expectedProvenance, result.Provenance)
 
@@ -781,7 +735,10 @@ func TestUpdateMuteTimings(t *testing.T) {
 			require.Equal(t, orgID, store.Calls[1].Args[2])
 			revision := store.Calls[1].Args[1].(*legacy_storage.ConfigRevision)
 
-			require.EqualValues(t, []v1.TimeInterval{v1.TimeInterval(timing.MuteTimeInterval), {Name: "Test2"}}, revision.Config.AlertmanagerConfig.TimeIntervals)
+			stored, ok := revision.Config.TimeIntervals[v1.TimeIntervalUID(expected.Title)]
+			require.True(t, ok)
+			require.Equal(t, timing.Title, stored.Title)
+			require.EqualValues(t, timing.TimeIntervals, stored.TimeIntervals)
 		})
 	})
 
@@ -794,29 +751,33 @@ func TestUpdateMuteTimings(t *testing.T) {
 			assertInTransaction(t, ctx)
 			return nil
 		}
-		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(expectedProvenance, nil)
+		original := initialConfig().TimeIntervals[v1.TimeIntervalUID("Test2")]
+
+		prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{original.Title: expectedProvenance}, nil)
 		prov.EXPECT().SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
 			func(ctx context.Context, _ models.Provisionable, _ int64, _ models.Provenance) error {
 				assertInTransaction(t, ctx)
 				return nil
 			})
 
-		original := initialConfig().AlertmanagerConfig.TimeIntervals[1]
-
 		expected := expected
-		expected.Name = original.Name
+		expected.Title = original.Title
+		expected.UID = original.UID
 		timing := timing
-		timing.MuteTimeInterval = definitions.AmMuteTimeInterval(expected)
-		timing.Version = calculateMuteTimeIntervalFingerprint(original)
-		expectedVersion := calculateMuteTimeIntervalFingerprint(expected)
+		timing.Title = expected.Title
+		timing.UID = expected.UID
+		timing.TimeIntervals = expected.TimeIntervals
+		timing.Version = v1.TimeIntervalFingerprint(original)
+		expectedVersion := v1.TimeIntervalFingerprint(expected)
 
 		result, err := sut.UpdateMuteTiming(context.Background(), timing, orgID)
 		require.NoError(t, err)
 
-		require.EqualValues(t, expected, result.MuteTimeInterval)
+		require.EqualValues(t, expected.Title, result.Title)
+		require.EqualValues(t, expected.TimeIntervals, result.TimeIntervals)
 		require.EqualValues(t, expectedProvenance, result.Provenance)
 		require.EqualValues(t, expectedVersion, result.Version)
-		require.Equal(t, legacy_storage.NameToUid(result.Name), result.UID)
+		require.Equal(t, v1.TimeIntervalUID(result.Title), result.UID)
 
 		require.Len(t, store.Calls, 2)
 		require.Equal(t, "Get", store.Calls[0].Method)
@@ -826,9 +787,12 @@ func TestUpdateMuteTimings(t *testing.T) {
 		require.Equal(t, orgID, store.Calls[1].Args[2])
 		revision := store.Calls[1].Args[1].(*legacy_storage.ConfigRevision)
 
-		require.EqualValues(t, []v1.TimeInterval{{Name: "Test"}, expected}, revision.Config.AlertmanagerConfig.TimeIntervals)
+		stored, ok := revision.Config.TimeIntervals[v1.TimeIntervalUID(expected.Title)]
+		require.True(t, ok)
+		require.Equal(t, expected.Title, stored.Title)
+		require.EqualValues(t, expected.TimeIntervals, stored.TimeIntervals)
 
-		prov.AssertCalled(t, "SetProvenance", mock.Anything, &timing, orgID, expectedProvenance)
+		prov.AssertCalled(t, "SetProvenance", mock.Anything, mock.MatchedBy(func(m *v1.TimeInterval) bool { return m.Title == timing.Title }), orgID, expectedProvenance)
 	})
 
 	t.Run("renames interval and all its dependencies", func(t *testing.T) {
@@ -841,7 +805,8 @@ func TestUpdateMuteTimings(t *testing.T) {
 			assertInTransaction(t, ctx)
 			return nil
 		}
-		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(expectedProvenance, nil)
+		prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{expected.Title: expectedProvenance}, nil)
+		prov.EXPECT().GetProvenance(mock.Anything, mock.MatchedBy(func(*v1.Route) bool { return true }), mock.Anything).Return(expectedProvenance, nil).Maybe()
 		prov.EXPECT().DeleteProvenance(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, provisionable models.Provisionable, i int64) error {
 			assertInTransaction(t, ctx)
 			return nil
@@ -861,37 +826,38 @@ func TestUpdateMuteTimings(t *testing.T) {
 		sut.ruleNotificationsStore = ruleStore
 
 		interval := expected
-		interval.Name = "another-time-interval"
-		timing := definitions.MuteTimeInterval{
-			UID:              expectedUID,
-			MuteTimeInterval: definitions.AmMuteTimeInterval(interval),
-			Version:          originalVersion,
-			Provenance:       definitions.Provenance(expectedProvenance),
+		interval.Title = "another-time-interval"
+		timing := v1.TimeInterval{
+			ResourceMetadata: v1.ResourceMetadata{UID: expectedUID, Version: originalVersion, Provenance: expectedProvenance},
+			Title:            interval.Title,
+			TimeIntervals:    interval.TimeIntervals,
 		}
 
 		result, err := sut.UpdateMuteTiming(context.Background(), timing, orgID)
 		require.NoError(t, err)
 
-		require.EqualValues(t, interval, result.MuteTimeInterval)
+		require.EqualValues(t, interval.Title, result.Title)
+		require.EqualValues(t, interval.TimeIntervals, result.TimeIntervals)
 		require.EqualValues(t, expectedProvenance, result.Provenance)
-		require.EqualValues(t, calculateMuteTimeIntervalFingerprint(interval), result.Version)
-		require.Equal(t, legacy_storage.NameToUid(result.Name), result.UID)
+		require.EqualValues(t, v1.TimeIntervalFingerprint(interval), result.Version)
+		// The UID is derived from the title, so a rename moves the interval to a new UID.
+		require.Equal(t, v1.TimeIntervalUID(interval.Title), result.UID)
+		require.NotEqual(t, expectedUID, result.UID)
 
 		require.Len(t, ruleStore.Calls, 1)
 		assert.Equal(t, "RenameTimeIntervalInNotificationSettings", ruleStore.Calls[0].Method)
 		assert.Equal(t, orgID, ruleStore.Calls[0].Args[1])
-		assert.Equal(t, original.Name, ruleStore.Calls[0].Args[2])
-		assert.Equal(t, interval.Name, ruleStore.Calls[0].Args[3])
+		assert.Equal(t, original.Title, ruleStore.Calls[0].Args[2])
+		assert.Equal(t, interval.Title, ruleStore.Calls[0].Args[3])
 		assert.NotNil(t, ruleStore.Calls[0].Args[4])
 		assert.False(t, ruleStore.Calls[0].Args[5].(bool))
 
-		prov.AssertCalled(t, "SetProvenance", mock.Anything, mock.MatchedBy(func(m *definitions.MuteTimeInterval) bool {
-			return m.Name == interval.Name
+		prov.AssertCalled(t, "SetProvenance", mock.Anything, mock.MatchedBy(func(m *v1.TimeInterval) bool {
+			return m.Title == interval.Title
 		}), orgID, expectedProvenance)
-		prov.AssertCalled(t, "DeleteProvenance", mock.Anything, mock.MatchedBy(func(m *definitions.MuteTimeInterval) bool {
-			return m.Name == original.Name
+		prov.AssertCalled(t, "DeleteProvenance", mock.Anything, mock.MatchedBy(func(m *v1.TimeInterval) bool {
+			return m.Title == original.Title
 		}), orgID)
-		prov.AssertExpectations(t)
 
 		require.Len(t, store.Calls, 2)
 		require.Equal(t, "Get", store.Calls[0].Method)
@@ -901,13 +867,15 @@ func TestUpdateMuteTimings(t *testing.T) {
 		assert.Equal(t, orgID, store.Calls[1].Args[2])
 
 		revision := store.Calls[1].Args[1].(*legacy_storage.ConfigRevision)
-		expectedTimings := slices.DeleteFunc(initialConfig().AlertmanagerConfig.TimeIntervals, func(i v1.TimeInterval) bool {
-			return i.Name == original.Name
-		})
-		expectedTimings = append(expectedTimings, interval)
-		assert.EqualValues(t, expectedTimings, revision.Config.AlertmanagerConfig.TimeIntervals)
-		assert.Falsef(t, revision.TimeIntervalUsedByRoutes(expected.Name), "There are still references to the old time interval")
-		assert.Truef(t, revision.TimeIntervalUsedByRoutes(interval.Name), "There are no references to the new time interval")
+		// The renamed interval is stored under its new UID with the new title.
+		renamed, hasNew := revision.Config.TimeIntervals[v1.TimeIntervalUID(interval.Title)]
+		require.Truef(t, hasNew, "renamed time interval should be present under its new UID")
+		assert.Equal(t, interval.Title, renamed.Title)
+		// The interval previously stored under the original name is no longer referenced by its old title.
+		_, stillOld := revision.Config.TimeIntervals[expectedUID]
+		assert.False(t, stillOld || hasTimeIntervalWithTitle(revision.Config.TimeIntervals, original.Title), "old time interval should no longer be present under its original title")
+		assert.Falsef(t, revision.TimeIntervalUsedByRoutes(expected.Title), "There are still references to the old time interval")
+		assert.Truef(t, revision.TimeIntervalUsedByRoutes(interval.Title), "There are no references to the new time interval")
 	})
 
 	t.Run("returns ErrTimeIntervalDependentResourcesProvenance if route has different provenance status", func(t *testing.T) {
@@ -916,8 +884,8 @@ func TestUpdateMuteTimings(t *testing.T) {
 		store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {
 			return &legacy_storage.ConfigRevision{Config: initialConfig()}, nil
 		}
+		prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{expected.Title: expectedProvenance}, nil)
 		prov.EXPECT().GetProvenance(mock.Anything, mock.MatchedBy(func(*v1.Route) bool { return true }), mock.Anything).Return(models.ProvenanceFile, nil)
-		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(expectedProvenance, nil)
 
 		ruleStore := &fakeAlertRuleNotificationStore{
 			RenameTimeIntervalInNotificationSettingsFn: func(ctx context.Context, orgID int64, old, new string, validate func(models.Provenance) bool, dryRun bool) ([]models.AlertRuleKey, []models.AlertRuleKey, error) {
@@ -928,12 +896,11 @@ func TestUpdateMuteTimings(t *testing.T) {
 		sut.ruleNotificationsStore = ruleStore
 
 		interval := expected
-		interval.Name = "another-time-interval"
-		timing := definitions.MuteTimeInterval{
-			UID:              expectedUID,
-			MuteTimeInterval: definitions.AmMuteTimeInterval(interval),
-			Version:          originalVersion,
-			Provenance:       definitions.Provenance(expectedProvenance),
+		interval.Title = "another-time-interval"
+		timing := v1.TimeInterval{
+			ResourceMetadata: v1.ResourceMetadata{UID: expectedUID, Version: originalVersion, Provenance: expectedProvenance},
+			Title:            interval.Title,
+			TimeIntervals:    interval.TimeIntervals,
 		}
 
 		_, err := sut.UpdateMuteTiming(context.Background(), timing, orgID)
@@ -942,8 +909,8 @@ func TestUpdateMuteTimings(t *testing.T) {
 		require.Len(t, ruleStore.Calls, 1)
 		assert.Equal(t, "RenameTimeIntervalInNotificationSettings", ruleStore.Calls[0].Method)
 		assert.Equal(t, orgID, ruleStore.Calls[0].Args[1])
-		assert.Equal(t, original.Name, ruleStore.Calls[0].Args[2])
-		assert.Equal(t, interval.Name, ruleStore.Calls[0].Args[3])
+		assert.Equal(t, original.Title, ruleStore.Calls[0].Args[2])
+		assert.Equal(t, interval.Title, ruleStore.Calls[0].Args[3])
 		assert.NotNil(t, ruleStore.Calls[0].Args[4])
 		assert.True(t, ruleStore.Calls[0].Args[5].(bool)) // still check if there are rules that have incompatible provenance
 	})
@@ -954,8 +921,8 @@ func TestUpdateMuteTimings(t *testing.T) {
 		store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {
 			return &legacy_storage.ConfigRevision{Config: initialConfig()}, nil
 		}
+		prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{expected.Title: expectedProvenance}, nil)
 		prov.EXPECT().GetProvenance(mock.Anything, mock.MatchedBy(func(*v1.Route) bool { return true }), mock.Anything).Return(models.ProvenanceNone, nil)
-		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(expectedProvenance, nil)
 
 		ruleStore := &fakeAlertRuleNotificationStore{
 			RenameTimeIntervalInNotificationSettingsFn: func(ctx context.Context, orgID int64, old, new string, validate func(models.Provenance) bool, dryRun bool) ([]models.AlertRuleKey, []models.AlertRuleKey, error) {
@@ -966,12 +933,11 @@ func TestUpdateMuteTimings(t *testing.T) {
 		sut.ruleNotificationsStore = ruleStore
 
 		interval := expected
-		interval.Name = "another-time-interval"
-		timing := definitions.MuteTimeInterval{
-			UID:              expectedUID,
-			MuteTimeInterval: definitions.AmMuteTimeInterval(interval),
-			Version:          originalVersion,
-			Provenance:       definitions.Provenance(expectedProvenance),
+		interval.Title = "another-time-interval"
+		timing := v1.TimeInterval{
+			ResourceMetadata: v1.ResourceMetadata{UID: expectedUID, Version: originalVersion, Provenance: expectedProvenance},
+			Title:            interval.Title,
+			TimeIntervals:    interval.TimeIntervals,
 		}
 
 		_, err := sut.UpdateMuteTiming(context.Background(), timing, orgID)
@@ -980,8 +946,8 @@ func TestUpdateMuteTimings(t *testing.T) {
 		require.Len(t, ruleStore.Calls, 1)
 		assert.Equal(t, "RenameTimeIntervalInNotificationSettings", ruleStore.Calls[0].Method)
 		assert.Equal(t, orgID, ruleStore.Calls[0].Args[1])
-		assert.Equal(t, original.Name, ruleStore.Calls[0].Args[2])
-		assert.Equal(t, interval.Name, ruleStore.Calls[0].Args[3])
+		assert.Equal(t, original.Title, ruleStore.Calls[0].Args[2])
+		assert.Equal(t, interval.Title, ruleStore.Calls[0].Args[3])
 		assert.NotNil(t, ruleStore.Calls[0].Args[4])
 		assert.False(t, ruleStore.Calls[0].Args[5].(bool))
 	})
@@ -990,7 +956,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 		t.Run("when unable to read config", func(t *testing.T) {
 			sut, store, prov := createMuteTimingSvcSut()
 			expectedErr := errors.New("test-err")
-			prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(expectedProvenance, nil)
+			prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{expected.Title: expectedProvenance}, nil).Maybe()
 			store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {
 				return nil, expectedErr
 			}
@@ -1005,8 +971,8 @@ func TestUpdateMuteTimings(t *testing.T) {
 			}
 			expectedErr := fmt.Errorf("failed to save provenance")
 			sut.provenanceStore.(*MockProvisioningStore).EXPECT().
-				GetProvenance(mock.Anything, mock.Anything, mock.Anything).
-				Return(expectedProvenance, nil)
+				GetProvenances(mock.Anything, mock.Anything, mock.Anything).
+				Return(map[string]models.Provenance{expected.Title: expectedProvenance}, nil)
 			sut.provenanceStore.(*MockProvisioningStore).EXPECT().
 				SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return(expectedErr)
@@ -1028,8 +994,8 @@ func TestUpdateMuteTimings(t *testing.T) {
 				return &legacy_storage.ConfigRevision{Config: initialConfig()}, nil
 			}
 			sut.provenanceStore.(*MockProvisioningStore).EXPECT().
-				GetProvenance(mock.Anything, mock.Anything, mock.Anything).
-				Return(expectedProvenance, nil)
+				GetProvenances(mock.Anything, mock.Anything, mock.Anything).
+				Return(map[string]models.Provenance{expected.Title: expectedProvenance}, nil)
 			expectedErr := errors.New("test-err")
 			store.SaveFn = func(ctx context.Context, revision *legacy_storage.ConfigRevision) error {
 				return expectedErr
@@ -1051,9 +1017,10 @@ func TestUpdateMuteTimings(t *testing.T) {
 			store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {
 				return &legacy_storage.ConfigRevision{Config: initialConfig()}, nil
 			}
-			prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(expectedProvenance, nil)
-			prov.EXPECT().DeleteProvenance(mock.Anything, mock.Anything, mock.Anything).Return(nil)
-			prov.EXPECT().SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{expected.Title: expectedProvenance}, nil)
+			prov.EXPECT().GetProvenance(mock.Anything, mock.MatchedBy(func(*v1.Route) bool { return true }), mock.Anything).Return(expectedProvenance, nil).Maybe()
+			prov.EXPECT().DeleteProvenance(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+			prov.EXPECT().SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 			expectedErr := errors.New("test-err")
 
 			ruleStore := &fakeAlertRuleNotificationStore{
@@ -1064,12 +1031,11 @@ func TestUpdateMuteTimings(t *testing.T) {
 			sut.ruleNotificationsStore = ruleStore
 
 			interval := expected
-			interval.Name = "another-time-interval"
-			timing := definitions.MuteTimeInterval{
-				UID:              expectedUID,
-				MuteTimeInterval: definitions.AmMuteTimeInterval(interval),
-				Version:          originalVersion,
-				Provenance:       definitions.Provenance(expectedProvenance),
+			interval.Title = "another-time-interval"
+			timing := v1.TimeInterval{
+				ResourceMetadata: v1.ResourceMetadata{UID: expectedUID, Version: originalVersion, Provenance: expectedProvenance},
+				Title:            interval.Title,
+				TimeIntervals:    interval.TimeIntervals,
 			}
 
 			_, err := sut.UpdateMuteTiming(context.Background(), timing, orgID)
@@ -1081,8 +1047,8 @@ func TestUpdateMuteTimings(t *testing.T) {
 func TestDeleteMuteTimings(t *testing.T) {
 	orgID := int64(1)
 
-	timingToDelete := v1.TimeInterval{Name: "unused-timing"}
-	correctVersion := calculateMuteTimeIntervalFingerprint(timingToDelete)
+	timingToDelete := v1.TimeInterval{ResourceMetadata: v1.ResourceMetadata{UID: v1.TimeIntervalUID("unused-timing")}, Title: "unused-timing"}
+	correctVersion := v1.TimeIntervalFingerprint(timingToDelete)
 	usedMuteTiming := "used-timing"
 	usedActiveTiming := "used-active-timing"
 	managedRouteMuteTiming := "managed-route-used-timing"
@@ -1090,29 +1056,19 @@ func TestDeleteMuteTimings(t *testing.T) {
 	initialConfig := func() *v1.AMConfigV1 {
 		return &v1.AMConfigV1{
 			Templates: nil,
+			TimeIntervals: map[v1.ResourceUID]v1.TimeInterval{
+				v1.TimeIntervalUID(usedMuteTiming):           v1.NewTimeInterval(usedMuteTiming, nil, models.ProvenanceNone),
+				v1.TimeIntervalUID(timingToDelete.Title):     v1.NewTimeInterval(timingToDelete.Title, nil, models.ProvenanceNone),
+				v1.TimeIntervalUID(usedActiveTiming):         v1.NewTimeInterval(usedActiveTiming, nil, models.ProvenanceNone),
+				v1.TimeIntervalUID("timing-to-delete2"):      v1.NewTimeInterval("timing-to-delete2", nil, models.ProvenanceNone),
+				v1.TimeIntervalUID(managedRouteMuteTiming):   v1.NewTimeInterval(managedRouteMuteTiming, nil, models.ProvenanceNone),
+				v1.TimeIntervalUID(managedRouteActiveTiming): v1.NewTimeInterval(managedRouteActiveTiming, nil, models.ProvenanceNone),
+			},
 			AlertmanagerConfig: v1.PostableApiAlertingConfig{
 				Config: v1.Config{
 					Route: &v1.Route{
 						MuteTimeIntervals:   []string{usedMuteTiming},
 						ActiveTimeIntervals: []string{usedActiveTiming},
-					},
-					TimeIntervals: []v1.TimeInterval{
-						{
-							Name: usedMuteTiming,
-						},
-						timingToDelete,
-						{
-							Name: managedRouteMuteTiming,
-						},
-						{
-							Name: usedActiveTiming,
-						},
-						{
-							Name: "timing-to-delete2",
-						},
-						{
-							Name: managedRouteActiveTiming,
-						},
 					},
 				},
 				Receivers: nil,
@@ -1139,9 +1095,9 @@ func TestDeleteMuteTimings(t *testing.T) {
 		store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {
 			return &legacy_storage.ConfigRevision{Config: initialConfig()}, nil
 		}
-		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceAPI, nil)
+		prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{}, nil)
 
-		err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Name, orgID, definitions.Provenance(models.ProvenanceNone), correctVersion)
+		err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Title, orgID, models.ProvenanceNone, correctVersion)
 		require.ErrorIs(t, err, expectedErr)
 	})
 
@@ -1150,9 +1106,9 @@ func TestDeleteMuteTimings(t *testing.T) {
 		store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {
 			return &legacy_storage.ConfigRevision{Config: initialConfig()}, nil
 		}
-		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceAPI, nil)
+		prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{}, nil)
 
-		err := sut.DeleteMuteTiming(context.Background(), usedMuteTiming, orgID, definitions.Provenance(models.ProvenanceAPI), correctVersion)
+		err := sut.DeleteMuteTiming(context.Background(), usedMuteTiming, orgID, models.ProvenanceAPI, correctVersion)
 
 		require.Len(t, store.Calls, 1)
 		require.Equal(t, "Get", store.Calls[0].Method)
@@ -1165,9 +1121,9 @@ func TestDeleteMuteTimings(t *testing.T) {
 		store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {
 			return &legacy_storage.ConfigRevision{Config: initialConfig()}, nil
 		}
-		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceAPI, nil)
+		prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{}, nil)
 
-		err := sut.DeleteMuteTiming(context.Background(), usedActiveTiming, orgID, definitions.Provenance(models.ProvenanceAPI), correctVersion)
+		err := sut.DeleteMuteTiming(context.Background(), usedActiveTiming, orgID, models.ProvenanceAPI, correctVersion)
 
 		require.Len(t, store.Calls, 1)
 		require.Equal(t, "Get", store.Calls[0].Method)
@@ -1180,10 +1136,10 @@ func TestDeleteMuteTimings(t *testing.T) {
 		store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {
 			return &legacy_storage.ConfigRevision{Config: initialConfig()}, nil
 		}
-		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceAPI, nil)
+		prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{}, nil)
 
-		version := calculateMuteTimeIntervalFingerprint(v1.TimeInterval{Name: managedRouteMuteTiming})
-		err := sut.DeleteMuteTiming(context.Background(), managedRouteMuteTiming, orgID, definitions.Provenance(models.ProvenanceAPI), version)
+		version := v1.TimeIntervalFingerprint(v1.TimeInterval{Title: managedRouteMuteTiming})
+		err := sut.DeleteMuteTiming(context.Background(), managedRouteMuteTiming, orgID, models.ProvenanceAPI, version)
 
 		require.Len(t, store.Calls, 1)
 		require.Equal(t, "Get", store.Calls[0].Method)
@@ -1196,10 +1152,10 @@ func TestDeleteMuteTimings(t *testing.T) {
 		store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {
 			return &legacy_storage.ConfigRevision{Config: initialConfig()}, nil
 		}
-		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceAPI, nil)
+		prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{}, nil)
 
-		version := calculateMuteTimeIntervalFingerprint(v1.TimeInterval{Name: managedRouteActiveTiming})
-		err := sut.DeleteMuteTiming(context.Background(), managedRouteActiveTiming, orgID, definitions.Provenance(models.ProvenanceAPI), version)
+		version := v1.TimeIntervalFingerprint(v1.TimeInterval{Title: managedRouteActiveTiming})
+		err := sut.DeleteMuteTiming(context.Background(), managedRouteActiveTiming, orgID, models.ProvenanceAPI, version)
 
 		require.Len(t, store.Calls, 1)
 		require.Equal(t, "Get", store.Calls[0].Method)
@@ -1214,7 +1170,7 @@ func TestDeleteMuteTimings(t *testing.T) {
 			ListContactPointRoutingsFn: func(ctx context.Context, q models.ListContactPointRoutingsQuery) (map[models.AlertRuleKey]models.ContactPointRouting, error) {
 				assertInTransaction(t, ctx)
 				assert.Equal(t, orgID, q.OrgID)
-				assert.Equal(t, timingToDelete.Name, q.TimeIntervalName)
+				assert.Equal(t, timingToDelete.Title, q.TimeIntervalName)
 				assert.Empty(t, q.ReceiverName)
 				return map[models.AlertRuleKey]models.ContactPointRouting{
 					ruleKey: {},
@@ -1225,9 +1181,9 @@ func TestDeleteMuteTimings(t *testing.T) {
 		store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {
 			return &legacy_storage.ConfigRevision{Config: initialConfig()}, nil
 		}
-		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceAPI, nil)
+		prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{}, nil)
 
-		err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Name, orgID, definitions.Provenance(models.ProvenanceAPI), correctVersion)
+		err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Title, orgID, models.ProvenanceAPI, correctVersion)
 
 		require.Len(t, store.Calls, 1)
 		require.Equal(t, "Get", store.Calls[0].Method)
@@ -1246,9 +1202,9 @@ func TestDeleteMuteTimings(t *testing.T) {
 		store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {
 			return &legacy_storage.ConfigRevision{Config: initialConfig()}, nil
 		}
-		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceAPI, nil)
+		prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{}, nil)
 
-		err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Name, orgID, definitions.Provenance(models.ProvenanceAPI), "test-version")
+		err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Title, orgID, models.ProvenanceAPI, "test-version")
 
 		require.Len(t, store.Calls, 1)
 		require.Equal(t, "Get", store.Calls[0].Method)
@@ -1265,14 +1221,14 @@ func TestDeleteMuteTimings(t *testing.T) {
 			assertInTransaction(t, ctx)
 			return nil
 		}
-		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceNone, nil)
+		prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{}, nil)
 		prov.EXPECT().DeleteProvenance(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
 			func(ctx context.Context, _ models.Provisionable, _ int64) error {
 				assertInTransaction(t, ctx)
 				return nil
 			})
 
-		err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Name, orgID, "", correctVersion)
+		err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Title, orgID, "", correctVersion)
 		require.NoError(t, err)
 
 		require.Len(t, store.Calls, 2)
@@ -1283,26 +1239,22 @@ func TestDeleteMuteTimings(t *testing.T) {
 		require.Equal(t, orgID, store.Calls[1].Args[2])
 		revision := store.Calls[1].Args[1].(*legacy_storage.ConfigRevision)
 
-		expectedMuteTimings := slices.DeleteFunc(initialConfig().AlertmanagerConfig.TimeIntervals, func(interval v1.TimeInterval) bool {
-			return interval.Name == timingToDelete.Name
-		})
-		require.EqualValues(t, expectedMuteTimings, revision.Config.AlertmanagerConfig.TimeIntervals)
+		assert.NotContains(t, revision.Config.TimeIntervals, v1.TimeIntervalUID(timingToDelete.Title))
+		// Other intervals are preserved.
+		assert.Contains(t, revision.Config.TimeIntervals, v1.TimeIntervalUID(usedMuteTiming))
 
-		prov.AssertCalled(t, "DeleteProvenance", mock.Anything, &timingToDelete, orgID)
+		prov.AssertCalled(t, "DeleteProvenance", mock.Anything, mock.MatchedBy(func(mt models.Provisionable) bool { return mt.ResourceID() == timingToDelete.ResourceID() }), orgID)
 
 		t.Run("should bypass optimistic concurrency check if version is empty", func(t *testing.T) {
 			store.Calls = nil
-			err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Name, orgID, "", "")
+			err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Title, orgID, "", "")
 			require.NoError(t, err)
 
 			require.Equal(t, "Save", store.Calls[1].Method)
 			require.Equal(t, orgID, store.Calls[1].Args[2])
 			revision := store.Calls[1].Args[1].(*legacy_storage.ConfigRevision)
 
-			expectedMuteTimings := slices.DeleteFunc(initialConfig().AlertmanagerConfig.TimeIntervals, func(interval v1.TimeInterval) bool {
-				return interval.Name == timingToDelete.Name
-			})
-			require.EqualValues(t, expectedMuteTimings, revision.Config.AlertmanagerConfig.TimeIntervals)
+			assert.NotContains(t, revision.Config.TimeIntervals, v1.TimeIntervalUID(timingToDelete.Title))
 
 			prov.AssertCalled(t, "DeleteProvenance", mock.Anything, mock.MatchedBy(func(mt models.Provisionable) bool { return mt.ResourceID() == timingToDelete.ResourceID() }), orgID)
 		})
@@ -1317,17 +1269,17 @@ func TestDeleteMuteTimings(t *testing.T) {
 			assertInTransaction(t, ctx)
 			return nil
 		}
-		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceNone, nil)
+		prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{}, nil)
 		prov.EXPECT().DeleteProvenance(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
 			func(ctx context.Context, _ models.Provisionable, _ int64) error {
 				assertInTransaction(t, ctx)
 				return nil
 			})
 
-		timingToDelete := initialConfig().AlertmanagerConfig.TimeIntervals[4]
-		correctVersion := calculateMuteTimeIntervalFingerprint(timingToDelete)
+		timingToDelete := initialConfig().TimeIntervals[v1.TimeIntervalUID("timing-to-delete2")]
+		correctVersion := v1.TimeIntervalFingerprint(timingToDelete)
 
-		err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Name, orgID, "", correctVersion)
+		err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Title, orgID, "", correctVersion)
 		require.NoError(t, err)
 
 		require.Len(t, store.Calls, 2)
@@ -1338,12 +1290,12 @@ func TestDeleteMuteTimings(t *testing.T) {
 		require.Equal(t, orgID, store.Calls[1].Args[2])
 		revision := store.Calls[1].Args[1].(*legacy_storage.ConfigRevision)
 
-		expectedMuteTimings := slices.DeleteFunc(initialConfig().AlertmanagerConfig.TimeIntervals, func(interval v1.TimeInterval) bool {
-			return interval.Name == timingToDelete.Name
-		})
-		require.EqualValues(t, expectedMuteTimings, revision.Config.AlertmanagerConfig.TimeIntervals)
+		assert.NotContains(t, revision.Config.TimeIntervals, v1.TimeIntervalUID(timingToDelete.Title))
+		// Other intervals are preserved.
+		assert.Contains(t, revision.Config.TimeIntervals, v1.TimeIntervalUID(usedMuteTiming))
+		assert.Contains(t, revision.Config.TimeIntervals, v1.TimeIntervalUID(usedActiveTiming))
 
-		prov.AssertCalled(t, "DeleteProvenance", mock.Anything, mock.MatchedBy(func(mt models.Provisionable) bool { return mt.ResourceID() == timingToDelete.Name }), orgID)
+		prov.AssertCalled(t, "DeleteProvenance", mock.Anything, mock.MatchedBy(func(mt models.Provisionable) bool { return mt.ResourceID() == timingToDelete.Title }), orgID)
 	})
 
 	t.Run("deletes mute timing and provenance by UID", func(t *testing.T) {
@@ -1355,14 +1307,14 @@ func TestDeleteMuteTimings(t *testing.T) {
 			assertInTransaction(t, ctx)
 			return nil
 		}
-		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceNone, nil)
+		prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{}, nil)
 		prov.EXPECT().DeleteProvenance(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
 			func(ctx context.Context, _ models.Provisionable, _ int64) error {
 				assertInTransaction(t, ctx)
 				return nil
 			})
 
-		uid := legacy_storage.NameToUid(timingToDelete.Name)
+		uid := string(v1.TimeIntervalUID(timingToDelete.Title))
 
 		err := sut.DeleteMuteTiming(context.Background(), uid, orgID, "", correctVersion)
 		require.NoError(t, err)
@@ -1375,10 +1327,7 @@ func TestDeleteMuteTimings(t *testing.T) {
 		require.Equal(t, orgID, store.Calls[1].Args[2])
 		revision := store.Calls[1].Args[1].(*legacy_storage.ConfigRevision)
 
-		expectedMuteTimings := slices.DeleteFunc(initialConfig().AlertmanagerConfig.TimeIntervals, func(interval v1.TimeInterval) bool {
-			return interval.Name == timingToDelete.Name
-		})
-		require.EqualValues(t, expectedMuteTimings, revision.Config.AlertmanagerConfig.TimeIntervals)
+		assert.NotContains(t, revision.Config.TimeIntervals, v1.TimeIntervalUID(timingToDelete.Title))
 
 		prov.AssertCalled(t, "DeleteProvenance", mock.Anything, mock.MatchedBy(func(mt models.Provisionable) bool { return mt.ResourceID() == timingToDelete.ResourceID() }), orgID)
 	})
@@ -1387,17 +1336,17 @@ func TestDeleteMuteTimings(t *testing.T) {
 		t.Run("when unable to read config", func(t *testing.T) {
 			sut, store, prov := createMuteTimingSvcSut()
 			expectedErr := errors.New("test-err")
-			prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceNone, nil)
+			prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{}, nil)
 			store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {
 				return nil, expectedErr
 			}
-			err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Name, orgID, "", "")
+			err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Title, orgID, "", "")
 			require.ErrorIs(t, err, expectedErr)
 		})
 
 		t.Run("when provenance fails to save", func(t *testing.T) {
 			sut, store, prov := createMuteTimingSvcSut()
-			prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceNone, nil)
+			prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{}, nil)
 			store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {
 				return &legacy_storage.ConfigRevision{Config: initialConfig()}, nil
 			}
@@ -1406,7 +1355,7 @@ func TestDeleteMuteTimings(t *testing.T) {
 				DeleteProvenance(mock.Anything, mock.Anything, mock.Anything).
 				Return(expectedErr)
 
-			err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Name, orgID, "", "")
+			err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Title, orgID, "", "")
 
 			require.ErrorIs(t, err, expectedErr)
 
@@ -1419,7 +1368,7 @@ func TestDeleteMuteTimings(t *testing.T) {
 
 		t.Run("when AM config fails to save", func(t *testing.T) {
 			sut, store, prov := createMuteTimingSvcSut()
-			prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceNone, nil)
+			prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{}, nil)
 			store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {
 				return &legacy_storage.ConfigRevision{Config: initialConfig()}, nil
 			}
@@ -1428,7 +1377,7 @@ func TestDeleteMuteTimings(t *testing.T) {
 				return expectedErr
 			}
 
-			err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Name, orgID, "", "")
+			err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Title, orgID, "", "")
 
 			require.ErrorIs(t, err, expectedErr)
 
@@ -1457,6 +1406,15 @@ func createMuteTimingSvcSut() (*MuteTimingService, *legacy_storage.AlertmanagerC
 	}, store, prov
 }
 
+func hasTimeIntervalWithTitle(intervals map[v1.ResourceUID]v1.TimeInterval, title string) bool {
+	for _, ti := range intervals {
+		if ti.Title == title {
+			return true
+		}
+	}
+	return false
+}
+
 // buildMimirAMConfigWithTimeIntervals creates a Mimir alertmanager config YAML string
 // containing the provided time intervals for use in ExtraConfigs.
 // This generates a minimal but valid Prometheus alertmanager config with a route and receiver.
@@ -1474,7 +1432,7 @@ func buildMimirAMConfigWithTimeIntervals(intervals []v1.TimeInterval) string {
 	// Add time intervals
 	yaml += "time_intervals:\n"
 	for _, interval := range intervals {
-		yaml += fmt.Sprintf("  - name: %s\n", interval.Name)
+		yaml += fmt.Sprintf("  - name: %s\n", interval.Title)
 		if len(interval.TimeIntervals) > 0 {
 			yaml += "    time_intervals:\n"
 			for _, ti := range interval.TimeIntervals {
@@ -1506,12 +1464,13 @@ func buildMimirAMConfigWithTimeIntervals(intervals []v1.TimeInterval) string {
 // createConfigWithImportedIntervals creates a ConfigRevision with both Grafana and imported
 // Mimir time intervals for testing.
 func createConfigWithImportedIntervals(grafanaIntervals []v1.TimeInterval, importedIntervals []v1.TimeInterval) *legacy_storage.ConfigRevision {
-	cfg := &v1.AMConfigV1{
-		AlertmanagerConfig: v1.PostableApiAlertingConfig{
-			Config: v1.Config{
-				TimeIntervals: grafanaIntervals,
-			},
-		},
+	cfg := &v1.AMConfigV1{}
+	for _, ti := range grafanaIntervals {
+		if cfg.TimeIntervals == nil {
+			cfg.TimeIntervals = make(map[v1.ResourceUID]v1.TimeInterval)
+		}
+		ti.UID = v1.TimeIntervalUID(ti.Title)
+		cfg.TimeIntervals[ti.UID] = ti
 	}
 
 	if len(importedIntervals) > 0 {

--- a/pkg/services/ngalert/provisioning/notification_policies_test.go
+++ b/pkg/services/ngalert/provisioning/notification_policies_test.go
@@ -69,7 +69,7 @@ func TestUpdatePolicyTree(t *testing.T) {
 			{
 				Receiver: "",
 				MuteTimeIntervals: []string{
-					rev.Config.AlertmanagerConfig.TimeIntervals[0].Name,
+					"test-mute-interval",
 				},
 			},
 			{
@@ -298,10 +298,8 @@ func TestResetPolicyTree(t *testing.T) {
 	currentRevision.Config.Templates = map[v1.ResourceUID]v1.TemplateGroup{
 		v1.TemplateUID(v1.TemplateKindGrafana, "test"): v1.NewTemplateGroup("", "test", "test", v1.TemplateKindGrafana, models.ProvenanceNone),
 	}
-	currentRevision.Config.AlertmanagerConfig.TimeIntervals = []v1.TimeInterval{
-		{
-			Name: "test",
-		},
+	currentRevision.Config.TimeIntervals = map[v1.ResourceUID]v1.TimeInterval{
+		v1.TimeIntervalUID("test"): {Title: "test"},
 	}
 	currentRevision.Config.AlertmanagerConfig.Receivers = []*v1.PostableApiReceiver{
 		{
@@ -533,17 +531,15 @@ func getDefaultConfigRevision() legacy_storage.ConfigRevision {
 						Receiver: "test-receiver",
 					},
 					InhibitRules: nil,
-					TimeIntervals: []v1.TimeInterval{
-						{
-							Name: "test-mute-interval",
-						},
-					},
 				},
 				Receivers: []*v1.PostableApiReceiver{
 					{
 						Name: "test-receiver",
 					},
 				},
+			},
+			TimeIntervals: map[v1.ResourceUID]v1.TimeInterval{
+				v1.TimeIntervalUID("test-mute-interval"): {Title: "test-mute-interval"},
 			},
 		},
 		ConcurrencyToken: util.GenerateShortUID(),

--- a/pkg/services/ngalert/remote/alertmanager_test.go
+++ b/pkg/services/ngalert/remote/alertmanager_test.go
@@ -626,7 +626,7 @@ func TestCompareAndSendConfiguration(t *testing.T) {
 					AlertmanagerConfig: func() definition.PostableApiAlertingConfig {
 						c := policy_exports.Config()
 						c.AlertmanagerConfig.Route = legacy_storage.WithManagedRoutes(c.AlertmanagerConfig.Route, c.ManagedRoutes)
-						return notifier.PostableApiAlertingConfigToAPI(c.AlertmanagerConfig)
+						return notifier.PostableApiAlertingConfigToAPI(c.AlertmanagerConfig, c.SortedTimeIntervals())
 					}(),
 				},
 			},

--- a/pkg/services/provisioning/alerting/config_reader_test.go
+++ b/pkg/services/provisioning/alerting/config_reader_test.go
@@ -131,7 +131,7 @@ func TestConfigReader(t *testing.T) {
 	t.Run("a mute times file with correct properties and specific org should not error", func(t *testing.T) {
 		file, err := configReader.readConfig(ctx, testFileCorrectProperties_mt)
 		require.NoError(t, err)
-		require.Equal(t, "test", file[0].MuteTimes[0].MuteTime.Name)
+		require.Equal(t, "test", file[0].MuteTimes[0].MuteTime.Title)
 	})
 	t.Run("a mute times file with correct properties and specific org should not error", func(t *testing.T) {
 		file, err := configReader.readConfig(ctx, testFileCorrectPropertiesWithOrg_mt)

--- a/pkg/services/provisioning/alerting/mute_times_provisioner.go
+++ b/pkg/services/provisioning/alerting/mute_times_provisioner.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 )
@@ -29,7 +28,7 @@ func NewMuteTimesProvisioner(logger log.Logger,
 
 func (c *defaultMuteTimesProvisioner) Provision(ctx context.Context,
 	files []*AlertingFile) error {
-	cache := map[int64]map[string]definitions.MuteTimeInterval{}
+	cache := map[int64]map[string]struct{}{}
 	for _, file := range files {
 		for _, muteTiming := range file.MuteTimes {
 			if _, exists := cache[muteTiming.OrgID]; !exists {
@@ -37,13 +36,13 @@ func (c *defaultMuteTimesProvisioner) Provision(ctx context.Context,
 				if err != nil {
 					return err
 				}
-				cache[muteTiming.OrgID] = make(map[string]definitions.MuteTimeInterval, len(intervals))
+				cache[muteTiming.OrgID] = make(map[string]struct{}, len(intervals))
 				for _, interval := range intervals {
-					cache[muteTiming.OrgID][interval.Name] = interval
+					cache[muteTiming.OrgID][interval.Title] = struct{}{}
 				}
 			}
-			muteTiming.MuteTime.Provenance = definitions.Provenance(models.ProvenanceFile)
-			if _, exists := cache[muteTiming.OrgID][muteTiming.MuteTime.Name]; exists {
+			muteTiming.MuteTime.Provenance = models.ProvenanceFile
+			if _, exists := cache[muteTiming.OrgID][muteTiming.MuteTime.Title]; exists {
 				_, err := c.muteTimingService.UpdateMuteTiming(ctx, muteTiming.MuteTime, muteTiming.OrgID)
 				if err != nil {
 					return err
@@ -63,7 +62,7 @@ func (c *defaultMuteTimesProvisioner) Unprovision(ctx context.Context,
 	files []*AlertingFile) error {
 	for _, file := range files {
 		for _, deleteMuteTime := range file.DeleteMuteTimes {
-			err := c.muteTimingService.DeleteMuteTiming(ctx, deleteMuteTime.Name, deleteMuteTime.OrgID, definitions.Provenance(models.ProvenanceFile), "")
+			err := c.muteTimingService.DeleteMuteTiming(ctx, deleteMuteTime.Name, deleteMuteTime.OrgID, models.ProvenanceFile, "")
 			if err != nil {
 				return err
 			}

--- a/pkg/services/provisioning/alerting/mute_times_types.go
+++ b/pkg/services/provisioning/alerting/mute_times_types.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
 	"github.com/grafana/grafana/pkg/services/provisioning/values"
 )
 
@@ -13,20 +15,26 @@ type MuteTimeV1 struct {
 	MuteTime definitions.MuteTimeInterval `json:",inline" yaml:",inline"`
 }
 
-func (v1 *MuteTimeV1) mapToModel() MuteTime {
-	orgID := v1.OrgID.Value()
+func (mt *MuteTimeV1) mapToModel() MuteTime {
+	orgID := mt.OrgID.Value()
 	if orgID < 1 {
 		orgID = 1
 	}
 	return MuteTime{
-		OrgID:    orgID,
-		MuteTime: v1.MuteTime,
+		OrgID: orgID,
+		MuteTime: v1.TimeInterval{
+			ResourceMetadata: v1.ResourceMetadata{
+				Provenance: models.ProvenanceFile,
+			},
+			Title:         mt.MuteTime.Name,
+			TimeIntervals: mt.MuteTime.TimeIntervals,
+		},
 	}
 }
 
 type MuteTime struct {
 	OrgID    int64
-	MuteTime definitions.MuteTimeInterval
+	MuteTime v1.TimeInterval
 }
 
 type DeleteMuteTimeV1 struct {

--- a/pkg/tests/apis/alerting/notifications/routingtree/routing_tree_test.go
+++ b/pkg/tests/apis/alerting/notifications/routingtree/routing_tree_test.go
@@ -892,7 +892,7 @@ func TestIntegrationMultipleRoutesCRUD(t *testing.T) {
 	// Prep config so that referenced receivers and time intervals exist.
 	cfg := policy_exports.Config()
 	createReceiverStubs(t, admin, cfg.AlertmanagerConfig.Receivers)
-	createTimeIntervalStubs(t, admin, cfg.AlertmanagerConfig.TimeIntervals)
+	createTimeIntervalStubs(t, admin, cfg.SortedTimeIntervals())
 
 	// Sanity check there aren't any existing managed routes other than the default.
 	list, err := adminClient.List(ctx, apis.DefaultNamespace, resource.ListOptions{})
@@ -1419,12 +1419,13 @@ func TestIntegrationMultipleRoutesReferentialIntegrity(t *testing.T) {
 	// Prep config so that referenced receivers and time intervals exist.
 	cfg := policy_exports.Config()
 	receivers := createReceiverStubs(t, admin, cfg.AlertmanagerConfig.Receivers)
-	timeIntervals := createTimeIntervalStubs(t, admin, cfg.AlertmanagerConfig.TimeIntervals)
+	sortedIntervals := cfg.SortedTimeIntervals()
+	timeIntervals := createTimeIntervalStubs(t, admin, sortedIntervals)
 
 	recv0 := cfg.AlertmanagerConfig.Receivers[0].Name
 	recv1 := cfg.AlertmanagerConfig.Receivers[1].Name
-	ti0 := cfg.AlertmanagerConfig.TimeIntervals[0].Name
-	ti1 := cfg.AlertmanagerConfig.TimeIntervals[1].Name
+	ti0 := sortedIntervals[0].Title
+	ti1 := sortedIntervals[1].Title
 
 	// Create routes that reference the receivers and time intervals.
 	routeDef := v1model.Route{
@@ -1550,10 +1551,10 @@ func createTimeIntervalStubs(t *testing.T, user apis.User, timeIntervals []v1mod
 	for _, ti := range timeIntervals {
 		created, err := timeIntervalClient.Create(context.Background(), &v1beta1.TimeInterval{
 			ObjectMeta: v1.ObjectMeta{Namespace: apis.DefaultNamespace},
-			Spec:       v1beta1.TimeIntervalSpec{Name: ti.Name},
+			Spec:       v1beta1.TimeIntervalSpec{Name: ti.Title},
 		}, resource.CreateOptions{})
 		require.NoError(t, err)
-		res[ti.Name] = created
+		res[ti.Title] = created
 	}
 	return res
 }

--- a/pkg/tests/apis/alerting/notifications/timeinterval/timeinterval_test.go
+++ b/pkg/tests/apis/alerting/notifications/timeinterval/timeinterval_test.go
@@ -10,7 +10,6 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/prometheus/alertmanager/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -31,6 +30,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/folder/foldertest"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+	v1model "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/tests/api/alerting"
@@ -694,10 +694,8 @@ func TestIntegrationTimeIntervalListSelector(t *testing.T) {
 	ac := acimpl.ProvideAccessControl(env.FeatureToggles)
 	db, err := store.ProvideDBStore(env.Cfg, env.FeatureToggles, env.SQLStore, &foldertest.FakeService{}, &dashboards.FakeDashboardService{}, ac, bus.ProvideBus(tracing.InitializeTracerForTest()))
 	require.NoError(t, err)
-	require.NoError(t, db.SetProvenance(ctx, &definitions.MuteTimeInterval{
-		MuteTimeInterval: config.MuteTimeInterval{
-			Name: interval2.Spec.Name,
-		},
+	require.NoError(t, db.SetProvenance(ctx, &v1model.TimeInterval{
+		Title: interval2.Spec.Name,
 	}, helper.Org1.Admin.Identity.GetOrgID(), "API"))
 	interval2, err = adminClient.Get(ctx, interval2.GetStaticMetadata().Identifier())
 
@@ -765,10 +763,11 @@ func TestIntegrationTimeIntervalReferentialIntegrity(t *testing.T) {
 	var amConfig definitions.PostableUserConfig
 	require.NoError(t, json.Unmarshal(alertmanagerRaw, &amConfig))
 
-	mtis := make([]definitions.MuteTimeInterval, 0, len(amConfig.AlertmanagerConfig.MuteTimeIntervals))
+	mtis := make([]v1model.TimeInterval, 0, len(amConfig.AlertmanagerConfig.MuteTimeIntervals))
 	for _, interval := range amConfig.AlertmanagerConfig.MuteTimeIntervals {
-		mtis = append(mtis, definitions.MuteTimeInterval{
-			MuteTimeInterval: interval,
+		mtis = append(mtis, v1model.TimeInterval{
+			Title:         interval.Name,
+			TimeIntervals: interval.TimeIntervals,
 		})
 	}
 


### PR DESCRIPTION
## What is this feature?

Another step in the incremental refactor that moves each Alertmanager resource out of `AMConfigV1.AlertmanagerConfig.Config` into a top-level UID-keyed map on `AMConfigV1`.

## Why do we need this feature?

`v1.TimeInterval` was a bare `{Name, TimeIntervals}` alias with no identity of its own.
Every caller had to derive the UID from the name, recompute the version fingerprint, and
fetch provenance separately. Identity logic was duplicated across the provisioning
service, the k8s layer and the merge code, and `definitions.MuteTimeInterval` (a wire type)
was being passed around as the service-layer model.

The larger effort intends to separate db/domain/api layer models and add dedicated persisted UIDs to alertmanager resources.

## What changed

**Model**
- `v1.TimeInterval` becomes a first-class resource in its own file: embeds
  `ResourceMetadata` (UID, Version, Provenance), `Name` becomes `Title` to disambiguate from k8s Name, and gains
  `NewTimeInterval`, `TimeIntervalUID`, `TimeIntervalFingerprint` and `Validate()` methods.
- `AMConfigV1.TimeIntervals` moves from `AlertmanagerConfig.Config.TimeIntervals
  []TimeInterval` to a top-level `map[ResourceUID]TimeInterval`.
- The fingerprint moves out of `provisioning` into the model; version is carried on the
  resource instead of being recomputed per call.

**Service and API**
- `MuteTimingService` and the k8s `TimeIntervalService` interfaces now speak
  `v1.TimeInterval`. `definitions.MuteTimeInterval` survives only as the wire DTO,
  converted at the edge by the new `api/compat_mute_timings.go`.
- `ConfigRevision` gains `GetTimeIntervalWithTitle` / `SetTimeInterval` /
  `DeleteTimeInterval`, mirroring the templates and inhibition-rule helpers.
- Provenance is assigned onto the model once per request rather than looked up per interval.
- `merge.TimeIntervals` operates on the map and returns added UIDs, matching `MergeTemplates`.

## Behaviour changes

- Time intervals are written back to the DB sorted by name rather than in stored order.
  Visible in the raw Alertmanager config `GET` and in exports; hence the golden-file churn
  in `merge/testdata/`.

## Special notes for your reviewer

Backend only. No API schema, response shape or frontend changes.

The new `v1/time_interval_test.go` pins the fingerprint with a golden hash plus a
reflect-driven check that every `ResourceMetadata` field is excluded from it and every
`timeinterval.TimeInterval` field is included, so a future field addition fails loudly
rather than silently invalidating stored versions.

- Removes a `400 "title of cannot be changed"` from the k8s time-interval update path. The
  condition compared `metadata.name` against a UID derived from that same value, so it was
  unreachable; renames were already supported and are covered by integration tests.

## Core changes

1. `v1/time_interval.go`: the point of the PR. The new resource type: `ResourceMetadata` + `Title`, `NewTimeInterval`, `TimeIntervalUID`, `TimeIntervalFingerprint`, `Validate()`, `SortedTimeIntervals()`. Everything else follows from this file.
2. `provisioning/mute_timings.go`: the largest behavioural rewrite. `Provenance` is now assigned in one pass over the revision instead of per-lookup; create/update/delete operate on the UID-keyed map; version handling delegates to the model.
3. `v1/compat.go`: the model/DB boundary. `TimeIntervalsToModel` folds both interval lists into one UID map, and `PostableApiAlertingConfigToDB` now takes `SortedTimeIntervals()` that single argument is what makes every save name-sorted, and is the whole reason the golden files churn.
4. `merge/merge.go`: merging over a map rather than a slice.
5. `legacy_storage/time_intervals.go`: some small helpers mirroring other resources.
