### PR TITLE
Dashboards: Fix stale panel context app after returning to a cached dashboard

### DIFF
--- a/public/app/features/dashboard-scene/scene/setDashboardPanelContext.test.ts
+++ b/public/app/features/dashboard-scene/scene/setDashboardPanelContext.test.ts
@@ -1,5 +1,6 @@
 import {
   type AdHocVariableModel,
+  CoreApp,
   EventBusSrv,
   type GroupByVariableModel,
   type Scope,
@@ -11,6 +12,7 @@ import { GroupByVariable, sceneGraph, SceneQueryRunner } from '@grafana/scenes';
 import { type AdHocFilterItem, type PanelContext } from '@grafana/ui';
 
 import { isAnnotationApiAvailable } from '../../annotations/isAnnotationApiAvailable';
+import { buildPanelEditScene } from '../panel-edit/PanelEditor';
 import { transformSaveModelToScene } from '../serialization/transformSaveModelToScene';
 import { findVizPanelByKey, getQueryRunnerFor } from '../utils/utils';
 
@@ -61,6 +63,38 @@ beforeEach(() => {
 });
 
 describe('setDashboardPanelContext', () => {
+  describe('app', () => {
+    it('Is PanelEditor while the panel edit pane is open', () => {
+      const { scene, vizPanel, context } = buildTestScene({});
+
+      expect(context.app).toBe(CoreApp.Dashboard);
+
+      scene.onEnterEditMode();
+      scene.setState({ editPanel: buildPanelEditScene(vizPanel) });
+
+      expect(context.app).toBe(CoreApp.PanelEditor);
+    });
+
+    it('Still tracks the panel edit pane after the scene is deactivated and reactivated', async () => {
+      // Activating the scene resolves the panel datasource, which this suite does not register.
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const { scene, vizPanel, context } = buildTestScene({});
+
+      // Navigating away leaves the scene in the page cache, so the same context object is reused.
+      scene.activate()();
+      const deactivate = scene.activate();
+
+      scene.onEnterEditMode();
+      scene.setState({ editPanel: buildPanelEditScene(vizPanel) });
+
+      expect(context.app).toBe(CoreApp.PanelEditor);
+
+      deactivate();
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      warnSpy.mockRestore();
+    });
+  });
+
   describe('canAddAnnotations', () => {
     it('Can add when builtIn is enabled and permissions allow', () => {
       const { context } = buildTestScene({ builtInAnnotationsEnabled: true, dashboardCanEdit: true, canAdd: true });

--- a/public/app/features/dashboard-scene/scene/setDashboardPanelContext.ts
+++ b/public/app/features/dashboard-scene/scene/setDashboardPanelContext.ts
@@ -21,14 +21,13 @@ import { type DashboardScene } from './DashboardScene';
 
 export function setDashboardPanelContext(vizPanel: VizPanel, context: PanelContext) {
   const dashboard = getDashboardSceneFor(vizPanel);
-  context.app = dashboard.state.editPanel ? CoreApp.PanelEditor : CoreApp.Dashboard;
 
-  dashboard.subscribeToState((state) => {
-    if (state.editPanel) {
-      context.app = CoreApp.PanelEditor;
-    } else {
-      context.app = CoreApp.Dashboard;
-    }
+  // Read on access. The panel context is built once and cached on the VizPanel, but deactivating the
+  // dashboard clears its event bus, so a subscription here would be dropped and never re-established.
+  Object.defineProperty(context, 'app', {
+    enumerable: true,
+    configurable: true,
+    get: () => (dashboard.state.editPanel ? CoreApp.PanelEditor : CoreApp.Dashboard),
   });
 
   context.canAddAnnotations = () => {


### PR DESCRIPTION
#### What is this fixing?

`PanelContext.app` could get stuck on `dashboard` and never flip to `panel-editor`. `setDashboardPanelContext` kept `app` up to date with a `dashboard.subscribeToState` subscription, but `_panelContext` is built once and cached on the `VizPanel`, while `SceneObjectBase._internalDeactivate` calls `_events.removeAllListeners()`. Navigate away from a dashboard and back — the scene comes from the page cache with the same panels, and the subscription is gone for good.

Replaced with a getter that resolves `dashboard.state.editPanel` on access, matching how the rest of the file already re-resolves the dashboard lazily. Also drops a subscription that was never unsubscribed.

#### Why it showed up now

The `Text v2` panel is the first consumer where `app === PanelEditor` swaps in a different UI (the inline editor), so a stale value looks like the editor toolbar is missing. Other consumers either treat `Dashboard` and `PanelEditor` as the same branch, or degrade cosmetically.

Before

https://github.com/user-attachments/assets/a1451c21-d89d-4b0d-b5f0-51baee056a85



After

https://github.com/user-attachments/assets/6e94ff03-8a33-4d69-96c6-1fa395e06aca




**Special notes for your reviewer:**
**How to test**
1. Open a saved dashboard with a text panel, visible on screen.
2. Navigate away via the left nav (not a reload), then back to the same dashboard.
3. Enter panel edit - the write/split/preview toolbar is missing before this change.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
