### PR TITLE
CI: Log patch job URL once located

### DIFF
--- a/.github/workflows/pr-patch-check.yml
+++ b/.github/workflows/pr-patch-check.yml
@@ -47,6 +47,7 @@ jobs:
         uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
         with:
           github_app: grafana-releases-oss
+
       - name: "Dispatch job"
         uses: actions/github-script@v8
         with:
@@ -69,6 +70,7 @@ jobs:
                   triggering_github_handle: SENDER
                 }
             })
+
       - name: "Wait for success"
         # Only run metadata reads (status/conclusion) — never fetch logs or artifacts,
         # since the security-patch-actions workflow output must not be exposed.
@@ -109,6 +111,7 @@ jobs:
                 );
                 if (matchingRun) {
                   runId = matchingRun.id;
+                  console.log(`Dispatched workflow run: ${matchingRun.html_url}`);
                 } else {
                   await sleep(pollIntervalMs);
                   continue;


### PR DESCRIPTION
**What is this feature?**

Logs the patch job URL identified as matching the branch.

**Why do we need this feature?**

Makes it far easier to jump into the workflow if an issue occurs.

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
