### PR TITLE
Table: make Tooltip from field picker clearable

### DIFF
--- a/e2e-playwright/panels-suite/table-kitchenSink.spec.ts
+++ b/e2e-playwright/panels-suite/table-kitchenSink.spec.ts
@@ -503,6 +503,34 @@ test.describe('Panels test: Table - Kitchen Sink', { tag: ['@panels', '@table'] 
     ).not.toBeVisible();
   });
 
+  test('Tooltip from field picker can be cleared', async ({ gotoDashboardPage, selectors, page }) => {
+    const dashboardPage = await gotoDashboardPage({
+      uid: DASHBOARD_UID,
+      queryParams: new URLSearchParams({ editPanel: '12' }),
+    });
+
+    await expect(
+      dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.title('Tooltip from field'))
+    ).toBeVisible();
+    await waitForTableLoad(page);
+
+    // this panel ships with a field override that renders a tooltip caret on the "Info" column.
+    const caret = dashboardPage.getByGrafanaSelector(selectors.components.Panels.Visualization.TableNG.Tooltip.Caret);
+    await expect(caret.first()).toBeVisible();
+
+    const overrideGroup = dashboardPage.getByGrafanaSelector(
+      selectors.components.OptionsGroup.group('panel-options-override-1')
+    );
+    const tooltipFieldPicker = overrideGroup.getByLabel('Tooltip from field');
+    await expect(tooltipFieldPicker).toHaveValue('Long Text');
+
+    // clearing the picker should remove the tooltip entirely, not just leave it stuck on a value.
+    await overrideGroup.getByRole('button', { name: 'Clear value' }).click();
+
+    await expect(tooltipFieldPicker).toHaveValue('');
+    await expect(caret).toHaveCount(0);
+  });
+
   test('Styling overrides with styling from field', async ({ gotoDashboardPage, selectors, page }) => {
     const dashboardPage = await gotoDashboardPage({
       uid: DASHBOARD_UID,

--- a/public/app/plugins/panel/table/module.test.ts
+++ b/public/app/plugins/panel/table/module.test.ts
@@ -84,9 +84,6 @@ describe('table module', () => {
     );
   });
 
-  it('makes the "Tooltip from field" picker clearable', () => {
-    expect(customConfigItem('tooltip.field').settings).toEqual(expect.objectContaining({ isClearable: true }));
-  });
 
   describe('"Tooltip placement" visibility', () => {
     const showIf = (field?: string) =>

--- a/public/app/plugins/panel/table/module.test.ts
+++ b/public/app/plugins/panel/table/module.test.ts
@@ -84,6 +84,10 @@ describe('table module', () => {
     );
   });
 
+  it('makes the "Tooltip from field" picker clearable', () => {
+    expect(customConfigItem('tooltip.field').settings).toEqual(expect.objectContaining({ isClearable: true }));
+  });
+
   describe('"Tooltip placement" visibility', () => {
     const showIf = (field?: string) =>
       customConfigItem('tooltip.placement').showIf!(

--- a/public/app/plugins/panel/table/module.test.ts
+++ b/public/app/plugins/panel/table/module.test.ts
@@ -84,7 +84,6 @@ describe('table module', () => {
     );
   });
 
-
   describe('"Tooltip placement" visibility', () => {
     const showIf = (field?: string) =>
       customConfigItem('tooltip.placement').showIf!(

--- a/public/app/plugins/panel/table/module.tsx
+++ b/public/app/plugins/panel/table/module.tsx
@@ -93,6 +93,9 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TablePanel)
             'Render a cell from a field (hidden or visible) in a tooltip'
           ),
           category: cellCategory,
+          settings: {
+            isClearable: true,
+          },
         })
         .addSelect({
           path: 'tooltip.placement',


### PR DESCRIPTION
## What is this feature?

Fixes the table panel's "Tooltip from field" picker so a chosen value can be cleared back to unset.

## Why do we need this feature?

Closes #130580. Once a field was picked for "Tooltip from field" there was no way to unset it — the field-name picker had no `isClearable` setting, so it never rendered the clear ("X") affordance. This also left "Tooltip placement" stuck visible, since that option's `showIf` only hides once `tooltip.field` is undefined again.

## Who is this feature for?

Anyone using the table panel's cell tooltip option.

## Which issue(s) does this PR fix?

Closes #130580

## Notes for the reviewer

Reuses the existing `settings: { isClearable: true }` pattern already used by the Trend panel's "X field" picker (`public/app/plugins/panel/trend/module.tsx`) — same first-class `FieldNamePickerConfigSettings.isClearable` setting, just not turned on here before. No new components or behavior needed.

Added a unit test asserting the setting, and a Playwright e2e test that clears the picker via the panel editor and confirms the tooltip caret disappears from the table.