### PR TITLE
DeleteActions: Use the same icon and button styles for delete/removal actions

### DIFF
--- a/packages/grafana-o11y-ds-frontend/src/TraceToMetrics/TraceToMetricsSettings.tsx
+++ b/packages/grafana-o11y-ds-frontend/src/TraceToMetrics/TraceToMetricsSettings.tsx
@@ -165,9 +165,9 @@ export function TraceToMetricsSettings({ options, onOptionsChange }: Props) {
           </InlineField>
 
           <Button
-            variant="destructive"
+            variant="secondary"
             aria-label="Remove query"
-            icon="times"
+            icon="trash-alt"
             type="button"
             onClick={() => {
               const newQueries = options.jsonData.tracesToMetrics?.queries.filter((_, index) => index !== i);

--- a/packages/grafana-ui/src/components/Button/Button.mdx
+++ b/packages/grafana-ui/src/components/Button/Button.mdx
@@ -153,7 +153,7 @@ The secondary `Button` is the default button style and can trigger various actio
 ## Destructive
 
 Used for triggering a removing or deleting action. Because of its dominant coloring, it should be used sparingly. If you need multiple Destructive `Button` components in one view, we recommend using a secondary `Button` or Link variant instead and only use the Destructive variant to double confirm.
-If a destructive action has a confirmation step it does not need to be destructive, as long as the confirmation step has a destructive button. In tables containing delete actions we recommond using a secondary variant `Button` with trash-alt icon.
+If a destructive action has a confirmation step it does not need to be destructive, as long as the confirmation step has a destructive button. In tables containing delete actions we recommend using a secondary variant `Button` with trash-alt icon.
 
 <ExampleFrame>
   <Button variant="destructive" size="sm" style={{ margin: '5px' }}>

--- a/packages/grafana-ui/src/components/Button/Button.mdx
+++ b/packages/grafana-ui/src/components/Button/Button.mdx
@@ -153,7 +153,7 @@ The secondary `Button` is the default button style and can trigger various actio
 ## Destructive
 
 Used for triggering a removing or deleting action. Because of its dominant coloring, it should be used sparingly. If you need multiple Destructive `Button` components in one view, we recommend using a secondary `Button` or Link variant instead and only use the Destructive variant to double confirm.
-If a destructive action has a confirmation step it does no need to be destructive, as long as the confirmation step has a destructive button. In tables containing delete actions we recommond using a secondary variant `Button` with trash-alt icon.
+If a destructive action has a confirmation step it does not need to be destructive, as long as the confirmation step has a destructive button. In tables containing delete actions we recommond using a secondary variant `Button` with trash-alt icon.
 
 <ExampleFrame>
   <Button variant="destructive" size="sm" style={{ margin: '5px' }}>

--- a/packages/grafana-ui/src/components/Button/Button.mdx
+++ b/packages/grafana-ui/src/components/Button/Button.mdx
@@ -153,6 +153,7 @@ The secondary `Button` is the default button style and can trigger various actio
 ## Destructive
 
 Used for triggering a removing or deleting action. Because of its dominant coloring, it should be used sparingly. If you need multiple Destructive `Button` components in one view, we recommend using a secondary `Button` or Link variant instead and only use the Destructive variant to double confirm.
+If a destructive action has a confirmation step it does no need to be destructive, as long as the confirmation step has a destructive button. In tables containing delete actions we recommond using a secondary variant `Button` with trash-alt icon.
 
 <ExampleFrame>
   <Button variant="destructive" size="sm" style={{ margin: '5px' }}>

--- a/packages/grafana-ui/src/components/ConfirmButton/DeleteButton.tsx
+++ b/packages/grafana-ui/src/components/ConfirmButton/DeleteButton.tsx
@@ -29,8 +29,8 @@ export const DeleteButton = ({ size, disabled, onConfirm, 'aria-label': ariaLabe
     >
       <Button
         aria-label={ariaLabel ?? t('grafana-ui.confirm-button.aria-label-delete', 'Delete')}
-        variant="destructive"
-        icon="times"
+        variant="secondary"
+        icon="trash-alt"
         size={size || 'sm'}
       />
     </ConfirmButton>

--- a/public/app/core/components/AccessControl/PermissionListItem.tsx
+++ b/public/app/core/components/AccessControl/PermissionListItem.tsx
@@ -58,8 +58,8 @@ export const PermissionListItem = ({ item, permissionLevels, canSet, onRemove, o
         {item.isManaged ? (
           <Button
             size="sm"
-            icon="times"
-            variant="destructive"
+            icon="trash-alt"
+            variant="secondary"
             disabled={!canSet}
             onClick={() => onRemove(item)}
             aria-label={t(

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlags.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlags.tsx
@@ -52,7 +52,7 @@ export const FeatureControlFlags = () => {
                   setIsAccessible(false);
                 }}
                 destructive
-                icon="times"
+                icon="trash-alt"
                 label={t('feature-control.dismiss.label', 'Remove UI and toolbar button')}
                 component={() => (
                   <Text color="secondary" variant="bodySmall" textAlignment="start">

--- a/public/app/features/admin/AdminOrgsTable.tsx
+++ b/public/app/features/admin/AdminOrgsTable.tsx
@@ -49,9 +49,9 @@ function AdminOrgsTableComponent({ orgs, onDelete }: Props) {
             </td>
             <td className="text-right">
               <Button
-                variant="destructive"
+                variant="secondary"
                 size="sm"
-                icon="times"
+                icon="trash-alt"
                 onClick={() => setDeleteOrg(org)}
                 aria-label={t('admin.admin-orgs-table.aria-label-delete-org', 'Delete org')}
                 disabled={!canDeleteOrgs}

--- a/public/app/features/admin/Users/OrgUsersTable.tsx
+++ b/public/app/features/admin/Users/OrgUsersTable.tsx
@@ -240,11 +240,11 @@ export const OrgUsersTable = ({
             contextSrv.hasPermissionInMetadata(AccessControlAction.OrgUsersRemove, original) && (
               <Button
                 size="sm"
-                variant="destructive"
+                variant="secondary"
                 onClick={() => {
                   setUserToRemove(original);
                 }}
-                icon="times"
+                icon="trash-alt"
                 aria-label={t('admin.org-users-table.delete-aria-label', 'Delete user: {{name}}', {
                   name: original.name,
                 })}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/DeleteConfirm.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/DeleteConfirm.tsx
@@ -85,7 +85,7 @@ export function DeleteConfirm({ confirmStyle, description, onConfirm, onCancel }
         size="sm"
         fill="text"
         variant="secondary"
-        icon="trash-alt"
+        icon="times"
         className={confirmStyle === ConfirmationStyle.compact ? styles.iconButton : undefined}
         aria-label={cancelDeleteAria}
         onClick={handleCancelClick}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/DeleteConfirm.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/DeleteConfirm.tsx
@@ -85,7 +85,7 @@ export function DeleteConfirm({ confirmStyle, description, onConfirm, onCancel }
         size="sm"
         fill="text"
         variant="secondary"
-        icon="times"
+        icon="trash-alt"
         className={confirmStyle === ConfirmationStyle.compact ? styles.iconButton : undefined}
         aria-label={cancelDeleteAria}
         onClick={handleCancelClick}

--- a/public/app/features/serviceaccounts/ServiceAccountTable.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountTable.tsx
@@ -212,30 +212,37 @@ const getActionsCell = (
     return !original.isExternal ? (
       <Stack alignItems="center" justifyContent="flex-end">
         {contextSrv.hasPermission(AccessControlAction.ServiceAccountsWrite) && !original.tokens && (
-          <Button onClick={() => onAddTokenClick(original)} disabled={original.isDisabled}>
+          <Button
+            onClick={() => onAddTokenClick(original)}
+            disabled={original.isDisabled}
+            variant="secondary"
+            size="sm"
+            icon="plus"
+          >
             <Trans i18nKey="serviceaccounts.get-actions-cell.add-token">Add token</Trans>
           </Button>
         )}
         {contextSrv.hasPermissionInMetadata(AccessControlAction.ServiceAccountsWrite, original) &&
           (original.isDisabled ? (
-            <Button variant="secondary" size="md" onClick={() => onEnable(original)}>
+            <Button variant="secondary" size="sm" onClick={() => onEnable(original)} icon="ban">
               <Trans i18nKey="serviceaccounts.get-actions-cell.enable">Enable</Trans>
             </Button>
           ) : (
-            <Button variant="secondary" size="md" onClick={() => onDisable(original)}>
+            <Button variant="secondary" size="sm" onClick={() => onDisable(original)} icon="ban">
               <Trans i18nKey="serviceaccounts.get-actions-cell.disable">Disable</Trans>
             </Button>
           ))}
 
         {contextSrv.hasPermissionInMetadata(AccessControlAction.ServiceAccountsDelete, original) && (
-          <IconButton
-            name="trash-alt"
+          <Button
+            variant="secondary"
+            size="sm"
+            icon="trash-alt"
             aria-label={t(
               'serviceaccounts.get-actions-cell.aria-label-delete-button',
               'Delete service account {{serviceAccountName}}',
               { serviceAccountName: original.name }
             )}
-            variant="secondary"
             onClick={() => onRemoveButtonClick(original)}
           />
         )}

--- a/public/app/features/serviceaccounts/ServiceAccountTable.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountTable.tsx
@@ -224,7 +224,7 @@ const getActionsCell = (
         )}
         {contextSrv.hasPermissionInMetadata(AccessControlAction.ServiceAccountsWrite, original) &&
           (original.isDisabled ? (
-            <Button variant="secondary" size="sm" onClick={() => onEnable(original)} icon="ban">
+            <Button variant="secondary" size="sm" onClick={() => onEnable(original)} icon="check">
               <Trans i18nKey="serviceaccounts.get-actions-cell.enable">Enable</Trans>
             </Button>
           ) : (

--- a/public/app/features/teams/TeamList.test.tsx
+++ b/public/app/features/teams/TeamList.test.tsx
@@ -37,7 +37,7 @@ describe('TeamList', () => {
     const mockTeam = MOCK_TEAMS[0];
     jest.spyOn(appEvents, 'publish');
     render(<TeamList />);
-    await userEvent.click(await screen.findByRole('button', { name: `Delete ${mockTeam.spec.title}` }));
+    await userEvent.click(await screen.findByRole('button', { name: `Delete team ${mockTeam.spec.title}` }));
 
     expect(appEvents.publish).toHaveBeenCalledWith(
       new ShowModalReactEvent(
@@ -130,7 +130,7 @@ describe('TeamList', () => {
     );
 
     // Click the delete button to open the modal
-    await userEvent.click(await screen.findByRole('button', { name: `Delete ${mockTeam.spec.title}` }));
+    await userEvent.click(await screen.findByRole('button', { name: `Delete team ${mockTeam.spec.title}` }));
 
     // The modal should be visible with a Delete heading
     const modalTitle = await screen.findByRole('heading', { name: /delete/i });

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -12,7 +12,7 @@ import {
   type Column,
   EmptyState,
   FilterInput,
-  IconButton,
+  Button,
   InlineField,
   InteractiveTable,
   LinkButton,
@@ -267,9 +267,9 @@ const TeamList = () => {
             <Stack direction="row" justifyContent="flex-end" gap={2}>
               {canReadTeam && (
                 <a href={`org/teams/edit/${original.uid}`} style={{ display: 'inline-flex' }}>
-                  <IconButton
-                    name="pen"
-                    size="md"
+                  <Button
+                    icon="pen"
+                    size="sm"
                     variant="secondary"
                     aria-label={t('teams.team-list.columns.aria-label-edit-team', 'Edit team {{teamName}}', {
                       teamName: original.name,
@@ -278,12 +278,12 @@ const TeamList = () => {
                   />
                 </a>
               )}
-              <IconButton
+              <Button
                 onClick={showDeleteModal}
-                variant="destructive"
+                variant="secondary"
                 disabled={!canDelete}
-                name="times"
-                size="md"
+                icon="trash-alt"
+                size="sm"
                 tooltip={t('teams.team-list.columns.tooltip-delete-button', 'Delete {{teamName}}', {
                   teamName: original.name,
                 })}


### PR DESCRIPTION
This updates a number of table views to use a the same icon (trash-alt) and button style for the delete action. 

Before 
<img width="1915" height="624" alt="Screenshot 2026-08-13 at 14 15 05" src="https://github.com/user-attachments/assets/b4c6abc6-a355-4704-b37a-de2b0f6e4b97" />

After:
<img width="1782" height="780" alt="Screenshot 2026-08-13 at 16 00 25" src="https://github.com/user-attachments/assets/07d69621-d2ef-439d-add6-8d9336b324e2" />

Before:
<img width="1782" height="780" alt="Screenshot 2026-08-13 at 16 01 30" src="https://github.com/user-attachments/assets/c2c47fbe-531c-4d75-a3e4-8df53e55b2c0" />

After: 
<img width="1914" height="878" alt="Screenshot 2026-08-13 at 15 26 09" src="https://github.com/user-attachments/assets/4e47ecfd-aa78-4fbc-bee1-eacc4dcecef8" />

