### PR TITLE
Provisioning: Enable Git Sync conventions by default in public preview

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -77,30 +77,31 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 
 [Public preview](https://grafana.com/docs/release-life-cycle/#public-preview) features are supported by our Support teams, but might be limited to enablement, configuration, and some troubleshooting.
 
-| Feature toggle name               | Description                                                                                    |
-| --------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `panelTitleSearch`                | Search for dashboards using panel title                                                        |
-| `faroDatasourceSelector`          | Enable the data source selector within the Frontend Apps section of the Frontend Observability |
-| `provisioning.readmes`            | Render the README.md of a Git Sync provisioned folder inline below its dashboards list         |
-| `provisioning.userAttribution`    | Author Git Sync commits as the acting Grafana user                                             |
-| `externalServiceAccounts`         | Automatic service account and token setup for plugins                                          |
-| `feedbackButton`                  | Enables the feedback button in the dashboard edit sidebar                                      |
-| `pdfTables`                       | Enables generating table data as PDF in reporting                                              |
-| `canvasPanelPanZoom`              | Allow pan and zoom in canvas panel                                                             |
-| `timeComparison`                  | Enables time comparison option in supported panels                                             |
-| `secretsManagementAppPlatformUI`  | Enable the secrets management app platform UI                                                  |
-| `dashboardTemplates`              | Enables a flow to get started with a new dashboard from a template                             |
-| `alertRuleRestore`                | Enables the alert rule restore feature                                                         |
-| `azureMonitorLogsBuilderEditor`   | Enables the logs builder mode for the Azure Monitor data source                                |
-| `alertingListViewV2PreviewToggle` | Enables the alerting list view v2 preview toggle                                               |
-| `interactiveLearning`             | Enables the interactive learning app                                                           |
-| `panelTimeSettings`               | Enables a new panel time settings drawer                                                       |
-| `transformationsEmptyPlaceholder` | Show transformation quick-start cards in empty transformations state                           |
-| `pyroscopeUTF8LabelNames`         | Enables support for UTF-8 label names in Pyroscope label selectors                             |
-| `queryEditorNext`                 | Enables next generation query editor experience                                                |
-| `flameGraphWithCallTree`          | Enables the new Flame Graph UI containing the Call Tree view                                   |
-| `splashScreen`                    | Enables the splash screen modal for introducing new Grafana features on first session          |
-| `grafana.dynamicTraceToLogs`      | Check for the existence of logs when linking from the Trace View                               |
+| Feature toggle name               | Description                                                                                      |
+| --------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `panelTitleSearch`                | Search for dashboards using panel title                                                          |
+| `faroDatasourceSelector`          | Enable the data source selector within the Frontend Apps section of the Frontend Observability   |
+| `provisioning.readmes`            | Render the README.md of a Git Sync provisioned folder inline below its dashboards list           |
+| `provisioning.gitConventions`     | Enable configurable commit message, branch name, and pull request title conventions for Git Sync |
+| `provisioning.userAttribution`    | Author Git Sync commits as the acting Grafana user                                               |
+| `externalServiceAccounts`         | Automatic service account and token setup for plugins                                            |
+| `feedbackButton`                  | Enables the feedback button in the dashboard edit sidebar                                        |
+| `pdfTables`                       | Enables generating table data as PDF in reporting                                                |
+| `canvasPanelPanZoom`              | Allow pan and zoom in canvas panel                                                               |
+| `timeComparison`                  | Enables time comparison option in supported panels                                               |
+| `secretsManagementAppPlatformUI`  | Enable the secrets management app platform UI                                                    |
+| `dashboardTemplates`              | Enables a flow to get started with a new dashboard from a template                               |
+| `alertRuleRestore`                | Enables the alert rule restore feature                                                           |
+| `azureMonitorLogsBuilderEditor`   | Enables the logs builder mode for the Azure Monitor data source                                  |
+| `alertingListViewV2PreviewToggle` | Enables the alerting list view v2 preview toggle                                                 |
+| `interactiveLearning`             | Enables the interactive learning app                                                             |
+| `panelTimeSettings`               | Enables a new panel time settings drawer                                                         |
+| `transformationsEmptyPlaceholder` | Show transformation quick-start cards in empty transformations state                             |
+| `pyroscopeUTF8LabelNames`         | Enables support for UTF-8 label names in Pyroscope label selectors                               |
+| `queryEditorNext`                 | Enables next generation query editor experience                                                  |
+| `flameGraphWithCallTree`          | Enables the new Flame Graph UI containing the Call Tree view                                     |
+| `splashScreen`                    | Enables the splash screen modal for introducing new Grafana features on first session            |
+| `grafana.dynamicTraceToLogs`      | Check for the existence of logs when linking from the Trace View                                 |
 
 ## Development feature toggles
 

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -827,10 +827,10 @@ export const useFlagPluginsUseMTPlugins = (options?: ReactFlagEvaluationOptions)
  *
  * **Details:**
  * - flag key: `provisioning.gitConventions`
- * - default value: `false`
+ * - default value: `true`
  */
 export const useFlagProvisioningGitConventions = (options?: ReactFlagEvaluationOptions): boolean => {
-  return useFlag("provisioning.gitConventions", false, options).value;
+  return useFlag("provisioning.gitConventions", true, options).value;
 };
 
 /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -264,10 +264,10 @@ var (
 		{
 			Name:            "provisioning.gitConventions",
 			Description:     "Enable configurable commit message, branch name, and pull request title conventions for Git Sync",
-			Stage:           FeatureStageExperimental,
+			Stage:           FeatureStagePublicPreview,
 			RequiresRestart: true,
 			Owner:           grafanaAppPlatformSquad,
-			Expression:      "false",
+			Expression:      "true", // enabled by default
 			Generate:        Generate{Go: true, React: true},
 		},
 		{

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -28,7 +28,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-05-22,provisioningFolderMetadata,GA,@grafana/grafana-app-platform-squad,false,true,false
 2026-05-22,provisioningExport,experimental,@grafana/grafana-app-platform-squad,false,true,false
 2026-05-22,provisioning.readmes,preview,@grafana/grafana-app-platform-squad,false,false,true
-2026-06-09,provisioning.gitConventions,experimental,@grafana/grafana-app-platform-squad,false,true,false
+2026-06-09,provisioning.gitConventions,preview,@grafana/grafana-app-platform-squad,false,true,false
 2026-07-08,provisioning.userAttribution,preview,@grafana/grafana-app-platform-squad,false,false,false
 2026-07-16,provisioning.performance,experimental,@grafana/grafana-app-platform-squad,false,false,false
 2023-07-21,awsAsyncQueryCaching,GA,@grafana/data-sources-plugins,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -5189,15 +5189,18 @@
     {
       "metadata": {
         "name": "provisioning.gitConventions",
-        "resourceVersion": "1780985056992",
-        "creationTimestamp": "2026-06-09T06:04:16Z"
+        "resourceVersion": "1786613642168",
+        "creationTimestamp": "2026-06-09T06:04:16Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-08-13 09:34:02.168032 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable configurable commit message, branch name, and pull request title conventions for Git Sync",
-        "stage": "experimental",
+        "stage": "preview",
         "codeowner": "@grafana/grafana-app-platform-squad",
         "requiresRestart": true,
-        "expression": "false"
+        "expression": "true"
       }
     },
     {


### PR DESCRIPTION
## What

Promotes the `provisioning.gitConventions` feature toggle from **experimental** to **public preview** and enables it by default.

- `Stage`: `experimental` → `public preview`
- `Expression`: `false` → `true` (enabled by default)
- `RequiresRestart: true` retained

## Why

Configurable commit message, branch name, and pull request title conventions for Git Sync are ready for broader use. Making it public preview and on-by-default lets users benefit without manual opt-in.

This follows the companion change enabling `provisioning.userAttribution` by default (#130671, merged).

## Notes

Generated files (`toggles_gen.csv`, `toggles_gen.json`, `openfeature.gen.ts`, feature-toggles docs) were regenerated to match the registry change. Branch is up to date with `main` (which now includes the merged `userAttribution` change); the net diff is scoped solely to `gitConventions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)