### PR TITLE
Alerting: Show query errors on Alert activity instead of "no alerts"

### DIFF
--- a/public/app/features/alerting/unified/triage/Workbench.test.tsx
+++ b/public/app/features/alerting/unified/triage/Workbench.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from 'test/test-utils';
+
+import { type SceneQueryRunner } from '@grafana/scenes';
+
+import { Workbench } from './Workbench';
+import { type Domain } from './types';
+
+// The labels column runs scene queries of its own, which need a scene context that is irrelevant here.
+jest.mock('./scene/filters/LabelsColumn', () => ({ LabelsColumn: () => null }));
+
+const domain: Domain = [new Date(0), new Date(60_000)];
+
+function renderWorkbench(props: Partial<React.ComponentProps<typeof Workbench>> = {}) {
+  return render(<Workbench data={[]} domain={domain} queryRunner={{} as SceneQueryRunner} {...props} />);
+}
+
+describe('Workbench', () => {
+  it('says the data source query was denied instead of reporting that nothing is alerting', () => {
+    renderWorkbench({ error: { status: 403, message: 'Access denied to data source' } });
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent(/do not have permission to query it/i);
+    expect(alert).toHaveTextContent('Access denied to data source');
+    expect(screen.queryByText(/no firing or pending instances/i)).not.toBeInTheDocument();
+  });
+
+  it('reports any other query failure without claiming that nothing is alerting', () => {
+    renderWorkbench({ error: { status: 500, message: 'Query error: 500 Internal Server Error' } });
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent(/cannot tell which alerts are firing or pending/i);
+    expect(alert).toHaveTextContent('Query error: 500 Internal Server Error');
+    expect(screen.queryByText(/no firing or pending instances/i)).not.toBeInTheDocument();
+  });
+
+  it('keeps the empty state when the query succeeded and returned nothing', () => {
+    renderWorkbench();
+
+    expect(screen.getByText(/no firing or pending instances/i)).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});

--- a/public/app/features/alerting/unified/triage/Workbench.tsx
+++ b/public/app/features/alerting/unified/triage/Workbench.tsx
@@ -3,11 +3,12 @@ import { take } from 'lodash';
 import { useState } from 'react';
 import { useMeasure } from 'react-use';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { type DataQueryError, type GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { Trans } from '@grafana/i18n';
+import { Trans, t } from '@grafana/i18n';
 import { type SceneQueryRunner } from '@grafana/scenes';
 import {
+  Alert,
   Box,
   Button,
   EmptyState,
@@ -41,6 +42,7 @@ type WorkbenchProps = {
   isInitialLoading?: boolean;
   isRefreshing?: boolean;
   hasActiveFilters?: boolean;
+  error?: DataQueryError;
 };
 
 const initialSize = 2 / 3;
@@ -125,6 +127,36 @@ function WorkbenchEmptyState({ hasActiveFilters }: { hasActiveFilters: boolean }
   );
 }
 
+function WorkbenchQueryError({ error }: { error: DataQueryError }) {
+  // Not having the "query" permission on the data source holding alert state history is by far the
+  // most common way this query fails, and the message the API returns for it doesn't say how to fix it.
+  const isPermissionError = error.status === 403;
+
+  return (
+    <Box display="flex" grow={1} alignItems="center" justifyContent="center" minHeight="400px">
+      <Alert severity="error" title={t('alerting.triage.query-error-title', 'Unable to load alert instances')}>
+        <Stack direction="column" gap={1}>
+          {isPermissionError ? (
+            <Trans i18nKey="alerting.triage.query-error-forbidden">
+              This page reads alert state history from a Prometheus data source, and you do not have permission to query
+              it. Ask an administrator to grant you the query permission for that data source.
+            </Trans>
+          ) : (
+            <Trans i18nKey="alerting.triage.query-error-generic">
+              The query for alert instances failed, so we cannot tell which alerts are firing or pending.
+            </Trans>
+          )}
+          {error.message && (
+            <Text variant="bodySmall" color="secondary">
+              {error.message}
+            </Text>
+          )}
+        </Stack>
+      </Alert>
+    </Box>
+  );
+}
+
 /**
  * The workbench displays groups of alerts, each group containing metadata and a chart.
  * Alerts can be arbitrarily grouped by any number of labels. By default all instances are grouped by alertname.
@@ -170,6 +202,7 @@ export function Workbench({
   isInitialLoading = false,
   isRefreshing = false,
   hasActiveFilters = false,
+  error,
 }: WorkbenchProps) {
   const styles = useStyles2(getStyles);
 
@@ -190,7 +223,10 @@ export function Workbench({
   // Calculate once: show folder metadata only if not grouping by grafana_folder
   const enableFolderMeta = !groupBy?.includes('grafana_folder');
 
-  const showEmptyState = !isInitialLoading && data.length === 0;
+  const hasNoRows = data.length === 0;
+  // A failed query means we don't know what is firing, so showing "no alerts" here would be a lie.
+  const queryError = hasNoRows ? error : undefined;
+  const showEmptyState = !isInitialLoading && !queryError && hasNoRows;
   const showData = data.length > 0;
   // splitter for template and payload editor
   const splitter = useSplitter({
@@ -209,6 +245,15 @@ export function Workbench({
   const itemsToRender = pageIndex * DEFAULT_PER_PAGE_PAGINATION;
   const dataSlice = take(data, itemsToRender);
   const hasMore = data.length > itemsToRender;
+
+  if (queryError) {
+    return (
+      <Stack gap={0} grow={1} width="100%" height="100%">
+        <LabelsColumn />
+        <WorkbenchQueryError error={queryError} />
+      </Stack>
+    );
+  }
 
   if (showEmptyState) {
     return (

--- a/public/app/features/alerting/unified/triage/scene/Workbench.tsx
+++ b/public/app/features/alerting/unified/triage/scene/Workbench.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useTransition } from 'react';
 
-import { type DataFrame } from '@grafana/data';
+import { type DataFrame, LoadingState } from '@grafana/data';
 import {
   AdHocFiltersVariable,
   SceneObjectBase,
@@ -81,6 +81,9 @@ function WorkbenchRenderer() {
     return () => subscription.unsubscribe();
   }, [runner]);
 
+  // Only surfaced when there are no rows to show — see Workbench.
+  const queryError = data?.state === LoadingState.Error ? (data.errors?.at(0) ?? data.error) : undefined;
+
   const isDataLoading = data?.state === 'Loading' || data?.state === 'NotStarted' || data === undefined;
   const isInitialLoading = (isDataLoading || isPending) && rows.length === 0;
   const isRefreshing = isDataLoading && rows.length > 0;
@@ -94,6 +97,7 @@ function WorkbenchRenderer() {
       isInitialLoading={isInitialLoading}
       isRefreshing={isRefreshing}
       hasActiveFilters={hasFiltersApplied}
+      error={queryError}
     />
   );
 }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3702,6 +3702,9 @@
       "no-matching-instances-with-filters": "No alert instances match your current set of filters for the selected time range.",
       "open-in-sidebar": "Open in sidebar",
       "open-rule-details": "Open rule details",
+      "query-error-forbidden": "This page reads alert state history from a Prometheus data source, and you do not have permission to query it. Ask an administrator to grant you the query permission for that data source.",
+      "query-error-generic": "The query for alert instances failed, so we cannot tell which alerts are firing or pending.",
+      "query-error-title": "Unable to load alert instances",
       "rule-details": {
         "subtitle": "Rule details and conditions",
         "title": "Rule Details"


### PR DESCRIPTION
**What is this feature?**

When the Alert activity (triage) page fails to query alert state history, it now says so instead of rendering its "no alerts" empty state.

The page reads `GRAFANA_ALERTS` straight from a Prometheus data source in the browser, so any query failure surfaces as `LoadingState.Error` on the query runner. Nothing checked for it: `WorkbenchRenderer` only branched on `Loading`/`NotStarted`/`undefined` and skipped its transform unless the state was `Done`, so a failure left `rows` empty and the page happily reported "You have no alert instances in a firing or pending state for the selected time range."

The single most common failure is the viewer not having the **query** permission on the data source holding alert state history, so that case (HTTP 403) gets a message naming the cause. Any other failure gets a generic one. Both render the message the API returned underneath.

**Why do we need this feature?**

A failed query and genuinely having nothing firing looked identical, so the page confidently asserted something it could not know. That sent a customer escalation off chasing missing alerts and missing rule permissions before anyone looked at data source RBAC — the page was reporting "no alerts" while returning 403 on every request.

**Who is this feature for?**

Anyone whose user cannot query the state history data source — most commonly Grafana Cloud users who restrict access to the provisioned Prometheus/Mimir data source, e.g. to enforce LBAC. Also anyone hitting a transient query failure, who currently gets told there are no alerts.

**Which issue(s) does this PR fix?**:

\/

**Special notes for your reviewer:**

Deliberately narrow — this fixes the misleading message only, not the underlying permission model:

- **Only when there are no rows.** A failed refresh with rows already on screen behaves as before and keeps showing them. Blanking out data the user is reading is a separate call.
- **Only the workbench body.** The labels column and summary chart issue the same queries and handle failure their own way. The false claim was the empty state.
- `LabelsColumn` still renders in the error branch, matching the existing empty-state layout.

Worth knowing: this page requires `datasources:query` on the state history data source *in addition to* `alert.rules:read`, which is undocumented and surprises people — Loki-backed state history goes through `/api/v1/rules/history` and is authorized on `alert.rules:read` alone, because the Prometheus historian has no server-side query support. Closing that gap is a bigger piece of work that I'll raise separately; this PR just stops the page from lying about it. Docs for the permission requirement are also worth a follow-up.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. (Page is behind `alertingTriage`.)
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc. — no docs change here; the permission requirement is a separate docs follow-up.
