### PR TITLE
NATS: Chunk stale peer cleanup deletes

### DIFF
--- a/pkg/infra/nats/discovery.go
+++ b/pkg/infra/nats/discovery.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"slices"
 	"time"
 
 	natsserver "github.com/nats-io/nats-server/v2/server"
@@ -15,6 +16,8 @@ import (
 )
 
 const (
+	maxPeerDeleteBatch = 199
+
 	// discoveryClusterName scopes peer rows so independent Grafana clusters can
 	// share one DB without cross-wiring meshes; matches Cluster.Name.
 	discoveryClusterName = "grafana"
@@ -255,10 +258,8 @@ func (s *kvPeerStore) listActive(ctx context.Context, ttl time.Duration) ([]peer
 		}
 		peers = append(peers, peer{ServerName: rec.ServerName, RouteURL: rec.RouteURL})
 	}
-	// Best-effort prune in one round-trip; the active set above already excludes
-	// these, so a failed delete just leaves them for the next tick.
-	if len(stale) > 0 {
-		if err := s.kv.BatchDelete(ctx, kv.NATSPeersSection, stale); err != nil {
+	for chunk := range slices.Chunk(stale, maxPeerDeleteBatch) {
+		if err := s.kv.BatchDelete(ctx, kv.NATSPeersSection, chunk); err != nil {
 			return peers, err
 		}
 	}

--- a/pkg/infra/nats/discovery.go
+++ b/pkg/infra/nats/discovery.go
@@ -258,7 +258,7 @@ func (s *kvPeerStore) listActive(ctx context.Context, ttl time.Duration) ([]peer
 		}
 		peers = append(peers, peer{ServerName: rec.ServerName, RouteURL: rec.RouteURL})
 	}
-	// Best-effort prune in one round-trip; the active set above already excludes
+	// Best-effort prune; the active set above already excludes
 	// these, so a failed delete just leaves them for the next tick.
 	for chunk := range slices.Chunk(stale, maxPeerDeleteBatch) {
 		if err := s.kv.BatchDelete(ctx, kv.NATSPeersSection, chunk); err != nil {

--- a/pkg/infra/nats/discovery.go
+++ b/pkg/infra/nats/discovery.go
@@ -258,6 +258,8 @@ func (s *kvPeerStore) listActive(ctx context.Context, ttl time.Duration) ([]peer
 		}
 		peers = append(peers, peer{ServerName: rec.ServerName, RouteURL: rec.RouteURL})
 	}
+	// Best-effort prune in one round-trip; the active set above already excludes
+	// these, so a failed delete just leaves them for the next tick.
 	for chunk := range slices.Chunk(stale, maxPeerDeleteBatch) {
 		if err := s.kv.BatchDelete(ctx, kv.NATSPeersSection, chunk); err != nil {
 			return peers, err

--- a/pkg/infra/nats/discovery.go
+++ b/pkg/infra/nats/discovery.go
@@ -16,6 +16,7 @@ import (
 )
 
 const (
+	// keeps each prune under the KV BatchDelete limit (200 keys).
 	maxPeerDeleteBatch = 199
 
 	// discoveryClusterName scopes peer rows so independent Grafana clusters can

--- a/pkg/infra/nats/discovery_store_test.go
+++ b/pkg/infra/nats/discovery_store_test.go
@@ -2,6 +2,7 @@ package nats
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -10,6 +11,16 @@ import (
 
 	"github.com/grafana/grafana/pkg/storage/unified/resource/kv"
 )
+
+type batchDeleteSpyKV struct {
+	kv.KV
+	sizes []int
+}
+
+func (s *batchDeleteSpyKV) BatchDelete(ctx context.Context, section string, keys []string) error {
+	s.sizes = append(s.sizes, len(keys))
+	return s.KV.BatchDelete(ctx, section, keys)
+}
 
 // newTestKVStore builds a kvPeerStore over an in-memory KV with a settable clock
 // so TTL behaviour is deterministic.
@@ -85,6 +96,35 @@ func TestKVPeerStore(t *testing.T) {
 		r, err := s.kv.Get(ctx, kv.NATSPeersSection, s.peerKey("fresh"))
 		require.NoError(t, err)
 		require.NoError(t, r.Close())
+	})
+
+	t.Run("prunes stale peers in chunks under the batch limit", func(t *testing.T) {
+		now := time.Unix(1_000, 0)
+		db, err := badger.Open(badger.DefaultOptions("").WithInMemory(true).WithLogger(nil))
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+		spy := &batchDeleteSpyKV{KV: kv.NewBadgerKV(db)}
+		s := newKVPeerStore(spy, "grafana")
+		s.now = func() time.Time { return now }
+
+		const staleCount = 2*maxPeerDeleteBatch + 1
+		for i := 0; i < staleCount; i++ {
+			require.NoError(t, s.upsert(ctx, peer{ServerName: fmt.Sprintf("stale-%d", i), RouteURL: "nats://10.0.0.1:6222"}))
+		}
+		now = now.Add(ttl + time.Second)
+
+		peers, err := s.listActive(ctx, ttl)
+		require.NoError(t, err)
+		require.Empty(t, peers)
+
+		total := 0
+		for _, n := range spy.sizes {
+			require.LessOrEqual(t, n, maxPeerDeleteBatch)
+			total += n
+		}
+		require.Equal(t, staleCount, total)
+		require.Greater(t, len(spy.sizes), 1)
 	})
 
 	t.Run("remove deletes a single peer", func(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

`kvPeerStore.listActive` (`pkg/infra/nats/discovery.go`) pruned every stale peer in a single `BatchDelete`. This chunks it to at most 199 keys per call, matching the other KV delete paths, so each `DELETE` stays small enough for the DB to keep using the `key_path` index.

**Why do we need this feature?**

Follow-up to the KV batch-delete size limit added in #130569 (per [this review](https://github.com/grafana/grafana/pull/130569#discussion_r3766907347)). Once 200+ stale peer rows accumulate, the un-chunked single `BatchDelete` would be rejected by that limit and the stale set could only grow. Chunking is also a safe improvement on its own.

**Who is this feature for?**

Operators running multi-instance Grafana with the NATS-based discovery peer store.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Small backend-only change under `pkg/infra/nats/`. Added a peer-store test (`discovery_store_test.go`) that seeds 399 stale peers and asserts every `BatchDelete` call stays ≤199 keys and all rows are pruned.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.