### PR TITLE
Dashboards: Migrate import utils to async DataSource APIs

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1896,11 +1896,6 @@
       "count": 1
     }
   },
-  "public/app/features/dashboard/dashgrid/DashboardLibrary/utils/communityDashboardHelpers.test.ts": {
-    "@grafana/no-get-data-source-srv": {
-      "count": 1
-    }
-  },
   "public/app/features/dashboard/dashgrid/SeriesVisibilityConfigFactory.ts": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1440,11 +1440,6 @@
       "count": 1
     }
   },
-  "public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts": {
-    "@grafana/no-get-data-source-srv": {
-      "count": 1
-    }
-  },
   "public/app/features/dashboard-scene/panel-edit/PanelDataPane/EmptyTransformationsMessage.test.tsx": {
     "@grafana/no-get-data-source-srv": {
       "count": 1
@@ -2244,11 +2239,6 @@
     }
   },
   "public/app/features/logs/components/panel/LogLineMenu.test.tsx": {
-    "@grafana/no-get-data-source-srv": {
-      "count": 1
-    }
-  },
-  "public/app/features/manage-dashboards/import/utils/inputs.ts": {
     "@grafana/no-get-data-source-srv": {
       "count": 1
     }

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -1,7 +1,8 @@
 import { locationUtil, type UrlQueryMap } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config, getBackendSrv, getDataSourceSrv, isFetchError, locationService } from '@grafana/runtime';
+import { config, getBackendSrv, isFetchError, locationService } from '@grafana/runtime';
 import { FlagKeys, getFeatureFlagClient, UserStorage } from '@grafana/runtime/internal';
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { sceneGraph } from '@grafana/scenes';
 import {
   type Spec as DashboardV2Spec,
@@ -722,7 +723,7 @@ export class DashboardScenePageStateManager extends DashboardScenePageStateManag
       throw new Error('Missing required parameters for template dashboard');
     }
 
-    const ds = getDataSourceSrv().getInstanceSettings(datasource);
+    const ds = await getDataSourceInstanceSettings(datasource);
     if (!ds) {
       throw new Error(`Datasource "${datasource}" not found. Please check your datasource configuration.`);
     }
@@ -757,7 +758,7 @@ export class DashboardScenePageStateManager extends DashboardScenePageStateManag
     const dashboardJson = gnetDashboard.json;
 
     // Interpolate in the frontend — no backend round-trip needed
-    const interpolatedDashboard = interpolateV1Dashboard(dashboardJson, [
+    const interpolatedDashboard = await interpolateV1Dashboard(dashboardJson, [
       {
         name: '*',
         type: 'datasource',
@@ -793,7 +794,7 @@ export class DashboardScenePageStateManager extends DashboardScenePageStateManag
     const dashboardJson = gnetDashboard.json;
 
     // Interpolate in the frontend — no backend round-trip needed
-    const interpolatedDashboard = interpolateV1Dashboard(dashboardJson, mappings);
+    const interpolatedDashboard = await interpolateV1Dashboard(dashboardJson, mappings);
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     return this.buildDashboardDTOFromInterpolated(interpolatedDashboard as DashboardDataDTO);
   }

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/utils/communityDashboardHelpers.test.ts
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/utils/communityDashboardHelpers.test.ts
@@ -1,5 +1,6 @@
 import { type DataSourceInstanceSettings } from '@grafana/data';
-import { getDataSourceSrv, locationService } from '@grafana/runtime';
+import { locationService } from '@grafana/runtime';
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import {
   InputType,
   type DataSourceInput,
@@ -42,17 +43,23 @@ jest.mock('../interactions', () => ({
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
-  getDataSourceSrv: jest.fn(),
   locationService: {
     push: jest.fn(),
   },
+}));
+
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstanceSettings: jest.fn(),
 }));
 
 // Mock function references
 const mockFetchCommunityDashboard = fetchCommunityDashboard as jest.MockedFunction<typeof fetchCommunityDashboard>;
 const mockTryAutoMapDatasources = tryAutoMapDatasources as jest.MockedFunction<typeof tryAutoMapDatasources>;
 const mockParseConstantInputs = parseConstantInputs as jest.MockedFunction<typeof parseConstantInputs>;
-const mockGetDataSourceSrv = getDataSourceSrv as jest.MockedFunction<typeof getDataSourceSrv>;
+const mockGetDataSourceInstanceSettings = getDataSourceInstanceSettings as jest.MockedFunction<
+  typeof getDataSourceInstanceSettings
+>;
 
 const createMockGnetDashboard = (overrides: Partial<GnetDashboard> = {}): GnetDashboard => ({
   id: 123,
@@ -634,14 +641,9 @@ describe('communityDashboardHelpers', () => {
     } as DataSourceInstanceSettings;
 
     beforeEach(() => {
-      mockGetDataSourceSrv.mockReturnValue({
-        getInstanceSettings: jest.fn((uid: string) => {
-          if (uid === 'prom-uid') {
-            return mockPromSettings;
-          }
-          return undefined;
-        }),
-      } as unknown as ReturnType<typeof getDataSourceSrv>);
+      mockGetDataSourceInstanceSettings.mockImplementation(async (uid) =>
+        uid === 'prom-uid' ? mockPromSettings : undefined
+      );
     });
 
     afterEach(() => {

--- a/public/app/features/manage-dashboards/import/utils/inputs.test.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.test.ts
@@ -1,4 +1,9 @@
-import { type DataSourceInstanceSettings } from '@grafana/data';
+import { type DataSourceInstanceListItem, type DataSourceInstanceSettings } from '@grafana/data';
+import {
+  getDataSourceInstance,
+  getDataSourceInstanceList,
+  getDataSourceInstanceSettings,
+} from '@grafana/runtime/unstable';
 import {
   type AnnotationQueryKind,
   type PanelKind,
@@ -30,17 +35,36 @@ import {
   type DatasourceMappings,
 } from './inputs';
 
-// Mock external dependencies
-const mockGetDataSourceSrv: Record<string, jest.Mock> = {
-  getList: jest.fn().mockReturnValue([{ uid: 'ds-1', name: 'Prometheus', type: 'prometheus' }]),
-  get: jest.fn().mockResolvedValue({ meta: { builtIn: false } }),
-  getInstanceSettings: jest.fn().mockReturnValue(undefined),
-};
-
-jest.mock('@grafana/runtime', () => ({
-  ...jest.requireActual('@grafana/runtime'),
-  getDataSourceSrv: () => mockGetDataSourceSrv,
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstanceList: jest.fn(),
+  getDataSourceInstance: jest.fn(),
+  getDataSourceInstanceSettings: jest.fn(),
 }));
+
+const mockGetDataSourceInstanceList = getDataSourceInstanceList as jest.MockedFunction<
+  typeof getDataSourceInstanceList
+>;
+const mockGetDataSourceInstance = getDataSourceInstance as jest.MockedFunction<typeof getDataSourceInstance>;
+const mockGetDataSourceInstanceSettings = getDataSourceInstanceSettings as jest.MockedFunction<
+  typeof getDataSourceInstanceSettings
+>;
+
+const listItem = (overrides: Partial<DataSourceInstanceListItem>): DataSourceInstanceListItem =>
+  ({
+    uid: 'uid',
+    name: 'Name',
+    type: 'type',
+    ...overrides,
+  }) as DataSourceInstanceListItem;
+
+beforeEach(() => {
+  mockGetDataSourceInstanceList.mockResolvedValue([listItem({ uid: 'ds-1', name: 'Prometheus', type: 'prometheus' })]);
+  mockGetDataSourceInstance.mockResolvedValue({ meta: { builtIn: false } } as Awaited<
+    ReturnType<typeof getDataSourceInstance>
+  >);
+  mockGetDataSourceInstanceSettings.mockResolvedValue(undefined);
+});
 
 jest.mock('../../../library-panels/state/api', () => ({
   getLibraryPanel: jest.fn().mockRejectedValue({ status: 404 }),
@@ -387,9 +411,9 @@ describe('extractV2Inputs', () => {
   });
 
   it('pre-selects the datasource when its name matches an existing one of the same plugin type', async () => {
-    mockGetDataSourceSrv.getList.mockReturnValueOnce([
-      { uid: 'ds-prod', name: 'Production MySQL', type: 'mysql' },
-      { uid: 'ds-stage', name: 'Staging MySQL', type: 'mysql' },
+    mockGetDataSourceInstanceList.mockResolvedValueOnce([
+      listItem({ uid: 'ds-prod', name: 'Production MySQL', type: 'mysql' }),
+      listItem({ uid: 'ds-stage', name: 'Staging MySQL', type: 'mysql' }),
     ]);
 
     const dashboard = {
@@ -418,7 +442,9 @@ describe('extractV2Inputs', () => {
   });
 
   it('does not pre-select a datasource when no name matches', async () => {
-    mockGetDataSourceSrv.getList.mockReturnValueOnce([{ uid: 'ds-stage', name: 'Staging MySQL', type: 'mysql' }]);
+    mockGetDataSourceInstanceList.mockResolvedValueOnce([
+      listItem({ uid: 'ds-stage', name: 'Staging MySQL', type: 'mysql' }),
+    ]);
 
     const dashboard = {
       elements: {},
@@ -442,7 +468,9 @@ describe('extractV2Inputs', () => {
   });
 
   it('does not pre-select when no original name is present', async () => {
-    mockGetDataSourceSrv.getList.mockReturnValueOnce([{ uid: 'ds-prod', name: 'Production MySQL', type: 'mysql' }]);
+    mockGetDataSourceInstanceList.mockResolvedValueOnce([
+      listItem({ uid: 'ds-prod', name: 'Production MySQL', type: 'mysql' }),
+    ]);
 
     const dashboard = {
       elements: {},
@@ -536,7 +564,9 @@ describe('extractV2Inputs', () => {
   });
 
   it('should skip built-in datasources', async () => {
-    mockGetDataSourceSrv.get.mockResolvedValueOnce({ meta: { builtIn: true } });
+    mockGetDataSourceInstance.mockResolvedValueOnce({ meta: { builtIn: true } } as Awaited<
+      ReturnType<typeof getDataSourceInstance>
+    >);
 
     const dashboard = {
       elements: {},
@@ -553,9 +583,9 @@ describe('extractV2Inputs', () => {
   });
 
   it('should keep non-built-in datasources and skip built-in ones', async () => {
-    mockGetDataSourceSrv.get
-      .mockResolvedValueOnce({ meta: { builtIn: false } })
-      .mockResolvedValueOnce({ meta: { builtIn: true } });
+    mockGetDataSourceInstance
+      .mockResolvedValueOnce({ meta: { builtIn: false } } as Awaited<ReturnType<typeof getDataSourceInstance>>)
+      .mockResolvedValueOnce({ meta: { builtIn: true } } as Awaited<ReturnType<typeof getDataSourceInstance>>);
 
     const dashboard = {
       elements: {},
@@ -711,12 +741,12 @@ describe('extractV2Inputs', () => {
       },
     };
 
-    mockGetDataSourceSrv.getList.mockImplementation(({ pluginId }: { pluginId: string }) => {
-      if (pluginId === 'prometheus') {
-        return [{ uid: 'p1', name: 'Prod Prom', type: 'prometheus' }];
+    mockGetDataSourceInstanceList.mockImplementation(async (filters) => {
+      if (filters?.pluginId === 'prometheus') {
+        return [listItem({ uid: 'p1', name: 'Prod Prom', type: 'prometheus' })];
       }
-      if (pluginId === 'loki') {
-        return [{ uid: 'l1', name: 'Prod Loki', type: 'loki' }];
+      if (filters?.pluginId === 'loki') {
+        return [listItem({ uid: 'l1', name: 'Prod Loki', type: 'loki' })];
       }
       return [];
     });
@@ -778,12 +808,12 @@ describe('extractV2Inputs', () => {
       variables: [],
     };
 
-    mockGetDataSourceSrv.getList.mockImplementation(({ pluginId }: { pluginId: string }) => {
-      if (pluginId === 'loki') {
-        return [{ uid: 'l1', name: 'Prod Loki', type: 'loki' }];
+    mockGetDataSourceInstanceList.mockImplementation(async (filters) => {
+      if (filters?.pluginId === 'loki') {
+        return [listItem({ uid: 'l1', name: 'Prod Loki', type: 'loki' })];
       }
-      if (pluginId === 'grafana-sqlite-datasource') {
-        return [{ uid: 's1', name: 'SQLite', type: 'grafana-sqlite-datasource' }];
+      if (filters?.pluginId === 'grafana-sqlite-datasource') {
+        return [listItem({ uid: 's1', name: 'SQLite', type: 'grafana-sqlite-datasource' })];
       }
       return [];
     });
@@ -2488,27 +2518,29 @@ describe('interpolateV1Dashboard', () => {
   const getPanel = (result: DashboardJson, idx = 0) => (result.panels as Panel[])[idx];
 
   beforeEach(() => {
-    mockGetDataSourceSrv.getInstanceSettings = jest
-      .fn()
-      .mockImplementation((uid: string) =>
-        uid === 'prom-uid' ? { uid: 'prom-uid', type: 'prometheus', name: 'Prometheus' } : undefined
-      );
+    mockGetDataSourceInstanceSettings.mockImplementation(async (uid) =>
+      uid === 'prom-uid'
+        ? ({ uid: 'prom-uid', type: 'prometheus', name: 'Prometheus' } as DataSourceInstanceSettings)
+        : undefined
+    );
   });
 
-  it('should replace datasource placeholders with wildcard mapping', () => {
-    const result = interpolateV1Dashboard(makeDashboard(), [{ name: '*', type: 'datasource', value: 'prom-uid' }]);
+  it('should replace datasource placeholders with wildcard mapping', async () => {
+    const result = await interpolateV1Dashboard(makeDashboard(), [
+      { name: '*', type: 'datasource', value: 'prom-uid' },
+    ]);
     expect(getPanel(result).datasource!.uid).toBe('prom-uid');
   });
 
-  it('should replace named datasource mapping', () => {
-    const result = interpolateV1Dashboard(makeDashboard(), [
+  it('should replace named datasource mapping', async () => {
+    const result = await interpolateV1Dashboard(makeDashboard(), [
       { name: 'DS_PROMETHEUS', type: 'datasource', pluginId: 'prometheus', value: 'prom-uid' },
     ]);
     expect(getPanel(result).datasource!.uid).toBe('prom-uid');
   });
 
-  it('should handle expression datasources', () => {
-    const result = interpolateV1Dashboard(makeExprDashboard(), [
+  it('should handle expression datasources', async () => {
+    const result = await interpolateV1Dashboard(makeExprDashboard(), [
       { name: 'DS_PROMETHEUS', type: 'datasource', pluginId: 'prometheus', value: 'prom-uid' },
     ]);
     const panel = getPanel(result);
@@ -2517,8 +2549,8 @@ describe('interpolateV1Dashboard', () => {
     expect((panel.targets![0].datasource as { type: string }).type).toBe('__expr__');
   });
 
-  it('should force expression datasource to __expr__ even when mapped to a real UID', () => {
-    const result = interpolateV1Dashboard(makeExprDashboard(), [
+  it('should force expression datasource to __expr__ even when mapped to a real UID', async () => {
+    const result = await interpolateV1Dashboard(makeExprDashboard(), [
       { name: 'DS_PROMETHEUS', type: 'datasource', pluginId: 'prometheus', value: 'prom-uid' },
       { name: 'DS_EXPRESSION', type: 'datasource', pluginId: '__expr__', value: 'some-real-uid' },
     ]);
@@ -2527,14 +2559,16 @@ describe('interpolateV1Dashboard', () => {
     expect((panel.targets![0].datasource as { type: string }).type).toBe('__expr__');
   });
 
-  it('should handle expression datasources with wildcard mapping', () => {
-    const result = interpolateV1Dashboard(makeExprDashboard(), [{ name: '*', type: 'datasource', value: 'prom-uid' }]);
+  it('should handle expression datasources with wildcard mapping', async () => {
+    const result = await interpolateV1Dashboard(makeExprDashboard(), [
+      { name: '*', type: 'datasource', value: 'prom-uid' },
+    ]);
     const panel = getPanel(result);
     expect(panel.datasource!.uid).toBe('prom-uid');
     expect((panel.targets![0].datasource as { uid: string }).uid).toBe('__expr__');
   });
 
-  it('should handle constants', () => {
+  it('should handle constants', async () => {
     const dashboard = makeDashboard({
       __inputs: [{ name: 'VAR_INTERVAL', type: 'constant', label: 'Interval', description: '', value: '1m' }],
       panels: [] as DashboardJson['panels'],
@@ -2550,34 +2584,34 @@ describe('interpolateV1Dashboard', () => {
         ],
       } as DashboardJson['templating'],
     });
-    const result = interpolateV1Dashboard(dashboard, [{ name: 'VAR_INTERVAL', type: 'constant', value: '5m' }]);
+    const result = await interpolateV1Dashboard(dashboard, [{ name: 'VAR_INTERVAL', type: 'constant', value: '5m' }]);
     const variable = result.templating!.list![0] as VariableModel & { query: string; current: { value: string } };
     expect(variable.query).toBe('5m');
     expect(variable.current.value).toBe('5m');
   });
 
-  it('should strip __inputs, __elements, __requires from result', () => {
+  it('should strip __inputs, __elements, __requires from result', async () => {
     const dashboard = makeDashboard({
       __elements: { somePanel: {} } as unknown as DashboardJson['__elements'],
       __requires: [{ type: 'panel', id: 'timeseries' }] as DashboardJson['__requires'],
     });
-    const result = interpolateV1Dashboard(dashboard, [{ name: '*', type: 'datasource', value: 'prom-uid' }]);
+    const result = await interpolateV1Dashboard(dashboard, [{ name: '*', type: 'datasource', value: 'prom-uid' }]);
     expect(result.__inputs).toBeUndefined();
     expect(result.__elements).toBeUndefined();
     expect(result.__requires).toBeUndefined();
   });
 
-  it('should work with no __inputs', () => {
+  it('should work with no __inputs', async () => {
     const dashboard = makeDashboard({ __inputs: undefined, panels: [] as DashboardJson['panels'] });
-    const result = interpolateV1Dashboard(dashboard, []);
+    const result = await interpolateV1Dashboard(dashboard, []);
     expect(result.title).toBe('Test');
   });
 
-  it('should throw when datasource UID cannot be resolved', () => {
-    expect(() =>
+  it('should throw when datasource UID cannot be resolved', async () => {
+    await expect(
       interpolateV1Dashboard(makeDashboard(), [
         { name: 'DS_PROMETHEUS', type: 'datasource', pluginId: 'prometheus', value: 'nonexistent-uid' },
       ])
-    ).toThrow('datasource input "DS_PROMETHEUS" references UID "nonexistent-uid" which was not found');
+    ).rejects.toThrow('datasource input "DS_PROMETHEUS" references UID "nonexistent-uid" which was not found');
   });
 });

--- a/public/app/features/manage-dashboards/import/utils/inputs.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.ts
@@ -1,6 +1,10 @@
 import { type DataSourceInstanceSettings, type VariableModel } from '@grafana/data';
-import { getDataSourceSrv } from '@grafana/runtime';
 import { ExpressionDatasourceRef } from '@grafana/runtime/internal';
+import {
+  getDataSourceInstance,
+  getDataSourceInstanceList,
+  getDataSourceInstanceSettings,
+} from '@grafana/runtime/unstable';
 import { type AnnotationQuery, type Dashboard, type Panel, type RowPanel } from '@grafana/schema';
 import { type AnnotationQueryKind, type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { isRecord } from 'app/core/utils/isRecord';
@@ -171,7 +175,7 @@ export async function extractV1Inputs(dashboard: unknown): Promise<DashboardInpu
         // Expression datasources do not need user input
         if (inputModel.pluginId !== ExpressionDatasourceRef.type) {
           // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-          (inputModel as DataSourceInput).description = getDataSourceDescription(input);
+          (inputModel as DataSourceInput).description = await getDataSourceDescription(input);
           // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           inputs.dataSources.push(inputModel as DataSourceInput);
         }
@@ -306,7 +310,7 @@ export async function extractV2Inputs(dashboard: unknown): Promise<DashboardInpu
 
   for (const [label, dsType] of Object.entries(dsTypes)) {
     try {
-      const datasource = await getDataSourceSrv().get({ type: dsType });
+      const datasource = await getDataSourceInstance({ type: dsType });
       if (datasource.meta?.builtIn) {
         continue;
       }
@@ -314,7 +318,7 @@ export async function extractV2Inputs(dashboard: unknown): Promise<DashboardInpu
       // datasource not found, still add it as an input so the user can pick one
     }
 
-    const dsInfo = getDataSourceSrv().getList({ pluginId: dsType });
+    const dsInfo = await getDataSourceInstanceList({ pluginId: dsType });
     const originalName = dsNames[label];
     const matchedDatasource = originalName ? dsInfo.find((ds) => ds.name === originalName) : undefined;
     const prompt = dsInfo.length > 0 ? `Select a ${dsType} data source` : `No ${dsType} data sources found`;
@@ -341,9 +345,9 @@ export async function extractV2Inputs(dashboard: unknown): Promise<DashboardInpu
   return inputs;
 }
 
-function getDataSourceDescription(input: Record<string, unknown>): string {
+async function getDataSourceDescription(input: Record<string, unknown>): Promise<string> {
   const pluginId = String(input.pluginId ?? '');
-  const dsInfo = getDataSourceSrv().getList({ pluginId });
+  const dsInfo = await getDataSourceInstanceList({ pluginId });
 
   if (dsInfo.length === 0) {
     return `No data sources of type ${pluginId} found`;
@@ -370,10 +374,10 @@ export interface InterpolateInputMapping {
  * Converts InputMapping[] (the format used by the community/suggested dashboard flow)
  * into the shape that applyV1Inputs expects and applies the substitution.
  */
-export function interpolateV1Dashboard(
+export async function interpolateV1Dashboard(
   dashboard: DashboardJson,
   inputMappings: InterpolateInputMapping[]
-): DashboardJson {
+): Promise<DashboardJson> {
   const rawInputs = dashboard.__inputs;
   const dsInputs: DataSourceInput[] = (rawInputs ?? [])
     .filter((input) => input.type === 'datasource' && 'pluginId' in input && typeof input.pluginId === 'string')
@@ -422,7 +426,7 @@ export function interpolateV1Dashboard(
       continue;
     }
 
-    const settings = getDataSourceSrv().getInstanceSettings(mapping.value);
+    const settings = await getDataSourceInstanceSettings(mapping.value);
     if (!settings) {
       throw new Error(
         `Dashboard import failed: datasource input "${mapping.name}" references UID "${mapping.value}" which was not found`


### PR DESCRIPTION
- Migrates dashboard import/interpolate helpers from deprecated `getDataSourceSrv` to async `getDataSourceInstance*` APIs (`@grafana/runtime/unstable`)
- Updates `DashboardScenePageStateManager` callers to `await` the now-async `interpolateV1Dashboard` / `getDataSourceInstanceSettings`
- Reworks `inputs.test.ts` mocks to target the unstable async APIs instead of the legacy srv

Part of #127032.

- [x] Import a classic (v1) dashboard with datasource inputs and confirm picker descriptions still resolve
- [x] Import a v2 dashboard export and confirm datasource matching / built-in skipping still works
- [x] Load a grafana.com / community template dashboard and confirm interpolation still applies the selected datasource