### PR TITLE
BackendSrv: only send X-Grafana-Device-Id on local requests

### DIFF
--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -266,11 +266,6 @@ export class BackendSrv implements BackendService {
       }
     }
 
-    if (!!this.deviceID) {
-      options.headers = options.headers ?? {};
-      options.headers['X-Grafana-Device-Id'] = `${this.deviceID}`;
-    }
-
     return parseUrlFromOptions(options).pipe(
       this.getFromFetchStream<T>(options),
       this.handleStreamResponse<T>(options),
@@ -301,6 +296,11 @@ export class BackendSrv implements BackendService {
       if (orgId) {
         options.headers = options.headers ?? {};
         options.headers['X-Grafana-Org-Id'] = orgId;
+      }
+
+      if (!!this.deviceID) {
+        options.headers = options.headers ?? {};
+        options.headers['X-Grafana-Device-Id'] = `${this.deviceID}`;
       }
 
       if (options.url.startsWith('/')) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Move the X-Grafana-Device-Id header to only be sent on local requests, matching the other X-Grafana-* headers.

**Why do we need this feature?**

X-Grafana-Device-Id is intended for Grafana's own backend, but it is added in internalFetch() without the isLocalUrl() gate the other X-Grafana-* headers use, so it is also sent on cross-origin access: direct data source requests, where it breaks the CORS preflight for backends with a strict Access-Control-Allow-Headers allowlist. This moves the header into the existing isLocalUrl(options.url) branch of parseRequestOptions(), next to X-Grafana-Org-Id, so it is only sent to local (Grafana backend) URLs — matching the sibling headers. Telemetry to the Grafana backend is unchanged. Fixes #81312 for data sources using the `access: direct` pattern.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #130878 

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
