### PR TITLE
Datasources: Migrate k8s group lookup off config.datasources

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2001,11 +2001,6 @@
       "count": 1
     }
   },
-  "public/app/features/datasources/api.ts": {
-    "@grafana/no-config-datasources": {
-      "count": 2
-    }
-  },
   "public/app/features/datasources/components/ButtonRow.tsx": {
     "@grafana/no-gf-form": {
       "count": 1

--- a/public/app/features/datasources/api.test.ts
+++ b/public/app/features/datasources/api.test.ts
@@ -254,8 +254,7 @@ describe('Datasources / API', () => {
       expect(deleteFn).not.toHaveBeenCalled();
     });
 
-    // The group lookup must be uid-exact: matching on name or id, or resolving `default`
-    // to the org default, would build a k8s URL for the wrong data source.
+    // A non-uid match would build a k8s URL for the wrong data source.
     it.each([
       ['a name rather than a uid', 'Marvin'],
       ['an id rather than a uid', '42'],

--- a/public/app/features/datasources/api.test.ts
+++ b/public/app/features/datasources/api.test.ts
@@ -1,7 +1,8 @@
 import { of } from 'rxjs';
 
-import { type DataSourceSettings } from '@grafana/data';
-import { type BackendSrvRequest, type FetchResponse } from '@grafana/runtime';
+import { type DataSourceInstanceSettings, type DataSourceSettings } from '@grafana/data';
+import { config, type BackendSrvRequest, type FetchResponse } from '@grafana/runtime';
+import { FlagKeys, getFeatureFlagClient, setDataSourceInstanceSettings } from '@grafana/runtime/internal';
 import { getBackendSrv } from 'app/core/services/backend_srv';
 
 import {
@@ -19,6 +20,32 @@ jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   getBackendSrv: jest.fn(),
 }));
+jest.mock('@grafana/runtime/internal', () => ({
+  ...jest.requireActual('@grafana/runtime/internal'),
+  getFeatureFlagClient: jest.fn(),
+}));
+
+const mockGetFeatureFlagClient = jest.mocked(getFeatureFlagClient);
+const getBooleanValueFn = jest.fn();
+
+// stubCRUDApisEnabled toggles only the new-CRUD-APIs flag; any other flag key
+// falls through to the default the caller supplied.
+function stubCRUDApisEnabled(enabled: boolean) {
+  getBooleanValueFn.mockImplementation((key: string, defaultValue: boolean) =>
+    key === FlagKeys.DatasourcesConfigUiUseNewDatasourceCRUDAPIs ? enabled : defaultValue
+  );
+}
+
+const marvinSettings = {
+  id: 42,
+  uid: 'abc123',
+  name: 'Marvin',
+  type: 'marvin',
+  access: 'proxy',
+  jsonData: {},
+  readOnly: false,
+  meta: { id: 'marvin' },
+} as DataSourceInstanceSettings;
 
 const mockResponse = (response: Partial<FetchResponse>) => {
   (getBackendSrv as jest.Mock).mockReturnValueOnce({
@@ -28,7 +55,31 @@ const mockResponse = (response: Partial<FetchResponse>) => {
   });
 };
 
+// The k8s read path issues two requests (the resource and its /access subresource),
+// so responses are picked by URL rather than by call order.
+const mockResponsesByUrl = (responses: Record<string, Partial<FetchResponse>>) => {
+  const fetch = jest.fn((options: BackendSrvRequest) => of(responses[options.url] as FetchResponse));
+  (getBackendSrv as jest.Mock).mockReturnValue({ fetch });
+  return fetch;
+};
+
+const originalNamespace = config.namespace;
+
 describe('Datasources / API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetFeatureFlagClient.mockReturnValue({ getBooleanValue: getBooleanValueFn } as unknown as ReturnType<
+      typeof getFeatureFlagClient
+    >);
+    stubCRUDApisEnabled(false);
+    setDataSourceInstanceSettings({ Marvin: marvinSettings });
+    config.namespace = 'default';
+  });
+
+  afterAll(() => {
+    config.namespace = originalNamespace;
+  });
+
   describe('getDataSourceByUid()', () => {
     it('should resolve to the datasource object in case it is fetched using a UID', async () => {
       const response = {
@@ -41,6 +92,37 @@ describe('Datasources / API', () => {
       mockResponse(response);
 
       expect(await getDataSourceByUid(response.data.uid)).toBe(response.data);
+    });
+
+    it('should derive the k8s group from the instance settings when the new CRUD APIs are enabled', async () => {
+      stubCRUDApisEnabled(true);
+      const base = '/apis/marvin.datasource.grafana.app/v0alpha1/namespaces/default/datasources/abc123';
+      const fetch = mockResponsesByUrl({
+        [base]: {
+          ok: true,
+          data: {
+            kind: 'DataSource',
+            apiVersion: 'marvin.datasource.grafana.app/v0alpha1',
+            metadata: { name: 'abc123', resourceVersion: '2' },
+            spec: { title: 'Marvin' },
+          },
+        },
+        [`${base}/access`]: { ok: true, data: { Permissions: { 'datasources:read': true } } },
+      });
+
+      const result = await getDataSourceByUid('abc123');
+
+      expect(fetch).toHaveBeenCalledWith(expect.objectContaining({ url: base }));
+      expect(fetch).toHaveBeenCalledWith(expect.objectContaining({ url: `${base}/access` }));
+      expect(result.uid).toBe('abc123');
+      expect(result.type).toBe('marvin');
+      expect(result.accessControl).toEqual({ 'datasources:read': true });
+    });
+
+    it('should reject when the uid is unknown and the new CRUD APIs are enabled', async () => {
+      stubCRUDApisEnabled(true);
+
+      await expect(getDataSourceByUid('nope')).rejects.toThrow('Could not find data source group with uid: "nope"');
     });
   });
   describe('convertK8sDatasourceSettingsToLegacyDatasourceSettings()', () => {
@@ -136,6 +218,27 @@ describe('Datasources / API', () => {
 
       expect(deleteFn).toHaveBeenCalledWith('/api/datasources/uid/abc123');
       expect(result).toEqual(deleteResult);
+    });
+
+    it('should delete through the k8s API when the new CRUD APIs are enabled', async () => {
+      stubCRUDApisEnabled(true);
+      const deleteFn = jest.fn().mockResolvedValue({});
+      (getBackendSrv as jest.Mock).mockReturnValueOnce({ delete: deleteFn });
+
+      await deleteDataSource('abc123');
+
+      expect(deleteFn).toHaveBeenCalledWith(
+        '/apis/marvin.datasource.grafana.app/v0alpha1/namespaces/default/datasources/abc123'
+      );
+    });
+
+    it('should reject rather than issue a request with an empty group when the uid is unknown', async () => {
+      stubCRUDApisEnabled(true);
+      const deleteFn = jest.fn();
+      (getBackendSrv as jest.Mock).mockReturnValueOnce({ delete: deleteFn });
+
+      await expect(deleteDataSource('nope')).rejects.toThrow('Could not find data source group with uid: "nope"');
+      expect(deleteFn).not.toHaveBeenCalled();
     });
   });
 

--- a/public/app/features/datasources/api.test.ts
+++ b/public/app/features/datasources/api.test.ts
@@ -47,6 +47,19 @@ const marvinSettings = {
   meta: { id: 'marvin' },
 } as DataSourceInstanceSettings;
 
+// getDataSourceInstanceList appends -- Grafana -- to most results, so the group
+// lookup has to keep excluding built-ins itself.
+const grafanaSettings = {
+  id: 1,
+  uid: '-- Grafana --',
+  name: '-- Grafana --',
+  type: 'grafana',
+  access: 'proxy',
+  jsonData: {},
+  readOnly: true,
+  meta: { id: 'grafana' },
+} as DataSourceInstanceSettings;
+
 const mockResponse = (response: Partial<FetchResponse>) => {
   (getBackendSrv as jest.Mock).mockReturnValueOnce({
     fetch: (options: BackendSrvRequest) => {
@@ -72,7 +85,7 @@ describe('Datasources / API', () => {
       typeof getFeatureFlagClient
     >);
     stubCRUDApisEnabled(false);
-    setDataSourceInstanceSettings({ Marvin: marvinSettings });
+    setDataSourceInstanceSettings({ Marvin: marvinSettings, '-- Grafana --': grafanaSettings }, 'Marvin');
     config.namespace = 'default';
   });
 
@@ -238,6 +251,22 @@ describe('Datasources / API', () => {
       (getBackendSrv as jest.Mock).mockReturnValueOnce({ delete: deleteFn });
 
       await expect(deleteDataSource('nope')).rejects.toThrow('Could not find data source group with uid: "nope"');
+      expect(deleteFn).not.toHaveBeenCalled();
+    });
+
+    // The group lookup must be uid-exact: matching on name or id, or resolving `default`
+    // to the org default, would build a k8s URL for the wrong data source.
+    it.each([
+      ['a name rather than a uid', 'Marvin'],
+      ['an id rather than a uid', '42'],
+      ['the literal "default"', 'default'],
+      ['a built-in data source', '-- Grafana --'],
+    ])('should reject when given %s', async (_, uid) => {
+      stubCRUDApisEnabled(true);
+      const deleteFn = jest.fn();
+      (getBackendSrv as jest.Mock).mockReturnValueOnce({ delete: deleteFn });
+
+      await expect(deleteDataSource(uid)).rejects.toThrow(`Could not find data source group with uid: "${uid}"`);
       expect(deleteFn).not.toHaveBeenCalled();
     });
   });

--- a/public/app/features/datasources/api.ts
+++ b/public/app/features/datasources/api.ts
@@ -58,12 +58,7 @@ export interface DataSourceSettingsK8s {
   secure?: Record<string, Record<string, string>>;
 }
 
-// Scans the list rather than calling getDataSourceInstanceSettings, which resolves a ref
-// through uid, then name, then id, and maps `default` to the org default — so a colliding
-// name would yield the wrong group. This lookup has to be uid-exact.
 const getDataSourceK8sGroup = async (uid: string): Promise<string> => {
-  // `all: true` keeps data sources that expose no query capability, matching the previous
-  // scan over every entry in config.datasources.
   const instances = await getDataSourceInstanceList({ all: true });
   for (const ds of instances) {
     // Built-in data sources (-- Grafana --, -- Mixed --, -- Dashboard --) have no k8s group.

--- a/public/app/features/datasources/api.ts
+++ b/public/app/features/datasources/api.ts
@@ -4,7 +4,7 @@ import { lastValueFrom } from 'rxjs';
 import { type DataSourceSettings, type DataSourceJsonData } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
-import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
+import { getDataSourceInstanceList } from '@grafana/runtime/unstable';
 import { getBackendSrv } from 'app/core/services/backend_srv';
 import { accessControlQueryParam } from 'app/core/utils/accessControl';
 
@@ -58,11 +58,23 @@ export interface DataSourceSettingsK8s {
   secure?: Record<string, Record<string, string>>;
 }
 
-// Passing a ref object rather than a bare uid string keeps this a strict uid lookup — a
-// string would also match on name/id and resolve `default` to the default data source.
+// Scans the list rather than calling getDataSourceInstanceSettings, which resolves a ref
+// through uid, then name, then id, and maps `default` to the org default — so a colliding
+// name would yield the wrong group. This lookup has to be uid-exact.
 const getDataSourceK8sGroup = async (uid: string): Promise<string> => {
-  const settings = await getDataSourceInstanceSettings({ uid });
-  return settings ? `${settings.type}.datasource.grafana.app` : '';
+  // `all: true` keeps data sources that expose no query capability, matching the previous
+  // scan over every entry in config.datasources.
+  const instances = await getDataSourceInstanceList({ all: true });
+  for (const ds of instances) {
+    // Built-in data sources (-- Grafana --, -- Mixed --, -- Dashboard --) have no k8s group.
+    if (ds.name.startsWith('--')) {
+      continue;
+    }
+    if (ds.uid === uid) {
+      return ds.type + '.datasource.grafana.app';
+    }
+  }
+  return '';
 };
 
 const convertLegacyDatasourceSettingsPartialToK8sDatasourceSettings = (

--- a/public/app/features/datasources/api.ts
+++ b/public/app/features/datasources/api.ts
@@ -4,6 +4,7 @@ import { lastValueFrom } from 'rxjs';
 import { type DataSourceSettings, type DataSourceJsonData } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { getBackendSrv } from 'app/core/services/backend_srv';
 import { accessControlQueryParam } from 'app/core/utils/accessControl';
 
@@ -57,16 +58,11 @@ export interface DataSourceSettingsK8s {
   secure?: Record<string, Record<string, string>>;
 }
 
-const getDataSourceK8sGroup = (uid: string): string => {
-  for (const [key, ds] of Object.entries(config.datasources)) {
-    if (key.startsWith('--')) {
-      continue;
-    }
-    if (config.datasources[key].uid === uid) {
-      return ds.type + '.datasource.grafana.app';
-    }
-  }
-  return '';
+// Passing a ref object rather than a bare uid string keeps this a strict uid lookup — a
+// string would also match on name/id and resolve `default` to the default data source.
+const getDataSourceK8sGroup = async (uid: string): Promise<string> => {
+  const settings = await getDataSourceInstanceSettings({ uid });
+  return settings ? `${settings.type}.datasource.grafana.app` : '';
 };
 
 const convertLegacyDatasourceSettingsPartialToK8sDatasourceSettings = (
@@ -194,7 +190,7 @@ const getSecretName = async (datasourceUid: string, fieldName: string): Promise<
 const getDataSourceFromK8sAPI = async (k8sName: string, namespace: string) => {
   // TODO: read this from backend.
   let k8sVersion = 'v0alpha1';
-  let k8sGroup = getDataSourceK8sGroup(k8sName);
+  let k8sGroup = await getDataSourceK8sGroup(k8sName);
   if (k8sGroup === '') {
     throw Error(`Could not find data source group with uid: "${k8sName}"`);
   }
@@ -334,11 +330,15 @@ export const updateDataSource = async (dataSource: DataSourceSettings) => {
     .then((response) => response.datasource);
 };
 
-export const deleteDataSource = (uid: string) => {
+export const deleteDataSource = async (uid: string) => {
   let deleteUrl = `/api/datasources/uid/${uid}`;
   if (getFeatureFlagClient().getBooleanValue(FlagKeys.DatasourcesConfigUiUseNewDatasourceCRUDAPIs, false)) {
     let namespace = config.namespace;
-    let apiVersion = `${getDataSourceK8sGroup(uid)}/v0alpha1`;
+    let k8sGroup = await getDataSourceK8sGroup(uid);
+    if (k8sGroup === '') {
+      throw Error(`Could not find data source group with uid: "${uid}"`);
+    }
+    let apiVersion = `${k8sGroup}/v0alpha1`;
     deleteUrl = `/apis/${apiVersion}/namespaces/${namespace}/datasources/${uid}`;
   }
   return getBackendSrv().delete(deleteUrl);


### PR DESCRIPTION
Part of #125089 (wave 2.1)

This is needed for the MT Grafana work to progress.

`config.datasources` is the synchronous boot-time map of every datasource instance setting. While code reads it directly, those settings can never be paginated or lazy-loaded. This migrates the smallest, most self-contained call site.
