### PR TITLE
Table: Fix remaining storybook a11y issues

### DIFF
--- a/packages/grafana-ui/src/components/Table/Table.story.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.story.tsx
@@ -34,24 +34,9 @@ const meta: Meta<typeof Table> = {
     },
     a11y: {
       config: {
-        // TODO comment out rules that are currently failing in the story and fix them one by one
-        // see https://github.com/grafana/grafana/issues/117606
         rules: [
           {
-            id: 'aria-required-children',
-            enabled: false,
-          },
-          {
-            id: 'aria-required-parent',
-            enabled: false,
-          },
-          {
-            id: 'empty-table-header',
-            enabled: false,
-          },
-          {
             // This does not need to be fixed! It is already specified in the storybook root preview.
-            // Once the other a11y issues are fixed, it can be removed.
             // Unfortunately we have to duplicate it here because you can't inherit *and* append additional config rules...
             id: 'scrollable-region-focusable',
             selector: 'body',

--- a/packages/grafana-ui/src/components/Table/Table.test.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.test.tsx
@@ -325,13 +325,13 @@ describe('Table', () => {
         }),
       });
 
-      expect(within(getFooter()).getByRole('columnheader').getElementsByTagName('span')[0]).toHaveTextContent('7');
+      expect(within(getFooter()).getByRole('cell').getElementsByTagName('span')[0]).toHaveTextContent('7');
 
       await userEvent.click(within(getColumnHeader(/number/)).getByRole('button', { name: '' }));
       await userEvent.click(screen.getByLabelText('1'));
       await userEvent.click(screen.getByText('Ok'));
 
-      expect(within(getFooter()).getByRole('columnheader').getElementsByTagName('span')[0]).toHaveTextContent('3');
+      expect(within(getFooter()).getByRole('cell').getElementsByTagName('span')[0]).toHaveTextContent('3');
     });
 
     it('should filter rows and recalculate footer values when multiple filter values are selected', async () => {
@@ -354,17 +354,18 @@ describe('Table', () => {
         }),
       });
 
-      expect(within(getTable()).getAllByRole('row')).toHaveLength(8);
-      expect(within(getFooter()).getByRole('columnheader').getElementsByTagName('span')[0]).toHaveTextContent('13');
+      // 7 data rows + header row + footer row
+      expect(within(getTable()).getAllByRole('row')).toHaveLength(9);
+      expect(within(getFooter()).getByRole('cell').getElementsByTagName('span')[0]).toHaveTextContent('13');
 
       await userEvent.click(within(getColumnHeader(/number/)).getByRole('button', { name: '' }));
       await userEvent.click(screen.getByLabelText('2'));
       await userEvent.click(screen.getByLabelText('3'));
       await userEvent.click(screen.getByText('Ok'));
 
-      //4 + header row
-      expect(within(getTable()).getAllByRole('row')).toHaveLength(5);
-      expect(within(getFooter()).getByRole('columnheader').getElementsByTagName('span')[0]).toHaveTextContent('10');
+      //4 + header row + footer row
+      expect(within(getTable()).getAllByRole('row')).toHaveLength(6);
+      expect(within(getFooter()).getByRole('cell').getElementsByTagName('span')[0]).toHaveTextContent('10');
     });
 
     it('should reset when clear filters button is pressed', async () => {
@@ -391,16 +392,16 @@ describe('Table', () => {
       await userEvent.click(screen.getByLabelText('1'));
       await userEvent.click(screen.getByText('Ok'));
 
-      //3 + header row
-      expect(within(getTable()).getAllByRole('row')).toHaveLength(4);
-      expect(within(getFooter()).getByRole('columnheader').getElementsByTagName('span')[0]).toHaveTextContent('3');
+      //3 + header row + footer row
+      expect(within(getTable()).getAllByRole('row')).toHaveLength(5);
+      expect(within(getFooter()).getByRole('cell').getElementsByTagName('span')[0]).toHaveTextContent('3');
 
       await userEvent.click(within(getColumnHeader(/number/)).getByRole('button', { name: '' }));
       await userEvent.click(screen.getByText('Clear filter'));
 
-      //5 + header row
-      expect(within(getTable()).getAllByRole('row')).toHaveLength(6);
-      expect(within(getFooter()).getByRole('columnheader').getElementsByTagName('span')[0]).toHaveTextContent('7');
+      //5 + header row + footer row
+      expect(within(getTable()).getAllByRole('row')).toHaveLength(7);
+      expect(within(getFooter()).getByRole('cell').getElementsByTagName('span')[0]).toHaveTextContent('7');
     });
   });
 
@@ -425,9 +426,9 @@ describe('Table', () => {
         }),
       });
 
-      //5 + header row
-      expect(within(getTable()).getAllByRole('row')).toHaveLength(6);
-      expect(within(getFooter()).getByRole('columnheader').getElementsByTagName('span')[0]).toHaveTextContent('7');
+      //5 + header row + footer row
+      expect(within(getTable()).getAllByRole('row')).toHaveLength(7);
+      expect(within(getFooter()).getByRole('cell').getElementsByTagName('span')[0]).toHaveTextContent('7');
 
       const onSortByChange = jest.fn();
       const onCellFilterAdded = jest.fn();
@@ -465,9 +466,9 @@ describe('Table', () => {
 
       rerender(<Table {...props} />);
 
-      //4 + header row
-      expect(within(getTable()).getAllByRole('row')).toHaveLength(5);
-      expect(within(getFooter()).getByRole('columnheader').getElementsByTagName('span')[0]).toHaveTextContent('5');
+      //4 + header row + footer row
+      expect(within(getTable()).getAllByRole('row')).toHaveLength(6);
+      expect(within(getFooter()).getByRole('cell').getElementsByTagName('span')[0]).toHaveTextContent('5');
     });
   });
 
@@ -517,7 +518,7 @@ describe('Table', () => {
         }),
       });
 
-      expect(within(getFooter()).getByRole('columnheader').getElementsByTagName('span')[0]).toHaveTextContent('4');
+      expect(within(getFooter()).getByRole('cell').getElementsByTagName('span')[0]).toHaveTextContent('4');
     });
 
     it('should show count of rows when `count rows` is selected', async () => {
@@ -540,8 +541,8 @@ describe('Table', () => {
         }),
       });
 
-      expect(within(getFooter()).getByRole('columnheader').getElementsByTagName('span')[0]).toHaveTextContent('Count');
-      expect(within(getFooter()).getByRole('columnheader').getElementsByTagName('span')[1]).toHaveTextContent('5');
+      expect(within(getFooter()).getByRole('cell').getElementsByTagName('span')[0]).toHaveTextContent('Count');
+      expect(within(getFooter()).getByRole('cell').getElementsByTagName('span')[1]).toHaveTextContent('5');
     });
 
     it('should show correct counts when turning `count rows` on and off', async () => {
@@ -564,8 +565,8 @@ describe('Table', () => {
         }),
       });
 
-      expect(within(getFooter()).getByRole('columnheader').getElementsByTagName('span')[0]).toHaveTextContent('Count');
-      expect(within(getFooter()).getByRole('columnheader').getElementsByTagName('span')[1]).toHaveTextContent('5');
+      expect(within(getFooter()).getByRole('cell').getElementsByTagName('span')[0]).toHaveTextContent('Count');
+      expect(within(getFooter()).getByRole('cell').getElementsByTagName('span')[1]).toHaveTextContent('5');
 
       const onSortByChange = jest.fn();
       const onCellFilterAdded = jest.fn();
@@ -603,7 +604,7 @@ describe('Table', () => {
 
       rerender(<Table {...props} />);
 
-      expect(within(getFooter()).getByRole('columnheader').getElementsByTagName('span')[0]).toHaveTextContent('4');
+      expect(within(getFooter()).getByRole('cell').getElementsByTagName('span')[0]).toHaveTextContent('4');
     });
   });
 

--- a/packages/grafana-ui/src/components/Table/Table.test.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.test.tsx
@@ -242,6 +242,15 @@ describe('Table', () => {
       expect(getTable()).toBeInTheDocument();
       expect(getFooter()).toBeInTheDocument();
     });
+
+    it('then the footer row is included in aria-rowcount and has its own aria-rowindex', () => {
+      const footerValues = ['a', 'b', 'c'];
+      getTestContext({ footerValues });
+
+      // 1 header row + 4 data rows + 1 footer row
+      expect(getTable()).toHaveAttribute('aria-rowcount', '6');
+      expect(getFooter()).toHaveAttribute('aria-rowindex', '6');
+    });
   });
 
   describe('when sorting with column header', () => {

--- a/packages/grafana-ui/src/components/Table/TableRT/ExpandedRow.tsx
+++ b/packages/grafana-ui/src/components/Table/TableRT/ExpandedRow.tsx
@@ -55,7 +55,14 @@ export function ExpandedRow({ tableStyles, nestedData, rowIndex, width, cellHeig
     );
   });
 
-  return <div className={styles.subTables}>{subTables}</div>;
+  // This wrapper is rendered as a sibling of the row's cells, inside the row's `role="row"` div.
+  // A `row` can only own `cell`/`gridcell`/`columnheader`/`rowheader` children, so this needs a
+  // `cell` role of its own to legally contain the nested sub-table(s).
+  return (
+    <div className={styles.subTables} role="cell">
+      {subTables}
+    </div>
+  );
 }
 
 const getStyles = (theme: GrafanaTheme2) => {

--- a/packages/grafana-ui/src/components/Table/TableRT/FooterRow.tsx
+++ b/packages/grafana-ui/src/components/Table/TableRT/FooterRow.tsx
@@ -14,10 +14,12 @@ export interface FooterRowProps {
   footerValues: FooterItem[];
   isPaginationVisible: boolean;
   tableStyles: TableStyles;
+  /** 1-based ARIA row index for this row, consistent with the header/data rows and `aria-rowcount`. */
+  ariaRowIndex: number;
 }
 
 export function FooterRow(props: FooterRowProps) {
-  const { totalColumnsWidth, footerGroups, isPaginationVisible, tableStyles } = props;
+  const { totalColumnsWidth, footerGroups, isPaginationVisible, tableStyles, ariaRowIndex } = props;
   const e2eSelectorsTable = selectors.components.Panels.Visualization.Table;
 
   return (
@@ -35,6 +37,7 @@ export function FooterRow(props: FooterRowProps) {
             className={tableStyles.tfoot}
             {...footerGroupProps}
             role="row"
+            aria-rowindex={ariaRowIndex}
             key={key}
             data-testid={e2eSelectorsTable.footer}
           >

--- a/packages/grafana-ui/src/components/Table/TableRT/FooterRow.tsx
+++ b/packages/grafana-ui/src/components/Table/TableRT/FooterRow.tsx
@@ -31,7 +31,13 @@ export function FooterRow(props: FooterRowProps) {
       {footerGroups.map((footerGroup: HeaderGroup) => {
         const { key, ...footerGroupProps } = footerGroup.getFooterGroupProps();
         return (
-          <div className={tableStyles.tfoot} {...footerGroupProps} key={key} data-testid={e2eSelectorsTable.footer}>
+          <div
+            className={tableStyles.tfoot}
+            {...footerGroupProps}
+            role="row"
+            key={key}
+            data-testid={e2eSelectorsTable.footer}
+          >
             {footerGroup.headers.map((column: ColumnInstance) => renderFooterCell(column, tableStyles))}
           </div>
         );
@@ -50,6 +56,10 @@ function renderFooterCell(column: ColumnInstance, tableStyles: TableStyles) {
   footerProps.style = footerProps.style ?? {};
   footerProps.style.position = 'absolute';
   footerProps.style.justifyContent = (column as any).justifyContent;
+  // getHeaderProps() defaults to role="columnheader", which is wrong here: footer cells
+  // summarize column values, they don't label them, and an empty footer value would then
+  // be an empty header (which axe flags). "cell" is the correct role for a footer/summary row.
+  footerProps.role = 'cell';
 
   return (
     <div key={key} className={tableStyles.headerCell} {...footerProps}>

--- a/packages/grafana-ui/src/components/Table/TableRT/RowExpander.tsx
+++ b/packages/grafana-ui/src/components/Table/TableRT/RowExpander.tsx
@@ -12,7 +12,7 @@ export interface Props {
 
 export function RowExpander({ row, tableStyles }: Props) {
   return (
-    <div className={tableStyles.expanderCell} {...row.getToggleRowExpandedProps()}>
+    <div className={tableStyles.expanderCell} role="cell" {...row.getToggleRowExpandedProps()}>
       <Icon
         aria-label={
           row.isExpanded

--- a/packages/grafana-ui/src/components/Table/TableRT/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/TableRT/Table.tsx
@@ -285,8 +285,8 @@ export const Table = memo((props: Props) => {
   const itemCount = enablePagination ? page.length : rows.length;
 
   // Virtualization means only the visible rows exist in the DOM, so we announce the real
-  // row count to screen readers. ARIA row counts are 1-based and include the header row.
-  const ariaRowCount = (noHeader ? 0 : 1) + rows.length;
+  // row count to screen readers. ARIA row counts are 1-based and include the header and footer rows.
+  const ariaRowCount = (noHeader ? 0 : 1) + rows.length + (footerItems ? 1 : 0);
   let paginationEl = null;
   if (enablePagination) {
     const itemsRangeStart = state.pageIndex * state.pageSize + 1;
@@ -408,6 +408,7 @@ export const Table = memo((props: Props) => {
                     footerGroups={footerGroups}
                     totalColumnsWidth={totalColumnsWidth}
                     tableStyles={tableStyles}
+                    ariaRowIndex={ariaRowCount}
                   />
                 )}
               </div>

--- a/packages/grafana-ui/src/components/Table/TableRT/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/TableRT/Table.tsx
@@ -338,72 +338,94 @@ export const Table = memo((props: Props) => {
 
   const rendered = (
     <>
-      <div
-        {...getTableProps()}
-        className={tableStyles.table}
-        aria-label={ariaLabel}
-        aria-rowcount={ariaRowCount}
-        role="table"
-        ref={tableDivRef}
-        style={{ width, height }}
-      >
-        <CustomScrollbar hideVerticalTrack={true}>
-          <div className={tableStyles.tableContentWrapper(totalColumnsWidth)}>
-            {!noHeader && (
-              <HeaderRow headerGroups={headerGroups} showTypeIcons={showTypeIcons} tableStyles={tableStyles} />
-            )}
-            {itemCount > 0 ? (
-              <div
-                data-testid={selectors.components.Panels.Visualization.Table.body}
-                ref={variableSizeListScrollbarRef}
-              >
-                <RowsList
-                  headerGroups={headerGroups}
-                  data={data}
-                  rows={rows}
-                  width={width}
-                  cellHeight={cellHeight}
-                  headerHeight={headerHeight}
-                  rowHeight={tableStyles.rowHeight}
-                  itemCount={itemCount}
-                  noHeader={noHeader}
-                  pageIndex={state.pageIndex}
-                  listHeight={listHeight}
-                  listRef={listRef}
-                  tableState={state}
-                  prepareRow={prepareRow}
-                  timeRange={timeRange}
-                  onCellFilterAdded={onCellFilterAdded}
-                  nestedDataField={nestedDataField}
-                  tableStyles={tableStyles}
-                  footerPaginationEnabled={Boolean(enablePagination)}
-                  enableSharedCrosshair={enableSharedCrosshair}
-                  initialRowIndex={initialRowIndex}
-                  longestField={longestField}
-                  textWrapField={textWrapField}
-                  getActions={getActions}
-                  replaceVariables={replaceVariables}
-                  setInspectCell={setInspectCell}
-                />
+      {/*
+        `paginationEl` is not row/rowgroup content, so when present it can't live inside the
+        `role="table"` element below (a `table` may only own `row`/`rowgroup` children). In that
+        case, `tableGrid` gets an extra, visually-transparent (`display: contents`) outer layer so
+        the actual sizing/layout (`tableStyles.table`, explicit width/height) can move to a plain
+        wrapper div shared with the pagination control, keeping `role="table"` off of the pagination
+        control's ancestor chain. When there's no pagination, `tableGrid` renders exactly as before.
+      */}
+      {(() => {
+        const tableGrid = (
+          <div
+            {...getTableProps()}
+            className={paginationEl ? undefined : tableStyles.table}
+            aria-label={ariaLabel}
+            aria-rowcount={ariaRowCount}
+            role="table"
+            ref={tableDivRef}
+            style={paginationEl ? { display: 'contents' } : { width, height }}
+          >
+            <CustomScrollbar hideVerticalTrack={true}>
+              <div className={tableStyles.tableContentWrapper(totalColumnsWidth)}>
+                {!noHeader && (
+                  <HeaderRow headerGroups={headerGroups} showTypeIcons={showTypeIcons} tableStyles={tableStyles} />
+                )}
+                {itemCount > 0 ? (
+                  <div
+                    data-testid={selectors.components.Panels.Visualization.Table.body}
+                    ref={variableSizeListScrollbarRef}
+                  >
+                    <RowsList
+                      headerGroups={headerGroups}
+                      data={data}
+                      rows={rows}
+                      width={width}
+                      cellHeight={cellHeight}
+                      headerHeight={headerHeight}
+                      rowHeight={tableStyles.rowHeight}
+                      itemCount={itemCount}
+                      noHeader={noHeader}
+                      pageIndex={state.pageIndex}
+                      listHeight={listHeight}
+                      listRef={listRef}
+                      tableState={state}
+                      prepareRow={prepareRow}
+                      timeRange={timeRange}
+                      onCellFilterAdded={onCellFilterAdded}
+                      nestedDataField={nestedDataField}
+                      tableStyles={tableStyles}
+                      footerPaginationEnabled={Boolean(enablePagination)}
+                      enableSharedCrosshair={enableSharedCrosshair}
+                      initialRowIndex={initialRowIndex}
+                      longestField={longestField}
+                      textWrapField={textWrapField}
+                      getActions={getActions}
+                      replaceVariables={replaceVariables}
+                      setInspectCell={setInspectCell}
+                    />
+                  </div>
+                ) : (
+                  <div style={{ height: height - headerHeight, width }} className={tableStyles.noData}>
+                    {noValuesDisplayText}
+                  </div>
+                )}
+                {footerItems && (
+                  <FooterRow
+                    isPaginationVisible={Boolean(enablePagination)}
+                    footerValues={footerItems}
+                    footerGroups={footerGroups}
+                    totalColumnsWidth={totalColumnsWidth}
+                    tableStyles={tableStyles}
+                  />
+                )}
               </div>
-            ) : (
-              <div style={{ height: height - headerHeight, width }} className={tableStyles.noData}>
-                {noValuesDisplayText}
-              </div>
-            )}
-            {footerItems && (
-              <FooterRow
-                isPaginationVisible={Boolean(enablePagination)}
-                footerValues={footerItems}
-                footerGroups={footerGroups}
-                totalColumnsWidth={totalColumnsWidth}
-                tableStyles={tableStyles}
-              />
-            )}
+            </CustomScrollbar>
           </div>
-        </CustomScrollbar>
-        {paginationEl}
-      </div>
+        );
+
+        if (!paginationEl) {
+          return tableGrid;
+        }
+
+        return (
+          <div className={tableStyles.table} style={{ width, height }}>
+            {tableGrid}
+            {paginationEl}
+          </div>
+        );
+      })()}
 
       {inspectCell !== null && (
         <TableCellInspector

--- a/packages/grafana-ui/src/components/Table/utils.ts
+++ b/packages/grafana-ui/src/components/Table/utils.ts
@@ -1,5 +1,6 @@
 import { clone, sampleSize } from 'lodash';
 import memoize from 'micro-memoize';
+import { createElement } from 'react';
 import { type HeaderGroup, type Row } from 'react-table';
 
 import {
@@ -18,6 +19,7 @@ import {
   reduceField,
   type SelectableValue,
 } from '@grafana/data';
+import { t } from '@grafana/i18n';
 import { TableCellDisplayMode } from '@grafana/schema';
 
 import { ActionsCell } from './ActionsCell';
@@ -54,8 +56,14 @@ export function getColumns(
 
   if (expander) {
     columns.push({
-      // Make an expander cell
-      Header: () => null, // No header
+      // Make an expander cell. The column has no visible header, but the columnheader cell still
+      // needs an accessible name, so it renders a visually-hidden label instead of nothing.
+      Header: () =>
+        createElement(
+          'span',
+          { className: 'sr-only' },
+          t('grafana-ui.table.nested-table.expander-column-name', 'Expand nested rows')
+        ),
       id: 'expander', // It needs an ID
       // @ts-expect-error
       // TODO fix type error here


### PR DESCRIPTION
**What is this feature?**

Fixes the `aria-required-children`, `aria-required-parent`, and `empty-table-header` a11y violations that were disabled in the Table storybook config (`Table.story.tsx`), specifically in the `Footer`, `Pagination`, and `Sub Tables` stories.

**Why do we need this feature?**

These rules were disabled with a TODO to fix them one-by-one. Each disabled rule corresponded to a real accessibility defect in `TableRT`:

- **Footer cells** reused react-table's `getHeaderProps()`, giving them `role="columnheader"` with no `role="row"` ancestor (`aria-required-parent`), and an empty footer value had no accessible name (`empty-table-header`). Footer cells now use `role="cell"`, and the footer row wrapper gets `role="row"`.
- **The sub-table expander wrapper** rendered a full nested `role="table"` as a direct child of the outer `role="row"`, which only permits `cell`/`gridcell`/`columnheader`/`rowheader` children (`aria-required-children`). It now wraps that content in `role="cell"`.
- **The row-expander toggle icon** had no role at all, making its SVG an invalid direct child of `role="row"` (`aria-required-children`). It now has `role="cell"`.
- **The expander column's header** rendered nothing (`Header: () => null`), leaving an empty `columnheader` (`empty-table-header`). It now renders a visually-hidden accessible label.
- **The `Pagination` control** (`role="navigation"`, containing an `<ol>`) was nested directly inside `role="table"`, which only permits `row`/`rowgroup` children (`aria-required-children`). The paginated table now renders the table grid and pagination as siblings instead of nesting one inside the other (only when pagination is actually shown — nested sub-tables, which never paginate, are unaffected).

With these fixed, `Table.story.tsx` no longer needs to disable any of the three rules — only the pre-existing `scrollable-region-focusable` ignore remains (already covered by the root Storybook preview config, not something that needs fixing here).

**Who is this feature for?**

Screen reader / assistive technology users of Grafana's Table panel, and anyone relying on the Storybook a11y addon to catch regressions in this component going forward.

**Which issue(s) does this PR fix?**:

Closes #117606

**Special notes for your reviewer:**

- `Table.test.tsx` is updated to match: footer cells are now queried by `role="cell"` instead of `"columnheader"`, and `role="row"` counts include the new footer row where a footer is present.
- Verified live: ran the Storybook a11y addon (via `@axe-core/playwright`) against all Table stories (`Basic`, `Footer`, `Pagination`, `Sub Tables`, `BarGaugeCell`, `ColoredCells`, `CustomColumn`) — zero `aria-required-children` / `aria-required-parent` / `empty-table-header` violations remain.
- Screenshotted the `Pagination`, `Footer`, and `Sub Tables` stories to confirm no visual/layout regression from the `Table.tsx` restructuring.
- `yarn jest packages/grafana-ui/src/components/Table` passes (811 tests), as does `yarn tsc --noEmit` and `yarn eslint` on all changed files.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle. _(n/a — bugfix, not a feature)_
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc. _(n/a — internal a11y fix, no user-facing behavior change)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)