### PR TITLE
Plugins: report render errors to Faro from PluginErrorBoundary

### DIFF
--- a/public/app/features/plugins/components/PluginErrorBoundary.test.tsx
+++ b/public/app/features/plugins/components/PluginErrorBoundary.test.tsx
@@ -3,8 +3,17 @@ import * as React from 'react';
 
 import { type PluginMeta, PluginType, PluginContext } from '@grafana/data';
 import { getMockPlugin } from '@grafana/data/test';
+import { faro } from '@grafana/faro-web-sdk';
 
 import { PluginErrorBoundary } from './PluginErrorBoundary';
+
+jest.mock('@grafana/faro-web-sdk', () => ({
+  faro: {
+    api: {
+      pushError: jest.fn(),
+    },
+  },
+}));
 
 const ThrowingComponent = ({ shouldThrow }: { shouldThrow: boolean }) => {
   if (shouldThrow) {
@@ -52,6 +61,7 @@ describe('PluginErrorBoundary', () => {
 
   afterEach(() => {
     consoleErrorSpy.mockRestore();
+    jest.mocked(faro.api.pushError).mockClear();
   });
 
   it('should render children normally when no error occurs', () => {
@@ -102,7 +112,43 @@ describe('PluginErrorBoundary', () => {
     );
   });
 
-  it('should handle error when plugin context is not available', () => {
+  it('should report the error to Faro with the plugin id as the boundary source', () => {
+    const mockPluginMeta = getMockPlugin({ id: 'my-test-plugin', type: PluginType.datasource });
+
+    renderWithPluginContext({ children: <ThrowingComponent shouldThrow={true} />, pluginMeta: mockPluginMeta });
+
+    expect(faro.api.pushError).toHaveBeenCalledTimes(1);
+    expect(faro.api.pushError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Test error message' }),
+      {
+        context: expect.objectContaining({
+          type: 'boundary',
+          source: 'my-test-plugin',
+          componentStack: expect.any(String),
+        }),
+      }
+    );
+  });
+
+  it('should still report to Faro when an onError callback is provided', () => {
+    const onErrorMock = jest.fn();
+
+    renderWithPluginContext({ children: <ThrowingComponent shouldThrow={true} />, onError: onErrorMock });
+
+    expect(onErrorMock).toHaveBeenCalledTimes(1);
+    expect(faro.api.pushError).toHaveBeenCalledTimes(1);
+    expect(faro.api.pushError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Test error message' }),
+      {
+        context: expect.objectContaining({
+          type: 'boundary',
+          source: 'test-plugin',
+        }),
+      }
+    );
+  });
+
+  it('should report to Faro with source unknown when plugin context is not available', () => {
     render(
       <PluginErrorBoundary>
         <ThrowingComponent shouldThrow={true} />
@@ -115,6 +161,15 @@ describe('PluginErrorBoundary', () => {
       expect.objectContaining({
         componentStack: expect.any(String),
       })
+    );
+    expect(faro.api.pushError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Test error message' }),
+      {
+        context: expect.objectContaining({
+          type: 'boundary',
+          source: 'unknown',
+        }),
+      }
     );
   });
 

--- a/public/app/features/plugins/components/PluginErrorBoundary.tsx
+++ b/public/app/features/plugins/components/PluginErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { PluginContext } from '@grafana/data';
+import { faro } from '@grafana/faro-web-sdk';
 
 interface PluginErrorBoundaryProps {
   children: React.ReactNode;
@@ -29,6 +30,17 @@ export class PluginErrorBoundary extends React.Component<PluginErrorBoundaryProp
   }
 
   componentDidCatch(error: Error, info: React.ErrorInfo) {
+    // Mirror @grafana/ui ErrorBoundary: React render errors never reach
+    // window.onerror (the boundary swallows them), so they have to be pushed
+    // to Faro explicitly. Plugin id is the boundaryName equivalent.
+    faro?.api?.pushError(error, {
+      context: {
+        type: 'boundary',
+        source: this.context?.meta.id ?? 'unknown',
+        ...(info.componentStack ? { componentStack: info.componentStack } : {}),
+      },
+    });
+
     if (this.props.onError) {
       this.props.onError(error, info);
     } else {


### PR DESCRIPTION
**What is this feature?**

`PluginErrorBoundary` now reports caught render errors to Faro, matching `@grafana/ui`'s `ErrorBoundary`. The plugin id is the `boundaryName` equivalent (`context.source`), and the React `componentStack` is included on the event.

**Why do we need this feature?**

React render errors never reach `window.onerror` / `ErrorsInstrumentation` — the boundary swallows them, so they have to be pushed explicitly. Today `PluginErrorBoundary` only `console.error`s (or calls a custom `onError`). Core's own `ErrorBoundary` already calls `faro.api.pushError`. That gap means no plugin's render errors become structured Faro events in Grafana's frontend-o11y app, which is why plugins like grafana-collector-app keep a second Faro instance just for `FaroErrorBoundary`.

If this lands, those plugins can delete their own instance and filter core's app by `page_id`. Every other plugin gets structured render errors for free.

**Who is this feature for?**

Plugin authors and anyone looking at Grafana's own frontend observability. No user-facing UI change.

**Which issue(s) does this PR fix?**:

N/A — came out of the Fleet Management / Instrumentation Hub Faro dogfooding thread with frontend-o11y.

Companion (does not block this): https://github.com/grafana/grafana-collector-app/pull/1915

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

Draft for shopping around with @grafana/grafana-frontend-platform and frontend-o11y.

Behaviour:
- Always `faro?.api?.pushError` (no-op if Grafana's JS agent is off), same optional chaining as `ErrorBoundary`.
- Then the existing `onError` callback **or** `console.error` — `onError` callers such as `ExtensionErrorBoundary` still get their log, and Faro still gets the event.
- Tests pin the plugin id as `source`, `componentStack` on the payload, Faro still firing when `onError` is passed, and `source: 'unknown'` when `PluginContext` is missing.

Not in this PR: deleting any plugin's Faro instance. That's a follow-up in each plugin after this ships.