### PR TITLE
I18n: Mark up Explore ErrorContainer for translations

### DIFF
--- a/public/app/features/explore/ErrorContainer.tsx
+++ b/public/app/features/explore/ErrorContainer.tsx
@@ -1,4 +1,5 @@
 import { type DataQueryError } from '@grafana/data';
+import { t } from '@grafana/i18n';
 import { Alert } from '@grafana/ui';
 import { FadeIn } from 'app/core/components/Animations/FadeIn';
 
@@ -10,7 +11,9 @@ export const ErrorContainer = (props: ErrorContainerProps) => {
   const { queryError } = props;
   const showError = queryError ? true : false;
   const duration = showError ? 100 : 10;
-  const title = queryError ? 'Query error' : 'Unknown error';
+  const title = queryError
+    ? t('explore.error-container.title-query-error', 'Query error')
+    : t('explore.error-container.title-unknown-error', 'Unknown error');
   const message = queryError?.message || queryError?.data?.message || null;
 
   return (

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8509,6 +8509,10 @@
       "aria-label-links": "Links",
       "links": "Links"
     },
+    "error-container": {
+      "title-query-error": "Query error",
+      "title-unknown-error": "Unknown error"
+    },
     "explore": {
       "title-flame-graph": "Flame graph",
       "title-graph": "Graph",


### PR DESCRIPTION
**What is this feature?**

This PR adds internationalization (i18n) markup to the `ErrorContainer` component in `public/app/features/explore/`.

The two alert titles rendered by this component, "Query error" and "Unknown error", were hardcoded English strings. They are now wrapped with the `t()` macro from `@grafana/i18n`, and the extracted keys have been added to the `en-US` catalog via the extractor.

`t()` is used here rather than `<Trans />` because the title is passed to `<Alert />` as a prop, per the guidance in `contribute/internationalization.md`.

```diff
- const title = queryError ? 'Query error' : 'Unknown error';
+ const title = queryError
+   ? t('explore.error-container.title-query-error', 'Query error')
+   : t('explore.error-container.title-unknown-error', 'Unknown error');
```

**Why do we need this feature?**

When a user switches their Grafana profile language, the error alert shown in Explore when a query fails still displays hardcoded English. Marking these strings up allows them to be translated so the Explore error state is localized along with the rest of the UI.

**Who is this feature for?**

Grafana users who use the interface in a language other than English.

**Which issue(s) does this PR fix?**:

Part of the `/explore` internationalization effort under the epic issue #73984.

Following the maintainer guidance on that issue to split the work into small PRs covering one or two components each, this PR covers `ErrorContainer` only. `NoData` is already covered by #126913.

**Special notes for your reviewer:**

- No translation files other than `en-US/grafana.json` were touched, and that file was updated by running the extractor rather than by hand.
- The existing `ErrorContainer.test.tsx` suite passes unchanged (3/3), since the assertions match on rendered text and the default English phrase is used as the fallback.
- `yarn typecheck`, `eslint`, and `prettier --check` all pass on the changed files.
