### PR TITLE
grafana-o11y-ds-frontend: Migrate TraceToProfilesSettings to useDataSourceInstance

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -308,9 +308,6 @@
     }
   },
   "packages/grafana-o11y-ds-frontend/src/TraceToProfiles/TraceToProfilesSettings.tsx": {
-    "@grafana/no-get-data-source-srv": {
-      "count": 1
-    },
     "react-hooks/exhaustive-deps": {
       "count": 1
     }

--- a/packages/grafana-o11y-ds-frontend/src/TraceToProfiles/TraceToProfilesSettings.test.tsx
+++ b/packages/grafana-o11y-ds-frontend/src/TraceToProfiles/TraceToProfilesSettings.test.tsx
@@ -1,9 +1,15 @@
 import { render, screen, waitFor } from '@testing-library/react';
 
-import { type DataSourceInstanceSettings, type DataSourceSettings } from '@grafana/data';
+import { type DataSourceApi, type DataSourceInstanceSettings, type DataSourceSettings } from '@grafana/data';
 import { type DataSourceSrv, setDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 
 import { type TraceToProfilesData, TraceToProfilesSettings } from './TraceToProfilesSettings';
+
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstance: jest.fn(),
+}));
 
 const defaultOption: DataSourceSettings<TraceToProfilesData> = {
   jsonData: {
@@ -33,6 +39,7 @@ describe('TraceToProfilesSettings', () => {
         return pyroSettings;
       },
     } as unknown as DataSourceSrv);
+    jest.mocked(getDataSourceInstance).mockResolvedValue(pyroSettings as unknown as DataSourceApi);
   });
 
   it('should render without error', () => {

--- a/packages/grafana-o11y-ds-frontend/src/TraceToProfiles/TraceToProfilesSettings.tsx
+++ b/packages/grafana-o11y-ds-frontend/src/TraceToProfiles/TraceToProfilesSettings.tsx
@@ -10,7 +10,8 @@ import {
   updateDatasourcePluginJsonDataOption,
 } from '@grafana/data';
 import { ConfigDescriptionLink, ConfigSection } from '@grafana/plugin-ui';
-import { DataSourcePicker, DataSourceWithBackend, getDataSourceSrv } from '@grafana/runtime';
+import { DataSourcePicker, DataSourceWithBackend } from '@grafana/runtime';
+import { useDataSourceInstance } from '@grafana/runtime/unstable';
 import { InlineField, InlineFieldRow, Input, InlineSwitch } from '@grafana/ui';
 
 import { TagMappingInput } from '../TraceToLogs/TagMappingInput';
@@ -43,9 +44,7 @@ export function TraceToProfilesSettings({ options, onOptionsChange }: Props) {
     return placeholder;
   }, [options.jsonData.tracesToProfiles?.datasourceUid, profileTypes]);
 
-  const { value: dataSource } = useAsync(async () => {
-    return await getDataSourceSrv().get(options.jsonData.tracesToProfiles?.datasourceUid);
-  }, [options.jsonData.tracesToProfiles?.datasourceUid]);
+  const { dataSource } = useDataSourceInstance(options.jsonData.tracesToProfiles?.datasourceUid);
 
   const { value: pTypes } = useAsync(async () => {
     if (


### PR DESCRIPTION
Part of #127034 (parent: #125083).

Migrates `TraceToProfilesSettings.tsx` from the `useAsync` + deprecated `getDataSourceSrv().get()` pattern to the async `useDataSourceInstance` hook from `@grafana/runtime/unstable`.

The test keeps the existing `setDataSourceSrv` mock (the embedded `DataSourcePicker` still relies on the sync service) and adds a mock for `getDataSourceInstance` so the async API doesn't hit the legacy fallback path, which would log a warning and trip jest-fail-on-console.

Verified `yarn workspace @grafana/o11y-ds-frontend typecheck` and `build`: the published bundle keeps `@grafana/runtime/unstable` as an external import (via `rollup-plugin-node-externals`), same as the main `@grafana/runtime` entry point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)