### PR TITLE
Unified storage: Index spec.tags and spec.description in the standard document builder

### DIFF
--- a/pkg/storage/unified/resource/document.go
+++ b/pkg/storage/unified/resource/document.go
@@ -254,6 +254,14 @@ func NewIndexableDocument(key *resourcepb.ResourceKey, rv int64, obj utils.Grafa
 		CreatedBy: obj.GetCreatedBy(),
 		UpdatedBy: obj.GetUpdatedBy(),
 	}
+	// Tags are read here rather than in a per-kind builder so that any kind
+	// declaring spec.tags is filterable and facetable without one. A kind with its
+	// own builder may still overwrite this: dashboards do, from their parsed summary.
+	if spec, err := obj.GetSpec(); err == nil {
+		if specValue, ok := spec.(map[string]any); ok {
+			doc.Tags = specTags(specValue["tags"])
+		}
+	}
 	m, ok := obj.GetManagerProperties()
 	if ok {
 		doc.Manager = &m
@@ -278,6 +286,28 @@ func NewIndexableDocument(key *resourcepb.ResourceKey, rv int64, obj utils.Grafa
 		}
 	}
 	return doc.UpdateCopyFields()
+}
+
+// specTags reads a spec.tags value, which unstructured decoding yields as a
+// []any of strings. Anything else — a missing key, a non-list, a non-string
+// entry — is skipped rather than failing: a malformed tag should not keep the
+// whole resource out of the index. Returns nil when nothing usable is found, so
+// the field stays omitted rather than serializing as an empty list.
+func specTags(raw any) []string {
+	values, ok := raw.([]any)
+	if !ok {
+		return nil
+	}
+	tags := make([]string, 0, len(values))
+	for _, v := range values {
+		if s, ok := v.(string); ok && s != "" {
+			tags = append(tags, s)
+		}
+	}
+	if len(tags) == 0 {
+		return nil
+	}
+	return tags
 }
 
 // StandardDocumentBuilder returns the standard document builder backed by the

--- a/pkg/storage/unified/resource/document.go
+++ b/pkg/storage/unified/resource/document.go
@@ -254,12 +254,17 @@ func NewIndexableDocument(key *resourcepb.ResourceKey, rv int64, obj utils.Grafa
 		CreatedBy: obj.GetCreatedBy(),
 		UpdatedBy: obj.GetUpdatedBy(),
 	}
-	// Tags are read here rather than in a per-kind builder so that any kind
-	// declaring spec.tags is filterable and facetable without one. A kind with its
-	// own builder may still overwrite this: dashboards do, from their parsed summary.
+	// Tags and description are read here rather than in a per-kind builder, so any
+	// kind declaring them is searchable without needing one. Both are already
+	// declared standard fields and mapped for every kind; only the population was
+	// dashboard-specific. A kind with its own builder may still overwrite them:
+	// dashboards do, from their parsed summary.
 	if spec, err := obj.GetSpec(); err == nil {
 		if specValue, ok := spec.(map[string]any); ok {
 			doc.Tags = specTags(specValue["tags"])
+			if description, ok := specValue["description"].(string); ok {
+				doc.Description = description
+			}
 		}
 	}
 	m, ok := obj.GetManagerProperties()

--- a/pkg/storage/unified/resource/document_test.go
+++ b/pkg/storage/unified/resource/document_test.go
@@ -42,6 +42,7 @@ func TestStandardDocumentBuilder(t *testing.T) {
 		"title": "Test Playlist from Unified Storage",
 		"title_ngram": "Test Playlist from Unified Storage",
 		"title_phrase": "test playlist from unified storage",
+		"description": "description for the test playlist",
 		"created": 1717236672000,
 		"createdBy": "user:ABC",
 		"updatedBy": "user:XYZ",
@@ -310,11 +311,11 @@ func TestStandardDocumentBuilder_ReloadThroughRegistry(t *testing.T) {
 	require.NotContains(t, doc.SelectableFields, "spec.x")
 }
 
-// Tags come from spec.tags via the standard builder, so a kind gets them without
-// registering its own document builder. Before this, doc.Tags was only ever set by
-// the dashboard builder, and every other kind indexed with no tags at all — the
-// field was declared and mapped, but never populated.
-func TestStandardDocumentBuilder_Tags(t *testing.T) {
+// Tags and description come from the spec via the standard builder, so a kind gets
+// them without registering its own document builder. Before this, doc.Tags and
+// doc.Description were only ever set by the dashboard builder, and every other kind
+// indexed without them — both fields were declared and mapped, but never populated.
+func TestStandardDocumentBuilder_SpecFields(t *testing.T) {
 	ctx := context.Background()
 	builder := StandardDocumentBuilder(nil)
 
@@ -357,5 +358,33 @@ func TestStandardDocumentBuilder_Tags(t *testing.T) {
 
 	t.Run("ignores a tags value that is not a list", func(t *testing.T) {
 		assert.Nil(t, build(t, `{"title": "Wrong shape", "tags": "incident"}`).Tags)
+	})
+
+	t.Run("reads spec.description", func(t *testing.T) {
+		doc := build(t, `{"title": "Checkout latency", "description": "Why checkout got slow"}`)
+		assert.Equal(t, "Why checkout got slow", doc.Description)
+	})
+
+	t.Run("leaves description empty when there is none", func(t *testing.T) {
+		assert.Empty(t, build(t, `{"title": "No description"}`).Description, "absent")
+		assert.Empty(t, build(t, `{"title": "Blank", "description": ""}`).Description, "empty string")
+	})
+
+	t.Run("ignores a description that is not a string", func(t *testing.T) {
+		assert.Empty(t, build(t, `{"title": "Wrong shape", "description": {"nested": true}}`).Description)
+	})
+
+	// The two are read from the same spec lookup, so a kind declaring both gets both.
+	t.Run("reads tags and description together", func(t *testing.T) {
+		doc := build(t, `{"title": "Both", "tags": ["incident"], "description": "Has both"}`)
+		assert.Equal(t, []string{"incident"}, doc.Tags)
+		assert.Equal(t, "Has both", doc.Description)
+	})
+
+	// The spec lookup must not displace what the constructor already resolves.
+	t.Run("still populates the standard fields", func(t *testing.T) {
+		doc := build(t, `{"title": "Checkout latency", "tags": ["incident"], "description": "d"}`)
+		assert.Equal(t, "Checkout latency", doc.Title)
+		assert.Equal(t, "nb1", doc.Name)
 	})
 }

--- a/pkg/storage/unified/resource/document_test.go
+++ b/pkg/storage/unified/resource/document_test.go
@@ -309,3 +309,53 @@ func TestStandardDocumentBuilder_ReloadThroughRegistry(t *testing.T) {
 	require.Contains(t, doc.SelectableFields, "spec.y")
 	require.NotContains(t, doc.SelectableFields, "spec.x")
 }
+
+// Tags come from spec.tags via the standard builder, so a kind gets them without
+// registering its own document builder. Before this, doc.Tags was only ever set by
+// the dashboard builder, and every other kind indexed with no tags at all — the
+// field was declared and mapped, but never populated.
+func TestStandardDocumentBuilder_Tags(t *testing.T) {
+	ctx := context.Background()
+	builder := StandardDocumentBuilder(nil)
+
+	key := &resourcepb.ResourceKey{
+		Namespace: "default",
+		Group:     "dashboard.grafana.app",
+		Resource:  "notebooks",
+		Name:      "nb1",
+	}
+
+	build := func(t *testing.T, spec string) *IndexableDocument {
+		t.Helper()
+		body := []byte(`{
+			"apiVersion": "dashboard.grafana.app/v2beta1",
+			"kind": "Notebook",
+			"metadata": {"name": "nb1"},
+			"spec": ` + spec + `
+		}`)
+		doc, err := builder.BuildDocument(ctx, key, 1, body)
+		require.NoError(t, err)
+		return doc
+	}
+
+	t.Run("reads spec.tags", func(t *testing.T) {
+		doc := build(t, `{"title": "Checkout latency", "tags": ["incident", "checkout"]}`)
+		assert.Equal(t, []string{"incident", "checkout"}, doc.Tags)
+	})
+
+	t.Run("leaves tags unset when there are none", func(t *testing.T) {
+		assert.Nil(t, build(t, `{"title": "No tags"}`).Tags, "absent")
+		assert.Nil(t, build(t, `{"title": "Empty", "tags": []}`).Tags, "empty list")
+	})
+
+	// One malformed entry should not cost the resource its place in the index, nor
+	// the tags around it.
+	t.Run("skips entries that are not usable strings", func(t *testing.T) {
+		doc := build(t, `{"title": "Mixed", "tags": ["good", 42, null, "", "also-good"]}`)
+		assert.Equal(t, []string{"good", "also-good"}, doc.Tags)
+	})
+
+	t.Run("ignores a tags value that is not a list", func(t *testing.T) {
+		assert.Nil(t, build(t, `{"title": "Wrong shape", "tags": "incident"}`).Tags)
+	})
+}


### PR DESCRIPTION
**What is this feature?**

Populates `doc.Tags` from `spec.tags` and `doc.Description` from `spec.description` in `NewIndexableDocument`, so a kind gets both indexed without needing its own document builder.

**Why do we need this feature?**

Both are declared standard search fields and mapped for every kind, but only ever assigned by the dashboard document builder (`builders/dashboard.go:138-139`). For every other kind — notebooks, playlists, folders, saved queries, annotations — tag filtering and faceting silently return nothing, and description is never searchable.

**Who is this feature for?**

Any kind with `spec.tags` or `spec.description` that doesn't have a custom document builder.

**Which issue(s) does this PR fix?**

<!-- Fixes # -->

**Special notes for your reviewer:**

- Dashboards are unaffected — their builder still overwrites both fields afterwards with the same values.
- No mapping change, so `IndexAffectingHash` does not move.
- Malformed input is skipped, not fatal: a non-list `tags`, a non-string entry, or a non-string `description` won't keep a resource out of the index.
- `TestStandardDocumentBuilder`'s golden document gains `"description"` because the playlist fixture carries one — the change working on a real non-dashboard kind.

**Rollout — the backfill needs a trigger**

Existing indexes only pick these up on the next write. `IndexAffectingHash` can't help (it returns `""` for kinds without manifest-declared `searchFields`, which is all of these), and non-dashboard indexes never age out (`max_file_index_age` defaults to `0`).

Proposing **`min_file_index_build_version`** bumped to the release carrying this: async, and it doesn't gate index use. I deliberately avoided an `IndexFeature` in `requiredIndexFeatures` — its own docs say to require only features "whose absence gives wrong answers, not one that only makes results incomplete", and this is the latter.

@pstibrany — could you confirm that bump, or point me at a mechanism you'd prefer?

Please check that:

- [ ] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
