### PR TITLE
Dashboards: Make the add row/add tab buttons respect default grid

### DIFF
--- a/public/app/features/dashboard-scene/scene/layouts-shared/addNew.test.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/addNew.test.ts
@@ -62,6 +62,23 @@ describe('addNewTabTo', () => {
       const newBody = (grid.parent as DashboardScene).state.body as TabsLayoutManager;
       expect(newBody.state.tabs[0].getLayout()).toBeInstanceOf(DefaultGridLayoutManager);
     });
+
+    it('should keep an existing rows layout that has no panels', () => {
+      const rowsLayout = new RowsLayoutManager({
+        rows: [new RowItem({ title: 'Row 1' }), new RowItem({ title: 'Row 2' })],
+      });
+      new DashboardScene({
+        body: rowsLayout,
+        preferences: { defaultLayoutTemplate: DefaultGridLayoutManager.createEmpty() },
+      });
+
+      addNewTabTo(rowsLayout);
+
+      const newBody = (rowsLayout.parent as DashboardScene).state.body as TabsLayoutManager;
+      const tabLayout = newBody.state.tabs[0].getLayout();
+      expect(tabLayout).toBeInstanceOf(RowsLayoutManager);
+      expect((tabLayout as RowsLayoutManager).state.rows.map((row) => row.state.title)).toEqual(['Row 1', 'Row 2']);
+    });
   });
 
   describe('when layout already has tabs', () => {

--- a/public/app/features/dashboard-scene/scene/layouts-shared/addNew.test.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/addNew.test.ts
@@ -2,6 +2,7 @@ import { config } from '@grafana/runtime';
 import { VizPanel } from '@grafana/scenes';
 
 import { DashboardScene } from '../DashboardScene';
+import { AutoGridLayoutManager } from '../layout-auto-grid/AutoGridLayoutManager';
 import { DefaultGridLayoutManager } from '../layout-default/DefaultGridLayoutManager';
 import { RowItem } from '../layout-rows/RowItem';
 import { RowsLayoutManager } from '../layout-rows/RowsLayoutManager';
@@ -47,6 +48,19 @@ describe('addNewTabTo', () => {
       const tabs = (newBody as TabsLayoutManager).state.tabs;
       expect(tabs).toHaveLength(1);
       expect(tabs[0].getLayout().getVizPanels()).toHaveLength(1);
+    });
+
+    it('should use the dashboard default layout when the existing layout is empty', () => {
+      const grid = AutoGridLayoutManager.createEmpty();
+      new DashboardScene({
+        body: grid,
+        preferences: { defaultLayoutTemplate: DefaultGridLayoutManager.createEmpty() },
+      });
+
+      addNewTabTo(grid);
+
+      const newBody = (grid.parent as DashboardScene).state.body as TabsLayoutManager;
+      expect(newBody.state.tabs[0].getLayout()).toBeInstanceOf(DefaultGridLayoutManager);
     });
   });
 
@@ -127,6 +141,19 @@ describe('addNewRowTo', () => {
       const rows = (newBody as RowsLayoutManager).state.rows;
       expect(rows).toHaveLength(1);
       expect(rows[0].getLayout().getVizPanels()).toHaveLength(1);
+    });
+
+    it('should use the dashboard default layout when the existing layout is empty', () => {
+      const grid = AutoGridLayoutManager.createEmpty();
+      new DashboardScene({
+        body: grid,
+        preferences: { defaultLayoutTemplate: DefaultGridLayoutManager.createEmpty() },
+      });
+
+      addNewRowTo(grid);
+
+      const newBody = (grid.parent as DashboardScene).state.body as RowsLayoutManager;
+      expect(newBody.state.rows[0].getLayout()).toBeInstanceOf(DefaultGridLayoutManager);
     });
   });
 

--- a/public/app/features/dashboard-scene/scene/layouts-shared/addNew.test.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/addNew.test.ts
@@ -59,6 +59,23 @@ describe('addNewTabTo', () => {
       const newBody = (grid.parent as DashboardScene).state.body as TabsLayoutManager;
       expect(newBody.state.tabs[0].getLayout()).toBeInstanceOf(DefaultGridLayoutManager);
     });
+
+    it('should keep an existing rows layout that has no panels', () => {
+      const rowsLayout = new RowsLayoutManager({
+        rows: [new RowItem({ title: 'Row 1' }), new RowItem({ title: 'Row 2' })],
+      });
+      new DashboardScene({
+        body: rowsLayout,
+        preferences: { defaultLayoutTemplate: DefaultGridLayoutManager.createEmpty() },
+      });
+
+      addNewTabTo(rowsLayout);
+
+      const newBody = (rowsLayout.parent as DashboardScene).state.body as TabsLayoutManager;
+      const tabLayout = newBody.state.tabs[0].getLayout();
+      expect(tabLayout).toBeInstanceOf(RowsLayoutManager);
+      expect((tabLayout as RowsLayoutManager).state.rows.map((row) => row.state.title)).toEqual(['Row 1', 'Row 2']);
+    });
   });
 
   describe('when layout already has tabs', () => {

--- a/public/app/features/dashboard-scene/scene/layouts-shared/addNew.test.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/addNew.test.ts
@@ -1,5 +1,5 @@
 import { config } from '@grafana/runtime';
-import { VizPanel } from '@grafana/scenes';
+import { SceneGridLayout, VizPanel } from '@grafana/scenes';
 
 import { DashboardScene } from '../DashboardScene';
 import { AutoGridLayoutManager } from '../layout-auto-grid/AutoGridLayoutManager';
@@ -77,6 +77,30 @@ describe('addNewTabTo', () => {
       const tabLayout = newBody.state.tabs[0].getLayout();
       expect(tabLayout).toBeInstanceOf(DefaultGridLayoutManager);
       expect(tabLayout.getVizPanels()).toHaveLength(1);
+    });
+
+    it('should enable dragging and resizing on the default layout when the dashboard is being edited', () => {
+      jest.useFakeTimers();
+      try {
+        const grid = AutoGridLayoutManager.createEmpty();
+        // Mimic a template deserialized from preferences, where edit-mode flags are unset
+        const template = new DefaultGridLayoutManager({ grid: new SceneGridLayout({ children: [] }) });
+        new DashboardScene({
+          body: grid,
+          isEditing: true,
+          preferences: { defaultLayoutTemplate: template },
+        });
+
+        addNewTabTo(grid);
+        jest.runAllTimers();
+
+        const newBody = (grid.parent as DashboardScene).state.body as TabsLayoutManager;
+        const tabLayout = newBody.state.tabs[0].getLayout() as DefaultGridLayoutManager;
+        expect(tabLayout.state.grid.state.isDraggable).toBe(true);
+        expect(tabLayout.state.grid.state.isResizable).toBe(true);
+      } finally {
+        jest.useRealTimers();
+      }
     });
 
     it('should keep an existing rows layout that has no panels', () => {
@@ -205,6 +229,30 @@ describe('addNewRowTo', () => {
       const rowLayout = newBody.state.rows[0].getLayout();
       expect(rowLayout).toBeInstanceOf(DefaultGridLayoutManager);
       expect(rowLayout.getVizPanels()).toHaveLength(1);
+    });
+
+    it('should enable dragging and resizing on the default layout when the dashboard is being edited', () => {
+      jest.useFakeTimers();
+      try {
+        const grid = AutoGridLayoutManager.createEmpty();
+        // Mimic a template deserialized from preferences, where edit-mode flags are unset
+        const template = new DefaultGridLayoutManager({ grid: new SceneGridLayout({ children: [] }) });
+        new DashboardScene({
+          body: grid,
+          isEditing: true,
+          preferences: { defaultLayoutTemplate: template },
+        });
+
+        addNewRowTo(grid);
+        jest.runAllTimers();
+
+        const newBody = (grid.parent as DashboardScene).state.body as RowsLayoutManager;
+        const rowLayout = newBody.state.rows[0].getLayout() as DefaultGridLayoutManager;
+        expect(rowLayout.state.grid.state.isDraggable).toBe(true);
+        expect(rowLayout.state.grid.state.isResizable).toBe(true);
+      } finally {
+        jest.useRealTimers();
+      }
     });
   });
 

--- a/public/app/features/dashboard-scene/scene/layouts-shared/addNew.test.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/addNew.test.ts
@@ -63,6 +63,22 @@ describe('addNewTabTo', () => {
       expect(newBody.state.tabs[0].getLayout()).toBeInstanceOf(DefaultGridLayoutManager);
     });
 
+    it('should not use the dashboard default layout when the existing grid has panels', () => {
+      const panel = new VizPanel({ key: 'panel-1', pluginId: 'text' });
+      const grid = DefaultGridLayoutManager.fromVizPanels([panel]);
+      new DashboardScene({
+        body: grid,
+        preferences: { defaultLayoutTemplate: AutoGridLayoutManager.createEmpty() },
+      });
+
+      addNewTabTo(grid);
+
+      const newBody = (grid.parent as DashboardScene).state.body as TabsLayoutManager;
+      const tabLayout = newBody.state.tabs[0].getLayout();
+      expect(tabLayout).toBeInstanceOf(DefaultGridLayoutManager);
+      expect(tabLayout.getVizPanels()).toHaveLength(1);
+    });
+
     it('should keep an existing rows layout that has no panels', () => {
       const rowsLayout = new RowsLayoutManager({
         rows: [new RowItem({ title: 'Row 1' }), new RowItem({ title: 'Row 2' })],
@@ -172,6 +188,23 @@ describe('addNewRowTo', () => {
       const newBody = (grid.parent as DashboardScene).state.body as RowsLayoutManager;
       expect(newBody).toBeInstanceOf(RowsLayoutManager);
       expect(newBody.state.rows[0].getLayout()).toBeInstanceOf(DefaultGridLayoutManager);
+    });
+
+    it('should not use the dashboard default layout when the existing grid has panels', () => {
+      const panel = new VizPanel({ key: 'panel-1', pluginId: 'text' });
+      const grid = DefaultGridLayoutManager.fromVizPanels([panel]);
+      new DashboardScene({
+        body: grid,
+        preferences: { defaultLayoutTemplate: AutoGridLayoutManager.createEmpty() },
+      });
+
+      addNewRowTo(grid);
+
+      const newBody = (grid.parent as DashboardScene).state.body as RowsLayoutManager;
+      expect(newBody).toBeInstanceOf(RowsLayoutManager);
+      const rowLayout = newBody.state.rows[0].getLayout();
+      expect(rowLayout).toBeInstanceOf(DefaultGridLayoutManager);
+      expect(rowLayout.getVizPanels()).toHaveLength(1);
     });
   });
 

--- a/public/app/features/dashboard-scene/scene/layouts-shared/addNew.test.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/addNew.test.ts
@@ -2,6 +2,7 @@ import { config } from '@grafana/runtime';
 import { VizPanel } from '@grafana/scenes';
 
 import { DashboardScene } from '../DashboardScene';
+import { AutoGridLayoutManager } from '../layout-auto-grid/AutoGridLayoutManager';
 import { DefaultGridLayoutManager } from '../layout-default/DefaultGridLayoutManager';
 import { RowItem } from '../layout-rows/RowItem';
 import { RowsLayoutManager } from '../layout-rows/RowsLayoutManager';
@@ -44,6 +45,19 @@ describe('addNewTabTo', () => {
       const tabs = (newBody as TabsLayoutManager).state.tabs;
       expect(tabs).toHaveLength(1);
       expect(tabs[0].getLayout().getVizPanels()).toHaveLength(1);
+    });
+
+    it('should use the dashboard default layout when the existing layout is empty', () => {
+      const grid = AutoGridLayoutManager.createEmpty();
+      new DashboardScene({
+        body: grid,
+        preferences: { defaultLayoutTemplate: DefaultGridLayoutManager.createEmpty() },
+      });
+
+      addNewTabTo(grid);
+
+      const newBody = (grid.parent as DashboardScene).state.body as TabsLayoutManager;
+      expect(newBody.state.tabs[0].getLayout()).toBeInstanceOf(DefaultGridLayoutManager);
     });
   });
 
@@ -124,6 +138,19 @@ describe('addNewRowTo', () => {
       const rows = (newBody as RowsLayoutManager).state.rows;
       expect(rows).toHaveLength(1);
       expect(rows[0].getLayout().getVizPanels()).toHaveLength(1);
+    });
+
+    it('should use the dashboard default layout when the existing layout is empty', () => {
+      const grid = AutoGridLayoutManager.createEmpty();
+      new DashboardScene({
+        body: grid,
+        preferences: { defaultLayoutTemplate: DefaultGridLayoutManager.createEmpty() },
+      });
+
+      addNewRowTo(grid);
+
+      const newBody = (grid.parent as DashboardScene).state.body as RowsLayoutManager;
+      expect(newBody.state.rows[0].getLayout()).toBeInstanceOf(DefaultGridLayoutManager);
     });
   });
 

--- a/public/app/features/dashboard-scene/scene/layouts-shared/addNew.test.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/addNew.test.ts
@@ -170,6 +170,7 @@ describe('addNewRowTo', () => {
       addNewRowTo(grid);
 
       const newBody = (grid.parent as DashboardScene).state.body as RowsLayoutManager;
+      expect(newBody).toBeInstanceOf(RowsLayoutManager);
       expect(newBody.state.rows[0].getLayout()).toBeInstanceOf(DefaultGridLayoutManager);
     });
   });

--- a/public/app/features/dashboard-scene/scene/layouts-shared/addNew.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/addNew.ts
@@ -2,10 +2,11 @@ import { config } from '@grafana/runtime';
 import { type SceneGridRow } from '@grafana/scenes';
 
 import { NewObjectAddedToCanvasEvent } from '../../sidebar/events';
+import { getDashboardSceneFor } from '../../utils/utils';
 import { DefaultGridLayoutManager } from '../layout-default/DefaultGridLayoutManager';
-import { type RowItem } from '../layout-rows/RowItem';
+import { RowItem } from '../layout-rows/RowItem';
 import { RowsLayoutManager } from '../layout-rows/RowsLayoutManager';
-import { type TabItem } from '../layout-tabs/TabItem';
+import { TabItem } from '../layout-tabs/TabItem';
 import { TabsLayoutManager } from '../layout-tabs/TabsLayoutManager';
 import { type DashboardLayoutManager } from '../types/DashboardLayoutManager';
 import { isLayoutParent } from '../types/LayoutParent';
@@ -21,8 +22,11 @@ export function addNewTabTo(layout: DashboardLayoutManager): TabItem {
   }
 
   // Create new tabs layout and wrap the current layout in the first tab
-  const tabsLayout = TabsLayoutManager.createEmpty();
-  tabsLayout.state.tabs[0].setState({ layout: layout.clone() });
+  const defaultLayout =
+    layout.getVizPanels().length === 0 ? getDashboardSceneFor(layout).getDefaultLayout() : undefined;
+  const tabsLayout = new TabsLayoutManager({
+    tabs: [new TabItem({ layout: defaultLayout ?? layout.clone() })],
+  });
 
   layoutParent.switchLayout(tabsLayout);
 
@@ -64,7 +68,11 @@ export function addNewRowTo(layout: DashboardLayoutManager): RowItem | SceneGrid
   // If we want to add a row and current layout is custom grid or auto we migrate to rows layout
   // And wrap current layout in a row
 
-  const rowsLayout = RowsLayoutManager.createFromLayout(layoutParent.getLayout());
+  const defaultLayout =
+    layout.getVizPanels().length === 0 ? getDashboardSceneFor(layout).getDefaultLayout() : undefined;
+  const rowsLayout = defaultLayout
+    ? new RowsLayoutManager({ rows: [new RowItem({ layout: defaultLayout })] })
+    : RowsLayoutManager.createFromLayout(layoutParent.getLayout());
   layoutParent.switchLayout(rowsLayout);
 
   const row = rowsLayout.state.rows[0];

--- a/public/app/features/dashboard-scene/scene/layouts-shared/addNew.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/addNew.ts
@@ -3,9 +3,9 @@ import { type SceneGridRow } from '@grafana/scenes';
 
 import { NewObjectAddedToCanvasEvent } from '../../sidebar/events';
 import { DefaultGridLayoutManager } from '../layout-default/DefaultGridLayoutManager';
-import { RowItem } from '../layout-rows/RowItem';
+import { type RowItem } from '../layout-rows/RowItem';
 import { RowsLayoutManager } from '../layout-rows/RowsLayoutManager';
-import { TabItem } from '../layout-tabs/TabItem';
+import { type TabItem } from '../layout-tabs/TabItem';
 import { TabsLayoutManager } from '../layout-tabs/TabsLayoutManager';
 import { type DashboardLayoutManager } from '../types/DashboardLayoutManager';
 import { isLayoutParent } from '../types/LayoutParent';
@@ -23,6 +23,18 @@ function getDefaultLayoutForEmptyGrid(layout: DashboardLayoutManager): Dashboard
   return getDashboardSceneLike(layout).getDefaultLayout();
 }
 
+function createTabsLayoutContaining(layout: DashboardLayoutManager): TabsLayoutManager {
+  const tabsLayout = TabsLayoutManager.createEmpty();
+  tabsLayout.state.tabs[0].setState({ layout });
+  return tabsLayout;
+}
+
+function createRowsLayoutContaining(layout: DashboardLayoutManager): RowsLayoutManager {
+  const rowsLayout = RowsLayoutManager.createEmpty();
+  rowsLayout.state.rows[0].setState({ layout });
+  return rowsLayout;
+}
+
 export function addNewTabTo(layout: DashboardLayoutManager): TabItem {
   const layoutParent = layout.parent!;
   if (!isLayoutParent(layoutParent)) {
@@ -34,14 +46,12 @@ export function addNewTabTo(layout: DashboardLayoutManager): TabItem {
   }
 
   // Create new tabs layout and wrap the current layout in the first tab
-  const defaultLayout = getDefaultLayoutForEmptyGrid(layout);
-  const tabsLayout = new TabsLayoutManager({
-    tabs: [new TabItem({ layout: defaultLayout ?? layout.clone() })],
-  });
+  const layoutToWrap = getDefaultLayoutForEmptyGrid(layout) ?? layout.clone();
+  const tabsLayout = createTabsLayoutContaining(layoutToWrap);
+  const tab = tabsLayout.state.tabs[0];
 
   layoutParent.switchLayout(tabsLayout);
 
-  const tab = tabsLayout.state.tabs[0];
   layout.publishEvent(new NewObjectAddedToCanvasEvent(tab), true);
 
   return tab;
@@ -81,7 +91,7 @@ export function addNewRowTo(layout: DashboardLayoutManager): RowItem | SceneGrid
 
   const defaultLayout = getDefaultLayoutForEmptyGrid(layout);
   const rowsLayout = defaultLayout
-    ? new RowsLayoutManager({ rows: [new RowItem({ layout: defaultLayout })] })
+    ? createRowsLayoutContaining(defaultLayout)
     : RowsLayoutManager.createFromLayout(layoutParent.getLayout());
   layoutParent.switchLayout(rowsLayout);
 

--- a/public/app/features/dashboard-scene/scene/layouts-shared/addNew.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/addNew.ts
@@ -20,7 +20,16 @@ function getDefaultLayoutForEmptyGrid(layout: DashboardLayoutManager): Dashboard
     return undefined;
   }
 
-  return getDashboardSceneLike(layout).getDefaultLayout();
+  const dashboard = getDashboardSceneLike(layout);
+  const defaultLayout = dashboard.getDefaultLayout();
+
+  // A template deserialized from preferences carries no edit-mode flags, so without this
+  // panels in the new group would not be draggable/resizable until edit mode is re-entered
+  if (dashboard.state.isEditing) {
+    defaultLayout?.editModeChanged?.(true);
+  }
+
+  return defaultLayout;
 }
 
 function createTabsLayoutContaining(layout: DashboardLayoutManager): TabsLayoutManager {

--- a/public/app/features/dashboard-scene/scene/layouts-shared/addNew.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/addNew.ts
@@ -92,7 +92,7 @@ export function addNewRowTo(layout: DashboardLayoutManager): RowItem | SceneGrid
   const defaultLayout = getDefaultLayoutForEmptyGrid(layout);
   const rowsLayout = defaultLayout
     ? createRowsLayoutContaining(defaultLayout)
-    : RowsLayoutManager.createFromLayout(layoutParent.getLayout());
+    : RowsLayoutManager.createFromLayout(layout);
   layoutParent.switchLayout(rowsLayout);
 
   const row = rowsLayout.state.rows[0];

--- a/public/app/features/dashboard-scene/scene/layouts-shared/addNew.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/addNew.ts
@@ -2,7 +2,6 @@ import { config } from '@grafana/runtime';
 import { type SceneGridRow } from '@grafana/scenes';
 
 import { NewObjectAddedToCanvasEvent } from '../../sidebar/events';
-import { getDashboardSceneFor } from '../../utils/utils';
 import { DefaultGridLayoutManager } from '../layout-default/DefaultGridLayoutManager';
 import { RowItem } from '../layout-rows/RowItem';
 import { RowsLayoutManager } from '../layout-rows/RowsLayoutManager';
@@ -10,6 +9,7 @@ import { TabItem } from '../layout-tabs/TabItem';
 import { TabsLayoutManager } from '../layout-tabs/TabsLayoutManager';
 import { type DashboardLayoutManager } from '../types/DashboardLayoutManager';
 import { isLayoutParent } from '../types/LayoutParent';
+import { getDashboardSceneLike } from '../types/dashboard';
 
 /**
  * Dashboard default layout to start the new group with, when the current layout holds nothing worth keeping.
@@ -20,7 +20,7 @@ function getDefaultLayoutForEmptyGrid(layout: DashboardLayoutManager): Dashboard
     return undefined;
   }
 
-  return getDashboardSceneFor(layout).getDefaultLayout();
+  return getDashboardSceneLike(layout).getDefaultLayout();
 }
 
 export function addNewTabTo(layout: DashboardLayoutManager): TabItem {

--- a/public/app/features/dashboard-scene/scene/layouts-shared/addNew.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/addNew.ts
@@ -11,6 +11,18 @@ import { TabsLayoutManager } from '../layout-tabs/TabsLayoutManager';
 import { type DashboardLayoutManager } from '../types/DashboardLayoutManager';
 import { isLayoutParent } from '../types/LayoutParent';
 
+/**
+ * Dashboard default layout to start the new group with, when the current layout holds nothing worth keeping.
+ * Only grids qualify: rows and tabs carry structure the user built even while they contain no panels.
+ */
+function getDefaultLayoutForEmptyGrid(layout: DashboardLayoutManager): DashboardLayoutManager | undefined {
+  if (!layout.descriptor.isGridLayout || layout.getVizPanels().length > 0) {
+    return undefined;
+  }
+
+  return getDashboardSceneFor(layout).getDefaultLayout();
+}
+
 export function addNewTabTo(layout: DashboardLayoutManager): TabItem {
   const layoutParent = layout.parent!;
   if (!isLayoutParent(layoutParent)) {
@@ -22,8 +34,7 @@ export function addNewTabTo(layout: DashboardLayoutManager): TabItem {
   }
 
   // Create new tabs layout and wrap the current layout in the first tab
-  const defaultLayout =
-    layout.getVizPanels().length === 0 ? getDashboardSceneFor(layout).getDefaultLayout() : undefined;
+  const defaultLayout = getDefaultLayoutForEmptyGrid(layout);
   const tabsLayout = new TabsLayoutManager({
     tabs: [new TabItem({ layout: defaultLayout ?? layout.clone() })],
   });
@@ -68,8 +79,7 @@ export function addNewRowTo(layout: DashboardLayoutManager): RowItem | SceneGrid
   // If we want to add a row and current layout is custom grid or auto we migrate to rows layout
   // And wrap current layout in a row
 
-  const defaultLayout =
-    layout.getVizPanels().length === 0 ? getDashboardSceneFor(layout).getDefaultLayout() : undefined;
+  const defaultLayout = getDefaultLayoutForEmptyGrid(layout);
   const rowsLayout = defaultLayout
     ? new RowsLayoutManager({ rows: [new RowItem({ layout: defaultLayout })] })
     : RowsLayoutManager.createFromLayout(layoutParent.getLayout());

--- a/public/app/features/dashboard-scene/scene/types/dashboard.ts
+++ b/public/app/features/dashboard-scene/scene/types/dashboard.ts
@@ -83,6 +83,8 @@ export interface DashboardSceneLike extends SceneObject<DashboardSceneState>, La
   isDashboardScene: boolean;
 
   copyPanel(vizPanel: VizPanel): void;
+
+  getDefaultLayout(): DashboardLayoutManager;
 }
 
 function isDashboardSceneLike(obj: SceneObject): obj is DashboardSceneLike {

--- a/public/app/features/dashboard-scene/scene/types/dashboard.ts
+++ b/public/app/features/dashboard-scene/scene/types/dashboard.ts
@@ -84,7 +84,7 @@ export interface DashboardSceneLike extends SceneObject<DashboardSceneState>, La
 
   copyPanel(vizPanel: VizPanel): void;
 
-  getDefaultLayout(): DashboardLayoutManager;
+  getDefaultLayout(): DashboardLayoutManager | undefined;
 }
 
 function isDashboardSceneLike(obj: SceneObject): obj is DashboardSceneLike {


### PR DESCRIPTION
**What is this feature?**

Make the add row and add tab buttons in the add sidepane respect the default grid.

**Why do we need this feature?**

Consistency.

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/130032

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
