### PR TITLE
NavTree: Hide Assistant Cloud-only pages when ossMode is enabled

### DIFF
--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -37,14 +37,6 @@ var assistantTrialNavigationPaths = map[string]struct{}{
 	"/a/grafana-assistant-app/workspace": {},
 }
 
-// Cloud-only assistant pages that must stay hidden when the plugin is running
-// in ossMode, including on Grafana Enterprise / Cloud.
-var assistantOSSHiddenNavigationPaths = map[string]struct{}{
-	"/a/grafana-assistant-app/automations":      {},
-	"/a/grafana-assistant-app/watchers":         {},
-	"/a/grafana-assistant-app/assistant-search": {},
-}
-
 func (s *ServiceImpl) addAppLinks(treeRoot *navtree.NavTreeRoot, c *contextmodel.ReqContext) error {
 	hasAccess := ac.HasAccess(s.accessControl, c)
 	appLinks := []*navtree.NavLink{}
@@ -385,17 +377,12 @@ func (s *ServiceImpl) shouldIncludeAssistantNavigation(plugin pluginstore.Plugin
 		_, allowed := assistantTrialNavigationPaths[include.Path]
 		return allowed
 	}
-	if ossMode {
-		if _, hidden := assistantOSSHiddenNavigationPaths[include.Path]; hidden {
-			return false
-		}
-	}
-	if s.cfg.IsEnterprise || s.cfg.StackID != "" {
-		return true
+	if ossMode || !(s.cfg.IsEnterprise || s.cfg.StackID != "") {
+		_, allowed := assistantOSSNavigationPaths[include.Path]
+		return allowed
 	}
 
-	_, allowed := assistantOSSNavigationPaths[include.Path]
-	return allowed
+	return true
 }
 
 // attachPendingIncludes puts pages under their nearest path ancestor when nesting

--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -197,7 +197,7 @@ type pendingInclude struct {
 func (s *ServiceImpl) processAppPlugin(plugin pluginstore.Plugin, c *contextmodel.ReqContext, treeRoot *navtree.NavTreeRoot) *navtree.NavLink {
 	hasAccessToInclude := s.hasAccessToInclude(c, plugin.ID)
 	assistantTrialMode := s.isAssistantTrialMode(plugin, c)
-	assistantOSSMode := s.isAssistantOSSMode(plugin, c)
+	assistantOSSMode, assistantOSSModeSet := s.assistantOSSMode(plugin, c)
 	appLink := &navtree.NavLink{
 		Text:       plugin.Name,
 		Id:         "plugin-page-" + plugin.ID,
@@ -224,7 +224,7 @@ func (s *ServiceImpl) processAppPlugin(plugin pluginstore.Plugin, c *contextmode
 			continue
 		}
 
-		if !s.shouldIncludeAssistantNavigation(plugin, include, assistantTrialMode, assistantOSSMode) {
+		if !s.shouldIncludeAssistantNavigation(plugin, include, assistantTrialMode, assistantOSSMode, assistantOSSModeSet) {
 			continue
 		}
 
@@ -349,16 +349,11 @@ func (s *ServiceImpl) isAssistantTrialMode(plugin pluginstore.Plugin, c *context
 	return ok && value
 }
 
-func (s *ServiceImpl) isAssistantOSSMode(plugin pluginstore.Plugin, c *contextmodel.ReqContext) bool {
+func (s *ServiceImpl) assistantOSSMode(plugin pluginstore.Plugin, c *contextmodel.ReqContext) (ossMode bool, set bool) {
 	if plugin.ID != assistantAppID {
-		return false
+		return false, false
 	}
-	value, ok := s.assistantPluginJSONDataBool(plugin, c, "ossMode")
-	if !ok {
-		// Match the plugin: unset ossMode means OSS.
-		return true
-	}
-	return value
+	return s.assistantPluginJSONDataBool(plugin, c, "ossMode")
 }
 
 func (s *ServiceImpl) assistantPluginJSONDataBool(plugin pluginstore.Plugin, c *contextmodel.ReqContext, key string) (bool, bool) {
@@ -378,7 +373,7 @@ func (s *ServiceImpl) assistantPluginJSONDataBool(plugin pluginstore.Plugin, c *
 	return value, ok
 }
 
-func (s *ServiceImpl) shouldIncludeAssistantNavigation(plugin pluginstore.Plugin, include *plugins.Includes, trialMode, ossMode bool) bool {
+func (s *ServiceImpl) shouldIncludeAssistantNavigation(plugin pluginstore.Plugin, include *plugins.Includes, trialMode, ossMode, ossModeSet bool) bool {
 	if plugin.ID != assistantAppID {
 		return true
 	}
@@ -386,12 +381,21 @@ func (s *ServiceImpl) shouldIncludeAssistantNavigation(plugin pluginstore.Plugin
 		_, allowed := assistantTrialNavigationPaths[include.Path]
 		return allowed
 	}
-	if ossMode {
-		_, allowed := assistantOSSNavigationPaths[include.Path]
-		return allowed
+	if ossModeSet {
+		if ossMode {
+			_, allowed := assistantOSSNavigationPaths[include.Path]
+			return allowed
+		}
+		return true
 	}
-
-	return true
+	// ossMode was not persisted or plugin settings could not be read. Keep the
+	// previous Cloud/Enterprise default so unprovisioned stacks still show
+	// Cloud-only pages.
+	if s.cfg.IsEnterprise || s.cfg.StackID != "" {
+		return true
+	}
+	_, allowed := assistantOSSNavigationPaths[include.Path]
+	return allowed
 }
 
 // attachPendingIncludes puts pages under their nearest path ancestor when nesting

--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -37,6 +37,14 @@ var assistantTrialNavigationPaths = map[string]struct{}{
 	"/a/grafana-assistant-app/workspace": {},
 }
 
+// Cloud-only assistant pages that must stay hidden when the plugin is running
+// in ossMode, including on Grafana Enterprise / Cloud.
+var assistantOSSHiddenNavigationPaths = map[string]struct{}{
+	"/a/grafana-assistant-app/automations":      {},
+	"/a/grafana-assistant-app/watchers":         {},
+	"/a/grafana-assistant-app/assistant-search": {},
+}
+
 func (s *ServiceImpl) addAppLinks(treeRoot *navtree.NavTreeRoot, c *contextmodel.ReqContext) error {
 	hasAccess := ac.HasAccess(s.accessControl, c)
 	appLinks := []*navtree.NavLink{}
@@ -197,6 +205,7 @@ type pendingInclude struct {
 func (s *ServiceImpl) processAppPlugin(plugin pluginstore.Plugin, c *contextmodel.ReqContext, treeRoot *navtree.NavTreeRoot) *navtree.NavLink {
 	hasAccessToInclude := s.hasAccessToInclude(c, plugin.ID)
 	assistantTrialMode := s.isAssistantTrialMode(plugin, c)
+	assistantOSSMode := s.isAssistantOSSMode(plugin, c)
 	appLink := &navtree.NavLink{
 		Text:       plugin.Name,
 		Id:         "plugin-page-" + plugin.ID,
@@ -223,7 +232,7 @@ func (s *ServiceImpl) processAppPlugin(plugin pluginstore.Plugin, c *contextmode
 			continue
 		}
 
-		if !s.shouldIncludeAssistantNavigation(plugin, include, assistantTrialMode) {
+		if !s.shouldIncludeAssistantNavigation(plugin, include, assistantTrialMode, assistantOSSMode) {
 			continue
 		}
 
@@ -344,6 +353,14 @@ func (s *ServiceImpl) processAppPlugin(plugin pluginstore.Plugin, c *contextmode
 }
 
 func (s *ServiceImpl) isAssistantTrialMode(plugin pluginstore.Plugin, c *contextmodel.ReqContext) bool {
+	return s.assistantPluginJSONDataBool(plugin, c, "trialMode")
+}
+
+func (s *ServiceImpl) isAssistantOSSMode(plugin pluginstore.Plugin, c *contextmodel.ReqContext) bool {
+	return s.assistantPluginJSONDataBool(plugin, c, "ossMode")
+}
+
+func (s *ServiceImpl) assistantPluginJSONDataBool(plugin pluginstore.Plugin, c *contextmodel.ReqContext, key string) bool {
 	if plugin.ID != assistantAppID {
 		return false
 	}
@@ -352,21 +369,26 @@ func (s *ServiceImpl) isAssistantTrialMode(plugin pluginstore.Plugin, c *context
 		PluginID: plugin.ID,
 		OrgID:    c.GetOrgID(),
 	})
-	if err != nil {
+	if err != nil || ps.JSONData == nil {
 		return false
 	}
 
-	trialMode, ok := ps.JSONData["trialMode"].(bool)
-	return ok && trialMode
+	value, ok := ps.JSONData[key].(bool)
+	return ok && value
 }
 
-func (s *ServiceImpl) shouldIncludeAssistantNavigation(plugin pluginstore.Plugin, include *plugins.Includes, trialMode bool) bool {
+func (s *ServiceImpl) shouldIncludeAssistantNavigation(plugin pluginstore.Plugin, include *plugins.Includes, trialMode, ossMode bool) bool {
 	if plugin.ID != assistantAppID {
 		return true
 	}
 	if trialMode {
 		_, allowed := assistantTrialNavigationPaths[include.Path]
 		return allowed
+	}
+	if ossMode {
+		if _, hidden := assistantOSSHiddenNavigationPaths[include.Path]; hidden {
+			return false
+		}
 	}
 	if s.cfg.IsEnterprise || s.cfg.StackID != "" {
 		return true

--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -345,16 +345,25 @@ func (s *ServiceImpl) processAppPlugin(plugin pluginstore.Plugin, c *contextmode
 }
 
 func (s *ServiceImpl) isAssistantTrialMode(plugin pluginstore.Plugin, c *contextmodel.ReqContext) bool {
-	return s.assistantPluginJSONDataBool(plugin, c, "trialMode")
+	value, ok := s.assistantPluginJSONDataBool(plugin, c, "trialMode")
+	return ok && value
 }
 
 func (s *ServiceImpl) isAssistantOSSMode(plugin pluginstore.Plugin, c *contextmodel.ReqContext) bool {
-	return s.assistantPluginJSONDataBool(plugin, c, "ossMode")
-}
-
-func (s *ServiceImpl) assistantPluginJSONDataBool(plugin pluginstore.Plugin, c *contextmodel.ReqContext, key string) bool {
 	if plugin.ID != assistantAppID {
 		return false
+	}
+	value, ok := s.assistantPluginJSONDataBool(plugin, c, "ossMode")
+	if !ok {
+		// Match the plugin: unset ossMode means OSS.
+		return true
+	}
+	return value
+}
+
+func (s *ServiceImpl) assistantPluginJSONDataBool(plugin pluginstore.Plugin, c *contextmodel.ReqContext, key string) (bool, bool) {
+	if plugin.ID != assistantAppID {
+		return false, false
 	}
 
 	ps, err := s.pluginSettings.GetPluginSettingByPluginID(c.Req.Context(), &pluginsettings.GetByPluginIDArgs{
@@ -362,11 +371,11 @@ func (s *ServiceImpl) assistantPluginJSONDataBool(plugin pluginstore.Plugin, c *
 		OrgID:    c.GetOrgID(),
 	})
 	if err != nil || ps.JSONData == nil {
-		return false
+		return false, false
 	}
 
 	value, ok := ps.JSONData[key].(bool)
-	return ok && value
+	return value, ok
 }
 
 func (s *ServiceImpl) shouldIncludeAssistantNavigation(plugin pluginstore.Plugin, include *plugins.Includes, trialMode, ossMode bool) bool {
@@ -377,7 +386,7 @@ func (s *ServiceImpl) shouldIncludeAssistantNavigation(plugin pluginstore.Plugin
 		_, allowed := assistantTrialNavigationPaths[include.Path]
 		return allowed
 	}
-	if ossMode || !(s.cfg.IsEnterprise || s.cfg.StackID != "") {
+	if ossMode {
 		_, allowed := assistantOSSNavigationPaths[include.Path]
 		return allowed
 	}

--- a/pkg/services/navtree/navtreeimpl/applinks_test.go
+++ b/pkg/services/navtree/navtreeimpl/applinks_test.go
@@ -950,10 +950,11 @@ func TestProcessAssistantAppPlugin(t *testing.T) {
 		name           string
 		cfg            *setting.Cfg
 		jsonData       map[string]any
+		omitSettings   bool
 		wantChildPaths []string
 	}{
 		{
-			name:           "unset ossMode defaults to supported OSS entries",
+			name:           "unset ossMode on OSS Grafana only includes supported OSS entries",
 			jsonData:       map[string]any{},
 			wantChildPaths: ossChildPaths,
 		},
@@ -980,6 +981,24 @@ func TestProcessAssistantAppPlugin(t *testing.T) {
 			wantChildPaths: ossChildPaths,
 		},
 		{
+			name:           "unset ossMode on Enterprise includes all entries",
+			cfg:            &setting.Cfg{IsEnterprise: true},
+			jsonData:       map[string]any{},
+			wantChildPaths: cloudChildPaths,
+		},
+		{
+			name:           "unset ossMode on Cloud includes all entries",
+			cfg:            &setting.Cfg{StackID: "1"},
+			jsonData:       map[string]any{},
+			wantChildPaths: cloudChildPaths,
+		},
+		{
+			name:           "missing plugin settings on Enterprise includes all entries",
+			cfg:            &setting.Cfg{IsEnterprise: true},
+			omitSettings:   true,
+			wantChildPaths: cloudChildPaths,
+		},
+		{
 			name: "Trial mode only includes the homepage and workspace",
 			jsonData: map[string]any{
 				"trialMode": true,
@@ -995,11 +1014,13 @@ func TestProcessAssistantAppPlugin(t *testing.T) {
 			if cfg == nil {
 				cfg = setting.NewCfg()
 			}
+			plugins := map[string]*pluginsettings.DTO{}
+			if !tt.omitSettings {
+				plugins[assistantAppID] = &pluginsettings.DTO{OrgID: 1, PluginID: assistantAppID, JSONData: tt.jsonData}
+			}
 			service := ServiceImpl{
-				cfg: cfg,
-				pluginSettings: &pluginsettings.FakePluginSettings{Plugins: map[string]*pluginsettings.DTO{
-					assistantAppID: {OrgID: 1, PluginID: assistantAppID, JSONData: tt.jsonData},
-				}},
+				cfg:            cfg,
+				pluginSettings: &pluginsettings.FakePluginSettings{Plugins: plugins},
 			}
 			treeRoot := navtree.NavTreeRoot{}
 			service.processAppPlugin(assistantApp, reqCtx, &treeRoot)

--- a/pkg/services/navtree/navtreeimpl/applinks_test.go
+++ b/pkg/services/navtree/navtreeimpl/applinks_test.go
@@ -948,6 +948,7 @@ func TestProcessAssistantAppPlugin(t *testing.T) {
 
 	for _, tt := range []struct {
 		name           string
+		cfg            *setting.Cfg
 		jsonData       map[string]any
 		wantChildPaths []string
 	}{
@@ -967,6 +968,18 @@ func TestProcessAssistantAppPlugin(t *testing.T) {
 			wantChildPaths: cloudChildPaths,
 		},
 		{
+			name:           "Enterprise includes all entries when ossMode is false",
+			cfg:            &setting.Cfg{IsEnterprise: true},
+			jsonData:       map[string]any{"ossMode": false},
+			wantChildPaths: cloudChildPaths,
+		},
+		{
+			name:           "Enterprise ossMode only includes supported OSS entries",
+			cfg:            &setting.Cfg{IsEnterprise: true},
+			jsonData:       map[string]any{"ossMode": true},
+			wantChildPaths: ossChildPaths,
+		},
+		{
 			name: "Trial mode only includes the homepage and workspace",
 			jsonData: map[string]any{
 				"trialMode": true,
@@ -978,8 +991,12 @@ func TestProcessAssistantAppPlugin(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.cfg
+			if cfg == nil {
+				cfg = setting.NewCfg()
+			}
 			service := ServiceImpl{
-				cfg: setting.NewCfg(),
+				cfg: cfg,
 				pluginSettings: &pluginsettings.FakePluginSettings{Plugins: map[string]*pluginsettings.DTO{
 					assistantAppID: {OrgID: 1, PluginID: assistantAppID, JSONData: tt.jsonData},
 				}},

--- a/pkg/services/navtree/navtreeimpl/applinks_test.go
+++ b/pkg/services/navtree/navtreeimpl/applinks_test.go
@@ -948,55 +948,40 @@ func TestProcessAssistantAppPlugin(t *testing.T) {
 
 	for _, tt := range []struct {
 		name           string
-		cfg            *setting.Cfg
-		trialMode      bool
-		ossMode        bool
+		jsonData       map[string]any
 		wantChildPaths []string
 	}{
 		{
-			name:           "OSS only includes supported entries",
-			cfg:            setting.NewCfg(),
+			name:           "unset ossMode defaults to supported OSS entries",
+			jsonData:       map[string]any{},
 			wantChildPaths: ossChildPaths,
 		},
 		{
-			name:           "Enterprise includes all entries",
-			cfg:            &setting.Cfg{IsEnterprise: true},
+			name:           "ossMode only includes supported OSS entries",
+			jsonData:       map[string]any{"ossMode": true},
+			wantChildPaths: ossChildPaths,
+		},
+		{
+			name:           "ossMode false includes all entries",
+			jsonData:       map[string]any{"ossMode": false},
 			wantChildPaths: cloudChildPaths,
 		},
 		{
-			name:           "Cloud includes all entries",
-			cfg:            &setting.Cfg{StackID: "1"},
-			wantChildPaths: cloudChildPaths,
-		},
-		{
-			name:      "Trial mode only includes the homepage and workspace",
-			cfg:       setting.NewCfg(),
-			trialMode: true,
+			name: "Trial mode only includes the homepage and workspace",
+			jsonData: map[string]any{
+				"trialMode": true,
+				"ossMode":   true,
+			},
 			wantChildPaths: []string{
 				"/a/grafana-assistant-app/workspace",
 			},
 		},
-		{
-			name:           "Enterprise ossMode only includes supported OSS entries",
-			cfg:            &setting.Cfg{IsEnterprise: true},
-			ossMode:        true,
-			wantChildPaths: ossChildPaths,
-		},
-		{
-			name:           "Cloud ossMode only includes supported OSS entries",
-			cfg:            &setting.Cfg{StackID: "1"},
-			ossMode:        true,
-			wantChildPaths: ossChildPaths,
-		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			service := ServiceImpl{
-				cfg: tt.cfg,
+				cfg: setting.NewCfg(),
 				pluginSettings: &pluginsettings.FakePluginSettings{Plugins: map[string]*pluginsettings.DTO{
-					assistantAppID: {OrgID: 1, PluginID: assistantAppID, JSONData: map[string]any{
-						"trialMode": tt.trialMode,
-						"ossMode":   tt.ossMode,
-					}},
+					assistantAppID: {OrgID: 1, PluginID: assistantAppID, JSONData: tt.jsonData},
 				}},
 			}
 			treeRoot := navtree.NavTreeRoot{}

--- a/pkg/services/navtree/navtreeimpl/applinks_test.go
+++ b/pkg/services/navtree/navtreeimpl/applinks_test.go
@@ -924,16 +924,34 @@ func TestProcessAssistantAppPlugin(t *testing.T) {
 			Includes: []*plugins.Includes{
 				{Name: "Home", Path: "/a/grafana-assistant-app", Type: "page", AddToNav: true, DefaultNav: true},
 				{Name: "Workspace", Path: "/a/grafana-assistant-app/workspace", Type: "page", AddToNav: true},
+				{Name: "Automations", Path: "/a/grafana-assistant-app/automations", Type: "page", AddToNav: true},
+				{Name: "Watchers", Path: "/a/grafana-assistant-app/watchers", Type: "page", AddToNav: true},
+				{Name: "Search", Path: "/a/grafana-assistant-app/assistant-search", Type: "page", AddToNav: true},
 				{Name: "Settings", Path: "/a/grafana-assistant-app/settings", Type: "page", AddToNav: true},
 				{Name: "Irrelevant", Path: "/a/grafana-assistant-app/irrelevant", Type: "page", AddToNav: true},
 			},
 		},
 	}
 
+	cloudChildPaths := []string{
+		"/a/grafana-assistant-app/workspace",
+		"/a/grafana-assistant-app/automations",
+		"/a/grafana-assistant-app/watchers",
+		"/a/grafana-assistant-app/assistant-search",
+		"/a/grafana-assistant-app/settings",
+		"/a/grafana-assistant-app/irrelevant",
+	}
+	ossModeChildPaths := []string{
+		"/a/grafana-assistant-app/workspace",
+		"/a/grafana-assistant-app/settings",
+		"/a/grafana-assistant-app/irrelevant",
+	}
+
 	for _, tt := range []struct {
 		name           string
 		cfg            *setting.Cfg
 		trialMode      bool
+		ossMode        bool
 		wantChildPaths []string
 	}{
 		{
@@ -945,22 +963,14 @@ func TestProcessAssistantAppPlugin(t *testing.T) {
 			},
 		},
 		{
-			name: "Enterprise includes all entries",
-			cfg:  &setting.Cfg{IsEnterprise: true},
-			wantChildPaths: []string{
-				"/a/grafana-assistant-app/workspace",
-				"/a/grafana-assistant-app/settings",
-				"/a/grafana-assistant-app/irrelevant",
-			},
+			name:           "Enterprise includes all entries",
+			cfg:            &setting.Cfg{IsEnterprise: true},
+			wantChildPaths: cloudChildPaths,
 		},
 		{
-			name: "Cloud includes all entries",
-			cfg:  &setting.Cfg{StackID: "1"},
-			wantChildPaths: []string{
-				"/a/grafana-assistant-app/workspace",
-				"/a/grafana-assistant-app/settings",
-				"/a/grafana-assistant-app/irrelevant",
-			},
+			name:           "Cloud includes all entries",
+			cfg:            &setting.Cfg{StackID: "1"},
+			wantChildPaths: cloudChildPaths,
 		},
 		{
 			name:      "Trial mode only includes the homepage and workspace",
@@ -970,12 +980,27 @@ func TestProcessAssistantAppPlugin(t *testing.T) {
 				"/a/grafana-assistant-app/workspace",
 			},
 		},
+		{
+			name:           "Enterprise ossMode hides Automations, Watchers, and Search",
+			cfg:            &setting.Cfg{IsEnterprise: true},
+			ossMode:        true,
+			wantChildPaths: ossModeChildPaths,
+		},
+		{
+			name:           "Cloud ossMode hides Automations, Watchers, and Search",
+			cfg:            &setting.Cfg{StackID: "1"},
+			ossMode:        true,
+			wantChildPaths: ossModeChildPaths,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			service := ServiceImpl{
 				cfg: tt.cfg,
 				pluginSettings: &pluginsettings.FakePluginSettings{Plugins: map[string]*pluginsettings.DTO{
-					assistantAppID: {OrgID: 1, PluginID: assistantAppID, JSONData: map[string]any{"trialMode": tt.trialMode}},
+					assistantAppID: {OrgID: 1, PluginID: assistantAppID, JSONData: map[string]any{
+						"trialMode": tt.trialMode,
+						"ossMode":   tt.ossMode,
+					}},
 				}},
 			}
 			treeRoot := navtree.NavTreeRoot{}

--- a/pkg/services/navtree/navtreeimpl/applinks_test.go
+++ b/pkg/services/navtree/navtreeimpl/applinks_test.go
@@ -941,10 +941,9 @@ func TestProcessAssistantAppPlugin(t *testing.T) {
 		"/a/grafana-assistant-app/settings",
 		"/a/grafana-assistant-app/irrelevant",
 	}
-	ossModeChildPaths := []string{
+	ossChildPaths := []string{
 		"/a/grafana-assistant-app/workspace",
 		"/a/grafana-assistant-app/settings",
-		"/a/grafana-assistant-app/irrelevant",
 	}
 
 	for _, tt := range []struct {
@@ -955,12 +954,9 @@ func TestProcessAssistantAppPlugin(t *testing.T) {
 		wantChildPaths []string
 	}{
 		{
-			name: "OSS only includes supported entries",
-			cfg:  setting.NewCfg(),
-			wantChildPaths: []string{
-				"/a/grafana-assistant-app/workspace",
-				"/a/grafana-assistant-app/settings",
-			},
+			name:           "OSS only includes supported entries",
+			cfg:            setting.NewCfg(),
+			wantChildPaths: ossChildPaths,
 		},
 		{
 			name:           "Enterprise includes all entries",
@@ -981,16 +977,16 @@ func TestProcessAssistantAppPlugin(t *testing.T) {
 			},
 		},
 		{
-			name:           "Enterprise ossMode hides Automations, Watchers, and Search",
+			name:           "Enterprise ossMode only includes supported OSS entries",
 			cfg:            &setting.Cfg{IsEnterprise: true},
 			ossMode:        true,
-			wantChildPaths: ossModeChildPaths,
+			wantChildPaths: ossChildPaths,
 		},
 		{
-			name:           "Cloud ossMode hides Automations, Watchers, and Search",
+			name:           "Cloud ossMode only includes supported OSS entries",
 			cfg:            &setting.Cfg{StackID: "1"},
 			ossMode:        true,
-			wantChildPaths: ossModeChildPaths,
+			wantChildPaths: ossChildPaths,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

Filters Grafana Assistant nav items using the plugin's `ossMode` setting, the same way we already do for `trialMode`. When `ossMode` is true, the nav uses the existing OSS allowlist (Home, Workspace, Settings) even on Grafana Enterprise or Cloud.

**Why do we need this feature?**

Cloud-only Assistant pages (Automations, Watchers, Search, Usage, and any later additions) currently show up whenever Grafana itself is Enterprise or Cloud, regardless of the plugin running in OSS mode. That leaks nav entries the plugin UI already hides.

**Who is this feature for?**

Users running `grafana-assistant-app` with `ossMode: true`, including Grafana Enterprise.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

- Trial mode remains stricter (Home + Workspace only) and still takes precedence.
- Grafana OSS (no Enterprise, no stack ID) continues to use the same allowlist as before.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.