### PR TITLE
UI: Add extension point for profile menu

### DIFF
--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -226,6 +226,7 @@ export enum PluginExtensionPoints {
   DataSourceConfigStatus = 'grafana/datasources/config/status',
   ExploreToolbarAction = 'grafana/explore/toolbar/action',
   UserProfileTab = 'grafana/user/profile/tab',
+  UserProfileMenu = 'grafana/user/profile/menu/v1',
   TraceViewDetails = 'grafana/traceview/details',
   TraceViewHeaderActions = 'grafana/traceview/header/actions',
   QueryEditorRowAdaptiveTelemetryV1 = 'grafana/query-editor-row/adaptivetelemetry/v1',

--- a/public/app/core/components/AppChrome/TopBar/ProfileButton.test.tsx
+++ b/public/app/core/components/AppChrome/TopBar/ProfileButton.test.tsx
@@ -3,8 +3,14 @@ import userEvent from '@testing-library/user-event';
 import { render } from 'test/test-utils';
 
 import { config } from '@grafana/runtime';
+import { createComponentWithMeta, usePluginComponents } from 'app/features/plugins/extensions/usePluginComponents';
 
 import { ProfileButton } from './ProfileButton';
+
+jest.mock('app/features/plugins/extensions/usePluginComponents', () => ({
+  ...jest.requireActual('app/features/plugins/extensions/usePluginComponents'),
+  usePluginComponents: jest.fn(),
+}));
 
 // Mock the news feed to avoid real network requests that can cause flaky
 // moment.js deprecation warnings when parsing RSS pubDate values.
@@ -14,6 +20,23 @@ jest.mock('app/plugins/panel/news/feed', () => ({
 }));
 
 describe('ProfileButton', () => {
+  const usePluginComponentsMock = jest.mocked(usePluginComponents);
+  const setupGuideMenuComponent = createComponentWithMeta(
+    {
+      pluginId: 'grafana-setupguide-app',
+      title: 'Profile setup action',
+      component: () => <div>setupguide-profile-menu-extension</div>,
+    },
+    'grafana/user/profile/menu/v1'
+  );
+  const otherPluginMenuComponent = createComponentWithMeta(
+    {
+      pluginId: 'my-other-plugin',
+      title: 'Other profile action',
+      component: () => <div>other-profile-menu-extension</div>,
+    },
+    'grafana/user/profile/menu/v1'
+  );
   let mainView: HTMLDivElement;
   let user: ReturnType<typeof userEvent.setup>;
   const defaultProps = {
@@ -32,6 +55,7 @@ describe('ProfileButton', () => {
     user = userEvent.setup();
     config.newsFeedEnabled = true;
     config.auth.disableSignoutMenu = false;
+    usePluginComponentsMock.mockReturnValue({ isLoading: false, components: [] });
 
     // Drawer portals into .main-view
     mainView = document.createElement('div');
@@ -40,6 +64,7 @@ describe('ProfileButton', () => {
   });
 
   afterEach(() => {
+    usePluginComponentsMock.mockReset();
     config.newsFeedEnabled = originalNewsFeedEnabled;
     config.auth.disableSignoutMenu = originalDisableSignoutMenu;
     document.body.removeChild(mainView);
@@ -77,5 +102,23 @@ describe('ProfileButton', () => {
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
     expect(profileButton).toHaveFocus();
+  });
+
+  it('should render a setupguide profile menu extension component', async () => {
+    usePluginComponentsMock.mockReturnValue({ isLoading: false, components: [setupGuideMenuComponent] });
+
+    render(<ProfileButton {...defaultProps} />);
+
+    await user.click(screen.getByRole('button', { name: /profile/i }));
+    expect(await screen.findByText('setupguide-profile-menu-extension')).toBeInTheDocument();
+  });
+
+  it('should not render non-setupguide profile menu extension components', async () => {
+    usePluginComponentsMock.mockReturnValue({ isLoading: false, components: [otherPluginMenuComponent] });
+
+    render(<ProfileButton {...defaultProps} />);
+
+    await user.click(screen.getByRole('button', { name: /profile/i }));
+    expect(screen.queryByText('other-profile-menu-extension')).not.toBeInTheDocument();
   });
 });

--- a/public/app/core/components/AppChrome/TopBar/ProfileButton.tsx
+++ b/public/app/core/components/AppChrome/TopBar/ProfileButton.tsx
@@ -2,11 +2,13 @@ import { css } from '@emotion/css';
 import { cloneDeep } from 'lodash';
 import { useToggle } from 'react-use';
 
-import { type GrafanaTheme2, type NavModelItem } from '@grafana/data';
+import { type GrafanaTheme2, type NavModelItem, PluginExtensionPoints } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
+import { config, renderLimitedComponents } from '@grafana/runtime';
 import { Dropdown, Menu, MenuItem, ToolbarButton, useStyles2 } from '@grafana/ui';
+import { SETUPGUIDE_PLUGIN_ID } from 'app/core/constants';
 import { contextSrv } from 'app/core/services/context_srv';
+import { usePluginComponents } from 'app/features/plugins/extensions/usePluginComponents';
 
 import { ThemeSelectorDrawer } from '../../ThemeSelector/ThemeSelectorDrawer';
 import { enrichWithInteractionTracking } from '../MegaMenu/utils';
@@ -24,6 +26,9 @@ export function ProfileButton({ profileNode, onToggleKioskMode }: Props) {
   const node = enrichWithInteractionTracking(cloneDeep(profileNode), false);
   const [showNewsDrawer, onToggleShowNewsDrawer] = useToggle(false);
   const [showThemeDrawer, onToggleThemeDrawer] = useToggle(false);
+  const { components } = usePluginComponents({
+    extensionPointId: PluginExtensionPoints.UserProfileMenu,
+  });
 
   if (!node) {
     return null;
@@ -45,6 +50,12 @@ export function ProfileButton({ profileNode, onToggleKioskMode }: Props) {
             label={t('navigation.rss-button', 'Latest from the blog')}
           />
         )}
+        {renderLimitedComponents({
+          props: {},
+          components,
+          limit: 1,
+          pluginId: SETUPGUIDE_PLUGIN_ID,
+        })}
         {!config.auth.disableSignoutMenu && (
           <>
             <Menu.Divider />


### PR DESCRIPTION
**What is this feature?**

Introduces a new extension point that allows the setupguide app to inject custom content into the profile menu dropdown.

**Why do we need this feature?**

In concert with https://github.com/grafana/grafana-setupguide-app/pull/1371 (🔐), allows cloud users to see what stack they're on and switch stacks from any page in Grafana. This is already available as a command palette action, but felt like something that should be in the profile menu as well.

<img width="201" height="375" alt="image" src="https://github.com/user-attachments/assets/98285bf0-0a56-4e7f-8225-cd9906a719b5" />

**Who is this feature for?**

All Cloud users.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
