### PR TITLE
Apistore: add LegacyCodec down-conversion test

### DIFF
--- a/pkg/registry/apis/dashboard/register_test.go
+++ b/pkg/registry/apis/dashboard/register_test.go
@@ -3,17 +3,21 @@ package dashboard
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apiserver/pkg/admission"
 
 	dashv1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
+	"github.com/grafana/grafana/apps/dashboard/pkg/migration"
+	"github.com/grafana/grafana/apps/dashboard/pkg/migration/testutil"
 	common "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -222,4 +226,72 @@ func (m *mockK8sHandler) GetStats(_ context.Context, _ int64) (*resourcepb.Resou
 }
 func (m *mockK8sHandler) GetUsersFromMeta(_ context.Context, _ []string) (map[string]*user.User, error) {
 	return nil, nil
+}
+
+// TestCodecPathResourcesRegisterOneVersionPerType guards apimachinery's LegacyCodec version-order
+// fallback (see assertNoTypeSpansMultipleGVKs).
+func TestCodecPathResourcesRegisterOneVersionPerType(t *testing.T) {
+	migration.ResetForTesting()
+	migration.Initialize(testutil.NewDataSourceProvider(testutil.StandardTestConfig), testutil.NewLibraryElementProvider(), migration.DefaultCacheTTL)
+
+	scheme := runtime.NewScheme()
+	b := &DashboardsAPIBuilder{}
+	require.NoError(t, b.InstallSchema(scheme))
+
+	assertNoTypeSpansMultipleGVKs(t, scheme)
+}
+
+// commonMultiVersionTypes are known-safe exceptions to assertNoTypeSpansMultipleGVKs: k8s bookkeeping
+// types every group-version registers by convention (never round-trip through Storage.Create), plus
+// v1beta1's documented type aliases to v1 (Dashboard's StorageOptions sets Scheme, so it never takes
+// the codec path anyway; DashboardWithAccessInfo is a read-only /dto response, also never written).
+// Add here on exception basis with a description.
+var commonMultiVersionTypes = func() map[reflect.Type]bool {
+	m := map[reflect.Type]bool{}
+	for _, o := range []runtime.Object{
+		&metav1.WatchEvent{}, &metav1.InternalEvent{}, &metav1.ListOptions{}, &metav1.GetOptions{},
+		&metav1.DeleteOptions{}, &metav1.CreateOptions{}, &metav1.UpdateOptions{}, &metav1.PatchOptions{},
+		&metav1.PartialObjectMetadata{}, &metav1.PartialObjectMetadataList{},
+		&dashv1.Dashboard{}, &dashv1.DashboardList{}, &dashv1.DashboardWithAccessInfo{},
+	} {
+		m[reflect.TypeOf(o).Elem()] = true
+	}
+	return m
+}()
+
+// assertNoTypeSpansMultipleGVKs fails if any type a real InstallSchema registers has 2+
+// GroupVersionKinds, or is registered at runtime.APIVersionInternal at all. Either shape activates
+// apimachinery's LegacyCodec order-fallback (a type sharing a GVK with the internal version, or with
+// another external version, has no exact match in the codec's version list), which would let
+// preferred_api_version silently pick the persisted version instead of only discovery order. A
+// same-struct hub isn't required: a distinct internal-only struct plus distinct external structs hits
+// the same fallback, since the fallback keys on the object's own GVK never exactly matching the
+// codec's target list, not on the Go type being reused. Walks every registered type rather than a
+// hardcoded list, so a new resource is covered too.
+func assertNoTypeSpansMultipleGVKs(t *testing.T, scheme *runtime.Scheme) {
+	t.Helper()
+	byType := map[reflect.Type][]schema.GroupVersionKind{}
+	for gvk, typ := range scheme.AllKnownTypes() {
+		if commonMultiVersionTypes[typ] {
+			continue
+		}
+		obj, ok := reflect.New(typ).Interface().(runtime.Object)
+		if !ok {
+			continue
+		}
+		if unversioned, ok := scheme.IsUnversioned(obj); ok && unversioned {
+			continue // e.g. metav1.Status - genuinely version-independent, not a codec-fallback risk
+		}
+		require.NotEqualf(t, runtime.APIVersionInternal, gvk.Version,
+			"%s is registered at the internal version (%v) - a hub type never exactly matches any "+
+				"external version in the LegacyCodec's list, so encoding it always hits the "+
+				"order-fallback and lets preferred_api_version pick the persisted version", typ, gvk)
+		byType[typ] = append(byType[typ], gvk)
+	}
+	for typ, gvks := range byType {
+		require.Lenf(t, gvks, 1,
+			"%s is registered at %v - a Go type shared across group versions activates the LegacyCodec "+
+				"order-fallback, so preferred_api_version would now silently pick the persisted version "+
+				"for this type instead of only ordering API discovery", typ, gvks)
+	}
 }

--- a/pkg/registry/apis/iam/register_test.go
+++ b/pkg/registry/apis/iam/register_test.go
@@ -102,8 +102,8 @@ func TestCodecPathResourcesRegisterOneVersionPerType(t *testing.T) {
 var commonMultiVersionTypes = func() map[reflect.Type]bool {
 	m := map[reflect.Type]bool{}
 	for _, o := range []runtime.Object{
-		&metav1.WatchEvent{}, &metav1.ListOptions{}, &metav1.GetOptions{}, &metav1.DeleteOptions{},
-		&metav1.CreateOptions{}, &metav1.UpdateOptions{}, &metav1.PatchOptions{},
+		&metav1.WatchEvent{}, &metav1.InternalEvent{}, &metav1.ListOptions{}, &metav1.GetOptions{},
+		&metav1.DeleteOptions{}, &metav1.CreateOptions{}, &metav1.UpdateOptions{}, &metav1.PatchOptions{},
 		&metav1.PartialObjectMetadata{}, &metav1.PartialObjectMetadataList{},
 		// legacyiamv0.AddKnownTypes(scheme, version) is called for both legacyiamv0.VERSION and
 		// runtime.APIVersionInternal (register.go's InstallSchema) "to avoid the error: no kind is
@@ -138,6 +138,10 @@ func assertNoTypeSpansMultipleGVKs(t *testing.T, scheme *runtime.Scheme) {
 		if unversioned, ok := scheme.IsUnversioned(obj); ok && unversioned {
 			continue // e.g. metav1.Status - genuinely version-independent, not a codec-fallback risk
 		}
+		require.NotEqualf(t, runtime.APIVersionInternal, gvk.Version,
+			"%s is registered at the internal version (%v) - a hub type never exactly matches any "+
+				"external version in the LegacyCodec's list, so encoding it always hits the "+
+				"order-fallback and lets preferred_api_version pick the persisted version", typ, gvk)
 		byType[typ] = append(byType[typ], gvk)
 	}
 	for typ, gvks := range byType {

--- a/pkg/storage/unified/apistore/prepare.go
+++ b/pkg/storage/unified/apistore/prepare.go
@@ -500,7 +500,7 @@ func (s *Storage) enforceMaxAllowedVersion(version string) error {
 		return nil
 	}
 	return apierrors.NewBadRequest(fmt.Sprintf(
-		"%s: version %s exceeds the configured maximum version %s for group %s",
+		"%s: version %q exceeds the configured maximum version %s for group %s",
 		s.gr.String(), version, maxAllowed, s.gr.Group))
 }
 

--- a/pkg/storage/unified/apistore/prepare_test.go
+++ b/pkg/storage/unified/apistore/prepare_test.go
@@ -19,6 +19,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -963,6 +964,28 @@ func TestEncodeMaxVersionEnforcement(t *testing.T) {
 		require.NoError(t, codecStorage(reg, "v2").encode(dashboardAt("v2"), &buf, true))
 	})
 
+	t.Run("codec path: real LegacyCodec down-converts to the cap version (preferred==cap)", func(t *testing.T) {
+		// Real LegacyCodec, not a fake, with cap version first (as ReorderGroupVersionsForLegacyCodec does).
+		capGroup := "captest.grafana.app"
+		capGV := schema.GroupVersion{Group: capGroup, Version: "v1"}
+		higherGV := schema.GroupVersion{Group: capGroup, Version: "v2"}
+		codec := newCapCodec(t, capGV, higherGV)
+
+		reg := newGlobalCapRegistry(capGroup, []string{"v2", "v1"}, "v1")
+		s := &Storage{
+			gr:    schema.GroupResource{Group: capGroup, Resource: "widgets"},
+			codec: codec,
+			opts:  StorageOptions{Scheme: nil, VersionPolicy: reg},
+		}
+
+		var buf bytes.Buffer
+		require.NoError(t, s.encode(&capWidget{Value: "hi"}, &buf, true))
+
+		out := &unstructured.Unstructured{}
+		require.NoError(t, json.Unmarshal(buf.Bytes(), out))
+		require.Equal(t, capGroup+"/v1", out.GetAPIVersion(), "preferred==cap: codec must persist the cap version")
+	})
+
 	t.Run("codec path: a persisted version from another group is rejected, not silently allowed", func(t *testing.T) {
 		// The codec picks a GVK outside the resource's group. That version cannot be ranked against the
 		// group's cap, so it must be rejected rather than slip through as unregistered.
@@ -1004,6 +1027,69 @@ type upcastCodec struct {
 func (c upcastCodec) Encode(_ runtime.Object, w io.Writer) error {
 	_, err := fmt.Fprintf(w, `{"apiVersion":%q,"kind":"Dashboard","metadata":{"name":"x"}}`, c.apiVersion)
 	return err
+}
+
+// capWidget is a hub (internal) test type; capWidgetV1/capWidgetV2 are its external versions.
+type capWidget struct {
+	v1.TypeMeta   `json:",inline"`
+	v1.ObjectMeta `json:"metadata,omitempty"`
+	Value         string `json:"value"`
+}
+
+func (in *capWidget) DeepCopyObject() runtime.Object {
+	out := &capWidget{TypeMeta: in.TypeMeta, Value: in.Value}
+	in.DeepCopyInto(&out.ObjectMeta)
+	return out
+}
+
+type capWidgetV1 struct {
+	v1.TypeMeta   `json:",inline"`
+	v1.ObjectMeta `json:"metadata,omitempty"`
+	Value         string `json:"value"`
+}
+
+func (in *capWidgetV1) DeepCopyObject() runtime.Object {
+	out := &capWidgetV1{TypeMeta: in.TypeMeta, Value: in.Value}
+	in.DeepCopyInto(&out.ObjectMeta)
+	return out
+}
+
+type capWidgetV2 struct {
+	v1.TypeMeta   `json:",inline"`
+	v1.ObjectMeta `json:"metadata,omitempty"`
+	Value         string `json:"value"`
+}
+
+func (in *capWidgetV2) DeepCopyObject() runtime.Object {
+	out := &capWidgetV2{TypeMeta: in.TypeMeta, Value: in.Value}
+	in.DeepCopyInto(&out.ObjectMeta)
+	return out
+}
+
+// newCapCodec registers capWidget as the hub and versions[0]/[1] as its spokes, returning a real
+// serializer.CodecFactory.LegacyCodec(versions...).
+func newCapCodec(t *testing.T, versions ...schema.GroupVersion) runtime.Codec {
+	t.Helper()
+	require.Len(t, versions, 2, "newCapCodec takes exactly the two external spokes, cap version first")
+
+	s := runtime.NewScheme()
+	internalGV := schema.GroupVersion{Group: versions[0].Group, Version: runtime.APIVersionInternal}
+	s.AddKnownTypeWithName(internalGV.WithKind("Widget"), &capWidget{})
+	s.AddKnownTypeWithName(versions[0].WithKind("Widget"), &capWidgetV1{})
+	s.AddKnownTypeWithName(versions[1].WithKind("Widget"), &capWidgetV2{})
+
+	require.NoError(t, s.AddConversionFunc((*capWidget)(nil), (*capWidgetV1)(nil), func(a, b interface{}, _ conversion.Scope) error {
+		in, out := a.(*capWidget), b.(*capWidgetV1)
+		out.ObjectMeta, out.Value = in.ObjectMeta, in.Value
+		return nil
+	}))
+	require.NoError(t, s.AddConversionFunc((*capWidget)(nil), (*capWidgetV2)(nil), func(a, b interface{}, _ conversion.Scope) error {
+		in, out := a.(*capWidget), b.(*capWidgetV2)
+		out.ObjectMeta, out.Value = in.ObjectMeta, in.Value
+		return nil
+	}))
+
+	return serializer.NewCodecFactory(s).LegacyCodec(versions...)
 }
 
 // TestUpdateCapExemptsDeletion covers the drain-only policy: an object stored above the cap cannot be


### PR DESCRIPTION
## Summary
- `enforceMaxAllowedVersion`'s error rendered `version  exceeds...` (double space) when the persisted version was empty. Changed `%s`→`%q` so it reads `version "" exceeds...`.
- Added a codec-path test using a **real** `serializer.CodecFactory.LegacyCodec` (not a fake) via a local hub+two-spoke test type, cap-version-first. Proves `preferred==cap` makes a real `LegacyCodec` convert an over-cap write down to the cap version instead of rejecting it — the intended remediation.
- Added `TestCodecPathResourcesRegisterOneVersionPerType`: walks the real `DashboardsAPIBuilder.InstallSchema`'s full scheme and asserts no type is registered at 2+ `GroupVersionKind`s, **or at `runtime.APIVersionInternal` at all**. Guards apimachinery's `LegacyCodec` order-fallback — it fires whenever an object's own GVK has no exact match in the codec's version list, which covers both a Go struct shared across external versions *and* the standard hub pattern (a distinct internal-only struct alongside distinct external structs, each with only one GVK — a shared struct isn't required). No current resource hits either shape, so today `preferred_api_version` only affects discovery ordering, not storage — this test fails the day that stops being true.
- Rebased onto latest `main` and ported the same fix to IAM's copy of this guard (`pkg/registry/apis/iam/register_test.go`). #130758 already merged before that fix was pushed, so it's included here instead of a new IAM PR.

Follow-up D from grafana/search-and-storage-team#881.

## Test plan
- [x] `go test ./pkg/storage/unified/apistore/... -run TestEncodeMaxVersionEnforcement -v` — new subtest passes, existing cases unchanged.
- [x] `go test ./pkg/storage/unified/apistore/...` — full package green.
- [x] `go test ./pkg/registry/apis/dashboard/... -run TestCodecPathResourcesRegisterOneVersionPerType -v` and the iam equivalent — both pass; verified each catches drift by injecting a duplicate GVK and by injecting an internal-only-registered type, reverted after both.
- [x] `golangci-lint run` (pinned CI version, v2.12.2) on all touched packages — 0 issues.