### PR TITLE
test: Fix stale sidebar page object calls in custom grid resize spec

### DIFF
--- a/e2e-playwright/dashboard-new-layouts/dashboards-custom-grid-resize.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-custom-grid-resize.spec.ts
@@ -109,8 +109,8 @@ async function prepareTestDashboard(
   const dashboardPage = await gotoDashboardPage({});
   await undockMegaMenu(dashboardPage, selectors);
 
-  await sidebar.addOptions.clickNewPanelButton();
-  await sidebar.clickCloseButton();
+  await sidebar.addOptions.addPanel();
+  await sidebar.closePane();
 }
 
 /**


### PR DESCRIPTION
Both tests in `dashboards-custom-grid-resize.spec.ts` fail in CI:

```
TypeError: sidebar.addOptions.clickNewPanelButton is not a function
```

**Cause:** #130571 renamed `AddOptions.clickNewPanelButton` to `addPanel`, and `Sidebar.clickCloseButton` to `closePane`. #130514 added this spec from a branch that was cut before that rename, and merged after it. Neither PR conflicts with the other, so the break only appeared at runtime. Both tests call the shared `prepareTestDashboard` helper, so both fail.

This PR updates the two calls to the current names. The clicks are the same.

**Why CI did not catch it earlier:** `e2e-playwright/` is not in the `include` list of the root `tsconfig.json`, and it has no tsconfig of its own. `yarn typecheck` never reads these files. A separate change can add this directory to a typechecked project.

Failing job: https://github.com/grafana/grafana/actions/runs/31814721460/job/94819305281
