### PR TITLE
Add security reporting guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ Grafana is a monitoring and observability platform. Go backend, TypeScript/React
 - Keep changes focused — avoid over-engineering
 - Separate PRs for frontend and backend changes (deployed at different cadences)
 - Security: prevent XSS, SQL injection, command injection
+- Security issues should be reported via [Grafana's security issue reporting page](https://grafana.com/legal/report-a-security-issue/) and not directly in this repository.
 
 ## Comments
 


### PR DESCRIPTION
## What changed

- Added guidance to the root `AGENTS.md` directing security issues to Grafana's security reporting page instead of the repository.

## Why

This makes the expected reporting channel explicit for agents working in the repository.

## Validation

- `git diff --check`
- Confirmed the commit changes only `AGENTS.md` with one added line.