### PR TITLE
Unified storage: Enable preferences migration by default

### DIFF
--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -38,7 +38,7 @@ var MigratedUnifiedResources = map[string]bool{
 	ShortURLResource:         true,  // Only Mode5!
 	SnapshotResource:         false, // Requires kubernetesSnapshots to be enabled by default
 	StarsResource:            false,
-	PreferencesResource:      false,
+	PreferencesResource:      true, // Only Mode5!
 	DataSourceResources:      false,
 	QueryCacheConfigResource: false,
 }

--- a/pkg/storage/unified/migrations/migrator_test.go
+++ b/pkg/storage/unified/migrations/migrator_test.go
@@ -368,7 +368,7 @@ var migrationIDsToDefault = map[string]bool{
 	shorturlsID:            true,
 	datasourceID:           false,
 	starsID:                false,
-	preferencesID:          false,
+	preferencesID:          true,
 	snapshotsID:            false,
 }
 


### PR DESCRIPTION
**What is this feature?**

Enables the preferences unified storage migration by default. On-premises instances will migrate preferences and serve them from unified storage in mode 5.

**Why do we need this feature?**

Preferences should use unified storage by default on-premises, without relying on the cloud-specific `dualWritePreferencesMode5` configuration.

**Who is this feature for?**

Grafana operators and users of on-premises Grafana installations.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

This intentionally changes only the default migration map entry. Existing unified storage configuration tests cover mode 5 enforcement for resources enabled by default.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. (Not applicable.)
- [x] The docs are updated, and if this is a notable improvement, it's added to What's New. (No documentation change needed for this internal default.)

**Tested with:**

`go test ./pkg/setting -run 'TestCfg_setUnifiedStorageConfig|TestApplyMigrationEnforcements'`