### PR TITLE
Search: fix the Build call left behind by two merges

### DIFF
--- a/pkg/services/apiserver/searchroutes/searchroutes_test.go
+++ b/pkg/services/apiserver/searchroutes/searchroutes_test.go
@@ -164,7 +164,7 @@ func TestBuild_MountsNotebooksOnDeclaringVersionOnly(t *testing.T) {
 	}
 	require.NotEmpty(t, dashboardGVs)
 
-	got := paths(Build(true, nil, fakeClient{},
+	got := paths(Build(true, false, nil, fakeClient{},
 		[]builder.APIGroupBuilder{&fakeBuilder{gvs: dashboardGVs}}, nil))
 
 	for _, gv := range dashboardGVs {


### PR DESCRIPTION
The notebooks test was written against `Build`'s old single-switch signature, and the trash endpoint gave it a second one. Both merged without seeing each other, so `pkg/services/apiserver/searchroutes` does not compile and `lint-go` fails on main for every PR.

One argument.

- grafana/grafana#130486 added the second switch (`41075c37e61`)
- grafana/grafana#130573 added the call (`2d545184948`), written before that landed