### PR TITLE
VisualRefresh: Update drag handle styles

### DIFF
--- a/packages/grafana-ui/src/components/DragHandle/DragHandle.tsx
+++ b/packages/grafana-ui/src/components/DragHandle/DragHandle.tsx
@@ -7,10 +7,10 @@ export type DragHandlePosition = 'middle' | 'start' | 'end';
 export const getDragStyles = (theme: GrafanaTheme2, handlePosition?: DragHandlePosition) => {
   const position = handlePosition || 'middle';
   const baseColor = theme.colors.emphasize(theme.colors.background.secondary, 0.15);
-  const hoverColor = theme.colors.accent.main;
-  const clickTargetSize = theme.spacing(2);
-  const handlebarThickness = 4;
-  const handlebarWidth = 200;
+  const hoverColor = theme.colors.accent.background;
+  const clickTargetSize = theme.spacing(1);
+  const handlebarThickness = 2;
+  const handlebarWidth = theme.spacing(4);
   let verticalOffset = '50%';
   let horizontalOffset = '50%';
 
@@ -53,23 +53,24 @@ export const getDragStyles = (theme: GrafanaTheme2, handlePosition?: DragHandleP
 
     '&:hover': {
       '&:before': {
-        borderColor: hoverColor,
+        background: hoverColor,
       },
 
       '&:after': {
-        background: hoverColor,
+        background: theme.colors.accent.main,
       },
     },
   });
 
   const beforeVertical = {
-    borderRight: '1px solid transparent',
+    width: theme.spacing(0.5),
     height: '100%',
     left: verticalOffset,
     transform: 'translateX(-50%)',
   };
 
   const beforeHorizontal = {
+    height: theme.spacing(0.5),
     borderTop: '1px solid transparent',
     top: horizontalOffset,
     transform: 'translateY(-50%)',
@@ -91,6 +92,13 @@ export const getDragStyles = (theme: GrafanaTheme2, handlePosition?: DragHandleP
           height: handlebarWidth,
           width: handlebarThickness,
         },
+
+        '&:hover': {
+          '&:after': {
+            background: theme.colors.accent.main,
+            width: handlebarThickness * 2,
+          },
+        },
       })
     ),
     dragHandleHorizontal: cx(
@@ -106,6 +114,13 @@ export const getDragStyles = (theme: GrafanaTheme2, handlePosition?: DragHandleP
           top: horizontalOffset,
           height: handlebarThickness,
           width: handlebarWidth,
+        },
+
+        '&:hover': {
+          '&:after': {
+            background: theme.colors.accent.main,
+            height: handlebarThickness * 2,
+          },
         },
       })
     ),

--- a/packages/grafana-ui/src/components/Drawer/Drawer.tsx
+++ b/packages/grafana-ui/src/components/Drawer/Drawer.tsx
@@ -8,7 +8,7 @@ import { type GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 
-import { useStyles2 } from '../../themes/ThemeContext';
+import { useStyles2, useTheme2 } from '../../themes/ThemeContext';
 import { Button } from '../Button/Button';
 import { getDragStyles } from '../DragHandle/DragHandle';
 import { Stack } from '../Layout/Stack/Stack';
@@ -187,15 +187,22 @@ function useResizebleDrawer(): [
   React.EventHandler<React.TouchEvent>,
 ] {
   const [drawerWidth, setDrawerWidth] = useState<string | undefined>(undefined);
+  const visualDesignRefresh = useTheme2().flags.visualDesignRefresh;
 
-  const onMouseMove = useCallback((e: MouseEvent) => {
-    setDrawerWidth(getCustomDrawerWidth(e.clientX));
-  }, []);
+  const onMouseMove = useCallback(
+    (e: MouseEvent) => {
+      setDrawerWidth(getCustomDrawerWidth(e.clientX, visualDesignRefresh));
+    },
+    [visualDesignRefresh]
+  );
 
-  const onTouchMove = useCallback((e: TouchEvent) => {
-    const touch = e.touches[0];
-    setDrawerWidth(getCustomDrawerWidth(touch.clientX));
-  }, []);
+  const onTouchMove = useCallback(
+    (e: TouchEvent) => {
+      const touch = e.touches[0];
+      setDrawerWidth(getCustomDrawerWidth(touch.clientX, visualDesignRefresh));
+    },
+    [visualDesignRefresh]
+  );
 
   const onMouseUp = useCallback(
     (e: MouseEvent) => {
@@ -232,8 +239,8 @@ function useResizebleDrawer(): [
   return [drawerWidth, onMouseDown, onTouchStart];
 }
 
-function getCustomDrawerWidth(clientX: number) {
-  let offsetRight = document.body.offsetWidth - (clientX - document.body.offsetLeft);
+function getCustomDrawerWidth(clientX: number, visualRefreshEnabled?: boolean): string {
+  let offsetRight = document.body.offsetWidth - (clientX - document.body.offsetLeft + (visualRefreshEnabled ? 8 : 0));
   let widthPercent = Math.min((offsetRight / document.body.clientWidth) * 100, 98).toFixed(2);
   return `${widthPercent}vw`;
 }
@@ -380,7 +387,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
     resizer: css({
       top: 0,
-      left: theme.spacing(-1),
+      left: theme.spacing(-0.5),
       bottom: 0,
       position: 'absolute',
       zIndex: theme.zIndex.modal,

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/VizAndDataPaneNext.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/VizAndDataPaneNext.tsx
@@ -3,7 +3,7 @@ import { useRef } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { type SceneComponentProps } from '@grafana/scenes';
-import { useStyles2 } from '@grafana/ui';
+import { getDragStyles, useStyles2 } from '@grafana/ui';
 
 import { PanelEditPanelWrapper } from '../PanelEditPanelWrapper';
 import { type PanelEditor } from '../PanelEditor';
@@ -20,6 +20,7 @@ export function VizAndDataPaneNext({ model }: SceneComponentProps<PanelEditor>) 
   const { showBanner, dismissBanner } = useQueryEditorBanner();
   const { scene, layout } = useVizAndDataPaneLayout(model, containerRef, showBanner);
   const styles = useStyles2(getStyles, layout.sidebarSize);
+  const dragStyles = useStyles2(getDragStyles);
 
   const nextDataPane = scene.dataPane instanceof PanelDataPaneNext ? scene.dataPane : null;
 
@@ -28,13 +29,11 @@ export function VizAndDataPaneNext({ model }: SceneComponentProps<PanelEditor>) 
       <div className={cx(styles.viz, { [styles.fixedSizeViz]: layout.isScrollingLayout })}>
         <PanelEditPanelWrapper panel={scene.panel} tableView={scene.tableView} dashboard={scene.dashboard} />
         {nextDataPane && (
-          <div className={styles.vizResizeHandle}>
-            <div
-              ref={layout.vizResizeHandle.ref}
-              className={layout.vizResizeHandle.className}
-              data-testid="viz-resizer"
-            />
-          </div>
+          <div
+            className={cx(styles.vizResizeHandle, dragStyles.dragHandleHorizontal)}
+            ref={layout.vizResizeHandle.ref}
+            data-testid="viz-resizer"
+          />
         )}
       </div>
       {nextDataPane && (
@@ -55,13 +54,11 @@ export function VizAndDataPaneNext({ model }: SceneComponentProps<PanelEditor>) 
             <div className={styles.sidebarContent}>
               <Sidebar sidebarSize={layout.sidebarSize} setSidebarSize={layout.setSidebarSize} />
             </div>
-            <div className={styles.sidebarResizeHandle}>
-              <div
-                ref={layout.sidebarResizeHandle.ref}
-                className={cx(layout.sidebarResizeHandle.className, styles.resizeHandlePill)}
-                data-testid="sidebar-resizer"
-              />
-            </div>
+            <div
+              ref={layout.sidebarResizeHandle.ref}
+              className={cx(dragStyles.dragHandleVertical, styles.sidebarResizeHandle)}
+              data-testid="sidebar-resizer"
+            />
           </div>
           <div className={styles.dataPane}>
             <nextDataPane.Component model={nextDataPane} />
@@ -123,6 +120,7 @@ function getStyles(theme: GrafanaTheme2, sidebarSize: SidebarSize) {
       bottom: 0,
       left: 0,
       right: 0,
+      top: theme.spacing(0.5),
     }),
     sidebarResizeHandle: css({
       position: 'absolute',
@@ -133,15 +131,6 @@ function getStyles(theme: GrafanaTheme2, sidebarSize: SidebarSize) {
       // which renders at the inner right edge of the sidebar box.
       right: `-${theme.spacing(2)}`,
       width: theme.spacing(2),
-    }),
-    resizeHandlePill: css({
-      height: '100%',
-      // Pill (::after) is 200px by default. Shrink to half when sidebar is tight.
-      '@container (max-height: 250px)': {
-        '&::after': {
-          height: 100,
-        },
-      },
     }),
   };
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/hooks.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/hooks.ts
@@ -141,7 +141,7 @@ export function usePanelEditorShell(model: PanelEditor) {
 
   const splitter = useSnappingSplitter({
     direction: 'row',
-    dragPosition: 'end',
+    dragPosition: 'middle',
     initialSize: 330,
     usePixels: true,
     collapsed: isInitiallyCollapsed,

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditorRenderer.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditorRenderer.tsx
@@ -36,7 +36,7 @@ export function PanelEditorRenderer({ model }: SceneComponentProps<PanelEditor>)
   const { containerProps, primaryProps, secondaryProps, splitterProps, splitterState, onToggleCollapse } =
     useSnappingSplitter({
       direction: 'row',
-      dragPosition: 'end',
+      dragPosition: 'middle',
       initialSize: 330,
       usePixels: true,
       collapsed: isInitiallyCollapsed,
@@ -92,7 +92,7 @@ function VizAndDataPane({ model }: SceneComponentProps<PanelEditor>) {
   const { containerProps, primaryProps, secondaryProps, splitterProps, splitterState, onToggleCollapse } =
     useSnappingSplitter({
       direction: 'column',
-      dragPosition: 'start',
+      dragPosition: 'middle',
       initialSize: 0.5,
       collapseBelowPixels: 150,
       disabled: isScrollingLayout,


### PR DESCRIPTION

* Update design of resize handles (make them smaller, more subtle) 
* Align design with what is found in AI workspace (they use 1px width, which I think is a bit too small for the spacing in panel edit) 
* Fix janky drawer resize bug due to visual refresh 8px right side padding 

https://github.com/user-attachments/assets/c1266943-c25e-493b-826a-a7f758292435

