### PR TITLE
Unified Storage: build KV backend options in one place

### DIFF
--- a/pkg/storage/unified/resource/kv_backend_options_test.go
+++ b/pkg/storage/unified/resource/kv_backend_options_test.go
@@ -79,6 +79,8 @@ func requirePopulated(t *testing.T, v reflect.Value, path string) {
 			if value.Elem().Kind() == reflect.Struct {
 				requirePopulated(t, value.Elem(), fieldPath)
 			}
+		default:
+			// Anything else is a leaf, and the non-zero check above is all there is to do.
 		}
 	}
 }
@@ -142,6 +144,8 @@ func fullyPopulatedCfg() *setting.Cfg {
 			field.SetUint(uint64(i + 1))
 		case reflect.Float32, reflect.Float64:
 			field.SetFloat(float64(i + 1))
+		default:
+			// Only scalars: nothing reads a config field of another kind into the options.
 		}
 	}
 

--- a/pkg/storage/unified/resource/kv_backend_options_test.go
+++ b/pkg/storage/unified/resource/kv_backend_options_test.go
@@ -1,0 +1,156 @@
+package resource
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+// callerSuppliedFields lists the options NewKVBackendOptions does not set, and
+// why. A field that is neither set nor listed here fails the test below, so
+// adding an option forces a decision about where its value comes from.
+var callerSuppliedFields = map[string]string{
+	"KvStore":                  "the store itself; chosen by the wiring",
+	"ExperimentalKV":           "an alternative store; chosen by the wiring",
+	"Reg":                      "metrics registry owned by the caller",
+	"Log":                      "logger owned by the caller",
+	"DBKeepAlive":              "reference to the caller's database provider",
+	"GCGate":                   "shared with the caller's startup sequencing",
+	"UseChannelNotifier":       "derived from high-availability detection, not from a single setting",
+	"RvManager":                "built by the caller from a live database connection",
+	"EventPublisher":           "NATS publisher injected by the caller",
+	"EventSubscriber":          "NATS subscriber injected by the caller",
+	"EnableNatsNotifier":       "set together with EventSubscriber by the caller",
+	"EnableNatsNotifierShadow": "set together with EventSubscriber by the caller",
+	"EmbeddingDeleter":         "vector backend injected by the caller",
+
+	// The lease options are set together, and the holder comes from
+	// sql.ResolveLeaseHolder, which this package cannot import.
+	"EnableKVLeases": "set together with Holder, which the caller resolves",
+	"Holder":         "resolved by sql.ResolveLeaseHolder, which this package cannot call",
+	"LeaseTTL":       "set together with Holder, which the caller resolves",
+	"LeaseAutoRenew": "set together with Holder, which the caller resolves",
+
+	"WatchOptions.BufferSize": "no setting; defaulted in WatchOptions.normalize",
+	"WatchOptions.MinBackoff": "no setting; defaulted in WatchOptions.normalize",
+	"WatchOptions.MaxBackoff": "no setting; defaulted in WatchOptions.normalize",
+
+	"TenantWatcherConfig.ResyncInterval": "no setting; defaulted by the tenant watcher",
+	"TenantWatcherConfig.RetryMaxDelay":  "no setting; defaulted by the tenant watcher",
+}
+
+func TestNewKVBackendOptionsSetsEveryConfigDerivedField(t *testing.T) {
+	opts := NewKVBackendOptions(fullyPopulatedCfg())
+
+	requirePopulated(t, reflect.ValueOf(opts), "")
+}
+
+func requirePopulated(t *testing.T, v reflect.Value, path string) {
+	t.Helper()
+
+	typ := v.Type()
+	for i := range typ.NumField() {
+		field := typ.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+
+		fieldPath := field.Name
+		if path != "" {
+			fieldPath = path + "." + field.Name
+		}
+		if _, ok := callerSuppliedFields[fieldPath]; ok {
+			continue
+		}
+
+		value := v.Field(i)
+		require.Falsef(t, value.IsZero(),
+			"%s is zero: either populate it in NewKVBackendOptions or add it to callerSuppliedFields with a reason",
+			fieldPath)
+
+		switch value.Kind() {
+		case reflect.Struct:
+			requirePopulated(t, value, fieldPath)
+		case reflect.Pointer:
+			if value.Elem().Kind() == reflect.Struct {
+				requirePopulated(t, value.Elem(), fieldPath)
+			}
+		}
+	}
+}
+
+// The walk above only checks for non-zero, so it cannot catch two settings
+// swapped between options. These assertions can.
+func TestNewKVBackendOptionsValues(t *testing.T) {
+	cfg := setting.NewCfg()
+	cfg.MaxFileIndexAge = 1 * time.Minute
+	cfg.EventRetentionPeriod = 2 * time.Minute
+	cfg.EventPruningInterval = 3 * time.Minute
+	cfg.SearchLookback = 4 * time.Minute
+	cfg.NotifierSettleDelay = 5 * time.Minute
+	cfg.DashboardVersionsToKeep = 7
+	cfg.EnableGarbageCollection = true
+	cfg.GarbageCollectionDryRun = true
+	cfg.GarbageCollectionInterval = 6 * time.Minute
+	cfg.GarbageCollectionBatchSize = 8
+	cfg.GarbageCollectionBatchWait = 7 * time.Minute
+	cfg.GarbageCollectionMaxAge = 8 * time.Minute
+	cfg.DashboardsGarbageCollectionMaxAge = 9 * time.Minute
+
+	opts := NewKVBackendOptions(cfg)
+
+	require.Equal(t, 1*time.Minute, opts.LastImportTimeMaxAge)
+	require.Equal(t, 2*time.Minute, opts.EventRetentionPeriod)
+	require.Equal(t, 3*time.Minute, opts.EventPruningInterval)
+	require.Equal(t, 4*time.Minute, opts.SearchLookback)
+	require.Equal(t, WatchOptions{SettleDelay: 5 * time.Minute}, opts.WatchOptions)
+	require.Equal(t, 7, opts.DashboardVersionsToKeep)
+	require.Equal(t, GarbageCollectionConfig{
+		Enabled:          true,
+		DryRun:           true,
+		Interval:         6 * time.Minute,
+		BatchSize:        8,
+		BatchWait:        7 * time.Minute,
+		MaxAge:           8 * time.Minute,
+		DashboardsMaxAge: 9 * time.Minute,
+	}, opts.GarbageCollection)
+}
+
+// fullyPopulatedCfg sets every scalar setting to a non-zero value, so an option
+// that comes out zero was not read from the config at all.
+func fullyPopulatedCfg() *setting.Cfg {
+	cfg := setting.NewCfg()
+
+	v := reflect.ValueOf(cfg).Elem()
+	for i := range v.NumField() {
+		field := v.Field(i)
+		if !field.CanSet() {
+			continue
+		}
+		switch field.Kind() {
+		case reflect.Bool:
+			field.SetBool(true)
+		case reflect.String:
+			field.SetString("populated")
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			field.SetInt(int64(i + 1))
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			field.SetUint(uint64(i + 1))
+		case reflect.Float32, reflect.Float64:
+			field.SetFloat(float64(i + 1))
+		}
+	}
+
+	// The tenant watcher reads these from an ini section rather than a field,
+	// and drops the insecure-TLS flag outside development.
+	cfg.Env = setting.Dev
+	grpcSection := cfg.SectionWithEnvOverrides("grpc_client_authentication")
+	grpcSection.Key("token").SetValue("token")
+	grpcSection.Key("token_exchange_url").SetValue("https://example.com/token-exchange")
+
+	return cfg
+}

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/resource/kv"
 	"github.com/grafana/grafana/pkg/storage/unified/resource/lease"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
@@ -307,6 +308,34 @@ type KVBackendOptions struct {
 	// is not lost while a slow write is still in flight. Only effective when
 	// EnableKVLeases is true.
 	LeaseAutoRenew bool
+}
+
+// NewKVBackendOptions returns the options that come from Grafana's config. The
+// caller adds the rest: the KV store, the logger, the metrics registry.
+//
+// Config is read here and nowhere else, so a new setting reaches every wiring
+// rather than only the one it was added to.
+func NewKVBackendOptions(cfg *setting.Cfg) KVBackendOptions {
+	return KVBackendOptions{
+		DisablePruner:           cfg.DisablePruner,
+		LastImportTimeMaxAge:    cfg.MaxFileIndexAge,
+		EventRetentionPeriod:    cfg.EventRetentionPeriod,
+		EventPruningInterval:    cfg.EventPruningInterval,
+		SearchLookback:          cfg.SearchLookback,
+		WatchOptions:            WatchOptions{SettleDelay: cfg.NotifierSettleDelay},
+		DashboardVersionsToKeep: cfg.DashboardVersionsToKeep,
+		TenantWatcherConfig:     NewTenantWatcherConfig(cfg),
+		TenantDeleterConfig:     NewTenantDeleterConfig(cfg),
+		GarbageCollection: GarbageCollectionConfig{
+			Enabled:          cfg.EnableGarbageCollection,
+			DryRun:           cfg.GarbageCollectionDryRun,
+			Interval:         cfg.GarbageCollectionInterval,
+			BatchSize:        cfg.GarbageCollectionBatchSize,
+			BatchWait:        cfg.GarbageCollectionBatchWait,
+			MaxAge:           cfg.GarbageCollectionMaxAge,
+			DashboardsMaxAge: cfg.DashboardsGarbageCollectionMaxAge,
+		},
+	}
 }
 
 var (

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -201,31 +201,13 @@ func NewStorageBackend(
 		return nil, fmt.Errorf("unsupported database driver: %s", dbConn.DriverName())
 	}
 
-	kvBackendOpts := resource.KVBackendOptions{
-		KvStore:              kvStore,
-		Reg:                  reg,
-		UseChannelNotifier:   !isHA,
-		Log:                  log.New("storage-backend"),
-		DBKeepAlive:          eDB,
-		LastImportTimeMaxAge: cfg.MaxFileIndexAge,
-		TenantWatcherConfig:  resource.NewTenantWatcherConfig(cfg),
-		TenantDeleterConfig:  resource.NewTenantDeleterConfig(cfg),
-		GCGate:               gcGate,
-		GarbageCollection: resource.GarbageCollectionConfig{
-			Enabled:          cfg.EnableGarbageCollection,
-			DryRun:           cfg.GarbageCollectionDryRun,
-			Interval:         cfg.GarbageCollectionInterval,
-			BatchSize:        cfg.GarbageCollectionBatchSize,
-			BatchWait:        cfg.GarbageCollectionBatchWait,
-			MaxAge:           cfg.GarbageCollectionMaxAge,
-			DashboardsMaxAge: cfg.DashboardsGarbageCollectionMaxAge,
-		},
-		EventRetentionPeriod:    cfg.EventRetentionPeriod,
-		EventPruningInterval:    cfg.EventPruningInterval,
-		SearchLookback:          cfg.SearchLookback,
-		WatchOptions:            resource.WatchOptions{SettleDelay: cfg.NotifierSettleDelay},
-		DashboardVersionsToKeep: cfg.DashboardVersionsToKeep,
-	}
+	kvBackendOpts := resource.NewKVBackendOptions(cfg)
+	kvBackendOpts.KvStore = kvStore
+	kvBackendOpts.Reg = reg
+	kvBackendOpts.UseChannelNotifier = !isHA
+	kvBackendOpts.Log = log.New("storage-backend")
+	kvBackendOpts.DBKeepAlive = eDB
+	kvBackendOpts.GCGate = gcGate
 
 	for _, opt := range opts {
 		opt(&kvBackendOpts)


### PR DESCRIPTION
`resource.KVBackendOptions` was assembled by hand in every wiring that creates a KV backend, so a setting added to one of them was silently ignored by the others. This adds `resource.NewKVBackendOptions(cfg)` next to the struct, which reads the config once, and changes `sql.NewStorageBackend` to use it. Callers still supply what config cannot describe: the KV store, logger, metrics registry, database reference, GC gate and the HA-derived notifier flag.

A test walks the options by reflection against a config with every setting filled in, and requires each field to be either populated by the constructor or listed with a reason for being left to the caller. Adding an option now forces that decision instead of leaving a zero value behind.

This also fixes one gap the test found: `disable_pruner` reached the SQL backend but never the KV backend. It is only set programmatically, by the integration test harness when the database is SQLite, so the KV pruner now switches off there as intended.

No behaviour change otherwise, and no changes outside OSS storage. An enterprise PR adopting the constructor at its own call sites will follow.