### PR TITLE
TableNG: Make gauge and sparkline cell widths account for cell padding and border

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/render-hooks.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/render-hooks.test.tsx
@@ -2,7 +2,7 @@
 import { render, renderHook, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import memoize from 'micro-memoize';
-import { type ComponentProps, createRef, isValidElement, type Key } from 'react';
+import { Children, type ComponentProps, createRef, isValidElement, type Key, type ReactNode } from 'react';
 
 import {
   createDataFrame,
@@ -21,8 +21,16 @@ import { getTextColorForBackground } from '../../../utils/colors';
 import { type PanelContext } from '../../PanelChrome';
 
 import { type HeaderCell } from './components/HeaderCell';
+import { TABLE } from './constants';
 import { type ColumnBuildConfig, useColumnBuilderFromFields, useDataGridRows } from './render-hooks';
-import { type FilterType, type NestedRowEntry, type TableColumn, type TableRow, type TableSummaryRow } from './types';
+import {
+  type FilterType,
+  type NestedRowEntry,
+  type TableCellRendererProps,
+  type TableColumn,
+  type TableRow,
+  type TableSummaryRow,
+} from './types';
 import { type ApplyFilterResult, applyFilter, getCellColorInlineStylesFactory } from './utils';
 
 // -----------------------------------------------------------------------------
@@ -286,6 +294,29 @@ function getHeaderCellProps(column: TableColumn): ComponentProps<typeof HeaderCe
   return node.props;
 }
 
+/**
+ * The width handed to a cell renderer is only observable through the cell component's props;
+ * renderCell wraps that component in a fragment alongside the optional cell actions.
+ */
+function getCellRendererProps(column: TableColumn, row: TableRow): TableCellRendererProps {
+  const node = column.renderCell?.({
+    column: column as unknown as CalculatedColumn<TableRow, TableSummaryRow>,
+    row,
+    rowIdx: row.__index,
+    isCellEditable: false,
+    tabIndex: -1,
+    onRowChange: jest.fn(),
+  });
+  if (!isValidElement<{ children: ReactNode }>(node)) {
+    throw new Error(`renderCell did not return an element for column "${column.key}"`);
+  }
+  const [cell] = Children.toArray(node.props.children);
+  if (!isValidElement<TableCellRendererProps>(cell)) {
+    throw new Error(`renderCell did not render a cell component for column "${column.key}"`);
+  }
+  return cell.props;
+}
+
 function makeConfig(overrides: Partial<ColumnBuildConfig> = {}): ColumnBuildConfig {
   const theme = createTheme();
   const getCellColorInlineStyles = getCellColorInlineStylesFactory(theme);
@@ -391,6 +422,15 @@ describe('useColumnBuilderFromFields', () => {
     const result = callFromFields(hook, frame.fields, [150, 200], frame, rows, rows);
     expect(result.columns[0].width).toBe(150);
     expect(result.columns[1].width).toBe(200);
+  });
+
+  it('hands cell renderers the column width reduced by the cell chrome (padding and border)', () => {
+    const hook = renderColumnBuilderHook({ filterResult: makeFilterResult(), config: makeConfig() });
+    const result = callFromFields(hook, frame.fields, [150, 200], frame, rows, rows);
+
+    const cellChrome = 2 * TABLE.CELL_PADDING + TABLE.BORDER_RIGHT;
+    expect(getCellRendererProps(result.columns[0], rows[0]).width).toBe(150 - cellChrome);
+    expect(getCellRendererProps(result.columns[1], rows[0]).width).toBe(200 - cellChrome);
   });
 
   function makePillFrame({ withMappings }: { withMappings: boolean }): DataFrame {

--- a/packages/grafana-ui/src/components/Table/TableNG/render-hooks.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/render-hooks.tsx
@@ -44,6 +44,7 @@ import { HeaderCell } from './components/HeaderCell';
 import { SummaryCell } from './components/SummaryCell';
 import { TableCellActions } from './components/TableCellActions';
 import { TableCellTooltip } from './components/TableCellTooltip';
+import { CELL_HORIZONTAL_CHROME } from './constants';
 import {
   getCellActionStyles,
   getDefaultCellStyles,
@@ -293,6 +294,7 @@ function buildColumnsFromFields(
     const showFilters = Boolean(field.config.filterable && onCellFilterAdded != null);
     const showActions = cellInspect || showFilters;
     const width = widths[i];
+    const contentWidth = width - CELL_HORIZONTAL_CHROME;
 
     // helps us avoid string cx and emotion per-cell
     const cellActionClassName = showActions
@@ -392,7 +394,7 @@ function buildColumnsFromFields(
             rowIdx={rowIdx}
             theme={theme}
             value={value}
-            width={width}
+            width={contentWidth}
             timeRange={timeRange}
             cellInspect={cellInspect}
             showFilters={showFilters}


### PR DESCRIPTION
**What is this feature?**

It fixes the width of Gauge and Sparkline cells. The width incorrectly included padding and border pixels (13px total). The issues caused were proportionally greater the narrower the column, since the padding and border values are of fixed size. 

**Why do we need this feature?**

For Gauges this caused them to look fuller than they should have for a given value, e.g. 60% might appear as a gauge 70% full. 

| Before | After |
| --- | --- |
| <img width="131" alt="BeforeGauge" src="https://github.com/user-attachments/assets/bc807a4c-c8c3-441f-b6d1-ddece925f5ec" /> | <img width="131" alt="AfterGauge" src="https://github.com/user-attachments/assets/207eb139-9853-4ff0-9291-1a468129fbde" /> |

For Sparklines it resulted in truncation and drawing into the right-side padding. 

| Before | After |
| --- | --- |
| <img width="350" alt="BeforeSparkline" src="https://github.com/user-attachments/assets/029bd17c-f083-4bf5-88d4-cde60f3c08e1" /> | <img width="350" alt="AfterSparkline" src="https://github.com/user-attachments/assets/a9e2748c-692a-4bb5-841e-129ce62977f0" /> |

**Who is this feature for?**

Anyone using table panels with Gauge or Sparkline cell types. 

**Which issue(s) does this PR fix?**:

N/A. Found while iterating on the Cloud Integration team's linux-node integration, which features a table with gauges for metrics such as memory usage. 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.