### PR TITLE
Calendar: Patch react-calendar to expose the selected date

### DIFF
--- a/.yarn/patches/react-calendar-npm-6.0.1-22fe91a41c.patch
+++ b/.yarn/patches/react-calendar-npm-6.0.1-22fe91a41c.patch
@@ -1,0 +1,16 @@
+diff --git a/dist/Tile.js b/dist/Tile.js
+index fe301036ba80727138e62bebe4df48f5c02b6869..5054a73453a09e5908543f5d25e2fb342a4008c9 100644
+--- a/dist/Tile.js
++++ b/dist/Tile.js
+@@ -11,7 +11,10 @@ export default function Tile(props) {
+         const args = { activeStartDate, date, view };
+         return typeof tileContentProps === 'function' ? tileContentProps(args) : tileContentProps;
+     }, [activeStartDate, date, tileContentProps, view]);
+-    return (_jsxs("button", { className: clsx(classes, tileClassName), disabled: (minDate && minDateTransform(minDate) > date) ||
++    // Grafana patch: the selected tile is marked with a CSS class only, so screen readers cannot
++    // tell it apart from the other tiles. Mirrors the closed upstream PR 940.
++    const isSelected = (classes || []).some((className) => className.endsWith('--active') || className.endsWith('--hasActive'));
++    return (_jsxs("button", { "aria-pressed": isSelected, className: clsx(classes, tileClassName), disabled: (minDate && minDateTransform(minDate) > date) ||
+             (maxDate && maxDateTransform(maxDate) < date) ||
+             (tileDisabled === null || tileDisabled === void 0 ? void 0 : tileDisabled({ activeStartDate, date, view })), onClick: onClick ? (event) => onClick(date, event) : undefined, onFocus: onMouseOver ? () => onMouseOver(date) : undefined, onMouseOver: onMouseOver ? () => onMouseOver(date) : undefined, style: style, type: "button", children: [formatAbbr ? _jsx("abbr", { "aria-label": formatAbbr(locale, date), children: children }) : children, tileContent] }));
+ }

--- a/package.json
+++ b/package.json
@@ -459,7 +459,8 @@
     "tmp": "0.2.7",
     "yaml@npm:^1.10.0": "1.10.3",
     "tar@npm:7.5.11": "7.5.21",
-    "linkify-it": "5.0.2"
+    "linkify-it": "5.0.2",
+    "react-calendar@npm:^6.0.0": "patch:react-calendar@npm%3A6.0.1#~/.yarn/patches/react-calendar-npm-6.0.1-22fe91a41c.patch"
   },
   "workspaces": {
     "packages": [

--- a/packages/grafana-ui/src/components/DateTimePickers/DatePicker/DatePicker.test.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DatePicker/DatePicker.test.tsx
@@ -28,6 +28,13 @@ describe('DatePicker', () => {
     expect(screen.getByText('December 2020')).toBeInTheDocument();
   });
 
+  it('exposes the selected state of the selected date', () => {
+    render(<DatePicker isOpen={true} value={new Date(1607431703363)} onChange={jest.fn()} onClose={jest.fn()} />);
+
+    expect(screen.getByRole('button', { name: 'December 8, 2020', pressed: true })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'December 9, 2020', pressed: false })).toBeInTheDocument();
+  });
+
   it('calls onChange when date is selected', async () => {
     const onChange = jest.fn();
     const user = userEvent.setup();

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.test.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.test.tsx
@@ -189,6 +189,19 @@ describe('TimeRangeForm', () => {
     expect(to).toHaveClass('react-calendar__tile--rangeEnd');
   });
 
+  it('should expose the selected state of every day in the selected range', async () => {
+    const { getAllByRole, getCalendarDayByLabelText } = setup();
+    const openCalendarButton = getAllByRole('button', { name: 'Open calendar' });
+
+    await user.click(openCalendarButton[0]);
+
+    expect(getCalendarDayByLabelText('June 16, 2021')).toHaveAttribute('aria-pressed', 'false');
+    for (const day of [17, 18, 19]) {
+      expect(getCalendarDayByLabelText(`June ${day}, 2021`)).toHaveAttribute('aria-pressed', 'true');
+    }
+    expect(getCalendarDayByLabelText('June 20, 2021')).toHaveAttribute('aria-pressed', 'false');
+  });
+
   it('should select correct time range in calendar when having a custom time zone', async () => {
     const { getAllByRole, getCalendarDayByLabelText } = setup(defaultTimeRange, 'Asia/Tokyo');
     const openCalendarButton = getAllByRole('button', { name: 'Open calendar' });

--- a/yarn.lock
+++ b/yarn.lock
@@ -28697,7 +28697,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-calendar@npm:^6.0.0":
+"react-calendar@npm:6.0.1":
   version: 6.0.1
   resolution: "react-calendar@npm:6.0.1"
   dependencies:
@@ -28713,6 +28713,25 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10/c0beb9bc4d600641881b4989525e384ca74d04de879956f087aad1ae84fa6a3c7de52bc79e9f39a3c284a5cc6c3f917885d5760593c0b0aafdcc315a631faac3
+  languageName: node
+  linkType: hard
+
+"react-calendar@patch:react-calendar@npm%3A6.0.1#~/.yarn/patches/react-calendar-npm-6.0.1-22fe91a41c.patch":
+  version: 6.0.1
+  resolution: "react-calendar@patch:react-calendar@npm%3A6.0.1#~/.yarn/patches/react-calendar-npm-6.0.1-22fe91a41c.patch::version=6.0.1&hash=738a30"
+  dependencies:
+    "@wojtekmaj/date-utils": "npm:^2.0.2"
+    clsx: "npm:^2.0.0"
+    get-user-locale: "npm:^3.0.0"
+    warning: "npm:^4.0.0"
+  peerDependencies:
+    "@types/react": ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/02772e7725c6a6abeebe3214f46fc2355ab574e498f08054c0135c7f49207b52c34afa8cffd5a347c6a61f0a040b343380605380a1eccdeecf43c48ab5e9709f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`react-calendar` marks the selected date with a CSS class only. The tile buttons have no `aria-pressed` and no `aria-selected`. A screen reader announces the selected date exactly like every other date in the month.

This patches `react-calendar` to set `aria-pressed` on the tile buttons. The value comes from the same classes that give the tile its highlight. Nothing changes visually, and the accessible name stays the same.

The patch makes the same change as https://github.com/wojtekmaj/react-calendar/pull/940, which is closed. If it ever lands upstream, we can drop the patch.

Alternative to #130675, which puts the state in the accessible name instead.

Fixes #118784
