### PR TITLE
User: trim leading/trailing whitespace from login and email

### DIFF
--- a/pkg/api/admin_users.go
+++ b/pkg/api/admin_users.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"golang.org/x/sync/errgroup"
 
@@ -46,8 +47,8 @@ func (hs *HTTPServer) AdminCreateUser(c *contextmodel.ReqContext) response.Respo
 	}
 
 	cmd := user.CreateUserCommand{
-		Login:    form.Login,
-		Email:    form.Email,
+		Login:    strings.TrimSpace(form.Login),
+		Email:    strings.TrimSpace(form.Email),
 		Password: form.Password,
 		Name:     form.Name,
 		OrgID:    form.OrgId,

--- a/pkg/services/user/userimpl/legacy_user.go
+++ b/pkg/services/user/userimpl/legacy_user.go
@@ -94,6 +94,10 @@ func (s *LegacyService) Create(ctx context.Context, cmd *user.CreateUserCommand)
 	ctx, span := s.tracer.Start(ctx, "user.legacy.Create")
 	defer span.End()
 
+	// Trim before empty checks / conflict detection so stored login matches what the UI displays.
+	cmd.Login = strings.TrimSpace(cmd.Login)
+	cmd.Email = strings.TrimSpace(cmd.Email)
+
 	if len(cmd.Login) == 0 {
 		cmd.Login = cmd.Email
 	}

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -143,8 +143,8 @@ func (ss *sqlStore) notServiceAccountFilter() string {
 }
 
 func (ss *sqlStore) GetByLogin(ctx context.Context, query *user.GetUserByLoginQuery) (*user.User, error) {
-	// enforcement of lowercase due to forcement of caseinsensitive login
-	query.LoginOrEmail = strings.ToLower(query.LoginOrEmail)
+	// Trim then lowercase so accidental whitespace around typed credentials does not fail login.
+	query.LoginOrEmail = strings.ToLower(strings.TrimSpace(query.LoginOrEmail))
 
 	usr := &user.User{}
 	err := ss.db.WithDbSession(ctx, func(sess *db.Session) error {
@@ -237,9 +237,9 @@ func (ss *sqlStore) LoginConflict(ctx context.Context, login, email string) erro
 }
 
 func (ss *sqlStore) Update(ctx context.Context, cmd *user.UpdateUserCommand) error {
-	// enforcement of lowercase due to forcement of caseinsensitive login
-	cmd.Login = strings.ToLower(cmd.Login)
-	cmd.Email = strings.ToLower(cmd.Email)
+	// Trim then lowercase so leading/trailing whitespace cannot leave logins that the UI hides.
+	cmd.Login = strings.ToLower(strings.TrimSpace(cmd.Login))
+	cmd.Email = strings.ToLower(strings.TrimSpace(cmd.Email))
 
 	return ss.db.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
 		usr := user.User{

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -223,25 +223,46 @@ func (ss *sqlStore) getByExactOrTrimmed(sess *db.Session, usr *user.User, column
 // LoginConflict returns an error if the provided email or login are already
 // associated with a user.
 func (ss *sqlStore) LoginConflict(ctx context.Context, login, email string) error {
-	// Trim then lowercase so create/update cannot collide with legacy spaced rows, and so
-	// whitespace-only differences are treated as the same identity.
+	return ss.db.WithDbSession(ctx, func(sess *db.Session) error {
+		return ss.loginConflict(sess, login, email, 0)
+	})
+}
+
+// loginConflict returns ErrUserAlreadyExists if login/email collide with another user,
+// including legacy rows that still have leading/trailing whitespace. excludeUserID, when
+// non-zero, is ignored so a user can normalize their own spaced login/email on update.
+func (ss *sqlStore) loginConflict(sess *db.Session, login, email string, excludeUserID int64) error {
 	login = strings.ToLower(strings.TrimSpace(login))
 	email = strings.ToLower(strings.TrimSpace(email))
 
-	err := ss.db.WithDbSession(ctx, func(sess *db.Session) error {
-		where := "email=? OR login=? OR TRIM(email)=? OR TRIM(login)=?"
-
-		exists, err := sess.Where(where, email, login, email, login).Get(&user.User{})
-		if err != nil {
-			return err
-		}
-		if exists {
-			return user.ErrUserAlreadyExists
-		}
-
+	var parts []string
+	var args []any
+	if login != "" {
+		parts = append(parts, "login=? OR TRIM(login)=?")
+		args = append(args, login, login)
+	}
+	if email != "" {
+		parts = append(parts, "email=? OR TRIM(email)=?")
+		args = append(args, email, email)
+	}
+	if len(parts) == 0 {
 		return nil
-	})
-	return err
+	}
+
+	where := "(" + strings.Join(parts, " OR ") + ")"
+	if excludeUserID > 0 {
+		where += " AND id<>?"
+		args = append(args, excludeUserID)
+	}
+
+	exists, err := sess.Where(where, args...).Get(&user.User{})
+	if err != nil {
+		return err
+	}
+	if exists {
+		return user.ErrUserAlreadyExists
+	}
+	return nil
 }
 
 func (ss *sqlStore) Update(ctx context.Context, cmd *user.UpdateUserCommand) error {
@@ -250,6 +271,12 @@ func (ss *sqlStore) Update(ctx context.Context, cmd *user.UpdateUserCommand) err
 	cmd.Email = strings.ToLower(strings.TrimSpace(cmd.Email))
 
 	return ss.db.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
+		// Block updates that would take the trimmed identity of a different legacy spaced row.
+		// Excludes the user being updated so they can still normalize their own login/email.
+		if err := ss.loginConflict(sess, cmd.Login, cmd.Email, cmd.UserID); err != nil {
+			return err
+		}
+
 		usr := user.User{
 			Name:    cmd.Name,
 			Theme:   cmd.Theme,

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -152,15 +152,13 @@ func (ss *sqlStore) GetByLogin(ctx context.Context, query *user.GetUserByLoginQu
 			return user.ErrUserNotFound
 		}
 
-		var where string
 		var has bool
 		var err error
 
 		// Since username can be an email address, attempt login with email address
 		// first if the login field has the "@" symbol.
 		if strings.Contains(query.LoginOrEmail, "@") {
-			where = "email=?"
-			has, err = sess.Where(ss.notServiceAccountFilter()).Where(where, query.LoginOrEmail).Get(usr)
+			has, err = ss.getByExactOrTrimmed(sess, usr, "email", query.LoginOrEmail)
 			if err != nil {
 				return err
 			}
@@ -168,8 +166,7 @@ func (ss *sqlStore) GetByLogin(ctx context.Context, query *user.GetUserByLoginQu
 
 		// Look for the login field instead of email
 		if !has {
-			where = "login=?"
-			has, err = sess.Where(ss.notServiceAccountFilter()).Where(where, query.LoginOrEmail).Get(usr)
+			has, err = ss.getByExactOrTrimmed(sess, usr, "login", query.LoginOrEmail)
 		}
 
 		if err != nil {
@@ -188,8 +185,8 @@ func (ss *sqlStore) GetByLogin(ctx context.Context, query *user.GetUserByLoginQu
 }
 
 func (ss *sqlStore) GetByEmail(ctx context.Context, query *user.GetUserByEmailQuery) (*user.User, error) {
-	// enforcement of lowercase due to forcement of caseinsensitive login
-	query.Email = strings.ToLower(query.Email)
+	// Trim then lowercase so accidental whitespace around typed credentials does not fail lookup.
+	query.Email = strings.ToLower(strings.TrimSpace(query.Email))
 
 	usr := &user.User{}
 	err := ss.db.WithDbSession(ctx, func(sess *db.Session) error {
@@ -197,9 +194,7 @@ func (ss *sqlStore) GetByEmail(ctx context.Context, query *user.GetUserByEmailQu
 			return user.ErrUserNotFound
 		}
 
-		where := "email=?"
-		has, err := sess.Where(ss.notServiceAccountFilter()).Where(where, query.Email).Get(usr)
-
+		has, err := ss.getByExactOrTrimmed(sess, usr, "email", query.Email)
 		if err != nil {
 			return err
 		} else if !has {
@@ -213,17 +208,30 @@ func (ss *sqlStore) GetByEmail(ctx context.Context, query *user.GetUserByEmailQu
 	return usr, nil
 }
 
+// getByExactOrTrimmed finds a non-service-account user by exact column match, then by TRIM(column)
+// so legacy rows that still contain leading/trailing whitespace remain reachable after lookup keys are trimmed.
+func (ss *sqlStore) getByExactOrTrimmed(sess *db.Session, usr *user.User, column, value string) (bool, error) {
+	has, err := sess.Where(ss.notServiceAccountFilter()).Where(column+"=?", value).Get(usr)
+	if err != nil || has {
+		return has, err
+	}
+
+	*usr = user.User{}
+	return sess.Where(ss.notServiceAccountFilter()).Where("TRIM("+column+")=?", value).Get(usr)
+}
+
 // LoginConflict returns an error if the provided email or login are already
 // associated with a user.
 func (ss *sqlStore) LoginConflict(ctx context.Context, login, email string) error {
-	// enforcement of lowercase due to forcement of caseinsensitive login
-	login = strings.ToLower(login)
-	email = strings.ToLower(email)
+	// Trim then lowercase so create/update cannot collide with legacy spaced rows, and so
+	// whitespace-only differences are treated as the same identity.
+	login = strings.ToLower(strings.TrimSpace(login))
+	email = strings.ToLower(strings.TrimSpace(email))
 
 	err := ss.db.WithDbSession(ctx, func(sess *db.Session) error {
-		where := "email=? OR login=?"
+		where := "email=? OR login=? OR TRIM(email)=? OR TRIM(login)=?"
 
-		exists, err := sess.Where(where, email, login).Get(&user.User{})
+		exists, err := sess.Where(where, email, login, email, login).Get(&user.User{})
 		if err != nil {
 			return err
 		}

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -286,12 +286,15 @@ func (ss *sqlStore) Update(ctx context.Context, cmd *user.UpdateUserCommand) err
 
 			loginToCheck := ""
 			emailToCheck := ""
-			if cmd.Login != "" && cmd.Login != strings.ToLower(strings.TrimSpace(existing.Login)) {
-				loginToCheck = cmd.Login
-			}
-			if cmd.Email != "" && cmd.Email != strings.ToLower(strings.TrimSpace(existing.Email)) {
-				emailToCheck = cmd.Email
-			}
+		// Detect a real column change against the stored value (lowercased only). Comparing after
+		// TrimSpace would treat whitespace normalization as "unchanged", skip conflict checks,
+		// then still write the trimmed value and collide with peers that differ only by spacing.
+		if cmd.Login != "" && cmd.Login != strings.ToLower(existing.Login) {
+			loginToCheck = cmd.Login
+		}
+		if cmd.Email != "" && cmd.Email != strings.ToLower(existing.Email) {
+			emailToCheck = cmd.Email
+		}
 			if err := ss.loginConflict(sess, loginToCheck, emailToCheck, cmd.UserID); err != nil {
 				return err
 			}

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -230,7 +230,7 @@ func (ss *sqlStore) LoginConflict(ctx context.Context, login, email string) erro
 
 // loginConflict returns ErrUserAlreadyExists if login/email collide with another user,
 // including legacy rows that still have leading/trailing whitespace. excludeUserID, when
-// non-zero, is ignored so a user can normalize their own spaced login/email on update.
+// non-zero, is excluded so a user can normalize their own spaced login/email on update.
 func (ss *sqlStore) loginConflict(sess *db.Session, login, email string, excludeUserID int64) error {
 	login = strings.ToLower(strings.TrimSpace(login))
 	email = strings.ToLower(strings.TrimSpace(email))
@@ -271,10 +271,30 @@ func (ss *sqlStore) Update(ctx context.Context, cmd *user.UpdateUserCommand) err
 	cmd.Email = strings.ToLower(strings.TrimSpace(cmd.Email))
 
 	return ss.db.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
-		// Block updates that would take the trimmed identity of a different legacy spaced row.
-		// Excludes the user being updated so they can still normalize their own login/email.
-		if err := ss.loginConflict(sess, cmd.Login, cmd.Email, cmd.UserID); err != nil {
-			return err
+		// Only conflict-check login/email when they are actually changing. Otherwise a clean
+		// user who already shares a trimmed identity with a legacy spaced peer would be
+		// unable to save an ordinary profile update (name/theme/etc.).
+		if cmd.Login != "" || cmd.Email != "" {
+			var existing user.User
+			has, err := sess.ID(cmd.UserID).Where(ss.notServiceAccountFilter()).Get(&existing)
+			if err != nil {
+				return err
+			}
+			if !has {
+				return user.ErrUserNotFound
+			}
+
+			loginToCheck := ""
+			emailToCheck := ""
+			if cmd.Login != "" && cmd.Login != strings.ToLower(strings.TrimSpace(existing.Login)) {
+				loginToCheck = cmd.Login
+			}
+			if cmd.Email != "" && cmd.Email != strings.ToLower(strings.TrimSpace(existing.Email)) {
+				emailToCheck = cmd.Email
+			}
+			if err := ss.loginConflict(sess, loginToCheck, emailToCheck, cmd.UserID); err != nil {
+				return err
+			}
 		}
 
 		usr := user.User{

--- a/pkg/services/user/userimpl/user_test.go
+++ b/pkg/services/user/userimpl/user_test.go
@@ -637,6 +637,32 @@ func TestIntegrationCreateUser(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "callview", usr.Login)
 	})
+
+	t.Run("GetByLogin and LoginConflict handle legacy login with trailing whitespace", func(t *testing.T) {
+		// Simulate a pre-fix row that still has trailing whitespace in the DB.
+		_, err := userStore.Insert(context.Background(), &user.User{
+			Email:   "legacy-spaced@example.com",
+			Login:   "legacyuser ",
+			Name:    "legacyuser",
+			Created: time.Now(),
+			Updated: time.Now(),
+		})
+		require.NoError(t, err)
+
+		usr, err := userStore.GetByLogin(context.Background(), &user.GetUserByLoginQuery{LoginOrEmail: "legacyuser"})
+		require.NoError(t, err)
+		require.Equal(t, "legacyuser ", usr.Login)
+
+		usr, err = userStore.GetByLogin(context.Background(), &user.GetUserByLoginQuery{LoginOrEmail: "  legacyuser  "})
+		require.NoError(t, err)
+		require.Equal(t, "legacyuser ", usr.Login)
+
+		err = userStore.LoginConflict(context.Background(), "legacyuser", "other@example.com")
+		require.ErrorIs(t, err, user.ErrUserAlreadyExists)
+
+		err = userStore.LoginConflict(context.Background(), "  legacyuser  ", "another@example.com")
+		require.ErrorIs(t, err, user.ErrUserAlreadyExists)
+	})
 }
 
 type FakeUserStore struct {

--- a/pkg/services/user/userimpl/user_test.go
+++ b/pkg/services/user/userimpl/user_test.go
@@ -704,6 +704,58 @@ func TestIntegrationCreateUser(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "spacedlogin", usr.Login)
 	})
+
+	t.Run("Update with unchanged login succeeds when a legacy spaced duplicate exists", func(t *testing.T) {
+		cleanID, err := userStore.Insert(context.Background(), &user.User{
+			Email:   "clean-dup@example.com",
+			Login:   "duplogin",
+			Name:    "clean-dup",
+			Created: time.Now(),
+			Updated: time.Now(),
+		})
+		require.NoError(t, err)
+
+		_, err = userStore.Insert(context.Background(), &user.User{
+			Email:   "spaced-dup@example.com",
+			Login:   "duplogin ",
+			Name:    "spaced-dup",
+			Created: time.Now(),
+			Updated: time.Now(),
+		})
+		require.NoError(t, err)
+
+		// Ordinary profile save must not fail just because a legacy spaced peer exists.
+		err = userStore.Update(context.Background(), &user.UpdateUserCommand{
+			UserID: cleanID,
+			Login:  "duplogin",
+			Email:  "clean-dup@example.com",
+			Name:   "clean-dup-renamed",
+		})
+		require.NoError(t, err)
+
+		usr, err := userStore.GetByID(context.Background(), cleanID)
+		require.NoError(t, err)
+		require.Equal(t, "clean-dup-renamed", usr.Name)
+		require.Equal(t, "duplogin", usr.Login)
+
+		// Changing onto that trimmed identity from a third user must still be blocked.
+		thirdID, err := userStore.Insert(context.Background(), &user.User{
+			Email:   "third-dup@example.com",
+			Login:   "thirdlogin",
+			Name:    "third-dup",
+			Created: time.Now(),
+			Updated: time.Now(),
+		})
+		require.NoError(t, err)
+
+		err = userStore.Update(context.Background(), &user.UpdateUserCommand{
+			UserID: thirdID,
+			Login:  "duplogin",
+			Email:  "third-dup@example.com",
+			Name:   "third-dup",
+		})
+		require.ErrorIs(t, err, user.ErrUserAlreadyExists)
+	})
 }
 
 type FakeUserStore struct {

--- a/pkg/services/user/userimpl/user_test.go
+++ b/pkg/services/user/userimpl/user_test.go
@@ -756,6 +756,39 @@ func TestIntegrationCreateUser(t *testing.T) {
 		})
 		require.ErrorIs(t, err, user.ErrUserAlreadyExists)
 	})
+
+	t.Run("Update normalizing spaced login conflicts with peer that differs only by spacing", func(t *testing.T) {
+		trailingID, err := userStore.Insert(context.Background(), &user.User{
+			Email:   "trailing-space@example.com",
+			Login:   "normlogin ",
+			Name:    "trailing",
+			Created: time.Now(),
+			Updated: time.Now(),
+		})
+		require.NoError(t, err)
+
+		_, err = userStore.Insert(context.Background(), &user.User{
+			Email:   "leading-space@example.com",
+			Login:   " normlogin",
+			Name:    "leading",
+			Created: time.Now(),
+			Updated: time.Now(),
+		})
+		require.NoError(t, err)
+
+		// Normalizing "normlogin " -> "normlogin" must not skip conflict against " normlogin".
+		err = userStore.Update(context.Background(), &user.UpdateUserCommand{
+			UserID: trailingID,
+			Login:  "normlogin",
+			Email:  "trailing-space@example.com",
+			Name:   "trailing",
+		})
+		require.ErrorIs(t, err, user.ErrUserAlreadyExists)
+
+		usr, err := userStore.GetByID(context.Background(), trailingID)
+		require.NoError(t, err)
+		require.Equal(t, "normlogin ", usr.Login, "failed normalization must leave login unchanged")
+	})
 }
 
 type FakeUserStore struct {

--- a/pkg/services/user/userimpl/user_test.go
+++ b/pkg/services/user/userimpl/user_test.go
@@ -663,6 +663,47 @@ func TestIntegrationCreateUser(t *testing.T) {
 		err = userStore.LoginConflict(context.Background(), "  legacyuser  ", "another@example.com")
 		require.ErrorIs(t, err, user.ErrUserAlreadyExists)
 	})
+
+	t.Run("Update cannot take trimmed login of a different legacy spaced user", func(t *testing.T) {
+		spacedID, err := userStore.Insert(context.Background(), &user.User{
+			Email:   "spaced-owner@example.com",
+			Login:   "spacedlogin ",
+			Name:    "spaced-owner",
+			Created: time.Now(),
+			Updated: time.Now(),
+		})
+		require.NoError(t, err)
+
+		otherID, err := userStore.Insert(context.Background(), &user.User{
+			Email:   "other-owner@example.com",
+			Login:   "otherlogin",
+			Name:    "other-owner",
+			Created: time.Now(),
+			Updated: time.Now(),
+		})
+		require.NoError(t, err)
+
+		err = userStore.Update(context.Background(), &user.UpdateUserCommand{
+			UserID: otherID,
+			Login:  "spacedlogin",
+			Email:  "other-owner@example.com",
+			Name:   "other-owner",
+		})
+		require.ErrorIs(t, err, user.ErrUserAlreadyExists)
+
+		// The spaced user can still normalize their own login.
+		err = userStore.Update(context.Background(), &user.UpdateUserCommand{
+			UserID: spacedID,
+			Login:  "spacedlogin",
+			Email:  "spaced-owner@example.com",
+			Name:   "spaced-owner",
+		})
+		require.NoError(t, err)
+
+		usr, err := userStore.GetByID(context.Background(), spacedID)
+		require.NoError(t, err)
+		require.Equal(t, "spacedlogin", usr.Login)
+	})
 }
 
 type FakeUserStore struct {

--- a/pkg/services/user/userimpl/user_test.go
+++ b/pkg/services/user/userimpl/user_test.go
@@ -52,6 +52,18 @@ func TestUserService(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("create user trims leading and trailing whitespace from login and email", func(t *testing.T) {
+		_, err := userService.Create(context.Background(), &user.CreateUserCommand{
+			Email: "  spaced@example.com  ",
+			Login: "  callview  ",
+			Name:  "name",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, userStore.LastInsertedUser)
+		require.Equal(t, "callview", userStore.LastInsertedUser.Login)
+		require.Equal(t, "spaced@example.com", userStore.LastInsertedUser.Email)
+	})
+
 	t.Run("create user should fail when username and email are empty", func(t *testing.T) {
 		_, err := userService.Create(context.Background(), &user.CreateUserCommand{
 			Email: "",
@@ -597,6 +609,34 @@ func TestIntegrationCreateUser(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorIs(t, err, user.ErrUserNotFound)
 	})
+
+	t.Run("create user trims login whitespace so GetByLogin works without spaces", func(t *testing.T) {
+		userService := LegacyService{
+			store:        userStore,
+			orgService:   &orgtest.FakeOrgService{},
+			cacheService: localcache.ProvideService(),
+			teamService:  &teamtest.FakeService{},
+			tracer:       tracing.InitializeTracerForTest(),
+			cfg:          setting.NewCfg(),
+			db:           ss,
+		}
+		created, err := userService.Create(context.Background(), &user.CreateUserCommand{
+			Email:        "trimspace@example.com",
+			Login:        "  callview  ",
+			Name:         "callview",
+			SkipOrgSetup: true,
+		})
+		require.NoError(t, err)
+		require.Equal(t, "callview", created.Login)
+
+		usr, err := userService.GetByLogin(context.Background(), &user.GetUserByLoginQuery{LoginOrEmail: "callview"})
+		require.NoError(t, err)
+		require.Equal(t, "callview", usr.Login)
+
+		usr, err = userService.GetByLogin(context.Background(), &user.GetUserByLoginQuery{LoginOrEmail: "  callview  "})
+		require.NoError(t, err)
+		require.Equal(t, "callview", usr.Login)
+	})
 }
 
 type FakeUserStore struct {
@@ -608,6 +648,7 @@ type FakeUserStore struct {
 	ExpectedDeleteUserError                 error
 	ExpectedCountUserAccountsWithEmptyRoles int64
 	ExpectedListUsersByIdOrUid              []*user.User
+	LastInsertedUser                        *user.User
 }
 
 func newUserStoreFake() *FakeUserStore {
@@ -615,7 +656,9 @@ func newUserStoreFake() *FakeUserStore {
 }
 
 func (f *FakeUserStore) Insert(ctx context.Context, query *user.User) (int64, error) {
-	return 0, f.ExpectedError
+	copied := *query
+	f.LastInsertedUser = &copied
+	return 1, f.ExpectedError
 }
 
 func (f *FakeUserStore) Delete(ctx context.Context, userID int64) error {

--- a/pkg/services/user/userk8s/user.go
+++ b/pkg/services/user/userk8s/user.go
@@ -608,9 +608,9 @@ func (s *UserK8sService) GetSignedInUser(ctx context.Context, cmd *user.GetSigne
 	case cmd.UserID > 0:
 		found, lookupErr = s.getByInternalID(ctx, ctxLogger, client, cmd.UserID, namespace)
 	case cmd.Login != "":
-		found, lookupErr = s.getByFieldSelectorRaw(ctx, ctxLogger, client, "spec.login", strings.ToLower(cmd.Login), namespace)
+		found, lookupErr = s.getByFieldSelectorRaw(ctx, ctxLogger, client, "spec.login", strings.ToLower(strings.TrimSpace(cmd.Login)), namespace)
 	case cmd.Email != "":
-		found, lookupErr = s.getByFieldSelectorRaw(ctx, ctxLogger, client, "spec.email", strings.ToLower(cmd.Email), namespace)
+		found, lookupErr = s.getByFieldSelectorRaw(ctx, ctxLogger, client, "spec.email", strings.ToLower(strings.TrimSpace(cmd.Email)), namespace)
 	default:
 		span.RecordError(user.ErrNoUniqueID)
 		span.SetStatus(codes.Error, user.ErrNoUniqueID.Error())

--- a/pkg/services/user/userk8s/user.go
+++ b/pkg/services/user/userk8s/user.go
@@ -436,7 +436,7 @@ func (s *UserK8sService) GetByEmail(ctx context.Context, cmd *user.GetUserByEmai
 		return nil, err
 	}
 
-	u, err := s.getByFieldSelector(ctx, ctxLogger, client, "spec.email", strings.ToLower(cmd.Email), namespace, orgID)
+	u, err := s.getByFieldSelector(ctx, ctxLogger, client, "spec.email", strings.ToLower(strings.TrimSpace(cmd.Email)), namespace, orgID)
 	if err != nil {
 		span.RecordError(err)
 		return nil, err

--- a/pkg/services/user/userk8s/user.go
+++ b/pkg/services/user/userk8s/user.go
@@ -94,6 +94,10 @@ func (s *UserK8sService) getRESTClient(ctx context.Context) (*rest.RESTClient, e
 }
 
 func (s *UserK8sService) Create(ctx context.Context, cmd *user.CreateUserCommand) (*user.User, error) {
+	// Trim before empty checks so stored login matches what the UI displays.
+	cmd.Login = strings.TrimSpace(cmd.Login)
+	cmd.Email = strings.TrimSpace(cmd.Email)
+
 	ctx, span := s.tracer.Start(ctx, "user.create", trace.WithAttributes(
 		attribute.String("login", cmd.Login),
 	))
@@ -372,7 +376,7 @@ func (s *UserK8sService) GetByLogin(ctx context.Context, cmd *user.GetUserByLogi
 
 	ctxLogger := s.logger.FromContext(ctx)
 
-	loginOrEmail := strings.ToLower(cmd.LoginOrEmail)
+	loginOrEmail := strings.ToLower(strings.TrimSpace(cmd.LoginOrEmail))
 
 	orgID, err := s.getOrgID(ctx, ctxLogger)
 	if err != nil {
@@ -479,10 +483,10 @@ func (s *UserK8sService) Update(ctx context.Context, cmd *user.UpdateUserCommand
 		existing.Spec.Title = cmd.Name
 	}
 	if cmd.Email != "" {
-		existing.Spec.Email = strings.ToLower(cmd.Email)
+		existing.Spec.Email = strings.ToLower(strings.TrimSpace(cmd.Email))
 	}
 	if cmd.Login != "" {
-		existing.Spec.Login = strings.ToLower(cmd.Login)
+		existing.Spec.Login = strings.ToLower(strings.TrimSpace(cmd.Login))
 	}
 	if cmd.IsDisabled != nil {
 		existing.Spec.Disabled = *cmd.IsDisabled

--- a/public/app/features/admin/UserCreatePage.tsx
+++ b/public/app/features/admin/UserCreatePage.tsx
@@ -34,7 +34,12 @@ const UserCreatePage = () => {
 
   const onSubmit = useCallback(
     async (data: UserDTO) => {
-      const { uid } = await createUser(data);
+      const { uid } = await createUser({
+        ...data,
+        login: data.login?.trim(),
+        email: data.email?.trim(),
+        name: data.name?.trim(),
+      });
 
       navigate(`/admin/users/edit/${uid}`);
     },


### PR DESCRIPTION
## Summary
- Trim leading/trailing whitespace from username and email on create/update (legacy + k8s user services, admin create API, and admin UI form submit).
- Also trim typed credentials in `GetByLogin` so accidental spaces around login input do not fail auth.
- Adds unit and integration coverage for the create/login path described in #130611.

Fixes #130611

## Test plan
- [ ] Create a user via Admin → Users → New user with username `  callview  ` and confirm the stored/displayed login is `callview`
- [ ] Log in as `callview` successfully
- [ ] Edit an existing user login/email to include surrounding spaces and confirm they are trimmed on save
- [ ] `go test ./pkg/services/user/userimpl/ -count=1`