### PR TITLE
Apiserver: Let the multi-tenant apiserver enforce the version policy cap

### DIFF
--- a/pkg/extensions/enterprise_imports.go
+++ b/pkg/extensions/enterprise_imports.go
@@ -341,6 +341,7 @@ import (
 	_ "github.com/grafana/grafana/pkg/services/apiserver/searchroutes"
 	_ "github.com/grafana/grafana/pkg/services/apiserver/standalone"
 	_ "github.com/grafana/grafana/pkg/services/apiserver/utils"
+	_ "github.com/grafana/grafana/pkg/services/apiserver/versionpolicy"
 	_ "github.com/grafana/grafana/pkg/services/auth"
 	_ "github.com/grafana/grafana/pkg/services/auth/authimpl"
 	_ "github.com/grafana/grafana/pkg/services/auth/authtest"

--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -1179,7 +1179,7 @@ func NewLocalStore(resourceInfo utils.ResourceInfo, scheme *runtime.Scheme, defa
 	}
 
 	client := resource.NewLocalResourceClient(server)
-	optsGetter := apistore.NewRESTOptionsGetterForClient(client, nil, defaultOpts.StorageConfig.Config, nil)
+	optsGetter := apistore.NewRESTOptionsGetterForClient(client, nil, defaultOpts.StorageConfig.Config, nil, nil)
 
 	store, err := grafanaregistry.NewRegistryStoreWithSelectableFields(scheme, resourceInfo, optsGetter, selectableFieldsOpts)
 	return store, err

--- a/pkg/services/apiserver/appinstaller/installer_test.go
+++ b/pkg/services/apiserver/appinstaller/installer_test.go
@@ -180,7 +180,7 @@ func TestRegisterStorageOptions(t *testing.T) {
 		installer := &mockAppInstaller{
 			groupVersions: []schema.GroupVersion{{Group: "test.example.com", Version: "v1"}},
 		}
-		reg := apistore.NewRESTOptionsGetterForClient(nil, nil, storagebackend.Config{}, nil)
+		reg := apistore.NewRESTOptionsGetterForClient(nil, nil, storagebackend.Config{}, nil, nil)
 		registerStorageOptions(installer, reg, logging.DefaultLogger)
 	})
 
@@ -201,7 +201,7 @@ func TestRegisterStorageOptions(t *testing.T) {
 				return nil
 			},
 		}
-		reg := apistore.NewRESTOptionsGetterForClient(nil, nil, storagebackend.Config{}, nil)
+		reg := apistore.NewRESTOptionsGetterForClient(nil, nil, storagebackend.Config{}, nil, nil)
 		registerStorageOptions(installer, reg, logging.DefaultLogger)
 
 		require.Len(t, called, 2)
@@ -226,7 +226,7 @@ func TestRegisterStorageOptions(t *testing.T) {
 				return &apistore.StorageOptions{EnableFolderSupport: true}
 			},
 		}
-		reg := apistore.NewRESTOptionsGetterForClient(nil, nil, storagebackend.Config{}, nil)
+		reg := apistore.NewRESTOptionsGetterForClient(nil, nil, storagebackend.Config{}, nil, nil)
 		registerStorageOptions(installer, reg, logging.DefaultLogger)
 
 		assert.Equal(t, 1, callCount)

--- a/pkg/services/apiserver/options/storage.go
+++ b/pkg/services/apiserver/options/storage.go
@@ -25,6 +25,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	secret "github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	inlinesecurevalue "github.com/grafana/grafana/pkg/registry/apis/secret/inline"
+	"github.com/grafana/grafana/pkg/services/apiserver/versionpolicy"
 	"github.com/grafana/grafana/pkg/services/authn/grpcutils"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/apistore"
@@ -100,6 +101,11 @@ type StorageOptions struct {
 
 	// Access to the other clients
 	ConfigProvider RestConfigProvider
+
+	// VersionPolicy caps the version each resource may persist. Built by the caller, which is where
+	// the scheme's natural version order and the configured cap are both available; nil disables
+	// enforcement.
+	VersionPolicy *versionpolicy.VersionPolicyRegistry
 }
 
 // unifiedStorageConfigValue implements pflag.Value for parsing unified storage config
@@ -297,8 +303,7 @@ func (o *StorageOptions) ApplyTo(serverConfig *genericapiserver.RecommendedConfi
 
 	o.SearchIndexClient = unified
 
-	getter := apistore.NewRESTOptionsGetterForClient(unified, o.InlineSecrets, etcdOptions.StorageConfig, o.ConfigProvider)
-	serverConfig.RESTOptionsGetter = getter
+	serverConfig.RESTOptionsGetter = apistore.NewRESTOptionsGetterForClient(unified, o.InlineSecrets, etcdOptions.StorageConfig, o.ConfigProvider, o.VersionPolicy)
 	return nil
 }
 

--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -349,7 +349,7 @@ func (s *service) start(ctx context.Context) error {
 	}
 
 	// Snapshot natural priority before applyPreferredAPIVersions reorders the scheme, so the cap ranks against natural order and preferred can't weaken it.
-	naturalOrder := naturalOrderSnapshot(s.scheme, groupVersions)
+	naturalOrder := NaturalOrderSnapshot(s.scheme, groupVersions)
 
 	if err := applyPreferredAPIVersions(s.log, s.cfg, s.scheme, apiResourceConfig); err != nil {
 		return err
@@ -377,8 +377,6 @@ func (s *service) start(ctx context.Context) error {
 			return err
 		}
 	} else {
-		getter := apistore.NewRESTOptionsGetterForClient(s.unified, s.secrets, o.RecommendedOptions.Etcd.StorageConfig, s.restConfigProvider)
-
 		if s.cfg.EnableVersionPolicy {
 			versionPolicyIni, err := buildVersionPolicyIniLayer(s.cfg)
 			if err != nil {
@@ -391,8 +389,9 @@ func (s *service) start(ctx context.Context) error {
 			if err := s.vpRegistry.Validate(); err != nil {
 				return err
 			}
-			getter.SetVersionPolicy(s.vpRegistry)
 		}
+
+		getter := apistore.NewRESTOptionsGetterForClient(s.unified, s.secrets, o.RecommendedOptions.Etcd.StorageConfig, s.restConfigProvider, s.vpRegistry)
 
 		optsregister = getter.RegisterOptions
 		serverConfig.RESTOptionsGetter = getter

--- a/pkg/services/apiserver/version_policy.go
+++ b/pkg/services/apiserver/version_policy.go
@@ -10,9 +10,9 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-// naturalOrderSnapshot captures each group's natural version priority (highest first) before
+// NaturalOrderSnapshot captures each group's natural version priority (highest first) before
 // applyPreferredAPIVersions reorders the scheme, so the cap ranks against natural order.
-func naturalOrderSnapshot(scheme *runtime.Scheme, groupVersions []schema.GroupVersion) map[string][]string {
+func NaturalOrderSnapshot(scheme *runtime.Scheme, groupVersions []schema.GroupVersion) map[string][]string {
 	order := make(map[string][]string, len(groupVersions))
 	for _, gv := range groupVersions {
 		if _, ok := order[gv.Group]; ok {

--- a/pkg/services/apiserver/version_policy_test.go
+++ b/pkg/services/apiserver/version_policy_test.go
@@ -30,7 +30,7 @@ func TestCapRanksMajorFirst(t *testing.T) {
 	}
 
 	t.Run("the whole v2 line outranks a v1 cap and is rejected", func(t *testing.T) {
-		reg := capRegistry(naturalOrderSnapshot(scheme, groupVersions))
+		reg := capRegistry(NaturalOrderSnapshot(scheme, groupVersions))
 		for _, v := range []string{"v2", "v2beta1", "v2alpha1"} {
 			allowed, maxAllowed := reg.IsVersionAllowed(group, v)
 			require.False(t, allowed, "%s must be rejected by max=v1", v)
@@ -39,7 +39,7 @@ func TestCapRanksMajorFirst(t *testing.T) {
 	})
 
 	t.Run("lower majors stay below the cap and are allowed", func(t *testing.T) {
-		reg := capRegistry(naturalOrderSnapshot(scheme, groupVersions))
+		reg := capRegistry(NaturalOrderSnapshot(scheme, groupVersions))
 		for _, v := range []string{"v1", "v1beta1", "v0alpha1"} {
 			allowed, _ := reg.IsVersionAllowed(group, v)
 			require.True(t, allowed, "%s must be allowed under max=v1", v)
@@ -48,7 +48,7 @@ func TestCapRanksMajorFirst(t *testing.T) {
 
 	t.Run("reordering the scheme does not move the ceiling", func(t *testing.T) {
 		require.NoError(t, scheme.SetVersionPriority(gv("v1"), gv("v2"), gv("v0alpha1"), gv("v2beta1"), gv("v2alpha1"), gv("v1beta1")))
-		allowed, _ := capRegistry(naturalOrderSnapshot(scheme, groupVersions)).IsVersionAllowed(group, "v2beta1")
+		allowed, _ := capRegistry(NaturalOrderSnapshot(scheme, groupVersions)).IsVersionAllowed(group, "v2beta1")
 		require.False(t, allowed, "v2beta1 still rejected: ranking is major-first, not registration order")
 	})
 }

--- a/pkg/storage/unified/apistore/restoptions.go
+++ b/pkg/storage/unified/apistore/restoptions.go
@@ -40,10 +40,11 @@ type RESTOptionsGetter struct {
 	versionPolicy *versionpolicy.VersionPolicyRegistry
 }
 
-// SetVersionPolicy sets the shared registry consulted by apistore.encode, so every resource served by
-// this getter enforces the cap against the same instance.
-func (r *RESTOptionsGetter) SetVersionPolicy(vp *versionpolicy.VersionPolicyRegistry) {
-	r.versionPolicy = vp
+// VersionPolicy returns the registry this getter enforces against; nil when enforcement is disabled.
+// A getter that wraps this one and replaces the RESTOptions decorator has to copy this onto the
+// StorageOptions it builds, or the resources it serves skip the cap.
+func (r *RESTOptionsGetter) VersionPolicy() *versionpolicy.VersionPolicyRegistry {
+	return r.versionPolicy
 }
 
 func NewRESTOptionsGetterForClient(
@@ -51,6 +52,7 @@ func NewRESTOptionsGetterForClient(
 	secrets secret.InlineSecureValueSupport,
 	original storagebackend.Config,
 	configProvider RestConfigProvider,
+	versionPolicy *versionpolicy.VersionPolicyRegistry,
 ) *RESTOptionsGetter {
 	return &RESTOptionsGetter{
 		client:         client,
@@ -58,6 +60,7 @@ func NewRESTOptionsGetterForClient(
 		original:       original,
 		options:        make(map[string]StorageOptions),
 		configProvider: configProvider,
+		versionPolicy:  versionPolicy,
 	}
 }
 
@@ -94,6 +97,7 @@ func NewRESTOptionsGetterMemory(originalStorageConfig storagebackend.Config, sec
 		resource.NewLocalResourceClient(server),
 		secrets,
 		originalStorageConfig,
+		nil,
 		nil,
 	), nil
 }
@@ -134,6 +138,7 @@ func NewRESTOptionsGetterForFileXX(path string,
 		resource.NewLocalResourceClient(server),
 		nil, // secrets
 		originalStorageConfig,
+		nil,
 		nil,
 	), nil
 }


### PR DESCRIPTION
**What is this feature?**

Makes the version-policy `maxAllowedVersion` ceiling reachable from the multi-tenant / standalone apiserver:

- the registry is now a parameter of `apistore.NewRESTOptionsGetterForClient` (the `SetVersionPolicy` setter is gone)
- `options.StorageOptions` carries it, and `ApplyTo` passes it to the getter it builds
- `naturalOrderSnapshot` is exported as `NaturalOrderSnapshot`

**Why do we need this feature?**

The cap is enforced in `apistore.encode` from the registry on the `RESTOptionsGetter`, but only the embedded apiserver ever set it — the multi-tenant apiserver builds its own getter in `StorageOptions.ApplyTo`, so the cap was silently absent there. Exporting `NaturalOrderSnapshot` is required because the cap ranks against scheme priority *before* preferred versions reorder it, which cannot be reconstructed afterwards.

No behaviour change: every caller passes `nil` except the embedded apiserver, and `version_policy_enabled` still defaults to off.

**Who is this feature for?**

Operators of multi-tenant / standalone Grafana apiservers.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/search-and-storage-team/issues/881

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)