### PR TITLE
AuthZ: Return all actions and scopes from RBAC permission queries

### DIFF
--- a/pkg/services/authz/rbac/store/permission_query.sql
+++ b/pkg/services/authz/rbac/store/permission_query.sql
@@ -1,4 +1,4 @@
-SELECT p.kind, p.attribute, p.identifier, p.scope FROM {{ .Ident .PermissionTable }} as p
+SELECT{{ if not .Query.Action }} p.action,{{ end }} p.kind, p.attribute, p.identifier, p.scope FROM {{ .Ident .PermissionTable }} as p
 INNER JOIN (
   SELECT role_id FROM {{ .Ident .BuiltinRoleTable }} as br WHERE (br.role = {{ .Arg .Query.Role }} AND (br.org_id = {{ .Arg .Query.OrgID }} OR br.org_id = 0))
     {{ if .Query.IsServerAdmin }}
@@ -13,9 +13,11 @@ INNER JOIN (
   SELECT role_id FROM {{ .Ident .TeamRoleTable }} as tr WHERE tr.team_id IN ({{ .ArgList .Query.TeamIDs }}) AND tr.org_id = {{ .Arg .Query.OrgID }}
   {{ end }}
 ) as roles ON p.role_id = roles.role_id
+{{ if .Query.Action }}
 WHERE
   {{ if .Query.ActionSets }}
   p.action IN ({{ .ArgList .Query.ActionSets }}, {{ .Arg .Query.Action }})
   {{ else }}
   p.action = {{ .Arg .Query.Action }}
   {{ end }}
+{{ end }}

--- a/pkg/services/authz/rbac/store/permission_store.go
+++ b/pkg/services/authz/rbac/store/permission_store.go
@@ -91,7 +91,14 @@ func (s *SQLPermissionsStore) GetUserPermissions(ctx context.Context, ns types.N
 	var perms []accesscontrol.Permission
 	for res.Next() {
 		var perm accesscontrol.Permission
-		if err := res.Scan(&perm.Kind, &perm.Attribute, &perm.Identifier, &perm.Scope); err != nil {
+		perm.Action = query.Action
+		var err error
+		if query.Action == "" {
+			err = res.Scan(&perm.Action, &perm.Kind, &perm.Attribute, &perm.Identifier, &perm.Scope)
+		} else {
+			err = res.Scan(&perm.Kind, &perm.Attribute, &perm.Identifier, &perm.Scope)
+		}
+		if err != nil {
 			return nil, err
 		}
 		perms = append(perms, perm)

--- a/pkg/services/authz/rbac/store/permission_store.go
+++ b/pkg/services/authz/rbac/store/permission_store.go
@@ -133,7 +133,7 @@ func (s *StaticPermissionStore) GetUserPermissions(ctx context.Context, ns types
 		}
 
 		for _, p := range r.Permissions {
-			if p.Action == query.Action {
+			if query.Action == "" || p.Action == query.Action {
 				permissions = append(permissions, p)
 			}
 		}

--- a/pkg/services/authz/rbac/store/permission_store_test.go
+++ b/pkg/services/authz/rbac/store/permission_store_test.go
@@ -1,0 +1,51 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/authlib/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+)
+
+type staticRoleService struct {
+	accesscontrol.Service
+	roles map[string]*accesscontrol.RoleDTO
+}
+
+func (s *staticRoleService) GetStaticRoles(context.Context) map[string]*accesscontrol.RoleDTO {
+	return s.roles
+}
+
+func TestStaticPermissionStoreGetUserPermissions(t *testing.T) {
+	permissions := []accesscontrol.Permission{
+		{Action: "dashboards:read", Scope: "dashboards:*"},
+		{Action: "folders:read", Scope: "folders:*"},
+	}
+	store := NewStaticPermissionStore(&staticRoleService{
+		roles: map[string]*accesscontrol.RoleDTO{
+			"Viewer": {Permissions: permissions},
+		},
+	})
+
+	t.Run("returns permissions for the requested action", func(t *testing.T) {
+		got, err := store.GetUserPermissions(t.Context(), types.NamespaceInfo{}, PermissionsQuery{
+			Role:   "Viewer",
+			Action: "dashboards:read",
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, permissions[:1], got)
+	})
+
+	t.Run("returns permissions for every action when action is empty", func(t *testing.T) {
+		got, err := store.GetUserPermissions(t.Context(), types.NamespaceInfo{}, PermissionsQuery{
+			Role: "Viewer",
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, permissions, got)
+	})
+}

--- a/pkg/services/authz/rbac/store/sql_test.go
+++ b/pkg/services/authz/rbac/store/sql_test.go
@@ -107,6 +107,14 @@ func TestIdentityQueries(t *testing.T) {
 					}),
 				},
 				{
+					Name: "all_user_permissions",
+					Data: getPermissions(&PermissionsQuery{
+						UserID: 1,
+						OrgID:  1,
+						Role:   "Editor",
+					}),
+				},
+				{
 					Name: "With_action_sets",
 					Data: getPermissions(&PermissionsQuery{
 						UserID:     1,

--- a/pkg/services/authz/rbac/store/testdata/mysql--permission_query-all_user_permissions.sql
+++ b/pkg/services/authz/rbac/store/testdata/mysql--permission_query-all_user_permissions.sql
@@ -1,0 +1,6 @@
+SELECT p.action, p.kind, p.attribute, p.identifier, p.scope FROM `grafana`.`permission` as p
+INNER JOIN (
+  SELECT role_id FROM `grafana`.`builtin_role` as br WHERE (br.role = 'Editor' AND (br.org_id = 1 OR br.org_id = 0))
+  UNION ALL
+  SELECT role_id FROM `grafana`.`user_role` as ur WHERE ur.user_id = 1 AND (ur.org_id = 1 OR ur.org_id = 0)
+) as roles ON p.role_id = roles.role_id

--- a/pkg/services/authz/rbac/store/testdata/postgres--permission_query-all_user_permissions.sql
+++ b/pkg/services/authz/rbac/store/testdata/postgres--permission_query-all_user_permissions.sql
@@ -1,0 +1,6 @@
+SELECT p.action, p.kind, p.attribute, p.identifier, p.scope FROM "grafana"."permission" as p
+INNER JOIN (
+  SELECT role_id FROM "grafana"."builtin_role" as br WHERE (br.role = 'Editor' AND (br.org_id = 1 OR br.org_id = 0))
+  UNION ALL
+  SELECT role_id FROM "grafana"."user_role" as ur WHERE ur.user_id = 1 AND (ur.org_id = 1 OR ur.org_id = 0)
+) as roles ON p.role_id = roles.role_id

--- a/pkg/services/authz/rbac/store/testdata/sqlite--permission_query-all_user_permissions.sql
+++ b/pkg/services/authz/rbac/store/testdata/sqlite--permission_query-all_user_permissions.sql
@@ -1,0 +1,6 @@
+SELECT p.action, p.kind, p.attribute, p.identifier, p.scope FROM "grafana"."permission" as p
+INNER JOIN (
+  SELECT role_id FROM "grafana"."builtin_role" as br WHERE (br.role = 'Editor' AND (br.org_id = 1 OR br.org_id = 0))
+  UNION ALL
+  SELECT role_id FROM "grafana"."user_role" as ur WHERE ur.user_id = 1 AND (ur.org_id = 1 OR ur.org_id = 0)
+) as roles ON p.role_id = roles.role_id


### PR DESCRIPTION
## What is this feature?

Changes the RBAC permission query so it can return complete action/scope pairs when no action filter is supplied.

Today the query assumes the caller already knows the action and therefore returns only scopes. `GetUserPermissions` needs every permission for a user, so it cannot supply one action up front. The query now has two explicit modes:

- with an action: return the scopes for that action, preserving existing callers
- without an action: return both the action and scope for every matching permission

The PR includes MySQL, PostgreSQL, and SQLite query snapshots because Grafana supports all three databases and their generated SQL differs.

## Stack

- Base: https://github.com/grafana/grafana/pull/130888
- Next: https://github.com/grafana/grafana/pull/130892

## How was this tested?

- `go test ./pkg/services/authz/rbac/store ./pkg/services/authz/rbac` — 604 tests passed in 2 packages
