### PR TITLE
Dashboards: Support panel and URL provided transformations

### DIFF
--- a/packages/grafana-schema/src/raw/composable/debug/panelcfg/x/types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/debug/panelcfg/x/types.gen.ts
@@ -24,6 +24,7 @@ export enum DebugMode {
   Render = 'render',
   State = 'State',
   ThrowError = 'ThrowError',
+  Transformations = 'transformations',
 }
 
 export interface Options {

--- a/packages/grafana-ui/src/components/PanelChrome/PanelContext.ts
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelContext.ts
@@ -3,9 +3,11 @@ import { createContext, useContext } from 'react';
 import {
   type AnnotationEventUIModel,
   type CoreApp,
+  type CustomTransformOperator,
   type DashboardCursorSync,
   type DataFrame,
   type DataLinkPostProcessor,
+  type DataTransformerConfig,
   type EventBus,
   EventBusSrv,
 } from '@grafana/data';
@@ -85,6 +87,19 @@ export interface PanelContext {
    * in a the Promise resolving to a false value.
    */
   onUpdateData?: (frames: DataFrame[]) => Promise<boolean>;
+
+  /**
+   * Sets panel provided (system) transformations that are combined with the user configured ones.
+   * Prepended transformations run before the user transformations, appended ones after.
+   * Repeated calls replace the previous system transformations, calling with empty arrays clears them.
+   * Only supported in dashboard panel context currently.
+   *
+   * @alpha -- experimental
+   */
+  onSetSystemTransformations?: (transformations: {
+    prepend?: Array<DataTransformerConfig | CustomTransformOperator>;
+    append?: Array<DataTransformerConfig | CustomTransformOperator>;
+  }) => void;
 
   /**
    * Optional supplier for internal data links. If not provided a link pointing to Explore will be generated.

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataTransformationsTab.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataTransformationsTab.test.tsx
@@ -64,6 +64,23 @@ describe('PanelDataTransformationsModel', () => {
     transformsTab.onChangeTransformations([{ id: 'calculateField', options: {} }]);
     expect(transformsTab.getDataTransformer().state.transformations).toEqual([{ id: 'calculateField', options: {} }]);
   });
+
+  it('preserves system transformations when changing user transformations', () => {
+    const { transformsTab } = setupTabScene('panel-1');
+    const transformer = transformsTab.getDataTransformer();
+    transformer.setSystemTransformations({
+      prepend: [{ id: 'limit', options: {} }],
+      append: [{ id: 'reduce', options: {} }],
+    });
+
+    transformsTab.onChangeTransformations([{ id: 'calculateField', options: {} }]);
+
+    expect(transformer.state.transformations).toEqual([
+      { id: 'limit', options: {}, origin: 'system', position: 'prepend' },
+      { id: 'calculateField', options: {} },
+      { id: 'reduce', options: {}, origin: 'system', position: 'append' },
+    ]);
+  });
 });
 
 describe('PanelDataTransformationsTab', () => {
@@ -161,6 +178,42 @@ describe('PanelDataTransformationsTab', () => {
     await userEvent.click(confirmButton);
 
     expect(onChangeTransformation).toHaveBeenCalledWith([]);
+  });
+
+  it('renders system transformations as read-only rows', async () => {
+    const modelMock = createModelMock(
+      mockData,
+      [
+        { id: 'limit', options: {}, origin: 'system', position: 'prepend' },
+        { id: 'calculateField', options: {} },
+        { id: 'reduce', options: {}, origin: 'system', position: 'append' },
+      ] as DataTransformerConfig[],
+      jest.fn()
+    );
+    render(<PanelDataTransformationsTabRendered model={modelMock}></PanelDataTransformationsTabRendered>);
+
+    await screen.findByText('1 - Add field from calculation');
+    const systemRows = screen.getAllByTestId('system-transformation-row');
+    expect(systemRows).toHaveLength(2);
+    expect(systemRows[0]).toHaveTextContent('Limit');
+    expect(systemRows[1]).toHaveTextContent('Reduce');
+
+    // Only the user transformation row is editable
+    expect(screen.getAllByTestId(selectors.components.QueryEditorRow.actionButton('Remove'))).toHaveLength(1);
+  });
+
+  it('renders read-only rows instead of the empty message when there are only system transformations', async () => {
+    const modelMock = createModelMock(
+      mockData,
+      [{ id: 'reduce', options: {}, origin: 'system', position: 'append' }] as DataTransformerConfig[],
+      jest.fn()
+    );
+    render(<PanelDataTransformationsTabRendered model={modelMock}></PanelDataTransformationsTabRendered>);
+
+    await screen.findByTestId('system-transformation-row');
+    await screen.findByTestId(selectors.components.Transforms.addTransformationButton);
+    // Nothing to delete when there are no user transformations
+    expect(screen.queryByTestId(selectors.components.Transforms.removeAllTransformationsButton)).toBeNull();
   });
 
   it('can filter transformations in the drawer', async () => {

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataTransformationsTab.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataTransformationsTab.tsx
@@ -3,12 +3,19 @@ import { DragDropContext, type DropResult, Droppable } from '@hello-pangea/dnd';
 import { throttle } from 'lodash';
 import { useCallback, useMemo, useState } from 'react';
 
-import { type DataTransformerConfig, type GrafanaTheme2, type PanelData } from '@grafana/data';
+import {
+  type DataTransformerConfig,
+  type GrafanaTheme2,
+  type PanelData,
+  standardTransformersRegistry,
+} from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
 import {
+  isSystemTransformation,
   type SceneComponentProps,
+  type SceneDataTransformation,
   SceneDataTransformer,
   SceneObjectBase,
   type SceneObjectRef,
@@ -16,7 +23,7 @@ import {
   type SceneQueryRunner,
   type VizPanel,
 } from '@grafana/scenes';
-import { Button, ButtonGroup, ConfirmModal, Tab, useStyles2 } from '@grafana/ui';
+import { Badge, Button, ButtonGroup, ConfirmModal, Icon, Tab, useStyles2 } from '@grafana/ui';
 import { TransformationOperationRows } from 'app/features/dashboard/components/TransformationsEditor/TransformationOperationRows';
 import { ExpressionQueryType } from 'app/features/expressions/types';
 
@@ -71,9 +78,36 @@ export class PanelDataTransformationsTab
 
   public onChangeTransformations(transformations: DataTransformerConfig[]) {
     const transformer = this.getDataTransformer();
-    transformer.setState({ transformations });
+    const { systemPrepend, systemAppend } = splitSystemTransformations(transformer.state.transformations);
+
+    // User edits never touch system (panel provided) transformations - preserve them at the edges
+    transformer.setState({ transformations: [...systemPrepend, ...transformations, ...systemAppend] });
     transformer.reprocessTransformations();
   }
+}
+
+/**
+ * Splits transformations into the system (panel provided, read-only) groups and the user configured ones.
+ * System transformations carry their placement in the `position` property.
+ */
+export function splitSystemTransformations(transformations: SceneDataTransformation[]): {
+  systemPrepend: SceneDataTransformation[];
+  userTransformations: SceneDataTransformation[];
+  systemAppend: SceneDataTransformation[];
+} {
+  const systemPrepend: SceneDataTransformation[] = [];
+  const userTransformations: SceneDataTransformation[] = [];
+  const systemAppend: SceneDataTransformation[] = [];
+
+  for (const transformation of transformations) {
+    if (isSystemTransformation(transformation)) {
+      (transformation.position === 'append' ? systemAppend : systemPrepend).push(transformation);
+    } else {
+      userTransformations.push(transformation);
+    }
+  }
+
+  return { systemPrepend, userTransformations, systemAppend };
 }
 
 export function PanelDataTransformationsTabRendered({ model }: SceneComponentProps<PanelDataTransformationsTab>) {
@@ -81,15 +115,19 @@ export function PanelDataTransformationsTabRendered({ model }: SceneComponentPro
   const sourceData = model.getQueryRunner().useState();
   const { data, transformations: transformsWrongType } = model.getDataTransformer().useState();
 
+  const { systemPrepend, userTransformations, systemAppend } = useMemo(
+    () => splitSystemTransformations(Array.isArray(transformsWrongType) ? transformsWrongType : []),
+    [transformsWrongType]
+  );
+
   // Type guard to ensure transformations are DataTransformerConfig[]
   const transformations = useMemo<DataTransformerConfig[]>(() => {
-    return Array.isArray(transformsWrongType)
-      ? transformsWrongType.filter(
-          (t): t is DataTransformerConfig =>
-            t !== null && typeof t === 'object' && 'id' in t && typeof t.id === 'string'
-        )
-      : [];
-  }, [transformsWrongType]);
+    return userTransformations.filter(
+      (t): t is DataTransformerConfig => t !== null && typeof t === 'object' && 'id' in t && typeof t.id === 'string'
+    );
+  }, [userTransformations]);
+
+  const hasSystemTransformations = systemPrepend.length > 0 || systemAppend.length > 0;
 
   const [drawerOpen, setDrawerOpen] = useState<boolean>(false);
   const [confirmModalOpen, setConfirmModalOpen] = useState<boolean>(false);
@@ -143,7 +181,7 @@ export function PanelDataTransformationsTabRendered({ model }: SceneComponentPro
     />
   );
 
-  if (transformations.length < 1) {
+  if (transformations.length < 1 && !hasSystemTransformations) {
     return (
       <>
         <EmptyTransformationsMessage
@@ -161,7 +199,11 @@ export function PanelDataTransformationsTabRendered({ model }: SceneComponentPro
 
   return (
     <>
-      <TransformationsEditor data={sourceData.data} transformations={transformations} model={model} />
+      <SystemTransformationRows transformations={systemPrepend} />
+      {transformations.length > 0 && (
+        <TransformationsEditor data={sourceData.data} transformations={transformations} model={model} />
+      )}
+      <SystemTransformationRows transformations={systemAppend} />
       <ButtonGroup>
         <Button
           icon="plus"
@@ -173,17 +215,19 @@ export function PanelDataTransformationsTabRendered({ model }: SceneComponentPro
             Add another transformation
           </Trans>
         </Button>
-        <Button
-          data-testid={selectors.components.Transforms.removeAllTransformationsButton}
-          className={styles.removeAll}
-          icon="times"
-          variant="secondary"
-          onClick={() => setConfirmModalOpen(true)}
-        >
-          <Trans i18nKey="dashboard-scene.panel-data-transformations-tab-rendered.delete-all-transformations">
-            Delete all transformations
-          </Trans>
-        </Button>
+        {transformations.length > 0 && (
+          <Button
+            data-testid={selectors.components.Transforms.removeAllTransformationsButton}
+            className={styles.removeAll}
+            icon="times"
+            variant="secondary"
+            onClick={() => setConfirmModalOpen(true)}
+          >
+            <Trans i18nKey="dashboard-scene.panel-data-transformations-tab-rendered.delete-all-transformations">
+              Delete all transformations
+            </Trans>
+          </Button>
+        )}
       </ButtonGroup>
       <ConfirmModal
         isOpen={confirmModalOpen}
@@ -277,9 +321,74 @@ function TransformationsEditor({ transformations, model, data }: TransformationE
   );
 }
 
+interface SystemTransformationRowsProps {
+  transformations: SceneDataTransformation[];
+}
+
+function SystemTransformationRows({ transformations }: SystemTransformationRowsProps) {
+  const styles = useStyles2(getStyles);
+
+  if (transformations.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      {transformations.map((transformation, index) => {
+        const id = 'id' in transformation && typeof transformation.id === 'string' ? transformation.id : undefined;
+        const name = id
+          ? (standardTransformersRegistry.getIfExists(id)?.name ?? id)
+          : t(
+              'dashboard-scene.system-transformation-rows.custom-transformation-name',
+              'Custom transformation (code defined)'
+            );
+        const fromUrl = 'origin' in transformation && transformation.origin === 'url';
+
+        return (
+          <div key={`${id ?? 'custom'}-${index}`} className={styles.systemRow} data-testid="system-transformation-row">
+            <Icon name="lock" size="sm" />
+            <span className={styles.systemRowName}>{name}</span>
+            <Badge
+              text={
+                fromUrl
+                  ? t('dashboard-scene.system-transformation-rows.badge-url', 'URL')
+                  : t('dashboard-scene.system-transformation-rows.badge-system', 'System')
+              }
+              color="blue"
+              tooltip={
+                fromUrl
+                  ? t('dashboard-scene.system-transformation-rows.tooltip-url', 'Added from the URL. Read-only.')
+                  : t(
+                      'dashboard-scene.system-transformation-rows.tooltip-system',
+                      'Added automatically by the panel. Read-only.'
+                    )
+              }
+            />
+          </div>
+        );
+      })}
+    </>
+  );
+}
+
 const getStyles = (theme: GrafanaTheme2) => ({
   removeAll: css({
     marginLeft: theme.spacing(2),
+  }),
+  systemRow: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    padding: theme.spacing(1, 2),
+    marginBottom: theme.spacing(1),
+    background: theme.colors.background.secondary,
+    border: `1px dashed ${theme.colors.border.weak}`,
+    borderRadius: theme.shape.radius.default,
+    color: theme.colors.text.secondary,
+  }),
+  systemRowName: css({
+    color: theme.colors.text.primary,
+    fontWeight: theme.typography.fontWeightMedium,
   }),
 });
 

--- a/public/app/features/dashboard-scene/scene/setDashboardPanelContext.test.ts
+++ b/public/app/features/dashboard-scene/scene/setDashboardPanelContext.test.ts
@@ -7,7 +7,7 @@ import {
 } from '@grafana/data';
 import { type BackendSrv, config, setBackendSrv } from '@grafana/runtime';
 import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
-import { GroupByVariable, sceneGraph, SceneQueryRunner } from '@grafana/scenes';
+import { GroupByVariable, SceneDataTransformer, sceneGraph, SceneQueryRunner } from '@grafana/scenes';
 import { type AdHocFilterItem, type PanelContext } from '@grafana/ui';
 
 import { isAnnotationApiAvailable } from '../../annotations/isAnnotationApiAvailable';
@@ -507,6 +507,27 @@ describe('setDashboardPanelContext', () => {
 
       context.onAddAdHocFilters?.(filters);
       expect(variable.state.filters).toEqual([]);
+    });
+  });
+
+  describe('onSetSystemTransformations', () => {
+    it('updates the panel data transformer with system transformations', () => {
+      const { vizPanel, context } = buildTestScene({});
+
+      context.onSetSystemTransformations!({
+        prepend: [{ id: 'limit', options: {} }],
+        append: [{ id: 'reduce', options: {} }],
+      });
+
+      const transformer = vizPanel.state.$data;
+      if (!(transformer instanceof SceneDataTransformer)) {
+        throw new Error('Expected panel data provider to be a SceneDataTransformer');
+      }
+
+      expect(transformer.state.transformations).toEqual([
+        { id: 'limit', options: {}, origin: 'system', position: 'prepend' },
+        { id: 'reduce', options: {}, origin: 'system', position: 'append' },
+      ]);
     });
   });
 });

--- a/public/app/features/dashboard-scene/scene/setDashboardPanelContext.ts
+++ b/public/app/features/dashboard-scene/scene/setDashboardPanelContext.ts
@@ -1,6 +1,13 @@
 import { AnnotationChangeEvent, type AnnotationEventUIModel, CoreApp, type DataFrame } from '@grafana/data';
 import { getDataSourceSrv, reportInteraction } from '@grafana/runtime';
-import { AdHocFiltersVariable, dataLayers, sceneGraph, sceneUtils, type VizPanel } from '@grafana/scenes';
+import {
+  AdHocFiltersVariable,
+  dataLayers,
+  SceneDataTransformer,
+  sceneGraph,
+  sceneUtils,
+  type VizPanel,
+} from '@grafana/scenes';
 import { type DataSourceRef } from '@grafana/schema';
 import { type AdHocFilterItem, type PanelContext } from '@grafana/ui';
 import { FILTER_OUT_OPERATOR } from '@grafana/ui/internal';
@@ -211,6 +218,14 @@ export function setDashboardPanelContext(vizPanel: VizPanel, context: PanelConte
     // TODO
     //return onUpdatePanelSnapshotData(this.props.panel, frames);
     return Promise.resolve(true);
+  };
+
+  context.onSetSystemTransformations = (transformations) => {
+    const provider = vizPanel.state.$data;
+
+    if (provider instanceof SceneDataTransformer) {
+      provider.setSystemTransformations(transformations);
+    }
   };
 
   // Only wire up the status-popover inspector opener when the new panel errors UI is enabled.

--- a/public/app/features/dashboard-scene/scene/syncTransformationsFromUrl.test.ts
+++ b/public/app/features/dashboard-scene/scene/syncTransformationsFromUrl.test.ts
@@ -1,0 +1,111 @@
+import { locationService } from '@grafana/runtime';
+import { SceneDataTransformer } from '@grafana/scenes';
+import { type DashboardDataDTO } from 'app/types/dashboard';
+
+import { transformSaveModelToScene } from '../serialization/transformSaveModelToScene';
+import { findVizPanelByKey } from '../utils/utils';
+
+import { type DashboardScene } from './DashboardScene';
+import { syncTransformationsFromUrl, TRANSFORMATIONS_URL_PARAM } from './syncTransformationsFromUrl';
+
+function buildScene() {
+  return transformSaveModelToScene({
+    dashboard: {
+      title: 'test',
+      uid: 'dash-1',
+      schemaVersion: 38,
+      panels: [
+        {
+          type: 'timeseries',
+          id: 3,
+          targets: [],
+          transformations: [{ id: 'organize', options: {} }],
+        },
+        { type: 'timeseries', id: 4, targets: [] },
+      ],
+    } as unknown as DashboardDataDTO,
+    meta: {},
+  });
+}
+
+function getTransformer(scene: DashboardScene, key: string): SceneDataTransformer {
+  const provider = findVizPanelByKey(scene, key)!.state.$data;
+
+  if (!(provider instanceof SceneDataTransformer)) {
+    throw new Error(`Expected SceneDataTransformer for ${key}`);
+  }
+
+  return provider;
+}
+
+function pushParam(value: unknown) {
+  locationService.push(`/?${TRANSFORMATIONS_URL_PARAM}=${encodeURIComponent(JSON.stringify(value))}`);
+}
+
+describe('syncTransformationsFromUrl', () => {
+  afterEach(() => {
+    locationService.replace('/');
+  });
+
+  it('applies panel targeted transformations from the url', () => {
+    pushParam({ '3': { prepend: [{ id: 'limit', options: {} }], append: [{ id: 'reduce', options: {} }] } });
+    const scene = buildScene();
+    const cleanup = syncTransformationsFromUrl(scene);
+
+    expect(getTransformer(scene, 'panel-3').state.transformations).toEqual([
+      { id: 'limit', options: {}, origin: 'url', position: 'prepend' },
+      { id: 'organize', options: {} },
+      { id: 'reduce', options: {}, origin: 'url', position: 'append' },
+    ]);
+    expect(getTransformer(scene, 'panel-4').state.transformations).toEqual([]);
+
+    cleanup();
+  });
+
+  it('applies the array shorthand to all panels and clears when the param goes away', () => {
+    pushParam([{ id: 'reduce', options: {} }]);
+    const scene = buildScene();
+    const cleanup = syncTransformationsFromUrl(scene);
+
+    expect(getTransformer(scene, 'panel-3').state.transformations).toEqual([
+      { id: 'organize', options: {} },
+      { id: 'reduce', options: {}, origin: 'url', position: 'append' },
+    ]);
+    expect(getTransformer(scene, 'panel-4').state.transformations).toEqual([
+      { id: 'reduce', options: {}, origin: 'url', position: 'append' },
+    ]);
+
+    locationService.push('/');
+
+    expect(getTransformer(scene, 'panel-3').state.transformations).toEqual([{ id: 'organize', options: {} }]);
+    expect(getTransformer(scene, 'panel-4').state.transformations).toEqual([]);
+
+    cleanup();
+  });
+
+  it('ignores an invalid json param', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    locationService.push(`/?${TRANSFORMATIONS_URL_PARAM}=not-json`);
+    const scene = buildScene();
+    const cleanup = syncTransformationsFromUrl(scene);
+
+    expect(getTransformer(scene, 'panel-3').state.transformations).toEqual([{ id: 'organize', options: {} }]);
+    expect(warnSpy).toHaveBeenCalled();
+
+    cleanup();
+    warnSpy.mockRestore();
+  });
+
+  it('drops entries that are not transformer configs', () => {
+    pushParam({ '3': { append: [{ id: 'reduce', options: {} }, { notATransform: true }, 'nope'] } });
+    const scene = buildScene();
+    const cleanup = syncTransformationsFromUrl(scene);
+
+    expect(getTransformer(scene, 'panel-3').state.transformations).toEqual([
+      { id: 'organize', options: {} },
+      { id: 'reduce', options: {}, origin: 'url', position: 'append' },
+    ]);
+
+    cleanup();
+  });
+});

--- a/public/app/features/dashboard-scene/scene/syncTransformationsFromUrl.ts
+++ b/public/app/features/dashboard-scene/scene/syncTransformationsFromUrl.ts
@@ -1,0 +1,103 @@
+import { type DataTransformerConfig } from '@grafana/data';
+import { locationService } from '@grafana/runtime';
+import { SceneDataTransformer } from '@grafana/scenes';
+
+import { dashboardSceneGraph } from '../utils/dashboardSceneGraph';
+import { getPanelIdForVizPanel } from '../utils/utils';
+
+import { type DashboardScene } from './DashboardScene';
+
+export const TRANSFORMATIONS_URL_PARAM = 'transformations';
+
+/** Targets all panels on the dashboard */
+const ALL_PANELS = '*';
+
+interface UrlTransformations {
+  prepend: DataTransformerConfig[];
+  append: DataTransformerConfig[];
+}
+
+const EMPTY: UrlTransformations = { prepend: [], append: [] };
+
+/**
+ * Dashboard behavior that applies transformations provided through the `transformations` URL parameter.
+ * They are combined with (never replace) user configured transformations, show up as read-only rows in
+ * the panel editor and are never persisted.
+ *
+ * Supported shapes (URL encoded JSON):
+ * - `[{"id":"reduce","options":{}}]` - appended to every panel
+ * - `{"3":{"prepend":[...],"append":[...]}}` - keyed by panel id
+ * - `{"3":[...]}` - shorthand, appended to panel 3
+ */
+export function syncTransformationsFromUrl(scene: DashboardScene) {
+  const apply = () => {
+    const raw = locationService.getSearch().get(TRANSFORMATIONS_URL_PARAM);
+    const byPanel = parseTransformationsParam(raw);
+
+    for (const panel of dashboardSceneGraph.getVizPanels(scene)) {
+      const provider = panel.state.$data;
+
+      if (!(provider instanceof SceneDataTransformer)) {
+        continue;
+      }
+
+      // Always apply - an empty update clears previous url transformations when the param goes away
+      const transformations = byPanel.get(String(getPanelIdForVizPanel(panel))) ?? byPanel.get(ALL_PANELS) ?? EMPTY;
+      provider.setSystemTransformations({ ...transformations, origin: 'url' });
+    }
+  };
+
+  apply();
+
+  const unlisten = locationService.getHistory().listen(() => apply());
+
+  return () => unlisten();
+}
+
+function parseTransformationsParam(raw: string | null): Map<string, UrlTransformations> {
+  const byPanel = new Map<string, UrlTransformations>();
+
+  if (!raw) {
+    return byPanel;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    console.warn(`Ignoring invalid ${TRANSFORMATIONS_URL_PARAM} URL parameter`, err);
+    return byPanel;
+  }
+
+  if (Array.isArray(parsed)) {
+    byPanel.set(ALL_PANELS, toUrlTransformations(parsed));
+    return byPanel;
+  }
+
+  if (parsed !== null && typeof parsed === 'object') {
+    for (const [panelId, value] of Object.entries(parsed)) {
+      byPanel.set(panelId, toUrlTransformations(value));
+    }
+  }
+
+  return byPanel;
+}
+
+function toUrlTransformations(value: unknown): UrlTransformations {
+  if (Array.isArray(value)) {
+    return { prepend: [], append: value.filter(isTransformerConfig) };
+  }
+
+  if (value !== null && typeof value === 'object') {
+    return {
+      prepend: 'prepend' in value && Array.isArray(value.prepend) ? value.prepend.filter(isTransformerConfig) : [],
+      append: 'append' in value && Array.isArray(value.append) ? value.append.filter(isTransformerConfig) : [],
+    };
+  }
+
+  return EMPTY;
+}
+
+function isTransformerConfig(value: unknown): value is DataTransformerConfig {
+  return value !== null && typeof value === 'object' && 'id' in value && typeof value.id === 'string';
+}

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
@@ -79,6 +79,7 @@ import { registerDashboardMacro } from '../scene/DashboardMacro';
 import { DashboardReloadBehavior } from '../scene/DashboardReloadBehavior';
 import { DashboardScene } from '../scene/DashboardScene';
 import { ReportInteractionBehavior } from '../scene/ReportInteractionBehavior';
+import { syncTransformationsFromUrl } from '../scene/syncTransformationsFromUrl';
 import { type DashboardLayoutManager } from '../scene/types/DashboardLayoutManager';
 import { getIntervalsFromQueryString } from '../utils/utils';
 
@@ -261,6 +262,7 @@ export function transformSaveModelSchemaV2ToScene(
         registerPanelInteractionsReporter,
         new behaviors.LiveNowTimer({ enabled: dashboard.liveNow }),
         addPanelsOnLoadBehavior,
+        syncTransformationsFromUrl,
         new DashboardReloadBehavior({
           reloadOnParamsChange:
             config.featureToggles.reloadDashboardsOnParamsChange &&

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
@@ -59,6 +59,7 @@ import { RowsLayoutManager } from '../scene/layout-rows/RowsLayoutManager';
 import { getIsLazy } from '../scene/layouts-shared/utils';
 import { PanelTimeRange } from '../scene/panel-timerange/PanelTimeRange';
 import { setDashboardPanelContext } from '../scene/setDashboardPanelContext';
+import { syncTransformationsFromUrl } from '../scene/syncTransformationsFromUrl';
 import { type DashboardLayoutManager } from '../scene/types/DashboardLayoutManager';
 import { createPanelDataProvider } from '../utils/createPanelDataProvider';
 import { DashboardInteractions } from '../utils/interactions';
@@ -373,6 +374,7 @@ export function createDashboardSceneFromDashboardModel(
     registerPanelInteractionsReporter,
     new behaviors.LiveNowTimer({ enabled: oldModel.liveNow }),
     addPanelsOnLoadBehavior,
+    syncTransformationsFromUrl,
     new DashboardReloadBehavior({
       reloadOnParamsChange: config.featureToggles.reloadDashboardsOnParamsChange && oldModel.meta.reloadOnParamsChange,
       uid,

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.test.ts
@@ -21,6 +21,7 @@ import {
   CustomVariable,
   type MultiValueVariable,
   sceneGraph,
+  SceneDataTransformer,
   SceneGridLayout,
   type SceneGridRow,
   VizPanel,
@@ -693,6 +694,28 @@ describe('transformSceneToSaveModel', () => {
         uid: 'abc',
       });
     });
+
+    it('Given panel with system transformations, they are not persisted', () => {
+      const gridItem = buildGridItemFromPanelSchema({
+        transformations: [{ id: 'reduce', options: {} }],
+        targets: [{ refId: 'A', datasource: { type: 'grafana-testdata', uid: 'abc' } }],
+      });
+
+      const transformer = gridItem.state.body.state.$data;
+      if (!(transformer instanceof SceneDataTransformer)) {
+        throw new Error('Expected panel data provider to be a SceneDataTransformer');
+      }
+
+      transformer.setSystemTransformations({
+        prepend: [{ id: 'limit', options: {} }],
+        append: [{ id: 'organize', options: {} }],
+      });
+
+      const result = gridItemToPanel(gridItem);
+
+      expect(result.transformations).toEqual([{ id: 'reduce', options: {} }]);
+    });
+
     it('Given panel with shared query', () => {
       const panel = buildGridItemFromPanelSchema({
         datasource: {

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.ts
@@ -3,6 +3,7 @@ import { defaults, isEqual } from 'lodash';
 import { isEmptyObject, type ScopedVars, type TimeRange } from '@grafana/data';
 import {
   behaviors,
+  isSystemTransformation,
   type SceneGridItemLike,
   SceneGridRow,
   VizPanel,
@@ -336,7 +337,10 @@ function vizPanelDataToPanel(
   }
 
   if (dataProvider instanceof SceneDataTransformer) {
-    panel.transformations = dataProvider.state.transformations as DataTransformerConfig[];
+    // System (panel provided) transformations are runtime-only and never persisted
+    panel.transformations = dataProvider.state.transformations.filter(
+      (t) => !isSystemTransformation(t)
+    ) as DataTransformerConfig[];
   }
 
   if (dataProvider && isSnapshot) {

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
@@ -77,6 +77,7 @@ import {
   getDataQueryKind,
   getAutoAssignedDSRef,
   getVizPanelQueries,
+  getVizPanelTransformations,
   vizPanelToSchemaV2,
 } from './transformSceneToSaveModelSchemaV2';
 
@@ -2300,5 +2301,36 @@ describe('normalizeDataSourceRef', () => {
     // Template variables short-circuit and never call getInstanceSettings.
     expect(normalizeDataSourceRef('$datasource')).toEqual({ uid: '$datasource' });
     expect(normalizeDataSourceRef('${datasource}')).toEqual({ uid: '${datasource}' });
+  });
+});
+
+describe('getVizPanelTransformations', () => {
+  it('excludes system transformations from the save model', () => {
+    const transformer = new SceneDataTransformer({
+      $data: new SceneDataNode({}),
+      transformations: [{ id: 'reduce', options: { reducers: ['max'] } }],
+    });
+
+    const vizPanel = new VizPanel({
+      key: 'panel-1',
+      pluginId: 'timeseries',
+      $data: transformer,
+    });
+
+    transformer.setSystemTransformations({
+      prepend: [{ id: 'limit', options: {} }],
+      // Custom operators can not be persisted and would previously throw on save
+      append: [() => (source) => source],
+    });
+
+    const result = getVizPanelTransformations(vizPanel);
+
+    expect(result).toEqual([
+      {
+        kind: 'Transformation',
+        group: 'reduce',
+        spec: { options: { reducers: ['max'] } },
+      },
+    ]);
   });
 });

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -6,6 +6,7 @@ import { ExpressionDatasourceRef } from '@grafana/runtime/internal';
 import {
   behaviors,
   dataLayers,
+  isSystemTransformation,
   LocalValueVariable,
   type QueryVariable,
   sceneGraph,
@@ -571,11 +572,12 @@ export function getDataQueryKind(query: SceneDataQuery | string | undefined, que
   return defaultDS?.type || '';
 }
 
-function getVizPanelTransformations(vizPanel: VizPanel): TransformationKind[] {
+export function getVizPanelTransformations(vizPanel: VizPanel): TransformationKind[] {
   let transformations: TransformationKind[] = [];
   const dataProvider = vizPanel.state.$data;
   if (dataProvider instanceof SceneDataTransformer) {
-    const transformationList = dataProvider.state.transformations;
+    // System (panel provided) transformations are runtime-only and never persisted
+    const transformationList = dataProvider.state.transformations.filter((t) => !isSystemTransformation(t));
 
     if (transformationList.length === 0) {
       return [];

--- a/public/app/plugins/panel/debug/DebugPanel.tsx
+++ b/public/app/plugins/panel/debug/DebugPanel.tsx
@@ -4,6 +4,7 @@ import { CursorView } from './CursorView';
 import { EventBusLoggerPanel } from './EventBusLogger';
 import { RenderInfoViewer } from './RenderInfoViewer';
 import { StateView } from './StateView';
+import { SystemTransformationsView } from './SystemTransformationsView';
 import { type Options, DebugMode } from './panelcfg.gen';
 
 type Props = PanelProps<Options>;
@@ -18,6 +19,8 @@ export function DebugPanel(props: Props) {
       return <CursorView eventBus={props.eventBus} />;
     case DebugMode.State:
       return <StateView {...props} />;
+    case DebugMode.Transformations:
+      return <SystemTransformationsView {...props} />;
     case DebugMode.ThrowError:
       throw new Error('I failed you and for that i am deeply sorry');
     default:

--- a/public/app/plugins/panel/debug/SystemTransformationsView.tsx
+++ b/public/app/plugins/panel/debug/SystemTransformationsView.tsx
@@ -1,0 +1,58 @@
+import { useEffect } from 'react';
+
+import { type PanelProps, ReducerID } from '@grafana/data';
+import { Trans } from '@grafana/i18n';
+import { usePanelContext } from '@grafana/ui';
+
+import { type Options } from './panelcfg.gen';
+
+type Props = PanelProps<Options>;
+
+/**
+ * Example of panel provided (system) transformations. The panel prepends a limit transformation and
+ * appends a reduce transformation around whatever transformations the user configured. They show up
+ * as read-only rows in the panel editor transformations tab and are never persisted to the dashboard.
+ */
+export function SystemTransformationsView({ data }: Props) {
+  const { onSetSystemTransformations } = usePanelContext();
+
+  useEffect(() => {
+    if (!onSetSystemTransformations) {
+      return;
+    }
+
+    onSetSystemTransformations({
+      prepend: [{ id: 'limit', options: { limitField: 100 } }],
+      append: [{ id: 'reduce', options: { reducers: [ReducerID.mean] } }],
+    });
+
+    // Clear the system transformations when the mode changes or the panel unmounts
+    return () => onSetSystemTransformations({});
+  }, [onSetSystemTransformations]);
+
+  return (
+    <div>
+      <p>
+        <Trans i18nKey="debug.system-transformations-view.description">
+          This mode prepends a limit transformation and appends a reduce transformation to the user configured ones.
+          Open the transformations tab in the panel editor to see them as read-only rows.
+        </Trans>
+      </p>
+      <ul>
+        {data.series.map((frame, index) => {
+          const name = frame.refId ?? frame.name ?? String(index);
+          const fieldCount = frame.fields.length;
+          const rowCount = frame.length;
+
+          return (
+            <li key={index}>
+              <Trans i18nKey="debug.system-transformations-view.frame-summary">
+                {{ name }}: {{ fieldCount }} fields, {{ rowCount }} rows
+              </Trans>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/public/app/plugins/panel/debug/module.tsx
+++ b/public/app/plugins/panel/debug/module.tsx
@@ -17,6 +17,7 @@ export const plugin = new PanelPlugin<Options>(DebugPanel).useFieldConfig().setP
           { label: 'Cursor', value: DebugMode.Cursor },
           { label: 'Cursor', value: DebugMode.Cursor },
           { label: 'Share state', value: DebugMode.State },
+          { label: 'System transformations', value: DebugMode.Transformations },
           { label: 'Throw error', value: DebugMode.ThrowError },
         ],
       },

--- a/public/app/plugins/panel/debug/panelcfg.cue
+++ b/public/app/plugins/panel/debug/panelcfg.cue
@@ -27,7 +27,7 @@ composableKinds: PanelCfg: {
 					schemaChanged: bool
 				} @cuetsy(kind="type")
 
-				DebugMode: "render" | "events" | "cursor" | "State" | "ThrowError" @cuetsy(kind="enum")
+				DebugMode: "render" | "events" | "cursor" | "State" | "ThrowError" | "transformations" @cuetsy(kind="enum")
 
 				Options: {
 					mode:      DebugMode

--- a/public/app/plugins/panel/debug/panelcfg.gen.ts
+++ b/public/app/plugins/panel/debug/panelcfg.gen.ts
@@ -22,6 +22,7 @@ export enum DebugMode {
   Render = 'render',
   State = 'State',
   ThrowError = 'ThrowError',
+  Transformations = 'transformations',
 }
 
 export interface Options {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -7682,6 +7682,13 @@
       "value-pair-type": "Value pair type",
       "value-pair-type-description": "Choose the type of values for the switch states"
     },
+    "system-transformation-rows": {
+      "badge-system": "System",
+      "badge-url": "URL",
+      "custom-transformation-name": "Custom transformation (code defined)",
+      "tooltip-system": "Added automatically by the panel. Read-only.",
+      "tooltip-url": "Added from the URL. Read-only."
+    },
     "text-box-variable": {
       "name-default-value": "Default value"
     },
@@ -8213,6 +8220,10 @@
     "state-view": {
       "current-value": "Current value: {{currentValue}} ",
       "label-state-name": "State name"
+    },
+    "system-transformations-view": {
+      "description": "This mode prepends a limit transformation and appends a reduce transformation to the user configured ones. Open the transformations tab in the panel editor to see them as read-only rows.",
+      "frame-summary": "{{name}}: {{fieldCount}} fields, {{rowCount}} rows"
     }
   },
   "diff-viewer": {


### PR DESCRIPTION
Panel plugins can now inject transformations into their panel's pipeline via `PanelContext.onSetSystemTransformations`, and URLs can do the same through a new `transformations` query parameter. Both combine with the user configured transformations, render as read-only rows badged `System` or `URL` in the transformations tab, and are filtered out of the save model so they're never persisted. A new Debug panel mode demonstrates the panel API.

Depends on [grafana/scenes#1614](https://github.com/grafana/scenes/pull/1614) - draft until that lands and the `@grafana/scenes` dependency is bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)