### PR TITLE
IAM: Add role-based userActions endpoint on iam.grafana.app

### DIFF
--- a/packages/grafana-api-clients/src/clients/rtkq/iam/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/iam/v0alpha1/endpoints.gen.ts
@@ -1,5 +1,13 @@
 import { api } from './baseAPI';
-export const addTagTypes = ['API Discovery', 'Display', 'Search', 'ServiceAccount', 'Team', 'User'] as const;
+export const addTagTypes = [
+  'API Discovery',
+  'Display',
+  'Search',
+  'ServiceAccount',
+  'Team',
+  'UserActions',
+  'User',
+] as const;
 const injectedRtkApi = api
   .enhanceEndpoints({
     addTagTypes,
@@ -300,6 +308,15 @@ const injectedRtkApi = api
       createTeamRemovemember: build.mutation<CreateTeamRemovememberApiResponse, CreateTeamRemovememberApiArg>({
         query: (queryArg) => ({ url: `/teams/${queryArg.name}/removemember`, method: 'POST' }),
         invalidatesTags: ['Team'],
+      }),
+      getUserActions: build.query<GetUserActionsApiResponse, GetUserActionsApiArg>({
+        query: (queryArg) => ({
+          url: `/userActions`,
+          params: {
+            reloadcache: queryArg.reloadcache,
+          },
+        }),
+        providesTags: ['UserActions'],
       }),
       listUser: build.query<ListUserApiResponse, ListUserApiArg>({
         query: (queryArg) => ({
@@ -751,6 +768,13 @@ export type CreateTeamRemovememberApiResponse =
 export type CreateTeamRemovememberApiArg = {
   /** name of the TeamMemberList */
   name: string;
+};
+export type GetUserActionsApiResponse = /** status 200 Map of RBAC action to true */ {
+  [key: string]: boolean;
+};
+export type GetUserActionsApiArg = {
+  /** Resolve permissions afresh rather than serving a cached set */
+  reloadcache?: boolean;
 };
 export type ListUserApiResponse = /** status 200 OK */ UserList;
 export type ListUserApiArg = {
@@ -1292,6 +1316,8 @@ export const {
   useGetTeamMembersQuery,
   useLazyGetTeamMembersQuery,
   useCreateTeamRemovememberMutation,
+  useGetUserActionsQuery,
+  useLazyGetUserActionsQuery,
   useListUserQuery,
   useLazyListUserQuery,
   useCreateUserMutation,

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -906,6 +906,11 @@ export interface FeatureToggles {
   */
   kubernetesAuthzResourcePermissionApis?: boolean;
   /**
+  * Registers the IAM userActions /apis endpoint
+  * @default false
+  */
+  kubernetesUserActionsApi?: boolean;
+  /**
   * Enable sync of Zanzana authorization store on AuthZ CRD mutations
   * @default false
   */

--- a/packages/grafana-openapi/src/apis/iam.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/iam.grafana.app-v0alpha1.json
@@ -1834,6 +1834,38 @@
         }
       ]
     },
+    "/userActions": {
+      "get": {
+        "tags": ["UserActions"],
+        "description": "Returns the RBAC actions granted to the calling user, as a map of action to true.",
+        "operationId": "getUserActions",
+        "parameters": [
+          {
+            "name": "reloadcache",
+            "in": "query",
+            "description": "Resolve permissions afresh rather than serving a cached set",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Map of RBAC action to true",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/users": {
       "get": {
         "tags": ["User"],

--- a/pkg/registry/apis/iam/authorizer.go
+++ b/pkg/registry/apis/iam/authorizer.go
@@ -13,6 +13,7 @@ import (
 	legacyiamv0 "github.com/grafana/grafana/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/display"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/legacy"
+	"github.com/grafana/grafana/pkg/registry/apis/iam/useractions"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	gfauthorizer "github.com/grafana/grafana/pkg/services/apiserver/auth/authorizer"
 )
@@ -52,6 +53,18 @@ func newIAMAuthorizer(
 	// Identity specific resources
 	legacyAuthorizer := gfauthorizer.NewResourceAuthorizer(legacyAccessClient)
 	resourceAuthorizer["display"] = legacyAuthorizer
+
+	// The userActions response is strictly self-scoped (derived from the
+	// caller's own role), so any authenticated identity may read it — same
+	// rationale as the current-user display route.
+	resourceAuthorizer[useractions.RoutePath] = authorizer.AuthorizerFunc(func(
+		ctx context.Context, attr authorizer.Attributes,
+	) (authorizer.Decision, string, error) {
+		if _, ok := authlib.AuthInfoFrom(ctx); ok {
+			return authorizer.DecisionAllow, "", nil
+		}
+		return authorizer.DecisionDeny, "cannot read user actions without an identity", nil
+	})
 
 	// Temporary security fix: Block Watch on ResourcePermissions until proper filtering is implemented
 	blockWatchAuthorizer := authorizer.AuthorizerFunc(func(

--- a/pkg/registry/apis/iam/models.go
+++ b/pkg/registry/apis/iam/models.go
@@ -21,6 +21,7 @@ import (
 	"github.com/grafana/grafana/pkg/registry/apis/iam/team"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/teambinding"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/user"
+	"github.com/grafana/grafana/pkg/registry/apis/iam/useractions"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/apiserver/builder"
 	"github.com/grafana/grafana/pkg/services/authz/zanzana"
@@ -94,8 +95,9 @@ type IdentityAccessManagementAPIBuilder struct {
 
 	teamGroupsHandlerProvider externalgroupmapping.TeamGroupsHandlerProvider
 
-	// non-k8s api route
-	display *display.DisplayHandler
+	// non-k8s api routes
+	display            *display.DisplayHandler
+	userActionsHandler *useractions.Handler
 
 	// ac is used for legacy permission checks in role bindings.
 	// nil where only k8s-mapped permissions are supported.

--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -46,6 +46,7 @@ import (
 	"github.com/grafana/grafana/pkg/registry/apis/iam/team"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/teambinding"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/user"
+	"github.com/grafana/grafana/pkg/registry/apis/iam/useractions"
 	"github.com/grafana/grafana/pkg/registry/fieldselectors"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/apiserver"
@@ -53,6 +54,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/apiserver/auth/authorizer/storewrapper"
 	"github.com/grafana/grafana/pkg/services/apiserver/builder"
 	"github.com/grafana/grafana/pkg/services/apiserver/versionpolicy"
+	authzstore "github.com/grafana/grafana/pkg/services/authz/rbac/store"
 	"github.com/grafana/grafana/pkg/services/authz/zanzana"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/org"
@@ -76,6 +78,7 @@ func RegisterAPIService(
 	ssoService ssosettings.Service,
 	sql db.DB,
 	ac accesscontrol.AccessControl,
+	actionResolver accesscontrol.ActionResolver,
 	accessClient types.AccessClient,
 	zClient zanzana.Client,
 	reg prometheus.Registerer,
@@ -185,6 +188,12 @@ func RegisterAPIService(
 			display.NewLegacyDisplayProvider(store),   // Do legacy first
 			display.NewSearchDisplayProvider(unified), // then use search index
 		),
+		userActionsHandler: useractions.NewHandler(useractions.NewCachedProvider(useractions.NewSQLProvider(
+			useractions.NewSQLActionStore(dbProvider, tracing),
+			authzstore.NewStore(dbProvider, tracing),
+			store,
+			actionResolver,
+		))),
 		ofClient: openfeature.NewDefaultClient(),
 	}
 	builder.userSearchHandler = user.NewSearchHandler(tracing, builder.userSearchClient, cfg, accessClient)
@@ -237,6 +246,12 @@ func NewAPIService(
 			display.NewLegacyDisplayProvider(store),
 			// TODO: include the search client here
 		),
+		userActionsHandler: useractions.NewHandler(useractions.NewCachedProvider(useractions.NewSQLProvider(
+			useractions.NewSQLActionStore(dbProvider, tracingService),
+			authzstore.NewStore(dbProvider, tracingService),
+			store,
+			useractions.NewActionSetResolver(),
+		))),
 		tracing:                    tracingService,
 		resourcePermissionsStorage: resourcePermissionsStorage,
 		mappers:                    mappers,
@@ -306,6 +321,16 @@ func NewAPIService(
 
 				if a.GetResource() == "users" {
 					return userAuthorizer.Authorize(ctx, a)
+				}
+
+				if a.GetResource() == useractions.RoutePath {
+					// Strictly self-scoped: derived from the caller's own role.
+					switch user.GetIdentityType() {
+					case types.TypeUser, types.TypeServiceAccount:
+						return authorizer.DecisionAllow, "", nil
+					default:
+						return authorizer.DecisionDeny, "userActions requires a user identity", nil
+					}
 				}
 
 				if a.GetResource() == iamv0.ServiceAccountResourceInfo.GetName() {
@@ -953,6 +978,7 @@ func (b *IdentityAccessManagementAPIBuilder) GetAPIRoutes(gv schema.GroupVersion
 	enableTeamsApi := client.Boolean(ctx, featuremgmt.FlagKubernetesTeamsApi, false, openfeature.TransactionContext(ctx))
 	enableUserApi := b.isSingleOrgSetup() && client.Boolean(ctx, featuremgmt.FlagKubernetesUsersApi, false, openfeature.TransactionContext(ctx))
 	enableResourcePermissionsApi := client.Boolean(ctx, featuremgmt.FlagKubernetesAuthzResourcePermissionApis, false, openfeature.TransactionContext(ctx))
+	enableUserActionsApi := client.Boolean(ctx, featuremgmt.FlagKubernetesUserActionsApi, false, openfeature.TransactionContext(ctx))
 
 	searchRoutes := make([]*builder.APIRoutes, 0, 4)
 	if enableUserApi && b.userSearchHandler != nil {
@@ -971,8 +997,11 @@ func (b *IdentityAccessManagementAPIBuilder) GetAPIRoutes(gv schema.GroupVersion
 		searchRoutes = append(searchRoutes, b.externalGroupMappingSearchHandler.GetAPIRoutes(defs))
 	}
 
-	routes := make([]*builder.APIRoutes, 0, 1+len(searchRoutes))
+	routes := make([]*builder.APIRoutes, 0, 2+len(searchRoutes))
 	routes = append(routes, b.display.GetAPIRoutes(defs))
+	if enableUserActionsApi && b.userActionsHandler != nil {
+		routes = append(routes, b.userActionsHandler.GetAPIRoutes(defs))
+	}
 	routes = append(routes, searchRoutes...)
 	return mergeAPIRoutes(routes...)
 }

--- a/pkg/registry/apis/iam/useractions/actionsets.go
+++ b/pkg/registry/apis/iam/useractions/actionsets.go
@@ -1,0 +1,27 @@
+package useractions
+
+import (
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/ossaccesscontrol"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
+)
+
+// NewActionSetResolver seeds a resolver with the resource permission action
+// sets, so stored action sets can be expanded into the actions they stand for.
+// Single-tenant gets this from the resource permission services registering
+// themselves at startup; those services do not run in multi-tenant, so the same
+// grants are seeded from the definitions they would have registered.
+func NewActionSetResolver() accesscontrol.ActionResolver {
+	svc := resourcepermissions.NewActionSetService()
+	for name, actions := range map[string][]string{
+		"dashboards:view":  ossaccesscontrol.DashboardViewActions,
+		"dashboards:edit":  ossaccesscontrol.DashboardEditActions,
+		"dashboards:admin": ossaccesscontrol.DashboardAdminActions,
+		"folders:view":     append(ossaccesscontrol.DashboardViewActions, ossaccesscontrol.FolderViewActions...),
+		"folders:edit":     append(ossaccesscontrol.DashboardEditActions, ossaccesscontrol.FolderEditActions...),
+		"folders:admin":    append(ossaccesscontrol.DashboardAdminActions, ossaccesscontrol.FolderAdminActions...),
+	} {
+		svc.StoreActionSet(name, actions)
+	}
+	return svc
+}

--- a/pkg/registry/apis/iam/useractions/actionsets_test.go
+++ b/pkg/registry/apis/iam/useractions/actionsets_test.go
@@ -1,0 +1,24 @@
+package useractions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+)
+
+func TestNewActionSetResolver(t *testing.T) {
+	resolver := NewActionSetResolver()
+
+	expanded := resolver.ExpandActionSets([]accesscontrol.Permission{
+		{Action: "folders:edit", Scope: "folders:uid:abc"},
+		{Action: "alert.rules:read"},
+	})
+
+	actions := accesscontrol.BuildPermissionsMap(expanded)
+	require.True(t, actions["dashboards:read"], "folders:edit must expand to dashboard reads")
+	require.True(t, actions["folders:read"])
+	require.True(t, actions["dashboards:write"])
+	require.True(t, actions["alert.rules:read"], "non action-set permissions must pass through")
+}

--- a/pkg/registry/apis/iam/useractions/cache.go
+++ b/pkg/registry/apis/iam/useractions/cache.go
@@ -1,0 +1,62 @@
+package useractions
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	k8srequest "k8s.io/apiserver/pkg/endpoints/request"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/infra/localcache"
+)
+
+const (
+	// cacheTTL bounds how long a stale permission set can be served. There is no
+	// invalidation hook for permission changes, so a caller that needs to observe
+	// its own new grant immediately passes Options.ReloadCache.
+	cacheTTL = 30 * time.Second
+	// cleanupInterval is how often expired entries are evicted.
+	cleanupInterval = time.Minute
+)
+
+type cachedProvider struct {
+	next  RolePermissionProvider
+	cache *localcache.CacheService
+}
+
+// NewCachedProvider memoizes the resolved action map per identity and tenant.
+// Resolving costs three queries plus a paged team lookup, so an uncached call
+// per page load would multiply load on the tenant database.
+func NewCachedProvider(next RolePermissionProvider) RolePermissionProvider {
+	return &cachedProvider{next: next, cache: localcache.New(cacheTTL, cleanupInterval)}
+}
+
+func (p *cachedProvider) ActionsForUser(ctx context.Context, requester identity.Requester, opts Options) (map[string]bool, error) {
+	// The namespace is part of the key: the same identity can be resolved
+	// against more than one tenant, and each has its own permissions.
+	key := k8srequest.NamespaceValue(ctx) + "/" + requester.GetIdentifier()
+
+	if opts.ReloadCache {
+		p.cache.ExclusiveDelete(key)
+	}
+
+	value, err := p.cache.GetOrExclusiveSet(key, func() (any, error) {
+		return p.next.ActionsForUser(ctx, requester, opts)
+	}, cacheTTL)
+	if err != nil {
+		return nil, err
+	}
+
+	cached, ok := value.(map[string]bool)
+	if !ok {
+		return nil, fmt.Errorf("unexpected cached value of type %T", value)
+	}
+
+	// Copy so callers cannot mutate the shared cached map.
+	actions := make(map[string]bool, len(cached))
+	for action := range cached {
+		actions[action] = true
+	}
+	return actions, nil
+}

--- a/pkg/registry/apis/iam/useractions/cache_test.go
+++ b/pkg/registry/apis/iam/useractions/cache_test.go
@@ -1,0 +1,74 @@
+package useractions
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/services/user"
+)
+
+// countingProvider reports how many times it was asked to resolve, and returns a
+// different action each call so cache hits are distinguishable from misses.
+type countingProvider struct{ calls int }
+
+func (c *countingProvider) ActionsForUser(_ context.Context, _ identity.Requester, _ Options) (map[string]bool, error) {
+	c.calls++
+	return map[string]bool{"call": true, string(rune('a'+c.calls-1)) + ":read": true}, nil
+}
+
+func TestCachedProvider(t *testing.T) {
+	caller := &user.SignedInUser{OrgID: 1, UserID: 1, UserUID: "u1"}
+
+	t.Run("resolves once for repeated calls", func(t *testing.T) {
+		counting := &countingProvider{}
+		provider := NewCachedProvider(counting)
+
+		first, err := provider.ActionsForUser(nsCtx("default"), caller, Options{})
+		require.NoError(t, err)
+		second, err := provider.ActionsForUser(nsCtx("default"), caller, Options{})
+		require.NoError(t, err)
+
+		require.Equal(t, 1, counting.calls, "second call must be served from cache")
+		require.Equal(t, first, second)
+	})
+
+	t.Run("ReloadCache resolves again", func(t *testing.T) {
+		counting := &countingProvider{}
+		provider := NewCachedProvider(counting)
+
+		_, err := provider.ActionsForUser(nsCtx("default"), caller, Options{})
+		require.NoError(t, err)
+		got, err := provider.ActionsForUser(nsCtx("default"), caller, Options{ReloadCache: true})
+		require.NoError(t, err)
+
+		require.Equal(t, 2, counting.calls)
+		require.True(t, got["b:read"], "must return the freshly resolved set")
+	})
+
+	t.Run("caches per tenant", func(t *testing.T) {
+		counting := &countingProvider{}
+		provider := NewCachedProvider(counting)
+
+		_, err := provider.ActionsForUser(nsCtx("stacks-11"), caller, Options{})
+		require.NoError(t, err)
+		_, err = provider.ActionsForUser(nsCtx("stacks-22"), caller, Options{})
+		require.NoError(t, err)
+
+		require.Equal(t, 2, counting.calls, "the same identity in another tenant must not hit the cache")
+	})
+
+	t.Run("returned map is not the cached map", func(t *testing.T) {
+		provider := NewCachedProvider(&countingProvider{})
+
+		first, err := provider.ActionsForUser(nsCtx("default"), caller, Options{})
+		require.NoError(t, err)
+		first["mutated"] = true
+
+		second, err := provider.ActionsForUser(nsCtx("default"), caller, Options{})
+		require.NoError(t, err)
+		require.False(t, second["mutated"], "mutating a returned map must not corrupt the cache")
+	})
+}

--- a/pkg/registry/apis/iam/useractions/handler.go
+++ b/pkg/registry/apis/iam/useractions/handler.go
@@ -1,0 +1,110 @@
+package useractions
+
+import (
+	"encoding/json"
+	"net/http"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/kube-openapi/pkg/common"
+	"k8s.io/kube-openapi/pkg/spec3"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/services/apiserver/builder"
+	"github.com/grafana/grafana/pkg/util/errhttp"
+)
+
+// RoutePath is the route, and the resource name it is authorized as.
+const RoutePath = "userActions"
+
+// Handler serves the caller's RBAC actions as a map of action -> true, matching
+// the legacy /api/access-control/user/actions endpoint.
+type Handler struct {
+	provider RolePermissionProvider
+}
+
+func NewHandler(provider RolePermissionProvider) *Handler {
+	return &Handler{provider: provider}
+}
+
+func (h *Handler) GetAPIRoutes(_ map[string]common.OpenAPIDefinition) *builder.APIRoutes {
+	return &builder.APIRoutes{
+		Namespace: []builder.APIRouteHandler{
+			{
+				Path: RoutePath,
+				Spec: &spec3.PathProps{
+					Get: &spec3.Operation{
+						OperationProps: spec3.OperationProps{
+							OperationId: "getUserActions", // This is used by RTK client generator
+							Tags:        []string{"UserActions"},
+							Description: "Returns the RBAC actions granted to the calling user, as a map of action to true.",
+							Parameters: []*spec3.Parameter{
+								{
+									ParameterProps: spec3.ParameterProps{
+										Name:        "namespace",
+										In:          "path",
+										Required:    true,
+										Example:     "default",
+										Description: "workspace",
+										Schema:      spec.StringProperty(),
+									},
+								},
+								{
+									ParameterProps: spec3.ParameterProps{
+										Name:        "reloadcache",
+										In:          "query",
+										Required:    false,
+										Description: "Resolve permissions afresh rather than serving a cached set",
+										Schema:      spec.BooleanProperty(),
+									},
+								},
+							},
+							Responses: &spec3.Responses{
+								ResponsesProps: spec3.ResponsesProps{
+									StatusCodeResponses: map[int]*spec3.Response{
+										200: {
+											ResponseProps: spec3.ResponseProps{
+												Description: "Map of RBAC action to true",
+												Content: map[string]*spec3.MediaType{
+													"application/json": {
+														MediaTypeProps: spec3.MediaTypeProps{
+															Schema: spec.MapProperty(spec.BooleanProperty()),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Handler: h.handle,
+			},
+		},
+	}
+}
+
+func (h *Handler) handle(w http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
+
+	requester, err := identity.GetRequester(ctx)
+	if err != nil {
+		errhttp.Write(ctx, apierrors.NewUnauthorized("no identity found"), w)
+		return
+	}
+
+	// reloadcache mirrors the legacy endpoint, which the frontend uses to pick up
+	// its own permission changes straight after a mutation.
+	opts := Options{ReloadCache: req.URL.Query().Get("reloadcache") == "true"}
+
+	actions, err := h.provider.ActionsForUser(ctx, requester, opts)
+	if err != nil {
+		errhttp.Write(ctx, err, w)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(actions)
+}

--- a/pkg/registry/apis/iam/useractions/handler_test.go
+++ b/pkg/registry/apis/iam/useractions/handler_test.go
@@ -1,0 +1,62 @@
+package useractions
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/services/user"
+)
+
+type fakeProvider struct {
+	actions map[string]bool
+	err     error
+}
+
+func (f *fakeProvider) ActionsForUser(_ context.Context, _ identity.Requester, _ Options) (map[string]bool, error) {
+	return f.actions, f.err
+}
+
+func do(t *testing.T, handler *Handler, requester identity.Requester) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/apis/iam.grafana.app/v0alpha1/namespaces/default/userActions", nil)
+	if requester != nil {
+		req = req.WithContext(identity.WithRequester(req.Context(), requester))
+	}
+	rec := httptest.NewRecorder()
+	handler.handle(rec, req)
+	return rec
+}
+
+func TestHandler(t *testing.T) {
+	requester := &user.SignedInUser{OrgID: 1, OrgRole: org.RoleEditor}
+
+	t.Run("returns the provider's action map as json", func(t *testing.T) {
+		handler := NewHandler(&fakeProvider{actions: map[string]bool{"dashboards:read": true}})
+		rec := do(t, handler, requester)
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var actions map[string]bool
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &actions))
+		require.Equal(t, map[string]bool{"dashboards:read": true}, actions)
+	})
+
+	t.Run("empty action set encodes as an empty object", func(t *testing.T) {
+		handler := NewHandler(&fakeProvider{actions: map[string]bool{}})
+		rec := do(t, handler, requester)
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.JSONEq(t, "{}", rec.Body.String())
+	})
+
+	t.Run("missing identity is unauthorized", func(t *testing.T) {
+		handler := NewHandler(&fakeProvider{actions: map[string]bool{}})
+		rec := do(t, handler, nil)
+		require.Equal(t, http.StatusUnauthorized, rec.Code)
+	})
+}

--- a/pkg/registry/apis/iam/useractions/provider.go
+++ b/pkg/registry/apis/iam/useractions/provider.go
@@ -1,0 +1,155 @@
+package useractions
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	claims "github.com/grafana/authlib/types"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/registry/apis/iam/common"
+	"github.com/grafana/grafana/pkg/registry/apis/iam/legacy"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
+	authzstore "github.com/grafana/grafana/pkg/services/authz/rbac/store"
+)
+
+// teamPageSize bounds each page of the team lookup.
+const teamPageSize = 50
+
+// Options mirrors the legacy endpoint's reloadcache behaviour.
+type Options struct {
+	// ReloadCache resolves permissions afresh instead of serving a cached set.
+	ReloadCache bool
+}
+
+// RolePermissionProvider resolves the RBAC actions granted to the caller.
+type RolePermissionProvider interface {
+	ActionsForUser(ctx context.Context, requester identity.Requester, opts Options) (map[string]bool, error)
+}
+
+// identityStore resolves the teams an identity belongs to.
+type identityStore interface {
+	ListUserTeams(ctx context.Context, ns claims.NamespaceInfo, query legacy.ListUserTeamsQuery) (*legacy.ListUserTeamsResult, error)
+}
+
+// identifierStore resolves an identity's internal id and its basic role.
+type identifierStore interface {
+	GetUserIdentifiers(ctx context.Context, query authzstore.UserIdentifierQuery) (*authzstore.UserIdentifiers, error)
+	GetBasicRoles(ctx context.Context, ns claims.NamespaceInfo, query authzstore.BasicRoleQuery) (*authzstore.BasicRole, error)
+}
+
+type sqlProvider struct {
+	actions        ActionStore
+	identifiers    identifierStore
+	identities     identityStore
+	actionResolver accesscontrol.ActionResolver
+}
+
+// NewSQLProvider resolves actions from the RBAC tables, keyed off the request
+// namespace so it serves both single- and multi-tenant deployments. It covers
+// the caller's basic role, Grafana Admin for server admins, and roles assigned
+// to the user and its teams. actionResolver expands action sets and may be nil
+// where none are registered, in which case action sets are reported as-is.
+func NewSQLProvider(actions ActionStore, identifiers identifierStore, identities identityStore, actionResolver accesscontrol.ActionResolver) RolePermissionProvider {
+	return &sqlProvider{
+		actions:        actions,
+		identifiers:    identifiers,
+		identities:     identities,
+		actionResolver: actionResolver,
+	}
+}
+
+func (p *sqlProvider) ActionsForUser(ctx context.Context, requester identity.Requester, _ Options) (map[string]bool, error) {
+	// Only users and service accounts hold RBAC assignments.
+	if !requester.IsIdentityType(claims.TypeUser, claims.TypeServiceAccount) {
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("cannot resolve actions for a %s identity", requester.GetIdentityType()))
+	}
+
+	// The request namespace is the tenant the caller asked about, is already
+	// checked by the namespace authorizer, and is what the org id came from.
+	ns, err := request.NamespaceInfoFrom(ctx, true)
+	if err != nil {
+		return nil, err
+	}
+
+	ids, err := p.identifiers.GetUserIdentifiers(ctx, authzstore.UserIdentifierQuery{UserUID: requester.GetIdentifier()})
+	if err != nil {
+		return nil, notFoundOrErr(err, requester.GetIdentifier(), "could not resolve identity")
+	}
+
+	basicRole, err := p.identifiers.GetBasicRoles(ctx, ns, authzstore.BasicRoleQuery{UserID: ids.ID})
+	if err != nil {
+		return nil, notFoundOrErr(err, ids.UID, "could not resolve basic role")
+	}
+
+	teamIDs, err := p.userTeams(ctx, ns, ids.UID)
+	if err != nil {
+		return nil, err
+	}
+
+	actions, err := p.actions.GetUserActions(ctx, ns, ActionsQuery{
+		UserID:        ids.ID,
+		TeamIDs:       teamIDs,
+		Role:          basicRole.Role,
+		IsServerAdmin: basicRole.IsAdmin,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not resolve actions: %w", err)
+	}
+
+	return p.buildActionMap(actions), nil
+}
+
+func (p *sqlProvider) userTeams(ctx context.Context, ns claims.NamespaceInfo, userUID string) ([]int64, error) {
+	var teamIDs []int64
+	query := legacy.ListUserTeamsQuery{
+		UserUID:    userUID,
+		Pagination: common.Pagination{Limit: teamPageSize},
+	}
+
+	for {
+		teams, err := p.identities.ListUserTeams(ctx, ns, query)
+		if err != nil {
+			return nil, fmt.Errorf("could not resolve teams: %w", err)
+		}
+		for _, team := range teams.Items {
+			teamIDs = append(teamIDs, team.ID)
+		}
+		if teams.Continue == 0 {
+			return teamIDs, nil
+		}
+		query.Pagination.Continue = teams.Continue
+	}
+}
+
+// buildActionMap expands action sets when a resolver is configured.
+func (p *sqlProvider) buildActionMap(actions []string) map[string]bool {
+	if p.actionResolver == nil {
+		out := make(map[string]bool, len(actions))
+		for _, action := range actions {
+			out[action] = true
+		}
+		return out
+	}
+
+	permissions := make([]accesscontrol.Permission, 0, len(actions))
+	for _, action := range actions {
+		permissions = append(permissions, accesscontrol.Permission{Action: action})
+	}
+	return accesscontrol.BuildPermissionsMap(p.actionResolver.ExpandActionSets(permissions))
+}
+
+// notFoundOrErr turns "the identity has no row in this tenant" into a 404. It is
+// a normal outcome for a token that authenticates for a stack the user is not a
+// member of, and would otherwise surface as a 500.
+func notFoundOrErr(err error, name, context string) error {
+	if errors.Is(err, authzstore.ErrUserNotFound) || errors.Is(err, authzstore.ErrBasicRoleNotFound) {
+		return apierrors.NewNotFound(schema.GroupResource{Group: "iam.grafana.app", Resource: "users"}, name)
+	}
+	return fmt.Errorf("%s: %w", context, err)
+}

--- a/pkg/registry/apis/iam/useractions/provider_test.go
+++ b/pkg/registry/apis/iam/useractions/provider_test.go
@@ -1,0 +1,147 @@
+package useractions
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	k8srequest "k8s.io/apiserver/pkg/endpoints/request"
+
+	claims "github.com/grafana/authlib/types"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/registry/apis/iam/legacy"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	authzstore "github.com/grafana/grafana/pkg/services/authz/rbac/store"
+	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/services/user"
+)
+
+// nsCtx mimics the apiserver, which puts the request's namespace in the context.
+func nsCtx(namespace string) context.Context {
+	return k8srequest.WithNamespace(context.Background(), namespace)
+}
+
+type fakeActionStore struct {
+	gotQuery ActionsQuery
+	gotNs    claims.NamespaceInfo
+	actions  []string
+}
+
+func (f *fakeActionStore) GetUserActions(_ context.Context, ns claims.NamespaceInfo, q ActionsQuery) ([]string, error) {
+	f.gotNs, f.gotQuery = ns, q
+	return f.actions, nil
+}
+
+type fakeIdentifierStore struct {
+	ids  authzstore.UserIdentifiers
+	role authzstore.BasicRole
+}
+
+func (f *fakeIdentifierStore) GetUserIdentifiers(_ context.Context, _ authzstore.UserIdentifierQuery) (*authzstore.UserIdentifiers, error) {
+	return &f.ids, nil
+}
+
+func (f *fakeIdentifierStore) GetBasicRoles(_ context.Context, _ claims.NamespaceInfo, _ authzstore.BasicRoleQuery) (*authzstore.BasicRole, error) {
+	return &f.role, nil
+}
+
+// fakeIdentityStore returns teams one page at a time so the paging loop is exercised.
+type fakeIdentityStore struct {
+	pages [][]int64
+	calls int
+}
+
+func (f *fakeIdentityStore) ListUserTeams(_ context.Context, _ claims.NamespaceInfo, _ legacy.ListUserTeamsQuery) (*legacy.ListUserTeamsResult, error) {
+	page := f.pages[f.calls]
+	f.calls++
+	res := &legacy.ListUserTeamsResult{}
+	for _, id := range page {
+		res.Items = append(res.Items, legacy.UserTeam{ID: id})
+	}
+	if f.calls < len(f.pages) {
+		res.Continue = int64(f.calls)
+	}
+	return res, nil
+}
+
+func TestSQLProvider_ActionsForUser(t *testing.T) {
+	t.Run("returns every granted action and passes the resolved identity to the store", func(t *testing.T) {
+		actions := &fakeActionStore{actions: []string{"dashboards:read", "teams:create", "users:read"}}
+		ids := &fakeIdentifierStore{
+			ids:  authzstore.UserIdentifiers{ID: 7, UID: "u7"},
+			role: authzstore.BasicRole{Role: "Editor", IsAdmin: true},
+		}
+		provider := NewSQLProvider(actions, ids, &fakeIdentityStore{pages: [][]int64{{1, 2}, {3}}}, nil)
+
+		got, err := provider.ActionsForUser(nsCtx("default"), &user.SignedInUser{
+			OrgID: 1, UserID: 7, UserUID: "u7", OrgRole: org.RoleEditor,
+		}, Options{})
+		require.NoError(t, err)
+		require.Equal(t, map[string]bool{"dashboards:read": true, "teams:create": true, "users:read": true}, got)
+
+		require.Equal(t, int64(7), actions.gotQuery.UserID)
+		require.Equal(t, "Editor", actions.gotQuery.Role)
+		require.True(t, actions.gotQuery.IsServerAdmin)
+		require.Equal(t, []int64{1, 2, 3}, actions.gotQuery.TeamIDs, "must collect every page of teams")
+		require.Equal(t, int64(1), actions.gotNs.OrgID)
+	})
+
+	// Multi-tenant addresses tenants as stacks-<id>, which resolves to org 1.
+	t.Run("resolves a stacks namespace to org 1", func(t *testing.T) {
+		actions := &fakeActionStore{actions: []string{"dashboards:read"}}
+		ids := &fakeIdentifierStore{
+			ids:  authzstore.UserIdentifiers{ID: 3, UID: "u3"},
+			role: authzstore.BasicRole{Role: "Admin"},
+		}
+		provider := NewSQLProvider(actions, ids, &fakeIdentityStore{pages: [][]int64{nil}}, nil)
+
+		got, err := provider.ActionsForUser(nsCtx("stacks-11"), &user.SignedInUser{OrgID: 1, UserID: 3, UserUID: "u3"}, Options{})
+		require.NoError(t, err)
+		require.Equal(t, map[string]bool{"dashboards:read": true}, got)
+		require.Equal(t, int64(1), actions.gotNs.OrgID)
+		require.Equal(t, int64(11), actions.gotNs.StackID)
+	})
+
+	t.Run("expands action sets when a resolver is configured", func(t *testing.T) {
+		actions := &fakeActionStore{actions: []string{"folders:edit"}}
+		provider := NewSQLProvider(actions, &fakeIdentifierStore{}, &fakeIdentityStore{pages: [][]int64{nil}}, expandFolderEdit{})
+
+		got, err := provider.ActionsForUser(nsCtx("default"), &user.SignedInUser{OrgID: 1, UserID: 1, UserUID: "u1"}, Options{})
+		require.NoError(t, err)
+		require.Equal(t, map[string]bool{"folders:read": true, "dashboards:read": true}, got)
+	})
+
+	t.Run("identities that cannot hold RBAC assignments are rejected", func(t *testing.T) {
+		actions := &fakeActionStore{actions: []string{"should:not:be:read"}}
+		provider := NewSQLProvider(actions, &fakeIdentifierStore{}, &fakeIdentityStore{}, nil)
+
+		// An access policy identity is neither a user nor a service account.
+		_, err := provider.ActionsForUser(nsCtx("default"), &identity.StaticRequester{
+			Type: claims.TypeAccessPolicy, OrgID: 1,
+		}, Options{})
+		require.Error(t, err)
+		require.True(t, apierrors.IsBadRequest(err))
+	})
+}
+
+// expandFolderEdit stands in for the action set service: it turns the
+// folders:edit action set into the actions it represents.
+type expandFolderEdit struct{ accesscontrol.ActionResolver }
+
+func (expandFolderEdit) ExpandActionSets(permissions []accesscontrol.Permission) []accesscontrol.Permission {
+	var out []accesscontrol.Permission
+	for _, p := range permissions {
+		if p.Action == "folders:edit" {
+			out = append(out,
+				accesscontrol.Permission{Action: "folders:read"},
+				accesscontrol.Permission{Action: "dashboards:read"},
+			)
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
+}

--- a/pkg/registry/apis/iam/useractions/store.go
+++ b/pkg/registry/apis/iam/useractions/store.go
@@ -1,0 +1,125 @@
+package useractions
+
+import (
+	"context"
+	"text/template"
+
+	claims "github.com/grafana/authlib/types"
+
+	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
+)
+
+// actionsQuery selects the distinct actions of every role granting permissions
+// to an identity: its basic role (and Grafana Admin when it is a server admin),
+// roles assigned to the user, and roles assigned to its teams.
+const actionsQuery = `
+SELECT DISTINCT p.action FROM {{ .Ident .PermissionTable }} as p
+INNER JOIN (
+  SELECT role_id FROM {{ .Ident .BuiltinRoleTable }} as br WHERE (br.role = {{ .Arg .Query.Role }} AND (br.org_id = {{ .Arg .Query.OrgID }} OR br.org_id = 0))
+    {{ if .Query.IsServerAdmin }}
+    OR (br.role = 'Grafana Admin')
+    {{ end }}
+    {{ if .Query.UserID }}
+  UNION ALL
+  SELECT role_id FROM {{ .Ident .UserRoleTable }} as ur WHERE ur.user_id = {{ .Arg .Query.UserID }} AND (ur.org_id = {{ .Arg .Query.OrgID }} OR ur.org_id = 0)
+    {{ end }}
+    {{ if .Query.TeamIDs }}
+  UNION ALL
+  SELECT role_id FROM {{ .Ident .TeamRoleTable }} as tr WHERE tr.team_id IN ({{ .ArgList .Query.TeamIDs }}) AND tr.org_id = {{ .Arg .Query.OrgID }}
+  {{ end }}
+) as roles ON p.role_id = roles.role_id
+`
+
+var sqlQueryActions = template.Must(template.New("actions_query.sql").Parse(actionsQuery))
+
+// ActionsQuery identifies whose actions to look up.
+type ActionsQuery struct {
+	OrgID         int64
+	UserID        int64
+	TeamIDs       []int64
+	Role          string
+	IsServerAdmin bool
+}
+
+type getActionsQuery struct {
+	sqltemplate.SQLTemplate
+	Query *ActionsQuery
+
+	PermissionTable  string
+	UserRoleTable    string
+	TeamRoleTable    string
+	BuiltinRoleTable string
+}
+
+func (r getActionsQuery) Validate() error {
+	return nil
+}
+
+func newGetActions(sql *legacysql.LegacyDatabaseHelper, q *ActionsQuery) getActionsQuery {
+	return getActionsQuery{
+		SQLTemplate:      sqltemplate.New(sql.DialectForDriver()),
+		Query:            q,
+		PermissionTable:  sql.Table("permission"),
+		UserRoleTable:    sql.Table("user_role"),
+		TeamRoleTable:    sql.Table("team_role"),
+		BuiltinRoleTable: sql.Table("builtin_role"),
+	}
+}
+
+// ActionStore lists the distinct RBAC actions granted to an identity.
+type ActionStore interface {
+	GetUserActions(ctx context.Context, ns claims.NamespaceInfo, query ActionsQuery) ([]string, error)
+}
+
+// SQLActionStore reads actions from the RBAC tables. It goes through legacysql
+// so the same implementation serves single-tenant Grafana and the multi-tenant
+// IAM apiserver, where the tables live in a per-tenant schema resolved from the
+// request namespace.
+type SQLActionStore struct {
+	sql    legacysql.LegacyDatabaseProvider
+	tracer tracing.Tracer
+}
+
+func NewSQLActionStore(sql legacysql.LegacyDatabaseProvider, tracer tracing.Tracer) *SQLActionStore {
+	return &SQLActionStore{sql: sql, tracer: tracer}
+}
+
+func (s *SQLActionStore) GetUserActions(ctx context.Context, ns claims.NamespaceInfo, query ActionsQuery) ([]string, error) {
+	ctx, span := s.tracer.Start(ctx, "iam.useractions.store.GetUserActions")
+	defer span.End()
+
+	sql, err := s.sql(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	query.OrgID = ns.OrgID
+	req := newGetActions(sql, &query)
+	q, err := sqltemplate.Execute(sqlQueryActions, req)
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := sql.DB.GetSqlxSession().Query(ctx, q, req.GetArgs()...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if rows != nil {
+			_ = rows.Close()
+		}
+	}()
+
+	var actions []string
+	for rows.Next() {
+		var action string
+		if err := rows.Scan(&action); err != nil {
+			return nil, err
+		}
+		actions = append(actions, action)
+	}
+
+	return actions, rows.Err()
+}

--- a/pkg/server/bootstrap/wire/wire_gen.go
+++ b/pkg/server/bootstrap/wire/wire_gen.go
@@ -943,7 +943,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts server.Options, apiO
 	noopSearchREST := externalgroupmapping.ProvideNoopSearchREST()
 	externalGroupReconciler := _wireNoopExternalGroupReconcilerValue
 	mappersRegistry := resourcepermission.ProvideMappersRegistry()
-	identityAccessManagementAPIBuilder, err := iam.RegisterAPIService(cfg, configProvider, apiserverService, ssosettingsimplService, sqlStore, accessControl, accessClient, zanzanaClient, registerer, roleApiInstaller, globalRoleApiInstaller, teamLBACApiInstaller, tracingService, roleBindingApiInstaller, teamGroupsHandlerProvider, noopSearchREST, externalGroupReconciler, dualwriteService, resourceClient, orgService, userimplService, teamimplService, eventualRestConfigProvider, mappersRegistry)
+	identityAccessManagementAPIBuilder, err := iam.RegisterAPIService(cfg, configProvider, apiserverService, ssosettingsimplService, sqlStore, accessControl, actionSetService, accessClient, zanzanaClient, registerer, roleApiInstaller, globalRoleApiInstaller, teamLBACApiInstaller, tracingService, roleBindingApiInstaller, teamGroupsHandlerProvider, noopSearchREST, externalGroupReconciler, dualwriteService, resourceClient, orgService, userimplService, teamimplService, eventualRestConfigProvider, mappersRegistry)
 	if err != nil {
 		return nil, err
 	}
@@ -1704,7 +1704,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	noopSearchREST := externalgroupmapping.ProvideNoopSearchREST()
 	externalGroupReconciler := _wireNoopExternalGroupReconcilerValue
 	mappersRegistry := resourcepermission.ProvideMappersRegistry()
-	identityAccessManagementAPIBuilder, err := iam.RegisterAPIService(cfg, configProvider, apiserverService, ssosettingsimplService, sqlStore, accessControl, accessClient, zanzanaClient, registerer, roleApiInstaller, globalRoleApiInstaller, teamLBACApiInstaller, tracingService, roleBindingApiInstaller, teamGroupsHandlerProvider, noopSearchREST, externalGroupReconciler, dualwriteService, resourceClient, orgService, userimplService, teamimplService, eventualRestConfigProvider, mappersRegistry)
+	identityAccessManagementAPIBuilder, err := iam.RegisterAPIService(cfg, configProvider, apiserverService, ssosettingsimplService, sqlStore, accessControl, actionSetService, accessClient, zanzanaClient, registerer, roleApiInstaller, globalRoleApiInstaller, teamLBACApiInstaller, tracingService, roleBindingApiInstaller, teamGroupsHandlerProvider, noopSearchREST, externalGroupReconciler, dualwriteService, resourceClient, orgService, userimplService, teamimplService, eventualRestConfigProvider, mappersRegistry)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/authz/rbac/store/store.go
+++ b/pkg/services/authz/rbac/store/store.go
@@ -2,13 +2,20 @@ package store
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	claims "github.com/grafana/authlib/types"
 
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
+)
+
+// Callers use these to tell "the identity is not in this tenant" apart from a
+// database failure, which are otherwise both opaque errors.
+var (
+	ErrUserNotFound      = errors.New("user could not be found")
+	ErrBasicRoleNotFound = errors.New("no basic roles found for the user")
 )
 
 type Store interface {
@@ -54,7 +61,7 @@ func (s *StoreImpl) GetUserIdentifiers(ctx context.Context, query UserIdentifier
 	}
 
 	if !rows.Next() {
-		return nil, fmt.Errorf("user could not be found")
+		return nil, ErrUserNotFound
 	}
 
 	var userIDs UserIdentifiers
@@ -92,7 +99,7 @@ func (s *StoreImpl) GetBasicRoles(ctx context.Context, ns claims.NamespaceInfo, 
 	}
 
 	if !rows.Next() {
-		return nil, fmt.Errorf("no basic roles found for the user")
+		return nil, ErrBasicRoleNotFound
 	}
 
 	var role BasicRole

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1758,6 +1758,15 @@ var (
 			Generate:     Generate{LegacyGo: true, LegacyFrontend: true},
 		},
 		{
+			Name:         "kubernetesUserActionsApi",
+			Description:  "Registers the IAM userActions /apis endpoint",
+			Stage:        FeatureStageExperimental,
+			Owner:        identityAccessTeam,
+			HideFromDocs: true,
+			Expression:   "false",
+			Generate:     Generate{LegacyGo: true, LegacyFrontend: true},
+		},
+		{
 			Name:         "kubernetesAuthzZanzanaSync",
 			Description:  "Enable sync of Zanzana authorization store on AuthZ CRD mutations",
 			Stage:        FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -204,6 +204,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2025-04-24,alertingBulkActionsInUI,GA,@grafana/alerting-squad,false,false,true
 2026-05-22,kubernetesAuthZResourcePermissionsRedirect,experimental,@grafana/identity-access-team,false,false,false
 2025-07-31,kubernetesAuthzResourcePermissionApis,experimental,@grafana/identity-access-team,false,false,false
+2026-08-18,kubernetesUserActionsApi,experimental,@grafana/identity-access-team,false,false,false
 2025-10-13,kubernetesAuthzZanzanaSync,experimental,@grafana/identity-access-team,false,false,false
 2026-01-15,kubernetesAuthzGlobalRolesApi,experimental,@grafana/identity-access-team,false,false,false
 2026-01-12,kubernetesAuthzRolesApi,experimental,@grafana/identity-access-team,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -574,6 +574,10 @@ const (
 	// Registers AuthZ resource permission /apis endpoints
 	FlagKubernetesAuthzResourcePermissionApis = "kubernetesAuthzResourcePermissionApis"
 
+	// FlagKubernetesUserActionsApi
+	// Registers the IAM userActions /apis endpoint
+	FlagKubernetesUserActionsApi = "kubernetesUserActionsApi"
+
 	// FlagKubernetesAuthzZanzanaSync
 	// Enable sync of Zanzana authorization store on AuthZ CRD mutations
 	FlagKubernetesAuthzZanzanaSync = "kubernetesAuthzZanzanaSync"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -4223,6 +4223,20 @@
     },
     {
       "metadata": {
+        "name": "kubernetesUserActionsApi",
+        "resourceVersion": "1787051168157",
+        "creationTimestamp": "2026-08-18T11:06:08Z"
+      },
+      "spec": {
+        "description": "Registers the IAM userActions /apis endpoint",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team",
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "kubernetesUsersApi",
         "resourceVersion": "1779440584464",
         "creationTimestamp": "2026-05-22T09:03:04Z"

--- a/pkg/tests/apis/iam/useractions/useractions_test.go
+++ b/pkg/tests/apis/iam/useractions/useractions_test.go
@@ -1,0 +1,127 @@
+package useractions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/tests/apis"
+	"github.com/grafana/grafana/pkg/tests/testinfra"
+	"github.com/grafana/grafana/pkg/tests/testsuite"
+	"github.com/grafana/grafana/pkg/util/testutil"
+)
+
+func TestMain(m *testing.M) {
+	testsuite.Run(m)
+}
+
+const (
+	routePath       = "/apis/iam.grafana.app/v0alpha1/namespaces/default/userActions"
+	legacyRoutePath = "/api/access-control/user/actions?reloadcache=true"
+)
+
+func TestIntegrationUserActions(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
+		AppModeProduction: false,
+		DisableAnonymous:  true,
+		EnableFeatureToggles: []string{
+			featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs,
+			featuremgmt.FlagKubernetesUserActionsApi,
+		},
+	})
+	t.Cleanup(helper.Shutdown)
+
+	getUserActions := func(t *testing.T, user apis.User) map[string]bool {
+		t.Helper()
+		res := map[string]bool{}
+		rsp := apis.DoRequest(helper, apis.RequestParams{
+			User: user,
+			Path: routePath,
+		}, &res)
+		require.Equal(t, 200, rsp.Response.StatusCode)
+		return res
+	}
+
+	getLegacyActions := func(t *testing.T, user apis.User) map[string]bool {
+		t.Helper()
+		res := map[string]bool{}
+		rsp := apis.DoRequest(helper, apis.RequestParams{
+			User: user,
+			Path: legacyRoutePath,
+		}, &res)
+		require.Equal(t, 200, rsp.Response.StatusCode)
+		return res
+	}
+
+	t.Run("viewer gets read but not write actions", func(t *testing.T) {
+		actions := getUserActions(t, helper.Org1.Viewer)
+		require.True(t, actions["folders:read"])
+		require.True(t, actions["annotations:read"])
+		require.False(t, actions["dashboards:create"])
+		require.False(t, actions["teams:create"])
+	})
+
+	t.Run("editor gets editor actions", func(t *testing.T) {
+		actions := getUserActions(t, helper.Org1.Editor)
+		require.True(t, actions["dashboards:create"])
+		require.True(t, actions["folders:create"])
+		require.False(t, actions["teams:create"])
+	})
+
+	t.Run("admin gets admin actions", func(t *testing.T) {
+		actions := getUserActions(t, helper.Org1.Admin)
+		require.True(t, actions["dashboards:create"])
+		require.True(t, actions["teams:create"])
+		require.True(t, actions["users:read"])
+	})
+
+	// Editor is a member of the helper's Staff team, which carries a managed
+	// team permission. Viewer is not, so teams:read can only come from the
+	// team assignment.
+	t.Run("includes permissions granted through a team", func(t *testing.T) {
+		require.True(t, getUserActions(t, helper.Org1.Editor)["teams:read"])
+		require.False(t, getUserActions(t, helper.Org1.Viewer)["teams:read"])
+	})
+
+	// The endpoint must be a drop-in replacement for the legacy one, including
+	// permissions that come from team membership. The helper puts Admin and
+	// Editor in its Staff team, so those two exercise the team-derived path.
+	t.Run("matches the legacy endpoint exactly", func(t *testing.T) {
+		for name, user := range map[string]apis.User{
+			"viewer": helper.Org1.Viewer,
+			"editor": helper.Org1.Editor,
+			"admin":  helper.Org1.Admin,
+		} {
+			t.Run(name, func(t *testing.T) {
+				actions := getUserActions(t, user)
+				require.NotEmpty(t, actions)
+				require.Equal(t, getLegacyActions(t, user), actions)
+			})
+		}
+	})
+
+	// The frontend calls the legacy endpoint with reloadcache=true after mutating
+	// its own permissions, so the same parameter has to bypass the cache here.
+	t.Run("reloadcache returns a freshly resolved set", func(t *testing.T) {
+		before := getUserActions(t, helper.Org1.Editor)
+
+		res := map[string]bool{}
+		rsp := apis.DoRequest(helper, apis.RequestParams{
+			User: helper.Org1.Editor,
+			Path: routePath + "?reloadcache=true",
+		}, &res)
+		require.Equal(t, 200, rsp.Response.StatusCode)
+		require.Equal(t, before, res)
+	})
+
+	t.Run("unauthenticated is rejected", func(t *testing.T) {
+		res := map[string]any{}
+		rsp := apis.DoRequest(helper, apis.RequestParams{
+			Path: routePath,
+		}, &res)
+		require.Equal(t, 401, rsp.Response.StatusCode)
+	})
+}

--- a/pkg/tests/apis/openapi_snapshots/iam.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/iam.grafana.app-v0alpha1.json
@@ -2024,6 +2024,50 @@
         }
       ]
     },
+    "/apis/iam.grafana.app/v0alpha1/namespaces/{namespace}/userActions": {
+      "get": {
+        "tags": [
+          "UserActions"
+        ],
+        "description": "Returns the RBAC actions granted to the calling user, as a map of action to true.",
+        "operationId": "getUserActions",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "workspace",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "default"
+          },
+          {
+            "name": "reloadcache",
+            "in": "query",
+            "description": "Resolve permissions afresh rather than serving a cached set",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Map of RBAC action to true",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/apis/iam.grafana.app/v0alpha1/namespaces/{namespace}/users": {
       "get": {
         "tags": [

--- a/pkg/tests/apis/openapi_test.go
+++ b/pkg/tests/apis/openapi_test.go
@@ -39,6 +39,7 @@ func TestIntegrationOpenAPIs(t *testing.T) {
 			featuremgmt.FlagKubernetesLogsDrilldown,
 			featuremgmt.FlagKubernetesTeamsApi,
 			featuremgmt.FlagKubernetesUsersApi,
+			featuremgmt.FlagKubernetesUserActionsApi,
 			featuremgmt.FlagKubernetesServiceAccountsApi,
 			featuremgmt.FlagKubernetesServiceAccountTokensApi,
 			featuremgmt.FlagDatasourcesApiServerEnableHealthEndpoint,


### PR DESCRIPTION
**What is this feature?**

Adds `GET /apis/iam.grafana.app/v0alpha1/namespaces/{namespace}/userActions`, returning the calling user's RBAC actions as a map of action → `true` — a drop-in equivalent of the legacy `/api/access-control/user/actions` endpoint that the frontend already consumes via `contextSrv.hasPermission()`.

Permissions are resolved from the RBAC tables, covering every source the legacy endpoint covers:

- the caller's basic role, plus `Grafana Admin` for server admins,
- roles assigned directly to the user,
- roles assigned to the user's teams,
- action sets, expanded where an action set resolver is available.

One implementation serves both deployment shapes. It reads through `legacysql`, so in single-tenant Grafana it hits the local database and in the multi-tenant IAM apiserver it resolves the per-tenant schema from the request namespace — which that API group already does for its other stores.

Most of the resolution reuses what exists rather than adding new machinery:

| Step | Reused from |
|---|---|
| user internal id, basic role | `pkg/services/authz/rbac/store` (`Store`), already `legacysql`-backed |
| team membership | `pkg/registry/apis/iam/legacy` `ListUserTeams`, the same call the authz service makes |
| action enumeration | **new** — `actions_query.sql`, modelled on the neighbouring `permission_query.sql` |

The authz service itself has no enumeration API (only per-action `Check`/`BatchCheck`/`List`), which is why the action query is added here rather than as a new RPC.

Any authenticated identity may read its own actions, so the route is authorized like the existing current-user `display` route. Identities that cannot hold RBAC assignments (anonymous, access policies) get an empty map rather than an error.

**Why do we need this feature?**

The frontend decides what UI to show from `contextSrv.hasPermission()`, populated by `/api/access-control/user/actions`. That endpoint lives in the legacy HTTP API, which is not served by a multi-tenant standalone apiserver. As resources move to the App Platform for multitenancy, the frontend needs an equivalent it can call in both deployment shapes — and it has to be a faithful equivalent, or the UI would hide functionality users are entitled to.

**Who is this feature for?**

Grafana developers working on the multitenant App Platform migration. No user-facing change yet: the frontend switch-over is a separate follow-up PR, since frontend and backend ship at different cadences.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

⚠️ **Requires the companion enterprise PR** — https://github.com/grafana/grafana-enterprise/pull/13183. `RegisterAPIService` gains an `accesscontrol.ActionResolver` parameter, so the enterprise wire graph must be regenerated; that PR is the two-line generated change and must merge together with this one. `NewAPIService` takes no new parameters, so no other enterprise change is needed.

Verified by hand against a local enterprise-linked instance (`make run`), comparing the new endpoint with the legacy one. Built-in roles match exactly:

| Role | New | Legacy | Identical |
|---|---|---|---|
| Admin | 304 actions | 304 | ✅ |
| Editor | 121 | 121 | ✅ |
| Viewer | 59 | 59 | ✅ |

The interesting case is a user holding permissions through assignments rather than a role. For an Editor with one custom role assigned directly, a second custom role assigned to a team it belongs to, and that team's managed membership permission, both endpoints return an identical 124 actions — including `users:read` (user-assigned), `teams:create` (team-assigned) and `teams:read` (team membership).

The integration test asserts exact equality with the legacy endpoint for viewer, editor and admin. The test helper puts admin and editor in its Staff team, so the team-derived path is covered in CI, and a dedicated subtest pins that `teams:read` reaches the editor only through that team.

Auth behaviour: unauthenticated and bad credentials return 401, `POST` returns 405, and a non-admin requesting another org's namespace gets 403.

Two behaviours worth knowing:

- The response is **namespace-scoped**, unlike the legacy endpoint. `orgIDFromNamespace` (`pkg/services/authn/authnimpl/service.go`) resolves the org from the URL namespace for all `/apis` requests, so a Grafana admin querying `namespaces/org-2` correctly gets only the actions they hold there. The namespace is taken from the request rather than the identity, because identity namespaces are not always populated and `ParseNamespace("")` yields an invalid org id without an error.
- **Action set expansion is single-tenant only.** `accesscontrol.ActionResolver` is wire-bound in OSS and enterprise, but the resource permission services that register action sets do not run in multi-tenant, so there action sets are reported as-is. Worth revisiting if action sets appear in cloud tenant data.

No CUE route declaration was added: the route is served through the group's existing `GetAPIRoutes` mechanism, as `display` already is, and codegen support for a bare-map response type is unverified.

Please check that:
- [ ] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. — n/a, no user-facing change; consistent with the ungated `display` route. Happy to add a toggle if preferred.
- [x] The docs are updated — n/a, no user-facing change yet.
