### PR TITLE
CI: Fix frontend preview uploads and relax the eligibility check

### DIFF
--- a/.github/actions/frontend-preview-check/action.yml
+++ b/.github/actions/frontend-preview-check/action.yml
@@ -1,7 +1,7 @@
 name: Frontend preview check
 description: >-
   Determines whether a pull request is eligible for a frontend preview deploy:
-  not from a fork, and only changing frontend code. Used by the
+  not from a fork, and not changing backend code. Used by the
   deploy-frontend-preview workflow.
 
 inputs:
@@ -16,7 +16,7 @@ outputs:
   should-deploy:
     description: >-
       'true' when the PR is eligible for a frontend preview deploy: not from a
-      fork, and every changed file is frontend code
+      fork, and no changed file is backend code
     value: ${{ steps.check.outputs.should-deploy }}
   head-sha:
     description: Head commit SHA of the pull request
@@ -47,9 +47,8 @@ runs:
 
         files=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')
 
-        # A PR is frontend-only when every changed file matches this allowlist.
-        # Keep it conservative: anything not listed (backend code, config,
-        # schemas, CI, docs tooling, ...) makes the PR ineligible.
+        # A preview only swaps out the frontend assets served by an existing
+        # instance, so backend changes in the PR would not be reflected.
         frontend_only=true
         if [ -z "$files" ]; then
           frontend_only=false
@@ -57,9 +56,7 @@ runs:
 
         while IFS= read -r file; do
           case "$file" in
-            public/* | packages/* | e2e-playwright/* | scripts/webpack/*) ;;
-            package.json | yarn.lock | .yarnrc.yml | nx.json | tsconfig.json) ;;
-            *)
+            pkg/*)
               echo "Not frontend-only, found: ${file}"
               frontend_only=false
               break

--- a/.github/workflows/deploy-frontend-preview.yml
+++ b/.github/workflows/deploy-frontend-preview.yml
@@ -197,6 +197,9 @@ jobs:
           path: public/build
           service_account: github-gf-frontend-preview-dev@grafanalabs-workload-identity.iam.gserviceaccount.com
           parent: false
+          # The action's default ACL is rejected by the bucket's uniform
+          # bucket-level access. Public read comes from an IAM binding instead.
+          predefinedAcl: ""
 
       - name: Upload manifests to switch the preview to this build
         uses: grafana/shared-workflows/actions/push-to-gcs@main
@@ -207,6 +210,7 @@ jobs:
           path: preview-manifest
           service_account: github-gf-frontend-preview-dev@grafanalabs-workload-identity.iam.gserviceaccount.com
           parent: false
+          predefinedAcl: ""
 
       - name: Set preview URL
         id: preview-url


### PR DESCRIPTION
Two fixes to the frontend preview workflow, found while testing an actual deploy.

- **Uploads failed against the bucket.** `push-to-gcs` sets a predefined ACL by default, which the preview bucket rejects because it has uniform bucket-level access enabled. Passing an empty `predefinedAcl` skips it; public read comes from an IAM binding on the bucket instead.

- **The eligibility check was too strict.** It used an allowlist, so a PR was only eligible if every changed file sat under `public/`, `packages/`, `e2e-playwright/`, `scripts/webpack/` or a handful of root manifests.

Both changes were verified end to end on #130672: the check accepted a PR touching `.github/`, the build ran, and both uploads completed against the bucket.

See design doc for more info: https://docs.google.com/document/d/1fwfoCOxXSDd5nGYVAR2ZsioBBgSRs1CxjdVXpCbwUI8/edit
