### PR TITLE
Search: stop a per-kind field claiming a standard field's name

### DIFF
--- a/pkg/registry/apis/dashboard/search.go
+++ b/pkg/registry/apis/dashboard/search.go
@@ -888,8 +888,8 @@ func convertHttpSearchRequestToResourceSearchRequest(queryParams url.Values, use
 
 	// Add sorting. Dashboard-specific fields live under the fields.*
 	// sub-document inside bleve; clients pass the bare name (e.g.
-	// ?sort=panel_types) and the search backend needs the prefixed form
-	// (fields.panel_types) to find them. The leading "-" descending marker
+	// ?sort=views_total) and the search backend needs the prefixed form
+	// (fields.views_total) to find them. The leading "-" descending marker
 	// is stripped first so the dashboard-field lookup sees the bare name
 	// regardless of direction.
 	if queryParams.Has("sort") {

--- a/pkg/storage/unified/resource/search_field.go
+++ b/pkg/storage/unified/resource/search_field.go
@@ -32,8 +32,8 @@ const (
 	// SearchCapabilityPartial enables substring matching (Bleve ngram
 	// analyzer). Requires SearchCapabilityText.
 	SearchCapabilityPartial SearchCapability = "partial"
-	// SearchCapabilitySort makes the field sortable. It also enables DocValues
-	// on the keyword variant for column-wise reads and stable sort tie-breakers.
+	// SearchCapabilitySort enables sorting on the field. A search request can only
+	// sort on fields that declare it.
 	SearchCapabilitySort     SearchCapability = "sort"
 	SearchCapabilityFacet    SearchCapability = "facet"    // facetable on the keyword variant
 	SearchCapabilityRetrieve SearchCapability = "retrieve" // value is stored and returned in search results

--- a/pkg/storage/unified/search/bleve_mappings.go
+++ b/pkg/storage/unified/search/bleve_mappings.go
@@ -174,8 +174,10 @@ func keywordFieldsForMapping(provider resource.SearchFieldsProvider, group, kind
 	for _, def := range fieldDefinitionsForMapping(provider, group, kindResource) {
 		add(resource.SEARCH_FIELD_PREFIX+def.Name, def, resource.SEARCH_FIELD_PREFIX)
 		// Requests may name a per-kind field without the internal fields prefix.
-		// A standard field of the same name wins, matching resolveFieldName.
-		if _, taken := fields[def.Name]; !taken {
+		// A top-level field of the same name wins, matching resolveFieldName. The
+		// name check covers standard fields with no keyword form, which are absent
+		// from the map and so would leave the bare name free to claim.
+		if _, taken := fields[def.Name]; !taken && !isReservedTopLevelField(def.Name) {
 			add(def.Name, def, resource.SEARCH_FIELD_PREFIX)
 		}
 	}

--- a/pkg/storage/unified/search/bleve_mappings_internal_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_internal_test.go
@@ -285,6 +285,21 @@ func TestKeywordFieldsForMapping_StandardNameWins(t *testing.T) {
 	assert.Equal(t, resource.SEARCH_FIELD_PREFIX+resource.SEARCH_FIELD_TAGS, fields[resource.SEARCH_FIELD_PREFIX+resource.SEARCH_FIELD_TAGS].name)
 }
 
+func TestKeywordFieldsForMapping_StandardNameWithoutKeywordFormStillWins(t *testing.T) {
+	// description is a standard field with no keyword form, so it is absent from
+	// the map. The bare name must stay free of the per-kind field anyway: a filter
+	// on "description" resolves to the top-level field, so pointing it at
+	// fields.description would query the wrong one.
+	gvr := schema.GroupVersionResource{Group: "example.test", Version: "v1", Resource: "widgets"}
+	provider := resource.NewMapProvider(map[schema.GroupVersionResource][]resource.SearchFieldDefinition{
+		gvr: {{Name: resource.SEARCH_FIELD_DESCRIPTION, Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter}}},
+	}, nil)
+
+	fields := keywordFieldsForMapping(provider, gvr.Group, gvr.Resource, nil)
+	assert.NotContains(t, fields, resource.SEARCH_FIELD_DESCRIPTION)
+	assert.Equal(t, resource.SEARCH_FIELD_PREFIX+resource.SEARCH_FIELD_DESCRIPTION, fields[resource.SEARCH_FIELD_PREFIX+resource.SEARCH_FIELD_DESCRIPTION].name)
+}
+
 func TestSortableFieldsForMapping(t *testing.T) {
 	gvr := schema.GroupVersionResource{Group: "example.test", Version: "v1", Resource: "widgets"}
 	provider := resource.NewMapProvider(map[schema.GroupVersionResource][]resource.SearchFieldDefinition{


### PR DESCRIPTION
A per-kind field named like a standard field that has no keyword form, such as `description`, took over the bare name in the keyword lookup. A filter naming that field resolves to the top-level one, so it would have queried the per-kind copy instead. The numeric lookup added in #130851 already guards against this; the string one did not. No kind declares such a name today, so this is latent.

Also corrects two comments. The `sort` capability enables sorting rather than making it possible — any indexed field can be ordered, doc values only make it cheaper, which came up while working on #130912. And the dashboard handler's example named `panel_types`, a field that cannot be sorted on.

`no-check-unified-storage-compatibility` is set because the API-layer file in this PR changes one comment and no code, so there is nothing that could break compatibility between the two services during a rollout. Splitting a comment fix into its own PR did not seem worth it.
