### PR TITLE
Runtime: Add setDataSourceInstanceSettings test helper

### DIFF
--- a/packages/grafana-runtime/src/internal/index.ts
+++ b/packages/grafana-runtime/src/internal/index.ts
@@ -79,6 +79,10 @@ export { logPluginMetaError, logPluginMetaWarning } from '../services/pluginMeta
 export { refetchPluginSettings } from '../services/pluginSettings/refetchPluginSettings';
 export { invalidatePluginSettingsCache } from '../services/pluginSettings/invalidatePluginSettingsCache';
 
-export { initDataSourceInstanceSettings, syncDataSourceInstanceSettings } from '../services/dataSource/settings';
+export {
+  initDataSourceInstanceSettings,
+  setDataSourceInstanceSettings,
+  syncDataSourceInstanceSettings,
+} from '../services/dataSource/settings';
 export { setDataSourcePluginImporter } from '../services/dataSource/dataSource';
 export { setExpressionDataSourceInstance } from '../services/dataSource/expressionDs';

--- a/packages/grafana-runtime/src/services/dataSource/settings.test.ts
+++ b/packages/grafana-runtime/src/services/dataSource/settings.test.ts
@@ -15,6 +15,7 @@ import {
   hasDataSourceInstance,
   initDataSourceInstanceSettings,
   reloadDataSourceInstanceSettings,
+  setDataSourceInstanceSettings,
   syncDataSourceInstanceSettings,
   upsertRuntimeDataSourceInstanceSettings,
 } from './settings';
@@ -848,6 +849,71 @@ describe('instanceSettings', () => {
       syncDataSourceInstanceSettings({ datasources: { Alpha: fixtures.Alpha }, defaultDatasource: 'Alpha' });
 
       expect((await getDataSourceInstanceSettings('runtime-ds'))?.name).toBe('Runtime');
+    });
+  });
+
+  describe('setDataSourceInstanceSettings', () => {
+    it('populates the cache so lookups by uid, name and id resolve', async () => {
+      setDataSourceInstanceSettings(fixtures, 'Bravo');
+
+      expect((await getDataSourceInstanceSettings('uid-alpha'))?.name).toBe('Alpha');
+      expect((await getDataSourceInstanceSettings('Charlie'))?.uid).toBe('uid-charlie');
+      expect((await getDataSourceInstanceSettings('3'))?.name).toBe('Charlie');
+      expect((await getDataSourceInstanceSettings(null))?.name).toBe('Bravo');
+      expect(backendGet).not.toHaveBeenCalled();
+    });
+
+    it('derives the default from isDefault when defaultDatasourceName is omitted', async () => {
+      setDataSourceInstanceSettings(fixtures);
+      expect((await getDataSourceInstanceSettings(null))?.name).toBe('Bravo');
+    });
+
+    it('leaves the default unset when omitted and nothing is flagged as default', async () => {
+      setDataSourceInstanceSettings({ Alpha: fixtures.Alpha });
+      expect(await getDataSourceInstanceSettings(null)).toBeUndefined();
+    });
+
+    it('fully resets prior state, including runtime and expression data sources', async () => {
+      initDataSourceInstanceSettings(fixtures, 'Bravo');
+      upsertRuntimeDataSourceInstanceSettings(ds({ uid: 'runtime-ds', name: 'Runtime', type: 'runtime' }));
+      setExpressionDataSourceInstance(expressionInstance(fixtures.Expression));
+
+      setDataSourceInstanceSettings({ Alpha: fixtures.Alpha }, 'Alpha');
+
+      expect(await getDataSourceInstanceSettings('runtime-ds')).toBeUndefined();
+      expect(await getDataSourceInstanceSettings('__expr__')).toBeUndefined();
+      expect(await getDataSourceInstanceSettings('uid-bravo')).toBeUndefined();
+      expect((await getDataSourceInstanceSettings('uid-alpha'))?.name).toBe('Alpha');
+    });
+
+    it('does not mutate the passed fixtures', async () => {
+      // populateMaps normalizes a missing uid to the name; that must happen on a
+      // clone, not on the caller's fixture object.
+      const noUid = ds({ id: 7, name: 'NoUid', type: 'test-db' });
+      // @ts-expect-error - simulating boot data entries without a uid
+      noUid.uid = undefined;
+
+      setDataSourceInstanceSettings({ NoUid: noUid }, 'NoUid');
+
+      expect(noUid.uid).toBeUndefined();
+      expect((await getDataSourceInstanceSettings('NoUid'))?.uid).toBe('NoUid');
+    });
+
+    describe('when process is under development', () => {
+      let originalNodeEnv = process.env.NODE_ENV;
+      beforeEach(() => {
+        process.env.NODE_ENV = 'development';
+      });
+
+      afterEach(() => {
+        process.env.NODE_ENV = originalNodeEnv;
+      });
+
+      it('setDataSourceInstanceSettings should throw', () => {
+        expect(() => setDataSourceInstanceSettings(fixtures, 'Bravo')).toThrow(
+          new Error('setDataSourceInstanceSettings() function can only be called from tests.')
+        );
+      });
     });
   });
 

--- a/packages/grafana-runtime/src/services/dataSource/settings.ts
+++ b/packages/grafana-runtime/src/services/dataSource/settings.ts
@@ -49,6 +49,7 @@ function populateMaps(settings: Record<string, DataSourceInstanceSettings>) {
 /**
  * Populate the instance-settings cache from boot data. Intended to be called
  * exactly once at application startup via the `@grafana/runtime/internal` export.
+ * In tests, use {@link setDataSourceInstanceSettings} instead.
  *
  * @internal
  */
@@ -58,6 +59,28 @@ export function initDataSourceInstanceSettings(
 ): void {
   defaultName = defaultDsName;
   populateMaps(settings);
+}
+
+/**
+ * Test helper — the sanctioned way to seed the instance-settings cache in tests.
+ * Fully resets all module state (including runtime and expression data sources),
+ * then populates the cache from a clone of `settings` so test fixtures are never
+ * mutated. When `defaultDatasourceName` is omitted, the entry flagged with
+ * `isDefault: true` becomes the default. Should only be called from tests.
+ *
+ * @internal
+ */
+export function setDataSourceInstanceSettings(
+  settings: Record<string, DataSourceInstanceSettings>,
+  defaultDatasourceName?: string
+): void {
+  if (process.env.NODE_ENV !== 'test') {
+    throw new Error('setDataSourceInstanceSettings() function can only be called from tests.');
+  }
+
+  _resetForTests();
+  populateMaps(structuredClone(settings));
+  defaultName = defaultDatasourceName ?? Object.values(settings).find((ds) => ds.isDefault)?.name ?? '';
 }
 
 /**


### PR DESCRIPTION
**What is this feature?**

Adds `setDataSourceInstanceSettings` to `@grafana/runtime/internal` — the sanctioned test helper for seeding the datasource instance-settings cache, mirroring the existing `setDatasourcePluginMetas`:

- Throws unless `NODE_ENV === 'test'`
- Fully resets module state first (including runtime and expression data sources), so every test starts from a deterministic clean slate
- Populates from a `structuredClone` of the input, so test fixtures are never mutated (`populateMaps` normalizes a missing `uid` to the `name` in place)
- Derives the default datasource from the entry flagged `isDefault: true` when the second argument is omitted

**Why do we need this feature?**

Task 1.2 of #125089 (part of the #114536 lazy-loading EPIC). Tests currently reach for `initDataSourceInstanceSettings` (the boot-time entry point) plus the package-private `_resetForTests`. Every migration task in waves 2–4 of #125089 rewrites test setup, so the helper story needs to be settled first so they all use the same one.

Migrating existing test call sites to this helper will follow in a stacked PR.

**Who is this feature for?**

Grafana frontend contributors writing tests that involve datasource instance settings.

Part of #125089

🤖 Generated with [Claude Code](https://claude.com/claude-code)