### PR TITLE
Query Editor: Reveal the query name edit icon on hover

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/EditableQueryName.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/EditableQueryName.tsx
@@ -138,7 +138,9 @@ export function EditableQueryName({ query, queries, onQueryUpdate }: EditableQue
           {query.refId}
         </Text>
       </span>
-      <Icon name="pen" className={styles.queryEditIcon} data-edit-icon size="sm" />
+      <div className={styles.hoverAction}>
+        <Icon name="pen" size="sm" />
+      </div>
     </button>
   );
 }
@@ -147,54 +149,88 @@ function isSidebarCardElement(target: EventTarget | null) {
   return target instanceof HTMLElement && target.closest(`[${SIDEBAR_CARD_DATA_ATTR}]`) !== null;
 }
 
-const getStyles = (theme: GrafanaTheme2) => ({
-  queryNameWrapper: css({
+const getStyles = (theme: GrafanaTheme2) => {
+  const fadeToHoverBackground = [
+    `linear-gradient(270deg, ${theme.colors.action.hover} 80%, transparent)`,
+    `linear-gradient(270deg, ${theme.colors.background.secondary} 80%, transparent)`,
+  ].join(', ');
+
+  // Keep on a plain element: Icon runs className through emotion's cx, which merges
+  // registered classes into a new one, so this name would never reach the DOM.
+  const hoverAction = css({
+    position: 'absolute',
+    inset: '0 0 0 auto',
     display: 'flex',
     alignItems: 'center',
-    gap: theme.spacing(1.5),
-    cursor: 'pointer',
-    border: '1px solid transparent',
-    borderRadius: theme.shape.radius.default,
-    padding: theme.spacing(0, 0.5),
-    margin: 0,
-    background: 'transparent',
-    overflow: 'hidden',
-
-    '&:hover': {
-      background: theme.colors.action.hover,
-      border: `1px dashed ${theme.colors.border.strong}`,
-    },
-
-    '&:focus-visible': {
-      border: `2px solid ${theme.colors.primary.border}`,
-    },
-  }),
-  queryNameText: css({
-    display: 'block',
-    maxWidth: '180px',
-    minWidth: 0,
-    overflow: 'hidden',
-  }),
-  queryNameInput: css({
-    maxWidth: '300px',
-
-    input: {
-      fontFamily: theme.typography.fontFamily,
-    },
-  }),
-  inputRow: css({
-    position: 'relative',
-  }),
-  queryEditIcon: css({
+    padding: theme.spacing(0, 0.5, 0, 1.5),
     color: theme.colors.text.secondary,
-  }),
-  validationMessage: css({
-    position: 'absolute',
-    top: '100%',
-    left: 0,
-    marginTop: theme.spacing(0.5),
-    whiteSpace: 'normal',
-    maxWidth: 'min(360px, 40vw)',
-    zIndex: theme.zIndex.tooltip,
-  }),
-});
+    background: fadeToHoverBackground,
+    opacity: 0,
+    transform: 'translateX(8px)',
+    [theme.transitions.handleMotion('no-preference', 'reduce')]: {
+      transition: theme.transitions.create(['opacity', 'transform']),
+    },
+  });
+
+  return {
+    queryNameWrapper: css({
+      position: 'relative',
+      display: 'flex',
+      alignItems: 'center',
+      cursor: 'pointer',
+      // Dashed at rest so hover only changes the color; border-style cannot transition.
+      border: '1px dashed transparent',
+      borderRadius: theme.shape.radius.default,
+      padding: theme.spacing(0.5, 1),
+      margin: 0,
+      background: 'transparent',
+      overflow: 'hidden',
+      textAlign: 'left',
+
+      [theme.transitions.handleMotion('no-preference', 'reduce')]: {
+        transition: theme.transitions.create(['background-color', 'border-color']),
+      },
+
+      '&:hover': {
+        background: theme.colors.action.hover,
+        borderColor: theme.colors.border.strong,
+      },
+
+      '&:focus-visible': {
+        border: `2px solid ${theme.colors.primary.border}`,
+      },
+
+      [`&:hover .${hoverAction}, &:focus-visible .${hoverAction}`]: {
+        opacity: 1,
+        transform: 'translateX(0)',
+      },
+    }),
+    queryNameText: css({
+      display: 'block',
+      maxWidth: '180px',
+      // Keeps a single-character refId clear of the icon and its gradient.
+      minWidth: theme.spacing(4),
+      overflow: 'hidden',
+    }),
+    queryNameInput: css({
+      maxWidth: '300px',
+
+      input: {
+        fontFamily: theme.typography.fontFamily,
+      },
+    }),
+    inputRow: css({
+      position: 'relative',
+    }),
+    hoverAction,
+    validationMessage: css({
+      position: 'absolute',
+      top: '100%',
+      left: 0,
+      marginTop: theme.spacing(0.5),
+      whiteSpace: 'normal',
+      maxWidth: 'min(360px, 40vw)',
+      zIndex: theme.zIndex.tooltip,
+    }),
+  };
+};

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/EditableQueryName.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/EditableQueryName.tsx
@@ -138,7 +138,9 @@ export function EditableQueryName({ query, queries, onQueryUpdate }: EditableQue
           {query.refId}
         </Text>
       </span>
-      <Icon name="pen" className={styles.queryEditIcon} data-edit-icon size="sm" />
+      <div className={styles.hoverAction}>
+        <Icon name="pen" size="sm" />
+      </div>
     </button>
   );
 }
@@ -147,54 +149,88 @@ function isSidebarCardElement(target: EventTarget | null) {
   return target instanceof HTMLElement && target.closest(`[${SIDEBAR_CARD_DATA_ATTR}]`) !== null;
 }
 
-const getStyles = (theme: GrafanaTheme2) => ({
-  queryNameWrapper: css({
+const getStyles = (theme: GrafanaTheme2) => {
+  const fadeToHoverBackground = [
+    `linear-gradient(270deg, ${theme.colors.action.hover} 80%, transparent)`,
+    `linear-gradient(270deg, ${theme.colors.background.secondary} 80%, transparent)`,
+  ].join(', ');
+
+  // Keep on a plain element: Icon runs className through emotion's cx, which merges
+  // registered classes into a new one, so this name would never reach the DOM.
+  const hoverAction = css({
+    position: 'absolute',
+    inset: '0 0 0 auto',
     display: 'flex',
     alignItems: 'center',
-    gap: theme.spacing(1.5),
-    cursor: 'pointer',
-    border: '1px solid transparent',
-    borderRadius: theme.shape.radius.default,
-    padding: theme.spacing(0, 0.5),
-    margin: 0,
-    background: 'transparent',
-    overflow: 'hidden',
-
-    '&:hover': {
-      background: theme.colors.action.hover,
-      border: `1px dashed ${theme.colors.border.strong}`,
-    },
-
-    '&:focus-visible': {
-      border: `2px solid ${theme.colors.primary.border}`,
-    },
-  }),
-  queryNameText: css({
-    display: 'block',
-    maxWidth: '180px',
-    minWidth: 0,
-    overflow: 'hidden',
-  }),
-  queryNameInput: css({
-    maxWidth: '300px',
-
-    input: {
-      fontFamily: theme.typography.fontFamilyMonospace,
-    },
-  }),
-  inputRow: css({
-    position: 'relative',
-  }),
-  queryEditIcon: css({
+    padding: theme.spacing(0, 0.5, 0, 1.5),
     color: theme.colors.text.secondary,
-  }),
-  validationMessage: css({
-    position: 'absolute',
-    top: '100%',
-    left: 0,
-    marginTop: theme.spacing(0.5),
-    whiteSpace: 'normal',
-    maxWidth: 'min(360px, 40vw)',
-    zIndex: theme.zIndex.tooltip,
-  }),
-});
+    background: fadeToHoverBackground,
+    opacity: 0,
+    transform: 'translateX(8px)',
+    [theme.transitions.handleMotion('no-preference', 'reduce')]: {
+      transition: theme.transitions.create(['opacity', 'transform']),
+    },
+  });
+
+  return {
+    queryNameWrapper: css({
+      position: 'relative',
+      display: 'flex',
+      alignItems: 'center',
+      cursor: 'pointer',
+      // Dashed at rest so hover only changes the color; border-style cannot transition.
+      border: '1px dashed transparent',
+      borderRadius: theme.shape.radius.default,
+      padding: theme.spacing(0.5, 1),
+      margin: 0,
+      background: 'transparent',
+      overflow: 'hidden',
+      textAlign: 'left',
+
+      [theme.transitions.handleMotion('no-preference', 'reduce')]: {
+        transition: theme.transitions.create(['background-color', 'border-color']),
+      },
+
+      '&:hover': {
+        background: theme.colors.action.hover,
+        borderColor: theme.colors.border.strong,
+      },
+
+      '&:focus-visible': {
+        border: `2px solid ${theme.colors.primary.border}`,
+      },
+
+      [`&:hover .${hoverAction}, &:focus-visible .${hoverAction}`]: {
+        opacity: 1,
+        transform: 'translateX(0)',
+      },
+    }),
+    queryNameText: css({
+      display: 'block',
+      maxWidth: '180px',
+      // Keeps a single-character refId clear of the icon and its gradient.
+      minWidth: theme.spacing(4),
+      overflow: 'hidden',
+    }),
+    queryNameInput: css({
+      maxWidth: '300px',
+
+      input: {
+        fontFamily: theme.typography.fontFamilyMonospace,
+      },
+    }),
+    inputRow: css({
+      position: 'relative',
+    }),
+    hoverAction,
+    validationMessage: css({
+      position: 'absolute',
+      top: '100%',
+      left: 0,
+      marginTop: theme.spacing(0.5),
+      whiteSpace: 'normal',
+      maxWidth: 'min(360px, 40vw)',
+      zIndex: theme.zIndex.tooltip,
+    }),
+  };
+};


### PR DESCRIPTION
## Description
<!--- A high level description of what this PR is doing -->

The query editor's content header is dense — data source picker, separator, query name, header extras and the header actions share one row — yet the pen icon beside the query name was rendered permanently for an action that is only used occasionally. It now appears on hover or keyboard focus, which is the gesture users already reach for when renaming something.

## Changes
<!--- Describe your changes in detail -->
* The pen icon fades and slides in on `:hover` and `:focus-visible` of the query name button, reusing the hover-action pattern from the query editor's `SidebarCard`.
* The icon overlays the name with a gradient that fades out a long, truncated name underneath it, so the resting hover target stays compact instead of permanently reserving a slot.
* The name reserves a small minimum width, keeping single-character refIds clear of both the icon and the leading edge of its gradient.
* The hover border and background now transition on the same timing as the icon, so the affordance arrives as one motion; the border is dashed at rest because `border-style` itself cannot be animated.
* The icon moved from a `className` on `Icon` onto a plain wrapper element. `Icon` composes `className` through emotion's `cx`, which merges registered classes into a new one, so a class name handed to `Icon` never reaches the DOM for a parent reveal selector to match.

## Risks
<!--- Describe what risks you've considered i.e. what features are most likely to break -->

Limited to the query name control in the new query editor header. The rename flow itself is untouched, and the button keeps its `aria-label` and full click target, so the reveal is purely presentational. Reduced-motion users get the same reveal without the transition.

## Demo
<!--- Attach a demo gif/video or screenshots of the changes if applicable -->

<img width="1111" height="129" alt="Screenshot 2026-08-17 at 20 10 22" src="https://github.com/user-attachments/assets/ecb20e79-8a24-45a1-83bb-ef4eadf44634" />
<img width="1110" height="99" alt="Screenshot 2026-08-17 at 20 11 57" src="https://github.com/user-attachments/assets/429b9d74-5a0e-41bf-bfb2-7db7bcc566a0" />
<img width="1110" height="106" alt="Screenshot 2026-08-17 at 20 12 19" src="https://github.com/user-attachments/assets/184bcf31-0e54-4598-86d5-c72712faeb14" />


## Testing Instructions
<!--- Provide step by step instructions and the dashboard if applicable -->
* Open a panel in edit mode with the new query editor and confirm the pen icon is absent until you hover the query name, then fades in together with the dashed border and background.
* Tab to the query name and confirm the icon appears on keyboard focus too, and that clicking or pressing Enter still opens the rename input.
* Check a single-character refId such as `A` and confirm the letter stays fully legible, clear of the icon and its gradient.
* Check a long query name and confirm it truncates and fades out beneath the icon rather than colliding with it.
* Enable reduced motion at the OS level and confirm the icon still appears on hover, without the transition.

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable

Close DPRO-332