### PR TITLE
Search: count only authorized hits in trash totals

### DIFF
--- a/pkg/storage/unified/proto/search.proto
+++ b/pkg/storage/unified/proto/search.proto
@@ -185,10 +185,11 @@ message ResourceSearchResponse {
   int64 total_hits = 4;
 
   // Whether total_hits is exact. When false, total_hits is a best-effort
-  // approximation because the exact count could not be determined cheaply. For
-  // example, a bounded post-ranking authz scan that does not run to exhaustion
-  // reports the pre-authorization match count, which over-counts the authorized
-  // total.
+  // approximation because the exact count could not be determined cheaply, and
+  // whether it over- or under-counts depends on the request. A bounded
+  // post-ranking authz scan that does not run to exhaustion reports the
+  // pre-authorization match count, which over-counts. A search of deleted
+  // resources counts only authorized hits.
   bool total_hits_exact = 9;
 
   // indicates how expensive was the query with respect to bytes read

--- a/pkg/storage/unified/resourcepb/search.pb.go
+++ b/pkg/storage/unified/resourcepb/search.pb.go
@@ -393,10 +393,11 @@ type ResourceSearchResponse struct {
 	// The total hit count
 	TotalHits int64 `protobuf:"varint,4,opt,name=total_hits,json=totalHits,proto3" json:"total_hits,omitempty"`
 	// Whether total_hits is exact. When false, total_hits is a best-effort
-	// approximation because the exact count could not be determined cheaply. For
-	// example, a bounded post-ranking authz scan that does not run to exhaustion
-	// reports the pre-authorization match count, which over-counts the authorized
-	// total.
+	// approximation because the exact count could not be determined cheaply, and
+	// whether it over- or under-counts depends on the request. A bounded
+	// post-ranking authz scan that does not run to exhaustion reports the
+	// pre-authorization match count, which over-counts. A search of deleted
+	// resources counts only authorized hits.
 	TotalHitsExact bool `protobuf:"varint,9,opt,name=total_hits_exact,json=totalHitsExact,proto3" json:"total_hits_exact,omitempty"`
 	// indicates how expensive was the query with respect to bytes read
 	QueryCost float64 `protobuf:"fixed64,5,opt,name=query_cost,json=queryCost,proto3" json:"query_cost,omitempty"`

--- a/pkg/storage/unified/search/bleve_postrank_authz.go
+++ b/pkg/storage/unified/search/bleve_postrank_authz.go
@@ -263,6 +263,12 @@ func (b *bleveIndex) runPostFilterAuthz(
 	// set is exhausted or the candidate budget is reached.
 	countOnly := limit == 0 && !wantFacets
 
+	// A trash total counts only hits the caller is allowed to see, so the scan
+	// cannot stop at a full page and fall back to the unfiltered match count. It
+	// keeps counting instead, which trash can afford: the deleter half costs no
+	// authorization call and the folder half is one cached call per folder.
+	countEveryHit := countOnly || trashAuthz != nil
+
 	agg, facetAuthorized, facetExhausted, err := b.prepareFacetAggregation(
 		ctx, access, req, index, firstReq, resources, stats, trashAuthz,
 	)
@@ -354,7 +360,7 @@ func (b *bleveIndex) runPostFilterAuthz(
 				page = append(page, info.doc)
 			}
 			// Stop as soon as the page is full (early-exit).
-			if !countOnly && len(page) >= limit {
+			if !countEveryHit && len(page) >= limit {
 				stop = true
 				break
 			}
@@ -407,7 +413,7 @@ func (b *bleveIndex) runPostFilterAuthz(
 		exhausted = facetExhausted
 	}
 	return response, b.finalizePostFilter(ctx, response, page, selectFields, firstReq.Sort, req, firstRes,
-		authorized, exhausted, reverseSort, wantFacets, agg, stats)
+		authorized, exhausted, reverseSort, wantFacets, trashAuthz != nil, agg, stats)
 }
 
 // authorizeHits filters ranked hits by the trash rule when trashAuthz is set,
@@ -579,19 +585,28 @@ func (b *bleveIndex) finalizePostFilter(
 	req *resourcepb.ResourceSearchRequest,
 	firstRes *bleve.SearchResult,
 	authorized int64,
-	exhausted, reverseSort, wantFacets bool,
+	exhausted, reverseSort, wantFacets, trash bool,
 	agg *facetAggregator,
 	stats *resource.SearchStats,
 ) error {
+	fromTop := len(req.SearchAfter) == 0 && len(req.SearchBefore) == 0
 	exact := exhausted
-	if wantFacets {
+	switch {
+	case wantFacets:
 		response.TotalHits = authorized
-	} else if exhausted && len(req.SearchAfter) == 0 && len(req.SearchBefore) == 0 {
+	case trash:
+		// The unfiltered count would say how many deleted objects match regardless
+		// of who deleted them, which is what the trash rule exists to withhold: a
+		// caller could vary filters and read other people's deletions off the
+		// total. Only authorized hits are counted, even when that undercounts.
+		response.TotalHits = authorized
+		exact = exhausted && fromTop
+	case exhausted && fromTop:
 		// The scan saw every match from the top, so the authorized count is
 		// exact. Count-only requests (Limit == 0) reach this too: they scan
 		// solely to total, and only fall through when the budget cuts them off.
 		response.TotalHits = authorized
-	} else {
+	default:
 		exact = false
 		// Approximate: report the pre-authz match count (an over-count of the
 		// authorized total) instead of paying for a full scan.

--- a/pkg/storage/unified/search/trash_authz_test.go
+++ b/pkg/storage/unified/search/trash_authz_test.go
@@ -2,6 +2,7 @@ package search_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -415,4 +416,101 @@ func TestTrashAuthz_AppliesOnEveryPage(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TotalHits must count only what the caller may see. The unfiltered count would
+// let someone with one deletion of their own vary filters and read other people's
+// deletions off the total, which no "inexact" flag prevents.
+func TestTrashAuthz_TotalHitsCountOnlyAuthorizedHits(t *testing.T) {
+	// Alice owns one; Bob owns four that match the same query.
+	build := func(t *testing.T, postRank bool) resource.ResourceIndex {
+		var index resource.ResourceIndex
+		if postRank {
+			index = newTestDashboardsIndexPostRank(t, 20)
+		} else {
+			index = newTestDashboardsIndex(t, threshold, 20, func(resource.ResourceIndex) (int64, error) { return 1, nil })
+		}
+		bobs := []string{"bob-1", "bob-2", "bob-3", "bob-4"}
+		docs := make([]*resource.BulkIndexItem, 0, len(bobs)+1)
+		docs = append(docs, trashDoc("alice-1", "folder-1", trashAlice))
+		for _, name := range bobs {
+			docs = append(docs, trashDoc(name, "folder-1", trashBob))
+		}
+		indexDocs(t, index, docs)
+		return index
+	}
+
+	for _, path := range []struct {
+		name     string
+		postRank bool
+	}{{"in-searcher", false}, {"post-rank", true}} {
+		t.Run(path.name, func(t *testing.T) {
+			// limit 1 is the case that used to leak: the page fills on Alice's only
+			// hit, so the scan stopped before exhausting and reported Bleve's
+			// unfiltered count of 5.
+			for _, limit := range []int64{1, 2, 100} {
+				t.Run(fmt.Sprintf("limit %d", limit), func(t *testing.T) {
+					index := build(t, path.postRank)
+					q := trashQueryFor(func(q *resourcepb.ResourceSearchRequest) { q.Limit = limit })
+
+					res := runTrashSearch(t, index, &trashAccessClient{}, "alice", q)
+
+					assert.Equal(t, []string{"alice-1"}, namesOf(res))
+					assert.Equal(t, int64(1), res.TotalHits, "Bob's four deletions must not be counted")
+					assert.True(t, res.TotalHitsExact, "the whole match set was scanned, so the count is exact")
+				})
+			}
+		})
+	}
+}
+
+// A zero limit means "count only" to the backend: it returns the total and no rows
+// at all. Not reachable through /trash, which resolves a zero limit to the default
+// page size, and deliberately so -- this covers the backend contract for callers
+// that reach it directly.
+func TestTrashAuthz_CountOnlyTotalIsAuthorized(t *testing.T) {
+	index := newTestDashboardsIndexPostRank(t, 20)
+	indexDocs(t, index, []*resource.BulkIndexItem{
+		trashDoc("alice-1", "folder-1", trashAlice),
+		trashDoc("bob-1", "folder-1", trashBob),
+		trashDoc("bob-2", "folder-1", trashBob),
+	})
+
+	q := trashQueryFor(func(q *resourcepb.ResourceSearchRequest) { q.Limit = 0 })
+	res := runTrashSearch(t, index, &trashAccessClient{}, "alice", q)
+
+	assert.Empty(t, namesOf(res))
+	assert.Equal(t, int64(1), res.TotalHits)
+	assert.True(t, res.TotalHitsExact)
+}
+
+// Counting from a cursor cannot produce a total, so the count is marked inexact
+// rather than being topped up from the unfiltered count.
+func TestTrashAuthz_CursorPageTotalIsInexactNotUnfiltered(t *testing.T) {
+	index := newTestDashboardsIndexPostRank(t, 20)
+	docs := make([]*resource.BulkIndexItem, 0, 8)
+	for i := range 4 {
+		suffix := string(rune('a' + i))
+		docs = append(docs, trashDoc(suffix+"-alice", "folder-1", trashAlice))
+		docs = append(docs, trashDoc(suffix+"-bob", "folder-1", trashBob))
+	}
+	indexDocs(t, index, docs)
+
+	first := runTrashSearch(t, index, &trashAccessClient{}, "alice",
+		trashQueryFor(func(q *resourcepb.ResourceSearchRequest) { q.Limit = 2 }))
+	require.Len(t, first.Results.GetRows(), 2)
+	assert.Equal(t, int64(4), first.TotalHits, "the first page sees the whole set")
+	assert.True(t, first.TotalHitsExact)
+
+	after := first.Results.GetRows()[1].SortFields
+	require.NotEmpty(t, after)
+
+	second := runTrashSearch(t, index, &trashAccessClient{}, "alice",
+		trashQueryFor(func(q *resourcepb.ResourceSearchRequest) {
+			q.Limit = 2
+			q.SearchAfter = after
+		}))
+
+	assert.LessOrEqual(t, second.TotalHits, int64(4), "never more than Alice's own deletions")
+	assert.False(t, second.TotalHitsExact, "counted from the cursor, so not a total")
 }


### PR DESCRIPTION
A trash search reported Bleve's unfiltered match count as `TotalHits` whenever its page filled before the scan exhausted. That count includes deletions belonging to other users, so a caller with one deletion of their own could vary title or field filters and read other people's off the total — for example seeing `2` where only one deletion is theirs. Marking the count inexact does not prevent that; the number is a reliable signal either way.

The scan no longer stops at a full page for trash, so the total covers the whole match set rather than just the page. Trash can afford this where live search cannot: recognising the deleter costs no authorization call, and the folder check is one cached call per folder, still bounded by the candidate budget.

Counting from a `SearchAfter` cursor cannot produce a total, so those requests report what they saw and mark it inexact, rather than topping it up from the unfiltered count. That makes an inexact trash total an under-count where every other inexact total is an over-count. `total_hits_exact` is a bool and cannot express the direction, so the comment does.

Only the post-rank path was affected — the in-searcher path authorizes inside the searcher, so its count was already filtered.

Follow-up to #130481, where this was reported in review.

Two notes for review:

- **Both code changes are needed.** Verified by reverting each alone: without the page-fill change the original leak returns; without the `trash` branch in `finalizePostFilter` the cursor case still falls through to the unfiltered count. Either looks redundant in isolation.
- **Remaining imprecision.** On cursor pages a lower bound is reported as `lte` — safe, but the wrong direction, and the same imprecision the facet path already has. Fixing it needs either a `gte` relation on the wire or an independent count scan from the top. Left for a separate decision.
