### PR TITLE
SystemTransforms: Fix transform pass-thru

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataTransformationsTab.systemTransformations.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataTransformationsTab.systemTransformations.test.tsx
@@ -13,11 +13,12 @@ import {
 import { getPanelPlugin } from '@grafana/data/test';
 import { setPluginImportUtils } from '@grafana/runtime';
 import { FlagKeys } from '@grafana/runtime/internal';
-import { SceneQueryRunner, VizPanel } from '@grafana/scenes';
+import { SceneDataNode, SceneQueryRunner, VizPanel } from '@grafana/scenes';
 import { setTestFlags } from '@grafana/test-utils/unstable';
 import { getStandardTransformers } from 'app/features/transformers/standardTransformers';
 
 import { PanelDataTransformer } from '../../scene/PanelDataTransformer';
+import { activateFullSceneTree } from '../../utils/test-utils';
 
 import { type PanelDataTransformationsTab, PanelDataTransformationsTabRendered } from './PanelDataTransformationsTab';
 
@@ -57,9 +58,14 @@ const extractLabels = {
 const organize: DataTransformerConfig = { id: 'organize', options: {} };
 
 function createModel(pluginId: string) {
-  const transformer = new PanelDataTransformer({ data: rawData, transformations: [organize] });
-  // Parents the transformer, which is how the plugin's transformations resolve their panel.
-  new VizPanel({ pluginId, $data: transformer });
+  // Needs a source to activate against; the tab reads the raw frames from the query runner below.
+  const transformer = new PanelDataTransformer({
+    $data: new SceneDataNode({ data: rawData }),
+    transformations: [organize],
+  });
+  // Activating parents the transformer and is what installs the plugin's transformations — they are
+  // only added once a resolved plugin reports that it registers any.
+  activateFullSceneTree(new VizPanel({ pluginId, $data: transformer }));
 
   return {
     getDataTransformer: () => transformer,

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataTransformationsTab.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataTransformationsTab.tsx
@@ -123,9 +123,16 @@ function useSystemTransformedData(
 export function PanelDataTransformationsTabRendered({ model }: SceneComponentProps<PanelDataTransformationsTab>) {
   const styles = useStyles2(getStyles);
   const sourceData = model.getQueryRunner().useState();
-  const { data, transformations: transformsWrongType } = model.getDataTransformer().useState();
+  const {
+    data,
+    transformations: transformsWrongType,
+    systemTransformations: systemTransformationsState,
+  } = model.getDataTransformer().useState();
 
-  const systemTransformations = useMemo(() => getReplayableSystemTransformations(model.getDataTransformer()), [model]);
+  const systemTransformations = useMemo(
+    () => getReplayableSystemTransformations(systemTransformationsState),
+    [systemTransformationsState]
+  );
   const editorData = useSystemTransformedData(sourceData.data, systemTransformations);
 
   // Type guard to ensure transformations are DataTransformerConfig[]

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.tsx
@@ -52,6 +52,7 @@ export function QueryEditorContextWrapper({
   const pendingSavedQuery = isDrawerOpen ? pendingSavedQueryState : null;
 
   const dataTransformer = panel.state.$data instanceof SceneDataTransformer ? panel.state.$data : null;
+  const transformerState = dataTransformer?.useState();
   const transformations = useTransformations(dataTransformer);
   const alertingState = useAlertRulesForPanel(dataPane, panel);
 
@@ -302,9 +303,13 @@ export function QueryEditorContextWrapper({
     [queryRunnerState?.queries, queryRunnerState?.data, queryError]
   );
 
-  // Not subscribed: `systemTransformations` is write-once at construction, and replacing the panel's
-  // `$data` yields a new transformer instance, which re-renders this anyway.
-  const systemTransformations = useMemo(() => getReplayableSystemTransformations(dataTransformer), [dataTransformer]);
+  // Read from subscribed state, not the instance: the plugin's transformations are installed on
+  // activation and reinstalled when the panel's plugin changes, so switching visualization while the
+  // editor is open has to reach the rows that replay them.
+  const systemTransformations = useMemo(
+    () => getReplayableSystemTransformations(transformerState?.systemTransformations),
+    [transformerState?.systemTransformations]
+  );
 
   const panelState = useMemo(() => {
     return {

--- a/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.test.tsx
@@ -1044,20 +1044,26 @@ describe('DashboardDatasourceBehaviour', () => {
     jest.spyOn(console, 'error').mockImplementation();
     setTestFlags({ [FlagKeys.GrafanaPanelPluginTransformations]: true });
 
+    // An empty user list, so only the plugin's transformations make the transformer emit. Gating on
+    // `state.transformations.length` subscribes to the query runner instead and misses a reprocess,
+    // which runs no query.
+    const sourceTransformer = new PanelDataTransformer({
+      transformations: [],
+      $data: new SceneQueryRunner({
+        datasource: { uid: 'grafana' },
+        queries: [{ refId: 'A', queryType: 'randomWalk' }],
+      }),
+    });
+    // Installed directly rather than through a registered plugin — this behaviour only cares that
+    // the source has effective transformations at all. Set after construction because the
+    // constructor drops the field, which is what stops a clone inheriting the source panel's.
+    sourceTransformer.setState({ systemTransformations: { prepend: [() => (source) => source] } });
+
     const sourcePanel = new VizPanel({
       title: 'Panel A',
       pluginId: 'table',
       key: 'panel-1',
-      $data: new PanelDataTransformer({
-        // An empty user list, so only the plugin's transformations make the transformer emit.
-        // Gating on `state.transformations.length` here subscribes to the query runner instead
-        // and misses a reprocess, which runs no query.
-        transformations: [],
-        $data: new SceneQueryRunner({
-          datasource: { uid: 'grafana' },
-          queries: [{ refId: 'A', queryType: 'randomWalk' }],
-        }),
-      }),
+      $data: sourceTransformer,
     });
 
     const dashboardDSPanel = new VizPanel({

--- a/public/app/features/dashboard-scene/scene/PanelDataTransformer.test.ts
+++ b/public/app/features/dashboard-scene/scene/PanelDataTransformer.test.ts
@@ -13,12 +13,13 @@ import {
 import { getPanelPlugin } from '@grafana/data/test';
 import { setPluginImportUtils } from '@grafana/runtime';
 import { FlagKeys } from '@grafana/runtime/internal';
-import { SceneDataNode, type SceneDataTransformer, VizPanel } from '@grafana/scenes';
+import { SceneDataNode, type SceneDataTransformer, SceneObjectStateChangedEvent, VizPanel } from '@grafana/scenes';
 import { DataTopic } from '@grafana/schema';
 import { setTestFlags } from '@grafana/test-utils/unstable';
 import { getStandardTransformers } from 'app/features/transformers/standardTransformers';
 
 import { PanelDataPaneNext } from '../panel-edit/PanelEditNext/PanelDataPaneNext';
+import { DashboardSceneChangeTracker } from '../saving/DashboardSceneChangeTracker';
 import { activateFullSceneTree } from '../utils/test-utils';
 
 import { PanelDataTransformer } from './PanelDataTransformer';
@@ -192,16 +193,99 @@ describe('PanelDataTransformer', () => {
     registerPlugin('plain');
 
     const series = [frameWithLabels()];
-    const { transformer } = buildPipeline({ pluginId: 'plain', series });
+    const { source, transformer } = buildPipeline({ pluginId: 'plain', series });
     activateFullSceneTree(transformer);
 
     await waitFor(() => {
       expect(transformer.state.data?.state).toBe(LoadingState.Done);
     });
-    // Scenes rebuilds the series array whenever a transformer has any entry, so the array itself
-    // is new. What must hold is that the frames pass through untouched, so no extra work lands
-    // downstream in structure comparison or field overrides.
+    // Nothing is installed at all, so the base class keeps its passthrough and the PanelData object
+    // itself is forwarded. Anything less — a rebuilt series array, `annotations` promoted from
+    // undefined to [] — is downstream work for every panel on the dashboard.
+    expect(transformer.state.systemTransformations).toBeUndefined();
+    expect(transformer.state.data === source.state.data).toBe(true);
     expect(transformer.state.data?.series[0] === series[0]).toBe(true);
+  });
+
+  describe('installing the operator', () => {
+    it('leaves it off for a plugin that registers nothing, keeping the base class fast path', async () => {
+      registerPlugin('plain');
+
+      const { transformer } = buildPipeline({ pluginId: 'plain', series: [frameWithLabels()] });
+      activateFullSceneTree(transformer);
+
+      await waitFor(() => {
+        expect(transformer.state.data?.state).toBe(LoadingState.Done);
+      });
+      expect(transformer.getEffectiveTransformations()).toHaveLength(0);
+    });
+
+    it('removes it when the panel switches to a plugin that registers nothing', async () => {
+      registerPlugin('logs-table', (p) => p.setDataTransformations(() => [extractLabels]));
+      registerPlugin('plain');
+
+      const series = [frameWithLabels()];
+      const { source, transformer, panel } = buildPipeline({ pluginId: 'logs-table', series });
+      activateFullSceneTree(transformer);
+
+      await waitFor(() => {
+        expect(transformer.state.data?.series[0]?.fields.map((f) => f.name)).toContain('level');
+      });
+
+      panel.setState({ pluginId: 'plain' });
+
+      // Back to the fast path rather than an installed operator that resolves to no configs.
+      await waitFor(() => {
+        expect(transformer.state.systemTransformations).toBeUndefined();
+      });
+      expect(transformer.state.data === source.state.data).toBe(true);
+    });
+
+    it('does not mark the dashboard dirty when it installs', async () => {
+      registerPlugin('logs-table', (p) => p.setDataTransformations(() => [extractLabels]));
+
+      const { transformer, panel } = buildPipeline({ pluginId: 'logs-table', series: [frameWithLabels()] });
+
+      // Installing happens with a parent attached now, so — unlike a write from the constructor —
+      // the event really does bubble to the dashboard's change tracker.
+      const events: SceneObjectStateChangedEvent[] = [];
+      panel.subscribeToEvent(SceneObjectStateChangedEvent, (event) => events.push(event));
+
+      activateFullSceneTree(transformer);
+
+      await waitFor(() => {
+        expect(transformer.state.systemTransformations?.prepend).toHaveLength(1);
+      });
+
+      const installEvent = events.find((event) =>
+        Object.prototype.hasOwnProperty.call(event.payload.partialUpdate ?? {}, 'systemTransformations')
+      );
+
+      expect(installEvent).toBeDefined();
+      expect(DashboardSceneChangeTracker.isUpdatingPersistedState(installEvent!)).toBe(false);
+    });
+
+    it('re-runs when the panel switches between two plugins that both register transformations', async () => {
+      registerPlugin('logs-table', (p) => p.setDataTransformations(() => [extractLabels]));
+      registerPlugin('reducer', (p) =>
+        p.setDataTransformations(() => [{ id: 'reduce', options: { reducers: ['max'] } }])
+      );
+
+      const { transformer, panel } = buildPipeline({ pluginId: 'logs-table', series: [frameWithLabels()] });
+      activateFullSceneTree(transformer);
+
+      await waitFor(() => {
+        expect(transformer.state.data?.series[0]?.fields.map((f) => f.name)).toContain('level');
+      });
+
+      panel.setState({ pluginId: 'reducer' });
+
+      // The operator stays installed across this swap, so only a reprocess surfaces the new output.
+      await waitFor(() => {
+        expect(transformer.state.data?.series[0]?.fields.map((f) => f.name)).toEqual(['Field', 'Max']);
+      });
+      expect(transformer.state.systemTransformations?.prepend).toHaveLength(1);
+    });
   });
 
   it('lets the supplier branch on frame metadata', async () => {

--- a/public/app/features/dashboard-scene/scene/PanelDataTransformer.ts
+++ b/public/app/features/dashboard-scene/scene/PanelDataTransformer.ts
@@ -1,4 +1,4 @@
-import { catchError, from, of, switchMap } from 'rxjs';
+import { of, switchMap } from 'rxjs';
 
 import {
   type CustomTransformOperator,
@@ -26,72 +26,41 @@ export class PanelDataTransformer extends SceneDataTransformer {
     // which is bound to the source panel. Dropping it here is what keeps a duplicated panel on its own plugin's transformations.
     super({ ...state, systemTransformations: undefined });
 
-    // Gating installation keeps the base class's identity-preserving fast path for everyone the
-    // feature is off for. The operator re-reads the flag on every emission, so this check only
-    // decides whether the operator exists — never whether it applies.
-    if (!pluginTransformationsEnabled()) {
-      return;
-    }
-
-    // Installed from the constructor rather than from an activation handler or a behaviour: the
-    // base class transforms whatever the source already holds as soon as it activates, and
-    // `$behaviors` activate after `$data`, so anything later renders a frame of unprepared data on
-    // every re-activation — entering and leaving panel edit, duplicating a panel, repeat rebuilds.
-    this.setState({ systemTransformations: { prepend: [this._runPluginTransformations] } });
-
     this.addActivationHandler(() => this._activationHandler());
   }
 
+  /** The plugin the installed operator belongs to, resolved once rather than per emission. */
+  private _plugin?: PanelPlugin;
+
   /**
-   * Resolves the plugin inside the pipeline rather than at construction time: scenes are
-   * built before `VizPanel` activates and loads its plugin, so there is nothing to ask when
-   * this object is created.
+   * Asks the plugin for its transformations per emission rather than caching the result: the supplier
+   * receives the frames, so its answer can legitimately differ between refreshes.
    *
-   * The panel's own plugin is preferred — scenes resolves it through Grafana's cache AND its
-   * runtime-plugin registry, so ids like the unconfigured panel's are found here despite being
-   * invisible to `importPanelPlugin`. The awaited import remains as a fallback for plugins the
-   * panel has not loaded yet. An id that no layer resolves passes the frames through untouched
-   * and is retried when the panel's plugin lands (see the activation handler): resolution
-   * failure must never error the panel's data.
-   *
-   * Whichever layer answers, it must answer for the panel's *current* `pluginId` — see
-   * {@link getLoadedPluginFor}.
+   * The plugin itself is not re-resolved here. `_syncSystemTransformations` owns that, because the
+   * only way to reach some ids is an async import — an operator cannot await one without making the
+   * whole pipeline asynchronous on every emission.
    */
   private _runPluginTransformations: CustomTransformOperator = (ctx) => (source) =>
     source.pipe(
       switchMap((frames) => {
-        // Re-read rather than reuse the constructor's result: flag values change over a session, so
+        // Re-read rather than reuse the install-time result: flag values change over a session, so
         // caching one would leave the toggle unable to stop a panel it already applies to.
-        if (!pluginTransformationsEnabled()) {
+        if (!pluginTransformationsEnabled() || frames.length === 0) {
           return of(frames);
         }
 
         const panel = getAncestorVizPanel(this);
+        const plugin = this._plugin;
 
-        if (!panel || frames.length === 0) {
+        // Only ever answer for the panel's current plugin. A swap re-syncs through the subscription
+        // below; until the new plugin resolves these frames belong to neither, so pass them through.
+        if (!panel || plugin?.meta.id !== panel.state.pluginId) {
           return of(frames);
         }
 
-        const loaded = getLoadedPluginFor(panel) ?? syncGetPanelPlugin(panel.state.pluginId);
-        const plugin$ = loaded
-          ? of(loaded)
-          : from(importPanelPlugin(panel.state.pluginId)).pipe(catchError(() => of(undefined)));
+        const configs = plugin.getDataTransformations({ series: frames }).filter(appliesToSeriesTopic);
 
-        return plugin$.pipe(
-          switchMap((plugin: PanelPlugin | undefined) => {
-            if (!plugin) {
-              return of(frames);
-            }
-
-            const configs = plugin.getDataTransformations({ series: frames }).filter(appliesToSeriesTopic);
-
-            // Passing the input frames through untouched preserves their identity: the base
-            // class rebuilds the series array either way, but structurally identical frames
-            // keep the panel's structureRev stable, so panels that register no transformations
-            // avoid needless re-configuration.
-            return configs.length ? transformDataFrame(configs, frames, ctx) : of(frames);
-          })
-        );
+        return transformDataFrame(configs, frames, ctx);
       })
     );
 
@@ -102,30 +71,88 @@ export class PanelDataTransformer extends SceneDataTransformer {
       return;
     }
 
-    // The supplier can return different transformations per plugin, and switching visualization
-    // does not produce new data, so nothing else would re-run the pipeline.
+    this._syncSystemTransformations(panel);
+
+    // Two things invalidate the decision above and neither produces new data, so nothing else would
+    // re-run the pipeline: switching visualization (a different plugin, with a different answer), and
+    // the panel finishing a plugin load that had not resolved yet. The second cannot be detected from
+    // `pluginId` — `_pluginLoaded` writes the value already in state — so watch the plugin itself.
+    let loadedPlugin = getLoadedPluginFor(panel);
+
     this._subs.add(
       panel.subscribeToState((newState, prevState) => {
-        if (newState.pluginId !== prevState.pluginId) {
-          this.reprocessTransformations();
+        const nextPlugin = getLoadedPluginFor(panel);
+
+        if (newState.pluginId === prevState.pluginId && nextPlugin === loadedPlugin) {
+          return;
         }
+
+        loadedPlugin = nextPlugin;
+        this._syncSystemTransformations(panel);
       })
     );
+  }
 
-    // Data can be processed before the panel loads its plugin: the panel's own activation loads
-    // the plugin before activating `$data`, but other activators (the dashboard datasource's
-    // source-panel path, tests) reach the data chain directly. Only ids no synchronous layer can
-    // resolve need this — for the rest the operator already resolves on its first emission, and
-    // reprocessing on plugin arrival would just repeat the same transform.
-    if (!getLoadedPluginFor(panel) && !syncGetPanelPlugin(panel.state.pluginId)) {
-      const pluginLoadSub = panel.subscribeToState(() => {
-        if (getLoadedPluginFor(panel)) {
-          pluginLoadSub.unsubscribe();
-          this.reprocessTransformations();
-        }
-      });
-      this._subs.add(pluginLoadSub);
+  /**
+   * Installs the operator only for panels whose plugin actually registers transformations, and
+   * removes it again when one no longer does.
+   *
+   * The alternative — installing unconditionally — is what it replaces, and it costs every panel on
+   * every dashboard: a non-empty `getEffectiveTransformations()` permanently disables the base
+   * class's passthrough, so each emission rebuilds `PanelData` through the full pipeline even when
+   * there is nothing to run.
+   *
+   * Deliberately not done in the constructor: the plugin is reachable only through the panel, and
+   * `this.parent` is not set yet at that point.
+   */
+  private _syncSystemTransformations(panel: VizPanel) {
+    const plugin = getLoadedPluginFor(panel) ?? syncGetPanelPlugin(panel.state.pluginId);
+
+    if (plugin) {
+      this._installSystemTransformations(plugin);
+      return;
     }
+
+    // Nothing resolves this id synchronously, and the panel may never load it: a provider can be
+    // activated on its own, without its panel — conditional rendering and the dashboard datasource's
+    // source-panel path both do. Import it from here, once per resolution attempt, rather than from
+    // the operator: `importPanelPlugin` deletes its promise cache entry on failure, so an operator
+    // that awaited it would re-import and re-reject on every single emission.
+    const { pluginId } = panel.state;
+
+    importPanelPlugin(pluginId)
+      .then((imported) => {
+        // The panel may have been swapped or the provider torn down while the chunk loaded.
+        if (this.isActive && panel.state.pluginId === pluginId) {
+          this._installSystemTransformations(imported);
+        }
+      })
+      // An id nothing can resolve leaves the panel on its untransformed data, which is the same
+      // outcome as a plugin that registers nothing. Never error the panel's data over it.
+      .catch(() => undefined);
+  }
+
+  private _installSystemTransformations(plugin: PanelPlugin) {
+    const shouldInstall = pluginTransformationsEnabled() && plugin.hasDataTransformations();
+    const nextPlugin = shouldInstall ? plugin : undefined;
+    const isInstalled = Boolean(this.state.systemTransformations?.prepend?.length);
+
+    // Idempotent, so re-activating a panel does not re-transform data that is already correct.
+    if (nextPlugin === this._plugin && shouldInstall === isInstalled) {
+      return;
+    }
+
+    this._plugin = nextPlugin;
+
+    // Swapping between two plugins that both register transformations leaves the operator in place,
+    // but its output changes, so the pipeline still has to re-run.
+    if (shouldInstall !== isInstalled) {
+      this.setState({
+        systemTransformations: shouldInstall ? { prepend: [this._runPluginTransformations] } : undefined,
+      });
+    }
+
+    this.reprocessTransformations();
   }
 }
 
@@ -140,9 +167,9 @@ function pluginTransformationsEnabled(): boolean {
  * `setState`, so the placeholder is still loaded when this object activates.
  *
  * Reading it unqualified is wrong twice over — the placeholder answers the supplier call meant for
- * the real plugin, and it makes the panel look resolved, so the retry below is never armed. That
- * retry is the only one that can fire on this path: the plugin arrives via `pluginId`'s *own* value,
- * so the `pluginId`-change subscription above cannot see it.
+ * the real plugin, and it makes the panel look resolved, so `_syncSystemTransformations` settles on
+ * the placeholder's answer and never revisits it. Comparing identity is also what lets the panel
+ * subscription notice the real plugin arriving, since it lands under the `pluginId` already in state.
  */
 function getLoadedPluginFor(panel: VizPanel): PanelPlugin | undefined {
   const plugin = panel.getPlugin();

--- a/public/app/features/dashboard-scene/scene/systemTransformations.ts
+++ b/public/app/features/dashboard-scene/scene/systemTransformations.ts
@@ -1,5 +1,5 @@
 import { type CustomTransformOperator, type DataTransformerConfig } from '@grafana/data';
-import { type SceneDataTransformer } from '@grafana/scenes';
+import { type SceneDataTransformerState } from '@grafana/scenes';
 import { DataTopic } from '@grafana/schema';
 
 /** Stable identity so consumers that memoize on this — or use it as an effect dep — do not churn. */
@@ -15,11 +15,15 @@ const NONE: Array<DataTransformerConfig | CustomTransformOperator> = [];
  *
  * Entries may be bare operators, configs, or operators scoped to a topic. Only series-topic ones
  * reach a user transformation's input, matching how the pipeline splits topics.
+ *
+ * Takes the state value rather than the provider so callers memoize on something that actually
+ * changes: `PanelDataTransformer` installs on activation and reinstalls when the panel's plugin
+ * changes, so this is not fixed for the lifetime of the object.
  */
 export function getReplayableSystemTransformations(
-  provider: SceneDataTransformer | null | undefined
+  systemTransformations: SceneDataTransformerState['systemTransformations']
 ): Array<DataTransformerConfig | CustomTransformOperator> {
-  const entries = provider?.state.systemTransformations?.prepend;
+  const entries = systemTransformations?.prepend;
 
   if (!entries?.length) {
     return NONE;

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.test.ts
@@ -1764,7 +1764,10 @@ describe('given a panel plugin that registers transformations', () => {
     });
 
     const dataProvider = panel.state.body.state.$data as SceneDataTransformer;
-    // The plugin's slot really is populated, otherwise this test proves nothing.
+    // Populated directly: `PanelDataTransformer` installs the operator on activation once it has
+    // resolved a plugin, and that mechanism is its own concern. What matters here is that a
+    // populated slot never reaches the save model.
+    dataProvider.setState({ systemTransformations: { prepend: [() => (source) => source] } });
     expect(dataProvider.state.systemTransformations?.prepend).toHaveLength(1);
 
     const result = gridItemToPanel(panel);

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
@@ -1290,6 +1290,10 @@ describe('given a panel plugin that registers transformations', () => {
       data: { series: [transformedFrame], state: LoadingState.Done, timeRange },
     });
 
+    // Populated directly: `PanelDataTransformer` installs the operator on activation once it has
+    // resolved a plugin, and that mechanism is its own concern. What matters here is that a
+    // populated slot never reaches the save model.
+    dataProvider.setState({ systemTransformations: { prepend: [() => (source) => source] } });
     expect(dataProvider.state.systemTransformations?.prepend).toHaveLength(1);
 
     return new VizPanel({ key: 'panel-1', pluginId: 'timeseries', $data: dataProvider });


### PR DESCRIPTION
**What is this feature?**

Performance follow-up of https://github.com/grafana/grafana/pull/130860

**Why do we need this feature?**
https://github.com/grafana/scenes/pull/1611 disabled zero-transform fast-path for every panel when `grafana.panelPluginTransformations` was enabled. 

**Special notes for your reviewer:**
Initially thought it would be easier to review in isolation but I changed my mind.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
