### PR TITLE
unified-search: release the lock left by the lock contract test

### DIFF
--- a/pkg/storage/unified/search/lock_objstore_test.go
+++ b/pkg/storage/unified/search/lock_objstore_test.go
@@ -364,6 +364,9 @@ func TestLockBackendSeparatesHeldFromNotOwned(t *testing.T) {
 			backend := newBackend(t)
 			key := testKey(t)
 			require.NoError(t, backend.Create(ctx, key, newLockInfo("owner-1", time.Minute)))
+			// Nothing below releases it: the key is derived from the test name, so against
+			// a real bucket a rerun inside the TTL would fail the Create above.
+			t.Cleanup(func() { _ = backend.Delete(context.Background(), key, "owner-1") })
 
 			// Someone else got there first.
 			require.ErrorIs(t, backend.Create(ctx, key, newLockInfo("owner-2", time.Minute)), errLockHeld)
@@ -371,6 +374,9 @@ func TestLockBackendSeparatesHeldFromNotOwned(t *testing.T) {
 			// Ours to begin with, no longer.
 			require.ErrorIs(t, backend.Update(ctx, key, newLockInfo("owner-2", time.Minute)), errLockNotOwned)
 			require.ErrorIs(t, backend.Delete(ctx, key, "owner-2"), errLockNotOwned)
+
+			// Still owner-1's after those refusals, so it can release it.
+			require.NoError(t, backend.Delete(ctx, key, "owner-1"))
 		})
 	}
 }


### PR DESCRIPTION
Follow-up to #130840, addressing a review comment I merged past.

The contract test creates a lock owned by `owner-1` and then only attempts deletes as `owner-2`, which are refused by design. Against a real bucket (`CDK_TEST_BUCKET_URL`) the lock stays behind, and since the key comes from the test name, a rerun inside the one minute TTL fails on the initial `Create`.

The test now releases it as `owner-1`, which doubles as an assertion that the lock was still theirs after both refusals, with a `t.Cleanup` as a backstop for an early failure. Cleanup uses `context.Background()` since `t.Context()` is already cancelled by then, matching `createLockForTest`.
