### PR TITLE
Dashboards: Point scripted dashboard deprecation notice at What's new

### DIFF
--- a/public/app/features/dashboard/services/DashboardLoaderSrv.ts
+++ b/public/app/features/dashboard/services/DashboardLoaderSrv.ts
@@ -18,7 +18,7 @@ import { getDashboardSnapshotSrv } from './SnapshotSrv';
 type ScriptedDashboardExecution = { data: DashboardDataDTO };
 
 export const SCRIPTED_DASHBOARDS_DEPRECATION_URL =
-  'https://grafana.com/whats-new/2026-07-29-grafana-cloud-docs-get-a-new-home-for-ai/';
+  'https://grafana.com/whats-new/2026-08-12-scripted-dashboards-will-be-removed-in-grafana-14/';
 export const SCRIPTED_DASHBOARDS_DISABLED_MESSAGE_ID = 'scripted-dashboards-disabled';
 
 // Scripted dashboards are arbitrary user code, so nothing has validated what they return.

--- a/public/app/features/dashboard/services/DashboardLoaderSrv.ts
+++ b/public/app/features/dashboard/services/DashboardLoaderSrv.ts
@@ -17,7 +17,8 @@ import { getDashboardSnapshotSrv } from './SnapshotSrv';
 
 type ScriptedDashboardExecution = { data: DashboardDataDTO };
 
-export const SCRIPTED_DASHBOARDS_DEPRECATION_URL = 'https://github.com/grafana/grafana/issues/24059';
+export const SCRIPTED_DASHBOARDS_DEPRECATION_URL =
+  'https://grafana.com/whats-new/2026-07-29-grafana-cloud-docs-get-a-new-home-for-ai/';
 export const SCRIPTED_DASHBOARDS_DISABLED_MESSAGE_ID = 'scripted-dashboards-disabled';
 
 // Scripted dashboards are arbitrary user code, so nothing has validated what they return.


### PR DESCRIPTION
## What this PR does

Updates the `SCRIPTED_DASHBOARDS_DEPRECATION_URL` constant so the scripted-dashboards deprecation banner and the full-page "disabled" notice link to the published What's new post instead of the old GitHub issue (#24059):

https://grafana.com/whats-new/2026-08-12-scripted-dashboards-will-be-removed-in-grafana-14/

## Why

Follow-up to #130207. Users hitting the deprecation notice should land on the What's new entry rather than a five-year-old issue.