### PR TITLE
AuthN: Apply OpenFeature transaction context from baggage on gRPC Authenticate

### DIFF
--- a/pkg/infra/features/eval_context.go
+++ b/pkg/infra/features/eval_context.go
@@ -35,3 +35,10 @@ func EvaluationContextFromBaggage(ctx context.Context) openfeature.EvaluationCon
 func EvaluationContextFromTargetingKey(targetingKey string) openfeature.EvaluationContext {
 	return openfeature.NewEvaluationContext(targetingKey, make(map[string]any))
 }
+
+// WithTransactionContextFromBaggage merges the eval context derived from OTel
+// baggage into ctx as the OpenFeature transaction context. Shared by the HTTP
+// middleware and the gRPC path so evaluation behaves the same on both.
+func WithTransactionContextFromBaggage(ctx context.Context) context.Context {
+	return openfeature.MergeTransactionContext(ctx, EvaluationContextFromBaggage(ctx))
+}

--- a/pkg/infra/features/middleware.go
+++ b/pkg/infra/features/middleware.go
@@ -2,8 +2,6 @@ package features
 
 import (
 	"net/http"
-
-	"github.com/open-feature/go-sdk/openfeature"
 )
 
 // WithTransactionContextMiddleware is an HTTP middleware that reads OTel baggage
@@ -11,8 +9,7 @@ import (
 // Register it in each MT service's HTTP middleware chain.
 func WithTransactionContextMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		evalCtx := EvaluationContextFromBaggage(r.Context())
-		ctx := openfeature.MergeTransactionContext(r.Context(), evalCtx)
+		ctx := WithTransactionContextFromBaggage(r.Context())
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/pkg/services/authn/authnserver/service.go
+++ b/pkg/services/authn/authnserver/service.go
@@ -12,6 +12,7 @@ import (
 
 	authnv1 "github.com/grafana/authlib/authn/proto/v1"
 
+	"github.com/grafana/grafana/pkg/infra/features"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 )
@@ -67,6 +68,7 @@ func (s *Service) Authenticate(ctx context.Context, req *authnv1.AuthenticateReq
 
 	ctx = request.WithNamespace(ctx, req.Namespace)
 	ctx = log.WithContextualAttributes(ctx, []any{"namespace", req.Namespace})
+	ctx = features.WithTransactionContextFromBaggage(ctx)
 	span.SetAttributes(attribute.String("authn.namespace", req.Namespace))
 
 	grpclog.AddFields(ctx, grpclog.Fields{"authn.headers", headerNames(req.GetHttpHeaders())})

--- a/pkg/services/authn/authnserver/service_test.go
+++ b/pkg/services/authn/authnserver/service_test.go
@@ -7,8 +7,10 @@ import (
 	"testing"
 
 	grpclog "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
+	"github.com/open-feature/go-sdk/openfeature"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/baggage"
 	"k8s.io/apiserver/pkg/endpoints/request"
 
 	authnv1 "github.com/grafana/authlib/authn/proto/v1"
@@ -350,4 +352,29 @@ func TestAuthenticate_GRPCLogFields(t *testing.T) {
 		assert.Equal(t, "stacks-456", fields["authn.namespace"])
 		assert.Equal(t, "Authorization", fields["authn.headers"])
 	})
+}
+
+func TestAuthenticate_TransactionContextFromBaggage(t *testing.T) {
+	client := &mockClient{
+		name:         "test-client",
+		testResult:   true,
+		authResponse: &authnv1.AuthenticateResponse{Code: authnv1.AuthenticateCode_AUTHENTICATE_CODE_OK},
+	}
+	svc := NewService(tracing.InitializeTracerForTest())
+	svc.RegisterClient(client)
+
+	// Baggage as otelgrpc.NewServerHandler would have extracted it from the request.
+	bag, err := baggage.Parse("slug=myslug,plan=pro,channel=stable,namespace=stacks-42")
+	require.NoError(t, err)
+	ctx := baggage.ContextWithBaggage(context.Background(), bag)
+
+	_, err = svc.Authenticate(ctx, &authnv1.AuthenticateRequest{Namespace: "stacks-42"})
+	require.NoError(t, err)
+
+	require.NotNil(t, client.gotAuthCtx, "client should have been invoked")
+	evalCtx := openfeature.TransactionContext(client.gotAuthCtx)
+	assert.Equal(t, "stacks-42", evalCtx.TargetingKey(), "namespace is the targeting key")
+	assert.Equal(t, "myslug", evalCtx.Attributes()["slug"], "slug attribute enables goff.ForSlugs targeting")
+	assert.Equal(t, "pro", evalCtx.Attributes()["plan"])
+	assert.Equal(t, "stable", evalCtx.Attributes()["channel"])
 }


### PR DESCRIPTION
## Why

Per-tenant OpenFeature flag targeting (by slug / plan / channel / namespace) relies on an evaluation context we derive from OpenTelemetry baggage. That translation only existed inline in the HTTP middleware (`WithTransactionContextMiddleware`), so flags evaluated on the gRPC path — the authn-service `Authenticate` call — never got the tenant's targeting attributes, even once the gateway started propagating baggage over gRPC.

## What

- Extract the "OTel baggage → OpenFeature transaction context" step into a small exported helper `WithTransactionContextFromBaggage(ctx)` in `pkg/infra/features`, and refactor `WithTransactionContextMiddleware` to call it (no behavior change for HTTP).
- Consume the helper in `authnserver.Service.Authenticate`, so the gRPC path gets the exact same per-tenant evaluation context as HTTP.

Doing the merge directly in the OSS `authnserver.Service` (the shared choke point for the gRPC path) means no enterprise-side decorator is needed.