### PR TITLE
80065 reject mismatched datasource types

### DIFF
--- a/packages/grafana-runtime/src/components/DataSourcePicker.test.tsx
+++ b/packages/grafana-runtime/src/components/DataSourcePicker.test.tsx
@@ -6,7 +6,7 @@ import { type DataSourceInstanceSettings, type DataSourcePluginMeta } from '@gra
 import {
   DataSourcePicker,
   type DataSourcePickerProps,
-  getDataSourcePickerError,
+  isDataSourceCompatibleWithPicker,
   setDataSourcePicker,
 } from './DataSourcePicker';
 
@@ -141,7 +141,7 @@ describe('DataSourcePicker', () => {
     });
   });
 
-  describe('data source type checks', () => {
+  describe('data source compatibility', () => {
     const prometheusDs: DataSourceInstanceSettings = {
       uid: 'prom-uid',
       name: 'Prometheus',
@@ -179,28 +179,76 @@ describe('DataSourcePicker', () => {
       },
     };
 
-    it('returns an error when the current data source type is not in the filtered list', () => {
-      expect(getDataSourcePickerError('tempo-uid', tempoDs, [prometheusDs])).toBe(
-        'Data source type is not valid for this field: tempo'
+    it('rejects a current data source that is not in the filtered list', () => {
+      expect(isDataSourceCompatibleWithPicker('tempo-uid', tempoDs, [prometheusDs])).toBe(false);
+    });
+
+    it('allows a current data source that is in the filtered list', () => {
+      expect(isDataSourceCompatibleWithPicker('prom-uid', prometheusDs, [prometheusDs])).toBe(true);
+    });
+
+    it('allows an empty selection', () => {
+      expect(isDataSourceCompatibleWithPicker(null, undefined, [prometheusDs])).toBe(true);
+      expect(isDataSourceCompatibleWithPicker(undefined, undefined, [prometheusDs])).toBe(true);
+      expect(isDataSourceCompatibleWithPicker('', undefined, [prometheusDs])).toBe(true);
+    });
+
+    it('rejects a selected data source that cannot be resolved', () => {
+      expect(isDataSourceCompatibleWithPicker('missing-uid', undefined, [prometheusDs])).toBe(false);
+      expect(isDataSourceCompatibleWithPicker({ uid: 'missing-uid' }, undefined, [prometheusDs])).toBe(false);
+    });
+
+    it('allows expression datasources even when they are not in the filtered list', () => {
+      expect(isDataSourceCompatibleWithPicker('__expr__', undefined, [prometheusDs])).toBe(true);
+      expect(isDataSourceCompatibleWithPicker({ uid: '__expr__' }, undefined, [prometheusDs])).toBe(true);
+    });
+
+    it('allows template datasource refs that resolved via rawRef even when the variable uid is not in the list', () => {
+      const variableSettings: DataSourceInstanceSettings = {
+        ...prometheusDs,
+        uid: '${ds}',
+        name: '${ds}',
+        rawRef: { type: 'prometheus', uid: 'prom-uid' },
+      };
+      expect(isDataSourceCompatibleWithPicker('${ds}', variableSettings, [prometheusDs])).toBe(true);
+      expect(isDataSourceCompatibleWithPicker('$ds', { ...variableSettings, uid: '$ds', name: '$ds' }, [prometheusDs])).toBe(
+        true
       );
+      expect(
+        isDataSourceCompatibleWithPicker('${rowDs}', { ...variableSettings, uid: '${rowDs}', name: '${rowDs}' }, [
+          prometheusDs,
+        ])
+      ).toBe(true);
     });
 
-    it('returns undefined when the current data source type matches the filter', () => {
-      expect(getDataSourcePickerError('prom-uid', prometheusDs, [prometheusDs])).toBeUndefined();
+    it('rejects an unresolved template datasource ref', () => {
+      expect(isDataSourceCompatibleWithPicker('${missing}', undefined, [prometheusDs])).toBe(false);
     });
 
-    it('returns undefined when noDefault is set and nothing is selected', () => {
-      expect(getDataSourcePickerError(null, undefined, [prometheusDs], true)).toBeUndefined();
+    it('rejects a template datasource ref whose interpolated datasource is not in the filtered list', () => {
+      const variableSettings: DataSourceInstanceSettings = {
+        ...tempoDs,
+        uid: '${ds}',
+        name: '${ds}',
+        rawRef: { type: 'tempo', uid: 'tempo-uid' },
+      };
+      expect(isDataSourceCompatibleWithPicker('${ds}', variableSettings, [prometheusDs])).toBe(false);
     });
 
-    it('returns a not-found error when the current data source cannot be resolved', () => {
-      expect(getDataSourcePickerError('missing-uid', undefined, [prometheusDs])).toBe(
-        'Could not find data source missing-uid'
-      );
+    it('marks the select invalid when the current data source is not in the filtered list', () => {
+      mockGetInstanceSettings.mockReturnValue(tempoDs);
+      mockGetList.mockReturnValue([prometheusDs]);
+      render(<DataSourcePicker current="tempo-uid" pluginId="prometheus" onChange={jest.fn()} />);
+
+      expect(screen.getByRole('combobox')).toHaveAttribute('aria-invalid', 'true');
     });
 
-    it('returns undefined for expression datasources even when they are not in the filtered list', () => {
-      expect(getDataSourcePickerError('__expr__', undefined, [prometheusDs])).toBeUndefined();
+    it('does not mark the select invalid when the current data source matches the filter', () => {
+      mockGetInstanceSettings.mockReturnValue(prometheusDs);
+      mockGetList.mockReturnValue([prometheusDs]);
+      render(<DataSourcePicker current="prom-uid" pluginId="prometheus" onChange={jest.fn()} />);
+
+      expect(screen.getByRole('combobox')).toHaveAttribute('aria-invalid', 'false');
     });
 
     it('recomputes validity on render when the allowed list changes without filter prop changes', () => {
@@ -208,13 +256,12 @@ describe('DataSourcePicker', () => {
       mockGetList.mockReturnValue([prometheusDs]);
       const { rerender } = render(<DataSourcePicker current="prom-uid" pluginId="prometheus" onChange={jest.fn()} />);
 
-      const wrapper = () => screen.getByLabelText('Data source picker select container').querySelector('.ds-picker');
-      const validClass = wrapper()?.className;
+      expect(screen.getByRole('combobox')).toHaveAttribute('aria-invalid', 'false');
 
       mockGetList.mockReturnValue([]);
       rerender(<DataSourcePicker current="prom-uid" pluginId="prometheus" onChange={jest.fn()} />);
 
-      expect(wrapper()?.className).not.toBe(validClass);
+      expect(screen.getByRole('combobox')).toHaveAttribute('aria-invalid', 'true');
     });
   });
 

--- a/packages/grafana-runtime/src/components/DataSourcePicker.test.tsx
+++ b/packages/grafana-runtime/src/components/DataSourcePicker.test.tsx
@@ -3,7 +3,12 @@ import userEvent from '@testing-library/user-event';
 
 import { type DataSourceInstanceSettings, type DataSourcePluginMeta } from '@grafana/data';
 
-import { DataSourcePicker, type DataSourcePickerProps, setDataSourcePicker } from './DataSourcePicker';
+import {
+  DataSourcePicker,
+  type DataSourcePickerProps,
+  getDataSourcePickerError,
+  setDataSourcePicker,
+} from './DataSourcePicker';
 
 const mockGetInstanceSettings = jest.fn();
 const mockGetList = jest.fn();
@@ -133,6 +138,83 @@ describe('DataSourcePicker', () => {
 
       const input = screen.getByLabelText('Select a data source');
       expect(input).toHaveProperty('disabled', true);
+    });
+  });
+
+  describe('data source type checks', () => {
+    const prometheusDs: DataSourceInstanceSettings = {
+      uid: 'prom-uid',
+      name: 'Prometheus',
+      type: 'prometheus',
+      meta: {
+        id: 'prometheus',
+        name: 'Prometheus',
+        type: 'datasource',
+        info: {
+          logos: { small: 'prom.svg', large: 'prom.svg' },
+          author: { name: 'Grafana Labs' },
+          description: '',
+          links: [],
+          screenshots: [],
+          updated: '',
+          version: '1.0.0',
+        },
+        module: '',
+        baseUrl: '',
+      } as DataSourcePluginMeta,
+      readOnly: false,
+      jsonData: {},
+      access: 'proxy',
+    };
+
+    const tempoDs: DataSourceInstanceSettings = {
+      ...prometheusDs,
+      uid: 'tempo-uid',
+      name: 'Tempo',
+      type: 'tempo',
+      meta: {
+        ...prometheusDs.meta,
+        id: 'tempo',
+        name: 'Tempo',
+      },
+    };
+
+    it('returns an error when the current data source type is not in the filtered list', () => {
+      expect(getDataSourcePickerError('tempo-uid', tempoDs, [prometheusDs])).toBe(
+        'Data source type is not valid for this field: tempo'
+      );
+    });
+
+    it('returns undefined when the current data source type matches the filter', () => {
+      expect(getDataSourcePickerError('prom-uid', prometheusDs, [prometheusDs])).toBeUndefined();
+    });
+
+    it('returns undefined when noDefault is set and nothing is selected', () => {
+      expect(getDataSourcePickerError(null, undefined, [prometheusDs], true)).toBeUndefined();
+    });
+
+    it('returns a not-found error when the current data source cannot be resolved', () => {
+      expect(getDataSourcePickerError('missing-uid', undefined, [prometheusDs])).toBe(
+        'Could not find data source missing-uid'
+      );
+    });
+
+    it('returns undefined for expression datasources even when they are not in the filtered list', () => {
+      expect(getDataSourcePickerError('__expr__', undefined, [prometheusDs])).toBeUndefined();
+    });
+
+    it('recomputes validity on render when the allowed list changes without filter prop changes', () => {
+      mockGetInstanceSettings.mockReturnValue(prometheusDs);
+      mockGetList.mockReturnValue([prometheusDs]);
+      const { rerender } = render(<DataSourcePicker current="prom-uid" pluginId="prometheus" onChange={jest.fn()} />);
+
+      const wrapper = () => screen.getByLabelText('Data source picker select container').querySelector('.ds-picker');
+      const validClass = wrapper()?.className;
+
+      mockGetList.mockReturnValue([]);
+      rerender(<DataSourcePicker current="prom-uid" pluginId="prometheus" onChange={jest.fn()} />);
+
+      expect(wrapper()?.className).not.toBe(validClass);
     });
   });
 

--- a/packages/grafana-runtime/src/components/DataSourcePicker.test.tsx
+++ b/packages/grafana-runtime/src/components/DataSourcePicker.test.tsx
@@ -190,7 +190,10 @@ describe('DataSourcePicker', () => {
     it('allows an empty selection', () => {
       expect(isDataSourceCompatibleWithPicker(null, undefined, [prometheusDs])).toBe(true);
       expect(isDataSourceCompatibleWithPicker(undefined, undefined, [prometheusDs])).toBe(true);
-      expect(isDataSourceCompatibleWithPicker('', undefined, [prometheusDs])).toBe(true);
+    });
+
+    it('rejects an empty string uid that cannot be resolved', () => {
+      expect(isDataSourceCompatibleWithPicker('', undefined, [prometheusDs])).toBe(false);
     });
 
     it('rejects the org default when nothing is selected and the default is not in the filtered list', () => {
@@ -336,6 +339,13 @@ describe('DataSourcePicker', () => {
       render(<DataSourcePicker current={null} noDefault onChange={jest.fn()} />);
 
       expect(screen.getByRole('combobox')).toHaveAttribute('aria-invalid', 'false');
+    });
+
+    it('marks the select invalid when the current uid is an empty string that cannot be resolved', () => {
+      mockGetInstanceSettings.mockReturnValue(undefined);
+      render(<DataSourcePicker current="" pluginId="prometheus" onChange={jest.fn()} />);
+
+      expect(screen.getByRole('combobox')).toHaveAttribute('aria-invalid', 'true');
     });
 
     it('marks the select invalid when the org default is used and is not in the filtered list', () => {

--- a/packages/grafana-runtime/src/components/DataSourcePicker.test.tsx
+++ b/packages/grafana-runtime/src/components/DataSourcePicker.test.tsx
@@ -193,14 +193,44 @@ describe('DataSourcePicker', () => {
       expect(isDataSourceCompatibleWithPicker('', undefined, [prometheusDs])).toBe(true);
     });
 
+    it('rejects the org default when nothing is selected and the default is not in the filtered list', () => {
+      expect(isDataSourceCompatibleWithPicker(null, tempoDs, [prometheusDs])).toBe(false);
+      expect(isDataSourceCompatibleWithPicker(undefined, tempoDs, [prometheusDs])).toBe(false);
+    });
+
+    it('allows the org default when nothing is selected and the default is in the filtered list', () => {
+      expect(isDataSourceCompatibleWithPicker(null, prometheusDs, [prometheusDs])).toBe(true);
+    });
+
     it('rejects a selected data source that cannot be resolved', () => {
       expect(isDataSourceCompatibleWithPicker('missing-uid', undefined, [prometheusDs])).toBe(false);
       expect(isDataSourceCompatibleWithPicker({ uid: 'missing-uid' }, undefined, [prometheusDs])).toBe(false);
     });
 
     it('allows expression datasources even when they are not in the filtered list', () => {
+      const exprSettings: DataSourceInstanceSettings = {
+        ...prometheusDs,
+        uid: '__expr__',
+        name: 'Expression',
+        type: '__expr__',
+      };
       expect(isDataSourceCompatibleWithPicker('__expr__', undefined, [prometheusDs])).toBe(true);
       expect(isDataSourceCompatibleWithPicker({ uid: '__expr__' }, undefined, [prometheusDs])).toBe(true);
+      expect(isDataSourceCompatibleWithPicker({ type: '__expr__' }, exprSettings, [prometheusDs])).toBe(true);
+      expect(isDataSourceCompatibleWithPicker('Expression', undefined, [prometheusDs])).toBe(true);
+      expect(isDataSourceCompatibleWithPicker('-100', undefined, [prometheusDs])).toBe(true);
+      expect(isDataSourceCompatibleWithPicker('__expr__', exprSettings, [prometheusDs])).toBe(true);
+    });
+
+    it('rejects mixed and other built-in datasources when they are not in the filtered list', () => {
+      const mixedDs: DataSourceInstanceSettings = {
+        ...prometheusDs,
+        uid: '-- Mixed --',
+        name: '-- Mixed --',
+        type: 'mixed',
+      };
+      expect(isDataSourceCompatibleWithPicker('-- Mixed --', mixedDs, [prometheusDs])).toBe(false);
+      expect(isDataSourceCompatibleWithPicker('-- Mixed --', mixedDs, [prometheusDs, mixedDs])).toBe(true);
     });
 
     it('allows template datasource refs that resolved via rawRef even when the variable uid is not in the list', () => {
@@ -211,13 +241,20 @@ describe('DataSourcePicker', () => {
         rawRef: { type: 'prometheus', uid: 'prom-uid' },
       };
       expect(isDataSourceCompatibleWithPicker('${ds}', variableSettings, [prometheusDs])).toBe(true);
-      expect(isDataSourceCompatibleWithPicker('$ds', { ...variableSettings, uid: '$ds', name: '$ds' }, [prometheusDs])).toBe(
-        true
-      );
+      expect(
+        isDataSourceCompatibleWithPicker('$ds', { ...variableSettings, uid: '$ds', name: '$ds' }, [prometheusDs])
+      ).toBe(true);
       expect(
         isDataSourceCompatibleWithPicker('${rowDs}', { ...variableSettings, uid: '${rowDs}', name: '${rowDs}' }, [
           prometheusDs,
         ])
+      ).toBe(true);
+      expect(
+        isDataSourceCompatibleWithPicker(
+          'logs-${stage}-loki',
+          { ...variableSettings, uid: 'logs-${stage}-loki', name: 'logs-${stage}-loki' },
+          [prometheusDs]
+        )
       ).toBe(true);
     });
 
@@ -233,6 +270,36 @@ describe('DataSourcePicker', () => {
         rawRef: { type: 'tempo', uid: 'tempo-uid' },
       };
       expect(isDataSourceCompatibleWithPicker('${ds}', variableSettings, [prometheusDs])).toBe(false);
+    });
+
+    it('rejects a mismatched template ref even when getList injected the variable wrapper', () => {
+      const variableSettings: DataSourceInstanceSettings = {
+        ...tempoDs,
+        uid: '${ds}',
+        name: '${ds}',
+        rawRef: { type: 'tempo', uid: 'tempo-uid' },
+      };
+      const injectedVariable: DataSourceInstanceSettings = {
+        ...tempoDs,
+        uid: '${ds}',
+        name: '${ds}',
+      };
+      expect(isDataSourceCompatibleWithPicker('${ds}', variableSettings, [prometheusDs, injectedVariable])).toBe(false);
+    });
+
+    it('allows a matching template ref when getList injected the variable wrapper', () => {
+      const variableSettings: DataSourceInstanceSettings = {
+        ...prometheusDs,
+        uid: '${ds}',
+        name: '${ds}',
+        rawRef: { type: 'prometheus', uid: 'prom-uid' },
+      };
+      const injectedVariable: DataSourceInstanceSettings = {
+        ...prometheusDs,
+        uid: '${ds}',
+        name: '${ds}',
+      };
+      expect(isDataSourceCompatibleWithPicker('${ds}', variableSettings, [prometheusDs, injectedVariable])).toBe(true);
     });
 
     it('marks the select invalid when the current data source is not in the filtered list', () => {
@@ -260,6 +327,56 @@ describe('DataSourcePicker', () => {
 
       mockGetList.mockReturnValue([]);
       rerender(<DataSourcePicker current="prom-uid" pluginId="prometheus" onChange={jest.fn()} />);
+
+      expect(screen.getByRole('combobox')).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    it('does not mark the select invalid when noDefault is set and nothing is selected', () => {
+      mockGetInstanceSettings.mockReturnValue(undefined);
+      render(<DataSourcePicker current={null} noDefault onChange={jest.fn()} />);
+
+      expect(screen.getByRole('combobox')).toHaveAttribute('aria-invalid', 'false');
+    });
+
+    it('marks the select invalid when the org default is used and is not in the filtered list', () => {
+      mockGetInstanceSettings.mockReturnValue(tempoDs);
+      mockGetList.mockReturnValue([prometheusDs]);
+      render(<DataSourcePicker current={undefined} pluginId="prometheus" onChange={jest.fn()} />);
+
+      expect(screen.getByRole('combobox')).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    it('keeps the select invalid when the parent passes invalid even if the type matches', () => {
+      mockGetInstanceSettings.mockReturnValue(prometheusDs);
+      mockGetList.mockReturnValue([prometheusDs]);
+      render(<DataSourcePicker current="prom-uid" pluginId="prometheus" invalid onChange={jest.fn()} />);
+
+      expect(screen.getByRole('combobox')).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    it('marks the select invalid when a custom filter excludes the current data source', () => {
+      mockGetInstanceSettings.mockReturnValue(tempoDs);
+      mockGetList.mockReturnValue([prometheusDs]);
+      render(<DataSourcePicker current="tempo-uid" filter={(ds) => ds.uid === prometheusDs.uid} onChange={jest.fn()} />);
+
+      expect(screen.getByRole('combobox')).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    it('marks the select invalid when a template ref interpolates to a filtered-out data source even if the variable wrapper is listed', () => {
+      const variableSettings: DataSourceInstanceSettings = {
+        ...tempoDs,
+        uid: '${ds}',
+        name: '${ds}',
+        rawRef: { type: 'tempo', uid: 'tempo-uid' },
+      };
+      const injectedVariable: DataSourceInstanceSettings = {
+        ...tempoDs,
+        uid: '${ds}',
+        name: '${ds}',
+      };
+      mockGetInstanceSettings.mockReturnValue(variableSettings);
+      mockGetList.mockReturnValue([prometheusDs, injectedVariable]);
+      render(<DataSourcePicker current="${ds}" pluginId="prometheus" variables onChange={jest.fn()} />);
 
       expect(screen.getByRole('combobox')).toHaveAttribute('aria-invalid', 'true');
     });

--- a/packages/grafana-runtime/src/components/DataSourcePicker.tsx
+++ b/packages/grafana-runtime/src/components/DataSourcePicker.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import { type ComponentType, memo, useEffect, useState } from 'react';
+import { type ComponentType, memo } from 'react';
 
 // Components
 import {
@@ -14,7 +14,7 @@ import { type ActionMeta, PluginSignatureBadge, Select, Stack } from '@grafana/u
 
 import { getDataSourceSrv } from '../services/dataSourceSrv';
 
-import { ExpressionDatasourceRef } from './../utils/expressionRef';
+import { ExpressionDatasourceRef, isExpressionReference } from './../utils/expressionRef';
 
 /**
  * Component props description for the {@link DataSourcePicker}
@@ -54,6 +54,29 @@ export interface DataSourcePickerProps {
 type DataSourcePickerComponentType = ComponentType<DataSourcePickerProps>;
 
 let DataSourcePickerComponent: DataSourcePickerComponentType | undefined;
+
+/** @internal */
+export function getDataSourcePickerError(
+  current: DataSourcePickerProps['current'],
+  currentSettings: DataSourceInstanceSettings | undefined,
+  allowed: DataSourceInstanceSettings[],
+  noDefault?: boolean
+): string | undefined {
+  if (!current && noDefault) {
+    return undefined;
+  }
+  // Expressions are valid query datasources but are not returned by getList().
+  if (isExpressionReference(current) || isExpressionReference(currentSettings)) {
+    return undefined;
+  }
+  if (!currentSettings) {
+    return 'Could not find data source ' + current;
+  }
+  if (!allowed.some((ds) => ds.uid === currentSettings.uid)) {
+    return `Data source type is not valid for this field: ${currentSettings.type}`;
+  }
+  return undefined;
+}
 
 /**
  * Used to bootstrap the DataSourcePicker during application start, so the
@@ -115,14 +138,21 @@ export const LegacyDataSourcePicker = memo(function LegacyDataSourcePicker({
   isLoading = false,
 }: DataSourcePickerProps) {
   const dataSourceSrv = getDataSourceSrv();
-  const [error, setError] = useState<string | undefined>(undefined);
-
-  useEffect(() => {
-    const dsSettings = dataSourceSrv.getInstanceSettings(current);
-    if (!dsSettings) {
-      setError('Could not find data source ' + current);
-    }
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  const currentSettings = dataSourceSrv.getInstanceSettings(current);
+  const allowed = dataSourceSrv.getList({
+    alerting,
+    tracing,
+    metrics,
+    logs,
+    dashboard,
+    mixed,
+    variables,
+    annotations,
+    pluginId,
+    filter,
+    type,
+  });
+  const error = getDataSourcePickerError(current, currentSettings, allowed, noDefault);
 
   function handleChange(item: SelectableValue<string>, actionMeta: ActionMeta) {
     if (actionMeta.action === 'clear' && onClear) {
@@ -132,7 +162,6 @@ export const LegacyDataSourcePicker = memo(function LegacyDataSourcePicker({
     const dsSettings = dataSourceSrv.getInstanceSettings(item.value);
     if (dsSettings) {
       onChange(dsSettings);
-      setError(undefined);
     }
   }
 
@@ -140,14 +169,13 @@ export const LegacyDataSourcePicker = memo(function LegacyDataSourcePicker({
     if (!current && noDefault) {
       return;
     }
-    const ds = dataSourceSrv.getInstanceSettings(current);
-    if (ds) {
+    if (currentSettings) {
       return {
-        label: ds.name,
-        value: ds.uid,
-        imgUrl: ds.meta.info.logos.small,
+        label: currentSettings.name,
+        value: currentSettings.uid,
+        imgUrl: currentSettings.meta.info.logos.small,
         hideText: hideTextValue,
-        meta: ds.meta,
+        meta: currentSettings.meta,
       };
     }
     const uid = getDataSourceUID(current);
@@ -162,18 +190,12 @@ export const LegacyDataSourcePicker = memo(function LegacyDataSourcePicker({
     };
   }
 
-  function getDataSourceOptions() {
-    return dataSourceSrv
-      .getList({ alerting, tracing, metrics, logs, dashboard, mixed, variables, annotations, pluginId, filter, type })
-      .map((ds) => ({
-        value: ds.uid,
-        label: `${ds.name}${ds.isDefault ? ' (default)' : ''}`,
-        imgUrl: ds.meta.info.logos.small,
-        meta: ds.meta,
-      }));
-  }
-
-  const options = getDataSourceOptions();
+  const options = allowed.map((ds) => ({
+    value: ds.uid,
+    label: `${ds.name}${ds.isDefault ? ' (default)' : ''}`,
+    imgUrl: ds.meta.info.logos.small,
+    meta: ds.meta,
+  }));
   const value = getCurrentValue();
   const isClearable = typeof onClear === 'function';
 

--- a/packages/grafana-runtime/src/components/DataSourcePicker.tsx
+++ b/packages/grafana-runtime/src/components/DataSourcePicker.tsx
@@ -55,27 +55,34 @@ type DataSourcePickerComponentType = ComponentType<DataSourcePickerProps>;
 
 let DataSourcePickerComponent: DataSourcePickerComponentType | undefined;
 
-/** @internal */
-export function getDataSourcePickerError(
-  current: DataSourcePickerProps['current'],
-  currentSettings: DataSourceInstanceSettings | undefined,
-  allowed: DataSourceInstanceSettings[],
-  noDefault?: boolean
-): string | undefined {
-  if (!current && noDefault) {
-    return undefined;
-  }
+type DataSourcePickerSelection = string | DataSourceRef | DataSourceInstanceSettings | null | undefined;
+
+/**
+ * Config/provisioning can set a data source the UI picker would never offer
+ * (e.g. Tempo in a Prometheus-only field). Callers should pass `resolved` as
+ * undefined when `noDefault` is set and nothing is selected, so a fallback
+ * default is not treated as the current value.
+ *
+ * @internal
+ */
+export function isDataSourceCompatibleWithPicker(
+  selected: DataSourcePickerSelection,
+  resolved: DataSourceInstanceSettings | undefined,
+  allowed: DataSourceInstanceSettings[]
+): boolean {
   // Expressions are valid query datasources but are not returned by getList().
-  if (isExpressionReference(current) || isExpressionReference(currentSettings)) {
-    return undefined;
+  if (isExpressionReference(selected) || isExpressionReference(resolved)) {
+    return true;
   }
-  if (!currentSettings) {
-    return 'Could not find data source ' + current;
+  if (!resolved) {
+    return selected == null || selected === '';
   }
-  if (!allowed.some((ds) => ds.uid === currentSettings.uid)) {
-    return `Data source type is not valid for this field: ${currentSettings.type}`;
-  }
-  return undefined;
+  // Template refs keep the variable string as uid (`$ds`, `${ds}`, `logs-${stage}-loki`)
+  // and the concrete datasource in rawRef. Those wrapper uids are often missing from the
+  // picker list: getList({ variables: true }) injects `${name}` only for dashboard-level
+  // variables, not `$name`, interpolated names, or section-scoped refs. Match the
+  // interpolated datasource so a Tempo-backed ${ds} is still invalid in a Prometheus field.
+  return allowed.some((ds) => ds.uid === resolved.uid || ds.uid === resolved.rawRef?.uid);
 }
 
 /**
@@ -138,7 +145,7 @@ export const LegacyDataSourcePicker = memo(function LegacyDataSourcePicker({
   isLoading = false,
 }: DataSourcePickerProps) {
   const dataSourceSrv = getDataSourceSrv();
-  const currentSettings = dataSourceSrv.getInstanceSettings(current);
+  const currentSettings = !current && noDefault ? undefined : dataSourceSrv.getInstanceSettings(current);
   const allowed = dataSourceSrv.getList({
     alerting,
     tracing,
@@ -152,7 +159,7 @@ export const LegacyDataSourcePicker = memo(function LegacyDataSourcePicker({
     filter,
     type,
   });
-  const error = getDataSourcePickerError(current, currentSettings, allowed, noDefault);
+  const isCurrentCompatible = isDataSourceCompatibleWithPicker(current, currentSettings, allowed);
 
   function handleChange(item: SelectableValue<string>, actionMeta: ActionMeta) {
     if (actionMeta.action === 'clear' && onClear) {
@@ -198,6 +205,7 @@ export const LegacyDataSourcePicker = memo(function LegacyDataSourcePicker({
   }));
   const value = getCurrentValue();
   const isClearable = typeof onClear === 'function';
+  const isInvalid = Boolean(invalid) || !isCurrentCompatible;
 
   return (
     <div aria-label="Data source picker select container" data-testid={selectors.components.DataSourcePicker.container}>
@@ -205,6 +213,7 @@ export const LegacyDataSourcePicker = memo(function LegacyDataSourcePicker({
         isLoading={isLoading}
         disabled={disabled}
         aria-label={'Select a data source'}
+        aria-invalid={isInvalid}
         data-testid={selectors.components.DataSourcePicker.inputV2}
         inputId={inputId || 'data-source-picker'}
         className="ds-picker select-container"
@@ -221,7 +230,7 @@ export const LegacyDataSourcePicker = memo(function LegacyDataSourcePicker({
         placeholder={placeholder}
         noOptionsMessage="No datasources found"
         value={value ?? null}
-        invalid={Boolean(error) || Boolean(invalid)}
+        invalid={isInvalid}
         getOptionLabel={(o) => {
           if (o.meta && isUnsignedPluginSignature(o.meta.signature) && o !== value) {
             return (

--- a/packages/grafana-runtime/src/components/DataSourcePicker.tsx
+++ b/packages/grafana-runtime/src/components/DataSourcePicker.tsx
@@ -75,7 +75,8 @@ export function isDataSourceCompatibleWithPicker(
     return true;
   }
   if (!resolved) {
-    return selected == null || selected === '';
+    // Only null/undefined mean "nothing selected". An empty string is an unresolved uid.
+    return selected == null;
   }
   // Template refs keep the variable string as uid (`$ds`, `${ds}`, `logs-${stage}-loki`)
   // and the concrete datasource in rawRef. Match only the interpolated uid: getList({ variables: true })

--- a/packages/grafana-runtime/src/components/DataSourcePicker.tsx
+++ b/packages/grafana-runtime/src/components/DataSourcePicker.tsx
@@ -78,11 +78,12 @@ export function isDataSourceCompatibleWithPicker(
     return selected == null || selected === '';
   }
   // Template refs keep the variable string as uid (`$ds`, `${ds}`, `logs-${stage}-loki`)
-  // and the concrete datasource in rawRef. Those wrapper uids are often missing from the
-  // picker list: getList({ variables: true }) injects `${name}` only for dashboard-level
-  // variables, not `$name`, interpolated names, or section-scoped refs. Match the
-  // interpolated datasource so a Tempo-backed ${ds} is still invalid in a Prometheus field.
-  return allowed.some((ds) => ds.uid === resolved.uid || ds.uid === resolved.rawRef?.uid);
+  // and the concrete datasource in rawRef. Match only the interpolated uid: getList({ variables: true })
+  // injects `${name}` after type filters, so matching the wrapper uid would treat a Tempo-backed
+  // ${ds} as valid in a Prometheus field. `$name`, interpolated names, and section-scoped refs
+  // are also absent from that injected list.
+  const uidToMatch = resolved.rawRef?.uid ?? resolved.uid;
+  return allowed.some((ds) => ds.uid === uidToMatch);
 }
 
 /**

--- a/packages/grafana-runtime/src/internal/index.ts
+++ b/packages/grafana-runtime/src/internal/index.ts
@@ -10,7 +10,11 @@
  *
  */
 
-export { LegacyDataSourcePicker, setDataSourcePicker } from '../components/DataSourcePicker';
+export {
+  LegacyDataSourcePicker,
+  setDataSourcePicker,
+  isDataSourceCompatibleWithPicker,
+} from '../components/DataSourcePicker';
 export { setPanelDataErrorView } from '../components/PanelDataErrorView';
 export { setPanelRenderer } from '../components/PanelRenderer';
 export { type PageInfoItem, setPluginPage } from '../components/PluginPage';

--- a/public/app/features/datasources/components/picker/DataSourcePicker.test.tsx
+++ b/public/app/features/datasources/components/picker/DataSourcePicker.test.tsx
@@ -238,10 +238,36 @@ describe('DataSourcePicker', () => {
       mockUseDatasources.mockReturnValue([mockDS1]);
       getInstanceSettingsMock.mockReturnValue(undefined);
       render(<DataSourcePicker onChange={jest.fn()} current="__expr__" pluginId="prometheus"></DataSourcePicker>);
+      const input = screen.getByTestId(selectors.components.DataSourcePicker.inputV2);
+      expect(input).toHaveAttribute('aria-invalid', 'false');
+      expect(input).not.toHaveAttribute('placeholder', '__expr__ - not found');
+    });
+
+    it('should not mark the input as invalid when the current value is a template datasource ref', () => {
+      mockUseDatasources.mockReturnValue([mockDS1]);
+      getInstanceSettingsMock.mockReturnValue({
+        ...mockDS1,
+        uid: '${ds}',
+        name: '${ds}',
+        rawRef: { type: mockDS1.type, uid: mockDS1.uid },
+      });
+      render(<DataSourcePicker onChange={jest.fn()} current="${ds}" pluginId="prometheus"></DataSourcePicker>);
       expect(screen.getByTestId(selectors.components.DataSourcePicker.inputV2)).toHaveAttribute(
         'aria-invalid',
         'false'
       );
+    });
+
+    it('should mark the input as invalid when a template datasource ref interpolates to a filtered-out data source', () => {
+      mockUseDatasources.mockReturnValue([mockDS1]);
+      getInstanceSettingsMock.mockReturnValue({
+        ...mockDS2,
+        uid: '${ds}',
+        name: '${ds}',
+        rawRef: { type: mockDS2.type, uid: mockDS2.uid },
+      });
+      render(<DataSourcePicker onChange={jest.fn()} current="${ds}" pluginId="prometheus"></DataSourcePicker>);
+      expect(screen.getByTestId(selectors.components.DataSourcePicker.inputV2)).toHaveAttribute('aria-invalid', 'true');
     });
 
     it('should not mark the input as invalid when noDefault is set and nothing is selected', () => {

--- a/public/app/features/datasources/components/picker/DataSourcePicker.test.tsx
+++ b/public/app/features/datasources/components/picker/DataSourcePicker.test.tsx
@@ -74,13 +74,14 @@ jest.mock('@grafana/runtime', () => ({
   }),
 }));
 
+const mockUseDatasources = jest.fn(() => mockDSList);
 const pushRecentlyUsedDataSourceMock = jest.fn();
 jest.mock('../../hooks', () => {
   const actual = jest.requireActual('../../hooks');
   return {
     ...actual,
     useRecentlyUsedDataSources: () => [[mockDS2.name], pushRecentlyUsedDataSourceMock],
-    useDatasources: () => mockDSList,
+    useDatasources: () => mockUseDatasources(),
   };
 });
 
@@ -94,6 +95,7 @@ const getInstanceSettingsMock = jest.fn();
 beforeEach(() => {
   getListMock.mockReturnValue(mockDSList);
   getInstanceSettingsMock.mockReturnValue(mockDS1);
+  mockUseDatasources.mockReturnValue(mockDSList);
 });
 
 describe('DataSourcePicker', () => {
@@ -203,6 +205,73 @@ describe('DataSourcePicker', () => {
 
     it('should mark the input as invalid when `invalid` is true', () => {
       render(<DataSourcePicker onChange={jest.fn()} invalid></DataSourcePicker>);
+      expect(screen.getByTestId(selectors.components.DataSourcePicker.inputV2)).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    it('should mark the input as invalid when the current data source is not allowed by picker filters', () => {
+      mockUseDatasources.mockReturnValue([mockDS1]);
+      getInstanceSettingsMock.mockReturnValue(mockDS2);
+      render(<DataSourcePicker onChange={jest.fn()} current={mockDS2} pluginId="prometheus"></DataSourcePicker>);
+      expect(screen.getByTestId(selectors.components.DataSourcePicker.inputV2)).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    it('should not mark the input as invalid when the current data source matches picker filters', () => {
+      mockUseDatasources.mockReturnValue([mockDS1]);
+      getInstanceSettingsMock.mockReturnValue(mockDS1);
+      render(<DataSourcePicker onChange={jest.fn()} current={mockDS1} pluginId="prometheus"></DataSourcePicker>);
+      expect(screen.getByTestId(selectors.components.DataSourcePicker.inputV2)).toHaveAttribute(
+        'aria-invalid',
+        'false'
+      );
+    });
+
+    it('should mark the input as invalid when the current data source cannot be resolved', () => {
+      mockUseDatasources.mockReturnValue([mockDS1]);
+      getInstanceSettingsMock.mockReturnValue(undefined);
+      render(<DataSourcePicker onChange={jest.fn()} current="missing-uid" pluginId="prometheus"></DataSourcePicker>);
+      const input = screen.getByTestId(selectors.components.DataSourcePicker.inputV2);
+      expect(input).toHaveAttribute('aria-invalid', 'true');
+      expect(input).toHaveAttribute('placeholder', 'missing-uid - not found');
+    });
+
+    it('should not mark the input as invalid when the current value is an expression', () => {
+      mockUseDatasources.mockReturnValue([mockDS1]);
+      getInstanceSettingsMock.mockReturnValue(undefined);
+      render(<DataSourcePicker onChange={jest.fn()} current="__expr__" pluginId="prometheus"></DataSourcePicker>);
+      expect(screen.getByTestId(selectors.components.DataSourcePicker.inputV2)).toHaveAttribute(
+        'aria-invalid',
+        'false'
+      );
+    });
+
+    it('should not mark the input as invalid when noDefault is set and nothing is selected', () => {
+      getInstanceSettingsMock.mockReturnValue(undefined);
+      render(<DataSourcePicker onChange={jest.fn()} current={null} noDefault></DataSourcePicker>);
+      expect(screen.getByTestId(selectors.components.DataSourcePicker.inputV2)).toHaveAttribute(
+        'aria-invalid',
+        'false'
+      );
+    });
+
+    it('should keep the input invalid when the parent passes invalid even if the type matches', () => {
+      mockUseDatasources.mockReturnValue([mockDS1]);
+      getInstanceSettingsMock.mockReturnValue(mockDS1);
+      render(
+        <DataSourcePicker onChange={jest.fn()} current={mockDS1} pluginId="prometheus" invalid></DataSourcePicker>
+      );
+      expect(screen.getByTestId(selectors.components.DataSourcePicker.inputV2)).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    it('should mark the input as invalid when a custom filter excludes the current data source', () => {
+      mockUseDatasources.mockReturnValue([mockDS1, mockDS2]);
+      getInstanceSettingsMock.mockReturnValue(mockDS2);
+      render(
+        <DataSourcePicker
+          onChange={jest.fn()}
+          current={mockDS2}
+          filter={(ds) => ds.uid === mockDS1.uid}
+        ></DataSourcePicker>
+      );
       expect(screen.getByTestId(selectors.components.DataSourcePicker.inputV2)).toHaveAttribute('aria-invalid', 'true');
     });
 

--- a/public/app/features/datasources/components/picker/DataSourcePicker.test.tsx
+++ b/public/app/features/datasources/components/picker/DataSourcePicker.test.tsx
@@ -270,6 +270,72 @@ describe('DataSourcePicker', () => {
       expect(screen.getByTestId(selectors.components.DataSourcePicker.inputV2)).toHaveAttribute('aria-invalid', 'true');
     });
 
+    it('should mark the input as invalid when a listed template variable interpolates to a filtered-out data source', () => {
+      const injectedVariable = { ...mockDS2, uid: '${ds}', name: '${ds}' };
+      mockUseDatasources.mockReturnValue([mockDS1, injectedVariable]);
+      getInstanceSettingsMock.mockReturnValue({
+        ...mockDS2,
+        uid: '${ds}',
+        name: '${ds}',
+        rawRef: { type: mockDS2.type, uid: mockDS2.uid },
+      });
+      render(
+        <DataSourcePicker onChange={jest.fn()} current="${ds}" pluginId="prometheus" variables></DataSourcePicker>
+      );
+      expect(screen.getByTestId(selectors.components.DataSourcePicker.inputV2)).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    it('should not mark the input as invalid when a listed template variable interpolates to an allowed data source', () => {
+      const injectedVariable = { ...mockDS1, uid: '${ds}', name: '${ds}' };
+      mockUseDatasources.mockReturnValue([mockDS1, injectedVariable]);
+      getInstanceSettingsMock.mockReturnValue({
+        ...mockDS1,
+        uid: '${ds}',
+        name: '${ds}',
+        rawRef: { type: mockDS1.type, uid: mockDS1.uid },
+      });
+      render(
+        <DataSourcePicker onChange={jest.fn()} current="${ds}" pluginId="prometheus" variables></DataSourcePicker>
+      );
+      expect(screen.getByTestId(selectors.components.DataSourcePicker.inputV2)).toHaveAttribute(
+        'aria-invalid',
+        'false'
+      );
+    });
+
+    it('should mark the input as invalid when the org default is used and is not in the filtered list', () => {
+      mockUseDatasources.mockReturnValue([mockDS1]);
+      getInstanceSettingsMock.mockReturnValue(mockDS2);
+      render(<DataSourcePicker onChange={jest.fn()} current={undefined} pluginId="prometheus"></DataSourcePicker>);
+      expect(screen.getByTestId(selectors.components.DataSourcePicker.inputV2)).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    it('should not mark the input as invalid when the org default is used and matches picker filters', () => {
+      mockUseDatasources.mockReturnValue([mockDS1]);
+      getInstanceSettingsMock.mockReturnValue(mockDS1);
+      render(<DataSourcePicker onChange={jest.fn()} current={undefined} pluginId="prometheus"></DataSourcePicker>);
+      expect(screen.getByTestId(selectors.components.DataSourcePicker.inputV2)).toHaveAttribute(
+        'aria-invalid',
+        'false'
+      );
+    });
+
+    it('should recompute validity on render when the allowed list changes without filter prop changes', () => {
+      mockUseDatasources.mockReturnValue([mockDS1]);
+      getInstanceSettingsMock.mockReturnValue(mockDS1);
+      const { rerender } = render(
+        <DataSourcePicker onChange={jest.fn()} current={mockDS1} pluginId="prometheus"></DataSourcePicker>
+      );
+      expect(screen.getByTestId(selectors.components.DataSourcePicker.inputV2)).toHaveAttribute(
+        'aria-invalid',
+        'false'
+      );
+
+      mockUseDatasources.mockReturnValue([]);
+      rerender(<DataSourcePicker onChange={jest.fn()} current={mockDS1} pluginId="prometheus"></DataSourcePicker>);
+      expect(screen.getByTestId(selectors.components.DataSourcePicker.inputV2)).toHaveAttribute('aria-invalid', 'true');
+    });
+
     it('should not mark the input as invalid when noDefault is set and nothing is selected', () => {
       getInstanceSettingsMock.mockReturnValue(undefined);
       render(<DataSourcePicker onChange={jest.fn()} current={null} noDefault></DataSourcePicker>);

--- a/public/app/features/datasources/components/picker/DataSourcePicker.test.tsx
+++ b/public/app/features/datasources/components/picker/DataSourcePicker.test.tsx
@@ -345,6 +345,15 @@ describe('DataSourcePicker', () => {
       );
     });
 
+    it('should mark the input as invalid when the current uid is an empty string that cannot be resolved', () => {
+      mockUseDatasources.mockReturnValue([mockDS1]);
+      getInstanceSettingsMock.mockReturnValue(undefined);
+      render(<DataSourcePicker onChange={jest.fn()} current="" pluginId="prometheus"></DataSourcePicker>);
+      const input = screen.getByTestId(selectors.components.DataSourcePicker.inputV2);
+      expect(input).toHaveAttribute('aria-invalid', 'true');
+      expect(input).toHaveAttribute('placeholder', 'Select data source');
+    });
+
     it('should keep the input invalid when the parent passes invalid even if the type matches', () => {
       mockUseDatasources.mockReturnValue([mockDS1]);
       getInstanceSettingsMock.mockReturnValue(mockDS1);

--- a/public/app/features/datasources/components/picker/DataSourcePicker.tsx
+++ b/public/app/features/datasources/components/picker/DataSourcePicker.tsx
@@ -33,7 +33,7 @@ import { useDatasource, useDatasources } from '../../hooks';
 import { DataSourceList } from './DataSourceList';
 import { DataSourceLogo, DataSourceLogoPlaceHolder } from './DataSourceLogo';
 import { DataSourceModal } from './DataSourceModal';
-import { dataSourceLabel, matchDataSourceWithSearch } from './utils';
+import { dataSourceLabel, isDataSourceCompatibleWithPicker, matchDataSourceWithSearch } from './utils';
 
 export const INTERACTION_EVENT_NAME = 'dashboards_dspicker_clicked';
 export const INTERACTION_ITEM = {
@@ -134,6 +134,7 @@ export function DataSourcePicker(props: DataSourcePickerProps) {
     type: props.type,
     variables: props.variables,
   });
+  const isCurrentCompatible = isDataSourceCompatibleWithPicker(currentValue, dataSources, props.filter, current);
   const favoriteDataSources = useFavoriteDatasources();
   const placement = 'bottom-start';
 
@@ -291,8 +292,8 @@ export function DataSourcePicker(props: DataSourcePickerProps) {
           autoComplete="off"
           prefix={currentValue ? prefixIcon : undefined}
           suffix={suffix}
-          invalid={invalid}
-          placeholder={hideTextValue ? '' : dataSourceLabel(currentValue) || placeholder}
+          invalid={invalid || !isCurrentCompatible}
+          placeholder={hideTextValue ? '' : dataSourceLabel(currentValue ?? current) || placeholder}
           onFocus={() => {
             setInputHasFocus(true);
           }}

--- a/public/app/features/datasources/components/picker/DataSourcePicker.tsx
+++ b/public/app/features/datasources/components/picker/DataSourcePicker.tsx
@@ -34,7 +34,7 @@ import { useDatasource, useDatasources } from '../../hooks';
 import { DataSourceList } from './DataSourceList';
 import { DataSourceLogo, DataSourceLogoPlaceHolder } from './DataSourceLogo';
 import { DataSourceModal } from './DataSourceModal';
-import { dataSourceLabel, matchDataSourceWithSearch } from './utils';
+import { getDataSourcePickerPlaceholder, matchDataSourceWithSearch } from './utils';
 
 export const INTERACTION_EVENT_NAME = 'dashboards_dspicker_clicked';
 export const INTERACTION_ITEM = {
@@ -135,6 +135,7 @@ export function DataSourcePicker(props: DataSourcePickerProps) {
     type: props.type,
     variables: props.variables,
   });
+  // useDatasources() does not take `filter`; apply it so compatibility matches what the user can pick.
   const allowed = props.filter ? dataSources.filter(props.filter) : dataSources;
   const isCurrentCompatible = isDataSourceCompatibleWithPicker(current, currentValue, allowed);
   const favoriteDataSources = useFavoriteDatasources();
@@ -295,13 +296,13 @@ export function DataSourcePicker(props: DataSourcePickerProps) {
           prefix={currentValue ? prefixIcon : undefined}
           suffix={suffix}
           invalid={invalid || !isCurrentCompatible}
-          placeholder={
+          placeholder={getDataSourcePickerPlaceholder(
+            currentValue,
+            current,
+            isCurrentCompatible,
+            placeholder,
             hideTextValue
-              ? ''
-              : dataSourceLabel(currentValue) ||
-                (!isCurrentCompatible ? dataSourceLabel(current) : undefined) ||
-                placeholder
-          }
+          )}
           onFocus={() => {
             setInputHasFocus(true);
           }}

--- a/public/app/features/datasources/components/picker/DataSourcePicker.tsx
+++ b/public/app/features/datasources/components/picker/DataSourcePicker.tsx
@@ -12,6 +12,7 @@ import { type DataSourceInstanceSettings, type GrafanaTheme2, type ScopedVars } 
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { type FavoriteDatasources, reportInteraction, useFavoriteDatasources } from '@grafana/runtime';
+import { isDataSourceCompatibleWithPicker } from '@grafana/runtime/internal';
 import { type DataQuery, type DataSourceJsonData, type DataSourceRef } from '@grafana/schema';
 import {
   Button,
@@ -33,7 +34,7 @@ import { useDatasource, useDatasources } from '../../hooks';
 import { DataSourceList } from './DataSourceList';
 import { DataSourceLogo, DataSourceLogoPlaceHolder } from './DataSourceLogo';
 import { DataSourceModal } from './DataSourceModal';
-import { dataSourceLabel, isDataSourceCompatibleWithPicker, matchDataSourceWithSearch } from './utils';
+import { dataSourceLabel, matchDataSourceWithSearch } from './utils';
 
 export const INTERACTION_EVENT_NAME = 'dashboards_dspicker_clicked';
 export const INTERACTION_ITEM = {
@@ -134,7 +135,8 @@ export function DataSourcePicker(props: DataSourcePickerProps) {
     type: props.type,
     variables: props.variables,
   });
-  const isCurrentCompatible = isDataSourceCompatibleWithPicker(currentValue, dataSources, props.filter, current);
+  const allowed = props.filter ? dataSources.filter(props.filter) : dataSources;
+  const isCurrentCompatible = isDataSourceCompatibleWithPicker(current, currentValue, allowed);
   const favoriteDataSources = useFavoriteDatasources();
   const placement = 'bottom-start';
 
@@ -293,7 +295,13 @@ export function DataSourcePicker(props: DataSourcePickerProps) {
           prefix={currentValue ? prefixIcon : undefined}
           suffix={suffix}
           invalid={invalid || !isCurrentCompatible}
-          placeholder={hideTextValue ? '' : dataSourceLabel(currentValue ?? current) || placeholder}
+          placeholder={
+            hideTextValue
+              ? ''
+              : dataSourceLabel(currentValue) ||
+                (!isCurrentCompatible ? dataSourceLabel(current) : undefined) ||
+                placeholder
+          }
           onFocus={() => {
             setInputHasFocus(true);
           }}

--- a/public/app/features/datasources/components/picker/utils.test.ts
+++ b/public/app/features/datasources/components/picker/utils.test.ts
@@ -1,11 +1,6 @@
 import { type DataSourceInstanceSettings, type DataSourceRef } from '@grafana/data';
 
-import {
-  isDataSourceMatch,
-  getDataSourceCompareFn,
-  matchDataSourceWithSearch,
-  isDataSourceCompatibleWithPicker,
-} from './utils';
+import { isDataSourceMatch, getDataSourceCompareFn, matchDataSourceWithSearch } from './utils';
 
 describe('isDataSourceMatch', () => {
   const dataSourceInstanceSettings = { uid: 'a' } as DataSourceInstanceSettings;
@@ -31,41 +26,6 @@ describe('isDataSourceMatch', () => {
   });
   it('doesnt match a datasource with a datasource ref with a different uid', () => {
     expect(isDataSourceMatch(dataSourceInstanceSettings, { uid: 'b' } as DataSourceRef)).toBeFalsy();
-  });
-});
-
-describe('isDataSourceCompatibleWithPicker', () => {
-  const prometheus = { uid: 'prom', type: 'prometheus' } as DataSourceInstanceSettings;
-  const tempo = { uid: 'tempo', type: 'tempo' } as DataSourceInstanceSettings;
-
-  it('allows an empty selection', () => {
-    expect(isDataSourceCompatibleWithPicker(undefined, [prometheus])).toBe(true);
-  });
-
-  it('rejects a selected data source that cannot be resolved', () => {
-    expect(isDataSourceCompatibleWithPicker(undefined, [prometheus], undefined, 'missing-uid')).toBe(false);
-    expect(isDataSourceCompatibleWithPicker(undefined, [prometheus], undefined, { uid: 'missing-uid' })).toBe(false);
-  });
-
-  it('allows an explicit empty string as no selection', () => {
-    expect(isDataSourceCompatibleWithPicker(undefined, [prometheus], undefined, '')).toBe(true);
-  });
-
-  it('allows expression datasources even when they are not in the filtered list', () => {
-    expect(isDataSourceCompatibleWithPicker(undefined, [prometheus], undefined, '__expr__')).toBe(true);
-    expect(isDataSourceCompatibleWithPicker(undefined, [prometheus], undefined, { uid: '__expr__' })).toBe(true);
-  });
-
-  it('allows a current data source that is in the filtered list', () => {
-    expect(isDataSourceCompatibleWithPicker(prometheus, [prometheus, tempo])).toBe(true);
-  });
-
-  it('rejects a current data source that is not in the filtered list', () => {
-    expect(isDataSourceCompatibleWithPicker(tempo, [prometheus])).toBe(false);
-  });
-
-  it('rejects a current data source excluded by the custom filter', () => {
-    expect(isDataSourceCompatibleWithPicker(tempo, [prometheus, tempo], (ds) => ds.type === 'prometheus')).toBe(false);
   });
 });
 

--- a/public/app/features/datasources/components/picker/utils.test.ts
+++ b/public/app/features/datasources/components/picker/utils.test.ts
@@ -1,6 +1,11 @@
 import { type DataSourceInstanceSettings, type DataSourceRef } from '@grafana/data';
 
-import { isDataSourceMatch, getDataSourceCompareFn, matchDataSourceWithSearch } from './utils';
+import {
+  isDataSourceMatch,
+  getDataSourceCompareFn,
+  getDataSourcePickerPlaceholder,
+  matchDataSourceWithSearch,
+} from './utils';
 
 describe('isDataSourceMatch', () => {
   const dataSourceInstanceSettings = { uid: 'a' } as DataSourceInstanceSettings;
@@ -116,6 +121,32 @@ describe('getDataSouceCompareFn', () => {
       { uid: 'D', name: 'D', meta: { builtIn: false } },
       { uid: 'a', name: 'a', meta: { builtIn: true } },
     ] as DataSourceInstanceSettings[]);
+  });
+});
+
+describe('getDataSourcePickerPlaceholder', () => {
+  const prometheus = { uid: 'prom-uid', name: 'Prometheus' } as DataSourceInstanceSettings;
+
+  it('returns an empty string when text is hidden', () => {
+    expect(getDataSourcePickerPlaceholder(prometheus, prometheus, true, 'Select data source', true)).toBe('');
+  });
+
+  it('returns the resolved data source name when settings exist', () => {
+    expect(getDataSourcePickerPlaceholder(prometheus, 'prom-uid', false, 'Select data source')).toBe('Prometheus');
+  });
+
+  it('returns a not-found label when the current value is unresolved and incompatible', () => {
+    expect(getDataSourcePickerPlaceholder(undefined, 'missing-uid', false, 'Select data source')).toBe(
+      'missing-uid - not found'
+    );
+  });
+
+  it('returns the default placeholder when nothing is selected', () => {
+    expect(getDataSourcePickerPlaceholder(undefined, null, true, 'Select data source')).toBe('Select data source');
+  });
+
+  it('returns the default placeholder when the current uid is an empty string', () => {
+    expect(getDataSourcePickerPlaceholder(undefined, '', false, 'Select data source')).toBe('Select data source');
   });
 });
 

--- a/public/app/features/datasources/components/picker/utils.test.ts
+++ b/public/app/features/datasources/components/picker/utils.test.ts
@@ -1,6 +1,11 @@
 import { type DataSourceInstanceSettings, type DataSourceRef } from '@grafana/data';
 
-import { isDataSourceMatch, getDataSourceCompareFn, matchDataSourceWithSearch } from './utils';
+import {
+  isDataSourceMatch,
+  getDataSourceCompareFn,
+  matchDataSourceWithSearch,
+  isDataSourceCompatibleWithPicker,
+} from './utils';
 
 describe('isDataSourceMatch', () => {
   const dataSourceInstanceSettings = { uid: 'a' } as DataSourceInstanceSettings;
@@ -26,6 +31,41 @@ describe('isDataSourceMatch', () => {
   });
   it('doesnt match a datasource with a datasource ref with a different uid', () => {
     expect(isDataSourceMatch(dataSourceInstanceSettings, { uid: 'b' } as DataSourceRef)).toBeFalsy();
+  });
+});
+
+describe('isDataSourceCompatibleWithPicker', () => {
+  const prometheus = { uid: 'prom', type: 'prometheus' } as DataSourceInstanceSettings;
+  const tempo = { uid: 'tempo', type: 'tempo' } as DataSourceInstanceSettings;
+
+  it('allows an empty selection', () => {
+    expect(isDataSourceCompatibleWithPicker(undefined, [prometheus])).toBe(true);
+  });
+
+  it('rejects a selected data source that cannot be resolved', () => {
+    expect(isDataSourceCompatibleWithPicker(undefined, [prometheus], undefined, 'missing-uid')).toBe(false);
+    expect(isDataSourceCompatibleWithPicker(undefined, [prometheus], undefined, { uid: 'missing-uid' })).toBe(false);
+  });
+
+  it('allows an explicit empty string as no selection', () => {
+    expect(isDataSourceCompatibleWithPicker(undefined, [prometheus], undefined, '')).toBe(true);
+  });
+
+  it('allows expression datasources even when they are not in the filtered list', () => {
+    expect(isDataSourceCompatibleWithPicker(undefined, [prometheus], undefined, '__expr__')).toBe(true);
+    expect(isDataSourceCompatibleWithPicker(undefined, [prometheus], undefined, { uid: '__expr__' })).toBe(true);
+  });
+
+  it('allows a current data source that is in the filtered list', () => {
+    expect(isDataSourceCompatibleWithPicker(prometheus, [prometheus, tempo])).toBe(true);
+  });
+
+  it('rejects a current data source that is not in the filtered list', () => {
+    expect(isDataSourceCompatibleWithPicker(tempo, [prometheus])).toBe(false);
+  });
+
+  it('rejects a current data source excluded by the custom filter', () => {
+    expect(isDataSourceCompatibleWithPicker(tempo, [prometheus, tempo], (ds) => ds.type === 'prometheus')).toBe(false);
   });
 });
 

--- a/public/app/features/datasources/components/picker/utils.ts
+++ b/public/app/features/datasources/components/picker/utils.ts
@@ -1,4 +1,5 @@
 import { type DataSourceInstanceSettings, type DataSourceJsonData, type DataSourceRef } from '@grafana/data';
+import { isExpressionReference } from '@grafana/runtime';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import {
   initLastUsedDatasourceKeyForDashboard,
@@ -21,6 +22,30 @@ export function isDataSourceMatch(
     return ds.uid === current;
   }
   return ds.uid === current.uid;
+}
+
+/**
+ * Config/provisioning can set a data source the UI picker would never offer
+ * (e.g. Tempo in a Prometheus-only field). Returns false when `current` is set
+ * but would be filtered out of the picker list, or when `selected` is set but
+ * cannot be resolved to instance settings.
+ */
+export function isDataSourceCompatibleWithPicker(
+  current: DataSourceInstanceSettings | undefined,
+  allowed: DataSourceInstanceSettings[],
+  filter?: (dataSource: DataSourceInstanceSettings) => boolean,
+  selected?: string | DataSourceRef | DataSourceInstanceSettings | null
+): boolean {
+  if (isExpressionReference(selected) || isExpressionReference(current)) {
+    return true;
+  }
+  if (!current) {
+    return selected == null || selected === '';
+  }
+  if (filter && !filter(current)) {
+    return false;
+  }
+  return allowed.some((ds) => ds.uid === current.uid);
 }
 
 export function dataSourceLabel(

--- a/public/app/features/datasources/components/picker/utils.ts
+++ b/public/app/features/datasources/components/picker/utils.ts
@@ -1,5 +1,4 @@
 import { type DataSourceInstanceSettings, type DataSourceJsonData, type DataSourceRef } from '@grafana/data';
-import { isExpressionReference } from '@grafana/runtime';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import {
   initLastUsedDatasourceKeyForDashboard,
@@ -22,30 +21,6 @@ export function isDataSourceMatch(
     return ds.uid === current;
   }
   return ds.uid === current.uid;
-}
-
-/**
- * Config/provisioning can set a data source the UI picker would never offer
- * (e.g. Tempo in a Prometheus-only field). Returns false when `current` is set
- * but would be filtered out of the picker list, or when `selected` is set but
- * cannot be resolved to instance settings.
- */
-export function isDataSourceCompatibleWithPicker(
-  current: DataSourceInstanceSettings | undefined,
-  allowed: DataSourceInstanceSettings[],
-  filter?: (dataSource: DataSourceInstanceSettings) => boolean,
-  selected?: string | DataSourceRef | DataSourceInstanceSettings | null
-): boolean {
-  if (isExpressionReference(selected) || isExpressionReference(current)) {
-    return true;
-  }
-  if (!current) {
-    return selected == null || selected === '';
-  }
-  if (filter && !filter(current)) {
-    return false;
-  }
-  return allowed.some((ds) => ds.uid === current.uid);
 }
 
 export function dataSourceLabel(

--- a/public/app/features/datasources/components/picker/utils.ts
+++ b/public/app/features/datasources/components/picker/utils.ts
@@ -45,6 +45,25 @@ export function dataSourceLabel(
   return undefined;
 }
 
+export function getDataSourcePickerPlaceholder(
+  currentValue: DataSourceInstanceSettings<DataSourceJsonData> | undefined,
+  current: DataSourceInstanceSettings<DataSourceJsonData> | string | DataSourceRef | null | undefined,
+  isCurrentCompatible: boolean,
+  placeholder: string,
+  hideTextValue?: boolean
+): string {
+  if (hideTextValue) {
+    return '';
+  }
+  if (currentValue) {
+    return dataSourceLabel(currentValue) || placeholder;
+  }
+  if (!isCurrentCompatible) {
+    return dataSourceLabel(current) || placeholder;
+  }
+  return placeholder;
+}
+
 export function getDataSourceCompareFn(
   current: DataSourceRef | DataSourceInstanceSettings | string | null | undefined,
   recentlyUsedDataSources: string[],


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Marks both the unified and legacy data source pickers invalid when the current value is not in the filtered list the picker would offer (for example a Tempo UID in a Prometheus-only field). The stored value is left unchanged; the field is shown as invalid so provisioned or config-file mismatches are visible at runtime.

Compatibility is shared via `isDataSourceCompatibleWithPicker`:
- Empty selection with `noDefault` stays valid
- Expressions (`__expr__`) stay valid (they are never returned by `getList()`)
- Template refs (`${ds}`, `$ds`, interpolated names) are checked against the interpolated datasource in `rawRef`, including when `getList({ variables: true })` has injected the variable wrapper

**Why do we need this feature?**

Provisioning and configuration files can set a data source the UI would never let you pick, because the picker filters by type/`pluginId`/`filter` but config does not. That leaves fields looking selected and valid while pointing at the wrong kind of data source.

**Who is this feature for?**

Anyone using type-restricted data source fields: plugin config (trace-to-metrics, trace-to-logs, X-Ray links), dashboard import mapping, and provisioned dashboards/datasources.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #80065

**Special notes for your reviewer:**

- Runtime UI validation only: we do not rewrite or clear the current value.
- Template variables: match `resolved.rawRef?.uid ?? resolved.uid`. Matching the wrapper uid would treat a Tempo-backed `${ds}` as valid in a Prometheus picker because `getList({ variables: true })` injects `${name}` after type filters.
- No docs or feature toggle; this is a validation/UX change on existing pickers.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.