### PR TITLE
Unified search: hide trash that garbage collection is about to remove

### DIFF
--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -129,7 +129,49 @@ type BleveOptions struct {
 	// PostRankAuthzEnabled is true. Zero values fall back to the defaults in
 	// PostRankAuthzConfig.effective().
 	PostRankAuthz PostRankAuthzConfig
+
+	// TrashRetention hides trash that garbage collection is about to remove.
+	TrashRetention TrashRetentionConfig
 }
+
+// TrashRetentionConfig is how long a deleted object stays restorable.
+//
+// The values come from the garbage collection settings rather than search's own, so
+// the two cannot disagree about what is expired. Search and storage can be separate
+// deployments, so these have to be set for this process too.
+type TrashRetentionConfig struct {
+	// Enabled reports whether garbage collection runs. With it off nothing is ever
+	// collected, so old trash is still restorable and must not be hidden.
+	Enabled bool
+	MaxAge  time.Duration
+	// DashboardsMaxAge is separate because dashboards keep trash far longer.
+	DashboardsMaxAge time.Duration
+}
+
+// expirationThreshold returns the deletion time, in unix milliseconds, that trash
+// for this resource must be at or after to still be offered.
+//
+// Mirrors kvStorageBackend.garbageCollectionCutoffTimestamp. A window of zero
+// applies none, which would otherwise expire everything at once.
+func (c TrashRetentionConfig) expirationThreshold(group, resource string, now time.Time) (int64, bool) {
+	if !c.Enabled {
+		return 0, false
+	}
+	window := c.MaxAge
+	if group == dashboardGroup && resource == dashboardResource {
+		window = c.DashboardsMaxAge
+	}
+	if window <= 0 {
+		return 0, false
+	}
+	return now.Add(-window).UnixMilli(), true
+}
+
+// The one kind with its own retention period, matching the storage backend.
+const (
+	dashboardGroup    = "dashboard.grafana.app"
+	dashboardResource = "dashboards"
+)
 
 // SnapshotOptions configures remote index snapshot handling in BuildIndex and
 // background upload scheduling.
@@ -1704,6 +1746,8 @@ type bleveIndex struct {
 	// the in-searcher permissionScopedQuery path is used.
 	postRankAuthzEnabled bool
 	postRankAuthz        PostRankAuthzConfig
+
+	trashRetention TrashRetentionConfig
 }
 
 func (b *bleveBackend) newBleveIndex(
@@ -1738,6 +1782,7 @@ func (b *bleveBackend) newBleveIndex(
 		indexMetrics:         b.indexMetrics,
 		postRankAuthzEnabled: b.opts.PostRankAuthzEnabled,
 		postRankAuthz:        b.opts.PostRankAuthz.effective(),
+		trashRetention:       b.opts.TrashRetention,
 	}
 	bi.updaterCond = sync.NewCond(&bi.updaterMu)
 	if b.indexMetrics != nil {
@@ -2008,7 +2053,7 @@ func (b *bleveIndex) ListManagedObjects(ctx context.Context, req *resourcepb.Lis
 	stats.AddResultsConversionTime(time.Since(start))
 
 	found, err := b.index.SearchInContext(ctx, &bleve.SearchRequest{
-		Query: scopeQuery(q, false),
+		Query: scopeQuery(q, false, 0),
 		Fields: []string{
 			resource.SEARCH_FIELD_TITLE,
 			resource.SEARCH_FIELD_FOLDER,
@@ -2090,7 +2135,7 @@ func (b *bleveIndex) ListManagedObjects(ctx context.Context, req *resourcepb.Lis
 
 func (b *bleveIndex) CountManagedObjects(ctx context.Context, stats *resource.SearchStats) ([]*resourcepb.CountManagedObjectsResponse_ResourceCount, error) {
 	found, err := b.index.SearchInContext(ctx, &bleve.SearchRequest{
-		Query: scopeQuery(bleve.NewMatchAllQuery(), false),
+		Query: scopeQuery(bleve.NewMatchAllQuery(), false, 0),
 		Size:  0,
 		Facets: bleve.FacetsRequest{
 			"count": bleve.NewFacetRequest(resource.SEARCH_FIELD_MANAGED_BY, 1000), // typically less then 5
@@ -2301,7 +2346,7 @@ func (b *bleveIndex) DocCount(ctx context.Context, folder string, stats *resourc
 	req := &bleve.SearchRequest{
 		Size:   0, // we just need the count
 		Fields: []string{},
-		Query:  scopeQuery(q, false),
+		Query:  scopeQuery(q, false, 0),
 	}
 	rsp, err := b.index.SearchInContext(ctx, req)
 	if rsp == nil {
@@ -2442,7 +2487,13 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 		return nil, errResult
 	}
 	textQuery := b.buildTextQuery(searchrequest, req)
-	searchrequest.Query = scopeQuery(combineFilterAndTextQueries(filters, textQuery), req.IsDeleted)
+	expirationThreshold := int64(0)
+	if req.IsDeleted {
+		if t, ok := b.trashRetention.expirationThreshold(b.key.Group, b.key.Resource, time.Now()); ok {
+			expirationThreshold = t
+		}
+	}
+	searchrequest.Query = scopeQuery(combineFilterAndTextQueries(filters, textQuery), req.IsDeleted, expirationThreshold)
 
 	// postFilter applies authorization after ranking in runPostFilterAuthz, so
 	// skip the in-searcher wrapper here and let bleve return unfiltered ranked hits.
@@ -2512,7 +2563,7 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 //
 // Live is "not marked deleted" rather than "marked not deleted", because
 // documents written before the marker carry no value for the field.
-func scopeQuery(q query.Query, deleted bool) query.Query {
+func scopeQuery(q query.Query, deleted bool, expirationThreshold int64) query.Query {
 	marked := bleve.NewBoolFieldQuery(true)
 	marked.SetField(resource.SEARCH_FIELD_IS_DELETED)
 
@@ -2528,6 +2579,16 @@ func scopeQuery(q query.Query, deleted bool) query.Query {
 	provisioned := bleve.NewBoolFieldQuery(true)
 	provisioned.SetField(resource.SEARCH_FIELD_IS_PROVISIONED)
 	scoped.AddMustNot(provisioned)
+
+	// Excluding what is too old, rather than requiring a recent enough deletion,
+	// keeps the markers that carry no deletion time at all.
+	if expirationThreshold > 0 {
+		cutoff := float64(expirationThreshold)
+		inclusive := false
+		expired := bleve.NewNumericRangeInclusiveQuery(nil, &cutoff, nil, &inclusive)
+		expired.SetField(resource.SEARCH_FIELD_DELETION_TIME)
+		scoped.AddMustNot(expired)
+	}
 
 	// Bleve drives iteration from the Must clause and uses Filter only to test the
 	// documents that clause produced. With nothing to match on, the marker becomes

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -140,8 +140,9 @@ type BleveOptions struct {
 // the two cannot disagree about what is expired. Search and storage can be separate
 // deployments, so these have to be set for this process too.
 type TrashRetentionConfig struct {
-	// Enabled reports whether garbage collection runs. With it off nothing is ever
-	// collected, so old trash is still restorable and must not be hidden.
+	// Enabled reports whether garbage collection removes anything. With it off, or
+	// in dry run, nothing is ever collected, so old trash is still restorable and
+	// must not be hidden.
 	Enabled bool
 	MaxAge  time.Duration
 	// DashboardsMaxAge is separate because dashboards keep trash far longer.
@@ -151,8 +152,9 @@ type TrashRetentionConfig struct {
 // expirationThreshold returns the deletion time, in unix milliseconds, that trash
 // for this resource must be at or after to still be offered.
 //
-// Mirrors kvStorageBackend.garbageCollectionCutoffTimestamp. A window of zero
-// applies none, which would otherwise expire everything at once.
+// Mirrors kvStorageBackend.garbageCollectionCutoffTimestamp, including a window of
+// zero, which expires everything: the collector computes the same cutoff and
+// removes all of it.
 func (c TrashRetentionConfig) expirationThreshold(group, resource string, now time.Time) (int64, bool) {
 	if !c.Enabled {
 		return 0, false
@@ -160,9 +162,6 @@ func (c TrashRetentionConfig) expirationThreshold(group, resource string, now ti
 	window := c.MaxAge
 	if group == dashboardGroup && resource == dashboardResource {
 		window = c.DashboardsMaxAge
-	}
-	if window <= 0 {
-		return 0, false
 	}
 	return now.Add(-window).UnixMilli(), true
 }

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -2777,7 +2777,7 @@ func TestBulkIndexRemovesMarkedDocumentsWhenTrashFieldsAreNotMapped(t *testing.T
 // so leaving match-all there and testing the marker as a Filter would read every
 // document in the index to find the few deleted ones.
 func TestScopeQueryTrashBrowseDrivesOffTheMarker(t *testing.T) {
-	scoped, ok := scopeQuery(bleve.NewMatchAllQuery(), true).(*query.BooleanQuery)
+	scoped, ok := scopeQuery(bleve.NewMatchAllQuery(), true, 0).(*query.BooleanQuery)
 	require.True(t, ok)
 
 	assert.Equal(t, []string{resource.SEARCH_FIELD_IS_DELETED}, boolFieldsOf(t, scoped.Must),
@@ -2788,13 +2788,13 @@ func TestScopeQueryTrashBrowseDrivesOffTheMarker(t *testing.T) {
 	// A real query drives iteration itself, so the marker moves to Filter where it
 	// does not score.
 	textQuery := bleve.NewMatchQuery("hello")
-	scoped, ok = scopeQuery(textQuery, true).(*query.BooleanQuery)
+	scoped, ok = scopeQuery(textQuery, true, 0).(*query.BooleanQuery)
 	require.True(t, ok)
 	assert.Equal(t, []string{resource.SEARCH_FIELD_IS_DELETED}, boolFieldsOf(t, scoped.Filter))
 	assert.Equal(t, []string{resource.SEARCH_FIELD_IS_PROVISIONED}, boolFieldsOf(t, scoped.MustNot))
 
 	// Live searches only exclude the marker; provisioning is irrelevant to them.
-	scoped, ok = scopeQuery(bleve.NewMatchAllQuery(), false).(*query.BooleanQuery)
+	scoped, ok = scopeQuery(bleve.NewMatchAllQuery(), false, 0).(*query.BooleanQuery)
 	require.True(t, ok)
 	assert.Equal(t, []string{resource.SEARCH_FIELD_IS_DELETED}, boolFieldsOf(t, scoped.MustNot))
 	assert.Nil(t, scoped.Filter)
@@ -2885,10 +2885,10 @@ func TestScopeQueryKeepsScores(t *testing.T) {
 	assert.Equal(t, map[string]float64{
 		id("live-1"): unscoped[id("live-1")],
 		id("live-2"): unscoped[id("live-2")],
-	}, scores(scopeQuery(textQuery, false)))
+	}, scores(scopeQuery(textQuery, false, 0)))
 
 	assert.Equal(t, map[string]float64{
 		id("trashed-1"): unscoped[id("trashed-1")],
 		id("trashed-2"): unscoped[id("trashed-2")],
-	}, scores(scopeQuery(textQuery, true)))
+	}, scores(scopeQuery(textQuery, true, 0)))
 }

--- a/pkg/storage/unified/search/bleve_trash_retention_test.go
+++ b/pkg/storage/unified/search/bleve_trash_retention_test.go
@@ -1,0 +1,163 @@
+package search_test
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+	"github.com/grafana/grafana/pkg/storage/unified/search"
+)
+
+// Trash for an object garbage collection has already taken, or is about to, is a
+// restore offer that cannot be honoured. These cover which of those the index
+// still returns.
+func TestTrashRetentionWindow(t *testing.T) {
+	const day = 24 * time.Hour
+
+	// Deleted well before any window used here, and well after.
+	old := time.Now().Add(-30 * day).UnixMilli()
+	recent := time.Now().Add(-1 * time.Hour).UnixMilli()
+
+	for _, tc := range []struct {
+		name      string
+		group     string
+		resource  string
+		retention search.TrashRetentionConfig
+		want      []string
+	}{
+		{
+			// The case most likely to be got wrong: with collection off nothing is
+			// ever removed, so a year-old deletion is still fully restorable and
+			// hiding it would lose the user their object.
+			name:      "collection disabled returns trash of any age",
+			group:     "dashboard.grafana.app",
+			resource:  "dashboards",
+			retention: search.TrashRetentionConfig{Enabled: false, MaxAge: day, DashboardsMaxAge: day},
+			want:      []string{"no-timestamp", "old", "recent"},
+		},
+		{
+			name:      "collection enabled hides expired trash",
+			group:     "dashboard.grafana.app",
+			resource:  "dashboards",
+			retention: search.TrashRetentionConfig{Enabled: true, MaxAge: day, DashboardsMaxAge: day},
+			want:      []string{"no-timestamp", "recent"},
+		},
+		{
+			// Dashboards keep their trash far longer than everything else, so the
+			// window has to be per kind rather than one number.
+			name:      "dashboards use their own longer window",
+			group:     "dashboard.grafana.app",
+			resource:  "dashboards",
+			retention: search.TrashRetentionConfig{Enabled: true, MaxAge: time.Hour, DashboardsMaxAge: 365 * day},
+			want:      []string{"no-timestamp", "old", "recent"},
+		},
+		{
+			// A window of zero would otherwise expire everything the moment
+			// collection was switched on.
+			name:      "a zero window applies no filter",
+			group:     "dashboard.grafana.app",
+			resource:  "dashboards",
+			retention: search.TrashRetentionConfig{Enabled: true},
+			want:      []string{"no-timestamp", "old", "recent"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			index := newTrashRetentionIndex(t, tc.group, tc.resource, tc.retention, old, recent)
+
+			req := &resourcepb.ResourceSearchRequest{
+				Options:   &resourcepb.ListOptions{Key: &resourcepb.ResourceKey{Group: tc.group, Resource: tc.resource, Namespace: "default"}},
+				Limit:     10,
+				IsDeleted: true,
+			}
+			res, err := index.Search(context.Background(), nil, req, nil, nil)
+			require.NoError(t, err)
+			require.Nil(t, res.Error)
+
+			got := make([]string, 0, len(res.Results.Rows))
+			for _, row := range res.Results.Rows {
+				got = append(got, row.Key.Name)
+			}
+			require.ElementsMatch(t, tc.want, got)
+		})
+	}
+}
+
+// A live search must be unaffected by the window: live documents carry no
+// deletion time, and excluding them would empty the index for every caller.
+func TestTrashRetentionLeavesLiveSearchAlone(t *testing.T) {
+	index := newTrashRetentionIndex(t, "dashboard.grafana.app", "dashboards",
+		search.TrashRetentionConfig{Enabled: true, MaxAge: time.Hour, DashboardsMaxAge: time.Hour},
+		time.Now().Add(-30*24*time.Hour).UnixMilli(), time.Now().UnixMilli())
+
+	req := &resourcepb.ResourceSearchRequest{
+		Options: &resourcepb.ListOptions{Key: &resourcepb.ResourceKey{Group: "dashboard.grafana.app", Resource: "dashboards", Namespace: "default"}},
+		Limit:   10,
+	}
+	res, err := index.Search(context.Background(), nil, req, nil, nil)
+	require.NoError(t, err)
+	require.Nil(t, res.Error)
+
+	got := make([]string, 0, len(res.Results.Rows))
+	for _, row := range res.Results.Rows {
+		got = append(got, row.Key.Name)
+	}
+	require.Equal(t, []string{"live"}, got)
+}
+
+// newTrashRetentionIndex builds an index holding one live document and three
+// deleted ones: expired, recent, and one with no deletion time at all, which is
+// what a marker without a deletion timestamp produces.
+func newTrashRetentionIndex(t testing.TB, group, res string, retention search.TrashRetentionConfig, old, recent int64) resource.ResourceIndex {
+	t.Helper()
+
+	backend, err := search.NewBleveBackend(search.BleveOptions{
+		Root:          t.TempDir(),
+		FileThreshold: 5,
+		SearchFields: resource.NewSearchFieldsRegistry(nil, nil, map[resource.LowerGroupResource]resource.SearchFieldsProvider{
+			resource.NewLowerGroupResource(group, res): search.DashboardSearchFieldsProviderForTest(),
+		}),
+		TrashRetention: retention,
+	}, nil)
+	require.NoError(t, err)
+	t.Cleanup(backend.Stop)
+
+	key := resource.NamespacedResource{Namespace: "default", Group: group, Resource: res}
+	deleted := func(name string, at *int64, rv int64) *resource.BulkIndexItem {
+		rvs := strconv.FormatInt(rv, 10)
+		doc := &resource.IndexableDocument{
+			Key:       &resourcepb.ResourceKey{Namespace: key.Namespace, Group: key.Group, Resource: key.Resource, Name: name},
+			Name:      name,
+			Title:     name,
+			RV:        rv,
+			IsDeleted: ptr(true),
+			DeletedRV: &rvs,
+		}
+		doc.DeletionTime = at
+		return &resource.BulkIndexItem{Action: resource.ActionIndex, Doc: doc}
+	}
+
+	ctx := identity.WithRequester(context.Background(), &user.SignedInUser{Namespace: "ns"})
+	index, err := backend.BuildIndex(ctx, key, 4, "test", func(i resource.ResourceIndex) (int64, error) {
+		return 1, i.BulkIndex(&resource.BulkIndexRequest{Items: []*resource.BulkIndexItem{
+			deleted("old", &old, 10),
+			deleted("recent", &recent, 20),
+			deleted("no-timestamp", nil, 30),
+			{Action: resource.ActionIndex, Doc: &resource.IndexableDocument{
+				Key:   &resourcepb.ResourceKey{Namespace: key.Namespace, Group: key.Group, Resource: key.Resource, Name: "live"},
+				Name:  "live",
+				Title: "live",
+			}},
+		}})
+	}, nil, false, time.Time{}, 0)
+	require.NoError(t, err)
+	return index
+}
+
+func ptr[T any](v T) *T { return &v }

--- a/pkg/storage/unified/search/bleve_trash_retention_test.go
+++ b/pkg/storage/unified/search/bleve_trash_retention_test.go
@@ -59,13 +59,13 @@ func TestTrashRetentionWindow(t *testing.T) {
 			want:      []string{"no-timestamp", "old", "recent"},
 		},
 		{
-			// A window of zero would otherwise expire everything the moment
-			// collection was switched on.
-			name:      "a zero window applies no filter",
+			// The collector computes the same cutoff from a zero window and removes
+			// everything older, so search has to hide the same set.
+			name:      "a zero window expires everything with a deletion time",
 			group:     "dashboard.grafana.app",
 			resource:  "dashboards",
 			retention: search.TrashRetentionConfig{Enabled: true},
-			want:      []string{"no-timestamp", "old", "recent"},
+			want:      []string{"no-timestamp"},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/storage/unified/search/options.go
+++ b/pkg/storage/unified/search/options.go
@@ -124,7 +124,9 @@ func NewSearchOptions(
 			// From the garbage collection settings, so trash and storage cannot
 			// disagree about what is expired.
 			TrashRetention: TrashRetentionConfig{
-				Enabled:          cfg.EnableGarbageCollection,
+				// Dry run counts what it would remove and deletes nothing, so trash
+				// stays restorable and this stays off.
+				Enabled:          cfg.EnableGarbageCollection && !cfg.GarbageCollectionDryRun,
 				MaxAge:           cfg.GarbageCollectionMaxAge,
 				DashboardsMaxAge: cfg.DashboardsGarbageCollectionMaxAge,
 			},

--- a/pkg/storage/unified/search/options.go
+++ b/pkg/storage/unified/search/options.go
@@ -121,6 +121,13 @@ func NewSearchOptions(
 				MaxCandidates:   cfg.SearchPostRankAuthzMaxCandidates,
 				FacetSampleSize: cfg.SearchPostRankAuthzFacetSampleSize,
 			},
+			// From the garbage collection settings, so trash and storage cannot
+			// disagree about what is expired.
+			TrashRetention: TrashRetentionConfig{
+				Enabled:          cfg.EnableGarbageCollection,
+				MaxAge:           cfg.GarbageCollectionMaxAge,
+				DashboardsMaxAge: cfg.DashboardsGarbageCollectionMaxAge,
+			},
 		}, indexMetrics)
 
 		if err != nil {

--- a/pkg/storage/unified/search/options_test.go
+++ b/pkg/storage/unified/search/options_test.go
@@ -217,3 +217,38 @@ func fileBucketURL(t *testing.T, dir string) string {
 	u := url.URL{Scheme: "file", Path: dir}
 	return u.String()
 }
+
+// Dry run counts what the collector would remove and deletes nothing, so trash of
+// any age is still restorable and must stay searchable.
+func TestNewSearchOptionsTrashRetentionFollowsGarbageCollection(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		enabled     bool
+		dryRun      bool
+		wantEnabled bool
+	}{
+		{name: "collection off", enabled: false, wantEnabled: false},
+		{name: "collection on", enabled: true, wantEnabled: true},
+		{name: "collection on, dry run", enabled: true, dryRun: true, wantEnabled: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := snapshotOptionsTestCfg(t)
+			cfg.EnableSearch = true
+			cfg.BuildVersion = "11.0.0"
+			cfg.IndexPath = filepath.Join(t.TempDir(), "bleve")
+			cfg.EnableGarbageCollection = tc.enabled
+			cfg.GarbageCollectionDryRun = tc.dryRun
+			cfg.GarbageCollectionMaxAge = time.Hour
+
+			opts, err := NewSearchOptions(cfg, nil, resource.ProvideIndexMetrics(prometheus.NewRegistry()), nil, nil)
+			require.NoError(t, err)
+
+			backend, ok := opts.Backend.(*bleveBackend)
+			require.True(t, ok)
+			t.Cleanup(backend.Stop)
+
+			assert.Equal(t, tc.wantEnabled, backend.opts.TrashRetention.Enabled)
+			assert.Equal(t, time.Hour, backend.opts.TrashRetention.MaxAge)
+		})
+	}
+}


### PR DESCRIPTION
Garbage collection deletes the rows behind a trash entry and emits no events, so the index keeps serving it until a rebuild. Restoring one of those fails. An entry already past the retention window is in the same position, whether or not collection has reached it yet.

Trash searches now exclude documents whose deletion time is outside the window. The window comes from the garbage collection settings rather than a search-side setting of its own, so the two cannot disagree about what is expired. Dashboards keep trash far longer than other kinds, so it is per kind, mirroring `garbageCollectionCutoffTimestamp`.

It only applies when garbage collection is enabled. With collection off nothing is ever removed, so old trash is still restorable and hiding it would lose people their objects. That case has a test, since it is the one most likely to be got wrong.

Search and storage can be separate deployments, so the settings have to reach the search process for this to do anything.