### PR TITLE
Alerting: Make stage default import method in GMA import wizard

### DIFF
--- a/public/app/features/alerting/unified/components/import-to-gma/ImportToGMA.test.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ImportToGMA.test.tsx
@@ -7,6 +7,7 @@ import { AccessControlAction } from 'app/types/accessControl';
 
 import { setupMswServer } from '../../mockApi';
 import { grantUserPermissions } from '../../mocks';
+import { type AdminConfigPostState, setupAdminConfigPost } from '../../mocks/server/configure/admin_config';
 
 import { ImportWizardGate } from './ImportToGMA';
 
@@ -17,11 +18,15 @@ jest.mock('@grafana/runtime', () => ({
   reportInteraction: jest.fn(),
 }));
 
-// Seed a valid YAML notifications source (config + policy tree name + template files) and trigger the
-// dry-run, so the step reaches a passing validation state. Next is gated on a passing dry-run, so the
-// policy tree name and the onTriggerDryRun call are both required for the wizard to advance. The real
-// step body pulls in network-backed pickers we don't need — the assertion target is
-// handleConfirmImport's tracking payload, not the step UI.
+// Selects which fixture the mocked Step1Content below seeds. Prefixed `mock` per Jest's rule for
+// variables referenced from inside a jest.mock factory. Each describe block resets it in its own setup.
+let mockScenario: 'yaml' | 'auto-sync' = 'yaml';
+
+// Seeds either a valid YAML notifications source (config + policy tree name + template files, dry-run
+// triggered) or an Auto-sync-checked data source (dry-run never runs for that path). Next is gated on a
+// passing dry-run for the YAML fixture, so the policy tree name and the onTriggerDryRun call are both
+// required for the wizard to advance there. The real step body pulls in network-backed pickers we don't
+// need — the assertion target is handleConfirmImport's behavior, not the step UI.
 jest.mock('./steps/Step1AlertmanagerResources', () => {
   const { useEffect } = require('react');
   const { useFormContext } = require('react-hook-form');
@@ -29,6 +34,13 @@ jest.mock('./steps/Step1AlertmanagerResources', () => {
     Step1Content: function Step1Content({ onTriggerDryRun }: { onTriggerDryRun?: () => void }) {
       const { setValue } = useFormContext();
       useEffect(() => {
+        if (mockScenario === 'auto-sync') {
+          setValue('notificationsSource', 'datasource');
+          setValue('notificationsDatasourceUID', 'mimir-uid');
+          setValue('notificationsDatasourceName', 'Mimir Alertmanager');
+          setValue('autoSyncNotificationsEnabled', true);
+          return;
+        }
         setValue('notificationsSource', 'yaml');
         setValue('policyTreeName', 'prometheus-prod');
         setValue(
@@ -196,5 +208,89 @@ describe('ImportToGMA wizard — step 1 dry-run gating & review', () => {
 
     // The review notifications card lists the uploaded template files by name.
     expect(await screen.findByText('email.tmpl, slack.tmpl')).toBeInTheDocument();
+  });
+});
+
+describe('ImportToGMA wizard — auto-sync confirm flow', () => {
+  beforeEach(() => {
+    mockScenario = 'auto-sync';
+  });
+
+  afterEach(() => {
+    mockScenario = 'yaml';
+  });
+
+  /** Notifications -> Review, skipping Rules (force-skipped while Auto-sync is checked). */
+  async function advanceToReview(user: ReturnType<typeof render>['user']) {
+    await screen.findByRole('group', { name: /import notification resources/i });
+    await waitFor(() =>
+      expect(screen.getByTestId(selectors.pages.Alerting.ImportToGMA.nextButton)).toHaveAttribute(
+        'aria-disabled',
+        'false'
+      )
+    );
+    await user.click(screen.getByTestId(selectors.pages.Alerting.ImportToGMA.nextButton));
+    await screen.findByText(/review import/i);
+  }
+
+  it('skips the Rules step entirely and lands on Review', async () => {
+    const { user } = render(<ImportWizardGate />);
+
+    await advanceToReview(user);
+
+    expect(screen.queryByRole('group', { name: /import alert rules/i })).not.toBeInTheDocument();
+    expect(screen.getByText(/will sync continuously/i)).toBeInTheDocument();
+  });
+
+  it('calls saveAutoSync (not the staging import) and tracks success on confirm', async () => {
+    const postState: AdminConfigPostState = { lastPayload: null };
+    setupAdminConfigPost(server, postState, 200);
+    let stagingImportCalled = false;
+    server.use(
+      http.post(CONVERT_URL, () => {
+        stagingImportCalled = true;
+        return HttpResponse.json({ status: 'success' });
+      })
+    );
+
+    const { user } = render(<ImportWizardGate />);
+    await advanceToReview(user);
+
+    await user.click(screen.getByRole('button', { name: /enable auto-sync/i }));
+    const dialog = await screen.findByRole('dialog');
+    await user.click(within(dialog).getByRole('button', { name: /enable auto-sync/i }));
+
+    await waitFor(() => expect(postState.lastPayload).toEqual({ external_alertmanager_uid: 'mimir-uid' }));
+    expect(stagingImportCalled).toBe(false);
+    await waitFor(() =>
+      expect(mockReportInteraction).toHaveBeenCalledWith(
+        'grafana_alerting_import_to_gma_success',
+        expect.objectContaining({ notificationsSource: 'datasource' })
+      )
+    );
+    await waitFor(() => expect(locationService.getLocation().pathname).toContain('/alerting/admin/import'), {
+      timeout: 3000,
+    });
+  });
+
+  it('tracks an error and does not fall through to the staging import path when saveAutoSync fails', async () => {
+    const postState: AdminConfigPostState = { lastPayload: null };
+    setupAdminConfigPost(server, postState, 500);
+
+    const { user } = render(<ImportWizardGate />);
+    await advanceToReview(user);
+
+    await user.click(screen.getByRole('button', { name: /enable auto-sync/i }));
+    const dialog = await screen.findByRole('dialog');
+    await user.click(within(dialog).getByRole('button', { name: /enable auto-sync/i }));
+
+    await waitFor(() =>
+      expect(mockReportInteraction).toHaveBeenCalledWith(
+        'grafana_alerting_import_to_gma_error',
+        expect.objectContaining({ notificationsSource: 'datasource' })
+      )
+    );
+    expect(mockReportInteraction).not.toHaveBeenCalledWith('grafana_alerting_import_to_gma_success', expect.anything());
+    expect(within(dialog).getByText(/failed to enable auto-sync/i)).toBeInTheDocument();
   });
 });

--- a/public/app/features/alerting/unified/components/import-to-gma/ImportToGMA.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ImportToGMA.tsx
@@ -1,13 +1,14 @@
 import { css } from '@emotion/css';
 import { isEmpty } from 'lodash';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { FormProvider, useForm } from 'react-hook-form';
+import { FormProvider, useForm, useFormContext } from 'react-hook-form';
 
 import { type GrafanaTheme2, OrgRole } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config, locationService } from '@grafana/runtime';
 import {
   Alert,
+  Badge,
   Box,
   Button,
   CodeEditor,
@@ -46,6 +47,7 @@ import { createRelativeUrl } from '../../utils/url';
 import { withPageErrorBoundary } from '../../withPageErrorBoundary';
 import { AlertingPageWrapper } from '../AlertingPageWrapper';
 import { useGetRulerRules } from '../rule-editor/useAlertRuleSuggestions';
+import { useAutoSyncConfiguration } from '../settings/useAutoSyncConfiguration';
 
 import { RenamedResourcesList } from './CollapsibleRenameList';
 import { PolicyTreeNameHelp } from './PolicyTreeNameHelp';
@@ -53,7 +55,7 @@ import { CancelButton } from './Wizard/CancelButton';
 import { StepperStateProvider, useStepperState } from './Wizard/StepperState';
 import { WizardLayout } from './Wizard/WizardLayout';
 import { WizardStep } from './Wizard/WizardStep';
-import { getPauseRulesLabel } from './Wizard/steps';
+import { getPauseRulesLabel, isRulesForcedSkipped } from './Wizard/steps';
 import { StepKey } from './Wizard/types';
 import { Step1Content, useStep1Validation } from './steps/Step1AlertmanagerResources';
 import { Step2Content, useStep2Validation } from './steps/Step2AlertRules';
@@ -82,6 +84,8 @@ export interface ImportFormValues {
   notificationsDatasourceName: string | null;
   notificationsYamlFile: File | null;
   notificationsTemplateFiles: File[];
+  /** Checked in Step 1 when the source is a data source; enables continuous sync instead of staging. */
+  autoSyncNotificationsEnabled?: boolean;
 
   // Step 2: Alert rules
   step2Completed: boolean;
@@ -213,6 +217,7 @@ function ImportWizardContent() {
 
   const importNotifications = useImportNotifications();
   const importRules = useImportRules();
+  const { save: saveAutoSync } = useAutoSyncConfiguration();
   const notifyApp = useAppNotification();
 
   const formAPI = useForm<ImportFormValues>({
@@ -226,6 +231,7 @@ function ImportWizardContent() {
       notificationsDatasourceName: null,
       notificationsYamlFile: null,
       notificationsTemplateFiles: [],
+      autoSyncNotificationsEnabled: false,
       // Step 2
       step2Completed: false,
       step2Skipped: false,
@@ -332,6 +338,10 @@ function ImportWizardContent() {
 
   // Get ruler rules for rules import (needed when importing from datasource)
   const formValues = getValues();
+  const autoSyncActive = isRulesForcedSkipped(
+    formValues.autoSyncNotificationsEnabled ?? false,
+    formValues.notificationsSource
+  );
   const shouldFetchRules =
     formValues.step2Completed && !formValues.step2Skipped && formValues.rulesSource === 'datasource';
   const { rulerRules: rulesFromDatasource } = useGetRulerRules(
@@ -348,6 +358,31 @@ function ImportWizardContent() {
     const values = getValues();
     const willImportNotifications = values.step1Completed && !values.step1Skipped;
     const willImportRules = values.step2Completed && !values.step2Skipped;
+
+    // Auto-sync replaces staging entirely; `save()` already toasts, so this must not also fall
+    // into the catch below or the user sees two toasts for one outcome.
+    if (isRulesForcedSkipped(values.autoSyncNotificationsEnabled ?? false, values.notificationsSource)) {
+      const enabled = await saveAutoSync(values.notificationsDatasourceUID);
+      if (enabled) {
+        setImportStatus('success');
+        trackImportToGMASuccess({ notificationsSource: values.notificationsSource });
+        setTimeout(() => {
+          setShowConfirmModal(false);
+          notifyApp.success(
+            t('alerting.wizard-import-to-gma.autosync-success-title', 'Auto-sync enabled'),
+            t(
+              'alerting.wizard-import-to-gma.autosync-success-body',
+              'Grafana will keep syncing alert configuration from this data source.'
+            )
+          );
+          locationService.push(ALERTING_IMPORT_SETTINGS_URL);
+        }, 1500);
+      } else {
+        setImportStatus('error');
+        trackImportToGMAError({ notificationsSource: values.notificationsSource });
+      }
+      return;
+    }
 
     try {
       // Import notifications first (if step 1 was completed)
@@ -435,7 +470,7 @@ function ImportWizardContent() {
       });
       notifyApp.error(t('alerting.wizard-import-to-gma.error', 'Failed to import resources'), stringifyErrorLike(err));
     }
-  }, [getValues, importNotifications, importRules, rulesFromDatasource, notifyApp]);
+  }, [getValues, importNotifications, importRules, rulesFromDatasource, saveAutoSync, notifyApp]);
 
   const handleCancelConfirm = useCallback(() => {
     // Only allow closing if not importing
@@ -513,6 +548,7 @@ function ImportWizardContent() {
       <ConfirmImportModal
         isOpen={showConfirmModal}
         importStatus={importStatus}
+        autoSyncActive={autoSyncActive}
         onConfirm={handleConfirmImport}
         onDismiss={handleCancelConfirm}
       />
@@ -545,10 +581,15 @@ function Step1Wrapper({
   onResetDryRun,
 }: Step1WrapperProps) {
   const isStep1Valid = useStep1Validation(canImport);
-  // Only advance once a dry-run has actually passed for the current inputs. An `idle`/`loading` state
-  // means the config hasn't been validated yet, so it must not count as "ready to import".
+  const { watch } = useFormContext<ImportFormValues>();
+  const [autoSyncNotificationsEnabled, notificationsSource] = watch([
+    'autoSyncNotificationsEnabled',
+    'notificationsSource',
+  ]);
+  const autoSyncActive = isRulesForcedSkipped(autoSyncNotificationsEnabled ?? false, notificationsSource);
+  // Advance only once dry-run passes; Auto-sync skips it entirely and relies on validity alone.
   const dryRunPassed = dryRunState === 'success' || dryRunState === 'warning';
-  const canProceed = isStep1Valid && dryRunPassed;
+  const canProceed = autoSyncActive ? isStep1Valid : isStep1Valid && dryRunPassed;
 
   return (
     <WizardStep
@@ -677,6 +718,142 @@ const getValidationIndicatorStyles = (theme: GrafanaTheme2) => ({
   errorIcon: css({ color: theme.colors.error.main }),
 });
 
+interface NotificationsCardContentProps {
+  formData: ImportFormValues;
+  autoSyncActive: boolean;
+  willImportNotifications: boolean;
+  dryRunResult?: DryRunValidationResult;
+  styles: ReturnType<typeof getStyles>;
+}
+
+function NotificationsCardContent({
+  formData,
+  autoSyncActive,
+  willImportNotifications,
+  dryRunResult,
+  styles,
+}: NotificationsCardContentProps) {
+  if (!willImportNotifications) {
+    return (
+      <Text color="secondary">
+        <Trans i18nKey="alerting.import-to-gma.review.notifications-skipped">
+          Notification resources will not be imported.
+        </Trans>
+      </Text>
+    );
+  }
+
+  if (autoSyncActive) {
+    return (
+      <div className={styles.row}>
+        <Text color="secondary">{t('alerting.import-to-gma.review.source', 'Source')}</Text>
+        <Text>{formData.notificationsDatasourceName || 'Data source'}</Text>
+      </div>
+    );
+  }
+
+  return (
+    <Stack direction="column" gap={1}>
+      <div className={styles.row}>
+        <Text color="secondary">{t('alerting.import-to-gma.review.source', 'Source')}</Text>
+        <Text>
+          {formData.notificationsSource === 'yaml'
+            ? formData.notificationsYamlFile?.name || 'YAML file'
+            : formData.notificationsDatasourceName || 'Data source'}
+        </Text>
+      </div>
+      {/* Uploaded template files only apply to the YAML source; list them so the user can confirm
+          which templates will be imported. */}
+      {formData.notificationsSource === 'yaml' && formData.notificationsTemplateFiles.length > 0 && (
+        <div className={styles.row}>
+          <Text color="secondary">{t('alerting.import-to-gma.review.templates', 'Templates')}</Text>
+          <Text>{formData.notificationsTemplateFiles.map((file) => file.name).join(', ')}</Text>
+        </div>
+      )}
+      <div className={styles.row}>
+        <Text color="secondary">{t('alerting.import-to-gma.review.policy-tree', 'Policy tree')}</Text>
+        <Stack direction="row" gap={1} alignItems="center" wrap="wrap">
+          <Text weight="medium">{formData.policyTreeName}</Text>
+          <PolicyTreeNameHelp />
+        </Stack>
+      </div>
+      {dryRunResult && (
+        <Box marginTop={1}>
+          <ValidationStatusIndicator result={dryRunResult} />
+        </Box>
+      )}
+    </Stack>
+  );
+}
+
+interface RulesCardContentProps {
+  formData: ImportFormValues;
+  autoSyncActive: boolean;
+  willImportRules: boolean;
+  styles: ReturnType<typeof getStyles>;
+}
+
+function RulesCardContent({ formData, autoSyncActive, willImportRules, styles }: RulesCardContentProps) {
+  if (autoSyncActive) {
+    return null;
+  }
+
+  if (!willImportRules) {
+    return (
+      <Text color="secondary">
+        <Trans i18nKey="alerting.import-to-gma.review.rules-skipped">Alert rules will not be imported.</Trans>
+      </Text>
+    );
+  }
+
+  return (
+    <Stack direction="column" gap={1}>
+      <div className={styles.row}>
+        <Text color="secondary">{t('alerting.import-to-gma.review.source', 'Source')}</Text>
+        <Text>
+          {formData.rulesSource === 'yaml'
+            ? formData.rulesYamlFile?.name || 'YAML file'
+            : formData.rulesDatasourceName || 'Data source'}
+        </Text>
+      </div>
+      <div className={styles.row}>
+        <Text color="secondary">{t('alerting.import-to-gma.review.routing', 'Notification routing')}</Text>
+        <Text>
+          {formData.selectedRoutingTree
+            ? t('alerting.import-to-gma.review.routing-tree', 'Policy tree: {{name}}', {
+                name: getRoutingTreeLabel(formData.selectedRoutingTree),
+              })
+            : t('alerting.import-to-gma.review.routing-none', 'No policy tree selected')}
+        </Text>
+      </div>
+      {(formData.namespace || formData.ruleGroup) && (
+        <div className={styles.row}>
+          <Text color="secondary">{t('alerting.import-to-gma.review.filter', 'Filter')}</Text>
+          <Text>
+            {formData.namespace &&
+              !formData.ruleGroup &&
+              `${t('alerting.import-to-gma.review.namespace', 'Namespace')}: ${formData.namespace}`}
+            {formData.namespace && formData.ruleGroup && `${formData.namespace} / ${formData.ruleGroup}`}
+          </Text>
+        </div>
+      )}
+      {formData.targetFolder && (
+        <div className={styles.row}>
+          <Text color="secondary">{t('alerting.import-to-gma.review.folder', 'Target folder')}</Text>
+          <Text>{formData.targetFolder.title}</Text>
+        </div>
+      )}
+      <div className={styles.row}>
+        <Text color="secondary">{t('alerting.import-to-gma.review.pause', 'Pause rules')}</Text>
+        <Stack direction="row" gap={0.5} alignItems="center">
+          {(formData.pauseAlertingRules || formData.pauseRecordingRules) && <Icon name="pause" size="sm" />}
+          <Text>{getPauseRulesLabel(formData.pauseAlertingRules, formData.pauseRecordingRules)}</Text>
+        </Stack>
+      </div>
+    </Stack>
+  );
+}
+
 // Review Step Component
 interface ReviewStepProps {
   formData: ImportFormValues;
@@ -700,9 +877,14 @@ function ReviewStep({ formData, onStartImport, onCancel, dryRunResult, rulesFrom
   const willImportNotifications = formData.step1Completed && !formData.step1Skipped;
   const willImportRules = formData.step2Completed && !formData.step2Skipped;
   const nothingToImport = !willImportNotifications && !willImportRules;
+  const autoSyncActive = isRulesForcedSkipped(
+    formData.autoSyncNotificationsEnabled ?? false,
+    formData.notificationsSource
+  );
 
+  // Rules is unreachable while Auto-sync is active, so Back must land on Notifications instead.
   const handleBack = () => {
-    setActiveStep(StepKey.Rules);
+    setActiveStep(autoSyncActive ? StepKey.Notifications : StepKey.Rules);
   };
 
   // Load notifications preview content
@@ -798,7 +980,14 @@ function ReviewStep({ formData, onStartImport, onCancel, dryRunResult, rulesFrom
               <Text variant="h5" element="h3">
                 {t('alerting.import-to-gma.review.notifications-title', 'Notification Resources')}
               </Text>
-              {willImportNotifications && (
+              {autoSyncActive && (
+                <Badge
+                  color="green"
+                  icon="sync"
+                  text={t('alerting.import-to-gma.review.autosync-badge', 'Will sync continuously')}
+                />
+              )}
+              {!autoSyncActive && willImportNotifications && (
                 <button type="button" className={styles.badgeWithIcon} onClick={handlePreviewNotifications}>
                   {t('alerting.import-to-gma.review.will-import-config', 'Will import this configuration')}
                   <Icon name="eye" size="sm" />
@@ -809,44 +998,13 @@ function ReviewStep({ formData, onStartImport, onCancel, dryRunResult, rulesFrom
               )}
             </div>
             <div className={styles.cardContent}>
-              {willImportNotifications ? (
-                <Stack direction="column" gap={1}>
-                  <div className={styles.row}>
-                    <Text color="secondary">{t('alerting.import-to-gma.review.source', 'Source')}</Text>
-                    <Text>
-                      {formData.notificationsSource === 'yaml'
-                        ? formData.notificationsYamlFile?.name || 'YAML file'
-                        : formData.notificationsDatasourceName || 'Data source'}
-                    </Text>
-                  </div>
-                  {/* Uploaded template files only apply to the YAML source; list them so the user can
-                      confirm which templates will be imported. */}
-                  {formData.notificationsSource === 'yaml' && formData.notificationsTemplateFiles.length > 0 && (
-                    <div className={styles.row}>
-                      <Text color="secondary">{t('alerting.import-to-gma.review.templates', 'Templates')}</Text>
-                      <Text>{formData.notificationsTemplateFiles.map((file) => file.name).join(', ')}</Text>
-                    </div>
-                  )}
-                  <div className={styles.row}>
-                    <Text color="secondary">{t('alerting.import-to-gma.review.policy-tree', 'Policy tree')}</Text>
-                    <Stack direction="row" gap={1} alignItems="center" wrap="wrap">
-                      <Text weight="medium">{formData.policyTreeName}</Text>
-                      <PolicyTreeNameHelp />
-                    </Stack>
-                  </div>
-                  {dryRunResult && (
-                    <Box marginTop={1}>
-                      <ValidationStatusIndicator result={dryRunResult} />
-                    </Box>
-                  )}
-                </Stack>
-              ) : (
-                <Text color="secondary">
-                  <Trans i18nKey="alerting.import-to-gma.review.notifications-skipped">
-                    Notification resources will not be imported.
-                  </Trans>
-                </Text>
-              )}
+              <NotificationsCardContent
+                formData={formData}
+                autoSyncActive={autoSyncActive}
+                willImportNotifications={willImportNotifications}
+                dryRunResult={dryRunResult}
+                styles={styles}
+              />
             </div>
           </div>
 
@@ -856,7 +1014,14 @@ function ReviewStep({ formData, onStartImport, onCancel, dryRunResult, rulesFrom
               <Text variant="h5" element="h3">
                 {t('alerting.import-to-gma.review.rules-title', 'Alert Rules')}
               </Text>
-              {willImportRules && (
+              {autoSyncActive && (
+                <Badge
+                  color="green"
+                  icon="sync"
+                  text={t('alerting.import-to-gma.review.rules-autosync-badge', 'Syncs automatically')}
+                />
+              )}
+              {!autoSyncActive && willImportRules && (
                 <button type="button" className={styles.badgeWithIcon} onClick={handlePreviewRules}>
                   {rulesCount > 0
                     ? t('alerting.import-to-gma.review.will-import-rules-count', '', {
@@ -868,61 +1033,17 @@ function ReviewStep({ formData, onStartImport, onCancel, dryRunResult, rulesFrom
                   <Icon name="eye" size="sm" />
                 </button>
               )}
-              {formData.step2Skipped && (
+              {!autoSyncActive && formData.step2Skipped && (
                 <span className={styles.badgeSkipped}>{t('alerting.import-to-gma.review.skipped', 'Skipped')}</span>
               )}
             </div>
             <div className={styles.cardContent}>
-              {willImportRules ? (
-                <Stack direction="column" gap={1}>
-                  <div className={styles.row}>
-                    <Text color="secondary">{t('alerting.import-to-gma.review.source', 'Source')}</Text>
-                    <Text>
-                      {formData.rulesSource === 'yaml'
-                        ? formData.rulesYamlFile?.name || 'YAML file'
-                        : formData.rulesDatasourceName || 'Data source'}
-                    </Text>
-                  </div>
-                  <div className={styles.row}>
-                    <Text color="secondary">{t('alerting.import-to-gma.review.routing', 'Notification routing')}</Text>
-                    <Text>
-                      {formData.selectedRoutingTree
-                        ? t('alerting.import-to-gma.review.routing-tree', 'Policy tree: {{name}}', {
-                            name: getRoutingTreeLabel(formData.selectedRoutingTree),
-                          })
-                        : t('alerting.import-to-gma.review.routing-none', 'No policy tree selected')}
-                    </Text>
-                  </div>
-                  {(formData.namespace || formData.ruleGroup) && (
-                    <div className={styles.row}>
-                      <Text color="secondary">{t('alerting.import-to-gma.review.filter', 'Filter')}</Text>
-                      <Text>
-                        {formData.namespace &&
-                          !formData.ruleGroup &&
-                          `${t('alerting.import-to-gma.review.namespace', 'Namespace')}: ${formData.namespace}`}
-                        {formData.namespace && formData.ruleGroup && `${formData.namespace} / ${formData.ruleGroup}`}
-                      </Text>
-                    </div>
-                  )}
-                  {formData.targetFolder && (
-                    <div className={styles.row}>
-                      <Text color="secondary">{t('alerting.import-to-gma.review.folder', 'Target folder')}</Text>
-                      <Text>{formData.targetFolder.title}</Text>
-                    </div>
-                  )}
-                  <div className={styles.row}>
-                    <Text color="secondary">{t('alerting.import-to-gma.review.pause', 'Pause rules')}</Text>
-                    <Stack direction="row" gap={0.5} alignItems="center">
-                      {(formData.pauseAlertingRules || formData.pauseRecordingRules) && <Icon name="pause" size="sm" />}
-                      <Text>{getPauseRulesLabel(formData.pauseAlertingRules, formData.pauseRecordingRules)}</Text>
-                    </Stack>
-                  </div>
-                </Stack>
-              ) : (
-                <Text color="secondary">
-                  <Trans i18nKey="alerting.import-to-gma.review.rules-skipped">Alert rules will not be imported.</Trans>
-                </Text>
-              )}
+              <RulesCardContent
+                formData={formData}
+                autoSyncActive={autoSyncActive}
+                willImportRules={willImportRules}
+                styles={styles}
+              />
             </div>
           </div>
         </Stack>
@@ -932,10 +1053,19 @@ function ReviewStep({ formData, onStartImport, onCancel, dryRunResult, rulesFrom
       <Stack direction="row" justifyContent="space-between" alignItems="center">
         <Stack direction="row" gap={1}>
           <Button variant="secondary" icon="arrow-left" onClick={handleBack}>
-            {t('alerting.import-to-gma.review.back', 'Alert rules')}
+            {autoSyncActive
+              ? t('alerting.import-to-gma.review.back-notifications', 'Notification resources')
+              : t('alerting.import-to-gma.review.back', 'Alert rules')}
           </Button>
-          <Button variant="primary" icon="upload" onClick={onStartImport} disabled={nothingToImport}>
-            {t('alerting.import-to-gma.review.start', 'Start import')}
+          <Button
+            variant="primary"
+            icon={autoSyncActive ? 'sync' : 'upload'}
+            onClick={onStartImport}
+            disabled={nothingToImport}
+          >
+            {autoSyncActive
+              ? t('alerting.import-to-gma.review.enable-autosync', 'Enable auto-sync')
+              : t('alerting.import-to-gma.review.start', 'Start import')}
           </Button>
         </Stack>
         <CancelButton onCancel={onCancel} />
@@ -1026,46 +1156,70 @@ const getPreviewModalStyles = (theme: GrafanaTheme2) => ({
 interface ConfirmImportModalProps {
   isOpen: boolean;
   importStatus: 'idle' | 'importing' | 'success' | 'error';
+  /** Swaps the generic staging copy for Auto-sync-specific copy. */
+  autoSyncActive: boolean;
   onConfirm: () => void;
   onDismiss: () => void;
 }
 
-function ConfirmImportModal({ isOpen, importStatus, onConfirm, onDismiss }: ConfirmImportModalProps) {
+function ConfirmImportModal({ isOpen, importStatus, autoSyncActive, onConfirm, onDismiss }: ConfirmImportModalProps) {
   const isImporting = importStatus === 'importing';
   const isSuccess = importStatus === 'success';
   const isError = importStatus === 'error';
 
   const getTitle = () => {
     if (isImporting) {
-      return t('alerting.import-to-gma.confirm.importing-title', 'Importing...');
+      return autoSyncActive
+        ? t('alerting.import-to-gma.confirm.autosync-importing-title', 'Enabling auto-sync...')
+        : t('alerting.import-to-gma.confirm.importing-title', 'Importing...');
     }
     if (isSuccess) {
-      return t('alerting.import-to-gma.confirm.success-title', 'Import Successful');
+      return autoSyncActive
+        ? t('alerting.import-to-gma.confirm.autosync-success-title', 'Auto-sync Enabled')
+        : t('alerting.import-to-gma.confirm.success-title', 'Import Successful');
     }
     if (isError) {
-      return t('alerting.import-to-gma.confirm.error-title', 'Import Failed');
+      return autoSyncActive
+        ? t('alerting.import-to-gma.confirm.autosync-error-title', 'Auto-sync Failed')
+        : t('alerting.import-to-gma.confirm.error-title', 'Import Failed');
     }
-    return t('alerting.import-to-gma.confirm.title', 'Confirm Import');
+    return autoSyncActive
+      ? t('alerting.import-to-gma.confirm.autosync-title', 'Confirm Auto-sync')
+      : t('alerting.import-to-gma.confirm.title', 'Confirm Import');
   };
 
   return (
     <Modal isOpen={isOpen} title={getTitle()} onDismiss={onDismiss}>
       <Stack direction="column" gap={2}>
-        {importStatus === 'idle' && (
-          <Text>
-            <Trans i18nKey="alerting.import-to-gma.confirm.body">
-              Are you sure you want to start the import? This action will create new resources in Grafana Alerting.
-            </Trans>
-          </Text>
-        )}
+        {importStatus === 'idle' &&
+          (autoSyncActive ? (
+            <Text>
+              <Trans i18nKey="alerting.import-to-gma.confirm.autosync-body">
+                Are you sure you want to enable Auto-sync? Grafana will continuously sync alert configuration from this
+                data source until you turn it off in Alerting settings.
+              </Trans>
+            </Text>
+          ) : (
+            <Text>
+              <Trans i18nKey="alerting.import-to-gma.confirm.body">
+                Are you sure you want to start the import? This action will create new resources in Grafana Alerting.
+              </Trans>
+            </Text>
+          ))}
 
         {isImporting && (
           <Stack direction="row" gap={2} alignItems="center">
             <Spinner />
             <Text>
-              <Trans i18nKey="alerting.import-to-gma.confirm.importing-body">
-                Importing resources to Grafana Alerting. Please wait...
-              </Trans>
+              {autoSyncActive ? (
+                <Trans i18nKey="alerting.import-to-gma.confirm.autosync-importing-body">
+                  Enabling Auto-sync. Please wait...
+                </Trans>
+              ) : (
+                <Trans i18nKey="alerting.import-to-gma.confirm.importing-body">
+                  Importing resources to Grafana Alerting. Please wait...
+                </Trans>
+              )}
             </Text>
           </Stack>
         )}
@@ -1074,18 +1228,30 @@ function ConfirmImportModal({ isOpen, importStatus, onConfirm, onDismiss }: Conf
           <Stack direction="row" gap={2} alignItems="center">
             <Icon name="check-circle" size="xl" color="green" />
             <Text>
-              <Trans i18nKey="alerting.import-to-gma.confirm.success-body">
-                Resources imported successfully. Redirecting...
-              </Trans>
+              {autoSyncActive ? (
+                <Trans i18nKey="alerting.import-to-gma.confirm.autosync-success-body">
+                  Auto-sync enabled. Redirecting...
+                </Trans>
+              ) : (
+                <Trans i18nKey="alerting.import-to-gma.confirm.success-body">
+                  Resources imported successfully. Redirecting...
+                </Trans>
+              )}
             </Text>
           </Stack>
         )}
 
         {isError && (
           <Text color="error">
-            <Trans i18nKey="alerting.import-to-gma.confirm.error-body">
-              Failed to import resources. Please check the error details and try again.
-            </Trans>
+            {autoSyncActive ? (
+              <Trans i18nKey="alerting.import-to-gma.confirm.autosync-error-body">
+                Failed to enable Auto-sync. Please check the error details and try again.
+              </Trans>
+            ) : (
+              <Trans i18nKey="alerting.import-to-gma.confirm.error-body">
+                Failed to import resources. Please check the error details and try again.
+              </Trans>
+            )}
           </Text>
         )}
       </Stack>
@@ -1097,7 +1263,9 @@ function ConfirmImportModal({ isOpen, importStatus, onConfirm, onDismiss }: Conf
               {t('alerting.common.cancel', 'Cancel')}
             </Button>
             <Button variant="primary" fill="solid" onClick={onConfirm}>
-              {t('alerting.import-to-gma.confirm.confirm', 'Start Import')}
+              {autoSyncActive
+                ? t('alerting.import-to-gma.confirm.autosync-confirm', 'Enable auto-sync')
+                : t('alerting.import-to-gma.confirm.confirm', 'Start Import')}
             </Button>
           </>
         )}

--- a/public/app/features/alerting/unified/components/import-to-gma/Wizard/NextButton.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/Wizard/NextButton.tsx
@@ -4,6 +4,7 @@ import { Button, Stack } from '@grafana/ui';
 
 import { useStepperState } from './StepperState';
 import { getNextStep, isLastStep } from './steps';
+import { useIsRulesForcedSkipped } from './useIsRulesForcedSkipped';
 
 interface NextButtonProps {
   /** Handler called when clicking next - should return true to proceed */
@@ -26,7 +27,8 @@ interface NextButtonProps {
  */
 export const NextButton = ({ onNext, canSkip, skipLabel, onSkip, disabled, disabledTooltip }: NextButtonProps) => {
   const { activeStep, setActiveStep } = useStepperState();
-  const nextStep = getNextStep(activeStep);
+  const rulesForcedSkipped = useIsRulesForcedSkipped();
+  const nextStep = getNextStep(activeStep, rulesForcedSkipped);
   const isLast = isLastStep(activeStep);
 
   const handleClick = async () => {

--- a/public/app/features/alerting/unified/components/import-to-gma/Wizard/PreviousButton.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/Wizard/PreviousButton.tsx
@@ -3,6 +3,7 @@ import { Button } from '@grafana/ui';
 import { useStepperState } from './StepperState';
 import { getPreviousStep } from './steps';
 import { StepKey } from './types';
+import { useIsRulesForcedSkipped } from './useIsRulesForcedSkipped';
 
 interface PreviousButtonProps {
   /** Handler called when clicking back */
@@ -15,7 +16,8 @@ interface PreviousButtonProps {
  */
 export const PreviousButton = ({ onBack }: PreviousButtonProps) => {
   const { activeStep, setActiveStep, setVisitedStep } = useStepperState();
-  const previousStep = getPreviousStep(activeStep);
+  const rulesForcedSkipped = useIsRulesForcedSkipped();
+  const previousStep = getPreviousStep(activeStep, rulesForcedSkipped);
   const isFirst = activeStep === StepKey.Notifications;
 
   const handleClick = () => {

--- a/public/app/features/alerting/unified/components/import-to-gma/Wizard/Stepper.test.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/Wizard/Stepper.test.tsx
@@ -1,12 +1,34 @@
 import { useEffect } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
 import { render, screen, userEvent } from 'test/test-utils';
 
 import { Stepper } from './Stepper';
 import { StepperStateProvider, useStepperState } from './StepperState';
-import { StepKey } from './types';
+import { StepKey, type WizardFormValues } from './types';
 
-const renderWithProvider = (ui: React.ReactElement, initialStep?: StepKey) => {
-  return render(<StepperStateProvider initialStep={initialStep}>{ui}</StepperStateProvider>);
+function FormWrapper({
+  children,
+  autoSyncNotificationsEnabled = false,
+  notificationsSource = 'yaml',
+}: {
+  children: React.ReactNode;
+  autoSyncNotificationsEnabled?: boolean;
+  notificationsSource?: 'yaml' | 'datasource';
+}) {
+  const formAPI = useForm<WizardFormValues>({ defaultValues: { autoSyncNotificationsEnabled, notificationsSource } });
+  return <FormProvider {...formAPI}>{children}</FormProvider>;
+}
+
+const renderWithProvider = (
+  ui: React.ReactElement,
+  initialStep?: StepKey,
+  formValues?: { autoSyncNotificationsEnabled?: boolean; notificationsSource?: 'yaml' | 'datasource' }
+) => {
+  return render(
+    <FormWrapper {...formValues}>
+      <StepperStateProvider initialStep={initialStep}>{ui}</StepperStateProvider>
+    </FormWrapper>
+  );
 };
 
 describe('Stepper', () => {
@@ -208,5 +230,58 @@ describe('Stepper', () => {
     const svg = indicator?.querySelector('svg');
     expect(svg).toBeInTheDocument();
     expect(indicator).not.toHaveTextContent('1');
+  });
+
+  describe('Rules force-skipped by Auto-sync', () => {
+    it('renders Rules with strikethrough and disabled when Auto-sync is checked for the datasource source', () => {
+      renderWithProvider(<Stepper />, StepKey.Notifications, {
+        autoSyncNotificationsEnabled: true,
+        notificationsSource: 'datasource',
+      });
+
+      const rulesButton = screen.getByRole('button', { name: /alert rules/i });
+      expect(rulesButton).toBeDisabled();
+      expect(rulesButton).toHaveStyle('text-decoration: line-through');
+    });
+
+    it('does not force-skip Rules when Auto-sync is checked but the source is YAML', () => {
+      const TestComponent = () => {
+        const { setStepCompleted, setVisitedStep } = useStepperState();
+        useEffect(() => {
+          setVisitedStep(StepKey.Notifications);
+          setStepCompleted(StepKey.Notifications, true);
+        }, [setStepCompleted, setVisitedStep]);
+        return <Stepper />;
+      };
+
+      renderWithProvider(<TestComponent />, StepKey.Notifications, {
+        autoSyncNotificationsEnabled: true,
+        notificationsSource: 'yaml',
+      });
+
+      const rulesButton = screen.getByRole('button', { name: /alert rules/i });
+      expect(rulesButton).toBeEnabled();
+      expect(rulesButton).not.toHaveStyle('text-decoration: line-through');
+    });
+
+    it('restores Rules to normal once Auto-sync is unchecked', () => {
+      const TestComponent = () => {
+        const { setStepCompleted, setVisitedStep } = useStepperState();
+        useEffect(() => {
+          setVisitedStep(StepKey.Notifications);
+          setStepCompleted(StepKey.Notifications, true);
+        }, [setStepCompleted, setVisitedStep]);
+        return <Stepper />;
+      };
+
+      renderWithProvider(<TestComponent />, StepKey.Notifications, {
+        autoSyncNotificationsEnabled: false,
+        notificationsSource: 'datasource',
+      });
+
+      const rulesButton = screen.getByRole('button', { name: /alert rules/i });
+      expect(rulesButton).toBeEnabled();
+      expect(rulesButton).not.toHaveStyle('text-decoration: line-through');
+    });
   });
 });

--- a/public/app/features/alerting/unified/components/import-to-gma/Wizard/Stepper.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/Wizard/Stepper.tsx
@@ -5,19 +5,22 @@ import { Icon, useStyles2 } from '@grafana/ui';
 
 import { useStepperState } from './StepperState';
 import { getWizardSteps } from './steps';
-import { type StepKey, StepState } from './types';
+import { StepKey, StepState } from './types';
+import { useIsRulesForcedSkipped } from './useIsRulesForcedSkipped';
 
 /**
  * Stepper component - sidebar navigation for the wizard
  * - Completed without errors: green check icon
  * - Completed with errors/warnings: yellow warning icon
  * - Skipped: minus icon
+ * - Force-skipped (Auto-sync makes Rules redundant): minus icon, strikethrough, unclickable
  * - Pending: number
  */
 export const Stepper = () => {
   const styles = useStyles2(getStyles);
   const { activeStep, setActiveStep, setVisitedStep, visitedSteps, isStepCompleted, isStepSkipped, hasStepErrors } =
     useStepperState();
+  const rulesForcedSkipped = useIsRulesForcedSkipped();
 
   const steps = getWizardSteps();
   const lastStep = steps[steps.length - 1];
@@ -29,6 +32,10 @@ export const Stepper = () => {
   };
 
   const canNavigateToStep = (stepId: StepKey): boolean => {
+    if (stepId === StepKey.Rules && rulesForcedSkipped) {
+      return false;
+    }
+
     const stepIndex = steps.findIndex((s) => s.id === stepId);
     const activeIndex = steps.findIndex((s) => s.id === activeStep);
 
@@ -55,16 +62,17 @@ export const Stepper = () => {
         const isVisited = visitedSteps[step.id] === StepState.Visited;
         const isCompleted = isStepCompleted(step.id);
         const isSkipped = isStepSkipped(step.id);
+        const isForcedSkipped = step.id === StepKey.Rules && rulesForcedSkipped;
         const hasErrors = hasStepErrors(step.id);
         const canNavigate = canNavigateToStep(step.id);
 
         // Determine visual state
         // - Warning: visited, not current, not last, has validation errors
         // - Success: visited, not current, not last, completed without errors
-        // - Skipped: skipped and not active
+        // - Skipped: skipped (manually or force-skipped) and not active
         const showWarning = isVisited && !isActive && !isLast && hasErrors;
         const showSuccess = isVisited && !isActive && !isLast && isCompleted && !hasErrors && !isSkipped;
-        const showSkipped = isSkipped && !isActive;
+        const showSkipped = (isSkipped || isForcedSkipped) && !isActive;
         const showNumber = !showWarning && !showSuccess && !showSkipped;
 
         const itemStyles = cx(styles.item, {
@@ -77,6 +85,7 @@ export const Stepper = () => {
               type="button"
               className={cx(styles.stepButton, {
                 [styles.stepButtonDisabled]: !canNavigate,
+                [styles.stepNameStrikethrough]: isForcedSkipped,
               })}
               onClick={() => handleStepClick(step.id)}
               disabled={!canNavigate}
@@ -139,6 +148,9 @@ const getStyles = (theme: GrafanaTheme2) => ({
     '&:hover': {
       color: 'inherit',
     },
+  }),
+  stepNameStrikethrough: css({
+    textDecoration: 'line-through',
   }),
   indicator: css({
     display: 'flex',

--- a/public/app/features/alerting/unified/components/import-to-gma/Wizard/steps.test.ts
+++ b/public/app/features/alerting/unified/components/import-to-gma/Wizard/steps.test.ts
@@ -1,4 +1,4 @@
-import { getNextStep, getPreviousStep, getWizardSteps, isLastStep } from './steps';
+import { getNextStep, getPreviousStep, getWizardSteps, isLastStep, isRulesForcedSkipped } from './steps';
 import { StepKey } from './types';
 
 describe('getWizardSteps', () => {
@@ -16,6 +16,14 @@ describe('getNextStep', () => {
   it('returns undefined past the last step', () => {
     expect(getNextStep(StepKey.Review)).toBeUndefined();
   });
+
+  it('jumps from Notification resources straight to Review when Rules is force-skipped', () => {
+    expect(getNextStep(StepKey.Notifications, true)?.id).toBe(StepKey.Review);
+  });
+
+  it('does not skip Rules when skipRules is false', () => {
+    expect(getNextStep(StepKey.Notifications, false)?.id).toBe(StepKey.Rules);
+  });
 });
 
 describe('getPreviousStep', () => {
@@ -26,11 +34,33 @@ describe('getPreviousStep', () => {
   it('returns undefined before the first step', () => {
     expect(getPreviousStep(StepKey.Notifications)).toBeUndefined();
   });
+
+  it('jumps from Review straight back to Notification resources when Rules is force-skipped', () => {
+    expect(getPreviousStep(StepKey.Review, true)?.id).toBe(StepKey.Notifications);
+  });
+
+  it('does not skip Rules when skipRules is false', () => {
+    expect(getPreviousStep(StepKey.Review, false)?.id).toBe(StepKey.Rules);
+  });
 });
 
 describe('isLastStep', () => {
   it('is true only for the Review step', () => {
     expect(isLastStep(StepKey.Review)).toBe(true);
     expect(isLastStep(StepKey.Notifications)).toBe(false);
+  });
+});
+
+describe('isRulesForcedSkipped', () => {
+  it('is true only when Auto-sync is enabled and the source is a data source', () => {
+    expect(isRulesForcedSkipped(true, 'datasource')).toBe(true);
+  });
+
+  it('is false when Auto-sync is disabled', () => {
+    expect(isRulesForcedSkipped(false, 'datasource')).toBe(false);
+  });
+
+  it('is false for the YAML source, even with Auto-sync enabled', () => {
+    expect(isRulesForcedSkipped(true, 'yaml')).toBe(false);
   });
 });

--- a/public/app/features/alerting/unified/components/import-to-gma/Wizard/steps.ts
+++ b/public/app/features/alerting/unified/components/import-to-gma/Wizard/steps.ts
@@ -24,22 +24,31 @@ export const getWizardSteps = (): WizardStep[] => [
   },
 ];
 
-/**
- * Get the next step in the wizard
- */
-export const getNextStep = (currentStep: StepKey): WizardStep | undefined => {
+/** Whether Auto-sync makes the Alert Rules step redundant. */
+export function isRulesForcedSkipped(
+  autoSyncNotificationsEnabled: boolean,
+  notificationsSource: 'yaml' | 'datasource'
+): boolean {
+  return autoSyncNotificationsEnabled && notificationsSource === 'datasource';
+}
+
+/** Get the next step in the wizard, skipping Rules when auto-sync force-skips it. */
+export const getNextStep = (currentStep: StepKey, skipRules = false): WizardStep | undefined => {
   const steps = getWizardSteps();
   const currentIndex = steps.findIndex((s) => s.id === currentStep);
-  return steps[currentIndex + 1];
+  const next = steps[currentIndex + 1];
+  return next?.id === StepKey.Rules && skipRules ? steps[currentIndex + 2] : next;
 };
 
-/**
- * Get the previous step in the wizard
- */
-export const getPreviousStep = (currentStep: StepKey): WizardStep | undefined => {
+/** Get the previous step in the wizard, mirroring `getNextStep`'s Rules skip. */
+export const getPreviousStep = (currentStep: StepKey, skipRules = false): WizardStep | undefined => {
   const steps = getWizardSteps();
   const currentIndex = steps.findIndex((s) => s.id === currentStep);
-  return currentIndex > 0 ? steps[currentIndex - 1] : undefined;
+  if (currentIndex <= 0) {
+    return undefined;
+  }
+  const previous = steps[currentIndex - 1];
+  return previous?.id === StepKey.Rules && skipRules ? steps[currentIndex - 2] : previous;
 };
 
 /**

--- a/public/app/features/alerting/unified/components/import-to-gma/Wizard/types.ts
+++ b/public/app/features/alerting/unified/components/import-to-gma/Wizard/types.ts
@@ -10,6 +10,15 @@ export enum StepKey {
 
 export type ImportMethod = 'stage' | 'legacy-datasource-rules';
 
+/**
+ * Minimal form shape for cross-cutting `useWatch` calls inside `Wizard/` (e.g.
+ * `useIsRulesForcedSkipped`) — avoids an import cycle with `ImportToGMA.tsx`.
+ */
+export interface WizardFormValues {
+  autoSyncNotificationsEnabled?: boolean;
+  notificationsSource: 'yaml' | 'datasource';
+}
+
 export enum StepState {
   Idle = 'idle',
   Visited = 'visited',

--- a/public/app/features/alerting/unified/components/import-to-gma/Wizard/useIsRulesForcedSkipped.ts
+++ b/public/app/features/alerting/unified/components/import-to-gma/Wizard/useIsRulesForcedSkipped.ts
@@ -1,0 +1,13 @@
+import { useWatch } from 'react-hook-form';
+
+import { isRulesForcedSkipped } from './steps';
+import { type WizardFormValues } from './types';
+
+/** Whether the Rules step is force-skipped; uses `useWatch` so callers re-render when it changes. */
+export function useIsRulesForcedSkipped(): boolean {
+  const autoSyncNotificationsEnabled = useWatch<WizardFormValues, 'autoSyncNotificationsEnabled'>({
+    name: 'autoSyncNotificationsEnabled',
+  });
+  const notificationsSource = useWatch<WizardFormValues, 'notificationsSource'>({ name: 'notificationsSource' });
+  return isRulesForcedSkipped(autoSyncNotificationsEnabled ?? false, notificationsSource ?? 'yaml');
+}

--- a/public/app/features/alerting/unified/components/import-to-gma/steps/Step1AlertmanagerResources.test.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/steps/Step1AlertmanagerResources.test.tsx
@@ -2,11 +2,16 @@ import userEvent from '@testing-library/user-event';
 import { HttpResponse, http } from 'msw';
 import React, { useCallback, useEffect } from 'react';
 import { FormProvider, useForm, useFormContext } from 'react-hook-form';
-import { act, render, screen, waitFor } from 'test/test-utils';
+import { act, render, screen, testWithFeatureToggles, waitFor } from 'test/test-utils';
 
 import { mockBoundingClientRect } from '@grafana/test-utils';
 import { setupMswServer } from 'app/features/alerting/unified/mockApi';
-import { grantUserPermissions, mockDataSource } from 'app/features/alerting/unified/mocks';
+import { grantUserPermissions, grantUserRole, mockDataSource } from 'app/features/alerting/unified/mocks';
+import {
+  setupAdminConfigGet,
+  setupAlertmanagersStatus,
+} from 'app/features/alerting/unified/mocks/server/configure/admin_config';
+import { setupDatasourcesEndpoint } from 'app/features/alerting/unified/mocks/server/configure/datasources';
 import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
 import { type SupportedRulesSourceType } from 'app/features/alerting/unified/utils/datasource';
 import {
@@ -65,6 +70,17 @@ function ValidationHookWrapper({ canImport, onResult }: { canImport: boolean; on
   useEffect(() => {
     onResult(isValid);
   }, [isValid, onResult]);
+  return null;
+}
+
+// Surfaces a watched field's value via a callback, so a test can assert on internal form state
+// without depending on how a given field happens to render.
+function FieldWatcher({ name, onChange }: { name: keyof ImportFormValues; onChange: (value: unknown) => void }) {
+  const { watch } = useFormContext<ImportFormValues>();
+  const value = watch(name);
+  useEffect(() => {
+    onChange(value);
+  }, [value, onChange]);
   return null;
 }
 
@@ -471,6 +487,154 @@ describe('Step1AlertmanagerResources', () => {
 
       const policyTreeInput = screen.getByPlaceholderText(/prometheus-prod/i);
       expect(policyTreeInput).toHaveValue('my-alertmanager-production');
+    });
+  });
+
+  describe('Auto-sync checkbox', () => {
+    const MIMIR_DS = {
+      id: 10,
+      uid: 'mimir-uid',
+      orgId: 1,
+      name: 'Mimir Alertmanager',
+      type: 'alertmanager',
+      url: 'http://localhost:9009',
+      jsonData: { implementation: 'mimir' },
+    };
+
+    beforeEach(() => {
+      setupAlertmanagersStatus(server);
+    });
+
+    it('is not rendered without the feature toggle, even for admins', () => {
+      grantUserRole('Admin');
+      render(
+        <TestWrapper defaultValues={{ notificationsSource: 'datasource' }}>
+          <Step1Content {...defaultStep1Props} />
+        </TestWrapper>
+      );
+
+      expect(screen.queryByRole('switch', { name: /auto-sync/i })).not.toBeInTheDocument();
+    });
+
+    describe('with the feature toggle on', () => {
+      testWithFeatureToggles({ enable: ['alerting.syncExternalAlertmanager'] });
+
+      it('is not rendered for non-admins', () => {
+        grantUserRole('Editor');
+        render(
+          <TestWrapper defaultValues={{ notificationsSource: 'datasource' }}>
+            <Step1Content {...defaultStep1Props} />
+          </TestWrapper>
+        );
+
+        expect(screen.queryByRole('switch', { name: /auto-sync/i })).not.toBeInTheDocument();
+      });
+
+      it('is not rendered for the YAML source', () => {
+        grantUserRole('Admin');
+        render(
+          <TestWrapper defaultValues={{ notificationsSource: 'yaml' }}>
+            <Step1Content {...defaultStep1Props} />
+          </TestWrapper>
+        );
+
+        expect(screen.queryByRole('switch', { name: /auto-sync/i })).not.toBeInTheDocument();
+      });
+
+      it('is rendered for admins on the datasource source', () => {
+        grantUserRole('Admin');
+        setupAdminConfigGet(server, null);
+        setupDatasourcesEndpoint(server, [MIMIR_DS]);
+        render(
+          <TestWrapper defaultValues={{ notificationsSource: 'datasource' }}>
+            <Step1Content {...defaultStep1Props} />
+          </TestWrapper>
+        );
+
+        expect(screen.getByRole('switch', { name: /auto-sync/i })).toBeInTheDocument();
+      });
+
+      it('disables Policy Tree Name and skips the dry-run once checked', async () => {
+        grantUserRole('Admin');
+        setupAdminConfigGet(server, null);
+        setupDatasourcesEndpoint(server, [MIMIR_DS]);
+        const user = userEvent.setup();
+        const onTriggerDryRun = jest.fn();
+
+        render(
+          <TestWrapper
+            defaultValues={{ notificationsSource: 'datasource', notificationsDatasourceUID: 'alertmanager-uid' }}
+          >
+            <Step1Content {...defaultStep1Props} onTriggerDryRun={onTriggerDryRun} />
+          </TestWrapper>
+        );
+
+        onTriggerDryRun.mockClear();
+        await user.click(screen.getByRole('switch', { name: /auto-sync/i }));
+
+        expect(screen.getByPlaceholderText(/prometheus-prod/i)).toBeDisabled();
+        expect(onTriggerDryRun).not.toHaveBeenCalled();
+      });
+
+      it('narrows the data source list to Mimir/Cortex once checked, clearing an incompatible selection', async () => {
+        grantUserRole('Admin');
+        setupAdminConfigGet(server, null);
+        setupDatasourcesEndpoint(server, [MIMIR_DS]);
+        const user = userEvent.setup();
+
+        render(
+          <TestWrapper
+            defaultValues={{ notificationsSource: 'datasource', notificationsDatasourceUID: 'alertmanager-uid' }}
+          >
+            <Step1Content {...defaultStep1Props} />
+          </TestWrapper>
+        );
+
+        await user.click(screen.getByRole('switch', { name: /auto-sync/i }));
+
+        const select = await screen.findByRole('combobox');
+        await user.click(select);
+        expect(await screen.findByText('Mimir Alertmanager')).toBeInTheDocument();
+        expect(screen.queryByText('Alertmanager')).not.toBeInTheDocument();
+      });
+
+      it('does not clear an already-valid selection while the datasource list is still loading', async () => {
+        grantUserRole('Admin');
+        setupAdminConfigGet(server, null);
+        let resolveDatasources = (_response: unknown) => {};
+        const datasourcesResponse = new Promise((resolve) => {
+          resolveDatasources = resolve;
+        });
+        server.use(
+          http.get('/api/datasources', async () => {
+            await datasourcesResponse;
+            return HttpResponse.json([MIMIR_DS]);
+          })
+        );
+        const user = userEvent.setup();
+        const onDatasourceUIDChange = jest.fn();
+
+        render(
+          <TestWrapper defaultValues={{ notificationsSource: 'datasource', notificationsDatasourceUID: MIMIR_DS.uid }}>
+            <Step1Content {...defaultStep1Props} />
+            <FieldWatcher name="notificationsDatasourceUID" onChange={onDatasourceUIDChange} />
+          </TestWrapper>
+        );
+
+        onDatasourceUIDChange.mockClear();
+        await user.click(screen.getByRole('switch', { name: /auto-sync/i }));
+
+        // The datasources request is still pending — the pre-existing, actually-valid selection must
+        // survive rather than being cleared against the momentarily-empty list.
+        expect(onDatasourceUIDChange).not.toHaveBeenCalledWith(undefined);
+
+        resolveDatasources(undefined);
+        await user.click(screen.getByRole('combobox'));
+        // The pre-existing selection survived, so it's already shown as the current value — meaning
+        // it now also appears a second time as the highlighted option in the open menu.
+        expect(await screen.findByRole('option', { name: 'Mimir Alertmanager' })).toBeInTheDocument();
+        expect(onDatasourceUIDChange).not.toHaveBeenCalledWith(undefined);
+      });
     });
   });
 });

--- a/public/app/features/alerting/unified/components/import-to-gma/steps/Step1AlertmanagerResources.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/steps/Step1AlertmanagerResources.tsx
@@ -2,9 +2,10 @@ import { kebabCase } from 'lodash';
 import { useCallback, useEffect, useMemo } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 
-import { type SelectableValue } from '@grafana/data';
+import { OrgRole, type SelectableValue } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import {
   Alert,
   Box,
@@ -12,22 +13,34 @@ import {
   Field,
   FileDropzone,
   FileUpload,
+  Icon,
   IconButton,
+  InlineField,
+  InlineSwitch,
   Input,
+  Label,
   RadioButtonList,
   Select,
   Stack,
   Text,
+  Tooltip,
 } from '@grafana/ui';
+import { contextSrv } from 'app/core/services/context_srv';
 
 import { getAlertManagerDataSources } from '../../../utils/datasource';
+import { useAutoSyncConfiguration } from '../../settings/useAutoSyncConfiguration';
 import { type ImportFormValues } from '../ImportToGMA';
 import { PolicyTreeNameHelp } from '../PolicyTreeNameHelp';
 import { ValidationStatus } from '../ValidationStatus';
-import { getNotificationsSourceOptions } from '../Wizard/steps';
+import { getNotificationsSourceOptions, isRulesForcedSkipped } from '../Wizard/steps';
 import { type DryRunValidationResult } from '../types';
 
 import { findDuplicateTemplateFileName, hasValidSourceSelection, isStep1Valid, validatePolicyTreeName } from './utils';
+
+/** Whether the Auto-sync checkbox may be offered: requires the sync toggle and Org Admin. */
+function isAutoSyncSegmentEnabled(): boolean {
+  return Boolean(config.featureToggles['alerting.syncExternalAlertmanager']) && contextSrv.hasRole(OrgRole.Admin);
+}
 
 interface Step1ContentProps {
   /** Whether the user has permission to import notifications */
@@ -60,6 +73,7 @@ export function Step1Content({
     watch,
     setValue,
     trigger,
+    clearErrors,
     formState: { errors },
   } = useFormContext<ImportFormValues>();
 
@@ -69,18 +83,24 @@ export function Step1Content({
     notificationsDatasourceUID,
     notificationsYamlFile,
     notificationsTemplateFiles,
+    autoSyncNotificationsEnabled,
   ] = watch([
     'notificationsSource',
     'policyTreeName',
     'notificationsDatasourceUID',
     'notificationsYamlFile',
     'notificationsTemplateFiles',
+    'autoSyncNotificationsEnabled',
   ]);
+
+  // Auto-sync mirrors the source directly, skipping Policy Tree Name and the dry-run.
+  const autoSyncActive = isRulesForcedSkipped(autoSyncNotificationsEnabled ?? false, notificationsSource);
 
   const duplicateTemplateFileName = findDuplicateTemplateFileName(notificationsTemplateFiles);
 
   // Whether we have enough data to run a dry-run validation
   const canRunDryRun =
+    !autoSyncActive &&
     Boolean(policyTreeName) &&
     validatePolicyTreeName(policyTreeName) === true &&
     !duplicateTemplateFileName &&
@@ -104,6 +124,13 @@ export function Step1Content({
     notificationsDatasourceUID,
     notificationsTemplateFiles,
   ]);
+
+  // Drop any leftover Policy Tree Name error once Auto-sync disables the field.
+  useEffect(() => {
+    if (autoSyncActive) {
+      clearErrors('policyTreeName');
+    }
+  }, [autoSyncActive, clearErrors]);
 
   // Trigger validation + dry-run when the policy tree name input loses focus
   const handlePolicyTreeNameBlur = useCallback(async () => {
@@ -252,7 +279,28 @@ export function Step1Content({
               </Stack>
             )}
 
-            {notificationsSource === 'datasource' && <AlertmanagerDataSourceSelect />}
+            {notificationsSource === 'datasource' && (
+              <Stack direction="column" gap={2}>
+                <AlertmanagerDataSourceSelect autoSyncActive={autoSyncActive} />
+                {isAutoSyncSegmentEnabled() && (
+                  <InlineField
+                    transparent
+                    label={t('alerting.import-to-gma.step1.autosync-label', 'Auto-sync')}
+                    labelWidth={30}
+                    tooltip={t(
+                      'alerting.import-to-gma.step1.autosync-tooltip',
+                      'Continuously sync alert configuration from this data source instead of importing once. Skips the Alert Rules step since rules sync automatically too.'
+                    )}
+                  >
+                    <InlineSwitch
+                      transparent
+                      id="autosync-notifications-enabled"
+                      {...register('autoSyncNotificationsEnabled')}
+                    />
+                  </InlineField>
+                )}
+              </Stack>
+            )}
           </Box>
         </Box>
       </Box>
@@ -276,17 +324,38 @@ export function Step1Content({
           </Stack>
           <Box marginTop={2}>
             <Field
-              label={t('alerting.import-to-gma.step1.policy-tree-name', 'Policy tree name')}
+              label={
+                autoSyncActive ? (
+                  <Label>
+                    <Stack direction="row" alignItems="center" gap={0.5}>
+                      {t('alerting.import-to-gma.step1.policy-tree-name', 'Policy tree name')}
+                      <Tooltip
+                        content={t(
+                          'alerting.import-to-gma.step1.policy-tree-autosync-disabled',
+                          "Not needed. Auto-sync mirrors the source directly, so there's no policy tree to name."
+                        )}
+                      >
+                        <Icon name="info-circle" size="sm" />
+                      </Tooltip>
+                    </Stack>
+                  </Label>
+                ) : (
+                  t('alerting.import-to-gma.step1.policy-tree-name', 'Policy tree name')
+                )
+              }
               invalid={!!errors.policyTreeName}
               error={errors.policyTreeName?.message}
               noMargin
             >
               <Input
                 {...register('policyTreeName', {
-                  required: t('alerting.import-to-gma.step1.policy-tree-required', 'Policy tree name is required'),
-                  validate: validatePolicyTreeName,
+                  required: autoSyncActive
+                    ? undefined
+                    : t('alerting.import-to-gma.step1.policy-tree-required', 'Policy tree name is required'),
+                  validate: autoSyncActive ? undefined : validatePolicyTreeName,
                   onBlur: handlePolicyTreeNameBlur,
                 })}
+                disabled={autoSyncActive}
                 placeholder={t('alerting.import-to-gma.step1.policy-tree-placeholder', 'prometheus-prod')}
                 width={40}
               />
@@ -318,12 +387,14 @@ export function useStep1Validation(canImport: boolean): boolean {
     notificationsDatasourceUID,
     notificationsYamlFile,
     notificationsTemplateFiles,
+    autoSyncNotificationsEnabled,
   ] = watch([
     'notificationsSource',
     'policyTreeName',
     'notificationsDatasourceUID',
     'notificationsYamlFile',
     'notificationsTemplateFiles',
+    'autoSyncNotificationsEnabled',
   ]);
 
   const hasStep1Errors =
@@ -342,13 +413,28 @@ export function useStep1Validation(canImport: boolean): boolean {
     notificationsYamlFile,
     notificationsDatasourceUID,
     notificationsTemplateFiles,
+    autoSyncNotificationsEnabled: autoSyncNotificationsEnabled ?? false,
   });
 }
 
-/**
- * Component to select an Alertmanager data source (excludes Grafana built-in)
- */
-function AlertmanagerDataSourceSelect() {
+interface AlertmanagerDataSourceSelectProps {
+  /** Narrows the option list to Mimir/Cortex only, the sources Auto-sync can mirror. */
+  autoSyncActive: boolean;
+}
+
+/** Dispatches to the Mimir/Cortex-only variant when Auto-sync is active, so its admin-only queries only run then. */
+function AlertmanagerDataSourceSelect({ autoSyncActive }: AlertmanagerDataSourceSelectProps) {
+  return autoSyncActive ? <MimirCortexDataSourceSelect /> : <AnyAlertmanagerDataSourceSelect />;
+}
+
+interface DataSourceSelectFieldProps {
+  options: Array<SelectableValue<string>>;
+  noOptionsMessage: string;
+  description?: string;
+}
+
+/** Shared Select + autofill logic for both the broad and Mimir/Cortex-only data source pickers. */
+function DataSourceSelectField({ options, noOptionsMessage, description }: DataSourceSelectFieldProps) {
   const {
     control,
     setValue,
@@ -356,7 +442,48 @@ function AlertmanagerDataSourceSelect() {
     formState: { errors },
   } = useFormContext<ImportFormValues>();
 
-  // Get external Alertmanager data sources (same function used by AlertManagerPicker)
+  return (
+    <Field
+      label={t('alerting.import-to-gma.step1.datasource', 'Alertmanager data source')}
+      description={description}
+      invalid={!!errors.notificationsDatasourceUID}
+      error={errors.notificationsDatasourceUID?.message}
+      noMargin
+      data-testid={selectors.pages.Alerting.ImportToGMA.alertmanagerDataSourceField}
+    >
+      <Controller
+        render={({ field: { ref, onChange, ...field } }) => (
+          <Select
+            {...field}
+            options={options}
+            onChange={(selected) => {
+              if (selected?.value) {
+                onChange(selected.value);
+                const ds = options.find((o) => o.value === selected.value);
+                const dsName = typeof ds?.label === 'string' ? ds.label : undefined;
+                setValue('notificationsDatasourceName', dsName ?? null);
+
+                // Auto-populate policy tree name with sanitized datasource name if empty
+                const currentPolicyTreeName = getValues('policyTreeName');
+                if (!currentPolicyTreeName && dsName) {
+                  setValue('policyTreeName', kebabCase(dsName));
+                }
+              }
+            }}
+            placeholder={t('alerting.import-to-gma.step1.select-datasource', 'Select data source')}
+            width={40}
+            noOptionsMessage={noOptionsMessage}
+          />
+        )}
+        control={control}
+        name="notificationsDatasourceUID"
+      />
+    </Field>
+  );
+}
+
+/** Broad Alertmanager data source list (excludes Grafana built-in), same source used by AlertManagerPicker. */
+function AnyAlertmanagerDataSourceSelect() {
   const alertmanagerOptions: Array<SelectableValue<string>> = useMemo(() => {
     const alertmanagerDataSources = getAlertManagerDataSources();
     return alertmanagerDataSources.map((ds) => ({
@@ -368,39 +495,48 @@ function AlertmanagerDataSourceSelect() {
   }, []);
 
   return (
-    <Field
-      label={t('alerting.import-to-gma.step1.datasource', 'Alertmanager data source')}
-      invalid={!!errors.notificationsDatasourceUID}
-      error={errors.notificationsDatasourceUID?.message}
-      noMargin
-      data-testid={selectors.pages.Alerting.ImportToGMA.alertmanagerDataSourceField}
-    >
-      <Controller
-        render={({ field: { ref, onChange, ...field } }) => (
-          <Select
-            {...field}
-            options={alertmanagerOptions}
-            onChange={(selected) => {
-              if (selected?.value) {
-                onChange(selected.value);
-                const ds = getAlertManagerDataSources().find((d) => d.uid === selected.value);
-                setValue('notificationsDatasourceName', ds?.name ?? null);
+    <DataSourceSelectField
+      options={alertmanagerOptions}
+      noOptionsMessage={t('alerting.import-to-gma.step1.no-datasources', 'No Alertmanager data sources found')}
+    />
+  );
+}
 
-                // Auto-populate policy tree name with sanitized datasource name if empty
-                const currentPolicyTreeName = getValues('policyTreeName');
-                if (!currentPolicyTreeName && ds?.name) {
-                  setValue('policyTreeName', kebabCase(ds.name));
-                }
-              }
-            }}
-            placeholder={t('alerting.import-to-gma.step1.select-datasource', 'Select data source')}
-            width={40}
-            noOptionsMessage={t('alerting.import-to-gma.step1.no-datasources', 'No Alertmanager data sources found')}
-          />
-        )}
-        control={control}
-        name="notificationsDatasourceUID"
-      />
-    </Field>
+/** Mimir/Cortex-only data source list for Auto-sync. Mounted only while checked, so its admin-only queries don't otherwise run. */
+function MimirCortexDataSourceSelect() {
+  const { watch, setValue } = useFormContext<ImportFormValues>();
+  const notificationsDatasourceUID = watch('notificationsDatasourceUID');
+  const { mimirCortexDatasources, isLoading } = useAutoSyncConfiguration();
+
+  const options: Array<SelectableValue<string>> = useMemo(
+    () => mimirCortexDatasources.map((ds) => ({ value: ds.uid, label: ds.name, imgUrl: ds.typeLogoUrl })),
+    [mimirCortexDatasources]
+  );
+
+  // Clears a selection no longer in the narrowed list. Skip while loading — the list is also
+  // empty before the first response, which would wrongly clear a selection that's actually valid.
+  useEffect(() => {
+    if (
+      !isLoading &&
+      notificationsDatasourceUID &&
+      !mimirCortexDatasources.some((ds) => ds.uid === notificationsDatasourceUID)
+    ) {
+      setValue('notificationsDatasourceUID', undefined);
+      setValue('notificationsDatasourceName', null);
+    }
+  }, [isLoading, notificationsDatasourceUID, mimirCortexDatasources, setValue]);
+
+  return (
+    <DataSourceSelectField
+      options={options}
+      noOptionsMessage={t(
+        'alerting.import-to-gma.step1.no-mimir-cortex-datasources',
+        'No Mimir or Cortex data sources found'
+      )}
+      description={t(
+        'alerting.import-to-gma.step1.autosync-datasource-filtered',
+        'Auto-sync can only mirror from Mimir or Cortex Alertmanager data sources.'
+      )}
+    />
   );
 }

--- a/public/app/features/alerting/unified/components/import-to-gma/steps/utils.test.ts
+++ b/public/app/features/alerting/unified/components/import-to-gma/steps/utils.test.ts
@@ -54,6 +54,7 @@ describe('isStep1Valid', () => {
         notificationsYamlFile: yamlFile,
         notificationsDatasourceUID: undefined,
         notificationsTemplateFiles: [],
+        autoSyncNotificationsEnabled: false,
       })
     ).toBe(true);
   });
@@ -66,6 +67,7 @@ describe('isStep1Valid', () => {
         notificationsYamlFile: null,
         notificationsDatasourceUID: 'am-uid',
         notificationsTemplateFiles: [],
+        autoSyncNotificationsEnabled: false,
       })
     ).toBe(true);
   });
@@ -78,6 +80,7 @@ describe('isStep1Valid', () => {
         notificationsYamlFile: yamlFile,
         notificationsDatasourceUID: undefined,
         notificationsTemplateFiles: [],
+        autoSyncNotificationsEnabled: false,
       })
     ).toBe(false);
   });
@@ -90,6 +93,7 @@ describe('isStep1Valid', () => {
         notificationsYamlFile: yamlFile,
         notificationsDatasourceUID: undefined,
         notificationsTemplateFiles: [],
+        autoSyncNotificationsEnabled: false,
       })
     ).toBe(false);
   });
@@ -105,6 +109,7 @@ describe('isStep1Valid', () => {
           new File(['a'], 'dup.tmpl', { type: 'text/plain' }),
           new File(['b'], 'dup.tmpl', { type: 'text/plain' }),
         ],
+        autoSyncNotificationsEnabled: false,
       })
     ).toBe(false);
   });
@@ -117,7 +122,49 @@ describe('isStep1Valid', () => {
         notificationsYamlFile: null,
         notificationsDatasourceUID: undefined,
         notificationsTemplateFiles: [],
+        autoSyncNotificationsEnabled: false,
       })
     ).toBe(false);
+  });
+
+  describe('with Auto-sync enabled', () => {
+    it('returns true once a data source is selected, even without a policy tree name', () => {
+      expect(
+        isStep1Valid({
+          policyTreeName: '',
+          notificationsSource: 'datasource',
+          notificationsYamlFile: null,
+          notificationsDatasourceUID: 'mimir-uid',
+          notificationsTemplateFiles: [],
+          autoSyncNotificationsEnabled: true,
+        })
+      ).toBe(true);
+    });
+
+    it('returns false without a data source selected', () => {
+      expect(
+        isStep1Valid({
+          policyTreeName: '',
+          notificationsSource: 'datasource',
+          notificationsYamlFile: null,
+          notificationsDatasourceUID: undefined,
+          notificationsTemplateFiles: [],
+          autoSyncNotificationsEnabled: true,
+        })
+      ).toBe(false);
+    });
+
+    it('is ignored for the YAML source — behaves as if unchecked', () => {
+      expect(
+        isStep1Valid({
+          policyTreeName: '',
+          notificationsSource: 'yaml',
+          notificationsYamlFile: yamlFile,
+          notificationsDatasourceUID: undefined,
+          notificationsTemplateFiles: [],
+          autoSyncNotificationsEnabled: true,
+        })
+      ).toBe(false);
+    });
   });
 });

--- a/public/app/features/alerting/unified/components/import-to-gma/steps/utils.ts
+++ b/public/app/features/alerting/unified/components/import-to-gma/steps/utils.ts
@@ -1,6 +1,7 @@
 /**
  * Shared validation utilities for import-to-gma steps
  */
+import { isRulesForcedSkipped } from '../Wizard/steps';
 
 /** RFC 1123 subdomain pattern — must match the backend's identifier validation */
 const POLICY_TREE_NAME_PATTERN = /^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$/;
@@ -62,10 +63,12 @@ export interface Step1ValidationParams {
   notificationsYamlFile: File | null;
   notificationsDatasourceUID: string | null | undefined;
   notificationsTemplateFiles: File[];
+  autoSyncNotificationsEnabled: boolean;
 }
 
 /**
- * Validates that Step 1 form is complete and valid
+ * Validates that Step 1 form is complete and valid. When Auto-sync force-skips Rules, only a
+ * data source is required.
  */
 export function isStep1Valid(params: Step1ValidationParams): boolean {
   const {
@@ -74,7 +77,12 @@ export function isStep1Valid(params: Step1ValidationParams): boolean {
     notificationsYamlFile,
     notificationsDatasourceUID,
     notificationsTemplateFiles,
+    autoSyncNotificationsEnabled,
   } = params;
+
+  if (isRulesForcedSkipped(autoSyncNotificationsEnabled, notificationsSource)) {
+    return Boolean(notificationsDatasourceUID);
+  }
 
   if (!policyTreeName || validatePolicyTreeName(policyTreeName) !== true) {
     return false;

--- a/public/app/features/alerting/unified/components/settings/useAutoSyncConfiguration.tsx
+++ b/public/app/features/alerting/unified/components/settings/useAutoSyncConfiguration.tsx
@@ -54,10 +54,8 @@ export function isOperatorManaged(state: AutoSyncState): state is Extract<AutoSy
 }
 
 export function useAutoSyncConfiguration(): UseAutoSyncConfigurationResult {
-  // Both endpoints require Org Admin (admin_config) or are only meaningful behind the sync toggle;
-  // skip them for everyone else so callers that mount this unconditionally (e.g. the Import wizard)
-  // don't fire a guaranteed-403 request on every page load. Must match Step1AlertmanagerResources's
-  // `isAutoSyncSegmentEnabled` gate for the Auto-sync checkbox itself.
+  // admin_config requires Org Admin; skip for everyone else so unconditional callers (e.g. the
+  // Import wizard) don't fire a guaranteed 403. Must match Step1's `isAutoSyncSegmentEnabled` gate.
   const canAccess =
     Boolean(config.featureToggles['alerting.syncExternalAlertmanager']) && contextSrv.hasRole(OrgRole.Admin);
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1619,6 +1619,15 @@
         "title": "Auto-sync is enabled"
       },
       "confirm": {
+        "autosync-body": "Are you sure you want to enable Auto-sync? Grafana will continuously sync alert configuration from this data source until you turn it off in Alerting settings.",
+        "autosync-confirm": "Enable auto-sync",
+        "autosync-error-body": "Failed to enable Auto-sync. Please check the error details and try again.",
+        "autosync-error-title": "Auto-sync Failed",
+        "autosync-importing-body": "Enabling Auto-sync. Please wait...",
+        "autosync-importing-title": "Enabling auto-sync...",
+        "autosync-success-body": "Auto-sync enabled. Redirecting...",
+        "autosync-success-title": "Auto-sync Enabled",
+        "autosync-title": "Confirm Auto-sync",
         "body": "Are you sure you want to start the import? This action will create new resources in Grafana Alerting.",
         "confirm": "Start Import",
         "error-body": "Failed to import resources. Please check the error details and try again.",
@@ -1688,7 +1697,10 @@
       "renamed-receivers_one": "{{count}} contact points will be renamed",
       "renamed-receivers_other": "{{count}} contact points will be renamed",
       "review": {
+        "autosync-badge": "Will sync continuously",
         "back": "Alert rules",
+        "back-notifications": "Notification resources",
+        "enable-autosync": "Enable auto-sync",
         "filter": "Filter",
         "folder": "Target folder",
         "heading": "Review Import",
@@ -1706,6 +1718,7 @@
         "routing": "Notification routing",
         "routing-none": "No policy tree selected",
         "routing-tree": "Policy tree: {{name}}",
+        "rules-autosync-badge": "Syncs automatically",
         "rules-skipped": "Alert rules will not be imported.",
         "rules-title": "Alert Rules",
         "skipped": "Skipped",
@@ -1731,12 +1744,17 @@
         "yaml-description": "Import rules from a Prometheus YAML file."
       },
       "step1": {
+        "autosync-datasource-filtered": "Auto-sync can only mirror from Mimir or Cortex Alertmanager data sources.",
+        "autosync-label": "Auto-sync",
+        "autosync-tooltip": "Continuously sync alert configuration from this data source instead of importing once. Skips the Alert Rules step since rules sync automatically too.",
         "datasource": "Alertmanager data source",
         "heading": "Import Notification Resources",
         "next-disabled-tooltip": "Complete the required fields and wait for validation to pass before continuing.",
         "no-datasources": "No Alertmanager data sources found",
+        "no-mimir-cortex-datasources": "No Mimir or Cortex data sources found",
         "no-permission-desc": "You do not have permission to import notification resources. You need the <strong>alerting.notifications:write</strong> permission. You can skip this step.",
         "no-permission-title": "Insufficient permissions",
+        "policy-tree-autosync-disabled": "Not needed. Auto-sync mirrors the source directly, so there's no policy tree to name.",
         "policy-tree-desc": "When you import, Grafana creates a separate notification policy tree. Enter a name you will recognize.",
         "policy-tree-help": "When you import this Alertmanager configuration, Grafana will create a separate notification policy tree for it. The name you enter here will identify that tree in the UI and is what you select when you import alert rules that should use this routing. Use a label you will recognize — for example data source, team, cluster, or environment (such as prometheus-prod or platform-team).",
         "policy-tree-help-title": "About policy tree names",
@@ -3863,6 +3881,8 @@
       "title-notification-policies": "Notification policies"
     },
     "wizard-import-to-gma": {
+      "autosync-success-body": "Grafana will keep syncing alert configuration from this data source.",
+      "autosync-success-title": "Auto-sync enabled",
       "error": "Failed to import resources",
       "staged-success-body": "Your imported config is now staged in the Import tab.",
       "staged-success-title": "Configuration staged",


### PR DESCRIPTION
**Changes**

This refactor makes the auto-sync option a choice done in the first step of the import to GMA wizard, updating the wizard form dynamically instead of forcing the choice in the first step. The goal is to simplify the wizard UI and cause less confusion to users during the import process. It also simplified the navigation logic to always redirect to the import settings tab when the user finished the wizard.


https://github.com/user-attachments/assets/bf29a83a-ca2a-4d63-b82a-bf44c5b2df1c

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
