### PR TITLE
Dashboards: Remember View panel side pane closed state instead of auto-opening it on every panel view

### DIFF
--- a/docs/sources/visualizations/panels-visualizations/panel-overview/index.md
+++ b/docs/sources/visualizations/panels-visualizations/panel-overview/index.md
@@ -92,6 +92,9 @@ When you open a panel in full-screen view mode, Grafana displays a **View panel*
 These controls make it easier to view specific data or identify patterns and correlations.
 Because these controls exist in view mode, you don't need edit permissions to use them, and the changes you make don't affect the saved dashboard.
 
+If you close the sidebar, Grafana remembers your choice and doesn't open it automatically the next time you view a panel.
+To open it again, click the **View panel controls** button in the sidebar toolbar, which also restores the automatic opening.
+
 The sidebar includes the following controls:
 
 - **Quick toggles**: Adjust common visualization options, such as legend visibility and basic graph styles.

--- a/e2e-playwright/dashboards-suite/dashboard-view-panel.spec.ts
+++ b/e2e-playwright/dashboards-suite/dashboard-view-panel.spec.ts
@@ -26,6 +26,38 @@ test.describe('View panel', { tag: ['@dashboards'] }, () => {
     await expect(dashboardPage.getByGrafanaSelector(selectors.components.Sidebar.headerTitle)).not.toBeVisible();
   });
 
+  test('Remembers when the pane was closed and does not auto-open it again', async ({
+    gotoDashboardPage,
+    selectors,
+  }) => {
+    let dashboardPage = await openTestDashboardAndEnterViewPanel(gotoDashboardPage, selectors);
+
+    await expect(dashboardPage.getByGrafanaSelector(selectors.components.Sidebar.headerTitle)).toContainText(
+      'View panel'
+    );
+
+    // Close the pane, then re-enter view mode: the pane should stay closed
+    await dashboardPage.getByGrafanaSelector(selectors.components.Sidebar.closePane).click();
+    await expect(dashboardPage.getByGrafanaSelector(selectors.components.Sidebar.headerTitle)).not.toBeVisible();
+
+    dashboardPage = await openTestDashboardAndEnterViewPanel(gotoDashboardPage, selectors);
+
+    await expect(dashboardPage.getByGrafanaSelector(selectors.pages.Dashboard.Sidebar.viewPanelControls)).toBeVisible();
+    await expect(dashboardPage.getByGrafanaSelector(selectors.components.Sidebar.headerTitle)).not.toBeVisible();
+
+    // Reopen the pane via the sidebar button: auto-open is restored
+    await dashboardPage.getByGrafanaSelector(selectors.pages.Dashboard.Sidebar.viewPanelControls).click();
+    await expect(dashboardPage.getByGrafanaSelector(selectors.components.Sidebar.headerTitle)).toContainText(
+      'View panel'
+    );
+
+    dashboardPage = await openTestDashboardAndEnterViewPanel(gotoDashboardPage, selectors);
+
+    await expect(dashboardPage.getByGrafanaSelector(selectors.components.Sidebar.headerTitle)).toContainText(
+      'View panel'
+    );
+  });
+
   test('Can toggle panel viz option', async ({ gotoDashboardPage, selectors, page }) => {
     const dashboardPage = await openTestDashboardAndEnterViewPanel(gotoDashboardPage, selectors);
 

--- a/public/app/features/dashboard-scene/solo/ViewPanelWrapper.test.tsx
+++ b/public/app/features/dashboard-scene/solo/ViewPanelWrapper.test.tsx
@@ -1,0 +1,126 @@
+import { act } from '@testing-library/react';
+import { type MemoryHistoryBuildOptions } from 'history';
+import { render } from 'test/test-utils';
+
+import { LoadingState, getDefaultTimeRange, store } from '@grafana/data';
+import { getPanelPlugin } from '@grafana/data/test';
+import { setPluginImportUtils } from '@grafana/runtime';
+import { SceneDataNode, SceneGridLayout, SceneTimeRange, VizPanel } from '@grafana/scenes';
+
+import { DashboardScene } from '../scene/DashboardScene';
+import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
+import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLayoutManager';
+import { ToggleViewPanePaneEvent } from '../sidebar/events';
+import { activateFullSceneTree } from '../utils/test-utils';
+
+import { VIEW_PANEL_PANE_CLOSED_KEY, ViewPanelWrapper } from './ViewPanelWrapper';
+
+setPluginImportUtils({
+  importPanelPlugin: (id: string) => Promise.resolve(getPanelPlugin({})),
+  getPanelPluginFromCache: (id: string) => undefined,
+});
+
+jest.mock('app/core/hooks/useMediaQueryMinWidth', () => ({
+  useMediaQueryMinWidth: () => true,
+}));
+
+jest.mock('@grafana/runtime/internal', () => ({
+  ...jest.requireActual('@grafana/runtime/internal'),
+  useFlagGrafanaViewPanelPane: jest.fn().mockReturnValue(true),
+}));
+
+function buildTestScene() {
+  const panel = new VizPanel({
+    key: 'panel-1',
+    pluginId: 'text',
+    $data: new SceneDataNode({
+      data: { state: LoadingState.Done, series: [], timeRange: getDefaultTimeRange() },
+    }),
+  });
+
+  const dashboard = new DashboardScene({
+    $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
+    viewPanel: 'panel-1',
+    body: new DefaultGridLayoutManager({
+      grid: new SceneGridLayout({
+        children: [new DashboardGridItem({ body: panel })],
+      }),
+    }),
+  });
+
+  return { dashboard, panel };
+}
+
+async function setup(historyOptions?: MemoryHistoryBuildOptions) {
+  const { dashboard, panel } = buildTestScene();
+  const deactivate = activateFullSceneTree(dashboard);
+
+  const renderResult = render(<ViewPanelWrapper panel={panel} showControlsPane={true} />, { historyOptions });
+
+  // Let the async panel plugin load settle
+  await act(async () => {});
+
+  return { dashboard, sidebar: dashboard.state.sidebar, panel, deactivate, renderResult };
+}
+
+describe('ViewPanelWrapper', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('opens the pane on mount by default', async () => {
+    const { sidebar } = await setup();
+
+    expect(sidebar.state.openPane?.getId()).toBe('view-panel-pane');
+  });
+
+  it('does not open the pane when the user closed it before', async () => {
+    store.set(VIEW_PANEL_PANE_CLOSED_KEY, true);
+
+    const { sidebar } = await setup();
+
+    expect(sidebar.state.openPane).toBeUndefined();
+  });
+
+  it('opens the pane despite a remembered close when url has a fanout param', async () => {
+    store.set(VIEW_PANEL_PANE_CLOSED_KEY, true);
+
+    const { sidebar } = await setup({ initialEntries: ['/?fanout=$__by_series__$'] });
+
+    expect(sidebar.state.openPane?.getId()).toBe('view-panel-pane');
+  });
+
+  it('remembers when the user closes the pane in view mode', async () => {
+    const { sidebar } = await setup();
+
+    act(() => sidebar.closePane());
+
+    expect(store.getBool(VIEW_PANEL_PANE_CLOSED_KEY, false)).toBe(true);
+  });
+
+  it('clears the remembered close when the pane is reopened', async () => {
+    store.set(VIEW_PANEL_PANE_CLOSED_KEY, true);
+
+    const { sidebar } = await setup();
+
+    act(() => sidebar.publishEvent(new ToggleViewPanePaneEvent()));
+
+    expect(sidebar.state.openPane?.getId()).toBe('view-panel-pane');
+    expect(store.getBool(VIEW_PANEL_PANE_CLOSED_KEY, false)).toBe(false);
+  });
+
+  it('does not remember the programmatic close that happens when leaving view mode', async () => {
+    const { dashboard, sidebar } = await setup();
+
+    act(() => {
+      dashboard.setState({ viewPanel: undefined });
+      sidebar.closePane();
+    });
+
+    expect(store.getBool(VIEW_PANEL_PANE_CLOSED_KEY, false)).toBe(false);
+  });
+});

--- a/public/app/features/dashboard-scene/solo/ViewPanelWrapper.tsx
+++ b/public/app/features/dashboard-scene/solo/ViewPanelWrapper.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 
+import { store } from '@grafana/data';
+import { locationService } from '@grafana/runtime';
 import { useFlagGrafanaViewPanelPane } from '@grafana/runtime/internal';
 import { type SceneDataProvider, type VizPanel, useSceneObjectState } from '@grafana/scenes';
 import { SceneContext, SceneContextObject } from '@grafana/scenes-react';
@@ -10,6 +12,8 @@ import { ToggleViewPanePaneEvent } from '../sidebar/events';
 
 import { FanoutPanel } from './FanoutPanel';
 import { ViewPanelSidePane } from './ViewPanelSidePane';
+
+export const VIEW_PANEL_PANE_CLOSED_KEY = 'grafana.dashboard.sidebar.viewPanelPane.closed';
 
 export function ViewPanelWrapper({ panel, showControlsPane }: { panel: VizPanel; showControlsPane?: boolean }) {
   const viewPanelPane = useFlagGrafanaViewPanelPane();
@@ -31,12 +35,33 @@ function ViewPanelWithPane({ panel, dataProvider }: { panel: VizPanel; dataProvi
   const viewPanelPane = useMemo(() => new ViewPanelSidePane({ panelRef: panel.getRef() }), [panel]);
   const { fanoutMode } = useSceneObjectState(viewPanelPane, { shouldActivateOrKeepAlive: true });
 
-  // Open pane on mount
+  // Open pane on mount, unless the user closed it the last time it was open. A fanout url param
+  // always opens the pane as the pane's url sync is only registered while it is open.
   useEffect(() => {
-    if (!isSmallScreen) {
+    const hasFanoutInUrl = Boolean(locationService.getSearchObject().fanout);
+
+    if (!isSmallScreen && (hasFanoutInUrl || !store.getBool(VIEW_PANEL_PANE_CLOSED_KEY, false))) {
       sidebar.openPane(viewPanelPane);
     }
   }, [sidebar, isSmallScreen, viewPanelPane]);
+
+  // Remember open / closed so the user's last choice is the default for the next panel view.
+  // Closes that happen when leaving view mode are programmatic (viewPanel is cleared first) and must not count.
+  useEffect(() => {
+    const sub = sidebar.subscribeToState((newState, prevState) => {
+      if (newState.openPane === prevState.openPane) {
+        return;
+      }
+
+      if (newState.openPane === viewPanelPane) {
+        store.set(VIEW_PANEL_PANE_CLOSED_KEY, false);
+      } else if (prevState.openPane === viewPanelPane && dashboard.state.viewPanel) {
+        store.set(VIEW_PANEL_PANE_CLOSED_KEY, true);
+      }
+    });
+
+    return () => sub.unsubscribe();
+  }, [sidebar, viewPanelPane, dashboard]);
 
   // Handle manual toggling of the pane via the sidebar buttons
   // This is done via an event that sidebar pane button publishes as the ViewPanelSidePane instance & panel ref is only available from this component


### PR DESCRIPTION
**What is this feature?**

The View panel side pane (`grafana.viewPanelPane`) currently opens every time a panel is opened in view mode. Closing it does not stick, the next panel view opens it right back up. This PR remembers the user's last choice in local storage (like the sidebar's docked and size state already are) and uses it as the default:

- Closing the pane (close button, sidebar toggle button, or click away in undocked mode) keeps it closed for later panel views.
- Reopening it via the **View panel controls** sidebar button restores the automatic opening.
- Programmatic closes when leaving view mode do not count, only closes made while the panel is still in view mode.
- A `fanout` url param still always opens the pane, since the pane's url sync is only registered while it is open.

**Why do we need this feature?**

The pane force-opens on every panel view with no way to keep it closed short of disabling the feature toggle entirely. On narrower viewports the undocked pane overlays the visualization the user opened view mode to read.

**Who is this feature for?**

Anyone who opens panels in view mode to read dense graphs and does not want the side pane every time, while keeping quick toggles and fanout one click away on the sidebar.

**Which issue(s) does this PR fix?**:

Fixes #131011

**Special notes for your reviewer:**

- The remembered state is written on any sidebar `openPane` transition away from the view panel pane while `viewPanel` is still set. That includes the click away close in undocked mode. If you would rather only count explicit closes, that needs a close reason plumbed through `onClosePane`; happy to adjust.
- Unit tests cover the default open, the remembered close, reopening, the programmatic close exclusion, and the fanout url exception. An e2e test covers the full close, revisit, reopen cycle.
- The View panel sidebar section of the panel overview docs is updated to describe the new behavior.
