### PR TITLE
SSO: forward the real secret to MT-Settings on SSOSetting create

### DIFF
--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -449,11 +449,8 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *ge
 	// SSO settings apis
 	if enableSsoSettingsApi && b.ssoLegacyStore != nil {
 		ssoResource := legacyiamv0.SSOSettingResourceInfo
-		// When the MT-Settings client is configured, the SSOSetting kind rides the
-		// standard dual-writer (legacy + MT-Settings), which routes reads and writes
-		// by the [unified_storage.ssosettings.iam.grafana.app] storage mode. Without
-		// it (e.g. on-prem, or when the builder is unavailable) the legacy store
-		// serves alone.
+		// With an MT-Settings client the SSOSetting kind rides the dual-writer (mode-gated
+		// reads/writes); without it (on-prem) the legacy store serves alone.
 		if b.ssoSettingsClient != nil && opts.DualWriteBuilder != nil {
 			writer, _ := b.ssoSettingsClient.(settingsvc.Writer)
 			mtStore := sso.NewMTSettingsStore(b.ssoSettingsClient, writer)

--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -461,9 +461,21 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *ge
 			if err != nil {
 				return err
 			}
-			storage[ssoResource.StoragePath()] = dw
+			// The legacy adapter returns the raw secret on Create so the dual-writer
+			// forwards it to MT-Settings; redact it back out of the client response.
+			redacted, err := sso.NewRedactingStore(dw)
+			if err != nil {
+				return err
+			}
+			storage[ssoResource.StoragePath()] = redacted
 		} else {
-			storage[ssoResource.StoragePath()] = b.ssoLegacyStore
+			// Legacy serves alone, but its Create still returns the raw input, so
+			// redact the response here too.
+			redacted, err := sso.NewRedactingStore(b.ssoLegacyStore)
+			if err != nil {
+				return err
+			}
+			storage[ssoResource.StoragePath()] = redacted
 		}
 	}
 

--- a/pkg/registry/apis/iam/sso/mtsettings_store.go
+++ b/pkg/registry/apis/iam/sso/mtsettings_store.go
@@ -179,6 +179,20 @@ func (s *MTSettingsStore) Update(ctx context.Context, name string, objInfo rest.
 	section := sectionFor(name)
 	desired := ssoSetting.Spec.Settings.UnstructuredContent()
 
+	// A read redacts secrets to a placeholder, so a read-then-write round-trip
+	// would persist the placeholder as the secret. Restore the stored value for
+	// any secret the client sent back unchanged (mirrors the legacy mergeSecrets).
+	if !created {
+		stored := current.Spec.Settings.Object
+		for key, val := range desired {
+			if str, ok := val.(string); ok && str == setting.RedactedPassword && isSecretField(key) {
+				if prev, ok := stored[key]; ok {
+					desired[key] = prev
+				}
+			}
+		}
+	}
+
 	// Upsert every desired key first — a required value is never removed before
 	// its replacement is durable.
 	for key, val := range desired {
@@ -337,11 +351,34 @@ func isSecretField(key string) bool {
 func redactSecrets(obj *iamv0.SSOSetting) *iamv0.SSOSetting {
 	out := obj.DeepCopy()
 	settings := out.Spec.Settings.UnstructuredContent()
-	for k, v := range settings {
-		if str, ok := v.(string); ok && str != "" && isSecretField(k) {
-			settings[k] = setting.RedactedPassword
+	for _, m := range secretMaps(settings) {
+		for k, v := range m {
+			if str, ok := v.(string); ok && str != "" && isSecretField(k) {
+				m[k] = setting.RedactedPassword
+			}
 		}
 	}
 	out.Spec.Settings = common.Unstructured{Object: settings}
 	return out
+}
+
+// secretMaps returns every map that may hold secret fields. LDAP nests secrets
+// (e.g. bind_password) under config.servers[], so scanning only the top level
+// would leak them (mirrors the legacy getConfigMaps).
+func secretMaps(settings map[string]any) []map[string]any {
+	maps := []map[string]any{settings}
+	config, ok := settings["config"].(map[string]any)
+	if !ok {
+		return maps
+	}
+	servers, ok := config["servers"].([]any)
+	if !ok {
+		return maps
+	}
+	for _, srv := range servers {
+		if m, ok := srv.(map[string]any); ok {
+			maps = append(maps, m)
+		}
+	}
+	return maps
 }

--- a/pkg/registry/apis/iam/sso/mtsettings_store_test.go
+++ b/pkg/registry/apis/iam/sso/mtsettings_store_test.go
@@ -303,6 +303,25 @@ func TestMTSettingsStore(t *testing.T) {
 			},
 		},
 		{
+			name: "Update keeps the stored secret when the client sends back the redacted placeholder",
+			rows: []*settingsvc.Setting{
+				usRow("auth.generic_oauth", "client_id", "abc"),
+				usRow("auth.generic_oauth", "client_secret", "storedsecret"),
+			},
+			op: func(s *MTSettingsStore) (runtime.Object, bool, error) {
+				return s.Update(nsCtx(), "generic_oauth",
+					rest.DefaultUpdatedObjectInfo(ssoObj("generic_oauth", map[string]any{"client_id": "abc", "client_secret": setting.RedactedPassword})),
+					nil, nil, false, &metav1.UpdateOptions{})
+			},
+			assert: func(t *testing.T, sso *iamv0.SSOSetting, _ bool, err error, f *fakeSettings) {
+				require.NoError(t, err)
+				require.NotNil(t, sso)
+				// The placeholder is not persisted; the stored secret is preserved.
+				assert.Equal(t, "storedsecret", f.upserts["client_secret"])
+				assert.Equal(t, setting.RedactedPassword, sso.Spec.Settings.Object["client_secret"])
+			},
+		},
+		{
 			name: "List is not implemented",
 			rows: nil,
 			op: func(s *MTSettingsStore) (runtime.Object, bool, error) {
@@ -327,6 +346,28 @@ func TestMTSettingsStore(t *testing.T) {
 			tc.assert(t, sso, ok, err, f)
 		})
 	}
+}
+
+// TestRedactSecretsNestedLDAP covers LDAP's nested servers config, whose secrets
+// sit under config.servers[] rather than at the top level.
+func TestRedactSecretsNestedLDAP(t *testing.T) {
+	in := ssoObj("ldap", map[string]any{
+		"config": map[string]any{
+			"servers": []any{
+				map[string]any{"host": "ldap.example.com", "bind_password": "topsecret"},
+			},
+		},
+	})
+
+	out := redactSecrets(in)
+
+	server := out.Spec.Settings.Object["config"].(map[string]any)["servers"].([]any)[0].(map[string]any)
+	assert.Equal(t, setting.RedactedPassword, server["bind_password"])
+	assert.Equal(t, "ldap.example.com", server["host"])
+
+	// The input is left untouched (redaction works on a copy).
+	inServer := in.Spec.Settings.Object["config"].(map[string]any)["servers"].([]any)[0].(map[string]any)
+	assert.Equal(t, "topsecret", inServer["bind_password"])
 }
 
 func TestCoarseResourceVersion(t *testing.T) {

--- a/pkg/registry/apis/iam/sso/redacting_store.go
+++ b/pkg/registry/apis/iam/sso/redacting_store.go
@@ -1,0 +1,61 @@
+package sso
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/registry/rest"
+
+	iamv0 "github.com/grafana/grafana/pkg/apis/iam/v0alpha1"
+)
+
+// ssoStorage is the interface set shared by every store the SSOSetting kind rides on
+// (legacy, dual-writer, MT-Settings). The decorator embeds it so overriding Create drops
+// no capability the kind serves in any storage mode.
+type ssoStorage interface {
+	rest.Storage
+	rest.Scoper
+	rest.Getter
+	rest.Lister
+	rest.Creater
+	rest.Updater
+	rest.GracefulDeleter
+	rest.SingularNameProvider
+	rest.TableConvertor
+}
+
+var (
+	_ ssoStorage = (*LegacyStore)(nil)
+	_ ssoStorage = (*MTSettingsStore)(nil)
+)
+
+// redactingStore redacts the secrets in the Create response. The legacy adapter returns
+// the raw admin input on Create, so the dual-writer can send the real secret to
+// MT-Settings. That raw object is also the client response. In legacy-only mode it is the
+// response directly. The other verbs redact their own responses.
+type redactingStore struct {
+	ssoStorage
+}
+
+// NewRedactingStore wraps the SSOSetting dual-writer. It errors if the storage does not
+// expose the expected interface set, which would mean the wrapper drops a capability.
+func NewRedactingStore(storage rest.Storage) (rest.Storage, error) {
+	inner, ok := storage.(ssoStorage)
+	if !ok {
+		return nil, fmt.Errorf("sso storage does not implement the expected interface set")
+	}
+	return &redactingStore{inner}, nil
+}
+
+func (s *redactingStore) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
+	out, err := s.ssoStorage.Create(ctx, obj, createValidation, options)
+	if err != nil {
+		return nil, err
+	}
+	if setting, ok := out.(*iamv0.SSOSetting); ok {
+		return redactSecrets(setting), nil
+	}
+	return out, nil
+}

--- a/pkg/registry/apis/iam/sso/redacting_store.go
+++ b/pkg/registry/apis/iam/sso/redacting_store.go
@@ -11,9 +11,8 @@ import (
 	iamv0 "github.com/grafana/grafana/pkg/apis/iam/v0alpha1"
 )
 
-// ssoStorage is the interface set shared by every store the SSOSetting kind rides on
-// (legacy, dual-writer, MT-Settings). The decorator embeds it so overriding Create drops
-// no capability the kind serves in any storage mode.
+// ssoStorage is the common interface set of every store the SSOSetting kind uses. The
+// decorator embeds it so overriding Create drops no capability.
 type ssoStorage interface {
 	rest.Storage
 	rest.Scoper
@@ -31,16 +30,13 @@ var (
 	_ ssoStorage = (*MTSettingsStore)(nil)
 )
 
-// redactingStore redacts the secrets in the Create response. The legacy adapter returns
-// the raw admin input on Create, so the dual-writer can send the real secret to
-// MT-Settings. That raw object is also the client response. In legacy-only mode it is the
-// response directly. The other verbs redact their own responses.
+// redactingStore redacts secrets in the Create response. LegacyStore.Create returns the raw
+// secret so the dual-writer forwards it to MT-Settings; this keeps it out of the response.
 type redactingStore struct {
 	ssoStorage
 }
 
-// NewRedactingStore wraps the SSOSetting dual-writer. It errors if the storage does not
-// expose the expected interface set, which would mean the wrapper drops a capability.
+// NewRedactingStore wraps the SSOSetting store, erroring if it lacks a required capability.
 func NewRedactingStore(storage rest.Storage) (rest.Storage, error) {
 	inner, ok := storage.(ssoStorage)
 	if !ok {

--- a/pkg/registry/apis/iam/sso/redacting_store_test.go
+++ b/pkg/registry/apis/iam/sso/redacting_store_test.go
@@ -1,0 +1,47 @@
+package sso
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/registry/rest"
+
+	iamv0 "github.com/grafana/grafana/pkg/apis/iam/v0alpha1"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+type fakeInner struct {
+	ssoStorage
+	created *iamv0.SSOSetting
+}
+
+func (f *fakeInner) Create(context.Context, runtime.Object, rest.ValidateObjectFunc, *metav1.CreateOptions) (runtime.Object, error) {
+	return f.created, nil
+}
+
+func TestRedactingStore_CreateRedactsResponse(t *testing.T) {
+	inner := &fakeInner{created: ssoObj("generic_oauth", map[string]any{"client_id": "abc", "client_secret": "topsecret"})}
+	store, err := NewRedactingStore(inner)
+	require.NoError(t, err)
+
+	out, err := store.(rest.Creater).Create(context.Background(), ssoObj("generic_oauth", map[string]any{}), nil, &metav1.CreateOptions{})
+	require.NoError(t, err)
+	sso, ok := out.(*iamv0.SSOSetting)
+	require.True(t, ok)
+	assert.Equal(t, setting.RedactedPassword, sso.Spec.Settings.Object["client_secret"])
+	assert.Equal(t, "abc", sso.Spec.Settings.Object["client_id"])
+}
+
+type onlyStorage struct{}
+
+func (onlyStorage) New() runtime.Object { return nil }
+func (onlyStorage) Destroy()            {}
+
+func TestNewRedactingStore_RejectsIncompleteStorage(t *testing.T) {
+	_, err := NewRedactingStore(onlyStorage{})
+	require.Error(t, err)
+}

--- a/pkg/registry/apis/iam/sso/store.go
+++ b/pkg/registry/apis/iam/sso/store.go
@@ -134,7 +134,11 @@ func (s *LegacyStore) Create(ctx context.Context, obj runtime.Object, createVali
 	if err := s.service.Upsert(ctx, mapToModel(setting), ident); err != nil {
 		return nil, err
 	}
-	return s.Get(ctx, setting.Name, nil)
+	// Return the input as written so the dual-writer forwards the raw secret to
+	// MT-Settings; the store decorator redacts the response.
+	ns, _ := request.NamespaceInfoFrom(ctx, false)
+	created := mapToObject(ns.Value, mapToModel(setting))
+	return &created, nil
 }
 
 // Update implements rest.Updater.

--- a/pkg/registry/apis/iam/sso/store_test.go
+++ b/pkg/registry/apis/iam/sso/store_test.go
@@ -68,6 +68,21 @@ func TestLegacyStore_Create(t *testing.T) {
 			},
 		},
 		{
+			name: "returns the raw secret so the dual-writer forwards it to MT-Settings",
+			svc:  &fakeSSOService{},
+			op: func(s *LegacyStore) (runtime.Object, error) {
+				return s.Create(reqCtx(), ssoObj("generic_oauth", map[string]any{"client_id": "abc", "client_secret": "topsecret"}), nil, &metav1.CreateOptions{})
+			},
+			assert: func(t *testing.T, sso *iamv0.SSOSetting, err error, svc *fakeSSOService) {
+				require.NoError(t, err)
+				require.NotNil(t, sso)
+				assert.Equal(t, "topsecret", sso.Spec.Settings.Object["client_secret"])
+				assert.Equal(t, "abc", sso.Spec.Settings.Object["client_id"])
+				require.NotNil(t, svc.upserted)
+				assert.Equal(t, "topsecret", svc.upserted.Settings["client_secret"])
+			},
+		},
+		{
 			name: "fails without an identity and does not upsert",
 			svc:  &fakeSSOService{},
 			op: func(s *LegacyStore) (runtime.Object, error) {


### PR DESCRIPTION
## What

On a live create of the `SSOSetting` kind, forward the real (plaintext) secret to the MT-Settings store so its mutator encrypts it into a SecureValue. `LegacyStore.Create` now returns the raw admin input (real secret in `Spec.Settings`) instead of the redacted read, so the dual-writer forwards it to MT-Settings. A store decorator redacts the secret back out of the client response so it never leaks.

## Why

Previously `LegacyStore.Create` returned the redacted/merged projection, so the dual-writer forwarded a redacted secret (and defaults-expanded rows) to MT-Settings — the write landed but the secret was wrong. This is Stage 3.4.2 of the SSO Settings → MT-Settings migration.

## Notes

- Create-only: the Update path already forwards the admin's raw input to MT-Settings (the dual-writer re-runs the original request), so it is unchanged.
- The decorator embeds the common store interface and overrides only Create. It drops the collection-delete verb that only the dual-writer exposed — an unused, mode-dependent capability — making the kind's verbs consistent across storage modes.
- Both wiring paths (dual-writer and legacy-alone / on-prem) are wrapped, so no path echoes the secret.

Fixes grafana/identity-access-team#2328

## Test Plan

- `go test ./pkg/registry/apis/iam/sso/...` — Create returns the raw secret; the decorator redacts the Create response; the wrapper rejects incomplete storage.
- `make lint-go` — clean.
