### PR TITLE
CI: Detect devenv/dev-dashboards and devenv/jsonnet changes for backend codegen checks

### DIFF
--- a/.github/actions/change-detection/action.yml
+++ b/.github/actions/change-detection/action.yml
@@ -55,6 +55,9 @@ outputs:
   devenv:
     description: Whether the devenv or self have changed in any way
     value: ${{ steps.changed-files.outputs.devenv_any_modified || 'true' }}
+  dev-dashboards:
+    description: Whether the dev-dashboards jsonnet codegen inputs (devenv/dev-dashboards/** or devenv/jsonnet/**) or self have changed
+    value: ${{ steps.changed-files.outputs.dev_dashboards_any_modified || 'true' }}
 runs:
   using: composite
   steps:
@@ -302,6 +305,14 @@ runs:
             - 'devenv/**'
             - '.dockerignore'
             - '${{ inputs.self }}'
+          dev_dashboards:
+            # devenv/dev-dashboards/** is go:embed'd and drives the devenv/jsonnet
+            # codegen (dev-dashboards.libsonnet); devenv/jsonnet/** is that codegen
+            # itself. Narrower than `devenv` so unrelated devenv/** changes (e.g.
+            # devenv/docker/blocks/**) don't trigger backend codegen verification.
+            - 'devenv/dev-dashboards/**'
+            - 'devenv/jsonnet/**'
+            - '${{ inputs.self }}'
     - name: Print all change groups
       shell: bash
       run: |
@@ -337,3 +348,5 @@ runs:
         echo " --> ${{ steps.changed-files.outputs.rpm_packaging_all_modified_files }}"
         echo "devenv: ${{ steps.changed-files.outputs.devenv_any_modified || 'true' }}"
         echo " --> ${{ steps.changed-files.outputs.devenv_all_modified_files }}"
+        echo "Dev dashboards: ${{ steps.changed-files.outputs.dev_dashboards_any_modified || 'true' }}"
+        echo " --> ${{ steps.changed-files.outputs.dev_dashboards_all_modified_files }}"

--- a/.github/workflows/backend-code-checks.yml
+++ b/.github/workflows/backend-code-checks.yml
@@ -28,6 +28,7 @@ jobs:
       contents: read
     outputs:
       changed: ${{ steps.detect-changes.outputs.backend }}
+      dev-dashboards-changed: ${{ steps.detect-changes.outputs.dev-dashboards }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -45,7 +46,7 @@ jobs:
       contents: read
       id-token: write
     needs: detect-changes
-    if: needs.detect-changes.outputs.changed == 'true'
+    if: needs.detect-changes.outputs.changed == 'true' || needs.detect-changes.outputs.dev-dashboards-changed == 'true'
     name: Validate Backend Configs
     runs-on: ubuntu-x64
     steps:


### PR DESCRIPTION
### What

The `validate-configs` job in `backend-code-checks.yml` runs `CODEGEN_VERIFY=1 make gen-jsonnet` to verify `devenv/jsonnet/dev-dashboards.libsonnet` — a manifest listing every `devenv/dev-dashboards/**.json` file as a jsonnet import, generated by `devenv/jsonnet/dev-dashboards.go` — is up to date. That job only runs when the shared change-detection action's `backend` category reports a change, and that category's globs don't cover `devenv/dev-dashboards/**` or `devenv/jsonnet/**`.

This adds a narrowly-scoped `dev-dashboards` category (just those two paths, not all of `devenv/**`) and ORs it into `validate-configs`'s trigger condition, so a PR that only touches `devenv/dev-dashboards/**` or `devenv/jsonnet/**` reliably runs the drift check.

### Why

#129236 added `devenv/dev-dashboards/panel-table/table-auto-column-widths.json` without running `make gen-jsonnet`. None of that PR's changed files (the new JSON, plus some `packages/grafana-ui` and `public/app/features/table` TS/TSX files) matched the `backend` category, so `validate-configs` was skipped entirely on that PR's own CI run, and the stale manifest merged into main undetected. It only surfaced later when an unrelated PR (#130636) that *did* touch backend files ran the same check against `main` + its diff and hit the pre-existing drift:

https://github.com/grafana/grafana/actions/runs/31730327829/job/94549054603

```
generated code is not up to date:
dev-dashboards.libsonnet would have changed:
+ 	    "table-auto-column-widths": (import '../dev-dashboards/panel-table/table-auto-column-widths.json'),
run `make gen-jsonnet` to regenerate
```

That break was fixed directly on main in #130707. This PR closes the CI gap that let it happen.

### Why this scope, not a broader one

- Didn't widen the shared `backend`/`backend_src` category directly — those also gate `backend-unit-tests.yml`, `go-lint.yml`, `feature-toggles-ci.yml`, `pr-build-grafana.yml`, `pr-go-workspace-check.yml`, `pr-test-integration.yml`, and `swagger-gen.yml`, which is disproportionate for a JSON-dashboard-only change.
- Didn't reuse the existing (currently unwired) `devenv` output (`devenv/**`) — too broad; it'd also fire `validate-configs` for unrelated `devenv/docker/blocks/**` etc. changes that can never cause jsonnet drift.
- Didn't add a new dedicated workflow — `gen-jsonnet` verify is a single `run:` line already living in `validate-configs`, which can reuse its existing checkout/Go-setup steps.

### Testing

- Reverted the single manifest line #129236 was missing and ran `CODEGEN_VERIFY=1 make gen-jsonnet` locally — reproduced the exact failure from the broken CI run; restored it and confirmed a clean pass.
- `gh pr diff 129236 --name-only` confirms the new dashboard JSON is the only file in that PR the new `dev-dashboards` category matches — none of its other files match `backend`/`backend_src` either, so this is the minimal addition needed to have caught it.

See also #130636 (the follow-up chore adding an analogous lefthook pre-commit hook, split out per review as a separate, independent PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)