### PR TITLE
[3/9] CI: Use the S3 remote Go cache for enterprise backend tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1283,6 +1283,7 @@ embed.go @grafana/grafana-as-code
 /.github/actions/check-jobs/action.yml @grafana/grafana-frontend-platform
 /.github/actions/setup-enterprise/action.yml @grafana/grafana-operator-experience-squad
 /.github/actions/setup-go/action.yml @grafana/grafana-backend-services-squad
+/.github/actions/setup-go-remote-cache/action.yml @grafana/grafana-backend-services-squad
 /.github/actions/report-go-cache-sizes/ @grafana/grafana-operator-experience-squad
 /.github/actions/build-go @grafana/grafana-operator-experience-squad
 /.github/actions/build-targz @grafana/grafana-operator-experience-squad

--- a/.github/actions/setup-go-remote-cache/action.yml
+++ b/.github/actions/setup-go-remote-cache/action.yml
@@ -1,0 +1,107 @@
+name: Setup remote Go cache
+description: >-
+  Authenticates to AWS and starts the S3-backed Go build cache
+  (go-cache-plugin). Subsequent go commands in the job use the remote cache
+  through GOCACHEPROG and download modules through the local proxy.
+  Only usable in jobs that can assume the grafana-cicd role; the role trust
+  is granted per workflow file, so fork PRs cannot use it.
+
+inputs:
+  download-only:
+    description: >-
+      Populate the plugin cache without authenticating to AWS or starting the
+      server. Used by a warm-up job so matrix jobs restore the binary from the
+      cache instead of each downloading it.
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve go-cache-plugin release
+      shell: bash
+      run: |
+        set -euo pipefail
+        case "$RUNNER_ARCH" in
+          X64)
+            GOCP_OS='linux-amd64'
+            GOCP_HASH='66e0f3e2ea1515d73540a57efcdd1ebcec8bc1f233af452f30ad32fb84feff9f'
+            ;;
+          ARM64)
+            GOCP_OS='linux-arm64'
+            GOCP_HASH='a6f164d1c38700a1aaafb8537aa405a2edf0c9897e7f62fa4b902445921a23bb'
+            ;;
+          *)
+            echo "Unsupported runner architecture: $RUNNER_ARCH" >&2
+            exit 1
+            ;;
+        esac
+        {
+          echo "GOCP_VERSION=v0.1.4-otel-exporter5"
+          echo "GOCP_OS=${GOCP_OS}"
+          echo "GOCP_HASH=${GOCP_HASH}"
+        } >> "$GITHUB_ENV"
+
+    # Without this, every job in a matrix downloads the same release asset and
+    # GitHub throttles them once enough shards start at once.
+    - name: Cache go-cache-plugin
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+      with:
+        path: ~/.cache/go-cache-plugin
+        key: go-cache-plugin-${{ env.GOCP_VERSION }}-${{ env.GOCP_OS }}
+
+    - name: Download go-cache-plugin
+      shell: bash
+      run: |
+        set -euo pipefail
+        BIN="$HOME/.cache/go-cache-plugin/go-cache-plugin"
+        if [ -f "$BIN" ]; then
+          echo -e "$GOCP_HASH\t$BIN" | sha256sum --check
+          exit 0
+        fi
+        mkdir -p "$(dirname "$BIN")"
+        # Publish into the cached directory only once the checksum passes, so a
+        # corrupted download cannot be restored by later jobs.
+        TMP="$(mktemp "$(dirname "$BIN")/.download.XXXXXX")"
+        trap 'rm -f "$TMP"' EXIT
+        curl --fail --retry 5 --retry-delay 2 --retry-all-errors -Lo "$TMP" \
+          https://github.com/grafana/go-cache-plugin/releases/download/"$GOCP_VERSION"/go-cache-plugin-"$GOCP_OS"
+        echo -e "$GOCP_HASH\t$TMP" | sha256sum --check
+        mv "$TMP" "$BIN"
+
+    - name: Auth to AWS
+      if: inputs.download-only != 'true'
+      uses: grafana/shared-workflows/actions/aws-auth@aws-auth/v1.0.2
+      with:
+        aws-region: 'us-east-2'
+        pass-claims: 'repository_owner, repository_name, job_workflow_ref, ref, event_name'
+        set-creds-in-environment: true
+        role-arn: 'arn:aws:iam::422075448034:role/github-actions/grafana-cicd'
+
+    - name: Configure Go cache environment
+      if: inputs.download-only != 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        {
+          echo "GOCACHE_HTTP=localhost:12345"
+          echo "GOCACHE_MODPROXY=true"
+          echo "GOCACHE_PLUGIN=1234"
+          echo "GOCACHE_S3_BUCKET=grafana-cicd-gha-cache-workloads-prod"
+          echo "GOCACHE_S3_REGION=us-east-2"
+          echo "GOCACHE_METRICS=true"
+          echo "GOCACHE_DIR=/tmp/gocache"
+          echo "GOCACHEPROG=go-cache-plugin connect 1234"
+          echo "GOPROXY=http://localhost:12345/mod"
+          echo "GOSUMDB=sum.golang.org http://localhost:12345/mod/sumdb/sum.golang.org"
+        } >> "$GITHUB_ENV"
+
+    - name: Start go-cache-plugin
+      if: inputs.download-only != 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        sudo install -m 0755 "$HOME/.cache/go-cache-plugin/go-cache-plugin" /usr/local/bin/go-cache-plugin
+        go-cache-plugin serve > /tmp/go-cache-plugin.log 2>&1 &
+        # go commands fail confusingly if they reach the proxy before it listens.
+        timeout 30 bash -c 'until (exec 3<>/dev/tcp/localhost/12345) 2>/dev/null; do sleep 0.2; done'

--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -69,9 +69,28 @@ jobs:
           readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/shard.sh -N"$SHARD")"
           CGO_ENABLED=0 go test -vet=off -short -timeout=30m "${PACKAGES[@]}"
 
-  grafana-enterprise:
-    # Run this workflow for non-PR events (like pushes to `main` or `release-*`) OR for internal PRs (PRs not from forks)
+  warm-go-cache:
+    # Populate the tooling cache once; the shards below would otherwise each
+    # download the same release asset and get throttled.
     needs: detect-changes
+    if: needs.detect-changes.outputs.changed == 'true'
+    name: Warm Go cache tooling
+    runs-on: ubuntu-x64-small
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - name: Warm the tooling cache
+        uses: ./.github/actions/setup-go-remote-cache
+        with:
+          download-only: 'true'
+
+  grafana-enterprise:
+    needs: [detect-changes, warm-go-cache]
+    # Run this workflow for non-PR events (like pushes to `main` or `release-*`) OR for internal PRs (PRs not from forks)
     if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && needs.detect-changes.outputs.changed == 'true')
     strategy:
       matrix:
@@ -101,10 +120,12 @@ jobs:
         uses: ./.github/actions/setup-enterprise
         with:
           token: ${{ steps.get-github-app-token.outputs.token }}
-      # Enterprise must be cloned before setup-go so that enterprise
-      # modules are visible when the Go cache key is computed.
+      - name: Set up remote Go cache
+        uses: ./.github/actions/setup-go-remote-cache
       - name: Setup Go
         uses: ./.github/actions/setup-go
+        with:
+          cache: 'false'
 
       # Run code
       - name: Run unit tests
@@ -124,6 +145,7 @@ jobs:
   #   so they won't be accepted by a ruleset.
   required-backend-unit-tests:
     needs:
+      - warm-go-cache
       - grafana
       - grafana-enterprise
     # always() is the best function here.

--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -22,6 +22,7 @@ on:
       - scripts/ci/backend-tests/**
       - devenv/**
       - .github/actions/setup-go/**
+      - .github/actions/setup-go-remote-cache/**
       - .github/actions/setup-enterprise/**
       - .github/workflows/pr-test-integration.yml
 
@@ -171,7 +172,26 @@ jobs:
           make devenv-down sources=postgres_tests
 
   #### Enterprise
+  warm-go-cache:
+    # Populate the tooling cache once; the shards below would otherwise each
+    # download the same release asset and get throttled.
+    if: (github.event_name == 'push' && github.repository == 'grafana/grafana') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
+    name: Warm Go cache tooling
+    runs-on: ubuntu-x64-small
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - name: Warm the tooling cache
+        uses: ./.github/actions/setup-go-remote-cache
+        with:
+          download-only: 'true'
+
   sqlite-enterprise:
+    needs: warm-go-cache
     # Run this workflow for pushes to `main` or `release-*` on `grafana/grafana` (not mirrors) OR for internal PRs (PRs not from forks)
     if: (github.event_name == 'push' && github.repository == 'grafana/grafana') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
     strategy:
@@ -203,10 +223,12 @@ jobs:
         uses: ./.github/actions/setup-enterprise
         with:
           token: ${{ steps.get-github-app-token.outputs.token }}
-      # Enterprise must be cloned before setup-go so that enterprise
-      # modules are visible when the Go cache key is computed.
+      - name: Set up remote Go cache
+        uses: ./.github/actions/setup-go-remote-cache
       - name: Setup Go
         uses: ./.github/actions/setup-go
+        with:
+          cache: 'false'
       - name: Run tests
         env:
           SHARD: ${{ matrix.shard }}
@@ -217,6 +239,7 @@ jobs:
           go test -vet=off -tags=enterprise -timeout=16m -run '^TestIntegration' "${PACKAGES[@]}"
 
   mysql-enterprise:
+    needs: warm-go-cache
     # Run this workflow for pushes to `main` or `release-*` on `grafana/grafana` (not mirrors) OR for internal PRs (PRs not from forks)
     if: (github.event_name == 'push' && github.repository == 'grafana/grafana') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
     strategy:
@@ -253,10 +276,12 @@ jobs:
         uses: ./.github/actions/setup-enterprise
         with:
           token: ${{ steps.get-github-app-token.outputs.token }}
-      # Enterprise must be cloned before setup-go so that enterprise
-      # modules are visible when the Go cache key is computed.
+      - name: Set up remote Go cache
+        uses: ./.github/actions/setup-go-remote-cache
       - name: Setup Go
         uses: ./.github/actions/setup-go
+        with:
+          cache: 'false'
       - name: Wait for MySQL
         run: |
           for _ in $(seq 1 60); do
@@ -280,6 +305,7 @@ jobs:
         run: make devenv-down sources=mysql_tests
 
   postgres-enterprise:
+    needs: warm-go-cache
     # Run this workflow for pushes to `main` or `release-*` on `grafana/grafana` (not mirrors) OR for internal PRs (PRs not from forks)
     if: (github.event_name == 'push' && github.repository == 'grafana/grafana') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
     strategy:
@@ -318,10 +344,12 @@ jobs:
         uses: ./.github/actions/setup-enterprise
         with:
           token: ${{ steps.get-github-app-token.outputs.token }}
-      # Enterprise must be cloned before setup-go so that enterprise
-      # modules are visible when the Go cache key is computed.
+      - name: Set up remote Go cache
+        uses: ./.github/actions/setup-go-remote-cache
       - name: Setup Go
         uses: ./.github/actions/setup-go
+        with:
+          cache: 'false'
       - name: Setup Postgres devenv
         run: psql -p 5432 -h 127.0.0.1 -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
       - name: Run tests


### PR DESCRIPTION
**What is this change?**

Routes the Go build cache through the S3-backed `go-cache-plugin` for the enterprise backend unit shards and the enterprise integration shards, instead of `actions/setup-go`'s local cache.

- Backend unit: 427.1s to [342.5s](https://github.com/grafana/grafana/actions/runs/31636334226) per shard (n=8 both sides). `Setup Go` 92.4s to 8.5s, plus a 9.8s cache step.
- Integration: SQLite 448.2s to 377.5s, MySQL 673.5s to 580.5s, Postgres 648.9s to 569.3s per shard. [PR run](https://github.com/grafana/grafana/actions/runs/31636334073) against mains [31634191067](https://github.com/grafana/grafana/actions/runs/31634191067), [31635358802](https://github.com/grafana/grafana/actions/runs/31635358802), [31635441106](https://github.com/grafana/grafana/actions/runs/31635441106).

A prewarm job populates the plugin binary once ([16s](https://github.com/grafana/grafana/actions/runs/31636334226/job/94252319765)) so matrix shards restore it from cache rather than each pulling the release asset, which GitHub throttles once enough shards start together.

**Why do we need this?**

All 48 integration shards shared a single `actions/setup-go` cache entry keyed on `hashFiles('**/*.mod')`, which is identical for every shard. Whichever shard finished first owned the entry, so the other 47 restored a cache missing their test-only modules and build artifacts. The S3 cache is content-addressed and shared across branches, so it does not have that failure mode.

**Special notes for your reviewer:**

The remote cache is only usable in jobs that can assume the `grafana-cicd` role, and the role trust is granted per workflow file. Both workflow files are already in the trust policy on `deployment_tools` master ([#686019](https://github.com/grafana/deployment_tools/pull/686019)), so no infra change is needed for this to land.

This is deliberately not applied to the enterprise repo's integration suites. Those are per-suite with short compilations, where the plugin's per-object round trips cost more than they save.

The plugin is started in the background, so the step now waits for the proxy to accept connections before returning. Without that, a `go` command reaching the proxy first fails in a way that looks like a module download error.

Description generated by Claude Code.
