### PR TITLE
Provisioning: complete migrate/export jobs as warning when disabled by config

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/driver.go
+++ b/pkg/registry/apis/provisioning/jobs/driver.go
@@ -270,12 +270,20 @@ func (d *jobProcessor) processKey(ctx context.Context, namespace, name string, t
 		"warningCount", len(status.Warnings),
 		"message", status.Message,
 	}
-	switch {
-	case err != nil:
-		logger.Error("job failed", append(logFields, "error", err)...)
-	case status.State == provisioning.JobStateError:
-		logger.Error("job completed with errors", logFields...)
-	case status.State == provisioning.JobStateWarning:
+	if err != nil {
+		logFields = append(logFields, "error", err)
+	}
+	// Key the log level off the final job state, not off err: a worker can return
+	// an error that maps to a warning state (e.g. a feature disabled by
+	// configuration), which should not be logged or alerted as a failure.
+	switch status.State {
+	case provisioning.JobStateError:
+		if err != nil {
+			logger.Error("job failed", logFields...)
+		} else {
+			logger.Error("job completed with errors", logFields...)
+		}
+	case provisioning.JobStateWarning:
 		logger.Warn("job completed with warnings", logFields...)
 	default:
 		logger.Info("job complete", logFields...)

--- a/pkg/registry/apis/provisioning/jobs/export/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/export/worker.go
@@ -61,7 +61,9 @@ func (r *ExportWorker) IsSupported(ctx context.Context, job provisioning.Job) bo
 // Process will start a job
 func (r *ExportWorker) Process(ctx context.Context, repo repository.Repository, job provisioning.Job, progress jobs.JobProgressRecorder) (processErr error) {
 	if !r.enabled {
-		return fmt.Errorf("export functionality is disabled by configuration")
+		// A disabled feature is an expected configuration state, not a failure:
+		// complete the job in a warning state so it is not logged or alerted as an error.
+		return jobs.AsWarning(errors.New("export functionality is disabled by configuration"))
 	}
 
 	options := job.Spec.Push

--- a/pkg/registry/apis/provisioning/jobs/migrate/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/worker.go
@@ -41,7 +41,9 @@ func (w *MigrationWorker) IsSupported(ctx context.Context, job provisioning.Job)
 
 func (w *MigrationWorker) Process(ctx context.Context, repo repository.Repository, job provisioning.Job, progress jobs.JobProgressRecorder) (processErr error) {
 	if !w.enabled {
-		return errors.New("migrate functionality is disabled by configuration")
+		// A disabled feature is an expected configuration state, not a failure:
+		// complete the job in a warning state so it is not logged or alerted as an error.
+		return jobs.AsWarning(errors.New("migrate functionality is disabled by configuration"))
 	}
 
 	options := job.Spec.Migrate

--- a/pkg/registry/apis/provisioning/jobs/progress.go
+++ b/pkg/registry/apis/provisioning/jobs/progress.go
@@ -380,7 +380,11 @@ func (r *jobProgressRecorder) Complete(ctx context.Context, err error) provision
 	}
 
 	if err != nil {
-		jobStatus.State = provisioning.JobStateError
+		if IsWarning(err) {
+			jobStatus.State = provisioning.JobStateWarning
+		} else {
+			jobStatus.State = provisioning.JobStateError
+		}
 		jobStatus.Message = err.Error()
 	}
 

--- a/pkg/registry/apis/provisioning/jobs/progress_test.go
+++ b/pkg/registry/apis/provisioning/jobs/progress_test.go
@@ -3,6 +3,7 @@ package jobs
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 
@@ -1091,6 +1092,41 @@ func TestJobProgressRecorderResultReasons(t *testing.T) {
 		assert.Empty(t, recorder.resultReasons)
 		recorder.mu.RUnlock()
 	})
+}
+
+func TestJobProgressRecorderCompleteWithWarningError(t *testing.T) {
+	ctx := context.Background()
+	mockProgressFn := func(ctx context.Context, status provisioning.JobStatus) error { return nil }
+
+	t.Run("warning-wrapped error completes in warning state and keeps its message", func(t *testing.T) {
+		recorder := newJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
+
+		finalStatus := recorder.Complete(ctx, AsWarning(errors.New("migrate functionality is disabled by configuration")))
+
+		assert.Equal(t, provisioning.JobStateWarning, finalStatus.State)
+		assert.Equal(t, "migrate functionality is disabled by configuration", finalStatus.Message)
+	})
+
+	t.Run("plain error still completes in error state", func(t *testing.T) {
+		recorder := newJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
+
+		finalStatus := recorder.Complete(ctx, errors.New("boom"))
+
+		assert.Equal(t, provisioning.JobStateError, finalStatus.State)
+		assert.Equal(t, "boom", finalStatus.Message)
+	})
+}
+
+func TestAsWarning(t *testing.T) {
+	assert.Nil(t, AsWarning(nil))
+	assert.False(t, IsWarning(nil))
+	assert.False(t, IsWarning(errors.New("plain")))
+
+	err := AsWarning(errors.New("disabled by configuration"))
+	assert.True(t, IsWarning(err))
+	assert.Equal(t, "disabled by configuration", err.Error())
+	// Preserves the wrapped error for errors.Is/As chains.
+	assert.True(t, IsWarning(fmt.Errorf("wrapped: %w", err)))
 }
 
 func TestJobProgressRecorderTooManyErrorsConcurrency(t *testing.T) {

--- a/pkg/registry/apis/provisioning/jobs/warning.go
+++ b/pkg/registry/apis/provisioning/jobs/warning.go
@@ -1,0 +1,29 @@
+package jobs
+
+import "errors"
+
+// warningError marks a benign condition that should complete a job in a warning
+// state rather than a failure. Workers return it from Process when the job could
+// not do its work for an expected, non-failing reason (for example, a feature
+// disabled by configuration) so the outcome is not logged or alerted as an error.
+type warningError struct {
+	err error
+}
+
+func (w *warningError) Error() string { return w.err.Error() }
+func (w *warningError) Unwrap() error { return w.err }
+
+// AsWarning wraps err so that returning it from a Worker completes the job in a
+// warning state instead of an error state. It returns nil when err is nil.
+func AsWarning(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &warningError{err: err}
+}
+
+// IsWarning reports whether err was marked as a warning-level condition via AsWarning.
+func IsWarning(err error) bool {
+	var w *warningError
+	return errors.As(err, &w)
+}

--- a/pkg/tests/apis/provisioning/disabledfeatures_test.go
+++ b/pkg/tests/apis/provisioning/disabledfeatures_test.go
@@ -37,7 +37,7 @@ func TestIntegrationProvisioning_MigrateDisabledByConfiguration(t *testing.T) {
 	state, found, err := unstructured.NestedString(status, "state")
 	require.NoError(t, err)
 	require.True(t, found)
-	require.Equal(t, "error", state, "job should have error state")
+	require.Equal(t, "warning", state, "a disabled feature is a configuration state, not a failure")
 
 	message, found, err := unstructured.NestedString(status, "message")
 	require.NoError(t, err)

--- a/pkg/tests/apis/provisioning/disabledfeatures_test.go
+++ b/pkg/tests/apis/provisioning/disabledfeatures_test.go
@@ -73,7 +73,7 @@ func TestIntegrationProvisioning_ExportDisabledByConfiguration(t *testing.T) {
 	state, found, err := unstructured.NestedString(status, "state")
 	require.NoError(t, err)
 	require.True(t, found)
-	require.Equal(t, "error", state, "job should have error state")
+	require.Equal(t, "warning", state, "a disabled feature is a configuration state, not a failure")
 
 	message, found, err := unstructured.NestedString(status, "message")
 	require.NoError(t, err)


### PR DESCRIPTION
**What is this feature?**

A `migrate` job — or an export (`push`) job — submitted while its feature is disabled by configuration now completes in a **warning** job state instead of an **error** state, and the job driver logs it at **warn** level instead of `error`.

Before:
```
level=error ... msg="job failed" ... action=migrate state=error errorCount=0 warningCount=0 message="migrate functionality is disabled by configuration"
```
After: the same condition ends as `state=warning`, logged via `"job completed with warnings"` at warn level. The user-facing message is unchanged.

Implementation:
- New typed-error helper in the `jobs` package — `AsWarning(err)` / `IsWarning(err)` — lets a worker signal that its returned error is a benign condition that should complete the job in a warning state. It wraps the underlying error and preserves `errors.Is`/`errors.As` chains.
- `MigrationWorker.Process` and `ExportWorker.Process` return `jobs.AsWarning(...)` for the disabled case instead of a plain error.
- `jobProgressRecorder.Complete` maps a warning-wrapped error to `JobStateWarning` (message still taken from the error).
- The driver's completion logging keys the log level off the **final job state** rather than off `err != nil`. Existing `"job failed"` / `"job completed with errors"` wording is preserved for genuine failures.

**Why do we need this feature?**

A job that lands while its feature is disabled by configuration is an expected configuration state, not a failure. Treating it as an error meant every such job ended in an `error` state, was logged as `"job failed"` at error level, and counted as an `error` outcome in job metrics. In stacks where migrate/export are disabled this produces a steady stream of error-level log noise and spurious error signal for alerting, even though nothing actually failed.

Side effect (intended): the job metric's `outcome` label for these cases changes from `error` to `warning`, so it no longer inflates error counts.

**Who is this feature for?**

Operators and on-call engineers running Grafana instances (notably multi-tenant/cloud stacks) where provisioning migrate or export is disabled by configuration — they get cleaner error logs and accurate error alerting.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

- No new feature toggle: this changes the outcome classification of an already-existing disabled-by-config path.
- Tests: `go build ./pkg/registry/apis/provisioning/jobs/...` and `go vet` pass; unit tests pass for `jobs`, `jobs/migrate`, `jobs/export`. Added `TestAsWarning` and `TestJobProgressRecorderCompleteWithWarningError`; updated the migrate/export disabled-by-config integration tests to expect `state=warning`.
- Heads-up: any dashboard/alert keying off the job `outcome` metric label will now see these as `warning` rather than `error`.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)