### PR TITLE
docs: improve PostgreSQL read-only user permission example

### DIFF
--- a/docs/sources/datasources/postgres/configure/_index.md
+++ b/docs/sources/datasources/postgres/configure/_index.md
@@ -37,11 +37,12 @@ Example:
 
 ```sql
 CREATE USER grafanareader WITH PASSWORD 'password';
-GRANT USAGE ON SCHEMA schema TO grafanareader;
-GRANT SELECT ON schema.table TO grafanareader;
+GRANT USAGE ON SCHEMA public TO grafanareader;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO grafanareader;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO grafanareader;
 ```
 
-Replace `schema` and `table` with your schema and table names.
+Replace `public` with your schema name if different, and replace `'password'` with a secure password.
 
 ## Add the PostgreSQL data source
 


### PR DESCRIPTION
### What is this feature?
Updates the PostgreSQL documentation's user permission example to grant read access across all tables in a schema (`GRANT SELECT ON ALL TABLES IN SCHEMA public`) and include `ALTER DEFAULT PRIVILEGES` for newly created tables. It also updates placeholder names to standard defaults (`public`).

### Why do we need this feature?
The previous example only granted `SELECT` permissions on a single literal placeholder table (`schema.table`), leading to immediate `permission denied` errors when users queried other tables across their database. Providing permissions for all tables and future tables creates a working, copy-pasteable reference for production setups.

### Who is this feature for?
Grafana administrators and developers configuring a PostgreSQL data source with a dedicated read-only database user.
