### PR TITLE
Packaging: Fix issue with bundled plugins not being moved properly

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -25,6 +25,9 @@ logs = data/log
 # Directory where grafana will automatically scan and look for plugins
 plugins = data/plugins
 
+# Directory where grafana looks for the plugins bundled with the Grafana distribution
+bundled_plugins = data/plugins-bundled
+
 # folder that contains provisioning config files that grafana will apply on startup and while running.
 provisioning = conf/provisioning
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -23,6 +23,9 @@
 # Directory where grafana will automatically scan and look for plugins
 ;plugins = /var/lib/grafana/plugins
 
+# Directory where grafana looks for the plugins bundled with the Grafana distribution
+;bundled_plugins = /var/lib/grafana/plugins-bundled
+
 # folder that contains provisioning config files that grafana will apply on startup and while running.
 ;provisioning = conf/provisioning
 

--- a/packaging/deb/control/postinst
+++ b/packaging/deb/control/postinst
@@ -33,7 +33,11 @@ if [ "$1" = configure ]; then
 
   # Set user permissions on /var/log/grafana, /var/lib/grafana
   mkdir -p /var/log/grafana /var/lib/grafana
-  # Move plugins-bundled into place, see https://github.com/grafana/grafana/issues/123110
+  # Bundled plugins must live under $DATA_DIR (writable by grafana) so the
+  # plugin auto-updater can replace them; the service points
+  # paths.bundled_plugins there. Copy instead of move so the packaged files
+  # stay in place and `dpkg --verify` stays clean. Any copy already at the
+  # destination is safe to clobber.
   if [ -d "$GRAFANA_HOME/data/plugins-bundled" ]; then
     if [ "$IS_UPGRADE" = "true" ] && [ "$RESTART_ON_UPGRADE" = "true" ]; then
       if command -v systemctl >/dev/null; then
@@ -42,7 +46,7 @@ if [ "$1" = configure ]; then
     fi
     mkdir -p "$DATA_DIR"
     rm -rf "${DATA_DIR:?}/plugins-bundled"
-    mv "$GRAFANA_HOME/data/plugins-bundled" "$DATA_DIR"
+    cp -a "$GRAFANA_HOME/data/plugins-bundled" "$DATA_DIR"
     chown -R "$GRAFANA_USER":"$GRAFANA_GROUP" "$DATA_DIR/plugins-bundled"
   fi
 

--- a/packaging/deb/systemd/grafana-server.service
+++ b/packaging/deb/systemd/grafana-server.service
@@ -21,7 +21,8 @@ ExecStart=/usr/share/grafana/bin/grafana server                                 
                             cfg:default.paths.logs=${LOG_DIR}                       \
                             cfg:default.paths.data=${DATA_DIR}                      \
                             cfg:default.paths.plugins=${PLUGINS_DIR}                \
-                            cfg:default.paths.provisioning=${PROVISIONING_CFG_DIR}
+                            cfg:default.paths.provisioning=${PROVISIONING_CFG_DIR}  \
+                            cfg:default.paths.bundled_plugins=${DATA_DIR}/plugins-bundled
 
 LimitNOFILE=10000
 TimeoutStopSec=20

--- a/packaging/rpm/control/postinst
+++ b/packaging/rpm/control/postinst
@@ -36,11 +36,15 @@ if [ "$1" -eq 1 ] ; then
 
   # Set user permissions on /var/log/grafana, /var/lib/grafana
   mkdir -p /var/log/grafana /var/lib/grafana
-  # Move plugins-bundled into place - see https://github.com/grafana/grafana/issues/123110
+  # Bundled plugins must live under $DATA_DIR (writable by grafana) so the
+  # plugin auto-updater can replace them; the service points
+  # paths.bundled_plugins there. Copy instead of move so the packaged files
+  # stay in place and `rpm -V` stays clean. Any copy already at the
+  # destination is safe to clobber
   if [ -d "$GRAFANA_HOME/data/plugins-bundled" ]; then
     mkdir -p "$DATA_DIR"
     rm -rf "${DATA_DIR:?}/plugins-bundled"
-    mv "$GRAFANA_HOME/data/plugins-bundled" "$DATA_DIR"
+    cp -a "$GRAFANA_HOME/data/plugins-bundled" "$DATA_DIR"
     chown -R "$GRAFANA_USER":"$GRAFANA_GROUP" "$DATA_DIR/plugins-bundled"
   fi
   chown -R "$GRAFANA_USER":"$GRAFANA_GROUP" /var/log/grafana /var/lib/grafana
@@ -95,11 +99,12 @@ elif [ "$1" -ge 2 ] ; then
     stopGrafana
   fi
 
-  # Replace bundled plugins with the new version - see https://github.com/grafana/grafana/issues/123110
+  # Replace the bundled plugins with the ones shipped in the new package.
+  # See the matching copy in the fresh-install branch above.
   if [ -d "$GRAFANA_HOME/data/plugins-bundled" ]; then
     mkdir -p "$DATA_DIR"
     rm -rf "${DATA_DIR:?}/plugins-bundled"
-    mv "$GRAFANA_HOME/data/plugins-bundled" "$DATA_DIR"
+    cp -a "$GRAFANA_HOME/data/plugins-bundled" "$DATA_DIR"
     chown -R "$GRAFANA_USER":"$GRAFANA_GROUP" "$DATA_DIR/plugins-bundled"
   fi
 

--- a/packaging/rpm/systemd/grafana-server.service
+++ b/packaging/rpm/systemd/grafana-server.service
@@ -21,7 +21,8 @@ ExecStart=/usr/share/grafana/bin/grafana server                                 
                             cfg:default.paths.logs=${LOG_DIR}                       \
                             cfg:default.paths.data=${DATA_DIR}                      \
                             cfg:default.paths.plugins=${PLUGINS_DIR}                \
-                            cfg:default.paths.provisioning=${PROVISIONING_CFG_DIR}
+                            cfg:default.paths.provisioning=${PROVISIONING_CFG_DIR}  \
+                            cfg:default.paths.bundled_plugins=${DATA_DIR}/plugins-bundled
 
 LimitNOFILE=10000
 TimeoutStopSec=20

--- a/packaging/wrappers/grafana
+++ b/packaging/wrappers/grafana
@@ -37,7 +37,7 @@ if [ "$1" = cli ] || [ "$1" = server ]; then
   OPTS=(
     "--homepath=${GRAFANA_HOME}"
     "--config=${CONF_FILE}"
-    "--configOverrides=cfg:default.paths.provisioning=${PROVISIONING_CFG_DIR} cfg:default.paths.data=${DATA_DIR} cfg:default.paths.logs=${LOG_DIR} cfg:default.paths.plugins=${PLUGINS_DIR}"
+    "--configOverrides=cfg:default.paths.provisioning=${PROVISIONING_CFG_DIR} cfg:default.paths.data=${DATA_DIR} cfg:default.paths.logs=${LOG_DIR} cfg:default.paths.plugins=${PLUGINS_DIR} cfg:default.paths.bundled_plugins=${DATA_DIR}/plugins-bundled"
   )
   # special handling to pass --pluginsDir to cli
   # can remove once it fully supports cfg:default.paths.plugins


### PR DESCRIPTION
This should fix https://github.com/grafana/grafana/issues/130921 for 13.2.0/13.3.0+ the same way https://github.com/grafana/grafana/pull/129003 did for 13.2.1.