### PR TITLE
SQLite: Revert the journal mode when wal is disabled

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -475,6 +475,8 @@ Defaults to `private`.
 
 For "sqlite3" only. Setting to enable/disable [Write-Ahead Logging](https://sqlite.org/wal.html). The default value is `false` (disabled).
 
+SQLite stores the journal mode in the database file, so a database that was opened with WAL keeps using it. Setting `wal` back to `false` puts the database into `DELETE` journal mode again on the next start.
+
 #### `query_retries`
 
 This setting applies to `sqlite` only and controls the number of times the system retries a query when the database is locked. The default value is `0` (disabled).

--- a/pkg/services/sqlstore/database_config.go
+++ b/pkg/services/sqlstore/database_config.go
@@ -202,8 +202,12 @@ func (dbCfg *DatabaseConfig) buildConnectionString(cfg *setting.Cfg, features fe
 
 		cnnstr = fmt.Sprintf("file:%s?cache=%s&mode=rwc", dbCfg.Path, dbCfg.CacheMode)
 
+		// SQLite keeps the journal mode in the database file, so a database that was once
+		// opened with WAL stays in WAL until we ask for something else.
 		if dbCfg.WALEnabled {
 			cnnstr += "&_journal_mode=WAL"
+		} else {
+			cnnstr += "&_journal_mode=DELETE"
 		}
 
 		cnnstr += buildExtraConnectionString('&', dbCfg.UrlQueryParams)

--- a/pkg/services/sqlstore/wal_test.go
+++ b/pkg/services/sqlstore/wal_test.go
@@ -1,0 +1,79 @@
+package sqlstore
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func TestSQLiteJournalMode(t *testing.T) {
+	t.Run("wal enabled asks for WAL", func(t *testing.T) {
+		dbCfg := sqliteConfig(t, true)
+		require.NoError(t, dbCfg.buildConnectionString(&setting.Cfg{}, nil))
+		assert.Contains(t, dbCfg.ConnectionString, "_journal_mode=WAL")
+	})
+
+	t.Run("wal disabled asks for DELETE", func(t *testing.T) {
+		dbCfg := sqliteConfig(t, false)
+		require.NoError(t, dbCfg.buildConnectionString(&setting.Cfg{}, nil))
+		assert.Contains(t, dbCfg.ConnectionString, "_journal_mode=DELETE")
+	})
+}
+
+// A database converted to WAL keeps that mode in its file, so disabling the setting
+// has to put it back, otherwise there is no way to undo the conversion.
+func TestWALDatabaseIsRevertedWhenWALIsDisabled(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "grafana.db")
+
+	walCfg := sqliteConfig(t, true)
+	walCfg.Path = path
+	require.NoError(t, walCfg.buildConnectionString(&setting.Cfg{}, nil))
+
+	walDB, err := sql.Open("sqlite3", walCfg.ConnectionString)
+	require.NoError(t, err)
+	_, err = walDB.Exec("CREATE TABLE t (a int)")
+	require.NoError(t, err)
+	_, err = walDB.Exec("INSERT INTO t VALUES (42)")
+	require.NoError(t, err)
+	require.Equal(t, "wal", journalMode(t, walDB))
+	require.NoError(t, walDB.Close())
+
+	offCfg := sqliteConfig(t, false)
+	offCfg.Path = path
+	require.NoError(t, offCfg.buildConnectionString(&setting.Cfg{}, nil))
+
+	offDB, err := sql.Open("sqlite3", offCfg.ConnectionString)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, offDB.Close()) }()
+
+	assert.Equal(t, "delete", journalMode(t, offDB))
+
+	var value int
+	require.NoError(t, offDB.QueryRow("SELECT a FROM t").Scan(&value))
+	assert.Equal(t, 42, value, "reverting the journal mode keeps the data")
+}
+
+func sqliteConfig(t *testing.T, walEnabled bool) *DatabaseConfig {
+	t.Helper()
+
+	return &DatabaseConfig{
+		Type:       migrator.SQLite,
+		Path:       filepath.Join(t.TempDir(), "grafana.db"),
+		CacheMode:  "private",
+		WALEnabled: walEnabled,
+	}
+}
+
+func journalMode(t *testing.T, db *sql.DB) string {
+	t.Helper()
+
+	var mode string
+	require.NoError(t, db.QueryRow("PRAGMA journal_mode").Scan(&mode))
+	return mode
+}


### PR DESCRIPTION
SQLite stores the journal mode in the database file, so a database opened once with `wal = true` keeps using WAL. Grafana only set the pragma when WAL was enabled, so switching `wal` back to `false` had no effect and the conversion couldn't be undone. That is the cause of the "I reverted the setting and it still crashed" reports on #65115.

Grafana now asks for `DELETE` journal mode when `wal` is disabled, so the setting works in both directions. The default is unchanged.

One consequence worth knowing: converting out of WAL needs exclusive access, so if another process holds the database in WAL, the pragma fails with `SQLITE_BUSY`. Two processes on one SQLite file is unsupported anyway, and failing loudly beats starting in the wrong mode.

Ref #65115
