### PR TITLE
Fix hide datasource managed tab

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -509,7 +509,7 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange, mod
                 }}
               />
             </Field>
-            {mode === 'edit' && hasAlertEnabledDataSources && (
+            {mode === 'edit' && canSelectDataSourceManaged && (
               <>
                 <Divider />
                 <SmartAlertTypeDetector


### PR DESCRIPTION
The SmartAlertTypeDetector toggle for cloud alert rules was missing the `alertingDisableDMAinUI` feature flag check, so the "Data source-managed" tab could still appear in the rule editor even when the flag was enabled.

**What is this feature?**
A one-line fix that makes the cloud-alert-rule branch of the rule editor reuse the existing `canSelectDataSourceManaged` variable (already used elsewhere in the same file) instead of the narrower `hasAlertEnabledDataSources` check, so it correctly respects the `alertingDisableDMAinUI` feature flag.

**Why do we need this feature?**
When `alertingDisableDMAinUI` is enabled, admins expect all paths to the "Data source-managed" rule type to be hidden. One of the two places this toggle is rendered was missing that check, so the tab could still surface.

**Who is this feature for?**
Admins running Grafana with `alertingDisableDMAinUI` enabled who want to fully restrict users to Grafana-managed alert rules.

**Which issue(s) does this PR fix?**
Closes #115015

**Special notes for your reviewer:**
Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.

**How I tested it:** Verified the fix reuses the same `canSelectDataSourceManaged` gating already applied to the Grafana-managed rule branch further down in the same file, confirmed via `git diff` that this is the only line changed. Not yet verified in a running instance — still setting up a local Go environment.