### PR TITLE
Annotations: use `contains` param when searching tags via proxy

### DIFF
--- a/pkg/services/annotations/annotationsapi/api_client.go
+++ b/pkg/services/annotations/annotationsapi/api_client.go
@@ -208,7 +208,7 @@ func (s *annotationAPIClient) ListTags(ctx context.Context, orgID int64, query *
 		Resource("tags")
 
 	if query.Tag != "" {
-		req = req.Param("prefix", query.Tag)
+		req = req.Param("contains", query.Tag)
 	}
 	if query.Limit != 0 {
 		req = req.Param("limit", strconv.FormatInt(query.Limit, 10))

--- a/pkg/services/annotations/annotationsapi/api_client_test.go
+++ b/pkg/services/annotations/annotationsapi/api_client_test.go
@@ -343,9 +343,9 @@ func TestAnnotationAPIClient_Requests(t *testing.T) {
 		assert.Equal(t, http.MethodGet, req.method)
 		assert.Equal(t, base+"/tags", req.path, "tags hangs off the namespace, not the annotations collection")
 		assert.Equal(t, url.Values{
-			"prefix": {"out"},
-			"limit":  {"25"},
-		}, req.query, "the legacy tag term becomes a prefix match")
+			"contains": {"out"},
+			"limit":    {"25"},
+		}, req.query, "the legacy tag term becomes a contains match")
 	})
 
 	t.Run("ListTags omits parameters the query leaves unset", func(t *testing.T) {


### PR DESCRIPTION
This PR updates the annotation migration proxy layer to use the `contains` query parameter when searching tags (added in https://github.com/grafana/grafana/pull/130536) instead of `prefix`. This aligns the proxy's behavior with how tag searching works today in the legacy API, matching a case-insensitive substring.