### PR TITLE
Unified storage: add global dashboard variables to RBAC allowlist

### DIFF
--- a/pkg/storage/unified/resource/access.go
+++ b/pkg/storage/unified/resource/access.go
@@ -79,7 +79,7 @@ func newMetrics(reg prometheus.Registerer) *accessMetrics {
 
 // rbacAllowlist is a map of group to resources that are compatible with RBAC.
 var rbacAllowlist = groupResource{
-	"dashboard.grafana.app": map[string]interface{}{"dashboards": nil},
+	"dashboard.grafana.app": map[string]interface{}{"dashboards": nil, "variables": nil},
 	"folder.grafana.app":    map[string]interface{}{"folders": nil},
 	"iam.grafana.app":       map[string]interface{}{"users": nil, "teams": nil, "serviceaccounts": nil},
 }

--- a/pkg/storage/unified/resource/access_test.go
+++ b/pkg/storage/unified/resource/access_test.go
@@ -104,6 +104,7 @@ func TestAuthzLimitedClient_Check(t *testing.T) {
 		expected bool
 	}{
 		{"dashboard.grafana.app", "dashboards", false},
+		{"dashboard.grafana.app", "variables", false},
 		{"folder.grafana.app", "folders", false},
 		{"unknown.group", "unknown.resource", true},
 	}
@@ -131,6 +132,7 @@ func TestAuthzLimitedClient_Compile(t *testing.T) {
 		expected bool
 	}{
 		{"dashboard.grafana.app", "dashboards", false},
+		{"dashboard.grafana.app", "variables", false},
 		{"folder.grafana.app", "folders", false},
 		{"unknown.group", "unknown.resource", true},
 	}
@@ -252,6 +254,7 @@ func TestValidateAuthzOptions(t *testing.T) {
 
 	for _, value := range []string{
 		"dashboard.grafana.app/dashboards",
+		"dashboard.grafana.app/variables",
 		"folder.grafana.app/folders",
 		"iam.grafana.app/users",
 		"iam.grafana.app/teams",


### PR DESCRIPTION
- Adds `dashboard.grafana.app/variables` to the unified-storage limited authz client's `rbacAllowlist`, so Check/Compile/BatchCheck forward to the authz service instead of allow-all.
- Storage/search can deploy this independently from the Grafana API. Variable list/get filtering cannot be correct until this is on the storage servers.
- API-layer Variable RBAC (`variables:*` authorizer, mapper, roles) stays in the follow-up: #129470.

This split is required by the unified-storage compatibility check. #129470 previously mixed both sides.

Until the follow-up lands, mapper miss uses the K8s-native folder-authz fallback.