### PR TITLE
Alerting: Fix useAutoSyncConfiguration's queries behind Org Admin + feature toggle

### DIFF
--- a/public/app/features/alerting/unified/components/settings/AutoSyncConfiguration.test.tsx
+++ b/public/app/features/alerting/unified/components/settings/AutoSyncConfiguration.test.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react';
-import { render } from 'test/test-utils';
+import { render, testWithFeatureToggles } from 'test/test-utils';
 import { byLabelText, byRole, byText } from 'testing-library-selector';
 
 import {
@@ -72,6 +72,10 @@ function registerMimirDataSources(datasources: Array<typeof MIMIR_DS_PAYLOAD> = 
 }
 
 const postState: AdminConfigPostState = { lastPayload: null };
+
+// The underlying hook now gates its queries on this toggle + Org Admin (it's only ever mounted here,
+// behind both — see ImportSettingsPage.tsx), so these tests need it on to exercise the real path.
+testWithFeatureToggles({ enable: ['alerting.syncExternalAlertmanager'] });
 
 beforeEach(() => {
   postState.lastPayload = null;

--- a/public/app/features/alerting/unified/components/settings/useAutoSyncConfiguration.test.tsx
+++ b/public/app/features/alerting/unified/components/settings/useAutoSyncConfiguration.test.tsx
@@ -1,9 +1,10 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
-import { getWrapper } from 'test/test-utils';
+import { getWrapper, testWithFeatureToggles } from 'test/test-utils';
 
 import { AlertmanagerChoice } from 'app/plugins/datasource/alertmanager/types';
 
 import { setupMswServer } from '../../mockApi';
+import { grantUserRole } from '../../mocks';
 import {
   type AdminConfigPostState,
   setupAdminConfigGet,
@@ -49,8 +50,13 @@ const VANILLA_DS = {
 
 const postState: AdminConfigPostState = { lastPayload: null };
 
+// The hook itself now gates its queries on Org Admin + this toggle (it's only ever mounted from the
+// Settings tab, which is already gated on both) — grant them so these tests exercise the real path.
+testWithFeatureToggles({ enable: ['alerting.syncExternalAlertmanager'] });
+
 beforeEach(() => {
   postState.lastPayload = null;
+  grantUserRole('Admin');
   setupAlertmanagersStatus(server);
 });
 

--- a/public/app/features/alerting/unified/components/settings/useAutoSyncConfiguration.tsx
+++ b/public/app/features/alerting/unified/components/settings/useAutoSyncConfiguration.tsx
@@ -1,8 +1,10 @@
 import { useMemo, useState } from 'react';
 
-import { type DataSourceSettings } from '@grafana/data';
+import { type DataSourceSettings, OrgRole } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import { useAppNotification } from 'app/core/copy/appNotification';
+import { contextSrv } from 'app/core/services/context_srv';
 import {
   type AlertManagerDataSourceJsonData,
   AlertManagerImplementation,
@@ -52,11 +54,19 @@ export function isOperatorManaged(state: AutoSyncState): state is Extract<AutoSy
 }
 
 export function useAutoSyncConfiguration(): UseAutoSyncConfigurationResult {
+  // Both endpoints require Org Admin (admin_config) or are only meaningful behind the sync toggle;
+  // skip them for everyone else so callers that mount this unconditionally (e.g. the Import wizard)
+  // don't fire a guaranteed-403 request on every page load. Must match Step1AlertmanagerResources's
+  // `isAutoSyncSegmentEnabled` gate for the Auto-sync checkbox itself.
+  const canAccess =
+    Boolean(config.featureToggles['alerting.syncExternalAlertmanager']) && contextSrv.hasRole(OrgRole.Admin);
+
   const { currentData: configuration, isLoading: isLoadingConfig } =
-    alertmanagerApi.endpoints.getGrafanaAlertingConfiguration.useQuery();
+    alertmanagerApi.endpoints.getGrafanaAlertingConfiguration.useQuery(undefined, { skip: !canAccess });
   const { currentData: allDatasources, isLoading: isLoadingDatasources } =
     dataSourcesApi.endpoints.getAllDataSourceSettings.useQuery(undefined, {
       refetchOnMountOrArgChange: true,
+      skip: !canAccess,
     });
   const [updateConfiguration, updateConfigurationState] =
     alertmanagerApi.endpoints.updateGrafanaAlertingConfiguration.useMutation();


### PR DESCRIPTION
**Changes**

Both endpoints require Org Admin (admin_config) or are only meaningful behind the sync toggle. A future caller mounting this hook unconditionally would otherwise fire a guaranteed-403 request on every page load for non-admin users.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
