### PR TITLE
Provisioning: Add GOFF for OAuth connections

### DIFF
--- a/pkg/registry/apis/provisioning/oauth_connections_test.go
+++ b/pkg/registry/apis/provisioning/oauth_connections_test.go
@@ -8,7 +8,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
-	"github.com/grafana/grafana/apps/provisioning/pkg/connection"
 )
 
 func TestValidateOAuthConnectionsEnabled(t *testing.T) {
@@ -20,11 +19,7 @@ func TestValidateOAuthConnectionsEnabled(t *testing.T) {
 	oauthConnection.Name = "oauth-connection"
 
 	t.Run("rejects OAuth connections when disabled", func(t *testing.T) {
-		builder := &APIBuilder{
-			oauthConnectionsEnabled: func(context.Context) bool { return false },
-		}
-
-		err := builder.validateOAuthConnectionsEnabled(t.Context(), oauthConnection)
+		err := validateOAuthConnectionsEnabled(t.Context(), oauthConnection, func(context.Context) bool { return false })
 
 		require.Error(t, err)
 		require.True(t, apierrors.IsForbidden(err))
@@ -32,59 +27,16 @@ func TestValidateOAuthConnectionsEnabled(t *testing.T) {
 	})
 
 	t.Run("allows OAuth connections when enabled", func(t *testing.T) {
-		builder := &APIBuilder{
-			oauthConnectionsEnabled: func(context.Context) bool { return true },
-		}
-
-		require.NoError(t, builder.validateOAuthConnectionsEnabled(t.Context(), oauthConnection))
+		require.NoError(t, validateOAuthConnectionsEnabled(t.Context(), oauthConnection, func(context.Context) bool { return true }))
 	})
 
 	t.Run("allows non-OAuth connections when disabled", func(t *testing.T) {
-		builder := &APIBuilder{
-			oauthConnectionsEnabled: func(context.Context) bool { return false },
-		}
 		githubConnection := &provisioning.Connection{
 			Spec: provisioning.ConnectionSpec{
 				Type: provisioning.GithubConnectionType,
 			},
 		}
 
-		require.NoError(t, builder.validateOAuthConnectionsEnabled(t.Context(), githubConnection))
-	})
-}
-
-func TestOAuthFeatureGatedConnectionFactory(t *testing.T) {
-	oauthConnection := &provisioning.Connection{
-		Spec: provisioning.ConnectionSpec{
-			OAuth: &provisioning.ConnectionOAuthConfig{},
-		},
-	}
-	oauthConnection.Name = "oauth-connection"
-
-	t.Run("does not build OAuth connections when disabled", func(t *testing.T) {
-		factory := connection.NewMockFactory(t)
-		gated := &oauthFeatureGatedConnectionFactory{
-			Factory: factory,
-			enabled: func(context.Context) bool { return false },
-		}
-
-		built, err := gated.Build(t.Context(), oauthConnection)
-
-		require.Nil(t, built)
-		require.True(t, apierrors.IsForbidden(err))
-	})
-
-	t.Run("does not delegate validation for OAuth connections when disabled", func(t *testing.T) {
-		factory := connection.NewMockFactory(t)
-		gated := &oauthFeatureGatedConnectionFactory{
-			Factory: factory,
-			enabled: func(context.Context) bool { return false },
-		}
-
-		errs := gated.Validate(t.Context(), oauthConnection)
-
-		require.Len(t, errs, 1)
-		require.Equal(t, "spec.oauth", errs[0].Field)
-		require.Contains(t, errs[0].Detail, "provisioning.oauthConnections")
+		require.NoError(t, validateOAuthConnectionsEnabled(t.Context(), githubConnection, func(context.Context) bool { return false }))
 	})
 }

--- a/pkg/registry/apis/provisioning/oauth_connections_test.go
+++ b/pkg/registry/apis/provisioning/oauth_connections_test.go
@@ -1,0 +1,90 @@
+package provisioning
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/apps/provisioning/pkg/connection"
+)
+
+func TestValidateOAuthConnectionsEnabled(t *testing.T) {
+	oauthConnection := &provisioning.Connection{
+		Spec: provisioning.ConnectionSpec{
+			OAuth: &provisioning.ConnectionOAuthConfig{},
+		},
+	}
+	oauthConnection.Name = "oauth-connection"
+
+	t.Run("rejects OAuth connections when disabled", func(t *testing.T) {
+		builder := &APIBuilder{
+			oauthConnectionsEnabled: func(context.Context) bool { return false },
+		}
+
+		err := builder.validateOAuthConnectionsEnabled(t.Context(), oauthConnection)
+
+		require.Error(t, err)
+		require.True(t, apierrors.IsForbidden(err))
+		require.ErrorContains(t, err, "provisioning.oauthConnections")
+	})
+
+	t.Run("allows OAuth connections when enabled", func(t *testing.T) {
+		builder := &APIBuilder{
+			oauthConnectionsEnabled: func(context.Context) bool { return true },
+		}
+
+		require.NoError(t, builder.validateOAuthConnectionsEnabled(t.Context(), oauthConnection))
+	})
+
+	t.Run("allows non-OAuth connections when disabled", func(t *testing.T) {
+		builder := &APIBuilder{
+			oauthConnectionsEnabled: func(context.Context) bool { return false },
+		}
+		githubConnection := &provisioning.Connection{
+			Spec: provisioning.ConnectionSpec{
+				Type: provisioning.GithubConnectionType,
+			},
+		}
+
+		require.NoError(t, builder.validateOAuthConnectionsEnabled(t.Context(), githubConnection))
+	})
+}
+
+func TestOAuthFeatureGatedConnectionFactory(t *testing.T) {
+	oauthConnection := &provisioning.Connection{
+		Spec: provisioning.ConnectionSpec{
+			OAuth: &provisioning.ConnectionOAuthConfig{},
+		},
+	}
+	oauthConnection.Name = "oauth-connection"
+
+	t.Run("does not build OAuth connections when disabled", func(t *testing.T) {
+		factory := connection.NewMockFactory(t)
+		gated := &oauthFeatureGatedConnectionFactory{
+			Factory: factory,
+			enabled: func(context.Context) bool { return false },
+		}
+
+		built, err := gated.Build(t.Context(), oauthConnection)
+
+		require.Nil(t, built)
+		require.True(t, apierrors.IsForbidden(err))
+	})
+
+	t.Run("does not delegate validation for OAuth connections when disabled", func(t *testing.T) {
+		factory := connection.NewMockFactory(t)
+		gated := &oauthFeatureGatedConnectionFactory{
+			Factory: factory,
+			enabled: func(context.Context) bool { return false },
+		}
+
+		errs := gated.Validate(t.Context(), oauthConnection)
+
+		require.Len(t, errs, 1)
+		require.Equal(t, "spec.oauth", errs[0].Field)
+		require.Contains(t, errs[0].Detail, "provisioning.oauthConnections")
+	})
+}

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -156,6 +157,7 @@ type APIBuilder struct {
 	registry                      prometheus.Registerer
 	quotaGetter                   quotas.QuotaGetter
 	folderMetadataEnabled         bool
+	oauthConnectionsEnabled       func(context.Context) bool
 	maxFileSize                   int64
 	syncResourceTimeout           time.Duration
 	incrementalPolicy             repository.IncrementalSyncPolicy
@@ -255,7 +257,7 @@ func NewAPIBuilder(
 		usageStats:                          usageStats,
 		features:                            features,
 		repoFactory:                         repoFactory,
-		connectionFactory:                   connectionFactory,
+		connectionFactory:                   newOAuthFeatureGatedConnectionFactory(connectionFactory, oauthConnectionsEnabled),
 		clients:                             clients,
 		supportedResources:                  supportedResources,
 		parsers:                             parsers,
@@ -275,6 +277,7 @@ func NewAPIBuilder(
 		useExclusivelyAccessCheckerForAuthz: useExclusivelyAccessCheckerForAuthz,
 		quotaGetter:                         quotaGetter,
 		folderMetadataEnabled:               folderMetadataEnabled,
+		oauthConnectionsEnabled:             oauthConnectionsEnabled,
 		incrementalPolicy:                   incrementalPolicy,
 		// Per-file cap for the files API. Non-positive (<=0) disables the cap.
 		maxFileSize: maxFileSize,
@@ -958,6 +961,10 @@ func performanceEnabled(ctx context.Context) bool {
 	return openfeature.NewDefaultClient().Boolean(ctx, featuremgmt.FlagProvisioningPerformance, false, openfeature.TransactionContext(ctx))
 }
 
+func oauthConnectionsEnabled(ctx context.Context) bool {
+	return openfeature.NewDefaultClient().Boolean(ctx, featuremgmt.FlagProvisioningOauthConnections, false, openfeature.TransactionContext(ctx))
+}
+
 // Mutate delegates to the admission handler for resource-specific mutation
 func (b *APIBuilder) Mutate(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) error {
 	obj := a.GetObject()
@@ -971,6 +978,13 @@ func (b *APIBuilder) Mutate(ctx context.Context, a admission.Attributes, o admis
 
 // Validate delegates to the admission handler for resource-specific validation
 func (b *APIBuilder) Validate(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) (err error) {
+	if a.GetOperation() == admission.Create || a.GetOperation() == admission.Update {
+		if connection, ok := a.GetObject().(*provisioning.Connection); ok {
+			if err := b.validateOAuthConnectionsEnabled(ctx, connection); err != nil {
+				return err
+			}
+		}
+	}
 	return b.admissionHandler.Validate(ctx, a, o)
 }
 
@@ -1852,7 +1866,6 @@ func (b *APIBuilder) asConnection(ctx context.Context, obj runtime.Object, old r
 	if !ok {
 		return nil, fmt.Errorf("expected connection object")
 	}
-
 	// Copy previous values if they exist
 	if old != nil {
 		if oldConn, ok := old.(*provisioning.Connection); ok {
@@ -1861,6 +1874,48 @@ func (b *APIBuilder) asConnection(ctx context.Context, obj runtime.Object, old r
 	}
 
 	return b.connectionFactory.Build(ctx, c)
+}
+
+type oauthFeatureGatedConnectionFactory struct {
+	connection.Factory
+	enabled func(context.Context) bool
+}
+
+func newOAuthFeatureGatedConnectionFactory(factory connection.Factory, enabled func(context.Context) bool) connection.Factory {
+	return &oauthFeatureGatedConnectionFactory{Factory: factory, enabled: enabled}
+}
+
+func (f *oauthFeatureGatedConnectionFactory) Build(ctx context.Context, conn *provisioning.Connection) (connection.Connection, error) {
+	if err := validateOAuthConnectionsEnabled(ctx, conn, f.enabled); err != nil {
+		return nil, err
+	}
+	return f.Factory.Build(ctx, conn)
+}
+
+func (f *oauthFeatureGatedConnectionFactory) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
+	conn, ok := obj.(*provisioning.Connection)
+	if ok {
+		if err := validateOAuthConnectionsEnabled(ctx, conn, f.enabled); err != nil {
+			return field.ErrorList{field.Forbidden(field.NewPath("spec", "oauth"), err.Error())}
+		}
+	}
+	return f.Factory.Validate(ctx, obj)
+}
+
+func (b *APIBuilder) validateOAuthConnectionsEnabled(ctx context.Context, connection *provisioning.Connection) error {
+	return validateOAuthConnectionsEnabled(ctx, connection, b.oauthConnectionsEnabled)
+}
+
+func validateOAuthConnectionsEnabled(ctx context.Context, connection *provisioning.Connection, enabled func(context.Context) bool) error {
+	if connection.Spec.OAuth == nil || enabled == nil || enabled(ctx) {
+		return nil
+	}
+
+	return apierrors.NewForbidden(
+		provisioning.ConnectionResourceInfo.GroupResource(),
+		connection.GetName(),
+		fmt.Errorf("OAuth connections require the %s feature flag", featuremgmt.FlagProvisioningOauthConnections),
+	)
 }
 
 func getJSONResponse(ref string) *spec3.Responses {

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -157,7 +156,6 @@ type APIBuilder struct {
 	registry                      prometheus.Registerer
 	quotaGetter                   quotas.QuotaGetter
 	folderMetadataEnabled         bool
-	oauthConnectionsEnabled       func(context.Context) bool
 	maxFileSize                   int64
 	syncResourceTimeout           time.Duration
 	incrementalPolicy             repository.IncrementalSyncPolicy
@@ -257,7 +255,7 @@ func NewAPIBuilder(
 		usageStats:                          usageStats,
 		features:                            features,
 		repoFactory:                         repoFactory,
-		connectionFactory:                   newOAuthFeatureGatedConnectionFactory(connectionFactory, oauthConnectionsEnabled),
+		connectionFactory:                   connectionFactory,
 		clients:                             clients,
 		supportedResources:                  supportedResources,
 		parsers:                             parsers,
@@ -277,7 +275,6 @@ func NewAPIBuilder(
 		useExclusivelyAccessCheckerForAuthz: useExclusivelyAccessCheckerForAuthz,
 		quotaGetter:                         quotaGetter,
 		folderMetadataEnabled:               folderMetadataEnabled,
-		oauthConnectionsEnabled:             oauthConnectionsEnabled,
 		incrementalPolicy:                   incrementalPolicy,
 		// Per-file cap for the files API. Non-positive (<=0) disables the cap.
 		maxFileSize: maxFileSize,
@@ -980,7 +977,7 @@ func (b *APIBuilder) Mutate(ctx context.Context, a admission.Attributes, o admis
 func (b *APIBuilder) Validate(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) (err error) {
 	if a.GetOperation() == admission.Create || a.GetOperation() == admission.Update {
 		if connection, ok := a.GetObject().(*provisioning.Connection); ok {
-			if err := b.validateOAuthConnectionsEnabled(ctx, connection); err != nil {
+			if err := validateOAuthConnectionsEnabled(ctx, connection, oauthConnectionsEnabled); err != nil {
 				return err
 			}
 		}
@@ -1873,37 +1870,10 @@ func (b *APIBuilder) asConnection(ctx context.Context, obj runtime.Object, old r
 		}
 	}
 
-	return b.connectionFactory.Build(ctx, c)
-}
-
-type oauthFeatureGatedConnectionFactory struct {
-	connection.Factory
-	enabled func(context.Context) bool
-}
-
-func newOAuthFeatureGatedConnectionFactory(factory connection.Factory, enabled func(context.Context) bool) connection.Factory {
-	return &oauthFeatureGatedConnectionFactory{Factory: factory, enabled: enabled}
-}
-
-func (f *oauthFeatureGatedConnectionFactory) Build(ctx context.Context, conn *provisioning.Connection) (connection.Connection, error) {
-	if err := validateOAuthConnectionsEnabled(ctx, conn, f.enabled); err != nil {
+	if err := validateOAuthConnectionsEnabled(ctx, c, oauthConnectionsEnabled); err != nil {
 		return nil, err
 	}
-	return f.Factory.Build(ctx, conn)
-}
-
-func (f *oauthFeatureGatedConnectionFactory) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
-	conn, ok := obj.(*provisioning.Connection)
-	if ok {
-		if err := validateOAuthConnectionsEnabled(ctx, conn, f.enabled); err != nil {
-			return field.ErrorList{field.Forbidden(field.NewPath("spec", "oauth"), err.Error())}
-		}
-	}
-	return f.Factory.Validate(ctx, obj)
-}
-
-func (b *APIBuilder) validateOAuthConnectionsEnabled(ctx context.Context, connection *provisioning.Connection) error {
-	return validateOAuthConnectionsEnabled(ctx, connection, b.oauthConnectionsEnabled)
+	return b.connectionFactory.Build(ctx, c)
 }
 
 func validateOAuthConnectionsEnabled(ctx context.Context, connection *provisioning.Connection, enabled func(context.Context) bool) error {

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -287,6 +287,14 @@ var (
 			Generate:    Generate{Go: true},
 		},
 		{
+			Name:        "provisioning.oauthConnections",
+			Description: "Enables OAuth app connections for Git Sync provisioning",
+			Stage:       FeatureStageExperimental,
+			Owner:       grafanaAppPlatformSquad,
+			Expression:  "false",
+			Generate:    Generate{Go: true},
+		},
+		{
 			Name:        "awsAsyncQueryCaching",
 			Description: "Enable caching for async queries for Redshift and Athena. Requires that the data source has caching and async query support enabled",
 			Stage:       FeatureStageGeneralAvailability,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -31,6 +31,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-06-09,provisioning.gitConventions,preview,@grafana/grafana-app-platform-squad,false,true,false
 2026-07-08,provisioning.userAttribution,preview,@grafana/grafana-app-platform-squad,false,false,false
 2026-07-16,provisioning.performance,experimental,@grafana/grafana-app-platform-squad,false,false,false
+2026-08-17,provisioning.oauthConnections,experimental,@grafana/grafana-app-platform-squad,false,false,false
 2023-07-21,awsAsyncQueryCaching,GA,@grafana/data-sources-plugins,false,false,false
 2023-07-26,configurableSchedulerTick,experimental,@grafana/alerting-squad,false,true,false
 2026-05-22,reportingHeaderSettings,experimental,@grafana/grafana-operator-experience-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -99,6 +99,10 @@ const (
 	// Enables the synthetic 'test' provisioning job type for load and performance testing of the job queue and controllers
 	FlagProvisioningPerformance = "provisioning.performance"
 
+	// FlagProvisioningOauthConnections
+	// Enables OAuth app connections for Git Sync provisioning
+	FlagProvisioningOauthConnections = "provisioning.oauthConnections"
+
 	// FlagAwsAsyncQueryCaching
 	// Enable caching for async queries for Redshift and Athena. Requires that the data source has caching and async query support enabled
 	FlagAwsAsyncQueryCaching = "awsAsyncQueryCaching"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -5292,6 +5292,19 @@
     },
     {
       "metadata": {
+        "name": "provisioning.oauthConnections",
+        "resourceVersion": "1786982687758",
+        "creationTimestamp": "2026-08-17T16:04:47Z"
+      },
+      "spec": {
+        "description": "Enables OAuth app connections for Git Sync provisioning",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "provisioning.performance",
         "resourceVersion": "1784287498952",
         "creationTimestamp": "2026-07-16T08:21:47Z",

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -5271,6 +5271,19 @@
     },
     {
       "metadata": {
+        "name": "provisioning.oauthConnections",
+        "resourceVersion": "1786982687758",
+        "creationTimestamp": "2026-08-17T16:04:47Z"
+      },
+      "spec": {
+        "description": "Enables OAuth app connections for Git Sync provisioning",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "provisioning.performance",
         "resourceVersion": "1784287498952",
         "creationTimestamp": "2026-07-16T08:21:47Z",

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -1505,6 +1505,10 @@ func WithoutProvisioningFolderMetadata(opts *testinfra.GrafanaOpts) {
 	opts.DisableFeatureToggles = append(opts.DisableFeatureToggles, featuremgmt.FlagProvisioningFolderMetadata)
 }
 
+func WithOAuthConnections(opts *testinfra.GrafanaOpts) {
+	opts.EnableFeatureToggles = append(opts.EnableFeatureToggles, featuremgmt.FlagProvisioningOauthConnections)
+}
+
 func WithRepositoryTypes(types []string) GrafanaOption {
 	return func(opts *testinfra.GrafanaOpts) {
 		opts.ProvisioningRepositoryTypes = types


### PR DESCRIPTION
**What is this feature?**

Adds the experimental `provisioning.oauthConnections` feature toggle. When disabled, creating or updating OAuth connections is rejected and existing OAuth connections cannot be built for provisioning operations.

**Why do we need this feature?**

OAuth-based Git Sync connections need an explicit rollout gate.

**Who is this feature for?**

Grafana operators testing OAuth connections for Git Sync provisioning.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Sister enterprise PR: https://github.com/grafana/grafana-enterprise/pull/13205

Validated locally: the connections API returns `403 Forbidden` when the toggle is disabled.

_Description generated by Pi._