### PR TITLE
Alerting: Fix the swagger spec cron job so it can open its PR

### DIFF
--- a/.github/workflows/alerting-swagger-gen.yml
+++ b/.github/workflows/alerting-swagger-gen.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-arm64
     permissions:
       contents: read
+      id-token: write # required to mint the alerting-team app token below
 
     steps:
       - name: Checkout repository
@@ -23,10 +24,17 @@ jobs:
       - name: Build swagger
         run: |
           make -C pkg/services/ngalert/api/tooling post.json api.json
+      # GITHUB_TOKEN cannot push a branch here, so the PR step needs an app
+      # token, the same way alerting-update-module.yml gets one.
+      - name: Get GitHub App token
+        id: get-github-app-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
+        with:
+          github_app: alerting-team
       - name: Open Pull Request
         uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.get-github-app-token.outputs.token }}
           commit-message: "chore: update alerting swagger spec"
           title: "Alerting: Update Swagger spec"
           body: |


### PR DESCRIPTION
**What is this feature?**

A fix for `alerting-swagger-gen.yml`. The weekly cron builds the spec correctly and then fails on the last step, so it has never opened the PR it exists to open.

```
remote: Permission to grafana/grafana.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/grafana/grafana/': The requested URL returned error: 403
##[error]The process '/usr/bin/git' failed with exit code 128
```

The job grants `GITHUB_TOKEN` only `contents: read`, which the run log confirms:

```
##[group]GITHUB_TOKEN Permissions
Contents: read
Metadata: read
##[endgroup]
```

`create-pull-request` is handed that token, so it cannot push `update-alerting-swagger-spec`.

**Why do we need this feature?**

The last successful run was **2025-09-01**, so the alerting swagger spec has had no automated update in about eleven months. The last 20 runs are all failures. Every week the job does a full Go build and `make post.json api.json`, then throws the result away at the push.

**Who is this feature for?**

The alerting backend team, who own this cron and are the `team-reviewers` on the PR it is supposed to open.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

I want to be clear about how I picked the fix, because the obvious one looks wrong for this repo.

Raising `GITHUB_TOKEN` to `contents: write` would be the first instinct, but that is not how grafana/grafana opens automated PRs. `i18n-crowdin-download.yml` keeps `contents: read` and mints an app token, and more to the point **`alerting-update-module.yml`, owned by the same team and using the same `peter-evans/create-pull-request` action, already does exactly this**:

```yaml
      - name: Get GitHub App token
        id: get-github-app-token
        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b
        with:
          github_app: alerting-team

      - name: Create Pull Request
        uses: peter-evans/create-pull-request@...
        with:
          token: '${{ steps.get-github-app-token.outputs.token }}'
```

That workflow passes (9 of its last 10 runs succeed), so this is a working in-repo pattern rather than something I invented. This PR copies it: mint an `alerting-team` token and pass that to the PR step. `contents: read` still covers the checkout, and `id-token: write` is what the app-token action needs.

Two things worth a reviewer's eye, since I cannot run this from a fork:

- Whether `alerting-team` is the app you want here. It is the one the team's other cron uses, but you may prefer a different one for a docs-flavoured PR.
- Whether that app can resolve `team-reviewers: 'grafana/alerting-backend'`. `alerting-update-module.yml` does not set `team-reviewers`, so this is the one part of the config its success does not already prove out. If the app lacks org read, that field is the thing that would complain.

I did not touch anything else in the file, and did not add `sign-commits: true` even though the sibling sets it, since that is a separate decision.

Testing: this is `schedule` plus `workflow_dispatch`, so it cannot run from a fork PR and I have not executed it end to end. The file parses under `yaml.safe_load`. The quickest confirmation after merge is a manual `workflow_dispatch`, where the thing to watch is simply that the `Open Pull Request` step gets past the push.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. — N/A, CI only.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc. — N/A, no user-facing change.
