### PR TITLE
App plugins: Prepare to support multiple apiversions

### DIFF
--- a/pkg/registry/apis/appplugin/context.go
+++ b/pkg/registry/apis/appplugin/context.go
@@ -42,14 +42,12 @@ func (b *AppPluginAPIBuilder) getSettings(ctx context.Context) (*apppluginV0.Set
 }
 
 // Gets plugin context with decrypted secure values
-func (b *AppPluginAPIBuilder) getPluginContext(ctx context.Context) (context.Context, backend.PluginContext, error) {
+func (b *AppPluginAPIBuilder) getPluginContext(ctx context.Context, apiVersion string) (context.Context, backend.PluginContext, error) {
 	settings, secure, err := b.getSettings(ctx)
 	if err != nil {
 		return ctx, backend.PluginContext{}, err
 	}
-	instance := &backend.AppInstanceSettings{
-		APIVersion: b.groupVersion.Version,
-	}
+	instance := &backend.AppInstanceSettings{APIVersion: apiVersion}
 	instance.JSONData, err = json.Marshal(settings.Spec.JsonData)
 	if err != nil {
 		return ctx, backend.PluginContext{}, fmt.Errorf("error marshalling JsonData: %w", err)

--- a/pkg/registry/apis/appplugin/openapi.go
+++ b/pkg/registry/apis/appplugin/openapi.go
@@ -2,6 +2,7 @@ package appplugin
 
 import (
 	"fmt"
+	"strings"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-openapi/pkg/common"
@@ -19,9 +20,16 @@ func (b *AppPluginAPIBuilder) GetOpenAPIDefinitions() common.GetOpenAPIDefinitio
 }
 
 func (b *AppPluginAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.OpenAPI, error) {
+	// This is called once per group version, but the target version is not
+	// passed in -- recover it from the spec's Info.Title stamp.
+	version := b.specVersion(oas)
+
 	var schema *pluginschema.PluginSchema
 	if b.schemas != nil {
-		schema = b.schemas[b.GetGroupVersion().Version]
+		schema = b.schemas[version]
+		if schema.IsZero() {
+			schema = b.schemas[apppluginV0.VERSION] // v0 is always configured
+		}
 	}
 
 	// The plugin description
@@ -40,7 +48,7 @@ func (b *AppPluginAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.Ope
 	oas.Info.AddExtension("x-grafana-plugin", info)
 
 	// The root api URL
-	root := "/apis/" + b.groupVersion.String() + "/"
+	root := fmt.Sprintf("/apis/%s/%s/", b.pluginJSON.ID, version)
 
 	// Hide the resource+proxy routes -- explicit ones will be added if defined below
 	for _, v := range []string{"resources", "proxy"} {
@@ -63,7 +71,7 @@ func (b *AppPluginAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.Ope
 	if !ok {
 		return nil, fmt.Errorf("missing settings type")
 	}
-	ps.Properties["apiVersion"] = *spec.StringProperty().WithEnum(b.GetGroupVersion().String())
+	ps.Properties["apiVersion"] = *spec.StringProperty().WithEnum(fmt.Sprintf("%s/%s", b.pluginJSON.ID, version))
 	ps.Properties["kind"] = *spec.StringProperty().WithEnum("Settings")
 
 	// Always transform results
@@ -81,6 +89,19 @@ func (b *AppPluginAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.Ope
 		Path:     root + "namespaces/{namespace}/app",
 		IsApp:    true,
 	})
+}
+
+// specVersion returns the version of the group-version spec being processed.
+// The builder framework stamps every per-version spec with
+// Info.Title = "<group>/<version>" before post-processing runs, and for app
+// plugins the group is the plugin id.
+func (b *AppPluginAPIBuilder) specVersion(oas *spec3.OpenAPI) string {
+	if oas.Info != nil {
+		if version, ok := strings.CutPrefix(oas.Info.Title, b.pluginJSON.ID+"/"); ok && version != "" {
+			return version
+		}
+	}
+	return apppluginV0.VERSION
 }
 
 func defaultSchema() *pluginschema.PluginSchema {

--- a/pkg/registry/apis/appplugin/register.go
+++ b/pkg/registry/apis/appplugin/register.go
@@ -32,8 +32,8 @@ import (
 )
 
 var (
-	_ builder.APIGroupBuilder         = (*AppPluginAPIBuilder)(nil)
-	_ builder.APIGroupVersionProvider = (*AppPluginAPIBuilder)(nil)
+	_ builder.APIGroupBuilder          = (*AppPluginAPIBuilder)(nil)
+	_ builder.APIGroupVersionsProvider = (*AppPluginAPIBuilder)(nil)
 )
 
 // PluginClient is a subset of the plugins.Client interface with only the
@@ -66,7 +66,6 @@ type AppPluginRunnerOptions struct {
 // AppPluginAPIBuilder builds an apiserver for a single app plugin.
 type AppPluginAPIBuilder struct {
 	pluginJSON      plugins.JSONData
-	groupVersion    schema.GroupVersion
 	client          PluginClient // will only ever be called with the same plugin id!
 	contextProvider PluginContextWrapper
 	schemas         map[string]*pluginschema.PluginSchema
@@ -94,11 +93,7 @@ func NewAppPluginAPIBuilder(
 	features featuremgmt.FeatureToggles, // needed for proxy
 ) (*AppPluginAPIBuilder, error) {
 	return &AppPluginAPIBuilder{
-		pluginJSON: plugin.JSONData,
-		groupVersion: schema.GroupVersion{
-			Group:   plugin.JSONData.ID,
-			Version: apiVersion,
-		},
+		pluginJSON:      plugin.JSONData,
 		client:          client,
 		contextProvider: contextProvider,
 		schemas:         plugin.Schemas,
@@ -144,7 +139,7 @@ func RegisterAPIService(
 		}, true)
 
 	if err != nil {
-		return nil, fmt.Errorf("error getting list of datasource plugins: %s", err)
+		return nil, fmt.Errorf("error getting list of app plugins: %w", err)
 	}
 
 	var last *AppPluginAPIBuilder
@@ -170,69 +165,88 @@ func RegisterAPIService(
 		if err != nil {
 			return nil, err
 		}
+
 		apiRegistrar.RegisterAPI(b)
 		last = b
 	}
 	return last, nil
 }
 
-func (b *AppPluginAPIBuilder) GetGroupVersion() schema.GroupVersion {
-	return b.groupVersion
+// GetGroupVersions returns the served versions, preferred version first.
+// The settings kind is registered in every version so it is always reachable.
+func (b *AppPluginAPIBuilder) GetGroupVersions() []schema.GroupVersion {
+	return []schema.GroupVersion{{
+		Group:   b.pluginJSON.ID,
+		Version: apppluginV0.VERSION,
+	}}
 }
 
 func (b *AppPluginAPIBuilder) InstallSchema(scheme *runtime.Scheme) error {
-	if err := apppluginV0.AddKnownTypes(scheme, b.groupVersion); err != nil {
-		return err
+	gvs := b.GetGroupVersions()
+	for _, gv := range gvs {
+		if err := apppluginV0.AddKnownTypes(scheme, gv); err != nil {
+			return err
+		}
 	}
-	return scheme.SetVersionPriority(b.groupVersion)
+
+	return scheme.SetVersionPriority(gvs...)
 }
 
 func (b *AppPluginAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.APIGroupInfo, opts builder.APIGroupOptions) error {
 	registerSubresourceMetrics(opts.MetricsRegister)
 
 	settingsRI := apppluginV0.SettingsResourceInfo.WithGroupAndShortName(
-		b.groupVersion.Group, b.pluginJSON.ID,
+		b.pluginJSON.ID, b.pluginJSON.ID,
 	)
 
-	if opts.StorageOptsRegister != nil {
-		opts.StorageOptsRegister(settingsRI.GroupResource(), apistore.StorageOptions{
-			EnableFolderSupport: false,
-			Scheme:              opts.Scheme,
-		})
+	if opts.StorageOptsRegister == nil {
+		return fmt.Errorf("apps require storage opts")
 	}
+	opts.StorageOptsRegister(settingsRI.GroupResource(), apistore.StorageOptions{
+		EnableFolderSupport: false,
+		Scheme:              opts.Scheme,
+	})
 
 	b.applyDefaultStorageConfig(opts, settingsRI)
 
-	storage := map[string]rest.Storage{}
-
+	// The settings store is version-independent
+	var settingsStorage rest.Storage
 	unified, err := grafanaregistry.NewRegistryStore(opts.Scheme, settingsRI, opts.OptsGetter)
 	if err != nil {
 		return err
 	}
-	storage[settingsRI.StoragePath()] = unified
+	settingsStorage = unified
 	if b.opts.LegacyStore != nil && opts.DualWriteBuilder != nil {
-		store, err := opts.DualWriteBuilder(settingsRI.GroupResource(), b.opts.LegacyStore, unified)
+		settingsStorage, err = opts.DualWriteBuilder(settingsRI.GroupResource(), b.opts.LegacyStore, unified)
 		if err != nil {
 			return err
 		}
-		storage[settingsRI.StoragePath()] = store
 	}
+	b.getter = settingsStorage.(rest.Getter)
 
-	storage[settingsRI.StoragePath("health")] = &subHealthREST{
-		client:          b.client,
-		contextProvider: b.getPluginContext,
-	}
-	storage[settingsRI.StoragePath("resources")] = &subResourceREST{
-		pluginID:        b.pluginJSON.ID,
-		client:          b.client,
-		contextProvider: b.getPluginContext,
-	}
-	if len(b.pluginJSON.Routes) > 0 && b.opts.RegisterProxy {
-		storage[settingsRI.StoragePath("proxy")] = newProxy(b)
-	}
+	for _, gv := range b.GetGroupVersions() {
+		storage := map[string]rest.Storage{}
+		storage[settingsRI.StoragePath()] = settingsStorage
 
-	b.getter = storage[settingsRI.StoragePath()].(rest.Getter)
-	apiGroupInfo.VersionedResourcesStorageMap[b.groupVersion.Version] = storage
+		provider := func(ctx context.Context) (context.Context, backend.PluginContext, error) {
+			return b.getPluginContext(ctx, gv.Version)
+		}
+
+		storage[settingsRI.StoragePath("health")] = &subHealthREST{
+			client:          b.client,
+			contextProvider: provider,
+		}
+		storage[settingsRI.StoragePath("resources")] = &subResourceREST{
+			pluginID:        b.pluginJSON.ID,
+			client:          b.client,
+			contextProvider: provider,
+		}
+		if len(b.pluginJSON.Routes) > 0 && b.opts.RegisterProxy {
+			storage[settingsRI.StoragePath("proxy")] = newProxy(b)
+		}
+
+		apiGroupInfo.VersionedResourcesStorageMap[gv.Version] = storage
+	}
 	return nil
 }
 

--- a/pkg/registry/apis/appplugin/register_test.go
+++ b/pkg/registry/apis/appplugin/register_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	apppluginV0 "github.com/grafana/grafana/pkg/apis/appplugin/v0alpha1"
@@ -150,10 +149,6 @@ func TestApplyDefaultStorageConfig(t *testing.T) {
 	newBuilder := func(pluginID string) *AppPluginAPIBuilder {
 		return &AppPluginAPIBuilder{
 			pluginJSON: plugins.JSONData{ID: pluginID},
-			groupVersion: schema.GroupVersion{
-				Group:   pluginID,
-				Version: apppluginV0.VERSION,
-			},
 		}
 	}
 


### PR DESCRIPTION
This updates builder structure so it is no longer pinned to a single apiVersion -- this will help with https://github.com/grafana/grafana/pull/130738

This does not introduce any behavior changes