### PR TITLE
Chore: package-level annotation app tracing

### DIFF
--- a/pkg/registry/apps/annotation/authz.go
+++ b/pkg/registry/apps/annotation/authz.go
@@ -6,11 +6,13 @@ import (
 	"strconv"
 
 	authtypes "github.com/grafana/authlib/types"
-	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 
 	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 )
 
 // DashboardFolderResolver returns the parent folder UID for a dashboard, or "" if not found.
@@ -49,6 +51,11 @@ func canAccessAnnotation(ctx context.Context, accessClient authtypes.AccessClien
 // canAccessAnnotations checks permissions for a batch of annotations,
 // returning a boolean slice aligned with the input items slice
 func canAccessAnnotations(ctx context.Context, accessClient authtypes.AccessClient, folderResolver DashboardFolderResolver, namespace string, items []annotationV0.Annotation, verb string) ([]bool, error) {
+	ctx, span := tracer.Start(ctx, "annotation.authz.canAccessAnnotations", trace.WithAttributes(
+		attribute.Int("item_count", len(items)),
+	))
+	defer span.End()
+
 	if len(items) == 0 {
 		return nil, nil
 	}
@@ -107,6 +114,9 @@ func canAccessAnnotations(ctx context.Context, accessClient authtypes.AccessClie
 // resolveDashboardFolders maps dashboard UID -> parent folder UID for unique dashboards in items.
 // TODO: cache results (TTL LRU by namespace+UID) and run lookups in parallel. Folder rarely changes.
 func resolveDashboardFolders(ctx context.Context, folderResolver DashboardFolderResolver, namespace string, items []annotationV0.Annotation) (map[string]string, error) {
+	ctx, span := tracer.Start(ctx, "annotation.authz.resolveDashboardFolders")
+	defer span.End()
+
 	uids := make(map[string]struct{})
 	for _, anno := range items {
 		if anno.Spec.DashboardUID != nil && *anno.Spec.DashboardUID != "" {

--- a/pkg/registry/apps/annotation/authz_test.go
+++ b/pkg/registry/apps/annotation/authz_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/infra/tracing"
 )
 
 // newTestAdapter builds a k8sRESTAdapter with the observability deps wired to
@@ -34,7 +33,6 @@ func newTestAdapter(store Store, ac authtypes.AccessClient, fr ...DashboardFolde
 		store:          store,
 		accessClient:   ac,
 		folderResolver: resolver,
-		tracer:         tracing.InitializeTracerForTest(),
 		logger:         log.NewNopLogger(),
 		metrics:        ProvideMetrics(nil),
 		// use a large retention window in case of long-running tests.

--- a/pkg/registry/apps/annotation/dashboard_folder_lookup.go
+++ b/pkg/registry/apps/annotation/dashboard_folder_lookup.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 
 	authlib "github.com/grafana/authlib/types"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -38,6 +40,11 @@ type dashboardFolderResolver struct {
 }
 
 func (r *dashboardFolderResolver) ResolveFolder(ctx context.Context, namespace, dashboardUID string) (string, error) {
+	ctx, span := tracer.Start(ctx, "annotation.authz.dashboardFolderResolver.ResolveFolder", trace.WithAttributes(
+		attribute.String("dashboard_uid", dashboardUID),
+	))
+	defer span.End()
+
 	nsInfo, err := authlib.ParseNamespace(namespace)
 	if err != nil {
 		return "", fmt.Errorf("parse namespace %q: %w", namespace, err)

--- a/pkg/registry/apps/annotation/graphite_handler.go
+++ b/pkg/registry/apps/annotation/graphite_handler.go
@@ -23,7 +23,6 @@ import (
 // and legacy-ID handling with the standard Create path.
 func newGraphiteHandler(
 	creator rest.Creater,
-	tracer trace.Tracer,
 	metrics *Metrics,
 	logger log.Logger,
 ) func(ctx context.Context, writer app.CustomRouteResponseWriter, request *app.CustomRouteRequest) error {

--- a/pkg/registry/apps/annotation/graphite_handler_test.go
+++ b/pkg/registry/apps/annotation/graphite_handler_test.go
@@ -20,7 +20,6 @@ import (
 	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/infra/tracing"
 )
 
 func TestGraphiteHandler(t *testing.T) {
@@ -31,7 +30,7 @@ func TestGraphiteHandler(t *testing.T) {
 	// (the created Annotation) when the call succeeds.
 	run := func(t *testing.T, adapter *k8sRESTAdapter, body string) (annotationV0.Annotation, error) {
 		t.Helper()
-		handler := newGraphiteHandler(adapter, tracing.InitializeTracerForTest(), ProvideMetrics(nil), log.NewNopLogger())
+		handler := newGraphiteHandler(adapter, ProvideMetrics(nil), log.NewNopLogger())
 		writer := &mockResponseWriter{header: make(http.Header), body: &bytes.Buffer{}}
 		err := handler(ctx, writer, newGraphiteRequest(body))
 		var resp annotationV0.Annotation

--- a/pkg/registry/apps/annotation/instrumented_store.go
+++ b/pkg/registry/apps/annotation/instrumented_store.go
@@ -14,24 +14,22 @@ import (
 // instrumentedStore decorates any Store with tracing, logging, and metrics.
 type instrumentedStore struct {
 	innerStore Store
-	tracer     trace.Tracer
 	metrics    *Metrics
 	logger     log.Logger
 }
 
 var _ Store = (*instrumentedStore)(nil)
 
-func newInstrumentedStore(innerStore Store, tracer trace.Tracer, metrics *Metrics, logger log.Logger) *instrumentedStore {
+func newInstrumentedStore(innerStore Store, metrics *Metrics, logger log.Logger) *instrumentedStore {
 	return &instrumentedStore{
 		innerStore: innerStore,
-		tracer:     tracer,
 		metrics:    metrics,
 		logger:     logger,
 	}
 }
 
 func (s *instrumentedStore) Get(ctx context.Context, namespace, name string) (out *annotationV0.Annotation, err error) {
-	ctx, span := s.tracer.Start(ctx, "annotation.store.get", trace.WithAttributes(
+	ctx, span := tracer.Start(ctx, "annotation.store.get", trace.WithAttributes(
 		attribute.String("namespace", namespace),
 		attribute.String("name", name),
 	))
@@ -54,7 +52,7 @@ func (s *instrumentedStore) List(ctx context.Context, namespace string, opts Lis
 	if opts.PanelID != 0 {
 		attrs = append(attrs, attribute.Int64("panel_id", opts.PanelID))
 	}
-	ctx, span := s.tracer.Start(ctx, "annotation.store.list", trace.WithAttributes(attrs...))
+	ctx, span := tracer.Start(ctx, "annotation.store.list", trace.WithAttributes(attrs...))
 	defer span.End()
 	start := time.Now()
 	defer func() {
@@ -68,7 +66,7 @@ func (s *instrumentedStore) List(ctx context.Context, namespace string, opts Lis
 }
 
 func (s *instrumentedStore) Create(ctx context.Context, anno *annotationV0.Annotation) (out *annotationV0.Annotation, err error) {
-	ctx, span := s.tracer.Start(ctx, "annotation.store.create", trace.WithAttributes(
+	ctx, span := tracer.Start(ctx, "annotation.store.create", trace.WithAttributes(
 		attribute.String("namespace", anno.Namespace),
 	))
 	defer span.End()
@@ -79,7 +77,7 @@ func (s *instrumentedStore) Create(ctx context.Context, anno *annotationV0.Annot
 }
 
 func (s *instrumentedStore) Update(ctx context.Context, anno *annotationV0.Annotation) (out *annotationV0.Annotation, err error) {
-	ctx, span := s.tracer.Start(ctx, "annotation.store.update", trace.WithAttributes(
+	ctx, span := tracer.Start(ctx, "annotation.store.update", trace.WithAttributes(
 		attribute.String("namespace", anno.Namespace),
 		attribute.String("name", anno.Name),
 	))
@@ -91,7 +89,7 @@ func (s *instrumentedStore) Update(ctx context.Context, anno *annotationV0.Annot
 }
 
 func (s *instrumentedStore) Delete(ctx context.Context, namespace, name string) (err error) {
-	ctx, span := s.tracer.Start(ctx, "annotation.store.delete", trace.WithAttributes(
+	ctx, span := tracer.Start(ctx, "annotation.store.delete", trace.WithAttributes(
 		attribute.String("namespace", namespace),
 		attribute.String("name", name),
 	))

--- a/pkg/registry/apps/annotation/instrumented_store_test.go
+++ b/pkg/registry/apps/annotation/instrumented_store_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 	otelcodes "go.opentelemetry.io/otel/codes"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
-	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -48,27 +47,29 @@ func (f *fakeStore) Delete(_ context.Context, _, _ string) error {
 
 func (f *fakeStore) Close() error { return nil }
 
-// newTestInstrumentedStore wires a real (in-memory) tracer + prometheus
-// registry so tests can read back what the instrumentation actually emitted.
-func newTestInstrumentedStore(t *testing.T, inner Store) (*instrumentedStore, *tracetest.SpanRecorder, prometheus.Gatherer) {
+// newTestInstrumentedStore wires a prometheus registry and returns a view over
+// the spans this test emits, so tests can read back what the instrumentation
+// actually recorded via the shared package-level tracer.
+func newTestInstrumentedStore(t *testing.T, inner Store) (*instrumentedStore, func() []tracesdk.ReadOnlySpan, prometheus.Gatherer) {
 	t.Helper()
-	recorder := tracetest.NewSpanRecorder()
-	tp := tracesdk.NewTracerProvider(tracesdk.WithSpanProcessor(recorder))
-	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	start := len(testSpanRecorder.Ended())
+	spansSince := func() []tracesdk.ReadOnlySpan {
+		return testSpanRecorder.Ended()[start:]
+	}
 
 	reg := prometheus.NewRegistry()
 	m := ProvideMetrics(reg)
-	store := newInstrumentedStore(inner, tp.Tracer("annotation-test"), m, log.NewNopLogger())
-	return store, recorder, reg
+	store := newInstrumentedStore(inner, m, log.NewNopLogger())
+	return store, spansSince, reg
 }
 
 func TestInstrumentedStore_RecordsSuccessfulCall(t *testing.T) {
-	store, recorder, reg := newTestInstrumentedStore(t, &fakeStore{getRes: &annotationV0.Annotation{}})
+	store, spansSince, reg := newTestInstrumentedStore(t, &fakeStore{getRes: &annotationV0.Annotation{}})
 
 	_, err := store.Get(context.Background(), "ns", "n")
 	require.NoError(t, err)
 
-	spans := recorder.Ended()
+	spans := spansSince()
 	require.Len(t, spans, 1)
 	assert.Equal(t, "annotation.store.get", spans[0].Name())
 	assert.Equal(t, otelcodes.Unset, spans[0].Status().Code, "successful op should not set Error status")
@@ -82,12 +83,12 @@ func TestInstrumentedStore_RecordsSuccessfulCall(t *testing.T) {
 }
 
 func TestInstrumentedStore_ExpectedClientErrorAttachesButDoesNotFail(t *testing.T) {
-	store, recorder, reg := newTestInstrumentedStore(t, &fakeStore{getErr: ErrNotFound})
+	store, spansSince, reg := newTestInstrumentedStore(t, &fakeStore{getErr: ErrNotFound})
 
 	_, err := store.Get(context.Background(), "ns", "missing")
 	require.ErrorIs(t, err, ErrNotFound)
 
-	spans := recorder.Ended()
+	spans := spansSince()
 	require.Len(t, spans, 1)
 	assert.Equal(t, otelcodes.Unset, spans[0].Status().Code,
 		"expected client errors must NOT mark span as Error — keeps trace error rates clean")
@@ -105,12 +106,12 @@ func TestInstrumentedStore_ExpectedClientErrorAttachesButDoesNotFail(t *testing.
 
 func TestInstrumentedStore_UnexpectedErrorMarksSpanFailed(t *testing.T) {
 	boom := errors.New("backend exploded")
-	store, recorder, reg := newTestInstrumentedStore(t, &fakeStore{getErr: boom})
+	store, spansSince, reg := newTestInstrumentedStore(t, &fakeStore{getErr: boom})
 
 	_, err := store.Get(context.Background(), "ns", "n")
 	require.ErrorIs(t, err, boom)
 
-	spans := recorder.Ended()
+	spans := spansSince()
 	require.Len(t, spans, 1)
 	assert.Equal(t, otelcodes.Error, spans[0].Status().Code,
 		"unexpected errors must mark span as Error so trace dashboards page on them")
@@ -125,13 +126,13 @@ func TestInstrumentedStore_UnexpectedErrorMarksSpanFailed(t *testing.T) {
 
 func TestInstrumentedStore_ApierrorsForbiddenIsExpected(t *testing.T) {
 	gr := schema.GroupResource{Group: "annotation.grafana.app", Resource: "annotations"}
-	store, recorder, _ := newTestInstrumentedStore(t,
+	store, spansSince, _ := newTestInstrumentedStore(t,
 		&fakeStore{getErr: apierrors.NewForbidden(gr, "n", errors.New("nope"))})
 
 	_, err := store.Get(context.Background(), "ns", "n")
 	require.Error(t, err)
 
-	spans := recorder.Ended()
+	spans := spansSince()
 	require.Len(t, spans, 1)
 	assert.Equal(t, otelcodes.Unset, spans[0].Status().Code,
 		"forbidden is part of normal API traffic, must not mark span Error")

--- a/pkg/registry/apps/annotation/k8s_adapter.go
+++ b/pkg/registry/apps/annotation/k8s_adapter.go
@@ -107,7 +107,6 @@ type k8sRESTAdapter struct {
 	// immediately purged. A zero TTL disables this bound.
 	retentionTTL time.Duration
 
-	tracer  trace.Tracer
 	metrics *Metrics
 	logger  log.Logger
 }
@@ -150,7 +149,7 @@ func (s *k8sRESTAdapter) ConvertToTable(ctx context.Context, object runtime.Obje
 
 func (s *k8sRESTAdapter) List(ctx context.Context, options *internalversion.ListOptions) (out runtime.Object, err error) {
 	namespace := request.NamespaceValue(ctx)
-	ctx, span := s.tracer.Start(ctx, "annotation.k8s.list", trace.WithAttributes(
+	ctx, span := tracer.Start(ctx, "annotation.k8s.list", trace.WithAttributes(
 		attribute.String("namespace", namespace),
 	))
 	defer span.End()
@@ -211,7 +210,7 @@ func (s *k8sRESTAdapter) List(ctx context.Context, options *internalversion.List
 
 func (s *k8sRESTAdapter) Get(ctx context.Context, name string, options *metav1.GetOptions) (out runtime.Object, err error) {
 	namespace := request.NamespaceValue(ctx)
-	ctx, span := s.tracer.Start(ctx, "annotation.k8s.get", trace.WithAttributes(
+	ctx, span := tracer.Start(ctx, "annotation.k8s.get", trace.WithAttributes(
 		attribute.String("namespace", namespace),
 		attribute.String("name", name),
 	))
@@ -247,7 +246,7 @@ func (s *k8sRESTAdapter) Create(ctx context.Context,
 	options *metav1.CreateOptions,
 ) (out runtime.Object, err error) {
 	namespace := request.NamespaceValue(ctx)
-	ctx, span := s.tracer.Start(ctx, "annotation.k8s.create", trace.WithAttributes(
+	ctx, span := tracer.Start(ctx, "annotation.k8s.create", trace.WithAttributes(
 		attribute.String("namespace", namespace),
 	))
 	defer span.End()
@@ -309,7 +308,7 @@ func (s *k8sRESTAdapter) Update(ctx context.Context,
 	options *metav1.UpdateOptions,
 ) (out runtime.Object, created bool, err error) {
 	namespace := request.NamespaceValue(ctx)
-	ctx, span := s.tracer.Start(ctx, "annotation.k8s.update", trace.WithAttributes(
+	ctx, span := tracer.Start(ctx, "annotation.k8s.update", trace.WithAttributes(
 		attribute.String("namespace", namespace),
 		attribute.String("name", name),
 	))
@@ -391,7 +390,7 @@ func (s *k8sRESTAdapter) Update(ctx context.Context,
 
 func (s *k8sRESTAdapter) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions) (out runtime.Object, completed bool, err error) {
 	namespace := request.NamespaceValue(ctx)
-	ctx, span := s.tracer.Start(ctx, "annotation.k8s.delete", trace.WithAttributes(
+	ctx, span := tracer.Start(ctx, "annotation.k8s.delete", trace.WithAttributes(
 		attribute.String("namespace", namespace),
 		attribute.String("name", name),
 	))

--- a/pkg/registry/apps/annotation/lifecycle.go
+++ b/pkg/registry/apps/annotation/lifecycle.go
@@ -47,7 +47,7 @@ func (a *AppInstaller) runCleanup(ctx context.Context, lifecycleMgr LifecycleMan
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
 
-	ctx, span := a.tracer.Start(ctx, "annotation.cleanup")
+	ctx, span := tracer.Start(ctx, "annotation.cleanup")
 	defer span.End()
 
 	before := time.Now().UTC().Add(-retentionTTL)

--- a/pkg/registry/apps/annotation/register.go
+++ b/pkg/registry/apps/annotation/register.go
@@ -12,7 +12,6 @@ import (
 	"github.com/bwmarrin/snowflake"
 	authtypes "github.com/grafana/authlib/types"
 	"github.com/prometheus/client_golang/prometheus"
-	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
@@ -46,7 +45,6 @@ type AppInstaller struct {
 	cleanupCancel context.CancelFunc
 	cleanupWg     sync.WaitGroup
 	logger        log.Logger
-	tracer        trace.Tracer
 	metrics       *Metrics
 }
 
@@ -57,10 +55,9 @@ func RegisterAppInstaller(
 	cleaner annotations.Cleaner,
 	accessClient authtypes.AccessClient,
 	restConfigProvider apiserver.RestConfigProvider,
-	tracer trace.Tracer,
 	reg prometheus.Registerer,
 ) (*AppInstaller, error) {
-	return NewAppInstaller(newConfigFromSettings(cfg), service, cleaner, accessClient, NewDashboardFolderResolver(restConfigProvider.GetRestConfig), tracer, reg)
+	return NewAppInstaller(newConfigFromSettings(cfg), service, cleaner, accessClient, NewDashboardFolderResolver(restConfigProvider.GetRestConfig), reg)
 }
 
 // NewAppInstaller Layers (from bottom to top):
@@ -76,7 +73,6 @@ func NewAppInstaller(
 	cleaner annotations.Cleaner,
 	accessClient authtypes.AccessClient,
 	folderResolver DashboardFolderResolver,
-	tracer trace.Tracer,
 	reg prometheus.Registerer,
 ) (*AppInstaller, error) {
 	if folderResolver == nil {
@@ -86,7 +82,6 @@ func NewAppInstaller(
 	metrics := ProvideMetrics(reg)
 	installer := &AppInstaller{
 		logger:  logger,
-		tracer:  tracer,
 		metrics: metrics,
 	}
 
@@ -102,7 +97,7 @@ func NewAppInstaller(
 		reg.MustRegister(newPgxPoolCollector(pgStore.pool))
 	}
 
-	instrumentedStore := newInstrumentedStore(store, installer.tracer, installer.metrics, logger)
+	instrumentedStore := newInstrumentedStore(store, installer.metrics, logger)
 
 	// Start background cleanup if the store supports lifecycle management
 	if lifecycleMgr, ok := store.(LifecycleManager); ok {
@@ -126,7 +121,6 @@ func NewAppInstaller(
 		snowflakeNode:  sfNode,
 		maxScopeCount:  cfg.MaxScopeCount,
 		retentionTTL:   cfg.RetentionTTL,
-		tracer:         installer.tracer,
 		metrics:        installer.metrics,
 		logger:         logger,
 	}
@@ -136,13 +130,13 @@ func NewAppInstaller(
 		// We could consider combining the TagProvider with the Store interface to avoid this type assertion?
 		return nil, fmt.Errorf("store does not implement TagProvider, cannot serve tags API")
 	}
-	tagHandler := withAPIStatusErrorResponse(newTagsHandler(tagProvider, accessClient, installer.tracer, installer.metrics, logger))
+	tagHandler := withAPIStatusErrorResponse(newTagsHandler(tagProvider, accessClient, installer.metrics, logger))
 
 	// Create the search handler
-	searchHandler := withAPIStatusErrorResponse(newSearchHandler(instrumentedStore, accessClient, folderResolver, installer.tracer, installer.metrics, logger))
+	searchHandler := withAPIStatusErrorResponse(newSearchHandler(instrumentedStore, accessClient, folderResolver, installer.metrics, logger))
 
 	// Create the graphite handler
-	graphiteHandler := withAPIStatusErrorResponse(newGraphiteHandler(installer.k8sAdapter, installer.tracer, installer.metrics, logger))
+	graphiteHandler := withAPIStatusErrorResponse(newGraphiteHandler(installer.k8sAdapter, installer.metrics, logger))
 
 	provider := simple.NewAppProvider(apis.LocalManifest(), nil, annotationapp.New)
 

--- a/pkg/registry/apps/annotation/search_handler.go
+++ b/pkg/registry/apps/annotation/search_handler.go
@@ -22,7 +22,6 @@ func newSearchHandler(
 	store Store,
 	accessClient authtypes.AccessClient,
 	folderResolver DashboardFolderResolver,
-	tracer trace.Tracer,
 	metrics *Metrics,
 	logger log.Logger,
 ) func(ctx context.Context, writer app.CustomRouteResponseWriter, request *app.CustomRouteRequest) error {

--- a/pkg/registry/apps/annotation/search_handler_test.go
+++ b/pkg/registry/apps/annotation/search_handler_test.go
@@ -13,7 +13,6 @@ import (
 	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -193,7 +192,7 @@ func TestSearchHandler(t *testing.T) {
 			for _, name := range tt.deleteFirst {
 				require.NoError(t, store.Delete(ctx, metav1.NamespaceDefault, name))
 			}
-			handler := newSearchHandler(store, accessClient, dashClient, tracing.InitializeTracerForTest(), ProvideMetrics(nil), log.NewNopLogger())
+			handler := newSearchHandler(store, accessClient, dashClient, ProvideMetrics(nil), log.NewNopLogger())
 
 			u := &url.URL{
 				Scheme:   "http",

--- a/pkg/registry/apps/annotation/sql_adapter_test.go
+++ b/pkg/registry/apps/annotation/sql_adapter_test.go
@@ -10,6 +10,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/db"
@@ -26,7 +29,10 @@ import (
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 )
 
+var testSpanRecorder = tracetest.NewSpanRecorder()
+
 func TestMain(m *testing.M) {
+	otel.SetTracerProvider(tracesdk.NewTracerProvider(tracesdk.WithSpanProcessor(testSpanRecorder)))
 	testsuite.Run(m)
 }
 

--- a/pkg/registry/apps/annotation/tags_handler.go
+++ b/pkg/registry/apps/annotation/tags_handler.go
@@ -28,7 +28,6 @@ type TagItem struct {
 func newTagsHandler(
 	tagProvider TagProvider,
 	accessClient authtypes.AccessClient,
-	tracer trace.Tracer,
 	metrics *Metrics,
 	logger log.Logger,
 ) func(ctx context.Context, writer app.CustomRouteResponseWriter, request *app.CustomRouteRequest) error {

--- a/pkg/registry/apps/annotation/tags_handler_test.go
+++ b/pkg/registry/apps/annotation/tags_handler_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -84,7 +83,7 @@ func TestIntegrationTagsHandler(t *testing.T) {
 	}
 
 	allowAll := &fakeAccessClient{fn: func(authtypes.BatchCheckItem) bool { return true }}
-	handler := newTagsHandler(store, allowAll, tracing.InitializeTracerForTest(), ProvideMetrics(nil), log.NewNopLogger())
+	handler := newTagsHandler(store, allowAll, ProvideMetrics(nil), log.NewNopLogger())
 
 	tests := []struct {
 		name             string
@@ -363,7 +362,7 @@ func TestIntegrationTagsHandlerAuthorization(t *testing.T) {
 
 	t.Run("denies callers without organization annotation read", func(t *testing.T) {
 		denyAll := &fakeAccessClient{fn: func(authtypes.BatchCheckItem) bool { return false }}
-		handler := newTagsHandler(store, denyAll, tracing.InitializeTracerForTest(), ProvideMetrics(nil), log.NewNopLogger())
+		handler := newTagsHandler(store, denyAll, ProvideMetrics(nil), log.NewNopLogger())
 
 		req, writer := newRequest()
 		err := handler(ctx, writer, req)
@@ -382,7 +381,7 @@ func TestIntegrationTagsHandlerAuthorization(t *testing.T) {
 				item.Name == "organization" &&
 				item.Verb == utils.VerbList
 		}}
-		handler := newTagsHandler(store, orgReader, tracing.InitializeTracerForTest(), ProvideMetrics(nil), log.NewNopLogger())
+		handler := newTagsHandler(store, orgReader, ProvideMetrics(nil), log.NewNopLogger())
 
 		req, writer := newRequest()
 		err := handler(ctx, writer, req)

--- a/pkg/registry/apps/annotation/tracing.go
+++ b/pkg/registry/apps/annotation/tracing.go
@@ -1,0 +1,6 @@
+package annotation
+
+import "go.opentelemetry.io/otel"
+
+// tracer is the package-level tracer for all annotation app tracing.
+var tracer = otel.Tracer("github.com/grafana/grafana/pkg/registry/apps/annotation")

--- a/pkg/server/bootstrap/wire/wire_gen.go
+++ b/pkg/server/bootstrap/wire/wire_gen.go
@@ -845,7 +845,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts server.Options, apiO
 	if err != nil {
 		return nil, err
 	}
-	annotationAppInstaller, err := annotation.RegisterAppInstaller(cfg, repositoryImpl, cleanupServiceImpl, accessClient, eventualRestConfigProvider, tracer, registerer)
+	annotationAppInstaller, err := annotation.RegisterAppInstaller(cfg, repositoryImpl, cleanupServiceImpl, accessClient, eventualRestConfigProvider, registerer)
 	if err != nil {
 		return nil, err
 	}
@@ -1606,7 +1606,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	if err != nil {
 		return nil, err
 	}
-	annotationAppInstaller, err := annotation.RegisterAppInstaller(cfg, repositoryImpl, cleanupServiceImpl, accessClient, eventualRestConfigProvider, tracer, registerer)
+	annotationAppInstaller, err := annotation.RegisterAppInstaller(cfg, repositoryImpl, cleanupServiceImpl, accessClient, eventualRestConfigProvider, registerer)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR refactors the tracing within `pkg/registry/apps/annotation` to leverage a package-level tracer instead of the global tracer passed through via dependency injection. The goal being to provide a more ergonomic way to add traces throughout parts of the annotation app's code without needing to thread through the additional tracer dependency.

This PR also adds some additional tracing to the annotation authz paths to provide more visibility into if/when it becomes a bottleneck.