### PR TITLE
Docs: Update log level colors for debug and info

### DIFF
--- a/docs/sources/visualizations/explore/logs-integration.md
+++ b/docs/sources/visualizations/explore/logs-integration.md
@@ -127,10 +127,10 @@ When using the Loki data source, if `level` is part of your log line, you can us
 | critical  | purple     | emerg, emergency, fatal, alert, crit, critical, 0, 1, 2 |
 | error     | red        | err, eror, error, 3                                     |
 | warning   | yellow     | warn, warning, 4                                        |
-| info      | green      | info, information, informational, notice, 5, 6          |
-| debug     | blue       | dbug, debug, 7                                          |
+| info      | blue       | info, information, informational, notice, 5, 6          |
+| debug     | gray       | dbug, debug, 7                                          |
 | trace     | light blue | trace                                                   |
-| unknown   | grey       | \*                                                      |
+| unknown   | gray       | \*                                                      |
 
 ### Highlight searched words
 


### PR DESCRIPTION
## What is this feature?

Updates the log level color table in the Explore logs integration doc to match the new log level colors:

- **debug**: blue → gray (changed in #129896)
- **info**: green → blue

Also normalizes "grey" → "gray" for the unknown level (US spelling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)