### PR TITLE
Unified Storage: Fix slow KV garbage collection deletes and add safeguards

### DIFF
--- a/pkg/storage/unified/resource/kv/sqlkv.go
+++ b/pkg/storage/unified/resource/kv/sqlkv.go
@@ -559,12 +559,11 @@ func (k *SqlKV) Delete(ctx context.Context, section string, key string) error {
 	return nil
 }
 
-// deleteChunkSize caps the IN-list size per DELETE. A large key_path IN list makes
-// the MySQL optimizer abandon the key_path index (index dives stop past
-// eq_range_index_dive_limit, and the range optimizer exceeds range_optimizer_max_mem_size),
-// degrading the delete to a full table scan of resource_history. Chunking keeps each
-// statement in the index-friendly range.
-const deleteChunkSize = 200
+// deleteChunkSize caps the IN-list size per DELETE. A large key_path IN list makes MySQL
+// stop using the key_path index (dives stop past eq_range_index_dive_limit, range optimizer
+// exceeds range_optimizer_max_mem_size). MySQL permits index dives for up to
+// eq_range_index_dive_limit (default 200), so 199 respects the default path.
+const deleteChunkSize = 199
 
 func (k *SqlKV) BatchDelete(ctx context.Context, section string, keys []string) error {
 	if len(keys) == 0 {

--- a/pkg/storage/unified/resource/kv/sqlkv.go
+++ b/pkg/storage/unified/resource/kv/sqlkv.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"iter"
+	"slices"
 	"strings"
 	"time"
 
@@ -558,6 +559,13 @@ func (k *SqlKV) Delete(ctx context.Context, section string, key string) error {
 	return nil
 }
 
+// deleteChunkSize caps the IN-list size per DELETE. A large key_path IN list makes
+// the MySQL optimizer abandon the key_path index (index dives stop past
+// eq_range_index_dive_limit, and the range optimizer exceeds range_optimizer_max_mem_size),
+// degrading the delete to a full table scan of resource_history. Chunking keeps each
+// statement in the index-friendly range.
+const deleteChunkSize = 200
+
 func (k *SqlKV) BatchDelete(ctx context.Context, section string, keys []string) error {
 	if len(keys) == 0 {
 		return nil
@@ -568,10 +576,11 @@ func (k *SqlKV) BatchDelete(ctx context.Context, section string, keys []string) 
 		return err
 	}
 
-	keyPaths := getKeyPaths(section, keys)
-	query, args := qb.buildBatchDeleteQuery(keyPaths)
-	if _, err := k.conn(ctx).ExecContext(ctx, query, args...); err != nil {
-		return fmt.Errorf("failed to batch delete keys: %w", err)
+	for chunk := range slices.Chunk(getKeyPaths(section, keys), deleteChunkSize) {
+		query, args := qb.buildBatchDeleteQuery(chunk)
+		if _, err := k.conn(ctx).ExecContext(ctx, query, args...); err != nil {
+			return fmt.Errorf("failed to batch delete keys: %w", err)
+		}
 	}
 
 	return nil

--- a/pkg/storage/unified/resource/kv/sqlkv.go
+++ b/pkg/storage/unified/resource/kv/sqlkv.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"iter"
-	"slices"
 	"strings"
 	"time"
 
@@ -559,15 +558,15 @@ func (k *SqlKV) Delete(ctx context.Context, section string, key string) error {
 	return nil
 }
 
-// deleteChunkSize caps the IN-list size per DELETE. A large key_path IN list makes MySQL
-// stop using the key_path index (dives stop past eq_range_index_dive_limit, range optimizer
-// exceeds range_optimizer_max_mem_size). MySQL permits index dives for up to
-// eq_range_index_dive_limit (default 200), so 199 respects the default path.
-const deleteChunkSize = 199
+// maxBatchDeleteKeys bounds a DELETE's IN list.
+const maxBatchDeleteKeys = 200
 
 func (k *SqlKV) BatchDelete(ctx context.Context, section string, keys []string) error {
 	if len(keys) == 0 {
 		return nil
+	}
+	if len(keys) >= maxBatchDeleteKeys {
+		return fmt.Errorf("batch delete of %d keys exceeds max %d; caller must chunk", len(keys), maxBatchDeleteKeys-1)
 	}
 
 	qb, err := k.getQueryBuilder(section)
@@ -575,11 +574,10 @@ func (k *SqlKV) BatchDelete(ctx context.Context, section string, keys []string) 
 		return err
 	}
 
-	for chunk := range slices.Chunk(getKeyPaths(section, keys), deleteChunkSize) {
-		query, args := qb.buildBatchDeleteQuery(chunk)
-		if _, err := k.conn(ctx).ExecContext(ctx, query, args...); err != nil {
-			return fmt.Errorf("failed to batch delete keys: %w", err)
-		}
+	keyPaths := getKeyPaths(section, keys)
+	query, args := qb.buildBatchDeleteQuery(keyPaths)
+	if _, err := k.conn(ctx).ExecContext(ctx, query, args...); err != nil {
+		return fmt.Errorf("failed to batch delete keys: %w", err)
 	}
 
 	return nil

--- a/pkg/storage/unified/resource/kv/sqlkv_test.go
+++ b/pkg/storage/unified/resource/kv/sqlkv_test.go
@@ -3,6 +3,7 @@ package kv
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"errors"
 	"fmt"
 	"testing"
@@ -254,19 +255,29 @@ func TestSQLKVInsertDataImportBatchUsesLegacyFields(t *testing.T) {
 func TestSQLKV_BatchDelete_ChunksLargeKeyList(t *testing.T) {
 	sqlKV, _, mock := setupSQLKVMock(t, "sqlite")
 
-	// A large key_path IN list makes MySQL abandon the index and full-scan, so BatchDelete
-	// chunks into <= deleteChunkSize keys per DELETE. 450 keys -> 3 DELETEs (200,200,50).
-	keys := make([]string, 2*deleteChunkSize+50)
+	// BatchDelete chunks into <= deleteChunkSize keys per DELETE to keep each statement on
+	// the key_path index. 450 keys -> 3 DELETEs with 199, 199, 52 key_path args.
+	keys := make([]string, 2*deleteChunkSize+52)
 	for i := range keys {
 		keys[i] = fmt.Sprintf("k-%04d", i)
 	}
-	for range 3 {
+	for _, argCount := range []int{deleteChunkSize, deleteChunkSize, 52} {
 		mock.ExpectExec(`(?i)delete from .*resource_history.* where .*key_path.* in \(`).
+			WithArgs(anyArgs(argCount)...).
 			WillReturnResult(sqlmock.NewResult(0, 1))
 	}
 
 	require.NoError(t, sqlKV.BatchDelete(context.Background(), DataSection, keys))
 	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// anyArgs returns n matchers, so WithArgs asserts exactly n arguments in the statement.
+func anyArgs(n int) []driver.Value {
+	args := make([]driver.Value, n)
+	for i := range args {
+		args[i] = sqlmock.AnyArg()
+	}
+	return args
 }
 
 func TestSQLKV_Batch_RejectsDataSection(t *testing.T) {

--- a/pkg/storage/unified/resource/kv/sqlkv_test.go
+++ b/pkg/storage/unified/resource/kv/sqlkv_test.go
@@ -252,22 +252,23 @@ func TestSQLKVInsertDataImportBatchUsesLegacyFields(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestSQLKV_BatchDelete_ChunksLargeKeyList(t *testing.T) {
+func TestSQLKV_BatchDelete_RejectsOversizedBatch(t *testing.T) {
 	sqlKV, _, mock := setupSQLKVMock(t, "sqlite")
 
-	// BatchDelete chunks into <= deleteChunkSize keys per DELETE to keep each statement on
-	// the key_path index. 450 keys -> 3 DELETEs with 199, 199, 52 key_path args.
-	keys := make([]string, 2*deleteChunkSize+52)
+	keys := make([]string, maxBatchDeleteKeys)
 	for i := range keys {
 		keys[i] = fmt.Sprintf("k-%04d", i)
 	}
-	for _, argCount := range []int{deleteChunkSize, deleteChunkSize, 52} {
-		mock.ExpectExec(`(?i)delete from .*resource_history.* where .*key_path.* in \(`).
-			WithArgs(anyArgs(argCount)...).
-			WillReturnResult(sqlmock.NewResult(0, 1))
-	}
 
-	require.NoError(t, sqlKV.BatchDelete(context.Background(), DataSection, keys))
+	// A batch at or above the max is rejected before any DELETE runs.
+	require.Error(t, sqlKV.BatchDelete(context.Background(), DataSection, keys))
+
+	// One below the max runs as a single DELETE with that many key_path args.
+	allowed := keys[:maxBatchDeleteKeys-1]
+	mock.ExpectExec(`(?i)delete from .*resource_history.* where .*key_path.* in \(`).
+		WithArgs(anyArgs(len(allowed))...).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	require.NoError(t, sqlKV.BatchDelete(context.Background(), DataSection, allowed))
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/pkg/storage/unified/resource/kv/sqlkv_test.go
+++ b/pkg/storage/unified/resource/kv/sqlkv_test.go
@@ -251,6 +251,24 @@ func TestSQLKVInsertDataImportBatchUsesLegacyFields(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestSQLKV_BatchDelete_ChunksLargeKeyList(t *testing.T) {
+	sqlKV, _, mock := setupSQLKVMock(t, "sqlite")
+
+	// A large key_path IN list makes MySQL abandon the index and full-scan, so BatchDelete
+	// chunks into <= deleteChunkSize keys per DELETE. 450 keys -> 3 DELETEs (200,200,50).
+	keys := make([]string, 2*deleteChunkSize+50)
+	for i := range keys {
+		keys[i] = fmt.Sprintf("k-%04d", i)
+	}
+	for range 3 {
+		mock.ExpectExec(`(?i)delete from .*resource_history.* where .*key_path.* in \(`).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+	}
+
+	require.NoError(t, sqlKV.BatchDelete(context.Background(), DataSection, keys))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestSQLKV_Batch_RejectsDataSection(t *testing.T) {
 	sqlKV, _, mock := setupSQLKVMock(t, "sqlite")
 

--- a/pkg/storage/unified/resource/kv/test/kv.go
+++ b/pkg/storage/unified/resource/kv/test/kv.go
@@ -995,23 +995,6 @@ func runTestKVBatchDelete(t *testing.T, kv kvpkg.KV, nsPrefix string) {
 		err = reader.Close()
 		require.NoError(t, err)
 	})
-
-	t.Run("batch delete spanning multiple chunks", func(t *testing.T) {
-		// SqlKV chunks the IN list; delete more keys than one chunk to exercise the loop.
-		const n = 450 // > deleteChunkSize (199)
-		keys := make([]string, n)
-		for i := range keys {
-			keys[i] = namespacedKey(nsPrefix, fmt.Sprintf("chunk/%04d", i))
-			saveKVHelper(t, kv, ctx, testSection, keys[i], strings.NewReader("v"))
-		}
-
-		require.NoError(t, kv.BatchDelete(ctx, testSection, keys))
-
-		for _, key := range keys {
-			_, err := kv.Get(ctx, testSection, key)
-			assert.Equal(t, kvpkg.ErrNotFound, err)
-		}
-	})
 }
 
 // saveKVHelper is a helper function to save data to KV store using the new WriteCloser interface

--- a/pkg/storage/unified/resource/kv/test/kv.go
+++ b/pkg/storage/unified/resource/kv/test/kv.go
@@ -998,7 +998,7 @@ func runTestKVBatchDelete(t *testing.T, kv kvpkg.KV, nsPrefix string) {
 
 	t.Run("batch delete spanning multiple chunks", func(t *testing.T) {
 		// SqlKV chunks the IN list; delete more keys than one chunk to exercise the loop.
-		const n = 450 // > deleteChunkSize (200)
+		const n = 450 // > deleteChunkSize (199)
 		keys := make([]string, n)
 		for i := range keys {
 			keys[i] = namespacedKey(nsPrefix, fmt.Sprintf("chunk/%04d", i))

--- a/pkg/storage/unified/resource/kv/test/kv.go
+++ b/pkg/storage/unified/resource/kv/test/kv.go
@@ -995,6 +995,23 @@ func runTestKVBatchDelete(t *testing.T, kv kvpkg.KV, nsPrefix string) {
 		err = reader.Close()
 		require.NoError(t, err)
 	})
+
+	t.Run("batch delete spanning multiple chunks", func(t *testing.T) {
+		// SqlKV chunks the IN list; delete more keys than one chunk to exercise the loop.
+		const n = 450 // > deleteChunkSize (200)
+		keys := make([]string, n)
+		for i := range keys {
+			keys[i] = namespacedKey(nsPrefix, fmt.Sprintf("chunk/%04d", i))
+			saveKVHelper(t, kv, ctx, testSection, keys[i], strings.NewReader("v"))
+		}
+
+		require.NoError(t, kv.BatchDelete(ctx, testSection, keys))
+
+		for _, key := range keys {
+			_, err := kv.Get(ctx, testSection, key)
+			assert.Equal(t, kvpkg.ErrNotFound, err)
+		}
+	})
 }
 
 // saveKVHelper is a helper function to save data to KV store using the new WriteCloser interface

--- a/pkg/storage/unified/resource/lease/gc.go
+++ b/pkg/storage/unified/resource/lease/gc.go
@@ -33,7 +33,7 @@ const (
 	gcGracePeriod = time.Minute
 
 	// batch size used when running a GC cycle.
-	batchSize = 200
+	batchSize = 199
 )
 
 // gcMetadata is the data written on the `gcKey` entry.

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -810,7 +810,11 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 					continue
 				}
 
-				// if not in dry run mode, batch delete the keys
+				// if not in dry run mode, batch delete the keys.
+				// keysToDelete is ordered oldest-first (SortOrderAsc above), so the deletion
+				// marker (highest RV) is deleted last. BatchDelete may delete in chunks and
+				// stop on the first failure, so a partial delete always leaves the marker
+				// behind; the next GC pass re-finds it and finishes. Do not reorder.
 				err = b.kv.BatchDelete(ctx, kv.DataSection, keysToDelete)
 				if err != nil {
 					return fmt.Errorf("failed to batch delete keys: %s", err)

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -134,6 +134,7 @@ type kvBackendMetrics struct {
 	NatsNotifierDropped              *prometheus.CounterVec
 	WatchNotificationsPublished      *prometheus.CounterVec
 	WatchNotificationPublishFailures *prometheus.CounterVec
+	GCGroupResourceDuration          *prometheus.HistogramVec
 }
 
 func newKVBackendMetrics(reg prometheus.Registerer) *kvBackendMetrics {
@@ -160,7 +161,22 @@ func newKVBackendMetrics(reg prometheus.Registerer) *kvBackendMetrics {
 			Name: "storage_server_watch_notifications_publish_failures_total",
 			Help: "Watch notifications that failed to marshal or publish to NATS, by group, resource, and action. Each one is an event live consumers never receive; they recover it on their next re-list.",
 		}, []string{"group", "resource", "action"}),
+		GCGroupResourceDuration: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: "storage_server",
+			Name:      "gc_group_resource_duration_seconds",
+			Help:      "Duration of a garbage-collection pass over one group/resource.",
+			Buckets:   []float64{0.01, 0.05, 0.1, 0.5, 1, 5, 30, 60, 300, 1800, 7200},
+		}, []string{"group", "resource"}),
 	}
+}
+
+// observeGCGroupResource records how long a GC pass over one group/resource took.
+// Nil-safe for test backends.
+func (m *kvBackendMetrics) observeGCGroupResource(group, resource string, d time.Duration) {
+	if m == nil {
+		return
+	}
+	m.GCGroupResourceDuration.WithLabelValues(group, resource).Observe(d.Seconds())
 }
 
 func (m *kvBackendMetrics) recordConflict(event WriteEvent) {
@@ -676,6 +692,10 @@ func (b *kvStorageBackend) runGarbageCollection(ctx context.Context, cutoffTimeS
 	}
 }
 
+// gcDeleteTimeout bounds a single GC history delete so a slow statement self-limits instead
+// of stalling writes. A healthy indexed delete is milliseconds. Var so tests can shorten it.
+var gcDeleteTimeout = 30 * time.Second
+
 // garbageCollectGroupResource scans batches of entries in the datastore for a given group+resource,
 // in descending order of resource version, looking for deleted entries with resource versions
 // older than the cutoff timestamp.
@@ -691,6 +711,7 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 
 	//nolint:staticcheck
 	start := time.Now()
+	defer func() { b.metrics.observeGCGroupResource(group, resourceName, time.Since(start)) }()
 
 	totalDeleted := int64(0)
 	totalDryRun := int64(0)
@@ -810,12 +831,14 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 					continue
 				}
 
-				// if not in dry run mode, batch delete the keys.
-				// keysToDelete is ordered oldest-first (SortOrderAsc above), so the deletion
-				// marker (highest RV) is deleted last. BatchDelete may delete in chunks and
-				// stop on the first failure, so a partial delete always leaves the marker
-				// behind; the next GC pass re-finds it and finishes. Do not reorder.
-				err = b.kv.BatchDelete(ctx, kv.DataSection, keysToDelete)
+				// batch delete the keys. keysToDelete is oldest-first (SortOrderAsc above), so
+				// the deletion marker (highest RV) goes last: a partial/chunked failure leaves
+				// the marker behind and the next GC pass finishes. Do not reorder.
+				// Bound the delete so a slow statement self-limits instead of stalling writes;
+				// GC is idempotent, so a timed-out delete just retries next pass.
+				deleteCtx, cancel := context.WithTimeout(ctx, gcDeleteTimeout)
+				err = b.kv.BatchDelete(deleteCtx, kv.DataSection, keysToDelete)
+				cancel()
 				if err != nil {
 					return fmt.Errorf("failed to batch delete keys: %s", err)
 				}

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -793,20 +793,13 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 				// mark the key as seen
 				seenKeys[k] = struct{}{}
 
-				startKeyToDelete := k.Prefix()
-				// end key is exclusive, so we need to add a suffix to make sure we include all the versions we want to delete
-				endKeyToDelete := PrefixRangeEnd(dk.String())
-
-				keysToDelete := []string{}
-				for deleteKey, err := range b.kv.Keys(ctx, kv.DataSection, ListOptions{
-					StartKey: startKeyToDelete,
-					EndKey:   endKeyToDelete,
-					Sort:     kv.SortOrderAsc,
-				}) {
+				// Collect all revisions of this resource, oldest-first, via the datastore.
+				keysToDelete := []DataKey{}
+				for parsed, err := range b.dataStore.Keys(ctx, k, SortOrderAsc) {
 					if err != nil {
 						return fmt.Errorf("failed to get keys for resource '%s': %s", dk, err)
 					}
-					keysToDelete = append(keysToDelete, deleteKey)
+					keysToDelete = append(keysToDelete, parsed)
 				}
 
 				// check if the resource still exists
@@ -831,13 +824,14 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 					continue
 				}
 
-				// batch delete the keys. keysToDelete is oldest-first (SortOrderAsc above), so
-				// the deletion marker (highest RV) goes last: a partial/chunked failure leaves
-				// the marker behind and the next GC pass finishes. Do not reorder.
+				// batch delete the keys via the datastore, which chunks them (and SqlKV chunks
+				// again per statement). keysToDelete is oldest-first (SortOrderAsc above), so the
+				// deletion marker (highest RV) goes last: a partial/chunked failure leaves the
+				// marker behind and the next GC pass finishes. Do not reorder.
 				// Bound the delete so a slow statement self-limits instead of stalling writes;
 				// GC is idempotent, so a timed-out delete just retries next pass.
 				deleteCtx, cancel := context.WithTimeout(ctx, gcDeleteTimeout)
-				err = b.kv.BatchDelete(deleteCtx, kv.DataSection, keysToDelete)
+				err = b.dataStore.batchDelete(deleteCtx, keysToDelete)
 				cancel()
 				if err != nil {
 					return fmt.Errorf("failed to batch delete keys: %s", err)

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -692,10 +692,6 @@ func (b *kvStorageBackend) runGarbageCollection(ctx context.Context, cutoffTimeS
 	}
 }
 
-// gcDeleteTimeout bounds a single GC history delete so a slow statement self-limits instead
-// of stalling writes. A healthy indexed delete is milliseconds. Var so tests can shorten it.
-var gcDeleteTimeout = 30 * time.Second
-
 // garbageCollectGroupResource scans batches of entries in the datastore for a given group+resource,
 // in descending order of resource version, looking for deleted entries with resource versions
 // older than the cutoff timestamp.
@@ -795,11 +791,11 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 
 				// Collect all revisions of this resource, oldest-first, via the datastore.
 				keysToDelete := []DataKey{}
-				for parsed, err := range b.dataStore.Keys(ctx, k, SortOrderAsc) {
+				for deleteKey, err := range b.dataStore.Keys(ctx, k, SortOrderAsc) {
 					if err != nil {
 						return fmt.Errorf("failed to get keys for resource '%s': %s", dk, err)
 					}
-					keysToDelete = append(keysToDelete, parsed)
+					keysToDelete = append(keysToDelete, deleteKey)
 				}
 
 				// check if the resource still exists
@@ -824,15 +820,9 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 					continue
 				}
 
-				// batch delete the keys via the datastore, which chunks them (and SqlKV chunks
-				// again per statement). keysToDelete is oldest-first (SortOrderAsc above), so the
-				// deletion marker (highest RV) goes last: a partial/chunked failure leaves the
-				// marker behind and the next GC pass finishes. Do not reorder.
-				// Bound the delete so a slow statement self-limits instead of stalling writes;
-				// GC is idempotent, so a timed-out delete just retries next pass.
-				deleteCtx, cancel := context.WithTimeout(ctx, gcDeleteTimeout)
-				err = b.dataStore.batchDelete(deleteCtx, keysToDelete)
-				cancel()
+				// Oldest-first (SortOrderAsc), so a partial delete leaves the deletion marker
+				// behind and the next GC pass finishes.
+				err = b.dataStore.batchDelete(ctx, keysToDelete)
 				if err != nil {
 					return fmt.Errorf("failed to batch delete keys: %s", err)
 				}

--- a/pkg/storage/unified/resource/storage_backend_gc_test.go
+++ b/pkg/storage/unified/resource/storage_backend_gc_test.go
@@ -37,20 +37,6 @@ func (p *partialDeleteKV) BatchDelete(ctx context.Context, section string, keys 
 	return p.KV.BatchDelete(ctx, section, keys)
 }
 
-// slowDeleteKV blocks on data-section deletes until the context is cancelled, simulating a
-// statement that hangs (e.g. on a pathological plan).
-type slowDeleteKV struct {
-	KV
-}
-
-func (s *slowDeleteKV) BatchDelete(ctx context.Context, section string, keys []string) error {
-	if section == dataSection {
-		<-ctx.Done()
-		return ctx.Err()
-	}
-	return s.KV.BatchDelete(ctx, section, keys)
-}
-
 // writeEventOption is a function that modifies writeEventOptions
 type writeEventOption func(*writeEventOptions)
 
@@ -746,37 +732,6 @@ func TestIntegrationGarbageCollectionLoop(t *testing.T) {
 		require.Nil(t, trashResp.Error)
 		require.Len(t, trashResp.Items, 1)
 	})
-}
-
-func TestIntegrationGarbageCollectionDeleteTimeout(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
-	orig := gcDeleteTimeout
-	gcDeleteTimeout = 50 * time.Millisecond
-	t.Cleanup(func() { gcDeleteTimeout = orig })
-
-	ctx := testutil.NewTestContext(t, time.Now().Add(30*time.Second))
-
-	b := setupTestStorageBackend(t, func(opts *KVBackendOptions) {
-		opts.GarbageCollection = GarbageCollectionConfig{
-			Enabled: true, DryRun: false, Interval: time.Minute, BatchSize: 100, DashboardsMaxAge: 24 * time.Hour,
-		}
-		opts.KvStore = &slowDeleteKV{KV: setupBadgerKV(t)}
-	})
-
-	rv1, err := writeEvent(t, ctx, b, "resource1", resourcepb.WatchEvent_ADDED)
-	require.NoError(t, err)
-	_, err = writeEvent(t, ctx, b, "resource1", resourcepb.WatchEvent_DELETED,
-		func(o *writeEventOptions) { o.PreviousRV = rv1 })
-	require.NoError(t, err)
-
-	cutoff := b.garbageCollectionCutoffTimestamp("group", "resource", time.Now().Add(time.Hour).UnixMicro())
-
-	// The hanging delete self-limits at gcDeleteTimeout instead of blocking forever.
-	start := time.Now()
-	err = b.garbageCollectGroupResource(ctx, "group", "resource", cutoff)
-	require.Error(t, err)
-	require.Less(t, time.Since(start), 5*time.Second)
 }
 
 func TestIntegrationGarbageCollectionPartialDeleteConverges(t *testing.T) {

--- a/pkg/storage/unified/resource/storage_backend_gc_test.go
+++ b/pkg/storage/unified/resource/storage_backend_gc_test.go
@@ -37,6 +37,20 @@ func (p *partialDeleteKV) BatchDelete(ctx context.Context, section string, keys 
 	return p.KV.BatchDelete(ctx, section, keys)
 }
 
+// slowDeleteKV blocks on data-section deletes until the context is cancelled, simulating a
+// statement that hangs (e.g. on a pathological plan).
+type slowDeleteKV struct {
+	KV
+}
+
+func (s *slowDeleteKV) BatchDelete(ctx context.Context, section string, keys []string) error {
+	if section == dataSection {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	return s.KV.BatchDelete(ctx, section, keys)
+}
+
 // writeEventOption is a function that modifies writeEventOptions
 type writeEventOption func(*writeEventOptions)
 
@@ -732,6 +746,37 @@ func TestIntegrationGarbageCollectionLoop(t *testing.T) {
 		require.Nil(t, trashResp.Error)
 		require.Len(t, trashResp.Items, 1)
 	})
+}
+
+func TestIntegrationGarbageCollectionDeleteTimeout(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	orig := gcDeleteTimeout
+	gcDeleteTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { gcDeleteTimeout = orig })
+
+	ctx := testutil.NewTestContext(t, time.Now().Add(30*time.Second))
+
+	b := setupTestStorageBackend(t, func(opts *KVBackendOptions) {
+		opts.GarbageCollection = GarbageCollectionConfig{
+			Enabled: true, DryRun: false, Interval: time.Minute, BatchSize: 100, DashboardsMaxAge: 24 * time.Hour,
+		}
+		opts.KvStore = &slowDeleteKV{KV: setupBadgerKV(t)}
+	})
+
+	rv1, err := writeEvent(t, ctx, b, "resource1", resourcepb.WatchEvent_ADDED)
+	require.NoError(t, err)
+	_, err = writeEvent(t, ctx, b, "resource1", resourcepb.WatchEvent_DELETED,
+		func(o *writeEventOptions) { o.PreviousRV = rv1 })
+	require.NoError(t, err)
+
+	cutoff := b.garbageCollectionCutoffTimestamp("group", "resource", time.Now().Add(time.Hour).UnixMicro())
+
+	// The hanging delete self-limits at gcDeleteTimeout instead of blocking forever.
+	start := time.Now()
+	err = b.garbageCollectGroupResource(ctx, "group", "resource", cutoff)
+	require.Error(t, err)
+	require.Less(t, time.Since(start), 5*time.Second)
 }
 
 func TestIntegrationGarbageCollectionPartialDeleteConverges(t *testing.T) {

--- a/pkg/storage/unified/resource/storage_backend_gc_test.go
+++ b/pkg/storage/unified/resource/storage_backend_gc_test.go
@@ -2,6 +2,7 @@ package resource
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -15,6 +16,26 @@ import (
 	"github.com/grafana/grafana/pkg/util/testutil"
 	"github.com/stretchr/testify/require"
 )
+
+// partialDeleteKV simulates a partial chunked delete: the first data-section BatchDelete
+// deletes only its first key and then returns an error; later calls delegate fully. GC
+// deletes oldest-first, so the deletion marker (highest RV) is last and survives the
+// partial failure — the next GC pass must re-find it and finish.
+type partialDeleteKV struct {
+	KV
+	failedOnce bool
+}
+
+func (p *partialDeleteKV) BatchDelete(ctx context.Context, section string, keys []string) error {
+	if !p.failedOnce && section == dataSection && len(keys) > 1 {
+		p.failedOnce = true
+		if err := p.KV.BatchDelete(ctx, section, keys[:1]); err != nil {
+			return err
+		}
+		return errors.New("simulated partial batch delete failure")
+	}
+	return p.KV.BatchDelete(ctx, section, keys)
+}
 
 // writeEventOption is a function that modifies writeEventOptions
 type writeEventOption func(*writeEventOptions)
@@ -711,4 +732,61 @@ func TestIntegrationGarbageCollectionLoop(t *testing.T) {
 		require.Nil(t, trashResp.Error)
 		require.Len(t, trashResp.Items, 1)
 	})
+}
+
+func TestIntegrationGarbageCollectionPartialDeleteConverges(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	ctx := testutil.NewTestContext(t, time.Now().Add(30*time.Second))
+
+	wrapped := &partialDeleteKV{KV: setupBadgerKV(t)}
+	b := setupTestStorageBackend(t, func(opts *KVBackendOptions) {
+		opts.GarbageCollection = GarbageCollectionConfig{
+			Enabled: true, DryRun: false, Interval: time.Minute, BatchSize: 100, DashboardsMaxAge: 24 * time.Hour,
+		}
+		opts.KvStore = wrapped
+	})
+
+	// One resource, several revisions ending in a deletion.
+	rv1, err := writeEvent(t, ctx, b, "resource1", resourcepb.WatchEvent_ADDED)
+	require.NoError(t, err)
+	rv2, err := writeEvent(t, ctx, b, "resource1", resourcepb.WatchEvent_MODIFIED,
+		func(o *writeEventOptions) { o.PreviousRV = rv1 })
+	require.NoError(t, err)
+	_, err = writeEvent(t, ctx, b, "resource1", resourcepb.WatchEvent_DELETED,
+		func(o *writeEventOptions) { o.PreviousRV = rv2 })
+	require.NoError(t, err)
+
+	countHistory := func() int {
+		it := b.kv.Keys(ctx, dataSection, ListOptions{
+			StartKey: "group/resource/namespace/",
+			EndKey:   "group/resource/namespace0",
+		})
+		count := 0
+		it(func(_ string, err error) bool {
+			require.NoError(t, err)
+			count++
+			return true
+		})
+		return count
+	}
+
+	cutoff := b.garbageCollectionCutoffTimestamp("group", "resource", time.Now().Add(time.Hour).UnixMicro())
+
+	initial := countHistory()
+	require.Equal(t, 3, initial, "expected 3 history revisions before GC")
+
+	// First pass fails mid-delete. It must delete something (partial progress) yet leave
+	// the deletion marker (deleted last) behind.
+	err = b.garbageCollectGroupResource(ctx, "group", "resource", cutoff)
+	require.Error(t, err)
+	require.True(t, wrapped.failedOnce, "partial delete was not exercised")
+	afterPartial := countHistory()
+	require.Less(t, afterPartial, initial, "partial delete should have removed at least one revision")
+	require.Greater(t, afterPartial, 0, "partial failure should leave the deletion marker behind")
+
+	// Second pass (no injected failure) re-finds the marker and finishes.
+	err = b.garbageCollectGroupResource(ctx, "group", "resource", cutoff)
+	require.NoError(t, err)
+	require.Equal(t, 0, countHistory(), "GC did not converge after a partial delete")
 }


### PR DESCRIPTION
**What is this feature?**

Fixes and hardens the Unified Storage KV garbage collection delete path: `SqlKV.BatchDelete` now chunks the `key_path IN (...)` DELETE into ≤199 keys per statement (staying within `eq_range_index_dive_limit`) so every statement uses the `key_path` index; the GC delete is bounded by a 30s statement timeout so a slow plan self-limits instead of stalling writes; and each `garbageCollectGroupResource` pass is recorded as the `storage_server_gc_group_resource_duration_seconds` histogram.

**Why do we need this feature?**

When garbage-collecting a heavily-revised resource, the single large `DELETE ... WHERE key_path IN (...)` grew big enough that MySQL stopped using the `key_path` index and full-scanned the `resource_history` table, so one GC run took hours (~2.4h per statement) and starved writes. Chunking keeps every statement on the index, the timeout caps any pathological delete, and the metric makes the duration observable in-process.

**Who is this feature for?**

Operators of Unified Storage instances whose garbage collection was running for hours (observed on `dashboard.grafana.app` and `plugins.grafana.app` resources).

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Backend-only change under `pkg/storage/unified/`, no API/wire contract change.

EXPLAIN: a ~10k-key IN plans as `type: ALL` (table scan), while small chunks / pure range stay `type: range` on `IDX_resource_history_key_path`. Tests cover the chunk boundary (per-statement arg counts), the GC delete timeout, and partial-delete convergence (GC deletes oldest-first, so a partial/timed-out delete leaves the deletion marker and the next pass finishes).

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.