### PR TITLE
fix: SMD managedFields conversion for dashboard v2 schemas

### DIFF
--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"maps"
 	"strconv"
+	"strings"
 	"sync"
+	"unicode"
 
 	"github.com/prometheus/client_golang/prometheus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -1344,29 +1346,113 @@ func (b *DashboardsAPIBuilder) GetOpenAPIDefinitions() common.GetOpenAPIDefiniti
 			}
 		}
 
-		// Fix legacyOptions schema for v2alpha1, v2beta1, and v2 to allow any value type
-		// The generated schema incorrectly restricts values to objects, but map[string]interface{} can hold any type
-		// This fix must be applied here so structured-merge-diff uses the correct schema
-		// For some reason this issue occurs with both the kubernetes-generated openAPI sourced from go, _and_ the OpenAPI from the AppManifest
-		// TODO: @IfSentient this should really be addressed in the app-sdk's generation, or work out what about this particular CUE value is broken
-		for _, defKey := range []string{
-			"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1.DashboardAnnotationQuerySpec",
-			"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2beta1.DashboardAnnotationQuerySpec",
-			"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2.DashboardAnnotationQuerySpec",
-		} {
-			if def, ok := defs[defKey]; ok {
-				if legacyOptions, ok := def.Schema.Properties["legacyOptions"]; ok {
-					// Fix: Use additionalProperties: true to allow any value type (string, number, boolean, array, object, etc.)
-					// instead of restricting to objects only. This must match map[string]interface{} semantics.
-					legacyOptions.AdditionalProperties = &spec.SchemaOrBool{Allows: true}
-					def.Schema.Properties["legacyOptions"] = legacyOptions
-					defs[defKey] = def
-				}
-			}
-		}
+		// Relax the v2* dashboard schemas that structured-merge-diff cannot type-convert.
+		// Without this, managedFields updates fail (logged as "[SHOULD NOT HAPPEN] failed
+		// to update managedFields") and the apiserver strips Server-Side-Apply field
+		// ownership from the stored object.
+		relaxDashboardSchemasForSMD(defs)
 
 		return defs
 	}
+}
+
+// relaxDashboardSchemasForSMD works around app-sdk OpenAPI generation that
+// structured-merge-diff (SMD) cannot convert against the object's on-the-wire
+// shape. When ObjectToTyped fails, the field manager can't build managedFields,
+// so it logs "[SHOULD NOT HAPPEN] failed to update managedFields" and drops SSA
+// field ownership for the object.
+//
+// Two generated shapes are relaxed on the dashboard v2, v2alpha1 and v2beta1
+// schemas (v0/v1 use an untyped spec and are unaffected):
+//
+//  1. Discriminated-union wrappers ("…KindOr…Kind" — elements, layout, variables,
+//     preferences.layout, …). The app-sdk models these as objects with one property
+//     per Go variant field (PanelKind, LibraryPanelKind, GridLayoutKind, …), but the
+//     types marshal to the flattened {kind, spec} shape on the wire, so SMD rejects
+//     the real kind/spec fields as "field not declared in schema". These are detected
+//     structurally: a generated wrapper's property names are all PascalCase Go type
+//     names, whereas real kinds use camelCase JSON fields. Marked preserve-unknown so
+//     SMD treats the value as free-form.
+//
+//  2. Opaque object maps (DataQueryKind.spec, AnnotationQuerySpec.legacyOptions, …)
+//     modeled as additionalProperties:{type:object}, which forces every value to be a
+//     map — but query params are scalars, so SMD fails with "expected map, got …".
+//     Relaxed to additionalProperties:true so SMD deduces each value's type.
+//
+// TODO: this should be fixed in the app-sdk's OpenAPI generation.
+func relaxDashboardSchemasForSMD(defs map[string]common.OpenAPIDefinition) {
+	for key, def := range defs {
+		// Match both the Go-generated model names ("…apis.dashboard.v2.Dashboard…")
+		// and the app-sdk manifest names ("…apis/dashboard/v2.Dashboard…"). The
+		// substring also covers v2alpha1/v2beta1 while excluding v0/v1.
+		if !strings.Contains(key, "apis/dashboard/v2") && !strings.Contains(key, "apis.dashboard.v2") {
+			continue
+		}
+		def.Schema = relaxSchemaForSMD(def.Schema)
+		defs[key] = def
+	}
+}
+
+func relaxSchemaForSMD(s spec.Schema) spec.Schema {
+	// Rule 1: a generated discriminated-union wrapper becomes a preserve-unknown
+	// free-form object so SMD accepts the flattened {kind, spec} wire form.
+	if isGeneratedUnionSchema(s) {
+		s.Properties = nil
+		s.AdditionalProperties = nil
+		s.Type = spec.StringOrArray{"object"}
+		s.AddExtension("x-kubernetes-preserve-unknown-fields", true)
+		return s
+	}
+
+	// Rule 2: an opaque object map is relaxed to allow any value type.
+	if ap := s.AdditionalProperties; ap != nil && isBareObjectSchema(ap.Schema) {
+		s.AdditionalProperties = &spec.SchemaOrBool{Allows: true}
+	}
+
+	for name, prop := range s.Properties {
+		s.Properties[name] = relaxSchemaForSMD(prop)
+	}
+	if s.AdditionalProperties != nil && s.AdditionalProperties.Schema != nil {
+		relaxed := relaxSchemaForSMD(*s.AdditionalProperties.Schema)
+		s.AdditionalProperties.Schema = &relaxed
+	}
+	if s.Items != nil {
+		if s.Items.Schema != nil {
+			relaxed := relaxSchemaForSMD(*s.Items.Schema)
+			s.Items.Schema = &relaxed
+		}
+		for i := range s.Items.Schemas {
+			s.Items.Schemas[i] = relaxSchemaForSMD(s.Items.Schemas[i])
+		}
+	}
+	return s
+}
+
+// isGeneratedUnionSchema reports whether s is an app-sdk union wrapper, identified
+// by every property being a PascalCase Go variant name rather than a camelCase JSON
+// field. Real kinds always expose at least one camelCase field (kind, spec, …).
+func isGeneratedUnionSchema(s spec.Schema) bool {
+	if len(s.Properties) == 0 {
+		return false
+	}
+	for name := range s.Properties {
+		if name == "" || !unicode.IsUpper([]rune(name)[0]) {
+			return false
+		}
+	}
+	return true
+}
+
+// isBareObjectSchema reports whether s is an untyped free-form object
+// (additionalProperties:{type:object}) — a map that must accept any value type.
+func isBareObjectSchema(s *spec.Schema) bool {
+	if s == nil {
+		return false
+	}
+	return len(s.Type) == 1 && s.Type[0] == "object" &&
+		len(s.Properties) == 0 &&
+		s.Ref.String() == "" &&
+		s.AdditionalProperties == nil
 }
 
 func (b *DashboardsAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.OpenAPI, error) {

--- a/pkg/registry/apis/dashboard/register_smd_test.go
+++ b/pkg/registry/apis/dashboard/register_smd_test.go
@@ -1,0 +1,113 @@
+package dashboard
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/kube-openapi/pkg/common"
+	"k8s.io/kube-openapi/pkg/schemaconv"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+	smdschema "sigs.k8s.io/structured-merge-diff/v6/schema"
+	"sigs.k8s.io/structured-merge-diff/v6/typed"
+
+	dashv2 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2"
+)
+
+// TestRelaxDashboardSchemasForSMD reproduces the "[SHOULD NOT HAPPEN] failed to
+// update managedFields ... to smd typed" failure and verifies the schema
+// relaxation fixes it. The apiserver field manager converts the object to a
+// structured-merge-diff typed value via schemaconv.ToSchemaFromOpenAPI +
+// typed.Parser (exactly what is exercised here); if that conversion fails,
+// managedFields (Server-Side-Apply ownership) is silently dropped.
+func TestRelaxDashboardSchemasForSMD(t *testing.T) {
+	// A minimal but realistic v2 dashboard spec covering every field flavour that
+	// tripped the converter: kind/spec discriminated unions (elements, layout,
+	// variables, preferences.layout) and the opaque, scalar-valued query spec.
+	specValue := map[string]interface{}{
+		"annotations": []interface{}{
+			map[string]interface{}{
+				"kind": "AnnotationQuery",
+				"spec": map[string]interface{}{
+					"query": map[string]interface{}{
+						"kind":    "DataQuery",
+						"group":   "grafana",
+						"version": "v0",
+						"spec": map[string]interface{}{
+							"limit":    int64(3),
+							"matchAny": true,
+							"tags":     []interface{}{"a", "b"},
+							"type":     "dashboard",
+						},
+					},
+				},
+			},
+		},
+		"elements": map[string]interface{}{
+			"panel-1": map[string]interface{}{
+				"kind": "Panel",
+				"spec": map[string]interface{}{"id": int64(1)},
+			},
+		},
+		"layout": map[string]interface{}{
+			"kind": "GridLayout",
+			"spec": map[string]interface{}{},
+		},
+		"variables": []interface{}{
+			map[string]interface{}{
+				"kind": "QueryVariable",
+				"spec": map[string]interface{}{},
+			},
+		},
+		"preferences": map[string]interface{}{
+			"layout": map[string]interface{}{
+				"kind": "AutoGridLayout",
+				"spec": map[string]interface{}{},
+			},
+		},
+	}
+
+	specModel := dashv2.DashboardSpec{}.OpenAPIModelName()
+
+	// Baseline: the unmodified generated schema cannot type-convert the object.
+	baseline := parserFromDefs(t, dashboardV2Defs())
+	_, err := baseline.Type(specModel).FromUnstructured(specValue)
+	require.Error(t, err, "expected the unmodified v2 schema to fail SMD conversion")
+
+	// After relaxation the same object converts cleanly.
+	fixed := dashboardV2Defs()
+	relaxDashboardSchemasForSMD(fixed)
+	_, err = parserFromDefs(t, fixed).Type(specModel).FromUnstructured(specValue)
+	require.NoError(t, err, "relaxed v2 schema should type-convert the dashboard spec")
+}
+
+func TestIsGeneratedUnionSchema(t *testing.T) {
+	defs := dashboardV2Defs()
+
+	// A generated union wrapper: all properties are PascalCase Go variant names.
+	union := defs[dashv2.DashboardPanelKindOrLibraryPanelKind{}.OpenAPIModelName()]
+	require.True(t, isGeneratedUnionSchema(union.Schema))
+
+	// A real kind exposes camelCase JSON fields and must not be treated as a union.
+	real := defs[dashv2.DashboardPanelKind{}.OpenAPIModelName()]
+	require.NotEmpty(t, real.Schema.Properties)
+	require.False(t, isGeneratedUnionSchema(real.Schema))
+}
+
+// dashboardV2Defs returns a fresh copy of the generated v2 OpenAPI definitions
+// with refs pointing at their model-name keys, so schemaconv can resolve them.
+func dashboardV2Defs() map[string]common.OpenAPIDefinition {
+	ref := func(path string) spec.Ref { return spec.MustCreateRef("#/definitions/" + path) }
+	return dashv2.GetOpenAPIDefinitions(ref)
+}
+
+func parserFromDefs(t *testing.T, defs map[string]common.OpenAPIDefinition) *typed.Parser {
+	t.Helper()
+	models := make(map[string]*spec.Schema, len(defs))
+	for name, def := range defs {
+		s := def.Schema
+		models[name] = &s
+	}
+	typeSchema, err := schemaconv.ToSchemaFromOpenAPI(models, false)
+	require.NoError(t, err)
+	return &typed.Parser{Schema: smdschema.Schema{Types: typeSchema.Types}}
+}


### PR DESCRIPTION
## What

Fixes the recurring apiserver error on dashboard v2 objects:

```
[SHOULD NOT HAPPEN] failed to update managedFields ... to smd typed: errors:
  .spec.annotations[0].spec.query.spec.limit: expected map, got &{... 3}
  .spec.layout.kind: field not declared in schema
  .spec.preferences.layout.kind: field not declared in schema
  .spec.elements.panel-3.kind: field not declared in schema
  ... (etc)
```

After this change the dashboard v2/v2alpha1/v2beta1 OpenAPI schemas convert cleanly to a structured-merge-diff typed value, so `managedFields` (Server-Side-Apply field ownership) is preserved on writes instead of being silently stripped.

## Why

The dashboard v2 OpenAPI (generated by the app-sdk from the manifest CUE and used to build the apiserver field manager's type converter) does **not** match the objects' on-the-wire shape. When `ObjectToTyped` fails, `managedfields.UpdateNoErrors` logs `[SHOULD NOT HAPPEN] failed to update managedFields` (throttled ~1/sec) and **removes `managedFields` from the object**. The write still succeeds, but the stored object loses SSA field-ownership metadata — so apply-based writers (GitOps/provisioning, `kubectl apply`) no longer get conflict detection and can silently clobber each other's fields.

Two generated shapes trip the converter:

- **Discriminated-union wrappers** (`…KindOr…Kind`: `elements`, `layout`, `variables`, `preferences.layout`, …). The app-sdk models these as objects with one property per Go variant field (`PanelKind`, `LibraryPanelKind`, `GridLayoutKind`, …), but the types marshal to the flattened `{kind, spec}` form on the wire. SMD then rejects the real `kind`/`spec` fields as `field not declared in schema`.
- **Opaque object maps** (`DataQueryKind.spec`, `AnnotationQuerySpec.legacyOptions`, …) modeled as `additionalProperties:{type:object}`, which forces every value to be a map — but query params are scalars, so SMD fails with `expected map, got …`.

This has been latent since the v2 schema was first generated via the app-sdk. An earlier fix in this file already worked around it for the single `legacyOptions` field; this PR generalizes that so the union and query-spec fields in the error above are covered too.

## How

Generalizes the previous `legacyOptions`-only hand-patch into `relaxDashboardSchemasForSMD(defs)` — a recursive pass over the v2* dashboard OpenAPI defs that:

1. Marks generated union wrappers `x-kubernetes-preserve-unknown-fields: true` (detected structurally: a wrapper's property names are all PascalCase Go type names, whereas real kinds expose camelCase JSON fields — verified zero false positives across all v2 property keys).
2. Relaxes opaque `additionalProperties:{type:object}` maps to `additionalProperties: true` so SMD deduces each value's type.

Key-matching covers both the Go-generated model names (`…apis.dashboard.v2…`) and the app-sdk manifest names (`…apis/dashboard/v2…`), and matches v2/v2alpha1/v2beta1 while excluding v0/v1 (which use an untyped spec).

Semantically these subtrees become SSA-atomic (deduced) rather than field-granular — strictly better than today's *no* managedFields at all. The proper long-term fix belongs in the app-sdk's OpenAPI generation; a `TODO` marks this.

## Testing

- `go test ./pkg/registry/apis/dashboard/` — passes.
- New `register_smd_test.go` drives the exact field-manager path (`schemaconv.ToSchemaFromOpenAPI` + `typed.Parser`). The unmodified schema reproduces the exact production errors (`.layout.kind` / `.preferences.layout.kind: field not declared`, `.query.spec.limit: expected map, got`); after relaxation the same object converts with no error. A second test locks in the union-detection heuristic.
- `go vet` and `gofmt` clean.

## Checklist
- [x] Tests added/updated
- [x] No breaking changes
- [ ] Backport labels (if this needs to reach released versions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)