### PR TITLE
Drawer: Improve close button placement

### DIFF
--- a/packages/grafana-ui/src/components/Drawer/Drawer.tsx
+++ b/packages/grafana-ui/src/components/Drawer/Drawer.tsx
@@ -9,8 +9,8 @@ import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 
 import { useStyles2 } from '../../themes/ThemeContext';
+import { Button } from '../Button/Button';
 import { getDragStyles } from '../DragHandle/DragHandle';
-import { IconButton } from '../IconButton/IconButton';
 import { Stack } from '../Layout/Stack/Stack';
 import { getPortalContainer } from '../Portal/Portal';
 import { ScrollContainer } from '../ScrollContainer/ScrollContainer';
@@ -141,8 +141,9 @@ export function Drawer({
           />
           <div className={cx(styles.header, Boolean(tabs) && styles.headerWithTabs)}>
             <div className={styles.actions}>
-              <IconButton
-                name="times"
+              <Button
+                icon="times"
+                size="sm"
                 variant="secondary"
                 onClick={onClose}
                 data-testid={selectors.components.Drawer.General.close}


### PR DESCRIPTION
Noticed the close button is misaligned in the corner due to an annoying right margin on IconButton. 

Think a plain secondary (sm) button here looks a bit better 

Before:
<img width="1185" height="1037" alt="Screenshot 2026-08-14 at 10 21 48" src="https://github.com/user-attachments/assets/37b79b4f-7475-445a-9ef6-749e656f7dc5" />

After:
<img width="1181" height="1040" alt="Screenshot 2026-08-14 at 10 21 27" src="https://github.com/user-attachments/assets/fa742b8b-ffd4-47c9-917c-f1b80bffcfa5" />
