### PR TITLE
Chore: []byte(fmt.Sprintf(...)) → fmt.Appendf(nil, ...)

### DIFF
--- a/pkg/registry/apis/folders/continue.go
+++ b/pkg/registry/apis/folders/continue.go
@@ -53,5 +53,5 @@ func readContinueToken(options *internalversion.ListOptions) (*continueToken, er
 }
 
 func (t *continueToken) GetNextPageToken() string {
-	return base64.StdEncoding.EncodeToString((fmt.Appendf(nil, "%d|%d", t.limit, t.page+1)))
+	return base64.StdEncoding.EncodeToString(fmt.Appendf(nil, "%d|%d", t.limit, t.page+1))
 }

--- a/pkg/registry/apis/folders/continue.go
+++ b/pkg/registry/apis/folders/continue.go
@@ -53,5 +53,5 @@ func readContinueToken(options *internalversion.ListOptions) (*continueToken, er
 }
 
 func (t *continueToken) GetNextPageToken() string {
-	return base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%d|%d", t.limit, t.page+1)))
+	return base64.StdEncoding.EncodeToString((fmt.Appendf(nil, "%d|%d", t.limit, t.page+1)))
 }

--- a/pkg/registry/apis/provisioning/jobs/sync/folder_metadata_incremental_diff_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/folder_metadata_incremental_diff_test.go
@@ -1208,7 +1208,7 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 
 func expectFolderMetadataReadTimes(repo *compositeRepo, folderPath, ref, uid string, times int) {
 	repo.MockReader.On("Read", mock.Anything, folderPath+"_folder.json", ref).Return(&repository.FileInfo{
-		Data: (fmt.Appendf(nil, `{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":"%s"},"spec":{"title":"Title"}}`, uid)),
+		Data: fmt.Appendf(nil, `{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":"%s"},"spec":{"title":"Title"}}`, uid),
 	}, nil).Times(times)
 }
 

--- a/pkg/registry/apis/provisioning/jobs/sync/folder_metadata_incremental_diff_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/folder_metadata_incremental_diff_test.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
 func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T) {
@@ -1207,7 +1208,7 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 
 func expectFolderMetadataReadTimes(repo *compositeRepo, folderPath, ref, uid string, times int) {
 	repo.MockReader.On("Read", mock.Anything, folderPath+"_folder.json", ref).Return(&repository.FileInfo{
-		Data: []byte(fmt.Sprintf(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":"%s"},"spec":{"title":"Title"}}`, uid)),
+		Data: (fmt.Appendf(nil, `{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":"%s"},"spec":{"title":"Title"}}`, uid)),
 	}, nil).Times(times)
 }
 

--- a/pkg/server/search_server_distributor_test.go
+++ b/pkg/server/search_server_distributor_test.go
@@ -444,7 +444,7 @@ func generatePlaylistPayload(ns string) *resourcepb.CreateRequest {
 	name := "playlist" + strconv.Itoa(counter)
 	counter += 1
 	return &resourcepb.CreateRequest{
-		Value: (fmt.Appendf(nil, `{
+		Value: fmt.Appendf(nil, `{
     		"apiVersion": "playlist.grafana.app/v0alpha1",
 			"kind": "Playlist",
 			"metadata": {
@@ -467,7 +467,7 @@ func generatePlaylistPayload(ns string) *resourcepb.CreateRequest {
 					}
 				]
 			}
-		}`, name, ns)),
+		}`, name, ns),
 		Key: &resourcepb.ResourceKey{
 			Group:     "playlist.grafana.app",
 			Resource:  "aoeuaeou",

--- a/pkg/server/search_server_distributor_test.go
+++ b/pkg/server/search_server_distributor_test.go
@@ -444,7 +444,7 @@ func generatePlaylistPayload(ns string) *resourcepb.CreateRequest {
 	name := "playlist" + strconv.Itoa(counter)
 	counter += 1
 	return &resourcepb.CreateRequest{
-		Value: []byte(fmt.Sprintf(`{
+		Value: (fmt.Appendf(nil, `{
     		"apiVersion": "playlist.grafana.app/v0alpha1",
 			"kind": "Playlist",
 			"metadata": {

--- a/pkg/services/authn/clients/api_key_test.go
+++ b/pkg/services/authn/clients/api_key_test.go
@@ -8,10 +8,9 @@ import (
 	"testing"
 	"time"
 
+	claims "github.com/grafana/authlib/types"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apiserver/pkg/endpoints/request"
-
-	claims "github.com/grafana/authlib/types"
 
 	"github.com/grafana/grafana/pkg/components/satokengen"
 	"github.com/grafana/grafana/pkg/infra/tracing"

--- a/pkg/services/authn/clients/api_key_test.go
+++ b/pkg/services/authn/clients/api_key_test.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apiserver/pkg/endpoints/request"
 
 	claims "github.com/grafana/authlib/types"
+
 	"github.com/grafana/grafana/pkg/components/satokengen"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/apikey"
@@ -238,5 +239,5 @@ func genApiKey() (string, string) {
 }
 
 func encodeBasicAuth(username, password string) string {
-	return "Basic " + base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password)))
+	return "Basic " + base64.StdEncoding.EncodeToString((fmt.Appendf(nil, "%s:%s", username, password)))
 }

--- a/pkg/services/authn/clients/api_key_test.go
+++ b/pkg/services/authn/clients/api_key_test.go
@@ -239,5 +239,5 @@ func genApiKey() (string, string) {
 }
 
 func encodeBasicAuth(username, password string) string {
-	return "Basic " + base64.StdEncoding.EncodeToString((fmt.Appendf(nil, "%s:%s", username, password)))
+	return "Basic " + base64.StdEncoding.EncodeToString(fmt.Appendf(nil, "%s:%s", username, password))
 }

--- a/pkg/services/authn/clients/proxy_test.go
+++ b/pkg/services/authn/clients/proxy_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	claims "github.com/grafana/authlib/types"
+
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/authn/authntest"
@@ -324,7 +325,7 @@ func TestProxy_Hook(t *testing.T) {
 			assert.NoError(t, err)
 			expectedCache := map[string][]byte{
 				cacheKey: []byte("1"),
-				fmt.Sprintf("%s:%s", proxyCachePrefix, "johndoe"): []byte(fmt.Sprintf("users:johndoe-%s", role)),
+				fmt.Sprintf("%s:%s", proxyCachePrefix, "johndoe"): (fmt.Appendf(nil, "users:johndoe-%s", role)),
 			}
 			assert.Equal(t, expectedCache, cache.data)
 		}

--- a/pkg/services/authn/clients/proxy_test.go
+++ b/pkg/services/authn/clients/proxy_test.go
@@ -325,7 +325,7 @@ func TestProxy_Hook(t *testing.T) {
 			assert.NoError(t, err)
 			expectedCache := map[string][]byte{
 				cacheKey: []byte("1"),
-				fmt.Sprintf("%s:%s", proxyCachePrefix, "johndoe"): (fmt.Appendf(nil, "users:johndoe-%s", role)),
+				fmt.Sprintf("%s:%s", proxyCachePrefix, "johndoe"): fmt.Appendf(nil, "users:johndoe-%s", role),
 			}
 			assert.Equal(t, expectedCache, cache.data)
 		}

--- a/pkg/services/ngalert/api/util.go
+++ b/pkg/services/ngalert/api/util.go
@@ -57,7 +57,7 @@ func isLotexRulerCompatible(dsType string) bool {
 func toMacaronPath(path string) string {
 	return string(searchRegex.ReplaceAllFunc([]byte(path), func(s []byte) []byte {
 		m := string(s[1 : len(s)-1])
-		return (fmt.Appendf(nil, ":%s", m))
+		return fmt.Appendf(nil, ":%s", m)
 	}))
 }
 

--- a/pkg/services/ngalert/api/util.go
+++ b/pkg/services/ngalert/api/util.go
@@ -57,7 +57,7 @@ func isLotexRulerCompatible(dsType string) bool {
 func toMacaronPath(path string) string {
 	return string(searchRegex.ReplaceAllFunc([]byte(path), func(s []byte) []byte {
 		m := string(s[1 : len(s)-1])
-		return []byte(fmt.Sprintf(":%s", m))
+		return (fmt.Appendf(nil, ":%s", m))
 	}))
 }
 

--- a/pkg/services/ngalert/store/range_to_instant_test.go
+++ b/pkg/services/ngalert/store/range_to_instant_test.go
@@ -358,7 +358,7 @@ func prometheusQueryWithoutDS(t *testing.T, refID, datasourceUID string, isInsta
 	return models.AlertQuery{
 		RefID:         refID,
 		DatasourceUID: datasourceUID,
-		Model: []byte(fmt.Sprintf(`{
+		Model: (fmt.Appendf(nil, `{
 					"instant": %t,
 					"range": %t,
 					"editorMode": "code",

--- a/pkg/services/ngalert/store/range_to_instant_test.go
+++ b/pkg/services/ngalert/store/range_to_instant_test.go
@@ -358,7 +358,7 @@ func prometheusQueryWithoutDS(t *testing.T, refID, datasourceUID string, isInsta
 	return models.AlertQuery{
 		RefID:         refID,
 		DatasourceUID: datasourceUID,
-		Model: (fmt.Appendf(nil, `{
+		Model: fmt.Appendf(nil, `{
 					"instant": %t,
 					"range": %t,
 					"editorMode": "code",
@@ -366,7 +366,7 @@ func prometheusQueryWithoutDS(t *testing.T, refID, datasourceUID string, isInsta
 					"intervalMs": 1000,
 					"maxDataPoints": 43200,
 					"refId": "%s"
-				}`, isInstant, !isInstant, refID)),
+				}`, isInstant, !isInstant, refID),
 	}
 }
 

--- a/pkg/services/provisioning/values/values_test.go
+++ b/pkg/services/provisioning/values/values_test.go
@@ -321,7 +321,7 @@ func TestValues_readFile(t *testing.T) {
 	require.NoError(t, f.Close())
 
 	data := &Data{}
-	err = yaml.Unmarshal([]byte(fmt.Sprintf("val: $__file{%s}", file)), data)
+	err = yaml.Unmarshal((fmt.Appendf(nil, "val: $__file{%s}", file)), data)
 	require.NoError(t, err)
 	assert.Equal(t, expected, data.Val.Value())
 }

--- a/pkg/services/provisioning/values/values_test.go
+++ b/pkg/services/provisioning/values/values_test.go
@@ -321,7 +321,7 @@ func TestValues_readFile(t *testing.T) {
 	require.NoError(t, f.Close())
 
 	data := &Data{}
-	err = yaml.Unmarshal((fmt.Appendf(nil, "val: $__file{%s}", file)), data)
+	err = yaml.Unmarshal(fmt.Appendf(nil, "val: $__file{%s}", file), data)
 	require.NoError(t, err)
 	assert.Equal(t, expected, data.Val.Value())
 }

--- a/pkg/storage/secret/encryption/encrypted_value_store_test.go
+++ b/pkg/storage/secret/encryption/encrypted_value_store_test.go
@@ -12,6 +12,10 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+	"pgregory.net/rapid"
+
 	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/encryption/cipher"
@@ -20,9 +24,6 @@ import (
 	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
 	"github.com/grafana/grafana/pkg/storage/secret/encryption"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
-	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel/trace/noop"
-	"pgregory.net/rapid"
 )
 
 func TestEncryptedValueStoreImpl(t *testing.T) {
@@ -357,7 +358,7 @@ func TestEncryptedValueStoreUpdateBulk(t *testing.T) {
 		for i := 1; i <= 5; i++ {
 			ev, err := sut.EncryptedValueStorage.Create(ctx, ns, fmt.Sprintf("name-%d", i), int64(i), contracts.EncryptedPayload{
 				DataKeyID:     "key",
-				EncryptedData: []byte(fmt.Sprintf("data-%d", i)),
+				EncryptedData: (fmt.Appendf(nil, "data-%d", i)),
 			})
 			require.NoError(t, err)
 			created = append(created, ev)

--- a/pkg/storage/secret/encryption/encrypted_value_store_test.go
+++ b/pkg/storage/secret/encryption/encrypted_value_store_test.go
@@ -358,7 +358,7 @@ func TestEncryptedValueStoreUpdateBulk(t *testing.T) {
 		for i := 1; i <= 5; i++ {
 			ev, err := sut.EncryptedValueStorage.Create(ctx, ns, fmt.Sprintf("name-%d", i), int64(i), contracts.EncryptedPayload{
 				DataKeyID:     "key",
-				EncryptedData: (fmt.Appendf(nil, "data-%d", i)),
+				EncryptedData: fmt.Appendf(nil, "data-%d", i),
 			})
 			require.NoError(t, err)
 			created = append(created, ev)

--- a/pkg/storage/unified/migrations/resource_migration_test.go
+++ b/pkg/storage/unified/migrations/resource_migration_test.go
@@ -844,7 +844,7 @@ func TestIntegrationRun_SQLiteLargeMigrationRebuildUsesMigrationTransaction(t *t
 							Name:      fmt.Sprintf("large-item-%d", i),
 						},
 						Action: resourcepb.BulkRequest_ADDED,
-						Value: []byte(fmt.Sprintf(`{"apiVersion":"folder.grafana.app/v0alpha1","kind":"Folder","metadata":{"name":"large-item-%d","namespace":"%s"},"spec":{"title":"%s"}}`,
+						Value: (fmt.Appendf(nil, `{"apiVersion":"folder.grafana.app/v0alpha1","kind":"Folder","metadata":{"name":"large-item-%d","namespace":"%s"},"spec":{"title":"%s"}}`,
 							i, opts.Namespace, largeTitle)),
 					})
 					if err != nil {

--- a/pkg/storage/unified/migrations/resource_migration_test.go
+++ b/pkg/storage/unified/migrations/resource_migration_test.go
@@ -844,8 +844,8 @@ func TestIntegrationRun_SQLiteLargeMigrationRebuildUsesMigrationTransaction(t *t
 							Name:      fmt.Sprintf("large-item-%d", i),
 						},
 						Action: resourcepb.BulkRequest_ADDED,
-						Value: (fmt.Appendf(nil, `{"apiVersion":"folder.grafana.app/v0alpha1","kind":"Folder","metadata":{"name":"large-item-%d","namespace":"%s"},"spec":{"title":"%s"}}`,
-							i, opts.Namespace, largeTitle)),
+						Value: fmt.Appendf(nil, `{"apiVersion":"folder.grafana.app/v0alpha1","kind":"Folder","metadata":{"name":"large-item-%d","namespace":"%s"},"spec":{"title":"%s"}}`,
+							i, opts.Namespace, largeTitle),
 					})
 					if err != nil {
 						return err

--- a/pkg/storage/unified/resource/datastore_test.go
+++ b/pkg/storage/unified/resource/datastore_test.go
@@ -1584,7 +1584,7 @@ func testDataStoreLastResourceVersion(t *testing.T, ctx context.Context, ds *dat
 				Action:          DataActionCreated,
 			}
 
-			err := ds.Save(ctx, dataKey, bytes.NewReader([]byte(fmt.Sprintf("version-%d", version))))
+			err := ds.Save(ctx, dataKey, bytes.NewReader((fmt.Appendf(nil, "version-%d", version))))
 			require.NoError(t, err)
 		}
 
@@ -3069,7 +3069,7 @@ func testDataStoreGetGroupResources(t *testing.T, ctx context.Context, ds *dataS
 			Folder:          "test-folder",
 		}
 
-		err := ds.Save(ctx, dataKey, bytes.NewReader([]byte(fmt.Sprintf("content-%d", i))))
+		err := ds.Save(ctx, dataKey, bytes.NewReader((fmt.Appendf(nil, "content-%d", i))))
 		require.NoError(t, err)
 	}
 
@@ -3334,7 +3334,7 @@ func testDataStoreBatchGet(t *testing.T, ctx context.Context, ds *dataStore) {
 				Action:          DataActionCreated,
 				Folder:          "test-folder",
 			}
-			err := ds.Save(ctx, existingKeys[i], bytes.NewReader([]byte(fmt.Sprintf("value-%d", i))))
+			err := ds.Save(ctx, existingKeys[i], bytes.NewReader((fmt.Appendf(nil, "value-%d", i))))
 			require.NoError(t, err)
 		}
 
@@ -3452,7 +3452,7 @@ func testDataStoreGetLatestAndPredecessor(t *testing.T, ctx context.Context, ds 
 				Action:          DataActionCreated,
 			}
 
-			err := ds.Save(ctx, dataKey, bytes.NewReader([]byte(fmt.Sprintf("version-%d", version))))
+			err := ds.Save(ctx, dataKey, bytes.NewReader((fmt.Appendf(nil, "version-%d", version))))
 			require.NoError(t, err)
 		}
 

--- a/pkg/storage/unified/resource/datastore_test.go
+++ b/pkg/storage/unified/resource/datastore_test.go
@@ -1584,7 +1584,7 @@ func testDataStoreLastResourceVersion(t *testing.T, ctx context.Context, ds *dat
 				Action:          DataActionCreated,
 			}
 
-			err := ds.Save(ctx, dataKey, bytes.NewReader((fmt.Appendf(nil, "version-%d", version))))
+			err := ds.Save(ctx, dataKey, bytes.NewReader(fmt.Appendf(nil, "version-%d", version)))
 			require.NoError(t, err)
 		}
 
@@ -3069,7 +3069,7 @@ func testDataStoreGetGroupResources(t *testing.T, ctx context.Context, ds *dataS
 			Folder:          "test-folder",
 		}
 
-		err := ds.Save(ctx, dataKey, bytes.NewReader((fmt.Appendf(nil, "content-%d", i))))
+		err := ds.Save(ctx, dataKey, bytes.NewReader(fmt.Appendf(nil, "content-%d", i)))
 		require.NoError(t, err)
 	}
 
@@ -3334,7 +3334,7 @@ func testDataStoreBatchGet(t *testing.T, ctx context.Context, ds *dataStore) {
 				Action:          DataActionCreated,
 				Folder:          "test-folder",
 			}
-			err := ds.Save(ctx, existingKeys[i], bytes.NewReader((fmt.Appendf(nil, "value-%d", i))))
+			err := ds.Save(ctx, existingKeys[i], bytes.NewReader(fmt.Appendf(nil, "value-%d", i)))
 			require.NoError(t, err)
 		}
 
@@ -3452,7 +3452,7 @@ func testDataStoreGetLatestAndPredecessor(t *testing.T, ctx context.Context, ds 
 				Action:          DataActionCreated,
 			}
 
-			err := ds.Save(ctx, dataKey, bytes.NewReader((fmt.Appendf(nil, "version-%d", version))))
+			err := ds.Save(ctx, dataKey, bytes.NewReader(fmt.Appendf(nil, "version-%d", version)))
 			require.NoError(t, err)
 		}
 

--- a/pkg/storage/unified/resource/lease/metrics_test.go
+++ b/pkg/storage/unified/resource/lease/metrics_test.go
@@ -299,7 +299,7 @@ func (r *retryKV) Batch(ctx context.Context, section string, ops []kv.BatchOp) e
 // lock and takes the skip path.
 func writeGCInternalKey(t *testing.T, store kv.KV, expires time.Time) {
 	t.Helper()
-	data := (fmt.Appendf(nil, `{"expires":%d}`, expires.UnixNano()))
+	data := fmt.Appendf(nil, `{"expires":%d}`, expires.UnixNano())
 	w, err := store.Save(t.Context(), kv.LeasesSection, "lease-internal/gc")
 	require.NoError(t, err)
 	_, err = w.Write(data)

--- a/pkg/storage/unified/resource/lease/metrics_test.go
+++ b/pkg/storage/unified/resource/lease/metrics_test.go
@@ -299,7 +299,7 @@ func (r *retryKV) Batch(ctx context.Context, section string, ops []kv.BatchOp) e
 // lock and takes the skip path.
 func writeGCInternalKey(t *testing.T, store kv.KV, expires time.Time) {
 	t.Helper()
-	data := []byte(fmt.Sprintf(`{"expires":%d}`, expires.UnixNano()))
+	data := (fmt.Appendf(nil, `{"expires":%d}`, expires.UnixNano()))
 	w, err := store.Save(t.Context(), kv.LeasesSection, "lease-internal/gc")
 	require.NoError(t, err)
 	_, err = w.Write(data)

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -1924,19 +1924,19 @@ func (i *trashIterator) Folder() string         { return "" }
 func (i *trashIterator) Value() []byte          { return i.entries[i.pos].value }
 
 func testObjectJSON(name, title string) []byte {
-	return []byte(fmt.Sprintf(`{"apiVersion":"group/v1","kind":"Thing","metadata":{"name":%q},"spec":{"title":%q,"tags":["tag-a"]}}`, name, title))
+	return (fmt.Appendf(nil, `{"apiVersion":"group/v1","kind":"Thing","metadata":{"name":%q},"spec":{"title":%q,"tags":["tag-a"]}}`, name, title))
 }
 
 // testDeletedObjectJSON is what storage holds after a delete: the deletion marker
 // records who deleted the object as its last updater, and when (see server.go).
 func testDeletedObjectJSON(name, title, deletedBy string, deletedAt time.Time) []byte {
-	return []byte(fmt.Sprintf(
+	return (fmt.Appendf(nil,
 		`{"apiVersion":"group/v1","kind":"Thing","metadata":{"name":%q,"deletionTimestamp":%q,"annotations":{%q:%q}},"spec":{"title":%q}}`,
 		name, deletedAt.UTC().Format(time.RFC3339), utils.AnnoKeyUpdatedBy, deletedBy, title))
 }
 
 func testProvisionedObjectJSON(name, title string) []byte {
-	return []byte(fmt.Sprintf(`{"apiVersion":"group/v1","kind":"Thing","metadata":{"name":%q,"annotations":{%q:"repo"}},"spec":{"title":%q}}`,
+	return (fmt.Appendf(nil, `{"apiVersion":"group/v1","kind":"Thing","metadata":{"name":%q,"annotations":{%q:"repo"}},"spec":{"title":%q}}`,
 		name, utils.AnnoKeyManagerKind, title))
 }
 

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -1924,20 +1924,20 @@ func (i *trashIterator) Folder() string         { return "" }
 func (i *trashIterator) Value() []byte          { return i.entries[i.pos].value }
 
 func testObjectJSON(name, title string) []byte {
-	return (fmt.Appendf(nil, `{"apiVersion":"group/v1","kind":"Thing","metadata":{"name":%q},"spec":{"title":%q,"tags":["tag-a"]}}`, name, title))
+	return fmt.Appendf(nil, `{"apiVersion":"group/v1","kind":"Thing","metadata":{"name":%q},"spec":{"title":%q,"tags":["tag-a"]}}`, name, title)
 }
 
 // testDeletedObjectJSON is what storage holds after a delete: the deletion marker
 // records who deleted the object as its last updater, and when (see server.go).
 func testDeletedObjectJSON(name, title, deletedBy string, deletedAt time.Time) []byte {
-	return (fmt.Appendf(nil,
+	return fmt.Appendf(nil,
 		`{"apiVersion":"group/v1","kind":"Thing","metadata":{"name":%q,"deletionTimestamp":%q,"annotations":{%q:%q}},"spec":{"title":%q}}`,
-		name, deletedAt.UTC().Format(time.RFC3339), utils.AnnoKeyUpdatedBy, deletedBy, title))
+		name, deletedAt.UTC().Format(time.RFC3339), utils.AnnoKeyUpdatedBy, deletedBy, title)
 }
 
 func testProvisionedObjectJSON(name, title string) []byte {
-	return (fmt.Appendf(nil, `{"apiVersion":"group/v1","kind":"Thing","metadata":{"name":%q,"annotations":{%q:"repo"}},"spec":{"title":%q}}`,
-		name, utils.AnnoKeyManagerKind, title))
+	return fmt.Appendf(nil, `{"apiVersion":"group/v1","kind":"Thing","metadata":{"name":%q,"annotations":{%q:"repo"}},"spec":{"title":%q}}`,
+		name, utils.AnnoKeyManagerKind, title)
 }
 
 // trashSearchOptions returns search options with deleted objects kept in the

--- a/pkg/storage/unified/resource/server_test.go
+++ b/pkg/storage/unified/resource/server_test.go
@@ -586,7 +586,7 @@ func TestListStoredResources(t *testing.T) {
 	})
 
 	create := func(namespace, name string) {
-		raw := []byte(fmt.Sprintf(`{
+		raw := (fmt.Appendf(nil, `{
 			"apiVersion": "playlist.grafana.app/v0alpha1",
 			"kind": "Playlist",
 			"metadata": {"name": %q, "namespace": %q},

--- a/pkg/storage/unified/resource/server_test.go
+++ b/pkg/storage/unified/resource/server_test.go
@@ -586,12 +586,12 @@ func TestListStoredResources(t *testing.T) {
 	})
 
 	create := func(namespace, name string) {
-		raw := (fmt.Appendf(nil, `{
+		raw := fmt.Appendf(nil, `{
 			"apiVersion": "playlist.grafana.app/v0alpha1",
 			"kind": "Playlist",
 			"metadata": {"name": %q, "namespace": %q},
 			"spec": {"title": "hello", "interval": "5m"}
-		}`, name, namespace))
+		}`, name, namespace)
 		resp, err := server.Create(ctx, &resourcepb.CreateRequest{
 			Value: raw,
 			Key: &resourcepb.ResourceKey{

--- a/pkg/storage/unified/resource/storage_backend_bulk_test.go
+++ b/pkg/storage/unified/resource/storage_backend_bulk_test.go
@@ -372,7 +372,7 @@ func newBulkImportRequest(namespace, name string, action resourcepb.BulkRequest_
 			Name:      name,
 		},
 		Action: action,
-		Value: []byte(fmt.Sprintf(
+		Value: (fmt.Appendf(nil,
 			`{"apiVersion":"bulk.grafana.app/v1","kind":"Item","metadata":{"name":"%s","namespace":"%s"},"spec":{"name":"%s"}}`,
 			name,
 			namespace,
@@ -390,7 +390,7 @@ func newBulkImportRequestWithGeneration(namespace, name string, action resourcep
 			Name:      name,
 		},
 		Action: action,
-		Value: []byte(fmt.Sprintf(
+		Value: (fmt.Appendf(nil,
 			`{"apiVersion":"bulk.grafana.app/v1","kind":"Item","metadata":{"name":"%s","namespace":"%s","generation":%d},"spec":{"name":"%s"}}`,
 			name,
 			namespace,

--- a/pkg/storage/unified/resource/storage_backend_bulk_test.go
+++ b/pkg/storage/unified/resource/storage_backend_bulk_test.go
@@ -372,12 +372,12 @@ func newBulkImportRequest(namespace, name string, action resourcepb.BulkRequest_
 			Name:      name,
 		},
 		Action: action,
-		Value: (fmt.Appendf(nil,
+		Value: fmt.Appendf(nil,
 			`{"apiVersion":"bulk.grafana.app/v1","kind":"Item","metadata":{"name":"%s","namespace":"%s"},"spec":{"name":"%s"}}`,
 			name,
 			namespace,
 			name,
-		)),
+		),
 	}
 }
 
@@ -390,13 +390,13 @@ func newBulkImportRequestWithGeneration(namespace, name string, action resourcep
 			Name:      name,
 		},
 		Action: action,
-		Value: (fmt.Appendf(nil,
+		Value: fmt.Appendf(nil,
 			`{"apiVersion":"bulk.grafana.app/v1","kind":"Item","metadata":{"name":"%s","namespace":"%s","generation":%d},"spec":{"name":"%s"}}`,
 			name,
 			namespace,
 			generation,
 			name,
-		)),
+		),
 	}
 }
 

--- a/pkg/storage/unified/sql/backend_bulk_chunked_test.go
+++ b/pkg/storage/unified/sql/backend_bulk_chunked_test.go
@@ -63,9 +63,9 @@ func (r *commitRecorder) byPhase(phase string) []chunkedCommit {
 // large enough that a tiny per-chunk budget forces multiple history chunks.
 func chunkedTestValue(name string, version, padBytes int) []byte {
 	pad := strings.Repeat("x", padBytes)
-	return (fmt.Appendf(nil,
+	return fmt.Appendf(nil,
 		`{"apiVersion":"shorturl.grafana.app/v1beta1","kind":"ShortURL","metadata":{"name":%q,"namespace":"default"},"spec":{"path":"d/%s-v%d","pad":%q}}`,
-		name, name, version, pad))
+		name, name, version, pad)
 }
 
 // buildMultiVersionBulk emits `versions` ADDED/MODIFIED events per name (plus a

--- a/pkg/storage/unified/sql/backend_bulk_chunked_test.go
+++ b/pkg/storage/unified/sql/backend_bulk_chunked_test.go
@@ -63,7 +63,7 @@ func (r *commitRecorder) byPhase(phase string) []chunkedCommit {
 // large enough that a tiny per-chunk budget forces multiple history chunks.
 func chunkedTestValue(name string, version, padBytes int) []byte {
 	pad := strings.Repeat("x", padBytes)
-	return []byte(fmt.Sprintf(
+	return (fmt.Appendf(nil,
 		`{"apiVersion":"shorturl.grafana.app/v1beta1","kind":"ShortURL","metadata":{"name":%q,"namespace":"default"},"spec":{"path":"d/%s-v%d","pad":%q}}`,
 		name, name, version, pad))
 }

--- a/pkg/storage/unified/sql/backend_test.go
+++ b/pkg/storage/unified/sql/backend_test.go
@@ -777,14 +777,14 @@ func TestBackend_getHistory(t *testing.T) {
 				historyRows := sqlmock.NewRows(cols)
 				for _, rv := range tc.expectedVersions {
 					historyRows.AddRow(
-						"guid",                           // guid
-						rv,                               // resource_version
-						"ns",                             // namespace
-						"gr",                             // group
-						"rs",                             // resource
-						"nm",                             // name
-						"folder",                         // folder
-						[]byte(fmt.Sprintf("rv-%d", rv)), // value
+						"guid",                          // guid
+						rv,                              // resource_version
+						"ns",                            // namespace
+						"gr",                            // group
+						"rs",                            // resource
+						"nm",                            // name
+						"folder",                        // folder
+						(fmt.Appendf(nil, "rv-%d", rv)), // value
 					)
 				}
 				b.SQLMock.ExpectQuery("SELECT .* FROM resource_history").WillReturnRows(historyRows)
@@ -956,14 +956,14 @@ func setupHistoryTest(b testBackend, resourceVersions []int64, latestRV int64, e
 	historyRows := sqlmock.NewRows(cols)
 	for _, rv := range resourceVersions {
 		historyRows.AddRow(
-			"guid",                           // guid
-			rv,                               // resource_version
-			"ns",                             // namespace
-			"gr",                             // group
-			"rs",                             // resource
-			"nm",                             // name
-			"folder",                         // folder
-			[]byte(fmt.Sprintf("rv-%d", rv)), // value
+			"guid",                          // guid
+			rv,                              // resource_version
+			"ns",                            // namespace
+			"gr",                            // group
+			"rs",                            // resource
+			"nm",                            // name
+			"folder",                        // folder
+			(fmt.Appendf(nil, "rv-%d", rv)), // value
 		)
 	}
 

--- a/pkg/storage/unified/sql/backend_test.go
+++ b/pkg/storage/unified/sql/backend_test.go
@@ -777,14 +777,14 @@ func TestBackend_getHistory(t *testing.T) {
 				historyRows := sqlmock.NewRows(cols)
 				for _, rv := range tc.expectedVersions {
 					historyRows.AddRow(
-						"guid",                          // guid
-						rv,                              // resource_version
-						"ns",                            // namespace
-						"gr",                            // group
-						"rs",                            // resource
-						"nm",                            // name
-						"folder",                        // folder
-						(fmt.Appendf(nil, "rv-%d", rv)), // value
+						"guid",                        // guid
+						rv,                            // resource_version
+						"ns",                          // namespace
+						"gr",                          // group
+						"rs",                          // resource
+						"nm",                          // name
+						"folder",                      // folder
+						fmt.Appendf(nil, "rv-%d", rv), // value
 					)
 				}
 				b.SQLMock.ExpectQuery("SELECT .* FROM resource_history").WillReturnRows(historyRows)
@@ -956,14 +956,14 @@ func setupHistoryTest(b testBackend, resourceVersions []int64, latestRV int64, e
 	historyRows := sqlmock.NewRows(cols)
 	for _, rv := range resourceVersions {
 		historyRows.AddRow(
-			"guid",                          // guid
-			rv,                              // resource_version
-			"ns",                            // namespace
-			"gr",                            // group
-			"rs",                            // resource
-			"nm",                            // name
-			"folder",                        // folder
-			(fmt.Appendf(nil, "rv-%d", rv)), // value
+			"guid",                        // guid
+			rv,                            // resource_version
+			"ns",                          // namespace
+			"gr",                          // group
+			"rs",                          // resource
+			"nm",                          // name
+			"folder",                      // folder
+			fmt.Appendf(nil, "rv-%d", rv), // value
 		)
 	}
 

--- a/pkg/storage/unified/testing/storage_backend.go
+++ b/pkg/storage/unified/testing/storage_backend.go
@@ -2120,7 +2120,7 @@ func runTestIntegrationBackendErrorResponses(t *testing.T, backend resource.Stor
 	kind := "ErrorResource"
 
 	makeValue := func(name string) []byte {
-		return []byte(fmt.Sprintf(
+		return (fmt.Appendf(nil,
 			`{"apiVersion":"%s/v0alpha1","kind":"%s","metadata":{"name":"%s","namespace":"%s","uid":"%s"}}`,
 			group, kind, name, ns, uuid.New().String(),
 		))

--- a/pkg/storage/unified/testing/storage_backend.go
+++ b/pkg/storage/unified/testing/storage_backend.go
@@ -2120,10 +2120,10 @@ func runTestIntegrationBackendErrorResponses(t *testing.T, backend resource.Stor
 	kind := "ErrorResource"
 
 	makeValue := func(name string) []byte {
-		return (fmt.Appendf(nil,
+		return fmt.Appendf(nil,
 			`{"apiVersion":"%s/v0alpha1","kind":"%s","metadata":{"name":"%s","namespace":"%s","uid":"%s"}}`,
 			group, kind, name, ns, uuid.New().String(),
-		))
+		)
 	}
 
 	t.Run("read nonexistent resource returns 404", func(t *testing.T) {

--- a/pkg/tests/api/alerting/testing.go
+++ b/pkg/tests/api/alerting/testing.go
@@ -13,11 +13,12 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v3"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 
 	"github.com/grafana/grafana/pkg/api"
 	"github.com/grafana/grafana/pkg/configprovider"
@@ -810,7 +811,7 @@ func (a apiClient) CreateDatasource(t *testing.T, dsType string) (result api.Cre
 	if resp.StatusCode != 200 {
 		require.Failf(t, "failed to create data source", "API request to create a datasource failed. Status code: %d, response: %s", resp.StatusCode, string(b))
 	}
-	require.NoError(t, json.Unmarshal([]byte(fmt.Sprintf(`{ "body": %s }`, string(b))), &result))
+	require.NoError(t, json.Unmarshal((fmt.Appendf(nil, `{ "body": %s }`, string(b))), &result))
 	return result
 }
 

--- a/pkg/tests/api/alerting/testing.go
+++ b/pkg/tests/api/alerting/testing.go
@@ -811,7 +811,7 @@ func (a apiClient) CreateDatasource(t *testing.T, dsType string) (result api.Cre
 	if resp.StatusCode != 200 {
 		require.Failf(t, "failed to create data source", "API request to create a datasource failed. Status code: %d, response: %s", resp.StatusCode, string(b))
 	}
-	require.NoError(t, json.Unmarshal((fmt.Appendf(nil, `{ "body": %s }`, string(b))), &result))
+	require.NoError(t, json.Unmarshal(fmt.Appendf(nil, `{ "body": %s }`, string(b)), &result))
 	return result
 }
 

--- a/pkg/tests/api/alerting/testing.go
+++ b/pkg/tests/api/alerting/testing.go
@@ -19,7 +19,6 @@ import (
 	"go.yaml.in/yaml/v3"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-
 	"github.com/grafana/grafana/pkg/api"
 	"github.com/grafana/grafana/pkg/configprovider"
 	"github.com/grafana/grafana/pkg/expr"

--- a/pkg/tests/api/dashboards/api_dashboards_test.go
+++ b/pkg/tests/api/dashboards/api_dashboards_test.go
@@ -12,9 +12,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/setting"
 
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/components/simplejson"
@@ -389,7 +390,7 @@ func TestIntegrationUpdatingProvisionionedDashboards(t *testing.T) {
 
 	provDashboardsDir := filepath.Join(dir, "conf", "provisioning", "dashboards")
 	provDashboardsCfg := filepath.Join(provDashboardsDir, "dev.yaml")
-	blob := []byte(fmt.Sprintf(`
+	blob := (fmt.Appendf(nil, `
 apiVersion: 1
 
 providers:

--- a/pkg/tests/api/dashboards/api_dashboards_test.go
+++ b/pkg/tests/api/dashboards/api_dashboards_test.go
@@ -390,7 +390,7 @@ func TestIntegrationUpdatingProvisionionedDashboards(t *testing.T) {
 
 	provDashboardsDir := filepath.Join(dir, "conf", "provisioning", "dashboards")
 	provDashboardsCfg := filepath.Join(provDashboardsDir, "dev.yaml")
-	blob := (fmt.Appendf(nil, `
+	blob := fmt.Appendf(nil, `
 apiVersion: 1
 
 providers:
@@ -398,7 +398,7 @@ providers:
   type: file
   allowUiUpdates: false
   options:
-   path: %s`, provDashboardsDir))
+   path: %s`, provDashboardsDir)
 	err := os.WriteFile(provDashboardsCfg, blob, 0644)
 	require.NoError(t, err)
 	input, err := os.ReadFile(filepath.Join("./home.json"))

--- a/pkg/tests/api/dashboards/api_dashboards_test.go
+++ b/pkg/tests/api/dashboards/api_dashboards_test.go
@@ -15,8 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/setting"
-
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/services/dashboardimport"
@@ -26,6 +24,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/plugindashboards"
 	"github.com/grafana/grafana/pkg/services/search/model"
 	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tests"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
 	"github.com/grafana/grafana/pkg/tests/testsuite"

--- a/pkg/tests/api/diagnostics/diagnostics_test.go
+++ b/pkg/tests/api/diagnostics/diagnostics_test.go
@@ -409,7 +409,7 @@ func addTestDataSource(t *testing.T, ctx context.Context, testEnv *server.TestEn
 // singlePanelBody builds a POST /api/ds/diagnostics body: a MetricRequest plus the client-supplied
 // panel/dashboard JSON the endpoint echoes into the bundle.
 func singlePanelBody(dsUID, scenario string) []byte {
-	return []byte(fmt.Sprintf(`{
+	return (fmt.Appendf(nil, `{
 		"from": "now-1h",
 		"to": "now",
 		"queries": [{"refId":"A","scenarioId":%q,"datasource":{"uid":%q,"type":%q}}],
@@ -421,7 +421,7 @@ func singlePanelBody(dsUID, scenario string) []byte {
 // dashboardBody builds a POST /api/ds/dashboard-diagnostics body with two data panels: one succeeds
 // (random_walk) and one fails per-refID (random_walk_with_error).
 func dashboardBody(dsUID string) []byte {
-	return []byte(fmt.Sprintf(`{
+	return (fmt.Appendf(nil, `{
 		"dashboard": {"title":"Diag Dashboard","uid":"diag-dash-1","panels":[]},
 		"panels": [
 			{

--- a/pkg/tests/api/diagnostics/diagnostics_test.go
+++ b/pkg/tests/api/diagnostics/diagnostics_test.go
@@ -409,19 +409,19 @@ func addTestDataSource(t *testing.T, ctx context.Context, testEnv *server.TestEn
 // singlePanelBody builds a POST /api/ds/diagnostics body: a MetricRequest plus the client-supplied
 // panel/dashboard JSON the endpoint echoes into the bundle.
 func singlePanelBody(dsUID, scenario string) []byte {
-	return (fmt.Appendf(nil, `{
+	return fmt.Appendf(nil, `{
 		"from": "now-1h",
 		"to": "now",
 		"queries": [{"refId":"A","scenarioId":%q,"datasource":{"uid":%q,"type":%q}}],
 		"panel": {"id":1,"title":"Diag Panel","type":"timeseries"},
 		"dashboard": {"title":"Diag Dashboard","uid":"diag-1"}
-	}`, scenario, dsUID, testDataSourceType))
+	}`, scenario, dsUID, testDataSourceType)
 }
 
 // dashboardBody builds a POST /api/ds/dashboard-diagnostics body with two data panels: one succeeds
 // (random_walk) and one fails per-refID (random_walk_with_error).
 func dashboardBody(dsUID string) []byte {
-	return (fmt.Appendf(nil, `{
+	return fmt.Appendf(nil, `{
 		"dashboard": {"title":"Diag Dashboard","uid":"diag-dash-1","panels":[]},
 		"panels": [
 			{
@@ -441,7 +441,7 @@ func dashboardBody(dsUID string) []byte {
 				"queries": [{"refId":"A","scenarioId":"random_walk_with_error","datasource":{"uid":%q,"type":%q}}]
 			}
 		]
-	}`, dsUID, testDataSourceType, dsUID, testDataSourceType))
+	}`, dsUID, testDataSourceType, dsUID, testDataSourceType)
 }
 
 func diagURL(addr, user, pass, path string) string {

--- a/pkg/tests/apis/annotations/annotations_test.go
+++ b/pkg/tests/apis/annotations/annotations_test.go
@@ -282,7 +282,7 @@ func TestIntegrationAnnotationGraphite(t *testing.T) {
 		User:   helper.Org1.Admin,
 		Method: http.MethodPost,
 		Path:   path,
-		Body:   []byte(fmt.Sprintf(`{"what":"deployment","when":%d,"data":"v1.2.3","tags":["release","prod"]}`, when)),
+		Body:   (fmt.Appendf(nil, `{"what":"deployment","when":%d,"data":"v1.2.3","tags":["release","prod"]}`, when)),
 	}, &annotationV0.Annotation{})
 	require.Equal(t, http.StatusOK, rsp.Response.StatusCode)
 	require.NotEmpty(t, rsp.Result.GetName())

--- a/pkg/tests/apis/annotations/annotations_test.go
+++ b/pkg/tests/apis/annotations/annotations_test.go
@@ -282,7 +282,7 @@ func TestIntegrationAnnotationGraphite(t *testing.T) {
 		User:   helper.Org1.Admin,
 		Method: http.MethodPost,
 		Path:   path,
-		Body:   (fmt.Appendf(nil, `{"what":"deployment","when":%d,"data":"v1.2.3","tags":["release","prod"]}`, when)),
+		Body:   fmt.Appendf(nil, `{"what":"deployment","when":%d,"data":"v1.2.3","tags":["release","prod"]}`, when),
 	}, &annotationV0.Annotation{})
 	require.Equal(t, http.StatusOK, rsp.Response.StatusCode)
 	require.NotEmpty(t, rsp.Result.GetName())

--- a/pkg/tests/apis/dashboard/search_test.go
+++ b/pkg/tests/apis/dashboard/search_test.go
@@ -443,7 +443,7 @@ func runSearchPermissionTest(t *testing.T, mode rest.DualWriterMode) {
 			require.NoError(t, err)
 
 			var statusCode int
-			body := []byte(fmt.Sprintf(`{"uid":"%s","title":"Permission Test Folder"}`, folderUID))
+			body := (fmt.Appendf(nil, `{"uid":"%s","title":"Permission Test Folder"}`, folderUID))
 			result := restClient.Post().AbsPath("api", "folders").
 				Body(body).
 				SetHeader("Content-type", "application/json").

--- a/pkg/tests/apis/dashboard/search_test.go
+++ b/pkg/tests/apis/dashboard/search_test.go
@@ -443,7 +443,7 @@ func runSearchPermissionTest(t *testing.T, mode rest.DualWriterMode) {
 			require.NoError(t, err)
 
 			var statusCode int
-			body := (fmt.Appendf(nil, `{"uid":"%s","title":"Permission Test Folder"}`, folderUID))
+			body := fmt.Appendf(nil, `{"uid":"%s","title":"Permission Test Folder"}`, folderUID)
 			result := restClient.Post().AbsPath("api", "folders").
 				Body(body).
 				SetHeader("Content-type", "application/json").

--- a/pkg/tests/apis/dashboard/searchapi_test.go
+++ b/pkg/tests/apis/dashboard/searchapi_test.go
@@ -262,7 +262,7 @@ func createFolder(t *testing.T, ctx context.Context, helper *apis.K8sTestHelper,
 
 	var code int
 	res := restClient.Post().AbsPath("api", "folders").
-		Body((fmt.Appendf(nil, `{"uid":%q,"title":%q}`, uid, title))).
+		Body(fmt.Appendf(nil, `{"uid":%q,"title":%q}`, uid, title)).
 		SetHeader("Content-type", "application/json").
 		Do(ctx).
 		StatusCode(&code)

--- a/pkg/tests/apis/dashboard/searchapi_test.go
+++ b/pkg/tests/apis/dashboard/searchapi_test.go
@@ -262,7 +262,7 @@ func createFolder(t *testing.T, ctx context.Context, helper *apis.K8sTestHelper,
 
 	var code int
 	res := restClient.Post().AbsPath("api", "folders").
-		Body([]byte(fmt.Sprintf(`{"uid":%q,"title":%q}`, uid, title))).
+		Body((fmt.Appendf(nil, `{"uid":%q,"title":%q}`, uid, title))).
 		SetHeader("Content-type", "application/json").
 		Do(ctx).
 		StatusCode(&code)

--- a/pkg/tests/apis/folder/folders_test.go
+++ b/pkg/tests/apis/folder/folders_test.go
@@ -905,7 +905,7 @@ func TestIntegrationFolderCreatePermissionsK8S(t *testing.T) {
 					User:   helper.Org1.Admin,
 					Method: http.MethodPost,
 					Path:   "/api/folders",
-					Body:   []byte(fmt.Sprintf(`{"uid":%q,"title":"Parent folder %d"}`, parentUID, i)),
+					Body:   (fmt.Appendf(nil, `{"uid":%q,"title":"Parent folder %d"}`, parentUID, i)),
 				}, &folder.Folder{})
 				require.Equal(t, http.StatusOK, parentCreate.Response.StatusCode)
 			}
@@ -2028,7 +2028,7 @@ func setupProvisioningDir(t *testing.T, opts *testinfra.GrafanaOpts) {
 	// Create provisioning directories
 	provDashboardsDir := fmt.Sprintf("%s/conf/provisioning/dashboards", opts.Dir)
 	provDashboardsCfg := fmt.Sprintf("%s/dev.yaml", provDashboardsDir)
-	blob := []byte(fmt.Sprintf(`
+	blob := (fmt.Appendf(nil, `
 apiVersion: 1
 
 providers:

--- a/pkg/tests/apis/folder/folders_test.go
+++ b/pkg/tests/apis/folder/folders_test.go
@@ -905,7 +905,7 @@ func TestIntegrationFolderCreatePermissionsK8S(t *testing.T) {
 					User:   helper.Org1.Admin,
 					Method: http.MethodPost,
 					Path:   "/api/folders",
-					Body:   (fmt.Appendf(nil, `{"uid":%q,"title":"Parent folder %d"}`, parentUID, i)),
+					Body:   fmt.Appendf(nil, `{"uid":%q,"title":"Parent folder %d"}`, parentUID, i),
 				}, &folder.Folder{})
 				require.Equal(t, http.StatusOK, parentCreate.Response.StatusCode)
 			}
@@ -2028,7 +2028,7 @@ func setupProvisioningDir(t *testing.T, opts *testinfra.GrafanaOpts) {
 	// Create provisioning directories
 	provDashboardsDir := fmt.Sprintf("%s/conf/provisioning/dashboards", opts.Dir)
 	provDashboardsCfg := fmt.Sprintf("%s/dev.yaml", provDashboardsDir)
-	blob := (fmt.Appendf(nil, `
+	blob := fmt.Appendf(nil, `
 apiVersion: 1
 
 providers:
@@ -2037,7 +2037,7 @@ providers:
   orgId: 1
   folder: 'GrafanaCloud'
   options:
-   path: %s`, provDashboardsDir))
+   path: %s`, provDashboardsDir)
 	err := os.WriteFile(provDashboardsCfg, blob, 0o644)
 	require.NoError(t, err)
 	input, err := os.ReadFile(filepath.Join("testdata/dashboard.json"))

--- a/pkg/tests/apis/provisioning/git/webhook/webhook_test.go
+++ b/pkg/tests/apis/provisioning/git/webhook/webhook_test.go
@@ -427,7 +427,7 @@ func TestIntegrationProvisioning_WebhookSecretRotatedWhenExpired(t *testing.T) {
 	// stale secure name makes the server reject this status patch with
 	// "secure value not found" even though the patch itself doesn't touch secure.
 	expiredTimestamp := int64(1)
-	patch := (fmt.Appendf(nil, `{"status":{"webhook":{"id":200,"url":"https://grafana.example.com/hook","subscribedEvents":["pull_request","push"],"lastRotated":%d}}}`, expiredTimestamp))
+	patch := fmt.Appendf(nil, `{"status":{"webhook":{"id":200,"url":"https://grafana.example.com/hook","subscribedEvents":["pull_request","push"],"lastRotated":%d}}}`, expiredTimestamp)
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		_, err := helper.Repositories.Resource.Patch(t.Context(), repoName, types.MergePatchType, patch, metav1.PatchOptions{}, "status")
 		assert.NoError(collect, err)

--- a/pkg/tests/apis/provisioning/git/webhook/webhook_test.go
+++ b/pkg/tests/apis/provisioning/git/webhook/webhook_test.go
@@ -427,7 +427,7 @@ func TestIntegrationProvisioning_WebhookSecretRotatedWhenExpired(t *testing.T) {
 	// stale secure name makes the server reject this status patch with
 	// "secure value not found" even though the patch itself doesn't touch secure.
 	expiredTimestamp := int64(1)
-	patch := []byte(fmt.Sprintf(`{"status":{"webhook":{"id":200,"url":"https://grafana.example.com/hook","subscribedEvents":["pull_request","push"],"lastRotated":%d}}}`, expiredTimestamp))
+	patch := (fmt.Appendf(nil, `{"status":{"webhook":{"id":200,"url":"https://grafana.example.com/hook","subscribedEvents":["pull_request","push"],"lastRotated":%d}}}`, expiredTimestamp))
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		_, err := helper.Repositories.Resource.Patch(t.Context(), repoName, types.MergePatchType, patch, metav1.PatchOptions{}, "status")
 		assert.NoError(collect, err)

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource_test.go
@@ -102,7 +102,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 			name:      "Query with macros should be interpolated",
 			fromAlert: false,
 			queryModel: backend.DataQuery{
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"resource":     "/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace",
@@ -110,7 +110,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 							"resultFormat": "%s",
 							"dashboardTime": false
 						}
-					}`, dataquery.ResultFormatTimeSeries)),
+					}`, dataquery.ResultFormatTimeSeries),
 				RefID:     "A",
 				TimeRange: timeRange,
 				QueryType: string(dataquery.AzureQueryTypeLogAnalytics),
@@ -119,7 +119,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTimeSeries,
 				URL:          "v1/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace/query",
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"resource":     "/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace",
@@ -127,7 +127,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 							"resultFormat": "%s",
 							"dashboardTime": false
 						}
-					}`, dataquery.ResultFormatTimeSeries)),
+					}`, dataquery.ResultFormatTimeSeries),
 				Query:            "Perf | where ['TimeGenerated'] >= datetime('2018-03-15T13:00:00Z') and ['TimeGenerated'] <= datetime('2018-03-15T13:34:00Z') | where ['Computer'] in ('comp1','comp2') | summarize avg(CounterValue) by bin(TimeGenerated, 34000ms), Computer",
 				Resources:        []string{"/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace"},
 				TimeRange:        timeRange,
@@ -141,14 +141,14 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 			name:      "Legacy queries with a workspace GUID should use workspace-centric url",
 			fromAlert: false,
 			queryModel: backend.DataQuery{
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"workspace":    "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
 							"query":        "Perf",
 							"resultFormat": "%s"
 						}
-					}`, dataquery.ResultFormatTimeSeries)),
+					}`, dataquery.ResultFormatTimeSeries),
 				RefID:     "A",
 				QueryType: string(dataquery.AzureQueryTypeLogAnalytics),
 			},
@@ -156,14 +156,14 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTimeSeries,
 				URL:          "v1/workspaces/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/query",
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"workspace":    "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
 							"query":        "Perf",
 							"resultFormat": "%s"
 						}
-					}`, dataquery.ResultFormatTimeSeries)),
+					}`, dataquery.ResultFormatTimeSeries),
 				Query:            "Perf",
 				Resources:        []string{},
 				QueryType:        dataquery.AzureQueryTypeLogAnalytics,
@@ -176,14 +176,14 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 			name:      "Legacy workspace queries with a resource URI (from a template variable) should use resource-centric url",
 			fromAlert: false,
 			queryModel: backend.DataQuery{
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"workspace":    "/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace",
 							"query":        "Perf",
 							"resultFormat": "%s"
 						}
-					}`, dataquery.ResultFormatTimeSeries)),
+					}`, dataquery.ResultFormatTimeSeries),
 				RefID:     "A",
 				QueryType: string(dataquery.AzureQueryTypeLogAnalytics),
 			},
@@ -191,14 +191,14 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTimeSeries,
 				URL:          "v1/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace/query",
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"workspace":    "/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace",
 							"query":        "Perf",
 							"resultFormat": "%s"
 						}
-					}`, dataquery.ResultFormatTimeSeries)),
+					}`, dataquery.ResultFormatTimeSeries),
 				Query:            "Perf",
 				Resources:        []string{},
 				QueryType:        dataquery.AzureQueryTypeLogAnalytics,
@@ -211,7 +211,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 			name:      "Queries with multiple resources",
 			fromAlert: false,
 			queryModel: backend.DataQuery{
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"resource":     "/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace",
@@ -219,7 +219,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 							"resultFormat": "%s",
 							"dashboardTime": false
 						}
-					}`, dataquery.ResultFormatTimeSeries)),
+					}`, dataquery.ResultFormatTimeSeries),
 				RefID:     "A",
 				QueryType: string(dataquery.AzureQueryTypeLogAnalytics),
 			},
@@ -227,7 +227,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTimeSeries,
 				URL:          "v1/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace/query",
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"resource":     "/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace",
@@ -235,7 +235,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 							"resultFormat": "%s",
 							"dashboardTime": false
 						}
-					}`, dataquery.ResultFormatTimeSeries)),
+					}`, dataquery.ResultFormatTimeSeries),
 				Query:            "Perf",
 				Resources:        []string{"/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace"},
 				QueryType:        dataquery.AzureQueryTypeLogAnalytics,
@@ -248,7 +248,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 			name:      "Query with multiple resources",
 			fromAlert: false,
 			queryModel: backend.DataQuery{
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"resources":     ["/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace",  "/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace2"],
@@ -256,7 +256,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 							"resultFormat": "%s",
 							"dashboardTime": false
 						}
-					}`, dataquery.ResultFormatTimeSeries)),
+					}`, dataquery.ResultFormatTimeSeries),
 				RefID:     "A",
 				TimeRange: timeRange,
 				QueryType: string(dataquery.AzureQueryTypeLogAnalytics),
@@ -265,7 +265,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTimeSeries,
 				URL:          "v1/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace/query",
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"resources":     ["/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace",  "/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace2"],
@@ -273,7 +273,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 							"resultFormat": "%s",
 							"dashboardTime": false
 						}
-					}`, dataquery.ResultFormatTimeSeries)),
+					}`, dataquery.ResultFormatTimeSeries),
 				Query:            "Perf",
 				Resources:        []string{"/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace", "/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace2"},
 				TimeRange:        timeRange,
@@ -287,7 +287,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 			name:      "Query that uses dashboard time",
 			fromAlert: false,
 			queryModel: backend.DataQuery{
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"resources":     ["/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace"],
@@ -296,7 +296,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 							"dashboardTime": true,
 							"timeColumn":	"TimeGenerated"
 						}
-					}`, dataquery.ResultFormatTimeSeries)),
+					}`, dataquery.ResultFormatTimeSeries),
 				RefID:     "A",
 				TimeRange: timeRange,
 				QueryType: string(dataquery.AzureQueryTypeLogAnalytics),
@@ -305,7 +305,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTimeSeries,
 				URL:          "v1/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace/query",
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"resources":     ["/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace"],
@@ -314,7 +314,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 							"dashboardTime": true,
 							"timeColumn":	"TimeGenerated"
 						}
-					}`, dataquery.ResultFormatTimeSeries)),
+					}`, dataquery.ResultFormatTimeSeries),
 				Query:            "Perf",
 				Resources:        []string{"/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace"},
 				TimeRange:        timeRange,
@@ -330,7 +330,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 			fromAlert:        false,
 			basicLogsEnabled: true,
 			queryModel: backend.DataQuery{
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"resources":     ["/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/TestDataWorkspace"],
@@ -340,7 +340,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 							"timeColumn":	"TimeGenerated",
 							"basicLogsQuery": true
 						}
-					}`, dataquery.ResultFormatTimeSeries)),
+					}`, dataquery.ResultFormatTimeSeries),
 				RefID:     "A",
 				TimeRange: timeRange,
 				QueryType: string(dataquery.AzureQueryTypeLogAnalytics),
@@ -349,7 +349,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTimeSeries,
 				URL:          "v1/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/TestDataWorkspace/search",
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"resources":     ["/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/TestDataWorkspace"],
@@ -359,7 +359,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 							"timeColumn":	"TimeGenerated",
 							"basicLogsQuery": true
 						}
-					}`, dataquery.ResultFormatTimeSeries)),
+					}`, dataquery.ResultFormatTimeSeries),
 				Query:            "Perf",
 				Resources:        []string{"/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/TestDataWorkspace"},
 				TimeRange:        timeRange,
@@ -376,7 +376,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 			fromAlert:        false,
 			basicLogsEnabled: true,
 			queryModel: backend.DataQuery{
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"resources":     ["/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/TestDataWorkspace1", "/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/TestDataWorkspace2"],
@@ -386,7 +386,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 							"timeColumn":	"TimeGenerated",
 							"basicLogsQuery": true
 						}
-					}`, dataquery.ResultFormatTimeSeries)),
+					}`, dataquery.ResultFormatTimeSeries),
 				RefID:     "A",
 				TimeRange: timeRange,
 				QueryType: string(dataquery.AzureQueryTypeLogAnalytics),
@@ -399,7 +399,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 			fromAlert:        false,
 			basicLogsEnabled: true,
 			queryModel: backend.DataQuery{
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
@@ -409,7 +409,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 							"timeColumn":	"TimeGenerated",
 							"basicLogsQuery": true
 						}
-					}`, dataquery.ResultFormatTimeSeries)),
+					}`, dataquery.ResultFormatTimeSeries),
 				RefID:     "A",
 				TimeRange: timeRange,
 				QueryType: string(dataquery.AzureQueryTypeLogAnalytics),
@@ -422,7 +422,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 			fromAlert:        true,
 			basicLogsEnabled: true,
 			queryModel: backend.DataQuery{
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
@@ -432,7 +432,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 							"timeColumn":	"TimeGenerated",
 							"basicLogsQuery": true
 						}
-					}`, dataquery.ResultFormatTimeSeries)),
+					}`, dataquery.ResultFormatTimeSeries),
 				RefID:     "A",
 				TimeRange: timeRange,
 				QueryType: string(dataquery.AzureQueryTypeLogAnalytics),
@@ -445,7 +445,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 			fromAlert:        true,
 			basicLogsEnabled: false,
 			queryModel: backend.DataQuery{
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
@@ -455,7 +455,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 							"timeColumn":   "TimeGenerated",
 							"basicLogsQuery": true
 						}
-					}`, dataquery.ResultFormatTimeSeries)),
+					}`, dataquery.ResultFormatTimeSeries),
 				RefID:     "A",
 				TimeRange: timeRange,
 				QueryType: string(dataquery.AzureQueryTypeLogAnalytics),
@@ -468,7 +468,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 			name:      "Detects App Insights resource queries",
 			fromAlert: false,
 			queryModel: backend.DataQuery{
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"resources":     ["/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.Insights/components/AppInsightsTestDataWorkspace"],
@@ -476,7 +476,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 							"resultFormat": "%s",
 							"dashboardTime": false
 						}
-					}`, dataquery.ResultFormatTimeSeries)),
+					}`, dataquery.ResultFormatTimeSeries),
 				RefID:     "A",
 				TimeRange: timeRange,
 				QueryType: string(dataquery.AzureQueryTypeLogAnalytics),
@@ -485,7 +485,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTimeSeries,
 				URL:          "v1/apps/AppInsightsTestDataWorkspace/query",
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"resources":     ["/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.Insights/components/AppInsightsTestDataWorkspace"],
@@ -493,7 +493,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 							"resultFormat": "%s",
 							"dashboardTime": false
 						}
-					}`, dataquery.ResultFormatTimeSeries)),
+					}`, dataquery.ResultFormatTimeSeries),
 				Query:            "Perf | where ['TimeGenerated'] >= datetime('2018-03-15T13:00:00Z') and ['TimeGenerated'] <= datetime('2018-03-15T13:34:00Z') | where ['Computer'] in ('comp1','comp2') | summarize avg(CounterValue) by bin(TimeGenerated, 34000ms), Computer",
 				Resources:        []string{"/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.Insights/components/AppInsightsTestDataWorkspace"},
 				TimeRange:        timeRange,
@@ -507,7 +507,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 			name:      "Detects App Insights resource queries (case insensitive)",
 			fromAlert: false,
 			queryModel: backend.DataQuery{
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"resources":     ["/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/microsoft.insights/components/AppInsightsTestDataWorkspace"],
@@ -515,7 +515,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 							"resultFormat": "%s",
 							"dashboardTime": false
 						}
-					}`, dataquery.ResultFormatTimeSeries)),
+					}`, dataquery.ResultFormatTimeSeries),
 				RefID:     "A",
 				TimeRange: timeRange,
 				QueryType: string(dataquery.AzureQueryTypeLogAnalytics),
@@ -524,7 +524,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTimeSeries,
 				URL:          "v1/apps/AppInsightsTestDataWorkspace/query",
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"resources":     ["/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/microsoft.insights/components/AppInsightsTestDataWorkspace"],
@@ -532,7 +532,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 							"resultFormat": "%s",
 							"dashboardTime": false
 						}
-					}`, dataquery.ResultFormatTimeSeries)),
+					}`, dataquery.ResultFormatTimeSeries),
 				Query:            "Perf | where ['TimeGenerated'] >= datetime('2018-03-15T13:00:00Z') and ['TimeGenerated'] <= datetime('2018-03-15T13:34:00Z') | where ['Computer'] in ('comp1','comp2') | summarize avg(CounterValue) by bin(TimeGenerated, 34000ms), Computer",
 				Resources:        []string{"/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/microsoft.insights/components/AppInsightsTestDataWorkspace"},
 				TimeRange:        timeRange,

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource_test.go
@@ -102,7 +102,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 			name:      "Query with macros should be interpolated",
 			fromAlert: false,
 			queryModel: backend.DataQuery{
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"resource":     "/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace",
@@ -119,7 +119,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTimeSeries,
 				URL:          "v1/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace/query",
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"resource":     "/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace",
@@ -141,7 +141,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 			name:      "Legacy queries with a workspace GUID should use workspace-centric url",
 			fromAlert: false,
 			queryModel: backend.DataQuery{
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"workspace":    "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
@@ -156,7 +156,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTimeSeries,
 				URL:          "v1/workspaces/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/query",
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"workspace":    "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
@@ -176,7 +176,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 			name:      "Legacy workspace queries with a resource URI (from a template variable) should use resource-centric url",
 			fromAlert: false,
 			queryModel: backend.DataQuery{
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"workspace":    "/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace",
@@ -191,7 +191,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTimeSeries,
 				URL:          "v1/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace/query",
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"workspace":    "/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace",
@@ -211,7 +211,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 			name:      "Queries with multiple resources",
 			fromAlert: false,
 			queryModel: backend.DataQuery{
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"resource":     "/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace",
@@ -227,7 +227,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTimeSeries,
 				URL:          "v1/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace/query",
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"resource":     "/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace",
@@ -248,7 +248,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 			name:      "Query with multiple resources",
 			fromAlert: false,
 			queryModel: backend.DataQuery{
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"resources":     ["/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace",  "/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace2"],
@@ -265,7 +265,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTimeSeries,
 				URL:          "v1/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace/query",
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"resources":     ["/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace",  "/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace2"],
@@ -287,7 +287,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 			name:      "Query that uses dashboard time",
 			fromAlert: false,
 			queryModel: backend.DataQuery{
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"resources":     ["/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace"],
@@ -305,7 +305,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTimeSeries,
 				URL:          "v1/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace/query",
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"resources":     ["/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace"],
@@ -330,7 +330,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 			fromAlert:        false,
 			basicLogsEnabled: true,
 			queryModel: backend.DataQuery{
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"resources":     ["/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/TestDataWorkspace"],
@@ -349,7 +349,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTimeSeries,
 				URL:          "v1/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/TestDataWorkspace/search",
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"resources":     ["/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/TestDataWorkspace"],
@@ -376,7 +376,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 			fromAlert:        false,
 			basicLogsEnabled: true,
 			queryModel: backend.DataQuery{
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"resources":     ["/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/TestDataWorkspace1", "/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/TestDataWorkspace2"],
@@ -399,7 +399,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 			fromAlert:        false,
 			basicLogsEnabled: true,
 			queryModel: backend.DataQuery{
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
@@ -422,7 +422,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 			fromAlert:        true,
 			basicLogsEnabled: true,
 			queryModel: backend.DataQuery{
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
@@ -445,7 +445,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 			fromAlert:        true,
 			basicLogsEnabled: false,
 			queryModel: backend.DataQuery{
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
@@ -468,7 +468,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 			name:      "Detects App Insights resource queries",
 			fromAlert: false,
 			queryModel: backend.DataQuery{
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"resources":     ["/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.Insights/components/AppInsightsTestDataWorkspace"],
@@ -485,7 +485,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTimeSeries,
 				URL:          "v1/apps/AppInsightsTestDataWorkspace/query",
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"resources":     ["/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.Insights/components/AppInsightsTestDataWorkspace"],
@@ -507,7 +507,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 			name:      "Detects App Insights resource queries (case insensitive)",
 			fromAlert: false,
 			queryModel: backend.DataQuery{
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"resources":     ["/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/microsoft.insights/components/AppInsightsTestDataWorkspace"],
@@ -524,7 +524,7 @@ func TestBuildLogAnalyticsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTimeSeries,
 				URL:          "v1/apps/AppInsightsTestDataWorkspace/query",
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
 							"resources":     ["/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/microsoft.insights/components/AppInsightsTestDataWorkspace"],

--- a/pkg/tsdb/azuremonitor/loganalytics/traces_test.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/traces_test.go
@@ -12,12 +12,13 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/kinds/dataquery"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/types"
-	"github.com/stretchr/testify/require"
 )
 
 func TestBuildAppInsightsQuery(t *testing.T) {
@@ -105,7 +106,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 		{
 			name: "trace query",
 			queryModel: backend.DataQuery{
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
@@ -122,7 +123,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTable,
 				URL:          "v1/apps/r1/query",
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
@@ -257,7 +258,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 		{
 			name: "trace query with no operation ID",
 			queryModel: backend.DataQuery{
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
@@ -272,7 +273,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTable,
 				URL:          "v1/apps/r1/query",
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
@@ -329,7 +330,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 		{
 			name: "trace query with no types",
 			queryModel: backend.DataQuery{
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
@@ -345,7 +346,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTable,
 				URL:          "v1/apps/r1/query",
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
@@ -404,7 +405,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 		{
 			name: "trace query with eq filter",
 			queryModel: backend.DataQuery{
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 								"queryType": "Azure Traces",
 								"azureTraces": {
 									"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
@@ -421,7 +422,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTable,
 				URL:          "v1/apps/r1/query",
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 								"queryType": "Azure Traces",
 								"azureTraces": {
 									"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
@@ -484,7 +485,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 		{
 			name: "trace query with ne filter",
 			queryModel: backend.DataQuery{
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 								"queryType": "Azure Traces",
 								"azureTraces": {
 									"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
@@ -501,7 +502,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTable,
 				URL:          "v1/apps/r1/query",
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 								"queryType": "Azure Traces",
 								"azureTraces": {
 									"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
@@ -564,7 +565,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 		{
 			name: "trace query with multiple filters",
 			queryModel: backend.DataQuery{
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 								"queryType": "Azure Traces",
 								"azureTraces": {
 									"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
@@ -581,7 +582,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTable,
 				URL:          "v1/apps/r1/query",
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 								"queryType": "Azure Traces",
 								"azureTraces": {
 									"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
@@ -644,7 +645,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 		{
 			name: "trace query with trace result format",
 			queryModel: backend.DataQuery{
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
@@ -659,7 +660,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTrace,
 				URL:          "v1/apps/r1/query",
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
@@ -716,7 +717,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 		{
 			name: "trace query with trace result format and operation ID",
 			queryModel: backend.DataQuery{
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"operationId": 	"test-op-id",
@@ -732,7 +733,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTrace,
 				URL:          "v1/apps/r1/query",
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"operationId": 	"test-op-id",
@@ -791,7 +792,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 		{
 			name: "trace query with trace result format and only trace type",
 			queryModel: backend.DataQuery{
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"operationId": 	"test-op-id",
@@ -808,7 +809,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTrace,
 				URL:          "v1/apps/r1/query",
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"operationId": 	"test-op-id",
@@ -834,7 +835,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 		{
 			name: "trace query with operation ID and correlated workspaces",
 			queryModel: backend.DataQuery{
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"operationId": 	"op-id-multi",
@@ -850,7 +851,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTrace,
 				URL:          "v1/apps/r1/query",
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"operationId": 	"op-id-multi",
@@ -913,7 +914,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 		{
 			name: "trace query with multiple resources",
 			queryModel: backend.DataQuery{
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"resources":    ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1", "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r2"],
@@ -928,7 +929,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTrace,
 				URL:          "v1/apps/r1/query",
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"resources":    ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1", "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r2"],
@@ -989,7 +990,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 		{
 			name: "trace query with multiple resources and overlapping correlated workspaces",
 			queryModel: backend.DataQuery{
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"operationId": 	"op-id-multi",
@@ -1005,7 +1006,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTrace,
 				URL:          "v1/apps/r1/query",
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"operationId": 	"op-id-multi",
@@ -1068,7 +1069,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 		{
 			name: "trace query with multiple resources and non-overlapping correlated workspaces",
 			queryModel: backend.DataQuery{
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"operationId": 	"op-id-non-overlapping",
@@ -1084,7 +1085,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTrace,
 				URL:          "v1/apps/r1/query",
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"operationId": 	"op-id-non-overlapping",
@@ -1154,7 +1155,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 		{
 			name: "trace query with missing operation ID",
 			queryModel: backend.DataQuery{
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
@@ -1239,7 +1240,7 @@ func TestBuildAppInsightsQuery_EmptyResources(t *testing.T) {
 		{
 			name: "empty resources array should return error",
 			queryModel: backend.DataQuery{
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 					"queryType": "Azure Traces",
 					"azureTraces": {
 						"resources": [],
@@ -1256,7 +1257,7 @@ func TestBuildAppInsightsQuery_EmptyResources(t *testing.T) {
 		{
 			name: "missing resources field should return error",
 			queryModel: backend.DataQuery{
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 					"queryType": "Azure Traces",
 					"azureTraces": {
 						"resultFormat": "%s",
@@ -1272,7 +1273,7 @@ func TestBuildAppInsightsQuery_EmptyResources(t *testing.T) {
 		{
 			name: "trace exemplar with empty correlation resources should return error",
 			queryModel: backend.DataQuery{
-				JSON: []byte(fmt.Sprintf(`{
+				JSON: (fmt.Appendf(nil, `{
 					"queryType": "Azure Traces",
 					"azureTraces": {
 						"resources": ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],

--- a/pkg/tsdb/azuremonitor/loganalytics/traces_test.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/traces_test.go
@@ -106,7 +106,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 		{
 			name: "trace query",
 			queryModel: backend.DataQuery{
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
@@ -114,7 +114,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 								"traceTypes":	["trace"],
 								"operationId":	"test-op-id"
 							}
-						}`, dataquery.ResultFormatTable)),
+						}`, dataquery.ResultFormatTable),
 				RefID:     "A",
 				TimeRange: timeRange,
 				QueryType: string(dataquery.AzureQueryTypeAzureTraces),
@@ -123,7 +123,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTable,
 				URL:          "v1/apps/r1/query",
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
@@ -131,7 +131,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 								"traceTypes":	["trace"],
 								"operationId":	"test-op-id"
 							}
-						}`, dataquery.ResultFormatTable)),
+						}`, dataquery.ResultFormatTable),
 				Query: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true trace` +
 					`| where (operation_Id != '' and operation_Id == 'test-op-id') or (customDimensions.ai_legacyRootId != '' and customDimensions.ai_legacyRootId == 'test-op-id')` +
 					`| extend duration = iff(isnull(column_ifexists("duration", real(null))), toreal(0), column_ifexists("duration", real(null)))` +
@@ -258,13 +258,13 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 		{
 			name: "trace query with no operation ID",
 			queryModel: backend.DataQuery{
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
 								"resultFormat": "%s"
 							}
-						}`, dataquery.ResultFormatTable)),
+						}`, dataquery.ResultFormatTable),
 				RefID:     "A",
 				TimeRange: timeRange,
 				QueryType: string(dataquery.AzureQueryTypeAzureTraces),
@@ -273,13 +273,13 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTable,
 				URL:          "v1/apps/r1/query",
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
 								"resultFormat": "%s"
 							}
-						}`, dataquery.ResultFormatTable)),
+						}`, dataquery.ResultFormatTable),
 				Query: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,traces` +
 					`| extend duration = iff(isnull(column_ifexists("duration", real(null))), toreal(0), column_ifexists("duration", real(null)))` +
 					`| extend spanID = iff(itemType == "pageView" or isempty(column_ifexists("id", "")), tostring(new_guid()), column_ifexists("id", ""))` +
@@ -330,14 +330,14 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 		{
 			name: "trace query with no types",
 			queryModel: backend.DataQuery{
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
 								"resultFormat": "%s",
 								"operationId":	"test-op-id"
 							}
-						}`, dataquery.ResultFormatTable)),
+						}`, dataquery.ResultFormatTable),
 				RefID:     "A",
 				TimeRange: timeRange,
 				QueryType: string(dataquery.AzureQueryTypeAzureTraces),
@@ -346,14 +346,14 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTable,
 				URL:          "v1/apps/r1/query",
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
 								"resultFormat": "%s",
 								"operationId":	"test-op-id"
 							}
-						}`, dataquery.ResultFormatTable)),
+						}`, dataquery.ResultFormatTable),
 				Query: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,traces` +
 					`| where (operation_Id != '' and operation_Id == 'test-op-id') or (customDimensions.ai_legacyRootId != '' and customDimensions.ai_legacyRootId == 'test-op-id')` +
 					`| extend duration = iff(isnull(column_ifexists("duration", real(null))), toreal(0), column_ifexists("duration", real(null)))` +
@@ -405,7 +405,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 		{
 			name: "trace query with eq filter",
 			queryModel: backend.DataQuery{
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 								"queryType": "Azure Traces",
 								"azureTraces": {
 									"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
@@ -413,7 +413,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 									"operationId":	"test-op-id",
 									"filters":		[{"filters": ["test-app-id"], "property": "appId", "operation": "eq"}]
 								}
-							}`, dataquery.ResultFormatTable)),
+							}`, dataquery.ResultFormatTable),
 				RefID:     "A",
 				TimeRange: timeRange,
 				QueryType: string(dataquery.AzureQueryTypeAzureTraces),
@@ -422,7 +422,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTable,
 				URL:          "v1/apps/r1/query",
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 								"queryType": "Azure Traces",
 								"azureTraces": {
 									"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
@@ -430,7 +430,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 									"operationId":	"test-op-id",
 									"filters":		[{"filters": ["test-app-id"], "property": "appId", "operation": "eq"}]
 								}
-							}`, dataquery.ResultFormatTable)),
+							}`, dataquery.ResultFormatTable),
 				Query: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,traces` +
 					`| where (operation_Id != '' and operation_Id == 'test-op-id') or (customDimensions.ai_legacyRootId != '' and customDimensions.ai_legacyRootId == 'test-op-id')` +
 					`| extend duration = iff(isnull(column_ifexists("duration", real(null))), toreal(0), column_ifexists("duration", real(null)))` +
@@ -485,7 +485,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 		{
 			name: "trace query with ne filter",
 			queryModel: backend.DataQuery{
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 								"queryType": "Azure Traces",
 								"azureTraces": {
 									"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
@@ -493,7 +493,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 									"operationId":	"test-op-id",
 									"filters":		[{"filters": ["test-app-id"], "property": "appId", "operation": "ne"}]
 								}
-							}`, dataquery.ResultFormatTable)),
+							}`, dataquery.ResultFormatTable),
 				RefID:     "A",
 				TimeRange: timeRange,
 				QueryType: string(dataquery.AzureQueryTypeAzureTraces),
@@ -502,7 +502,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTable,
 				URL:          "v1/apps/r1/query",
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 								"queryType": "Azure Traces",
 								"azureTraces": {
 									"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
@@ -510,7 +510,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 									"operationId":	"test-op-id",
 									"filters":		[{"filters": ["test-app-id"], "property": "appId", "operation": "ne"}]
 								}
-							}`, dataquery.ResultFormatTable)),
+							}`, dataquery.ResultFormatTable),
 				Query: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,traces` +
 					`| where (operation_Id != '' and operation_Id == 'test-op-id') or (customDimensions.ai_legacyRootId != '' and customDimensions.ai_legacyRootId == 'test-op-id')` +
 					`| extend duration = iff(isnull(column_ifexists("duration", real(null))), toreal(0), column_ifexists("duration", real(null)))` +
@@ -565,7 +565,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 		{
 			name: "trace query with multiple filters",
 			queryModel: backend.DataQuery{
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 								"queryType": "Azure Traces",
 								"azureTraces": {
 									"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
@@ -573,7 +573,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 									"operationId":	"test-op-id",
 									"filters":		[{"filters": ["test-app-id"], "property": "appId", "operation": "ne"},{"filters": ["test-client-id"], "property": "clientId", "operation": "eq"}]
 							}
-						}`, dataquery.ResultFormatTable)),
+						}`, dataquery.ResultFormatTable),
 				RefID:     "A",
 				TimeRange: timeRange,
 				QueryType: string(dataquery.AzureQueryTypeAzureTraces),
@@ -582,7 +582,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTable,
 				URL:          "v1/apps/r1/query",
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 								"queryType": "Azure Traces",
 								"azureTraces": {
 									"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
@@ -590,7 +590,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 									"operationId":	"test-op-id",
 									"filters":		[{"filters": ["test-app-id"], "property": "appId", "operation": "ne"},{"filters": ["test-client-id"], "property": "clientId", "operation": "eq"}]
 							}
-						}`, dataquery.ResultFormatTable)),
+						}`, dataquery.ResultFormatTable),
 				Query: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,traces` +
 					`| where (operation_Id != '' and operation_Id == 'test-op-id') or (customDimensions.ai_legacyRootId != '' and customDimensions.ai_legacyRootId == 'test-op-id')` +
 					`| extend duration = iff(isnull(column_ifexists("duration", real(null))), toreal(0), column_ifexists("duration", real(null)))` +
@@ -645,13 +645,13 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 		{
 			name: "trace query with trace result format",
 			queryModel: backend.DataQuery{
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
 								"resultFormat": "%s"
 							}
-						}`, dataquery.ResultFormatTrace)),
+						}`, dataquery.ResultFormatTrace),
 				RefID:     "A",
 				TimeRange: timeRange,
 				QueryType: string(dataquery.AzureQueryTypeAzureTraces),
@@ -660,13 +660,13 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTrace,
 				URL:          "v1/apps/r1/query",
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
 								"resultFormat": "%s"
 							}
-						}`, dataquery.ResultFormatTrace)),
+						}`, dataquery.ResultFormatTrace),
 				Query: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests` +
 					`| extend duration = iff(isnull(column_ifexists("duration", real(null))), toreal(0), column_ifexists("duration", real(null)))` +
 					`| extend spanID = iff(itemType == "pageView" or isempty(column_ifexists("id", "")), tostring(new_guid()), column_ifexists("id", ""))` +
@@ -717,14 +717,14 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 		{
 			name: "trace query with trace result format and operation ID",
 			queryModel: backend.DataQuery{
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"operationId": 	"test-op-id",
 								"resources":    ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
 								"resultFormat": "%s"
 							}
-						}`, dataquery.ResultFormatTrace)),
+						}`, dataquery.ResultFormatTrace),
 				RefID:     "A",
 				TimeRange: timeRange,
 				QueryType: string(dataquery.AzureQueryTypeAzureTraces),
@@ -733,14 +733,14 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTrace,
 				URL:          "v1/apps/r1/query",
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"operationId": 	"test-op-id",
 								"resources":    ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
 								"resultFormat": "%s"
 							}
-						}`, dataquery.ResultFormatTrace)),
+						}`, dataquery.ResultFormatTrace),
 				Query: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests` +
 					`| where (operation_Id != '' and operation_Id == 'test-op-id') or (customDimensions.ai_legacyRootId != '' and customDimensions.ai_legacyRootId == 'test-op-id')` +
 					`| extend duration = iff(isnull(column_ifexists("duration", real(null))), toreal(0), column_ifexists("duration", real(null)))` +
@@ -792,7 +792,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 		{
 			name: "trace query with trace result format and only trace type",
 			queryModel: backend.DataQuery{
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"operationId": 	"test-op-id",
@@ -800,7 +800,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 								"resultFormat": "%s",
 								"traceTypes":		["traces"]
 							}
-						}`, dataquery.ResultFormatTrace)),
+						}`, dataquery.ResultFormatTrace),
 				RefID:     "A",
 				TimeRange: timeRange,
 				QueryType: string(dataquery.AzureQueryTypeAzureTraces),
@@ -809,7 +809,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTrace,
 				URL:          "v1/apps/r1/query",
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"operationId": 	"test-op-id",
@@ -817,7 +817,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 								"resultFormat": "%s",
 								"traceTypes":		["traces"]
 							}
-						}`, dataquery.ResultFormatTrace)),
+						}`, dataquery.ResultFormatTrace),
 				Query:                   "",
 				Resources:               []string{"/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"},
 				TimeRange:               timeRange,
@@ -835,14 +835,14 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 		{
 			name: "trace query with operation ID and correlated workspaces",
 			queryModel: backend.DataQuery{
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"operationId": 	"op-id-multi",
 								"resources":    ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
 								"resultFormat": "%s"
 							}
-						}`, dataquery.ResultFormatTrace)),
+						}`, dataquery.ResultFormatTrace),
 				RefID:     "A",
 				TimeRange: timeRange,
 				QueryType: string(dataquery.AzureQueryTypeAzureTraces),
@@ -851,14 +851,14 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTrace,
 				URL:          "v1/apps/r1/query",
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"operationId": 	"op-id-multi",
 								"resources":    ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
 								"resultFormat": "%s"
 							}
-						}`, dataquery.ResultFormatTrace)),
+						}`, dataquery.ResultFormatTrace),
 				Query: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').availabilityResults,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').customEvents,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').dependencies,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').exceptions,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').pageViews,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').requests` +
 					`| where (operation_Id != '' and operation_Id == 'op-id-multi') or (customDimensions.ai_legacyRootId != '' and customDimensions.ai_legacyRootId == 'op-id-multi')` +
 					`| extend duration = iff(isnull(column_ifexists("duration", real(null))), toreal(0), column_ifexists("duration", real(null)))` +
@@ -914,13 +914,13 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 		{
 			name: "trace query with multiple resources",
 			queryModel: backend.DataQuery{
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"resources":    ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1", "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r2"],
 								"resultFormat": "%s"
 							}
-						}`, dataquery.ResultFormatTrace)),
+						}`, dataquery.ResultFormatTrace),
 				RefID:     "A",
 				TimeRange: timeRange,
 				QueryType: string(dataquery.AzureQueryTypeAzureTraces),
@@ -929,13 +929,13 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTrace,
 				URL:          "v1/apps/r1/query",
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"resources":    ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1", "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r2"],
 								"resultFormat": "%s"
 							}
-						}`, dataquery.ResultFormatTrace)),
+						}`, dataquery.ResultFormatTrace),
 				Query: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').availabilityResults,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').customEvents,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').dependencies,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').exceptions,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').pageViews,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').requests` +
 					`| extend duration = iff(isnull(column_ifexists("duration", real(null))), toreal(0), column_ifexists("duration", real(null)))` +
 					`| extend spanID = iff(itemType == "pageView" or isempty(column_ifexists("id", "")), tostring(new_guid()), column_ifexists("id", ""))` +
@@ -990,14 +990,14 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 		{
 			name: "trace query with multiple resources and overlapping correlated workspaces",
 			queryModel: backend.DataQuery{
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"operationId": 	"op-id-multi",
 								"resources":    ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1", "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r2"],
 								"resultFormat": "%s"
 							}
-						}`, dataquery.ResultFormatTrace)),
+						}`, dataquery.ResultFormatTrace),
 				RefID:     "A",
 				TimeRange: timeRange,
 				QueryType: string(dataquery.AzureQueryTypeAzureTraces),
@@ -1006,14 +1006,14 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTrace,
 				URL:          "v1/apps/r1/query",
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"operationId": 	"op-id-multi",
 								"resources":    ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1", "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r2"],
 								"resultFormat": "%s"
 							}
-						}`, dataquery.ResultFormatTrace)),
+						}`, dataquery.ResultFormatTrace),
 				Query: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').availabilityResults,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').customEvents,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').dependencies,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').exceptions,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').pageViews,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').requests` +
 					`| where (operation_Id != '' and operation_Id == 'op-id-multi') or (customDimensions.ai_legacyRootId != '' and customDimensions.ai_legacyRootId == 'op-id-multi')` +
 					`| extend duration = iff(isnull(column_ifexists("duration", real(null))), toreal(0), column_ifexists("duration", real(null)))` +
@@ -1069,14 +1069,14 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 		{
 			name: "trace query with multiple resources and non-overlapping correlated workspaces",
 			queryModel: backend.DataQuery{
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"operationId": 	"op-id-non-overlapping",
 								"resources":    ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1", "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r2"],
 								"resultFormat": "%s"
 							}
-						}`, dataquery.ResultFormatTrace)),
+						}`, dataquery.ResultFormatTrace),
 				RefID:     "A",
 				TimeRange: timeRange,
 				QueryType: string(dataquery.AzureQueryTypeAzureTraces),
@@ -1085,14 +1085,14 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 				RefID:        "A",
 				ResultFormat: dataquery.ResultFormatTrace,
 				URL:          "v1/apps/r1/query",
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"operationId": 	"op-id-non-overlapping",
 								"resources":    ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1", "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r2"],
 								"resultFormat": "%s"
 							}
-						}`, dataquery.ResultFormatTrace)),
+						}`, dataquery.ResultFormatTrace),
 				Query: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').availabilityResults,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').customEvents,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').dependencies,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').exceptions,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').pageViews,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').requests,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r3').availabilityResults,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r3').customEvents,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r3').dependencies,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r3').exceptions,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r3').pageViews,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r3').requests` +
 					`| where (operation_Id != '' and operation_Id == 'op-id-non-overlapping') or (customDimensions.ai_legacyRootId != '' and customDimensions.ai_legacyRootId == 'op-id-non-overlapping')` +
 					`| extend duration = iff(isnull(column_ifexists("duration", real(null))), toreal(0), column_ifexists("duration", real(null)))` +
@@ -1155,7 +1155,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 		{
 			name: "trace query with missing operation ID",
 			queryModel: backend.DataQuery{
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
@@ -1163,7 +1163,7 @@ func TestBuildAppInsightsQuery(t *testing.T) {
 								"traceTypes":	["trace"],
 								"operationId":	"missing-op-id"
 							}
-						}`, dataquery.ResultFormatTable)),
+						}`, dataquery.ResultFormatTable),
 				RefID:     "A",
 				TimeRange: timeRange,
 				QueryType: string(dataquery.AzureQueryTypeAzureTraces),
@@ -1240,14 +1240,14 @@ func TestBuildAppInsightsQuery_EmptyResources(t *testing.T) {
 		{
 			name: "empty resources array should return error",
 			queryModel: backend.DataQuery{
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 					"queryType": "Azure Traces",
 					"azureTraces": {
 						"resources": [],
 						"resultFormat": "%s",
 						"traceTypes": ["trace"]
 					}
-				}`, dataquery.ResultFormatTable)),
+				}`, dataquery.ResultFormatTable),
 				RefID:     "A",
 				TimeRange: timeRange,
 				QueryType: string(dataquery.AzureQueryTypeAzureTraces),
@@ -1257,13 +1257,13 @@ func TestBuildAppInsightsQuery_EmptyResources(t *testing.T) {
 		{
 			name: "missing resources field should return error",
 			queryModel: backend.DataQuery{
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 					"queryType": "Azure Traces",
 					"azureTraces": {
 						"resultFormat": "%s",
 						"traceTypes": ["trace"]
 					}
-				}`, dataquery.ResultFormatTable)),
+				}`, dataquery.ResultFormatTable),
 				RefID:     "A",
 				TimeRange: timeRange,
 				QueryType: string(dataquery.AzureQueryTypeAzureTraces),
@@ -1273,7 +1273,7 @@ func TestBuildAppInsightsQuery_EmptyResources(t *testing.T) {
 		{
 			name: "trace exemplar with empty correlation resources should return error",
 			queryModel: backend.DataQuery{
-				JSON: (fmt.Appendf(nil, `{
+				JSON: fmt.Appendf(nil, `{
 					"queryType": "Azure Traces",
 					"azureTraces": {
 						"resources": ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
@@ -1281,7 +1281,7 @@ func TestBuildAppInsightsQuery_EmptyResources(t *testing.T) {
 						"traceTypes": ["trace"],
 						"operationId": "missing-op-id"
 					}
-				}`, dataquery.ResultFormatTable)),
+				}`, dataquery.ResultFormatTable),
 				RefID:     "A",
 				TimeRange: timeRange,
 				QueryType: string(dataquery.AzureQueryTypeTraceExemplar),

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/grafana/grafana-azure-sdk-go/v2/azusercontext"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/kinds/dataquery"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/testdata"
 	azTime "github.com/grafana/grafana/pkg/tsdb/azuremonitor/time"

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
@@ -17,12 +17,13 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana-azure-sdk-go/v2/azcredentials"
 	"github.com/grafana/grafana-azure-sdk-go/v2/azusercontext"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/kinds/dataquery"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/testdata"
@@ -284,7 +285,7 @@ func TestAzureMonitorBuildQueries(t *testing.T) {
 			azureMonitorJSON, _ := json.Marshal(tt.azureMonitorVariedProperties)
 			tsdbQuery := []backend.DataQuery{
 				{
-					JSON: []byte(fmt.Sprintf(`{
+					JSON: (fmt.Appendf(nil, `{
 							"subscription": "12345678-aaaa-bbbb-cccc-123456789abc",
 							"azureMonitor": %s
 						}`, string(azureMonitorJSON))),

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
@@ -285,10 +285,10 @@ func TestAzureMonitorBuildQueries(t *testing.T) {
 			azureMonitorJSON, _ := json.Marshal(tt.azureMonitorVariedProperties)
 			tsdbQuery := []backend.DataQuery{
 				{
-					JSON: (fmt.Appendf(nil, `{
+					JSON: fmt.Appendf(nil, `{
 							"subscription": "12345678-aaaa-bbbb-cccc-123456789abc",
 							"azureMonitor": %s
-						}`, string(azureMonitorJSON))),
+						}`, string(azureMonitorJSON)),
 					RefID:    "A",
 					Interval: tt.queryInterval,
 					TimeRange: backend.TimeRange{

--- a/pkg/tsdb/grafana-testdata-datasource/scenarios_test.go
+++ b/pkg/tsdb/grafana-testdata-datasource/scenarios_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-
 	"github.com/grafana/grafana/pkg/tsdb/grafana-testdata-datasource/kinds"
 )
 

--- a/pkg/tsdb/grafana-testdata-datasource/scenarios_test.go
+++ b/pkg/tsdb/grafana-testdata-datasource/scenarios_test.go
@@ -7,10 +7,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 
 	"github.com/grafana/grafana/pkg/tsdb/grafana-testdata-datasource/kinds"
 )
@@ -193,7 +194,7 @@ func TestTestdataScenarios(t *testing.T) {
 						},
 						Interval:      100 * time.Millisecond,
 						MaxDataPoints: 100,
-						JSON: []byte(fmt.Sprintf(
+						JSON: (fmt.Appendf(nil,
 							`{"queryDelay":"0s","errorProbability":%v,"errorMessage":"test error","errorStatusCode":400,"errorSource":"downstream"}`,
 							probability,
 						)),

--- a/pkg/tsdb/grafana-testdata-datasource/scenarios_test.go
+++ b/pkg/tsdb/grafana-testdata-datasource/scenarios_test.go
@@ -194,10 +194,10 @@ func TestTestdataScenarios(t *testing.T) {
 						},
 						Interval:      100 * time.Millisecond,
 						MaxDataPoints: 100,
-						JSON: (fmt.Appendf(nil,
+						JSON: fmt.Appendf(nil,
 							`{"queryDelay":"0s","errorProbability":%v,"errorMessage":"test error","errorStatusCode":400,"errorSource":"downstream"}`,
 							probability,
-						)),
+						),
 					},
 				},
 			}


### PR DESCRIPTION

### Summary
Optimized string/byte formatting by replacing `[]byte(fmt.Sprintf(...))` with `fmt.Appendf(nil, ...)`.

### Why?
The old pattern `[]byte(fmt.Sprintf(...))` creates an expensive intermediate string on the heap, allocates a separate byte slice, and copies the data twice. 

By switching to `fmt.Appendf`, we append formatted data directly to a byte slice, dropping the intermediate string allocation entirely. This was explicitly introduced in **[Go 1.19](https://go.dev)** to eliminate this exact performance bottleneck.

- **Reduces allocations**: Lowers total heap allocations from 2 to 1 (or 0 if appending to a pre-allocated buffer).
- **Cleaner code**: Directly communicates that our desired output format is a byte slice, not a string.

**References:**
- Official Release Notes: [Go 1.19 Standard Library Updates](https://go.dev)
- Design Proposal: [Go Issue #47579 - Add fmt.Appendf](https://github.com)
