### PR TITLE
Navigation: Bind LocationService methods to fix Alertmanager picker

### DIFF
--- a/packages/grafana-runtime/src/services/LocationService.tsx
+++ b/packages/grafana-runtime/src/services/LocationService.tsx
@@ -66,8 +66,11 @@ export class HistoryWrapper implements LocationService, H.History {
     return this.base.location;
   }
 
-  // Arrow class fields auto-bind, so detached calls (`const m = history.push; m(loc)`)
-  // keep `this` and the orgId injection still fires.
+  // Every member below is an arrow class field, not a prototype method, because callers alias
+  // them off the instance (`const m = history.push; m(loc)` in react-router, `const update =
+  // locationService.partial` in AlertmanagerContext). Arrow fields auto-bind, so `this` — and
+  // therefore the orgId injection — survives being detached. Do not convert these back to
+  // methods without binding them in the constructor.
   push: H.History['push'] = (location, state) =>
     this.singleHistoryEntryMode
       ? this.base.replace(this.appendOrgId(location), state)
@@ -81,16 +84,20 @@ export class HistoryWrapper implements LocationService, H.History {
   block: H.History['block'] = (prompt) => this.base.block(prompt);
   listen: H.History['listen'] = (listener) => this.base.listen(listener);
 
-  setOrgIdGetter(fn: () => number) {
+  setOrgIdGetter = (fn: () => number) => {
     this.orgIdGetter = fn;
-  }
+  };
 
   // While enabled, `push` behaves as `replace`, so everything navigated to stays within
   // the entry that was current when the mode was enabled
-  setSingleHistoryEntryMode(enabled: boolean) {
+  setSingleHistoryEntryMode = (enabled: boolean) => {
     this.singleHistoryEntryMode = enabled;
-  }
+  };
 
+  // The only prototype method left: the overloads are needed because `base.createHref` accepts
+  // only a LocationDescriptorObject, and an arrow field cannot carry overloads without a cast.
+  // Safe because it is on neither LocationService nor H.History, so nothing detaches it — every
+  // caller reaches it as `this.appendOrgId(...)` from the bound arrow fields above.
   appendOrgId(location: H.LocationDescriptorObject): H.LocationDescriptorObject;
   appendOrgId(location: H.Path | H.LocationDescriptor): H.Path | H.LocationDescriptor;
   appendOrgId(location: H.Path | H.LocationDescriptor): H.Path | H.LocationDescriptor {
@@ -124,27 +131,27 @@ export class HistoryWrapper implements LocationService, H.History {
   }
 
   // LocationService
-  getLocationObservable() {
+  getLocationObservable = () => {
     return this.locationObservable.asObservable();
-  }
+  };
 
-  getHistory() {
+  getHistory = () => {
     return this;
-  }
+  };
 
-  getSearch() {
+  getSearch = () => {
     return new URLSearchParams(this.base.location.search);
-  }
+  };
 
-  getLocation() {
+  getLocation = () => {
     return this.base.location;
-  }
+  };
 
-  getSearchObject() {
+  getSearchObject = () => {
     return locationSearchToObject(this.base.location.search);
-  }
+  };
 
-  partial(query: Record<string, any>, replace?: boolean) {
+  partial = (query: Record<string, any>, replace?: boolean) => {
     const currentLocation = this.base.location;
     const newQuery = this.getSearchObject();
 
@@ -164,9 +171,9 @@ export class HistoryWrapper implements LocationService, H.History {
     } else {
       this.push(updatedUrl, currentLocation.state);
     }
-  }
+  };
 
-  reload() {
+  reload = () => {
     const state = this.base.location.state;
     let prevCounter: number | undefined;
     if (state !== null && typeof state === 'object' && 'routeReloadCounter' in state) {
@@ -179,10 +186,10 @@ export class HistoryWrapper implements LocationService, H.History {
       ...this.base.location,
       state: { routeReloadCounter: prevCounter !== undefined ? prevCounter + 1 : 1 },
     });
-  }
+  };
 
   /** @deprecated use partial, push or replace instead */
-  update(options: LocationUpdate) {
+  update = (options: LocationUpdate) => {
     deprecationWarning('LocationSrv', 'update', 'partial, push or replace');
     if (options.partial && options.query) {
       this.partial(options.query, options.partial);
@@ -199,7 +206,7 @@ export class HistoryWrapper implements LocationService, H.History {
         this.push(newLocation);
       }
     }
-  }
+  };
 }
 
 /**

--- a/public/app/features/alerting/unified/components/AlertingPageWrapper.test.tsx
+++ b/public/app/features/alerting/unified/components/AlertingPageWrapper.test.tsx
@@ -1,13 +1,16 @@
+import { clickSelectOption } from 'test/helpers/selectOptionInTest';
 import { render, screen, testWithFeatureToggles, waitFor } from 'test/test-utils';
 import { byRole } from 'testing-library-selector';
 
-import { type NavModelItem, OrgRole } from '@grafana/data';
+import { type NavModelItem, OrgRole, store } from '@grafana/data';
+import { config, locationService } from '@grafana/runtime';
 import { type AlertManagerDataSourceJsonData } from 'app/plugins/datasource/alertmanager/types';
 import { AccessControlAction } from 'app/types/accessControl';
 
 import { setupMswServer } from '../mockApi';
 import { grantUserPermissions, grantUserRole, mockDataSource } from '../mocks';
 import { setupAutoSyncConfig } from '../mocks/server/handlers/k8s/config.k8s';
+import { getOrgAlertmanagerLocalStorageKey } from '../state/AlertmanagerContext';
 import { setupDataSources } from '../testSetup/datasources';
 import { ALERTMANAGER_NAME_QUERY_KEY } from '../utils/constants';
 import { DataSourceType, GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
@@ -164,6 +167,50 @@ describe('AlertmanagerPageWrapper', () => {
       );
 
       expect(screen.queryByTestId('alertmanager-picker')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('AlertManagerPicker selection', () => {
+    const setup = (initialEntry: string) => {
+      const alertmanagerDataSource = mockDataSource<AlertManagerDataSourceJsonData>({
+        name: 'external-alertmanager',
+        uid: 'external-alertmanager-uid',
+        type: DataSourceType.Alertmanager,
+      });
+      setupDataSources(alertmanagerDataSource);
+      grantUserPermissions([
+        AccessControlAction.AlertingNotificationsRead,
+        AccessControlAction.AlertingNotificationsExternalRead,
+      ]);
+
+      return render(
+        <AlertmanagerPageWrapper accessType="notification" pageNav={testPageNav}>
+          <div>Test content</div>
+        </AlertmanagerPageWrapper>,
+        { historyOptions: { initialEntries: [initialEntry] } }
+      );
+    };
+
+    // The provider mirrors the selection into localStorage, so without this a previous test's
+    // selection decides which option is already active here.
+    beforeEach(() => {
+      store.delete(getOrgAlertmanagerLocalStorageKey(config.bootData.user.orgId));
+    });
+
+    it('selecting an external Alertmanager puts it in the url', async () => {
+      setup('/alerting/notifications');
+
+      await clickSelectOption(await screen.findByTestId('alertmanager-picker'), 'external-alertmanager');
+
+      expect(locationService.getSearch().get(ALERTMANAGER_NAME_QUERY_KEY)).toBe('external-alertmanager');
+    });
+
+    it('selecting the Grafana Alertmanager clears it from the url', async () => {
+      setup(`/alerting/notifications?${ALERTMANAGER_NAME_QUERY_KEY}=external-alertmanager`);
+
+      await clickSelectOption(await screen.findByTestId('alertmanager-picker'), 'Grafana');
+
+      expect(locationService.getSearch().get(ALERTMANAGER_NAME_QUERY_KEY)).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary

- #120978 removed the constructor `.bind(this)` calls from `HistoryWrapper` but only re-added auto-binding (as arrow class fields) for the `H.History` methods. That left `partial`, `reload`, `update`, `getHistory`, `getSearch`, `getSearchObject`, `getLocation`, `getLocationObservable` and the two setters as unbound prototype methods.

- `AlertmanagerContext` aliases `locationService.partial` off the instance, so by the time the Alertmanager picker's `onChange` called it, `this` was `undefined` and it threw `TypeError: Cannot read properties of undefined (reading 'base')`. Switching Alertmanager silently failed on every alerting page that renders the picker — i.e. installs with at least one external Alertmanager data source. Not in any tagged release; main/Cloud only.

- Converts the remaining methods to arrow class fields so they keep working when detached. `appendOrgId` stays a prototype method: its overloads are required because `base.createHref` accepts only a `LocationDescriptorObject`, and an arrow field cannot carry overloads without a cast. Nothing detaches it, since it is on neither `LocationService` nor `H.History`.

- Adds integration tests covering both branches of `updateSelectedAlertmanager` — switching to an external Alertmanager and switching back to Grafana. Both fail before the fix with the exact production stack trace.