### PR TITLE
fix(MultiCombobox): let checkbox click propagate to keep menu open

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/ComboboxList.tsx
+++ b/packages/grafana-ui/src/components/Combobox/ComboboxList.tsx
@@ -146,7 +146,8 @@ export const ComboboxList = <T extends string | number>({
                         indeterminate={item.value === ALL_OPTION_VALUE && selectedItems.length > 0 && !allItemsSelected}
                         aria-labelledby={itemId}
                         onClick={(e) => {
-                          e.stopPropagation();
+                          // Let event propagate to parent option row
+                          // so Downshift handles selection and keeps menu open
                         }}
                         data-testid={`${itemId}-checkbox`}
                       />


### PR DESCRIPTION
Fixes #130688

Clicking the checkbox inside a MultiCombobox option closed the menu
instead of keeping it open for multi-select. The root cause was
e.stopPropagation() on the checkbox preventing Downshift's handler
from toggling the selection and persisting the menu.

**Fix:** Remove the stopPropagation call so the click event propagates
to the parent option row where Downshift's getItemProps handles it.