### PR TITLE
Unified storage: coalesce NULL folder in vector reads

### DIFF
--- a/pkg/storage/unified/search/vector/data/vector_collection_get_content.sql
+++ b/pkg/storage/unified/search/vector/data/vector_collection_get_content.sql
@@ -1,7 +1,7 @@
 SELECT
     {{ .Ident "subresource" | .Into .Response.Subresource }},
     {{ .Ident "content" | .Into .Response.Content }},
-    {{ .Ident "folder" | .Into .Response.Folder }}
+    COALESCE({{ .Ident "folder" }}, '') AS {{ .Ident "folder" | .Into .Response.Folder }}
     FROM embeddings
     WHERE {{ .Ident "resource" }}  = {{ .Arg .Resource }}
     AND {{ .Ident "namespace" }} = {{ .Arg .Namespace }}

--- a/pkg/storage/unified/search/vector/data/vector_collection_search.sql
+++ b/pkg/storage/unified/search/vector/data/vector_collection_search.sql
@@ -4,7 +4,7 @@ SELECT
     {{ .Ident "subresource" | .Into .Response.Subresource }},
     {{ .Ident "content" | .Into .Response.Content }},
     {{ .Ident "embedding" }} <=> {{ .Arg .QueryEmbedding }} AS {{ .Ident "score" | .Into .Response.Score }},
-    {{ .Ident "folder" | .Into .Response.Folder }},
+    COALESCE({{ .Ident "folder" }}, '') AS {{ .Ident "folder" | .Into .Response.Folder }},
     {{ .Ident "metadata" | .Into .Response.Metadata }}
     FROM embeddings
     WHERE {{ .Ident "resource" }}  = {{ .Arg .Resource }}

--- a/pkg/storage/unified/search/vector/integration_test.go
+++ b/pkg/storage/unified/search/vector/integration_test.go
@@ -1297,3 +1297,32 @@ func TestIntegrationEnsureCollection_PartitionKeyConflict(t *testing.T) {
 	_, err = backend.EnsureCollection(ctx, "one.example.com", "clash-things", true)
 	require.NoError(t, err)
 }
+
+// TestIntegrationVectorNullFolder pins that reads tolerate legacy rows whose
+// folder column is NULL (written before the column existed): scanning into a
+// plain string must not error, and NULL comes back as "".
+func TestIntegrationVectorNullFolder(t *testing.T) {
+	backend, engine, ctx := setupIntegrationTest(t)
+
+	require.NoError(t, backend.Upsert(ctx, []Vector{
+		{Namespace: "integration-test", Resource: testResource, UID: "null-folder-dash", Title: "T",
+			Subresource: "panel/1", Content: "legacy content", Metadata: json.RawMessage(`{}`),
+			Embedding: makeEmbedding(0.5, 0.5), Model: testModel, ContentVersion: 1},
+	}))
+	_, err := engine.Exec("UPDATE embeddings SET folder = NULL WHERE uid = 'null-folder-dash'")
+	require.NoError(t, err)
+
+	stored, folder, err := backend.GetSubresourceContent(ctx, "integration-test", testModel, testResource, "null-folder-dash")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"panel/1": "legacy content"}, stored)
+	assert.Empty(t, folder)
+
+	results, err := backend.Search(ctx, "integration-test", testModel, testResource, makeEmbedding(0.5, 0.5), 10)
+	require.NoError(t, err)
+	require.NotEmpty(t, results)
+	for _, r := range results {
+		if r.UID == "null-folder-dash" {
+			assert.Empty(t, r.Folder)
+		}
+	}
+}

--- a/pkg/storage/unified/search/vector/testdata/postgres--vector_collection_get_content-simple.sql
+++ b/pkg/storage/unified/search/vector/testdata/postgres--vector_collection_get_content-simple.sql
@@ -1,7 +1,7 @@
 SELECT
     "subresource",
     "content",
-    "folder"
+    COALESCE("folder", '') AS "folder"
     FROM embeddings
     WHERE "resource"  = 'dashboards'
     AND "namespace" = 'stacks-123'

--- a/pkg/storage/unified/search/vector/testdata/postgres--vector_collection_search-no_filters.sql
+++ b/pkg/storage/unified/search/vector/testdata/postgres--vector_collection_search-no_filters.sql
@@ -4,7 +4,7 @@ SELECT
     "subresource",
     "content",
     "embedding" <=> '[0.1 0.2 0.3]' AS "score",
-    "folder",
+    COALESCE("folder", '') AS "folder",
     "metadata"
     FROM embeddings
     WHERE "resource"  = 'dashboards'

--- a/pkg/storage/unified/search/vector/testdata/postgres--vector_collection_search-with_all_filters.sql
+++ b/pkg/storage/unified/search/vector/testdata/postgres--vector_collection_search-with_all_filters.sql
@@ -4,7 +4,7 @@ SELECT
     "subresource",
     "content",
     "embedding" <=> '[0.1 0.2 0.3]' AS "score",
-    "folder",
+    COALESCE("folder", '') AS "folder",
     "metadata"
     FROM embeddings
     WHERE "resource"  = 'dashboards'

--- a/pkg/storage/unified/search/vector/testdata/postgres--vector_collection_search-with_uid_filter.sql
+++ b/pkg/storage/unified/search/vector/testdata/postgres--vector_collection_search-with_uid_filter.sql
@@ -4,7 +4,7 @@ SELECT
     "subresource",
     "content",
     "embedding" <=> '[0.1 0.2 0.3]' AS "score",
-    "folder",
+    COALESCE("folder", '') AS "folder",
     "metadata"
     FROM embeddings
     WHERE "resource"  = 'dashboards'


### PR DESCRIPTION
Legacy embeddings rows written before the folder column existed carry NULL folders, which the get-content and search scans rejected — wedging backfill jobs.

- `COALESCE(folder, '')` in `vector_collection_get_content.sql` and `vector_collection_search.sql`
- integration test covering both read paths against a NULL-folder row

🤖 Generated with [Claude Code](https://claude.com/claude-code)