### PR TITLE
chore: Update resource span filter and limit

### DIFF
--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
@@ -109,14 +109,14 @@ const useResourceAttributesExtensionLinks = ({
 
   const { links } = usePluginLinks({
     extensionPointId: PluginExtensionPoints.TraceViewResourceAttributes,
-    limitPerPlugin: 10,
+    limitPerPlugin: 15,
     context,
   });
 
   const resourceLinksGetter = useCallback(
     (pairs: TraceKeyValuePair[], index: number) => {
       const { key } = pairs[index] ?? {};
-      return links.filter((link) => link.category === key);
+      return links.filter((link) => (link.group?.name ?? link.category) === key);
     },
     [links]
   );


### PR DESCRIPTION
**What is this feature?**

Needed for https://github.com/grafana/traces-drilldown/pull/854#discussion_r3775007731

chore: Update resource span filter and limit

**Why do we need this feature?**

So we filter by new API and up limit

**Who is this feature for?**

Trace view users
