### PR TITLE
Alerting: Use early return in onRunQueries for readability

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1234,11 +1234,6 @@
       "count": 1
     }
   },
-  "public/app/features/alerting/unified/hooks/useAlertQueriesStatus.ts": {
-    "@grafana/no-get-data-source-srv": {
-      "count": 1
-    }
-  },
   "public/app/features/alerting/unified/hooks/useAlertmanagerConfig.ts": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1

--- a/public/app/features/alerting/unified/components/rule-viewer/tabs/QueryAndCondition.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/tabs/QueryAndCondition.tsx
@@ -65,17 +65,19 @@ const QueryAndCondition = ({ rule }: Props) => {
   const [isRunning, setIsRunning] = useState(false);
 
   const onRunQueries = useCallback(() => {
-    if (queries.length > 0 && !isDsLoading && allDataSourcesAvailable) {
-      let condition;
-      if (rule && rulerRuleType.grafana.rule(rule.rulerRule)) {
-        condition = rule.rulerRule.grafana_alert.condition;
-      }
-      setIsRunning(true);
-      // Run original queries for expression evaluation
-      runExpressionQueries(queries, condition ?? 'A');
-      // Run range-converted data source queries for visualization
-      runVisualizationQueries(visualizationQueries, '');
+    if (queries.length === 0 || isDsLoading || !allDataSourcesAvailable) {
+      return;
     }
+
+    let condition;
+    if (rule && rulerRuleType.grafana.rule(rule.rulerRule)) {
+      condition = rule.rulerRule.grafana_alert.condition;
+    }
+    setIsRunning(true);
+    // Run original queries for expression evaluation
+    runExpressionQueries(queries, condition ?? 'A');
+    // Run range-converted data source queries for visualization
+    runVisualizationQueries(visualizationQueries, '');
   }, [
     queries,
     visualizationQueries,


### PR DESCRIPTION
## What is this feature?

Refactors `onRunQueries` in `QueryAndCondition.tsx` to use an early return (guard clause) instead of wrapping the whole body in a positive condition. No behavior change.

## Why do we need this feature?

Follow-up to review feedback from @konstantinmv on #126652 ([review thread](https://github.com/grafana/grafana/pull/126652#discussion_r3774009597)) — the suggestion was deferred there to keep the migration PR minimal.

## Who is this feature for?

Maintainers of the alerting rule viewer.

## Which issue(s) does this PR fix?

Follow-up to #126652.

## Special notes for your reviewer:

Pure readability refactor: `queries.length > 0 && !isDsLoading && allDataSourcesAvailable` inverted to a guard `queries.length === 0 || isDsLoading || !allDataSourcesAvailable`. Existing unit tests (`QueryAndCondition.test.tsx`, 7 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)