### PR TITLE
Alerting: Prevent streamed rows from leaking table mappings

### DIFF
--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -304,12 +304,10 @@ func TestIntegrationUpdateAlertRules(t *testing.T) {
 		assert.Equal(t, folderBTitle, updatedRule.FolderFullpath, "FolderFullpath should be updated to Folder B")
 	})
 
-	t.Run("should preserve guid and use correct table when called inside an outer transaction", func(t *testing.T) {
-		// Regression test for the ORM table inference bug where UpdateAlertRules was
-		// called from callers (UpdateRuleGroup, UpdateAlertRule) that already hold an
-		// outer InTransaction session on the context. A prior query on that shared
-		// session could leave xorm's table state pointing at the wrong model,
-		// causing "SELECT alert_rule columns FROM user" on PostgreSQL.
+	t.Run("should not leak streamed rule mapping and should preserve guid inside an outer transaction", func(t *testing.T) {
+		// Regression test for a streamed alert-rule read leaving xorm's table state
+		// on the shared transaction session. The next string-table lookup could then
+		// select alert_rule columns from user, aborting the transaction on PostgreSQL.
 		rule := createRule(t, store, gen)
 		require.NotEmpty(t, rule.GUID, "rule must have a guid after insert")
 		originalGUID := rule.GUID
@@ -318,13 +316,28 @@ func TestIntegrationUpdateAlertRules(t *testing.T) {
 		newRule.Title = util.GenerateShortUID()
 
 		err := sqlStore.InTransaction(context.Background(), func(ctx context.Context) error {
-			// Simulate a prior query on the shared session using a different table,
-			// as would happen when the folder service or provenance store runs on
-			// the same transaction context before UpdateAlertRules is called.
-			_ = sqlStore.WithDbSession(ctx, func(sess *db.Session) error {
-				_, _ = sess.Table("alert_rule_version").Where("1=0").Count()
-				return nil
+			listed, err := store.ListAlertRules(ctx, &models.ListAlertRulesQuery{
+				OrgID:    rule.OrgID,
+				RuleUIDs: []string{rule.UID},
 			})
+			if err != nil {
+				return fmt.Errorf("stream alert rules: %w", err)
+			}
+			if len(listed) != 1 {
+				return fmt.Errorf("stream alert rules: got %d rules, want 1", len(listed))
+			}
+
+			err = sqlStore.WithDbSession(ctx, func(sess *db.Session) error {
+				var users []struct {
+					ID  int64  `xorm:"id"`
+					UID string `xorm:"uid"`
+				}
+				return sess.Table("user").Where("1=0").Find(&users)
+			})
+			if err != nil {
+				return fmt.Errorf("query user table after streamed alert rules: %w", err)
+			}
+
 			return store.UpdateAlertRules(ctx, &usr, []models.UpdateRule{{
 				Existing: rule,
 				New:      *newRule,

--- a/pkg/util/xorm/rows.go
+++ b/pkg/util/xorm/rows.go
@@ -16,11 +16,14 @@ import (
 type Rows struct {
 	session   *Session
 	rows      *core.Rows
+	table     *core.Table
 	beanType  reflect.Type
 	lastError error
 }
 
 func newRows(session *Session, bean any) (*Rows, error) {
+	defer session.resetStatement()
+
 	rows := new(Rows)
 	rows.session = session
 	rows.beanType = reflect.Indirect(reflect.ValueOf(bean)).Type()
@@ -32,6 +35,7 @@ func newRows(session *Session, bean any) (*Rows, error) {
 	if err = rows.session.statement.setRefBean(bean); err != nil {
 		return nil, err
 	}
+	rows.table = rows.session.statement.RefTable
 
 	if len(session.statement.TableName()) <= 0 {
 		return nil, ErrTableNotFound
@@ -84,10 +88,6 @@ func (rows *Rows) Scan(bean any) error {
 		return fmt.Errorf("scan arg is incompatible type to [%v]", rows.beanType)
 	}
 
-	if err := rows.session.statement.setRefBean(bean); err != nil {
-		return err
-	}
-
 	fields, err := rows.rows.Columns()
 	if err != nil {
 		return err
@@ -99,7 +99,7 @@ func (rows *Rows) Scan(bean any) error {
 	}
 
 	dataStruct := rValue(bean)
-	_, err = rows.session.slice2Bean(scanResults, fields, bean, &dataStruct, rows.session.statement.RefTable)
+	_, err = rows.session.slice2Bean(scanResults, fields, bean, &dataStruct, rows.table)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/xorm/rows_test.go
+++ b/pkg/util/xorm/rows_test.go
@@ -1,0 +1,151 @@
+package xorm
+
+import (
+	"testing"
+
+	_ "github.com/grafana/grafana/pkg/util/sqlite"
+	"github.com/grafana/grafana/pkg/util/xorm/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type rowsScanSource struct {
+	ID          int64  `xorm:"'id' pk"`
+	SourceValue string `xorm:"source_value"`
+}
+
+func (rowsScanSource) TableName() string {
+	return "rows_scan_source"
+}
+
+type rowsScanTarget struct {
+	ID          int64  `xorm:"'id' pk"`
+	TargetValue string `xorm:"target_value"`
+}
+
+func (rowsScanTarget) TableName() string {
+	return "rows_scan_target"
+}
+
+type rowsScanHookState struct {
+	statementClean bool
+}
+
+type rowsScanSourceWithHook struct {
+	ID          int64              `xorm:"'id' pk"`
+	SourceValue string             `xorm:"source_value"`
+	hookState   *rowsScanHookState `xorm:"-"`
+}
+
+func (rowsScanSourceWithHook) TableName() string {
+	return "rows_scan_source"
+}
+
+func (r *rowsScanSourceWithHook) AfterLoad(session *Session) {
+	r.hookState.statementClean = statementMappingIsClean(session)
+}
+
+func statementMappingIsClean(session *Session) bool {
+	return session.statement.RefTable == nil &&
+		session.statement.AltTableName == "" &&
+		session.statement.tableName == "" &&
+		session.statement.ColumnStr == "" &&
+		session.statement.RawSQL == ""
+}
+
+func TestRowsScanDoesNotLeakStatementMapping(t *testing.T) {
+	eng, err := NewEngine("sqlite3", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, eng.Close()) })
+
+	require.NoError(t, eng.Sync(new(rowsScanSource), new(rowsScanTarget)))
+	_, err = eng.Insert(&rowsScanSource{ID: 1, SourceValue: "source"})
+	require.NoError(t, err)
+	_, err = eng.Insert(&rowsScanSource{ID: 2, SourceValue: "second source"})
+	require.NoError(t, err)
+	_, err = eng.Insert(&rowsScanTarget{ID: 1, TargetValue: "target"})
+	require.NoError(t, err)
+
+	session := eng.NewSession()
+	t.Cleanup(session.Close)
+
+	rows, err := session.Asc("id").Rows(new(rowsScanSource))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, rows.Close()) })
+
+	for _, expected := range []rowsScanSource{
+		{ID: 1, SourceValue: "source"},
+		{ID: 2, SourceValue: "second source"},
+	} {
+		require.True(t, rows.Next())
+		var source rowsScanSource
+		require.NoError(t, rows.Scan(&source))
+		require.Equal(t, expected, source)
+		assert.True(t, statementMappingIsClean(session))
+	}
+	require.NoError(t, rows.Close())
+
+	var targets []rowsScanTarget
+	require.NoError(t, session.Table("rows_scan_target").Find(&targets))
+	require.Equal(t, []rowsScanTarget{{ID: 1, TargetValue: "target"}}, targets)
+}
+
+func TestRowsScanRunsAfterLoadWithCleanStatement(t *testing.T) {
+	eng, err := NewEngine("sqlite3", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, eng.Close()) })
+
+	require.NoError(t, eng.Sync(new(rowsScanSource)))
+	_, err = eng.Insert(&rowsScanSource{ID: 1, SourceValue: "source"})
+	require.NoError(t, err)
+
+	session := eng.NewSession()
+	t.Cleanup(session.Close)
+
+	rows, err := session.Rows(new(rowsScanSourceWithHook))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, rows.Close()) })
+	require.True(t, rows.Next())
+
+	hookState := new(rowsScanHookState)
+	source := rowsScanSourceWithHook{hookState: hookState}
+	require.NoError(t, rows.Scan(&source))
+	require.True(t, hookState.statementClean)
+}
+
+func TestRowsScanRawSQLUsesCursorMappingWithoutLeakingIt(t *testing.T) {
+	eng, err := NewEngine("sqlite3", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, eng.Close()) })
+
+	require.NoError(t, eng.Sync(new(rowsScanSource)))
+	_, err = eng.Insert(&rowsScanSource{ID: 1, SourceValue: "source"})
+	require.NoError(t, err)
+
+	session := eng.NewSession()
+	t.Cleanup(session.Close)
+
+	rows, err := session.SQL("SELECT id, source_value FROM rows_scan_source").Rows(new(rowsScanSource))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, rows.Close()) })
+	require.True(t, rows.Next())
+
+	var source rowsScanSource
+	require.NoError(t, rows.Scan(&source))
+	require.Equal(t, rowsScanSource{ID: 1, SourceValue: "source"}, source)
+	require.True(t, statementMappingIsClean(session))
+}
+
+func TestRowsConstructionErrorResetsStatement(t *testing.T) {
+	eng, err := NewEngine("sqlite3", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, eng.Close()) })
+
+	session := eng.NewSession()
+	t.Cleanup(session.Close)
+
+	_, err = session.ID(core.PK{1, 2}).Rows(new(rowsScanSource))
+	require.ErrorContains(t, err, "expect 1 primarykeys, there are 2")
+	require.True(t, statementMappingIsClean(session))
+	require.Nil(t, session.statement.idParam)
+}


### PR DESCRIPTION
**What is this feature?**

This change makes xorm `Rows` retain the table mapping created for its cursor and use that mapping for every `Scan`. It resets the reusable session statement when the cursor is constructed, including setup failures, so scans and `AfterLoad` hooks no longer leave or observe stale query state.

It adds focused coverage for repeated scans, raw SQL cursors, `AfterLoad` hooks, and construction errors. The alerting integration test now exercises the production failure pattern on one outer transaction: stream an alert rule, perform a string-bound `user` lookup, update the rule, commit, and preserve its GUID.

**Why do we need this feature?**

`queryRows` resets xorm's shared statement after creating a cursor. Before this change, `Rows.Scan` rebuilt `RefTable` but did not reset it. A later `.Table("user").Find(...)` on the reused transaction session could therefore select `alert_rule` columns from the `user` table. PostgreSQL reports error 42703 and aborts the transaction; later alert-rule writes then fail with error 25P02, blocking provisioning.

**Who is this feature for?**

Grafana users affected by PostgreSQL alert-provisioning failures when a provisioned rule change and folder user-attribution lookup share a database transaction.

**Which issue(s) does this PR fix?**

Fixes #127899

**Special notes for your reviewer:**

The new xorm regression test fails on the base revision because `Rows.Scan` leaves the source mapping attached to the session; the following string-table query then requests the source column from the target table.

Tests completed:

- `go test ./pkg/util/xorm -count=1`

- `go test ./pkg/util/xorm -run '^TestRows' -count=20`

- `go test -race ./pkg/util/xorm -run '^TestRows' -count=1`

- `go test ./pkg/services/ngalert/store -count=1 -timeout=10m`

- `GRAFANA_TEST_DB=postgres go test ./pkg/services/ngalert/store -run '^TestIntegrationUpdateAlertRules$' -count=1 -timeout=10m`

- `GRAFANA_TEST_DB=mysql go test ./pkg/services/ngalert/store -run '^TestIntegrationUpdateAlertRules$' -count=1 -timeout=10m`

- `make lint-go GO_LINT_FILES='./pkg/util/xorm/... ./pkg/services/ngalert/store/...'`

This contribution was prepared with AI assistance. The final patch and reported test evidence were reviewed before submission.
