### PR TITLE
Search: let kinds declare which search endpoints they serve

### DIFF
--- a/pkg/services/apiserver/searchroutes/searchroutes.go
+++ b/pkg/services/apiserver/searchroutes/searchroutes.go
@@ -6,6 +6,7 @@
 package searchroutes
 
 import (
+	"github.com/grafana/grafana-app-sdk/app"
 	appsdkapiserver "github.com/grafana/grafana-app-sdk/k8s/apiserver"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -24,7 +25,8 @@ const namespacedScope = "Namespaced"
 //
 // Temporary. Every namespaced kind is a candidate, but turning them all on at
 // once would expose endpoints on kinds nobody has looked at yet, so the set is
-// widened deliberately. A manifest opt-out replaces this.
+// widened deliberately. Kinds state their own choice in their manifest; this
+// list holds that choice back until someone has reviewed the kind.
 var allowed = map[groupResource]bool{
 	{group: "dashboard.grafana.app", resource: "dashboards"}: true,
 	{group: "folder.grafana.app", resource: "folders"}:       true,
@@ -61,7 +63,20 @@ func Build(
 
 	// Search fields come from the compiled-in app manifests, the same
 	// declarations the index mapping is built from.
-	manifests := resource.AppManifests()
+	return build(resource.AppManifests(), searchEnabled, trashEnabled, tracer, index, builders, installers)
+}
+
+// build takes the manifests as an argument so a test can describe a kind that
+// opts out. No compiled-in manifest does yet.
+func build(
+	manifests []app.Manifest,
+	searchEnabled bool,
+	trashEnabled bool,
+	tracer tracing.Tracer,
+	index resourcepb.ResourceIndexClient,
+	builders []builder.APIGroupBuilder,
+	installers []appsdkapiserver.AppInstaller,
+) []builder.GroupVersionRoutes {
 	handler := searchapi.NewHandler(index, resource.NewManifestBackedProvider(manifests), tracer)
 
 	served := servedGroupVersions(builders, installers)
@@ -87,11 +102,13 @@ func Build(
 				if !allowed[groupResource{group: gv.Group, resource: resourceName}] {
 					continue
 				}
-				if searchEnabled {
+				// The list above and the kind's manifest both have to want the
+				// endpoint. The two endpoints are answered separately.
+				if searchEnabled && kind.HasSearchEndpoint() {
 					byGroupVersion[gv] = append(byGroupVersion[gv],
 						handler.SearchRoute(gv.Group, gv.Version, resourceName, kind.Kind))
 				}
-				if trashEnabled {
+				if trashEnabled && kind.HasTrashEndpoint() {
 					byGroupVersion[gv] = append(byGroupVersion[gv],
 						handler.TrashRoute(gv.Group, gv.Version, resourceName, kind.Kind))
 				}

--- a/pkg/services/apiserver/searchroutes/searchroutes_test.go
+++ b/pkg/services/apiserver/searchroutes/searchroutes_test.go
@@ -1,8 +1,10 @@
 package searchroutes
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/grafana/grafana-app-sdk/app"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -174,6 +176,111 @@ func TestBuild_MountsNotebooksOnDeclaringVersionOnly(t *testing.T) {
 		}
 		assert.NotContains(t, got[gv.String()], "notebooks/search", "unexpected notebooks route on %s", gv)
 	}
+}
+
+// allServedGroupVersions lets a test ask for everything at once and see what
+// comes back.
+func allServedGroupVersions(t *testing.T) []schema.GroupVersion {
+	t.Helper()
+
+	var gvs []schema.GroupVersion
+	for _, m := range resource.AppManifests() {
+		if m.ManifestData == nil {
+			continue
+		}
+		for _, v := range m.ManifestData.Versions {
+			if v.Served {
+				gvs = append(gvs, schema.GroupVersion{Group: m.ManifestData.Group, Version: v.Name})
+			}
+		}
+	}
+	require.NotEmpty(t, gvs)
+	return gvs
+}
+
+// Reading the manifest must not widen what is served. Adding a kind here should
+// be a decision, not a side effect of a manifest default.
+func TestBuild_ServedKindsAreOnlyTheAllowedOnes(t *testing.T) {
+	got := paths(Build(true, true, nil, fakeClient{},
+		[]builder.APIGroupBuilder{&fakeBuilder{gvs: allServedGroupVersions(t)}}, nil))
+
+	resources := map[string]bool{}
+	for _, ps := range got {
+		for _, p := range ps {
+			resources[strings.SplitN(p, "/", 2)[0]] = true
+		}
+	}
+
+	assert.Equal(t, map[string]bool{
+		"dashboards": true,
+		"folders":    true,
+		"notebooks":  true,
+	}, resources)
+}
+
+// Declining one endpoint must leave the other alone.
+func TestBuild_ManifestOptOutIsHonoured(t *testing.T) {
+	gv := schema.GroupVersion{Group: "dashboard.grafana.app", Version: "v1"}
+	builders := []builder.APIGroupBuilder{&fakeBuilder{gvs: []schema.GroupVersion{gv}}}
+
+	dashboards := func(search *app.ManifestVersionKindSearch) []app.Manifest {
+		return []app.Manifest{{ManifestData: &app.ManifestData{
+			Group: gv.Group,
+			Versions: []app.ManifestVersion{{
+				Name:   gv.Version,
+				Served: true,
+				Kinds: []app.ManifestVersionKind{{
+					Kind:   "Dashboard",
+					Plural: "dashboards",
+					Scope:  namespacedScope,
+					Search: search,
+				}},
+			}},
+		}}}
+	}
+	optOut := func(v bool) *bool { return &v }
+
+	t.Run("says nothing, so gets both", func(t *testing.T) {
+		got := paths(build(dashboards(nil), true, true, nil, fakeClient{}, builders, nil))
+		assert.ElementsMatch(t, []string{"dashboards/search", "dashboards/trash"}, got[gv.String()])
+	})
+
+	t.Run("declines search, keeps trash", func(t *testing.T) {
+		search := &app.ManifestVersionKindSearch{Endpoint: optOut(false)}
+		got := paths(build(dashboards(search), true, true, nil, fakeClient{}, builders, nil))
+		assert.Equal(t, []string{"dashboards/trash"}, got[gv.String()])
+	})
+
+	t.Run("declines trash, keeps search", func(t *testing.T) {
+		search := &app.ManifestVersionKindSearch{Trash: optOut(false)}
+		got := paths(build(dashboards(search), true, true, nil, fakeClient{}, builders, nil))
+		assert.Equal(t, []string{"dashboards/search"}, got[gv.String()])
+	})
+
+	t.Run("declines both", func(t *testing.T) {
+		search := &app.ManifestVersionKindSearch{Endpoint: optOut(false), Trash: optOut(false)}
+		assert.Empty(t, paths(build(dashboards(search), true, true, nil, fakeClient{}, builders, nil)))
+	})
+}
+
+// Until the allowlist goes away, it still gates a kind that wants the endpoint.
+func TestBuild_AllowlistStillGatesAKindThatWantsIt(t *testing.T) {
+	gv := schema.GroupVersion{Group: "playlist.grafana.app", Version: "v0alpha1"}
+	manifests := []app.Manifest{{ManifestData: &app.ManifestData{
+		Group: gv.Group,
+		Versions: []app.ManifestVersion{{
+			Name:   gv.Version,
+			Served: true,
+			Kinds: []app.ManifestVersionKind{{
+				Kind:   "Playlist",
+				Plural: "playlists",
+				Scope:  namespacedScope,
+			}},
+		}},
+	}}}
+	builders := []builder.APIGroupBuilder{&fakeBuilder{gvs: []schema.GroupVersion{gv}}}
+
+	assert.Empty(t, paths(build(manifests, true, true, nil, fakeClient{}, builders, nil)))
 }
 
 func TestServedGroupVersions_CoversBothRegistrationPaths(t *testing.T) {


### PR DESCRIPTION
Kinds can now state in their manifest whether they serve the per-resource `/search` and `/trash` endpoints. `searchroutes` reads that choice alongside the existing allowlist: both have to want the endpoint before a route is mounted, and the two endpoints are answered separately, since `/trash` sits behind its own config key.

The manifest side landed in the app SDK ([#1471](https://github.com/grafana/grafana-app-sdk/pull/1471)) and arrived with v0.57.1. `HasSearchEndpoint()` and `HasTrashEndpoint()` treat an absent value as "served", so a kind whose manifest says nothing behaves exactly as it does today.

## This does not change which kinds are served

The allowlist still decides that — dashboards, folders and notebooks — and no kind opts out yet. This only moves where the intent is recorded, so the allowlist can be removed later without having to work out what each kind wants at that point. A test pins the served set so that reading the manifest cannot widen it by accident.

Removing the allowlist is deliberately not part of this PR: 43 namespaced kinds sit on served versions today and none declare a `search` block, so dropping it now would take the served set from 3 to 43 in one step. That widening wants a per-kind audit and will come separately.

## Tests

- The served set is exactly dashboards, folders and notebooks, checked by asking for every served group version Grafana has
- A kind that declines an endpoint gets no route, and declining one endpoint leaves the other alone
- A kind that wants an endpoint but is not on the allowlist still gets nothing