### PR TITLE
fix: nats async error handling

### DIFF
--- a/pkg/infra/nats/connection.go
+++ b/pkg/infra/nats/connection.go
@@ -38,9 +38,6 @@ type connection struct {
 	config      *Config
 	credentials func() string
 
-	// onAsyncError, when set, is invoked from the NATS async error handler after logging.
-	onAsyncError func(error)
-
 	// disconnectedAt holds the unix-nano timestamp of the last disconnect so the
 	// reconnect handler can record how long the connection was down. Accessed only
 	// from the NATS callback goroutine, but kept atomic to stay race-free.
@@ -218,14 +215,8 @@ func (c *connection) connectOptions() ([]natsclient.Option, error) {
 			c.log.Info("nats connection closed", "role", roleStr, "last_err", nc.LastError())
 		}),
 		natsclient.ErrorHandler(func(_ *natsclient.Conn, sub *natsclient.Subscription, err error) {
-			subject := ""
-			if sub != nil {
-				subject = sub.Subject
-			}
-			c.log.Warn("nats async error", "role", roleStr, "subject", subject, "err", err)
-			if c.onAsyncError != nil {
-				c.onAsyncError(err)
-			}
+			c.log.Warn("nats async error", "role", roleStr, "subject", asyncErrorSubject(sub, err), "reason", asyncErrorReason(err), "err", err)
+			c.metrics.recordAsyncError(sub, err)
 		}),
 	}
 

--- a/pkg/infra/nats/errors.go
+++ b/pkg/infra/nats/errors.go
@@ -26,12 +26,14 @@ var connStateErrs = []error{
 	natsclient.ErrConnectionDraining,
 }
 
-// publishPermissionsRe extracts the subject from a publish permissions
-// violation. The server names the rejected subject in the error text only —
-// nats.go passes a nil *Subscription for a publish rejection, since no
-// subscription is involved — so the subject has to be read back out of the
-// message. Mirrors nats.go's own permissionsRe for the subscribe direction.
-var publishPermissionsRe = regexp.MustCompile(`Publish to "(\S+)"`)
+// permissionsSubjectRes extract the rejected subject from a permissions
+// violation. nats.go reports these through processTransientError, which always
+// passes a nil *Subscription — for subscribe rejections as much as publish ones
+// — so the subject is only available from the error text.
+var permissionsSubjectRes = []*regexp.Regexp{
+	regexp.MustCompile(`Publish to "(\S+)"`),
+	regexp.MustCompile(`Subscription to "(\S+)"`),
+}
 
 func isConnStateErr(err error) bool {
 	for _, target := range connStateErrs {
@@ -67,8 +69,11 @@ func asyncErrorSubject(sub *natsclient.Subscription, err error) string {
 	if sub != nil {
 		return sub.Subject
 	}
-	if match := publishPermissionsRe.FindStringSubmatch(err.Error()); len(match) == 2 {
-		return match[1]
+	msg := err.Error()
+	for _, re := range permissionsSubjectRes {
+		if match := re.FindStringSubmatch(msg); len(match) == 2 {
+			return match[1]
+		}
 	}
 	return ""
 }

--- a/pkg/infra/nats/errors.go
+++ b/pkg/infra/nats/errors.go
@@ -1,0 +1,79 @@
+package nats
+
+import (
+	"errors"
+	"regexp"
+
+	natsclient "github.com/nats-io/nats.go"
+
+	"github.com/grafana/grafana/pkg/storage/unified/resourcewatch"
+)
+
+const (
+	reasonPermissionsViolation = "permissions_violation"
+	reasonAuthorization        = "authorization"
+	reasonAuthExpired          = "auth_expired"
+	reasonAuthRevoked          = "auth_revoked"
+	reasonAccountAuthExpired   = "account_auth_expired"
+	reasonMaxSubscriptions     = "max_subscriptions"
+	reasonSlowConsumer         = "slow_consumer"
+	reasonOther                = "other"
+)
+
+var connStateErrs = []error{
+	natsclient.ErrReconnectBufExceeded,
+	natsclient.ErrConnectionClosed,
+	natsclient.ErrConnectionDraining,
+}
+
+// publishPermissionsRe extracts the subject from a publish permissions
+// violation. The server names the rejected subject in the error text only —
+// nats.go passes a nil *Subscription for a publish rejection, since no
+// subscription is involved — so the subject has to be read back out of the
+// message. Mirrors nats.go's own permissionsRe for the subscribe direction.
+var publishPermissionsRe = regexp.MustCompile(`Publish to "(\S+)"`)
+
+func isConnStateErr(err error) bool {
+	for _, target := range connStateErrs {
+		if errors.Is(err, target) {
+			return true
+		}
+	}
+	return false
+}
+
+func asyncErrorReason(err error) string {
+	switch {
+	case errors.Is(err, natsclient.ErrPermissionViolation):
+		return reasonPermissionsViolation
+	case errors.Is(err, natsclient.ErrAuthorization):
+		return reasonAuthorization
+	case errors.Is(err, natsclient.ErrAuthExpired):
+		return reasonAuthExpired
+	case errors.Is(err, natsclient.ErrAuthRevoked):
+		return reasonAuthRevoked
+	case errors.Is(err, natsclient.ErrAccountAuthExpired):
+		return reasonAccountAuthExpired
+	case errors.Is(err, natsclient.ErrMaxSubscriptionsExceeded):
+		return reasonMaxSubscriptions
+	case errors.Is(err, natsclient.ErrSlowConsumer):
+		return reasonSlowConsumer
+	default:
+		return reasonOther
+	}
+}
+
+func asyncErrorSubject(sub *natsclient.Subscription, err error) string {
+	if sub != nil {
+		return sub.Subject
+	}
+	if match := publishPermissionsRe.FindStringSubmatch(err.Error()); len(match) == 2 {
+		return match[1]
+	}
+	return ""
+}
+
+func asyncErrorLabels(sub *natsclient.Subscription, err error) (group, resource, reason string) {
+	group, _, resource, _ = resourcewatch.ParseSubject(asyncErrorSubject(sub, err))
+	return group, resource, asyncErrorReason(err)
+}

--- a/pkg/infra/nats/errors_test.go
+++ b/pkg/infra/nats/errors_test.go
@@ -31,12 +31,17 @@ func TestIsConnStateErr(t *testing.T) {
 }
 
 func TestRecordAsyncError(t *testing.T) {
-	// The exact text nats-server sends for a rejected publish, as nats.go wraps it
-	// (see processErr -> processTransientError). Publish has already returned nil
-	// by the time this arrives, and the *Subscription is nil, so the subject is
-	// only available from the message itself.
+	// The exact text nats-server sends for a rejected publish or subscribe, as
+	// nats.go wraps it (see processErr -> processTransientError). Both arrive with
+	// a nil *Subscription, so the subject is only available from the message.
 	publishViolation := func(subject string) error {
 		return fmt.Errorf("%w: Permissions Violation for Publish to %q", natsclient.ErrPermissionViolation, subject)
+	}
+	subscribeViolation := func(subject string) error {
+		return fmt.Errorf("%w: Permissions Violation for Subscription to %q", natsclient.ErrPermissionViolation, subject)
+	}
+	queueSubscribeViolation := func(subject, queue string) error {
+		return fmt.Errorf("%w: Permissions Violation for Subscription to %q using queue %q", natsclient.ErrPermissionViolation, subject, queue)
 	}
 
 	tests := []struct {
@@ -60,12 +65,23 @@ func TestRecordAsyncError(t *testing.T) {
 			wantReason: reasonPermissionsViolation,
 		},
 		{
-			name:         "rejected subscribe is attributed from the subscription",
-			sub:          &natsclient.Subscription{Subject: "us.watch.v1.dashboard.grafana.app.stacks-1.dashboards"},
-			err:          natsclient.ErrPermissionViolation,
+			name:         "rejected subscribe is attributed to its group and resource",
+			err:          subscribeViolation("us.watch.v1.dashboard.grafana.app.stacks-1.dashboards"),
 			wantGroup:    "dashboard.grafana.app",
 			wantResource: "dashboards",
 			wantReason:   reasonPermissionsViolation,
+		},
+		{
+			name:         "rejected queue subscribe is attributed to its group and resource",
+			err:          queueSubscribeViolation("us.watch.v1.dashboard.grafana.app.stacks-1.dashboards", "dashboards-workers"),
+			wantGroup:    "dashboard.grafana.app",
+			wantResource: "dashboards",
+			wantReason:   reasonPermissionsViolation,
+		},
+		{
+			name:       "rejected subscribe on a subject this bus does not own",
+			err:        subscribeViolation("some.other.subject"),
+			wantReason: reasonPermissionsViolation,
 		},
 		{
 			name:         "slow consumer keeps the subscription's attribution",

--- a/pkg/infra/nats/errors_test.go
+++ b/pkg/infra/nats/errors_test.go
@@ -1,0 +1,114 @@
+package nats
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	natsclient "github.com/nats-io/nats.go"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsConnStateErr(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"reconnect buffer exceeded", natsclient.ErrReconnectBufExceeded, true},
+		{"connection closed", natsclient.ErrConnectionClosed, true},
+		{"connection draining", natsclient.ErrConnectionDraining, true},
+		{"wrapped", fmt.Errorf("publish: %w", natsclient.ErrConnectionClosed), true},
+		{"max payload", natsclient.ErrMaxPayload, false},
+		{"bad subject", natsclient.ErrBadSubject, false},
+		{"nil", nil, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, isConnStateErr(tc.err))
+		})
+	}
+}
+
+func TestRecordAsyncError(t *testing.T) {
+	// The exact text nats-server sends for a rejected publish, as nats.go wraps it
+	// (see processErr -> processTransientError). Publish has already returned nil
+	// by the time this arrives, and the *Subscription is nil, so the subject is
+	// only available from the message itself.
+	publishViolation := func(subject string) error {
+		return fmt.Errorf("%w: Permissions Violation for Publish to %q", natsclient.ErrPermissionViolation, subject)
+	}
+
+	tests := []struct {
+		name         string
+		sub          *natsclient.Subscription
+		err          error
+		wantGroup    string
+		wantResource string
+		wantReason   string
+	}{
+		{
+			name:         "rejected publish is attributed to its group and resource",
+			err:          publishViolation("us.watch.v1.provisioning.grafana.app.stacks-1.jobs"),
+			wantGroup:    "provisioning.grafana.app",
+			wantResource: "jobs",
+			wantReason:   reasonPermissionsViolation,
+		},
+		{
+			name:       "rejected publish on a subject this bus does not own",
+			err:        publishViolation("some.other.subject"),
+			wantReason: reasonPermissionsViolation,
+		},
+		{
+			name:         "rejected subscribe is attributed from the subscription",
+			sub:          &natsclient.Subscription{Subject: "us.watch.v1.dashboard.grafana.app.stacks-1.dashboards"},
+			err:          natsclient.ErrPermissionViolation,
+			wantGroup:    "dashboard.grafana.app",
+			wantResource: "dashboards",
+			wantReason:   reasonPermissionsViolation,
+		},
+		{
+			name:         "slow consumer keeps the subscription's attribution",
+			sub:          &natsclient.Subscription{Subject: "us.watch.v1.provisioning.grafana.app.stacks-1.jobs"},
+			err:          natsclient.ErrSlowConsumer,
+			wantGroup:    "provisioning.grafana.app",
+			wantResource: "jobs",
+			wantReason:   reasonSlowConsumer,
+		},
+		{
+			name:       "authorization violation carries no subject",
+			err:        natsclient.ErrAuthorization,
+			wantReason: reasonAuthorization,
+		},
+		{
+			name:       "expired credentials",
+			err:        natsclient.ErrAuthExpired,
+			wantReason: reasonAuthExpired,
+		},
+		{
+			name:       "unclassified errors are not dropped",
+			err:        context.Canceled,
+			wantReason: reasonOther,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, role := range []connRole{rolePublisher, roleSubscriber} {
+				t.Run(string(role), func(t *testing.T) {
+					m := newConnectionMetrics(role)
+					m.recordAsyncError(tc.sub, tc.err)
+
+					require.Equal(t, float64(1), testutil.ToFloat64(m.asyncErrors.WithLabelValues(tc.wantGroup, tc.wantResource, tc.wantReason)))
+					require.Equal(t, 1, testutil.CollectAndCount(m.asyncErrors), "exactly one series must be touched")
+				})
+			}
+		})
+	}
+
+	t.Run("a nil error is ignored", func(t *testing.T) {
+		m := newConnectionMetrics(rolePublisher)
+		m.recordAsyncError(nil, nil)
+		require.Equal(t, 0, testutil.CollectAndCount(m.asyncErrors))
+	})
+}

--- a/pkg/infra/nats/metrics.go
+++ b/pkg/infra/nats/metrics.go
@@ -69,6 +69,7 @@ type publisherMetrics struct {
 	connectionMetrics
 	messagesPublished prometheus.Counter
 	publishErrors     prometheus.Counter
+	asyncErrors       *prometheus.CounterVec
 }
 
 func newPublisherMetrics() *publisherMetrics {
@@ -86,11 +87,17 @@ func newPublisherMetrics() *publisherMetrics {
 			Name:      "publisher_publish_errors_total",
 			Help:      "Total number of NATS publish errors.",
 		}),
+		asyncErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
+			Name:      "publisher_async_errors_total",
+			Help:      "NATS asynchronous errors reported on the publisher connection, by group, resource and classified error. A non-zero permissions_violation means published messages are being dropped by the broker even though Publish returned successfully.",
+		}, []string{"group", "resource", "error"}),
 	}
 }
 
 func (m *publisherMetrics) collectors() []prometheus.Collector {
-	return append(m.connectionMetrics.collectors(), m.messagesPublished, m.publishErrors)
+	return append(m.connectionMetrics.collectors(), m.messagesPublished, m.publishErrors, m.asyncErrors)
 }
 
 // subscriberMetrics covers the subscriber connection plus its delivery counters.

--- a/pkg/infra/nats/metrics.go
+++ b/pkg/infra/nats/metrics.go
@@ -1,6 +1,7 @@
 package nats
 
 import (
+	natsclient "github.com/nats-io/nats.go"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -18,6 +19,7 @@ type connectionMetrics struct {
 	disconnects         prometheus.Counter
 	connectionErrors    prometheus.Counter
 	disconnectedSeconds prometheus.Histogram
+	asyncErrors         *prometheus.CounterVec
 }
 
 func newConnectionMetrics(role connRole) connectionMetrics {
@@ -45,7 +47,7 @@ func newConnectionMetrics(role connRole) connectionMetrics {
 			Namespace: metricsNamespace,
 			Subsystem: metricsSubsystem,
 			Name:      prefix + "connection_errors_total",
-			Help:      "Total number of NATS asynchronous connection errors.",
+			Help:      "Total number of failed NATS connect attempts.",
 		}),
 		// Observed when the connection is re-established: the length of each outage
 		// is exactly the window during which this node relies on the polling
@@ -57,11 +59,24 @@ func newConnectionMetrics(role connRole) connectionMetrics {
 			Help:      "Duration of NATS disconnections, observed when the connection reconnects.",
 			Buckets:   []float64{0.5, 1, 2, 5, 10, 30, 60, 120, 300},
 		}),
+		asyncErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
+			Name:      prefix + "async_errors_total",
+			Help:      "NATS asynchronous errors reported on the connection, by group, resource and classified error.",
+		}, []string{"group", "resource", "error"}),
 	}
 }
 
+func (m connectionMetrics) recordAsyncError(sub *natsclient.Subscription, err error) {
+	if err == nil {
+		return
+	}
+	m.asyncErrors.WithLabelValues(asyncErrorLabels(sub, err)).Inc()
+}
+
 func (m connectionMetrics) collectors() []prometheus.Collector {
-	return []prometheus.Collector{m.connectionStatus, m.reconnects, m.disconnects, m.connectionErrors, m.disconnectedSeconds}
+	return []prometheus.Collector{m.connectionStatus, m.reconnects, m.disconnects, m.connectionErrors, m.disconnectedSeconds, m.asyncErrors}
 }
 
 // publisherMetrics covers the publisher connection plus its publish counters.
@@ -69,7 +84,6 @@ type publisherMetrics struct {
 	connectionMetrics
 	messagesPublished prometheus.Counter
 	publishErrors     prometheus.Counter
-	asyncErrors       *prometheus.CounterVec
 }
 
 func newPublisherMetrics() *publisherMetrics {
@@ -87,17 +101,11 @@ func newPublisherMetrics() *publisherMetrics {
 			Name:      "publisher_publish_errors_total",
 			Help:      "Total number of NATS publish errors.",
 		}),
-		asyncErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: metricsNamespace,
-			Subsystem: metricsSubsystem,
-			Name:      "publisher_async_errors_total",
-			Help:      "NATS asynchronous errors reported on the publisher connection, by group, resource and classified error. A non-zero permissions_violation means published messages are being dropped by the broker even though Publish returned successfully.",
-		}, []string{"group", "resource", "error"}),
 	}
 }
 
 func (m *publisherMetrics) collectors() []prometheus.Collector {
-	return append(m.connectionMetrics.collectors(), m.messagesPublished, m.publishErrors, m.asyncErrors)
+	return append(m.connectionMetrics.collectors(), m.messagesPublished, m.publishErrors)
 }
 
 // subscriberMetrics covers the subscriber connection plus its delivery counters.
@@ -106,7 +114,6 @@ type subscriberMetrics struct {
 	messagesReceived prometheus.Counter
 	subscribeErrors  prometheus.Counter
 	handlerDuration  prometheus.Histogram
-	slowConsumers    prometheus.Counter
 }
 
 func newSubscriberMetrics() *subscriberMetrics {
@@ -126,7 +133,7 @@ func newSubscriberMetrics() *subscriberMetrics {
 		}),
 		// Time spent in the message handler, the leading indicator of a slow
 		// consumer: a handler that lags lets the client-side buffer fill until the
-		// broker drops messages (slowConsumers below).
+		// broker drops messages (asyncErrors, error="slow_consumer").
 		handlerDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Namespace: metricsNamespace,
 			Subsystem: metricsSubsystem,
@@ -134,19 +141,11 @@ func newSubscriberMetrics() *subscriberMetrics {
 			Help:      "Time spent processing a received message in the subscriber handler.",
 			Buckets:   prometheus.DefBuckets,
 		}),
-		// Slow-consumer async errors are connection-wide (NATS cannot attribute the
-		// dropped messages to a single logical subscriber), so this is unlabeled.
-		slowConsumers: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: metricsNamespace,
-			Subsystem: metricsSubsystem,
-			Name:      "subscriber_slow_consumers_total",
-			Help:      "Total number of NATS slow-consumer errors (messages dropped because the client could not keep up).",
-		}),
 	}
 }
 
 func (m *subscriberMetrics) collectors() []prometheus.Collector {
-	return append(m.connectionMetrics.collectors(), m.messagesReceived, m.subscribeErrors, m.handlerDuration, m.slowConsumers)
+	return append(m.connectionMetrics.collectors(), m.messagesReceived, m.subscribeErrors, m.handlerDuration)
 }
 
 // serverMetrics covers the embedded NATS server. It is registered only in

--- a/pkg/infra/nats/publisher.go
+++ b/pkg/infra/nats/publisher.go
@@ -4,21 +4,41 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 
 	"github.com/grafana/dskit/services"
 	natsclient "github.com/nats-io/nats.go"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcewatch"
 )
 
 const publisherName = "nats-publisher"
+
+const (
+	reasonPermissionsViolation = "permissions_violation"
+	reasonAuthorization        = "authorization"
+	reasonAuthExpired          = "auth_expired"
+	reasonAuthRevoked          = "auth_revoked"
+	reasonAccountAuthExpired   = "account_auth_expired"
+	reasonMaxSubscriptions     = "max_subscriptions"
+	reasonSlowConsumer         = "slow_consumer"
+	reasonOther                = "other"
+)
 
 var connStateErrs = []error{
 	natsclient.ErrReconnectBufExceeded,
 	natsclient.ErrConnectionClosed,
 	natsclient.ErrConnectionDraining,
 }
+
+// publishPermissionsRe extracts the subject from a publish permissions
+// violation. The server names the rejected subject in the error text only —
+// nats.go passes a nil *Subscription for a publish rejection, since no
+// subscription is involved — so the subject has to be read back out of the
+// message. Mirrors nats.go's own permissionsRe for the subscribe direction.
+var publishPermissionsRe = regexp.MustCompile(`Publish to "(\S+)"`)
 
 // Publisher hides nats.go types so callers can mock it.
 type Publisher interface {
@@ -35,6 +55,7 @@ type PublisherService struct {
 
 func newPublisher(logger log.Logger, m *publisherMetrics, config *Config) *PublisherService {
 	conn := newConnection(rolePublisher, logger, m.connectionMetrics, config, config.PublisherCredentials)
+	conn.onAsyncError = func(err error) { m.recordAsyncError(err) }
 	p := &PublisherService{connection: conn, metrics: m}
 	p.NamedService = services.NewBasicService(nil, p.running, p.stopping).WithName(publisherName)
 	return p
@@ -101,4 +122,38 @@ func isConnStateErr(err error) bool {
 		}
 	}
 	return false
+}
+
+func (m *publisherMetrics) recordAsyncError(err error) {
+	if err == nil {
+		return
+	}
+	var group, resource string
+	if errors.Is(err, natsclient.ErrPermissionViolation) {
+		if match := publishPermissionsRe.FindStringSubmatch(err.Error()); len(match) == 2 {
+			group, _, resource, _ = resourcewatch.ParseSubject(match[1])
+		}
+	}
+	m.asyncErrors.WithLabelValues(group, resource, asyncErrorReason(err)).Inc()
+}
+
+func asyncErrorReason(err error) string {
+	switch {
+	case errors.Is(err, natsclient.ErrPermissionViolation):
+		return reasonPermissionsViolation
+	case errors.Is(err, natsclient.ErrAuthorization):
+		return reasonAuthorization
+	case errors.Is(err, natsclient.ErrAuthExpired):
+		return reasonAuthExpired
+	case errors.Is(err, natsclient.ErrAuthRevoked):
+		return reasonAuthRevoked
+	case errors.Is(err, natsclient.ErrAccountAuthExpired):
+		return reasonAccountAuthExpired
+	case errors.Is(err, natsclient.ErrMaxSubscriptionsExceeded):
+		return reasonMaxSubscriptions
+	case errors.Is(err, natsclient.ErrSlowConsumer):
+		return reasonSlowConsumer
+	default:
+		return reasonOther
+	}
 }

--- a/pkg/infra/nats/publisher.go
+++ b/pkg/infra/nats/publisher.go
@@ -2,43 +2,15 @@ package nats
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"regexp"
 
 	"github.com/grafana/dskit/services"
-	natsclient "github.com/nats-io/nats.go"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/storage/unified/resourcewatch"
 )
 
 const publisherName = "nats-publisher"
-
-const (
-	reasonPermissionsViolation = "permissions_violation"
-	reasonAuthorization        = "authorization"
-	reasonAuthExpired          = "auth_expired"
-	reasonAuthRevoked          = "auth_revoked"
-	reasonAccountAuthExpired   = "account_auth_expired"
-	reasonMaxSubscriptions     = "max_subscriptions"
-	reasonSlowConsumer         = "slow_consumer"
-	reasonOther                = "other"
-)
-
-var connStateErrs = []error{
-	natsclient.ErrReconnectBufExceeded,
-	natsclient.ErrConnectionClosed,
-	natsclient.ErrConnectionDraining,
-}
-
-// publishPermissionsRe extracts the subject from a publish permissions
-// violation. The server names the rejected subject in the error text only —
-// nats.go passes a nil *Subscription for a publish rejection, since no
-// subscription is involved — so the subject has to be read back out of the
-// message. Mirrors nats.go's own permissionsRe for the subscribe direction.
-var publishPermissionsRe = regexp.MustCompile(`Publish to "(\S+)"`)
 
 // Publisher hides nats.go types so callers can mock it.
 type Publisher interface {
@@ -55,7 +27,6 @@ type PublisherService struct {
 
 func newPublisher(logger log.Logger, m *publisherMetrics, config *Config) *PublisherService {
 	conn := newConnection(rolePublisher, logger, m.connectionMetrics, config, config.PublisherCredentials)
-	conn.onAsyncError = func(err error) { m.recordAsyncError(err) }
 	p := &PublisherService{connection: conn, metrics: m}
 	p.NamedService = services.NewBasicService(nil, p.running, p.stopping).WithName(publisherName)
 	return p
@@ -113,47 +84,4 @@ func (p *PublisherService) Publish(ctx context.Context, subject string, data []b
 	p.metrics.messagesPublished.Inc()
 	p.log.Debug("published message", "subject", subject, "bytes", len(data))
 	return nil
-}
-
-func isConnStateErr(err error) bool {
-	for _, target := range connStateErrs {
-		if errors.Is(err, target) {
-			return true
-		}
-	}
-	return false
-}
-
-func (m *publisherMetrics) recordAsyncError(err error) {
-	if err == nil {
-		return
-	}
-	var group, resource string
-	if errors.Is(err, natsclient.ErrPermissionViolation) {
-		if match := publishPermissionsRe.FindStringSubmatch(err.Error()); len(match) == 2 {
-			group, _, resource, _ = resourcewatch.ParseSubject(match[1])
-		}
-	}
-	m.asyncErrors.WithLabelValues(group, resource, asyncErrorReason(err)).Inc()
-}
-
-func asyncErrorReason(err error) string {
-	switch {
-	case errors.Is(err, natsclient.ErrPermissionViolation):
-		return reasonPermissionsViolation
-	case errors.Is(err, natsclient.ErrAuthorization):
-		return reasonAuthorization
-	case errors.Is(err, natsclient.ErrAuthExpired):
-		return reasonAuthExpired
-	case errors.Is(err, natsclient.ErrAuthRevoked):
-		return reasonAuthRevoked
-	case errors.Is(err, natsclient.ErrAccountAuthExpired):
-		return reasonAccountAuthExpired
-	case errors.Is(err, natsclient.ErrMaxSubscriptionsExceeded):
-		return reasonMaxSubscriptions
-	case errors.Is(err, natsclient.ErrSlowConsumer):
-		return reasonSlowConsumer
-	default:
-		return reasonOther
-	}
 }

--- a/pkg/infra/nats/publisher_test.go
+++ b/pkg/infra/nats/publisher_test.go
@@ -2,11 +2,9 @@ package nats
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	natsclient "github.com/nats-io/nats.go"
-	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -50,26 +48,6 @@ func TestPublisher(t *testing.T) {
 		require.ErrorContains(t, err, "connection not established")
 	})
 
-	t.Run("isConnStateErr", func(t *testing.T) {
-		for _, tc := range []struct {
-			name string
-			err  error
-			want bool
-		}{
-			{"reconnect buffer exceeded", natsclient.ErrReconnectBufExceeded, true},
-			{"connection closed", natsclient.ErrConnectionClosed, true},
-			{"connection draining", natsclient.ErrConnectionDraining, true},
-			{"wrapped", fmt.Errorf("publish: %w", natsclient.ErrConnectionClosed), true},
-			{"max payload", natsclient.ErrMaxPayload, false},
-			{"bad subject", natsclient.ErrBadSubject, false},
-			{"nil", nil, false},
-		} {
-			t.Run(tc.name, func(t *testing.T) {
-				require.Equal(t, tc.want, isConnStateErr(tc.err))
-			})
-		}
-	})
-
 	t.Run("publish honours a cancelled context", func(t *testing.T) {
 		p := newTestPublisher(t, startTestServer(t))
 
@@ -80,72 +58,5 @@ func TestPublisher(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		require.ErrorIs(t, p.Publish(ctx, "grafana.test.a", []byte("world")), context.Canceled)
-	})
-}
-
-func TestPublisherAsyncErrors(t *testing.T) {
-	// The exact text nats-server sends for a rejected publish, as nats.go wraps it
-	// (see processErr -> processTransientError). Publish has already returned nil
-	// by the time this arrives, and the *Subscription is nil, so the subject is
-	// only available from the message itself.
-	permissionsViolation := func(subject string) error {
-		return fmt.Errorf("%w: Permissions Violation for Publish to %q", natsclient.ErrPermissionViolation, subject)
-	}
-
-	tests := []struct {
-		name         string
-		err          error
-		wantGroup    string
-		wantResource string
-		wantReason   string
-	}{
-		{
-			name:         "rejected publish is attributed to its group and resource",
-			err:          permissionsViolation("us.watch.v1.provisioning.grafana.app.stacks-1.jobs"),
-			wantGroup:    "provisioning.grafana.app",
-			wantResource: "jobs",
-			wantReason:   reasonPermissionsViolation,
-		},
-		{
-			name:       "rejected publish on a subject this bus does not own",
-			err:        permissionsViolation("some.other.subject"),
-			wantReason: reasonPermissionsViolation,
-		},
-		{
-			name:       "authorization violation carries no subject",
-			err:        natsclient.ErrAuthorization,
-			wantReason: reasonAuthorization,
-		},
-		{
-			name:       "expired credentials",
-			err:        natsclient.ErrAuthExpired,
-			wantReason: reasonAuthExpired,
-		},
-		{
-			name:       "unclassified errors are not dropped",
-			err:        context.Canceled,
-			wantReason: reasonOther,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			m := newPublisherMetrics()
-			cfg := setting.NATSSettings{Enabled: true}
-			p := newPublisher(log.NewNopLogger(), m, newConfig(cfg, nil))
-
-			// Drive the connection's async error hook directly, as the NATS client
-			// would from its own goroutine.
-			p.onAsyncError(tc.err)
-
-			require.Equal(t, float64(1), testutil.ToFloat64(m.asyncErrors.WithLabelValues(tc.wantGroup, tc.wantResource, tc.wantReason)))
-			require.Equal(t, 1, testutil.CollectAndCount(m.asyncErrors), "exactly one series must be touched")
-		})
-	}
-
-	t.Run("a nil error is ignored", func(t *testing.T) {
-		m := newPublisherMetrics()
-		m.recordAsyncError(nil)
-		require.Equal(t, 0, testutil.CollectAndCount(m.asyncErrors))
 	})
 }

--- a/pkg/infra/nats/publisher_test.go
+++ b/pkg/infra/nats/publisher_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	natsclient "github.com/nats-io/nats.go"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -79,5 +80,72 @@ func TestPublisher(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		require.ErrorIs(t, p.Publish(ctx, "grafana.test.a", []byte("world")), context.Canceled)
+	})
+}
+
+func TestPublisherAsyncErrors(t *testing.T) {
+	// The exact text nats-server sends for a rejected publish, as nats.go wraps it
+	// (see processErr -> processTransientError). Publish has already returned nil
+	// by the time this arrives, and the *Subscription is nil, so the subject is
+	// only available from the message itself.
+	permissionsViolation := func(subject string) error {
+		return fmt.Errorf("%w: Permissions Violation for Publish to %q", natsclient.ErrPermissionViolation, subject)
+	}
+
+	tests := []struct {
+		name         string
+		err          error
+		wantGroup    string
+		wantResource string
+		wantReason   string
+	}{
+		{
+			name:         "rejected publish is attributed to its group and resource",
+			err:          permissionsViolation("us.watch.v1.provisioning.grafana.app.stacks-1.jobs"),
+			wantGroup:    "provisioning.grafana.app",
+			wantResource: "jobs",
+			wantReason:   reasonPermissionsViolation,
+		},
+		{
+			name:       "rejected publish on a subject this bus does not own",
+			err:        permissionsViolation("some.other.subject"),
+			wantReason: reasonPermissionsViolation,
+		},
+		{
+			name:       "authorization violation carries no subject",
+			err:        natsclient.ErrAuthorization,
+			wantReason: reasonAuthorization,
+		},
+		{
+			name:       "expired credentials",
+			err:        natsclient.ErrAuthExpired,
+			wantReason: reasonAuthExpired,
+		},
+		{
+			name:       "unclassified errors are not dropped",
+			err:        context.Canceled,
+			wantReason: reasonOther,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newPublisherMetrics()
+			cfg := setting.NATSSettings{Enabled: true}
+			p := newPublisher(log.NewNopLogger(), m, newConfig(cfg, nil))
+
+			// Drive the connection's async error hook directly, as the NATS client
+			// would from its own goroutine.
+			p.onAsyncError(tc.err)
+
+			require.Equal(t, float64(1), testutil.ToFloat64(m.asyncErrors.WithLabelValues(tc.wantGroup, tc.wantResource, tc.wantReason)))
+			require.Equal(t, 1, testutil.CollectAndCount(m.asyncErrors), "exactly one series must be touched")
+		})
+	}
+
+	t.Run("a nil error is ignored", func(t *testing.T) {
+		m := newPublisherMetrics()
+		m.recordAsyncError(nil)
+		require.Equal(t, 0, testutil.CollectAndCount(m.asyncErrors))
 	})
 }

--- a/pkg/infra/nats/subscriber.go
+++ b/pkg/infra/nats/subscriber.go
@@ -2,7 +2,6 @@ package nats
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -68,12 +67,6 @@ type SubscriberService struct {
 
 func newSubscriber(logger log.Logger, m *subscriberMetrics, config *Config) *SubscriberService {
 	conn := newConnection(roleSubscriber, logger, m.connectionMetrics, config, config.SubscriberCredentials)
-	// A slow consumer means the broker dropped messages the client could not drain in time.
-	conn.onAsyncError = func(err error) {
-		if errors.Is(err, natsclient.ErrSlowConsumer) {
-			m.slowConsumers.Inc()
-		}
-	}
 	s := &SubscriberService{connection: conn, metrics: m}
 	s.NamedService = services.NewBasicService(nil, s.running, s.stopping).WithName(subscriberName)
 	return s

--- a/pkg/infra/nats/subscriber_test.go
+++ b/pkg/infra/nats/subscriber_test.go
@@ -146,15 +146,10 @@ func TestSubscriber(t *testing.T) {
 
 	t.Run("counts slow-consumer async errors", func(t *testing.T) {
 		m := newSubscriberMetrics()
-		cfg := setting.NATSSettings{Enabled: true}
-		sub := newSubscriber(log.NewNopLogger(), m, newConfig(cfg, nil))
 
-		// Drive the connection's async error hook directly: slow-consumer errors are
-		// counted, unrelated async errors are ignored.
-		sub.onAsyncError(natsclient.ErrSlowConsumer)
-		sub.onAsyncError(context.Canceled)
+		m.recordAsyncError(&natsclient.Subscription{Subject: "us.watch.v1.provisioning.grafana.app.stacks-1.jobs"}, natsclient.ErrSlowConsumer)
 
-		require.Equal(t, float64(1), testutil.ToFloat64(m.slowConsumers))
+		require.Equal(t, float64(1), testutil.ToFloat64(m.asyncErrors.WithLabelValues("provisioning.grafana.app", "jobs", reasonSlowConsumer)))
 	})
 
 	t.Run("subscribe honours a cancelled context", func(t *testing.T) {

--- a/pkg/storage/unified/resourcewatch/subject.go
+++ b/pkg/storage/unified/resourcewatch/subject.go
@@ -59,3 +59,41 @@ func Subject(gvr schema.GroupVersionResource, namespace string) string {
 	}
 	return strings.Join([]string{subjectRoot, group, namespace, resource}, ".")
 }
+
+// ParseSubject decomposes a subject produced by Subject back into its
+// components. It is the inverse of Subject: the core group's "_core" token maps
+// back to the empty group, and a "*" in the namespace or resource position is
+// returned verbatim, so Subject(ParseSubject(s)) == s.
+//
+// The group's own dots make its token count variable, but namespace and resource
+// are always exactly one token and always last, so the split is taken from the
+// tail rather than a fixed offset. ok is false for anything that is not a
+// Subject: a different root, a ">" tail (SubjectAllResources cannot be
+// decomposed — it names no single group), or too few tokens to fill all three
+// positions.
+//
+// It exists for the reverse direction of the publish path: NATS reports a
+// publish permissions violation asynchronously, carrying only the subject text,
+// so the group and resource behind a rejected publish have to be recovered from
+// the subject itself.
+func ParseSubject(subject string) (group, namespace, resource string, ok bool) {
+	rest, found := strings.CutPrefix(subject, subjectRoot+".")
+	if !found {
+		return "", "", "", false
+	}
+	tokens := strings.Split(rest, ".")
+	// One token each for namespace and resource, at least one for the group.
+	if len(tokens) < 3 {
+		return "", "", "", false
+	}
+	for _, token := range tokens {
+		if token == "" || token == ">" {
+			return "", "", "", false
+		}
+	}
+	group = strings.Join(tokens[:len(tokens)-2], ".")
+	if group == coreGroup {
+		group = ""
+	}
+	return group, tokens[len(tokens)-2], tokens[len(tokens)-1], true
+}

--- a/pkg/storage/unified/resourcewatch/subject_test.go
+++ b/pkg/storage/unified/resourcewatch/subject_test.go
@@ -212,3 +212,80 @@ func subjectMatches(pattern, subject string) bool {
 	}
 	return len(patternTokens) == len(subjectTokens)
 }
+
+func TestParseSubject(t *testing.T) {
+	tests := []struct {
+		name          string
+		subject       string
+		wantGroup     string
+		wantNamespace string
+		wantResource  string
+		wantOK        bool
+	}{
+		{
+			name:          "multi-token group",
+			subject:       "us.watch.v1.provisioning.grafana.app.stacks-1.repositories",
+			wantGroup:     "provisioning.grafana.app",
+			wantNamespace: "stacks-1",
+			wantResource:  "repositories",
+			wantOK:        true,
+		},
+		{
+			name:          "core group token maps back to the empty group",
+			subject:       "us.watch.v1._core.default.configmaps",
+			wantGroup:     "",
+			wantNamespace: "default",
+			wantResource:  "configmaps",
+			wantOK:        true,
+		},
+		{
+			name:          "single-token group",
+			subject:       "us.watch.v1.dashboard.default.dashboards",
+			wantGroup:     "dashboard",
+			wantNamespace: "default",
+			wantResource:  "dashboards",
+			wantOK:        true,
+		},
+		{
+			name:          "wildcard positions are returned verbatim",
+			subject:       "us.watch.v1.provisioning.grafana.app.*.*",
+			wantGroup:     "provisioning.grafana.app",
+			wantNamespace: anyToken,
+			wantResource:  anyToken,
+			wantOK:        true,
+		},
+		{name: "another root is not a subject", subject: "other.root.v1.g.ns.r"},
+		{name: "the root alone", subject: subjectRoot},
+		{name: "too few tokens for all three positions", subject: "us.watch.v1.group.namespace"},
+		{name: "the firehose cannot be decomposed", subject: SubjectAllResources},
+		{name: "a tail wildcard in the resource position", subject: "us.watch.v1.group.namespace.>"},
+		{name: "an empty token", subject: "us.watch.v1.group..resource"},
+		{name: "empty", subject: ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			group, namespace, resource, ok := ParseSubject(tc.subject)
+			assert.Equal(t, tc.wantOK, ok)
+			assert.Equal(t, tc.wantGroup, group)
+			assert.Equal(t, tc.wantNamespace, namespace)
+			assert.Equal(t, tc.wantResource, resource)
+		})
+	}
+}
+
+func TestParseSubjectRoundTrip(t *testing.T) {
+	for _, gvr := range []schema.GroupVersionResource{
+		{Group: "provisioning.grafana.app", Resource: "jobs"},
+		{Group: "dashboard", Resource: "dashboards"},
+		{Group: "", Resource: "configmaps"},
+		{Group: "provisioning.grafana.app", Resource: ""},
+	} {
+		for _, namespace := range []string{"stacks-42", ""} {
+			subject := Subject(gvr, namespace)
+			group, gotNamespace, resource, ok := ParseSubject(subject)
+			require.True(t, ok, "subject %q must parse", subject)
+			require.Equal(t, subject, Subject(schema.GroupVersionResource{Group: group, Resource: resource}, gotNamespace))
+		}
+	}
+}


### PR DESCRIPTION
Centralize error handling for nats package, improve async error handling for nats connection and publish relevant metrics when errors are encountered.

Ticket: https://github.com/grafana/search-and-storage-team/issues/906