### PR TITLE
fix: improve handling of nats connection error and extend metric label

### DIFF
--- a/pkg/infra/nats/connection.go
+++ b/pkg/infra/nats/connection.go
@@ -3,6 +3,7 @@ package nats
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -168,7 +169,7 @@ func (c *connection) connect(ctx context.Context) (*natsclient.Conn, error) {
 			c.metrics.connectionErrors.Inc()
 			c.log.Warn("nats initial connect did not complete; retrying in the background",
 				"role", c.role,
-				"urls", strings.Join(urls, ","),
+				"urls", redactURLs(urls),
 				"status", res.conn.Status(),
 				"err", res.conn.LastError())
 		}
@@ -193,7 +194,7 @@ func (c *connection) connectOptions() ([]natsclient.Option, error) {
 		natsclient.ReconnectBufSize(-1),
 		natsclient.ConnectHandler(func(nc *natsclient.Conn) {
 			c.metrics.connectionStatus.Set(1)
-			c.log.Info("nats connected", "role", roleStr, "url", nc.ConnectedUrl())
+			c.log.Info("nats connected", "role", roleStr, "url", redactURL(nc.ConnectedUrl()))
 		}),
 		natsclient.DisconnectErrHandler(func(_ *natsclient.Conn, err error) {
 			c.metrics.connectionStatus.Set(0)
@@ -209,7 +210,7 @@ func (c *connection) connectOptions() ([]natsclient.Option, error) {
 			if down := c.disconnectedAt.Swap(0); down != 0 {
 				c.metrics.disconnectedSeconds.Observe(time.Since(time.Unix(0, down)).Seconds())
 			}
-			c.log.Info("nats reconnected", "role", roleStr, "url", nc.ConnectedUrl())
+			c.log.Info("nats reconnected", "role", roleStr, "url", redactURL(nc.ConnectedUrl()))
 			c.fireReconnect()
 		}),
 		natsclient.ClosedHandler(func(nc *natsclient.Conn) {
@@ -321,4 +322,27 @@ func (c *connection) close() {
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
+}
+
+func redactURL(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "<invalid url>"
+	}
+	if u.User == nil {
+		return raw
+	}
+	u.User = nil
+	return u.String()
+}
+
+func redactURLs(urls []string) string {
+	redacted := make([]string, 0, len(urls))
+	for _, raw := range urls {
+		redacted = append(redacted, redactURL(raw))
+	}
+	return strings.Join(redacted, ",")
 }

--- a/pkg/infra/nats/connection.go
+++ b/pkg/infra/nats/connection.go
@@ -164,10 +164,14 @@ func (c *connection) connect(ctx context.Context) (*natsclient.Conn, error) {
 			c.metrics.connectionErrors.Inc()
 			return nil, fmt.Errorf("connect nats %s: %w", c.role, res.err)
 		}
-		// connectionStatus is driven solely by the connect/reconnect/disconnect
-		// handlers: with RetryOnFailedConnect the conn returned here may still be
-		// dialing in the background, so setting it to 1 now would report a healthy
-		// connection that is not yet established.
+		if !res.conn.IsConnected() {
+			c.metrics.connectionErrors.Inc()
+			c.log.Warn("nats initial connect did not complete; retrying in the background",
+				"role", c.role,
+				"urls", strings.Join(urls, ","),
+				"status", res.conn.Status(),
+				"err", res.conn.LastError())
+		}
 		return res.conn, nil
 	}
 }

--- a/pkg/infra/nats/connection_test.go
+++ b/pkg/infra/nats/connection_test.go
@@ -180,6 +180,31 @@ func TestConnection(t *testing.T) {
 		})
 	})
 
+	t.Run("redactURL", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			raw  string
+			want string
+		}{
+			{"empty", "", ""},
+			{"no userinfo", "nats://us-nats.us-nats.svc.cluster.local:4222", "nats://us-nats.us-nats.svc.cluster.local:4222"},
+			{"user and password", "nats://user:s3cret@host:4222", "nats://host:4222"},
+			{"token only", "nats://s3cret@host:4222", "nats://host:4222"},
+			{"unparseable", "nats://host:4222/\x7f", "<invalid url>"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				got := redactURL(tc.raw)
+				require.Equal(t, tc.want, got)
+				require.NotContains(t, got, "s3cret")
+			})
+		}
+	})
+
+	t.Run("redactURLs joins every url with credentials stripped", func(t *testing.T) {
+		got := redactURLs([]string{"nats://user:s3cret@a:4222", "nats://b:4222"})
+		require.Equal(t, "nats://a:4222,nats://b:4222", got)
+	})
+
 	t.Run("connectOptions", func(t *testing.T) {
 		t.Run("builds base options without auth", func(t *testing.T) {
 			cfg := setting.NATSSettings{Enabled: true}

--- a/pkg/infra/nats/publisher.go
+++ b/pkg/infra/nats/publisher.go
@@ -14,6 +14,12 @@ import (
 
 const publisherName = "nats-publisher"
 
+var connStateErrs = []error{
+	natsclient.ErrReconnectBufExceeded,
+	natsclient.ErrConnectionClosed,
+	natsclient.ErrConnectionDraining,
+}
+
 // Publisher hides nats.go types so callers can mock it.
 type Publisher interface {
 	Enabler
@@ -78,7 +84,7 @@ func (p *PublisherService) Publish(ctx context.Context, subject string, data []b
 	}
 	if err := nc.Publish(subject, data); err != nil {
 		p.metrics.publishErrors.Inc()
-		if errors.Is(err, natsclient.ErrReconnectBufExceeded) {
+		if isConnStateErr(err) {
 			return fmt.Errorf("publish to %q: nats connection not established (status=%s, last_err=%v): %w", subject, nc.Status(), nc.LastError(), err)
 		}
 		return fmt.Errorf("publish to %q: %w", subject, err)
@@ -86,4 +92,13 @@ func (p *PublisherService) Publish(ctx context.Context, subject string, data []b
 	p.metrics.messagesPublished.Inc()
 	p.log.Debug("published message", "subject", subject, "bytes", len(data))
 	return nil
+}
+
+func isConnStateErr(err error) bool {
+	for _, target := range connStateErrs {
+		if errors.Is(err, target) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/infra/nats/publisher.go
+++ b/pkg/infra/nats/publisher.go
@@ -2,9 +2,11 @@ package nats
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/grafana/dskit/services"
+	natsclient "github.com/nats-io/nats.go"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -76,6 +78,9 @@ func (p *PublisherService) Publish(ctx context.Context, subject string, data []b
 	}
 	if err := nc.Publish(subject, data); err != nil {
 		p.metrics.publishErrors.Inc()
+		if errors.Is(err, natsclient.ErrReconnectBufExceeded) {
+			return fmt.Errorf("publish to %q: nats connection not established (status=%s, last_err=%v): %w", subject, nc.Status(), nc.LastError(), err)
+		}
 		return fmt.Errorf("publish to %q: %w", subject, err)
 	}
 	p.metrics.messagesPublished.Inc()

--- a/pkg/infra/nats/publisher_test.go
+++ b/pkg/infra/nats/publisher_test.go
@@ -2,6 +2,7 @@ package nats
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	natsclient "github.com/nats-io/nats.go"
@@ -46,6 +47,26 @@ func TestPublisher(t *testing.T) {
 		err := p.Publish(context.Background(), "grafana.test.a", []byte("hello"))
 		require.ErrorIs(t, err, natsclient.ErrReconnectBufExceeded)
 		require.ErrorContains(t, err, "connection not established")
+	})
+
+	t.Run("isConnStateErr", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			err  error
+			want bool
+		}{
+			{"reconnect buffer exceeded", natsclient.ErrReconnectBufExceeded, true},
+			{"connection closed", natsclient.ErrConnectionClosed, true},
+			{"connection draining", natsclient.ErrConnectionDraining, true},
+			{"wrapped", fmt.Errorf("publish: %w", natsclient.ErrConnectionClosed), true},
+			{"max payload", natsclient.ErrMaxPayload, false},
+			{"bad subject", natsclient.ErrBadSubject, false},
+			{"nil", nil, false},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				require.Equal(t, tc.want, isConnStateErr(tc.err))
+			})
+		}
 	})
 
 	t.Run("publish honours a cancelled context", func(t *testing.T) {

--- a/pkg/infra/nats/publisher_test.go
+++ b/pkg/infra/nats/publisher_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	natsclient "github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -31,6 +32,20 @@ func TestPublisher(t *testing.T) {
 
 		p.close()
 		require.ErrorIs(t, p.Publish(context.Background(), "grafana.test.a", []byte("world")), ErrClosed)
+	})
+
+	t.Run("publish reports a connection that was never established", func(t *testing.T) {
+		cfg := setting.NATSSettings{
+			Enabled:    true,
+			Mode:       setting.NATSModeExternal,
+			ClientURLs: []string{"nats://127.0.0.1:1"},
+		}
+		p := newPublisher(log.NewNopLogger(), newPublisherMetrics(), newConfig(cfg, nil))
+		t.Cleanup(p.close)
+
+		err := p.Publish(context.Background(), "grafana.test.a", []byte("hello"))
+		require.ErrorIs(t, err, natsclient.ErrReconnectBufExceeded)
+		require.ErrorContains(t, err, "connection not established")
 	})
 
 	t.Run("publish honours a cancelled context", func(t *testing.T) {

--- a/pkg/infra/nats/subscriber.go
+++ b/pkg/infra/nats/subscriber.go
@@ -168,7 +168,16 @@ func (s *SubscriberService) subscribe(ctx context.Context, subject string, sub f
 	natsSub, err := sub(nc, cb)
 	if err != nil {
 		s.metrics.subscribeErrors.Inc()
+		if isConnStateErr(err) {
+			return nil, fmt.Errorf("subscribe to %q: nats connection not established (status=%s, last_err=%v): %w", subject, nc.Status(), nc.LastError(), err)
+		}
 		return nil, fmt.Errorf("subscribe to %q: %w", subject, err)
+	}
+	if !nc.IsConnected() {
+		s.log.Warn("subscribed while the nats connection is not established; delivery starts once it connects",
+			"subject", subject,
+			"status", nc.Status(),
+			"last_err", nc.LastError())
 	}
 	return natsSub, nil
 }

--- a/pkg/infra/nats/subscriber_test.go
+++ b/pkg/infra/nats/subscriber_test.go
@@ -26,6 +26,20 @@ func TestSubscriber(t *testing.T) {
 		require.ErrorIs(t, err, ErrDisabled)
 	})
 
+	t.Run("subscribe succeeds even when the connection was never established", func(t *testing.T) {
+		cfg := setting.NATSSettings{
+			Enabled:    true,
+			Mode:       setting.NATSModeExternal,
+			ClientURLs: []string{"nats://127.0.0.1:1"},
+		}
+		s := newSubscriber(log.NewNopLogger(), newSubscriberMetrics(), newConfig(cfg, nil))
+		t.Cleanup(s.close)
+
+		sub, err := s.Subscribe(context.Background(), "grafana.test.a", func(string, []byte) {})
+		require.NoError(t, err)
+		require.NotNil(t, sub)
+	})
+
 	t.Run("delivers a published message to the handler", func(t *testing.T) {
 		srv := startTestServer(t)
 		pub := newTestPublisher(t, srv)

--- a/pkg/storage/unified/resource/metrics.go
+++ b/pkg/storage/unified/resource/metrics.go
@@ -20,13 +20,13 @@ type StorageMetrics struct {
 func ProvideStorageMetrics(reg prometheus.Registerer) *StorageMetrics {
 	return &StorageMetrics{
 		WatchEventLatency: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
-			Name:                            "storage_server_watch_latency_seconds",
-			Help:                            "Time (in seconds) spent waiting for watch events to be sent",
+			Name:                            "storage_server_watch_event_latency_seconds",
+			Help:                            "Time (in seconds) from resource commit to the watch event being sent to the client",
 			Buckets:                         instrument.DefBuckets,
 			NativeHistogramBucketFactor:     1.1, // enable native histograms
 			NativeHistogramMaxBucketNumber:  160,
 			NativeHistogramMinResetDuration: time.Hour,
-		}, []string{"resource"}),
+		}, []string{"group", "resource"}),
 		PollerLatency: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 			Name:                            "storage_server_poller_query_latency_seconds",
 			Help:                            "poller query latency",

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -2103,7 +2103,7 @@ func (s *server) Watch(req *resourcepb.WatchRequest, srv resourcepb.ResourceStor
 					// or a snowflake ID (KV backend), so we use ResourceVersionTime to handle both formats.
 					latencySeconds := time.Since(ResourceVersionTime(event.ResourceVersion)).Seconds()
 					if latencySeconds > 0 {
-						s.storageMetrics.WatchEventLatency.WithLabelValues(event.Key.Resource).Observe(latencySeconds)
+						s.storageMetrics.WatchEventLatency.WithLabelValues(event.Key.Group, event.Key.Resource).Observe(latencySeconds)
 					}
 				}
 			}

--- a/pkg/storage/unified/resource/server_test.go
+++ b/pkg/storage/unified/resource/server_test.go
@@ -1766,7 +1766,7 @@ func TestWatchEventMetricsWithSinceRV(t *testing.T) {
 	// observing them inflates the histogram with the time elapsed since they
 	// were originally written, not the actual reaction time of this watcher.
 	// Only the post-subscription event should be counted.
-	obs, err := metrics.WatchEventLatency.GetMetricWithLabelValues(watchTestResource)
+	obs, err := metrics.WatchEventLatency.GetMetricWithLabelValues(watchTestGroup, watchTestResource)
 	require.NoError(t, err)
 	m := &dto.Metric{}
 	require.NoError(t, obs.(prometheus.Metric).Write(m))


### PR DESCRIPTION
Make a NATS connection that never establishes visible, and label the watch latency histogram with `group`.

`nats.Connect` runs with `RetryOnFailedConnect(true)`, so it returns a usable `*nats.Conn` even when the initial dial failed. Nothing logged it and `connection_errors_total` stayed at 0, so a publisher that never connected looked identical to an idle one. Because the client also runs with `ReconnectBufSize(-1)` (fail fast instead of buffering 8MB during an outage), every publish on that connection returned `nats: outbound buffer limit exceeded`. That message reads as "a buffer filled up" when it actually means "there is no connection". In dev this cost hours: the real cause was a missing NetworkPolicy egress rule to `us-nats:4222`, and the only signal pointing at it was `publisher_connection_status == 0`.

### Changes

- `connect()` now increments `connection_errors_total` and logs `nats initial connect did not complete; retrying in the background` (with urls, status and last error) when `Connect` hands back an unconnected conn.
- `Publish` translates `ErrReconnectBufExceeded` into `nats connection not established (status=..., last_err=...)`, still wrapping the sentinel so `errors.Is` keeps working.
- `storage_server_watch_latency_seconds` → `storage_server_watch_event_latency_seconds`, now labelled `(group, resource)` and documented as commit → gRPC send, which is what it always measured. Matches the publisher counters' label set.
