### PR TITLE
Combobox: prefer exact match when available

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
@@ -143,6 +143,37 @@ describe('Combobox', () => {
     expect(screen.getByDisplayValue('Option 3')).toBeInTheDocument();
   });
 
+  it('selects the exact match over an option that only contains the search', async () => {
+    const substringOptions: ComboboxOption[] = [
+      { label: 'go_memstats_alloc_bytes_total', value: '1' },
+      { label: 'go_memstats_alloc_bytes', value: '2' },
+    ];
+    render(<Combobox options={substringOptions} value={null} onChange={onChangeHandler} />);
+
+    const input = screen.getByRole('combobox');
+    await userEvent.type(input, 'go_memstats_alloc_bytes');
+    await userEvent.keyboard('{Enter}');
+
+    expect(onChangeHandler).toHaveBeenCalledWith(substringOptions[1]);
+    expect(screen.getByDisplayValue('go_memstats_alloc_bytes')).toBeInTheDocument();
+  });
+
+  it('selects the exact match when another value is already selected', async () => {
+    const substringOptions: ComboboxOption[] = [
+      { label: 'go_memstats_alloc_bytes_total', value: '1' },
+      { label: 'go_memstats_alloc_bytes', value: '2' },
+      { label: 'other_metric', value: '3' },
+    ];
+    render(<Combobox options={substringOptions} value="3" onChange={onChangeHandler} />);
+
+    const input = screen.getByRole('combobox');
+    await userEvent.click(input);
+    await userEvent.type(input, 'go_memstats_alloc_bytes');
+    await userEvent.keyboard('{Enter}');
+
+    expect(onChangeHandler).toHaveBeenCalledWith(substringOptions[1]);
+  });
+
   it('selects value by using keyboard only', async () => {
     render(<Combobox options={options} value={null} onChange={onChangeHandler} />);
 
@@ -473,6 +504,22 @@ describe('Combobox', () => {
 
       expect(onChangeHandler).toHaveBeenCalledWith(simpleAsyncOptions[2]);
       expect(screen.getByDisplayValue('Option 3')).toBeInTheDocument();
+    });
+
+    it('should select the exact match of async options over an option that only contains the search', async () => {
+      const substringOptions = [{ value: 'go_memstats_alloc_bytes_total' }, { value: 'go_memstats_alloc_bytes' }];
+      const asyncOptions = jest.fn(() => Promise.resolve(substringOptions));
+      render(<Combobox options={asyncOptions} value={null} onChange={onChangeHandler} />);
+
+      const input = screen.getByRole('combobox');
+      await user.click(input);
+      await act(async () => {
+        await user.keyboard('go_memstats_alloc_bytes');
+        jest.advanceTimersByTime(DEBOUNCE_TIME_MS);
+      });
+      await user.keyboard('{Enter}');
+
+      expect(onChangeHandler).toHaveBeenCalledWith(substringOptions[1]);
     });
 
     it('should ignore late responses', async () => {

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -363,6 +363,15 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
       const menuBeingOpened = state.isOpen === false && changes.isOpen === true;
       const menuBeingClosed = state.isOpen === true && changes.isOpen === false;
 
+      // Downshift resets the highlight to defaultHighlightedIndex, which points at the selected item and is
+      // meaningless once the list is filtered by a search. Highlight the best match for the search instead.
+      if (actionAndChanges.type === useCombobox.stateChangeTypes.InputChange) {
+        changes = {
+          ...changes,
+          highlightedIndex: 0,
+        };
+      }
+
       // Reset the input value when the menu is opened. If the menu is opened due to an input change
       // then make sure we keep that.
       // This will trigger onInputValueChange to load async options

--- a/packages/grafana-ui/src/components/Combobox/filter.ts
+++ b/packages/grafana-ui/src/components/Combobox/filter.ts
@@ -17,3 +17,54 @@ export function fuzzyFind<T extends string | number>(
   const indices = fuzzySearch(haystack, needle);
   return indices.map((idx) => options[idx]);
 }
+
+/**
+ * Returns the index of the option whose displayed text is exactly the search term, or -1 if there is none.
+ * A case sensitive match wins over a case insensitive one.
+ */
+export function findExactMatchIndex<T extends string | number>(options: Array<ComboboxOption<T>>, needle: string) {
+  if (needle === '') {
+    return -1;
+  }
+
+  const lowerCaseNeedle = needle.toLowerCase();
+  let caseInsensitiveMatchIndex = -1;
+
+  for (let index = 0; index < options.length; index++) {
+    const optionText = itemToString(options[index]);
+
+    // Comparing the lengths first keeps the common case cheap - lists of options can be very long
+    if (optionText.length !== needle.length) {
+      continue;
+    }
+
+    if (optionText === needle) {
+      return index;
+    }
+
+    if (caseInsensitiveMatchIndex === -1 && optionText.toLowerCase() === lowerCaseNeedle) {
+      caseInsensitiveMatchIndex = index;
+    }
+  }
+
+  return caseInsensitiveMatchIndex;
+}
+
+/**
+ * Moves the option that exactly matches the search term to the front of the list. Without this, an option that
+ * merely contains the search term can sort first and become the option that pressing enter selects.
+ */
+export function hoistExactMatch<T extends string | number>(options: Array<ComboboxOption<T>>, needle: string) {
+  const exactMatchIndex = findExactMatchIndex(options, needle);
+
+  if (exactMatchIndex <= 0) {
+    return options;
+  }
+
+  // Make sure to clone the array first to avoid mutating the original array!
+  const reordered = options.slice();
+  const [exactMatch] = reordered.splice(exactMatchIndex, 1);
+  reordered.unshift(exactMatch);
+
+  return reordered;
+}

--- a/packages/grafana-ui/src/components/Combobox/useOptions.test.ts
+++ b/packages/grafana-ui/src/components/Combobox/useOptions.test.ts
@@ -100,6 +100,50 @@ describe('useOptions', () => {
     expect(result.current.options).toEqual([{ label: 'Carrot', value: 'carrot' }]);
   });
 
+  it('should move an exact match to the front of synchronous options', () => {
+    const options = [
+      { label: 'go_memstats_alloc_bytes_total', value: '1' },
+      { label: 'go_memstats_alloc_bytes', value: '2' },
+    ];
+    const { result } = renderHook(() => useOptions(options, false));
+
+    act(() => {
+      result.current.updateOptions('go_memstats_alloc_bytes');
+    });
+
+    expect(result.current.options[0]).toEqual({ label: 'go_memstats_alloc_bytes', value: '2' });
+  });
+
+  it('should move an exact match to the front of asynchronous options', async () => {
+    const asyncOptions = jest.fn().mockResolvedValue([
+      { label: 'go_memstats_alloc_bytes_total', value: '1' },
+      { label: 'go_memstats_alloc_bytes', value: '2' },
+    ]);
+    const { result } = renderHook(() => useOptions(asyncOptions, false));
+
+    act(() => {
+      result.current.updateOptions('go_memstats_alloc_bytes');
+    });
+
+    await waitFor(() => expect(result.current.asyncLoading).toBe(false));
+
+    expect(result.current.options[0]).toEqual({ label: 'go_memstats_alloc_bytes', value: '2' });
+  });
+
+  it('should keep the order of the options when there is no exact match', () => {
+    const options = [
+      { label: 'go_memstats_alloc_bytes_total', value: '1' },
+      { label: 'go_memstats_alloc_bytes_sum', value: '2' },
+    ];
+    const { result } = renderHook(() => useOptions(options, false));
+
+    act(() => {
+      result.current.updateOptions('go_memstats_alloc_bytes');
+    });
+
+    expect(result.current.options).toEqual(options);
+  });
+
   it('should handle errors in asynchronous options', async () => {
     jest.spyOn(console, 'error').mockImplementation();
 

--- a/packages/grafana-ui/src/components/Combobox/useOptions.ts
+++ b/packages/grafana-ui/src/components/Combobox/useOptions.ts
@@ -6,7 +6,7 @@ import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 
 import { t } from '@grafana/i18n';
 
-import { fuzzyFind, itemToString } from './filter';
+import { fuzzyFind, hoistExactMatch, itemToString } from './filter';
 import { type ComboboxOption } from './types';
 import { StaleResultError, useLatestAsyncCall } from './useLatestAsyncCall';
 
@@ -122,11 +122,9 @@ export function useOptions<T extends string | number>(
   // Create a list of options filtered by the current search.
   // If async, just returns the async options.
   const filteredOptions = useMemo(() => {
-    if (isAsync) {
-      return asyncOptions;
-    }
+    const matchingOptions = isAsync ? asyncOptions : fuzzyFind(rawOptions, stringifiedOptions, userTypedSearch);
 
-    return fuzzyFind(rawOptions, stringifiedOptions, userTypedSearch);
+    return hoistExactMatch(matchingOptions, userTypedSearch);
   }, [asyncOptions, isAsync, rawOptions, stringifiedOptions, userTypedSearch]);
 
   const [finalOptions, groupStartIndices] = useMemo(() => {


### PR DESCRIPTION


**What is this feature?**

When a user types an exact metric name they want in the combobox input area their metric should be the first choice.

**Why do we need this feature?**

So that the user doesn't have to scroll potentially thousands of partial matches to find the exact match.

**Who is this feature for?**

People who use Grafana web UI, in particular Explore and Dashboards with the Prometheus data source.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-prometheus-datasource/issues/316

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
