### PR TITLE
Alerting: skip flakey query and condition test

### DIFF
--- a/public/app/features/alerting/unified/components/rule-viewer/tabs/QueryAndCondition.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/tabs/QueryAndCondition.test.tsx
@@ -180,7 +180,7 @@ describe('loading state', () => {
     return { evalRequests: () => requestCount, resolveEval };
   }
 
-  it('renders the rule definition immediately while eval is pending, then clears the loading bar', async () => {
+  it.skip('renders the rule definition immediately while eval is pending, then clears the loading bar', async () => {
     const { resolveEval } = blockEvalRequests();
 
     const rule = makeGrafanaRule([


### PR DESCRIPTION
**What is this feature?**

Skipping a test that has been failing in the CI for some days. We've attempted fixing it in https://github.com/grafana/grafana/pull/130692 but it seems it didn't do the trick.
Skipping it for now and coming back to it at a later stage.

**Why do we need this feature?**

Unblock the CI runs.