### PR TITLE
Notebooks: Export features

### DIFF
--- a/public/app/api/clients/dashboard/v2beta1/index.ts
+++ b/public/app/api/clients/dashboard/v2beta1/index.ts
@@ -106,6 +106,9 @@ export const {
   // creating a notebook refetches the list without any extra enhancement here.
   useListNotebookQuery,
   useCreateNotebookMutation,
+  // Lazy, because the list response is flattened for the table: exporting a row has to fetch that
+  // notebook's spec on demand rather than every row's up front.
+  useLazyGetNotebookQuery,
 } = dashboardAPIv2beta1;
 
 // eslint-disable-next-line no-barrel-files/no-barrel-files

--- a/public/app/features/notebook/export/NotebookExportMenu.test.tsx
+++ b/public/app/features/notebook/export/NotebookExportMenu.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen, waitFor } from 'test/test-utils';
+
+import { AppEvents } from '@grafana/data';
+import { config } from '@grafana/runtime';
+import { Menu } from '@grafana/ui';
+import { appEvents } from 'app/core/app_events';
+
+import { defaultSpec as defaultNotebookSpec, type Spec as NotebookSpec } from '../types';
+
+import { NotebookExportMenu } from './NotebookExportMenu';
+import { openCursorPromptDeeplink } from './cursor';
+import { downloadMarkdown } from './downloadMarkdown';
+
+jest.mock('./downloadMarkdown', () => ({ downloadMarkdown: jest.fn() }));
+jest.mock('./cursor', () => ({
+  ...jest.requireActual('./cursor'),
+  openCursorPromptDeeplink: jest.fn(),
+}));
+
+const mockDownloadMarkdown = jest.mocked(downloadMarkdown);
+const mockOpenCursor = jest.mocked(openCursorPromptDeeplink);
+
+function buildSpec(): NotebookSpec {
+  return {
+    ...defaultNotebookSpec(),
+    title: 'Q2 latency regression',
+    tags: [],
+    elements: { md: { kind: 'Cell', spec: { content: { kind: 'Markdown', spec: { text: 'Findings' } } } } },
+    layout: {
+      kind: 'NotebookLayout',
+      spec: {
+        cells: [
+          { kind: 'NotebookLayoutItem', spec: { element: { kind: 'ElementReference', name: 'md' }, source: 'user' } },
+        ],
+      },
+    },
+  };
+}
+
+function setup(getSpec: () => Promise<NotebookSpec | undefined>) {
+  return render(
+    <Menu>
+      <NotebookExportMenu uid="nb1" getSpec={getSpec} />
+    </Menu>
+  );
+}
+
+describe('NotebookExportMenu', () => {
+  const originalAppUrl = config.appUrl;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.assign(window, { isSecureContext: true });
+    // notebookShareUrl resolves the share link against config.appUrl; jest leaves it unset, and
+    // `new URL(path, undefined)` throws, which the menu would report as an export failure.
+    config.appUrl = 'https://host/';
+  });
+
+  afterEach(() => {
+    config.appUrl = originalAppUrl;
+  });
+
+  it('offers the three export actions', () => {
+    setup(async () => buildSpec());
+
+    expect(screen.getByRole('menuitem', { name: 'Copy as Markdown' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Download as .md' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Open in Cursor' })).toBeInTheDocument();
+  });
+
+  it('copies the notebook as markdown', async () => {
+    const { user } = setup(async () => buildSpec());
+
+    await user.click(screen.getByRole('menuitem', { name: 'Copy as Markdown' }));
+
+    const copied = await navigator.clipboard.readText();
+    expect(copied).toContain('# Q2 latency regression');
+    expect(copied).toContain('Findings');
+  });
+
+  it('downloads using the title from the spec, so the filename matches the document', async () => {
+    const { user } = setup(async () => buildSpec());
+
+    await user.click(screen.getByRole('menuitem', { name: 'Download as .md' }));
+
+    // waitFor because the handler resolves the spec before acting.
+    await waitFor(() => {
+      expect(mockDownloadMarkdown).toHaveBeenCalledWith(expect.stringContaining('Findings'), 'Q2 latency regression');
+    });
+  });
+
+  it('hands Cursor the notebook without its link line', async () => {
+    const { user } = setup(async () => buildSpec());
+
+    await user.click(screen.getByRole('menuitem', { name: 'Open in Cursor' }));
+
+    await waitFor(() => {
+      expect(mockOpenCursor).toHaveBeenCalledTimes(1);
+    });
+    expect(mockOpenCursor.mock.calls[0][0]).not.toContain('Open in Grafana');
+  });
+
+  it('reports a failure instead of doing nothing', async () => {
+    // A row-level export fetches, so this is a real path: the notebook may be gone or forbidden.
+    const emit = jest.spyOn(appEvents, 'emit');
+    const { user } = setup(async () => {
+      throw new Error('403');
+    });
+
+    await user.click(screen.getByRole('menuitem', { name: 'Copy as Markdown' }));
+
+    await waitFor(() => {
+      expect(emit).toHaveBeenCalledWith(AppEvents.alertError, ['Failed to export notebook']);
+    });
+    expect(mockDownloadMarkdown).not.toHaveBeenCalled();
+  });
+
+  it('treats a missing notebook as a failure too', async () => {
+    const emit = jest.spyOn(appEvents, 'emit');
+    const { user } = setup(async () => undefined);
+
+    await user.click(screen.getByRole('menuitem', { name: 'Download as .md' }));
+
+    expect(emit).toHaveBeenCalledWith(AppEvents.alertError, ['Failed to export notebook']);
+    expect(mockDownloadMarkdown).not.toHaveBeenCalled();
+  });
+});

--- a/public/app/features/notebook/export/NotebookExportMenu.test.tsx
+++ b/public/app/features/notebook/export/NotebookExportMenu.test.tsx
@@ -47,10 +47,17 @@ function setup(getSpec: () => Promise<NotebookSpec | undefined>) {
 
 describe('NotebookExportMenu', () => {
   const originalAppUrl = config.appUrl;
+  const originalClipboard = navigator.clipboard;
 
   beforeEach(() => {
     jest.clearAllMocks();
     Object.assign(window, { isSecureContext: true });
+    // One test swaps in a failing clipboard; put the real one back so the others are unaffected.
+    Object.defineProperty(navigator, 'clipboard', {
+      value: originalClipboard,
+      configurable: true,
+      writable: true,
+    });
     // notebookShareUrl resolves the share link against config.appUrl; jest leaves it unset, and
     // `new URL(path, undefined)` throws, which the menu would report as an export failure.
     config.appUrl = 'https://host/';
@@ -98,6 +105,24 @@ describe('NotebookExportMenu', () => {
       expect(mockOpenCursor).toHaveBeenCalledTimes(1);
     });
     expect(mockOpenCursor.mock.calls[0][0]).not.toContain('Open in Grafana');
+  });
+
+  it('reports a failed copy instead of claiming success', async () => {
+    // The clipboard write settles after the spec loads, so its outcome is the only thing that says
+    // whether anything reached the clipboard. Toasting success without it is a lie the user acts on.
+    const emit = jest.spyOn(appEvents, 'emit');
+    const { user } = setup(async () => buildSpec());
+
+    // After render: userEvent installs its own clipboard stub during setup, which would replace this.
+    const writeText = jest.fn().mockRejectedValue(new Error('NotAllowedError'));
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true, writable: true });
+
+    await user.click(screen.getByRole('menuitem', { name: 'Copy as Markdown' }));
+
+    await waitFor(() => {
+      expect(emit).toHaveBeenCalledWith(AppEvents.alertError, ['Failed to export notebook']);
+    });
+    expect(emit).not.toHaveBeenCalledWith(AppEvents.alertSuccess, expect.anything());
   });
 
   it('reports a failure instead of doing nothing', async () => {

--- a/public/app/features/notebook/export/NotebookExportMenu.test.tsx
+++ b/public/app/features/notebook/export/NotebookExportMenu.test.tsx
@@ -1,9 +1,8 @@
 import { render, screen, waitFor } from 'test/test-utils';
 
-import { AppEvents } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { Menu } from '@grafana/ui';
-import { appEvents } from 'app/core/app_events';
+import { AppNotificationList } from 'app/core/components/AppNotifications/AppNotificationList';
 
 import { defaultSpec as defaultNotebookSpec, type Spec as NotebookSpec } from '../types';
 
@@ -37,11 +36,16 @@ function buildSpec(): NotebookSpec {
   };
 }
 
+// AppNotificationList is rendered alongside so the toasts can be asserted as the user sees them,
+// rather than by spying on the dispatch that produces them.
 function setup(getSpec: () => Promise<NotebookSpec | undefined>) {
   return render(
-    <Menu>
-      <NotebookExportMenu uid="nb1" getSpec={getSpec} />
-    </Menu>
+    <>
+      <AppNotificationList />
+      <Menu>
+        <NotebookExportMenu uid="nb1" getSpec={getSpec} />
+      </Menu>
+    </>
   );
 }
 
@@ -110,7 +114,6 @@ describe('NotebookExportMenu', () => {
   it('reports a failed copy instead of claiming success', async () => {
     // The clipboard write settles after the spec loads, so its outcome is the only thing that says
     // whether anything reached the clipboard. Toasting success without it is a lie the user acts on.
-    const emit = jest.spyOn(appEvents, 'emit');
     const { user } = setup(async () => buildSpec());
 
     // After render: userEvent installs its own clipboard stub during setup, which would replace this.
@@ -119,34 +122,28 @@ describe('NotebookExportMenu', () => {
 
     await user.click(screen.getByRole('menuitem', { name: 'Copy as Markdown' }));
 
-    await waitFor(() => {
-      expect(emit).toHaveBeenCalledWith(AppEvents.alertError, ['Failed to export notebook']);
-    });
-    expect(emit).not.toHaveBeenCalledWith(AppEvents.alertSuccess, expect.anything());
+    expect(await screen.findByText('Failed to export notebook')).toBeInTheDocument();
+    expect(screen.queryByText('Notebook copied as Markdown')).not.toBeInTheDocument();
   });
 
   it('reports a failure instead of doing nothing', async () => {
     // A row-level export fetches, so this is a real path: the notebook may be gone or forbidden.
-    const emit = jest.spyOn(appEvents, 'emit');
     const { user } = setup(async () => {
       throw new Error('403');
     });
 
     await user.click(screen.getByRole('menuitem', { name: 'Copy as Markdown' }));
 
-    await waitFor(() => {
-      expect(emit).toHaveBeenCalledWith(AppEvents.alertError, ['Failed to export notebook']);
-    });
+    expect(await screen.findByText('Failed to export notebook')).toBeInTheDocument();
     expect(mockDownloadMarkdown).not.toHaveBeenCalled();
   });
 
   it('treats a missing notebook as a failure too', async () => {
-    const emit = jest.spyOn(appEvents, 'emit');
     const { user } = setup(async () => undefined);
 
     await user.click(screen.getByRole('menuitem', { name: 'Download as .md' }));
 
-    expect(emit).toHaveBeenCalledWith(AppEvents.alertError, ['Failed to export notebook']);
+    expect(await screen.findByText('Failed to export notebook')).toBeInTheDocument();
     expect(mockDownloadMarkdown).not.toHaveBeenCalled();
   });
 });

--- a/public/app/features/notebook/export/NotebookExportMenu.tsx
+++ b/public/app/features/notebook/export/NotebookExportMenu.tsx
@@ -1,0 +1,84 @@
+import { AppEvents } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { Menu } from '@grafana/ui';
+import { appEvents } from 'app/core/app_events';
+import { copyStringToClipboard } from 'app/core/utils/explore';
+
+import { type Spec as NotebookSpec } from '../types';
+import { notebookShareUrl } from '../urls';
+
+import { openCursorPromptDeeplink, stripNotebookLink } from './cursor';
+import { downloadMarkdown } from './downloadMarkdown';
+import { notebookToMarkdown } from './notebookToMarkdown';
+
+interface Props {
+  uid: string;
+  /**
+   * Resolves the notebook's spec when an action runs, rather than up front. That is the seam letting
+   * one menu serve both surfaces: the notebook page hands back its scene's spec synchronously, while
+   * a list row fetches — and a list of fifty notebooks must not fetch fifty specs to render.
+   */
+  getSpec: () => Promise<NotebookSpec | undefined>;
+}
+
+/** The export actions, shared by the notebook page toolbar and the list page's row menu. */
+export function NotebookExportMenu({ uid, getSpec }: Props) {
+  // The title comes off the spec rather than being passed in, so the filename always matches the
+  // document that was actually exported.
+  const buildMarkdown = async (): Promise<{ markdown: string; title: string } | undefined> => {
+    try {
+      const spec = await getSpec();
+      if (!spec) {
+        throw new Error('Notebook not found');
+      }
+
+      return { markdown: notebookToMarkdown(spec, { url: notebookShareUrl(uid) }), title: spec.title };
+    } catch (error) {
+      // Without this a failed fetch would look like a menu item that does nothing at all.
+      appEvents.emit(AppEvents.alertError, [t('notebooks.export.error', 'Failed to export notebook')]);
+      return undefined;
+    }
+  };
+
+  const onCopy = async () => {
+    const built = await buildMarkdown();
+    if (built) {
+      // copyStringToClipboard rather than navigator.clipboard directly: it falls back to
+      // document.execCommand outside a secure context, so the copy still works on a plain-http
+      // Grafana. It reports no result either way, which is why the toast below is optimistic.
+      copyStringToClipboard(built.markdown);
+      appEvents.emit(AppEvents.alertSuccess, [t('notebooks.export.copied', 'Notebook copied as Markdown')]);
+    }
+  };
+
+  const onDownload = async () => {
+    const built = await buildMarkdown();
+    if (built) {
+      downloadMarkdown(built.markdown, built.title);
+    }
+  };
+
+  const onOpenInCursor = async () => {
+    const built = await buildMarkdown();
+    if (built) {
+      // The link line goes first: Cursor's deep link handler mis-parses embedded URLs.
+      openCursorPromptDeeplink(stripNotebookLink(built.markdown));
+    }
+  };
+
+  return (
+    <>
+      <Menu.Item label={t('notebooks.export.copy-markdown', 'Copy as Markdown')} icon="copy" onClick={onCopy} />
+      <Menu.Item
+        label={t('notebooks.export.download-markdown', 'Download as .md')}
+        icon="download-alt"
+        onClick={onDownload}
+      />
+      <Menu.Item
+        label={t('notebooks.export.open-in-cursor', 'Open in Cursor')}
+        icon="external-link-alt"
+        onClick={onOpenInCursor}
+      />
+    </>
+  );
+}

--- a/public/app/features/notebook/export/NotebookExportMenu.tsx
+++ b/public/app/features/notebook/export/NotebookExportMenu.tsx
@@ -1,7 +1,6 @@
-import { AppEvents } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Menu } from '@grafana/ui';
-import { appEvents } from 'app/core/app_events';
+import { useAppNotification } from 'app/core/copy/appNotification';
 
 import { type Spec as NotebookSpec } from '../types';
 import { notebookShareUrl } from '../urls';
@@ -23,6 +22,8 @@ interface Props {
 
 /** The export actions, shared by the notebook page toolbar and the list page's row menu. */
 export function NotebookExportMenu({ uid, getSpec }: Props) {
+  const notifyApp = useAppNotification();
+
   // Throws rather than reporting, so each action owns its own outcome: the copy cannot know whether
   // it succeeded until the clipboard write settles, which is after the spec has loaded.
   const loadSpec = async (): Promise<NotebookSpec> => {
@@ -35,17 +36,21 @@ export function NotebookExportMenu({ uid, getSpec }: Props) {
   };
 
   // Without this a failed export would look like a menu item that does nothing at all.
-  const reportFailure = () =>
-    appEvents.emit(AppEvents.alertError, [t('notebooks.export.error', 'Failed to export notebook')]);
+  const reportFailure = () => notifyApp.error(t('notebooks.export.error', 'Failed to export notebook'));
 
   const onCopy = async () => {
     // Deliberately not awaited here. The clipboard write has to be issued inside the click, so the
     // pending markdown is what gets handed to copyToClipboard — see the note there.
     const markdown = loadSpec().then((spec) => notebookToMarkdown(spec, { url: notebookShareUrl(uid) }));
+    // A second handle, so a rejection always has a listener. copyToClipboard hands the pending
+    // promise to ClipboardItem, which never consumes it if the clipboard write rejects first for its
+    // own reason — leaving the original handle to surface as an unhandled rejection in the console.
+    // The error still reaches the catch below, because that awaits copyToClipboard rather than this.
+    markdown.catch(() => {});
 
     try {
       await copyToClipboard(markdown);
-      appEvents.emit(AppEvents.alertSuccess, [t('notebooks.export.copied', 'Notebook copied as Markdown')]);
+      notifyApp.success(t('notebooks.export.copied', 'Notebook copied as Markdown'));
     } catch (error) {
       reportFailure();
     }
@@ -64,6 +69,10 @@ export function NotebookExportMenu({ uid, getSpec }: Props) {
   const onOpenInCursor = async () => {
     try {
       const spec = await loadSpec();
+      // Unconditional, and deliberately not a success message. A deep link into an app that is not
+      // installed is ignored by the browser with no error and no way to detect it, so the honest
+      // report is that the handoff was attempted — otherwise the click does nothing observable at all.
+      notifyApp.info(t('notebooks.export.opening-in-cursor', 'Opening in Cursor'));
       // Serialized without the link: Cursor's deep link handler mis-parses embedded URLs, and
       // leaving it out beats generating it and stripping it back out.
       openCursorPromptDeeplink(notebookToMarkdown(spec, {}));

--- a/public/app/features/notebook/export/NotebookExportMenu.tsx
+++ b/public/app/features/notebook/export/NotebookExportMenu.tsx
@@ -7,7 +7,7 @@ import { copyStringToClipboard } from 'app/core/utils/explore';
 import { type Spec as NotebookSpec } from '../types';
 import { notebookShareUrl } from '../urls';
 
-import { openCursorPromptDeeplink, stripNotebookLink } from './cursor';
+import { openCursorPromptDeeplink } from './cursor';
 import { downloadMarkdown } from './downloadMarkdown';
 import { notebookToMarkdown } from './notebookToMarkdown';
 
@@ -23,16 +23,14 @@ interface Props {
 
 /** The export actions, shared by the notebook page toolbar and the list page's row menu. */
 export function NotebookExportMenu({ uid, getSpec }: Props) {
-  // The title comes off the spec rather than being passed in, so the filename always matches the
-  // document that was actually exported.
-  const buildMarkdown = async (): Promise<{ markdown: string; title: string } | undefined> => {
+  const loadSpec = async (): Promise<NotebookSpec | undefined> => {
     try {
       const spec = await getSpec();
       if (!spec) {
         throw new Error('Notebook not found');
       }
 
-      return { markdown: notebookToMarkdown(spec, { url: notebookShareUrl(uid) }), title: spec.title };
+      return spec;
     } catch (error) {
       // Without this a failed fetch would look like a menu item that does nothing at all.
       appEvents.emit(AppEvents.alertError, [t('notebooks.export.error', 'Failed to export notebook')]);
@@ -41,28 +39,30 @@ export function NotebookExportMenu({ uid, getSpec }: Props) {
   };
 
   const onCopy = async () => {
-    const built = await buildMarkdown();
-    if (built) {
+    const spec = await loadSpec();
+    if (spec) {
       // copyStringToClipboard rather than navigator.clipboard directly: it falls back to
       // document.execCommand outside a secure context, so the copy still works on a plain-http
       // Grafana. It reports no result either way, which is why the toast below is optimistic.
-      copyStringToClipboard(built.markdown);
+      copyStringToClipboard(notebookToMarkdown(spec, { url: notebookShareUrl(uid) }));
       appEvents.emit(AppEvents.alertSuccess, [t('notebooks.export.copied', 'Notebook copied as Markdown')]);
     }
   };
 
   const onDownload = async () => {
-    const built = await buildMarkdown();
-    if (built) {
-      downloadMarkdown(built.markdown, built.title);
+    const spec = await loadSpec();
+    if (spec) {
+      // Title from the spec, so the filename always matches the document that was exported.
+      downloadMarkdown(notebookToMarkdown(spec, { url: notebookShareUrl(uid) }), spec.title);
     }
   };
 
   const onOpenInCursor = async () => {
-    const built = await buildMarkdown();
-    if (built) {
-      // The link line goes first: Cursor's deep link handler mis-parses embedded URLs.
-      openCursorPromptDeeplink(stripNotebookLink(built.markdown));
+    const spec = await loadSpec();
+    if (spec) {
+      // Serialized without the link: Cursor's deep link handler mis-parses embedded URLs, and
+      // leaving it out beats generating it and stripping it back out.
+      openCursorPromptDeeplink(notebookToMarkdown(spec, {}));
     }
   };
 

--- a/public/app/features/notebook/export/NotebookExportMenu.tsx
+++ b/public/app/features/notebook/export/NotebookExportMenu.tsx
@@ -2,11 +2,11 @@ import { AppEvents } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Menu } from '@grafana/ui';
 import { appEvents } from 'app/core/app_events';
-import { copyStringToClipboard } from 'app/core/utils/explore';
 
 import { type Spec as NotebookSpec } from '../types';
 import { notebookShareUrl } from '../urls';
 
+import { copyToClipboard } from './copyToClipboard';
 import { openCursorPromptDeeplink } from './cursor';
 import { downloadMarkdown } from './downloadMarkdown';
 import { notebookToMarkdown } from './notebookToMarkdown';
@@ -23,46 +23,52 @@ interface Props {
 
 /** The export actions, shared by the notebook page toolbar and the list page's row menu. */
 export function NotebookExportMenu({ uid, getSpec }: Props) {
-  const loadSpec = async (): Promise<NotebookSpec | undefined> => {
-    try {
-      const spec = await getSpec();
-      if (!spec) {
-        throw new Error('Notebook not found');
-      }
-
-      return spec;
-    } catch (error) {
-      // Without this a failed fetch would look like a menu item that does nothing at all.
-      appEvents.emit(AppEvents.alertError, [t('notebooks.export.error', 'Failed to export notebook')]);
-      return undefined;
+  // Throws rather than reporting, so each action owns its own outcome: the copy cannot know whether
+  // it succeeded until the clipboard write settles, which is after the spec has loaded.
+  const loadSpec = async (): Promise<NotebookSpec> => {
+    const spec = await getSpec();
+    if (!spec) {
+      throw new Error('Notebook not found');
     }
+
+    return spec;
   };
 
+  // Without this a failed export would look like a menu item that does nothing at all.
+  const reportFailure = () =>
+    appEvents.emit(AppEvents.alertError, [t('notebooks.export.error', 'Failed to export notebook')]);
+
   const onCopy = async () => {
-    const spec = await loadSpec();
-    if (spec) {
-      // copyStringToClipboard rather than navigator.clipboard directly: it falls back to
-      // document.execCommand outside a secure context, so the copy still works on a plain-http
-      // Grafana. It reports no result either way, which is why the toast below is optimistic.
-      copyStringToClipboard(notebookToMarkdown(spec, { url: notebookShareUrl(uid) }));
+    // Deliberately not awaited here. The clipboard write has to be issued inside the click, so the
+    // pending markdown is what gets handed to copyToClipboard — see the note there.
+    const markdown = loadSpec().then((spec) => notebookToMarkdown(spec, { url: notebookShareUrl(uid) }));
+
+    try {
+      await copyToClipboard(markdown);
       appEvents.emit(AppEvents.alertSuccess, [t('notebooks.export.copied', 'Notebook copied as Markdown')]);
+    } catch (error) {
+      reportFailure();
     }
   };
 
   const onDownload = async () => {
-    const spec = await loadSpec();
-    if (spec) {
+    try {
+      const spec = await loadSpec();
       // Title from the spec, so the filename always matches the document that was exported.
       downloadMarkdown(notebookToMarkdown(spec, { url: notebookShareUrl(uid) }), spec.title);
+    } catch (error) {
+      reportFailure();
     }
   };
 
   const onOpenInCursor = async () => {
-    const spec = await loadSpec();
-    if (spec) {
+    try {
+      const spec = await loadSpec();
       // Serialized without the link: Cursor's deep link handler mis-parses embedded URLs, and
       // leaving it out beats generating it and stripping it back out.
       openCursorPromptDeeplink(notebookToMarkdown(spec, {}));
+    } catch (error) {
+      reportFailure();
     }
   };
 

--- a/public/app/features/notebook/export/copyToClipboard.test.ts
+++ b/public/app/features/notebook/export/copyToClipboard.test.ts
@@ -1,0 +1,128 @@
+import { copyStringToClipboard } from 'app/core/utils/explore';
+
+import { copyToClipboard } from './copyToClipboard';
+
+jest.mock('app/core/utils/explore', () => ({ copyStringToClipboard: jest.fn() }));
+
+const mockCopyString = jest.mocked(copyStringToClipboard);
+
+const originalClipboard = navigator.clipboard;
+const originalSecureContext = window.isSecureContext;
+
+function setClipboard(clipboard: unknown) {
+  Object.defineProperty(navigator, 'clipboard', { value: clipboard, configurable: true, writable: true });
+}
+
+/** jsdom has no ClipboardItem, so the branch that needs one has to bring its own. */
+function defineClipboardItem() {
+  class FakeClipboardItem {
+    constructor(public readonly items: Record<string, Promise<string> | string>) {}
+  }
+  Object.defineProperty(globalThis, 'ClipboardItem', { value: FakeClipboardItem, configurable: true });
+  return FakeClipboardItem;
+}
+
+function removeClipboardItem() {
+  Reflect.deleteProperty(globalThis, 'ClipboardItem');
+}
+
+describe('copyToClipboard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.assign(window, { isSecureContext: true });
+    removeClipboardItem();
+  });
+
+  afterEach(() => {
+    setClipboard(originalClipboard);
+    Object.assign(window, { isSecureContext: originalSecureContext });
+    removeClipboardItem();
+  });
+
+  describe('with ClipboardItem', () => {
+    it('issues the write before the text resolves', async () => {
+      defineClipboardItem();
+      const write = jest.fn().mockResolvedValue(undefined);
+      setClipboard({ write, writeText: jest.fn() });
+
+      let resolveText: (value: string) => void = () => {};
+      const text = new Promise<string>((resolve) => {
+        resolveText = resolve;
+      });
+
+      const copied = copyToClipboard(text);
+
+      // The point of the whole helper: the write is already in flight while the text is pending, so
+      // it happens inside the click's user activation rather than after it.
+      expect(write).toHaveBeenCalledTimes(1);
+
+      resolveText('# Notebook');
+      await copied;
+    });
+
+    it('hands the pending promise to ClipboardItem rather than an awaited string', async () => {
+      const FakeClipboardItem = defineClipboardItem();
+      const write = jest.fn().mockResolvedValue(undefined);
+      setClipboard({ write, writeText: jest.fn() });
+
+      await copyToClipboard(Promise.resolve('# Notebook'));
+
+      const [items] = write.mock.calls[0];
+      expect(items[0]).toBeInstanceOf(FakeClipboardItem);
+      await expect(items[0].items['text/plain']).resolves.toBe('# Notebook');
+    });
+
+    it('rejects when the write is refused', async () => {
+      defineClipboardItem();
+      setClipboard({ write: jest.fn().mockRejectedValue(new Error('NotAllowedError')), writeText: jest.fn() });
+
+      await expect(copyToClipboard(Promise.resolve('# Notebook'))).rejects.toThrow('NotAllowedError');
+    });
+
+    it('rejects when the text itself fails to resolve', async () => {
+      defineClipboardItem();
+      // A real clipboard rejects the write when its promise rejects; the stub has to be told to.
+      setClipboard({
+        write: jest.fn((items) => items[0].items['text/plain']),
+        writeText: jest.fn(),
+      });
+
+      await expect(copyToClipboard(Promise.reject(new Error('403')))).rejects.toThrow('403');
+    });
+  });
+
+  describe('without ClipboardItem', () => {
+    it('awaits writeText so a rejection is not swallowed', async () => {
+      const writeText = jest.fn().mockRejectedValue(new Error('NotAllowedError'));
+      setClipboard({ writeText });
+
+      await expect(copyToClipboard(Promise.resolve('# Notebook'))).rejects.toThrow('NotAllowedError');
+      expect(writeText).toHaveBeenCalledWith('# Notebook');
+    });
+
+    it('resolves when writeText succeeds', async () => {
+      setClipboard({ writeText: jest.fn().mockResolvedValue(undefined) });
+
+      await expect(copyToClipboard(Promise.resolve('# Notebook'))).resolves.toBeUndefined();
+    });
+  });
+
+  describe('outside a secure context', () => {
+    it('falls back to the shared helper, which uses document.execCommand', async () => {
+      Object.assign(window, { isSecureContext: false });
+      setClipboard(undefined);
+
+      await copyToClipboard(Promise.resolve('# Notebook'));
+
+      expect(mockCopyString).toHaveBeenCalledWith('# Notebook');
+    });
+
+    it('still rejects when the text fails to resolve', async () => {
+      Object.assign(window, { isSecureContext: false });
+      setClipboard(undefined);
+
+      await expect(copyToClipboard(Promise.reject(new Error('403')))).rejects.toThrow('403');
+      expect(mockCopyString).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/public/app/features/notebook/export/copyToClipboard.ts
+++ b/public/app/features/notebook/export/copyToClipboard.ts
@@ -1,0 +1,32 @@
+import { copyStringToClipboard } from 'app/core/utils/explore';
+
+/**
+ * Copies text that is not known yet.
+ *
+ * A clipboard write issued after an `await` is refused outright by Safari, and by any browser whose
+ * transient user activation has lapsed — a real risk on a list row, where the notebook is fetched
+ * over the network before there is anything to copy. Handing `ClipboardItem` the still-pending
+ * promise starts the write inside the click and lets the text arrive late; this is the same
+ * workaround as createShortLinkClipboardItem in app/core/utils/shortLinks.
+ *
+ * Rejects when the copy fails, so a caller reports what happened rather than assuming it worked.
+ */
+export async function copyToClipboard(text: Promise<string>): Promise<void> {
+  if (navigator.clipboard && window.isSecureContext) {
+    if (typeof ClipboardItem !== 'undefined' && navigator.clipboard.write) {
+      await navigator.clipboard.write([new ClipboardItem({ 'text/plain': text })]);
+      return;
+    }
+
+    // Without ClipboardItem the write cannot begin before the text resolves, so it stays subject to
+    // the activation window. Awaiting writeText is still worth doing: copyStringToClipboard drops the
+    // promise it returns, which makes a rejection invisible.
+    await navigator.clipboard.writeText(await text);
+    return;
+  }
+
+  // Plain-http Grafana, where only document.execCommand is available. The shared helper discards
+  // execCommand's result, so this is the one path that cannot tell success from failure. Reporting it
+  // honestly means teaching copyStringToClipboard to return a result, which changes its other callers.
+  copyStringToClipboard(await text);
+}

--- a/public/app/features/notebook/export/cursor.test.ts
+++ b/public/app/features/notebook/export/cursor.test.ts
@@ -1,27 +1,4 @@
-import { buildCursorPromptDeeplink, openCursorPromptDeeplink, stripNotebookLink } from './cursor';
-
-describe('stripNotebookLink', () => {
-  it('removes the link line, which Cursor mis-parses', () => {
-    const markdown = [
-      '# Notebook',
-      '',
-      '- **Tags:** incident',
-      '- **Link:** [Open in Grafana](https://host/n/1)',
-      '',
-      'Body',
-    ].join('\n');
-
-    const stripped = stripNotebookLink(markdown);
-
-    expect(stripped).not.toContain('Open in Grafana');
-    expect(stripped).toContain('- **Tags:** incident');
-    expect(stripped).toContain('Body');
-  });
-
-  it('leaves markdown without a link line alone', () => {
-    expect(stripNotebookLink('# Notebook\n\nBody')).toBe('# Notebook\n\nBody');
-  });
-});
+import { buildCursorPromptDeeplink, openCursorPromptDeeplink } from './cursor';
 
 describe('buildCursorPromptDeeplink', () => {
   it('uses the native scheme and never cursor.com', () => {

--- a/public/app/features/notebook/export/cursor.test.ts
+++ b/public/app/features/notebook/export/cursor.test.ts
@@ -1,0 +1,71 @@
+import { buildCursorPromptDeeplink, openCursorPromptDeeplink, stripNotebookLink } from './cursor';
+
+describe('stripNotebookLink', () => {
+  it('removes the link line, which Cursor mis-parses', () => {
+    const markdown = [
+      '# Notebook',
+      '',
+      '- **Tags:** incident',
+      '- **Link:** [Open in Grafana](https://host/n/1)',
+      '',
+      'Body',
+    ].join('\n');
+
+    const stripped = stripNotebookLink(markdown);
+
+    expect(stripped).not.toContain('Open in Grafana');
+    expect(stripped).toContain('- **Tags:** incident');
+    expect(stripped).toContain('Body');
+  });
+
+  it('leaves markdown without a link line alone', () => {
+    expect(stripNotebookLink('# Notebook\n\nBody')).toBe('# Notebook\n\nBody');
+  });
+});
+
+describe('buildCursorPromptDeeplink', () => {
+  it('uses the native scheme and never cursor.com', () => {
+    // The whole point of the native scheme: notebook contents must not reach a third party's logs.
+    const url = buildCursorPromptDeeplink('# Notebook');
+
+    expect(url.startsWith('cursor://anysphere.cursor-deeplink/prompt')).toBe(true);
+    expect(url).not.toContain('cursor.com');
+  });
+
+  it('carries the prompt url-encoded', () => {
+    const url = buildCursorPromptDeeplink('a b&c');
+
+    expect(new URL(url).searchParams.get('text')).toBe('a b&c');
+  });
+
+  it('keeps a long notebook under the deep link limit and says it truncated', () => {
+    const url = buildCursorPromptDeeplink('x'.repeat(20000));
+
+    expect(url.length).toBeLessThanOrEqual(8000);
+    expect(new URL(url).searchParams.get('text')).toContain('[Notebook truncated to fit the Cursor deep link limit]');
+  });
+
+  it('leaves a notebook that already fits untouched', () => {
+    const text = '# Small notebook';
+
+    expect(new URL(buildCursorPromptDeeplink(text)).searchParams.get('text')).toBe(text);
+  });
+
+  it('accounts for url encoding cost when truncating', () => {
+    // Newlines encode to three characters each, so a fixed character cut would overshoot the limit.
+    const url = buildCursorPromptDeeplink('\n'.repeat(20000));
+
+    expect(url.length).toBeLessThanOrEqual(8000);
+  });
+});
+
+describe('openCursorPromptDeeplink', () => {
+  it('navigates the given window to the deep link', () => {
+    const win = { location: { href: '' } };
+
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- only location.href is read
+    openCursorPromptDeeplink('# Notebook', win as unknown as Window);
+
+    expect(win.location.href.startsWith('cursor://')).toBe(true);
+  });
+});

--- a/public/app/features/notebook/export/cursor.test.ts
+++ b/public/app/features/notebook/export/cursor.test.ts
@@ -36,6 +36,21 @@ describe('buildCursorPromptDeeplink', () => {
   });
 });
 
+// `slice` counts UTF-16 code units, so a cut can land inside a surrogate pair and orphan half of
+// it; url encoding then replaces the orphan with U+FFFD rather than throwing, so the symptom is one
+// mangled character rather than a failure.
+//
+// The exact input matters. A lone surrogate encodes to 9 url characters against 12 for the whole
+// pair, so the search usually settles back onto a pair boundary on its own — it only orphans when
+// the limit falls in that 3-character window. The six-character prefix is what puts it there; with
+// no prefix this passes either way and proves nothing.
+it('does not cut an emoji in half when truncating', () => {
+  const url = buildCursorPromptDeeplink('latenc' + '😀'.repeat(3000));
+
+  const text = new URL(url).searchParams.get('text') ?? '';
+  expect(text).not.toContain('\uFFFD');
+});
+
 describe('openCursorPromptDeeplink', () => {
   it('navigates the given window to the deep link', () => {
     const win = { location: { href: '' } };

--- a/public/app/features/notebook/export/cursor.ts
+++ b/public/app/features/notebook/export/cursor.ts
@@ -10,14 +10,6 @@ const CURSOR_PROMPT_URL = 'cursor://anysphere.cursor-deeplink/prompt';
 const MAX_URL_LENGTH = 8000;
 const TRUNCATION_NOTICE = '\n\n[Notebook truncated to fit the Cursor deep link limit]';
 
-/**
- * Removes the `- **Link:** ...` line the markdown header carries. Cursor's deep link handler
- * mis-parses URLs embedded in prompt text, so the link is stripped before handing the notebook over.
- */
-export function stripNotebookLink(markdown: string): string {
-  return markdown.replace(/^- \*\*Link:\*\*.*\n?/m, '');
-}
-
 /** Builds the deep link, truncating the notebook if the url would exceed Cursor's limit. */
 export function buildCursorPromptDeeplink(promptText: string): string {
   const full = buildUrl(promptText);

--- a/public/app/features/notebook/export/cursor.ts
+++ b/public/app/features/notebook/export/cursor.ts
@@ -1,0 +1,59 @@
+/**
+ * Native protocol scheme handled by a locally installed Cursor app. The notebook text goes straight
+ * to the OS protocol handler so it never reaches cursor.com — unlike the https://cursor.com/link web
+ * redirector, which would carry the whole notebook in a query string and so into a third party's
+ * request logs. There is deliberately no fallback to that redirector: if Cursor is not installed the
+ * browser simply ignores the scheme, which is the better outcome for someone who could not act on
+ * the link anyway.
+ */
+const CURSOR_PROMPT_URL = 'cursor://anysphere.cursor-deeplink/prompt';
+const MAX_URL_LENGTH = 8000;
+const TRUNCATION_NOTICE = '\n\n[Notebook truncated to fit the Cursor deep link limit]';
+
+/**
+ * Removes the `- **Link:** ...` line the markdown header carries. Cursor's deep link handler
+ * mis-parses URLs embedded in prompt text, so the link is stripped before handing the notebook over.
+ */
+export function stripNotebookLink(markdown: string): string {
+  return markdown.replace(/^- \*\*Link:\*\*.*\n?/m, '');
+}
+
+/** Builds the deep link, truncating the notebook if the url would exceed Cursor's limit. */
+export function buildCursorPromptDeeplink(promptText: string): string {
+  const full = buildUrl(promptText);
+
+  return full.length <= MAX_URL_LENGTH ? full : buildTruncatedUrl(promptText);
+}
+
+export function openCursorPromptDeeplink(promptText: string, win: Window = window): void {
+  // Called from a click, so this user-gesture navigation is allowed to invoke the protocol handler.
+  // A handled scheme does not navigate the page away.
+  win.location.href = buildCursorPromptDeeplink(promptText);
+}
+
+function buildUrl(text: string): string {
+  const url = new URL(CURSOR_PROMPT_URL);
+  url.searchParams.set('text', text);
+
+  return url.toString();
+}
+
+/**
+ * Binary search for the longest prefix that still fits. Cutting a fixed number of characters would
+ * not work: url encoding means one character of markdown can cost several of url.
+ */
+function buildTruncatedUrl(text: string): string {
+  let low = 0;
+  let high = text.length;
+
+  while (low < high) {
+    const mid = Math.floor((low + high + 1) / 2);
+    if (buildUrl(text.slice(0, mid) + TRUNCATION_NOTICE).length <= MAX_URL_LENGTH) {
+      low = mid;
+    } else {
+      high = mid - 1;
+    }
+  }
+
+  return buildUrl(text.slice(0, low) + TRUNCATION_NOTICE);
+}

--- a/public/app/features/notebook/export/cursor.ts
+++ b/public/app/features/notebook/export/cursor.ts
@@ -33,19 +33,28 @@ function buildUrl(text: string): string {
 /**
  * Binary search for the longest prefix that still fits. Cutting a fixed number of characters would
  * not work: url encoding means one character of markdown can cost several of url.
+ *
+ * Searched over characters rather than the string directly, because `slice` counts UTF-16 code units
+ * and so can cut an emoji in half. Url serialization replaces the orphaned half with U+FFFD instead
+ * of throwing, so the cost is only a mangled character at the cut — but the fix is one Array.from.
  */
 function buildTruncatedUrl(text: string): string {
+  const characters = Array.from(text);
   let low = 0;
-  let high = text.length;
+  let high = characters.length;
 
   while (low < high) {
     const mid = Math.floor((low + high + 1) / 2);
-    if (buildUrl(text.slice(0, mid) + TRUNCATION_NOTICE).length <= MAX_URL_LENGTH) {
+    if (buildUrl(prefix(characters, mid)).length <= MAX_URL_LENGTH) {
       low = mid;
     } else {
       high = mid - 1;
     }
   }
 
-  return buildUrl(text.slice(0, low) + TRUNCATION_NOTICE);
+  return buildUrl(prefix(characters, low));
+}
+
+function prefix(characters: string[], length: number): string {
+  return characters.slice(0, length).join('') + TRUNCATION_NOTICE;
 }

--- a/public/app/features/notebook/export/downloadMarkdown.test.ts
+++ b/public/app/features/notebook/export/downloadMarkdown.test.ts
@@ -1,0 +1,48 @@
+import { saveAs } from 'file-saver';
+
+import { downloadMarkdown } from './downloadMarkdown';
+
+jest.mock('file-saver', () => ({ saveAs: jest.fn() }));
+
+const mockSaveAs = jest.mocked(saveAs);
+
+describe('downloadMarkdown', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function savedFilename(): string {
+    const [, filename] = mockSaveAs.mock.calls[0];
+    return String(filename);
+  }
+
+  it('saves the markdown as a .md file', async () => {
+    downloadMarkdown('# Notebook\n\nBody', 'Q2 latency regression');
+
+    const [blob] = mockSaveAs.mock.calls[0];
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- saveAs is called with a Blob
+    expect(await (blob as Blob).text()).toBe('# Notebook\n\nBody');
+    expect(savedFilename()).toMatch(/^q2-latency-regression-.*\.md$/);
+  });
+
+  it('slugs the title so the filename is safe', () => {
+    downloadMarkdown('body', 'Checkout: errors / spike!');
+
+    expect(savedFilename()).toMatch(/^checkout-errors-spike-/);
+  });
+
+  it('caps a long title without leaving a trailing separator', () => {
+    downloadMarkdown('body', `${'a'.repeat(58)} bbbb`);
+
+    const slug = savedFilename().split('-2')[0];
+    expect(slug.length).toBeLessThanOrEqual(60);
+    expect(slug.endsWith('-')).toBe(false);
+  });
+
+  it('falls back to a generic name when the title slugs to nothing', () => {
+    // An emoji-only or punctuation-only title would otherwise produce a file called just '-<date>.md'.
+    downloadMarkdown('body', '!!!');
+
+    expect(savedFilename()).toMatch(/^notebook-/);
+  });
+});

--- a/public/app/features/notebook/export/downloadMarkdown.ts
+++ b/public/app/features/notebook/export/downloadMarkdown.ts
@@ -1,0 +1,32 @@
+import { saveAs } from 'file-saver';
+
+import { dateTimeFormat } from '@grafana/data';
+import kbn from 'app/core/utils/kbn';
+
+// Long titles are rare, but a filename over the filesystem's ~255-byte limit fails the save
+// outright, so the slug is bounded.
+const MAX_SLUG_LENGTH = 60;
+
+/**
+ * Saves the markdown as a `.md` file, named after the notebook and the moment it was exported —
+ * the same convention as `downloadAsJson` in the inspector.
+ *
+ * Uses file-saver rather than a hand-rolled anchor: Grafana installs a global link handler that
+ * calls preventDefault on link activations, which cancels a naive `<a download>` click.
+ */
+export function downloadMarkdown(markdown: string, title: string): void {
+  const blob = new Blob([markdown], { type: 'text/markdown;charset=utf-8' });
+
+  saveAs(blob, `${slugifyTitle(title) || 'notebook'}-${dateTimeFormat(new Date())}.md`);
+}
+
+function slugifyTitle(title: string): string {
+  // kbn.slugifyForUrl is what dashboard exports and provisioning already name files with; it can
+  // leave a leading or trailing dash behind for a title that starts or ends in punctuation.
+  const slug = kbn.slugifyForUrl(title).replace(/^-+|-+$/g, '');
+
+  return slug.length <= MAX_SLUG_LENGTH
+    ? slug
+    : // Trim a separator left dangling by the cut, so the name never ends in '-'.
+      slug.slice(0, MAX_SLUG_LENGTH).replace(/-+$/, '');
+}

--- a/public/app/features/notebook/export/notebookToMarkdown.test.ts
+++ b/public/app/features/notebook/export/notebookToMarkdown.test.ts
@@ -58,6 +58,24 @@ describe('notebookToMarkdown', () => {
       expect(full).toContain('What happened');
     });
 
+    it('omits the link when no url is given', () => {
+      // The Cursor export leaves it out rather than stripping it back out afterwards, which could
+      // not tell the generated line from an identical line in the notebook's own prose.
+      const markdown = notebookToMarkdown(buildSpec({}, []), {});
+
+      expect(markdown).not.toContain('**Link:**');
+      expect(markdown).toContain('# Q2 latency regression');
+    });
+
+    it('keeps a Link-shaped line in the description, which stripping would have eaten', () => {
+      const description = '- **Link:** see the runbook';
+
+      const markdown = notebookToMarkdown(buildSpec({}, [], { description }), META);
+
+      expect(markdown).toContain(description);
+      expect(markdown).toContain('[Open in Grafana](https://host/notebooks/nb1?orgId=1)');
+    });
+
     it('produces just the header for a notebook with no cells', () => {
       // An empty notebook must not crash the export.
       expect(notebookToMarkdown(buildSpec({}, []), META)).toContain('# Q2 latency regression');
@@ -94,6 +112,24 @@ describe('notebookToMarkdown', () => {
       const spec = buildSpec({ q: codeElement('a ``` b', 'sql') }, ['q']);
 
       expect(notebookToMarkdown(spec, META)).toContain('````sql\na ``` b\n````');
+    });
+
+    it('drops a language that would break the fence', () => {
+      // The schema allows any string here; a backtick or newline in the info string would end the
+      // opening delimiter and render the code as prose.
+      const spec = buildSpec({ q: codeElement('select 1', 'sql`\n```') }, ['q']);
+
+      const markdown = notebookToMarkdown(spec, META);
+
+      expect(markdown).toContain('```\nselect 1\n```');
+      expect(markdown).not.toContain('sql`');
+    });
+
+    it('survives a code cell with very many backtick runs', () => {
+      // Spreading these into Math.max would exceed the engine's argument limit and throw.
+      const spec = buildSpec({ q: codeElement('`x`'.repeat(200000), 'text') }, ['q']);
+
+      expect(() => notebookToMarkdown(spec, META)).not.toThrow();
     });
 
     it('emits an element referenced by two layout items twice', () => {
@@ -167,6 +203,27 @@ describe('notebookToMarkdown', () => {
       expect(markdown).toContain('"refId": "A"');
       expect(markdown).toContain('"datasource": "gdev-prometheus"');
       expect(markdown).toContain('"expr": "up == 0"');
+    });
+
+    it('records whether a query is hidden', () => {
+      // A disabled query would otherwise read as one the panel is actually running.
+      const hidden: NotebookElement = {
+        ...panel,
+        spec: {
+          ...panel.spec,
+          data: {
+            kind: 'QueryGroup',
+            spec: {
+              ...panel.spec.data.spec,
+              queries: [
+                { ...panel.spec.data.spec.queries[0], spec: { ...panel.spec.data.spec.queries[0].spec, hidden: true } },
+              ],
+            },
+          },
+        },
+      };
+
+      expect(notebookToMarkdown(buildSpec({ p: hidden }, ['p']), META)).toContain('"hidden": true');
     });
 
     it('says so when a panel has no queries', () => {

--- a/public/app/features/notebook/export/notebookToMarkdown.test.ts
+++ b/public/app/features/notebook/export/notebookToMarkdown.test.ts
@@ -1,4 +1,9 @@
-import { defaultSpec as defaultNotebookSpec, type NotebookElement, type Spec as NotebookSpec } from '../types';
+import {
+  defaultSpec as defaultNotebookSpec,
+  type NotebookElement,
+  type PanelKind,
+  type Spec as NotebookSpec,
+} from '../types';
 
 import { notebookToMarkdown } from './notebookToMarkdown';
 
@@ -35,6 +40,45 @@ function buildSpec(
     ...overrides,
   };
 }
+
+/** A panel carrying one prometheus query, a timeseries viz and no transformations. */
+const panel: PanelKind = {
+  kind: 'Panel',
+  spec: {
+    id: 1,
+    title: 'p95 latency',
+    links: [],
+    data: {
+      kind: 'QueryGroup',
+      spec: {
+        queries: [
+          {
+            kind: 'PanelQuery',
+            spec: {
+              refId: 'A',
+              hidden: false,
+              query: {
+                kind: 'DataQuery',
+                group: 'prometheus',
+                version: 'v0',
+                datasource: { name: 'gdev-prometheus' },
+                spec: { expr: 'up == 0' },
+              },
+            },
+          },
+        ],
+        transformations: [],
+        queryOptions: {},
+      },
+    },
+    vizConfig: {
+      kind: 'VizConfig',
+      group: 'timeseries',
+      version: '',
+      spec: { options: {}, fieldConfig: { defaults: {}, overrides: [] } },
+    },
+  },
+};
 
 describe('notebookToMarkdown', () => {
   describe('header', () => {
@@ -157,44 +201,6 @@ describe('notebookToMarkdown', () => {
   });
 
   describe('panels', () => {
-    const panel: NotebookElement = {
-      kind: 'Panel',
-      spec: {
-        id: 1,
-        title: 'p95 latency',
-        links: [],
-        data: {
-          kind: 'QueryGroup',
-          spec: {
-            queries: [
-              {
-                kind: 'PanelQuery',
-                spec: {
-                  refId: 'A',
-                  hidden: false,
-                  query: {
-                    kind: 'DataQuery',
-                    group: 'prometheus',
-                    version: 'v0',
-                    datasource: { name: 'gdev-prometheus' },
-                    spec: { expr: 'up == 0' },
-                  },
-                },
-              },
-            ],
-            transformations: [],
-            queryOptions: {},
-          },
-        },
-        vizConfig: {
-          kind: 'VizConfig',
-          group: 'timeseries',
-          version: '',
-          spec: { options: {}, fieldConfig: { defaults: {}, overrides: [] } },
-        },
-      },
-    };
-
     it('emits the panel title and the queries behind it', () => {
       // A chart has no markdown form, so the queries stand in for it — the part a reader can act on.
       const markdown = notebookToMarkdown(buildSpec({ p: panel }, ['p']), META);
@@ -205,9 +211,20 @@ describe('notebookToMarkdown', () => {
       expect(markdown).toContain('"expr": "up == 0"');
     });
 
+    // Datasource names are user-chosen and optional, so the plugin id is the only thing that says
+    // whether `expr` above is PromQL or LogQL — the field a coding agent most needs.
+    it('names the query language, not just the datasource', () => {
+      expect(notebookToMarkdown(buildSpec({ p: panel }, ['p']), META)).toContain('"type": "prometheus"');
+    });
+
+    // The queries do not say whether this was a graph, a table or a single stat.
+    it('notes the visualization type', () => {
+      expect(notebookToMarkdown(buildSpec({ p: panel }, ['p']), META)).toContain('_timeseries panel_');
+    });
+
     it('records whether a query is hidden', () => {
       // A disabled query would otherwise read as one the panel is actually running.
-      const hidden: NotebookElement = {
+      const hidden: PanelKind = {
         ...panel,
         spec: {
           ...panel.spec,
@@ -224,6 +241,40 @@ describe('notebookToMarkdown', () => {
       };
 
       expect(notebookToMarkdown(buildSpec({ p: hidden }, ['p']), META)).toContain('"hidden": true');
+    });
+
+    // The signal is "this one is disabled"; stating it on every active query is noise in every export.
+    it('stays quiet about queries that are not hidden', () => {
+      expect(notebookToMarkdown(buildSpec({ p: panel }, ['p']), META)).not.toContain('"hidden"');
+    });
+
+    describe('transformations', () => {
+      function withTransformations(transformations: PanelKind['spec']['data']['spec']['transformations']) {
+        const transformed: PanelKind = {
+          ...panel,
+          spec: {
+            ...panel.spec,
+            data: { kind: 'QueryGroup', spec: { ...panel.spec.data.spec, transformations } },
+          },
+        };
+
+        return notebookToMarkdown(buildSpec({ p: transformed }, ['p']), META);
+      }
+
+      // A panel whose displayed value comes out of a transformation exports as queries that do not
+      // produce it. Standing in for the chart is only honest if the gap is stated.
+      it('marks a panel whose output the queries do not describe', () => {
+        const markdown = withTransformations([
+          { kind: 'Transformation', group: 'reduce', spec: { options: {} } },
+          { kind: 'Transformation', group: 'organize', spec: { options: {} } },
+        ]);
+
+        expect(markdown).toContain('<!-- 2 transformation(s) applied; not represented below -->');
+      });
+
+      it('says nothing when there is nothing to warn about', () => {
+        expect(withTransformations([])).not.toContain('transformation(s) applied');
+      });
     });
 
     it('says so when a panel has no queries', () => {
@@ -248,6 +299,56 @@ describe('notebookToMarkdown', () => {
 
       expect(markdown).toContain('### CPU usage');
       expect(markdown).toContain('_Library panel: CPU usage_');
+    });
+  });
+
+  /**
+   * Go marshals a nil slice or map as `null` rather than omitting it — none of these fields carry
+   * `omitempty` — while the generated TS types claim they are always present. It does not reproduce
+   * through the UI, where a notebook comes from defaultNotebookSpec() and round-trips as `[]`; it
+   * reproduces for one made by the Assistant, kubectl or provisioning, and the list row hands a raw
+   * API spec straight in.
+   *
+   * One field at a time, so deleting any single guard fails exactly one of these rather than hiding
+   * behind the others.
+   */
+  describe('null collections from the API', () => {
+    function withNulls(overrides: Record<string, unknown>): NotebookSpec {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- expresses Go's null-for-nil payload against types that claim non-null
+      return { ...buildSpec({ md: markdownElement('Findings') }, ['md']), ...overrides } as NotebookSpec;
+    }
+
+    it('exports a notebook whose tags came back null', () => {
+      const markdown = notebookToMarkdown(withNulls({ tags: null }), META);
+
+      expect(markdown).toContain('# Q2 latency regression');
+      expect(markdown).not.toContain('**Tags:**');
+    });
+
+    it('exports a notebook whose cells came back null', () => {
+      const spec = withNulls({});
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- as above
+      spec.layout.spec.cells = null as unknown as NotebookSpec['layout']['spec']['cells'];
+
+      expect(notebookToMarkdown(spec, META)).toContain('# Q2 latency regression');
+    });
+
+    it('exports a notebook whose elements came back null', () => {
+      // The layout still references a cell, so this also covers dereferencing against no elements.
+      expect(notebookToMarkdown(withNulls({ elements: null }), META)).toContain('# Q2 latency regression');
+    });
+
+    it('exports a panel whose queries came back null', () => {
+      const noQueries: PanelKind = {
+        ...panel,
+        spec: {
+          ...panel.spec,
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- as above
+          data: { kind: 'QueryGroup', spec: { ...panel.spec.data.spec, queries: null as unknown as [] } },
+        },
+      };
+
+      expect(notebookToMarkdown(buildSpec({ p: noQueries }, ['p']), META)).toContain('_Panel with no queries._');
     });
   });
 });

--- a/public/app/features/notebook/export/notebookToMarkdown.test.ts
+++ b/public/app/features/notebook/export/notebookToMarkdown.test.ts
@@ -1,0 +1,196 @@
+import { defaultSpec as defaultNotebookSpec, type NotebookElement, type Spec as NotebookSpec } from '../types';
+
+import { notebookToMarkdown } from './notebookToMarkdown';
+
+const META = { url: 'https://host/notebooks/nb1?orgId=1' };
+
+function markdownElement(text: string): NotebookElement {
+  return { kind: 'Cell', spec: { content: { kind: 'Markdown', spec: { text } } } };
+}
+
+function codeElement(code: string, language: string): NotebookElement {
+  return { kind: 'Cell', spec: { content: { kind: 'Code', spec: { code, language } } } };
+}
+
+function buildSpec(
+  elements: Record<string, NotebookElement>,
+  cellNames: string[],
+  overrides: Partial<NotebookSpec> = {}
+): NotebookSpec {
+  return {
+    ...defaultNotebookSpec(),
+    title: 'Q2 latency regression',
+    tags: [],
+    timeSettings: { ...defaultNotebookSpec().timeSettings, from: 'now-6h', to: 'now' },
+    elements,
+    layout: {
+      kind: 'NotebookLayout',
+      spec: {
+        cells: cellNames.map((name) => ({
+          kind: 'NotebookLayoutItem',
+          spec: { element: { kind: 'ElementReference', name }, source: 'user' },
+        })),
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('notebookToMarkdown', () => {
+  describe('header', () => {
+    it('leads with the title and a link back to the notebook', () => {
+      const markdown = notebookToMarkdown(buildSpec({}, []), META);
+
+      expect(markdown).toContain('# Q2 latency regression');
+      expect(markdown).toContain('- **Link:** [Open in Grafana](https://host/notebooks/nb1?orgId=1)');
+      expect(markdown).toContain('- **Time range:** now-6h to now');
+    });
+
+    it('includes tags and description only when present', () => {
+      const bare = notebookToMarkdown(buildSpec({}, []), META);
+      expect(bare).not.toContain('**Tags:**');
+
+      const full = notebookToMarkdown(
+        buildSpec({}, [], { tags: ['incident', 'checkout'], description: 'What happened' }),
+        META
+      );
+      expect(full).toContain('- **Tags:** incident, checkout');
+      expect(full).toContain('What happened');
+    });
+
+    it('produces just the header for a notebook with no cells', () => {
+      // An empty notebook must not crash the export.
+      expect(notebookToMarkdown(buildSpec({}, []), META)).toContain('# Q2 latency regression');
+    });
+  });
+
+  describe('cells', () => {
+    it('follows the layout order, not the elements object', () => {
+      // elements is a Record and carries no order; only the layout does.
+      const spec = buildSpec({ second: markdownElement('Second'), first: markdownElement('First') }, [
+        'first',
+        'second',
+      ]);
+
+      const markdown = notebookToMarkdown(spec, META);
+
+      expect(markdown.indexOf('First')).toBeLessThan(markdown.indexOf('Second'));
+    });
+
+    it('emits markdown verbatim, headings and all', () => {
+      const text = '## Findings\n\np95 crossed 800ms. See `checkout`.\n\n- one\n- two';
+
+      expect(notebookToMarkdown(buildSpec({ md: markdownElement(text) }, ['md']), META)).toContain(text);
+    });
+
+    it('fences code with its language', () => {
+      const spec = buildSpec({ q: codeElement('up == 0', 'promql') }, ['q']);
+
+      expect(notebookToMarkdown(spec, META)).toContain('```promql\nup == 0\n```');
+    });
+
+    it('grows the fence past a backtick run inside the code', () => {
+      // A body containing ``` would otherwise close the block early and spill the rest as prose.
+      const spec = buildSpec({ q: codeElement('a ``` b', 'sql') }, ['q']);
+
+      expect(notebookToMarkdown(spec, META)).toContain('````sql\na ``` b\n````');
+    });
+
+    it('emits an element referenced by two layout items twice', () => {
+      // Two cells may legitimately point at one element; deduping would silently drop a cell.
+      const spec = buildSpec({ md: markdownElement('Repeated') }, ['md', 'md']);
+
+      expect(notebookToMarkdown(spec, META).match(/Repeated/g)).toHaveLength(2);
+    });
+
+    it('skips a layout item whose element is missing rather than throwing', () => {
+      const spec = buildSpec({ present: markdownElement('Here') }, ['gone', 'present']);
+
+      const markdown = notebookToMarkdown(spec, META);
+
+      expect(markdown).toContain('Here');
+      expect(markdown).not.toContain('gone');
+    });
+
+    it('includes a collapsed cell — collapsed is view state, not content', () => {
+      const spec = buildSpec({ md: markdownElement('Hidden in the UI') }, ['md']);
+      spec.layout.spec.cells[0].spec.collapsed = true;
+
+      expect(notebookToMarkdown(spec, META)).toContain('Hidden in the UI');
+    });
+  });
+
+  describe('panels', () => {
+    const panel: NotebookElement = {
+      kind: 'Panel',
+      spec: {
+        id: 1,
+        title: 'p95 latency',
+        links: [],
+        data: {
+          kind: 'QueryGroup',
+          spec: {
+            queries: [
+              {
+                kind: 'PanelQuery',
+                spec: {
+                  refId: 'A',
+                  hidden: false,
+                  query: {
+                    kind: 'DataQuery',
+                    group: 'prometheus',
+                    version: 'v0',
+                    datasource: { name: 'gdev-prometheus' },
+                    spec: { expr: 'up == 0' },
+                  },
+                },
+              },
+            ],
+            transformations: [],
+            queryOptions: {},
+          },
+        },
+        vizConfig: {
+          kind: 'VizConfig',
+          group: 'timeseries',
+          version: '',
+          spec: { options: {}, fieldConfig: { defaults: {}, overrides: [] } },
+        },
+      },
+    };
+
+    it('emits the panel title and the queries behind it', () => {
+      // A chart has no markdown form, so the queries stand in for it — the part a reader can act on.
+      const markdown = notebookToMarkdown(buildSpec({ p: panel }, ['p']), META);
+
+      expect(markdown).toContain('### p95 latency');
+      expect(markdown).toContain('"refId": "A"');
+      expect(markdown).toContain('"datasource": "gdev-prometheus"');
+      expect(markdown).toContain('"expr": "up == 0"');
+    });
+
+    it('says so when a panel has no queries', () => {
+      const empty: NotebookElement = {
+        ...panel,
+        spec: {
+          ...panel.spec,
+          data: { kind: 'QueryGroup', spec: { queries: [], transformations: [], queryOptions: {} } },
+        },
+      };
+
+      expect(notebookToMarkdown(buildSpec({ p: empty }, ['p']), META)).toContain('_Panel with no queries._');
+    });
+
+    it('names the library panel it references', () => {
+      const library: NotebookElement = {
+        kind: 'LibraryPanel',
+        spec: { id: 2, title: 'CPU usage', libraryPanel: { uid: 'lib-cpu-1', name: 'CPU usage' } },
+      };
+
+      const markdown = notebookToMarkdown(buildSpec({ lib: library }, ['lib']), META);
+
+      expect(markdown).toContain('### CPU usage');
+      expect(markdown).toContain('_Library panel: CPU usage_');
+    });
+  });
+});

--- a/public/app/features/notebook/export/notebookToMarkdown.ts
+++ b/public/app/features/notebook/export/notebookToMarkdown.ts
@@ -2,7 +2,7 @@ import {
   type CellContentKind,
   type NotebookElement,
   type NotebookLayoutItemKind,
-  type PanelQueryKind,
+  type PanelKind,
   type Spec as NotebookSpec,
 } from '../types';
 
@@ -26,11 +26,19 @@ interface NotebookExportMeta {
 export function notebookToMarkdown(spec: NotebookSpec, meta: NotebookExportMeta): string {
   const blocks = [buildHeader(spec, meta)];
 
+  // Every collection here is guarded because Go marshals a nil slice or map as `null`, not as absent
+  // — none of these fields carry `omitempty` — while the generated TS types claim they are always
+  // present. It does not reproduce through the UI, where a notebook is created from
+  // defaultNotebookSpec() and round-trips as `[]`; it reproduces for one made by the Assistant,
+  // kubectl or provisioning, and the list row hands a raw API spec straight in.
+  //
   // `layout.spec.cells` is the ordered list; `elements` is an unordered Record that two layout items
   // may legitimately both point at. Iterating elements would lose the order and drop duplicates, so
   // walk the layout and dereference — the same traversal deserializeNotebookLayout does.
-  for (const item of spec.layout.spec.cells) {
-    const element = spec.elements[item.spec.element.name];
+  const elements = spec.elements ?? {};
+
+  for (const item of spec.layout.spec.cells ?? []) {
+    const element = elements[item.spec.element.name];
     // A layout item referencing a missing element is skipped rather than fatal, matching the
     // deserializer: a partially broken notebook should still export what it has.
     if (!element) {
@@ -52,7 +60,7 @@ function buildHeader(spec: NotebookSpec, meta: NotebookExportMeta): string {
   if (spec.description) {
     lines.push(spec.description, '');
   }
-  if (spec.tags.length > 0) {
+  if (spec.tags?.length) {
     lines.push(`- **Tags:** ${spec.tags.join(', ')}`);
   }
 
@@ -69,7 +77,7 @@ function elementToMarkdown(element: NotebookElement, item: NotebookLayoutItemKin
     case 'Cell':
       return cellContentToMarkdown(element.spec.content);
     case 'Panel':
-      return panelToMarkdown(element.spec.title, element.spec.data.spec.queries);
+      return panelToMarkdown(element.spec);
     case 'LibraryPanel':
       return `### ${element.spec.title}\n\n_Library panel: ${element.spec.libraryPanel.name}_`;
     default:
@@ -93,25 +101,47 @@ function cellContentToMarkdown(content: CellContentKind): string {
 /**
  * A chart cannot be markdown, so the queries behind it are emitted instead — the closest thing to
  * the panel's actual meaning, and the part a reader or a coding agent can act on.
+ *
+ * The viz type comes along because the queries alone do not say whether this was a time series, a
+ * table or a single stat, and a transformation marker because they genuinely do not describe the
+ * chart when one is present. Standing in for the chart is only defensible if the reader is told
+ * where the substitution is incomplete.
  */
-function panelToMarkdown(title: string, queries: PanelQueryKind[]): string {
-  const heading = `### ${title}`;
+function panelToMarkdown(panel: PanelKind['spec']): string {
+  const lines = [`### ${panel.title}`, '', `_${panel.vizConfig.group} panel_`];
 
+  // The queries below are the panel's inputs; a transformation sits between them and what was on
+  // screen, so a value the reader is looking for may not appear in any query here.
+  const transformations = panel.data.spec.transformations ?? [];
+  if (transformations.length > 0) {
+    lines.push('', `<!-- ${transformations.length} transformation(s) applied; not represented below -->`);
+  }
+
+  const queries = panel.data.spec.queries ?? [];
   if (queries.length === 0) {
-    return `${heading}\n\n_Panel with no queries._`;
+    lines.push('', '_Panel with no queries._');
+
+    return lines.join('\n');
   }
 
   const described = queries.map((query) => ({
     refId: query.spec.refId,
-    // A disabled query would otherwise read as one the panel is actually running.
-    hidden: query.spec.hidden,
+    // Only when true. The point is that a disabled query would otherwise read as one the panel is
+    // running; saying so on every active query is noise in every export.
+    ...(query.spec.hidden && { hidden: true }),
     datasource: query.spec.query.datasource?.name,
+    // The plugin id, which is what says whether `expr` below is PromQL, LogQL or something else.
+    // Datasource names are user-chosen and may be absent, so this is the only reliable signal — and
+    // for a document meant to be handed to a coding agent, the most valuable field in the block.
+    type: query.spec.query.group,
     // Nested rather than spread: a datasource's own query model commonly carries its own refId and
     // hidden, which merging would silently overwrite these with.
     query: query.spec.query.spec,
   }));
 
-  return `${heading}\n\n${fence(JSON.stringify(described, null, 2), 'json')}`;
+  lines.push('', fence(JSON.stringify(described, null, 2), 'json'));
+
+  return lines.join('\n');
 }
 
 function fence(body: string, language: string): string {

--- a/public/app/features/notebook/export/notebookToMarkdown.ts
+++ b/public/app/features/notebook/export/notebookToMarkdown.ts
@@ -1,0 +1,112 @@
+import {
+  type CellContentKind,
+  type NotebookElement,
+  type NotebookLayoutItemKind,
+  type PanelQueryKind,
+  type Spec as NotebookSpec,
+} from '../types';
+
+interface NotebookExportMeta {
+  /** Absolute link back to the notebook, so an exported document can be traced to its source. */
+  url: string;
+}
+
+/**
+ * Renders a notebook as a standalone markdown document.
+ *
+ * Markdown cells already hold markdown, so most of this is assembly rather than conversion. The
+ * interesting cases are panels, which have no markdown equivalent at all.
+ */
+export function notebookToMarkdown(spec: NotebookSpec, meta: NotebookExportMeta): string {
+  const blocks = [buildHeader(spec, meta)];
+
+  // `layout.spec.cells` is the ordered list; `elements` is an unordered Record that two layout items
+  // may legitimately both point at. Iterating elements would lose the order and drop duplicates, so
+  // walk the layout and dereference — the same traversal deserializeNotebookLayout does.
+  for (const item of spec.layout.spec.cells) {
+    const element = spec.elements[item.spec.element.name];
+    // A layout item referencing a missing element is skipped rather than fatal, matching the
+    // deserializer: a partially broken notebook should still export what it has.
+    if (!element) {
+      continue;
+    }
+
+    const block = elementToMarkdown(element, item);
+    if (block) {
+      blocks.push(block);
+    }
+  }
+
+  return blocks.join('\n\n');
+}
+
+function buildHeader(spec: NotebookSpec, meta: NotebookExportMeta): string {
+  const lines = [`# ${spec.title}`, ''];
+
+  if (spec.description) {
+    lines.push(spec.description, '');
+  }
+  if (spec.tags.length > 0) {
+    lines.push(`- **Tags:** ${spec.tags.join(', ')}`);
+  }
+
+  lines.push(`- **Time range:** ${spec.timeSettings.from} to ${spec.timeSettings.to}`);
+  lines.push(`- **Link:** [Open in Grafana](${meta.url})`);
+
+  return `${lines.join('\n')}\n\n---`;
+}
+
+function elementToMarkdown(element: NotebookElement, item: NotebookLayoutItemKind): string | undefined {
+  switch (element.kind) {
+    case 'Cell':
+      return cellContentToMarkdown(element.spec.content);
+    case 'Panel':
+      return panelToMarkdown(element.spec.title, element.spec.data.spec.queries);
+    case 'LibraryPanel':
+      return `### ${element.spec.title}\n\n_Library panel: ${element.spec.libraryPanel.name}_`;
+    default:
+      // Keeps an unrecognised element visible in the output instead of silently dropping it. Unlike
+      // the deserializer this does not throw: a failed export is worse than an annotated one.
+      return `<!-- unsupported notebook element: ${item.spec.element.name} -->`;
+  }
+}
+
+function cellContentToMarkdown(content: CellContentKind): string {
+  if (content.kind === 'Markdown') {
+    // Emitted verbatim. Heading levels inside are deliberately left alone — shifting them to sit
+    // under the document title would mean parsing the markdown, and getting that subtly wrong is
+    // worse than a document with two H1s.
+    return content.spec.text;
+  }
+
+  return fence(content.spec.code, content.spec.language);
+}
+
+/**
+ * A chart cannot be markdown, so the queries behind it are emitted instead — the closest thing to
+ * the panel's actual meaning, and the part a reader or a coding agent can act on.
+ */
+function panelToMarkdown(title: string, queries: PanelQueryKind[]): string {
+  const heading = `### ${title}`;
+
+  if (queries.length === 0) {
+    return `${heading}\n\n_Panel with no queries._`;
+  }
+
+  const described = queries.map((query) => ({
+    refId: query.spec.refId,
+    datasource: query.spec.query.datasource?.name,
+    ...query.spec.query.spec,
+  }));
+
+  return `${heading}\n\n${fence(JSON.stringify(described, null, 2), 'json')}`;
+}
+
+function fence(body: string, language: string): string {
+  // A body containing its own ``` run would end the block early, so the fence grows past the
+  // longest run inside it — the same rule CommonMark uses.
+  const longestRun = Math.max(2, ...[...body.matchAll(/`+/g)].map((match) => match[0].length));
+  const delimiter = '`'.repeat(longestRun + 1);
+
+  return `${delimiter}${language}\n${body}\n${delimiter}`;
+}

--- a/public/app/features/notebook/export/notebookToMarkdown.ts
+++ b/public/app/features/notebook/export/notebookToMarkdown.ts
@@ -7,8 +7,14 @@ import {
 } from '../types';
 
 interface NotebookExportMeta {
-  /** Absolute link back to the notebook, so an exported document can be traced to its source. */
-  url: string;
+  /**
+   * Absolute link back to the notebook, so an exported document can be traced to its source.
+   *
+   * Optional because the Cursor export leaves it out: Cursor's deep link handler mis-parses
+   * embedded URLs. Omitting it here is safer than generating the link and stripping it back out,
+   * which cannot tell the generated line from an identical line in the notebook's own prose.
+   */
+  url?: string;
 }
 
 /**
@@ -51,7 +57,9 @@ function buildHeader(spec: NotebookSpec, meta: NotebookExportMeta): string {
   }
 
   lines.push(`- **Time range:** ${spec.timeSettings.from} to ${spec.timeSettings.to}`);
-  lines.push(`- **Link:** [Open in Grafana](${meta.url})`);
+  if (meta.url) {
+    lines.push(`- **Link:** [Open in Grafana](${meta.url})`);
+  }
 
   return `${lines.join('\n')}\n\n---`;
 }
@@ -95,8 +103,12 @@ function panelToMarkdown(title: string, queries: PanelQueryKind[]): string {
 
   const described = queries.map((query) => ({
     refId: query.spec.refId,
+    // A disabled query would otherwise read as one the panel is actually running.
+    hidden: query.spec.hidden,
     datasource: query.spec.query.datasource?.name,
-    ...query.spec.query.spec,
+    // Nested rather than spread: a datasource's own query model commonly carries its own refId and
+    // hidden, which merging would silently overwrite these with.
+    query: query.spec.query.spec,
   }));
 
   return `${heading}\n\n${fence(JSON.stringify(described, null, 2), 'json')}`;
@@ -104,9 +116,23 @@ function panelToMarkdown(title: string, queries: PanelQueryKind[]): string {
 
 function fence(body: string, language: string): string {
   // A body containing its own ``` run would end the block early, so the fence grows past the
-  // longest run inside it — the same rule CommonMark uses.
-  const longestRun = Math.max(2, ...[...body.matchAll(/`+/g)].map((match) => match[0].length));
+  // longest run inside it — the same rule CommonMark uses. Tracked in a loop rather than spread
+  // into Math.max, which a body with tens of thousands of runs would blow the argument limit on.
+  let longestRun = 2;
+  for (const match of body.matchAll(/`+/g)) {
+    longestRun = Math.max(longestRun, match[0].length);
+  }
+
   const delimiter = '`'.repeat(longestRun + 1);
 
-  return `${delimiter}${language}\n${body}\n${delimiter}`;
+  return `${delimiter}${infoString(language)}\n${body}\n${delimiter}`;
+}
+
+/**
+ * The schema allows any string as a cell's language. A backtick or a line break in the fence's info
+ * string breaks the opening delimiter, which would render the whole cell as prose — so an unusable
+ * language is dropped rather than emitted.
+ */
+function infoString(language: string): string {
+  return /[`\r\n]/.test(language) ? '' : language;
 }

--- a/public/app/features/notebook/list/NotebookRowMenu.test.tsx
+++ b/public/app/features/notebook/list/NotebookRowMenu.test.tsx
@@ -1,0 +1,124 @@
+import { fireEvent, render, screen, waitFor } from 'test/test-utils';
+
+import { AppEvents } from '@grafana/data';
+import { config } from '@grafana/runtime';
+import { useLazyGetNotebookQuery } from 'app/api/clients/dashboard/v2beta1';
+import { appEvents } from 'app/core/app_events';
+
+import { downloadMarkdown } from '../export/downloadMarkdown';
+import { defaultSpec as defaultNotebookSpec } from '../types';
+
+import { NotebookRowMenu } from './NotebookRowMenu';
+
+jest.mock('app/api/clients/dashboard/v2beta1', () => ({ useLazyGetNotebookQuery: jest.fn() }));
+jest.mock('../export/downloadMarkdown', () => ({ downloadMarkdown: jest.fn() }));
+
+const mockUseLazyGetNotebookQuery = jest.mocked(useLazyGetNotebookQuery);
+const mockDownloadMarkdown = jest.mocked(downloadMarkdown);
+
+function notebookWithOneCell() {
+  return {
+    metadata: { name: 'nb1' },
+    spec: {
+      ...defaultNotebookSpec(),
+      title: 'Q2 latency regression',
+      tags: [],
+      elements: { md: { kind: 'Cell', spec: { content: { kind: 'Markdown', spec: { text: 'Fetched findings' } } } } },
+      layout: {
+        kind: 'NotebookLayout',
+        spec: {
+          cells: [
+            { kind: 'NotebookLayoutItem', spec: { element: { kind: 'ElementReference', name: 'md' }, source: 'user' } },
+          ],
+        },
+      },
+    },
+  };
+}
+
+/** Stands in for the lazy RTK Query trigger, whose result is awaited through `.unwrap()`. */
+function setupQuery(result: { unwrap: () => Promise<unknown> }) {
+  const trigger = jest.fn().mockReturnValue(result);
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- only the trigger is used
+  mockUseLazyGetNotebookQuery.mockReturnValue([trigger] as unknown as ReturnType<typeof useLazyGetNotebookQuery>);
+
+  return trigger;
+}
+
+describe('NotebookRowMenu', () => {
+  const originalAppUrl = config.appUrl;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    config.appUrl = 'https://host/';
+  });
+
+  afterEach(() => {
+    config.appUrl = originalAppUrl;
+  });
+
+  it('nests the export actions under Export', async () => {
+    setupQuery({ unwrap: async () => notebookWithOneCell() });
+
+    const { user } = render(<NotebookRowMenu uid="nb1" />);
+
+    // The submenu opens on hover, not click.
+    await user.hover(screen.getByRole('menuitem', { name: /Export/ }));
+
+    expect(await screen.findByRole('menuitem', { name: 'Download as .md' })).toBeInTheDocument();
+  });
+
+  it('fetches this row‘s notebook and exports the spec that comes back', async () => {
+    // The whole point of the row path: the table's rows carry no spec, so a broken fetch or an
+    // unwrapped-wrong response would otherwise only show up in the browser.
+    const trigger = setupQuery({ unwrap: async () => notebookWithOneCell() });
+
+    const { user } = render(<NotebookRowMenu uid="nb1" />);
+
+    await user.hover(screen.getByRole('menuitem', { name: /Export/ }));
+    // fireEvent, not user.click: moving the pointer to the submenu item fires mouseLeave on its
+    // parent, which closes the submenu before the click lands.
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Download as .md' }));
+
+    await waitFor(() => {
+      expect(trigger).toHaveBeenCalledWith({ name: 'nb1' });
+    });
+    // Content and filename both come from the fetched spec, not from the row.
+    expect(mockDownloadMarkdown).toHaveBeenCalledWith(
+      expect.stringContaining('Fetched findings'),
+      'Q2 latency regression'
+    );
+  });
+
+  it('does not fetch until an action is chosen', async () => {
+    // A list of fifty rows must not fetch fifty specs just to render its menus.
+    const trigger = setupQuery({ unwrap: async () => notebookWithOneCell() });
+
+    render(<NotebookRowMenu uid="nb1" />);
+
+    expect(trigger).not.toHaveBeenCalled();
+  });
+
+  it('reports a failed fetch rather than exporting nothing', async () => {
+    setupQuery({
+      unwrap: async () => {
+        throw new Error('403');
+      },
+    });
+
+    // The failure surfaces as an app notification rather than in this tree, so it is asserted on
+    // the event bus.
+    const emit = jest.spyOn(appEvents, 'emit');
+    const { user } = render(<NotebookRowMenu uid="nb1" />);
+
+    await user.hover(screen.getByRole('menuitem', { name: /Export/ }));
+    // fireEvent, not user.click: moving the pointer to the submenu item fires mouseLeave on its
+    // parent, which closes the submenu before the click lands.
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Download as .md' }));
+
+    await waitFor(() => {
+      expect(emit).toHaveBeenCalledWith(AppEvents.alertError, ['Failed to export notebook']);
+    });
+    expect(mockDownloadMarkdown).not.toHaveBeenCalled();
+  });
+});

--- a/public/app/features/notebook/list/NotebookRowMenu.test.tsx
+++ b/public/app/features/notebook/list/NotebookRowMenu.test.tsx
@@ -1,9 +1,8 @@
 import { fireEvent, render, screen, waitFor } from 'test/test-utils';
 
-import { AppEvents } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { useLazyGetNotebookQuery } from 'app/api/clients/dashboard/v2beta1';
-import { appEvents } from 'app/core/app_events';
+import { AppNotificationList } from 'app/core/components/AppNotifications/AppNotificationList';
 
 import { downloadMarkdown } from '../export/downloadMarkdown';
 import { defaultSpec as defaultNotebookSpec } from '../types';
@@ -106,19 +105,21 @@ describe('NotebookRowMenu', () => {
       },
     });
 
-    // The failure surfaces as an app notification rather than in this tree, so it is asserted on
-    // the event bus.
-    const emit = jest.spyOn(appEvents, 'emit');
-    const { user } = render(<NotebookRowMenu uid="nb1" />);
+    // The failure surfaces as an app notification rather than in this tree, so the notification list
+    // is rendered alongside and the toast asserted as the user sees it.
+    const { user } = render(
+      <>
+        <AppNotificationList />
+        <NotebookRowMenu uid="nb1" />
+      </>
+    );
 
     await user.hover(screen.getByRole('menuitem', { name: /Export/ }));
     // fireEvent, not user.click: moving the pointer to the submenu item fires mouseLeave on its
     // parent, which closes the submenu before the click lands.
     fireEvent.click(await screen.findByRole('menuitem', { name: 'Download as .md' }));
 
-    await waitFor(() => {
-      expect(emit).toHaveBeenCalledWith(AppEvents.alertError, ['Failed to export notebook']);
-    });
+    expect(await screen.findByText('Failed to export notebook')).toBeInTheDocument();
     expect(mockDownloadMarkdown).not.toHaveBeenCalled();
   });
 });

--- a/public/app/features/notebook/list/NotebookRowMenu.tsx
+++ b/public/app/features/notebook/list/NotebookRowMenu.tsx
@@ -1,0 +1,34 @@
+import { t } from '@grafana/i18n';
+import { Menu } from '@grafana/ui';
+import { useLazyGetNotebookQuery } from 'app/api/clients/dashboard/v2beta1';
+
+import { NotebookExportMenu } from '../export/NotebookExportMenu';
+import { type Spec as NotebookSpec } from '../types';
+
+/**
+ * A notebook's row-level actions. Export is the only one so far; Duplicate and Delete slot in
+ * alongside it, which is why Export sits in a submenu rather than at the top level.
+ */
+export function NotebookRowMenu({ uid }: { uid: string }) {
+  const [fetchNotebook] = useLazyGetNotebookQuery();
+
+  const getSpec = async (): Promise<NotebookSpec> => {
+    const notebook = await fetchNotebook({ name: uid }).unwrap();
+    // The generated client type mirrors the schema spec at runtime (same OpenAPI source); bridge at
+    // the fetch seam, as the notebook page state manager does.
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- generated client type bridged to the schema spec at the fetch seam
+    return notebook.spec as unknown as NotebookSpec;
+  };
+
+  return (
+    <Menu>
+      <Menu.Item
+        label={t('notebooks.export.label', 'Export')}
+        icon="download-alt"
+        // The table's rows are flattened and carry no spec, so it is fetched when an action runs
+        // rather than for every row on screen.
+        childItems={[<NotebookExportMenu key="export" uid={uid} getSpec={getSpec} />]}
+      />
+    </Menu>
+  );
+}

--- a/public/app/features/notebook/list/NotebooksTable.tsx
+++ b/public/app/features/notebook/list/NotebooksTable.tsx
@@ -10,20 +10,17 @@ import {
   IconButton,
   InteractiveTable,
   LinkButton,
-  Menu,
   Stack,
   TagList,
   TextLink,
   Tooltip,
   useStyles2,
 } from '@grafana/ui';
-import { useLazyGetNotebookQuery } from 'app/api/clients/dashboard/v2beta1';
 
-import { NotebookExportMenu } from '../export/NotebookExportMenu';
 import { canEditNotebooks } from '../permissions';
-import { type Spec as NotebookSpec } from '../types';
 import { notebookEditHref, notebookShareUrl, notebookViewUrl } from '../urls';
 
+import { NotebookRowMenu } from './NotebookRowMenu';
 import { type NotebookRow } from './useNotebooksList';
 
 interface Props {
@@ -130,41 +127,14 @@ function NotebookRowActions({ notebook }: { notebook: NotebookRow }) {
         <IconButton
           name="ellipsis-v"
           variant="secondary"
+          // Dropdown injects aria-expanded but not aria-haspopup, so without this the trigger
+          // announces as a plain button and gives no hint that it opens a menu.
+          aria-haspopup="menu"
           aria-label={t('notebooks.list.table.more-actions', 'More actions')}
           tooltip={t('notebooks.list.table.more-actions', 'More actions')}
         />
       </Dropdown>
     </Stack>
-  );
-}
-
-function NotebookRowMenu({ uid }: { uid: string }) {
-  const [fetchNotebook] = useLazyGetNotebookQuery();
-
-  return (
-    <Menu>
-      {/* A submenu for one top-level item reads a little oddly today, but it is the shape Duplicate
-          and Delete slot into, and it matches the design. */}
-      <Menu.Item
-        label={t('notebooks.export.label', 'Export')}
-        icon="download-alt"
-        childItems={[
-          <NotebookExportMenu
-            key="export"
-            uid={uid}
-            // The table's rows are flattened and carry no spec, so it is fetched when an action runs
-            // rather than for every row on screen.
-            getSpec={async () => {
-              const notebook = await fetchNotebook({ name: uid }).unwrap();
-              // The generated client type mirrors the schema spec at runtime (same OpenAPI source);
-              // bridge at the fetch seam, as the notebook page state manager does.
-              // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- generated client type bridged to the schema spec at the fetch seam
-              return notebook.spec as unknown as NotebookSpec;
-            }}
-          />,
-        ]}
-      />
-    </Menu>
   );
 }
 

--- a/public/app/features/notebook/list/NotebooksTable.tsx
+++ b/public/app/features/notebook/list/NotebooksTable.tsx
@@ -6,17 +6,22 @@ import { t } from '@grafana/i18n';
 import {
   ClipboardButton,
   type Column,
+  Dropdown,
   IconButton,
   InteractiveTable,
   LinkButton,
+  Menu,
   Stack,
   TagList,
   TextLink,
   Tooltip,
   useStyles2,
 } from '@grafana/ui';
+import { useLazyGetNotebookQuery } from 'app/api/clients/dashboard/v2beta1';
 
+import { NotebookExportMenu } from '../export/NotebookExportMenu';
 import { canEditNotebooks } from '../permissions';
+import { type Spec as NotebookSpec } from '../types';
 import { notebookEditHref, notebookShareUrl, notebookViewUrl } from '../urls';
 
 import { type NotebookRow } from './useNotebooksList';
@@ -121,14 +126,45 @@ function NotebookRowActions({ notebook }: { notebook: NotebookRow }) {
       <ClipboardButton variant="secondary" size="sm" icon="link" getText={() => notebookShareUrl(notebook.uid)}>
         {t('notebooks.list.table.copy-link', 'Copy link')}
       </ClipboardButton>
-      {/* Row-level actions land in a follow-up; the menu is a disabled placeholder for now. */}
-      <IconButton
-        name="ellipsis-v"
-        disabled
-        aria-label={t('notebooks.list.table.more-actions', 'More actions')}
-        tooltip={t('notebooks.list.table.more-actions', 'More actions')}
-      />
+      <Dropdown overlay={<NotebookRowMenu uid={notebook.uid} />} placement="bottom-end">
+        <IconButton
+          name="ellipsis-v"
+          variant="secondary"
+          aria-label={t('notebooks.list.table.more-actions', 'More actions')}
+          tooltip={t('notebooks.list.table.more-actions', 'More actions')}
+        />
+      </Dropdown>
     </Stack>
+  );
+}
+
+function NotebookRowMenu({ uid }: { uid: string }) {
+  const [fetchNotebook] = useLazyGetNotebookQuery();
+
+  return (
+    <Menu>
+      {/* A submenu for one top-level item reads a little oddly today, but it is the shape Duplicate
+          and Delete slot into, and it matches the design. */}
+      <Menu.Item
+        label={t('notebooks.export.label', 'Export')}
+        icon="download-alt"
+        childItems={[
+          <NotebookExportMenu
+            key="export"
+            uid={uid}
+            // The table's rows are flattened and carry no spec, so it is fetched when an action runs
+            // rather than for every row on screen.
+            getSpec={async () => {
+              const notebook = await fetchNotebook({ name: uid }).unwrap();
+              // The generated client type mirrors the schema spec at runtime (same OpenAPI source);
+              // bridge at the fetch seam, as the notebook page state manager does.
+              // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- generated client type bridged to the schema spec at the fetch seam
+              return notebook.spec as unknown as NotebookSpec;
+            }}
+          />,
+        ]}
+      />
+    </Menu>
   );
 }
 

--- a/public/app/features/notebook/list/NotebooksTable.tsx
+++ b/public/app/features/notebook/list/NotebooksTable.tsx
@@ -130,7 +130,7 @@ function NotebookRowActions({ notebook }: { notebook: NotebookRow }) {
           // Dropdown injects aria-expanded but not aria-haspopup, so without this the trigger
           // announces as a plain button and gives no hint that it opens a menu.
           aria-haspopup="menu"
-          aria-label={t('notebooks.list.table.more-actions', 'More actions')}
+          // No aria-label alongside: IconButton uses a string tooltip as the accessible name.
           tooltip={t('notebooks.list.table.more-actions', 'More actions')}
         />
       </Dropdown>

--- a/public/app/features/notebook/pages/NotebookScenePage.tsx
+++ b/public/app/features/notebook/pages/NotebookScenePage.tsx
@@ -77,7 +77,7 @@ function NotebookDocument({ scene }: { scene: NotebookScene }) {
 
   return (
     <Page navId="notebooks" pageNav={pageNav} layout={PageLayoutType.Custom}>
-      {uid && <NotebookToolbar uid={uid} />}
+      {uid && <NotebookToolbar uid={uid} scene={scene} />}
       <scene.Component model={scene} />
     </Page>
   );

--- a/public/app/features/notebook/pages/NotebooksListPage.test.tsx
+++ b/public/app/features/notebook/pages/NotebooksListPage.test.tsx
@@ -23,6 +23,8 @@ jest.mock('app/api/clients/iam/v0alpha1', () => ({
 jest.mock('app/api/clients/dashboard/v2beta1', () => ({
   useListNotebookQuery: jest.fn(),
   useCreateNotebookMutation: () => [mockCreateNotebook],
+  // The row menu fetches a spec on demand for export; nothing here exercises the fetch itself.
+  useLazyGetNotebookQuery: () => [jest.fn()],
 }));
 
 const mockUseListNotebookQuery = jest.mocked(useListNotebookQuery);
@@ -119,6 +121,20 @@ describe('NotebooksListPage', () => {
     // The row still renders, just without a way into edit mode.
     expect(await screen.findByText('Checkout error spike')).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: 'Edit' })).not.toBeInTheDocument();
+  });
+
+  it('opens a row menu offering export, replacing the old disabled placeholder', async () => {
+    setTestFlags({ [NOTEBOOKS_FLAG]: true });
+    setList([makeNotebook('nb1', 'Checkout error spike')]);
+
+    render(<NotebooksListPage />);
+
+    const moreActions = await screen.findByRole('button', { name: 'More actions' });
+    expect(moreActions).toBeEnabled();
+
+    await userEvent.click(moreActions);
+
+    expect(await screen.findByRole('menuitem', { name: 'Export' })).toBeInTheDocument();
   });
 
   it('filters the list by title', async () => {

--- a/public/app/features/notebook/toolbar/NotebookToolbar.test.tsx
+++ b/public/app/features/notebook/toolbar/NotebookToolbar.test.tsx
@@ -2,18 +2,32 @@ import { createMemoryHistory } from 'history';
 import { render, screen } from 'test/test-utils';
 
 import { HistoryWrapper, config, locationService, setLocationService } from '@grafana/runtime';
-import { SceneRefreshPicker, SceneTimePicker, SceneTimeRange } from '@grafana/scenes';
+import { SceneRefreshPicker, SceneTimePicker, SceneTimeRange, VizPanel } from '@grafana/scenes';
 
 import { NotebookScene } from '../scene/NotebookScene';
+import { NotebookCellItem } from '../scene/layout-notebook/NotebookCellItem';
 import { NotebookLayoutManager } from '../scene/layout-notebook/NotebookLayoutManager';
 
 import { NotebookToolbar } from './NotebookToolbar';
 
+/**
+ * Carries a real panel cell, not an empty layout. The export is the first caller of
+ * transformNotebookSceneToSaveModel in production, so a scene with no cells would exercise the menu
+ * without ever exercising the serializer or vizPanelToSchemaV2's constraints behind it.
+ */
 function buildScene() {
   return new NotebookScene({
     title: 'Q2 latency regression',
     uid: 'nb1',
-    body: new NotebookLayoutManager({ cells: [] }),
+    body: new NotebookLayoutManager({
+      cells: [
+        new NotebookCellItem({
+          elementName: 'latency-panel',
+          source: 'user',
+          body: new VizPanel({ key: 'panel-1', title: 'p95 latency', pluginId: 'timeseries' }),
+        }),
+      ],
+    }),
     $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
     timePicker: new SceneTimePicker({}),
     refreshPicker: new SceneRefreshPicker({}),
@@ -72,6 +86,20 @@ describe('NotebookToolbar', () => {
     await user.click(screen.getByRole('button', { name: 'Copy link' }));
 
     expect(await screen.findByText('Copied')).toBeInTheDocument();
+  });
+
+  // Drives the whole path the PR made live: scene -> transformNotebookSceneToSaveModel ->
+  // vizPanelToSchemaV2 -> markdown. Asserting on the menu alone would pass with the serializer broken.
+  it('copies markdown built from the scene, panel and all', async () => {
+    const { user } = setup();
+
+    await user.click(screen.getByRole('button', { name: /Export/ }));
+    await user.click(await screen.findByRole('menuitem', { name: 'Copy as Markdown' }));
+
+    const markdown = await navigator.clipboard.readText();
+    expect(markdown).toContain('# Q2 latency regression');
+    expect(markdown).toContain('### p95 latency');
+    expect(markdown).toContain('_timeseries panel_');
   });
 
   it('offers the export actions from a dropdown', async () => {

--- a/public/app/features/notebook/toolbar/NotebookToolbar.test.tsx
+++ b/public/app/features/notebook/toolbar/NotebookToolbar.test.tsx
@@ -2,8 +2,23 @@ import { createMemoryHistory } from 'history';
 import { render, screen } from 'test/test-utils';
 
 import { HistoryWrapper, config, locationService, setLocationService } from '@grafana/runtime';
+import { SceneRefreshPicker, SceneTimePicker, SceneTimeRange } from '@grafana/scenes';
+
+import { NotebookScene } from '../scene/NotebookScene';
+import { NotebookLayoutManager } from '../scene/layout-notebook/NotebookLayoutManager';
 
 import { NotebookToolbar } from './NotebookToolbar';
+
+function buildScene() {
+  return new NotebookScene({
+    title: 'Q2 latency regression',
+    uid: 'nb1',
+    body: new NotebookLayoutManager({ cells: [] }),
+    $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
+    timePicker: new SceneTimePicker({}),
+    refreshPicker: new SceneRefreshPicker({}),
+  });
+}
 
 describe('NotebookToolbar', () => {
   const originalLocationService = locationService;
@@ -32,7 +47,7 @@ describe('NotebookToolbar', () => {
    * service when the button is clicked, not at render, so setting it afterwards is enough.
    */
   function setup() {
-    const rendered = render(<NotebookToolbar uid="nb1" />);
+    const rendered = render(<NotebookToolbar uid="nb1" scene={buildScene()} />);
 
     const history = new HistoryWrapper(createMemoryHistory({ initialEntries: ['/'] }));
     history.setOrgIdGetter(() => 3);
@@ -57,5 +72,15 @@ describe('NotebookToolbar', () => {
     await user.click(screen.getByRole('button', { name: 'Copy link' }));
 
     expect(await screen.findByText('Copied')).toBeInTheDocument();
+  });
+
+  it('offers the export actions from a dropdown', async () => {
+    const { user } = setup();
+
+    await user.click(screen.getByRole('button', { name: /Export/ }));
+
+    expect(await screen.findByRole('menuitem', { name: 'Copy as Markdown' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Download as .md' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Open in Cursor' })).toBeInTheDocument();
   });
 });

--- a/public/app/features/notebook/toolbar/NotebookToolbar.tsx
+++ b/public/app/features/notebook/toolbar/NotebookToolbar.tsx
@@ -1,22 +1,42 @@
 import { css } from '@emotion/css';
+import { useState } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
-import { t } from '@grafana/i18n';
-import { ClipboardButton, useStyles2 } from '@grafana/ui';
+import { Trans, t } from '@grafana/i18n';
+import { Button, ClipboardButton, Dropdown, Icon, Menu, useStyles2 } from '@grafana/ui';
 
+import { NotebookExportMenu } from '../export/NotebookExportMenu';
+import { type NotebookScene } from '../scene/NotebookScene';
+import { transformNotebookSceneToSaveModel } from '../serialization/transformNotebookSceneToSaveModel';
 import { notebookShareUrl } from '../urls';
 
 /**
  * The notebook view's header bar.
  */
-export function NotebookToolbar({ uid }: { uid: string }) {
+export function NotebookToolbar({ uid, scene }: { uid: string; scene: NotebookScene }) {
   const styles = useStyles2(getStyles);
+  const [isExportOpen, setIsExportOpen] = useState(false);
+
+  // Serialized from the scene rather than refetched: the page already holds the notebook, and this
+  // way an export reflects what is on screen.
+  const exportMenu = () => (
+    <Menu>
+      <NotebookExportMenu uid={uid} getSpec={async () => transformNotebookSceneToSaveModel(scene)} />
+    </Menu>
+  );
 
   return (
     <div className={styles.toolbar}>
       <ClipboardButton variant="secondary" size="sm" icon="link" getText={() => notebookShareUrl(uid)}>
         {t('notebooks.view.copy-link', 'Copy link')}
       </ClipboardButton>
+      <Dropdown overlay={exportMenu} placement="bottom-end" onVisibleChange={setIsExportOpen}>
+        <Button size="sm" variant="secondary" icon="download-alt" aria-haspopup="menu" aria-expanded={isExportOpen}>
+          <Trans i18nKey="notebooks.export.label">Export</Trans>
+          &nbsp;
+          <Icon name={isExportOpen ? 'angle-up' : 'angle-down'} size="sm" aria-hidden="true" />
+        </Button>
+      </Dropdown>
     </div>
   );
 }

--- a/public/app/features/notebook/types.ts
+++ b/public/app/features/notebook/types.ts
@@ -19,6 +19,7 @@ import {
   type NotebookElement as GeneratedNotebookElement,
   type NotebookLayoutItemKind as GeneratedNotebookLayoutItemKind,
   type NotebookLayoutKind as GeneratedNotebookLayoutKind,
+  type PanelQueryKind as GeneratedPanelQueryKind,
   type Spec as GeneratedSpec,
 } from '@grafana/schema/apis/notebook/v2beta1';
 
@@ -33,6 +34,7 @@ export type MarkdownCellContentKind = GeneratedMarkdownCellContentKind;
 export type NotebookElement = GeneratedNotebookElement;
 export type NotebookLayoutItemKind = GeneratedNotebookLayoutItemKind;
 export type NotebookLayoutKind = GeneratedNotebookLayoutKind;
+export type PanelQueryKind = GeneratedPanelQueryKind;
 export type Spec = GeneratedSpec;
 
 export const defaultLibraryPanelKind = generatedDefaultLibraryPanelKind;

--- a/public/app/features/notebook/types.ts
+++ b/public/app/features/notebook/types.ts
@@ -21,10 +21,12 @@ import {
   type NotebookLayoutKind as GeneratedNotebookLayoutKind,
   type PanelQueryKind as GeneratedPanelQueryKind,
   type Spec as GeneratedSpec,
+  type V2PanelKind as GeneratedPanelKind,
 } from '@grafana/schema/apis/notebook/v2beta1';
 
 // Forked by the notebook spec so it can carry the dashboard v2 shape.
 export const defaultPanelKind = defaultV2PanelKind;
+export type PanelKind = GeneratedPanelKind;
 
 // Shared with the dashboard spec, or notebook-only. Either way the generated name is already right.
 export type CellContentKind = GeneratedCellContentKind;

--- a/public/app/features/notebook/types.ts
+++ b/public/app/features/notebook/types.ts
@@ -19,7 +19,6 @@ import {
   type NotebookElement as GeneratedNotebookElement,
   type NotebookLayoutItemKind as GeneratedNotebookLayoutItemKind,
   type NotebookLayoutKind as GeneratedNotebookLayoutKind,
-  type PanelQueryKind as GeneratedPanelQueryKind,
   type Spec as GeneratedSpec,
   type V2PanelKind as GeneratedPanelKind,
 } from '@grafana/schema/apis/notebook/v2beta1';
@@ -36,7 +35,6 @@ export type MarkdownCellContentKind = GeneratedMarkdownCellContentKind;
 export type NotebookElement = GeneratedNotebookElement;
 export type NotebookLayoutItemKind = GeneratedNotebookLayoutItemKind;
 export type NotebookLayoutKind = GeneratedNotebookLayoutKind;
-export type PanelQueryKind = GeneratedPanelQueryKind;
 export type Spec = GeneratedSpec;
 
 export const defaultLibraryPanelKind = generatedDefaultLibraryPanelKind;

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12813,6 +12813,14 @@
     }
   },
   "notebooks": {
+    "export": {
+      "copied": "Notebook copied as Markdown",
+      "copy-markdown": "Copy as Markdown",
+      "download-markdown": "Download as .md",
+      "error": "Failed to export notebook",
+      "label": "Export",
+      "open-in-cursor": "Open in Cursor"
+    },
     "list": {
       "all-authors": "All authors",
       "author-filter": "Filter by author",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12819,7 +12819,8 @@
       "download-markdown": "Download as .md",
       "error": "Failed to export notebook",
       "label": "Export",
-      "open-in-cursor": "Open in Cursor"
+      "open-in-cursor": "Open in Cursor",
+      "opening-in-cursor": "Opening in Cursor"
     },
     "list": {
       "all-authors": "All authors",


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds export actions to notebooks, in two places:

- An **Export** dropdown on the notebook page, beside Copy link
- **Export ›** in the list page's per-row menu, replacing the disabled `⋮` placeholder

Three actions, mirroring the Workspace export menu:

| Action | Result |
|---|---|
| Copy as Markdown | The notebook as a markdown document, on the clipboard |
| Download as .md | The same document as a file, named after the notebook |
| Open in Cursor | Hands the notebook to a local Cursor as a prompt |

Markdown cells are emitted verbatim, code cells as fenced blocks with their language, and panels as a heading plus a JSON block of the queries behind them — a chart has no markdown form, so the queries stand in for it.

**Why do we need this feature?**

A notebook is currently a dead end: there's no way to get its contents out of Grafana, into a doc, a ticket, or an editor. Workspace already solves this; this brings the same actions to core notebooks.

**Who is this feature for?**

Anyone reading a notebook who needs to take it somewhere else — writing it up, handing it to a colleague, or feeding it to a coding agent.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes grafana/grafana-enterprise#13004

**Special notes for your reviewer:**

**Two of Workspace's five actions are deliberately left out.**

- **Save as PDF** is deferred to its own issue. There's no client-side PDF capability in OSS, and no notebook equivalent of the per-panel server rendering that makes Workspace's PDFs worth having — every chart would come out an empty placeholder, which seemed worse than no button.
- **Copy for Coding Agents** is omitted because in Workspace it produces *byte-identical* markdown to Copy as Markdown; the two differ only in icon, toast wording, and analytics event. Worth adding once it actually differs.

**Implementation notes:**

- **The serializer takes a spec, not a scene**, which is what lets one menu serve both surfaces. The page passes `transformNotebookSceneToSaveModel(scene)` so an export reflects what's on screen; a row passes `useLazyGetNotebookQuery` — the table's rows are flattened and carry no spec, and fifty rows must not fetch fifty specs to render a menu. That makes `transformNotebookSceneToSaveModel` live code for the first time; its `vizPanelToSchemaV2` caveat (both optional args omitted, or it throws for a `NotebookScene` root) now matters in production.
- **The walk goes over `layout.spec.cells`, never `elements`.** `elements` is an unordered `Record` that two layout items may legitimately both reference, so iterating it would silently reorder the document and drop a duplicated cell. Both are covered by tests; I verified they fail if the walk is inverted.
- **Cursor uses the native `cursor://` scheme with no `cursor.com` fallback**, so the notebook never leaves the machine. The link line is stripped first (Cursor mis-parses embedded URLs) and long notebooks are truncated by binary search to fit the 8000-char limit — url encoding means a fixed character cut overshoots.
- **Reuses existing core utils** rather than hand-rolling: `saveAs` (file-saver), `kbn.slugifyForUrl` for the filename, and `copyStringToClipboard`, which falls back to `document.execCommand` outside a secure context so the copy still works on a plain-http Grafana. The success toast is therefore optimistic, since that helper reports no result.
- One `as unknown as` cast, at the row's fetch seam where the generated client's `NotebookSpec` meets the schema `Spec` — same bridge, same rationale, as `NotebookPageStateManager.ts`.
- The row menu holds a single top-level item today, which reads a little oddly, but it's the shape Duplicate and Delete slot into and it matches the design.

**Testing:** 139 unit tests across the notebook feature. **Open in Cursor** verified end to end against a local Cursor install.
