### PR TITLE
Logs Table: Fix keyboard navigation

### DIFF
--- a/public/app/plugins/panel/logstable/LogsTableDetails.test.tsx
+++ b/public/app/plugins/panel/logstable/LogsTableDetails.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { CoreApp, dateTime, EventBusSrv, LogLevel } from '@grafana/data';
+import { CoreApp, dateTime, EventBusSrv, LogLevel, LogsSortOrder } from '@grafana/data';
 import { type DataSourceSrv, getDataSourceSrv, usePluginLinks } from '@grafana/runtime';
 import { defaultTableOptions } from '@grafana/schema';
 import { type PanelContext, PanelContextProvider } from '@grafana/ui';
@@ -326,6 +326,85 @@ describe('LogsTableDetails', () => {
 
     expect(replaceDetails).toHaveBeenCalledTimes(1);
     expect(replaceDetails).toHaveBeenCalledWith(logA);
+  });
+
+  test('ArrowDown and ArrowUp follow table sort order, not query order', async () => {
+    const oldest = createLogLine({
+      uid: 'oldest',
+      timeEpochMs: 1546297200000,
+      datasourceUid: lokiDS.uid,
+    });
+    const middle = createLogLine({
+      uid: 'middle',
+      timeEpochMs: 1546297200001,
+      datasourceUid: lokiDS.uid,
+    });
+    const newest = createLogLine({
+      uid: 'newest',
+      timeEpochMs: 1546297200002,
+      datasourceUid: lokiDS.uid,
+    });
+    // Query/frame order is oldest-first; the table is sorted newest-first.
+    const replaceDetails = jest.fn();
+    setup(
+      { currentLog: middle, showDetails: [oldest, middle, newest], replaceDetails },
+      { sortOrder: LogsSortOrder.Descending, sortBy: [{ displayName: 'Time', desc: true }] },
+      undefined,
+      jest.fn(),
+      [oldest, middle, newest]
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Log line')).toBeInTheDocument();
+    });
+
+    await userEvent.keyboard('{ArrowDown}');
+
+    expect(replaceDetails).toHaveBeenCalledWith(oldest);
+
+    replaceDetails.mockClear();
+    await userEvent.keyboard('{ArrowUp}');
+
+    expect(replaceDetails).toHaveBeenCalledWith(newest);
+  });
+
+  test('ArrowDown and ArrowUp follow sort order of a non-time column', async () => {
+    const zebra = createLogLine({
+      uid: 'zebra',
+      labels: { env: 'zebra' },
+      datasourceUid: lokiDS.uid,
+    });
+    const middle = createLogLine({
+      uid: 'middle',
+      labels: { env: 'middle' },
+      datasourceUid: lokiDS.uid,
+    });
+    const alpha = createLogLine({
+      uid: 'alpha',
+      labels: { env: 'alpha' },
+      datasourceUid: lokiDS.uid,
+    });
+    const replaceDetails = jest.fn();
+    setup(
+      { currentLog: middle, showDetails: [zebra, middle, alpha], replaceDetails },
+      { sortBy: [{ displayName: 'env', desc: false }] },
+      undefined,
+      jest.fn(),
+      [zebra, middle, alpha]
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Log line')).toBeInTheDocument();
+    });
+
+    await userEvent.keyboard('{ArrowDown}');
+
+    expect(replaceDetails).toHaveBeenCalledWith(zebra);
+
+    replaceDetails.mockClear();
+    await userEvent.keyboard('{ArrowUp}');
+
+    expect(replaceDetails).toHaveBeenCalledWith(alpha);
   });
 
   test('forwards label filters to the panel ad-hoc filter handler', async () => {

--- a/public/app/plugins/panel/logstable/LogsTableDetails.tsx
+++ b/public/app/plugins/panel/logstable/LogsTableDetails.tsx
@@ -18,6 +18,7 @@ import { LogLineDetailsHeader } from 'app/features/logs/components/panel/LogLine
 import { LogListContextProvider } from 'app/features/logs/components/panel/LogListContext';
 
 import { useLogDetailsContext } from './LogDetailsContext';
+import { sortLogsToMatchTable } from './sortLogsToMatchTable';
 import { SETTING_KEY_ROOT } from './constants';
 import { type Options } from './options/types';
 import { isCoreApp, isIsLabelFilterActive } from './types';
@@ -48,6 +49,9 @@ export const LogsTableDetails = ({ containerElement, options, onOptionsChange, t
   const inputRef = useRef('');
   const styles = useStyles2(getStyles);
   const dragStyles = useStyles2(getDragStyles);
+  // Clicks use frame `rowIndex` (TableNG `__index`), so `logs` stays in query order.
+  // Arrow keys follow the table's visible order for whatever column `sortBy` uses.
+  const navigableLogs = useMemo(() => sortLogsToMatchTable(logs, options.sortBy), [logs, options.sortBy]);
 
   const handleCloseDetails = useCallback(() => {
     inputRef.current = '';
@@ -85,10 +89,10 @@ export const LogsTableDetails = ({ containerElement, options, onOptionsChange, t
       } else {
         return;
       }
-      if (!currentLog || logs.findIndex((log) => log.uid === currentLog.uid) < 0) {
+      if (!currentLog || navigableLogs.findIndex((log) => log.uid === currentLog.uid) < 0) {
         return;
       }
-      const nextLog = logs[logs.findIndex((log) => log.uid === currentLog.uid) + delta];
+      const nextLog = navigableLogs[navigableLogs.findIndex((log) => log.uid === currentLog.uid) + delta];
       if (!nextLog) {
         return;
       }
@@ -97,7 +101,7 @@ export const LogsTableDetails = ({ containerElement, options, onOptionsChange, t
     }
     document.addEventListener('keydown', handleKeydown);
     return () => document.removeEventListener('keydown', handleKeydown);
-  }, [containerElement, currentLog, logs, replaceDetails]);
+  }, [containerElement, currentLog, navigableLogs, replaceDetails]);
 
   const handleSearch = useCallback((newSearch: string) => {
     inputRef.current = newSearch;

--- a/public/app/plugins/panel/logstable/LogsTableDetails.tsx
+++ b/public/app/plugins/panel/logstable/LogsTableDetails.tsx
@@ -18,6 +18,7 @@ import { LogLineDetailsHeader } from 'app/features/logs/components/panel/LogLine
 import { LogListContextProvider } from 'app/features/logs/components/panel/LogListContext';
 
 import { useLogDetailsContext } from './LogDetailsContext';
+import { sortLogsToMatchTable } from './sortLogsToMatchTable';
 import { SETTING_KEY_ROOT } from './constants';
 import { type Options } from './options/types';
 import { isCoreApp, isIsLabelFilterActive } from './types';
@@ -46,6 +47,9 @@ export const LogsTableDetails = ({ containerElement, options, onOptionsChange, t
   const inputRef = useRef('');
   const styles = useStyles2(getStyles);
   const dragStyles = useStyles2(getDragStyles);
+  // Clicks use frame `rowIndex` (TableNG `__index`), so `logs` stays in query order.
+  // Arrow keys follow the table's visible order for whatever column `sortBy` uses.
+  const navigableLogs = useMemo(() => sortLogsToMatchTable(logs, options.sortBy), [logs, options.sortBy]);
 
   const handleCloseDetails = useCallback(() => {
     inputRef.current = '';
@@ -83,10 +87,10 @@ export const LogsTableDetails = ({ containerElement, options, onOptionsChange, t
       } else {
         return;
       }
-      if (!currentLog || logs.findIndex((log) => log.uid === currentLog.uid) < 0) {
+      if (!currentLog || navigableLogs.findIndex((log) => log.uid === currentLog.uid) < 0) {
         return;
       }
-      const nextLog = logs[logs.findIndex((log) => log.uid === currentLog.uid) + delta];
+      const nextLog = navigableLogs[navigableLogs.findIndex((log) => log.uid === currentLog.uid) + delta];
       if (!nextLog) {
         return;
       }
@@ -95,7 +99,7 @@ export const LogsTableDetails = ({ containerElement, options, onOptionsChange, t
     }
     document.addEventListener('keydown', handleKeydown);
     return () => document.removeEventListener('keydown', handleKeydown);
-  }, [containerElement, currentLog, logs, replaceDetails]);
+  }, [containerElement, currentLog, navigableLogs, replaceDetails]);
 
   const handleSearch = useCallback((newSearch: string) => {
     inputRef.current = newSearch;

--- a/public/app/plugins/panel/logstable/LogsTableDetails.tsx
+++ b/public/app/plugins/panel/logstable/LogsTableDetails.tsx
@@ -18,9 +18,9 @@ import { LogLineDetailsHeader } from 'app/features/logs/components/panel/LogLine
 import { LogListContextProvider } from 'app/features/logs/components/panel/LogListContext';
 
 import { useLogDetailsContext } from './LogDetailsContext';
-import { sortLogsToMatchTable } from './sortLogsToMatchTable';
 import { SETTING_KEY_ROOT } from './constants';
 import { type Options } from './options/types';
+import { sortLogsToMatchTable } from './sortLogsToMatchTable';
 import { isCoreApp, isIsLabelFilterActive } from './types';
 
 interface Props extends Pick<PanelProps<Options>, 'onOptionsChange'> {

--- a/public/app/plugins/panel/logstable/sortLogsToMatchTable.test.ts
+++ b/public/app/plugins/panel/logstable/sortLogsToMatchTable.test.ts
@@ -1,0 +1,59 @@
+import { FieldType, toDataFrame } from '@grafana/data';
+import { createLogLine } from 'app/features/logs/components/mocks/logRow';
+
+import { sortLogsToMatchTable } from './sortLogsToMatchTable';
+
+describe('sortLogsToMatchTable', () => {
+  const older = createLogLine({ uid: 'older', rowIndex: 0, timeEpochMs: 1000, labels: { env: 'prod' } });
+  const newer = createLogLine({ uid: 'newer', rowIndex: 1, timeEpochMs: 2000, labels: { env: 'dev' } });
+  const logs = [older, newer];
+
+  test('preserves query order when the table is not sorted', () => {
+    expect(sortLogsToMatchTable(logs).map((log) => log.uid)).toEqual(['older', 'newer']);
+    expect(sortLogsToMatchTable(logs, []).map((log) => log.uid)).toEqual(['older', 'newer']);
+  });
+
+  test('sorts by timestamp descending', () => {
+    expect(sortLogsToMatchTable(logs, [{ displayName: 'Time', desc: true }]).map((log) => log.uid)).toEqual([
+      'newer',
+      'older',
+    ]);
+  });
+
+  test('sorts by timestamp ascending', () => {
+    expect(sortLogsToMatchTable(logs, [{ displayName: 'Time', desc: false }]).map((log) => log.uid)).toEqual([
+      'older',
+      'newer',
+    ]);
+  });
+
+  test('sorts by a label column', () => {
+    expect(sortLogsToMatchTable(logs, [{ displayName: 'env', desc: false }]).map((log) => log.uid)).toEqual([
+      'newer',
+      'older',
+    ]);
+  });
+
+  test('sorts by a non-time field on the data frame', () => {
+    const frame = toDataFrame({
+      fields: [
+        { name: 'Time', type: FieldType.time, values: [1000, 2000] },
+        { name: 'Line', type: FieldType.string, values: ['beta', 'alpha'] },
+      ],
+    });
+    const first = createLogLine({ uid: 'first', rowIndex: 0, timeEpochMs: 1000, dataFrame: frame });
+    const second = createLogLine({ uid: 'second', rowIndex: 1, timeEpochMs: 2000, dataFrame: frame });
+
+    expect(sortLogsToMatchTable([first, second], [{ displayName: 'Line', desc: false }]).map((log) => log.uid)).toEqual([
+      'second',
+      'first',
+    ]);
+  });
+
+  test('does not mutate the input array', () => {
+    const result = sortLogsToMatchTable(logs, [{ displayName: 'Time', desc: true }]);
+
+    expect(result).not.toBe(logs);
+    expect(logs.map((log) => log.uid)).toEqual(['older', 'newer']);
+  });
+});

--- a/public/app/plugins/panel/logstable/sortLogsToMatchTable.test.ts
+++ b/public/app/plugins/panel/logstable/sortLogsToMatchTable.test.ts
@@ -44,10 +44,9 @@ describe('sortLogsToMatchTable', () => {
     const first = createLogLine({ uid: 'first', rowIndex: 0, timeEpochMs: 1000, dataFrame: frame });
     const second = createLogLine({ uid: 'second', rowIndex: 1, timeEpochMs: 2000, dataFrame: frame });
 
-    expect(sortLogsToMatchTable([first, second], [{ displayName: 'Line', desc: false }]).map((log) => log.uid)).toEqual([
-      'second',
-      'first',
-    ]);
+    expect(sortLogsToMatchTable([first, second], [{ displayName: 'Line', desc: false }]).map((log) => log.uid)).toEqual(
+      ['second', 'first']
+    );
   });
 
   test('does not mutate the input array', () => {

--- a/public/app/plugins/panel/logstable/sortLogsToMatchTable.test.ts
+++ b/public/app/plugins/panel/logstable/sortLogsToMatchTable.test.ts
@@ -34,6 +34,18 @@ describe('sortLogsToMatchTable', () => {
     ]);
   });
 
+  test('keeps mixed-case ties in query order, matching TableNG', () => {
+    const apple = createLogLine({ uid: 'apple', labels: { env: 'apple' } });
+    const banana = createLogLine({ uid: 'banana', labels: { env: 'Banana' } });
+    const APPLE = createLogLine({ uid: 'APPLE', labels: { env: 'APPLE' } });
+
+    // TableNG Collator('en', { sensitivity: 'base' }) treats 'apple' and 'APPLE' as
+    // equal, so Array.sort keeps their query order. localeCompare reorders them.
+    expect(
+      sortLogsToMatchTable([APPLE, banana, apple], [{ displayName: 'env', desc: false }]).map((log) => log.uid)
+    ).toEqual(['APPLE', 'apple', 'banana']);
+  });
+
   test('sorts by a non-time field on the data frame', () => {
     const frame = toDataFrame({
       fields: [

--- a/public/app/plugins/panel/logstable/sortLogsToMatchTable.ts
+++ b/public/app/plugins/panel/logstable/sortLogsToMatchTable.ts
@@ -1,0 +1,54 @@
+import { FieldType, type LogRowModel } from '@grafana/data';
+import { type TableSortByFieldState } from '@grafana/schema';
+import { sortInAscendingOrder } from 'app/features/logs/utils';
+
+function findSortField(log: LogRowModel, displayName: string) {
+  return log.dataFrame?.fields.find(
+    (field) =>
+      field.name === displayName || field.state?.displayName === displayName || field.config.displayName === displayName
+  );
+}
+
+function compareValues(a: unknown, b: unknown): number {
+  if (a == null && b == null) {
+    return 0;
+  }
+  if (a == null) {
+    return -1;
+  }
+  if (b == null) {
+    return 1;
+  }
+  if (typeof a === 'number' && typeof b === 'number') {
+    return a - b;
+  }
+  return String(a).localeCompare(String(b), undefined, { numeric: true });
+}
+
+function compareLogsByColumn(a: LogRowModel, b: LogRowModel, displayName: string): number {
+  const field = findSortField(a, displayName) ?? findSortField(b, displayName);
+  if (field?.type === FieldType.time) {
+    return sortInAscendingOrder(a, b);
+  }
+  if (field) {
+    return compareValues(field.values[a.rowIndex], field.values[b.rowIndex]);
+  }
+  return compareValues(a.labels?.[displayName], b.labels?.[displayName]);
+}
+
+/** Reorders logs to match TableNG `sortBy` (any column). Empty `sortBy` keeps query order. */
+export function sortLogsToMatchTable<T extends LogRowModel>(logs: T[], sortBy?: TableSortByFieldState[]): T[] {
+  if (!logs.length || !sortBy?.length) {
+    return logs;
+  }
+
+  return [...logs].sort((a, b) => {
+    for (const { displayName, desc } of sortBy) {
+      const result = compareLogsByColumn(a, b, displayName);
+      if (result !== 0) {
+        return desc ? -result : result;
+      }
+    }
+    return 0;
+  });
+}

--- a/public/app/plugins/panel/logstable/sortLogsToMatchTable.ts
+++ b/public/app/plugins/panel/logstable/sortLogsToMatchTable.ts
@@ -9,20 +9,14 @@ function findSortField(log: LogRowModel, displayName: string) {
   );
 }
 
+// Same collator as TableNG so arrow-key order matches the visible table.
+const compareStrings = new Intl.Collator('en', { sensitivity: 'base', numeric: true }).compare;
+
 function compareValues(a: unknown, b: unknown): number {
-  if (a == null && b == null) {
-    return 0;
-  }
-  if (a == null) {
-    return -1;
-  }
-  if (b == null) {
-    return 1;
-  }
   if (typeof a === 'number' && typeof b === 'number') {
     return a - b;
   }
-  return String(a).localeCompare(String(b), undefined, { numeric: true });
+  return compareStrings(String(a ?? ''), String(b ?? ''));
 }
 
 function compareLogsByColumn(a: LogRowModel, b: LogRowModel, displayName: string): number {


### PR DESCRIPTION
This PR fixes keyboard navigation for the Logs Table. It was broken because the previous/next log didn't match the current table order.

https://github.com/user-attachments/assets/8f879fcc-d707-4111-a00f-168d685063de

