### PR TITLE
APIServer: Validate handles disabled resource in preferredVersion

### DIFF
--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -386,7 +386,7 @@ func (s *service) start(ctx context.Context) error {
 				versionpolicy.NewResolver(naturalOrder),
 				versionPolicyIni,
 			)
-			if err := s.vpRegistry.Validate(); err != nil {
+			if err := s.vpRegistry.Validate(apiResourceConfig); err != nil {
 				return err
 			}
 		}

--- a/pkg/services/apiserver/versionpolicy/registry.go
+++ b/pkg/services/apiserver/versionpolicy/registry.go
@@ -11,9 +11,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// ResourceEnabledChecker reports whether a GroupVersionResource is enabled.
+// ResourceEnabledChecker reports whether a GroupVersionResource is enabled, and whether any
+// resource in a group is enabled at all. *serverstorage.ResourceConfig satisfies this directly.
 type ResourceEnabledChecker interface {
 	ResourceEnabled(gvr schema.GroupVersionResource) bool
+	AnyResourceForGroupEnabled(group string) bool
 }
 
 type VersionPolicy struct {
@@ -128,6 +130,11 @@ func (r *VersionPolicyRegistry) Validate(resourceChecker ResourceEnabledChecker)
 	// also setting preferredVersion; reject the config at boot rather than serve a self-contradicting API.
 	for group, p := range r.global {
 		if p.MaxAllowedVersion == "" {
+			continue
+		}
+		// InstallAPIs skips installing the group entirely once every version is filtered out as
+		// disabled, so discovery advertises nothing for it - nothing to compare against the cap.
+		if resourceChecker != nil && !resourceChecker.AnyResourceForGroupEnabled(group) {
 			continue
 		}
 		if resourceChecker != nil && !resourceChecker.ResourceEnabled(schema.GroupVersion{Group: group, Version: p.MaxAllowedVersion}.WithResource("")) {

--- a/pkg/services/apiserver/versionpolicy/registry.go
+++ b/pkg/services/apiserver/versionpolicy/registry.go
@@ -95,6 +95,8 @@ func (r *VersionPolicyRegistry) HasMaxAllowed(group string) bool {
 
 // Validate checks the static boot configuration (defaults, ini) and fails fast on a misconfiguration.
 // The live runtime layer is deliberately not checked here (Resolve drops a bad value with a warn).
+// resourceChecker may be nil (no enablement info available to the caller), in which case every
+// registered preferredVersion/maxAllowedVersion is assumed enabled.
 func (r *VersionPolicyRegistry) Validate(resourceChecker ResourceEnabledChecker) error {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -128,12 +130,12 @@ func (r *VersionPolicyRegistry) Validate(resourceChecker ResourceEnabledChecker)
 		if p.MaxAllowedVersion == "" {
 			continue
 		}
-		if !resourceChecker.ResourceEnabled(schema.GroupVersion{Group: group, Version: p.MaxAllowedVersion}.WithResource("")) {
+		if resourceChecker != nil && !resourceChecker.ResourceEnabled(schema.GroupVersion{Group: group, Version: p.MaxAllowedVersion}.WithResource("")) {
 			logger.Warn("maxAllowedVersion is registered but disabled; the cap version itself is unreachable via the API",
 				"group", group, "version", p.MaxAllowedVersion)
 		}
 		advertised := p.PreferredVersion
-		if advertised != "" && !resourceChecker.ResourceEnabled(schema.GroupVersion{Group: group, Version: advertised}.WithResource("")) {
+		if advertised != "" && resourceChecker != nil && !resourceChecker.ResourceEnabled(schema.GroupVersion{Group: group, Version: advertised}.WithResource("")) {
 			logger.Warn("ApplyPreferredForGroup skips the preferred resource version because it is disabled",
 				"group", group, "version", advertised)
 			advertised = ""

--- a/pkg/services/apiserver/versionpolicy/registry.go
+++ b/pkg/services/apiserver/versionpolicy/registry.go
@@ -7,7 +7,14 @@ import (
 	"fmt"
 	"maps"
 	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
+// ResourceEnabledChecker reports whether a GroupVersionResource is enabled.
+type ResourceEnabledChecker interface {
+	ResourceEnabled(gvr schema.GroupVersionResource) bool
+}
 
 type VersionPolicy struct {
 	// advisory: affects discovery only, never storage
@@ -87,9 +94,9 @@ func (r *VersionPolicyRegistry) HasMaxAllowed(group string) bool {
 }
 
 // Validate checks the static boot configuration (defaults, ini) and fails fast on a misconfiguration.
-// The live runtime layer is deliberately not checked here: a bad runtime value must not crash a running
-// server (Resolve drops it with a warn and the last-known policy stands).
-func (r *VersionPolicyRegistry) Validate() error {
+// The live runtime layer is deliberately not checked here (Resolve drops a bad value with a warn).
+// resourceChecker may be nil, in which case every registered preferredVersion is assumed enabled.
+func (r *VersionPolicyRegistry) Validate(resourceChecker ResourceEnabledChecker) error {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
@@ -122,12 +129,22 @@ func (r *VersionPolicyRegistry) Validate() error {
 		if p.MaxAllowedVersion == "" {
 			continue
 		}
+		if resourceChecker != nil && !resourceChecker.ResourceEnabled(schema.GroupVersion{Group: group, Version: p.MaxAllowedVersion}.WithResource("")) {
+			logger.Warn("maxAllowedVersion is registered but disabled; the cap version itself is unreachable via the API",
+				"group", group, "version", p.MaxAllowedVersion)
+		}
 		advertised := p.PreferredVersion
+		if advertised != "" && resourceChecker != nil && !resourceChecker.ResourceEnabled(schema.GroupVersion{Group: group, Version: advertised}.WithResource("")) {
+			logger.Warn("ApplyPreferredForGroup skips the preferred resource version because it is disabled",
+				"group", group, "version", advertised)
+			advertised = ""
+		}
+		preferredApplies := advertised != ""
 		if advertised == "" {
 			advertised = r.resolver.naturalPreferred(group)
 		}
 		if advertised != "" && r.resolver.Outranks(group, advertised, p.MaxAllowedVersion) {
-			if p.PreferredVersion == "" {
+			if !preferredApplies {
 				return fmt.Errorf("version policy for group %q: maxAllowedVersion %q is below the version %q that discovery advertises; set preferredVersion to %q or lower",
 					group, p.MaxAllowedVersion, advertised, p.MaxAllowedVersion)
 			}

--- a/pkg/services/apiserver/versionpolicy/registry.go
+++ b/pkg/services/apiserver/versionpolicy/registry.go
@@ -95,7 +95,6 @@ func (r *VersionPolicyRegistry) HasMaxAllowed(group string) bool {
 
 // Validate checks the static boot configuration (defaults, ini) and fails fast on a misconfiguration.
 // The live runtime layer is deliberately not checked here (Resolve drops a bad value with a warn).
-// resourceChecker may be nil, in which case every registered preferredVersion is assumed enabled.
 func (r *VersionPolicyRegistry) Validate(resourceChecker ResourceEnabledChecker) error {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -129,12 +128,12 @@ func (r *VersionPolicyRegistry) Validate(resourceChecker ResourceEnabledChecker)
 		if p.MaxAllowedVersion == "" {
 			continue
 		}
-		if resourceChecker != nil && !resourceChecker.ResourceEnabled(schema.GroupVersion{Group: group, Version: p.MaxAllowedVersion}.WithResource("")) {
+		if !resourceChecker.ResourceEnabled(schema.GroupVersion{Group: group, Version: p.MaxAllowedVersion}.WithResource("")) {
 			logger.Warn("maxAllowedVersion is registered but disabled; the cap version itself is unreachable via the API",
 				"group", group, "version", p.MaxAllowedVersion)
 		}
 		advertised := p.PreferredVersion
-		if advertised != "" && resourceChecker != nil && !resourceChecker.ResourceEnabled(schema.GroupVersion{Group: group, Version: advertised}.WithResource("")) {
+		if advertised != "" && !resourceChecker.ResourceEnabled(schema.GroupVersion{Group: group, Version: advertised}.WithResource("")) {
 			logger.Warn("ApplyPreferredForGroup skips the preferred resource version because it is disabled",
 				"group", group, "version", advertised)
 			advertised = ""

--- a/pkg/services/apiserver/versionpolicy/registry_test.go
+++ b/pkg/services/apiserver/versionpolicy/registry_test.go
@@ -16,6 +16,8 @@ func (f fakeResourceEnabled) ResourceEnabled(gvr schema.GroupVersionResource) bo
 	return !f.disabled[gvr]
 }
 
+var allEnabled = fakeResourceEnabled{}
+
 var fooOrder = map[string][]string{"foo.grafana.app": {"v2", "v1", "v1beta1"}}
 
 func newTestRegistry(order map[string][]string, base ...map[string]VersionPolicy) *VersionPolicyRegistry {
@@ -136,7 +138,7 @@ func TestVersionPolicyRegistryValidate(t *testing.T) {
 	t.Run("preferred outranking max is rejected", func(t *testing.T) {
 		r := newTestRegistry(fooOrder, nil,
 			map[string]VersionPolicy{"foo.grafana.app": {PreferredVersion: "v2", MaxAllowedVersion: "v1"}})
-		err := r.Validate(nil)
+		err := r.Validate(allEnabled)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "foo.grafana.app")
 	})
@@ -144,7 +146,7 @@ func TestVersionPolicyRegistryValidate(t *testing.T) {
 	t.Run("preferred at or below max is allowed", func(t *testing.T) {
 		r := newTestRegistry(fooOrder, nil,
 			map[string]VersionPolicy{"foo.grafana.app": {PreferredVersion: "v1beta1", MaxAllowedVersion: "v1"}})
-		assert.NoError(t, r.Validate(nil))
+		assert.NoError(t, r.Validate(allEnabled))
 	})
 
 	// fooOrder's natural (highest-priority) version is v2, so it is what discovery advertises when no
@@ -152,7 +154,7 @@ func TestVersionPolicyRegistryValidate(t *testing.T) {
 	t.Run("cap below the natural preferred with no preferredVersion set is rejected", func(t *testing.T) {
 		r := newTestRegistry(fooOrder, nil,
 			map[string]VersionPolicy{"foo.grafana.app": {MaxAllowedVersion: "v1"}})
-		err := r.Validate(nil)
+		err := r.Validate(allEnabled)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "discovery advertises")
 	})
@@ -160,19 +162,19 @@ func TestVersionPolicyRegistryValidate(t *testing.T) {
 	t.Run("cap at or above the natural preferred with no preferredVersion set is allowed", func(t *testing.T) {
 		r := newTestRegistry(fooOrder, nil,
 			map[string]VersionPolicy{"foo.grafana.app": {MaxAllowedVersion: "v2"}})
-		assert.NoError(t, r.Validate(nil))
+		assert.NoError(t, r.Validate(allEnabled))
 	})
 
 	t.Run("cap below the natural preferred is allowed once preferredVersion is set to the cap", func(t *testing.T) {
 		r := newTestRegistry(fooOrder, nil,
 			map[string]VersionPolicy{"foo.grafana.app": {PreferredVersion: "v1", MaxAllowedVersion: "v1"}})
-		assert.NoError(t, r.Validate(nil))
+		assert.NoError(t, r.Validate(allEnabled))
 	})
 
 	t.Run("an unregistered version in a known group is a hard error, not a silent drop", func(t *testing.T) {
 		r := newTestRegistry(fooOrder, nil,
 			map[string]VersionPolicy{"foo.grafana.app": {MaxAllowedVersion: "vtypo"}})
-		err := r.Validate(nil)
+		err := r.Validate(allEnabled)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "vtypo")
 	})
@@ -180,7 +182,7 @@ func TestVersionPolicyRegistryValidate(t *testing.T) {
 	t.Run("a policy for a group not registered on this instance is skipped, not a boot failure", func(t *testing.T) {
 		r := newTestRegistry(fooOrder, nil,
 			map[string]VersionPolicy{"not-on-this-instance.grafana.app": {PreferredVersion: "v1", MaxAllowedVersion: "v1"}})
-		assert.NoError(t, r.Validate(nil))
+		assert.NoError(t, r.Validate(allEnabled))
 	})
 
 	t.Run("preferred set to the cap but disabled falls back to natural, which outranks the cap", func(t *testing.T) {
@@ -197,8 +199,7 @@ func TestVersionPolicyRegistryValidate(t *testing.T) {
 	t.Run("preferred set to the cap and enabled is allowed", func(t *testing.T) {
 		r := newTestRegistry(fooOrder, nil,
 			map[string]VersionPolicy{"foo.grafana.app": {PreferredVersion: "v1", MaxAllowedVersion: "v1"}})
-		enabled := fakeResourceEnabled{disabled: map[schema.GroupVersionResource]bool{}}
-		assert.NoError(t, r.Validate(enabled))
+		assert.NoError(t, r.Validate(allEnabled))
 	})
 
 	t.Run("maxAllowedVersion registered but disabled only warns, does not fail validation", func(t *testing.T) {

--- a/pkg/services/apiserver/versionpolicy/registry_test.go
+++ b/pkg/services/apiserver/versionpolicy/registry_test.go
@@ -4,7 +4,17 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
+// fakeResourceEnabled reports every GVR enabled except those explicitly listed as disabled.
+type fakeResourceEnabled struct {
+	disabled map[schema.GroupVersionResource]bool
+}
+
+func (f fakeResourceEnabled) ResourceEnabled(gvr schema.GroupVersionResource) bool {
+	return !f.disabled[gvr]
+}
 
 var fooOrder = map[string][]string{"foo.grafana.app": {"v2", "v1", "v1beta1"}}
 
@@ -126,7 +136,7 @@ func TestVersionPolicyRegistryValidate(t *testing.T) {
 	t.Run("preferred outranking max is rejected", func(t *testing.T) {
 		r := newTestRegistry(fooOrder, nil,
 			map[string]VersionPolicy{"foo.grafana.app": {PreferredVersion: "v2", MaxAllowedVersion: "v1"}})
-		err := r.Validate()
+		err := r.Validate(nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "foo.grafana.app")
 	})
@@ -134,7 +144,7 @@ func TestVersionPolicyRegistryValidate(t *testing.T) {
 	t.Run("preferred at or below max is allowed", func(t *testing.T) {
 		r := newTestRegistry(fooOrder, nil,
 			map[string]VersionPolicy{"foo.grafana.app": {PreferredVersion: "v1beta1", MaxAllowedVersion: "v1"}})
-		assert.NoError(t, r.Validate())
+		assert.NoError(t, r.Validate(nil))
 	})
 
 	// fooOrder's natural (highest-priority) version is v2, so it is what discovery advertises when no
@@ -142,7 +152,7 @@ func TestVersionPolicyRegistryValidate(t *testing.T) {
 	t.Run("cap below the natural preferred with no preferredVersion set is rejected", func(t *testing.T) {
 		r := newTestRegistry(fooOrder, nil,
 			map[string]VersionPolicy{"foo.grafana.app": {MaxAllowedVersion: "v1"}})
-		err := r.Validate()
+		err := r.Validate(nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "discovery advertises")
 	})
@@ -150,19 +160,19 @@ func TestVersionPolicyRegistryValidate(t *testing.T) {
 	t.Run("cap at or above the natural preferred with no preferredVersion set is allowed", func(t *testing.T) {
 		r := newTestRegistry(fooOrder, nil,
 			map[string]VersionPolicy{"foo.grafana.app": {MaxAllowedVersion: "v2"}})
-		assert.NoError(t, r.Validate())
+		assert.NoError(t, r.Validate(nil))
 	})
 
 	t.Run("cap below the natural preferred is allowed once preferredVersion is set to the cap", func(t *testing.T) {
 		r := newTestRegistry(fooOrder, nil,
 			map[string]VersionPolicy{"foo.grafana.app": {PreferredVersion: "v1", MaxAllowedVersion: "v1"}})
-		assert.NoError(t, r.Validate())
+		assert.NoError(t, r.Validate(nil))
 	})
 
 	t.Run("an unregistered version in a known group is a hard error, not a silent drop", func(t *testing.T) {
 		r := newTestRegistry(fooOrder, nil,
 			map[string]VersionPolicy{"foo.grafana.app": {MaxAllowedVersion: "vtypo"}})
-		err := r.Validate()
+		err := r.Validate(nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "vtypo")
 	})
@@ -170,6 +180,35 @@ func TestVersionPolicyRegistryValidate(t *testing.T) {
 	t.Run("a policy for a group not registered on this instance is skipped, not a boot failure", func(t *testing.T) {
 		r := newTestRegistry(fooOrder, nil,
 			map[string]VersionPolicy{"not-on-this-instance.grafana.app": {PreferredVersion: "v1", MaxAllowedVersion: "v1"}})
-		assert.NoError(t, r.Validate())
+		assert.NoError(t, r.Validate(nil))
+	})
+
+	t.Run("preferred set to the cap but disabled falls back to natural, which outranks the cap", func(t *testing.T) {
+		r := newTestRegistry(fooOrder, nil,
+			map[string]VersionPolicy{"foo.grafana.app": {PreferredVersion: "v1", MaxAllowedVersion: "v1"}})
+		enabled := fakeResourceEnabled{disabled: map[schema.GroupVersionResource]bool{
+			{Group: "foo.grafana.app", Version: "v1"}: true,
+		}}
+		err := r.Validate(enabled)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "discovery advertises")
+	})
+
+	t.Run("preferred set to the cap and enabled is allowed", func(t *testing.T) {
+		r := newTestRegistry(fooOrder, nil,
+			map[string]VersionPolicy{"foo.grafana.app": {PreferredVersion: "v1", MaxAllowedVersion: "v1"}})
+		enabled := fakeResourceEnabled{disabled: map[schema.GroupVersionResource]bool{}}
+		assert.NoError(t, r.Validate(enabled))
+	})
+
+	t.Run("maxAllowedVersion registered but disabled only warns, does not fail validation", func(t *testing.T) {
+		// fooOrder's natural preferred is v2, so cap=v2 with no preferredVersion set always passes on
+		// its own; disabling v2 exercises only the new warning path, not the preferred fallback.
+		r := newTestRegistry(fooOrder, nil,
+			map[string]VersionPolicy{"foo.grafana.app": {MaxAllowedVersion: "v2"}})
+		enabled := fakeResourceEnabled{disabled: map[schema.GroupVersionResource]bool{
+			{Group: "foo.grafana.app", Version: "v2"}: true,
+		}}
+		assert.NoError(t, r.Validate(enabled))
 	})
 }

--- a/pkg/services/apiserver/versionpolicy/registry_test.go
+++ b/pkg/services/apiserver/versionpolicy/registry_test.go
@@ -202,6 +202,12 @@ func TestVersionPolicyRegistryValidate(t *testing.T) {
 		assert.NoError(t, r.Validate(allEnabled))
 	})
 
+	t.Run("nil resourceChecker (no enablement info available) assumes everything enabled", func(t *testing.T) {
+		r := newTestRegistry(fooOrder, nil,
+			map[string]VersionPolicy{"foo.grafana.app": {PreferredVersion: "v1", MaxAllowedVersion: "v1"}})
+		assert.NoError(t, r.Validate(nil))
+	})
+
 	t.Run("maxAllowedVersion registered but disabled only warns, does not fail validation", func(t *testing.T) {
 		// fooOrder's natural preferred is v2, so cap=v2 with no preferredVersion set always passes on
 		// its own; disabling v2 exercises only the new warning path, not the preferred fallback.

--- a/pkg/services/apiserver/versionpolicy/registry_test.go
+++ b/pkg/services/apiserver/versionpolicy/registry_test.go
@@ -7,13 +7,18 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// fakeResourceEnabled reports every GVR enabled except those explicitly listed as disabled.
+// fakeResourceEnabled reports every GVR and group enabled except those explicitly listed.
 type fakeResourceEnabled struct {
-	disabled map[schema.GroupVersionResource]bool
+	disabled      map[schema.GroupVersionResource]bool
+	groupDisabled map[string]bool
 }
 
 func (f fakeResourceEnabled) ResourceEnabled(gvr schema.GroupVersionResource) bool {
 	return !f.disabled[gvr]
+}
+
+func (f fakeResourceEnabled) AnyResourceForGroupEnabled(group string) bool {
+	return !f.groupDisabled[group]
 }
 
 var allEnabled = fakeResourceEnabled{}
@@ -194,6 +199,22 @@ func TestVersionPolicyRegistryValidate(t *testing.T) {
 		err := r.Validate(enabled)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "discovery advertises")
+	})
+
+	t.Run("whole group disabled is skipped, even if the natural fallback would outrank the cap", func(t *testing.T) {
+		// Same setup as "preferred set to the cap but disabled" above (which correctly fails), plus every
+		// version of the group disabled. InstallAPIs then skips installing the group entirely, so
+		// discovery advertises nothing for it - there's nothing to compare against the cap, and this
+		// must not fail startup the way the single-version-disabled case does.
+		r := newTestRegistry(fooOrder, nil,
+			map[string]VersionPolicy{"foo.grafana.app": {PreferredVersion: "v1", MaxAllowedVersion: "v1"}})
+		enabled := fakeResourceEnabled{
+			disabled: map[schema.GroupVersionResource]bool{
+				{Group: "foo.grafana.app", Version: "v1"}: true,
+			},
+			groupDisabled: map[string]bool{"foo.grafana.app": true},
+		}
+		assert.NoError(t, r.Validate(enabled))
 	})
 
 	t.Run("preferred set to the cap and enabled is allowed", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- `Validate` assumed a configured `preferredVersion` is always what discovery advertises. But `ApplyPreferredForGroup` skips reordering the scheme when the preferred version is registered but **disabled** via `apiResourceConfig`, leaving discovery on the natural first version instead. A cap set equal to a disabled preferred therefore passed `Validate` at boot while discovery could still advertise an over-cap version at runtime — the exact self-contradiction `Validate` exists to catch.
- `Validate` now takes a `ResourceEnabledChecker` (small interface; `*serverstorage.ResourceConfig` — already in scope at the one call site, `service.go:389` — satisfies it directly, no adapter needed) and falls back to the natural preferred when the configured one is disabled, mirroring `ApplyPreferredForGroup`'s own skip condition.
- Also warns (does not fail validation) when `maxAllowedVersion` itself is registered but disabled: unlike preferred, nothing skips cap enforcement based on enablement, so this doesn't create the same self-contradiction — just a config smell (the cap version is unreachable via the API) worth surfacing.

Follow-up C from grafana/search-and-storage-team#881.

## Test plan
- [x] New subtests in `TestVersionPolicyRegistryValidate`: disabled-preferred-falls-back-to-natural (fails as expected), preferred-enabled (passes), max-disabled-warns-only (passes).
- [x] Verified the disabled-preferred test is load-bearing: reverted the enablement check, confirmed the test failed, restored.
- [x] `go test ./pkg/services/apiserver/...` — full package green.
- [x] `golangci-lint run` — 0 issues.