### PR TITLE
Command Palette: Fix sizing in medium view ports

### DIFF
--- a/public/app/features/commandPalette/CommandPalette.tsx
+++ b/public/app/features/commandPalette/CommandPalette.tsx
@@ -7,7 +7,6 @@ import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 
 import { OpenAssistantButton, useAssistant } from '@grafana/assistant';
 import { type GrafanaTheme2 } from '@grafana/data';
-import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
 import { useFlagDashboardVectorSearch, useFlagGrafanaVectorSearchCmdk } from '@grafana/runtime/internal';
@@ -43,8 +42,7 @@ export function CommandPalette() {
  * @constructor
  */
 function CommandPaletteContents() {
-  const lateralSpace = getCommandPalettePosition();
-  const styles = useStyles2(getSearchStyles, lateralSpace);
+  const styles = useStyles2(getSearchStyles);
 
   const { query, searchQuery, currentRootActionId } = useKBar((state) => ({
     showing: state.visualState === VisualState.showing,
@@ -178,8 +176,7 @@ function CommandPaletteContents() {
  * @constructor
  */
 function AncestorBreadcrumbs() {
-  const lateralSpace = getCommandPalettePosition();
-  const styles = useStyles2(getSearchStyles, lateralSpace);
+  const styles = useStyles2(getSearchStyles);
 
   const { actions, currentRootActionId } = useKBar((state) => ({
     actions: state.actions,
@@ -227,8 +224,7 @@ const RenderResults = ({
   const { results: kbarResults, rootActionId } = useMatches();
   const { query, activeIndex } = useKBar((state) => ({ activeIndex: state.activeIndex }));
   const { isAvailable: isAssistantAvailable } = useAssistant();
-  const lateralSpace = getCommandPalettePosition();
-  const styles = useStyles2(getSearchStyles, lateralSpace);
+  const styles = useStyles2(getSearchStyles);
 
   const dashboardsSectionTitle = t('command-palette.section.dashboard-search-results', 'Dashboards');
   const foldersSectionTitle = t('command-palette.section.folder-search-results', 'Folders');
@@ -551,14 +547,6 @@ const RenderResults = ({
   );
 };
 
-const getCommandPalettePosition = () => {
-  const input = document.querySelector(`[data-testid="${selectors.components.NavToolbar.commandPaletteTrigger}"]`);
-  const inputRightPosition = input?.getBoundingClientRect().right ?? 0;
-  const screenWidth = document.body.clientWidth;
-  const lateralSpace = screenWidth - inputRightPosition;
-  return lateralSpace;
-};
-
 // Denominator for Deep Search Discovery/Adoption: fire once per settled deep
 // search render. useDeepSearchResults already debounces the fetch, so keying
 // off its fetching flag settling to false gives one event per result set
@@ -585,7 +573,7 @@ function useDeepSearchResultsShownReporting(
   }, [isFetchingDeepSearchResults, showDeepSearch, deepSearchResultsLength, deepSearchEnabled, searchQueryLength]);
 }
 
-const getSearchStyles = (theme: GrafanaTheme2, lateralSpace: number) => {
+const getSearchStyles = (theme: GrafanaTheme2) => {
   return {
     positioner: css({
       zIndex: theme.zIndex.portal,
@@ -603,20 +591,13 @@ const getSearchStyles = (theme: GrafanaTheme2, lateralSpace: number) => {
     }),
     animator: css({
       width: '100%',
-      maxWidth: theme.breakpoints.values.md,
+      maxWidth: theme.breakpoints.values.lg,
       background: theme.colors.background.primary,
       color: theme.colors.text.primary,
       borderRadius: theme.shape.radius.lg,
       border: `1px solid ${theme.colors.border.weak}`,
       overflow: 'hidden',
       boxShadow: theme.shadows.z3,
-      [theme.breakpoints.up('lg')]: {
-        position: 'fixed',
-        right: lateralSpace,
-        left: lateralSpace,
-        maxWidth: 'unset',
-        width: 'unset',
-      },
     }),
     loadingBarContainer: css({
       position: 'absolute',


### PR DESCRIPTION
The command palette had a sizing rule that tried to align it with the top bar search input. This meant that if there are more items in the top bar that push the search input to the middle the size of the palette gets smaller:

<img width="811" height="697" alt="Screenshot 2026-08-18 at 11 25 24" src="https://github.com/user-attachments/assets/5a9a0987-4125-46fb-8791-6d08a8d353cb" />

This PR simplifies the rules and abandons the alignment of the palette to the input, improving the sizing across view port sizes:


https://github.com/user-attachments/assets/b94aeece-f49c-480a-9f39-7b418c46bec4

