### PR TITLE
Dashboards: Add xxhash and xxh3 template variable formats

### DIFF
--- a/docs/sources/visualizations/dashboards/variables/variable-syntax.md
+++ b/docs/sources/visualizations/dashboards/variables/variable-syntax.md
@@ -225,6 +225,28 @@ String to interpolate: '${servers:text}'
 Interpolation result: "test1 + test2"
 ```
 
+### `xxh3`
+
+Hashes the interpolated value with [xxHash](https://xxhash.com/) (xxh3 64-bit) and returns the digest as zero-padded lowercase hex (16 characters). Useful when a downstream data source stores xxh3-hashed identifiers - for example, a Loki label that holds an `xxh3-64` of a serial number - and users want to query using the original, unhashed value.
+
+Multi-valued variables are hashed element-wise and joined with commas. Seeds are not supported for `xxh3`; the seed is always `0`. If you need a seeded hash, use `xxhash` instead.
+
+```bash
+serial = 'SN-42'
+String to interpolate: '${serial:xxh3}'
+Interpolation result: '<16-hex-char xxh3-64 digest>'
+```
+
+```bash
+serials = ['SN-1', 'SN-2']
+String to interpolate: '${serials:xxh3}'
+Interpolation result: '<digest-1>,<digest-2>'
+```
+
+{{< admonition type="note" >}}
+The `xxh3` formatter loads its WebAssembly implementation asynchronously the first time a dashboard using it is opened. If a query is dispatched before the WebAssembly finishes loading (typically only on the very first render after a hard reload), the variable interpolates to the unhashed value and a warning is logged to the browser console; reloading the panel produces the correct hash.
+{{< /admonition >}}
+
 ### `xxhash`
 
 Hashes the interpolated value with [xxHash](https://xxhash.com/) (xxhash64) and returns the digest as zero-padded lowercase hex (16 characters). Useful when a downstream data source stores hashed identifiers - for example, a Loki label that holds an `xxhash64` of a serial number - and users want to query using the original, unhashed value.

--- a/docs/sources/visualizations/dashboards/variables/variable-syntax.md
+++ b/docs/sources/visualizations/dashboards/variables/variable-syntax.md
@@ -227,9 +227,9 @@ Interpolation result: "test1 + test2"
 
 ### `xxh3`
 
-Hashes the interpolated value with [xxHash](https://xxhash.com/) (xxh3 64-bit) and returns the digest as zero-padded lowercase hex (16 characters). Useful when a downstream data source stores xxh3-hashed identifiers - for example, a Loki label that holds an `xxh3-64` of a serial number - and users want to query using the original, unhashed value.
+Hashes the interpolated value with [xxHash](https://xxhash.com/) (XXH3_64bits) and returns a 16-character, zero-padded lowercase hexadecimal string. Useful when a downstream data source stores XXH3-hashed identifiers—for example, a Loki label that holds an XXH3_64bits hash of a serial number—and users want to query using the original, un-hashed value.
 
-Multi-valued variables are hashed element-wise and joined with commas. Seeds are not supported for `xxh3`; the seed is always `0`. If you need a seeded hash, use `xxhash` instead.
+Multi-valued variables are hashed individually, then joined with commas. `xxh3` always uses a seed of `0` and does not support custom seeds. To specify a seed, use `xxhash` instead.
 
 ```bash
 serial = 'SN-42'
@@ -244,14 +244,14 @@ Interpolation result: '<digest-1>,<digest-2>'
 ```
 
 {{< admonition type="note" >}}
-The `xxh3` formatter loads its WebAssembly implementation asynchronously the first time a dashboard using it is opened. If a query is dispatched before the WebAssembly finishes loading (typically only on the very first render after a hard reload), the variable interpolates to the unhashed value and a warning is logged to the browser console; reloading the panel produces the correct hash.
+The `xxh3` formatter loads its WebAssembly implementation asynchronously the first time a dashboard using it is opened. If the dashboard dispatches a query before the WebAssembly finishes loading (typically only on the very first render after a hard reload), the variable interpolates to the un-hashed value and a warning is logged to the browser console. Reload the panel produces the correct hash.
 {{< /admonition >}}
 
 ### `xxhash`
 
-Hashes the interpolated value with [xxHash](https://xxhash.com/) (xxhash64) and returns the digest as zero-padded lowercase hex (16 characters). Useful when a downstream data source stores hashed identifiers - for example, a Loki label that holds an `xxhash64` of a serial number - and users want to query using the original, unhashed value.
+Hashes the interpolated value with [xxHash](https://xxhash.com/) (XXH64) and returns a 16-character, zero-padded lowercase hexadecimal string. Useful when a downstream data source stores hashed identifiers—for example, a Loki label that holds an XXH64 hash of a serial number—and users want to query using the original, un-hashed value.
 
-Multi-valued variables are hashed element-wise and joined with commas. An optional seed argument can be supplied in decimal (`${var:xxhash:1234}`) or hex (`${var:xxhash:0x1234}`) form; the default seed is `0`.
+Multi-valued variables are hashed individually, then joined with commas. An optional seed argument can be supplied in decimal (`${var:xxhash:1234}`) or hexadecimal (`${var:xxhash:0x1234}`) form. The default seed is `0`.
 
 ```bash
 serial = 'SN-42'

--- a/docs/sources/visualizations/dashboards/variables/variable-syntax.md
+++ b/docs/sources/visualizations/dashboards/variables/variable-syntax.md
@@ -224,3 +224,21 @@ servers = ["test1", "test2"]
 String to interpolate: '${servers:text}'
 Interpolation result: "test1 + test2"
 ```
+
+### `xxhash`
+
+Hashes the interpolated value with [xxHash](https://xxhash.com/) (xxhash64) and returns the digest as zero-padded lowercase hex (16 characters). Useful when a downstream data source stores hashed identifiers - for example, a Loki label that holds an `xxhash64` of a serial number - and users want to query using the original, unhashed value.
+
+Multi-valued variables are hashed element-wise and joined with commas. An optional seed argument can be supplied in decimal (`${var:xxhash:1234}`) or hex (`${var:xxhash:0x1234}`) form; the default seed is `0`.
+
+```bash
+serial = 'SN-42'
+String to interpolate: '${serial:xxhash}'
+Interpolation result: '<16-hex-char xxhash64 digest>'
+```
+
+```bash
+serials = ['SN-1', 'SN-2']
+String to interpolate: '${serials:xxhash}'
+Interpolation result: '<digest-1>,<digest-2>'
+```

--- a/packages/grafana-schema/src/common/common.gen.ts
+++ b/packages/grafana-schema/src/common/common.gen.ts
@@ -911,6 +911,7 @@ export enum VariableFormatID {
   SingleQuote = 'singlequote',
   Text = 'text',
   UriEncode = 'uriencode',
+  XXH3 = 'xxh3',
   XXHash = 'xxhash',
 }
 

--- a/packages/grafana-schema/src/common/common.gen.ts
+++ b/packages/grafana-schema/src/common/common.gen.ts
@@ -911,6 +911,7 @@ export enum VariableFormatID {
   SingleQuote = 'singlequote',
   Text = 'text',
   UriEncode = 'uriencode',
+  XXHash = 'xxhash',
 }
 
 export interface DataSourceRef {

--- a/packages/grafana-schema/src/common/variables.cue
+++ b/packages/grafana-schema/src/common/variables.cue
@@ -40,4 +40,6 @@ VariableFormatID:
 	// Format variables as URL parameters. Example in multi-variable scenario A + B + C => var-foo=A&var-foo=B&var-foo=C.
 	"queryparam" |
 	// Format variables as URL parameters with custom parameter name and value prefix.
-	"customqueryparam" @cuetsy(kind="enum",memberNames="Join|Lucene|Raw|Regex|Pipe|Distributed|CSV|HTML|JSON|PercentEncode|UriEncode|SingleQuote|DoubleQuote|SQLString|Date|Glob|Text|QueryParam|CustomQueryParam")
+	"customqueryparam" |
+	// Hash values using xxhash64 as zero-padded hex. Useful for querying data sources that store hashed identifiers.
+	"xxhash" @cuetsy(kind="enum",memberNames="Join|Lucene|Raw|Regex|Pipe|Distributed|CSV|HTML|JSON|PercentEncode|UriEncode|SingleQuote|DoubleQuote|SQLString|Date|Glob|Text|QueryParam|CustomQueryParam|XXHash")

--- a/packages/grafana-schema/src/common/variables.cue
+++ b/packages/grafana-schema/src/common/variables.cue
@@ -42,4 +42,6 @@ VariableFormatID:
 	// Format variables as URL parameters with custom parameter name and value prefix.
 	"customqueryparam" |
 	// Hash values using xxhash64 as zero-padded hex. Useful for querying data sources that store hashed identifiers.
-	"xxhash" @cuetsy(kind="enum",memberNames="Join|Lucene|Raw|Regex|Pipe|Distributed|CSV|HTML|JSON|PercentEncode|UriEncode|SingleQuote|DoubleQuote|SQLString|Date|Glob|Text|QueryParam|CustomQueryParam|XXHash")
+	"xxhash" |
+	// Hash values using xxh3 (64-bit) as zero-padded hex. Useful for querying data sources that store xxh3-hashed identifiers.
+	"xxh3" @cuetsy(kind="enum",memberNames="Join|Lucene|Raw|Regex|Pipe|Distributed|CSV|HTML|JSON|PercentEncode|UriEncode|SingleQuote|DoubleQuote|SQLString|Date|Glob|Text|QueryParam|CustomQueryParam|XXHash|XXH3")


### PR DESCRIPTION
## Summary

Adds `xxhash` and `xxh3` to the `VariableFormatID` enum and documents the new `${var:xxhash}` and `${var:xxh3}` template variable format functions. The formatters themselves live in `@grafana/scenes` — see [grafana/scenes#1606](https://github.com/grafana/scenes/pull/1606). This PR wires the enum entries and user-facing docs so the formats can be referenced by name once the depended `@grafana/scenes` version is bumped.

### What the formatters do

- **`${var:xxhash}`** — xxhash64, zero-padded 16-char lowercase hex. Optional seed via `${var:xxhash:1234}` (decimal) or `${var:xxhash:0x1234}` (hex).
- **`${var:xxh3}`** — xxh3-64, zero-padded 16-char lowercase hex. Seed always 0.

Multi-valued variables are hashed element-wise and comma-joined by both formatters.

### Motivation

Some data sources store hashed identifiers — a common pattern for high-cardinality labels in Loki or Prometheus, where the emitter replaces a serial number, tenant id, or account id with an xxHash at ingest for faster label matching. Users querying those sources today have no way to type the original unhashed value in a variable input; they have to compute the hash out-of-band and paste it. `${var:xxhash}` and `${var:xxh3}` close that gap: users type the raw value, Grafana hashes it client-side before the query is sent.

```
Loki query: {serial=~"${serialNumber:xxh3}"}
User input in variable: SN-42
Sent to Loki:           {serial=~"<xxh3-64('SN-42') hex>"}
```

Two formatters are shipped because different producers pick different xxHash variants: `xxhash64` is the older widely-adopted default; `xxh3-64` is the newer default that many recent tools have moved to.

## Changes

- `packages/grafana-schema/src/common/variables.cue` — add `"xxhash"` and `"xxh3"` to the `VariableFormatID` union + `XXHash` and `XXH3` to the cuetsy `memberNames` list.
- `packages/grafana-schema/src/common/common.gen.ts` — add `XXHash = 'xxhash'` and `XXH3 = 'xxh3'` enum members. **Note for reviewers:** I hand-updated the generated file to keep the diff self-contained; please run the usual cuetsy regeneration step to confirm the output matches.
- `docs/sources/visualizations/dashboards/variables/variable-syntax.md` — new `### xxh3` and `### xxhash` sections with single-value, multi-value, and Loki examples. The `xxh3` section includes an admonition explaining that its WebAssembly implementation loads asynchronously the first time a dashboard using `${var:xxh3}` is opened (see the companion scenes PR for detail).

## Sequencing

1. **grafana/scenes#1606** merges and releases (the formatters themselves).
2. **This PR** merges (enum entries + docs).
3. Follow-up PR bumps `@grafana/scenes` in `package.json` to the version containing the formatters — at that point `${var:xxhash}` and `${var:xxh3}` start working in Grafana Cloud.

Steps 1 and 2 can proceed in parallel; the enum entries are inert without the formatters, so there is no risk of shipping a half-wired feature.

## Test plan

- [ ] Reviewer: run cuetsy regeneration to confirm `common.gen.ts` matches the hand-update
- [ ] Reviewer: after the `@grafana/scenes` bump lands, verify both `${var:xxhash}` and `${var:xxh3}` interpolate to a 16-hex-char digest in a Loki panel and Explore
- [ ] Reviewer: verify the new docs sections render correctly on the docs preview, including the `xxh3` async-init admonition