### PR TITLE
Chore: Compile all Zod schema automatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -276,7 +276,7 @@
     "webpack-subresource-integrity": "^5.2.0-rc.1",
     "webpackbar": "^7.0.0",
     "yargs": "^18.0.0",
-    "zod": "^4.3.0"
+    "zod": "^4.5.4"
   },
   "dependencies": {
     "@bsull/augurs": "^0.10.0",

--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -93,7 +93,7 @@
     "tinycolor2": "^1.6.0",
     "uplot": "^1.6.32",
     "xss": "^1.0.14",
-    "zod": "^4.3.0"
+    "zod": "^4.5.4"
   },
   "devDependencies": {
     "@rollup/plugin-json": "6.1.0",

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -5,6 +5,9 @@ import 'whatwg-fetch'; // fetch polyfill needed for PhantomJs rendering
 import 'file-saver';
 import 'jquery';
 
+// eslint-disable-next-line @grafana/zod-import-namespace
+import 'zod/compile';
+
 import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -1,5 +1,8 @@
 import 'jquery';
 
+// eslint-disable-next-line @grafana/zod-import-namespace
+import 'zod/compile';
+
 import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2455,7 +2455,7 @@ __metadata:
     typescript: "npm:@typescript/typescript6@^6.0.2"
     uplot: "npm:^1.6.32"
     xss: "npm:^1.0.14"
-    zod: "npm:^4.3.0"
+    zod: "npm:^4.5.4"
   peerDependencies:
     react: ">=19"
     react-dom: ">=19"
@@ -20402,7 +20402,7 @@ __metadata:
     webpackbar: "npm:^7.0.0"
     whatwg-fetch: "npm:3.6.20"
     yargs: "npm:^18.0.0"
-    zod: "npm:^4.3.0"
+    zod: "npm:^4.5.4"
   dependenciesMeta:
     msw:
       built: true
@@ -35945,10 +35945,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.25 || ^4.0, zod@npm:^4.1.11, zod@npm:^4.3.0":
+"zod@npm:^3.25 || ^4.0, zod@npm:^4.1.11":
   version: 4.4.3
   resolution: "zod@npm:4.4.3"
   checksum: 10/804b9a42aa8f35f2b3c5a8dff906291cb749115f83ee2afe3576d70b5b5c53c965365c7f4967690647a9c54af9838ff232a85ff9577a0a36c44b68bc6cdefe36
+  languageName: node
+  linkType: hard
+
+"zod@npm:^4.5.4":
+  version: 4.5.4
+  resolution: "zod@npm:4.5.4"
+  checksum: 10/b2fd4aaf358359650a1f27f303a462f0f49b4e5582f517ad8894ed566fdceb9da391b59babffe3c70574c8064174883735657eb28e12db5c7021455a631866c4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What is this feature?**

Introduces the global Zod compile registration side-effect at the start of the `app.ts` entrypoint, enabling all our Zod schemas to be automatically compiled.

https://github.com/colinhacks/zod/pull/6085
https://zod.dev/compile
https://github.com/colinhacks/zod/blob/main/packages/zod/src/compile.ts

**Why do we need this feature?**

Performance:tm:

\<insert speed + memory + size benchmarks here\>

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
