### PR TITLE
Search: pass the trash authorizer to the searcher constructor

### DIFF
--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -3584,9 +3584,8 @@ func (q *permissionScopedQuery) Searcher(ctx context.Context, i index.IndexReade
 		return nil, err
 	}
 
-	s := newBatchAuthzSearcher(ctx, searcher, i, dvReader, q.access, q.namespace, q.group, q.resources, q.log.FromContext(ctx))
-	s.trash = q.trash
-	return s, nil
+	return newBatchAuthzSearcher(ctx, searcher, i, dvReader,
+		q.access, q.namespace, q.group, q.resources, q.trash, q.log.FromContext(ctx)), nil
 }
 
 // docInfo holds document information for authorization
@@ -3639,6 +3638,7 @@ func newBatchAuthzSearcher(
 	namespace string,
 	group string,
 	resources map[string]string,
+	trash *resource.TrashAuthorizer,
 	logger log.Logger,
 ) *batchAuthzSearcher {
 	ctx, span := tracer.Start(ctx, "search.batchAuthzSearcher", trace.WithAttributes(
@@ -3656,6 +3656,7 @@ func newBatchAuthzSearcher(
 		namespace:   namespace,
 		group:       group,
 		resources:   resources,
+		trash:       trash,
 		log:         logger,
 	}
 }


### PR DESCRIPTION
`permissionScopedQuery.Searcher` constructed `batchAuthzSearcher` and then assigned its `trash` field. There is only one caller, so it can be a constructor parameter instead, and the searcher is never briefly in a half-built state.

No behaviour change — the searcher ends up in the same state, just built in one step.

Follow-up to a review comment on #130481.
