### PR TITLE
Search: check the sort capability in the backend

### DIFF
--- a/apps/iam/kinds/user.cue
+++ b/apps/iam/kinds/user.cue
@@ -30,14 +30,16 @@ userv0alpha1: userKind & {
 			name: "email"
 			path: "spec.email"
 			type: "string"
-			capabilities: ["filter", "retrieve"]
+			// sort: user search offers ?sort=email.
+			capabilities: ["filter", "sort", "retrieve"]
 			description: "The email address of the user"
 		},
 		{
 			name: "login"
 			path: "spec.login"
 			type: "string"
-			capabilities: ["filter", "retrieve"]
+			// sort: user search sorts by login when no sort is given.
+			capabilities: ["filter", "sort", "retrieve"]
 			description: "The login of the user"
 		},
 		{

--- a/apps/iam/pkg/apis/iam_manifest.go
+++ b/apps/iam/pkg/apis/iam_manifest.go
@@ -77,14 +77,14 @@ var appManifestData = app.ManifestData{
 							Name:         "email",
 							Path:         "spec.email",
 							Type:         "string",
-							Capabilities: []string{"filter", "retrieve"},
+							Capabilities: []string{"filter", "sort", "retrieve"},
 							Description:  "The email address of the user",
 						},
 						{
 							Name:         "login",
 							Path:         "spec.login",
 							Type:         "string",
-							Capabilities: []string{"filter", "retrieve"},
+							Capabilities: []string{"filter", "sort", "retrieve"},
 							Description:  "The login of the user",
 						},
 						{

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -764,6 +764,10 @@ type Cfg struct {
 	SearchInjectFailuresPercent                int
 	EnableSearch                               bool
 	EnableSearchClient                         bool
+	// SearchEnforceSortCapability rejects a sort on a field that does not declare
+	// sorting. Off by default: violations are counted first, so they can be fixed
+	// before requests start failing.
+	SearchEnforceSortCapability bool
 	// SearchPostRankAuthz enables the post-filter authorization search path:
 	// bleve ranks without the in-searcher authz wrapper and authorization runs
 	// app-side in rank order with early exit once the page is filled.

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -182,6 +182,7 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 		cfg.SearchInjectFailuresPercent = 100
 	}
 	cfg.EnableSearch = section.Key("enable_search").MustBool(true)
+	cfg.SearchEnforceSortCapability = section.Key("search_enforce_sort_capability").MustBool(false)
 	cfg.SearchPostRankAuthz = section.Key("search_post_rank_authz").MustBool(false)
 	// Zero values keep the search.PostRankAuthzConfig.effective() defaults.
 	cfg.SearchPostRankAuthzOverFetchFactor = section.Key("search_post_rank_authz_over_fetch_factor").MustInt(0)

--- a/pkg/storage/unified/resource/bleve_index_metrics.go
+++ b/pkg/storage/unified/resource/bleve_index_metrics.go
@@ -33,6 +33,8 @@ type BleveIndexMetrics struct {
 
 	IndexDiskCleanupRuns        *prometheus.CounterVec
 	IndexDiskCleanupDirsDeleted *prometheus.CounterVec
+
+	SearchCapabilityViolations *prometheus.CounterVec
 }
 
 var IndexCreationBuckets = []float64{1, 5, 10, 25, 50, 75, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000}
@@ -149,6 +151,10 @@ func ProvideIndexMetrics(reg prometheus.Registerer) *BleveIndexMetrics {
 			Name: "index_server_disk_cleanup_dirs_deleted_total",
 			Help: "Number of on-disk directories the disk cleanup pass attempted to delete, by kind and outcome.",
 		}, []string{"kind", "outcome"}), // kind: index, snapshot_staging. outcome: success, error
+		SearchCapabilityViolations: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "index_server_search_capability_violations_total",
+			Help: "Number of search requests that used a field in a way its declaration does not allow. Counted whether or not the request was rejected.",
+		}, []string{"resource", "capability"}),
 	}
 
 	// Always-on label series. Snapshot-specific series are initialised separately

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -126,6 +126,11 @@ type BleveOptions struct {
 	// cannot leave trash missing what was deleted while it was off.
 	IndexDeletedDocuments bool
 
+	// EnforceSortCapability rejects a sort on a field that does not declare the
+	// sort capability. When false the violation is only counted, so an operator
+	// can see what real traffic would break before turning this on.
+	EnforceSortCapability bool
+
 	// PostRankAuthzEnabled enables the post-filter (post-rank) authorization
 	// path. Set from the search_post_rank_authz config option at backend init.
 	// When false, the in-searcher permissionScopedQuery path is used.
@@ -1757,6 +1762,8 @@ type bleveIndex struct {
 	// stored in Bleve internal data, so concurrent BulkIndex calls don't lose increments.
 	snapshotMutationMu sync.Mutex
 
+	enforceSortCapability bool
+
 	// postRankAuthzEnabled enables the post-ranking authz path. When false,
 	// the in-searcher permissionScopedQuery path is used.
 	postRankAuthzEnabled bool
@@ -1798,6 +1805,7 @@ func (b *bleveBackend) newBleveIndex(
 		updaterFn:             updaterFn,
 		minUpdateInterval:     b.opts.IndexMinUpdateInterval,
 		indexMetrics:          b.indexMetrics,
+		enforceSortCapability: b.opts.EnforceSortCapability,
 		postRankAuthzEnabled:  b.opts.PostRankAuthzEnabled,
 		postRankAuthz:         b.opts.PostRankAuthz.effective(),
 		trashRetention:        b.opts.TrashRetention,
@@ -2537,6 +2545,10 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 		// scan loads the stored facet fields on its own request copy
 		// (facetScanFields), separate from the response column list.
 		searchrequest.Facets = nil
+	}
+
+	if errResult := b.checkSortCapability(req); errResult != nil {
+		return nil, errResult
 	}
 
 	// Add the sort fields
@@ -3290,6 +3302,38 @@ const (
 	lowerCase            = "phrase"
 	whitespaceCharacters = " \t\r\n"
 )
+
+// checkSortCapability holds a sort to what the field declares. A field that is
+// not indexed at all (a retrieve-only number, or a name no version declares)
+// silently comes back in an arbitrary order.
+func (b *bleveIndex) checkSortCapability(req *resourcepb.ResourceSearchRequest) *resourcepb.ErrorResult {
+	for _, sort := range req.SortBy {
+		if b.sortableField(sort.Field) {
+			continue
+		}
+		if b.indexMetrics != nil {
+			b.indexMetrics.SearchCapabilityViolations.WithLabelValues(b.key.Resource, string(resource.SearchCapabilitySort)).Inc()
+		}
+		if !b.enforceSortCapability {
+			b.logger.Warn("search sorts on a field that does not declare the sort capability", "field", sort.Field)
+			continue
+		}
+		return resource.NewBadRequestError(fmt.Sprintf("field %q does not support sorting", sort.Field))
+	}
+	return nil
+}
+
+// sortableField reports whether a request may sort on this field name.
+func (b *bleveIndex) sortableField(key string) bool {
+	fields := b.searchFields.sortableFields
+	if fields == nil {
+		// Index opened without per-kind declarations; standard fields still apply.
+		fields = standardSortableFields
+	}
+	// Both the bare and the prefixed name are keys, so no trimming here: a bare
+	// name a standard field owns must not become sortable under the prefix.
+	return fields[key]
+}
 
 // keywordFieldFor reports the keyword-analyzed index field backing a filter or
 // sort field, and false when the field has no keyword form.

--- a/pkg/storage/unified/search/bleve_mappings.go
+++ b/pkg/storage/unified/search/bleve_mappings.go
@@ -31,6 +31,8 @@ type kindSearchFields struct {
 	// textQueryKinds maps physical index field names to the query their analyzer
 	// needs.
 	textQueryKinds map[string]textQueryKind
+	// sortableFields holds the names a request may sort on.
+	sortableFields map[string]bool
 	// variants drives the index-time copy of per-kind values into the variant
 	// fields this kind's mapping declares.
 	variants []fieldVariant
@@ -42,6 +44,7 @@ func newKindSearchFields(provider resource.SearchFieldsProvider, group, kindReso
 		numberOrBoolFields: numberOrBoolFieldsForMapping(provider, group, kindResource),
 		storedFacetFields:  storedFacetFieldsForMapping(provider, group, kindResource),
 		textQueryKinds:     textQueryKindsForMapping(provider, group, kindResource, selectableFields),
+		sortableFields:     sortableFieldsForMapping(provider, group, kindResource),
 		variants:           fieldVariantsOf(fieldDefinitionsForMapping(provider, group, kindResource)),
 	}
 }
@@ -190,6 +193,43 @@ func keywordFieldsForMapping(provider resource.SearchFieldsProvider, group, kind
 
 // standardKeywordFields covers an index opened without per-kind declarations.
 var standardKeywordFields = keywordFieldsForMapping(nil, "", "", nil)
+
+// sortableFieldsForMapping derives which field names a request may sort on from
+// the declarations that produced the mapping.
+//
+// Keys are the names sorts arrive with. Labels and selectable fields are absent
+// because they declare no capabilities and exist to be filtered on.
+func sortableFieldsForMapping(provider resource.SearchFieldsProvider, group, kindResource string) map[string]bool {
+	fields := map[string]bool{}
+	add := func(key string, def resource.SearchFieldDefinition) {
+		if def.HasCapability(resource.SearchCapabilitySort) {
+			fields[key] = true
+		}
+	}
+
+	for _, def := range resource.StandardSearchFieldDefinitions() {
+		add(def.Name, def)
+		// Callers that name a physical title variant directly still mean title.
+		if def.Name == resource.SEARCH_FIELD_TITLE {
+			add(resource.SEARCH_FIELD_TITLE_PHRASE, def)
+		}
+	}
+	for _, def := range resource.TrashSearchFieldDefinitions() {
+		add(def.Name, def)
+	}
+	for _, def := range fieldDefinitionsForMapping(provider, group, kindResource) {
+		add(resource.SEARCH_FIELD_PREFIX+def.Name, def)
+		// A bare name a standard field already uses resolves to the standard field
+		// (see resolveFieldName), so a per-kind declaration cannot widen it.
+		if !isReservedTopLevelField(def.Name) {
+			add(def.Name, def)
+		}
+	}
+	return fields
+}
+
+// standardSortableFields covers an index opened without per-kind declarations.
+var standardSortableFields = sortableFieldsForMapping(nil, "", "")
 
 // filterable is separate from the type because such a field can be indexed for
 // sorting alone, or only stored.

--- a/pkg/storage/unified/search/bleve_mappings_internal_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_internal_test.go
@@ -285,6 +285,45 @@ func TestKeywordFieldsForMapping_StandardNameWins(t *testing.T) {
 	assert.Equal(t, resource.SEARCH_FIELD_PREFIX+resource.SEARCH_FIELD_TAGS, fields[resource.SEARCH_FIELD_PREFIX+resource.SEARCH_FIELD_TAGS].name)
 }
 
+func TestSortableFieldsForMapping(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "example.test", Version: "v1", Resource: "widgets"}
+	provider := resource.NewMapProvider(map[schema.GroupVersionResource][]resource.SearchFieldDefinition{
+		gvr: {
+			{Name: "note", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilitySort}},
+			{Name: "category", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter}},
+			{Name: "views", Type: resource.SearchFieldTypeInt64, Capabilities: []resource.SearchCapability{resource.SearchCapabilitySort}},
+			// Must not make the standard "created" field sortable.
+			{Name: resource.SEARCH_FIELD_CREATED, Type: resource.SearchFieldTypeInt64, Capabilities: []resource.SearchCapability{resource.SearchCapabilitySort}},
+		},
+	}, nil)
+
+	fields := sortableFieldsForMapping(provider, gvr.Group, gvr.Resource)
+
+	// A sort may name a per-kind field with or without the prefix.
+	assert.True(t, fields["fields.note"])
+	assert.True(t, fields["note"])
+	assert.True(t, fields["fields.views"])
+	assert.True(t, fields["views"])
+	// Standard fields, including the physical title variant clients name directly.
+	assert.True(t, fields[resource.SEARCH_FIELD_TITLE])
+	assert.True(t, fields[resource.SEARCH_FIELD_TITLE_PHRASE])
+	assert.True(t, fields[resource.SEARCH_FIELD_NAME])
+	assert.True(t, fields[resource.SEARCH_FIELD_FOLDER])
+	assert.True(t, fields[resource.SEARCH_FIELD_DELETION_TIME])
+	// Selectable fields exist to be filtered on; nothing sorts on them.
+	assert.False(t, fields[resource.SEARCH_SELECTABLE_FIELDS_PREFIX+"spec.slug"])
+
+	// Declared, but not with sort.
+	assert.False(t, fields["fields.category"])
+	assert.False(t, fields["category"])
+	// Retrieve-only standard fields, and a name nothing declares.
+	assert.False(t, fields[resource.SEARCH_FIELD_CREATED])
+	assert.False(t, fields[resource.SEARCH_FIELD_UPDATED])
+	assert.False(t, fields[resource.SEARCH_FIELD_DESCRIPTION])
+	assert.False(t, fields["nonexistent"])
+	// The per-kind field shadowing "created" is only reachable under the prefix.
+	assert.True(t, fields[resource.SEARCH_FIELD_PREFIX+resource.SEARCH_FIELD_CREATED])
+}
 func TestStoredFacetFieldsForMapping(t *testing.T) {
 	gvr := schema.GroupVersionResource{Group: "example.test", Version: "v1", Resource: "widgets"}
 	provider := resource.NewMapProvider(map[schema.GroupVersionResource][]resource.SearchFieldDefinition{

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -953,6 +953,131 @@ func TestBleveSearchRequestDefaultSortIncludesNameTieBreaker(t *testing.T) {
 	})
 }
 
+// TestBleveSortCapabilityCheck covers both the counting and the rejecting mode.
+func TestBleveSortCapabilityCheck(t *testing.T) {
+	const group, kindResource = "example.grafana.app", "widgets"
+	// v1 and v2 declare different fields on purpose: a request naming no version
+	// is validated against the union.
+	provider := resource.NewMapProvider(map[schema.GroupVersionResource][]resource.SearchFieldDefinition{
+		{Group: group, Version: "v1", Resource: kindResource}: {
+			{
+				Name:         "note",
+				Type:         resource.SearchFieldTypeString,
+				Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilitySort},
+			},
+			{
+				Name:         "category",
+				Type:         resource.SearchFieldTypeString,
+				Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilityRetrieve},
+			},
+		},
+		{Group: group, Version: "v2", Resource: kindResource}: {
+			{
+				Name:         "weight",
+				Type:         resource.SearchFieldTypeInt64,
+				Capabilities: []resource.SearchCapability{resource.SearchCapabilitySort, resource.SearchCapabilityRetrieve},
+			},
+		},
+	}, map[schema.GroupResource]string{{Group: group, Resource: kindResource}: "v1"})
+
+	newIndex := func(enforce bool) *bleveIndex {
+		return &bleveIndex{
+			key:                   resource.NamespacedResource{Namespace: "ns", Group: group, Resource: kindResource},
+			fields:                resource.StandardSearchFields(),
+			searchFields:          newKindSearchFields(provider, group, kindResource, []string{"spec.slug"}),
+			enforceSortCapability: enforce,
+			logger:                log.NewNopLogger(),
+		}
+	}
+
+	sortBy := func(field string) *resourcepb.ResourceSearchRequest {
+		return &resourcepb.ResourceSearchRequest{
+			Options: &resourcepb.ListOptions{},
+			Limit:   10,
+			SortBy:  []*resourcepb.ResourceSearchRequest_Sort{{Field: field}},
+		}
+	}
+
+	accepted := []struct {
+		name  string
+		field string
+	}{
+		{"standard sortable field", resource.SEARCH_FIELD_TITLE},
+		{"physical title variant", resource.SEARCH_FIELD_TITLE_PHRASE},
+		{"name", resource.SEARCH_FIELD_NAME},
+		{"folder", resource.SEARCH_FIELD_FOLDER},
+		{"per-kind field, bare name", "note"},
+		{"per-kind field, prefixed name", resource.SEARCH_FIELD_PREFIX + "note"},
+		// Declared by v2 only.
+		{"field declared by another version", resource.SEARCH_FIELD_PREFIX + "weight"},
+	}
+	for _, tc := range accepted {
+		t.Run("accepts "+tc.name, func(t *testing.T) {
+			searchReq, errResult := newIndex(true).toBleveSearchRequest(t.Context(), sortBy(tc.field), nil, false, nil)
+			require.Nil(t, errResult)
+			require.NotNil(t, searchReq)
+		})
+	}
+
+	rejected := []struct {
+		name  string
+		field string
+	}{
+		{"standard retrieve-only field", resource.SEARCH_FIELD_CREATED},
+		{"per-kind field without sort", "category"},
+		{"per-kind field without sort, prefixed", resource.SEARCH_FIELD_PREFIX + "category"},
+		{"undeclared field", "nonexistent"},
+		{"label", "labels.region"},
+		// A standard field lives top-level, so nothing is indexed under this path.
+		{"standard field under the per-kind prefix", resource.SEARCH_FIELD_PREFIX + resource.SEARCH_FIELD_TITLE},
+		// Selectable fields exist to be filtered on; nothing sorts on them.
+		{"selectable field", resource.SEARCH_SELECTABLE_FIELDS_PREFIX + "spec.slug"},
+	}
+	for _, tc := range rejected {
+		t.Run("rejects "+tc.name, func(t *testing.T) {
+			searchReq, errResult := newIndex(true).toBleveSearchRequest(t.Context(), sortBy(tc.field), nil, false, nil)
+			require.Nil(t, searchReq)
+			require.NotNil(t, errResult)
+			assert.Contains(t, errResult.Message, fmt.Sprintf("field %q does not support sorting", tc.field))
+		})
+
+		t.Run("counts but allows "+tc.name+" with enforcement off", func(t *testing.T) {
+			idx := newIndex(false)
+			reg := prometheus.NewPedanticRegistry()
+			idx.indexMetrics = resource.ProvideIndexMetrics(reg)
+
+			searchReq, errResult := idx.toBleveSearchRequest(t.Context(), sortBy(tc.field), nil, false, nil)
+			require.Nil(t, errResult)
+			require.NotNil(t, searchReq)
+			assert.Equal(t, 1, testutil.CollectAndCount(idx.indexMetrics.SearchCapabilityViolations, "index_server_search_capability_violations_total"))
+		})
+	}
+
+	// Trash fields are refused on a live search, so they cannot go in the list above.
+	t.Run("accepts a trash field when searching deleted resources", func(t *testing.T) {
+		idx := newIndex(true)
+		idx.keepsDeletedDocuments = true
+		idx.wantsDeletedDocuments = true
+		req := sortBy(resource.SEARCH_FIELD_DELETION_TIME)
+		req.IsDeleted = true
+		_, errResult := idx.toBleveSearchRequest(t.Context(), req, nil, false, nil)
+		require.Nil(t, errResult)
+	})
+
+	t.Run("an index without declarations still allows standard sortable fields", func(t *testing.T) {
+		idx := &bleveIndex{
+			fields:                resource.StandardSearchFields(),
+			enforceSortCapability: true,
+			logger:                log.NewNopLogger(),
+		}
+		_, errResult := idx.toBleveSearchRequest(t.Context(), sortBy(resource.SEARCH_FIELD_TITLE), nil, false, nil)
+		require.Nil(t, errResult)
+
+		_, errResult = idx.toBleveSearchRequest(t.Context(), sortBy(resource.SEARCH_FIELD_CREATED), nil, false, nil)
+		require.NotNil(t, errResult)
+	})
+}
+
 var _ authlib.AccessClient = (*StubAccessClient)(nil)
 
 func NewStubAccessClient(permissions map[string]bool) *StubAccessClient {

--- a/pkg/storage/unified/search/options.go
+++ b/pkg/storage/unified/search/options.go
@@ -115,6 +115,7 @@ func NewSearchOptions(
 			DiskCleanupGracePeriod:         cfg.DiskIndexCleanupGracePeriod,
 			DiskCleanupUnopenedGracePeriod: cfg.DiskIndexCleanupUnopenedGracePeriod,
 			PostRankAuthzEnabled:           cfg.SearchPostRankAuthz,
+			EnforceSortCapability:          cfg.SearchEnforceSortCapability,
 			IndexDeletedDocuments:          cfg.IndexDeletedDocuments,
 			PostRankAuthz: PostRankAuthzConfig{
 				OverFetchFactor: cfg.SearchPostRankAuthzOverFetchFactor,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_user.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_user.json
@@ -127,6 +127,7 @@
                 "analyzer": "keyword",
                 "store": true,
                 "index": true,
+                "docvalues": true,
                 "skip_freq_norm": true
               }
             ]
@@ -164,6 +165,7 @@
                 "analyzer": "keyword",
                 "store": true,
                 "index": true,
+                "docvalues": true,
                 "skip_freq_norm": true
               }
             ]


### PR DESCRIPTION
The search backend accepted a sort on any field name. A field that is not indexed — a retrieve-only number, or a name no version declares — came back in an arbitrary order with no error. Search v1 already checks this; the legacy gRPC callers bypass it.

Sorts are now held to what the field declares, against the union of fields across served versions. A violation is counted in `index_server_search_capability_violations_total` and logged, and only rejected when `search_enforce_sort_capability` is on. It is off by default so real traffic can be checked first.

IAM's user kind now declares `sort` on `login` and `email`, which user search already sorts by. That adds doc values to both keyword fields, so IAM indexes rebuild once.

Once enforcement is on, dashboard search returns 400 for `?sort=` on `panel_types`, `ds_types`, `transformation`, `created`, `updated`, `schema_version` and `link_count`. No in-tree caller sends these, and the last four are already silently unsorted.

Filtering and faceting are already checked and untouched. The `text` capability is deliberately not checked: IAM user search queries keyword-only `login` and `email` on purpose.

Tracked on grafana/search-and-storage-team#869.
