### PR TITLE
StateTimeline: Hide pagination when there is a single page

### DIFF
--- a/public/app/plugins/panel/state-timeline/hooks.test.tsx
+++ b/public/app/plugins/panel/state-timeline/hooks.test.tsx
@@ -75,20 +75,22 @@ describe('StateTimelinePanel hooks', () => {
       });
     });
 
-    const frame = createDataFrame({
-      fields: [
-        { name: 'time', type: FieldType.time, values: [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000] },
-        { name: 'value-A', type: FieldType.number, values: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
-        { name: 'value-B', type: FieldType.number, values: [11, 12, 13, 14, 15, 16, 17, 18, 19, 20] },
-        { name: 'value-C', type: FieldType.number, values: [21, 22, 23, 24, 25, 26, 27, 28, 29, 30] },
-      ],
+    it('renders the pagination control when there is more than one page', () => {
+      const frame = createDataFrame({
+        fields: [
+          { name: 'time', type: FieldType.time, values: [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000] },
+          { name: 'value-A', type: FieldType.number, values: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+          { name: 'value-B', type: FieldType.number, values: [11, 12, 13, 14, 15, 16, 17, 18, 19, 20] },
+          { name: 'value-C', type: FieldType.number, values: [21, 22, 23, 24, 25, 26, 27, 28, 29, 30] },
+        ],
+      });
+      const { result } = renderHook(() => usePagination([frame], 2));
+
+      render(result.current.paginationElement);
+
+      expect(screen.getByText('1')).toBeInTheDocument(); // current page
+      expect(screen.getByText('2')).toBeInTheDocument(); // last page
+      expect(screen.getByLabelText('next page')).not.toBeDisabled();
     });
-    const { result } = renderHook(() => usePagination([frame], 2));
-
-    render(result.current.paginationElement);
-
-    expect(screen.getByText('1')).toBeInTheDocument(); // current page
-    expect(screen.getByText('2')).toBeInTheDocument(); // last page
-    expect(screen.getByLabelText('next page')).not.toBeDisabled();
   });
 });

--- a/public/app/plugins/panel/state-timeline/hooks.test.tsx
+++ b/public/app/plugins/panel/state-timeline/hooks.test.tsx
@@ -43,6 +43,38 @@ describe('StateTimelinePanel hooks', () => {
       expect(result.current.paginatedFrames?.length).toBe(2);
     });
 
+    describe('single page', () => {
+      const buildFrame = (numberOfSeries: number) =>
+        createDataFrame({
+          fields: [
+            { name: 'time', type: FieldType.time, values: [100, 200, 300] },
+            ...Array.from({ length: numberOfSeries }, (_, index) => ({
+              name: `value-${index}`,
+              type: FieldType.number,
+              values: [4, 5, 6],
+            })),
+          ],
+        });
+
+      it('renders nothing while every series fits on one page', () => {
+        const { result } = renderHook(() => usePagination([buildFrame(3)], 3));
+
+        render(result.current.paginationElement);
+
+        expect(screen.queryByRole('navigation')).not.toBeInTheDocument();
+        expect(screen.queryByLabelText('next page')).not.toBeInTheDocument();
+      });
+
+      it('renders as soon as one series does not fit', () => {
+        const { result } = renderHook(() => usePagination([buildFrame(4)], 3));
+
+        render(result.current.paginationElement);
+
+        expect(screen.getByRole('navigation')).toBeInTheDocument();
+        expect(screen.getByLabelText('next page')).not.toBeDisabled();
+      });
+    });
+
     const frame = createDataFrame({
       fields: [
         { name: 'time', type: FieldType.time, values: [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000] },

--- a/public/app/plugins/panel/state-timeline/hooks.test.tsx
+++ b/public/app/plugins/panel/state-timeline/hooks.test.tsx
@@ -26,6 +26,32 @@ describe('StateTimelinePanel hooks', () => {
           paginationHeight: 0,
         });
       });
+
+      it('renders no pagination when there are no frames to paginate', () => {
+        const { result } = renderHook(() => usePagination([], 5));
+
+        expect(result.current.paginatedFrames).toEqual([]);
+        expect(result.current.paginationRev).toBe('0/5');
+
+        render(result.current.paginationElement);
+
+        expect(screen.queryByRole('navigation')).not.toBeInTheDocument();
+        expect(screen.queryByText('0')).not.toBeInTheDocument();
+      });
+
+      it('renders no pagination when the frames hold no series', () => {
+        const timeOnly = createDataFrame({
+          fields: [{ name: 'time', type: FieldType.time, values: [100, 200, 300] }],
+        });
+
+        const { result } = renderHook(() => usePagination([timeOnly], 5));
+
+        expect(result.current.paginatedFrames).toEqual([]);
+
+        render(result.current.paginationElement);
+
+        expect(screen.queryByRole('navigation')).not.toBeInTheDocument();
+      });
     });
 
     it('returns the React element to be rendered for pagination', () => {
@@ -59,6 +85,8 @@ describe('StateTimelinePanel hooks', () => {
       it('renders nothing while every series fits on one page', () => {
         const { result } = renderHook(() => usePagination([buildFrame(3)], 3));
 
+        expect(result.current.paginatedFrames).toHaveLength(3);
+
         render(result.current.paginationElement);
 
         expect(screen.queryByRole('navigation')).not.toBeInTheDocument();
@@ -68,9 +96,12 @@ describe('StateTimelinePanel hooks', () => {
       it('renders as soon as one series does not fit', () => {
         const { result } = renderHook(() => usePagination([buildFrame(4)], 3));
 
+        expect(result.current.paginatedFrames).toHaveLength(3); // 4 series, page 1 of 2
+
         render(result.current.paginationElement);
 
         expect(screen.getByRole('navigation')).toBeInTheDocument();
+        expect(screen.getByText('2')).toBeInTheDocument(); // last page
         expect(screen.getByLabelText('next page')).not.toBeDisabled();
       });
     });

--- a/public/app/plugins/panel/state-timeline/hooks.tsx
+++ b/public/app/plugins/panel/state-timeline/hooks.tsx
@@ -61,6 +61,7 @@ export function usePagination(frames?: DataFrame[], perPage?: number) {
         className={paginationStyles.paginationElement}
         currentPage={currentPageCapped}
         numberOfPages={numberOfPages}
+        hideWhenSinglePage
         showSmallVersion={showSmallVersion}
         onNavigate={setCurrentPage}
       />


### PR DESCRIPTION
**What is this feature?**

`usePagination` builds the pagination control whenever `perPage` is set, so a state timeline whose series already fit on a single page still renders page buttons that cannot navigate anywhere, and the chart loses around 40px of height to them.

`Pagination` already supports `hideWhenSinglePage` ("when set to true and the pagination result is only one page it will not render the pagination at all"), the hook simply never passed it. This passes it.

The guard is `numberOfPages <= 1`, so this fixes a second case too: with no series to paginate, `numberOfPages` is 0, `pageButtons` comes back empty, and `Pagination` falls back to printing `currentPage`, which `Math.min` caps to 0. A panel with Page size set and an empty result therefore rendered a bare `0` between the two arrows. It is now hidden along with the single-page control.

Status history uses the same hook, so it gets the same behaviour.

**Why do we need this feature?**

Page size is the only way to keep a state timeline readable when the series count is driven by a dashboard variable and can be anything from 3 to 40 rows. Today, enabling it to protect the large case permanently costs vertical space in the small case, which discourages using it at all.

**Who is this feature for?**

Anyone setting Page size on a state timeline or status history panel where the number of series varies.

**Which issue(s) does this PR fix?**:

None filed.

**Special notes for your reviewer**

The wrapper `div` collapses to zero height when `Pagination` returns `null`: the container has no `gap` and the `marginTop` lives on the `Pagination` element itself, so `paginationHeight` measures 0 and the chart gets the full panel height back.

`public/app/plugins/panel/state-timeline/hooks.test.tsx` goes from 3 tests to 8. Four of them fail without `hideWhenSinglePage`: the two single-page boundary cases and the two empty cases.

One commit here is unrelated housekeeping in the same file. The block that asserted on the multi-page control was never inside an `it()`, so it ran during describe collection: jest counted 3 tests instead of 4, a failure would have surfaced as a suite-level crash with no test name, and its `render()` left a pagination element in `document.body` until the first `afterEach` cleanup. That last part is what makes it worth fixing here, since this PR adds assertions that no pagination is rendered.

`paginationHeight` is deliberately not asserted anywhere: `useMeasure` returns 0 under jsdom regardless, so such a test would pass on `main` too and would read as proof of something it does not check.
