### PR TITLE
RecentlyViewedDashboards: Cap recently viewed results 

### DIFF
--- a/public/app/features/browse-dashboards/api/recentlyViewed.test.ts
+++ b/public/app/features/browse-dashboards/api/recentlyViewed.test.ts
@@ -1,0 +1,92 @@
+import impressionSrv from 'app/core/services/impression_srv';
+import { getGrafanaSearcher } from 'app/features/search/service/searcher';
+import { type DashboardQueryResult } from 'app/features/search/service/types';
+
+import { getRecentlyViewedDashboards } from './recentlyViewed';
+
+jest.mock('app/features/search/service/searcher', () => ({
+  getGrafanaSearcher: jest.fn(),
+}));
+
+jest.mock('app/core/services/impression_srv', () => ({
+  __esModule: true,
+  default: {
+    getDashboardOpened: jest.fn(),
+  },
+}));
+
+const getDashboardOpenedMock = jest.mocked(impressionSrv.getDashboardOpened);
+const getGrafanaSearcherMock = jest.mocked(getGrafanaSearcher);
+
+function hit(uid: string): DashboardQueryResult {
+  return { uid, name: uid, url: `/d/${uid}` } as DashboardQueryResult;
+}
+
+/** Stubs the searcher so it responds with `hits`, and records the query it was called with. */
+function setupSearcher(hits: DashboardQueryResult[]) {
+  const search = jest.fn().mockResolvedValue({ view: { toArray: () => hits } });
+  getGrafanaSearcherMock.mockReturnValue({ search } as unknown as ReturnType<typeof getGrafanaSearcher>);
+  return search;
+}
+
+describe('getRecentlyViewedDashboards', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns dashboards in the order they were opened', async () => {
+    getDashboardOpenedMock.mockResolvedValue(['a', 'b', 'c']);
+    setupSearcher([hit('c'), hit('a'), hit('b')]);
+
+    const result = await getRecentlyViewedDashboards(5);
+
+    expect(result.map((d) => d.uid)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('pushes dashboards missing from the impression list to the end', async () => {
+    getDashboardOpenedMock.mockResolvedValue(['a', 'b']);
+    setupSearcher([hit('unknown'), hit('b'), hit('a')]);
+
+    const result = await getRecentlyViewedDashboards(5);
+
+    expect(result.map((d) => d.uid)).toEqual(['a', 'b', 'unknown']);
+  });
+
+  it('only asks the search backend for maxItems dashboards', async () => {
+    getDashboardOpenedMock.mockResolvedValue(['a', 'b', 'c', 'd']);
+    const search = setupSearcher([hit('a'), hit('b')]);
+
+    await getRecentlyViewedDashboards(2);
+
+    expect(search).toHaveBeenCalledWith(expect.objectContaining({ uid: ['a', 'b'], limit: 2 }));
+  });
+
+  it('caps the results at maxItems when the search backend returns more hits than requested', async () => {
+    getDashboardOpenedMock.mockResolvedValue(['a', 'b', 'c']);
+    setupSearcher([hit('a'), hit('b'), hit('c'), hit('extra-1'), hit('extra-2')]);
+
+    const result = await getRecentlyViewedDashboards(2);
+
+    // The two most recently opened dashboards survive; unrequested hits are dropped
+    expect(result.map((d) => d.uid)).toEqual(['a', 'b']);
+  });
+
+  it('does not search when nothing has been opened', async () => {
+    getDashboardOpenedMock.mockResolvedValue([]);
+    const search = setupSearcher([]);
+
+    expect(await getRecentlyViewedDashboards(5)).toEqual([]);
+    expect(search).not.toHaveBeenCalled();
+  });
+
+  it('returns no dashboards when the search fails', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    getDashboardOpenedMock.mockResolvedValue(['a']);
+    const search = jest.fn().mockRejectedValue(new Error('search is down'));
+    getGrafanaSearcherMock.mockReturnValue({ search } as unknown as ReturnType<typeof getGrafanaSearcher>);
+
+    expect(await getRecentlyViewedDashboards(5)).toEqual([]);
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to load recently viewed dashboards', expect.anything());
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/public/app/features/browse-dashboards/api/recentlyViewed.ts
+++ b/public/app/features/browse-dashboards/api/recentlyViewed.ts
@@ -28,7 +28,9 @@ export async function getRecentlyViewedDashboards(maxItems = 5): Promise<Dashboa
     };
 
     dashboards.sort((a, b) => order(a.uid) - order(b.uid));
-    return dashboards;
+    // The uid filter and limit are only hints to the search backend, so trim the response
+    // to keep the maxItems contract even if it returns more hits than we asked for.
+    return dashboards.slice(0, maxItems);
   } catch (error) {
     console.error('Failed to load recently viewed dashboards', error);
     return [];

--- a/public/app/features/browse-dashboards/api/recentlyViewed.ts
+++ b/public/app/features/browse-dashboards/api/recentlyViewed.ts
@@ -28,8 +28,7 @@ export async function getRecentlyViewedDashboards(maxItems = 5): Promise<Dashboa
     };
 
     dashboards.sort((a, b) => order(a.uid) - order(b.uid));
-    // The uid filter and limit are only hints to the search backend, so trim the response
-    // to keep the maxItems contract even if it returns more hits than we asked for.
+    // Defensive: never return more than the caller asked for
     return dashboards.slice(0, maxItems);
   } catch (error) {
     console.error('Failed to load recently viewed dashboards', error);


### PR DESCRIPTION
**What is this feature?**

- `getRecentlyViewedDashboards(maxItems)` now returns at most `maxItems` dashboards.

This came up because a Meticulous replay ([here](https://app.meticulous.ai/projects/grafana/grafana/test-runs/DQMgjtNFTg9mFL6QpQrgG6h6k7?source=github)) rendered ~34 cards in the "Recently viewed" section. The inflated response came from the replayed network layer rather than a real backend, but the component happily rendered all of it, which is what this change guards against.

**Why do we need this feature?**

The function sliced the impression list to `maxItems` and passed `limit` to the search backend, but then returned every hit in the response without trimming it. So `maxItems` was a request, not a guarantee — anything that hands back more hits than we asked for goes straight through to the callers.
Three callers rely on this limit, so the effect isn't only cosmetic:
- `RecentlyViewedDashboards` (browse page) asks for 5, and an over-long response turns the single row of cards into a grid many rows deep, pushing the dashboard list below the fold.
- `dashboardActions` asks for 5 and feeds the results straight into the command palette, so extra hits become extra actions.
- `DashboardTabs` (home page) asks for 20.
The trim is applied after the "keep the order the user opened them" sort, so the dashboards that survive are the most recently opened ones.



**Which issue(s) does this PR fix?**:

Fixes N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
