### PR TITLE
Navigation: drop a duplicate test mutex that breaks the build

### DIFF
--- a/pkg/services/navtree/navtreeimpl/applinks_test.go
+++ b/pkg/services/navtree/navtreeimpl/applinks_test.go
@@ -2,7 +2,6 @@ package navtreeimpl
 
 import (
 	"net/http"
-	"sync"
 	"testing"
 
 	"github.com/open-feature/go-sdk/openfeature"
@@ -1061,10 +1060,9 @@ func TestNestMaintenanceWindowsUnderSLO(t *testing.T) {
 	})
 }
 
-var openfeatureTestMutex sync.Mutex
-
 // setupOpenFeatureFlag sets a global OpenFeature provider for the duration of the
 // test, guarded by a mutex so flag-dependent tests don't race on the shared client.
+// The mutex is declared in navtree_test.go and shared across the package.
 func setupOpenFeatureFlag(t *testing.T, flag string, value bool) {
 	t.Helper()
 	openfeatureTestMutex.Lock()


### PR DESCRIPTION
Two changes each added a package-level `openfeatureTestMutex` in a different file of `navtreeimpl`, so neither conflicted on merge and the package stopped compiling:

- `navtree_test.go` — #130445, merged 11 Aug
- `applinks_test.go` — #127817, merged 12 Aug

Since then `lint-go` fails with `openfeatureTestMutex redeclared in this block`, and the backend test shards fail with it, on every pull request against main.

This keeps the declaration in `navtree_test.go`, which carries the comment explaining what it is for, and drops the one in `applinks_test.go` along with its now-unused `sync` import. Both helpers go on sharing the one mutex, which is what each was after.

Test code only.

Not addressed here: the package now has two helpers doing much the same job, `setupOpenFeatureFlag` and `setOpenFeatureFlags`, which is probably why both changes reached for their own mutex. Worth merging, but not in a fix meant to go in quickly.