### PR TITLE
CloudWatch: Migrate datalinks to getDataSourceInstanceSettings

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2873,9 +2873,6 @@
     }
   },
   "public/app/plugins/datasource/cloudwatch/utils/datalinks.ts": {
-    "@grafana/no-get-data-source-srv": {
-      "count": 1
-    },
     "@typescript-eslint/consistent-type-assertions": {
       "count": 2
     }

--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.test.ts
@@ -1,9 +1,21 @@
-import { type DataQueryRequest, type DataQueryResponse, dateMath, FieldType } from '@grafana/data';
-import { config, setDataSourceSrv, type DataSourceSrv } from '@grafana/runtime';
+import {
+  type DataQueryRequest,
+  type DataQueryResponse,
+  type DataSourceInstanceSettings,
+  dateMath,
+  FieldType,
+} from '@grafana/data';
+import { config } from '@grafana/runtime';
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 
 import { type CloudWatchQuery } from '../types';
 
 import { addDataLinksToLogsResponse } from './datalinks';
+
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstanceSettings: jest.fn(),
+}));
 
 describe('addDataLinksToLogsResponse', () => {
   // @ts-ignore ignore feature toggle type error
@@ -55,13 +67,9 @@ describe('addDataLinksToLogsResponse', () => {
       range: { ...time, raw: time },
     } as DataQueryRequest<CloudWatchQuery>;
 
-    setDataSourceSrv({
-      async get() {
-        return {
-          name: 'Xray',
-        };
-      },
-    } as DataSourceSrv);
+    jest
+      .mocked(getDataSourceInstanceSettings)
+      .mockResolvedValue({ name: 'Xray' } as unknown as DataSourceInstanceSettings);
 
     await addDataLinksToLogsResponse(
       mockResponse,

--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.test.ts
@@ -255,6 +255,55 @@ describe('addDataLinksToLogsResponse', () => {
     });
   });
 
+  it('should not add xray data link when the linked data source is missing', async () => {
+    // @ts-ignore ignore feature toggle type error
+    config.featureToggles.cloudWatchLogsInsightsDataLinks = false;
+
+    const mockResponse: DataQueryResponse = {
+      data: [
+        {
+          fields: [
+            {
+              name: '@xrayTraceId',
+              config: {},
+              values: ['id1', 'id2'],
+            },
+          ],
+          refId: 'A',
+        },
+      ],
+    };
+
+    const mockOptions = {
+      targets: [
+        {
+          refId: 'A',
+          expression: 'stats count(@message) by bin(1h)',
+          logGroupNames: ['fake-log-group-one'],
+          logGroups: [{}],
+          region: 'us-east-1',
+        },
+      ],
+      range: { ...time, raw: time },
+    } as DataQueryRequest<CloudWatchQuery>;
+
+    jest.mocked(getDataSourceInstanceSettings).mockResolvedValue(undefined);
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    await addDataLinksToLogsResponse(
+      mockResponse,
+      mockOptions,
+      (s) => s ?? '',
+      (v) => [v],
+      (r) => r,
+      'xrayUid'
+    );
+
+    expect(mockResponse.data[0].fields[0].config.links).toBeUndefined();
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+
   it('should not add CloudWatch console link when feature toggle is disabled', async () => {
     // @ts-ignore ignore feature toggle type error
     config.featureToggles.cloudWatchLogsInsightsDataLinks = false;

--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
@@ -7,7 +7,8 @@ import {
   type ScopedVars,
   type TimeRange,
 } from '@grafana/data';
-import { config, getDataSourceSrv } from '@grafana/runtime';
+import { config } from '@grafana/runtime';
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 
 import { type AwsUrl, encodeUrl } from '../aws_url';
 import { type CloudWatchLogsQuery } from '../dataquery.gen';
@@ -65,9 +66,13 @@ export async function addDataLinksToLogsResponse(
 async function createInternalXrayLink(datasourceUid: string, region: string): Promise<DataLink | undefined> {
   let ds;
   try {
-    ds = await getDataSourceSrv().get(datasourceUid);
+    ds = await getDataSourceInstanceSettings(datasourceUid);
   } catch (e) {
     console.error('Could not load linked xray data source, it was probably deleted after it was linked', e);
+    return undefined;
+  }
+
+  if (!ds) {
     return undefined;
   }
 

--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
@@ -68,11 +68,14 @@ async function createInternalXrayLink(datasourceUid: string, region: string): Pr
   try {
     ds = await getDataSourceInstanceSettings(datasourceUid);
   } catch (e) {
-    console.error('Could not load linked xray data source, it was probably deleted after it was linked', e);
+    console.error('Could not load linked X-Ray data source', e);
     return undefined;
   }
 
   if (!ds) {
+    console.error(
+      `Could not find linked X-Ray data source with uid: ${datasourceUid}, it was probably deleted after it was linked`
+    );
     return undefined;
   }
 


### PR DESCRIPTION
Part of #127034 (parent: #125083).

Migrates `datalinks.ts` from the deprecated sync `getDataSourceSrv().get()` to the async `getDataSourceInstanceSettings()` from `@grafana/runtime/unstable`. Since the new API resolves `undefined` for a missing data source instead of throwing, a guard is added after the lookup. Test mocks are migrated from `setDataSourceSrv` to mocking the unstable module.

Recreates the stale-closed #126648.

Note: CloudWatch is mirrored to an external data source repo — this migration may need to be applied there as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)