### PR TITLE
Plugins: disable version history install for unentitled marketplace plugins

### DIFF
--- a/public/app/features/plugins/admin/components/VersionList.test.tsx
+++ b/public/app/features/plugins/admin/components/VersionList.test.tsx
@@ -1,17 +1,103 @@
 import { OpenFeatureTestProvider } from '@openfeature/react-sdk';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import type { JSX } from 'react';
 import { Provider } from 'react-redux';
 
 import { config } from '@grafana/runtime';
 import { configureStore } from 'app/store/configureStore';
 
+import { getPluginEntitlement } from '../api';
+import { clearEntitlementCache } from '../hooks/usePluginEntitlement';
 import { getCatalogPluginMock } from '../mocks/mockHelpers';
 import { PluginUpdateStrategy } from '../types';
 
 import { VersionList } from './VersionList';
 
+jest.mock('../api', () => ({
+  ...jest.requireActual('../api'),
+  getPluginEntitlement: jest.fn(),
+}));
+
+const mockGetPluginEntitlement = jest.mocked(getPluginEntitlement);
+
 describe('VersionList', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearEntitlementCache();
+  });
+
+  it('should disable install buttons for a marketplace plugin the org is not entitled to', async () => {
+    mockGetPluginEntitlement.mockResolvedValue(false);
+
+    const versions = [
+      {
+        version: '1.0.0',
+        createdAt: '',
+        isCompatible: true,
+        grafanaDependency: null,
+      },
+      {
+        version: '1.0.1',
+        createdAt: '',
+        isCompatible: true,
+        grafanaDependency: null,
+      },
+    ];
+
+    const plugin = getCatalogPluginMock({
+      distributionType: 'marketplace',
+      details: {
+        grafanaDependency: '>=8.0.0',
+        pluginDependencies: [],
+        links: [{ name: 'GitHub', url: 'https://example.com' }],
+        versions,
+      },
+      managed: { enabled: false, strategy: PluginUpdateStrategy.MajorAligned },
+    });
+
+    renderWithStore(<VersionList plugin={plugin} />);
+
+    await waitFor(() => {
+      expect(mockGetPluginEntitlement).toHaveBeenCalledWith(plugin.id);
+    });
+
+    const buttons = await screen.findAllByText('Install');
+    buttons.forEach((btn) => expect(btn.closest('button')).toHaveAttribute('aria-disabled', 'true'));
+  });
+
+  it('should enable install buttons for a marketplace plugin the org is entitled to', async () => {
+    mockGetPluginEntitlement.mockResolvedValue(true);
+
+    const versions = [
+      {
+        version: '1.0.0',
+        createdAt: '',
+        isCompatible: true,
+        grafanaDependency: null,
+      },
+    ];
+
+    const plugin = getCatalogPluginMock({
+      distributionType: 'marketplace',
+      details: {
+        grafanaDependency: '>=8.0.0',
+        pluginDependencies: [],
+        links: [{ name: 'GitHub', url: 'https://example.com' }],
+        versions,
+      },
+      managed: { enabled: false, strategy: PluginUpdateStrategy.MajorAligned },
+    });
+
+    renderWithStore(<VersionList plugin={plugin} />);
+
+    await waitFor(() => {
+      expect(mockGetPluginEntitlement).toHaveBeenCalledWith(plugin.id);
+    });
+
+    const button = await screen.findByText('Install');
+    expect(button.closest('button')).toBeEnabled();
+  });
+
   it('should only show installs when no version is installed', () => {
     const versions = [
       {

--- a/public/app/features/plugins/admin/components/VersionList.tsx
+++ b/public/app/features/plugins/admin/components/VersionList.tsx
@@ -7,7 +7,13 @@ import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { useStyles2, Badge } from '@grafana/ui';
 
-import { formatGrafanaDependency, getLatestCompatibleVersion, shouldDisablePluginInstall } from '../helpers';
+import {
+  formatGrafanaDependency,
+  getLatestCompatibleVersion,
+  isMarketplacePlugin,
+  shouldDisablePluginInstall,
+} from '../helpers';
+import { usePluginEntitlement } from '../hooks/usePluginEntitlement';
 import { type CatalogPlugin, PluginUpdateStrategy, type Version } from '../types';
 
 import { VersionInstallButton } from './VersionInstallButton';
@@ -21,6 +27,8 @@ export const VersionList = ({ plugin }: Props) => {
   const pluginId = plugin.id;
   const versions = useMemo(() => plugin.details?.versions ?? [], [plugin.details?.versions]);
   const disableInstallation = useMemo(() => shouldDisablePluginInstall(plugin), [plugin]);
+  const entitlement = usePluginEntitlement(plugin);
+  const notEntitled = isMarketplacePlugin(plugin) && !entitlement.entitled;
 
   const isManagedPlugin = plugin.managed.enabled;
   // For managed plugins the stored installedVersion may be stale, so it is never displayed as
@@ -91,6 +99,10 @@ export const VersionList = ({ plugin }: Props) => {
             tooltip = `This plugin can't be managed through the Plugin Catalog`;
           }
 
+          if (notEntitled) {
+            tooltip = 'Contact us to install this plugin';
+          }
+
           return (
             <tr key={version.version}>
               {/* Version number */}
@@ -131,6 +143,7 @@ export const VersionList = ({ plugin }: Props) => {
                       version.angularDetected ||
                       !version.isCompatible ||
                       disableInstallation ||
+                      notEntitled ||
                       shouldDisableVersionInstallation({
                         version,
                         latestMajorVersions,


### PR DESCRIPTION
## Summary
- The plugin details page's top-level action button already shows "Contact us" instead of "Install" for marketplace-distribution plugins the org isn't entitled to (via `usePluginEntitlement`).
- The Version History tab's per-row install buttons had no such check, so a user could still click Install on individual versions even when the top-level action showed "Contact us".

## Test plan
- [x] Added unit tests in `VersionList.test.tsx` covering disabled (not entitled) and enabled (entitled) states for a marketplace plugin