### PR TITLE
Unified storage: serve LIST with label selectors through search

### DIFF
--- a/pkg/storage/unified/resource/list_with_selectors.go
+++ b/pkg/storage/unified/resource/list_with_selectors.go
@@ -9,9 +9,10 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+	"k8s.io/apimachinery/pkg/selection"
 )
 
-func (s *server) listWithFieldSelectors(ctx context.Context, req *resourcepb.ListRequest) (*resourcepb.ListResponse, error) {
+func (s *server) listWithSelectors(ctx context.Context, req *resourcepb.ListRequest) (*resourcepb.ListResponse, error) {
 	ctx, span := tracer.Start(ctx, "resource.server.ListWithFieldSelectors")
 	defer span.End()
 
@@ -39,6 +40,11 @@ func (s *server) listWithFieldSelectors(ctx context.Context, req *resourcepb.Lis
 				Error: NewBadRequestError("invalid continue token"),
 			}, nil
 		}
+		if tokenFromOtherListPath(token, true) {
+			return &resourcepb.ListResponse{
+				Error: NewBadRequestError("continue token was not issued for a search-backed list"),
+			}, nil
+		}
 		listRv = token.ResourceVersion
 		srq.SearchAfter = token.SearchAfter
 		srq.SearchBefore = token.SearchBefore
@@ -51,7 +57,7 @@ func (s *server) listWithFieldSelectors(ctx context.Context, req *resourcepb.Lis
 		searchResp, err = s.search.Search(ctx, srq)
 	} else {
 		// Use remote search service
-		// useFieldSelectorSearch() already checks that either s.search or s.searchClient is set
+		// useSelectorSearch() already checks that either s.search or s.searchClient is set
 		searchResp, err = s.searchClient.Search(ctx, srq)
 	}
 	if err != nil {
@@ -69,7 +75,7 @@ func (s *server) listWithFieldSelectors(ctx context.Context, req *resourcepb.Lis
 		ResourceVersion: listRv,
 	}
 
-	s.log.Info("Search used for List with field selectors", "group", req.Options.Key.Group, "resource", req.Options.Key.Resource, "search_hits", searchResp.TotalHits, "with_pagination", req.NextPageToken != "", "search_after", srq.SearchAfter, "selectable_fields", req.Options.Fields)
+	s.log.Info("Search used for List with selectors", "group", req.Options.Key.Group, "resource", req.Options.Key.Resource, "search_hits", searchResp.TotalHits, "with_pagination", req.NextPageToken != "", "search_after", srq.SearchAfter, "selectable_fields", req.Options.Fields, "labels", req.Options.Labels)
 	// Using searchResp.GetResults().GetRows() will not panic if anything is nil on the path.
 	for _, row := range searchResp.GetResults().GetRows() {
 		// TODO: use batch reads
@@ -107,9 +113,25 @@ func (s *server) listWithFieldSelectors(ctx context.Context, req *resourcepb.Lis
 	return rsp, nil
 }
 
-func filterFieldSelectors(req *resourcepb.ListRequest) *resourcepb.ListRequest {
+// tokenFromOtherListPath reports whether a continue token was issued by the other
+// list path. The two encode a position differently, sort values against the index
+// and a name against the store, so continuing with the wrong one would silently
+// restart from the first result.
+func tokenFromOtherListPath(token *ContinueToken, searchPath bool) bool {
+	if searchPath {
+		return token.Name != "" || token.Namespace != ""
+	}
+	return len(token.SearchAfter) > 0 || len(token.SearchBefore) > 0
+}
+
+// filterSelectors drops the requirements the index cannot answer, so a request
+// carrying one of them is still served rather than refused. Callers re-apply the
+// selector to the returned objects, so a dropped requirement costs extra reads
+// rather than correctness.
+func filterSelectors(req *resourcepb.ListRequest) *resourcepb.ListRequest {
 	fields := make([]*resourcepb.Requirement, 0, len(req.Options.Fields))
 	for _, f := range req.Options.Fields {
+		// metadata.namespace is already in the request key.
 		if (f.Operator != "=" && f.Operator != "==") || f.Key == "metadata.namespace" {
 			continue
 		}
@@ -117,11 +139,34 @@ func filterFieldSelectors(req *resourcepb.ListRequest) *resourcepb.ListRequest {
 	}
 	req.Options.Fields = fields
 
+	labels := make([]*resourcepb.Requirement, 0, len(req.Options.Labels))
+	for _, l := range req.Options.Labels {
+		if !indexableSelectorOperator(l.Operator) {
+			continue
+		}
+		labels = append(labels, l)
+	}
+	req.Options.Labels = labels
+
 	return req
 }
 
-func (s *server) useFieldSelectorSearch(req *resourcepb.ListRequest) bool {
-	if (s.searchClient == nil && s.search == nil) || req.Source != resourcepb.ListRequest_STORE || len(req.Options.Fields) == 0 {
+// indexableSelectorOperator reports whether requirementQuery can turn the operator
+// into an index query. A label selector may also carry !=, key and !key.
+func indexableSelectorOperator(op string) bool {
+	switch selection.Operator(op) {
+	case selection.Equals, selection.DoubleEquals, selection.In, selection.NotIn:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *server) useSelectorSearch(req *resourcepb.ListRequest) bool {
+	if (s.searchClient == nil && s.search == nil) || req.Source != resourcepb.ListRequest_STORE {
+		return false
+	}
+	if len(req.Options.Fields) == 0 && len(req.Options.Labels) == 0 {
 		return false
 	}
 

--- a/pkg/storage/unified/resource/list_with_selectors.go
+++ b/pkg/storage/unified/resource/list_with_selectors.go
@@ -166,6 +166,11 @@ func (s *server) useSelectorSearch(req *resourcepb.ListRequest) bool {
 	if (s.searchClient == nil && s.search == nil) || req.Source != resourcepb.ListRequest_STORE {
 		return false
 	}
+	// An index covers one namespace, so a cross-namespace list stays on the store
+	// scan, which supports it.
+	if req.Options.Key.Namespace == "" {
+		return false
+	}
 	if len(req.Options.Fields) == 0 && len(req.Options.Labels) == 0 {
 		return false
 	}

--- a/pkg/storage/unified/resource/list_with_selectors_test.go
+++ b/pkg/storage/unified/resource/list_with_selectors_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/util/scheduler"
 )
 
-func TestUseFieldSelectorSearch(t *testing.T) {
+func TestUseSelectorSearch(t *testing.T) {
 	tests := map[string]struct {
 		disableSearch   bool
 		req             *resourcepb.ListRequest
@@ -44,7 +44,7 @@ func TestUseFieldSelectorSearch(t *testing.T) {
 			},
 			expectedAllowed: false,
 		},
-		"false when no field selectors": {
+		"false when no field or label selectors": {
 			req: &resourcepb.ListRequest{
 				Source: resourcepb.ListRequest_STORE,
 				Options: &resourcepb.ListOptions{
@@ -52,6 +52,16 @@ func TestUseFieldSelectorSearch(t *testing.T) {
 				},
 			},
 			expectedAllowed: false,
+		},
+		"true when store, labels only, and search client": {
+			req: &resourcepb.ListRequest{
+				Source: resourcepb.ListRequest_STORE,
+				Options: &resourcepb.ListOptions{
+					Key:    &resourcepb.ResourceKey{Namespace: "nsx", Group: "advisor.grafana.app"},
+					Labels: []*resourcepb.Requirement{{Key: "alerting.grafana.app/has-rules", Operator: "=", Values: []string{"true"}}},
+				},
+			},
+			expectedAllowed: true,
 		},
 		"false when version match exact": {
 			req: &resourcepb.ListRequest{
@@ -104,12 +114,12 @@ func TestUseFieldSelectorSearch(t *testing.T) {
 				s.searchClient = &stubSearchClient{}
 			}
 
-			require.Equal(t, tc.expectedAllowed, s.useFieldSelectorSearch(tc.req))
+			require.Equal(t, tc.expectedAllowed, s.useSelectorSearch(tc.req))
 		})
 	}
 }
 
-func TestFilterFieldSelectors(t *testing.T) {
+func TestFilterSelectors(t *testing.T) {
 	tests := map[string]struct {
 		req           *resourcepb.ListRequest
 		wantFieldKeys []string
@@ -142,7 +152,7 @@ func TestFilterFieldSelectors(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			out := filterFieldSelectors(tc.req)
+			out := filterSelectors(tc.req)
 
 			gotKeys := make([]string, 0, len(out.Options.Fields))
 			for _, f := range out.Options.Fields {
@@ -153,8 +163,109 @@ func TestFilterFieldSelectors(t *testing.T) {
 	}
 }
 
-func TestListWithFieldSelectors(t *testing.T) {
+func TestFilterSelectors_Labels(t *testing.T) {
+	req := &resourcepb.ListRequest{
+		Options: &resourcepb.ListOptions{
+			Key: &resourcepb.ResourceKey{Namespace: "nsx"},
+			Labels: []*resourcepb.Requirement{
+				{Key: "keep-equals", Operator: "="},
+				{Key: "keep-double-equals", Operator: "=="},
+				{Key: "keep-in", Operator: "in"},
+				{Key: "keep-notin", Operator: "notin"},
+				{Key: "drop-not-equals", Operator: "!="},
+				{Key: "drop-exists", Operator: "exists"},
+			},
+		},
+	}
+
+	got := make([]string, 0, len(req.Options.Labels))
+	for _, l := range filterSelectors(req).Options.Labels {
+		got = append(got, l.Key)
+	}
+	require.Equal(t, []string{"keep-equals", "keep-double-equals", "keep-in", "keep-notin"}, got)
+}
+
+func TestTokenFromOtherListPath(t *testing.T) {
+	searchToken := &ContinueToken{SearchAfter: []string{"s1"}, ResourceVersion: 100}
+	scanToken := &ContinueToken{Name: "a", ResourceVersion: 100}
+
+	require.False(t, tokenFromOtherListPath(searchToken, true))
+	require.True(t, tokenFromOtherListPath(searchToken, false))
+	require.True(t, tokenFromOtherListPath(scanToken, true))
+	require.False(t, tokenFromOtherListPath(scanToken, false))
+}
+
+func TestListWithSelectors(t *testing.T) {
 	searchServerRv := int64(100)
+
+	t.Run("label selectors reach search unprefixed, fields are prefixed", func(t *testing.T) {
+		ctx := identity.WithServiceIdentityContext(context.Background(), 1)
+		searchClient := &stubSearchClient{resp: &resourcepb.ResourceSearchResponse{ResourceVersion: searchServerRv}}
+		s := createTestServer(searchClient, 1024)
+		req := &resourcepb.ListRequest{
+			Limit: 10,
+			Options: &resourcepb.ListOptions{
+				Key:    &resourcepb.ResourceKey{Namespace: "nsx"},
+				Fields: []*resourcepb.Requirement{{Key: "spec.foo", Operator: "=", Values: []string{"bar"}}},
+				Labels: []*resourcepb.Requirement{{Key: "alerting.grafana.app/has-rules", Operator: "=", Values: []string{"true"}}},
+			},
+		}
+
+		_, err := s.listWithSelectors(ctx, req)
+		require.NoError(t, err)
+		require.NotNil(t, searchClient.last)
+		// The search backend prefixes label keys itself, so they are passed through.
+		require.Equal(t, "alerting.grafana.app/has-rules", searchClient.last.Options.Labels[0].Key)
+		require.Equal(t, SEARCH_SELECTABLE_FIELDS_PREFIX+"spec.foo", searchClient.last.Options.Fields[0].Key)
+	})
+
+	t.Run("rejects a continue token from the store path", func(t *testing.T) {
+		ctx := identity.WithServiceIdentityContext(context.Background(), 1)
+		s := createTestServer(&stubSearchClient{resp: &resourcepb.ResourceSearchResponse{}}, 1024)
+		req := &resourcepb.ListRequest{
+			Limit:         10,
+			NextPageToken: ContinueToken{Name: "a", ResourceVersion: searchServerRv}.String(),
+			Options: &resourcepb.ListOptions{
+				Key:    &resourcepb.ResourceKey{Namespace: "nsx"},
+				Labels: []*resourcepb.Requirement{{Key: "has-rules", Operator: "=", Values: []string{"true"}}},
+			},
+		}
+
+		resp, err := s.listWithSelectors(ctx, req)
+		require.NoError(t, err)
+		require.NotNil(t, resp.Error)
+		require.Equal(t, int32(http.StatusBadRequest), resp.Error.Code)
+	})
+
+	t.Run("a page left empty by authorization returns no items and no token", func(t *testing.T) {
+		ctx := identity.WithServiceIdentityContext(context.Background(), 1)
+		searchClient := &stubSearchClient{
+			resp: &resourcepb.ResourceSearchResponse{
+				ResourceVersion: searchServerRv,
+				Results: &resourcepb.ResourceTable{
+					Rows: []*resourcepb.ResourceTableRow{
+						{Key: &resourcepb.ResourceKey{Namespace: "nsx", Group: "grp", Resource: "res", Name: "a"}, ResourceVersion: 1, SortFields: []string{"s1"}},
+						{Key: &resourcepb.ResourceKey{Namespace: "nsx", Group: "grp", Resource: "res", Name: "b"}, ResourceVersion: 2, SortFields: []string{"s2"}},
+					},
+				},
+			},
+		}
+		s := createTestServer(searchClient, 1024)
+		s.backend = &fakeBackend{forbidden: map[string]struct{}{"a": {}, "b": {}}}
+		req := &resourcepb.ListRequest{
+			Limit: 10,
+			Options: &resourcepb.ListOptions{
+				Key:    &resourcepb.ResourceKey{Namespace: "nsx"},
+				Labels: []*resourcepb.Requirement{{Key: "has-rules", Operator: "=", Values: []string{"true"}}},
+			},
+		}
+
+		resp, err := s.listWithSelectors(ctx, req)
+		require.NoError(t, err)
+		require.Empty(t, resp.Items)
+		require.Empty(t, resp.NextPageToken)
+		require.Equal(t, searchServerRv, resp.ResourceVersion)
+	})
 
 	t.Run("a single page result will have index rv and no next page token", func(t *testing.T) {
 		ctx := identity.WithServiceIdentityContext(context.Background(), 1)
@@ -181,7 +292,7 @@ func TestListWithFieldSelectors(t *testing.T) {
 			},
 		}
 
-		resp, err := s.listWithFieldSelectors(ctx, req)
+		resp, err := s.listWithSelectors(ctx, req)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		require.Len(t, resp.Items, 1)
@@ -227,7 +338,7 @@ func TestListWithFieldSelectors(t *testing.T) {
 			},
 		}
 
-		resp, err := s.listWithFieldSelectors(ctx, req)
+		resp, err := s.listWithSelectors(ctx, req)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		require.Len(t, resp.Items, 1)
@@ -264,7 +375,7 @@ func TestListWithFieldSelectors(t *testing.T) {
 			},
 		}
 
-		resp, err := s.listWithFieldSelectors(ctx, req)
+		resp, err := s.listWithSelectors(ctx, req)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		require.Equal(t, searchServerRv, resp.ResourceVersion)
@@ -311,7 +422,7 @@ func TestListWithFieldSelectors(t *testing.T) {
 			},
 		}
 
-		resp, err := s.listWithFieldSelectors(ctx, req)
+		resp, err := s.listWithSelectors(ctx, req)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		require.Equal(t, searchServerRv, resp.ResourceVersion)
@@ -361,7 +472,7 @@ func TestListWithFieldSelectors(t *testing.T) {
 			},
 		}
 
-		resp, err := s.listWithFieldSelectors(ctx, req)
+		resp, err := s.listWithSelectors(ctx, req)
 
 		require.NoError(t, err)
 		require.NotNil(t, resp)

--- a/pkg/storage/unified/resource/list_with_selectors_test.go
+++ b/pkg/storage/unified/resource/list_with_selectors_test.go
@@ -53,6 +53,17 @@ func TestUseSelectorSearch(t *testing.T) {
 			},
 			expectedAllowed: false,
 		},
+		"false when the list is cross-namespace": {
+			req: &resourcepb.ListRequest{
+				Source: resourcepb.ListRequest_STORE,
+				Options: &resourcepb.ListOptions{
+					Key:    &resourcepb.ResourceKey{Group: "advisor.grafana.app"},
+					Fields: []*resourcepb.Requirement{{Key: "spec.foo"}},
+					Labels: []*resourcepb.Requirement{{Key: "has-rules", Operator: "=", Values: []string{"true"}}},
+				},
+			},
+			expectedAllowed: false,
+		},
 		"true when store, labels only, and search client": {
 			req: &resourcepb.ListRequest{
 				Source: resourcepb.ListRequest_STORE,

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -1580,15 +1580,23 @@ func (s *server) List(ctx context.Context, req *resourcepb.ListRequest) (*resour
 		req.Limit = 500 // default max 500 items in a page
 	}
 
-	req = filterFieldSelectors(req)
-	if s.useFieldSelectorSearch(req) {
-		// If we get here, we're doing list with selectable fields. Let's do search instead, since
-		// we index all selectable fields, and fetch resulting documents one by one.
+	req = filterSelectors(req)
+	if s.useSelectorSearch(req) {
+		// If we get here, we're doing list with selectable fields or labels. Let's do
+		// search instead, since we index both, and fetch resulting documents one by one.
 		gr := req.Options.Key.Group + "/" + req.Options.Key.Resource
 		if s.storageMetrics != nil {
 			s.storageMetrics.ListWithFieldSelectors.WithLabelValues(gr, "search").Inc()
 		}
-		return s.listWithFieldSelectors(ctx, req)
+		return s.listWithSelectors(ctx, req)
+	}
+
+	if req.NextPageToken != "" {
+		if token, err := GetContinueToken(req.NextPageToken); err == nil && tokenFromOtherListPath(token, false) {
+			return &resourcepb.ListResponse{
+				Error: NewBadRequestError("continue token was issued for a search-backed list"),
+			}, nil
+		}
 	}
 
 	switch req.Source {


### PR DESCRIPTION
A LIST carrying a label selector was a full scan. Labels reached neither the index nor the SQL query, so every row in the namespace was read and authorized before the caller applied the selector app-side. Alerting hit this: it labels folders with `alerting.grafana.app/has-rules` and lists the labelled ones, per org, on every replica.

Label requirements now qualify a request for the search path that field selectors already take. Fixes grafana/search-and-storage-team#935.

Details:

- Only operators the index can answer are kept (`=`, `==`, `in`, `notin`). A selector may also carry `!=`, `key` and `!key`; those are dropped, and a request left with nothing indexable falls back to the scan. Callers re-apply the selector to the returned objects, so a dropped requirement costs extra reads rather than correctness — the same trade-off field selectors already make.
- The two paths encode pagination differently, sort values against the index and a name against the store, so a continue token issued by one is now refused by the other instead of silently restarting from the first result.
- The file and its functions lose the "field" in their names, since they are no longer field-only. The metric keeps its name, renaming it would break dashboards.

Unchanged: field selector behaviour, and the restriction to groups with a manifest. That gate exists because selectable fields come from manifests; labels are indexed for every kind, so it is stricter than labels need. Dropping it is worth its own change, and the kinds in question (folders, dashboards, rules, iam) already qualify.

Tests: labels-only LIST reaches search with keys unprefixed, unsupported operators dropped, continue token refused in both directions, a page left empty by authorization, plus the existing pagination cases.

**Before indexes are rebuilt** with the keyword label analyzer (grafana/search-and-storage-team#805), a label filter still runs against values split into words, so this path can return fewer items than the scan would in two cases: `notin`, where the exclusion matches too much and drops items that should be listed, and a value the text analyzer reduces to nothing (a single English stop word, or punctuation only), which matches no document at all. Overmatching is harmless because the caller re-applies the selector; these two are not, and no caller can add the missing items back. Accepting it for now: no in-tree caller uses `notin` on labels, and a rebuilt index is exact.
