### PR TITLE
Provisioning: Configure connection types

### DIFF
--- a/apps/provisioning/kinds/connection.cue
+++ b/apps/provisioning/kinds/connection.cue
@@ -63,7 +63,7 @@ connection: {
 				}
 				spec: {
 					// The connection provider type
-					type: "github" | "githubEnterprise" | "bitbucket" | "gitlab"
+					type: "github" | "githubEnterprise" | "bitbucketOAuth" | "gitlabOAuth"
 					// The connection URL.
 					url: *"" | string
 					// GitHub connection configuration.
@@ -73,7 +73,7 @@ connection: {
 					// Only applicable when provider is "githubEnterprise".
 					githubEnterprise?: #GitHubEnterpriseConnectionConfig
 					// Bitbucket connection configuration
-					// Only applicable when provider is "bitbucket"
+					// Only applicable when provider is "bitbucketOAuth"
 					bitbucket?: #BitbucketConnectionConfig
 					// OAuth app configuration shared by all OAuth app providers
 					oauth?: #ConnectionOAuthConfig

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/connections.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/connections.go
@@ -117,8 +117,8 @@ func (ConnectionType) OpenAPIModelName() string {
 const (
 	GithubConnectionType           ConnectionType = "github"
 	GithubEnterpriseConnectionType ConnectionType = "githubEnterprise"
-	GitlabConnectionType           ConnectionType = "gitlab"
-	BitbucketConnectionType        ConnectionType = "bitbucket"
+	GitlabOAuthConnectionType      ConnectionType = "gitlabOAuth"
+	BitbucketOAuthConnectionType   ConnectionType = "bitbucketOAuth"
 )
 
 type ConnectionSpec struct {
@@ -138,7 +138,7 @@ type ConnectionSpec struct {
 	// Only applicable when provider is "githubEnterprise"
 	GitHubEnterprise *GitHubEnterpriseConnectionConfig `json:"githubEnterprise,omitempty"`
 	// Bitbucket connection configuration
-	// Only applicable when provider is "bitbucket"
+	// Only applicable when provider is "bitbucketOAuth"
 	Bitbucket *BitbucketConnectionConfig `json:"bitbucket,omitempty"`
 
 	// OAuth app configuration shared by all OAuth app providers

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/settings.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/settings.go
@@ -21,6 +21,9 @@ type RepositoryViewList struct {
 	// AvailableRepositoryTypes is the list of repository types supported in this instance (e.g. git, bitbucket, github, etc)
 	AvailableRepositoryTypes []RepositoryType `json:"availableRepositoryTypes,omitempty"`
 
+	// AvailableConnectionTypes is the list of connection types supported in this instance
+	AvailableConnectionTypes []ConnectionType `json:"availableConnectionTypes,omitempty"`
+
 	// AvailableResources is the list of resource types declared for provisioning in this
 	// instance, including disabled ones (see SupportedResource.Disabled).
 	AvailableResources []SupportedResource `json:"availableResources,omitempty"`

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.deepcopy.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.deepcopy.go
@@ -1356,6 +1356,11 @@ func (in *RepositoryViewList) DeepCopyInto(out *RepositoryViewList) {
 		*out = make([]RepositoryType, len(*in))
 		copy(*out, *in)
 	}
+	if in.AvailableConnectionTypes != nil {
+		in, out := &in.AvailableConnectionTypes, &out.AvailableConnectionTypes
+		*out = make([]ConnectionType, len(*in))
+		copy(*out, *in)
+	}
 	if in.AvailableResources != nil {
 		in, out := &in.AvailableResources, &out.AvailableResources
 		*out = make([]SupportedResource, len(*in))

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
@@ -601,11 +601,11 @@ func schema_pkg_apis_provisioning_v0alpha1_ConnectionSpec(ref common.ReferenceCa
 					},
 					"type": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The connection provider type\n\nPossible enum values:\n - `\"bitbucket\"`\n - `\"github\"`\n - `\"githubEnterprise\"`\n - `\"gitlab\"`",
+							Description: "The connection provider type\n\nPossible enum values:\n - `\"bitbucketOAuth\"`\n - `\"github\"`\n - `\"githubEnterprise\"`\n - `\"gitlabOAuth\"`",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
-							Enum:        []interface{}{"bitbucket", "github", "githubEnterprise", "gitlab"},
+							Enum:        []interface{}{"bitbucketOAuth", "github", "githubEnterprise", "gitlabOAuth"},
 						},
 					},
 					"url": {
@@ -629,7 +629,7 @@ func schema_pkg_apis_provisioning_v0alpha1_ConnectionSpec(ref common.ReferenceCa
 					},
 					"bitbucket": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Bitbucket connection configuration Only applicable when provider is \"bitbucket\"",
+							Description: "Bitbucket connection configuration Only applicable when provider is \"bitbucketOAuth\"",
 							Ref:         ref(BitbucketConnectionConfig{}.OpenAPIModelName()),
 						},
 					},
@@ -2941,6 +2941,22 @@ func schema_pkg_apis_provisioning_v0alpha1_RepositoryViewList(ref common.Referen
 										Type:    []string{"string"},
 										Format:  "",
 										Enum:    []interface{}{"bitbucket", "git", "github", "githubEnterprise", "gitlab", "local"},
+									},
+								},
+							},
+						},
+					},
+					"availableConnectionTypes": {
+						SchemaProps: spec.SchemaProps{
+							Description: "AvailableConnectionTypes is the list of connection types supported in this instance",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+										Enum:    []interface{}{"bitbucketOAuth", "github", "githubEnterprise", "gitlabOAuth"},
 									},
 								},
 							},

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi_violation_exceptions.list
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi_violation_exceptions.list
@@ -19,6 +19,7 @@ API rule violation: list_type_missing,github.com/grafana/grafana/apps/provisioni
 API rule violation: list_type_missing,github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1,RepositorySpec,Workflows
 API rule violation: list_type_missing,github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1,RepositoryView,Workflows
 API rule violation: list_type_missing,github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1,RepositoryViewList,AllowedTargets
+API rule violation: list_type_missing,github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1,RepositoryViewList,AvailableConnectionTypes
 API rule violation: list_type_missing,github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1,RepositoryViewList,AvailableRepositoryTypes
 API rule violation: list_type_missing,github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1,RepositoryViewList,AvailableResources
 API rule violation: list_type_missing,github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1,RepositoryViewList,Items

--- a/apps/provisioning/pkg/connection/factory.go
+++ b/apps/provisioning/pkg/connection/factory.go
@@ -32,11 +32,9 @@ type factory struct {
 	enabled map[provisioning.ConnectionType]struct{}
 }
 
-// ToConnectionTypes maps the configured repository types to the connection
-// types they enable.
-func ToConnectionTypes(repositoryTypes []string) map[provisioning.ConnectionType]struct{} {
-	enabled := make(map[provisioning.ConnectionType]struct{}, len(repositoryTypes))
-	for _, t := range repositoryTypes {
+func ToConnectionTypes(connectionTypes []string) map[provisioning.ConnectionType]struct{} {
+	enabled := make(map[provisioning.ConnectionType]struct{}, len(connectionTypes))
+	for _, t := range connectionTypes {
 		enabled[provisioning.ConnectionType(t)] = struct{}{}
 	}
 	return enabled

--- a/apps/provisioning/pkg/connection/factory_test.go
+++ b/apps/provisioning/pkg/connection/factory_test.go
@@ -31,13 +31,13 @@ func TestProvideFactory(t *testing.T) {
 				extra1.EXPECT().Type().Return(provisioning.GithubConnectionType)
 
 				extra2 := connection.NewMockExtra(t)
-				extra2.EXPECT().Type().Return(provisioning.GitlabConnectionType)
+				extra2.EXPECT().Type().Return(provisioning.GitlabOAuthConnectionType)
 
 				return []connection.Extra{extra1, extra2}
 			},
 			enabled: map[provisioning.ConnectionType]struct{}{
-				provisioning.GithubConnectionType: {},
-				provisioning.GitlabConnectionType: {},
+				provisioning.GithubConnectionType:      {},
+				provisioning.GitlabOAuthConnectionType: {},
 			},
 			wantErr: false,
 		},
@@ -93,23 +93,23 @@ func TestFactory_Types(t *testing.T) {
 	}{
 		{
 			name:       "should return only enabled types that have extras",
-			extraTypes: []provisioning.ConnectionType{provisioning.GithubConnectionType, provisioning.GitlabConnectionType},
+			extraTypes: []provisioning.ConnectionType{provisioning.GithubConnectionType, provisioning.GitlabOAuthConnectionType},
 			enabled: map[provisioning.ConnectionType]struct{}{
-				provisioning.GithubConnectionType: {},
-				provisioning.GitlabConnectionType: {},
+				provisioning.GithubConnectionType:      {},
+				provisioning.GitlabOAuthConnectionType: {},
 			},
 			expectedLen:  2,
-			expectedList: []provisioning.ConnectionType{provisioning.GithubConnectionType, provisioning.GitlabConnectionType},
+			expectedList: []provisioning.ConnectionType{provisioning.GithubConnectionType, provisioning.GitlabOAuthConnectionType},
 		},
 		{
 			name:       "should return sorted list of types",
-			extraTypes: []provisioning.ConnectionType{provisioning.GitlabConnectionType, provisioning.GithubConnectionType},
+			extraTypes: []provisioning.ConnectionType{provisioning.GitlabOAuthConnectionType, provisioning.GithubConnectionType},
 			enabled: map[provisioning.ConnectionType]struct{}{
-				provisioning.GithubConnectionType: {},
-				provisioning.GitlabConnectionType: {},
+				provisioning.GithubConnectionType:      {},
+				provisioning.GitlabOAuthConnectionType: {},
 			},
 			expectedLen:  2,
-			expectedList: []provisioning.ConnectionType{provisioning.GithubConnectionType, provisioning.GitlabConnectionType},
+			expectedList: []provisioning.ConnectionType{provisioning.GithubConnectionType, provisioning.GitlabOAuthConnectionType},
 			checkSorted:  true,
 		},
 		{
@@ -123,15 +123,15 @@ func TestFactory_Types(t *testing.T) {
 			name:       "should not return types that are enabled but have no extras",
 			extraTypes: []provisioning.ConnectionType{provisioning.GithubConnectionType},
 			enabled: map[provisioning.ConnectionType]struct{}{
-				provisioning.GithubConnectionType: {},
-				provisioning.GitlabConnectionType: {},
+				provisioning.GithubConnectionType:      {},
+				provisioning.GitlabOAuthConnectionType: {},
 			},
 			expectedLen:  1,
 			expectedList: []provisioning.ConnectionType{provisioning.GithubConnectionType},
 		},
 		{
 			name:       "should not return types that have extras but are not enabled",
-			extraTypes: []provisioning.ConnectionType{provisioning.GithubConnectionType, provisioning.GitlabConnectionType},
+			extraTypes: []provisioning.ConnectionType{provisioning.GithubConnectionType, provisioning.GitlabOAuthConnectionType},
 			enabled: map[provisioning.ConnectionType]struct{}{
 				provisioning.GithubConnectionType: {},
 			},
@@ -212,10 +212,10 @@ func TestFactory_Build(t *testing.T) {
 		},
 		{
 			name:           "should return error when type is not enabled",
-			connectionType: provisioning.GitlabConnectionType,
+			connectionType: provisioning.GitlabOAuthConnectionType,
 			setupExtras: func(t *testing.T, ctx context.Context) ([]connection.Extra, connection.Connection, error) {
 				extra := connection.NewMockExtra(t)
-				extra.EXPECT().Type().Return(provisioning.GitlabConnectionType)
+				extra.EXPECT().Type().Return(provisioning.GitlabOAuthConnectionType)
 
 				return []connection.Extra{extra}, nil, nil
 			},
@@ -224,12 +224,12 @@ func TestFactory_Build(t *testing.T) {
 			},
 			wantErr: true,
 			validateError: func(t *testing.T, err error) {
-				assert.Contains(t, err.Error(), "connection type \"gitlab\" is not enabled")
+				assert.Contains(t, err.Error(), "connection type \"gitlabOAuth\" is not enabled")
 			},
 		},
 		{
 			name:           "should return error when type is not supported",
-			connectionType: provisioning.GitlabConnectionType,
+			connectionType: provisioning.GitlabOAuthConnectionType,
 			setupExtras: func(t *testing.T, ctx context.Context) ([]connection.Extra, connection.Connection, error) {
 				extra := connection.NewMockExtra(t)
 				extra.EXPECT().Type().Return(provisioning.GithubConnectionType)
@@ -241,7 +241,7 @@ func TestFactory_Build(t *testing.T) {
 			},
 			wantErr: true,
 			validateError: func(t *testing.T, err error) {
-				assert.Contains(t, err.Error(), "connection type \"gitlab\" is not supported")
+				assert.Contains(t, err.Error(), "connection type \"gitlabOAuth\" is not supported")
 			},
 		},
 		{
@@ -270,7 +270,7 @@ func TestFactory_Build(t *testing.T) {
 		},
 		{
 			name:           "should build with multiple extras registered",
-			connectionType: provisioning.GitlabConnectionType,
+			connectionType: provisioning.GitlabOAuthConnectionType,
 			setupExtras: func(t *testing.T, ctx context.Context) ([]connection.Extra, connection.Connection, error) {
 				mockConnection := connection.NewMockConnection(t)
 				mockConnection.EXPECT().Test(mock.Anything).Return(&provisioning.TestResults{Success: true}, nil).Maybe()
@@ -279,19 +279,19 @@ func TestFactory_Build(t *testing.T) {
 				extra1.EXPECT().Type().Return(provisioning.GithubConnectionType)
 
 				extra2 := connection.NewMockExtra(t)
-				extra2.EXPECT().Type().Return(provisioning.GitlabConnectionType)
+				extra2.EXPECT().Type().Return(provisioning.GitlabOAuthConnectionType)
 				extra2.EXPECT().Build(ctx, &provisioning.Connection{
 					ObjectMeta: metav1.ObjectMeta{Name: "test-connection"},
 					Spec: provisioning.ConnectionSpec{
-						Type: provisioning.GitlabConnectionType,
+						Type: provisioning.GitlabOAuthConnectionType,
 					},
 				}).Return(mockConnection, nil)
 
 				return []connection.Extra{extra1, extra2}, mockConnection, nil
 			},
 			enabled: map[provisioning.ConnectionType]struct{}{
-				provisioning.GithubConnectionType: {},
-				provisioning.GitlabConnectionType: {},
+				provisioning.GithubConnectionType:      {},
+				provisioning.GitlabOAuthConnectionType: {},
 			},
 			wantErr: false,
 		},
@@ -385,14 +385,14 @@ func TestFactory_Mutate(t *testing.T) {
 				extra1.EXPECT().Mutate(ctx, obj).Return(nil)
 
 				extra2 := connection.NewMockExtra(t)
-				extra2.EXPECT().Type().Return(provisioning.GitlabConnectionType)
+				extra2.EXPECT().Type().Return(provisioning.GitlabOAuthConnectionType)
 				extra2.EXPECT().Mutate(ctx, obj).Return(nil)
 
 				return []connection.Extra{extra1, extra2}
 			},
 			enabled: map[provisioning.ConnectionType]struct{}{
-				provisioning.GithubConnectionType: {},
-				provisioning.GitlabConnectionType: {},
+				provisioning.GithubConnectionType:      {},
+				provisioning.GitlabOAuthConnectionType: {},
 			},
 			obj: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-connection"},
@@ -496,7 +496,7 @@ func TestFactory_Validate(t *testing.T) {
 			name: "should return error when connection type is not supported",
 			connection: &provisioning.Connection{
 				Spec: provisioning.ConnectionSpec{
-					Type: provisioning.GitlabConnectionType,
+					Type: provisioning.GitlabOAuthConnectionType,
 				},
 			},
 			setupExtras: func(t *testing.T, ctx context.Context) []connection.Extra {
@@ -513,7 +513,7 @@ func TestFactory_Validate(t *testing.T) {
 				assert.Equal(t, "spec.title", errs[0].Field)
 				assert.Contains(t, errs[0].Detail, "title is required")
 				assert.Equal(t, "spec.type", errs[1].Field)
-				assert.Contains(t, errs[1].Detail, "connection type \"gitlab\" is not supported")
+				assert.Contains(t, errs[1].Detail, "connection type \"gitlabOAuth\" is not supported")
 			},
 		},
 		{
@@ -544,12 +544,12 @@ func TestFactory_Validate(t *testing.T) {
 			name: "should return error when connection type is not enabled",
 			connection: &provisioning.Connection{
 				Spec: provisioning.ConnectionSpec{
-					Type: provisioning.GitlabConnectionType,
+					Type: provisioning.GitlabOAuthConnectionType,
 				},
 			},
 			setupExtras: func(t *testing.T, ctx context.Context) []connection.Extra {
 				extra := connection.NewMockExtra(t)
-				extra.EXPECT().Type().Return(provisioning.GitlabConnectionType)
+				extra.EXPECT().Type().Return(provisioning.GitlabOAuthConnectionType)
 				return []connection.Extra{extra}
 			},
 			enabled: map[provisioning.ConnectionType]struct{}{
@@ -561,7 +561,7 @@ func TestFactory_Validate(t *testing.T) {
 				assert.Equal(t, "spec.title", errs[0].Field)
 				assert.Contains(t, errs[0].Detail, "title is required")
 				assert.Equal(t, "spec.type", errs[1].Field)
-				assert.Contains(t, errs[1].Detail, "connection type \"gitlab\" is not enabled")
+				assert.Contains(t, errs[1].Detail, "connection type \"gitlabOAuth\" is not enabled")
 			},
 		},
 		{
@@ -626,14 +626,14 @@ func TestFactory_Validate(t *testing.T) {
 				extra1.EXPECT().Validate(ctx, mock.Anything).Return(field.ErrorList{})
 
 				extra2 := connection.NewMockExtra(t)
-				extra2.EXPECT().Type().Return(provisioning.GitlabConnectionType)
+				extra2.EXPECT().Type().Return(provisioning.GitlabOAuthConnectionType)
 				extra2.EXPECT().Validate(ctx, mock.Anything).Return(field.ErrorList{})
 
 				return []connection.Extra{extra1, extra2}
 			},
 			enabled: map[provisioning.ConnectionType]struct{}{
-				provisioning.GithubConnectionType: {},
-				provisioning.GitlabConnectionType: {},
+				provisioning.GithubConnectionType:      {},
+				provisioning.GitlabOAuthConnectionType: {},
 			},
 			expectedErrs: 0,
 		},
@@ -641,7 +641,7 @@ func TestFactory_Validate(t *testing.T) {
 			name: "should return error for unsupported type before checking enabled",
 			connection: &provisioning.Connection{
 				Spec: provisioning.ConnectionSpec{
-					Type: provisioning.BitbucketConnectionType,
+					Type: provisioning.BitbucketOAuthConnectionType,
 				},
 			},
 			setupExtras: func(t *testing.T, ctx context.Context) []connection.Extra {
@@ -650,8 +650,8 @@ func TestFactory_Validate(t *testing.T) {
 				return []connection.Extra{extra}
 			},
 			enabled: map[provisioning.ConnectionType]struct{}{
-				provisioning.GithubConnectionType:    {},
-				provisioning.BitbucketConnectionType: {}, // Even if enabled, not supported
+				provisioning.GithubConnectionType:         {},
+				provisioning.BitbucketOAuthConnectionType: {}, // Even if enabled, not supported
 			},
 			expectedErrs: 2,
 			validateError: func(t *testing.T, errs []*field.Error) {
@@ -659,7 +659,7 @@ func TestFactory_Validate(t *testing.T) {
 				assert.Equal(t, "spec.title", errs[0].Field)
 				assert.Contains(t, errs[0].Detail, "title is required")
 				assert.Equal(t, "spec.type", errs[1].Field)
-				assert.Contains(t, errs[1].Detail, "connection type \"bitbucket\" is not supported")
+				assert.Contains(t, errs[1].Detail, "connection type \"bitbucketOAuth\" is not supported")
 			},
 		},
 	}

--- a/apps/provisioning/pkg/connection/github/connection_test.go
+++ b/apps/provisioning/pkg/connection/github/connection_test.go
@@ -115,7 +115,7 @@ func TestConnection_Mutate(t *testing.T) {
 			connection: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-connection"},
 				Spec: provisioning.ConnectionSpec{
-					Type: provisioning.GitlabConnectionType,
+					Type: provisioning.GitlabOAuthConnectionType,
 					OAuth: &provisioning.ConnectionOAuthConfig{
 						ClientID: "clientID",
 					},
@@ -1548,7 +1548,7 @@ func TestConnection_GenerateConnectionToken(t *testing.T) {
 			connection: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-connection"},
 				Spec: provisioning.ConnectionSpec{
-					Type: provisioning.GitlabConnectionType,
+					Type: provisioning.GitlabOAuthConnectionType,
 					OAuth: &provisioning.ConnectionOAuthConfig{
 						ClientID: "clientID",
 					},
@@ -1716,7 +1716,7 @@ func TestConnection_GenerateRepositoryToken(t *testing.T) {
 			connection: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-connection"},
 				Spec: provisioning.ConnectionSpec{
-					Type: provisioning.GitlabConnectionType,
+					Type: provisioning.GitlabOAuthConnectionType,
 					OAuth: &provisioning.ConnectionOAuthConfig{
 						ClientID: "clientID",
 					},
@@ -2002,7 +2002,7 @@ func TestConnection_ListRepositories(t *testing.T) {
 		c := &provisioning.Connection{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-connection"},
 			Spec: provisioning.ConnectionSpec{
-				Type: provisioning.GitlabConnectionType,
+				Type: provisioning.GitlabOAuthConnectionType,
 			},
 		}
 

--- a/apps/provisioning/pkg/connection/github/extra_test.go
+++ b/apps/provisioning/pkg/connection/github/extra_test.go
@@ -284,7 +284,7 @@ func TestExtra_Mutate(t *testing.T) {
 			obj: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-connection"},
 				Spec: provisioning.ConnectionSpec{
-					Type: provisioning.GitlabConnectionType,
+					Type: provisioning.GitlabOAuthConnectionType,
 					OAuth: &provisioning.ConnectionOAuthConfig{
 						ClientID: "clientID",
 					},

--- a/apps/provisioning/pkg/connection/github/mutator_test.go
+++ b/apps/provisioning/pkg/connection/github/mutator_test.go
@@ -111,7 +111,7 @@ func TestMutate(t *testing.T) {
 			obj: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-connection"},
 				Spec: provisioning.ConnectionSpec{
-					Type: provisioning.GitlabConnectionType,
+					Type: provisioning.GitlabOAuthConnectionType,
 					OAuth: &provisioning.ConnectionOAuthConfig{
 						ClientID: "client-id",
 					},

--- a/apps/provisioning/pkg/connection/github/validator_test.go
+++ b/apps/provisioning/pkg/connection/github/validator_test.go
@@ -35,7 +35,7 @@ func TestValidate(t *testing.T) {
 					Name: "test-conn",
 				},
 				Spec: provisioning.ConnectionSpec{
-					Type: provisioning.GitlabConnectionType,
+					Type: provisioning.GitlabOAuthConnectionType,
 				},
 			},
 		},

--- a/apps/provisioning/pkg/connection/mutator_test.go
+++ b/apps/provisioning/pkg/connection/mutator_test.go
@@ -136,7 +136,7 @@ func TestAdmissionMutator_MutateUpdateOAuthToken(t *testing.T) {
 	}{
 		{
 			name:      "removes token when connection type is changed",
-			newType:   provisioning.GitlabConnectionType,
+			newType:   provisioning.GitlabOAuthConnectionType,
 			newOAuth:  &provisioning.ConnectionOAuthConfig{ClientID: "same-client"},
 			oldOAuth:  &provisioning.ConnectionOAuthConfig{ClientID: "same-client"},
 			wantToken: common.InlineSecureValue{Remove: true},

--- a/apps/provisioning/pkg/connection/oauth/extra_test.go
+++ b/apps/provisioning/pkg/connection/oauth/extra_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestExtra_Type(t *testing.T) {
 	e := newTestExtra(t, connection.NewMockSecureValues(t), nil)
-	assert.Equal(t, provisioning.GitlabConnectionType, e.Type())
+	assert.Equal(t, provisioning.GitlabOAuthConnectionType, e.Type())
 }
 
 func TestExtra_Build(t *testing.T) {
@@ -34,7 +34,7 @@ func TestExtra_Build(t *testing.T) {
 			conn: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-connection"},
 				Spec: provisioning.ConnectionSpec{
-					Type:  provisioning.GitlabConnectionType,
+					Type:  provisioning.GitlabOAuthConnectionType,
 					OAuth: &provisioning.ConnectionOAuthConfig{ClientID: "client-id"},
 				},
 			},
@@ -52,7 +52,7 @@ func TestExtra_Build(t *testing.T) {
 			conn: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-connection"},
 				Spec: provisioning.ConnectionSpec{
-					Type: provisioning.GitlabConnectionType,
+					Type: provisioning.GitlabOAuthConnectionType,
 				},
 			},
 			expectedErr: "oauth configuration is required",
@@ -62,7 +62,7 @@ func TestExtra_Build(t *testing.T) {
 			conn: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-connection"},
 				Spec: provisioning.ConnectionSpec{
-					Type:  provisioning.GitlabConnectionType,
+					Type:  provisioning.GitlabOAuthConnectionType,
 					OAuth: &provisioning.ConnectionOAuthConfig{ClientID: "client-id"},
 				},
 			},
@@ -76,7 +76,7 @@ func TestExtra_Build(t *testing.T) {
 			conn: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-connection"},
 				Spec: provisioning.ConnectionSpec{
-					Type:  provisioning.GitlabConnectionType,
+					Type:  provisioning.GitlabOAuthConnectionType,
 					OAuth: &provisioning.ConnectionOAuthConfig{ClientID: "client-id"},
 				},
 			},
@@ -127,7 +127,7 @@ func TestExtra_Build_PassesAccessToken(t *testing.T) {
 			var gotToken string
 			e := oauth.NewExtra(
 				func(*provisioning.Connection) connection.SecureValues { return secure },
-				provisioning.GitlabConnectionType,
+				provisioning.GitlabOAuthConnectionType,
 				provisioning.GitLabRepositoryType,
 				func(_ provisioning.ConnectionSpec, accessToken string) (oauth.Provider, error) {
 					gotToken = accessToken
@@ -161,7 +161,7 @@ func TestExtra_Build_ProviderError(t *testing.T) {
 
 	e := oauth.NewExtra(
 		func(*provisioning.Connection) connection.SecureValues { return secure },
-		provisioning.GitlabConnectionType,
+		provisioning.GitlabOAuthConnectionType,
 		provisioning.GitLabRepositoryType,
 		func(_ provisioning.ConnectionSpec, _ string) (oauth.Provider, error) {
 			return nil, errors.New("boom")
@@ -177,7 +177,7 @@ func newBuildTestConnection() *provisioning.Connection {
 	return &provisioning.Connection{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-connection"},
 		Spec: provisioning.ConnectionSpec{
-			Type:  provisioning.GitlabConnectionType,
+			Type:  provisioning.GitlabOAuthConnectionType,
 			OAuth: &provisioning.ConnectionOAuthConfig{ClientID: "client-id"},
 		},
 	}
@@ -211,7 +211,7 @@ func TestExtra_Validate(t *testing.T) {
 			name: "missing oauth config",
 			obj: &provisioning.Connection{
 				Spec: provisioning.ConnectionSpec{
-					Type: provisioning.GitlabConnectionType,
+					Type: provisioning.GitlabOAuthConnectionType,
 				},
 			},
 			errorContains: []string{"oauth info must be specified", "clientSecret"},
@@ -220,7 +220,7 @@ func TestExtra_Validate(t *testing.T) {
 			name: "missing client ID",
 			obj: &provisioning.Connection{
 				Spec: provisioning.ConnectionSpec{
-					Type:  provisioning.GitlabConnectionType,
+					Type:  provisioning.GitlabOAuthConnectionType,
 					OAuth: &provisioning.ConnectionOAuthConfig{},
 				},
 				Secure: provisioning.ConnectionSecure{
@@ -233,7 +233,7 @@ func TestExtra_Validate(t *testing.T) {
 			name: "missing client secret",
 			obj: &provisioning.Connection{
 				Spec: provisioning.ConnectionSpec{
-					Type:  provisioning.GitlabConnectionType,
+					Type:  provisioning.GitlabOAuthConnectionType,
 					OAuth: &provisioning.ConnectionOAuthConfig{ClientID: "client-id"},
 				},
 			},
@@ -243,7 +243,7 @@ func TestExtra_Validate(t *testing.T) {
 			name: "removed client secret",
 			obj: &provisioning.Connection{
 				Spec: provisioning.ConnectionSpec{
-					Type:  provisioning.GitlabConnectionType,
+					Type:  provisioning.GitlabOAuthConnectionType,
 					OAuth: &provisioning.ConnectionOAuthConfig{ClientID: "client-id"},
 				},
 				Secure: provisioning.ConnectionSecure{
@@ -256,7 +256,7 @@ func TestExtra_Validate(t *testing.T) {
 			name: "forbidden private key",
 			obj: &provisioning.Connection{
 				Spec: provisioning.ConnectionSpec{
-					Type:  provisioning.GitlabConnectionType,
+					Type:  provisioning.GitlabOAuthConnectionType,
 					OAuth: &provisioning.ConnectionOAuthConfig{ClientID: "client-id"},
 				},
 				Secure: provisioning.ConnectionSecure{
@@ -270,7 +270,7 @@ func TestExtra_Validate(t *testing.T) {
 			name: "provider-specific spec errors are appended",
 			obj: &provisioning.Connection{
 				Spec: provisioning.ConnectionSpec{
-					Type:  provisioning.GitlabConnectionType,
+					Type:  provisioning.GitlabOAuthConnectionType,
 					OAuth: &provisioning.ConnectionOAuthConfig{ClientID: "client-id"},
 				},
 				Secure: provisioning.ConnectionSecure{
@@ -286,7 +286,7 @@ func TestExtra_Validate(t *testing.T) {
 			name: "valid",
 			obj: &provisioning.Connection{
 				Spec: provisioning.ConnectionSpec{
-					Type:  provisioning.GitlabConnectionType,
+					Type:  provisioning.GitlabOAuthConnectionType,
 					OAuth: &provisioning.ConnectionOAuthConfig{ClientID: "client-id"},
 				},
 				Secure: provisioning.ConnectionSecure{
@@ -317,7 +317,7 @@ func TestExtra_Validate(t *testing.T) {
 func newTestExtra(t *testing.T, secure *connection.MockSecureValues, validateSpec oauth.ValidateSpecFunc) connection.Extra {
 	return oauth.NewExtra(
 		func(*provisioning.Connection) connection.SecureValues { return secure },
-		provisioning.GitlabConnectionType,
+		provisioning.GitlabOAuthConnectionType,
 		provisioning.GitLabRepositoryType,
 		func(_ provisioning.ConnectionSpec, _ string) (oauth.Provider, error) {
 			return oauth.NewMockProvider(t), nil

--- a/apps/provisioning/pkg/connection/validator_test.go
+++ b/apps/provisioning/pkg/connection/validator_test.go
@@ -370,7 +370,7 @@ func TestAdmissionValidator_Validate_DryRun(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: provisioning.ConnectionSpec{
 					Title: "Test Connection",
-					Type:  provisioning.GitlabConnectionType,
+					Type:  provisioning.GitlabOAuthConnectionType,
 					OAuth: &provisioning.ConnectionOAuthConfig{
 						ClientID: "client-123",
 					},

--- a/apps/provisioning/pkg/generated/applyconfiguration/provisioning/v0alpha1/connectionspec.go
+++ b/apps/provisioning/pkg/generated/applyconfiguration/provisioning/v0alpha1/connectionspec.go
@@ -26,7 +26,7 @@ type ConnectionSpecApplyConfiguration struct {
 	// Only applicable when provider is "githubEnterprise"
 	GitHubEnterprise *GitHubEnterpriseConnectionConfigApplyConfiguration `json:"githubEnterprise,omitempty"`
 	// Bitbucket connection configuration
-	// Only applicable when provider is "bitbucket"
+	// Only applicable when provider is "bitbucketOAuth"
 	Bitbucket *BitbucketConnectionConfigApplyConfiguration `json:"bitbucket,omitempty"`
 	// OAuth app configuration shared by all OAuth app providers
 	OAuth *ConnectionOAuthConfigApplyConfiguration `json:"oauth,omitempty"`

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2602,6 +2602,12 @@ min_sync_interval = 10s
 # Grafana Enterprise additionally supports bitbucket and gitlab.
 repository_types =
 
+# List of enabled connection types, separated by |.
+# When empty, defaults are applied by each subsystem.
+# Supported types: github.
+# Grafana Enterprise additionally supports githubEnterprise, bitbucketOAuth, and gitlabOAuth.
+connection_types =
+
 # Maximum number of repositories allowed. Default is 10.
 # Set to 0 for unlimited repositories.
 max_repositories = 10

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2906,7 +2906,7 @@ Supported types: `local`, `git`, `github`. Grafana Enterprise additionally suppo
 
 #### `connection_types`
 
-List of enabled connection types, separated by `|`. When empty, all registered connection types are enabled.
+List of enabled connection types, separated by `|`. When empty, defaults are applied by each subsystem.
 
 Supported types: `github`. Grafana Enterprise additionally supports `githubEnterprise`, `bitbucketOAuth`, and `gitlabOAuth`.
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2904,6 +2904,12 @@ List of enabled repository types, separated by `|`. When empty, defaults are app
 
 Supported types: `local`, `git`, `github`. Grafana Enterprise additionally supports `bitbucket` and `gitlab`.
 
+#### `connection_types`
+
+List of enabled connection types, separated by `|`. When empty, all registered connection types are enabled.
+
+Supported types: `github`. Grafana Enterprise additionally supports `githubEnterprise`, `bitbucketOAuth`, and `gitlabOAuth`.
+
 #### `max_repositories`
 
 Maximum number of repositories allowed. Default is `10`. Set to `0` for unlimited repositories.

--- a/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
@@ -1499,7 +1499,7 @@ export type ConnectionWebhookConfig = {
   disabled?: boolean;
 };
 export type ConnectionSpec = {
-  /** Bitbucket connection configuration Only applicable when provider is "bitbucket" */
+  /** Bitbucket connection configuration Only applicable when provider is "bitbucketOAuth" */
   bitbucket?: BitbucketConnectionConfig;
   /** The connection description */
   description?: string;
@@ -1518,7 +1518,7 @@ export type ConnectionSpec = {
      - `"github"`
      - `"githubEnterprise"`
      - `"gitlab"` */
-  type: 'bitbucket' | 'github' | 'githubEnterprise' | 'gitlab';
+  type: 'bitbucketOAuth' | 'github' | 'githubEnterprise' | 'gitlabOAuth';
   /** The connection URL */
   url?: string;
   /** Webhook configuration for this connection */
@@ -2290,6 +2290,8 @@ export type RepositoryViewList = {
   allowedTargets?: ('folder' | 'folderless' | 'instance')[];
   /** APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources */
   apiVersion?: string;
+  /** AvailableConnectionTypes is the list of connection types supported in this instance */
+  availableConnectionTypes?: ('bitbucketOAuth' | 'github' | 'githubEnterprise' | 'gitlabOAuth')[];
   /** AvailableRepositoryTypes is the list of repository types supported in this instance (e.g. git, bitbucket, github, etc) */
   availableRepositoryTypes?: ('bitbucket' | 'git' | 'github' | 'githubEnterprise' | 'gitlab' | 'local')[];
   /** AvailableResources is the list of resource types declared for provisioning in this instance, including disabled ones (see SupportedResource.Disabled). */

--- a/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
@@ -1514,10 +1514,10 @@ export type ConnectionSpec = {
   /** The connection provider type
     
     Possible enum values:
-     - `"bitbucket"`
+     - `"bitbucketOAuth"`
      - `"github"`
      - `"githubEnterprise"`
-     - `"gitlab"` */
+     - `"gitlabOAuth"` */
   type: 'bitbucketOAuth' | 'github' | 'githubEnterprise' | 'gitlabOAuth';
   /** The connection URL */
   url?: string;

--- a/packages/grafana-openapi/src/apis/provisioning.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/provisioning.grafana.app-v0alpha1.json
@@ -4127,7 +4127,7 @@
             "default": ""
           },
           "type": {
-            "description": "The connection provider type\n\nPossible enum values:\n - `\"bitbucket\"`\n - `\"github\"`\n - `\"githubEnterprise\"`\n - `\"gitlab\"`",
+            "description": "The connection provider type\n\nPossible enum values:\n - `\"bitbucketOAuth\"`\n - `\"github\"`\n - `\"githubEnterprise\"`\n - `\"gitlabOAuth\"`",
             "type": "string",
             "default": "",
             "enum": ["bitbucketOAuth", "github", "githubEnterprise", "gitlabOAuth"]

--- a/packages/grafana-openapi/src/apis/provisioning.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/provisioning.grafana.app-v0alpha1.json
@@ -4086,7 +4086,7 @@
         "required": ["title", "type"],
         "properties": {
           "bitbucket": {
-            "description": "Bitbucket connection configuration Only applicable when provider is \"bitbucket\"",
+            "description": "Bitbucket connection configuration Only applicable when provider is \"bitbucketOAuth\"",
             "allOf": [
               {
                 "$ref": "#/components/schemas/BitbucketConnectionConfig"
@@ -4130,7 +4130,7 @@
             "description": "The connection provider type\n\nPossible enum values:\n - `\"bitbucket\"`\n - `\"github\"`\n - `\"githubEnterprise\"`\n - `\"gitlab\"`",
             "type": "string",
             "default": "",
-            "enum": ["bitbucket", "github", "githubEnterprise", "gitlab"]
+            "enum": ["bitbucketOAuth", "github", "githubEnterprise", "gitlabOAuth"]
           },
           "url": {
             "description": "The connection URL",
@@ -5685,6 +5685,15 @@
           "apiVersion": {
             "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
             "type": "string"
+          },
+          "availableConnectionTypes": {
+            "description": "AvailableConnectionTypes is the list of connection types supported in this instance",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": "",
+              "enum": ["bitbucketOAuth", "github", "githubEnterprise", "gitlabOAuth"]
+            }
           },
           "availableRepositoryTypes": {
             "description": "AvailableRepositoryTypes is the list of repository types supported in this instance (e.g. git, bitbucket, github, etc)",

--- a/packages/grafana-openapi/src/apis/provisioning.grafana.app-v1beta1.json
+++ b/packages/grafana-openapi/src/apis/provisioning.grafana.app-v1beta1.json
@@ -4040,7 +4040,7 @@
             "default": ""
           },
           "type": {
-            "description": "The connection provider type\n\nPossible enum values:\n - `\"bitbucket\"`\n - `\"github\"`\n - `\"githubEnterprise\"`\n - `\"gitlab\"`",
+            "description": "The connection provider type\n\nPossible enum values:\n - `\"bitbucketOAuth\"`\n - `\"github\"`\n - `\"githubEnterprise\"`\n - `\"gitlabOAuth\"`",
             "type": "string",
             "default": "",
             "enum": ["bitbucketOAuth", "github", "githubEnterprise", "gitlabOAuth"]

--- a/packages/grafana-openapi/src/apis/provisioning.grafana.app-v1beta1.json
+++ b/packages/grafana-openapi/src/apis/provisioning.grafana.app-v1beta1.json
@@ -4019,7 +4019,7 @@
         "required": ["title", "type"],
         "properties": {
           "bitbucket": {
-            "description": "Bitbucket connection configuration Only applicable when provider is \"bitbucket\""
+            "description": "Bitbucket connection configuration Only applicable when provider is \"bitbucketOAuth\""
           },
           "description": {
             "description": "The connection description",
@@ -4043,7 +4043,7 @@
             "description": "The connection provider type\n\nPossible enum values:\n - `\"bitbucket\"`\n - `\"github\"`\n - `\"githubEnterprise\"`\n - `\"gitlab\"`",
             "type": "string",
             "default": "",
-            "enum": ["bitbucket", "github", "githubEnterprise", "gitlab"]
+            "enum": ["bitbucketOAuth", "github", "githubEnterprise", "gitlabOAuth"]
           },
           "url": {
             "description": "The connection URL",
@@ -5271,6 +5271,15 @@
           "apiVersion": {
             "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
             "type": "string"
+          },
+          "availableConnectionTypes": {
+            "description": "AvailableConnectionTypes is the list of connection types supported in this instance",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": "",
+              "enum": ["bitbucketOAuth", "github", "githubEnterprise", "gitlabOAuth"]
+            }
           },
           "availableRepositoryTypes": {
             "description": "AvailableRepositoryTypes is the list of repository types supported in this instance (e.g. git, bitbucket, github, etc)",

--- a/packages/grafana-test-utils/src/handlers/apis/provisioning.grafana.app/v0alpha1/handlers.ts
+++ b/packages/grafana-test-utils/src/handlers/apis/provisioning.grafana.app/v0alpha1/handlers.ts
@@ -8,7 +8,6 @@ const defaultSettings = {
   items: [],
   allowImageRendering: true,
   availableRepositoryTypes: ['github', 'gitlab', 'bitbucket', 'git', 'local'],
-  availableConnectionTypes: ['github', 'gitlabOAuth', 'bitbucketOAuth'],
 };
 
 const defaultStats = {

--- a/packages/grafana-test-utils/src/handlers/apis/provisioning.grafana.app/v0alpha1/handlers.ts
+++ b/packages/grafana-test-utils/src/handlers/apis/provisioning.grafana.app/v0alpha1/handlers.ts
@@ -8,6 +8,7 @@ const defaultSettings = {
   items: [],
   allowImageRendering: true,
   availableRepositoryTypes: ['github', 'gitlab', 'bitbucket', 'git', 'local'],
+  availableConnectionTypes: ['github', 'gitlabOAuth', 'bitbucketOAuth'],
 };
 
 const defaultStats = {

--- a/pkg/operators/provisioning/config.go
+++ b/pkg/operators/provisioning/config.go
@@ -104,6 +104,7 @@ type ControllerConfig struct {
 // local_permitted_prefixes =
 // [provisioning]
 // repository_types =
+// connection_types =
 // [nats]
 // # when enabled, the informers take their watch from NATS instead of the
 // # apiserver watch; operators use an external NATS (no embedded server).
@@ -515,13 +516,15 @@ func (c *ControllerConfig) ConnectionFactory() (connection.Factory, error) {
 		return nil, err
 	}
 
-	// Build enabled types from the extras
-	enabledTypes := make(map[provisioning.ConnectionType]struct{})
-	for _, extra := range extras {
-		enabledTypes[extra.Type()] = struct{}{}
+	types := c.Settings.ProvisioningConnectionTypes
+	if len(types) == 0 {
+		types = make([]string, 0, len(extras))
+		for _, extra := range extras {
+			types = append(types, string(extra.Type()))
+		}
 	}
 
-	connectionFactory, err := connection.ProvideFactory(enabledTypes, extras)
+	connectionFactory, err := connection.ProvideFactory(connection.ToConnectionTypes(types), extras)
 	if err != nil {
 		return nil, fmt.Errorf("create connection factory: %w", err)
 	}

--- a/pkg/operators/provisioning/config.go
+++ b/pkg/operators/provisioning/config.go
@@ -518,10 +518,7 @@ func (c *ControllerConfig) ConnectionFactory() (connection.Factory, error) {
 
 	types := c.Settings.ProvisioningConnectionTypes
 	if len(types) == 0 {
-		types = make([]string, 0, len(extras))
-		for _, extra := range extras {
-			types = append(types, string(extra.Type()))
-		}
+		types = defaultConnectionTypes(extras)
 	}
 
 	connectionFactory, err := connection.ProvideFactory(connection.ToConnectionTypes(types), extras)
@@ -750,4 +747,14 @@ func NewDirectConfigProvider(cfg *rest.Config) apiserver.RestConfigProvider {
 
 func (r *directConfigProvider) GetRestConfig(ctx context.Context) (*rest.Config, error) {
 	return r.cfg, nil
+}
+
+func defaultConnectionTypes(extras []connection.Extra) []string {
+	types := []string{string(provisioning.GithubConnectionType)}
+	for _, extra := range extras {
+		if extra.Type() == provisioning.GithubEnterpriseConnectionType {
+			types = append(types, string(extra.Type()))
+		}
+	}
+	return types
 }

--- a/pkg/operators/provisioning/config_test.go
+++ b/pkg/operators/provisioning/config_test.go
@@ -1,0 +1,27 @@
+package provisioning
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	apisprovisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/apps/provisioning/pkg/connection"
+)
+
+func TestDefaultConnectionTypes(t *testing.T) {
+	registeredTypes := []apisprovisioning.ConnectionType{
+		apisprovisioning.GithubConnectionType,
+		apisprovisioning.GithubEnterpriseConnectionType,
+		apisprovisioning.BitbucketOAuthConnectionType,
+		apisprovisioning.GitlabOAuthConnectionType,
+	}
+	extras := make([]connection.Extra, 0, len(registeredTypes))
+	for _, connectionType := range registeredTypes {
+		extra := connection.NewMockExtra(t)
+		extra.On("Type").Return(connectionType)
+		extras = append(extras, extra)
+	}
+
+	require.ElementsMatch(t, []string{"github", "githubEnterprise"}, defaultConnectionTypes(extras))
+}

--- a/pkg/registry/apis/provisioning/extras/register.go
+++ b/pkg/registry/apis/provisioning/extras/register.go
@@ -92,9 +92,8 @@ func ProvideQuotaGetter(cfg *setting.Cfg) quotas.QuotaGetter {
 func ProvideConnectionFactoryFromConfig(cfg *setting.Cfg, extras []connection.Extra) (connection.Factory, error) {
 	types := cfg.ProvisioningConnectionTypes
 	if len(types) == 0 {
-		for _, extra := range extras {
-			types = append(types, string(extra.Type()))
-		}
+		// Enforcing default connection values if settings are not set
+		types = []string{string(apisprovisioning.GithubConnectionType)}
 	}
 
 	return connection.ProvideFactory(connection.ToConnectionTypes(types), extras)

--- a/pkg/registry/apis/provisioning/extras/register.go
+++ b/pkg/registry/apis/provisioning/extras/register.go
@@ -90,10 +90,11 @@ func ProvideQuotaGetter(cfg *setting.Cfg) quotas.QuotaGetter {
 }
 
 func ProvideConnectionFactoryFromConfig(cfg *setting.Cfg, extras []connection.Extra) (connection.Factory, error) {
-	types := cfg.ProvisioningRepositoryTypes
+	types := cfg.ProvisioningConnectionTypes
 	if len(types) == 0 {
-		// Enforcing default connection values if settings are not set
-		types = []string{"github"}
+		for _, extra := range extras {
+			types = append(types, string(extra.Type()))
+		}
 	}
 
 	return connection.ProvideFactory(connection.ToConnectionTypes(types), extras)

--- a/pkg/registry/apis/provisioning/routes.go
+++ b/pkg/registry/apis/provisioning/routes.go
@@ -183,6 +183,7 @@ func (b *APIBuilder) handleSettings(w http.ResponseWriter, r *http.Request) {
 		Items:                    make([]provisioning.RepositoryView, len(all)),
 		AllowedTargets:           b.allowedTargets,
 		AvailableRepositoryTypes: b.repoFactory.Types(),
+		AvailableConnectionTypes: b.connectionFactory.Types(),
 		AvailableResources:       availableResources,
 		AllowImageRendering:      b.allowImageRendering,
 		MaxRepositories:          quotaStatus.MaxRepositories,

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -196,6 +196,7 @@ type Cfg struct {
 	ProvisioningAllowInsecure                 bool // allow http:// repository URLs together with a token (cleartext credentials); local/dev only
 	ProvisioningMinSyncInterval               time.Duration
 	ProvisioningRepositoryTypes               []string
+	ProvisioningConnectionTypes               []string
 	ProvisioningLokiURL                       string
 	ProvisioningLokiUser                      string
 	ProvisioningLokiPassword                  string
@@ -2543,6 +2544,19 @@ func (cfg *Cfg) readProvisioningSettings(iniFile *ini.File) error {
 			}
 
 			cfg.ProvisioningRepositoryTypes[i] = s
+		}
+	}
+
+	connectionTypes := strings.TrimSpace(valueAsString(iniFile.Section("provisioning"), "connection_types", ""))
+	if connectionTypes != "|" && connectionTypes != "" {
+		cfg.ProvisioningConnectionTypes = strings.Split(connectionTypes, "|")
+		for i, s := range cfg.ProvisioningConnectionTypes {
+			s = strings.TrimSpace(s)
+			if s == "" {
+				return fmt.Errorf("a provisioning connection type is empty in '%s' (at index %d)", connectionTypes, i)
+			}
+
+			cfg.ProvisioningConnectionTypes[i] = s
 		}
 	}
 

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
@@ -4448,7 +4448,7 @@
         ],
         "properties": {
           "bitbucket": {
-            "description": "Bitbucket connection configuration Only applicable when provider is \"bitbucket\"",
+            "description": "Bitbucket connection configuration Only applicable when provider is \"bitbucketOAuth\"",
             "allOf": [
               {
                 "$ref": "#/components/schemas/com.github.grafana.grafana.apps.provisioning.pkg.apis.provisioning.v0alpha1.BitbucketConnectionConfig"
@@ -4493,10 +4493,10 @@
             "type": "string",
             "default": "",
             "enum": [
-              "bitbucket",
+              "bitbucketOAuth",
               "github",
               "githubEnterprise",
-              "gitlab"
+              "gitlabOAuth"
             ]
           },
           "url": {
@@ -6163,6 +6163,20 @@
           "apiVersion": {
             "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
             "type": "string"
+          },
+          "availableConnectionTypes": {
+            "description": "AvailableConnectionTypes is the list of connection types supported in this instance",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": "",
+              "enum": [
+                "bitbucketOAuth",
+                "github",
+                "githubEnterprise",
+                "gitlabOAuth"
+              ]
+            }
           },
           "availableRepositoryTypes": {
             "description": "AvailableRepositoryTypes is the list of repository types supported in this instance (e.g. git, bitbucket, github, etc)",

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
@@ -4489,7 +4489,7 @@
             "default": ""
           },
           "type": {
-            "description": "The connection provider type\n\nPossible enum values:\n - `\"bitbucket\"`\n - `\"github\"`\n - `\"githubEnterprise\"`\n - `\"gitlab\"`",
+            "description": "The connection provider type\n\nPossible enum values:\n - `\"bitbucketOAuth\"`\n - `\"github\"`\n - `\"githubEnterprise\"`\n - `\"gitlabOAuth\"`",
             "type": "string",
             "default": "",
             "enum": [

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v1beta1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v1beta1.json
@@ -4402,7 +4402,7 @@
             "default": ""
           },
           "type": {
-            "description": "The connection provider type\n\nPossible enum values:\n - `\"bitbucket\"`\n - `\"github\"`\n - `\"githubEnterprise\"`\n - `\"gitlab\"`",
+            "description": "The connection provider type\n\nPossible enum values:\n - `\"bitbucketOAuth\"`\n - `\"github\"`\n - `\"githubEnterprise\"`\n - `\"gitlabOAuth\"`",
             "type": "string",
             "default": "",
             "enum": [

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v1beta1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v1beta1.json
@@ -4381,7 +4381,7 @@
         ],
         "properties": {
           "bitbucket": {
-            "description": "Bitbucket connection configuration Only applicable when provider is \"bitbucket\""
+            "description": "Bitbucket connection configuration Only applicable when provider is \"bitbucketOAuth\""
           },
           "description": {
             "description": "The connection description",
@@ -4406,10 +4406,10 @@
             "type": "string",
             "default": "",
             "enum": [
-              "bitbucket",
+              "bitbucketOAuth",
               "github",
               "githubEnterprise",
-              "gitlab"
+              "gitlabOAuth"
             ]
           },
           "url": {
@@ -5749,6 +5749,20 @@
           "apiVersion": {
             "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
             "type": "string"
+          },
+          "availableConnectionTypes": {
+            "description": "AvailableConnectionTypes is the list of connection types supported in this instance",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": "",
+              "enum": [
+                "bitbucketOAuth",
+                "github",
+                "githubEnterprise",
+                "gitlabOAuth"
+              ]
+            }
           },
           "availableRepositoryTypes": {
             "description": "AvailableRepositoryTypes is the list of repository types supported in this instance (e.g. git, bitbucket, github, etc)",

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -1511,6 +1511,12 @@ func WithRepositoryTypes(types []string) GrafanaOption {
 	}
 }
 
+func WithConnectionTypes(types []string) GrafanaOption {
+	return func(opts *testinfra.GrafanaOpts) {
+		opts.ProvisioningConnectionTypes = types
+	}
+}
+
 func WithProvisioningPublicRootURL(url string) GrafanaOption {
 	return func(opts *testinfra.GrafanaOpts) {
 		opts.ProvisioningPublicRootURL = url

--- a/pkg/tests/apis/provisioning/settings_stats_auth_test.go
+++ b/pkg/tests/apis/provisioning/settings_stats_auth_test.go
@@ -103,6 +103,18 @@ func TestIntegrationProvisioning_SettingsAuthorization(t *testing.T) {
 		require.Equal(t, int64(1000), settings.MaxRepositories, "MaxRepositories should be 1000 when configured")
 	})
 
+	t.Run("settings endpoint includes GitHub connections by default", func(t *testing.T) {
+		settings := &provisioning.RepositoryViewList{}
+		result := helper.AdminREST.Get().
+			Namespace("default").
+			Resource("settings").
+			Do(t.Context())
+
+		require.NoError(t, result.Error(), "should be able to GET settings")
+		require.NoError(t, result.Into(settings), "should be able to unmarshal settings response")
+		require.Contains(t, settings.AvailableConnectionTypes, provisioning.GithubConnectionType)
+	})
+
 	t.Run("settings endpoint surfaces the default supported resources, enabled and disabled", func(t *testing.T) {
 		settings := &provisioning.RepositoryViewList{}
 		result := helper.AdminREST.Get().

--- a/pkg/tests/apis/provisioning/v1beta1/connection_test.go
+++ b/pkg/tests/apis/provisioning/v1beta1/connection_test.go
@@ -102,7 +102,7 @@ func TestIntegrationV1Beta1Connection_Create_GitLab(t *testing.T) {
 		},
 		Spec: provisioning.ConnectionSpec{
 			Title: "Test GitLab Connection",
-			Type:  provisioning.GitlabConnectionType,
+			Type:  provisioning.GitlabOAuthConnectionType,
 			OAuth: &provisioning.ConnectionOAuthConfig{
 				ClientID: "gitlab-client-123",
 			},
@@ -123,7 +123,7 @@ func TestIntegrationV1Beta1Connection_Create_GitLab(t *testing.T) {
 
 	createdConn, err := common.FromUnstructured[provisioning.Connection](created)
 	require.NoError(t, err)
-	require.Equal(t, provisioning.GitlabConnectionType, createdConn.Spec.Type)
+	require.Equal(t, provisioning.GitlabOAuthConnectionType, createdConn.Spec.Type)
 	require.Equal(t, "gitlab-client-123", createdConn.Spec.OAuth.ClientID)
 
 	// Clean up. Retry on transient 409 conflicts: unified storage guards the delete with the object's
@@ -157,7 +157,7 @@ func TestIntegrationV1Beta1Connection_Create_Bitbucket(t *testing.T) {
 		},
 		Spec: provisioning.ConnectionSpec{
 			Title: "Test Bitbucket Connection",
-			Type:  provisioning.BitbucketConnectionType,
+			Type:  provisioning.BitbucketOAuthConnectionType,
 			OAuth: &provisioning.ConnectionOAuthConfig{
 				ClientID: "bitbucket-client-456",
 			},
@@ -178,7 +178,7 @@ func TestIntegrationV1Beta1Connection_Create_Bitbucket(t *testing.T) {
 
 	createdConn, err := common.FromUnstructured[provisioning.Connection](created)
 	require.NoError(t, err)
-	require.Equal(t, provisioning.BitbucketConnectionType, createdConn.Spec.Type)
+	require.Equal(t, provisioning.BitbucketOAuthConnectionType, createdConn.Spec.Type)
 	require.Equal(t, "bitbucket-client-456", createdConn.Spec.OAuth.ClientID)
 
 	// Clean up. Retry on transient 409 conflicts: unified storage guards the delete with the object's

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -895,6 +895,12 @@ func createGrafDir(t *testing.T, tmpDir string, opts GrafanaOpts) (string, strin
 		_, err = provisioningSect.NewKey("repository_types", strings.Join(opts.ProvisioningRepositoryTypes, "|"))
 		require.NoError(t, err)
 	}
+	if len(opts.ProvisioningConnectionTypes) > 0 {
+		provisioningSect, err := getOrCreateSection("provisioning")
+		require.NoError(t, err)
+		_, err = provisioningSect.NewKey("connection_types", strings.Join(opts.ProvisioningConnectionTypes, "|"))
+		require.NoError(t, err)
+	}
 	if opts.ProvisioningMaxResourcesPerRepository > 0 {
 		provisioningSect, err := getOrCreateSection("provisioning")
 		require.NoError(t, err)
@@ -1143,6 +1149,7 @@ type GrafanaOpts struct {
 	ProvisioningAllowInsecure             bool
 	ProvisioningPublicRootURL             string
 	ProvisioningRepositoryTypes           []string
+	ProvisioningConnectionTypes           []string
 	ProvisioningResources                 []string
 	ProvisioningMaxResourcesPerRepository int64
 	ProvisioningMaxRepositories           int64

--- a/public/app/features/provisioning/Connection/ConnectionForm.test.tsx
+++ b/public/app/features/provisioning/Connection/ConnectionForm.test.tsx
@@ -75,7 +75,7 @@ describe('ConnectionForm', () => {
       mockComboboxRect();
       server.use(
         http.get(`${BASE}/settings`, () =>
-          HttpResponse.json({ availableRepositoryTypes: ['github', 'githubEnterprise'] })
+          HttpResponse.json({ availableConnectionTypes: ['github', 'githubEnterprise'] })
         )
       );
 

--- a/public/app/features/provisioning/Connection/ConnectionForm.test.tsx
+++ b/public/app/features/provisioning/Connection/ConnectionForm.test.tsx
@@ -75,7 +75,7 @@ describe('ConnectionForm', () => {
       mockComboboxRect();
       server.use(
         http.get(`${BASE}/settings`, () =>
-          HttpResponse.json({ availableConnectionTypes: ['github', 'githubEnterprise'] })
+          HttpResponse.json({ availableRepositoryTypes: ['github', 'githubEnterprise'] })
         )
       );
 

--- a/public/app/features/provisioning/Connection/ConnectionForm.tsx
+++ b/public/app/features/provisioning/Connection/ConnectionForm.tsx
@@ -31,10 +31,12 @@ export function ConnectionForm({ data }: ConnectionFormProps) {
   const navigate = useNavigate();
 
   const { data: frontendSettings } = useGetFrontendSettingsQuery();
-  const availableTypes = frontendSettings?.availableRepositoryTypes ?? [];
+  const availableTypes = frontendSettings?.availableConnectionTypes ?? [];
   const providerOptions = [
-    // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
-    { value: 'github', label: 'GitHub' },
+    ...(availableTypes.includes('github')
+      ? // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
+        [{ value: 'github', label: 'GitHub' }]
+      : []),
     ...(availableTypes.includes('githubEnterprise')
       ? // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
         [{ value: 'githubEnterprise', label: 'GitHub Enterprise' }]

--- a/public/app/features/provisioning/Connection/ConnectionForm.tsx
+++ b/public/app/features/provisioning/Connection/ConnectionForm.tsx
@@ -31,12 +31,10 @@ export function ConnectionForm({ data }: ConnectionFormProps) {
   const navigate = useNavigate();
 
   const { data: frontendSettings } = useGetFrontendSettingsQuery();
-  const availableTypes = frontendSettings?.availableConnectionTypes ?? [];
+  const availableTypes = frontendSettings?.availableRepositoryTypes ?? [];
   const providerOptions = [
-    ...(availableTypes.includes('github')
-      ? // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
-        [{ value: 'github', label: 'GitHub' }]
-      : []),
+    // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
+    { value: 'github', label: 'GitHub' },
     ...(availableTypes.includes('githubEnterprise')
       ? // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
         [{ value: 'githubEnterprise', label: 'GitHub Enterprise' }]

--- a/public/app/features/provisioning/Connection/ConnectionList.test.tsx
+++ b/public/app/features/provisioning/Connection/ConnectionList.test.tsx
@@ -47,7 +47,7 @@ const mockConnections: Connection[] = [
   }),
   createMockConnection({
     metadata: { name: 'gitlab-conn-2' },
-    spec: { title: 'GitLab Connection 2', type: 'gitlab', url: 'https://gitlab.com/org2/repo2' },
+    spec: { title: 'GitLab Connection 2', type: 'gitlabOAuth', url: 'https://gitlab.com/org2/repo2' },
   }),
   createMockConnection({
     metadata: { name: 'another-github' },
@@ -83,6 +83,7 @@ describe('ConnectionList', () => {
         screen.getByRole('link', { name: 'https://github.com/settings/installations/103343308' })
       ).toBeInTheDocument();
       expect(screen.getByRole('link', { name: 'https://gitlab.com/org2/repo2' })).toBeInTheDocument();
+      expect(screen.getByRole('img', { name: 'GitLab' })).toBeInTheDocument();
       expect(
         screen.getByRole('link', { name: 'https://github.com/settings/installations/987654321' })
       ).toBeInTheDocument();

--- a/public/app/features/provisioning/Connection/ConnectionList.test.tsx
+++ b/public/app/features/provisioning/Connection/ConnectionList.test.tsx
@@ -47,7 +47,7 @@ const mockConnections: Connection[] = [
   }),
   createMockConnection({
     metadata: { name: 'gitlab-conn-2' },
-    spec: { title: 'GitLab Connection 2', type: 'gitlabOAuth', url: 'https://gitlab.com/org2/repo2' },
+    spec: { title: 'GitLab Connection 2', type: 'gitlab', url: 'https://gitlab.com/org2/repo2' },
   }),
   createMockConnection({
     metadata: { name: 'another-github' },

--- a/public/app/features/provisioning/Connection/ConnectionList.test.tsx
+++ b/public/app/features/provisioning/Connection/ConnectionList.test.tsx
@@ -47,7 +47,7 @@ const mockConnections: Connection[] = [
   }),
   createMockConnection({
     metadata: { name: 'gitlab-conn-2' },
-    spec: { title: 'GitLab Connection 2', type: 'gitlab', url: 'https://gitlab.com/org2/repo2' },
+    spec: { title: 'GitLab Connection 2', type: 'gitlabOAuth', url: 'https://gitlab.com/org2/repo2' },
   }),
   createMockConnection({
     metadata: { name: 'another-github' },

--- a/public/app/features/provisioning/Connection/ConnectionListItem.tsx
+++ b/public/app/features/provisioning/Connection/ConnectionListItem.tsx
@@ -21,8 +21,7 @@ export function ConnectionListItem({ connection, isSelected, onClick }: Props) {
   const title = spec?.title || name;
   const description = spec?.description;
   const url = spec?.url;
-  const providerType: RepoType =
-    spec?.type === 'bitbucketOAuth' ? 'bitbucket' : spec?.type === 'gitlabOAuth' ? 'gitlab' : (spec?.type ?? 'github');
+  const providerType: RepoType = spec?.type ?? 'github';
   return (
     <Card noMargin key={name} isSelected={isSelected} onClick={onClick}>
       <Card.Figure>

--- a/public/app/features/provisioning/Connection/ConnectionListItem.tsx
+++ b/public/app/features/provisioning/Connection/ConnectionListItem.tsx
@@ -21,7 +21,8 @@ export function ConnectionListItem({ connection, isSelected, onClick }: Props) {
   const title = spec?.title || name;
   const description = spec?.description;
   const url = spec?.url;
-  const providerType: RepoType = spec?.type ?? 'github';
+  const providerType: RepoType =
+    spec?.type === 'bitbucketOAuth' ? 'bitbucket' : spec?.type === 'gitlabOAuth' ? 'gitlab' : (spec?.type ?? 'github');
   return (
     <Card noMargin key={name} isSelected={isSelected} onClick={onClick}>
       <Card.Figure>


### PR DESCRIPTION
**What is this feature?**

Configures provisioning connection types independently from repository types. Unset configuration keeps all registered connection types enabled. The settings API now reports available connection types directly.

Bitbucket and GitLab OAuth connections use the explicit `bitbucketOAuth` and `gitlabOAuth` identifiers.

**Why do we need this feature?**

A repository provider can support multiple connection mechanisms. Deriving connection types from repository types prevents independent rollout and makes OAuth naming inconsistent.

Sister enterprise PR: https://github.com/grafana/grafana-enterprise/pull/13207

Design context: https://raintank-corp.slack.com/archives/C08T7NVBCUA/p1784836884084069

**Who is this feature for?**

Admins configuring Git Sync provisioning.

_Description generated by Pi._