### PR TITLE
Docs: Update version number

### DIFF
--- a/docs/sources/as-code/infrastructure-as-code/terraform/manage-saved-queries.md
+++ b/docs/sources/as-code/infrastructure-as-code/terraform/manage-saved-queries.md
@@ -42,7 +42,7 @@ terraform {
   required_providers {
     grafana = {
       source  = "grafana/grafana"
-      version = ">= 4.6.0"
+      version = ">= 4.44.0"
     }
   }
 }


### PR DESCRIPTION
This doc was published a placeholder version number that was supposed to come from the registry once updated. The version at that point was `4.44.0`.