### PR TITLE
Search: update label filter comments after the analyzer fix

### DIFF
--- a/pkg/registry/apis/search/translate.go
+++ b/pkg/registry/apis/search/translate.go
@@ -466,11 +466,12 @@ func filterRequirement(f *searchv0.FilterPredicate) *resourcepb.Requirement {
 	return &resourcepb.Requirement{Key: f.Field, Operator: op, Values: f.Values}
 }
 
-// applyLabelSelector lowers the selector onto Options.Labels. Exact-match label
-// semantics are a backend prerequisite: labels are indexed with the default
-// analyzer, so In/NotIn currently overmatch (env=foo matches env=foo-bar). This
-// endpoint does not re-apply the selector to full resources, so the backend
-// needs keyword label mapping/querying (or a post-filter) before /search wires.
+// applyLabelSelector lowers the selector onto Options.Labels. The backend now
+// indexes label values whole, so In/NotIn match exactly and case-sensitively.
+// An index built before that change still holds analyzed values and keeps
+// overmatching (env=foo matches env=foo-bar) until it is rebuilt, and this
+// endpoint does not re-apply the selector to full resources, so its answers are
+// only as exact as the index it read.
 func applyLabelSelector(req *resourcepb.ResourceSearchRequest, sel *metav1.LabelSelector) {
 	if sel == nil {
 		return

--- a/pkg/registry/apps/alerting/rules/search/query.go
+++ b/pkg/registry/apps/alerting/rules/search/query.go
@@ -360,12 +360,10 @@ var selectableLabelKeys = map[string]struct{}{
 // generic search.grafana.app translation), not on the rules' spec labels: those
 // are filtered through a where filter leaf on the indexed "labels" field.
 //
-// Known limitation on the unified backend: metadata labels are indexed with the
-// default analyzer, so value matching can overmatch on values that share a
-// prefix segment (the same caveat the generic search translator carries).
-// Exact-match label semantics in the backend are the fix; until then, restrict
-// selection to the controlled keys below, whose values are generated and do not
-// collide in practice.
+// The unified backend now indexes label values whole, so matching is exact on any
+// index built since. An index built before that still overmatches values sharing
+// a word, until it is rebuilt, which is one reason selection stays restricted to
+// selectableLabelKeys, whose values are generated and do not collide in practice.
 func applyLabelSelector(req *resourcepb.ResourceSearchRequest, selector *string) error {
 	if selector == nil || *selector == "" {
 		return nil


### PR DESCRIPTION
Both label selector translators carried a comment saying exact label matching was still missing in the backend. It has since landed: label values are indexed whole, so `In`/`NotIn` match exactly and case-sensitively.

What remains is narrower, and the comments now say that instead: an index built before the analyzer change still holds analyzed values and keeps overmatching until it is rebuilt, and `/search` does not re-apply the selector to the resource, so its answers are only as exact as the index it read.

Comments only, no behaviour change. Also corrects a stale "the controlled keys below" in the alerting comment, since `selectableLabelKeys` is declared above it.
