### PR TITLE
Dashboards: Use async DataSource APIs in panel edit and scene context

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1472,33 +1472,8 @@
       "count": 1
     }
   },
-  "public/app/features/dashboard-scene/panel-edit/PanelDataPane/EmptyTransformationsMessage.test.tsx": {
-    "@grafana/no-get-data-source-srv": {
-      "count": 1
-    }
-  },
-  "public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx": {
-    "@grafana/no-get-data-source-srv": {
-      "count": 1
-    }
-  },
-  "public/app/features/dashboard-scene/panel-edit/PanelDataPane/utils.test.ts": {
-    "@grafana/no-get-data-source-srv": {
-      "count": 1
-    }
-  },
-  "public/app/features/dashboard-scene/panel-edit/PanelDataPane/utils.ts": {
-    "@grafana/no-get-data-source-srv": {
-      "count": 1
-    }
-  },
   "public/app/features/dashboard-scene/saving/SaveDashboardForm.tsx": {
     "@grafana/require-no-margin": {
-      "count": 1
-    }
-  },
-  "public/app/features/dashboard-scene/scene/DashboardDataLayerSet.tsx": {
-    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
@@ -1561,16 +1536,6 @@
       "count": 1
     },
     "react-hooks/rules-of-hooks": {
-      "count": 1
-    }
-  },
-  "public/app/features/dashboard-scene/scene/panel-actions/PanelGroupByAction/PanelGroupByAction.tsx": {
-    "@grafana/no-get-data-source-srv": {
-      "count": 1
-    }
-  },
-  "public/app/features/dashboard-scene/scene/setDashboardPanelContext.ts": {
-    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/EmptyTransformationsMessage.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/EmptyTransformationsMessage.test.tsx
@@ -1,9 +1,9 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { type DataSourceInstanceSettings, standardTransformersRegistry } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import config from 'app/core/config';
 import { getStandardTransformers } from 'app/features/transformers/standardTransformers';
 
@@ -13,9 +13,17 @@ const MOCK_DATA_SOURCE_UID = 'test-ds';
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
-  getDataSourceSrv: jest.fn(),
   reportInteraction: jest.fn(),
 }));
+
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstanceSettings: jest.fn(),
+}));
+
+const mockGetDataSourceInstanceSettings = getDataSourceInstanceSettings as jest.MockedFunction<
+  typeof getDataSourceInstanceSettings
+>;
 
 describe('EmptyTransformationsMessage', () => {
   standardTransformersRegistry.setInit(getStandardTransformers);
@@ -56,7 +64,7 @@ describe('EmptyTransformationsMessage', () => {
     beforeEach(() => {
       config.featureToggles.transformationsEmptyPlaceholder = true;
 
-      const mockGetInstanceSettings = jest.fn().mockReturnValue({
+      mockGetDataSourceInstanceSettings.mockResolvedValue({
         uid: MOCK_DATA_SOURCE_UID,
         type: 'test',
         name: 'Test DS',
@@ -64,13 +72,9 @@ describe('EmptyTransformationsMessage', () => {
           backend: true,
         },
       } as DataSourceInstanceSettings);
-
-      (getDataSourceSrv as jest.Mock).mockReturnValue({
-        getInstanceSettings: mockGetInstanceSettings,
-      });
     });
 
-    it('should render SQL expression card and transformation cards when sqlExpressions toggle is enabled', () => {
+    it('should render SQL expression card and transformation cards when sqlExpressions toggle is enabled', async () => {
       config.featureToggles.sqlExpressions = true;
 
       render(
@@ -85,7 +89,7 @@ describe('EmptyTransformationsMessage', () => {
       );
 
       // Should show SQL transformation card
-      expect(screen.getByText('Transform with SQL')).toBeInTheDocument();
+      expect(await screen.findByText('Transform with SQL')).toBeInTheDocument();
       expect(screen.getByText('Organize fields by name')).toBeInTheDocument();
       expect(screen.getByText('Group by')).toBeInTheDocument();
       expect(screen.getByText('Extract fields')).toBeInTheDocument();
@@ -124,7 +128,7 @@ describe('EmptyTransformationsMessage', () => {
         />
       );
 
-      const sqlCard = screen.getByTestId('transform-with-sql-card');
+      const sqlCard = await screen.findByTestId('transform-with-sql-card');
       const button = sqlCard.querySelector('button');
       await user.click(button!);
 
@@ -148,8 +152,8 @@ describe('EmptyTransformationsMessage', () => {
       expect(screen.getByTestId(selectors.components.Transforms.addTransformationButton)).toBeInTheDocument();
     });
 
-    it('should hide SQL expression card for frontend datasources', () => {
-      const mockGetInstanceSettings = jest.fn().mockReturnValue({
+    it('should hide SQL expression card for frontend datasources', async () => {
+      mockGetDataSourceInstanceSettings.mockResolvedValue({
         uid: MOCK_DATA_SOURCE_UID,
         type: 'test',
         name: 'Test DS',
@@ -157,10 +161,6 @@ describe('EmptyTransformationsMessage', () => {
           backend: false, // Frontend datasource
         },
       } as DataSourceInstanceSettings);
-
-      (getDataSourceSrv as jest.Mock).mockReturnValue({
-        getInstanceSettings: mockGetInstanceSettings,
-      });
 
       render(
         <EmptyTransformationsMessage
@@ -173,6 +173,8 @@ describe('EmptyTransformationsMessage', () => {
         />
       );
 
+      await waitFor(() => expect(mockGetDataSourceInstanceSettings).toHaveBeenCalled());
+
       // SQL card should not be shown for frontend datasource
       expect(screen.queryByTestId('transform-with-sql-card')).not.toBeInTheDocument();
 
@@ -180,8 +182,8 @@ describe('EmptyTransformationsMessage', () => {
       expect(screen.getByText('Organize fields by name')).toBeInTheDocument();
     });
 
-    it('should show SQL expression card for backend datasources', () => {
-      const mockGetInstanceSettings = jest.fn().mockReturnValue({
+    it('should show SQL expression card for backend datasources', async () => {
+      mockGetDataSourceInstanceSettings.mockResolvedValue({
         uid: 'prometheus-uid',
         type: 'prometheus',
         name: 'Prometheus',
@@ -189,10 +191,6 @@ describe('EmptyTransformationsMessage', () => {
           backend: true, // Backend datasource
         },
       } as DataSourceInstanceSettings);
-
-      (getDataSourceSrv as jest.Mock).mockReturnValue({
-        getInstanceSettings: mockGetInstanceSettings,
-      });
 
       render(
         <EmptyTransformationsMessage
@@ -206,7 +204,7 @@ describe('EmptyTransformationsMessage', () => {
       );
 
       // SQL card should be shown for backend datasource
-      expect(screen.getByTestId('transform-with-sql-card')).toBeInTheDocument();
+      expect(await screen.findByTestId('transform-with-sql-card')).toBeInTheDocument();
     });
   });
 });

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/EmptyTransformationsMessage.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/EmptyTransformationsMessage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { type DataSourceInstanceSettings, standardTransformersRegistry } from '@grafana/data';
@@ -96,7 +96,7 @@ describe('EmptyTransformationsMessage', () => {
       expect(screen.getByText('Filter data by values')).toBeInTheDocument();
     });
 
-    it('should not show SQL expression card when sqlExpressions toggle is disabled', () => {
+    it('should not show SQL expression card when sqlExpressions toggle is disabled', async () => {
       config.featureToggles.sqlExpressions = false;
 
       render(
@@ -107,6 +107,10 @@ describe('EmptyTransformationsMessage', () => {
           data={[]}
         />
       );
+
+      await act(async () => {
+        await Promise.resolve();
+      });
 
       expect(screen.queryByText('Transform with SQL')).not.toBeInTheDocument();
       // But should still show transformation cards
@@ -135,16 +139,24 @@ describe('EmptyTransformationsMessage', () => {
       expect(onGoToQueries).toHaveBeenCalledTimes(1);
     });
 
-    it('should not show SQL transformation card when onGoToQueries is not provided', () => {
+    it('should not show SQL transformation card when onGoToQueries is not provided', async () => {
       render(
         <EmptyTransformationsMessage onShowPicker={onShowPicker} onAddTransformation={onAddTransformation} data={[]} />
       );
 
+      await act(async () => {
+        await Promise.resolve();
+      });
+
       expect(screen.queryByText('Transform with SQL')).not.toBeInTheDocument();
     });
 
-    it('should not show transformation cards grid when neither onGoToQueries nor onAddTransformation are provided', () => {
+    it('should not show transformation cards grid when neither onGoToQueries nor onAddTransformation are provided', async () => {
       render(<EmptyTransformationsMessage onShowPicker={onShowPicker} data={[]} />);
+
+      await act(async () => {
+        await Promise.resolve();
+      });
 
       expect(screen.queryByText('Transform with SQL')).not.toBeInTheDocument();
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/EmptyTransformationsMessage.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/EmptyTransformationsMessage.tsx
@@ -20,7 +20,7 @@ import { TransformationCard } from '../../../dashboard/components/Transformation
 import sqlDarkImage from '../../../expressions/images/dark/sqlExpression.svg';
 import sqlLightImage from '../../../expressions/images/light/sqlExpression.svg';
 
-import { hasBackendDatasource } from './utils';
+import { useHasBackendDatasource } from './utils';
 
 interface EmptyTransformationsProps {
   onShowPicker: () => void;
@@ -110,11 +110,13 @@ function NewEmptyTransformationsMessage(props: EmptyTransformationsProps) {
     props.onShowPicker();
   };
 
+  const hasBackendDs = useHasBackendDatasource({
+    datasourceUid: props.datasourceUid,
+    queries: props.queries,
+  });
+
   // Show the SQL Expression card if any datasource in the query set is a backend datasource.
-  const showSqlCard =
-    hasGoToQueries &&
-    config.featureToggles.sqlExpressions &&
-    hasBackendDatasource({ datasourceUid: props.datasourceUid, queries: props.queries });
+  const showSqlCard = hasGoToQueries && config.featureToggles.sqlExpressions && hasBackendDs;
 
   return (
     <Box padding={2}>

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.test.tsx
@@ -204,6 +204,46 @@ const MixedDsSettingsMock = {
 
 const panelPlugin = getPanelPlugin({ id: 'timeseries', skipDataQuery: false });
 
+function resolveMockUid(ref?: DataSourceRef | string | null) {
+  return typeof ref === 'string' ? ref : ref?.uid;
+}
+
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstance: async (ref?: DataSourceRef | string | null) => {
+    const uid = resolveMockUid(ref);
+    if (uid === '-- Grafana --') {
+      return grafanaDs;
+    }
+    if (uid === 'gdev-testdata') {
+      return ds1Mock;
+    }
+    if (uid === 'gdev-prometheus') {
+      return ds2Mock;
+    }
+    if (uid === '-- Mixed --') {
+      return MixedDs;
+    }
+    if (uid === SHARED_DASHBOARD_QUERY) {
+      return ds3Mock;
+    }
+    return defaultDsMock;
+  },
+  getDataSourceInstanceSettings: async (ref?: DataSourceRef | string | null) => {
+    const uid = resolveMockUid(ref);
+    if (uid === 'gdev-testdata') {
+      return instance1SettingsMock;
+    }
+    if (uid === 'gdev-prometheus') {
+      return instance2SettingsMock;
+    }
+    if (uid === '-- Mixed --') {
+      return MixedDsSettingsMock;
+    }
+    return instance1SettingsMock;
+  },
+}));
+
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   getRunRequest: () => (ds: DataSourceApi, request: DataQueryRequest) => {
@@ -370,7 +410,7 @@ describe('PanelDataQueriesTab', () => {
     it('can add a new query', async () => {
       const { queriesTab } = await setupScene('panel-1');
 
-      queriesTab.addQueryClick();
+      await queriesTab.addQueryClick();
 
       expect(queriesTab.queryRunner.state.queries).toHaveLength(2);
       expect(queriesTab.queryRunner.state.queries[1].refId).toBe('B');
@@ -387,7 +427,7 @@ describe('PanelDataQueriesTab', () => {
       expect(queriesTab.state.datasource?.uid).toBe('-- Mixed --');
       expect(queriesTab.queryRunner.state.datasource?.uid).toBe('-- Mixed --');
 
-      queriesTab.addQueryClick();
+      await queriesTab.addQueryClick();
 
       expect(queriesTab.queryRunner.state.queries).toHaveLength(2);
       expect(queriesTab.queryRunner.state.queries[1].refId).toBe('B');

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
@@ -401,13 +401,18 @@ export function PanelDataQueriesTabRendered({ model }: SceneComponentProps<Panel
 
   // Determine which expressions should be disabled (for frontend-only datasources)
   const disabledExpressions = useMemo(() => {
-    if (!hasBackendDs) {
-      return {
-        [ExpressionQueryType.sql]:
-          'SQL expressions can only evaluate results from backend datasources. This panel only contains frontend datasources.',
-      };
+    if (hasBackendDs === true) {
+      return {};
     }
-    return {};
+
+    // Pending (`undefined`) must not keep SQL enabled after a backend → frontend switch,
+    // and must not claim the panel is frontend-only before the lookup resolves.
+    return {
+      [ExpressionQueryType.sql]:
+        hasBackendDs === false
+          ? 'SQL expressions can only evaluate results from backend datasources. This panel only contains frontend datasources.'
+          : 'SQL expressions can only evaluate results from backend datasources.',
+    };
   }, [hasBackendDs]);
 
   if (!datasource || !dsSettings || !data) {

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
@@ -3,7 +3,8 @@ import { useCallback, useMemo } from 'react';
 import { CoreApp, type DataSourceApi, type DataSourceInstanceSettings, getDataSourceRef } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
-import { config, getDataSourceSrv, reportInteraction } from '@grafana/runtime';
+import { config, reportInteraction } from '@grafana/runtime';
+import { getDataSourceInstance, getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import {
   SafeSerializableSceneObject,
   type SceneComponentProps,
@@ -36,7 +37,6 @@ import { MIXED_DATASOURCE_NAME } from '../../../../plugins/datasource/mixed/Mixe
 import { useQueryLibraryContext } from '../../../explore/QueryLibrary/QueryLibraryContext';
 import { hasSavedQueryReadPermissions } from '../../../explore/QueryLibrary/utils/identity';
 import { ExpressionDatasourceUID } from '../../../expressions/types';
-import { getDatasourceSrv } from '../../../plugins/datasource_srv';
 import { PanelInspectDrawer } from '../../inspect/PanelInspectDrawer';
 import { PanelTimeRange } from '../../scene/panel-timerange/PanelTimeRange';
 import { getUpdatedHoverHeader } from '../../scene/panel-timerange/utils';
@@ -44,7 +44,7 @@ import { getDashboardSceneFor, getQueryRunnerFor } from '../../utils/utils';
 import { trackAddQuery } from '../PanelEditNext/tracking';
 
 import { type PanelDataPaneTab, type PanelDataTabHeaderProps, TabId } from './types';
-import { hasBackendDatasource } from './utils';
+import { useHasBackendDatasource } from './utils';
 
 interface PanelDataQueriesTabState extends SceneObjectState {
   datasource?: DataSourceApi;
@@ -122,9 +122,9 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
         // do we have a last used datasource for this dashboard
         if (lastUsedDatasource?.datasourceUid !== null) {
           // get datasource from dashbopard uid
-          dsSettings = getDataSourceSrv().getInstanceSettings({ uid: lastUsedDatasource?.datasourceUid }, panelContext);
+          dsSettings = await getDataSourceInstanceSettings({ uid: lastUsedDatasource?.datasourceUid }, panelContext);
           if (dsSettings) {
-            datasource = await getDataSourceSrv().get(
+            datasource = await getDataSourceInstance(
               {
                 uid: lastUsedDatasource?.datasourceUid,
                 type: dsSettings.type,
@@ -141,8 +141,8 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
           }
         }
       } else {
-        datasource = await getDataSourceSrv().get(datasourceToLoad, panelContext);
-        dsSettings = getDataSourceSrv().getInstanceSettings(datasourceToLoad, panelContext);
+        datasource = await getDataSourceInstance(datasourceToLoad, panelContext);
+        dsSettings = await getDataSourceInstanceSettings(datasourceToLoad, panelContext);
       }
 
       if (datasource && dsSettings) {
@@ -151,8 +151,8 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
       }
     } catch (err) {
       //set default datasource if we fail to load the datasource
-      const datasource = await getDataSourceSrv().get(config.defaultDatasource);
-      const dsSettings = getDataSourceSrv().getInstanceSettings(config.defaultDatasource);
+      const datasource = await getDataSourceInstance(config.defaultDatasource);
+      const dsSettings = await getDataSourceInstanceSettings(config.defaultDatasource);
 
       if (datasource && dsSettings) {
         this.setState({
@@ -215,8 +215,8 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
     const queryRunner = this.queryRunner;
     const panelContext = this.getPanelContext();
 
-    const currentDS = dsSettings ? await getDataSourceSrv().get({ uid: dsSettings.uid }, panelContext) : undefined;
-    const nextDS = await getDataSourceSrv().get({ uid: newSettings.uid }, panelContext);
+    const currentDS = dsSettings ? await getDataSourceInstance({ uid: dsSettings.uid }, panelContext) : undefined;
+    const nextDS = await getDataSourceInstance({ uid: newSettings.uid }, panelContext);
 
     const currentQueries = queryRunner.state.queries;
 
@@ -229,7 +229,7 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
       queryRunner.runQueries();
     }
 
-    this.loadDataSource();
+    await this.loadDataSource();
   };
 
   public onQueryOptionsChange = (options: QueryGroupOptions) => {
@@ -288,7 +288,7 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
     return this.queryRunner.state.queries;
   }
 
-  public newQuery(): Partial<DataQuery> {
+  public async newQuery(): Promise<Partial<DataQuery>> {
     const { dsSettings, datasource } = this.state;
     let ds;
 
@@ -298,7 +298,7 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
       ds = datasource; // Use datasource if dsSettings is mixed but datasource is not
     } else {
       // Use default datasource if both are mixed or just datasource is mixed
-      ds = getDataSourceSrv().getInstanceSettings(config.defaultDatasource);
+      ds = await getDataSourceInstanceSettings(config.defaultDatasource);
     }
 
     return {
@@ -307,10 +307,10 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
     };
   }
 
-  public addQueryClick = () => {
+  public addQueryClick = async () => {
     const queries = this.getQueries();
     trackAddQuery('new_query', 'legacy', { silent: true });
-    this.onQueriesChange(addQuery(queries, this.newQuery()));
+    this.onQueriesChange(addQuery(queries, await this.newQuery()));
   };
 
   public onAddQuery = (query: Partial<DataQuery>) => {
@@ -364,7 +364,7 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
     const { datasource } = this.state;
     const shouldChangeDatasource = datasource?.uid !== newDatasourceRef.uid;
     if (shouldChangeDatasource) {
-      const newDatasource = getDatasourceSrv().getInstanceSettings(newDatasourceRef);
+      const newDatasource = await getDataSourceInstanceSettings(newDatasourceRef);
       if (newDatasource) {
         await this.onChangeDataSource(newDatasource);
       }
@@ -394,9 +394,13 @@ export function PanelDataQueriesTabRendered({ model }: SceneComponentProps<Panel
     model.setState({ scrollToRefId: undefined });
   }, [model]);
 
+  const hasBackendDs = useHasBackendDatasource({
+    datasourceUid: datasourceState?.uid ?? dsSettings?.uid,
+    queries,
+  });
+
   // Determine which expressions should be disabled (for frontend-only datasources)
   const disabledExpressions = useMemo(() => {
-    const hasBackendDs = hasBackendDatasource({ datasourceUid: datasourceState?.uid ?? dsSettings?.uid, queries });
     if (!hasBackendDs) {
       return {
         [ExpressionQueryType.sql]:
@@ -404,7 +408,7 @@ export function PanelDataQueriesTabRendered({ model }: SceneComponentProps<Panel
       };
     }
     return {};
-  }, [datasourceState?.uid, dsSettings?.uid, queries]);
+  }, [hasBackendDs]);
 
   if (!datasource || !dsSettings || !data) {
     return null;

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
@@ -410,8 +410,14 @@ export function PanelDataQueriesTabRendered({ model }: SceneComponentProps<Panel
     return {
       [ExpressionQueryType.sql]:
         hasBackendDs === false
-          ? 'SQL expressions can only evaluate results from backend datasources. This panel only contains frontend datasources.'
-          : 'SQL expressions can only evaluate results from backend datasources.',
+          ? t(
+              'dashboard-scene.panel-data-queries-tab-rendered.sql-expressions-frontend-only',
+              'SQL expressions can only evaluate results from backend datasources. This panel only contains frontend datasources.'
+            )
+          : t(
+              'dashboard-scene.panel-data-queries-tab-rendered.sql-expressions-pending',
+              'SQL expressions can only evaluate results from backend datasources.'
+            ),
     };
   }, [hasBackendDs]);
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataTransformationsTab.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataTransformationsTab.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import {
@@ -185,7 +185,11 @@ describe('PanelDataTransformationsTab', () => {
     const modelMock = createModelMock(mockData);
     render(<PanelDataTransformationsTabRendered model={modelMock}></PanelDataTransformationsTabRendered>);
 
-    // Should show SQL transformation card in empty state
+    // Flush useHasBackendDatasource so setResolved is wrapped in act
+    await act(async () => {
+      await Promise.resolve();
+    });
+
     expect(screen.getByText('Add a Transformation')).toBeInTheDocument();
   });
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/utils.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/utils.test.ts
@@ -1,10 +1,12 @@
+import { renderHook, waitFor } from '@testing-library/react';
+
 import { type DataSourceInstanceSettings } from '@grafana/data';
 import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { type DataQuery } from '@grafana/schema';
 import { ExpressionDatasourceUID } from 'app/features/expressions/types';
 import { SHARED_DASHBOARD_QUERY } from 'app/plugins/datasource/dashboard/constants';
 
-import { hasBackendDatasource } from './utils';
+import { hasBackendDatasource, useHasBackendDatasource } from './utils';
 
 jest.mock('@grafana/runtime/unstable', () => ({
   ...jest.requireActual('@grafana/runtime/unstable'),
@@ -161,5 +163,100 @@ describe('hasBackendDatasource', () => {
 
     const result = await hasBackendDatasource({ datasourceUid: undefined, queries: [{ refId: 'A' }] });
     expect(result).toBe(false);
+  });
+});
+
+describe('useHasBackendDatasource', () => {
+  const mockGetDataSourceInstanceSettings = jest.mocked(getDataSourceInstanceSettings);
+
+  const backendSettings = {
+    uid: 'backend-ds',
+    type: 'prometheus',
+    name: 'Prometheus',
+    meta: { backend: true },
+  } as DataSourceInstanceSettings;
+
+  const frontendSettings = {
+    uid: 'frontend-ds',
+    type: 'grafana',
+    name: 'Grafana',
+    meta: {},
+  } as DataSourceInstanceSettings;
+
+  function deferred<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((res) => {
+      resolve = res;
+    });
+    return { promise, resolve };
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns undefined until the datasource lookup resolves', async () => {
+    const pending = deferred<DataSourceInstanceSettings | undefined>();
+    mockGetDataSourceInstanceSettings.mockReturnValue(pending.promise);
+
+    const { result } = renderHook(() => useHasBackendDatasource({ datasourceUid: 'backend-ds' }));
+
+    expect(result.current).toBeUndefined();
+
+    pending.resolve(backendSettings);
+
+    await waitFor(() => {
+      expect(result.current).toBe(true);
+    });
+  });
+
+  it('clears a previous true while a frontend lookup is in flight', async () => {
+    mockGetDataSourceInstanceSettings.mockResolvedValueOnce(backendSettings);
+
+    const { result, rerender } = renderHook(({ datasourceUid }) => useHasBackendDatasource({ datasourceUid }), {
+      initialProps: { datasourceUid: 'backend-ds' },
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBe(true);
+    });
+
+    const pending = deferred<DataSourceInstanceSettings | undefined>();
+    mockGetDataSourceInstanceSettings.mockReturnValue(pending.promise);
+
+    rerender({ datasourceUid: 'frontend-ds' });
+
+    expect(result.current).toBeUndefined();
+
+    pending.resolve(frontendSettings);
+
+    await waitFor(() => {
+      expect(result.current).toBe(false);
+    });
+  });
+
+  it('does not apply a stale backend result after switching to a frontend datasource', async () => {
+    const first = deferred<DataSourceInstanceSettings | undefined>();
+    const second = deferred<DataSourceInstanceSettings | undefined>();
+    mockGetDataSourceInstanceSettings.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+
+    const { result, rerender } = renderHook(({ datasourceUid }) => useHasBackendDatasource({ datasourceUid }), {
+      initialProps: { datasourceUid: 'backend-ds' },
+    });
+
+    expect(result.current).toBeUndefined();
+
+    rerender({ datasourceUid: 'frontend-ds' });
+    expect(result.current).toBeUndefined();
+
+    first.resolve(backendSettings);
+    await Promise.resolve();
+    expect(result.current).toBeUndefined();
+
+    second.resolve(frontendSettings);
+
+    await waitFor(() => {
+      expect(result.current).toBe(false);
+    });
   });
 });

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/utils.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/utils.test.ts
@@ -1,18 +1,20 @@
 import { type DataSourceInstanceSettings } from '@grafana/data';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { type DataQuery } from '@grafana/schema';
 import { ExpressionDatasourceUID } from 'app/features/expressions/types';
 import { SHARED_DASHBOARD_QUERY } from 'app/plugins/datasource/dashboard/constants';
 
 import { hasBackendDatasource } from './utils';
 
-jest.mock('@grafana/runtime', () => ({
-  ...jest.requireActual('@grafana/runtime'),
-  getDataSourceSrv: jest.fn(),
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstanceSettings: jest.fn(),
 }));
 
 describe('hasBackendDatasource', () => {
-  const mockGetDataSourceSrv = getDataSourceSrv as jest.Mock;
+  const mockGetDataSourceInstanceSettings = getDataSourceInstanceSettings as jest.MockedFunction<
+    typeof getDataSourceInstanceSettings
+  >;
 
   const prometheusSettings = {
     uid: 'prometheus-uid',
@@ -30,8 +32,9 @@ describe('hasBackendDatasource', () => {
   } as DataSourceInstanceSettings;
 
   function mockInstanceSettings(...available: DataSourceInstanceSettings[]) {
-    mockGetDataSourceSrv.mockReturnValue({
-      getInstanceSettings: jest.fn((uid: string) => available.find((settings) => settings.uid === uid) ?? null),
+    mockGetDataSourceInstanceSettings.mockImplementation(async (uid) => {
+      const resolvedUid = typeof uid === 'string' ? uid : uid?.uid;
+      return available.find((settings) => settings.uid === resolvedUid);
     });
   }
 
@@ -39,60 +42,55 @@ describe('hasBackendDatasource', () => {
     jest.clearAllMocks();
   });
 
-  it('should return false when datasourceUid is SHARED_DASHBOARD_QUERY', () => {
-    const result = hasBackendDatasource({ datasourceUid: SHARED_DASHBOARD_QUERY });
+  it('should return false when datasourceUid is SHARED_DASHBOARD_QUERY', async () => {
+    const result = await hasBackendDatasource({ datasourceUid: SHARED_DASHBOARD_QUERY });
     expect(result).toBe(false);
   });
 
-  it('should return false when datasourceUid is undefined', () => {
-    const result = hasBackendDatasource({ datasourceUid: undefined });
+  it('should return false when datasourceUid is undefined', async () => {
+    const result = await hasBackendDatasource({ datasourceUid: undefined });
     expect(result).toBe(false);
   });
 
-  it('should return false when datasource settings cannot be found', () => {
-    mockGetDataSourceSrv.mockReturnValue({
-      getInstanceSettings: jest.fn().mockReturnValue(null),
-    });
+  it('should return false when datasource settings cannot be found', async () => {
+    mockGetDataSourceInstanceSettings.mockResolvedValue(undefined);
 
-    const result = hasBackendDatasource({ datasourceUid: 'unknown-uid' });
+    const result = await hasBackendDatasource({ datasourceUid: 'unknown-uid' });
     expect(result).toBe(false);
   });
 
-  it('should return true when datasource has meta.backend === true', () => {
-    mockGetDataSourceSrv.mockReturnValue({
-      getInstanceSettings: jest.fn().mockReturnValue({
-        uid: 'test-ds',
-        type: 'test',
-        name: 'Test DS',
-        meta: {
-          backend: true,
-        },
-      } as DataSourceInstanceSettings),
-    });
+  it('should return true when datasource has meta.backend === true', async () => {
+    mockGetDataSourceInstanceSettings.mockResolvedValue({
+      uid: 'test-ds',
+      type: 'test',
+      name: 'Test DS',
+      meta: {
+        backend: true,
+      },
+    } as DataSourceInstanceSettings);
 
-    const result = hasBackendDatasource({ datasourceUid: 'test-ds' });
+    const result = await hasBackendDatasource({ datasourceUid: 'test-ds' });
     expect(result).toBe(true);
   });
 
-  it('should return false when datasource has meta.backend === undefined', () => {
-    mockGetDataSourceSrv.mockReturnValue({
-      getInstanceSettings: jest.fn().mockReturnValue({
-        uid: 'test-ds',
-        type: 'test',
-        name: 'Test DS',
-        meta: {
-          // backend is undefined
-        },
-      } as DataSourceInstanceSettings),
-    });
+  it('should return false when datasource has meta.backend === undefined', async () => {
+    mockGetDataSourceInstanceSettings.mockResolvedValue({
+      uid: 'test-ds',
+      type: 'test',
+      name: 'Test DS',
+      meta: {
+        // backend is undefined
+      },
+    } as DataSourceInstanceSettings);
 
-    const result = hasBackendDatasource({ datasourceUid: 'test-ds' });
+    const result = await hasBackendDatasource({ datasourceUid: 'test-ds' });
     expect(result).toBe(false);
   });
 
-  it('should return true when mixed datasource has at least one query using a backend datasource', () => {
-    const mockGetInstanceSettings = jest.fn((uid: string) => {
-      if (uid === 'mixed-uid') {
+  it('should return true when mixed datasource has at least one query using a backend datasource', async () => {
+    mockGetDataSourceInstanceSettings.mockImplementation(async (uid) => {
+      const resolvedUid = typeof uid === 'string' ? uid : uid?.uid;
+      if (resolvedUid === 'mixed-uid') {
         return {
           uid: 'mixed-uid',
           type: 'mixed',
@@ -102,7 +100,7 @@ describe('hasBackendDatasource', () => {
           },
         } as DataSourceInstanceSettings;
       }
-      if (uid === 'prometheus-uid') {
+      if (resolvedUid === 'prometheus-uid') {
         return {
           uid: 'prometheus-uid',
           type: 'prometheus',
@@ -112,11 +110,7 @@ describe('hasBackendDatasource', () => {
           },
         } as DataSourceInstanceSettings;
       }
-      return null;
-    });
-
-    mockGetDataSourceSrv.mockReturnValue({
-      getInstanceSettings: mockGetInstanceSettings,
+      return undefined;
     });
 
     const queries: DataQuery[] = [
@@ -124,22 +118,22 @@ describe('hasBackendDatasource', () => {
       { refId: 'B', datasource: { uid: 'prometheus-uid', type: 'prometheus' } },
     ];
 
-    const result = hasBackendDatasource({ datasourceUid: 'mixed-uid', queries });
+    const result = await hasBackendDatasource({ datasourceUid: 'mixed-uid', queries });
     expect(result).toBe(true);
   });
 
   // V2 panels only carry a panel level datasource when their queries are mixed.
-  it('should fall back to the queries when there is no panel level datasource', () => {
+  it('should fall back to the queries when there is no panel level datasource', async () => {
     mockInstanceSettings(prometheusSettings);
 
     const queries: DataQuery[] = [{ refId: 'A', datasource: { uid: 'prometheus-uid', type: 'prometheus' } }];
 
-    const result = hasBackendDatasource({ datasourceUid: undefined, queries });
+    const result = await hasBackendDatasource({ datasourceUid: undefined, queries });
     expect(result).toBe(true);
   });
 
   // Callers that infer the panel datasource from the first query land here when it is an expression.
-  it('should fall back to the queries when the panel level datasource is an expression', () => {
+  it('should fall back to the queries when the panel level datasource is an expression', async () => {
     mockInstanceSettings(expressionSettings, prometheusSettings);
 
     const queries: DataQuery[] = [
@@ -147,25 +141,25 @@ describe('hasBackendDatasource', () => {
       { refId: 'B', datasource: { uid: 'prometheus-uid', type: 'prometheus' } },
     ];
 
-    const result = hasBackendDatasource({ datasourceUid: ExpressionDatasourceUID, queries });
+    const result = await hasBackendDatasource({ datasourceUid: ExpressionDatasourceUID, queries });
     expect(result).toBe(true);
   });
 
-  it('should return false when the queries only use expressions', () => {
+  it('should return false when the queries only use expressions', async () => {
     mockInstanceSettings(expressionSettings);
 
     const queries: DataQuery[] = [
       { refId: 'A', datasource: { uid: ExpressionDatasourceUID, type: ExpressionDatasourceUID } },
     ];
 
-    const result = hasBackendDatasource({ datasourceUid: undefined, queries });
+    const result = await hasBackendDatasource({ datasourceUid: undefined, queries });
     expect(result).toBe(false);
   });
 
-  it('should return false when neither the panel nor its queries have a datasource', () => {
+  it('should return false when neither the panel nor its queries have a datasource', async () => {
     mockInstanceSettings(prometheusSettings);
 
-    const result = hasBackendDatasource({ datasourceUid: undefined, queries: [{ refId: 'A' }] });
+    const result = await hasBackendDatasource({ datasourceUid: undefined, queries: [{ refId: 'A' }] });
     expect(result).toBe(false);
   });
 });

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/utils.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/utils.ts
@@ -49,22 +49,28 @@ export async function hasBackendDatasource({
   return results.some(Boolean);
 }
 
+/**
+ * `undefined` means the lookup has not resolved for the current datasource/queries yet.
+ * Callers must not treat that as frontend-only — the previous result is also discarded
+ * as soon as the inputs change, so a stale `true` cannot linger mid-switch.
+ */
 export function useHasBackendDatasource({
   datasourceUid,
   queries,
 }: {
   datasourceUid: string | undefined;
   queries?: DataQuery[];
-}): boolean {
-  const [result, setResult] = useState(false);
+}): boolean | undefined {
   const queryKey = useMemo(() => JSON.stringify(queries?.map((query) => query.datasource?.uid) ?? []), [queries]);
+  const lookupKey = `${datasourceUid ?? ''}:${queryKey}`;
+  const [resolved, setResolved] = useState<{ key: string; value: boolean }>();
 
   useEffect(() => {
     let cancelled = false;
 
     hasBackendDatasource({ datasourceUid, queries }).then((value) => {
       if (!cancelled) {
-        setResult(value);
+        setResolved({ key: lookupKey, value });
       }
     });
 
@@ -73,7 +79,7 @@ export function useHasBackendDatasource({
     };
     // queryKey covers query datasource identity; queries is read inside the callback
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [datasourceUid, queryKey]);
+  }, [datasourceUid, queryKey, lookupKey]);
 
-  return result;
+  return resolved?.key === lookupKey ? resolved.value : undefined;
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/utils.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/utils.ts
@@ -1,12 +1,15 @@
-import { getDataSourceSrv, isExpressionReference } from '@grafana/runtime';
+import { useEffect, useMemo, useState } from 'react';
+
+import { isExpressionReference } from '@grafana/runtime';
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { type DataQuery } from '@grafana/schema';
 import { SHARED_DASHBOARD_QUERY } from 'app/plugins/datasource/dashboard/constants';
 
-function isBackendDatasource(uid: string): boolean {
+async function isBackendDatasource(uid: string): Promise<boolean> {
   if (uid === SHARED_DASHBOARD_QUERY) {
     return false;
   }
-  const settings = getDataSourceSrv().getInstanceSettings(uid);
+  const settings = await getDataSourceInstanceSettings(uid);
   return settings?.meta.backend === true;
 }
 
@@ -14,13 +17,13 @@ function isBackendDatasource(uid: string): boolean {
  * Checks if there's at least one backend datasource available in the panel
  * Backend datasources have meta.backend === true
  */
-export function hasBackendDatasource({
+export async function hasBackendDatasource({
   datasourceUid,
   queries,
 }: {
   datasourceUid: string | undefined;
   queries?: DataQuery[];
-}): boolean {
+}): Promise<boolean> {
   if (datasourceUid === SHARED_DASHBOARD_QUERY) {
     return false;
   }
@@ -29,12 +32,48 @@ export function hasBackendDatasource({
   // panels don't carry one unless the queries are mixed, and callers that infer it from the first
   // query can land on an expression ref, so both of those fall through to the queries below.
   if (datasourceUid && !isExpressionReference(datasourceUid)) {
-    const mainDsSettings = getDataSourceSrv().getInstanceSettings(datasourceUid);
+    const mainDsSettings = await getDataSourceInstanceSettings(datasourceUid);
     if (mainDsSettings && !mainDsSettings.meta.mixed) {
       return mainDsSettings.meta.backend === true;
     }
   }
 
   // Expression queries resolve to settings without meta.backend, so they never count as backend.
-  return queries?.some((query) => query.datasource?.uid && isBackendDatasource(query.datasource.uid)) ?? false;
+  if (!queries?.length) {
+    return false;
+  }
+
+  const results = await Promise.all(
+    queries.map((query) => (query.datasource?.uid ? isBackendDatasource(query.datasource.uid) : Promise.resolve(false)))
+  );
+  return results.some(Boolean);
+}
+
+export function useHasBackendDatasource({
+  datasourceUid,
+  queries,
+}: {
+  datasourceUid: string | undefined;
+  queries?: DataQuery[];
+}): boolean {
+  const [result, setResult] = useState(false);
+  const queryKey = useMemo(() => JSON.stringify(queries?.map((query) => query.datasource?.uid) ?? []), [queries]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    hasBackendDatasource({ datasourceUid, queries }).then((value) => {
+      if (!cancelled) {
+        setResult(value);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+    // queryKey covers query datasource identity; queries is read inside the callback
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [datasourceUid, queryKey]);
+
+  return result;
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/TransformationTypePicker.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/TransformationTypePicker.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor, within } from '@testing-library/react';
+import { act, screen, waitFor, within } from '@testing-library/react';
 
 import { standardTransformersRegistry } from '@grafana/data';
 import { getStandardTransformers } from 'app/features/transformers/standardTransformers';
@@ -10,8 +10,12 @@ import { TransformationTypePicker } from './TransformationTypePicker';
 describe('TransformationTypePicker', () => {
   standardTransformersRegistry.setInit(getStandardTransformers);
 
-  it('renders a search input and the transformation cards', () => {
+  it('renders a search input and the transformation cards', async () => {
     renderWithQueryEditorProvider(<TransformationTypePicker />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
 
     expect(screen.getByPlaceholderText('Search for transformation')).toBeInTheDocument();
     expect(screen.getByText('Reduce')).toBeInTheDocument();

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/TransformationTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/TransformationTypePicker.tsx
@@ -9,7 +9,7 @@ import { EmptyState, FilterPill, Grid, IconButton, Input, Stack, Switch, useStyl
 import config from 'app/core/config';
 import { TransformationCard } from 'app/features/dashboard/components/TransformationsEditor/TransformationCard';
 import { TransformationSearchStatus } from 'app/features/dashboard/components/TransformationsEditor/TransformationSearchStatus';
-import { hasBackendDatasource } from 'app/features/dashboard-scene/panel-edit/PanelDataPane/utils';
+import { useHasBackendDatasource } from 'app/features/dashboard-scene/panel-edit/PanelDataPane/utils';
 import { ExpressionQueryType } from 'app/features/expressions/types';
 
 import { trackTransformationFilterChanged, trackTransformationSearch } from '../../tracking';
@@ -39,8 +39,8 @@ export function TransformationTypePicker() {
     allTransformationsCount,
   } = useTransformationSearchAndFilter(finalizePendingTransformation);
 
-  const showSqlCTA =
-    config.featureToggles.sqlExpressions && hasBackendDatasource({ datasourceUid: dsSettings?.uid, queries });
+  const hasBackendDs = useHasBackendDatasource({ datasourceUid: dsSettings?.uid, queries });
+  const showSqlCTA = config.featureToggles.sqlExpressions && hasBackendDs;
 
   const handleAddSqlExpression = useCallback(() => {
     reportInteraction('dashboards_expression_interaction', {

--- a/public/app/features/dashboard-scene/scene/DashboardDataLayerSet.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardDataLayerSet.tsx
@@ -1,5 +1,5 @@
 import { type AnnotationQuery, getDataSourceRef } from '@grafana/data';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import {
   type SceneDataLayerProviderState,
   type SceneDataLayerProvider,
@@ -56,8 +56,8 @@ export class DashboardDataLayerSet
     this.setState({ annotationLayers: [...this.state.annotationLayers, layer] });
   }
 
-  public createDefaultAnnotationLayer(): DashboardAnnotationsDataLayer {
-    const defaultDatasource = getDataSourceSrv().getInstanceSettings(null);
+  public async createDefaultAnnotationLayer(): Promise<DashboardAnnotationsDataLayer> {
+    const defaultDatasource = await getDataSourceInstanceSettings(null);
     const datasourceRef = defaultDatasource?.meta.annotations ? getDataSourceRef(defaultDatasource) : undefined;
 
     const newAnnotationQuery: AnnotationQuery = {

--- a/public/app/features/dashboard-scene/scene/panel-actions/PanelGroupByAction/PanelGroupByAction.tsx
+++ b/public/app/features/dashboard-scene/scene/panel-actions/PanelGroupByAction/PanelGroupByAction.tsx
@@ -3,7 +3,7 @@ import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { fuzzySearch, type MetricFindValue } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans } from '@grafana/i18n';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import {
   type AdHocFiltersVariable,
   GroupByVariable,
@@ -42,7 +42,7 @@ export function PanelGroupByAction({ groupByVariable, adhocGroupByVariable, quer
       let fetchedOptions: VariableValueOption[];
 
       if (groupByVariable) {
-        const ds = await getDataSourceSrv().get(groupByVariable.state.datasource);
+        const ds = await getDataSourceInstance(groupByVariable.state.datasource);
         const keys = await groupByVariable._getKeys(ds, queries);
         fetchedOptions = metricFindValuesToOptions(Array.isArray(keys) ? keys : (keys.data ?? []));
       } else if (adhocGroupByVariable) {

--- a/public/app/features/dashboard-scene/scene/setDashboardPanelContext.test.ts
+++ b/public/app/features/dashboard-scene/scene/setDashboardPanelContext.test.ts
@@ -20,6 +20,13 @@ jest.mock('../../annotations/isAnnotationApiAvailable');
 jest.mock('@grafana/runtime/internal', () => ({
   ...jest.requireActual('@grafana/runtime/internal'),
   getFeatureFlagClient: jest.fn(),
+  getDatasourcePluginMeta: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstance: jest.fn().mockResolvedValue({ uid: 'my-ds-uid', type: 'prometheus' }),
+  getDataSourceInstanceSettings: jest.fn().mockResolvedValue(undefined),
 }));
 
 const mockIsAnnotationApiAvailable = jest.mocked(isAnnotationApiAvailable);
@@ -283,13 +290,13 @@ describe('setDashboardPanelContext', () => {
   });
 
   describe('onAddAdHocFilter', () => {
-    it('Should add new filter set', () => {
+    it('Should add new filter set', async () => {
       const { scene, context } = buildTestScene({});
 
-      context.onAddAdHocFilter!({ key: 'hello', value: 'world', operator: '!=' });
-      context.onAddAdHocFilter!({ key: 'hello', value: 'world2', operator: '!=' });
+      await context.onAddAdHocFilter!({ key: 'hello', value: 'world', operator: '!=' });
+      await context.onAddAdHocFilter!({ key: 'hello', value: 'world2', operator: '!=' });
 
-      const variable = getAdHocFilterVariableFor(scene, { uid: 'my-ds-uid' });
+      const variable = await getAdHocFilterVariableFor(scene, { uid: 'my-ds-uid' });
 
       expect(variable.state.filters).toEqual([
         { key: 'hello', value: 'world', operator: '!=' },
@@ -298,30 +305,30 @@ describe('setDashboardPanelContext', () => {
       ]);
     });
 
-    it('Should update and add filter to existing set', () => {
+    it('Should update and add filter to existing set', async () => {
       const { scene, context } = buildTestScene({ existingFilterVariable: true });
 
-      const variable = getAdHocFilterVariableFor(scene, { uid: 'my-ds-uid' });
+      const variable = await getAdHocFilterVariableFor(scene, { uid: 'my-ds-uid' });
 
       variable.setState({ filters: [{ key: 'existing', value: 'world', operator: '=' }] });
 
-      context.onAddAdHocFilter!({ key: 'hello', value: 'world', operator: '=' });
+      await context.onAddAdHocFilter!({ key: 'hello', value: 'world', operator: '=' });
 
       expect(variable.state.filters.length).toBe(2);
 
       // Can update existing filter value without adding a new filter
-      context.onAddAdHocFilter!({ key: 'hello', value: 'world', operator: '!=' });
+      await context.onAddAdHocFilter!({ key: 'hello', value: 'world', operator: '!=' });
       // Verify existing filter value updated
       expect(variable.state.filters[1].operator).toBe('!=');
     });
 
-    it('Should use existing adhoc filter when panel has no panel-level datasource because queries have all the same datasources (v2 behavior)', () => {
+    it('Should use existing adhoc filter when panel has no panel-level datasource because queries have all the same datasources (v2 behavior)', async () => {
       const { scene, context } = buildTestScene({ existingFilterVariable: true, panelDatasourceUndefined: true });
 
-      const variable = getAdHocFilterVariableFor(scene, { uid: 'my-ds-uid' });
+      const variable = await getAdHocFilterVariableFor(scene, { uid: 'my-ds-uid' });
       variable.setState({ filters: [] });
 
-      context.onAddAdHocFilter!({ key: 'hello', value: 'world', operator: '=' });
+      await context.onAddAdHocFilter!({ key: 'hello', value: 'world', operator: '=' });
 
       // Should use the existing adhoc filter variable, not create a new one
       expect(variable.state.filters).toEqual([{ key: 'hello', value: 'world', operator: '=' }]);
@@ -415,31 +422,31 @@ describe('setDashboardPanelContext', () => {
   });
 
   describe('onAddAdHocFilters', () => {
-    it('should add adhoc filters', () => {
+    it('should add adhoc filters', async () => {
       const { scene, context } = buildTestScene({
         existingFilterVariable: true,
       });
 
-      const variable = getAdHocFilterVariableFor(scene, { uid: 'my-ds-uid' });
+      const variable = await getAdHocFilterVariableFor(scene, { uid: 'my-ds-uid' });
 
       const filters: AdHocFilterItem[] = [
         { key: 'existing', value: 'val', operator: '=' },
         { key: 'cluster', value: 'cluster', operator: '=' },
       ];
 
-      context.onAddAdHocFilters?.(filters);
+      await context.onAddAdHocFilters?.(filters);
       expect(variable.state.filters).toEqual([
         { key: 'existing', value: 'val', operator: '=' },
         { key: 'cluster', value: 'cluster', operator: '=' },
       ]);
     });
 
-    it('should update and add adhoc filters', () => {
+    it('should update and add adhoc filters', async () => {
       const { scene, context } = buildTestScene({
         existingFilterVariable: true,
       });
 
-      const variable = getAdHocFilterVariableFor(scene, { uid: 'my-ds-uid' });
+      const variable = await getAdHocFilterVariableFor(scene, { uid: 'my-ds-uid' });
 
       variable.setState({ filters: [{ key: 'existing', value: 'val', operator: '=' }] });
 
@@ -450,7 +457,7 @@ describe('setDashboardPanelContext', () => {
         { key: 'id', value: 'id', operator: '=' },
       ];
 
-      context.onAddAdHocFilters?.(filters);
+      await context.onAddAdHocFilters?.(filters);
       expect(variable.state.filters).toEqual([
         { key: 'existing', value: 'val', operator: '!=' },
         { key: 'cluster', value: 'cluster', operator: '=' },
@@ -459,12 +466,12 @@ describe('setDashboardPanelContext', () => {
       ]);
     });
 
-    it('should not add a filter that already exists with the same key, value and operator', () => {
+    it('should not add a filter that already exists with the same key, value and operator', async () => {
       const { scene, context } = buildTestScene({
         existingFilterVariable: true,
       });
 
-      const variable = getAdHocFilterVariableFor(scene, { uid: 'my-ds-uid' });
+      const variable = await getAdHocFilterVariableFor(scene, { uid: 'my-ds-uid' });
 
       variable.setState({ filters: [{ key: 'existing', value: 'val', operator: '=' }] });
 
@@ -473,39 +480,39 @@ describe('setDashboardPanelContext', () => {
         { key: 'cluster', value: 'cluster', operator: '=' },
       ];
 
-      context.onAddAdHocFilters?.(filters);
+      await context.onAddAdHocFilters?.(filters);
       expect(variable.state.filters).toEqual([
         { key: 'existing', value: 'val', operator: '=' },
         { key: 'cluster', value: 'cluster', operator: '=' },
       ]);
     });
 
-    it('should not update the filters when all new filters are duplicates', () => {
+    it('should not update the filters when all new filters are duplicates', async () => {
       const { scene, context } = buildTestScene({
         existingFilterVariable: true,
       });
 
-      const variable = getAdHocFilterVariableFor(scene, { uid: 'my-ds-uid' });
+      const variable = await getAdHocFilterVariableFor(scene, { uid: 'my-ds-uid' });
 
       variable.setState({ filters: [{ key: 'existing', value: 'val', operator: '=' }] });
       const updateFiltersSpy = jest.spyOn(variable, 'updateFilters');
 
-      context.onAddAdHocFilters?.([{ key: 'existing', value: 'val', operator: '=' }]);
+      await context.onAddAdHocFilters?.([{ key: 'existing', value: 'val', operator: '=' }]);
 
       expect(updateFiltersSpy).not.toHaveBeenCalled();
       expect(variable.state.filters).toEqual([{ key: 'existing', value: 'val', operator: '=' }]);
     });
 
-    it('should not do anything if filters empty', () => {
+    it('should not do anything if filters empty', async () => {
       const { scene, context } = buildTestScene({
         existingFilterVariable: true,
       });
 
-      const variable = getAdHocFilterVariableFor(scene, { uid: 'my-ds-uid' });
+      const variable = await getAdHocFilterVariableFor(scene, { uid: 'my-ds-uid' });
 
       const filters: AdHocFilterItem[] = [];
 
-      context.onAddAdHocFilters?.(filters);
+      await context.onAddAdHocFilters?.(filters);
       expect(variable.state.filters).toEqual([]);
     });
   });

--- a/public/app/features/dashboard-scene/scene/setDashboardPanelContext.test.ts
+++ b/public/app/features/dashboard-scene/scene/setDashboardPanelContext.test.ts
@@ -340,6 +340,21 @@ describe('setDashboardPanelContext', () => {
     });
   });
 
+  describe('getAdHocFilterVariableFor', () => {
+    it('does not create duplicate Filters variables when called concurrently', async () => {
+      const { scene } = buildTestScene({});
+
+      const [first, second] = await Promise.all([
+        getAdHocFilterVariableFor(scene, { uid: 'my-ds-uid' }),
+        getAdHocFilterVariableFor(scene, { uid: 'my-ds-uid' }),
+      ]);
+
+      const adhocVars = sceneGraph.getVariables(scene).state.variables.filter((v) => v.state.type === 'adhoc');
+      expect(adhocVars).toHaveLength(1);
+      expect(first).toBe(second);
+    });
+  });
+
   describe('getFiltersBasedOnGrouping', () => {
     beforeAll(() => {
       config.featureToggles.groupByVariable = true;

--- a/public/app/features/dashboard-scene/scene/setDashboardPanelContext.ts
+++ b/public/app/features/dashboard-scene/scene/setDashboardPanelContext.ts
@@ -285,6 +285,12 @@ function getAdHocGroupByVariableFor(scene: DashboardScene, ds: DataSourceRef | n
 }
 
 export async function getAdHocFilterVariableFor(scene: DashboardScene, ds: DataSourceRef | null | undefined) {
+  // Resolve plugin meta before scanning so no await sits between the read and the
+  // setState write. Overlapping "Filter for value" actions would otherwise both
+  // miss the existing-variable scan and append a second Filters variable.
+  const pluginId = ds?.type ?? (await getDataSourceInstanceSettings(ds))?.type ?? '';
+  const supportsMultiValueOperators = Boolean((await getDatasourcePluginMeta(pluginId))?.multiValueFilterOperators);
+
   const variables = sceneGraph.getVariables(scene);
 
   for (const variable of variables.state.variables) {
@@ -296,11 +302,10 @@ export async function getAdHocFilterVariableFor(scene: DashboardScene, ds: DataS
     }
   }
 
-  const pluginId = ds?.type ?? (await getDataSourceInstanceSettings(ds))?.type ?? '';
   const newVariable = new AdHocFiltersVariable({
     name: 'Filters',
     datasource: ds,
-    supportsMultiValueOperators: Boolean((await getDatasourcePluginMeta(pluginId))?.multiValueFilterOperators),
+    supportsMultiValueOperators,
     useQueriesAsFilterForOptions: true,
   });
 

--- a/public/app/features/dashboard-scene/scene/setDashboardPanelContext.ts
+++ b/public/app/features/dashboard-scene/scene/setDashboardPanelContext.ts
@@ -1,5 +1,7 @@
 import { AnnotationChangeEvent, type AnnotationEventUIModel, CoreApp, type DataFrame } from '@grafana/data';
-import { getDataSourceSrv, reportInteraction } from '@grafana/runtime';
+import { reportInteraction } from '@grafana/runtime';
+import { getDatasourcePluginMeta } from '@grafana/runtime/internal';
+import { getDataSourceInstance, getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { AdHocFiltersVariable, dataLayers, sceneGraph, sceneUtils, type VizPanel } from '@grafana/scenes';
 import { type DataSourceRef } from '@grafana/schema';
 import { type AdHocFilterItem, type PanelContext } from '@grafana/ui';
@@ -128,14 +130,14 @@ export function setDashboardPanelContext(vizPanel: VizPanel, context: PanelConte
     // If the datasource is type-only (e.g. it's possible that only group is set in V2 schema queries)
     // we need to resolve it to a full datasource
     if (datasource && !datasource.uid) {
-      const datasourceToLoad = await getDataSourceSrv().get(datasource);
+      const datasourceToLoad = await getDataSourceInstance(datasource);
       datasource = {
         uid: datasourceToLoad.uid,
         type: datasourceToLoad.type,
       };
     }
 
-    const filterVar = getAdHocFilterVariableFor(dashboard, datasource);
+    const filterVar = await getAdHocFilterVariableFor(dashboard, datasource);
     updateAdHocFilterVariable(filterVar, newFilter);
   };
 
@@ -184,13 +186,13 @@ export function setDashboardPanelContext(vizPanel: VizPanel, context: PanelConte
     // If the datasource is type-only (e.g. it's possible that only group is set in V2 schema queries)
     // we need to resolve it to a full datasource
     if (datasource && !datasource.uid) {
-      const datasourceToLoad = await getDataSourceSrv().get(datasource);
+      const datasourceToLoad = await getDataSourceInstance(datasource);
       datasource = {
         uid: datasourceToLoad.uid,
         type: datasourceToLoad.type,
       };
     }
-    const filterVar = getAdHocFilterVariableFor(dashboard, datasource);
+    const filterVar = await getAdHocFilterVariableFor(dashboard, datasource);
     bulkUpdateAdHocFiltersVariable(filterVar, items);
 
     if (items.length > 0) {
@@ -282,7 +284,7 @@ function getAdHocGroupByVariableFor(scene: DashboardScene, ds: DataSourceRef | n
   return null;
 }
 
-export function getAdHocFilterVariableFor(scene: DashboardScene, ds: DataSourceRef | null | undefined) {
+export async function getAdHocFilterVariableFor(scene: DashboardScene, ds: DataSourceRef | null | undefined) {
   const variables = sceneGraph.getVariables(scene);
 
   for (const variable of variables.state.variables) {
@@ -294,10 +296,11 @@ export function getAdHocFilterVariableFor(scene: DashboardScene, ds: DataSourceR
     }
   }
 
+  const pluginId = ds?.type ?? (await getDataSourceInstanceSettings(ds))?.type ?? '';
   const newVariable = new AdHocFiltersVariable({
     name: 'Filters',
     datasource: ds,
-    supportsMultiValueOperators: Boolean(getDataSourceSrv().getInstanceSettings(ds)?.meta.multiValueFilterOperators),
+    supportsMultiValueOperators: Boolean((await getDatasourcePluginMeta(pluginId))?.multiValueFilterOperators),
     useQueriesAsFilterForOptions: true,
   });
 

--- a/public/app/features/dashboard-scene/sidebar/add-new/AddAnnotationQuery.tsx
+++ b/public/app/features/dashboard-scene/sidebar/add-new/AddAnnotationQuery.tsx
@@ -10,8 +10,8 @@ import { dashboardSceneGraph } from '../../utils/dashboardSceneGraph';
 import { AddButton } from './AddButton';
 
 export const useBuildAddAnnotation = (dataLayers: DashboardDataLayerSet) =>
-  useCallback(() => {
-    const newAnnotation = dataLayers.createDefaultAnnotationLayer();
+  useCallback(async () => {
+    const newAnnotation = await dataLayers.createDefaultAnnotationLayer();
     annotationEditActions.addAnnotation({
       source: dataLayers,
       addedObject: newAnnotation,

--- a/public/app/features/dashboard-scene/sidebar/dashboard/DashboardAnnotationsList.test.tsx
+++ b/public/app/features/dashboard-scene/sidebar/dashboard/DashboardAnnotationsList.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, within } from '@testing-library/react';
+import { act, fireEvent, render, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { DashboardAnnotationsDataLayer } from '../../scene/DashboardAnnotationsDataLayer';
@@ -200,6 +200,7 @@ describe('User interactions', () => {
 
       await user.click(elements.addAnnotationButton());
 
+      await waitFor(() => expect(annotationEditActions.addAnnotation).toHaveBeenCalled());
       expect(annotationEditActions.addAnnotation).toHaveBeenCalledWith({
         source: elements.dataLayerSet,
         addedObject: expect.objectContaining({

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -7377,7 +7377,9 @@
     },
     "panel-data-queries-tab-rendered": {
       "add-query": "Add query",
-      "expression": "Expression "
+      "expression": "Expression ",
+      "sql-expressions-frontend-only": "SQL expressions can only evaluate results from backend datasources. This panel only contains frontend datasources.",
+      "sql-expressions-pending": "SQL expressions can only evaluate results from backend datasources."
     },
     "panel-data-transformations-tab": {
       "tab-label": "Transformations"


### PR DESCRIPTION
- `PanelDataQueriesTab`: load, switch, and add-query paths use `getDataSourceInstance` / `getDataSourceInstanceSettings` instead of `getDataSourceSrv().get` / `getInstanceSettings`
- `hasBackendDatasource` is async; added `useHasBackendDatasource` for React callers (`PanelDataQueriesTab`, `EmptyTransformationsMessage`, `TransformationTypePicker`)
- `DashboardDataLayerSet.createDefaultAnnotationLayer` is async and uses `getDataSourceInstanceSettings`; `AddAnnotationQuery` awaits it
- `PanelGroupByAction` loads the group-by datasource with `getDataSourceInstance`
- `setDashboardPanelContext` resolves type-only refs with `getDataSourceInstance`; `getAdHocFilterVariableFor` is async and reads `multiValueFilterOperators` from `getDatasourcePluginMeta`
- Tests updated for the async APIs and awaited call sites

Part of #127032 