### PR TITLE
chore: Previous link do not work. It has moved.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ## This is a self-documented Makefile. For usage information, run `make help`:
 ##
-## For more information, refer to https://suva.sh/posts/well-documented-makefiles/
+## For more information, refer to https://www.thapaliya.com/en/writings/well-documented-makefiles/
 
 WIRE_TAGS = "oss"
 


### PR DESCRIPTION
New link seems to have moved to https://www.thapaliya.com/en/writings/well-documented-makefiles/.

**What is this feature?**

Not a feature, a link in the Makefile does not work anymore.



