### PR TITLE
Alerting: escape backslashes in folder titles

### DIFF
--- a/public/app/features/alerting/unified/hooks/useFolder.test.ts
+++ b/public/app/features/alerting/unified/hooks/useFolder.test.ts
@@ -14,6 +14,19 @@ describe('with slashes', () => {
   });
 });
 
+describe('with backslashes', () => {
+  it('should escape a backslash in the title', () => {
+    const folder = mockFolder({ title: 'my\\folder' });
+    expect(stringifyFolder(folder)).toEqual('my\\\\folder');
+  });
+
+  it('should escape a nested folder whose parent title ends in a backslash', () => {
+    // "team\" must become "team\\" so it does not merge with the following separator when parsed
+    const folder = mockFolder({ title: 'alerts', parents: [mockFolder({ title: 'team\\' })] });
+    expect(stringifyFolder(folder)).toEqual('team\\\\/alerts');
+  });
+});
+
 describe('without slashes', () => {
   it('should correctly stringify a folder', () => {
     const folder = mockFolder({ title: 'my folder' });

--- a/public/app/features/alerting/unified/hooks/useFolder.ts
+++ b/public/app/features/alerting/unified/hooks/useFolder.ts
@@ -26,5 +26,5 @@ export function stringifyFolder({ title, parents }: FolderDTO) {
 }
 
 function encodeTitle(title: string): string {
-  return title.replaceAll('/', '\\/');
+  return title.replaceAll('\\', '\\\\').replaceAll('/', '\\/');
 }


### PR DESCRIPTION
**What is this feature?**

#128956 updates the backend folder logic to escape backslashes along with forward slashes. The frontend logic here is no longer load bearing since we match folders using the prom namespace now but updating it to keep the logic consistent.