### PR TITLE
AuthZ: Route OSS user permissions through AuthZ

### DIFF
--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/open-feature/go-sdk/openfeature"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/attribute"
 
@@ -162,6 +163,36 @@ func (s *Service) GetUserPermissions(ctx context.Context, user identity.Requeste
 	timer := prometheus.NewTimer(metrics.MAccessPermissionsSummary)
 	defer timer.ObserveDuration()
 
+	if user.GetOrgID() != accesscontrol.GlobalOrgID && openfeature.NewDefaultClient().Boolean(ctx, featuremgmt.FlagAuthzUserPermissions, false, openfeature.TransactionContext(ctx)) {
+		if s.userPermissionsClient == nil {
+			return nil, fmt.Errorf("AuthZ user permissions client is not configured")
+		}
+		return s.userPermissionsClient.GetUserPermissions(ctx, user, options)
+	}
+	return s.getLocalUserPermissions(ctx, user, options)
+}
+
+// GetLocalUserPermissions evaluates effective local permissions without delegating back to AuthZ.
+func (s *Service) GetLocalUserPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
+	ctx, span := tracer.Start(ctx, "accesscontrol.acimpl.GetLocalUserPermissions")
+	defer span.End()
+
+	timer := prometheus.NewTimer(metrics.MAccessPermissionsSummary)
+	defer timer.ObserveDuration()
+
+	return s.getLocalUserPermissions(ctx, user, options)
+}
+
+func (s *Service) getLocalUserPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
+	permissions, err := s.GetRBACUserPermissions(ctx, user, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.mergeZanzanaUserPermissions(ctx, user, permissions, options), nil
+}
+
+func (s *Service) GetRBACUserPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
 	var permissions []accesscontrol.Permission
 	var err error
 
@@ -175,11 +206,7 @@ func (s *Service) GetUserPermissions(ctx context.Context, user identity.Requeste
 		return nil, err
 	}
 
-	return s.mergeZanzanaUserPermissions(ctx, user, permissions, options), nil
-}
-
-func (s *Service) GetLocalUserPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
-	return s.GetUserPermissions(ctx, user, options)
+	return permissions, nil
 }
 
 func (s *Service) mergeZanzanaUserPermissions(ctx context.Context, user identity.Requester, legacy []accesscontrol.Permission, options accesscontrol.Options) []accesscontrol.Permission {

--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -163,7 +163,7 @@ func (s *Service) GetUserPermissions(ctx context.Context, user identity.Requeste
 	timer := prometheus.NewTimer(metrics.MAccessPermissionsSummary)
 	defer timer.ObserveDuration()
 
-	if user.GetOrgID() != accesscontrol.GlobalOrgID && openfeature.NewDefaultClient().Boolean(ctx, featuremgmt.FlagAuthzUserPermissions, false, openfeature.TransactionContext(ctx)) {
+	if s.cfg.RBAC.SingleOrganization && user.GetOrgID() != accesscontrol.GlobalOrgID && openfeature.NewDefaultClient().Boolean(ctx, featuremgmt.FlagAuthzUserPermissions, false, openfeature.TransactionContext(ctx)) {
 		if s.userPermissionsClient == nil {
 			return nil, fmt.Errorf("AuthZ user permissions client is not configured")
 		}

--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/open-feature/go-sdk/openfeature"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/attribute"
 
@@ -162,6 +163,36 @@ func (s *Service) GetUserPermissions(ctx context.Context, user identity.Requeste
 	timer := prometheus.NewTimer(metrics.MAccessPermissionsSummary)
 	defer timer.ObserveDuration()
 
+	if user.GetOrgID() != accesscontrol.GlobalOrgID && openfeature.NewDefaultClient().Boolean(ctx, featuremgmt.FlagAuthzUserPermissions, false, openfeature.TransactionContext(ctx)) {
+		if s.userPermissionsClient == nil {
+			return nil, fmt.Errorf("AuthZ user permissions client is not configured")
+		}
+		return s.userPermissionsClient.GetUserPermissions(ctx, user, options)
+	}
+	return s.getLocalUserPermissions(ctx, user, options)
+}
+
+// GetLocalUserPermissions evaluates effective local permissions without delegating back to AuthZ.
+func (s *Service) GetLocalUserPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
+	ctx, span := tracer.Start(ctx, "accesscontrol.acimpl.GetLocalUserPermissions")
+	defer span.End()
+
+	timer := prometheus.NewTimer(metrics.MAccessPermissionsSummary)
+	defer timer.ObserveDuration()
+
+	return s.getLocalUserPermissions(ctx, user, options)
+}
+
+func (s *Service) getLocalUserPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
+	permissions, err := s.GetRBACUserPermissions(ctx, user, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.mergeZanzanaUserPermissions(ctx, user, permissions, options), nil
+}
+
+func (s *Service) GetRBACUserPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
 	var permissions []accesscontrol.Permission
 	var err error
 
@@ -175,11 +206,7 @@ func (s *Service) GetUserPermissions(ctx context.Context, user identity.Requeste
 		return nil, err
 	}
 
-	return s.mergeZanzanaUserPermissions(ctx, user, permissions, options), nil
-}
-
-func (s *Service) GetLocalUserPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
-	return s.GetUserPermissions(ctx, user, options)
+	return permissions, nil
 }
 
 func (s *Service) mergeZanzanaUserPermissions(ctx context.Context, user identity.Requester, legacy []accesscontrol.Permission, options accesscontrol.Options) []accesscontrol.Permission {
@@ -516,6 +543,9 @@ func (s *Service) getCachedTeamsPermissions(ctx context.Context, user identity.R
 func (s *Service) ClearUserPermissionCache(user identity.Requester) {
 	s.cache.ExclusiveDelete(accesscontrol.GetUserDirectPermissionCacheKey(user))
 	s.cache.ExclusiveDelete(accesscontrol.GetZanzanaUserPermissionCacheKey(user))
+	if s.userPermissionsClient != nil {
+		s.userPermissionsClient.ClearUserPermissionCache(user)
+	}
 }
 
 func (s *Service) DeleteUserPermissions(ctx context.Context, orgID int64, userID int64) error {

--- a/pkg/services/accesscontrol/acimpl/user_permissions_test.go
+++ b/pkg/services/accesscontrol/acimpl/user_permissions_test.go
@@ -1,0 +1,106 @@
+package acimpl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/open-feature/go-sdk/openfeature"
+	"github.com/open-feature/go-sdk/openfeature/memprovider"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/authlib/types"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+)
+
+func TestServiceGetUserPermissionsDelegatesToAuthZ(t *testing.T) {
+	service := setupTestEnv(t, false)
+	service.features = featuremgmt.WithFeatures()
+	setAuthZUserPermissionsFlag(t, true)
+	expected := []accesscontrol.Permission{{Action: "dashboards:read", Scope: "dashboards:*"}}
+	client := &fakeUserPermissionsClient{permissions: expected}
+	service.SetUserPermissionsClient(client)
+	user := &identity.StaticRequester{Type: types.TypeUser, UserID: 1, UserUID: "user-uid", OrgID: 2}
+	options := accesscontrol.Options{ReloadCache: true}
+
+	permissions, err := service.GetUserPermissions(t.Context(), user, options)
+
+	require.NoError(t, err)
+	require.Equal(t, expected, permissions)
+	require.Same(t, user, client.user)
+	require.Equal(t, options, client.options)
+	require.Equal(t, 1, client.calls)
+}
+
+func TestServiceGetUserPermissionsUsesLocalRBACForGlobalOrg(t *testing.T) {
+	service := setupTestEnv(t, false)
+	service.features = featuremgmt.WithFeatures()
+	setAuthZUserPermissionsFlag(t, true)
+	client := &fakeUserPermissionsClient{}
+	service.SetUserPermissionsClient(client)
+	user := &identity.StaticRequester{Type: types.TypeUser, UserID: 1, UserUID: "user-uid", OrgID: accesscontrol.GlobalOrgID}
+
+	_, err := service.GetUserPermissions(t.Context(), user, accesscontrol.Options{ReloadCache: true})
+
+	require.NoError(t, err)
+	require.Zero(t, client.calls)
+}
+
+func setAuthZUserPermissionsFlag(t *testing.T, enabled bool) {
+	t.Helper()
+	provider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
+		featuremgmt.FlagAuthzUserPermissions: {
+			Key:      featuremgmt.FlagAuthzUserPermissions,
+			Variants: map[string]any{"": enabled},
+		},
+	})
+	require.NoError(t, openfeature.SetProviderAndWait(provider))
+	t.Cleanup(func() {
+		require.NoError(t, openfeature.SetProviderAndWait(openfeature.NoopProvider{}))
+	})
+}
+
+func TestServiceGetRBACUserPermissionsDoesNotDelegateToAuthZ(t *testing.T) {
+	service := setupTestEnv(t, false)
+	service.features = featuremgmt.WithFeatures()
+	client := &fakeUserPermissionsClient{}
+	service.SetUserPermissionsClient(client)
+	user := &identity.StaticRequester{Type: types.TypeUser, UserID: 1, UserUID: "user-uid", OrgID: 2}
+
+	_, err := service.GetRBACUserPermissions(t.Context(), user, accesscontrol.Options{ReloadCache: true})
+
+	require.NoError(t, err)
+	require.Zero(t, client.calls)
+}
+
+func TestServiceClearUserPermissionCacheInvalidatesAuthZCache(t *testing.T) {
+	service := setupTestEnv(t, false)
+	client := &fakeUserPermissionsClient{}
+	service.SetUserPermissionsClient(client)
+	user := &identity.StaticRequester{Type: types.TypeUser, UserID: 1, UserUID: "user-uid", OrgID: 2}
+
+	service.ClearUserPermissionCache(user)
+
+	require.Equal(t, user, client.invalidatedUser)
+}
+
+type fakeUserPermissionsClient struct {
+	permissions     []accesscontrol.Permission
+	user            identity.Requester
+	options         accesscontrol.Options
+	invalidatedUser identity.Requester
+	calls           int
+}
+
+func (c *fakeUserPermissionsClient) GetUserPermissions(_ context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
+	c.calls++
+	c.user = user
+	c.options = options
+	return c.permissions, nil
+}
+
+func (c *fakeUserPermissionsClient) ClearUserPermissionCache(user identity.Requester) {
+	c.invalidatedUser = user
+}

--- a/pkg/services/accesscontrol/acimpl/user_permissions_test.go
+++ b/pkg/services/accesscontrol/acimpl/user_permissions_test.go
@@ -17,6 +17,7 @@ import (
 
 func TestServiceGetUserPermissionsDelegatesToAuthZ(t *testing.T) {
 	service := setupTestEnv(t, false)
+	service.cfg.RBAC.SingleOrganization = true
 	service.features = featuremgmt.WithFeatures()
 	setAuthZUserPermissionsFlag(t, true)
 	expected := []accesscontrol.Permission{{Action: "dashboards:read", Scope: "dashboards:*"}}
@@ -32,6 +33,21 @@ func TestServiceGetUserPermissionsDelegatesToAuthZ(t *testing.T) {
 	require.Same(t, user, client.user)
 	require.Equal(t, options, client.options)
 	require.Equal(t, 1, client.calls)
+}
+
+func TestServiceGetUserPermissionsUsesLocalRBACForMultiOrg(t *testing.T) {
+	service := setupTestEnv(t, false)
+	service.cfg.RBAC.SingleOrganization = false
+	service.features = featuremgmt.WithFeatures()
+	setAuthZUserPermissionsFlag(t, true)
+	client := &fakeUserPermissionsClient{}
+	service.SetUserPermissionsClient(client)
+	user := &identity.StaticRequester{Type: types.TypeUser, UserID: 1, UserUID: "user-uid", OrgID: 2}
+
+	_, err := service.GetUserPermissions(t.Context(), user, accesscontrol.Options{ReloadCache: true})
+
+	require.NoError(t, err)
+	require.Zero(t, client.calls)
 }
 
 func TestServiceGetUserPermissionsUsesLocalRBACForGlobalOrg(t *testing.T) {
@@ -75,23 +91,11 @@ func TestServiceGetRBACUserPermissionsDoesNotDelegateToAuthZ(t *testing.T) {
 	require.Zero(t, client.calls)
 }
 
-func TestServiceClearUserPermissionCacheInvalidatesAuthZCache(t *testing.T) {
-	service := setupTestEnv(t, false)
-	client := &fakeUserPermissionsClient{}
-	service.SetUserPermissionsClient(client)
-	user := &identity.StaticRequester{Type: types.TypeUser, UserID: 1, UserUID: "user-uid", OrgID: 2}
-
-	service.ClearUserPermissionCache(user)
-
-	require.Equal(t, user, client.invalidatedUser)
-}
-
 type fakeUserPermissionsClient struct {
-	permissions     []accesscontrol.Permission
-	user            identity.Requester
-	options         accesscontrol.Options
-	invalidatedUser identity.Requester
-	calls           int
+	permissions []accesscontrol.Permission
+	user        identity.Requester
+	options     accesscontrol.Options
+	calls       int
 }
 
 func (c *fakeUserPermissionsClient) GetUserPermissions(_ context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
@@ -101,6 +105,4 @@ func (c *fakeUserPermissionsClient) GetUserPermissions(_ context.Context, user i
 	return c.permissions, nil
 }
 
-func (c *fakeUserPermissionsClient) ClearUserPermissionCache(user identity.Requester) {
-	c.invalidatedUser = user
-}
+func (c *fakeUserPermissionsClient) ClearUserPermissionCache(identity.Requester) {}

--- a/pkg/services/authz/rbac.go
+++ b/pkg/services/authz/rbac.go
@@ -46,8 +46,6 @@ import (
 // AuthzServiceAudience is the audience for the authz service.
 const AuthzServiceAudience = "authzService"
 
-const userPermissionsDelegatedGrant = "authz.grafana.app/userpermissions:get"
-
 // ProvideAuthZClient provides an AuthZ client and creates the AuthZ service.
 func ProvideAuthZClient(
 	cfg *setting.Cfg,
@@ -161,11 +159,11 @@ func ProvideAuthZClient(
 			authzlib.WithCacheClientOption(&NoopCache{}),
 			authzlib.WithTracerClientOption(tracer),
 		)
+
 		configureUserPermissionsClient(acService, rbacClient, cfg.IDUseExternalGroupsForGroupsClaim)
 		if zanzanaNoLegacy {
 			return zanzanaClient, nil
 		}
-
 		if zanzanaEnabled {
 			return newZanzanaAwareClient(cfg, rbacClient, zanzanaClient, reg)
 		}

--- a/pkg/services/authz/rbac.go
+++ b/pkg/services/authz/rbac.go
@@ -45,8 +45,6 @@ import (
 // AuthzServiceAudience is the audience for the authz service.
 const AuthzServiceAudience = "authzService"
 
-const userPermissionsDelegatedGrant = "authz.grafana.app/userpermissions:get"
-
 // ProvideAuthZClient provides an AuthZ client and creates the AuthZ service.
 func ProvideAuthZClient(
 	cfg *setting.Cfg,
@@ -165,11 +163,11 @@ func ProvideAuthZClient(
 			authzlib.WithCacheClientOption(&NoopCache{}),
 			authzlib.WithTracerClientOption(tracer),
 		)
+
 		configureUserPermissionsClient(acService, rbacClient, cfg.IDUseExternalGroupsForGroupsClaim)
 		if zanzanaNoLegacy {
 			return zanzanaClient, nil
 		}
-
 		if zanzanaEnabled {
 			return newZanzanaAwareClient(cfg, rbacClient, zanzanaClient, reg)
 		}

--- a/pkg/services/authz/user_permissions_client.go
+++ b/pkg/services/authz/user_permissions_client.go
@@ -9,6 +9,8 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 )
 
+const userPermissionsDelegatedGrant = "authz.grafana.app/userpermissions:get"
+
 var _ accesscontrol.UserPermissionsClient = (*userPermissionsClient)(nil)
 
 type userPermissionsClient struct {


### PR DESCRIPTION
## What is this feature?

Routes OSS user-permission requests through AuthZ when the `authz.userPermissions` OpenFeature flag is enabled.

Positive organization IDs can use AuthZ. Grafana-global requests for org `0` remain on the local RBAC path because a hosted stack's tenant-scoped AuthZ namespace cannot represent global Grafana permissions. The local evaluation method also prevents the in-process AuthZ server from delegating back into itself.

`GetUserPermissions` is a temporary compatibility API that unblocks the multi-tenant frontend tenant service. A future API contract will supersede it.

## Stack

- Base: https://github.com/grafana/grafana/pull/130890

## How was this tested?

- `go test ./pkg/services/authz/... ./pkg/services/accesscontrol/...` — 1,807 tests passed in 29 packages
- Paired Enterprise-tagged suite — 2,163 tests passed in 31 packages
- Fresh OSS single-binary run with `authz.userPermissions` enabled:
  - the permissions endpoint returned the admin permissions
  - global admin user creation and deletion succeeded
- Standalone topology with OSS Grafana connected to Enterprise AuthZ, the local signer, and the hosted-Grafana MySQL tenant database:
  - a stack-scoped user loaded `dashboards:read` through remote AuthZ
  - global user creation and deletion still used local RBAC successfully
