### PR TITLE
Explore: Add a metric detail panel to the signal explorer

### DIFF
--- a/public/app/features/explore/ContentOutline/ContentOutline.tsx
+++ b/public/app/features/explore/ContentOutline/ContentOutline.tsx
@@ -318,6 +318,9 @@ export function ContentOutline({
   );
 }
 
+/** What the Datasource explorer keeps for itself before the outline below it starts scrolling. */
+const EXPLORER_MIN_HEIGHT_UNITS = 25;
+
 const getStyles = (theme: GrafanaTheme2, expanded: boolean, signalExplorerVisible: boolean) => {
   const expandedWidth = signalExplorerVisible ? '300px' : '160px';
 
@@ -341,10 +344,13 @@ const getStyles = (theme: GrafanaTheme2, expanded: boolean, signalExplorerVisibl
       minHeight: 0,
       ...(signalExplorerVisible
         ? {
-            // Shrinkable so a tall outline scrolls (via ScrollContainer) instead of
-            // clipping against the wrapper, while still sizing to content and sitting
-            // at the bottom.
-            flex: '0 1 auto',
+            // Not shrinkable: flexbox spreads a deficit across every shrinkable item, so expanding a
+            // card in the explorer above would take height from these rows too.
+            flex: '0 0 auto',
+            // Capped so a tall outline scrolls inside `ScrollContainer` rather than clipping against
+            // the wrapper's `overflow: hidden`, and floored at half so a short sidebar — where the
+            // subtraction goes negative — cannot hide the rows altogether.
+            maxHeight: `max(50%, calc(100% - ${theme.spacing(EXPLORER_MIN_HEIGHT_UNITS)}))`,
             marginTop: 'auto',
             borderTop: `1px solid ${theme.colors.border.weak}`,
           }

--- a/public/app/features/explore/SignalExplorer/MetricDetailPanel.test.tsx
+++ b/public/app/features/explore/SignalExplorer/MetricDetailPanel.test.tsx
@@ -37,6 +37,26 @@ describe('<MetricDetailPanel />', () => {
     expect(screen.queryByText('Total number of HTTP requests observed.')).not.toBeInTheDocument();
   });
 
+  // The description scrolls once the help text passes its cap, and a scroll region with no tab stop
+  // is help text a keyboard user cannot read past the first few lines.
+  it('lets a keyboard reach the description to scroll it', async () => {
+    render(<MetricDetailPanel refId="A" metric={metric()} onClose={jest.fn()} />);
+
+    // The close button comes first in the panel, so the description is the second stop.
+    await userEvent.tab();
+    await userEvent.tab();
+
+    expect(screen.getByText('Total number of HTTP requests observed.')).toHaveFocus();
+  });
+
+  it('leaves no stray tab stop when there is no description to scroll', async () => {
+    render(<MetricDetailPanel refId="A" metric={metric({ help: undefined })} onClose={jest.fn()} />);
+
+    await userEvent.tab();
+
+    expect(screen.getByRole('button', { name: 'Close metric details' })).toHaveFocus();
+  });
+
   it.each<[MetricType, string]>([
     ['counter', 'COUNTER'],
     ['gauge', 'GAUGE'],

--- a/public/app/features/explore/SignalExplorer/MetricDetailPanel.test.tsx
+++ b/public/app/features/explore/SignalExplorer/MetricDetailPanel.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { MetricDetailPanel } from './MetricDetailPanel';
+import { type MetricInfo, type MetricType } from './types';
+
+const metric = (overrides: Partial<MetricInfo> = {}): MetricInfo => ({
+  name: 'http_server_requests_seconds_count',
+  type: 'counter',
+  help: 'Total number of HTTP requests observed.',
+  ...overrides,
+});
+
+describe('<MetricDetailPanel />', () => {
+  it('renders the metric name and its help text as the description', () => {
+    render(<MetricDetailPanel refId="A" metric={metric()} onClose={jest.fn()} />);
+
+    expect(screen.getByText('http_server_requests_seconds_count')).toBeInTheDocument();
+    expect(screen.getByText('Total number of HTTP requests observed.')).toBeInTheDocument();
+  });
+
+  // The same name can carry different metadata on two datasources, so the panel has to say whose
+  // list it came from.
+  it('names the query the metric was selected from', () => {
+    render(<MetricDetailPanel refId="short-name" metric={metric()} onClose={jest.fn()} />);
+
+    expect(screen.getByText('Query short-name')).toBeInTheDocument();
+  });
+
+  // Prometheus metadata is optional, so a metric with no help text has to render as a panel with no
+  // description rather than an empty line under the name.
+  it('renders no description for a metric the datasource gave no help text for', () => {
+    render(<MetricDetailPanel refId="A" metric={metric({ help: undefined })} onClose={jest.fn()} />);
+
+    const panel = screen.getByTestId('metric-detail-panel');
+    expect(panel).toHaveTextContent('http_server_requests_seconds_count');
+    expect(screen.queryByText('Total number of HTTP requests observed.')).not.toBeInTheDocument();
+  });
+
+  it.each<[MetricType, string]>([
+    ['counter', 'COUNTER'],
+    ['gauge', 'GAUGE'],
+    ['histogram', 'HISTOGRAM'],
+    ['native histogram', 'NATIVE HISTOGRAM'],
+    ['summary', 'SUMMARY'],
+    ['unknown', 'UNKNOWN'],
+  ])('labels a %s with a badge', (type, badge) => {
+    render(<MetricDetailPanel refId="A" metric={metric({ type })} onClose={jest.fn()} />);
+
+    expect(screen.getByText(badge)).toBeInTheDocument();
+  });
+
+  it('closes on request', async () => {
+    const onClose = jest.fn();
+    render(<MetricDetailPanel refId="A" metric={metric()} onClose={onClose} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Close metric details' }));
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/public/app/features/explore/SignalExplorer/MetricDetailPanel.tsx
+++ b/public/app/features/explore/SignalExplorer/MetricDetailPanel.tsx
@@ -55,7 +55,14 @@ export function MetricDetailPanel({ refId, metric, onClose }: Props) {
           />
         </div>
         <div className={styles.name}>{metric.name}</div>
-        {metric.help && <div className={styles.description}>{metric.help}</div>}
+        {metric.help && (
+          // Focusable because it scrolls once the help text passes the cap, and a scroll region a
+          // keyboard cannot reach is text a keyboard cannot read.
+          // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+          <div className={styles.description} tabIndex={0}>
+            {metric.help}
+          </div>
+        )}
         {/* Additional data (active series, scrape interval, cardinality) lands here. */}
       </div>
     </section>
@@ -66,11 +73,15 @@ export function MetricDetailPanel({ refId, metric, onClose }: Props) {
 const DESCRIPTION_MAX_HEIGHT = 100;
 
 const getStyles = (theme: GrafanaTheme2) => ({
-  // Takes the height it needs; the card list's scroll region above gives up exactly that much. The
-  // rule runs the full sidebar width, so it sits on the wrapper rather than the inset card.
+  // Takes the height it needs and the card list above gives up exactly that much — but never past
+  // half the sidebar, or a verbose metric on a short viewport would leave no list to pick the next
+  // one from. The rule runs the full width, so it sits on the wrapper rather than the inset card.
   panel: css({
     label: 'metric-detail-panel',
-    flex: '0 0 auto',
+    display: 'flex',
+    flex: '0 1 auto',
+    minHeight: 0,
+    maxHeight: '50%',
     padding: theme.spacing(1),
     borderTop: `1px solid ${theme.colors.border.weak}`,
   }),
@@ -78,16 +89,20 @@ const getStyles = (theme: GrafanaTheme2) => ({
     label: 'metric-detail-panel-card',
     display: 'flex',
     flexDirection: 'column',
+    flex: '1 1 auto',
+    minHeight: 0,
     gap: theme.spacing(0.5),
     padding: theme.spacing(1),
     background: theme.colors.background.secondary,
     border: `1px solid ${theme.colors.border.weak}`,
     borderRadius: theme.shape.radius.default,
+    overflow: 'hidden',
   }),
   header: css({
     label: 'metric-detail-panel-header',
     display: 'flex',
     alignItems: 'center',
+    flex: '0 0 auto',
     gap: theme.spacing(1),
   }),
   fromQuery: css({
@@ -104,18 +119,25 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   name: css({
     label: 'metric-detail-panel-name',
+    flex: '0 0 auto',
     color: theme.colors.text.primary,
     fontSize: theme.typography.bodySmall.fontSize,
     fontFamily: theme.typography.fontFamilyMonospace,
     overflowWrap: 'anywhere',
   }),
-  // Help text is unbounded and every line of it costs the card list above. Capped so a verbose metric
-  // takes a known amount of room instead of all of it.
+  // Help text is unbounded and every line of it costs the card list above, so it is capped and
+  // scrolls. The only part of the panel that shrinks, so squeezing the panel never clips the name.
   description: css({
     label: 'metric-detail-panel-description',
+    flex: '0 1 auto',
+    minHeight: 0,
     maxHeight: DESCRIPTION_MAX_HEIGHT,
     overflowY: 'auto',
     color: theme.colors.text.secondary,
     fontSize: theme.typography.bodySmall.fontSize,
+    '&:focus-visible': {
+      outline: `2px solid ${theme.colors.accent.main}`,
+      outlineOffset: '-2px',
+    },
   }),
 });

--- a/public/app/features/explore/SignalExplorer/MetricDetailPanel.tsx
+++ b/public/app/features/explore/SignalExplorer/MetricDetailPanel.tsx
@@ -1,0 +1,121 @@
+import { css } from '@emotion/css';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { Badge, type BadgeColor, IconButton, useStyles2 } from '@grafana/ui';
+
+import { type MetricInfo, type MetricType } from './types';
+
+interface Props {
+  /** The query whose list the metric came from — rendered, because a Mixed pane has more than one. */
+  refId: string;
+  metric: MetricInfo;
+  onClose: () => void;
+}
+
+const BADGE_COLORS: Record<MetricType, BadgeColor> = {
+  counter: 'blue',
+  histogram: 'orange',
+  // Shares the histogram colour: a separate one would suggest a different kind of signal.
+  'native histogram': 'orange',
+  summary: 'purple',
+  gauge: 'green',
+  unknown: 'darkgrey',
+};
+
+/**
+ * Detail of the metric selected in a SignalCard's list, pinned to the bottom of the Datasource
+ * explorer sidebar. Presentational: everything comes from the catalog entry the list already holds,
+ * so selecting a metric costs no request.
+ */
+export function MetricDetailPanel({ refId, metric, onClose }: Props) {
+  const styles = useStyles2(getStyles);
+  const fromQuery = t('explore.metric-detail-panel.from-query', 'Query {{refId}}', { refId });
+
+  return (
+    <section
+      className={styles.panel}
+      aria-label={t('explore.metric-detail-panel.aria-label', 'Metric details')}
+      data-testid="metric-detail-panel"
+    >
+      <div className={styles.card}>
+        <div className={styles.header}>
+          <Badge text={metric.type.toUpperCase()} color={BADGE_COLORS[metric.type]} />
+          {/* refIds are user-editable, so the full value goes in a tooltip and the label truncates
+              rather than pushing the close button out of the panel. */}
+          <span className={styles.fromQuery} title={fromQuery}>
+            {fromQuery}
+          </span>
+          <IconButton
+            name="times"
+            size="sm"
+            variant="secondary"
+            tooltip={t('explore.metric-detail-panel.close', 'Close metric details')}
+            onClick={onClose}
+          />
+        </div>
+        <div className={styles.name}>{metric.name}</div>
+        {metric.help && <div className={styles.description}>{metric.help}</div>}
+        {/* Additional data (active series, scrape interval, cardinality) lands here. */}
+      </div>
+    </section>
+  );
+}
+
+/** Roughly six lines at the sidebar's width, which covers a stock Prometheus catalog. */
+const DESCRIPTION_MAX_HEIGHT = 100;
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  // Takes the height it needs; the card list's scroll region above gives up exactly that much. The
+  // rule runs the full sidebar width, so it sits on the wrapper rather than the inset card.
+  panel: css({
+    label: 'metric-detail-panel',
+    flex: '0 0 auto',
+    padding: theme.spacing(1),
+    borderTop: `1px solid ${theme.colors.border.weak}`,
+  }),
+  card: css({
+    label: 'metric-detail-panel-card',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(0.5),
+    padding: theme.spacing(1),
+    background: theme.colors.background.secondary,
+    border: `1px solid ${theme.colors.border.weak}`,
+    borderRadius: theme.shape.radius.default,
+  }),
+  header: css({
+    label: 'metric-detail-panel-header',
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+  }),
+  fromQuery: css({
+    label: 'metric-detail-panel-from-query',
+    // Takes the room between the badge and the close button, and gives it up first when short of it.
+    flex: '1 1 auto',
+    minWidth: 0,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    textAlign: 'right',
+    color: theme.colors.text.secondary,
+    fontSize: theme.typography.bodySmall.fontSize,
+  }),
+  name: css({
+    label: 'metric-detail-panel-name',
+    color: theme.colors.text.primary,
+    fontSize: theme.typography.bodySmall.fontSize,
+    fontFamily: theme.typography.fontFamilyMonospace,
+    overflowWrap: 'anywhere',
+  }),
+  // Help text is unbounded and every line of it costs the card list above. Capped so a verbose metric
+  // takes a known amount of room instead of all of it.
+  description: css({
+    label: 'metric-detail-panel-description',
+    maxHeight: DESCRIPTION_MAX_HEIGHT,
+    overflowY: 'auto',
+    color: theme.colors.text.secondary,
+    fontSize: theme.typography.bodySmall.fontSize,
+  }),
+});

--- a/public/app/features/explore/SignalExplorer/MetricRow.tsx
+++ b/public/app/features/explore/SignalExplorer/MetricRow.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import { memo } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
@@ -8,6 +8,7 @@ import { Icon, useStyles2 } from '@grafana/ui';
 interface Props {
   name: string;
   expanded: boolean;
+  selected: boolean;
   /**
    * `id` of the block this row expands, so assistive technology can follow `aria-expanded` to the
    * thing that actually appeared. The list owns it because the block is this row's sibling, not its
@@ -16,53 +17,62 @@ interface Props {
   labelsId: string;
   /**
    * Takes the name rather than closing over it, so the list can hoist one stable callback out of its
-   * map and let the `memo` below do its job.
+   * map and let the `memo` below do its job. Same for `onSelect`.
    */
   onToggle: (name: string) => void;
+  onSelect: (name: string) => void;
 }
 
 // Memoized: the list re-renders on every keystroke and every expansion, and only the one or two rows
 // whose own props moved need to re-render with it.
-export const MetricRow = memo(function MetricRow({ name, expanded, labelsId, onToggle }: Props) {
+export const MetricRow = memo(function MetricRow({ name, expanded, selected, labelsId, onToggle, onSelect }: Props) {
   const styles = useStyles2(getStyles);
 
   return (
-    <button
-      type="button"
-      className={styles.row}
-      title={name}
-      aria-expanded={expanded}
-      // Only while expanded: a collapsed row's block is unmounted, and pointing at an id that is not
-      // in the document is worse than saying nothing.
-      aria-controls={expanded ? labelsId : undefined}
-      aria-label={
-        expanded
-          ? t('explore.metrics-list.collapse-metric', 'Collapse {{name}}', { name })
-          : t('explore.metrics-list.expand-metric', 'Expand {{name}}', { name })
-      }
-      onClick={() => onToggle(name)}
-    >
-      <Icon name={expanded ? 'angle-down' : 'angle-right'} className={styles.chevron} />
-      <span className={styles.name}>{name}</span>
-    </button>
+    <div className={cx(styles.row, selected && styles.rowSelected)}>
+      {/* Siblings, not nested: WebKit treats a button's content as presentational, so a control
+          inside one is invisible to VoiceOver. */}
+      <button
+        type="button"
+        className={styles.chevronButton}
+        aria-expanded={expanded}
+        // Only while expanded: a collapsed row's block is unmounted, and pointing at an id that is not
+        // in the document is worse than saying nothing.
+        aria-controls={expanded ? labelsId : undefined}
+        aria-label={
+          expanded
+            ? t('explore.metrics-list.collapse-metric', 'Collapse {{name}}', { name })
+            : t('explore.metrics-list.expand-metric', 'Expand {{name}}', { name })
+        }
+        onClick={() => onToggle(name)}
+      >
+        <Icon name={expanded ? 'angle-down' : 'angle-right'} />
+      </button>
+      <button
+        type="button"
+        className={styles.nameButton}
+        title={name}
+        // A toggle, because re-picking the open metric closes the panel.
+        aria-pressed={selected}
+        aria-label={t('explore.metrics-list.show-metric-details', 'Show details for {{name}}', { name })}
+        onClick={() => onSelect(name)}
+      >
+        <span className={styles.name}>{name}</span>
+      </button>
+    </div>
   );
 });
 
 const getStyles = (theme: GrafanaTheme2) => ({
-  // The whole row is the control, not just the chevron: it is a bigger pointer target and one
-  // tab stop per metric instead of two.
+  // Two controls, so two tab stops per metric: the chevron opens the row's labels in place, the name
+  // opens the metric in the detail panel. No gap between them, or the strip would belong to neither
+  // and clicking it would do nothing — their own padding sets them apart.
   row: css({
     label: 'metric-row',
     display: 'flex',
     alignItems: 'center',
-    gap: theme.spacing(0.5),
     width: '100%',
-    padding: theme.spacing(0.5, 0.5),
     borderRadius: theme.shape.radius.default,
-    background: 'none',
-    border: 'none',
-    textAlign: 'left',
-    cursor: 'pointer',
     '&:hover': {
       backgroundColor: theme.colors.background.secondary,
       '& span': {
@@ -70,10 +80,43 @@ const getStyles = (theme: GrafanaTheme2) => ({
       },
     },
   }),
-  chevron: css({
+  // `&:hover` is restated because the hover rule above is more specific and would otherwise repaint
+  // the selected row as merely hovered.
+  rowSelected: css({
+    label: 'metric-row-selected',
+    '&, &:hover': {
+      backgroundColor: theme.colors.action.selected,
+    },
+    '& span': {
+      color: theme.colors.text.primary,
+    },
+  }),
+  chevronButton: css({
     label: 'metric-row-chevron',
+    display: 'flex',
+    alignItems: 'center',
     flexShrink: 0,
+    padding: theme.spacing(0.5, 0, 0.5, 0.5),
+    background: 'none',
+    border: 'none',
     color: theme.colors.text.secondary,
+    cursor: 'pointer',
+    '&:hover': {
+      color: theme.colors.text.primary,
+    },
+  }),
+  nameButton: css({
+    label: 'metric-row-name-button',
+    // Takes the rest of the row, so the pointer target is the whole line rather than just the text.
+    flex: '1 1 auto',
+    minWidth: 0,
+    display: 'flex',
+    alignItems: 'center',
+    padding: theme.spacing(0.5),
+    background: 'none',
+    border: 'none',
+    textAlign: 'left',
+    cursor: 'pointer',
   }),
   name: css({
     label: 'metric-row-name',

--- a/public/app/features/explore/SignalExplorer/MetricsList.test.tsx
+++ b/public/app/features/explore/SignalExplorer/MetricsList.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { type ComponentProps } from 'react';
 
 import { type TimeRange } from '@grafana/data';
 
@@ -28,7 +29,20 @@ const setCatalog = (metrics: MetricInfo[], rest: { loading?: boolean; error?: Er
   useMetricCatalogMock.mockReturnValue({ metrics, loading: false, ...rest });
 };
 
-const renderList = () => render(<MetricsList dsUid="prom-uid" dsType="prometheus" timeRange={timeRange} />);
+const onSelectMetric = jest.fn();
+
+const list = (props: Partial<ComponentProps<typeof MetricsList>> = {}) => (
+  <MetricsList
+    refId="A"
+    dsUid="prom-uid"
+    dsType="prometheus"
+    timeRange={timeRange}
+    onSelectMetric={onSelectMetric}
+    {...props}
+  />
+);
+
+const renderList = (props?: Partial<ComponentProps<typeof MetricsList>>) => render(list(props));
 
 const rowCount = () => screen.getAllByRole('listitem').length;
 
@@ -44,6 +58,7 @@ const expandMetric = (name: string) => userEvent.click(screen.getByRole('button'
 
 describe('<MetricsList />', () => {
   beforeEach(() => {
+    onSelectMetric.mockReset();
     useMetricCatalogMock.mockReset();
     useMetricDetailMock.mockReset().mockReturnValue({ labelKeys: [], loading: false });
     useLabelValuesMock.mockReset().mockReturnValue({ values: [], loading: false });
@@ -270,6 +285,65 @@ describe('<MetricsList />', () => {
     });
   });
 
+  describe('selecting a metric', () => {
+    const selectMetric = (name: string) =>
+      userEvent.click(screen.getByRole('button', { name: `Show details for ${name}` }));
+
+    // The whole entry, not the name, so the panel needs no request of its own.
+    it('hands the whole catalog entry up', async () => {
+      setCatalog([{ name: 'up', type: 'gauge', help: 'Whether the target is reachable.' }]);
+      renderList();
+
+      await selectMetric('up');
+
+      expect(onSelectMetric).toHaveBeenCalledWith({
+        refId: 'A',
+        dsUid: 'prom-uid',
+        metric: { name: 'up', type: 'gauge', help: 'Whether the target is reachable.' },
+      });
+    });
+
+    // The entry is read through a ref to keep the callback stable; the ref has to keep up.
+    it('hands up the entry from the catalog as it stands, not as it first rendered', async () => {
+      useMetricCatalogMock.mockImplementation((_dsRef, _timeRange, opts) => ({
+        metrics: [{ name: 'up', type: 'gauge', help: opts?.searchText ? 'Searched help.' : 'Initial help.' }],
+        loading: false,
+      }));
+      renderList();
+
+      await userEvent.type(screen.getByPlaceholderText('Search metrics'), 'u');
+      await selectMetric('up');
+
+      expect(onSelectMetric).toHaveBeenCalledWith(
+        expect.objectContaining({ metric: expect.objectContaining({ help: 'Searched help.' }) })
+      );
+    });
+
+    it('does not expand the row, and expanding the row does not select it', async () => {
+      setCatalog([row('up')]);
+      setLabelKeys(['job']);
+      renderList();
+
+      await selectMetric('up');
+      expect(screen.getByRole('button', { name: 'Expand up' })).toBeInTheDocument();
+      expect(useMetricDetailMock).not.toHaveBeenCalled();
+
+      await expandMetric('up');
+      expect(onSelectMetric).toHaveBeenCalledTimes(1);
+    });
+
+    it('marks the row the panel is showing as pressed', () => {
+      setCatalog([row('up'), row('node_load1')]);
+      renderList({ selectedMetric: 'up' });
+
+      expect(screen.getByRole('button', { name: 'Show details for up' })).toHaveAttribute('aria-pressed', 'true');
+      expect(screen.getByRole('button', { name: 'Show details for node_load1' })).toHaveAttribute(
+        'aria-pressed',
+        'false'
+      );
+    });
+  });
+
   describe('expanding a label key', () => {
     const expandLabel = (key: string) =>
       userEvent.click(screen.getByRole('button', { name: `Show values for ${key}` }));
@@ -357,7 +431,7 @@ describe('<MetricsList />', () => {
       await userEvent.click(screen.getByRole('button', { name: 'Show more values' }));
       expect(screen.getAllByTestId('signal-explorer-value-row')).toHaveLength(50);
 
-      rerender(<MetricsList dsUid="prom-uid" dsType="prometheus" timeRange={otherTimeRange} />);
+      rerender(list({ timeRange: otherTimeRange }));
 
       expect(screen.getAllByTestId('signal-explorer-value-row')).toHaveLength(25);
     });

--- a/public/app/features/explore/SignalExplorer/MetricsList.tsx
+++ b/public/app/features/explore/SignalExplorer/MetricsList.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { memo, useCallback, useId, useMemo, useState } from 'react';
+import { memo, useCallback, useId, useMemo, useRef, useState } from 'react';
 
 import { type DataSourceRef, type GrafanaTheme2, type TimeRange } from '@grafana/data';
 import { t } from '@grafana/i18n';
@@ -11,8 +11,11 @@ import { blockId } from './blockId';
 import { dsKey, rangeKey } from './data/metricResourceClient';
 import { useMetricCatalog } from './data/useMetricCatalog';
 import { useVisibleBatch } from './hooks/useVisibleBatch';
+import { type MetricSelection } from './types';
 
 interface Props {
+  /** The owning card's query, named back to the explorer so it knows whose row was selected. */
+  refId: string;
   /**
    * The card's datasource, as primitives rather than a `DataSourceRef`, because this component is the
    * `memo()` boundary: the explorer above rebuilds its card descriptors on every keystroke in a query
@@ -22,6 +25,13 @@ interface Props {
   dsUid?: string;
   dsType?: string;
   timeRange: TimeRange;
+  /** Name of the metric the detail panel is showing, if it belongs to this list. */
+  selectedMetric?: string;
+  /**
+   * Hands over the whole catalog entry rather than the name, so the panel needs no request of its
+   * own. Must be stable, or the `memo()` above stops earning its keep.
+   */
+  onSelectMetric: (selection: MetricSelection) => void;
 }
 
 /**
@@ -32,10 +42,18 @@ interface Props {
  * names. Searching is the catalog hook's job, not this component's: the list being searched is the
  * whole datasource's catalog, which this component never holds.
  *
- * A row expands to its label keys and a label key to its values. One metric and one label at a time:
- * every open row holds a request open, and both lists are unbounded.
+ * A row's chevron expands it to its label keys and a label key to its values. One metric and one label
+ * at a time: every open row holds a request open, and both lists are unbounded. The row's name is a
+ * separate control, selecting the metric for the sidebar's detail panel.
  */
-export const MetricsList = memo(function MetricsList({ dsUid, dsType, timeRange }: Props) {
+export const MetricsList = memo(function MetricsList({
+  refId,
+  dsUid,
+  dsType,
+  timeRange,
+  selectedMetric,
+  onSelectMetric,
+}: Props) {
   const styles = useStyles2(getStyles);
   const [searchTerm, setSearchTerm] = useState('');
 
@@ -64,6 +82,21 @@ export const MetricsList = memo(function MetricsList({ dsUid, dsType, timeRange 
   // a ref object without one identity change per render turning into a refetch.
   const dsRef = useMemo<DataSourceRef>(() => ({ uid: dsUid, type: dsType }), [dsUid, dsType]);
   const { metrics, loading, error } = useMetricCatalog(dsRef, timeRange, { searchText: searchTerm });
+
+  // Rows are handed a name, so the entry is looked up here. Through a ref, not a dependency:
+  // `metrics` is a fresh array on every keystroke, which would undo `MetricRow`'s `memo()`.
+  const metricsRef = useRef(metrics);
+  metricsRef.current = metrics;
+
+  const selectMetric = useCallback(
+    (name: string) => {
+      const metric = metricsRef.current.find((candidate) => candidate.name === name);
+      if (metric) {
+        onSelectMetric({ refId, dsUid, metric });
+      }
+    },
+    [onSelectMetric, refId, dsUid]
+  );
 
   // Paging resets on anything that swaps the catalog out for a different one — the search, but also
   // the datasource and the range. An offset into the old list means nothing in the new one.
@@ -105,7 +138,14 @@ export const MetricsList = memo(function MetricsList({ dsUid, dsType, timeRange 
 
               return (
                 <li key={metric.name}>
-                  <MetricRow name={metric.name} expanded={expanded} labelsId={labelsId} onToggle={toggleMetric} />
+                  <MetricRow
+                    name={metric.name}
+                    expanded={expanded}
+                    selected={metric.name === selectedMetric}
+                    labelsId={labelsId}
+                    onToggle={toggleMetric}
+                    onSelect={selectMetric}
+                  />
                   {expanded && (
                     <MetricLabels
                       id={labelsId}

--- a/public/app/features/explore/SignalExplorer/SignalExplorer.test.tsx
+++ b/public/app/features/explore/SignalExplorer/SignalExplorer.test.tsx
@@ -1,5 +1,5 @@
-import { act, render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { act, render, screen, within } from '@testing-library/react';
+import userEvent, { type UserEvent } from '@testing-library/user-event';
 
 import {
   type DataSourceApi,
@@ -13,10 +13,16 @@ import { type DataQuery } from '@grafana/schema';
 import { type ContentOutlineItemContextProps } from '../ContentOutline/ContentOutlineContext';
 
 import { SignalExplorer } from './SignalExplorer';
+import { useMetricCatalog } from './data/useMetricCatalog';
 
 jest.mock('../ContentOutline/ContentOutlineContext', () => ({
   useContentOutlineContext: jest.fn(),
 }));
+
+// Mocked so an expanded card's metric list needs no Prometheus behind it.
+jest.mock('./data/useMetricCatalog');
+
+const useMetricCatalogMock = jest.mocked(useMetricCatalog);
 
 const makeMeta = (id: string) =>
   ({
@@ -51,12 +57,13 @@ const promQuery = (refId: string, expr = ''): DataQuery =>
   ({ refId, datasource: { uid: 'prom-uid', type: 'prometheus' }, expr }) as DataQuery;
 
 const timeRange = { raw: { from: 'now-1h', to: 'now' }, from: {}, to: {} } as unknown as TimeRange;
+const otherTimeRange = { raw: { from: 'now-6h', to: 'now' }, from: {}, to: {} } as unknown as TimeRange;
 
-const explorer = (queries: DataQuery[], paneDatasource?: DataSourceApi) => (
+const explorer = (queries: DataQuery[], paneDatasource?: DataSourceApi, range: TimeRange = timeRange) => (
   <SignalExplorer
     queries={queries}
     paneDatasource={paneDatasource}
-    timeRange={timeRange}
+    timeRange={range}
     scroller={scrollerMock}
     toggleButton={<button type="button">Collapse outline</button>}
   />
@@ -115,6 +122,10 @@ const setup = async (queries: DataQuery[], paneDatasource?: DataSourceApi) => {
 };
 
 describe('<SignalExplorer />', () => {
+  beforeEach(() => {
+    useMetricCatalogMock.mockReset().mockReturnValue({ metrics: [], loading: false });
+  });
+
   it('renders the header with the injected toggle button', async () => {
     await setup([]);
 
@@ -312,5 +323,125 @@ describe('<SignalExplorer />', () => {
     await user.click(screen.getByRole('button', { name: 'Expand datasource explorer for query A' }));
 
     expect(scrollerMock.scroll).not.toHaveBeenCalled();
+  });
+
+  // One panel for the whole sidebar, so one metric at a time across every card.
+  describe('metric detail panel', () => {
+    const catalog = [{ name: 'up', type: 'gauge' as const, help: 'Whether the target is reachable.' }];
+
+    const openCard = async (refId: string) => {
+      useMetricCatalogMock.mockReturnValue({ metrics: catalog, loading: false });
+      const rendered = await setup([promQuery('A'), promQuery('B')]);
+      await rendered.user.click(screen.getByRole('button', { name: `Expand datasource explorer for query ${refId}` }));
+      return rendered;
+    };
+
+    // Scoped to the card: both offer `up` once open, with the same accessible name.
+    const selectUpIn = (user: UserEvent, refId: string) =>
+      user.click(
+        within(screen.getByTestId(`signal-card-${refId}`)).getByRole('button', { name: 'Show details for up' })
+      );
+
+    it('stays out of the sidebar until a metric is selected', async () => {
+      const { user } = await openCard('A');
+      expect(screen.queryByTestId('metric-detail-panel')).not.toBeInTheDocument();
+
+      await selectUpIn(user, 'A');
+
+      const panel = screen.getByTestId('metric-detail-panel');
+      expect(panel).toHaveTextContent('up');
+      expect(panel).toHaveTextContent('Whether the target is reachable.');
+      expect(panel).toHaveTextContent('GAUGE');
+    });
+
+    // Two cards can point at different instances, where one name carries different metadata.
+    it('names the query the metric was selected from', async () => {
+      const { user } = await openCard('B');
+
+      await selectUpIn(user, 'B');
+
+      expect(screen.getByTestId('metric-detail-panel')).toHaveTextContent('Query B');
+    });
+
+    it('closes when the same metric is selected again', async () => {
+      const { user } = await openCard('A');
+      await selectUpIn(user, 'A');
+
+      await selectUpIn(user, 'A');
+
+      expect(screen.queryByTestId('metric-detail-panel')).not.toBeInTheDocument();
+    });
+
+    it('closes on request', async () => {
+      const { user } = await openCard('A');
+      await selectUpIn(user, 'A');
+
+      await user.click(screen.getByRole('button', { name: 'Close metric details' }));
+
+      expect(screen.queryByTestId('metric-detail-panel')).not.toBeInTheDocument();
+    });
+
+    it('closes when the card the metric was selected from collapses', async () => {
+      const { user } = await openCard('A');
+      await selectUpIn(user, 'A');
+
+      await user.click(screen.getByRole('button', { name: 'Collapse datasource explorer for query A' }));
+
+      expect(screen.queryByTestId('metric-detail-panel')).not.toBeInTheDocument();
+    });
+
+    it('stays open when another card collapses', async () => {
+      const { user } = await openCard('A');
+      await user.click(screen.getByRole('button', { name: 'Expand datasource explorer for query B' }));
+      await selectUpIn(user, 'A');
+
+      await user.click(screen.getByRole('button', { name: 'Collapse datasource explorer for query B' }));
+
+      expect(screen.getByTestId('metric-detail-panel')).toBeInTheDocument();
+    });
+
+    it('closes when the query the metric was selected from is deleted', async () => {
+      const { user, rerender } = await openCard('A');
+      await selectUpIn(user, 'A');
+
+      rerender(explorer([promQuery('B')]));
+
+      expect(screen.queryByTestId('metric-detail-panel')).not.toBeInTheDocument();
+    });
+
+    // The refId survives here; only the catalog underneath changes.
+    it('closes when the query the metric was selected from moves to another datasource', async () => {
+      const { user, rerender } = await openCard('A');
+      await selectUpIn(user, 'A');
+
+      const ampQuery = {
+        refId: 'A',
+        datasource: { uid: 'amp-uid', type: 'grafana-amazonprometheus-datasource' },
+      } as DataQuery;
+      rerender(explorer([ampQuery, promQuery('B')]));
+
+      expect(screen.queryByTestId('metric-detail-panel')).not.toBeInTheDocument();
+    });
+
+    // A new range fetches a new catalog, which need not still hold the metric.
+    it('closes when the time range changes', async () => {
+      const { user, rerender } = await openCard('A');
+      await selectUpIn(user, 'A');
+
+      rerender(explorer([promQuery('A'), promQuery('B')], undefined, otherTimeRange));
+
+      expect(screen.queryByTestId('metric-detail-panel')).not.toBeInTheDocument();
+    });
+
+    // Explore rebuilds the range object every refresh tick, and the catalog does not refetch for it.
+    it('stays open across a refresh that re-resolves the same relative range', async () => {
+      const { user, rerender } = await openCard('A');
+      await selectUpIn(user, 'A');
+
+      const refreshed = { raw: { from: 'now-1h', to: 'now' }, from: {}, to: {} } as unknown as TimeRange;
+      rerender(explorer([promQuery('A'), promQuery('B')], undefined, refreshed));
+
+      expect(screen.getByTestId('metric-detail-panel')).toBeInTheDocument();
+    });
   });
 });

--- a/public/app/features/explore/SignalExplorer/SignalExplorer.tsx
+++ b/public/app/features/explore/SignalExplorer/SignalExplorer.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { type ReactNode, useEffect, useMemo, useState } from 'react';
+import { type ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { type DataSourceApi, type GrafanaTheme2, type TimeRange } from '@grafana/data';
 import { t } from '@grafana/i18n';
@@ -13,8 +13,11 @@ import { QUERIES_PANEL_ID } from '../ContentOutline/ContentOutlineItem';
 import { scrollOutlineItemIntoView } from '../ContentOutline/scrollIntoView';
 import { isPrometheusType } from '../utils/prometheus';
 
+import { MetricDetailPanel } from './MetricDetailPanel';
 import { MetricsList } from './MetricsList';
 import { SignalCard } from './SignalCard';
+import { rangeKey } from './data/metricResourceClient';
+import { type MetricSelection } from './types';
 
 interface CardDescriptor {
   refId: string;
@@ -54,6 +57,7 @@ export function SignalExplorer({ queries, paneDatasource, timeRange, scroller, t
   const styles = useStyles2(getStyles);
   const { outlineItems } = useContentOutlineContext() ?? { outlineItems: [] };
   const [expandedRefIds, setExpandedRefIds] = useState<Set<string>>(new Set());
+  const [selectedMetric, setSelectedMetric] = useState<MetricSelection | null>(null);
 
   // The whole list once, rather than a lookup per ref: a card's datasource is resolved inside the
   // memo below, and one hook per query would break the rules of hooks as queries come and go.
@@ -107,21 +111,43 @@ export function SignalExplorer({ queries, paneDatasource, timeRange, scroller, t
   //   added, so the next query in that slot would render already expanded;
   // - a query that moved to a datasource with no explorer, because the card collapses on
   //   screen and would otherwise reopen by itself if the query moved back.
+  // The selected metric goes with them, and also when its card keeps its refId but changes
+  // datasource, because the list underneath is then a different catalog.
   useEffect(() => {
+    const expandable = new Map(cards.filter((card) => card.isExpandable).map((card) => [card.refId, card.dsUid]));
+
     setExpandedRefIds((prev) => {
       if (prev.size === 0) {
         return prev;
       }
 
-      const expandable = new Set(cards.filter((card) => card.isExpandable).map((card) => card.refId));
       const next = new Set([...prev].filter((refId) => expandable.has(refId)));
 
       // Returning the previous set lets React skip the extra render.
       return next.size === prev.size ? prev : next;
     });
+
+    setSelectedMetric((prev) => {
+      if (!prev) {
+        return prev;
+      }
+      // `has` as well as `get`: a card with no resolved uid stores `undefined`, which `get` alone
+      // cannot tell from a refId that has left the pane.
+      return expandable.has(prev.refId) && expandable.get(prev.refId) === prev.dsUid ? prev : null;
+    });
   }, [cards]);
 
+  // A new range fetches a new catalog, which need not still hold the selected metric. Keyed on
+  // `rangeKey`, not the range object Explore rebuilds every refresh tick, so a refresh changes
+  // nothing here for the same reason it refetches nothing.
+  const range = rangeKey(timeRange);
+  useEffect(() => {
+    setSelectedMetric(null);
+  }, [range]);
+
   const toggleExpanded = (refId: string) => {
+    const collapsing = expandedRefIds.has(refId);
+
     setExpandedRefIds((prev) => {
       const next = new Set(prev);
       if (!next.delete(refId)) {
@@ -129,7 +155,21 @@ export function SignalExplorer({ queries, paneDatasource, timeRange, scroller, t
       }
       return next;
     });
+
+    // A collapsing card takes its metric rows with it.
+    if (collapsing) {
+      setSelectedMetric((prev) => (prev?.refId === refId ? null : prev));
+    }
   };
+
+  // One callback for every card, so `MetricsList`'s `memo()` holds while the explorer re-renders on
+  // every keystroke in a query editor. Hence the card identifying itself in the argument.
+  const selectMetric = useCallback((selection: MetricSelection) => {
+    // Re-picking the open metric closes the panel, which is what `aria-pressed` on the row announces.
+    setSelectedMetric((prev) =>
+      prev?.refId === selection.refId && prev.metric.name === selection.metric.name ? null : selection
+    );
+  }, []);
 
   const jumpToQuery = (refId: string) => {
     // Query rows register themselves as children of the Queries outline item, so
@@ -175,12 +215,29 @@ export function SignalExplorer({ queries, paneDatasource, timeRange, scroller, t
                 onToggleExpanded={() => toggleExpanded(card.refId)}
                 onJumpToQuery={() => jumpToQuery(card.refId)}
               >
-                <MetricsList dsUid={card.dsUid} dsType={card.dsType} timeRange={timeRange} />
+                <MetricsList
+                  refId={card.refId}
+                  dsUid={card.dsUid}
+                  dsType={card.dsType}
+                  timeRange={timeRange}
+                  selectedMetric={selectedMetric?.refId === card.refId ? selectedMetric.metric.name : undefined}
+                  onSelectMetric={selectMetric}
+                />
               </SignalCard>
             ))
           )}
         </div>
       </ScrollContainer>
+
+      {/* A sibling of the scroll region, not the last thing inside it, so it stays put while the
+          cards scroll. */}
+      {selectedMetric && (
+        <MetricDetailPanel
+          refId={selectedMetric.refId}
+          metric={selectedMetric.metric}
+          onClose={() => setSelectedMetric(null)}
+        />
+      )}
     </div>
   );
 }

--- a/public/app/features/explore/SignalExplorer/types.ts
+++ b/public/app/features/explore/SignalExplorer/types.ts
@@ -9,3 +9,13 @@ export interface MetricInfo {
   help?: string;
   unit?: string;
 }
+
+/**
+ * The metric the sidebar's detail panel is showing. Carried by value so the panel costs no request,
+ * and tagged with the card it came from, whose catalog is the only one it is true of.
+ */
+export interface MetricSelection {
+  refId: string;
+  dsUid?: string;
+  metric: MetricInfo;
+}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8677,6 +8677,11 @@
     "logs-volumne-panel-list": {
       "body-no-logs-volume-available": "No volume information available for the current queries and time range."
     },
+    "metric-detail-panel": {
+      "aria-label": "Metric details",
+      "close": "Close metric details",
+      "from-query": "Query {{refId}}"
+    },
     "metrics-list": {
       "collapse-metric": "Collapse {{name}}",
       "error": "Failed to load metrics",
@@ -8689,6 +8694,7 @@
       "loading-values": "Loading values…",
       "no-metrics": "No metrics found",
       "search-placeholder": "Search metrics",
+      "show-metric-details": "Show details for {{name}}",
       "show-more": "Show more",
       "show-more-metrics": "Show more metrics",
       "show-more-values": "Show more values",


### PR DESCRIPTION
## Description
<!--- A high level description of what this PR is doing -->
Selecting a metric in the signal explorer now opens a detail panel pinned to the bottom of the sidebar, showing the metric's type, name and description. Also fixes a pre-existing layout bug this surfaced, where the content outline's jump links were pushed into a scroll region when a datasource was expanded.

## Changes
<!--- Describe your changes in detail -->
* Adds `MetricDetailPanel`, pinned below the card list, which gives up exactly the height the panel takes.
* Splits a metric row into two controls: the chevron expands labels in place, the name opens the detail panel.
* Clears the selection when its query's card leaves the pane or switches to a different datasource, so the panel never shows a metric from another catalog.
* Stops the content outline shrinking in its flex column, capped so a long outline scrolls only once the explorer is down to a usable floor.

## Risks
<!--- Describe what risks you've considered i.e. what features are most likely to break -->
The outline change touches shared Explore sidebar layout, so the outline and the signal explorer could compete for height on short viewports. The cap is a `max()` with a 50% floor so neither can collapse the other entirely.

## Demo
<!--- Attach a demo gif/video or screenshots of the changes if applicable -->
<img width="1980" height="1010" alt="image" src="https://github.com/user-attachments/assets/51d159b0-99e8-4bbe-ad93-5761cd6f40f4" />

## Testing Instructions
<!--- Provide step by step instructions and the dashboard if applicable -->
* Open Explore with a Prometheus datasource and the signal explorer sidebar visible.
* Expand a query card, then click a metric name — the detail panel opens at the bottom and the card list shrinks to make room.
* Click the chevron on a row instead and confirm it expands labels without opening the panel.
* Expand several datasources and confirm the outline's jump links stay put rather than scrolling.
* Switch the query to a different Prometheus datasource and confirm the panel closes.

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable

Close DPRO-218