### PR TITLE
fix: update nats watch subject scheme

### DIFF
--- a/pkg/storage/unified/README.md
+++ b/pkg/storage/unified/README.md
@@ -1393,7 +1393,8 @@ curl -s -u admin:admin -X POST \
 ```
 
 The `nats sub` window then shows a message on subject
-`playlist.grafana.app.default.playlists` (format: `{group}.{namespace}.{resource}`).
+`us.watch.v1.playlist.grafana.app.default.playlists` (format:
+`us.watch.v1.{group}.{namespace}.{resource}`).
 The payload is a protobuf `WatchNotification` (binary), so it renders as raw
 bytes — a message appearing on that subject with a non-empty body confirms the
 publish path.
@@ -1431,7 +1432,7 @@ Payloads are protobuf `WatchNotification` (see
 `UNKNOWN=0, ADDED=1, MODIFIED=2, DELETED=3`. A quick raw capture + hexdump:
 
 ```bash
-nats sub "playlist.grafana.app.>" --raw --count 1 > /tmp/n.bin & \
+nats sub "us.watch.v1.playlist.grafana.app.>" --raw --count 1 > /tmp/n.bin & \
   curl -s -u admin:admin -X POST \
   http://localhost:3000/apis/playlist.grafana.app/v0alpha1/namespaces/default/playlists \
   -H 'Content-Type: application/json' \

--- a/pkg/storage/unified/resource/notifier_nats_integration_test.go
+++ b/pkg/storage/unified/resource/notifier_nats_integration_test.go
@@ -132,7 +132,7 @@ func TestIntegrationNatsWatchNotificationRoundTrip(t *testing.T) {
 			select {
 			case subj := <-got:
 				require.Equal(t, subject, subj)
-				require.Equal(t, "provisioning.grafana.app.default.repositories", subj)
+				require.Equal(t, "us.watch.v1.provisioning.grafana.app.default.repositories", subj)
 				return true
 			case <-time.After(20 * time.Millisecond):
 				return false

--- a/pkg/storage/unified/resource/watch_publisher_test.go
+++ b/pkg/storage/unified/resource/watch_publisher_test.go
@@ -58,7 +58,7 @@ func TestPublishWatchNotification(t *testing.T) {
 		backend.publishWatchNotification(context.Background(), event)
 
 		require.Len(t, pub.subjects, 1)
-		assert.Equal(t, "provisioning.grafana.app.default.repositories", pub.subjects[0])
+		assert.Equal(t, "us.watch.v1.provisioning.grafana.app.default.repositories", pub.subjects[0])
 
 		var got resourcepb.WatchNotification
 		require.NoError(t, proto.Unmarshal(pub.payloads[0], &got))

--- a/pkg/storage/unified/resourcewatch/subject.go
+++ b/pkg/storage/unified/resourcewatch/subject.go
@@ -6,40 +6,56 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// allNamespaces is the NATS single-token wildcard ("*") used in the namespace
-// position to watch every namespace's notifications for a resource.
-const allNamespaces = "*"
+// subjectRoot prefixes every resource-change subject. It isolates this traffic
+// from the rest of the bus, so a ">" tail wildcard can never deliver unrelated
+// messages (e.g. $SYS.*), and its version token lets the layout below change
+// without a flag day: publisher and consumers move root by root.
+const subjectRoot = "us.watch.v1"
 
-// SubjectAllResources matches every Subject(...) whose group is a single-token
-// grafana.app group ({group}.grafana.app.{namespace}.{resource}). Single-token
-// "*" wildcards keep out non-resource bus traffic (e.g. $SYS.*) that a ">"
-// firehose would deliver and fail to unmarshal. Groups with >1 token before
-// .grafana.app are not matched.
-const SubjectAllResources = "*.grafana.app.*.*"
+// anyToken is the NATS single-token wildcard, used in the namespace or resource
+// position to match every value of it.
+const anyToken = "*"
+
+// coreGroup stands in for the empty (core) group, which would otherwise yield an
+// empty token. The leading underscore is illegal in a DNS label and therefore in
+// an API group, so it cannot collide with a real group.
+const coreGroup = "_core"
+
+// SubjectAllResources matches every Subject(...), whatever the group's token
+// count. It is confined to subjectRoot, so it is a firehose over resource
+// notifications only.
+const SubjectAllResources = subjectRoot + ".>"
 
 // Subject returns the NATS subject that carries change notifications for a
 // resource type within a namespace, as the dotted tokens
 //
-//	{group}.{namespace}.{resource}
+//	us.watch.v1.{group}.{namespace}.{resource}
+//
+// The components follow the Kubernetes path order
+// (/apis/{group}/{version}/namespaces/{namespace}/{resource}), so a subject in a
+// log line reads the same way as the API path it came from. The group keeps its
+// own dots and so spans a variable number of tokens; nothing depends on a fixed
+// offset, because publisher, consumer and the us-nats auth callout all compose
+// the subject from a group they know textually, using only the single-token "*"
+// wildcard. Namespace and resource are always exactly one token: Grafana
+// namespaces and resource names contain no dots.
 //
 // The version is intentionally absent: notifications are version-agnostic and a
 // consumer resolves the object at its own version via GET, so a single subject
-// serves every version. An empty namespace yields the "*" single-token wildcard
-// in the namespace position, so a consumer can watch every namespace's
-// notifications for the resource (Grafana namespaces have no dots, so a concrete
-// namespace is always exactly one token and never bleeds into the wildcard).
-//
-// The group keeps its dots and therefore spans several tokens
-// (provisioning.grafana.app -> three tokens); publisher and consumer build the
-// subject the same way from the same GVR, so this is consistent on both sides.
+// serves every version. An empty namespace or resource yields the single-token
+// wildcard in its position, so a consumer can watch every namespace, or every
+// resource of a group.
 func Subject(gvr schema.GroupVersionResource, namespace string) string {
-	ns := namespace
-	if ns == "" {
-		ns = allNamespaces
+	group := gvr.Group
+	if group == "" {
+		group = coreGroup
 	}
-	return strings.Join([]string{
-		gvr.Group,
-		ns,
-		gvr.Resource,
-	}, ".")
+	if namespace == "" {
+		namespace = anyToken
+	}
+	resource := gvr.Resource
+	if resource == "" {
+		resource = anyToken
+	}
+	return strings.Join([]string{subjectRoot, group, namespace, resource}, ".")
 }

--- a/pkg/storage/unified/resourcewatch/subject_test.go
+++ b/pkg/storage/unified/resourcewatch/subject_test.go
@@ -87,6 +87,15 @@ func TestGrantSubjects(t *testing.T) {
 		misses  []schema.GroupVersionResource
 	}{
 		{
+			grant: "*/*",
+			want:  SubjectAllResources,
+			matches: []schema.GroupVersionResource{
+				{Group: "provisioning.grafana.app", Resource: "jobs"},
+				{Group: "notifications.alerting.grafana.app", Resource: "receivers"},
+				{Resource: "configmaps"},
+			},
+		},
+		{
 			grant: "provisioning.grafana.app/jobs",
 			want:  "us.watch.v1.provisioning.grafana.app.*.jobs",
 			matches: []schema.GroupVersionResource{
@@ -147,7 +156,7 @@ func TestGrantSubjects(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.grant, func(t *testing.T) {
-			pattern := grantSubject(tt.grant)
+			pattern := grantSubject(t, tt.grant)
 			require.Equal(t, tt.want, pattern)
 
 			for _, gvr := range tt.matches {
@@ -165,10 +174,22 @@ func TestGrantSubjects(t *testing.T) {
 // grantSubject mirrors the us-nats auth callout: a <group>/<resource> grant
 // becomes a subject with the group's tokens copied verbatim and the namespace
 // wildcarded between group and resource.
-func grantSubject(grant string) string {
+//
+// A group of exactly "*" is the exception: it stands for every group, whatever
+// its token count, which no fixed-width pattern can cover. Only a ">" tail can,
+// and ">" is legal only as the final token, so it swallows the resource
+// position too — hence the callout expands it to the firehose and a whole-group
+// wildcard is only ever granted as "*/*".
+func grantSubject(t *testing.T, grant string) string {
+	t.Helper()
+
 	group, resource, _ := strings.Cut(grant, "/")
-	if group == "" {
+	switch group {
+	case "":
 		group = coreGroup
+	case anyToken:
+		require.Equal(t, anyToken, resource, "a %q group can only be granted with a %q resource", anyToken, anyToken)
+		return SubjectAllResources
 	}
 	return strings.Join([]string{subjectRoot, group, anyToken, resource}, ".")
 }

--- a/pkg/storage/unified/resourcewatch/subject_test.go
+++ b/pkg/storage/unified/resourcewatch/subject_test.go
@@ -1,9 +1,11 @@
 package resourcewatch
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -24,31 +26,168 @@ func TestSubject(t *testing.T) {
 			name:      "namespaced, version-agnostic",
 			gvr:       gvr,
 			namespace: "default",
-			want:      "provisioning.grafana.app.default.repositories",
+			want:      "us.watch.v1.provisioning.grafana.app.default.repositories",
 		},
 		{
 			name:      "empty namespace becomes the single-token wildcard",
 			gvr:       gvr,
 			namespace: "",
-			want:      "provisioning.grafana.app.*.repositories",
+			want:      "us.watch.v1.provisioning.grafana.app.*.repositories",
 		},
 		{
 			name:      "version is ignored",
 			gvr:       schema.GroupVersionResource{Group: "provisioning.grafana.app", Version: "v9", Resource: "repositories"},
 			namespace: "stacks-1",
-			want:      "provisioning.grafana.app.stacks-1.repositories",
+			want:      "us.watch.v1.provisioning.grafana.app.stacks-1.repositories",
+		},
+		{
+			name:      "multi-token group keeps its tokens",
+			gvr:       schema.GroupVersionResource{Group: "notifications.alerting.grafana.app", Resource: "receivers"},
+			namespace: "stacks-1",
+			want:      "us.watch.v1.notifications.alerting.grafana.app.stacks-1.receivers",
+		},
+		{
+			name:      "empty resource becomes the single-token wildcard",
+			gvr:       schema.GroupVersionResource{Group: "provisioning.grafana.app"},
+			namespace: "default",
+			want:      "us.watch.v1.provisioning.grafana.app.default.*",
 		},
 		{
 			name:      "groupless resource",
 			gvr:       schema.GroupVersionResource{Resource: "configmaps"},
 			namespace: "default",
-			want:      ".default.configmaps",
+			want:      "us.watch.v1._core.default.configmaps",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, Subject(tt.gvr, tt.namespace))
+			got := Subject(tt.gvr, tt.namespace)
+			assert.Equal(t, tt.want, got)
+			assert.True(t, subjectMatches(SubjectAllResources, got), "%q must match the firehose", got)
 		})
 	}
+}
+
+func TestSubjectAllResources(t *testing.T) {
+	assert.False(t, subjectMatches(SubjectAllResources, "$SYS.SERVER.ACCOUNT.X.CONNS"))
+	assert.False(t, subjectMatches(SubjectAllResources, "us.watch.v2.provisioning.grafana.app.default.repositories"))
+	assert.False(t, subjectMatches(SubjectAllResources, subjectRoot))
+}
+
+// TestGrantSubjects pins the layout against the us-nats auth callout, which
+// expands an access-policy grant into a NATS permission. Both sides must agree
+// token for token, so the grants are translated here the way the callout does and
+// asserted against real Subject(...) output.
+func TestGrantSubjects(t *testing.T) {
+	tests := []struct {
+		grant   string
+		want    string
+		matches []schema.GroupVersionResource
+		misses  []schema.GroupVersionResource
+	}{
+		{
+			grant: "provisioning.grafana.app/jobs",
+			want:  "us.watch.v1.provisioning.grafana.app.*.jobs",
+			matches: []schema.GroupVersionResource{
+				{Group: "provisioning.grafana.app", Resource: "jobs"},
+			},
+			misses: []schema.GroupVersionResource{
+				{Group: "provisioning.grafana.app", Resource: "repositories"},
+				{Group: "jobs.provisioning.grafana.app", Resource: "jobs"},
+			},
+		},
+		{
+			grant: "provisioning.grafana.app/*",
+			want:  "us.watch.v1.provisioning.grafana.app.*.*",
+			matches: []schema.GroupVersionResource{
+				{Group: "provisioning.grafana.app", Resource: "jobs"},
+				{Group: "provisioning.grafana.app", Resource: "repositories"},
+			},
+			misses: []schema.GroupVersionResource{
+				{Group: "dashboard.grafana.app", Resource: "dashboards"},
+				{Group: "jobs.provisioning.grafana.app", Resource: "jobs"},
+			},
+		},
+		{
+			grant: "*.grafana.app/*",
+			want:  "us.watch.v1.*.grafana.app.*.*",
+			matches: []schema.GroupVersionResource{
+				{Group: "provisioning.grafana.app", Resource: "jobs"},
+				{Group: "dashboard.grafana.app", Resource: "dashboards"},
+			},
+			misses: []schema.GroupVersionResource{
+				{Group: "notifications.alerting.grafana.app", Resource: "receivers"},
+				{Group: "provisioning.grafana.com", Resource: "jobs"},
+			},
+		},
+		{
+			grant: "*.*.grafana.app/*",
+			want:  "us.watch.v1.*.*.grafana.app.*.*",
+			matches: []schema.GroupVersionResource{
+				{Group: "notifications.alerting.grafana.app", Resource: "receivers"},
+				{Group: "loki.datasource.grafana.app", Resource: "datasources"},
+			},
+			misses: []schema.GroupVersionResource{
+				{Group: "provisioning.grafana.app", Resource: "jobs"},
+			},
+		},
+		{
+			grant: "*.alerting.grafana.app/receivers",
+			want:  "us.watch.v1.*.alerting.grafana.app.*.receivers",
+			matches: []schema.GroupVersionResource{
+				{Group: "notifications.alerting.grafana.app", Resource: "receivers"},
+			},
+			misses: []schema.GroupVersionResource{
+				{Group: "notifications.alerting.grafana.app", Resource: "templategroups"},
+				{Group: "alerting.grafana.app", Resource: "receivers"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.grant, func(t *testing.T) {
+			pattern := grantSubject(tt.grant)
+			require.Equal(t, tt.want, pattern)
+
+			for _, gvr := range tt.matches {
+				subject := Subject(gvr, "stacks-1")
+				assert.True(t, subjectMatches(pattern, subject), "%q must match %q", pattern, subject)
+			}
+			for _, gvr := range tt.misses {
+				subject := Subject(gvr, "stacks-1")
+				assert.False(t, subjectMatches(pattern, subject), "%q must not match %q", pattern, subject)
+			}
+		})
+	}
+}
+
+// grantSubject mirrors the us-nats auth callout: a <group>/<resource> grant
+// becomes a subject with the group's tokens copied verbatim and the namespace
+// wildcarded between group and resource.
+func grantSubject(grant string) string {
+	group, resource, _ := strings.Cut(grant, "/")
+	if group == "" {
+		group = coreGroup
+	}
+	return strings.Join([]string{subjectRoot, group, anyToken, resource}, ".")
+}
+
+// subjectMatches implements NATS subject matching: "*" matches exactly one
+// token, ">" matches one or more and only as the final token.
+func subjectMatches(pattern, subject string) bool {
+	patternTokens := strings.Split(pattern, ".")
+	subjectTokens := strings.Split(subject, ".")
+	for i, token := range patternTokens {
+		if token == ">" {
+			return i < len(subjectTokens)
+		}
+		if i >= len(subjectTokens) {
+			return false
+		}
+		if token != anyToken && token != subjectTokens[i] {
+			return false
+		}
+	}
+	return len(patternTokens) == len(subjectTokens)
 }


### PR DESCRIPTION

Token order still follows the Kubernetes API path (`/apis/{group}/{version}/namespaces/{namespace}/{resource}`), so a subject in a log line reads like the path it came from. The version is still absent from the resource part of the subject — notifications are metadata-only and the consumer resolves the object at its own version via GET, so one subject serves every version.

Changes in [subject.go](pkg/storage/unified/resourcewatch/subject.go):

- **`subjectRoot = "us.watch.v1"`** prefixes every subject.
- **Firehose is now `us.watch.v1.>`** instead of `*.grafana.app.*.*`.
- **Empty group → `_core`** instead of an empty token. A leading underscore is
  illegal in a DNS label and therefore in an API group, so `_core` cannot collide
  with a real group.
- **Empty resource → `*`**, so a consumer can watch every resource of a group
  (previously only the namespace position wildcarded).

## Why

**The old firehose silently dropped multi-token groups.** `*.grafana.app.*.*` is exactly five tokens, so it matched `provisioning.grafana.app.…` but *never* matched a four-label group such as `notifications.alerting.grafana.app.…` (six tokens). The firehose subscriber in [notifier_nats.go:199](pkg/storage/unified/resource/notifier_nats.go#L199) was therefore blind to alerting-style groups, with no error anywhere. The old pattern existed because a bare `>` on the root of the bus would also deliver `$SYS.*` and fail to unmarshal — a dedicated root removes that trade-off: `us.watch.v1.>` is a true firehose over resource notifications *only*.

**The version token buys a flag day back.** Layout changes (adding a token, reordering) become a move from `us.watch.v1` to `us.watch.v2`, done root by root: publisher dual-publishes, consumers migrate, old root retires. Without a root there is no way to express "the new layout" as a subject a consumer can opt into.

## Permission mappings (us-nats auth callout)

The callout expands an access-policy grant into a NATS permission. Both sides must agree token for token, so `TestGrantSubjects` in [subject_test.go](pkg/storage/unified/resourcewatch/subject_test.go) translates grants the way the callout does and asserts the result against real `Subject(...)` output. The mapping the callout must produce:

| Access-policy grant | NATS subscribe permission |
| --- | --- |
| `provisioning.grafana.app/jobs` | `us.watch.v1.provisioning.grafana.app.*.jobs` |
| `provisioning.grafana.app/*` | `us.watch.v1.provisioning.grafana.app.*.*` |
| `*.grafana.app/*` | `us.watch.v1.*.grafana.app.*.*` |
| `*.*.grafana.app/*` | `us.watch.v1.*.*.grafana.app.*.*` |
| `*.alerting.grafana.app/receivers` | `us.watch.v1.*.alerting.grafana.app.*.receivers` |
| `/configmaps` (core group) | `us.watch.v1._core.*.configmaps` |
| `*/*` | `us.watch.v1.>` |

