### PR TITLE
Revert "Datasources: Add `useDatasourcesAsync()` hook with loading and error state"

### DIFF
--- a/public/app/features/datasources/hooks.test.ts
+++ b/public/app/features/datasources/hooks.test.ts
@@ -1,26 +1,15 @@
-import { renderHook, act, waitFor } from '@testing-library/react';
-
-import { type DataSourceInstanceListItem, type DataSourceInstanceSettings } from '@grafana/data';
-import { getDataSourceInstanceList, getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
+import { renderHook, act } from '@testing-library/react';
 
 import { TestDataSettings } from '../query/state/mocks/mockDataSource';
 
-import { useDatasourcesAsync, useRecentlyUsedDataSources } from './hooks';
+import { useRecentlyUsedDataSources } from './hooks';
 
-// Mock react-use's useLocalStorage, keeping the real useAsync
+// Mock react-use's useLocalStorage
 jest.mock('react-use', () => ({
-  ...jest.requireActual('react-use'),
   useLocalStorage: jest.fn(),
 }));
 
-jest.mock('@grafana/runtime/unstable', () => ({
-  getDataSourceInstanceList: jest.fn(),
-  getDataSourceInstanceSettings: jest.fn(),
-}));
-
 const mockUseLocalStorage = jest.requireMock('react-use').useLocalStorage;
-const mockGetDataSourceInstanceList = jest.mocked(getDataSourceInstanceList);
-const mockGetDataSourceInstanceSettings = jest.mocked(getDataSourceInstanceSettings);
 
 describe('useRecentlyUsedDataSources', () => {
   let mockSetStorage: jest.Mock;
@@ -121,109 +110,5 @@ describe('useRecentlyUsedDataSources', () => {
       // Should remove the first item and add new one at the end
       expect(mockSetStorage).toHaveBeenCalledWith(['uid2', 'uid3', 'uid4', 'uid5', 'test-uid']);
     });
-  });
-});
-
-describe('useDatasourcesAsync', () => {
-  function createSettings(uid: string, name: string): DataSourceInstanceSettings {
-    return { ...TestDataSettings, uid, name };
-  }
-
-  function toListItem(settings: DataSourceInstanceSettings): DataSourceInstanceListItem {
-    const { uid, type, name, meta, readOnly } = settings;
-    return { uid, type, name, meta, readOnly, isDefault: settings.isDefault ?? false };
-  }
-
-  const settingsA = createSettings('uid-a', 'Datasource A');
-  const settingsB = createSettings('uid-b', 'Datasource B');
-  const settingsByUid: Record<string, DataSourceInstanceSettings> = {
-    [settingsA.uid]: settingsA,
-    [settingsB.uid]: settingsB,
-  };
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockGetDataSourceInstanceList.mockResolvedValue([settingsA, settingsB].map(toListItem));
-    mockGetDataSourceInstanceSettings.mockImplementation(async (ref) =>
-      typeof ref === 'string' ? settingsByUid[ref] : undefined
-    );
-  });
-
-  it('should resolve the full settings for each listed data source, preserving order', async () => {
-    const { result } = renderHook(() => useDatasourcesAsync({}));
-
-    await waitFor(() => expect(result.current.dataSources).toEqual([settingsA, settingsB]));
-    expect(result.current.isLoading).toBe(false);
-    expect(result.current.error).toBeUndefined();
-  });
-
-  it('should forward the filters to getDataSourceInstanceList', async () => {
-    const filters = { alerting: true, type: 'prometheus' };
-
-    renderHook(() => useDatasourcesAsync(filters));
-
-    await waitFor(() => expect(mockGetDataSourceInstanceList).toHaveBeenCalledWith(filters));
-  });
-
-  it('should report isLoading with an empty list while the lookup is pending', () => {
-    // Never resolves so the hook stays in its loading state.
-    mockGetDataSourceInstanceList.mockReturnValue(new Promise(() => {}));
-
-    const { result } = renderHook(() => useDatasourcesAsync({}));
-
-    expect(result.current.isLoading).toBe(true);
-    expect(result.current.dataSources).toEqual([]);
-  });
-
-  it('should surface a failed lookup through the error field', async () => {
-    const lookupError = new Error('lookup failed');
-    mockGetDataSourceInstanceList.mockRejectedValue(lookupError);
-
-    const { result } = renderHook(() => useDatasourcesAsync({}));
-
-    await waitFor(() => expect(result.current.error).toBe(lookupError));
-    expect(result.current.isLoading).toBe(false);
-    expect(result.current.dataSources).toEqual([]);
-  });
-
-  it('should re-fetch when the filters change value, but not for a value-equal object', async () => {
-    const { rerender } = renderHook(({ filters }) => useDatasourcesAsync(filters), {
-      initialProps: { filters: { alerting: true } },
-    });
-
-    await waitFor(() => expect(mockGetDataSourceInstanceList).toHaveBeenCalledTimes(1));
-
-    rerender({ filters: { alerting: true } });
-    // Flush microtasks so a second fetch would have started by now.
-    await act(async () => {});
-    expect(mockGetDataSourceInstanceList).toHaveBeenCalledTimes(1);
-
-    rerender({ filters: { alerting: false } });
-    await waitFor(() => expect(mockGetDataSourceInstanceList).toHaveBeenCalledTimes(2));
-  });
-
-  it('should keep the previous list with isLoading=true while a re-fetch is pending', async () => {
-    const { result, rerender } = renderHook(({ filters }) => useDatasourcesAsync(filters), {
-      initialProps: { filters: { alerting: true } },
-    });
-
-    await waitFor(() => expect(result.current.dataSources).toEqual([settingsA, settingsB]));
-
-    // The re-fetch never resolves so the hook stays in its re-fetching state.
-    mockGetDataSourceInstanceList.mockReturnValue(new Promise(() => {}));
-    rerender({ filters: { alerting: false } });
-
-    await waitFor(() => expect(result.current.isLoading).toBe(true));
-    expect(result.current.dataSources).toEqual([settingsA, settingsB]);
-  });
-
-  it('should omit data sources whose settings cannot be resolved', async () => {
-    mockGetDataSourceInstanceSettings.mockImplementation(async (ref) =>
-      ref === settingsA.uid ? settingsA : undefined
-    );
-
-    const { result } = renderHook(() => useDatasourcesAsync({}));
-
-    await waitFor(() => expect(result.current.dataSources).toEqual([settingsA]));
   });
 });

--- a/public/app/features/datasources/hooks.ts
+++ b/public/app/features/datasources/hooks.ts
@@ -1,15 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type * as React from 'react';
-import { useAsync, useLocalStorage } from 'react-use';
+import { useLocalStorage } from 'react-use';
 import { type Observable } from 'rxjs';
 
 import { type DataSourceInstanceSettings, type DataSourceRef, type ScopedVars } from '@grafana/data';
 import { type GetDataSourceListFilters, getDataSourceSrv } from '@grafana/runtime';
-import {
-  type GetDataSourceInstanceListFilters,
-  getDataSourceInstanceList,
-  getDataSourceInstanceSettings,
-} from '@grafana/runtime/unstable';
 
 const LOCAL_STORAGE_KEY = 'grafana.features.datasources.components.picker.DataSourceDropDown.history';
 
@@ -47,10 +42,6 @@ export function useRecentlyUsedDataSources(): [string[], (ds: DataSourceInstance
   return [value, pushRecentlyUsedDataSource];
 }
 
-/**
- * @deprecated Use {@link useDatasourcesAsync} instead — call sites are being migrated to it
- * one by one, and once all are done it takes over this hook's name.
- */
 export function useDatasources(filters: GetDataSourceListFilters, datasources?: DataSourceInstanceSettings[]) {
   if (datasources) {
     return datasources;
@@ -59,44 +50,6 @@ export function useDatasources(filters: GetDataSourceListFilters, datasources?: 
   const dataSources = dataSourceSrv.getList(filters);
 
   return dataSources;
-}
-
-export interface UseDatasourcesAsyncResult {
-  isLoading: boolean;
-  error?: Error;
-  dataSources: DataSourceInstanceSettings[];
-}
-
-/**
- * Async replacement for {@link useDatasources}, resolving the data sources matching `filters`
- * from the in-memory cache with explicit loading and error state. While a re-fetch is pending,
- * the previous list is kept with `isLoading: true`.
- *
- * Known limitation: the result is only re-fetched when `filters` change, so a mounted consumer
- * does not pick up data sources added or removed via reloadDataSourceInstanceSettings() until
- * it remounts or its filters change.
- */
-export function useDatasourcesAsync(filters: GetDataSourceInstanceListFilters = {}): UseDatasourcesAsyncResult {
-  // Consumers pass `filters` as an inline object literal — a new reference on every render.
-  // Serialize it for the useAsync() deps so the fetch only re-runs when a filter value
-  // actually changes. The `filter` callback can't be serialized; it is compared by reference.
-  const { filter: filterFunc, ...serializableFilters } = filters;
-  const filtersKey = JSON.stringify(serializableFilters);
-
-  const { loading, error, value } = useAsync(
-    async () => {
-      const items = await getDataSourceInstanceList(filters);
-      // getDataSourceInstanceList() returns slim list items, but the pickers built on this
-      // hook pass full DataSourceInstanceSettings to their public onChange/filter props, so
-      // fetch the full settings for each item. Both calls read the same in-memory cache.
-      const settings = await Promise.all(items.map((item) => getDataSourceInstanceSettings(item.uid)));
-      return settings.filter((s) => s !== undefined);
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [filtersKey, filterFunc]
-  );
-
-  return { isLoading: loading, error, dataSources: value ?? [] };
 }
 
 export function useDatasource(


### PR DESCRIPTION
Reverts the `useDatasourcesAsync()` hook added in #130650.

## Why

We don't want to expose another data source list hook in app code. `@grafana/runtime/unstable` already ships the canonical async hook, `useDataSourceInstanceList()`, and `useDatasourcesAsync()` was largely a re-implementation of it that additionally resolved the full instance settings per item. What we want to do is to migrate consumers of the `useDatasources` into the new list hook.

Nothing consumed the hook yet, so this restores `public/app/features/datasources/hooks.ts` and its test to exactly their pre-#130650 state — `useDatasources()` is back to the plain legacy `getDataSourceSrv().getList()` hook with no deprecation tag.

## What changed

- Removed `useDatasourcesAsync()` and `UseDatasourcesAsyncResult`, along with the `@grafana/runtime/unstable` and `useAsync` imports.
- Removed the `@deprecated` JSDoc that pointed `useDatasources()` at the new hook.
- Removed the `describe('useDatasourcesAsync')` test block and restored the original `jest.mock('react-use')` without the `requireActual` spread.

`git diff aa092da2da3~1` over both files is empty, so this is an exact restore rather than an approximation.