### PR TITLE
Teams: Read kubernetesTeamsApi flag in UI via OpenFeature

### DIFF
--- a/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
@@ -48,6 +48,7 @@ declare module "@openfeature/core" {
     | "globalDashboardVariables"
     | "grafana.dashboardGlobalVariables"
     | "queryEditorNext"
+    | "kubernetesTeamsApi"
     | "managedPluginsV2"
     | "analyticsFramework"
     | "grafana.scenesFlickeringFix"

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -113,6 +113,8 @@ export const FlagKeys = {
   GrafanaVisualDesignRefresh: "grafana.visualDesignRefresh",
   /** Enables an inline version of Log Details that creates no new scrolls */
   InlineLogDetailsNoScrolls: "inlineLogDetailsNoScrolls",
+  /** Enables team APIs in the app platform */
+  KubernetesTeamsApi: "kubernetesTeamsApi",
   /** Enables the logs tableNG panel to replace existing tableRT */
   LogsTablePanelNG: "logsTablePanelNG",
   /** Use stream shards to split queries into smaller subqueries */
@@ -721,6 +723,17 @@ export const useFlagGrafanaVisualDesignRefresh = (options?: ReactFlagEvaluationO
  */
 export const useFlagInlineLogDetailsNoScrolls = (options?: ReactFlagEvaluationOptions): boolean => {
   return useFlag("inlineLogDetailsNoScrolls", false, options).value;
+};
+
+/**
+ * Enables team APIs in the app platform
+ *
+ * **Details:**
+ * - flag key: `kubernetesTeamsApi`
+ * - default value: `false`
+ */
+export const useFlagKubernetesTeamsApi = (options?: ReactFlagEvaluationOptions): boolean => {
+  return useFlag("kubernetesTeamsApi", false, options).value;
 };
 
 /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2323,7 +2323,7 @@ var (
 			Owner:        identityAccessTeam,
 			HideFromDocs: true,
 			Expression:   "false",
-			Generate:     Generate{LegacyGo: true, LegacyFrontend: true},
+			Generate:     Generate{LegacyGo: true, LegacyFrontend: true, React: true},
 		},
 		{
 			Name:         "kubernetesTeamsRedirect",

--- a/public/app/core/components/OwnerReferences/OwnerReferenceSelector.test.tsx
+++ b/public/app/core/components/OwnerReferences/OwnerReferenceSelector.test.tsx
@@ -1,10 +1,11 @@
 import { HttpResponse, http } from 'msw';
-import { render, screen, testWithFeatureToggles, waitFor, within } from 'test/test-utils';
+import { act, render, screen, waitFor, within } from 'test/test-utils';
 
-import { type FeatureToggles } from '@grafana/data';
 import { setBackendSrv } from '@grafana/runtime';
+import { FlagKeys } from '@grafana/runtime/internal';
 import { mockComboboxRect } from '@grafana/test-utils';
 import { setupMockServer } from '@grafana/test-utils/server';
+import { setTestFlags } from '@grafana/test-utils/unstable';
 
 import { backendSrv } from '../../services/backend_srv';
 
@@ -14,13 +15,19 @@ setBackendSrv(backendSrv);
 const server = setupMockServer();
 mockComboboxRect();
 
-const toggle: Array<keyof FeatureToggles> = ['kubernetesTeamsApi'];
-
 describe.each([
-  { name: 'IAM path', toggles: { enable: toggle } },
-  { name: 'legacy path', toggles: { disable: toggle } },
-])('OwnerReferenceSelector ($name)', ({ toggles }) => {
-  testWithFeatureToggles(toggles);
+  { name: 'IAM path', flags: { [FlagKeys.KubernetesTeamsApi]: true } },
+  { name: 'legacy path', flags: { [FlagKeys.KubernetesTeamsApi]: false } },
+])('OwnerReferenceSelector ($name)', ({ flags }) => {
+  beforeEach(() => {
+    setTestFlags(flags);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      setTestFlags({});
+    });
+  });
 
   it('shows load error but keeps selector interactive', async () => {
     const { getByRole, findByText } = render(

--- a/public/app/features/browse-dashboards/BrowseDashboardsPage.test.tsx
+++ b/public/app/features/browse-dashboards/BrowseDashboardsPage.test.tsx
@@ -3,7 +3,7 @@ import { type ComponentProps } from 'react';
 import { useParams } from 'react-router-dom-v5-compat';
 import type AutoSizer from 'react-virtualized-auto-sizer';
 import { of } from 'rxjs';
-import { render as testRender, screen, waitFor, testWithFeatureToggles } from 'test/test-utils';
+import { act, render as testRender, screen, waitFor, testWithFeatureToggles } from 'test/test-utils';
 
 import { type DataSourceInstanceListItem } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -409,8 +409,10 @@ describe('browse-dashboards BrowseDashboardsPage', () => {
         setTestFlags({ 'grafana.starredFolders': true });
       });
 
-      afterEach(() => {
-        setTestFlags({});
+      afterEach(async () => {
+        await act(async () => {
+          setTestFlags({});
+        });
       });
 
       it('shows the star toggle as the first action, before "Recently deleted"', async () => {

--- a/public/app/features/teams/hooks.ts
+++ b/public/app/features/teams/hooks.ts
@@ -1,7 +1,7 @@
 import { skipToken } from '@reduxjs/toolkit/query';
 import { useCallback, useEffect, useMemo } from 'react';
 
-import { config } from '@grafana/runtime';
+import { useFlagKubernetesTeamsApi } from '@grafana/runtime/internal';
 import {
   API_GROUP,
   API_VERSION,
@@ -160,13 +160,11 @@ function legacySearchToIamSearchHits(teams: TeamDto[]): Array<{ title: string; n
   return teams.map((t) => ({ title: t.name, name: t.uid }));
 }
 
-const appPlatformIamEnabled = () => Boolean(config.featureToggles.kubernetesTeamsApi);
-
 /**
  * Facade hook: get a team by UID, using IAM or legacy endpoint based on feature toggle.
  */
 export function useGetTeamByUidQuery(args: GetTeamApiArg | typeof skipToken) {
-  const enabled = appPlatformIamEnabled();
+  const enabled = useFlagKubernetesTeamsApi();
 
   const iamResult = useGetTeamQueryIam(enabled ? args : skipToken);
   const legacyResult = useGetTeamByIdQuery(!enabled && args !== skipToken ? { teamId: args.name } : skipToken);
@@ -185,7 +183,7 @@ export function useGetTeamByUidQuery(args: GetTeamApiArg | typeof skipToken) {
  * Calls either the IAM or legacy get team by UID endpoint based on the feature toggle.
  */
 export function useLazyGetTeamByUidQuery() {
-  const enabled = appPlatformIamEnabled();
+  const enabled = useFlagKubernetesTeamsApi();
   const [iamTrigger, iamResult] = useLazyGetTeamQueryIam();
   const [legacyTrigger, legacyResult] = useLazyGetTeamByIdQueryLegacy();
 
@@ -220,7 +218,7 @@ export function useLazyGetTeamByUidQuery() {
  * Calls either the IAM or legacy search teams endpoint based on the feature toggle.
  */
 export function useLazySearchTeamsQuery() {
-  const enabled = appPlatformIamEnabled();
+  const enabled = useFlagKubernetesTeamsApi();
   const [iamTrigger, iamResult] = useLazyGetSearchTeamsQueryIam();
   const [legacyTrigger, legacyResult] = useLazySearchTeamsQueryLegacy();
 


### PR DESCRIPTION
## What is this feature?

The Teams UI checks the `kubernetesTeamsApi` flag through `config.featureToggles`, which only ever carries flags delivered on the legacy `config.ini` channel. The flag is actually deployed via GOFF, so the check was always `false` and the UI silently kept calling legacy `/api/teams` even where the flag was on.

This switches the check to the OpenFeature client, so that the UI actually use `teams.iam.grafana.app` when the flag is enabled.

## Why do we need this feature?

The dev rollout enabled `kubernetesTeamsApi` in GOFF and only the backend half took effect.

## Who is this feature for?
Any instances with `kubernetesTeamsApi` enabled (currently only dev instances).

part of https://github.com/grafana/identity-access-team/issues/2138