### PR TITLE
AuthN: pass context to AllowUserMapping

### DIFF
--- a/pkg/services/authn/authnimpl/sync/user_sync.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync.go
@@ -511,7 +511,7 @@ func (s *UserSync) updateUserAttributes(ctx context.Context, usr *user.User, id 
 
 	needsConnectionCreation := userAuth == nil
 
-	if errProtection := s.userProtectionService.AllowUserMapping(usr, id.AuthenticatedBy); errProtection != nil {
+	if errProtection := s.userProtectionService.AllowUserMapping(ctx, usr, id.AuthenticatedBy); errProtection != nil {
 		span.RecordError(errProtection)
 		span.SetStatus(codes.Error, errProtection.Error())
 		return errUserProtection.Errorf("user mapping not allowed: %w", errProtection)

--- a/pkg/services/login/authinfoimpl/userprotection.go
+++ b/pkg/services/login/authinfoimpl/userprotection.go
@@ -13,7 +13,7 @@ func ProvideOSSUserProtectionService() *OSSUserProtectionImpl {
 	return &OSSUserProtectionImpl{}
 }
 
-func (*OSSUserProtectionImpl) AllowUserMapping(_ *user.User, _ string) error {
+func (*OSSUserProtectionImpl) AllowUserMapping(_ context.Context, _ *user.User, _ string) error {
 	return nil
 }
 

--- a/pkg/services/login/userprotection.go
+++ b/pkg/services/login/userprotection.go
@@ -7,6 +7,6 @@ import (
 )
 
 type UserProtectionService interface {
-	AllowUserMapping(user *user.User, authModule string) error
+	AllowUserMapping(ctx context.Context, user *user.User, authModule string) error
 	ShouldProtect(ctx context.Context, user *user.User) (bool, error)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

**Why:** `UserProtectionService.AllowUserMapping` took no request context, so the enterprise implementation had to call `GetAuthInfo` / `GetUserOrgList` with `context.TODO()`. That works in single-tenant Grafana, but multi-tenant authn resolves the DB from the request namespace. Without a context, protected-user mapping checks fail with a missing-namespace error and can break those logins.

**What:**
- Add `context.Context` to `login.UserProtectionService.AllowUserMapping`
- Pass the request context from `UserSync.updateUserAttributes`
- Update the OSS no-op implementation

**Which issue(s) this PR fixes**:

N/A (enables a companion enterprise change)

**Special notes for your reviewer**:

Interface-only for OSS callers today; the enterprise `userprotection` implementation needs to consume the new context argument.

Test plan:
- [ ] OSS builds with the updated interface
- [ ] Existing user sync tests still pass