### PR TITLE
Middleware: Skip gzip for HEAD requests to prevent pgzip goroutine leaks

### DIFF
--- a/pkg/middleware/gziper.go
+++ b/pkg/middleware/gziper.go
@@ -71,6 +71,17 @@ func Gziper() func(http.Handler) http.Handler {
 				return
 			}
 
+			// A HEAD response has no body, and the web.ResponseWriter below
+			// swallows writes with a (0, nil) short write. pgzip treats that
+			// as a write failure, skips the close path that releases its
+			// writer goroutine, and leaks one goroutine per request (gh #130649).
+			// Compressing a body that is discarded by definition is wasted
+			// work even when it does not leak, so skip the middleware entirely.
+			if req.Method == http.MethodHead {
+				next.ServeHTTP(rw, req)
+				return
+			}
+
 			grw := &gzipResponseWriter{gzip.NewWriter(rw), rw.(web.ResponseWriter)}
 			grw.Header().Set("Content-Encoding", "gzip")
 			grw.Header().Set("Vary", "Accept-Encoding")

--- a/pkg/middleware/gziper_test.go
+++ b/pkg/middleware/gziper_test.go
@@ -1,0 +1,77 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/web"
+)
+
+// TestGziperHeadRequestsDoNotCompress covers gh #130649: every HEAD request
+// with Accept-Encoding: gzip leaked one pgzip writer goroutine because the
+// web.ResponseWriter reports a (0, nil) short write for HEAD, and pgzip skips
+// the close path that releases its writer goroutine on a short write.
+func TestGziperHeadRequestsDoNotCompress(t *testing.T) {
+	var gotEncoding string
+	var gotWrites int
+	handler := Gziper()(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		gotEncoding = rw.Header().Get("Content-Encoding")
+		_, _ = rw.Write([]byte("body"))
+		gotWrites++
+	}))
+
+	req := httptest.NewRequest(http.MethodHead, "/d/abc/dash", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(web.Rw(rec, req), req)
+
+	require.Empty(t, gotEncoding, "HEAD responses must not be gzip-compressed")
+	require.Equal(t, 1, gotWrites, "the handler must still run exactly once")
+}
+
+// TestGziperHeadRequestsLeakNoGoroutines verifies the goroutine count stays
+// flat across repeated HEAD requests with gzip accepted.
+func TestGziperHeadRequestsLeakNoGoroutines(t *testing.T) {
+	handler := Gziper()(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		_, _ = rw.Write([]byte("body"))
+	}))
+
+	run := func() {
+		req := httptest.NewRequest(http.MethodHead, "/d/abc/dash", nil)
+		req.Header.Set("Accept-Encoding", "gzip")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(web.Rw(rec, req), req)
+		require.Equal(t, http.StatusOK, rec.Code)
+	}
+
+	run()
+	runtime.GC()
+	before := runtime.NumGoroutine()
+	for i := 0; i < 100; i++ {
+		run()
+	}
+	runtime.GC()
+	after := runtime.NumGoroutine()
+
+	require.LessOrEqual(t, after, before+5, "goroutine count grew across HEAD requests: before=%d after=%d", before, after)
+}
+
+// TestGziperGetRequestsStillCompress guards the normal path.
+func TestGziperGetRequestsStillCompress(t *testing.T) {
+	handler := Gziper()(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		_, _ = rw.Write([]byte(strings.Repeat("a", 1024)))
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/d/abc/dash", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(web.Rw(rec, req), req)
+
+	require.Equal(t, "gzip", rec.Header().Get("Content-Encoding"))
+	require.NotEmpty(t, rec.Body.Bytes())
+}


### PR DESCRIPTION
## Summary

With `enable_gzip = true`, every `HEAD` request carrying `Accept-Encoding: gzip` leaks one pgzip writer goroutine permanently (gh #130649). The `web.ResponseWriter` swallows HEAD body writes with `(0, nil)`; pgzip treats that as a short write, skips the close path that closes `results`, and its writer goroutine parks on a channel receive forever. Reproduced as +100 goroutines per 100 requests.

## Fix

`Gziper` now skips compression entirely for `HEAD` requests. A HEAD response has no body by definition, so compressing it is wasted work even when it does not leak. The handler still runs and writes its headers normally; only the gzip wrapper is bypassed.

## Validation

- New `TestGziperHeadRequestsDoNotCompress`: HEAD + gzip reaches the handler without a `Content-Encoding` header
- New `TestGziperHeadRequestsLeakNoGoroutines`: 100 HEAD+gzip requests leave the goroutine count flat. Verified the test reproduces the leak on the unfixed code (+100 goroutines) and passes with the fix
- New `TestGziperGetRequestsStillCompress`: GET + gzip still compresses
- `go test ./pkg/middleware/` — full package passes
- `gofmt` and `go vet` on the changed package — clean
- `git diff --check` — clean
