### PR TITLE
CI: Upload fonts with the frontend preview build

### DIFF
--- a/.github/workflows/deploy-frontend-preview.yml
+++ b/.github/workflows/deploy-frontend-preview.yml
@@ -137,7 +137,10 @@ jobs:
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: frontend-preview-build
-          path: public/build
+          # Both paths share public/ as their root inside the artifact
+          path: |
+            public/build
+            public/fonts
           retention-days: 1
 
   deploy:
@@ -168,7 +171,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: frontend-preview-build
-          path: public/build
+          path: public
 
       # The deploy name is the folder users put in the preview assets cookie.
       # It must match the backend's validation: alphanumeric and underscores
@@ -199,6 +202,17 @@ jobs:
           parent: false
           # The action's default ACL is rejected by the bucket's uniform
           # bucket-level access. Public read comes from an IAM binding instead.
+          predefinedAcl: ""
+
+      - name: Upload fonts
+        uses: grafana/shared-workflows/actions/push-to-gcs@main
+        with:
+          environment: dev
+          bucket: ${{ env.BUCKET_NAME }}
+          bucket_path: ${{ steps.deploy-name.outputs.deploy-name }}/public/fonts
+          path: public/fonts
+          service_account: github-gf-frontend-preview-dev@grafanalabs-workload-identity.iam.gserviceaccount.com
+          parent: false
           predefinedAcl: ""
 
       - name: Upload manifests to switch the preview to this build


### PR DESCRIPTION
Fonts did not load in the frontend preview. The app requests them from the preview bucket, but they were never uploaded.

`getFontStyles` builds font URLs from `window.__grafana_public_path__`, which points at the preview bucket. Webpack copies `img`, `maps` and `gazetteer` into `public/build`, but not `public/fonts`. The workflow only uploaded `public/build`, so every font request returned 404 and the preview used a system font. The icon fonts worked, because SCSS references them with a relative `url()` and webpack emits them into the build.

The build job now puts `public/fonts` in the artifact next to `public/build`, and the deploy job uploads it to `<deploy-name>/public/fonts`. The manifests still upload last.

Not verified with a real deploy yet. I will run `/deploy-to-fs` on this PR and confirm that `Inter-Regular.woff2` returns 200.

The asymmetry in the webpack copy list is worth a separate fix: fonts could live in the build like the other assets. That moves font URLs for every Grafana deployment, so it does not belong here.

See design doc for more info: https://docs.google.com/document/d/1fwfoCOxXSDd5nGYVAR2ZsioBBgSRs1CxjdVXpCbwUI8/edit
