### PR TITLE
unified-search: skip snapshots missing a required index feature

### DIFF
--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -205,9 +205,16 @@ func RequiredIndexFeatures(postRankAuthz bool) []IndexFeature {
 // Features the index has and this binary does not require are ignored: an index
 // from a newer binary is the build version check's business.
 func MissingIndexFeatures(buildInfo IndexBuildInfo, requiredFeatures []IndexFeature) []IndexFeature {
+	return MissingFeatures(buildInfo.Features, requiredFeatures)
+}
+
+// MissingFeatures returns the required features absent from have. Takes the
+// feature list on its own, for callers holding a snapshot manifest rather than
+// an opened index.
+func MissingFeatures(have, requiredFeatures []IndexFeature) []IndexFeature {
 	var missing []IndexFeature
 	for _, feature := range requiredFeatures {
-		if !slices.Contains(buildInfo.Features, feature) {
+		if !slices.Contains(have, feature) {
 			missing = append(missing, feature)
 		}
 	}

--- a/pkg/storage/unified/search/bleve_snapshot.go
+++ b/pkg/storage/unified/search/bleve_snapshot.go
@@ -324,7 +324,7 @@ func (b *bleveBackend) pickBestSnapshot(all map[ulid.ULID]*IndexMeta, notOlderTh
 	minVersion := b.opts.Snapshot.MinBuildVersion
 	running := b.runningBuildVersion
 
-	var droppedAge, droppedUnparseable, droppedFormatUnsupported, droppedUnknownRequirements int
+	var droppedAge, droppedUnparseable, droppedFormatUnsupported, droppedUnknownRequirements, droppedMissingFeatures int
 	candidates := make([]snapshotCandidate, 0, len(all))
 	for k, m := range all {
 		// Hard filter: age.
@@ -342,6 +342,20 @@ func (b *bleveBackend) pickBestSnapshot(all map[ulid.ULID]*IndexMeta, notOlderTh
 				"version", m.BuildVersion,
 			)
 			continue
+		}
+		// Hard filter: lacks a feature this instance requires, so it would be rejected
+		// after download anyway. Snapshots that recorded no features are kept, since
+		// their contents are unknown rather than known to be unusable.
+		if m.FeaturesRecorded {
+			if missing := resource.MissingFeatures(m.Features, b.requiredFeatures); len(missing) > 0 {
+				droppedMissingFeatures++
+				logger.Debug("index snapshot candidate dropped: missing required features",
+					"key", k.String(),
+					"missing_features", missing,
+					"version", m.BuildVersion,
+				)
+				continue
+			}
 		}
 		if !isSnapshotIndexFormatUnknownOrSupported(m.IndexFormat, b.maxSupportedIndexFormat) {
 			droppedFormatUnsupported++
@@ -382,7 +396,7 @@ func (b *bleveBackend) pickBestSnapshot(all map[ulid.ULID]*IndexMeta, notOlderTh
 	}
 
 	if len(candidates) == 0 {
-		logger.Debug("no index snapshot candidates", "total", len(all), "dropped_age", droppedAge, "dropped_unparseable", droppedUnparseable, "dropped_format_unsupported", droppedFormatUnsupported, "dropped_unknown_requirements", droppedUnknownRequirements, "max_supported_format", b.maxSupportedIndexFormat)
+		logger.Debug("no index snapshot candidates", "total", len(all), "dropped_age", droppedAge, "dropped_unparseable", droppedUnparseable, "dropped_format_unsupported", droppedFormatUnsupported, "dropped_unknown_requirements", droppedUnknownRequirements, "dropped_missing_features", droppedMissingFeatures, "max_supported_format", b.maxSupportedIndexFormat)
 		return snapshotCandidate{}, false
 	}
 
@@ -432,8 +446,8 @@ func snapshotTier(v, minVersion, running *semver.Version) int {
 //
 // Snapshot selection accepts an older Grafana version (see snapshotTier), so
 // this is where a snapshot that would answer incorrectly gets rejected. Selection
-// already skips manifests declaring requirements we do not understand; this covers
-// snapshots uploaded before that field existed.
+// already skips manifests declaring requirements we do not understand or missing a
+// required feature; this covers snapshots uploaded before those fields existed.
 func (b *bleveBackend) validateDownloadedIndex(idx bleve.Index) (int64, error) {
 	rv, err := getRV(idx)
 	if err != nil {

--- a/pkg/storage/unified/search/bleve_snapshot_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_test.go
@@ -186,6 +186,55 @@ func TestPickBestSnapshot(t *testing.T) {
 		assert.Equal(t, key, c.key)
 	})
 
+	requiringFeatures := func(features ...resource.IndexFeature) *bleveBackend {
+		be := newBackend(minV)
+		be.requiredFeatures = features
+		return be
+	}
+	having := func(ver string, rv int64, age time.Duration, features ...resource.IndexFeature) *IndexMeta {
+		m := snap(ver, rv, age)
+		m.Features = features
+		m.FeaturesRecorded = true
+		return m
+	}
+
+	t.Run("dropped when missing a required feature", func(t *testing.T) {
+		all := map[ulid.ULID]*IndexMeta{makeULID(t, now): having("11.5.0", 100, time.Minute)}
+		_, ok := requiringFeatures("alpha").pickBestSnapshot(all, cutoff(24*time.Hour), log.New("bleve-snapshot-test"))
+		assert.False(t, ok)
+	})
+
+	t.Run("kept when it has the required feature", func(t *testing.T) {
+		key := makeULID(t, now)
+		all := map[ulid.ULID]*IndexMeta{key: having("11.5.0", 100, time.Minute, "alpha")}
+		c, ok := requiringFeatures("alpha").pickBestSnapshot(all, cutoff(24*time.Hour), log.New("bleve-snapshot-test"))
+		require.True(t, ok)
+		assert.Equal(t, key, c.key)
+	})
+
+	// Snapshots uploaded before features were recorded are unknown, not known to be
+	// unusable, so they stay in the running as before.
+	t.Run("kept when features were not recorded", func(t *testing.T) {
+		key := makeULID(t, now)
+		all := map[ulid.ULID]*IndexMeta{key: snap("11.5.0", 100, time.Minute)}
+		c, ok := requiringFeatures("alpha").pickBestSnapshot(all, cutoff(24*time.Hour), log.New("bleve-snapshot-test"))
+		require.True(t, ok)
+		assert.Equal(t, key, c.key)
+	})
+
+	// What the filter is for: the newest snapshot lacks the feature, so an older one
+	// that has it is used instead of downloading, rejecting and rebuilding.
+	t.Run("falls back to an older snapshot that has the feature", func(t *testing.T) {
+		usable := makeULID(t, now.Add(-30*time.Second))
+		all := map[ulid.ULID]*IndexMeta{
+			usable:           having("11.4.5", 100, time.Minute, "alpha"),
+			makeULID(t, now): having("11.5.0", 999, time.Minute),
+		}
+		c, ok := requiringFeatures("alpha").pickBestSnapshot(all, cutoff(24*time.Hour), log.New("bleve-snapshot-test"))
+		require.True(t, ok)
+		assert.Equal(t, usable, c.key)
+	})
+
 	// Without the filter the newer one wins as tier 2 and its documents are misread.
 	t.Run("falls back to an older snapshot when the newest needs an unknown feature", func(t *testing.T) {
 		compatible := makeULID(t, now.Add(-30*time.Second))

--- a/pkg/storage/unified/search/bleve_snapshot_upload.go
+++ b/pkg/storage/unified/search/bleve_snapshot_upload.go
@@ -170,9 +170,14 @@ func (b *bleveBackend) snapshotCopyAndUpload(ctx context.Context, key resource.N
 	}
 
 	meta := IndexMeta{
-		BuildVersion:          bi.BuildVersion,
-		IndexFormat:           indexFormat,
-		ReaderRequirements:    bi.ReaderRequirements,
+		BuildVersion:       bi.BuildVersion,
+		IndexFormat:        indexFormat,
+		Features:           bi.Features,
+		ReaderRequirements: bi.ReaderRequirements,
+		// Describes the index being uploaded, not this binary: an index built before
+		// index features existed records none, and readers must not read that as
+		// "has no features".
+		FeaturesRecorded:      bi.Features != nil,
 		LatestResourceVersion: rv,
 		DocCount:              docCount,
 	}

--- a/pkg/storage/unified/search/bleve_snapshot_upload_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_upload_test.go
@@ -89,6 +89,10 @@ func TestUploadSnapshot_Success(t *testing.T) {
 	assert.Equal(t, int64(42), uploadedMeta.LatestResourceVersion)
 	assert.Equal(t, be.opts.BuildVersion, uploadedMeta.BuildVersion)
 	assert.NotZero(t, uploadedMeta.IndexFormat)
+	// Recorded so selection can skip a snapshot missing a feature this instance
+	// requires, without downloading it first.
+	assert.True(t, uploadedMeta.FeaturesRecorded)
+	assert.Equal(t, resource.CurrentIndexFeatures(), uploadedMeta.Features)
 	// The test index holds a single document; DocCount is recorded for
 	// debugging only, but verify it reflects the index contents.
 	assert.Equal(t, uint64(1), uploadedMeta.DocCount)

--- a/pkg/storage/unified/search/remote_index_store.go
+++ b/pkg/storage/unified/search/remote_index_store.go
@@ -90,6 +90,14 @@ type IndexMeta struct {
 	// IndexFormat identifies the Bleve segment format that wrote this snapshot
 	// (for example, "zap/16"). Empty on legacy snapshots means "unknown, assume compatible".
 	IndexFormat string `json:"index_format,omitempty"`
+	// Features are the index features the snapshot was built with, letting selection
+	// skip a snapshot missing a feature this instance requires instead of finding out
+	// after downloading it. Only meaningful when FeaturesRecorded is set.
+	Features []resource.IndexFeature `json:"features,omitempty"`
+	// FeaturesRecorded distinguishes "no features" from "not recorded", which the
+	// Features field alone cannot. False for a snapshot uploaded before this field
+	// existed, and for one whose index predates index features.
+	FeaturesRecorded bool `json:"features_recorded,omitempty"`
 	// ReaderRequirements are the features an instance must understand before using
 	// this snapshot. Selection skips a snapshot declaring one it does not recognise.
 	// Empty on snapshots uploaded before this field existed.


### PR DESCRIPTION
A snapshot manifest records the build version and index format, but not the index features the snapshot was built with. So an instance only finds out a snapshot lacks a feature it requires after downloading and opening it — the download is wasted, and on a cold start it then builds from scratch instead of trying an older snapshot that would have worked.

Manifests now record the features, and selection drops a candidate missing one this instance requires, alongside the existing format and reader-requirement filters. Build version can't stand in for this: which features are required depends on a config option, so instances of the same version can differ.

Snapshots that recorded no features are kept as candidates — their contents are unknown rather than known to be unusable, and rejecting them would discard every existing snapshot at once. That's also why the manifest records whether features were recorded at all: an empty list and a missing one are otherwise indistinguishable. The flag describes the index being uploaded rather than the binary uploading it, so re-uploading an index built before index features existed still records "unknown".

This narrows the download-then-reject path without closing it: an index built before index features existed records nothing, so such a snapshot is still downloaded before it can be rejected.

Part of https://github.com/grafana/search-and-storage-team/issues/895
