### PR TITLE
Unified storage: honour garbage_collection_dry_run in the SQL backend

### DIFF
--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -54,11 +54,26 @@ const defaultGarbageCollectionBatchWait = 1 * time.Second
 
 type GarbageCollectionConfig struct {
 	Enabled          bool
+	DryRun           bool
 	Interval         time.Duration // how often the process runs
 	BatchSize        int           // max number of candidates to delete (unique NGR)
 	BatchWait        time.Duration // wait between batches to avoid overwhelming the datastore
 	MaxAge           time.Duration // retention period
 	DashboardsMaxAge time.Duration // dashboard retention
+}
+
+// NewGarbageCollectionConfig keeps the mapping from settings in one place, so callers
+// building the SQL backend themselves cannot miss a field.
+func NewGarbageCollectionConfig(cfg *setting.Cfg) GarbageCollectionConfig {
+	return GarbageCollectionConfig{
+		Enabled:          cfg.EnableGarbageCollection,
+		DryRun:           cfg.GarbageCollectionDryRun,
+		Interval:         cfg.GarbageCollectionInterval,
+		BatchSize:        cfg.GarbageCollectionBatchSize,
+		BatchWait:        cfg.GarbageCollectionBatchWait,
+		MaxAge:           cfg.GarbageCollectionMaxAge,
+		DashboardsMaxAge: cfg.DashboardsGarbageCollectionMaxAge,
+	}
 }
 
 func ProvideStorageBackend(
@@ -159,20 +174,13 @@ func NewStorageBackend(
 
 	if !cfg.EnableSQLKVBackend {
 		return NewBackend(BackendOptions{
-			DBProvider:           eDB,
-			Reg:                  reg,
-			IsHA:                 isHA,
-			storageMetrics:       storageMetrics,
-			LastImportTimeMaxAge: cfg.MaxFileIndexAge,
-			GCGate:               gcGate,
-			GarbageCollection: GarbageCollectionConfig{
-				Enabled:          cfg.EnableGarbageCollection,
-				Interval:         cfg.GarbageCollectionInterval,
-				BatchSize:        cfg.GarbageCollectionBatchSize,
-				BatchWait:        cfg.GarbageCollectionBatchWait,
-				MaxAge:           cfg.GarbageCollectionMaxAge,
-				DashboardsMaxAge: cfg.DashboardsGarbageCollectionMaxAge,
-			},
+			DBProvider:              eDB,
+			Reg:                     reg,
+			IsHA:                    isHA,
+			storageMetrics:          storageMetrics,
+			LastImportTimeMaxAge:    cfg.MaxFileIndexAge,
+			GCGate:                  gcGate,
+			GarbageCollection:       NewGarbageCollectionConfig(cfg),
 			SimulatedNetworkLatency: cfg.SimulatedNetworkLatency,
 			MigrationParquetBuffer:  cfg.MigrationParquetBuffer,
 			MigrationChunkedWrites:  cfg.MigrationChunkedWrites,
@@ -586,7 +594,7 @@ func (b *backend) initPruner(ctx context.Context) error {
 }
 
 func (b *backend) initGarbageCollection(ctx context.Context) error {
-	b.log.Info("starting garbage collection loop")
+	b.log.Info("starting garbage collection loop", "dry_run", b.garbageCollection.DryRun)
 
 	go func() {
 		// Wait for the migration gate so GC never prunes rows an in-process
@@ -652,6 +660,11 @@ func (b *backend) runGarbageCollection(ctx context.Context, cutoffTimeStamp int6
 					break
 				}
 				totalDeleted += deleted
+				// A dry run deletes nothing, so the next batch would return the same
+				// candidates forever. Stop after the first batch.
+				if b.garbageCollection.DryRun {
+					break
+				}
 				if deleted < int64(b.garbageCollection.BatchSize) {
 					break
 				}
@@ -662,7 +675,11 @@ func (b *backend) runGarbageCollection(ctx context.Context, cutoffTimeStamp int6
 				}
 			}
 			if totalDeleted > 0 {
-				b.log.Info("garbage collection deleted history",
+				message := "garbage collection deleted history"
+				if b.garbageCollection.DryRun {
+					message = "garbage collection dry run"
+				}
+				b.log.Info(message,
 					"group", group,
 					"resource", resourceName,
 					"rows", totalDeleted,
@@ -706,6 +723,13 @@ func (b *backend) garbageCollectBatch(ctx context.Context, group, resourceName s
 			return nil
 		}
 		span.AddEvent("candidates", trace.WithAttributes(attribute.Int("candidates", len(candidates))))
+		if b.garbageCollection.DryRun {
+			// Report the candidates instead of deleting them. This counts resources, not
+			// history rows, because each candidate can have several rows.
+			rowsAffected = int64(len(candidates))
+			span.AddEvent("dry run", trace.WithAttributes(attribute.Int64("candidates", rowsAffected)))
+			return nil
+		}
 		res, err := dbutil.Exec(ctx, tx, sqlResourceHistoryGCDeleteByNames, &sqlGarbageCollectDeleteByNamesRequest{
 			SQLTemplate: sqltemplate.New(b.dialect),
 			Group:       group,

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -677,7 +677,9 @@ func (b *backend) runGarbageCollection(ctx context.Context, cutoffTimeStamp int6
 			if totalDeleted > 0 {
 				message := "garbage collection deleted history"
 				if b.garbageCollection.DryRun {
-					message = "garbage collection dry run"
+					// The count is one batch, not the whole backlog, so the message must not
+					// read like a total.
+					message = "garbage collection dry run, first batch only"
 				}
 				b.log.Info(message,
 					"group", group,

--- a/pkg/storage/unified/sql/backend_gc_test.go
+++ b/pkg/storage/unified/sql/backend_gc_test.go
@@ -77,6 +77,42 @@ func TestIntegrationGarbageCollectionBatch(t *testing.T) {
 		require.Len(t, historyResp.Items, 0)
 	})
 
+	t.Run("dry run reports candidates without deleting history", func(t *testing.T) {
+		testutil.SkipIntegrationTestInShortMode(t)
+		t.Cleanup(db.CleanupTestDB)
+
+		ctx := testutil.NewTestContext(t, time.Now().Add(30*time.Second))
+
+		dryRunConfig := gcConfig
+		dryRunConfig.DryRun = true
+		storageBackend, sqlDB := newTestBackend(t, dryRunConfig)
+		b := storageBackend.(*backend)
+
+		rv1, err := test.WriteEvent(ctx, storageBackend, "resource1", resourcepb.WatchEvent_ADDED)
+		require.NoError(t, err)
+		_, err = test.WriteEvent(ctx, storageBackend, "resource1", resourcepb.WatchEvent_DELETED, test.WithNamespaceAndRV("namespace", rv1))
+		require.NoError(t, err)
+
+		historyRows := func() int {
+			var n int
+			row := sqlDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM resource_history")
+			require.NoError(t, row.Scan(&n))
+			return n
+		}
+		require.Equal(t, 2, historyRows())
+
+		cutoffTimestamp := time.Now().Add(time.Hour).UnixMicro() // everything eligible for deletion
+		candidates, err := b.garbageCollectBatch(ctx, "group", "resource", cutoffTimestamp, 100)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), candidates)
+		require.Equal(t, 2, historyRows())
+
+		// The loop must not spin on candidates it never deletes.
+		results := b.runGarbageCollection(ctx, cutoffTimestamp)
+		require.Equal(t, int64(1), results["group/resource"])
+		require.Equal(t, 2, historyRows())
+	})
+
 	t.Run("will only garbage collect eligible resources before cutoff", func(t *testing.T) {
 		testutil.SkipIntegrationTestInShortMode(t)
 		t.Cleanup(db.CleanupTestDB)


### PR DESCRIPTION
`garbage_collection_dry_run` was ignored by the SQL backend, which is the default. The collector deleted `resource_history` rows anyway, so anyone trying dry run on a default deployment was losing history while believing nothing was removed. Only the sqlkv backend respected the setting.

Dry run now counts the candidates it found, skips the delete and logs `garbage collection dry run` with the same fields as sqlkv. It stops after one batch, since nothing is deleted and the same candidates would keep coming back. Without dry run, behaviour is unchanged. The count is candidate resources, not history rows, because an exact row count would need an extra query.

Also a prerequisite for #130676, which reads `garbage_collection_dry_run` to mean "nothing is being deleted, so keep showing trash".