### PR TITLE
chore: add a comment to the external PR notify trigger

### DIFF
--- a/.github/workflows/external-pr-notify-trigger.yml
+++ b/.github/workflows/external-pr-notify-trigger.yml
@@ -13,6 +13,7 @@ on:
 permissions:
   contents: read
 
+# One run per PR; the handler does the routing work.
 concurrency:
   group: notify-pr-trigger-${{ github.event.pull_request.number }}
   cancel-in-progress: false


### PR DESCRIPTION
Checking which automation applies the pr/external label on a same-repo branch. Will close once recorded.