### PR TITLE
Notebooks: autosave an existing notebook as it changes

### DIFF
--- a/public/app/features/notebook/api/notebookResource.test.ts
+++ b/public/app/features/notebook/api/notebookResource.test.ts
@@ -1,0 +1,129 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { type UnknownAction } from 'redux';
+import { of, throwError } from 'rxjs';
+import { createFetchResponse } from 'test/helpers/createFetchResponse';
+
+import { type BackendSrv, setBackendSrv } from '@grafana/runtime';
+import { dashboardAPIv2beta1 } from 'app/api/clients/dashboard/v2beta1';
+
+import { codeCell, markdownCell, notebookSpec } from '../mutation-api/test-utils';
+import { type Spec as NotebookSpec } from '../types';
+
+import { updateNotebook } from './notebookResource';
+
+// The write dispatches through the app store; route that dispatch to a test store carrying the dashboard
+// v2beta1 API so the real RTK mutation, and the real base query that decides the patch content type, both
+// run. Only the transport is faked.
+const createTestStore = () =>
+  configureStore({
+    reducer: { [dashboardAPIv2beta1.reducerPath]: dashboardAPIv2beta1.reducer },
+    // The dev-only serializable/immutable checks log on the error path (the rejected RTK action carries an
+    // Error instance) and jest-fail-on-console turns that into a failure.
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware({ serializableCheck: false, immutableCheck: false }).concat(dashboardAPIv2beta1.middleware),
+  });
+
+let testStore: ReturnType<typeof createTestStore>;
+
+jest.mock('app/store/store', () => {
+  const actual = jest.requireActual('app/store/store');
+  return {
+    ...actual,
+    dispatch: jest.fn((action: UnknownAction) => (testStore ? testStore.dispatch(action) : action)),
+  };
+});
+
+/** What the apiserver returns from a notebook write: the whole resource, not just the fields one test reads. */
+function savedNotebook(spec: NotebookSpec, generation = 2) {
+  return {
+    apiVersion: 'dashboard.grafana.app/v2beta1',
+    kind: 'Notebook',
+    metadata: {
+      name: 'nb-1',
+      namespace: 'default',
+      uid: '9f1c4d2e-0b7a-4c33-8a11-6d2e5b8f0c41',
+      resourceVersion: '1755',
+      generation,
+      creationTimestamp: '2026-08-17T09:12:44Z',
+      annotations: { 'grafana.app/folder': 'incidents' },
+    },
+    spec,
+  };
+}
+
+function fetchOf(response: unknown) {
+  const fetch = jest.fn().mockReturnValue(of(createFetchResponse(response)));
+  setBackendSrv({ fetch } as unknown as BackendSrv);
+  return fetch;
+}
+
+describe('updateNotebook', () => {
+  beforeEach(() => {
+    testStore = createTestStore();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('patches the notebook by replacing its whole spec in one json-patch op', async () => {
+    const spec = notebookSpec();
+    const fetch = fetchOf(savedNotebook(spec));
+
+    await updateNotebook('nb-1', spec);
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const request = fetch.mock.calls[0][0];
+    expect(request.method).toBe('PATCH');
+    expect(request.url).toMatch(/\/notebooks\/nb-1$/);
+    expect(request.data).toEqual([{ op: 'replace', path: '/spec', value: spec }]);
+    // Not merge-patch: the base query infers this from the op array, and the whole point of the op array
+    // is that a merge patch would keep elements this spec no longer has.
+    expect(request.headers['Content-Type']).toBe('application/json-patch+json');
+  });
+
+  it("returns the resource's new generation, so a caller can update what it cached", async () => {
+    const spec = notebookSpec();
+    fetchOf(savedNotebook(spec, 7));
+
+    await expect(updateNotebook('nb-1', spec)).resolves.toEqual({ generation: 7 });
+  });
+
+  it('sends only the remaining elements once a cell is deleted', async () => {
+    // The case a merge patch gets wrong: `query` is gone from both the layout and the elements map, and a
+    // patch that merely mentioned the survivors would leave it on the server.
+    const spec = notebookSpec({
+      elements: { intro: markdownCell('## Checkout latency spike') },
+      cells: ['intro'],
+    });
+    const fetch = fetchOf(savedNotebook(spec));
+
+    await updateNotebook('nb-1', spec);
+
+    const sentSpec = fetch.mock.calls[0][0].data[0].value;
+    expect(Object.keys(sentSpec.elements)).toEqual(['intro']);
+    expect(sentSpec.layout.spec.cells).toHaveLength(1);
+  });
+
+  it("throws the apiserver's own rejection message", async () => {
+    setBackendSrv({
+      fetch: jest
+        .fn()
+        .mockReturnValue(throwError(() => ({ status: 400, data: { message: 'spec.layout: unsupported kind' } }))),
+    } as unknown as BackendSrv);
+
+    await expect(updateNotebook('nb-1', notebookSpec())).rejects.toThrow('spec.layout: unsupported kind');
+  });
+
+  it('throws rather than reporting a saved notebook when the write fails with no message', async () => {
+    setBackendSrv({
+      fetch: jest.fn().mockReturnValue(throwError(() => ({ status: 500 }))),
+    } as unknown as BackendSrv);
+
+    // The message here comes from the shared base query's normalization, so this only pins that a failure
+    // reaches the caller at all: resolving would report a generation of undefined as if the save worked.
+    await expect(
+      updateNotebook('nb-1', notebookSpec({ elements: { query: codeCell('up') }, cells: ['query'] }))
+    ).rejects.toThrow();
+  });
+});

--- a/public/app/features/notebook/api/notebookResource.ts
+++ b/public/app/features/notebook/api/notebookResource.ts
@@ -6,6 +6,7 @@
 
 import { API_GROUP, API_VERSION, type Notebook } from '@grafana/api-clients/rtkq/dashboard/v2beta1';
 import { dashboardAPIv2beta1 } from 'app/api/clients/dashboard/v2beta1';
+import { extractErrorMessage } from 'app/api/utils';
 import { type Resource } from 'app/features/apiserver/types';
 import { dispatch } from 'app/store/store';
 
@@ -59,7 +60,7 @@ export async function createNotebook(spec: NotebookSpec): Promise<CreatedNoteboo
   const result = await dispatch(dashboardAPIv2beta1.endpoints.createNotebook.initiate({ notebook }, { track: false }));
 
   if ('error' in result && result.error) {
-    throw new Error(notebookWriteError(result.error));
+    throw new Error(extractErrorMessage(result.error, 'Failed to create the notebook.'));
   }
 
   const uid = result.data?.metadata?.name;
@@ -72,13 +73,29 @@ export async function createNotebook(spec: NotebookSpec): Promise<CreatedNoteboo
   return { uid, url: notebookViewUrl(uid) };
 }
 
-/** The apiserver's own message: without it a caller cannot see what is wrong, and will retry the same spec. */
-function notebookWriteError(error: unknown): string {
-  if (typeof error === 'object' && error !== null && 'data' in error) {
-    const data: unknown = error.data;
-    if (typeof data === 'object' && data !== null && 'message' in data && typeof data.message === 'string') {
-      return data.message;
-    }
+/**
+ * Replace an existing notebook's spec, leaving its metadata alone.
+ *
+ * A JSON patch replacing all of `/spec`, not a merge patch: `spec.elements` is a keyed map, so a merge
+ * would leave a deleted cell's element behind. Not a PUT either, which would replace metadata and strip
+ * the notebook's folder annotation. Full reasoning in the spec, section 5.1.
+ *
+ * `generation` is optional rather than defaulted to 0, because the caller compares it with `===` against
+ * an optional field and a 0 would read as a difference.
+ */
+export async function updateNotebook(uid: string, spec: NotebookSpec): Promise<{ generation?: number }> {
+  const result = await dispatch(
+    dashboardAPIv2beta1.endpoints.updateNotebook.initiate(
+      // `createBaseQuery` infers the json-patch content type from the array of ops.
+      { name: uid, patch: [{ op: 'replace', path: '/spec', value: spec }] },
+      // Untracked like the create: nothing renders this mutation's state, and autosave writes often.
+      { track: false }
+    )
+  );
+
+  if ('error' in result && result.error) {
+    throw new Error(extractErrorMessage(result.error, 'Failed to save the notebook.'));
   }
-  return 'Failed to create the notebook.';
+
+  return { generation: result.data?.metadata?.generation };
 }

--- a/public/app/features/notebook/mutation-api/commands/applyNotebookSpec.test.ts
+++ b/public/app/features/notebook/mutation-api/commands/applyNotebookSpec.test.ts
@@ -2,7 +2,7 @@ import { SceneObjectBase } from '@grafana/scenes';
 import { setTestFlags } from '@grafana/test-utils/unstable';
 import { contextSrv } from 'app/core/services/context_srv';
 
-import { notebookResourceFor } from '../../api/notebookResource';
+import { notebookResourceFor, updateNotebook } from '../../api/notebookResource';
 import { NotebookLayoutManager } from '../../scene/layout-notebook/NotebookLayoutManager';
 import { transformNotebookToScene } from '../../serialization/transformNotebookToScene';
 import { NotebookMutationClient } from '../NotebookMutationClient';
@@ -16,6 +16,13 @@ import {
   panelCell,
 } from '../test-utils';
 
+// Only the network write is stubbed. `notebookResourceFor` and everything else in the module stay real,
+// so the spec these tests assert on is the one that would be sent.
+jest.mock('../../api/notebookResource', () => ({
+  ...jest.requireActual('../../api/notebookResource'),
+  updateNotebook: jest.fn(),
+}));
+
 /** Concrete stand-in: SceneObjectBase is abstract, and overlay just needs a SceneObject. */
 class TestOverlay extends SceneObjectBase {}
 
@@ -23,6 +30,7 @@ describe('APPLY_NOTEBOOK_SPEC', () => {
   beforeEach(() => {
     setTestFlags({ [NOTEBOOKS_FLAG]: true });
     jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(true);
+    jest.mocked(updateNotebook).mockReset().mockResolvedValue({ generation: 2 });
   });
 
   afterEach(() => {
@@ -142,7 +150,8 @@ describe('APPLY_NOTEBOOK_SPEC', () => {
     ]);
   });
 
-  it('says so when it cannot tell which cells survived', async () => {
+  // The save serializes the same scene, so a serializer that throws stops the write as well as the check.
+  it('says so when it cannot tell which cells survived, and that nothing was saved', async () => {
     const scene = notebookScene();
     const client = new NotebookMutationClient(scene);
     // Spied on the prototype because the rebuild swaps in a new layout manager, so the instance the scene
@@ -153,7 +162,8 @@ describe('APPLY_NOTEBOOK_SPEC', () => {
 
     const result = await client.execute({ type: 'APPLY_NOTEBOOK_SPEC', payload: { spec: notebookSpec() } });
 
-    expect(result.success).toBe(true);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('could not be saved');
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- narrowing the command's own result shape
     expect((result.data as { spec?: unknown }).spec).toBeUndefined();
     expect(result.warnings).toEqual([
@@ -291,9 +301,8 @@ describe('APPLY_NOTEBOOK_SPEC', () => {
     expect(scene.state.body.state.isEditing).toBe(false);
   });
 
-  it('hands the applied change to autosave, which the change signal would otherwise miss', async () => {
+  it('saves the applied change, which the scene change signal would otherwise miss', async () => {
     const scene = notebookScene();
-    const notify = jest.spyOn(scene.autosave, 'notifyDocumentChanged');
     const client = new NotebookMutationClient(scene);
 
     const result = await client.execute({
@@ -304,7 +313,26 @@ describe('APPLY_NOTEBOOK_SPEC', () => {
     expect(result.success).toBe(true);
     // The notebook was never in edit mode, so the scene's own change signal is ignored for this write.
     expect(scene.state.isEditing).toBeFalsy();
-    expect(notify).toHaveBeenCalledTimes(1);
+    // Asserted on the request, not on a call to autosave, so what was sent is what the caller asked for.
+    expect(updateNotebook).toHaveBeenCalledTimes(1);
+    const [, sent] = jest.mocked(updateNotebook).mock.calls[0];
+    expect(sent.layout.spec.cells.map((cell) => cell.spec.element.name)).toEqual(['summary']);
+  });
+
+  // The scene already shows the new document, but nothing durable happened. A caller told this succeeded
+  // would tell someone their notebook was written when the server never got it.
+  it('reports a failure when the applied change could not be saved', async () => {
+    jest.mocked(updateNotebook).mockRejectedValue(new Error('The notebook was changed by someone else.'));
+    const scene = notebookScene();
+    const client = new NotebookMutationClient(scene);
+
+    const result = await client.execute({
+      type: 'APPLY_NOTEBOOK_SPEC',
+      payload: { spec: notebookSpec({ elements: { summary: markdownCell('## Resolved') }, cells: ['summary'] }) },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('The notebook was changed by someone else.');
   });
 
   it('is refused without dashboard write permission', async () => {

--- a/public/app/features/notebook/mutation-api/commands/applyNotebookSpec.test.ts
+++ b/public/app/features/notebook/mutation-api/commands/applyNotebookSpec.test.ts
@@ -291,6 +291,22 @@ describe('APPLY_NOTEBOOK_SPEC', () => {
     expect(scene.state.body.state.isEditing).toBe(false);
   });
 
+  it('hands the applied change to autosave, which the change signal would otherwise miss', async () => {
+    const scene = notebookScene();
+    const notify = jest.spyOn(scene.autosave, 'notifyDocumentChanged');
+    const client = new NotebookMutationClient(scene);
+
+    const result = await client.execute({
+      type: 'APPLY_NOTEBOOK_SPEC',
+      payload: { spec: notebookSpec({ elements: { summary: markdownCell('## Resolved') }, cells: ['summary'] }) },
+    });
+
+    expect(result.success).toBe(true);
+    // The notebook was never in edit mode, so the scene's own change signal is ignored for this write.
+    expect(scene.state.isEditing).toBeFalsy();
+    expect(notify).toHaveBeenCalledTimes(1);
+  });
+
   it('is refused without dashboard write permission', async () => {
     jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(false);
     const scene = notebookScene();

--- a/public/app/features/notebook/mutation-api/commands/applyNotebookSpec.ts
+++ b/public/app/features/notebook/mutation-api/commands/applyNotebookSpec.ts
@@ -5,8 +5,9 @@
  * swapped onto the live NotebookScene in place (as `JsonModelEditView.onSaveSuccess` does for a
  * dashboard), so transient runtime state (in-flight queries, scroll position) is reset.
  *
- * After the swap it tells the notebook's autosave, which then saves it. The scene's own change signal only
- * counts while the notebook is being edited, and there is no edit mode to enter from here.
+ * After the swap it hands the change to the notebook's autosave and waits for the write. The scene's own
+ * change signal only counts while the notebook is being edited, and there is no edit mode to enter from
+ * here.
  */
 
 import * as z from 'zod';
@@ -103,16 +104,33 @@ export const applyNotebookSpecCommand: MutationCommand<ApplyNotebookSpecPayload,
         overlay: undefined,
       });
 
-      scene.autosave.notifyDocumentChanged();
-
-      // Echo the re-serialized spec so the caller sees what landed, and check it for dropped cells. One
-      // guard around both: the write has already landed, so nothing below may report `success: false`.
+      // Echo the re-serialized spec so the caller sees what landed, and check it for dropped cells. Both
+      // describe the scene rather than the save, so they run before it and one guard covers both: a check
+      // that cannot run is a warning, never a failure.
       let appliedNotebook: NotebookSpec | undefined;
       try {
         appliedNotebook = transformNotebookSceneToSaveModel(scene);
         warnings.push(...droppedCellWarnings(notebookSpec, appliedNotebook));
       } catch {
         warnings.push(UNKNOWN_SURVIVORS_WARNING);
+      }
+
+      // Waited on rather than left to the debounce: this result is the caller's only signal, and one that
+      // said the write succeeded while it was still in flight would report a notebook that never saved.
+      try {
+        await scene.autosave.saveDocumentChange();
+      } catch (error) {
+        return {
+          success: false,
+          // Says which half failed, because they differ: the scene on screen holds the new document, and
+          // the server still holds the old one. The notebook offers a Retry.
+          error: `The notebook was changed but could not be saved: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+          data: { applied: true, spec: appliedNotebook },
+          changes: [],
+          warnings: warnings.length > 0 ? warnings : undefined,
+        };
       }
 
       return {

--- a/public/app/features/notebook/mutation-api/commands/applyNotebookSpec.ts
+++ b/public/app/features/notebook/mutation-api/commands/applyNotebookSpec.ts
@@ -5,7 +5,8 @@
  * swapped onto the live NotebookScene in place (as `JsonModelEditView.onSaveSuccess` does for a
  * dashboard), so transient runtime state (in-flight queries, scroll position) is reset.
  *
- * In memory only. Saving is the caller's, and there is no notebook save flow yet.
+ * After the swap it tells the notebook's autosave, which then saves it. The scene's own change signal only
+ * counts while the notebook is being edited, and there is no edit mode to enter from here.
  */
 
 import * as z from 'zod';
@@ -64,7 +65,7 @@ export const applyNotebookSpecCommand: MutationCommand<ApplyNotebookSpecPayload,
   description:
     'Replace the notebook with a complete NotebookSpec: settings, elements (markdown, code, panel and ' +
     'library panel cells) and the ordered NotebookLayout that places them. The scene is rebuilt from ' +
-    'the spec. The change is in memory and is not saved.',
+    'the spec. The change is saved automatically.',
 
   payloadSchema: applyNotebookSpecPayloadSchema,
   permission: requiresNotebookEdit,
@@ -101,6 +102,8 @@ export const applyNotebookSpecCommand: MutationCommand<ApplyNotebookSpecPayload,
         ...sceneUtils.cloneSceneObjectState(rebuilt.state, { key: scene.state.key }),
         overlay: undefined,
       });
+
+      scene.autosave.notifyDocumentChanged();
 
       // Echo the re-serialized spec so the caller sees what landed, and check it for dropped cells. One
       // guard around both: the write has already landed, so nothing below may report `success: false`.

--- a/public/app/features/notebook/pages/NotebookPageStateManager.test.ts
+++ b/public/app/features/notebook/pages/NotebookPageStateManager.test.ts
@@ -33,11 +33,11 @@ jest.mock('app/store/store', () => {
   };
 });
 
-function notebookResource(name = 'nb-1'): Resource<NotebookSpec> {
+function notebookResource(name = 'nb-1', generation = 1): Resource<NotebookSpec> {
   return {
     apiVersion: 'dashboard.grafana.app/v2beta1',
     kind: 'Notebook',
-    metadata: { name, resourceVersion: '1', generation: 1, creationTimestamp: '2026-07-01T00:00:00Z' },
+    metadata: { name, resourceVersion: '1', generation, creationTimestamp: '2026-07-01T00:00:00Z' },
     spec: {
       ...defaultNotebookSpec(),
       title: 'My notebook',
@@ -88,6 +88,63 @@ describe('NotebookPageStateManager', () => {
 
     await manager.loadNotebook('nb-1');
     const first = manager.state.scene?.state.key;
+    await manager.loadNotebook('nb-1');
+
+    expect(manager.state.scene?.state.key).toBe(first);
+  });
+
+  it("reuses the cached scene when the only thing that moved the generation was this page's own save", async () => {
+    const fetch = jest
+      .fn()
+      .mockReturnValueOnce(of(createFetchResponse(notebookResource('nb-1', 1))))
+      .mockReturnValueOnce(of(createFetchResponse(notebookResource('nb-1', 2))));
+    setBackendSrv({ fetch } as unknown as BackendSrv);
+    const manager = new NotebookPageStateManager({ isLoading: false });
+
+    await manager.loadNotebook('nb-1');
+    const first = manager.state.scene?.state.key;
+    manager.state.scene?.autosave.setState({ savedGeneration: 2 });
+    // Emptied so the second load actually reaches the server, which is what happens once the query
+    // layer's own entry expires.
+    testStore.dispatch(dashboardAPIv2beta1.util.resetApiState());
+
+    await manager.loadNotebook('nb-1');
+
+    expect(manager.state.scene?.state.key).toBe(first);
+  });
+
+  it('rebuilds the scene when the server moved past what this page saved', async () => {
+    const fetch = jest
+      .fn()
+      .mockReturnValueOnce(of(createFetchResponse(notebookResource('nb-1', 1))))
+      .mockReturnValueOnce(of(createFetchResponse(notebookResource('nb-1', 3))));
+    setBackendSrv({ fetch } as unknown as BackendSrv);
+    const manager = new NotebookPageStateManager({ isLoading: false });
+
+    await manager.loadNotebook('nb-1');
+    const first = manager.state.scene?.state.key;
+    manager.state.scene?.autosave.setState({ savedGeneration: 2 });
+    testStore.dispatch(dashboardAPIv2beta1.util.resetApiState());
+
+    await manager.loadNotebook('nb-1');
+
+    expect(manager.state.scene).toBeInstanceOf(NotebookScene);
+    expect(manager.state.scene?.state.key).not.toBe(first);
+  });
+
+  it('keeps the cached scene when the query layer answers from before this page saved', async () => {
+    // No reset here: the query layer still holds the response from the first load, so the second one is
+    // answered with the generation from before the save. Rebuilding from that would put the notebook
+    // back to how it looked before the edits autosave had already persisted.
+    setBackendSrv({
+      fetch: jest.fn().mockReturnValue(of(createFetchResponse(notebookResource('nb-1', 1)))),
+    } as unknown as BackendSrv);
+    const manager = new NotebookPageStateManager({ isLoading: false });
+
+    await manager.loadNotebook('nb-1');
+    const first = manager.state.scene?.state.key;
+    manager.state.scene?.autosave.setState({ savedGeneration: 2 });
+
     await manager.loadNotebook('nb-1');
 
     expect(manager.state.scene?.state.key).toBe(first);

--- a/public/app/features/notebook/pages/NotebookPageStateManager.ts
+++ b/public/app/features/notebook/pages/NotebookPageStateManager.ts
@@ -69,7 +69,11 @@ export class NotebookPageStateManager extends StateManagerBase<NotebookPageState
       const notebook = result.data as unknown as Resource<NotebookSpec>;
 
       const cached = this.cache.get(uid);
-      if (cached && cached.generation === notebook.metadata.generation) {
+      // The generation this was loaded at goes stale the moment the page saves, because autosave advances
+      // the server's copy without reloading. Where the scene has saved since, that is the newer number, and
+      // it is what separates this page's own write from somebody else's.
+      const cachedGeneration = cached ? (cached.scene.autosave.state.savedGeneration ?? cached.generation) : undefined;
+      if (cached && isAtLeastAsNew(cachedGeneration, notebook.metadata.generation)) {
         if (this.isSuperseded(seq)) {
           return;
         }
@@ -126,6 +130,19 @@ export class NotebookPageStateManager extends StateManagerBase<NotebookPageState
   public clearSceneCache(): void {
     this.cache.clear();
   }
+}
+
+/**
+ * Deliberately not an equality check. `generation` only ever goes up, and the query layer can answer a load
+ * with a response it recorded before this page's own save, which a rebuild would then undo. Only a higher
+ * number means somebody else wrote. Falls back to equality when either side is missing.
+ */
+function isAtLeastAsNew(cached: number | undefined, fetched: number | undefined): boolean {
+  if (cached === undefined || fetched === undefined) {
+    return cached === fetched;
+  }
+
+  return cached >= fetched;
 }
 
 let notebookPageStateManager: NotebookPageStateManager | undefined;

--- a/public/app/features/notebook/scene/NotebookAutosave.test.ts
+++ b/public/app/features/notebook/scene/NotebookAutosave.test.ts
@@ -133,6 +133,38 @@ describe('NotebookAutosave', () => {
     expect(scene.autosave.state.status).toBe('saved');
   });
 
+  // Coming back to a notebook reuses the cached scene and reactivates it, so this is the same
+  // controller it was before, holding edits that never reached the server.
+  it('still sends an edit whose save failed, after leaving the notebook and coming back', async () => {
+    const scene = activateEditing();
+    jest.mocked(updateNotebook).mockRejectedValueOnce(new Error('apiserver said no'));
+
+    editFirstCell(scene, 'work I would rather not lose');
+    await jest.advanceTimersByTimeAsync(IDLE_BEFORE_SAVE_MS);
+    expect(scene.autosave.state.status).toBe('error');
+
+    deactivate?.();
+    deactivate = scene.activate();
+    await jest.advanceTimersByTimeAsync(IDLE_BEFORE_SAVE_MS);
+
+    expect(savedTexts()).toEqual(['work I would rather not lose', 'work I would rather not lose']);
+    expect(scene.autosave.state.status).toBe('saved');
+  });
+
+  it('sends nothing when a notebook with no unsaved work is reopened', async () => {
+    const scene = activateEditing();
+
+    editFirstCell(scene, 'Hello world');
+    await jest.advanceTimersByTimeAsync(IDLE_BEFORE_SAVE_MS);
+    expect(updateNotebook).toHaveBeenCalledTimes(1);
+
+    deactivate?.();
+    deactivate = scene.activate();
+    await jest.advanceTimersByTimeAsync(IDLE_BEFORE_SAVE_MS);
+
+    expect(updateNotebook).toHaveBeenCalledTimes(1);
+  });
+
   it('sends a failed save again when asked to retry', async () => {
     const scene = activateEditing();
     jest.mocked(updateNotebook).mockRejectedValueOnce(new Error('apiserver said no'));

--- a/public/app/features/notebook/scene/NotebookAutosave.test.ts
+++ b/public/app/features/notebook/scene/NotebookAutosave.test.ts
@@ -257,18 +257,64 @@ describe('NotebookAutosave', () => {
     expect(jest.mocked(updateNotebook).mock.calls[0][1].timeSettings.from).toBe('now-1h');
   });
 
-  // A writer that does not go through edit mode announces itself instead. APPLY_NOTEBOOK_SPEC is the
+  // A writer that does not go through edit mode asks for the save itself. APPLY_NOTEBOOK_SPEC is the
   // one that matters; that it actually calls this is covered in applyNotebookSpec.test.ts.
   it('saves a change announced by a writer that is not in edit mode', async () => {
     const scene = buildScene();
     deactivate = scene.activate();
 
     scene.state.body.state.cells[0].setState({ content: { kind: 'Markdown', spec: { text: 'Written elsewhere' } } });
-    scene.autosave.notifyDocumentChanged();
-    await jest.advanceTimersByTimeAsync(IDLE_BEFORE_SAVE_MS);
+    // No clock advanced: this caller is handed the outcome, so its save cannot sit on the debounce.
+    await scene.autosave.saveDocumentChange();
 
     expect(scene.state.isEditing).toBeFalsy();
     expect(savedTexts()).toEqual(['Written elsewhere']);
+  });
+
+  it('tells a writer whose save failed, instead of letting it report a write that never landed', async () => {
+    jest.mocked(updateNotebook).mockRejectedValue(new Error('The notebook was changed by someone else.'));
+    const scene = buildScene();
+    deactivate = scene.activate();
+
+    scene.state.body.state.cells[0].setState({ content: { kind: 'Markdown', spec: { text: 'Written elsewhere' } } });
+
+    await expect(scene.autosave.saveDocumentChange()).rejects.toThrow('The notebook was changed by someone else.');
+    expect(scene.autosave.state.status).toBe('error');
+  });
+
+  it('writes nothing when the announced document is already what was saved', async () => {
+    const scene = buildScene();
+    deactivate = scene.activate();
+
+    await scene.autosave.saveDocumentChange();
+
+    expect(updateNotebook).not.toHaveBeenCalled();
+  });
+
+  // The change is carried by the save queued behind the request already running, so waiting on the
+  // running one would hand the writer a success before its own content had been written.
+  it('waits for the queued save when a save was already in flight', async () => {
+    let finishFirstSave = () => {};
+    jest
+      .mocked(updateNotebook)
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            finishFirstSave = () => resolve({ generation: 2 });
+          })
+      )
+      .mockResolvedValue({ generation: 3 });
+
+    const scene = activateEditing();
+    editFirstCell(scene, 'First');
+    await jest.advanceTimersByTimeAsync(IDLE_BEFORE_SAVE_MS);
+
+    editFirstCell(scene, 'Second');
+    const saved = scene.autosave.saveDocumentChange();
+    finishFirstSave();
+    await saved;
+
+    expect(savedTexts()).toEqual(['First', 'Second']);
   });
 
   it('collapses several rapid edits into one request carrying the last of them', async () => {

--- a/public/app/features/notebook/scene/NotebookAutosave.test.ts
+++ b/public/app/features/notebook/scene/NotebookAutosave.test.ts
@@ -106,13 +106,13 @@ describe('NotebookAutosave', () => {
     expect(scene.autosave.state.status).toBe('saved');
   });
 
-  // Lots of things change the scene without changing what gets saved. Left on pending after one of those,
-  // the notebook would go on saying it has unsaved changes with nothing to save.
-  it('stops reporting unsaved changes when the change did not touch the spec', async () => {
+  // Lots of things change the scene without changing what gets saved. Reporting those would have the
+  // notebook claim unsaved changes it does not have.
+  it('reports no unsaved changes when the change did not touch the spec', async () => {
     const scene = activateEditing();
 
     scene.showModal(new TestOverlay({}));
-    expect(scene.autosave.state.status).toBe('pending');
+    expect(scene.autosave.state.status).toBe('idle');
 
     await jest.advanceTimersByTimeAsync(IDLE_BEFORE_SAVE_MS);
 
@@ -120,7 +120,7 @@ describe('NotebookAutosave', () => {
     expect(scene.autosave.state.status).toBe('idle');
   });
 
-  it('falls back to saved, not idle, when a spec-less change follows a real save', async () => {
+  it('goes on saying saved when a spec-less change follows a real save', async () => {
     const scene = activateEditing();
 
     editFirstCell(scene, 'Hello world');
@@ -205,6 +205,43 @@ describe('NotebookAutosave', () => {
     deactivate = scene.activate();
 
     scene.state.$timeRange.setState({ from: 'now-1h', to: 'now' });
+    await jest.advanceTimersByTimeAsync(MAX_WAIT_MS);
+
+    expect(updateNotebook).not.toHaveBeenCalled();
+  });
+
+  // A notebook opens at the time range it was saved with, so a range someone picked while reading it must
+  // not become the range it opens at for everyone else.
+  it('keeps the saved time range when a reader moved theirs before editing something else', async () => {
+    const scene = buildScene();
+    deactivate = scene.activate();
+
+    scene.state.$timeRange.setState({ from: 'now-1h', to: 'now' });
+    scene.onEnterEditMode();
+    editFirstCell(scene, 'Hello world');
+    await jest.advanceTimersByTimeAsync(IDLE_BEFORE_SAVE_MS);
+
+    expect(savedTexts()).toEqual(['Hello world']);
+    expect(jest.mocked(updateNotebook).mock.calls[0][1].timeSettings.from).toBe('now-6h');
+  });
+
+  it('sends nothing when a notebook is reopened after a reader moved the time range', async () => {
+    const scene = buildScene();
+    deactivate = scene.activate();
+
+    scene.state.$timeRange.setState({ from: 'now-1h', to: 'now' });
+    deactivate();
+    deactivate = scene.activate();
+    await jest.advanceTimersByTimeAsync(MAX_WAIT_MS);
+
+    expect(updateNotebook).not.toHaveBeenCalled();
+  });
+
+  it('reports nothing when edit mode is entered and nothing has been changed', async () => {
+    const scene = activateEditing();
+
+    expect(scene.autosave.state.status).toBe('idle');
+
     await jest.advanceTimersByTimeAsync(MAX_WAIT_MS);
 
     expect(updateNotebook).not.toHaveBeenCalled();

--- a/public/app/features/notebook/scene/NotebookAutosave.test.ts
+++ b/public/app/features/notebook/scene/NotebookAutosave.test.ts
@@ -1,0 +1,299 @@
+import { SceneObjectBase, SceneRefreshPicker, SceneTimePicker, SceneTimeRange } from '@grafana/scenes';
+import { contextSrv } from 'app/core/services/context_srv';
+
+import { updateNotebook } from '../api/notebookResource';
+
+import { NotebookScene } from './NotebookScene';
+import { NotebookCellItem } from './layout-notebook/NotebookCellItem';
+import { NotebookLayoutManager } from './layout-notebook/NotebookLayoutManager';
+
+// The network write is the only thing stubbed. Everything above it is the real scene, the real layout
+// manager and the real serializer, so the spec these tests assert on is the one that would be sent.
+jest.mock('../api/notebookResource', () => ({
+  updateNotebook: jest.fn(),
+}));
+
+// Mirrors the constants in NotebookAutosave. Duplicated rather than exported so that changing a timing
+// number has to be a deliberate edit here too.
+const IDLE_BEFORE_SAVE_MS = 2000;
+const MAX_WAIT_MS = 15000;
+
+/** Concrete stand-in: SceneObjectBase is abstract, and overlay just needs a SceneObject. */
+class TestOverlay extends SceneObjectBase {}
+
+function buildScene() {
+  return new NotebookScene({
+    uid: 'nb-1',
+    title: 'My notebook',
+    body: new NotebookLayoutManager({
+      cells: [
+        new NotebookCellItem({
+          elementName: 'md1',
+          source: 'user',
+          content: { kind: 'Markdown', spec: { text: 'Hello' } },
+        }),
+      ],
+    }),
+    $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
+    timePicker: new SceneTimePicker({}),
+    // No refresh interval: an active refresh picker schedules its own timers, which the fake clock
+    // below would then drive alongside the debounce.
+    refreshPicker: new SceneRefreshPicker({ refresh: '', intervals: ['10s'] }),
+  });
+}
+
+function editFirstCell(scene: NotebookScene, text: string) {
+  const [cell] = scene.state.body.state.cells;
+  scene.state.body.setCellContent(cell, { kind: 'Markdown', spec: { text } });
+}
+
+function savedTexts() {
+  return jest.mocked(updateNotebook).mock.calls.map(([, spec]) => {
+    const element = spec.elements.md1;
+    return element.kind === 'Cell' && element.spec.content.kind === 'Markdown' ? element.spec.content.spec.text : '';
+  });
+}
+
+describe('NotebookAutosave', () => {
+  let deactivate: (() => void) | undefined;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(true);
+    jest.mocked(updateNotebook).mockReset().mockResolvedValue({ generation: 2 });
+  });
+
+  afterEach(() => {
+    deactivate?.();
+    deactivate = undefined;
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  function activateEditing() {
+    const scene = buildScene();
+    deactivate = scene.activate();
+    scene.onEnterEditMode();
+    return scene;
+  }
+
+  it('saves an edit made in edit mode, with no save button', async () => {
+    const scene = activateEditing();
+
+    editFirstCell(scene, 'Hello world');
+    await jest.advanceTimersByTimeAsync(IDLE_BEFORE_SAVE_MS);
+
+    expect(updateNotebook).toHaveBeenCalledTimes(1);
+    const [uid, spec] = jest.mocked(updateNotebook).mock.calls[0];
+    expect(uid).toBe('nb-1');
+    expect(spec.elements.md1).toEqual({
+      kind: 'Cell',
+      spec: { content: { kind: 'Markdown', spec: { text: 'Hello world' } } },
+    });
+    expect(scene.autosave.state.status).toBe('saved');
+  });
+
+  it('reports unsaved changes while a save is still waiting on the debounce', async () => {
+    const scene = activateEditing();
+
+    editFirstCell(scene, 'Hello world');
+
+    expect(scene.autosave.state.status).toBe('pending');
+    expect(updateNotebook).not.toHaveBeenCalled();
+
+    await jest.advanceTimersByTimeAsync(IDLE_BEFORE_SAVE_MS);
+
+    expect(scene.autosave.state.status).toBe('saved');
+  });
+
+  // Lots of things change the scene without changing what gets saved. Left on pending after one of those,
+  // the notebook would go on saying it has unsaved changes with nothing to save.
+  it('stops reporting unsaved changes when the change did not touch the spec', async () => {
+    const scene = activateEditing();
+
+    scene.showModal(new TestOverlay({}));
+    expect(scene.autosave.state.status).toBe('pending');
+
+    await jest.advanceTimersByTimeAsync(IDLE_BEFORE_SAVE_MS);
+
+    expect(updateNotebook).not.toHaveBeenCalled();
+    expect(scene.autosave.state.status).toBe('idle');
+  });
+
+  it('falls back to saved, not idle, when a spec-less change follows a real save', async () => {
+    const scene = activateEditing();
+
+    editFirstCell(scene, 'Hello world');
+    await jest.advanceTimersByTimeAsync(IDLE_BEFORE_SAVE_MS);
+
+    scene.showModal(new TestOverlay({}));
+    await jest.advanceTimersByTimeAsync(IDLE_BEFORE_SAVE_MS);
+
+    expect(updateNotebook).toHaveBeenCalledTimes(1);
+    expect(scene.autosave.state.status).toBe('saved');
+  });
+
+  it('sends a failed save again when asked to retry', async () => {
+    const scene = activateEditing();
+    jest.mocked(updateNotebook).mockRejectedValueOnce(new Error('apiserver said no'));
+
+    editFirstCell(scene, 'Hello world');
+    await jest.advanceTimersByTimeAsync(IDLE_BEFORE_SAVE_MS);
+    expect(scene.autosave.state.status).toBe('error');
+
+    scene.autosave.retry();
+    await jest.advanceTimersByTimeAsync(0);
+
+    expect(savedTexts()).toEqual(['Hello world', 'Hello world']);
+    expect(scene.autosave.state.status).toBe('saved');
+  });
+
+  it('records the generation the server returned, so a later load can tell its own save apart', async () => {
+    const scene = activateEditing();
+
+    editFirstCell(scene, 'Hello world');
+    await jest.advanceTimersByTimeAsync(IDLE_BEFORE_SAVE_MS);
+
+    expect(scene.autosave.state.savedGeneration).toBe(2);
+  });
+
+  it('records no generation when the response carried none', async () => {
+    const scene = activateEditing();
+    jest.mocked(updateNotebook).mockResolvedValue({});
+
+    editFirstCell(scene, 'Hello world');
+    await jest.advanceTimersByTimeAsync(IDLE_BEFORE_SAVE_MS);
+
+    expect(scene.autosave.state.status).toBe('saved');
+    expect(scene.autosave.state.savedGeneration).toBeUndefined();
+  });
+
+  it('does not save a time range change made outside edit mode', async () => {
+    const scene = buildScene();
+    deactivate = scene.activate();
+
+    scene.state.$timeRange.setState({ from: 'now-1h', to: 'now' });
+    await jest.advanceTimersByTimeAsync(MAX_WAIT_MS);
+
+    expect(updateNotebook).not.toHaveBeenCalled();
+  });
+
+  it('saves a time range change made in edit mode', async () => {
+    const scene = activateEditing();
+
+    scene.state.$timeRange.setState({ from: 'now-1h', to: 'now' });
+    await jest.advanceTimersByTimeAsync(IDLE_BEFORE_SAVE_MS);
+
+    expect(updateNotebook).toHaveBeenCalledTimes(1);
+    expect(jest.mocked(updateNotebook).mock.calls[0][1].timeSettings.from).toBe('now-1h');
+  });
+
+  // A writer that does not go through edit mode announces itself instead. APPLY_NOTEBOOK_SPEC is the
+  // one that matters; that it actually calls this is covered in applyNotebookSpec.test.ts.
+  it('saves a change announced by a writer that is not in edit mode', async () => {
+    const scene = buildScene();
+    deactivate = scene.activate();
+
+    scene.state.body.state.cells[0].setState({ content: { kind: 'Markdown', spec: { text: 'Written elsewhere' } } });
+    scene.autosave.notifyDocumentChanged();
+    await jest.advanceTimersByTimeAsync(IDLE_BEFORE_SAVE_MS);
+
+    expect(scene.state.isEditing).toBeFalsy();
+    expect(savedTexts()).toEqual(['Written elsewhere']);
+  });
+
+  it('collapses several rapid edits into one request carrying the last of them', async () => {
+    const scene = activateEditing();
+
+    editFirstCell(scene, 'one');
+    await jest.advanceTimersByTimeAsync(100);
+    editFirstCell(scene, 'two');
+    await jest.advanceTimersByTimeAsync(100);
+    editFirstCell(scene, 'three');
+    await jest.advanceTimersByTimeAsync(IDLE_BEFORE_SAVE_MS);
+
+    expect(updateNotebook).toHaveBeenCalledTimes(1);
+    expect(savedTexts()).toEqual(['three']);
+  });
+
+  it('saves at the ceiling when typing never pauses long enough to go quiet', async () => {
+    const scene = activateEditing();
+
+    for (let i = 0; i < 14; i++) {
+      editFirstCell(scene, `keystroke ${i}`);
+      await jest.advanceTimersByTimeAsync(IDLE_BEFORE_SAVE_MS / 2);
+    }
+
+    expect(updateNotebook).not.toHaveBeenCalled();
+
+    editFirstCell(scene, 'last keystroke');
+    await jest.advanceTimersByTimeAsync(MAX_WAIT_MS - 14 * (IDLE_BEFORE_SAVE_MS / 2));
+
+    expect(updateNotebook).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends nothing when an edit is undone back to the original content', async () => {
+    const scene = activateEditing();
+
+    editFirstCell(scene, 'Changed');
+    editFirstCell(scene, 'Hello');
+    await jest.advanceTimersByTimeAsync(IDLE_BEFORE_SAVE_MS);
+
+    expect(updateNotebook).not.toHaveBeenCalled();
+  });
+
+  it('leaves the undo history intact after a save', async () => {
+    const scene = activateEditing();
+
+    editFirstCell(scene, 'Hello world');
+    await jest.advanceTimersByTimeAsync(IDLE_BEFORE_SAVE_MS);
+
+    expect(updateNotebook).toHaveBeenCalledTimes(1);
+    expect(scene.editHistory.state.canUndo).toBe(true);
+    expect(scene.editHistory.undo()).toBe(true);
+    expect(scene.state.body.state.cells[0].state.content).toEqual({ kind: 'Markdown', spec: { text: 'Hello' } });
+  });
+
+  it('carries a failed edit into the next save rather than losing it', async () => {
+    const scene = activateEditing();
+    jest.mocked(updateNotebook).mockRejectedValueOnce(new Error('apiserver said no'));
+
+    editFirstCell(scene, 'first');
+    await jest.advanceTimersByTimeAsync(IDLE_BEFORE_SAVE_MS);
+
+    expect(scene.autosave.state.status).toBe('error');
+    expect(scene.autosave.state.errorMessage).toBe('apiserver said no');
+
+    editFirstCell(scene, 'second');
+    await jest.advanceTimersByTimeAsync(IDLE_BEFORE_SAVE_MS);
+
+    expect(savedTexts()).toEqual(['first', 'second']);
+    expect(scene.autosave.state.status).toBe('saved');
+  });
+
+  it('flushes a pending edit when the scene is torn down', async () => {
+    const scene = activateEditing();
+
+    editFirstCell(scene, 'typed just before leaving');
+    await jest.advanceTimersByTimeAsync(IDLE_BEFORE_SAVE_MS / 4);
+    expect(updateNotebook).not.toHaveBeenCalled();
+
+    deactivate?.();
+    deactivate = undefined;
+
+    expect(savedTexts()).toEqual(['typed just before leaving']);
+  });
+
+  it('flushes a pending edit when the page is hidden', async () => {
+    const scene = activateEditing();
+
+    editFirstCell(scene, 'typed just before hiding');
+    await jest.advanceTimersByTimeAsync(IDLE_BEFORE_SAVE_MS / 4);
+    expect(updateNotebook).not.toHaveBeenCalled();
+
+    Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(savedTexts()).toEqual(['typed just before hiding']);
+  });
+});

--- a/public/app/features/notebook/scene/NotebookAutosave.ts
+++ b/public/app/features/notebook/scene/NotebookAutosave.ts
@@ -53,9 +53,18 @@ export class NotebookAutosave extends StateManagerBase<NotebookAutosaveState> {
 
   /** Begins watching for changes. Returns the teardown, which flushes anything still pending. */
   public start(): () => void {
-    // Entering edit mode publishes state changes of its own, so without a baseline the first comparison
-    // would write the notebook straight back unchanged.
-    this.lastSaved = JSON.stringify(transformNotebookSceneToSaveModel(this.scene));
+    const current = JSON.stringify(transformNotebookSceneToSaveModel(this.scene));
+
+    if (this.lastSaved === undefined) {
+      // Entering edit mode publishes state changes of its own, so without a baseline the first
+      // comparison would write the notebook straight back unchanged.
+      this.lastSaved = current;
+    } else if (current !== this.lastSaved) {
+      // A scene is cached and reactivated when you come back to a notebook, so this can be the same
+      // controller with edits that never reached the server. Recording them as written here would lose
+      // them, so try the save again instead of waiting for a change that may never come.
+      this.schedule();
+    }
 
     this.changeSub = this.scene.subscribeToEvent(SceneObjectStateChangedEvent, () => {
       if (!this.scene.state.isEditing) {

--- a/public/app/features/notebook/scene/NotebookAutosave.ts
+++ b/public/app/features/notebook/scene/NotebookAutosave.ts
@@ -39,7 +39,7 @@ export interface NotebookAutosaveState {
  * Changes only count while the notebook is being edited, and a time range only counts when it was changed
  * in that time: the time picker is there for readers too, and the range a reader picked is theirs, not the
  * range the notebook should open at for everyone. Writers that never enter edit mode call
- * `notifyDocumentChanged` instead.
+ * `saveDocumentChange` instead.
  */
 export class NotebookAutosave extends StateManagerBase<NotebookAutosaveState> {
   /** The spec we treat as already written: what the last save sent, or the notebook as it was loaded. */
@@ -50,6 +50,8 @@ export class NotebookAutosave extends StateManagerBase<NotebookAutosaveState> {
   private timeSettingsEdited = false;
   private changeSub?: Unsubscribable;
   private inFlight = false;
+  /** The save now running, so a caller that reports an outcome can wait for the write to land. */
+  private inFlightSave?: Promise<void>;
   private saveAgainWhenIdle = false;
   private changePending = false;
   private hasSavedOnce = false;
@@ -91,16 +93,35 @@ export class NotebookAutosave extends StateManagerBase<NotebookAutosaveState> {
   }
 
   /**
-   * Schedules a save for a writer that does not go through edit mode.
+   * Saves a change made by a writer that does not go through edit mode, and waits for the write.
    *
    * The mutation API has no edit mode to enter (see `requiresNotebookEdit`), so its writes never set
    * `isEditing` and the change signal above ignores them. A write command that skips this does not save.
+   *
+   * It waits instead of leaving the save on the debounce because the caller reports an outcome: the
+   * assistant tells someone their notebook was written, and only the finished request knows whether it
+   * was. Throws when the save failed, so the caller can say that rather than claim a write that never
+   * reached the server.
    */
-  public notifyDocumentChanged(): void {
+  public async saveDocumentChange(): Promise<void> {
     // These writers hand over a whole document, time settings included, so what is in the scene now is
     // the notebook's own.
     this.timeSettingsEdited = true;
     this.schedule();
+    this.flush();
+
+    // `flush` runs the save synchronously, so anything to write is already in flight by now. A save that
+    // was already running when this arrived leaves this one queued behind it, and the queued one is the
+    // one carrying the change, so waiting on a single request would return before it was written.
+    while (this.inFlightSave) {
+      await this.inFlightSave;
+    }
+
+    // Nothing is left in flight, so the status now says how it went. Still no error means the write
+    // landed, or there was nothing to write and the notebook already holds what was asked for.
+    if (this.state.status === 'error') {
+      throw new Error(this.state.errorMessage ?? 'The notebook could not be saved.');
+    }
   }
 
   /**
@@ -221,8 +242,18 @@ export class NotebookAutosave extends StateManagerBase<NotebookAutosaveState> {
 
     this.changePending = false;
 
-    const spec = this.buildSpecToSave();
-    const serialized = JSON.stringify(spec);
+    let spec: NotebookSpec;
+    let serialized: string;
+    try {
+      spec = this.buildSpecToSave();
+      serialized = JSON.stringify(spec);
+    } catch (error) {
+      // `hasSomethingToWrite` leaves this for the save to report, because this is the one place with
+      // somewhere to say it. A notebook whose spec cannot be built is not going to save.
+      this.setState({ status: 'error', errorMessage: error instanceof Error ? error.message : String(error) });
+      return;
+    }
+
     if (serialized === this.baseline) {
       // Lots of things change the scene without changing what gets saved. Left on `pending`, the
       // notebook would go on saying it has unsaved changes when it has none.
@@ -233,7 +264,7 @@ export class NotebookAutosave extends StateManagerBase<NotebookAutosaveState> {
     this.inFlight = true;
     this.setState({ status: 'saving', errorMessage: undefined });
 
-    updateNotebook(uid, spec)
+    this.inFlightSave = updateNotebook(uid, spec)
       .then(({ generation }) => {
         this.recordWritten(spec, serialized);
         this.hasSavedOnce = true;
@@ -256,6 +287,8 @@ export class NotebookAutosave extends StateManagerBase<NotebookAutosaveState> {
       })
       .finally(() => {
         this.inFlight = false;
+        // Cleared before the queued save runs, so that save can record its own request here.
+        this.inFlightSave = undefined;
         if (this.saveAgainWhenIdle) {
           this.saveAgainWhenIdle = false;
           this.saveNow();

--- a/public/app/features/notebook/scene/NotebookAutosave.ts
+++ b/public/app/features/notebook/scene/NotebookAutosave.ts
@@ -1,0 +1,182 @@
+import { debounce } from 'lodash';
+import { type Unsubscribable } from 'rxjs';
+
+import { SceneObjectStateChangedEvent } from '@grafana/scenes';
+import { StateManagerBase } from 'app/core/services/StateManagerBase';
+
+import { updateNotebook } from '../api/notebookResource';
+import { transformNotebookSceneToSaveModel } from '../serialization/transformNotebookSceneToSaveModel';
+
+import { type NotebookScene } from './NotebookScene';
+
+/**
+ * Two seconds is about how long a pause means someone stopped typing, rather than thinking mid-sentence.
+ * Save sooner and we save in the middle of a word, and every save sends the whole notebook.
+ */
+const IDLE_BEFORE_SAVE_MS = 2000;
+
+/** Every update writes a `resource_history` row, so this caps someone typing non-stop at 4 saves a minute. */
+const MAX_WAIT_MS = 15000;
+
+export type NotebookSaveStatus = 'idle' | 'pending' | 'saving' | 'saved' | 'error';
+
+export interface NotebookAutosaveState {
+  status: NotebookSaveStatus;
+  errorMessage?: string;
+  /** The resource generation the last successful save produced, when the server reported one. */
+  savedGeneration?: number;
+}
+
+/**
+ * Saves a notebook as it is changed, with no save button.
+ *
+ * It watches the scene's own state changes, not the edit history, because the edit history records a
+ * typing session once at the first keystroke and would miss everything typed after it. It does not try to
+ * work out which changes matter: `saveNow` compares what would be saved against what was saved last, and
+ * skips the write when they match.
+ *
+ * Changes only count while the notebook is being edited. Time settings are part of what gets saved and the
+ * time picker is there for readers too, so counting a reader's change would save their time range as the
+ * notebook's own. Writers that never enter edit mode call `notifyDocumentChanged` instead.
+ */
+export class NotebookAutosave extends StateManagerBase<NotebookAutosaveState> {
+  private lastSaved?: string;
+  private changeSub?: Unsubscribable;
+  private inFlight = false;
+  private saveAgainWhenIdle = false;
+  private changePending = false;
+  private hasSavedOnce = false;
+
+  public constructor(private scene: NotebookScene) {
+    super({ status: 'idle' });
+  }
+
+  /** Begins watching for changes. Returns the teardown, which flushes anything still pending. */
+  public start(): () => void {
+    // Entering edit mode publishes state changes of its own, so without a baseline the first comparison
+    // would write the notebook straight back unchanged.
+    this.lastSaved = JSON.stringify(transformNotebookSceneToSaveModel(this.scene));
+
+    this.changeSub = this.scene.subscribeToEvent(SceneObjectStateChangedEvent, () => {
+      if (!this.scene.state.isEditing) {
+        return;
+      }
+
+      this.schedule();
+    });
+
+    // Not beforeunload: adding an unload listener stops the browser reusing the page when you navigate
+    // back, for everyone. Going hidden is the last thing a page is sure to see before it disappears.
+    document.addEventListener('visibilitychange', this.onVisibilityChange);
+
+    return () => this.stop();
+  }
+
+  /**
+   * Schedules a save for a writer that does not go through edit mode.
+   *
+   * The mutation API has no edit mode to enter (see `requiresNotebookEdit`), so its writes never set
+   * `isEditing` and the change signal above ignores them. A write command that skips this does not save.
+   */
+  public notifyDocumentChanged(): void {
+    this.schedule();
+  }
+
+  /** Tries a failed save again. A failure waits for the next change, which may never come. */
+  public retry(): void {
+    this.schedule();
+    this.flush();
+  }
+
+  /** Writes a pending save immediately, if there is one. */
+  public flush(): void {
+    this.scheduleSave.flush();
+  }
+
+  private stop(): void {
+    document.removeEventListener('visibilitychange', this.onVisibilityChange);
+    this.changeSub?.unsubscribe();
+    this.changeSub = undefined;
+    this.flush();
+  }
+
+  private onVisibilityChange = (): void => {
+    if (document.visibilityState === 'hidden') {
+      this.flush();
+    }
+  };
+
+  private scheduleSave = debounce(() => this.saveNow(), IDLE_BEFORE_SAVE_MS, { maxWait: MAX_WAIT_MS });
+
+  private schedule(): void {
+    this.changePending = true;
+
+    // Guarded so a keystroke does not publish state on every character.
+    if (this.state.status !== 'pending') {
+      this.setState({ status: 'pending' });
+    }
+
+    this.scheduleSave();
+  }
+
+  /** What to report when there is nothing waiting to be written. */
+  private restingStatus(): NotebookSaveStatus {
+    return this.hasSavedOnce ? 'saved' : 'idle';
+  }
+
+  private saveNow(): void {
+    // Two writes in flight can land out of order and let the older spec win.
+    if (this.inFlight) {
+      this.saveAgainWhenIdle = true;
+      return;
+    }
+
+    const { uid } = this.scene.state;
+    if (!uid) {
+      return;
+    }
+
+    this.changePending = false;
+
+    const spec = transformNotebookSceneToSaveModel(this.scene);
+    const serialized = JSON.stringify(spec);
+    if (serialized === this.lastSaved) {
+      // Lots of things change the scene without changing what gets saved. Left on `pending`, the
+      // notebook would go on saying it has unsaved changes when it has none.
+      this.setState({ status: this.restingStatus() });
+      return;
+    }
+
+    this.inFlight = true;
+    this.setState({ status: 'saving', errorMessage: undefined });
+
+    updateNotebook(uid, spec)
+      .then(({ generation }) => {
+        this.lastSaved = serialized;
+        this.hasSavedOnce = true;
+        this.setState({
+          // Something can have changed while this was in flight, and reporting it saved would claim
+          // content that has not been written.
+          status: this.changePending || this.saveAgainWhenIdle ? 'pending' : 'saved',
+          errorMessage: undefined,
+          // Only recorded when the server sent one. `NotebookPageStateManager` decides whether to reuse
+          // its cached scene by comparing this, so a number we guessed could make it keep a stale one.
+          ...(generation !== undefined ? { savedGeneration: generation } : {}),
+        });
+      })
+      .catch((error) => {
+        // Leave `lastSaved` alone, so the next comparison still sees a difference and tries again.
+        this.setState({
+          status: 'error',
+          errorMessage: error instanceof Error ? error.message : String(error),
+        });
+      })
+      .finally(() => {
+        this.inFlight = false;
+        if (this.saveAgainWhenIdle) {
+          this.saveAgainWhenIdle = false;
+          this.saveNow();
+        }
+      });
+  }
+}

--- a/public/app/features/notebook/scene/NotebookAutosave.ts
+++ b/public/app/features/notebook/scene/NotebookAutosave.ts
@@ -1,11 +1,12 @@
 import { debounce } from 'lodash';
 import { type Unsubscribable } from 'rxjs';
 
-import { SceneObjectStateChangedEvent } from '@grafana/scenes';
+import { SceneObjectStateChangedEvent, type SceneObjectStateChangedPayload } from '@grafana/scenes';
 import { StateManagerBase } from 'app/core/services/StateManagerBase';
 
 import { updateNotebook } from '../api/notebookResource';
 import { transformNotebookSceneToSaveModel } from '../serialization/transformNotebookSceneToSaveModel';
+import { type Spec as NotebookSpec } from '../types';
 
 import { type NotebookScene } from './NotebookScene';
 
@@ -35,12 +36,18 @@ export interface NotebookAutosaveState {
  * work out which changes matter: `saveNow` compares what would be saved against what was saved last, and
  * skips the write when they match.
  *
- * Changes only count while the notebook is being edited. Time settings are part of what gets saved and the
- * time picker is there for readers too, so counting a reader's change would save their time range as the
- * notebook's own. Writers that never enter edit mode call `notifyDocumentChanged` instead.
+ * Changes only count while the notebook is being edited, and a time range only counts when it was changed
+ * in that time: the time picker is there for readers too, and the range a reader picked is theirs, not the
+ * range the notebook should open at for everyone. Writers that never enter edit mode call
+ * `notifyDocumentChanged` instead.
  */
 export class NotebookAutosave extends StateManagerBase<NotebookAutosaveState> {
-  private lastSaved?: string;
+  /** The spec we treat as already written: what the last save sent, or the notebook as it was loaded. */
+  private baseline?: string;
+  /** The time settings of `baseline`, sent again for as long as nobody has edited them. */
+  private savedTimeSettings?: NotebookSpec['timeSettings'];
+  /** Whether the time settings now in the scene are the notebook's own, rather than one reader's. */
+  private timeSettingsEdited = false;
   private changeSub?: Unsubscribable;
   private inFlight = false;
   private saveAgainWhenIdle = false;
@@ -53,22 +60,24 @@ export class NotebookAutosave extends StateManagerBase<NotebookAutosaveState> {
 
   /** Begins watching for changes. Returns the teardown, which flushes anything still pending. */
   public start(): () => void {
-    const current = JSON.stringify(transformNotebookSceneToSaveModel(this.scene));
-
-    if (this.lastSaved === undefined) {
+    if (this.baseline === undefined) {
       // Entering edit mode publishes state changes of its own, so without a baseline the first
       // comparison would write the notebook straight back unchanged.
-      this.lastSaved = current;
-    } else if (current !== this.lastSaved) {
+      this.recordWritten(this.buildSpecToSave());
+    } else {
       // A scene is cached and reactivated when you come back to a notebook, so this can be the same
-      // controller with edits that never reached the server. Recording them as written here would lose
-      // them, so try the save again instead of waiting for a change that may never come.
+      // controller with edits that never reached the server. Waiting for a change that may never come
+      // would lose them, and scheduling costs nothing when there is nothing to write.
       this.schedule();
     }
 
-    this.changeSub = this.scene.subscribeToEvent(SceneObjectStateChangedEvent, () => {
+    this.changeSub = this.scene.subscribeToEvent(SceneObjectStateChangedEvent, ({ payload }) => {
       if (!this.scene.state.isEditing) {
         return;
+      }
+
+      if (changesTimeSettings(payload, this.scene)) {
+        this.timeSettingsEdited = true;
       }
 
       this.schedule();
@@ -88,7 +97,20 @@ export class NotebookAutosave extends StateManagerBase<NotebookAutosaveState> {
    * `isEditing` and the change signal above ignores them. A write command that skips this does not save.
    */
   public notifyDocumentChanged(): void {
+    // These writers hand over a whole document, time settings included, so what is in the scene now is
+    // the notebook's own.
+    this.timeSettingsEdited = true;
     this.schedule();
+  }
+
+  /**
+   * Marks the start of an editing session.
+   *
+   * A time range left behind by reading the notebook belongs to whoever was reading it, so a session
+   * starts by disowning the one that is there and counts only the changes made from here on.
+   */
+  public notifyEditingStarted(): void {
+    this.timeSettingsEdited = false;
   }
 
   /** Tries a failed save again. A failure waits for the next change, which may never come. */
@@ -118,6 +140,10 @@ export class NotebookAutosave extends StateManagerBase<NotebookAutosaveState> {
   private scheduleSave = debounce(() => this.saveNow(), IDLE_BEFORE_SAVE_MS, { maxWait: MAX_WAIT_MS });
 
   private schedule(): void {
+    if (!this.hasSomethingToWrite()) {
+      return;
+    }
+
     this.changePending = true;
 
     // Guarded so a keystroke does not publish state on every character.
@@ -126,6 +152,54 @@ export class NotebookAutosave extends StateManagerBase<NotebookAutosaveState> {
     }
 
     this.scheduleSave();
+  }
+
+  /**
+   * Most state changes leave the saved notebook exactly as it is: opening a modal, a query finishing, a
+   * reader moving their own time range. Scheduling those would have the notebook report unsaved changes
+   * it does not have.
+   */
+  private hasSomethingToWrite(): boolean {
+    // Already known to differ, so a keystroke does not pay for a comparison.
+    if (this.state.status === 'pending') {
+      return true;
+    }
+
+    // A save in flight leaves the baseline on the older spec, so an edit back to what the server is
+    // about to hold would look like nothing to write when it is the next thing to write.
+    if (this.inFlight) {
+      return true;
+    }
+
+    // Serializing walks the whole scene, and a scene that cannot be serialized is a bug somewhere else.
+    // Throwing here would report it in whatever changed the scene, which has nowhere to say so, and the
+    // notebook would look fine while nothing saved. Assume there is work and let the save report it.
+    try {
+      return JSON.stringify(this.buildSpecToSave()) !== this.baseline;
+    } catch {
+      return true;
+    }
+  }
+
+  /**
+   * The spec a save would send: the scene as it is, except for time settings nobody has edited, which
+   * stay as they were saved.
+   */
+  private buildSpecToSave(): NotebookSpec {
+    const spec = transformNotebookSceneToSaveModel(this.scene);
+
+    if (this.timeSettingsEdited || !this.savedTimeSettings) {
+      return spec;
+    }
+
+    return { ...spec, timeSettings: this.savedTimeSettings };
+  }
+
+  /** Records a spec as one there is no longer any reason to write. */
+  private recordWritten(spec: NotebookSpec, serialized = JSON.stringify(spec)): void {
+    this.baseline = serialized;
+    this.savedTimeSettings = spec.timeSettings;
+    this.timeSettingsEdited = false;
   }
 
   /** What to report when there is nothing waiting to be written. */
@@ -147,9 +221,9 @@ export class NotebookAutosave extends StateManagerBase<NotebookAutosaveState> {
 
     this.changePending = false;
 
-    const spec = transformNotebookSceneToSaveModel(this.scene);
+    const spec = this.buildSpecToSave();
     const serialized = JSON.stringify(spec);
-    if (serialized === this.lastSaved) {
+    if (serialized === this.baseline) {
       // Lots of things change the scene without changing what gets saved. Left on `pending`, the
       // notebook would go on saying it has unsaved changes when it has none.
       this.setState({ status: this.restingStatus() });
@@ -161,7 +235,7 @@ export class NotebookAutosave extends StateManagerBase<NotebookAutosaveState> {
 
     updateNotebook(uid, spec)
       .then(({ generation }) => {
-        this.lastSaved = serialized;
+        this.recordWritten(spec, serialized);
         this.hasSavedOnce = true;
         this.setState({
           // Something can have changed while this was in flight, and reporting it saved would claim
@@ -174,7 +248,7 @@ export class NotebookAutosave extends StateManagerBase<NotebookAutosaveState> {
         });
       })
       .catch((error) => {
-        // Leave `lastSaved` alone, so the next comparison still sees a difference and tries again.
+        // Leave the baseline alone, so the next comparison still sees a difference and tries again.
         this.setState({
           status: 'error',
           errorMessage: error instanceof Error ? error.message : String(error),
@@ -188,4 +262,21 @@ export class NotebookAutosave extends StateManagerBase<NotebookAutosaveState> {
         }
       });
   }
+}
+
+/**
+ * Whether a state change was a change to the notebook's time settings.
+ *
+ * `buildTimeSettingsSpec` reads them from these four places, so all four have to be named here: one left
+ * out is one whose edits get thrown away as if a reader had made them.
+ */
+function changesTimeSettings(payload: SceneObjectStateChangedPayload, scene: NotebookScene): boolean {
+  const { changedObject, partialUpdate } = payload;
+  const { $timeRange, timePicker, refreshPicker } = scene.state;
+
+  if (changedObject === scene) {
+    return 'hideTimeControls' in partialUpdate;
+  }
+
+  return changedObject === $timeRange || changedObject === timePicker || changedObject === refreshPicker;
 }

--- a/public/app/features/notebook/scene/NotebookSaveStatus.test.tsx
+++ b/public/app/features/notebook/scene/NotebookSaveStatus.test.tsx
@@ -41,7 +41,6 @@ describe('NotebookSaveStatus', () => {
 
   it.each([
     ['pending', 'Unsaved changes'],
-    ['saving', 'Saving…'],
     ['saved', 'Saved'],
     ['error', 'Save failed'],
   ] as const)('renders %s as "%s"', (status, label) => {
@@ -51,6 +50,31 @@ describe('NotebookSaveStatus', () => {
     render(<NotebookSaveStatus autosave={autosave} />);
 
     expect(screen.getByText(label)).toBeInTheDocument();
+  });
+
+  describe('while a save is in flight', () => {
+    beforeEach(() => jest.useFakeTimers());
+    afterEach(() => jest.useRealTimers());
+
+    it('goes on reporting unsaved changes while the save is too quick to be worth a word', () => {
+      const autosave = buildAutosave();
+      autosave.setState({ status: 'saving' });
+
+      render(<NotebookSaveStatus autosave={autosave} />);
+
+      expect(screen.getByText('Unsaved changes')).toBeInTheDocument();
+      expect(screen.queryByText('Saving…')).not.toBeInTheDocument();
+    });
+
+    it('says it is saving once the save has taken long enough to notice', () => {
+      const autosave = buildAutosave();
+      autosave.setState({ status: 'saving' });
+
+      render(<NotebookSaveStatus autosave={autosave} />);
+      act(() => jest.advanceTimersByTime(150));
+
+      expect(screen.getByText('Saving…')).toBeInTheDocument();
+    });
   });
 
   describe('once the save has landed', () => {

--- a/public/app/features/notebook/scene/NotebookSaveStatus.test.tsx
+++ b/public/app/features/notebook/scene/NotebookSaveStatus.test.tsx
@@ -1,0 +1,103 @@
+import { act, render, screen, userEvent } from 'test/test-utils';
+
+import { SceneRefreshPicker, SceneTimePicker, SceneTimeRange } from '@grafana/scenes';
+
+import { NotebookSaveStatus } from './NotebookSaveStatus';
+import { NotebookScene } from './NotebookScene';
+import { NotebookCellItem } from './layout-notebook/NotebookCellItem';
+import { NotebookLayoutManager } from './layout-notebook/NotebookLayoutManager';
+
+// A real scene and its real controller, never activated: these tests are about what the controller's
+// state looks like on screen, so the state is set directly rather than driven through a save.
+function buildAutosave() {
+  const scene = new NotebookScene({
+    uid: 'nb-1',
+    title: 'My notebook',
+    body: new NotebookLayoutManager({
+      cells: [
+        new NotebookCellItem({
+          elementName: 'md1',
+          source: 'user',
+          content: { kind: 'Markdown', spec: { text: 'Hello' } },
+        }),
+      ],
+    }),
+    $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
+    timePicker: new SceneTimePicker({}),
+    refreshPicker: new SceneRefreshPicker({ refresh: '', intervals: ['10s'] }),
+  });
+
+  return scene.autosave;
+}
+
+describe('NotebookSaveStatus', () => {
+  it('says nothing about a notebook nobody has changed', () => {
+    const autosave = buildAutosave();
+
+    const { container } = render(<NotebookSaveStatus autosave={autosave} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it.each([
+    ['pending', 'Unsaved changes'],
+    ['saving', 'Saving…'],
+    ['saved', 'Saved'],
+    ['error', 'Save failed'],
+  ] as const)('renders %s as "%s"', (status, label) => {
+    const autosave = buildAutosave();
+    autosave.setState({ status });
+
+    render(<NotebookSaveStatus autosave={autosave} />);
+
+    expect(screen.getByText(label)).toBeInTheDocument();
+  });
+
+  describe('once the save has landed', () => {
+    beforeEach(() => jest.useFakeTimers());
+    afterEach(() => jest.useRealTimers());
+
+    it('stops saying Saved after a couple of seconds', () => {
+      const autosave = buildAutosave();
+      autosave.setState({ status: 'saved' });
+
+      render(<NotebookSaveStatus autosave={autosave} />);
+      expect(screen.getByText('Saved')).toBeInTheDocument();
+
+      act(() => jest.advanceTimersByTime(2000));
+
+      expect(screen.queryByText('Saved')).not.toBeInTheDocument();
+    });
+
+    it('keeps a failure on screen, since it is still true', () => {
+      const autosave = buildAutosave();
+      autosave.setState({ status: 'error' });
+
+      render(<NotebookSaveStatus autosave={autosave} />);
+
+      act(() => jest.advanceTimersByTime(2000));
+
+      expect(screen.getByText('Save failed')).toBeInTheDocument();
+    });
+  });
+
+  it('offers a retry on failure, and asks the controller to try again', async () => {
+    const autosave = buildAutosave();
+    const retry = jest.spyOn(autosave, 'retry').mockImplementation(() => {});
+    autosave.setState({ status: 'error' });
+
+    render(<NotebookSaveStatus autosave={autosave} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+
+  it('offers no retry when there is nothing to retry', () => {
+    const autosave = buildAutosave();
+    autosave.setState({ status: 'saving' });
+
+    render(<NotebookSaveStatus autosave={autosave} />);
+
+    expect(screen.queryByRole('button', { name: 'Retry' })).not.toBeInTheDocument();
+  });
+});

--- a/public/app/features/notebook/scene/NotebookSaveStatus.tsx
+++ b/public/app/features/notebook/scene/NotebookSaveStatus.tsx
@@ -9,6 +9,12 @@ import { type NotebookAutosave, type NotebookSaveStatus as SaveStatus } from './
 const SAVED_VISIBLE_MS = 2000;
 
 /**
+ * Most saves land sooner than this. A word that appears and disappears in under a sixth of a second is a
+ * flicker rather than something anyone can read, so only a save slow enough to notice says it is saving.
+ */
+const SAVING_SHOWN_AFTER_MS = 150;
+
+/**
  * What the notebook's autosave is doing, in words. There is no save button, so nothing else tells a user
  * whether their work is safe, including when the assistant is the one writing.
  *
@@ -18,6 +24,7 @@ const SAVED_VISIBLE_MS = 2000;
 export function NotebookSaveStatus({ autosave }: { autosave: NotebookAutosave }) {
   const { status, errorMessage } = autosave.useState();
   const [savedExpired, setSavedExpired] = useState(false);
+  const [savingShown, setSavingShown] = useState(false);
 
   useEffect(() => {
     setSavedExpired(false);
@@ -30,7 +37,21 @@ export function NotebookSaveStatus({ autosave }: { autosave: NotebookAutosave })
     return () => clearTimeout(timeout);
   }, [status]);
 
-  if (status === 'idle' || (status === 'saved' && savedExpired)) {
+  useEffect(() => {
+    setSavingShown(false);
+
+    if (status !== 'saving') {
+      return;
+    }
+
+    const timeout = setTimeout(() => setSavingShown(true), SAVING_SHOWN_AFTER_MS);
+    return () => clearTimeout(timeout);
+  }, [status]);
+
+  // A save always starts from unsaved changes, so a save too quick to announce keeps saying that instead.
+  const shown = status === 'saving' && !savingShown ? 'pending' : status;
+
+  if (shown === 'idle' || (shown === 'saved' && savedExpired)) {
     return null;
   }
 
@@ -43,21 +64,21 @@ export function NotebookSaveStatus({ autosave }: { autosave: NotebookAutosave })
 
   const label = (
     <Text variant="bodySmall" color="secondary">
-      {labels[status]}
+      {labels[shown]}
     </Text>
   );
 
   return (
     <Stack gap={0.5} alignItems="center">
       {/* The message is the only thing saying WHY it failed, and too long to sit in the row. */}
-      {status === 'error' && errorMessage ? (
+      {shown === 'error' && errorMessage ? (
         <Tooltip content={errorMessage}>
           <span>{label}</span>
         </Tooltip>
       ) : (
         label
       )}
-      {status === 'error' ? (
+      {shown === 'error' ? (
         <Button variant="secondary" fill="text" size="sm" onClick={() => autosave.retry()}>
           {t('notebooks.save-status.retry', 'Retry')}
         </Button>

--- a/public/app/features/notebook/scene/NotebookSaveStatus.tsx
+++ b/public/app/features/notebook/scene/NotebookSaveStatus.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react';
+
+import { t } from '@grafana/i18n';
+import { Button, Stack, Text, Tooltip } from '@grafana/ui';
+
+import { type NotebookAutosave, type NotebookSaveStatus as SaveStatus } from './NotebookAutosave';
+
+/** The same two seconds `AutoSaveField` waits, so a saved notebook reads like the rest of Grafana. */
+const SAVED_VISIBLE_MS = 2000;
+
+/**
+ * What the notebook's autosave is doing, in words. There is no save button, so nothing else tells a user
+ * whether their work is safe, including when the assistant is the one writing.
+ *
+ * Nothing is shown while `idle`. Saying "Saved" about a notebook nobody has touched claims something we
+ * did not do, and a label that is always there stops being information.
+ */
+export function NotebookSaveStatus({ autosave }: { autosave: NotebookAutosave }) {
+  const { status, errorMessage } = autosave.useState();
+  const [savedExpired, setSavedExpired] = useState(false);
+
+  useEffect(() => {
+    setSavedExpired(false);
+
+    if (status !== 'saved') {
+      return;
+    }
+
+    const timeout = setTimeout(() => setSavedExpired(true), SAVED_VISIBLE_MS);
+    return () => clearTimeout(timeout);
+  }, [status]);
+
+  if (status === 'idle' || (status === 'saved' && savedExpired)) {
+    return null;
+  }
+
+  const labels: Record<Exclude<SaveStatus, 'idle'>, string> = {
+    pending: t('notebooks.save-status.pending', 'Unsaved changes'),
+    saving: t('notebooks.save-status.saving', 'Saving…'),
+    saved: t('notebooks.save-status.saved', 'Saved'),
+    error: t('notebooks.save-status.failed', 'Save failed'),
+  };
+
+  const label = (
+    <Text variant="bodySmall" color="secondary">
+      {labels[status]}
+    </Text>
+  );
+
+  return (
+    <Stack gap={0.5} alignItems="center">
+      {/* The message is the only thing saying WHY it failed, and too long to sit in the row. */}
+      {status === 'error' && errorMessage ? (
+        <Tooltip content={errorMessage}>
+          <span>{label}</span>
+        </Tooltip>
+      ) : (
+        label
+      )}
+      {status === 'error' ? (
+        <Button variant="secondary" fill="text" size="sm" onClick={() => autosave.retry()}>
+          {t('notebooks.save-status.retry', 'Retry')}
+        </Button>
+      ) : null}
+    </Stack>
+  );
+}

--- a/public/app/features/notebook/scene/NotebookScene.test.tsx
+++ b/public/app/features/notebook/scene/NotebookScene.test.tsx
@@ -190,6 +190,24 @@ describe('NotebookScene', () => {
       expect(screen.getByRole('button', { name: 'Undo' })).toBeInTheDocument();
     });
 
+    // The assistant writes without entering edit mode, so gating the status on `isEditing` would hide a
+    // failed save from the only person who could retry it.
+    it('reports a save outside edit mode, where the assistant writes', () => {
+      const scene = buildScene(false);
+      activate(scene);
+      render(<scene.Component model={scene} />);
+
+      expect(screen.queryByText('Save failed')).not.toBeInTheDocument();
+
+      act(() =>
+        scene.autosave.setState({ status: 'error', errorMessage: 'The notebook was changed by someone else.' })
+      );
+
+      expect(scene.state.isEditing).toBeUndefined();
+      expect(screen.getByText('Save failed')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+    });
+
     it('records history for a body replaced before activation', () => {
       const scene = buildScene(false);
       const replacement = new NotebookLayoutManager({ cells: [] });

--- a/public/app/features/notebook/scene/NotebookScene.tsx
+++ b/public/app/features/notebook/scene/NotebookScene.tsx
@@ -157,6 +157,9 @@ export class NotebookScene extends SceneObjectBase<NotebookSceneState> implement
       return;
     }
 
+    // Before the state change, because entering edit mode is itself a state change and autosave decides
+    // what to write the moment it sees one.
+    this.autosave.notifyEditingStarted();
     this.setState({ isEditing: true });
     // Same channel DashboardScene uses to tell its layout the mode changed.
     this.state.body.editModeChanged?.(true);

--- a/public/app/features/notebook/scene/NotebookScene.tsx
+++ b/public/app/features/notebook/scene/NotebookScene.tsx
@@ -24,9 +24,11 @@ import { getClosestVizPanel, getPanelIdForVizPanel } from 'app/features/dashboar
 
 import { canEditNotebooks } from '../permissions';
 
+import { NotebookAutosave } from './NotebookAutosave';
 import { NotebookEditHistory } from './NotebookEditHistory';
 import { NotebookEditHistoryControls } from './NotebookEditHistoryControls';
 import { NotebookEditToggle } from './NotebookEditToggle';
+import { NotebookSaveStatus } from './NotebookSaveStatus';
 import { NotebookSceneUrlSync } from './NotebookSceneUrlSync';
 import { type NotebookLayoutManager } from './layout-notebook/NotebookLayoutManager';
 
@@ -56,6 +58,7 @@ export class NotebookScene extends SceneObjectBase<NotebookSceneState> implement
   // The layout manager needs to find the scene it lives in. It cannot use instanceof, because
   // importing this class would make the two files import each other, so it looks for this field.
   public readonly isNotebookScene = true;
+  public readonly autosave = new NotebookAutosave(this);
 
   // Edit mode is reflected in the url by this handler rather than by the methods below, so the url
   // stays a projection of the state instead of a second copy of it.
@@ -118,8 +121,10 @@ export class NotebookScene extends SceneObjectBase<NotebookSceneState> implement
       });
 
       const destroyMutationClient = createMutationClient(this, 'notebook');
+      const stopAutosave = this.autosave.start();
 
       return () => {
+        stopAutosave();
         destroyMutationClient();
         stateSub.unsubscribe();
         refreshPickerDeactivation?.();
@@ -161,6 +166,9 @@ export class NotebookScene extends SceneObjectBase<NotebookSceneState> implement
     this.state.body.commitContentEdits();
     this.setState({ isEditing: false });
     this.state.body.editModeChanged?.(false);
+    // Leaving edit mode is a natural save point, and it is where changes stop counting. Without this, a
+    // save still waiting on the debounce would sit there until the page unmounts.
+    this.autosave.flush();
   };
 
   public showModal(modal: SceneObject) {
@@ -203,6 +211,7 @@ function NotebookSceneRenderer({ model }: SceneComponentProps<NotebookScene>) {
     <div className={styles.container}>
       <NotebookHiddenVariables model={model} />
       <div className={styles.controls}>
+        {isEditing && <NotebookSaveStatus autosave={model.autosave} />}
         {isEditing && <NotebookEditHistoryControls history={model.editHistory} />}
         <NotebookEditToggle notebook={model} />
         {!hideTimeControls && (

--- a/public/app/features/notebook/scene/NotebookScene.tsx
+++ b/public/app/features/notebook/scene/NotebookScene.tsx
@@ -214,7 +214,9 @@ function NotebookSceneRenderer({ model }: SceneComponentProps<NotebookScene>) {
     <div className={styles.container}>
       <NotebookHiddenVariables model={model} />
       <div className={styles.controls}>
-        {isEditing && <NotebookSaveStatus autosave={model.autosave} />}
+        {/* Not gated on edit mode: the assistant writes without entering it, and a failed save has to
+            be visible and retryable there too. This renders nothing until there is something to say. */}
+        <NotebookSaveStatus autosave={model.autosave} />
         {isEditing && <NotebookEditHistoryControls history={model.editHistory} />}
         <NotebookEditToggle notebook={model} />
         {!hideTimeControls && (

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12921,6 +12921,13 @@
       },
       "unknown-author": "Anonymous"
     },
+    "save-status": {
+      "failed": "Save failed",
+      "pending": "Unsaved changes",
+      "retry": "Retry",
+      "saved": "Saved",
+      "saving": "Saving…"
+    },
     "view": {
       "copy-link": "Copy link",
       "mode-edit": "Edit",


### PR DESCRIPTION
Built on #130816, so it cannot merge until that lands.

**What is this feature?**

Notebooks save themselves as you edit, with no save button. This covers notebooks that already exist. support autosave on new notebook after first change is made will be tackle on a different PR

https://github.com/user-attachments/assets/f48f952d-ea79-41d0-bfa1-2d2699806dde

**Technical Details**

- New `NotebookAutosave` controller and a save-status label in the controls row
- `updateNotebook` writes a JSON patch replacing all of `/spec`
- `APPLY_NOTEBOOK_SPEC` now tells autosave when it writes
- The page's scene cache tracks the generation a save produced

**Saving only happens while you are editing.** A notebook's own time range is stored in the same spec we write out. The time picker is visible to readers too, so if any change triggered a save, someone just reading a notebook and flicking to yesterday would overwrite its saved default. The assistant never enters edit mode, so it calls autosave directly instead. Without that its edits were dropped entirely, which is the easiest thing here to miss.

**Why the cached-scene check is `>=` and not `==`.** The API server bumps a `generation` counter on every write, and the notebook page keeps a built scene cached against that number so it can skip rebuilding when nothing changed. After our own save the counter has moved on, but the query layer can still answer the next load from its own cache, carrying the old number. Comparing for equality sees a mismatch there, rebuilds the scene from that stale response, and throws away the edit we just saved. So we keep the cached scene whenever what we hold is at least as new.

**Still open, and I would like your input.** Nobody has looked at the save label from a design angle, and the 2s and 15s numbers are mine. The 15s cap is the one that matters, it holds `resource_history` to roughly 4 writes a minute per editor. 

Out of scope and tracked separately: conflict handling for two editors, notebook version history, per-resource authz (#130290), and create-on-first-edit.

**Which issue(s) does this PR fix?**:

Related grafana/grafana-enterprise#13003

**Special notes for your reviewer:**

**Undo after an assistant edit is still broken, but is not related to the scope of this PR.** I tried my PR with the branch that adds notebooks tools to assistant https://github.com/grafana/grafana-assistant-app/pull/9040 , and found an issue: When the assistant applies a spec it rebuilds the notebook, and the scene throws away undo history whenever that happens. Autosave sharpens it: the change is on the server about two seconds later, so there is no longer the possibility to say "assistant please adjust x panel and and just don't save". 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
