### PR TITLE
Home: Support hash anchors to overview options

### DIFF
--- a/public/app/features/home/Overview/Overview.test.tsx
+++ b/public/app/features/home/Overview/Overview.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from 'test/test-utils';
+import { render, screen, waitFor } from 'test/test-utils';
 
 import { ctaClicked } from '../analytics/main';
 
@@ -72,6 +72,34 @@ describe('Overview', () => {
     expect(screen.getByText('Start setup')).toBeInTheDocument();
   });
 
+  it('selects the overview option from the hash anchor', async () => {
+    const guide = {
+      id: 'app-monitoring',
+      title: 'Set up app monitoring',
+      description: 'Visualize traces, metrics, and logs from services you build and run.',
+      icon: 'apps' as const,
+      color: '#ff780a',
+      cta: 'Start setup',
+      href: '#',
+    };
+    const scrollIntoView = jest.fn();
+    const originalScrollIntoView = window.HTMLElement.prototype.scrollIntoView;
+    window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+
+    try {
+      mockUseGuides.mockReturnValue([guide]);
+
+      render(<Overview />, { historyOptions: { initialEntries: ['/#get-started'] } });
+
+      await waitFor(() => expect(screen.getByRole('button', { name: /get started/i })).toBeInTheDocument());
+      expect(screen.getByText('Recommended getting started guides')).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'Set up app monitoring' })).toBeInTheDocument();
+      expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
+    } finally {
+      window.HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+    }
+  });
+
   it('tracks overview filter changes from the dropdown', async () => {
     mockUseGuides.mockReturnValue([]);
 
@@ -84,7 +112,7 @@ describe('Overview', () => {
       surface: 'overview',
       action: 'change_overview_filter',
       placement: 'menu',
-      solution: 'attention',
+      solution: 'needs-attention',
     });
   });
 });

--- a/public/app/features/home/Overview/Overview.tsx
+++ b/public/app/features/home/Overview/Overview.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/css';
-import { Fragment, useMemo, useState, type ReactNode } from 'react';
+import { Fragment, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { useLocation } from 'react-router-dom-v5-compat';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
@@ -29,22 +30,22 @@ export function Overview() {
   const options = useMemo<Option[]>(
     () => [
       {
-        value: 'all',
+        value: 'all-solutions',
         label: t('home.overview.options.all', 'All solutions'),
         content: <></>,
       },
       {
-        value: 'attention',
+        value: 'needs-attention',
         label: t('home.overview.options.attention', 'Needs attention'),
         content: <></>,
       },
       {
-        value: 'enabled',
+        value: 'enabled-solutions',
         label: t('home.overview.options.enabled', 'Enabled solutions'),
         content: <></>,
       },
       {
-        value: 'available',
+        value: 'available-solutions',
         label: t('home.overview.options.available', 'Available solutions'),
         content: <></>,
       },
@@ -65,6 +66,16 @@ export function Overview() {
   );
   const [stored, setStored] = useStoredString(HOME_OVERVIEW_OPTION_LOCAL_STORAGE_KEY, options[0].value);
   const option = useMemo(() => options.find((o) => o.value === stored) ?? options[0], [options, stored]);
+
+  const ref = useRef<HTMLDivElement>(null);
+  const location = useLocation();
+  useEffect(() => {
+    const match = options.find((o) => o.value === location.hash.slice(1));
+    if (match) {
+      setStored(match.value);
+      ref.current?.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [options, location.hash, setStored]);
 
   const menu = useMemo(
     () => (
@@ -103,7 +114,7 @@ export function Overview() {
   const [open, setOpen] = useState(false);
 
   return (
-    <div>
+    <div ref={ref}>
       <Stack direction="row" alignItems="center" justifyContent="space-between" columnGap={2} rowGap={1} wrap="wrap">
         <Text element="h2" variant="h5">
           <Trans i18nKey="home.overview.title">Your observability stack overview</Trans>


### PR DESCRIPTION
**What is this feature?**

Allows for hash anchors in the URL to deep-link to specific options in the overview section of the homepage.

**Why do we need this feature?**

Enables the existing getting started guide to be redirected to the version on the homepage when it is available.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

cc #127458

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
