### PR TITLE
User: inject legacy database provider

### DIFF
--- a/pkg/api/folder_bench_test.go
+++ b/pkg/api/folder_bench_test.go
@@ -175,7 +175,7 @@ func setupDB(b testing.TB) benchScenario {
 
 	cache := localcache.ProvideService()
 	userSvc, err := userimpl.ProvideService(
-		db, orgService, cfg, teamSvc, cache, tracing.InitializeTracerForTest(),
+		legacysql.NewDatabaseProvider(db), orgService, cfg, teamSvc, cache, tracing.InitializeTracerForTest(),
 		&quotatest.FakeQuotaService{}, bundleregistry.ProvideService(), nil,
 	)
 	require.NoError(b, err)

--- a/pkg/api/org_users_test.go
+++ b/pkg/api/org_users_test.go
@@ -58,7 +58,7 @@ func setUpGetOrgUsersDB(t *testing.T, sqlStore db.DB, cfg *setting.Cfg) {
 	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(sqlStore), cfg, quotaService)
 	require.NoError(t, err)
 	usrSvc, err := userimpl.ProvideService(
-		sqlStore, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
+		legacysql.NewDatabaseProvider(sqlStore), orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
 		quotaService, supportbundlestest.NewFakeBundleService(), nil,
 	)
 	require.NoError(t, err)

--- a/pkg/api/user_test.go
+++ b/pkg/api/user_test.go
@@ -94,7 +94,7 @@ func TestIntegrationUserAPIEndpoint_userLoggedIn(t *testing.T) {
 		orgSvc, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(sqlStore), settings, quotatest.New(false, nil))
 		require.NoError(t, err)
 		userSvc, err := userimpl.ProvideService(
-			sqlStore, orgSvc, sc.cfg, nil, nil, tracing.InitializeTracerForTest(),
+			legacysql.NewDatabaseProvider(sqlStore), orgSvc, sc.cfg, nil, nil, tracing.InitializeTracerForTest(),
 			quotatest.New(false, nil), supportbundlestest.NewFakeBundleService(), nil,
 		)
 		require.NoError(t, err)
@@ -169,7 +169,7 @@ func TestIntegrationUserAPIEndpoint_userLoggedIn(t *testing.T) {
 		orgSvc, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(sqlStore), sc.cfg, quotatest.New(false, nil))
 		require.NoError(t, err)
 		userSvc, err := userimpl.ProvideService(
-			sqlStore, orgSvc, sc.cfg, nil, nil, tracing.InitializeTracerForTest(),
+			legacysql.NewDatabaseProvider(sqlStore), orgSvc, sc.cfg, nil, nil, tracing.InitializeTracerForTest(),
 			quotatest.New(false, nil), supportbundlestest.NewFakeBundleService(), nil,
 		)
 		require.NoError(t, err)
@@ -201,7 +201,7 @@ func TestIntegrationUserAPIEndpoint_userLoggedIn(t *testing.T) {
 		orgSvc, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(sqlStore), sc.cfg, quotatest.New(false, nil))
 		require.NoError(t, err)
 		userSvc, err := userimpl.ProvideService(
-			sqlStore, orgSvc, sc.cfg, nil, nil, tracing.InitializeTracerForTest(),
+			legacysql.NewDatabaseProvider(sqlStore), orgSvc, sc.cfg, nil, nil, tracing.InitializeTracerForTest(),
 			quotatest.New(false, nil), supportbundlestest.NewFakeBundleService(), nil,
 		)
 		require.NoError(t, err)
@@ -677,7 +677,7 @@ func setupUpdateEmailTests(t *testing.T, cfg *setting.Cfg) (*user.User, *HTTPSer
 	orgSvc, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(sqlStore), cfg, quotatest.New(false, nil))
 	require.NoError(t, err)
 	userSvc, err := userimpl.ProvideService(
-		sqlStore, orgSvc, cfg, nil, nil, tracing.InitializeTracerForTest(),
+		legacysql.NewDatabaseProvider(sqlStore), orgSvc, cfg, nil, nil, tracing.InitializeTracerForTest(),
 		quotatest.New(false, nil), supportbundlestest.NewFakeBundleService(), nil,
 	)
 	require.NoError(t, err)
@@ -908,7 +908,7 @@ func TestIntegrationUser_UpdateEmail(t *testing.T) {
 		orgSvc, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(sqlStore), settings, quotatest.New(false, nil))
 		require.NoError(t, err)
 		userSvc, err := userimpl.ProvideService(
-			sqlStore, orgSvc, settings, nil, nil, tracing.InitializeTracerForTest(),
+			legacysql.NewDatabaseProvider(sqlStore), orgSvc, settings, nil, nil, tracing.InitializeTracerForTest(),
 			quotatest.New(false, nil), supportbundlestest.NewFakeBundleService(), nil,
 		)
 		require.NoError(t, err)

--- a/pkg/server/bootstrap/wire/wire_gen.go
+++ b/pkg/server/bootstrap/wire/wire_gen.go
@@ -374,7 +374,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts server.Options, apiO
 	if err != nil {
 		return nil, err
 	}
-	userimplService, err := userimpl.ProvideService(sqlStore, orgService, cfg, teamimplService, cacheService, tracingService, quotaService, bundleregistryService, eventualRestConfigProvider)
+	userimplService, err := userimpl.ProvideService(legacyDatabaseProvider, orgService, cfg, teamimplService, cacheService, tracingService, quotaService, bundleregistryService, eventualRestConfigProvider)
 	if err != nil {
 		return nil, err
 	}
@@ -1136,7 +1136,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	if err != nil {
 		return nil, err
 	}
-	userimplService, err := userimpl.ProvideService(sqlStore, orgService, cfg, teamimplService, cacheService, tracingService, quotaService, bundleregistryService, eventualRestConfigProvider)
+	userimplService, err := userimpl.ProvideService(legacyDatabaseProvider, orgService, cfg, teamimplService, cacheService, tracingService, quotaService, bundleregistryService, eventualRestConfigProvider)
 	if err != nil {
 		return nil, err
 	}
@@ -1841,7 +1841,7 @@ func InitializeForCLI(ctx context.Context, cfg *setting.Cfg) (server.Runner, err
 		return server.Runner{}, err
 	}
 	cacheService := localcache.ProvideService()
-	userimplService, err := userimpl.ProvideService(sqlStore, orgService, cfg, teamimplService, cacheService, tracingService, quotaService, bundleregistryService, eventualRestConfigProvider)
+	userimplService, err := userimpl.ProvideService(legacyDatabaseProvider, orgService, cfg, teamimplService, cacheService, tracingService, quotaService, bundleregistryService, eventualRestConfigProvider)
 	if err != nil {
 		return server.Runner{}, err
 	}

--- a/pkg/services/accesscontrol/database/database_test.go
+++ b/pkg/services/accesscontrol/database/database_test.go
@@ -636,7 +636,7 @@ func setupTestEnv(t testing.TB) (*database.AccessControlStore, rs.Store, user.Se
 	require.NoError(t, err)
 
 	userService, err := userimpl.ProvideService(
-		sql, orgService, cfg, teamService, localcache.ProvideService(), tracing.InitializeTracerForTest(),
+		legacysql.NewDatabaseProvider(sql), orgService, cfg, teamService, localcache.ProvideService(), tracing.InitializeTracerForTest(),
 		quotatest.New(false, nil), supportbundlestest.NewFakeBundleService(), nil,
 	)
 	require.NoError(t, err)

--- a/pkg/services/accesscontrol/dualwrite/collectors_test.go
+++ b/pkg/services/accesscontrol/dualwrite/collectors_test.go
@@ -65,7 +65,7 @@ func setupTestEnv(t *testing.T) *testEnv {
 	require.NoError(t, err)
 
 	userService, err := userimpl.ProvideService(
-		sql, orgService, cfg, teamService, localcache.ProvideService(), tracing.InitializeTracerForTest(),
+		legacysql.NewDatabaseProvider(sql), orgService, cfg, teamService, localcache.ProvideService(), tracing.InitializeTracerForTest(),
 		quotatest.New(false, nil), supportbundlestest.NewFakeBundleService(), nil,
 	)
 	require.NoError(t, err)

--- a/pkg/services/accesscontrol/ossaccesscontrol/testutil/testutil.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/testutil/testutil.go
@@ -61,7 +61,7 @@ func ProvideFolderPermissions(
 	cache := localcache.ProvideService()
 
 	userSvc, err := userimpl.ProvideService(
-		sqlStore,
+		legacysql.NewDatabaseProvider(sqlStore),
 		orgService,
 		cfg,
 		teamSvc,

--- a/pkg/services/accesscontrol/resourcepermissions/service_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service_test.go
@@ -848,7 +848,7 @@ func setupTestEnvironmentWithCfg(t *testing.T, ops Options, features featuremgmt
 	require.NoError(t, err)
 
 	userSvc, err := userimpl.ProvideService(
-		sql, orgSvc, cfg, teamSvc, nil, tracer,
+		legacysql.NewDatabaseProvider(sql), orgSvc, cfg, teamSvc, nil, tracer,
 		quotatest.New(false, nil), supportbundlestest.NewFakeBundleService(), nil,
 	)
 	require.NoError(t, err)

--- a/pkg/services/accesscontrol/resourcepermissions/store_bench_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/store_bench_test.go
@@ -153,7 +153,7 @@ func generateTeamsAndUsers(b *testing.B, store db.DB, cfg *setting.Cfg, users in
 	orgSvc, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(store), cfg, qs)
 	require.NoError(b, err)
 	usrSvc, err := userimpl.ProvideService(
-		store, orgSvc, cfg, nil, nil, tracing.InitializeTracerForTest(),
+		legacysql.NewDatabaseProvider(store), orgSvc, cfg, nil, nil, tracing.InitializeTracerForTest(),
 		qs, supportbundlestest.NewFakeBundleService(), nil)
 	require.NoError(b, err)
 	userIds := make([]int64, 0)

--- a/pkg/services/accesscontrol/resourcepermissions/store_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/store_test.go
@@ -527,7 +527,7 @@ func seedResourcePermissions(
 	require.NoError(t, err)
 
 	usrSvc, err := userimpl.ProvideService(
-		sql, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
+		legacysql.NewDatabaseProvider(sql), orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
 		quotatest.New(false, nil), supportbundlestest.NewFakeBundleService(), nil,
 	)
 	require.NoError(t, err)

--- a/pkg/services/libraryelements/libraryelements_permissions_test.go
+++ b/pkg/services/libraryelements/libraryelements_permissions_test.go
@@ -444,7 +444,7 @@ func createUserInOrg(t *testing.T, db db.DB, cfg *setting.Cfg, cmd user.CreateUs
 	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(db), cfg, quotaService)
 	require.NoError(t, err)
 	usrSvc, err := userimpl.ProvideService(
-		db, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
+		legacysql.NewDatabaseProvider(db), orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
 		quotaService, supportbundlestest.NewFakeBundleService(), nil,
 	)
 	require.NoError(t, err)

--- a/pkg/services/libraryelements/libraryelements_test.go
+++ b/pkg/services/libraryelements/libraryelements_test.go
@@ -353,7 +353,7 @@ func setupTestScenario(t *testing.T) scenarioContext {
 	orgSvc, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(sqlStore), cfg, quotaService)
 	require.NoError(t, err)
 	usrSvc, err := userimpl.ProvideService(
-		sqlStore, orgSvc, cfg, nil, nil, tracer,
+		legacysql.NewDatabaseProvider(sqlStore), orgSvc, cfg, nil, nil, tracer,
 		quotaService, supportbundlestest.NewFakeBundleService(), nil,
 	)
 	require.NoError(t, err)

--- a/pkg/services/librarypanels/librarypanels_test.go
+++ b/pkg/services/librarypanels/librarypanels_test.go
@@ -533,7 +533,7 @@ func testScenario(t *testing.T, desc string, fn func(t *testing.T, sc scenarioCo
 		orgSvc, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(sqlStore), cfg, quotaService)
 		require.NoError(t, err)
 		usrSvc, err := userimpl.ProvideService(
-			sqlStore, orgSvc, cfg, nil, nil, tracing.InitializeTracerForTest(),
+			legacysql.NewDatabaseProvider(sqlStore), orgSvc, cfg, nil, nil, tracing.InitializeTracerForTest(),
 			quotaService, supportbundlestest.NewFakeBundleService(), nil,
 		)
 		require.NoError(t, err)

--- a/pkg/services/org/orgimpl/store_test.go
+++ b/pkg/services/org/orgimpl/store_test.go
@@ -1380,7 +1380,7 @@ func createOrgAndUserSvc(t *testing.T, store db.DB, cfg *setting.Cfg) (org.Servi
 	orgService, err := ProvideService(legacysql.NewDatabaseProvider(store), cfg, quotaService)
 	require.NoError(t, err)
 	usrSvc, err := userimpl.ProvideService(
-		store, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
+		legacysql.NewDatabaseProvider(store), orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
 		quotaService, supportbundlestest.NewFakeBundleService(), nil,
 	)
 	require.NoError(t, err)

--- a/pkg/services/queryhistory/queryhistory_test.go
+++ b/pkg/services/queryhistory/queryhistory_test.go
@@ -71,7 +71,7 @@ func testScenario(t *testing.T, desc string, isViewer bool, hasDatasourceExplore
 		orgSvc, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(sqlStore), cfg, quotaService)
 		require.NoError(t, err)
 		usrSvc, err := userimpl.ProvideService(
-			sqlStore, orgSvc, cfg, nil, nil, tracing.InitializeTracerForTest(),
+			legacysql.NewDatabaseProvider(sqlStore), orgSvc, cfg, nil, nil, tracing.InitializeTracerForTest(),
 			quotaService, supportbundlestest.NewFakeBundleService(), nil,
 		)
 		require.NoError(t, err)

--- a/pkg/services/quota/quotaimpl/quota_test.go
+++ b/pkg/services/quota/quotaimpl/quota_test.go
@@ -115,7 +115,7 @@ func TestIntegrationQuotaCommandsAndQueries(t *testing.T) {
 	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(sqlStore), cfg, quotaService)
 	require.NoError(t, err)
 	userService, err := userimpl.ProvideService(
-		sqlStore, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
+		legacysql.NewDatabaseProvider(sqlStore), orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
 		quotaService, supportbundlestest.NewFakeBundleService(), nil,
 	)
 	require.NoError(t, err)

--- a/pkg/services/serviceaccounts/database/store_test.go
+++ b/pkg/services/serviceaccounts/database/store_test.go
@@ -252,7 +252,7 @@ func setupTestDatabase(t *testing.T) (db.DB, *ServiceAccountsStoreImpl) {
 	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(db), cfg, quotaService)
 	require.NoError(t, err)
 	userSvc, err := userimpl.ProvideService(
-		db, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
+		legacysql.NewDatabaseProvider(db), orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
 		quotaService, supportbundlestest.NewFakeBundleService(), nil,
 	)
 	require.NoError(t, err)

--- a/pkg/services/serviceaccounts/tests/common.go
+++ b/pkg/services/serviceaccounts/tests/common.go
@@ -51,7 +51,7 @@ func SetupUserServiceAccount(t *testing.T, db db.DB, cfg *setting.Cfg, testUser 
 	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(db), cfg, quotaService)
 	require.NoError(t, err)
 	usrSvc, err := userimpl.ProvideService(
-		db, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
+		legacysql.NewDatabaseProvider(db), orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
 		quotaService, supportbundlestest.NewFakeBundleService(), nil,
 	)
 	require.NoError(t, err)
@@ -132,7 +132,7 @@ func SetupUsersServiceAccounts(t *testing.T, sqlStore db.DB, cfg *setting.Cfg, t
 	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(sqlStore), cfg, quotaService)
 	require.NoError(t, err)
 	usrSvc, err := userimpl.ProvideService(
-		sqlStore, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
+		legacysql.NewDatabaseProvider(sqlStore), orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
 		quotaService, supportbundlestest.NewFakeBundleService(), nil,
 	)
 	require.NoError(t, err)

--- a/pkg/services/stats/statsimpl/stats_test.go
+++ b/pkg/services/stats/statsimpl/stats_test.go
@@ -153,7 +153,7 @@ func populateDB(t *testing.T, db db.DB, cfg *setting.Cfg) org.Service {
 
 	orgService, _ := orgimpl.ProvideService(legacysql.NewDatabaseProvider(db), cfg, quotatest.New(false, nil))
 	userSvc, _ := userimpl.ProvideService(
-		db, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
+		legacysql.NewDatabaseProvider(db), orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
 		&quotatest.FakeQuotaService{}, supportbundlestest.NewFakeBundleService(), nil,
 	)
 

--- a/pkg/services/team/teamimpl/store_test.go
+++ b/pkg/services/team/teamimpl/store_test.go
@@ -57,7 +57,7 @@ func TestIntegrationTeamCommandsAndQueries(t *testing.T) {
 		orgSvc, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(sqlStore), cfg, quotaService)
 		require.NoError(t, err)
 		userSvc, err := userimpl.ProvideService(
-			sqlStore, orgSvc, cfg, teamSvc, nil, tracing.InitializeTracerForTest(),
+			legacysql.NewDatabaseProvider(sqlStore), orgSvc, cfg, teamSvc, nil, tracing.InitializeTracerForTest(),
 			quotaService, supportbundlestest.NewFakeBundleService(), nil,
 		)
 		require.NoError(t, err)
@@ -509,7 +509,7 @@ func TestIntegrationTeamCommandsAndQueries(t *testing.T) {
 				orgSvc, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(sqlStore), cfg, quotaService)
 				require.NoError(t, err)
 				userSvc, err := userimpl.ProvideService(
-					sqlStore, orgSvc, cfg, teamSvc, nil, tracing.InitializeTracerForTest(),
+					legacysql.NewDatabaseProvider(sqlStore), orgSvc, cfg, teamSvc, nil, tracing.InitializeTracerForTest(),
 					quotaService, supportbundlestest.NewFakeBundleService(), nil,
 				)
 				require.NoError(t, err)
@@ -755,7 +755,7 @@ func TestIntegrationSQLStore_GetTeamMembers_ACFilter(t *testing.T) {
 		orgSvc, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(store), cfg, quotaService)
 		require.NoError(t, err)
 		userSvc, err := userimpl.ProvideService(
-			store, orgSvc, cfg, teamSvc, nil, tracing.InitializeTracerForTest(),
+			legacysql.NewDatabaseProvider(store), orgSvc, cfg, teamSvc, nil, tracing.InitializeTracerForTest(),
 			quotaService, supportbundlestest.NewFakeBundleService(), nil,
 		)
 		require.NoError(t, err)

--- a/pkg/services/user/userimpl/legacy_user.go
+++ b/pkg/services/user/userimpl/legacy_user.go
@@ -3,6 +3,7 @@ package userimpl
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -131,6 +132,9 @@ func (s *LegacyService) Create(ctx context.Context, cmd *user.CreateUserCommand)
 	}
 
 	if err := s.store.LoginConflict(ctx, cmd.Login, cmd.Email); err != nil {
+		if !errors.Is(err, user.ErrUserAlreadyExists) {
+			return nil, err
+		}
 		return nil, user.ErrUserAlreadyExists
 	}
 
@@ -453,6 +457,9 @@ func (s *LegacyService) CreateServiceAccount(ctx context.Context, cmd *user.Crea
 	cmd.Email = cmd.Login
 	err := s.store.LoginConflict(ctx, cmd.Login, cmd.Email)
 	if err != nil {
+		if !errors.Is(err, user.ErrUserAlreadyExists) {
+			return nil, err
+		}
 		return nil, serviceaccounts.ErrServiceAccountAlreadyExists.Errorf("service account with login %s already exists", cmd.Login)
 	}
 

--- a/pkg/services/user/userimpl/legacy_user.go
+++ b/pkg/services/user/userimpl/legacy_user.go
@@ -132,10 +132,7 @@ func (s *LegacyService) Create(ctx context.Context, cmd *user.CreateUserCommand)
 	}
 
 	if err := s.store.LoginConflict(ctx, cmd.Login, cmd.Email); err != nil {
-		if !errors.Is(err, user.ErrUserAlreadyExists) {
-			return nil, err
-		}
-		return nil, user.ErrUserAlreadyExists
+		return nil, err
 	}
 
 	// create user

--- a/pkg/services/user/userimpl/legacy_user.go
+++ b/pkg/services/user/userimpl/legacy_user.go
@@ -11,7 +11,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
-	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/localcache"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -22,6 +21,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/team"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/util"
 )
 
@@ -32,18 +32,18 @@ type LegacyService struct {
 	cacheService *localcache.CacheService
 	cfg          *setting.Cfg
 	tracer       tracing.Tracer
-	db           db.DB
+	sql          legacysql.LegacyDatabaseProvider
 }
 
 func NewLegacyService(
-	db db.DB,
+	sql legacysql.LegacyDatabaseProvider,
 	orgService org.Service,
 	cfg *setting.Cfg,
 	teamService team.Service,
 	cacheService *localcache.CacheService, tracer tracing.Tracer,
 	quotaService quota.Service, bundleRegistry supportbundles.Service,
 ) (user.Service, error) {
-	store := ProvideStore(db, cfg)
+	store := ProvideStore(sql, cfg)
 	s := &LegacyService{
 		store:        &store,
 		orgService:   orgService,
@@ -51,7 +51,7 @@ func NewLegacyService(
 		teamService:  teamService,
 		cacheService: cacheService,
 		tracer:       tracer,
-		db:           db,
+		sql:          sql,
 	}
 
 	defaultLimits, err := readQuotaConfig(cfg)
@@ -174,7 +174,12 @@ func (s *LegacyService) Create(ctx context.Context, cmd *user.CreateUserCommand)
 		}
 	}
 
-	err = s.db.InTransaction(ctx, func(ctx context.Context) error {
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	err = dbHelper.DB.InTransaction(ctx, func(ctx context.Context) error {
 		_, err = s.store.Insert(ctx, usr)
 		if err != nil {
 			return err

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -561,7 +561,7 @@ func (ss *sqlStore) Search(ctx context.Context, query *user.SearchUsersQuery) (*
 		whereParams := make([]any, 0)
 		userTable := dbHelper.Table("user")
 		userAuthTable := dbHelper.Table("user_auth")
-		quotedUserAuthTable := quoteTable(dbHelper, "user_auth")
+		qUserAuth := quoteTable(dbHelper, "user_auth")
 		sess := dbSess.Table(userTable).Alias("u")
 
 		whereConditions = append(whereConditions, "u.is_service_account = ?")
@@ -569,7 +569,7 @@ func (ss *sqlStore) Search(ctx context.Context, query *user.SearchUsersQuery) (*
 
 		// Join with only most recent auth module
 		joinCondition := `(
-		SELECT id from ` + quotedUserAuthTable + ` AS user_auth
+		SELECT id from ` + qUserAuth + ` AS user_auth
 			WHERE user_auth.user_id = u.id
 			ORDER BY user_auth.created DESC `
 		joinCondition = "user_auth.id=" + joinCondition + dbHelper.DB.GetDialect().Limit(1) + ")"

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -41,6 +41,11 @@ type sqlStore struct {
 	cfg    *setting.Cfg
 }
 
+// quoteTable resolves a table name and quotes it for use in raw SQL.
+func quoteTable(dbHelper *legacysql.LegacyDatabaseHelper, name string) string {
+	return dbHelper.DB.Quote(dbHelper.Table(name))
+}
+
 func ProvideStore(sql legacysql.LegacyDatabaseProvider, cfg *setting.Cfg) sqlStore {
 	return sqlStore{
 		sql:    sql,
@@ -81,7 +86,7 @@ func (ss *sqlStore) Delete(ctx context.Context, userID int64) error {
 	}
 
 	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
-		var rawSQL = "DELETE FROM " + dbHelper.DB.Quote(dbHelper.Table("user")) + " WHERE id = ?"
+		var rawSQL = "DELETE FROM " + quoteTable(dbHelper, "user") + " WHERE id = ?"
 		_, err := sess.Exec(rawSQL, userID)
 		return err
 	})
@@ -157,7 +162,7 @@ func (ss *sqlStore) ListByIdOrUID(ctx context.Context, uids []string, ids []int6
 
 func (ss *sqlStore) notServiceAccountFilter(dbHelper *legacysql.LegacyDatabaseHelper) string {
 	return fmt.Sprintf("%s.is_service_account = %s",
-		dbHelper.DB.Quote(dbHelper.Table("user")),
+		quoteTable(dbHelper, "user"),
 		dbHelper.DB.GetDialect().BooleanStr(false))
 }
 
@@ -376,9 +381,9 @@ func (ss *sqlStore) GetSignedInUser(ctx context.Context, query *user.GetSignedIn
 		org_user.role         as org_role,
 		org.id                as org_id,
 		u.is_service_account  as is_service_account
-		FROM ` + dbHelper.DB.Quote(dbHelper.Table("user")) + ` AS u
-		LEFT OUTER JOIN ` + dbHelper.DB.Quote(dbHelper.Table("org_user")) + ` AS org_user ON org_user.org_id = ` + orgID + ` AND org_user.user_id = u.id
-		LEFT OUTER JOIN ` + dbHelper.DB.Quote(dbHelper.Table("org")) + ` AS org ON org.id = org_user.org_id `
+		FROM ` + quoteTable(dbHelper, "user") + ` AS u
+		LEFT OUTER JOIN ` + quoteTable(dbHelper, "org_user") + ` AS org_user ON org_user.org_id = ` + orgID + ` AND org_user.user_id = u.id
+		LEFT OUTER JOIN ` + quoteTable(dbHelper, "org") + ` AS org ON org.id = org_user.org_id `
 
 		sess := dbSess.Table(dbHelper.Table("user"))
 		sess = sess.Context(ctx)
@@ -462,7 +467,7 @@ func (ss *sqlStore) Count(ctx context.Context) (int64, error) {
 	}
 
 	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
-		rawSQL := fmt.Sprintf("SELECT COUNT(*) as count from %s WHERE is_service_account=%s", dbHelper.DB.Quote(dbHelper.Table("user")), dbHelper.DB.GetDialect().BooleanStr(false))
+		rawSQL := fmt.Sprintf("SELECT COUNT(*) as count from %s WHERE is_service_account=%s", quoteTable(dbHelper, "user"), dbHelper.DB.GetDialect().BooleanStr(false))
 		if _, err := sess.SQL(rawSQL).Get(&r); err != nil {
 			return err
 		}
@@ -482,8 +487,8 @@ func (ss *sqlStore) CountUserAccountsWithEmptyRole(ctx context.Context) (int64, 
 		SELECT sub.user_accounts_with_no_role
 		FROM (
 		  SELECT COUNT(*) AS user_accounts_with_no_role
-		  FROM ` + dbHelper.DB.Quote(dbHelper.Table("org_user")) + ` AS ou
-		  LEFT JOIN ` + dbHelper.DB.Quote(dbHelper.Table("user")) + ` AS u ON u.id = ou.user_id
+		  FROM ` + quoteTable(dbHelper, "org_user") + ` AS ou
+		  LEFT JOIN ` + quoteTable(dbHelper, "user") + ` AS u ON u.id = ou.user_id
 		  WHERE ou.role = ?
 		  AND u.is_service_account = ` + dbHelper.DB.GetDialect().BooleanStr(false) + `
 		  AND u.is_disabled = ` + dbHelper.DB.GetDialect().BooleanStr(false) + `
@@ -530,7 +535,7 @@ func (ss *sqlStore) BatchDisableUsers(ctx context.Context, cmd *user.BatchDisabl
 		}
 
 		user_id_params := strings.Repeat(",?", len(userIds)-1)
-		disableSQL := "UPDATE " + dbHelper.DB.Quote(dbHelper.Table("user")) + " SET is_disabled=? WHERE Id IN (?" + user_id_params + ")"
+		disableSQL := "UPDATE " + quoteTable(dbHelper, "user") + " SET is_disabled=? WHERE Id IN (?" + user_id_params + ")"
 
 		disableParams := []any{disableSQL, cmd.IsDisabled}
 		for _, v := range userIds {

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -535,14 +535,15 @@ func (ss *sqlStore) BatchDisableUsers(ctx context.Context, cmd *user.BatchDisabl
 		}
 
 		user_id_params := strings.Repeat(",?", len(userIds)-1)
-		disableSQL := "UPDATE " + quoteTable(dbHelper, "user") + " SET is_disabled=? WHERE Id IN (?" + user_id_params + ")"
+		disableSQL := "UPDATE " + quoteTable(dbHelper, "user") + " SET is_disabled=? WHERE Id IN (?" + user_id_params + ")" +
+			" AND is_service_account=" + dbHelper.DB.GetDialect().BooleanStr(false)
 
 		disableParams := []any{disableSQL, cmd.IsDisabled}
 		for _, v := range userIds {
 			disableParams = append(disableParams, v)
 		}
 
-		_, err := sess.Where(ss.notServiceAccountFilter(dbHelper)).Exec(disableParams...)
+		_, err := sess.Exec(disableParams...)
 		return err
 	})
 }

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -3,7 +3,6 @@ package userimpl
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/util"
 )
 
@@ -36,45 +36,52 @@ type store interface {
 }
 
 type sqlStore struct {
-	db      db.DB
-	dialect migrator.Dialect
-	logger  log.Logger
-	cfg     *setting.Cfg
+	sql    legacysql.LegacyDatabaseProvider
+	logger log.Logger
+	cfg    *setting.Cfg
 }
 
-func ProvideStore(db db.DB, cfg *setting.Cfg) sqlStore {
+func ProvideStore(sql legacysql.LegacyDatabaseProvider, cfg *setting.Cfg) sqlStore {
 	return sqlStore{
-		db:      db,
-		dialect: db.GetDialect(),
-		cfg:     cfg,
-		logger:  log.New("user.store"),
+		sql:    sql,
+		cfg:    cfg,
+		logger: log.New("user.store"),
 	}
 }
 
 func (ss *sqlStore) Insert(ctx context.Context, cmd *user.User) (int64, error) {
-	var err error
-	err = ss.db.WithDbSession(ctx, func(sess *db.Session) error {
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
 		sess.UseBool("is_admin")
 		if cmd.UID == "" {
 			cmd.UID = util.GenerateShortUID()
 		}
 
-		if _, err = sess.Insert(cmd); err != nil {
+		if _, err = sess.Table(dbHelper.Table("user")).Insert(cmd); err != nil {
 			return err
 		}
 		return nil
 	})
 
 	if err != nil {
-		return 0, handleSQLError(ss.dialect, err)
+		return 0, handleSQLError(dbHelper.DB.GetDialect(), err)
 	}
 
 	return cmd.ID, nil
 }
 
 func (ss *sqlStore) Delete(ctx context.Context, userID int64) error {
-	err := ss.db.WithDbSession(ctx, func(sess *db.Session) error {
-		var rawSQL = "DELETE FROM " + ss.dialect.Quote("user") + " WHERE id = ?"
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
+		var rawSQL = "DELETE FROM " + dbHelper.DB.Quote(dbHelper.Table("user")) + " WHERE id = ?"
 		_, err := sess.Exec(rawSQL, userID)
 		return err
 	})
@@ -86,10 +93,14 @@ func (ss *sqlStore) Delete(ctx context.Context, userID int64) error {
 
 func (ss *sqlStore) GetByID(ctx context.Context, userID int64) (*user.User, error) {
 	var usr user.User
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
 
-	err := ss.db.WithDbSession(ctx, func(sess *db.Session) error {
-		has, err := sess.ID(&userID).
-			Where(ss.notServiceAccountFilter()).
+	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
+		has, err := sess.Table(dbHelper.Table("user")).ID(&userID).
+			Where(ss.notServiceAccountFilter(dbHelper)).
 			Get(&usr)
 
 		if err != nil {
@@ -104,9 +115,13 @@ func (ss *sqlStore) GetByID(ctx context.Context, userID int64) (*user.User, erro
 
 func (ss *sqlStore) GetByUID(ctx context.Context, uid string) (*user.User, error) {
 	var usr user.User
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
 
-	err := ss.db.WithDbSession(ctx, func(sess *db.Session) error {
-		has, err := sess.Table("user").Where("uid = ?", uid).Get(&usr)
+	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
+		has, err := sess.Table(dbHelper.Table("user")).Where("uid = ?", uid).Get(&usr)
 		if err != nil {
 			return err
 		} else if !has {
@@ -119,9 +134,13 @@ func (ss *sqlStore) GetByUID(ctx context.Context, uid string) (*user.User, error
 
 func (ss *sqlStore) ListByIdOrUID(ctx context.Context, uids []string, ids []int64) ([]*user.User, error) {
 	users := make([]*user.User, 0)
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
 
-	err := ss.db.WithDbSession(ctx, func(sess *db.Session) error {
-		err := sess.Table("user").In("uid", uids).OrIn("id", ids).Find(&users)
+	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
+		err := sess.Table(dbHelper.Table("user")).In("uid", uids).OrIn("id", ids).Find(&users)
 		if err != nil {
 			return err
 		}
@@ -136,10 +155,10 @@ func (ss *sqlStore) ListByIdOrUID(ctx context.Context, uids []string, ids []int6
 	return users, err
 }
 
-func (ss *sqlStore) notServiceAccountFilter() string {
+func (ss *sqlStore) notServiceAccountFilter(dbHelper *legacysql.LegacyDatabaseHelper) string {
 	return fmt.Sprintf("%s.is_service_account = %s",
-		ss.dialect.Quote("user"),
-		ss.dialect.BooleanStr(false))
+		dbHelper.DB.Quote(dbHelper.Table("user")),
+		dbHelper.DB.GetDialect().BooleanStr(false))
 }
 
 func (ss *sqlStore) GetByLogin(ctx context.Context, query *user.GetUserByLoginQuery) (*user.User, error) {
@@ -147,7 +166,12 @@ func (ss *sqlStore) GetByLogin(ctx context.Context, query *user.GetUserByLoginQu
 	query.LoginOrEmail = strings.ToLower(query.LoginOrEmail)
 
 	usr := &user.User{}
-	err := ss.db.WithDbSession(ctx, func(sess *db.Session) error {
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
 		if query.LoginOrEmail == "" {
 			return user.ErrUserNotFound
 		}
@@ -160,7 +184,7 @@ func (ss *sqlStore) GetByLogin(ctx context.Context, query *user.GetUserByLoginQu
 		// first if the login field has the "@" symbol.
 		if strings.Contains(query.LoginOrEmail, "@") {
 			where = "email=?"
-			has, err = sess.Where(ss.notServiceAccountFilter()).Where(where, query.LoginOrEmail).Get(usr)
+			has, err = sess.Table(dbHelper.Table("user")).Where(ss.notServiceAccountFilter(dbHelper)).Where(where, query.LoginOrEmail).Get(usr)
 			if err != nil {
 				return err
 			}
@@ -169,7 +193,7 @@ func (ss *sqlStore) GetByLogin(ctx context.Context, query *user.GetUserByLoginQu
 		// Look for the login field instead of email
 		if !has {
 			where = "login=?"
-			has, err = sess.Where(ss.notServiceAccountFilter()).Where(where, query.LoginOrEmail).Get(usr)
+			has, err = sess.Table(dbHelper.Table("user")).Where(ss.notServiceAccountFilter(dbHelper)).Where(where, query.LoginOrEmail).Get(usr)
 		}
 
 		if err != nil {
@@ -192,13 +216,18 @@ func (ss *sqlStore) GetByEmail(ctx context.Context, query *user.GetUserByEmailQu
 	query.Email = strings.ToLower(query.Email)
 
 	usr := &user.User{}
-	err := ss.db.WithDbSession(ctx, func(sess *db.Session) error {
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
 		if query.Email == "" {
 			return user.ErrUserNotFound
 		}
 
 		where := "email=?"
-		has, err := sess.Where(ss.notServiceAccountFilter()).Where(where, query.Email).Get(usr)
+		has, err := sess.Table(dbHelper.Table("user")).Where(ss.notServiceAccountFilter(dbHelper)).Where(where, query.Email).Get(usr)
 
 		if err != nil {
 			return err
@@ -220,10 +249,15 @@ func (ss *sqlStore) LoginConflict(ctx context.Context, login, email string) erro
 	login = strings.ToLower(login)
 	email = strings.ToLower(email)
 
-	err := ss.db.WithDbSession(ctx, func(sess *db.Session) error {
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
 		where := "email=? OR login=?"
 
-		exists, err := sess.Where(where, email, login).Get(&user.User{})
+		exists, err := sess.Table(dbHelper.Table("user")).Where(where, email, login).Get(&user.User{})
 		if err != nil {
 			return err
 		}
@@ -241,7 +275,12 @@ func (ss *sqlStore) Update(ctx context.Context, cmd *user.UpdateUserCommand) err
 	cmd.Login = strings.ToLower(cmd.Login)
 	cmd.Email = strings.ToLower(cmd.Email)
 
-	return ss.db.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	return dbHelper.DB.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
 		usr := user.User{
 			Name:    cmd.Name,
 			Theme:   cmd.Theme,
@@ -250,7 +289,7 @@ func (ss *sqlStore) Update(ctx context.Context, cmd *user.UpdateUserCommand) err
 			Updated: time.Now(),
 		}
 
-		q := sess.ID(cmd.UserID).Where(ss.notServiceAccountFilter())
+		q := sess.Table(dbHelper.Table("user")).ID(cmd.UserID).Where(ss.notServiceAccountFilter(dbHelper))
 
 		setOptional(cmd.OrgID, func(v int64) { usr.OrgID = v })
 		setOptional(cmd.Password, func(v user.Password) { usr.Password = v })
@@ -272,12 +311,12 @@ func (ss *sqlStore) Update(ctx context.Context, cmd *user.UpdateUserCommand) err
 		})
 
 		if _, err := q.Update(&usr); err != nil {
-			return handleSQLError(ss.dialect, err)
+			return handleSQLError(dbHelper.DB.GetDialect(), err)
 		}
 
 		if cmd.IsGrafanaAdmin != nil && !*cmd.IsGrafanaAdmin {
 			// validate that after update there is at least one server admin
-			if err := validateOneAdminLeft(sess); err != nil {
+			if err := validateOneAdminLeft(dbHelper, sess); err != nil {
 				return err
 			}
 		}
@@ -290,23 +329,36 @@ func (ss *sqlStore) UpdateLastSeenAt(ctx context.Context, cmd *user.UpdateUserLa
 	if cmd.UserID <= 0 {
 		return user.ErrUpdateInvalidID
 	}
-	return ss.db.WithDbSession(ctx, func(sess *db.Session) error {
+
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	return dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
 		user := user.User{
 			ID:         cmd.UserID,
 			LastSeenAt: time.Now(),
 		}
 
-		_, err := sess.ID(cmd.UserID).Update(&user)
+		_, err := sess.Table(dbHelper.Table("user")).ID(cmd.UserID).Update(&user)
 		return err
 	})
 }
 
 func (ss *sqlStore) GetSignedInUser(ctx context.Context, query *user.GetSignedInUserQuery) (*user.SignedInUser, error) {
 	var signedInUser user.SignedInUser
-	err := ss.db.WithDbSession(ctx, func(dbSess *db.Session) error {
-		orgId := "u.org_id"
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	err = dbHelper.DB.WithDbSession(ctx, func(dbSess *db.Session) error {
+		orgID := "u.org_id"
+		orgIDParams := make([]any, 0, 1)
 		if query.OrgID > 0 {
-			orgId = strconv.FormatInt(query.OrgID, 10)
+			orgID = "?"
+			orgIDParams = append(orgIDParams, query.OrgID)
 		}
 
 		var rawSQL = `SELECT
@@ -324,19 +376,23 @@ func (ss *sqlStore) GetSignedInUser(ctx context.Context, query *user.GetSignedIn
 		org_user.role         as org_role,
 		org.id                as org_id,
 		u.is_service_account  as is_service_account
-		FROM ` + ss.dialect.Quote("user") + ` as u
-		LEFT OUTER JOIN org_user on org_user.org_id = ` + orgId + ` and org_user.user_id = u.id
-		LEFT OUTER JOIN org on org.id = org_user.org_id `
+		FROM ` + dbHelper.DB.Quote(dbHelper.Table("user")) + ` AS u
+		LEFT OUTER JOIN ` + dbHelper.DB.Quote(dbHelper.Table("org_user")) + ` AS org_user ON org_user.org_id = ` + orgID + ` AND org_user.user_id = u.id
+		LEFT OUTER JOIN ` + dbHelper.DB.Quote(dbHelper.Table("org")) + ` AS org ON org.id = org_user.org_id `
 
-		sess := dbSess.Table("user")
+		sess := dbSess.Table(dbHelper.Table("user"))
 		sess = sess.Context(ctx)
+		params := append([]any{}, orgIDParams...)
 		switch {
 		case query.UserID > 0:
-			sess.SQL(rawSQL+"WHERE u.id=?", query.UserID)
+			params = append(params, query.UserID)
+			sess.SQL(rawSQL+"WHERE u.id=?", params...)
 		case query.Login != "":
-			sess.SQL(rawSQL+"WHERE LOWER(u.login)=LOWER(?)", query.Login)
+			params = append(params, query.Login)
+			sess.SQL(rawSQL+"WHERE LOWER(u.login)=LOWER(?)", params...)
 		case query.Email != "":
-			sess.SQL(rawSQL+"WHERE LOWER(u.email)=LOWER(?)", query.Email)
+			params = append(params, query.Email)
+			sess.SQL(rawSQL+"WHERE LOWER(u.email)=LOWER(?)", params...)
 		default:
 			return user.ErrNoUniqueID
 		}
@@ -360,8 +416,13 @@ func (ss *sqlStore) GetSignedInUser(ctx context.Context, query *user.GetSignedIn
 func (ss *sqlStore) GetProfile(ctx context.Context, query *user.GetUserProfileQuery) (*user.UserProfileDTO, error) {
 	var usr user.User
 	var userProfile user.UserProfileDTO
-	err := ss.db.WithDbSession(ctx, func(sess *db.Session) error {
-		has, err := sess.ID(query.UserID).Where(ss.notServiceAccountFilter()).Get(&usr)
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
+		has, err := sess.Table(dbHelper.Table("user")).ID(query.UserID).Where(ss.notServiceAccountFilter(dbHelper)).Get(&usr)
 
 		if err != nil {
 			return err
@@ -395,8 +456,13 @@ func (ss *sqlStore) Count(ctx context.Context) (int64, error) {
 	}
 
 	r := result{}
-	err := ss.db.WithDbSession(ctx, func(sess *db.Session) error {
-		rawSQL := fmt.Sprintf("SELECT COUNT(*) as count from %s WHERE is_service_account=%s", ss.db.GetDialect().Quote("user"), ss.db.GetDialect().BooleanStr(false))
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
+		rawSQL := fmt.Sprintf("SELECT COUNT(*) as count from %s WHERE is_service_account=%s", dbHelper.DB.Quote(dbHelper.Table("user")), dbHelper.DB.GetDialect().BooleanStr(false))
 		if _, err := sess.SQL(rawSQL).Get(&r); err != nil {
 			return err
 		}
@@ -406,22 +472,27 @@ func (ss *sqlStore) Count(ctx context.Context) (int64, error) {
 }
 
 func (ss *sqlStore) CountUserAccountsWithEmptyRole(ctx context.Context) (int64, error) {
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return -1, fmt.Errorf("get legacy DB: %w", err)
+	}
+
 	sb := &db.SQLBuilder{}
 	sb.Write(`
 		SELECT sub.user_accounts_with_no_role
 		FROM (
 		  SELECT COUNT(*) AS user_accounts_with_no_role
-		  FROM ` + ss.dialect.Quote("org_user") + ` AS ou
-		  LEFT JOIN ` + ss.dialect.Quote("user") + ` AS u ON u.id = ou.user_id
+		  FROM ` + dbHelper.DB.Quote(dbHelper.Table("org_user")) + ` AS ou
+		  LEFT JOIN ` + dbHelper.DB.Quote(dbHelper.Table("user")) + ` AS u ON u.id = ou.user_id
 		  WHERE ou.role = ?
-		  AND u.is_service_account = ` + ss.dialect.BooleanStr(false) + `
-		  AND u.is_disabled = ` + ss.dialect.BooleanStr(false) + `
+		  AND u.is_service_account = ` + dbHelper.DB.GetDialect().BooleanStr(false) + `
+		  AND u.is_disabled = ` + dbHelper.DB.GetDialect().BooleanStr(false) + `
 		) AS sub
 	`)
 	sb.AddParams("None")
 
 	var countStats int64
-	if err := ss.db.WithDbSession(ctx, func(sess *db.Session) error {
+	if err := dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
 		_, err := sess.SQL(sb.GetSQLString(), sb.GetParams()...).Get(&countStats)
 		return err
 	}); err != nil {
@@ -432,8 +503,8 @@ func (ss *sqlStore) CountUserAccountsWithEmptyRole(ctx context.Context) (int64, 
 }
 
 // validateOneAdminLeft validate that there is an admin user left
-func validateOneAdminLeft(sess *db.Session) error {
-	count, err := sess.Where("is_admin=?", true).Count(&user.User{})
+func validateOneAdminLeft(dbHelper *legacysql.LegacyDatabaseHelper, sess *db.Session) error {
+	count, err := sess.Table(dbHelper.Table("user")).Where("is_admin=?", true).Count(&user.User{})
 	if err != nil {
 		return err
 	}
@@ -446,7 +517,12 @@ func validateOneAdminLeft(sess *db.Session) error {
 }
 
 func (ss *sqlStore) BatchDisableUsers(ctx context.Context, cmd *user.BatchDisableUsersCommand) error {
-	return ss.db.WithDbSession(ctx, func(sess *db.Session) error {
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	return dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
 		userIds := cmd.UserIDs
 
 		if len(userIds) == 0 {
@@ -454,14 +530,14 @@ func (ss *sqlStore) BatchDisableUsers(ctx context.Context, cmd *user.BatchDisabl
 		}
 
 		user_id_params := strings.Repeat(",?", len(userIds)-1)
-		disableSQL := "UPDATE " + ss.dialect.Quote("user") + " SET is_disabled=? WHERE Id IN (?" + user_id_params + ")"
+		disableSQL := "UPDATE " + dbHelper.DB.Quote(dbHelper.Table("user")) + " SET is_disabled=? WHERE Id IN (?" + user_id_params + ")"
 
 		disableParams := []any{disableSQL, cmd.IsDisabled}
 		for _, v := range userIds {
 			disableParams = append(disableParams, v)
 		}
 
-		_, err := sess.Where(ss.notServiceAccountFilter()).Exec(disableParams...)
+		_, err := sess.Where(ss.notServiceAccountFilter(dbHelper)).Exec(disableParams...)
 		return err
 	})
 }
@@ -470,21 +546,29 @@ func (ss *sqlStore) Search(ctx context.Context, query *user.SearchUsersQuery) (*
 	result := user.SearchUserQueryResult{
 		Users: make([]*user.UserSearchHitDTO, 0),
 	}
-	err := ss.db.WithDbSession(ctx, func(dbSess *db.Session) error {
+	dbHelper, err := ss.sql(ctx)
+	if err != nil {
+		return &result, fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	err = dbHelper.DB.WithDbSession(ctx, func(dbSess *db.Session) error {
 		whereConditions := make([]string, 0)
 		whereParams := make([]any, 0)
-		sess := dbSess.Table("user").Alias("u")
+		userTable := dbHelper.Table("user")
+		userAuthTable := dbHelper.Table("user_auth")
+		quotedUserAuthTable := dbHelper.DB.Quote(userAuthTable)
+		sess := dbSess.Table(userTable).Alias("u")
 
 		whereConditions = append(whereConditions, "u.is_service_account = ?")
-		whereParams = append(whereParams, ss.dialect.BooleanValue(false))
+		whereParams = append(whereParams, dbHelper.DB.GetDialect().BooleanValue(false))
 
 		// Join with only most recent auth module
 		joinCondition := `(
-		SELECT id from user_auth
+		SELECT id from ` + quotedUserAuthTable + ` AS user_auth
 			WHERE user_auth.user_id = u.id
 			ORDER BY user_auth.created DESC `
-		joinCondition = "user_auth.id=" + joinCondition + ss.dialect.Limit(1) + ")"
-		sess.Join("LEFT", "user_auth", joinCondition)
+		joinCondition = "user_auth.id=" + joinCondition + dbHelper.DB.GetDialect().Limit(1) + ")"
+		sess.Join("LEFT", []string{userAuthTable, "user_auth"}, joinCondition)
 		if query.OrgID > 0 {
 			whereConditions = append(whereConditions, "org_id = ?")
 			whereParams = append(whereParams, query.OrgID)
@@ -499,9 +583,9 @@ func (ss *sqlStore) Search(ctx context.Context, query *user.SearchUsersQuery) (*
 		whereParams = append(whereParams, acFilter.Args...)
 
 		if query.Query != "" {
-			emailSql, emailArg := ss.dialect.LikeOperator("email", true, query.Query, true)
-			nameSql, nameArg := ss.dialect.LikeOperator("name", true, query.Query, true)
-			loginSql, loginArg := ss.dialect.LikeOperator("login", true, query.Query, true)
+			emailSql, emailArg := dbHelper.DB.GetDialect().LikeOperator("email", true, query.Query, true)
+			nameSql, nameArg := dbHelper.DB.GetDialect().LikeOperator("name", true, query.Query, true)
+			loginSql, loginArg := dbHelper.DB.GetDialect().LikeOperator("login", true, query.Query, true)
 			whereConditions = append(whereConditions, fmt.Sprintf("(%s OR %s OR %s)", emailSql, nameSql, loginSql))
 			whereParams = append(whereParams, emailArg, nameArg, loginArg)
 		}
@@ -522,7 +606,7 @@ func (ss *sqlStore) Search(ctx context.Context, query *user.SearchUsersQuery) (*
 
 		for _, filter := range query.Filters {
 			if jc := filter.JoinCondition(); jc != nil {
-				sess.Join(jc.Operator, jc.Table, jc.Params)
+				sess.Join(jc.Operator, []string{dbHelper.Table(jc.Table), jc.Table}, jc.Params)
 			}
 			if ic := filter.InCondition(); ic != nil {
 				sess.In(ic.Condition, ic.Params)
@@ -555,11 +639,11 @@ func (ss *sqlStore) Search(ctx context.Context, query *user.SearchUsersQuery) (*
 
 		// get total
 		user := user.User{}
-		countSess := dbSess.Table("user").Alias("u")
+		countSess := dbSess.Table(userTable).Alias("u")
 
 		// Join with user_auth table if users filtered by auth_module
 		if query.AuthModule != "" {
-			countSess.Join("LEFT", "user_auth", joinCondition)
+			countSess.Join("LEFT", []string{userAuthTable, "user_auth"}, joinCondition)
 		}
 
 		if len(whereConditions) > 0 {
@@ -568,7 +652,7 @@ func (ss *sqlStore) Search(ctx context.Context, query *user.SearchUsersQuery) (*
 
 		for _, filter := range query.Filters {
 			if jc := filter.JoinCondition(); jc != nil {
-				countSess.Join(jc.Operator, jc.Table, jc.Params)
+				countSess.Join(jc.Operator, []string{dbHelper.Table(jc.Table), jc.Table}, jc.Params)
 			}
 			if ic := filter.InCondition(); ic != nil {
 				countSess.In(ic.Condition, ic.Params)

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -561,7 +561,7 @@ func (ss *sqlStore) Search(ctx context.Context, query *user.SearchUsersQuery) (*
 		whereParams := make([]any, 0)
 		userTable := dbHelper.Table("user")
 		userAuthTable := dbHelper.Table("user_auth")
-		quotedUserAuthTable := dbHelper.DB.Quote(userAuthTable)
+		quotedUserAuthTable := quoteTable(dbHelper, "user_auth")
 		sess := dbSess.Table(userTable).Alias("u")
 
 		whereConditions = append(whereConditions, "u.is_service_account = ?")

--- a/pkg/services/user/userimpl/store_provider_test.go
+++ b/pkg/services/user/userimpl/store_provider_test.go
@@ -105,6 +105,13 @@ func TestStoreUsesProviderTables(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	require.NoError(t, store.Delete(ctx, 7))
 
+	mock.ExpectExec(`(?s)UPDATE .*test_schema.*user.*SET is_disabled=\?.*WHERE Id IN \(\?,\?\).*is_service_account`).
+		WithArgs(true, int64(7), int64(11)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	require.NoError(t, store.BatchDisableUsers(ctx, &user.BatchDisableUsersCommand{
+		UserIDs: []int64{7, 11}, IsDisabled: true,
+	}))
+
 	mock.ExpectQuery(`(?s).*FROM .*test_schema.*user.*LEFT OUTER JOIN .*test_schema.*org_user.*LEFT OUTER JOIN .*test_schema.*org.*WHERE u.id=\?`).
 		WithArgs(int64(42), int64(7)).
 		WillReturnRows(sqlmock.NewRows([]string{"user_id"}).AddRow(int64(7)))
@@ -112,7 +119,7 @@ func TestStoreUsesProviderTables(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(7), signedInUser.UserID)
 
-	require.Equal(t, 4, providerCalls)
+	require.Equal(t, 5, providerCalls)
 	require.Contains(t, resolvedTables, "user")
 	require.Contains(t, resolvedTables, "org_user")
 	require.Contains(t, resolvedTables, "org")

--- a/pkg/services/user/userimpl/store_provider_test.go
+++ b/pkg/services/user/userimpl/store_provider_test.go
@@ -1,0 +1,120 @@
+package userimpl
+
+import (
+	"context"
+	"regexp"
+	"sync"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/db/dbtest"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
+	"github.com/grafana/grafana/pkg/util/xorm"
+	"github.com/grafana/grafana/pkg/util/xorm/core"
+)
+
+var registerUserSQLMockXormDriverOnce sync.Once
+
+type userSQLMockXormDriver struct{}
+
+func (userSQLMockXormDriver) Parse(string, string) (*core.Uri, error) {
+	return &core.Uri{DbType: core.SQLITE}, nil
+}
+
+type sqlmockUserDB struct {
+	dbtest.FakeDB
+	engine *xorm.Engine
+}
+
+func (d *sqlmockUserDB) WithDbSession(_ context.Context, callback sqlstore.DBTransactionFunc) error {
+	sess := &sqlstore.DBSession{Session: d.engine.NewSession()}
+	defer sess.Close()
+	return callback(sess)
+}
+
+func (d *sqlmockUserDB) WithTransactionalDbSession(ctx context.Context, callback sqlstore.DBTransactionFunc) error {
+	return d.WithDbSession(ctx, callback)
+}
+
+func (d *sqlmockUserDB) GetDBType() core.DbType {
+	return core.SQLITE
+}
+
+func (d *sqlmockUserDB) GetDialect() migrator.Dialect {
+	return migrator.NewSQLite3Dialect()
+}
+
+func (d *sqlmockUserDB) Quote(value string) string {
+	return d.engine.Quote(value)
+}
+
+func TestStoreUsesProviderTables(t *testing.T) {
+	registerUserSQLMockXormDriverOnce.Do(func() {
+		if core.QueryDriver("sqlmock") == nil {
+			core.RegisterDriver("sqlmock", userSQLMockXormDriver{})
+		}
+	})
+
+	dsn := "userimpl-store"
+	mockDB, mock, err := sqlmock.NewWithDSN(dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mockDB.Close() })
+
+	engine, err := xorm.NewEngine("sqlmock", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = engine.Close() })
+
+	legacyDB := &sqlmockUserDB{engine: engine}
+	type contextKey struct{}
+	ctx := context.WithValue(context.Background(), contextKey{}, "provider context")
+	providerCalls := 0
+	resolvedTables := make([]string, 0)
+	provider := func(gotCtx context.Context) (*legacysql.LegacyDatabaseHelper, error) {
+		require.Equal(t, "provider context", gotCtx.Value(contextKey{}))
+		providerCalls++
+		return &legacysql.LegacyDatabaseHelper{
+			DB: legacyDB,
+			Table: func(name string) string {
+				resolvedTables = append(resolvedTables, name)
+				return "test_schema." + name
+			},
+		}, nil
+	}
+	store := ProvideStore(provider, nil)
+
+	mock.ExpectQuery(`(?s).*FROM .*test_schema.*user.*uid = \?`).
+		WithArgs("user-uid").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "uid"}).AddRow(int64(7), "user-uid"))
+	got, err := store.GetByUID(ctx, "user-uid")
+	require.NoError(t, err)
+	require.Equal(t, int64(7), got.ID)
+
+	mock.ExpectExec(`(?s)INSERT INTO .*test_schema.*user.*`).
+		WillReturnResult(sqlmock.NewResult(11, 1))
+	insertedID, err := store.Insert(ctx, &user.User{Email: "inserted@example.com", Login: "inserted"})
+	require.NoError(t, err)
+	require.Equal(t, int64(11), insertedID)
+
+	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM `test_schema`.`user` WHERE id = ?")).
+		WithArgs(int64(7)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	require.NoError(t, store.Delete(ctx, 7))
+
+	mock.ExpectQuery(`(?s).*FROM .*test_schema.*user.*LEFT OUTER JOIN .*test_schema.*org_user.*LEFT OUTER JOIN .*test_schema.*org.*WHERE u.id=\?`).
+		WithArgs(int64(42), int64(7)).
+		WillReturnRows(sqlmock.NewRows([]string{"user_id"}).AddRow(int64(7)))
+	signedInUser, err := store.GetSignedInUser(ctx, &user.GetSignedInUserQuery{UserID: 7, OrgID: 42})
+	require.NoError(t, err)
+	require.Equal(t, int64(7), signedInUser.UserID)
+
+	require.Equal(t, 4, providerCalls)
+	require.Contains(t, resolvedTables, "user")
+	require.Contains(t, resolvedTables, "org_user")
+	require.Contains(t, resolvedTables, "org")
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/pkg/services/user/userimpl/store_test.go
+++ b/pkg/services/user/userimpl/store_test.go
@@ -1084,7 +1084,7 @@ func TestIntegrationBatchDisableUsersExcludesServiceAccounts(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	ctx := context.Background()
-	ss := db.InitTestDB(t)
+	ss := sqlstore.NewTestStore(t)
 	store := ProvideStore(legacysql.NewDatabaseProvider(ss), setting.NewCfg())
 	now := time.Now()
 

--- a/pkg/services/user/userimpl/store_test.go
+++ b/pkg/services/user/userimpl/store_test.go
@@ -1080,6 +1080,46 @@ func createFiveTestUsers(t *testing.T, svc user.Service, fn func(i int) *user.Cr
 	return users
 }
 
+func TestIntegrationBatchDisableUsersExcludesServiceAccounts(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	ctx := context.Background()
+	ss := db.InitTestDB(t)
+	store := ProvideStore(legacysql.NewDatabaseProvider(ss), setting.NewCfg())
+	now := time.Now()
+
+	regularID, err := store.Insert(ctx, &user.User{
+		UID: "batch-disable-user", Email: "batch-disable-user@example.com", Login: "batch-disable-user",
+		Created: now, Updated: now,
+	})
+	require.NoError(t, err)
+	serviceAccountID, err := store.Insert(ctx, &user.User{
+		UID: "batch-disable-service-account", Email: "batch-disable-service-account@example.com", Login: "batch-disable-service-account",
+		IsServiceAccount: true, Created: now, Updated: now,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, store.BatchDisableUsers(ctx, &user.BatchDisableUsersCommand{
+		UserIDs: []int64{regularID, serviceAccountID}, IsDisabled: true,
+	}))
+
+	type disabledUser struct {
+		ID         int64 `xorm:"id"`
+		IsDisabled bool  `xorm:"is_disabled"`
+	}
+	rows := make([]disabledUser, 0, 2)
+	require.NoError(t, ss.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
+		return sess.Table("user").In("id", []int64{regularID, serviceAccountID}).Cols("id", "is_disabled").Find(&rows)
+	}))
+
+	gotDisabled := make(map[int64]bool, len(rows))
+	for _, row := range rows {
+		gotDisabled[row.ID] = row.IsDisabled
+	}
+	require.True(t, gotDisabled[regularID])
+	require.False(t, gotDisabled[serviceAccountID])
+}
+
 func TestIntegrationMetricsUsage(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 

--- a/pkg/services/user/userimpl/store_test.go
+++ b/pkg/services/user/userimpl/store_test.go
@@ -43,9 +43,9 @@ func TestIntegrationUserDataAccess(t *testing.T) {
 	quotaService := quotaimpl.ProvideService(context.Background(), legacysql.NewDatabaseProvider(ss), cfgProvider)
 	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(ss), cfg, quotaService)
 	require.NoError(t, err)
-	userStore := ProvideStore(ss, setting.NewCfg())
+	userStore := ProvideStore(legacysql.NewDatabaseProvider(ss), setting.NewCfg())
 	usrSvc, err := ProvideService(
-		ss, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
+		legacysql.NewDatabaseProvider(ss), orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
 		quotaService, supportbundlestest.NewFakeBundleService(), nil,
 	)
 	require.NoError(t, err)
@@ -459,7 +459,7 @@ func TestIntegrationUserDataAccess(t *testing.T) {
 	t.Run("Testing DB - return list users based on their is_disabled flag", func(t *testing.T) {
 		ss = db.InitTestDB(t) //nolint:staticcheck // legacy shared-DB test setup; migrate to NewTestStore
 		_, usrSvc := createOrgAndUserSvc(t, ss, cfg)
-		userStore := ProvideStore(ss, cfg)
+		userStore := ProvideStore(legacysql.NewDatabaseProvider(ss), cfg)
 
 		createFiveTestUsers(t, usrSvc, func(i int) *user.CreateUserCommand {
 			return &user.CreateUserCommand{
@@ -561,7 +561,7 @@ func TestIntegrationUserDataAccess(t *testing.T) {
 		orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(ss), cfg, quotaService)
 		require.NoError(t, err)
 		usrSvc, err := ProvideService(
-			ss, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
+			legacysql.NewDatabaseProvider(ss), orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
 			quotaService, supportbundlestest.NewFakeBundleService(), nil,
 		)
 		require.NoError(t, err)
@@ -977,7 +977,7 @@ func TestIntegrationUserUpdate(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	ss, cfg := db.InitTestDBWithCfg(t) //nolint:staticcheck // legacy shared-DB test setup; migrate to NewTestStore
-	userStore := ProvideStore(ss, cfg)
+	userStore := ProvideStore(legacysql.NewDatabaseProvider(ss), cfg)
 	_, usrSvc := createOrgAndUserSvc(t, ss, cfg)
 
 	users := createFiveTestUsers(t, usrSvc, func(i int) *user.CreateUserCommand {
@@ -1084,7 +1084,7 @@ func TestIntegrationMetricsUsage(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	ss, cfg := db.InitTestDBWithCfg(t) //nolint:staticcheck // legacy shared-DB test setup; migrate to NewTestStore
-	userStore := ProvideStore(ss, setting.NewCfg())
+	userStore := ProvideStore(legacysql.NewDatabaseProvider(ss), setting.NewCfg())
 	cfgProvider, err := configprovider.ProvideService(cfg)
 	require.NoError(t, err)
 	quotaService := quotaimpl.ProvideService(context.Background(), legacysql.NewDatabaseProvider(ss), cfgProvider)
@@ -1140,7 +1140,7 @@ func createOrgAndUserSvc(t *testing.T, store db.DB, cfg *setting.Cfg) (org.Servi
 	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(store), cfg, quotaService)
 	require.NoError(t, err)
 	usrSvc, err := ProvideService(
-		store, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
+		legacysql.NewDatabaseProvider(store), orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
 		quotaService, supportbundlestest.NewFakeBundleService(), nil,
 	)
 	require.NoError(t, err)

--- a/pkg/services/user/userimpl/user.go
+++ b/pkg/services/user/userimpl/user.go
@@ -11,7 +11,6 @@ import (
 
 	claims "github.com/grafana/authlib/types"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
-	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/localcache"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
@@ -25,6 +24,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/userk8s"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
 )
 
 type Service struct {
@@ -38,14 +38,14 @@ type Service struct {
 
 var _ user.Service = (*Service)(nil)
 
-func ProvideService(db db.DB,
+func ProvideService(sql legacysql.LegacyDatabaseProvider,
 	orgService org.Service,
 	cfg *setting.Cfg,
 	teamService team.Service,
 	cacheService *localcache.CacheService, tracer tracing.Tracer,
 	quotaService quota.Service, bundleRegistry supportbundles.Service,
 	configProvider apiserver.DirectRestConfigProvider) (*Service, error) {
-	legacyService, err := NewLegacyService(db, orgService, cfg, teamService, cacheService, tracer, quotaService, bundleRegistry)
+	legacyService, err := NewLegacyService(sql, orgService, cfg, teamService, cacheService, tracer, quotaService, bundleRegistry)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/user/userimpl/user_test.go
+++ b/pkg/services/user/userimpl/user_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/usertest"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
 
@@ -39,7 +40,7 @@ func TestUserService(t *testing.T) {
 		cacheService: localcache.ProvideService(),
 		teamService:  &teamtest.FakeService{},
 		tracer:       tracing.InitializeTracerForTest(),
-		db:           db.InitTestDB(t), //nolint:staticcheck // legacy shared-DB test setup; migrate to NewTestStore
+		sql:          legacysql.NewDatabaseProvider(db.InitTestDB(t)), //nolint:staticcheck // legacy shared-DB test setup; migrate to NewTestStore
 	}
 	userService.cfg = setting.NewCfg()
 
@@ -572,10 +573,9 @@ func TestIntegrationCreateUser(t *testing.T) {
 	cfg := setting.NewCfg()
 	ss := db.InitTestDB(t) //nolint:staticcheck // legacy shared-DB test setup; migrate to NewTestStore
 	userStore := &sqlStore{
-		db:      ss,
-		dialect: ss.GetDialect(),
-		logger:  log.NewNopLogger(),
-		cfg:     cfg,
+		sql:    legacysql.NewDatabaseProvider(ss),
+		logger: log.NewNopLogger(),
+		cfg:    cfg,
 	}
 
 	t.Run("SkipOrgSetup=true: InsertOrgUser is not called, DefaultOrgRole is ignored", func(t *testing.T) {
@@ -592,7 +592,7 @@ func TestIntegrationCreateUser(t *testing.T) {
 			teamService:  &teamtest.FakeService{},
 			tracer:       tracing.InitializeTracerForTest(),
 			cfg:          setting.NewCfg(),
-			db:           ss,
+			sql:          legacysql.NewDatabaseProvider(ss),
 		}
 		_, err := userService.Create(context.Background(), &user.CreateUserCommand{
 			Email:          "skip@example.com",
@@ -622,7 +622,7 @@ func TestIntegrationCreateUser(t *testing.T) {
 			teamService:  &teamtest.FakeService{},
 			tracer:       tracing.InitializeTracerForTest(),
 			cfg:          cfg,
-			db:           ss,
+			sql:          legacysql.NewDatabaseProvider(ss),
 		}
 		_, err := userService.Create(context.Background(), &user.CreateUserCommand{
 			Email: "fallback@example.com",
@@ -644,7 +644,7 @@ func TestIntegrationCreateUser(t *testing.T) {
 			teamService:  &teamtest.FakeService{},
 			tracer:       tracing.InitializeTracerForTest(),
 			cfg:          setting.NewCfg(),
-			db:           ss,
+			sql:          legacysql.NewDatabaseProvider(ss),
 		}
 		_, err := userService.Create(context.Background(), &user.CreateUserCommand{
 			Email: "email",

--- a/pkg/services/user/userimpl/user_test.go
+++ b/pkg/services/user/userimpl/user_test.go
@@ -165,6 +165,33 @@ func TestUserService(t *testing.T) {
 	})
 }
 
+func TestCreatePropagatesLoginConflictErrors(t *testing.T) {
+	expectedErr := errors.New("database unavailable")
+	service := LegacyService{
+		store:      &FakeUserStore{ExpectedError: expectedErr},
+		orgService: orgtest.NewOrgServiceFake(),
+		cfg:        setting.NewCfg(),
+		tracer:     tracing.InitializeTracerForTest(),
+	}
+
+	_, err := service.Create(context.Background(), &user.CreateUserCommand{
+		Email: "user@example.com",
+		Login: "user",
+	})
+	require.ErrorIs(t, err, expectedErr)
+}
+
+func TestCreateServiceAccountPropagatesLoginConflictErrors(t *testing.T) {
+	expectedErr := errors.New("database unavailable")
+	service := LegacyService{
+		store:  &FakeUserStore{ExpectedError: expectedErr},
+		tracer: tracing.InitializeTracerForTest(),
+	}
+
+	_, err := service.CreateServiceAccount(context.Background(), &user.CreateUserCommand{Login: "service-account"})
+	require.ErrorIs(t, err, expectedErr)
+}
+
 func TestService_Update(t *testing.T) {
 	setup := func(opts ...func(svc *LegacyService)) *LegacyService {
 		service := &LegacyService{

--- a/pkg/tests/api/alerting/testing.go
+++ b/pkg/tests/api/alerting/testing.go
@@ -1649,7 +1649,7 @@ func createUser(t *testing.T, db db.DB, cfg *setting.Cfg, cmd user.CreateUserCom
 	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(db), cfg, quotaService)
 	require.NoError(t, err)
 	usrSvc, err := userimpl.ProvideService(
-		db, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
+		legacysql.NewDatabaseProvider(db), orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
 		quotaService, supportbundlestest.NewFakeBundleService(), nil,
 	)
 	require.NoError(t, err)

--- a/pkg/tests/api/correlations/common_test.go
+++ b/pkg/tests/api/correlations/common_test.go
@@ -168,7 +168,7 @@ func (c TestContext) createUser(cmd user.CreateUserCommand) User {
 	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(store), c.env.Cfg, quotaService)
 	require.NoError(c.t, err)
 	usrSvc, err := userimpl.ProvideService(
-		store, orgService, c.env.Cfg, nil, nil, tracing.InitializeTracerForTest(),
+		legacysql.NewDatabaseProvider(store), orgService, c.env.Cfg, nil, nil, tracing.InitializeTracerForTest(),
 		quotaService, supportbundlestest.NewFakeBundleService(), nil,
 	)
 	require.NoError(c.t, err)

--- a/pkg/tests/api/plugins/api_plugins_test.go
+++ b/pkg/tests/api/plugins/api_plugins_test.go
@@ -204,7 +204,7 @@ func createUser(t *testing.T, db db.DB, cfg *setting.Cfg, cmd user.CreateUserCom
 	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(db), cfg, quotaService)
 	require.NoError(t, err)
 	usrSvc, err := userimpl.ProvideService(
-		db, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
+		legacysql.NewDatabaseProvider(db), orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
 		quotaService, supportbundlestest.NewFakeBundleService(), nil,
 	)
 	require.NoError(t, err)

--- a/pkg/tests/api/shorturl/short_url_test.go
+++ b/pkg/tests/api/shorturl/short_url_test.go
@@ -118,7 +118,7 @@ func createUser(t *testing.T, db db.DB, cfg *setting.Cfg, cmd user.CreateUserCom
 	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(db), cfg, quotaService)
 	require.NoError(t, err)
 	usrSvc, err := userimpl.ProvideService(
-		db, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
+		legacysql.NewDatabaseProvider(db), orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
 		quotaService, supportbundlestest.NewFakeBundleService(), nil,
 	)
 	require.NoError(t, err)

--- a/pkg/tests/api/stats/admin_test.go
+++ b/pkg/tests/api/stats/admin_test.go
@@ -98,7 +98,7 @@ func createUser(t *testing.T, db db.DB, cfg *setting.Cfg, cmd user.CreateUserCom
 	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(db), cfg, quotaService)
 	require.NoError(t, err)
 	usrSvc, err := userimpl.ProvideService(
-		db, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
+		legacysql.NewDatabaseProvider(db), orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
 		quotaService, supportbundlestest.NewFakeBundleService(), nil,
 	)
 	require.NoError(t, err)

--- a/pkg/tests/apis/helper.go
+++ b/pkg/tests/apis/helper.go
@@ -207,7 +207,7 @@ func buildK8sTestHelper(t *testing.T, opts K8sTestHelperOpts, listenerAddress st
 	c.teamSvc = teamSvc
 
 	userSvc, err := userimpl.NewLegacyService(
-		c.env.SQLStore, orgSvc, c.env.Cfg, teamSvc,
+		legacysql.NewDatabaseProvider(c.env.SQLStore), orgSvc, c.env.Cfg, teamSvc,
 		localcache.ProvideService(), tracing.NewNoopTracerService(), quotaService,
 		supportbundlestest.NewFakeBundleService())
 	require.NoError(c.t, err)

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -1241,7 +1241,7 @@ func CreateUser(t *testing.T, store db.DB, cfg *setting.Cfg, cmd user.CreateUser
 	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(store), cfg, quotaService)
 	require.NoError(t, err)
 	usrSvc, err := userimpl.ProvideService(
-		store, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(), quotaService, supportbundlestest.NewFakeBundleService(), nil,
+		legacysql.NewDatabaseProvider(store), orgService, cfg, nil, nil, tracing.InitializeTracerForTest(), quotaService, supportbundlestest.NewFakeBundleService(), nil,
 	)
 	require.NoError(t, err)
 

--- a/pkg/tests/utils.go
+++ b/pkg/tests/utils.go
@@ -37,7 +37,7 @@ func CreateUser(t *testing.T, db db.DB, cfg *setting.Cfg, cmd user.CreateUserCom
 	orgService, err := orgimpl.ProvideService(legacysql.NewDatabaseProvider(db), cfg, quotaService)
 	require.NoError(t, err)
 	usrSvc, err := userimpl.ProvideService(
-		db, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
+		legacysql.NewDatabaseProvider(db), orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
 		quotaService, supportbundlestest.NewFakeBundleService(), nil,
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
## What changed

- `userimpl` now accepts `LegacyDatabaseProvider` instead of `db.DB`.
- Each user operation gets a database helper from its request context.
- User queries resolve `user`, `user_auth`, `org_user`, and `org` through that helper.
- Server wiring and tests wrap fixed databases with `legacysql.NewDatabaseProvider`.
- `LoginConflict` now returns provider and database errors instead of reporting that the user already exists.
- `BatchDisableUsers` now excludes service accounts in the raw `UPDATE` query.

## Why

During cookie-session authentication, the Enterprise authn service reads the user from the database. These queries must use the tables for the current request namespace.

This PR prepares the user store for that wiring. It keeps the existing XORM and raw SQL query styles; SQL template changes are separate work.

## Related

Enterprise wiring: https://github.com/grafana/grafana-enterprise/pull/13072
