### PR TITLE
Azure Monitor: Give dimension filter inputs accessible names

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/components/MetricsQueryEditor/DimensionFields.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/MetricsQueryEditor/DimensionFields.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { openMenu } from 'react-select-event';
 
@@ -76,6 +76,52 @@ describe(`Azure Monitor QueryEditor`, () => {
     });
     expect(screen.queryByText('Test Dimension 1')).toBeInTheDocument();
     expect(screen.queryByText('==')).toBeInTheDocument();
+  });
+
+  it('gives every input an accessible name that identifies its row', async () => {
+    const mockQuery = createMockQuery();
+    mockQuery.azureMonitor = {
+      ...mockQuery.azureMonitor,
+      dimensionFilters: [
+        { dimension: 'TestDimension1', operator: 'eq', filters: [] },
+        { dimension: 'TestDimension2', operator: 'sw', filters: [] },
+      ],
+    };
+    render(
+      <DimensionFields
+        data={createMockPanelData()}
+        subscriptionId="123"
+        query={mockQuery}
+        onQueryChange={jest.fn()}
+        datasource={mockDatasource}
+        variableOptionGroup={variableOptionGroup}
+        setError={() => {}}
+        dimensionOptions={[
+          { label: 'Test Dimension 1', value: 'TestDimension1' },
+          { label: 'Test Dimension 2', value: 'TestDimension2' },
+        ]}
+      />
+    );
+
+    // The "Dimensions" label groups the rows, so it must be the accessible name of a group.
+    const dimensions = screen.getByRole('group', { name: 'Dimensions' });
+
+    expect(screen.getByRole('combobox', { name: 'Dimension 1 field' })).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: 'Dimension 1 operator' })).toBeInTheDocument();
+    // "eq" and "ne" allow several values, other operators only one, and the names follow suit.
+    expect(screen.getByRole('combobox', { name: 'Dimension 1 values' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Remove dimension 1' })).toBeInTheDocument();
+
+    expect(screen.getByRole('combobox', { name: 'Dimension 2 field' })).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: 'Dimension 2 operator' })).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: 'Dimension 2 value' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Remove dimension 2' })).toBeInTheDocument();
+
+    const names = within(dimensions)
+      .getAllByRole('combobox')
+      .map((combobox) => combobox.getAttribute('aria-label'));
+    expect(names).toHaveLength(6);
+    expect(new Set(names).size).toBe(names.length);
   });
 
   it('correctly filters out dimensions when selected', async () => {

--- a/public/app/plugins/datasource/azuremonitor/components/MetricsQueryEditor/DimensionFields.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/MetricsQueryEditor/DimensionFields.tsx
@@ -149,10 +149,18 @@ const DimensionFields = ({ data, query, dimensionOptions, onQueryChange }: Dimen
     onChange: (item: Partial<AzureMetricDimension>) => void,
     onDelete: () => void
   ) => {
+    // None of the three inputs has a visible label of its own, and screen readers announce the
+    // "Dimensions" legend inconsistently, so each name has to identify the row on its own.
+    // EditorList doesn't pass an index to renderItem, but it renders the array we hand it.
+    const position = dimensionFilters.indexOf(item) + 1;
+
     return (
       <Stack gap={0}>
         <Select
           menuShouldPortal
+          aria-label={t('components.dimension-fields.aria-label-field', 'Dimension {{position}} field', {
+            position,
+          })}
           placeholder={t('components.dimension-fields.placeholder-field', 'Field')}
           value={item.dimension}
           options={getValidDimensionOptions(item.dimension || '')}
@@ -160,6 +168,9 @@ const DimensionFields = ({ data, query, dimensionOptions, onQueryChange }: Dimen
         />
         <Select
           menuShouldPortal
+          aria-label={t('components.dimension-fields.aria-label-operator', 'Dimension {{position}} operator', {
+            position,
+          })}
           placeholder={t('components.dimension-fields.placeholder-operation', 'Operation')}
           value={item.operator}
           options={getValidOperators(item.operator || 'eq')}
@@ -169,6 +180,9 @@ const DimensionFields = ({ data, query, dimensionOptions, onQueryChange }: Dimen
         {item.operator === 'eq' || item.operator === 'ne' ? (
           <MultiSelect
             menuShouldPortal
+            aria-label={t('components.dimension-fields.aria-label-values', 'Dimension {{position}} values', {
+              position,
+            })}
             placeholder={t('components.dimension-fields.placeholder-select-values', 'Select value(s)')}
             value={item.filters}
             options={getValidMultiSelectOptions(item.filters, item.dimension ?? '')}
@@ -187,6 +201,9 @@ const DimensionFields = ({ data, query, dimensionOptions, onQueryChange }: Dimen
           // The API does not currently allow for multiple "starts with" clauses to be used.
           <Select
             menuShouldPortal
+            aria-label={t('components.dimension-fields.aria-label-value', 'Dimension {{position}} value', {
+              position,
+            })}
             placeholder={t('components.dimension-fields.placeholder-select-value', 'Select value')}
             value={item.filters ? item.filters[0] : ''}
             allowCustomValue
@@ -196,7 +213,9 @@ const DimensionFields = ({ data, query, dimensionOptions, onQueryChange }: Dimen
           />
         )}
         <AccessoryButton
-          aria-label={t('components.dimension-fields.aria-label-remove', 'Remove')}
+          aria-label={t('components.dimension-fields.aria-label-remove', 'Remove dimension {{position}}', {
+            position,
+          })}
           icon="times"
           variant="secondary"
           onClick={onDelete}

--- a/public/app/plugins/datasource/azuremonitor/locales/en-US/grafana-azure-monitor-datasource.json
+++ b/public/app/plugins/datasource/azuremonitor/locales/en-US/grafana-azure-monitor-datasource.json
@@ -105,7 +105,11 @@
       "load-subscriptions": "Load Subscriptions"
     },
     "dimension-fields": {
-      "aria-label-remove": "Remove",
+      "aria-label-field": "Dimension {{position}} field",
+      "aria-label-operator": "Dimension {{position}} operator",
+      "aria-label-remove": "Remove dimension {{position}}",
+      "aria-label-value": "Dimension {{position}} value",
+      "aria-label-values": "Dimension {{position}} values",
       "label-dimensions": "Dimensions",
       "placeholder-field": "Field",
       "placeholder-operation": "Operation",


### PR DESCRIPTION
**What is this feature?**

Gives each input in the Azure Monitor metrics **Dimensions** filter rows an accessible name, so screen readers announce what the control is and which row it belongs to:

```
group "Dimensions"
  combobox "Dimension 1 field" / "Dimension 1 operator" / "Dimension 1 values"
  button   "Remove dimension 1"
  combobox "Dimension 2 field" / "Dimension 2 operator" / "Dimension 2 value"
  button   "Remove dimension 2"
```

These are already in a fieldset, labelled by Dimensions

**Why do we need this feature?**

The three dimensions comboboxes didn't have any accessible labels, which made it difficult for all users to use the query editor.

**Who is this feature for?**

Screen reader users building Azure Monitor metrics queries.

**Which issue(s) does this PR fix?**:

Addresses the Azure Monitor dimensions part of #118767.