### PR TITLE
fix jsonnet after auto-width change

### DIFF
--- a/devenv/jsonnet/dev-dashboards.libsonnet
+++ b/devenv/jsonnet/dev-dashboards.libsonnet
@@ -104,6 +104,7 @@
     "slow_queries_and_annotations": (import '../dev-dashboards/scenarios/slow_queries_and_annotations.json'),
     "smoke": (import '../dev-dashboards/transforms/smoke.json'),
     "status-history-thresholds-mappings": (import '../dev-dashboards/panel-status-history/status-history-thresholds-mappings.json'),
+    "table-auto-column-widths": (import '../dev-dashboards/panel-table/table-auto-column-widths.json'),
     "table_footer": (import '../dev-dashboards/panel-table/table_footer.json'),
     "table_kitchen_sink": (import '../dev-dashboards/panel-table/table_kitchen_sink.json'),
     "table_markdown": (import '../dev-dashboards/panel-table/table_markdown.json'),


### PR DESCRIPTION
My auto-width PR has broken the provisioned dashboard file because the generated file was not checked in.