### PR TITLE
Notebooks: Add dedicated RBAC actions with folder inheritance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -184,6 +184,7 @@
 /pkg/services/licensing/ @grafana/grafana-operator-experience-squad
 /pkg/services/dsquerierclient/ @grafana/grafana-datasources-core-services
 /pkg/services/navtree/ @grafana/grafana-frontend-navigation
+/pkg/services/notebooks/ @grafana/sharing-squad
 /pkg/services/notifications/ @grafana/grafana-backend-services-squad
 /pkg/services/org/ @grafana/identity-squad
 /pkg/services/preference/ @grafana/grafana-backend-services-squad

--- a/pkg/registry/apis/folders/sub_access.go
+++ b/pkg/registry/apis/folders/sub_access.go
@@ -92,8 +92,9 @@ var folderTierChecks = []folderTierCheck{
 }
 
 // Action bundles below mirror FolderViewActions / FolderEditActions /
-// FolderAdminActions and DashboardViewActions / DashboardEditActions /
-// DashboardAdminActions in pkg/services/accesscontrol/ossaccesscontrol/. They
+// FolderAdminActions, DashboardViewActions / DashboardEditActions /
+// DashboardAdminActions, and NotebookViewActions / NotebookEditActions /
+// NotebookAdminActions in pkg/services/accesscontrol/ossaccesscontrol/. They
 // are inlined to avoid pulling that package's heavy DI graph into the apiserver
 // edge. Keep in sync if either bundle changes.
 var (
@@ -108,6 +109,7 @@ var (
 		"folders:delete",
 		"folders:create",
 		"dashboards:create",
+		"notebooks:create",
 		"alert.rules:create",
 		"alert.rules:write",
 		"alert.rules:delete",
@@ -137,6 +139,16 @@ var (
 		"dashboards.permissions:read",
 		"dashboards.permissions:write",
 	}...)
+
+	notebookViewActions = []string{
+		"notebooks:read",
+	}
+	notebookEditActions = append(append([]string{}, notebookViewActions...), []string{
+		"notebooks:write",
+		"notebooks:delete",
+	}...)
+	// No notebook-specific admin actions yet (no permissions management); Admin equals Edit.
+	notebookAdminActions = append([]string{}, notebookEditActions...)
 )
 
 func (r *subAccessREST) getAccessInfo(ctx context.Context, name string) (*foldersV1.FolderAccessInfo, error) {
@@ -249,17 +261,20 @@ func actionsForTier(tier folderTier) map[string]bool {
 	var actions []string
 	switch tier {
 	case tierAdmin:
-		actions = make([]string, 0, len(folderAdminActions)+len(dashboardAdminActions))
+		actions = make([]string, 0, len(folderAdminActions)+len(dashboardAdminActions)+len(notebookAdminActions))
 		actions = append(actions, folderAdminActions...)
 		actions = append(actions, dashboardAdminActions...)
+		actions = append(actions, notebookAdminActions...)
 	case tierEditor:
-		actions = make([]string, 0, len(folderEditActions)+len(dashboardEditActions))
+		actions = make([]string, 0, len(folderEditActions)+len(dashboardEditActions)+len(notebookEditActions))
 		actions = append(actions, folderEditActions...)
 		actions = append(actions, dashboardEditActions...)
+		actions = append(actions, notebookEditActions...)
 	case tierViewer:
-		actions = make([]string, 0, len(folderViewActions)+len(dashboardViewActions))
+		actions = make([]string, 0, len(folderViewActions)+len(dashboardViewActions)+len(notebookViewActions))
 		actions = append(actions, folderViewActions...)
 		actions = append(actions, dashboardViewActions...)
+		actions = append(actions, notebookViewActions...)
 	default:
 		return nil
 	}

--- a/pkg/registry/apis/folders/sub_access.go
+++ b/pkg/registry/apis/folders/sub_access.go
@@ -147,7 +147,7 @@ var (
 		"notebooks:write",
 		"notebooks:delete",
 	}...)
-	// No notebook-specific admin actions yet (no permissions management); Admin equals Edit.
+	// No notebook-specific admin actions (no per-notebook permissions management); Admin equals Edit.
 	notebookAdminActions = append([]string{}, notebookEditActions...)
 )
 

--- a/pkg/services/accesscontrol/ossaccesscontrol/folder.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/folder.go
@@ -3,6 +3,7 @@ package ossaccesscontrol
 import (
 	"context"
 	"errors"
+	"slices"
 
 	folderv1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
 	"github.com/grafana/grafana/pkg/api/routing"
@@ -17,6 +18,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/libraryelements"
 	"github.com/grafana/grafana/pkg/services/licensing"
+	"github.com/grafana/grafana/pkg/services/notebooks"
 	"github.com/grafana/grafana/pkg/services/team"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
@@ -33,6 +35,7 @@ var FolderEditActions = append(FolderViewActions, []string{
 	folder.ActionFoldersWrite,
 	folder.ActionFoldersDelete,
 	dashboards.ActionDashboardsCreate,
+	notebooks.ActionNotebooksCreate,
 	accesscontrol.ActionAlertingRuleCreate,
 	accesscontrol.ActionAlertingRuleUpdate,
 	accesscontrol.ActionAlertingRuleDelete,
@@ -58,7 +61,7 @@ func FolderFixedRoleRegistrations(wildcardSeed bool) []accesscontrol.RoleRegistr
 			DisplayName: "Viewer",
 			Description: "View all folders and dashboards.",
 			Group:       "Folders",
-			Permissions: accesscontrol.PermissionsForActions(append(DashboardViewActions, FolderViewActions...), folder.ScopeFoldersAll),
+			Permissions: accesscontrol.PermissionsForActions(slices.Concat(DashboardViewActions, NotebookViewActions, FolderViewActions), folder.ScopeFoldersAll),
 			Hidden:      true,
 		},
 		Grants: []string{"Viewer"},
@@ -70,7 +73,7 @@ func FolderFixedRoleRegistrations(wildcardSeed bool) []accesscontrol.RoleRegistr
 			DisplayName: "Editor",
 			Description: "Edit all folders and dashboards.",
 			Group:       "Folders",
-			Permissions: accesscontrol.PermissionsForActions(append(DashboardEditActions, FolderEditActions...), folder.ScopeFoldersAll),
+			Permissions: accesscontrol.PermissionsForActions(slices.Concat(DashboardEditActions, NotebookEditActions, FolderEditActions), folder.ScopeFoldersAll),
 			Hidden:      true,
 		},
 		Grants: []string{"Editor"},
@@ -82,7 +85,7 @@ func FolderFixedRoleRegistrations(wildcardSeed bool) []accesscontrol.RoleRegistr
 			DisplayName: "Admin",
 			Description: "Administer all folders and dashboards",
 			Group:       "folders",
-			Permissions: accesscontrol.PermissionsForActions(append(DashboardAdminActions, FolderAdminActions...), folder.ScopeFoldersAll),
+			Permissions: accesscontrol.PermissionsForActions(slices.Concat(DashboardAdminActions, NotebookAdminActions, FolderAdminActions), folder.ScopeFoldersAll),
 			Hidden:      true,
 		},
 		Grants: []string{"Admin"},
@@ -161,9 +164,9 @@ func ProvideFolderPermissions(
 			ServiceAccounts: true,
 		},
 		PermissionsToActions: map[string][]string{
-			"View":  append(DashboardViewActions, FolderViewActions...),
-			"Edit":  append(DashboardEditActions, FolderEditActions...),
-			"Admin": append(DashboardAdminActions, FolderAdminActions...),
+			"View":  slices.Concat(DashboardViewActions, NotebookViewActions, FolderViewActions),
+			"Edit":  slices.Concat(DashboardEditActions, NotebookEditActions, FolderEditActions),
+			"Admin": slices.Concat(DashboardAdminActions, NotebookAdminActions, FolderAdminActions),
 		},
 		ReaderRoleName:     permissionReaderRoleName,
 		WriterRoleName:     permissionWriterRoleName,

--- a/pkg/services/accesscontrol/ossaccesscontrol/notebook.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/notebook.go
@@ -6,8 +6,9 @@ import (
 
 // Notebook action sets mirror the dashboard ones (view/edit), minus annotations which notebooks
 // don't have. notebooks:create is folder-scoped, so it lives in FolderEditActions (see folder.go)
-// rather than here, matching how dashboards:create is handled. There is no notebook-specific admin
-// action yet (no permissions management), so Admin equals Edit.
+// rather than here, matching how dashboards:create is handled. There are no notebook-specific admin
+// actions (no per-notebook permissions management), so Admin equals Edit. The trash folder-admin
+// check is handled in the mapper via a set_permissions -> folders:admin route, not a granted action.
 var NotebookViewActions = []string{notebooks.ActionNotebooksRead}
 var NotebookEditActions = append(NotebookViewActions, []string{
 	notebooks.ActionNotebooksWrite,

--- a/pkg/services/accesscontrol/ossaccesscontrol/notebook.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/notebook.go
@@ -1,0 +1,16 @@
+package ossaccesscontrol
+
+import (
+	"github.com/grafana/grafana/pkg/services/notebooks"
+)
+
+// Notebook action sets mirror the dashboard ones (view/edit), minus annotations which notebooks
+// don't have. notebooks:create is folder-scoped, so it lives in FolderEditActions (see folder.go)
+// rather than here, matching how dashboards:create is handled. There is no notebook-specific admin
+// action yet (no permissions management), so Admin equals Edit.
+var NotebookViewActions = []string{notebooks.ActionNotebooksRead}
+var NotebookEditActions = append(NotebookViewActions, []string{
+	notebooks.ActionNotebooksWrite,
+	notebooks.ActionNotebooksDelete,
+}...)
+var NotebookAdminActions = NotebookEditActions

--- a/pkg/services/accesscontrol/resourcepermissions/service.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service.go
@@ -27,6 +27,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/licensing"
+	"github.com/grafana/grafana/pkg/services/notebooks"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginaccesscontrol"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts"
@@ -870,6 +871,7 @@ func (a *ActionSetSvc) RegisterActionSets(ctx context.Context, pluginID string, 
 
 func isActionSetEnabledResource(action string) bool {
 	return strings.HasPrefix(action, dashboards.ScopeDashboardsRoot) ||
+		strings.HasPrefix(action, notebooks.ScopeNotebooksRoot) ||
 		strings.HasPrefix(action, folder.ScopeFoldersRoot) ||
 		strings.HasPrefix(action, accesscontrol.AlertingRoutesKind) ||
 		strings.HasPrefix(action, serviceaccounts.ScopeServiceAccountRoot) ||

--- a/pkg/services/accesscontrol/resourcepermissions/service_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/licensing/licensingtest"
+	"github.com/grafana/grafana/pkg/services/notebooks"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
 	"github.com/grafana/grafana/pkg/services/quota/quotatest"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts"
@@ -832,6 +833,14 @@ func TestIsActionSetEnabledResource_ServiceAccount(t *testing.T) {
 	t.Run("serviceaccounts actions are enabled", func(t *testing.T) {
 		assert.True(t, isActionSetEnabledResource(serviceaccounts.ScopeServiceAccountRoot+":edit"))
 		assert.True(t, isActionSetEnabledResource(serviceaccounts.ScopeServiceAccountRoot+":admin"))
+	})
+}
+
+func TestIsActionSetEnabledResource_Notebook(t *testing.T) {
+	t.Run("notebooks actions are enabled", func(t *testing.T) {
+		assert.True(t, isActionSetEnabledResource(notebooks.ScopeNotebooksRoot+":view"))
+		assert.True(t, isActionSetEnabledResource(notebooks.ScopeNotebooksRoot+":edit"))
+		assert.True(t, isActionSetEnabledResource(notebooks.ScopeNotebooksRoot+":admin"))
 	})
 }
 

--- a/pkg/services/authz/rbac/mapper.go
+++ b/pkg/services/authz/rbac/mapper.go
@@ -174,6 +174,43 @@ func newDashboardTranslation() translation {
 	return dashTranslation
 }
 
+// newNotebookTranslation creates a translation for notebooks. Notebooks have their own
+// notebooks:* actions and a notebooks:uid: scope, but are folder-scoped like dashboards, so
+// their verbs map onto the folder action sets (folders:view/edit/admin) and folder grants
+// cover them. The notebooks:view/edit/admin object action sets (for per-notebook sharing) are
+// added later together with the notebook resource-permission service.
+func newNotebookTranslation() translation {
+	nbTranslation := newResourceTranslation("notebooks", "uid", true, nil)
+	// Notebooks have no permissions subresource yet, so drop the inherited permission verbs.
+	delete(nbTranslation.verbMapping, utils.VerbGetPermissions)
+	delete(nbTranslation.verbMapping, utils.VerbSetPermissions)
+
+	actionSetMapping := make(map[string][]string)
+	for verb, rbacAction := range nbTranslation.verbMapping {
+		var actionSets []string
+
+		// Notebook creation is only part of the folder action sets, so handle it separately.
+		if rbacAction == "notebooks:create" {
+			actionSets = append(actionSets, "folders:edit")
+			actionSets = append(actionSets, "folders:admin")
+		}
+
+		if slices.Contains(ossaccesscontrol.NotebookViewActions, rbacAction) {
+			actionSets = append(actionSets, "folders:view")
+		}
+		if slices.Contains(ossaccesscontrol.NotebookEditActions, rbacAction) {
+			actionSets = append(actionSets, "folders:edit")
+		}
+		if slices.Contains(ossaccesscontrol.NotebookAdminActions, rbacAction) {
+			actionSets = append(actionSets, "folders:admin")
+		}
+		actionSetMapping[verb] = actionSets
+	}
+
+	nbTranslation.actionSetMapping = actionSetMapping
+	return nbTranslation
+}
+
 // newFolderTranslation creates a translation for folders and also maps the actions to action sets
 func newFolderTranslation() translation {
 	folderTranslation := newResourceTranslation("folders", "uid", true, nil)
@@ -418,6 +455,7 @@ func NewMapperRegistry() MapperRegistry {
 		},
 		"dashboard.grafana.app": {
 			"dashboards":    newDashboardTranslation(),
+			"notebooks":     newNotebookTranslation(),
 			"librarypanels": newResourceTranslation("library.panels", "uid", true, nil),
 			// Annotations subresource for dashboards
 			// Uses dashboard scope (dashboards:uid:...) but annotation actions

--- a/pkg/services/authz/rbac/mapper.go
+++ b/pkg/services/authz/rbac/mapper.go
@@ -181,9 +181,6 @@ func newDashboardTranslation() translation {
 // added later together with the notebook resource-permission service.
 func newNotebookTranslation() translation {
 	nbTranslation := newResourceTranslation("notebooks", "uid", true, nil)
-	// Notebooks have no permissions subresource yet, so drop the inherited permission verbs.
-	delete(nbTranslation.verbMapping, utils.VerbGetPermissions)
-	delete(nbTranslation.verbMapping, utils.VerbSetPermissions)
 
 	actionSetMapping := make(map[string][]string)
 	for verb, rbacAction := range nbTranslation.verbMapping {
@@ -192,6 +189,13 @@ func newNotebookTranslation() translation {
 		// Notebook creation is only part of the folder action sets, so handle it separately.
 		if rbacAction == "notebooks:create" {
 			actionSets = append(actionSets, "folders:edit")
+			actionSets = append(actionSets, "folders:admin")
+		}
+		// The permission verbs come from the default translation. set_permissions is never a granted
+		// notebook action (no per-notebook permissions management) — it's mapped to folders:admin only
+		// so the trash folder-admin check (TrashAuthorizer.FolderAdmin) resolves. get_permissions
+		// falls through with no action set (nothing reads a notebook's permission list), so it's denied.
+		if rbacAction == "notebooks.permissions:write" {
 			actionSets = append(actionSets, "folders:admin")
 		}
 

--- a/pkg/services/authz/rbac/mapper_test.go
+++ b/pkg/services/authz/rbac/mapper_test.go
@@ -259,6 +259,43 @@ func TestMapper_ServiceAccountTranslation_ActionSets(t *testing.T) {
 	}
 }
 
+// TestMapperRegistry_Notebooks verifies notebooks have their own notebooks:* actions and a
+// notebooks:uid: scope, and — being folder-scoped like dashboards — map their verbs onto the
+// folder action sets so folder grants cover them.
+func TestMapperRegistry_Notebooks(t *testing.T) {
+	reg := NewMapperRegistry()
+	mapping, ok := reg.Get("dashboard.grafana.app", "notebooks", "")
+	require.True(t, ok)
+	require.NotNil(t, mapping)
+
+	// Dedicated notebook actions per verb.
+	for verb, want := range map[string]string{
+		utils.VerbGet:              "notebooks:read",
+		utils.VerbList:             "notebooks:read",
+		utils.VerbWatch:            "notebooks:read",
+		utils.VerbCreate:           "notebooks:create",
+		utils.VerbUpdate:           "notebooks:write",
+		utils.VerbPatch:            "notebooks:write",
+		utils.VerbDelete:           "notebooks:delete",
+		utils.VerbDeleteCollection: "notebooks:delete",
+	} {
+		action, ok := mapping.Action(verb)
+		require.True(t, ok, "verb %q should map to an action", verb)
+		assert.Equal(t, want, action, "verb %q", verb)
+	}
+
+	// Verbs map onto the folder action sets (read via all three, write/delete/create via edit+admin)
+	// so folder view/edit/admin grants cover notebooks.
+	assert.ElementsMatch(t, []string{"folders:view", "folders:edit", "folders:admin"}, mapping.ActionSets(utils.VerbGet))
+	assert.ElementsMatch(t, []string{"folders:edit", "folders:admin"}, mapping.ActionSets(utils.VerbCreate))
+	assert.ElementsMatch(t, []string{"folders:edit", "folders:admin"}, mapping.ActionSets(utils.VerbDelete))
+	assert.True(t, mapping.HasFolderSupport())
+
+	// Object scope stays in the notebook's own namespace.
+	assert.Equal(t, "notebooks:uid:", mapping.Prefix())
+	assert.Equal(t, "notebooks:uid:nb1", mapping.Scope("nb1"))
+}
+
 // TestMapperRegistry_AlertRules verifies the rules.alerting.grafana.app rule
 // resources map to the alert.rules:* actions, support folder inheritance, use a
 // rules-specific direct-scope prefix (so the per-object check never spuriously

--- a/pkg/services/authz/rbac/mapper_test.go
+++ b/pkg/services/authz/rbac/mapper_test.go
@@ -291,6 +291,13 @@ func TestMapperRegistry_Notebooks(t *testing.T) {
 	assert.ElementsMatch(t, []string{"folders:edit", "folders:admin"}, mapping.ActionSets(utils.VerbDelete))
 	assert.True(t, mapping.HasFolderSupport())
 
+	// set_permissions must resolve (to folders:admin) — the trash folder-admin check authorizes
+	// via this verb, so an unsupported verb here would break trash listing for folder admins.
+	setPerms, ok := mapping.Action(utils.VerbSetPermissions)
+	require.True(t, ok)
+	assert.Equal(t, "notebooks.permissions:write", setPerms)
+	assert.ElementsMatch(t, []string{"folders:admin"}, mapping.ActionSets(utils.VerbSetPermissions))
+
 	// Object scope stays in the notebook's own namespace.
 	assert.Equal(t, "notebooks:uid:", mapping.Prefix())
 	assert.Equal(t, "notebooks:uid:nb1", mapping.Scope("nb1"))

--- a/pkg/services/authz/rbac/service_test.go
+++ b/pkg/services/authz/rbac/service_test.go
@@ -243,6 +243,97 @@ func TestService_checkPermission(t *testing.T) {
 			expected: false,
 		},
 		{
+			name: "should allow reading a notebook via a folder permission",
+			permissions: []accesscontrol.Permission{
+				{
+					Scope:      "folders:uid:parent",
+					Kind:       "folders",
+					Attribute:  "uid",
+					Identifier: "parent",
+				},
+			},
+			folders: []store.Folder{
+				{UID: "parent"},
+				{UID: "child", ParentUID: new("parent")},
+			},
+			check: checkRequest{
+				Action:       "notebooks:read",
+				Group:        "dashboard.grafana.app",
+				Resource:     "notebooks",
+				Name:         "some_notebook",
+				ParentFolder: "child",
+			},
+			expected: true,
+		},
+		{
+			name: "should deny reading a notebook when the folder permission is on an unrelated folder",
+			permissions: []accesscontrol.Permission{
+				{
+					Scope:      "folders:uid:other",
+					Kind:       "folders",
+					Attribute:  "uid",
+					Identifier: "other",
+				},
+			},
+			folders: []store.Folder{
+				{UID: "parent"},
+				{UID: "child", ParentUID: new("parent")},
+				{UID: "other"},
+			},
+			check: checkRequest{
+				Action:       "notebooks:read",
+				Group:        "dashboard.grafana.app",
+				Resource:     "notebooks",
+				Name:         "some_notebook",
+				ParentFolder: "child",
+			},
+			expected: false,
+		},
+		{
+			name: "should allow creating a notebook in a folder the user can edit",
+			permissions: []accesscontrol.Permission{
+				{
+					Action:     "notebooks:create",
+					Scope:      "folders:uid:parent",
+					Kind:       "folders",
+					Attribute:  "uid",
+					Identifier: "parent",
+				},
+			},
+			folders: []store.Folder{{UID: "parent"}},
+			check: checkRequest{
+				Action:       "notebooks:create",
+				Group:        "dashboard.grafana.app",
+				Resource:     "notebooks",
+				Name:         "",
+				ParentFolder: "parent",
+				Verb:         utils.VerbCreate,
+			},
+			expected: true,
+		},
+		{
+			name: "should deny creating a notebook in a folder the user cannot edit",
+			permissions: []accesscontrol.Permission{
+				{
+					Action:     "notebooks:create",
+					Scope:      "folders:uid:parent",
+					Kind:       "folders",
+					Attribute:  "uid",
+					Identifier: "parent",
+				},
+			},
+			folders: []store.Folder{{UID: "parent"}, {UID: "other_parent"}},
+			check: checkRequest{
+				Action:       "notebooks:create",
+				Group:        "dashboard.grafana.app",
+				Resource:     "notebooks",
+				Name:         "",
+				ParentFolder: "other_parent",
+				Verb:         utils.VerbCreate,
+			},
+			expected: false,
+		},
+		{
 			name: "should allow if it's an any check",
 			permissions: []accesscontrol.Permission{
 				{

--- a/pkg/services/authz/zanzana/common/translations.go
+++ b/pkg/services/authz/zanzana/common/translations.go
@@ -7,6 +7,7 @@ import (
 	authlib "github.com/grafana/authlib/types"
 
 	dashboards "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
+	dashv2beta1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2beta1"
 	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
 	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 )
@@ -71,6 +72,9 @@ var (
 	dashboardGroup    = dashboards.DashboardResourceInfo.GroupResource().Group
 	dashboardResource = dashboards.DashboardResourceInfo.GroupResource().Resource
 
+	notebookGroup    = dashv2beta1.NotebookResourceInfo.GroupResource().Group
+	notebookResource = dashv2beta1.NotebookResourceInfo.GroupResource().Resource
+
 	iamGroup      = iamv0.TeamResourceInfo.GroupResource().Group
 	teamsResource = iamv0.TeamResourceInfo.GroupResource().Resource
 	usersResource = iamv0.UserResourceInfo.GroupResource().Resource
@@ -102,6 +106,14 @@ var resourceTranslations = map[string]resourceTranslation{
 			"dashboards:view":  newScopedMapping(RelationSetView, dashboardGroup, dashboardResource, ""),
 			"dashboards:edit":  newScopedMapping(RelationSetEdit, dashboardGroup, dashboardResource, ""),
 			"dashboards:admin": newScopedMapping(RelationSetAdmin, dashboardGroup, dashboardResource, ""),
+			// Notebooks (folder-inherited), scoped to the notebook group/resource
+			"notebooks:read":   newScopedMapping(RelationGet, notebookGroup, notebookResource, ""),
+			"notebooks:write":  newScopedMapping(RelationUpdate, notebookGroup, notebookResource, ""),
+			"notebooks:create": newScopedMapping(RelationCreate, notebookGroup, notebookResource, ""),
+			"notebooks:delete": newScopedMapping(RelationDelete, notebookGroup, notebookResource, ""),
+			"notebooks:view":   newScopedMapping(RelationSetView, notebookGroup, notebookResource, ""),
+			"notebooks:edit":   newScopedMapping(RelationSetEdit, notebookGroup, notebookResource, ""),
+			"notebooks:admin":  newScopedMapping(RelationSetAdmin, notebookGroup, notebookResource, ""),
 		},
 	},
 	KindDashboards: {
@@ -120,6 +132,21 @@ var resourceTranslations = map[string]resourceTranslation{
 			"dashboards:view":  newMapping(RelationSetView, ""),
 			"dashboards:edit":  newMapping(RelationSetEdit, ""),
 			"dashboards:admin": newMapping(RelationSetAdmin, ""),
+		},
+	},
+	KindNotebooks: {
+		typ:      TypeResource,
+		group:    notebookGroup,
+		resource: notebookResource,
+		mapping: map[string]actionMapping{
+			"notebooks:read":   newMapping(RelationGet, ""),
+			"notebooks:write":  newMapping(RelationUpdate, ""),
+			"notebooks:create": newMapping(RelationCreate, ""),
+			"notebooks:delete": newMapping(RelationDelete, ""),
+			// Action sets
+			"notebooks:view":  newMapping(RelationSetView, ""),
+			"notebooks:edit":  newMapping(RelationSetEdit, ""),
+			"notebooks:admin": newMapping(RelationSetAdmin, ""),
 		},
 	},
 	KindTeams: {

--- a/pkg/services/authz/zanzana/common/tuple.go
+++ b/pkg/services/authz/zanzana/common/tuple.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	dashboardV1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
+	dashv2beta1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2beta1"
 	folderV1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
 	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
@@ -42,6 +43,7 @@ const (
 )
 
 var (
+	KindNotebooks       string = dashv2beta1.NotebookResourceInfo.GroupResource().Resource
 	KindTeams           string = iamv0.TeamKind().GroupVersionResource().Resource
 	KindUsers           string = iamv0.UserKind().GroupVersionResource().Resource
 	KindServiceAccounts string = iamv0.ServiceAccountKind().GroupVersionResource().Resource

--- a/pkg/services/authz/zanzana/zanzana.go
+++ b/pkg/services/authz/zanzana/zanzana.go
@@ -69,6 +69,10 @@ const (
 )
 
 var (
+	// KindNotebooks is a var (not const) because common.KindNotebooks is derived from
+	// NotebookResourceInfo at init rather than a string constant.
+	KindNotebooks = common.KindNotebooks
+
 	ToAuthzExtTupleKey                  = common.ToAuthzExtTupleKey
 	ToAuthzExtTupleKeys                 = common.ToAuthzExtTupleKeys
 	ToAuthzExtTupleKeyWithoutCondition  = common.ToAuthzExtTupleKeyWithoutCondition

--- a/pkg/services/notebooks/accesscontrol.go
+++ b/pkg/services/notebooks/accesscontrol.go
@@ -1,0 +1,14 @@
+package notebooks
+
+// Notebooks are a folder-scoped resource in the dashboard.grafana.app group. They have their own
+// RBAC actions and (via the authz mapper) a notebooks:uid: scope, so notebook access is not
+// coupled to dashboard permissions. Permissions-management actions (notebooks.permissions:*) and
+// the notebooks:* scope helpers are added later with the notebook resource-permission service.
+const (
+	ScopeNotebooksRoot = "notebooks"
+
+	ActionNotebooksCreate = "notebooks:create"
+	ActionNotebooksRead   = "notebooks:read"
+	ActionNotebooksWrite  = "notebooks:write"
+	ActionNotebooksDelete = "notebooks:delete"
+)

--- a/pkg/services/notebooks/accesscontrol.go
+++ b/pkg/services/notebooks/accesscontrol.go
@@ -2,8 +2,8 @@ package notebooks
 
 // Notebooks are a folder-scoped resource in the dashboard.grafana.app group. They have their own
 // RBAC actions and (via the authz mapper) a notebooks:uid: scope, so notebook access is not
-// coupled to dashboard permissions. Permissions-management actions (notebooks.permissions:*) and
-// the notebooks:* scope helpers are added later with the notebook resource-permission service.
+// coupled to dashboard permissions. The notebooks:* scope helpers (provider/all-scope) are added
+// later with the notebook resource-permission service.
 const (
 	ScopeNotebooksRoot = "notebooks"
 


### PR DESCRIPTION
## What

  Notebooks (`dashboard.grafana.app/notebooks`) get their own RBAC actions — `notebooks:read/write/create/delete` with a `notebooks:uid:` scope — folded into the folder View/Edit/Admin action sets so folder permissions govern notebook access, the same way they do for dashboards. Notebook access is no longer coupled to dashboard permissions.

  ## Why

  Notebooks are a new folder-scoped resource with no RBAC of their own: under Unified Storage enforcement they'd fall back to a K8s-native action nobody holds (denied for everyone), and reusing `dashboards:read` makes a notebook and a same-UID dashboard in the same folder collide on the negative-authz cache key (`action+name+parent`), causing a transient wrong-deny. Dedicated actions authorize notebooks via folder inheritance and
  remove the collision.

  ## Scope & follow-ups

  Backend, folder-scoped enforcement only: folder Editors can create/update/delete notebooks and Viewers can read them, in the folders they're granted. Deferred (all additive on top of this): pickable `fixed:notebooks:*` roles (+ enterprise seeding), per-notebook sharing via a resource-permission service, and the notebook folder-placement UI that makes the folder scoping granular.

  ## Notes for reviewers

  - `isActionSetEnabledResource` gains a `notebooks` prefix — required, or the notebook action sets are silently dropped by action-set resolution. 
  - Folder coverage comes from adding the notebook actions to the folder action sets in `ossaccesscontrol/folder.go`; that's the load-bearing change for folder inheritance.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
