### PR TITLE
Docs: Add Alertmanager configuration import to Grafana-managed notifications

### DIFF
--- a/docs/sources/alerting/alerting-rules/alerting-migration.md
+++ b/docs/sources/alerting/alerting-rules/alerting-migration.md
@@ -30,6 +30,11 @@ refs:
       destination: /docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/create-recording-rules/create-grafana-managed-recording-rules/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/create-recording-rules/create-grafana-managed-recording-rules/
+  import-alertmanager-configuration:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/import-alertmanager-configuration/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/import-alertmanager-configuration/
 ---
 
 # Import data source-managed rules to Grafana-managed rules
@@ -45,6 +50,14 @@ This guide explains two methods for importing data source-managed rules:
 Importing rules is a safe operation: the original data source–managed rules remain intact in their original location. During import, the rules are converted into Grafana-managed rules while preserving their configuration and behavior.
 
 Choose the method that best fits your workflow. As a best practice, test and validate your import process before migrating all alert rules.
+
+## Import your notification configuration first
+
+Rules only tell you about a problem if the notification reaches someone. Grafana-managed rules route through Grafana's Alertmanager, not through the Alertmanager your data source-managed rules used, so imported rules notify through whatever contact points and notification policies already exist in Grafana.
+
+Consider [importing your Alertmanager configuration](ref:import-alertmanager-configuration) before you import rules. Grafana converts your receivers, routes, templates, and mute timings into Grafana-managed notification resources, so the rules you import next land in the routing you already have.
+
+This matters most if you route rules to a specific contact point: the [`X-Grafana-Alerting-Notification-Settings` header](#x-grafana-alerting-notification-settings) and the wizard's routing options both require the contact point or policy tree to exist in Grafana before the rules are imported.
 
 ## How it works
 

--- a/docs/sources/alerting/alerting-rules/alerting-migration.md
+++ b/docs/sources/alerting/alerting-rules/alerting-migration.md
@@ -53,7 +53,7 @@ Choose the method that best fits your workflow. As a best practice, test and val
 
 ## Import your notification configuration first
 
-Rules only tell you about a problem if the notification reaches someone. Grafana-managed rules route through Grafana's Alertmanager, not through the Alertmanager your data source-managed rules used, so imported rules notify through whatever contact points and notification policies already exist in Grafana.
+Rules only tell you about a problem if the notification reaches someone. Grafana-managed rules route through the Grafana Alertmanager, not through the Alertmanager your data source-managed rules used, so imported rules notify through whatever contact points and notification policies already exist in Grafana.
 
 Consider [importing your Alertmanager configuration](ref:import-alertmanager-configuration) before you import rules. Grafana imports the configuration as it is and evaluates it the way your Prometheus or Mimir Alertmanager does, so the rules you import next land in the routing you already have.
 

--- a/docs/sources/alerting/alerting-rules/alerting-migration.md
+++ b/docs/sources/alerting/alerting-rules/alerting-migration.md
@@ -30,6 +30,11 @@ refs:
       destination: /docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/create-recording-rules/create-grafana-managed-recording-rules/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/create-recording-rules/create-grafana-managed-recording-rules/
+  import-alertmanager-configuration:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/import-alertmanager-configuration/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/import-alertmanager-configuration/
 ---
 
 # Import data source-managed rules to Grafana-managed rules
@@ -45,6 +50,12 @@ This guide explains two methods for importing data source-managed rules:
 Importing rules is a safe operation: the original data source–managed rules remain intact in their original location. During import, the rules are converted into Grafana-managed rules while preserving their configuration and behavior.
 
 Choose the method that best fits your workflow. As a best practice, test and validate your import process before migrating all alert rules.
+
+## Import your notification configuration first
+
+Rules only tell you about a problem if the notification reaches someone. Grafana-managed rules route through Grafana's Alertmanager, not through the Alertmanager your data source-managed rules used, so imported rules notify through whatever contact points and notification policies already exist in Grafana.
+
+Consider [importing your Alertmanager configuration](ref:import-alertmanager-configuration) before you import rules. Grafana imports the configuration as it is and evaluates it the way your Prometheus or Mimir Alertmanager does, so the rules you import next land in the routing you already have.
 
 ## How it works
 

--- a/docs/sources/alerting/alerting-rules/alerting-migration.md
+++ b/docs/sources/alerting/alerting-rules/alerting-migration.md
@@ -55,7 +55,7 @@ Choose the method that best fits your workflow. As a best practice, test and val
 
 Rules only tell you about a problem if the notification reaches someone. Grafana-managed rules route through the Grafana Alertmanager, not through the Alertmanager your data source-managed rules used, so imported rules notify through whatever contact points and notification policies already exist in Grafana.
 
-Consider [importing your Alertmanager configuration](ref:import-alertmanager-configuration) before you import rules. Grafana imports the configuration as it is and evaluates it the way your Prometheus or Mimir Alertmanager does, so the rules you import next land in the routing you already have.
+Consider [importing your Alertmanager configuration](ref:import-alertmanager-configuration) before you import rules. Grafana imports the configuration as it is and runs it the way your Prometheus or Mimir Alertmanager does. You can then route the rules you import through the imported policy tree.
 
 ## How it works
 

--- a/docs/sources/alerting/configure-notifications/_index.md
+++ b/docs/sources/alerting/configure-notifications/_index.md
@@ -49,6 +49,11 @@ refs:
       destination: /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/inhibition-rules/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/inhibition-rules/
+  import-alertmanager-configuration:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/import-alertmanager-configuration/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/import-alertmanager-configuration/
 ---
 
 # Configure notifications
@@ -71,6 +76,7 @@ The topics in this section include step-by-step instructions for:
 - [Templating notifications](ref:configure-templates) to customize notification messages.
 - [Configuring silences](ref:configure-silences) or [mute timings](ref:configure-mute-timings) to stop notifications.
 - [Configuring inhibition rules](ref:configure-inhibition-rules) to suppress notifications for dependent alerts when a root-cause alert is already firing.
+- [Importing an Alertmanager configuration](ref:import-alertmanager-configuration) to convert an existing Prometheus or Mimir notification setup into Grafana-managed resources.
 
 ## Alertmanager architecture
 

--- a/docs/sources/alerting/configure-notifications/import-alertmanager-configuration.md
+++ b/docs/sources/alerting/configure-notifications/import-alertmanager-configuration.md
@@ -1,0 +1,270 @@
+---
+canonical: https://grafana.com/docs/grafana/latest/alerting/configure-notifications/import-alertmanager-configuration/
+description: Import an existing Prometheus or Mimir Alertmanager configuration into Grafana Alerting and operate it as Grafana-managed notification resources.
+keywords:
+  - grafana
+  - alerting
+  - alertmanager
+  - import
+  - notifications
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
+menuTitle: Import Alertmanager configuration
+title: Import Alertmanager configuration to Grafana-managed notifications
+weight: 460
+refs:
+  import-rules:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/alerting-migration/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/alerting-migration/
+  configure-contact-points:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/manage-contact-points/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/manage-contact-points/
+  configure-notification-policies:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/create-notification-policy/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/create-notification-policy/
+  configure-templates:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/template-notifications/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/template-notifications/
+  configure-mute-timings:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/mute-timings/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/mute-timings/
+  configure-inhibition-rules:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/inhibition-rules/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/inhibition-rules/
+  rbac:
+    - pattern: /docs/
+      destination: /docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/access-control/
+  service-accounts:
+    - pattern: /docs/
+      destination: /docs/grafana/<GRAFANA_VERSION>/administration/service-accounts/
+  feature-toggles:
+    - pattern: /docs/
+      destination: /docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/
+---
+
+# Import Alertmanager configuration to Grafana-managed notifications
+
+You can import an existing Prometheus or Mimir Alertmanager configuration into Grafana Alerting. Grafana converts the configuration into Grafana-managed notification resources—contact points, a notification policy tree, notification templates, mute timings, and inhibition rules—so you can operate your notification setup from Grafana.
+
+Importing is a safe operation. The source Alertmanager keeps its configuration, and Grafana never writes back to it.
+
+The import happens in two stages, so you can check the result before it affects live notifications:
+
+- **Stage**: Grafana stores the imported configuration next to your Grafana configuration and merges the two at runtime. Imported resources are visible but read-only, and you can revert the whole import in one action.
+- **Promote**: Grafana merges the imported configuration permanently into your Grafana configuration. Every imported resource becomes a normal, editable Grafana resource.
+
+{{< admonition type="note" >}}
+Importing Alertmanager configuration is in [public preview](https://grafana.com/docs/release-life-cycle/#public-preview). The API is behind the `alertingImportAlertmanagerAPI` [feature toggle](ref:feature-toggles) and the import wizard is behind `alertingMigrationWizardUI`. Both are disabled by default. In Grafana Cloud, contact Support to enable them.
+{{< /admonition >}}
+
+## Before you begin
+
+Before you import an Alertmanager configuration, make sure you have the following:
+
+- **An Alertmanager configuration to import**: either a configuration YAML file with its template files, or a configured Alertmanager data source that Grafana can read the configuration from.
+- **Permissions**: importing a configuration requires the `alert.notifications:write` permission, or the scoped Alertmanager imports permissions. Promoting an import additionally requires create permissions for each resource type in the configuration: contact points, notification policies, notification templates, mute timings, and inhibition rules. For more details, refer to [RBAC permissions](ref:rbac).
+- **A service account token** if you import through the API or `mimirtool`. For more details, refer to [service accounts](ref:service-accounts).
+
+## How it works
+
+Grafana keeps the imported configuration separate from your Grafana configuration until you promote it. Both configurations are merged when alerts are routed, so imported contact points and policies notify as soon as the import completes.
+
+### What each Alertmanager object becomes
+
+Grafana maps the Alertmanager configuration to its own notification resources:
+
+| Alertmanager configuration              | Grafana-managed resource                                               |
+| --------------------------------------- | ---------------------------------------------------------------------- |
+| `receivers`                             | Contact points                                                         |
+| `route`                                 | A separate notification policy tree, named after the import identifier |
+| `template_files`                        | Notification templates, one per file, named after the file             |
+| `time_intervals`, `mute_time_intervals` | Mute timings and active time intervals                                 |
+| `inhibit_rules`                         | Inhibition rules                                                       |
+| `global`                                | Not imported                                                           |
+
+### Routing
+
+Grafana doesn't merge the imported routing tree into your default notification policy. It adds the imported tree as a separate, named policy tree, and evaluates it before your existing routes.
+
+The imported root route gets explicit `group_wait`, `group_interval`, and `repeat_interval` values, so its timing doesn't change depending on what your Grafana root policy defines.
+
+You choose the tree name when you import. This name is also the identifier of the import, so pick something you recognize, such as `prometheus-prod`.
+
+### Name conflicts
+
+Contact points and time intervals are identified by name, and the imported configuration may reuse names that already exist in Grafana. Rather than fail or overwrite, Grafana renames the incoming resource:
+
+1. Grafana appends `_` and the import identifier to the name, for example `default` becomes `default_prometheus-prod`.
+1. If that name is also taken, Grafana appends a number, for example `_01`.
+
+All references to a renamed resource are updated throughout the imported configuration, so routing still points at the right contact point. Run a dry-run import to see the renames before you commit to them.
+
+### Staged resources are read-only
+
+While an import is staged, its resources appear in the Grafana Alerting user interface with an **Imported** status, and you can't edit or delete them individually. You also can't reference them from Grafana resources—for example, you can't pick an imported contact point in a Grafana notification policy or an alert rule.
+
+Label-based routing still works. Alerts that match the matchers of an imported policy are routed through it, whatever created them.
+
+To make imported resources editable and referenceable, promote the import.
+
+### One import at a time
+
+Grafana stores one imported configuration per organization. Importing a second configuration with a different identifier fails unless you explicitly replace the existing one.
+
+## Import with the Grafana Alerting user interface
+
+The import wizard imports notification resources and alert rules in one flow.
+
+1. Go to **Alerting** > **Alert rules**.
+1. In the **More** menu, click **Import to Grafana Alerting**.
+1. Choose how the resources are added:
+   - **Stage** brings the configuration in as a read-only, reversible copy.
+   - **Promote** merges the configuration into your live configuration immediately. This can't be undone—to reverse it you have to delete each resulting resource by hand.
+1. Click **Next**.
+1. On the **Import notification resources** step, choose the **Import source**:
+   - **Alertmanager config YAML** uploads a configuration file. Optionally, upload the template files the configuration references. Each file is imported as a template named after the file.
+   - **Alertmanager data source** reads the configuration from a configured Alertmanager data source.
+1. Enter a **Policy tree name**.
+
+   Grafana validates the configuration as you fill in the form and reports any conflicts. Resources that would be renamed are listed before you import.
+
+1. Click **Next**, and either configure the [alert rules import](ref:import-rules) or skip the step.
+1. Review the summary, then click **Start import**.
+
+## Import with the API
+
+The Alertmanager import endpoints are compatible with the [Mimir Alertmanager HTTP API](/docs/mimir/latest/references/http-api/#alertmanager), so you can use `mimirtool` or plain HTTP requests.
+
+In these endpoints, an import is addressed by its identifier, which is set with the `X-Grafana-Alerting-Config-Identifier` header and defaults to `imported`.
+
+| Method | Endpoint                                      | Summary                                                                            |
+| ------ | --------------------------------------------- | ---------------------------------------------------------------------------------- |
+| POST   | `/convert/api/v1/alerts`                      | Import an Alertmanager configuration, optionally promoting it in the same request. |
+| GET    | `/convert/api/v1/alerts`                      | Get the staged configuration. Secrets are masked.                                  |
+| DELETE | `/convert/api/v1/alerts`                      | Delete the staged configuration. The Grafana configuration is unaffected.          |
+| POST   | `/convert/api/v1/alerts/{Identifier}/promote` | Promote a staged configuration into the Grafana configuration.                     |
+
+The `POST` endpoint accepts YAML and JSON. If no media type is specified, YAML is assumed. The request body has the same shape as the Mimir Alertmanager configuration API:
+
+```yaml
+template_files:
+  default.tmpl: '{{ define "custom" }}Custom message{{ end }}'
+alertmanager_config: |
+  route:
+    receiver: webhook
+  receivers:
+    - name: webhook
+      webhook_configs:
+        - url: 'https://example.com/webhook'
+```
+
+A successful import returns the merge result, including any renamed resources:
+
+```json
+{
+  "status": "success",
+  "stats": {
+    "addedRoute": "prometheus-prod",
+    "addedReceivers": ["webhook"],
+    "addedTemplates": ["default.tmpl"]
+  },
+  "renameResources": {
+    "receivers": { "default": "default_prometheus-prod" }
+  }
+}
+```
+
+### Optional headers
+
+Use these headers for more granular import control:
+
+#### `X-Grafana-Alerting-Config-Identifier`
+
+The identifier of the import, which is also the name of the notification policy tree it creates. It must be a valid DNS subdomain name—lowercase alphanumeric characters, `-`, and `.`. Defaults to `imported`.
+
+#### `X-Grafana-Alerting-Dry-Run`
+
+Set to `true` to validate the configuration and report the merge result without saving anything. Use this to preview renames before importing.
+
+#### `X-Grafana-Alerting-Promote`
+
+Set to `true` to promote the configuration in the same request instead of staging it. Combine it with `X-Grafana-Alerting-Dry-Run` to preview what a promotion merges into the live configuration.
+
+#### `X-Grafana-Alerting-Config-Force-Replace`
+
+Set to `true` to replace an existing staged configuration that has a different identifier. Without it, importing a second configuration fails.
+
+### mimirtool
+
+Use `mimirtool alertmanager load` to import a configuration and its template files:
+
+```bash
+MIMIR_ADDRESS=<GRAFANA_BASE_URL>/api/convert/ \
+MIMIR_AUTH_TOKEN=<SERVICE_ACCOUNT_TOKEN> \
+MIMIR_TENANT_ID=1 \
+mimirtool alertmanager load alertmanager.yaml default.tmpl \
+  --extra-headers "X-Grafana-Alerting-Config-Identifier=prometheus-prod"
+```
+
+Replace the following placeholders:
+
+- `<GRAFANA_BASE_URL>`: the base URL of your Grafana instance.
+- `<SERVICE_ACCOUNT_TOKEN>`: a service account token with permission to import notification resources.
+
+When the address points at `<GRAFANA_BASE_URL>/api/convert/`, `mimirtool` talks to Grafana rather than to a Mimir instance, so `MIMIR_TENANT_ID` must always be `1`.
+
+`mimirtool alertmanager get` and `mimirtool alertmanager delete` read and remove the staged configuration in the same way.
+
+### Promote a staged configuration
+
+To promote a configuration that's already staged, call the promote endpoint with its identifier:
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer <SERVICE_ACCOUNT_TOKEN>" \
+  <GRAFANA_BASE_URL>/api/convert/api/v1/alerts/prometheus-prod/promote
+```
+
+After promotion, the staged configuration no longer exists—its resources are part of the Grafana configuration and are editable through the regular notification APIs and user interface.
+
+## Review, promote, or revert a staged configuration
+
+Staged configurations are managed in Grafana Alerting settings.
+
+1. Go to **Alerting** > **Settings**.
+1. Click the **Import** tab.
+
+The **Staged configuration** section lists the contact points, notification policies, templates, time intervals, and inhibition rules the import contains, and links to each resource so you can inspect it before promoting.
+
+To discard the import and everything it added, click **Revert**. Your Grafana configuration is unaffected.
+
+## Limitations
+
+Consider the following when you import an Alertmanager configuration:
+
+- **Unsupported receiver fields**: fields Grafana can't represent, such as `*_file` settings that read a secret from disk, cause the import to fail rather than being silently dropped. The error lists each unsupported field, such as `email_configs[0].auth_password_file`. Replace them with inline values before importing.
+- **Global settings**: the `global` section isn't imported. Configure the equivalent settings on each contact point, or in the Grafana configuration file.
+- **Inhibition rules**: imported inhibition rules are supported through the API only. There's no user interface for creating or editing them. For more details, refer to [configure inhibition rules](ref:configure-inhibition-rules).
+- **Provisioning**: staged resources can't be provisioned or have permissions assigned to them. Promote the import first.
+
+## Next steps
+
+After you import your notification configuration:
+
+- [Import your data source-managed alert rules](ref:import-rules) and route them through the imported policy tree.
+- Review the imported [contact points](ref:configure-contact-points), [notification policies](ref:configure-notification-policies), [templates](ref:configure-templates), and [mute timings](ref:configure-mute-timings).

--- a/docs/sources/alerting/configure-notifications/import-alertmanager-configuration.md
+++ b/docs/sources/alerting/configure-notifications/import-alertmanager-configuration.md
@@ -66,7 +66,7 @@ refs:
 
 # Import Alertmanager configuration to Grafana-managed notifications
 
-You can import an existing Prometheus or Mimir Alertmanager configuration into Grafana Alerting. Grafana stores the configuration as it is and evaluates it the way your Alertmanager does, then surfaces it as Grafana notification resources—contact points, a notification policy tree, notification templates, time intervals, and inhibition rules—so you can operate your notification setup from Grafana.
+You can import an existing Prometheus or Mimir Alertmanager configuration into Grafana Alerting. Grafana stores the configuration as-is and evaluates it the way your Alertmanager does. It then surfaces the configuration as Grafana notification resources: contact points, a notification policy tree, notification templates, time intervals, and inhibition rules. You operate your notification setup from Grafana.
 
 Importing is a safe operation. The source Alertmanager keeps its configuration, and Grafana never writes back to it.
 
@@ -85,8 +85,8 @@ Importing Alertmanager configuration is in [public preview](https://grafana.com/
 
 Before you import an Alertmanager configuration, make sure you have the following:
 
-- **A source Grafana can read**: a configuration YAML file with its template files, or a configured Mimir Alertmanager data source. Upstream Prometheus Alertmanager data sources aren't supported.
-- **Permissions**: importing a configuration requires the `alert.notifications:write` permission, or the scoped Alertmanager imports permissions. Both are granted to the Admin role by default. Promoting an import additionally requires create permissions for each resource type in the configuration: contact points, notification policies, notification templates, time intervals, and inhibition rules. For more details, refer to [RBAC permissions](ref:rbac).
+- **A source Grafana can read**: A configuration YAML file with its template files, or a configured Mimir Alertmanager data source. Upstream Prometheus Alertmanager data sources aren't supported.
+- **Permissions**: Importing a configuration requires the `alert.notifications:write` permission, or the scoped Alertmanager imports permissions. Both are granted to the Admin role by default. Promoting an import additionally requires create permissions for each resource type in the configuration: contact points, notification policies, notification templates, time intervals, and inhibition rules. For more details, refer to [RBAC permissions](ref:rbac).
 
 Not every Alertmanager configuration can be imported as it is. Refer to [limitations](#limitations) before you start.
 
@@ -125,9 +125,9 @@ Templates count conflicts differently. An imported template never conflicts with
 
 While an import is staged, its resources appear with an **Imported** status in the Grafana Alerting user interface and in the notification APIs, and you can't edit or delete them individually. The deprecated provisioning API is the exception: it doesn't return them at all.
 
-You also can't reference an imported resource from a Grafana resource—for example, you can't pick an imported contact point in a Grafana notification policy. The imported policy tree is the exception: an alert rule can route to it by name while the import is staged.
+You also can't reference an imported resource from a Grafana resource. For example, you can't pick an imported contact point in a Grafana notification policy. The imported policy tree is the exception: an alert rule can route to it by name while the import is staged.
 
-To make imported resources editable and referenceable, promote the import.
+To make imported resources editable and available for reference, promote the import.
 
 ### One import at a time
 
@@ -141,14 +141,14 @@ The Grafana Alerting user interface imports notification resources and alert rul
 1. In the **More** menu, click **Import to Grafana Alerting**.
 1. Choose how the resources are added:
    - **Stage** brings the configuration in as a read-only, reversible copy.
-   - **Promote** merges the configuration into your live configuration immediately. This can't be undone—to reverse it you have to delete each resulting resource by hand.
+   - **Promote** merges the configuration into your live configuration immediately. This can't be undone. To reverse it you have to delete each resulting resource by hand.
 1. Click **Next**.
 1. On the **Import notification resources** step, choose the **Import source**:
    - **Alertmanager config YAML** uploads a configuration file. Optionally, upload the template files the configuration references. Each file is imported as a template named after the file.
    - **Alertmanager data source** reads the configuration from a configured Alertmanager data source.
 1. Enter a **Policy tree name**.
 
-   Grafana validates the configuration as you fill in the form and reports any conflicts. Resources that would be renamed are listed before you import.
+   Grafana validates the configuration as you fill in the form and reports any conflicts. The form lists the resources that Grafana renames before you import.
 
 1. Click **Next**, and either configure the [alert rules import](ref:import-rules) or skip the step.
 1. Review the summary, then click **Start import**.
@@ -202,7 +202,7 @@ Use these headers for more granular import control:
 
 #### `X-Grafana-Alerting-Config-Identifier`
 
-The identifier of the import, which is also the name of the notification policy tree it creates. It must be a valid DNS subdomain name—lowercase alphanumeric characters, `-`, and `.`—and at most 40 characters. Defaults to `imported`.
+The identifier of the import, which is also the name of the notification policy tree it creates. It must be a valid DNS subdomain name of at most 40 characters, using only lowercase alphanumeric characters, `-`, and `.`. Defaults to `imported`.
 
 #### `X-Grafana-Alerting-Dry-Run`
 
@@ -216,7 +216,7 @@ Set to `true` to promote the configuration in the same request instead of stagin
 
 Set to `true` to replace an existing staged configuration that has a different identifier. Without it, importing a second configuration fails.
 
-### mimirtool
+### `mimirtool`
 
 Use `mimirtool alertmanager load` to import a configuration and its template files:
 
@@ -230,8 +230,8 @@ mimirtool alertmanager load alertmanager.yaml default.tmpl \
 
 Replace the following placeholders:
 
-- `<GRAFANA_BASE_URL>`: the base URL of your Grafana instance.
-- `<SERVICE_ACCOUNT_TOKEN>`: a service account token with permission to import notification resources.
+- `<GRAFANA_BASE_URL>`: The base URL of your Grafana instance.
+- `<SERVICE_ACCOUNT_TOKEN>`: A service account token with permission to import notification resources.
 
 When the address points at `<GRAFANA_BASE_URL>/api/convert/`, `mimirtool` talks to Grafana rather than to a Mimir instance, so `MIMIR_TENANT_ID` must always be `1`.
 
@@ -247,7 +247,7 @@ curl -X POST \
   <GRAFANA_BASE_URL>/api/convert/api/v1/alerts/prometheus-prod/promote
 ```
 
-After promotion, the staged configuration no longer exists—its resources are part of the Grafana configuration and are editable through the regular notification APIs and user interface.
+After promotion, the staged configuration no longer exists. Its resources are part of the Grafana configuration. You can edit them through the regular notification APIs and user interface.
 
 ## Review, promote, or revert a staged configuration
 
@@ -268,14 +268,14 @@ Reverting deletes the imported notification policy tree. Alert rules that route 
 
 Consider the following when you import an Alertmanager configuration:
 
-- **Unsupported receiver fields**: an integration field that reads its value from elsewhere—every `*_file` and `*_ref` variant—has no equivalent in Grafana. A configuration that contains one is rejected as a whole, so nothing is imported. Supply the value inline in the matching field instead, and drop the `_file` or `_ref` variant.
+- **Unsupported receiver fields**: An integration field that reads its value from elsewhere, which includes every `*_file` and `*_ref` variant. Has no equivalent in Grafana. Grafana rejects a configuration that contains one, so nothing is imported. Supply the value inline in the matching field instead, and drop the `_file` or `_ref` variant.
 - **Data source support**: Grafana reads a configuration from a Mimir Alertmanager data source. Upstream Prometheus Alertmanager doesn't expose a configuration API, so those data sources aren't supported. Import a configuration YAML file instead.
-- **Global settings**: after you promote an import, the `global` section no longer exists as a section of its own. Grafana has resolved its values into each integration setting that relies on them, so a promoted contact point carries the resolved value rather than a reference to `global`.
-- **Policy tree name**: the name of the imported policy tree, which is also the import identifier, must be a valid DNS subdomain name—lowercase alphanumeric characters, `-`, and `.`—and at most 40 characters.
+- **Global settings**: After you promote an import, the `global` section no longer exists as a section of its own. Grafana has resolved its values into each integration setting that relies on them, so a promoted contact point carries the resolved value rather than a reference to `global`.
+- **Policy tree name**: The name of the imported policy tree, which is also the import identifier, must be a valid DNS subdomain name of at most 40 characters, using only lowercase alphanumeric characters, `-`, and `.`.
 - **One staged configuration at a time**: Grafana stores one staged configuration per organization. Importing a second configuration with a different identifier fails unless you explicitly replace the existing one.
 - **Template name conflicts across imports**: Grafana renames colliding template files, but the templates defined inside those files share one namespace. Say an earlier import defines a template called `default.email` that renders `X`, and a new import defines `default.email` again, in a file under a different name, rendering `Y`. Which definition wins isn't deterministic, and every contact point that uses that name gets the winner—so contact points from the earlier import can start sending the wrong content. Check the names of the templates you define, not just the file names, before you import a second configuration.
-- **Deprecated provisioning API**: a staged configuration isn't visible in the deprecated provisioning API—its contact points, templates, and time intervals aren't returned. Use the Grafana Alerting notification API (`notifications.alerting.grafana.app`) instead.
-- **Inhibition rules**: imported inhibition rules are supported through the API only. There's no user interface for creating or editing them. For more details, refer to [configure inhibition rules](ref:configure-inhibition-rules).
+- **Deprecated provisioning API**: A staged configuration isn't visible in the deprecated provisioning API, which doesn't return its contact points, templates, or time intervals. Use the Grafana Alerting notification API (`notifications.alerting.grafana.app`) instead.
+- **Inhibition rules**: Imported inhibition rules are supported through the API only. There's no user interface for creating or editing them. For more details, refer to [configure inhibition rules](ref:configure-inhibition-rules).
 
 ## Next steps
 

--- a/docs/sources/alerting/configure-notifications/import-alertmanager-configuration.md
+++ b/docs/sources/alerting/configure-notifications/import-alertmanager-configuration.md
@@ -1,6 +1,6 @@
 ---
 canonical: https://grafana.com/docs/grafana/latest/alerting/configure-notifications/import-alertmanager-configuration/
-description: Import an existing Prometheus or Mimir Alertmanager configuration into Grafana Alerting and operate it as Grafana-managed notification resources.
+description: Import an existing Prometheus or Mimir Alertmanager configuration as Grafana-managed notification resources, then manage them directly in Grafana Alerting.
 keywords:
   - grafana
   - alerting
@@ -36,6 +36,11 @@ refs:
       destination: /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/create-notification-policy/#manage-multiple-notification-policies
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/create-notification-policy/#manage-multiple-notification-policies
+  notification-policy-default-timing:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/create-notification-policy/#edit-the-default-notification-policy
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/create-notification-policy/#edit-the-default-notification-policy
   configure-templates:
     - pattern: /docs/grafana/
       destination: /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/template-notifications/
@@ -66,7 +71,7 @@ refs:
 
 # Import Alertmanager configuration to Grafana-managed notifications
 
-You can import an existing Prometheus or Mimir Alertmanager configuration into Grafana Alerting. Grafana stores the configuration as-is and evaluates it the way your Alertmanager does. It then surfaces the configuration as Grafana notification resources: contact points, a notification policy tree, notification templates, time intervals, and inhibition rules. You operate your notification setup from Grafana.
+You can import an existing Prometheus or Mimir Alertmanager configuration into Grafana Alerting. Grafana runs the imported receivers as Mimir Alertmanager v0 integrations and surfaces the configuration as Grafana notification resources: contact points, a notification policy tree, notification templates, time intervals, and inhibition rules. You operate your notification setup from Grafana.
 
 Importing is a safe operation. The source Alertmanager keeps its configuration, and Grafana never writes back to it.
 
@@ -85,8 +90,8 @@ Importing Alertmanager configuration is in [public preview](https://grafana.com/
 
 Before you import an Alertmanager configuration, make sure you have the following:
 
-- **A source Grafana can read**: A configuration YAML file with its template files, or a configured Mimir Alertmanager data source. Upstream Prometheus Alertmanager data sources aren't supported.
-- **Permissions**: Importing a configuration requires the `alert.notifications:write` permission, or the scoped Alertmanager imports permissions. Both are granted to the Admin role by default. Promoting an import additionally requires create permissions for each resource type in the configuration: contact points, notification policies, notification templates, time intervals, and inhibition rules. For more details, refer to [RBAC permissions](ref:rbac).
+- **A source Grafana can read**: A configuration YAML file with its template files, or a configured Mimir Alertmanager data source. Prometheus Alertmanager data sources aren't supported.
+- **Permissions**: Creating, reading, updating, or deleting an import requires the corresponding scoped Alertmanager import permissions. Promoting an import requires read and delete permissions for the import, create permissions for contact points and notification policy trees, and write permissions for any notification templates, time intervals, and inhibition rules in the configuration. The Admin role has these permissions by default. For more details, refer to [RBAC permissions](ref:rbac).
 
 Not every Alertmanager configuration can be imported as it is. Refer to [limitations](#limitations) before you start.
 
@@ -94,7 +99,7 @@ Not every Alertmanager configuration can be imported as it is. Refer to [limitat
 
 Grafana imports the configuration as it is and evaluates it the way your source Alertmanager does. Receivers keep their Alertmanager fields, and they notify with the same logic and message format, because Grafana runs them as Mimir-compatible integrations instead of rewriting them into native Grafana ones.
 
-Mimir-compatible integrations don't offer what a native Grafana integration adds on top, such as [images in notifications](ref:images-in-notifications). To pick those up, promote the import and then rebuild the contact point as a Grafana one.
+Mimir-compatible integrations don't offer what a native Grafana integration adds on top, such as [images in notifications](ref:images-in-notifications). To use those features, promote the import and then rebuild the contact point as a Grafana one.
 
 ### What gets imported
 
@@ -104,18 +109,18 @@ The `global` section is the one part with no place of its own. Grafana resolves 
 
 ### Routing
 
-Grafana adds the imported routing tree as a named policy tree of its own, alongside your default notification policy. Alerts reach it only when an alert rule routes to it by name. The matchers inside the imported tree then sort those alerts the way they did in your source Alertmanager. For more details on serving more than one policy tree, refer to [manage multiple notification policies](ref:notification-policy-trees).
+Grafana adds the imported routing tree as a named policy tree of its own, alongside your default notification policy and any other named policy trees. Alerts reach it only when an alert rule routes to it by name. The matchers inside the imported tree then route those alerts the way they did in your source Alertmanager. For more details on serving more than one policy tree, refer to [manage multiple notification policies](ref:notification-policy-trees).
 
-If the imported root route leaves `group_wait`, `group_interval`, or `repeat_interval` unset, Grafana fills in the Alertmanager defaults: 30 seconds, 5 minutes, and 4 hours. The imported tree keeps its own timing instead of inheriting it from your Grafana root policy.
+If the imported root route leaves `group_wait`, `group_interval`, or `repeat_interval` unset, Grafana uses the [default notification timing values](ref:notification-policy-default-timing).
 
-You choose the tree name when you import. This name is also the identifier of the import, so pick something you recognize, such as `prometheus-prod`. The name has to be a valid DNS subdomain name and is length-limited; for more details, refer to [limitations](#limitations).
+You choose the tree name when you import. This name is also the identifier of the import, so pick something you recognize, such as `mimir-prod`. The name can't be `default` or match another named policy tree. It must be a valid DNS subdomain name and is length-limited; for more details, refer to [limitations](#limitations).
 
 ### Name conflicts
 
 Contact points, time intervals, and notification templates are identified by name, and the imported configuration may reuse names that already exist. Rather than fail or overwrite, Grafana renames the incoming resource:
 
-1. Grafana appends `_` and the import identifier to the name, for example `default` becomes `default_prometheus-prod`.
-1. If that name is also taken, Grafana appends a number, for example `default_prometheus-prod_01`.
+1. Grafana appends `_` and the import identifier to the name, for example `default` becomes `default_mimir-prod`.
+1. If that name is also taken, Grafana appends a number, for example `default_mimir-prod_01`.
 
 All references to a renamed resource are updated throughout the imported configuration, so routing still points at the right contact point.
 
@@ -131,7 +136,7 @@ To make imported resources editable and available for reference, promote the imp
 
 ### One import at a time
 
-Grafana stores one imported configuration per organization. Importing a second configuration with a different identifier fails unless you explicitly replace the existing one.
+Grafana stores one imported configuration per organization. Before you stage another configuration, promote or revert the existing one. You can also explicitly replace the existing configuration during import.
 
 ## Import with the Grafana Alerting user interface
 
@@ -141,7 +146,7 @@ The Grafana Alerting user interface imports notification resources and alert rul
 1. In the **More** menu, click **Import to Grafana Alerting**.
 1. Choose how the resources are added:
    - **Stage** brings the configuration in as a read-only, reversible copy.
-   - **Promote** merges the configuration into your live configuration immediately. This can't be undone. To reverse it you have to delete each resulting resource by hand.
+   - **Promote** merges the configuration into your live configuration immediately. This can't be undone. To reverse it, you have to delete each resulting resource by hand.
 1. Click **Next**.
 1. On the **Import notification resources** step, choose the **Import source**:
    - **Alertmanager config YAML** uploads a configuration file. Optionally, upload the template files the configuration references. Each file is imported as a template named after the file.
@@ -159,12 +164,12 @@ The Alertmanager import endpoints are compatible with the [Mimir Alertmanager HT
 
 In these endpoints, an import is addressed by its identifier, which is set with the `X-Grafana-Alerting-Config-Identifier` header and defaults to `imported`.
 
-| Method | Endpoint                                      | Summary                                                                            |
-| ------ | --------------------------------------------- | ---------------------------------------------------------------------------------- |
-| POST   | `/convert/api/v1/alerts`                      | Import an Alertmanager configuration, optionally promoting it in the same request. |
-| GET    | `/convert/api/v1/alerts`                      | Get the staged configuration. Secrets are masked.                                  |
-| DELETE | `/convert/api/v1/alerts`                      | Delete the staged configuration. The Grafana configuration is unaffected.          |
-| POST   | `/convert/api/v1/alerts/{Identifier}/promote` | Promote a staged configuration into the Grafana configuration.                     |
+| Method | Endpoint                                          | Summary                                                                            |
+| ------ | ------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| POST   | `/api/convert/api/v1/alerts`                      | Import an Alertmanager configuration, optionally promoting it in the same request. |
+| GET    | `/api/convert/api/v1/alerts`                      | Get the staged configuration. Secrets are masked.                                  |
+| DELETE | `/api/convert/api/v1/alerts`                      | Delete the staged configuration. The Grafana configuration is unaffected.          |
+| POST   | `/api/convert/api/v1/alerts/{Identifier}/promote` | Promote a staged configuration into the Grafana configuration.                     |
 
 The `POST` endpoint accepts YAML and JSON. If no media type is specified, YAML is assumed. The request body has the same shape as the Mimir Alertmanager configuration API:
 
@@ -180,18 +185,15 @@ alertmanager_config: |
         - url: 'https://example.com/webhook'
 ```
 
-A successful import returns the merge result, including any renamed resources:
+A successful import returns the merge result:
 
 ```json
 {
   "status": "success",
   "stats": {
-    "addedRoute": "prometheus-prod",
-    "addedReceivers": ["webhook", "default_prometheus-prod"],
-    "addedTemplates": ["default.tmpl"]
-  },
-  "renameResources": {
-    "receivers": { "default": "default_prometheus-prod" }
+    "added_route": "mimir-prod",
+    "added_receivers": ["webhook"],
+    "added_templates": ["default.tmpl"]
   }
 }
 ```
@@ -225,7 +227,7 @@ MIMIR_ADDRESS=<GRAFANA_BASE_URL>/api/convert/ \
 MIMIR_AUTH_TOKEN=<SERVICE_ACCOUNT_TOKEN> \
 MIMIR_TENANT_ID=1 \
 mimirtool alertmanager load alertmanager.yaml default.tmpl \
-  --extra-headers "X-Grafana-Alerting-Config-Identifier=prometheus-prod"
+  --extra-headers "X-Grafana-Alerting-Config-Identifier=mimir-prod"
 ```
 
 Replace the following placeholders:
@@ -244,7 +246,7 @@ To promote a configuration that's already staged, call the promote endpoint with
 ```bash
 curl -X POST \
   -H "Authorization: Bearer <SERVICE_ACCOUNT_TOKEN>" \
-  <GRAFANA_BASE_URL>/api/convert/api/v1/alerts/prometheus-prod/promote
+  <GRAFANA_BASE_URL>/api/convert/api/v1/alerts/mimir-prod/promote
 ```
 
 After promotion, the staged configuration no longer exists. Its resources are part of the Grafana configuration. You can edit them through the regular notification APIs and user interface.
@@ -268,12 +270,12 @@ Reverting deletes the imported notification policy tree. Alert rules that route 
 
 Consider the following when you import an Alertmanager configuration:
 
-- **Unsupported receiver fields**: An integration field that reads its value from elsewhere, which includes every `*_file` and `*_ref` variant. Has no equivalent in Grafana. Grafana rejects a configuration that contains one, so nothing is imported. Supply the value inline in the matching field instead, and drop the `_file` or `_ref` variant.
+- **Unsupported receiver fields**: Integration fields that read their values from elsewhere, including every `*_file` and `*_ref` variant, have no equivalent in Grafana. Grafana rejects a configuration that contains one, so nothing is imported. Supply the value inline in the matching field instead, and drop the `_file` or `_ref` variant.
 - **Data source support**: Grafana reads a configuration from a Mimir Alertmanager data source. Upstream Prometheus Alertmanager doesn't expose a configuration API, so those data sources aren't supported. Import a configuration YAML file instead.
 - **Global settings**: After you promote an import, the `global` section no longer exists as a section of its own. Grafana has resolved its values into each integration setting that relies on them, so a promoted contact point carries the resolved value rather than a reference to `global`.
 - **Policy tree name**: The name of the imported policy tree, which is also the import identifier, must be a valid DNS subdomain name of at most 40 characters, using only lowercase alphanumeric characters, `-`, and `.`.
-- **One staged configuration at a time**: Grafana stores one staged configuration per organization. Importing a second configuration with a different identifier fails unless you explicitly replace the existing one.
-- **Template name conflicts across imports**: Grafana renames colliding template files, but the templates defined inside those files share one namespace. Say an earlier import defines a template called `default.email` that renders `X`, and a new import defines `default.email` again, in a file under a different name, rendering `Y`. Which definition wins isn't deterministic, and every contact point that uses that name gets the winner—so contact points from the earlier import can start sending the wrong content. Check the names of the templates you define, not just the file names, before you import a second configuration.
+- **One staged configuration at a time**: Grafana stores one staged configuration per organization. Before you stage another configuration, promote or revert the existing one. You can also explicitly replace the existing configuration during import.
+- **Template name conflicts across imports**: Grafana renames colliding template files, but the templates defined inside those files share one namespace. Say an earlier import defines a template called `default.email` that renders `X`, and a new import defines `default.email` again, in a file under a different name, rendering `Y`. Which definition wins isn't deterministic, and every contact point that uses that template gets the winner. As a result, contact points from the earlier import can start sending the wrong content. Check the names of the templates you define, not just the file names, before you import a second configuration.
 - **Deprecated provisioning API**: A staged configuration isn't visible in the deprecated provisioning API, which doesn't return its contact points, templates, or time intervals. Use the Grafana Alerting notification API (`notifications.alerting.grafana.app`) instead.
 - **Inhibition rules**: Imported inhibition rules are supported through the API only. There's no user interface for creating or editing them. For more details, refer to [configure inhibition rules](ref:configure-inhibition-rules).
 

--- a/docs/sources/alerting/configure-notifications/import-alertmanager-configuration.md
+++ b/docs/sources/alerting/configure-notifications/import-alertmanager-configuration.md
@@ -1,0 +1,285 @@
+---
+canonical: https://grafana.com/docs/grafana/latest/alerting/configure-notifications/import-alertmanager-configuration/
+description: Import an existing Prometheus or Mimir Alertmanager configuration into Grafana Alerting and operate it as Grafana-managed notification resources.
+keywords:
+  - grafana
+  - alerting
+  - alertmanager
+  - import
+  - notifications
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
+menuTitle: Import Alertmanager configuration
+title: Import Alertmanager configuration to Grafana-managed notifications
+weight: 460
+refs:
+  import-rules:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/alerting-migration/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/alerting-migration/
+  configure-contact-points:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/manage-contact-points/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/manage-contact-points/
+  configure-notification-policies:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/create-notification-policy/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/create-notification-policy/
+  notification-policy-trees:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/create-notification-policy/#manage-multiple-notification-policies
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/create-notification-policy/#manage-multiple-notification-policies
+  configure-templates:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/template-notifications/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/template-notifications/
+  configure-mute-timings:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/mute-timings/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/mute-timings/
+  images-in-notifications:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/template-notifications/images-in-notifications/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/template-notifications/images-in-notifications/
+  configure-inhibition-rules:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/inhibition-rules/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/inhibition-rules/
+  rbac:
+    - pattern: /docs/
+      destination: /docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/access-control/
+  feature-toggles:
+    - pattern: /docs/
+      destination: /docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/
+---
+
+# Import Alertmanager configuration to Grafana-managed notifications
+
+You can import an existing Prometheus or Mimir Alertmanager configuration into Grafana Alerting. Grafana stores the configuration as it is and evaluates it the way your Alertmanager does, then surfaces it as Grafana notification resources—contact points, a notification policy tree, notification templates, time intervals, and inhibition rules—so you can operate your notification setup from Grafana.
+
+Importing is a safe operation. The source Alertmanager keeps its configuration, and Grafana never writes back to it.
+
+The import happens in two stages:
+
+- **Stage**: Grafana keeps the imported configuration as a unit of its own and combines it with your Grafana resources at runtime.
+- **Promote**: Grafana merges the imported configuration permanently into your Grafana configuration. Every imported resource becomes a normal, editable Grafana resource, and you can no longer revert the import in one action.
+
+Holding a staged configuration apart is what lets you revert or re-import all of it at once, instead of resource by resource. Its resources are read-only, and no Grafana resource can reference them. The imported policy tree is the exception: an alert rule can route to it by name. Until a rule does, your existing notifications are unchanged.
+
+{{< admonition type="note" >}}
+Importing Alertmanager configuration is in [public preview](https://grafana.com/docs/release-life-cycle/#public-preview). The API is behind the `alertingImportAlertmanagerAPI` [feature toggle](ref:feature-toggles) and the user interface is behind `alertingMigrationWizardUI`. Both are disabled by default. In Grafana Cloud, contact Support to enable them.
+{{< /admonition >}}
+
+## Before you begin
+
+Before you import an Alertmanager configuration, make sure you have the following:
+
+- **A source Grafana can read**: a configuration YAML file with its template files, or a configured Mimir Alertmanager data source. Upstream Prometheus Alertmanager data sources aren't supported.
+- **Permissions**: importing a configuration requires the `alert.notifications:write` permission, or the scoped Alertmanager imports permissions. Both are granted to the Admin role by default. Promoting an import additionally requires create permissions for each resource type in the configuration: contact points, notification policies, notification templates, time intervals, and inhibition rules. For more details, refer to [RBAC permissions](ref:rbac).
+
+Not every Alertmanager configuration can be imported as it is. Refer to [limitations](#limitations) before you start.
+
+## How it works
+
+Grafana imports the configuration as it is and evaluates it the way your source Alertmanager does. Receivers keep their Alertmanager fields, and they notify with the same logic and message format, because Grafana runs them as Mimir-compatible integrations instead of rewriting them into native Grafana ones.
+
+Mimir-compatible integrations don't offer what a native Grafana integration adds on top, such as [images in notifications](ref:images-in-notifications). To pick those up, promote the import and then rebuild the contact point as a Grafana one.
+
+### What gets imported
+
+Grafana imports every field of the configuration: receivers, the routing tree, template files, time intervals, and inhibition rules. Fields keep their names and values, apart from the renames described in [name conflicts](#name-conflicts). Both `time_intervals` and the deprecated `mute_time_intervals` become time intervals.
+
+The `global` section is the one part with no place of its own. Grafana resolves its values into the settings of each integration that relies on them as the configuration is parsed, so the defaults you set globally still apply.
+
+### Routing
+
+Grafana adds the imported routing tree as a named policy tree of its own, alongside your default notification policy. Alerts reach it only when an alert rule routes to it by name. The matchers inside the imported tree then sort those alerts the way they did in your source Alertmanager. For more details on serving more than one policy tree, refer to [manage multiple notification policies](ref:notification-policy-trees).
+
+If the imported root route leaves `group_wait`, `group_interval`, or `repeat_interval` unset, Grafana fills in the Alertmanager defaults: 30 seconds, 5 minutes, and 4 hours. The imported tree keeps its own timing instead of inheriting it from your Grafana root policy.
+
+You choose the tree name when you import. This name is also the identifier of the import, so pick something you recognize, such as `prometheus-prod`. The name has to be a valid DNS subdomain name and is length-limited; for more details, refer to [limitations](#limitations).
+
+### Name conflicts
+
+Contact points, time intervals, and notification templates are identified by name, and the imported configuration may reuse names that already exist. Rather than fail or overwrite, Grafana renames the incoming resource:
+
+1. Grafana appends `_` and the import identifier to the name, for example `default` becomes `default_prometheus-prod`.
+1. If that name is also taken, Grafana appends a number, for example `default_prometheus-prod_01`.
+
+All references to a renamed resource are updated throughout the imported configuration, so routing still points at the right contact point.
+
+Templates count conflicts differently. An imported template never conflicts with a Grafana-managed template of the same name, only with a template from another imported configuration. For more details, refer to [limitations](#limitations).
+
+### Staged resources are read-only
+
+While an import is staged, its resources appear with an **Imported** status in the Grafana Alerting user interface and in the notification APIs, and you can't edit or delete them individually. The deprecated provisioning API is the exception: it doesn't return them at all.
+
+You also can't reference an imported resource from a Grafana resource—for example, you can't pick an imported contact point in a Grafana notification policy. The imported policy tree is the exception: an alert rule can route to it by name while the import is staged.
+
+To make imported resources editable and referenceable, promote the import.
+
+### One import at a time
+
+Grafana stores one imported configuration per organization. Importing a second configuration with a different identifier fails unless you explicitly replace the existing one.
+
+## Import with the Grafana Alerting user interface
+
+The Grafana Alerting user interface imports notification resources and alert rules in one flow. It requires both the `alertingImportAlertmanagerAPI` and `alertingMigrationWizardUI` [feature toggles](ref:feature-toggles).
+
+1. Go to **Alerting** > **Alert rules**.
+1. In the **More** menu, click **Import to Grafana Alerting**.
+1. Choose how the resources are added:
+   - **Stage** brings the configuration in as a read-only, reversible copy.
+   - **Promote** merges the configuration into your live configuration immediately. This can't be undone—to reverse it you have to delete each resulting resource by hand.
+1. Click **Next**.
+1. On the **Import notification resources** step, choose the **Import source**:
+   - **Alertmanager config YAML** uploads a configuration file. Optionally, upload the template files the configuration references. Each file is imported as a template named after the file.
+   - **Alertmanager data source** reads the configuration from a configured Alertmanager data source.
+1. Enter a **Policy tree name**.
+
+   Grafana validates the configuration as you fill in the form and reports any conflicts. Resources that would be renamed are listed before you import.
+
+1. Click **Next**, and either configure the [alert rules import](ref:import-rules) or skip the step.
+1. Review the summary, then click **Start import**.
+
+## Import with the API
+
+The Alertmanager import endpoints are compatible with the [Mimir Alertmanager HTTP API](/docs/mimir/latest/references/http-api/#alertmanager), so you can use `mimirtool` or plain HTTP requests.
+
+In these endpoints, an import is addressed by its identifier, which is set with the `X-Grafana-Alerting-Config-Identifier` header and defaults to `imported`.
+
+| Method | Endpoint                                      | Summary                                                                            |
+| ------ | --------------------------------------------- | ---------------------------------------------------------------------------------- |
+| POST   | `/convert/api/v1/alerts`                      | Import an Alertmanager configuration, optionally promoting it in the same request. |
+| GET    | `/convert/api/v1/alerts`                      | Get the staged configuration. Secrets are masked.                                  |
+| DELETE | `/convert/api/v1/alerts`                      | Delete the staged configuration. The Grafana configuration is unaffected.          |
+| POST   | `/convert/api/v1/alerts/{Identifier}/promote` | Promote a staged configuration into the Grafana configuration.                     |
+
+The `POST` endpoint accepts YAML and JSON. If no media type is specified, YAML is assumed. The request body has the same shape as the Mimir Alertmanager configuration API:
+
+```yaml
+template_files:
+  default.tmpl: '{{ define "custom" }}Custom message{{ end }}'
+alertmanager_config: |
+  route:
+    receiver: webhook
+  receivers:
+    - name: webhook
+      webhook_configs:
+        - url: 'https://example.com/webhook'
+```
+
+A successful import returns the merge result, including any renamed resources:
+
+```json
+{
+  "status": "success",
+  "stats": {
+    "addedRoute": "prometheus-prod",
+    "addedReceivers": ["webhook", "default_prometheus-prod"],
+    "addedTemplates": ["default.tmpl"]
+  },
+  "renameResources": {
+    "receivers": { "default": "default_prometheus-prod" }
+  }
+}
+```
+
+### Optional headers
+
+Use these headers for more granular import control:
+
+#### `X-Grafana-Alerting-Config-Identifier`
+
+The identifier of the import, which is also the name of the notification policy tree it creates. It must be a valid DNS subdomain name—lowercase alphanumeric characters, `-`, and `.`—and at most 40 characters. Defaults to `imported`.
+
+#### `X-Grafana-Alerting-Dry-Run`
+
+Set to `true` to validate the configuration and report the merge result without saving anything. Use this to preview renames before importing.
+
+#### `X-Grafana-Alerting-Promote`
+
+Set to `true` to promote the configuration in the same request instead of staging it. Combine it with `X-Grafana-Alerting-Dry-Run` to preview what a promotion merges into the live configuration.
+
+#### `X-Grafana-Alerting-Config-Force-Replace`
+
+Set to `true` to replace an existing staged configuration that has a different identifier. Without it, importing a second configuration fails.
+
+### mimirtool
+
+Use `mimirtool alertmanager load` to import a configuration and its template files:
+
+```bash
+MIMIR_ADDRESS=<GRAFANA_BASE_URL>/api/convert/ \
+MIMIR_AUTH_TOKEN=<SERVICE_ACCOUNT_TOKEN> \
+MIMIR_TENANT_ID=1 \
+mimirtool alertmanager load alertmanager.yaml default.tmpl \
+  --extra-headers "X-Grafana-Alerting-Config-Identifier=prometheus-prod"
+```
+
+Replace the following placeholders:
+
+- `<GRAFANA_BASE_URL>`: the base URL of your Grafana instance.
+- `<SERVICE_ACCOUNT_TOKEN>`: a service account token with permission to import notification resources.
+
+When the address points at `<GRAFANA_BASE_URL>/api/convert/`, `mimirtool` talks to Grafana rather than to a Mimir instance, so `MIMIR_TENANT_ID` must always be `1`.
+
+`mimirtool alertmanager get` and `mimirtool alertmanager delete` read and remove the staged configuration in the same way.
+
+### Promote a staged configuration
+
+To promote a configuration that's already staged, call the promote endpoint with its identifier:
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer <SERVICE_ACCOUNT_TOKEN>" \
+  <GRAFANA_BASE_URL>/api/convert/api/v1/alerts/prometheus-prod/promote
+```
+
+After promotion, the staged configuration no longer exists—its resources are part of the Grafana configuration and are editable through the regular notification APIs and user interface.
+
+## Review, promote, or revert a staged configuration
+
+Staged configurations are managed in Grafana Alerting settings.
+
+1. Go to **Alerting** > **Settings**.
+1. Click the **Import** tab.
+
+The **Staged configuration** section lists the contact points, notification policies, templates, time intervals, and inhibition rules the import contains, and links to each resource so you can inspect it before promoting.
+
+To discard the import and everything it added, click **Revert**. Your Grafana configuration is unaffected.
+
+{{< admonition type="warning" >}}
+Reverting deletes the imported notification policy tree. Alert rules that route to that tree lose their target, and their alerts fall back to the root of your default notification policy. Repoint those rules before you revert.
+{{< /admonition >}}
+
+## Limitations
+
+Consider the following when you import an Alertmanager configuration:
+
+- **Unsupported receiver fields**: an integration field that reads its value from elsewhere—every `*_file` and `*_ref` variant—has no equivalent in Grafana. A configuration that contains one is rejected as a whole, so nothing is imported. Supply the value inline in the matching field instead, and drop the `_file` or `_ref` variant.
+- **Data source support**: Grafana reads a configuration from a Mimir Alertmanager data source. Upstream Prometheus Alertmanager doesn't expose a configuration API, so those data sources aren't supported. Import a configuration YAML file instead.
+- **Global settings**: after you promote an import, the `global` section no longer exists as a section of its own. Grafana has resolved its values into each integration setting that relies on them, so a promoted contact point carries the resolved value rather than a reference to `global`.
+- **Policy tree name**: the name of the imported policy tree, which is also the import identifier, must be a valid DNS subdomain name—lowercase alphanumeric characters, `-`, and `.`—and at most 40 characters.
+- **One staged configuration at a time**: Grafana stores one staged configuration per organization. Importing a second configuration with a different identifier fails unless you explicitly replace the existing one.
+- **Template name conflicts across imports**: Grafana renames colliding template files, but the templates defined inside those files share one namespace. Say an earlier import defines a template called `default.email` that renders `X`, and a new import defines `default.email` again, in a file under a different name, rendering `Y`. Which definition wins isn't deterministic, and every contact point that uses that name gets the winner—so contact points from the earlier import can start sending the wrong content. Check the names of the templates you define, not just the file names, before you import a second configuration.
+- **Deprecated provisioning API**: a staged configuration isn't visible in the deprecated provisioning API—its contact points, templates, and time intervals aren't returned. Use the Grafana Alerting notification API (`notifications.alerting.grafana.app`) instead.
+- **Inhibition rules**: imported inhibition rules are supported through the API only. There's no user interface for creating or editing them. For more details, refer to [configure inhibition rules](ref:configure-inhibition-rules).
+
+## Next steps
+
+After you import your notification configuration:
+
+- [Import your data source-managed alert rules](ref:import-rules) and route them through the imported policy tree.
+- Review the imported [contact points](ref:configure-contact-points), [notification policies](ref:configure-notification-policies), [templates](ref:configure-templates), and [time intervals](ref:configure-mute-timings).

--- a/docs/sources/shared/alerts/alerting_provisioning.md
+++ b/docs/sources/shared/alerts/alerting_provisioning.md
@@ -11,7 +11,7 @@ The Alerting Provisioning HTTP API can be used to create, modify, and delete res
 > If you are running Grafana Enterprise, you need to add specific permissions for some endpoints. For more information, refer to [Role-based access control permissions](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/access-control/custom-role-actions-scopes/).
 
 {{< admonition type="warning" >}}
-The contact points, notification policies, notification template groups, and mute timings endpoints in this API are deprecated and will be removed in a future release. Use the [Grafana App Platform alerting APIs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/grafana/grafana/main/packages/grafana-openapi/src/apis/notifications.alerting.grafana.app-v1beta1.json) instead.
+The contact points, notification policies, notification template groups, and mute timings endpoints in this API are deprecated and will be removed in a future release. These endpoints don't return resources from a staged Alertmanager configuration. Use the [Grafana App Platform alerting APIs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/grafana/grafana/main/packages/grafana-openapi/src/apis/notifications.alerting.grafana.app-v1beta1.json) instead.
 {{< /admonition >}}
 
 ## Grafana-managed endpoints


### PR DESCRIPTION
**What is this feature?**

Adds a documentation page for importing an existing Prometheus or Mimir Alertmanager configuration into Grafana Alerting: `alerting/configure-notifications/import-alertmanager-configuration`.

It covers:

- The stage / promote model, and why staging exists.
- What each Alertmanager object becomes — `receivers`, `route`, `template_files`, `time_intervals`, `inhibit_rules`, and that `global` isn't imported.
- Routing: the import lands as a separate named policy tree evaluated before existing routes, with explicit `group_wait` / `group_interval` / `repeat_interval`.
- Name-conflict renaming (`_<identifier>`, then `_01`) and the dry run that previews it.
- Why staged resources are read-only and can't be referenced from Grafana routes or rules.
- The import wizard, the convert API endpoints and headers, `mimirtool alertmanager load`, and the promote endpoint.
- Reviewing and reverting a staged import from **Alerting > Settings > Import**.
- Limitations: unsupported `*_file` receiver fields fail the import, `global` isn't imported, inhibition rules are API-only, and staged resources can't be provisioned.

It also adds an **Import your notification configuration first** section to the existing rule import page. Grafana-managed rules route through Grafana's Alertmanager rather than the one the data source-managed rules used, and `X-Grafana-Alerting-Notification-Settings` requires the contact point to already exist in Grafana — so the notification import genuinely wants to happen first.

**Why do we need this feature?**

The import feature had no user-facing documentation. The rule import page also didn't say anything about where imported rules actually notify, which is the first thing that surprises someone mid-migration.

**Who is this feature for?**

Users migrating an existing Prometheus or Mimir Alertmanager setup to Grafana-managed notifications.

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/alerting-squad/issues/1154

**Special notes for your reviewer:**

- **Depends on https://github.com/grafana/grafana/pull/130883**, which promotes `alertingImportAlertmanagerAPI` and `alertingMigrationWizardUI` to public preview. This page describes the feature as public preview and links the toggle docs, so that PR should merge first.
- Content is written from the current implementation (`api_convert_prometheus.go`, the merge package, and the import wizard), not from the design docs. Two things from the design discussions are deliberately **not** documented because I couldn't confirm them in `main`: the `v0mimir1` / `v0mimir2` integration versioning, and Mimir templates being usable only with v0 integrations. Please flag if either is real and user-visible.
- Auto-sync (`alerting.syncExternalAlertmanager`) is not covered — it's a hidden experimental toggle and a separate feature. That does mean the page doesn't yet explain the "Auto-sync is enabled" block a user can hit in the wizard.