### PR TITLE
Logs Table: Time sorting now exclusively managed from the Table Controls

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/components/HeaderCell.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/HeaderCell.test.tsx
@@ -78,6 +78,42 @@ describe('HeaderCell', () => {
     expect(screen.queryByLabelText('Filter Field1')).not.toBeInTheDocument();
   });
 
+  it('uses the display name as the native title when there is no description', () => {
+    render(<HeaderCell {...baseProps} field={makeField()} />);
+    expect(screen.getByRole('button', { name: 'Field1' })).toHaveAttribute('title', 'Field1');
+  });
+
+  it('shows a tooltip from the field description instead of a native title', async () => {
+    render(
+      <HeaderCell
+        {...baseProps}
+        field={makeField({
+          config: {
+            description: 'Time sorting is controlled by the table controls on the right side',
+            custom: { sortable: false },
+          },
+        })}
+      />
+    );
+    const label = screen.getByRole('button', { name: 'Field1' });
+    expect(label).not.toHaveAttribute('title');
+    await userEvent.hover(label);
+    expect(
+      await screen.findByText('Time sorting is controlled by the table controls on the right side')
+    ).toBeInTheDocument();
+  });
+
+  it('still renders the sort direction indicator when the column is not header-sortable', () => {
+    const { container } = render(
+      <HeaderCell
+        {...baseProps}
+        direction="DESC"
+        field={makeField({ config: { custom: { sortable: false } } })}
+      />
+    );
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
   it('exposes the filter popover state via aria-expanded on the filter button', async () => {
     render(<HeaderCell {...baseProps} field={makeField({ config: { custom: { filterable: true } } })} />);
     const filterButton = screen.getByLabelText('Filter Field1');

--- a/packages/grafana-ui/src/components/Table/TableNG/components/HeaderCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/HeaderCell.tsx
@@ -9,6 +9,7 @@ import { useStyles2 } from '../../../../themes/ThemeContext';
 import { getFieldTypeIcon } from '../../../../types/icon';
 import { Icon } from '../../../Icon/Icon';
 import { Stack } from '../../../Layout/Stack/Stack';
+import { Tooltip } from '../../../Tooltip/Tooltip';
 import { Filter } from '../Filter/Filter';
 import { type FilterType, type TableRow, type TableSummaryRow } from '../types';
 import { getDisplayName } from '../utils';
@@ -44,9 +45,11 @@ export const HeaderCell: React.FC<HeaderCellProps> = ({
 }) => {
   const ref = useRef<HTMLDivElement>(null);
   const headerCellWrap = field.config.custom?.wrapHeaderText ?? false;
-  const styles = useStyles2(getStyles, headerCellWrap);
+  const sortable = field.config.custom?.sortable !== false;
+  const styles = useStyles2(getStyles, headerCellWrap, sortable);
   const displayName = getDisplayName(field);
   const filterable = field.config.custom?.filterable ?? false;
+  const tooltipContent = field.config.description;
 
   // we have to remove/reset the filter if the column is not filterable
   useEffect(() => {
@@ -58,6 +61,20 @@ export const HeaderCell: React.FC<HeaderCellProps> = ({
       });
     }
   }, [filterable, displayName, filter, setFilter]);
+
+  const headerLabel = (
+    <button
+      tabIndex={0}
+      className={styles.headerCellLabel}
+      title={tooltipContent ? undefined : displayName}
+      type="button"
+    >
+      {displayName}
+      {direction && (
+        <Icon className={styles.headerCellIcon} size="lg" name={direction === 'ASC' ? 'arrow-up' : 'arrow-down'} />
+      )}
+    </button>
+  );
 
   /* eslint-disable jsx-a11y/no-static-element-interactions */
   return (
@@ -100,12 +117,13 @@ export const HeaderCell: React.FC<HeaderCellProps> = ({
       {showTypeIcons && (
         <Icon className={styles.headerCellIcon} name={getFieldTypeIcon(field)} title={field?.type} size="sm" />
       )}
-      <button tabIndex={0} className={styles.headerCellLabel} title={displayName}>
-        {displayName}
-        {direction && (
-          <Icon className={styles.headerCellIcon} size="lg" name={direction === 'ASC' ? 'arrow-up' : 'arrow-down'} />
-        )}
-      </button>
+      {tooltipContent ? (
+        <Tooltip content={tooltipContent} placement="top">
+          {headerLabel}
+        </Tooltip>
+      ) : (
+        headerLabel
+      )}
 
       {filterable && (
         <Filter
@@ -124,10 +142,10 @@ export const HeaderCell: React.FC<HeaderCellProps> = ({
   );
 };
 
-const getStyles = memoize((theme: GrafanaTheme2, headerTextWrap?: boolean) => ({
+const getStyles = memoize((theme: GrafanaTheme2, headerTextWrap?: boolean, sortable = true) => ({
   headerCellLabel: css({
     all: 'unset',
-    cursor: 'pointer',
+    cursor: sortable ? 'pointer' : 'default',
     fontWeight: theme.typography.fontWeightMedium,
     color: theme.colors.text.secondary,
     overflow: 'hidden',
@@ -136,7 +154,7 @@ const getStyles = memoize((theme: GrafanaTheme2, headerTextWrap?: boolean) => ({
     borderRadius: theme.spacing(0.25),
     lineHeight: '20px',
     '&:hover': {
-      textDecoration: 'underline',
+      textDecoration: sortable ? 'underline' : 'none',
     },
     '&::selection': {
       backgroundColor: 'var(--rdg-background-color)',

--- a/packages/grafana-ui/src/components/Table/TableNG/render-hooks.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/render-hooks.test.tsx
@@ -380,6 +380,42 @@ describe('useColumnBuilderFromFields', () => {
     expect(result.columns[1].width).toBe(200);
   });
 
+  it('marks columns sortable by default', () => {
+    const hook = renderColumnBuilderHook({ filterResult: makeFilterResult(), config: makeConfig() });
+    const result = callFromFields(hook, frame.fields, [100, 100], frame, rows, rows);
+    expect(result.columns[0].sortable).toBe(true);
+    expect(result.columns[1].sortable).toBe(true);
+  });
+
+  it('disables header sorting when field.config.custom.sortable is false', () => {
+    const nonSortableFrame = createDataFrame({
+      fields: [
+        {
+          name: 'timestamp',
+          type: FieldType.time,
+          values: [1, 2],
+          config: { custom: { sortable: false } },
+        },
+        { name: 'body', type: FieldType.string, values: ['a', 'b'] },
+      ],
+    });
+    const nonSortableRows: TableRow[] = [
+      { __depth: 0, __index: 0, timestamp: 1, body: 'a' },
+      { __depth: 0, __index: 1, timestamp: 2, body: 'b' },
+    ];
+    const hook = renderColumnBuilderHook({ filterResult: makeFilterResult(), config: makeConfig() });
+    const result = callFromFields(
+      hook,
+      nonSortableFrame.fields,
+      [100, 100],
+      nonSortableFrame,
+      nonSortableRows,
+      nonSortableRows
+    );
+    expect(result.columns[0].sortable).toBe(false);
+    expect(result.columns[1].sortable).toBe(true);
+  });
+
   function makePillFrame({ withMappings }: { withMappings: boolean }): DataFrame {
     return createDataFrame({
       fields: [

--- a/packages/grafana-ui/src/components/Table/TableNG/render-hooks.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/render-hooks.tsx
@@ -507,6 +507,9 @@ function buildColumnsFromFields(
       key: displayName,
       name: displayName,
       width,
+      // Default true; set field.config.custom.sortable === false to disable header-click sorting.
+      // Programmatic sortColumns (e.g. managed sortBy) still apply when sortable is false.
+      sortable: field.config.custom?.sortable !== false,
       headerCellClass,
       frozen: Math.min(frozenColumns, numFrozenColsFullyInView) > i,
       renderCell: renderCellContent,

--- a/public/app/plugins/panel/logstable/hooks/useOrganizeFields.test.tsx
+++ b/public/app/plugins/panel/logstable/hooks/useOrganizeFields.test.tsx
@@ -267,6 +267,37 @@ describe('useOrganizeFields', () => {
         expect(organizedFields.current.organizedFrame?.fields[0].config.custom.filterable).toBe(true);
       });
     });
+
+    test('disables timestamp header sorting and sets a controls tooltip', async () => {
+      const { result: organizedFields } = renderHook(() =>
+        useOrganizeFields({
+          extractedFrame,
+          bodyFieldName: LOGS_DATAPLANE_BODY_NAME,
+          levelFieldName: 'level',
+          logsFrame: testLogsFrame,
+          onPermalinkClick: () => null,
+          options: {},
+          supportsPermalink: false,
+          timeFieldName: LOGS_DATAPLANE_TIMESTAMP_NAME,
+          fieldConfig: { defaults: {}, overrides: [] },
+        })
+      );
+
+      await waitFor(() => {
+        const timeField = organizedFields.current.organizedFrame?.fields.find(
+          (f) => f.name === LOGS_DATAPLANE_TIMESTAMP_NAME
+        );
+        const bodyField = organizedFields.current.organizedFrame?.fields.find(
+          (f) => f.name === LOGS_DATAPLANE_BODY_NAME
+        );
+        expect(timeField?.config.custom?.sortable).toBe(false);
+        expect(timeField?.config.description).toBe(
+          'Time sorting is controlled by the table controls on the right side'
+        );
+        expect(bodyField?.config.custom?.sortable).not.toBe(false);
+        expect(bodyField?.config.description).toBeUndefined();
+      });
+    });
   });
 
   describe('log level column enhancements', () => {

--- a/public/app/plugins/panel/logstable/hooks/useOrganizeFields.tsx
+++ b/public/app/plugins/panel/logstable/hooks/useOrganizeFields.tsx
@@ -4,6 +4,7 @@ import useMountedState from 'react-use/lib/useMountedState';
 import { lastValueFrom } from 'rxjs';
 
 import { type DataFrame, type FieldConfigSource, transformDataFrame } from '@grafana/data';
+import { t } from '@grafana/i18n';
 import { type CustomCellRendererProps, TableCellDisplayMode } from '@grafana/ui';
 import { type LogsFrame } from 'app/features/logs/logsFrame';
 
@@ -149,15 +150,26 @@ const organizeFields = async (
         configAfterLevel.custom.cellOptions = undefined;
       }
 
+      const isTimeField = field.name === timeFieldName;
+
       field.config = {
         ...configAfterLevel,
+        // Time sort is driven by LogTableControls; keep managed sortBy working but disable header-click sorting.
+        ...(isTimeField
+          ? {
+              description: t(
+                'logs.logs-table.timestamp-sort-tooltip',
+                'Use the table controls on the right to manage time sorting.'
+              ),
+            }
+          : {}),
         filterable: field.config?.filterable ?? doesFieldSupportAdHocFiltering(field, timeFieldName, bodyFieldName),
         custom: {
           ...configAfterLevel.custom,
-          width:
-            field.name === timeFieldName
-              ? getTimeFieldWidth(configAfterLevel.custom?.width, fieldIndex, options)
-              : configAfterLevel.custom?.width,
+          width: isTimeField
+            ? getTimeFieldWidth(configAfterLevel.custom?.width, fieldIndex, options)
+            : configAfterLevel.custom?.width,
+          ...(isTimeField ? { sortable: false } : {}),
           inspect: configAfterLevel.custom?.inspect ?? doesFieldSupportInspector(field),
           cellOptions:
             isFirstField && bodyFieldName && (supportsPermalink || options.enableLogDetails)


### PR DESCRIPTION
POC.


https://github.com/user-attachments/assets/5d4ffe27-07d6-482e-8245-a5603fc32515

