### PR TITLE
Search API: Accept numeric and boolean filters, and the range leaf

### DIFF
--- a/pkg/apis/search/v0alpha1/types.go
+++ b/pkg/apis/search/v0alpha1/types.go
@@ -31,9 +31,9 @@ const (
 //
 // All node types are modelled so the schema is future-proof, but v1 only
 // accepts a narrow subset (top-level single leaf or a single and of leaves;
-// text and filter leaves; In/NotIn filter operators). Everything else is
-// rejected with 422 Unprocessable Entity by the validation layer. range and
-// exists are sketched for future versions and always rejected today.
+// text, filter and range leaves; In/NotIn filter operators). Everything else is
+// rejected with 422 Unprocessable Entity by the validation layer. exists is
+// sketched for a future version and always rejected today.
 //
 // +k8s:deepcopy-gen=true
 type WhereNode struct {
@@ -45,7 +45,7 @@ type WhereNode struct {
 	// Leaves.
 	Text   *TextPredicate   `json:"text,omitempty"`
 	Filter *FilterPredicate `json:"filter,omitempty"`
-	Range  *RangePredicate  `json:"range,omitempty"`  // future, rejected in v1
+	Range  *RangePredicate  `json:"range,omitempty"`
 	Exists *ExistsPredicate `json:"exists,omitempty"` // future, rejected in v1
 }
 
@@ -62,6 +62,12 @@ type TextPredicate struct {
 }
 
 // FilterPredicate is an exact / set-based predicate against a single field.
+// Values are strings whatever the field's declared type, so a boolean field
+// takes "true" or "false" and a numeric field takes the number written out.
+//
+// Numbers are held as float64, so only integers up to 2^53 are compared exactly.
+// Past that, values a whole number apart share one representation, and a filter
+// can both match a neighbour and miss the value asked for.
 //
 // +k8s:deepcopy-gen=true
 type FilterPredicate struct {
@@ -71,8 +77,14 @@ type FilterPredicate struct {
 	Values   []string `json:"values"`
 }
 
-// RangePredicate is a future numeric/date range predicate. Modelled for schema
-// stability; always rejected in v1.
+// RangePredicate compares a numeric field against one or two bounds. At least
+// one bound is required, gt cannot be combined with gte, and lt cannot be
+// combined with lte. Boolean and string fields are rejected: only numbers have
+// the order a range asks about. On an integer field a bound must be whole.
+//
+// Bounds are held as float64, so only integers up to 2^53 are compared exactly.
+// Past that, values a whole number apart share one representation, and a bound
+// can both admit a neighbour and exclude the value asked for.
 //
 // +k8s:deepcopy-gen=true
 type RangePredicate struct {

--- a/pkg/apis/search/v0alpha1/types.go
+++ b/pkg/apis/search/v0alpha1/types.go
@@ -31,9 +31,9 @@ const (
 //
 // All node types are modelled so the schema is future-proof, but v1 only
 // accepts a narrow subset (top-level single leaf or a single and of leaves;
-// text and filter leaves; In/NotIn filter operators). Everything else is
-// rejected with 422 Unprocessable Entity by the validation layer. range and
-// exists are sketched for future versions and always rejected today.
+// text, filter and range leaves; In/NotIn filter operators). Everything else is
+// rejected with 422 Unprocessable Entity by the validation layer. exists is
+// sketched for a future version and always rejected today.
 //
 // +k8s:deepcopy-gen=true
 type WhereNode struct {
@@ -45,7 +45,7 @@ type WhereNode struct {
 	// Leaves.
 	Text   *TextPredicate   `json:"text,omitempty"`
 	Filter *FilterPredicate `json:"filter,omitempty"`
-	Range  *RangePredicate  `json:"range,omitempty"`  // future, rejected in v1
+	Range  *RangePredicate  `json:"range,omitempty"`
 	Exists *ExistsPredicate `json:"exists,omitempty"` // future, rejected in v1
 }
 
@@ -62,6 +62,8 @@ type TextPredicate struct {
 }
 
 // FilterPredicate is an exact / set-based predicate against a single field.
+// Values are strings whatever the field's declared type, so a boolean field
+// takes "true" or "false" and a numeric field takes the number written out.
 //
 // +k8s:deepcopy-gen=true
 type FilterPredicate struct {
@@ -71,8 +73,10 @@ type FilterPredicate struct {
 	Values   []string `json:"values"`
 }
 
-// RangePredicate is a future numeric/date range predicate. Modelled for schema
-// stability; always rejected in v1.
+// RangePredicate compares a numeric field against one or two bounds. At least
+// one bound is required, gt cannot be combined with gte, and lt cannot be
+// combined with lte. Boolean and string fields are rejected: only numbers have
+// the order a range asks about. On an integer field a bound must be whole.
 //
 // +k8s:deepcopy-gen=true
 type RangePredicate struct {

--- a/pkg/apis/search/v0alpha1/zz_generated.openapi.go
+++ b/pkg/apis/search/v0alpha1/zz_generated.openapi.go
@@ -85,7 +85,7 @@ func schema_pkg_apis_search_v0alpha1_FilterPredicate(ref common.ReferenceCallbac
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "FilterPredicate is an exact / set-based predicate against a single field.",
+				Description: "FilterPredicate is an exact / set-based predicate against a single field. Values are strings whatever the field's declared type, so a boolean field takes \"true\" or \"false\" and a numeric field takes the number written out.\n\nNumbers are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a filter can both match a neighbour and miss the value asked for.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"field": {
@@ -128,7 +128,7 @@ func schema_pkg_apis_search_v0alpha1_RangePredicate(ref common.ReferenceCallback
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "RangePredicate is a future numeric/date range predicate. Modelled for schema stability; always rejected in v1.",
+				Description: "RangePredicate compares a numeric field against one or two bounds. At least one bound is required, gt cannot be combined with gte, and lt cannot be combined with lte. Boolean and string fields are rejected: only numbers have the order a range asks about. On an integer field a bound must be whole.\n\nBounds are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a bound can both admit a neighbour and exclude the value asked for.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"field": {
@@ -651,7 +651,7 @@ func schema_pkg_apis_search_v0alpha1_WhereNode(ref common.ReferenceCallback) com
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text and filter leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. range and exists are sketched for future versions and always rejected today.",
+				Description: "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"and": {
@@ -704,8 +704,7 @@ func schema_pkg_apis_search_v0alpha1_WhereNode(ref common.ReferenceCallback) com
 					},
 					"exists": {
 						SchemaProps: spec.SchemaProps{
-							Description: "future, rejected in v1",
-							Ref:         ref("github.com/grafana/grafana/pkg/apis/search/v0alpha1.ExistsPredicate"),
+							Ref: ref("github.com/grafana/grafana/pkg/apis/search/v0alpha1.ExistsPredicate"),
 						},
 					},
 				},

--- a/pkg/apis/search/v0alpha1/zz_generated.openapi.go
+++ b/pkg/apis/search/v0alpha1/zz_generated.openapi.go
@@ -85,7 +85,7 @@ func schema_pkg_apis_search_v0alpha1_FilterPredicate(ref common.ReferenceCallbac
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "FilterPredicate is an exact / set-based predicate against a single field.",
+				Description: "FilterPredicate is an exact / set-based predicate against a single field. Values are strings whatever the field's declared type, so a boolean field takes \"true\" or \"false\" and a numeric field takes the number written out.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"field": {
@@ -128,7 +128,7 @@ func schema_pkg_apis_search_v0alpha1_RangePredicate(ref common.ReferenceCallback
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "RangePredicate is a future numeric/date range predicate. Modelled for schema stability; always rejected in v1.",
+				Description: "RangePredicate compares a numeric field against one or two bounds. At least one bound is required, gt cannot be combined with gte, and lt cannot be combined with lte. Boolean and string fields are rejected: only numbers have the order a range asks about. On an integer field a bound must be whole.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"field": {
@@ -651,7 +651,7 @@ func schema_pkg_apis_search_v0alpha1_WhereNode(ref common.ReferenceCallback) com
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text and filter leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. range and exists are sketched for future versions and always rejected today.",
+				Description: "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"and": {
@@ -704,8 +704,7 @@ func schema_pkg_apis_search_v0alpha1_WhereNode(ref common.ReferenceCallback) com
 					},
 					"exists": {
 						SchemaProps: spec.SchemaProps{
-							Description: "future, rejected in v1",
-							Ref:         ref("github.com/grafana/grafana/pkg/apis/search/v0alpha1.ExistsPredicate"),
+							Ref: ref("github.com/grafana/grafana/pkg/apis/search/v0alpha1.ExistsPredicate"),
 						},
 					},
 				},

--- a/pkg/registry/apis/search/translate.go
+++ b/pkg/registry/apis/search/translate.go
@@ -8,13 +8,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	searchv0 "github.com/grafana/grafana/pkg/apis/search/v0alpha1"
@@ -202,8 +205,8 @@ func validateWhere(where *searchv0.WhereNode, fs *fieldSet, p *field.Path) ([]se
 				errs = append(errs, cerr)
 				continue
 			}
-			if ck != "text" && ck != "filter" {
-				errs = append(errs, field.Invalid(cp, ck, "only text and filter leaves are allowed inside and in v1"))
+			if ck != "text" && ck != "filter" && ck != "range" {
+				errs = append(errs, field.Invalid(cp, ck, "only text, filter and range leaves are allowed inside and in v1"))
 				continue
 			}
 			// A second text leaf would overwrite the backend Query, so v1 rejects it.
@@ -218,10 +221,10 @@ func validateWhere(where *searchv0.WhereNode, fs *fieldSet, p *field.Path) ([]se
 			leaves = append(leaves, child)
 		}
 		return leaves, errs
-	case "text", "filter":
+	case "text", "filter", "range":
 		return []searchv0.WhereNode{*where}, validateLeaf(where, key, fs, p)
 	default:
-		// or, not, range, exists: modelled for the future, rejected in v1.
+		// or, not, exists: modelled for the future, rejected in v1.
 		return nil, field.ErrorList{field.Invalid(p, key, fmt.Sprintf("%q is not supported in v1", key))}
 	}
 }
@@ -255,7 +258,7 @@ func singleKey(n *searchv0.WhereNode, p *field.Path) (string, *field.Error) {
 	case 1:
 		return set[0], nil
 	case 0:
-		return "", field.Invalid(p, "{}", "node must set exactly one of: and, or, not, text, filter")
+		return "", field.Invalid(p, "{}", "node must set exactly one of: and, or, not, text, filter, range")
 	default:
 		return "", field.Invalid(p, strings.Join(set, ", "), "node must set exactly one key")
 	}
@@ -293,11 +296,17 @@ func validateLeaf(n *searchv0.WhereNode, key string, fs *fieldSet, p *field.Path
 		} else {
 			capErrs := checkCapability(fs, f.Field, resource.SearchCapabilityFilter, fp.Child("field"))
 			errs = append(errs, capErrs...)
-			// v1 filters are string-only (scalar or string array); numeric/boolean
-			// filters need the future range leaf.
 			if len(capErrs) == 0 {
-				if def := fs.byName[f.Field]; def.Type != resource.SearchFieldTypeString {
-					errs = append(errs, field.Invalid(fp.Child("field"), f.Field, "v1 filters support string fields only"))
+				def := fs.byName[f.Field]
+				if !filterableFieldType(def.Type) {
+					errs = append(errs, field.Invalid(fp.Child("field"), f.Field, "v1 filters support string, numeric and boolean fields only"))
+				}
+				// Caught here so the caller gets a field path, instead of a 400 from the
+				// search server.
+				for i, v := range f.Values {
+					if err := checkFilterValue(def.Type, v); err != nil {
+						errs = append(errs, field.Invalid(fp.Child("values").Index(i), v, err.Error()))
+					}
 				}
 			}
 		}
@@ -315,10 +324,130 @@ func validateLeaf(n *searchv0.WhereNode, key string, fs *fieldSet, p *field.Path
 				errs = append(errs, field.Invalid(fp.Child("values").Index(i), v, "wildcard values are not allowed"))
 			}
 		}
+	case "range":
+		errs = append(errs, validateRangeLeaf(n.Range, fs, p.Child("range"))...)
 	}
 	return errs
 }
 
+func validateRangeLeaf(r *searchv0.RangePredicate, fs *fieldSet, p *field.Path) field.ErrorList {
+	errs := field.ErrorList{}
+	bounds := rangeBounds(r)
+	if r.Field == "" {
+		errs = append(errs, field.Required(p.Child("field"), "range field is required"))
+	} else {
+		capErrs := checkCapability(fs, r.Field, resource.SearchCapabilityFilter, p.Child("field"))
+		errs = append(errs, capErrs...)
+		if len(capErrs) == 0 {
+			def := fs.byName[r.Field]
+			// Only numbers have the order a range asks about. A boolean carries the
+			// filter capability too, which is why this is checked separately.
+			if !numericFieldType(def.Type) {
+				errs = append(errs, field.Invalid(p.Child("field"), r.Field, "range supports numeric fields only"))
+			} else if def.Type == resource.SearchFieldTypeInt64 {
+				for _, b := range bounds {
+					if err := checkIntegerBound(b.value); err != nil {
+						errs = append(errs, field.Invalid(p.Child(b.jsonField), b.value, err.Error()))
+					}
+				}
+			}
+		}
+	}
+	if len(bounds) == 0 {
+		errs = append(errs, field.Required(p, "at least one of gt, gte, lt, lte is required"))
+	}
+	// Two bounds on the same side are either redundant or contradictory, and which
+	// one wins would not be obvious.
+	if r.GT != nil && r.GTE != nil {
+		errs = append(errs, field.Invalid(p, "gt, gte", "gt and gte cannot be combined"))
+	}
+	if r.LT != nil && r.LTE != nil {
+		errs = append(errs, field.Invalid(p, "lt, lte", "lt and lte cannot be combined"))
+	}
+	return errs
+}
+
+// rangeBound carries both the name the request used and the operator the backend
+// wants, so neither has to be derived from the other.
+type rangeBound struct {
+	jsonField string
+	operator  string
+	value     float64
+}
+
+// Fixed order, so both the errors and the translated request come out the same
+// way every time.
+func rangeBounds(r *searchv0.RangePredicate) []rangeBound {
+	var out []rangeBound
+	for _, b := range []struct {
+		jsonField string
+		operator  string
+		value     *float64
+	}{
+		{"gt", string(selection.GreaterThan), r.GT},
+		{"gte", string(resource.OperatorGreaterThanOrEqual), r.GTE},
+		{"lt", string(selection.LessThan), r.LT},
+		{"lte", string(resource.OperatorLessThanOrEqual), r.LTE},
+	} {
+		if b.value != nil {
+			out = append(out, rangeBound{jsonField: b.jsonField, operator: b.operator, value: *b.value})
+		}
+	}
+	return out
+}
+
+// date is absent because the backend has not settled on a value format for it.
+func filterableFieldType(t resource.SearchFieldType) bool {
+	return t == resource.SearchFieldTypeString || t == resource.SearchFieldTypeBoolean || numericFieldType(t)
+}
+
+func numericFieldType(t resource.SearchFieldType) bool {
+	return t == resource.SearchFieldTypeInt64 || t == resource.SearchFieldTypeDouble
+}
+
+// Values travel as strings whatever the field's type, so this is the only place
+// the two meet.
+func checkFilterValue(t resource.SearchFieldType, value string) error {
+	switch t {
+	case resource.SearchFieldTypeBoolean:
+		// Only the two canonical spellings, matching the backend.
+		if value != "true" && value != "false" {
+			return errors.New(`must be "true" or "false"`)
+		}
+	case resource.SearchFieldTypeInt64:
+		if _, err := strconv.ParseInt(value, 10, 64); err != nil {
+			return errors.New("must be an integer")
+		}
+	case resource.SearchFieldTypeDouble:
+		f, err := strconv.ParseFloat(value, 64)
+		if err != nil || math.IsNaN(f) || math.IsInf(f, 0) {
+			return errors.New("must be a finite number")
+		}
+	default:
+		// A string holds any value. The types with no filter support at all are
+		// refused by filterableFieldType before this runs.
+	}
+	return nil
+}
+
+// Bounds arrive as float64, so the limits are too. Both are powers of two and
+// exact, unlike math.MaxInt64, which rounds up to 2^63 and would let it through.
+const (
+	int64LowerBound float64 = -1 << 63 // inclusive, and a valid int64
+	int64UpperBound float64 = 1 << 63  // exclusive: one past the largest int64
+)
+
+// The schema types every bound as a number, so an integer field has to refuse the
+// fractional ones itself.
+func checkIntegerBound(bound float64) error {
+	if bound != math.Trunc(bound) {
+		return errors.New("must be a whole number on an integer field")
+	}
+	if bound < int64LowerBound || bound >= int64UpperBound {
+		return errors.New("is out of range for an integer field")
+	}
+	return nil
+}
 func validateSort(sorts []searchv0.SortField, fs *fieldSet, p *field.Path) field.ErrorList {
 	errs := field.ErrorList{}
 	for i, s := range sorts {
@@ -437,6 +566,8 @@ func applyLeaves(req *resourcepb.ResourceSearchRequest, leaves []searchv0.WhereN
 			applyText(req, n.Text)
 		case n.Filter != nil:
 			req.Options.Fields = append(req.Options.Fields, filterRequirement(n.Filter))
+		case n.Range != nil:
+			req.Options.Fields = append(req.Options.Fields, rangeRequirements(n.Range)...)
 		}
 	}
 }
@@ -464,6 +595,31 @@ func filterRequirement(f *searchv0.FilterPredicate) *resourcepb.Requirement {
 		op = "notin"
 	}
 	return &resourcepb.Requirement{Key: f.Field, Operator: op, Values: f.Values}
+}
+
+// Each bound becomes its own requirement, which the backend ANDs together like
+// any other pair of field filters.
+func rangeRequirements(r *searchv0.RangePredicate) []*resourcepb.Requirement {
+	bounds := rangeBounds(r)
+	out := make([]*resourcepb.Requirement, 0, len(bounds))
+	for _, b := range bounds {
+		out = append(out, &resourcepb.Requirement{
+			Key:      r.Field,
+			Operator: b.operator,
+			Values:   []string{formatBound(b.value)},
+		})
+	}
+	return out
+}
+
+// FormatFloat's shortest form is not the value it was given: the lowest int64
+// comes out as -9223372036854776000, which the backend cannot parse. A whole
+// bound is written exactly instead.
+func formatBound(bound float64) string {
+	if bound == math.Trunc(bound) && bound >= int64LowerBound && bound < int64UpperBound {
+		return strconv.FormatInt(int64(bound), 10)
+	}
+	return strconv.FormatFloat(bound, 'f', -1, 64)
 }
 
 // applyLabelSelector lowers the selector onto Options.Labels. The backend now

--- a/pkg/registry/apis/search/translate.go
+++ b/pkg/registry/apis/search/translate.go
@@ -8,13 +8,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	searchv0 "github.com/grafana/grafana/pkg/apis/search/v0alpha1"
@@ -202,8 +205,8 @@ func validateWhere(where *searchv0.WhereNode, fs *fieldSet, p *field.Path) ([]se
 				errs = append(errs, cerr)
 				continue
 			}
-			if ck != "text" && ck != "filter" {
-				errs = append(errs, field.Invalid(cp, ck, "only text and filter leaves are allowed inside and in v1"))
+			if ck != "text" && ck != "filter" && ck != "range" {
+				errs = append(errs, field.Invalid(cp, ck, "only text, filter and range leaves are allowed inside and in v1"))
 				continue
 			}
 			// A second text leaf would overwrite the backend Query, so v1 rejects it.
@@ -218,10 +221,10 @@ func validateWhere(where *searchv0.WhereNode, fs *fieldSet, p *field.Path) ([]se
 			leaves = append(leaves, child)
 		}
 		return leaves, errs
-	case "text", "filter":
+	case "text", "filter", "range":
 		return []searchv0.WhereNode{*where}, validateLeaf(where, key, fs, p)
 	default:
-		// or, not, range, exists: modelled for the future, rejected in v1.
+		// or, not, exists: modelled for the future, rejected in v1.
 		return nil, field.ErrorList{field.Invalid(p, key, fmt.Sprintf("%q is not supported in v1", key))}
 	}
 }
@@ -255,7 +258,7 @@ func singleKey(n *searchv0.WhereNode, p *field.Path) (string, *field.Error) {
 	case 1:
 		return set[0], nil
 	case 0:
-		return "", field.Invalid(p, "{}", "node must set exactly one of: and, or, not, text, filter")
+		return "", field.Invalid(p, "{}", "node must set exactly one of: and, or, not, text, filter, range")
 	default:
 		return "", field.Invalid(p, strings.Join(set, ", "), "node must set exactly one key")
 	}
@@ -293,11 +296,17 @@ func validateLeaf(n *searchv0.WhereNode, key string, fs *fieldSet, p *field.Path
 		} else {
 			capErrs := checkCapability(fs, f.Field, resource.SearchCapabilityFilter, fp.Child("field"))
 			errs = append(errs, capErrs...)
-			// v1 filters are string-only (scalar or string array); numeric/boolean
-			// filters need the future range leaf.
 			if len(capErrs) == 0 {
-				if def := fs.byName[f.Field]; def.Type != resource.SearchFieldTypeString {
-					errs = append(errs, field.Invalid(fp.Child("field"), f.Field, "v1 filters support string fields only"))
+				def := fs.byName[f.Field]
+				if !filterableFieldType(def.Type) {
+					errs = append(errs, field.Invalid(fp.Child("field"), f.Field, "v1 filters support string, numeric and boolean fields only"))
+				}
+				// Caught here so the caller gets a field path, instead of a 400 from the
+				// search server.
+				for i, v := range f.Values {
+					if err := checkFilterValue(def.Type, v); err != nil {
+						errs = append(errs, field.Invalid(fp.Child("values").Index(i), v, err.Error()))
+					}
 				}
 			}
 		}
@@ -315,10 +324,129 @@ func validateLeaf(n *searchv0.WhereNode, key string, fs *fieldSet, p *field.Path
 				errs = append(errs, field.Invalid(fp.Child("values").Index(i), v, "wildcard values are not allowed"))
 			}
 		}
+	case "range":
+		errs = append(errs, validateRangeLeaf(n.Range, fs, p.Child("range"))...)
 	}
 	return errs
 }
 
+func validateRangeLeaf(r *searchv0.RangePredicate, fs *fieldSet, p *field.Path) field.ErrorList {
+	errs := field.ErrorList{}
+	if r.Field == "" {
+		errs = append(errs, field.Required(p.Child("field"), "range field is required"))
+	} else {
+		capErrs := checkCapability(fs, r.Field, resource.SearchCapabilityFilter, p.Child("field"))
+		errs = append(errs, capErrs...)
+		if len(capErrs) == 0 {
+			def := fs.byName[r.Field]
+			// Only numbers have the order a range asks about. A boolean carries the
+			// filter capability too, which is why this is checked separately.
+			if !numericFieldType(def.Type) {
+				errs = append(errs, field.Invalid(p.Child("field"), r.Field, "range supports numeric fields only"))
+			} else if def.Type == resource.SearchFieldTypeInt64 {
+				for _, b := range rangeBounds(r) {
+					if err := checkIntegerBound(b.value); err != nil {
+						errs = append(errs, field.Invalid(p.Child(b.jsonField), b.value, err.Error()))
+					}
+				}
+			}
+		}
+	}
+	if len(rangeBounds(r)) == 0 {
+		errs = append(errs, field.Required(p, "at least one of gt, gte, lt, lte is required"))
+	}
+	// Two bounds on the same side are either redundant or contradictory, and which
+	// one wins would not be obvious.
+	if r.GT != nil && r.GTE != nil {
+		errs = append(errs, field.Invalid(p, "gt, gte", "gt and gte cannot be combined"))
+	}
+	if r.LT != nil && r.LTE != nil {
+		errs = append(errs, field.Invalid(p, "lt, lte", "lt and lte cannot be combined"))
+	}
+	return errs
+}
+
+// rangeBound carries both the name the request used and the operator the backend
+// wants, so neither has to be derived from the other.
+type rangeBound struct {
+	jsonField string
+	operator  string
+	value     float64
+}
+
+// Fixed order, so both the errors and the translated request come out the same
+// way every time.
+func rangeBounds(r *searchv0.RangePredicate) []rangeBound {
+	var out []rangeBound
+	for _, b := range []struct {
+		jsonField string
+		operator  string
+		value     *float64
+	}{
+		{"gt", string(selection.GreaterThan), r.GT},
+		{"gte", string(resource.OperatorGreaterThanOrEqual), r.GTE},
+		{"lt", string(selection.LessThan), r.LT},
+		{"lte", string(resource.OperatorLessThanOrEqual), r.LTE},
+	} {
+		if b.value != nil {
+			out = append(out, rangeBound{jsonField: b.jsonField, operator: b.operator, value: *b.value})
+		}
+	}
+	return out
+}
+
+// date is absent because the backend has not settled on a value format for it.
+func filterableFieldType(t resource.SearchFieldType) bool {
+	return t == resource.SearchFieldTypeString || t == resource.SearchFieldTypeBoolean || numericFieldType(t)
+}
+
+func numericFieldType(t resource.SearchFieldType) bool {
+	return t == resource.SearchFieldTypeInt64 || t == resource.SearchFieldTypeDouble
+}
+
+// Values travel as strings whatever the field's type, so this is the only place
+// the two meet.
+func checkFilterValue(t resource.SearchFieldType, value string) error {
+	switch t {
+	case resource.SearchFieldTypeBoolean:
+		// Only the two canonical spellings, matching the backend.
+		if value != "true" && value != "false" {
+			return errors.New(`must be "true" or "false"`)
+		}
+	case resource.SearchFieldTypeInt64:
+		if _, err := strconv.ParseInt(value, 10, 64); err != nil {
+			return errors.New("must be an integer")
+		}
+	case resource.SearchFieldTypeDouble:
+		f, err := strconv.ParseFloat(value, 64)
+		if err != nil || math.IsNaN(f) || math.IsInf(f, 0) {
+			return errors.New("must be a finite number")
+		}
+	default:
+		// A string holds any value. The types with no filter support at all are
+		// refused by filterableFieldType before this runs.
+	}
+	return nil
+}
+
+// Bounds arrive as float64, so the limits are too. Both are powers of two and
+// exact, unlike math.MaxInt64, which rounds up to 2^63 and would let it through.
+const (
+	int64LowerBound float64 = -1 << 63 // inclusive, and a valid int64
+	int64UpperBound float64 = 1 << 63  // exclusive: one past the largest int64
+)
+
+// The schema types every bound as a number, so an integer field has to refuse the
+// fractional ones itself.
+func checkIntegerBound(bound float64) error {
+	if bound != math.Trunc(bound) {
+		return errors.New("must be a whole number on an integer field")
+	}
+	if bound < int64LowerBound || bound >= int64UpperBound {
+		return errors.New("is out of range for an integer field")
+	}
+	return nil
+}
 func validateSort(sorts []searchv0.SortField, fs *fieldSet, p *field.Path) field.ErrorList {
 	errs := field.ErrorList{}
 	for i, s := range sorts {
@@ -437,6 +565,8 @@ func applyLeaves(req *resourcepb.ResourceSearchRequest, leaves []searchv0.WhereN
 			applyText(req, n.Text)
 		case n.Filter != nil:
 			req.Options.Fields = append(req.Options.Fields, filterRequirement(n.Filter))
+		case n.Range != nil:
+			req.Options.Fields = append(req.Options.Fields, rangeRequirements(n.Range)...)
 		}
 	}
 }
@@ -464,6 +594,31 @@ func filterRequirement(f *searchv0.FilterPredicate) *resourcepb.Requirement {
 		op = "notin"
 	}
 	return &resourcepb.Requirement{Key: f.Field, Operator: op, Values: f.Values}
+}
+
+// Each bound becomes its own requirement, which the backend ANDs together like
+// any other pair of field filters.
+func rangeRequirements(r *searchv0.RangePredicate) []*resourcepb.Requirement {
+	bounds := rangeBounds(r)
+	out := make([]*resourcepb.Requirement, 0, len(bounds))
+	for _, b := range bounds {
+		out = append(out, &resourcepb.Requirement{
+			Key:      r.Field,
+			Operator: b.operator,
+			Values:   []string{formatBound(b.value)},
+		})
+	}
+	return out
+}
+
+// FormatFloat's shortest form is not the value it was given: the lowest int64
+// comes out as -9223372036854776000, which the backend cannot parse. A whole
+// bound is written exactly instead.
+func formatBound(bound float64) string {
+	if bound == math.Trunc(bound) && bound >= int64LowerBound && bound < int64UpperBound {
+		return strconv.FormatInt(int64(bound), 10)
+	}
+	return strconv.FormatFloat(bound, 'f', -1, 64)
 }
 
 // applyLabelSelector lowers the selector onto Options.Labels. The backend now

--- a/pkg/registry/apis/search/translate_test.go
+++ b/pkg/registry/apis/search/translate_test.go
@@ -2,6 +2,8 @@ package search
 
 import (
 	"encoding/base64"
+	"math"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -51,10 +53,21 @@ func testProvider() resource.SearchFieldsProvider {
 			Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilityRetrieve},
 		},
 		{
-			// non-string but sortable (shaped like alert-rule "panelID").
+			// non-string, filterable and sortable (shaped like alert-rule "panelID").
 			Name:         "panel_id",
 			Type:         resource.SearchFieldTypeInt64,
-			Capabilities: []resource.SearchCapability{resource.SearchCapabilitySort, resource.SearchCapabilityRetrieve},
+			Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilitySort, resource.SearchCapabilityRetrieve},
+		},
+		{
+			Name:         "ratio",
+			Type:         resource.SearchFieldTypeDouble,
+			Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilityRetrieve},
+		},
+		{
+			// numeric without the filter capability, so a range on it is refused.
+			Name:         "weight",
+			Type:         resource.SearchFieldTypeInt64,
+			Capabilities: []resource.SearchCapability{resource.SearchCapabilityRetrieve},
 		},
 		{
 			// string array with sort capability: exercises the Array half of the
@@ -291,11 +304,87 @@ func TestTranslateSearchQuery_ValidationErrors(t *testing.T) {
 			wantField: "sort[0].field",
 		},
 		{
-			name: "filter on non-string field",
+			// Membership of an empty set is not the same as no filter at all, which is
+			// what the backend would read it as.
+			name: "filter with no values",
 			mutate: func(q *searchv0.SearchQuery) {
-				q.Where = &searchv0.WhereNode{Filter: &searchv0.FilterPredicate{Field: "paused", Operator: "In", Values: []string{"true"}}}
+				q.Where = &searchv0.WhereNode{Filter: &searchv0.FilterPredicate{Field: "folder", Operator: "In"}}
 			},
-			wantField: "where.filter.field",
+			wantField: "where.filter.values",
+		},
+		{
+			name: "filter on a boolean field with a value that is not true or false",
+			mutate: func(q *searchv0.SearchQuery) {
+				q.Where = &searchv0.WhereNode{Filter: &searchv0.FilterPredicate{Field: "paused", Operator: "In", Values: []string{"yes"}}}
+			},
+			wantField: "where.filter.values[0]",
+		},
+		{
+			name: "filter on an integer field with a value that is not a number",
+			mutate: func(q *searchv0.SearchQuery) {
+				q.Where = &searchv0.WhereNode{Filter: &searchv0.FilterPredicate{Field: "panel_id", Operator: "In", Values: []string{"ten"}}}
+			},
+			wantField: "where.filter.values[0]",
+		},
+		{
+			name: "range without a bound",
+			mutate: func(q *searchv0.SearchQuery) {
+				q.Where = &searchv0.WhereNode{Range: &searchv0.RangePredicate{Field: "panel_id"}}
+			},
+			wantField: "where.range",
+		},
+		{
+			name: "range with both gt and gte",
+			mutate: func(q *searchv0.SearchQuery) {
+				q.Where = &searchv0.WhereNode{Range: &searchv0.RangePredicate{Field: "panel_id", GT: new(1.0), GTE: new(2.0)}}
+			},
+			wantField: "where.range",
+		},
+		{
+			name: "range on a boolean field",
+			mutate: func(q *searchv0.SearchQuery) {
+				q.Where = &searchv0.WhereNode{Range: &searchv0.RangePredicate{Field: "paused", GT: new(1.0)}}
+			},
+			wantField: "where.range.field",
+		},
+		{
+			name: "range on a string field",
+			mutate: func(q *searchv0.SearchQuery) {
+				q.Where = &searchv0.WhereNode{Range: &searchv0.RangePredicate{Field: "folder", GT: new(1.0)}}
+			},
+			wantField: "where.range.field",
+		},
+		{
+			name: "range on a field that cannot be filtered",
+			mutate: func(q *searchv0.SearchQuery) {
+				q.Where = &searchv0.WhereNode{Range: &searchv0.RangePredicate{Field: "weight", GT: new(1.0)}}
+			},
+			wantField: "where.range.field",
+		},
+		{
+			// The schema types every bound as a number, so an integer field has to
+			// refuse the fractional ones itself.
+			name: "fractional bound on an integer field",
+			mutate: func(q *searchv0.SearchQuery) {
+				q.Where = &searchv0.WhereNode{Range: &searchv0.RangePredicate{Field: "panel_id", GT: new(1.5)}}
+			},
+			wantField: "where.range.gt",
+		},
+		{
+			// float64 rounds MaxInt64 up to 2^63, so refusing it here beats a 400 from
+			// the search server.
+			name: "integer bound at the edge of what an int64 holds",
+			mutate: func(q *searchv0.SearchQuery) {
+				q.Where = &searchv0.WhereNode{Range: &searchv0.RangePredicate{Field: "panel_id", LT: new(float64(math.MaxInt64))}}
+			},
+			wantField: "where.range.lt",
+		},
+		{
+			name: "unknown field in a range",
+			mutate: func(q *searchv0.SearchQuery) {
+				q.Where = &searchv0.WhereNode{Range: &searchv0.RangePredicate{Field: "nope", GT: new(1.0)}}
+			},
+			wantField: "where.range.field",
 		},
 		{
 			name: "whitespace-only text value",
@@ -502,4 +591,138 @@ func TestTranslateSearchQuery_ContinueToken(t *testing.T) {
 	req, errs := TranslateSearchQuery(q, dashboardsGVR, "default", testProvider())
 	require.Empty(t, errs)
 	assert.Equal(t, []string{"cursor-value"}, req.SearchAfter)
+}
+
+// Boolean and numeric filters reach the backend as the strings it parses back,
+// so the two sides have to agree on the spelling.
+func TestTranslateSearchQuery_FilterOnNumberAndBooleanFields(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		filter   searchv0.FilterPredicate
+		operator string
+		values   []string
+	}{
+		{"boolean", searchv0.FilterPredicate{Field: "paused", Operator: "In", Values: []string{"true"}}, "in", []string{"true"}},
+		{"boolean excluded", searchv0.FilterPredicate{Field: "paused", Operator: "NotIn", Values: []string{"false"}}, "notin", []string{"false"}},
+		{"integer set", searchv0.FilterPredicate{Field: "panel_id", Operator: "In", Values: []string{"10", "20"}}, "in", []string{"10", "20"}},
+		{"double", searchv0.FilterPredicate{Field: "ratio", Operator: "In", Values: []string{"0.5"}}, "in", []string{"0.5"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			q := searchQuery(nil)
+			q.Where = &searchv0.WhereNode{Filter: &tc.filter}
+			req, errs := TranslateSearchQuery(q, dashboardsGVR, "default", testProvider())
+			require.Empty(t, errs)
+			require.Len(t, req.Options.Fields, 1)
+			assert.Equal(t, tc.filter.Field, req.Options.Fields[0].Key)
+			assert.Equal(t, tc.operator, req.Options.Fields[0].Operator)
+			assert.Equal(t, tc.values, req.Options.Fields[0].Values)
+		})
+	}
+}
+
+// Each bound becomes its own requirement, which the backend ANDs together like
+// any other pair of field filters.
+func TestTranslateSearchQuery_RangeLeaf(t *testing.T) {
+	q := searchQuery(nil)
+	q.Where = &searchv0.WhereNode{Range: &searchv0.RangePredicate{Field: "panel_id", GTE: new(10.0), LT: new(20.0)}}
+	req, errs := TranslateSearchQuery(q, dashboardsGVR, "default", testProvider())
+	require.Empty(t, errs)
+	require.Len(t, req.Options.Fields, 2)
+	// Bounds come out in a fixed order.
+	assert.Equal(t, "gte", req.Options.Fields[0].Operator)
+	assert.Equal(t, []string{"10"}, req.Options.Fields[0].Values, "a whole bound carries no decimal point, so an integer field accepts it")
+	assert.Equal(t, "lt", req.Options.Fields[1].Operator)
+	assert.Equal(t, []string{"20"}, req.Options.Fields[1].Values)
+	for _, r := range req.Options.Fields {
+		assert.Equal(t, "panel_id", r.Key)
+	}
+}
+
+func TestTranslateSearchQuery_RangeOnDoubleKeepsFraction(t *testing.T) {
+	q := searchQuery(nil)
+	q.Where = &searchv0.WhereNode{Range: &searchv0.RangePredicate{Field: "ratio", GT: new(0.25)}}
+	req, errs := TranslateSearchQuery(q, dashboardsGVR, "default", testProvider())
+	require.Empty(t, errs)
+	require.Len(t, req.Options.Fields, 1)
+	assert.Equal(t, "gt", req.Options.Fields[0].Operator)
+	assert.Equal(t, []string{"0.25"}, req.Options.Fields[0].Values)
+}
+
+// A range next to a text leaf and a filter leaf, which is how the alert rule
+// list view asks its question.
+func TestTranslateSearchQuery_RangeInsideAnd(t *testing.T) {
+	q := searchQuery(nil)
+	q.Where = &searchv0.WhereNode{And: []searchv0.WhereNode{
+		{Text: &searchv0.TextPredicate{Value: "cpu"}},
+		{Filter: &searchv0.FilterPredicate{Field: "paused", Operator: "In", Values: []string{"false"}}},
+		{Range: &searchv0.RangePredicate{Field: "panel_id", GT: new(5.0)}},
+	}}
+	req, errs := TranslateSearchQuery(q, dashboardsGVR, "default", testProvider())
+	require.Empty(t, errs)
+	assert.Equal(t, "cpu", req.Query)
+	require.Len(t, req.Options.Fields, 2)
+	assert.Equal(t, "paused", req.Options.Fields[0].Key)
+	assert.Equal(t, "panel_id", req.Options.Fields[1].Key)
+	assert.Equal(t, "gt", req.Options.Fields[1].Operator)
+}
+
+// The high end of the int64 range is not exact as a float64, so both edges are
+// worth pinning.
+func TestTranslateSearchQuery_IntegerBoundEdges(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		bound  float64
+		accept bool
+	}{
+		{"lowest int64", math.MinInt64, true},
+		{"below the lowest int64", -math.Exp2(63) - 2048, false},
+		{"highest whole float below 2^63", math.Exp2(63) - 1024, true},
+		{"MaxInt64, which float64 rounds up to 2^63", math.MaxInt64, false},
+		{"above int64", math.Exp2(64), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			q := searchQuery(nil)
+			q.Where = &searchv0.WhereNode{Range: &searchv0.RangePredicate{Field: "panel_id", LT: &tc.bound}}
+			_, errs := TranslateSearchQuery(q, dashboardsGVR, "default", testProvider())
+			if tc.accept {
+				require.Empty(t, errs)
+				return
+			}
+			require.Len(t, errs, 1)
+			assert.Equal(t, "where.range.lt", errs[0].Field)
+		})
+	}
+}
+
+// At the extremes FormatFloat's shortest form is neither parseable by the backend
+// nor the number the caller sent.
+func TestTranslateSearchQuery_BoundValuesSurviveTheHandover(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		field string
+		bound float64
+		want  string
+	}{
+		{"lowest int64", "panel_id", math.MinInt64, "-9223372036854775808"},
+		{"largest float64 below 2^63", "panel_id", math.Exp2(63) - 1024, "9223372036854774784"},
+		{"a value past 2^53", "panel_id", math.Exp2(53) + 2, "9007199254740994"},
+		{"a small integer", "panel_id", 10, "10"},
+		{"a whole bound on a double field", "ratio", 3, "3"},
+		{"a fraction on a double field", "ratio", 0.25, "0.25"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			q := searchQuery(nil)
+			q.Where = &searchv0.WhereNode{Range: &searchv0.RangePredicate{Field: tc.field, GTE: &tc.bound}}
+			req, errs := TranslateSearchQuery(q, dashboardsGVR, "default", testProvider())
+			require.Empty(t, errs)
+			require.Len(t, req.Options.Fields, 1)
+			require.Equal(t, []string{tc.want}, req.Options.Fields[0].Values)
+
+			// A value ParseInt rejects would be a 400 the API layer should have caught.
+			if tc.field == "panel_id" {
+				_, err := strconv.ParseInt(tc.want, 10, 64)
+				require.NoError(t, err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
A filter leaf on a field declared `boolean`, `int64` or `double` was refused with "v1 filters support string fields only". The search server can now answer those, so the endpoint accepts them and checks each value against the field's declared type:

```
paused  = "yes"  ->  422  where.filter.values[0]: must be "true" or "false"
panelID = "ten"  ->  422  where.filter.values[0]: must be an integer
```

Catching it here names the offending value, rather than surfacing a 400 from the search server.

The `range` leaf was modelled in the types but always rejected. It is now accepted on numeric fields, standalone or inside `and`, with each bound lowered to its own requirement so the backend ANDs them together:

```json
{"range": {"field": "panelID", "gte": 10, "lt": 20}}
```

becomes `panelID gte ["10"]` and `panelID lt ["20"]`.

Rejected: no bounds at all, `gt` with `gte`, `lt` with `lte`, a range on a boolean or string field, and a field without the `filter` capability. Bounds are typed as numbers by the schema, so an integer field also refuses a fractional bound rather than forwarding a value the backend would reject.

`date` fields stay unsupported on both sides until the value format is settled.

Part of grafana/search-and-storage-team#928 (steps 4 and 5).

