### PR TITLE
Unified Storage: client handles expired watch resource version

### DIFF
--- a/pkg/storage/unified/apistore/stream.go
+++ b/pkg/storage/unified/apistore/stream.go
@@ -9,12 +9,14 @@ import (
 
 	grpcCodes "google.golang.org/grpc/codes"
 	grpcStatus "google.golang.org/grpc/status"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/klog/v2"
 
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
 
@@ -28,6 +30,7 @@ type streamDecoder struct {
 
 	sendInitialEvents   bool
 	initialBookmarkSent bool
+	expiredSent         bool
 }
 
 func newStreamDecoder(client resourcepb.ResourceStore_WatchClient, newFunc func() runtime.Object, predicate storage.SelectionPredicate, codec runtime.Codec, cancelWatch context.CancelFunc, sendInitialEvents bool) *streamDecoder {
@@ -77,6 +80,22 @@ decode:
 			return watch.Error, nil, io.EOF
 		case grpcStatus.Code(err) == grpcCodes.Canceled:
 			return watch.Error, nil, err
+		case resource.IsResourceVersionExpired(err):
+			// Surface a 410/Expired status object (instead of an error) so clients
+			// such as reflectors re-list from scratch rather than retrying the
+			// watch from a resource version the server can no longer serve.
+			if d.expiredSent {
+				return watch.Error, nil, io.EOF
+			}
+			d.expiredSent = true
+			klog.V(2).Infof("client: watch resource version expired: %s", err)
+			status := resource.AsErrorResult(err)
+			return watch.Error, &metav1.Status{
+				Status:  metav1.StatusFailure,
+				Code:    status.Code,
+				Reason:  metav1.StatusReason(status.Reason),
+				Message: status.Message,
+			}, nil
 		case err != nil:
 			klog.Errorf("client: error receiving result: %s", err)
 			return watch.Error, nil, err

--- a/pkg/storage/unified/apistore/stream_test.go
+++ b/pkg/storage/unified/apistore/stream_test.go
@@ -3,11 +3,14 @@ package apistore
 import (
 	"context"
 	"io"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -15,6 +18,7 @@ import (
 	"k8s.io/apiserver/pkg/storage"
 
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
 
@@ -121,4 +125,41 @@ func TestStreamDecoderBookmarkAnnotation(t *testing.T) {
 			require.Empty(t, annotations["k8s.io/initial-events-end"])
 		}
 	})
+}
+
+// errWatchClient implements resourcepb.ResourceStore_WatchClient and always
+// fails Recv with the same error, like a terminated gRPC stream does.
+type errWatchClient struct {
+	grpc.ClientStream
+	ctx context.Context
+	err error
+}
+
+func (m *errWatchClient) Recv() (*resourcepb.WatchEvent, error) { return nil, m.err }
+func (m *errWatchClient) Context() context.Context              { return m.ctx }
+func (m *errWatchClient) Header() (metadata.MD, error)          { return nil, nil }
+func (m *errWatchClient) Trailer() metadata.MD                  { return nil }
+func (m *errWatchClient) CloseSend() error                      { return nil }
+func (m *errWatchClient) SendMsg(any) error                     { return nil }
+func (m *errWatchClient) RecvMsg(any) error                     { return nil }
+
+func TestStreamDecoderExpiredResourceVersion(t *testing.T) {
+	newFunc := func() runtime.Object { return &unstructured.Unstructured{} }
+	client := &errWatchClient{ctx: t.Context(), err: resource.NewResourceVersionExpiredError(1234)}
+	decoder := newStreamDecoder(client, newFunc, storage.Everything, unstructuredCodec(), func() {}, false)
+
+	// The expired resource version is reported as a 410/Expired status object so
+	// that clients (e.g. reflectors) re-list from scratch.
+	action, obj, err := decoder.Decode()
+	require.NoError(t, err)
+	require.Equal(t, watch.Error, action)
+	status, ok := obj.(*metav1.Status)
+	require.True(t, ok, "expected a metav1.Status, got %T", obj)
+	require.Equal(t, int32(http.StatusGone), status.Code)
+	require.Equal(t, metav1.StatusReasonExpired, status.Reason)
+	require.True(t, apierrors.IsResourceExpired(apierrors.FromObject(status)))
+
+	// The stream is done: the same error must not be reported again.
+	_, _, err = decoder.Decode()
+	require.ErrorIs(t, err, io.EOF)
 }

--- a/pkg/storage/unified/resource/errors.go
+++ b/pkg/storage/unified/resource/errors.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -50,6 +51,45 @@ func NewNotFoundError(key *resourcepb.ResourceKey) *resourcepb.ErrorResult {
 			Name:  key.Name,
 		},
 	}
+}
+
+func NewResourceVersionExpiredError(rv int64) error {
+	result := &resourcepb.ErrorResult{
+		Message: fmt.Sprintf("too old resource version: %d", rv),
+		Code:    http.StatusGone,
+		Reason:  string(metav1.StatusReasonExpired),
+	}
+	st := grpcstatus.New(grpccodes.OutOfRange, result.Message)
+	if withDetails, err := st.WithDetails(result); err == nil {
+		st = withDetails
+	}
+	return st.Err()
+}
+
+func IsResourceVersionExpired(err error) bool {
+	if err == nil {
+		return false
+	}
+	if apierrors.IsResourceExpired(err) || apierrors.IsGone(err) {
+		return true
+	}
+	if res := errorResultFromGRPCDetails(err); res != nil {
+		return res.Code == http.StatusGone || res.Reason == string(metav1.StatusReasonExpired)
+	}
+	return false
+}
+
+func errorResultFromGRPCDetails(err error) *resourcepb.ErrorResult {
+	st, ok := grpcstatus.FromError(err)
+	if !ok || st == nil {
+		return nil
+	}
+	for _, detail := range st.Details() {
+		if res, ok := detail.(*resourcepb.ErrorResult); ok {
+			return res
+		}
+	}
+	return nil
 }
 
 func NewTooManyRequestsError(msg string) *resourcepb.ErrorResult {
@@ -123,6 +163,12 @@ func newRequiredFieldError(
 func AsErrorResult(err error) *resourcepb.ErrorResult {
 	if err == nil {
 		return nil
+	}
+
+	// Structured results attached to a gRPC error keep their reason/code across
+	// the wire, so prefer them over the generic mapping below.
+	if res := errorResultFromGRPCDetails(err); res != nil {
+		return res
 	}
 
 	var apistatus apierrors.APIStatus


### PR DESCRIPTION
client side counter-part of https://github.com/grafana/grafana/pull/130440