### PR TITLE
Navigation: Add the help, saved items and admin nav sections to the client-built tree

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -924,6 +924,7 @@ playwright.storybook.config.ts @grafana/grafana-frontend-platform
 /public/app/core/navtree/ @grafana/grafana-frontend-navigation
 /public/app/core/navtree/sections/dashboards.navEntry.ts @grafana/grafana-frontend-navigation @grafana/dashboards-squad
 /public/app/core/navtree/sections/profile.navEntry.ts @grafana/grafana-frontend-navigation @grafana/grafana-frontend-platform
+/public/app/core/navtree/sections/admin.navEntry.ts @grafana/grafana-frontend-navigation @grafana/identity-access-team
 /public/app/core/journeys/ @grafana/dashboards-squad
 /scripts/cuj-new.ts @grafana/dashboards-squad
 /scripts/cuj-smoke.ts @grafana/dashboards-squad

--- a/public/app/core/navtree/buildStaticNavTree.test.ts
+++ b/public/app/core/navtree/buildStaticNavTree.test.ts
@@ -1,25 +1,45 @@
 import { type NavModelItem } from '@grafana/data';
+import { GrafanaEdition } from '@grafana/data/internal';
+import { config } from '@grafana/runtime';
 import { AccessControlAction } from 'app/types/accessControl';
 
 import { buildStaticNavTree } from './buildStaticNavTree';
 import { NavID } from './constants';
 import { navIds as ids, setupNavTestState as setup } from './test-utils';
-import { applyAppSubUrl, findNavById as findById, sortNavTree } from './utils';
+import { applyAppSubUrl, findNavById as findById, pruneEmptyNavSections, sortNavTree } from './utils';
 
 const DASHBOARD_READER = [AccessControlAction.DashboardsRead];
 
 describe('buildStaticNavTree', () => {
   describe('sections', () => {
-    it('builds Home and Profile for a signed-in user with no permissions', () => {
+    it('builds the minimal tree for a user with no permissions', () => {
       setup();
+      // cfg is an attachment-parent shell here; pruneEmptyNavSections removes it
+      const tree = buildStaticNavTree();
 
-      expect(ids(buildStaticNavTree())).toEqual([NavID.home, NavID.profile]);
+      expect(ids(tree)).toEqual([NavID.home, NavID.bookmarks, NavID.cfg, NavID.profile, NavID.help]);
     });
 
-    it('seeds Home first, then the sections a user can see', () => {
+    it('orders sections by sort weight', () => {
       setup({ permissions: DASHBOARD_READER });
 
-      expect(ids(buildStaticNavTree())).toEqual([NavID.home, NavID.dashboards, NavID.profile]);
+      expect(ids(buildStaticNavTree())).toEqual([
+        NavID.home,
+        NavID.bookmarks,
+        NavID.starred,
+        NavID.dashboards,
+        NavID.cfg,
+        NavID.profile,
+        NavID.help,
+      ]);
+    });
+
+    it('omits signed-in-only sections for anonymous users', () => {
+      setup({ isSignedIn: false, config: { anonymousEnabled: true } });
+      const tree = buildStaticNavTree();
+
+      expect(findById(tree, NavID.profile)).toBeUndefined();
+      expect(findById(tree, NavID.bookmarks)).toBeUndefined();
     });
 
     it('points home at the login page when signed out and anonymous access is disabled', () => {
@@ -32,7 +52,10 @@ describe('buildStaticNavTree', () => {
       setup({ permissions: DASHBOARD_READER, config: { appSubUrl: '/grafana' } });
       const tree = applyAppSubUrl(buildStaticNavTree());
 
+      expect(findById(tree, NavID.starred)?.url).toBe('/grafana/dashboards?starred');
       expect(findById(tree, NavID.dashboards)?.url).toBe('/grafana/dashboards');
+      // Anchor-only urls (Help) are left alone
+      expect(findById(tree, NavID.help)?.url).toBe('#');
     });
 
     it('shows global variables under dashboards with the toggle and write access', () => {
@@ -125,33 +148,140 @@ describe('buildStaticNavTree', () => {
     );
   });
 
-  describe('profile section', () => {
-    it('builds the profile node from user details', () => {
+  describe('administration section', () => {
+    it('always contains the subsection shells so plugin pages and enterprise items can inject into them', () => {
       setup();
-      const profile = findById(buildStaticNavTree(), NavID.profile);
+      const tree = buildStaticNavTree();
 
-      expect(profile?.text).toBe('Test User');
-      expect(profile?.subTitle).toBe('testuser');
-      expect(ids(profile?.children ?? [])).toEqual(['profile/settings', 'profile/notifications', 'profile/password']);
+      expect(findById(tree, NavID.cfg)).toBeDefined();
+      expect(ids(findById(tree, NavID.cfg)?.children ?? [])).toEqual([
+        NavID.cfgGeneral,
+        NavID.cfgPlugins,
+        NavID.cfgAccess,
+      ]);
     });
 
-    it('omits the change password link when the login form is disabled', () => {
-      setup({ config: { disableLoginForm: true } });
+    it('builds general, plugins, access and authentication nodes for an admin', () => {
+      setup({
+        orgRole: 'Admin',
+        isGrafanaAdmin: true,
+        permissions: [
+          AccessControlAction.OrgsRead,
+          AccessControlAction.OrgsWrite,
+          AccessControlAction.SettingsRead,
+          AccessControlAction.SettingsWrite,
+          AccessControlAction.DataSourcesExplore,
+          AccessControlAction.OrgUsersRead,
+          AccessControlAction.ActionTeamsCreate,
+          AccessControlAction.ServiceAccountsRead,
+        ],
+      });
 
-      expect(ids(findById(buildStaticNavTree(), NavID.profile)?.children ?? [])).not.toContain('profile/password');
+      const cfg = findById(buildStaticNavTree(), NavID.cfg);
+      expect(ids(cfg?.children ?? [])).toEqual([NavID.cfgGeneral, NavID.cfgPlugins, NavID.cfgAccess, 'authentication']);
+      expect(ids(findById(cfg?.children ?? [], NavID.cfgGeneral)?.children ?? [])).toEqual([
+        'upgrading',
+        'org-settings',
+        'server-settings',
+        'global-orgs',
+      ]);
+      expect(ids(findById(cfg?.children ?? [], NavID.cfgAccess)?.children ?? [])).toEqual([
+        'global-users',
+        'teams',
+        'serviceaccounts',
+      ]);
+      expect(cfg?.subTitle).toBe('Organization: Main Org.');
     });
 
-    it('omits the change password link when login is disabled', () => {
-      setup({ config: { auth: { disableLogin: true } } });
+    it('hides the stats and license item on enterprise builds, where enterprise registers its own', () => {
+      setup({
+        orgRole: 'Admin',
+        isGrafanaAdmin: true,
+        permissions: [AccessControlAction.OrgsRead, AccessControlAction.OrgsWrite, AccessControlAction.SettingsRead],
+      });
+      config.buildInfo = { ...config.buildInfo, edition: GrafanaEdition.Enterprise };
 
-      expect(ids(findById(buildStaticNavTree(), NavID.profile)?.children ?? [])).not.toContain('profile/password');
+      const general = findById(findById(buildStaticNavTree(), NavID.cfg)?.children ?? [], NavID.cfgGeneral);
+      expect(ids(general?.children ?? [])).toEqual(['org-settings', 'server-settings', 'global-orgs']);
     });
 
-    it('omits the profile node for anonymous users', () => {
-      setup({ isSignedIn: false, config: { anonymousEnabled: true } });
+    it('gates provisioning on the config param, for org admins and server admins', () => {
+      const provisioning = (tree: NavModelItem[]) => {
+        const general = findById(findById(tree, NavID.cfg)?.children ?? [], NavID.cfgGeneral);
+        return findById(general?.children ?? [], 'provisioning');
+      };
 
-      expect(findById(buildStaticNavTree(), NavID.profile)).toBeUndefined();
+      setup({ orgRole: 'Admin', config: { provisioningEnabled: true } });
+      expect(provisioning(buildStaticNavTree())).toBeDefined();
+
+      // A Grafana server admin passes regardless of org role, like Go's HasRole
+      setup({ orgRole: 'Viewer', isGrafanaAdmin: true, config: { provisioningEnabled: true } });
+      expect(provisioning(buildStaticNavTree())).toBeDefined();
+
+      setup({ orgRole: 'Admin' });
+      expect(provisioning(buildStaticNavTree())).toBeUndefined();
     });
+
+    it('requires server admin for the organizations item', () => {
+      setup({ permissions: [AccessControlAction.OrgsRead], isGrafanaAdmin: false });
+
+      const general = findById(findById(buildStaticNavTree(), NavID.cfg)?.children ?? [], NavID.cfgGeneral);
+      expect(findById(general?.children ?? [], 'global-orgs')).toBeUndefined();
+    });
+
+    it('shows the plugins page for org admins without plugin permissions', () => {
+      setup({ orgRole: 'Admin' });
+
+      const plugins = findById(findById(buildStaticNavTree(), NavID.cfg)?.children ?? [], NavID.cfgPlugins);
+      expect(ids(plugins?.children ?? [])).toContain('plugins');
+    });
+
+    it('shows the extensions page in dev environments', () => {
+      setup();
+      config.buildInfo.env = 'development';
+
+      const plugins = findById(findById(buildStaticNavTree(), NavID.cfg)?.children ?? [], NavID.cfgPlugins);
+      expect(ids(plugins?.children ?? [])).toContain('extensions');
+    });
+  });
+
+  describe('help', () => {
+    it('adds support bundles with config and permission', () => {
+      setup({ permissions: [AccessControlAction.ActionSupportBundlesRead], config: { supportBundlesEnabled: true } });
+
+      expect(ids(findById(buildStaticNavTree(), NavID.help)?.children ?? [])).toEqual(['support-bundles']);
+    });
+  });
+});
+
+describe('pruneEmptyNavSections', () => {
+  it('removes empty cfg/access and cfg shells like the server does', () => {
+    setup();
+    const tree = pruneEmptyNavSections(buildStaticNavTree());
+
+    expect(ids(tree)).toEqual([NavID.home, NavID.bookmarks, NavID.profile, NavID.help]);
+  });
+
+  it('keeps sections that gained children', () => {
+    setup({ orgRole: 'Admin', permissions: [AccessControlAction.OrgUsersRead] });
+    const tree = pruneEmptyNavSections(buildStaticNavTree());
+
+    expect(ids(tree)).toContain(NavID.cfg);
+    const cfg = findById(tree, NavID.cfg);
+    expect(ids(cfg?.children ?? [])).toContain(NavID.cfgAccess);
+  });
+
+  it('removes empty General and Plugins and data admin subsections like the server does', () => {
+    // org.users:read keeps cfg/access (and so cfg) alive, while General and
+    // Plugins and data have no visible children for an editor with this
+    // permission set
+    setup({ orgRole: 'Editor', permissions: [AccessControlAction.OrgUsersRead] });
+    const cfg = findById(pruneEmptyNavSections(buildStaticNavTree()), NavID.cfg);
+
+    expect(cfg).toBeDefined();
+    expect(ids(cfg?.children ?? [])).not.toContain(NavID.cfgGeneral);
+    expect(ids(cfg?.children ?? [])).not.toContain(NavID.cfgPlugins);
+    expect(ids(cfg?.children ?? [])).toContain(NavID.cfgAccess);
   });
 });
 

--- a/public/app/core/navtree/buildStaticNavTree.ts
+++ b/public/app/core/navtree/buildStaticNavTree.ts
@@ -4,9 +4,12 @@ import { type NavModelItem } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 
+import { adminNavEntry } from './sections/admin.navEntry';
 import { dashboardsNavEntry } from './sections/dashboards.navEntry';
+import { helpNavEntry } from './sections/help.navEntry';
 import { getHomeNode } from './sections/home.navEntry';
 import { profileNavEntry } from './sections/profile.navEntry';
+import { bookmarksNavEntry, starredNavEntry } from './sections/savedItems.navEntry';
 import { applyAppSubUrl, buildEntries, type NavEntryBuilder, pruneEmptyNavSections, sortNavTree } from './utils';
 
 /**
@@ -49,8 +52,8 @@ export function getInitialNavTree(): NavModelItem[] {
   }
 
   const staticTree = applyAppSubUrl(buildStaticNavTree());
-  // Empty attachment-parent sections are pruned like the server prunes them
-  // after its enterprise hooks run.
+  // Empty sections (cfg/access without children) are pruned like the server
+  // prunes them after its enterprise hooks run.
   return pruneEmptyNavSections(staticTree);
 }
 
@@ -60,7 +63,14 @@ export function getInitialNavTree(): NavModelItem[] {
  * seeds the tree. The entries are defined in ./sections; this module only
  * composes them.
  */
-const STATIC_NAV_ENTRIES: NavEntryBuilder[] = [dashboardsNavEntry, profileNavEntry];
+const STATIC_NAV_ENTRIES: NavEntryBuilder[] = [
+  starredNavEntry,
+  dashboardsNavEntry,
+  profileNavEntry,
+  adminNavEntry,
+  helpNavEntry,
+  bookmarksNavEntry,
+];
 
 /**
  * Builds the static (non-plugin) portion of the nav tree, sorted, with urls

--- a/public/app/core/navtree/pageAccess.ts
+++ b/public/app/core/navtree/pageAccess.ts
@@ -12,3 +12,7 @@ export const dashboardVariablesAccess = () =>
   hasAny(AccessControlAction.DashboardsCreate, AccessControlAction.DashboardsWrite);
 export const snapshotsAccess = () => contextSrv.hasPermission(AccessControlAction.SnapshotsRead);
 export const playlistsAccess = () => contextSrv.hasPermission(AccessControlAction.PlaylistsRead);
+
+export const serviceAccountsAccess = () =>
+  hasAny(AccessControlAction.ServiceAccountsRead, AccessControlAction.ServiceAccountsCreate);
+export const migrateToCloudAccess = () => contextSrv.hasPermission(AccessControlAction.MigrationAssistantMigrate);

--- a/public/app/core/navtree/sections/admin.navEntry.ts
+++ b/public/app/core/navtree/sections/admin.navEntry.ts
@@ -1,0 +1,247 @@
+import { type NavModelItem } from '@grafana/data';
+import { GrafanaEdition } from '@grafana/data/internal';
+import { config } from '@grafana/runtime';
+import { contextSrv } from 'app/core/services/context_srv';
+import { AccessControlAction } from 'app/types/accessControl';
+
+import { NavID, NavWeight } from '../constants';
+import { migrateToCloudAccess, serviceAccountsAccess } from '../pageAccess';
+import { buildEntries, hasAny, isOrgAdmin, type NavEntryBuilder } from '../utils';
+
+const canManageOrgs = () =>
+  contextSrv.hasPermission(AccessControlAction.OrgsRead) && contextSrv.hasPermission(AccessControlAction.OrgsWrite);
+const canManageOrgPreferences = () =>
+  contextSrv.hasPermission(AccessControlAction.OrgsPreferencesRead) &&
+  contextSrv.hasPermission(AccessControlAction.OrgsPreferencesWrite);
+// Server admin is required on top of the org-scoped orgs:read the frontend
+// sees, because the item is global: a custom role granting only global
+// orgs:read passes on the server but not here (hidden, never leaked). The
+// scoped-permissions fetch will let us drop the server-admin approximation.
+const canViewGlobalOrgs = () => contextSrv.isGrafanaAdmin && contextSrv.hasPermission(AccessControlAction.OrgsRead);
+
+const ADMIN_GENERAL_CHILDREN: NavEntryBuilder[] = [
+  {
+    // The edition gate mirrors the wire-level substitution: enterprise binaries
+    // replace the OSS licensing service, so this OSS-only item is hidden there
+    // and enterprise registers its own licensing item via the registry.
+    when: () => contextSrv.isGrafanaAdmin && config.buildInfo.edition === GrafanaEdition.OpenSource,
+    build: () => ({
+      text: 'Stats and license',
+      id: 'upgrading',
+      url: '/admin/upgrading',
+      icon: 'unlock',
+      sortWeight: -1,
+    }),
+  },
+  {
+    when: () => canManageOrgs() || canManageOrgPreferences(),
+    build: () => ({
+      text: 'Default preferences',
+      id: 'org-settings',
+      subTitle: 'Manage preferences across an organization',
+      icon: 'sliders-v-alt',
+      url: '/org',
+    }),
+  },
+  {
+    // The bootdata permissions map collapses every settings:read scope into one
+    // boolean, so an OAuth/SAML-scoped grant passes here even though the page
+    // requires settings:*. Accepted for now: the scoped-permissions fetch (the
+    // same one the plugin-access work introduces) will let this require the
+    // full scope, matching the server nav and API.
+    when: () => contextSrv.hasPermission(AccessControlAction.SettingsRead),
+    build: () => ({
+      text: 'Settings',
+      subTitle: 'View the settings defined in your Grafana config',
+      id: 'server-settings',
+      url: '/admin/settings',
+      icon: 'sliders-v-alt',
+    }),
+  },
+  {
+    when: canViewGlobalOrgs,
+    build: () => ({
+      text: 'Organizations',
+      subTitle: 'Isolated instances of Grafana running on the same server',
+      id: 'global-orgs',
+      url: '/admin/orgs',
+      icon: 'building',
+    }),
+  },
+  {
+    when: () => Boolean(config.cloudMigrationEnabled) && migrateToCloudAccess(),
+    build: () => ({
+      text: 'Migrate to Grafana Cloud',
+      id: 'migrate-to-cloud',
+      subTitle: 'Copy resources from your self-managed installation to a cloud stack',
+      url: '/admin/migrate-to-cloud',
+    }),
+  },
+  {
+    when: () => (isOrgAdmin() || contextSrv.isGrafanaAdmin) && config.provisioningEnabled,
+    build: () => ({
+      text: 'Provisioning',
+      id: 'provisioning',
+      subTitle: 'View and manage your provisioning connections',
+      url: '/admin/provisioning',
+      keywords: ['git sync', 'git-sync', 'repository', 'version control', 'as code'],
+    }),
+  },
+];
+
+const ADMIN_PLUGINS_CHILDREN: NavEntryBuilder[] = [
+  {
+    when: () =>
+      isOrgAdmin() ||
+      (config.pluginAdminEnabled && contextSrv.isGrafanaAdmin) ||
+      hasAny(AccessControlAction.PluginsWrite, AccessControlAction.PluginsInstall),
+    build: () => ({
+      text: 'Plugins',
+      id: 'plugins',
+      subTitle: 'Extend the Grafana experience with plugins',
+      icon: 'plug',
+      url: '/plugins',
+    }),
+  },
+  {
+    when: () => contextSrv.hasPermission(AccessControlAction.DataSourcesExplore),
+    build: () => ({
+      text: 'Correlations',
+      icon: 'gf-glue',
+      subTitle: 'Add and configure correlations',
+      id: 'correlations',
+      url: '/datasources/correlations',
+    }),
+  },
+  {
+    when: () =>
+      config.buildInfo.env === 'development' ||
+      (Boolean(config.featureToggles.enableExtensionsAdminPage) &&
+        hasAny(AccessControlAction.PluginsWrite, AccessControlAction.PluginsInstall)),
+    build: () => ({
+      text: 'Extensions',
+      icon: 'plug',
+      subTitle: 'Extend the UI of plugins and Grafana',
+      id: 'extensions',
+      url: '/admin/extensions',
+    }),
+  },
+];
+
+const canCreateTeams = () => contextSrv.hasPermission(AccessControlAction.ActionTeamsCreate);
+const canManageTeams = () =>
+  contextSrv.hasPermission(AccessControlAction.ActionTeamsRead) &&
+  hasAny(
+    AccessControlAction.ActionTeamsWrite,
+    AccessControlAction.ActionTeamsPermissionsWrite,
+    AccessControlAction.ActionTeamsPermissionsRead
+  );
+
+const ADMIN_ACCESS_CHILDREN: NavEntryBuilder[] = [
+  {
+    when: () => hasAny(AccessControlAction.OrgUsersRead, AccessControlAction.UsersRead),
+    build: () => ({
+      text: 'Users',
+      subTitle: 'Manage users in Grafana',
+      id: 'global-users',
+      url: '/admin/users',
+      icon: 'user',
+    }),
+  },
+  {
+    when: () => canCreateTeams() || canManageTeams(),
+    build: () => ({
+      text: 'Teams',
+      id: 'teams',
+      subTitle: 'Groups of users that have common dashboard and permission needs',
+      icon: 'users-alt',
+      url: '/org/teams',
+    }),
+  },
+  {
+    when: serviceAccountsAccess,
+    build: () => ({
+      text: 'Service accounts',
+      id: 'serviceaccounts',
+      subTitle: 'Use service accounts to run automated workloads in Grafana',
+      icon: 'gf-service-account',
+      url: '/org/serviceaccounts',
+    }),
+  },
+];
+
+// The backend evaluates these with settings scopes (SAML/OAuth providers)
+// which the frontend permissions map cannot express; the unscoped actions are
+// the closest approximation.
+const authSettingsAccess = () => {
+  const samlLicensed = Boolean(config.licenseInfo?.enabledFeatures?.saml);
+  const authConfigUIAvailable = samlLicensed || config.ldapEnabled;
+  const canEditAuthSettings =
+    contextSrv.hasPermission(AccessControlAction.SettingsRead) &&
+    contextSrv.hasPermission(AccessControlAction.SettingsWrite);
+  const canReadLDAPStatus = contextSrv.hasPermission(AccessControlAction.LDAPStatusRead);
+  const canManageSSOSettings = hasAny(AccessControlAction.SettingsRead, AccessControlAction.SettingsWrite);
+
+  return (authConfigUIAvailable && (canEditAuthSettings || canReadLDAPStatus)) || canManageSSOSettings;
+};
+
+const ADMIN_CONFIG_NODES: NavEntryBuilder[] = [
+  {
+    // Always present (even when empty) so enterprise items (e.g. banner
+    // settings) can be registered into it; pruned late when nothing attached
+    build: () => ({
+      text: 'General',
+      subTitle: 'Manage default preferences and settings across Grafana',
+      id: NavID.cfgGeneral,
+      url: '/admin/general',
+      icon: 'shield',
+      children: buildEntries(ADMIN_GENERAL_CHILDREN),
+    }),
+  },
+  {
+    // Always present (even when empty) so enterprise items (e.g. recorded
+    // queries) can be registered into it; pruned late when nothing attached
+    build: () => ({
+      text: 'Plugins and data',
+      subTitle: 'Install plugins and define the relationships between data',
+      id: NavID.cfgPlugins,
+      url: '/admin/plugins',
+      icon: 'shield',
+      children: buildEntries(ADMIN_PLUGINS_CHILDREN),
+    }),
+  },
+  {
+    // Always present (even when empty) so grafana-auth-app can inject into it
+    build: () => ({
+      text: 'Users and access',
+      subTitle: 'Configure access for individual users, teams, and service accounts',
+      id: NavID.cfgAccess,
+      url: '/admin/access',
+      icon: 'shield',
+      children: buildEntries(ADMIN_ACCESS_CHILDREN),
+    }),
+  },
+  {
+    when: authSettingsAccess,
+    build: () => ({
+      text: 'Authentication',
+      id: 'authentication',
+      subTitle: 'Manage your auth settings and configure single sign-on',
+      icon: 'signin',
+      isSection: true,
+      url: '/admin/authentication',
+    }),
+  },
+];
+
+export const adminNavEntry: NavEntryBuilder = {
+  build: (): NavModelItem => ({
+    id: NavID.cfg,
+    text: 'Administration',
+    subTitle: `Organization: ${contextSrv.user.orgName}`,
+    icon: 'cog',
+    sortWeight: NavWeight.config,
+    children: buildEntries(ADMIN_CONFIG_NODES),
+    url: '/admin',
+  }),
+};

--- a/public/app/core/navtree/sections/admin.navEntry.ts
+++ b/public/app/core/navtree/sections/admin.navEntry.ts
@@ -6,7 +6,7 @@ import { AccessControlAction } from 'app/types/accessControl';
 
 import { NavID, NavWeight } from '../constants';
 import { migrateToCloudAccess, serviceAccountsAccess } from '../pageAccess';
-import { buildEntries, hasAny, isOrgAdmin, type NavEntryBuilder } from '../utils';
+import { buildEntries, hasAny, type NavEntryBuilder } from '../utils';
 
 const canManageOrgs = () =>
   contextSrv.hasPermission(AccessControlAction.OrgsRead) && contextSrv.hasPermission(AccessControlAction.OrgsWrite);
@@ -78,7 +78,7 @@ const ADMIN_GENERAL_CHILDREN: NavEntryBuilder[] = [
     }),
   },
   {
-    when: () => (isOrgAdmin() || contextSrv.isGrafanaAdmin) && config.provisioningEnabled,
+    when: () => (contextSrv.hasRole('Admin') || contextSrv.isGrafanaAdmin) && config.provisioningEnabled,
     build: () => ({
       text: 'Provisioning',
       id: 'provisioning',
@@ -92,7 +92,7 @@ const ADMIN_GENERAL_CHILDREN: NavEntryBuilder[] = [
 const ADMIN_PLUGINS_CHILDREN: NavEntryBuilder[] = [
   {
     when: () =>
-      isOrgAdmin() ||
+      contextSrv.hasRole('Admin') ||
       (config.pluginAdminEnabled && contextSrv.isGrafanaAdmin) ||
       hasAny(AccessControlAction.PluginsWrite, AccessControlAction.PluginsInstall),
     build: () => ({

--- a/public/app/core/navtree/sections/help.navEntry.ts
+++ b/public/app/core/navtree/sections/help.navEntry.ts
@@ -1,0 +1,32 @@
+import { config } from '@grafana/runtime';
+import { AccessControlAction } from 'app/types/accessControl';
+
+import { NavID, NavWeight } from '../constants';
+import { buildEntries, hasAny, type NavEntryBuilder } from '../utils';
+
+const HELP_CHILDREN: NavEntryBuilder[] = [
+  {
+    when: () =>
+      config.supportBundlesEnabled &&
+      hasAny(AccessControlAction.ActionSupportBundlesRead, AccessControlAction.ActionSupportBundlesCreate),
+    build: () => ({
+      text: 'Support bundles',
+      id: 'support-bundles',
+      url: '/support-bundles',
+      icon: 'wrench',
+      sortWeight: NavWeight.help,
+    }),
+  },
+];
+
+export const helpNavEntry: NavEntryBuilder = {
+  when: () => config.helpEnabled,
+  build: () => ({
+    text: 'Help',
+    id: NavID.help,
+    url: '#',
+    icon: 'question-circle',
+    sortWeight: NavWeight.help,
+    children: buildEntries(HELP_CHILDREN),
+  }),
+};

--- a/public/app/core/navtree/sections/help.navEntry.ts
+++ b/public/app/core/navtree/sections/help.navEntry.ts
@@ -19,6 +19,13 @@ const HELP_CHILDREN: NavEntryBuilder[] = [
   },
 ];
 
+// hideFromTabs is deliberately not set here, even though the server-built tree
+// sets it when an interactive learning plugin is installed (and the top bar
+// keys off it to open interactive learning instead of the Help dropdown).
+// Whether those plugins are installed is async plugin data, so it cannot be
+// resolved in this synchronous static build; the plugin nav phase applies it as
+// a PLUGIN_NAV_OVERRIDES entry once the installed app set is known. Until that
+// phase is enabled the Help button falls back to the dropdown.
 export const helpNavEntry: NavEntryBuilder = {
   when: () => config.helpEnabled,
   build: () => ({

--- a/public/app/core/navtree/sections/savedItems.navEntry.ts
+++ b/public/app/core/navtree/sections/savedItems.navEntry.ts
@@ -1,0 +1,35 @@
+import { contextSrv } from 'app/core/services/context_srv';
+import { AccessControlAction } from 'app/types/accessControl';
+
+import { NavID, NavWeight } from '../constants';
+import { isSignedIn, type NavEntryBuilder } from '../utils';
+
+// Both are empty containers filled at runtime (starred dashboards by
+// useSyncStarredItemsInNav, bookmarks from preferences), same as with the
+// server-built tree.
+
+export const starredNavEntry: NavEntryBuilder = {
+  when: () => contextSrv.hasPermission(AccessControlAction.DashboardsRead),
+  build: () => ({
+    text: 'Starred',
+    id: NavID.starred,
+    icon: 'star',
+    sortWeight: NavWeight.savedItems,
+    children: [],
+    emptyMessageId: 'starred-empty',
+    url: '/dashboards?starred',
+  }),
+};
+
+export const bookmarksNavEntry: NavEntryBuilder = {
+  when: isSignedIn,
+  build: () => ({
+    text: 'Bookmarks',
+    id: NavID.bookmarks,
+    icon: 'bookmark',
+    sortWeight: NavWeight.bookmarks,
+    children: [],
+    emptyMessageId: 'bookmarks-empty',
+    url: '/bookmarks',
+  }),
+};

--- a/public/app/core/navtree/utils.ts
+++ b/public/app/core/navtree/utils.ts
@@ -7,7 +7,6 @@ import { NavID, type NavId } from './constants';
 export const hasAny = (...actions: string[]) => userHasAnyPermission(actions, contextSrv.user);
 export const isSignedIn = () => contextSrv.isSignedIn;
 export const anonymousOrSignedIn = () => isSignedIn() || config.anonymousEnabled;
-export const isOrgAdmin = () => contextSrv.user.orgRole === 'Admin';
 
 export interface NavEntryBuilder {
   /** Whether this item is visible at all (permission/config/sign-in gates); absent means always visible */

--- a/public/app/core/navtree/utils.ts
+++ b/public/app/core/navtree/utils.ts
@@ -7,6 +7,7 @@ import { NavID, type NavId } from './constants';
 export const hasAny = (...actions: string[]) => userHasAnyPermission(actions, contextSrv.user);
 export const isSignedIn = () => contextSrv.isSignedIn;
 export const anonymousOrSignedIn = () => isSignedIn() || config.anonymousEnabled;
+export const isOrgAdmin = () => contextSrv.user.orgRole === 'Admin';
 
 export interface NavEntryBuilder {
   /** Whether this item is visible at all (permission/config/sign-in gates); absent means always visible */


### PR DESCRIPTION
## What

Adds the **help**, **saved items** (starred + bookmarks) and **admin** sections to the client-built static nav tree.

## Why

Continues the client-built nav tree behind `grafana.multiTenantNavTree`, so the frontend service no longer depends on the server-built tree for these sections.

This PR was originally "add the remaining static nav sections" — all seven at once. It has been split so each area's owners review their own section. The rest stack on top of this one:

- alerting → #131647
- connections → #131648
- explore + drilldown → #131649
- notebooks → #131650

## Who is this for

Anyone running the multi-tenant frontend service. No behaviour change with the flag off.
