### PR TITLE
Templating: Fix crash when the __data.fields proxy is coerced to a primitive 

### DIFF
--- a/packages/grafana-data/src/field/getFieldDisplayValuesProxy.test.tsx
+++ b/packages/grafana-data/src/field/getFieldDisplayValuesProxy.test.tsx
@@ -83,6 +83,11 @@ describe('getFieldDisplayValuesProxy', () => {
     expect(p[100]).toBeUndefined();
   });
 
+  it('should not throw when coerced to a primitive directly', () => {
+    const p = getFieldDisplayValuesProxy({ frame: dataShortTimeRange, rowIndex: 0 });
+    expect(`${p}`).toBe('');
+  });
+
   it('should use default display processor if display is not defined', () => {
     const p = getFieldDisplayValuesProxy({
       frame: createDataFrame({ fields: [{ name: 'test', values: [1, 2] }] }),

--- a/packages/grafana-data/src/field/getFieldDisplayValuesProxy.ts
+++ b/packages/grafana-data/src/field/getFieldDisplayValuesProxy.ts
@@ -24,7 +24,11 @@ export function getFieldDisplayValuesProxy(options: {
   return new Proxy(
     {},
     {
-      get: (obj, key): DisplayValue | undefined => {
+      get: (obj, key): DisplayValue | undefined | (() => string) => {
+        if (key === Symbol.toPrimitive) {
+          return () => '';
+        }
+
         // 1. Match the name
         let field = options.frame.fields.find((f) => key === f.name);
         if (!field) {


### PR DESCRIPTION
`getFieldDisplayValuesProxy`'s proxy has no field named toString/valueOf, so stringifying it directly (e.g. an in-progress ${__data.fields} macro) threw `TypeError: Cannot convert object to primitive value` instead of resolving to a field. 
Added a Symbol.toPrimitive handler returning '', plus a regression test. 

Before

https://github.com/user-attachments/assets/e08efaf5-5d1d-48e9-baf6-e682abc063f0


After

https://github.com/user-attachments/assets/c60f7f6b-18da-4db8-bab7-bd4a542d8cd4



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
