### PR TITLE
Unified storage: derive DisableStorageServices from the module target

### DIFF
--- a/pkg/server/module_server.go
+++ b/pkg/server/module_server.go
@@ -260,7 +260,9 @@ func (s *ModuleServer) Run() error {
 
 	m.RegisterInvisibleModule(modules.NATS, s.initNATSModule)
 
-	m.RegisterInvisibleModule(modules.UnifiedBackend, s.initUnifiedBackendModule(m.IsModuleEnabled(modules.StorageServer)))
+	// Same decision as resource.NewKVBackendOptions makes for wirings that do not
+	// pass it in, so both agree on which process runs the background write jobs.
+	m.RegisterInvisibleModule(modules.UnifiedBackend, s.initUnifiedBackendModule(s.cfg.StorageServicesEnabled()))
 
 	m.RegisterInvisibleModule(modules.UnifiedVectorBackend, s.initUnifiedVectorBackend(m.IsModuleEnabled(modules.StorageServer)))
 
@@ -354,11 +356,11 @@ func (s *ModuleServer) initNATSModule() (services.Service, error) {
 	).WithName(modules.NATS), nil
 }
 
-func (s *ModuleServer) initUnifiedBackendModule(storageServerEnabled bool) func() (services.Service, error) {
+func (s *ModuleServer) initUnifiedBackendModule(storageServicesEnabled bool) func() (services.Service, error) {
 	return func() (services.Service, error) {
 		if s.storageBackend == nil {
 			// If storage server not being used, disable GC, pruner, and RV manager
-			disableStorageServices := !storageServerEnabled
+			disableStorageServices := !storageServicesEnabled
 			eDB, err := sql.ProvideResourceDB(s.cfg, nil)
 			if err != nil {
 				return nil, err

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -429,6 +429,17 @@ func (cfg *Cfg) shouldProxySearchRemotely() bool {
 		!slices.Contains(cfg.Target, "search-server")
 }
 
+// StorageServicesEnabled reports whether this process should run the unified
+// storage background jobs that write, such as garbage collection and event
+// pruning. Only the process that runs the storage server may run them,
+// otherwise every replica would delete data on its own. A process with no
+// module targets, or with the "all" target, does everything itself.
+func (cfg *Cfg) StorageServicesEnabled() bool {
+	return len(cfg.Target) == 0 ||
+		slices.Contains(cfg.Target, "all") ||
+		slices.Contains(cfg.Target, "storage-server")
+}
+
 // ShouldRunMigrations reports whether data migrations to unified storage should run.
 func (cfg *Cfg) ShouldRunMigrations() bool {
 	return cfg.UnifiedStorageType() == "unified" &&

--- a/pkg/setting/setting_unified_storage_test.go
+++ b/pkg/setting/setting_unified_storage_test.go
@@ -1,6 +1,7 @@
 package setting
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/grafana/grafana/pkg/apiserver/rest"
@@ -532,4 +533,25 @@ func TestVectorAllowedCollections(t *testing.T) {
 		assert.Equal(t, []string{"dashboard.grafana.app/dashboards", "folder.grafana.app/folders"}, cfg.VectorAllowedInternalCollections)
 		assert.Equal(t, []string{"ext.example.com/my-things"}, cfg.VectorAllowedExternalCollections)
 	})
+}
+
+func TestStorageServicesEnabled(t *testing.T) {
+	for _, tc := range []struct {
+		target []string
+		want   bool
+	}{
+		{target: nil, want: true},
+		{target: []string{"all"}, want: true},
+		{target: []string{"storage-server"}, want: true},
+		{target: []string{"core", "storage-server"}, want: true},
+		{target: []string{"core"}, want: false},
+		{target: []string{"search-server"}, want: false},
+	} {
+		t.Run(strings.Join(tc.target, ","), func(t *testing.T) {
+			cfg := NewCfg()
+			cfg.Target = tc.target
+
+			assert.Equal(t, tc.want, cfg.StorageServicesEnabled())
+		})
+	}
 }

--- a/pkg/storage/unified/resource/kv_backend_options_test.go
+++ b/pkg/storage/unified/resource/kv_backend_options_test.go
@@ -1,6 +1,7 @@
 package resource
 
 import (
+	"context"
 	"reflect"
 	"testing"
 	"time"
@@ -27,7 +28,10 @@ var callerSuppliedFields = map[string]string{
 	"EnableNatsNotifier":       "set together with EventSubscriber by the caller",
 	"EnableNatsNotifierShadow": "set together with EventSubscriber by the caller",
 	"EmbeddingDeleter":         "vector backend injected by the caller",
-	"DisableStorageServices":   "derived from which modules the process runs, not from a setting",
+	// Derived from cfg.Target rather than a setting of its own, and false for a
+	// process that runs everything, so the non-zero walk cannot check it.
+	// TestNewKVBackendOptionsDisableStorageServices covers it instead.
+	"DisableStorageServices": "derived from cfg.Target, and false when this process runs the storage server",
 
 	// The lease options are set together, and the holder comes from
 	// sql.ResolveLeaseHolder, which this package cannot import.
@@ -84,6 +88,40 @@ func requirePopulated(t *testing.T, v reflect.Value, path string) {
 			// Anything else is a leaf, and the non-zero check above is all there is to do.
 		}
 	}
+}
+
+func TestNewKVBackendOptionsDisableStorageServices(t *testing.T) {
+	// Garbage collection refuses a zero interval, so a backend that starts it
+	// fails to build. That is what makes "did it start" observable here without
+	// waiting on the loop.
+	buildBackend := func(t *testing.T, target ...string) error {
+		cfg := setting.NewCfg()
+		cfg.Target = target
+		cfg.EnableGarbageCollection = true
+		cfg.GarbageCollectionMaxAge = time.Hour
+
+		opts := NewKVBackendOptions(cfg)
+		opts.KvStore = setupBadgerKV(t)
+		backend, err := NewKVStorageBackend(opts)
+		if err == nil {
+			t.Cleanup(func() {
+				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
+				_ = backend.Stop(ctx)
+			})
+		}
+		return err
+	}
+
+	t.Run("collection starts where the storage server runs", func(t *testing.T) {
+		require.ErrorContains(t, buildBackend(t, "storage-server"), "garbage collection")
+	})
+
+	// Otherwise every replica of a process that only reads collects, and
+	// collection deletes.
+	t.Run("and not where it does not", func(t *testing.T) {
+		require.NoError(t, buildBackend(t, "core"))
+	})
 }
 
 // The walk above only checks for non-zero, so it cannot catch two settings

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -328,6 +328,9 @@ func NewKVBackendOptions(cfg *setting.Cfg) KVBackendOptions {
 		DashboardVersionsToKeep: cfg.DashboardVersionsToKeep,
 		TenantWatcherConfig:     NewTenantWatcherConfig(cfg),
 		TenantDeleterConfig:     NewTenantDeleterConfig(cfg),
+		// Callers that know better override this. Without a default, a wiring
+		// that forgets to set it runs garbage collection on every replica.
+		DisableStorageServices: !cfg.StorageServicesEnabled(),
 		GarbageCollection: GarbageCollectionConfig{
 			Enabled:          cfg.EnableGarbageCollection,
 			DryRun:           cfg.GarbageCollectionDryRun,


### PR DESCRIPTION
`KVBackendOptions.DisableStorageServices` stops the background jobs that write — garbage collection and event pruning. It had no default, so a wiring that built a KV backend without setting it ran collection on every replica, and collection deletes.

`NewKVBackendOptions` now defaults it from `cfg.Target` via a new `cfg.StorageServicesEnabled()`: on where the target lists `storage-server`, or where one process does everything (`all`, or no target). Explicit values still win, so the SQL backend and the in-process client are unchanged. The module server now asks the same helper instead of deriving the answer a second time.

The gap this closes is on `unified-kv-grpc`, where two enterprise builders relied on the default. A companion enterprise PR adds tests for those paths.
