### PR TITLE
Docs: Update button names

### DIFF
--- a/docs/sources/fundamentals/getting-started/first-dashboards/_index.md
+++ b/docs/sources/fundamentals/getting-started/first-dashboards/_index.md
@@ -68,10 +68,10 @@ To create your first dashboard using the built-in `-- Grafana --` data source:
 1. Click **Refresh** to query the data source.
 1. When you've finished editing your panel, click **Save**.
 
-   Alternatively, click **Back to dashboard** if you want to see your changes applied to the dashboard first. Then click **Save** when you're ready.
+   Alternatively, click **Back** if you want to see your changes applied to the dashboard first. Then click **Save** when you're ready.
 
 1. Add a descriptive title for the dashboard, or have Grafana create one using [generative AI features](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/manage-dashboards#set-up-generative-ai-features-for-dashboards), and then click **Save**.
-1. Click **Back to dashboard** and then **Exit edit**.
+1. Click **Back** and then **Exit edit**.
 
 Congratulations, you have created your first dashboard and it's displaying results.
 

--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/_index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/_index.md
@@ -146,7 +146,7 @@ To create a dashboard, follow these steps:
 1. Enter a title and description for the dashboard or have Grafana create them using [generative AI features](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/manage-dashboards/#set-up-generative-ai-features-for-dashboards).
 1. Select a folder, if applicable.
 1. Click **Save**
-1. Click **Back to dashboard**.
+1. Click **Back**.
 1. Click **Exit edit**.
 
 {{< /docs/list >}}
@@ -243,7 +243,7 @@ To edit a dashboard, follow these steps:
 1. When you've finished making changes, click **Save**.
 1. (Optional) Enter a description of the changes you've made.
 1. Click **Save**.
-1. Click **Back to dashboard**, if needed.
+1. Click **Back**, if needed.
 1. Click **Exit edit**
 
 ## Panel layouts

--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/_index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/_index.md
@@ -122,7 +122,7 @@ To create a dashboard, follow these steps:
 1. Click **Refresh** to query the data source.
 1. Select a suggested visualization or click **All visualizations** and select one from the full list.
 
-   {{< figure src="/media/docs/grafana/panels-visualizations/screenshot-viz-suggestion-2-v13.0.png" max-width="300px" alt="Visualization selector" >}}
+   {{< figure src="/media/docs/grafana/panels-visualizations/screenshot-viz-suggestions-v13.2.png" max-width="300px" alt="Visualization selector" >}}
 
    Grafana displays a preview of your query results with the visualization applied.
 

--- a/docs/sources/visualizations/dashboards/build-dashboards/filter-group-by/index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/filter-group-by/index.md
@@ -176,7 +176,7 @@ To use filters on data from an unsupported data source, follow these steps:
 1. Configure any other needed options for the panel.
 1. Click **Save** in the top-right corner.
 1. Enter an optional description of your changes and click **Save**.
-1. Click **Back to dashboard** and then **Exit edit**.
+1. Click **Back** and then **Exit edit**.
 
 Now you can filter the data from the source panel by way of the Dashboard data source.
 Add as many panels as you need.

--- a/docs/sources/visualizations/dashboards/build-dashboards/manage-dashboard-links/index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/manage-dashboard-links/index.md
@@ -95,7 +95,7 @@ The default link type is **Dashboards**.
 1. Click **Save**.
 1. (Optional) Enter a description of the changes you've made.
 1. Click **Save**.
-1. Click **Back to dashboard** and **Exit edit**.
+1. Click **Back** and **Exit edit**.
 
 {{< /docs/list >}}
 
@@ -138,7 +138,7 @@ To add a URL link to your dashboard, follow these steps:
 
 1. Click **Save** in the top-right corner.
 1. Enter an optional description of your changes and click **Save**.
-1. Click **Back to dashboard** and then **Exit edit**.
+1. Click **Back** and then **Exit edit**.
 
 {{< /docs/list >}}
 
@@ -157,7 +157,7 @@ To edit, duplicate, or delete dashboard link, follow these steps:
 
 1. Click **Save** in the top-right corner.
 1. Enter an optional description of your changes and click **Save**.
-1. Click **Back to dashboard** and then **Exit edit**.
+1. Click **Back** and then **Exit edit**.
 
 ## Panel links
 
@@ -186,7 +186,7 @@ Click the icon next to the panel title to see available panel links.
 1. Click **Save** to save changes and close the dialog box.
 1. Click **Save** in the top-right corner.
 1. Enter an optional description of your changes and click **Save**.
-1. Click **Back to dashboard** and then **Exit edit**.
+1. Click **Back** and then **Exit edit**.
 
 ### Update a panel link
 
@@ -202,7 +202,7 @@ Click the icon next to the panel title to see available panel links.
 1. Click **Save** to save changes and close the dialog box.
 1. Click **Save** in the top-right corner.
 1. Enter an optional description of your changes and click **Save**.
-1. Click **Back to dashboard** and then **Exit edit**.
+1. Click **Back** and then **Exit edit**.
 
 ### Delete a panel link
 
@@ -216,4 +216,4 @@ Click the icon next to the panel title to see available panel links.
 1. Click the **X** icon next to the link you want to delete.
 1. Click **Save** in the top-right corner.
 1. Enter an optional description of your changes and click **Save**.
-1. Click **Back to dashboard** and then **Exit edit**.
+1. Click **Back** and then **Exit edit**.

--- a/docs/sources/visualizations/dashboards/build-dashboards/manage-version-history/index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/manage-version-history/index.md
@@ -40,7 +40,7 @@ To compare two dashboard versions, follow these steps:
 1. Click **Compare versions** to view the diff between the two versions.
 1. Review the text descriptions of the differences between the versions.
 1. (Optional) Expand the **View JSON Diff** section of the page to see the diff of the raw JSON that represents your dashboard.
-1. When you've finished comparing versions, click **Back to dashboard** and **Exit edit**.
+1. When you've finished comparing versions, click **Back** and **Exit edit**.
 
 When you're comparing versions, if one of the versions you've selected is the latest version, a button to restore the previous version is also displayed, so you can restore a version from the compare view:
 

--- a/docs/sources/visualizations/dashboards/build-dashboards/view-dashboard-json-model/index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/view-dashboard-json-model/index.md
@@ -65,7 +65,7 @@ To access the JSON representation of a dashboard:
 1. In the sidebar, click **Settings**.
 1. Go to the **JSON Model** tab.
 1. When you've finished updating the JSON, click **Save changes** at the bottom of the tab.
-1. Click **Back to dashboard** and **Exit edit**.
+1. Click **Back** and **Exit edit**.
 
 ## V2 Resource model
 

--- a/docs/sources/visualizations/panels-visualizations/configure-data-links/index.md
+++ b/docs/sources/visualizations/panels-visualizations/configure-data-links/index.md
@@ -329,7 +329,7 @@ To add a data link, follow these steps:
 1. Click **Save** to save changes and close the dialog box.
 1. Click **Save** in the top-right corner.
 1. Enter an optional description of your changes and click **Save**.
-1. Click **Back to dashboard** and then **Exit edit**.
+1. Click **Back** and then **Exit edit**.
 
    {{< /tab-content >}}
    {{< tab-content name="Add actions" >}}
@@ -363,7 +363,7 @@ To add a data link, follow these steps:
 1. Click **Save** to save changes and close the dialog box.
 1. Click **Save** in the top-right corner.
 1. Enter an optional description of your changes and click **Save**.
-1. Click **Back to dashboard** and then **Exit edit**.
+1. Click **Back** and then **Exit edit**.
    {{< /tab-content >}}
    {{< /tabs >}}
 

--- a/docs/sources/visualizations/panels-visualizations/configure-overrides/index.md
+++ b/docs/sources/visualizations/panels-visualizations/configure-overrides/index.md
@@ -259,7 +259,7 @@ To add a field override, follow these steps:
 1. Add as many overrides as you need.
 1. When you're finished, click **Save** in the top-right corner.
 1. Enter an optional description of your changes and click **Save**.
-1. Click **Back to dashboard** and then **Exit edit**.
+1. Click **Back** and then **Exit edit**.
 
 ## Edit a field override
 
@@ -276,6 +276,6 @@ To edit a field override, follow these steps:
    - Delete an override entirely by clicking the trash icon at the top-right corner.
 1. Click **Save** in the top-right corner.
 1. Enter an optional description of your changes and click **Save**.
-1. Click **Back to dashboard** and then **Exit edit**.
+1. Click **Back** and then **Exit edit**.
 
 The changes you make take effect immediately.

--- a/docs/sources/visualizations/panels-visualizations/configure-thresholds/index.md
+++ b/docs/sources/visualizations/panels-visualizations/configure-thresholds/index.md
@@ -187,6 +187,6 @@ You can add as many thresholds to a visualization as you want. Grafana automatic
 1. Under **Show thresholds**, set how the threshold is displayed or turn it off.
 1. Click **Save** in the top-right corner.
 1. Enter an optional description of your changes and click **Save**.
-1. Click **Back to dashboard** and then **Exit edit**.
+1. Click **Back** and then **Exit edit**.
 
 To delete a threshold, navigate to the panel that contains the threshold and click the trash icon next to the threshold you want to remove.

--- a/docs/sources/visualizations/panels-visualizations/configure-value-mappings/index.md
+++ b/docs/sources/visualizations/panels-visualizations/configure-value-mappings/index.md
@@ -221,4 +221,4 @@ ERROR[\s\S]*
 After you've added a mapping, the **Edit value mappings** button replaces the **Add value mappings** button. Click the edit button to add or update mappings.
 
 1. Click **Save dashboard**.
-1. Click **Back to dashboard** and then **Exit edit**.
+1. Click **Back** and then **Exit edit**.

--- a/docs/sources/visualizations/panels-visualizations/panel-editor-overview/index.md
+++ b/docs/sources/visualizations/panels-visualizations/panel-editor-overview/index.md
@@ -31,7 +31,7 @@ weight: 20
 
 In the panel editor, you can update all the elements of a visualization including the data source, queries, time range, and visualization display options.
 
-![Panel editor](/media/docs/grafana/panels-visualizations/screenshot-panel-editor-v12.4.png)
+![Panel editor](/media/docs/grafana/panels-visualizations/screenshot-panel-editor-2-v12.4.png)
 
 This following sections describe the areas of the Grafana panel editor.
 
@@ -82,7 +82,7 @@ For more information about individual visualizations, refer to [Visualizations o
 
 While visualization suggestions help you choose _which_ panel type to use, panel styles help you decide _how_ that panel should look. The **Panel styles** section of the panel editor sidebar contains preconfigured options for the currently selected visualization. It appears after you've selected a visualization and the panel has data.
 
-![Panel styles example for time series visualization](/media/docs/grafana/panels-visualizations/visualization-presets-13.png)
+![Panel styles example for time series visualization](/media/docs/grafana/panels-visualizations/screenshot-visualization-presets-v13.0.png)
 
 Each style is displayed as a live preview card that shows how it changes the visualization. Clicking a style applies a combination of display options and field configuration to the panel. For example, changing a style might switch a time series visualization from a line chart with a gradient fill to a stacked bar chart, or update the color scheme and graph mode of a stat visualization.
 

--- a/docs/sources/visualizations/panels-visualizations/panel-editor-overview/index.md
+++ b/docs/sources/visualizations/panels-visualizations/panel-editor-overview/index.md
@@ -39,8 +39,8 @@ This following sections describe the areas of the Grafana panel editor.
 
 The header section lists the dashboard in which the panel appears and the following controls:
 
-- **Back to dashboard** - Return to the dashboard with changes applied, but not yet saved.
-- **Discard panel changes** - Discard changes you have made to the panel since you last saved the dashboard.
+- **Back** - Return to the dashboard with changes applied, but not yet saved.
+- **Discard** - Discard changes you have made to the panel since you last saved the dashboard.
 - **Save** - Save your changes to the dashboard.
 
 ## Visualization preview

--- a/docs/sources/visualizations/panels-visualizations/visualizations/traces/index.md
+++ b/docs/sources/visualizations/panels-visualizations/visualizations/traces/index.md
@@ -106,7 +106,7 @@ This procedure uses dashboard variables and templates to allow you to enter trac
 
    {{< figure src="/static/img/docs/panels/traces/screenshot-traces-template-query.png" alt="Add a template query" >}}
 
-1. Click **Back to dashboard**.
+1. Click **Back**.
 1. Click the **Add new element** icon and click **Variable**.
 1. Add a new variable called `traceId`, of variable type **Custom**, giving it a label if required.
 
@@ -137,7 +137,7 @@ It's more useful to instead be able to use TraceQL queries to search for specifi
 
 1. Click **Save**.
 1. Enter an optional description of your changes, and click **Save**.
-1. Click **Back to dashboard** and **Exit edit**.
+1. Click **Back** and **Exit edit**.
 
 When results are returned from a query, the results are rendered in the panel’s table.
 
@@ -162,7 +162,7 @@ To create a set of data links in the panel, use the following steps:
 
 1. Select **Save** to save the data link.
 1. Enter an optional description of your changes, and click **Save**.
-1. Click **Back to dashboard** and **Exit edit**.
+1. Click **Back** and **Exit edit**.
 
 You should now see a list of matching traces in the table visualization. While selecting the **TraceID** or **SpanID** fields will give you the option to either open the **Explore** page to visualize the trace or following the data link, selecting any other field (such as **Start time**, **Name** or **Duration**) automatically follows the data link, filling in the `traceId` dashboard variable, and then shows the relevant trace in the trace panel.
 


### PR DESCRIPTION
This PR updates the following button names in the docs:

- Back to dashboard > Back
- Discard panel changes > Discard

Also crops some screenshots so these buttons aren't visible

Per https://github.com/grafana/grafana/pull/129334 