### PR TITLE
Chore: regenerate the enterprise imports list

### DIFF
--- a/pkg/extensions/enterprise_imports_test.go
+++ b/pkg/extensions/enterprise_imports_test.go
@@ -43,6 +43,8 @@ import (
 	_ "github.com/grafana/grafana/pkg/services/user/usertest"
 	_ "github.com/grafana/grafana/pkg/storage/unified/resource/kv/test"
 	_ "github.com/grafana/grafana/pkg/storage/unified/resource/lease"
+	_ "github.com/grafana/grafana/pkg/storage/unified/search/embed/embedder"
+	_ "github.com/grafana/grafana/pkg/storage/unified/search/rerank"
 	_ "github.com/grafana/grafana/pkg/storage/unified/sql/db/dbimpl"
 	_ "github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate/mocks"
 	_ "github.com/grafana/grafana/pkg/storage/unified/testing"


### PR DESCRIPTION
Generated by `make update-workspace`. A test in grafana/grafana-enterprise#13044 builds an embedder and a reranker, so those two packages join the list of OSS packages that enterprise code imports.

The enterprise PR's Go Workspace Check stays red until this merges.
