### PR TITLE
Unified storage: drop disablePruner from the KV backend

### DIFF
--- a/pkg/storage/unified/apistore/restoptions.go
+++ b/pkg/storage/unified/apistore/restoptions.go
@@ -75,9 +75,9 @@ func NewRESTOptionsGetterMemory(originalStorageConfig storagebackend.Config, sec
 
 	kv := resource.NewBadgerKV(db)
 	backend, err := resource.NewKVStorageBackend(resource.KVBackendOptions{
-		KvStore:       kv,
-		Log:           log.New(),
-		DisablePruner: true,
+		KvStore:                kv,
+		Log:                    log.New(),
+		DisableStorageServices: true,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/storage/unified/migrations/resource_migration_test.go
+++ b/pkg/storage/unified/migrations/resource_migration_test.go
@@ -617,11 +617,11 @@ func TestIntegrationRun_SQLiteRetryReleasesLock(t *testing.T) {
 		require.NoError(t, err)
 
 		backend, err := resource.NewKVStorageBackend(resource.KVBackendOptions{
-			KvStore:       kvStore,
-			RvManager:     rvMgr,
-			DBKeepAlive:   eDB,
-			DisablePruner: true,
-			Log:           log.New("test.kv.retry"),
+			KvStore:                kvStore,
+			RvManager:              rvMgr,
+			DBKeepAlive:            eDB,
+			DisableStorageServices: true,
+			Log:                    log.New("test.kv.retry"),
 		})
 		require.NoError(t, err)
 
@@ -715,7 +715,6 @@ func newRetryTestResourceServerWithSearch(t *testing.T, backend resource.Storage
 	cfg.EnableSearch = true
 	cfg.IndexFileThreshold = 1000
 	cfg.IndexPath = t.TempDir()
-	cfg.DisablePruner = true
 
 	docBuilders := &resource.TestDocumentBuilderSupplier{
 		GroupsResources: map[string]string{

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -86,7 +86,6 @@ type kvStorageBackend struct {
 	eventPublisher          EventPublisher
 	natsShadow              *natsShadow
 	log                     log.Logger
-	disablePruner           bool
 	disableStorageServices  bool
 	dashboardVersionsToKeep int
 	eventRetentionPeriod    time.Duration
@@ -241,7 +240,6 @@ type KVBackendOptions struct {
 	// ExperimentalKV, when set, routes flagged use-cases to an alternative KV.
 	// Nil preserves existing behavior.
 	ExperimentalKV       *ExperimentalKVOptions
-	DisablePruner        bool
 	EventRetentionPeriod time.Duration // How long to keep events (default: 1 hour)
 	EventPruningInterval time.Duration // How often to run the event pruning (default: 5 minutes)
 	Reg                  prometheus.Registerer
@@ -322,7 +320,6 @@ type KVBackendOptions struct {
 // rather than only the one it was added to.
 func NewKVBackendOptions(cfg *setting.Cfg) KVBackendOptions {
 	return KVBackendOptions{
-		DisablePruner:           cfg.DisablePruner,
 		LastImportTimeMaxAge:    cfg.MaxFileIndexAge,
 		EventRetentionPeriod:    cfg.EventRetentionPeriod,
 		EventPruningInterval:    cfg.EventPruningInterval,
@@ -436,7 +433,6 @@ func NewKVStorageBackend(opts KVBackendOptions) (KVBackend, error) {
 		garbageCollection:       garbageCollection,
 		gcGate:                  opts.GCGate,
 		searchLookback:          opts.SearchLookback,
-		disablePruner:           opts.DisablePruner,
 		disableStorageServices:  opts.DisableStorageServices,
 		dashboardVersionsToKeep: opts.DashboardVersionsToKeep,
 		cancel:                  cancel,
@@ -444,6 +440,7 @@ func NewKVStorageBackend(opts KVBackendOptions) (KVBackend, error) {
 	}
 	err = backend.initPruner(ctx, opts.Reg)
 	if err != nil {
+		cancel()
 		return nil, fmt.Errorf("failed to initialize pruner: %w", err)
 	}
 	if backend.garbageCollection.Enabled {
@@ -452,6 +449,8 @@ func NewKVStorageBackend(opts KVBackendOptions) (KVBackend, error) {
 			// own garbage collector.
 			logger.Warn("garbage collection is enabled but storage services are disabled, not starting it")
 		} else if err := backend.initGarbageCollection(ctx); err != nil {
+			// The pruner is already running, so it has to be stopped here.
+			cancel()
 			return nil, fmt.Errorf("failed to initialize garbage collection: %w", err)
 		}
 	}
@@ -462,6 +461,7 @@ func NewKVStorageBackend(opts KVBackendOptions) (KVBackend, error) {
 			return backend.WriteEvent(ctx, *event)
 		}, *opts.TenantWatcherConfig)
 		if err != nil {
+			cancel()
 			return nil, fmt.Errorf("failed to start tenant watcher: %w", err)
 		}
 		backend.tenantWatcher = tw
@@ -620,7 +620,7 @@ func (k *kvStorageBackend) pruneEvents(ctx context.Context, key PruningKey) erro
 }
 
 func (k *kvStorageBackend) initPruner(ctx context.Context, reg prometheus.Registerer) error {
-	if k.disablePruner || k.disableStorageServices {
+	if k.disableStorageServices {
 		k.log.Debug("Pruner disabled, using noop pruner")
 		k.historyPruner = &NoopPruner{}
 		return nil

--- a/pkg/storage/unified/resource/storage_backend_test.go
+++ b/pkg/storage/unified/resource/storage_backend_test.go
@@ -3941,9 +3941,6 @@ func TestKVStorageBackendDisableStorageServices(t *testing.T) {
 		_, err := NewKVStorageBackend(KVBackendOptions{
 			KvStore:           setupBadgerKV(t),
 			GarbageCollection: gc,
-			// Construction fails here, so there is no backend to stop and the
-			// pruner would be left running.
-			DisablePruner: true,
 		})
 		require.ErrorContains(t, err, "garbage collection")
 	})

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -208,7 +208,9 @@ func NewStorageBackend(
 	kvBackendOpts.Log = log.New("storage-backend")
 	kvBackendOpts.DBKeepAlive = eDB
 	kvBackendOpts.GCGate = gcGate
-	kvBackendOpts.DisableStorageServices = disableStorageServices
+	// The KV backend has one switch for all background write jobs, so the older
+	// pruner-only setting maps onto it.
+	kvBackendOpts.DisableStorageServices = disableStorageServices || cfg.DisablePruner
 
 	for _, opt := range opts {
 		opt(&kvBackendOpts)


### PR DESCRIPTION
Follow-up to a review comment on #130593: https://github.com/grafana/grafana/pull/130593#discussion_r3767958988

The KV storage backend had two flags that both mean "do not run background write jobs": `disablePruner` and `disableStorageServices`. This keeps only the latter. `disablePruner` was added for the sqlite tests in #120047, and those are fine without garbage collection running either.

Notes for review:

- `cfg.DisablePruner` is not readable from the ini config, only set by Go test helpers, so this is not a user-visible settings change. It now maps onto `DisableStorageServices` when the KV backend is wired up.
- The older `sql` backend keeps its own separate `disablePruner`.
- Extra fix: `NewKVStorageBackend` now cancels its context when construction fails after the pruner has started, so the pruner goroutine does not outlive the failed backend.

**Why the `no-check-unified-storage-compatibility` label**

The check fires because `apistore/` counts as client side while `resource/` and `sql/` count as server side. The only client-side change is `NewRESTOptionsGetterMemory` swapping one Go struct field on an in-process, in-memory Badger backend. Nothing crosses the client/server boundary and there is no `proto/` change, so no version pairing is affected.
