### PR TITLE
[release-13.1.4] Go: Update version to 1.26.6

### DIFF
--- a/.citools/src/air/go.mod
+++ b/.citools/src/air/go.mod
@@ -1,6 +1,6 @@
 module air
 
-go 1.26.5
+go 1.26.6
 
 tool github.com/air-verse/air
 

--- a/.citools/src/cue/go.mod
+++ b/.citools/src/cue/go.mod
@@ -1,6 +1,6 @@
 module cue
 
-go 1.26.5
+go 1.26.6
 
 tool cuelang.org/go/cmd/cue
 

--- a/.citools/src/golangci-lint/go.mod
+++ b/.citools/src/golangci-lint/go.mod
@@ -1,6 +1,6 @@
 module golangci-lint
 
-go 1.26.5
+go 1.26.6
 
 tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 

--- a/.citools/src/govulncheck/go.mod
+++ b/.citools/src/govulncheck/go.mod
@@ -1,6 +1,6 @@
 module govulncheck
 
-go 1.26.5
+go 1.26.6
 
 tool golang.org/x/vuln/cmd/govulncheck
 

--- a/.citools/src/lefthook/go.mod
+++ b/.citools/src/lefthook/go.mod
@@ -1,6 +1,6 @@
 module lefthook
 
-go 1.26.5
+go 1.26.6
 
 tool github.com/evilmartians/lefthook
 

--- a/.citools/src/swagger/go.mod
+++ b/.citools/src/swagger/go.mod
@@ -1,6 +1,6 @@
 module swagger
 
-go 1.26.5
+go 1.26.6
 
 tool github.com/go-swagger/go-swagger/cmd/swagger
 

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -23,7 +23,7 @@ runs:
   steps:
     # When cache-build is enabled, use the built-in setup-go caching
     # which stores both GOMODCACHE and GOCACHE together.
-    - uses: actions/setup-go@v6.0.0
+    - uses: actions/setup-go@v6.5.0
       with:
         go-version-file: ${{ inputs.go-version-file }}
         cache: ${{ inputs.cache == 'true' && inputs.cache-build == 'true' }}

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -154,7 +154,7 @@ jobs:
       # workspace (the release-branch checkout). That subtree may lag main and miss the action,
       # failing the step. Mirror cache-build:false behavior (no GOCACHE; modules via actions/cache).
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v6.5.0
         with:
           go-version-file: .grafana-main/go.mod
           cache: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ARG JS_SRC=js-builder
 # By using FROM instructions we can delegate dependency updates to dependabot
 FROM alpine:3.24.1 AS alpine-base
 FROM ubuntu:24.04 AS ubuntu-base
-FROM golang:1.26.5-alpine AS go-builder-base
+FROM golang:1.26.6-alpine AS go-builder-base
 FROM --platform=${JS_PLATFORM} node:24-alpine AS js-builder-base
 FROM gcr.io/distroless/static-debian13 AS distroless-base
 # Javascript build stage

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ WIRE_TAGS = "oss"
 include .citools/Variables.mk
 
 GO = go
-GO_VERSION = 1.26.5
+GO_VERSION = 1.26.6
 GO_HOST_OS := $(shell $(GO) env GOHOSTOS)
 GO_HOST_ARCH := $(shell $(GO) env GOHOSTARCH)
 GO_LINT_FILES ?= $(shell ./scripts/go-workspace/golangci-lint-includes.sh)

--- a/apps/advisor/go.mod
+++ b/apps/advisor/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/advisor
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0

--- a/apps/alerting/alertenrichment/go.mod
+++ b/apps/alerting/alertenrichment/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/alerting/alertenrichment
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6

--- a/apps/alerting/notifications/go.mod
+++ b/apps/alerting/notifications/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/alerting/notifications
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/grafana/grafana-app-sdk v0.56.2

--- a/apps/alerting/rules/go.mod
+++ b/apps/alerting/rules/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/alerting/rules
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/getkin/kin-openapi v0.144.0

--- a/apps/annotation/go.mod
+++ b/apps/annotation/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/annotation
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/grafana/grafana-app-sdk v0.56.2

--- a/apps/collections/go.mod
+++ b/apps/collections/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/collections
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/grafana/grafana-app-sdk v0.56.2

--- a/apps/correlations/go.mod
+++ b/apps/correlations/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/correlations
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/grafana/grafana-app-sdk v0.56.2

--- a/apps/dashboard/go.mod
+++ b/apps/dashboard/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/dashboard
 
-go 1.26.5
+go 1.26.6
 
 require (
 	cuelang.org/go v0.11.1

--- a/apps/dashvalidator/go.mod
+++ b/apps/dashvalidator/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/dashvalidator
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/grafana/authlib/types v0.0.0-20260603144019-18cfcbc9496a

--- a/apps/example/go.mod
+++ b/apps/example/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/example
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/grafana/grafana-app-sdk v0.56.2

--- a/apps/folder/go.mod
+++ b/apps/folder/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/folder
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/grafana/grafana-app-sdk v0.56.2

--- a/apps/iam/go.mod
+++ b/apps/iam/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/iam
 
-go 1.26.5
+go 1.26.6
 
 // transitive dependencies that need replaced
 // TODO: stop depending on grafana core(

--- a/apps/live/go.mod
+++ b/apps/live/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/live
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/grafana/grafana-app-sdk v0.56.2

--- a/apps/logsdrilldown/go.mod
+++ b/apps/logsdrilldown/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/logsdrilldown
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/grafana/grafana-app-sdk v0.56.2

--- a/apps/playlist/go.mod
+++ b/apps/playlist/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/playlist
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/grafana/grafana-app-sdk v0.56.2

--- a/apps/plugins/go.mod
+++ b/apps/plugins/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/plugins
 
-go 1.26.5
+go 1.26.6
 
 replace github.com/grafana/grafana => ../..
 

--- a/apps/preferences/go.mod
+++ b/apps/preferences/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/preferences
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/grafana/grafana-app-sdk v0.56.2

--- a/apps/provisioning/go.mod
+++ b/apps/provisioning/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/provisioning
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/bwmarrin/snowflake v0.3.0

--- a/apps/quotas/go.mod
+++ b/apps/quotas/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/quotas
 
-go 1.26.5
+go 1.26.6
 
 // transitive dependencies that need replaced
 // TODO: stop depending on grafana core(

--- a/apps/scope/go.mod
+++ b/apps/scope/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/scope
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6

--- a/apps/secret/go.mod
+++ b/apps/secret/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/secret
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/grafana/grafana-app-sdk v0.56.2

--- a/apps/shorturl/go.mod
+++ b/apps/shorturl/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/shorturl
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/grafana/grafana-app-sdk v0.56.2

--- a/devenv/docker/blocks/prometheus_high_card/go.mod
+++ b/devenv/docker/blocks/prometheus_high_card/go.mod
@@ -1,6 +1,6 @@
 module high-card
 
-go 1.26.5
+go 1.26.6
 
 require github.com/prometheus/client_golang v1.23.2
 

--- a/devenv/docker/blocks/prometheus_utf8/go.mod
+++ b/devenv/docker/blocks/prometheus_utf8/go.mod
@@ -1,6 +1,6 @@
 module utf8-support
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/prometheus/client_golang v1.23.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana
 
-go 1.26.5
+go 1.26.6
 
 // Direct requirements -- every entry needs an owner
 require (

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.26.5
+go 1.26.6
 
 // The `skip:golangci-lint` comment tag is used to exclude the package from the `golangci-lint` GitHub Action.
 // The module at the root of the repo (`.`) is excluded because ./pkg/... is included manually in the `golangci-lint` configuration.

--- a/hack/go.mod
+++ b/hack/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/hack
 
-go 1.26.5
+go 1.26.6
 
 require k8s.io/code-generator v0.36.0
 

--- a/pkg/apimachinery/go.mod
+++ b/pkg/apimachinery/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/apimachinery
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/go-jose/go-jose/v4 v4.1.4

--- a/pkg/apiserver/go.mod
+++ b/pkg/apiserver/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/apiserver
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/pkg/build/wire/go.mod
+++ b/pkg/build/wire/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/build/wire
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/pkg/codegen/go.mod
+++ b/pkg/codegen/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/codegen
 
-go 1.26.5
+go 1.26.6
 
 require (
 	cuelang.org/go v0.11.1

--- a/pkg/infra/features/go.mod
+++ b/pkg/infra/features/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/infra/features
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0

--- a/pkg/plugins/codegen/go.mod
+++ b/pkg/plugins/codegen/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/plugins/codegen
 
-go 1.26.5
+go 1.26.6
 
 replace github.com/grafana/grafana/pkg/codegen => ../../codegen
 

--- a/pkg/plugins/go.mod
+++ b/pkg/plugins/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/plugins
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/Machiel/slugify v1.0.1

--- a/pkg/plugins/manager/testdata/test-app-with-backend/go.mod
+++ b/pkg/plugins/manager/testdata/test-app-with-backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/plugins/manager/testdata/test-app-with-backend
 
-go 1.26.5
+go 1.26.6
 
 require github.com/grafana/grafana-plugin-sdk-go v0.292.0
 

--- a/pkg/storage/unified/resource/kv/go.mod
+++ b/pkg/storage/unified/resource/kv/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/storage/unified/resource/kv
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/pkg/storage/unified/resourcepb/go.mod
+++ b/pkg/storage/unified/resourcepb/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/storage/unified/resourcepb
 
-go 1.26.5
+go 1.26.6
 
 require (
 	google.golang.org/grpc v1.82.1

--- a/pkg/util/sqlite/go.mod
+++ b/pkg/util/sqlite/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/util/sqlite
 
-go 1.26.5
+go 1.26.6
 
 require modernc.org/sqlite v1.52.0
 

--- a/scripts/go-workspace/go.mod
+++ b/scripts/go-workspace/go.mod
@@ -1,5 +1,5 @@
 module github.com/grafana/grafana/scripts/go-workspace
 
-go 1.26.5
+go 1.26.6
 
 require golang.org/x/mod v0.37.0

--- a/scripts/modowners/go.mod
+++ b/scripts/modowners/go.mod
@@ -1,5 +1,5 @@
 module github.com/grafana/grafana/scripts/modowners
 
-go 1.26.5
+go 1.26.6
 
 require golang.org/x/mod v0.37.0


### PR DESCRIPTION
Backport e416adfacf7bfad7730cea950db7015caecd3af6 from #130724

---

From Golang mailing list:

```
Hello gophers,

We have just released Go versions 1.26.6 and 1.25.13, minor point releases.

These releases include 10 security fixes following the [security policy](https://go.dev/doc/security/policy):

    x/mod/sumdb/tlog: fix transparency log tile verification bypass

    A malicious GOPROXY was previously capable of forging
    up to two sumdb tiles that allow for a requested module
    to bypass the GOSUMDB check and persist attacker-controlled
    module content to a local Go module cache.

    This attack allows for a malicious GOPROXY to serve
    malicious module content that cannot be detected
    by evaluating the transparency log.

    All tiles are now correctly verified against their parents.

    In order to determine if you have been affected:

    rm -r go.sum go.work.sum vendor/ && go mod tidy

    Thanks to Filippo Valsorda (Geomys) for reporting this issue.

    This is CVE-2026-56865 and Go issue https://go.dev/issue/80744.

    x/mod/sumdb: ignore unrelated, unauthenticated hashes in Lookup

    A malicious GOSUMDB was capable of serving arbitrary
    module content not contained within the transparency
    log.

    This attack allows for a coordinating GOPROXY and
    GOSUMDB to serve a client malicious module content
    that cannot be detected by evaluating the transparency
    log.

    In order to determine if you have been affected:

    rm -r go.sum go.work.sum vendor/ && go mod tidy

    Thanks to mundur for reporting this issue.

    This is CVE-2026-56864 and Go issue https://go.dev/issue/80745.

    encoding/xml: add recursion depth guard during decode

    Previously, DecodeElement would reset the depth counter
    causing it to never fire; this could lead to stack
    exhaustion.

    This is CVE-2026-56859 and Go issue https://go.dev/issue/80481.

    net/http: apply ReadHeaderTimeout when doing unencrypted HTTP/2 check

    When a server is configured to support unencrypted HTTP/2, it reads a
    few bytes from each new connection to see if they contain the HTTP/2
    client preface. Previously, this was being done with no timeout applied.
    ReadHeaderTimeout is now applied for this.

    This is CVE-2026-56853 and Go issue https://go.dev/issue/80205.

    net/url: avoid quadratic complexity in resolvePath

    Previously, resolving relative paths containing parent directory (..) segments performed string conversions and buffer rewrites on each step, resulting in quadratic time complexity and high memory allocation overhead.

    Now, path resolution operates on a byte buffer using index-based backtracking for .. segments, eliminating the quadratic time complexity and significantly reducing memory allocations.

    This is CVE-2026-56860 and Go issue https://go.dev/issue/80494.

    [golang.org/x/net/dns/dnsmessage](http://golang.org/x/net/dns/dnsmessage): panic when parsing invalid SVCB record

    Parsing an invalid SVCB or HTTPS RR can panic when
    the size of a parameter value overflows the message buffer.

    Thanks to Mundur (https://github.com/M0nd0R) for reporting this issue.

    This is CVE-2026-46600 and Go issue https://go.dev/issue/79795.

    crypto/tls: limit handshake messages we are willing to accept post-handshake

    Previously, we always counted handshake messages, such as KeyUpdate, as
    state-advancing, regardless of whether a handshake has been completed or
    not. As a result, a malicious client can keep sending KeyUpdate messages
    to force the server to keep performing key derivation operations
    indefinitely.

    Thanks to Qi Deng of Aurascape.ai for reporting this issue.

    This is CVE-2026-56862 and Go issue https://go.dev/issue/80528.

    html/template: fix Javascript regexp context tracking

    Previously, pathological inputs could close an
    unescaped / early, allowing for attack-controlled
    data to inject arbitrary content, potentially
    leading to XSS.

    Thanks to Ali Sherif for reporting this issue.

    This is CVE-2026-56858 and Go issue https://go.dev/issue/80435.

    x/net/idna: failure to reject ASCII-only Punycode-encoded labels

    The ToASCII and ToUnicode functions incorrectly accepted Punycode-encoded labels
    that decode to an ASCII-only label. For example, ToUnicode("xn--example-.com")
    incorrectly returned the name "[example.com](http://example.com/)" rather than an error.

    The idna package implements the processing algorithm from UTS 46.
    Older versions of UTS 46 included a specification bug which permitted
    multiple ASCII labels to decode to the same Unicode label.
    UTS 46 revision 33 fixed the specification bug.
    The idna package now implements the updated specification.

    This behavior can lead to privilege escalation in programs using the idna package.
    For example, a program which performs privilege checks on the ASCII hostname
    may reject "[example.com](http://example.com/)" but permit "xn--example-.com". If that program subsequently
    converts the ASCII hostname to Unicode, it will inadvertently permits access
    to the Unicode name "[example.com](http://example.com/)".

    Thanks to KC1zs4 (https://github.com/KC1zs4) for reporting this issue.

    This is CVE-2026-39821 and Go issue https://go.dev/issue/78760.

    encoding/asn1: enforce maximum recursion depth

    Enforce a recursion limit in Unmarshal to prevent stack exhaustion
    when parsing deeply-nested, recursive structures.

    Thanks to Marwan Atia ([marwans...@gmail.com](https://groups.google.com/)) for reporting this issue.

    This is CVE-2026-33818 and Go issue https://go.dev/issue/80405.
```
