### PR TITLE
unified-search: try the next snapshot when one fails to download

### DIFF
--- a/pkg/storage/unified/resource/bleve_index_metrics.go
+++ b/pkg/storage/unified/resource/bleve_index_metrics.go
@@ -22,7 +22,7 @@ type BleveIndexMetrics struct {
 	SearchUpdateWaitTime *prometheus.HistogramVec
 	RebuildQueueLength   prometheus.Gauge
 
-	IndexSnapshotDownloads                *prometheus.CounterVec
+	IndexSnapshotDownloadAttempts         *prometheus.CounterVec
 	IndexSnapshotDownloadDuration         prometheus.Histogram
 	IndexSnapshotUploads                  *prometheus.CounterVec
 	IndexSnapshotUploadDuration           prometheus.Histogram
@@ -101,8 +101,8 @@ func ProvideIndexMetrics(reg prometheus.Registerer) *BleveIndexMetrics {
 			Name: "index_server_rebuild_queue_length",
 			Help: "Number of indexes waiting for rebuild",
 		}),
-		IndexSnapshotDownloads: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-			Name: "index_server_snapshot_downloads_total",
+		IndexSnapshotDownloadAttempts: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "index_server_snapshot_download_attempts_total",
 			Help: "Number of remote index snapshot download attempts at index build time, by selection policy and outcome.",
 		}, []string{"policy", "status"}), // policy: tiered, same_version. status: success, empty, download_error, validate_error
 		IndexSnapshotDownloadDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
@@ -169,10 +169,10 @@ func (m *BleveIndexMetrics) InitSnapshotMetrics() {
 		return
 	}
 	for _, policy := range []string{"tiered", "same_version", "cold_start"} {
-		m.IndexSnapshotDownloads.WithLabelValues(policy, "success").Add(0)
-		m.IndexSnapshotDownloads.WithLabelValues(policy, "empty").Add(0)
-		m.IndexSnapshotDownloads.WithLabelValues(policy, "download_error").Add(0)
-		m.IndexSnapshotDownloads.WithLabelValues(policy, "validate_error").Add(0)
+		m.IndexSnapshotDownloadAttempts.WithLabelValues(policy, "success").Add(0)
+		m.IndexSnapshotDownloadAttempts.WithLabelValues(policy, "empty").Add(0)
+		m.IndexSnapshotDownloadAttempts.WithLabelValues(policy, "download_error").Add(0)
+		m.IndexSnapshotDownloadAttempts.WithLabelValues(policy, "validate_error").Add(0)
 	}
 	m.IndexSnapshotUploads.WithLabelValues("success").Add(0)
 	m.IndexSnapshotUploads.WithLabelValues("skip_no_changes").Add(0)

--- a/pkg/storage/unified/search/bleve_snapshot.go
+++ b/pkg/storage/unified/search/bleve_snapshot.go
@@ -90,13 +90,20 @@ type snapshotCandidate struct {
 	tier    int             // 0 = best, 2 = last resort
 }
 
-// snapshotSelectFn picks a snapshot under a given policy.
-//
-// Returns:
-//   - (key, meta, nil):                a snapshot was chosen.
-//   - (zero ULID, nil, nil):           no candidate; caller proceeds to its fallback.
-//   - (zero ULID, nil, err):           selection failed; caller treats as a download error.
-type snapshotSelectFn func(context.Context) (ulid.ULID, *IndexMeta, error)
+// snapshotChoice is a snapshot to try downloading.
+type snapshotChoice struct {
+	key  ulid.ULID
+	meta *IndexMeta
+}
+
+// snapshotSelectFn returns the snapshots to try, best first. Empty means no
+// candidate; an error is treated as a download error.
+type snapshotSelectFn func(context.Context) ([]snapshotChoice, error)
+
+// maxSnapshotDownloadAttempts bounds the retries, since each one is a full
+// download: enough to get past a broken snapshot, not enough for a namespace of
+// them to delay startup.
+const maxSnapshotDownloadAttempts = 3
 
 // tryDownloadRemoteSnapshot lists remote snapshots for the given resource,
 // picks the best candidate (see pickBestSnapshot), downloads and opens it
@@ -117,20 +124,21 @@ func (b *bleveBackend) tryDownloadRemoteSnapshot(
 	logger.Info("Remote index snapshot download started", "policy", snapshotPolicyTiered)
 	return b.downloadSelectedSnapshot(ctx, key, resourceDir,
 		snapshotPolicyTiered, "search.remote_index_snapshot.download", logger,
-		func(ctx context.Context) (ulid.ULID, *IndexMeta, error) {
+		func(ctx context.Context) ([]snapshotChoice, error) {
 			all, err := ListIndexSnapshots(ctx, b.opts.Snapshot.Store, key, logger)
 			if err != nil {
-				return ulid.ULID{}, nil, fmt.Errorf("listing remote snapshots: %w", err)
+				return nil, fmt.Errorf("listing remote snapshots: %w", err)
 			}
 			notOlderThan := time.Time{}
 			if maxAge := b.opts.Snapshot.MaxIndexAge; maxAge > 0 {
 				notOlderThan = time.Now().Add(-maxAge)
 			}
-			c, ok := b.pickBestSnapshot(all, notOlderThan, logger)
-			if !ok {
-				return ulid.ULID{}, nil, nil
+			ranked := b.rankSnapshots(all, notOlderThan, logger)
+			choices := make([]snapshotChoice, 0, len(ranked))
+			for _, c := range ranked {
+				choices = append(choices, snapshotChoice{key: c.key, meta: c.meta})
 			}
-			return c.key, c.meta, nil
+			return choices, nil
 		},
 	)
 }
@@ -163,12 +171,17 @@ func (b *bleveBackend) tryDownloadFreshSameVersionSnapshot(
 	}
 
 	return b.downloadSelectedSnapshot(ctx, key, resourceDir, policy, spanName, logger,
-		func(ctx context.Context) (ulid.ULID, *IndexMeta, error) {
+		func(ctx context.Context) ([]snapshotChoice, error) {
 			k, m, err := findFreshSnapshotByBuildStart(ctx, b.opts.Snapshot.Store, key, notOlderThan, b.opts.BuildVersion, b.maxSupportedIndexFormat, logger)
 			if err != nil {
-				return ulid.ULID{}, nil, fmt.Errorf("probing for fresh snapshot: %w", err)
+				return nil, fmt.Errorf("probing for fresh snapshot: %w", err)
 			}
-			return k, m, nil
+			if m == nil {
+				return nil, nil
+			}
+			// One candidate: the rebuild scan and the cold-start wait loop re-run this
+			// path, so a failure is retried anyway.
+			return []snapshotChoice{{key: k, meta: m}}, nil
 		},
 	)
 }
@@ -177,6 +190,10 @@ func (b *bleveBackend) tryDownloadFreshSameVersionSnapshot(
 // helpers: trace span, completion / failure log, outcome metric, and the
 // reserve-download-open-validate flow. Each policy provides its
 // selection logic via selectFn; the template handles everything else.
+//
+// Candidates are tried in order, so a snapshot that only proves unusable once
+// downloaded does not cost the caller its whole snapshot path. The outcome metric
+// counts one attempt, not one call.
 func (b *bleveBackend) downloadSelectedSnapshot(
 	ctx context.Context,
 	key resource.NamespacedResource,
@@ -223,40 +240,81 @@ func (b *bleveBackend) downloadSelectedSnapshot(
 		} else {
 			logger.Info("Remote index snapshot download completed", "elapsed", elapsed, "policy", policy, "outcome", outcome)
 		}
-		b.recordSnapshotDownloadOutcome(policy, outcome)
 		span.End()
 	}()
 
-	var err error
-	snapKey, meta, err = selectFn(ctx)
+	var lastErr error
+
+	choices, err := selectFn(ctx)
 	if err != nil {
 		outcome = snapshotStatusDownloadError
+		b.recordSnapshotDownloadOutcome(policy, outcome)
 		return nil, "", 0, err
 	}
-	if meta == nil {
+	if len(choices) == 0 {
 		outcome = snapshotStatusEmpty
+		b.recordSnapshotDownloadOutcome(policy, outcome)
 		return nil, "", 0, nil
 	}
 
-	logFields := []any{
-		"snapshot_key", snapKey.String(),
-		"snapshot_version", meta.BuildVersion,
-		"snapshot_index_format", meta.IndexFormat,
-		"snapshot_rv", meta.LatestResourceVersion,
-		"snapshot_uploaded", meta.UploadTimestamp,
-	}
-	if !meta.BuildTime.IsZero() {
-		logFields = append(logFields, "snapshot_build_time", meta.BuildTime)
-	}
-	logger = logger.New(logFields...)
+	attempts := 0
+	for _, choice := range choices {
+		if attempts == maxSnapshotDownloadAttempts {
+			break
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, "", 0, ctxErr
+		}
+		attempts++
 
+		// Span attributes and the closing log line describe the snapshot we ended on.
+		snapKey, meta = choice.key, choice.meta
+
+		logFields := []any{
+			"snapshot_key", snapKey.String(),
+			"snapshot_version", meta.BuildVersion,
+			"snapshot_index_format", meta.IndexFormat,
+			"snapshot_rv", meta.LatestResourceVersion,
+			"snapshot_uploaded", meta.UploadTimestamp,
+		}
+		if !meta.BuildTime.IsZero() {
+			logFields = append(logFields, "snapshot_build_time", meta.BuildTime)
+		}
+		attemptLogger := logger.New(logFields...)
+
+		idx, name, rv, attemptOutcome, err := b.downloadSnapshotCandidate(ctx, key, resourceDir, snapKey, meta, attemptLogger)
+		outcome = attemptOutcome
+		b.recordSnapshotDownloadOutcome(policy, outcome)
+		if err == nil {
+			logger = attemptLogger
+			return idx, name, rv, nil
+		}
+
+		lastErr = err
+		attemptLogger.Warn("Remote index snapshot attempt failed", "policy", policy, "outcome", outcome, "attempt", attempts, "err", err)
+	}
+
+	span.SetAttributes(attribute.Int("attempts", attempts))
+	return nil, "", 0, lastErr
+}
+
+// downloadSnapshotCandidate downloads, opens and validates one snapshot, and
+// returns the outcome to record for the attempt. Cleans up everything it created
+// before returning an error, so the caller can try the next candidate.
+func (b *bleveBackend) downloadSnapshotCandidate(
+	ctx context.Context,
+	key resource.NamespacedResource,
+	resourceDir string,
+	snapKey ulid.ULID,
+	meta *IndexMeta,
+	logger log.Logger,
+) (_ bleve.Index, _ string, _ int64, _ string, retErr error) {
 	// Pick and reserve a fresh destination directory name. DownloadIndexSnapshot
 	// refuses to overwrite an existing destDir, so reserveIndexDir protects the
 	// not-yet-created path from other in-process builds while we download.
 	destDir, name, err := b.reserveIndexDir(resourceDir)
 	if err != nil {
-		outcome = snapshotStatusDownloadError
-		return nil, "", 0, fmt.Errorf("reserving local snapshot dir: %w", err)
+		return nil, "", 0, snapshotStatusDownloadError, fmt.Errorf("reserving local snapshot dir: %w", err)
 	}
 
 	// On success, ownership of the reservation transfers to the caller
@@ -272,23 +330,20 @@ func (b *bleveBackend) downloadSelectedSnapshot(
 	downloadedMeta, err := DownloadIndexSnapshot(ctx, b.opts.Snapshot.Store, key, snapKey, destDir)
 	if err != nil {
 		_ = os.RemoveAll(destDir)
-		outcome = snapshotStatusDownloadError
-		return nil, "", 0, fmt.Errorf("downloading snapshot: %w", err)
+		return nil, "", 0, snapshotStatusDownloadError, fmt.Errorf("downloading snapshot: %w", err)
 	}
 
 	idx, err := bleve.OpenUsing(destDir, map[string]interface{}{"bolt_timeout": boltTimeout})
 	if err != nil {
 		_ = os.RemoveAll(destDir)
-		outcome = snapshotStatusValidateError
-		return nil, "", 0, fmt.Errorf("opening downloaded snapshot: %w", err)
+		return nil, "", 0, snapshotStatusValidateError, fmt.Errorf("opening downloaded snapshot: %w", err)
 	}
 
 	rv, err := b.validateDownloadedIndex(idx)
 	if err != nil {
 		_ = idx.Close()
 		_ = os.RemoveAll(destDir)
-		outcome = snapshotStatusValidateError
-		return nil, "", 0, fmt.Errorf("validating downloaded snapshot: %w", err)
+		return nil, "", 0, snapshotStatusValidateError, fmt.Errorf("validating downloaded snapshot: %w", err)
 	}
 
 	if b.indexMetrics != nil {
@@ -303,24 +358,23 @@ func (b *bleveBackend) downloadSelectedSnapshot(
 	if err := writeSnapshotMutationCount(idx, 0); err != nil {
 		_ = idx.Close()
 		_ = os.RemoveAll(destDir)
-		outcome = snapshotStatusValidateError
-		return nil, "", 0, fmt.Errorf("resetting snapshot mutation count: %w", err)
+		return nil, "", 0, snapshotStatusValidateError, fmt.Errorf("resetting snapshot mutation count: %w", err)
 	}
 	b.setUploadTracking(key, uploadedAt)
 
-	return idx, name, rv, nil
+	return idx, name, rv, snapshotStatusSuccess, nil
 }
 
-// pickBestSnapshot applies hard filters (upload time, index format,
+// rankSnapshots applies hard filters (upload time, index format,
 // unparseable version) and the three-tier preference to pick the best
-// snapshot, if any.
+// candidates in preference order, best first.
 //
 // Tier 0 (ideal): MinBuildVersion <= v <= runningVersion
 // Tier 1 (older, acceptable): v < MinBuildVersion
 // Tier 2 (newer, last resort): v > runningVersion
 //
 // Within each tier, sort by version desc -> RV desc -> upload time desc.
-func (b *bleveBackend) pickBestSnapshot(all map[ulid.ULID]*IndexMeta, notOlderThan time.Time, logger log.Logger) (snapshotCandidate, bool) {
+func (b *bleveBackend) rankSnapshots(all map[ulid.ULID]*IndexMeta, notOlderThan time.Time, logger log.Logger) []snapshotCandidate {
 	minVersion := b.opts.Snapshot.MinBuildVersion
 	running := b.runningBuildVersion
 
@@ -397,7 +451,7 @@ func (b *bleveBackend) pickBestSnapshot(all map[ulid.ULID]*IndexMeta, notOlderTh
 
 	if len(candidates) == 0 {
 		logger.Debug("no index snapshot candidates", "total", len(all), "dropped_age", droppedAge, "dropped_unparseable", droppedUnparseable, "dropped_format_unsupported", droppedFormatUnsupported, "dropped_unknown_requirements", droppedUnknownRequirements, "dropped_missing_features", droppedMissingFeatures, "max_supported_format", b.maxSupportedIndexFormat)
-		return snapshotCandidate{}, false
+		return nil
 	}
 
 	sort.Slice(candidates, func(i, j int) bool {
@@ -423,7 +477,16 @@ func (b *bleveBackend) pickBestSnapshot(all map[ulid.ULID]*IndexMeta, notOlderTh
 		"dropped_unparseable", droppedUnparseable,
 		"dropped_format_unsupported", droppedFormatUnsupported,
 	)
-	return candidates[0], true
+	return candidates
+}
+
+// pickBestSnapshot returns the best candidate, for callers that do not retry.
+func (b *bleveBackend) pickBestSnapshot(all map[ulid.ULID]*IndexMeta, notOlderThan time.Time, logger log.Logger) (snapshotCandidate, bool) {
+	ranked := b.rankSnapshots(all, notOlderThan, logger)
+	if len(ranked) == 0 {
+		return snapshotCandidate{}, false
+	}
+	return ranked[0], true
 }
 
 // snapshotTier returns the preference tier of v relative to the configured
@@ -473,7 +536,7 @@ func (b *bleveBackend) recordSnapshotDownloadOutcome(policy, status string) {
 	if b.indexMetrics == nil {
 		return
 	}
-	b.indexMetrics.IndexSnapshotDownloads.WithLabelValues(policy, status).Inc()
+	b.indexMetrics.IndexSnapshotDownloadAttempts.WithLabelValues(policy, status).Inc()
 }
 
 // findFreshSnapshotByUploadTime walks namespace snapshots newest-first and

--- a/pkg/storage/unified/search/bleve_snapshot_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_test.go
@@ -371,7 +371,7 @@ func (dt downloadTest) run(t *testing.T) (bleve.Index, int64, error) {
 }
 
 func (dt downloadTest) counter(status string) float64 {
-	return testutil.ToFloat64(dt.metrics.IndexSnapshotDownloads.WithLabelValues(snapshotPolicyTiered, status))
+	return testutil.ToFloat64(dt.metrics.IndexSnapshotDownloadAttempts.WithLabelValues(snapshotPolicyTiered, status))
 }
 
 func TestTryDownloadRemoteSnapshot_Empty(t *testing.T) {
@@ -447,6 +447,57 @@ func TestTryDownloadRemoteSnapshot_Success(t *testing.T) {
 	m := &dto.Metric{}
 	require.NoError(t, dt.metrics.IndexSnapshotDownloadDuration.Write(m))
 	assert.Equal(t, uint64(1), m.GetHistogram().GetSampleCount())
+}
+
+// Without the fallback this would rebuild from scratch instead.
+func TestTryDownloadRemoteSnapshot_FallsBackToNextCandidate(t *testing.T) {
+	store := newHookableStore(t)
+	dt := newDownloadTest(t, store)
+	dt.be.requiredFeatures = []resource.IndexFeature{"alpha"}
+
+	// Ranked first on RV, but its index lacks the required feature — which selection
+	// cannot see, because the manifest recorded no features.
+	seedDownloadableSnapshot(t, t.Context(), store.bucket, dt.ns, makeULID(t, time.Now()), &IndexMeta{
+		BuildVersion:          "11.5.0",
+		LatestResourceVersion: 100,
+		UploadTimestamp:       time.Now(),
+	})
+	seedDownloadableSnapshot(t, t.Context(), store.bucket, dt.ns, makeULID(t, time.Now().Add(-time.Minute)), &IndexMeta{
+		BuildVersion:          "11.5.0",
+		LatestResourceVersion: 50,
+		UploadTimestamp:       time.Now().Add(-time.Minute),
+		Features:              []resource.IndexFeature{"alpha"},
+	})
+
+	idx, rv, err := dt.run(t)
+	require.NoError(t, err)
+	require.NotNil(t, idx)
+	assert.Equal(t, int64(50), rv, "should end up on the older snapshot that validates")
+	// One outcome per attempt, not per call.
+	assert.Equal(t, 1.0, dt.counter(snapshotStatusValidateError))
+	assert.Equal(t, 1.0, dt.counter(snapshotStatusSuccess))
+}
+
+// The cap keeps a namespace full of unusable snapshots from delaying startup.
+func TestTryDownloadRemoteSnapshot_StopsAtAttemptCap(t *testing.T) {
+	store := newHookableStore(t)
+	dt := newDownloadTest(t, store)
+	dt.be.requiredFeatures = []resource.IndexFeature{"alpha"}
+
+	for i := range maxSnapshotDownloadAttempts + 2 {
+		age := time.Duration(i) * time.Minute
+		seedDownloadableSnapshot(t, t.Context(), store.bucket, dt.ns, makeULID(t, time.Now().Add(-age)), &IndexMeta{
+			BuildVersion:          "11.5.0",
+			LatestResourceVersion: int64(100 - i),
+			UploadTimestamp:       time.Now().Add(-age),
+		})
+	}
+
+	_, _, err := dt.run(t)
+	require.Error(t, err)
+	// Stops at the cap rather than working through all five candidates.
+	assert.Equal(t, float64(maxSnapshotDownloadAttempts), dt.counter(snapshotStatusValidateError))
+	assert.Zero(t, dt.counter(snapshotStatusSuccess))
 }
 
 func TestTryDownloadRemoteSnapshot_AllFilteredOut(t *testing.T) {
@@ -527,7 +578,7 @@ func (dt freshDownloadTest) run(t *testing.T, lastImportTime time.Time, maxFresh
 }
 
 func (dt freshDownloadTest) counter(status string) float64 {
-	return testutil.ToFloat64(dt.metrics.IndexSnapshotDownloads.WithLabelValues(snapshotPolicySameVersion, status))
+	return testutil.ToFloat64(dt.metrics.IndexSnapshotDownloadAttempts.WithLabelValues(snapshotPolicySameVersion, status))
 }
 
 // freshSnapshot returns metadata for a freshly-built same-version snapshot at age.
@@ -702,7 +753,7 @@ func TestBuildIndex_RebuildUsesFreshSnapshot(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, idx)
 	assert.Zero(t, builderCalled.Load(), "builder should not run when a fresh remote snapshot is used")
-	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotDownloads.WithLabelValues(snapshotPolicySameVersion, snapshotStatusSuccess)))
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotDownloadAttempts.WithLabelValues(snapshotPolicySameVersion, snapshotStatusSuccess)))
 }
 
 // TestBuildIndex_RebuildFallsBackToBuilder verifies that on the rebuild path
@@ -735,7 +786,7 @@ func TestBuildIndex_RebuildFallsBackToBuilder(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, idx)
 	assert.Equal(t, int32(1), builderCalled.Load(), "builder should run when no fresh snapshot is available")
-	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotDownloads.WithLabelValues(snapshotPolicySameVersion, snapshotStatusEmpty)))
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotDownloadAttempts.WithLabelValues(snapshotPolicySameVersion, snapshotStatusEmpty)))
 	assert.Zero(t, store.downloadCalls.Load(), "older snapshot must not be downloaded on the rebuild path")
 }
 
@@ -1173,7 +1224,7 @@ func TestBleveSnapshotLifecycleWithFileBucket(t *testing.T) {
 	require.NotNil(t, idxB)
 
 	assert.False(t, builderCalled.Load())
-	assert.Equal(t, 1.0, testutil.ToFloat64(metricsB.IndexSnapshotDownloads.WithLabelValues(snapshotPolicyTiered, snapshotStatusSuccess)))
+	assert.Equal(t, 1.0, testutil.ToFloat64(metricsB.IndexSnapshotDownloadAttempts.WithLabelValues(snapshotPolicyTiered, snapshotStatusSuccess)))
 
 	res, err := idxB.Search(ctx, nil, &resourcepb.ResourceSearchRequest{
 		Options: &resourcepb.ListOptions{Key: &resourcepb.ResourceKey{
@@ -1259,7 +1310,7 @@ func TestIntegrationBleveSnapshotRoundTrip(t *testing.T) {
 	require.NotNil(t, idx)
 
 	assert.False(t, builderCalled.Load(), "builder should not be called when a remote snapshot is available")
-	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotDownloads.WithLabelValues(snapshotPolicyTiered, snapshotStatusSuccess)))
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotDownloadAttempts.WithLabelValues(snapshotPolicyTiered, snapshotStatusSuccess)))
 	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexBuildSkipped))
 
 	bi, ok := idx.(*bleveIndex)
@@ -1742,7 +1793,7 @@ func TestBuildIndex_ColdStartFastPathDownloads(t *testing.T) {
 	// that's enough to skip the builder. The cold-start path only runs if
 	// the tiered selection misses; here it finds the snapshot first.
 	assert.Zero(t, builderCalled.Load(), "builder must not run when a snapshot is available")
-	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotDownloads.WithLabelValues(snapshotPolicyTiered, snapshotStatusSuccess)))
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotDownloadAttempts.WithLabelValues(snapshotPolicyTiered, snapshotStatusSuccess)))
 }
 
 // TestBuildIndex_ColdStartLeaderUploads exercises the leader path: empty

--- a/pkg/storage/unified/search/remote_index_store_test.go
+++ b/pkg/storage/unified/search/remote_index_store_test.go
@@ -1531,6 +1531,7 @@ func buildDownloadableSnapshot(t *testing.T, ns resource.NamespacedResource, ind
 	bi, err := json.Marshal(buildInfo{
 		BuildTime:    buildTime.Unix(),
 		BuildVersion: meta.BuildVersion,
+		Features:     meta.Features,
 	})
 	require.NoError(t, err)
 	require.NoError(t, idx.SetInternal([]byte(internalBuildInfoKey), bi))


### PR DESCRIPTION
Snapshot selection picked a single candidate, and if it failed to download, open or validate, the whole snapshot path was abandoned — `BuildIndex` logged "will build from scratch" and went on to a cold-start build. For a large index that's hours of work, often with another usable snapshot sitting right behind the one that failed.

Candidates are now tried in order until one opens and validates, three attempts at most. Each attempt is a full download, so the cap stops a namespace of broken snapshots from holding up startup.

Only the tiered path passes more than one candidate. The rebuild and cold-start probes still pass one, since the rebuild scan and the cold-start wait loop re-run them anyway.

The download outcome metric is renamed to `index_server_snapshot_download_attempts_total` and counts one outcome per attempt rather than per call, so a snapshot that was downloaded and then rejected becomes visible.

Part of https://github.com/grafana/search-and-storage-team/issues/916
