### PR TITLE
IAM: enforce version-policy cap on the local-store path

### DIFF
--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -52,6 +52,7 @@ import (
 	gfauthorizer "github.com/grafana/grafana/pkg/services/apiserver/auth/authorizer"
 	"github.com/grafana/grafana/pkg/services/apiserver/auth/authorizer/storewrapper"
 	"github.com/grafana/grafana/pkg/services/apiserver/builder"
+	"github.com/grafana/grafana/pkg/services/apiserver/versionpolicy"
 	"github.com/grafana/grafana/pkg/services/authz/zanzana"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/org"
@@ -1180,8 +1181,13 @@ func NewLocalStore(resourceInfo utils.ResourceInfo, scheme *runtime.Scheme, defa
 		return nil, err
 	}
 
+	var vp *versionpolicy.VersionPolicyRegistry
+	if g, ok := defaultOptsGetter.(*apistore.RESTOptionsGetter); ok {
+		vp = g.VersionPolicy()
+	}
+
 	client := resource.NewLocalResourceClient(server)
-	optsGetter := apistore.NewRESTOptionsGetterForClient(client, nil, defaultOpts.StorageConfig.Config, nil, nil)
+	optsGetter := apistore.NewRESTOptionsGetterForClient(client, nil, defaultOpts.StorageConfig.Config, nil, vp)
 
 	store, err := grafanaregistry.NewRegistryStoreWithSelectableFields(scheme, resourceInfo, optsGetter, selectableFieldsOpts)
 	return store, err

--- a/pkg/registry/apis/iam/register_test.go
+++ b/pkg/registry/apis/iam/register_test.go
@@ -3,6 +3,7 @@ package iam
 import (
 	"fmt"
 	"io"
+	"reflect"
 	"testing"
 
 	badger "github.com/dgraph-io/badger/v4"
@@ -11,12 +12,15 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
 
 	authlib "github.com/grafana/authlib/types"
 	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	legacyiamv0 "github.com/grafana/grafana/pkg/apis/iam/v0alpha1"
 	grafanaregistry "github.com/grafana/grafana/pkg/apiserver/registry/generic"
 	"github.com/grafana/grafana/pkg/services/apiserver/versionpolicy"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -67,9 +71,9 @@ func TestInstallSchema_ResourcePermissionsGate(t *testing.T) {
 
 // TestCodecPathResourcesRegisterOneVersionPerType guards apimachinery's LegacyCodec version-order
 // fallback: it only lets preferred_api_version reorder the persisted version when a type has no
-// exact-match GVK. It runs InstallSchema for real (all gates on), so any future version reusing an
-// existing struct fails here too. See the dashboard package's test of the same name for the other
-// codec-path group.
+// exact-match GVK. It runs InstallSchema for real (all gates on) and walks every type it registers,
+// so any resource - not just a hardcoded list - fails here if it starts sharing a Go struct across
+// versions. See the dashboard package's test of the same name for the other codec-path group.
 func TestCodecPathResourcesRegisterOneVersionPerType(t *testing.T) {
 	allOn := map[string]memprovider.InMemoryFlag{}
 	for _, flag := range []string{
@@ -87,19 +91,60 @@ func TestCodecPathResourcesRegisterOneVersionPerType(t *testing.T) {
 	b := &IdentityAccessManagementAPIBuilder{ofClient: openfeature.NewDefaultClient()}
 	require.NoError(t, b.InstallSchema(scheme))
 
-	for _, obj := range []runtime.Object{
-		iamv0.TeamResourceInfo.NewFunc(),
-		iamv0.UserResourceInfo.NewFunc(),
-		iamv0.ServiceAccountResourceInfo.NewFunc(),
-		iamv0.RoleInfo.NewFunc(),
-		iamv0.GlobalRoleInfo.NewFunc(),
+	assertNoTypeSpansMultipleGVKs(t, scheme)
+}
+
+// commonMultiVersionTypes are registered once per group-version by convention (metav1.
+// AddToGroupVersion's WatchEvent/options types, and each app's own PartialObjectMetadata(List)
+// registration), plus app-specific types deliberately shared across versions. None of these round-trip
+// through Storage.Create, so they're not the risk assertNoTypeSpansMultipleGVKs guards against. Adding
+// to this list is a conscious, reviewed exception, not a silent pass - any new entry should say why.
+var commonMultiVersionTypes = func() map[reflect.Type]bool {
+	m := map[reflect.Type]bool{}
+	for _, o := range []runtime.Object{
+		&metav1.WatchEvent{}, &metav1.ListOptions{}, &metav1.GetOptions{}, &metav1.DeleteOptions{},
+		&metav1.CreateOptions{}, &metav1.UpdateOptions{}, &metav1.PatchOptions{},
+		&metav1.PartialObjectMetadata{}, &metav1.PartialObjectMetadataList{},
+		// legacyiamv0.AddKnownTypes(scheme, version) is called for both legacyiamv0.VERSION and
+		// runtime.APIVersionInternal (register.go's InstallSchema) "to avoid the error: no kind is
+		// registered for the type" on PATCH/server-side-apply - not a codec-path write; none of these
+		// go through StorageOptsRegister with Scheme == nil.
+		&legacyiamv0.SSOSetting{}, &legacyiamv0.SSOSettingList{}, &legacyiamv0.UserTeamList{},
+		&legacyiamv0.DisplayList{}, &legacyiamv0.TeamMemberList{},
 	} {
-		gvks, _, err := scheme.ObjectKinds(obj)
-		require.NoError(t, err)
+		m[reflect.TypeOf(o).Elem()] = true
+	}
+	return m
+}()
+
+// assertNoTypeSpansMultipleGVKs walks every type a scheme actually knows about (as built by a
+// builder's real InstallSchema) and fails if any resource type is registered at 2+
+// GroupVersionKinds. apimachinery's LegacyCodec order-fallback only fires for such a type - the "true
+// internal/hub Go struct shared across versions" pattern - so this is what would flip
+// preferred_api_version from a discovery-only setting into one that silently picks what gets
+// persisted. It intentionally covers every registered resource, not a hardcoded list, so a brand new
+// resource kind is checked without editing this test.
+func assertNoTypeSpansMultipleGVKs(t *testing.T, scheme *runtime.Scheme) {
+	t.Helper()
+	byType := map[reflect.Type][]schema.GroupVersionKind{}
+	for gvk, typ := range scheme.AllKnownTypes() {
+		if commonMultiVersionTypes[typ] {
+			continue
+		}
+		obj, ok := reflect.New(typ).Interface().(runtime.Object)
+		if !ok {
+			continue
+		}
+		if unversioned, ok := scheme.IsUnversioned(obj); ok && unversioned {
+			continue // e.g. metav1.Status - genuinely version-independent, not a codec-fallback risk
+		}
+		byType[typ] = append(byType[typ], gvk)
+	}
+	for typ, gvks := range byType {
 		require.Lenf(t, gvks, 1,
-			"%T is registered at %v - a Go type shared across group versions activates the LegacyCodec "+
-				"order-fallback, so preferred_api_version would now pick the persisted version for this "+
-				"resource instead of only ordering API discovery", obj, gvks)
+			"%s is registered at %v - a Go type shared across group versions activates the LegacyCodec "+
+				"order-fallback, so preferred_api_version would now silently pick the persisted version "+
+				"for this type instead of only ordering API discovery", typ, gvks)
 	}
 }
 

--- a/pkg/registry/apis/iam/register_test.go
+++ b/pkg/registry/apis/iam/register_test.go
@@ -65,6 +65,44 @@ func TestInstallSchema_ResourcePermissionsGate(t *testing.T) {
 	}
 }
 
+// TestCodecPathResourcesRegisterOneVersionPerType guards apimachinery's LegacyCodec version-order
+// fallback: it only lets preferred_api_version reorder the persisted version when a type has no
+// exact-match GVK. It runs InstallSchema for real (all gates on), so any future version reusing an
+// existing struct fails here too. See the dashboard package's test of the same name for the other
+// codec-path group.
+func TestCodecPathResourcesRegisterOneVersionPerType(t *testing.T) {
+	allOn := map[string]memprovider.InMemoryFlag{}
+	for _, flag := range []string{
+		featuremgmt.FlagKubernetesAuthzRolesApi,
+		featuremgmt.FlagKubernetesAuthzRoleBindingsApi,
+		featuremgmt.FlagKubernetesAuthzGlobalRolesApi,
+		featuremgmt.FlagKubernetesAuthzTeamLBACRuleApi,
+		featuremgmt.FlagKubernetesAuthzResourcePermissionApis,
+	} {
+		allOn[flag] = memprovider.InMemoryFlag{Key: flag, DefaultVariant: "default", Variants: map[string]any{"default": true}}
+	}
+	require.NoError(t, openfeature.SetProviderAndWait(memprovider.NewInMemoryProvider(allOn)))
+
+	scheme := runtime.NewScheme()
+	b := &IdentityAccessManagementAPIBuilder{ofClient: openfeature.NewDefaultClient()}
+	require.NoError(t, b.InstallSchema(scheme))
+
+	for _, obj := range []runtime.Object{
+		iamv0.TeamResourceInfo.NewFunc(),
+		iamv0.UserResourceInfo.NewFunc(),
+		iamv0.ServiceAccountResourceInfo.NewFunc(),
+		iamv0.RoleInfo.NewFunc(),
+		iamv0.GlobalRoleInfo.NewFunc(),
+	} {
+		gvks, _, err := scheme.ObjectKinds(obj)
+		require.NoError(t, err)
+		require.Lenf(t, gvks, 1,
+			"%T is registered at %v - a Go type shared across group versions activates the LegacyCodec "+
+				"order-fallback, so preferred_api_version would now pick the persisted version for this "+
+				"resource instead of only ordering API discovery", obj, gvks)
+	}
+}
+
 // fixedVersionCodec always encodes to a fixed apiVersion, standing in for a real versioning codec
 // (e.g. a LegacyCodec after ReorderGroupVersionsForLegacyCodec) that persists a different version
 // than the caller declared. Decode/Identifier are unused on the create path this test exercises.

--- a/pkg/registry/apis/iam/register_test.go
+++ b/pkg/registry/apis/iam/register_test.go
@@ -1,15 +1,27 @@
 package iam
 
 import (
+	"fmt"
+	"io"
 	"testing"
 
+	badger "github.com/dgraph-io/badger/v4"
 	"github.com/open-feature/go-sdk/openfeature"
 	"github.com/open-feature/go-sdk/openfeature/memprovider"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/storage/storagebackend"
 
+	authlib "github.com/grafana/authlib/types"
 	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	grafanaregistry "github.com/grafana/grafana/pkg/apiserver/registry/generic"
+	"github.com/grafana/grafana/pkg/services/apiserver/versionpolicy"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/storage/unified/apistore"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
 )
 
 func TestInstallSchema_ResourcePermissionsGate(t *testing.T) {
@@ -51,4 +63,63 @@ func TestInstallSchema_ResourcePermissionsGate(t *testing.T) {
 				"ResourcePermission kind registration should match %s=%v", featuremgmt.FlagKubernetesAuthzResourcePermissionApis, tt.flagEnabled)
 		})
 	}
+}
+
+// fixedVersionCodec always encodes to a fixed apiVersion, standing in for a real versioning codec
+// (e.g. a LegacyCodec after ReorderGroupVersionsForLegacyCodec) that persists a different version
+// than the caller declared. Decode/Identifier are unused on the create path this test exercises.
+type fixedVersionCodec struct {
+	runtime.Codec
+	apiVersion string
+}
+
+func (c fixedVersionCodec) Encode(_ runtime.Object, w io.Writer) error {
+	_, err := fmt.Fprintf(w, `{"apiVersion":%q,"kind":"GlobalRole","metadata":{"name":"over-cap"}}`, c.apiVersion)
+	return err
+}
+
+// TestNewLocalStore_EnforcesVersionCap is a regression guard for the fix in NewLocalStore: it used
+// to build its RESTOptionsGetter with a nil version policy, so writes through the local-store path
+// bypassed the group's maxAllowedVersion cap entirely (unlike the sibling uniStore path). This drives
+// a real Create through the store NewLocalStore returns and asserts an over-cap write is now rejected.
+func TestNewLocalStore_EnforcesVersionCap(t *testing.T) {
+	group := iamv0.GROUP
+
+	vp := versionpolicy.NewVersionPolicyRegistry(
+		versionpolicy.NewResolver(map[string][]string{group: {"v1", "v0alpha1"}}),
+		map[string]versionpolicy.VersionPolicy{group: {MaxAllowedVersion: "v0alpha1"}},
+	)
+	// GetRESTOptions never touches the client, only original.Codec/original.EncodeVersioner - so a
+	// nil client is fine here; this getter stands in for the outer apiserver's RESTOptionsGetter.
+	defaultOptsGetter := apistore.NewRESTOptionsGetterForClient(nil, nil, storagebackend.Config{
+		Codec: fixedVersionCodec{apiVersion: group + "/v1"}, // simulates a codec persisting above the v0alpha1 cap
+	}, nil, vp)
+
+	db, err := badger.Open(badger.DefaultOptions("").WithInMemory(true).WithLogger(nil))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	backend, err := resource.NewKVStorageBackend(resource.KVBackendOptions{
+		KvStore:                resource.NewBadgerKV(db),
+		DisableStorageServices: true,
+	})
+	require.NoError(t, err)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, iamv0.AddToScheme(scheme))
+
+	regStore, err := NewLocalStore(iamv0.GlobalRoleInfo, scheme, defaultOptsGetter, prometheus.NewRegistry(), nil, backend, grafanaregistry.SelectableFieldsOptions{})
+	require.NoError(t, err)
+
+	ctx := authlib.WithAuthInfo(t.Context(), &identity.StaticRequester{UserID: 1, UserUID: "u1", Type: authlib.TypeUser})
+	key, err := regStore.KeyFunc(ctx, "over-cap")
+	require.NoError(t, err)
+
+	obj := &iamv0.GlobalRole{}
+	obj.Name = "over-cap"
+	out := &iamv0.GlobalRole{}
+	err = regStore.Storage.Storage.Create(ctx, key, obj, out, 0)
+
+	require.Error(t, err, "write above the group's maxAllowedVersion cap must be rejected")
+	require.True(t, apierrors.IsBadRequest(err), "expected a 4xx, got %v", err)
+	require.Contains(t, err.Error(), "v0alpha1", "message should name the cap version")
 }


### PR DESCRIPTION
## Summary
- `NewLocalStore` built its own `apistore.RESTOptionsGetter` with a hardcoded `nil` version policy, so writes through this local/legacy path bypassed `maxAllowedVersion` cap enforcement while the sibling `uniStore` path already enforced it.
- Pulls the policy off the caller's getter via the `VersionPolicy()` accessor (added for the multi-tenant apiserver cap work) and threads it through. Type-assert failure (not our getter) falls back to nil, unchanged from today.
- **Added `TestCodecPathResourcesRegisterOneVersionPerType`** — an unrelated but adjacent guard test, see below. (Companion of grafana/grafana#130759's dashboard version of the same test.)

Follow-up A from grafana/search-and-storage-team#881.

### Why the extra test

While working the sibling apistore PR (#130759) we confirmed that `preferred_api_version` (`ReorderGroupVersionsForLegacyCodec`) has **no effect on what's actually persisted** for any current codec-path (`apistore.StorageOptions.Scheme == nil`) resource — it only affects API discovery ordering. That's because apimachinery's `LegacyCodec` only lets version-list order pick the persisted version when the encoded object has **no exact-match GVK** among the list, which requires a true internal/hub Go type shared across versions. Every IAM codec-path resource registers one distinct Go struct at `v0alpha1` today, so that never happens.

`TestCodecPathResourcesRegisterOneVersionPerType` guards that invariant. It drives the **real** `IdentityAccessManagementAPIBuilder.InstallSchema` with every relevant feature gate turned on, then walks **every type the scheme actually knows about** (not a hardcoded resource list) and asserts each resolves to exactly one `GroupVersionKind`. This closes a gap an earlier version of this test had: checking only a fixed list of resource kinds by name would silently miss any *new* resource kind added later. The only exclusions are:
- k8s-standard per-group-version bookkeeping types (`WatchEvent`, the `*Options` types) that every `metav1.AddToGroupVersion` call registers by convention and that never round-trip through `Storage.Create`.
- `legacyiamv0`'s `SSOSetting`/`SSOSettingList`/`UserTeamList`/`DisplayList`/`TeamMemberList`, which `InstallSchema` deliberately registers at both `v0alpha1` and the internal GV ("avoids the error: no kind is registered for the type" on PATCH/server-side-apply) — confirmed none of these are registered via `StorageOptsRegister` with `Scheme == nil`, so they never reach `s.codec.Encode` either.

Because it calls the real `InstallSchema` and walks its full output, any future registration change is automatically covered without editing this test — verified by injecting a duplicate GVK for `Team` and confirming the assertion fires, then reverting.

## Test plan
- [x] `TestNewLocalStore_EnforcesVersionCap` (new): drives a real `Create` through the store `NewLocalStore` returns (in-memory badger backend), asserts an over-cap write is rejected. Verified it catches the regression by reverting the fix locally and confirming the cap check no longer fires.
- [x] `TestCodecPathResourcesRegisterOneVersionPerType` (new): passes; verified it catches drift by injecting a duplicate `Team` GVK and confirming the assertion fires, and separately confirmed the `legacyiamv0` exclusion is load-bearing (test fails without it), both reverted after.
- [x] `go test ./pkg/registry/apis/iam/...`
- [x] `golangci-lint run ./pkg/registry/apis/iam/...` (pinned CI version, v2.12.2)