### PR TITLE
unified-search: separate "lock is held" from "lock is not ours"

### DIFF
--- a/pkg/storage/unified/search/lock_cdk_backend.go
+++ b/pkg/storage/unified/search/lock_cdk_backend.go
@@ -92,14 +92,22 @@ func (b *cdkLockBackend) Create(ctx context.Context, key string, info lockInfo) 
 	// The local expiry check is a best-effort optimization: attrs and existing
 	// may be from different generations if the object was replaced between the
 	// two reads. Correctness is enforced by IfMatch=attrs.ETag on the conditional
-	// write below — a generation mismatch will be rejected as errLockHeld.
+	// write below — a generation mismatch means another instance got there first.
 	b.log.Info("taking over expired lock", "key", key, "previous_owner", existing.Owner)
 	err = b.conditionalWrite(ctx, key, data, attrs)
 	if errors.Is(err, errLockNotFound) {
 		return createIfNotExists()
 	}
+	if errors.Is(err, errLockChanged) {
+		return errLockHeld
+	}
 	return err
 }
+
+// errLockChanged means the object moved between read and write. Whether that means
+// losing a race or losing our own lock depends on the caller, so callers translate
+// it rather than returning it.
+var errLockChanged = errors.New("lock changed during write")
 
 // conditionalWrite writes with If-Match semantics via the provider's ops.
 func (b *cdkLockBackend) conditionalWrite(ctx context.Context, key string, data []byte, attrs *blob.Attributes) error {
@@ -110,8 +118,7 @@ func (b *cdkLockBackend) conditionalWrite(ctx context.Context, key string, data 
 	err := b.bucket.WriteAll(ctx, key, data, opts)
 	if err != nil {
 		if isObjectExistsErr(err) {
-			// Another instance modified the lock between our read and write.
-			return errLockHeld
+			return errLockChanged
 		}
 		if gcerrors.Code(err) == gcerrors.NotFound {
 			// Lock object was deleted between Attributes/ReadAll and this write.
@@ -128,7 +135,7 @@ func (b *cdkLockBackend) Update(ctx context.Context, key string, info lockInfo) 
 		return err
 	}
 	if existing.Owner != info.Owner {
-		return errLockHeld
+		return errLockNotOwned
 	}
 
 	// No clockSkewAllowance: holder should detect expiry before a takeover node does.
@@ -141,7 +148,11 @@ func (b *cdkLockBackend) Update(ctx context.Context, key string, info lockInfo) 
 		return err
 	}
 
-	return b.conditionalWrite(ctx, key, data, attrs)
+	err = b.conditionalWrite(ctx, key, data, attrs)
+	if errors.Is(err, errLockChanged) {
+		return errLockNotOwned
+	}
+	return err
 }
 
 // Delete atomically deletes a lock, verifying ownership.
@@ -151,12 +162,12 @@ func (b *cdkLockBackend) Delete(ctx context.Context, key string, owner string) e
 		return err
 	}
 	if existing.Owner != owner {
-		return errLockHeld
+		return errLockNotOwned
 	}
 
 	if err := b.ops.Delete(ctx, key, attrs); err != nil {
 		if errors.Is(err, errPreconditionFailed) || gcerrors.Code(err) == gcerrors.FailedPrecondition {
-			return fmt.Errorf("lock was modified during delete: %w", errLockHeld)
+			return fmt.Errorf("lock was modified during delete: %w", errLockNotOwned)
 		}
 		return err
 	}

--- a/pkg/storage/unified/search/lock_cdk_backend_test.go
+++ b/pkg/storage/unified/search/lock_cdk_backend_test.go
@@ -200,7 +200,7 @@ func TestCDKLockBackend_Update(t *testing.T) {
 		createLockForTest(t, backend, key, "owner-1", time.Minute)
 
 		err := backend.Update(ctx, key, newLockInfo("owner-2", time.Minute))
-		require.ErrorIs(t, err, errLockHeld)
+		require.ErrorIs(t, err, errLockNotOwned)
 	})
 
 	t.Run("returns errLockNotFound for missing key", func(t *testing.T) {
@@ -223,7 +223,7 @@ func TestCDKLockBackend_Update(t *testing.T) {
 		injectETagMismatch(backend, bucket, "lock-1")
 
 		err := backend.Update(ctx, "lock-1", newLockInfo("owner-1", 2*time.Minute))
-		require.ErrorIs(t, err, errLockHeld)
+		require.ErrorIs(t, err, errLockNotOwned)
 	})
 
 	t.Run("rejects renewal of expired lease", func(t *testing.T) {
@@ -296,7 +296,7 @@ func TestCDKLockBackend_Delete(t *testing.T) {
 		createLockForTest(t, backend, key, "owner-1", time.Minute)
 
 		err := backend.Delete(ctx, key, "owner-2")
-		require.ErrorIs(t, err, errLockHeld)
+		require.ErrorIs(t, err, errLockNotOwned)
 	})
 
 	t.Run("returns errLockNotFound for missing key", func(t *testing.T) {

--- a/pkg/storage/unified/search/lock_local_backend.go
+++ b/pkg/storage/unified/search/lock_local_backend.go
@@ -52,7 +52,7 @@ func (b *localLockBackend) Update(ctx context.Context, key string, info lockInfo
 		return errLockNotFound
 	}
 	if existing.Owner != info.Owner {
-		return errLockHeld
+		return errLockNotOwned
 	}
 	if !b.now().Before(existing.Heartbeat.Add(existing.TTL)) {
 		return errLeaseExpired
@@ -75,7 +75,7 @@ func (b *localLockBackend) Delete(ctx context.Context, key string, owner string)
 		return errLockNotFound
 	}
 	if existing.Owner != owner {
-		return errLockHeld
+		return errLockNotOwned
 	}
 
 	delete(b.locks, key)

--- a/pkg/storage/unified/search/lock_objstore.go
+++ b/pkg/storage/unified/search/lock_objstore.go
@@ -22,19 +22,25 @@ type lockBackend interface {
 	Create(ctx context.Context, key string, info lockInfo) error
 
 	// Update atomically updates an existing lock, verifying ownership.
-	// Returns error if lock does not exist or is owned by a different owner.
+	// Returns errLockNotOwned once it is someone else's, errLeaseExpired once ours
+	// has run out, errLockNotFound if it is gone.
 	Update(ctx context.Context, key string, info lockInfo) error
 
 	// Delete atomically deletes a lock, verifying ownership.
-	// Returns error if lock does not exist or is owned by a different owner.
+	// Returns errLockNotOwned once it is someone else's, errLockNotFound if it is gone.
 	Delete(ctx context.Context, key string, owner string) error
 
 	// Read returns the current lock info, or errLockNotFound if no lock exists.
 	Read(ctx context.Context, key string) (*lockInfo, error)
 }
 
-// errLockHeld is returned when a lock cannot be acquired because it is held by another owner.
+// errLockHeld means another owner has the lock, so a caller waiting for a leader
+// keeps waiting.
 var errLockHeld = errors.New("lock is held by another owner")
+
+// errLockNotOwned means a lock we believed we held is no longer ours, so work under
+// it must stop. The opposite response to errLockHeld.
+var errLockNotOwned = errors.New("lock is not owned by this instance")
 
 // errLockNotFound is returned when a lock operation targets a non-existent lock.
 var errLockNotFound = errors.New("lock not found")
@@ -171,7 +177,7 @@ func (l *objectStorageLock) Acquire(ctx context.Context) error {
 // Release stops the heartbeat and deletes the lock object.
 // After Lost is signaled, Release is best-effort cleanup; a nil return does not mean
 // this caller retained ownership until release.
-// Non-retriable errors: errLockHeld, errLockNotFound
+// Non-retriable errors: errLockNotOwned, errLockNotFound
 func (l *objectStorageLock) Release() error {
 	if !l.held {
 		return nil
@@ -182,7 +188,7 @@ func (l *objectStorageLock) Release() error {
 	ctx, cancel := context.WithTimeout(context.Background(), l.releaseDeleteTimeout)
 	defer cancel()
 	err := l.backend.Delete(ctx, l.key, l.owner)
-	if err == nil || errors.Is(err, errLockNotFound) || errors.Is(err, errLockHeld) {
+	if err == nil || errors.Is(err, errLockNotFound) || errors.Is(err, errLockNotOwned) {
 		l.held = false
 	}
 	// On transient Delete errors, keep held=true so a retry re-enters this path
@@ -230,7 +236,7 @@ func (l *objectStorageLock) runHeartbeat(ctx context.Context, done chan struct{}
 					return
 				}
 				// Definitive loss: another owner took the lock, it was deleted, or our lease expired.
-				if errors.Is(err, errLockHeld) || errors.Is(err, errLockNotFound) || errors.Is(err, errLeaseExpired) {
+				if errors.Is(err, errLockNotOwned) || errors.Is(err, errLockNotFound) || errors.Is(err, errLeaseExpired) {
 					close(l.lostCh)
 					return
 				}

--- a/pkg/storage/unified/search/lock_objstore_test.go
+++ b/pkg/storage/unified/search/lock_objstore_test.go
@@ -349,11 +349,37 @@ func TestObjectStorageLock_HeartbeatLossDetectedBeforeTTL(t *testing.T) {
 	require.Less(t, elapsed, ttl-hbi/2, "loss should be detected with safety margin before TTL (got %s, ttl=%s)", elapsed, ttl)
 }
 
+// The two ask opposite things: keep waiting, or stop work under a lock that is gone.
+// Returning one where the other is meant spins forever or drops a live lock.
+func TestLockBackendSeparatesHeldFromNotOwned(t *testing.T) {
+	require.NotErrorIs(t, errLockHeld, errLockNotOwned)
+	require.NotErrorIs(t, errLockNotOwned, errLockHeld)
+
+	for name, newBackend := range map[string]func(t *testing.T) lockBackend{
+		"local": func(*testing.T) lockBackend { return newLocalLockBackend() },
+		"cdk":   func(t *testing.T) lockBackend { return testBackend(t) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx := t.Context()
+			backend := newBackend(t)
+			key := testKey(t)
+			require.NoError(t, backend.Create(ctx, key, newLockInfo("owner-1", time.Minute)))
+
+			// Someone else got there first.
+			require.ErrorIs(t, backend.Create(ctx, key, newLockInfo("owner-2", time.Minute)), errLockHeld)
+
+			// Ours to begin with, no longer.
+			require.ErrorIs(t, backend.Update(ctx, key, newLockInfo("owner-2", time.Minute)), errLockNotOwned)
+			require.ErrorIs(t, backend.Delete(ctx, key, "owner-2"), errLockNotOwned)
+		})
+	}
+}
+
 func TestObjectStorageLock_ImmediateLossOnOwnershipError(t *testing.T) {
 	backend := &failingUpdateBackend{
 		lockBackend:   newFakeBackend(newConditionalBucket()),
 		failAfterN:    0,
-		updateErrFunc: func() error { return errLockHeld },
+		updateErrFunc: func() error { return errLockNotOwned },
 	}
 
 	lock := newTestLock(t, backend, "test-lock", "instance-1", 5*time.Second, 50*time.Millisecond)
@@ -364,7 +390,7 @@ func TestObjectStorageLock_ImmediateLossOnOwnershipError(t *testing.T) {
 	select {
 	case <-lock.Lost():
 	case <-time.After(500 * time.Millisecond):
-		t.Fatal("expected immediate lock loss on errLockHeld, but it was not detected")
+		t.Fatal("expected immediate lock loss on errLockNotOwned, but it was not detected")
 	}
 }
 


### PR DESCRIPTION
`errLockHeld` meant two things depending on which operation returned it. From `Create`: another instance has the lock, so a caller waiting for a leader should keep waiting. From `Update` or `Delete`: a lock we believed we held is no longer ours and work under it must stop. A caller matching the error couldn't tell which.

Ownership failures now return `errLockNotOwned`. `Create` keeps `errLockHeld`, so the acquire-side callers are unchanged, while the heartbeat's loss detection and `Release`'s non-retriable check match the ownership error they were always reading.

No behaviour change and no bug fixed: each call site consumes one operation, so it only ever saw one meaning. What's gone is the trap for the next one.

The CDK backend needed care — its conditional write serves both meanings, so it now returns a private error that each caller translates.

Closes https://github.com/grafana/search-and-storage-team/issues/896
