### PR TITLE
CI: Cache Playwright browsers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1290,6 +1290,7 @@ embed.go @grafana/grafana-as-code
 /.github/actions/change-detection @grafana/grafana-backend-services-squad
 /.github/actions/setup-fpm @grafana/grafana-backend-services-squad
 /.github/actions/setup-node @grafana/grafana-frontend-platform
+/.github/actions/setup-playwright/action.yml @grafana/grafana-frontend-platform
 /.github/actions/yarn-install/action.yml @grafana/grafana-frontend-platform
 /.github/workflows/actionlint-format.txt @grafana/grafana-backend-services-squad
 /.github/workflows/actionlint.yml @grafana/grafana-backend-services-squad

--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -1,0 +1,25 @@
+name: Setup Playwright
+description: Install Playwright browsers, restored from a cache keyed on the Playwright version.
+
+runs:
+  using: composite
+  steps:
+    - name: Get Playwright version
+      id: version
+      shell: bash
+      run: |
+        set -euo pipefail
+        version="$(jq -er '.devDependencies["@playwright/test"]' package.json)"
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+
+    - name: Cache Playwright browsers
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ steps.version.outputs.version }}-chromium
+
+    # Runs on a cache hit too: --with-deps installs system packages that live
+    # outside the cached browser directory.
+    - name: Install Playwright browsers
+      shell: bash
+      run: yarn playwright install chromium --with-deps

--- a/.github/workflows/frontend-perf-tests.yaml
+++ b/.github/workflows/frontend-perf-tests.yaml
@@ -41,7 +41,7 @@ jobs:
         uses: ./.github/actions/yarn-install
 
       - name: Install Playwright browsers
-        run: yarn playwright install chromium --with-deps
+        uses: ./.github/actions/setup-playwright
 
       - name: Run Playwright tests (fsperf)
         id: pw-fsperf

--- a/.github/workflows/pr-diagnostics-e2e.yml
+++ b/.github/workflows/pr-diagnostics-e2e.yml
@@ -72,7 +72,7 @@ jobs:
             > grafana-server/grafana.log 2>&1 &
 
       - name: Install Playwright browsers
-        run: yarn playwright install chromium --with-deps
+        uses: ./.github/actions/setup-playwright
 
       - name: Wait for Grafana server to start
         run: |

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -149,7 +149,7 @@ jobs:
         uses: ./.github/actions/yarn-install
 
       - name: Install Playwright browsers
-        run: yarn playwright install chromium --with-deps
+        uses: ./.github/actions/setup-playwright
 
       - name: Run Storybook and E2E tests
         run: yarn e2e:playwright:storybook
@@ -229,7 +229,7 @@ jobs:
           echo "To view the server logs, wait for this job to complete and downloaded the 'grafana-server-log-${{ matrix.shard }}' artifact."
 
       - name: Install Playwright browsers
-        run: yarn playwright install chromium --with-deps
+        uses: ./.github/actions/setup-playwright
 
       - name: Wait for Grafana server to start
         run: |

--- a/.github/workflows/release-verify-packages.yml
+++ b/.github/workflows/release-verify-packages.yml
@@ -89,7 +89,7 @@ jobs:
           echo "$!" > /tmp/release-verify-deb.pid
 
       - name: Install Playwright browsers
-        run: yarn playwright install chromium --with-deps
+        uses: ./.github/actions/setup-playwright
 
       - name: Wait for Grafana server to start
         run: |
@@ -190,7 +190,7 @@ jobs:
           echo "$!" > /tmp/release-verify-rpm.pid
 
       - name: Install Playwright browsers
-        run: yarn playwright install chromium --with-deps
+        uses: ./.github/actions/setup-playwright
 
       - name: Wait for Grafana server to start
         run: |
@@ -276,7 +276,7 @@ jobs:
         run: docker run -d --name grafana-verify -p 3000:3000 -e GF_FEATURE_TOGGLES_splashScreen=false "${IMAGE_UNDER_TEST}"
 
       - name: Install Playwright browsers
-        run: yarn playwright install chromium --with-deps
+        uses: ./.github/actions/setup-playwright
 
       - name: Wait for Grafana server to start
         run: |
@@ -363,7 +363,7 @@ jobs:
         run: docker run -d --name grafana-verify -p 3000:3000 -e GF_FEATURE_TOGGLES_splashScreen=false "${IMAGE_UNDER_TEST}"
 
       - name: Install Playwright browsers
-        run: yarn playwright install chromium --with-deps
+        uses: ./.github/actions/setup-playwright
 
       - name: Wait for Grafana server to start
         run: |

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -73,7 +73,7 @@ jobs:
             > grafana-server/grafana.log 2>&1 &
 
       - name: Install Playwright browsers
-        run: yarn playwright install chromium --with-deps
+        uses: ./.github/actions/setup-playwright
 
       - name: Wait for Grafana server to start
         run: |

--- a/.github/workflows/storybook-a11y.yml
+++ b/.github/workflows/storybook-a11y.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Install yarn dependencies
       uses: ./.github/actions/yarn-install
     - name: Install Playwright browsers
-      run: yarn playwright install chromium --with-deps
+      uses: ./.github/actions/setup-playwright
     - name: Start Storybook
       run: STORYBOOK_THEME=${{ matrix.STORYBOOK_THEME }} yarn storybook &
     - name: Run tests


### PR DESCRIPTION
**What is this change?**

Adds a `setup-playwright` composite action that restores `~/.cache/ms-playwright` from a cache keyed on the Playwright version in `package.json`, and uses it in every job that runs browser tests: the e2e shards, the storybook a11y matrix, release verification and the frontend performance tests.

Browsers were downloaded fresh from the CDN in each of those jobs. OS-level dependencies are still installed on every run via `--with-deps`; only the browser binaries are cached.

**Why do we need this?**

Measured on the e2e shards: 347.2s per shard (n=24) before, 329.5s (n=8) after, roughly −18s per shard ([run](https://github.com/grafana/grafana/actions/runs/31636334503) vs [baseline](https://github.com/grafana/grafana/actions/runs/31636450267)). The install step itself goes 26.0s to 20.8s.

Being straight about the numbers: the shard totals are close to noise. The value that this data cannot quantify is removing one CDN download per browser-testing job, which is the part that fails or stalls when the CDN is having a bad day.

**Special notes for your reviewer:**

The cache key is the version string parsed out of `package.json`, so a Playwright bump invalidates it. A version-matched cache entry cannot serve the wrong browser build.

Cache entries are scoped per branch, so a PR sees a hit only after main has populated the shared entry.

Description generated by Claude Code.
