### PR TITLE
Unified search: support filtering on numeric and boolean fields

### DIFF
--- a/pkg/storage/unified/resource/document.go
+++ b/pkg/storage/unified/resource/document.go
@@ -9,6 +9,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/selection"
 
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -578,6 +579,15 @@ const (
 	SEARCH_FIELD_DELETED_BY    = "deleted_by"
 	SEARCH_FIELD_DELETION_TIME = "deletion_time"
 	SEARCH_FIELD_DELETED_RV    = "deleted_rv"
+)
+
+// Range operators for Requirement.Operator, which otherwise carries a k8s
+// selection operator. That set names only gt and lt. Sending these as operator
+// strings is what makes an older search server answer with a bad request rather
+// than drop the bound.
+const (
+	OperatorGreaterThanOrEqual selection.Operator = "gte"
+	OperatorLessThanOrEqual    selection.Operator = "lte"
 )
 
 var standardSearchFieldsInit sync.Once

--- a/pkg/storage/unified/resource/search_field.go
+++ b/pkg/storage/unified/resource/search_field.go
@@ -62,6 +62,11 @@ const (
 	// into a single int64. Standard fields never use INT32 today, and
 	// numeric search behaviour is identical (bleve indexes through float64
 	// internally).
+	//
+	// That float64 is exact only up to 2^53, which is far above a timestamp in
+	// millis but below a resource version. Declare a field whose values can reach
+	// that far as a string, the way SEARCH_FIELD_DELETED_RV is: filters and sorts
+	// on a larger int64 cannot tell neighbouring values apart.
 	SearchFieldTypeInt64 SearchFieldType = "int64"
 	// SearchFieldTypeDouble covers floating-point fields. The protobuf-level
 	// distinction between FLOAT and DOUBLE is similarly collapsed; SFDs use

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -3508,7 +3508,9 @@ func parseBooleanFilterValue(value string) (bool, bool) {
 func parseNumericFilterValue(nb numberOrBoolField, key, value string) (float64, *resourcepb.ErrorResult) {
 	if nb.fieldType == resource.SearchFieldTypeDouble {
 		f, err := strconv.ParseFloat(value, 64)
-		if err != nil {
+		// ParseFloat also reads NaN and Inf, which no JSON number can hold. As a
+		// bound they would give an empty or unbounded result rather than an error.
+		if err != nil || math.IsNaN(f) || math.IsInf(f, 0) {
 			return 0, resource.NewBadRequestError(fmt.Sprintf("invalid number value for field %s: %q", key, value))
 		}
 		return f, nil

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -3397,8 +3397,9 @@ func numberOrBoolQuery(nb numberOrBoolField, req *resourcepb.Requirement) (query
 		return numberOrBoolSetQuery(nb, req)
 	case selection.GreaterThan, selection.LessThan, resource.OperatorGreaterThanOrEqual, resource.OperatorLessThanOrEqual:
 		return numberOrBoolRangeQuery(nb, req)
+	default:
+		return nil, unsupportedRequirementError(req)
 	}
-	return nil, unsupportedRequirementError(req)
 }
 
 // Combining rules follow the string path: "=" with several values is an AND,

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -3278,6 +3278,18 @@ func (b *bleveIndex) keywordFieldFor(key string) (keywordField, bool) {
 	return kf, ok
 }
 
+// numberOrBoolFieldFor is the counterpart of keywordFieldFor for fields that are
+// not strings.
+func (b *bleveIndex) numberOrBoolFieldFor(key string) (numberOrBoolField, bool) {
+	fields := b.searchFields.numberOrBoolFields
+	if fields == nil {
+		// Index opened without per-kind declarations; standard fields still apply.
+		fields = standardNumberOrBoolFields
+	}
+	nb, ok := fields[key]
+	return nb, ok
+}
+
 // usesExactTermFilter reports whether "=" or "in" on key matches the whole value
 // as one token rather than going through the analyzed path. That is what the
 // filter capability means: the field is keyword-analyzed. "==" does not ask,
@@ -3299,6 +3311,11 @@ func (b *bleveIndex) usesExactTermFilter(key string) bool {
 
 // Convert a "requirement" into a bleve query
 func (b *bleveIndex) requirementQuery(req *resourcepb.Requirement) (query.Query, *resourcepb.ErrorResult) {
+	// Boolean and numeric fields are indexed in their native form, which a term
+	// or match query cannot reach, so they take a separate path.
+	if nb, ok := b.numberOrBoolFieldFor(req.Key); ok {
+		return numberOrBoolQuery(nb, req)
+	}
 	useExactTermQuery := b.usesExactTermFilter(req.Key)
 	switch selection.Operator(req.Operator) {
 	case selection.DoubleEquals:
@@ -3359,9 +3376,148 @@ func (b *bleveIndex) requirementQuery(req *resourcepb.Requirement) (query.Query,
 	case selection.LessThan:
 	case selection.Exists:
 	}
-	return nil, resource.NewBadRequestError(
+	return nil, unsupportedRequirementError(req)
+}
+
+func unsupportedRequirementError(req *resourcepb.Requirement) *resourcepb.ErrorResult {
+	return resource.NewBadRequestError(
 		fmt.Sprintf("unsupported query operation (%s %s %v)", req.Key, req.Operator, req.Values),
 	)
+}
+
+func numberOrBoolQuery(nb numberOrBoolField, req *resourcepb.Requirement) (query.Query, *resourcepb.ErrorResult) {
+	if !nb.filterable {
+		// The field is not indexed for filtering, so the alternative is an empty
+		// page with no sign the filter was ignored.
+		return nil, resource.NewBadRequestError(fmt.Sprintf("field %s does not support filtering", req.Key))
+	}
+
+	switch selection.Operator(req.Operator) {
+	case selection.Equals, selection.DoubleEquals, selection.In, selection.NotIn:
+		return numberOrBoolSetQuery(nb, req)
+	case selection.GreaterThan, selection.LessThan, resource.OperatorGreaterThanOrEqual, resource.OperatorLessThanOrEqual:
+		return numberOrBoolRangeQuery(nb, req)
+	}
+	return nil, unsupportedRequirementError(req)
+}
+
+// Combining rules follow the string path: "=" with several values is an AND,
+// "in" is an OR.
+func numberOrBoolSetQuery(nb numberOrBoolField, req *resourcepb.Requirement) (query.Query, *resourcepb.ErrorResult) {
+	op := selection.Operator(req.Operator)
+	if op == selection.DoubleEquals && len(req.Values) != 1 {
+		return nil, unsupportedRequirementError(req)
+	}
+	// The string path answers match-all here, turning "in the empty set" into no
+	// filter at all. Nothing can depend on that for these fields yet.
+	if len(req.Values) == 0 {
+		return nil, resource.NewBadRequestError(fmt.Sprintf("filter on field %s has no values", req.Key))
+	}
+
+	queries := make([]query.Query, 0, len(req.Values))
+	for _, v := range req.Values {
+		q, errRes := numberOrBoolValueQuery(nb, req.Key, v)
+		if errRes != nil {
+			return nil, errRes
+		}
+		queries = append(queries, q)
+	}
+
+	switch {
+	case op == selection.NotIn:
+		boolQuery := bleve.NewBooleanQuery()
+		boolQuery.AddMustNot(queries...)
+		// must still have a value
+		boolQuery.AddMust(bleve.NewMatchAllQuery())
+		return boolQuery, nil
+	case len(queries) == 1:
+		return queries[0], nil
+	case op == selection.Equals:
+		return query.NewConjunctionQuery(queries), nil
+	default:
+		return query.NewDisjunctionQuery(queries), nil
+	}
+}
+
+// A number has no term form, so equality has to be a range with both bounds on
+// the value.
+func numberOrBoolValueQuery(nb numberOrBoolField, key, value string) (query.Query, *resourcepb.ErrorResult) {
+	if nb.isBoolean() {
+		b, ok := parseBooleanFilterValue(value)
+		if !ok {
+			return nil, resource.NewBadRequestError(fmt.Sprintf("invalid boolean value for field %s: %q", key, value))
+		}
+		q := bleve.NewBoolFieldQuery(b)
+		q.SetField(nb.name)
+		return q, nil
+	}
+
+	n, errRes := parseNumericFilterValue(nb, key, value)
+	if errRes != nil {
+		return nil, errRes
+	}
+	inclusive := true
+	q := bleve.NewNumericRangeInclusiveQuery(&n, &n, &inclusive, &inclusive)
+	q.SetField(nb.name)
+	return q, nil
+}
+
+func numberOrBoolRangeQuery(nb numberOrBoolField, req *resourcepb.Requirement) (query.Query, *resourcepb.ErrorResult) {
+	if nb.isBoolean() {
+		return nil, resource.NewBadRequestError(fmt.Sprintf("field %s is a boolean and cannot be compared with %s", req.Key, req.Operator))
+	}
+	if len(req.Values) != 1 {
+		return nil, resource.NewBadRequestError(fmt.Sprintf("operator %s on field %s takes exactly one value", req.Operator, req.Key))
+	}
+	bound, errRes := parseNumericFilterValue(nb, req.Key, req.Values[0])
+	if errRes != nil {
+		return nil, errRes
+	}
+
+	op := selection.Operator(req.Operator)
+	inclusive := op == resource.OperatorGreaterThanOrEqual || op == resource.OperatorLessThanOrEqual
+
+	var q *query.NumericRangeQuery
+	if op == selection.GreaterThan || op == resource.OperatorGreaterThanOrEqual {
+		q = bleve.NewNumericRangeInclusiveQuery(&bound, nil, &inclusive, nil)
+	} else {
+		q = bleve.NewNumericRangeInclusiveQuery(nil, &bound, nil, &inclusive)
+	}
+	q.SetField(nb.name)
+	return q, nil
+}
+
+// Only the two canonical spellings, so "yes" is reported rather than read as
+// false.
+func parseBooleanFilterValue(value string) (bool, bool) {
+	switch value {
+	case "true":
+		return true, true
+	case "false":
+		return false, true
+	}
+	return false, false
+}
+
+// An int64 field takes integers only, so "0.5" is reported rather than turned
+// into a query that cannot match.
+//
+// Bleve stores numbers as float64, so two int64 values past 2^53 can collapse
+// onto one. The bound is converted the same way as the indexed value, so such a
+// filter can match a neighbour but never misses.
+func parseNumericFilterValue(nb numberOrBoolField, key, value string) (float64, *resourcepb.ErrorResult) {
+	if nb.fieldType == resource.SearchFieldTypeDouble {
+		f, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return 0, resource.NewBadRequestError(fmt.Sprintf("invalid number value for field %s: %q", key, value))
+		}
+		return f, nil
+	}
+	n, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return 0, resource.NewBadRequestError(fmt.Sprintf("invalid integer value for field %s: %q", key, value))
+	}
+	return float64(n), nil
 }
 
 // allRequirementValuesQuery preserves selector semantics where multiple "=" values are combined with AND.

--- a/pkg/storage/unified/search/bleve_mappings.go
+++ b/pkg/storage/unified/search/bleve_mappings.go
@@ -21,6 +21,10 @@ type kindSearchFields struct {
 	// keywordFields maps a filter, sort or facet field name to the
 	// keyword-analyzed index field backing it.
 	keywordFields map[string]keywordField
+	// numberOrBoolFields maps a field name to the boolean or numeric index field
+	// backing it. Those have no keyword form, so keywordFields cannot describe
+	// them.
+	numberOrBoolFields map[string]numberOrBoolField
 	// storedFacetFields maps a facet field name to the stored canonical field
 	// post-rank authorization loads for app-side aggregation.
 	storedFacetFields map[string]string
@@ -34,10 +38,11 @@ type kindSearchFields struct {
 
 func newKindSearchFields(provider resource.SearchFieldsProvider, group, kindResource string, selectableFields []string) kindSearchFields {
 	return kindSearchFields{
-		keywordFields:     keywordFieldsForMapping(provider, group, kindResource, selectableFields),
-		storedFacetFields: storedFacetFieldsForMapping(provider, group, kindResource),
-		textQueryKinds:    textQueryKindsForMapping(provider, group, kindResource, selectableFields),
-		variants:          fieldVariantsOf(fieldDefinitionsForMapping(provider, group, kindResource)),
+		keywordFields:      keywordFieldsForMapping(provider, group, kindResource, selectableFields),
+		numberOrBoolFields: numberOrBoolFieldsForMapping(provider, group, kindResource),
+		storedFacetFields:  storedFacetFieldsForMapping(provider, group, kindResource),
+		textQueryKinds:     textQueryKindsForMapping(provider, group, kindResource, selectableFields),
+		variants:           fieldVariantsOf(fieldDefinitionsForMapping(provider, group, kindResource)),
 	}
 }
 
@@ -185,6 +190,63 @@ func keywordFieldsForMapping(provider resource.SearchFieldsProvider, group, kind
 // standardKeywordFields covers an index opened without per-kind declarations.
 var standardKeywordFields = keywordFieldsForMapping(nil, "", "", nil)
 
+// filterable is separate from the type because such a field can be indexed for
+// sorting alone, or only stored.
+type numberOrBoolField struct {
+	name       string
+	fieldType  resource.SearchFieldType
+	filterable bool
+}
+
+// isBoolean splits the two shapes nonStringFieldMapping emits, so a query
+// cannot disagree with what was indexed.
+func (f numberOrBoolField) isBoolean() bool {
+	return f.fieldType == resource.SearchFieldTypeBoolean
+}
+
+// Derived from the declarations that produced the mapping, so the query side
+// cannot drift from it (see nonStringFieldMapping).
+//
+// Keys are the names filters arrive with. Fields that cannot be filtered are
+// listed too, so a filter on one is refused rather than matching nothing.
+func numberOrBoolFieldsForMapping(provider resource.SearchFieldsProvider, group, kindResource string) map[string]numberOrBoolField {
+	fields := map[string]numberOrBoolField{}
+	add := func(key string, def resource.SearchFieldDefinition, prefix string) {
+		// date is left out because no kind declares one and whether its values are
+		// RFC3339 or unix millis is still open. An unrecognised type stays on the
+		// string path rather than being guessed at.
+		switch def.Type {
+		case resource.SearchFieldTypeBoolean, resource.SearchFieldTypeInt64, resource.SearchFieldTypeDouble:
+		default:
+			return
+		}
+		fields[key] = numberOrBoolField{
+			name:       prefix + def.Name,
+			fieldType:  def.Type,
+			filterable: def.HasCapability(resource.SearchCapabilityFilter),
+		}
+	}
+
+	for _, def := range resource.StandardSearchFieldDefinitions() {
+		add(def.Name, def, "")
+	}
+	for _, def := range resource.TrashSearchFieldDefinitions() {
+		add(def.Name, def, "")
+	}
+	for _, def := range fieldDefinitionsForMapping(provider, group, kindResource) {
+		add(resource.SEARCH_FIELD_PREFIX+def.Name, def, resource.SEARCH_FIELD_PREFIX)
+		// Requests may name a per-kind field without the internal fields prefix.
+		// A top-level field of the same name wins, matching resolveFieldName.
+		if _, taken := fields[def.Name]; !taken && !isReservedTopLevelField(def.Name) {
+			add(def.Name, def, resource.SEARCH_FIELD_PREFIX)
+		}
+	}
+	return fields
+}
+
+// standardNumberOrBoolFields covers an index opened without per-kind declarations.
+var standardNumberOrBoolFields = numberOrBoolFieldsForMapping(nil, "", "")
+
 // keywordSubDocumentFields are keyword-mapped fields that live in sub-documents
 // and so are not modellable as SearchFieldDefinitions yet (see
 // managerSubDocumentMapping and sourceSubDocumentMapping). The labels
@@ -270,7 +332,7 @@ func addCapabilityFieldMappings(parent *mapping.DocumentMapping, def resource.Se
 	// only filter, sort and retrieve reach here for non-strings.
 	if def.Type != resource.SearchFieldTypeString {
 		if hasFilter || hasSort || hasRetrieve {
-			m := typedNonStringFieldMapping(def.Type)
+			m := nonStringFieldMapping(def.Type)
 			// bleve can sort an indexed numeric field even without doc values, so
 			// sort only needs the field indexed.
 			m.Index = hasFilter || hasSort
@@ -333,11 +395,11 @@ func addCapabilityFieldMappings(parent *mapping.DocumentMapping, def resource.Se
 	}
 }
 
-// typedNonStringFieldMapping returns a bleve field mapping matching a
+// nonStringFieldMapping returns a bleve field mapping matching a
 // non-string search field's type, so the value is indexed and stored in its
 // native form instead of being coerced through keyword analysis (which drops
 // it).
-func typedNonStringFieldMapping(t resource.SearchFieldType) *mapping.FieldMapping {
+func nonStringFieldMapping(t resource.SearchFieldType) *mapping.FieldMapping {
 	switch t {
 	case resource.SearchFieldTypeBoolean:
 		return bleve.NewBooleanFieldMapping()

--- a/pkg/storage/unified/search/bleve_mappings_internal_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_internal_test.go
@@ -762,6 +762,13 @@ func TestRequirementQuery_NumericField(t *testing.T) {
 	require.True(t, ok)
 	assert.Len(t, dq.Disjuncts, 2)
 
+	// No JSON number can hold these, and as a bound they would quietly widen or
+	// empty the result instead of failing.
+	for _, value := range []string{"NaN", "+Inf", "-Inf", "Inf", "inf"} {
+		assertBadRequest(t, b, resource.SEARCH_FIELD_PREFIX+"ratio", "gt", value)
+		assertBadRequest(t, b, resource.SEARCH_FIELD_PREFIX+"ratio", "=", value)
+	}
+
 	// A double field takes fractional values, an int64 field does not.
 	ratio := numericRangeOf(t, mustQuery(t, b, resource.SEARCH_FIELD_PREFIX+"ratio", "gt", "0.5"))
 	assert.Equal(t, 0.5, *ratio.Min)

--- a/pkg/storage/unified/search/bleve_mappings_internal_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_internal_test.go
@@ -642,6 +642,179 @@ func TestRequirementQuery_ExactPathFromCapabilities(t *testing.T) {
 	assert.True(t, ok, "= on an undeclared field should build an analyzed MatchQuery")
 }
 
+// numberOrBoolFieldsIndex returns an index declaring one boolean and one numeric
+// filterable field, plus a numeric field that can only be sorted.
+func numberOrBoolFieldsIndex(t *testing.T) *bleveIndex {
+	t.Helper()
+	return customFieldsIndex(t,
+		resource.SearchFieldDefinition{Name: "paused", Type: resource.SearchFieldTypeBoolean, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter}},
+		resource.SearchFieldDefinition{Name: "panelID", Type: resource.SearchFieldTypeInt64, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter}},
+		resource.SearchFieldDefinition{Name: "ratio", Type: resource.SearchFieldTypeDouble, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter}},
+		resource.SearchFieldDefinition{Name: "weight", Type: resource.SearchFieldTypeInt64, Capabilities: []resource.SearchCapability{resource.SearchCapabilitySort}},
+		resource.SearchFieldDefinition{Name: "when", Type: resource.SearchFieldTypeDate, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter}},
+	)
+}
+
+// A date filter is out of scope until the value format is settled, so it keeps
+// the behaviour it had rather than picking RFC3339 or unix millis here.
+func TestRequirementQuery_DateFieldIsNotTypedYet(t *testing.T) {
+	b := numberOrBoolFieldsIndex(t)
+	_, ok := b.numberOrBoolFieldFor(resource.SEARCH_FIELD_PREFIX + "when")
+	assert.False(t, ok)
+}
+
+func TestRequirementQuery_BooleanField(t *testing.T) {
+	b := numberOrBoolFieldsIndex(t)
+	paused := resource.SEARCH_FIELD_PREFIX + "paused"
+
+	q, errRes := b.requirementQuery(&resourcepb.Requirement{Key: paused, Operator: "=", Values: []string{"true"}})
+	require.Nil(t, errRes)
+	bq, ok := q.(*query.BoolFieldQuery)
+	require.True(t, ok, "a boolean field needs a bool query; a term query cannot reach it")
+	assert.Equal(t, paused, bq.Field())
+	assert.True(t, bq.Bool)
+
+	// The unprefixed name a caller may send resolves to the same field.
+	q, errRes = b.requirementQuery(&resourcepb.Requirement{Key: "paused", Operator: "=", Values: []string{"false"}})
+	require.Nil(t, errRes)
+	bq, ok = q.(*query.BoolFieldQuery)
+	require.True(t, ok)
+	assert.Equal(t, paused, bq.Field())
+	assert.False(t, bq.Bool)
+
+	// notin excludes, and still requires the document to match something.
+	q, errRes = b.requirementQuery(&resourcepb.Requirement{Key: paused, Operator: "notin", Values: []string{"true"}})
+	require.Nil(t, errRes)
+	boolQuery, ok := q.(*query.BooleanQuery)
+	require.True(t, ok)
+	mustNot, ok := boolQuery.MustNot.(*query.DisjunctionQuery)
+	require.True(t, ok)
+	require.Len(t, mustNot.Disjuncts, 1)
+	_, ok = mustNot.Disjuncts[0].(*query.BoolFieldQuery)
+	assert.True(t, ok)
+
+	// Anything but the two canonical spellings is a mistake, not false.
+	for _, value := range []string{"yes", "True", "1", ""} {
+		q, errRes = b.requirementQuery(&resourcepb.Requirement{Key: paused, Operator: "=", Values: []string{value}})
+		require.Nil(t, q)
+		require.NotNil(t, errRes, "value %q", value)
+		assert.Equal(t, int32(400), errRes.Code)
+	}
+
+	// A boolean has no order, so a range comparison on it is refused.
+	q, errRes = b.requirementQuery(&resourcepb.Requirement{Key: paused, Operator: "gt", Values: []string{"true"}})
+	require.Nil(t, q)
+	require.NotNil(t, errRes)
+	assert.Equal(t, int32(400), errRes.Code)
+}
+
+func TestRequirementQuery_NumericField(t *testing.T) {
+	b := numberOrBoolFieldsIndex(t)
+	panelID := resource.SEARCH_FIELD_PREFIX + "panelID"
+
+	rangeOf := func(q query.Query) *query.NumericRangeQuery {
+		nq := numericRangeOf(t, q)
+		assert.Equal(t, panelID, nq.Field())
+		return nq
+	}
+
+	// Equality is a range with both bounds on the value: a number has no term form.
+	eq := rangeOf(mustQuery(t, b, panelID, "=", "10"))
+	assert.Equal(t, 10.0, *eq.Min)
+	assert.Equal(t, 10.0, *eq.Max)
+	assert.True(t, *eq.InclusiveMin)
+	assert.True(t, *eq.InclusiveMax)
+
+	for _, tc := range []struct {
+		operator     string
+		min, max     *float64
+		inclusiveMin bool
+		inclusiveMax bool
+	}{
+		{operator: "gt", min: new(15.0)},
+		{operator: "gte", min: new(15.0), inclusiveMin: true},
+		{operator: "lt", max: new(15.0)},
+		{operator: "lte", max: new(15.0), inclusiveMax: true},
+	} {
+		t.Run(tc.operator, func(t *testing.T) {
+			nq := rangeOf(mustQuery(t, b, panelID, tc.operator, "15"))
+			if tc.min == nil {
+				assert.Nil(t, nq.Min)
+			} else {
+				require.NotNil(t, nq.Min)
+				assert.Equal(t, *tc.min, *nq.Min)
+				assert.Equal(t, tc.inclusiveMin, *nq.InclusiveMin)
+			}
+			if tc.max == nil {
+				assert.Nil(t, nq.Max)
+			} else {
+				require.NotNil(t, nq.Max)
+				assert.Equal(t, *tc.max, *nq.Max)
+				assert.Equal(t, tc.inclusiveMax, *nq.InclusiveMax)
+			}
+		})
+	}
+
+	// A set of values is an OR of exact matches.
+	q, errRes := b.requirementQuery(&resourcepb.Requirement{Key: panelID, Operator: "in", Values: []string{"10", "20"}})
+	require.Nil(t, errRes)
+	dq, ok := q.(*query.DisjunctionQuery)
+	require.True(t, ok)
+	assert.Len(t, dq.Disjuncts, 2)
+
+	// A double field takes fractional values, an int64 field does not.
+	ratio := numericRangeOf(t, mustQuery(t, b, resource.SEARCH_FIELD_PREFIX+"ratio", "gt", "0.5"))
+	assert.Equal(t, 0.5, *ratio.Min)
+	assertBadRequest(t, b, panelID, "=", "0.5")
+	assertBadRequest(t, b, panelID, "=", "ten")
+
+	// A range needs exactly one bound value.
+	assertBadRequest(t, b, panelID, "gt", "1", "2")
+
+	// Membership of an empty set is not the same as no filter at all.
+	assertBadRequest(t, b, panelID, "in")
+	assertBadRequest(t, b, panelID, "=")
+}
+
+func TestRequirementQuery_TypedFieldWithoutFilterCapability(t *testing.T) {
+	b := numberOrBoolFieldsIndex(t)
+
+	// A sort-only field is indexed, but a filter on it was never declared: an
+	// empty page would read as "no results" rather than "wrong field".
+	assertBadRequest(t, b, resource.SEARCH_FIELD_PREFIX+"weight", "=", "1")
+
+	// The standard timestamps are stored but not indexed, so the same applies.
+	assertBadRequest(t, b, resource.SEARCH_FIELD_CREATED, "gt", "0")
+	assertBadRequest(t, b, resource.SEARCH_FIELD_UPDATED, "=", "0")
+}
+
+// mustQuery builds the query for one requirement and fails when it is refused.
+func mustQuery(t *testing.T, b *bleveIndex, key, operator string, values ...string) query.Query {
+	t.Helper()
+	q, errRes := b.requirementQuery(&resourcepb.Requirement{Key: key, Operator: operator, Values: values})
+	require.Nil(t, errRes)
+	require.NotNil(t, q)
+	return q
+}
+
+// assertBadRequest asserts that a requirement is refused with a 400 rather than
+// answered with a query that matches nothing.
+func assertBadRequest(t *testing.T, b *bleveIndex, key, operator string, values ...string) {
+	t.Helper()
+	q, errRes := b.requirementQuery(&resourcepb.Requirement{Key: key, Operator: operator, Values: values})
+	require.Nil(t, q)
+	require.NotNil(t, errRes)
+	assert.Equal(t, int32(400), errRes.Code)
+}
+
+// numericRangeOf asserts the query is the numeric range a non-string field needs.
+func numericRangeOf(t *testing.T, q query.Query) *query.NumericRangeQuery {
+	t.Helper()
+	nq, ok := q.(*query.NumericRangeQuery)
+	require.True(t, ok, "a numeric field needs a numeric range query")
+	return nq
+}
+
 func TestRequirementQuery_StandardExactFields(t *testing.T) {
 	// createdBy and ownerReferences are declared filter-capable standard fields:
 	// they stay exact without being named anywhere in the query path.

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -3220,3 +3220,110 @@ func TestTrashFieldsAreFilterableSortableAndReturned(t *testing.T) {
 		}
 	})
 }
+
+// The mapping and the query have to agree on a field's type, and neither side
+// fails loudly when they don't, so these filters run against a real index
+// instead of asserting on query shapes.
+func TestFilteringOnBooleanAndNumericFields(t *testing.T) {
+	key := resource.NamespacedResource{
+		Namespace: "default",
+		Group:     "rules.alerting.grafana.app",
+		Resource:  "rules",
+	}
+	index := newTestIndexWithTypedFields(t, key, []resource.SearchFieldDefinition{
+		{Name: "paused", Type: resource.SearchFieldTypeBoolean, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilityRetrieve}},
+		{Name: "panelID", Type: resource.SearchFieldTypeInt64, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilityRetrieve}},
+	})
+
+	rule := func(name string, paused bool, panelID int64) *resource.BulkIndexItem {
+		return &resource.BulkIndexItem{
+			Action: resource.ActionIndex,
+			Doc: &resource.IndexableDocument{
+				Key: &resourcepb.ResourceKey{
+					Namespace: key.Namespace, Group: key.Group, Resource: key.Resource, Name: name,
+				},
+				Name:   name,
+				Title:  name,
+				RV:     1,
+				Fields: map[string]any{"paused": paused, "panelID": panelID},
+			},
+		}
+	}
+	require.NoError(t, index.BulkIndex(&resource.BulkIndexRequest{Items: []*resource.BulkIndexItem{
+		rule("rule-paused", true, 10),
+		rule("rule-active", false, 20),
+	}}))
+
+	filter := func(field, operator string, values ...string) *resourcepb.ResourceSearchRequest {
+		return &resourcepb.ResourceSearchRequest{
+			Options: &resourcepb.ListOptions{
+				Key:    &resourcepb.ResourceKey{Namespace: key.Namespace, Group: key.Group, Resource: key.Resource},
+				Fields: []*resourcepb.Requirement{{Key: field, Operator: operator, Values: values}},
+			},
+			Limit: 100,
+		}
+	}
+
+	for _, tc := range []struct {
+		name     string
+		query    *resourcepb.ResourceSearchRequest
+		expected []string
+	}{
+		{"boolean equals", filter("paused", "=", "true"), []string{"rule-paused"}},
+		{"boolean not in", filter("paused", "notin", "true"), []string{"rule-active"}},
+		{"number equals", filter("panelID", "=", "10"), []string{"rule-paused"}},
+		{"number in", filter("panelID", "in", "10", "20"), []string{"rule-paused", "rule-active"}},
+		{"number greater than", filter("panelID", "gt", "15"), []string{"rule-active"}},
+		{"number greater than or equal", filter("panelID", "gte", "20"), []string{"rule-active"}},
+		{"number less than", filter("panelID", "lt", "20"), []string{"rule-paused"}},
+		{"number less than or equal", filter("panelID", "lte", "15"), []string{"rule-paused"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			checkSearchQueryUnordered(t, index, tc.query, tc.expected)
+		})
+	}
+
+	// A value that does not parse, or a comparison the field's type has no
+	// meaning for, is a caller mistake. Answering with an empty page would look
+	// like a rule set with nothing in it.
+	for _, tc := range []struct {
+		name  string
+		query *resourcepb.ResourceSearchRequest
+	}{
+		{"boolean value that is not true or false", filter("paused", "=", "yes")},
+		{"boolean compared with a range", filter("paused", "gt", "true")},
+		{"number value that is not a number", filter("panelID", "=", "ten")},
+		{"filter on a field that only declares retrieve", filter(resource.SEARCH_FIELD_CREATED, "gt", "0")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := index.Search(context.Background(), nil, tc.query, nil, nil)
+			require.NoError(t, err, "a bad request comes back in the response, not as an error")
+			require.NotNil(t, res.Error)
+			require.Equal(t, int32(400), res.Error.Code)
+		})
+	}
+}
+
+// newTestIndexWithTypedFields creates a test index whose kind declares the
+// given search fields, so non-string types keep their declared mapping.
+func newTestIndexWithTypedFields(t testing.TB, key resource.NamespacedResource, sfds []resource.SearchFieldDefinition) resource.ResourceIndex {
+	gvr := apischema.GroupVersionResource{Group: key.Group, Version: "v0", Resource: key.Resource}
+	provider := resource.NewMapProvider(
+		map[apischema.GroupVersionResource][]resource.SearchFieldDefinition{gvr: sfds},
+		map[apischema.GroupResource]string{gvr.GroupResource(): gvr.Version},
+	)
+	sfKey := resource.NewLowerGroupResource(key.Group, key.Resource)
+
+	backend, err := search.NewBleveBackend(search.BleveOptions{
+		Root:          t.TempDir(),
+		FileThreshold: threshold,
+		SearchFields:  resource.NewSearchFieldsRegistry(nil, nil, map[resource.LowerGroupResource]resource.SearchFieldsProvider{sfKey: provider}),
+	}, nil)
+	require.NoError(t, err)
+	t.Cleanup(backend.Stop)
+
+	ctx := identity.WithRequester(context.Background(), &user.SignedInUser{Namespace: "ns"})
+	index, err := backend.BuildIndex(ctx, key, 2, "test", noop, nil, false, time.Time{}, 0)
+	require.NoError(t, err)
+	return index
+}


### PR DESCRIPTION
Filtering a search field declared `boolean`, `int64` or `double` returned no results and no error. The values were indexed correctly — only the query side was string-only, building term and match queries that cannot reach a boolean or numeric field.

Those filters now parse values against the declared type. Adds the range operators `gte` and `lte` alongside `gt` and `lt`. A filter that cannot work answers with a bad request instead of an empty page, so a caller can tell a broken filter from an empty result set.

```
paused  = true     -> rule-paused      panelID gt  15 -> rule-active
paused  notin true -> rule-active      panelID lte 15 -> rule-paused
panelID in 10,20   -> both             panelID =   10 -> rule-paused
paused  = yes      -> 400 invalid boolean value
created gt 0       -> 400 field does not support filtering
```

Every line above returned zero hits before.

Search server only — opening this up on the public `/search` endpoint is a follow-up, since the API layer deploys separately. No `.proto` change: the new operators travel as strings, so an older server rejects a range bound rather than dropping it. No mapping change, so no index rebuild.

`date` fields stay on the old path on purpose: no kind declares one, and RFC3339 vs unix millis is still open.

Closes grafana/search-and-storage-team#928
