### PR TITLE
chore: bump TRIAGE_REF to community-triage main (slop line fixes + notification layout)

### DIFF
--- a/.github/workflows/external-fr-notify.yml
+++ b/.github/workflows/external-fr-notify.yml
@@ -18,7 +18,7 @@ concurrency:
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: 4f7abe69c9c0bc4a4d0befaaef0f1ea04509c29f # trufflehog:ignore
+  TRIAGE_REF: d932eb937eb0b51d23a6d71e0f3026710d0f10c8 # trufflehog:ignore
 
 jobs:
   notify:

--- a/.github/workflows/external-fr-notify.yml
+++ b/.github/workflows/external-fr-notify.yml
@@ -18,7 +18,7 @@ concurrency:
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: d932eb937eb0b51d23a6d71e0f3026710d0f10c8 # trufflehog:ignore
+  TRIAGE_REF: b4e1f1626a802465167a9d6003d541a4966c8c6e # trufflehog:ignore
 
 jobs:
   notify:

--- a/.github/workflows/external-fr-weekly-digest.yml
+++ b/.github/workflows/external-fr-weekly-digest.yml
@@ -31,7 +31,7 @@ concurrency:
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: 4f7abe69c9c0bc4a4d0befaaef0f1ea04509c29f # trufflehog:ignore
+  TRIAGE_REF: d932eb937eb0b51d23a6d71e0f3026710d0f10c8 # trufflehog:ignore
 
 jobs:
   digest:

--- a/.github/workflows/external-fr-weekly-digest.yml
+++ b/.github/workflows/external-fr-weekly-digest.yml
@@ -31,7 +31,7 @@ concurrency:
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: d932eb937eb0b51d23a6d71e0f3026710d0f10c8 # trufflehog:ignore
+  TRIAGE_REF: b4e1f1626a802465167a9d6003d541a4966c8c6e # trufflehog:ignore
 
 jobs:
   digest:

--- a/.github/workflows/external-issue-notify.yml
+++ b/.github/workflows/external-issue-notify.yml
@@ -18,7 +18,7 @@ concurrency:
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: 4f7abe69c9c0bc4a4d0befaaef0f1ea04509c29f # trufflehog:ignore
+  TRIAGE_REF: d932eb937eb0b51d23a6d71e0f3026710d0f10c8 # trufflehog:ignore
 
 jobs:
   notify:

--- a/.github/workflows/external-issue-notify.yml
+++ b/.github/workflows/external-issue-notify.yml
@@ -18,7 +18,7 @@ concurrency:
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: d932eb937eb0b51d23a6d71e0f3026710d0f10c8 # trufflehog:ignore
+  TRIAGE_REF: b4e1f1626a802465167a9d6003d541a4966c8c6e # trufflehog:ignore
 
 jobs:
   notify:

--- a/.github/workflows/external-issue-weekly-digest.yml
+++ b/.github/workflows/external-issue-weekly-digest.yml
@@ -31,7 +31,7 @@ concurrency:
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: 4f7abe69c9c0bc4a4d0befaaef0f1ea04509c29f # trufflehog:ignore
+  TRIAGE_REF: d932eb937eb0b51d23a6d71e0f3026710d0f10c8 # trufflehog:ignore
 
 jobs:
   digest:

--- a/.github/workflows/external-issue-weekly-digest.yml
+++ b/.github/workflows/external-issue-weekly-digest.yml
@@ -31,7 +31,7 @@ concurrency:
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: d932eb937eb0b51d23a6d71e0f3026710d0f10c8 # trufflehog:ignore
+  TRIAGE_REF: b4e1f1626a802465167a9d6003d541a4966c8c6e # trufflehog:ignore
 
 jobs:
   digest:

--- a/.github/workflows/external-pr-notify-handler.yml
+++ b/.github/workflows/external-pr-notify-handler.yml
@@ -25,7 +25,7 @@ env:
   # community-triage logic version this repo is pinned to (main as of PR #6).
   # Bump deliberately; re-resolve with:
   #   git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: 4f7abe69c9c0bc4a4d0befaaef0f1ea04509c29f # trufflehog:ignore
+  TRIAGE_REF: d932eb937eb0b51d23a6d71e0f3026710d0f10c8 # trufflehog:ignore
 
 jobs:
   triage:

--- a/.github/workflows/external-pr-notify-handler.yml
+++ b/.github/workflows/external-pr-notify-handler.yml
@@ -25,7 +25,7 @@ env:
   # community-triage logic version this repo is pinned to (main as of PR #6).
   # Bump deliberately; re-resolve with:
   #   git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: d932eb937eb0b51d23a6d71e0f3026710d0f10c8 # trufflehog:ignore
+  TRIAGE_REF: b4e1f1626a802465167a9d6003d541a4966c8c6e # trufflehog:ignore
 
 jobs:
   triage:

--- a/.github/workflows/external-pr-weekly-digest.yml
+++ b/.github/workflows/external-pr-weekly-digest.yml
@@ -31,7 +31,7 @@ permissions: {}
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: 4f7abe69c9c0bc4a4d0befaaef0f1ea04509c29f # trufflehog:ignore
+  TRIAGE_REF: d932eb937eb0b51d23a6d71e0f3026710d0f10c8 # trufflehog:ignore
   STALE_THRESHOLD_DAYS: ${{ inputs.stale_days || 30 }}
 
 concurrency:

--- a/.github/workflows/external-pr-weekly-digest.yml
+++ b/.github/workflows/external-pr-weekly-digest.yml
@@ -31,7 +31,7 @@ permissions: {}
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: d932eb937eb0b51d23a6d71e0f3026710d0f10c8 # trufflehog:ignore
+  TRIAGE_REF: b4e1f1626a802465167a9d6003d541a4966c8c6e # trufflehog:ignore
   STALE_THRESHOLD_DAYS: ${{ inputs.stale_days || 30 }}
 
 concurrency:


### PR DESCRIPTION
Follow-up to #130776. Bumps the pinned `TRIAGE_REF` in the six community-triage wiring workflows 