### PR TITLE
Search: enrol kinds that declare search fields

### DIFF
--- a/pkg/services/apiserver/searchroutes/searchroutes.go
+++ b/pkg/services/apiserver/searchroutes/searchroutes.go
@@ -21,21 +21,21 @@ import (
 // namespace. Cluster-scoped kinds have no namespace to search within.
 const namespacedScope = "Namespaced"
 
-// allowed lists the kinds that expose the search API, as (group, resource).
+// enrolledWithoutSearchFields keeps kinds that were already served but declare
+// no search fields, which enrolled would otherwise drop.
 //
-// Temporary. Every namespaced kind is a candidate, but turning them all on at
-// once would expose endpoints on kinds nobody has looked at yet, so the set is
-// widened deliberately. Kinds state their own choice in their manifest; this
-// list holds that choice back until someone has reviewed the kind.
-var allowed = map[groupResource]bool{
-	{group: "dashboard.grafana.app", resource: "dashboards"}: true,
-	{group: "folder.grafana.app", resource: "folders"}:       true,
-	{group: "dashboard.grafana.app", resource: "notebooks"}:  true,
+// Temporary: we plan to stop asking for fields at all.
+var enrolledWithoutSearchFields = map[string]bool{
+	"folder.grafana.app/folders":      true,
+	"dashboard.grafana.app/notebooks": true,
 }
 
-type groupResource struct {
-	group    string
-	resource string
+// enrolled reports whether a kind gets the search endpoints at all.
+//
+// Declared fields stand in for "someone reviewed this kind". Search works
+// without them, so this gate is about review, not capability.
+func enrolled(group, resourceName string, kind app.ManifestVersionKind) bool {
+	return len(kind.SearchFields) > 0 || enrolledWithoutSearchFields[group+"/"+resourceName]
 }
 
 // Build returns the search and trash routes to mount, or nil when both are off or
@@ -99,11 +99,11 @@ func build(
 					continue
 				}
 				resourceName := resource.ManifestResourceName(kind)
-				if !allowed[groupResource{group: gv.Group, resource: resourceName}] {
+				if !enrolled(gv.Group, resourceName, kind) {
 					continue
 				}
-				// The list above and the kind's manifest both have to want the
-				// endpoint. The two endpoints are answered separately.
+				// Answered separately so a kind can opt out of one endpoint
+				// without the other.
 				if searchEnabled && kind.HasSearchEndpoint() {
 					byGroupVersion[gv] = append(byGroupVersion[gv],
 						handler.SearchRoute(gv.Group, gv.Version, resourceName, kind.Kind))

--- a/pkg/services/apiserver/searchroutes/searchroutes_test.go
+++ b/pkg/services/apiserver/searchroutes/searchroutes_test.go
@@ -81,14 +81,39 @@ func TestBuild_SearchAndTrashAreIndependent(t *testing.T) {
 	})
 }
 
-// Trash must not reach a kind that search cannot.
-func TestBuild_TrashRespectsTheAllowlist(t *testing.T) {
-	b := &fakeBuilder{gvs: []schema.GroupVersion{{Group: "playlist.grafana.app", Version: "v0alpha1"}}}
+// Search fields are the enrolment signal, so a kind without them gets nothing.
+func TestBuild_SearchFieldsEnrolAKind(t *testing.T) {
+	gv := schema.GroupVersion{Group: "playlist.grafana.app", Version: "v0alpha1"}
+	builders := []builder.APIGroupBuilder{&fakeBuilder{gvs: []schema.GroupVersion{gv}}}
 
-	assert.Empty(t, paths(Build(true, true, nil, fakeClient{}, []builder.APIGroupBuilder{b}, nil)))
+	playlists := func(fields []app.ManifestVersionKindSearchField) []app.Manifest {
+		return []app.Manifest{{ManifestData: &app.ManifestData{
+			Group: gv.Group,
+			Versions: []app.ManifestVersion{{
+				Name:   gv.Version,
+				Served: true,
+				Kinds: []app.ManifestVersionKind{{
+					Kind:         "Playlist",
+					Plural:       "playlists",
+					Scope:        namespacedScope,
+					SearchFields: fields,
+				}},
+			}},
+		}}}
+	}
+
+	t.Run("no fields, not enrolled", func(t *testing.T) {
+		assert.Empty(t, paths(build(playlists(nil), true, true, nil, fakeClient{}, builders, nil)))
+	})
+
+	t.Run("one field, gets both endpoints", func(t *testing.T) {
+		fields := []app.ManifestVersionKindSearchField{{Name: "interval", Path: "spec.interval", Type: "string"}}
+		got := paths(build(playlists(fields), true, true, nil, fakeClient{}, builders, nil))
+		assert.ElementsMatch(t, []string{"playlists/search", "playlists/trash"}, got[gv.String()])
+	})
 }
 
-func TestBuild_MountsAllowedKinds(t *testing.T) {
+func TestBuild_MountsNamespacedKinds(t *testing.T) {
 	b := &fakeBuilder{gvs: []schema.GroupVersion{
 		{Group: "dashboard.grafana.app", Version: "v1"},
 		{Group: "folder.grafana.app", Version: "v1"},
@@ -111,16 +136,25 @@ func TestBuild_SkipsGroupVersionsNotServed(t *testing.T) {
 	assert.NotContains(t, got, "dashboard.grafana.app/v2", "v2 is a served version, but not served by this builder")
 }
 
-// The allowlist is what keeps the endpoint off kinds nobody has reviewed yet.
-func TestBuild_SkipsKindsNotAllowed(t *testing.T) {
-	notAllowed := []schema.GroupVersion{
-		{Group: "secret.grafana.app", Version: "v1beta1"},
+// Serving a group must not enrol the kinds in it that declare no fields.
+func TestBuild_EnrolmentIsPerKindNotPerGroup(t *testing.T) {
+	gvs := []schema.GroupVersion{
 		{Group: "iam.grafana.app", Version: "v0alpha1"},
+		{Group: "secret.grafana.app", Version: "v1beta1"},
 		{Group: "playlist.grafana.app", Version: "v0alpha1"},
 	}
-	b := &fakeBuilder{gvs: notAllowed}
 
-	assert.Empty(t, paths(Build(true, false, nil, fakeClient{}, []builder.APIGroupBuilder{b}, nil)))
+	got := paths(Build(true, false, nil, fakeClient{}, []builder.APIGroupBuilder{&fakeBuilder{gvs: gvs}}, nil))
+
+	assert.ElementsMatch(t, []string{
+		"users/search",
+		"teams/search",
+		"teambindings/search",
+		"externalgroupmappings/search",
+	}, got["iam.grafana.app/v0alpha1"], "only the IAM kinds declaring search fields")
+
+	assert.Empty(t, got["secret.grafana.app/v1beta1"])
+	assert.Empty(t, got["playlist.grafana.app/v0alpha1"])
 }
 
 // Every served version of an allowed kind gets the endpoint, so a client can use
@@ -198,9 +232,9 @@ func allServedGroupVersions(t *testing.T) []schema.GroupVersion {
 	return gvs
 }
 
-// Reading the manifest must not widen what is served. Adding a kind here should
-// be a decision, not a side effect of a manifest default.
-func TestBuild_ServedKindsAreOnlyTheAllowedOnes(t *testing.T) {
+// A kind can gain two public endpoints without anyone editing this package.
+// Listing the set makes that a failing test rather than a silent change.
+func TestBuild_EnrolledKindsAreListedHere(t *testing.T) {
 	got := paths(Build(true, true, nil, fakeClient{},
 		[]builder.APIGroupBuilder{&fakeBuilder{gvs: allServedGroupVersions(t)}}, nil))
 
@@ -210,12 +244,24 @@ func TestBuild_ServedKindsAreOnlyTheAllowedOnes(t *testing.T) {
 			resources[strings.SplitN(p, "/", 2)[0]] = true
 		}
 	}
+	names := make([]string, 0, len(resources))
+	for r := range resources {
+		names = append(names, r)
+	}
 
-	assert.Equal(t, map[string]bool{
-		"dashboards": true,
-		"folders":    true,
-		"notebooks":  true,
-	}, resources)
+	assert.ElementsMatch(t, []string{
+		// Declare search fields.
+		"alertrules",
+		"dashboards",
+		"externalgroupmappings",
+		"recordingrules",
+		"teambindings",
+		"teams",
+		"users",
+		// Served before enrolment asked for search fields.
+		"folders",
+		"notebooks",
+	}, names)
 }
 
 // Declining one endpoint must leave the other alone.
@@ -234,6 +280,10 @@ func TestBuild_ManifestOptOutIsHonoured(t *testing.T) {
 					Plural: "dashboards",
 					Scope:  namespacedScope,
 					Search: search,
+					// Enrols the kind, so what is under test is the opt-out alone.
+					SearchFields: []app.ManifestVersionKindSearchField{
+						{Name: "title", Path: "spec.title", Type: "string"},
+					},
 				}},
 			}},
 		}}}
@@ -261,26 +311,6 @@ func TestBuild_ManifestOptOutIsHonoured(t *testing.T) {
 		search := &app.ManifestVersionKindSearch{Endpoint: optOut(false), Trash: optOut(false)}
 		assert.Empty(t, paths(build(dashboards(search), true, true, nil, fakeClient{}, builders, nil)))
 	})
-}
-
-// Until the allowlist goes away, it still gates a kind that wants the endpoint.
-func TestBuild_AllowlistStillGatesAKindThatWantsIt(t *testing.T) {
-	gv := schema.GroupVersion{Group: "playlist.grafana.app", Version: "v0alpha1"}
-	manifests := []app.Manifest{{ManifestData: &app.ManifestData{
-		Group: gv.Group,
-		Versions: []app.ManifestVersion{{
-			Name:   gv.Version,
-			Served: true,
-			Kinds: []app.ManifestVersionKind{{
-				Kind:   "Playlist",
-				Plural: "playlists",
-				Scope:  namespacedScope,
-			}},
-		}},
-	}}}
-	builders := []builder.APIGroupBuilder{&fakeBuilder{gvs: []schema.GroupVersion{gv}}}
-
-	assert.Empty(t, paths(build(manifests, true, true, nil, fakeClient{}, builders, nil)))
 }
 
 func TestServedGroupVersions_CoversBothRegistrationPaths(t *testing.T) {


### PR DESCRIPTION
The per-resource `/search` and `/trash` endpoints were limited to a hardcoded list of three kinds. This replaces that list with a rule read from the app manifest: a kind is enrolled when it declares search fields and does not opt out.

Declaring fields stands in for review, not capability — search works without them. That takes the set from 3 kinds to 9: dashboards, alert rules, recording rules, users, teams, team bindings and external group mappings declare fields. Folders and notebooks were already served and declare none, so a temporary list keeps them.

A search request is authorized as a list on the same resource, so an enrolled kind exposes nothing that listing it did not already expose. Trash authorizes on a different rule and keeps its own setting. Both endpoints stay off unless `enable_search_api` or `enable_trash_api` is set, and no config file sets either today.

One test lists the enrolled kinds by name, so a kind gaining these endpoints shows up in review.