### PR TITLE
DataViz: Fix sparklines flattening to zero for values below 1e-6

### DIFF
--- a/packages/grafana-data/src/utils/numbers.test.ts
+++ b/packages/grafana-data/src/utils/numbers.test.ts
@@ -1,0 +1,43 @@
+import { guessDecimals, roundDecimals } from './numbers';
+
+describe('guessDecimals', () => {
+  it.each([
+    [10, 0],
+    [10.5, 1],
+    [0.125, 3],
+    [-0.25, 2],
+    [0.000001, 6], // largest magnitude still stringified in decimal notation
+  ])('counts decimals of plain notation %d', (input, expected) => {
+    expect(guessDecimals(input)).toBe(expected);
+  });
+
+  it.each([
+    [1e-7, 7],
+    [5e-7, 7],
+    [1.5e-7, 8],
+    [-1.5e-7, 8],
+    [2.5e-8, 9],
+  ])('derives decimals from the exponent for %d (stringified exponentially)', (input, expected) => {
+    expect(guessDecimals(input)).toBe(expected);
+  });
+
+  it.each([
+    [1e21, 0],
+    [1.5e21, 0],
+    [-1e22, 0],
+  ])('returns 0 for large exponential notation %d', (input, expected) => {
+    expect(guessDecimals(input)).toBe(expected);
+  });
+
+  it('keeps the documented heuristic behavior for imprecise floats', () => {
+    expect(guessDecimals(371.499999999999)).toBe(12);
+  });
+
+  it('no longer collapses a sub-1e-6 range to zero when picking sparkline precision', () => {
+    // The Sparkline fallback: decimals = max(guessDecimals(min), guessDecimals(max))
+    const min = 1e-7;
+    const max = 5e-7;
+    const decimals = Math.max(guessDecimals(min), guessDecimals(max));
+    expect(roundDecimals(min, decimals)).not.toBe(roundDecimals(max, decimals));
+  });
+});

--- a/packages/grafana-data/src/utils/numbers.ts
+++ b/packages/grafana-data/src/utils/numbers.ts
@@ -25,5 +25,16 @@ export function roundDecimals(val: number, dec = 0) {
  * bad  for arbitrary floats:     371.499999999999 -> 12
  */
 export function guessDecimals(num: number) {
-  return (('' + num).split('.')[1] || '').length;
+  const str = '' + num;
+  const eIndex = str.indexOf('e');
+
+  // JS switches to exponential notation below 1e-6 and at or above 1e21, so the
+  // string is not a decimal expansion; derive the count from the exponent instead.
+  if (eIndex !== -1) {
+    const exponent = Number(str.slice(eIndex + 1));
+    const mantissaDecimals = (str.slice(0, eIndex).split('.')[1] || '').length;
+    return Math.max(0, mantissaDecimals - exponent);
+  }
+
+  return (str.split('.')[1] || '').length;
 }


### PR DESCRIPTION
**What is this feature?**

`guessDecimals` counts decimal places by splitting the string form of a number on the decimal point. JavaScript switches to exponential notation below 1e-6 and at or above 1e21, so for those values the string isn't a decimal expansion and the count comes out wrong.

1e-7 returns 0, and 1.5e-7 returns 4 by counting the characters of the exponent (5e-7) as if they were decimal places.

Plain-notation behaviour is unchanged, including the documented heuristic weakness for imprecise floats e.g. 371.499999999999 turning to 12 which is pinned by a test.

The fix derives the count from the exponent when the string form is exponential so 
1e-7 is now 7,
1.5e-7 is now 8, 
1e21 stays 0 

**Why do we need this feature?**

`Sparkline/utils.ts` uses `guessDecimals(min)`/`guessDecimals(max)` as the fallback rounding precision for the sparkline's own range. For any series sitting below 1e-6 (small error rates, ratios), the guess comes out as 0, both ends round to zero, and the sparkline collapses to a flat line. UPlotAxisBuilder hits the same root cause on its tick-increment path, though its existing `roundDecimals(tickIncr, 6)` cap masks the worst of it.

**Who is this feature for?**

Anyone visualising sub-1e-6 values in Stat panel sparklines or timeseries axes.

**Which issue(s) does this PR fix?**:

Fixes #130409

**Special notes for your reviewer:**

Added new unit tests in numbers.test.ts covering both sides of the 1e-6 stringification boundary, the large-exponent clamp, negatives, and a case replicating the Sparkline min/max fallback to show the range no longer collapses. 7 of the 15 cases fail without the fix.

Existing Sparkline and uPlot suites pass unchanged (189 tests), and typecheck/lint/prettier are clean.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
