### PR TITLE
Alerting docs: Alertmanager import wizard

### DIFF
--- a/docs/sources/alerting/alerting-rules/alerting-migration.md
+++ b/docs/sources/alerting/alerting-rules/alerting-migration.md
@@ -30,6 +30,31 @@ refs:
       destination: /docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/create-recording-rules/create-grafana-managed-recording-rules/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/create-recording-rules/create-grafana-managed-recording-rules/
+  import-alertmanager-configuration:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/import-alertmanager-configuration/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/set-up/import-alertmanager-configuration/
+  convert-api:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/convert-api/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/set-up/convert-api/
+  convert-api-headers:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/convert-api/#rule-import-headers
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/set-up/convert-api/#rule-import-headers
+  convert-api-disable-provenance:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/convert-api/#x-disable-provenance
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/set-up/convert-api/#x-disable-provenance
+  convert-api-datasource-uid:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/convert-api/#x-grafana-alerting-datasource-uid
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/set-up/convert-api/#x-grafana-alerting-datasource-uid
 ---
 
 # Import data source-managed rules to Grafana-managed rules
@@ -45,6 +70,8 @@ This guide explains two methods for importing data source-managed rules:
 Importing rules is a safe operation: the original data source–managed rules remain intact in their original location. During import, the rules are converted into Grafana-managed rules while preserving their configuration and behavior.
 
 Choose the method that best fits your workflow. As a best practice, test and validate your import process before migrating all alert rules.
+
+This guide covers alert rules and recording rules. To import notification configuration such as contact points, notification policies, templates, and time intervals, refer to [import Alertmanager configuration to Grafana](ref:import-alertmanager-configuration).
 
 ## How it works
 
@@ -98,7 +125,7 @@ You can use the Grafana Alerting user interface to import rules from the followi
 
 Imported rules using this method are editable in the user interface. Like regular Grafana-managed rules, you can later export them for provisioning.
 
-#### Before you begin
+### Before you begin
 
 To use Grafana Alerting to migrate rules, you need the following [RBAC permissions](/docs/grafana/latest/administration/roles-and-permissions/access-control/):
 
@@ -151,9 +178,9 @@ Both tools provide `rules` commands to import rules groups. For example:
 - `rules load` can import rule groups from files.
 - `rules sync` can read rule files and applies only the differences compared to existing Grafana-managed rules. This is useful for automation workflows and pipelines.
 
-By default, rules imported using the API or command-line tools are **Provisioned** and not editable in the user interface. To make them editable, enable the [X-Disable-Provenance](#x-disable-provenance) header.
+By default, rules imported using the API or command-line tools are **Provisioned** and not editable in the user interface. To make them editable, enable the [X-Disable-Provenance](ref:convert-api-disable-provenance) header.
 
-#### Before you begin
+### Before you begin
 
 You need to have installed [`mimirtool`](/docs/mimir/latest/manage/tools/mimirtool/) or [`cortextool`](https://github.com/grafana/cortex-tools) (version `0.11.3` or later).
 
@@ -180,7 +207,7 @@ mimirtool rules load rule_file.yaml \
 This command imports Prometheus alert rules defined in `rule_file.yaml` as Grafana-managed alert rules. It's important to know that:
 
 1. When using the `<GRAFANA_BASE_URL>/api/convert/` endpoint, `mimirtool` interacts with Grafana—not with a Mimir instance. In this case, `MIMIR_TENANT_ID` must always be set to `1`.
-1. The [`X-Grafana-Alerting-Datasource-UID` header](#x-grafana-alerting-datasource-uid) configures the data source that the imported alert rules will query. Use multiple `--extra-headers` flags to include other [optional headers](#optional-headers).
+1. The [`X-Grafana-Alerting-Datasource-UID` header](ref:convert-api-datasource-uid) configures the data source that the imported alert rules will query. Use multiple `--extra-headers` flags to include other [optional headers](ref:convert-api-headers).
 
 Similarly, the `rules sync` command can import and update Grafana-managed alert rules.
 
@@ -216,112 +243,6 @@ cortextool rules load loki_rules.yaml \
   --backend=loki
 ```
 
-### Optional Headers
+## API endpoints and headers
 
-Additional configuration headers for more granular import control include the following:
-
-#### `X-Disable-Provenance`
-
-When this header is set to `true`:
-
-- The imported rules are not marked as provisioned.
-- They can then be edited in the Grafana UI.
-- They are excluded from the `GET` and `DELETE` operations on the [`/api/convert` endpoints](#compatible-endpoints).
-
-Do not enable this header when using the `rules sync` command, as it relies on the `GET` and `DELETE` operations to detect and update existing rules.
-
-#### `X-Grafana-Alerting-Alert-Rules-Paused`
-
-Set to `true` to import alert rules in paused state.
-
-#### `X-Grafana-Alerting-Recording-Rules-Paused`
-
-Set to `true` to import recording rules in paused state.
-
-#### `X-Grafana-Alerting-Datasource-UID`
-
-The UID of the data source to use for alert rule queries.
-
-If not specified in the header, Grafana uses the configured default from `unified_alerting.prometheus_conversion.default_datasource_uid`. If neither the header nor the configuration option is provided, the request fails.
-
-#### `X-Grafana-Alerting-Target-Datasource-UID`
-
-The UID of the target data source for recording rules. If not specified, the value from `X-Grafana-Alerting-Datasource-UID` is used.
-
-#### `X-Grafana-Alerting-Folder-UID`
-
-Enter the UID of the target destination folder for imported rules.
-
-#### `X-Grafana-Alerting-Notification-Settings`
-
-JSON-encoded [`AlertRuleNotificationSettings` object](#alertrulenotificationsettings-object) that allows setting the contact point for the alert rules.
-
-{{< collapse title="AlertRuleNotificationSettings object" >}}
-
-##### AlertRuleNotificationSettings object
-
-When you set `X-Grafana-Alerting-Notification-Settings`, the header value must be a JSON-encoded object with the following keys:
-
-| Field                   | Type       | Required | Example                                    | Description                                                                                             |
-| ----------------------- | ---------- | -------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
-| `receiver`              | `string`   | Yes      | `"grafana-default"`                        | Name of the contact point (receiver) to which alerts are routed. Must exist in Grafana before import.   |
-| `group_by`              | `[]string` | No       | `["alertname","grafana_folder","cluster"]` | Label set used by Alertmanager to aggregate alerts into a single notification.                          |
-| `group_wait`            | `duration` | No       | `"30s"`                                    | How long Alertmanager waits before sending the first notification for a new group.                      |
-| `group_interval`        | `duration` | No       | `"5m"`                                     | Time to wait before adding new alerts to an existing group's next notification.                         |
-| `repeat_interval`       | `duration` | No       | `"4h"`                                     | Minimum time before a previously-sent notification is repeated. Must not be less than `group_interval`. |
-| `mute_time_intervals`   | `[]string` | No       | `["maintenance"]`                          | One or more mute time interval names that silence alerts during those windows.                          |
-| `active_time_intervals` | `[]string` | No       | `["maintenance"]`                          | List of active time interval names. Alerts are suppressed unless the current time matches one of them.  |
-
-{{< /collapse >}}
-
-### Compatible endpoints
-
-The API endpoints listed in this section are supported in Grafana and are used by `mimirtool` and `cortextool`, as shown earlier. These endpoints are compatible with [Mimir HTTP API](/docs/mimir/latest/references/http-api/).
-
-In these endpoints, a "namespace" corresponds to a folder title in Grafana.
-
-The `POST` endpoints can be used to import data source–managed alert rules. They accept requests in both YAML and JSON. If no media type is specified, YAML is assumed.
-
-| Endpoint | Method                                                | Summary                                                                                                                                                                                         | Mimir equivalent                                                         |
-| -------- | ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| POST     | `/convert/prometheus/config/v1/rules`                 | [Create or update multiple rule groups](#create-or-update-multiple-rule-groups) across multiple namespaces. Requires [`X-Grafana-Alerting-Datasource-UID`](#x-grafana-alerting-datasource-uid). | None                                                                     |
-| POST     | `/convert/prometheus/config/v1/rules/:namespaceTitle` | Create or update a single rule group in a namespace. Requires [`X-Grafana-Alerting-Datasource-UID`](#x-grafana-alerting-datasource-uid).                                                        | [Set rule group](/docs/mimir/latest/references/http-api/#set-rule-group) |
-
-The `GET` and `DELETE` endpoints work only with provisioned and imported alert rules. All `GET` endpoints support both JSON and YAML response formats based on the `Accept` header: use `application/json` for JSON responses, or `application/yaml` for YAML responses. YAML is the default format when no `Accept` header is specified.
-
-| Endpoint | Method                                                       | Summary                                             | Mimir equivalent                                                                                     |
-| -------- | ------------------------------------------------------------ | --------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| GET      | `/convert/prometheus/config/v1/rules`                        | Get all imported rule groups across all namespaces. | [List rule groups](/docs/mimir/latest/references/http-api/#list-rule-groups)                         |
-| GET      | `/convert/prometheus/config/v1/rules/:namespaceTitle`        | Get imported rule groups in a specific namespace.   | [Get rule groups by namespace](/docs/mimir/latest/references/http-api/#get-rule-groups-by-namespace) |
-| GET      | `/convert/prometheus/config/v1/rules/:namespaceTitle/:group` | Get imported rule group in a specific namespace.    | [Get rule group](/docs/mimir/latest/references/http-api/#get-rule-group)                             |
-| DELETE   | `/convert/prometheus/config/v1/rules/:namespaceTitle`        | Delete all imported alert rules in a namespace.     | [Delete namespace](/docs/mimir/latest/references/http-api/#delete-namespace)                         |
-| DELETE   | `/convert/prometheus/config/v1/rules/:namespaceTitle/:group` | Delete a specific imported rule group.              | [Delete rule group](/docs/mimir/latest/references/http-api/#delete-rule-group)                       |
-
-#### Create or update multiple rule groups
-
-```
-POST /convert/prometheus/config/v1/rules
-```
-
-Creates or updates multiple rule groups across multiple namespaces. This endpoint expects a request with a map of namespace titles to arrays of rule groups, and returns `202` on success.
-
-This endpoint has no Mimir equivalent and is Grafana-specific for bulk operations.
-
-##### Example request body
-
-```yaml
-namespace1:
-  - name: MyGroupName1
-    rules:
-      - alert: MyAlertName1
-        expr: up == 0
-        labels:
-          severity: warning
-namespace2:
-  - name: MyGroupName2
-    rules:
-      - alert: MyAlertName2
-        expr: rate(http_requests_total[5m]) > 0.1
-        labels:
-          severity: critical
-```
+The command-line tools call the Grafana convert API, which you can also call directly. For its endpoints and the optional headers that control the import, refer to [Convert API](ref:convert-api).

--- a/docs/sources/alerting/set-up/configure-alertmanager/_index.md
+++ b/docs/sources/alerting/set-up/configure-alertmanager/_index.md
@@ -51,6 +51,11 @@ refs:
       destination: /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/provision-alerting-resources/export-alerting-resources/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/alerting-and-irm/alerting/set-up/provision-alerting-resources/export-alerting-resources/
+  import-alertmanager-configuration:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/import-alertmanager-configuration/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/set-up/import-alertmanager-configuration/
 ---
 
 {{< admonition type="caution" >}}
@@ -155,6 +160,7 @@ On the Settings page, you can also manage your Alertmanager configurations.
 
 - Manage version snapshots for the built-in Alertmanager, which allows administrators to roll back unintentional changes or mistakes in the Alertmanager configuration.
 - Compare the historical snapshot with the latest configuration to see which changes were made.
+- Import notification configuration from another Alertmanager. For more details, refer to [import Alertmanager configuration to Grafana](ref:import-alertmanager-configuration).
 
 ### Configuration history limits
 

--- a/docs/sources/alerting/set-up/convert-api.md
+++ b/docs/sources/alerting/set-up/convert-api.md
@@ -1,0 +1,188 @@
+---
+canonical: https://grafana.com/docs/grafana/latest/alerting/set-up/convert-api/
+description: Reference for the endpoints and headers of the Grafana Alerting convert API, which imports Prometheus-style alert rules and Alertmanager notification configuration into Grafana.
+keywords:
+  - grafana
+  - alerting
+  - api
+  - convert
+  - import
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
+title: Convert API
+menuTitle: Convert API
+weight: 220
+refs:
+  import-rules:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/alerting-migration/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/alerting-migration/
+  import-alertmanager-configuration:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/import-alertmanager-configuration/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/set-up/import-alertmanager-configuration/
+  configure-feature-toggles:
+    - pattern: /docs/
+      destination: /docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/
+---
+
+# Convert API
+
+The convert API imports Prometheus-style alert rules and Alertmanager notification configuration into Grafana. Grafana serves it under `/api/convert/`, and the following tools use it:
+
+- `mimirtool` and `cortextool`, when you [import data source-managed rules to Grafana-managed rules](ref:import-rules).
+- The Grafana Alerting import wizard, when you [import Alertmanager configuration to Grafana](ref:import-alertmanager-configuration).
+
+This page lists the endpoints and headers. For the import procedures, refer to those two pages.
+
+## Rule endpoints
+
+The rule endpoints are compatible with the [Mimir HTTP API](/docs/mimir/latest/references/http-api/) and are the endpoints that `mimirtool` and `cortextool` call.
+
+In these endpoints, a "namespace" corresponds to a folder title in Grafana.
+
+The `POST` endpoints can be used to import data source–managed alert rules. They accept requests in both YAML and JSON. If no media type is specified, YAML is assumed.
+
+| Endpoint | Method                                                | Summary                                                                                                                                                                                         | Mimir equivalent                                                         |
+| -------- | ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| POST     | `/convert/prometheus/config/v1/rules`                 | [Create or update multiple rule groups](#create-or-update-multiple-rule-groups) across multiple namespaces. Requires [`X-Grafana-Alerting-Datasource-UID`](#x-grafana-alerting-datasource-uid). | None                                                                     |
+| POST     | `/convert/prometheus/config/v1/rules/:namespaceTitle` | Create or update a single rule group in a namespace. Requires [`X-Grafana-Alerting-Datasource-UID`](#x-grafana-alerting-datasource-uid).                                                        | [Set rule group](/docs/mimir/latest/references/http-api/#set-rule-group) |
+
+The `GET` and `DELETE` endpoints work only with provisioned and imported alert rules. All `GET` endpoints support both JSON and YAML response formats based on the `Accept` header: use `application/json` for JSON responses, or `application/yaml` for YAML responses. YAML is the default format when no `Accept` header is specified.
+
+| Endpoint | Method                                                       | Summary                                             | Mimir equivalent                                                                                     |
+| -------- | ------------------------------------------------------------ | --------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| GET      | `/convert/prometheus/config/v1/rules`                        | Get all imported rule groups across all namespaces. | [List rule groups](/docs/mimir/latest/references/http-api/#list-rule-groups)                         |
+| GET      | `/convert/prometheus/config/v1/rules/:namespaceTitle`        | Get imported rule groups in a specific namespace.   | [Get rule groups by namespace](/docs/mimir/latest/references/http-api/#get-rule-groups-by-namespace) |
+| GET      | `/convert/prometheus/config/v1/rules/:namespaceTitle/:group` | Get imported rule group in a specific namespace.    | [Get rule group](/docs/mimir/latest/references/http-api/#get-rule-group)                             |
+| DELETE   | `/convert/prometheus/config/v1/rules/:namespaceTitle`        | Delete all imported alert rules in a namespace.     | [Delete namespace](/docs/mimir/latest/references/http-api/#delete-namespace)                         |
+| DELETE   | `/convert/prometheus/config/v1/rules/:namespaceTitle/:group` | Delete a specific imported rule group.              | [Delete rule group](/docs/mimir/latest/references/http-api/#delete-rule-group)                       |
+
+### Create or update multiple rule groups
+
+```
+POST /convert/prometheus/config/v1/rules
+```
+
+Creates or updates multiple rule groups across multiple namespaces. This endpoint expects a request with a map of namespace titles to arrays of rule groups, and returns `202` on success.
+
+This endpoint has no Mimir equivalent and is Grafana-specific for bulk operations.
+
+#### Example request body
+
+```yaml
+namespace1:
+  - name: MyGroupName1
+    rules:
+      - alert: MyAlertName1
+        expr: up == 0
+        labels:
+          severity: warning
+namespace2:
+  - name: MyGroupName2
+    rules:
+      - alert: MyAlertName2
+        expr: rate(http_requests_total[5m]) > 0.1
+        labels:
+          severity: critical
+```
+
+## Rule import headers
+
+Additional configuration headers for more granular import control include the following:
+
+### `X-Disable-Provenance`
+
+When this header is set to `true`:
+
+- The imported rules are not marked as provisioned.
+- They can then be edited in the Grafana UI.
+- They are excluded from the `GET` and `DELETE` operations on the [rule endpoints](#rule-endpoints).
+
+Do not enable this header when using the `rules sync` command, as it relies on the `GET` and `DELETE` operations to detect and update existing rules.
+
+### `X-Grafana-Alerting-Alert-Rules-Paused`
+
+Set to `true` to import alert rules in paused state.
+
+### `X-Grafana-Alerting-Recording-Rules-Paused`
+
+Set to `true` to import recording rules in paused state.
+
+### `X-Grafana-Alerting-Datasource-UID`
+
+The UID of the data source to use for alert rule queries.
+
+If not specified in the header, Grafana uses the configured default from `unified_alerting.prometheus_conversion.default_datasource_uid`. If neither the header nor the configuration option is provided, the request fails.
+
+### `X-Grafana-Alerting-Target-Datasource-UID`
+
+The UID of the target data source for recording rules. If not specified, the value from `X-Grafana-Alerting-Datasource-UID` is used.
+
+### `X-Grafana-Alerting-Folder-UID`
+
+Enter the UID of the target destination folder for imported rules.
+
+### `X-Grafana-Alerting-Notification-Settings`
+
+JSON-encoded [`AlertRuleNotificationSettings` object](#alertrulenotificationsettings-object) that allows setting the contact point for the alert rules.
+
+{{< collapse title="AlertRuleNotificationSettings object" >}}
+
+#### AlertRuleNotificationSettings object
+
+When you set `X-Grafana-Alerting-Notification-Settings`, the header value must be a JSON-encoded object with the following keys:
+
+| Field                   | Type       | Required | Example                                    | Description                                                                                             |
+| ----------------------- | ---------- | -------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
+| `receiver`              | `string`   | Yes      | `"grafana-default"`                        | Name of the contact point (receiver) to which alerts are routed. Must exist in Grafana before import.   |
+| `group_by`              | `[]string` | No       | `["alertname","grafana_folder","cluster"]` | Label set used by Alertmanager to aggregate alerts into a single notification.                          |
+| `group_wait`            | `duration` | No       | `"30s"`                                    | How long Alertmanager waits before sending the first notification for a new group.                      |
+| `group_interval`        | `duration` | No       | `"5m"`                                     | Time to wait before adding new alerts to an existing group's next notification.                         |
+| `repeat_interval`       | `duration` | No       | `"4h"`                                     | Minimum time before a previously-sent notification is repeated. Must not be less than `group_interval`. |
+| `mute_time_intervals`   | `[]string` | No       | `["maintenance"]`                          | One or more mute time interval names that silence alerts during those windows.                          |
+| `active_time_intervals` | `[]string` | No       | `["maintenance"]`                          | List of active time interval names. Alerts are suppressed unless the current time matches one of them.  |
+
+{{< /collapse >}}
+
+## Alertmanager configuration endpoints
+
+The following endpoints back the import wizard and the **Import** tab. They're in public preview and are available when the `alertingImportAlertmanagerAPI` feature toggle is enabled. For more details, refer to [configure feature toggles](ref:configure-feature-toggles).
+
+| Method | Endpoint                                          | Summary                                                      |
+| ------ | ------------------------------------------------- | ------------------------------------------------------------ |
+| POST   | `/api/convert/api/v1/alerts`                      | Stage an Alertmanager configuration, or promote it directly. |
+| GET    | `/api/convert/api/v1/alerts`                      | Get the staged Alertmanager configuration.                   |
+| DELETE | `/api/convert/api/v1/alerts`                      | Revert the staged Alertmanager configuration.                |
+| POST   | `/api/convert/api/v1/alerts/{IDENTIFIER}/promote` | Merge an already-staged configuration into the live one.     |
+
+The `POST` and `DELETE` endpoints take the identifier in a header rather than the path. The request body holds the Alertmanager configuration and its templates:
+
+```json
+{
+  "alertmanager_config": "<ALERTMANAGER_CONFIG_YAML>",
+  "template_files": {
+    "<TEMPLATE_FILE_NAME>": "<TEMPLATE_CONTENT>"
+  }
+}
+```
+
+Replace the following placeholders:
+
+- _`<ALERTMANAGER_CONFIG_YAML>`_: your Alertmanager configuration, as a YAML string.
+- _`<TEMPLATE_FILE_NAME>`_: the name of a template file. This becomes the template name in Grafana.
+- _`<TEMPLATE_CONTENT>`_: the contents of that template file.
+
+## Alertmanager configuration headers
+
+| Header                                    | Description                                                                                                          |
+| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `X-Grafana-Alerting-Config-Identifier`    | Names the staged configuration and the policy tree it produces. Defaults to `imported`.                              |
+| `X-Grafana-Alerting-Config-Force-Replace` | Set to `true` to replace a staged configuration that has a different identifier.                                     |
+| `X-Grafana-Alerting-Dry-Run`              | Set to `true` to validate the configuration and report conflicts and renames without saving it.                      |
+| `X-Grafana-Alerting-Promote`              | Set to `true` to merge the configuration into the live one instead of only staging it. This is a one-time operation. |

--- a/docs/sources/alerting/set-up/import-alertmanager-configuration.md
+++ b/docs/sources/alerting/set-up/import-alertmanager-configuration.md
@@ -1,0 +1,243 @@
+---
+canonical: https://grafana.com/docs/grafana/latest/alerting/set-up/import-alertmanager-configuration/
+description: Import contact points, notification policies, templates, time intervals, and inhibition rules from a Prometheus, Mimir, or Cortex Alertmanager into Grafana. Stage the configuration as a read-only copy, review it, then promote or revert it.
+keywords:
+  - grafana
+  - alerting
+  - import
+  - alertmanager
+  - migration
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
+title: Import Alertmanager configuration to Grafana
+menuTitle: Import Alertmanager configuration
+weight: 210
+refs:
+  convert-api:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/convert-api/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/set-up/convert-api/
+  import-rules:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/alerting-migration/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/alerting-migration/
+  configure-alertmanager:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/configure-alertmanager/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/set-up/configure-alertmanager/
+  contact-points:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/manage-contact-points/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/manage-contact-points/
+  notification-policies:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/create-notification-policy/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/create-notification-policy/
+  templates:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/template-notifications/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/template-notifications/
+  time-intervals:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/mute-timings/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/mute-timings/
+  inhibition-rules:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/inhibition-rules/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/inhibition-rules/
+  rbac:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/access-control/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/account-management/authentication-and-permissions/access-control/
+  configure-feature-toggles:
+    - pattern: /docs/
+      destination: /docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/
+---
+
+# Import Alertmanager configuration to Grafana
+
+{{< docs/public-preview product="Alertmanager configuration import" >}}
+
+You can import notification configuration from a Prometheus, Mimir, or Cortex Alertmanager into Grafana. The Import Alertmanager configuration tool imports contact points, the notification policy tree, notification templates, time interval configurations, and inhibition rules into Grafana Alerting.
+
+The import process is a staged operation. Grafana first saves the incoming configuration as a read-only copy that doesn't affect notification delivery. You review that copy, then either promote it into your live configuration or revert it.
+
+This page covers notification configuration only. To convert alert rules and recording rules from Mimir, Loki, or Prometheus into Grafana-managed rules, refer to [import data source-managed rules to Grafana-managed rules](ref:import-rules).
+
+## Before you begin
+
+Ensure you have the following:
+
+- **Feature toggles enabled**: This feature is in public preview and is off by default. Enable both `alertingMigrationWizardUI`, which adds the **Import** tab and the import wizard, and `alertingImportAlertmanagerAPI`, which adds the API endpoints the import uses. For more details, refer to [configure feature toggles](ref:configure-feature-toggles).
+- **The organization Admin role**: The **Import** tab under **Alerting** > **Settings** is only available to organization administrators.
+- **An import source**: The import tool accepts either an Alertmanager data source that Grafana can reach, or an Alertmanager configuration YAML file.
+- **RBAC permissions**: The following [RBAC](ref:rbac) actions apply:
+
+  | Action                                                          | Needed to                                            |
+  | --------------------------------------------------------------- | ---------------------------------------------------- |
+  | `notifications.alerting.grafana.app/alertmanagerimports:create` | Import a configuration and stage it                  |
+  | `notifications.alerting.grafana.app/alertmanagerimports:get`    | View a staged configuration                          |
+  | `notifications.alerting.grafana.app/alertmanagerimports:delete` | Revert a staged configuration, and promote one       |
+  | `alert.notifications.receivers:create`                          | Promote the contact points in a staged configuration |
+  | `notifications.alerting.grafana.app/routingtrees:create`        | Promote the notification policy tree                 |
+
+  The legacy `alert.notifications:write` permission also grants all of the preceding actions.
+
+## Import method
+
+The first step of the import wizard asks how you want to bring the resources in. Choose the method that matches your intent.
+
+| Method    | What it does                                                                                                                       | Reversible                                 |
+| --------- | ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| Stage     | Saves a read-only copy for review. Nothing merges into your live configuration until you promote it.                               | Yes. Revert removes the copy.              |
+| Promote   | Merges the resources straight into your live configuration as normal, editable Grafana resources.                                  | No. You must delete each resource by hand. |
+| Auto-sync | Continuously syncs configuration from a Mimir or Cortex Alertmanager data source. The synced resources stay read-only and tracked. | Yes. Disable sync to stop it.              |
+
+**Auto-sync** appears only when the `alerting.syncExternalAlertmanager` feature toggle is enabled and you hold the Admin organization role. Choosing it collapses the wizard to a single confirmation step, because there's nothing to configure per resource.
+
+As a best practice, choose **Stage** the first time you import from a given source. Review what landed, then promote it.
+
+## Import an Alertmanager configuration
+
+To import notification configuration through the Grafana Alerting user interface, complete the following steps.
+
+1. Go to **Alerting** > **Settings** and click the **Import** tab.
+
+1. Click **Import Alertmanager configuration**.
+
+   If a configuration is already staged, promote or revert it first.
+
+1. On the **Import method** step, select **Stage** or **Promote**, then click **Notification resources**.
+
+   To sync continuously instead of importing once, select **Auto-sync** and refer to [Import with auto-sync](#import-with-auto-sync).
+
+1. On the **Notification resources** step, choose an **Import source**:
+   - **YAML file**: Upload your Alertmanager configuration YAML file. You can also upload the template files your configuration references. Grafana imports each file as a template named after the file, so filenames must be unique.
+   - **Data source**: Select an Alertmanager data source. Grafana reads the configuration from it.
+
+1. Enter a **Policy tree name**.
+
+   This is the identifier for the import. Grafana creates a separate notification policy tree with this name rather than merging routes into your default policy. Selecting a data source pre-fills this field with the data source name.
+
+   Grafana validates the configuration as you fill in this step and reports conflicts before you continue.
+
+1. Click **Alert rules**.
+
+   The **Alert rules** step imports alert rules and recording rules. For details, refer to [import data source-managed rules to Grafana-managed rules](ref:import-rules). To import notification configuration only, click **Skip this step**.
+
+1. On the **Review & import** step, check the summary and click **Start import**.
+
+   Each section shows what happens to it, for example **Will import this configuration** or **Skipped**.
+
+1. Click **Start Import** to confirm.
+
+A staged import returns you to the **Import** tab so you can review the staged copy. A promoted import takes you to the alert rule list.
+
+The wizard names each navigation button after the step it takes you to, rather than labeling them **Next** and **Back**.
+
+## Review a staged configuration
+
+The **Import** tab shows the staged configuration as a card titled with its identifier and badged **Staged · read-only**.
+
+Expand **Resources** to see what the import contains, grouped by type with a count for each:
+
+- **Contact points**, with their integration types
+- **Notification policy**, showing the imported policy tree and its child routes with their matchers and target contact points
+- **Templates**
+- **Time intervals**
+- **Inhibition rules**, showing source and target matchers inline
+
+Each row has a **View** link that opens the resource in its usual management page, in read-only form.
+
+## Promote a staged configuration
+
+Promoting merges the staged resources into your live Grafana Alertmanager and turns them into normal, editable Grafana resources. Grafana then removes the staged copy, which frees the slot for another import.
+
+{{< admonition type="caution" >}}
+Promoting can't be undone. To reverse it, you have to delete each resulting resource by hand.
+{{< /admonition >}}
+
+1. On the **Import** tab, click **Promote to live config**.
+
+1. Review the preview.
+
+   Grafana validates the merge and shows what changes under **Will merge into your live config**. The preview counts the contact points, templates, time intervals, inhibition rules, and notification routes that it adds.
+
+   Grafana renames any imported resource whose name already exists in your live configuration. The **Renamed to avoid conflicts** section lists both the original name and the replacement.
+
+1. Click **Promote to live config**.
+
+Alert rules aren't part of a promote. Rules imported through the wizard are already active as Grafana-managed rules, so promoting only merges the Alertmanager resources.
+
+### How the merge resolves conflicts
+
+Grafana applies the following rules when it merges a staged configuration into your live one:
+
+- **Name collisions**: Grafana renames the incoming resource rather than overwriting yours. It appends `_` and the import identifier to the name, for example `oncall_prometheus-prod`. If that name is also taken, it adds a numbered suffix, such as `_01`. It then updates every reference to the renamed resource.
+- **Policy tree placement**: Grafana inserts the imported routing tree as the first route under your live root route, rather than merging it in. It sets `group_wait`, `group_interval`, and `repeat_interval` explicitly on that route so it doesn't inherit unintended defaults from the parent.
+- **Inhibition rules**: Grafana copies them into your live configuration unchanged.
+- **Tree name conflicts**: The merge fails if a policy tree with the import identifier already exists. It also fails if the identifier matches the default tree name.
+
+## Revert a staged configuration
+
+Reverting discards the staged copy. It's a safe operation:
+
+- Your live Alertmanager configuration isn't affected.
+- Anything you already promoted stays in place.
+- You can import the same configuration again later.
+
+To revert, click **Revert** on the staged configuration card, then confirm.
+
+## Import with auto-sync
+
+Auto-sync keeps an imported configuration up to date instead of importing it once. It can only read from a Mimir or Cortex Alertmanager data source.
+
+To enable auto-sync, complete the following steps:
+
+1. Go to **Alerting** > **Settings** and click the **Import** tab.
+
+1. Click **Import Alertmanager configuration**.
+
+1. On the **Import method** step, select **Auto-sync**, then select a **Data source**.
+
+   The picker lists only Mimir and Cortex Alertmanager data sources. If you have none, add one and start the wizard again.
+
+1. Click **Review & enable**, then click **Enable auto-sync**.
+
+You can also enable it without the wizard: on the **Import** tab, select a **Datasource** in the **Auto-sync configuration** card and click **Save**. The card shows a **Not configured** or **Active** badge. To stop syncing, click **Disable sync** and confirm.
+
+If auto-sync is set through the `external_alertmanager_uid` key in the `[unified_alerting]` section of the Grafana configuration file, the card is read-only. Change the key and restart Grafana, or remove it to manage auto-sync from the UI.
+
+When auto-sync writes the staged configuration, the card shows a **Synced · read-only** badge. Grafana hides the **Revert** button, because the next sync would recreate the copy. To remove the configuration, disable auto-sync instead.
+
+You can still promote a synced configuration. Promoting merges the resources into your live configuration, stops them from tracking the data source, and turns auto-sync off.
+
+Because Grafana holds one staged configuration at a time, a manually staged import blocks auto-sync from starting: the sync writes to the same slot and every attempt fails. When this happens, the **Auto-sync configuration** card reports that auto-sync is unavailable and names the identifier occupying the slot. Promote or revert that configuration to free it.
+
+## Import with the API
+
+You can stage, promote, and revert configurations with the convert API instead of the wizard. Its endpoints are available when the `alertingImportAlertmanagerAPI` feature toggle is enabled.
+
+For the endpoints, the request body, and the headers that name a configuration or turn a stage into a promote, refer to [Convert API](ref:convert-api).
+
+## Next steps
+
+- [Configure Alertmanagers](ref:configure-alertmanager)
+- [Import data source-managed rules to Grafana-managed rules](ref:import-rules)
+- [Manage contact points](ref:contact-points)
+- [Configure notification policies](ref:notification-policies)
+- [Configure notification templates](ref:templates)
+- [Configure mute timings and active time intervals](ref:time-intervals)
+- [Configure inhibition rules](ref:inhibition-rules)

--- a/docs/sources/alerting/set-up/import-alertmanager-configuration.md
+++ b/docs/sources/alerting/set-up/import-alertmanager-configuration.md
@@ -95,21 +95,9 @@ Ensure you have the following:
 
   The legacy `alert.notifications:write` permission also grants all of the preceding actions.
 
-## Import method
-
-The first step of the import wizard asks how you want to bring the resources in. Choose the method that matches your intent.
-
-| Method    | What it does                                                                                                                       | Reversible                                 |
-| --------- | ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
-| Stage     | Saves a read-only copy for review. Nothing merges into your live configuration until you promote it.                               | Yes. Revert removes the copy.              |
-| Promote   | Merges the resources straight into your live configuration as normal, editable Grafana resources.                                  | No. You must delete each resource by hand. |
-| Auto-sync | Continuously syncs configuration from a Mimir or Cortex Alertmanager data source. The synced resources stay read-only and tracked. | Yes. Disable sync to stop it.              |
-
-**Auto-sync** appears only when the `alerting.syncExternalAlertmanager` feature toggle is enabled and you hold the Admin organization role. Choosing it collapses the wizard to a single confirmation step, because there's nothing to configure per resource.
-
-As a best practice, choose **Stage** the first time you import from a given source. Review what landed, then promote it.
-
 ## Import an Alertmanager configuration
+
+The wizard always stages what it imports. It never writes to your live Alertmanager, so you can review the result before you promote it.
 
 To import notification configuration through the Grafana Alerting user interface, complete the following steps.
 
@@ -118,10 +106,6 @@ To import notification configuration through the Grafana Alerting user interface
 1. Click **Import Alertmanager configuration**.
 
    If a configuration is already staged, promote or revert it first.
-
-1. On the **Import method** step, select **Stage** or **Promote**, then click **Notification resources**.
-
-   To sync continuously instead of importing once, select **Auto-sync** and refer to [Import with auto-sync](#import-with-auto-sync).
 
 1. On the **Notification resources** step, choose an **Import source**:
    - **YAML file**: Upload your Alertmanager configuration YAML file. You can also upload the template files your configuration references. Grafana imports each file as a template named after the file, so filenames must be unique.
@@ -141,11 +125,11 @@ To import notification configuration through the Grafana Alerting user interface
 
    Each section shows what happens to it, for example **Will import this configuration** or **Skipped**.
 
-1. Click **Start Import** to confirm.
+1. In **Confirm Import**, click **Start Import**.
 
-A staged import returns you to the **Import** tab so you can review the staged copy. A promoted import takes you to the alert rule list.
+Grafana stages the configuration and returns you to the **Import** tab, where you can review it. If you skipped the notification resources step and imported only alert rules, you land on the alert rule list instead.
 
-The wizard names each navigation button after the step it takes you to, rather than labeling them **Next** and **Back**.
+The wizard's navigation buttons are named after the step they open rather than **Next** and **Back**.
 
 ## Review a staged configuration
 
@@ -202,29 +186,22 @@ To revert, click **Revert** on the staged configuration card, then confirm.
 
 ## Import with auto-sync
 
-Auto-sync keeps an imported configuration up to date instead of importing it once. It can only read from a Mimir or Cortex Alertmanager data source.
+Auto-sync keeps an imported configuration up to date instead of importing it once. It reads from a Mimir or Cortex Alertmanager data source and writes to the same staged slot a manual import uses, so the synced resources stay read-only.
 
-To enable auto-sync, complete the following steps:
+You configure auto-sync on the **Import** tab rather than in the wizard. The **Auto-sync configuration** card appears only when the `alerting.syncExternalAlertmanager` feature toggle is enabled.
 
-1. Go to **Alerting** > **Settings** and click the **Import** tab.
+To turn auto-sync on, select a **Datasource** and click **Save**. The card badge changes from **Not configured** to **Active**. To turn it off, click **Disable sync** and confirm.
 
-1. Click **Import Alertmanager configuration**.
-
-1. On the **Import method** step, select **Auto-sync**, then select a **Data source**.
-
-   The picker lists only Mimir and Cortex Alertmanager data sources. If you have none, add one and start the wizard again.
-
-1. Click **Review & enable**, then click **Enable auto-sync**.
-
-You can also enable it without the wizard: on the **Import** tab, select a **Datasource** in the **Auto-sync configuration** card and click **Save**. The card shows a **Not configured** or **Active** badge. To stop syncing, click **Disable sync** and confirm.
-
-If auto-sync is set through the `external_alertmanager_uid` key in the `[unified_alerting]` section of the Grafana configuration file, the card is read-only. Change the key and restart Grafana, or remove it to manage auto-sync from the UI.
+If the `external_alertmanager_uid` key in the `[unified_alerting]` section of `grafana.ini` sets the data source, the card shows a **Managed by operator** badge and you can't change the picker. Change the key and restart Grafana, or remove it to manage auto-sync from the UI.
 
 When auto-sync writes the staged configuration, the card shows a **Synced · read-only** badge. Grafana hides the **Revert** button, because the next sync would recreate the copy. To remove the configuration, disable auto-sync instead.
 
-You can still promote a synced configuration. Promoting merges the resources into your live configuration, stops them from tracking the data source, and turns auto-sync off.
+You can still promote a synced configuration. Promoting stops the resources from tracking the data source and turns auto-sync off.
 
-Because Grafana holds one staged configuration at a time, a manually staged import blocks auto-sync from starting: the sync writes to the same slot and every attempt fails. When this happens, the **Auto-sync configuration** card reports that auto-sync is unavailable and names the identifier occupying the slot. Promote or revert that configuration to free it.
+Auto-sync and the wizard compete for the same slot, so only one of them can hold a configuration at a time:
+
+- While auto-sync is active, the wizard won't import notification resources. It shows an **Auto-sync is enabled** warning and points you to Alerting settings to disable sync first. You can still import alert rules.
+- While a manually staged configuration occupies the slot, auto-sync can't start. The card reports **Auto-sync is unavailable while a configuration is staged** and names the identifier holding it. Promote or revert that configuration to free the slot.
 
 ## Import with the API
 


### PR DESCRIPTION
First draft of documentation for new [Alertmanager import feature](https://github.com/grafana/grafana/pull/129243).
Also moved some of the old migration docs over so that it's all in one place.
[Preview of the new page here](https://deploy-preview-grafana-130808-zb444pucvq-vp.a.run.app/docs/grafana/next/alerting/set-up/import-alertmanager-configuration/).

