### PR TITLE
Select/Combobox: Show better focus ring for keyboard actions

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -1,7 +1,7 @@
 import { cx } from '@emotion/css';
 import { useVirtualizer, type Range } from '@tanstack/react-virtual';
 import { useCombobox } from 'downshift';
-import React, { type ComponentProps, useCallback, useId, useMemo } from 'react';
+import React, { type ComponentProps, useCallback, useId, useMemo, useState } from 'react';
 
 import { t } from '@grafana/i18n';
 
@@ -19,7 +19,7 @@ import { getComboboxStyles, MENU_OPTION_HEIGHT, MENU_OPTION_HEIGHT_DESCRIPTION }
 import { type ComboboxOption } from './types';
 import { useComboboxFloat } from './useComboboxFloat';
 import { useOptions } from './useOptions';
-import { isNewGroup } from './utils';
+import { isNewGroup, isPointerStateChange } from './utils';
 
 // TODO: It would be great if ComboboxOption["label"] was more generic so that if consumers do pass it in (for async),
 // then the onChange handler emits ComboboxOption with the label as non-undefined.
@@ -224,6 +224,8 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
 
   const styles = useStyles2(getComboboxStyles);
 
+  const [showFocusRing, setShowFocusRing] = useState(false);
+
   const onIsOpenChangeHandler = useCallback(
     (changes: { isOpen: boolean; inputValue?: string }) => {
       onIsOpenChangeProp?.(changes.isOpen);
@@ -338,6 +340,8 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
       }
     },
     onStateChange: ({ inputValue: newInputValue, type, selectedItem: newSelectedItem }) => {
+      setShowFocusRing(!isPointerStateChange(type));
+
       switch (type) {
         case useCombobox.stateChangeTypes.InputChange:
           updateOptions(newInputValue ?? '');
@@ -467,6 +471,7 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
               loading={loading}
               options={filteredOptions}
               highlightedIndex={highlightedIndex}
+              showFocusRing={showFocusRing}
               selectedItems={selectedItem ? [selectedItem] : []}
               scrollRef={scrollRef}
               getItemProps={getItemProps}

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -15,7 +15,12 @@ import { Portal } from '../Portal/Portal';
 import { ComboboxList } from './ComboboxList';
 import { SuffixIcon } from './SuffixIcon';
 import { itemToString } from './filter';
-import { getComboboxStyles, MENU_OPTION_HEIGHT, MENU_OPTION_HEIGHT_DESCRIPTION } from './getComboboxStyles';
+import {
+  getComboboxStyles,
+  MENU_OPTION_HEIGHT,
+  MENU_OPTION_HEIGHT_DESCRIPTION,
+  MENU_PADDING,
+} from './getComboboxStyles';
 import { type ComboboxOption } from './types';
 import { useComboboxFloat } from './useComboboxFloat';
 import { useOptions } from './useOptions';
@@ -279,7 +284,7 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
       if (firstGroupItem && hasGroup) {
         itemHeight += MENU_OPTION_HEIGHT;
       }
-      return itemHeight;
+      return itemHeight + 2 * MENU_PADDING;
     },
     getItemKey: (index: number) => filteredOptions[index]?.value ?? index,
     overscan: VIRTUAL_OVERSCAN_ITEMS,

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -284,11 +284,13 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
       if (firstGroupItem && hasGroup) {
         itemHeight += MENU_OPTION_HEIGHT;
       }
-      return itemHeight + 2 * MENU_PADDING;
+      return itemHeight;
     },
     getItemKey: (index: number) => filteredOptions[index]?.value ?? index,
     overscan: VIRTUAL_OVERSCAN_ITEMS,
     rangeExtractor,
+    paddingStart: MENU_PADDING,
+    paddingEnd: MENU_PADDING,
   });
 
   const {

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -19,7 +19,7 @@ import { getComboboxStyles, MENU_OPTION_HEIGHT, MENU_OPTION_HEIGHT_DESCRIPTION }
 import { type ComboboxOption } from './types';
 import { useComboboxFloat } from './useComboboxFloat';
 import { useOptions } from './useOptions';
-import { isNewGroup, isPointerStateChange } from './utils';
+import { isNewGroup, isKeyboardEvent } from './utils';
 
 // TODO: It would be great if ComboboxOption["label"] was more generic so that if consumers do pass it in (for async),
 // then the onChange handler emits ComboboxOption with the label as non-undefined.
@@ -340,7 +340,7 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
       }
     },
     onStateChange: ({ inputValue: newInputValue, type, selectedItem: newSelectedItem }) => {
-      setShowFocusRing(!isPointerStateChange(type));
+      setShowFocusRing(isKeyboardEvent(type));
 
       switch (type) {
         case useCombobox.stateChangeTypes.InputChange:

--- a/packages/grafana-ui/src/components/Combobox/ComboboxList.tsx
+++ b/packages/grafana-ui/src/components/Combobox/ComboboxList.tsx
@@ -19,6 +19,8 @@ const VIRTUAL_OVERSCAN_ITEMS = 4;
 interface ComboboxListProps<T extends string | number> {
   options: Array<ComboboxOption<T>>;
   highlightedIndex: number | null;
+  /** Whether the highlighted option should show a focus ring, rather than just the muted highlight */
+  showFocusRing?: boolean;
   selectedItems?: Array<ComboboxOption<T>>;
   scrollRef: React.RefObject<HTMLDivElement | null>;
   getItemProps: UseComboboxPropGetters<ComboboxOption<T>>['getItemProps'];
@@ -32,6 +34,7 @@ interface ComboboxListProps<T extends string | number> {
 export const ComboboxList = <T extends string | number>({
   options,
   highlightedIndex,
+  showFocusRing = false,
   selectedItems = [],
   scrollRef,
   getItemProps,
@@ -77,11 +80,12 @@ export const ComboboxList = <T extends string | number>({
   const allItemsSelected = enableAllOption && options.length > 1 && selectedItems.length === options.length - 1;
 
   return (
-    <ScrollContainer showScrollIndicators maxHeight="inherit" ref={scrollRef} padding={0.5}>
+    <ScrollContainer showScrollIndicators maxHeight="inherit" ref={scrollRef}>
       <div style={{ height: rowVirtualizer.getTotalSize() }} className={styles.menuUlContainer}>
         {rowVirtualizer.getVirtualItems().map((virtualRow, index, allVirtualRows) => {
           const item = options[virtualRow.index];
           const startingNewGroup = isNewGroup(item, options[virtualRow.index - 1]);
+          const isHighlighted = highlightedIndex === virtualRow.index && !item.infoOption;
 
           // Find the item that renders the group header. It can be this same item if this is rendering it.
           const groupHeaderIndex = allVirtualRows.find((row) => {
@@ -127,7 +131,8 @@ export const ComboboxList = <T extends string | number>({
                 className={cx(
                   styles.option,
                   !isMultiSelect && isOptionSelected(item) && styles.optionSelected,
-                  highlightedIndex === virtualRow.index && !item.infoOption && styles.optionFocused,
+                  isHighlighted && styles.optionFocused,
+                  isHighlighted && showFocusRing && styles.optionFocusRing,
                   item.infoOption && styles.optionInfo
                 )}
                 {...getItemProps({

--- a/packages/grafana-ui/src/components/Combobox/ComboboxList.tsx
+++ b/packages/grafana-ui/src/components/Combobox/ComboboxList.tsx
@@ -10,7 +10,12 @@ import { Stack } from '../Layout/Stack/Stack';
 import { ScrollContainer } from '../ScrollContainer/ScrollContainer';
 
 import { AsyncError, LoadingOptions, NotFoundError } from './MessageRows';
-import { getComboboxStyles, MENU_OPTION_HEIGHT, MENU_OPTION_HEIGHT_DESCRIPTION } from './getComboboxStyles';
+import {
+  getComboboxStyles,
+  MENU_OPTION_HEIGHT,
+  MENU_OPTION_HEIGHT_DESCRIPTION,
+  MENU_PADDING,
+} from './getComboboxStyles';
 import { ALL_OPTION_VALUE, type ComboboxOption } from './types';
 import { isNewGroup } from './utils';
 
@@ -70,6 +75,11 @@ export const ComboboxList = <T extends string | number>({
     estimateSize,
     getItemKey: (index: number) => options[index]?.value ?? index,
     overscan: VIRTUAL_OVERSCAN_ITEMS,
+    // Vertical padding belongs to the virtualizer rather than CSS so that row offsets, the total
+    // size and scrollToIndex all account for it. Padding it in CSS instead would shift every row
+    // down without the virtualizer knowing, and scrolling would stop short of the focus ring.
+    paddingStart: MENU_PADDING,
+    paddingEnd: MENU_PADDING,
   });
 
   const isOptionSelected = useCallback(

--- a/packages/grafana-ui/src/components/Combobox/MultiCombobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/MultiCombobox.tsx
@@ -24,6 +24,7 @@ import { useComboboxFloat } from './useComboboxFloat';
 import { MAX_SHOWN_ITEMS, useMeasureMulti } from './useMeasureMulti';
 import { useMultiInputAutoSize } from './useMultiInputAutoSize';
 import { useOptions } from './useOptions';
+import { isPointerStateChange } from './utils';
 
 interface MultiComboboxBaseProps<T extends string | number>
   extends Omit<ComboboxBaseProps<T>, 'value' | 'onChange' | 'isClearable'> {
@@ -64,6 +65,7 @@ export const MultiCombobox = <T extends string | number>(props: MultiComboboxPro
 
   const styles = useStyles2(getComboboxStyles);
   const [inputValue, setInputValue] = useState('');
+  const [showFocusRing, setShowFocusRing] = useState(false);
 
   const fieldContext = useFieldContext();
   const id = idProp ?? fieldContext.id;
@@ -222,6 +224,8 @@ export const MultiCombobox = <T extends string | number>(props: MultiComboboxPro
     },
 
     onStateChange: ({ inputValue: newInputValue, type, selectedItem: newSelectedItem }) => {
+      setShowFocusRing(!isPointerStateChange(type));
+
       switch (type) {
         case useCombobox.stateChangeTypes.InputKeyDownEnter:
         case useCombobox.stateChangeTypes.ItemClick:
@@ -392,6 +396,7 @@ export const MultiCombobox = <T extends string | number>(props: MultiComboboxPro
               loading={loading}
               options={options}
               highlightedIndex={highlightedIndex}
+              showFocusRing={showFocusRing}
               selectedItems={selectedItems}
               scrollRef={scrollRef}
               getItemProps={getItemProps}

--- a/packages/grafana-ui/src/components/Combobox/MultiCombobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/MultiCombobox.tsx
@@ -24,7 +24,7 @@ import { useComboboxFloat } from './useComboboxFloat';
 import { MAX_SHOWN_ITEMS, useMeasureMulti } from './useMeasureMulti';
 import { useMultiInputAutoSize } from './useMultiInputAutoSize';
 import { useOptions } from './useOptions';
-import { isPointerStateChange } from './utils';
+import { isKeyboardEvent } from './utils';
 
 interface MultiComboboxBaseProps<T extends string | number>
   extends Omit<ComboboxBaseProps<T>, 'value' | 'onChange' | 'isClearable'> {
@@ -224,7 +224,7 @@ export const MultiCombobox = <T extends string | number>(props: MultiComboboxPro
     },
 
     onStateChange: ({ inputValue: newInputValue, type, selectedItem: newSelectedItem }) => {
-      setShowFocusRing(!isPointerStateChange(type));
+      setShowFocusRing(isKeyboardEvent(type));
 
       switch (type) {
         case useCombobox.stateChangeTypes.InputKeyDownEnter:

--- a/packages/grafana-ui/src/components/Combobox/getComboboxStyles.ts
+++ b/packages/grafana-ui/src/components/Combobox/getComboboxStyles.ts
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 
-import { getFocusStyles } from '../../internal';
+import { getFocusStyles } from '../../themes/mixins';
 
 // We need a px font size to accurately measure the width of items.
 // This should be in sync with the body font size in the theme.

--- a/packages/grafana-ui/src/components/Combobox/getComboboxStyles.ts
+++ b/packages/grafana-ui/src/components/Combobox/getComboboxStyles.ts
@@ -10,6 +10,8 @@ export const MENU_ITEM_FONT_SIZE = 14;
 export const MENU_ITEM_DESCRIPTION_FONT_SIZE = 12;
 export const MENU_ITEM_FONT_WEIGHT = 500;
 export const MENU_ITEM_PADDING = 8;
+// Padding around the option list, so the focused option's focus ring isn't clipped by the menu.
+export const MENU_PADDING = 4;
 const MENU_ITEM_GAP = 2;
 const MENU_ITEM_LINE_HEIGHT = 1.5;
 
@@ -20,7 +22,6 @@ export const MENU_OPTION_HEIGHT_DESCRIPTION =
 export const POPOVER_MAX_HEIGHT = MENU_OPTION_HEIGHT * 8.5;
 
 export const getComboboxStyles = (theme: GrafanaTheme2) => {
-  const menuPadding = theme.spacing(0.5);
   return {
     menuClosed: css({
       display: 'none',
@@ -37,7 +38,8 @@ export const getComboboxStyles = (theme: GrafanaTheme2) => {
     menuUlContainer: css({
       label: 'combobox-menu-ul-container',
       listStyle: 'none',
-      padding: menuPadding,
+      // Horizontal only - the vertical padding comes from the virtualizer's paddingStart/paddingEnd
+      padding: `0 ${MENU_PADDING}px`,
     }),
 
     // The wrapper around the group header and option, not the option itself.
@@ -45,7 +47,7 @@ export const getComboboxStyles = (theme: GrafanaTheme2) => {
     listItem: css({
       label: 'list-item',
       position: 'absolute',
-      width: `calc(100% - ${menuPadding} * 2)`, // account for padding on the menu container
+      width: `calc(100% - ${MENU_PADDING * 2}px)`, // account for padding on the menu container
     }),
 
     optionGroupHeader: css({

--- a/packages/grafana-ui/src/components/Combobox/getComboboxStyles.ts
+++ b/packages/grafana-ui/src/components/Combobox/getComboboxStyles.ts
@@ -2,6 +2,8 @@ import { css } from '@emotion/css';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 
+import { getFocusStyles } from '../../internal';
+
 // We need a px font size to accurately measure the width of items.
 // This should be in sync with the body font size in the theme.
 export const MENU_ITEM_FONT_SIZE = 14;
@@ -18,6 +20,7 @@ export const MENU_OPTION_HEIGHT_DESCRIPTION =
 export const POPOVER_MAX_HEIGHT = MENU_OPTION_HEIGHT * 8.5;
 
 export const getComboboxStyles = (theme: GrafanaTheme2) => {
+  const menuPadding = theme.spacing(0.5);
   return {
     menuClosed: css({
       display: 'none',
@@ -34,6 +37,7 @@ export const getComboboxStyles = (theme: GrafanaTheme2) => {
     menuUlContainer: css({
       label: 'combobox-menu-ul-container',
       listStyle: 'none',
+      padding: menuPadding,
     }),
 
     // The wrapper around the group header and option, not the option itself.
@@ -41,7 +45,7 @@ export const getComboboxStyles = (theme: GrafanaTheme2) => {
     listItem: css({
       label: 'list-item',
       position: 'absolute',
-      width: '100%',
+      width: `calc(100% - ${menuPadding} * 2)`, // account for padding on the menu container
     }),
 
     optionGroupHeader: css({
@@ -121,11 +125,14 @@ export const getComboboxStyles = (theme: GrafanaTheme2) => {
 
     optionFocused: css({
       label: 'combobox-option-focused',
-      // top: 0,
       background: theme.colors.action.focus,
       '@media (forced-colors: active), (prefers-contrast: more)': {
         border: `1px solid ${theme.colors.primary.border}`,
       },
+    }),
+    optionFocusRing: css({
+      label: 'combobox-option-focus-ring',
+      ...getFocusStyles(theme),
     }),
     optionSelected: css({
       background: theme.colors.action.selected,

--- a/packages/grafana-ui/src/components/Combobox/utils.ts
+++ b/packages/grafana-ui/src/components/Combobox/utils.ts
@@ -16,12 +16,7 @@ export const isNewGroup = <T extends string | number>(option: ComboboxOption<T>,
   return prevOption.group !== currentGroup;
 };
 
-/**
- * Downshift keeps DOM focus on the input and highlights options for mouse and pointer
- * interactions as well as keyboard nav, so `:focus-visible` can't be used to decide when to
- * draw a focus ring on an option. Instead, work it out from the downshift state change type.
- */
-export const isPointerStateChange = (type: string) => type.includes('mouse') || type.includes('click');
+export const isKeyboardEvent = (type: string) => type.includes('keydown');
 
 /**
  * returns a ComboboxOption from a SelectableValue, or undefined if it could not be converted.

--- a/packages/grafana-ui/src/components/Combobox/utils.ts
+++ b/packages/grafana-ui/src/components/Combobox/utils.ts
@@ -1,4 +1,4 @@
-import { UseComboboxStateChangeTypes } from 'downshift';
+import { useCombobox, type UseComboboxStateChangeTypes } from 'downshift';
 
 import { isIconName, type SelectableValue } from '@grafana/data';
 
@@ -19,14 +19,14 @@ export const isNewGroup = <T extends string | number>(option: ComboboxOption<T>,
 };
 
 const KEYBOARD_STATE_CHANGE_TYPES: UseComboboxStateChangeTypes[] = [
-  UseComboboxStateChangeTypes.InputKeyDownArrowDown,
-  UseComboboxStateChangeTypes.InputKeyDownArrowUp,
-  UseComboboxStateChangeTypes.InputKeyDownEnd,
-  UseComboboxStateChangeTypes.InputKeyDownEnter,
-  UseComboboxStateChangeTypes.InputKeyDownEscape,
-  UseComboboxStateChangeTypes.InputKeyDownHome,
-  UseComboboxStateChangeTypes.InputKeyDownPageDown,
-  UseComboboxStateChangeTypes.InputKeyDownPageUp,
+  useCombobox.stateChangeTypes.InputKeyDownArrowDown,
+  useCombobox.stateChangeTypes.InputKeyDownArrowUp,
+  useCombobox.stateChangeTypes.InputKeyDownEnd,
+  useCombobox.stateChangeTypes.InputKeyDownEnter,
+  useCombobox.stateChangeTypes.InputKeyDownEscape,
+  useCombobox.stateChangeTypes.InputKeyDownHome,
+  useCombobox.stateChangeTypes.InputKeyDownPageDown,
+  useCombobox.stateChangeTypes.InputKeyDownPageUp,
 ];
 
 export const isKeyboardEvent = (type: UseComboboxStateChangeTypes) => KEYBOARD_STATE_CHANGE_TYPES.includes(type);

--- a/packages/grafana-ui/src/components/Combobox/utils.ts
+++ b/packages/grafana-ui/src/components/Combobox/utils.ts
@@ -1,3 +1,5 @@
+import { UseComboboxStateChangeTypes } from 'downshift';
+
 import { isIconName, type SelectableValue } from '@grafana/data';
 
 import { type ComboboxOption } from './types';
@@ -16,7 +18,18 @@ export const isNewGroup = <T extends string | number>(option: ComboboxOption<T>,
   return prevOption.group !== currentGroup;
 };
 
-export const isKeyboardEvent = (type: string) => type.includes('keydown');
+const KEYBOARD_STATE_CHANGE_TYPES: UseComboboxStateChangeTypes[] = [
+  UseComboboxStateChangeTypes.InputKeyDownArrowDown,
+  UseComboboxStateChangeTypes.InputKeyDownArrowUp,
+  UseComboboxStateChangeTypes.InputKeyDownEnd,
+  UseComboboxStateChangeTypes.InputKeyDownEnter,
+  UseComboboxStateChangeTypes.InputKeyDownEscape,
+  UseComboboxStateChangeTypes.InputKeyDownHome,
+  UseComboboxStateChangeTypes.InputKeyDownPageDown,
+  UseComboboxStateChangeTypes.InputKeyDownPageUp,
+];
+
+export const isKeyboardEvent = (type: UseComboboxStateChangeTypes) => KEYBOARD_STATE_CHANGE_TYPES.includes(type);
 
 /**
  * returns a ComboboxOption from a SelectableValue, or undefined if it could not be converted.

--- a/packages/grafana-ui/src/components/Combobox/utils.ts
+++ b/packages/grafana-ui/src/components/Combobox/utils.ts
@@ -17,6 +17,13 @@ export const isNewGroup = <T extends string | number>(option: ComboboxOption<T>,
 };
 
 /**
+ * Downshift keeps DOM focus on the input and highlights options for mouse and pointer
+ * interactions as well as keyboard nav, so `:focus-visible` can't be used to decide when to
+ * draw a focus ring on an option. Instead, work it out from the downshift state change type.
+ */
+export const isPointerStateChange = (type: string) => type.includes('mouse') || type.includes('click');
+
+/**
  * returns a ComboboxOption from a SelectableValue, or undefined if it could not be converted.
  * @param v - The SelectableValue to convert.
  * @returns The ComboboxOption, or undefined if it could not be converted.

--- a/packages/grafana-ui/src/components/Select/SelectBase.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.tsx
@@ -170,6 +170,9 @@ export function SelectBase<T, Rest = {}>({
   const [hasInputValue, setHasInputValue] = useState<boolean>(!!inputValue);
   // local state to track when menu is open - used to stop Escape key from propagating to parent overlays when menu is open
   const [open, setOpen] = useState(!!isOpen);
+  // react-select focuses an option as soon as the menu opens, so only draw a focus ring on it
+  // once the user has actually pressed a key
+  const [showFocusRing, setShowFocusRing] = useState(false);
 
   useImperativeHandle(selectRef, () => reactSelectRef.current!, []);
 
@@ -180,6 +183,7 @@ export function SelectBase<T, Rest = {}>({
 
   const handleMenuClose = useCallback(() => {
     setOpen(false);
+    setShowFocusRing(false);
     onCloseMenu?.();
   }, [onCloseMenu]);
 
@@ -190,6 +194,7 @@ export function SelectBase<T, Rest = {}>({
       if (event.key === 'Escape' && open) {
         event.stopPropagation();
       }
+      setShowFocusRing(true);
       onKeyDown?.(event);
     },
     [onKeyDown, open]
@@ -412,6 +417,7 @@ export function SelectBase<T, Rest = {}>({
             selectedCount: Array.isArray(selectedValue) ? selectedValue.length : undefined,
           }
         }
+        showFocusRing={showFocusRing}
         styles={selectStyles}
         className={className}
         autoWidth={width === 'auto'}

--- a/packages/grafana-ui/src/components/Select/SelectBase.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.tsx
@@ -170,8 +170,6 @@ export function SelectBase<T, Rest = {}>({
   const [hasInputValue, setHasInputValue] = useState<boolean>(!!inputValue);
   // local state to track when menu is open - used to stop Escape key from propagating to parent overlays when menu is open
   const [open, setOpen] = useState(!!isOpen);
-  // react-select focuses an option as soon as the menu opens, so only draw a focus ring on it
-  // once the user has actually pressed a key
   const [showFocusRing, setShowFocusRing] = useState(false);
 
   useImperativeHandle(selectRef, () => reactSelectRef.current!, []);

--- a/packages/grafana-ui/src/components/Select/SelectMenu.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectMenu.tsx
@@ -10,6 +10,7 @@ import { t, Trans } from '@grafana/i18n';
 import { useTheme2 } from '../../themes/ThemeContext';
 import { clearButtonStyles } from '../Button/Button';
 import { Icon } from '../Icon/Icon';
+import { Box } from '../Layout/Box/Box';
 import { ScrollContainer } from '../ScrollContainer/ScrollContainer';
 
 import { getSelectStyles } from './getSelectStyles';
@@ -53,16 +54,18 @@ export const SelectMenu = ({
       style={{ maxHeight }}
       aria-label={t('grafana-ui.select.menu-label', 'Select options menu')}
     >
-      <ScrollContainer ref={innerRef} maxHeight="inherit" overflowX="hidden" showScrollIndicators padding={0.5}>
-        {toggleAllOptions && (
-          <ToggleAllOption
-            state={toggleAllOptions.state}
-            optionComponent={optionsElement}
-            selectedCount={toggleAllOptions.selectedCount}
-            onClick={toggleAllOptions.selectAllClicked}
-          ></ToggleAllOption>
-        )}
-        {children}
+      <ScrollContainer ref={innerRef} maxHeight="inherit" overflowX="hidden" showScrollIndicators>
+        <Box padding={0.5} display="flex" direction="column" gap={0}>
+          {toggleAllOptions && (
+            <ToggleAllOption
+              state={toggleAllOptions.state}
+              optionComponent={optionsElement}
+              selectedCount={toggleAllOptions.selectedCount}
+              onClick={toggleAllOptions.selectAllClicked}
+            ></ToggleAllOption>
+          )}
+          {children}
+        </Box>
       </ScrollContainer>
     </div>
   );
@@ -72,9 +75,15 @@ SelectMenu.displayName = 'SelectMenu';
 
 const VIRTUAL_LIST_ITEM_HEIGHT = 37;
 const VIRTUAL_LIST_WIDTH_ESTIMATE_MULTIPLIER = 8;
-const VIRTUAL_LIST_PADDING = 8;
+const VIRTUAL_LIST_PADDING = 4;
 // Some list items have icons or checkboxes so we need some extra width
 const VIRTUAL_LIST_WIDTH_EXTRA = 58;
+
+// need to set position: relative on the inner element so that the absolutely positioned rows resolve against it.
+const VirtualInnerElement = React.forwardRef<HTMLDivElement, JSX.IntrinsicElements['div']>(
+  ({ style, ...rest }, ref) => <div ref={ref} style={{ ...style, position: 'relative' }} {...rest} />
+);
+VirtualInnerElement.displayName = 'VirtualInnerElement';
 
 // A virtualized version of the SelectMenu, descriptions for SelectableValue options not supported since those are of a variable height.
 //
@@ -178,20 +187,26 @@ export const VirtualizedSelectMenu = ({
   }
   const widthEstimate =
     longestOption * VIRTUAL_LIST_WIDTH_ESTIMATE_MULTIPLIER + VIRTUAL_LIST_PADDING * 2 + VIRTUAL_LIST_WIDTH_EXTRA;
-  const heightEstimate = Math.min(flattenedChildren.length * VIRTUAL_LIST_ITEM_HEIGHT, maxHeight);
+  const heightEstimate = Math.min(
+    flattenedChildren.length * VIRTUAL_LIST_ITEM_HEIGHT + VIRTUAL_LIST_PADDING * 2,
+    maxHeight
+  );
 
   return (
     <List
       outerRef={scrollRef}
       ref={listRef}
       className={styles.menu}
+      // Padding leaves room for the focused option's focus ring, which would otherwise be clipped.
+      style={{ padding: VIRTUAL_LIST_PADDING }}
+      innerElementType={VirtualInnerElement}
       height={heightEstimate}
       width={widthEstimate}
       aria-label={t('grafana-ui.select.menu-label', 'Select options menu')}
       itemCount={flattenedChildren.length}
       itemSize={VIRTUAL_LIST_ITEM_HEIGHT}
     >
-      {({ index, style }) => <div style={{ ...style, overflow: 'hidden' }}>{flattenedChildren[index]}</div>}
+      {({ index, style }) => <div style={style}>{flattenedChildren[index]}</div>}
     </List>
   );
 };
@@ -213,6 +228,9 @@ interface SelectMenuOptionProps<T> {
   innerRef: RefCallback<HTMLDivElement>;
   renderOptionLabel?: (value: SelectableValue<T>) => JSX.Element;
   data: SelectableValue<T>;
+  selectProps?: {
+    showFocusRing?: boolean;
+  };
 }
 
 const ToggleAllOption = ({
@@ -264,6 +282,7 @@ export const SelectMenuOptions = ({
   isFocused,
   isSelected,
   renderOptionLabel,
+  selectProps,
 }: React.PropsWithChildren<SelectMenuOptionProps<unknown>>) => {
   const theme = useTheme2();
   const styles = getSelectStyles(theme);
@@ -279,6 +298,7 @@ export const SelectMenuOptions = ({
       className={cx(
         styles.option,
         isFocused && styles.optionFocused,
+        isFocused && selectProps?.showFocusRing && styles.optionFocusRing,
         isSelected && styles.optionSelected,
         data.isDisabled && styles.optionDisabled
       )}

--- a/packages/grafana-ui/src/components/Select/getSelectStyles.ts
+++ b/packages/grafana-ui/src/components/Select/getSelectStyles.ts
@@ -2,6 +2,7 @@ import { css } from '@emotion/css';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 
+import { getFocusStyles } from '../../internal';
 import { stylesFactory } from '../../themes/stylesFactory';
 
 export const getSelectStyles = stylesFactory((theme: GrafanaTheme2) => {
@@ -65,6 +66,10 @@ export const getSelectStyles = stylesFactory((theme: GrafanaTheme2) => {
       '@media (forced-colors: active), (prefers-contrast: more)': {
         border: `1px solid ${theme.colors.primary.border}`,
       },
+    }),
+    optionFocusRing: css({
+      label: 'grafana-select-option-focus-ring',
+      ...getFocusStyles(theme),
     }),
     optionSelected: css({
       background: theme.colors.action.selected,

--- a/packages/grafana-ui/src/components/Select/getSelectStyles.ts
+++ b/packages/grafana-ui/src/components/Select/getSelectStyles.ts
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 
-import { getFocusStyles } from '../../internal';
+import { getFocusStyles } from '../../themes/mixins';
 import { stylesFactory } from '../../themes/stylesFactory';
 
 export const getSelectStyles = stylesFactory((theme: GrafanaTheme2) => {

--- a/public/app/core/components/SharedPreferences/SharedPreferencesFunctional.test.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferencesFunctional.test.tsx
@@ -30,9 +30,16 @@ const getPrefsUpdateRequest = async (requests: Request[]) => {
 
 const [_, { dashbdD, dashbdE }] = getFolderFixtures();
 
-const selectComboboxOptionInTest = async (input: HTMLElement, optionOrOptions: string | RegExp) => {
+const selectComboboxOptionInTest = async (
+  input: HTMLElement,
+  optionOrOptions: string | RegExp,
+  filterText?: string
+) => {
   const user = userEvent.setup();
   await user.click(input);
+  if (filterText) {
+    await user.type(input, filterText, { skipClick: true });
+  }
   const option = await screen.findByRole('option', { name: optionOrOptions });
   await user.click(option);
 };
@@ -148,7 +155,11 @@ describe('SharedPreferencesFunctional', () => {
     const capture = captureRequests();
     const { user } = await setup();
 
-    await selectComboboxOptionInTest(await screen.findByRole('combobox', { name: /Interface theme/ }), 'Gilded grove');
+    await selectComboboxOptionInTest(
+      await screen.findByRole('combobox', { name: /Interface theme/ }),
+      'Gilded grove',
+      'Gilded'
+    );
 
     await user.click(screen.getByText('Save preferences'));
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- shows a focus ring (similar to `Menu`) when navigating `Select`/`Combobox` options with the keyboard
- importantly, **does not** show this just whilst hovering

**Why do we need this feature?**

- better a11y for `Select` and `Combobox`

**Who is this feature for?**

- everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/117286

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
