### PR TITLE
chore: bump the pinned TRIAGE_REF across the external contribution workflows

### DIFF
--- a/.github/workflows/external-fr-notify.yml
+++ b/.github/workflows/external-fr-notify.yml
@@ -18,7 +18,7 @@ concurrency:
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: 1a4b9aafb8511b66fb01abc2d87d9fc3037106e4 # trufflehog:ignore
+  TRIAGE_REF: 91bd2f3de830e057768c8bbf7354dfe897937b86 # trufflehog:ignore
 
 jobs:
   notify:

--- a/.github/workflows/external-fr-weekly-digest.yml
+++ b/.github/workflows/external-fr-weekly-digest.yml
@@ -31,7 +31,7 @@ concurrency:
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: 1a4b9aafb8511b66fb01abc2d87d9fc3037106e4 # trufflehog:ignore
+  TRIAGE_REF: 91bd2f3de830e057768c8bbf7354dfe897937b86 # trufflehog:ignore
 
 jobs:
   digest:

--- a/.github/workflows/external-issue-notify.yml
+++ b/.github/workflows/external-issue-notify.yml
@@ -18,7 +18,7 @@ concurrency:
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: 1a4b9aafb8511b66fb01abc2d87d9fc3037106e4 # trufflehog:ignore
+  TRIAGE_REF: 91bd2f3de830e057768c8bbf7354dfe897937b86 # trufflehog:ignore
 
 jobs:
   notify:

--- a/.github/workflows/external-issue-weekly-digest.yml
+++ b/.github/workflows/external-issue-weekly-digest.yml
@@ -31,7 +31,7 @@ concurrency:
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: 1a4b9aafb8511b66fb01abc2d87d9fc3037106e4 # trufflehog:ignore
+  TRIAGE_REF: 91bd2f3de830e057768c8bbf7354dfe897937b86 # trufflehog:ignore
 
 jobs:
   digest:

--- a/.github/workflows/external-pr-notify-handler.yml
+++ b/.github/workflows/external-pr-notify-handler.yml
@@ -25,7 +25,7 @@ env:
   # community-triage logic version this repo is pinned to (main as of PR #6).
   # Bump deliberately; re-resolve with:
   #   git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: 1a4b9aafb8511b66fb01abc2d87d9fc3037106e4 # trufflehog:ignore
+  TRIAGE_REF: 91bd2f3de830e057768c8bbf7354dfe897937b86 # trufflehog:ignore
 
 jobs:
   triage:

--- a/.github/workflows/external-pr-weekly-digest.yml
+++ b/.github/workflows/external-pr-weekly-digest.yml
@@ -31,7 +31,7 @@ permissions: {}
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: 1a4b9aafb8511b66fb01abc2d87d9fc3037106e4 # trufflehog:ignore
+  TRIAGE_REF: 91bd2f3de830e057768c8bbf7354dfe897937b86 # trufflehog:ignore
   STALE_THRESHOLD_DAYS: ${{ inputs.stale_days || 30 }}
 
 concurrency:


### PR DESCRIPTION
Bumps the pinned TRIAGE_REF across the six external contribution workflows.