### PR TITLE
[5/9] Build: Speed up catalog downloads, app codegen and test sharding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,9 +241,8 @@ do-gen-apps: ## Generate code for Grafana App SDK apps
 		echo "Generating code for app: $(app)"; \
 		$(MAKE) -C $$app_dir generate; \
 	else \
-		for dir in $(APPS_DIRS); do \
-			$(MAKE) -C $$dir generate; \
-		done; \
+		$(MAKE) -C $(firstword $(APPS_DIRS)) install-app-sdk; \
+		printf '%s\n' $(APPS_DIRS) | xargs -P8 -I{} $(MAKE) -C {} generate; \
 		./hack/update-codegen.sh; \
 	fi
 

--- a/scripts/ci/backend-tests/pkgs-with-tests-named.sh
+++ b/scripts/ci/backend-tests/pkgs-with-tests-named.sh
@@ -59,13 +59,16 @@ fi
 
 readarray -t PACKAGES <<< "$(go list -f '{{.Dir}}' -e "${dirs[@]}")"
 
+declare -A HAS_MATCH=()
+while IFS= read -r f; do
+    HAS_MATCH["${f%/*}"]=1
+done < <(find "${PACKAGES[@]}" -maxdepth 1 -type f -name '*_test.go' -print0 | xargs -0 -r grep -l "^func $beginningWith")
+if [[ ${#HAS_MATCH[@]} -eq 0 ]]; then
+    echo "No packages with tests named $beginningWith* found in: ${dirs[*]}" >&2
+    exit 1
+fi
 for i in "${!PACKAGES[@]}"; do
-    readarray -t PKG_FILES <<< "$(find "${PACKAGES[$i]}" -maxdepth 1 -type f -name '*_test.go')"
-    if [ ${#PKG_FILES[@]} -eq 0 ] || [ ${#PKG_FILES[@]} -eq 1 ] && [ -z "${PKG_FILES[0]}" ]; then
-        unset "PACKAGES[$i]"
-        continue
-    fi
-    if ! grep -q "^func $beginningWith" "${PKG_FILES[@]}"; then
+    if [[ -z "${HAS_MATCH[${PACKAGES[$i]}]:-}" ]]; then
         unset "PACKAGES[$i]"
     fi
 done

--- a/scripts/ci/backend-tests/shard.sh
+++ b/scripts/ci/backend-tests/shard.sh
@@ -127,8 +127,16 @@ if [[ ${#PACKAGES[@]} -eq 0 ]]; then
     exit 1
 fi
 
+declare -A HAS_TESTS=()
+while IFS= read -r f; do
+    HAS_TESTS["${f%/*}"]=1
+done < <(find "${PACKAGES[@]}" -maxdepth 1 -type f -name '*_test.go')
+if [[ ${#HAS_TESTS[@]} -eq 0 ]]; then
+    echo "No packages with test files found in: ${dirs[*]}" >&2
+    exit 1
+fi
 for i in "${!PACKAGES[@]}"; do
-    if [ -z "$(find "${PACKAGES[i]}" -maxdepth 1 -type f -name '*_test.go' -printf '.' -quit)" ]; then
+    if [[ -z "${HAS_TESTS[${PACKAGES[i]}]:-}" ]]; then
         # There are no test files in this package.
         unset 'PACKAGES[i]'
     fi

--- a/scripts/download-catalog-plugins.sh
+++ b/scripts/download-catalog-plugins.sh
@@ -104,7 +104,7 @@ fetch_resolved_meta() {
   os_arch_key="$(echo "${os}" | tr '[:upper:]' '[:lower:]')-${arch}"
 
   local url="${GRAFANA_CATALOG_API}/${plugin_id}/versions"
-  local hdrs=(-fSL)
+  local hdrs=(-fSL --no-progress-meter)
   if [[ -n "${grafana_ver}" ]]; then
     hdrs+=(-H "grafana-version: ${grafana_ver}" -H "User-Agent: grafana ${grafana_ver}")
   fi
@@ -145,7 +145,7 @@ download_plugin_archive() {
 
   local dl_url="${GRAFANA_CATALOG_API}/${plugin_id}/versions/${resolved_version}/download"
   # pkg/build/daggerbuild/plugins.DownloadPlugins curl (zip fetch), not repo.Client User-Agent.
-  local hdrs=(-fSL -H "User-Agent: grafana-build")
+  local hdrs=(-fSL --no-progress-meter -H "User-Agent: grafana-build")
   if [[ -n "${grafana_ver}" ]]; then
     hdrs+=(-H "grafana-version: ${grafana_ver}")
   fi
@@ -269,37 +269,52 @@ main() {
   rm -rf "${out}"
   mkdir -p "${out}"
 
-  local line plugin_id plan_ver spec_checksum meta resolved_ver sha tmp_zip
+  local line pids=() pid rc=0
   while IFS= read -r line; do
     [[ -z "${line}" ]] && continue
-    IFS='|' read -r plugin_id plan_ver spec_checksum <<<"${line}"
+    while (( $(jobs -rp | wc -l) >= 6 )); do
+      wait -n || rc=1
+    done
+    download_one "${line}" "${grafana_version}" "${os_str}" "${arch_str}" "${out}" &
+    pids+=("$!")
+  done < <(merge_specs_lines <"${specs_tmp}")
 
-    if [[ -n "${plan_ver}" ]]; then
-      # pkg/build/daggerbuild/plugins.ResolvePluginVersions (pinned): no versions API call;
-      # URL from BuildPluginDownloadURL; checksum only from spec (optional).
-      resolved_ver="${plan_ver}"
-      sha="${spec_checksum}"
-      if [[ -n "${sha}" ]]; then
-        sha="${sha#sha256:}"
-      fi
-    else
-      meta="$(fetch_resolved_meta "${plugin_id}" "${grafana_version}" "${os_str}" "${arch_str}")"
-      resolved_ver="$(jq -r '.version' <<<"${meta}")"
-      sha="$(jq -r '.sha256 // empty' <<<"${meta}")"
+  for pid in "${pids[@]+"${pids[@]}"}"; do
+    wait "${pid}" || rc=1
+  done
+  return "${rc}"
+}
+
+download_one() {
+  local line="$1" grafana_version="$2" os_str="$3" arch_str="$4" out="$5"
+  local plugin_id plan_ver spec_checksum meta resolved_ver sha tmp_zip
+  IFS='|' read -r plugin_id plan_ver spec_checksum <<<"${line}"
+
+  if [[ -n "${plan_ver}" ]]; then
+    # pkg/build/daggerbuild/plugins.ResolvePluginVersions (pinned): no versions API call;
+    # URL from BuildPluginDownloadURL; checksum only from spec (optional).
+    resolved_ver="${plan_ver}"
+    sha="${spec_checksum}"
+    if [[ -n "${sha}" ]]; then
+      sha="${sha#sha256:}"
+    fi
+  else
+    meta="$(fetch_resolved_meta "${plugin_id}" "${grafana_version}" "${os_str}" "${arch_str}")"
+    resolved_ver="$(jq -r '.version' <<<"${meta}")"
+    sha="$(jq -r '.sha256 // empty' <<<"${meta}")"
+    if [[ -n "${spec_checksum}" ]]; then
+      spec_checksum="${spec_checksum#sha256:}"
       if [[ -n "${spec_checksum}" ]]; then
-        spec_checksum="${spec_checksum#sha256:}"
-        if [[ -n "${spec_checksum}" ]]; then
-          sha="${spec_checksum}"
-        fi
+        sha="${spec_checksum}"
       fi
     fi
+  fi
 
-    tmp_zip="$(mktemp)"
+  tmp_zip="$(mktemp)"
+  trap 'rm -f "${tmp_zip}"' EXIT
 
-    download_plugin_archive "${plugin_id}" "${resolved_ver}" "${sha}" "${grafana_version}" "${os_str}" "${arch_str}" "${tmp_zip}"
-    extract_plugin_zip "${tmp_zip}" "${out}/${plugin_id}"
-    rm -f "${tmp_zip}"
-  done < <(merge_specs_lines <"${specs_tmp}")
+  download_plugin_archive "${plugin_id}" "${resolved_ver}" "${sha}" "${grafana_version}" "${os_str}" "${arch_str}" "${tmp_zip}"
+  extract_plugin_zip "${tmp_zip}" "${out}/${plugin_id}"
 }
 
 main "$@"


### PR DESCRIPTION
**What is this change?**

Three independent build-script speedups.

- Catalog plugin downloads run up to six at a time instead of serially. The `build-targz` step, which contains the download, goes 91s to [66s](https://github.com/grafana/grafana/actions/runs/31636595765).
- App SDK codegen fans out across eight workers, with the SDK binary installed once up front so the parallel targets do not race to write it. Codegen phase 196.8s to 171.5s.
- The two backend test sharding scripts ran a `find` per package to decide whether it holds test files. They now collect that in a single pass.

**Why do we need this?**

The plugin downloads are network-bound and independent, so serialising them was pure latency. The per-package `find` calls scaled with package count: roughly 1000 process spawns per invocation.

**Special notes for your reviewer:**

The sharding change alters test selection logic, so equivalence is the thing to verify. Output was compared against the previous implementation and is byte-identical: 67, 64 and 70 packages for shards 1, 4 and 8 of `./pkg/...`, and 168 packages for the integration list. The package set still comes from `go list -e` with the same `find` predicate and the same line-anchored `grep`, so build tags, external test packages and exclusions behave as before, and ordering is untouched so shard assignment is unchanged.

Both scripts now fail loudly if the scan returns nothing. Previously an empty result silently selected zero packages, and `go test` with no package arguments exits 0, which would have been a green run with no tests.

Error propagation in the parallel download: each background job is waited on by pid and any failure sets the exit status, so a failed download still fails the script rather than shipping an incomplete tarball. Concurrency is bounded because the plugin list is caller-supplied.

Description generated by Claude Code.
