### PR TITLE
Alerting: Read staged config origin from the managed_by field

### DIFF
--- a/public/app/features/alerting/unified/settings/import/ImportSettingsPage.test.tsx
+++ b/public/app/features/alerting/unified/settings/import/ImportSettingsPage.test.tsx
@@ -1,5 +1,5 @@
 import { HttpResponse, http } from 'msw';
-import { act, render, testWithFeatureToggles, waitFor } from 'test/test-utils';
+import { render, testWithFeatureToggles } from 'test/test-utils';
 import { byRole, byText } from 'testing-library-selector';
 
 import { type AlertManagerCortexConfig } from 'app/plugins/datasource/alertmanager/types';
@@ -10,7 +10,6 @@ import { convertToGMAApi } from '../../api/convertToGMAApi';
 import { setupGrafanaManagedServer } from '../../components/settings/mocks/server';
 import { setupMswServer } from '../../mockApi';
 import { grantUserPermissions, grantUserRole } from '../../mocks';
-import { setupAutoSyncConfig } from '../../mocks/server/handlers/k8s/config.k8s';
 import { setupDataSources } from '../../testSetup/datasources';
 
 import ImportSettingsPage from './ImportSettingsPage';
@@ -25,7 +24,6 @@ const server = setupMswServer();
 
 const AM_CONFIG_URL = '/api/alertmanager/:name/config/api/v1/alerts';
 const CONVERT_URL = '/api/convert/api/v1/alerts';
-const CONFIG_SINGLETON_URL = '/apis/notifications.alerting.grafana.app/v0alpha1/namespaces/:namespace/configs/:name';
 
 const stagedAlertmanagerConfig = 'route:\n  receiver: default\nreceivers:\n  - name: default\n';
 
@@ -33,15 +31,26 @@ const stagedConfig: StagedExtraConfig = {
   identifier: 'prometheus-prod',
   alertmanager_config: stagedAlertmanagerConfig,
   template_files: {},
+  managed_by: 'manual',
 };
 
 const SYNC_DATASOURCE_UID = 'mimir-ds-uid';
 
 /** A staged config the syncer owns: the backend keys its own extra_config by the datasource UID. */
-const syncOwnedConfig: StagedExtraConfig = { ...stagedConfig, identifier: SYNC_DATASOURCE_UID };
+const syncOwnedConfig: StagedExtraConfig = {
+  ...stagedConfig,
+  identifier: SYNC_DATASOURCE_UID,
+  managed_by: 'auto-sync',
+};
+
+/** A staged config from a backend that predates the managed_by field. */
+const legacyStagedConfig: StagedExtraConfig = {
+  identifier: stagedConfig.identifier,
+  alertmanager_config: stagedConfig.alertmanager_config,
+  template_files: stagedConfig.template_files,
+};
 
 const ui = {
-  loading: byText(/loading imported configurations/i),
   autoSyncCard: byRole('region', { name: /auto-sync configuration/i }),
   emptyState: byText(/no configuration imported yet/i),
   importCta: byRole('link', { name: /import alertmanager configuration/i }),
@@ -135,17 +144,8 @@ describe('Import settings tab', () => {
     });
 
     describe('sync ownership of the staged card', () => {
-      beforeEach(() => {
-        // Ownership is read from the Config singleton, which needs the scoped config:get permission.
-        grantUserPermissions([
-          AccessControlAction.AlertingNotificationsRead,
-          AccessControlAction.ActionAlertingNotificationsConfigRead,
-        ]);
-      });
-
-      it('marks the staged card as synced when its identifier matches the synced datasource', async () => {
+      it('marks the staged card as synced when managed_by is auto-sync', async () => {
         serveStagedConfig(syncOwnedConfig);
-        setupAutoSyncConfig(server, { specUid: SYNC_DATASOURCE_UID });
 
         render(<ImportSettingsPage />);
 
@@ -154,22 +154,8 @@ describe('Import settings tab', () => {
         expect(ui.revertButton.query()).not.toBeInTheDocument();
       });
 
-      // The operator ini override (unified_alerting.external_alertmanager_uid) never reaches spec, so
-      // ownership has to be read off status or the card offers a Revert the next tick would undo.
-      it('marks the staged card as synced when an ini-configured sync owns it', async () => {
-        serveStagedConfig(syncOwnedConfig);
-        setupAutoSyncConfig(server, { statusUid: SYNC_DATASOURCE_UID, statusOrigin: 'ini' });
-
-        render(<ImportSettingsPage />);
-
-        expect(await ui.syncedConfigHeading.find()).toBeInTheDocument();
-        expect(ui.syncedBadge.get()).toBeInTheDocument();
-        expect(ui.revertButton.query()).not.toBeInTheDocument();
-      });
-
-      it('keeps revert available for a manual import while sync runs against another datasource', async () => {
+      it('keeps revert available when managed_by is manual', async () => {
         serveStagedConfig(stagedConfig);
-        setupAutoSyncConfig(server, { specUid: SYNC_DATASOURCE_UID });
 
         render(<ImportSettingsPage />);
 
@@ -177,54 +163,13 @@ describe('Import settings tab', () => {
         expect(ui.revertButton.get()).toBeInTheDocument();
       });
 
-      // Ownership resolves independently of the Alertmanager config, so the card must wait for it —
-      // otherwise an unresolved query reads as "not sync-managed" and offers a Revert that the next
-      // sync tick would immediately undo.
-      it('does not offer revert before sync ownership is known', async () => {
-        const amConfigServed = jest.fn();
-        let resolveOwnership = () => {};
-        const ownershipResolved = new Promise<void>((resolve) => {
-          resolveOwnership = resolve;
-        });
-
-        server.use(
-          http.get(AM_CONFIG_URL, () => {
-            amConfigServed();
-            return HttpResponse.json<AlertManagerCortexConfig>({
-              alertmanager_config: {},
-              template_files: {},
-              extra_config: [syncOwnedConfig],
-            });
-          }),
-          http.get(CONFIG_SINGLETON_URL, async () => {
-            await ownershipResolved;
-            return HttpResponse.json({
-              apiVersion: 'notifications.alerting.grafana.app/v0alpha1',
-              kind: 'Config',
-              metadata: { name: 'default' },
-              spec: { externalAlertmanagerSync: { datasourceUid: SYNC_DATASOURCE_UID } },
-            });
-          })
-        );
+      it('keeps revert available when managed_by is absent (pre-rollout backend)', async () => {
+        serveStagedConfig(legacyStagedConfig);
 
         render(<ImportSettingsPage />);
 
-        // Let the Alertmanager config land while ownership is still in flight — the window in which the
-        // card would otherwise render as a plain staged import.
-        await waitFor(() => expect(amConfigServed).toHaveBeenCalled());
-        await act(async () => {
-          await Promise.resolve();
-          await Promise.resolve();
-        });
-
-        expect(ui.loading.get()).toBeInTheDocument();
-        expect(ui.revertButton.query()).not.toBeInTheDocument();
-        expect(ui.syncedConfigHeading.query()).not.toBeInTheDocument();
-
-        resolveOwnership();
-
-        expect(await ui.syncedConfigHeading.find()).toBeInTheDocument();
-        expect(ui.revertButton.query()).not.toBeInTheDocument();
+        expect(await ui.stagedConfigHeading.find()).toBeInTheDocument();
+        expect(ui.revertButton.get()).toBeInTheDocument();
       });
     });
   });

--- a/public/app/features/alerting/unified/settings/import/ImportSettingsPage.tsx
+++ b/public/app/features/alerting/unified/settings/import/ImportSettingsPage.tsx
@@ -8,7 +8,6 @@ import { logError } from '../../Analytics';
 import { AlertingPageWrapper } from '../../components/AlertingPageWrapper';
 import { WithReturnButton } from '../../components/WithReturnButton';
 import { AutoSyncConfiguration } from '../../components/settings/AutoSyncConfiguration';
-import { useIsAutoSyncActive } from '../../hooks/useIsAutoSyncActive';
 import { AlertmanagerProvider } from '../../state/AlertmanagerContext';
 import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
 import { DOCS_URL_ALERTING_MIGRATION } from '../../utils/docs';
@@ -63,12 +62,8 @@ function ImportSettingsContent() {
 function StagedConfigurationSection() {
   const { canRevert } = getStagedConfigPermissions();
   const { stagedConfig, liveConfig, isLoading, isError, error, refetch } = useStagedConfig();
-  const { datasourceUid: autoSyncUid, isLoading: isLoadingAutoSync } = useIsAutoSyncActive();
 
-  // The syncer addresses its own staged config by the datasource UID, so a matching identifier means this
-  // staged config is auto-sync's output rather than a manual import.
-  const isSyncManaged = Boolean(autoSyncUid) && stagedConfig?.identifier === autoSyncUid;
-  const isLoadingCard = isLoading || isLoadingAutoSync;
+  const isSyncManaged = stagedConfig?.managed_by === 'auto-sync';
 
   useEffect(() => {
     if (isError) {
@@ -88,7 +83,7 @@ function StagedConfigurationSection() {
         </Trans>
       </Text>
 
-      {isLoadingCard && (
+      {isLoading && (
         <LoadingPlaceholder text={t('alerting.settings.import.loading', 'Loading imported configurations…')} />
       )}
 
@@ -108,7 +103,7 @@ function StagedConfigurationSection() {
         </Alert>
       )}
 
-      {!isLoadingCard && !isError && !stagedConfig && (
+      {!isLoading && !isError && !stagedConfig && (
         <EmptyState
           variant="call-to-action"
           message={t('alerting.settings.import.empty-title', 'No configuration imported yet')}
@@ -128,7 +123,7 @@ function StagedConfigurationSection() {
         </EmptyState>
       )}
 
-      {!isLoadingCard && !isError && stagedConfig && (
+      {!isLoading && !isError && stagedConfig && (
         <StagedConfiguration
           stagedConfig={stagedConfig}
           canRevert={canRevert}

--- a/public/app/features/alerting/unified/settings/import/stagedConfig.ts
+++ b/public/app/features/alerting/unified/settings/import/stagedConfig.ts
@@ -13,6 +13,7 @@ export interface StagedExtraConfig {
   /** The imported Alertmanager configuration, as a YAML string. */
   alertmanager_config?: string;
   template_files?: Record<string, string>;
+  managed_by?: 'manual' | 'auto-sync';
 }
 
 export function isStagedExtraConfig(value: unknown): value is StagedExtraConfig {


### PR DESCRIPTION
**What is this feature?**

Fixes how the Import settings page decides whether a staged Alertmanager config is manual or sync owned. It now reads the `managed_by` field the backend computes and serializes on `ExtraConfiguration`, instead of comparing two separately fetched, separately permissioned queries.

**Why do we need this feature?**

The old comparison needed both the staged config and the auto-sync ownership query to succeed. A custom role with `alertmanagerimports:delete` but not `configs:get` saw the ownership query fail permission checks. That quietly resolved to "not sync-managed" and showed an enabled Revert button on a config the sync worker would overwrite on its next tick.

This PR removes the second query (`useIsAutoSyncActive`) and the identifier-matching comparison from `ImportSettingsPage`. The `useIsAutoSyncActive` hook itself is untouched. `ImportToGMA` and `useImportEntrypointState` still use it for unrelated gating.

**Who is this feature for?**

Alerting users

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
