### PR TITLE
Storage API: singleton lock for Garbage Collector across replicas

### DIFF
--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -51,12 +51,12 @@ const (
 	// gcLeaseName is the lease used to ensure only one storage-api replica
 	// runs a garbage collection cycle at a time. See runGarbageCollectionWithLock.
 	gcLeaseName = "resource-gc"
-
-	// gcLeaseTTL is short because the lease auto-renews for as long as the GC
-	// cycle runs; it only bounds how quickly the lock is reclaimed if a
-	// replica crashes mid-cycle.
-	gcLeaseTTL = time.Minute
 )
+
+// gcLeaseTTL is short because the lease auto-renews for as long as the GC
+// cycle runs; it only bounds how quickly the lock is reclaimed if a replica
+// crashes mid-cycle. A var (not const) so tests can shrink it.
+var gcLeaseTTL = time.Minute
 
 // IsResourceNameMixedCase reports whether a successful read returned a
 // resource whose stored name matches the requested name case-insensitively but
@@ -728,13 +728,28 @@ func (b *kvStorageBackend) runGarbageCollectionWithLock(ctx context.Context, cut
 		}
 		return
 	}
+
+	// Cancel the cycle if the lease is lost mid-run (e.g. renewal failure),
+	// so this replica stops deleting once another replica may have taken over.
+	leaseCtx, cancel := context.WithCancel(ctx)
+	watcherDone := make(chan struct{})
+	go func() {
+		defer close(watcherDone)
+		select {
+		case <-l.Lost():
+			cancel()
+		case <-leaseCtx.Done():
+		}
+	}()
 	defer func() {
+		cancel()
+		<-watcherDone
 		if err := b.leaseManager.Release(context.WithoutCancel(ctx), l); err != nil {
 			b.log.Warn("releasing garbage collection lease failed", "error", err)
 		}
 	}()
 
-	b.runGarbageCollection(ctx, cutoffTimeStamp)
+	b.runGarbageCollection(leaseCtx, cutoffTimeStamp)
 }
 
 // runGarbageCollection identifies deleted resources that are safe

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -47,6 +47,15 @@ const (
 	defaultSearchLookback             = 1 * time.Second
 	defaultGarbageCollectionBatchWait = 1 * time.Second
 	persistDeadline                   = 10 * time.Second
+
+	// gcLeaseName is the lease used to ensure only one storage-api replica
+	// runs a garbage collection cycle at a time. See runGarbageCollectionWithLock.
+	gcLeaseName = "resource-gc"
+
+	// gcLeaseTTL bounds how long a GC cycle can hold the lease. If a cycle
+	// runs longer, the lease expires and another replica may pick it up too;
+	// harmless since deletes are idempotent.
+	gcLeaseTTL = 10 * time.Minute
 )
 
 // IsResourceNameMixedCase reports whether a successful read returned a
@@ -695,12 +704,39 @@ func (b *kvStorageBackend) initGarbageCollection(ctx context.Context) error {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				b.runGarbageCollection(ctx, time.Now().Add(-b.garbageCollection.MaxAge).UnixMicro())
+				b.runGarbageCollectionWithLock(ctx, time.Now().Add(-b.garbageCollection.MaxAge).UnixMicro())
 			}
 		}
 	}()
 
 	return nil
+}
+
+// runGarbageCollectionWithLock is a best-effort attempt at having only one
+// storage-api replica run a GC cycle at a time, using the same lease
+// primitive as usage-stats flushing and search snapshot build/cleanup.
+// Deletes are idempotent, so a concurrent run by two replicas is safe, just
+// redundant; when leases are disabled, GC simply runs on every replica.
+func (b *kvStorageBackend) runGarbageCollectionWithLock(ctx context.Context, cutoffTimeStamp int64) {
+	if b.leaseManager == nil {
+		b.runGarbageCollection(ctx, cutoffTimeStamp)
+		return
+	}
+
+	l, err := b.leaseManager.Acquire(ctx, gcLeaseName, lease.WithTTL(gcLeaseTTL))
+	if err != nil {
+		if !errors.Is(err, lease.ErrLeaseAlreadyHeld) {
+			b.log.Error("failed to acquire garbage collection lease", "error", err)
+		}
+		return
+	}
+	defer func() {
+		if err := b.leaseManager.Release(context.WithoutCancel(ctx), l); err != nil {
+			b.log.Warn("releasing garbage collection lease failed", "error", err)
+		}
+	}()
+
+	b.runGarbageCollection(ctx, cutoffTimeStamp)
 }
 
 // runGarbageCollection identifies deleted resources that are safe

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -52,10 +52,10 @@ const (
 	// runs a garbage collection cycle at a time. See runGarbageCollectionWithLock.
 	gcLeaseName = "resource-gc"
 
-	// gcLeaseTTL bounds how long a GC cycle can hold the lease. If a cycle
-	// runs longer, the lease expires and another replica may pick it up too;
-	// harmless since deletes are idempotent.
-	gcLeaseTTL = 10 * time.Minute
+	// gcLeaseTTL is short because the lease auto-renews for as long as the GC
+	// cycle runs; it only bounds how quickly the lock is reclaimed if a
+	// replica crashes mid-cycle.
+	gcLeaseTTL = time.Minute
 )
 
 // IsResourceNameMixedCase reports whether a successful read returned a
@@ -713,17 +713,15 @@ func (b *kvStorageBackend) initGarbageCollection(ctx context.Context) error {
 }
 
 // runGarbageCollectionWithLock is a best-effort attempt at having only one
-// storage-api replica run a GC cycle at a time, using the same lease
-// primitive as usage-stats flushing and search snapshot build/cleanup.
-// Deletes are idempotent, so a concurrent run by two replicas is safe, just
-// redundant; when leases are disabled, GC simply runs on every replica.
+// storage-api replica run a GC cycle at a time; deletes are idempotent, so a
+// concurrent run by two replicas is safe, just redundant.
 func (b *kvStorageBackend) runGarbageCollectionWithLock(ctx context.Context, cutoffTimeStamp int64) {
 	if b.leaseManager == nil {
 		b.runGarbageCollection(ctx, cutoffTimeStamp)
 		return
 	}
 
-	l, err := b.leaseManager.Acquire(ctx, gcLeaseName, lease.WithTTL(gcLeaseTTL))
+	l, err := b.leaseManager.Acquire(ctx, gcLeaseName, lease.WithTTL(gcLeaseTTL), lease.WithAutoRenew())
 	if err != nil {
 		if !errors.Is(err, lease.ErrLeaseAlreadyHeld) {
 			b.log.Error("failed to acquire garbage collection lease", "error", err)

--- a/pkg/storage/unified/resource/storage_backend_gc_test.go
+++ b/pkg/storage/unified/resource/storage_backend_gc_test.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/storage/unified/resource/lease"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 	"github.com/grafana/grafana/pkg/util/testutil"
 	"github.com/stretchr/testify/require"
@@ -789,4 +790,110 @@ func TestIntegrationGarbageCollectionPartialDeleteConverges(t *testing.T) {
 	err = b.garbageCollectGroupResource(ctx, "group", "resource", cutoff)
 	require.NoError(t, err)
 	require.Equal(t, 0, countHistory(), "GC did not converge after a partial delete")
+}
+
+// TestIntegrationGarbageCollectionLock verifies the best-effort singleton
+// lock that ensures only one storage-api replica runs a GC cycle at a time,
+// built on the same lease primitive used for usage-stats flushing and
+// search snapshot build/cleanup locks.
+func TestIntegrationGarbageCollectionLock(t *testing.T) {
+	gcConfig := GarbageCollectionConfig{
+		Enabled:          true,
+		Interval:         time.Minute,
+		BatchSize:        100,
+		DashboardsMaxAge: 24 * time.Hour,
+	}
+
+	countHistoryEntries := func(t *testing.T, ctx context.Context, b *kvStorageBackend) int {
+		count := 0
+		resp := b.kv.Keys(ctx, dataSection, ListOptions{
+			StartKey: "group/resource/namespace/",
+			EndKey:   "group/resource/namespace0",
+		})
+		resp(func(k string, err error) bool {
+			require.NoError(t, err)
+			count++
+			return true
+		})
+		return count
+	}
+
+	setupBackendWithHistory := func(t *testing.T, configs ...func(*KVBackendOptions)) (*kvStorageBackend, context.Context) {
+		ctx := testutil.NewTestContext(t, time.Now().Add(2*time.Minute))
+
+		storageBackend := setupTestStorageBackend(t, append([]func(*KVBackendOptions){func(opts *KVBackendOptions) {
+			opts.GarbageCollection = gcConfig
+		}}, configs...)...)
+
+		server, err := NewResourceServer(ResourceServerOptions{
+			Backend: storageBackend,
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			_ = server.Stop(ctx)
+		})
+
+		rv1, err := writeEvent(t, ctx, storageBackend, "resource1", resourcepb.WatchEvent_ADDED)
+		require.NoError(t, err)
+		_, err = writeEvent(t, ctx, storageBackend, "resource1", resourcepb.WatchEvent_DELETED,
+			func(o *writeEventOptions) {
+				o.PreviousRV = rv1
+			})
+		require.NoError(t, err)
+		require.Equal(t, 2, countHistoryEntries(t, ctx, storageBackend))
+
+		return storageBackend, ctx
+	}
+
+	withKVLeases := func(opts *KVBackendOptions) {
+		opts.EnableKVLeases = true
+		opts.Holder = "test-holder"
+	}
+
+	t.Run("skips the cycle when another replica holds the lock", func(t *testing.T) {
+		testutil.SkipIntegrationTestInShortMode(t)
+
+		b, ctx := setupBackendWithHistory(t, withKVLeases)
+
+		// Simulate another replica that is already running a GC cycle.
+		l, err := b.leaseManager.Acquire(ctx, gcLeaseName, lease.WithTTL(gcLeaseTTL))
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = b.leaseManager.Release(ctx, l) })
+
+		cutoffTimestamp := time.Now().Add(time.Hour).UnixMicro() // everything eligible for deletion
+		b.runGarbageCollectionWithLock(ctx, cutoffTimestamp)
+
+		// GC must have been skipped: history entries remain untouched.
+		require.Equal(t, 2, countHistoryEntries(t, ctx, b))
+	})
+
+	t.Run("runs and releases the lock when no other replica holds it", func(t *testing.T) {
+		testutil.SkipIntegrationTestInShortMode(t)
+
+		b, ctx := setupBackendWithHistory(t, withKVLeases)
+
+		cutoffTimestamp := time.Now().Add(time.Hour).UnixMicro() // everything eligible for deletion
+		b.runGarbageCollectionWithLock(ctx, cutoffTimestamp)
+
+		require.Equal(t, 0, countHistoryEntries(t, ctx, b))
+
+		// the lock must be released so a future cycle isn't skipped forever
+		l, err := b.leaseManager.Acquire(ctx, gcLeaseName, lease.WithTTL(gcLeaseTTL))
+		require.NoError(t, err)
+		require.NoError(t, b.leaseManager.Release(ctx, l))
+	})
+
+	t.Run("runs on every replica when leases are disabled", func(t *testing.T) {
+		testutil.SkipIntegrationTestInShortMode(t)
+
+		b, ctx := setupBackendWithHistory(t)
+		require.Nil(t, b.leaseManager)
+
+		cutoffTimestamp := time.Now().Add(time.Hour).UnixMicro() // everything eligible for deletion
+		b.runGarbageCollectionWithLock(ctx, cutoffTimestamp)
+
+		require.Equal(t, 0, countHistoryEntries(t, ctx, b))
+	})
 }

--- a/pkg/storage/unified/resource/storage_backend_gc_test.go
+++ b/pkg/storage/unified/resource/storage_backend_gc_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"iter"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -896,4 +899,116 @@ func TestIntegrationGarbageCollectionLock(t *testing.T) {
 
 		require.Equal(t, 0, countHistoryEntries(t, ctx, b))
 	})
+}
+
+// blockOnFirstDataKeysKV blocks the first Keys call against dataSection made
+// after arm() until release is closed, letting a test pause a GC cycle
+// mid-flight without also blocking on Keys calls made during test setup.
+type blockOnFirstDataKeysKV struct {
+	KV
+	armed   atomic.Bool
+	once    sync.Once
+	release chan struct{}
+	blocked chan struct{}
+}
+
+func (w *blockOnFirstDataKeysKV) arm() {
+	w.armed.Store(true)
+}
+
+func (w *blockOnFirstDataKeysKV) Keys(ctx context.Context, section string, opt ListOptions) iter.Seq2[string, error] {
+	if section == dataSection && w.armed.Load() {
+		w.once.Do(func() {
+			close(w.blocked)
+			<-w.release
+		})
+	}
+	return w.KV.Keys(ctx, section, opt)
+}
+
+// TestIntegrationGarbageCollectionLockCancelsOnLeaseLoss verifies that a GC
+// cycle stops once its auto-renewed lease is lost to another replica,
+// instead of continuing to delete under a context nobody still owns the lock for.
+func TestIntegrationGarbageCollectionLockCancelsOnLeaseLoss(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	// 10s is the lease package's minimum allowed TTL (lease.Manager.minTTL);
+	// renewInterval = ttl/3, so replica-a's next renewal attempt lands ~3.3s in.
+	origTTL := gcLeaseTTL
+	gcLeaseTTL = 10 * time.Second
+	t.Cleanup(func() { gcLeaseTTL = origTTL })
+
+	ctx := testutil.NewTestContext(t, time.Now().Add(2*time.Minute))
+
+	wrapped := &blockOnFirstDataKeysKV{KV: setupBadgerKV(t), release: make(chan struct{}), blocked: make(chan struct{})}
+	b := setupTestStorageBackend(t, withKV(wrapped), func(opts *KVBackendOptions) {
+		opts.GarbageCollection = GarbageCollectionConfig{
+			Enabled: true, Interval: time.Minute, BatchSize: 100, DashboardsMaxAge: 24 * time.Hour,
+		}
+		opts.EnableKVLeases = true
+		opts.Holder = "replica-a"
+	})
+
+	rv1, err := writeEvent(t, ctx, b, "resource1", resourcepb.WatchEvent_ADDED)
+	require.NoError(t, err)
+	_, err = writeEvent(t, ctx, b, "resource1", resourcepb.WatchEvent_DELETED,
+		func(o *writeEventOptions) { o.PreviousRV = rv1 })
+	require.NoError(t, err)
+
+	countHistory := func() int {
+		count := 0
+		b.kv.Keys(ctx, dataSection, ListOptions{
+			StartKey: "group/resource/namespace/",
+			EndKey:   "group/resource/namespace0",
+		})(func(_ string, err error) bool {
+			require.NoError(t, err)
+			count++
+			return true
+		})
+		return count
+	}
+	require.Equal(t, 2, countHistory())
+
+	wrapped.arm()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		cutoffTimestamp := time.Now().Add(time.Hour).UnixMicro() // everything eligible for deletion
+		b.runGarbageCollectionWithLock(ctx, cutoffTimestamp)
+	}()
+
+	select {
+	case <-wrapped.blocked:
+	case <-time.After(5 * time.Second):
+		t.Fatal("GC cycle never called Keys(dataSection); block point not reached")
+	}
+
+	// Steal the lease out from under replica-a using a clock-skewed manager,
+	// mirroring how the lease package's own renewal-loss tests force a steal.
+	stealer := lease.NewManager(wrapped, "replica-b", nil,
+		lease.WithGarbageCollectionDisabled,
+		lease.WithInternalNowFunc(func() time.Time { return time.Now().Add(time.Hour) }),
+	)
+	require.Eventually(t, func() bool {
+		l, err := stealer.Acquire(ctx, gcLeaseName, lease.WithTTL(gcLeaseTTL))
+		if err != nil {
+			return false
+		}
+		t.Cleanup(func() { _ = stealer.Release(ctx, l) })
+		return true
+	}, time.Second, 10*time.Millisecond, "replica-b never stole the GC lease")
+
+	// Give replica-a's auto-renew loop time to discover the theft and cancel.
+	time.Sleep(5 * time.Second)
+	close(wrapped.release)
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("runGarbageCollectionWithLock did not return after lease loss")
+	}
+
+	// The cycle must have stopped before deleting anything once its context
+	// was cancelled by the lost lease.
+	require.Equal(t, 2, countHistory())
 }


### PR DESCRIPTION
Every storage-api replica runs its own resource-history GC cycle independently, causing redundant, duplicated deletion work on every interval as replica count grows. 

This PR adds a best-effort singleton lock via the existing `lease.Manager` (auto-renewed, cancelling the cycle if the lease is lost) so only one replica runs GC at a time, falling back to today's per-replica behavior when `EnableKVLeases` is off.