### PR TITLE
Chore: escape an underscore in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,7 +128,7 @@
 - **Provisioning:** Make Migrate to GitOps resource-agnostic for playlists [#127028](https://github.com/grafana/grafana/pull/127028), [@MissingRoberto](https://github.com/MissingRoberto)
 - **Provisioning:** Make Resources tab tree foldable [#128453](https://github.com/grafana/grafana/pull/128453), [@MissingRoberto](https://github.com/MissingRoberto)
 - **Provisioning:** Paginate the Migrate to GitOps resources table [#128042](https://github.com/grafana/grafana/pull/128042), [@MissingRoberto](https://github.com/MissingRoberto)
-- **Provisioning:** Pretty-print generated _folder.json [#127947](https://github.com/grafana/grafana/pull/127947), [@MissingRoberto](https://github.com/MissingRoberto)
+- **Provisioning:** Pretty-print generated \_folder.json [#127947](https://github.com/grafana/grafana/pull/127947), [@MissingRoberto](https://github.com/MissingRoberto)
 - **Provisioning:** Show folder path in Migrate resources list [#128454](https://github.com/grafana/grafana/pull/128454), [@MissingRoberto](https://github.com/MissingRoberto)
 - **Provisioning:** Show job author and origin in recent jobs [#128820](https://github.com/grafana/grafana/pull/128820), [@amalavet](https://github.com/amalavet)
 - **Provisioning:** Show job errors in Migrate to GitOps drawer [#127936](https://github.com/grafana/grafana/pull/127936), [@MissingRoberto](https://github.com/MissingRoberto)


### PR DESCRIPTION
The changelog generator wrote a bare underscore in `_folder.json` (line 131, from #130903). Prettier reads it as the start of emphasis and wants it escaped, so the Lint check fails on every open pull request against main.

This is the one-line `yarn prettier:write CHANGELOG.md` output. #130924 carries the same change as a drive-by; close this one if that merges first.
