### PR TITLE
Navigation: Rename "AI & machine learning" nav label to "Machine learning"

### DIFF
--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -156,7 +156,7 @@ export function getNavTitle(navId: string | undefined) {
     case 'plugin-page-grafana-incident-app':
       return t('nav.incidents.title', 'Incident');
     case 'plugin-page-grafana-ml-app':
-      return t('nav.machine-learning.title', 'AI & machine learning');
+      return t('nav.machine-learning.title', 'Machine learning');
     case 'plugin-page-grafana-slo-app':
       return t('nav.slo.title', 'SLO');
     case 'plugin-page-k6-app':

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12468,7 +12468,7 @@
     },
     "machine-learning": {
       "subtitle": "Explore AI and machine learning features",
-      "title": "AI & machine learning"
+      "title": "Machine learning"
     },
     "manage-folder": {
       "subtitle": "Manage folder dashboards and permissions"


### PR DESCRIPTION
**Background**
<img width="1321" height="967" alt="Screenshot 2026-08-17 at 12 57 10 PM" src="https://github.com/user-attachments/assets/8ac560be-c76e-475a-94b5-27f583c6a2b8" />


Renames the Grafana Machine Learning app's nav label from "AI & machine learning" to "Machine learning".

The backend nav config in `pkg/services/navtree/navtreeimpl/applinks.go` already says `Text: "Machine Learning"` — the string users actually see comes from the frontend i18n override in `navBarItem-translations.ts`, which is what this PR changes (plus the matching `en-US` locale entry). Frontend-only, so it can ship independently of the backend.

**Why do we need this feature?**

Follow-up to #130825. That PR reverted the Assistant `AI` rename because "AI" collided with "AI & machine learning" in the nav. Dropping the "AI &" prefix clears the conflict so the Assistant rename can land.

It also matches what we already call the product in the docs — [Grafana Machine Learning](https://grafana.com/docs/grafana-cloud/ai-tools/dynamic-alerting/#grafana-machine-learning).

**Who is this feature for?**

All Grafana Cloud users with the `grafana-ml-app` plugin installed.

**Which issue(s) does this PR fix?**:

Unblocks the Assistant nav rename reverted in #130825.

**Special notes for your reviewer:**

- Sentence-cased "Machine learning" to match the rest of the nav ("Library panels", "Saved queries", "Recently deleted", "Alert activity"). Note this leaves it differing from the title-cased `Text: "Machine Learning"` in `applinks.go` — the frontend override wins, so there's no user-visible impact, but worth a separate backend PR to align if reviewers want.
- Only the title changed. The subtitle is still "Explore AI and machine learning features" — happy to reword that too.
- Non-`en-US` locales are Crowdin-managed and intentionally untouched.
