### PR TITLE
Folders: Log resource identifiers when the folder reconciler deletes alert rules and library elements

### DIFF
--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -837,14 +837,26 @@ func (l *LibraryElementService) deleteLibraryElementsInFolderUIDUnchecked(c cont
 		}
 	}
 
-	identifiers := make([]string, 0, len(elements))
-	for _, elem := range elements {
-		identifiers = append(identifiers, fmt.Sprintf("%s (%s)", elem.UID, elem.Name))
-	}
-
+	// Delete one row at a time so a concurrent move out of this folder (which leaves the row in
+	// place but changes its folder_uid) shows up as zero rows affected instead of being reported
+	// as deleted.
+	var identifiers []string
 	err = l.SQLStore.WithTransactionalDbSession(c, func(session *db.Session) error {
-		_, err := session.Exec("DELETE FROM library_element WHERE folder_uid=? AND org_id=?", folderUID, orgID)
-		return err
+		identifiers = identifiers[:0]
+		for _, elem := range elements {
+			res, err := session.Exec("DELETE FROM library_element WHERE uid=? AND folder_uid=? AND org_id=?", elem.UID, folderUID, orgID)
+			if err != nil {
+				return err
+			}
+			rowsAffected, err := res.RowsAffected()
+			if err != nil {
+				return err
+			}
+			if rowsAffected > 0 {
+				identifiers = append(identifiers, fmt.Sprintf("%s (%s)", elem.UID, elem.Name))
+			}
+		}
+		return nil
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -803,38 +803,53 @@ func (l *LibraryElementService) deleteLibraryElementsInFolderUID(c context.Conte
 		}
 		return err
 	}
-	return l.deleteLibraryElementsInFolderUIDUnchecked(c, signedInUser.GetOrgID(), folderUID)
+	_, err := l.deleteLibraryElementsInFolderUIDUnchecked(c, signedInUser.GetOrgID(), folderUID)
+	return err
 }
 
 // deleteLibraryElementsInFolderUIDUnchecked deletes all Library Elements in a folder without
 // checking folder permissions; callers must have already confirmed the folder is gone. Elements
 // still connected to a dashboard are kept and block the delete (as in the permission-checked path).
-func (l *LibraryElementService) deleteLibraryElementsInFolderUIDUnchecked(c context.Context, orgID int64, folderUID string) error {
+// It returns "uid (name)" identifiers of the deleted elements, for callers that want to log them.
+func (l *LibraryElementService) deleteLibraryElementsInFolderUIDUnchecked(c context.Context, orgID int64, folderUID string) ([]string, error) {
 	var elements []struct {
-		UID string `xorm:"uid"`
+		UID  string `xorm:"uid"`
+		Name string `xorm:"name"`
 	}
 	err := l.SQLStore.WithDbSession(c, func(session *db.Session) error {
-		return session.SQL("SELECT uid FROM library_element WHERE folder_uid=? AND org_id=?", folderUID, orgID).Find(&elements)
+		return session.SQL("SELECT uid, name FROM library_element WHERE folder_uid=? AND org_id=?", folderUID, orgID).Find(&elements)
 	})
 	if err != nil {
-		return err
+		return nil, err
+	}
+	if len(elements) == 0 {
+		return nil, nil
 	}
 
 	serviceCtx, _ := identity.WithServiceIdentity(c, orgID)
 	for _, elem := range elements {
 		connectedDashboards, err := l.dashboardsService.GetDashboardsByLibraryPanelUID(serviceCtx, elem.UID, orgID)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if len(connectedDashboards) > 0 {
-			return model.ErrFolderHasConnectedLibraryElements
+			return nil, model.ErrFolderHasConnectedLibraryElements
 		}
 	}
 
-	return l.SQLStore.WithTransactionalDbSession(c, func(session *db.Session) error {
+	identifiers := make([]string, 0, len(elements))
+	for _, elem := range elements {
+		identifiers = append(identifiers, fmt.Sprintf("%s (%s)", elem.UID, elem.Name))
+	}
+
+	err = l.SQLStore.WithTransactionalDbSession(c, func(session *db.Session) error {
 		_, err := session.Exec("DELETE FROM library_element WHERE folder_uid=? AND org_id=?", folderUID, orgID)
 		return err
 	})
+	if err != nil {
+		return nil, err
+	}
+	return identifiers, nil
 }
 
 // folderUIDsInUse returns the distinct folder UIDs that contain library elements in the org.

--- a/pkg/services/libraryelements/folder_consumer.go
+++ b/pkg/services/libraryelements/folder_consumer.go
@@ -3,19 +3,22 @@ package libraryelements
 import (
 	"context"
 	"sync"
+
+	"github.com/grafana/grafana/pkg/infra/log"
 )
 
 // FolderConsumer reports and deletes library elements by folder for the folder reconciler.
 type FolderConsumer struct {
 	svc    *LibraryElementService
 	repair *FolderUIDRepairService
+	log    log.Logger
 
 	// warnOnce keeps the gate from logging on every reconcile tick.
 	warnOnce sync.Once
 }
 
 func ProvideFolderConsumer(svc *LibraryElementService, repair *FolderUIDRepairService) *FolderConsumer {
-	return &FolderConsumer{svc: svc, repair: repair}
+	return &FolderConsumer{svc: svc, repair: repair, log: log.New("libraryelements.folder-consumer")}
 }
 
 func (c *FolderConsumer) Name() string { return "library-elements" }
@@ -39,5 +42,12 @@ func (c *FolderConsumer) FoldersInUse(ctx context.Context, orgID int64) ([]strin
 }
 
 func (c *FolderConsumer) DeleteInFolder(ctx context.Context, orgID int64, folderUID string) error {
-	return c.svc.deleteLibraryElementsInFolderUIDUnchecked(ctx, orgID, folderUID)
+	identifiers, err := c.svc.deleteLibraryElementsInFolderUIDUnchecked(ctx, orgID, folderUID)
+	if err != nil {
+		return err
+	}
+	if len(identifiers) > 0 {
+		c.log.Info("Deleted library elements in deleted folder", "org_id", orgID, "folder_uid", folderUID, "count", len(identifiers), "elements", identifiers)
+	}
+	return nil
 }

--- a/pkg/services/libraryelements/folder_consumer_test.go
+++ b/pkg/services/libraryelements/folder_consumer_test.go
@@ -190,4 +190,45 @@ func TestIntegration_FolderConsumer_DeleteInFolder(t *testing.T) {
 		require.NoError(t, dbErr)
 		require.Equal(t, []string{"panel-1"}, remaining)
 	})
+
+	t.Run("does not report an element moved out of the folder before delete", func(t *testing.T) {
+		store := db.InitTestDB(t) //nolint:staticcheck // legacy shared-DB test setup; migrate to NewTestStore
+		repair := &FolderUIDRepairService{store: store, kv: kvstore.NewFakeKVStore(), log: log.New("test")}
+		markRepairComplete(t, repair)
+		insertLibraryElement(t, store, "panel-1", "CPU usage", "f1")
+		insertLibraryElement(t, store, "panel-2", "Memory usage", "f1")
+
+		dashSvc := dashboards.NewFakeDashboardService(t)
+		// The dashboard-connection check is the last read before the delete, so use it to land a
+		// concurrent move out of the folder right in the middle of DeleteInFolder's own work.
+		dashSvc.On("GetDashboardsByLibraryPanelUID", mock.Anything, "panel-1", mock.Anything).
+			Run(func(mock.Arguments) {
+				moveErr := store.WithDbSession(context.Background(), func(sess *db.Session) error {
+					_, err := sess.Exec("UPDATE library_element SET folder_uid=? WHERE uid=?", "f2", "panel-1")
+					return err
+				})
+				require.NoError(t, moveErr)
+			}).
+			Return([]*dashboards.DashboardRef{}, nil)
+		dashSvc.On("GetDashboardsByLibraryPanelUID", mock.Anything, "panel-2", mock.Anything).
+			Return([]*dashboards.DashboardRef{}, nil)
+
+		svc := &LibraryElementService{SQLStore: store, log: log.New("test"), dashboardsService: dashSvc}
+		c := ProvideFolderConsumer(svc, repair)
+		fakeLog := &logtest.Fake{}
+		c.log = fakeLog
+
+		require.NoError(t, c.DeleteInFolder(context.Background(), repairOrgID, "f1"))
+
+		require.Equal(t, 1, fakeLog.InfoLogs.Calls)
+		require.Equal(t, []string{"panel-2 (Memory usage)"}, logCtxValue(t, fakeLog.InfoLogs.Ctx, "elements"))
+
+		var movedFolder string
+		err := store.WithDbSession(context.Background(), func(sess *db.Session) error {
+			_, err := sess.SQL("SELECT folder_uid FROM library_element WHERE uid=?", "panel-1").Get(&movedFolder)
+			return err
+		})
+		require.NoError(t, err)
+		require.Equal(t, "f2", movedFolder)
+	})
 }

--- a/pkg/services/libraryelements/folder_consumer_test.go
+++ b/pkg/services/libraryelements/folder_consumer_test.go
@@ -2,6 +2,7 @@ package libraryelements
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/open-feature/go-sdk/openfeature"
@@ -110,8 +111,9 @@ func TestIntegration_FolderConsumer_FoldersInUse(t *testing.T) {
 }
 
 // deleteConsumerSetup wires a FolderConsumer with the repair already marked complete and an
-// observable logger, ready to exercise DeleteInFolder.
-func deleteConsumerSetup(t *testing.T) (*FolderConsumer, db.DB, *logtest.Fake) {
+// observable logger, ready to exercise DeleteInFolder. dashboardsErr, if non-nil, is returned by
+// the dashboard-lookup dependency instead of an empty connected-dashboards list.
+func deleteConsumerSetup(t *testing.T, dashboardsErr error) (*FolderConsumer, db.DB, *logtest.Fake) {
 	t.Helper()
 	store := db.InitTestDB(t) //nolint:staticcheck // legacy shared-DB test setup; migrate to NewTestStore
 	repair := &FolderUIDRepairService{store: store, kv: kvstore.NewFakeKVStore(), log: log.New("test")}
@@ -119,7 +121,7 @@ func deleteConsumerSetup(t *testing.T) (*FolderConsumer, db.DB, *logtest.Fake) {
 
 	dashSvc := dashboards.NewFakeDashboardService(t)
 	dashSvc.On("GetDashboardsByLibraryPanelUID", mock.Anything, mock.Anything, mock.Anything).
-		Return([]*dashboards.DashboardRef{}, nil).Maybe()
+		Return([]*dashboards.DashboardRef{}, dashboardsErr).Maybe()
 
 	svc := &LibraryElementService{SQLStore: store, log: log.New("test"), dashboardsService: dashSvc}
 	c := ProvideFolderConsumer(svc, repair)
@@ -144,7 +146,7 @@ func TestIntegration_FolderConsumer_DeleteInFolder(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	t.Run("logs uid and name of deleted elements", func(t *testing.T) {
-		c, store, fakeLog := deleteConsumerSetup(t)
+		c, store, fakeLog := deleteConsumerSetup(t, nil)
 		insertLibraryElement(t, store, "panel-1", "CPU usage", "f1")
 		insertLibraryElement(t, store, "panel-2", "Memory usage", "f1")
 
@@ -166,9 +168,26 @@ func TestIntegration_FolderConsumer_DeleteInFolder(t *testing.T) {
 	})
 
 	t.Run("does not log when there is nothing to delete", func(t *testing.T) {
-		c, _, fakeLog := deleteConsumerSetup(t)
+		c, _, fakeLog := deleteConsumerSetup(t, nil)
 
 		require.NoError(t, c.DeleteInFolder(context.Background(), repairOrgID, "empty-folder"))
 		require.Equal(t, 0, fakeLog.InfoLogs.Calls)
+	})
+
+	t.Run("does not log when the dashboard lookup fails", func(t *testing.T) {
+		lookupErr := errors.New("dashboard lookup failed")
+		c, store, fakeLog := deleteConsumerSetup(t, lookupErr)
+		insertLibraryElement(t, store, "panel-1", "CPU usage", "f1")
+
+		err := c.DeleteInFolder(context.Background(), repairOrgID, "f1")
+		require.ErrorIs(t, err, lookupErr)
+		require.Equal(t, 0, fakeLog.InfoLogs.Calls)
+
+		var remaining []string
+		dbErr := store.WithDbSession(context.Background(), func(sess *db.Session) error {
+			return sess.SQL("SELECT uid FROM library_element WHERE folder_uid=?", "f1").Find(&remaining)
+		})
+		require.NoError(t, dbErr)
+		require.Equal(t, []string{"panel-1"}, remaining)
 	})
 }

--- a/pkg/services/libraryelements/folder_consumer_test.go
+++ b/pkg/services/libraryelements/folder_consumer_test.go
@@ -6,14 +6,29 @@ import (
 
 	"github.com/open-feature/go-sdk/openfeature"
 	"github.com/open-feature/go-sdk/openfeature/memprovider"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/kvstore"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/log/logtest"
+	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
+
+// logCtxValue looks up a key in the alternating key/value slice a log.Logger call receives.
+func logCtxValue(t *testing.T, ctx []any, key string) any {
+	t.Helper()
+	for i := 0; i+1 < len(ctx); i += 2 {
+		if ctx[i] == key {
+			return ctx[i+1]
+		}
+	}
+	t.Fatalf("key %q not found in log context %v", key, ctx)
+	return nil
+}
 
 // enableRepairFlag turns the repair toggle on, which is what makes the cleanup gate apply.
 func enableRepairFlag(t *testing.T) {
@@ -91,5 +106,69 @@ func TestIntegration_FolderConsumer_FoldersInUse(t *testing.T) {
 		uids, err := c.FoldersInUse(context.Background(), repairOrgID)
 		require.NoError(t, err)
 		require.Empty(t, uids)
+	})
+}
+
+// deleteConsumerSetup wires a FolderConsumer with the repair already marked complete and an
+// observable logger, ready to exercise DeleteInFolder.
+func deleteConsumerSetup(t *testing.T) (*FolderConsumer, db.DB, *logtest.Fake) {
+	t.Helper()
+	store := db.InitTestDB(t) //nolint:staticcheck // legacy shared-DB test setup; migrate to NewTestStore
+	repair := &FolderUIDRepairService{store: store, kv: kvstore.NewFakeKVStore(), log: log.New("test")}
+	markRepairComplete(t, repair)
+
+	dashSvc := dashboards.NewFakeDashboardService(t)
+	dashSvc.On("GetDashboardsByLibraryPanelUID", mock.Anything, mock.Anything, mock.Anything).
+		Return([]*dashboards.DashboardRef{}, nil).Maybe()
+
+	svc := &LibraryElementService{SQLStore: store, log: log.New("test"), dashboardsService: dashSvc}
+	c := ProvideFolderConsumer(svc, repair)
+	fakeLog := &logtest.Fake{}
+	c.log = fakeLog
+	return c, store, fakeLog
+}
+
+func insertLibraryElement(t *testing.T, store db.DB, uid, name, folderUID string) {
+	t.Helper()
+	err := store.WithDbSession(context.Background(), func(sess *db.Session) error {
+		_, err := sess.Exec(`INSERT INTO library_element
+			(org_id, folder_id, folder_uid, uid, name, kind, type, description, model, version, created, created_by, updated, updated_by)
+			VALUES (?, 0, ?, ?, ?, 1, 'timeseries', '', '{}', 1, '2024-01-01', 1, '2024-01-01', 1)`,
+			repairOrgID, folderUID, uid, name)
+		return err
+	})
+	require.NoError(t, err)
+}
+
+func TestIntegration_FolderConsumer_DeleteInFolder(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	t.Run("logs uid and name of deleted elements", func(t *testing.T) {
+		c, store, fakeLog := deleteConsumerSetup(t)
+		insertLibraryElement(t, store, "panel-1", "CPU usage", "f1")
+		insertLibraryElement(t, store, "panel-2", "Memory usage", "f1")
+
+		require.NoError(t, c.DeleteInFolder(context.Background(), repairOrgID, "f1"))
+
+		require.Equal(t, 1, fakeLog.InfoLogs.Calls)
+		require.Equal(t, "Deleted library elements in deleted folder", fakeLog.InfoLogs.Message)
+		require.ElementsMatch(t, []string{"panel-1 (CPU usage)", "panel-2 (Memory usage)"},
+			logCtxValue(t, fakeLog.InfoLogs.Ctx, "elements"))
+		require.Equal(t, 2, logCtxValue(t, fakeLog.InfoLogs.Ctx, "count"))
+		require.Equal(t, "f1", logCtxValue(t, fakeLog.InfoLogs.Ctx, "folder_uid"))
+
+		var remaining []string
+		err := store.WithDbSession(context.Background(), func(sess *db.Session) error {
+			return sess.SQL("SELECT uid FROM library_element WHERE folder_uid=?", "f1").Find(&remaining)
+		})
+		require.NoError(t, err)
+		require.Empty(t, remaining)
+	})
+
+	t.Run("does not log when there is nothing to delete", func(t *testing.T) {
+		c, _, fakeLog := deleteConsumerSetup(t)
+
+		require.NoError(t, c.DeleteInFolder(context.Background(), repairOrgID, "empty-folder"))
+		require.Equal(t, 0, fakeLog.InfoLogs.Calls)
 	})
 }

--- a/pkg/services/ngalert/folder_consumer.go
+++ b/pkg/services/ngalert/folder_consumer.go
@@ -2,8 +2,10 @@ package ngalert
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 )
@@ -17,10 +19,11 @@ type alertRuleStore interface {
 // AlertRuleFolderConsumer reports and deletes alert rules by folder for the folder reconciler.
 type AlertRuleFolderConsumer struct {
 	store alertRuleStore
+	log   log.Logger
 }
 
 func ProvideAlertRuleFolderConsumer(store *store.DBstore) *AlertRuleFolderConsumer {
-	return &AlertRuleFolderConsumer{store: store}
+	return &AlertRuleFolderConsumer{store: store, log: log.New("ngalert.folder-consumer")}
 }
 
 func (c *AlertRuleFolderConsumer) Name() string { return "alert-rules" }
@@ -50,11 +53,17 @@ func (c *AlertRuleFolderConsumer) DeleteInFolder(ctx context.Context, orgID int6
 		return err
 	}
 	uids := make([]string, 0, len(rules))
+	identifiers := make([]string, 0, len(rules))
 	for _, r := range rules {
 		uids = append(uids, r.UID)
+		identifiers = append(identifiers, fmt.Sprintf("%s (%s)", r.UID, r.Title))
 	}
 	if len(uids) == 0 {
 		return nil
 	}
-	return c.store.DeleteAlertRulesByUID(ctx, orgID, models.NewUserUID(user), false, uids...)
+	if err := c.store.DeleteAlertRulesByUID(ctx, orgID, models.NewUserUID(user), false, uids...); err != nil {
+		return err
+	}
+	c.log.Info("Deleted alert rules in deleted folder", "org_id", orgID, "folder_uid", folderUID, "count", len(uids), "rules", identifiers)
+	return nil
 }

--- a/pkg/services/ngalert/folder_consumer_test.go
+++ b/pkg/services/ngalert/folder_consumer_test.go
@@ -2,17 +2,19 @@ package ngalert
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/log/logtest"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
 type fakeAlertRuleStore struct {
-	rules   map[int64][]*models.AlertRule
-	deleted []string
+	rules     map[int64][]*models.AlertRule
+	deleted   []string
+	deleteErr error
 }
 
 func (s *fakeAlertRuleStore) ListAlertRules(_ context.Context, q *models.ListAlertRulesQuery) (models.RulesGroup, error) {
@@ -33,19 +35,35 @@ func (s *fakeAlertRuleStore) ListAlertRules(_ context.Context, q *models.ListAle
 }
 
 func (s *fakeAlertRuleStore) DeleteAlertRulesByUID(_ context.Context, _ int64, _ *models.UserUID, _ bool, ruleUID ...string) error {
+	if s.deleteErr != nil {
+		return s.deleteErr
+	}
 	s.deleted = append(s.deleted, ruleUID...)
+	return nil
+}
+
+// logCtxValue looks up a key in the alternating key/value slice a log.Logger call receives.
+func logCtxValue(t *testing.T, ctx []any, key string) any {
+	t.Helper()
+	for i := 0; i+1 < len(ctx); i += 2 {
+		if ctx[i] == key {
+			return ctx[i+1]
+		}
+	}
+	t.Fatalf("key %q not found in log context %v", key, ctx)
 	return nil
 }
 
 func TestAlertRuleFolderConsumer(t *testing.T) {
 	store := &fakeAlertRuleStore{rules: map[int64][]*models.AlertRule{
 		1: {
-			{OrgID: 1, NamespaceUID: "a", UID: "r1"},
-			{OrgID: 1, NamespaceUID: "a", UID: "r2"},
-			{OrgID: 1, NamespaceUID: "b", UID: "r3"},
+			{OrgID: 1, NamespaceUID: "a", UID: "r1", Title: "CPU alert"},
+			{OrgID: 1, NamespaceUID: "a", UID: "r2", Title: "Memory alert"},
+			{OrgID: 1, NamespaceUID: "b", UID: "r3", Title: "Disk alert"},
 		},
 	}}
-	c := &AlertRuleFolderConsumer{store: store, log: log.NewNopLogger()}
+	fakeLog := &logtest.Fake{}
+	c := &AlertRuleFolderConsumer{store: store, log: fakeLog}
 
 	uids, err := c.FoldersInUse(context.Background(), 1)
 	require.NoError(t, err)
@@ -53,4 +71,34 @@ func TestAlertRuleFolderConsumer(t *testing.T) {
 
 	require.NoError(t, c.DeleteInFolder(context.Background(), 1, "a"))
 	require.ElementsMatch(t, []string{"r1", "r2"}, store.deleted)
+
+	require.Equal(t, 1, fakeLog.InfoLogs.Calls)
+	require.Equal(t, "Deleted alert rules in deleted folder", fakeLog.InfoLogs.Message)
+	require.ElementsMatch(t, []string{"r1 (CPU alert)", "r2 (Memory alert)"}, logCtxValue(t, fakeLog.InfoLogs.Ctx, "rules"))
+	require.Equal(t, 2, logCtxValue(t, fakeLog.InfoLogs.Ctx, "count"))
+	require.Equal(t, "a", logCtxValue(t, fakeLog.InfoLogs.Ctx, "folder_uid"))
+}
+
+func TestAlertRuleFolderConsumer_NoRulesToDelete_DoesNotLog(t *testing.T) {
+	store := &fakeAlertRuleStore{rules: map[int64][]*models.AlertRule{}}
+	fakeLog := &logtest.Fake{}
+	c := &AlertRuleFolderConsumer{store: store, log: fakeLog}
+
+	require.NoError(t, c.DeleteInFolder(context.Background(), 1, "a"))
+	require.Equal(t, 0, fakeLog.InfoLogs.Calls)
+}
+
+func TestAlertRuleFolderConsumer_DeleteError_DoesNotLog(t *testing.T) {
+	store := &fakeAlertRuleStore{
+		rules: map[int64][]*models.AlertRule{
+			1: {{OrgID: 1, NamespaceUID: "a", UID: "r1", Title: "CPU alert"}},
+		},
+		deleteErr: errors.New("boom"),
+	}
+	fakeLog := &logtest.Fake{}
+	c := &AlertRuleFolderConsumer{store: store, log: fakeLog}
+
+	err := c.DeleteInFolder(context.Background(), 1, "a")
+	require.ErrorIs(t, err, store.deleteErr)
+	require.Equal(t, 0, fakeLog.InfoLogs.Calls)
 }

--- a/pkg/services/ngalert/folder_consumer_test.go
+++ b/pkg/services/ngalert/folder_consumer_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
@@ -44,7 +45,7 @@ func TestAlertRuleFolderConsumer(t *testing.T) {
 			{OrgID: 1, NamespaceUID: "b", UID: "r3"},
 		},
 	}}
-	c := &AlertRuleFolderConsumer{store: store}
+	c := &AlertRuleFolderConsumer{store: store, log: log.NewNopLogger()}
 
 	uids, err := c.FoldersInUse(context.Background(), 1)
 	require.NoError(t, err)


### PR DESCRIPTION
Adds resource-level detail (UID + title/name) to the folder reconciler's delete logs for alert rules and library elements, and gives library elements their own libraryelements.folder-consumer logger to match.

Logging now fires only after a successful delete, so failures aren't misreported as completed.