### PR TITLE
Logs: Add independent JSON prettifying in Log Details

### DIFF
--- a/public/app/features/logs/components/panel/LogDetailsContext.test.tsx
+++ b/public/app/features/logs/components/panel/LogDetailsContext.test.tsx
@@ -1,9 +1,12 @@
 import { act, renderHook } from '@testing-library/react';
 import { type ReactNode } from 'react';
 
+import { store } from '@grafana/data';
+
 import { createLogLine } from '../mocks/logRow';
 
 import {
+  emptyContextData,
   LogDetailsContextProvider,
   useLogDetailsContextData,
   useLogDetailsContext,
@@ -13,6 +16,7 @@ import {
 
 const log = createLogLine({ rowId: 'yep', uid: 'uid' });
 const contextValue: LogDetailsContextData = {
+  ...emptyContextData,
   currentLog: log,
   closeDetails: () => {},
   detailsDisplayed: () => false,
@@ -125,5 +129,52 @@ describe('replaceDetails', () => {
     expect(result.current.currentLog).toBe(logARefreshed);
     expect(result.current.showDetails).toEqual([logA]);
     expect(result.current.detailsDisplayed(logARefreshed)).toBe(true);
+  });
+});
+
+describe('prettifyDetailsJSON', () => {
+  const storageKey = 'grafana.logs.test.prettifyDetailsJSON';
+
+  afterEach(() => {
+    store.delete(`${storageKey}.prettifyDetailsJSON`);
+  });
+
+  function prettifyWrapper() {
+    return function Wrapper({ children }: { children: ReactNode }) {
+      return (
+        <LogDetailsContextProvider
+          detailsMode="sidebar"
+          enableLogDetails
+          logOptionsStorageKey={storageKey}
+          logs={logs}
+          showControls={false}
+        >
+          {children}
+        </LogDetailsContextProvider>
+      );
+    };
+  }
+
+  const logs = [log];
+
+  test('defaults to true', () => {
+    const { result } = renderHook(() => useLogDetailsContext(), {
+      wrapper: prettifyWrapper(),
+    });
+
+    expect(result.current.prettifyDetailsJSON).toBe(true);
+  });
+
+  test('setPrettifyDetailsJSON updates state and local storage', () => {
+    const { result } = renderHook(() => useLogDetailsContext(), {
+      wrapper: prettifyWrapper(),
+    });
+
+    act(() => {
+      result.current.setPrettifyDetailsJSON(false);
+    });
+
+    expect(result.current.prettifyDetailsJSON).toBe(false);
+    expect(store.getBool(`${storageKey}.prettifyDetailsJSON`, true)).toBe(false);
   });
 });

--- a/public/app/features/logs/components/panel/LogDetailsContext.tsx
+++ b/public/app/features/logs/components/panel/LogDetailsContext.tsx
@@ -16,10 +16,12 @@ export interface LogDetailsContextData {
   detailsMode: LogLineDetailsMode;
   detailsWidth: number;
   enableLogDetails: boolean;
+  prettifyDetailsJSON: boolean;
   replaceDetails: (log: LogListModel) => void;
   setCurrentLog: (log: LogListModel) => void;
   setDetailsMode: (mode: LogLineDetailsMode) => void;
   setDetailsWidth: (width: number) => void;
+  setPrettifyDetailsJSON: (prettifyDetailsJSON: boolean) => void;
   showDetails: LogListModel[];
   toggleDetails: (log: LogListModel) => void;
 }
@@ -31,10 +33,12 @@ export const emptyContextData: LogDetailsContextData = {
   detailsMode: 'sidebar',
   detailsWidth: 0,
   enableLogDetails: false,
+  prettifyDetailsJSON: true,
   replaceDetails: () => {},
   setCurrentLog: () => {},
   setDetailsMode: () => {},
   setDetailsWidth: () => {},
+  setPrettifyDetailsJSON: () => {},
   showDetails: [],
   toggleDetails: () => {},
 };
@@ -57,6 +61,7 @@ export interface Props {
   enableLogDetails: boolean;
   logs: LogRowModel[];
   logOptionsStorageKey?: string;
+  prettifyDetailsJSON?: boolean;
   showControls: boolean;
   showFieldSelector?: boolean;
 }
@@ -70,12 +75,17 @@ export const LogDetailsContextProvider = ({
     ? (store.get(`${logOptionsStorageKey}.detailsMode`) ?? getDefaultDetailsMode(containerElement))
     : getDefaultDetailsMode(containerElement),
   logs,
+  prettifyDetailsJSON: prettifyDetailsJSONProp,
   showControls,
   showFieldSelector,
 }: Props) => {
   const [showDetails, setShowDetails] = useState<LogListModel[]>([]);
 
   const [currentLog, setCurrentLog] = useState<LogListModel | undefined>(undefined);
+  const [prettifyDetailsJSON, setPrettifyDetailsJSONState] = useState(
+    prettifyDetailsJSONProp ??
+      (logOptionsStorageKey ? store.getBool(`${logOptionsStorageKey}.prettifyDetailsJSON`, true) : true)
+  );
   const [detailsWidth, setDetailsWidthState] = useState(
     getDetailsWidth(containerElement, logOptionsStorageKey, undefined, detailsModeProp, showControls, showFieldSelector)
   );
@@ -89,6 +99,13 @@ export const LogDetailsContextProvider = ({
       setDetailsMode(detailsModeProp);
     }
   }, [detailsModeProp]);
+
+  // Sync prettifyDetailsJSON
+  useEffect(() => {
+    if (prettifyDetailsJSONProp !== undefined) {
+      setPrettifyDetailsJSONState(prettifyDetailsJSONProp);
+    }
+  }, [prettifyDetailsJSONProp]);
 
   // Sync show details
   useEffect(() => {
@@ -182,6 +199,16 @@ export const LogDetailsContextProvider = ({
     [currentLog, enableLogDetails, showDetails]
   );
 
+  const setPrettifyDetailsJSON = useCallback(
+    (prettifyDetailsJSON: boolean) => {
+      setPrettifyDetailsJSONState(prettifyDetailsJSON);
+      if (logOptionsStorageKey) {
+        store.set(`${logOptionsStorageKey}.prettifyDetailsJSON`, prettifyDetailsJSON);
+      }
+    },
+    [logOptionsStorageKey]
+  );
+
   const setDetailsWidth = useCallback(
     (width: number) => {
       if (!logOptionsStorageKey || !containerElement) {
@@ -211,10 +238,12 @@ export const LogDetailsContextProvider = ({
         detailsMode,
         detailsWidth,
         enableLogDetails,
+        prettifyDetailsJSON,
         replaceDetails,
         setCurrentLog,
         setDetailsMode,
         setDetailsWidth,
+        setPrettifyDetailsJSON,
         showDetails,
         toggleDetails,
       }}

--- a/public/app/features/logs/components/panel/LogLineDetails.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.test.tsx
@@ -769,7 +769,7 @@ describe('LogLineDetails', () => {
         expect(screen.getByText(/value2/)).toBeInTheDocument();
       });
 
-      test('Shows a prettify switch for JSON log lines', async () => {
+      test('Shows a prettify switch for JSON log lines when the log line section is open', async () => {
         const jsonEntry = '{"key":"value"}';
         const log = createLogLine({
           entry: jsonEntry,
@@ -781,11 +781,17 @@ describe('LogLineDetails', () => {
 
         await setup({ logs: [log] }, undefined, undefined, { showDetails: [log], currentLog: log });
 
+        expect(screen.queryByRole('switch', { name: 'Prettify' })).not.toBeInTheDocument();
+
+        await userEvent.click(screen.getByText('Log line'));
+
         expect(screen.getByRole('switch', { name: 'Prettify' })).toBeInTheDocument();
       });
 
       test('Does not show a prettify switch for non-JSON log lines', async () => {
         await setup(undefined, { entry: 'plain log line', labels: { key1: 'label1' } });
+
+        await userEvent.click(screen.getByText('Log line'));
 
         expect(screen.queryByRole('switch', { name: 'Prettify' })).not.toBeInTheDocument();
       });
@@ -808,6 +814,7 @@ describe('LogLineDetails', () => {
           setPrettifyDetailsJSON,
         });
 
+        await userEvent.click(screen.getByText('Log line'));
         await userEvent.click(screen.getByRole('switch', { name: 'Prettify' }));
 
         expect(setPrettifyDetailsJSON).toHaveBeenCalledWith(false);

--- a/public/app/features/logs/components/panel/LogLineDetails.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.test.tsx
@@ -769,6 +769,96 @@ describe('LogLineDetails', () => {
         expect(screen.getByText(/value2/)).toBeInTheDocument();
       });
 
+      test('Shows a prettify switch for JSON log lines', async () => {
+        const jsonEntry = '{"key":"value"}';
+        const log = createLogLine({
+          entry: jsonEntry,
+          logLevel: LogLevel.error,
+          timeEpochMs: 1546297200000,
+          datasourceUid: lokiDS.uid,
+        });
+        void log.body;
+
+        await setup({ logs: [log] }, undefined, undefined, { showDetails: [log], currentLog: log });
+
+        expect(screen.getByRole('switch', { name: 'Prettify' })).toBeInTheDocument();
+      });
+
+      test('Does not show a prettify switch for non-JSON log lines', async () => {
+        await setup(undefined, { entry: 'plain log line', labels: { key1: 'label1' } });
+
+        expect(screen.queryByRole('switch', { name: 'Prettify' })).not.toBeInTheDocument();
+      });
+
+      test('Toggling the prettify switch calls setPrettifyDetailsJSON', async () => {
+        const jsonEntry = '{"key":"value"}';
+        const log = createLogLine({
+          entry: jsonEntry,
+          logLevel: LogLevel.error,
+          timeEpochMs: 1546297200000,
+          datasourceUid: lokiDS.uid,
+        });
+        void log.body;
+        const setPrettifyDetailsJSON = jest.fn();
+
+        await setup({ logs: [log] }, undefined, undefined, {
+          showDetails: [log],
+          currentLog: log,
+          prettifyDetailsJSON: true,
+          setPrettifyDetailsJSON,
+        });
+
+        await userEvent.click(screen.getByRole('switch', { name: 'Prettify' }));
+
+        expect(setPrettifyDetailsJSON).toHaveBeenCalledWith(false);
+      });
+
+      test('Renders a compact JSON log line when prettifyDetailsJSON is false', async () => {
+        const jsonEntry = '{"key":"value"}';
+        const log = createLogLine({
+          entry: jsonEntry,
+          logLevel: LogLevel.error,
+          timeEpochMs: 1546297200000,
+          datasourceUid: lokiDS.uid,
+        });
+        void log.body;
+
+        await setup(
+          { logs: [log] },
+          undefined,
+          { syntaxHighlighting: false },
+          { showDetails: [log], currentLog: log, prettifyDetailsJSON: false }
+        );
+
+        await userEvent.click(screen.getByText('Log line'));
+
+        expect(screen.getByText(jsonEntry)).toBeInTheDocument();
+      });
+
+      test('Renders a prettified JSON log line when prettifyDetailsJSON is true', async () => {
+        const jsonEntry = '{"key":"value"}';
+        const log = createLogLine({
+          entry: jsonEntry,
+          logLevel: LogLevel.error,
+          timeEpochMs: 1546297200000,
+          datasourceUid: lokiDS.uid,
+        });
+        void log.body;
+
+        await setup(
+          { logs: [log] },
+          undefined,
+          { syntaxHighlighting: false },
+          { showDetails: [log], currentLog: log, prettifyDetailsJSON: true }
+        );
+
+        await userEvent.click(screen.getByText('Log line'));
+
+        expect(screen.queryByText(jsonEntry)).not.toBeInTheDocument();
+        expect(screen.getByText(/"key"/)).toBeInTheDocument();
+        expect(screen.getByText(/"value"/)).toBeInTheDocument();
+      });
+
       test('Exposes buttons to reorder displayed fields', async () => {
         const setDisplayedFields = jest.fn();
         const onClickHideField = jest.fn();

--- a/public/app/features/logs/components/panel/LogLineDetails.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.tsx
@@ -97,8 +97,10 @@ const LogLineDetailsTabs = memo(
       currentLog,
       closeDetails,
       detailsMode,
+      prettifyDetailsJSON,
       replaceDetails,
       setCurrentLog,
+      setPrettifyDetailsJSON,
       showDetails,
       setDetailsMode,
       toggleDetails,
@@ -209,7 +211,9 @@ const LogLineDetailsTabs = memo(
           <LogLineDetailsComponent
             log={currentLog}
             logs={logs}
+            prettifyDetailsJSON={prettifyDetailsJSON}
             search={search}
+            setPrettifyDetailsJSON={setPrettifyDetailsJSON}
             timeRange={timeRange}
             timeZone={timeZone}
           />
@@ -230,7 +234,8 @@ export interface InlineLogLineDetailsProps {
 
 export const InlineLogLineDetails = memo(({ logs, log, onResize, timeRange, timeZone }: InlineLogLineDetailsProps) => {
   const { app, fontSize, logOptionsStorageKey, noInteractions } = useLogListContext();
-  const { closeDetails, detailsMode, detailsWidth, setDetailsMode } = useLogDetailsContext();
+  const { closeDetails, detailsMode, detailsWidth, prettifyDetailsJSON, setDetailsMode, setPrettifyDetailsJSON } =
+    useLogDetailsContext();
   const styles = useStyles2(getStyles, 'inline', undefined, fontSize);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const [search, setSearch] = useState('');
@@ -295,11 +300,27 @@ export const InlineLogLineDetails = memo(({ logs, log, onResize, timeRange, time
         />
         {inlineNoScroll ? (
           <div>
-            <LogLineDetailsComponent log={log} logs={logs} search={search} timeRange={timeRange} timeZone={timeZone} />
+            <LogLineDetailsComponent
+              log={log}
+              logs={logs}
+              prettifyDetailsJSON={prettifyDetailsJSON}
+              search={search}
+              setPrettifyDetailsJSON={setPrettifyDetailsJSON}
+              timeRange={timeRange}
+              timeZone={timeZone}
+            />
           </div>
         ) : (
           <ScrollContainer ref={scrollRef} onScroll={saveScroll} overflowY="auto" maxHeight={LOG_LINE_DETAILS_HEIGHT}>
-            <LogLineDetailsComponent log={log} logs={logs} search={search} timeRange={timeRange} timeZone={timeZone} />
+            <LogLineDetailsComponent
+              log={log}
+              logs={logs}
+              prettifyDetailsJSON={prettifyDetailsJSON}
+              search={search}
+              setPrettifyDetailsJSON={setPrettifyDetailsJSON}
+              timeRange={timeRange}
+              timeZone={timeZone}
+            />
           </ScrollContainer>
         )}
       </div>

--- a/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
@@ -13,12 +13,13 @@ import {
 import { t, Trans } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
 import { getDataSourceInstance } from '@grafana/runtime/unstable';
-import { Box, ControlledCollapse, useStyles2 } from '@grafana/ui';
+import { Box, ControlledCollapse, InlineSwitch, Stack, useStyles2 } from '@grafana/ui';
 
 import { getLabelTypeFromRow } from '../../utils';
 import { createLogLineLinks } from '../logParser';
 import { useAttributesExtensionLinks } from '../useAttributesExtensionLinks';
 
+import { useLogDetailsContext } from './LogDetailsContext';
 import { LogLineDetailsDisplayedFields } from './LogLineDetailsDisplayedFields';
 import { type LabelWithLinks, LogLineDetailsFields, LogLineDetailsLabelFields } from './LogLineDetailsFields';
 import { LogLineDetailsLinks } from './LogLineDetailsLinks';
@@ -41,6 +42,7 @@ export const LogLineDetailsComponent = memo(
   ({ log, logs, search = '', timeRange, timeZone }: LogLineDetailsComponentProps) => {
     const { displayedFields, noInteractions, logOptionsStorageKey, setDisplayedFields, syntaxHighlighting } =
       useLogListContext();
+    const { prettifyDetailsJSON, setPrettifyDetailsJSON } = useLogDetailsContext();
 
     const [ds, setDs] = useState<DataSourceApi | null | undefined>(undefined);
     const styles = useStyles2(getStyles);
@@ -170,11 +172,26 @@ export const LogLineDetailsComponent = memo(
       <div className={styles.componentWrapper}>
         <ControlledCollapse
           className={styles.collapsable}
-          label={t('logs.log-line-details.log-line-section', 'Log line')}
+          label={
+            <Stack justifyContent="space-between" flex={1} alignItems="center">
+              {t('logs.log-line-details.log-line-section', 'Log line')}
+              {log.isJSON && (
+                // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+                <div onClick={(event) => event.stopPropagation()}>
+                  <InlineSwitch
+                    label={t('logs.log-line-details.prettify', 'Prettify')}
+                    showLabel
+                    value={prettifyDetailsJSON}
+                    onChange={(event) => setPrettifyDetailsJSON(event.currentTarget.checked)}
+                  />
+                </div>
+              )}
+            </Stack>
+          }
           isOpen={logLineOpen}
           onToggle={(isOpen: boolean) => handleToggle('logLineOpen', isOpen)}
         >
-          <LogLineDetailsLog log={log} syntaxHighlighting={syntaxHighlighting ?? true} />
+          <LogLineDetailsLog log={log} syntaxHighlighting={syntaxHighlighting ?? true} prettifyJSON={prettifyDetailsJSON} />
         </ControlledCollapse>
         {displayedFields.length > 0 && setDisplayedFields && (
           <ControlledCollapse

--- a/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
@@ -13,7 +13,7 @@ import {
 import { t, Trans } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
 import { getDataSourceInstance } from '@grafana/runtime/unstable';
-import { Box, ControlledCollapse, InlineSwitch, Stack, useStyles2 } from '@grafana/ui';
+import { Box, ControlledCollapse, InlineField, InlineSwitch, Stack, useStyles2 } from '@grafana/ui';
 
 import { getLabelTypeFromRow } from '../../utils';
 import { createLogLineLinks } from '../logParser';
@@ -53,6 +53,9 @@ export const LogLineDetailsComponent = memo(
       useLogListContext();
 
     const [ds, setDs] = useState<DataSourceApi | null | undefined>(undefined);
+    const [logLineOpen, setLogLineOpen] = useState(
+      logOptionsStorageKey ? store.getBool(`${logOptionsStorageKey}.log-details.logLineOpen`, false) : false
+    );
     const styles = useStyles2(getStyles);
 
     const extensionLinks = useAttributesExtensionLinks(log, timeRange);
@@ -110,9 +113,6 @@ export const LogLineDetailsComponent = memo(
 
     const labelGroups = useMemo(() => Object.keys(groupedLabels), [groupedLabels]);
 
-    const logLineOpen = logOptionsStorageKey
-      ? store.getBool(`${logOptionsStorageKey}.log-details.logLineOpen`, false)
-      : false;
     const linksOpen = logOptionsStorageKey
       ? store.getBool(`${logOptionsStorageKey}.log-details.linksOpen`, true)
       : true;
@@ -129,6 +129,9 @@ export const LogLineDetailsComponent = memo(
     const handleToggle = useCallback(
       (option: string, isOpen: boolean) => {
         store.set(`${logOptionsStorageKey}.log-details.${option}`, isOpen);
+        if (option === 'logLineOpen') {
+          setLogLineOpen(isOpen);
+        }
         if (!noInteractions) {
           reportInteraction('logs_log_line_details_section_toggled', {
             section: option.replace('Open', ''),
@@ -183,16 +186,16 @@ export const LogLineDetailsComponent = memo(
           label={
             <Stack justifyContent="space-between" flex={1} alignItems="center">
               {t('logs.log-line-details.log-line-section', 'Log line')}
-              {log.body && log.isJSON && (
+              {log.body && log.isJSON && logLineOpen && (
                 // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-                <div onClick={(event) => event.stopPropagation()}>
-                  <InlineSwitch
-                    label={t('logs.log-line-details.prettify', 'Prettify')}
-                    showLabel
-                    value={prettifyDetailsJSON}
-                    onChange={(event) => setPrettifyDetailsJSON(event.currentTarget.checked)}
-                  />
-                </div>
+                <Stack alignItems="center" onClick={(event) => event.stopPropagation()}>
+                  <InlineField label={t('logs.log-line-details.prettify', 'Prettify')}>
+                    <InlineSwitch
+                      value={prettifyDetailsJSON}
+                      onChange={(event) => setPrettifyDetailsJSON(event.currentTarget.checked)}
+                    />
+                  </InlineField>
+                </Stack>
               )}
             </Stack>
           }

--- a/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
@@ -183,7 +183,7 @@ export const LogLineDetailsComponent = memo(
           label={
             <Stack justifyContent="space-between" flex={1} alignItems="center">
               {t('logs.log-line-details.log-line-section', 'Log line')}
-              {log.isJSON && (
+              {log.body && log.isJSON && (
                 // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
                 <div onClick={(event) => event.stopPropagation()}>
                   <InlineSwitch

--- a/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
@@ -19,7 +19,6 @@ import { getLabelTypeFromRow } from '../../utils';
 import { createLogLineLinks } from '../logParser';
 import { useAttributesExtensionLinks } from '../useAttributesExtensionLinks';
 
-import { useLogDetailsContext } from './LogDetailsContext';
 import { LogLineDetailsDisplayedFields } from './LogLineDetailsDisplayedFields';
 import { type LabelWithLinks, LogLineDetailsFields, LogLineDetailsLabelFields } from './LogLineDetailsFields';
 import { LogLineDetailsLinks } from './LogLineDetailsLinks';
@@ -33,16 +32,25 @@ import { type LogListModel } from './processing';
 interface LogLineDetailsComponentProps {
   log: LogListModel;
   logs: LogListModel[];
+  prettifyDetailsJSON: boolean;
   search?: string;
+  setPrettifyDetailsJSON: (prettifyDetailsJSON: boolean) => void;
   timeRange: TimeRange;
   timeZone: string;
 }
 
 export const LogLineDetailsComponent = memo(
-  ({ log, logs, search = '', timeRange, timeZone }: LogLineDetailsComponentProps) => {
+  ({
+    log,
+    logs,
+    prettifyDetailsJSON,
+    search = '',
+    setPrettifyDetailsJSON,
+    timeRange,
+    timeZone,
+  }: LogLineDetailsComponentProps) => {
     const { displayedFields, noInteractions, logOptionsStorageKey, setDisplayedFields, syntaxHighlighting } =
       useLogListContext();
-    const { prettifyDetailsJSON, setPrettifyDetailsJSON } = useLogDetailsContext();
 
     const [ds, setDs] = useState<DataSourceApi | null | undefined>(undefined);
     const styles = useStyles2(getStyles);
@@ -191,7 +199,11 @@ export const LogLineDetailsComponent = memo(
           isOpen={logLineOpen}
           onToggle={(isOpen: boolean) => handleToggle('logLineOpen', isOpen)}
         >
-          <LogLineDetailsLog log={log} syntaxHighlighting={syntaxHighlighting ?? true} prettifyJSON={prettifyDetailsJSON} />
+          <LogLineDetailsLog
+            log={log}
+            syntaxHighlighting={syntaxHighlighting ?? true}
+            prettifyJSON={prettifyDetailsJSON}
+          />
         </ControlledCollapse>
         {displayedFields.length > 0 && setDisplayedFields && (
           <ControlledCollapse

--- a/public/app/features/logs/components/panel/LogLineDetailsLog.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsLog.tsx
@@ -15,17 +15,18 @@ import { type LogListModel } from './processing';
 
 interface Props {
   log: LogListModel;
+  prettifyJSON?: boolean;
   syntaxHighlighting: boolean;
 }
 
-export const LogLineDetailsLog = memo(({ log: originalLog, syntaxHighlighting }: Props) => {
+export const LogLineDetailsLog = memo(({ log: originalLog, prettifyJSON, syntaxHighlighting }: Props) => {
   const { fontSize, noInteractions, onClickFilterOutString, onClickFilterString } = useLogListContext();
   const logStyles = useStyles2(getStyles);
   const styles = useStyles2(getLogLineDetailsLogStyles);
   const log = useMemo(() => {
-    const log = originalLog.clone();
+    const log = originalLog.clone({ prettifyJSON });
     return log;
-  }, [originalLog]);
+  }, [originalLog, prettifyJSON]);
 
   const filterLogLine = useCallback(() => {
     onClickFilterString?.(log.entry, log.dataFrame?.refId);

--- a/public/app/features/logs/components/panel/processing.test.ts
+++ b/public/app/features/logs/components/panel/processing.test.ts
@@ -197,6 +197,29 @@ describe('preProcessLogs', () => {
       expect(logListModel.body).not.toBe(entry);
     });
 
+    test('clone can enable JSON prettify independently of the original log', () => {
+      const entry = '{"key": "value"}';
+      const logListModel = createLogLine(
+        { entry },
+        {
+          escape: false,
+          order: LogsSortOrder.Descending,
+          timeZone: 'browser',
+          wrapLogMessage: false,
+          prettifyJSON: false,
+        }
+      );
+      expect(logListModel.body).toBe(entry);
+
+      const pretty = logListModel.clone({ prettifyJSON: true });
+      expect(pretty.body).toBe(`{
+  "key": "value"
+}`);
+
+      const compact = logListModel.clone({ prettifyJSON: false });
+      expect(compact.body).toBe(entry);
+    });
+
     test('Prettifies JSON with duplicate keys', () => {
       const entry = '{"key": "value", "key": "otherValue"}';
       const logListModel = createLogLine(

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -130,9 +130,12 @@ export class LogListModel implements LogRowModel {
     }
   }
 
-  clone() {
+  clone({ prettifyJSON }: { prettifyJSON?: boolean }) {
     const clone = Object.assign(Object.create(Object.getPrototypeOf(this)), this);
     // Unless this function is required outside of <LogLineDetailsLog />, we create a wrapped clone, so new lines are not stripped.
+    if (prettifyJSON !== undefined) {
+      clone._prettifyJSON = prettifyJSON;
+    }
     clone._wrapLogMessage = true;
     clone._body = undefined;
     clone._highlightTokens = undefined;

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -130,7 +130,7 @@ export class LogListModel implements LogRowModel {
     }
   }
 
-  clone({ prettifyJSON }: { prettifyJSON?: boolean }) {
+  clone({ prettifyJSON }: { prettifyJSON?: boolean } = {}) {
     const clone = Object.assign(Object.create(Object.getPrototypeOf(this)), this);
     // Unless this function is required outside of <LogLineDetailsLog />, we create a wrapped clone, so new lines are not stripped.
     if (prettifyJSON !== undefined) {

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -145,8 +145,9 @@ export class LogListModel implements LogRowModel {
 
   get body(): string {
     if (this._body === undefined) {
+      let raw = this.raw;
       try {
-        const parsed = parse(this.raw, undefined, {
+        const parsed = parse(raw, undefined, {
           onDuplicateKey: ({ newValue }) => newValue,
         });
         if (typeof parsed === 'object' && parsed !== null && !(parsed instanceof LosslessNumber)) {
@@ -154,15 +155,14 @@ export class LogListModel implements LogRowModel {
         }
         const reStringified = this._wrapLogMessage && this._prettifyJSON ? stringify(parsed, undefined, 2) : this.raw;
         if (reStringified) {
-          this.raw = reStringified;
+          raw = reStringified;
         }
       } catch (error) {}
 
       // always escape for literal \n, \t, \r sequences so "Escape newlines" works for all log types.
       if (this._escapeUnescapedString) {
-        this.raw = escapeUnescapedString(this.raw);
+        raw = escapeUnescapedString(raw);
       }
-      const raw = this.raw;
       this._body = this.collapsed
         ? raw.substring(0, this._virtualization?.getTruncationLength(null) ?? TRUNCATION_DEFAULT_LENGTH)
         : raw;

--- a/public/app/plugins/panel/logstable/LogDetailsContext.test.tsx
+++ b/public/app/plugins/panel/logstable/LogDetailsContext.test.tsx
@@ -1,6 +1,7 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { type ReactNode } from 'react';
 
+import { store } from '@grafana/data';
 import { createLogLine } from 'app/features/logs/components/mocks/logRow';
 import { type LogListModel } from 'app/features/logs/components/panel/processing';
 
@@ -234,5 +235,44 @@ describe('LogDetailsContextProvider', () => {
       expect(result.current.showDetails.map((l) => l.uid)).toEqual([log1.uid, log2.uid]);
       expect(result.current.currentLog?.uid).toBe(log1.uid);
     });
+  });
+});
+
+describe('prettifyDetailsJSON', () => {
+  const storageKey = 'grafana.logstable.test.prettifyDetailsJSON';
+
+  afterEach(() => {
+    store.delete(`${storageKey}.prettifyDetailsJSON`);
+  });
+
+  function prettifyWrapper() {
+    return function Wrapper({ children }: { children: ReactNode }) {
+      return (
+        <LogDetailsContextProvider enableLogDetails logOptionsStorageKey={storageKey} logs={[log1, log2]}>
+          {children}
+        </LogDetailsContextProvider>
+      );
+    };
+  }
+
+  test('defaults to true', () => {
+    const { result } = renderHook(() => useLogDetailsContext(), {
+      wrapper: prettifyWrapper(),
+    });
+
+    expect(result.current.prettifyDetailsJSON).toBe(true);
+  });
+
+  test('setPrettifyDetailsJSON updates state and local storage', () => {
+    const { result } = renderHook(() => useLogDetailsContext(), {
+      wrapper: prettifyWrapper(),
+    });
+
+    act(() => {
+      result.current.setPrettifyDetailsJSON(false);
+    });
+
+    expect(result.current.prettifyDetailsJSON).toBe(false);
+    expect(store.getBool(`${storageKey}.prettifyDetailsJSON`, true)).toBe(false);
   });
 });

--- a/public/app/plugins/panel/logstable/LogDetailsContext.tsx
+++ b/public/app/plugins/panel/logstable/LogDetailsContext.tsx
@@ -67,9 +67,9 @@ export const LogDetailsContextProvider = ({
   useEffect(() => {
     if (currentLog) {
       // Call the body getter to trigger its logic.
-      void currentLog?.body;
+      void currentLog.body;
     }
-  }, [currentLog])
+  }, [currentLog]);
 
   // Sync prettifyDetailsJSON
   useEffect(() => {

--- a/public/app/plugins/panel/logstable/LogDetailsContext.tsx
+++ b/public/app/plugins/panel/logstable/LogDetailsContext.tsx
@@ -1,5 +1,7 @@
 import { createContext, type ReactNode, useCallback, useContext, useEffect, useState } from 'react';
 
+import { store } from '@grafana/data';
+
 import { type LogListModel } from 'app/features/logs/components/panel/processing';
 
 export interface LogDetailsContextData {
@@ -8,8 +10,10 @@ export interface LogDetailsContextData {
   detailsDisplayed: (rowIndex: number) => boolean;
   enableLogDetails: boolean;
   logs: LogListModel[];
+  prettifyDetailsJSON: boolean;
   replaceDetails: (log: LogListModel) => void;
   setCurrentLog: (log: LogListModel) => void;
+  setPrettifyDetailsJSON: (prettifyDetailsJSON: boolean) => void;
   showDetails: LogListModel[];
   toggleDetails: (log: number | LogListModel) => void;
 }
@@ -20,8 +24,10 @@ export const emptyContextData: LogDetailsContextData = {
   detailsDisplayed: () => false,
   enableLogDetails: false,
   logs: [],
+  prettifyDetailsJSON: true,
   replaceDetails: () => {},
   setCurrentLog: () => {},
+  setPrettifyDetailsJSON: () => {},
   showDetails: [],
   toggleDetails: () => {},
 };
@@ -40,11 +46,37 @@ export interface Props {
   children?: ReactNode;
   enableLogDetails: boolean;
   logs: LogListModel[];
+  logOptionsStorageKey?: string;
+  prettifyDetailsJSON?: boolean;
 }
 
-export const LogDetailsContextProvider = ({ children, enableLogDetails, logs }: Props) => {
+export const LogDetailsContextProvider = ({
+  children,
+  enableLogDetails,
+  logs,
+  logOptionsStorageKey,
+  prettifyDetailsJSON: prettifyDetailsJSONProp,
+}: Props) => {
   const [showDetails, setShowDetails] = useState<LogListModel[]>([]);
   const [currentLog, setCurrentLog] = useState<LogListModel | undefined>(undefined);
+  const [prettifyDetailsJSON, setPrettifyDetailsJSONState] = useState(
+    prettifyDetailsJSONProp ??
+      (logOptionsStorageKey ? store.getBool(`${logOptionsStorageKey}.prettifyDetailsJSON`, true) : true)
+  );
+
+  useEffect(() => {
+    if (currentLog) {
+      // Call the body getter to trigger its logic.
+      void currentLog?.body;
+    }
+  }, [currentLog])
+
+  // Sync prettifyDetailsJSON
+  useEffect(() => {
+    if (prettifyDetailsJSONProp !== undefined) {
+      setPrettifyDetailsJSONState(prettifyDetailsJSONProp);
+    }
+  }, [prettifyDetailsJSONProp]);
 
   // Sync show details
   useEffect(() => {
@@ -116,6 +148,16 @@ export const LogDetailsContextProvider = ({ children, enableLogDetails, logs }: 
     [currentLog, enableLogDetails, showDetails]
   );
 
+  const setPrettifyDetailsJSON = useCallback(
+    (prettifyDetailsJSON: boolean) => {
+      setPrettifyDetailsJSONState(prettifyDetailsJSON);
+      if (logOptionsStorageKey) {
+        store.set(`${logOptionsStorageKey}.prettifyDetailsJSON`, prettifyDetailsJSON);
+      }
+    },
+    [logOptionsStorageKey]
+  );
+
   return (
     <LogDetailsContext.Provider
       value={{
@@ -124,8 +166,10 @@ export const LogDetailsContextProvider = ({ children, enableLogDetails, logs }: 
         detailsDisplayed,
         enableLogDetails,
         logs,
+        prettifyDetailsJSON,
         replaceDetails,
         setCurrentLog,
+        setPrettifyDetailsJSON,
         showDetails,
         toggleDetails,
       }}

--- a/public/app/plugins/panel/logstable/LogDetailsContext.tsx
+++ b/public/app/plugins/panel/logstable/LogDetailsContext.tsx
@@ -63,13 +63,6 @@ export const LogDetailsContextProvider = ({
       (logOptionsStorageKey ? store.getBool(`${logOptionsStorageKey}.prettifyDetailsJSON`, true) : true)
   );
 
-  useEffect(() => {
-    if (currentLog) {
-      // Call the body getter to trigger its logic.
-      void currentLog.body;
-    }
-  }, [currentLog]);
-
   // Sync prettifyDetailsJSON
   useEffect(() => {
     if (prettifyDetailsJSONProp !== undefined) {

--- a/public/app/plugins/panel/logstable/LogDetailsContext.tsx
+++ b/public/app/plugins/panel/logstable/LogDetailsContext.tsx
@@ -1,7 +1,6 @@
 import { createContext, type ReactNode, useCallback, useContext, useEffect, useState } from 'react';
 
 import { store } from '@grafana/data';
-
 import { type LogListModel } from 'app/features/logs/components/panel/processing';
 
 export interface LogDetailsContextData {

--- a/public/app/plugins/panel/logstable/LogsTable.tsx
+++ b/public/app/plugins/panel/logstable/LogsTable.tsx
@@ -307,7 +307,11 @@ export const LogsTable = ({
   return (
     <div className={styles.wrapper} ref={containerRef}>
       {renderTable && containerElement && (
-        <LogDetailsContextProvider enableLogDetails={options.enableLogDetails ?? true} logs={logRows}>
+        <LogDetailsContextProvider
+          enableLogDetails={options.enableLogDetails ?? true}
+          logs={logRows}
+          logOptionsStorageKey={SETTING_KEY_ROOT}
+        >
           <LogsTableFields
             tableWidth={width}
             fieldSelectorWidth={options.fieldSelectorWidth}

--- a/public/app/plugins/panel/logstable/LogsTableDetails.tsx
+++ b/public/app/plugins/panel/logstable/LogsTableDetails.tsx
@@ -35,8 +35,10 @@ export const LogsTableDetails = ({ containerElement, options, onOptionsChange, t
     closeDetails,
     enableLogDetails,
     logs,
+    prettifyDetailsJSON,
     replaceDetails,
     setCurrentLog,
+    setPrettifyDetailsJSON,
     showDetails,
     toggleDetails,
   } = useLogDetailsContext();
@@ -208,7 +210,9 @@ export const LogsTableDetails = ({ containerElement, options, onOptionsChange, t
               <LogLineDetailsComponent
                 log={currentLog}
                 logs={logs}
+                prettifyDetailsJSON={prettifyDetailsJSON}
                 search={search}
+                setPrettifyDetailsJSON={setPrettifyDetailsJSON}
                 timeRange={timeRange}
                 timeZone={timeZone}
               />

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11734,6 +11734,7 @@
       "no-details": "No fields to display.",
       "open-assistant": "Explain log line in Assistant",
       "pin-line": "Pin log",
+      "prettify": "Prettify",
       "remove-displayed-field": "Remove field",
       "remove-log": "Remove log",
       "scroll-to-logline": "Scroll to log line",


### PR DESCRIPTION
Closes #126735

This PR adds an independent option to conditionally prettify, or not, JSON logs when shown in Logs Detail. The purpose is to dettach this function from the chosen display format in the Logs Panel, and to bring the option of prettifying JSON for Log Details in the Logs Table.

https://github.com/user-attachments/assets/999876c2-4f98-4aa4-8003-52358514103c

### How to test

- With JSON logs, open Log Details in the Logs Panel and Logs Table.
- JSON prettifying should be conditionally applied in Details.
- The option should not be available for non-JSON logs.