### PR TITLE
SQL Expressions: Contain horizontal editor overscroll

### DIFF
--- a/public/app/features/expressions/components/SqlExpressions/SqlEditor/SqlEditor.test.tsx
+++ b/public/app/features/expressions/components/SqlExpressions/SqlEditor/SqlEditor.test.tsx
@@ -1,0 +1,20 @@
+import { render } from '@testing-library/react';
+
+import { SqlEditor } from './SqlEditor';
+
+jest.mock('@grafana/ui/unstable', () => ({
+  CodeMirrorEditor: () => <div className="cm-scroller" />,
+  signatureHelp: jest.fn(),
+}));
+
+describe('SqlEditor', () => {
+  it('contains horizontal overscroll within the editor', () => {
+    render(<SqlEditor value="SELECT * FROM A" onChange={jest.fn()} />);
+
+    const overscrollRule = Array.from(document.styleSheets)
+      .flatMap((styleSheet) => Array.from(styleSheet.cssRules))
+      .find((rule) => rule.cssText.includes('cm-scroller') && rule.cssText.includes('overscroll-behavior-x'));
+
+    expect(overscrollRule?.cssText).toContain('overscroll-behavior-x: contain');
+  });
+});

--- a/public/app/features/expressions/components/SqlExpressions/SqlEditor/SqlEditor.tsx
+++ b/public/app/features/expressions/components/SqlExpressions/SqlEditor/SqlEditor.tsx
@@ -92,5 +92,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
     borderTopLeftRadius: theme.shape.radius.default,
     borderTopRightRadius: theme.shape.radius.default,
     overflow: 'hidden',
+    '.cm-scroller': {
+      overscrollBehaviorX: 'contain',
+    },
   }),
 });


### PR DESCRIPTION
## Related Issue
Fixes #115625, Fixes DPRO-315

## Description
Contains horizontal overscroll within the SQL Expressions CodeMirror editor so trackpad gestures do not escape the editor and trigger browser back or forward navigation.

The CodeMirror `.cm-scroller` owns horizontal overflow, but previously used the default `overscroll-behavior-x: auto`. At a horizontal boundary, Chrome could chain the gesture into browser history navigation.

## Changes
* Apply `overscroll-behavior-x: contain` to the SQL Expressions CodeMirror scroller
* Add focused coverage for the scoped generated CSS rule

## Risks
The rule is scoped to the SQL Expressions editor. Horizontal scrolling remains enabled, but gestures at either boundary no longer chain to an ancestor or browser navigation.

## Demo
<img width="800" height="390" alt="CleanShot 2026-08-12 at 12 43 58" src="https://github.com/user-attachments/assets/473b1aae-1137-4270-8620-788d695bf66c" />

## Testing Instructions
* Enable `sqlExpressionsCodeMirror`
* Add a SQL expression with a line long enough to overflow horizontally
* Scroll right, then left to the boundary, and continue the leftward trackpad gesture
* Confirm the editor remains open and Chrome does not navigate backward

## Reviewer Checklist
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable