### PR TITLE
Browse dashboards: remove recently viewed feature toggles

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -951,16 +951,6 @@ export interface FeatureToggles {
   */
   kubernetesAuthzServiceAccountResourcePermissions?: boolean;
   /**
-  * Enables recently viewed dashboards section in the browsing dashboard page
-  * @default false
-  */
-  recentlyViewedDashboards?: boolean;
-  /**
-  * A/A test for recently viewed dashboards feature
-  * @default false
-  */
-  experimentRecentlyViewedDashboards?: boolean;
-  /**
   * Enable configuration of alert enrichments in Grafana Cloud.
   * @default false
   */

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
@@ -38,8 +38,6 @@ declare module "@openfeature/core" {
     | "alerting.manualAssistantInvestigation"
     | "alerting.ruleQuality"
     | "datasources.azureMonitorBatchAPI"
-    | "recentlyViewedDashboards"
-    | "experimentRecentlyViewedDashboards"
     | "otelLogsFormatting"
     | "grafana.starredFolders"
     | "grafana.newTextPanel"

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -47,8 +47,6 @@ export const FlagKeys = {
   DatasourcesApiServerEnableHealthEndpointFrontend: "datasourcesApiServerEnableHealthEndpointFrontend",
   /** Enables additional experimental color schemes for visualizations. */
   DatavizExperimentalColorSchemes: "dataviz.experimentalColorSchemes",
-  /** A/A test for recently viewed dashboards feature */
-  ExperimentRecentlyViewedDashboards: "experimentRecentlyViewedDashboards",
   /** Enable Faro session replay for Grafana */
   FaroSessionReplay: "faroSessionReplay",
   /** Enables the feedback button in the dashboard edit sidebar */
@@ -153,8 +151,6 @@ export const FlagKeys = {
   QueryHistoryRecentQueriesUI: "queryHistory.recentQueriesUI",
   /** Renders the raw Prometheus query results table using TableNG instead of the legacy Table */
   RawPrometheusTableNg: "rawPrometheus.tableNg",
-  /** Enables recently viewed dashboards section in the browsing dashboard page */
-  RecentlyViewedDashboards: "recentlyViewedDashboards",
   /** Enables reporting for any page in Grafana */
   ReportingAnyPageReporting: "reporting.anyPageReporting",
   /** Routes snapshot requests from /api to the /apis endpoint */
@@ -366,17 +362,6 @@ export const useFlagDatasourcesApiServerEnableHealthEndpointFrontend = (options?
  */
 export const useFlagDatavizExperimentalColorSchemes = (options?: ReactFlagEvaluationOptions): boolean => {
   return useFlag("dataviz.experimentalColorSchemes", false, options).value;
-};
-
-/**
- * A/A test for recently viewed dashboards feature
- *
- * **Details:**
- * - flag key: `experimentRecentlyViewedDashboards`
- * - default value: `false`
- */
-export const useFlagExperimentRecentlyViewedDashboards = (options?: ReactFlagEvaluationOptions): boolean => {
-  return useFlag("experimentRecentlyViewedDashboards", false, options).value;
 };
 
 /**
@@ -949,17 +934,6 @@ export const useFlagQueryHistoryRecentQueriesUI = (options?: ReactFlagEvaluation
  */
 export const useFlagRawPrometheusTableNg = (options?: ReactFlagEvaluationOptions): boolean => {
   return useFlag("rawPrometheus.tableNg", false, options).value;
-};
-
-/**
- * Enables recently viewed dashboards section in the browsing dashboard page
- *
- * **Details:**
- * - flag key: `recentlyViewedDashboards`
- * - default value: `false`
- */
-export const useFlagRecentlyViewedDashboards = (options?: ReactFlagEvaluationOptions): boolean => {
-  return useFlag("recentlyViewedDashboards", false, options).value;
 };
 
 /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1830,23 +1830,6 @@ var (
 			Generate:     Generate{LegacyGo: true, LegacyFrontend: true},
 		},
 		{
-			Name:        "recentlyViewedDashboards",
-			Description: "Enables recently viewed dashboards section in the browsing dashboard page",
-			Stage:       FeatureStageExperimental,
-			Owner:       grafanaFrontendNavigation,
-			Generate:    Generate{LegacyFrontend: true, React: true}, // legacy frontend for old naming convention
-			Expression:  "false",
-		},
-		{
-			Name:         "experimentRecentlyViewedDashboards",
-			Description:  "A/A test for recently viewed dashboards feature",
-			Stage:        FeatureStageExperimental,
-			Owner:        grafanaFrontendNavigation,
-			Generate:     Generate{LegacyFrontend: true, React: true},
-			HideFromDocs: true,
-			Expression:   "false",
-		},
-		{
 			Name:         "alertEnrichment",
 			Description:  "Enable configuration of alert enrichments in Grafana Cloud.",
 			Stage:        FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -212,8 +212,6 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-05-22,kubernetesAuthzRolesAndRoleBindingsRedirect,experimental,@grafana/identity-access-team,false,false,false
 2026-05-22,kubernetesAuthzDatasourceResourcePermissions,experimental,@grafana/identity-access-team,false,false,false
 2026-05-22,kubernetesAuthzServiceAccountResourcePermissions,experimental,@grafana/identity-access-team,false,false,false
-2025-12-10,recentlyViewedDashboards,experimental,@grafana/grafana-frontend-navigation,false,false,true
-2026-01-13,experimentRecentlyViewedDashboards,experimental,@grafana/grafana-frontend-navigation,false,false,true
 2025-06-06,alertEnrichment,experimental,@grafana/alerting-squad,false,false,false
 2025-07-31,alertEnrichmentMultiStep,experimental,@grafana/alerting-squad,false,false,false
 2025-07-31,alertEnrichmentConditional,experimental,@grafana/alerting-squad,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2450,7 +2450,8 @@
       "metadata": {
         "name": "experimentRecentlyViewedDashboards",
         "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-01-13T15:22:20Z"
+        "creationTimestamp": "2026-01-13T15:22:20Z",
+        "deletionTimestamp": "2026-08-18T16:59:52Z"
       },
       "spec": {
         "description": "A/A test for recently viewed dashboards feature",
@@ -5628,7 +5629,8 @@
       "metadata": {
         "name": "recentlyViewedDashboards",
         "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-12-10T16:28:19Z"
+        "creationTimestamp": "2025-12-10T16:28:19Z",
+        "deletionTimestamp": "2026-08-18T16:59:52Z"
       },
       "spec": {
         "description": "Enables recently viewed dashboards section in the browsing dashboard page",

--- a/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
+++ b/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/css';
-import { useBooleanFlagValue } from '@openfeature/react-sdk';
-import { memo, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useEffect, useMemo, useState } from 'react';
 import { useLocation, useParams } from 'react-router-dom-v5-compat';
 import AutoSizer, { type Size } from 'react-virtualized-auto-sizer';
 
@@ -52,10 +51,7 @@ const BrowseDashboardsPage = memo(({ queryParams }: { queryParams: Record<string
     orphanedRepoName,
     repository,
   } = useGetResourceRepositoryView({ folderName: folderUID });
-  const isRecentlyViewedEnabledValue = useBooleanFlagValue('recentlyViewedDashboards', false);
-  const isExperimentRecentlyViewedDashboards = useBooleanFlagValue('experimentRecentlyViewedDashboards', false);
   const { isAvailable: isTemplateDashboardsAvailable } = useTemplateDashboardsAvailability();
-  const isRecentlyViewedEnabled = !folderUID && isRecentlyViewedEnabledValue;
 
   // CUJ-only signal: silent so it doesn't create analytics noise
   useEffect(() => {
@@ -89,23 +85,6 @@ const BrowseDashboardsPage = memo(({ queryParams }: { queryParams: Record<string
       reportInteraction('grafana_empty_state_shown', { source: 'browse_dashboards' });
     }
   }, [isSearching, searchState.result, stateManager]);
-
-  // Emit exposure event for A/A test once when page loads
-  const hasEmittedExposureEvent = useRef(false);
-
-  useEffect(() => {
-    if (!isRecentlyViewedEnabled || hasEmittedExposureEvent.current) {
-      return;
-    }
-
-    hasEmittedExposureEvent.current = true;
-    const isExperimentTreatment = isExperimentRecentlyViewedDashboards;
-
-    reportInteraction('dashboards_browse_list_viewed', {
-      experiment_dashboard_list_recently_viewed: isExperimentTreatment ? 'treatment' : 'control',
-      has_recently_viewed_component: isExperimentTreatment,
-    });
-  }, [isRecentlyViewedEnabled, isExperimentRecentlyViewedDashboards]);
 
   const { data: folderDTO } = useGetFolderQueryFacade(folderUID);
   const navModel = useNavModel(folderDTO, 'dashboards');
@@ -181,8 +160,8 @@ const BrowseDashboardsPage = memo(({ queryParams }: { queryParams: Record<string
           <OrphanedResourceBanner repositoryName={orphanedRepoName} />
         )}
         <QuotaLimitBanner />
-        {/* only show recently viewed dashboards when in root and flag is enabled */}
-        {isRecentlyViewedEnabled && <RecentlyViewedDashboards />}
+        {/* only show recently viewed dashboards when in root */}
+        {!folderUID && <RecentlyViewedDashboards />}
         <div>
           <FilterInput
             data-testid={selectors.pages.BrowseDashboards.searchInput}


### PR DESCRIPTION
**What is this feature?**

- The "Recently viewed" section now shows for everyone on the top-level Dashboards page. It's no longer behind a feature toggle.
- Removed the tracking event that was only there for the A/A test.
- Deleted both feature toggles and regenerated the toggle files.

**Why?**

The experiment is done and the feature is ready for everyone, so the flags are just dead weight.


**Which issue(s) does this PR fix?**:

Fixes n/a

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
