### PR TITLE
Alerting: Fix reset default route wiping provenance for all managed routes

### DIFF
--- a/pkg/services/ngalert/store/provisioning_store.go
+++ b/pkg/services/ngalert/store/provisioning_store.go
@@ -239,11 +239,13 @@ func managerFromRecord(record provenanceRecord) utils.ManagerProperties {
 // DeleteProvenance deletes the provenance record from the table
 func (st DBstore) DeleteProvenance(ctx context.Context, o models.Provisionable, org int64) error {
 	return st.SQLStore.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
-		_, err := sess.Delete(provenanceRecord{
-			RecordKey:  o.ResourceID(),
-			RecordType: o.ResourceType(),
-			OrgID:      org,
-		})
+		// Explicit Where+Delete, not sess.Delete(&provenanceRecord{...}): xorm's struct-based
+		// Delete only conditions on non-zero fields, so a resource with ResourceID() == ""
+		// (e.g. the default alerting route) would drop record_key from the WHERE clause
+		// entirely and delete every record of that record_type/org.
+		_, err := sess.Table(provenanceRecord{}).
+			Where("record_key = ? AND record_type = ? AND org_id = ?", o.ResourceID(), o.ResourceType(), org).
+			Delete(&provenanceRecord{})
 		return err
 	})
 }

--- a/pkg/services/ngalert/store/provisioning_store_test.go
+++ b/pkg/services/ngalert/store/provisioning_store_test.go
@@ -203,9 +203,40 @@ func TestIntegrationProvisioningStore(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, models.ProvenanceNone, p)
 			})
+
+			t.Run("Deleting provenance of a resource with an empty ResourceID does not affect siblings of the same type", func(t *testing.T) {
+				// Some Provisionable resources (e.g. the default alerting route) use "" as their
+				// ResourceID for backwards compatibility, while sharing ResourceType with sibling
+				// resources that have real, non-empty IDs. Deleting the empty-ID one must not wipe
+				// out provenance for the others.
+				const orgID = 5678
+				empty := fakeProvisionable{resourceType: "route", resourceID: ""}
+				sibling := fakeProvisionable{resourceType: "route", resourceID: "route-a"}
+
+				require.NoError(t, store.SetProvenance(context.Background(), empty, orgID, models.ProvenanceFile))
+				require.NoError(t, store.SetProvenance(context.Background(), sibling, orgID, models.ProvenanceAPI))
+
+				require.NoError(t, store.DeleteProvenance(context.Background(), empty, orgID))
+
+				p, err := store.GetProvenance(context.Background(), empty, orgID)
+				require.NoError(t, err)
+				require.Equal(t, models.ProvenanceNone, p)
+
+				p, err = store.GetProvenance(context.Background(), sibling, orgID)
+				require.NoError(t, err)
+				require.Equal(t, models.ProvenanceAPI, p)
+			})
 		})
 	}
 }
+
+type fakeProvisionable struct {
+	resourceType string
+	resourceID   string
+}
+
+func (f fakeProvisionable) ResourceType() string { return f.resourceType }
+func (f fakeProvisionable) ResourceID() string   { return f.resourceID }
 
 func TestIntegrationProvisioningStoreManagerProperties(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)


### PR DESCRIPTION
Fixes a bug where deleting/resetting the default ("user-defined") alerting route also deleted the provenance of every other managed route in the org.

### Cause
                                                                                                                                                                                                                                                             
`ManagedRoute.ResourceID()` returns `""` for the default route (intentional, for legacy RBAC identity compatibility). `DBstore.DeleteProvenance` passed this into xorm's struct-based `sess.Delete(provenanceRecord{...})`, which
only builds WHERE conditions from non-zero struct fields, so an empty `RecordKey` was dropped from the query entirely. The delete degraded to `DELETE FROM provenance_type WHERE record_type = 'route' AND org_id = ?`, removing every managed route's provenance instead of just the default route's.

Every other method in `provisioning_store.go` already avoids this xorm pitfall by using explicit parameterized `Where(...)` clauses; `DeleteProvenance` was the one outlier still relying on struct-based condition matching.

### Fix

Build the delete with an explicit `Where("record_key = ? AND record_type = ? AND org_id = ?", ...)` clause instead of passing a struct with zero-valued fields.

Fixes #129430