### PR TITLE
Alerting: Add AccessControlAction entries for inhibition rules

### DIFF
--- a/public/app/features/alerting/unified/settings/import/stagedConfigPermissions.ts
+++ b/public/app/features/alerting/unified/settings/import/stagedConfigPermissions.ts
@@ -2,7 +2,6 @@ import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction } from 'app/types/accessControl';
 
 const ALERTMANAGER_IMPORTS_DELETE = 'notifications.alerting.grafana.app/alertmanagerimports:delete';
-const INHIBITION_RULES_WRITE = 'alert.notifications.inhibition-rules:write';
 
 // Promoting authorizes create/write on every resource type the import contains, which isn't known until
 // the dry-run has parsed it. Any one of them opens the modal; the dry-run reports what's actually missing.
@@ -11,7 +10,7 @@ const PROMOTE_ACTIONS = [
   AccessControlAction.ActionAlertingManagedRoutesCreate,
   AccessControlAction.AlertingTemplatesWrite,
   AccessControlAction.AlertingTimeIntervalsWrite,
-  INHIBITION_RULES_WRITE,
+  AccessControlAction.AlertingInhibitionRulesWrite,
 ];
 
 export interface StagedConfigPermissions {

--- a/public/app/types/accessControl.ts
+++ b/public/app/types/accessControl.ts
@@ -178,6 +178,11 @@ export enum AccessControlAction {
   AlertingTemplatesDelete = 'alert.notifications.templates:delete',
   AlertingNotificationsTemplatesTest = 'alert.notifications.templates.test:write',
 
+  // Alerting inhibition rules actions
+  AlertingInhibitionRulesRead = 'alert.notifications.inhibition-rules:read',
+  AlertingInhibitionRulesWrite = 'alert.notifications.inhibition-rules:write',
+  AlertingInhibitionRulesDelete = 'alert.notifications.inhibition-rules:delete',
+
   // Alerting enrichments actions
   AlertingEnrichmentsRead = 'alert.enrichments:read',
   AlertingEnrichmentsWrite = 'alert.enrichments:write',


### PR DESCRIPTION
**Changes**
Promote's permission gate referenced the inhibition-rules:write action as a raw string literal instead of an AccessControlAction enum member, unlike its four sibling actions in the same list. 

This PR adds the missing Read / Write / Delete entries to mirror the backend actions in `pkg/services/accesscontrol/models.go` and the existing sibling groups (templates, time intervals), then use the enum member in `stagedConfigPermissions.ts`.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
