### PR TITLE
Transformations: Show unrecognised transformations in panel edit

### DIFF
--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRows.test.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRows.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { TransformationOperationRows } from './TransformationOperationRows';
+import { type TransformationData } from './TransformationsEditor';
+
+const data: TransformationData = { series: [] };
+
+const unknownTransformation = {
+  id: '0',
+  transformation: { id: 'not-a-registered-transformation', options: {} },
+};
+
+describe('TransformationOperationRows', () => {
+  it('names a transformation the registry does not know', () => {
+    render(
+      <TransformationOperationRows
+        data={data}
+        configs={[unknownTransformation]}
+        onRemove={jest.fn()}
+        onChange={jest.fn()}
+      />
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent('not-a-registered-transformation');
+  });
+
+  it('removes an unknown transformation from the panel', async () => {
+    const onRemove = jest.fn();
+
+    render(
+      <TransformationOperationRows
+        data={data}
+        configs={[unknownTransformation]}
+        onRemove={onRemove}
+        onChange={jest.fn()}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /remove/i }));
+
+    expect(onRemove).toHaveBeenCalledWith(0);
+  });
+});

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRows.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRows.tsx
@@ -1,4 +1,6 @@
 import { type DataTransformerConfig, standardTransformersRegistry } from '@grafana/data';
+import { t, Trans } from '@grafana/i18n';
+import { Alert, Button } from '@grafana/ui';
 
 import { TransformationOperationRow } from './TransformationOperationRow';
 import { type TransformationData } from './TransformationsEditor';
@@ -19,18 +21,37 @@ export const TransformationOperationRows = ({
 }: TransformationOperationRowsProps) => {
   return (
     <>
-      {configs.map((t, i) => {
-        const uiConfig = standardTransformersRegistry.getIfExists(t.transformation.id);
+      {configs.map((config, i) => {
+        const uiConfig = standardTransformersRegistry.getIfExists(config.transformation.id);
 
+        // A dashboard can hold a transformation the registry does not know, for
+        // instance one persisted with a malformed id. Rendering nothing leaves an
+        // empty tab and editing the dashboard JSON as the only way to remove it.
         if (!uiConfig) {
-          return null;
+          return (
+            <Alert
+              key={`${config.id}`}
+              severity="error"
+              title={t(
+                'dashboard.transformation-operation-rows.title-unknown-transformation',
+                'Unknown transformation: {{transformationId}}',
+                { transformationId: config.transformation.id }
+              )}
+            >
+              <Button variant="secondary" size="sm" onClick={() => onRemove(i)}>
+                <Trans i18nKey="dashboard.transformation-operation-rows.remove-unknown-transformation">
+                  Remove transformation
+                </Trans>
+              </Button>
+            </Alert>
+          );
         }
 
         return (
           <TransformationOperationRow
             index={i}
-            id={`${t.id}`}
-            key={`${t.id}`}
+            id={`${config.id}`}
+            key={`${config.id}`}
             data={data}
             configs={configs}
             uiConfig={uiConfig}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6644,6 +6644,10 @@
       },
       "title-delete": "Delete {{name}}?"
     },
+    "transformation-operation-rows": {
+      "remove-unknown-transformation": "Remove transformation",
+      "title-unknown-transformation": "Unknown transformation: {{transformationId}}"
+    },
     "transformation-picker-ng": {
       "clear-search": "Clear search",
       "no-transformations-found": "No transformations found",


### PR DESCRIPTION
**What is this feature?**

`TransformationOperationRows` returns `null` when `standardTransformersRegistry.getIfExists` does not recognise a transformation id, so a persisted but unknown transformation renders as nothing at all. This renders an error alert naming the id instead, with a button that removes the transformation from the panel.

**Why do we need this feature?**

A dashboard that has already persisted a malformed transformation shows an empty Transformations tab in panel edit, with no way to see or remove the broken entries. Editing the dashboard JSON by hand is the only remedy today.

`PanelEditNext` already handles the sibling case: `TransformationEditorRenderer` renders an alert when a transformation has no editor component. This brings the same treatment to the rows, which the current default editor uses as well, since `PanelDataTransformationsTab` imports `TransformationOperationRows` directly.

**Who is this feature for?**

Anyone who opens a dashboard whose JSON carries a transformation id this Grafana does not know, whether it came from an older version, a removed plugin, or a generator bug.

**Which issue(s) does this PR fix?**

Fixes #129621

**Special notes for your reviewer:**

The remove control is a `Button` inside the alert body rather than the alert's own `onRemove` prop. `Alert` gives that control `aria-label="Close alert"`, which would be wrong here: the button deletes the transformation, it does not dismiss the message. Happy to switch to `onRemove` if you would rather keep the visual convention.

The rename of the `map` callback parameter from `t` to `config` is not cosmetic. `t` shadows the i18n function that the alert title needs.

Tests, run from this branch:

- `yarn jest public/app/features/dashboard/components/TransformationsEditor` passes, 29 tests across 5 suites, including the new `TransformationOperationRows.test.tsx`. Both new cases fail on `main`, where the component renders an empty document.
- `yarn typecheck`, `eslint` and `prettier --check` on the changed files are clean.
- `make i18n-extract` for the two new keys.

This contribution was made with AI assistance. I reviewed the change and ran every command quoted above.

One thing I did not change: the drag and drop indices still skip the position of an unrecognised transformation, because only `TransformationOperationRow` renders a `Draggable`. That is the behaviour on `main` today as well, since the row rendered nothing there, so this PR neither fixes nor worsens it. Tell me if you want it handled here.
