### PR TITLE
[4/9] CI: Fix gates that can report green without running

### DIFF
--- a/.github/actions/change-detection/action.yml
+++ b/.github/actions/change-detection/action.yml
@@ -20,6 +20,9 @@ outputs:
   frontend-src:
     description: Whether the frontend or self has changed, excluding test-only changes
     value: ${{ steps.changed-files.outputs.frontend_src_any_modified || 'true' }}
+  api-specs:
+    description: Whether the OpenAPI specs the generated API clients are built from have changed
+    value: ${{ steps.changed-files.outputs.api_specs_any_modified || 'true' }}
   frontend-dependencies:
     description: Whether the frontend dependencies or self have changed in any way
     value: ${{ steps.changed-files.outputs.frontend_dependencies_any_modified || 'true' }}
@@ -243,6 +246,11 @@ runs:
             - '!e2e-playwright/**'
             # apps/dashboard/pkg/migration/** carries Go tests; exclude them too.
             - '!**_test.go'
+          api_specs:
+            # The specs are JSON, so the frontend group's extension list does
+            # not match them.
+            - 'packages/grafana-openapi/**'
+            - '${{ inputs.self }}'
           frontend_dependencies:
             - 'yarn.lock'
             - 'package.json'

--- a/.github/actions/check-jobs/action.yml
+++ b/.github/actions/check-jobs/action.yml
@@ -33,8 +33,8 @@ runs:
         # Print the needs context, debugging
         echo "$NEEDS" | jq
 
-        # Extract failures
-        FAILURES="$(echo "$NEEDS" | jq 'with_entries(select(.value.result == "failure")) | map_values(.result)')"
+        # Skips are deliberate; a cancellation means the work never ran.
+        FAILURES="$(echo "$NEEDS" | jq 'with_entries(select(.value.result == "failure" or .value.result == "cancelled")) | map_values(.result)')"
 
         # Check if there are any failures
         if [ "$(echo "$FAILURES" | jq '. | length')" != "0" ]; then

--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -25,6 +25,7 @@ jobs:
       prettier: ${{ steps.detect-changes.outputs.frontend == 'true' || steps.detect-changes.outputs.docs == 'true' }}
       changed-frontend-packages: ${{ steps.detect-changes.outputs.frontend-packages }}
       changed-frontend-dependencies: ${{ steps.detect-changes.outputs.frontend-dependencies }}
+      changed-api-clients: ${{ steps.detect-changes.outputs.frontend == 'true' || steps.detect-changes.outputs.api-specs == 'true' }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -138,12 +139,13 @@ jobs:
     - run: yarn run typecheck
     - run: yarn run typecheck:smoke
   lint-frontend-api-clients:
+    needs: detect-changes
     permissions:
       contents: read
       id-token: write
     # Run this workflow only for PRs from forks; if it gets merged into `main` or `release-*`,
     # the `lint-frontend-api-clients-enterprise` workflow will run instead
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true && needs.detect-changes.outputs.changed-api-clients == 'true'
     name: Verify API clients
     runs-on: ubuntu-x64
     steps:
@@ -206,11 +208,12 @@ jobs:
             exit 1
         fi
   lint-frontend-api-clients-enterprise:
+    needs: detect-changes
     permissions:
       contents: read
       id-token: write
     # Run this workflow for pushes to `main` or `release-*` on `grafana/grafana` (not mirrors) OR for internal PRs (PRs not from forks)
-    if: (github.event_name == 'push' && github.repository == 'grafana/grafana') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
+    if: (github.event_name == 'push' && github.repository == 'grafana/grafana') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && needs.detect-changes.outputs.changed-api-clients == 'true')
     name: Verify API clients (enterprise)
     runs-on: ubuntu-x64
     steps:

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -304,6 +304,13 @@ jobs:
       contents: read
       id-token: write
     steps:
+      # Checkout wipes the workspace, so it has to precede the downloads below.
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            .github/actions/check-jobs
+
       - name: Download blob reports from GitHub Actions Artifacts
         if: needs.run-playwright-tests.result != 'skipped'
         uses: actions/download-artifact@v8
@@ -338,7 +345,7 @@ jobs:
 
       - name: Check test suites
         id: check-jobs
-        uses: grafana/grafana/.github/actions/check-jobs@main
+        uses: ./.github/actions/check-jobs
         continue-on-error: true # Failure will be reported on Check test results step
         with:
           needs: ${{ toJson(needs) }}

--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -366,3 +366,34 @@ jobs:
         if: always()
         run: |
           make devenv-down sources=postgres_tests
+
+  # Every job the matrices depend on must be listed below, or a failure there
+  # skips them and reports as a green gate.
+  required-integration-tests:
+    needs:
+      - warm-go-cache
+      - sqlite
+      - mysql
+      - postgres
+      - sqlite-enterprise
+      - mysql-enterprise
+      - postgres-enterprise
+    # always() is the best function here.
+    # success() || failure() will skip this job if any need is also skipped.
+    # That means conditional test suites would fail the entire requirement check.
+    if: always()
+
+    name: All integration tests complete
+    runs-on: ubuntu-arm64-small
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - name: Check test suites
+        uses: ./.github/actions/check-jobs
+        with:
+          needs: ${{ toJson(needs) }}
+          failure-message: "One or more integration test suites have failed"
+          success-message: "All integration test suites passed"

--- a/.github/workflows/storybook-a11y.yml
+++ b/.github/workflows/storybook-a11y.yml
@@ -80,13 +80,21 @@ jobs:
     needs:
       - detect-changes
       - test-storybook-a11y
+    permissions:
+      contents: read
     steps:
       - name: No frontend changes detected
         if: needs.detect-changes.outputs.changed != 'true'
         run: echo "No frontend changes detected, skipping storybook a11y tests"
+      - uses: actions/checkout@v5
+        if: needs.detect-changes.outputs.changed == 'true'
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            .github/actions/check-jobs
       - name: Check test suites
         if: needs.detect-changes.outputs.changed == 'true'
-        uses: grafana/grafana/.github/actions/check-jobs@main
+        uses: ./.github/actions/check-jobs
         with:
           needs: ${{ toJson(needs) }}
           failure-message: "One or more storybook a11y test suites have failed"


### PR DESCRIPTION
**What is this change?**

Four correctness fixes to CI gating. None of them saves time; two cost a little.

- The shared job-result gate selected only `failure`, so a cancelled job counted as a pass. Cancellations now fail the gate. Skips still pass, since gated suites are legitimately conditional.
- The integration workflow had no aggregate job. Its matrices depend on the cache prewarm, so a prewarm failure skipped all 48 shards and left the workflow with nothing failed to report. Adds [All integration tests complete](https://github.com/grafana/grafana/actions/runs/31636334073/job/94256862573), 18s.
- Two gate jobs used `grafana/grafana/.github/actions/check-jobs@main`, an unpinned reference to this repository from inside itself, which also meant edits to the gate were not exercised by the PR making them. They now use the local path. Costs about 11s for the added checkout, which is sparse.
- The API client lint jobs are gated on change detection with a new `api_specs` filter, so they skip on PRs that touch neither frontend code nor the specs. 71-83s when skipped.

**Why do we need this?**

Each of these is a way for CI to report green without having run the work.

**Special notes for your reviewer:**

The `api_specs` filter covers `packages/grafana-openapi/**` and the workflow itself. It deliberately excludes `pkg/tests/apis/**`: those Go tests *write* the spec files, while the gated job reads the committed ones, so a change there cannot alter the job's result but would force it to run on a large share of backend PRs.

Two things to be aware of before relying on the new integration gate:
- It must not be added to a ruleset yet. `pr-test-integration.yml` has a `pull_request` `paths:` filter, so on a docs-only PR the gate job does not exist at all, and rulesets have no path exemptions. Requiring it in that state would make those PRs permanently unmergeable. Making it required needs the paths filter replaced with a `detect-changes` job first, which is out of scope here.
- Treating cancellations as failures interacts with concurrency auto-cancellation, but safely: cancelling a superseded run cancels the gate too, so it never reports red for a normal supersede.

Also fixes an ordering bug this exposed in the Playwright gate: the added checkout wipes the workspace, so placing it after the blob-report download deleted the reports. It now runs first.

Description generated by Claude Code.
