### PR TITLE
Improve error handling for alert mute timings

### DIFF
--- a/public/app/features/alerting/unified/MuteTimings.test.tsx
+++ b/public/app/features/alerting/unified/MuteTimings.test.tsx
@@ -1,9 +1,11 @@
 import { type InitialEntry } from 'history';
 import { last } from 'lodash';
+import { HttpResponse, http } from 'msw';
 import { Route, Routes } from 'react-router-dom-v5-compat';
 import { render, screen, userEvent, within } from 'test/test-utils';
 import { byTestId } from 'testing-library-selector';
 
+import { AppNotificationList } from 'app/core/components/AppNotifications/AppNotificationList';
 import { setupMswServer } from 'app/features/alerting/unified/mockApi';
 import { setAlertmanagerConfig } from 'app/features/alerting/unified/mocks/server/entities/alertmanagers';
 import { captureRequests } from 'app/features/alerting/unified/mocks/server/events';
@@ -12,7 +14,9 @@ import {
   TIME_INTERVAL_NAME_FILE_PROVISIONED,
   TIME_INTERVAL_NAME_HAPPY_PATH,
 } from 'app/features/alerting/unified/mocks/server/handlers/k8s/timeIntervals.k8s';
+import { ALERTING_API_SERVER_BASE_URL } from 'app/features/alerting/unified/mocks/server/utils';
 import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
+import { ERROR_TIME_INTERVAL_NAME_EXISTS } from 'app/features/alerting/unified/utils/k8s/errors';
 import { type AlertManagerCortexConfig, type MuteTimeInterval } from 'app/plugins/datasource/alertmanager/types';
 import { AccessControlAction } from 'app/types/accessControl';
 
@@ -28,11 +32,14 @@ const Index = () => {
 };
 const renderMuteTimings = (location?: InitialEntry) => {
   render(
-    <Routes>
-      <Route path={'/alerting/routes'} element={<Index />} />
-      <Route path={'/alerting/routes/new'} element={<NewMuteTimingPage />} />
-      <Route path={'/alerting/routes/edit'} element={<EditMuteTimingPage />} />
-    </Routes>,
+    <>
+      <AppNotificationList />
+      <Routes>
+        <Route path={'/alerting/routes'} element={<Index />} />
+        <Route path={'/alerting/routes/new'} element={<NewMuteTimingPage />} />
+        <Route path={'/alerting/routes/edit'} element={<EditMuteTimingPage />} />
+      </Routes>
+    </>,
     { historyOptions: location ? { initialEntries: [location] } : undefined }
   );
 };
@@ -148,7 +155,7 @@ const saveMuteTiming = async () => {
   await user.click(await screen.findByText(/save time interval/i));
 };
 
-setupMswServer();
+const server = setupMswServer();
 
 const getAlertmanagerConfigUpdate = async (requests: Request[]): Promise<AlertManagerCortexConfig> => {
   const alertmanagerUpdate = requests.find(
@@ -324,6 +331,40 @@ describe('Mute timings', () => {
 
     await saveMuteTiming();
     await expectToHaveRedirectedToRoutesRoute();
+  });
+
+  it('shows an error notification when creating a mute timing fails', async () => {
+    server.use(
+      http.post(`${ALERTING_API_SERVER_BASE_URL}/namespaces/:namespace/timeintervals`, () =>
+        HttpResponse.json(
+          {
+            kind: 'Status',
+            apiVersion: 'v1',
+            metadata: {},
+            status: 'Failure',
+            code: 400,
+            reason: 'BadRequest',
+            message: 'Time interval with this name already exists. Use a different name or update existing one.',
+            details: {
+              uid: ERROR_TIME_INTERVAL_NAME_EXISTS,
+            },
+          },
+          { status: 400 }
+        )
+      )
+    );
+
+    renderMuteTimings({ pathname: '/alerting/routes/new', search: `?alertmanager=${GRAFANA_RULES_SOURCE_NAME}` });
+
+    await fillOutForm({ name: 'a new time interval' });
+    await saveMuteTiming();
+
+    const notification = await screen.findByRole('alert', { name: /failed to save time interval/i });
+    expect(
+      within(notification).getByText(
+        'Time interval with this name already exists. Use a different name or update existing one.'
+      )
+    ).toBeInTheDocument();
   });
 
   it('shows error when mute timing does not exist', async () => {

--- a/public/app/features/alerting/unified/api/alertmanagerApi.ts
+++ b/public/app/features/alerting/unified/api/alertmanagerApi.ts
@@ -355,6 +355,7 @@ export const alertmanagerApi = alertingApi.injectEndpoints({
         method: 'POST',
         data: config,
         showSuccessAlert: false,
+        showErrorAlert: false,
       }),
       invalidatesTags: ['AlertmanagerConfiguration', 'ContactPoint', 'ContactPointsStatus', 'Receiver'],
     }),

--- a/public/app/features/alerting/unified/components/mute-timings/MuteTimingForm.tsx
+++ b/public/app/features/alerting/unified/components/mute-timings/MuteTimingForm.tsx
@@ -3,8 +3,9 @@ import { FormProvider, useForm } from 'react-hook-form';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { config, locationService } from '@grafana/runtime';
+import { config, isFetchError, locationService } from '@grafana/runtime';
 import { Alert, Button, Field, FieldSet, Input, LinkButton, LoadingPlaceholder, useStyles2 } from '@grafana/ui';
+import { useAppNotification } from 'app/core/copy/appNotification';
 import {
   type MuteTiming,
   useCreateMuteTiming,
@@ -12,10 +13,11 @@ import {
   useValidateMuteTiming,
 } from 'app/features/alerting/unified/components/mute-timings/useMuteTimings';
 
+import { logError, logWarning } from '../../Analytics';
 import { useAlertmanager } from '../../state/AlertmanagerContext';
 import { type MuteTimingFields } from '../../types/mute-timing-form';
 import { isImportedResource, isProvisionedResource } from '../../utils/k8s/utils';
-import { makeAMLink } from '../../utils/misc';
+import { makeAMLink, stringifyErrorLike } from '../../utils/misc';
 import { createMuteTiming, defaultTimeInterval, isTimeIntervalDisabled } from '../../utils/mute-timings';
 import { ALERTING_PATHS } from '../../utils/navigation';
 import { ImportedTimeIntervalAlert, ProvisionedResource, ProvisioningAlert } from '../Provisioning';
@@ -60,6 +62,7 @@ const useDefaultValues = (muteTiming?: MuteTiming): MuteTimingFields => {
 
 const MuteTimingForm = ({ muteTiming, showError, loading, provenance, editMode }: Props) => {
   const { selectedAlertmanager } = useAlertmanager();
+  const notifyApp = useAppNotification();
   const hookArgs = { alertmanager: selectedAlertmanager! };
 
   const [createTimeInterval] = useCreateMuteTiming(hookArgs);
@@ -89,9 +92,24 @@ const MuteTimingForm = ({ muteTiming, showError, loading, provenance, editMode }
       return createTimeInterval.execute({ interval });
     };
 
-    return updateOrCreate().then(() => {
+    try {
+      await updateOrCreate();
       locationService.push(returnLink);
-    });
+    } catch (error) {
+      if (error instanceof Error || isFetchError(error)) {
+        const title = t('alerting.time-interval-form.error-save-time-interval', 'Failed to save time interval');
+        const message = stringifyErrorLike(error);
+        notifyApp.error(title, message);
+
+        if (isFetchError(error) && error.status >= 400 && error.status < 500) {
+          logWarning(title, { status: String(error.status), message });
+        } else {
+          const saveError = new Error(title);
+          saveError.cause = error;
+          logError(saveError);
+        }
+      }
+    }
   };
 
   if (loading) {

--- a/public/app/features/alerting/unified/components/mute-timings/MuteTimingForm.tsx
+++ b/public/app/features/alerting/unified/components/mute-timings/MuteTimingForm.tsx
@@ -17,7 +17,7 @@ import { logError, logWarning } from '../../Analytics';
 import { useAlertmanager } from '../../state/AlertmanagerContext';
 import { type MuteTimingFields } from '../../types/mute-timing-form';
 import { isImportedResource, isProvisionedResource } from '../../utils/k8s/utils';
-import { makeAMLink, stringifyErrorLike } from '../../utils/misc';
+import { isClientFetchError, makeAMLink, stringifyErrorLike } from '../../utils/misc';
 import { createMuteTiming, defaultTimeInterval, isTimeIntervalDisabled } from '../../utils/mute-timings';
 import { ALERTING_PATHS } from '../../utils/navigation';
 import { ImportedTimeIntervalAlert, ProvisionedResource, ProvisioningAlert } from '../Provisioning';
@@ -101,8 +101,6 @@ const MuteTimingForm = ({ muteTiming, showError, loading, provenance, editMode }
         const message = stringifyErrorLike(error);
         notifyApp.error(title, message);
 
-const isClientFetchError = (error: unknown): error is FetchError =>
-     isFetchError(error) && error.status >= 400 && error.status < 500;
         if (isClientFetchError(error)) {
           logWarning(title, { status: String(error.status), message });
         } else {

--- a/public/app/features/alerting/unified/components/mute-timings/MuteTimingForm.tsx
+++ b/public/app/features/alerting/unified/components/mute-timings/MuteTimingForm.tsx
@@ -101,7 +101,9 @@ const MuteTimingForm = ({ muteTiming, showError, loading, provenance, editMode }
         const message = stringifyErrorLike(error);
         notifyApp.error(title, message);
 
-        if (isFetchError(error) && error.status >= 400 && error.status < 500) {
+const isClientFetchError = (error: unknown): error is FetchError =>
+     isFetchError(error) && error.status >= 400 && error.status < 500;
+        if (isClientFetchError(error)) {
           logWarning(title, { status: String(error.status), message });
         } else {
           const saveError = new Error(title);

--- a/public/app/features/alerting/unified/components/receivers/form/ReceiverForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/ReceiverForm.tsx
@@ -20,7 +20,7 @@ import {
   type CommonSettingsComponentType,
   type ReceiverFormValues,
 } from '../../../types/receiver-form';
-import { makeAMLink, stringifyErrorLike } from '../../../utils/misc';
+import { isClientFetchError, makeAMLink, stringifyErrorLike } from '../../../utils/misc';
 import { initialAsyncRequestState } from '../../../utils/redux';
 
 import { ChannelSubForm } from './ChannelSubForm';
@@ -110,7 +110,7 @@ export function ReceiverForm<R extends ChannelValues>({
         const message = getErrorMessage(e);
         notifyApp.error('Failed to save the contact point', message);
 
-        if (isFetchError(e) && e.status >= 400 && e.status < 500) {
+        if (isClientFetchError(e)) {
           logWarning('Failed to save the contact point', {
             status: String(e.status),
             message,

--- a/public/app/features/alerting/unified/utils/k8s/errors.test.ts
+++ b/public/app/features/alerting/unified/utils/k8s/errors.test.ts
@@ -3,6 +3,7 @@ import {
   type ApiMachineryErrorResponse,
   ERROR_ROUTES_MATCHER_CONFLICT,
   ERROR_TIME_INTERVAL_IN_USE,
+  ERROR_TIME_INTERVAL_NAME_EXISTS,
   getErrorMessageFromApiMachineryErrorResponse,
 } from './errors';
 
@@ -25,6 +26,17 @@ function buildApiMachineryError(
 }
 
 describe('getErrorMessageFromCode', () => {
+  it(`should handle ${ERROR_TIME_INTERVAL_NAME_EXISTS}`, () => {
+    const error = buildApiMachineryError({
+      message: 'Time interval with this name already exists. Use a different name or update existing one.',
+      details: { uid: ERROR_TIME_INTERVAL_NAME_EXISTS },
+    });
+
+    expect(getErrorMessageFromApiMachineryErrorResponse(error)).toBe(
+      'Time interval with this name already exists. Use a different name or update existing one.'
+    );
+  });
+
   it(`should handle ${ERROR_ROUTES_MATCHER_CONFLICT}`, () => {
     const error: ApiMachineryErrorResponse = {
       status: 400,

--- a/public/app/features/alerting/unified/utils/k8s/errors.ts
+++ b/public/app/features/alerting/unified/utils/k8s/errors.ts
@@ -8,6 +8,7 @@ import { getErrorCode } from '../misc';
 export const ERROR_NEWER_CONFIGURATION = 'alerting.notifications.conflict' as const;
 export const ERROR_ROUTES_MATCHER_CONFLICT = 'alerting.notifications.routes.conflictingMatchers' as const;
 export const ERROR_TIME_INTERVAL_IN_USE = 'alerting.notifications.time-intervals.used' as const;
+export const ERROR_TIME_INTERVAL_NAME_EXISTS = 'alerting.notifications.time-intervals.nameExists' as const;
 
 export type ApiMachineryErrorResponse = FetchError<ApiMachineryError>;
 
@@ -17,7 +18,8 @@ export type KnownErrorCodes = typeof ERROR_NEWER_CONFIGURATION;
 type KnownMachineryErrorCodes =
   | KnownErrorCodes
   | typeof ERROR_ROUTES_MATCHER_CONFLICT
-  | typeof ERROR_TIME_INTERVAL_IN_USE;
+  | typeof ERROR_TIME_INTERVAL_IN_USE
+  | typeof ERROR_TIME_INTERVAL_NAME_EXISTS;
 
 /**
  * This function gives us the opportunity to translate or transform error codes that are returned from the Kubernetes APIs
@@ -46,6 +48,10 @@ export function getErrorMessageFromApiMachineryErrorResponse(error: ApiMachinery
     [ERROR_TIME_INTERVAL_IN_USE]: t(
       'alerting.errors.time-interval-in-use',
       'This time interval cannot be deleted because it is still used by one or more notification policies or alert rules.'
+    ),
+    [ERROR_TIME_INTERVAL_NAME_EXISTS]: t(
+      'alerting.errors.time-interval-name-exists',
+      'Time interval with this name already exists. Use a different name or update existing one.'
     ),
     [ERROR_ROUTES_MATCHER_CONFLICT]: t(
       'alerting.policies.update-errors.routes.conflictingMatchers',

--- a/public/app/features/alerting/unified/utils/misc.ts
+++ b/public/app/features/alerting/unified/utils/misc.ts
@@ -3,7 +3,7 @@ import { isString, sortBy } from 'lodash';
 import { type Labels, type UrlQueryMap } from '@grafana/data';
 import { GrafanaEdition } from '@grafana/data/internal';
 import { t } from '@grafana/i18n';
-import { config, isFetchError } from '@grafana/runtime';
+import { type FetchError, config, isFetchError } from '@grafana/runtime';
 import { type DataSourceRef } from '@grafana/schema';
 import { contextSrv } from 'app/core/services/context_srv';
 import { getMessageFromError, getRequestConfigFromError, getStatusFromError } from 'app/core/utils/errors';
@@ -289,6 +289,9 @@ export function isLocalDevEnv() {
 export function isErrorLike(error: unknown): error is Error {
   return Boolean(error && typeof error === 'object' && 'message' in error);
 }
+
+export const isClientFetchError = (error: unknown): error is FetchError =>
+  isFetchError(error) && error.status >= 400 && error.status < 500;
 
 // Small composable guards to safely inspect nested shapes without broad assertions
 function isObject(value: unknown): value is object {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1162,7 +1162,8 @@
         "with-causes": "{{-baseMessage}}: {{-causes}}"
       },
       "failedWith": "{{-config}} failed with {{status}}: {{-message}}",
-      "time-interval-in-use": "This time interval cannot be deleted because it is still used by one or more notification policies or alert rules."
+      "time-interval-in-use": "This time interval cannot be deleted because it is still used by one or more notification policies or alert rules.",
+      "time-interval-name-exists": "Time interval with this name already exists. Use a different name or update existing one."
     },
     "evaluate-every-validation-options": {
       "message": {
@@ -3606,6 +3607,7 @@
     },
     "time-interval-form": {
       "description-unique-time-interval": "A unique name for the time interval",
+      "error-save-time-interval": "Failed to save time interval",
       "text-loading-time-interval": "Loading time interval",
       "title-no-matching-time-interval-found": "No matching time interval found"
     },

--- a/public/locales/ru-RU/grafana.json
+++ b/public/locales/ru-RU/grafana.json
@@ -1176,7 +1176,8 @@
         "with-causes": ""
       },
       "failedWith": "Ошибка {{-config}} со статусом {{status}}: {{-message}}",
-      "time-interval-in-use": ""
+      "time-interval-in-use": "Невозможно удалить временной интервал, так как он используется либо политками уведомления либо правилами оповещения.",
+      "time-interval-name-exists": "Временной интервал с таким именем уже существует. Используйте другое имя или переименуйте существующий интервал."
     },
     "evaluate-every-validation-options": {
       "message": {
@@ -3658,6 +3659,7 @@
     },
     "time-interval-form": {
       "description-unique-time-interval": "Уникальное имя для временного интервала.",
+      "error-save-time-interval": "Не удалось сохранить временной интервал",
       "text-loading-time-interval": "Загрузка временного интервала",
       "title-no-matching-time-interval-found": "Соответствующий временной интервал не найден"
     },


### PR DESCRIPTION
Fixes error handling on time interval edit page. Makes it show error when time interval already exists and API returns 400 BadRequest 