### PR TITLE
DashboardModel: Don't compare moment objects in hasTimeChanged()

### DIFF
--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -1085,13 +1085,7 @@ export class DashboardModel implements TimeModel {
 
   hasTimeChanged() {
     const { time, originalTime } = this;
-
-    // Compare moment values vs strings values
-    return !(
-      isEqual(time, originalTime) ||
-      (isEqual(dateTime(time?.from), dateTime(originalTime?.from)) &&
-        isEqual(dateTime(time?.to), dateTime(originalTime?.to)))
-    );
+    return time.from !== originalTime.from || time.to !== originalTime.to;
   }
 
   autoFitPanels(viewHeight: number, kioskMode?: UrlQueryValue) {

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -5,7 +5,6 @@ import {
   type AnnotationQuery,
   type AppEvent,
   type DashboardCursorSync,
-  dateTime,
   dateTimeFormat,
   dateTimeFormatTimeAgo,
   type DateTimeInput,


### PR DESCRIPTION
in the [Moment removal PR](https://github.com/grafana/grafana/pull/130235), i'm getting a `hasTimeChanged()` test failure due to the method comparing moment objects.

https://github.com/grafana/grafana/blob/aeb5a063c42f580b2e9ae117652bdb02eb01fc95/public/app/features/dashboard/state/DashboardModel.ts#L1086-L1095

<img width="1180" height="498" alt="image" src="https://github.com/user-attachments/assets/478dd8b1-183e-4f43-8fe4-536367d5060e" />

---

i don't completely understand why this 2022-era change was done in: https://github.com/grafana/grafana/commit/15ca294be055225da24e5327efaa116d4f7fa166#diff-1246109f7d7d3f52aa2e377c19ae29439b007cac8424e2cdbc8487aca3d4969dL1079

was the purpose to compare computed timestamps that came from an unchanging relative range definition evaluated at a different "now"? :shrug: 