### PR TITLE
Alerting: Normalize scalar values in rule search filters

### DIFF
--- a/pkg/registry/apps/alerting/rules/search/query.go
+++ b/pkg/registry/apps/alerting/rules/search/query.go
@@ -22,7 +22,7 @@ import (
 // standard name/title/folder fields are included so identity and display fields
 // can be filtered too. A filter on any other field is rejected rather than
 // silently ignored, so a client learns its query targets an unindexed field.
-// Note: some entries here are further constrained by validateFilterLeaf (e.g.
+// Note: some entries here are further constrained by checkAndNormalizeFilterLeaf (e.g.
 // the legacy backend cannot yet filter every indexed field, see
 // legacyUnsupportedFilterFields).
 var filterableFields = map[string]struct{}{
@@ -232,7 +232,7 @@ func applyFilter(req *resourcepb.ResourceSearchRequest, leaf *model.CreateSearch
 	if err != nil {
 		return err
 	}
-	if err := validateFilterLeaf(leaf); err != nil {
+	if err := checkAndNormalizeFilterLeaf(leaf); err != nil {
 		return err
 	}
 
@@ -244,7 +244,7 @@ func applyFilter(req *resourcepb.ResourceSearchRequest, leaf *model.CreateSearch
 	}
 
 	if leaf.Field == fieldLabels {
-		// validateFilterLeaf holds labels to exactly one value (see scalarFields).
+		// checkAndNormalizeFilterLeaf holds labels to exactly one value (see scalarFields).
 		v := leaf.Values[0]
 		// The In/NotIn operator carries negation, so a "!"-prefixed value would
 		// double-negate. Reject it rather than resolve it ambiguously.
@@ -293,12 +293,15 @@ var legacyUnsupportedFilterFields = map[string]struct{}{
 	fieldAnnotations:   {},
 }
 
-// validateFilterLeaf rejects filter leaves the backend cannot faithfully apply,
-// so a client learns its query was not honored instead of getting wrong results
-// with a 200. Scalar fields must carry a single value; type must narrow to one
-// valid kind via In; paused must be a boolean; NotIn is only honored on labels;
-// and fields the legacy backend cannot filter are rejected outright.
-func validateFilterLeaf(leaf *model.CreateSearchRulesRequestSearchFilterLeaf) error {
+// checkAndNormalizeFilterLeaf rejects filter leaves the backend cannot faithfully
+// apply, so a client learns its query was not honored instead of getting wrong
+// results with a 200. Scalar fields must carry a single value; type must narrow to
+// one valid kind via In; paused must be a boolean; NotIn is only honored on
+// labels; and fields the legacy backend cannot filter are rejected outright.
+//
+// It also rewrites the values it parses into one spelling, because the two
+// backends parse them again themselves and do not agree on the accepted forms.
+func checkAndNormalizeFilterLeaf(leaf *model.CreateSearchRulesRequestSearchFilterLeaf) error {
 	if _, scalar := scalarFields[leaf.Field]; scalar && len(leaf.Values) != 1 {
 		return fmt.Errorf("filter on %q accepts exactly one value", leaf.Field)
 	}
@@ -323,13 +326,21 @@ func validateFilterLeaf(leaf *model.CreateSearchRulesRequestSearchFilterLeaf) er
 			return fmt.Errorf("invalid %q value %q: must be alertrule or recordingrule", fieldType, leaf.Values[0])
 		}
 	case fieldPaused:
-		if _, err := strconv.ParseBool(leaf.Values[0]); err != nil {
+		b, err := strconv.ParseBool(leaf.Values[0])
+		if err != nil {
 			return fmt.Errorf("invalid %q value %q: must be a boolean", fieldPaused, leaf.Values[0])
 		}
+		// "TRUE" and "1" are booleans to ParseBool, which the legacy backend also
+		// uses, but the unified index accepts only "true" and "false".
+		leaf.Values[0] = strconv.FormatBool(b)
 	case fieldPanelID:
-		if _, err := strconv.ParseInt(leaf.Values[0], 10, 64); err != nil {
+		n, err := strconv.ParseInt(leaf.Values[0], 10, 64)
+		if err != nil {
 			return fmt.Errorf("invalid %q value %q: must be an integer", fieldPanelID, leaf.Values[0])
 		}
+		// The legacy backend compares this as a string, so "+10" and "010" would
+		// match nothing there while the unified index reads them as 10.
+		leaf.Values[0] = strconv.FormatInt(n, 10)
 	}
 	return nil
 }

--- a/pkg/registry/apps/alerting/rules/search/query_test.go
+++ b/pkg/registry/apps/alerting/rules/search/query_test.go
@@ -351,6 +351,34 @@ func TestBuildSearchRequest_filterLeafValidation(t *testing.T) {
 	t.Run("paused accepts boolean", func(t *testing.T) {
 		require.NoError(t, build(filterLeaf(fieldPaused, opIn, "true")))
 	})
+
+	// Both backends parse these values again themselves and disagree on the forms
+	// they accept, so the request carries one spelling of each.
+	t.Run("scalar values are normalized", func(t *testing.T) {
+		for _, tc := range []struct {
+			field, value, want string
+		}{
+			{fieldPaused, "TRUE", "true"},
+			{fieldPaused, "True", "true"},
+			{fieldPaused, "1", "true"},
+			{fieldPaused, "t", "true"},
+			{fieldPaused, "0", "false"},
+			{fieldPanelID, "+10", "10"},
+			{fieldPanelID, "010", "10"},
+		} {
+			body := model.CreateSearchRulesRequestBody{Where: andNode(filterLeaf(tc.field, opIn, tc.value))}
+			req, _, err := buildSearchRequest(body, "default", alertrule.ResourceInfo.GroupResource(), nil)
+			require.NoError(t, err, "%s=%s", tc.field, tc.value)
+
+			var got []string
+			for _, r := range req.Options.Fields {
+				if r.Key == tc.field {
+					got = r.Values
+				}
+			}
+			require.Equal(t, []string{tc.want}, got, "%s=%s", tc.field, tc.value)
+		}
+	})
 	t.Run("type rejects NotIn", func(t *testing.T) {
 		require.Error(t, build(filterLeaf(fieldType, model.CreateSearchRulesRequestSearchFilterLeafOperatorNotIn, "alertrule")))
 	})


### PR DESCRIPTION
A rule search filter on `paused` or `panelID` is validated by parsing the value, then forwarded exactly as the caller wrote it. One handler serves both the legacy and the unified backend, and each parses the value again itself — without agreeing on the accepted forms.

```
paused=TRUE   legacy uses ParseBool and accepts it; the unified index takes only "true"/"false"
panelID=010   the unified index reads 10; legacy compares as a string and matches nothing
```

So the same query returns different results depending on which backend serves it, with a 200 either way.

Both values are now rewritten to one spelling right after they are parsed, so the two backends answer the same query the same way. `validateFilterLeaf` became `checkAndNormalizeFilterLeaf`, since it no longer only inspects the leaf.

No change to what is accepted or rejected — only to what is forwarded.

The `panelID` half is independent of the boolean one and predates the numeric filter work; happy to split it out if you'd rather review it separately.
