### PR TITLE
Variables: Migrate adhoc, datasource, and query paths to async DataSource APIs

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2687,9 +2687,6 @@
     }
   },
   "public/app/features/variables/query/actions.ts": {
-    "@grafana/no-get-data-source-srv": {
-      "count": 1
-    },
     "@typescript-eslint/no-explicit-any": {
       "count": 3
     }

--- a/public/app/features/variables/adhoc/picker/AdHocFilter.test.tsx
+++ b/public/app/features/variables/adhoc/picker/AdHocFilter.test.tsx
@@ -2,10 +2,17 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import selectEvent from 'react-select-event';
 
-import { type AdHocVariableFilter } from '@grafana/data';
-import { type DataSourceSrv, setDataSourceSrv } from '@grafana/runtime';
+import { type AdHocVariableFilter, type DataSourceApi } from '@grafana/data';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 
 import { AdHocFilter } from './AdHocFilter';
+
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstance: jest.fn(),
+}));
+
+const mockGetDataSourceInstance = getDataSourceInstance as jest.MockedFunction<typeof getDataSourceInstance>;
 
 describe('AdHocFilter', () => {
   it('renders filters', async () => {
@@ -64,18 +71,14 @@ describe('AdHocFilter', () => {
 });
 
 function setup() {
-  setDataSourceSrv({
-    get() {
-      return {
-        getTagKeys() {
-          return [{ text: 'key3' }];
-        },
-        getTagValues() {
-          return [{ text: 'val3' }, { text: 'val4' }];
-        },
-      };
+  mockGetDataSourceInstance.mockResolvedValue({
+    getTagKeys() {
+      return [{ text: 'key3' }];
     },
-  } as unknown as DataSourceSrv);
+    getTagValues() {
+      return [{ text: 'val3' }, { text: 'val4' }];
+    },
+  } as unknown as DataSourceApi);
 
   const filters: AdHocVariableFilter[] = [
     {

--- a/public/app/features/variables/adhoc/picker/AdHocFilterKey.tsx
+++ b/public/app/features/variables/adhoc/picker/AdHocFilterKey.tsx
@@ -2,9 +2,8 @@ import { type ReactElement } from 'react';
 
 import { type AdHocVariableFilter, type DataSourceRef, type SelectableValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { Icon, SegmentAsync } from '@grafana/ui';
-
-import { getDatasourceSrv } from '../../../plugins/datasource_srv';
 
 interface Props {
   datasource: DataSourceRef;
@@ -66,7 +65,7 @@ const fetchFilterKeys = async (
   currentKey: string | null,
   allFilters: AdHocVariableFilter[]
 ): Promise<Array<SelectableValue<string>>> => {
-  const ds = await getDatasourceSrv().get(datasource);
+  const ds = await getDataSourceInstance(datasource);
 
   if (!ds || !ds.getTagKeys) {
     return [];

--- a/public/app/features/variables/adhoc/picker/AdHocFilterValue.tsx
+++ b/public/app/features/variables/adhoc/picker/AdHocFilterValue.tsx
@@ -1,10 +1,9 @@
 import { css } from '@emotion/css';
 
 import { type AdHocVariableFilter, type DataSourceRef, type SelectableValue } from '@grafana/data';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { SegmentAsync, useStyles2 } from '@grafana/ui';
 import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
-
-import { getDatasourceSrv } from '../../../plugins/datasource_srv';
 
 interface Props {
   datasource: DataSourceRef;
@@ -47,7 +46,7 @@ const fetchFilterValues = async (
   key: string,
   allFilters: AdHocVariableFilter[]
 ): Promise<Array<SelectableValue<string>>> => {
-  const ds = await getDatasourceSrv().get(datasource);
+  const ds = await getDataSourceInstance(datasource);
 
   if (!ds || !ds.getTagValues) {
     return [];

--- a/public/app/features/variables/adhoc/picker/AdHocPicker.test.tsx
+++ b/public/app/features/variables/adhoc/picker/AdHocPicker.test.tsx
@@ -1,8 +1,8 @@
 import { screen, within } from '@testing-library/react';
 import { render } from 'test/test-utils';
 
-import { type AdHocVariableModel } from '@grafana/data';
-import { type DataSourceSrv, setDataSourceSrv } from '@grafana/runtime';
+import { type AdHocVariableModel, type DataSourceApi } from '@grafana/data';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 
 import { adHocBuilder } from '../../shared/testing/builders';
 import { getPreloadedState } from '../../state/helpers';
@@ -10,6 +10,13 @@ import * as actions from '../actions';
 
 import { REMOVE_FILTER_KEY } from './AdHocFilterKey';
 import { AdHocPicker } from './AdHocPicker';
+
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstance: jest.fn(),
+}));
+
+const mockGetDataSourceInstance = getDataSourceInstance as jest.MockedFunction<typeof getDataSourceInstance>;
 
 const defaultVariable = adHocBuilder()
   .withId('adhoc0')
@@ -19,18 +26,14 @@ const defaultVariable = adHocBuilder()
   .build();
 
 function setup(overrides: Partial<AdHocVariableModel> = {}, readOnly = false) {
-  setDataSourceSrv({
-    get() {
-      return {
-        getTagKeys() {
-          return [{ text: 'app' }];
-        },
-        getTagValues() {
-          return [{ text: 'frontend' }, { text: 'backend' }];
-        },
-      };
+  mockGetDataSourceInstance.mockResolvedValue({
+    getTagKeys() {
+      return [{ text: 'app' }];
     },
-  } as unknown as DataSourceSrv);
+    getTagValues() {
+      return [{ text: 'frontend' }, { text: 'backend' }];
+    },
+  } as unknown as DataSourceApi);
 
   const variable = { ...defaultVariable, ...overrides };
   const templatingState = {

--- a/public/app/features/variables/datasource/actions.test.ts
+++ b/public/app/features/variables/datasource/actions.test.ts
@@ -1,4 +1,4 @@
-import { type DataSourceInstanceSettings } from '@grafana/data';
+import { type DataSourceInstanceListItem } from '@grafana/data';
 import { getMockPlugin } from '@grafana/data/test';
 
 import { reduxTester } from '../../../../test/core/redux/reduxTester';
@@ -15,15 +15,16 @@ import { createDataSourceVariableAdapter } from './adapter';
 import { createDataSourceOptions } from './reducer';
 
 interface Args {
-  sources?: DataSourceInstanceSettings[];
+  sources?: DataSourceInstanceListItem[];
   query?: string;
   regex?: string;
 }
 
 function getTestContext({ sources = [], query, regex }: Args = {}) {
-  const getListMock = jest.fn().mockReturnValue(sources);
-  const getDatasourceSrvMock = jest.fn().mockReturnValue({ getList: getListMock });
-  const dependencies: DataSourceVariableActionDependencies = { getDatasourceSrv: getDatasourceSrvMock };
+  const getDataSourceInstanceListMock = jest.fn().mockResolvedValue(sources);
+  const dependencies: DataSourceVariableActionDependencies = {
+    getDataSourceInstanceList: getDataSourceInstanceListMock,
+  };
   const datasource = datasourceBuilder()
     .withId('0')
     .withRootStateKey('key')
@@ -31,7 +32,19 @@ function getTestContext({ sources = [], query, regex }: Args = {}) {
     .withRegEx(regex!)
     .build();
 
-  return { getListMock, getDatasourceSrvMock, dependencies, datasource };
+  return { getDataSourceInstanceListMock, dependencies, datasource };
+}
+
+function toListItem(name: string, meta: ReturnType<typeof getMockPlugin>): DataSourceInstanceListItem {
+  const settings = getDataSourceInstanceSetting(name, meta);
+  return {
+    uid: settings.uid,
+    type: settings.type,
+    name: settings.name,
+    meta: settings.meta,
+    readOnly: settings.readOnly,
+    isDefault: settings.isDefault ?? false,
+  };
 }
 
 describe('data source actions', () => {
@@ -41,11 +54,8 @@ describe('data source actions', () => {
     describe('and there is no regex', () => {
       it('then the correct actions are dispatched', async () => {
         const meta = getMockPlugin({ name: 'mock-data-name', id: 'mock-data-id' });
-        const sources: DataSourceInstanceSettings[] = [
-          getDataSourceInstanceSetting('first-name', meta),
-          getDataSourceInstanceSetting('second-name', meta),
-        ];
-        const { datasource, dependencies, getListMock, getDatasourceSrvMock } = getTestContext({
+        const sources: DataSourceInstanceListItem[] = [toListItem('first-name', meta), toListItem('second-name', meta)];
+        const { datasource, dependencies, getDataSourceInstanceListMock } = getTestContext({
           sources,
           query: 'mock-data-id',
         });
@@ -87,21 +97,17 @@ describe('data source actions', () => {
           )
         );
 
-        expect(getListMock).toHaveBeenCalledTimes(1);
-        expect(getListMock).toHaveBeenCalledWith({ metrics: true, variables: false });
-        expect(getDatasourceSrvMock).toHaveBeenCalledTimes(1);
+        expect(getDataSourceInstanceListMock).toHaveBeenCalledTimes(1);
+        expect(getDataSourceInstanceListMock).toHaveBeenCalledWith({ metrics: true, variables: false });
       });
     });
 
     describe('and there is a regex', () => {
       it('then the correct actions are dispatched', async () => {
         const meta = getMockPlugin({ name: 'mock-data-name', id: 'mock-data-id' });
-        const sources: DataSourceInstanceSettings[] = [
-          getDataSourceInstanceSetting('first-name', meta),
-          getDataSourceInstanceSetting('second-name', meta),
-        ];
+        const sources: DataSourceInstanceListItem[] = [toListItem('first-name', meta), toListItem('second-name', meta)];
 
-        const { datasource, dependencies, getListMock, getDatasourceSrvMock } = getTestContext({
+        const { datasource, dependencies, getDataSourceInstanceListMock } = getTestContext({
           sources,
           query: 'mock-data-id',
           regex: '/.*(second-name).*/',
@@ -144,9 +150,8 @@ describe('data source actions', () => {
           )
         );
 
-        expect(getListMock).toHaveBeenCalledTimes(1);
-        expect(getListMock).toHaveBeenCalledWith({ metrics: true, variables: false });
-        expect(getDatasourceSrvMock).toHaveBeenCalledTimes(1);
+        expect(getDataSourceInstanceListMock).toHaveBeenCalledTimes(1);
+        expect(getDataSourceInstanceListMock).toHaveBeenCalledWith({ metrics: true, variables: false });
       });
     });
   });

--- a/public/app/features/variables/datasource/actions.ts
+++ b/public/app/features/variables/datasource/actions.ts
@@ -1,8 +1,8 @@
 import { stringToJsRegex } from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime';
+import { getDataSourceInstanceList } from '@grafana/runtime/unstable';
 import { type ThunkResult } from 'app/types/store';
 
-import { getDatasourceSrv } from '../../plugins/datasource_srv';
 import { validateVariableSelectionState } from '../state/actions';
 import { toKeyedAction } from '../state/keyedVariablesReducer';
 import { getVariable } from '../state/selectors';
@@ -12,17 +12,17 @@ import { toVariablePayload } from '../utils';
 import { createDataSourceOptions } from './reducer';
 
 export interface DataSourceVariableActionDependencies {
-  getDatasourceSrv: typeof getDatasourceSrv;
+  getDataSourceInstanceList: typeof getDataSourceInstanceList;
 }
 
 export const updateDataSourceVariableOptions =
   (
     identifier: KeyedVariableIdentifier,
-    dependencies: DataSourceVariableActionDependencies = { getDatasourceSrv: getDatasourceSrv }
+    dependencies: DataSourceVariableActionDependencies = { getDataSourceInstanceList }
   ): ThunkResult<void> =>
   async (dispatch, getState) => {
     const { rootStateKey } = identifier;
-    const sources = dependencies.getDatasourceSrv().getList({ metrics: true, variables: false });
+    const sources = await dependencies.getDataSourceInstanceList({ metrics: true, variables: false });
     const variableInState = getVariable(identifier, getState());
     if (variableInState.type !== 'datasource') {
       return;

--- a/public/app/features/variables/datasource/reducer.test.ts
+++ b/public/app/features/variables/datasource/reducer.test.ts
@@ -1,6 +1,6 @@
 import { cloneDeep } from 'lodash';
 
-import { type DataSourceInstanceSettings, type DataSourceVariableModel } from '@grafana/data';
+import { type DataSourceInstanceListItem, type DataSourceVariableModel } from '@grafana/data';
 import { getMockPlugins } from '@grafana/data/test';
 
 import { reducerTester } from '../../../../test/core/redux/reducerTester';
@@ -12,11 +12,25 @@ import { toVariablePayload } from '../utils';
 import { createDataSourceVariableAdapter } from './adapter';
 import { createDataSourceOptions, dataSourceVariableReducer } from './reducer';
 
+function toListItems(plugins: ReturnType<typeof getMockPlugins>): DataSourceInstanceListItem[] {
+  return plugins.map((p) => {
+    const settings = getDataSourceInstanceSetting(p.name, p);
+    return {
+      uid: settings.uid,
+      type: settings.type,
+      name: settings.name,
+      meta: settings.meta,
+      readOnly: settings.readOnly,
+      isDefault: settings.isDefault ?? false,
+    };
+  });
+}
+
 describe('dataSourceVariableReducer', () => {
   const adapter = createDataSourceVariableAdapter();
   describe('when createDataSourceOptions is dispatched', () => {
     const plugins = getMockPlugins(3);
-    const sources: DataSourceInstanceSettings[] = plugins.map((p) => getDataSourceInstanceSetting(p.name, p));
+    const sources = toListItems(plugins);
 
     it.each`
       query                 | regex                           | includeAll | expected
@@ -50,8 +64,7 @@ describe('dataSourceVariableReducer', () => {
 
   describe('when createDataSourceOptions is dispatched and item is default data source', () => {
     it('then the state should include an extra default option', () => {
-      const plugins = getMockPlugins(3);
-      const sources: DataSourceInstanceSettings[] = plugins.map((p) => getDataSourceInstanceSetting(p.name, p));
+      const sources = toListItems(getMockPlugins(3));
       sources[1].isDefault = true;
 
       const { initialState } = getVariableTestContext<DataSourceVariableModel>(adapter, {
@@ -78,8 +91,7 @@ describe('dataSourceVariableReducer', () => {
 
   describe('when createDataSourceOptions is dispatched with default in the regex and item is default data source', () => {
     it('then the state should include an extra default option', () => {
-      const plugins = getMockPlugins(3);
-      const sources: DataSourceInstanceSettings[] = plugins.map((p) => getDataSourceInstanceSetting(p.name, p));
+      const sources = toListItems(getMockPlugins(3));
       sources[1].isDefault = true;
 
       const { initialState } = getVariableTestContext<DataSourceVariableModel>(adapter, {
@@ -103,8 +115,7 @@ describe('dataSourceVariableReducer', () => {
 
   describe('when createDataSourceOptions is dispatched without default in the regex and item is default data source', () => {
     it('then the state not should include an extra default option', () => {
-      const plugins = getMockPlugins(3);
-      const sources: DataSourceInstanceSettings[] = plugins.map((p) => getDataSourceInstanceSetting(p.name, p));
+      const sources = toListItems(getMockPlugins(3));
       sources[1].isDefault = true;
 
       const { initialState } = getVariableTestContext<DataSourceVariableModel>(adapter, {
@@ -128,8 +139,7 @@ describe('dataSourceVariableReducer', () => {
 
   describe('when createDataSourceOptions is dispatched without the regex and item is default data source', () => {
     it('then the state should include an extra default option', () => {
-      const plugins = getMockPlugins(3);
-      const sources: DataSourceInstanceSettings[] = plugins.map((p) => getDataSourceInstanceSetting(p.name, p));
+      const sources = toListItems(getMockPlugins(3));
       sources[1].isDefault = true;
 
       const { initialState } = getVariableTestContext<DataSourceVariableModel>(adapter, {

--- a/public/app/features/variables/datasource/reducer.ts
+++ b/public/app/features/variables/datasource/reducer.ts
@@ -1,7 +1,7 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
 import {
-  type DataSourceInstanceSettings,
+  type DataSourceInstanceListItem,
   type DataSourceVariableModel,
   matchPluginId,
   type VariableOption,
@@ -32,7 +32,7 @@ const dataSourceVariableSlice = createSlice({
   reducers: {
     createDataSourceOptions: (
       state: VariablesState,
-      action: PayloadAction<VariablePayload<{ sources: DataSourceInstanceSettings[]; regex: RegExp | undefined }>>
+      action: PayloadAction<VariablePayload<{ sources: DataSourceInstanceListItem[]; regex: RegExp | undefined }>>
     ) => {
       const { sources, regex } = action.payload.data;
       const options: VariableOption[] = [];
@@ -78,7 +78,7 @@ const dataSourceVariableSlice = createSlice({
   },
 });
 
-function isValid(source: DataSourceInstanceSettings, regex?: RegExp) {
+function isValid(source: DataSourceInstanceListItem, regex?: RegExp) {
   if (!regex) {
     return true;
   }
@@ -86,7 +86,7 @@ function isValid(source: DataSourceInstanceSettings, regex?: RegExp) {
   return regex.exec(source.name);
 }
 
-function isDefault(source: DataSourceInstanceSettings, regex?: RegExp) {
+function isDefault(source: DataSourceInstanceListItem, regex?: RegExp) {
   if (!source.isDefault) {
     return false;
   }

--- a/public/app/features/variables/query/actions.ts
+++ b/public/app/features/variables/query/actions.ts
@@ -1,6 +1,7 @@
 import { Subscription } from 'rxjs';
 
-import { getDataSourceSrv, toDataQueryError } from '@grafana/runtime';
+import { toDataQueryError } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { type ThunkResult } from 'app/types/store';
 
 import { getVariable } from '../state/selectors';
@@ -27,7 +28,7 @@ export const updateQueryVariableOptions = (
         return;
       }
 
-      const datasource = await getDataSourceSrv().get(variableInState.datasource ?? '');
+      const datasource = await getDataSourceInstance(variableInState.datasource ?? '');
 
       // We need to await the result from variableQueryRunner before moving on otherwise variables dependent on this
       // variable will have the wrong current value as input


### PR DESCRIPTION
- Migrates ad hoc filter key/value loading from `getDatasourceSrv().get()` to `getDataSourceInstance`
- Migrates datasource variable options from `getList()` to `getDataSourceInstanceList`, and updates the reducer payload type to slim `DataSourceInstanceListItem[]`
- Migrates query variable option updates from `getDataSourceSrv().get()` to `getDataSourceInstance`

Part of #127032