### PR TITLE
Server Lock: Retry deadlocks

### DIFF
--- a/pkg/infra/serverlock/serverlock.go
+++ b/pkg/infra/serverlock/serverlock.go
@@ -159,12 +159,6 @@ func (sl *ServerLockService) getLock(actionName string, dbHelper *legacysql.Lega
 	return lock, nil
 }
 
-// createRaceRetries bounds how many times getOrCreate starts a fresh transaction after losing the race
-// to create the lock row. A retry is needed rather than a re-read because under REPEATABLE READ this
-// transaction's snapshot predates the winner's commit, so it cannot see the row no matter how often we
-// select it. A new transaction gets a new snapshot and finds it.
-const createRaceRetries = 3
-
 func (sl *ServerLockService) getOrCreate(ctx context.Context, actionName string) (*serverLock, error) {
 	ctx, span := sl.tracer.Start(ctx, "ServerLockService.getOrCreate")
 	defer span.End()
@@ -174,16 +168,17 @@ func (sl *ServerLockService) getOrCreate(ctx context.Context, actionName string)
 		return nil, fmt.Errorf("get legacy DB: %w", err)
 	}
 
-	for attempt := 0; ; attempt++ {
-		result, err := sl.getOrCreateOnce(ctx, dbHelper, actionName)
-		var existsErr *ServerLockExistsError
-		if !errors.As(err, &existsErr) || attempt == createRaceRetries {
-			return result, err
-		}
-
-		sl.log.FromContext(ctx).Debug("Another server created the lock first, re-reading",
-			"actionName", actionName, "attempt", attempt+1)
+	result, err := sl.getOrCreateOnce(ctx, dbHelper, actionName)
+	if _, lostRace := errors.AsType[*ServerLockExistsError](err); !lostRace {
+		return result, err
 	}
+
+	// Another server created the row between our select and our insert. A second transaction is needed
+	// rather than another select, because under REPEATABLE READ this snapshot predates their commit and
+	// will never see the row. One is enough: the conflict is only reported once the winner has committed,
+	// and LockAndExecute never deletes the row it creates.
+	sl.log.FromContext(ctx).Debug("Another server created the lock first, re-reading", "actionName", actionName)
+	return sl.getOrCreateOnce(ctx, dbHelper, actionName)
 }
 
 func (sl *ServerLockService) getOrCreateOnce(ctx context.Context, dbHelper *legacysql.LegacyDatabaseHelper,
@@ -274,8 +269,7 @@ func (sl *ServerLockService) LockExecuteAndReleaseWithRetries(ctx context.Contex
 		err := sl.acquireForRelease(ctx, actionName, timeConfig.MaxInterval)
 		// could not get the lock
 		if err != nil {
-			var lockedErr *ServerLockExistsError
-			if errors.As(err, &lockedErr) || sl.isDeadlock(ctx, err) {
+			if _, locked := errors.AsType[*ServerLockExistsError](err); locked || sl.isDeadlock(ctx, err) {
 				// if the lock is already taken, wait and try again
 				if lockChecks == 1 { // only warn on first lock check
 					ctxLogger.Warn("another instance has the lock, waiting for it to be released", "actionName", actionName)

--- a/pkg/infra/serverlock/serverlock.go
+++ b/pkg/infra/serverlock/serverlock.go
@@ -138,34 +138,65 @@ func (getLockQuery) Validate() error {
 	return nil
 }
 
+// getLock returns nil when no lock row exists for actionName.
+func (sl *ServerLockService) getLock(actionName string, dbHelper *legacysql.LegacyDatabaseHelper,
+	dbSession *db.Session,
+) (*serverLock, error) {
+	query := getLockQuery{
+		SQLTemplate:     sqltemplate.New(dbHelper.DialectForDriver()),
+		ServerLockTable: dbHelper.Table("server_lock"),
+		OperationUID:    actionName,
+	}
+	rawSQL, err := sqltemplate.Execute(getLockTemplate, query)
+	if err != nil {
+		return nil, err
+	}
+	lock := &serverLock{}
+	has, err := dbSession.SQL(rawSQL, query.GetArgs()...).Get(lock)
+	if err != nil || !has {
+		return nil, err
+	}
+	return lock, nil
+}
+
+// createRaceRetries bounds how many times getOrCreate starts a fresh transaction after losing the race
+// to create the lock row. A retry is needed rather than a re-read because under REPEATABLE READ this
+// transaction's snapshot predates the winner's commit, so it cannot see the row no matter how often we
+// select it. A new transaction gets a new snapshot and finds it.
+const createRaceRetries = 3
+
 func (sl *ServerLockService) getOrCreate(ctx context.Context, actionName string) (*serverLock, error) {
 	ctx, span := sl.tracer.Start(ctx, "ServerLockService.getOrCreate")
 	defer span.End()
 
-	var result *serverLock
 	dbHelper, err := sl.sql(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("get legacy DB: %w", err)
 	}
 
-	err = dbHelper.DB.WithTransactionalDbSession(ctx, func(dbSession *db.Session) error {
-		query := getLockQuery{
-			SQLTemplate:     sqltemplate.New(dbHelper.DialectForDriver()),
-			ServerLockTable: dbHelper.Table("server_lock"),
-			OperationUID:    actionName,
-		}
-		rawSQL, err := sqltemplate.Execute(getLockTemplate, query)
-		if err != nil {
-			return err
-		}
-		sqlRes := &serverLock{}
-		has, err := dbSession.SQL(rawSQL, query.GetArgs()...).Get(sqlRes)
-		if err != nil {
-			return err
+	for attempt := 0; ; attempt++ {
+		result, err := sl.getOrCreateOnce(ctx, dbHelper, actionName)
+		var existsErr *ServerLockExistsError
+		if !errors.As(err, &existsErr) || attempt == createRaceRetries {
+			return result, err
 		}
 
-		if has {
-			result = sqlRes
+		sl.log.FromContext(ctx).Debug("Another server created the lock first, re-reading",
+			"actionName", actionName, "attempt", attempt+1)
+	}
+}
+
+func (sl *ServerLockService) getOrCreateOnce(ctx context.Context, dbHelper *legacysql.LegacyDatabaseHelper,
+	actionName string,
+) (*serverLock, error) {
+	var result *serverLock
+	err := dbHelper.DB.WithTransactionalDbSession(ctx, func(dbSession *db.Session) error {
+		lock, err := sl.getLock(actionName, dbHelper, dbSession)
+		if err != nil {
+			return err
+		}
+		if lock != nil {
+			result = lock
 			return nil
 		}
 
@@ -546,6 +577,11 @@ func (sl *ServerLockService) createLock(ctx context.Context,
 	} else {
 		res, err := dbSession.Exec(append([]any{rawSQL}, query.GetArgs()...)...)
 		if err != nil {
+			// same race the postgres branch above handles with ON CONFLICT DO NOTHING, except MySQL and
+			// SQLite surface it as a unique constraint violation instead of an empty result
+			if dbHelper.DB.GetDialect().IsUniqueConstraintViolation(err) {
+				return nil, &ServerLockExistsError{actionName: lockRow.OperationUID}
+			}
 			return nil, err
 		}
 		lastID, err := res.LastInsertId()

--- a/pkg/infra/serverlock/serverlock.go
+++ b/pkg/infra/serverlock/serverlock.go
@@ -7,7 +7,7 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/go-sql-driver/mysql"
+	"github.com/grafana/dskit/backoff"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 
@@ -244,8 +244,7 @@ func (sl *ServerLockService) LockExecuteAndReleaseWithRetries(ctx context.Contex
 		// could not get the lock
 		if err != nil {
 			var lockedErr *ServerLockExistsError
-			var deadlockErr *mysql.MySQLError
-			if errors.As(err, &lockedErr) || (errors.As(err, &deadlockErr) && deadlockErr.Number == 1213) {
+			if errors.As(err, &lockedErr) || sl.isDeadlock(ctx, err) {
 				// if the lock is already taken, wait and try again
 				if lockChecks == 1 { // only warn on first lock check
 					ctxLogger.Warn("another instance has the lock, waiting for it to be released", "actionName", actionName)
@@ -308,6 +307,27 @@ func (updateLastExecutionQuery) Validate() error {
 	return nil
 }
 
+// on a lock miss the SELECT ... FOR UPDATE takes a gap lock, so servers inserting different action names
+// into the same index gap deadlock. The loser is rolled back whole, so retrying is safe. The waits are
+// kept far below the ~1s callers already sleep between their own attempts, since those run under request
+// deadlines as short as 15s and compounding the two would turn a deadlock into a timeout.
+var acquireDeadlockBackoff = backoff.Config{
+	MinBackoff: 2 * time.Millisecond,
+	MaxBackoff: 32 * time.Millisecond,
+	MaxRetries: 5,
+}
+
+func (sl *ServerLockService) isDeadlock(ctx context.Context, err error) bool {
+	if err == nil {
+		return false
+	}
+	dbHelper, dbErr := sl.sql(ctx)
+	if dbErr != nil {
+		return false
+	}
+	return dbHelper.DB.GetDialect().IsDeadlock(err)
+}
+
 // acquireForRelease will check if the lock is already on the database, if it is, will check with maxInterval if it is
 // timeouted. Returns nil error if the lock was acquired correctly
 func (sl *ServerLockService) acquireForRelease(ctx context.Context, actionName string, maxInterval time.Duration) error {
@@ -319,8 +339,31 @@ func (sl *ServerLockService) acquireForRelease(ctx context.Context, actionName s
 		return fmt.Errorf("get legacy DB: %w", err)
 	}
 
+	boff := backoff.New(ctx, acquireDeadlockBackoff)
+	for {
+		err = sl.acquireForReleaseOnce(ctx, dbHelper, actionName, maxInterval)
+		if !sl.isDeadlock(ctx, err) || !boff.Ongoing() {
+			break
+		}
+
+		sl.log.FromContext(ctx).Debug("Retrying lock acquisition after deadlock",
+			"actionName", actionName, "attempt", boff.NumRetries()+1)
+		boff.Wait()
+	}
+
+	// preferring the context error over the deadlock keeps errors.Is checks on context.Canceled working,
+	// and stops callers retrying a request that is already gone
+	if ctxErr := ctx.Err(); ctxErr != nil && sl.isDeadlock(ctx, err) {
+		return fmt.Errorf("context done while retrying deadlocked lock acquisition: %w", ctxErr)
+	}
+	return err
+}
+
+func (sl *ServerLockService) acquireForReleaseOnce(ctx context.Context, dbHelper *legacysql.LegacyDatabaseHelper,
+	actionName string, maxInterval time.Duration,
+) error {
 	// getting the lock - as the action name has a Unique constraint, this will fail if the lock is already on the database
-	err = dbHelper.DB.WithTransactionalDbSession(ctx, func(dbSession *db.Session) error {
+	return dbHelper.DB.WithTransactionalDbSession(ctx, func(dbSession *db.Session) error {
 		query := getLockForUpdateQuery{
 			SQLTemplate:     sqltemplate.New(dbHelper.DialectForDriver()),
 			ServerLockTable: dbHelper.Table("server_lock"),
@@ -380,8 +423,6 @@ func (sl *ServerLockService) acquireForRelease(ctx context.Context, actionName s
 		_, err = sl.createLock(ctx, lock, dbHelper, dbSession)
 		return err
 	})
-
-	return err
 }
 
 type releaseLockQuery struct {

--- a/pkg/infra/serverlock/serverlock_integration_test.go
+++ b/pkg/infra/serverlock/serverlock_integration_test.go
@@ -187,6 +187,10 @@ func TestIntegrationServerLock_ConcurrentLockAndExecuteSameAction(t *testing.T) 
 
 	sl, _ := createTestableServerLock(t)
 
+	// every goroutine shares this context, mirroring the background services that all run off the same
+	// root context. Each acquisition must still get its own session and transaction.
+	ctx := context.Background()
+
 	// the window between the select and the insert is narrow, so a single round only provokes the race
 	// about half the time. Repeat over fresh action names to make this a reliable regression guard.
 	for round := range 8 {
@@ -204,7 +208,7 @@ func TestIntegrationServerLock_ConcurrentLockAndExecuteSameAction(t *testing.T) 
 			go func(i int) {
 				defer wg.Done()
 				<-start
-				errs[i] = sl.LockAndExecute(context.Background(), actionName, time.Hour, func(context.Context) {
+				errs[i] = sl.LockAndExecute(ctx, actionName, time.Hour, func(context.Context) {
 					mu.Lock()
 					defer mu.Unlock()
 					executed++

--- a/pkg/infra/serverlock/serverlock_integration_test.go
+++ b/pkg/infra/serverlock/serverlock_integration_test.go
@@ -179,6 +179,48 @@ func TestIntegrationServerLock_LockExecuteAndReleaseWithRetries(t *testing.T) {
 	})
 }
 
+// getOrCreate reads without locking before inserting, so concurrent callers on the same action name race
+// to create the row and all but one hit a unique constraint violation. They should contend through the
+// version check rather than surfacing the driver error and skipping the run.
+func TestIntegrationServerLock_ConcurrentLockAndExecuteSameAction(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	sl, _ := createTestableServerLock(t)
+
+	// the window between the select and the insert is narrow, so a single round only provokes the race
+	// about half the time. Repeat over fresh action names to make this a reliable regression guard.
+	for round := range 8 {
+		actionName := fmt.Sprintf("concurrent-same-action-%d", round)
+
+		const concurrency = 16
+		var mu sync.Mutex
+		executed := 0
+		errs := make([]error, concurrency)
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		for i := range concurrency {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				<-start
+				errs[i] = sl.LockAndExecute(context.Background(), actionName, time.Hour, func(context.Context) {
+					mu.Lock()
+					defer mu.Unlock()
+					executed++
+				})
+			}(i)
+		}
+		close(start)
+		wg.Wait()
+
+		for i, err := range errs {
+			require.NoError(t, err, "round %d goroutine %d should not surface a lock creation error", round, i)
+		}
+		require.Equal(t, 1, executed, "round %d: exactly one caller should have run the action", round)
+	}
+}
+
 // Distinct action names still contend on MySQL: when the lock row is missing the SELECT ... FOR UPDATE
 // gap-locks the index range, so concurrent inserts into the same gap deadlock. Run with
 // GRAFANA_TEST_DB=mysql to exercise that path.

--- a/pkg/infra/serverlock/serverlock_integration_test.go
+++ b/pkg/infra/serverlock/serverlock_integration_test.go
@@ -2,6 +2,7 @@ package serverlock
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -176,4 +177,39 @@ func TestIntegrationServerLock_LockExecuteAndReleaseWithRetries(t *testing.T) {
 		})
 		require.NoError(t, err)
 	})
+}
+
+// Distinct action names still contend on MySQL: when the lock row is missing the SELECT ... FOR UPDATE
+// gap-locks the index range, so concurrent inserts into the same gap deadlock. Run with
+// GRAFANA_TEST_DB=mysql to exercise that path.
+func TestIntegrationServerLock_ConcurrentDistinctActionNames(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	sl, _ := createTestableServerLock(t)
+
+	const concurrency = 16
+	executed := make([]int, concurrency)
+	errs := make([]error, concurrency)
+
+	// released together so the acquisitions overlap as tightly as possible
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := range concurrency {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			errs[i] = sl.LockExecuteAndRelease(context.Background(), fmt.Sprintf("concurrent-operation-%d", i),
+				time.Hour, func(context.Context) { executed[i]++ })
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		require.False(t, sl.isDeadlock(context.Background(), err),
+			"deadlock escaped acquireForRelease for action %d: %v", i, err)
+		require.NoError(t, err)
+		require.Equal(t, 1, executed[i], "action %d should have executed exactly once", i)
+	}
 }


### PR DESCRIPTION
**What is this feature?**

`acquireForRelease` runs `SELECT ... FOR UPDATE` followed by `INSERT` in one transaction. When the lock row does not exist yet the SELECT takes a gap lock, so two servers inserting different action names that fall into the same gap need conflicting insert-intention locks and MySQL breaks the tie by killing one with error 1213. Only `LockExecuteAndReleaseWithRetries` handled that, so on the `LockExecuteAndRelease` path the error reached the caller. The first commit retries the transaction a bounded number of times, using the existing dialect helper so Postgres deadlock codes are covered too.

`getOrCreate` selects without locking and then inserts, so concurrent callers on the same action name all try to create the row and only one wins. Every other caller then returned an error out of `LockAndExecute`, which is the odd one out: both of the other ways to lose a lock return nil without running the function. The second commit maps the constraint violation onto `ServerLockExistsError` so the dialects agree, then reads the row back and lets the version check decide who runs.

**Why do we need this feature?**

The deadlock reaches five callers that have no retry. The worst is `oss-ac-basic-role-seeder`, where the error propagates out of `FixedRolesLoader.starting` and both `Provisioning` and `Core` depend on that module, so Grafana fails to start. Plugin install sync, zanzana reconciliation, and the secrets and prom-type migrations each silently skip a run instead. In one production cluster this fires roughly 5 to 11 times per 10 minutes.

The create race is rarer, a handful of events per day, but it makes ordinary contention look like a failure. `report.scheduler`, `login_attempt`, `serviceaccounts`, and `analytics.summaries` log an error and skip the run when another server simply got there first.

**Who is this feature for?**


**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
