### PR TITLE
Runtime: Resolve empty datasource refs like the legacy DataSourceSrv

### DIFF
--- a/packages/grafana-runtime/src/services/dataSource/dataSource.test.ts
+++ b/packages/grafana-runtime/src/services/dataSource/dataSource.test.ts
@@ -277,6 +277,18 @@ describe('plugin', () => {
         expect(logWarning).not.toHaveBeenCalled();
       });
 
+      it('loads the configured default datasource when ref has an empty uid and no type', async () => {
+        const { bravo } = seedAlphaBravo();
+        const instance = Object.create(DataSourceApi.prototype) as DataSourceApi;
+        const MockClass = importerReturning(instance);
+
+        const result = await getDataSourceInstance({ uid: '' });
+
+        expect(MockClass).toHaveBeenCalledWith(bravo);
+        expect(result).toBe(instance);
+        expect(logWarning).not.toHaveBeenCalled();
+      });
+
       it('resolves a ref with an empty uid by its type', async () => {
         const { bravo } = seedAlphaBravo();
         const MockClass = importerReturning(Object.create(DataSourceApi.prototype));

--- a/packages/grafana-runtime/src/services/dataSource/dataSource.test.ts
+++ b/packages/grafana-runtime/src/services/dataSource/dataSource.test.ts
@@ -265,6 +265,28 @@ describe('plugin', () => {
         expect(MockClass).toHaveBeenCalledWith(bravo);
       });
 
+      it('loads the configured default datasource when ref is an empty string', async () => {
+        const { bravo } = seedAlphaBravo();
+        const instance = Object.create(DataSourceApi.prototype) as DataSourceApi;
+        const MockClass = importerReturning(instance);
+
+        const result = await getDataSourceInstance('');
+
+        expect(MockClass).toHaveBeenCalledWith(bravo);
+        expect(result).toBe(instance);
+        expect(logWarning).not.toHaveBeenCalled();
+      });
+
+      it('resolves a ref with an empty uid by its type', async () => {
+        const { bravo } = seedAlphaBravo();
+        const MockClass = importerReturning(Object.create(DataSourceApi.prototype));
+
+        await getDataSourceInstance({ type: 'test-db', uid: '' });
+
+        expect(MockClass).toHaveBeenCalledWith(bravo);
+        expect(logWarning).not.toHaveBeenCalled();
+      });
+
       it('falls back to the configured default for a type-only ref with no match', async () => {
         const { bravo } = seedAlphaBravo();
         const MockClass = importerReturning(Object.create(DataSourceApi.prototype));

--- a/packages/grafana-runtime/src/services/dataSource/dataSource.ts
+++ b/packages/grafana-runtime/src/services/dataSource/dataSource.ts
@@ -37,6 +37,8 @@ export async function getDataSourceInstance(
   ref?: DataSourceRef | string | null,
   scopedVars?: ScopedVars
 ): Promise<DataSourceApi> {
+  ref = normalizeEmptyRef(ref);
+
   if (isExpressionReference(ref)) {
     const expressionDs = getExpressionDataSourceInstance();
     if (!expressionDs) {
@@ -91,6 +93,19 @@ export async function getDataSourceInstance(
   } catch (err) {
     return getDataSourceInstanceFallback(ref, scopedVars, err);
   }
+}
+
+// Legacy DataSourceSrv.get() treats an empty ref ('' or { uid: '' }) as "default datasource"
+// (or a type-only lookup when ref.type is set). getDataSourceInstanceSettings only does this
+// for null/undefined, so normalize here to keep getDataSourceInstance in parity with get().
+function normalizeEmptyRef(ref: DataSourceRef | string | null | undefined): DataSourceRef | string | null | undefined {
+  if (ref === '') {
+    return undefined;
+  }
+  if (typeof ref === 'object' && ref !== null && ref.uid === '') {
+    return { ...ref, uid: undefined };
+  }
+  return ref;
 }
 
 async function loadDataSourceInstance(cacheUid: string, settings: DataSourceInstanceSettings): Promise<DataSourceApi> {

--- a/packages/grafana-runtime/src/services/dataSource/dataSource.ts
+++ b/packages/grafana-runtime/src/services/dataSource/dataSource.ts
@@ -103,7 +103,10 @@ function normalizeEmptyRef(ref: DataSourceRef | string | null | undefined): Data
     return undefined;
   }
   if (typeof ref === 'object' && ref !== null && ref.uid === '') {
-    return { ...ref, uid: undefined };
+    // Keep the object only when a type-only lookup is possible; otherwise this is a plain
+    // "default datasource" request (same as an empty string), and normalizing to undefined
+    // lets describeRef report 'default' instead of 'unknown' if resolution fails.
+    return ref.type ? { ...ref, uid: undefined } : undefined;
   }
   return ref;
 }

--- a/packages/grafana-runtime/src/services/dataSource/logging.ts
+++ b/packages/grafana-runtime/src/services/dataSource/logging.ts
@@ -17,7 +17,9 @@ export function describeRef(ref: DataSourceRef | string | null | undefined): str
     return 'default';
   }
   if (typeof ref === 'string') {
-    return ref;
+    // Faro drops empty attribute values, so give '' a visible label.
+    return ref === '' ? 'empty' : ref;
   }
-  return ref.uid ?? ref.type ?? 'unknown';
+  // An empty uid falls through to the type so the log still identifies the ref.
+  return ref.uid || ref.type || 'unknown';
 }

--- a/packages/grafana-runtime/src/services/dataSource/logging.ts
+++ b/packages/grafana-runtime/src/services/dataSource/logging.ts
@@ -17,8 +17,9 @@ export function describeRef(ref: DataSourceRef | string | null | undefined): str
     return 'default';
   }
   if (typeof ref === 'string') {
-    // Faro drops empty attribute values, so give '' a visible label.
-    return ref === '' ? 'empty' : ref;
+    // Faro drops empty attribute values, so give '' a visible label. The synthetic
+    // <empty> marker cannot collide with a real uid/name, unlike a bare word.
+    return ref === '' ? '<empty>' : ref;
   }
   // An empty uid falls through to the type so the log still identifies the ref.
   return ref.uid || ref.type || 'unknown';


### PR DESCRIPTION
**What is this feature?**

`getDataSourceInstance` now resolves empty datasource refs (`''` or `{ uid: '' }`) to the default datasource — or by `type` when set — matching the legacy `DataSourceSrv.get()` falsy-ref behavior. It also gives empty refs a visible label in the fallback warning logs, since Faro drops empty attribute values.

**Why do we need this feature?**

Production Faro logs show `getDataSourceInstance failed via the new path but the legacy DataSourceSrv resolved it — falling back` warnings on builds that already contain #130175. The remaining cases are Explore URLs carrying `"datasource":""` / `{"type":"loki","uid":""}`: legacy `get()` treats an empty ref as the default datasource via a falsy check, while the new path only did so for `null`/`undefined`, so empty refs failed and hit the legacy fallback.

**Who is this feature for?**

Users on instances migrating to the async datasource APIs, and the team tracking the new-vs-legacy divergence warnings.

**Which issue(s) does this PR fix?**:

n/a — follow-up to #130175 based on production fallback logs.

**Special notes for your reviewer:**

`getDataSourceInstanceSettings` is intentionally unchanged: legacy `getInstanceSettings('')` also returns `undefined`, so only the instance path diverged. Covered by new parity tests in `dataSource.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)