### PR TITLE
Provisioning: Enable Git Sync user attribution by default

### DIFF
--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -849,10 +849,10 @@ export const useFlagProvisioningReadmes = (options?: ReactFlagEvaluationOptions)
  *
  * **Details:**
  * - flag key: `provisioning.userAttribution`
- * - default value: `false`
+ * - default value: `true`
  */
 export const useFlagProvisioningUserAttribution = (options?: ReactFlagEvaluationOptions): boolean => {
-  return useFlag("provisioning.userAttribution", false, options).value;
+  return useFlag("provisioning.userAttribution", true, options).value;
 };
 
 /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -275,7 +275,7 @@ var (
 			Description: "Author Git Sync commits as the acting Grafana user",
 			Stage:       FeatureStagePublicPreview,
 			Owner:       grafanaAppPlatformSquad,
-			Expression:  "false",
+			Expression:  "true", // enabled by default
 			Generate:    Generate{Go: true, React: true},
 		},
 		{

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -5236,17 +5236,17 @@
     {
       "metadata": {
         "name": "provisioning.userAttribution",
-        "resourceVersion": "1783717809512",
+        "resourceVersion": "1786613782023",
         "creationTimestamp": "2026-07-08T13:32:58Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2026-07-10 21:10:09.512157 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2026-08-13 09:36:22.023466 +0000 UTC"
         }
       },
       "spec": {
         "description": "Author Git Sync commits as the acting Grafana user",
         "stage": "preview",
         "codeowner": "@grafana/grafana-app-platform-squad",
-        "expression": "false"
+        "expression": "true"
       }
     },
     {


### PR DESCRIPTION
## What

Enables the `provisioning.userAttribution` public preview feature toggle by default.

- `Expression`: `false` → `true` (enabled by default)
- Stage stays **public preview**

## Why

Authoring Git Sync commits as the acting Grafana user is ready for default-on in public preview, so commits carry the correct author attribution without manual opt-in.

## Notes

Generated files (`toggles_gen.json`, `openfeature.gen.ts`) were regenerated to match the registry change. No CSV/docs stage move needed since the toggle was already public preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)