### PR TITLE
TableNG: Add hidden sortable field option adjacent to filterable

### DIFF
--- a/packages/grafana-schema/src/common/common.gen.ts
+++ b/packages/grafana-schema/src/common/common.gen.ts
@@ -1100,6 +1100,10 @@ export interface TableFieldOptions extends HideableFieldConfig {
   inspect: boolean;
   minWidth?: number;
   /**
+   * Controls whether the column can be sorted. Every column is sortable by default; set to false to disable sorting for this column.
+   */
+  sortable?: boolean;
+  /**
    * The name of the field which contains styling overrides for this cell
    */
   styleField?: string;

--- a/packages/grafana-schema/src/common/table.cue
+++ b/packages/grafana-schema/src/common/table.cue
@@ -147,6 +147,8 @@ TableFieldOptions: {
 	cellOptions:  TableCellOptions
 	inspect:      bool | *false
 	filterable?:  bool
+	// Controls whether the column can be sorted. Every column is sortable by default; set to false to disable sorting for this column.
+	sortable?: bool
 	// Hides any header for a column, useful for columns that show some static content or buttons.
 	hideHeader?: bool
 	// if true, wrap the text content of the cell

--- a/packages/grafana-ui/src/components/Table/TableNG/components/HeaderCell.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/HeaderCell.test.tsx
@@ -63,6 +63,18 @@ describe('HeaderCell', () => {
     expect(container.querySelector('svg')).toBeInTheDocument();
   });
 
+  it('shows a pointer cursor and underlines the label on hover by default', () => {
+    render(<HeaderCell {...baseProps} field={makeField()} />);
+    const label = screen.getByRole('button', { name: 'Field1' });
+    expect(window.getComputedStyle(label).cursor).toBe('pointer');
+  });
+
+  it('uses a default cursor and drops the hover underline when the field is not sortable', () => {
+    render(<HeaderCell {...baseProps} field={makeField({ config: { custom: { sortable: false } } })} />);
+    const label = screen.getByRole('button', { name: 'Field1' });
+    expect(window.getComputedStyle(label).cursor).toBe('default');
+  });
+
   it('renders with wrapped header text when wrapHeaderText is enabled', () => {
     render(<HeaderCell {...baseProps} field={makeField({ config: { custom: { wrapHeaderText: true } } })} />);
     expect(screen.getByRole('button', { name: 'Field1' })).toBeInTheDocument();

--- a/packages/grafana-ui/src/components/Table/TableNG/components/HeaderCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/HeaderCell.tsx
@@ -44,7 +44,8 @@ export const HeaderCell: React.FC<HeaderCellProps> = ({
 }) => {
   const ref = useRef<HTMLDivElement>(null);
   const headerCellWrap = field.config.custom?.wrapHeaderText ?? false;
-  const styles = useStyles2(getStyles, headerCellWrap);
+  const sortable = field.config.custom?.sortable !== false;
+  const styles = useStyles2(getStyles, headerCellWrap, sortable);
   const displayName = getDisplayName(field);
   const filterable = field.config.custom?.filterable ?? false;
 
@@ -124,10 +125,10 @@ export const HeaderCell: React.FC<HeaderCellProps> = ({
   );
 };
 
-const getStyles = memoize((theme: GrafanaTheme2, headerTextWrap?: boolean) => ({
+const getStyles = memoize((theme: GrafanaTheme2, headerTextWrap?: boolean, sortable = true) => ({
   headerCellLabel: css({
     all: 'unset',
-    cursor: 'pointer',
+    cursor: sortable ? 'pointer' : 'default',
     fontWeight: theme.typography.fontWeightMedium,
     color: theme.colors.text.secondary,
     overflow: 'hidden',
@@ -136,7 +137,7 @@ const getStyles = memoize((theme: GrafanaTheme2, headerTextWrap?: boolean) => ({
     borderRadius: theme.spacing(0.25),
     lineHeight: '20px',
     '&:hover': {
-      textDecoration: 'underline',
+      textDecoration: sortable ? 'underline' : 'none',
     },
     '&::selection': {
       backgroundColor: 'var(--rdg-background-color)',

--- a/packages/grafana-ui/src/components/Table/TableNG/render-hooks.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/render-hooks.test.tsx
@@ -373,6 +373,19 @@ describe('useColumnBuilderFromFields', () => {
     expect(result.columns[1].frozen).toBe(false);
   });
 
+  it('is sortable by default, and only opts out when custom.sortable is explicitly false', () => {
+    const unsortableFrame = createDataFrame({
+      fields: [
+        { name: 'A', type: FieldType.string, values: ['x', 'y'] },
+        { name: 'B', type: FieldType.number, values: [1, 2], config: { custom: { sortable: false } } },
+        { name: 'C', type: FieldType.number, values: [1, 2], config: { custom: { sortable: true } } },
+      ],
+    });
+    const hook = renderColumnBuilderHook({ filterResult: makeFilterResult(), config: makeConfig() });
+    const result = callFromFields(hook, unsortableFrame.fields, [100, 100, 100], unsortableFrame, rows, rows);
+    expect(result.columns.map((c) => c.sortable)).toEqual([true, false, true]);
+  });
+
   it('sets column widths from the widths array', () => {
     const hook = renderColumnBuilderHook({ filterResult: makeFilterResult(), config: makeConfig() });
     const result = callFromFields(hook, frame.fields, [150, 200], frame, rows, rows);

--- a/packages/grafana-ui/src/components/Table/TableNG/render-hooks.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/render-hooks.tsx
@@ -509,6 +509,8 @@ function buildColumnsFromFields(
       width,
       headerCellClass,
       frozen: Math.min(frozenColumns, numFrozenColsFullyInView) > i,
+      // every column is sortable unless explicitly disabled
+      sortable: field.config.custom?.sortable !== false,
       renderCell: renderCellContent,
       renderHeaderCell: ({ column, sortDirection }) => (
         <HeaderCell


### PR DESCRIPTION
## What is this feature?

Adds a `sortable` field option to `TableFieldOptions`, adjacent to the existing `filterable` option. Every column is sortable by default; setting `custom.sortable` to `false` on a field disables sorting for that column.

This is a schema-only, programmatic option for now — there is no field-config UI switch exposed. Only consumers setting `field.config.custom.sortable` directly (e.g. via panel JSON, data source, or transformation) can use it.

## Why do we need this feature?

TableNG currently makes every column sortable unconditionally (`defaultColumnOptions.sortable: true` on the underlying react-data-grid). Some programmatic consumers of TableNG, like LogsTable and Flamegraph, need to disable sorting on a per-column basis (e.g. columns backed by non-comparable or synthetic data). This mirrors the existing `filterable` option's shape so it's easy to extend to a UI switch later if needed.

## Who is this feature for?

Programmatic/embedded consumers of TableNG that configure field config directly, rather than through the Table panel's field-config UI.

## Which issue(s) does this PR fixes?

N/A

## Special notes for your reviewer

- `packages/grafana-schema/src/common/table.cue`: added `sortable?: bool`, regenerated `common.gen.ts` via `go generate ./public/app/plugins/gen.go`.
- `packages/grafana-ui/src/components/Table/TableNG/render-hooks.tsx`: column now sets `sortable: field.config.custom?.sortable !== false` per column. react-data-grid gates click/keyboard sort and the sortable CSS class on this per-column `Column.sortable` flag internally, so no other TableNG changes were needed.
- Intentionally did **not** wire up a field-config UI switch (`addTableCustomConfig.ts`), docs, or i18n strings — this is meant to stay a hidden/programmatic-only option for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)