### PR TITLE
User: template raw SQL queries

### DIFF
--- a/pkg/services/user/userimpl/queries/batch_disable_users.sql
+++ b/pkg/services/user/userimpl/queries/batch_disable_users.sql
@@ -1,0 +1,4 @@
+UPDATE {{ .Ident .UserTable }}
+SET is_disabled = {{ .Arg .IsDisabled }}
+WHERE id IN ({{ .ArgList .UserIDs }})
+  AND is_service_account = FALSE

--- a/pkg/services/user/userimpl/queries/count_search_users.sql
+++ b/pkg/services/user/userimpl/queries/count_search_users.sql
@@ -1,0 +1,43 @@
+SELECT COUNT(*) AS count
+FROM {{ .Ident .UserTable }} AS u
+{{ if .IncludeAuthJoin -}}
+LEFT JOIN {{ .Ident .UserAuthTable }} AS user_auth ON user_auth.id = (
+  SELECT id
+  FROM {{ .Ident .UserAuthTable }} AS user_auth
+  WHERE user_auth.user_id = u.id
+  ORDER BY user_auth.created DESC
+  LIMIT 1
+)
+{{ end -}}
+{{ range .Joins -}}
+{{ .Operator }} JOIN {{ $.Ident .Table }} AS {{ $.Ident .Alias }} ON {{ .Condition }}
+{{ end -}}
+WHERE u.is_service_account = {{ .Arg .IsServiceAccount }}
+{{ if gt .OrgID 0 -}}
+  AND u.org_id = {{ .Arg .OrgID }}
+{{ end -}}
+{{ if .AccessUserIDs -}}
+  AND u.id IN ({{ .ArgList .AccessUserIDs }})
+{{ else if not .AccessAll -}}
+  AND 1 = 0
+{{ end -}}
+{{ if .QueryPattern -}}
+  AND (
+    u.email {{ if eq .DialectName "postgres" }}ILIKE{{ else }}LIKE{{ end }} {{ .Arg .QueryPattern }}
+    OR u.name {{ if eq .DialectName "postgres" }}ILIKE{{ else }}LIKE{{ end }} {{ .Arg .QueryPattern }}
+    OR u.login {{ if eq .DialectName "postgres" }}ILIKE{{ else }}LIKE{{ end }} {{ .Arg .QueryPattern }}
+  )
+{{ end -}}
+{{ if .HasIsDisabled -}}
+  AND u.is_disabled = {{ .Arg .IsDisabled }}
+{{ end -}}
+{{ if .AuthModule -}}
+  AND user_auth.auth_module = {{ .Arg .AuthModule }}
+{{ end -}}
+{{ range .Filters -}}
+{{ if eq .Kind "in" -}}
+  AND {{ .Condition }} IN ({{ $.ArgList .Values }})
+{{ else -}}
+  AND {{ range .Parts }}{{ .SQL }}{{ if .HasValue }}{{ $.Arg .Value }}{{ end }}{{ end }}
+{{ end -}}
+{{ end -}}

--- a/pkg/services/user/userimpl/queries/count_search_users.sql
+++ b/pkg/services/user/userimpl/queries/count_search_users.sql
@@ -36,7 +36,11 @@ WHERE u.is_service_account = {{ .Arg .IsServiceAccount }}
 {{ end -}}
 {{ range .Filters -}}
 {{ if eq .Kind "in" -}}
-  AND {{ .Condition }} IN ({{ $.ArgList .Values }})
+{{ if .Values -}}
+  AND {{ $.Ident .Condition }} IN ({{ $.ArgList .Values }})
+{{ else -}}
+  AND 0 = 1
+{{ end -}}
 {{ else -}}
   AND {{ range .Parts }}{{ .SQL }}{{ if .HasValue }}{{ $.Arg .Value }}{{ end }}{{ end }}
 {{ end -}}

--- a/pkg/services/user/userimpl/queries/count_search_users.sql
+++ b/pkg/services/user/userimpl/queries/count_search_users.sql
@@ -12,7 +12,7 @@ LEFT JOIN {{ .Ident .UserAuthTable }} AS user_auth ON user_auth.id = (
 {{ range .Joins -}}
 {{ .Operator }} JOIN {{ $.Ident .Table }} AS {{ $.Ident .Alias }} ON {{ .Condition }}
 {{ end -}}
-WHERE u.is_service_account = {{ .Arg .IsServiceAccount }}
+WHERE u.is_service_account = FALSE
 {{ if gt .OrgID 0 -}}
   AND u.org_id = {{ .Arg .OrgID }}
 {{ end -}}

--- a/pkg/services/user/userimpl/queries/count_search_users.sql
+++ b/pkg/services/user/userimpl/queries/count_search_users.sql
@@ -12,36 +12,4 @@ LEFT JOIN {{ .Ident .UserAuthTable }} AS user_auth ON user_auth.id = (
 {{ range .Joins -}}
 {{ .Operator }} JOIN {{ $.Ident .Table }} AS {{ $.Ident .Alias }} ON {{ .Condition }}
 {{ end -}}
-WHERE u.is_service_account = FALSE
-{{ if gt .OrgID 0 -}}
-  AND u.org_id = {{ .Arg .OrgID }}
-{{ end -}}
-{{ if .AccessUserIDs -}}
-  AND u.id IN ({{ .ArgList .AccessUserIDs }})
-{{ else if not .AccessAll -}}
-  AND 1 = 0
-{{ end -}}
-{{ if .QueryPattern -}}
-  AND (
-    u.email {{ if eq .DialectName "postgres" }}ILIKE{{ else }}LIKE{{ end }} {{ .Arg .QueryPattern }}
-    OR u.name {{ if eq .DialectName "postgres" }}ILIKE{{ else }}LIKE{{ end }} {{ .Arg .QueryPattern }}
-    OR u.login {{ if eq .DialectName "postgres" }}ILIKE{{ else }}LIKE{{ end }} {{ .Arg .QueryPattern }}
-  )
-{{ end -}}
-{{ if .IsDisabled -}}
-  AND u.is_disabled = {{ .Arg .IsDisabledValue }}
-{{ end -}}
-{{ if .AuthModule -}}
-  AND user_auth.auth_module = {{ .Arg .AuthModule }}
-{{ end -}}
-{{ range .Filters -}}
-{{ if eq .Kind "in" -}}
-{{ if .Values -}}
-  AND {{ $.Ident .Condition }} IN ({{ $.ArgList .Values }})
-{{ else -}}
-  AND 0 = 1
-{{ end -}}
-{{ else -}}
-  AND {{ range .Parts }}{{ .SQL }}{{ if .HasValue }}{{ $.Arg .Value }}{{ end }}{{ end }}
-{{ end -}}
-{{ end -}}
+{{ template "search_users_where" . }}

--- a/pkg/services/user/userimpl/queries/count_search_users.sql
+++ b/pkg/services/user/userimpl/queries/count_search_users.sql
@@ -28,8 +28,8 @@ WHERE u.is_service_account = {{ .Arg .IsServiceAccount }}
     OR u.login {{ if eq .DialectName "postgres" }}ILIKE{{ else }}LIKE{{ end }} {{ .Arg .QueryPattern }}
   )
 {{ end -}}
-{{ if .HasIsDisabled -}}
-  AND u.is_disabled = {{ .Arg .IsDisabled }}
+{{ if .IsDisabled -}}
+  AND u.is_disabled = {{ .Arg .IsDisabledValue }}
 {{ end -}}
 {{ if .AuthModule -}}
   AND user_auth.auth_module = {{ .Arg .AuthModule }}

--- a/pkg/services/user/userimpl/queries/count_user_accounts_with_empty_role.sql
+++ b/pkg/services/user/userimpl/queries/count_user_accounts_with_empty_role.sql
@@ -1,0 +1,9 @@
+SELECT sub.user_accounts_with_no_role
+FROM (
+  SELECT COUNT(*) AS user_accounts_with_no_role
+  FROM {{ .Ident .OrgUserTable }} AS ou
+  LEFT JOIN {{ .Ident .UserTable }} AS u ON u.id = ou.user_id
+  WHERE ou.role = {{ .Arg .Role }}
+    AND u.is_service_account = FALSE
+    AND u.is_disabled = FALSE
+) AS sub

--- a/pkg/services/user/userimpl/queries/count_users.sql
+++ b/pkg/services/user/userimpl/queries/count_users.sql
@@ -1,0 +1,3 @@
+SELECT COUNT(*) AS count
+FROM {{ .Ident .UserTable }}
+WHERE is_service_account = FALSE

--- a/pkg/services/user/userimpl/queries/delete_user.sql
+++ b/pkg/services/user/userimpl/queries/delete_user.sql
@@ -1,0 +1,2 @@
+DELETE FROM {{ .Ident .UserTable }}
+WHERE id = {{ .Arg .UserID }}

--- a/pkg/services/user/userimpl/queries/get_signed_in_user.sql
+++ b/pkg/services/user/userimpl/queries/get_signed_in_user.sql
@@ -1,0 +1,28 @@
+SELECT
+  u.id AS user_id,
+  u.uid AS user_uid,
+  u.is_admin AS is_grafana_admin,
+  u.email AS email,
+  u.email_verified AS email_verified,
+  u.login AS login,
+  u.name AS name,
+  u.is_disabled AS is_disabled,
+  u.help_flags1 AS help_flags1,
+  u.last_seen_at AS last_seen_at,
+  org.name AS org_name,
+  org_user.role AS org_role,
+  org.id AS org_id,
+  u.is_service_account AS is_service_account
+FROM {{ .Ident .UserTable }} AS u
+LEFT OUTER JOIN {{ .Ident .OrgUserTable }} AS org_user
+  ON org_user.org_id = {{ if gt .OrgID 0 }}{{ .Arg .OrgID }}{{ else }}u.org_id{{ end }}
+  AND org_user.user_id = u.id
+LEFT OUTER JOIN {{ .Ident .OrgTable }} AS org
+  ON org.id = org_user.org_id
+{{ if gt .UserID 0 -}}
+WHERE u.id = {{ .Arg .UserID }}
+{{ else if .Login -}}
+WHERE LOWER(u.login) = LOWER({{ .Arg .Login }})
+{{ else if .Email -}}
+WHERE LOWER(u.email) = LOWER({{ .Arg .Email }})
+{{ end -}}

--- a/pkg/services/user/userimpl/queries/get_user_by_id.sql
+++ b/pkg/services/user/userimpl/queries/get_user_by_id.sql
@@ -1,0 +1,4 @@
+SELECT *
+FROM {{ .Ident .UserTable }}
+WHERE id = {{ .Arg .UserID }}
+  AND is_service_account = {{ .Arg .IsServiceAccount }}

--- a/pkg/services/user/userimpl/queries/get_user_by_id.sql
+++ b/pkg/services/user/userimpl/queries/get_user_by_id.sql
@@ -1,4 +1,4 @@
 SELECT *
 FROM {{ .Ident .UserTable }}
 WHERE id = {{ .Arg .UserID }}
-  AND is_service_account = {{ .Arg .IsServiceAccount }}
+  AND is_service_account = FALSE

--- a/pkg/services/user/userimpl/queries/get_user_by_login_or_email.sql
+++ b/pkg/services/user/userimpl/queries/get_user_by_login_or_email.sql
@@ -1,0 +1,4 @@
+SELECT *
+FROM {{ .Ident .UserTable }}
+WHERE is_service_account = {{ .Arg .IsServiceAccount }}
+  AND {{ if .ByEmail }}email{{ else }}login{{ end }} = {{ .Arg .Identifier }}

--- a/pkg/services/user/userimpl/queries/get_user_by_login_or_email.sql
+++ b/pkg/services/user/userimpl/queries/get_user_by_login_or_email.sql
@@ -1,4 +1,4 @@
 SELECT *
 FROM {{ .Ident .UserTable }}
-WHERE is_service_account = {{ .Arg .IsServiceAccount }}
-  AND {{ if .ByEmail }}email{{ else }}login{{ end }} = {{ .Arg .Identifier }}
+WHERE is_service_account = FALSE
+  AND {{ .Ident .IdentifierColumn }} = {{ .Arg .Identifier }}

--- a/pkg/services/user/userimpl/queries/search_users.sql
+++ b/pkg/services/user/userimpl/queries/search_users.sql
@@ -45,7 +45,11 @@ WHERE u.is_service_account = {{ .Arg .IsServiceAccount }}
 {{ end -}}
 {{ range .Filters -}}
 {{ if eq .Kind "in" -}}
-  AND {{ .Condition }} IN ({{ $.ArgList .Values }})
+{{ if .Values -}}
+  AND {{ $.Ident .Condition }} IN ({{ $.ArgList .Values }})
+{{ else -}}
+  AND 0 = 1
+{{ end -}}
 {{ else -}}
   AND {{ range .Parts }}{{ .SQL }}{{ if .HasValue }}{{ $.Arg .Value }}{{ end }}{{ end }}
 {{ end -}}

--- a/pkg/services/user/userimpl/queries/search_users.sql
+++ b/pkg/services/user/userimpl/queries/search_users.sql
@@ -21,7 +21,7 @@ LEFT JOIN {{ .Ident .UserAuthTable }} AS user_auth ON user_auth.id = (
 {{ range .Joins -}}
 {{ .Operator }} JOIN {{ $.Ident .Table }} AS {{ $.Ident .Alias }} ON {{ .Condition }}
 {{ end -}}
-WHERE u.is_service_account = {{ .Arg .IsServiceAccount }}
+WHERE u.is_service_account = FALSE
 {{ if gt .OrgID 0 -}}
   AND u.org_id = {{ .Arg .OrgID }}
 {{ end -}}

--- a/pkg/services/user/userimpl/queries/search_users.sql
+++ b/pkg/services/user/userimpl/queries/search_users.sql
@@ -37,8 +37,8 @@ WHERE u.is_service_account = {{ .Arg .IsServiceAccount }}
     OR u.login {{ if eq .DialectName "postgres" }}ILIKE{{ else }}LIKE{{ end }} {{ .Arg .QueryPattern }}
   )
 {{ end -}}
-{{ if .HasIsDisabled -}}
-  AND u.is_disabled = {{ .Arg .IsDisabled }}
+{{ if .IsDisabled -}}
+  AND u.is_disabled = {{ .Arg .IsDisabledValue }}
 {{ end -}}
 {{ if .AuthModule -}}
   AND user_auth.auth_module = {{ .Arg .AuthModule }}

--- a/pkg/services/user/userimpl/queries/search_users.sql
+++ b/pkg/services/user/userimpl/queries/search_users.sql
@@ -1,0 +1,63 @@
+SELECT
+  u.id,
+  u.uid,
+  u.email,
+  u.name,
+  u.login,
+  u.is_admin,
+  u.is_disabled,
+  u.last_seen_at,
+  user_auth.auth_module,
+  u.is_provisioned,
+  u.created
+FROM {{ .Ident .UserTable }} AS u
+LEFT JOIN {{ .Ident .UserAuthTable }} AS user_auth ON user_auth.id = (
+  SELECT id
+  FROM {{ .Ident .UserAuthTable }} AS user_auth
+  WHERE user_auth.user_id = u.id
+  ORDER BY user_auth.created DESC
+  LIMIT 1
+)
+{{ range .Joins -}}
+{{ .Operator }} JOIN {{ $.Ident .Table }} AS {{ $.Ident .Alias }} ON {{ .Condition }}
+{{ end -}}
+WHERE u.is_service_account = {{ .Arg .IsServiceAccount }}
+{{ if gt .OrgID 0 -}}
+  AND u.org_id = {{ .Arg .OrgID }}
+{{ end -}}
+{{ if .AccessUserIDs -}}
+  AND u.id IN ({{ .ArgList .AccessUserIDs }})
+{{ else if not .AccessAll -}}
+  AND 1 = 0
+{{ end -}}
+{{ if .QueryPattern -}}
+  AND (
+    u.email {{ if eq .DialectName "postgres" }}ILIKE{{ else }}LIKE{{ end }} {{ .Arg .QueryPattern }}
+    OR u.name {{ if eq .DialectName "postgres" }}ILIKE{{ else }}LIKE{{ end }} {{ .Arg .QueryPattern }}
+    OR u.login {{ if eq .DialectName "postgres" }}ILIKE{{ else }}LIKE{{ end }} {{ .Arg .QueryPattern }}
+  )
+{{ end -}}
+{{ if .HasIsDisabled -}}
+  AND u.is_disabled = {{ .Arg .IsDisabled }}
+{{ end -}}
+{{ if .AuthModule -}}
+  AND user_auth.auth_module = {{ .Arg .AuthModule }}
+{{ end -}}
+{{ range .Filters -}}
+{{ if eq .Kind "in" -}}
+  AND {{ .Condition }} IN ({{ $.ArgList .Values }})
+{{ else -}}
+  AND {{ range .Parts }}{{ .SQL }}{{ if .HasValue }}{{ $.Arg .Value }}{{ end }}{{ end }}
+{{ end -}}
+{{ end -}}
+{{ if or .Sorts .UseDefaultSort -}}
+ORDER BY
+{{ if .Sorts -}}
+  {{ range $index, $sort := .Sorts }}{{ if $index }}, {{ end }}{{ $sort }}{{ end }}
+{{ else if .UseDefaultSort -}}
+  u.login ASC, u.email ASC
+{{ end -}}
+{{ end -}}
+{{ if gt .Limit 0 -}}
+LIMIT {{ .Arg .Limit }}{{ if gt .Offset 0 }} OFFSET {{ .Arg .Offset }}{{ end }}
+{{ end -}}

--- a/pkg/services/user/userimpl/queries/search_users.sql
+++ b/pkg/services/user/userimpl/queries/search_users.sql
@@ -1,26 +1,4 @@
-SELECT
-  u.id,
-  u.uid,
-  u.email,
-  u.name,
-  u.login,
-  u.is_admin,
-  u.is_disabled,
-  u.last_seen_at,
-  user_auth.auth_module,
-  u.is_provisioned,
-  u.created
-FROM {{ .Ident .UserTable }} AS u
-LEFT JOIN {{ .Ident .UserAuthTable }} AS user_auth ON user_auth.id = (
-  SELECT id
-  FROM {{ .Ident .UserAuthTable }} AS user_auth
-  WHERE user_auth.user_id = u.id
-  ORDER BY user_auth.created DESC
-  LIMIT 1
-)
-{{ range .Joins -}}
-{{ .Operator }} JOIN {{ $.Ident .Table }} AS {{ $.Ident .Alias }} ON {{ .Condition }}
-{{ end -}}
+{{ define "search_users_where" -}}
 WHERE u.is_service_account = FALSE
 {{ if gt .OrgID 0 -}}
   AND u.org_id = {{ .Arg .OrgID }}
@@ -54,6 +32,31 @@ WHERE u.is_service_account = FALSE
   AND {{ range .Parts }}{{ .SQL }}{{ if .HasValue }}{{ $.Arg .Value }}{{ end }}{{ end }}
 {{ end -}}
 {{ end -}}
+{{ end -}}
+SELECT
+  u.id,
+  u.uid,
+  u.email,
+  u.name,
+  u.login,
+  u.is_admin,
+  u.is_disabled,
+  u.last_seen_at,
+  user_auth.auth_module,
+  u.is_provisioned,
+  u.created
+FROM {{ .Ident .UserTable }} AS u
+LEFT JOIN {{ .Ident .UserAuthTable }} AS user_auth ON user_auth.id = (
+  SELECT id
+  FROM {{ .Ident .UserAuthTable }} AS user_auth
+  WHERE user_auth.user_id = u.id
+  ORDER BY user_auth.created DESC
+  LIMIT 1
+)
+{{ range .Joins -}}
+{{ .Operator }} JOIN {{ $.Ident .Table }} AS {{ $.Ident .Alias }} ON {{ .Condition }}
+{{ end -}}
+{{ template "search_users_where" . }}
 {{ if or .Sorts .UseDefaultSort -}}
 ORDER BY
 {{ if .Sorts -}}

--- a/pkg/services/user/userimpl/queries/update_user.sql
+++ b/pkg/services/user/userimpl/queries/update_user.sql
@@ -12,23 +12,23 @@ SET
 {{ if .Password -}}
   password = {{ .Arg .Password }},
 {{ end -}}
-{{ if .HasEmailVerified -}}
-  email_verified = {{ .Arg .EmailVerified }},
+{{ if .EmailVerified -}}
+  email_verified = {{ .Arg .EmailVerifiedValue }},
 {{ end -}}
 {{ if .Theme -}}
   theme = {{ .Arg .Theme }},
 {{ end -}}
-{{ if .HasIsDisabled -}}
-  is_disabled = {{ .Arg .IsDisabled }},
+{{ if .IsDisabled -}}
+  is_disabled = {{ .Arg .IsDisabledValue }},
 {{ end -}}
-{{ if .HasIsGrafanaAdmin -}}
-  is_admin = {{ .Arg .IsGrafanaAdmin }},
+{{ if .IsGrafanaAdmin -}}
+  is_admin = {{ .Arg .IsGrafanaAdminValue }},
 {{ end -}}
-{{ if .HasOrgID -}}
-  org_id = {{ .Arg .OrgID }},
+{{ if .OrgID -}}
+  org_id = {{ .Arg .OrgIDValue }},
 {{ end -}}
-{{ if .HasIsProvisioned -}}
-  is_provisioned = {{ .Arg .IsProvisioned }},
+{{ if .IsProvisioned -}}
+  is_provisioned = {{ .Arg .IsProvisionedValue }},
 {{ end -}}
   updated = {{ .Arg .Updated }}
 WHERE id = {{ .Arg .UserID }}

--- a/pkg/services/user/userimpl/queries/update_user.sql
+++ b/pkg/services/user/userimpl/queries/update_user.sql
@@ -1,0 +1,35 @@
+UPDATE {{ .Ident .UserTable }}
+SET
+{{ if .Email -}}
+  email = {{ .Arg .Email }},
+{{ end -}}
+{{ if .Name -}}
+  name = {{ .Arg .Name }},
+{{ end -}}
+{{ if .Login -}}
+  login = {{ .Arg .Login }},
+{{ end -}}
+{{ if .Password -}}
+  password = {{ .Arg .Password }},
+{{ end -}}
+{{ if .HasEmailVerified -}}
+  email_verified = {{ .Arg .EmailVerified }},
+{{ end -}}
+{{ if .Theme -}}
+  theme = {{ .Arg .Theme }},
+{{ end -}}
+{{ if .HasIsDisabled -}}
+  is_disabled = {{ .Arg .IsDisabled }},
+{{ end -}}
+{{ if .HasIsGrafanaAdmin -}}
+  is_admin = {{ .Arg .IsGrafanaAdmin }},
+{{ end -}}
+{{ if .HasOrgID -}}
+  org_id = {{ .Arg .OrgID }},
+{{ end -}}
+{{ if .HasIsProvisioned -}}
+  is_provisioned = {{ .Arg .IsProvisioned }},
+{{ end -}}
+  updated = {{ .Arg .Updated }}
+WHERE id = {{ .Arg .UserID }}
+  AND is_service_account = {{ .Arg .IsServiceAccount }}

--- a/pkg/services/user/userimpl/queries/update_user.sql
+++ b/pkg/services/user/userimpl/queries/update_user.sql
@@ -32,4 +32,4 @@ SET
 {{ end -}}
   updated = {{ .Arg .Updated }}
 WHERE id = {{ .Arg .UserID }}
-  AND is_service_account = {{ .Arg .IsServiceAccount }}
+  AND is_service_account = FALSE

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -367,7 +367,7 @@ func (ss *sqlStore) Update(ctx context.Context, cmd *user.UpdateUserCommand) err
 	}
 
 	return dbHelper.DB.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
-		now := time.Now().In(dbHelper.DB.GetEngine().DatabaseTZ)
+		now := time.Now().In(dbHelper.DB.GetEngine().DatabaseTZ).Truncate(time.Second)
 		query := updateUserQuery{
 			SQLTemplate:      sqltemplate.New(dbHelper.DialectForDriver()),
 			UserTable:        dbHelper.Table("user"),
@@ -711,9 +711,6 @@ func (q searchUsersQuery) Validate() error {
 	for _, filter := range q.Filters {
 		switch filter.Kind {
 		case "in":
-			if len(filter.Values) == 0 {
-				return fmt.Errorf("search filter values must not be empty")
-			}
 		case "where":
 			if len(filter.Parts) == 0 {
 				return fmt.Errorf("search filter condition must not be empty")
@@ -725,16 +722,13 @@ func (q searchUsersQuery) Validate() error {
 	return nil
 }
 
-func searchFilterArgs(params any) []any {
+func searchInFilterArgs(params any) []any {
 	if params == nil {
-		return nil
+		return []any{nil}
 	}
 
 	value := reflect.ValueOf(params)
 	if value.Kind() != reflect.Slice && value.Kind() != reflect.Array {
-		return []any{params}
-	}
-	if value.Type().Elem().Kind() == reflect.Uint8 {
 		return []any{params}
 	}
 
@@ -746,25 +740,24 @@ func searchFilterArgs(params any) []any {
 }
 
 func newSearchUserWhereFilter(condition string, params any) (searchUserFilter, error) {
-	args := searchFilterArgs(params)
 	parts := strings.Split(condition, "?")
-	if params == nil && len(parts) == 2 {
-		args = []any{nil}
-	}
-	if len(parts)-1 != len(args) {
-		return searchUserFilter{}, fmt.Errorf("search filter condition has %d placeholders for %d values", len(parts)-1, len(args))
-	}
-
-	conditionParts := make([]searchUserConditionPart, len(parts))
-	for i, part := range parts {
-		conditionParts[i].SQL = part
-		if i < len(args) {
-			conditionParts[i].Value = args[i]
-			conditionParts[i].HasValue = true
+	if len(parts) == 1 {
+		if params != nil {
+			return searchUserFilter{}, fmt.Errorf("search filter condition has no placeholder for its value")
 		}
+		return searchUserFilter{Kind: "where", Parts: []searchUserConditionPart{{SQL: condition}}}, nil
+	}
+	if len(parts) != 2 {
+		return searchUserFilter{}, fmt.Errorf("search filter condition must have one placeholder")
 	}
 
-	return searchUserFilter{Kind: "where", Parts: conditionParts}, nil
+	return searchUserFilter{
+		Kind: "where",
+		Parts: []searchUserConditionPart{
+			{SQL: parts[0]},
+			{SQL: parts[1], Value: params, HasValue: true},
+		},
+	}, nil
 }
 
 func buildSearchUserFilters(dbHelper *legacysql.LegacyDatabaseHelper, filters []user.Filter) ([]searchUserJoin, []searchUserFilter, error) {
@@ -782,10 +775,7 @@ func buildSearchUserFilters(dbHelper *legacysql.LegacyDatabaseHelper, filters []
 		}
 
 		if in := filter.InCondition(); in != nil {
-			values := searchFilterArgs(in.Params)
-			if len(values) == 0 {
-				return nil, nil, fmt.Errorf("search filter values must not be empty")
-			}
+			values := searchInFilterArgs(in.Params)
 			queryFilters = append(queryFilters, searchUserFilter{
 				Kind:      "in",
 				Condition: in.Condition,

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -333,25 +333,43 @@ func (ss *sqlStore) LoginConflict(ctx context.Context, login, email string) erro
 
 type updateUserQuery struct {
 	sqltemplate.SQLTemplate
-	UserTable         string
-	UserID            int64
-	IsServiceAccount  any
-	Email             string
-	Name              string
-	Login             string
-	Password          string
-	EmailVerified     bool
-	HasEmailVerified  bool
-	Theme             string
-	IsDisabled        bool
-	HasIsDisabled     bool
-	IsGrafanaAdmin    bool
-	HasIsGrafanaAdmin bool
-	OrgID             int64
-	HasOrgID          bool
-	IsProvisioned     bool
-	HasIsProvisioned  bool
-	Updated           legacysql.DBTime
+	UserTable        string
+	UserID           int64
+	IsServiceAccount any
+	Email            string
+	Name             string
+	Login            string
+	Password         string
+	EmailVerified    *bool
+	Theme            string
+	IsDisabled       *bool
+	IsGrafanaAdmin   *bool
+	OrgID            *int64
+	IsProvisioned    *bool
+	Updated          legacysql.DBTime
+}
+
+func (q updateUserQuery) EmailVerifiedValue() bool {
+	return q.EmailVerified != nil && *q.EmailVerified
+}
+
+func (q updateUserQuery) IsDisabledValue() bool {
+	return q.IsDisabled != nil && *q.IsDisabled
+}
+
+func (q updateUserQuery) IsGrafanaAdminValue() bool {
+	return q.IsGrafanaAdmin != nil && *q.IsGrafanaAdmin
+}
+
+func (q updateUserQuery) IsProvisionedValue() bool {
+	return q.IsProvisioned != nil && *q.IsProvisioned
+}
+
+func (q updateUserQuery) OrgIDValue() int64 {
+	if q.OrgID != nil {
+		return *q.OrgID
+	}
+	return 0
 }
 
 func (q updateUserQuery) Validate() error { return nil }
@@ -377,30 +395,17 @@ func (ss *sqlStore) Update(ctx context.Context, cmd *user.UpdateUserCommand) err
 			Name:             cmd.Name,
 			Login:            strings.ToLower(cmd.Login),
 			Theme:            cmd.Theme,
+			EmailVerified:    cmd.EmailVerified,
+			IsDisabled:       cmd.IsDisabled,
+			IsGrafanaAdmin:   cmd.IsGrafanaAdmin,
+			IsProvisioned:    cmd.IsProvisioned,
 			Updated:          legacysql.NewDBTime(now),
 		}
 		if cmd.Password != nil && *cmd.Password != "" {
 			query.Password = string(*cmd.Password)
 		}
 		if cmd.OrgID != nil && *cmd.OrgID != 0 {
-			query.HasOrgID = true
-			query.OrgID = *cmd.OrgID
-		}
-		if cmd.IsDisabled != nil {
-			query.HasIsDisabled = true
-			query.IsDisabled = *cmd.IsDisabled
-		}
-		if cmd.EmailVerified != nil {
-			query.HasEmailVerified = true
-			query.EmailVerified = *cmd.EmailVerified
-		}
-		if cmd.IsGrafanaAdmin != nil {
-			query.HasIsGrafanaAdmin = true
-			query.IsGrafanaAdmin = *cmd.IsGrafanaAdmin
-		}
-		if cmd.IsProvisioned != nil {
-			query.HasIsProvisioned = true
-			query.IsProvisioned = *cmd.IsProvisioned
+			query.OrgID = cmd.OrgID
 		}
 
 		rawSQL, err := renderUserQuery(updateUserTemplate, query)
@@ -696,8 +701,7 @@ type searchUsersQuery struct {
 	AccessAll        bool
 	AccessUserIDs    []any
 	QueryPattern     string
-	HasIsDisabled    bool
-	IsDisabled       bool
+	IsDisabled       *bool
 	AuthModule       string
 	Filters          []searchUserFilter
 	Sorts            []string
@@ -705,6 +709,10 @@ type searchUsersQuery struct {
 	Limit            int
 	Offset           int
 	IncludeAuthJoin  bool
+}
+
+func (q searchUsersQuery) IsDisabledValue() bool {
+	return q.IsDisabled != nil && *q.IsDisabled
 }
 
 func (q searchUsersQuery) Validate() error {
@@ -836,14 +844,11 @@ func (ss *sqlStore) Search(ctx context.Context, query *user.SearchUsersQuery) (*
 			AccessAll:        accessAll,
 			AccessUserIDs:    acFilter.Args,
 			QueryPattern:     searchQueryPattern(query.Query),
+			IsDisabled:       query.IsDisabled,
 			Filters:          queryFilters,
 			Sorts:            sorts,
 			UseDefaultSort:   len(query.SortOpts) == 0,
 			IncludeAuthJoin:  true,
-		}
-		if query.IsDisabled != nil {
-			searchQuery.HasIsDisabled = true
-			searchQuery.IsDisabled = *query.IsDisabled
 		}
 		if query.AuthModule != "" {
 			searchQuery.AuthModule = query.AuthModule

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -112,19 +112,17 @@ func (ss *sqlStore) Delete(ctx context.Context, userID int64) error {
 
 type getUserByIDQuery struct {
 	sqltemplate.SQLTemplate
-	UserTable        string
-	UserID           int64
-	IsServiceAccount any
+	UserTable string
+	UserID    int64
 }
 
 func (q getUserByIDQuery) Validate() error { return nil }
 
 func getUserByID(dbHelper *legacysql.LegacyDatabaseHelper, sess *db.Session, userID int64) (user.User, bool, error) {
 	query := getUserByIDQuery{
-		SQLTemplate:      sqltemplate.New(dbHelper.DialectForDriver()),
-		UserTable:        dbHelper.Table("user"),
-		UserID:           userID,
-		IsServiceAccount: dbHelper.DB.GetDialect().BooleanValue(false),
+		SQLTemplate: sqltemplate.New(dbHelper.DialectForDriver()),
+		UserTable:   dbHelper.Table("user"),
+		UserID:      userID,
 	}
 	rawSQL, err := renderUserQuery(getUserByIDTemplate, query)
 	if err != nil {
@@ -205,19 +203,29 @@ type getUserByLoginOrEmailQuery struct {
 	sqltemplate.SQLTemplate
 	UserTable        string
 	Identifier       string
-	ByEmail          bool
-	IsServiceAccount any
+	IdentifierColumn string
 }
 
-func (q getUserByLoginOrEmailQuery) Validate() error { return nil }
+const (
+	userEmailColumn = "email"
+	userLoginColumn = "login"
+)
 
-func getUserByLoginOrEmail(dbHelper *legacysql.LegacyDatabaseHelper, sess *db.Session, identifier string, byEmail bool, usr *user.User) (bool, error) {
+func (q getUserByLoginOrEmailQuery) Validate() error {
+	switch q.IdentifierColumn {
+	case userEmailColumn, userLoginColumn:
+		return nil
+	default:
+		return fmt.Errorf("invalid user identifier column %q", q.IdentifierColumn)
+	}
+}
+
+func getUserByLoginOrEmail(dbHelper *legacysql.LegacyDatabaseHelper, sess *db.Session, identifier, identifierColumn string, usr *user.User) (bool, error) {
 	query := getUserByLoginOrEmailQuery{
 		SQLTemplate:      sqltemplate.New(dbHelper.DialectForDriver()),
 		UserTable:        dbHelper.Table("user"),
 		Identifier:       identifier,
-		ByEmail:          byEmail,
-		IsServiceAccount: dbHelper.DB.GetDialect().BooleanValue(false),
+		IdentifierColumn: identifierColumn,
 	}
 	rawSQL, err := renderUserQuery(getUserByLoginOrEmailTemplate, query)
 	if err != nil {
@@ -247,7 +255,7 @@ func (ss *sqlStore) GetByLogin(ctx context.Context, query *user.GetUserByLoginQu
 		// Since username can be an email address, attempt login with email address
 		// first if the login field has the "@" symbol.
 		if strings.Contains(query.LoginOrEmail, "@") {
-			has, err = getUserByLoginOrEmail(dbHelper, sess, query.LoginOrEmail, true, usr)
+			has, err = getUserByLoginOrEmail(dbHelper, sess, query.LoginOrEmail, userEmailColumn, usr)
 			if err != nil {
 				return err
 			}
@@ -255,7 +263,7 @@ func (ss *sqlStore) GetByLogin(ctx context.Context, query *user.GetUserByLoginQu
 
 		// Look for the login field instead of email
 		if !has {
-			has, err = getUserByLoginOrEmail(dbHelper, sess, query.LoginOrEmail, false, usr)
+			has, err = getUserByLoginOrEmail(dbHelper, sess, query.LoginOrEmail, userLoginColumn, usr)
 		}
 
 		if err != nil {
@@ -288,7 +296,7 @@ func (ss *sqlStore) GetByEmail(ctx context.Context, query *user.GetUserByEmailQu
 			return user.ErrUserNotFound
 		}
 
-		has, err := getUserByLoginOrEmail(dbHelper, sess, query.Email, true, usr)
+		has, err := getUserByLoginOrEmail(dbHelper, sess, query.Email, userEmailColumn, usr)
 
 		if err != nil {
 			return err
@@ -333,20 +341,19 @@ func (ss *sqlStore) LoginConflict(ctx context.Context, login, email string) erro
 
 type updateUserQuery struct {
 	sqltemplate.SQLTemplate
-	UserTable        string
-	UserID           int64
-	IsServiceAccount any
-	Email            string
-	Name             string
-	Login            string
-	Password         string
-	EmailVerified    *bool
-	Theme            string
-	IsDisabled       *bool
-	IsGrafanaAdmin   *bool
-	OrgID            *int64
-	IsProvisioned    *bool
-	Updated          legacysql.DBTime
+	UserTable      string
+	UserID         int64
+	Email          string
+	Name           string
+	Login          string
+	Password       string
+	EmailVerified  *bool
+	Theme          string
+	IsDisabled     *bool
+	IsGrafanaAdmin *bool
+	OrgID          *int64
+	IsProvisioned  *bool
+	Updated        legacysql.DBTime
 }
 
 func (q updateUserQuery) EmailVerifiedValue() bool {
@@ -387,19 +394,18 @@ func (ss *sqlStore) Update(ctx context.Context, cmd *user.UpdateUserCommand) err
 	return dbHelper.DB.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
 		now := time.Now().In(dbHelper.DB.GetEngine().DatabaseTZ).Truncate(time.Second)
 		query := updateUserQuery{
-			SQLTemplate:      sqltemplate.New(dbHelper.DialectForDriver()),
-			UserTable:        dbHelper.Table("user"),
-			UserID:           cmd.UserID,
-			IsServiceAccount: dbHelper.DB.GetDialect().BooleanValue(false),
-			Email:            strings.ToLower(cmd.Email),
-			Name:             cmd.Name,
-			Login:            strings.ToLower(cmd.Login),
-			Theme:            cmd.Theme,
-			EmailVerified:    cmd.EmailVerified,
-			IsDisabled:       cmd.IsDisabled,
-			IsGrafanaAdmin:   cmd.IsGrafanaAdmin,
-			IsProvisioned:    cmd.IsProvisioned,
-			Updated:          legacysql.NewDBTime(now),
+			SQLTemplate:    sqltemplate.New(dbHelper.DialectForDriver()),
+			UserTable:      dbHelper.Table("user"),
+			UserID:         cmd.UserID,
+			Email:          strings.ToLower(cmd.Email),
+			Name:           cmd.Name,
+			Login:          strings.ToLower(cmd.Login),
+			Theme:          cmd.Theme,
+			EmailVerified:  cmd.EmailVerified,
+			IsDisabled:     cmd.IsDisabled,
+			IsGrafanaAdmin: cmd.IsGrafanaAdmin,
+			IsProvisioned:  cmd.IsProvisioned,
+			Updated:        legacysql.NewDBTime(now),
 		}
 		if cmd.Password != nil && *cmd.Password != "" {
 			query.Password = string(*cmd.Password)
@@ -693,22 +699,21 @@ type searchUserFilter struct {
 
 type searchUsersQuery struct {
 	sqltemplate.SQLTemplate
-	UserTable        string
-	UserAuthTable    string
-	Joins            []searchUserJoin
-	IsServiceAccount any
-	OrgID            int64
-	AccessAll        bool
-	AccessUserIDs    []any
-	QueryPattern     string
-	IsDisabled       *bool
-	AuthModule       string
-	Filters          []searchUserFilter
-	Sorts            []string
-	UseDefaultSort   bool
-	Limit            int
-	Offset           int
-	IncludeAuthJoin  bool
+	UserTable       string
+	UserAuthTable   string
+	Joins           []searchUserJoin
+	OrgID           int64
+	AccessAll       bool
+	AccessUserIDs   []any
+	QueryPattern    string
+	IsDisabled      *bool
+	AuthModule      string
+	Filters         []searchUserFilter
+	Sorts           []string
+	UseDefaultSort  bool
+	Limit           int
+	Offset          int
+	IncludeAuthJoin bool
 }
 
 func (q searchUsersQuery) IsDisabledValue() bool {
@@ -835,20 +840,19 @@ func (ss *sqlStore) Search(ctx context.Context, query *user.SearchUsersQuery) (*
 		}
 
 		searchQuery := searchUsersQuery{
-			SQLTemplate:      sqltemplate.New(dbHelper.DialectForDriver()),
-			UserTable:        dbHelper.Table("user"),
-			UserAuthTable:    dbHelper.Table("user_auth"),
-			Joins:            joins,
-			IsServiceAccount: dbHelper.DB.GetDialect().BooleanValue(false),
-			OrgID:            query.OrgID,
-			AccessAll:        accessAll,
-			AccessUserIDs:    acFilter.Args,
-			QueryPattern:     searchQueryPattern(query.Query),
-			IsDisabled:       query.IsDisabled,
-			Filters:          queryFilters,
-			Sorts:            sorts,
-			UseDefaultSort:   len(query.SortOpts) == 0,
-			IncludeAuthJoin:  true,
+			SQLTemplate:     sqltemplate.New(dbHelper.DialectForDriver()),
+			UserTable:       dbHelper.Table("user"),
+			UserAuthTable:   dbHelper.Table("user_auth"),
+			Joins:           joins,
+			OrgID:           query.OrgID,
+			AccessAll:       accessAll,
+			AccessUserIDs:   acFilter.Args,
+			QueryPattern:    searchQueryPattern(query.Query),
+			IsDisabled:      query.IsDisabled,
+			Filters:         queryFilters,
+			Sorts:           sorts,
+			UseDefaultSort:  len(query.SortOpts) == 0,
+			IncludeAuthJoin: true,
 		}
 		if query.AuthModule != "" {
 			searchQuery.AuthModule = query.AuthModule

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -3,7 +3,9 @@ package userimpl
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
+	"text/template"
 	"time"
 
 	"github.com/grafana/grafana/pkg/infra/db"
@@ -13,6 +15,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/legacysql"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
 	"github.com/grafana/grafana/pkg/util"
 )
 
@@ -41,11 +44,6 @@ type sqlStore struct {
 	cfg    *setting.Cfg
 }
 
-// quoteTable resolves a table name and quotes it for use in raw SQL.
-func quoteTable(dbHelper *legacysql.LegacyDatabaseHelper, name string) string {
-	return dbHelper.DB.Quote(dbHelper.Table(name))
-}
-
 func ProvideStore(sql legacysql.LegacyDatabaseProvider, cfg *setting.Cfg) sqlStore {
 	return sqlStore{
 		sql:    sql,
@@ -53,6 +51,14 @@ func ProvideStore(sql legacysql.LegacyDatabaseProvider, cfg *setting.Cfg) sqlSto
 		logger: log.New("user.store"),
 	}
 }
+
+type deleteUserQuery struct {
+	sqltemplate.SQLTemplate
+	UserTable string
+	UserID    int64
+}
+
+func (q deleteUserQuery) Validate() error { return nil }
 
 func (ss *sqlStore) Insert(ctx context.Context, cmd *user.User) (int64, error) {
 	dbHelper, err := ss.sql(ctx)
@@ -86,14 +92,48 @@ func (ss *sqlStore) Delete(ctx context.Context, userID int64) error {
 	}
 
 	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
-		var rawSQL = "DELETE FROM " + quoteTable(dbHelper, "user") + " WHERE id = ?"
-		_, err := sess.Exec(rawSQL, userID)
+		query := deleteUserQuery{
+			SQLTemplate: sqltemplate.New(dbHelper.DialectForDriver()),
+			UserTable:   dbHelper.Table("user"),
+			UserID:      userID,
+		}
+		rawSQL, err := renderUserQuery(deleteUserTemplate, query)
+		if err != nil {
+			return err
+		}
+		_, err = sess.Exec(append([]any{rawSQL}, query.GetArgs()...)...)
 		return err
 	})
 	if err != nil {
 		return err
 	}
 	return nil
+}
+
+type getUserByIDQuery struct {
+	sqltemplate.SQLTemplate
+	UserTable        string
+	UserID           int64
+	IsServiceAccount any
+}
+
+func (q getUserByIDQuery) Validate() error { return nil }
+
+func getUserByID(dbHelper *legacysql.LegacyDatabaseHelper, sess *db.Session, userID int64) (user.User, bool, error) {
+	query := getUserByIDQuery{
+		SQLTemplate:      sqltemplate.New(dbHelper.DialectForDriver()),
+		UserTable:        dbHelper.Table("user"),
+		UserID:           userID,
+		IsServiceAccount: dbHelper.DB.GetDialect().BooleanValue(false),
+	}
+	rawSQL, err := renderUserQuery(getUserByIDTemplate, query)
+	if err != nil {
+		return user.User{}, false, err
+	}
+
+	var usr user.User
+	exists, err := sess.SQL(rawSQL, query.GetArgs()...).Get(&usr)
+	return usr, exists, err
 }
 
 func (ss *sqlStore) GetByID(ctx context.Context, userID int64) (*user.User, error) {
@@ -104,10 +144,8 @@ func (ss *sqlStore) GetByID(ctx context.Context, userID int64) (*user.User, erro
 	}
 
 	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
-		has, err := sess.Table(dbHelper.Table("user")).ID(&userID).
-			Where(ss.notServiceAccountFilter(dbHelper)).
-			Get(&usr)
-
+		var has bool
+		usr, has, err = getUserByID(dbHelper, sess, userID)
 		if err != nil {
 			return err
 		} else if !has {
@@ -115,7 +153,10 @@ func (ss *sqlStore) GetByID(ctx context.Context, userID int64) (*user.User, erro
 		}
 		return nil
 	})
-	return &usr, err
+	if err != nil {
+		return &usr, err
+	}
+	return &usr, nil
 }
 
 func (ss *sqlStore) GetByUID(ctx context.Context, uid string) (*user.User, error) {
@@ -160,10 +201,29 @@ func (ss *sqlStore) ListByIdOrUID(ctx context.Context, uids []string, ids []int6
 	return users, err
 }
 
-func (ss *sqlStore) notServiceAccountFilter(dbHelper *legacysql.LegacyDatabaseHelper) string {
-	return fmt.Sprintf("%s.is_service_account = %s",
-		quoteTable(dbHelper, "user"),
-		dbHelper.DB.GetDialect().BooleanStr(false))
+type getUserByLoginOrEmailQuery struct {
+	sqltemplate.SQLTemplate
+	UserTable        string
+	Identifier       string
+	ByEmail          bool
+	IsServiceAccount any
+}
+
+func (q getUserByLoginOrEmailQuery) Validate() error { return nil }
+
+func getUserByLoginOrEmail(dbHelper *legacysql.LegacyDatabaseHelper, sess *db.Session, identifier string, byEmail bool, usr *user.User) (bool, error) {
+	query := getUserByLoginOrEmailQuery{
+		SQLTemplate:      sqltemplate.New(dbHelper.DialectForDriver()),
+		UserTable:        dbHelper.Table("user"),
+		Identifier:       identifier,
+		ByEmail:          byEmail,
+		IsServiceAccount: dbHelper.DB.GetDialect().BooleanValue(false),
+	}
+	rawSQL, err := renderUserQuery(getUserByLoginOrEmailTemplate, query)
+	if err != nil {
+		return false, err
+	}
+	return sess.SQL(rawSQL, query.GetArgs()...).Get(usr)
 }
 
 func (ss *sqlStore) GetByLogin(ctx context.Context, query *user.GetUserByLoginQuery) (*user.User, error) {
@@ -181,15 +241,13 @@ func (ss *sqlStore) GetByLogin(ctx context.Context, query *user.GetUserByLoginQu
 			return user.ErrUserNotFound
 		}
 
-		var where string
 		var has bool
 		var err error
 
 		// Since username can be an email address, attempt login with email address
 		// first if the login field has the "@" symbol.
 		if strings.Contains(query.LoginOrEmail, "@") {
-			where = "email=?"
-			has, err = sess.Table(dbHelper.Table("user")).Where(ss.notServiceAccountFilter(dbHelper)).Where(where, query.LoginOrEmail).Get(usr)
+			has, err = getUserByLoginOrEmail(dbHelper, sess, query.LoginOrEmail, true, usr)
 			if err != nil {
 				return err
 			}
@@ -197,8 +255,7 @@ func (ss *sqlStore) GetByLogin(ctx context.Context, query *user.GetUserByLoginQu
 
 		// Look for the login field instead of email
 		if !has {
-			where = "login=?"
-			has, err = sess.Table(dbHelper.Table("user")).Where(ss.notServiceAccountFilter(dbHelper)).Where(where, query.LoginOrEmail).Get(usr)
+			has, err = getUserByLoginOrEmail(dbHelper, sess, query.LoginOrEmail, false, usr)
 		}
 
 		if err != nil {
@@ -231,8 +288,7 @@ func (ss *sqlStore) GetByEmail(ctx context.Context, query *user.GetUserByEmailQu
 			return user.ErrUserNotFound
 		}
 
-		where := "email=?"
-		has, err := sess.Table(dbHelper.Table("user")).Where(ss.notServiceAccountFilter(dbHelper)).Where(where, query.Email).Get(usr)
+		has, err := getUserByLoginOrEmail(dbHelper, sess, query.Email, true, usr)
 
 		if err != nil {
 			return err
@@ -275,6 +331,31 @@ func (ss *sqlStore) LoginConflict(ctx context.Context, login, email string) erro
 	return err
 }
 
+type updateUserQuery struct {
+	sqltemplate.SQLTemplate
+	UserTable         string
+	UserID            int64
+	IsServiceAccount  any
+	Email             string
+	Name              string
+	Login             string
+	Password          string
+	EmailVerified     bool
+	HasEmailVerified  bool
+	Theme             string
+	IsDisabled        bool
+	HasIsDisabled     bool
+	IsGrafanaAdmin    bool
+	HasIsGrafanaAdmin bool
+	OrgID             int64
+	HasOrgID          bool
+	IsProvisioned     bool
+	HasIsProvisioned  bool
+	Updated           legacysql.DBTime
+}
+
+func (q updateUserQuery) Validate() error { return nil }
+
 func (ss *sqlStore) Update(ctx context.Context, cmd *user.UpdateUserCommand) error {
 	// enforcement of lowercase due to forcement of caseinsensitive login
 	cmd.Login = strings.ToLower(cmd.Login)
@@ -286,36 +367,47 @@ func (ss *sqlStore) Update(ctx context.Context, cmd *user.UpdateUserCommand) err
 	}
 
 	return dbHelper.DB.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
-		usr := user.User{
-			Name:    cmd.Name,
-			Theme:   cmd.Theme,
-			Email:   strings.ToLower(cmd.Email),
-			Login:   strings.ToLower(cmd.Login),
-			Updated: time.Now(),
+		now := time.Now().In(dbHelper.DB.GetEngine().DatabaseTZ)
+		query := updateUserQuery{
+			SQLTemplate:      sqltemplate.New(dbHelper.DialectForDriver()),
+			UserTable:        dbHelper.Table("user"),
+			UserID:           cmd.UserID,
+			IsServiceAccount: dbHelper.DB.GetDialect().BooleanValue(false),
+			Email:            strings.ToLower(cmd.Email),
+			Name:             cmd.Name,
+			Login:            strings.ToLower(cmd.Login),
+			Theme:            cmd.Theme,
+			Updated:          legacysql.NewDBTime(now),
+		}
+		if cmd.Password != nil && *cmd.Password != "" {
+			query.Password = string(*cmd.Password)
+		}
+		if cmd.OrgID != nil && *cmd.OrgID != 0 {
+			query.HasOrgID = true
+			query.OrgID = *cmd.OrgID
+		}
+		if cmd.IsDisabled != nil {
+			query.HasIsDisabled = true
+			query.IsDisabled = *cmd.IsDisabled
+		}
+		if cmd.EmailVerified != nil {
+			query.HasEmailVerified = true
+			query.EmailVerified = *cmd.EmailVerified
+		}
+		if cmd.IsGrafanaAdmin != nil {
+			query.HasIsGrafanaAdmin = true
+			query.IsGrafanaAdmin = *cmd.IsGrafanaAdmin
+		}
+		if cmd.IsProvisioned != nil {
+			query.HasIsProvisioned = true
+			query.IsProvisioned = *cmd.IsProvisioned
 		}
 
-		q := sess.Table(dbHelper.Table("user")).ID(cmd.UserID).Where(ss.notServiceAccountFilter(dbHelper))
-
-		setOptional(cmd.OrgID, func(v int64) { usr.OrgID = v })
-		setOptional(cmd.Password, func(v user.Password) { usr.Password = v })
-		setOptional(cmd.IsDisabled, func(v bool) {
-			q = q.UseBool("is_disabled")
-			usr.IsDisabled = v
-		})
-		setOptional(cmd.EmailVerified, func(v bool) {
-			q = q.UseBool("email_verified")
-			usr.EmailVerified = v
-		})
-		setOptional(cmd.IsGrafanaAdmin, func(v bool) {
-			q = q.UseBool("is_admin")
-			usr.IsAdmin = v
-		})
-		setOptional(cmd.IsProvisioned, func(v bool) {
-			q = q.UseBool("is_provisioned")
-			usr.IsProvisioned = v
-		})
-
-		if _, err := q.Update(&usr); err != nil {
+		rawSQL, err := renderUserQuery(updateUserTemplate, query)
+		if err != nil {
+			return err
+		}
+		if _, err := sess.Exec(append([]any{rawSQL}, query.GetArgs()...)...); err != nil {
 			return handleSQLError(dbHelper.DB.GetDialect(), err)
 		}
 
@@ -351,6 +443,24 @@ func (ss *sqlStore) UpdateLastSeenAt(ctx context.Context, cmd *user.UpdateUserLa
 	})
 }
 
+type signedInUserQuery struct {
+	sqltemplate.SQLTemplate
+	UserTable    string
+	OrgUserTable string
+	OrgTable     string
+	OrgID        int64
+	UserID       int64
+	Login        string
+	Email        string
+}
+
+func (q signedInUserQuery) Validate() error {
+	if q.UserID <= 0 && q.Login == "" && q.Email == "" {
+		return user.ErrNoUniqueID
+	}
+	return nil
+}
+
 func (ss *sqlStore) GetSignedInUser(ctx context.Context, query *user.GetSignedInUserQuery) (*user.SignedInUser, error) {
 	var signedInUser user.SignedInUser
 	dbHelper, err := ss.sql(ctx)
@@ -358,50 +468,24 @@ func (ss *sqlStore) GetSignedInUser(ctx context.Context, query *user.GetSignedIn
 		return nil, fmt.Errorf("get legacy DB: %w", err)
 	}
 
-	err = dbHelper.DB.WithDbSession(ctx, func(dbSess *db.Session) error {
-		orgID := "u.org_id"
-		orgIDParams := make([]any, 0, 1)
-		if query.OrgID > 0 {
-			orgID = "?"
-			orgIDParams = append(orgIDParams, query.OrgID)
+	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
+		sqlQuery := signedInUserQuery{
+			SQLTemplate:  sqltemplate.New(dbHelper.DialectForDriver()),
+			UserTable:    dbHelper.Table("user"),
+			OrgUserTable: dbHelper.Table("org_user"),
+			OrgTable:     dbHelper.Table("org"),
+			OrgID:        query.OrgID,
+			UserID:       query.UserID,
+			Login:        query.Login,
+			Email:        query.Email,
+		}
+		rawSQL, err := renderUserQuery(getSignedInUserTemplate, sqlQuery)
+		if err != nil {
+			return err
 		}
 
-		var rawSQL = `SELECT
-		u.id                  as user_id,
-		u.uid                 as user_uid,
-		u.is_admin            as is_grafana_admin,
-		u.email               as email,
-		u.email_verified      as email_verified,
-		u.login               as login,
-		u.name                as name,
-		u.is_disabled         as is_disabled,
-		u.help_flags1         as help_flags1,
-		u.last_seen_at        as last_seen_at,
-		org.name              as org_name,
-		org_user.role         as org_role,
-		org.id                as org_id,
-		u.is_service_account  as is_service_account
-		FROM ` + quoteTable(dbHelper, "user") + ` AS u
-		LEFT OUTER JOIN ` + quoteTable(dbHelper, "org_user") + ` AS org_user ON org_user.org_id = ` + orgID + ` AND org_user.user_id = u.id
-		LEFT OUTER JOIN ` + quoteTable(dbHelper, "org") + ` AS org ON org.id = org_user.org_id `
-
-		sess := dbSess.Table(dbHelper.Table("user"))
-		sess = sess.Context(ctx)
-		params := append([]any{}, orgIDParams...)
-		switch {
-		case query.UserID > 0:
-			params = append(params, query.UserID)
-			sess.SQL(rawSQL+"WHERE u.id=?", params...)
-		case query.Login != "":
-			params = append(params, query.Login)
-			sess.SQL(rawSQL+"WHERE LOWER(u.login)=LOWER(?)", params...)
-		case query.Email != "":
-			params = append(params, query.Email)
-			sess.SQL(rawSQL+"WHERE LOWER(u.email)=LOWER(?)", params...)
-		default:
-			return user.ErrNoUniqueID
-		}
-		has, err := sess.Get(&signedInUser)
+		sess.Session = sess.Context(ctx)
+		has, err := sess.SQL(rawSQL, sqlQuery.GetArgs()...).Get(&signedInUser)
 		if err != nil {
 			return err
 		} else if !has {
@@ -427,7 +511,8 @@ func (ss *sqlStore) GetProfile(ctx context.Context, query *user.GetUserProfileQu
 	}
 
 	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
-		has, err := sess.Table(dbHelper.Table("user")).ID(query.UserID).Where(ss.notServiceAccountFilter(dbHelper)).Get(&usr)
+		var has bool
+		usr, has, err = getUserByID(dbHelper, sess, query.UserID)
 
 		if err != nil {
 			return err
@@ -455,6 +540,13 @@ func (ss *sqlStore) GetProfile(ctx context.Context, query *user.GetUserProfileQu
 	return &userProfile, err
 }
 
+type countUsersQuery struct {
+	sqltemplate.SQLTemplate
+	UserTable string
+}
+
+func (q countUsersQuery) Validate() error { return nil }
+
 func (ss *sqlStore) Count(ctx context.Context) (int64, error) {
 	type result struct {
 		Count int64
@@ -467,14 +559,28 @@ func (ss *sqlStore) Count(ctx context.Context) (int64, error) {
 	}
 
 	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
-		rawSQL := fmt.Sprintf("SELECT COUNT(*) as count from %s WHERE is_service_account=%s", quoteTable(dbHelper, "user"), dbHelper.DB.GetDialect().BooleanStr(false))
-		if _, err := sess.SQL(rawSQL).Get(&r); err != nil {
+		query := countUsersQuery{
+			SQLTemplate: sqltemplate.New(dbHelper.DialectForDriver()),
+			UserTable:   dbHelper.Table("user"),
+		}
+		rawSQL, err := renderUserQuery(countUsersTemplate, query)
+		if err != nil {
 			return err
 		}
-		return nil
+		_, err = sess.SQL(rawSQL, query.GetArgs()...).Get(&r)
+		return err
 	})
 	return r.Count, err
 }
+
+type countUserAccountsWithEmptyRoleQuery struct {
+	sqltemplate.SQLTemplate
+	OrgUserTable string
+	UserTable    string
+	Role         string
+}
+
+func (q countUserAccountsWithEmptyRoleQuery) Validate() error { return nil }
 
 func (ss *sqlStore) CountUserAccountsWithEmptyRole(ctx context.Context) (int64, error) {
 	dbHelper, err := ss.sql(ctx)
@@ -482,23 +588,19 @@ func (ss *sqlStore) CountUserAccountsWithEmptyRole(ctx context.Context) (int64, 
 		return -1, fmt.Errorf("get legacy DB: %w", err)
 	}
 
-	sb := &db.SQLBuilder{}
-	sb.Write(`
-		SELECT sub.user_accounts_with_no_role
-		FROM (
-		  SELECT COUNT(*) AS user_accounts_with_no_role
-		  FROM ` + quoteTable(dbHelper, "org_user") + ` AS ou
-		  LEFT JOIN ` + quoteTable(dbHelper, "user") + ` AS u ON u.id = ou.user_id
-		  WHERE ou.role = ?
-		  AND u.is_service_account = ` + dbHelper.DB.GetDialect().BooleanStr(false) + `
-		  AND u.is_disabled = ` + dbHelper.DB.GetDialect().BooleanStr(false) + `
-		) AS sub
-	`)
-	sb.AddParams("None")
-
 	var countStats int64
 	if err := dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
-		_, err := sess.SQL(sb.GetSQLString(), sb.GetParams()...).Get(&countStats)
+		query := countUserAccountsWithEmptyRoleQuery{
+			SQLTemplate:  sqltemplate.New(dbHelper.DialectForDriver()),
+			OrgUserTable: dbHelper.Table("org_user"),
+			UserTable:    dbHelper.Table("user"),
+			Role:         "None",
+		}
+		rawSQL, err := renderUserQuery(countUserAccountsWithEmptyRoleTemplate, query)
+		if err != nil {
+			return err
+		}
+		_, err = sess.SQL(rawSQL, query.GetArgs()...).Get(&countStats)
 		return err
 	}); err != nil {
 		return -1, err
@@ -521,6 +623,20 @@ func validateOneAdminLeft(dbHelper *legacysql.LegacyDatabaseHelper, sess *db.Ses
 	return nil
 }
 
+type batchDisableUsersQuery struct {
+	sqltemplate.SQLTemplate
+	UserTable  string
+	UserIDs    []int64
+	IsDisabled bool
+}
+
+func (q batchDisableUsersQuery) Validate() error {
+	if len(q.UserIDs) == 0 {
+		return fmt.Errorf("user IDs must not be empty")
+	}
+	return nil
+}
+
 func (ss *sqlStore) BatchDisableUsers(ctx context.Context, cmd *user.BatchDisableUsersCommand) error {
 	dbHelper, err := ss.sql(ctx)
 	if err != nil {
@@ -534,18 +650,159 @@ func (ss *sqlStore) BatchDisableUsers(ctx context.Context, cmd *user.BatchDisabl
 			return nil
 		}
 
-		user_id_params := strings.Repeat(",?", len(userIds)-1)
-		disableSQL := "UPDATE " + quoteTable(dbHelper, "user") + " SET is_disabled=? WHERE Id IN (?" + user_id_params + ")" +
-			" AND is_service_account=" + dbHelper.DB.GetDialect().BooleanStr(false)
-
-		disableParams := []any{disableSQL, cmd.IsDisabled}
-		for _, v := range userIds {
-			disableParams = append(disableParams, v)
+		query := batchDisableUsersQuery{
+			SQLTemplate: sqltemplate.New(dbHelper.DialectForDriver()),
+			UserTable:   dbHelper.Table("user"),
+			UserIDs:     userIds,
+			IsDisabled:  cmd.IsDisabled,
+		}
+		disableSQL, err := renderUserQuery(batchDisableUsersTemplate, query)
+		if err != nil {
+			return err
 		}
 
-		_, err := sess.Exec(disableParams...)
+		_, err = sess.Exec(append([]any{disableSQL}, query.GetArgs()...)...)
 		return err
 	})
+}
+
+type searchUserJoin struct {
+	Operator  string
+	Table     string
+	Alias     string
+	Condition string
+}
+
+type searchUserConditionPart struct {
+	SQL      string
+	Value    any
+	HasValue bool
+}
+
+type searchUserFilter struct {
+	Kind      string
+	Condition string
+	Values    []any
+	Parts     []searchUserConditionPart
+}
+
+type searchUsersQuery struct {
+	sqltemplate.SQLTemplate
+	UserTable        string
+	UserAuthTable    string
+	Joins            []searchUserJoin
+	IsServiceAccount any
+	OrgID            int64
+	AccessAll        bool
+	AccessUserIDs    []any
+	QueryPattern     string
+	HasIsDisabled    bool
+	IsDisabled       bool
+	AuthModule       string
+	Filters          []searchUserFilter
+	Sorts            []string
+	UseDefaultSort   bool
+	Limit            int
+	Offset           int
+	IncludeAuthJoin  bool
+}
+
+func (q searchUsersQuery) Validate() error {
+	for _, filter := range q.Filters {
+		switch filter.Kind {
+		case "in":
+			if len(filter.Values) == 0 {
+				return fmt.Errorf("search filter values must not be empty")
+			}
+		case "where":
+			if len(filter.Parts) == 0 {
+				return fmt.Errorf("search filter condition must not be empty")
+			}
+		default:
+			return fmt.Errorf("unknown search filter kind %q", filter.Kind)
+		}
+	}
+	return nil
+}
+
+func searchFilterArgs(params any) []any {
+	if params == nil {
+		return nil
+	}
+
+	value := reflect.ValueOf(params)
+	if value.Kind() != reflect.Slice && value.Kind() != reflect.Array {
+		return []any{params}
+	}
+	if value.Type().Elem().Kind() == reflect.Uint8 {
+		return []any{params}
+	}
+
+	args := make([]any, value.Len())
+	for i := range args {
+		args[i] = value.Index(i).Interface()
+	}
+	return args
+}
+
+func newSearchUserWhereFilter(condition string, params any) (searchUserFilter, error) {
+	args := searchFilterArgs(params)
+	parts := strings.Split(condition, "?")
+	if params == nil && len(parts) == 2 {
+		args = []any{nil}
+	}
+	if len(parts)-1 != len(args) {
+		return searchUserFilter{}, fmt.Errorf("search filter condition has %d placeholders for %d values", len(parts)-1, len(args))
+	}
+
+	conditionParts := make([]searchUserConditionPart, len(parts))
+	for i, part := range parts {
+		conditionParts[i].SQL = part
+		if i < len(args) {
+			conditionParts[i].Value = args[i]
+			conditionParts[i].HasValue = true
+		}
+	}
+
+	return searchUserFilter{Kind: "where", Parts: conditionParts}, nil
+}
+
+func buildSearchUserFilters(dbHelper *legacysql.LegacyDatabaseHelper, filters []user.Filter) ([]searchUserJoin, []searchUserFilter, error) {
+	joins := make([]searchUserJoin, 0)
+	queryFilters := make([]searchUserFilter, 0)
+
+	for _, filter := range filters {
+		if join := filter.JoinCondition(); join != nil {
+			joins = append(joins, searchUserJoin{
+				Operator:  join.Operator,
+				Table:     dbHelper.Table(join.Table),
+				Alias:     join.Table,
+				Condition: join.Params,
+			})
+		}
+
+		if in := filter.InCondition(); in != nil {
+			values := searchFilterArgs(in.Params)
+			if len(values) == 0 {
+				return nil, nil, fmt.Errorf("search filter values must not be empty")
+			}
+			queryFilters = append(queryFilters, searchUserFilter{
+				Kind:      "in",
+				Condition: in.Condition,
+				Values:    values,
+			})
+		}
+
+		if where := filter.WhereCondition(); where != nil {
+			queryFilter, err := newSearchUserWhereFilter(where.Condition, where.Params)
+			if err != nil {
+				return nil, nil, err
+			}
+			queryFilters = append(queryFilters, queryFilter)
+		}
+	}
+
+	return joins, queryFilters, nil
 }
 
 func (ss *sqlStore) Search(ctx context.Context, query *user.SearchUsersQuery) (*user.SearchUserQueryResult, error) {
@@ -558,132 +815,104 @@ func (ss *sqlStore) Search(ctx context.Context, query *user.SearchUsersQuery) (*
 	}
 
 	err = dbHelper.DB.WithDbSession(ctx, func(dbSess *db.Session) error {
-		whereConditions := make([]string, 0)
-		whereParams := make([]any, 0)
-		userTable := dbHelper.Table("user")
-		userAuthTable := dbHelper.Table("user_auth")
-		qUserAuth := quoteTable(dbHelper, "user_auth")
-		sess := dbSess.Table(userTable).Alias("u")
-
-		whereConditions = append(whereConditions, "u.is_service_account = ?")
-		whereParams = append(whereParams, dbHelper.DB.GetDialect().BooleanValue(false))
-
-		// Join with only most recent auth module
-		joinCondition := `(
-		SELECT id from ` + qUserAuth + ` AS user_auth
-			WHERE user_auth.user_id = u.id
-			ORDER BY user_auth.created DESC `
-		joinCondition = "user_auth.id=" + joinCondition + dbHelper.DB.GetDialect().Limit(1) + ")"
-		sess.Join("LEFT", []string{userAuthTable, "user_auth"}, joinCondition)
-		if query.OrgID > 0 {
-			whereConditions = append(whereConditions, "org_id = ?")
-			whereParams = append(whereParams, query.OrgID)
-		}
-
 		// user only sees the users for which it has read permissions
 		acFilter, err := accesscontrol.Filter(query.SignedInUser, "u.id", "global.users:id:", accesscontrol.ActionUsersRead)
 		if err != nil {
 			return err
 		}
-		whereConditions = append(whereConditions, acFilter.Where)
-		whereParams = append(whereParams, acFilter.Args...)
 
-		if query.Query != "" {
-			emailSql, emailArg := dbHelper.DB.GetDialect().LikeOperator("email", true, query.Query, true)
-			nameSql, nameArg := dbHelper.DB.GetDialect().LikeOperator("name", true, query.Query, true)
-			loginSql, loginArg := dbHelper.DB.GetDialect().LikeOperator("login", true, query.Query, true)
-			whereConditions = append(whereConditions, fmt.Sprintf("(%s OR %s OR %s)", emailSql, nameSql, loginSql))
-			whereParams = append(whereParams, emailArg, nameArg, loginArg)
-		}
-
-		if query.IsDisabled != nil {
-			whereConditions = append(whereConditions, "is_disabled = ?")
-			whereParams = append(whereParams, query.IsDisabled)
-		}
-
-		if query.AuthModule != "" {
-			whereConditions = append(whereConditions, `auth_module=?`)
-			whereParams = append(whereParams, query.AuthModule)
-		}
-
-		if len(whereConditions) > 0 {
-			sess.Where(strings.Join(whereConditions, " AND "), whereParams...)
-		}
-
-		for _, filter := range query.Filters {
-			if jc := filter.JoinCondition(); jc != nil {
-				sess.Join(jc.Operator, []string{dbHelper.Table(jc.Table), jc.Table}, jc.Params)
-			}
-			if ic := filter.InCondition(); ic != nil {
-				sess.In(ic.Condition, ic.Params)
-			}
-			if wc := filter.WhereCondition(); wc != nil {
-				sess.Where(wc.Condition, wc.Params)
-			}
-		}
-
-		if query.Limit > 0 {
-			offset := query.Limit * (query.Page - 1)
-			sess.Limit(query.Limit, offset)
-		}
-
-		sess.Cols("u.id", "u.uid", "u.email", "u.name", "u.login", "u.is_admin", "u.is_disabled", "u.last_seen_at", "user_auth.auth_module", "u.is_provisioned", "u.created")
-
-		if len(query.SortOpts) > 0 {
-			for i := range query.SortOpts {
-				for j := range query.SortOpts[i].Filter {
-					sess.OrderBy(query.SortOpts[i].Filter[j].OrderBy())
-				}
-			}
-		} else {
-			sess.Asc("u.login", "u.email")
-		}
-
-		if err := sess.Find(&result.Users); err != nil {
+		accessAll := strings.TrimSpace(acFilter.Where) == "1 = 1"
+		joins, queryFilters, err := buildSearchUserFilters(dbHelper, query.Filters)
+		if err != nil {
 			return err
 		}
 
-		// get total
-		user := user.User{}
-		countSess := dbSess.Table(userTable).Alias("u")
+		sorts := make([]string, 0)
+		if len(query.SortOpts) > 0 {
+			for i := range query.SortOpts {
+				for j := range query.SortOpts[i].Filter {
+					sorts = append(sorts, query.SortOpts[i].Filter[j].OrderBy())
+				}
+			}
+		}
 
-		// Join with user_auth table if users filtered by auth_module
+		searchQuery := searchUsersQuery{
+			SQLTemplate:      sqltemplate.New(dbHelper.DialectForDriver()),
+			UserTable:        dbHelper.Table("user"),
+			UserAuthTable:    dbHelper.Table("user_auth"),
+			Joins:            joins,
+			IsServiceAccount: dbHelper.DB.GetDialect().BooleanValue(false),
+			OrgID:            query.OrgID,
+			AccessAll:        accessAll,
+			AccessUserIDs:    acFilter.Args,
+			QueryPattern:     searchQueryPattern(query.Query),
+			Filters:          queryFilters,
+			Sorts:            sorts,
+			UseDefaultSort:   len(query.SortOpts) == 0,
+			IncludeAuthJoin:  true,
+		}
+		if query.IsDisabled != nil {
+			searchQuery.HasIsDisabled = true
+			searchQuery.IsDisabled = *query.IsDisabled
+		}
 		if query.AuthModule != "" {
-			countSess.Join("LEFT", []string{userAuthTable, "user_auth"}, joinCondition)
+			searchQuery.AuthModule = query.AuthModule
 		}
-
-		if len(whereConditions) > 0 {
-			countSess.Where(strings.Join(whereConditions, " AND "), whereParams...)
-		}
-
-		for _, filter := range query.Filters {
-			if jc := filter.JoinCondition(); jc != nil {
-				countSess.Join(jc.Operator, []string{dbHelper.Table(jc.Table), jc.Table}, jc.Params)
-			}
-			if ic := filter.InCondition(); ic != nil {
-				countSess.In(ic.Condition, ic.Params)
-			}
-			if wc := filter.WhereCondition(); wc != nil {
-				countSess.Where(wc.Condition, wc.Params)
+		if query.Limit > 0 {
+			searchQuery.Limit = query.Limit
+			searchQuery.Offset = query.Limit * (query.Page - 1)
+			if searchQuery.Offset < 0 {
+				searchQuery.Offset = 0
 			}
 		}
 
-		count, err := countSess.Count(&user)
-		result.TotalCount = count
+		rawSQL, err := renderUserQuery(searchUsersTemplate, searchQuery)
+		if err != nil {
+			return err
+		}
+		if err := dbSess.SQL(rawSQL, searchQuery.GetArgs()...).Find(&result.Users); err != nil {
+			return err
+		}
+
+		countQuery := searchQuery
+		countQuery.SQLTemplate = sqltemplate.New(dbHelper.DialectForDriver())
+		countQuery.IncludeAuthJoin = query.AuthModule != ""
+		countQuery.Sorts = nil
+		countQuery.Limit = 0
+		countQuery.Offset = 0
+		countSQL, err := renderUserQuery(countSearchUsersTemplate, countQuery)
+		if err != nil {
+			return err
+		}
+		var countResult struct {
+			Count int64
+		}
+		if _, err := dbSess.SQL(countSQL, countQuery.GetArgs()...).Get(&countResult); err != nil {
+			return err
+		}
+		result.TotalCount = countResult.Count
 
 		for _, user := range result.Users {
 			user.LastSeenAtAge = util.GetAgeString(user.LastSeenAt)
 		}
 
-		return err
+		return nil
 	})
 	return &result, err
 }
 
-func setOptional[T any](v *T, add func(v T)) {
-	if v != nil {
-		add(*v)
+func searchQueryPattern(query string) string {
+	if query == "" {
+		return ""
 	}
+	return "%" + query + "%"
+}
+
+func renderUserQuery(tmpl *template.Template, query sqltemplate.SQLTemplate) (string, error) {
+	if err := query.Validate(); err != nil {
+		return "", err
+	}
+	return sqltemplate.Execute(tmpl, query)
 }
 
 func handleSQLError(dialect migrator.Dialect, err error) error {

--- a/pkg/services/user/userimpl/store_provider_test.go
+++ b/pkg/services/user/userimpl/store_provider_test.go
@@ -100,19 +100,19 @@ func TestStoreUsesProviderTables(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(11), insertedID)
 
-	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM `test_schema`.`user` WHERE id = ?")).
+	mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM "test_schema"."user" WHERE id = ?`)).
 		WithArgs(int64(7)).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	require.NoError(t, store.Delete(ctx, 7))
 
-	mock.ExpectExec(`(?s)UPDATE .*test_schema.*user.*SET is_disabled=\?.*WHERE Id IN \(\?,\?\).*is_service_account`).
+	mock.ExpectExec(`(?s)UPDATE .*test_schema.*user.*SET is_disabled = \?.*WHERE id IN \(\?, \?\).*is_service_account`).
 		WithArgs(true, int64(7), int64(11)).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	require.NoError(t, store.BatchDisableUsers(ctx, &user.BatchDisableUsersCommand{
 		UserIDs: []int64{7, 11}, IsDisabled: true,
 	}))
 
-	mock.ExpectQuery(`(?s).*FROM .*test_schema.*user.*LEFT OUTER JOIN .*test_schema.*org_user.*LEFT OUTER JOIN .*test_schema.*org.*WHERE u.id=\?`).
+	mock.ExpectQuery(`(?s).*FROM .*test_schema.*user.*LEFT OUTER JOIN .*test_schema.*org_user.*LEFT OUTER JOIN .*test_schema.*org.*WHERE u.id = \?`).
 		WithArgs(int64(42), int64(7)).
 		WillReturnRows(sqlmock.NewRows([]string{"user_id"}).AddRow(int64(7)))
 	signedInUser, err := store.GetSignedInUser(ctx, &user.GetSignedInUserQuery{UserID: 7, OrgID: 42})

--- a/pkg/services/user/userimpl/templates.go
+++ b/pkg/services/user/userimpl/templates.go
@@ -1,0 +1,34 @@
+package userimpl
+
+import (
+	"embed"
+	"fmt"
+	"text/template"
+)
+
+var (
+	//go:embed queries/*.sql
+	sqlTemplatesFS embed.FS
+
+	sqlTemplates = template.Must(template.New("sql").ParseFS(sqlTemplatesFS, `queries/*.sql`))
+)
+
+func mustTemplate(filename string) *template.Template {
+	if tmpl := sqlTemplates.Lookup(filename); tmpl != nil {
+		return tmpl
+	}
+	panic(fmt.Sprintf("template file not found: %s", filename))
+}
+
+var (
+	deleteUserTemplate                     = mustTemplate("delete_user.sql")
+	getUserByIDTemplate                    = mustTemplate("get_user_by_id.sql")
+	getUserByLoginOrEmailTemplate          = mustTemplate("get_user_by_login_or_email.sql")
+	getSignedInUserTemplate                = mustTemplate("get_signed_in_user.sql")
+	countUsersTemplate                     = mustTemplate("count_users.sql")
+	countUserAccountsWithEmptyRoleTemplate = mustTemplate("count_user_accounts_with_empty_role.sql")
+	batchDisableUsersTemplate              = mustTemplate("batch_disable_users.sql")
+	searchUsersTemplate                    = mustTemplate("search_users.sql")
+	countSearchUsersTemplate               = mustTemplate("count_search_users.sql")
+	updateUserTemplate                     = mustTemplate("update_user.sql")
+)

--- a/pkg/services/user/userimpl/templates_test.go
+++ b/pkg/services/user/userimpl/templates_test.go
@@ -38,8 +38,7 @@ func TestTemplates(t *testing.T) {
 			query.AccessAll = false
 			query.AccessUserIDs = []any{11, 12}
 			query.QueryPattern = "%ops%"
-			query.HasIsDisabled = true
-			query.IsDisabled = true
+			query.IsDisabled = new(true)
 			query.AuthModule = "oauth"
 			query.Joins = []searchUserJoin{{
 				Operator:  "INNER",
@@ -205,26 +204,21 @@ func TestTemplates(t *testing.T) {
 				{
 					Name: "all_fields",
 					Data: &updateUserQuery{
-						SQLTemplate:       queryTemplate(),
-						UserTable:         dbHelper.Table("user"),
-						UserID:            42,
-						IsServiceAccount:  false,
-						Email:             "alice@example.com",
-						Name:              "Alice",
-						Login:             "alice",
-						Password:          "hashed-password",
-						EmailVerified:     true,
-						HasEmailVerified:  true,
-						Theme:             "dark",
-						IsDisabled:        false,
-						HasIsDisabled:     true,
-						IsGrafanaAdmin:    true,
-						HasIsGrafanaAdmin: true,
-						OrgID:             7,
-						HasOrgID:          true,
-						IsProvisioned:     false,
-						HasIsProvisioned:  true,
-						Updated:           legacysql.NewDBTime(time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)),
+						SQLTemplate:      queryTemplate(),
+						UserTable:        dbHelper.Table("user"),
+						UserID:           42,
+						IsServiceAccount: false,
+						Email:            "alice@example.com",
+						Name:             "Alice",
+						Login:            "alice",
+						Password:         "hashed-password",
+						EmailVerified:    new(true),
+						Theme:            "dark",
+						IsDisabled:       new(false),
+						IsGrafanaAdmin:   new(true),
+						OrgID:            new(int64(7)),
+						IsProvisioned:    new(false),
+						Updated:          legacysql.NewDBTime(time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)),
 					},
 				},
 			},
@@ -241,8 +235,7 @@ func TestSearchUsersQueryArguments(t *testing.T) {
 		OrgID:            7,
 		AccessUserIDs:    []any{11, 12},
 		QueryPattern:     "%ops%",
-		HasIsDisabled:    true,
-		IsDisabled:       true,
+		IsDisabled:       new(true),
 		AuthModule:       "oauth",
 		Filters: []searchUserFilter{
 			{
@@ -286,26 +279,21 @@ func TestSearchUsersQueryArguments(t *testing.T) {
 func TestUpdateUserQueryArguments(t *testing.T) {
 	updated := legacysql.NewDBTime(time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC))
 	query := updateUserQuery{
-		SQLTemplate:       sqltemplate.New(sqltemplate.PostgreSQL),
-		UserTable:         "test_schema.user",
-		UserID:            42,
-		IsServiceAccount:  false,
-		Email:             "alice@example.com",
-		Name:              "Alice",
-		Login:             "alice",
-		Password:          "hashed-password",
-		EmailVerified:     true,
-		HasEmailVerified:  true,
-		Theme:             "dark",
-		IsDisabled:        false,
-		HasIsDisabled:     true,
-		IsGrafanaAdmin:    true,
-		HasIsGrafanaAdmin: true,
-		OrgID:             7,
-		HasOrgID:          true,
-		IsProvisioned:     false,
-		HasIsProvisioned:  true,
-		Updated:           updated,
+		SQLTemplate:      sqltemplate.New(sqltemplate.PostgreSQL),
+		UserTable:        "test_schema.user",
+		UserID:           42,
+		IsServiceAccount: false,
+		Email:            "alice@example.com",
+		Name:             "Alice",
+		Login:            "alice",
+		Password:         "hashed-password",
+		EmailVerified:    new(true),
+		Theme:            "dark",
+		IsDisabled:       new(false),
+		IsGrafanaAdmin:   new(true),
+		OrgID:            new(int64(7)),
+		IsProvisioned:    new(false),
+		Updated:          updated,
 	}
 
 	_, err := renderUserQuery(updateUserTemplate, query)

--- a/pkg/services/user/userimpl/templates_test.go
+++ b/pkg/services/user/userimpl/templates_test.go
@@ -69,6 +69,8 @@ func TestTemplates(t *testing.T) {
 	}
 	emptyInSearchQuery := searchQuery(true, false)
 	emptyInSearchQuery.Filters = []searchUserFilter{{Kind: "in", Condition: "user_stats.billing_role"}}
+	emptyInCountSearchQuery := searchQuery(true, false)
+	emptyInCountSearchQuery.Filters = []searchUserFilter{{Kind: "in", Condition: "user_stats.billing_role"}}
 
 	mocks.CheckQuerySnapshots(t, mocks.TemplateTestSetup{
 		RootDir:        "testdata",
@@ -197,6 +199,7 @@ func TestTemplates(t *testing.T) {
 			countSearchUsersTemplate: {
 				{Name: "with_auth_filter", Data: searchQuery(true, true)},
 				{Name: "without_auth_filter", Data: searchQuery(false, false)},
+				{Name: "empty_in", Data: emptyInCountSearchQuery},
 			},
 			updateUserTemplate: {
 				{

--- a/pkg/services/user/userimpl/templates_test.go
+++ b/pkg/services/user/userimpl/templates_test.go
@@ -67,6 +67,8 @@ func TestTemplates(t *testing.T) {
 		}
 		return query
 	}
+	emptyInSearchQuery := searchQuery(true, false)
+	emptyInSearchQuery.Filters = []searchUserFilter{{Kind: "in", Condition: "user_stats.billing_role"}}
 
 	mocks.CheckQuerySnapshots(t, mocks.TemplateTestSetup{
 		RootDir:        "testdata",
@@ -190,6 +192,7 @@ func TestTemplates(t *testing.T) {
 			searchUsersTemplate: {
 				{Name: "all_filters", Data: searchQuery(true, true)},
 				{Name: "default", Data: searchQuery(true, false)},
+				{Name: "empty_in", Data: emptyInSearchQuery},
 			},
 			countSearchUsersTemplate: {
 				{Name: "with_auth_filter", Data: searchQuery(true, true)},
@@ -321,8 +324,16 @@ func TestUpdateUserQueryArguments(t *testing.T) {
 	}, query.GetArgs())
 }
 
+func TestSearchUserWhereFilterPreservesSliceValue(t *testing.T) {
+	value := []int{1, 2}
+	filter, err := newSearchUserWhereFilter("user_id = ?", value)
+	require.NoError(t, err)
+	require.Len(t, filter.Parts, 2)
+	require.Equal(t, value, filter.Parts[1].Value)
+}
+
 func TestQueryValidation(t *testing.T) {
 	require.ErrorIs(t, (&signedInUserQuery{}).Validate(), user.ErrNoUniqueID)
 	require.ErrorContains(t, (&batchDisableUsersQuery{}).Validate(), "user IDs must not be empty")
-	require.ErrorContains(t, (&searchUsersQuery{Filters: []searchUserFilter{{Kind: "in"}}}).Validate(), "must not be empty")
+	require.NoError(t, (&searchUsersQuery{Filters: []searchUserFilter{{Kind: "in"}}}).Validate())
 }

--- a/pkg/services/user/userimpl/templates_test.go
+++ b/pkg/services/user/userimpl/templates_test.go
@@ -1,0 +1,328 @@
+package userimpl
+
+import (
+	"testing"
+	"text/template"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate/mocks"
+)
+
+func TestTemplates(t *testing.T) {
+	dbHelper := &legacysql.LegacyDatabaseHelper{
+		Table: func(name string) string {
+			return "test_schema." + name
+		},
+	}
+	queryTemplate := func() sqltemplate.SQLTemplate {
+		return mocks.NewTestingSQLTemplate()
+	}
+
+	searchQuery := func(includeAuthJoin bool, withFilters bool) *searchUsersQuery {
+		query := &searchUsersQuery{
+			SQLTemplate:      queryTemplate(),
+			UserTable:        dbHelper.Table("user"),
+			UserAuthTable:    dbHelper.Table("user_auth"),
+			IsServiceAccount: false,
+			AccessAll:        true,
+			UseDefaultSort:   true,
+			IncludeAuthJoin:  includeAuthJoin,
+		}
+		if withFilters {
+			query.OrgID = 7
+			query.AccessAll = false
+			query.AccessUserIDs = []any{11, 12}
+			query.QueryPattern = "%ops%"
+			query.HasIsDisabled = true
+			query.IsDisabled = true
+			query.AuthModule = "oauth"
+			query.Joins = []searchUserJoin{{
+				Operator:  "INNER",
+				Table:     dbHelper.Table("user_stats"),
+				Alias:     "user_stats",
+				Condition: "user_stats.user_id = u.id",
+			}}
+			query.Filters = []searchUserFilter{
+				{
+					Kind:      "in",
+					Condition: "user_stats.billing_role",
+					Values:    []any{"admin", "editor"},
+				},
+				{
+					Kind: "where",
+					Parts: []searchUserConditionPart{
+						{SQL: "is_admin = "},
+						{Value: true, HasValue: true},
+					},
+				},
+			}
+			query.Sorts = []string{"u.login DESC", "u.email ASC"}
+			query.Limit = 25
+			query.Offset = 50
+		}
+		return query
+	}
+
+	mocks.CheckQuerySnapshots(t, mocks.TemplateTestSetup{
+		RootDir:        "testdata",
+		SQLTemplatesFS: sqlTemplatesFS,
+		Templates: map[*template.Template][]mocks.TemplateTestCase{
+			deleteUserTemplate: {
+				{
+					Name: "delete_user",
+					Data: &deleteUserQuery{
+						SQLTemplate: queryTemplate(),
+						UserTable:   dbHelper.Table("user"),
+						UserID:      42,
+					},
+				},
+			},
+			getUserByIDTemplate: {
+				{
+					Name: "user",
+					Data: &getUserByIDQuery{
+						SQLTemplate:      queryTemplate(),
+						UserTable:        dbHelper.Table("user"),
+						UserID:           42,
+						IsServiceAccount: false,
+					},
+				},
+			},
+			getUserByLoginOrEmailTemplate: {
+				{
+					Name: "by_email",
+					Data: &getUserByLoginOrEmailQuery{
+						SQLTemplate:      queryTemplate(),
+						UserTable:        dbHelper.Table("user"),
+						Identifier:       "alice@example.com",
+						ByEmail:          true,
+						IsServiceAccount: false,
+					},
+				},
+				{
+					Name: "by_login",
+					Data: &getUserByLoginOrEmailQuery{
+						SQLTemplate:      queryTemplate(),
+						UserTable:        dbHelper.Table("user"),
+						Identifier:       "alice",
+						IsServiceAccount: false,
+					},
+				},
+			},
+			getSignedInUserTemplate: {
+				{
+					Name: "by_id_with_org",
+					Data: &signedInUserQuery{
+						SQLTemplate:  queryTemplate(),
+						UserTable:    dbHelper.Table("user"),
+						OrgUserTable: dbHelper.Table("org_user"),
+						OrgTable:     dbHelper.Table("org"),
+						OrgID:        7,
+						UserID:       42,
+					},
+				},
+				{
+					Name: "by_login_without_org",
+					Data: &signedInUserQuery{
+						SQLTemplate:  queryTemplate(),
+						UserTable:    dbHelper.Table("user"),
+						OrgUserTable: dbHelper.Table("org_user"),
+						OrgTable:     dbHelper.Table("org"),
+						Login:        "alice",
+					},
+				},
+				{
+					Name: "by_email",
+					Data: &signedInUserQuery{
+						SQLTemplate:  queryTemplate(),
+						UserTable:    dbHelper.Table("user"),
+						OrgUserTable: dbHelper.Table("org_user"),
+						OrgTable:     dbHelper.Table("org"),
+						OrgID:        7,
+						Email:        "alice@example.com",
+					},
+				},
+			},
+			countUsersTemplate: {
+				{
+					Name: "users",
+					Data: &countUsersQuery{
+						SQLTemplate: queryTemplate(),
+						UserTable:   dbHelper.Table("user"),
+					},
+				},
+			},
+			countUserAccountsWithEmptyRoleTemplate: {
+				{
+					Name: "empty_role",
+					Data: &countUserAccountsWithEmptyRoleQuery{
+						SQLTemplate:  queryTemplate(),
+						OrgUserTable: dbHelper.Table("org_user"),
+						UserTable:    dbHelper.Table("user"),
+						Role:         "None",
+					},
+				},
+			},
+			batchDisableUsersTemplate: {
+				{
+					Name: "users",
+					Data: &batchDisableUsersQuery{
+						SQLTemplate: queryTemplate(),
+						UserTable:   dbHelper.Table("user"),
+						UserIDs:     []int64{11, 12, 13},
+						IsDisabled:  true,
+					},
+				},
+				{
+					Name:            "empty_user_ids",
+					ValidationError: "user IDs must not be empty",
+					Data: &batchDisableUsersQuery{
+						SQLTemplate: queryTemplate(),
+						UserTable:   dbHelper.Table("user"),
+					},
+				},
+			},
+			searchUsersTemplate: {
+				{Name: "all_filters", Data: searchQuery(true, true)},
+				{Name: "default", Data: searchQuery(true, false)},
+			},
+			countSearchUsersTemplate: {
+				{Name: "with_auth_filter", Data: searchQuery(true, true)},
+				{Name: "without_auth_filter", Data: searchQuery(false, false)},
+			},
+			updateUserTemplate: {
+				{
+					Name: "all_fields",
+					Data: &updateUserQuery{
+						SQLTemplate:       queryTemplate(),
+						UserTable:         dbHelper.Table("user"),
+						UserID:            42,
+						IsServiceAccount:  false,
+						Email:             "alice@example.com",
+						Name:              "Alice",
+						Login:             "alice",
+						Password:          "hashed-password",
+						EmailVerified:     true,
+						HasEmailVerified:  true,
+						Theme:             "dark",
+						IsDisabled:        false,
+						HasIsDisabled:     true,
+						IsGrafanaAdmin:    true,
+						HasIsGrafanaAdmin: true,
+						OrgID:             7,
+						HasOrgID:          true,
+						IsProvisioned:     false,
+						HasIsProvisioned:  true,
+						Updated:           legacysql.NewDBTime(time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestSearchUsersQueryArguments(t *testing.T) {
+	query := searchUsersQuery{
+		SQLTemplate:      sqltemplate.New(sqltemplate.PostgreSQL),
+		UserTable:        "test_schema.user",
+		UserAuthTable:    "test_schema.user_auth",
+		IsServiceAccount: false,
+		OrgID:            7,
+		AccessUserIDs:    []any{11, 12},
+		QueryPattern:     "%ops%",
+		HasIsDisabled:    true,
+		IsDisabled:       true,
+		AuthModule:       "oauth",
+		Filters: []searchUserFilter{
+			{
+				Kind:      "in",
+				Condition: "user_stats.billing_role",
+				Values:    []any{"admin", "editor"},
+			},
+			{
+				Kind: "where",
+				Parts: []searchUserConditionPart{
+					{SQL: "is_admin = "},
+					{Value: true, HasValue: true},
+				},
+			},
+		},
+		Limit:           25,
+		Offset:          50,
+		IncludeAuthJoin: true,
+	}
+
+	_, err := renderUserQuery(searchUsersTemplate, query)
+	require.NoError(t, err)
+	require.Equal(t, []any{
+		false,
+		int64(7),
+		11,
+		12,
+		"%ops%",
+		"%ops%",
+		"%ops%",
+		true,
+		"oauth",
+		"admin",
+		"editor",
+		true,
+		25,
+		50,
+	}, query.GetArgs())
+}
+
+func TestUpdateUserQueryArguments(t *testing.T) {
+	updated := legacysql.NewDBTime(time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC))
+	query := updateUserQuery{
+		SQLTemplate:       sqltemplate.New(sqltemplate.PostgreSQL),
+		UserTable:         "test_schema.user",
+		UserID:            42,
+		IsServiceAccount:  false,
+		Email:             "alice@example.com",
+		Name:              "Alice",
+		Login:             "alice",
+		Password:          "hashed-password",
+		EmailVerified:     true,
+		HasEmailVerified:  true,
+		Theme:             "dark",
+		IsDisabled:        false,
+		HasIsDisabled:     true,
+		IsGrafanaAdmin:    true,
+		HasIsGrafanaAdmin: true,
+		OrgID:             7,
+		HasOrgID:          true,
+		IsProvisioned:     false,
+		HasIsProvisioned:  true,
+		Updated:           updated,
+	}
+
+	_, err := renderUserQuery(updateUserTemplate, query)
+	require.NoError(t, err)
+	require.Equal(t, []any{
+		"alice@example.com",
+		"Alice",
+		"alice",
+		"hashed-password",
+		true,
+		"dark",
+		false,
+		true,
+		int64(7),
+		false,
+		updated,
+		int64(42),
+		false,
+	}, query.GetArgs())
+}
+
+func TestQueryValidation(t *testing.T) {
+	require.ErrorIs(t, (&signedInUserQuery{}).Validate(), user.ErrNoUniqueID)
+	require.ErrorContains(t, (&batchDisableUsersQuery{}).Validate(), "user IDs must not be empty")
+	require.ErrorContains(t, (&searchUsersQuery{Filters: []searchUserFilter{{Kind: "in"}}}).Validate(), "must not be empty")
+}

--- a/pkg/services/user/userimpl/templates_test.go
+++ b/pkg/services/user/userimpl/templates_test.go
@@ -25,13 +25,12 @@ func TestTemplates(t *testing.T) {
 
 	searchQuery := func(includeAuthJoin bool, withFilters bool) *searchUsersQuery {
 		query := &searchUsersQuery{
-			SQLTemplate:      queryTemplate(),
-			UserTable:        dbHelper.Table("user"),
-			UserAuthTable:    dbHelper.Table("user_auth"),
-			IsServiceAccount: false,
-			AccessAll:        true,
-			UseDefaultSort:   true,
-			IncludeAuthJoin:  includeAuthJoin,
+			SQLTemplate:     queryTemplate(),
+			UserTable:       dbHelper.Table("user"),
+			UserAuthTable:   dbHelper.Table("user_auth"),
+			AccessAll:       true,
+			UseDefaultSort:  true,
+			IncludeAuthJoin: includeAuthJoin,
 		}
 		if withFilters {
 			query.OrgID = 7
@@ -89,10 +88,9 @@ func TestTemplates(t *testing.T) {
 				{
 					Name: "user",
 					Data: &getUserByIDQuery{
-						SQLTemplate:      queryTemplate(),
-						UserTable:        dbHelper.Table("user"),
-						UserID:           42,
-						IsServiceAccount: false,
+						SQLTemplate: queryTemplate(),
+						UserTable:   dbHelper.Table("user"),
+						UserID:      42,
 					},
 				},
 			},
@@ -103,8 +101,7 @@ func TestTemplates(t *testing.T) {
 						SQLTemplate:      queryTemplate(),
 						UserTable:        dbHelper.Table("user"),
 						Identifier:       "alice@example.com",
-						ByEmail:          true,
-						IsServiceAccount: false,
+						IdentifierColumn: userEmailColumn,
 					},
 				},
 				{
@@ -113,7 +110,7 @@ func TestTemplates(t *testing.T) {
 						SQLTemplate:      queryTemplate(),
 						UserTable:        dbHelper.Table("user"),
 						Identifier:       "alice",
-						IsServiceAccount: false,
+						IdentifierColumn: userLoginColumn,
 					},
 				},
 			},
@@ -204,21 +201,20 @@ func TestTemplates(t *testing.T) {
 				{
 					Name: "all_fields",
 					Data: &updateUserQuery{
-						SQLTemplate:      queryTemplate(),
-						UserTable:        dbHelper.Table("user"),
-						UserID:           42,
-						IsServiceAccount: false,
-						Email:            "alice@example.com",
-						Name:             "Alice",
-						Login:            "alice",
-						Password:         "hashed-password",
-						EmailVerified:    new(true),
-						Theme:            "dark",
-						IsDisabled:       new(false),
-						IsGrafanaAdmin:   new(true),
-						OrgID:            new(int64(7)),
-						IsProvisioned:    new(false),
-						Updated:          legacysql.NewDBTime(time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)),
+						SQLTemplate:    queryTemplate(),
+						UserTable:      dbHelper.Table("user"),
+						UserID:         42,
+						Email:          "alice@example.com",
+						Name:           "Alice",
+						Login:          "alice",
+						Password:       "hashed-password",
+						EmailVerified:  new(true),
+						Theme:          "dark",
+						IsDisabled:     new(false),
+						IsGrafanaAdmin: new(true),
+						OrgID:          new(int64(7)),
+						IsProvisioned:  new(false),
+						Updated:        legacysql.NewDBTime(time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)),
 					},
 				},
 			},
@@ -228,15 +224,14 @@ func TestTemplates(t *testing.T) {
 
 func TestSearchUsersQueryArguments(t *testing.T) {
 	query := searchUsersQuery{
-		SQLTemplate:      sqltemplate.New(sqltemplate.PostgreSQL),
-		UserTable:        "test_schema.user",
-		UserAuthTable:    "test_schema.user_auth",
-		IsServiceAccount: false,
-		OrgID:            7,
-		AccessUserIDs:    []any{11, 12},
-		QueryPattern:     "%ops%",
-		IsDisabled:       new(true),
-		AuthModule:       "oauth",
+		SQLTemplate:   sqltemplate.New(sqltemplate.PostgreSQL),
+		UserTable:     "test_schema.user",
+		UserAuthTable: "test_schema.user_auth",
+		OrgID:         7,
+		AccessUserIDs: []any{11, 12},
+		QueryPattern:  "%ops%",
+		IsDisabled:    new(true),
+		AuthModule:    "oauth",
 		Filters: []searchUserFilter{
 			{
 				Kind:      "in",
@@ -259,7 +254,6 @@ func TestSearchUsersQueryArguments(t *testing.T) {
 	_, err := renderUserQuery(searchUsersTemplate, query)
 	require.NoError(t, err)
 	require.Equal(t, []any{
-		false,
 		int64(7),
 		11,
 		12,
@@ -279,21 +273,20 @@ func TestSearchUsersQueryArguments(t *testing.T) {
 func TestUpdateUserQueryArguments(t *testing.T) {
 	updated := legacysql.NewDBTime(time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC))
 	query := updateUserQuery{
-		SQLTemplate:      sqltemplate.New(sqltemplate.PostgreSQL),
-		UserTable:        "test_schema.user",
-		UserID:           42,
-		IsServiceAccount: false,
-		Email:            "alice@example.com",
-		Name:             "Alice",
-		Login:            "alice",
-		Password:         "hashed-password",
-		EmailVerified:    new(true),
-		Theme:            "dark",
-		IsDisabled:       new(false),
-		IsGrafanaAdmin:   new(true),
-		OrgID:            new(int64(7)),
-		IsProvisioned:    new(false),
-		Updated:          updated,
+		SQLTemplate:    sqltemplate.New(sqltemplate.PostgreSQL),
+		UserTable:      "test_schema.user",
+		UserID:         42,
+		Email:          "alice@example.com",
+		Name:           "Alice",
+		Login:          "alice",
+		Password:       "hashed-password",
+		EmailVerified:  new(true),
+		Theme:          "dark",
+		IsDisabled:     new(false),
+		IsGrafanaAdmin: new(true),
+		OrgID:          new(int64(7)),
+		IsProvisioned:  new(false),
+		Updated:        updated,
 	}
 
 	_, err := renderUserQuery(updateUserTemplate, query)
@@ -311,7 +304,6 @@ func TestUpdateUserQueryArguments(t *testing.T) {
 		false,
 		updated,
 		int64(42),
-		false,
 	}, query.GetArgs())
 }
 
@@ -326,5 +318,6 @@ func TestSearchUserWhereFilterPreservesSliceValue(t *testing.T) {
 func TestQueryValidation(t *testing.T) {
 	require.ErrorIs(t, (&signedInUserQuery{}).Validate(), user.ErrNoUniqueID)
 	require.ErrorContains(t, (&batchDisableUsersQuery{}).Validate(), "user IDs must not be empty")
+	require.ErrorContains(t, (&getUserByLoginOrEmailQuery{}).Validate(), "invalid user identifier column")
 	require.NoError(t, (&searchUsersQuery{Filters: []searchUserFilter{{Kind: "in"}}}).Validate())
 }

--- a/pkg/services/user/userimpl/testdata/mysql--batch_disable_users-users.sql
+++ b/pkg/services/user/userimpl/testdata/mysql--batch_disable_users-users.sql
@@ -1,0 +1,4 @@
+UPDATE `test_schema`.`user`
+SET is_disabled = TRUE
+WHERE id IN (11, 12, 13)
+  AND is_service_account = FALSE

--- a/pkg/services/user/userimpl/testdata/mysql--count_search_users-empty_in.sql
+++ b/pkg/services/user/userimpl/testdata/mysql--count_search_users-empty_in.sql
@@ -1,0 +1,11 @@
+SELECT COUNT(*) AS count
+FROM `test_schema`.`user` AS u
+LEFT JOIN `test_schema`.`user_auth` AS user_auth ON user_auth.id = (
+  SELECT id
+  FROM `test_schema`.`user_auth` AS user_auth
+  WHERE user_auth.user_id = u.id
+  ORDER BY user_auth.created DESC
+  LIMIT 1
+)
+WHERE u.is_service_account = FALSE
+AND 0 = 1

--- a/pkg/services/user/userimpl/testdata/mysql--count_search_users-with_auth_filter.sql
+++ b/pkg/services/user/userimpl/testdata/mysql--count_search_users-with_auth_filter.sql
@@ -18,5 +18,5 @@ AND (
   )
 AND u.is_disabled = TRUE
 AND user_auth.auth_module = 'oauth'
-AND user_stats.billing_role IN ('admin', 'editor')
+AND `user_stats`.`billing_role` IN ('admin', 'editor')
 AND is_admin = TRUE

--- a/pkg/services/user/userimpl/testdata/mysql--count_search_users-with_auth_filter.sql
+++ b/pkg/services/user/userimpl/testdata/mysql--count_search_users-with_auth_filter.sql
@@ -1,0 +1,22 @@
+SELECT COUNT(*) AS count
+FROM `test_schema`.`user` AS u
+LEFT JOIN `test_schema`.`user_auth` AS user_auth ON user_auth.id = (
+  SELECT id
+  FROM `test_schema`.`user_auth` AS user_auth
+  WHERE user_auth.user_id = u.id
+  ORDER BY user_auth.created DESC
+  LIMIT 1
+)
+INNER JOIN `test_schema`.`user_stats` AS `user_stats` ON user_stats.user_id = u.id
+WHERE u.is_service_account = FALSE
+AND u.org_id = 7
+AND u.id IN (11, 12)
+AND (
+    u.email LIKE '%ops%'
+    OR u.name LIKE '%ops%'
+    OR u.login LIKE '%ops%'
+  )
+AND u.is_disabled = TRUE
+AND user_auth.auth_module = 'oauth'
+AND user_stats.billing_role IN ('admin', 'editor')
+AND is_admin = TRUE

--- a/pkg/services/user/userimpl/testdata/mysql--count_search_users-without_auth_filter.sql
+++ b/pkg/services/user/userimpl/testdata/mysql--count_search_users-without_auth_filter.sql
@@ -1,0 +1,3 @@
+SELECT COUNT(*) AS count
+FROM `test_schema`.`user` AS u
+WHERE u.is_service_account = FALSE

--- a/pkg/services/user/userimpl/testdata/mysql--count_user_accounts_with_empty_role-empty_role.sql
+++ b/pkg/services/user/userimpl/testdata/mysql--count_user_accounts_with_empty_role-empty_role.sql
@@ -1,0 +1,9 @@
+SELECT sub.user_accounts_with_no_role
+FROM (
+  SELECT COUNT(*) AS user_accounts_with_no_role
+  FROM `test_schema`.`org_user` AS ou
+  LEFT JOIN `test_schema`.`user` AS u ON u.id = ou.user_id
+  WHERE ou.role = 'None'
+    AND u.is_service_account = FALSE
+    AND u.is_disabled = FALSE
+) AS sub

--- a/pkg/services/user/userimpl/testdata/mysql--count_users-users.sql
+++ b/pkg/services/user/userimpl/testdata/mysql--count_users-users.sql
@@ -1,0 +1,3 @@
+SELECT COUNT(*) AS count
+FROM `test_schema`.`user`
+WHERE is_service_account = FALSE

--- a/pkg/services/user/userimpl/testdata/mysql--delete_user-delete_user.sql
+++ b/pkg/services/user/userimpl/testdata/mysql--delete_user-delete_user.sql
@@ -1,0 +1,2 @@
+DELETE FROM `test_schema`.`user`
+WHERE id = 42

--- a/pkg/services/user/userimpl/testdata/mysql--get_signed_in_user-by_email.sql
+++ b/pkg/services/user/userimpl/testdata/mysql--get_signed_in_user-by_email.sql
@@ -1,0 +1,22 @@
+SELECT
+  u.id AS user_id,
+  u.uid AS user_uid,
+  u.is_admin AS is_grafana_admin,
+  u.email AS email,
+  u.email_verified AS email_verified,
+  u.login AS login,
+  u.name AS name,
+  u.is_disabled AS is_disabled,
+  u.help_flags1 AS help_flags1,
+  u.last_seen_at AS last_seen_at,
+  org.name AS org_name,
+  org_user.role AS org_role,
+  org.id AS org_id,
+  u.is_service_account AS is_service_account
+FROM `test_schema`.`user` AS u
+LEFT OUTER JOIN `test_schema`.`org_user` AS org_user
+  ON org_user.org_id = 7
+  AND org_user.user_id = u.id
+LEFT OUTER JOIN `test_schema`.`org` AS org
+  ON org.id = org_user.org_id
+WHERE LOWER(u.email) = LOWER('alice@example.com')

--- a/pkg/services/user/userimpl/testdata/mysql--get_signed_in_user-by_id_with_org.sql
+++ b/pkg/services/user/userimpl/testdata/mysql--get_signed_in_user-by_id_with_org.sql
@@ -1,0 +1,22 @@
+SELECT
+  u.id AS user_id,
+  u.uid AS user_uid,
+  u.is_admin AS is_grafana_admin,
+  u.email AS email,
+  u.email_verified AS email_verified,
+  u.login AS login,
+  u.name AS name,
+  u.is_disabled AS is_disabled,
+  u.help_flags1 AS help_flags1,
+  u.last_seen_at AS last_seen_at,
+  org.name AS org_name,
+  org_user.role AS org_role,
+  org.id AS org_id,
+  u.is_service_account AS is_service_account
+FROM `test_schema`.`user` AS u
+LEFT OUTER JOIN `test_schema`.`org_user` AS org_user
+  ON org_user.org_id = 7
+  AND org_user.user_id = u.id
+LEFT OUTER JOIN `test_schema`.`org` AS org
+  ON org.id = org_user.org_id
+WHERE u.id = 42

--- a/pkg/services/user/userimpl/testdata/mysql--get_signed_in_user-by_login_without_org.sql
+++ b/pkg/services/user/userimpl/testdata/mysql--get_signed_in_user-by_login_without_org.sql
@@ -1,0 +1,22 @@
+SELECT
+  u.id AS user_id,
+  u.uid AS user_uid,
+  u.is_admin AS is_grafana_admin,
+  u.email AS email,
+  u.email_verified AS email_verified,
+  u.login AS login,
+  u.name AS name,
+  u.is_disabled AS is_disabled,
+  u.help_flags1 AS help_flags1,
+  u.last_seen_at AS last_seen_at,
+  org.name AS org_name,
+  org_user.role AS org_role,
+  org.id AS org_id,
+  u.is_service_account AS is_service_account
+FROM `test_schema`.`user` AS u
+LEFT OUTER JOIN `test_schema`.`org_user` AS org_user
+  ON org_user.org_id = u.org_id
+  AND org_user.user_id = u.id
+LEFT OUTER JOIN `test_schema`.`org` AS org
+  ON org.id = org_user.org_id
+WHERE LOWER(u.login) = LOWER('alice')

--- a/pkg/services/user/userimpl/testdata/mysql--get_user_by_id-user.sql
+++ b/pkg/services/user/userimpl/testdata/mysql--get_user_by_id-user.sql
@@ -1,0 +1,4 @@
+SELECT *
+FROM `test_schema`.`user`
+WHERE id = 42
+  AND is_service_account = FALSE

--- a/pkg/services/user/userimpl/testdata/mysql--get_user_by_login_or_email-by_email.sql
+++ b/pkg/services/user/userimpl/testdata/mysql--get_user_by_login_or_email-by_email.sql
@@ -1,0 +1,4 @@
+SELECT *
+FROM `test_schema`.`user`
+WHERE is_service_account = FALSE
+  AND email = 'alice@example.com'

--- a/pkg/services/user/userimpl/testdata/mysql--get_user_by_login_or_email-by_email.sql
+++ b/pkg/services/user/userimpl/testdata/mysql--get_user_by_login_or_email-by_email.sql
@@ -1,4 +1,4 @@
 SELECT *
 FROM `test_schema`.`user`
 WHERE is_service_account = FALSE
-  AND email = 'alice@example.com'
+  AND `email` = 'alice@example.com'

--- a/pkg/services/user/userimpl/testdata/mysql--get_user_by_login_or_email-by_login.sql
+++ b/pkg/services/user/userimpl/testdata/mysql--get_user_by_login_or_email-by_login.sql
@@ -1,0 +1,4 @@
+SELECT *
+FROM `test_schema`.`user`
+WHERE is_service_account = FALSE
+  AND login = 'alice'

--- a/pkg/services/user/userimpl/testdata/mysql--get_user_by_login_or_email-by_login.sql
+++ b/pkg/services/user/userimpl/testdata/mysql--get_user_by_login_or_email-by_login.sql
@@ -1,4 +1,4 @@
 SELECT *
 FROM `test_schema`.`user`
 WHERE is_service_account = FALSE
-  AND login = 'alice'
+  AND `login` = 'alice'

--- a/pkg/services/user/userimpl/testdata/mysql--search_users-all_filters.sql
+++ b/pkg/services/user/userimpl/testdata/mysql--search_users-all_filters.sql
@@ -1,0 +1,36 @@
+SELECT
+  u.id,
+  u.uid,
+  u.email,
+  u.name,
+  u.login,
+  u.is_admin,
+  u.is_disabled,
+  u.last_seen_at,
+  user_auth.auth_module,
+  u.is_provisioned,
+  u.created
+FROM `test_schema`.`user` AS u
+LEFT JOIN `test_schema`.`user_auth` AS user_auth ON user_auth.id = (
+  SELECT id
+  FROM `test_schema`.`user_auth` AS user_auth
+  WHERE user_auth.user_id = u.id
+  ORDER BY user_auth.created DESC
+  LIMIT 1
+)
+INNER JOIN `test_schema`.`user_stats` AS `user_stats` ON user_stats.user_id = u.id
+WHERE u.is_service_account = FALSE
+AND u.org_id = 7
+AND u.id IN (11, 12)
+AND (
+    u.email LIKE '%ops%'
+    OR u.name LIKE '%ops%'
+    OR u.login LIKE '%ops%'
+  )
+AND u.is_disabled = TRUE
+AND user_auth.auth_module = 'oauth'
+AND user_stats.billing_role IN ('admin', 'editor')
+AND is_admin = TRUE
+ORDER BY
+u.login DESC, u.email ASC
+LIMIT 25 OFFSET 50

--- a/pkg/services/user/userimpl/testdata/mysql--search_users-default.sql
+++ b/pkg/services/user/userimpl/testdata/mysql--search_users-default.sql
@@ -1,0 +1,23 @@
+SELECT
+  u.id,
+  u.uid,
+  u.email,
+  u.name,
+  u.login,
+  u.is_admin,
+  u.is_disabled,
+  u.last_seen_at,
+  user_auth.auth_module,
+  u.is_provisioned,
+  u.created
+FROM `test_schema`.`user` AS u
+LEFT JOIN `test_schema`.`user_auth` AS user_auth ON user_auth.id = (
+  SELECT id
+  FROM `test_schema`.`user_auth` AS user_auth
+  WHERE user_auth.user_id = u.id
+  ORDER BY user_auth.created DESC
+  LIMIT 1
+)
+WHERE u.is_service_account = FALSE
+ORDER BY
+u.login ASC, u.email ASC

--- a/pkg/services/user/userimpl/testdata/mysql--search_users-empty_in.sql
+++ b/pkg/services/user/userimpl/testdata/mysql--search_users-empty_in.sql
@@ -18,19 +18,7 @@ LEFT JOIN `test_schema`.`user_auth` AS user_auth ON user_auth.id = (
   ORDER BY user_auth.created DESC
   LIMIT 1
 )
-INNER JOIN `test_schema`.`user_stats` AS `user_stats` ON user_stats.user_id = u.id
 WHERE u.is_service_account = FALSE
-AND u.org_id = 7
-AND u.id IN (11, 12)
-AND (
-    u.email LIKE '%ops%'
-    OR u.name LIKE '%ops%'
-    OR u.login LIKE '%ops%'
-  )
-AND u.is_disabled = TRUE
-AND user_auth.auth_module = 'oauth'
-AND `user_stats`.`billing_role` IN ('admin', 'editor')
-AND is_admin = TRUE
+AND 0 = 1
 ORDER BY
-u.login DESC, u.email ASC
-LIMIT 25 OFFSET 50
+u.login ASC, u.email ASC

--- a/pkg/services/user/userimpl/testdata/mysql--update_user-all_fields.sql
+++ b/pkg/services/user/userimpl/testdata/mysql--update_user-all_fields.sql
@@ -1,0 +1,15 @@
+UPDATE `test_schema`.`user`
+SET
+email = 'alice@example.com',
+name = 'Alice',
+login = 'alice',
+password = 'hashed-password',
+email_verified = TRUE,
+theme = 'dark',
+is_disabled = FALSE,
+is_admin = TRUE,
+org_id = 7,
+is_provisioned = FALSE,
+updated = '2026-01-02 03:04:05'
+WHERE id = 42
+  AND is_service_account = FALSE

--- a/pkg/services/user/userimpl/testdata/postgres--batch_disable_users-users.sql
+++ b/pkg/services/user/userimpl/testdata/postgres--batch_disable_users-users.sql
@@ -1,0 +1,4 @@
+UPDATE "test_schema"."user"
+SET is_disabled = TRUE
+WHERE id IN (11, 12, 13)
+  AND is_service_account = FALSE

--- a/pkg/services/user/userimpl/testdata/postgres--count_search_users-empty_in.sql
+++ b/pkg/services/user/userimpl/testdata/postgres--count_search_users-empty_in.sql
@@ -1,0 +1,11 @@
+SELECT COUNT(*) AS count
+FROM "test_schema"."user" AS u
+LEFT JOIN "test_schema"."user_auth" AS user_auth ON user_auth.id = (
+  SELECT id
+  FROM "test_schema"."user_auth" AS user_auth
+  WHERE user_auth.user_id = u.id
+  ORDER BY user_auth.created DESC
+  LIMIT 1
+)
+WHERE u.is_service_account = FALSE
+AND 0 = 1

--- a/pkg/services/user/userimpl/testdata/postgres--count_search_users-with_auth_filter.sql
+++ b/pkg/services/user/userimpl/testdata/postgres--count_search_users-with_auth_filter.sql
@@ -18,5 +18,5 @@ AND (
   )
 AND u.is_disabled = TRUE
 AND user_auth.auth_module = 'oauth'
-AND user_stats.billing_role IN ('admin', 'editor')
+AND "user_stats"."billing_role" IN ('admin', 'editor')
 AND is_admin = TRUE

--- a/pkg/services/user/userimpl/testdata/postgres--count_search_users-with_auth_filter.sql
+++ b/pkg/services/user/userimpl/testdata/postgres--count_search_users-with_auth_filter.sql
@@ -1,0 +1,22 @@
+SELECT COUNT(*) AS count
+FROM "test_schema"."user" AS u
+LEFT JOIN "test_schema"."user_auth" AS user_auth ON user_auth.id = (
+  SELECT id
+  FROM "test_schema"."user_auth" AS user_auth
+  WHERE user_auth.user_id = u.id
+  ORDER BY user_auth.created DESC
+  LIMIT 1
+)
+INNER JOIN "test_schema"."user_stats" AS "user_stats" ON user_stats.user_id = u.id
+WHERE u.is_service_account = FALSE
+AND u.org_id = 7
+AND u.id IN (11, 12)
+AND (
+    u.email ILIKE '%ops%'
+    OR u.name ILIKE '%ops%'
+    OR u.login ILIKE '%ops%'
+  )
+AND u.is_disabled = TRUE
+AND user_auth.auth_module = 'oauth'
+AND user_stats.billing_role IN ('admin', 'editor')
+AND is_admin = TRUE

--- a/pkg/services/user/userimpl/testdata/postgres--count_search_users-without_auth_filter.sql
+++ b/pkg/services/user/userimpl/testdata/postgres--count_search_users-without_auth_filter.sql
@@ -1,0 +1,3 @@
+SELECT COUNT(*) AS count
+FROM "test_schema"."user" AS u
+WHERE u.is_service_account = FALSE

--- a/pkg/services/user/userimpl/testdata/postgres--count_user_accounts_with_empty_role-empty_role.sql
+++ b/pkg/services/user/userimpl/testdata/postgres--count_user_accounts_with_empty_role-empty_role.sql
@@ -1,0 +1,9 @@
+SELECT sub.user_accounts_with_no_role
+FROM (
+  SELECT COUNT(*) AS user_accounts_with_no_role
+  FROM "test_schema"."org_user" AS ou
+  LEFT JOIN "test_schema"."user" AS u ON u.id = ou.user_id
+  WHERE ou.role = 'None'
+    AND u.is_service_account = FALSE
+    AND u.is_disabled = FALSE
+) AS sub

--- a/pkg/services/user/userimpl/testdata/postgres--count_users-users.sql
+++ b/pkg/services/user/userimpl/testdata/postgres--count_users-users.sql
@@ -1,0 +1,3 @@
+SELECT COUNT(*) AS count
+FROM "test_schema"."user"
+WHERE is_service_account = FALSE

--- a/pkg/services/user/userimpl/testdata/postgres--delete_user-delete_user.sql
+++ b/pkg/services/user/userimpl/testdata/postgres--delete_user-delete_user.sql
@@ -1,0 +1,2 @@
+DELETE FROM "test_schema"."user"
+WHERE id = 42

--- a/pkg/services/user/userimpl/testdata/postgres--get_signed_in_user-by_email.sql
+++ b/pkg/services/user/userimpl/testdata/postgres--get_signed_in_user-by_email.sql
@@ -1,0 +1,22 @@
+SELECT
+  u.id AS user_id,
+  u.uid AS user_uid,
+  u.is_admin AS is_grafana_admin,
+  u.email AS email,
+  u.email_verified AS email_verified,
+  u.login AS login,
+  u.name AS name,
+  u.is_disabled AS is_disabled,
+  u.help_flags1 AS help_flags1,
+  u.last_seen_at AS last_seen_at,
+  org.name AS org_name,
+  org_user.role AS org_role,
+  org.id AS org_id,
+  u.is_service_account AS is_service_account
+FROM "test_schema"."user" AS u
+LEFT OUTER JOIN "test_schema"."org_user" AS org_user
+  ON org_user.org_id = 7
+  AND org_user.user_id = u.id
+LEFT OUTER JOIN "test_schema"."org" AS org
+  ON org.id = org_user.org_id
+WHERE LOWER(u.email) = LOWER('alice@example.com')

--- a/pkg/services/user/userimpl/testdata/postgres--get_signed_in_user-by_id_with_org.sql
+++ b/pkg/services/user/userimpl/testdata/postgres--get_signed_in_user-by_id_with_org.sql
@@ -1,0 +1,22 @@
+SELECT
+  u.id AS user_id,
+  u.uid AS user_uid,
+  u.is_admin AS is_grafana_admin,
+  u.email AS email,
+  u.email_verified AS email_verified,
+  u.login AS login,
+  u.name AS name,
+  u.is_disabled AS is_disabled,
+  u.help_flags1 AS help_flags1,
+  u.last_seen_at AS last_seen_at,
+  org.name AS org_name,
+  org_user.role AS org_role,
+  org.id AS org_id,
+  u.is_service_account AS is_service_account
+FROM "test_schema"."user" AS u
+LEFT OUTER JOIN "test_schema"."org_user" AS org_user
+  ON org_user.org_id = 7
+  AND org_user.user_id = u.id
+LEFT OUTER JOIN "test_schema"."org" AS org
+  ON org.id = org_user.org_id
+WHERE u.id = 42

--- a/pkg/services/user/userimpl/testdata/postgres--get_signed_in_user-by_login_without_org.sql
+++ b/pkg/services/user/userimpl/testdata/postgres--get_signed_in_user-by_login_without_org.sql
@@ -1,0 +1,22 @@
+SELECT
+  u.id AS user_id,
+  u.uid AS user_uid,
+  u.is_admin AS is_grafana_admin,
+  u.email AS email,
+  u.email_verified AS email_verified,
+  u.login AS login,
+  u.name AS name,
+  u.is_disabled AS is_disabled,
+  u.help_flags1 AS help_flags1,
+  u.last_seen_at AS last_seen_at,
+  org.name AS org_name,
+  org_user.role AS org_role,
+  org.id AS org_id,
+  u.is_service_account AS is_service_account
+FROM "test_schema"."user" AS u
+LEFT OUTER JOIN "test_schema"."org_user" AS org_user
+  ON org_user.org_id = u.org_id
+  AND org_user.user_id = u.id
+LEFT OUTER JOIN "test_schema"."org" AS org
+  ON org.id = org_user.org_id
+WHERE LOWER(u.login) = LOWER('alice')

--- a/pkg/services/user/userimpl/testdata/postgres--get_user_by_id-user.sql
+++ b/pkg/services/user/userimpl/testdata/postgres--get_user_by_id-user.sql
@@ -1,0 +1,4 @@
+SELECT *
+FROM "test_schema"."user"
+WHERE id = 42
+  AND is_service_account = FALSE

--- a/pkg/services/user/userimpl/testdata/postgres--get_user_by_login_or_email-by_email.sql
+++ b/pkg/services/user/userimpl/testdata/postgres--get_user_by_login_or_email-by_email.sql
@@ -1,0 +1,4 @@
+SELECT *
+FROM "test_schema"."user"
+WHERE is_service_account = FALSE
+  AND email = 'alice@example.com'

--- a/pkg/services/user/userimpl/testdata/postgres--get_user_by_login_or_email-by_email.sql
+++ b/pkg/services/user/userimpl/testdata/postgres--get_user_by_login_or_email-by_email.sql
@@ -1,4 +1,4 @@
 SELECT *
 FROM "test_schema"."user"
 WHERE is_service_account = FALSE
-  AND email = 'alice@example.com'
+  AND "email" = 'alice@example.com'

--- a/pkg/services/user/userimpl/testdata/postgres--get_user_by_login_or_email-by_login.sql
+++ b/pkg/services/user/userimpl/testdata/postgres--get_user_by_login_or_email-by_login.sql
@@ -1,0 +1,4 @@
+SELECT *
+FROM "test_schema"."user"
+WHERE is_service_account = FALSE
+  AND login = 'alice'

--- a/pkg/services/user/userimpl/testdata/postgres--get_user_by_login_or_email-by_login.sql
+++ b/pkg/services/user/userimpl/testdata/postgres--get_user_by_login_or_email-by_login.sql
@@ -1,4 +1,4 @@
 SELECT *
 FROM "test_schema"."user"
 WHERE is_service_account = FALSE
-  AND login = 'alice'
+  AND "login" = 'alice'

--- a/pkg/services/user/userimpl/testdata/postgres--search_users-all_filters.sql
+++ b/pkg/services/user/userimpl/testdata/postgres--search_users-all_filters.sql
@@ -1,0 +1,36 @@
+SELECT
+  u.id,
+  u.uid,
+  u.email,
+  u.name,
+  u.login,
+  u.is_admin,
+  u.is_disabled,
+  u.last_seen_at,
+  user_auth.auth_module,
+  u.is_provisioned,
+  u.created
+FROM "test_schema"."user" AS u
+LEFT JOIN "test_schema"."user_auth" AS user_auth ON user_auth.id = (
+  SELECT id
+  FROM "test_schema"."user_auth" AS user_auth
+  WHERE user_auth.user_id = u.id
+  ORDER BY user_auth.created DESC
+  LIMIT 1
+)
+INNER JOIN "test_schema"."user_stats" AS "user_stats" ON user_stats.user_id = u.id
+WHERE u.is_service_account = FALSE
+AND u.org_id = 7
+AND u.id IN (11, 12)
+AND (
+    u.email ILIKE '%ops%'
+    OR u.name ILIKE '%ops%'
+    OR u.login ILIKE '%ops%'
+  )
+AND u.is_disabled = TRUE
+AND user_auth.auth_module = 'oauth'
+AND user_stats.billing_role IN ('admin', 'editor')
+AND is_admin = TRUE
+ORDER BY
+u.login DESC, u.email ASC
+LIMIT 25 OFFSET 50

--- a/pkg/services/user/userimpl/testdata/postgres--search_users-default.sql
+++ b/pkg/services/user/userimpl/testdata/postgres--search_users-default.sql
@@ -1,0 +1,23 @@
+SELECT
+  u.id,
+  u.uid,
+  u.email,
+  u.name,
+  u.login,
+  u.is_admin,
+  u.is_disabled,
+  u.last_seen_at,
+  user_auth.auth_module,
+  u.is_provisioned,
+  u.created
+FROM "test_schema"."user" AS u
+LEFT JOIN "test_schema"."user_auth" AS user_auth ON user_auth.id = (
+  SELECT id
+  FROM "test_schema"."user_auth" AS user_auth
+  WHERE user_auth.user_id = u.id
+  ORDER BY user_auth.created DESC
+  LIMIT 1
+)
+WHERE u.is_service_account = FALSE
+ORDER BY
+u.login ASC, u.email ASC

--- a/pkg/services/user/userimpl/testdata/postgres--search_users-empty_in.sql
+++ b/pkg/services/user/userimpl/testdata/postgres--search_users-empty_in.sql
@@ -18,19 +18,7 @@ LEFT JOIN "test_schema"."user_auth" AS user_auth ON user_auth.id = (
   ORDER BY user_auth.created DESC
   LIMIT 1
 )
-INNER JOIN "test_schema"."user_stats" AS "user_stats" ON user_stats.user_id = u.id
 WHERE u.is_service_account = FALSE
-AND u.org_id = 7
-AND u.id IN (11, 12)
-AND (
-    u.email ILIKE '%ops%'
-    OR u.name ILIKE '%ops%'
-    OR u.login ILIKE '%ops%'
-  )
-AND u.is_disabled = TRUE
-AND user_auth.auth_module = 'oauth'
-AND "user_stats"."billing_role" IN ('admin', 'editor')
-AND is_admin = TRUE
+AND 0 = 1
 ORDER BY
-u.login DESC, u.email ASC
-LIMIT 25 OFFSET 50
+u.login ASC, u.email ASC

--- a/pkg/services/user/userimpl/testdata/postgres--update_user-all_fields.sql
+++ b/pkg/services/user/userimpl/testdata/postgres--update_user-all_fields.sql
@@ -1,0 +1,15 @@
+UPDATE "test_schema"."user"
+SET
+email = 'alice@example.com',
+name = 'Alice',
+login = 'alice',
+password = 'hashed-password',
+email_verified = TRUE,
+theme = 'dark',
+is_disabled = FALSE,
+is_admin = TRUE,
+org_id = 7,
+is_provisioned = FALSE,
+updated = '2026-01-02 03:04:05'
+WHERE id = 42
+  AND is_service_account = FALSE

--- a/pkg/services/user/userimpl/testdata/sqlite--batch_disable_users-users.sql
+++ b/pkg/services/user/userimpl/testdata/sqlite--batch_disable_users-users.sql
@@ -1,0 +1,4 @@
+UPDATE "test_schema"."user"
+SET is_disabled = TRUE
+WHERE id IN (11, 12, 13)
+  AND is_service_account = FALSE

--- a/pkg/services/user/userimpl/testdata/sqlite--count_search_users-empty_in.sql
+++ b/pkg/services/user/userimpl/testdata/sqlite--count_search_users-empty_in.sql
@@ -1,0 +1,11 @@
+SELECT COUNT(*) AS count
+FROM "test_schema"."user" AS u
+LEFT JOIN "test_schema"."user_auth" AS user_auth ON user_auth.id = (
+  SELECT id
+  FROM "test_schema"."user_auth" AS user_auth
+  WHERE user_auth.user_id = u.id
+  ORDER BY user_auth.created DESC
+  LIMIT 1
+)
+WHERE u.is_service_account = FALSE
+AND 0 = 1

--- a/pkg/services/user/userimpl/testdata/sqlite--count_search_users-with_auth_filter.sql
+++ b/pkg/services/user/userimpl/testdata/sqlite--count_search_users-with_auth_filter.sql
@@ -18,5 +18,5 @@ AND (
   )
 AND u.is_disabled = TRUE
 AND user_auth.auth_module = 'oauth'
-AND user_stats.billing_role IN ('admin', 'editor')
+AND "user_stats"."billing_role" IN ('admin', 'editor')
 AND is_admin = TRUE

--- a/pkg/services/user/userimpl/testdata/sqlite--count_search_users-with_auth_filter.sql
+++ b/pkg/services/user/userimpl/testdata/sqlite--count_search_users-with_auth_filter.sql
@@ -1,0 +1,22 @@
+SELECT COUNT(*) AS count
+FROM "test_schema"."user" AS u
+LEFT JOIN "test_schema"."user_auth" AS user_auth ON user_auth.id = (
+  SELECT id
+  FROM "test_schema"."user_auth" AS user_auth
+  WHERE user_auth.user_id = u.id
+  ORDER BY user_auth.created DESC
+  LIMIT 1
+)
+INNER JOIN "test_schema"."user_stats" AS "user_stats" ON user_stats.user_id = u.id
+WHERE u.is_service_account = FALSE
+AND u.org_id = 7
+AND u.id IN (11, 12)
+AND (
+    u.email LIKE '%ops%'
+    OR u.name LIKE '%ops%'
+    OR u.login LIKE '%ops%'
+  )
+AND u.is_disabled = TRUE
+AND user_auth.auth_module = 'oauth'
+AND user_stats.billing_role IN ('admin', 'editor')
+AND is_admin = TRUE

--- a/pkg/services/user/userimpl/testdata/sqlite--count_search_users-without_auth_filter.sql
+++ b/pkg/services/user/userimpl/testdata/sqlite--count_search_users-without_auth_filter.sql
@@ -1,0 +1,3 @@
+SELECT COUNT(*) AS count
+FROM "test_schema"."user" AS u
+WHERE u.is_service_account = FALSE

--- a/pkg/services/user/userimpl/testdata/sqlite--count_user_accounts_with_empty_role-empty_role.sql
+++ b/pkg/services/user/userimpl/testdata/sqlite--count_user_accounts_with_empty_role-empty_role.sql
@@ -1,0 +1,9 @@
+SELECT sub.user_accounts_with_no_role
+FROM (
+  SELECT COUNT(*) AS user_accounts_with_no_role
+  FROM "test_schema"."org_user" AS ou
+  LEFT JOIN "test_schema"."user" AS u ON u.id = ou.user_id
+  WHERE ou.role = 'None'
+    AND u.is_service_account = FALSE
+    AND u.is_disabled = FALSE
+) AS sub

--- a/pkg/services/user/userimpl/testdata/sqlite--count_users-users.sql
+++ b/pkg/services/user/userimpl/testdata/sqlite--count_users-users.sql
@@ -1,0 +1,3 @@
+SELECT COUNT(*) AS count
+FROM "test_schema"."user"
+WHERE is_service_account = FALSE

--- a/pkg/services/user/userimpl/testdata/sqlite--delete_user-delete_user.sql
+++ b/pkg/services/user/userimpl/testdata/sqlite--delete_user-delete_user.sql
@@ -1,0 +1,2 @@
+DELETE FROM "test_schema"."user"
+WHERE id = 42

--- a/pkg/services/user/userimpl/testdata/sqlite--get_signed_in_user-by_email.sql
+++ b/pkg/services/user/userimpl/testdata/sqlite--get_signed_in_user-by_email.sql
@@ -1,0 +1,22 @@
+SELECT
+  u.id AS user_id,
+  u.uid AS user_uid,
+  u.is_admin AS is_grafana_admin,
+  u.email AS email,
+  u.email_verified AS email_verified,
+  u.login AS login,
+  u.name AS name,
+  u.is_disabled AS is_disabled,
+  u.help_flags1 AS help_flags1,
+  u.last_seen_at AS last_seen_at,
+  org.name AS org_name,
+  org_user.role AS org_role,
+  org.id AS org_id,
+  u.is_service_account AS is_service_account
+FROM "test_schema"."user" AS u
+LEFT OUTER JOIN "test_schema"."org_user" AS org_user
+  ON org_user.org_id = 7
+  AND org_user.user_id = u.id
+LEFT OUTER JOIN "test_schema"."org" AS org
+  ON org.id = org_user.org_id
+WHERE LOWER(u.email) = LOWER('alice@example.com')

--- a/pkg/services/user/userimpl/testdata/sqlite--get_signed_in_user-by_id_with_org.sql
+++ b/pkg/services/user/userimpl/testdata/sqlite--get_signed_in_user-by_id_with_org.sql
@@ -1,0 +1,22 @@
+SELECT
+  u.id AS user_id,
+  u.uid AS user_uid,
+  u.is_admin AS is_grafana_admin,
+  u.email AS email,
+  u.email_verified AS email_verified,
+  u.login AS login,
+  u.name AS name,
+  u.is_disabled AS is_disabled,
+  u.help_flags1 AS help_flags1,
+  u.last_seen_at AS last_seen_at,
+  org.name AS org_name,
+  org_user.role AS org_role,
+  org.id AS org_id,
+  u.is_service_account AS is_service_account
+FROM "test_schema"."user" AS u
+LEFT OUTER JOIN "test_schema"."org_user" AS org_user
+  ON org_user.org_id = 7
+  AND org_user.user_id = u.id
+LEFT OUTER JOIN "test_schema"."org" AS org
+  ON org.id = org_user.org_id
+WHERE u.id = 42

--- a/pkg/services/user/userimpl/testdata/sqlite--get_signed_in_user-by_login_without_org.sql
+++ b/pkg/services/user/userimpl/testdata/sqlite--get_signed_in_user-by_login_without_org.sql
@@ -1,0 +1,22 @@
+SELECT
+  u.id AS user_id,
+  u.uid AS user_uid,
+  u.is_admin AS is_grafana_admin,
+  u.email AS email,
+  u.email_verified AS email_verified,
+  u.login AS login,
+  u.name AS name,
+  u.is_disabled AS is_disabled,
+  u.help_flags1 AS help_flags1,
+  u.last_seen_at AS last_seen_at,
+  org.name AS org_name,
+  org_user.role AS org_role,
+  org.id AS org_id,
+  u.is_service_account AS is_service_account
+FROM "test_schema"."user" AS u
+LEFT OUTER JOIN "test_schema"."org_user" AS org_user
+  ON org_user.org_id = u.org_id
+  AND org_user.user_id = u.id
+LEFT OUTER JOIN "test_schema"."org" AS org
+  ON org.id = org_user.org_id
+WHERE LOWER(u.login) = LOWER('alice')

--- a/pkg/services/user/userimpl/testdata/sqlite--get_user_by_id-user.sql
+++ b/pkg/services/user/userimpl/testdata/sqlite--get_user_by_id-user.sql
@@ -1,0 +1,4 @@
+SELECT *
+FROM "test_schema"."user"
+WHERE id = 42
+  AND is_service_account = FALSE

--- a/pkg/services/user/userimpl/testdata/sqlite--get_user_by_login_or_email-by_email.sql
+++ b/pkg/services/user/userimpl/testdata/sqlite--get_user_by_login_or_email-by_email.sql
@@ -1,0 +1,4 @@
+SELECT *
+FROM "test_schema"."user"
+WHERE is_service_account = FALSE
+  AND email = 'alice@example.com'

--- a/pkg/services/user/userimpl/testdata/sqlite--get_user_by_login_or_email-by_email.sql
+++ b/pkg/services/user/userimpl/testdata/sqlite--get_user_by_login_or_email-by_email.sql
@@ -1,4 +1,4 @@
 SELECT *
 FROM "test_schema"."user"
 WHERE is_service_account = FALSE
-  AND email = 'alice@example.com'
+  AND "email" = 'alice@example.com'

--- a/pkg/services/user/userimpl/testdata/sqlite--get_user_by_login_or_email-by_login.sql
+++ b/pkg/services/user/userimpl/testdata/sqlite--get_user_by_login_or_email-by_login.sql
@@ -1,0 +1,4 @@
+SELECT *
+FROM "test_schema"."user"
+WHERE is_service_account = FALSE
+  AND login = 'alice'

--- a/pkg/services/user/userimpl/testdata/sqlite--get_user_by_login_or_email-by_login.sql
+++ b/pkg/services/user/userimpl/testdata/sqlite--get_user_by_login_or_email-by_login.sql
@@ -1,4 +1,4 @@
 SELECT *
 FROM "test_schema"."user"
 WHERE is_service_account = FALSE
-  AND login = 'alice'
+  AND "login" = 'alice'

--- a/pkg/services/user/userimpl/testdata/sqlite--search_users-all_filters.sql
+++ b/pkg/services/user/userimpl/testdata/sqlite--search_users-all_filters.sql
@@ -29,7 +29,7 @@ AND (
   )
 AND u.is_disabled = TRUE
 AND user_auth.auth_module = 'oauth'
-AND user_stats.billing_role IN ('admin', 'editor')
+AND "user_stats"."billing_role" IN ('admin', 'editor')
 AND is_admin = TRUE
 ORDER BY
 u.login DESC, u.email ASC

--- a/pkg/services/user/userimpl/testdata/sqlite--search_users-all_filters.sql
+++ b/pkg/services/user/userimpl/testdata/sqlite--search_users-all_filters.sql
@@ -1,0 +1,36 @@
+SELECT
+  u.id,
+  u.uid,
+  u.email,
+  u.name,
+  u.login,
+  u.is_admin,
+  u.is_disabled,
+  u.last_seen_at,
+  user_auth.auth_module,
+  u.is_provisioned,
+  u.created
+FROM "test_schema"."user" AS u
+LEFT JOIN "test_schema"."user_auth" AS user_auth ON user_auth.id = (
+  SELECT id
+  FROM "test_schema"."user_auth" AS user_auth
+  WHERE user_auth.user_id = u.id
+  ORDER BY user_auth.created DESC
+  LIMIT 1
+)
+INNER JOIN "test_schema"."user_stats" AS "user_stats" ON user_stats.user_id = u.id
+WHERE u.is_service_account = FALSE
+AND u.org_id = 7
+AND u.id IN (11, 12)
+AND (
+    u.email LIKE '%ops%'
+    OR u.name LIKE '%ops%'
+    OR u.login LIKE '%ops%'
+  )
+AND u.is_disabled = TRUE
+AND user_auth.auth_module = 'oauth'
+AND user_stats.billing_role IN ('admin', 'editor')
+AND is_admin = TRUE
+ORDER BY
+u.login DESC, u.email ASC
+LIMIT 25 OFFSET 50

--- a/pkg/services/user/userimpl/testdata/sqlite--search_users-default.sql
+++ b/pkg/services/user/userimpl/testdata/sqlite--search_users-default.sql
@@ -1,0 +1,23 @@
+SELECT
+  u.id,
+  u.uid,
+  u.email,
+  u.name,
+  u.login,
+  u.is_admin,
+  u.is_disabled,
+  u.last_seen_at,
+  user_auth.auth_module,
+  u.is_provisioned,
+  u.created
+FROM "test_schema"."user" AS u
+LEFT JOIN "test_schema"."user_auth" AS user_auth ON user_auth.id = (
+  SELECT id
+  FROM "test_schema"."user_auth" AS user_auth
+  WHERE user_auth.user_id = u.id
+  ORDER BY user_auth.created DESC
+  LIMIT 1
+)
+WHERE u.is_service_account = FALSE
+ORDER BY
+u.login ASC, u.email ASC

--- a/pkg/services/user/userimpl/testdata/sqlite--search_users-empty_in.sql
+++ b/pkg/services/user/userimpl/testdata/sqlite--search_users-empty_in.sql
@@ -18,19 +18,7 @@ LEFT JOIN "test_schema"."user_auth" AS user_auth ON user_auth.id = (
   ORDER BY user_auth.created DESC
   LIMIT 1
 )
-INNER JOIN "test_schema"."user_stats" AS "user_stats" ON user_stats.user_id = u.id
 WHERE u.is_service_account = FALSE
-AND u.org_id = 7
-AND u.id IN (11, 12)
-AND (
-    u.email ILIKE '%ops%'
-    OR u.name ILIKE '%ops%'
-    OR u.login ILIKE '%ops%'
-  )
-AND u.is_disabled = TRUE
-AND user_auth.auth_module = 'oauth'
-AND "user_stats"."billing_role" IN ('admin', 'editor')
-AND is_admin = TRUE
+AND 0 = 1
 ORDER BY
-u.login DESC, u.email ASC
-LIMIT 25 OFFSET 50
+u.login ASC, u.email ASC

--- a/pkg/services/user/userimpl/testdata/sqlite--update_user-all_fields.sql
+++ b/pkg/services/user/userimpl/testdata/sqlite--update_user-all_fields.sql
@@ -1,0 +1,15 @@
+UPDATE "test_schema"."user"
+SET
+email = 'alice@example.com',
+name = 'Alice',
+login = 'alice',
+password = 'hashed-password',
+email_verified = TRUE,
+theme = 'dark',
+is_disabled = FALSE,
+is_admin = TRUE,
+org_id = 7,
+is_provisioned = FALSE,
+updated = '2026-01-02 03:04:05'
+WHERE id = 42
+  AND is_service_account = FALSE


### PR DESCRIPTION
## What changed

- Moves user store raw SQL and hybrid queries to embedded SQL templates.
- Uses qualified table names with Ident.
- Binds values with Arg and ArgList.
- Keeps the remaining fluent XORM queries unchanged.
- Adds MySQL, PostgreSQL, and SQLite SQL snapshots.

## Why

The user store must use the table names resolved for the current database context. Templates keep this qualification in one place and preserve the existing query behavior.

## Testing

- go test -count=1 ./pkg/services/user/userimpl
- go vet ./pkg/services/user/userimpl

This PR is stacked on the phase-1 user store branch.