### PR TITLE
fix: reject password change when new password equals current password

### DIFF
--- a/pkg/services/user/error.go
+++ b/pkg/services/user/error.go
@@ -22,5 +22,6 @@ var (
 	ErrEmptyUsernameAndEmail = errutil.BadRequest(
 		"user.empty-username-and-email", errutil.WithPublicMessage("Need to specify either username or email"),
 	)
-	ErrPasswordMissmatch = errutil.BadRequest("user.password-missmatch", errutil.WithPublicMessage("Invalid old password"))
+	ErrPasswordMissmatch     = errutil.BadRequest("user.password-missmatch", errutil.WithPublicMessage("Invalid old password"))
+	ErrNewPasswordSameAsOld  = errutil.BadRequest("user.new-password-same-as-old", errutil.WithPublicMessage("New password must be different from the current password"))
 )

--- a/pkg/services/user/userimpl/legacy_user.go
+++ b/pkg/services/user/userimpl/legacy_user.go
@@ -290,6 +290,12 @@ func (s *LegacyService) Update(ctx context.Context, cmd *user.UpdateUserCommand)
 		}
 	}
 
+	if cmd.OldPassword != nil && cmd.Password != nil {
+		if *cmd.OldPassword == *cmd.Password {
+			return user.ErrNewPasswordSameAsOld.Errorf("new password must be different from the current password")
+		}
+	}
+
 	if cmd.Password != nil {
 		if err := cmd.Password.Validate(s.cfg); err != nil {
 			return err


### PR DESCRIPTION
### Problem

Password reset behavior is inconsistent between the UI and API/CLI when reusing the current password:

- **UI**: rejects the password update when the new password matches the current password
- **API/CLI** (`PUT /api/user/password`, `ChangeUserPassword`): returns 200 OK and reports "User password changed" even when the new password is the same as the current one

### Fix

Added a check in `LegacyService.Update()` that compares the old and new passwords. If they are the same, the operation is rejected with a clear error message, making the behavior consistent with the UI.

### Changes

1. **pkg/services/user/userimpl/legacy_user.go**: Added `ErrNewPasswordSameAsOld` check — if both `OldPassword` and `Password` are provided and they match, return an error
2. **pkg/services/user/error.go**: Added `ErrNewPasswordSameAsOld` error constant

Closes #130559