### PR TITLE
Unified search: remove expired trash documents from the index

### DIFF
--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -319,6 +319,12 @@ type SearchBackend interface {
 	// GetOpenIndexes returns the list of indexes that are currently open.
 	GetOpenIndexes() []NamespacedResource
 
+	// RemoveExpiredTrash deletes trash documents for objects that garbage
+	// collection has already removed from storage. The backend decides what is
+	// expired, because it holds the retention window. Errors are the backend's to
+	// log: a caller can only let the next pass try again.
+	RemoveExpiredTrash(ctx context.Context)
+
 	// Stop closes indexes and stops backend background tasks.
 	Stop()
 }
@@ -1424,6 +1430,8 @@ func (s *searchServer) init(ctx context.Context) error {
 	s.bgTaskWg.Add(1)
 	go s.runPeriodicScanForIndexesToRebuild(subctx)
 
+	s.bgTaskWg.Go(func() { s.runPeriodicTrashCleanup(subctx) })
+
 	s.startRateBucketSweeper(subctx)
 
 	end := time.Now().Unix()
@@ -1477,6 +1485,23 @@ func (s *searchServer) runPeriodicScanForIndexesToRebuild(ctx context.Context) {
 				s.log.Error("failed to get import times", "error", err)
 			}
 			s.findIndexesToRebuild(importTimes, nil, time.Now(), true)
+		}
+	}
+}
+
+// Reads already hide expired trash, so this only reclaims space and can run
+// rarely. It gets its own goroutine because draining a large backlog would
+// otherwise hold up the rebuild scan.
+func (s *searchServer) runPeriodicTrashCleanup(ctx context.Context) {
+	ticker := time.NewTicker(time.Hour)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.search.RemoveExpiredTrash(ctx)
 		}
 	}
 }

--- a/pkg/storage/unified/resource/search_hybrid_test.go
+++ b/pkg/storage/unified/resource/search_hybrid_test.go
@@ -378,6 +378,7 @@ func (f *fakeSearchBackend) WriteOpenIndexStats(time.Time) error       { return 
 func (f *fakeSearchBackend) GetIndex(NamespacedResource) ResourceIndex { return f.idx }
 func (f *fakeSearchBackend) TotalDocs() int64                          { return 0 }
 func (f *fakeSearchBackend) GetOpenIndexes() []NamespacedResource      { return nil }
+func (f *fakeSearchBackend) RemoveExpiredTrash(context.Context)        {}
 func (f *fakeSearchBackend) SnapshotCountThreshold() int64             { return 0 }
 func (f *fakeSearchBackend) Stop()                                     {}
 func (f *fakeSearchBackend) BuildIndex(context.Context, NamespacedResource, int64, string, BuildFn, UpdateFn, bool, time.Time, time.Duration) (ResourceIndex, error) {

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -222,6 +222,8 @@ func (m *mockSearchBackend) SnapshotCountThreshold() int64 {
 	return m.snapshotThreshold
 }
 
+func (m *mockSearchBackend) RemoveExpiredTrash(context.Context) {}
+
 type buildIndexCall struct {
 	key  NamespacedResource
 	size int64

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -2584,11 +2584,7 @@ func scopeQuery(q query.Query, deleted bool, expirationThreshold int64) query.Qu
 	// Excluding what is too old, rather than requiring a recent enough deletion,
 	// keeps the markers that carry no deletion time at all.
 	if expirationThreshold > 0 {
-		cutoff := float64(expirationThreshold)
-		inclusive := false
-		expired := bleve.NewNumericRangeInclusiveQuery(nil, &cutoff, nil, &inclusive)
-		expired.SetField(resource.SEARCH_FIELD_DELETION_TIME)
-		scoped.AddMustNot(expired)
+		scoped.AddMustNot(expiredTrashQuery(expirationThreshold))
 	}
 
 	// Bleve drives iteration from the Must clause and uses Filter only to test the
@@ -2606,6 +2602,116 @@ func scopeQuery(q query.Query, deleted bool, expirationThreshold int64) query.Qu
 	scoped.AddMust(q)
 	scoped.AddFilter(marked)
 	return scoped
+}
+
+// expiredTrashQuery matches trash whose deletion time is before threshold, which
+// is the trash garbage collection has already taken or is about to. Both the read
+// paths (which hide it) and the cleanup pass (which removes it) build their query
+// from here, so they cannot disagree about what is expired.
+//
+// A document with no deletion time does not match: bleve has no value to compare,
+// and a missing field must not be read as "expired".
+func expiredTrashQuery(threshold int64) query.Query {
+	cutoff := float64(threshold)
+	inclusive := false
+	expired := bleve.NewNumericRangeInclusiveQuery(nil, &cutoff, nil, &inclusive)
+	expired.SetField(resource.SEARCH_FIELD_DELETION_TIME)
+	return expired
+}
+
+// Bounds the size of a single delete batch. The pass keeps issuing batches until
+// the index has no expired trash left.
+const trashCleanupBatchSize = 1000
+
+// RemoveExpiredTrash deletes trash documents for objects that garbage collection
+// has already removed from storage. Collection emits no events, so without this
+// the documents sit in the index until it is next rebuilt.
+func (b *bleveBackend) RemoveExpiredTrash(ctx context.Context) {
+	// With collection off nothing in storage expires, so this trash is still
+	// restorable and removing it would break a restore that works.
+	if !b.opts.TrashRetention.Enabled {
+		return
+	}
+
+	now := time.Now()
+	for _, key := range b.GetOpenIndexes() {
+		if ctx.Err() != nil {
+			return
+		}
+		// Peek, so this pass does not keep an index this instance no longer owns
+		// from being evicted.
+		idx := b.peekCachedIndex(key)
+		if idx == nil {
+			continue
+		}
+		removed, err := idx.removeExpiredTrash(ctx, now)
+		switch {
+		case errors.Is(err, bleve.ErrorIndexClosed):
+			// The index was evicted while this ran. The next pass picks up whatever
+			// was left, so this is not a failure.
+			b.log.Debug("index closed while removing expired trash documents", "key", key, "removed", removed)
+		case err != nil:
+			b.log.Error("failed to remove expired trash documents from index", "key", key, "removed", removed, "err", err)
+		case removed > 0:
+			b.log.Info("removed expired trash documents from index", "key", key, "removed", removed)
+		}
+	}
+}
+
+// removeExpiredTrash deletes this index's trash documents whose deletion time is
+// outside the retention window, and returns how many it removed.
+//
+// Trash with no deletion time never matches and stays: a missing field is not
+// evidence that storage collected the object. A rebuild clears those, because it
+// lists the trash storage currently holds.
+func (b *bleveIndex) removeExpiredTrash(ctx context.Context, now time.Time) (int, error) {
+	threshold, ok := b.trashRetention.expirationThreshold(b.key.Group, b.key.Resource, now)
+	if !ok {
+		return 0, nil
+	}
+
+	// Going through scopeQuery is what keeps this off live documents, and stops
+	// this pass growing its own notion of what trash is. The window goes in as the
+	// query because scopeQuery's own threshold excludes expired trash rather than
+	// selecting it.
+	q := scopeQuery(expiredTrashQuery(threshold), true, 0)
+
+	removed := 0
+	for {
+		if err := ctx.Err(); err != nil {
+			return removed, err
+		}
+
+		found, err := b.index.SearchInContext(ctx, &bleve.SearchRequest{
+			Query: q,
+			Size:  trashCleanupBatchSize,
+		})
+		if err != nil {
+			return removed, err
+		}
+		if len(found.Hits) == 0 {
+			return removed, nil
+		}
+
+		batch := b.index.NewBatch()
+		for _, hit := range found.Hits {
+			batch.Delete(hit.ID)
+		}
+		if err := b.index.Batch(batch); err != nil {
+			return removed, err
+		}
+		removed += len(found.Hits)
+
+		// Deletions change the index, so they count towards the next snapshot upload
+		// like any other mutation.
+		if err := b.addSnapshotMutationCount(int64(len(found.Hits))); err != nil {
+			return removed, err
+		}
+
+		if len(found.Hits) < trashCleanupBatchSize {
+			return removed, nil
+		}
+	}
 }
 
 // combineFilterAndTextQueries assembles the final bleve query from the filter

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -2664,6 +2664,13 @@ func (b *bleveBackend) RemoveExpiredTrash(ctx context.Context) {
 // Trash with no deletion time never matches and stays: a missing field is not
 // evidence that storage collected the object. A rebuild clears those, because it
 // lists the trash storage currently holds.
+//
+// Deletion is by document id, which an object keeps across delete and recreate.
+// If an object is recreated between the search and the delete, the new document
+// is removed and comes back on the next rebuild. Left as is: the window is a few
+// milliseconds on trash that has already sat there for the whole retention
+// period, and closing it would mean holding a write lock that index updates on
+// the query path would then wait for.
 func (b *bleveIndex) removeExpiredTrash(ctx context.Context, now time.Time) (int, error) {
 	threshold, ok := b.trashRetention.expirationThreshold(b.key.Group, b.key.Resource, now)
 	if !ok {

--- a/pkg/storage/unified/search/bleve_trash_cleanup_internal_test.go
+++ b/pkg/storage/unified/search/bleve_trash_cleanup_internal_test.go
@@ -1,0 +1,185 @@
+package search
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/blevesearch/bleve/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+)
+
+// What the pass removes, and more importantly what it leaves alone: deleting from
+// an index cannot be undone without a rebuild.
+func TestRemoveExpiredTrash(t *testing.T) {
+	const day = 24 * time.Hour
+
+	old := time.Now().Add(-30 * day).UnixMilli()
+	recent := time.Now().Add(-1 * time.Hour).UnixMilli()
+
+	for _, tc := range []struct {
+		name      string
+		retention TrashRetentionConfig
+		// Names the index still holds after the pass, trash and live together.
+		want []string
+	}{
+		{
+			// Nothing expires with collection off, so all of this is still restorable.
+			name:      "collection disabled removes nothing",
+			retention: TrashRetentionConfig{Enabled: false, MaxAge: day, DashboardsMaxAge: day},
+			want:      []string{"live", "old-live", "no-timestamp", "old", "recent"},
+		},
+		{
+			name:      "expired trash is removed and the rest is kept",
+			retention: TrashRetentionConfig{Enabled: true, MaxAge: day, DashboardsMaxAge: day},
+			want:      []string{"live", "old-live", "no-timestamp", "recent"},
+		},
+		{
+			// Dashboards keep trash far longer, so nothing here has expired yet.
+			name:      "dashboards use their own longer window",
+			retention: TrashRetentionConfig{Enabled: true, MaxAge: time.Hour, DashboardsMaxAge: 365 * day},
+			want:      []string{"live", "old-live", "no-timestamp", "old", "recent"},
+		},
+		{
+			// The collector computes the same cutoff from a zero window and removes
+			// everything, so the index has to as well.
+			name:      "a zero window removes all trash carrying a deletion time",
+			retention: TrashRetentionConfig{Enabled: true},
+			want:      []string{"live", "old-live", "no-timestamp"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			backend, idx := newTrashCleanupIndex(t, tc.retention, old, recent)
+
+			backend.RemoveExpiredTrash(t.Context())
+
+			require.ElementsMatch(t, tc.want, allDocumentIDs(t, idx))
+		})
+	}
+}
+
+// An index that has just started keeping trash can hold a large backlog, so one
+// pass has to drain past a single batch.
+func TestRemoveExpiredTrashDrainsMoreThanOneBatch(t *testing.T) {
+	backend, err := NewBleveBackend(BleveOptions{
+		Root:           t.TempDir(),
+		FileThreshold:  5,
+		SearchFields:   trashCleanupSearchFields(),
+		TrashRetention: TrashRetentionConfig{Enabled: true, MaxAge: time.Hour, DashboardsMaxAge: time.Hour},
+	}, nil)
+	require.NoError(t, err)
+	t.Cleanup(backend.Stop)
+
+	expired := time.Now().Add(-30 * 24 * time.Hour).UnixMilli()
+	total := trashCleanupBatchSize + 10
+
+	key := trashCleanupKey()
+	ctx := identity.WithRequester(t.Context(), &user.SignedInUser{Namespace: "ns"})
+	index, err := backend.BuildIndex(ctx, key, int64(total), "test", func(i resource.ResourceIndex) (int64, error) {
+		items := make([]*resource.BulkIndexItem, 0, total)
+		for n := range total {
+			items = append(items, deletedTrashItem(key, "trash-"+strconv.Itoa(n), &expired, int64(n+1)))
+		}
+		return 1, i.BulkIndex(&resource.BulkIndexRequest{Items: items})
+	}, nil, false, time.Time{}, 0)
+	require.NoError(t, err)
+
+	backend.RemoveExpiredTrash(t.Context())
+
+	require.Empty(t, allDocumentIDs(t, index))
+}
+
+// newTrashCleanupIndex builds an index holding two live documents, one older than
+// any window used here, and three deleted ones: expired, recent, and one with no
+// deletion time, as written before that field existed.
+func newTrashCleanupIndex(t testing.TB, retention TrashRetentionConfig, old, recent int64) (*bleveBackend, resource.ResourceIndex) {
+	t.Helper()
+
+	backend, err := NewBleveBackend(BleveOptions{
+		Root:           t.TempDir(),
+		FileThreshold:  5,
+		SearchFields:   trashCleanupSearchFields(),
+		TrashRetention: retention,
+	}, nil)
+	require.NoError(t, err)
+	t.Cleanup(backend.Stop)
+
+	key := trashCleanupKey()
+	live := func(name string, rv int64) *resource.BulkIndexItem {
+		return &resource.BulkIndexItem{Action: resource.ActionIndex, Doc: &resource.IndexableDocument{
+			Key:   &resourcepb.ResourceKey{Namespace: key.Namespace, Group: key.Group, Resource: key.Resource, Name: name},
+			Name:  name,
+			Title: name,
+			RV:    rv,
+		}}
+	}
+
+	ctx := identity.WithRequester(t.Context(), &user.SignedInUser{Namespace: "ns"})
+	index, err := backend.BuildIndex(ctx, key, 4, "test", func(i resource.ResourceIndex) (int64, error) {
+		return 1, i.BulkIndex(&resource.BulkIndexRequest{Items: []*resource.BulkIndexItem{
+			deletedTrashItem(key, "old", &old, 10),
+			deletedTrashItem(key, "recent", &recent, 20),
+			deletedTrashItem(key, "no-timestamp", nil, 30),
+			live("live", 40),
+			// Age alone must not get a live document removed.
+			live("old-live", 1),
+		}})
+	}, nil, false, time.Time{}, 0)
+	require.NoError(t, err)
+
+	return backend, index
+}
+
+func trashCleanupKey() resource.NamespacedResource {
+	return resource.NamespacedResource{Namespace: "default", Group: dashboardGroup, Resource: dashboardResource}
+}
+
+func trashCleanupSearchFields() *resource.SearchFieldsRegistry {
+	return resource.NewSearchFieldsRegistry(nil, nil, map[resource.LowerGroupResource]resource.SearchFieldsProvider{
+		resource.NewLowerGroupResource(dashboardGroup, dashboardResource): DashboardSearchFieldsProviderForTest(),
+	})
+}
+
+func deletedTrashItem(key resource.NamespacedResource, name string, deletedAt *int64, rv int64) *resource.BulkIndexItem {
+	rvs := strconv.FormatInt(rv, 10)
+	deleted := true
+	return &resource.BulkIndexItem{Action: resource.ActionIndex, Doc: &resource.IndexableDocument{
+		Key:          &resourcepb.ResourceKey{Namespace: key.Namespace, Group: key.Group, Resource: key.Resource, Name: name},
+		Name:         name,
+		Title:        name,
+		RV:           rv,
+		IsDeleted:    &deleted,
+		DeletedRV:    &rvs,
+		DeletionTime: deletedAt,
+	}}
+}
+
+// allDocumentIDs returns every document in the index, trash included, so a test
+// can tell removal from the read path merely hiding something.
+func allDocumentIDs(t testing.TB, index resource.ResourceIndex) []string {
+	t.Helper()
+
+	idx, ok := index.(*bleveIndex)
+	require.True(t, ok)
+
+	names := []string{}
+	docs, err := idx.index.DocCount()
+	require.NoError(t, err)
+	if docs == 0 {
+		return names
+	}
+
+	res, err := idx.index.Search(bleve.NewSearchRequestOptions(bleve.NewMatchAllQuery(), int(docs), 0, false))
+	require.NoError(t, err)
+	for _, hit := range res.Hits {
+		k := &resourcepb.ResourceKey{}
+		require.NoError(t, resource.ReadSearchID(k, hit.ID))
+		names = append(names, k.Name)
+	}
+	return names
+}


### PR DESCRIPTION
Garbage collection hard-deletes old trash from storage and emits no events, so nothing tells the search index those objects are gone. Their documents stay until the index happens to be rebuilt, and the index grows with trash nobody can restore.

An hourly pass now deletes trash whose deletion time is outside the garbage collection retention window. Follows #130676, which stopped that trash being returned: that was about correct results, this is about index size.

- Uses the same retention window the read paths use, so search and storage cannot disagree about what expired. No new setting.
- Only runs when collection is enabled — with it off, all trash is still restorable.
- Scoped through `scopeQuery`, so live documents are never touched. Batched, and stops on context cancellation.
- Trash with no deletion time is left alone: a missing field is not evidence storage collected the object. A rebuild clears those.

It runs on its own timer rather than the five-minute rebuild scan, so a large backlog cannot hold up rebuilds.
