### PR TITLE
Provisioning: Downgrade user permission/authentication errors to warn…

### DIFF
--- a/apps/provisioning/pkg/repository/github/error_translation_test.go
+++ b/apps/provisioning/pkg/repository/github/error_translation_test.go
@@ -61,7 +61,7 @@ func TestTranslateGitHubError(t *testing.T) {
 				Response: &http.Response{StatusCode: http.StatusForbidden},
 				Message:  "API rate limit exceeded",
 			},
-			expectedErr:         repo.ErrPermissionDenied,
+			expectedErr:         repo.ErrTooManyRequests,
 			expectedMsgContains: "API rate limit exceeded",
 		},
 		{

--- a/apps/provisioning/pkg/repository/github/impl.go
+++ b/apps/provisioning/pkg/repository/github/impl.go
@@ -55,7 +55,7 @@ func translateGitHubError(err error) error {
 		// 403 - Permission denied
 		// Special case: rate limit gets additional context
 		if strings.Contains(strings.ToLower(ghMessage), "rate limit") {
-			return fmt.Errorf("API rate limit exceeded: %w", repo.ErrPermissionDenied)
+			return fmt.Errorf("API rate limit exceeded: %w", repo.ErrTooManyRequests)
 		}
 		return repo.ErrPermissionDenied
 

--- a/apps/provisioning/pkg/repository/github/impl_test.go
+++ b/apps/provisioning/pkg/repository/github/impl_test.go
@@ -2422,7 +2422,7 @@ func TestGithubClient_GetRepository(t *testing.T) {
 			owner:      "test-owner",
 			repository: "test-repo",
 			wantRepo:   Repository{},
-			wantErr:    repo.ErrPermissionDenied,
+			wantErr:    repo.ErrTooManyRequests,
 		},
 		{
 			name: "internal server error",

--- a/apps/provisioning/pkg/repository/repository.go
+++ b/apps/provisioning/pkg/repository/repository.go
@@ -60,6 +60,13 @@ var ErrPermissionDenied error = &apierrors.StatusError{ErrStatus: metav1.Status{
 	Message: "permission denied",
 }}
 
+var ErrTooManyRequests error = &apierrors.StatusError{ErrStatus: metav1.Status{
+	Status:  metav1.StatusFailure,
+	Code:    http.StatusTooManyRequests,
+	Reason:  metav1.StatusReasonTooManyRequests,
+	Message: "too many requests",
+}}
+
 // ErrServerUnavailable indicates that the remote server is unavailable or returned a 5xx error.
 var ErrServerUnavailable error = &apierrors.StatusError{ErrStatus: metav1.Status{
 	Status:  metav1.StatusFailure,

--- a/pkg/registry/apis/provisioning/controller/repository.go
+++ b/pkg/registry/apis/provisioning/controller/repository.go
@@ -975,7 +975,7 @@ func (rc *RepositoryController) process(key string) error {
 
 // processHooks handles hook execution with intelligent retry logic
 // Returns hook operations, whether processing should continue, and any error
-func (rc *RepositoryController) processHooks(ctx context.Context, repo repository.Repository, obj *provisioning.Repository) ([]map[string]interface{}, bool, error) {
+func (rc *RepositoryController) processHooks(ctx context.Context, repo repository.Repository, obj *provisioning.Repository) (hookOps []map[string]interface{}, shouldContinue bool, err error) {
 	webhookMissing := len(obj.Spec.Workflows) > 0 &&
 		repository.GetID(obj.Status.Webhook).IsEmpty()
 
@@ -994,16 +994,31 @@ func (rc *RepositoryController) processHooks(ctx context.Context, repo repositor
 		return nil, true, nil
 	}
 
-	hookOps, err := rc.runHooks(ctx, repo, obj)
+	hookOps, err = rc.runHooks(ctx, repo, obj)
 	if err != nil {
 		if err := rc.healthChecker.RecordFailure(ctx, provisioning.HealthFailureHook, err, obj); err != nil {
 			return nil, false, fmt.Errorf("update status after hook failure: %w", err)
 		}
 
+		if rc.isUserCaused(err) {
+			logging.FromContext(ctx).Warn("repository hook failed with a user-facing error", "error", err)
+			return nil, false, nil
+		}
 		return nil, false, err
 	}
 
 	return hookOps, true, nil
+}
+
+// Returns errors that are due to user errors
+func (rc *RepositoryController) isUserCaused(err error) bool {
+	// List of errors that are user-facing errors and are left recorded on the repository
+	if errors.Is(err, repository.ErrUnauthorized) ||
+		errors.Is(err, repository.ErrPermissionDenied) {
+		return true
+	}
+
+	return false
 }
 
 // shouldRotateWebhookSecret returns true when a repository has an active webhook

--- a/pkg/registry/apis/provisioning/controller/repository_test.go
+++ b/pkg/registry/apis/provisioning/controller/repository_test.go
@@ -1651,6 +1651,95 @@ func TestRepositoryController_process_HookFailureCooldownSuppressesRetry(t *test
 		"existing HealthFailureHook status must not be overwritten during cooldown")
 }
 
+// TestRepositoryController_process_HookFailureUnauthorizedDoesNotReturnError
+// verifies that a webhook call failing with repository.ErrUnauthorized is a
+// user-facing state, not a controller error: process() must return nil (no
+// Error-level log, no queue retry) even though the hook attempt failed, while
+// still recording the failure on /status/health so it's visible to the user.
+func TestRepositoryController_process_HookFailureUnauthorizedDoesNotReturnError(t *testing.T) {
+	namespace := "default"
+	repoName := "test-repo"
+
+	repo := &provisioning.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       repoName,
+			Namespace:  namespace,
+			Generation: 1,
+		},
+		Spec: provisioning.RepositorySpec{
+			Type:      provisioning.GitHubRepositoryType,
+			Workflows: []provisioning.Workflow{provisioning.WriteWorkflow},
+			Sync:      provisioning.SyncOptions{Enabled: false},
+		},
+		Status: provisioning.RepositoryStatus{
+			ObservedGeneration: 0, // first sync -> webhookOnCreate runs
+		},
+	}
+
+	stub := &hookRepoStub{
+		cfg:        repo,
+		hookErr:    repository.ErrUnauthorized,
+		hookErrSet: true,
+	}
+	rc, patcher := newRecoveryController(t, repo, stub)
+
+	err := rc.process(namespace + "/" + repoName)
+	require.NoError(t, err, "an unauthorized hook failure must not surface as a controller error")
+
+	assert.Equal(t, int32(1), stub.onCreateCalls.Load(), "the hook attempt should still have run")
+
+	healthOp, healthPatched := patcher.findPatchOp("/status/health")
+	require.True(t, healthPatched, "the failure must still be recorded on /status/health")
+	healthStatus, ok := healthOp["value"].(provisioning.HealthStatus)
+	require.True(t, ok, "expected /status/health value to be HealthStatus")
+	assert.False(t, healthStatus.Healthy)
+	assert.Equal(t, provisioning.HealthFailureHook, healthStatus.Error)
+	require.Len(t, healthStatus.Message, 1)
+	assert.Contains(t, healthStatus.Message[0], repository.ErrUnauthorized.Error())
+}
+
+// TestRepositoryController_process_HookFailureNonAuthErrorStillReturnsError
+// a hook failure that is
+// NOT repository.ErrUnauthorized must still surface as a controller error
+// (Error-level log, eligible for retry), so only the specific user-fixable
+// auth case is silenced.
+func TestRepositoryController_process_HookFailureNonAuthErrorStillReturnsError(t *testing.T) {
+	namespace := "default"
+	repoName := "test-repo"
+
+	repo := &provisioning.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       repoName,
+			Namespace:  namespace,
+			Generation: 1,
+		},
+		Spec: provisioning.RepositorySpec{
+			Type:      provisioning.GitHubRepositoryType,
+			Workflows: []provisioning.Workflow{provisioning.WriteWorkflow},
+			Sync:      provisioning.SyncOptions{Enabled: false},
+		},
+		Status: provisioning.RepositoryStatus{
+			ObservedGeneration: 0, // first sync -> webhookOnCreate runs
+		},
+	}
+
+	stub := &hookRepoStub{cfg: repo} // hookErrSet is false -> hookResult() returns assert.AnError
+	rc, patcher := newRecoveryController(t, repo, stub)
+
+	err := rc.process(namespace + "/" + repoName)
+	require.Error(t, err, "a non-auth hook failure must still surface as a controller error")
+	assert.ErrorIs(t, err, assert.AnError)
+
+	assert.Equal(t, int32(1), stub.onCreateCalls.Load(), "the hook attempt should still have run")
+
+	healthOp, healthPatched := patcher.findPatchOp("/status/health")
+	require.True(t, healthPatched, "the failure must still be recorded on /status/health")
+	healthStatus, ok := healthOp["value"].(provisioning.HealthStatus)
+	require.True(t, ok, "expected /status/health value to be HealthStatus")
+	assert.False(t, healthStatus.Healthy)
+	assert.Equal(t, provisioning.HealthFailureHook, healthStatus.Error)
+}
+
 // newRecoveryController is a small helper that wires up the minimal set of
 // dependencies required to drive RepositoryController.process for the
 // HealthFailureHook recovery scenarios below.


### PR DESCRIPTION
**What is this feature?**
log `warn` instead of `error` for user errors (permission, authentication) for the `RepositoryController`

**Why do we need this feature?**
Getting a lot of error noise everytime a repository is reconciled (default once a minute). We already save the error on the repository and we want to keep retrying in case they have updated the permissions for their token/connection. 

We are using this dashboard to view top errors and the user-caused errors are the dominating the list so its hard to get a glance of app-wide errors that are actually problematic: 

<img width="1433" height="828" alt="Screenshot 2026-08-14 at 9 27 57 AM" src="https://github.com/user-attachments/assets/0e8f54b9-9e0e-4fa4-97e7-ad14fb1e4ed0" />
[Grafana Link](https://ops.grafana-ops.net/d/747008c5b31b8cd523733e93f1144a80/grafana-git-sync-main?orgId=1&from=now-5m&to=now&timezone=utc&var-stack=&var-group=$__all&var-kind=$__all&var-prom=grafanacloud-prom&var-loki=grafanacloud-logs&var-tempo=grafanacloud-demoinfra-traces&var-cluster=$__all&dtab=Stacks&refresh=30s&var-Filters=namespace_extracted%7C%3D%7C)

Keeping it as warning so we can still debug stacks that are lacking permissions.  


**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/1311
Fixes https://github.com/grafana/git-ui-sync-project/issues/1310

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
