### PR TITLE
Logs Panel: Make virtualization resilient to duplicated UIDs

### DIFF
--- a/public/app/features/logs/components/panel/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/panel/InfiniteScroll.tsx
@@ -306,7 +306,7 @@ export const InfiniteScroll = ({
     [infiniteLoaderState, logs, scrollElement]
   );
 
-  const getItemKey = useCallback((index: number) => (logs[index] ? logs[index].uid : index.toString()), [logs]);
+  const getItemKey = useCallback((index: number) => (logs[index] ? logs[index].uniqueKey : index.toString()), [logs]);
 
   const itemCount = logs.length && loadMore && infiniteLoaderState !== 'idle' ? logs.length + 1 : logs.length;
 

--- a/public/app/features/logs/components/panel/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/panel/InfiniteScroll.tsx
@@ -152,10 +152,10 @@ export const InfiniteScroll = ({
         return;
       }
       if (scrollDirection === ScrollDirection.Bottom) {
-        lastLogOfPage.current.push(logs[logs.length - 1].uniqueKey);
+        lastLogOfPage.current.push(logs[logs.length - 1].uid);
       } else {
         scrollToLogLineRef.current = logs[0];
-        lastLogOfPage.current.push(logs[0].uniqueKey);
+        lastLogOfPage.current.push(logs[0].uid);
       }
       // Snapshot the row count so the completion effect can tell whether new rows arrived.
       loadMoreCountRef.current = logs.length;
@@ -349,8 +349,8 @@ function getLogLineVariant(logs: LogListModel[], index: number, lastLogOfPage: s
     return undefined;
   }
   const prevLog = logs[index - 1];
-  for (const uniqueKey of lastLogOfPage) {
-    if (prevLog.uniqueKey === uniqueKey) {
+  for (const uid of lastLogOfPage) {
+    if (prevLog.uid === uid) {
       // First log of an infinite scrolling page
       return 'infinite-scroll';
     }

--- a/public/app/features/logs/components/panel/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/panel/InfiniteScroll.tsx
@@ -152,10 +152,10 @@ export const InfiniteScroll = ({
         return;
       }
       if (scrollDirection === ScrollDirection.Bottom) {
-        lastLogOfPage.current.push(logs[logs.length - 1].uid);
+        lastLogOfPage.current.push(logs[logs.length - 1].uniqueKey);
       } else {
         scrollToLogLineRef.current = logs[0];
-        lastLogOfPage.current.push(logs[0].uid);
+        lastLogOfPage.current.push(logs[0].uniqueKey);
       }
       // Snapshot the row count so the completion effect can tell whether new rows arrived.
       loadMoreCountRef.current = logs.length;
@@ -349,8 +349,8 @@ function getLogLineVariant(logs: LogListModel[], index: number, lastLogOfPage: s
     return undefined;
   }
   const prevLog = logs[index - 1];
-  for (const uid of lastLogOfPage) {
-    if (prevLog.uid === uid) {
+  for (const uniqueKey of lastLogOfPage) {
+    if (prevLog.uniqueKey === uniqueKey) {
       // First log of an infinite scrolling page
       return 'infinite-scroll';
     }

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -149,9 +149,9 @@ const LogLineComponent = memo(
       const calculatedHeight = typeof height === 'number' ? height : undefined;
       const actualHeight = getLogLineDOMHeight(logLineRef.current, calculatedHeight);
       if (actualHeight) {
-        onOverflow(index, log.uid, actualHeight);
+        onOverflow(index, log.uniqueKey, actualHeight);
       }
-    }, [height, index, intersection?.isIntersecting, log.uid, onOverflow]);
+    }, [height, index, intersection?.isIntersecting, log.uniqueKey, onOverflow]);
 
     useLayoutEffect(() => {
       handleLogLineResize();

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -186,7 +186,7 @@ const LogLineComponent = memo(
       } else {
         setCollapsed(log.collapsed ?? undefined);
       }
-    }, [log.uid, log.collapsed, wrapLogMessage]);
+    }, [log.uniqueKey, log.collapsed, wrapLogMessage]);
 
     const handleMouseOver = useCallback(() => onLogLineHover?.(log), [log, onLogLineHover]);
 
@@ -194,7 +194,7 @@ const LogLineComponent = memo(
       const newState = !collapsed;
       log.setCollapsedState(newState);
       setCollapsed(newState);
-      onOverflow?.(index, log.uid);
+      onOverflow?.(index, log.uniqueKey);
     }, [collapsed, index, log, onOverflow]);
 
     const handleClick = useCallback(

--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -345,12 +345,17 @@ export const LogLineContext = memo(
       () =>
         log instanceof LogListModel
           ? log
-          : new LogListModel(log, {
-              escape: false,
-              otelLogsFormattingEnabled,
-              timeZone,
-              wrapLogMessage,
-            }),
+          : // Standalone row, not part of a rendered array, so its uniqueKey's disambiguation index is irrelevant here.
+            new LogListModel(
+              log,
+              {
+                escape: false,
+                otelLogsFormattingEnabled,
+                timeZone,
+                wrapLogMessage,
+              },
+              0
+            ),
       [log, otelLogsFormattingEnabled, timeZone, wrapLogMessage]
     );
 

--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -345,8 +345,7 @@ export const LogLineContext = memo(
       () =>
         log instanceof LogListModel
           ? log
-          : // Standalone row, not part of a rendered array, so its uniqueKey's disambiguation index is irrelevant here.
-            new LogListModel(
+          : new LogListModel(
               log,
               {
                 escape: false,

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -446,10 +446,12 @@ const LogListComponent = ({
   );
 
   const handleScrollPosition = useCallback(
-    (log?: LogListModel) => {
-      const scrollToUID = log ? log.uid : permalinkedLogId;
+    (targetLog?: LogListModel) => {
+      const scrollToUID = targetLog ? targetLog.uniqueKey : permalinkedLogId;
       if (scrollToUID) {
-        const index = processedLogs.findIndex((log) => log.uid === scrollToUID);
+        const index = processedLogs.findIndex((log) =>
+          targetLog ? log.uniqueKey === scrollToUID : log.uid === scrollToUID
+        );
         if (index >= 0) {
           listRef.current?.scrollToItem(index, 'start');
           return;
@@ -473,7 +475,7 @@ const LogListComponent = ({
 
   const focusLogLine = useCallback(
     (log: LogListModel, align: Align = 'start') => {
-      const index = filteredLogs.findIndex((filteredLog) => filteredLog.uid === log.uid);
+      const index = filteredLogs.findIndex((filteredLog) => filteredLog.uniqueKey === log.uniqueKey);
       if (index >= 0) {
         debouncedScrollToItem(index, align);
       }

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -446,12 +446,10 @@ const LogListComponent = ({
   );
 
   const handleScrollPosition = useCallback(
-    (targetLog?: LogListModel) => {
-      const scrollToUID = targetLog ? targetLog.uniqueKey : permalinkedLogId;
+    (log?: LogListModel) => {
+      const scrollToUID = log ? log.uid : permalinkedLogId;
       if (scrollToUID) {
-        const index = processedLogs.findIndex((log) =>
-          targetLog ? log.uniqueKey === scrollToUID : log.uid === scrollToUID
-        );
+        const index = processedLogs.findIndex((log) => log.uid === scrollToUID);
         if (index >= 0) {
           listRef.current?.scrollToItem(index, 'start');
           return;

--- a/public/app/features/logs/components/panel/processing.test.ts
+++ b/public/app/features/logs/components/panel/processing.test.ts
@@ -102,7 +102,11 @@ describe('preProcessLogs', () => {
         entry: `35.191.12.195 - accounts.google.com:test@grafana.com [18/Mar/2025:08:58:38 +0000] 200 "POST /grafana/api/ds/query?ds_type=prometheus&requestId=SQR461 HTTP/1.1" 59460 "https://test.example.com/?orgId=1" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36" "95.91.240.90, 34.107.247.24"`,
         logLevel: LogLevel.critical,
       });
-      const logListModel = new LogListModel(logRowModel, { escape: false, timeZone: 'browser ', wrapLogMessage: true });
+      const logListModel = new LogListModel(
+        logRowModel,
+        { escape: false, timeZone: 'browser ', wrapLogMessage: true },
+        0
+      );
       expect(logListModel).toMatchObject(logRowModel);
     });
 

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -81,7 +81,9 @@ export class LogListModel implements LogRowModel {
       timeZone,
       virtualization,
       wrapLogMessage,
-    }: PreProcessLogOptions
+    }: PreProcessLogOptions,
+    // Position of this row within the array being processed.
+    index: number
   ) {
     // LogRowModel
     this.datasourceType = log.datasourceType;
@@ -106,7 +108,9 @@ export class LogListModel implements LogRowModel {
     this.timeLocal = log.timeLocal;
     this.timeUtc = log.timeUtc;
     this.uid = log.uid;
-    this.uniqueKey = `${log.uid}#${log.rowIndex}`;
+    // log.uid is not guaranteed unique, which causes troubles with virtualization. For that end, we create a trully unique
+    // identifier, while leaving the data source identifier unmodified
+    this.uniqueKey = `${log.uid}#${index}`;
     this.uniqueLabels = log.uniqueLabels;
 
     // LogListModel
@@ -320,17 +324,21 @@ export const preProcessLogs = (
   grammar?: Grammar
 ): LogListModel[] => {
   const orderedLogs = sortLogRows(logs, order);
-  return orderedLogs.map((log) =>
-    preProcessLog(log, {
-      escape,
-      getFieldLinks,
-      grammar,
-      otelLogsFormattingEnabled,
-      prettifyJSON,
-      timeZone,
-      virtualization,
-      wrapLogMessage,
-    })
+  return orderedLogs.map((log, index) =>
+    preProcessLog(
+      log,
+      {
+        escape,
+        getFieldLinks,
+        grammar,
+        otelLogsFormattingEnabled,
+        prettifyJSON,
+        timeZone,
+        virtualization,
+        wrapLogMessage,
+      },
+      index
+    )
   );
 };
 
@@ -344,8 +352,8 @@ interface PreProcessLogOptions {
   virtualization?: LogLineVirtualization;
   wrapLogMessage: boolean;
 }
-const preProcessLog = (log: LogRowModel, options: PreProcessLogOptions): LogListModel => {
-  return new LogListModel(log, options);
+const preProcessLog = (log: LogRowModel, options: PreProcessLogOptions, index: number): LogListModel => {
+  return new LogListModel(log, options, index);
 };
 
 function logLevelToDisplayLevel(level = '') {

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -108,7 +108,7 @@ export class LogListModel implements LogRowModel {
     this.timeLocal = log.timeLocal;
     this.timeUtc = log.timeUtc;
     this.uid = log.uid;
-    // log.uid is not guaranteed unique, which causes troubles with virtualization. For that end, we create a trully unique
+    // log.uid is not guaranteed unique, which causes troubles with virtualization. To that end, we create a truly unique
     // identifier, while leaving the data source identifier unmodified
     this.uniqueKey = `${log.uid}#${index}`;
     this.uniqueLabels = log.uniqueLabels;

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -52,6 +52,7 @@ export class LogListModel implements LogRowModel {
   timeLocal: string;
   timeUtc: string;
   uid: string;
+  readonly uniqueKey: string;
   uniqueLabels: Labels | undefined;
   uniqueLabelsExpanded = false;
 
@@ -105,6 +106,7 @@ export class LogListModel implements LogRowModel {
     this.timeLocal = log.timeLocal;
     this.timeUtc = log.timeUtc;
     this.uid = log.uid;
+    this.uniqueKey = `${log.uid}#${log.rowIndex}`;
     this.uniqueLabels = log.uniqueLabels;
 
     // LogListModel

--- a/public/app/features/logs/components/panel/virtualization.ts
+++ b/public/app/features/logs/components/panel/virtualization.ts
@@ -280,7 +280,7 @@ export function getLogLineSize(
     return virtualization.getLineHeight() + virtualization.getPaddingBottom();
   }
 
-  const storedSize = virtualization.retrieveLogLineSize(logs[index].uid, container);
+  const storedSize = virtualization.retrieveLogLineSize(logs[index].uniqueKey, container);
   if (storedSize) {
     return storedSize;
   }

--- a/public/app/plugins/panel/logstable/LogsTable.tsx
+++ b/public/app/plugins/panel/logstable/LogsTable.tsx
@@ -265,12 +265,16 @@ export const LogsTable = ({
   const logRows = useMemo(() => {
     const logs = rawTableFrame
       ? dataFrameToLogsModel([rawTableFrame], undefined, undefined, panelData.request?.targets, false).rows.map(
-          (logRow) =>
-            new LogListModel(logRow, {
-              escape: false,
-              timeZone,
-              wrapLogMessage: true,
-            })
+          (logRow, index) =>
+            new LogListModel(
+              logRow,
+              {
+                escape: false,
+                timeZone,
+                wrapLogMessage: true,
+              },
+              index
+            )
         )
       : null;
     return logs ?? [];


### PR DESCRIPTION
As described in the [Grafana Data Structure documentation](https://grafana.com/developers/dataplane/logs), logs are expected to optionally return a **unique** identifier for each log line. Given that this identifier was expected to be guaranteed to be unique within a result set, a large portion of the Logs Panel implementation, including but not only virtualization, relies on it.

But unfortunately, there are scenarios for different data sources (such as VictoriaLogs), where uids in a given result set will not be unique, resulting in rendered errors and other unexpected behaviors, which will be tracked by https://github.com/grafana/grafana/pull/130854, and will be addressed independently.

This particular PR aims to introduce an internal `uniqueKey`, which we can use for rendering and virtualization, preventing visualization issues, making the Logs Panel more resilient to bad data, even if it goes against the spec.

Before:

https://github.com/user-attachments/assets/71074b40-6872-432d-8068-d52249cb3d65

After:

https://github.com/user-attachments/assets/2a107070-929c-4359-9b7d-905ac0da84c6

Fixes https://github.com/grafana/grafana/issues/115385
