### PR TITLE
DashboardScene: Skip groupby variables in non-dashboard scenes

### DIFF
--- a/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.test.ts
+++ b/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.test.ts
@@ -924,6 +924,31 @@ describe('sceneVariablesSetToVariables', () => {
 
       expect(() => sceneVariablesSetToVariables(set)).toThrow('Unsupported variable type');
     });
+
+    it('should omit GroupByVariable without throwing when the scene is not a dashboard', () => {
+      const groupByVariable = new GroupByVariable({
+        name: 'test',
+        label: 'test-label',
+        description: 'test-desc',
+        hide: VariableHide.inControlsMenu,
+        datasource: { uid: 'fake-uid', type: 'fake-type' },
+        defaultOptions: [
+          {
+            text: 'Foo',
+            value: 'foo',
+          },
+        ],
+      });
+      const constantVariable = new ConstantVariable({ name: 'keep-me', value: 'val' });
+      const set = new SceneVariableSet({
+        variables: [groupByVariable, constantVariable],
+      });
+
+      const result = sceneVariablesSetToVariables(set, undefined, undefined, undefined, false);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('keep-me');
+    });
   });
 
   it('should handle SwitchVariable with "true" value', () => {

--- a/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
+++ b/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
@@ -51,7 +51,12 @@ import {
  *                           If `true`, the options for query variables are kept.
  * @param excludeVariable - (Optional) Scene variable instance to omit. Is used to avoid self-reference in that variable's editor.
  *                          e.g when editing it as a section variable.
- *
+ * @param isDashboardScene - (Optional, default `true`) Whether `set` belongs to a Grafana dashboard.
+ *                           Dashboards are already gated against unsupported/toggle-gated variable
+ *                           types at deserialization time, so encountering one here is a real bug and
+ *                           should throw. Non-dashboard scenes (e.g. an app plugin's own scene) can
+ *                           construct variable types directly with no such gating, so those are
+ *                           safely omitted instead of crashing the caller.
  *
  *  */
 
@@ -60,7 +65,8 @@ export function sceneVariablesSetToVariables(
   keepQueryOptions?: boolean,
   excludedVariable?: SceneObject,
   /** Include variables with `origin` (e.g. predefined global/folder). Default excludes them for persistence. */
-  includeRuntimeVariables?: boolean
+  includeRuntimeVariables?: boolean,
+  isDashboardScene = true
 ) {
   const variables: VariableModel[] = [];
 
@@ -279,6 +285,10 @@ export function sceneVariablesSetToVariables(
     } else if (variable.state.type === 'system' || variable.state.type === 'snapshot') {
       // Not persisted. Snapshot variables are read-only frozen values; the scene graph
       // interpolates them directly, so there is nothing to serialize here.
+    } else if (sceneUtils.isGroupByVariable(variable) && !isDashboardScene) {
+      // Recognized type, just gated off by the core groupByVariable toggle. Only safe to omit here
+      // because this isn't a Grafana dashboard (e.g. a plugin's own scene) — dashboards are already
+      // gated at deserialization time, so reaching this branch for one would mean that gate failed.
     } else {
       throw new Error('Unsupported variable type: ' + variable.state.type);
     }

--- a/public/app/features/dashboard-scene/utils/getVariablesCompatibility.test.ts
+++ b/public/app/features/dashboard-scene/utils/getVariablesCompatibility.test.ts
@@ -5,22 +5,26 @@ import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
 import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLayoutManager';
 import { RowItem } from '../scene/layout-rows/RowItem';
 import { RowsLayoutManager } from '../scene/layout-rows/RowsLayoutManager';
+import { sceneVariablesSetToVariables } from '../serialization/sceneVariablesSetToVariables';
 
 import { getVariablesCompatibility } from './getVariablesCompatibility';
 import { toControlSourceRef } from './predefinedVariables';
 
 jest.mock('../serialization/sceneVariablesSetToVariables', () => ({
-  sceneVariablesSetToVariables: (
-    set: { state: { variables: Array<{ state: { name: string; type?: string; origin?: unknown } }> } },
-    _keepQueryOptions?: boolean,
-    excludeVariable?: unknown,
-    includeRuntimeVariables?: boolean
-  ) => {
-    return set.state.variables
-      .filter((v) => v !== excludeVariable)
-      .filter((v) => includeRuntimeVariables || v.state.origin === undefined)
-      .map((v) => ({ name: v.state.name, type: v.state.type ?? 'custom' }));
-  },
+  sceneVariablesSetToVariables: jest.fn(
+    (
+      set: { state: { variables: Array<{ state: { name: string; type?: string; origin?: unknown } }> } },
+      _keepQueryOptions?: boolean,
+      excludeVariable?: unknown,
+      includeRuntimeVariables?: boolean,
+      _isDashboardScene?: boolean
+    ) => {
+      return set.state.variables
+        .filter((v) => v !== excludeVariable)
+        .filter((v) => includeRuntimeVariables || v.state.origin === undefined)
+        .map((v) => ({ name: v.state.name, type: v.state.type ?? 'custom' }));
+    }
+  ),
 }));
 
 function makeVar(name: string) {
@@ -245,6 +249,33 @@ describe('getVariablesCompatibility', () => {
       const matched = result.filter((v) => v.name === 'sharedName');
 
       expect(matched).toHaveLength(1);
+    });
+  });
+
+  describe('isDashboardScene flag', () => {
+    it('passes true when the scene object is a DashboardScene', () => {
+      const dashboard = new DashboardScene({
+        $variables: new SceneVariableSet({ variables: [makeVar('dashVar')] }),
+        body: new RowsLayoutManager({ rows: [] }),
+      });
+
+      getVariablesCompatibility(dashboard);
+
+      const isDashboardScene = jest.mocked(sceneVariablesSetToVariables).mock.calls.at(-1)?.[4];
+      expect(isDashboardScene).toBe(true);
+    });
+
+    it('passes false when the scene object is not a DashboardScene (e.g. a plugin scene)', () => {
+      const panel = new VizPanel({
+        key: 'panel-1',
+        pluginId: 'text',
+        $variables: new SceneVariableSet({ variables: [makeVar('pluginVar')] }),
+      });
+
+      getVariablesCompatibility(panel);
+
+      const isDashboardScene = jest.mocked(sceneVariablesSetToVariables).mock.calls.at(-1)?.[4];
+      expect(isDashboardScene).toBe(false);
     });
   });
 });

--- a/public/app/features/dashboard-scene/utils/getVariablesCompatibility.ts
+++ b/public/app/features/dashboard-scene/utils/getVariablesCompatibility.ts
@@ -5,13 +5,15 @@ import { DashboardScene } from '../scene/DashboardScene';
 import { sceneVariablesSetToVariables } from '../serialization/sceneVariablesSetToVariables';
 
 export function getVariablesCompatibility(sceneObject: SceneObject): TypedVariableModel[] {
+  const isDashboardScene = sceneObject instanceof DashboardScene;
+
   // When a panel is being edited, scope variables to that panel's ancestry.
   // This ensures the query editor autocomplete only shows the panel's own
   // section variables + dashboard globals, not variables from other sections.
   if (sceneObject instanceof DashboardScene && sceneObject.state.editPanel) {
     const panel = sceneObject.state.editPanel.state.panelRef.resolve();
     // @ts-expect-error
-    return collectAncestorVariables(panel);
+    return collectAncestorVariables(panel, isDashboardScene);
   }
 
   // When a scene object is selected in the sidebar (e.g., editing a section variable),
@@ -22,15 +24,15 @@ export function getVariablesCompatibility(sceneObject: SceneObject): TypedVariab
 
     if (selectedObject) {
       // @ts-expect-error
-      return collectAncestorVariables(selectedObject);
+      return collectAncestorVariables(selectedObject, isDashboardScene);
     }
   }
 
   // Default: dashboard global vars
-  return collectGlobalVariables(sceneObject);
+  return collectGlobalVariables(sceneObject, isDashboardScene);
 }
 
-function collectAncestorVariables(sceneObject: SceneObject): VariableModel[] {
+function collectAncestorVariables(sceneObject: SceneObject, isDashboardScene: boolean): VariableModel[] {
   const allModels: VariableModel[] = [];
   const seenNames = new Set<string>();
   const keepQueryOptions = true;
@@ -42,7 +44,7 @@ function collectAncestorVariables(sceneObject: SceneObject): VariableModel[] {
   while (current) {
     if (current.state.$variables instanceof SceneVariableSet) {
       const set = current.state.$variables;
-      const models = sceneVariablesSetToVariables(set, keepQueryOptions, excludedVariable, true);
+      const models = sceneVariablesSetToVariables(set, keepQueryOptions, excludedVariable, true, isDashboardScene);
 
       for (const model of models) {
         if (!seenNames.has(model.name)) {
@@ -57,11 +59,11 @@ function collectAncestorVariables(sceneObject: SceneObject): VariableModel[] {
   return allModels;
 }
 
-function collectGlobalVariables(sceneObject: SceneObject): TypedVariableModel[] {
+function collectGlobalVariables(sceneObject: SceneObject, isDashboardScene: boolean): TypedVariableModel[] {
   const set = sceneGraph.getVariables(sceneObject);
   const keepQueryOptions = true;
 
-  const legacyModels = sceneVariablesSetToVariables(set, keepQueryOptions, undefined, true);
+  const legacyModels = sceneVariablesSetToVariables(set, keepQueryOptions, undefined, true, isDashboardScene);
 
   // Sadly templateSrv.getVariables returns TypedVariableModel but sceneVariablesSetToVariables return persisted schema model
   // They look close to identical (differ in what is optional in some places).


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Grafana app plugins built with `@grafana/scenes`' `EmbeddedScene` (the standard way to build any
scene page) set `window.__grafanaSceneContext` to themselves on activation — this happens for any
scene page, not just Grafana core dashboards. If that page has its own `groupby`-type variable and
the core `groupByVariable` feature toggle is disabled, any call to `getTemplateSrv().getVariables()`
on that page throws `Unsupported variable type: groupby` and crashes the page.

This is a latent bug that's existed since #82185 (2023), but plugins never actually hit it until
#130258 unified the plugin-facing `DataSourcePicker` (`@grafana/runtime`) with the core picker —
enabled by default via `grafana.unifiedDataSourcePicker` — which landed in nightly recently. The old
plugin picker was a standalone `Select` implementation that never touched `templateSrv`. The core
picker it now renders (`DataSourceList.tsx`) calls `getTemplateSrv().getVariables()` unconditionally
on every render of its dropdown, which is what actually exposed the crash: any plugin with its own
`groupby` variable now crashes the moment its data source picker opens.

#82185 gated `groupby` variable creation behind the `groupByVariable` toggle everywhere *it*
controlled (dashboard JSON deserialization, the variable editor UI), and treated seeing one anywhere
else as an invariant violation worth failing loudly on — there's a test literally named "should not
handle GroupByVariable and throw an error". That assumption held in 2023, but doesn't anymore: a
plugin can construct `new GroupByVariable(...)` directly in its own `EmbeddedScene`, with no reason to
check Grafana core's internal toggle, so a perfectly legitimate plugin variable now hits the same
throw.

This PR keeps the throw for actual dashboards (still a valid safety net there — dashboards are
already gated at deserialization time in #82185, so reaching this branch for one still indicates a
real bug) and only skips a toggle-gated `groupby` variable when the enclosing scene is not a
`DashboardScene`.




**Why do we need this feature?**

To fix the Dbo11y app crashing on the Grafana nightly image.


https://github.com/user-attachments/assets/c7bd0d2d-5f24-46bb-ac65-2b6f724b10e8



**Who is this feature for?**

Plugin developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
