### PR TITLE
unified-search: wait longer for storage before giving up on a snapshot

### DIFF
--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -184,6 +184,8 @@ type SnapshotOptions struct {
 	MinDocCount int64
 
 	// MaxIndexAge is the maximum age of a remote snapshot that can be downloaded.
+	// Cleanup deletes by this value too, so snapshots cannot be kept for longer than
+	// instances will accept them. Raise it to cover a version compatibility window.
 	// Older snapshots are skipped (hard filter). Zero means "no age limit":
 	// snapshots are accepted regardless of age, and cleanup does not delete
 	// snapshots based on age (cleanup's per-version-group eviction of

--- a/pkg/storage/unified/search/bleve_snapshot.go
+++ b/pkg/storage/unified/search/bleve_snapshot.go
@@ -604,7 +604,7 @@ func findFreshSnapshot(
 	logger log.Logger,
 	isFresh func(*IndexMeta) bool,
 ) (ulid.ULID, *IndexMeta, error) {
-	keys, err := retryRemoteIndexStoreValue(ctx, snapshotStoreOpListIndexKeys, nil, func() ([]ulid.ULID, error) {
+	keys, err := retryMetadataRemoteIndexStoreValue(ctx, snapshotStoreOpListIndexKeys, nil, func() ([]ulid.ULID, error) {
 		return store.ListIndexKeys(ctx, ns)
 	})
 	if err != nil {

--- a/pkg/storage/unified/search/remote_index_store.go
+++ b/pkg/storage/unified/search/remote_index_store.go
@@ -49,11 +49,25 @@ const (
 	snapshotStoreOpDeleteIndex                      = "delete_index"
 )
 
+// snapshotStoreRetryBackoffConfig covers the per-file transfers, which only retry
+// on transient errors (see isRetryableSnapshotStoreError). Up to 10s each. Files
+// are fetched one after another, so a snapshot whose every file keeps failing costs
+// this once per file.
 var snapshotStoreRetryBackoffConfig = backoff.Config{
 	MinBackoff: 100 * time.Millisecond,
-	MaxBackoff: time.Second,
-	// dskit/backoff counts retries after the initial attempt, so this is at most three tries total.
-	MaxRetries: 2,
+	MaxBackoff: 4 * time.Second,
+	// dskit/backoff counts retries after the initial attempt, so this is seven tries.
+	MaxRetries: 6,
+}
+
+// snapshotStoreMetadataRetryBackoffConfig covers listing and manifest reads, which
+// run a few times per download rather than once per file. Failing them leaves no
+// candidate and the caller builds from scratch, which costs far more than waiting,
+// so these get about 30s against 10s for a file.
+var snapshotStoreMetadataRetryBackoffConfig = backoff.Config{
+	MinBackoff: 200 * time.Millisecond,
+	MaxBackoff: 5 * time.Second,
+	MaxRetries: 10,
 }
 
 // remoteIndexStoreRetryLogger is used only when callers do not have a contextual logger to pass in.
@@ -264,11 +278,20 @@ func retryRemoteIndexStore(ctx context.Context, operation string, logger log.Log
 }
 
 func retryRemoteIndexStoreValue[T any](ctx context.Context, operation string, logger log.Logger, fn func() (T, error)) (T, error) {
+	return retryRemoteIndexStoreValueWithBackoff(ctx, snapshotStoreRetryBackoffConfig, operation, logger, fn)
+}
+
+// retryMetadataRemoteIndexStoreValue retries with the longer metadata budget.
+func retryMetadataRemoteIndexStoreValue[T any](ctx context.Context, operation string, logger log.Logger, fn func() (T, error)) (T, error) {
+	return retryRemoteIndexStoreValueWithBackoff(ctx, snapshotStoreMetadataRetryBackoffConfig, operation, logger, fn)
+}
+
+func retryRemoteIndexStoreValueWithBackoff[T any](ctx context.Context, cfg backoff.Config, operation string, logger log.Logger, fn func() (T, error)) (T, error) {
 	if logger == nil {
 		logger = remoteIndexStoreRetryLogger
 	}
 
-	bo := backoff.New(ctx, snapshotStoreRetryBackoffConfig)
+	bo := backoff.New(ctx, cfg)
 	for {
 		result, err := fn()
 		if err == nil || !isRetryableSnapshotStoreError(ctx, err) {
@@ -748,7 +771,7 @@ func downloadSnapshotFileToDisk(ctx context.Context, store RemoteIndexStore, ns 
 // wrapping ErrInvalidManifest if the manifest is structurally invalid
 // (oversized, unparseable, empty file list, or non-canonical paths).
 func ReadIndexSnapshotManifest(ctx context.Context, store RemoteIndexStore, nsResource resource.NamespacedResource, indexKey ulid.ULID) (*IndexMeta, error) {
-	manifest, err := retryRemoteIndexStoreValue(ctx, snapshotStoreOpReadManifest, nil, func() ([]byte, error) {
+	manifest, err := retryMetadataRemoteIndexStoreValue(ctx, snapshotStoreOpReadManifest, nil, func() ([]byte, error) {
 		return store.ReadSnapshotManifest(ctx, nsResource, indexKey)
 	})
 	if err != nil {
@@ -797,7 +820,7 @@ func ValidateIndexSnapshotManifest(meta *IndexMeta) error {
 // (e.g. by a concurrent cleanup pass); callers acting on the returned
 // snapshots must handle ErrSnapshotNotFound from follow-up calls.
 func ListIndexSnapshots(ctx context.Context, store RemoteIndexStore, nsResource resource.NamespacedResource, logger log.Logger) (map[ulid.ULID]*IndexMeta, error) {
-	keys, err := retryRemoteIndexStoreValue(ctx, snapshotStoreOpListIndexKeys, logger, func() ([]ulid.ULID, error) {
+	keys, err := retryMetadataRemoteIndexStoreValue(ctx, snapshotStoreOpListIndexKeys, logger, func() ([]ulid.ULID, error) {
 		return store.ListIndexKeys(ctx, nsResource)
 	})
 	if err != nil {

--- a/pkg/storage/unified/search/remote_index_store_test.go
+++ b/pkg/storage/unified/search/remote_index_store_test.go
@@ -48,7 +48,27 @@ func useFastSnapshotStoreRetries(t *testing.T) {
 	snapshotStoreRetryBackoffConfig.MinBackoff = 0
 	snapshotStoreRetryBackoffConfig.MaxBackoff = 0
 	snapshotStoreRetryBackoffConfig.MaxRetries = 2
-	t.Cleanup(func() { snapshotStoreRetryBackoffConfig = old })
+	oldMeta := snapshotStoreMetadataRetryBackoffConfig
+	snapshotStoreMetadataRetryBackoffConfig.MinBackoff = 0
+	snapshotStoreMetadataRetryBackoffConfig.MaxBackoff = 0
+	t.Cleanup(func() {
+		snapshotStoreRetryBackoffConfig = old
+		snapshotStoreMetadataRetryBackoffConfig = oldMeta
+	})
+}
+
+// Failing a metadata read leaves no candidate, so it waits longer than a file read.
+func TestMetadataRetriesOutlastFileRetries(t *testing.T) {
+	require.Greater(t, snapshotStoreMetadataRetryBackoffConfig.MaxRetries, snapshotStoreRetryBackoffConfig.MaxRetries)
+
+	useFastSnapshotStoreRetries(t)
+	attempts := 0
+	_, err := retryMetadataRemoteIndexStoreValue(t.Context(), "test", nil, func() (struct{}, error) {
+		attempts++
+		return struct{}{}, transientTestError{}
+	})
+	require.Error(t, err)
+	require.Equal(t, snapshotStoreMetadataRetryBackoffConfig.MaxRetries+1, attempts)
 }
 
 // testBucket returns a bucket for testing. Uses CDK_TEST_BUCKET_URL if set,


### PR DESCRIPTION
A transient storage failure at index build time cost far more than it should. Retries gave up after three tries within about half a second, and once the snapshot path failed the caller built the index from scratch — hours of work for a large index.

Listing and manifest reads now retry for about 30s, each file transfer for up to 10s. They differ because file reads run once per file and one after another, so a long budget there multiplies, while failing a listing or manifest read leaves no candidate at all. Only transient errors are retried, as before.

Also records that `MaxIndexAge` is what cleanup deletes by, so snapshots cannot be kept for longer than instances will accept them.

Closes https://github.com/grafana/search-and-storage-team/issues/916
