### PR TITLE
Alerting: Check silence create permissions before showing the new silence form

### DIFF
--- a/public/app/features/alerting/unified/NewSilencePage.tsx
+++ b/public/app/features/alerting/unified/NewSilencePage.tsx
@@ -1,3 +1,4 @@
+import { skipToken } from '@reduxjs/toolkit/query';
 import { useLocation } from 'react-router-dom-v5-compat';
 
 import { Trans, t } from '@grafana/i18n';
@@ -42,8 +43,7 @@ const SilencesEditorComponent = () => {
     isLoading: silencedRuleLoading,
     isError: silencedRuleUnavailable,
   } = alertRuleApi.endpoints.getAlertRule.useQuery(
-    { uid: potentialRuleUid ?? '' },
-    { skip: isGeneralSilence || !isGrafanaAlertmanager }
+    isGeneralSilence || !isGrafanaAlertmanager ? skipToken : { uid: potentialRuleUid }
   );
   const createAbility = useSilenceAbility({
     action: SilenceAction.Create,

--- a/public/app/features/alerting/unified/NewSilencePage.tsx
+++ b/public/app/features/alerting/unified/NewSilencePage.tsx
@@ -1,6 +1,8 @@
 import { useLocation } from 'react-router-dom-v5-compat';
 
-import { t } from '@grafana/i18n';
+import { Trans, t } from '@grafana/i18n';
+import { Alert, LoadingPlaceholder } from '@grafana/ui';
+import { alertRuleApi } from 'app/features/alerting/unified/api/alertRuleApi';
 import {
   defaultsFromQuery,
   getDefaultSilenceFormValues,
@@ -11,19 +13,59 @@ import { parseQueryParamMatchers } from 'app/features/alerting/unified/utils/mat
 import { AlertmanagerPageWrapper } from './components/AlertingPageWrapper';
 import { GrafanaAlertmanagerWarning } from './components/GrafanaAlertmanagerWarning';
 import { SilencesEditor } from './components/silences/SilencesEditor';
+import { isLoading } from './hooks/abilities/abilityUtils';
+import { useSilenceAbility } from './hooks/abilities/alertmanager/useSilenceAbility';
+import { SilenceAction } from './hooks/abilities/types';
 import { useAlertmanager } from './state/AlertmanagerContext';
 import { withPageErrorBoundary } from './withPageErrorBoundary';
 
 const SilencesEditorComponent = () => {
   const location = useLocation();
   const queryParams = new URLSearchParams(location.search);
-  const { selectedAlertmanager = '' } = useAlertmanager();
+  const { selectedAlertmanager = '', isGrafanaAlertmanager } = useAlertmanager();
   const potentialAlertRuleMatcher = parseQueryParamMatchers(queryParams.getAll('matcher')).find(
     (m) => m.name === MATCHER_ALERT_RULE_UID
   );
 
   const potentialRuleUid = potentialAlertRuleMatcher?.value;
   const formValues = getDefaultSilenceFormValues(defaultsFromQuery(queryParams));
+
+  // Users can reach this page through a link, so check up front instead of letting them fill in a
+  // form that fails on save. The backend splits the check two ways: without a rule matcher this
+  // form creates what it calls a general silence, which can match alerts from any rule and so
+  // needs the org-wide permission. With a rule matcher the silence only affects that one rule, so
+  // permission on the rule's folder is enough - which means we need to know the rule's folder.
+  const isGeneralSilence = !potentialRuleUid;
+  const { data: silencedRule, isLoading: silencedRuleLoading } = alertRuleApi.endpoints.getAlertRule.useQuery(
+    { uid: potentialRuleUid ?? '' },
+    { skip: isGeneralSilence || !isGrafanaAlertmanager }
+  );
+  const createAbility = useSilenceAbility({
+    action: SilenceAction.Create,
+    folderUID: silencedRule?.grafana_alert.namespace_uid,
+  });
+
+  if (silencedRuleLoading || isLoading(createAbility)) {
+    return (
+      <LoadingPlaceholder text={t('alerting.new-silence-page.text-checking-permissions', 'Checking permissions...')} />
+    );
+  }
+
+  if (!createAbility.granted) {
+    return (
+      <Alert
+        severity="error"
+        title={t(
+          'alerting.new-silence-page.title-permission-create-silence',
+          'You do not have permission to create this silence'
+        )}
+      >
+        <Trans i18nKey="alerting.new-silence-page.body-permission-create-silence">
+          You can still silence individual alert rules from their detail pages.
+        </Trans>
+      </Alert>
+    );
+  }
 
   return (
     <>

--- a/public/app/features/alerting/unified/NewSilencePage.tsx
+++ b/public/app/features/alerting/unified/NewSilencePage.tsx
@@ -9,11 +9,12 @@ import {
 } from 'app/features/alerting/unified/components/silences/utils';
 import { MATCHER_ALERT_RULE_UID } from 'app/features/alerting/unified/utils/constants';
 import { parseQueryParamMatchers } from 'app/features/alerting/unified/utils/matchers';
+import { AccessControlAction } from 'app/types/accessControl';
 
 import { AlertmanagerPageWrapper } from './components/AlertingPageWrapper';
 import { GrafanaAlertmanagerWarning } from './components/GrafanaAlertmanagerWarning';
 import { SilencesEditor } from './components/silences/SilencesEditor';
-import { isLoading } from './hooks/abilities/abilityUtils';
+import { hasAnyPermission, isLoading } from './hooks/abilities/abilityUtils';
 import { useSilenceAbility } from './hooks/abilities/alertmanager/useSilenceAbility';
 import { SilenceAction } from './hooks/abilities/types';
 import { useAlertmanager } from './state/AlertmanagerContext';
@@ -71,6 +72,11 @@ const SilencesEditorComponent = () => {
       );
     }
 
+    // Pointing someone at the rule detail pages is only useful if they can silence a rule there:
+    // they need the folder-level permission somewhere, and those pages silence through the Grafana
+    // alertmanager.
+    const canSilenceSomeRule = isGrafanaAlertmanager && hasAnyPermission([AccessControlAction.AlertingSilenceCreate]);
+
     return (
       <Alert
         severity="error"
@@ -79,9 +85,11 @@ const SilencesEditorComponent = () => {
           'You do not have permission to create this silence'
         )}
       >
-        <Trans i18nKey="alerting.new-silence-page.body-permission-create-silence">
-          You can still silence individual alert rules from their detail pages.
-        </Trans>
+        {canSilenceSomeRule && (
+          <Trans i18nKey="alerting.new-silence-page.body-permission-create-silence">
+            You can still silence individual alert rules from their detail pages.
+          </Trans>
+        )}
       </Alert>
     );
   }

--- a/public/app/features/alerting/unified/NewSilencePage.tsx
+++ b/public/app/features/alerting/unified/NewSilencePage.tsx
@@ -36,7 +36,11 @@ const SilencesEditorComponent = () => {
   // needs the org-wide permission. With a rule matcher the silence only affects that one rule, so
   // permission on the rule's folder is enough - which means we need to know the rule's folder.
   const isGeneralSilence = !potentialRuleUid;
-  const { data: silencedRule, isLoading: silencedRuleLoading } = alertRuleApi.endpoints.getAlertRule.useQuery(
+  const {
+    data: silencedRule,
+    isLoading: silencedRuleLoading,
+    isError: silencedRuleUnavailable,
+  } = alertRuleApi.endpoints.getAlertRule.useQuery(
     { uid: potentialRuleUid ?? '' },
     { skip: isGeneralSilence || !isGrafanaAlertmanager }
   );
@@ -52,6 +56,21 @@ const SilencesEditorComponent = () => {
   }
 
   if (!createAbility.granted) {
+    // We never learned which folder to check, so a permission verdict isn't ours to give - the
+    // folder may well allow this silence. Say what actually went wrong instead.
+    if (silencedRuleUnavailable) {
+      return (
+        <Alert
+          severity="error"
+          title={t('alerting.new-silence-page.title-alert-rule-unavailable', 'Alert rule unavailable')}
+        >
+          <Trans i18nKey="alerting.new-silence-page.body-alert-rule-unavailable">
+            This alert rule may have been deleted, or you may not have permission to view it.
+          </Trans>
+        </Alert>
+      );
+    }
+
     return (
       <Alert
         severity="error"

--- a/public/app/features/alerting/unified/Silences.test.tsx
+++ b/public/app/features/alerting/unified/Silences.test.tsx
@@ -7,6 +7,7 @@ import { type DataSourceApi, dateTime } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { locationService } from '@grafana/runtime';
 import { mockAlertRuleApi, setupMswServer } from 'app/features/alerting/unified/mockApi';
+import { setFolderAccessControl } from 'app/features/alerting/unified/mocks/server/configure';
 import { waitForServerRequest } from 'app/features/alerting/unified/mocks/server/events';
 import {
   MOCK_DATASOURCE_NAME_BROKEN_ALERTMANAGER,
@@ -428,4 +429,42 @@ describe('Silence create/edit', () => {
     },
     TEST_TIMEOUT
   );
+
+  const ruleSilenceUrlPath = `${baseUrlPath}?matcher=${MATCHER_ALERT_RULE_UID}%3D${grafanaRulerRule.grafana_alert.uid}`;
+
+  // A silence with no rule attached can silence alerts from any rule, so the backend asks for the
+  // org-wide create permission - folder permissions are no help. Someone whose silence permission
+  // comes from a folder can still follow a link to this page, and should be told rather than shown
+  // a form that fails on save.
+  it('shows a permission error for a silence that is not tied to an alert rule', async () => {
+    grantUserPermissions([AccessControlAction.AlertingInstanceRead]);
+    setFolderAccessControl({ [AccessControlAction.AlertingSilenceCreate]: true });
+
+    renderSilences(baseUrlPath);
+
+    expect(await ui.noPermissionToEdit.find()).toBeInTheDocument();
+    expect(ui.editor.durationField.query()).not.toBeInTheDocument();
+  });
+
+  // A silence for a single rule only affects that rule, so silence create on the folder the rule
+  // lives in is enough - no org-wide permission needed.
+  it('renders the form for a rule silence when the rule folder allows creating silences', async () => {
+    grantUserPermissions([AccessControlAction.AlertingInstanceRead]);
+    setFolderAccessControl({ [AccessControlAction.AlertingSilenceCreate]: true });
+
+    renderSilences(ruleSilenceUrlPath);
+
+    expect(await screen.findByLabelText(/alert rule/i)).toHaveValue(grafanaRulerRule.grafana_alert.title);
+    expect(ui.noPermissionToEdit.query()).not.toBeInTheDocument();
+  });
+
+  it('shows a permission error for a rule silence when the rule folder does not allow creating silences', async () => {
+    grantUserPermissions([AccessControlAction.AlertingInstanceRead]);
+    setFolderAccessControl({ [AccessControlAction.AlertingSilenceRead]: true });
+
+    renderSilences(ruleSilenceUrlPath);
+
+    expect(await ui.noPermissionToEdit.find()).toBeInTheDocument();
+    expect(ui.editor.durationField.query()).not.toBeInTheDocument();
+  });
 });

--- a/public/app/features/alerting/unified/Silences.test.tsx
+++ b/public/app/features/alerting/unified/Silences.test.tsx
@@ -438,7 +438,7 @@ describe('Silence create/edit', () => {
   // comes from a folder can still follow a link to this page, and should be told rather than shown
   // a form that fails on save.
   it('shows a permission error for a silence that is not tied to an alert rule', async () => {
-    grantUserPermissions([AccessControlAction.AlertingInstanceRead]);
+    grantUserPermissions([AccessControlAction.AlertingInstanceRead, AccessControlAction.AlertingSilenceCreate]);
     setFolderAccessControl({ [AccessControlAction.AlertingSilenceCreate]: true });
 
     renderSilences(baseUrlPath);
@@ -481,6 +481,26 @@ describe('Silence create/edit', () => {
     expect(await ui.ruleUnavailable.find()).toBeInTheDocument();
     expect(ui.noPermissionToEdit.query()).not.toBeInTheDocument();
     expect(ui.editor.durationField.query()).not.toBeInTheDocument();
+  });
+
+  // Sending someone to the rule detail pages only helps if they can silence a rule once they get
+  // there. Reaching this page on silence update permission alone does not give them that.
+  it('omits the rule-page suggestion for a user who cannot silence any rule', async () => {
+    grantUserPermissions([AccessControlAction.AlertingInstanceRead, AccessControlAction.AlertingSilenceUpdate]);
+
+    renderSilences(baseUrlPath);
+
+    expect(await ui.noPermissionToEdit.find()).toBeInTheDocument();
+    expect(screen.queryByText(/silence individual alert rules/i)).not.toBeInTheDocument();
+  });
+
+  it('suggests the rule detail pages to a user who can silence rules in a folder', async () => {
+    grantUserPermissions([AccessControlAction.AlertingInstanceRead, AccessControlAction.AlertingSilenceCreate]);
+
+    renderSilences(baseUrlPath);
+
+    expect(await ui.noPermissionToEdit.find()).toBeInTheDocument();
+    expect(screen.getByText(/silence individual alert rules/i)).toBeInTheDocument();
   });
 
   // The backend lets anyone holding the org-wide permission through before it resolves the rule's

--- a/public/app/features/alerting/unified/Silences.test.tsx
+++ b/public/app/features/alerting/unified/Silences.test.tsx
@@ -74,6 +74,7 @@ const ui = {
   addSilenceButton: byRole('link', { name: /add silence/i }),
   existingSilenceNotFound: byRole('alert', { name: /existing silence .* not found/i }),
   noPermissionToEdit: byRole('alert', { name: /do not have permission/i }),
+  ruleUnavailable: byRole('alert', { name: /alert rule unavailable/i }),
   editor: {
     timeRange: byTestId(selectors.components.TimePicker.openButton),
     durationField: byLabelText('Duration'),
@@ -466,5 +467,31 @@ describe('Silence create/edit', () => {
 
     expect(await ui.noPermissionToEdit.find()).toBeInTheDocument();
     expect(ui.editor.durationField.query()).not.toBeInTheDocument();
+  });
+
+  // Reading the rule needs alert.rules:read on its folder, which the backend does not ask for when
+  // creating a silence. A failed lookup therefore says nothing about whether the silence is
+  // allowed, so blaming permissions would be misleading.
+  it('reports the rule as unavailable rather than blaming permissions when the rule cannot be loaded', async () => {
+    grantUserPermissions([AccessControlAction.AlertingInstanceRead]);
+    setFolderAccessControl({ [AccessControlAction.AlertingSilenceCreate]: true });
+
+    renderSilences(`${baseUrlPath}?matcher=${MATCHER_ALERT_RULE_UID}%3Ddoes-not-exist`);
+
+    expect(await ui.ruleUnavailable.find()).toBeInTheDocument();
+    expect(ui.noPermissionToEdit.query()).not.toBeInTheDocument();
+    expect(ui.editor.durationField.query()).not.toBeInTheDocument();
+  });
+
+  // The backend lets anyone holding the org-wide permission through before it resolves the rule's
+  // folder, so a rule we cannot load must not stop them.
+  it('renders the form for an unloadable rule when the org-wide permission is held', async () => {
+    grantUserPermissions([AccessControlAction.AlertingInstanceRead, AccessControlAction.AlertingInstanceCreate]);
+
+    renderSilences(`${baseUrlPath}?matcher=${MATCHER_ALERT_RULE_UID}%3Ddoes-not-exist`);
+
+    expect(await ui.editor.durationField.find()).toBeInTheDocument();
+    expect(ui.ruleUnavailable.query()).not.toBeInTheDocument();
+    expect(ui.noPermissionToEdit.query()).not.toBeInTheDocument();
   });
 });

--- a/public/app/features/alerting/unified/hooks/abilities/alertmanager/useSilenceAbility.test.tsx
+++ b/public/app/features/alerting/unified/hooks/abilities/alertmanager/useSilenceAbility.test.tsx
@@ -1,9 +1,11 @@
-import { renderHook } from 'test/test-utils';
+import { getWrapper, renderHook, waitFor } from 'test/test-utils';
 
 import { AccessControlAction } from 'app/types/accessControl';
 
 import { setupMswServer } from '../../../mockApi';
 import { grantUserPermissions } from '../../../mocks';
+import { setFolderAccessControl } from '../../../mocks/server/configure';
+import { useFolder } from '../../useFolder';
 import { isLoading } from '../abilityUtils';
 import { SilenceAction } from '../types';
 
@@ -15,7 +17,7 @@ import {
   setupGrafanaAlertmanager,
   setupMimirAlertmanager,
 } from './abilityTestUtils';
-import { useSilenceAbility } from './useSilenceAbility';
+import { useGlobalSilenceAbility, useSilenceAbility } from './useSilenceAbility';
 
 setupMswServer();
 
@@ -108,13 +110,79 @@ describe('useSilenceAbility', () => {
       expect(result.current.granted).toBe(true);
     });
 
-    it('should grant Create when only AlertingSilenceCreate is held', () => {
+    // AlertingSilenceCreate is always granted on folders, and the backend only accepts it for a
+    // silence that targets a single rule. Without a folderUID the silence is not tied to a rule,
+    // so holding it somewhere must not grant Create.
+    it('should deny Create when only AlertingSilenceCreate is held and no folderUID is given', () => {
       const amSource = setupGrafanaAlertmanager();
       grantUserPermissions([GRAFANA_AM_VISIBILITY_PERMISSION, AccessControlAction.AlertingSilenceCreate]);
+      setFolderAccessControl({ [AccessControlAction.AlertingSilenceCreate]: true });
 
       const { result } = renderHook(() => useSilenceAbility({ action: SilenceAction.Create }), {
         wrapper: createAlertmanagerWrapper(amSource),
       });
+
+      expect(result.current.granted).toBe(false);
+    });
+
+    // With a folderUID the silence targets a rule in that folder, which is what the backend
+    // accepts folder-level AlertingSilenceCreate for.
+    it('should grant Create when the rule folder allows AlertingSilenceCreate', async () => {
+      const amSource = setupGrafanaAlertmanager();
+      grantUserPermissions([GRAFANA_AM_VISIBILITY_PERMISSION]);
+      setFolderAccessControl({ [AccessControlAction.AlertingSilenceCreate]: true });
+
+      const { result } = renderHook(
+        () => useSilenceAbility({ action: SilenceAction.Create, folderUID: 'NAMESPACE_UID' }),
+        { wrapper: createAlertmanagerWrapper(amSource) }
+      );
+
+      await waitFor(() => expect(result.current.granted).toBe(true));
+    });
+
+    it('should deny Create when the rule folder does not allow AlertingSilenceCreate', async () => {
+      const amSource = setupGrafanaAlertmanager();
+      grantUserPermissions([GRAFANA_AM_VISIBILITY_PERMISSION]);
+      setFolderAccessControl({ [AccessControlAction.AlertingSilenceRead]: true });
+
+      const { result } = renderHook(
+        () => ({
+          folder: useFolder('NAMESPACE_UID').folder,
+          ability: useSilenceAbility({ action: SilenceAction.Create, folderUID: 'NAMESPACE_UID' }),
+        }),
+        { wrapper: createAlertmanagerWrapper(amSource) }
+      );
+
+      // Wait for the folder to arrive first - otherwise "denied" would pass while the check is
+      // still holding at Loading.
+      await waitFor(() => expect(result.current.folder).toBeDefined());
+      expect(isLoading(result.current.ability)).toBe(false);
+      expect(result.current.ability.granted).toBe(false);
+    });
+
+    // Denying before the folder arrives would hide a button the user is in fact allowed to use.
+    it('should report Loading while the rule folder is still resolving', () => {
+      const amSource = setupGrafanaAlertmanager();
+      grantUserPermissions([GRAFANA_AM_VISIBILITY_PERMISSION]);
+      setFolderAccessControl({ [AccessControlAction.AlertingSilenceCreate]: true });
+
+      const { result } = renderHook(
+        () => useSilenceAbility({ action: SilenceAction.Create, folderUID: 'NAMESPACE_UID' }),
+        { wrapper: createAlertmanagerWrapper(amSource) }
+      );
+
+      expect(isLoading(result.current)).toBe(true);
+    });
+
+    // Someone with the org-wide permission can silence any rule, so there is nothing to wait for.
+    it('should grant Create without waiting for the folder when AlertingInstanceCreate is held', () => {
+      const amSource = setupGrafanaAlertmanager();
+      grantUserPermissions([GRAFANA_AM_VISIBILITY_PERMISSION, AccessControlAction.AlertingInstanceCreate]);
+
+      const { result } = renderHook(
+        () => useSilenceAbility({ action: SilenceAction.Create, folderUID: 'NAMESPACE_UID' }),
+        { wrapper: createAlertmanagerWrapper(amSource) }
+      );
 
       expect(result.current.granted).toBe(true);
     });
@@ -140,6 +208,22 @@ describe('useSilenceAbility', () => {
         wrapper: createAlertmanagerWrapper(amSource),
       });
 
+      expect(result.current.granted).toBe(false);
+    });
+
+    // Grafana folders say nothing about who may silence in an external alertmanager, so a
+    // folderUID must not open the door here - and must not park the check at Loading either.
+    it('should ignore the rule folder and not wait for it', () => {
+      const amSource = setupMimirAlertmanager();
+      grantUserPermissions([EXTERNAL_AM_VISIBILITY_PERMISSION]);
+      setFolderAccessControl({ [AccessControlAction.AlertingSilenceCreate]: true });
+
+      const { result } = renderHook(
+        () => useSilenceAbility({ action: SilenceAction.Create, folderUID: 'NAMESPACE_UID' }),
+        { wrapper: createAlertmanagerWrapper(amSource) }
+      );
+
+      expect(isLoading(result.current)).toBe(false);
       expect(result.current.granted).toBe(false);
     });
 
@@ -248,6 +332,69 @@ describe('useSilenceAbility', () => {
       expect(isLoading(result.current.view)).toBe(true);
       expect(isLoading(result.current.preview)).toBe(true);
       expect(isLoading(result.current.update)).toBe(true);
+    });
+  });
+});
+
+describe('useGlobalSilenceAbility', () => {
+  // This hook reads folder access control through the store, so it needs the app providers
+  // even though it does no alertmanager-type gating. Build a fresh one per test so a folder
+  // fetched by one test isn't served from the query cache in the next.
+  let wrapper: ReturnType<typeof getWrapper>;
+  beforeEach(() => {
+    wrapper = getWrapper({ renderWithRouter: true });
+  });
+
+  // Mirrors the backend split: a silence with no rule attached needs the org-wide
+  // alert.instances:create, while a silence for a rule in a folder can also be created with
+  // alert.silences:create on that folder.
+  describe('silence that is not tied to a rule (no folderUID)', () => {
+    it('should grant Create when AlertingInstanceCreate is held', () => {
+      grantUserPermissions([AccessControlAction.AlertingInstanceCreate]);
+
+      const { result } = renderHook(() => useGlobalSilenceAbility({ action: SilenceAction.Create }), { wrapper });
+
+      expect(result.current.granted).toBe(true);
+    });
+
+    it('should deny Create when only AlertingSilenceCreate is held', () => {
+      grantUserPermissions([AccessControlAction.AlertingSilenceCreate]);
+
+      const { result } = renderHook(() => useGlobalSilenceAbility({ action: SilenceAction.Create }), { wrapper });
+
+      expect(result.current.granted).toBe(false);
+    });
+  });
+
+  describe('silence for a rule in a folder', () => {
+    it('should grant Create when the folder allows AlertingSilenceCreate', async () => {
+      grantUserPermissions([]);
+      setFolderAccessControl({ [AccessControlAction.AlertingSilenceCreate]: true });
+
+      const { result } = renderHook(
+        () => useGlobalSilenceAbility({ action: SilenceAction.Create, folderUID: 'NAMESPACE_UID' }),
+        { wrapper }
+      );
+
+      await waitFor(() => expect(result.current.granted).toBe(true));
+    });
+
+    it('should deny Create when the folder does not allow AlertingSilenceCreate', async () => {
+      grantUserPermissions([]);
+      setFolderAccessControl({ [AccessControlAction.AlertingSilenceRead]: true });
+
+      const { result } = renderHook(
+        () => ({
+          folder: useFolder('NAMESPACE_UID').folder,
+          ability: useGlobalSilenceAbility({ action: SilenceAction.Create, folderUID: 'NAMESPACE_UID' }),
+        }),
+        { wrapper }
+      );
+
+      // Wait for the folder to arrive first - otherwise "denied" would pass before the check
+      // has had any access control to look at.
+      await waitFor(() => expect(result.current.folder).toBeDefined());
+      expect(result.current.ability.granted).toBe(false);
     });
   });
 });

--- a/public/app/features/alerting/unified/hooks/abilities/alertmanager/useSilenceAbility.ts
+++ b/public/app/features/alerting/unified/hooks/abilities/alertmanager/useSilenceAbility.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 
 import { type Silence } from 'app/plugins/datasource/alertmanager/types';
 import { AccessControlAction } from 'app/types/accessControl';
+import { type FolderDTO } from 'app/types/folders';
 
 import { useFolder } from '../../../hooks/useFolder';
 import { useAlertmanager } from '../../../state/AlertmanagerContext';
@@ -11,7 +12,7 @@ import { type Ability, type AsyncAbility, Granted, InsufficientPermissions, Load
 
 export type SilenceAbilityParam =
   | { action: SilenceAction.View }
-  | { action: SilenceAction.Create }
+  | { action: SilenceAction.Create; folderUID?: string }
   | { action: SilenceAction.Preview }
   | { action: SilenceAction.Update; context?: Silence };
 
@@ -23,10 +24,14 @@ export type GlobalSilenceAbilityParam =
 
 // Backend HTTP gates accept either alert.instances:* or alert.silences:* for Grafana AM.
 // Frontend mirrors that by listing both in the accepted set.
+//
+// Create is the exception. alert.silences:create is always folder-scoped, so it only covers
+// silences for a rule in that folder - checked separately against folderUID. A silence that
+// isn't tied to a rule needs the org-wide alert.instances:create.
 const GRAFANA_PERMISSIONS: Record<SilenceAction, AccessControlAction[]> = {
   [SilenceAction.View]: [instancesPermissions.read.grafana, silencesPermissions.read.grafana],
   [SilenceAction.Preview]: [instancesPermissions.read.grafana, silencesPermissions.read.grafana],
-  [SilenceAction.Create]: [instancesPermissions.create.grafana, silencesPermissions.create.grafana],
+  [SilenceAction.Create]: [instancesPermissions.create.grafana],
   [SilenceAction.Update]: [instancesPermissions.update.grafana, silencesPermissions.update.grafana],
 };
 
@@ -38,13 +43,22 @@ const EXTERNAL_PERMISSIONS: Record<SilenceAction, AccessControlAction[]> = {
 };
 
 /**
+ * A user with AlertingSilenceCreate on a folder may silence the rules that live in it, so this
+ * stands in for the org-wide create permission when the silence targets a single rule.
+ */
+function canCreateSilenceInFolder(folder: FolderDTO | undefined): boolean {
+  return folder?.accessControl?.[AccessControlAction.AlertingSilenceCreate] ?? false;
+}
+
+/**
  * Global (unscoped) silence ability check, outside of AlertmanagerContext.
  *
  * Performs a pure RBAC check with no alertmanager-type gate.
  *
- * For `SilenceAction.Create`, an optional `folderUID` can be provided to also check
- * folder-level RBAC (`AlertingSilenceCreate` on that folder). When `folderUID` is
- * omitted the folder check is skipped and only global permissions are evaluated.
+ * For `SilenceAction.Create`, pass the `folderUID` of the rule the silence will target so
+ * folder-level RBAC (`AlertingSilenceCreate` on that folder) is taken into account. Leave it
+ * out when the silence is not tied to a single rule - only the org-wide permission counts
+ * then, which is what the backend enforces.
  */
 export function useGlobalSilenceAbility(payload: GlobalSilenceAbilityParam): Ability {
   const folderUID = payload.action === SilenceAction.Create ? payload.folderUID : undefined;
@@ -54,8 +68,9 @@ export function useGlobalSilenceAbility(payload: GlobalSilenceAbilityParam): Abi
     switch (payload.action) {
       case SilenceAction.Create: {
         const globalAbility = makeAbility(true, GRAFANA_PERMISSIONS[SilenceAction.Create]);
-        const hasFolderPermission = folder?.accessControl?.[AccessControlAction.AlertingSilenceCreate] ?? false;
-        return globalAbility.granted || hasFolderPermission ? Granted : globalAbility;
+        // Only meaningful when a folderUID was passed: the silence targets a rule in that
+        // folder, which folder-level AlertingSilenceCreate is enough to silence.
+        return globalAbility.granted || canCreateSilenceInFolder(folder) ? Granted : globalAbility;
       }
 
       case SilenceAction.View:
@@ -66,8 +81,19 @@ export function useGlobalSilenceAbility(payload: GlobalSilenceAbilityParam): Abi
   }, [payload.action, folder]);
 }
 
+/**
+ * Silence ability check within AlertmanagerContext, gated on the selected alertmanager type.
+ *
+ * For `SilenceAction.Create`, pass the `folderUID` of the rule the silence will target so
+ * folder-level RBAC is taken into account; leave it out for a silence that is not tied to a
+ * single rule. Folder permissions are only consulted for the Grafana alertmanager - external
+ * ones have a single org-wide permission and no notion of which folder a rule lives in.
+ */
 export function useSilenceAbility(payload: SilenceAbilityParam): AsyncAbility {
   const { selectedAlertmanager, isGrafanaAlertmanager } = useAlertmanager();
+
+  const folderUID = payload.action === SilenceAction.Create && isGrafanaAlertmanager ? payload.folderUID : undefined;
+  const { folder, loading: folderLoading } = useFolder(folderUID);
 
   return useMemo(() => {
     // Return Loading until the selected alertmanager is resolved so callers can
@@ -81,8 +107,20 @@ export function useSilenceAbility(payload: SilenceAbilityParam): AsyncAbility {
     switch (payload.action) {
       case SilenceAction.View:
       case SilenceAction.Preview:
-      case SilenceAction.Create:
         return makeAbility(true, permissions[payload.action]);
+
+      case SilenceAction.Create: {
+        const orgWideAbility = makeAbility(true, permissions[SilenceAction.Create]);
+        if (orgWideAbility.granted || !folderUID) {
+          return orgWideAbility;
+        }
+        // Hold at Loading rather than denying - until the folder arrives we cannot tell whether
+        // the user may silence rules in it.
+        if (folderLoading || !folder) {
+          return Loading;
+        }
+        return canCreateSilenceInFolder(folder) ? Granted : orgWideAbility;
+      }
 
       case SilenceAction.Update:
         if (payload.context?.accessControl?.write === false) {
@@ -90,5 +128,5 @@ export function useSilenceAbility(payload: SilenceAbilityParam): AsyncAbility {
         }
         return makeAbility(true, permissions[SilenceAction.Update]);
     }
-  }, [payload, selectedAlertmanager, isGrafanaAlertmanager]);
+  }, [payload, selectedAlertmanager, isGrafanaAlertmanager, folderUID, folder, folderLoading]);
 }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2259,6 +2259,7 @@
       "title-no-alerting-capable-query-found": "No alerting capable query found"
     },
     "new-silence-page": {
+      "body-permission-create-silence": "You can still silence individual alert rules from their detail pages.",
       "page-nav": {
         "subTitle": {
           "configure-silences-notifications-particular-alert": "Configure silences to stop notifications from a particular alert rule"
@@ -2266,7 +2267,9 @@
         "text": {
           "silence-alert-rule": "Silence alert rule"
         }
-      }
+      },
+      "text-checking-permissions": "Checking permissions...",
+      "title-permission-create-silence": "You do not have permission to create this silence"
     },
     "no-alert-managers-available": {
       "body-no-alertmanager-found": "We could not find any external Alertmanagers and you may not have access to the built-in Grafana Alertmanager.",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2259,6 +2259,7 @@
       "title-no-alerting-capable-query-found": "No alerting capable query found"
     },
     "new-silence-page": {
+      "body-alert-rule-unavailable": "This alert rule may have been deleted, or you may not have permission to view it.",
       "body-permission-create-silence": "You can still silence individual alert rules from their detail pages.",
       "page-nav": {
         "subTitle": {
@@ -2269,6 +2270,7 @@
         }
       },
       "text-checking-permissions": "Checking permissions...",
+      "title-alert-rule-unavailable": "Alert rule unavailable",
       "title-permission-create-silence": "You do not have permission to create this silence"
     },
     "no-alert-managers-available": {


### PR DESCRIPTION
**What is this feature?**

The new silence page now checks whether you're allowed to create the silence before rendering the form, mirroring the split the backend already enforces:

- A silence with no `__alert_rule_uid__` matcher can match alerts from any rule, so it needs the org-wide `alert.instances:create`. Folder-level `alert.silences:create` is not accepted (`createGeneralSilenceEvaluator`).
- A silence for a single rule only affects that rule, so `alert.silences:create` on the rule's folder is enough (`createRuleSilenceEvaluator`). The page looks the rule up to find which folder to check.

When you can't create the silence you get an explanation instead of a form. `useSilenceAbility({ action: Create })` takes an optional `folderUID` for this, and no longer accepts `alert.silences:create` on its own — that permission is always folder-scoped, so it can't stand in for the org-wide one.

**Why do we need this feature?**

The route to `/alerting/silence/new` admits anyone holding `alert.instances:create`, `alert.instances.external:write`, `alert.silences:create` or `alert.silences:write`. That's wider than what any individual silence needs, so users could follow a link to the page, fill in the whole form, and only find out on save that they weren't allowed. Buttons pointing at the general form — the silences list, the empty-state CTA, alert group details — had the same problem: they showed for folder-scoped users whose permission doesn't cover a general silence.

**Who is this feature for?**

Users whose alerting permissions are folder-scoped rather than org-wide.

**Which issue(s) does this PR fix?**:

N/A — no linked issue.

**Special notes for your reviewer:**

Frontend only, no backend changes. The backend already rejected these requests; this stops the UI from offering work that can't succeed. Nothing was possible before that isn't possible now.

The checks map to `pkg/services/ngalert/accesscontrol/silences.go`:

- `createGeneralSilenceEvaluator` → `GRAFANA_PERMISSIONS[SilenceAction.Create]`
- `createRuleSilenceEvaluator` → the `folderUID` branch in `useSilenceAbility`

Two decisions worth a look:

- While the rule's folder is resolving, the check holds at `LOADING` rather than denying — otherwise folder-scoped users get an error flash on every page load. Same approach as `useRulerSilenceState`. The tradeoff is that a failed folder read leaves you on the loading placeholder, which needs a rule to be readable while its folder isn't.
- Folder permissions are only consulted for the Grafana alertmanager. External ones have a single org-wide permission and no notion of a rule's folder, so a `folderUID` is ignored there.

Two gaps left deliberately:

- The backend also `EvalAll`s create with a read permission, which the frontend doesn't check. Unreachable in practice — the alertmanager picker already requires a read permission before this page renders.
- Finding the rule's folder means reading the rule, which needs `alert.rules:read` — stricter than the backend, which never asks for it when creating a silence. Someone with folder-scoped `alert.silences:create` but no rule read on that folder can't be verified here, so they get told the rule is unavailable rather than shown a form. It needs a hand-rolled custom role to reach (the folder presets grant rule read alongside), every in-product route here requires reading the rule first, and there's no way to resolve a rule's folder without reading the rule.

Verified with unit tests (`Silences.test.tsx`, `useSilenceAbility.test.tsx`); not exercised manually in a running instance.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
