### PR TITLE
Logs Table: Add tooltip for improved sorting when using Loki

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/components/HeaderCell.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/HeaderCell.test.tsx
@@ -92,6 +92,37 @@ describe('HeaderCell', () => {
     expect(screen.getByRole('button', { name: 'Field1' })).toBeInTheDocument();
   });
 
+  it('renders an info tooltip when headerTooltip is set', () => {
+    render(
+      <HeaderCell
+        {...baseProps}
+        field={makeField({ config: { custom: { headerTooltip: 'Only sorts the results on display' } } })}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Only sorts the results on display' })).toBeInTheDocument();
+  });
+
+  it('does not render an info tooltip when headerTooltip is not set', () => {
+    render(<HeaderCell {...baseProps} field={makeField()} />);
+    expect(screen.getByRole('button', { name: 'Field1' })).toBeInTheDocument();
+    expect(screen.getAllByRole('button')).toHaveLength(1);
+  });
+
+  it('does not bubble info tooltip clicks to the column header', async () => {
+    const onHeaderClick = jest.fn();
+    render(
+      // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+      <div onClick={onHeaderClick}>
+        <HeaderCell
+          {...baseProps}
+          field={makeField({ config: { custom: { headerTooltip: 'Only sorts the results on display' } } })}
+        />
+      </div>
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Only sorts the results on display' }));
+    expect(onHeaderClick).not.toHaveBeenCalled();
+  });
+
   it('renders a filter button when the field is filterable', () => {
     render(<HeaderCell {...baseProps} field={makeField({ config: { custom: { filterable: true } } })} />);
     expect(screen.getByLabelText('Filter Field1')).toBeInTheDocument();

--- a/packages/grafana-ui/src/components/Table/TableNG/components/HeaderCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/HeaderCell.tsx
@@ -119,6 +119,7 @@ export const HeaderCell: React.FC<HeaderCellProps> = ({
           name="info-circle"
           size="sm"
           tooltip={headerTooltip}
+          className={styles.headerTooltipIcon}
           onClick={(event) => event.stopPropagation()}
           onMouseDown={(event) => event.stopPropagation()}
           onPointerDown={(event) => event.stopPropagation()}
@@ -163,5 +164,8 @@ const getStyles = memoize((theme: GrafanaTheme2, headerTextWrap?: boolean, sorta
   }),
   headerCellIcon: css({
     color: theme.colors.text.secondary,
+  }),
+  headerTooltipIcon: css({
+    cursor: 'default',
   }),
 }));

--- a/packages/grafana-ui/src/components/Table/TableNG/components/HeaderCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/HeaderCell.tsx
@@ -8,6 +8,7 @@ import { type Column, type SortDirection } from '@grafana/react-data-grid';
 import { useStyles2 } from '../../../../themes/ThemeContext';
 import { getFieldTypeIcon } from '../../../../types/icon';
 import { Icon } from '../../../Icon/Icon';
+import { IconButton } from '../../../IconButton/IconButton';
 import { Stack } from '../../../Layout/Stack/Stack';
 import { Filter } from '../Filter/Filter';
 import { type FilterType, type TableRow, type TableSummaryRow } from '../types';
@@ -49,6 +50,7 @@ export const HeaderCell: React.FC<HeaderCellProps> = ({
   const displayName = getDisplayName(field);
   const filterable = field.config.custom?.filterable ?? false;
   const hideHeader = field.config.custom?.hideHeader ?? false;
+  const headerTooltip = field.config.custom?.headerTooltip;
 
   // we have to remove/reset the filter if the column is not filterable
   useEffect(() => {
@@ -112,6 +114,16 @@ export const HeaderCell: React.FC<HeaderCellProps> = ({
           <Icon className={styles.headerCellIcon} size="lg" name={direction === 'ASC' ? 'arrow-up' : 'arrow-down'} />
         )}
       </button>
+      {headerTooltip && (
+        <IconButton
+          name="info-circle"
+          size="sm"
+          tooltip={headerTooltip}
+          onClick={(event) => event.stopPropagation()}
+          onMouseDown={(event) => event.stopPropagation()}
+          onPointerDown={(event) => event.stopPropagation()}
+        />
+      )}
 
       {filterable && (
         <Filter

--- a/packages/grafana-ui/src/components/Table/types.ts
+++ b/packages/grafana-ui/src/components/Table/types.ts
@@ -161,6 +161,7 @@ export type TableCellOptions = schema.TableCellOptions | TableCustomCellOptions;
 export type TableFieldOptions = Omit<schema.TableFieldOptions, 'cellOptions'> & {
   cellOptions: TableCellOptions;
   headerComponent?: React.ComponentType<CustomHeaderRendererProps>;
+  headerTooltip?: string;
 };
 
 // Cell background and text colors

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -776,11 +776,15 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
     setFilterLevels(levels.map((level) => getLogLevelFromKey(level)));
   }, []);
 
-  const panelData: PanelData = {
-    state: loading ? LoadingState.Loading : LoadingState.Done,
-    series: props.logsFrames ?? [],
-    timeRange: props.range,
-  };
+  const panelData: PanelData = useMemo(
+    () => ({
+      state: loading ? LoadingState.Loading : LoadingState.Done,
+      series: props.logsFrames ?? [],
+      timeRange: props.range,
+      request: getState().explore.panes[exploreId]?.queryResponse.request,
+    }),
+    [exploreId, loading, props.logsFrames, props.range]
+  );
 
   return (
     <>

--- a/public/app/plugins/panel/logstable/LogsTable.test.tsx
+++ b/public/app/plugins/panel/logstable/LogsTable.test.tsx
@@ -429,7 +429,7 @@ describe('LogsTable', () => {
 
   describe('Loki time column tooltip', () => {
     const lokiTooltip =
-      'Sorting this column only changes the order of the displayed results. To update the query’s time-based sort order, use the Sort control on the right.';
+      "Sorting this column only changes the order of the displayed results. To update the query's time-based sort order, use the Sort control on the right.";
 
     it('shows a tooltip on the timestamp column when the query uses Loki', async () => {
       const { container } = setUp({

--- a/public/app/plugins/panel/logstable/LogsTable.test.tsx
+++ b/public/app/plugins/panel/logstable/LogsTable.test.tsx
@@ -429,7 +429,7 @@ describe('LogsTable', () => {
 
   describe('Loki time column tooltip', () => {
     const lokiTooltip =
-      'Sorting this column only reorders the results on display. Use the sort button in the controls on the right to control time sorting, which updates the underlying query.';
+      'Sorting this column only changes the order of the displayed results. To update the query’s time-based sort order, use the Sort control on the right.';
 
     it('shows a tooltip on the timestamp column when the query uses Loki', async () => {
       const { container } = setUp({

--- a/public/app/plugins/panel/logstable/LogsTable.test.tsx
+++ b/public/app/plugins/panel/logstable/LogsTable.test.tsx
@@ -7,6 +7,7 @@ import { Provider } from 'react-redux';
 import {
   type AbsoluteTimeRange,
   CoreApp,
+  type DataQueryRequest,
   type EventBus,
   EventBusSrv,
   type FieldConfigSource,
@@ -423,6 +424,43 @@ describe('LogsTable', () => {
       });
 
       expect(await screen.findByText('Data is missing a time field')).toBeInTheDocument();
+    });
+  });
+
+  describe('Loki time column tooltip', () => {
+    const lokiTooltip =
+      'Sorting this column only reorders the results on display. Use the sort button in the controls on the right to control time sorting, which updates the underlying query.';
+
+    it('shows a tooltip on the timestamp column when the query uses Loki', async () => {
+      const { container } = setUp({
+        data: getPanelData({
+          request: {
+            targets: [{ refId: 'A', datasource: { type: 'loki' } }],
+          } as DataQueryRequest,
+        }),
+      });
+
+      await waitFor(() => expect(screen.queryByText('Selected fields')).toBeInTheDocument());
+
+      expect(screen.getByRole('button', { name: lokiTooltip })).toBeInTheDocument();
+      const timestampHeader = Array.from(container.querySelectorAll('[role="columnheader"]')).find((header) =>
+        header.textContent?.includes('timestamp')
+      );
+      expect(timestampHeader).toContainElement(screen.getByRole('button', { name: lokiTooltip }));
+    });
+
+    it('does not show a timestamp tooltip for other data sources', async () => {
+      setUp({
+        data: getPanelData({
+          request: {
+            targets: [{ refId: 'A', datasource: { type: 'elasticsearch' } }],
+          } as DataQueryRequest,
+        }),
+      });
+
+      await waitFor(() => expect(screen.queryByText('Selected fields')).toBeInTheDocument());
+
+      expect(screen.queryByRole('button', { name: lokiTooltip })).not.toBeInTheDocument();
     });
   });
 });

--- a/public/app/plugins/panel/logstable/LogsTable.tsx
+++ b/public/app/plugins/panel/logstable/LogsTable.tsx
@@ -93,7 +93,7 @@ export const LogsTable = ({
   const timeColumnHeaderTooltip = isLokiDataSource(data, rawTableFrame)
     ? t(
         'explore.logs-table.loki-time-sort-tooltip',
-        'Sorting this column only changes the order of the displayed results. To update the query’s time-based sort order, use the Sort control on the right.'
+        "Sorting this column only changes the order of the displayed results. To update the query's time-based sort order, use the Sort control on the right."
       )
     : undefined;
 

--- a/public/app/plugins/panel/logstable/LogsTable.tsx
+++ b/public/app/plugins/panel/logstable/LogsTable.tsx
@@ -12,6 +12,7 @@ import {
   type PanelData,
   type PanelProps,
 } from '@grafana/data';
+import { t } from '@grafana/i18n';
 import { usePanelContext, useStyles2 } from '@grafana/ui';
 import { SETTING_KEY_ROOT } from 'app/features/explore/Logs/utils/logs';
 import { getDefaultFieldSelectorWidth } from 'app/features/logs/components/fieldSelector/FieldSelector';
@@ -89,6 +90,12 @@ export const LogsTable = ({
   const bodyFieldName = logsFrame?.bodyField.name ?? LOGS_DATAPLANE_BODY_NAME;
   const permalinkedLogId = options.permalinkedLogId ?? getLogsPanelState()?.logs?.id ?? undefined;
   const initialRowIndex = getInitialRowIndex(permalinkedLogId, logsFrame);
+  const timeColumnHeaderTooltip = isLokiDataSource(data, rawTableFrame)
+    ? t(
+        'explore.logs-table.loki-time-sort-tooltip',
+        'Sorting this column only changes the order of the displayed results. To update the query’s time-based sort order, use the Sort control on the right.'
+      )
+    : undefined;
 
   const onLogsTableOptionsChange: OnLogsTableOptionsChange | undefined = isOnLogsTableOptionsChange(onOptionsChange)
     ? onOptionsChange
@@ -235,6 +242,7 @@ export const LogsTable = ({
     onPermalinkClick: isBuildLinkToLogLine(options.buildLinkToLogLine) ? options.buildLinkToLogLine : onPermalinkClick,
     options,
     fieldConfig,
+    timeColumnHeaderTooltip,
   });
 
   // Build panel data
@@ -368,6 +376,20 @@ export const LogsTable = ({
     </div>
   );
 };
+
+function isLokiDataSource(data: PanelData, frame: DataFrame | null): boolean {
+  const targets = data.request?.targets;
+  if (!targets?.length) {
+    return false;
+  }
+
+  const matchingQuery = frame?.refId ? targets.find((query) => query.refId === frame.refId) : undefined;
+  if (matchingQuery) {
+    return matchingQuery.datasource?.type === 'loki';
+  }
+
+  return targets.some((query) => query.datasource?.type === 'loki');
+}
 
 const getStyles = (theme: GrafanaTheme2, height: number, width: number) => {
   return {

--- a/public/app/plugins/panel/logstable/hooks/useOrganizeFields.test.tsx
+++ b/public/app/plugins/panel/logstable/hooks/useOrganizeFields.test.tsx
@@ -298,4 +298,61 @@ describe('useOrganizeFields', () => {
       });
     });
   });
+
+  describe('time column header tooltip', () => {
+    test('sets headerTooltip on the time field when provided', async () => {
+      const { result: organizedFields } = renderHook(() =>
+        useOrganizeFields({
+          extractedFrame,
+          bodyFieldName: LOGS_DATAPLANE_BODY_NAME,
+          levelFieldName: 'level',
+          logsFrame: testLogsFrame,
+          onPermalinkClick: () => null,
+          options: {},
+          supportsPermalink: false,
+          timeFieldName: LOGS_DATAPLANE_TIMESTAMP_NAME,
+          fieldConfig: { defaults: {}, overrides: [] },
+          timeColumnHeaderTooltip: 'Only sorts the results on display',
+        })
+      );
+
+      await waitFor(() => {
+        expect(organizedFields.current.organizedFrame).not.toBeNull();
+      });
+
+      const timeField = organizedFields.current.organizedFrame?.fields.find(
+        (field) => field.name === LOGS_DATAPLANE_TIMESTAMP_NAME
+      );
+      const bodyField = organizedFields.current.organizedFrame?.fields.find(
+        (field) => field.name === LOGS_DATAPLANE_BODY_NAME
+      );
+      expect(timeField?.config.custom?.headerTooltip).toBe('Only sorts the results on display');
+      expect(bodyField?.config.custom?.headerTooltip).toBeUndefined();
+    });
+
+    test('does not set headerTooltip on the time field when omitted', async () => {
+      const { result: organizedFields } = renderHook(() =>
+        useOrganizeFields({
+          extractedFrame,
+          bodyFieldName: LOGS_DATAPLANE_BODY_NAME,
+          levelFieldName: 'level',
+          logsFrame: testLogsFrame,
+          onPermalinkClick: () => null,
+          options: {},
+          supportsPermalink: false,
+          timeFieldName: LOGS_DATAPLANE_TIMESTAMP_NAME,
+          fieldConfig: { defaults: {}, overrides: [] },
+        })
+      );
+
+      await waitFor(() => {
+        expect(organizedFields.current.organizedFrame).not.toBeNull();
+      });
+
+      const timeField = organizedFields.current.organizedFrame?.fields.find(
+        (field) => field.name === LOGS_DATAPLANE_TIMESTAMP_NAME
+      );
+      expect(timeField?.config.custom?.headerTooltip).toBeUndefined();
+    });
+  });
 });

--- a/public/app/plugins/panel/logstable/hooks/useOrganizeFields.tsx
+++ b/public/app/plugins/panel/logstable/hooks/useOrganizeFields.tsx
@@ -27,6 +27,7 @@ interface Props {
   supportsPermalink: boolean;
   onPermalinkClick: BuildLinkToLogLine;
   fieldConfig: FieldConfigSource;
+  timeColumnHeaderTooltip?: string;
 }
 
 export function useOrganizeFields({
@@ -39,6 +40,7 @@ export function useOrganizeFields({
   onPermalinkClick,
   options,
   fieldConfig,
+  timeColumnHeaderTooltip,
 }: Props) {
   const [organizedFrame, setOrganizedFrame] = useState<DataFrame | null>(null);
   const isMounted = useMountedState();
@@ -60,7 +62,8 @@ export function useOrganizeFields({
       bodyFieldName,
       supportsPermalink,
       onPermalinkClick,
-      fieldConfig
+      fieldConfig,
+      timeColumnHeaderTooltip
     )
       .then((frame) => {
         if (frame && isMounted()) {
@@ -81,6 +84,7 @@ export function useOrganizeFields({
     onPermalinkClick,
     isMounted,
     fieldConfig,
+    timeColumnHeaderTooltip,
   ]);
 
   return { organizedFrame };
@@ -95,7 +99,8 @@ const organizeFields = async (
   bodyFieldName: string,
   supportsPermalink: boolean,
   onPermalinkClick: BuildLinkToLogLine,
-  fieldConfig: FieldConfigSource
+  fieldConfig: FieldConfigSource,
+  timeColumnHeaderTooltip?: string
 ) => {
   if (!extractedFrame) {
     return Promise.resolve(null);
@@ -159,6 +164,9 @@ const organizeFields = async (
               ? getTimeFieldWidth(configAfterLevel.custom?.width, fieldIndex, options)
               : configAfterLevel.custom?.width,
           inspect: configAfterLevel.custom?.inspect ?? doesFieldSupportInspector(field),
+          ...(field.name === timeFieldName && timeColumnHeaderTooltip
+            ? { headerTooltip: timeColumnHeaderTooltip }
+            : {}),
           cellOptions:
             isFirstField && bodyFieldName && (supportsPermalink || options.enableLogDetails)
               ? {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8682,7 +8682,8 @@
         "inspect-value": "Inspect value",
         "show-details": "Show details",
         "view-log-line": "View log line"
-      }
+      },
+      "loki-time-sort-tooltip": "Sorting this column only changes the order of the displayed results. To update the query’s time-based sort order, use the Sort control on the right."
     },
     "logs-table-empty-fields": {
       "no-fields": "No fields"

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8683,7 +8683,7 @@
         "show-details": "Show details",
         "view-log-line": "View log line"
       },
-      "loki-time-sort-tooltip": "Sorting this column only changes the order of the displayed results. To update the query’s time-based sort order, use the Sort control on the right."
+      "loki-time-sort-tooltip": "Sorting this column only changes the order of the displayed results. To update the query's time-based sort order, use the Sort control on the right."
     },
     "logs-table-empty-fields": {
       "no-fields": "No fields"

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8672,7 +8672,8 @@
         "inspect-value": "Inspect value",
         "show-details": "Show details",
         "view-log-line": "View log line"
-      }
+      },
+      "loki-time-sort-tooltip": "Sorting this column only changes the order of the displayed results. To update the query’s time-based sort order, use the Sort control on the right."
     },
     "logs-table-empty-fields": {
       "no-fields": "No fields"


### PR DESCRIPTION
When logs are displayed in the Logs Panel or Logs Table, the sorting button from the visualization controls in the right side not only control the time-sequence of the results, but also change the underlying query in the case of Loki.

For Loki, depending on the time order, the underlying query will be changed to query in backwards or forward direction.

For the Logs Table, since the Table headers only controls the order of the results on display, we are adding a dedicated tooltip to let the users know that there's a dedicated control to get the newest or oldest values within a time range, without:

- Disabling client-side sorting: users can still choose to sort the results by time in any particular order, like it can be done for any other columns.
- Linking table header sorting with query direction. We maintain the headers function to sort the results on display, and we don't add a special case when the user clicks at the time columm.

E.g.

<img width="437" height="125" alt="imagen" src="https://github.com/user-attachments/assets/383cd181-b16e-46e7-9b0f-e273cca08cb2" />
