### PR TITLE
Alerting: Remove alertRuleRestore feature toggle

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -91,7 +91,6 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `timeComparison`                  | Enables time comparison option in supported panels                                               |
 | `secretsManagementAppPlatformUI`  | Enable the secrets management app platform UI                                                    |
 | `dashboardTemplates`              | Enables a flow to get started with a new dashboard from a template                               |
-| `alertRuleRestore`                | Enables the alert rule restore feature                                                           |
 | `azureMonitorLogsBuilderEditor`   | Enables the logs builder mode for the Azure Monitor data source                                  |
 | `alertingListViewV2PreviewToggle` | Enables the alerting list view v2 preview toggle                                                 |
 | `interactiveLearning`             | Enables the interactive learning app                                                             |

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -816,11 +816,6 @@ export interface FeatureToggles {
   */
   newShareReportDrawer?: boolean;
   /**
-  * Enables the alert rule restore feature
-  * @default true
-  */
-  alertRuleRestore?: boolean;
-  /**
   * Enables running Infinity queries in parallel
   * @default false
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1600,14 +1600,6 @@ var (
 			Expression:  "false",
 		},
 		{
-			Name:        "alertRuleRestore",
-			Description: "Enables the alert rule restore feature",
-			Stage:       FeatureStagePublicPreview,
-			Owner:       grafanaAlertingSquad,
-			Expression:  "true", // enabled by default
-			Generate:    Generate{LegacyGo: true, LegacyFrontend: true},
-		},
-		{
 			Name:        "infinityRunQueriesInParallel",
 			Description: "Enables running Infinity queries in parallel",
 			Stage:       FeatureStagePrivatePreview,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -185,7 +185,6 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2025-02-17,alertingRuleVersionHistoryRestore,GA,@grafana/alerting-squad,false,false,true
 2025-02-17,newShareReportDrawer,preview,@grafana/grafana-operator-experience-squad,false,false,false
 2026-05-22,grafana.assetSriChecks,experimental,@grafana/grafana-frontend-platform,false,false,false
-2025-03-05,alertRuleRestore,preview,@grafana/alerting-squad,false,false,false
 2025-03-14,infinityRunQueriesInParallel,privatePreview,@grafana/data-sources-plugins,false,false,false
 2025-03-14,alertingMigrationUI,GA,@grafana/alerting-squad,false,false,true
 2025-05-21,alertingImportYAMLUI,GA,@grafana/alerting-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -534,10 +534,6 @@ const (
 	// Enables SRI checks for Grafana JavaScript assets
 	FlagGrafanaAssetSriChecks = "grafana.assetSriChecks"
 
-	// FlagAlertRuleRestore
-	// Enables the alert rule restore feature
-	FlagAlertRuleRestore = "alertRuleRestore"
-
 	// FlagInfinityRunQueriesInParallel
 	// Enables running Infinity queries in parallel
 	FlagInfinityRunQueriesInParallel = "infinityRunQueriesInParallel"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -110,7 +110,8 @@
       "metadata": {
         "name": "alertRuleRestore",
         "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-03-05T14:15:26Z"
+        "creationTimestamp": "2025-03-05T14:15:26Z",
+        "deletionTimestamp": "2026-08-13T20:10:44Z"
       },
       "spec": {
         "description": "Enables the alert rule restore feature",

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -555,7 +555,7 @@ func (s *ServiceImpl) buildAlertNavLinks(c *contextmodel.ReqContext) *navtree.Na
 	}
 
 	//nolint:staticcheck // not yet migrated to OpenFeature
-	if c.GetOrgRole() == org.RoleAdmin && s.features.IsEnabled(c.Req.Context(), featuremgmt.FlagAlertRuleRestore) && s.features.IsEnabled(c.Req.Context(), featuremgmt.FlagAlertingRuleRecoverDeleted) {
+	if c.GetOrgRole() == org.RoleAdmin && s.features.IsEnabled(c.Req.Context(), featuremgmt.FlagAlertingRuleRecoverDeleted) {
 		// Only show as standalone item in legacy navigation (V2 shows it as a tab under Alert rules)
 		//nolint:staticcheck // not yet migrated to OpenFeature
 		if !s.features.IsEnabled(c.Req.Context(), featuremgmt.FlagAlertingNavigationV2) {

--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -264,10 +264,6 @@ func (srv RulerSrv) RouteGetRulesGroupConfig(c *contextmodel.ReqContext, namespa
 // RouteGetRulesConfig returns all alert rules that are available to the current user
 func (srv RulerSrv) RouteGetRulesConfig(c *contextmodel.ReqContext) response.Response {
 	if strings.ToLower(c.Query("deleted")) == "true" {
-		//nolint:staticcheck // not yet migrated to OpenFeature
-		if !srv.featureManager.IsEnabledGlobally(featuremgmt.FlagAlertRuleRestore) {
-			return ErrResp(http.StatusBadRequest, errors.New("restore of deleted rules is not enabled"), "")
-		}
 		if !c.HasRole(identity.RoleAdmin) {
 			return ErrResp(http.StatusForbidden, errors.New("only admins can get deleted rules"), "")
 		}

--- a/pkg/services/ngalert/api/api_ruler_test.go
+++ b/pkg/services/ngalert/api/api_ruler_test.go
@@ -827,7 +827,6 @@ func TestRouteGetRulesConfig(t *testing.T) {
 		}
 
 		svc := createService(ruleStore, nil)
-		svc.featureManager = featuremgmt.WithFeatures(featuremgmt.FlagAlertRuleRestore)
 
 		response := svc.RouteGetRulesConfig(req)
 		require.Equal(t, http.StatusOK, response.Status())

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -75,8 +75,7 @@ func (st DBstore) DeleteAlertRulesByUID(ctx context.Context, orgID int64, user *
 		logger.Debug("Deleted alert rule state", "count", rows)
 
 		var versions []alertRuleVersion
-		//nolint:staticcheck // not yet migrated to OpenFeature
-		if st.FeatureToggles.IsEnabledGlobally(featuremgmt.FlagAlertRuleRestore) && st.Cfg.DeletedRuleRetention > 0 && !permanently { // save deleted version only if retention is greater than 0
+		if st.Cfg.DeletedRuleRetention > 0 && !permanently { // save deleted version only if retention is greater than 0
 			versions, err = st.getLatestVersionOfRulesByUID(ctx, orgID, ruleUID)
 			if err != nil {
 				logger.Error("Failed to get latest version of deleted alert rules. The recovery will not be possible", "error", err)

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -717,7 +717,6 @@ func TestIntegration_DeleteAlertRulesByUID(t *testing.T) {
 		cfg.UnifiedAlerting.DeletedRuleRetention = 1000 * time.Hour
 
 		store := createTestStore(sqlStore, folderService, logger, cfg.UnifiedAlerting, b)
-		store.FeatureToggles = featuremgmt.WithFeatures(featuremgmt.FlagAlertRuleRestore)
 
 		result, err := store.InsertAlertRules(context.Background(), &models.AlertingUserUID, toInsertRules(gen.GenerateMany(3)))
 		uids := make([]string, 0, len(result))
@@ -784,7 +783,6 @@ func TestIntegration_DeleteAlertRulesByUID(t *testing.T) {
 		cfg.UnifiedAlerting.DeletedRuleRetention = 0
 
 		store := createTestStore(sqlStore, folderService, logger, cfg.UnifiedAlerting, b)
-		store.FeatureToggles = featuremgmt.WithFeatures(featuremgmt.FlagAlertRuleRestore)
 
 		result, err := store.InsertAlertRules(context.Background(), &models.AlertingUserUID, toInsertRules(gen.GenerateMany(3)))
 		uids := make([]string, 0, len(result))
@@ -837,7 +835,6 @@ func TestIntegration_DeleteAlertRulesByUID(t *testing.T) {
 		cfg.UnifiedAlerting.DeletedRuleRetention = 1000 * time.Hour
 
 		store := createTestStore(sqlStore, folderService, logger, cfg.UnifiedAlerting, b)
-		store.FeatureToggles = featuremgmt.WithFeatures(featuremgmt.FlagAlertRuleRestore)
 
 		result, err := store.InsertAlertRules(context.Background(), &models.AlertingUserUID, toInsertRules(gen.GenerateMany(3)))
 		uids := make([]string, 0, len(result))
@@ -3863,7 +3860,6 @@ func TestIntegration_ListDeletedRules(t *testing.T) {
 	folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())
 	b := &fakeBus{}
 	store := createTestStore(sqlStore, folderService, &logtest.Fake{}, cfg.UnifiedAlerting, b)
-	store.FeatureToggles = featuremgmt.WithFeatures(featuremgmt.FlagAlertRuleRestore)
 
 	oldT := TimeNow
 	t.Cleanup(func() {
@@ -3959,7 +3955,6 @@ func TestIntegration_CleanUpDeletedAlertRules(t *testing.T) {
 	folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())
 	logger := log.New("test-dbstore")
 	store := createTestStore(sqlStore, folderService, logger, cfg.UnifiedAlerting, &fakeBus{})
-	store.FeatureToggles = featuremgmt.WithFeatures(featuremgmt.FlagAlertRuleRestore)
 
 	gen := models.RuleGen
 	orgID := int64(rand.IntN(1000)) + 1

--- a/pkg/tests/api/alerting/api_ruler_test.go
+++ b/pkg/tests/api/alerting/api_ruler_test.go
@@ -4803,7 +4803,6 @@ func TestIntegrationRuleSoftDelete(t *testing.T) {
 		EnableQuota:           true,
 		DisableAnonymous:      true,
 		AppModeProduction:     true,
-		EnableFeatureToggles:  []string{featuremgmt.FlagAlertRuleRestore},
 	})
 
 	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, p)
@@ -4915,7 +4914,6 @@ func TestIntegrationRulePermanentlyDelete(t *testing.T) {
 		EnableQuota:           true,
 		DisableAnonymous:      true,
 		AppModeProduction:     true,
-		EnableFeatureToggles:  []string{featuremgmt.FlagAlertRuleRestore},
 	})
 
 	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, p)

--- a/pkg/tests/apis/alerting/rules/alertrule/history_trash_test.go
+++ b/pkg/tests/apis/alerting/rules/alertrule/history_trash_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/grafana/grafana/apps/alerting/rules/pkg/apis/alerting/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/tests/apis"
 	"github.com/grafana/grafana/pkg/tests/apis/alerting/rules/common"
@@ -167,17 +166,12 @@ func TestIntegrationListHistory(t *testing.T) {
 	})
 }
 
-// TestIntegrationListTrash exercises the grafana.app/get-trash label selector. The
-// alertRuleRestore feature flag is required for soft-deletes to be retained.
+// TestIntegrationListTrash exercises the grafana.app/get-trash label selector.
 func TestIntegrationListTrash(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	ctx := context.Background()
-	helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
-		EnableFeatureToggles: []string{
-			featuremgmt.FlagAlertRuleRestore,
-		},
-	})
+	helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{})
 	client := common.NewAlertRuleClient(t, helper.Org1.Admin)
 
 	common.CreateTestFolder(t, helper, "trash-folder")

--- a/pkg/tests/apis/alerting/rules/recordingrule/history_trash_test.go
+++ b/pkg/tests/apis/alerting/rules/recordingrule/history_trash_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/grafana/grafana/apps/alerting/rules/pkg/apis/alerting/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/tests/apis"
 	"github.com/grafana/grafana/pkg/tests/apis/alerting/rules/common"
@@ -173,16 +172,12 @@ func TestIntegrationListHistory(t *testing.T) {
 }
 
 // TestIntegrationListTrash exercises the grafana.app/get-trash label selector for
-// RecordingRule. The alertRuleRestore feature flag is required for soft-deletes to be retained.
+// RecordingRule.
 func TestIntegrationListTrash(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	ctx := context.Background()
-	helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
-		EnableFeatureToggles: []string{
-			featuremgmt.FlagAlertRuleRestore,
-		},
-	})
+	helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{})
 	client := common.NewRecordingRuleClient(t, helper.Org1.Admin)
 
 	common.CreateTestFolder(t, helper, "rec-trash-folder")

--- a/public/app/features/alerting/unified/components/rules/deleted-rules/DeletedRules.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/deleted-rules/DeletedRules.test.tsx
@@ -15,7 +15,7 @@ import { DeletedRules } from './DeletedRules';
 
 setupMswServer();
 testWithFeatureToggles({
-  enable: ['alertingRulePermanentlyDelete', 'alertingRuleRecoverDeleted', 'alertRuleRestore'],
+  enable: ['alertingRulePermanentlyDelete', 'alertingRuleRecoverDeleted'],
 });
 beforeEach(() => {
   grantUserRole('Admin');

--- a/public/app/features/alerting/unified/featureToggles.ts
+++ b/public/app/features/alerting/unified/featureToggles.ts
@@ -19,7 +19,7 @@ export const shouldUseAlertingListViewV2 = () => {
 };
 
 export const shouldAllowRecoveringDeletedRules = () =>
-  (isAdmin() && config.featureToggles.alertingRuleRecoverDeleted && config.featureToggles.alertRuleRestore) ?? false;
+  (isAdmin() && config.featureToggles.alertingRuleRecoverDeleted) ?? false;
 
 export const shouldAllowPermanentlyDeletingRules = () =>
   (shouldAllowRecoveringDeletedRules() && config.featureToggles.alertingRulePermanentlyDelete) ?? false;


### PR DESCRIPTION
## Summary
- Removes the `alertRuleRestore` feature toggle (public preview, enabled by default)
- The alert rule soft-delete/restore behavior it gated is now unconditional, still governed by `alertingRuleRecoverDeleted` and `DeletedRuleRetention`
- Regenerated `toggles_gen.*`, `featureToggles.gen.ts`, and the feature toggles docs table via `make gen-feature-toggles`

## Test plan
- [x] `go build`/`go vet`/`golangci-lint` clean on touched packages
- [x] `go test` passes for `ngalert/store`, `ngalert/api`, `navtree`, `featuremgmt`
- [x] `yarn jest DeletedRules.test.tsx` passes
- [x] `yarn typecheck` and `yarn eslint` clean on touched frontend files