### PR TITLE
Alerting: Cleanup promote staged config code

### DIFF
--- a/public/app/features/alerting/unified/components/import-to-gma/ImportToGMA.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ImportToGMA.tsx
@@ -405,6 +405,9 @@ function ImportWizardContent() {
         skipSubPath: true,
       });
 
+      // Hold the "Import Successful" state on screen for a beat before closing the modal and
+      // redirecting — Modal has no close animation, so this is what makes the confirmation visible
+      // rather than instantly disappearing.
       setTimeout(() => {
         setShowConfirmModal(false);
         // A staged notifications import lands on the Import tab so the user can review the staged

--- a/public/app/features/alerting/unified/components/import-to-gma/ImportToGMA.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ImportToGMA.tsx
@@ -405,9 +405,8 @@ function ImportWizardContent() {
         skipSubPath: true,
       });
 
-      // Hold the "Import Successful" state on screen for a beat before closing the modal and
-      // redirecting — Modal has no close animation, so this is what makes the confirmation visible
-      // rather than instantly disappearing.
+      // Holds the "Import Successful" state on screen for a beat — Modal has no close animation,
+      // so without this delay the confirmation would disappear instantly instead of being seen.
       setTimeout(() => {
         setShowConfirmModal(false);
         // A staged notifications import lands on the Import tab so the user can review the staged

--- a/public/app/features/alerting/unified/settings/import/PromoteConfirmModal.test.tsx
+++ b/public/app/features/alerting/unified/settings/import/PromoteConfirmModal.test.tsx
@@ -8,7 +8,7 @@ import { appEvents } from 'app/core/app_events';
 import { setupMswServer } from '../../mockApi';
 import { type AdminConfigPostState, setupAdminConfigPost } from '../../mocks/server/configure/admin_config';
 
-import { PromoteConfirmModal } from './PromoteConfirmModal';
+import { PromoteConfirmModal, getPreviewState } from './PromoteConfirmModal';
 
 const server = setupMswServer();
 
@@ -49,6 +49,46 @@ function fullDryRunResponse() {
     },
   });
 }
+
+describe('getPreviewState', () => {
+  const validResult = { valid: true, renamedReceivers: [], renamedTimeIntervals: [] };
+  const invalidResult = { valid: false, error: 'nope', renamedReceivers: [], renamedTimeIntervals: [] };
+
+  it('reports loading while the dry-run is in flight, regardless of other fields', () => {
+    expect(getPreviewState({ isLoading: true, isPreviewUnavailable: false })).toEqual({ kind: 'loading' });
+  });
+
+  it('reports unavailable for a dry-run error caused by a sync/permission gate', () => {
+    expect(getPreviewState({ isLoading: false, error: 'blocked', isPreviewUnavailable: true })).toEqual({
+      kind: 'unavailable',
+    });
+  });
+
+  it('reports error for a dry-run failure unrelated to the preview gates', () => {
+    expect(getPreviewState({ isLoading: false, error: 'server error', isPreviewUnavailable: false })).toEqual({
+      kind: 'error',
+      message: 'server error',
+    });
+  });
+
+  it('reports invalid with the backend error when the dry-run succeeds but the config is invalid', () => {
+    expect(getPreviewState({ isLoading: false, isPreviewUnavailable: false, result: invalidResult })).toEqual({
+      kind: 'invalid',
+      message: 'nope',
+    });
+  });
+
+  it('reports valid with the result when the dry-run succeeds and the config can be promoted', () => {
+    expect(getPreviewState({ isLoading: false, isPreviewUnavailable: false, result: validResult })).toEqual({
+      kind: 'valid',
+      result: validResult,
+    });
+  });
+
+  it('reports idle before the dry-run has settled (no error, no result, not loading)', () => {
+    expect(getPreviewState({ isLoading: false, isPreviewUnavailable: false })).toEqual({ kind: 'idle' });
+  });
+});
 
 describe('PromoteConfirmModal', () => {
   let appEventsEmitSpy: jest.SpyInstance;

--- a/public/app/features/alerting/unified/settings/import/PromoteConfirmModal.tsx
+++ b/public/app/features/alerting/unified/settings/import/PromoteConfirmModal.tsx
@@ -1,16 +1,11 @@
-import { generatedAPI as notificationsAPI } from '@grafana/api-clients/rtkq/notifications.alerting/v0alpha1';
 import { Trans, t } from '@grafana/i18n';
 import { Alert, ConfirmModal, Spinner, Stack, Text } from '@grafana/ui';
-import { useAppNotification } from 'app/core/copy/appNotification';
-import { useDispatch } from 'app/types/store';
 
-import { logError } from '../../Analytics';
-import { alertmanagerApi } from '../../api/alertmanagerApi';
-import { convertToGMAApi } from '../../api/convertToGMAApi';
-import { stringifyErrorLike } from '../../utils/misc';
+import { type DryRunValidationResult } from '../../components/import-to-gma/types';
 
 import { StagedPromotePreview } from './StagedPromotePreview';
 import { type StagedExtraConfig } from './stagedConfig';
+import { usePromoteStagedConfig } from './usePromoteStagedConfig';
 import { useStagedConfigDryRun } from './useStagedConfigDryRun';
 
 interface Props {
@@ -26,75 +21,12 @@ interface Props {
  * conflicts, then merges on confirm.
  */
 export function PromoteConfirmModal({ stagedConfig, isSyncManaged, onDismiss }: Props) {
-  const notifyApp = useAppNotification();
-  const dispatch = useDispatch();
   const { result, isLoading, error, isPreviewUnavailable } = useStagedConfigDryRun(stagedConfig);
-  const [promote, { isLoading: isPromoting }] = convertToGMAApi.usePromoteAlertmanagerConfigMutation();
-  const [updateAlertingConfiguration, { isLoading: isClearingAutoSync }] =
-    alertmanagerApi.endpoints.updateGrafanaAlertingConfiguration.useMutation();
+  const { onConfirm, isSubmitting } = usePromoteStagedConfig(stagedConfig, isSyncManaged, onDismiss);
 
-  const isSubmitting = isPromoting || isClearingAutoSync;
   // Enabled once the dry-run confirms the merge is valid, or the preview itself couldn't run for a
   // reason unrelated to whether the promote will succeed.
   const canPromote = !isLoading && !isSubmitting && (Boolean(result?.valid) || isPreviewUnavailable);
-
-  /**
-   * The sync worker stops on its own once it sees the merge committed, but the configured datasource
-   * UID stays on the org config — which keeps auto-sync reported as active and keeps the convert API
-   * rejecting notification imports. Clearing it is what actually ends the sync.
-   *
-   * Reports failure rather than throwing: it runs after an irreversible merge, so it must not be
-   * mistaken for a failed promote.
-   */
-  const clearAutoSync = async (): Promise<boolean> => {
-    try {
-      await updateAlertingConfiguration({
-        // Backend convention: empty string clears the configured UID.
-        external_alertmanager_uid: '',
-        notificationOptions: { showErrorAlert: false },
-      }).unwrap();
-      // The UID lives in a different RTKQ slice than the Config resource useIsAutoSyncActive reads,
-      // so tag invalidation doesn't cross over on its own.
-      dispatch(notificationsAPI.util.invalidateTags(['Config']));
-      return true;
-    } catch (err) {
-      logError(new Error(stringifyErrorLike(err)));
-      return false;
-    }
-  };
-
-  const onConfirm = async () => {
-    try {
-      await promote({ configIdentifier: stagedConfig.identifier }).unwrap();
-    } catch (err) {
-      logError(new Error(stringifyErrorLike(err)));
-      notifyApp.error(
-        t('alerting.settings.import.promote.error-title', 'Failed to promote configuration'),
-        stringifyErrorLike(err)
-      );
-      return;
-    }
-
-    // The merge has landed by this point, so nothing below may report the promote as failed.
-    if (isSyncManaged && !(await clearAutoSync())) {
-      notifyApp.warning(
-        t(
-          'alerting.settings.import.promote.sync-not-cleared-title',
-          'Configuration promoted, but auto-sync is still configured'
-        ),
-        t(
-          'alerting.settings.import.promote.sync-not-cleared-body',
-          'Nothing syncs from the datasource any more. Disable auto-sync in Alerting settings to import notification resources again — if it is set in grafana.ini, remove the key there.'
-        )
-      );
-    } else {
-      notifyApp.success(
-        t('alerting.settings.import.promote.success-title', 'Configuration promoted'),
-        t('alerting.settings.import.promote.success-body', 'The imported resources were merged into your live config.')
-      );
-    }
-    onDismiss();
-  };
 
   return (
     <ConfirmModal
@@ -128,56 +60,109 @@ export function PromoteConfirmModal({ stagedConfig, isSyncManaged, onDismiss }: 
             </Alert>
           )}
 
-          {isLoading && (
-            <Stack direction="row" gap={1} alignItems="center">
-              <Spinner size="sm" />
-              <Text color="secondary">
-                <Trans i18nKey="alerting.settings.import.promote.checking">Checking promotion impact…</Trans>
-              </Text>
-            </Stack>
-          )}
-
-          {!isLoading && error && isPreviewUnavailable && (
-            <Alert
-              severity="info"
-              title={t(
-                'alerting.settings.import.promote.dry-run-unavailable-title',
-                "Couldn't preview the promotion impact"
-              )}
-            >
-              <Trans i18nKey="alerting.settings.import.promote.dry-run-unavailable-body">
-                You can still promote — the merge itself is validated when you confirm.
-              </Trans>
-            </Alert>
-          )}
-
-          {!isLoading && error && !isPreviewUnavailable && (
-            <Alert
-              severity="error"
-              title={t('alerting.settings.import.promote.dry-run-error', "Couldn't check the promotion impact")}
-            >
-              {error}
-            </Alert>
-          )}
-
-          {!isLoading && !error && result && !result.valid && (
-            <Alert
-              severity="error"
-              title={t('alerting.settings.import.promote.invalid-title', "This configuration can't be promoted")}
-            >
-              {result.error}
-            </Alert>
-          )}
-
-          {!isLoading && !error && result?.valid && (
-            <StagedPromotePreview
-              stats={result.stats}
-              renamedReceivers={result.renamedReceivers}
-              renamedTimeIntervals={result.renamedTimeIntervals}
-            />
-          )}
+          <PromotePreviewBody
+            isLoading={isLoading}
+            error={error}
+            isPreviewUnavailable={isPreviewUnavailable}
+            result={result}
+          />
         </Stack>
       }
     />
   );
+}
+
+interface PromotePreviewBodyProps {
+  isLoading: boolean;
+  error?: string;
+  isPreviewUnavailable: boolean;
+  result?: DryRunValidationResult;
+}
+
+type PreviewState =
+  | { kind: 'loading' }
+  | { kind: 'unavailable' }
+  | { kind: 'error'; message: string }
+  | { kind: 'invalid'; message?: string }
+  | { kind: 'valid'; result: DryRunValidationResult }
+  | { kind: 'idle' };
+
+function getPreviewState({ isLoading, error, isPreviewUnavailable, result }: PromotePreviewBodyProps): PreviewState {
+  if (isLoading) {
+    return { kind: 'loading' };
+  }
+  if (error) {
+    return isPreviewUnavailable ? { kind: 'unavailable' } : { kind: 'error', message: error };
+  }
+  if (result && !result.valid) {
+    return { kind: 'invalid', message: result.error };
+  }
+  if (result?.valid) {
+    return { kind: 'valid', result };
+  }
+  return { kind: 'idle' };
+}
+
+/** Dry-run preview: a loading spinner, an unavailable/error/invalid banner, or the merge preview. */
+function PromotePreviewBody({ isLoading, error, isPreviewUnavailable, result }: PromotePreviewBodyProps) {
+  const state = getPreviewState({ isLoading, error, isPreviewUnavailable, result });
+
+  switch (state.kind) {
+    case 'loading':
+      return (
+        <Stack direction="row" gap={1} alignItems="center">
+          <Spinner size="sm" />
+          <Text color="secondary">
+            <Trans i18nKey="alerting.settings.import.promote.checking">Checking promotion impact…</Trans>
+          </Text>
+        </Stack>
+      );
+
+    case 'unavailable':
+      return (
+        <Alert
+          severity="info"
+          title={t(
+            'alerting.settings.import.promote.dry-run-unavailable-title',
+            "Couldn't preview the promotion impact"
+          )}
+        >
+          <Trans i18nKey="alerting.settings.import.promote.dry-run-unavailable-body">
+            You can still promote — the merge itself is validated when you confirm.
+          </Trans>
+        </Alert>
+      );
+
+    case 'error':
+      return (
+        <Alert
+          severity="error"
+          title={t('alerting.settings.import.promote.dry-run-error', "Couldn't check the promotion impact")}
+        >
+          {state.message}
+        </Alert>
+      );
+
+    case 'invalid':
+      return (
+        <Alert
+          severity="error"
+          title={t('alerting.settings.import.promote.invalid-title', "This configuration can't be promoted")}
+        >
+          {state.message}
+        </Alert>
+      );
+
+    case 'valid':
+      return (
+        <StagedPromotePreview
+          stats={state.result.stats}
+          renamedReceivers={state.result.renamedReceivers}
+          renamedTimeIntervals={state.result.renamedTimeIntervals}
+        />
+      );
+
+    case 'idle':
+      return null;
+  }
 }

--- a/public/app/features/alerting/unified/settings/import/PromoteConfirmModal.tsx
+++ b/public/app/features/alerting/unified/settings/import/PromoteConfirmModal.tsx
@@ -72,14 +72,14 @@ export function PromoteConfirmModal({ stagedConfig, isSyncManaged, onDismiss }: 
   );
 }
 
-interface PromotePreviewBodyProps {
+export interface PromotePreviewBodyProps {
   isLoading: boolean;
   error?: string;
   isPreviewUnavailable: boolean;
   result?: DryRunValidationResult;
 }
 
-type PreviewState =
+export type PreviewState =
   | { kind: 'loading' }
   | { kind: 'unavailable' }
   | { kind: 'error'; message: string }
@@ -87,7 +87,12 @@ type PreviewState =
   | { kind: 'valid'; result: DryRunValidationResult }
   | { kind: 'idle' };
 
-function getPreviewState({ isLoading, error, isPreviewUnavailable, result }: PromotePreviewBodyProps): PreviewState {
+export function getPreviewState({
+  isLoading,
+  error,
+  isPreviewUnavailable,
+  result,
+}: PromotePreviewBodyProps): PreviewState {
   if (isLoading) {
     return { kind: 'loading' };
   }
@@ -100,11 +105,13 @@ function getPreviewState({ isLoading, error, isPreviewUnavailable, result }: Pro
   if (result?.valid) {
     return { kind: 'valid', result };
   }
+  // Shouldn't be reachable once useStagedConfigDryRun resolves — kept for exhaustiveness.
   return { kind: 'idle' };
 }
 
 /** Dry-run preview: a loading spinner, an unavailable/error/invalid banner, or the merge preview. */
 function PromotePreviewBody({ isLoading, error, isPreviewUnavailable, result }: PromotePreviewBodyProps) {
+  // Re-packed (not `props` directly) so react/no-unused-prop-types can see each field is used.
   const state = getPreviewState({ isLoading, error, isPreviewUnavailable, result });
 
   switch (state.kind) {

--- a/public/app/features/alerting/unified/settings/import/StagedPromotePreview.tsx
+++ b/public/app/features/alerting/unified/settings/import/StagedPromotePreview.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 
 import { type GrafanaTheme2, type IconName } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
@@ -158,12 +158,12 @@ function RenamedList({ receivers, timeIntervals }: { receivers: RenameEntry[]; t
 function RenameRow({ label, from, to }: { label: string; from: string; to: string }) {
   const styles = useStyles2(getStyles);
   return (
-    <div className={styles.renameRow}>
+    <Stack direction="row" gap={1} alignItems="center">
       <span className={styles.renameLabel}>{label}</span>
-      <span className={styles.renameFrom}>{from}</span>
+      <span className={cx(styles.renameValue, styles.renameFrom)}>{from}</span>
       <Icon name="arrow-right" size="sm" />
-      <span className={styles.renameTo}>{to}</span>
-    </div>
+      <span className={cx(styles.renameValue, styles.renameTo)}>{to}</span>
+    </Stack>
   );
 }
 
@@ -176,20 +176,18 @@ const getStyles = (theme: GrafanaTheme2) => ({
   addedIcon: css({
     color: theme.colors.success.text,
   }),
-  renameRow: css({
-    display: 'flex',
-    alignItems: 'center',
-    gap: theme.spacing(1),
-    fontFamily: theme.typography.fontFamilyMonospace,
-    fontSize: theme.typography.bodySmall.fontSize,
-  }),
   renameLabel: css({
     // Fixed label column so the original → new pairs align across rows.
     width: theme.spacing(12),
     flex: 'none',
-    fontFamily: theme.typography.fontFamily,
     fontSize: theme.typography.bodySmall.fontSize,
     color: theme.colors.text.secondary,
+  }),
+  renameValue: css({
+    // Monospace aligns the renamed name pairs — the same convention StagedConfiguration.tsx
+    // uses for its own resource-identifier rows.
+    fontFamily: theme.typography.fontFamilyMonospace,
+    fontSize: theme.typography.bodySmall.fontSize,
   }),
   renameFrom: css({
     textDecoration: 'line-through',

--- a/public/app/features/alerting/unified/settings/import/usePromoteStagedConfig.ts
+++ b/public/app/features/alerting/unified/settings/import/usePromoteStagedConfig.ts
@@ -1,0 +1,95 @@
+import { generatedAPI as notificationsAPI } from '@grafana/api-clients/rtkq/notifications.alerting/v0alpha1';
+import { t } from '@grafana/i18n';
+import { useAppNotification } from 'app/core/copy/appNotification';
+import { useDispatch } from 'app/types/store';
+
+import { logError } from '../../Analytics';
+import { alertmanagerApi } from '../../api/alertmanagerApi';
+import { convertToGMAApi } from '../../api/convertToGMAApi';
+import { stringifyErrorLike } from '../../utils/misc';
+
+import { type StagedExtraConfig } from './stagedConfig';
+
+interface UsePromoteStagedConfigResult {
+  onConfirm: () => Promise<void>;
+  isSubmitting: boolean;
+}
+
+/**
+ * Promotes a staged Alertmanager config into the live one, then — for auto-sync-managed configs —
+ * clears the configured auto-sync datasource UID so the merge doesn't keep getting treated as
+ * sync-managed. Reports the outcome via app notifications and calls `onDismiss` once it settles.
+ */
+export function usePromoteStagedConfig(
+  stagedConfig: StagedExtraConfig,
+  isSyncManaged: boolean | undefined,
+  onDismiss: () => void
+): UsePromoteStagedConfigResult {
+  const notifyApp = useAppNotification();
+  const dispatch = useDispatch();
+  const [promote, { isLoading: isPromoting }] = convertToGMAApi.usePromoteAlertmanagerConfigMutation();
+  const [updateAlertingConfiguration, { isLoading: isClearingAutoSync }] =
+    alertmanagerApi.endpoints.updateGrafanaAlertingConfiguration.useMutation();
+
+  const isSubmitting = isPromoting || isClearingAutoSync;
+
+  /**
+   * The sync worker stops on its own once it sees the merge committed, but the configured datasource
+   * UID stays on the org config — which keeps auto-sync reported as active and keeps the convert API
+   * rejecting notification imports. Clearing it is what actually ends the sync.
+   *
+   * Reports failure rather than throwing: it runs after an irreversible merge, so it must not be
+   * mistaken for a failed promote.
+   */
+  const clearAutoSync = async (): Promise<boolean> => {
+    try {
+      await updateAlertingConfiguration({
+        // Backend convention: empty string clears the configured UID.
+        external_alertmanager_uid: '',
+        notificationOptions: { showErrorAlert: false },
+      }).unwrap();
+      // The UID lives in a different RTKQ slice than the Config resource useIsAutoSyncActive reads,
+      // so tag invalidation doesn't cross over on its own.
+      dispatch(notificationsAPI.util.invalidateTags(['Config']));
+      return true;
+    } catch (err) {
+      logError(new Error(stringifyErrorLike(err)));
+      return false;
+    }
+  };
+
+  const onConfirm = async () => {
+    try {
+      await promote({ configIdentifier: stagedConfig.identifier }).unwrap();
+    } catch (err) {
+      logError(new Error(stringifyErrorLike(err)));
+      notifyApp.error(
+        t('alerting.settings.import.promote.error-title', 'Failed to promote configuration'),
+        stringifyErrorLike(err)
+      );
+      return;
+    }
+
+    // The merge has landed by this point, so nothing below may report the promote as failed.
+    if (isSyncManaged && !(await clearAutoSync())) {
+      notifyApp.warning(
+        t(
+          'alerting.settings.import.promote.sync-not-cleared-title',
+          'Configuration promoted, but auto-sync is still configured'
+        ),
+        t(
+          'alerting.settings.import.promote.sync-not-cleared-body',
+          'Nothing syncs from the datasource any more. Disable auto-sync in Alerting settings to import notification resources again — if it is set in grafana.ini, remove the key there.'
+        )
+      );
+    } else {
+      notifyApp.success(
+        t('alerting.settings.import.promote.success-title', 'Configuration promoted'),
+        t('alerting.settings.import.promote.success-body', 'The imported resources were merged into your live config.')
+      );
+    }
+    onDismiss();
+  };
+
+  return { onConfirm, isSubmitting };
+}

--- a/public/app/features/alerting/unified/settings/import/useStagedConfigDryRun.ts
+++ b/public/app/features/alerting/unified/settings/import/useStagedConfigDryRun.ts
@@ -25,9 +25,7 @@ interface StagedConfigDryRun {
 export function useStagedConfigDryRun(stagedConfig: StagedExtraConfig): StagedConfigDryRun {
   const [dryRun, { data, isLoading, error }] = convertToGMAApi.useDryRunAlertmanagerConfigMutation();
 
-  // A staged config is immutable for a given identifier and the modal mounts fresh each time it opens,
-  // so we capture the config at mount and dry-run once. This avoids re-firing if a parent ever passes a
-  // new stagedConfig reference (e.g. a fresh template_files object) for the same underlying config.
+  // Captures stagedConfig at mount so the dry-run fires once per modal open, not on every re-render.
   const configRef = useRef(stagedConfig);
   useEffect(() => {
     const config = configRef.current;

--- a/public/app/features/alerting/unified/settings/import/useStagedConfigDryRun.ts
+++ b/public/app/features/alerting/unified/settings/import/useStagedConfigDryRun.ts
@@ -25,7 +25,8 @@ interface StagedConfigDryRun {
 export function useStagedConfigDryRun(stagedConfig: StagedExtraConfig): StagedConfigDryRun {
   const [dryRun, { data, isLoading, error }] = convertToGMAApi.useDryRunAlertmanagerConfigMutation();
 
-  // Captures stagedConfig at mount so the dry-run fires once per modal open, not on every re-render.
+  // Captures stagedConfig at mount so a parent passing a new-but-equivalent object on a later
+  // render doesn't re-fire the dry-run.
   const configRef = useRef(stagedConfig);
   useEffect(() => {
     const config = configRef.current;


### PR DESCRIPTION
**Changes**

A couple of refactors and cleanup addressing review comments from #130327:

- Extract the promote mutation, conditional auto-sync clear, and notification handling out of PromoteConfirmModal into a dedicated usePromoteStagedConfig hook.
- Replace the four independent isLoading/error/isPreviewUnavailable/ result conditions in the preview JSX with one derived PreviewState and a PromotePreviewBody component that switches on it.
- Swap StagedPromotePreview's manual flex CSS for Stack, keeping only the genuinely custom bits (fixed label column, strikethrough, monospace) as emotion styles.
- Document why the post-import redirect is deferred via setTimeout, and why useStagedConfigDryRun captures stagedConfig in a ref instead of depending on it directly.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
