### PR TITLE
chore: minor refactoring in infra/features to extract helper funcs for eval context

### DIFF
--- a/pkg/infra/features/eval_context.go
+++ b/pkg/infra/features/eval_context.go
@@ -2,7 +2,6 @@ package features
 
 import (
 	"context"
-	"net/http"
 
 	"go.opentelemetry.io/otel/baggage"
 
@@ -31,13 +30,8 @@ func EvaluationContextFromBaggage(ctx context.Context) openfeature.EvaluationCon
 	return openfeature.NewEvaluationContext(targetingKey, contextAtributes)
 }
 
-// WithTransactionContextMiddleware is an HTTP middleware that reads OTel baggage
-// from the incoming request and sets it as the OpenFeature transaction context.
-// Register it in each MT service's HTTP middleware chain.
-func WithTransactionContextMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		evalCtx := EvaluationContextFromBaggage(r.Context())
-		ctx := openfeature.MergeTransactionContext(r.Context(), evalCtx)
-		next.ServeHTTP(w, r.WithContext(ctx))
+func EvaluationContextFromNamespace(namespace string) openfeature.EvaluationContext {
+	return openfeature.NewEvaluationContext(namespace, map[string]any{
+		NamespaceKey: namespace,
 	})
 }

--- a/pkg/infra/features/eval_context.go
+++ b/pkg/infra/features/eval_context.go
@@ -30,8 +30,8 @@ func EvaluationContextFromBaggage(ctx context.Context) openfeature.EvaluationCon
 	return openfeature.NewEvaluationContext(targetingKey, contextAtributes)
 }
 
-func EvaluationContextFromNamespace(namespace string) openfeature.EvaluationContext {
-	return openfeature.NewEvaluationContext(namespace, map[string]any{
-		NamespaceKey: namespace,
-	})
+// EvaluationContextFromTargetingKey builds an evaluation context with no
+// attributes, using targetingKey as the sole subject identifier.
+func EvaluationContextFromTargetingKey(targetingKey string) openfeature.EvaluationContext {
+	return openfeature.NewEvaluationContext(targetingKey, make(map[string]any))
 }

--- a/pkg/infra/features/eval_context_test.go
+++ b/pkg/infra/features/eval_context_test.go
@@ -60,9 +60,9 @@ func TestEvaluationContextFromBaggage(t *testing.T) {
 	})
 }
 
-func TestEvaluationContextFromNamespace(t *testing.T) {
-	evalCtx := EvaluationContextFromNamespace("stacks-42")
+func TestEvaluationContextFromTargetingKey(t *testing.T) {
+	evalCtx := EvaluationContextFromTargetingKey("stacks-42")
 
 	assert.Equal(t, "stacks-42", evalCtx.TargetingKey())
-	assert.Equal(t, "stacks-42", evalCtx.Attributes()[NamespaceKey])
+	assert.Empty(t, evalCtx.Attributes())
 }

--- a/pkg/infra/features/eval_context_test.go
+++ b/pkg/infra/features/eval_context_test.go
@@ -40,7 +40,9 @@ func TestEvaluationContextFromBaggage(t *testing.T) {
 
 	t.Run("absent fields are not added to attributes", func(t *testing.T) {
 		req := baggageCtx(t, "slug=mystack,namespace=stacks-42")
+
 		evalCtx := EvaluationContextFromBaggage(req.Context())
+		assert.Equal(t, "stacks-42", evalCtx.TargetingKey())
 
 		attrs := evalCtx.Attributes()
 		assert.Contains(t, attrs, "slug")

--- a/pkg/infra/features/eval_context_test.go
+++ b/pkg/infra/features/eval_context_test.go
@@ -57,3 +57,10 @@ func TestEvaluationContextFromBaggage(t *testing.T) {
 		assert.Equal(t, "mystack", evalCtx.Attributes()["slug"])
 	})
 }
+
+func TestEvaluationContextFromNamespace(t *testing.T) {
+	evalCtx := EvaluationContextFromNamespace("stacks-42")
+
+	assert.Equal(t, "stacks-42", evalCtx.TargetingKey())
+	assert.Equal(t, "stacks-42", evalCtx.Attributes()[NamespaceKey])
+}

--- a/pkg/infra/features/eval_context_test.go
+++ b/pkg/infra/features/eval_context_test.go
@@ -1,0 +1,59 @@
+package features
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/baggage"
+)
+
+func baggageCtx(t *testing.T, members string) *http.Request {
+	t.Helper()
+	bag, err := baggage.Parse(members)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	return req.WithContext(baggage.ContextWithBaggage(req.Context(), bag))
+}
+
+func TestEvaluationContextFromBaggage(t *testing.T) {
+	t.Run("empty context returns empty eval context", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		evalCtx := EvaluationContextFromBaggage(req.Context())
+
+		assert.Empty(t, evalCtx.TargetingKey())
+		assert.Empty(t, evalCtx.Attributes())
+	})
+
+	t.Run("all canonical fields are extracted", func(t *testing.T) {
+		req := baggageCtx(t, "slug=mystack,plan=pro,channel=stable,namespace=stacks-42")
+		evalCtx := EvaluationContextFromBaggage(req.Context())
+
+		attrs := evalCtx.Attributes()
+		assert.Equal(t, "mystack", attrs["slug"])
+		assert.Equal(t, "pro", attrs["plan"])
+		assert.Equal(t, "stable", attrs["channel"])
+		assert.Equal(t, "stacks-42", attrs["namespace"])
+	})
+
+	t.Run("absent fields are not added to attributes", func(t *testing.T) {
+		req := baggageCtx(t, "slug=mystack,namespace=stacks-42")
+		evalCtx := EvaluationContextFromBaggage(req.Context())
+
+		attrs := evalCtx.Attributes()
+		assert.Contains(t, attrs, "slug")
+		assert.Contains(t, attrs, "namespace")
+		assert.NotContains(t, attrs, "plan")
+		assert.NotContains(t, attrs, "channel")
+	})
+
+	t.Run("missing namespace results in empty targeting key", func(t *testing.T) {
+		req := baggageCtx(t, "slug=mystack,plan=pro")
+		evalCtx := EvaluationContextFromBaggage(req.Context())
+
+		assert.Empty(t, evalCtx.TargetingKey())
+		assert.Equal(t, "mystack", evalCtx.Attributes()["slug"])
+	})
+}

--- a/pkg/infra/features/middleware.go
+++ b/pkg/infra/features/middleware.go
@@ -1,0 +1,18 @@
+package features
+
+import (
+	"net/http"
+
+	"github.com/open-feature/go-sdk/openfeature"
+)
+
+// WithTransactionContextMiddleware is an HTTP middleware that reads OTel baggage
+// from the incoming request and sets it as the OpenFeature transaction context.
+// Register it in each MT service's HTTP middleware chain.
+func WithTransactionContextMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		evalCtx := EvaluationContextFromBaggage(r.Context())
+		ctx := openfeature.MergeTransactionContext(r.Context(), evalCtx)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}

--- a/pkg/infra/features/middleware_test.go
+++ b/pkg/infra/features/middleware_test.go
@@ -8,56 +8,7 @@ import (
 	"github.com/open-feature/go-sdk/openfeature"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel/baggage"
 )
-
-func baggageCtx(t *testing.T, members string) *http.Request {
-	t.Helper()
-	bag, err := baggage.Parse(members)
-	require.NoError(t, err)
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	return req.WithContext(baggage.ContextWithBaggage(req.Context(), bag))
-}
-
-func TestEvaluationContextFromBaggage(t *testing.T) {
-	t.Run("empty context returns empty eval context", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/", nil)
-		evalCtx := EvaluationContextFromBaggage(req.Context())
-
-		assert.Empty(t, evalCtx.TargetingKey())
-		assert.Empty(t, evalCtx.Attributes())
-	})
-
-	t.Run("all canonical fields are extracted", func(t *testing.T) {
-		req := baggageCtx(t, "slug=mystack,plan=pro,channel=stable,namespace=stacks-42")
-		evalCtx := EvaluationContextFromBaggage(req.Context())
-
-		attrs := evalCtx.Attributes()
-		assert.Equal(t, "mystack", attrs["slug"])
-		assert.Equal(t, "pro", attrs["plan"])
-		assert.Equal(t, "stable", attrs["channel"])
-		assert.Equal(t, "stacks-42", attrs["namespace"])
-	})
-
-	t.Run("absent fields are not added to attributes", func(t *testing.T) {
-		req := baggageCtx(t, "slug=mystack,namespace=stacks-42")
-		evalCtx := EvaluationContextFromBaggage(req.Context())
-
-		attrs := evalCtx.Attributes()
-		assert.Contains(t, attrs, "slug")
-		assert.Contains(t, attrs, "namespace")
-		assert.NotContains(t, attrs, "plan")
-		assert.NotContains(t, attrs, "channel")
-	})
-
-	t.Run("missing namespace results in empty targeting key", func(t *testing.T) {
-		req := baggageCtx(t, "slug=mystack,plan=pro")
-		evalCtx := EvaluationContextFromBaggage(req.Context())
-
-		assert.Empty(t, evalCtx.TargetingKey())
-		assert.Equal(t, "mystack", evalCtx.Attributes()["slug"])
-	})
-}
 
 func TestWithTransactionContextMiddleware(t *testing.T) {
 	t.Run("sets OF transaction context from baggage", func(t *testing.T) {


### PR DESCRIPTION
Just a minor refactoring that separates the sheep from the goats. 

After refactoring the `baggage.go` we should have two files: 
* `eval_context.go` containing helper functions intended for creating OpenFeature eval context
* `middleware.go` containing middleware