### PR TITLE
Navigation: Add the nav entry registry for enterprise-contributed items

### DIFF
--- a/public/app/core/navtree/buildStaticNavTree.test.ts
+++ b/public/app/core/navtree/buildStaticNavTree.test.ts
@@ -5,6 +5,7 @@ import { AccessControlAction } from 'app/types/accessControl';
 
 import { buildStaticNavTree } from './buildStaticNavTree';
 import { NavID } from './constants';
+import { addNavEntries, clearRegisteredNavEntries } from './registry';
 import { navIds as ids, setupNavTestState as setup } from './test-utils';
 import { applyAppSubUrl, findNavById as findById, pruneEmptyNavSections, sortNavTree } from './utils';
 
@@ -452,5 +453,55 @@ describe('sortNavTree', () => {
 
     expect(ids(sorted)).toEqual(['a', 'b', 'c', 'd']);
     expect(ids(nodes)).toEqual(['c', 'a', 'd', 'b']);
+  });
+});
+
+describe('registered nav entries', () => {
+  afterEach(() => {
+    clearRegisteredNavEntries();
+  });
+
+  it('appends registered items into their parent section', () => {
+    setup({ orgRole: 'Admin', permissions: [AccessControlAction.OrgUsersRead] });
+    addNavEntries({
+      parentId: NavID.cfgGeneral,
+      entry: { build: () => ({ text: 'Announcement banner', id: 'banner-settings' }) },
+    });
+
+    const general = findById(buildStaticNavTree(), NavID.cfgGeneral);
+    expect(ids(general?.children ?? [])).toContain('banner-settings');
+  });
+
+  it('appends root-level entries to the top of the tree', () => {
+    setup();
+    addNavEntries({
+      parentId: NavID.root,
+      entry: { build: () => ({ text: 'Enterprise thing', id: 'enterprise-thing', sortWeight: 1 }) },
+    });
+
+    expect(ids(buildStaticNavTree())).toContain('enterprise-thing');
+  });
+
+  it('respects the entry gate', () => {
+    setup({ orgRole: 'Admin' });
+    addNavEntries({
+      parentId: NavID.cfgGeneral,
+      entry: { when: () => false, build: () => ({ text: 'Hidden', id: 'hidden-entry' }) },
+    });
+
+    expect(findById(buildStaticNavTree(), 'hidden-entry')).toBeUndefined();
+  });
+
+  it('warns and skips entries whose parent does not exist', () => {
+    setup();
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    addNavEntries({
+      parentId: 'no-such-section',
+      entry: { build: () => ({ text: 'Orphan', id: 'orphan-entry' }) },
+    });
+
+    expect(findById(buildStaticNavTree(), 'orphan-entry')).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith('[navtree] registered nav entry parent not found', 'no-such-section');
+    warn.mockRestore();
   });
 });

--- a/public/app/core/navtree/buildStaticNavTree.ts
+++ b/public/app/core/navtree/buildStaticNavTree.ts
@@ -5,6 +5,8 @@ import { config } from '@grafana/runtime';
 import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 import { alertingNavEntry } from 'app/features/alerting/unified/navigation/alerting.navEntry';
 
+import { NavID } from './constants';
+import { getRegisteredNavEntries } from './registry';
 import { adminNavEntry } from './sections/admin.navEntry';
 import { connectionsNavEntry } from './sections/connections.navEntry';
 import { dashboardsNavEntry } from './sections/dashboards.navEntry';
@@ -14,7 +16,15 @@ import { getHomeNode } from './sections/home.navEntry';
 import { notebooksNavEntry } from './sections/notebooks.navEntry';
 import { profileNavEntry } from './sections/profile.navEntry';
 import { bookmarksNavEntry, starredNavEntry } from './sections/savedItems.navEntry';
-import { applyAppSubUrl, buildEntries, type NavEntryBuilder, pruneEmptyNavSections, sortNavTree } from './utils';
+import {
+  applyAppSubUrl,
+  buildEntries,
+  findNavById,
+  type NavEntryBuilder,
+  pruneEmptyNavSections,
+  sortNavTree,
+  updateNavById,
+} from './utils';
 
 /**
  * Whether to build the nav tree client-side. Gated on grafana.multiTenantNavTree
@@ -84,8 +94,31 @@ const STATIC_NAV_ENTRIES: NavEntryBuilder[] = [
 /**
  * Builds the static (non-plugin) portion of the nav tree, sorted, with urls
  * app-sub-url relative: callers apply the prefix once via applyAppSubUrl at
- * the end of their pipeline.
+ * the end of their pipeline. Nav items registered via addNavEntries (e.g. by
+ * the enterprise bundle) are appended into their target sections.
  */
 export function buildStaticNavTree(): NavModelItem[] {
-  return sortNavTree([getHomeNode(), ...buildEntries(STATIC_NAV_ENTRIES)]);
+  const tree = [getHomeNode(), ...buildEntries(STATIC_NAV_ENTRIES)];
+  return sortNavTree(applyRegisteredNavEntries(tree));
+}
+
+/** Appends registered extension items into their parent sections. Returns a new tree. */
+function applyRegisteredNavEntries(tree: NavModelItem[]): NavModelItem[] {
+  return getRegisteredNavEntries().reduce((current, { parentId, entry }) => {
+    const built = buildEntries([entry]);
+    if (built.length === 0) {
+      return current;
+    }
+    if (parentId === NavID.root) {
+      return [...current, ...built];
+    }
+    if (!findNavById(current, parentId)) {
+      console.warn('[navtree] registered nav entry parent not found', parentId);
+      return current;
+    }
+    return updateNavById(current, parentId, (parent) => ({
+      ...parent,
+      children: [...(parent.children ?? []), ...built],
+    }));
+  }, tree);
 }

--- a/public/app/core/navtree/registry.ts
+++ b/public/app/core/navtree/registry.ts
@@ -1,0 +1,33 @@
+import { type NavEntryBuilder } from './utils';
+
+/** A nav item contributed from outside the static tree (e.g. the enterprise bundle) */
+export interface NavEntryExtension {
+  /** NavID of the section or subsection to append into, or 'root' for a top-level entry */
+  parentId: string;
+  entry: NavEntryBuilder;
+}
+
+const registeredNavEntries: NavEntryExtension[] = [];
+
+/**
+ * Registers nav items to be appended into the client-built static tree,
+ * following the addPageBanner pattern: a module-level registry the enterprise
+ * bundle fills at startup. Must be called before the redux store is created
+ * (the tree is first built inside configureStore), i.e. from module scope or
+ * addExtensionReducers — not from the extensions init() hook, which runs
+ * after.
+ */
+export function addNavEntries(...extensions: NavEntryExtension[]): void {
+  registeredNavEntries.push(...extensions);
+}
+
+export function getRegisteredNavEntries(): readonly NavEntryExtension[] {
+  return registeredNavEntries;
+}
+
+export function clearRegisteredNavEntries(): void {
+  if (process.env.NODE_ENV !== 'test') {
+    throw new Error('clearRegisteredNavEntries() can only be called from tests.');
+  }
+  registeredNavEntries.length = 0;
+}

--- a/public/app/core/navtree/utils.ts
+++ b/public/app/core/navtree/utils.ts
@@ -45,6 +45,20 @@ export function findNavById(nodes: NavModelItem[], id: string): NavModelItem | u
   return undefined;
 }
 
+/** Returns a new tree with the matching node (at any depth) replaced by update(node) */
+export function updateNavById(
+  nodes: NavModelItem[],
+  id: string,
+  update: (node: NavModelItem) => NavModelItem
+): NavModelItem[] {
+  return nodes.map((node) => {
+    if (node.id === id) {
+      return update(node);
+    }
+    return node.children ? { ...node, children: updateNavById(node.children, id, update) } : node;
+  });
+}
+
 /**
  * Prefixes every absolute url in the tree with the app sub url, so individual
  * items are declared sub-url agnostic. Anchor-only and relative urls (Help's

--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -255,6 +255,8 @@ export function getNavSubTitle(navId: string | undefined) {
       return t('nav.recently-deleted.subtitle', 'Deleted dashboards are kept for up to 12 months.');
     case 'saved-queries':
       return t('nav.saved-queries.subtitle', 'Reusable queries across Grafana');
+    case 'reports':
+      return t('nav.reporting.subtitle', 'Create and manage PDF reports distributed via e-mail');
     case 'banner-settings':
       return t('nav.banner-settings.subtitle', 'Show important updates and information at the top of every page');
     case 'secrets-management':

--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -116,6 +116,10 @@ export function getNavTitle(navId: string | undefined) {
       return t('nav.authentication.title', 'Authentication');
     case 'licensing':
       return t('nav.statistics-and-licensing.title', 'Statistics and licensing');
+    case 'banner-settings':
+      return t('nav.banner-settings.title', 'Announcement banner');
+    case 'secrets-management':
+      return t('nav.secrets-management.title', 'Secrets Management');
     case 'recordedQueries':
       return t('nav.recorded-queries.title', 'Recorded queries');
     case 'correlations':
@@ -251,6 +255,10 @@ export function getNavSubTitle(navId: string | undefined) {
       return t('nav.recently-deleted.subtitle', 'Deleted dashboards are kept for up to 12 months.');
     case 'saved-queries':
       return t('nav.saved-queries.subtitle', 'Reusable queries across Grafana');
+    case 'banner-settings':
+      return t('nav.banner-settings.subtitle', 'Show important updates and information at the top of every page');
+    case 'secrets-management':
+      return t('nav.secrets-management.subtitle', 'Manage secrets for your Grafana instance');
     case 'alerting':
       return t('nav.alerting.subtitle', 'Learn about problems in your systems moments after they occur');
     case 'alerting-upgrade':

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12535,6 +12535,10 @@
     "authentication": {
       "title": "Authentication"
     },
+    "banner-settings": {
+      "subtitle": "Show important updates and information at the top of every page",
+      "title": "Announcement banner"
+    },
     "bookmarks": {
       "title": "Bookmarks"
     },
@@ -12755,6 +12759,10 @@
     },
     "search-dashboards": {
       "title": "Search dashboards"
+    },
+    "secrets-management": {
+      "subtitle": "Manage secrets for your Grafana instance",
+      "title": "Secrets Management"
     },
     "server-settings": {
       "subtitle": "View the settings defined in your Grafana config",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12745,6 +12745,7 @@
       "title": "Recorded queries"
     },
     "reporting": {
+      "subtitle": "Create and manage PDF reports distributed via e-mail",
       "title": "Reporting"
     },
     "saved-queries": {


### PR DESCRIPTION
## What

Adds the **nav entry registry**, so nav items owned outside core — today the enterprise bundle — can contribute entries into the client-built tree before the redux store is created.

- `registry.ts` — `addNavEntries` / `getRegisteredNavEntries`, a module-level registry following the `addPageBanner` pattern, plus a test-only `clearRegisteredNavEntries`.
- `buildStaticNavTree` applies them via `applyRegisteredNavEntries`: each extension names a `parentId` and is appended to that section's children, or to the top level with `parentId: 'root'`. Unknown parents warn and are skipped rather than dropping the item silently.
- `updateNavById` added to `utils.ts` — returns a new tree with one node (at any depth) replaced, so the registry doesn't mutate the static tree.
- Registered entries go through the same `when` gate as core entries, so an item whose permissions don't hold never appears.
- Translations for the enterprise-registered items: `banner-settings`, `secrets-management`, and a `reports` subtitle.

This replaces the transitional `bootData.navTree` graft earlier revisions used to pull enterprise admin items across. https://github.com/grafana/grafana-enterprise/pull/13206 fills the registry.

## Why

Enterprise nav items have no client-side source once `/bootdata` is gone, and core can't import enterprise code to get them. The registry gives them a seam in the right direction: enterprise depends on core, not the reverse.

Timing is the constraint worth knowing about — `configureStore` builds the tree, so registration has to happen before that: module scope or `addExtensionReducers`, **not** the extensions `init()` hook, which runs later. The docblock on `addNavEntries` says so.

## Who is this for

Multi-tenant Grafana, and enterprise deployments once the companion PR lands. No behaviour change with `grafana.multiTenantNavTree` off — nothing calls `addNavEntries` in OSS.

Part of #130057. #130072 (plugin nav from the metas API) stacks on this one.
