### PR TITLE
unified storage: change grpc client calls to respect `ErrorResult` bedded in grpc errors

### DIFF
--- a/pkg/registry/apis/folders/cascade_delete_storage.go
+++ b/pkg/registry/apis/folders/cascade_delete_storage.go
@@ -289,6 +289,10 @@ func (s *cascadeDeleteStorage) dashboardsInFolder(ctx context.Context, namespace
 			Offset: offset,
 		})
 		if err != nil {
+			resErr := resource.ErrorResultFromGRPCDetails(err)
+			if resErr != nil {
+				return nil, fmt.Errorf("search dashboards in folder %q: %s", folderUID, resErr.Message)
+			}
 			return nil, fmt.Errorf("search dashboards in folder %q: %w", folderUID, err)
 		}
 		if resp.Error != nil {

--- a/pkg/registry/apis/folders/sub_children.go
+++ b/pkg/registry/apis/folders/sub_children.go
@@ -93,6 +93,11 @@ func (r *subChildrenREST) Connect(ctx context.Context, name string, _ runtime.Ob
 			Offset: offset,
 		})
 		if err != nil {
+			resErr := resource.ErrorResultFromGRPCDetails(err)
+			if resErr != nil {
+				responder.Error(resource.GetError(resErr))
+				return
+			}
 			responder.Error(err)
 			return
 		}

--- a/pkg/registry/apis/folders/sub_count.go
+++ b/pkg/registry/apis/folders/sub_count.go
@@ -75,6 +75,11 @@ func (r *subCountREST) Connect(ctx context.Context, name string, opts runtime.Ob
 			Folder:    []string{name},
 		})
 		if err != nil {
+			resErr := resource.ErrorResultFromGRPCDetails(err)
+			if resErr != nil {
+				responder.Error(resource.GetError(resErr))
+				return
+			}
 			responder.Error(err)
 			return
 		}

--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -526,6 +526,10 @@ func getChildrenBatch(ctx context.Context, searcher resourcepb.ResourceIndexClie
 		Offset: offset,
 	})
 	if err != nil {
+		resErr := resource.ErrorResultFromGRPCDetails(err)
+		if resErr != nil {
+			return nil, false, fmt.Errorf("search error: %s", resErr.Message)
+		}
 		return nil, false, fmt.Errorf("failed to search folders: %w", err)
 	}
 
@@ -570,6 +574,10 @@ func validateOnDelete(ctx context.Context,
 
 	resp, err := searcher.GetStats(ctx, &resourcepb.ResourceStatsRequest{Namespace: f.Namespace, Kinds: countedKinds, Folder: []string{f.Name}})
 	if err != nil {
+		resErr := resource.ErrorResultFromGRPCDetails(err)
+		if resErr != nil {
+			return fmt.Errorf("could not verify if folder is empty: %v", resErr)
+		}
 		return err
 	}
 

--- a/pkg/registry/apis/iam/user/rest_user_team.go
+++ b/pkg/registry/apis/iam/user/rest_user_team.go
@@ -160,6 +160,11 @@ func (s *UserTeamREST) Connect(ctx context.Context, name string, _ runtime.Objec
 
 		result, err := s.client.Search(ctx, searchRequest)
 		if err != nil {
+			resErr := resource.ErrorResultFromGRPCDetails(err)
+			if resErr != nil {
+				responder.Error(apierrors.NewInternalError(fmt.Errorf("%d error searching: %s: %s", resErr.Code, resErr.Message, resErr.Details)))
+				return
+			}
 			responder.Error(apierrors.NewInternalError(err))
 			return
 		}

--- a/pkg/registry/apis/provisioning/resources/object.go
+++ b/pkg/registry/apis/provisioning/resources/object.go
@@ -46,6 +46,10 @@ func (o *ResourceListerFromSearch) List(ctx context.Context, namespace, reposito
 		Id:        repository,
 	})
 	if err != nil {
+		resErr := resource.ErrorResultFromGRPCDetails(err)
+		if resErr != nil {
+			return nil, resource.GetError(resErr)
+		}
 		return nil, err
 	}
 	if objects.Error != nil {
@@ -80,6 +84,10 @@ func (o *ResourceListerFromSearch) Stats(ctx context.Context, namespace, reposit
 
 	counts, err := o.store.CountManagedObjects(ctx, req)
 	if err != nil {
+		resErr := resource.ErrorResultFromGRPCDetails(err)
+		if resErr != nil {
+			return nil, resource.GetError(resErr)
+		}
 		return nil, err
 	}
 	if counts.Error != nil {

--- a/pkg/registry/apis/provisioning/webhooks/render.go
+++ b/pkg/registry/apis/provisioning/webhooks/render.go
@@ -144,6 +144,11 @@ func (c *renderConnector) Connect(
 			Uid:            blobID,
 		})
 		if err != nil {
+			resErr := resource.ErrorResultFromGRPCDetails(err)
+			if resErr != nil {
+				responder.Error(resource.GetError(resErr))
+				return
+			}
 			responder.Error(err)
 			return
 		}

--- a/pkg/registry/apps/alerting/rules/search/search.go
+++ b/pkg/registry/apps/alerting/rules/search/search.go
@@ -120,6 +120,10 @@ func (h *Handler) run(ctx context.Context, body model.CreateSearchRulesRequestBo
 	}
 	resp, err := h.clientFor(primary).Search(ctx, searchReq)
 	if err != nil {
+		resErr := resource.ErrorResultFromGRPCDetails(err)
+		if resErr != nil {
+			return nil, "", resource.GetError(resErr)
+		}
 		return nil, "", err
 	}
 	if resp.Error != nil {

--- a/pkg/services/team/folderownership/validation.go
+++ b/pkg/services/team/folderownership/validation.go
@@ -43,6 +43,10 @@ func ValidateNoOwnedFolders(ctx context.Context, searcher resourcepb.ResourceInd
 		Limit: 1,
 	})
 	if err != nil {
+		resErr := resource.ErrorResultFromGRPCDetails(err)
+		if resErr != nil {
+			return resource.GetError(resErr)
+		}
 		return err
 	}
 	if resp == nil {

--- a/pkg/storage/unified/apistore/store.go
+++ b/pkg/storage/unified/apistore/store.go
@@ -320,6 +320,15 @@ func (s *Storage) Create(ctx context.Context, key string, obj runtime.Object, ou
 
 	rsp, err := s.store.Create(ctx, req)
 	if err != nil {
+		resError := resource.ErrorResultFromGRPCDetails(err)
+		if resError != nil {
+			err = resource.GetError(resError)
+			if resError.Code == http.StatusConflict {
+				err = storage.NewKeyExistsError(key, 0)
+			}
+
+			return v.finish(ctx, err, s.opts.SecureValues)
+		}
 		return v.finish(ctx, resource.GetError(resource.AsErrorResult(err)), s.opts.SecureValues)
 	}
 	if rsp.Error != nil {
@@ -422,6 +431,13 @@ func (s *Storage) Delete(
 		}
 		rsp, err := s.store.Delete(ctx, cmd)
 		if err != nil {
+			resErr := resource.ErrorResultFromGRPCDetails(err)
+			if resErr != nil {
+				if resErr.Code == http.StatusConflict && attempt < MaxUpdateAttempts {
+					continue
+				}
+				return resource.GetError(resErr)
+			}
 			return resource.GetError(resource.AsErrorResult(err))
 		}
 		if rsp.Error != nil {
@@ -509,6 +525,17 @@ func (s *Storage) Get(ctx context.Context, key string, opts storage.GetOptions, 
 
 	rsp, err := s.store.Read(ctx, req)
 	if err != nil {
+		resErr := resource.ErrorResultFromGRPCDetails(err)
+		if resErr != nil {
+			if resErr.Code == http.StatusNotFound {
+				if opts.IgnoreNotFound {
+					return runtime.SetZeroValue(objPtr)
+				}
+				return storage.NewKeyNotFoundError(key, req.ResourceVersion)
+			}
+			return resource.GetError(resErr)
+		}
+
 		return resource.GetError(resource.AsErrorResult(err))
 	}
 	if rsp.Error != nil {
@@ -549,6 +576,14 @@ func (s *Storage) GetList(ctx context.Context, key string, opts storage.ListOpti
 
 	rsp, err := s.store.List(ctx, req)
 	if err != nil {
+		// this is essentially the same as just
+		//  `return resource.GetError(resource.AsErrorResult(err))`
+		// but here for visibility for when we remove response.Error so that we know that we did not forget this
+		resErr := resource.ErrorResultFromGRPCDetails(err)
+		if resErr != nil {
+			return resource.GetError(resErr)
+		}
+
 		return resource.GetError(resource.AsErrorResult(err))
 	}
 	if rsp.Error != nil {
@@ -710,6 +745,17 @@ func (s *Storage) GuaranteedUpdate(
 		// Read the latest value
 		readResponse, err := s.store.Read(ctx, &resourcepb.ReadRequest{Key: req.Key})
 		if err != nil {
+			resErr := resource.ErrorResultFromGRPCDetails(err)
+			if resErr != nil {
+				if resErr.Code == http.StatusNotFound {
+					if !ignoreNotFound {
+						return apierrors.NewNotFound(s.gr, req.Key.Name)
+					}
+				} else {
+					return resource.GetError(resErr)
+				}
+			}
+
 			return resource.GetError(resource.AsErrorResult(err))
 		}
 
@@ -788,7 +834,19 @@ func (s *Storage) GuaranteedUpdate(
 		req.ResourceVersion = readResponse.ResourceVersion
 		updateResponse, err := s.store.Update(ctx, req) // Also does RBAC check
 		if err != nil {
-			err = resource.GetError(resource.AsErrorResult(err))
+			resErr := resource.ErrorResultFromGRPCDetails(err)
+			if resErr != nil {
+				if attempt < MaxUpdateAttempts && resErr.Code == http.StatusConflict {
+					// Delete the secure values this attempt created; the next attempt recreates them.
+					// finish only echoes the conflict back and logs any cleanup failure itself, so we
+					// discard its return and retry instead of surfacing it.
+					_ = v.finish(ctx, resource.GetError(resErr), s.opts.SecureValues)
+					continue // try the read again
+				}
+				err = resource.GetError(resErr)
+			} else {
+				err = resource.GetError(resource.AsErrorResult(err))
+			}
 		} else if updateResponse.Error != nil {
 			if attempt < MaxUpdateAttempts && updateResponse.Error.Code == http.StatusConflict {
 				// Delete the secure values this attempt created; the next attempt recreates them.

--- a/pkg/storage/unified/migrations/migrator.go
+++ b/pkg/storage/unified/migrations/migrator.go
@@ -275,6 +275,12 @@ func (m *unifiedMigration) rebuildIndexes(ctx context.Context, opts RebuildIndex
 		Keys:      keys,
 	})
 	if err != nil {
+		resErr := resource.ErrorResultFromGRPCDetails(err)
+		if resErr != nil {
+			m.log.Error("error rebuilding index for resource", "error", resErr.Message, "namespace", opts.NamespaceInfo.Value, "orgId", opts.NamespaceInfo.OrgID, "resources", opts.Resources)
+			return fmt.Errorf("rebuild index error: %s", resErr.Message)
+		}
+
 		return fmt.Errorf("error rebuilding index: %w", err)
 	}
 

--- a/pkg/storage/unified/migrations/resource_migration.go
+++ b/pkg/storage/unified/migrations/resource_migration.go
@@ -220,6 +220,11 @@ func (r *MigrationRunner) MigrateOrg(ctx context.Context, sess *xorm.Session, en
 	// Execute the migration via legacy migrator
 	response, err := r.unifiedMigrator.Migrate(ctx, migrateOpts)
 	if err != nil {
+		resErr := resource.ErrorResultFromGRPCDetails(err)
+		if resErr != nil {
+			r.log.Error("Migration reported error", "org_id", info.OrgID, "error", resErr.String(), "duration", time.Since(startTime))
+			return nil, fmt.Errorf("migration failed for org %d (%s): %w", info.OrgID, info.Value, fmt.Errorf("migration error: %s", resErr.Message))
+		}
 		r.log.Error("Migration failed", "org_id", info.OrgID, "error", err, "duration", time.Since(startTime))
 		return nil, fmt.Errorf("migration failed for org %d (%s): %w", info.OrgID, info.Value, err)
 	}

--- a/pkg/storage/unified/resource/errors.go
+++ b/pkg/storage/unified/resource/errors.go
@@ -83,13 +83,13 @@ func IsResourceVersionExpired(err error) bool {
 	if apierrors.IsResourceExpired(err) || apierrors.IsGone(err) {
 		return true
 	}
-	if res := errorResultFromGRPCDetails(err); res != nil {
+	if res := ErrorResultFromGRPCDetails(err); res != nil {
 		return res.Code == http.StatusGone || res.Reason == string(metav1.StatusReasonExpired)
 	}
 	return false
 }
 
-func errorResultFromGRPCDetails(err error) *resourcepb.ErrorResult {
+func ErrorResultFromGRPCDetails(err error) *resourcepb.ErrorResult {
 	st, ok := grpcstatus.FromError(err)
 	if !ok || st == nil {
 		return nil
@@ -179,7 +179,7 @@ func AsErrorResult(err error) *resourcepb.ErrorResult {
 
 	// Structured results attached to a gRPC error keep their reason/code across
 	// the wire, so prefer them over the generic mapping below.
-	if res := errorResultFromGRPCDetails(err); res != nil {
+	if res := ErrorResultFromGRPCDetails(err); res != nil {
 		return res
 	}
 
@@ -220,6 +220,59 @@ func AsErrorResult(err error) *resourcepb.ErrorResult {
 	return &resourcepb.ErrorResult{
 		Message: err.Error(),
 		Code:    int32(code),
+	}
+}
+
+// grpcCodeFromHTTPStatus is lossy in a way runtime.HTTPStatusFromCode is not:
+// several gRPC codes collapse onto the same HTTP status going out
+// (AlreadyExists and Aborted both become 409, InvalidArgument /
+// FailedPrecondition / OutOfRange all become 400), so coming back we pick the
+// code that unified storage actually produces for that status.
+func grpcCodeFromHTTPStatus(httpCode int32) grpccodes.Code {
+	switch httpCode {
+	case http.StatusOK:
+		return grpccodes.OK
+	case http.StatusBadRequest:
+		return grpccodes.InvalidArgument
+	case http.StatusUnauthorized:
+		return grpccodes.Unauthenticated
+	case http.StatusForbidden:
+		return grpccodes.PermissionDenied
+	case http.StatusNotFound:
+		return grpccodes.NotFound
+	case http.StatusRequestTimeout:
+		return grpccodes.DeadlineExceeded
+	case http.StatusConflict:
+		return grpccodes.AlreadyExists
+	case http.StatusPreconditionFailed:
+		return grpccodes.FailedPrecondition
+	case http.StatusRequestedRangeNotSatisfiable:
+		return grpccodes.OutOfRange
+	case http.StatusUnprocessableEntity:
+		return grpccodes.InvalidArgument
+	case http.StatusTooManyRequests:
+		return grpccodes.ResourceExhausted
+	case http.StatusInternalServerError:
+		return grpccodes.Internal
+	case http.StatusNotImplemented:
+		return grpccodes.Unimplemented
+	case http.StatusServiceUnavailable:
+		return grpccodes.Unavailable
+	case http.StatusGatewayTimeout:
+		return grpccodes.DeadlineExceeded
+	case 499:
+		return grpccodes.Canceled
+	}
+
+	switch {
+	case httpCode >= 500:
+		return grpccodes.Internal
+	case httpCode >= 400:
+		return grpccodes.InvalidArgument
+	default:
+		// An ErrorResult carrying a non-error status is a caller bug, not a
+		// success: codes.OK here would silently turn it into a nil error.
+		return grpccodes.Unknown
 	}
 }
 

--- a/pkg/storage/unified/resource/errors_test.go
+++ b/pkg/storage/unified/resource/errors_test.go
@@ -1,10 +1,12 @@
 package resource
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -47,4 +49,48 @@ func TestAsErrorResult_UnpackCorrectErrorDetails(t *testing.T) {
 	// diff used as require.Equal has it's issues with Details.Causes
 	diff := cmp.Diff(&errDetails, got, protocmp.Transform())
 	require.Empty(t, diff)
+}
+
+func TestGRPCCodeFromHTTPStatus(t *testing.T) {
+	tests := []struct {
+		httpCode int32
+		expected codes.Code
+	}{
+		{http.StatusOK, codes.OK},
+		{http.StatusBadRequest, codes.InvalidArgument},
+		{http.StatusUnauthorized, codes.Unauthenticated},
+		{http.StatusForbidden, codes.PermissionDenied},
+		{http.StatusNotFound, codes.NotFound},
+		{http.StatusRequestTimeout, codes.DeadlineExceeded},
+		{http.StatusConflict, codes.AlreadyExists},
+		{http.StatusPreconditionFailed, codes.FailedPrecondition},
+		{http.StatusRequestedRangeNotSatisfiable, codes.OutOfRange},
+		{http.StatusUnprocessableEntity, codes.InvalidArgument},
+		{http.StatusTooManyRequests, codes.ResourceExhausted},
+		{http.StatusInternalServerError, codes.Internal},
+		{http.StatusNotImplemented, codes.Unimplemented},
+		{http.StatusServiceUnavailable, codes.Unavailable},
+		{http.StatusGatewayTimeout, codes.DeadlineExceeded},
+		// Unmapped statuses fall back by class.
+		{http.StatusTeapot, codes.InvalidArgument},
+		{http.StatusInsufficientStorage, codes.Internal},
+		{http.StatusMovedPermanently, codes.Unknown},
+		{0, codes.Unknown},
+	}
+
+	for _, tt := range tests {
+		require.Equal(t, tt.expected, grpcCodeFromHTTPStatus(tt.httpCode),
+			"http %d", tt.httpCode)
+	}
+}
+
+// The HTTP status a gRPC code maps out to must map back to a code with the same
+// HTTP status, otherwise a request crossing the boundary twice changes meaning.
+func TestHTTPStatusRoundTrip(t *testing.T) {
+	for code := codes.OK; code <= codes.Unauthenticated; code++ {
+		httpCode := runtime.HTTPStatusFromCode(code)
+		back := grpcCodeFromHTTPStatus(int32(httpCode))
+		require.Equal(t, httpCode, runtime.HTTPStatusFromCode(back),
+			"%s -> %d -> %s", code, httpCode, back)
+	}
 }

--- a/pkg/storage/unified/resource/list_with_field_selectors.go
+++ b/pkg/storage/unified/resource/list_with_field_selectors.go
@@ -79,6 +79,13 @@ func (s *server) listWithFieldSelectors(ctx context.Context, req *resourcepb.Lis
 			ResourceVersion: row.ResourceVersion,
 		})
 		if err != nil {
+			resErr := ErrorResultFromGRPCDetails(err)
+			if resErr != nil {
+				if resErr.Code == http.StatusForbidden {
+					continue
+				}
+				return &resourcepb.ListResponse{Error: resErr}, nil
+			}
 			return &resourcepb.ListResponse{Error: AsErrorResult(err)}, nil
 		}
 		if val.Error != nil {

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"hash/fnv"
 	"math/rand"
-	"net/http"
 	"slices"
 	"strconv"
 	"strings"
@@ -804,7 +803,12 @@ func (s *searchServer) VectorSearch(ctx context.Context, req *resourcepb.VectorS
 
 	// record metrics at the end
 	defer func() {
-		code := vectorSearchResponseCode(resp, retErr)
+		code := codes.OK
+		if retErr != nil {
+			code = status.Code(retErr)
+		} else if resp != nil && resp.Error != nil {
+			code = grpcCodeFromHTTPStatus(resp.Error.Code)
+		}
 		if s.vectorMetrics != nil {
 			metricutil.ObserveWithExemplar(ctx,
 				s.vectorMetrics.SearchDuration.WithLabelValues(group, resource, code.String()),
@@ -913,31 +917,6 @@ func (s *searchServer) VectorSearch(ctx context.Context, req *resourcepb.VectorS
 		})
 	}
 	return resp, nil
-}
-
-// vectorSearchResponseCode maps a VectorSearch outcome to the gRPC code label
-// on the search-duration metric. ErrorResult carries HTTP-style codes; an
-// unmapped code labels as Unknown — a signal to add a mapping, not a silent
-// mislabel.
-func vectorSearchResponseCode(resp *resourcepb.VectorSearchResponse, retErr error) codes.Code {
-	switch {
-	case retErr != nil:
-		return status.Code(retErr)
-	case resp == nil || resp.Error == nil:
-		return codes.OK
-	}
-	switch resp.Error.Code {
-	case http.StatusBadRequest:
-		return codes.InvalidArgument
-	case http.StatusNotFound:
-		return codes.NotFound
-	case http.StatusForbidden:
-		return codes.PermissionDenied
-	case http.StatusUnauthorized:
-		return codes.Unauthenticated
-	default:
-		return codes.Unknown
-	}
 }
 
 // validateVectorSearchRequest returns a non-nil response with a

--- a/pkg/storage/unified/resource/search_hybrid.go
+++ b/pkg/storage/unified/resource/search_hybrid.go
@@ -221,10 +221,9 @@ func (s *searchServer) resolveFolderTitles(ctx context.Context, namespace string
 		resErr := ErrorResultFromGRPCDetails(err)
 		if resErr != nil {
 			err = grpcErrorFromErrorResult(resErr)
-		} else {
-			s.log.Warn("hybrid search: folder title resolution failed", "err", err)
-			return
 		}
+		s.log.Warn("hybrid search: folder title resolution failed", "err", err)
+		return
 	}
 
 	titles := make(map[string]string, len(uids))

--- a/pkg/storage/unified/resource/search_hybrid.go
+++ b/pkg/storage/unified/resource/search_hybrid.go
@@ -121,6 +121,10 @@ func (s *searchServer) HybridSearch(ctx context.Context, req *resourcepb.HybridS
 	g.Go(func() error {
 		lexResp, err := s.Search(gctx, hybridLexicalRequest(req, depth))
 		if err != nil {
+			resErr := ErrorResultFromGRPCDetails(err)
+			if resErr != nil {
+				return fmt.Errorf("lexical leg: %w", grpcErrorFromErrorResult(resErr))
+			}
 			return fmt.Errorf("lexical leg: %w", err)
 		}
 		if lexResp.Error != nil {
@@ -214,8 +218,13 @@ func (s *searchServer) resolveFolderTitles(ctx context.Context, namespace string
 		err = grpcErrorFromErrorResult(resp.Error)
 	}
 	if err != nil || resp == nil {
-		s.log.Warn("hybrid search: folder title resolution failed", "err", err)
-		return
+		resErr := ErrorResultFromGRPCDetails(err)
+		if resErr != nil {
+			err = grpcErrorFromErrorResult(resErr)
+		} else {
+			s.log.Warn("hybrid search: folder title resolution failed", "err", err)
+			return
+		}
 	}
 
 	titles := make(map[string]string, len(uids))

--- a/pkg/storage/unified/resource/search_server_distributor.go
+++ b/pkg/storage/unified/resource/search_server_distributor.go
@@ -226,6 +226,11 @@ func (ds *distributorServer) RebuildIndexes(ctx context.Context, r *resourcepb.R
 
 			rsp, err := client.(*RingClient).Client.RebuildIndexes(rCtx, r)
 			if err != nil {
+				resErr := ErrorResultFromGRPCDetails(err)
+				if resErr != nil {
+					errorCh <- fmt.Errorf("instance %s: rebuild index request returned the error %s", inst.Id, resErr.Message)
+					return
+				}
 				errorCh <- fmt.Errorf("instance %s: failed to distribute rebuild index request, %w", inst.Id, err)
 				return
 			}

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -2481,7 +2481,7 @@ func (s *server) checkQuota(ctx context.Context, nsr NamespacedResource) error {
 	})
 	if err != nil {
 		// this is the equivalent of checking statsRsp.Error below
-		if errorResultFromGRPCDetails(err) != nil {
+		if ErrorResultFromGRPCDetails(err) != nil {
 			s.degraded(ctx, "check_quota", "stats_error", nsr, err)
 			return nil
 		}

--- a/pkg/storage/unified/resource/server_test.go
+++ b/pkg/storage/unified/resource/server_test.go
@@ -1474,7 +1474,7 @@ func createTestPlaylist(ctx context.Context, srv *server) error {
 	}
 	created, err := srv.Create(ctx, &resourcepb.CreateRequest{Key: key, Value: value})
 	if err != nil {
-		resErr := errorResultFromGRPCDetails(err)
+		resErr := ErrorResultFromGRPCDetails(err)
 		if resErr != nil {
 			return fmt.Errorf("creating playlist %q: %v", name, resErr)
 		}

--- a/pkg/storage/unified/search/builders/dashboard.go
+++ b/pkg/storage/unified/search/builders/dashboard.go
@@ -115,6 +115,10 @@ func (s *DashboardDocumentBuilder) BuildDocument(ctx context.Context, key *resou
 	if blob != nil {
 		rsp, err := s.Blob.GetResourceBlob(ctx, key, blob, true)
 		if err != nil {
+			resErr := resource.ErrorResultFromGRPCDetails(err)
+			if resErr != nil {
+				return nil, fmt.Errorf("error reading blob: %+v", resErr)
+			}
 			return nil, err
 		}
 		if rsp.Error != nil {

--- a/pkg/storage/unified/testing/storage_backend_sql_compatibility.go
+++ b/pkg/storage/unified/testing/storage_backend_sql_compatibility.go
@@ -1809,6 +1809,10 @@ func runBackendOperationsWithCounts(ctx context.Context, server resource.Resourc
 			Value: []byte(resourceJSON),
 		})
 		if err != nil {
+			resErr := resource.ErrorResultFromGRPCDetails(err)
+			if resErr != nil {
+				return fmt.Errorf("create error for resource %d: %s", i, resErr.Message)
+			}
 			return fmt.Errorf("failed to create resource %d: %w", i, err)
 		}
 		if created.Error != nil {
@@ -1850,6 +1854,10 @@ func runBackendOperationsWithCounts(ctx context.Context, server resource.Resourc
 			ResourceVersion: resourceVersions[i-1],
 		})
 		if err != nil {
+			resErr := resource.ErrorResultFromGRPCDetails(err)
+			if resErr != nil {
+				return fmt.Errorf("update error for resource %d: %s", i, resErr.Message)
+			}
 			return fmt.Errorf("failed to update resource %d: %w", i, err)
 		}
 		if updated.Error != nil {
@@ -1876,6 +1884,10 @@ func runBackendOperationsWithCounts(ctx context.Context, server resource.Resourc
 			ResourceVersion: resourceVersions[i-1], // Use the resource version from updates
 		})
 		if err != nil {
+			resErr := resource.ErrorResultFromGRPCDetails(err)
+			if resErr != nil {
+				return fmt.Errorf("delete error for resource %d: %s", i, resErr.Message)
+			}
 			return fmt.Errorf("failed to delete resource %d: %w", i, err)
 		}
 		if deleted.Error != nil {

--- a/pkg/storage/unified/testing/storage_backend_test.go
+++ b/pkg/storage/unified/testing/storage_backend_test.go
@@ -289,6 +289,14 @@ func runConcurrentCreateRetry(t *testing.T, client resource.ResourceClient, ns s
 		wg.Go(func() {
 			rsp, err := client.Create(clientCtx, &resourcepb.CreateRequest{Key: key, Value: value}, retryOpts...)
 			if err != nil {
+				resErr := resource.ErrorResultFromGRPCDetails(err)
+				if resErr != nil {
+					results[i] = result{
+						err:           resource.GetError(resErr),
+						alreadyExists: resErr.Reason == string(metav1.StatusReasonAlreadyExists),
+					}
+					return
+				}
 				results[i] = result{err: err}
 				return
 			}


### PR DESCRIPTION
This PR (and the following ones) include fixes for https://github.com/grafana/pir-actions/issues/595.

 - PR 1 (https://github.com/grafana/grafana/pull/131038): adds config flag for reporting status codes in metric labels (mode: off)
 - PR 2 (this one): changes clients to respect ErrorResult embedded into gRPC errors as well as in response.Error
 - PR 3: changes server side to actually send ErrorResult as a real error and not only via response.Error
 - PR 4/5: cleanup/deprecation of response.Error in clients and server

https://github.com/grafana/grafana/pull/131038 Includes examples and an explanation for the client changes.

Base branch will be changed to `main` once the parent PR is merged.

> 
> There is an example of how clients will be updated in `server.go#L2302` with 
> ```go
> statsRsp, err := s.GetStats(ctx, &resourcepb.ResourceStatsRequest{
>     Namespace: nsr.Namespace,
>     Kinds:     []string{nsr.GroupResource()},
> })
> if err != nil {
>     resErr := ErrorResultFromGRPCDetails(err)
>     if resErr != nil {
>         return &resourcepb.QuotaUsageResponse{Error: resErr}, nil
>     }
>     return &resourcepb.QuotaUsageResponse{Error: AsErrorResult(err)}, nil
> }
> ```
> 
> Clients will try to read the `ErrorResult` from the embedded status metadata on the grpc returned error and act accordingly. It's essentially the exact same implementation as is done with the `res.Error != nil` check currently, e.g.
> ```go
> if statsRsp.Error != nil {
>     return &resourcepb.QuotaUsageResponse{Error: statsRsp.Error}, nil
> }
> ```
> 
> `ErrorResultFromGRPCDetails` is used instead of `AsErrorResult` to only work with "real" `ErrorResult`s returned from the gRPC servers in the error status metadata. `AsErrorResult` will always return an `ErrorReesult` if `err` is given which does not work for us, example here where the different error handlings between "any error" and manually put `response.Error` are different:
> 
> ```go
> rsp, err := s.store.Create(ctx, req)
> if err != nil {
> 	resError := resource.ErrorResultFromGRPCDetails(err)
> 	if resError != nil {
> 		err = resource.GetError(resError)
> 		if resError.Code == http.StatusConflict {
> 			err = storage.NewKeyExistsError(key, 0)
> 		}
> 		return v.finish(ctx, err, s.opts.SecureValues)
> 	}
> 	return v.finish(ctx, resource.GetError(resource.AsErrorResult(err)), s.opts.SecureValues)
> }
> if rsp.Error != nil {
> 	err = resource.GetError(rsp.Error)
> 	if rsp.Error.Code == http.StatusConflict {
> 		err = storage.NewKeyExistsError(key, 0)
> 	}
> 	return v.finish(ctx, err, s.opts.SecureValues)
> }
> ```
