### PR TITLE
Calendar: Announce the selected date to screen readers

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/DatePicker/DatePicker.test.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DatePicker/DatePicker.test.tsx
@@ -28,6 +28,13 @@ describe('DatePicker', () => {
     expect(screen.getByText('December 2020')).toBeInTheDocument();
   });
 
+  it('announces the selected state of the selected date', () => {
+    render(<DatePicker isOpen={true} value={new Date(1607431703363)} onChange={jest.fn()} onClose={jest.fn()} />);
+
+    expect(screen.getByRole('button', { name: 'December 8, 2020 selected' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'December 9, 2020' })).toBeInTheDocument();
+  });
+
   it('calls onChange when date is selected', async () => {
     const onChange = jest.fn();
     const user = userEvent.setup();

--- a/packages/grafana-ui/src/components/DateTimePickers/DatePicker/DatePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DatePicker/DatePicker.tsx
@@ -8,6 +8,7 @@ import { useStyles2 } from '../../../themes/ThemeContext';
 import { ClickOutsideWrapper } from '../../ClickOutsideWrapper/ClickOutsideWrapper';
 import { Icon } from '../../Icon/Icon';
 import { getBodyStyles } from '../TimeRangePicker/CalendarBody';
+import { getSelectedTileContent } from '../utils/getSelectedTileContent';
 
 /** @public */
 export interface DatePickerProps {
@@ -46,12 +47,14 @@ DatePicker.displayName = 'DatePicker';
 
 const Body = memo<DatePickerProps>(({ value, minDate, maxDate, onChange }) => {
   const styles = useStyles2(getBodyStyles);
+  const selectedDate = value || new Date();
 
   return (
     <Calendar
       className={styles.body}
       tileClassName={styles.title}
-      value={value || new Date()}
+      tileContent={getSelectedTileContent(selectedDate)}
+      value={selectedDate}
       minDate={minDate}
       maxDate={maxDate}
       nextLabel={<Icon name="angle-right" />}

--- a/packages/grafana-ui/src/components/DateTimePickers/DateTimePicker/DateTimePicker.test.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DateTimePicker/DateTimePicker.test.tsx
@@ -92,7 +92,7 @@ describe('Date time picker', () => {
       await userEvent.click(screen.getByRole('button', { name: 'Time picker' }));
 
       // Check the active day is the 5th
-      expect(screen.getByRole('button', { name: 'May 5, 2021' })).toHaveClass('react-calendar__tile--active');
+      expect(screen.getByRole('button', { name: 'May 5, 2021 selected' })).toHaveClass('react-calendar__tile--active');
 
       // open the time of day overlay
       await userEvent.click(screen.getByRole('combobox'));
@@ -101,7 +101,7 @@ describe('Date time picker', () => {
       await userEvent.click(screen.getByText('00:00'));
 
       // Check the active day is the 5th
-      expect(screen.getByRole('button', { name: 'May 5, 2021' })).toHaveClass('react-calendar__tile--active');
+      expect(screen.getByRole('button', { name: 'May 5, 2021 selected' })).toHaveClass('react-calendar__tile--active');
 
       await userEvent.type(screen.getByRole('combobox'), '23:00');
 
@@ -109,7 +109,7 @@ describe('Date time picker', () => {
       await userEvent.click(screen.getByText('23:00'));
 
       // Check the active day is the 5th
-      expect(screen.getByRole('button', { name: 'May 5, 2021' })).toHaveClass('react-calendar__tile--active');
+      expect(screen.getByRole('button', { name: 'May 5, 2021 selected' })).toHaveClass('react-calendar__tile--active');
     }
   );
 
@@ -149,7 +149,9 @@ describe('Date time picker', () => {
       await userEvent.click(screen.getByRole('button', { name: 'Time picker' }));
 
       // Check the active day matches the input
-      expect(screen.getByRole('button', { name: `May ${day}, 2021` })).toHaveClass('react-calendar__tile--active');
+      expect(screen.getByRole('button', { name: `May ${day}, 2021 selected` })).toHaveClass(
+        'react-calendar__tile--active'
+      );
     }
   );
 
@@ -239,7 +241,7 @@ describe('Date time picker', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'Time picker' }));
     // Check that calendar date is set correctly
-    expect(screen.getByRole('button', { name: `June 30, 2024` })).toHaveClass('react-calendar__tile--active');
+    expect(screen.getByRole('button', { name: `June 30, 2024 selected` })).toHaveClass('react-calendar__tile--active');
     // Check that time is set correctly
     expect(screen.getByRole('combobox')).toHaveValue('22:00:00');
   });

--- a/packages/grafana-ui/src/components/DateTimePickers/DateTimePicker/DateTimePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DateTimePicker/DateTimePicker.tsx
@@ -34,6 +34,7 @@ import { TimeOfDayPicker } from '../TimeOfDayPicker';
 import { getBodyStyles } from '../TimeRangePicker/CalendarBody';
 import { isValid } from '../utils';
 import { adjustDateForReactCalendar } from '../utils/adjustDateForReactCalendar';
+import { getSelectedTileContent } from '../utils/getSelectedTileContent';
 
 export interface Props {
   /** Input date for the component */
@@ -354,6 +355,7 @@ const DateTimeCalendar = React.forwardRef<HTMLDivElement, DateTimeCalendarProps>
           locale="en"
           className={calendarStyles.body}
           tileClassName={calendarStyles.title}
+          tileContent={getSelectedTileContent(reactCalendarDate)}
           maxDate={maxDate}
           minDate={minDate}
         />

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/CalendarBody.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/CalendarBody.tsx
@@ -9,6 +9,7 @@ import { useStyles2 } from '../../../themes/ThemeContext';
 import { Icon } from '../../Icon/Icon';
 import { getWeekStart, type WeekStart } from '../WeekStartPicker';
 import { adjustDateForReactCalendar } from '../utils/adjustDateForReactCalendar';
+import { getSelectedTileContent } from '../utils/getSelectedTileContent';
 
 import { type TimePickerCalendarProps } from './TimePickerCalendar';
 
@@ -31,6 +32,7 @@ export function Body({ onChange, from, to, timeZone, weekStart }: TimePickerCale
       prev2Label={null}
       className={styles.body}
       tileClassName={styles.title}
+      tileContent={getSelectedTileContent(value)}
       value={value}
       nextLabel={<Icon name="angle-right" />}
       nextAriaLabel={t('time-picker.calendar.next-month', 'Next month')}

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.test.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.test.tsx
@@ -189,6 +189,19 @@ describe('TimeRangeForm', () => {
     expect(to).toHaveClass('react-calendar__tile--rangeEnd');
   });
 
+  it('should announce the selected state of every day in the selected range', async () => {
+    const { getAllByRole } = setup();
+    const openCalendarButton = getAllByRole('button', { name: 'Open calendar' });
+
+    await user.click(openCalendarButton[0]);
+
+    expect(screen.getByRole('button', { name: 'June 16, 2021' })).toBeInTheDocument();
+    for (const day of [17, 18, 19]) {
+      expect(screen.getByRole('button', { name: `June ${day}, 2021 selected` })).toBeInTheDocument();
+    }
+    expect(screen.getByRole('button', { name: 'June 20, 2021' })).toBeInTheDocument();
+  });
+
   it('should select correct time range in calendar when having a custom time zone', async () => {
     const { getAllByRole, getCalendarDayByLabelText } = setup(defaultTimeRange, 'Asia/Tokyo');
     const openCalendarButton = getAllByRole('button', { name: 'Open calendar' });

--- a/packages/grafana-ui/src/components/DateTimePickers/utils/getSelectedTileContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/utils/getSelectedTileContent.tsx
@@ -1,0 +1,67 @@
+import { type TileArgs, type TileContentFunc } from 'react-calendar';
+
+import { t } from '@grafana/i18n';
+
+type CalendarValue = Date | [Date, Date] | null | undefined;
+
+/**
+ * react-calendar renders every tile as a plain button and marks the selected one with a CSS class,
+ * so screen readers announce the selected date exactly like every other date in the month.
+ * This adds visually hidden text to the selected tiles, making the selection part of the
+ * button's accessible name.
+ *
+ * react-calendar has no way to set attributes on the tile buttons, so this can only be improved
+ * (to a real programmatic state such as aria-pressed) upstream.
+ */
+export function getSelectedTileContent(value: CalendarValue): TileContentFunc {
+  return function SelectedTileContent({ date, view }) {
+    if (!isSelected(date, view, value)) {
+      return null;
+    }
+
+    return <span className="sr-only">{t('grafana-ui.date-time-pickers.tile-selected', 'selected')}</span>;
+  };
+}
+
+type View = TileArgs['view'];
+
+/**
+ * Mirrors how react-calendar picks the tiles it gives its --active/--hasActive classes to: a tile
+ * is selected when the value overlaps the period that tile covers.
+ */
+function isSelected(date: Date, view: View, value: CalendarValue): boolean {
+  if (!value) {
+    return false;
+  }
+
+  const [tileStart, tileEnd] = getTilePeriod(date, view);
+  // A single value selects the whole period it falls in, so 5pm on the 8th selects the 8th
+  const [valueStart, valueEnd] = Array.isArray(value) ? value : getTilePeriod(value, view);
+
+  return valueStart <= tileEnd && valueEnd >= tileStart;
+}
+
+/** The period a single tile covers - one day in the month view, one month in the year view, etc. */
+function getTilePeriod(date: Date, view: View): [Date, Date] {
+  const year = date.getFullYear();
+  const month = date.getMonth();
+  const day = date.getDate();
+
+  switch (view) {
+    case 'month':
+      return period(new Date(year, month, day), new Date(year, month, day + 1));
+    case 'year':
+      return period(new Date(year, month, 1), new Date(year, month + 1, 1));
+    case 'decade':
+      return period(new Date(year, 0, 1), new Date(year + 1, 0, 1));
+    case 'century': {
+      // react-calendar's decades run from a year ending in 1 to the next year ending in 0, e.g. 2021-2030
+      const decadeStart = year - ((year - 1) % 10);
+      return period(new Date(decadeStart, 0, 1), new Date(decadeStart + 10, 0, 1));
+    }
+  }
+}
+
+function period(start: Date, nextStart: Date): [Date, Date] {
+  return [start, new Date(nextStart.getTime() - 1)];
+}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10390,7 +10390,8 @@
         "today": "Today",
         "today-so-far": "Today so far",
         "yesterday": "Yesterday"
-      }
+      },
+      "tile-selected": "selected"
     },
     "drawer": {
       "close": "Close"


### PR DESCRIPTION
> [!NOTE]
> #130751 is an alternative to this PR. It patches `react-calendar` to set `aria-pressed` instead. Only one of the two can merge.

**What is this feature?**

Screen readers now announce which date is selected in the calendars of the time range picker, the `DatePicker` and the `DateTimePicker`.

`react-calendar` renders each date as a plain button. It marks the selected date with a CSS class only, and doesn't have the correct `aria-pressed` or `aria-selected` attributes.

This PR is a workaround to pass the `tileContent` prop and render visually hidden text in the selected tiles. The word "selected" becomes part of the accessible name of the button:

- **Before:** `August 13, 2026`
- **After:** `August 13, 2026 selected`

Nothing changes visually.

<img width="869" height="352" alt="Screenshot 2026-08-13 at 12 01 49 pm" src="https://github.com/user-attachments/assets/d58d3fbe-c7f4-4647-a8b5-5b458a12699a" />


**Why do we need this feature?**

The correct fix is upstream, but the PR hasn't been merged https://github.com/wojtekmaj/react-calendar/pull/940

The other approach would be to either fork react-calendar, or use a yarn patch to modify the library to add in the correct attributes.

**Who is this feature for?**

Users who select a date or a time range.

**Which issue(s) does this PR fix?**:

Fixes #118784


