### PR TITLE
Home: Add event to track recommendations shown

### DIFF
--- a/public/app/features/home/Recommendations/Recommendations.test.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.test.tsx
@@ -8,7 +8,7 @@ import { usePluginBridge } from 'app/features/alerting/unified/hooks/usePluginBr
 import { type LocalPlugin } from 'app/features/plugins/admin/types';
 import { AccessControlAction } from 'app/types/accessControl';
 
-import { ctaClicked } from '../analytics/main';
+import { ctaClicked, recommendationsShown } from '../analytics/main';
 
 import { Recommendations } from './Recommendations';
 import { HOSTED_TRACES_APP_ID } from './appPluginIds';
@@ -36,6 +36,7 @@ jest.mock('app/features/alerting/unified/hooks/usePluginBridge', () => ({
 
 jest.mock('../analytics/main', () => ({
   ctaClicked: jest.fn(),
+  recommendationsShown: jest.fn(),
 }));
 
 // The RecommendationExisting child fetches its overview from Prometheus; resolve to no
@@ -129,6 +130,7 @@ function setSolutionState(
 beforeEach(() => {
   window.localStorage.clear();
   jest.mocked(ctaClicked).mockClear();
+  jest.mocked(recommendationsShown).mockClear();
   mockUsePluginBridge.mockReset();
   mockUsePluginBridge.mockReturnValue({
     loading: false,
@@ -173,6 +175,20 @@ describe('Recommendations', () => {
     expect(
       within(region).getByRole('link', { name: /Enable Kubernetes Monitoring/, hidden: true })
     ).toBeInTheDocument();
+  });
+
+  it('tracks shown recommendations with the matrix starting state', async () => {
+    render(<Recommendations />);
+
+    await carouselRegion();
+
+    await waitFor(() =>
+      expect(jest.mocked(recommendationsShown)).toHaveBeenCalledWith({
+        recommendation_ids: ['hosted-traces', 'kubernetes-monitoring'],
+        starting_state: 'ml_no_traces',
+        solution: undefined,
+      })
+    );
   });
 
   it('follows the selected solution: metrics-led by default, logs-led after switching', async () => {

--- a/public/app/features/home/Recommendations/Recommendations.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import { useAsync } from 'react-use';
 
 import { config } from '@grafana/runtime';
@@ -56,61 +56,69 @@ function GatedRecommendations({ canInstall }: GatedRecommendationsProps) {
   const probesEnabled = everExpanded.current;
 
   const plugins = useAsync(async () => (probesEnabled ? fetchInstalledPlugins() : undefined), [probesEnabled]);
-  const pluginsById = new Map((plugins.value ?? []).map((plugin) => [plugin.id, plugin]));
+  const pluginsById = useMemo(
+    () => new Map((plugins.value ?? []).map((plugin) => [plugin.id, plugin])),
+    [plugins.value]
+  );
+
   // Derived from the settled value, not the loading flag: on the probesEnabled flip, useAsync
   // still reports the gated run's state for one frame, which must read as pending.
   const pluginsSettled = !!plugins.value || !!plugins.error;
 
   const { value: resolution } = useSolutionState(probesEnabled);
-  const selection = resolution ? selectRecommendations(resolution.state) : undefined;
-
-  const cardsById = getRecommendationCards();
-  const selectedCards = selection?.cards.map((id) => cardsById[id]) ?? [];
+  const selection = useMemo(() => (resolution ? selectRecommendations(resolution.state) : undefined), [resolution]);
+  const cardsById = useMemo(() => getRecommendationCards(), []);
 
   // An unavailable plugin list fails closed (plugin cards only). /api/plugins always lists at
   // least the core plugins, so an empty response means the list is unreliable and also fails closed.
   const listReady = !!plugins.value && plugins.value.length > 0;
 
-  const toItems = (cards: RecommendedCardId[]): RecommendationItem[] =>
-    cards.flatMap((cardId): RecommendationItem[] => {
-      const card = cardsById[cardId];
-      if (card.kind === 'connection') {
-        // Independent of the plugin list: a failing /api/plugins must not hide a connection card.
-        return contextSrv.hasPermission(AccessControlAction.DataSourcesCreate) ? [{ ...card, cta: 'enable' }] : [];
-      }
-      if (!listReady) {
-        return [];
-      }
-      const plugin = pluginsById.get(card.pluginId);
-      if (!plugin) {
-        // Unlistable plugins take the install-only path.
-        return canInstall ? [toEnableItem(card)] : [];
-      }
-      if (plugin.enabled) {
-        // Selection already established the solution is silent; the setup CTA leads into the app,
-        // so it only renders for users who can open it.
-        return contextSrv.hasPermissionInMetadata(AccessControlAction.PluginsAppAccess, plugin)
-          ? [toSetupItem(card)]
-          : [];
-      }
-      // plugins:write is scoped to this plugin.
-      return contextSrv.hasPermissionInMetadata(AccessControlAction.PluginsWrite, plugin) ? [toEnableItem(card)] : [];
-    });
+  const toItems = useCallback(
+    (cards: RecommendedCardId[]): RecommendationItem[] =>
+      cards.flatMap((cardId): RecommendationItem[] => {
+        const card = cardsById[cardId];
+        if (card.kind === 'connection') {
+          // Independent of the plugin list: a failing /api/plugins must not hide a connection card.
+          return contextSrv.hasPermission(AccessControlAction.DataSourcesCreate) ? [{ ...card, cta: 'enable' }] : [];
+        }
+        if (!listReady) {
+          return [];
+        }
+        const plugin = pluginsById.get(card.pluginId);
+        if (!plugin) {
+          // Unlistable plugins take the install-only path.
+          return canInstall ? [toEnableItem(card)] : [];
+        }
+        if (plugin.enabled) {
+          // Selection already established the solution is silent; the setup CTA leads into the app,
+          // so it only renders for users who can open it.
+          return contextSrv.hasPermissionInMetadata(AccessControlAction.PluginsAppAccess, plugin)
+            ? [toSetupItem(card)]
+            : [];
+        }
+        // plugins:write is scoped to this plugin.
+        return contextSrv.hasPermissionInMetadata(AccessControlAction.PluginsWrite, plugin) ? [toEnableItem(card)] : [];
+      }),
+    [canInstall, cardsById, listReady, pluginsById]
+  );
 
-  const recommendations = toItems(selection?.cards ?? []);
+  const recommendations = useMemo(() => toItems(selection?.cards ?? []), [selection?.cards, toItems]);
   // Per-solution views are permutations of the same selection (membership is the matrix's
   // call, never the view's), so the skeleton and region-hide gates below stay list-agnostic.
   // The Record type keeps the literal in lockstep with EXISTING_SOLUTION_IDS.
-  const forSolution = (id: ExistingSolutionId) => toItems(orderCardsForSolution(selection?.cards ?? [], id));
-  const recommendationsBySolution: Record<ExistingSolutionId, RecommendationItem[]> = {
-    kubernetes: forSolution('kubernetes'),
-    metrics: forSolution('metrics'),
-    logs: forSolution('logs'),
-    traces: forSolution('traces'),
-  };
+  const recommendationsBySolution: Record<ExistingSolutionId, RecommendationItem[]> = useMemo(() => {
+    const forSolution = (id: ExistingSolutionId) => toItems(orderCardsForSolution(selection?.cards ?? [], id));
+    return {
+      kubernetes: forSolution('kubernetes'),
+      metrics: forSolution('metrics'),
+      logs: forSolution('logs'),
+      traces: forSolution('traces'),
+    };
+  }, [selection?.cards, toItems]);
 
   // The region renders once state settles; recommendations only decide the right column.
   // Collapsed (gated-off) renders immediately as just the header row.
+  const selectedCards = selection?.cards.map((id) => cardsById[id]) ?? [];
   const waitingOnPlugins = !pluginsSettled && selectedCards.some((card) => card.kind === 'plugin');
   if (probesEnabled && (!selection || waitingOnPlugins)) {
     return <RecommendationsSkeleton />;

--- a/public/app/features/home/Recommendations/RecommendationsView.tsx
+++ b/public/app/features/home/Recommendations/RecommendationsView.tsx
@@ -6,6 +6,8 @@ import { type GrafanaTheme2 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { Badge, Button, Grid, Icon, Stack, Text, useStyles2 } from '@grafana/ui';
 
+import { recommendationsShown } from '../analytics/main';
+
 import { RecommendationCard } from './RecommendationCard';
 import { RecommendationExisting } from './RecommendationExisting';
 import { RecommendationPill } from './RecommendationPill';
@@ -74,6 +76,16 @@ export function RecommendationsView({
 
     return () => clearTimeout(timeout);
   }, [collapsed, paused, safeIndex, items.length, showControls, selectionPending]);
+
+  useEffect(() => {
+    if (items.length) {
+      recommendationsShown({
+        recommendation_ids: items.map((r) => r.id),
+        starting_state: startingState,
+        solution: activeSolution ?? undefined,
+      });
+    }
+  }, [items, startingState, activeSolution]);
 
   return (
     <div>

--- a/public/app/features/home/Recommendations/RecommendationsView.tsx
+++ b/public/app/features/home/Recommendations/RecommendationsView.tsx
@@ -78,14 +78,14 @@ export function RecommendationsView({
   }, [collapsed, paused, safeIndex, items.length, showControls, selectionPending]);
 
   useEffect(() => {
-    if (items.length) {
+    if (items.length && !selectionPending) {
       recommendationsShown({
         recommendation_ids: items.map((r) => r.id),
         starting_state: startingState,
         solution: activeSolution ?? undefined,
       });
     }
-  }, [items, startingState, activeSolution]);
+  }, [items, selectionPending, startingState, activeSolution]);
 
   return (
     <div>
@@ -94,7 +94,7 @@ export function RecommendationsView({
           <Trans i18nKey="home.recommendations.title">Recommendations for your stack</Trans>
         </Text>
 
-        {collapsed && hasRecommendations && (
+        {collapsed && hasRecommendations && !selectionPending && (
           <div className={styles.pills}>
             <Stack direction="row" alignItems="center" gap={1} wrap="wrap">
               {items.map((recommendation) => (

--- a/public/app/features/home/analytics/main.ts
+++ b/public/app/features/home/analytics/main.ts
@@ -1,11 +1,14 @@
 import { defineFeatureEvents } from '@grafana/runtime/unstable';
 
-import { type ClearHistoryClicked, type CtaClicked, type TabChanged } from './types';
+import { type RecommendationsShown, type ClearHistoryClicked, type CtaClicked, type TabChanged } from './types';
 
 const createHomepageEvent = defineFeatureEvents('grafana', 'homepage');
 
 /** Fired when the user clicks a tab on the homepage. */
 export const tabChanged = createHomepageEvent<TabChanged>('tab_changed');
+
+/** Fired when the user is shown recommendations on the homepage. */
+export const recommendationsShown = createHomepageEvent<RecommendationsShown>('recommendations_shown');
 
 /** Fired when the user clears their recently-viewed dashboard history. */
 export const clearHistoryClicked = createHomepageEvent<ClearHistoryClicked>('clear_history_clicked');

--- a/public/app/features/home/analytics/types.ts
+++ b/public/app/features/home/analytics/types.ts
@@ -5,6 +5,21 @@ export interface TabChanged extends EventProperty {
   tab: string;
 }
 
+export interface RecommendationsShown extends EventProperty {
+  /** Stable ids of the recommendations shown to the user. */
+  recommendation_ids: string[];
+  /**
+   * Matrix base-row id driving the current card selection;
+   * values are the BaseRow union in solutionsMatrix.ts.
+   */
+  starting_state: string;
+  /**
+   * Stable id of the solution that was selected when the recommendations were shown;
+   * absent when no solution is selected.
+   */
+  solution?: string;
+}
+
 export interface ClearHistoryClicked extends EventProperty {
   /** Number of dashboards in history before clearing. */
   dashboard_count: number;


### PR DESCRIPTION
**What is this feature?**

Adds a new event to track which recommendations were shown to a user on the homepage.

**Why do we need this feature?**

So we have visibility into the recommendations shown when doing analysis on the success of the new feature.

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

cc #127458

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
