### PR TITLE
Provisioning: reject migrate/export jobs at creation when disabled

### DIFF
--- a/pkg/registry/apis/provisioning/jobs.go
+++ b/pkg/registry/apis/provisioning/jobs.go
@@ -37,7 +37,7 @@ type jobsConnector struct {
 	clients               resources.ClientFactory
 	folderMetadataEnabled bool
 	perfTestingEnabled    func(ctx context.Context) bool
-	exportEnabled         func(ctx context.Context) bool
+	exportEnabled         bool
 }
 
 func NewJobsConnector(
@@ -49,7 +49,7 @@ func NewJobsConnector(
 	clients resources.ClientFactory,
 	folderMetadataEnabled bool,
 	perfTestingEnabled func(ctx context.Context) bool,
-	exportEnabled func(ctx context.Context) bool,
+	exportEnabled bool,
 ) *jobsConnector {
 	return &jobsConnector{
 		repoGetter:            repoGetter,
@@ -317,10 +317,10 @@ func (c *jobsConnector) authorizeJob(ctx context.Context, repo repository.Reposi
 	// Reject export (push) and migrate jobs up front when the feature is disabled,
 	// so the API user gets a clear error at creation time instead of a job that is
 	// created only to complete as a no-op.
-	if spec.Action == provisioning.JobActionPush && (c.exportEnabled == nil || !c.exportEnabled(ctx)) {
+	if spec.Action == provisioning.JobActionPush && !c.exportEnabled {
 		return apierrors.NewBadRequest("push jobs require the provisioningExport feature flag")
 	}
-	if spec.Action == provisioning.JobActionMigrate && (c.exportEnabled == nil || !c.exportEnabled(ctx)) {
+	if spec.Action == provisioning.JobActionMigrate && !c.exportEnabled {
 		return apierrors.NewBadRequest("migrate jobs require the provisioningExport feature flag")
 	}
 

--- a/pkg/registry/apis/provisioning/jobs.go
+++ b/pkg/registry/apis/provisioning/jobs.go
@@ -37,6 +37,7 @@ type jobsConnector struct {
 	clients               resources.ClientFactory
 	folderMetadataEnabled bool
 	perfTestingEnabled    func(ctx context.Context) bool
+	exportEnabled         func(ctx context.Context) bool
 }
 
 func NewJobsConnector(
@@ -48,6 +49,7 @@ func NewJobsConnector(
 	clients resources.ClientFactory,
 	folderMetadataEnabled bool,
 	perfTestingEnabled func(ctx context.Context) bool,
+	exportEnabled func(ctx context.Context) bool,
 ) *jobsConnector {
 	return &jobsConnector{
 		repoGetter:            repoGetter,
@@ -58,6 +60,7 @@ func NewJobsConnector(
 		clients:               clients,
 		folderMetadataEnabled: folderMetadataEnabled,
 		perfTestingEnabled:    perfTestingEnabled,
+		exportEnabled:         exportEnabled,
 	}
 }
 
@@ -310,6 +313,15 @@ func (c *jobsConnector) authorizeJob(ctx context.Context, repo repository.Reposi
 	}
 	if spec.Action == provisioning.JobActionTest && (c.perfTestingEnabled == nil || !c.perfTestingEnabled(ctx)) {
 		return apierrors.NewBadRequest("test jobs require the provisioning.performance feature flag")
+	}
+	// Reject export (push) and migrate jobs up front when the feature is disabled,
+	// so the API user gets a clear error at creation time instead of a job that is
+	// created only to complete as a no-op.
+	if spec.Action == provisioning.JobActionPush && (c.exportEnabled == nil || !c.exportEnabled(ctx)) {
+		return apierrors.NewBadRequest("push jobs require the provisioningExport feature flag")
+	}
+	if spec.Action == provisioning.JobActionMigrate && (c.exportEnabled == nil || !c.exportEnabled(ctx)) {
+		return apierrors.NewBadRequest("migrate jobs require the provisioningExport feature flag")
 	}
 
 	switch spec.Action {

--- a/pkg/registry/apis/provisioning/jobs_test.go
+++ b/pkg/registry/apis/provisioning/jobs_test.go
@@ -133,11 +133,9 @@ func TestFixFolderMetadataFeatureGate(t *testing.T) {
 func TestExportFeatureGate(t *testing.T) {
 	ctx := context.Background()
 	cfg := newTestRepo("my-repo", "default")
-	disabled := func(context.Context) bool { return false }
-	enabled := func(context.Context) bool { return true }
 
 	t.Run("push rejected when disabled", func(t *testing.T) {
-		c := &jobsConnector{exportEnabled: disabled}
+		c := &jobsConnector{exportEnabled: false}
 		spec := provisioning.JobSpec{Action: provisioning.JobActionPush, Push: &provisioning.ExportJobOptions{}}
 
 		err := c.authorizeJob(ctx, nil, cfg, spec)
@@ -147,7 +145,7 @@ func TestExportFeatureGate(t *testing.T) {
 	})
 
 	t.Run("migrate rejected when disabled", func(t *testing.T) {
-		c := &jobsConnector{exportEnabled: disabled}
+		c := &jobsConnector{exportEnabled: false}
 		spec := provisioning.JobSpec{Action: provisioning.JobActionMigrate, Migrate: &provisioning.MigrateJobOptions{}}
 
 		err := c.authorizeJob(ctx, nil, cfg, spec)
@@ -156,18 +154,8 @@ func TestExportFeatureGate(t *testing.T) {
 		assert.Contains(t, err.Error(), "migrate jobs require the provisioningExport feature flag")
 	})
 
-	t.Run("rejected when exportEnabled is unset", func(t *testing.T) {
-		c := &jobsConnector{}
-		spec := provisioning.JobSpec{Action: provisioning.JobActionPush, Push: &provisioning.ExportJobOptions{}}
-
-		err := c.authorizeJob(ctx, nil, cfg, spec)
-		require.Error(t, err)
-		assert.True(t, apierrors.IsBadRequest(err))
-		assert.Contains(t, err.Error(), "provisioningExport feature flag")
-	})
-
 	t.Run("migrate passes the gate when enabled", func(t *testing.T) {
-		c := &jobsConnector{exportEnabled: enabled}
+		c := &jobsConnector{exportEnabled: true}
 		// spec.Migrate == nil short-circuits authorizeMigrateJob after the gate,
 		// so this exercises the gate without needing authorization mocks.
 		spec := provisioning.JobSpec{Action: provisioning.JobActionMigrate}
@@ -177,7 +165,7 @@ func TestExportFeatureGate(t *testing.T) {
 	})
 
 	t.Run("push passes the gate when enabled", func(t *testing.T) {
-		c := &jobsConnector{exportEnabled: enabled}
+		c := &jobsConnector{exportEnabled: true}
 		spec := provisioning.JobSpec{Action: provisioning.JobActionPush, Push: &provisioning.ExportJobOptions{}}
 
 		// Past the gate the push authorizer runs; with a nil repo it fails on the

--- a/pkg/registry/apis/provisioning/jobs_test.go
+++ b/pkg/registry/apis/provisioning/jobs_test.go
@@ -130,6 +130,64 @@ func TestFixFolderMetadataFeatureGate(t *testing.T) {
 	})
 }
 
+func TestExportFeatureGate(t *testing.T) {
+	ctx := context.Background()
+	cfg := newTestRepo("my-repo", "default")
+	disabled := func(context.Context) bool { return false }
+	enabled := func(context.Context) bool { return true }
+
+	t.Run("push rejected when disabled", func(t *testing.T) {
+		c := &jobsConnector{exportEnabled: disabled}
+		spec := provisioning.JobSpec{Action: provisioning.JobActionPush, Push: &provisioning.ExportJobOptions{}}
+
+		err := c.authorizeJob(ctx, nil, cfg, spec)
+		require.Error(t, err)
+		assert.True(t, apierrors.IsBadRequest(err))
+		assert.Contains(t, err.Error(), "push jobs require the provisioningExport feature flag")
+	})
+
+	t.Run("migrate rejected when disabled", func(t *testing.T) {
+		c := &jobsConnector{exportEnabled: disabled}
+		spec := provisioning.JobSpec{Action: provisioning.JobActionMigrate, Migrate: &provisioning.MigrateJobOptions{}}
+
+		err := c.authorizeJob(ctx, nil, cfg, spec)
+		require.Error(t, err)
+		assert.True(t, apierrors.IsBadRequest(err))
+		assert.Contains(t, err.Error(), "migrate jobs require the provisioningExport feature flag")
+	})
+
+	t.Run("rejected when exportEnabled is unset", func(t *testing.T) {
+		c := &jobsConnector{}
+		spec := provisioning.JobSpec{Action: provisioning.JobActionPush, Push: &provisioning.ExportJobOptions{}}
+
+		err := c.authorizeJob(ctx, nil, cfg, spec)
+		require.Error(t, err)
+		assert.True(t, apierrors.IsBadRequest(err))
+		assert.Contains(t, err.Error(), "provisioningExport feature flag")
+	})
+
+	t.Run("migrate passes the gate when enabled", func(t *testing.T) {
+		c := &jobsConnector{exportEnabled: enabled}
+		// spec.Migrate == nil short-circuits authorizeMigrateJob after the gate,
+		// so this exercises the gate without needing authorization mocks.
+		spec := provisioning.JobSpec{Action: provisioning.JobActionMigrate}
+
+		err := c.authorizeJob(ctx, nil, cfg, spec)
+		require.NoError(t, err)
+	})
+
+	t.Run("push passes the gate when enabled", func(t *testing.T) {
+		c := &jobsConnector{exportEnabled: enabled}
+		spec := provisioning.JobSpec{Action: provisioning.JobActionPush, Push: &provisioning.ExportJobOptions{}}
+
+		// Past the gate the push authorizer runs; with a nil repo it fails on the
+		// reader check, which proves the feature gate let the request through.
+		err := c.authorizeJob(ctx, nil, cfg, spec)
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), "provisioningExport feature flag")
+	})
+}
+
 func TestValidateWriteAccess_FixFolderMetadata(t *testing.T) {
 	c := &jobsConnector{}
 

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -920,7 +920,7 @@ func (b *APIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.APIGroupI
 	storage[provisioning.RepositoryResourceInfo.StoragePath("refs")] = WithTimeout(NewRefsConnector(b), 30*time.Second)
 	storage[provisioning.RepositoryResourceInfo.StoragePath("resources")] = WithTimeout(NewListConnector(b, b.resourceLister), 30*time.Second)
 	storage[provisioning.RepositoryResourceInfo.StoragePath("history")] = WithTimeout(NewHistorySubresource(b), 30*time.Second)
-	storage[provisioning.RepositoryResourceInfo.StoragePath("jobs")] = WithTimeout(NewJobsConnector(b, b, b, jobHistory, b.access, b.clients, b.folderMetadataEnabled, performanceEnabled), 30*time.Second)
+	storage[provisioning.RepositoryResourceInfo.StoragePath("jobs")] = WithTimeout(NewJobsConnector(b, b, b, jobHistory, b.access, b.clients, b.folderMetadataEnabled, performanceEnabled, exportEnabled), 30*time.Second)
 
 	// Add any extra storage
 	for _, extra := range b.extras {
@@ -945,6 +945,13 @@ func userAttributionEnabled(ctx context.Context) bool {
 // startup) so the flag behaves consistently with the other provisioning flags.
 func performanceEnabled(ctx context.Context) bool {
 	return openfeature.NewDefaultClient().Boolean(ctx, featuremgmt.FlagProvisioningPerformance, false, openfeature.TransactionContext(ctx))
+}
+
+// exportEnabled reports whether export (push) and migrate jobs are enabled.
+// Both are gated by the same provisioningExport flag, evaluated per request via
+// OpenFeature so job creation is rejected up front when the feature is disabled.
+func exportEnabled(ctx context.Context) bool {
+	return openfeature.NewDefaultClient().Boolean(ctx, featuremgmt.FlagProvisioningExport, false, openfeature.TransactionContext(ctx))
 }
 
 // Mutate delegates to the admission handler for resource-specific mutation

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -920,6 +920,7 @@ func (b *APIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.APIGroupI
 	storage[provisioning.RepositoryResourceInfo.StoragePath("refs")] = WithTimeout(NewRefsConnector(b), 30*time.Second)
 	storage[provisioning.RepositoryResourceInfo.StoragePath("resources")] = WithTimeout(NewListConnector(b, b.resourceLister), 30*time.Second)
 	storage[provisioning.RepositoryResourceInfo.StoragePath("history")] = WithTimeout(NewHistorySubresource(b), 30*time.Second)
+	exportEnabled := b.features.IsEnabledGlobally(featuremgmt.FlagProvisioningExport) //nolint:staticcheck
 	storage[provisioning.RepositoryResourceInfo.StoragePath("jobs")] = WithTimeout(NewJobsConnector(b, b, b, jobHistory, b.access, b.clients, b.folderMetadataEnabled, performanceEnabled, exportEnabled), 30*time.Second)
 
 	// Add any extra storage
@@ -945,13 +946,6 @@ func userAttributionEnabled(ctx context.Context) bool {
 // startup) so the flag behaves consistently with the other provisioning flags.
 func performanceEnabled(ctx context.Context) bool {
 	return openfeature.NewDefaultClient().Boolean(ctx, featuremgmt.FlagProvisioningPerformance, false, openfeature.TransactionContext(ctx))
-}
-
-// exportEnabled reports whether export (push) and migrate jobs are enabled.
-// Both are gated by the same provisioningExport flag, evaluated per request via
-// OpenFeature so job creation is rejected up front when the feature is disabled.
-func exportEnabled(ctx context.Context) bool {
-	return openfeature.NewDefaultClient().Boolean(ctx, featuremgmt.FlagProvisioningExport, false, openfeature.TransactionContext(ctx))
 }
 
 // Mutate delegates to the admission handler for resource-specific mutation

--- a/pkg/tests/apis/provisioning/disabledfeatures_test.go
+++ b/pkg/tests/apis/provisioning/disabledfeatures_test.go
@@ -4,11 +4,32 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
+
+// createJobExpectingError posts a job to the repositories/{repo}/jobs subresource
+// and returns the API error, asserting the request failed. The shared test env
+// disables the provisioningExport feature flag, so migrate and export jobs are
+// rejected up front at job creation time.
+func createJobExpectingError(t *testing.T, helper *common.ProvisioningTestHelper, repo string, spec provisioning.JobSpec) error {
+	t.Helper()
+
+	result := helper.AdminREST.Post().
+		Namespace("default").
+		Resource("repositories").
+		Name(repo).
+		SubResource("jobs").
+		Body(common.AsJSON(spec)).
+		SetHeader("Content-Type", "application/json").
+		Do(t.Context())
+
+	err := result.Error()
+	require.Error(t, err, "job creation should be rejected while the feature is disabled")
+	return err
+}
 
 func TestIntegrationProvisioning_MigrateDisabledByConfiguration(t *testing.T) {
 	helper := sharedHelper(t)
@@ -28,21 +49,9 @@ func TestIntegrationProvisioning_MigrateDisabledByConfiguration(t *testing.T) {
 		},
 	}
 
-	job := helper.TriggerJobAndWaitForComplete(t, repo, spec)
-
-	status, found, err := unstructured.NestedMap(job.Object, "status")
-	require.NoError(t, err)
-	require.True(t, found, "job should have status")
-
-	state, found, err := unstructured.NestedString(status, "state")
-	require.NoError(t, err)
-	require.True(t, found)
-	require.Equal(t, "warning", state, "a disabled feature is a configuration state, not a failure")
-
-	message, found, err := unstructured.NestedString(status, "message")
-	require.NoError(t, err)
-	require.True(t, found)
-	require.Contains(t, message, "migrate functionality is disabled by configuration")
+	err := createJobExpectingError(t, helper, repo, spec)
+	require.True(t, apierrors.IsBadRequest(err), "expected a bad request, got %v", err)
+	require.Contains(t, err.Error(), "migrate jobs require the provisioningExport feature flag")
 }
 
 func TestIntegrationProvisioning_ExportDisabledByConfiguration(t *testing.T) {
@@ -64,19 +73,7 @@ func TestIntegrationProvisioning_ExportDisabledByConfiguration(t *testing.T) {
 		},
 	}
 
-	job := helper.TriggerJobAndWaitForComplete(t, repo, spec)
-
-	status, found, err := unstructured.NestedMap(job.Object, "status")
-	require.NoError(t, err)
-	require.True(t, found, "job should have status")
-
-	state, found, err := unstructured.NestedString(status, "state")
-	require.NoError(t, err)
-	require.True(t, found)
-	require.Equal(t, "warning", state, "a disabled feature is a configuration state, not a failure")
-
-	message, found, err := unstructured.NestedString(status, "message")
-	require.NoError(t, err)
-	require.True(t, found)
-	require.Contains(t, message, "export functionality is disabled by configuration")
+	err := createJobExpectingError(t, helper, repo, spec)
+	require.True(t, apierrors.IsBadRequest(err), "expected a bad request, got %v", err)
+	require.Contains(t, err.Error(), "push jobs require the provisioningExport feature flag")
 }


### PR DESCRIPTION
**What is this feature?**

Migrate and export (`push`) jobs are now rejected up front at **job-creation validation time** with a `400 Bad Request` when the `provisioningExport` feature flag is disabled, instead of the job being accepted and later completing as a no-op.

```
POST /apis/provisioning.grafana.app/v0alpha1/namespaces/<ns>/repositories/<repo>/jobs
{ "action": "migrate", ... }
=> 400 Bad Request: "migrate jobs require the provisioningExport feature flag"
```

Both actions are gated by the same `provisioningExport` flag. Implemented in `jobsConnector.authorizeJob`, which already runs before the job is inserted into the queue. The flag is captured once at storage setup via the feature toggle (`features.IsEnabledGlobally`), the same way `folderMetadataEnabled` is wired for this connector.

**Why do we need this feature?**

Follow-up to #130742. That PR made a migrate/export job submitted while the feature is disabled complete in a *warning* state instead of an error, removing the false-failure log/alert noise. This PR goes one step further, as suggested in review: when the request comes through the API, it is clearer for the API user to fail immediately at creation than to accept a job that silently does nothing.

The worker-level warning behavior from #130742 remains as defense-in-depth for jobs created outside this API path (for example the standalone jobs operator) or already queued when the flag flips.

**Who is this feature for?**

API users / operators of Grafana instances where provisioning migrate/export is disabled by configuration — they now get immediate, actionable feedback at job creation.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

- Depends conceptually on #130742 (already merged to `main`); this branch is based on the merged state.
- No new feature toggle — reuses the existing `provisioningExport` flag via the legacy feature-toggle mechanism (`b.features.IsEnabledGlobally`), consistent with how the export worker and `folderMetadataEnabled` read it today. Note: #130131 is separately migrating this toggle to OpenFeature; kept on the legacy flag here to avoid conflicting with that in-flight work.
- Tests: added `TestExportFeatureGate` (push/migrate rejected when disabled; both pass the gate when enabled). Updated the migrate/export disabled-by-config integration tests to assert the creation-time `BadRequest` (the shared integration env disables `provisioningExport`).
- `go build`, `go vet`, and the provisioning unit tests pass.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)