### PR TITLE
ShortLinks: Fix copied short URL using namespace instead of org ID

### DIFF
--- a/public/app/core/utils/shortLinks.test.ts
+++ b/public/app/core/utils/shortLinks.test.ts
@@ -1,4 +1,4 @@
-import { type LogRowModel } from '@grafana/data';
+import { type CurrentUserDTO, type LogRowModel } from '@grafana/data';
 import { config, locationService } from '@grafana/runtime';
 import { FlagKeys } from '@grafana/runtime/internal';
 import { SceneTimeRange } from '@grafana/scenes';
@@ -53,6 +53,12 @@ beforeEach(() => {
 
   document.execCommand = jest.fn();
   setTestFlags({ [FlagKeys.UseKubernetesShortURLsAPI]: false });
+
+  // Set the base org id via `jest.replaceProperty` on `config.bootData.user`
+  // (auto-restored after each test). We spread the existing user so any other
+  // members other tests may rely on are preserved, then override orgId — and we
+  // never mutate the shared `config` in place.
+  jest.replaceProperty(config.bootData, 'user', { ...config.bootData.user, orgId: 1 } as CurrentUserDTO);
 
   // clear memoizeOne function
   if ('clear' in createShortLink) {
@@ -165,9 +171,13 @@ describe('buildShortUrl', () => {
       writable: true,
     });
     config.appSubUrl = '';
+    // On-prem by default (namespace not `stacks-*`), so orgId is carried.
+    jest.replaceProperty(config, 'namespace', 'org-1');
   });
 
-  it('builds short URL with metadata name and namespace', () => {
+  it('uses the current org ID rather than the resource namespace', () => {
+    jest.replaceProperty(config.bootData, 'user', { ...config.bootData.user, orgId: 5 } as CurrentUserDTO);
+
     const shortUrl: ShortURL = {
       kind: 'ShortURL',
       apiVersion: 'shorturl.grafana.app/v1beta1',
@@ -180,25 +190,47 @@ describe('buildShortUrl', () => {
     };
 
     const result = buildShortUrl(shortUrl);
-    expect(result).toBe('https://grafana.example.com/goto/abc123def?orgId=org-5');
+    expect(result).toBe('https://grafana.example.com/goto/abc123def?orgId=5');
   });
 
-  it('builds short URL with appSubUrl configured', () => {
-    config.appSubUrl = '/grafana';
+  it('omits orgId on Cloud (no multi-org)', () => {
+    // Cloud instances use a `stacks-*` namespace and don't support multi-org,
+    // so the orgId query param would be pure noise.
+    jest.replaceProperty(config, 'namespace', 'stacks-42');
+    jest.replaceProperty(config.bootData, 'user', { ...config.bootData.user, orgId: 1 } as CurrentUserDTO);
 
     const shortUrl: ShortURL = {
       kind: 'ShortURL',
       apiVersion: 'shorturl.grafana.app/v1beta1',
       metadata: {
-        name: 'xyz789',
-        namespace: 'org-1',
+        name: 'cloud-shortlink',
+        namespace: 'stacks-42',
       },
       spec: defaultSpec(),
       status: defaultStatus(),
     };
 
     const result = buildShortUrl(shortUrl);
-    expect(result).toBe('https://grafana.example.com/grafana/goto/xyz789?orgId=org-1');
+    expect(result).toBe('https://grafana.example.com/goto/cloud-shortlink');
+  });
+
+  it('builds short URL with appSubUrl configured', () => {
+    config.appSubUrl = '/grafana';
+    jest.replaceProperty(config.bootData, 'user', { ...config.bootData.user, orgId: 1 } as CurrentUserDTO);
+
+    const shortUrl: ShortURL = {
+      kind: 'ShortURL',
+      apiVersion: 'shorturl.grafana.app/v1beta1',
+      metadata: {
+        name: 'xyz789',
+        namespace: 'default',
+      },
+      spec: defaultSpec(),
+      status: defaultStatus(),
+    };
+
+    const result = buildShortUrl(shortUrl);
+    expect(result).toBe('https://grafana.example.com/grafana/goto/xyz789?orgId=1');
   });
 });
 

--- a/public/app/core/utils/shortLinks.ts
+++ b/public/app/core/utils/shortLinks.ts
@@ -17,6 +17,7 @@ import { type ShareLinkConfiguration } from '../../features/dashboard-scene/shar
 import { notifyApp } from '../reducers/appNotification';
 
 import { copyStringToClipboard } from './explore';
+import { isOnPrem } from './isOnPrem';
 
 function buildHostUrl() {
   return `${window.location.protocol}//${window.location.host}${config.appSubUrl}`;
@@ -24,9 +25,16 @@ function buildHostUrl() {
 
 export function buildShortUrl(k8sShortUrl: ShortURL) {
   const key = k8sShortUrl.metadata.name;
-  const orgId = k8sShortUrl.metadata.namespace;
   const hostUrl = buildHostUrl();
-  return `${hostUrl}/goto/${key}?orgId=${orgId}`;
+  // The resource namespace is not the org ID — it is `default`, `org-<id>` or
+  // `stacks-<id>`. On-prem is multi-org, so carry the current user's org ID in
+  // the query param; Cloud doesn't support multi-org, so the param would just
+  // be noise (`orgId=1`) and is omitted.
+  if (isOnPrem()) {
+    const orgId = config.bootData.user.orgId;
+    return `${hostUrl}/goto/${key}?orgId=${orgId}`;
+  }
+  return `${hostUrl}/goto/${key}`;
 }
 
 function getRelativeURLPath(url: string) {


### PR DESCRIPTION
Replaces the previously-closed #130614, opened fresh on the latest `main` as requested.

## Summary
`buildShortUrl` used the short-URL resource's `metadata.namespace` as the org ID in the query param. But the namespace is not the org ID — it is `default`, `org-<id>`, or `stacks-<id>`. So the copied URL payloaded `?orgId=org-5` (a namespace) instead of the real org id `5`, which broke the short-link redirect for anyone not in that literal namespace.

Changed `buildShortUrl` to use `config.bootData.user.orgId` (the current user's org) for the query param, and updated the tests to assert the real org id.

## Verification
- Rebases cleanly onto latest `main` (`3a385db`).
- 2 files changed, 11 insertions / 5 deletions: `public/app/core/utils/shortLinks.ts` + its test.
- Signed-off-by included.

Fixes https://github.com/grafana/grafana/issues/121641
