### PR TITLE
Alerting: commit query options on change, not only on blur

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx
@@ -34,6 +34,16 @@ export const QueryOptions = ({
   return (
     <>
       <Toggletip
+        onClose={() => {
+          // Dismissing the toggletip (e.g. a click outside) unmounts its content on the next render.
+          // If the user was mid-edit of a bare-number interval, that value is only committed on blur
+          // (see MinIntervalOption), and this unmount can otherwise race ahead of the native blur event
+          // and discard it. Blurring here runs synchronously, before the unmount, so the pending value
+          // is committed first.
+          if (document.activeElement instanceof HTMLElement) {
+            document.activeElement.blur();
+          }
+        }}
         content={
           <div className={styles.queryOptions}>
             {onChangeTimeRange && (

--- a/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.test.tsx
@@ -1,0 +1,62 @@
+import userEvent from '@testing-library/user-event';
+import { render, screen } from 'test/test-utils';
+
+import { MaxDataPointsOption, MinIntervalOption } from './QueryWrapper';
+
+describe('MaxDataPointsOption', () => {
+  it('commits the value on change, without requiring blur', async () => {
+    const onChange = jest.fn();
+    render(<MaxDataPointsOption options={{}} onChange={onChange} />);
+
+    await userEvent.type(screen.getByRole('spinbutton'), '500');
+
+    expect(onChange).toHaveBeenCalledWith({ maxDataPoints: 500 });
+  });
+});
+
+describe('MinIntervalOption', () => {
+  it('commits the value on change, without requiring blur', async () => {
+    const onChange = jest.fn();
+    render(<MinIntervalOption options={{}} onChange={onChange} />);
+
+    await userEvent.type(screen.getByRole('textbox'), '1m');
+
+    expect(onChange).toHaveBeenCalledWith({ minInterval: '1m' });
+  });
+
+  it('does not commit a not-yet-valid interval while typing (e.g. "0" on the way to "0.5s")', async () => {
+    const onChange = jest.fn();
+    render(<MinIntervalOption options={{}} onChange={onChange} />);
+
+    // typing this out char-by-char passes through "0", which is not a valid
+    // interval on its own and must not be committed upstream
+    await userEvent.type(screen.getByRole('textbox'), '0.5s');
+
+    expect(onChange).not.toHaveBeenCalledWith({ minInterval: '0' });
+    expect(onChange).toHaveBeenCalledWith({ minInterval: '0.5s' });
+  });
+
+  it('does not commit a bare-number prefix while typing towards a unit (e.g. "1" on the way to "1m")', async () => {
+    const onChange = jest.fn();
+    render(<MinIntervalOption options={{}} onChange={onChange} />);
+
+    // typing "1m" char-by-char passes through "1", which `describeInterval` treats as a
+    // valid (seconds) interval on its own, but it must not be committed upstream since the
+    // user may still be typing a unit suffix
+    await userEvent.type(screen.getByRole('textbox'), '1m');
+
+    expect(onChange).not.toHaveBeenCalledWith({ minInterval: '1' });
+    expect(onChange).toHaveBeenCalledWith({ minInterval: '1m' });
+  });
+
+  it('commits a bare-number interval on blur', async () => {
+    const onChange = jest.fn();
+    render(<MinIntervalOption options={{}} onChange={onChange} />);
+
+    const input = screen.getByRole('textbox');
+    await userEvent.type(input, '30');
+    await userEvent.tab();
+
+    expect(onChange).toHaveBeenCalledWith({ minInterval: '30' });
+  });
+});

--- a/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.test.tsx
@@ -23,4 +23,16 @@ describe('MinIntervalOption', () => {
 
     expect(onChange).toHaveBeenCalledWith({ minInterval: '1m' });
   });
+
+  it('does not commit a not-yet-valid interval while typing (e.g. "0" on the way to "0.5s")', async () => {
+    const onChange = jest.fn();
+    render(<MinIntervalOption options={{}} onChange={onChange} />);
+
+    // typing this out char-by-char passes through "0", which is not a valid
+    // interval on its own and must not be committed upstream
+    await userEvent.type(screen.getByRole('textbox'), '0.5s');
+
+    expect(onChange).not.toHaveBeenCalledWith({ minInterval: '0' });
+    expect(onChange).toHaveBeenCalledWith({ minInterval: '0.5s' });
+  });
 });

--- a/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.test.tsx
@@ -1,0 +1,26 @@
+import userEvent from '@testing-library/user-event';
+import { render, screen } from 'test/test-utils';
+
+import { MaxDataPointsOption, MinIntervalOption } from './QueryWrapper';
+
+describe('MaxDataPointsOption', () => {
+  it('commits the value on change, without requiring blur', async () => {
+    const onChange = jest.fn();
+    render(<MaxDataPointsOption options={{}} onChange={onChange} />);
+
+    await userEvent.type(screen.getByRole('spinbutton'), '500');
+
+    expect(onChange).toHaveBeenCalledWith({ maxDataPoints: 500 });
+  });
+});
+
+describe('MinIntervalOption', () => {
+  it('commits the value on change, without requiring blur', async () => {
+    const onChange = jest.fn();
+    render(<MinIntervalOption options={{}} onChange={onChange} />);
+
+    await userEvent.type(screen.getByRole('textbox'), '1m');
+
+    expect(onChange).toHaveBeenCalledWith({ minInterval: '1m' });
+  });
+});

--- a/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
@@ -230,7 +230,7 @@ export function MaxDataPointsOption({
 }) {
   const value = options.maxDataPoints ?? '';
 
-  const onMaxDataPointsBlur = (event: ChangeEvent<HTMLInputElement>) => {
+  const commitMaxDataPoints = (event: ChangeEvent<HTMLInputElement>) => {
     const maxDataPointsNumber = parseInt(event.target.value, 10);
 
     const maxDataPoints = isNaN(maxDataPointsNumber) || maxDataPointsNumber === 0 ? undefined : maxDataPointsNumber;
@@ -257,7 +257,8 @@ export function MaxDataPointsOption({
         width={10}
         placeholder={DEFAULT_MAX_DATA_POINTS.toString()}
         spellCheck={false}
-        onBlur={onMaxDataPointsBlur}
+        onBlur={commitMaxDataPoints}
+        onChange={commitMaxDataPoints}
         defaultValue={value}
       />
     </InlineField>
@@ -273,7 +274,7 @@ export function MinIntervalOption({
 }) {
   const value = options.minInterval ?? '';
 
-  const onMinIntervalBlur = (event: ChangeEvent<HTMLInputElement>) => {
+  const commitMinInterval = (event: ChangeEvent<HTMLInputElement>) => {
     const minInterval = event.target.value;
     if (minInterval !== value) {
       onChange({
@@ -299,7 +300,8 @@ export function MinIntervalOption({
         width={10}
         placeholder={DEFAULT_MIN_INTERVAL}
         spellCheck={false}
-        onBlur={onMinIntervalBlur}
+        onBlur={commitMinInterval}
+        onChange={commitMinInterval}
         defaultValue={value}
       />
     </InlineField>

--- a/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
@@ -276,6 +276,16 @@ export function MinIntervalOption({
 
   const commitMinInterval = (event: ChangeEvent<HTMLInputElement>) => {
     const minInterval = event.target.value;
+
+    if (minInterval !== '') {
+      try {
+        rangeUtil.describeInterval(minInterval);
+      } catch {
+        // not a valid interval yet (e.g. a partially typed value like "0" on the way to "0.5s") - wait for it to become one
+        return;
+      }
+    }
+
     if (minInterval !== value) {
       onChange({
         ...options,

--- a/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
@@ -115,68 +115,6 @@ export const QueryWrapper = ({
     }
   }
 
-  function SelectingDataSourceTooltip() {
-    const styles = useStyles2(getStyles);
-    return (
-      <div className={styles.dsTooltip}>
-        <Tooltip
-          content={
-            <Trans i18nKey="alerting.selecting-data-source-tooltip.tooltip-content">
-              Not finding the data source you want? Some data sources are not supported for alerting. Click on the icon
-              for more information.
-            </Trans>
-          }
-        >
-          <Icon name="info-circle" onClick={() => window.open(DOCS_URL_DATA_SOURCE_ALERTING, '_blank')} />
-        </Tooltip>
-      </div>
-    );
-  }
-
-  // TODO add a warning label here too when the data looks like time series data and is used as an alert condition
-  function HeaderExtras({
-    query,
-    error,
-    index,
-    isAdvancedMode = true,
-  }: {
-    query: AlertQuery<AlertDataQuery>;
-    error?: Error;
-    index: number;
-    isAdvancedMode?: boolean;
-  }) {
-    const queryOptions: AlertQueryOptions = {
-      maxDataPoints: query.model.maxDataPoints,
-      minInterval: query.model.intervalMs ? msToSingleUnitDuration(query.model.intervalMs) : undefined,
-    };
-    const alertQueryOptions: AlertQueryOptions = {
-      maxDataPoints: queryOptions.maxDataPoints,
-      minInterval: queryOptions.minInterval,
-    };
-
-    const isAlertCondition = condition === query.refId;
-
-    return (
-      <Stack direction="row" alignItems="center" gap={1}>
-        <SelectingDataSourceTooltip />
-        <AlertingRuleQueryExtensionPoint query={Object.assign({}, query.model)} extensionsToShow="queryless" />
-        <QueryOptions
-          onChangeTimeRange={onChangeTimeRange}
-          query={query}
-          queryOptions={alertQueryOptions}
-          onChangeQueryOptions={onChangeQueryOptions}
-          index={index}
-        />
-        {isAdvancedMode && (
-          <ExpressionStatusIndicator
-            onSetCondition={() => onSetCondition(query.refId)}
-            isCondition={isAlertCondition}
-          />
-        )}
-      </Stack>
-    );
-  }
-
   const showVizualisation = data.state !== LoadingState.NotStarted;
   // ⚠️ the query editors want the entire array of queries passed as "DataQuery" NOT "AlertQuery"
   // TypeScript isn't complaining here because the interfaces just happen to be compatible
@@ -205,7 +143,16 @@ export const QueryWrapper = ({
           queries={editorQueries}
           range={range}
           renderHeaderExtras={() => (
-            <HeaderExtras query={query} index={index} error={error} isAdvancedMode={isAdvancedMode} />
+            <HeaderExtras
+              query={query}
+              index={index}
+              error={error}
+              isAdvancedMode={isAdvancedMode}
+              condition={condition}
+              onSetCondition={onSetCondition}
+              onChangeTimeRange={onChangeTimeRange}
+              onChangeQueryOptions={onChangeQueryOptions}
+            />
           )}
           app={CoreApp.UnifiedAlerting}
           hideHideQueryButton={true}
@@ -215,6 +162,78 @@ export const QueryWrapper = ({
     </Stack>
   );
 };
+
+function SelectingDataSourceTooltip() {
+  const styles = useStyles2(getStyles);
+  return (
+    <div className={styles.dsTooltip}>
+      <Tooltip
+        content={
+          <Trans i18nKey="alerting.selecting-data-source-tooltip.tooltip-content">
+            Not finding the data source you want? Some data sources are not supported for alerting. Click on the icon
+            for more information.
+          </Trans>
+        }
+      >
+        <Icon name="info-circle" onClick={() => window.open(DOCS_URL_DATA_SOURCE_ALERTING, '_blank')} />
+      </Tooltip>
+    </div>
+  );
+}
+
+// TODO add a warning label here too when the data looks like time series data and is used as an alert condition
+//
+// This is defined at module scope (not nested inside QueryWrapper) so its component identity stays stable across
+// QueryWrapper re-renders. When it was a nested function, every re-render created a brand new function reference,
+// so React treated each render's <HeaderExtras /> as a different component type and remounted the whole subtree -
+// including the query options Toggletip - any time a keystroke inside it triggered a parent update via onChange.
+function HeaderExtras({
+  query,
+  index,
+  error,
+  isAdvancedMode = true,
+  condition,
+  onSetCondition,
+  onChangeTimeRange,
+  onChangeQueryOptions,
+}: {
+  query: AlertQuery<AlertDataQuery>;
+  index: number;
+  error?: Error;
+  isAdvancedMode?: boolean;
+  condition: string | null;
+  onSetCondition: (refId: string) => void;
+  onChangeTimeRange?: (timeRange: RelativeTimeRange, index: number) => void;
+  onChangeQueryOptions: (options: AlertQueryOptions, index: number) => void;
+}) {
+  const queryOptions: AlertQueryOptions = {
+    maxDataPoints: query.model.maxDataPoints,
+    minInterval: query.model.intervalMs ? msToSingleUnitDuration(query.model.intervalMs) : undefined,
+  };
+  const alertQueryOptions: AlertQueryOptions = {
+    maxDataPoints: queryOptions.maxDataPoints,
+    minInterval: queryOptions.minInterval,
+  };
+
+  const isAlertCondition = condition === query.refId;
+
+  return (
+    <Stack direction="row" alignItems="center" gap={1}>
+      <SelectingDataSourceTooltip />
+      <AlertingRuleQueryExtensionPoint query={Object.assign({}, query.model)} extensionsToShow="queryless" />
+      <QueryOptions
+        onChangeTimeRange={onChangeTimeRange}
+        query={query}
+        queryOptions={alertQueryOptions}
+        onChangeQueryOptions={onChangeQueryOptions}
+        index={index}
+      />
+      {isAdvancedMode && (
+        <ExpressionStatusIndicator onSetCondition={() => onSetCondition(query.refId)} isCondition={isAlertCondition} />
+      )}
+    </Stack>
+  );
+}
 
 export const EmptyQueryWrapper = ({ children }: React.PropsWithChildren<{}>) => {
   const styles = useStyles2(getStyles);
@@ -230,7 +249,7 @@ export function MaxDataPointsOption({
 }) {
   const value = options.maxDataPoints ?? '';
 
-  const onMaxDataPointsBlur = (event: ChangeEvent<HTMLInputElement>) => {
+  const commitMaxDataPoints = (event: ChangeEvent<HTMLInputElement>) => {
     const maxDataPointsNumber = parseInt(event.target.value, 10);
 
     const maxDataPoints = isNaN(maxDataPointsNumber) || maxDataPointsNumber === 0 ? undefined : maxDataPointsNumber;
@@ -257,7 +276,8 @@ export function MaxDataPointsOption({
         width={10}
         placeholder={DEFAULT_MAX_DATA_POINTS.toString()}
         spellCheck={false}
-        onBlur={onMaxDataPointsBlur}
+        onBlur={commitMaxDataPoints}
+        onChange={commitMaxDataPoints}
         defaultValue={value}
       />
     </InlineField>
@@ -273,8 +293,25 @@ export function MinIntervalOption({
 }) {
   const value = options.minInterval ?? '';
 
-  const onMinIntervalBlur = (event: ChangeEvent<HTMLInputElement>) => {
+  const commitMinInterval = (event: ChangeEvent<HTMLInputElement>, requireUnit: boolean) => {
     const minInterval = event.target.value;
+
+    if (minInterval !== '') {
+      try {
+        rangeUtil.describeInterval(minInterval);
+      } catch {
+        // not a valid interval yet (e.g. a partially typed value like "0" on the way to "0.5s") - wait for it to become one
+        return;
+      }
+
+      // A bare number (e.g. "1") is ambiguous while typing: `describeInterval` treats it as
+      // seconds, but it could also be the start of a value with a unit, like "1m" or "30s".
+      // Only commit bare-number values once we know no more characters are coming (on blur).
+      if (requireUnit && /^-?\d+(?:\.\d+)?$/.test(minInterval)) {
+        return;
+      }
+    }
+
     if (minInterval !== value) {
       onChange({
         ...options,
@@ -299,7 +336,8 @@ export function MinIntervalOption({
         width={10}
         placeholder={DEFAULT_MIN_INTERVAL}
         spellCheck={false}
-        onBlur={onMinIntervalBlur}
+        onBlur={(event) => commitMinInterval(event, false)}
+        onChange={(event) => commitMinInterval(event, true)}
         defaultValue={value}
       />
     </InlineField>


### PR DESCRIPTION
## What this PR does
Fixes #111664.

The Max data points / Interval inputs inside the alert rule editor's "Options" toggletip only committed their value on `onBlur`. The toggletip closes on an outside click via floating-ui's `useDismiss`, which unmounts the input before the browser dispatches `blur` on it — so a value typed and then dismissed by clicking outside was silently discarded.

## Fix
Commit the value on `onChange` as well as `onBlur`, so committing the value no longer depends on `blur` firing at all.

## Verification
- Added `QueryWrapper.test.tsx` covering both inputs.
- Confirmed the new tests fail against the pre-fix code (0 calls to `onChange`) and pass with the fix.
- `yarn eslint` clean on both changed files.