### PR TITLE
IAM: Wire kubernetesUsersRedirectNoFallback into the user service

### DIFF
--- a/pkg/services/user/userimpl/user.go
+++ b/pkg/services/user/userimpl/user.go
@@ -183,7 +183,7 @@ func (s *Service) GetSignedInUser(ctx context.Context, cmd *user.GetSignedInUser
 			span.SetAttributes(attribute.Bool("fallback_to_legacy", false))
 			return result, nil
 		}
-		if !isNotFoundError(err) {
+		if !isNotFoundError(err) || s.isFallbackDisabled(ctx) {
 			span.RecordError(err)
 			span.SetAttributes(attribute.Bool("fallback_to_legacy", false))
 			return nil, err
@@ -267,13 +267,25 @@ func (s *Service) isKubernetesUserServiceEnabled(ctx context.Context) bool {
 	return s.openFeatureClient.Boolean(ctx, featuremgmt.FlagKubernetesUsersRedirect, false, openfeature.TransactionContext(ctx))
 }
 
+func (s *Service) isFallbackDisabled(ctx context.Context) bool {
+	if s.openFeatureClient == nil {
+		return false
+	}
+
+	return s.openFeatureClient.Boolean(ctx, featuremgmt.FlagKubernetesUsersRedirectNoFallback, false, openfeature.TransactionContext(ctx))
+}
+
 // shouldFallbackToLegacy determines whether to fall back to the legacy service
 // for a given request. The k8s redirect path builds its rest.Config from the
 // request context's *contextmodel.ReqContext so that the K8s apiserver sees
 // the original end-user identity; non-HTTP callers (authn sign-in sync,
 // grafana-cli) run as a service identity with no ReqContext on the context
-// and must keep working via the legacy path.
+// and must keep working via the legacy path, unless fallback has been
+// explicitly disabled.
 func (s *Service) shouldFallbackToLegacy(ctx context.Context) bool {
+	if s.isFallbackDisabled(ctx) {
+		return false
+	}
 	return identity.IsServiceIdentity(ctx) && contexthandler.FromContext(ctx) == nil
 }
 

--- a/pkg/services/user/userimpl/user_test.go
+++ b/pkg/services/user/userimpl/user_test.go
@@ -330,6 +330,38 @@ func TestService_NoLegacyFallback(t *testing.T) {
 	})
 }
 
+func TestService_NoFallback_ServiceIdentityWithoutReqContext(t *testing.T) {
+	noReqCtx := identity.WithServiceIdentityContext(context.Background(), 1)
+
+	t.Run("fallback disabled: k8s is used and its error is surfaced, not swallowed by legacy", func(t *testing.T) {
+		enableK8sUsersRedirectNoFallback(t)
+
+		k8sErr := errors.New("k8s error")
+		s := newWrapperServiceForTest(
+			&usertest.FakeUserService{ExpectedError: k8sErr},
+			&usertest.FakeUserService{ExpectedUser: &user.User{ID: 1, Login: "from-legacy"}},
+		)
+
+		got, err := s.GetByID(noReqCtx, &user.GetUserByIDQuery{ID: 5})
+		require.ErrorIs(t, err, k8sErr)
+		require.Nil(t, got)
+	})
+
+	t.Run("fallback enabled (default): legacy is used, k8s is never consulted", func(t *testing.T) {
+		enableK8sUsersRedirect(t)
+
+		legacyUser := &user.User{ID: 1, Login: "from-legacy"}
+		s := newWrapperServiceForTest(
+			&usertest.FakeUserService{ExpectedError: errors.New("k8s should not be called")},
+			&usertest.FakeUserService{ExpectedUser: legacyUser},
+		)
+
+		got, err := s.GetByID(noReqCtx, &user.GetUserByIDQuery{ID: 5})
+		require.NoError(t, err)
+		require.Equal(t, "from-legacy", got.Login)
+	})
+}
+
 func TestService_GetSignedInUser_FallbackOnlyOnNotFound(t *testing.T) {
 	enableK8sUsersRedirect(t)
 
@@ -386,6 +418,18 @@ func TestService_GetSignedInUser_FallbackOnlyOnNotFound(t *testing.T) {
 		_, err := s.GetSignedInUser(ctx, &user.GetSignedInUserQuery{OrgID: 2, UserID: 5})
 		require.NoError(t, err)
 		require.True(t, identity.IsServiceIdentity(k8s.gotCtx), "GetSignedInUser must resolve users as the service identity")
+	})
+
+	t.Run("fallback disabled: k8s not-found is surfaced, legacy is never consulted", func(t *testing.T) {
+		enableK8sUsersRedirectNoFallback(t)
+
+		s := newWrapperServiceForTest(
+			&usertest.FakeUserService{ExpectedError: user.ErrUserNotFound},
+			&usertest.FakeUserService{ExpectedError: errors.New("legacy should not be called")},
+		)
+		got, err := s.GetSignedInUser(context.Background(), &user.GetSignedInUserQuery{OrgID: 1, UserID: 5})
+		require.ErrorIs(t, err, user.ErrUserNotFound)
+		require.Nil(t, got)
 	})
 }
 
@@ -497,6 +541,23 @@ func enableK8sUsersRedirect(t *testing.T) {
 	require.NoError(t, err)
 	provider, err := featuremgmt.CreateStaticProviderWithStandardFlags(map[string]memprovider.InMemoryFlag{
 		featuremgmt.FlagKubernetesUsersRedirect: flag,
+	})
+	require.NoError(t, err)
+	require.NoError(t, openfeature.SetProviderAndWait(provider))
+	t.Cleanup(func() {
+		_ = openfeature.SetProviderAndWait(memprovider.NewInMemoryProvider(nil))
+	})
+}
+
+func enableK8sUsersRedirectNoFallback(t *testing.T) {
+	t.Helper()
+	redirectFlag, err := setting.ParseFlag(featuremgmt.FlagKubernetesUsersRedirect, "true")
+	require.NoError(t, err)
+	noFallbackFlag, err := setting.ParseFlag(featuremgmt.FlagKubernetesUsersRedirectNoFallback, "true")
+	require.NoError(t, err)
+	provider, err := featuremgmt.CreateStaticProviderWithStandardFlags(map[string]memprovider.InMemoryFlag{
+		featuremgmt.FlagKubernetesUsersRedirect:           redirectFlag,
+		featuremgmt.FlagKubernetesUsersRedirectNoFallback: noFallbackFlag,
 	})
 	require.NoError(t, err)
 	require.NoError(t, openfeature.SetProviderAndWait(provider))


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Wires the `kubernetesUsersRedirectNoFallback` flag into user service's fallback logic. With the flag on (alongside `kubernetesUsersRedirect`), the two places that silently fall back to legacy now skip that fallback and surface the k8s-side error instead:

- `shouldFallbackToLegacy` - previously always routed non-HTTP callers to legacy. Now returns false when the no-fallback flag is on, so those callers go through k8s too.
- `GetSignedInUser` - previously caught a k8s not-found and retried against legacy. Now returns the not-found error directly when the no-fallback flag is on.

**Why do we need this feature?**

This is needed to validate full k8s parity for the users redirect as part of the cloud rollout. With fallback disabled, any remaining gap surfaces as a hard error instead of being quietly absorbed by legacy.

**Who is this feature for?**

all users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
