### PR TITLE
Auth: fix concurrent map panic in OAuth strategy config loading

### DIFF
--- a/pkg/services/authn/clients/oauth.go
+++ b/pkg/services/authn/clients/oauth.go
@@ -212,7 +212,7 @@ func (c *OAuth) Authenticate(ctx context.Context, r *authn.Request) (*authn.Iden
 	}
 
 	lookupParams := login.UserLookupParams{}
-	allowInsecureEmailLookup := cfg.Raw.Section("auth").Key("oauth_allow_insecure_email_lookup").MustBool(false)
+	allowInsecureEmailLookup := cfg.OAuthAllowInsecureEmailLookup
 	if allowInsecureEmailLookup {
 		lookupParams.Email = &userInfo.Email
 	}

--- a/pkg/services/authn/clients/oauth_test.go
+++ b/pkg/services/authn/clients/oauth_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -327,10 +326,7 @@ func TestOAuth_Authenticate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			cfg := setting.NewCfg()
-			auth, err := cfg.Raw.NewSection("auth")
-			assert.NoError(t, err)
-			_, err = auth.NewKey("oauth_allow_insecure_email_lookup", strconv.FormatBool(tt.allowInsecureTakeover))
-			assert.NoError(t, err)
+			cfg.OAuthAllowInsecureEmailLookup = tt.allowInsecureTakeover
 
 			if tt.addStateCookie {
 				v := tt.stateCookieValue

--- a/pkg/services/ssosettings/strategies/oauth_strategy.go
+++ b/pkg/services/ssosettings/strategies/oauth_strategy.go
@@ -5,11 +5,12 @@ import (
 	"maps"
 	"slices"
 
+	"gopkg.in/ini.v1"
+
 	"github.com/grafana/grafana/pkg/configprovider"
 	"github.com/grafana/grafana/pkg/login/social"
 	"github.com/grafana/grafana/pkg/login/social/connectors"
 	"github.com/grafana/grafana/pkg/services/ssosettings"
-	"github.com/grafana/grafana/pkg/setting"
 )
 
 type OAuthStrategy struct {
@@ -48,15 +49,21 @@ func (s *OAuthStrategy) GetProviderConfig(ctx context.Context, provider string) 
 }
 
 func (s *OAuthStrategy) loadAllSettings(ctx context.Context) (map[string]map[string]any, error) {
-	cfg, err := s.cfgProvider.Get(ctx)
+	allProviders := slices.Concat(ssosettings.AllOAuthProviders, []string{social.GrafanaNetProviderName})
+
+	sections := make([]string, 0, len(allProviders))
+	for _, provider := range allProviders {
+		sections = append(sections, "auth."+provider)
+	}
+
+	iniFile, err := s.cfgProvider.GetSections(ctx, sections...)
 	if err != nil {
 		return nil, err
 	}
 
 	settingsByProvider := make(map[string]map[string]any)
-	allProviders := slices.Concat(ssosettings.AllOAuthProviders, []string{social.GrafanaNetProviderName})
 	for _, provider := range allProviders {
-		settings := loadSettingsForProvider(cfg, provider)
+		settings := loadSettingsFromSection(iniFile.Section("auth."+provider), provider)
 		// This is required to support the legacy settings for the provider (auth.grafananet section)
 		// It will use the settings (and overwrite the current grafana_com settings) from auth.grafananet if
 		// the auth.grafananet section is enabled and the auth.grafana_com section is disabled.
@@ -73,9 +80,7 @@ func shouldUseGrafanaNetSettings(settingsByProvider map[string]map[string]any) b
 	return settingsByProvider[social.GrafanaComProviderName]["enabled"] == false
 }
 
-func loadSettingsForProvider(cfg *setting.Cfg, provider string) map[string]any {
-	section := cfg.Raw.Section("auth." + provider)
-
+func loadSettingsFromSection(section *ini.Section, provider string) map[string]any {
 	result := map[string]any{
 		"client_authentication":         section.Key("client_authentication").Value(),
 		"client_id":                     section.Key("client_id").Value(),

--- a/pkg/services/ssosettings/strategies/oauth_strategy.go
+++ b/pkg/services/ssosettings/strategies/oauth_strategy.go
@@ -51,7 +51,8 @@ func (s *OAuthStrategy) GetProviderConfig(ctx context.Context, provider string) 
 func (s *OAuthStrategy) loadAllSettings(ctx context.Context) (map[string]map[string]any, error) {
 	allProviders := slices.Concat(ssosettings.AllOAuthProviders, []string{social.GrafanaNetProviderName})
 
-	sections := make([]string, 0, len(allProviders))
+	sections := make([]string, 1, len(allProviders)+1)
+	sections[0] = "auth"
 	for _, provider := range allProviders {
 		sections = append(sections, "auth."+provider)
 	}

--- a/pkg/services/ssosettings/strategies/oauth_strategy_test.go
+++ b/pkg/services/ssosettings/strategies/oauth_strategy_test.go
@@ -185,6 +185,25 @@ func TestOAuthStrategyUsesCurrentConfig(t *testing.T) {
 	require.Equal(t, "rotated-secret", rotated["client_secret"])
 }
 
+func TestOAuthStrategyPreservesAuthSectionInheritance(t *testing.T) {
+	raw, err := ini.Load([]byte(`
+[auth]
+signout_redirect_url = https://example.com/logout
+
+[auth.generic_oauth]
+enabled = true
+`))
+	require.NoError(t, err)
+
+	cfg := setting.NewCfg()
+	cfg.Raw = raw
+	strategy := NewOAuthStrategy(staticConfigProvider(t, cfg))
+
+	result, err := strategy.GetProviderConfig(context.Background(), social.GenericOAuthProviderName)
+	require.NoError(t, err)
+	require.Equal(t, "https://example.com/logout", result["signout_redirect_url"])
+}
+
 func oauthConfigWithClientSecret(t *testing.T, secret string) *setting.Cfg {
 	t.Helper()
 	raw, err := ini.Load([]byte("[auth.generic_oauth]\nclient_secret = " + secret))

--- a/pkg/services/ssosettings/strategies/oauth_strategy_test.go
+++ b/pkg/services/ssosettings/strategies/oauth_strategy_test.go
@@ -35,6 +35,25 @@ func (p *mutableConfigProvider) GetSections(ctx context.Context, sections ...str
 	return provider.GetSections(ctx, sections...)
 }
 
+// sharedRawConfigProvider simulates the enterprise ConfigProvider: every call
+// to Get returns the same *setting.Cfg (and therefore the same ini.File),
+// which is what triggers the concurrent map race inside ini.Section.Key().
+type sharedRawConfigProvider struct {
+	cfg *setting.Cfg
+}
+
+func (p *sharedRawConfigProvider) Get(context.Context) (*setting.Cfg, error) {
+	return p.cfg, nil
+}
+
+func (p *sharedRawConfigProvider) GetSections(ctx context.Context, sections ...string) (*ini.File, error) {
+	provider, err := configprovider.ProvideService(p.cfg)
+	if err != nil {
+		return nil, err
+	}
+	return provider.GetSections(ctx, sections...)
+}
+
 var (
 	iniContent = `
 	[auth.generic_oauth]
@@ -388,5 +407,38 @@ func TestGetProviderConfig_GrafanaComGrafanaNet(t *testing.T) {
 				require.Equal(t, value, actualConfig[key], "Difference in key: %s. Expected: %v, got: %v", key, value, actualConfig[key])
 			}
 		})
+	}
+}
+
+// TestGetProviderConfig_ConcurrentAccess exercises the code path that
+// previously panicked with "concurrent map read and map write" inside
+// gopkg.in/ini.v1 when multiple goroutines called GetProviderConfig on a
+// shared *setting.Cfg. Run with -race to verify the fix:
+//
+//	go test -race -run TestGetProviderConfig_ConcurrentAccess ./pkg/services/ssosettings/strategies/
+func TestGetProviderConfig_ConcurrentAccess(t *testing.T) {
+	iniFile, err := ini.Load([]byte(iniContent))
+	require.NoError(t, err)
+
+	cfg := setting.NewCfg()
+	cfg.Raw = iniFile
+
+	// sharedRawConfigProvider returns the same cfg (and thus the same
+	// ini.File) on every call, which is what the enterprise ConfigProvider
+	// does when the TTL cache is warm.
+	strategy := NewOAuthStrategy(&sharedRawConfigProvider{cfg: cfg})
+
+	const goroutines = 16
+	errs := make(chan error, goroutines)
+
+	for range goroutines {
+		go func() {
+			_, err := strategy.GetProviderConfig(t.Context(), "generic_oauth")
+			errs <- err
+		}()
+	}
+
+	for range goroutines {
+		require.NoError(t, <-errs)
 	}
 }

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -2119,7 +2119,7 @@ func readAuthSettings(iniFile *ini.File, cfg *Cfg) (err error) {
 
 	auth := iniFile.Section("auth")
 
-	cfg.OAuthAllowInsecureEmailLookup = auth.Key("oauth_allow_insecure_email_lookup").MustBool(false)
+	readOAuthAllowInsecureEmailLookup(iniFile, cfg)
 
 	cfg.ApiKeyMaxSecondsToLive = auth.Key("api_key_max_seconds_to_live").MustInt64(-1)
 

--- a/pkg/setting/setting_authn.go
+++ b/pkg/setting/setting_authn.go
@@ -35,6 +35,7 @@ func (cfg *Cfg) ApplyAuthnSettings(iniFile *ini.File) error {
 	if err := readSessionAuthSettings(iniFile, cfg); err != nil {
 		return err
 	}
+	readOAuthAllowInsecureEmailLookup(iniFile, cfg)
 	readOAuthCookieMaxAge(iniFile, cfg)
 	readOAuthRefreshLockSettings(iniFile, cfg)
 	readCookieSecuritySettings(iniFile, cfg)
@@ -77,6 +78,10 @@ func readSessionAuthSettings(iniFile *ini.File, cfg *Cfg) error {
 
 func readOAuthCookieMaxAge(iniFile *ini.File, cfg *Cfg) {
 	cfg.OAuthCookieMaxAge = iniFile.Section("auth").Key("oauth_state_cookie_max_age").MustInt(600)
+}
+
+func readOAuthAllowInsecureEmailLookup(iniFile *ini.File, cfg *Cfg) {
+	cfg.OAuthAllowInsecureEmailLookup = iniFile.Section("auth").Key("oauth_allow_insecure_email_lookup").MustBool(false)
 }
 
 func readOAuthRefreshLockSettings(iniFile *ini.File, cfg *Cfg) {

--- a/pkg/setting/setting_authn_test.go
+++ b/pkg/setting/setting_authn_test.go
@@ -38,6 +38,8 @@ func TestApplyAuthnSettings(t *testing.T) {
 		require.NoError(t, err)
 		_, err = auth.NewKey("oauth_refresh_token_server_lock_min_wait_ms", "1250")
 		require.NoError(t, err)
+		_, err = auth.NewKey("oauth_allow_insecure_email_lookup", "true")
+		require.NoError(t, err)
 
 		users, err := settings.NewSection("users")
 		require.NoError(t, err)
@@ -68,6 +70,7 @@ func TestApplyAuthnSettings(t *testing.T) {
 		assert.Equal(t, "secretKey.v1", cfg.Raw.Section("security").Key("encryption_provider").String())
 		assert.Equal(t, 900, cfg.OAuthCookieMaxAge)
 		assert.Equal(t, int64(1250), cfg.OAuthRefreshTokenServerLockMinWaitMs)
+		assert.True(t, cfg.OAuthAllowInsecureEmailLookup)
 		assert.True(t, cfg.CookieSecure)
 		assert.Equal(t, http.SameSiteStrictMode, cfg.CookieSameSiteMode)
 		assert.Equal(t, "http://localtest.example.com:8080/", cfg.AppURL)


### PR DESCRIPTION
## Summary

- Switch `OAuthStrategy.loadAllSettings` from `cfgProvider.Get(ctx)` + `cfg.Raw.Section(...)` to `cfgProvider.GetSections(ctx, ...)` which returns a private `ini.File` copy safe for concurrent use.
- Replace `cfg.Raw.Section("auth").Key("oauth_allow_insecure_email_lookup")` in the OAuth authn client with the already-parsed `cfg.OAuthAllowInsecureEmailLookup` struct field.

## Why

Follow-up to https://github.com/grafana/grafana/pull/130512. That PR made the OAuth strategy resolve config per-request via `ConfigProvider`. In Cloud, the enterprise `ConfigProvider` periodically refreshes settings (short TTL + singleflight), and concurrent goroutines calling `GetProviderConfig` race on the shared `ini.File`'s internal key map, causing `fatal error: concurrent map read and map write` panics that crash-loop stacks.

## Test plan

- [x] Added `TestGetProviderConfig_ConcurrentAccess`: 16 goroutines hit `GetProviderConfig` concurrently with a shared `cfg` (simulating the enterprise ConfigProvider's warm-cache behaviour)
- [x] Verified `-race` **catches** the issue on the old code (5/5 FAIL)
- [x] Verified `-race` **passes** cleanly with the fix (5/5 PASS)
- [x] Existing tests pass (`go test ./pkg/services/ssosettings/strategies/...`)

Made with [Cursor](https://cursor.com)