### PR TITLE
Docs: restore Aria-Labels vs data-testid guidance and scope the selector skill

### DIFF
--- a/.claude/skills/add-e2e-selectors/SKILL.md
+++ b/.claude/skills/add-e2e-selectors/SKILL.md
@@ -11,6 +11,32 @@ into the JSX as `data-testid`. This encodes the package's layout (`pages` vs `co
 semver versioning scheme, and its strict reuse / never-delete rules so selectors are added
 correctly and don't break plugin end-to-end tests.
 
+## Scope: this is about shipped UI, not about how you query in tests
+
+You may be carrying guidance that says to prefer `getByRole` / `getByText` and to reach for a
+test id only when there's no stable accessible name. That guidance is about **querying inside a
+test suite**, and it stays correct there:
+`contribute/style-guides/testing.md` and `contribute/style-guides/accessibility.md` both apply it
+to unit tests, and nothing in this skill overrides them.
+
+This skill is about **what the component ships**, which is a different question with a different
+answer. Two reasons the role/text approach can't carry a shipped selector:
+
+- **Accessible names are translated.** `@grafana/i18n/no-untranslated-strings` requires
+  `aria-label`, `title`, `placeholder`, and `subTitle` to pass through `t()` in
+  `public/app/features`. A selector resting on an accessible name only works in the locale it was
+  authored in.
+- **These selectors are a public contract.** External plugins and Grafana Pathfinder guides bind
+  to them at runtime, in environments and Grafana versions we don't control, and their authors
+  never see your PR. Pathfinder in particular is a user-facing product rather than a test suite:
+  when a selector rots there, a user gets stranded mid-walkthrough instead of a build going red.
+
+So: add the `data-testid`, and **keep the accessible name**. A test id is additive, never a
+substitute for a role or an aria-label that carries genuine accessibility value, and an
+aria-label must never be added purely as a test hook (enforced by
+`@grafana/no-aria-label-selectors`). See "Aria-Labels vs data-testid" in
+`contribute/style-guides/e2e-playwright.md`.
+
 ## Resolve the target
 
 Interpret the argument to decide scope:

--- a/contribute/style-guides/e2e-playwright.md
+++ b/contribute/style-guides/e2e-playwright.md
@@ -167,6 +167,42 @@ test(
 );
 ```
 
+### Aria-Labels vs data-testid
+
+Our selectors are set up to work with both aria-labels and data-testid attributes. Aria-labels help assistive technologies such as screen readers identify interactive elements of a page for our users.
+
+A good example of a time to use an aria-label might be if you have a button with an X to close:
+
+```jsx
+<button aria-label="Close">X</button>
+```
+
+It might be clear visually that the X closes the modal, but audibly it would not be.
+
+However, adding aria-labels to elements that are already clearly labeled, or that are not interactive, is confusing and redundant for users of assistive technologies. This example might read aloud as "Close, Close":
+
+```jsx
+<button aria-label="Close">Close</button>
+```
+
+In such cases, rather than adding an unnecessary aria-label so the element becomes selectable, use a data attribute that is not read aloud by assistive technology:
+
+```jsx
+<button data-testid="modal-close-button">Close</button>
+```
+
+Adding an aria-label purely as a test hook is enforced against by the `@grafana/no-aria-label-selectors` ESLint rule. Prefix a selector value with `data-testid` to tell the framework to match the `data-testid` attribute rather than the aria-label.
+
+#### Why we don't select on accessible names
+
+The wider testing literature recommends locating elements by role and text, on the grounds that this is how users find things on a page. That advice is sound for a suite whose environment you control, and you are free to follow it when querying inside your own tests. It does not work as the basis for a shipped selector, for two reasons.
+
+**Accessible names are translated.** The `@grafana/i18n/no-untranslated-strings` rule requires `aria-label`, `title`, `placeholder`, and `subTitle` to pass through `t()` in `public/app/features`. Anything selecting on an accessible name is therefore locale-dependent by construction, and only works in the locale it was authored in. A `data-testid` is the only anchor that survives translation.
+
+**Selectors in this package are a public contract.** External plugins and Grafana Pathfinder's interactive guides bind to them at runtime, in environments we don't control, on Grafana versions we didn't pick. Those consumers never see your PR, which is why the versioning rules in `@grafana/e2e-selectors` never delete an old selector version.
+
+A `data-testid` is additive, never a substitute. Keep the accessible name where it carries genuine accessibility value and add the test id alongside it.
+
 ### Advanced example
 
 Let's take a look at an example that uses the same selector for multiple items in a list for instance. In this example app, there's a list of data sources that we want to click on during an E2E test.


### PR DESCRIPTION
Two files link to an "Aria-Labels vs data-testid" section that stopped existing when `contribute/style-guides/e2e.md` was deleted. This restores it and adds the two arguments that were never written down: accessible names are lint-mandated to be translated, so selectors resting on them are locale-dependent; and these selectors are a public contract that external plugins and Pathfinder guides bind to at runtime.

Also scopes the `add-e2e-selectors` skill so it reads as governing shipped UI rather than contradicting the prefer-`*ByRole` advice in `testing.md` and `accessibility.md`. Test ids are additive, not a substitute for accessible names.

Companion to grafana/deployment_tools#685094.