### PR TITLE
[2/9] CI: Build PR artifacts and Docker variants once per PR

### DIFF
--- a/.github/workflows/build-docker-variants.yml
+++ b/.github/workflows/build-docker-variants.yml
@@ -5,7 +5,7 @@ name: Build Docker Variants
 # tarball for a single OS/arch combination.
 #
 # Called from release-build.yml (once per arch, tarball from build-targz) and
-# from pr-test-docker.yml (amd64 only, tarball built from source in the PR).
+# from pr-build-grafana.yml (amd64 only, tarball built from source in the PR).
 
 on:
   workflow_call:

--- a/.github/workflows/pr-build-grafana.yml
+++ b/.github/workflows/pr-build-grafana.yml
@@ -21,15 +21,15 @@ permissions: {}
 jobs:
   detect-changes:
     # Gate the whole workflow behind this check. Skip draft PRs entirely.
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.event.pull_request.draft == false
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
     name: Detect whether code changed
     runs-on: ubuntu-arm64-small
     permissions:
       contents: read
     outputs:
-      # Build when non-test frontend or backend changes: a test-only PR can't
-      # affect the built image, so it shouldn't trigger the Docker build.
-      changed: ${{ steps.detect-changes.outputs.frontend-src == 'true' || steps.detect-changes.outputs.backend-src == 'true' }}
+      # Build when non-test frontend, backend or Docker build files change: a
+      # test-only PR can't affect the built image, so it shouldn't build it.
+      changed: ${{ steps.detect-changes.outputs.frontend-src == 'true' || steps.detect-changes.outputs.backend-src == 'true' || steps.detect-changes.outputs.docker-build == 'true' }}
       # Meticulous only exercises frontend changes, so it gates on this alone.
       frontend-src: ${{ steps.detect-changes.outputs.frontend-src }}
     steps:
@@ -132,55 +132,31 @@ jobs:
           path: dist
           retention-days: 1
 
-  build-docker:
-    name: build docker
-    runs-on: ubuntu-x64-large
+  build-docker-variants:
+    name: build docker variants
     needs:
       - setup
       - build-targz
     permissions:
       contents: read
       id-token: write
-    steps:
-      - uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login/v1.0.2
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: pr-targz
-          path: dist
-      - name: Set up Docker Buildx
-        run: docker buildx create --use
-      - name: Build docker image
-        env:
-          GOOS: linux
-          GOARCH: amd64
-          BUILD_NUMBER: ${{ github.run_id }}
-          BUILD_VERSION: ${{ needs.setup.outputs.version }}
-        run: |
-          for TARGZ in dist/*.tar.gz; do break; done
-          TAG_VERSION="${BUILD_VERSION//+/-}"
-          make build-docker \
-            -o "$TARGZ" \
-            BUILD_VERSION="$BUILD_VERSION" \
-            BUILD_NUMBER="$BUILD_NUMBER" \
-            DOCKER_TAG="grafana/grafana-image-tags:${TAG_VERSION}-amd64"
-      - name: Stage docker artifact
-        run: |
-          mkdir -p upload
-          cp dist/*.docker.tar.gz upload/
-      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
-        with:
-          name: pr-docker
-          path: upload
-          retention-days: 1
+    uses: ./.github/workflows/build-docker-variants.yml
+    with:
+      targz-artifact-name: pr-targz
+      name: linux-amd64
+      os: linux
+      arch: amd64
+      arch-tag: amd64
+      version: ${{ needs.setup.outputs.version }}
+      build-number: ${{ github.run_id }}
+      tag-prefix: 'grafana/grafana-image-tags:'
 
   push-docker-image:
     needs:
       - detect-changes
-      - build-docker
-    if: needs.detect-changes.outputs.changed == 'true'
+      - build-docker-variants
+    # Pushing to the dev registry needs credentials a fork PR cannot have.
+    if: needs.detect-changes.outputs.changed == 'true' && github.event.pull_request.head.repo.fork == false
     name: Push PR Docker image
     outputs:
       IMAGE: ${{ steps.push-image.outputs.IMAGE }}
@@ -196,7 +172,7 @@ jobs:
           environment: 'dev'
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
-          name: pr-docker
+          name: artifacts-docker-linux-amd64
           path: .
       - name: Load & Push Docker image
         id: push-image

--- a/.github/workflows/pr-test-docker.yml
+++ b/.github/workflows/pr-test-docker.yml
@@ -39,7 +39,6 @@ on:
       - embed.go
       - packaging/docker/**
       - .github/workflows/pr-test-docker.yml
-      - .github/workflows/build-docker-variants.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -69,9 +68,9 @@ jobs:
         with:
           self: .github/workflows/pr-test-docker.yml
 
-  # ── Path 1 ────────────────────────────────────────────────────────────────
   # Full source build inside Docker. Validates that the complete compilation
   # pipeline (go-builder + js-builder + final stage) works end-to-end.
+  # The prod-like tarball → variants path runs in pr-build-grafana.yml.
   build-full:
     name: build / full source (alpine)
     needs: detect-changes
@@ -92,95 +91,3 @@ jobs:
         uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login/v1.0.4
       - name: Build alpine (full source)
         run: make build-docker-full DOCKER_BUILD_ARGS=--load
-
-  # ── Path 2 ────────────────────────────────────────────────────────────────
-  # Prod-like build: compile frontend + backend in parallel → assemble tarball
-  # → build all 6 Docker variants. Mirrors the release-build.yml structure so
-  # the same code paths are exercised on every PR.
-
-  build-frontend:
-    name: build / frontend
-    needs: detect-changes
-    if: needs.detect-changes.outputs.changed == 'true'
-    runs-on: ubuntu-x64-large
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/setup-node
-      - name: Install JS dependencies
-        run: yarn install --immutable
-      - name: Build frontend
-        run: yarn build
-      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
-        with:
-          name: pr-frontend
-          path: public
-          retention-days: 1
-
-  build-backend:
-    name: build / backend (linux-amd64)
-    needs: detect-changes
-    if: needs.detect-changes.outputs.changed == 'true'
-    runs-on: ubuntu-x64-large
-    permissions:
-      contents: read
-    outputs:
-      version: ${{ steps.build.outputs.version }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - id: build
-        uses: ./.github/actions/build-go
-        with:
-          build-number: ${{ github.run_id }}
-      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
-        with:
-          name: pr-backend-linux-amd64
-          path: bin/linux/amd64
-          retention-days: 1
-
-  build-source-targz:
-    name: build / source tarball
-    runs-on: ubuntu-x64-large
-    needs:
-      - build-frontend
-      - build-backend
-    permissions:
-      contents: read
-    outputs:
-      version: ${{ needs.build-backend.outputs.version }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/build-targz
-        with:
-          build-number: ${{ github.run_id }}
-          build-version: ${{ needs.build-backend.outputs.version }}
-          frontend-artifact: pr-frontend
-          backend-artifact: pr-backend-linux-amd64
-      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
-        with:
-          name: pr-source-targz
-          path: dist/*.tar.gz
-          retention-days: 1
-
-  build-docker-variants:
-    name: build / variants (targz)
-    needs: build-source-targz
-    permissions:
-      contents: read
-      id-token: write
-    uses: ./.github/workflows/build-docker-variants.yml
-    with:
-      targz-artifact-name: pr-source-targz
-      name: linux-amd64
-      os: linux
-      arch: amd64
-      arch-tag: amd64
-      version: ${{ needs.build-source-targz.outputs.version }}
-      build-number: ${{ github.run_id }}


### PR DESCRIPTION
**What is this change?**

`pr-build-grafana` and `pr-test-docker` each built the frontend, backend and tarball, and each built an overlapping set of Docker variants. This builds them once in `pr-build-grafana` and leaves `pr-test-docker` covering only the from-source image.

Measured on the same PR: 3563s and 3699s of runner time across the two workflows before, [2532s](https://github.com/grafana/grafana/actions/runs/31636595302) after, or 18.3 runner-minutes and 30% less. Baselines: [2436s](https://github.com/grafana/grafana/actions/runs/31636319245) plus [1127s](https://github.com/grafana/grafana/actions/runs/31636318992), and [2532s](https://github.com/grafana/grafana/actions/runs/31635749014) plus [1167s](https://github.com/grafana/grafana/actions/runs/31635748758).

**Why do we need this?**

The duplicated work was invisible because it was split across two workflows. `pr-test-docker` was rebuilding the backend (337s), frontend (275s) and tarball (117s) plus all six Docker variants that `pr-build-grafana` had already produced.

**Special notes for your reviewer:**

Coverage is preserved, and that is the thing to check. Every image built before is still built: `alpine-from-source` stays in `pr-test-docker`; `alpine`, `alpine-slim`, `ubuntu`, `ubuntu-slim`, `distroless` and `distroless-slim` all move to `pr-build-grafana`. The gating condition is the union of the two previous conditions (`frontend-src`, `backend-src`, `docker-build`), so it is a strict superset and no path that used to build now skips.

The fork gate needs attention. It previously sat on `detect-changes`, which would have suppressed the whole variant chain for fork PRs once the chain moved into this workflow. It now sits on `push-docker-image`, which is the only job needing dev-registry credentials, so fork PRs still get their builds.

One consequence not addressed here: `push-docker-image` now waits on all six variants although it only consumes the alpine artifact, so the Meticulous critical path is gated by the slowest variant. Worth measuring separately.

Description generated by Claude Code.
