### PR TITLE
Annotation: Fix unset annotation time handling

### DIFF
--- a/pkg/registry/apps/annotation/k8s_adapter.go
+++ b/pkg/registry/apps/annotation/k8s_adapter.go
@@ -540,6 +540,10 @@ func validateUpdate(existing, updated *annotationV0.Annotation) error {
 }
 
 func (s *k8sRESTAdapter) validateTimes(anno *annotationV0.Annotation) error {
+	if anno.Spec.Time == 0 {
+		return apierrors.NewBadRequest(fmt.Sprintf("%v: time is required", ErrInvalidInput))
+	}
+
 	now := time.Now().UTC()
 	maxFuture := now.Add(maxFutureWindow).UnixMilli()
 

--- a/pkg/registry/apps/annotation/k8s_adapter.go
+++ b/pkg/registry/apps/annotation/k8s_adapter.go
@@ -540,8 +540,8 @@ func validateUpdate(existing, updated *annotationV0.Annotation) error {
 }
 
 func (s *k8sRESTAdapter) validateTimes(anno *annotationV0.Annotation) error {
-	if anno.Spec.Time == 0 {
-		return apierrors.NewBadRequest(fmt.Sprintf("%v: time is required", ErrInvalidInput))
+	if anno.Spec.Time <= 0 {
+		return apierrors.NewBadRequest(fmt.Sprintf("%v: time is required and must be positive", ErrInvalidInput))
 	}
 
 	now := time.Now().UTC()

--- a/pkg/registry/apps/annotation/k8s_adapter_test.go
+++ b/pkg/registry/apps/annotation/k8s_adapter_test.go
@@ -161,7 +161,10 @@ func TestK8sAdapter_StoreErrorMapping(t *testing.T) {
 			})
 
 			t.Run("Create", func(t *testing.T) {
-				obj := &annotationV0.Annotation{ObjectMeta: metav1.ObjectMeta{Name: "obj", Namespace: ns}}
+				obj := &annotationV0.Annotation{
+					ObjectMeta: metav1.ObjectMeta{Name: "obj", Namespace: ns},
+					Spec:       annotationV0.AnnotationSpec{Time: 1000},
+				}
 				_, err := adapter.Create(ctx, obj, nil, &metav1.CreateOptions{})
 				assert.True(t, tc.predicate(err), "got %v", err)
 			})
@@ -182,7 +185,10 @@ func TestK8sAdapter_Create(t *testing.T) {
 		adapter := newTestAdapter(NewMemoryStore(), allowAll)
 		ctx := k8srequest.WithNamespace(identity.WithServiceIdentityContext(t.Context(), 1), ns)
 
-		obj := &annotationV0.Annotation{ObjectMeta: metav1.ObjectMeta{Name: "obj", Namespace: ns}}
+		obj := &annotationV0.Annotation{
+			ObjectMeta: metav1.ObjectMeta{Name: "obj", Namespace: ns},
+			Spec:       annotationV0.AnnotationSpec{Time: 1000},
+		}
 		_, err := adapter.Create(ctx, obj, nil, &metav1.CreateOptions{})
 		require.NoError(t, err)
 
@@ -687,6 +693,7 @@ func TestK8sAdapter_ValidateAnnotation(t *testing.T) {
 		errContains       string
 	}{
 		{name: "time is current", time: now, retentionTTL: defaultTTL},
+		{name: "time not present", time: 0, retentionTTL: defaultTTL, expectErr: true, errContains: "time is required"},
 		{name: "recent past within retention", time: now - retentionMs/2, retentionTTL: defaultTTL},
 		{name: "inside future bound", time: now + futureWindowMs - second, retentionTTL: defaultTTL},
 		{name: "too far in the future", time: now + futureWindowMs + second, retentionTTL: defaultTTL, expectErr: true, errContains: "time cannot be more than 1 week in the future"},

--- a/pkg/registry/apps/annotation/k8s_adapter_test.go
+++ b/pkg/registry/apps/annotation/k8s_adapter_test.go
@@ -694,6 +694,7 @@ func TestK8sAdapter_ValidateAnnotation(t *testing.T) {
 	}{
 		{name: "time is current", time: now, retentionTTL: defaultTTL},
 		{name: "time not present", time: 0, retentionTTL: defaultTTL, expectErr: true, errContains: "time is required"},
+		{name: "time negative", time: -1, retentionTTL: defaultTTL, expectErr: true, errContains: "time is required"},
 		{name: "recent past within retention", time: now - retentionMs/2, retentionTTL: defaultTTL},
 		{name: "inside future bound", time: now + futureWindowMs - second, retentionTTL: defaultTTL},
 		{name: "too far in the future", time: now + futureWindowMs + second, retentionTTL: defaultTTL, expectErr: true, errContains: "time cannot be more than 1 week in the future"},

--- a/pkg/services/annotations/annotationsapi/handler.go
+++ b/pkg/services/annotations/annotationsapi/handler.go
@@ -393,10 +393,10 @@ func annoToItemDTO(anno *annotationV0.Annotation) (*annotations.ItemDTO, error) 
 }
 
 func itemToAnnotation(item *annotations.Item) (*annotationV0.Annotation, error) {
-	// Legacy API defaults an unset time to now;
-	// the new API requires it, so the proxy must fill it in to keep legacy behavior unchanged
+	// Legacy API defaults an unset time to now and silently accepts negative values;
+	// the new API rejects both, so the proxy normalizes them here to keep legacy behavior unchanged
 	epoch := item.Epoch
-	if epoch == 0 {
+	if epoch <= 0 {
 		epoch = time.Now().UnixMilli()
 	}
 

--- a/pkg/services/annotations/annotationsapi/handler.go
+++ b/pkg/services/annotations/annotationsapi/handler.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"time"
 
 	authnlib "github.com/grafana/authlib/authn"
 	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
@@ -392,11 +393,19 @@ func annoToItemDTO(anno *annotationV0.Annotation) (*annotations.ItemDTO, error) 
 }
 
 func itemToAnnotation(item *annotations.Item) (*annotationV0.Annotation, error) {
+	// Legacy API defaults an unset time to now;
+	// the new API requires it, so the proxy must fill it in to keep legacy behavior unchanged
+	epoch := item.Epoch
+	if epoch == 0 {
+		epoch = time.Now().UnixMilli()
+	}
+
 	spec := annotationV0.AnnotationSpec{
 		Text: item.Text,
-		Time: item.Epoch,
+		Time: epoch,
 		Tags: item.Tags,
 	}
+
 	if item.EpochEnd != 0 {
 		spec.TimeEnd = &item.EpochEnd
 	}

--- a/pkg/services/annotations/annotationsapi/handler_test.go
+++ b/pkg/services/annotations/annotationsapi/handler_test.go
@@ -130,6 +130,16 @@ func TestItemAnnotationConversion(t *testing.T) {
 		require.LessOrEqual(t, anno.Spec.Time, after)
 	})
 
+	t.Run("negative epoch defaults to now instead of being rejected by the new API", func(t *testing.T) {
+		before := time.Now().UnixMilli()
+		anno, err := itemToAnnotation(&annotations.Item{Text: "hello", Epoch: -1})
+		require.NoError(t, err)
+		after := time.Now().UnixMilli()
+
+		require.GreaterOrEqual(t, anno.Spec.Time, before)
+		require.LessOrEqual(t, anno.Spec.Time, after)
+	})
+
 	t.Run("point annotation reads back TimeEnd == Time", func(t *testing.T) {
 		anno, err := itemToAnnotation(&annotations.Item{Text: "hello", Epoch: 1234})
 		require.NoError(t, err)

--- a/pkg/services/annotations/annotationsapi/handler_test.go
+++ b/pkg/services/annotations/annotationsapi/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -117,6 +118,16 @@ func TestItemAnnotationConversion(t *testing.T) {
 		dto, err := annoToItemDTO(anno)
 		require.NoError(t, err)
 		require.Nil(t, dto.Data)
+	})
+
+	t.Run("missing epoch defaults to now matching legacy behavior", func(t *testing.T) {
+		before := time.Now().UnixMilli()
+		anno, err := itemToAnnotation(&annotations.Item{Text: "hello"})
+		require.NoError(t, err)
+		after := time.Now().UnixMilli()
+
+		require.GreaterOrEqual(t, anno.Spec.Time, before)
+		require.LessOrEqual(t, anno.Spec.Time, after)
 	})
 
 	t.Run("point annotation reads back TimeEnd == Time", func(t *testing.T) {


### PR DESCRIPTION
Closes https://github.com/grafana/grafana-org/issues/974

Went with making time required in the new API - it matches how the rest of validation here already explicitly fails with errors instead of defaulting. Legacy behavior kept intact: the legacy-to-new-API path fills in time.Now() before forwarding.