### PR TITLE
Dashboards: Migrate scene variable editors to async DataSource APIs

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1621,9 +1621,6 @@
     }
   },
   "public/app/features/dashboard-scene/settings/variables/components/QueryVariableForm.tsx": {
-    "@grafana/no-get-data-source-srv": {
-      "count": 1
-    },
     "react-hooks/exhaustive-deps": {
       "count": 1
     }
@@ -1641,26 +1638,8 @@
       "count": 1
     }
   },
-  "public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.tsx": {
-    "@grafana/no-get-data-source-srv": {
-      "count": 1
-    }
-  },
   "public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.tsx": {
-    "@grafana/no-get-data-source-srv": {
-      "count": 1
-    },
     "react-hooks/exhaustive-deps": {
-      "count": 1
-    }
-  },
-  "public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/QueryVariableEditor.tsx": {
-    "@grafana/no-get-data-source-srv": {
-      "count": 1
-    }
-  },
-  "public/app/features/dashboard-scene/settings/variables/utils.ts": {
-    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },

--- a/public/app/features/dashboard-scene/settings/VariablesEditView.test.tsx
+++ b/public/app/features/dashboard-scene/settings/VariablesEditView.test.tsx
@@ -190,11 +190,11 @@ describe('VariablesEditView', () => {
       errorSpy.mockRestore();
     });
 
-    it('should change the variable type creating a new variable object', () => {
+    it('should change the variable type creating a new variable object', async () => {
       const previousVariable = variableView.getVariables()[1] as CustomVariable;
       variableView.onEdit('customVar2');
 
-      variableView.onTypeChange('adhoc');
+      await variableView.onTypeChange('adhoc');
       expect(variableView.getVariables()).toHaveLength(3);
       const variable = variableView.getVariables()[1];
       expect(variable).not.toBe(previousVariable);
@@ -213,8 +213,8 @@ describe('VariablesEditView', () => {
       expect(variableView.state.editIndex).toBeUndefined();
     });
 
-    it('should add default new query variable when onAdd is called', () => {
-      variableView.onAdd();
+    it('should add default new query variable when onAdd is called', async () => {
+      await variableView.onAdd();
       expect(variableView.getVariables()).toHaveLength(4);
       expect(variableView.getVariables()[3].state.name).toBe('query0');
       expect(variableView.getVariables()[3].state.type).toBe('query');
@@ -268,7 +268,7 @@ describe('VariablesEditView', () => {
     });
 
     // FIXME: This is not working because the variable is replaced or it is not resolved yet
-    it.skip('should keep dependencies between variables the type is changed so the variable is replaced', () => {
+    it.skip('should keep dependencies between variables the type is changed so the variable is replaced', async () => {
       // Uses function to avoid store reference to previous existing variables
       const getSourceVariable = () => variableView.getVariables()[0] as CustomVariable;
       const getDependantVariable = () => variableView.getVariables()[1] as CustomVariable;
@@ -279,7 +279,7 @@ describe('VariablesEditView', () => {
 
       variableView.onEdit(getSourceVariable().state.name);
       // Simulating changing the type and update the value
-      variableView.onTypeChange('constant');
+      await variableView.onTypeChange('constant');
       getSourceVariable().setState({ value: 'newValue' });
 
       expect(getSourceVariable().getValue()).toBe('newValue');
@@ -297,7 +297,7 @@ describe('VariablesEditView', () => {
 
       variableView.onEdit(getSourceVariable().state.name);
       // Simulating changing the type and update the value
-      variableView.onTypeChange('constant');
+      await variableView.onTypeChange('constant');
       getSourceVariable().setState({ value: 'newValue' });
 
       expect(getSourceVariable().getValue()).toBe('newValue');

--- a/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
@@ -173,17 +173,17 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
     this.setState({ editIndex: variableIndex });
   };
 
-  public onAdd = () => {
+  public onAdd = async () => {
     const variables = this.getVariables();
     const variableIndex = variables.length;
     //add the new variable to the end of the array
-    const defaultNewVariable = getVariableDefault(variables);
+    const defaultNewVariable = await getVariableDefault(variables);
 
     this.getVariableSet().setState({ variables: [...this.getVariables(), defaultNewVariable] });
     this.setState({ editIndex: variableIndex });
   };
 
-  public onTypeChange = (type: EditableVariableType) => {
+  public onTypeChange = async (type: EditableVariableType) => {
     // Find the index of the variable to be deleted
     const variableIndex = this.state.editIndex ?? -1;
     const { variables } = this.getVariableSet().state;
@@ -196,7 +196,7 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
     }
 
     const { name, label } = variable.state;
-    const newVariable = getVariableScene(type, { name, label });
+    const newVariable = await getVariableScene(type, { name, label });
     this.replaceEditVariable(newVariable);
   };
 

--- a/public/app/features/dashboard-scene/settings/variables/VariableTypeSelectionPane.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableTypeSelectionPane.test.tsx
@@ -70,7 +70,7 @@ describe('VariableAddPane', () => {
     jest.restoreAllMocks();
   });
 
-  it('calls DashboardInteractions.variableTypeSelected when a variable type is clicked', () => {
+  it('calls DashboardInteractions.variableTypeSelected when a variable type is clicked', async () => {
     const variableTypeSelectedSpy = jest.spyOn(DashboardInteractions, 'variableTypeSelected');
     const dashboard = buildTestScene();
     const pane = new VariableAddPane({ sectionOwner: dashboard.getRef() });
@@ -84,10 +84,10 @@ describe('VariableAddPane', () => {
 
     getByRole('button', { name: /query/i }).click();
 
-    expect(variableTypeSelectedSpy).toHaveBeenCalledWith({ type: 'query' });
+    await waitFor(() => expect(variableTypeSelectedSpy).toHaveBeenCalledWith({ type: 'query' }));
   });
 
-  it('generates a non-conflicting name when an existing variable already exists', () => {
+  it('generates a non-conflicting name when an existing variable already exists', async () => {
     const dashboard = buildTestSceneWithExistingVar('custom0');
     const pane = new VariableAddPane({ sectionOwner: dashboard.getRef() });
     dashboard.state.sidebar.openPane(pane);
@@ -100,11 +100,13 @@ describe('VariableAddPane', () => {
 
     getByRole('button', { name: /custom/i }).click();
 
-    const dashboardVars = dashboard.state.$variables;
-    expect(dashboardVars).toBeInstanceOf(SceneVariableSet);
-    const vars = (dashboardVars as SceneVariableSet).state.variables;
-    expect(vars).toHaveLength(2);
-    expect(vars[1].state.name).toBe('custom1');
+    await waitFor(() => {
+      const dashboardVars = dashboard.state.$variables;
+      expect(dashboardVars).toBeInstanceOf(SceneVariableSet);
+      const vars = (dashboardVars as SceneVariableSet).state.variables;
+      expect(vars).toHaveLength(2);
+      expect(vars[1].state.name).toBe('custom1');
+    });
   });
 });
 

--- a/public/app/features/dashboard-scene/settings/variables/VariableTypeSelectionPane.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableTypeSelectionPane.tsx
@@ -53,7 +53,7 @@ export class VariableAddPane extends SceneObjectBase<VariableAddPaneState> imple
 
 function VariableAddPaneRenderer({ model }: SceneComponentProps<VariableAddPane>) {
   const onAddVariable = useCallback(
-    (type: EditableVariableType) => {
+    async (type: EditableVariableType) => {
       const dashboard = getDashboardSceneLike(model);
       const sectionOwner = model.state.sectionOwner.resolve();
       const existing = sectionOwner.state.$variables;
@@ -64,7 +64,9 @@ function VariableAddPaneRenderer({ model }: SceneComponentProps<VariableAddPane>
       }
 
       const sectionVars = variablesSet.state.variables ?? [];
-      const newVar = getVariableScene(type, { name: getNextAvailableId(getVariableNamePrefix(type), sectionVars) });
+      const newVar = await getVariableScene(type, {
+        name: getNextAvailableId(getVariableNamePrefix(type), sectionVars),
+      });
 
       addVariable({ source: variablesSet, addedObject: newVar });
 
@@ -113,7 +115,7 @@ function VariableTypeChangePaneRenderer({ model }: SceneComponentProps<VariableT
   const variable = model.state.variableRef.resolve();
 
   const onChangeVariableType = useCallback(
-    (type: EditableVariableType) => {
+    async (type: EditableVariableType) => {
       const variableSet = variable.parent;
       const dashboard = getDashboardSceneLike(variable);
 
@@ -126,7 +128,7 @@ function VariableTypeChangePaneRenderer({ model }: SceneComponentProps<VariableT
         return;
       }
 
-      const newVariable = getVariableScene(type, {
+      const newVariable = await getVariableScene(type, {
         name: variable.state.name,
         label: variable.state.label,
         key: variable.state.key,

--- a/public/app/features/dashboard-scene/settings/variables/components/QueryVariableForm.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/QueryVariableForm.test.tsx
@@ -48,6 +48,22 @@ jest.mock('@grafana/runtime', () => ({
   }),
 }));
 
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstance: jest.fn(async () => ({
+    ...defaultDatasource,
+    variables: {
+      getType: () => VariableSupportType.Custom,
+      query: jest.fn(),
+      editor: jest.fn().mockImplementation(LegacyVariableQueryEditor),
+    },
+  })),
+  getDataSourceInstanceSettings: jest.fn(async (ref: { uid?: string } | string) => {
+    const uid = typeof ref === 'string' ? ref : ref?.uid;
+    return uid === promDatasource.uid ? promDatasource : defaultDatasource;
+  }),
+}));
+
 const runRequestMock = jest.fn().mockReturnValue(
   of<PanelData>({
     state: LoadingState.Done,

--- a/public/app/features/dashboard-scene/settings/variables/components/QueryVariableForm.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/QueryVariableForm.tsx
@@ -9,7 +9,7 @@ import {
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceInstance, getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { type QueryVariable, type VariableValueOption } from '@grafana/scenes';
 import { type DataSourceRef, type VariableRefresh, type VariableSort } from '@grafana/schema';
 import { Field, FieldSet } from '@grafana/ui';
@@ -90,7 +90,7 @@ export function QueryVariableEditorForm({
   options,
 }: QueryVariableEditorFormProps) {
   const { value: dsConfig } = useAsync(async () => {
-    const datasource = await getDataSourceSrv().get(datasourceRef ?? '');
+    const datasource = await getDataSourceInstance(datasourceRef ?? '');
     const VariableQueryEditor = await getVariableQueryEditor(datasource);
     const defaultQuery = datasource?.variables?.getDefaultQuery?.();
 
@@ -102,7 +102,10 @@ export function QueryVariableEditorForm({
 
     // update data source if it is not defined in variable model
     if (!datasourceRef) {
-      const instanceSettings = getDataSourceSrv().getInstanceSettings({ type: datasource.type, uid: datasource.uid });
+      const instanceSettings = await getDataSourceInstanceSettings({
+        type: datasource.type,
+        uid: datasource.uid,
+      });
       if (instanceSettings) {
         onDataSourceChange(instanceSettings, true);
       }

--- a/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.test.tsx
@@ -80,6 +80,20 @@ jest.mock('@grafana/runtime', () => ({
   }),
 }));
 
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstance: jest.fn(async () => ({
+    ...defaultDatasource,
+    variables: {
+      getType: () => VariableSupportType.Custom,
+      query: jest.fn(),
+      editor: jest.fn().mockImplementation(LegacyVariableQueryEditor),
+    },
+    getTagKeys: getTagKeysMock,
+    getGroupByKeys: getGroupByKeysMock,
+  })),
+}));
+
 const runRequestMock = jest.fn().mockReturnValue(
   of<PanelData>({
     state: LoadingState.Done,

--- a/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.tsx
@@ -9,7 +9,8 @@ import {
   getDataSourceRef,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config, getDataSourceSrv, reportInteraction } from '@grafana/runtime';
+import { config, reportInteraction } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { AdHocFiltersVariable, type AdHocFilterWithLabels, type SceneVariable } from '@grafana/scenes';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 
@@ -100,7 +101,7 @@ export function AdHocFiltersVariableEditor(props: AdHocFiltersVariableEditorProp
   };
 
   const { value: datasourceSettings } = useAsync(async () => {
-    return await getDataSourceSrv().get(datasourceRef);
+    return await getDataSourceInstance(datasourceRef);
   }, [datasourceRef]);
 
   const message = datasourceSettings?.getTagKeys
@@ -115,7 +116,7 @@ export function AdHocFiltersVariableEditor(props: AdHocFiltersVariableEditorProp
 
   const onDataSourceChange = async (ds: DataSourceInstanceSettings) => {
     const dsRef = getDataSourceRef(ds);
-    const dsInstance = await getDataSourceSrv().get(dsRef);
+    const dsInstance = await getDataSourceInstance(dsRef);
 
     variable.setState({
       datasource: dsRef,

--- a/public/app/features/dashboard-scene/settings/variables/editors/DataSourceVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/DataSourceVariableEditor.test.tsx
@@ -1,6 +1,6 @@
 // add unit test for the DataSourceVariableEditor component
 
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { JSX } from 'react';
 
@@ -9,43 +9,48 @@ import { DataSourceVariable } from '@grafana/scenes';
 
 import { DataSourceVariableEditor } from './DataSourceVariableEditor';
 
-//mock getDataSorceSrv.getList() to return a list of datasources
+//mock getDataSourceInstanceList() to return a list of datasources
+const dsList = [
+  {
+    name: 'DataSourceInstance1',
+    uid: 'ds1',
+    meta: {
+      name: 'ds1',
+      id: 'dsTestDataSource',
+    },
+  },
+  {
+    name: 'DataSourceInstance2',
+    uid: 'ds2',
+    meta: {
+      name: 'ds1',
+      id: 'dsTestDataSource',
+    },
+  },
+  {
+    name: 'ABCDataSourceInstance',
+    uid: 'ds3',
+    meta: {
+      name: 'abDS',
+      id: 'ABCDS',
+    },
+  },
+];
+
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   getDataSourceSrv: () => ({
-    getList: () => {
-      return [
-        {
-          name: 'DataSourceInstance1',
-          uid: 'ds1',
-          meta: {
-            name: 'ds1',
-            id: 'dsTestDataSource',
-          },
-        },
-        {
-          name: 'DataSourceInstance2',
-          uid: 'ds2',
-          meta: {
-            name: 'ds1',
-            id: 'dsTestDataSource',
-          },
-        },
-        {
-          name: 'ABCDataSourceInstance',
-          uid: 'ds3',
-          meta: {
-            name: 'abDS',
-            id: 'ABCDS',
-          },
-        },
-      ];
-    },
+    getList: () => dsList,
   }),
 }));
 
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstanceList: jest.fn(async () => dsList),
+}));
+
 describe('DataSourceVariableEditor', () => {
-  it('shoud render correctly with multi and all not checked', () => {
+  it('shoud render correctly with multi and all not checked', async () => {
     const variable = new DataSourceVariable({
       name: 'dsVariable',
       type: 'datasource',
@@ -70,7 +75,7 @@ describe('DataSourceVariableEditor', () => {
       selectors.pages.Dashboard.Settings.Variables.Edit.DatasourceVariable.datasourceSelect
     );
     expect(typeSelect).toBeInTheDocument();
-    expect(typeSelect.textContent).toBe('ds1');
+    await waitFor(() => expect(typeSelect.textContent).toBe('ds1'));
     expect(multiCheckbox).toBeInTheDocument();
     expect(multiCheckbox).not.toBeChecked();
     expect(allowCustomValueCheckbox).toBeInTheDocument();
@@ -79,7 +84,7 @@ describe('DataSourceVariableEditor', () => {
     expect(includeAllCheckbox).not.toBeChecked();
   });
 
-  it('shoud render correctly with multi and includeAll checked', () => {
+  it('shoud render correctly with multi and includeAll checked', async () => {
     const variable = new DataSourceVariable({
       name: 'dsVariable',
       type: 'datasource',
@@ -103,7 +108,7 @@ describe('DataSourceVariableEditor', () => {
       selectors.pages.Dashboard.Settings.Variables.Edit.DatasourceVariable.datasourceSelect
     );
     expect(typeSelect).toBeInTheDocument();
-    expect(typeSelect.textContent).toBe('ds1');
+    await waitFor(() => expect(typeSelect.textContent).toBe('ds1'));
     expect(multiCheckbox).toBeInTheDocument();
     expect(multiCheckbox).toBeChecked();
     expect(includeAllCheckbox).toBeInTheDocument();
@@ -126,6 +131,7 @@ describe('DataSourceVariableEditor', () => {
     const typeSelect = getByTestId(
       selectors.pages.Dashboard.Settings.Variables.Edit.DatasourceVariable.datasourceSelect
     );
+    await waitFor(() => expect(typeSelect.textContent).toBe('ds1'));
     // when user change type datasource
     await user.click(typeSelect);
     await user.type(typeSelect, 'abDS');

--- a/public/app/features/dashboard-scene/settings/variables/editors/DataSourceVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/DataSourceVariableEditor.tsx
@@ -1,4 +1,5 @@
 import React, { type FormEvent } from 'react';
+import { useAsync } from 'react-use';
 import { lastValueFrom } from 'rxjs';
 
 import { type SelectableValue } from '@grafana/data';
@@ -19,7 +20,7 @@ interface DataSourceVariableEditorProps {
 export function DataSourceVariableEditor({ variable, onRunQuery }: DataSourceVariableEditorProps) {
   const { pluginId, regex, isMulti, allValue, includeAll, allowCustomValue } = variable.useState();
 
-  const optionTypes = getOptionDataSourceTypes();
+  const { value: optionTypes = [] } = useAsync(getOptionDataSourceTypes, []);
 
   const onChangeType = (option: SelectableValue) => {
     variable.setState({
@@ -102,7 +103,7 @@ interface InputProps {
 
 function DataSourceTypeSelect({ variable, id }: InputProps) {
   const { pluginId } = variable.useState();
-  const options = getOptionDataSourceTypes();
+  const { value: options = [] } = useAsync(getOptionDataSourceTypes, []);
 
   const onChange = async (value: ComboboxOption<string>) => {
     variable.setState({ pluginId: value.value });

--- a/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.test.tsx
@@ -45,6 +45,19 @@ jest.mock('@grafana/runtime', () => ({
   }),
 }));
 
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstance: jest.fn(async () => ({
+    ...defaultDatasource,
+    variables: {
+      getType: () => VariableSupportType.Custom,
+      query: jest.fn(),
+      editor: jest.fn().mockImplementation(LegacyVariableQueryEditor),
+    },
+    getGroupByKeys: mockGetGroupByKeys,
+  })),
+}));
+
 describe('GroupByVariableEditor', () => {
   beforeAll(() => {
     mockBoundingClientRect({

--- a/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.tsx
@@ -8,7 +8,7 @@ import {
   type SelectableValue,
   getDataSourceRef,
 } from '@grafana/data';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { GroupByVariable, type SceneVariable } from '@grafana/scenes';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 
@@ -25,7 +25,7 @@ export function GroupByVariableEditor(props: GroupByVariableEditorProps) {
   const { datasource: datasourceRef, defaultOptions, allowCustomValue = true, defaultValue } = variable.useState();
 
   const { value: datasource } = useAsync(async () => {
-    return await getDataSourceSrv().get(datasourceRef);
+    return await getDataSourceInstance(datasourceRef);
   }, [variable.state]);
 
   const { value: groupByKeys = [] } = useAsync(async () => {

--- a/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/QueryVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/QueryVariableEditor.test.tsx
@@ -55,6 +55,20 @@ jest.mock('@grafana/runtime', () => ({
   }),
 }));
 
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstance: jest.fn(async () => ({
+    ...defaultDatasource,
+    variables: {
+      getType: () => VariableSupportType.Custom,
+      query: jest.fn(),
+      editor: jest.fn().mockImplementation(LegacyVariableQueryEditor),
+      getDefaultQuery: () => 'default-query',
+    },
+  })),
+  getDataSourceInstanceSettings: jest.fn(async () => ({ ...defaultDatasource })),
+}));
+
 const runRequestMock = jest.fn().mockReturnValue(
   of<PanelData>({
     state: LoadingState.Done,

--- a/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/QueryVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/QueryVariableEditor.tsx
@@ -9,7 +9,7 @@ import {
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { type QueryVariable, sceneGraph } from '@grafana/scenes';
 import { type VariableRefresh, type VariableSort } from '@grafana/schema';
 import { Field, Stack } from '@grafana/ui';
@@ -156,7 +156,7 @@ export function Editor({ variable, hideRefresh, hideStaticOptions, hidePreview }
   } = variable.useState();
   const { value: timeRange } = sceneGraph.getTimeRange(variable).useState();
   const { value: dsConfig } = useAsync(async () => {
-    const datasource = await getDataSourceSrv().get(datasourceRef ?? '');
+    const datasource = await getDataSourceInstance(datasourceRef ?? '');
     const VariableQueryEditor = await getVariableQueryEditor(datasource);
     const defaultQuery = datasource?.variables?.getDefaultQuery?.();
 

--- a/public/app/features/dashboard-scene/settings/variables/utils.test.ts
+++ b/public/app/features/dashboard-scene/settings/variables/utils.test.ts
@@ -87,6 +87,13 @@ jest.mock('@grafana/runtime', () => ({
   }),
 }));
 
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstance: jest.fn(async () => dsMock),
+  getDataSourceInstanceSettings: jest.fn(async (ref: string | null) => (ref === null ? defaultDsSettings : undefined)),
+  getDataSourceInstanceList: jest.fn(async () => [defaultDsSettings]),
+}));
+
 describe('isEditableVariableType', () => {
   it('should return true for editable variable types', () => {
     const editableTypes: VariableType[] = [
@@ -313,8 +320,8 @@ describe('getVariableScene', () => {
 
   it.each(Object.keys(editableVariables) as EditableVariableType[])(
     'should define a scene object for every variable type',
-    (type) => {
-      const variable = getVariableScene(type, { name: 'foo' });
+    async (type) => {
+      const variable = await getVariableScene(type, { name: 'foo' });
       expect(variable).toBeDefined();
     }
   );
@@ -327,17 +334,17 @@ describe('getVariableScene', () => {
     ['adhoc', AdHocFiltersVariable],
     ['groupby', GroupByVariable],
     ['textbox', TextBoxVariable],
-  ])('should return the scene variable instance for the given editable variable type', (type, instanceType) => {
+  ])('should return the scene variable instance for the given editable variable type', async (type, instanceType) => {
     const initialState = { name: 'MyVariable' };
-    const sceneVariable = getVariableScene(type as EditableVariableType, initialState);
+    const sceneVariable = await getVariableScene(type as EditableVariableType, initialState);
     expect(sceneVariable).toBeInstanceOf(instanceType);
     expect(sceneVariable.state.name).toBe(initialState.name);
     expect(sceneVariable.state.hide).toBe(undefined);
   });
 
-  it('should return the scene variable instance for the constant editable variable type', () => {
+  it('should return the scene variable instance for the constant editable variable type', async () => {
     const initialState = { name: 'MyVariable' };
-    const sceneVariable = getVariableScene('constant' as EditableVariableType, initialState);
+    const sceneVariable = await getVariableScene('constant' as EditableVariableType, initialState);
     expect(sceneVariable).toBeInstanceOf(ConstantVariable);
     expect(sceneVariable.state.name).toBe(initialState.name);
     expect(sceneVariable.state.hide).toBe(VariableHide.hideVariable);
@@ -421,8 +428,8 @@ describe('getDefinition', () => {
 });
 
 describe('getOptionDataSourceTypes', () => {
-  it('should return all data source types when no data source types are specified', () => {
-    const optionTypes = getOptionDataSourceTypes();
+  it('should return all data source types when no data source types are specified', async () => {
+    const optionTypes = await getOptionDataSourceTypes();
     expect(optionTypes).toHaveLength(1);
     expect(optionTypes[0].label).toBe('ds1');
   });
@@ -460,12 +467,12 @@ describe('getNextAvailableId', () => {
 });
 
 describe('getVariableDefault', () => {
-  it('should return a QueryVariable instance with the correct name', () => {
+  it('should return a QueryVariable instance with the correct name', async () => {
     const sceneVariables = new SceneVariableSet({
       variables: [],
     });
 
-    const defaultVariable = getVariableDefault(sceneVariables.state.variables);
+    const defaultVariable = await getVariableDefault(sceneVariables.state.variables);
 
     expect(defaultVariable).toBeInstanceOf(QueryVariable);
     expect(defaultVariable.state.name).toBe('query0');

--- a/public/app/features/dashboard-scene/settings/variables/utils.ts
+++ b/public/app/features/dashboard-scene/settings/variables/utils.ts
@@ -1,8 +1,9 @@
 import { chain } from 'lodash';
 
-import { type DataSourceInstanceSettings, getDataSourceRef, type SelectableValue } from '@grafana/data';
+import { type SelectableValue, getDataSourceRef } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config, getDataSourceSrv } from '@grafana/runtime';
+import { config } from '@grafana/runtime';
+import { getDataSourceInstanceList, getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import {
   ConstantVariable,
   CustomVariable,
@@ -231,12 +232,12 @@ export interface CommonVariableProperties {
   key?: string;
 }
 
-function getDefaultDatasourceRef(): DataSourceRef | undefined {
-  const defaultDs = getDataSourceSrv().getInstanceSettings(null);
+async function getDefaultDatasourceRef(): Promise<DataSourceRef | undefined> {
+  const defaultDs = await getDataSourceInstanceSettings(null);
   return defaultDs ? getDataSourceRef(defaultDs) : undefined;
 }
 
-export function getVariableScene(type: EditableVariableType, initialState: CommonVariableProperties) {
+export async function getVariableScene(type: EditableVariableType, initialState: CommonVariableProperties) {
   switch (type) {
     case 'custom':
       return new CustomVariable(initialState);
@@ -245,7 +246,7 @@ export function getVariableScene(type: EditableVariableType, initialState: Commo
       // this matches the behavior in Settings -> Variables -> Add Variable
       // otherwise v2 transformer to save model will treat the variable as auto-assigned and
       // not include it in the save model
-      const datasource = getDefaultDatasourceRef();
+      const datasource = await getDefaultDatasourceRef();
       return new QueryVariable({ ...initialState, ...(datasource && { datasource }) });
     }
     case 'constant':
@@ -267,7 +268,7 @@ export function getVariableScene(type: EditableVariableType, initialState: Commo
   }
 }
 
-export function getVariableDefault(variables: Array<SceneVariable<SceneVariableState>>) {
+export async function getVariableDefault(variables: Array<SceneVariable<SceneVariableState>>) {
   const nextVariableIdName = getNextAvailableId('query', variables);
   return getVariableScene('query', { name: nextVariableIdName });
 }
@@ -313,12 +314,12 @@ export function getDefinition(model: SceneVariable): string {
   return definition;
 }
 
-export function getOptionDataSourceTypes() {
-  const datasources = getDataSourceSrv().getList({ metrics: true, variables: true });
+export async function getOptionDataSourceTypes() {
+  const datasources = await getDataSourceInstanceList({ metrics: true, variables: true });
 
   const optionTypes = chain(datasources)
     .uniqBy('meta.id')
-    .map((ds: DataSourceInstanceSettings) => {
+    .map((ds) => {
       return { label: ds.meta.name, value: ds.meta.id };
     })
     .value();

--- a/public/app/features/dashboard-scene/sidebar/SectionFiltersList.tsx
+++ b/public/app/features/dashboard-scene/sidebar/SectionFiltersList.tsx
@@ -71,7 +71,7 @@ function AddFilterButton({ sectionOwner }: { sectionOwner: SceneObject }) {
       size="sm"
       variant="secondary"
       onClick={() => {
-        openAddFilterForm(dashboard, sectionOwner);
+        void openAddFilterForm(dashboard, sectionOwner);
         DashboardInteractions.addSectionFilterButtonClicked({ source: 'edit_pane' });
       }}
     >

--- a/public/app/features/dashboard-scene/sidebar/add-new/AddFilters.test.tsx
+++ b/public/app/features/dashboard-scene/sidebar/add-new/AddFilters.test.tsx
@@ -19,12 +19,12 @@ describe('openAddFilterForm', () => {
     addVariableMock.mockClear();
   });
 
-  it('adds an adhoc filter to the dashboard variable set', () => {
+  it('adds an adhoc filter to the dashboard variable set', async () => {
     const variableSet = new SceneVariableSet({ variables: [] });
     const dashboard = new DashboardScene({ $variables: variableSet, isEditing: true });
     jest.spyOn(dashboard.state.sidebar, 'selectObject');
 
-    openAddFilterForm(dashboard, dashboard);
+    await openAddFilterForm(dashboard, dashboard);
 
     expect(addVariableMock).toHaveBeenCalledTimes(1);
     const { source, addedObject } = addVariableMock.mock.calls[0][0];
@@ -33,7 +33,7 @@ describe('openAddFilterForm', () => {
     expect(dashboard.state.sidebar.selectObject).toHaveBeenCalledWith(addedObject, { force: true, multi: false });
   });
 
-  it('adds an adhoc filter to a section variable set', () => {
+  it('adds an adhoc filter to a section variable set', async () => {
     const sectionVarSet = new SceneVariableSet({ variables: [] });
     const row = new RowItem({
       $variables: sectionVarSet,
@@ -45,7 +45,7 @@ describe('openAddFilterForm', () => {
     });
     jest.spyOn(dashboard.state.sidebar, 'selectObject');
 
-    openAddFilterForm(dashboard, row);
+    await openAddFilterForm(dashboard, row);
 
     expect(addVariableMock).toHaveBeenCalledTimes(1);
     const { source, addedObject } = addVariableMock.mock.calls[0][0];
@@ -54,7 +54,7 @@ describe('openAddFilterForm', () => {
     expect(dashboard.state.sidebar.selectObject).toHaveBeenCalledWith(addedObject, { force: true, multi: false });
   });
 
-  it('creates a variable set on the section if none exists', () => {
+  it('creates a variable set on the section if none exists', async () => {
     const row = new RowItem({ layout: AutoGridLayoutManager.createEmpty() });
     const dashboard = new DashboardScene({
       body: new RowsLayoutManager({ rows: [row] }),
@@ -64,7 +64,7 @@ describe('openAddFilterForm', () => {
 
     expect(row.state.$variables).toBeUndefined();
 
-    openAddFilterForm(dashboard, row);
+    await openAddFilterForm(dashboard, row);
 
     expect(row.state.$variables).toBeInstanceOf(SceneVariableSet);
     expect(addVariableMock).toHaveBeenCalledTimes(1);
@@ -73,7 +73,7 @@ describe('openAddFilterForm', () => {
     expect(addedObject).toBeInstanceOf(AdHocFiltersVariable);
   });
 
-  it('generates a unique name when filters already exist', () => {
+  it('generates a unique name when filters already exist', async () => {
     const existingFilter = new AdHocFiltersVariable({ name: 'filter0', type: 'adhoc' });
     const sectionVarSet = new SceneVariableSet({ variables: [existingFilter] });
     const row = new RowItem({
@@ -86,7 +86,7 @@ describe('openAddFilterForm', () => {
     });
     jest.spyOn(dashboard.state.sidebar, 'selectObject');
 
-    openAddFilterForm(dashboard, row);
+    await openAddFilterForm(dashboard, row);
 
     const { addedObject } = addVariableMock.mock.calls[0][0];
     expect(addedObject.state.name).not.toBe('filter0');

--- a/public/app/features/dashboard-scene/sidebar/add-new/AddFilters.tsx
+++ b/public/app/features/dashboard-scene/sidebar/add-new/AddFilters.tsx
@@ -10,7 +10,7 @@ import { DashboardInteractions } from '../../utils/interactions';
 
 import { AddButton } from './AddButton';
 
-export function openAddFilterForm(dashboard: DashboardSceneLike, sectionOwner: SceneObject) {
+export async function openAddFilterForm(dashboard: DashboardSceneLike, sectionOwner: SceneObject) {
   const existing = sectionOwner.state.$variables;
   const variablesSet = existing instanceof SceneVariableSet ? existing : new SceneVariableSet({ variables: [] });
 
@@ -20,7 +20,7 @@ export function openAddFilterForm(dashboard: DashboardSceneLike, sectionOwner: S
 
   const type = 'adhoc';
   const name = getVariableNamePrefix(type);
-  const newVar = getVariableScene(type, {
+  const newVar = await getVariableScene(type, {
     name: getNextAvailableId(name, variablesSet.state.variables ?? []),
   });
 
@@ -30,7 +30,7 @@ export function openAddFilterForm(dashboard: DashboardSceneLike, sectionOwner: S
 
 export function AddFilters({ dashboardScene }: { dashboardScene: DashboardSceneLike }) {
   const onAddFiltersClick = useCallback(() => {
-    openAddFilterForm(dashboardScene, dashboardScene);
+    void openAddFilterForm(dashboardScene, dashboardScene);
     DashboardInteractions.addFilterButtonClicked({ source: 'edit_pane' });
   }, [dashboardScene]);
 

--- a/public/app/features/dashboard-scene/sidebar/dashboard/DashboardFiltersList.tsx
+++ b/public/app/features/dashboard-scene/sidebar/dashboard/DashboardFiltersList.tsx
@@ -96,7 +96,7 @@ const renderItemLabel = (v: SceneVariable) => <span data-testid="filter-name">{v
 
 export function AddFilterButton({ dashboard }: { dashboard: DashboardScene }) {
   const onAddFilter = useCallback(() => {
-    openAddFilterForm(dashboard, dashboard);
+    void openAddFilterForm(dashboard, dashboard);
     DashboardInteractions.addFilterButtonClicked({ source: 'edit_pane' });
   }, [dashboard]);
 

--- a/public/app/features/variables-management/VariableEditorView.tsx
+++ b/public/app/features/variables-management/VariableEditorView.tsx
@@ -5,7 +5,7 @@ import { useSearchParams } from 'react-router-dom-v5-compat';
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { EmbeddedScene, SceneFlexLayout, SceneTimeRange, type SceneVariable, SceneVariableSet } from '@grafana/scenes';
-import { Button, ConfirmModal, Field, Stack, useStyles2 } from '@grafana/ui';
+import { Button, ConfirmModal, Field, Spinner, Stack, useStyles2 } from '@grafana/ui';
 import {
   useCreateVariableMutation,
   useDeleteVariableMutation,
@@ -56,6 +56,50 @@ export interface VariableEditorViewProps {
  */
 export function VariableEditorView({ source, existingNames = [], onBack }: VariableEditorViewProps) {
   const styles = useStyles2(getStyles);
+  const [defaultName] = useState(() => getNextAvailableVariableName('query', existingNames));
+  const [initialVariable, setInitialVariable] = useState<SceneVariable | undefined>(() =>
+    source
+      ? // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        createSceneVariableFromVariableModel(getVariableKind(source) as TypedVariableModelV2)
+      : undefined
+  );
+
+  useEffect(() => {
+    if (initialVariable) {
+      return;
+    }
+
+    let cancelled = false;
+    getVariableScene('query', { name: defaultName }).then((variable) => {
+      if (!cancelled) {
+        setInitialVariable(variable);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [defaultName, initialVariable]);
+
+  if (!initialVariable) {
+    return (
+      <div className={styles.container}>
+        <Spinner />
+      </div>
+    );
+  }
+
+  return <VariableEditorLoaded source={source} onBack={onBack} initialVariable={initialVariable} />;
+}
+
+interface VariableEditorLoadedProps {
+  source?: Variable;
+  onBack: () => void;
+  initialVariable: SceneVariable;
+}
+
+function VariableEditorLoaded({ source, onBack, initialVariable }: VariableEditorLoadedProps) {
+  const styles = useStyles2(getStyles);
   const isNew = !source;
   const allowGlobalScope = canManageGlobalVariables();
   const [searchParams] = useSearchParams();
@@ -73,12 +117,7 @@ export function VariableEditorView({ source, existingNames = [], onBack }: Varia
     }
     return allowGlobalScope ? '' : undefined;
   });
-  const [sceneVariable, setSceneVariable] = useState<SceneVariable>(() =>
-    source
-      ? // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        createSceneVariableFromVariableModel(getVariableKind(source) as TypedVariableModelV2)
-      : getVariableScene('query', { name: getNextAvailableVariableName('query', existingNames) })
-  );
+  const [sceneVariable, setSceneVariable] = useState(initialVariable);
 
   const [createVariable, { isLoading: isCreating }] = useCreateVariableMutation();
   const [updateVariable, { isLoading: isUpdating }] = useUpdateVariableMutation();
@@ -154,9 +193,9 @@ export function VariableEditorView({ source, existingNames = [], onBack }: Varia
     return deactivate;
   }, [scene]);
 
-  const onTypeChange = (type: EditableVariableType) => {
+  const onTypeChange = async (type: EditableVariableType) => {
     const { name, label } = sceneVariable.state;
-    setSceneVariable(getVariableScene(type, { name, label }));
+    setSceneVariable(await getVariableScene(type, { name, label }));
     // The new scene carries over the last committed (valid) name.
     setHasNameError(false);
   };


### PR DESCRIPTION
- Migrates query/adhoc/groupby scene variable editors from `getDataSourceSrv` to async `getDataSourceInstance*` APIs
- Makes `getVariableScene` / `getOptionDataSourceTypes` async and updates callers (add variable, type change, filters sidebar)
- Updates related unit tests to mock `@grafana/runtime/unstable`

Part of #127032