### PR TITLE
Chore: Resolve bundle size stats against a configurable build directory

### DIFF
--- a/scripts/cli/reportBundleSizeStats.mts
+++ b/scripts/cli/reportBundleSizeStats.mts
@@ -3,7 +3,18 @@ import path, { dirname } from 'path';
 import { fileURLToPath } from 'url';
 
 const REPO_ROOT = path.resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
-const BUILD_DIR = path.join(REPO_ROOT, 'public', 'build');
+
+/**
+ * The publicPath every manifest value is prefixed with. Bundlers share one URL space, so this stays
+ * the same even when a build writes its output somewhere other than public/build.
+ */
+const PUBLIC_PATH = 'public/build/';
+
+/**
+ * Where the build wrote its output, relative to the repo root. Pass a different directory to measure
+ * a build that does not write to public/build, e.g. `yarn bundle-size:stats public/build-rspack`.
+ */
+const BUILD_DIR = path.resolve(REPO_ROOT, process.argv[2] || 'public/build');
 
 /**
  * The production builds we emit. The names are used as the metric prefix.
@@ -39,18 +50,22 @@ async function readEntrypoints(manifestPath: string): Promise<Record<string, Ent
 }
 
 /**
- * Asset paths in the manifest include the webpack publicPath (public/build/), which makes them
- * relative to the repo root.
+ * Manifest values are URLs, not disk paths. Strip the publicPath prefix so each asset resolves
+ * inside the build directory, wherever that build happened to write it.
  */
 async function totalSize(assetPaths: Iterable<string>) {
   let size = 0;
 
   for (const assetPath of assetPaths) {
-    const stats = await stat(path.join(REPO_ROOT, assetPath));
+    const stats = await stat(path.join(BUILD_DIR, stripPublicPath(assetPath)));
     size += stats.size;
   }
 
   return size;
+}
+
+function stripPublicPath(assetPath: string) {
+  return assetPath.startsWith(PUBLIC_PATH) ? assetPath.slice(PUBLIC_PATH.length) : assetPath;
 }
 
 function logStat(name: string, value: string | number) {


### PR DESCRIPTION
**What is this feature?**

`reportBundleSizeStats.mts` now takes an optional build directory argument (default `public/build`), and strips the `public/build/` publicPath prefix from manifest values before resolving them on disk.

**Why do we need this feature?**

The manifest stores URLs. The script treated them as repo-root-relative disk paths, which only works while webpack's output directory equals its publicPath. The rspack build breaks that identity deliberately — output goes to `public/build-rspack`, publicPath stays `public/build/` — so every `stat` throws ENOENT.

**Who is this feature for?**

No user-facing impact. Unblocks bundle size metrics for the rspack build.

**Which issue(s) does this PR fix?**:

None filed. Groundwork for #128309; build directory split described in #130433.

**Special notes for your reviewer:**

No behaviour change today: CI passes no argument, and output is byte-identical against the same `yarn build`. stdout format unchanged — `ci-frontend-metrics.sh` parses it.

Verified with a real `yarn build`. The split-directory case is verified by simulation (webpack output moved to `public/build-rspack`), since `build:rspack` doesn't exist on main yet — whoever lands the rspack build config should confirm against a real one.

No toggle, no docs.
