### PR TITLE
Search: match label filters on whole values

### DIFF
--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/blevesearch/bleve/v2"
+	"github.com/blevesearch/bleve/v2/analysis/analyzer/keyword"
 	"github.com/blevesearch/bleve/v2/analysis/analyzer/standard"
 	"github.com/blevesearch/bleve/v2/mapping"
 	"github.com/blevesearch/bleve/v2/search"
@@ -1705,6 +1706,8 @@ type bleveIndex struct {
 	index bleve.Index
 	// Index features this index was built with, from its build info.
 	features []resource.IndexFeature
+	// Whether this index holds label values whole, from its own mapping.
+	labelsAreKeyword bool
 	// Both are needed to tell "trash is off" from "trash is on but this index has
 	// not been rebuilt yet".
 	keepsDeletedDocuments bool
@@ -1784,6 +1787,7 @@ func (b *bleveBackend) newBleveIndex(
 		key:                   key,
 		index:                 index,
 		features:              features,
+		labelsAreKeyword:      labelAnalyzerIsKeyword(index),
 		keepsDeletedDocuments: slices.Contains(features, resource.IndexFeatureHoldsDeletedDocuments),
 		wantsDeletedDocuments: b.opts.IndexDeletedDocuments,
 		indexStorage:          newIndexType,
@@ -2995,12 +2999,33 @@ func (b *bleveIndex) textQueryKindFor(name string) textQueryKind {
 	if kind, ok := b.searchFields.textQueryKinds[name]; ok {
 		return kind
 	}
+	// Reference keys are dynamic, so the keyword sub-document is matched by prefix.
 	if strings.HasPrefix(name, referenceFieldPrefix) {
+		return textQueryTerm
+	}
+	// Label keys are dynamic too, but labels were text-analyzed until the keyword
+	// mapping shipped, so follow what this index actually holds.
+	if strings.HasPrefix(name, labelFieldPrefix) && b.labelsAreKeyword {
 		return textQueryTerm
 	}
 	// Undeclared fields (dynamically indexed, or named by a client we don't know
 	// about) keep the analyzed default.
 	return textQueryStandard
+}
+
+// labelAnalyzerIsKeyword reports whether an index holds label values whole. Read
+// from the index's own stored mapping, so an index written before labels became
+// keyword-analyzed is queried the way it was written. Any key answers for the
+// whole sub-document, which maps no key of its own.
+func labelAnalyzerIsKeyword(index bleve.Index) bool {
+	if index == nil {
+		return false
+	}
+	m := index.Mapping()
+	if m == nil {
+		return false
+	}
+	return m.AnalyzerNameForPath(labelFieldPrefix+"anyKey") == keyword.Name
 }
 
 // titleQueryFields expands a text query on the logical title field across its

--- a/pkg/storage/unified/search/bleve_mappings.go
+++ b/pkg/storage/unified/search/bleve_mappings.go
@@ -138,8 +138,9 @@ func (k keywordField) term(value string) string {
 // that keyword form lives, from the declarations that produced the mapping, so
 // the query side cannot drift from it (see keywordVariant).
 //
-// Keys are the names filters, sorts and facets arrive with. Labels are absent on
-// purpose: the label sub-document has no keyword analyzer.
+// Keys are the names filters, sorts and facets arrive with. Label keys are
+// absent because they are dynamic; a label filter is exact anyway, because bleve
+// analyzes it with the label sub-document's keyword analyzer.
 func keywordFieldsForMapping(provider resource.SearchFieldsProvider, group, kindResource string, selectableFields []string) map[string]keywordField {
 	fields := map[string]keywordField{}
 	add := func(key string, def resource.SearchFieldDefinition, prefix string) {
@@ -187,8 +188,8 @@ var standardKeywordFields = keywordFieldsForMapping(nil, "", "", nil)
 
 // keywordSubDocumentFields are keyword-mapped fields that live in sub-documents
 // and so are not modellable as SearchFieldDefinitions yet (see
-// managerSubDocumentMapping and sourceSubDocumentMapping). The labels
-// sub-document is deliberately absent: it has no keyword default analyzer.
+// managerSubDocumentMapping and sourceSubDocumentMapping). The labels and
+// reference sub-documents are absent because their keys are dynamic.
 var keywordSubDocumentFields = []string{
 	resource.SEARCH_FIELD_MANAGER_KIND,
 	resource.SEARCH_FIELD_MANAGER_ID,
@@ -199,6 +200,10 @@ var keywordSubDocumentFields = []string{
 // referenceFieldPrefix is the keyword-analyzed reference sub-document. Its keys
 // are resource kinds, so they cannot be enumerated up front.
 const referenceFieldPrefix = "reference."
+
+// labelFieldPrefix is the keyword-analyzed labels sub-document. Its keys are
+// label names, so they cannot be enumerated up front.
+const labelFieldPrefix = resource.SEARCH_FIELD_LABELS + "."
 
 // storedFacetFieldsForMapping returns the stored keyword field that post-rank
 // authorization can load for each facet-capable API field. Facet terms come
@@ -521,7 +526,10 @@ func getBleveDocMappings(provider resource.SearchFieldsProvider, group, kindReso
 	referenceMapper.DefaultAnalyzer = keyword.Name
 	mapper.AddSubDocumentMapping(strings.TrimSuffix(referenceFieldPrefix, "."), referenceMapper)
 
+	// Keyword so a label selector, which compares whole values case-sensitively,
+	// cannot match one word of a multi-word value.
 	labelMapper := bleve.NewDocumentMapping()
+	labelMapper.DefaultAnalyzer = keyword.Name
 	mapper.AddSubDocumentMapping(resource.SEARCH_FIELD_LABELS, labelMapper)
 
 	// Static so undeclared keys are dropped rather than dynamically indexed

--- a/pkg/storage/unified/search/bleve_mappings_internal_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_internal_test.go
@@ -408,7 +408,8 @@ func TestTextQueryKindsForMapping(t *testing.T) {
 	// Selectable fields are keyword-mapped.
 	assert.Equal(t, textQueryTerm, kinds[resource.SEARCH_SELECTABLE_FIELDS_PREFIX+"spec.slug"])
 
-	// Keyword-mapped sub-document fields, and labels which are not.
+	// Keyword-mapped sub-document fields. Label keys are dynamic, so
+	// textQueryKindFor matches them by prefix instead.
 	assert.Equal(t, textQueryTerm, kinds[resource.SEARCH_FIELD_MANAGER_KIND])
 	assert.Equal(t, textQueryTerm, kinds[resource.SEARCH_FIELD_SOURCE_PATH])
 	assert.NotContains(t, kinds, resource.SEARCH_FIELD_LABELS+".region")
@@ -422,9 +423,12 @@ func TestBleveIndex_textQueryKindFor(t *testing.T) {
 	assert.Equal(t, textQueryTerm, b.textQueryKindFor(resource.SEARCH_FIELD_TITLE_PHRASE))
 	// reference keys are dynamic, so the keyword sub-document is matched by prefix.
 	assert.Equal(t, textQueryTerm, b.textQueryKindFor("reference.datasource"))
-	// Undeclared fields fall back to the analyzed query.
+	// Undeclared fields fall back to the analyzed query, as do labels when there is
+	// no index to read the analyzer from (TestTextQueryKindFor_LabelsFollowIndexMapping).
+	assert.Equal(t, textQueryStandard, b.textQueryKindFor("somethingElse"))
 	assert.Equal(t, textQueryStandard, b.textQueryKindFor(resource.SEARCH_FIELD_LABELS+".region"))
 }
+
 func TestAddCapabilityFieldMappings_RetrieveOnly_StoreOnly(t *testing.T) {
 	// With no dynamic fallback, a retrieve-only field must be stored explicitly.
 	t.Run("int64", func(t *testing.T) {
@@ -658,9 +662,11 @@ func TestRequirementQuery_StandardExactFields(t *testing.T) {
 
 func TestFilterQueries_LabelsUseAnalyzedPath(t *testing.T) {
 	b := &bleveIndex{standard: resource.StandardSearchFields()}
-	// Labels are standard-analyzed, so every label filter goes through the
-	// analyzed path. "login" used to be an exception, hardcoded back when the
-	// exact-term decision was a name list.
+	// Label keys are dynamic, so label filters take the analyzed path. The value
+	// still matches whole, because bleve analyzes the MatchQuery with the label
+	// sub-document's keyword analyzer (TestLabelFilterExactMatch covers that end
+	// to end). "login" used to be an exception, hardcoded back when the exact-term
+	// decision was a name list.
 	req := &resourcepb.ResourceSearchRequest{Options: &resourcepb.ListOptions{
 		Labels: []*resourcepb.Requirement{{Key: "login", Operator: "in", Values: []string{"foo-bar"}}},
 	}}
@@ -675,7 +681,8 @@ func TestFilterQueries_LabelsUseAnalyzedPath(t *testing.T) {
 
 func TestFilterQueries_LabelNotInUsesAnalyzedPath(t *testing.T) {
 	b := &bleveIndex{standard: resource.StandardSearchFields()}
-	// A raw TermQuery here would fail to exclude standard-analyzed labels.
+	// The analyzed path keeps wildcard exclusions working, and the keyword
+	// analyzer makes a plain value exact anyway.
 	req := &resourcepb.ResourceSearchRequest{Options: &resourcepb.ListOptions{
 		Labels: []*resourcepb.Requirement{{Key: "login", Operator: "notin", Values: []string{"foo-bar"}}},
 	}}
@@ -689,6 +696,96 @@ func TestFilterQueries_LabelNotInUsesAnalyzedPath(t *testing.T) {
 	require.Len(t, mustNot.Disjuncts, 1)
 	_, ok = mustNot.Disjuncts[0].(*query.MatchQuery)
 	require.True(t, ok, "notin on a label should use an analyzed MatchQuery, not a raw TermQuery")
+}
+
+// labelIndex builds an in-memory index holding one document per label value,
+// named after its value. keywordLabels chooses between the current mapping and
+// the text-analyzed one every index used before it, so the same query can be run
+// against both.
+func labelIndex(t *testing.T, keywordLabels bool, key string, values ...string) bleve.Index {
+	t.Helper()
+	mappings, err := GetBleveMappings(nil, "", "", nil)
+	require.NoError(t, err)
+	if !keywordLabels {
+		im, ok := mappings.(*mapping.IndexMappingImpl)
+		require.True(t, ok)
+		im.DefaultMapping.Properties[resource.SEARCH_FIELD_LABELS].DefaultAnalyzer = ""
+	}
+	idx, err := bleve.NewMemOnly(mappings)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, idx.Close()) })
+	for _, value := range values {
+		require.NoError(t, idx.Index(value, map[string]any{resource.SEARCH_FIELD_LABELS: map[string]string{key: value}}))
+	}
+	return idx
+}
+
+// labelFilterHits returns the documents a label requirement matches in idx.
+func labelFilterHits(t *testing.T, idx bleve.Index, key, operator string, values ...string) []string {
+	t.Helper()
+	b := &bleveIndex{index: idx, labelsAreKeyword: labelAnalyzerIsKeyword(idx), standard: resource.StandardSearchFields()}
+	queries, errRes := b.filterQueries(&resourcepb.ResourceSearchRequest{Options: &resourcepb.ListOptions{
+		Labels: []*resourcepb.Requirement{{Key: key, Operator: operator, Values: values}},
+	}})
+	require.Nil(t, errRes)
+	require.Len(t, queries, 1)
+	res, err := idx.Search(bleve.NewSearchRequest(queries[0]))
+	require.NoError(t, err)
+	names := make([]string, 0, len(res.Hits))
+	for _, hit := range res.Hits {
+		names = append(names, hit.ID)
+	}
+	slices.Sort(names)
+	return names
+}
+
+// TestFilterQueries_LabelExactnessFollowsIndexMapping is the compatibility case:
+// bleve analyzes a MatchQuery with the analyzer stored in the index, so an index
+// written before labels were keyword-mapped keeps answering as it always has
+// instead of matching nothing.
+func TestFilterQueries_LabelExactnessFollowsIndexMapping(t *testing.T) {
+	// Values the text analyzer alters: case, a separator, and a word boundary.
+	values := []string{"Prod", "a/b", "Team Alpha", "true"}
+
+	t.Run("index written with the keyword mapping matches whole values", func(t *testing.T) {
+		idx := labelIndex(t, true, "env", values...)
+		for _, value := range values {
+			assert.Equal(t, []string{value}, labelFilterHits(t, idx, "env", "in", value))
+		}
+		assert.Empty(t, labelFilterHits(t, idx, "env", "in", "prod"), "exact means case-sensitive")
+		assert.Empty(t, labelFilterHits(t, idx, "env", "in", "alpha"), "a word of a value is not the value")
+	})
+
+	t.Run("index written before it still matches its analyzed tokens", func(t *testing.T) {
+		idx := labelIndex(t, false, "env", values...)
+		// The values an exact term query would silently stop matching here.
+		for _, value := range values {
+			assert.Equal(t, []string{value}, labelFilterHits(t, idx, "env", "in", value))
+		}
+		// The overmatching this mapping causes, until the index is rebuilt.
+		assert.Equal(t, []string{"Prod"}, labelFilterHits(t, idx, "env", "in", "prod"))
+		assert.Equal(t, []string{"Team Alpha"}, labelFilterHits(t, idx, "env", "in", "alpha"))
+		// A value that is only a stop word is dropped from both the document and the
+		// filter here, so it matches nothing. Pre-existing, and fixed by the keyword
+		// mapping above rather than caused by it.
+		assert.Empty(t, labelFilterHits(t, labelIndex(t, false, "env", "a"), "env", "in", "a"))
+		assert.Equal(t, []string{"a"}, labelFilterHits(t, labelIndex(t, true, "env", "a"), "env", "in", "a"))
+	})
+}
+
+// TestTextQueryKindFor_LabelsFollowIndexMapping covers the free-text path, where
+// the query kind is chosen by the binary rather than resolved by bleve, so it has
+// to read the analyzer out of the index.
+func TestTextQueryKindFor_LabelsFollowIndexMapping(t *testing.T) {
+	field := resource.SEARCH_FIELD_LABELS + ".env"
+
+	keywordIdx := labelIndex(t, true, "env", "Prod")
+	assert.True(t, labelAnalyzerIsKeyword(keywordIdx))
+	assert.Equal(t, textQueryTerm, (&bleveIndex{labelsAreKeyword: true}).textQueryKindFor(field))
+
+	textIdx := labelIndex(t, false, "env", "Prod")
+	assert.False(t, labelAnalyzerIsKeyword(textIdx))
+	assert.Equal(t, textQueryStandard, (&bleveIndex{}).textQueryKindFor(field))
 }
 
 func TestFilterQueries_DoesNotMutateRequest(t *testing.T) {

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -751,6 +751,126 @@ func TestTitleSetFilterExactMatch(t *testing.T) {
 	})
 }
 
+// TestLabelFilterExactMatch covers label selectors, which compare whole values
+// case-sensitively. /search does not re-apply the selector to the resource, so
+// whatever the index returns is the answer.
+func TestLabelFilterExactMatch(t *testing.T) {
+	key := resource.NamespacedResource{
+		Namespace: "default",
+		Group:     "dashboard.grafana.app",
+		Resource:  "dashboards",
+	}
+	seed := func(t *testing.T) resource.ResourceIndex {
+		index := newTestDashboardsIndex(t, threshold, 3, noop)
+		indexDocumentsWithLabels(t, index, key, map[string]map[string]string{
+			"name1": {"team": "Team Alpha"},
+			"name2": {"team": "alpha"},
+			"name3": {"team": "Team Beta"},
+		})
+		return index
+	}
+
+	for _, operator := range []string{"in", "="} {
+		t.Run(operator+" on a label matches the whole value", func(t *testing.T) {
+			checkSearchQuery(t, seed(t), labelFilterQuery(operator, "team", "Team Alpha"), []string{"name1"})
+		})
+
+		t.Run(operator+" on a label does not match a word of the value", func(t *testing.T) {
+			checkSearchQuery(t, seed(t), labelFilterQuery(operator, "team", "Team"), nil)
+			// "alpha" is a word of name1's value, and the whole value of name2.
+			checkSearchQuery(t, seed(t), labelFilterQuery(operator, "team", "alpha"), []string{"name2"})
+		})
+
+		t.Run(operator+" on a label is case sensitive", func(t *testing.T) {
+			checkSearchQuery(t, seed(t), labelFilterQuery(operator, "team", "team alpha"), nil)
+		})
+	}
+
+	t.Run("in on a label matches any listed value", func(t *testing.T) {
+		checkSearchQuery(t, seed(t), labelFilterQuery("in", "team", "Team Alpha", "Team Beta"), []string{"name1", "name3"})
+	})
+
+	t.Run("notin on a label excludes the whole value only", func(t *testing.T) {
+		checkSearchQuery(t, seed(t), labelFilterQuery("notin", "team", "Team Alpha"), []string{"name2", "name3"})
+		// The failure mode here is excluding too much.
+		checkSearchQuery(t, seed(t), labelFilterQuery("notin", "team", "Team"), []string{"name1", "name2", "name3"})
+		checkSearchQuery(t, seed(t), labelFilterQuery("notin", "team", "alpha"), []string{"name1", "name3"})
+	})
+
+	t.Run("wildcard label values still match", func(t *testing.T) {
+		checkSearchQuery(t, seed(t), labelFilterQuery("in", "team", "Team*"), []string{"name1", "name3"})
+		checkSearchQuery(t, seed(t), labelFilterQuery("notin", "team", "Team*"), []string{"name2"})
+	})
+
+	t.Run("filter on a label the document does not carry matches nothing", func(t *testing.T) {
+		checkSearchQuery(t, seed(t), labelFilterQuery("in", "other", "Team Alpha"), nil)
+	})
+
+	t.Run("values sharing a word do not match each other", func(t *testing.T) {
+		// Label values are identifiers, and a hyphen is a word boundary to the text
+		// analyzer, which is how these used to match each other.
+		index := newTestDashboardsIndex(t, threshold, 4, noop)
+		indexDocumentsWithLabels(t, index, key, map[string]map[string]string{
+			"ops":    {"team": "platform-ops"},
+			"eng":    {"team": "platform-engineering"},
+			"foo":    {"env": "foo"},
+			"foobar": {"env": "foo-bar"},
+		})
+		checkSearchQuery(t, index, labelFilterQuery("in", "team", "platform-ops"), []string{"ops"})
+		checkSearchQuery(t, index, labelFilterQuery("in", "env", "foo"), []string{"foo"})
+		checkSearchQuery(t, index, labelFilterQuery("notin", "env", "foo"), []string{"eng", "foobar", "ops"})
+	})
+
+	t.Run("a label is returned as written", func(t *testing.T) {
+		// Stored values are not analyzed, so retrieval is unaffected by the mapping.
+		q := labelFilterQuery("in", "team", "Team Alpha")
+		q.Fields = []string{"labels.team"}
+		res, err := seed(t).Search(context.Background(), nil, q, nil, nil)
+		require.NoError(t, err)
+		require.Len(t, res.Results.Rows, 1)
+		require.Equal(t, "Team Alpha", string(res.Results.Rows[0].Cells[0]))
+	})
+}
+
+func indexDocumentsWithLabels(t *testing.T, index resource.ResourceIndex, key resource.NamespacedResource, docsWithLabels map[string]map[string]string) {
+	items := make([]*resource.BulkIndexItem, 0, len(docsWithLabels))
+	for name, labels := range docsWithLabels {
+		items = append(items, &resource.BulkIndexItem{
+			Action: resource.ActionIndex,
+			Doc: &resource.IndexableDocument{
+				RV:   1,
+				Name: name,
+				Key: &resourcepb.ResourceKey{
+					Name:      name,
+					Namespace: key.Namespace,
+					Group:     key.Group,
+					Resource:  key.Resource,
+				},
+				Title:  name,
+				Labels: labels,
+			},
+		})
+	}
+	require.NoError(t, index.BulkIndex(&resource.BulkIndexRequest{Items: items}))
+}
+
+func labelFilterQuery(operator, key string, values ...string) *resourcepb.ResourceSearchRequest {
+	return &resourcepb.ResourceSearchRequest{
+		Options: &resourcepb.ListOptions{
+			Key: &resourcepb.ResourceKey{
+				Namespace: "default",
+				Group:     "dashboard.grafana.app",
+				Resource:  "dashboards",
+			},
+			Labels: []*resourcepb.Requirement{{Key: key, Operator: operator, Values: values}},
+		},
+		// Sort by name so multi-hit expectations are deterministic (filters alone
+		// impose no order).
+		SortBy: []*resourcepb.ResourceSearchRequest_Sort{{Field: resource.SEARCH_FIELD_NAME}},
+		Limit:  100000,
+	}
+}
+
 // TestPublicFieldNameFilter checks the filter path resolves a public field name
 // to its physical fields.* location, so callers don't supply the prefix.
 func TestPublicFieldNameFilter(t *testing.T) {

--- a/pkg/storage/unified/search/testdata/bleve_mapping_dashboard.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_dashboard.json
@@ -376,7 +376,8 @@
       },
       "labels": {
         "enabled": true,
-        "dynamic": true
+        "dynamic": true,
+        "default_analyzer": "keyword"
       },
       "managedBy": {
         "enabled": true,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_empty.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_empty.json
@@ -123,7 +123,8 @@
       },
       "labels": {
         "enabled": true,
-        "dynamic": true
+        "dynamic": true,
+        "default_analyzer": "keyword"
       },
       "managedBy": {
         "enabled": true,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_external_group_mapping.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_external_group_mapping.json
@@ -151,7 +151,8 @@
       },
       "labels": {
         "enabled": true,
-        "dynamic": true
+        "dynamic": true,
+        "default_analyzer": "keyword"
       },
       "managedBy": {
         "enabled": true,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_provider_driven.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_provider_driven.json
@@ -172,7 +172,8 @@
       },
       "labels": {
         "enabled": true,
-        "dynamic": true
+        "dynamic": true,
+        "default_analyzer": "keyword"
       },
       "managedBy": {
         "enabled": true,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_selectable_fields.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_selectable_fields.json
@@ -123,7 +123,8 @@
       },
       "labels": {
         "enabled": true,
-        "dynamic": true
+        "dynamic": true,
+        "default_analyzer": "keyword"
       },
       "managedBy": {
         "enabled": true,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_team.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_team.json
@@ -187,7 +187,8 @@
       },
       "labels": {
         "enabled": true,
-        "dynamic": true
+        "dynamic": true,
+        "default_analyzer": "keyword"
       },
       "managedBy": {
         "enabled": true,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_team_binding.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_team_binding.json
@@ -173,7 +173,8 @@
       },
       "labels": {
         "enabled": true,
-        "dynamic": true
+        "dynamic": true,
+        "default_analyzer": "keyword"
       },
       "managedBy": {
         "enabled": true,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_user.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_user.json
@@ -199,7 +199,8 @@
       },
       "labels": {
         "enabled": true,
-        "dynamic": true
+        "dynamic": true,
+        "default_analyzer": "keyword"
       },
       "managedBy": {
         "enabled": true,


### PR DESCRIPTION
Label values were indexed with the default text analyzer, so they were split into words and lowercased. A filter for one value matched others sharing a word: `env=foo` matched `env=foo-bar`, `platform-ops` matched `platform-engineering`. `notin` excluded too much for the same reason. Label selectors compare whole values case-sensitively, so both directions were wrong.

The labels sub-document now uses the keyword analyzer, like `reference.` already does. Fixes grafana/search-and-storage-team#805.

**No forced rebuild and no index feature.** Bleve stores the mapping in the index and resolves a match query's analyzer from it, and label filters build match queries — so each index is queried the way it was written. Old indexes keep today's behaviour, rebuilt ones are exact, and a downgrade rebuilds through the existing build-version check. Only the free-text path needed a code change, since it picks the query type in Go.

Worth knowing:

- `/search` label filters are not exact until an index is rebuilt. A plain upgrade does not rebuild; bumping `min_file_index_build_version` is the lever, as a separate operational decision.
- LIST is unaffected: the apistore re-applies the selector to each decoded object.
- Now case-sensitive on rebuilt indexes: `team alpha` no longer matches `Team Alpha`.
- No caller relies on the old behaviour (audit in grafana/search-and-storage-team#805).

Tests cover the named cases from grafana/search-and-storage-team#805 and #930 in both directions, plus one index per mapping to pin that older indexes still answer as they do today.
