### PR TITLE
AuthZ: Implement GetUserPermissions in the RBAC server

### DIFF
--- a/pkg/services/accesscontrol/accesscontrol.go
+++ b/pkg/services/accesscontrol/accesscontrol.go
@@ -88,7 +88,8 @@ type UserPermissionsEvaluator interface {
 }
 
 type Options struct {
-	ReloadCache bool
+	ReloadCache      bool
+	SkipZanzanaCache bool
 }
 
 type SearchOptions struct {

--- a/pkg/services/accesscontrol/accesscontrol.go
+++ b/pkg/services/accesscontrol/accesscontrol.go
@@ -83,6 +83,10 @@ type RoleRegistry interface {
 	RegisterFixedRoles(ctx context.Context) error
 }
 
+type UserPermissionsEvaluator interface {
+	GetLocalUserPermissions(ctx context.Context, user identity.Requester, options Options) ([]Permission, error)
+}
+
 type Options struct {
 	ReloadCache bool
 }

--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -181,7 +181,7 @@ func (s *Service) mergeZanzanaUserPermissions(ctx context.Context, user identity
 	if s.zanzanaResolver == nil {
 		return legacy
 	}
-	if !s.cfg.RBAC.PermissionCache || !user.HasUniqueId() {
+	if options.SkipZanzanaCache || !s.cfg.RBAC.PermissionCache || !user.HasUniqueId() {
 		return s.zanzanaResolver.MergeCurrentUser(ctx, user, legacy, s.log)
 	}
 

--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -173,6 +173,10 @@ func (s *Service) GetUserPermissions(ctx context.Context, user identity.Requeste
 	return s.mergeZanzanaUserPermissions(ctx, user, permissions, options), nil
 }
 
+func (s *Service) GetLocalUserPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
+	return s.GetUserPermissions(ctx, user, options)
+}
+
 func (s *Service) mergeZanzanaUserPermissions(ctx context.Context, user identity.Requester, legacy []accesscontrol.Permission, options accesscontrol.Options) []accesscontrol.Permission {
 	if s.zanzanaResolver == nil {
 		return legacy

--- a/pkg/services/accesscontrol/acimpl/zanzana_merge_test.go
+++ b/pkg/services/accesscontrol/acimpl/zanzana_merge_test.go
@@ -360,6 +360,33 @@ func TestService_GetUserPermissions_ReloadCacheBypassesZanzanaCache(t *testing.T
 	require.Greater(t, zClient.ListCallCount(), firstCalls, "ReloadCache should bypass Zanzana cache")
 }
 
+func TestService_GetUserPermissions_SkipZanzanaCacheDoesNotReadOrWriteCache(t *testing.T) {
+	store := &actest.FakeStore{}
+	zClient := &countingZanzanaClient{
+		fakeZanzanaClient: fakeZanzanaClient{
+			listResp: &authzv1.ListResponse{Items: []string{"cached-dash"}},
+		},
+	}
+	svc := setupServiceWithPermissionCache(t, store, zClient, &usertest.FakeUserService{}, true)
+	siu := testSignedInUser()
+
+	permissions, err := svc.GetUserPermissions(context.Background(), siu, accesscontrol.Options{})
+	require.NoError(t, err)
+	require.Contains(t, permissions, accesscontrol.Permission{Action: "dashboards:read", Scope: "dashboards:uid:cached-dash"})
+
+	zClient.listResp = &authzv1.ListResponse{Items: []string{"contextual-dash"}}
+	permissions, err = svc.GetUserPermissions(context.Background(), siu, accesscontrol.Options{SkipZanzanaCache: true})
+	require.NoError(t, err)
+	require.Contains(t, permissions, accesscontrol.Permission{Action: "dashboards:read", Scope: "dashboards:uid:contextual-dash"})
+	require.NotContains(t, permissions, accesscontrol.Permission{Action: "dashboards:read", Scope: "dashboards:uid:cached-dash"})
+
+	zClient.listResp = &authzv1.ListResponse{Items: []string{"unexpected-dash"}}
+	permissions, err = svc.GetUserPermissions(context.Background(), siu, accesscontrol.Options{})
+	require.NoError(t, err)
+	require.Contains(t, permissions, accesscontrol.Permission{Action: "dashboards:read", Scope: "dashboards:uid:cached-dash"})
+	require.NotContains(t, permissions, accesscontrol.Permission{Action: "dashboards:read", Scope: "dashboards:uid:contextual-dash"})
+}
+
 func TestService_GetUserPermissions_ClearUserPermissionCacheBypassesZanzanaCache(t *testing.T) {
 	store := &actest.FakeStore{}
 	zClient := &countingZanzanaClient{

--- a/pkg/services/accesscontrol/acimpl/zanzana_resolver.go
+++ b/pkg/services/accesscontrol/acimpl/zanzana_resolver.go
@@ -71,7 +71,10 @@ func (r *ZanzanaPermissionResolver) teamsForCurrentUser(usr identity.Requester) 
 // ResolveCurrentUserPermissions lists Zanzana-supported permissions for the signed-in identity.
 func (r *ZanzanaPermissionResolver) ResolveCurrentUserPermissions(ctx context.Context, usr identity.Requester) ([]ac.Permission, error) {
 	subject := usr.GetUID()
-	namespace := types.OrgNamespaceFormatter(usr.GetOrgID())
+	namespace := usr.GetNamespace()
+	if namespace == "" {
+		namespace = types.OrgNamespaceFormatter(usr.GetOrgID())
+	}
 	return r.listAllWithPrefix(ctx, namespace, subject, r.teamsForCurrentUser(usr), "", "")
 }
 

--- a/pkg/services/accesscontrol/acimpl/zanzana_resolver_test.go
+++ b/pkg/services/accesscontrol/acimpl/zanzana_resolver_test.go
@@ -55,6 +55,47 @@ func TestResolveCurrentUserPermissions_SkipsFailingAction(t *testing.T) {
 	require.Empty(t, permScopes(perms, "folders:create"))
 }
 
+func TestResolveCurrentUserPermissions_UsesRequesterNamespace(t *testing.T) {
+	client := &capturingZanzanaClient{fakeZanzanaClient: fakeZanzanaClient{
+		listResp: &authzv1.ListResponse{},
+	}}
+	r := NewZanzanaPermissionResolver(client, &usertest.FakeUserService{}, nil, false)
+	usr := &identity.StaticRequester{
+		Type:      claims.TypeUser,
+		UserID:    1,
+		UserUID:   "u1",
+		OrgID:     1,
+		Namespace: "stacks-123",
+	}
+
+	_, err := r.ResolveCurrentUserPermissions(context.Background(), usr)
+	require.NoError(t, err)
+	require.NotEmpty(t, client.listCalls)
+	for _, call := range client.listCalls {
+		require.Equal(t, "stacks-123", call.Namespace)
+	}
+}
+
+func TestResolveCurrentUserPermissions_DerivesNamespaceFromOrgWhenRequesterNamespaceIsEmpty(t *testing.T) {
+	client := &capturingZanzanaClient{fakeZanzanaClient: fakeZanzanaClient{
+		listResp: &authzv1.ListResponse{},
+	}}
+	r := NewZanzanaPermissionResolver(client, &usertest.FakeUserService{}, nil, false)
+	usr := &identity.StaticRequester{
+		Type:    claims.TypeUser,
+		UserID:  1,
+		UserUID: "u1",
+		OrgID:   2,
+	}
+
+	_, err := r.ResolveCurrentUserPermissions(context.Background(), usr)
+	require.NoError(t, err)
+	require.NotEmpty(t, client.listCalls)
+	for _, call := range client.listCalls {
+		require.Equal(t, claims.OrgNamespaceFormatter(int64(2)), call.Namespace)
+	}
+}
+
 // capturingZanzanaClient records every ListRequest it receives so tests can
 // assert on the group / resource / verb / subject sent to Zanzana.
 type capturingZanzanaClient struct {

--- a/pkg/services/authz/rbac.go
+++ b/pkg/services/authz/rbac.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/fullstorydev/grpchan/inprocgrpc"
+	grpcMiddleware "github.com/grpc-ecosystem/go-grpc-middleware/v2"
 	grpcAuth "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -142,7 +143,7 @@ func ProvideAuthZClient(
 		}
 		authInterceptor := grpcAuth.UnaryServerInterceptor(authenticate)
 		streamAuthInterceptor := grpcAuth.StreamServerInterceptor(authenticate)
-		channel.WithServerStreamInterceptor(streamAuthInterceptor)
+		channel.WithServerStreamInterceptor(inProcessStreamInterceptor(streamAuthInterceptor))
 
 		// Chain trace propagation with the auth interceptor.
 		// inprocgrpc.Channel wraps the server context with noValuesContext which
@@ -151,12 +152,7 @@ func ProvideAuthZClient(
 		// the original client context so that server-side spans are properly
 		// linked to the calling trace.
 		channel.WithServerUnaryInterceptor(func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
-			if clientCtx := inprocgrpc.ClientContext(ctx); clientCtx != nil {
-				if sc := trace.SpanContextFromContext(clientCtx); sc.IsValid() {
-					ctx = trace.ContextWithRemoteSpanContext(ctx, sc)
-				}
-			}
-			return authInterceptor(ctx, req, info, handler)
+			return authInterceptor(inProcessContextWithClientSpan(ctx), req, info, handler)
 		})
 		authzv1.RegisterAuthzServiceServer(channel, server)
 		rbacClient := authzlib.NewClient(
@@ -171,6 +167,23 @@ func ProvideAuthZClient(
 
 		return rbacClient, nil
 	}
+}
+
+func inProcessStreamInterceptor(next grpc.StreamServerInterceptor) grpc.StreamServerInterceptor {
+	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		wrapped := grpcMiddleware.WrapServerStream(stream)
+		wrapped.WrappedContext = inProcessContextWithClientSpan(stream.Context())
+		return next(srv, wrapped, info, handler)
+	}
+}
+
+func inProcessContextWithClientSpan(ctx context.Context) context.Context {
+	if clientCtx := inprocgrpc.ClientContext(ctx); clientCtx != nil {
+		if spanContext := trace.SpanContextFromContext(clientCtx); spanContext.IsValid() {
+			return trace.ContextWithRemoteSpanContext(ctx, spanContext)
+		}
+	}
+	return ctx
 }
 
 // ProvideStandaloneAuthZClient provides a standalone AuthZ client, without registering the AuthZ service.

--- a/pkg/services/authz/rbac.go
+++ b/pkg/services/authz/rbac.go
@@ -45,6 +45,8 @@ import (
 // AuthzServiceAudience is the audience for the authz service.
 const AuthzServiceAudience = "authzService"
 
+const userPermissionsDelegatedGrant = "authz.grafana.app/userpermissions:get"
+
 // ProvideAuthZClient provides an AuthZ client and creates the AuthZ service.
 func ProvideAuthZClient(
 	cfg *setting.Cfg,
@@ -87,6 +89,10 @@ func ProvideAuthZClient(
 		}
 		return rbacClient, nil
 	default:
+		userPermissionsEvaluator, ok := acService.(accesscontrol.UserPermissionsEvaluator)
+		if !ok {
+			return nil, errors.New("access control service does not support local user permission evaluation")
+		}
 		sql := legacysql.NewDatabaseProvider(db)
 		rbacSettings := rbac.Settings{
 			CacheTTL: authCfg.cacheTTL,
@@ -113,6 +119,9 @@ func ProvideAuthZClient(
 				store.NewStaticPermissionStore(acService),
 				store.NewSQLPermissionStore(sql, tracer),
 			),
+			userPermissionsEvaluator,
+			nil,
+			nil,
 			log.New("authz-grpc-server"),
 			tracer,
 			reg,
@@ -122,14 +131,18 @@ func ProvideAuthZClient(
 
 		channel := &inprocgrpc.Channel{}
 
-		authInterceptor := grpcAuth.UnaryServerInterceptor(func(ctx context.Context) (context.Context, error) {
+		authenticate := func(ctx context.Context) (context.Context, error) {
 			ctx = authlib.WithAuthInfo(ctx, authnlib.NewAccessTokenAuthInfo(authnlib.Claims[authnlib.AccessTokenClaims]{
 				Rest: authnlib.AccessTokenClaims{
-					Namespace: "*",
+					Namespace:   "*",
+					Permissions: []string{userPermissionsDelegatedGrant},
 				},
 			}))
 			return ctx, nil
-		})
+		}
+		authInterceptor := grpcAuth.UnaryServerInterceptor(authenticate)
+		streamAuthInterceptor := grpcAuth.StreamServerInterceptor(authenticate)
+		channel.WithServerStreamInterceptor(streamAuthInterceptor)
 
 		// Chain trace propagation with the auth interceptor.
 		// inprocgrpc.Channel wraps the server context with noValuesContext which
@@ -296,6 +309,8 @@ func RegisterRBACAuthZService(
 	tracer tracing.Tracer,
 	reg prometheus.Registerer,
 	cache cache.Cache,
+	actionResolver accesscontrol.ActionResolver,
+	userPermissionsResolver rbac.UserPermissionsResolver,
 	exchangeClient authnlib.TokenExchanger,
 	cfg RBACServerSettings,
 ) {
@@ -328,6 +343,9 @@ func RegisterRBACAuthZService(
 		folderStore,
 		legacy.NewLegacySQLStores(db),
 		store.NewSQLPermissionStore(db, tracer),
+		nil,
+		userPermissionsResolver,
+		actionResolver,
 		log.New("authz-grpc-server"),
 		tracer,
 		reg,

--- a/pkg/services/authz/rbac/service.go
+++ b/pkg/services/authz/rbac/service.go
@@ -19,6 +19,7 @@ import (
 	"github.com/grafana/authlib/cache"
 	"github.com/grafana/authlib/types"
 
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -38,11 +39,14 @@ const (
 type Service struct {
 	authzv1.UnimplementedAuthzServiceServer
 
-	store           store.Store
-	folderStore     store.FolderStore
-	permissionStore store.PermissionStore
-	identityStore   legacy.LegacyIdentityStore
-	settings        Settings
+	store                    store.Store
+	folderStore              store.FolderStore
+	permissionStore          store.PermissionStore
+	userPermissionsEvaluator accesscontrol.UserPermissionsEvaluator
+	userPermissionsResolver  UserPermissionsResolver
+	actionResolver           accesscontrol.ActionResolver
+	identityStore            legacy.LegacyIdentityStore
+	settings                 Settings
 
 	mapper MapperRegistry
 
@@ -63,6 +67,10 @@ type Service struct {
 	teamIDCache     cacheWrap[map[int64]string]
 }
 
+type UserPermissionsResolver interface {
+	ResolveCurrentUserPermissions(ctx context.Context, user identity.Requester) ([]accesscontrol.Permission, error)
+}
+
 type Settings struct {
 	AnonOrgRole string
 	// CacheTTL is the time to live for the permission cache entries.
@@ -78,6 +86,9 @@ func NewService(
 	folderStore store.FolderStore,
 	identityStore legacy.LegacyIdentityStore,
 	permissionStore store.PermissionStore,
+	userPermissionsEvaluator accesscontrol.UserPermissionsEvaluator,
+	userPermissionsResolver UserPermissionsResolver,
+	actionResolver accesscontrol.ActionResolver,
 	logger log.Logger,
 	tracer tracing.Tracer,
 	reg prometheus.Registerer,
@@ -88,23 +99,26 @@ func NewService(
 		settings.AnonOrgRole = "Viewer"
 	}
 	return &Service{
-		store:           store.NewStore(sql, tracer),
-		folderStore:     folderStore,
-		permissionStore: permissionStore,
-		identityStore:   identityStore,
-		settings:        settings,
-		logger:          logger,
-		tracer:          tracer,
-		metrics:         newMetrics(reg),
-		mapper:          NewMapperRegistry(),
-		idCache:         newCacheWrap[store.UserIdentifiers](cache, logger, tracer, longCacheTTL),
-		permCache:       newCacheWrap[map[string]bool](cache, logger, tracer, settings.CacheTTL),
-		permDenialCache: newCacheWrap[bool](cache, logger, tracer, settings.CacheTTL),
-		userTeamCache:   newCacheWrap[[]int64](cache, logger, tracer, settings.CacheTTL),
-		basicRoleCache:  newCacheWrap[store.BasicRole](cache, logger, tracer, settings.CacheTTL),
-		folderCache:     newCacheWrap[folderTree](cache, logger, tracer, settings.CacheTTL, settings.LocalFolderCacheTTL),
-		teamIDCache:     newCacheWrap[map[int64]string](cache, logger, tracer, longCacheTTL),
-		sf:              new(singleflight.Group),
+		store:                    store.NewStore(sql, tracer),
+		folderStore:              folderStore,
+		permissionStore:          permissionStore,
+		actionResolver:           actionResolver,
+		identityStore:            identityStore,
+		settings:                 settings,
+		userPermissionsEvaluator: userPermissionsEvaluator,
+		userPermissionsResolver:  userPermissionsResolver,
+		logger:                   logger,
+		tracer:                   tracer,
+		metrics:                  newMetrics(reg),
+		mapper:                   NewMapperRegistry(),
+		idCache:                  newCacheWrap[store.UserIdentifiers](cache, logger, tracer, longCacheTTL),
+		permCache:                newCacheWrap[map[string]bool](cache, logger, tracer, settings.CacheTTL),
+		permDenialCache:          newCacheWrap[bool](cache, logger, tracer, settings.CacheTTL),
+		userTeamCache:            newCacheWrap[[]int64](cache, logger, tracer, settings.CacheTTL),
+		basicRoleCache:           newCacheWrap[store.BasicRole](cache, logger, tracer, settings.CacheTTL),
+		folderCache:              newCacheWrap[folderTree](cache, logger, tracer, settings.CacheTTL, settings.LocalFolderCacheTTL),
+		teamIDCache:              newCacheWrap[map[int64]string](cache, logger, tracer, longCacheTTL),
+		sf:                       new(singleflight.Group),
 	}
 }
 
@@ -807,14 +821,22 @@ func (s *Service) getRendererPermissions(ctx context.Context, action string) (ma
 }
 
 func (s *Service) GetUserIdentifiers(ctx context.Context, ns types.NamespaceInfo, userUID string) (*store.UserIdentifiers, error) {
+	return s.getUserIdentifiers(ctx, ns, userUID, false)
+}
+
+func (s *Service) getUserIdentifiers(ctx context.Context, ns types.NamespaceInfo, userUID string, skipCache bool) (*store.UserIdentifiers, error) {
 	uidCacheKey := userIdentifierCacheKey(ns.Value, userUID)
-	if cached, ok := s.idCache.Get(ctx, uidCacheKey); ok {
-		return &cached, nil
+	if !skipCache {
+		if cached, ok := s.idCache.Get(ctx, uidCacheKey); ok {
+			return &cached, nil
+		}
 	}
 
 	idCacheKey := userIdentifierCacheKeyById(ns.Value, userUID)
-	if cached, ok := s.idCache.Get(ctx, idCacheKey); ok {
-		return &cached, nil
+	if !skipCache {
+		if cached, ok := s.idCache.Get(ctx, idCacheKey); ok {
+			return &cached, nil
+		}
 	}
 
 	var userIDQuery store.UserIdentifierQuery
@@ -836,13 +858,19 @@ func (s *Service) GetUserIdentifiers(ctx context.Context, ns types.NamespaceInfo
 }
 
 func (s *Service) getUserTeams(ctx context.Context, ns types.NamespaceInfo, userIdentifiers *store.UserIdentifiers) ([]int64, error) {
+	return s.getUserTeamsWithCache(ctx, ns, userIdentifiers, false)
+}
+
+func (s *Service) getUserTeamsWithCache(ctx context.Context, ns types.NamespaceInfo, userIdentifiers *store.UserIdentifiers, skipCache bool) ([]int64, error) {
 	ctx, span := s.tracer.Start(ctx, "authz_direct_db.service.getUserTeams")
 	defer span.End()
 
 	teamIDs := make([]int64, 0, 50)
 	teamsCacheKey := userTeamCacheKey(ns.Value, userIdentifiers.UID)
-	if cached, ok := s.userTeamCache.Get(ctx, teamsCacheKey); ok {
-		return cached, nil
+	if !skipCache {
+		if cached, ok := s.userTeamCache.Get(ctx, teamsCacheKey); ok {
+			return cached, nil
+		}
 	}
 
 	teamQuery := legacy.ListUserTeamsQuery{
@@ -870,12 +898,18 @@ func (s *Service) getUserTeams(ctx context.Context, ns types.NamespaceInfo, user
 }
 
 func (s *Service) getUserBasicRole(ctx context.Context, ns types.NamespaceInfo, userIdentifiers *store.UserIdentifiers) (store.BasicRole, error) {
+	return s.getUserBasicRoleWithCache(ctx, ns, userIdentifiers, false)
+}
+
+func (s *Service) getUserBasicRoleWithCache(ctx context.Context, ns types.NamespaceInfo, userIdentifiers *store.UserIdentifiers, skipCache bool) (store.BasicRole, error) {
 	ctx, span := s.tracer.Start(ctx, "authz_direct_db.service.getUserBasicRole")
 	defer span.End()
 
 	basicRoleKey := userBasicRoleCacheKey(ns.Value, userIdentifiers.UID)
-	if cached, ok := s.basicRoleCache.Get(ctx, basicRoleKey); ok {
-		return cached, nil
+	if !skipCache {
+		if cached, ok := s.basicRoleCache.Get(ctx, basicRoleKey); ok {
+			return cached, nil
+		}
 	}
 
 	basicRole, err := s.store.GetBasicRoles(ctx, ns, store.BasicRoleQuery{UserID: userIdentifiers.ID})

--- a/pkg/services/authz/rbac/user_permissions.go
+++ b/pkg/services/authz/rbac/user_permissions.go
@@ -135,7 +135,10 @@ func (s *Service) getAllIdentityPermissions(ctx context.Context, ns types.Namesp
 			ExternalGroups:   contextualTeams,
 		}
 		if s.userPermissionsEvaluator != nil {
-			permissions, err := s.userPermissionsEvaluator.GetLocalUserPermissions(ctx, requester, accesscontrol.Options{ReloadCache: skipCache})
+			permissions, err := s.userPermissionsEvaluator.GetLocalUserPermissions(ctx, requester, accesscontrol.Options{
+				ReloadCache:      skipCache,
+				SkipZanzanaCache: true,
+			})
 			return permissions, true, err
 		}
 		permissions, err := s.permissionStore.GetUserPermissions(ctx, ns, store.PermissionsQuery{
@@ -159,7 +162,10 @@ func (s *Service) getAllIdentityPermissions(ctx context.Context, ns types.Namesp
 			ExternalGroups: contextualTeams,
 		}
 		if s.userPermissionsEvaluator != nil {
-			permissions, err := s.userPermissionsEvaluator.GetLocalUserPermissions(ctx, requester, accesscontrol.Options{ReloadCache: skipCache})
+			permissions, err := s.userPermissionsEvaluator.GetLocalUserPermissions(ctx, requester, accesscontrol.Options{
+				ReloadCache:      skipCache,
+				SkipZanzanaCache: true,
+			})
 			return permissions, true, err
 		}
 		permissions, err := s.permissionStore.GetUserPermissions(ctx, ns, store.PermissionsQuery{Role: s.settings.AnonOrgRole})

--- a/pkg/services/authz/rbac/user_permissions.go
+++ b/pkg/services/authz/rbac/user_permissions.go
@@ -1,0 +1,181 @@
+package rbac
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/apiserver/pkg/endpoints/request"
+
+	authzlib "github.com/grafana/authlib/authz"
+	authzv1 "github.com/grafana/authlib/authz/proto/v1"
+	"github.com/grafana/authlib/types"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/authz/rbac/store"
+	"github.com/grafana/grafana/pkg/services/folder"
+	"github.com/grafana/grafana/pkg/services/user"
+)
+
+const userPermissionsChunkSize = 1000
+
+func (s *Service) GetUserPermissions(req *authzv1.GetUserPermissionsRequest, stream authzv1.AuthzService_GetUserPermissionsServer) error {
+	ctx, span := s.tracer.Start(stream.Context(), "authz_direct_db.service.GetUserPermissions")
+	defer span.End()
+
+	ns, err := validateNamespace(ctx, req.GetNamespace())
+	if err != nil {
+		return err
+	}
+	authInfo, ok := types.AuthInfoFrom(ctx)
+	if !ok {
+		return status.Error(codes.Internal, "could not get auth info from context")
+	}
+	if !authzlib.CheckServicePermissions(authInfo, "authz.grafana.app", "userpermissions", "get").Allowed {
+		return status.Error(codes.PermissionDenied, "user permissions request denied")
+	}
+
+	userUID, identityType, err := s.validateSubject(ctx, req.GetSubject())
+	if err != nil {
+		return err
+	}
+	ctx = request.WithNamespace(ctx, ns.Value)
+
+	permissions, evaluated, err := s.getAllIdentityPermissions(ctx, ns, identityType, userUID, req.GetTeams(), req.GetOptions().GetSkipcache())
+	if err != nil {
+		return err
+	}
+	if !evaluated {
+		if s.actionResolver != nil {
+			permissions = s.actionResolver.ExpandActionSets(permissions)
+		}
+		permissions = append(permissions, accesscontrol.Permission{
+			Action: folder.ActionFoldersRead,
+			Scope:  folder.ScopeFoldersProvider.GetResourceScopeUID(folder.SharedWithMeFolderUID),
+		})
+	}
+	permissions = deduplicateUserPermissions(permissions)
+
+	protoPermissions := make([]*authzv1.UserPermission, 0, len(permissions))
+	for _, permission := range permissions {
+		protoPermissions = append(protoPermissions, &authzv1.UserPermission{
+			Action: permission.Action,
+			Scope:  permission.Scope,
+		})
+	}
+
+	for start := 0; start < len(protoPermissions); start += userPermissionsChunkSize {
+		end := min(start+userPermissionsChunkSize, len(protoPermissions))
+		if err := stream.Send(&authzv1.GetUserPermissionsResponse{
+			Permissions: protoPermissions[start:end],
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Service) mergeZanzanaUserPermissions(ctx context.Context, requester identity.Requester, permissions []accesscontrol.Permission) []accesscontrol.Permission {
+	if s.userPermissionsResolver == nil {
+		return permissions
+	}
+	zanzanaPermissions, err := s.userPermissionsResolver.ResolveCurrentUserPermissions(ctx, requester)
+	if err != nil {
+		s.logger.Warn("could not get zanzana user permissions, using legacy only", "error", err)
+		return permissions
+	}
+	return append(permissions, zanzanaPermissions...)
+}
+
+func deduplicateUserPermissions(permissions []accesscontrol.Permission) []accesscontrol.Permission {
+	type key struct {
+		action string
+		scope  string
+	}
+
+	seen := make(map[key]struct{}, len(permissions))
+	result := make([]accesscontrol.Permission, 0, len(permissions))
+	for _, permission := range permissions {
+		permissionKey := key{action: permission.Action, scope: permission.Scope}
+		if _, ok := seen[permissionKey]; ok {
+			continue
+		}
+		seen[permissionKey] = struct{}{}
+		result = append(result, permission)
+	}
+	return result
+}
+
+func (s *Service) getAllIdentityPermissions(ctx context.Context, ns types.NamespaceInfo, identityType types.IdentityType, userUID string, contextualTeams []string, skipCache bool) ([]accesscontrol.Permission, bool, error) {
+	switch identityType {
+	case types.TypeUser, types.TypeServiceAccount:
+		identifiers, err := s.getUserIdentifiers(ctx, ns, userUID, skipCache)
+		if err != nil {
+			return nil, false, err
+		}
+		basicRole, err := s.getUserBasicRoleWithCache(ctx, ns, identifiers, skipCache)
+		if err != nil {
+			return nil, false, err
+		}
+		teamIDs, err := s.getUserTeamsWithCache(ctx, ns, identifiers, skipCache)
+		if err != nil {
+			return nil, false, err
+		}
+		requester := &user.SignedInUser{
+			UserID:           identifiers.ID,
+			UserUID:          identifiers.UID,
+			OrgID:            ns.OrgID,
+			OrgRole:          identity.RoleType(basicRole.Role),
+			Namespace:        ns.Value,
+			IsGrafanaAdmin:   basicRole.IsAdmin,
+			IsServiceAccount: identityType == types.TypeServiceAccount,
+			TeamIDs:          teamIDs,
+			TeamUIDs:         contextualTeams,
+			ExternalGroups:   contextualTeams,
+		}
+		if s.userPermissionsEvaluator != nil {
+			permissions, err := s.userPermissionsEvaluator.GetLocalUserPermissions(ctx, requester, accesscontrol.Options{ReloadCache: skipCache})
+			return permissions, true, err
+		}
+		permissions, err := s.permissionStore.GetUserPermissions(ctx, ns, store.PermissionsQuery{
+			UserID:        identifiers.ID,
+			TeamIDs:       teamIDs,
+			Role:          basicRole.Role,
+			IsServerAdmin: basicRole.IsAdmin,
+		})
+		if err != nil {
+			return nil, false, err
+		}
+		permissions = s.mergeZanzanaUserPermissions(ctx, requester, permissions)
+		return permissions, false, nil
+	case types.TypeAnonymous:
+		requester := &user.SignedInUser{
+			OrgID:          ns.OrgID,
+			OrgRole:        identity.RoleType(s.settings.AnonOrgRole),
+			Namespace:      ns.Value,
+			IsAnonymous:    true,
+			TeamUIDs:       contextualTeams,
+			ExternalGroups: contextualTeams,
+		}
+		if s.userPermissionsEvaluator != nil {
+			permissions, err := s.userPermissionsEvaluator.GetLocalUserPermissions(ctx, requester, accesscontrol.Options{ReloadCache: skipCache})
+			return permissions, true, err
+		}
+		permissions, err := s.permissionStore.GetUserPermissions(ctx, ns, store.PermissionsQuery{Role: s.settings.AnonOrgRole})
+		if err != nil {
+			return nil, false, err
+		}
+		return s.mergeZanzanaUserPermissions(ctx, requester, permissions), false, nil
+	case types.TypeRenderService:
+		return []accesscontrol.Permission{
+			{Action: "dashboards:read", Scope: "*"},
+			{Action: "folders:read", Scope: "*"},
+			{Action: "datasources:read", Scope: "*"},
+			{Action: "datasources:query", Scope: "*"},
+			{Action: "plugins.metas:read", Scope: "*"},
+		}, false, nil
+	default:
+		return nil, false, status.Error(codes.PermissionDenied, "unsupported identity type")
+	}
+}

--- a/pkg/services/authz/rbac/user_permissions_test.go
+++ b/pkg/services/authz/rbac/user_permissions_test.go
@@ -1,0 +1,467 @@
+package rbac
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	"github.com/grafana/authlib/authn"
+	authzv1 "github.com/grafana/authlib/authz/proto/v1"
+	"github.com/grafana/authlib/types"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/authz/rbac/store"
+)
+
+func TestService_GetUserPermissionsStreamsRBACSnapshot(t *testing.T) {
+	service := setupService()
+	service.store = &fakeStore{
+		userID:    &store.UserIdentifiers{UID: "test-uid", ID: 42},
+		basicRole: &store.BasicRole{Role: "Editor", IsAdmin: true},
+	}
+	service.identityStore = &fakeIdentityStore{userTeams: []int64{7, 9}}
+	permissionStore := &snapshotPermissionStore{permissions: []accesscontrol.Permission{
+		{Action: "dashboards:read", Scope: "dashboards:*"},
+		{Action: "folders:write", Scope: "folders:uid:team"},
+	}}
+	service.permissionStore = permissionStore
+
+	caller := authn.NewAccessTokenAuthInfo(authn.Claims[authn.AccessTokenClaims]{
+		Claims: jwt.Claims{Subject: types.NewTypeID(types.TypeAccessPolicy, "grafana")},
+		Rest: authn.AccessTokenClaims{
+			Namespace:   "org-12",
+			Permissions: []string{"authz.grafana.app/userpermissions:get"},
+		},
+	})
+	stream := &collectUserPermissionsStream{ctx: types.WithAuthInfo(t.Context(), caller)}
+
+	err := service.GetUserPermissions(&authzv1.GetUserPermissionsRequest{
+		Namespace: "org-12",
+		Subject:   "user:test-uid",
+		Options:   &authzv1.GetUserPermissionsOptions{Skipcache: true},
+	}, stream)
+	require.NoError(t, err)
+	require.Len(t, stream.responses, 1)
+	require.ElementsMatch(t, []*authzv1.UserPermission{
+		{Action: "dashboards:read", Scope: "dashboards:*"},
+		{Action: "folders:write", Scope: "folders:uid:team"},
+		{Action: "folders:read", Scope: "folders:uid:sharedwithme"},
+	}, stream.responses[0].Permissions)
+	require.Equal(t, store.PermissionsQuery{
+		UserID:        42,
+		TeamIDs:       []int64{7, 9},
+		Role:          "Editor",
+		IsServerAdmin: true,
+	}, permissionStore.query)
+}
+
+func TestService_GetUserPermissionsUsesLocalEvaluator(t *testing.T) {
+	service := setupService()
+	service.store = &fakeStore{
+		userID:    &store.UserIdentifiers{UID: "test-uid", ID: 42},
+		basicRole: &store.BasicRole{Role: "Editor", IsAdmin: true},
+	}
+	service.identityStore = &fakeIdentityStore{userTeams: []int64{7, 9}}
+	service.permissionStore = &snapshotPermissionStore{permissions: []accesscontrol.Permission{{
+		Action: "unexpected:read",
+		Scope:  "unexpected:*",
+	}}}
+	evaluator := &recordingUserPermissionsEvaluator{permissions: []accesscontrol.Permission{
+		{Action: "dashboards:read", Scope: "dashboards:*"},
+		{Action: "dashboards:read", Scope: "dashboards:*"},
+	}}
+	service.userPermissionsEvaluator = evaluator
+
+	caller := authn.NewAccessTokenAuthInfo(authn.Claims[authn.AccessTokenClaims]{
+		Claims: jwt.Claims{Subject: types.NewTypeID(types.TypeAccessPolicy, "grafana")},
+		Rest: authn.AccessTokenClaims{
+			Namespace:   "org-12",
+			Permissions: []string{"authz.grafana.app/userpermissions:get"},
+		},
+	})
+	stream := &collectUserPermissionsStream{ctx: types.WithAuthInfo(t.Context(), caller)}
+
+	err := service.GetUserPermissions(&authzv1.GetUserPermissionsRequest{
+		Namespace: "org-12",
+		Subject:   "user:test-uid",
+		Options:   &authzv1.GetUserPermissionsOptions{Skipcache: true},
+	}, stream)
+
+	require.NoError(t, err)
+	require.Len(t, stream.responses, 1)
+	require.Equal(t, []*authzv1.UserPermission{{Action: "dashboards:read", Scope: "dashboards:*"}}, stream.responses[0].Permissions)
+	userID, err := evaluator.user.GetInternalID()
+	require.NoError(t, err)
+	require.Equal(t, int64(42), userID)
+	require.Equal(t, "user:test-uid", evaluator.user.GetUID())
+	require.Equal(t, int64(12), evaluator.user.GetOrgID())
+	require.Equal(t, identity.RoleEditor, evaluator.user.GetOrgRole())
+	require.True(t, evaluator.user.GetIsGrafanaAdmin())
+	require.Equal(t, "org-12", evaluator.user.GetNamespace())
+	require.Equal(t, []int64{7, 9}, evaluator.teams)
+	require.Equal(t, accesscontrol.Options{ReloadCache: true}, evaluator.options)
+}
+
+func TestService_GetUserPermissionsMergesZanzanaPermissions(t *testing.T) {
+	service := setupService()
+	service.store = &fakeStore{
+		userID:    &store.UserIdentifiers{UID: "test-uid", ID: 42},
+		basicRole: &store.BasicRole{Role: "Viewer"},
+	}
+	service.identityStore = &fakeIdentityStore{userTeams: []int64{7}}
+	service.permissionStore = &snapshotPermissionStore{permissions: []accesscontrol.Permission{
+		{Action: "dashboards:read", Scope: "dashboards:*"},
+	}}
+	resolver := &recordingUserPermissionsResolver{permissions: []accesscontrol.Permission{
+		{Action: "dashboards:read", Scope: "dashboards:*"},
+		{Action: "folders:write", Scope: "folders:uid:zanzana"},
+	}}
+	service.userPermissionsResolver = resolver
+
+	caller := authn.NewAccessTokenAuthInfo(authn.Claims[authn.AccessTokenClaims]{
+		Claims: jwt.Claims{Subject: types.NewTypeID(types.TypeAccessPolicy, "grafana")},
+		Rest: authn.AccessTokenClaims{
+			Namespace:   "org-12",
+			Permissions: []string{"authz.grafana.app/userpermissions:get"},
+		},
+	})
+	stream := &collectUserPermissionsStream{ctx: types.WithAuthInfo(t.Context(), caller)}
+
+	err := service.GetUserPermissions(&authzv1.GetUserPermissionsRequest{
+		Namespace: "org-12",
+		Subject:   "user:test-uid",
+		Teams:     []string{"team-uid"},
+	}, stream)
+
+	require.NoError(t, err)
+	require.Len(t, stream.responses, 1)
+	require.ElementsMatch(t, []*authzv1.UserPermission{
+		{Action: "dashboards:read", Scope: "dashboards:*"},
+		{Action: "folders:write", Scope: "folders:uid:zanzana"},
+		{Action: "folders:read", Scope: "folders:uid:sharedwithme"},
+	}, stream.responses[0].Permissions)
+	require.Equal(t, []string{"team-uid"}, resolver.user.GetGroups())
+}
+
+func TestService_GetUserPermissionsMergesZanzanaPermissionsForAnonymous(t *testing.T) {
+	service := setupService()
+	service.permissionStore = &snapshotPermissionStore{permissions: []accesscontrol.Permission{
+		{Action: "dashboards:read", Scope: "dashboards:*"},
+	}}
+	service.userPermissionsResolver = &recordingUserPermissionsResolver{permissions: []accesscontrol.Permission{
+		{Action: "folders:write", Scope: "folders:uid:zanzana"},
+	}}
+
+	caller := authn.NewAccessTokenAuthInfo(authn.Claims[authn.AccessTokenClaims]{
+		Claims: jwt.Claims{Subject: types.NewTypeID(types.TypeAccessPolicy, "grafana")},
+		Rest: authn.AccessTokenClaims{
+			Namespace:   "org-12",
+			Permissions: []string{"authz.grafana.app/userpermissions:get"},
+		},
+	})
+	stream := &collectUserPermissionsStream{ctx: types.WithAuthInfo(t.Context(), caller)}
+
+	err := service.GetUserPermissions(&authzv1.GetUserPermissionsRequest{
+		Namespace: "org-12",
+		Subject:   "anonymous:0",
+	}, stream)
+
+	require.NoError(t, err)
+	require.Len(t, stream.responses, 1)
+	require.ElementsMatch(t, []*authzv1.UserPermission{
+		{Action: "dashboards:read", Scope: "dashboards:*"},
+		{Action: "folders:write", Scope: "folders:uid:zanzana"},
+		{Action: "folders:read", Scope: "folders:uid:sharedwithme"},
+	}, stream.responses[0].Permissions)
+}
+
+func TestService_GetUserPermissionsUsesRBACPermissionsWhenZanzanaFails(t *testing.T) {
+	service := setupService()
+	service.store = &fakeStore{
+		userID:    &store.UserIdentifiers{UID: "test-uid", ID: 42},
+		basicRole: &store.BasicRole{Role: "Viewer"},
+	}
+	service.permissionStore = &snapshotPermissionStore{permissions: []accesscontrol.Permission{
+		{Action: "dashboards:read", Scope: "dashboards:*"},
+	}}
+	service.userPermissionsResolver = &recordingUserPermissionsResolver{err: fmt.Errorf("zanzana unavailable")}
+
+	caller := authn.NewAccessTokenAuthInfo(authn.Claims[authn.AccessTokenClaims]{
+		Claims: jwt.Claims{Subject: types.NewTypeID(types.TypeAccessPolicy, "grafana")},
+		Rest: authn.AccessTokenClaims{
+			Namespace:   "org-12",
+			Permissions: []string{"authz.grafana.app/userpermissions:get"},
+		},
+	})
+	stream := &collectUserPermissionsStream{ctx: types.WithAuthInfo(t.Context(), caller)}
+
+	err := service.GetUserPermissions(&authzv1.GetUserPermissionsRequest{
+		Namespace: "org-12",
+		Subject:   "user:test-uid",
+	}, stream)
+
+	require.NoError(t, err)
+	require.Len(t, stream.responses, 1)
+	require.ElementsMatch(t, []*authzv1.UserPermission{
+		{Action: "dashboards:read", Scope: "dashboards:*"},
+		{Action: "folders:read", Scope: "folders:uid:sharedwithme"},
+	}, stream.responses[0].Permissions)
+}
+
+func TestService_GetUserPermissionsDeduplicatesPermissions(t *testing.T) {
+	service := setupService()
+	service.store = &fakeStore{
+		userID:    &store.UserIdentifiers{UID: "test-uid", ID: 42},
+		basicRole: &store.BasicRole{Role: "Viewer"},
+	}
+	service.permissionStore = &snapshotPermissionStore{permissions: []accesscontrol.Permission{
+		{Action: "dashboards:read", Scope: "dashboards:*"},
+		{Action: "dashboards:read", Scope: "dashboards:*"},
+		{Action: "dashboards:read", Scope: "dashboards:uid:one"},
+	}}
+
+	caller := authn.NewAccessTokenAuthInfo(authn.Claims[authn.AccessTokenClaims]{
+		Claims: jwt.Claims{Subject: types.NewTypeID(types.TypeAccessPolicy, "grafana")},
+		Rest: authn.AccessTokenClaims{
+			Namespace:   "org-12",
+			Permissions: []string{"authz.grafana.app/userpermissions:get"},
+		},
+	})
+	stream := &collectUserPermissionsStream{ctx: types.WithAuthInfo(t.Context(), caller)}
+
+	err := service.GetUserPermissions(&authzv1.GetUserPermissionsRequest{
+		Namespace: "org-12",
+		Subject:   "user:test-uid",
+	}, stream)
+
+	require.NoError(t, err)
+	require.Len(t, stream.responses, 1)
+	require.ElementsMatch(t, []*authzv1.UserPermission{
+		{Action: "dashboards:read", Scope: "dashboards:*"},
+		{Action: "dashboards:read", Scope: "dashboards:uid:one"},
+		{Action: "folders:read", Scope: "folders:uid:sharedwithme"},
+	}, stream.responses[0].Permissions)
+}
+
+func TestService_GetUserPermissionsExpandsActionSets(t *testing.T) {
+	service := setupService()
+	service.store = &fakeStore{
+		userID:    &store.UserIdentifiers{UID: "test-uid", ID: 42},
+		basicRole: &store.BasicRole{Role: "Viewer"},
+	}
+	service.permissionStore = &snapshotPermissionStore{permissions: []accesscontrol.Permission{{
+		Action: "dashboards:view",
+		Scope:  "dashboards:*",
+	}}}
+	service.actionResolver = expandingActionResolver{}
+
+	caller := authn.NewAccessTokenAuthInfo(authn.Claims[authn.AccessTokenClaims]{
+		Claims: jwt.Claims{Subject: types.NewTypeID(types.TypeAccessPolicy, "grafana")},
+		Rest: authn.AccessTokenClaims{
+			Namespace:   "org-12",
+			Permissions: []string{"authz.grafana.app/userpermissions:get"},
+		},
+	})
+	stream := &collectUserPermissionsStream{ctx: types.WithAuthInfo(t.Context(), caller)}
+
+	err := service.GetUserPermissions(&authzv1.GetUserPermissionsRequest{
+		Namespace: "org-12",
+		Subject:   "user:test-uid",
+	}, stream)
+	require.NoError(t, err)
+	require.Len(t, stream.responses, 1)
+	require.Contains(t, stream.responses[0].Permissions, &authzv1.UserPermission{Action: "dashboards:read", Scope: "dashboards:*"})
+	require.NotContains(t, stream.responses[0].Permissions, &authzv1.UserPermission{Action: "dashboards:view", Scope: "dashboards:*"})
+}
+
+func TestService_GetUserPermissionsSkipCacheBypassesIdentityCaches(t *testing.T) {
+	service := setupService()
+	service.store = &fakeStore{
+		userID:    &store.UserIdentifiers{UID: "test-uid", ID: 42},
+		basicRole: &store.BasicRole{Role: "Editor"},
+	}
+	service.identityStore = &fakeIdentityStore{userTeams: []int64{7}}
+	permissionStore := &snapshotPermissionStore{}
+	service.permissionStore = permissionStore
+
+	ctx := t.Context()
+	service.idCache.Set(ctx, userIdentifierCacheKey("org-12", "test-uid"), store.UserIdentifiers{UID: "test-uid", ID: 1})
+	service.basicRoleCache.Set(ctx, userBasicRoleCacheKey("org-12", "test-uid"), store.BasicRole{Role: "Viewer"})
+	service.userTeamCache.Set(ctx, userTeamCacheKey("org-12", "test-uid"), []int64{1})
+	caller := authn.NewAccessTokenAuthInfo(authn.Claims[authn.AccessTokenClaims]{
+		Claims: jwt.Claims{Subject: types.NewTypeID(types.TypeAccessPolicy, "grafana")},
+		Rest: authn.AccessTokenClaims{
+			Namespace:   "org-12",
+			Permissions: []string{"authz.grafana.app/userpermissions:get"},
+		},
+	})
+	stream := &collectUserPermissionsStream{ctx: types.WithAuthInfo(ctx, caller)}
+
+	err := service.GetUserPermissions(&authzv1.GetUserPermissionsRequest{
+		Namespace: "org-12",
+		Subject:   "user:test-uid",
+		Options:   &authzv1.GetUserPermissionsOptions{Skipcache: true},
+	}, stream)
+
+	require.NoError(t, err)
+	require.Equal(t, store.PermissionsQuery{
+		UserID:  42,
+		TeamIDs: []int64{7},
+		Role:    "Editor",
+	}, permissionStore.query)
+}
+
+func TestService_GetUserPermissionsUsesServerIdentityCachesIndependently(t *testing.T) {
+	service := setupService()
+	service.store = &fakeStore{
+		userID:    &store.UserIdentifiers{UID: "test-uid", ID: 42},
+		basicRole: &store.BasicRole{Role: "Editor"},
+	}
+	service.identityStore = &fakeIdentityStore{userTeams: []int64{7}}
+	permissionStore := &snapshotPermissionStore{}
+	service.permissionStore = permissionStore
+
+	ctx := t.Context()
+	service.idCache.Set(ctx, userIdentifierCacheKey("org-12", "test-uid"), store.UserIdentifiers{UID: "test-uid", ID: 1})
+	service.basicRoleCache.Set(ctx, userBasicRoleCacheKey("org-12", "test-uid"), store.BasicRole{Role: "Viewer"})
+	service.userTeamCache.Set(ctx, userTeamCacheKey("org-12", "test-uid"), []int64{1})
+	caller := authn.NewAccessTokenAuthInfo(authn.Claims[authn.AccessTokenClaims]{
+		Claims: jwt.Claims{Subject: types.NewTypeID(types.TypeAccessPolicy, "grafana")},
+		Rest: authn.AccessTokenClaims{
+			Namespace:   "org-12",
+			Permissions: []string{"authz.grafana.app/userpermissions:get"},
+		},
+	})
+	stream := &collectUserPermissionsStream{ctx: types.WithAuthInfo(ctx, caller)}
+
+	err := service.GetUserPermissions(&authzv1.GetUserPermissionsRequest{
+		Namespace: "org-12",
+		Subject:   "user:test-uid",
+	}, stream)
+
+	require.NoError(t, err)
+	require.Equal(t, store.PermissionsQuery{
+		UserID:  1,
+		TeamIDs: []int64{1},
+		Role:    "Viewer",
+	}, permissionStore.query)
+}
+
+func TestService_GetUserPermissionsStreamsLargeSnapshotsInChunks(t *testing.T) {
+	service := setupService()
+	service.store = &fakeStore{
+		userID:    &store.UserIdentifiers{UID: "test-uid", ID: 42},
+		basicRole: &store.BasicRole{Role: "Viewer"},
+	}
+	permissions := make([]accesscontrol.Permission, 1000)
+	for i := range permissions {
+		permissions[i] = accesscontrol.Permission{Action: "dashboards:read", Scope: fmt.Sprintf("dashboards:uid:%d", i)}
+	}
+	service.permissionStore = &snapshotPermissionStore{permissions: permissions}
+	caller := authn.NewAccessTokenAuthInfo(authn.Claims[authn.AccessTokenClaims]{
+		Claims: jwt.Claims{Subject: types.NewTypeID(types.TypeAccessPolicy, "grafana")},
+		Rest: authn.AccessTokenClaims{
+			Namespace:   "org-12",
+			Permissions: []string{"authz.grafana.app/userpermissions:get"},
+		},
+	})
+	stream := &collectUserPermissionsStream{ctx: types.WithAuthInfo(t.Context(), caller)}
+
+	err := service.GetUserPermissions(&authzv1.GetUserPermissionsRequest{
+		Namespace: "org-12",
+		Subject:   "user:test-uid",
+	}, stream)
+
+	require.NoError(t, err)
+	require.Len(t, stream.responses, 2)
+	require.Len(t, stream.responses[0].Permissions, 1000)
+	require.Len(t, stream.responses[1].Permissions, 1)
+}
+
+type expandingActionResolver struct{}
+
+func (expandingActionResolver) ExpandActionSets(permissions []accesscontrol.Permission) []accesscontrol.Permission {
+	result := make([]accesscontrol.Permission, 0, len(permissions))
+	for _, permission := range permissions {
+		if permission.Action == "dashboards:view" {
+			permission.Action = "dashboards:read"
+		}
+		result = append(result, permission)
+	}
+	return result
+}
+
+func (expandingActionResolver) ExpandActionSetsWithFilter(permissions []accesscontrol.Permission, _ func(string) bool) []accesscontrol.Permission {
+	return permissions
+}
+
+func (expandingActionResolver) ResolveAction(string) []string {
+	return nil
+}
+
+func (expandingActionResolver) ResolveActionPrefix(string) []string {
+	return nil
+}
+
+type snapshotPermissionStore struct {
+	permissions []accesscontrol.Permission
+	query       store.PermissionsQuery
+}
+
+type recordingUserPermissionsEvaluator struct {
+	permissions     []accesscontrol.Permission
+	rbacPermissions []accesscontrol.Permission
+	user            identity.Requester
+	teams           []int64
+	options         accesscontrol.Options
+}
+
+func (e *recordingUserPermissionsEvaluator) GetRBACUserPermissions(_ context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
+	e.user = user
+	e.teams = user.GetTeams()
+	e.options = options
+	return e.rbacPermissions, nil
+}
+
+func (e *recordingUserPermissionsEvaluator) GetLocalUserPermissions(_ context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
+	e.user = user
+	e.teams = user.GetTeams()
+	e.options = options
+	return e.permissions, nil
+}
+
+type recordingUserPermissionsResolver struct {
+	permissions []accesscontrol.Permission
+	user        identity.Requester
+	err         error
+}
+
+func (r *recordingUserPermissionsResolver) ResolveCurrentUserPermissions(_ context.Context, user identity.Requester) ([]accesscontrol.Permission, error) {
+	r.user = user
+	return r.permissions, r.err
+}
+
+func (s *snapshotPermissionStore) GetUserPermissions(_ context.Context, _ types.NamespaceInfo, query store.PermissionsQuery) ([]accesscontrol.Permission, error) {
+	s.query = query
+	return s.permissions, nil
+}
+
+type collectUserPermissionsStream struct {
+	grpc.ServerStream
+	ctx       context.Context
+	responses []*authzv1.GetUserPermissionsResponse
+}
+
+func (s *collectUserPermissionsStream) Context() context.Context {
+	return s.ctx
+}
+
+func (s *collectUserPermissionsStream) Send(response *authzv1.GetUserPermissionsResponse) error {
+	s.responses = append(s.responses, response)
+	return nil
+}

--- a/pkg/services/authz/rbac/user_permissions_test.go
+++ b/pkg/services/authz/rbac/user_permissions_test.go
@@ -104,7 +104,7 @@ func TestService_GetUserPermissionsUsesLocalEvaluator(t *testing.T) {
 	require.True(t, evaluator.user.GetIsGrafanaAdmin())
 	require.Equal(t, "org-12", evaluator.user.GetNamespace())
 	require.Equal(t, []int64{7, 9}, evaluator.teams)
-	require.Equal(t, accesscontrol.Options{ReloadCache: true}, evaluator.options)
+	require.Equal(t, accesscontrol.Options{ReloadCache: true, SkipZanzanaCache: true}, evaluator.options)
 }
 
 func TestService_GetUserPermissionsMergesZanzanaPermissions(t *testing.T) {

--- a/pkg/services/authz/rbac_stream_test.go
+++ b/pkg/services/authz/rbac_stream_test.go
@@ -1,0 +1,42 @@
+package authz
+
+import (
+	"context"
+	"testing"
+
+	"github.com/fullstorydev/grpchan/inprocgrpc"
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	oteltrace "go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	grpc_health_v1 "google.golang.org/grpc/health/grpc_health_v1"
+)
+
+func TestInProcessStreamInterceptorPropagatesClientSpan(t *testing.T) {
+	spanContexts := make(chan oteltrace.SpanContext, 1)
+	captureSpan := func(srv any, stream grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		spanContexts <- oteltrace.SpanContextFromContext(stream.Context())
+		return handler(srv, stream)
+	}
+
+	channel := (&inprocgrpc.Channel{}).WithServerStreamInterceptor(inProcessStreamInterceptor(captureSpan))
+	grpc_health_v1.RegisterHealthServer(channel, health.NewServer())
+
+	provider := sdktrace.NewTracerProvider()
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	ctx, parent := provider.Tracer("test").Start(ctx, "client")
+	defer parent.End()
+
+	stream, err := grpc_health_v1.NewHealthClient(channel).Watch(ctx, &grpc_health_v1.HealthCheckRequest{})
+	require.NoError(t, err)
+	_, err = stream.Recv()
+	require.NoError(t, err)
+
+	got := <-spanContexts
+	require.True(t, got.IsRemote())
+	require.Equal(t, parent.SpanContext().TraceID(), got.TraceID())
+	require.Equal(t, parent.SpanContext().SpanID(), got.SpanID())
+}

--- a/pkg/services/authz/zanzana/server/user_permissions_test.go
+++ b/pkg/services/authz/zanzana/server/user_permissions_test.go
@@ -1,0 +1,17 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	authzv1 "github.com/grafana/authlib/authz/proto/v1"
+)
+
+func TestServerGetUserPermissionsIsUnimplemented(t *testing.T) {
+	err := (&Server{}).GetUserPermissions(&authzv1.GetUserPermissionsRequest{}, nil)
+
+	require.Equal(t, codes.Unimplemented, status.Code(err))
+}


### PR DESCRIPTION
## What is this feature?

Implements the temporary `GetUserPermissions` stream in Grafana's RBAC AuthZ server.

The server reuses Grafana's existing local permission evaluator, expands action sets, merges configured Zanzana permissions into legacy-compatible permissions, and deduplicates the final action/scope pairs. Zanzana's own implementation intentionally returns `Unimplemented`; this compatibility API is supported by RBAC only and will be superseded by a future contract.

## Stack

- Base: https://github.com/grafana/grafana/pull/130889
- Next: https://github.com/grafana/grafana/pull/130890

## How was this tested?

- `go test ./pkg/services/authz/... ./pkg/services/accesscontrol/...` — 1,807 tests passed in 29 packages
- Paired Enterprise-tagged suite — 2,149 tests passed in 31 packages
