### PR TITLE
Dashboards: Prevent performance timeline entries from accumulating

### DIFF
--- a/public/app/features/dashboard/services/DashboardAnalyticsAggregator.ts
+++ b/public/app/features/dashboard/services/DashboardAnalyticsAggregator.ts
@@ -6,6 +6,7 @@ import { SLOW_OPERATION_THRESHOLD_MS } from './performanceConstants';
 import {
   registerPerformanceObserver,
   getPerformanceMemory,
+  getTimeSinceBoot,
   writePerformanceGroupStart,
   writePerformanceGroupLog,
   writePerformanceGroupEnd,
@@ -260,7 +261,7 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
       networkDuration: data.networkDuration || 0,
       startTs: data.timestamp,
       endTs: data.timestamp + (data.duration || 0),
-      timeSinceBoot: performance.measure('time_since_boot', 'frontend_boot_js_done_time_seconds').duration,
+      timeSinceBoot: getTimeSinceBoot(),
       longFramesCount: data.longFramesCount,
       longFramesTotalTime: data.longFramesTotalTime,
       // Omitted entirely when unknown (e.g. cached scene, no matching fetch recorded) rather than reported as 0.

--- a/public/app/features/dashboard/services/DashboardProfiler.ts
+++ b/public/app/features/dashboard/services/DashboardProfiler.ts
@@ -1,6 +1,8 @@
 import { logMeasurement, reportInteraction, config } from '@grafana/runtime';
 import { performanceUtils, type SceneObject } from '@grafana/scenes';
 
+import { getTimeSinceBoot } from './performanceUtils';
+
 interface SceneInteractionProfileEvent {
   origin: string;
   duration: number;
@@ -30,7 +32,7 @@ export function getDashboardComponentInteractionCallback(uid: string, title: str
       networkDuration: e.networkDuration,
       startTs: e.startTs,
       endTs: e.endTs,
-      timeSinceBoot: performance.measure('time_since_boot', 'frontend_boot_js_done_time_seconds').duration,
+      timeSinceBoot: getTimeSinceBoot(),
     };
 
     reportInteraction('dashboard_interaction', {

--- a/public/app/features/dashboard/services/ScenePerformanceLogger.test.ts
+++ b/public/app/features/dashboard/services/ScenePerformanceLogger.test.ts
@@ -1,0 +1,157 @@
+import { type performanceUtils } from '@grafana/scenes';
+
+import { ScenePerformanceLogger } from './ScenePerformanceLogger';
+import { observePerformanceEntries, setupNodePerformance } from './performanceTestUtils';
+
+function runDashboardRefresh(logger: ScenePerformanceLogger, index: number): void {
+  const operationId = `refresh-${index}`;
+  const timestamp = index * 10;
+
+  logger.onDashboardInteractionStart({
+    interactionType: 'refresh',
+    operationId,
+    timestamp,
+  } as performanceUtils.DashboardInteractionStartData);
+  logger.onDashboardInteractionMilestone({
+    operationId: `milestone-${operationId}`,
+    milestone: 'queries-started',
+    timestamp: timestamp + 1,
+  } as performanceUtils.DashboardInteractionMilestoneData);
+  logger.onPanelOperationStart({
+    panelId: '1',
+    panelKey: 'panel-1',
+    pluginId: 'timeseries',
+    operation: 'render',
+    operationId,
+    timestamp: timestamp + 2,
+    metadata: {},
+  } as performanceUtils.PanelPerformanceData);
+  logger.onPanelOperationComplete({
+    panelId: '1',
+    panelKey: 'panel-1',
+    pluginId: 'timeseries',
+    operation: 'render',
+    operationId,
+    timestamp: timestamp + 3,
+    duration: 1,
+    metadata: {},
+  } as performanceUtils.PanelPerformanceData);
+  logger.onPanelOperationStart({
+    panelId: '2',
+    panelKey: 'panel-2',
+    pluginId: 'timeseries',
+    operation: 'render',
+    operationId: `cancelled-${operationId}`,
+    timestamp: timestamp + 4,
+    metadata: {},
+  } as performanceUtils.PanelPerformanceData);
+  logger.onDashboardInteractionComplete({
+    interactionType: 'refresh',
+    operationId,
+    timestamp: timestamp + 5,
+    duration: 5,
+    networkDuration: 0,
+    longFramesCount: 0,
+    longFramesTotalTime: 0,
+  } as performanceUtils.DashboardInteractionCompleteData);
+}
+
+describe('ScenePerformanceLogger', () => {
+  setupNodePerformance();
+
+  it('does not retain owned entries across dashboard refreshes', () => {
+    const logger = new ScenePerformanceLogger();
+    performance.mark('unrelated-start');
+    performance.mark('unrelated-end');
+    performance.measure('unrelated-measure', 'unrelated-start', 'unrelated-end');
+
+    for (let index = 0; index < 100; index++) {
+      runDashboardRefresh(logger, index);
+    }
+
+    expect(performance.getEntriesByType('mark').filter(({ name }) => name.startsWith('scenes.'))).toHaveLength(0);
+    expect(performance.getEntriesByType('measure').filter(({ name }) => name.startsWith('scenes.'))).toHaveLength(0);
+    expect(performance.getEntriesByName('unrelated-start', 'mark')).toHaveLength(1);
+    expect(performance.getEntriesByName('unrelated-end', 'mark')).toHaveLength(1);
+    expect(performance.getEntriesByName('unrelated-measure', 'measure')).toHaveLength(1);
+  });
+
+  it('publishes late completions without fabricating missing durations', async () => {
+    const logger = new ScenePerformanceLogger();
+    const observedEntries = observePerformanceEntries();
+    const operation = {
+      panelId: '1',
+      panelKey: 'panel-1',
+      pluginId: 'timeseries',
+      operation: 'render',
+      operationId: 'late-render',
+      timestamp: 1,
+      metadata: {},
+    } as performanceUtils.PanelPerformanceData;
+
+    logger.onDashboardInteractionStart({
+      interactionType: 'refresh',
+      operationId: 'refresh',
+      timestamp: 0,
+    } as performanceUtils.DashboardInteractionStartData);
+    logger.onDashboardInteractionMilestone({
+      interactionType: 'refresh',
+      operationId: 'milestone-refresh',
+      milestone: 'queries-started',
+      timestamp: 0.5,
+    } as performanceUtils.DashboardInteractionMilestoneData);
+    logger.onPanelOperationStart(operation);
+    logger.onDashboardInteractionComplete({
+      interactionType: 'refresh',
+      operationId: 'refresh',
+      timestamp: 2,
+      networkDuration: 0,
+      longFramesCount: 0,
+      longFramesTotalTime: 0,
+    } as performanceUtils.DashboardInteractionCompleteData);
+
+    logger.onDashboardInteractionStart({
+      interactionType: 'refresh',
+      operationId: 'overlapping-refresh',
+      timestamp: 2.5,
+    } as performanceUtils.DashboardInteractionStartData);
+
+    expect(performance.getEntriesByName('scenes.panel.render.start.panel-1.late-render', 'mark')).toHaveLength(0);
+
+    logger.onPanelOperationComplete({ ...operation, timestamp: 3, duration: 2 });
+
+    expect(performance.getEntriesByName('scenes.panel.render.start.panel-1.late-render', 'mark')).toHaveLength(0);
+    expect(performance.getEntriesByName('scenes.panel.render.duration.panel-1.late-render', 'measure')).toHaveLength(0);
+    const entries = await observedEntries;
+    expect(entries).toEqual(
+      expect.arrayContaining([
+        {
+          name: 'scenes.dashboard.interaction.start.refresh',
+          startTime: 0,
+          duration: 0,
+        },
+        {
+          name: 'scenes.dashboard.milestone.queries-started.milestone-refresh',
+          startTime: 0.5,
+          duration: 0,
+        },
+        {
+          name: 'scenes.panel.render.start.panel-1.late-render',
+          startTime: 1,
+          duration: 0,
+        },
+        {
+          name: 'scenes.panel.render.end.panel-1.late-render',
+          startTime: 3,
+          duration: 0,
+        },
+        {
+          name: 'scenes.panel.render.duration.panel-1.late-render',
+          startTime: 1,
+          duration: 2,
+        },
+      ])
+    );
+    expect(entries.map(({ name }) => name)).not.toContain('scenes.dashboard.interaction.duration.refresh');
+  });
+});

--- a/public/app/features/dashboard/services/ScenePerformanceLogger.ts
+++ b/public/app/features/dashboard/services/ScenePerformanceLogger.ts
@@ -37,11 +37,10 @@ export class ScenePerformanceLogger implements performanceUtils.ScenePerformance
 
   onDashboardInteractionComplete = (data: performanceUtils.DashboardInteractionCompleteData): void => {
     const dashboardEndMark = PERFORMANCE_MARKS.DASHBOARD_INTERACTION_END(data.operationId);
-    const dashboardStartMark = PERFORMANCE_MARKS.DASHBOARD_INTERACTION_START(data.operationId);
     const dashboardMeasureName = PERFORMANCE_MEASURES.DASHBOARD_INTERACTION(data.operationId);
 
     createPerformanceMark(dashboardEndMark, data.timestamp);
-    createPerformanceMeasure(dashboardMeasureName, dashboardStartMark, dashboardEndMark);
+    createPerformanceMeasure(dashboardMeasureName, data.timestamp, data.duration);
 
     this.panelGroupsOpen.clear();
   };
@@ -80,11 +79,10 @@ export class ScenePerformanceLogger implements performanceUtils.ScenePerformance
 
   onQueryComplete = (data: performanceUtils.QueryPerformanceData): void => {
     const queryEndMark = PERFORMANCE_MARKS.QUERY_END(data.origin, data.queryId);
-    const queryStartMark = PERFORMANCE_MARKS.QUERY_START(data.origin, data.queryId);
     const queryMeasureName = PERFORMANCE_MEASURES.QUERY(data.origin, data.queryId);
 
     createPerformanceMark(queryEndMark, data.timestamp);
-    createPerformanceMeasure(queryMeasureName, queryStartMark, queryEndMark);
+    createPerformanceMeasure(queryMeasureName, data.timestamp, data.duration);
 
     const duration = (data.duration || 0).toFixed(1);
     const slowWarning = (data.duration || 0) > SLOW_OPERATION_THRESHOLD_MS ? ' ⚠️ SLOW' : '';
@@ -155,44 +153,29 @@ export class ScenePerformanceLogger implements performanceUtils.ScenePerformance
 
     switch (operation) {
       case 'query':
-        const startMark = PERFORMANCE_MARKS.PANEL_QUERY_START(panelKey, operationId);
-        const endMark = PERFORMANCE_MARKS.PANEL_QUERY_END(panelKey, operationId);
         const measureName = PERFORMANCE_MEASURES.PANEL_QUERY(panelKey, operationId);
-        createPerformanceMeasure(measureName, startMark, endMark);
+        createPerformanceMeasure(measureName, data.timestamp, data.duration);
         break;
 
       case 'plugin-load':
-        const pluginStartMark = PERFORMANCE_MARKS.PANEL_PLUGIN_LOAD_START(panelKey, operationId);
-        const pluginEndMark = PERFORMANCE_MARKS.PANEL_PLUGIN_LOAD_END(panelKey, operationId);
         const pluginMeasureName = PERFORMANCE_MEASURES.PANEL_PLUGIN_LOAD(panelKey, operationId);
-        createPerformanceMeasure(pluginMeasureName, pluginStartMark, pluginEndMark);
+        createPerformanceMeasure(pluginMeasureName, data.timestamp, data.duration);
         break;
 
       case 'fieldConfig':
-        const fieldConfigStartMark = PERFORMANCE_MARKS.PANEL_FIELD_CONFIG_START(panelKey, operationId);
-        const fieldConfigEndMark = PERFORMANCE_MARKS.PANEL_FIELD_CONFIG_END(panelKey, operationId);
         const fieldConfigMeasureName = PERFORMANCE_MEASURES.PANEL_FIELD_CONFIG(panelKey, operationId);
-        createPerformanceMeasure(fieldConfigMeasureName, fieldConfigStartMark, fieldConfigEndMark);
+        createPerformanceMeasure(fieldConfigMeasureName, data.timestamp, data.duration);
         break;
 
       case 'render':
-        const renderStartMark = PERFORMANCE_MARKS.PANEL_RENDER_START(panelKey, operationId);
-        const renderEndMark = PERFORMANCE_MARKS.PANEL_RENDER_END(panelKey, operationId);
         const renderMeasureName = PERFORMANCE_MEASURES.PANEL_RENDER(panelKey, operationId);
-        createPerformanceMeasure(renderMeasureName, renderStartMark, renderEndMark);
+        createPerformanceMeasure(renderMeasureName, data.timestamp, data.duration);
         break;
 
       case 'transform':
         const transformationId = data.metadata.transformationId;
-        const transformStartMark = PERFORMANCE_MARKS.PANEL_TRANSFORM_START(panelKey, transformationId, operationId);
-
-        const isError = data.metadata.error || data.metadata.success === false;
-        const transformEndMark = isError
-          ? PERFORMANCE_MARKS.PANEL_TRANSFORM_ERROR(panelKey, transformationId, operationId)
-          : PERFORMANCE_MARKS.PANEL_TRANSFORM_END(panelKey, transformationId, operationId);
-
         const transformMeasureName = PERFORMANCE_MEASURES.PANEL_TRANSFORM(panelKey, transformationId, operationId);
-        createPerformanceMeasure(transformMeasureName, transformStartMark, transformEndMark);
+        createPerformanceMeasure(transformMeasureName, data.timestamp, data.duration);
         break;
 
       default:

--- a/public/app/features/dashboard/services/dashboard-render-performance-profiling.md
+++ b/public/app/features/dashboard/services/dashboard-render-performance-profiling.md
@@ -103,7 +103,7 @@ const payload = {
   jsHeapSizeLimit: e.jsHeapSizeLimit,
   longFramesCount: e.longFramesCount,
   longFramesTotalTime: e.longFramesTotalTime,
-  timeSinceBoot: performance.measure('time_since_boot', 'frontend_boot_js_done_time_seconds').duration,
+  timeSinceBoot: getTimeSinceBoot(),
 };
 
 reportInteraction('dashboard_render', {

--- a/public/app/features/dashboard/services/performanceTestUtils.ts
+++ b/public/app/features/dashboard/services/performanceTestUtils.ts
@@ -1,0 +1,41 @@
+import { performance as nodePerformance, PerformanceObserver as NodePerformanceObserver } from 'node:perf_hooks';
+
+interface ObservedPerformanceEntry {
+  name: string;
+  startTime: number;
+  duration: number;
+}
+
+export function observePerformanceEntries(): Promise<ObservedPerformanceEntry[]> {
+  return new Promise((resolve) => {
+    const observer = new NodePerformanceObserver((entries, currentObserver) => {
+      currentObserver.disconnect();
+      resolve(entries.getEntries().map(({ name, startTime, duration }) => ({ name, startTime, duration })));
+    });
+    observer.observe({ entryTypes: ['mark', 'measure'] });
+  });
+}
+
+export function setupNodePerformance(): void {
+  // Node implements the User Timing APIs under test but omits unrelated browser-only fields.
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  const browserPerformance = nodePerformance as unknown as Performance;
+
+  beforeAll(() => {
+    jest.spyOn(globalThis, 'performance', 'get').mockReturnValue(browserPerformance);
+  });
+
+  beforeEach(() => {
+    performance.clearMarks();
+    performance.clearMeasures();
+  });
+
+  afterEach(() => {
+    performance.clearMarks();
+    performance.clearMeasures();
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+}

--- a/public/app/features/dashboard/services/performanceUtils.test.ts
+++ b/public/app/features/dashboard/services/performanceUtils.test.ts
@@ -1,0 +1,53 @@
+import { observePerformanceEntries, setupNodePerformance } from './performanceTestUtils';
+import { createPerformanceMark, createPerformanceMeasure, getTimeSinceBoot } from './performanceUtils';
+
+describe('performanceUtils', () => {
+  setupNodePerformance();
+
+  beforeEach(() => {
+    performance.mark('frontend_boot_js_done_time_seconds', { startTime: 0 });
+    performance.mark('unrelated-mark');
+  });
+
+  it('returns the duration without retaining its measure or clearing other marks', () => {
+    const durations = Array.from({ length: 100 }, getTimeSinceBoot);
+
+    expect(durations.every(Number.isFinite)).toBe(true);
+
+    expect(performance.getEntriesByName('time_since_boot', 'measure')).toHaveLength(0);
+    expect(performance.getEntriesByName('frontend_boot_js_done_time_seconds', 'mark')).toHaveLength(1);
+    expect(performance.getEntriesByName('unrelated-mark', 'mark')).toHaveLength(1);
+  });
+
+  it('publishes transient marks and measures to performance observers', async () => {
+    const observedEntries = observePerformanceEntries();
+
+    createPerformanceMark('observer-start', 10);
+    createPerformanceMark('observer-end', 25);
+    createPerformanceMeasure('observer-measure', 25, 15);
+    createPerformanceMeasure('zero-duration-measure', 25, 0);
+    createPerformanceMeasure('missing-duration-measure', 25, undefined);
+    createPerformanceMeasure('negative-duration-measure', 25, -1);
+    createPerformanceMeasure('non-finite-duration-measure', 25, Number.POSITIVE_INFINITY);
+    createPerformanceMeasure('non-finite-end-measure', Number.NaN, 1);
+
+    expect(performance.getEntriesByName('observer-start', 'mark')).toHaveLength(0);
+    expect(performance.getEntriesByName('observer-end', 'mark')).toHaveLength(0);
+    expect(performance.getEntriesByName('observer-measure', 'measure')).toHaveLength(0);
+    expect(performance.getEntriesByName('zero-duration-measure', 'measure')).toHaveLength(0);
+    const entries = await observedEntries;
+    expect(entries).toEqual(
+      expect.arrayContaining([
+        { name: 'observer-start', startTime: 10, duration: 0 },
+        { name: 'observer-end', startTime: 25, duration: 0 },
+        { name: 'observer-measure', startTime: 10, duration: 15 },
+        { name: 'zero-duration-measure', startTime: 25, duration: 0 },
+      ])
+    );
+    const entryNames = entries.map(({ name }) => name);
+    expect(entryNames).not.toContain('missing-duration-measure');
+    expect(entryNames).not.toContain('negative-duration-measure');
+    expect(entryNames).not.toContain('non-finite-duration-measure');
+    expect(entryNames).not.toContain('non-finite-end-measure');
+  });
+});

--- a/public/app/features/dashboard/services/performanceUtils.ts
+++ b/public/app/features/dashboard/services/performanceUtils.ts
@@ -39,6 +39,17 @@ function hasPerformanceMemory(perf: Performance): perf is PerformanceWithMemory 
 }
 
 /**
+ * Measures time since the shared frontend boot mark without retaining the temporary measure.
+ */
+export function getTimeSinceBoot(): number {
+  try {
+    return performance.measure('time_since_boot', 'frontend_boot_js_done_time_seconds').duration;
+  } finally {
+    performance.clearMeasures('time_since_boot');
+  }
+}
+
+/**
  * Safely get performance memory metrics (Chrome-specific, non-standard)
  * Returns zero values for browsers without performance.memory support
  */
@@ -105,7 +116,7 @@ export function writePerformanceGroupEnd(): void {
 }
 
 /**
- * Safely creates a performance mark, ignoring errors if the Performance API is not available.
+ * Safely publishes a performance mark without retaining it in the performance timeline.
  */
 export function createPerformanceMark(name: string, timestamp?: number): void {
   try {
@@ -118,22 +129,46 @@ export function createPerformanceMark(name: string, timestamp?: number): void {
     }
   } catch (error) {
     console.error(`❌ Failed to create performance mark: ${name}`, { timestamp, error });
+  } finally {
+    clearPerformanceMark(name);
+  }
+}
+
+function clearPerformanceMark(name: string): void {
+  try {
+    if (typeof performance !== 'undefined' && performance.clearMarks) {
+      performance.clearMarks(name);
+    }
+  } catch (error) {
+    console.error(`❌ Failed to clear performance mark: ${name}`, { error });
   }
 }
 
 /**
- * Safely creates a performance measure, ignoring errors if the Performance API is not available.
+ * Safely publishes a performance measure without retaining it in the performance timeline.
+ * Missing or invalid timing data is not published.
  */
-export function createPerformanceMeasure(name: string, startMark: string, endMark?: string): void {
+export function createPerformanceMeasure(name: string, endTime: number, duration: number | undefined): void {
   try {
-    if (typeof performance !== 'undefined' && performance.measure) {
-      if (endMark) {
-        performance.measure(name, startMark, endMark);
-      } else {
-        performance.measure(name, startMark);
-      }
+    if (
+      typeof performance !== 'undefined' &&
+      performance.measure &&
+      Number.isFinite(endTime) &&
+      duration !== undefined &&
+      Number.isFinite(duration) &&
+      duration >= 0
+    ) {
+      performance.measure(name, { end: endTime, duration });
     }
   } catch (error) {
-    console.error(`❌ Failed to create performance measure: ${name}`, { startMark, endMark, error });
+    console.error(`❌ Failed to create performance measure: ${name}`, { endTime, duration, error });
+  } finally {
+    try {
+      if (typeof performance !== 'undefined' && performance.clearMeasures) {
+        performance.clearMeasures(name);
+      }
+    } catch (error) {
+      console.error(`❌ Failed to clear performance measure: ${name}`, { error });
+    }
   }
 }


### PR DESCRIPTION
**What is this feature?**

This prevents Scene dashboard performance instrumentation from retaining an unbounded number of User Timing entries in the browser's Performance Timeline.

Performance marks are emitted and then cleared by their exact name. Measures are calculated from the completion event's timestamp and duration, emitted, and then cleared by their exact name. Temporary `time_since_boot` measures are also cleared while preserving the shared frontend boot mark.

**Why do we need this feature?**

When `dashboard_performance_metrics` is enabled, every dashboard load and refresh creates uniquely named marks and measures for dashboard, panel, and query operations.

These entries were never removed. Long-running or frequently refreshing dashboards therefore accumulated Performance Timeline entries indefinitely, eventually causing excessive browser memory usage and out-of-memory crashes.

Scene completion events already contain the end timestamp and duration, so start and end marks do not need to remain buffered to calculate the span.

**Who is this feature for?**

Users running dashboards with dashboard performance metrics enabled, particularly long-running dashboards using automatic refresh.

It also preserves live User Timing instrumentation for developers and active performance observers without using the browser timeline as permanent storage.

**Which issue(s) does this PR fix?**:

Fixes #130337

**Special notes for your reviewer:**

### Behavior and tradeoffs

Entry names and intended span semantics remain unchanged. An active `PerformanceObserver` continues to receive the emitted marks and measures.

The intentional behavior change is that completed entries are no longer available afterward through `performance.getEntries*()` or to an observer registered later with `buffered: true`. Consumers must observe or record the events while the dashboard interaction occurs.

Measures now use the completion event's `timestamp` and `duration` rather than correlating retained start and end marks. Current Scene completion emitters were audited and provide these values. Missing, negative, or non-finite timing data is ignored; a valid zero-duration operation is still emitted.

Cleanup uses exact entry names. It does not clear unrelated application or third-party instrumentation, nor the shared frontend boot mark.

### Validation

A regression harness demonstrated the original linear accumulation:

- 10 refreshes: 40 marks and 20 measures retained
- 100 refreshes: 400 marks and 200 measures retained

With this change, no Scene entries remain buffered.

A Chromium soak using a 12-panel TestData dashboard and 500 refreshes produced:

- 48,747 Scene marks delivered to an active observer
- 19,107 Scene measures delivered to an active observer
- 0 Scene marks or measures retained at every checkpoint
- Forced-GC JavaScript heap remained approximately flat: 38.7 MiB to 40.2 MiB
- No failed dashboard queries or server responses

As an A/B control, suppressing only the exact-name cleanup caused all 67,854 emitted entries to remain buffered, recreating the reported retention behavior.

The focused Jest suites, type checking, linting, formatting, production frontend build, and profiling documentation checks pass.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
