### PR TITLE
Chore: fix last circular deps in @grafana/ui

### DIFF
--- a/.madgerc
+++ b/.madgerc
@@ -1,4 +1,5 @@
 {
+  "excludeRegExp": ["Table/TableRT/ExpandedRow\\.tsx$"],
   "detectiveOptions": {
     "ts": {
       "skipTypeImports": true

--- a/packages/grafana-ui/src/graveyard/GraphNG/nullInsertThreshold.ts
+++ b/packages/grafana-ui/src/graveyard/GraphNG/nullInsertThreshold.ts
@@ -1,6 +1,4 @@
-import { DataFrame } from '@grafana/data';
-
-import { getRefField } from './utils';
+import { DataFrame, FieldType } from '@grafana/data';
 
 type InsertMode = (prev: number, next: number, threshold: number) => number;
 
@@ -17,6 +15,13 @@ interface NullInsertOptions {
   refFieldPseudoMax?: number;
   refFieldPseudoMin?: number;
   insertMode?: InsertMode;
+}
+
+export function getRefField(frame: DataFrame, refFieldName?: string | null) {
+  return frame.fields.find((field) => {
+    // note: getFieldDisplayName() would require full DF[]
+    return refFieldName != null ? field.name === refFieldName : field.type === FieldType.time;
+  });
 }
 
 /** @deprecated */

--- a/packages/grafana-ui/src/graveyard/GraphNG/utils.ts
+++ b/packages/grafana-ui/src/graveyard/GraphNG/utils.ts
@@ -9,7 +9,7 @@ import {
 
 import { FIXED_UNIT } from '../../components/uPlot/types';
 
-import { applyNullInsertThreshold } from './nullInsertThreshold';
+import { applyNullInsertThreshold, getRefField } from './nullInsertThreshold';
 import { nullToUndefThreshold } from './nullToUndefThreshold';
 import { XYFieldMatchers } from './types';
 
@@ -17,13 +17,6 @@ function isVisibleBarField(f: Field) {
   return (
     f.type === FieldType.number && f.config.custom?.drawStyle === GraphDrawStyle.Bars && !f.config.custom?.hideFrom?.viz
   );
-}
-
-export function getRefField(frame: DataFrame, refFieldName?: string | null) {
-  return frame.fields.find((field) => {
-    // note: getFieldDisplayName() would require full DF[]
-    return refFieldName != null ? field.name === refFieldName : field.type === FieldType.time;
-  });
 }
 
 // will mutate the DataFrame's fields' values


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- fixes/ignores the last circular deps in `@grafana/ui`
  - ignored `TableRT` because it's a genuine recursive reference (`Table` -> `ExpandedRow` -> `Table`), and `TableRT` is deprecated anyway.

**Why do we need this feature?**

- circular deps slow down builds/CI

**Who is this feature for?**

- grafana devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/117131

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
