### PR TITLE
Dashboard Export: migrate exporters to use async DataSource APIs

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1518,9 +1518,6 @@
     }
   },
   "public/app/features/dashboard-scene/scene/export/exporters.ts": {
-    "@grafana/no-get-data-source-srv": {
-      "count": 1
-    },
     "@typescript-eslint/consistent-type-assertions": {
       "count": 3
     },

--- a/public/app/features/dashboard-scene/scene/export/exporters.test.ts
+++ b/public/app/features/dashboard-scene/scene/export/exporters.test.ts
@@ -68,6 +68,12 @@ jest.mock('@grafana/runtime', () => ({
   },
 }));
 
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstance: (v: string | DataSourceRef) => Promise.resolve(getStubInstanceSettings(v)),
+  getDataSourceInstanceSettings: (v: string | DataSourceRef) => Promise.resolve(getStubInstanceSettings(v)),
+}));
+
 jest.mock('app/features/library-panels/state/api', () => ({
   getLibraryPanel: jest.fn().mockImplementation((uid: string) => {
     if (uid === 'test-library-panel-uid') {

--- a/public/app/features/dashboard-scene/scene/export/exporters.test.ts
+++ b/public/app/features/dashboard-scene/scene/export/exporters.test.ts
@@ -698,9 +698,10 @@ describe('dashboard exporter v1', () => {
         getVariablesFromState: () => [],
       });
 
-      const exported = (await makeExportableV1(dashboardModel)) as { error: Error };
-      expect(exported.error).toBeInstanceOf(Error);
-      expect(exported.error.message).toBe('Datasource missing-uid was not found');
+      const exported = (await makeExportableV1(dashboardModel)) as { error: { message: string } };
+      expect(JSON.parse(JSON.stringify(exported))).toEqual({
+        error: { message: 'Datasource missing-uid was not found' },
+      });
       expect(consoleSpy).toHaveBeenCalled();
       consoleSpy.mockRestore();
     });

--- a/public/app/features/dashboard-scene/scene/export/exporters.test.ts
+++ b/public/app/features/dashboard-scene/scene/export/exporters.test.ts
@@ -7,6 +7,7 @@ import {
   type TypedVariableModel,
 } from '@grafana/data';
 import { setPanelPluginMetas } from '@grafana/runtime/internal';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { type Dashboard, DashboardCursorSync, ThresholdsMode } from '@grafana/schema';
 import {
   type DatasourceVariableKind,
@@ -70,7 +71,7 @@ jest.mock('@grafana/runtime', () => ({
 
 jest.mock('@grafana/runtime/unstable', () => ({
   ...jest.requireActual('@grafana/runtime/unstable'),
-  getDataSourceInstance: (v: string | DataSourceRef) => Promise.resolve(getStubInstanceSettings(v)),
+  getDataSourceInstance: jest.fn((v: string | DataSourceRef) => Promise.resolve(getStubInstanceSettings(v))),
   getDataSourceInstanceSettings: (v: string | DataSourceRef) => Promise.resolve(getStubInstanceSettings(v)),
 }));
 
@@ -674,6 +675,34 @@ describe('dashboard exporter v1', () => {
           },
         ],
       });
+    });
+  });
+
+  describe('unresolvable datasource', () => {
+    it('fails the export when the datasource cannot be resolved', async () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      jest.mocked(getDataSourceInstance).mockRejectedValueOnce(new Error('Datasource missing-uid was not found'));
+
+      const dashboard: Dashboard = {
+        title: 'My dashboard',
+        panels: [
+          {
+            id: 1,
+            type: 'timeseries',
+            title: 'Panel',
+            datasource: { type: 'prometheus', uid: 'missing-uid' },
+          },
+        ],
+      } as Dashboard;
+      const dashboardModel = new DashboardModel(dashboard, undefined, {
+        getVariablesFromState: () => [],
+      });
+
+      const exported = (await makeExportableV1(dashboardModel)) as { error: Error };
+      expect(exported.error).toBeInstanceOf(Error);
+      expect(exported.error.message).toBe('Datasource missing-uid was not found');
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
     });
   });
 });

--- a/public/app/features/dashboard-scene/scene/export/exporters.ts
+++ b/public/app/features/dashboard-scene/scene/export/exporters.ts
@@ -356,9 +356,7 @@ export async function makeExportableV1(dashboard: DashboardModel) {
     return newObj;
   } catch (err) {
     console.error('Export failed:', err);
-    return {
-      error: err,
-    };
+    return toExportableError(err);
   }
 }
 
@@ -601,8 +599,12 @@ export async function makeExportableV2(dashboard: DashboardV2Spec, isSharingExte
     return dashboard;
   } catch (err) {
     console.error('Export failed:', err);
-    return {
-      error: err,
-    };
+    return toExportableError(err);
   }
+}
+
+function toExportableError(err: unknown): { error: { message: string } } {
+  return {
+    error: { message: err instanceof Error ? err.message : String(err) },
+  };
 }

--- a/public/app/features/dashboard-scene/scene/export/exporters.ts
+++ b/public/app/features/dashboard-scene/scene/export/exporters.ts
@@ -1,8 +1,8 @@
 import { defaults, each, sortBy } from 'lodash';
 
 import { type DataSourceRef, type VariableOption, VariableRefresh } from '@grafana/data';
-import { getDataSourceSrv } from '@grafana/runtime';
 import { getPanelPluginMeta } from '@grafana/runtime/internal';
+import { getDataSourceInstance, getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { type Panel } from '@grafana/schema';
 import {
   type Spec as DashboardV2Spec,
@@ -121,7 +121,7 @@ export async function makeExportableV1(dashboard: DashboardModel) {
 
   const datasourceVariableRefNameMap: { [key: string]: string } = {};
 
-  const templateizeDatasourceUsage = (obj: any, fallback?: DataSourceRef) => {
+  const templateizeDatasourceUsage = async (obj: any, fallback?: DataSourceRef) => {
     if (obj.datasource === undefined) {
       obj.datasource = fallback;
       return;
@@ -148,54 +148,51 @@ export async function makeExportableV1(dashboard: DashboardModel) {
       }
     }
 
-    return getDataSourceSrv()
-      .get(datasource)
-      .then((ds) => {
-        if (ds.meta?.builtIn) {
-          return;
-        }
+    const ds = await getDataSourceInstance(datasource);
+    if (ds.meta?.builtIn) {
+      return;
+    }
 
-        // add data source type to require list
-        requires['datasource' + ds.meta?.id] = {
-          type: 'datasource',
-          id: ds.meta.id,
-          name: ds.meta.name,
-          version: ds.meta.info.version || '1.0.0',
-        };
+    // add data source type to require list
+    requires['datasource' + ds.meta?.id] = {
+      type: 'datasource',
+      id: ds.meta.id,
+      name: ds.meta.name,
+      version: ds.meta.info.version || '1.0.0',
+    };
 
-        const libraryPanel = obj.libraryPanel;
-        const libraryPanelSuffix = !!libraryPanel ? '-for-library-panel' : '';
-        let refName = 'DS_' + ds.name.replace(' ', '_').toUpperCase() + libraryPanelSuffix.toUpperCase();
-        const templatedUid = '${' + refName + '}';
+    const libraryPanel = obj.libraryPanel;
+    const libraryPanelSuffix = !!libraryPanel ? '-for-library-panel' : '';
+    let refName = 'DS_' + ds.name.replace(' ', '_').toUpperCase() + libraryPanelSuffix.toUpperCase();
+    const templatedUid = '${' + refName + '}';
 
-        datasources[refName] = {
-          name: refName,
-          label: ds.name,
-          description: '',
-          type: 'datasource',
-          pluginId: ds.meta?.id,
-          pluginName: ds.meta?.name,
-          usage: datasources[refName]?.usage,
-        };
+    datasources[refName] = {
+      name: refName,
+      label: ds.name,
+      description: '',
+      type: 'datasource',
+      pluginId: ds.meta?.id,
+      pluginName: ds.meta?.name,
+      usage: datasources[refName]?.usage,
+    };
 
-        if (!!libraryPanel) {
-          const libPanels = datasources[refName]?.usage?.libraryPanels || [];
-          libPanels.push({ name: libraryPanel.name, uid: libraryPanel.uid });
+    if (!!libraryPanel) {
+      const libPanels = datasources[refName]?.usage?.libraryPanels || [];
+      libPanels.push({ name: libraryPanel.name, uid: libraryPanel.uid });
 
-          datasources[refName].usage = {
-            libraryPanels: libPanels,
-          };
-        }
+      datasources[refName].usage = {
+        libraryPanels: libPanels,
+      };
+    }
 
-        // if panel or query is relying on a datasource variable
-        // skip templating datasource uid but save the reference so we can set datasource variable's current prop
-        if (datasourceVariable && varName) {
-          datasourceVariableRefNameMap[varName] = '${' + refName + '}';
-          return;
-        }
+    // if panel or query is relying on a datasource variable
+    // skip templating datasource uid but save the reference so we can set datasource variable's current prop
+    if (datasourceVariable && varName) {
+      datasourceVariableRefNameMap[varName] = '${' + refName + '}';
+      return;
+    }
 
-        obj.datasource = { type: ds.meta.id, uid: templatedUid };
-      });
+    obj.datasource = { type: ds.meta.id, uid: templatedUid };
   };
 
   const processPanel = async (panel: PanelModel) => {
@@ -462,7 +459,7 @@ export async function makeExportableV2(dashboard: DashboardV2Spec, isSharingExte
     return varName !== undefined && datasourceVariablesByName.has(varName);
   };
 
-  const attachExportLabels = (
+  const attachExportLabels = async (
     group: string,
     datasourceUid: string,
     existingLabels: DataQueryKind['labels'] | AdhocVariableKind['labels']
@@ -471,7 +468,7 @@ export async function makeExportableV2(dashboard: DashboardV2Spec, isSharingExte
     // show the original datasource name — same idea as V1's datasourceVariableRefNameMap.
     const varName = getDatasourceVariableName(datasourceUid);
     const resolvedUid = (varName ? datasourceVariablesByName.get(varName)?.currentUid : undefined) ?? datasourceUid;
-    const datasourceName = getDatasourceDisplayName(resolvedUid);
+    const datasourceName = await getDatasourceDisplayName(resolvedUid);
 
     return {
       ...(existingLabels ?? {}),
@@ -480,7 +477,7 @@ export async function makeExportableV2(dashboard: DashboardV2Spec, isSharingExte
     };
   };
 
-  const processDataQueryKind = (dataQueryKind: DataQueryKind) => {
+  const processDataQueryKind = async (dataQueryKind: DataQueryKind) => {
     if (!dataQueryKind.datasource?.name) {
       return;
     }
@@ -489,15 +486,15 @@ export async function makeExportableV2(dashboard: DashboardV2Spec, isSharingExte
 
     if (isReferencingDsTemplateVariable(datasourceUid)) {
       // Keep $var on the query, but label it so external import can prompt for this DS type.
-      dataQueryKind.labels = attachExportLabels(dataQueryKind.group, datasourceUid, dataQueryKind.labels);
+      dataQueryKind.labels = await attachExportLabels(dataQueryKind.group, datasourceUid, dataQueryKind.labels);
       return;
     }
 
-    dataQueryKind.labels = attachExportLabels(dataQueryKind.group, datasourceUid, dataQueryKind.labels);
+    dataQueryKind.labels = await attachExportLabels(dataQueryKind.group, datasourceUid, dataQueryKind.labels);
     dataQueryKind.datasource = undefined;
   };
 
-  const processAdHocAndGroupByVariables = (variable: AdhocVariableKind | GroupByVariableKind) => {
+  const processAdHocAndGroupByVariables = async (variable: AdhocVariableKind | GroupByVariableKind) => {
     const datasourceUid = variable.datasource?.name;
 
     if (!datasourceUid) {
@@ -505,16 +502,16 @@ export async function makeExportableV2(dashboard: DashboardV2Spec, isSharingExte
     }
 
     if (isReferencingDsTemplateVariable(datasourceUid)) {
-      variable.labels = attachExportLabels(variable.group, datasourceUid, variable.labels);
+      variable.labels = await attachExportLabels(variable.group, datasourceUid, variable.labels);
       return;
     }
 
-    variable.labels = attachExportLabels(variable.group, datasourceUid, variable.labels);
+    variable.labels = await attachExportLabels(variable.group, datasourceUid, variable.labels);
     variable.datasource = undefined;
   };
 
-  const getDatasourceDisplayName = (datasourceUid: string): string | undefined => {
-    const settings = getDataSourceSrv().getInstanceSettings(datasourceUid);
+  const getDatasourceDisplayName = async (datasourceUid: string): Promise<string | undefined> => {
+    const settings = await getDataSourceInstanceSettings(datasourceUid);
     if (!settings || settings.meta?.builtIn) {
       return undefined;
     }
@@ -537,17 +534,17 @@ export async function makeExportableV2(dashboard: DashboardV2Spec, isSharingExte
     return `${datasourceGroup}-${index}`;
   };
 
-  const processPanel = (panel: PanelKind) => {
+  const processPanel = async (panel: PanelKind) => {
     if (panel.spec.data.spec.queries) {
       for (const query of panel.spec.data.spec.queries) {
-        processDataQueryKind(query.spec.query);
+        await processDataQueryKind(query.spec.query);
       }
     }
   };
 
-  const processVariable = (variable: DashboardV2Spec['variables'][number]) => {
+  const processVariable = async (variable: DashboardV2Spec['variables'][number]) => {
     if (variable.kind === 'QueryVariable') {
-      processDataQueryKind(variable.spec.query);
+      await processDataQueryKind(variable.spec.query);
       variable.spec.options = [];
       variable.spec.current = {
         text: '',
@@ -559,7 +556,7 @@ export async function makeExportableV2(dashboard: DashboardV2Spec, isSharingExte
         value: '',
       };
     } else if (variable.kind === 'AdhocVariable' || variable.kind === 'GroupByVariable') {
-      processAdHocAndGroupByVariables(variable);
+      await processAdHocAndGroupByVariables(variable);
     }
   };
 
@@ -569,13 +566,13 @@ export async function makeExportableV2(dashboard: DashboardV2Spec, isSharingExte
     // process elements
     for (const [key, element] of Object.entries(elements)) {
       if (element.kind === 'Panel') {
-        processPanel(element);
+        await processPanel(element);
       } else if (element.kind === 'LibraryPanel') {
         if (isSharingExternally) {
           // Convert library panel to inline panel for external sharing
           const inlinePanel = await convertLibraryPanelToInlinePanel(element);
           // Apply datasource templating to the converted panel
-          processPanel(inlinePanel);
+          await processPanel(inlinePanel);
           // Replace the library panel with the inline panel
           elements[key] = inlinePanel;
         }
@@ -585,17 +582,19 @@ export async function makeExportableV2(dashboard: DashboardV2Spec, isSharingExte
 
     // process dashboard-level and section (row/tab) template variables
     for (const variable of dashboard.variables) {
-      processVariable(variable);
+      await processVariable(variable);
     }
+    const sectionVariables: DashboardV2Spec['variables'] = [];
     visitDashboardLayoutSections(dashboard.layout, (variables) => {
-      for (const variable of variables) {
-        processVariable(variable);
-      }
+      sectionVariables.push(...variables);
     });
+    for (const variable of sectionVariables) {
+      await processVariable(variable);
+    }
 
     // process annotations vars
     for (const annotation of dashboard.annotations) {
-      processDataQueryKind(annotation.spec.query);
+      await processDataQueryKind(annotation.spec.query);
     }
 
     return dashboard;

--- a/public/app/features/dashboard-scene/scene/export/exporters.ts
+++ b/public/app/features/dashboard-scene/scene/export/exporters.ts
@@ -2,7 +2,7 @@ import { defaults, each, sortBy } from 'lodash';
 
 import { type DataSourceRef, type VariableOption, VariableRefresh } from '@grafana/data';
 import { getPanelPluginMeta } from '@grafana/runtime/internal';
-import { getDataSourceInstance, getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { type Panel } from '@grafana/schema';
 import {
   type Spec as DashboardV2Spec,

--- a/public/app/features/dashboard-scene/scene/export/exporters.ts
+++ b/public/app/features/dashboard-scene/scene/export/exporters.ts
@@ -148,7 +148,12 @@ export async function makeExportableV1(dashboard: DashboardModel) {
       }
     }
 
-    const ds = await getDataSourceInstance(datasource);
+    const ds = await getDataSourceInstanceSettings(datasource);
+
+    if (!ds) {
+      return;
+    }
+
     if (ds.meta?.builtIn) {
       return;
     }

--- a/public/app/features/dashboard-scene/scene/export/exporters.ts
+++ b/public/app/features/dashboard-scene/scene/export/exporters.ts
@@ -2,7 +2,7 @@ import { defaults, each, sortBy } from 'lodash';
 
 import { type DataSourceRef, type VariableOption, VariableRefresh } from '@grafana/data';
 import { getPanelPluginMeta } from '@grafana/runtime/internal';
-import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
+import { getDataSourceInstance, getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { type Panel } from '@grafana/schema';
 import {
   type Spec as DashboardV2Spec,
@@ -148,11 +148,7 @@ export async function makeExportableV1(dashboard: DashboardModel) {
       }
     }
 
-    const ds = await getDataSourceInstanceSettings(datasource);
-
-    if (!ds) {
-      return;
-    }
+    const ds = await getDataSourceInstance(datasource);
 
     if (ds.meta?.builtIn) {
       return;


### PR DESCRIPTION
Replaces legacy sync datasourceSrv with the async one. 


Part of https://github.com/grafana/grafana/issues/127032
