### PR TITLE
DashListItem: Adjust Icon right spacing

### DIFF
--- a/public/app/plugins/panel/dashlist/DashListItem.tsx
+++ b/public/app/plugins/panel/dashlist/DashListItem.tsx
@@ -74,7 +74,7 @@ export function DashListItem({
           }
         />
       ) : (
-        <Card noMargin className={css.dashlistCardContainer}>
+        <Card noMargin isCompact className={css.dashlistCardContainer}>
           <Stack justifyContent="space-between" alignItems="start" height="100%">
             <Link
               className={css.dashlistCard}

--- a/public/app/plugins/panel/dashlist/styles.ts
+++ b/public/app/plugins/panel/dashlist/styles.ts
@@ -13,9 +13,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
     dashlistCardContainer: css({
       display: 'block',
       height: '100%',
-      paddingTop: theme.spacing(1.25),
-      paddingBottom: theme.spacing(1.25),
-      paddingRight: theme.spacing(1.25),
+      paddingLeft: theme.spacing(2),
 
       '&:has(a:hover)': {
         backgroundImage: gradient,

--- a/public/app/plugins/panel/dashlist/styles.ts
+++ b/public/app/plugins/panel/dashlist/styles.ts
@@ -15,6 +15,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
       height: '100%',
       paddingTop: theme.spacing(1.25),
       paddingBottom: theme.spacing(1.25),
+      paddingRight: theme.spacing(1.25),
 
       '&:has(a:hover)': {
         backgroundImage: gradient,


### PR DESCRIPTION
**What is this feature?**

Browse dashboard page -> Recently viewed cards: Adjust star icon right spacing so it aligned with corner spacing 


| before | after |
| --- | --- |
| <img width="298" height="121" alt="image" src="https://github.com/user-attachments/assets/7e024901-105c-41f7-b976-82777601d688" /> | <img width="318" height="157" alt="image" src="https://github.com/user-attachments/assets/71bb4381-6419-430e-b0c0-4dee3bcc6002" /> |


**Which issue(s) does this PR fix?**:

Fixes N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
