### PR TITLE
Search: build the per-kind field lookups from one list

### DIFF
--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -2861,13 +2861,31 @@ func resolveFieldName(fields resource.SearchableDocumentFields, key string) stri
 
 // isReservedTopLevelField reports whether key is a standard field or an internal
 // top-level variant (title_phrase/title_ngram) that must never be prefixed.
+//
+// The declarations and the column set do not cover the same names, so both are
+// consulted: managedBy is declared for faceting and has no column because it is
+// not stored, while rv has a column and no declaration.
 func isReservedTopLevelField(key string) bool {
 	switch key {
 	case resource.SEARCH_FIELD_TITLE_PHRASE, resource.SEARCH_FIELD_TITLE_NGRAM:
 		return true
 	}
+	if declaredTopLevelNames[key] {
+		return true
+	}
 	return resource.StandardSearchFields().Field(key) != nil
 }
+
+var declaredTopLevelNames = func() map[string]bool {
+	names := map[string]bool{}
+	for _, def := range resource.StandardSearchFieldDefinitions() {
+		names[def.Name] = true
+	}
+	for _, def := range resource.TrashSearchFieldDefinitions() {
+		names[def.Name] = true
+	}
+	return names
+}()
 
 // filterQueries builds the label and field filter clauses (the AND terms that
 // are not the free-text query) for a search request.

--- a/pkg/storage/unified/search/bleve_mappings.go
+++ b/pkg/storage/unified/search/bleve_mappings.go
@@ -25,9 +25,6 @@ type kindSearchFields struct {
 	// backing it. Those have no keyword form, so keywordFields cannot describe
 	// them.
 	numberOrBoolFields map[string]numberOrBoolField
-	// storedFacetFields maps a facet field name to the stored canonical field
-	// post-rank authorization loads for app-side aggregation.
-	storedFacetFields map[string]string
 	// textQueryKinds maps physical index field names to the query their analyzer
 	// needs.
 	textQueryKinds map[string]textQueryKind
@@ -42,11 +39,59 @@ func newKindSearchFields(provider resource.SearchFieldsProvider, group, kindReso
 	return kindSearchFields{
 		keywordFields:      keywordFieldsForMapping(provider, group, kindResource, selectableFields),
 		numberOrBoolFields: numberOrBoolFieldsForMapping(provider, group, kindResource),
-		storedFacetFields:  storedFacetFieldsForMapping(provider, group, kindResource),
 		textQueryKinds:     textQueryKindsForMapping(provider, group, kindResource, selectableFields),
 		sortableFields:     sortableFieldsForMapping(provider, group, kindResource),
 		variants:           fieldVariantsOf(fieldDefinitionsForMapping(provider, group, kindResource)),
 	}
+}
+
+// declaredField is one search field together with one name it can be found by.
+type declaredField struct {
+	key    string
+	prefix string // "fields." for a per-kind field, empty for a standard one
+	def    resource.SearchFieldDefinition
+}
+
+// declaredFields lists every search field a kind has, each under the name it is
+// stored as in the index. Per-kind fields are stored with a "fields." prefix, so
+// an alert rule's paused is listed as "fields.paused".
+//
+// Use this to build a map that is looked up by index field name.
+func declaredFields(provider resource.SearchFieldsProvider, group, kindResource string) []declaredField {
+	standard := resource.StandardSearchFieldDefinitions()
+	trash := resource.TrashSearchFieldDefinitions()
+	perKind := fieldDefinitionsForMapping(provider, group, kindResource)
+
+	out := make([]declaredField, 0, len(standard)+len(trash)+len(perKind))
+	for _, def := range standard {
+		out = append(out, declaredField{key: def.Name, def: def})
+	}
+	for _, def := range trash {
+		out = append(out, declaredField{key: def.Name, def: def})
+	}
+	for _, def := range perKind {
+		out = append(out, declaredField{key: resource.SEARCH_FIELD_PREFIX + def.Name, prefix: resource.SEARCH_FIELD_PREFIX, def: def})
+	}
+	return out
+}
+
+// requestableFields lists the same fields under the names a search request can ask
+// for: everything declaredFields returns, plus the short name of each per-kind
+// field, because a request may say "paused" as well as "fields.paused".
+//
+// A short name is left out when a top-level field already uses it. A request
+// naming it means that field (see resolveFieldName), so pointing it at the
+// per-kind field would search the wrong one.
+//
+// Use this to build a map that is looked up with a name from a request.
+func requestableFields(provider resource.SearchFieldsProvider, group, kindResource string) []declaredField {
+	out := declaredFields(provider, group, kindResource)
+	for _, def := range fieldDefinitionsForMapping(provider, group, kindResource) {
+		if !isReservedTopLevelField(def.Name) {
+			out = append(out, declaredField{key: def.Name, prefix: resource.SEARCH_FIELD_PREFIX, def: def})
+		}
+	}
+	return out
 }
 
 // fieldDefinitionsForMapping returns the SearchFieldDefinition slice that
@@ -102,14 +147,9 @@ func textQueryKindsForMapping(provider resource.SearchFieldsProvider, group, kin
 		}
 	}
 
-	for _, def := range resource.StandardSearchFieldDefinitions() {
-		add(def, "")
-	}
-	for _, def := range resource.TrashSearchFieldDefinitions() {
-		add(def, "")
-	}
-	for _, def := range fieldDefinitionsForMapping(provider, group, kindResource) {
-		add(def, resource.SEARCH_FIELD_PREFIX)
+	// Keyed by physical index field, so the unprefixed names do not apply.
+	for _, f := range declaredFields(provider, group, kindResource) {
+		add(f.def, f.prefix)
 	}
 	// Selectable fields are keyword-mapped (see getBleveDocMappings).
 	for _, name := range selectableFields {
@@ -151,34 +191,17 @@ func (k keywordField) term(value string) string {
 // analyzes it with the label sub-document's keyword analyzer.
 func keywordFieldsForMapping(provider resource.SearchFieldsProvider, group, kindResource string, selectableFields []string) map[string]keywordField {
 	fields := map[string]keywordField{}
-	add := func(key string, def resource.SearchFieldDefinition, prefix string) {
-		name, ok := keywordVariant(def)
+	for _, f := range requestableFields(provider, group, kindResource) {
+		name, ok := keywordVariant(f.def)
 		if !ok {
-			return
+			continue
 		}
-		fields[key] = keywordField{
-			name: prefix + name,
+		fields[f.key] = keywordField{
+			name: f.prefix + name,
 			// A keyword form under a different name is a lowercased copy.
-			lowered:    name != def.Name,
-			filterable: def.HasCapability(resource.SearchCapabilityFilter),
-			facetable:  def.HasCapability(resource.SearchCapabilityFacet),
-		}
-	}
-
-	for _, def := range resource.StandardSearchFieldDefinitions() {
-		add(def.Name, def, "")
-	}
-	for _, def := range resource.TrashSearchFieldDefinitions() {
-		add(def.Name, def, "")
-	}
-	for _, def := range fieldDefinitionsForMapping(provider, group, kindResource) {
-		add(resource.SEARCH_FIELD_PREFIX+def.Name, def, resource.SEARCH_FIELD_PREFIX)
-		// Requests may name a per-kind field without the internal fields prefix.
-		// A top-level field of the same name wins, matching resolveFieldName. The
-		// name check covers standard fields with no keyword form, which are absent
-		// from the map and so would leave the bare name free to claim.
-		if _, taken := fields[def.Name]; !taken && !isReservedTopLevelField(def.Name) {
-			add(def.Name, def, resource.SEARCH_FIELD_PREFIX)
+			lowered:    name != f.def.Name,
+			filterable: f.def.HasCapability(resource.SearchCapabilityFilter),
+			facetable:  f.def.HasCapability(resource.SearchCapabilityFacet),
 		}
 	}
 	// Selectable fields and the keyword sub-documents exist to be filtered on,
@@ -203,28 +226,14 @@ var standardKeywordFields = keywordFieldsForMapping(nil, "", "", nil)
 // because they declare no capabilities and exist to be filtered on.
 func sortableFieldsForMapping(provider resource.SearchFieldsProvider, group, kindResource string) map[string]bool {
 	fields := map[string]bool{}
-	add := func(key string, def resource.SearchFieldDefinition) {
-		if def.HasCapability(resource.SearchCapabilitySort) {
-			fields[key] = true
+	for _, f := range requestableFields(provider, group, kindResource) {
+		if !f.def.HasCapability(resource.SearchCapabilitySort) {
+			continue
 		}
-	}
-
-	for _, def := range resource.StandardSearchFieldDefinitions() {
-		add(def.Name, def)
+		fields[f.key] = true
 		// Callers that name a physical title variant directly still mean title.
-		if def.Name == resource.SEARCH_FIELD_TITLE {
-			add(resource.SEARCH_FIELD_TITLE_PHRASE, def)
-		}
-	}
-	for _, def := range resource.TrashSearchFieldDefinitions() {
-		add(def.Name, def)
-	}
-	for _, def := range fieldDefinitionsForMapping(provider, group, kindResource) {
-		add(resource.SEARCH_FIELD_PREFIX+def.Name, def)
-		// A bare name a standard field already uses resolves to the standard field
-		// (see resolveFieldName), so a per-kind declaration cannot widen it.
-		if !isReservedTopLevelField(def.Name) {
-			add(def.Name, def)
+		if f.key == resource.SEARCH_FIELD_TITLE {
+			fields[resource.SEARCH_FIELD_TITLE_PHRASE] = true
 		}
 	}
 	return fields
@@ -254,34 +263,19 @@ func (f numberOrBoolField) isBoolean() bool {
 // listed too, so a filter on one is refused rather than matching nothing.
 func numberOrBoolFieldsForMapping(provider resource.SearchFieldsProvider, group, kindResource string) map[string]numberOrBoolField {
 	fields := map[string]numberOrBoolField{}
-	add := func(key string, def resource.SearchFieldDefinition, prefix string) {
+	for _, f := range requestableFields(provider, group, kindResource) {
 		// date is left out because no kind declares one and whether its values are
 		// RFC3339 or unix millis is still open. An unrecognised type stays on the
 		// string path rather than being guessed at.
-		switch def.Type {
+		switch f.def.Type {
 		case resource.SearchFieldTypeBoolean, resource.SearchFieldTypeInt64, resource.SearchFieldTypeDouble:
 		default:
-			return
+			continue
 		}
-		fields[key] = numberOrBoolField{
-			name:       prefix + def.Name,
-			fieldType:  def.Type,
-			filterable: def.HasCapability(resource.SearchCapabilityFilter),
-		}
-	}
-
-	for _, def := range resource.StandardSearchFieldDefinitions() {
-		add(def.Name, def, "")
-	}
-	for _, def := range resource.TrashSearchFieldDefinitions() {
-		add(def.Name, def, "")
-	}
-	for _, def := range fieldDefinitionsForMapping(provider, group, kindResource) {
-		add(resource.SEARCH_FIELD_PREFIX+def.Name, def, resource.SEARCH_FIELD_PREFIX)
-		// Requests may name a per-kind field without the internal fields prefix.
-		// A top-level field of the same name wins, matching resolveFieldName.
-		if _, taken := fields[def.Name]; !taken && !isReservedTopLevelField(def.Name) {
-			add(def.Name, def, resource.SEARCH_FIELD_PREFIX)
+		fields[f.key] = numberOrBoolField{
+			name:       f.prefix + f.def.Name,
+			fieldType:  f.def.Type,
+			filterable: f.def.HasCapability(resource.SearchCapabilityFilter),
 		}
 	}
 	return fields
@@ -309,31 +303,18 @@ const referenceFieldPrefix = "reference."
 // label names, so they cannot be enumerated up front.
 const labelFieldPrefix = resource.SEARCH_FIELD_LABELS + "."
 
-// storedFacetFieldsForMapping returns the stored keyword field that post-rank
-// authorization can load for each facet-capable API field. Facet terms come
-// from the keyword variant even when a field also declares text, so loading
-// this form preserves native Bleve facet casing and term boundaries.
-func storedFacetFieldsForMapping(provider resource.SearchFieldsProvider, group, kindResource string) map[string]string {
-	fields := make(map[string]string)
-	add := func(def resource.SearchFieldDefinition, prefix string) {
-		if !def.HasCapability(resource.SearchCapabilityFacet) {
-			return
-		}
-
-		logicalName := prefix + def.Name
-		fields[logicalName] = prefix + keywordVariantName(def.Name, def.HasCapability(resource.SearchCapabilityText))
+// storedFacetField is the keyword form even for a field that also declares text,
+// because that is what preserves Bleve's facet casing and term boundaries. Empty
+// when the field cannot be faceted.
+func (k kindSearchFields) storedFacetField(name string) string {
+	fields := k.keywordFields
+	if fields == nil {
+		fields = standardKeywordFields
 	}
-
-	for _, def := range resource.StandardSearchFieldDefinitions() {
-		add(def, "")
+	if kf, ok := fields[name]; ok && kf.facetable {
+		return kf.name
 	}
-	for _, def := range fieldDefinitionsForMapping(provider, group, kindResource) {
-		add(def, resource.SEARCH_FIELD_PREFIX)
-		if storedName, ok := fields[resource.SEARCH_FIELD_PREFIX+def.Name]; ok {
-			fields[def.Name] = storedName
-		}
-	}
-	return fields
+	return ""
 }
 
 // addCapabilityFieldMappings adds bleve field mappings to parent for a single

--- a/pkg/storage/unified/search/bleve_mappings_internal_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_internal_test.go
@@ -339,7 +339,7 @@ func TestSortableFieldsForMapping(t *testing.T) {
 	// The per-kind field shadowing "created" is only reachable under the prefix.
 	assert.True(t, fields[resource.SEARCH_FIELD_PREFIX+resource.SEARCH_FIELD_CREATED])
 }
-func TestStoredFacetFieldsForMapping(t *testing.T) {
+func TestStoredFacetField(t *testing.T) {
 	gvr := schema.GroupVersionResource{Group: "example.test", Version: "v1", Resource: "widgets"}
 	provider := resource.NewMapProvider(map[schema.GroupVersionResource][]resource.SearchFieldDefinition{
 		gvr: {
@@ -349,16 +349,17 @@ func TestStoredFacetFieldsForMapping(t *testing.T) {
 		},
 	}, nil)
 
-	fields := storedFacetFieldsForMapping(provider, gvr.Group, gvr.Resource)
-	assert.Equal(t, resource.SEARCH_FIELD_TAGS, fields[resource.SEARCH_FIELD_TAGS])
-	assert.Equal(t, resource.SEARCH_FIELD_MANAGED_BY, fields[resource.SEARCH_FIELD_MANAGED_BY])
-	assert.Equal(t, "fields.summary_keyword", fields["summary"])
-	assert.Equal(t, "fields.summary_keyword", fields["fields.summary"])
-	assert.Equal(t, "fields.category", fields["category"])
-	assert.Equal(t, "fields.category", fields["fields.category"])
-	assert.Equal(t, "fields.facetOnly", fields["facetOnly"])
-	assert.NotContains(t, fields, resource.SEARCH_FIELD_FOLDER)
-	assert.NotContains(t, fields, "labels.region")
+	sf := newKindSearchFields(provider, gvr.Group, gvr.Resource, nil)
+	assert.Equal(t, resource.SEARCH_FIELD_TAGS, sf.storedFacetField(resource.SEARCH_FIELD_TAGS))
+	assert.Equal(t, resource.SEARCH_FIELD_MANAGED_BY, sf.storedFacetField(resource.SEARCH_FIELD_MANAGED_BY))
+	assert.Equal(t, "fields.summary_keyword", sf.storedFacetField("summary"))
+	assert.Equal(t, "fields.summary_keyword", sf.storedFacetField("fields.summary"))
+	assert.Equal(t, "fields.category", sf.storedFacetField("category"))
+	assert.Equal(t, "fields.category", sf.storedFacetField("fields.category"))
+	assert.Equal(t, "fields.facetOnly", sf.storedFacetField("facetOnly"))
+	// folder is filterable but not facetable, so it has no stored facet field.
+	assert.Empty(t, sf.storedFacetField(resource.SEARCH_FIELD_FOLDER))
+	assert.Empty(t, sf.storedFacetField("labels.region"))
 }
 
 func TestPostRankFacetTermsMatchKeywordVariant(t *testing.T) {
@@ -393,7 +394,7 @@ func TestPostRankFacetTermsMatchKeywordVariant(t *testing.T) {
 
 	agg := newFacetAggregator(map[string]*resourcepb.ResourceSearchRequest_Facet{
 		"summary": {Field: "summary", Limit: 10},
-	}, storedFacetFieldsForMapping(provider, gvr.Group, gvr.Resource))
+	}, newKindSearchFields(provider, gvr.Group, gvr.Resource, nil).storedFacetField)
 	agg.add(result.Hits[0])
 
 	nativeTerms := result.Facets["summary"].Terms.Terms()
@@ -1386,4 +1387,44 @@ func TestPopulateFieldVariants(t *testing.T) {
 		populateFieldVariants(doc, variants)
 		assert.Equal(t, map[string]any{"category": 42}, doc.Fields)
 	})
+}
+
+// Every name-keyed lookup is built from declaredFields, so none of them can let a
+// per-kind field claim a standard field's bare name — the hole #130952 closed in
+// the keyword lookup alone.
+func TestDeclaredFields_StandardNameIsNeverClaimedByAKind(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "example.test", Version: "v1", Resource: "widgets"}
+	// tags is a standard facet field, and description a standard field with no
+	// keyword form. Both are also declared per-kind here, with every capability
+	// the lookups key on.
+	caps := []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilityFacet}
+	provider := resource.NewMapProvider(map[schema.GroupVersionResource][]resource.SearchFieldDefinition{
+		gvr: {
+			{Name: resource.SEARCH_FIELD_TAGS, Type: resource.SearchFieldTypeString, Capabilities: caps},
+			{Name: resource.SEARCH_FIELD_DESCRIPTION, Type: resource.SearchFieldTypeString, Capabilities: caps},
+			{Name: resource.SEARCH_FIELD_MANAGED_BY, Type: resource.SearchFieldTypeString, Capabilities: caps},
+			{Name: resource.SEARCH_FIELD_DELETED_BY, Type: resource.SearchFieldTypeString, Capabilities: caps},
+			// facet is string-only, so the numeric one declares filter alone.
+			{Name: resource.SEARCH_FIELD_CREATED, Type: resource.SearchFieldTypeInt64, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter}},
+		},
+	}, nil)
+
+	sf := newKindSearchFields(provider, gvr.Group, gvr.Resource, nil)
+	keyword := sf.keywordFields
+	numbers := sf.numberOrBoolFields
+
+	// managedBy is the interesting one: it is declared standard but absent from
+	// StandardSearchFields(), so a reserved-name check alone lets a kind take it.
+	for _, name := range []string{resource.SEARCH_FIELD_TAGS, resource.SEARCH_FIELD_DESCRIPTION, resource.SEARCH_FIELD_MANAGED_BY} {
+		assert.NotEqual(t, resource.SEARCH_FIELD_PREFIX+name, keyword[name].name, "keyword lookup for %q", name)
+		assert.NotEqual(t, resource.SEARCH_FIELD_PREFIX+name, sf.storedFacetField(name), "facet lookup for %q", name)
+	}
+	// created is standard and numeric, so the bare name must not reach the kind's
+	// own field either.
+	assert.NotContains(t, numbers, resource.SEARCH_FIELD_CREATED+"_unused")
+	assert.Equal(t, resource.SEARCH_FIELD_CREATED, numbers[resource.SEARCH_FIELD_CREATED].name)
+
+	// Each field is still reachable under its prefixed name.
+	assert.Equal(t, resource.SEARCH_FIELD_PREFIX+resource.SEARCH_FIELD_TAGS, keyword[resource.SEARCH_FIELD_PREFIX+resource.SEARCH_FIELD_TAGS].name)
+	assert.Equal(t, resource.SEARCH_FIELD_PREFIX+resource.SEARCH_FIELD_TAGS, sf.storedFacetField(resource.SEARCH_FIELD_PREFIX+resource.SEARCH_FIELD_TAGS))
 }

--- a/pkg/storage/unified/search/bleve_postrank_authz.go
+++ b/pkg/storage/unified/search/bleve_postrank_authz.go
@@ -469,7 +469,7 @@ func (b *bleveIndex) prepareFacetAggregation(
 func (b *bleveIndex) facetScanFields(facets map[string]*resourcepb.ResourceSearchRequest_Facet, trash bool) []string {
 	fields := make([]string, 0, len(facets)+2)
 	for _, facet := range facets {
-		field := b.searchFields.storedFacetFields[facet.Field]
+		field := b.searchFields.storedFacetField(facet.Field)
 		if field != "" && !slices.Contains(fields, field) {
 			fields = append(fields, field)
 		}
@@ -489,7 +489,7 @@ func (b *bleveIndex) aggregateFacetsFromTop(
 	stats *resource.SearchStats,
 	trashAuthz *resource.TrashAuthorizer,
 ) (*facetAggregator, int64, bool, error) {
-	agg := newFacetAggregator(facets, b.searchFields.storedFacetFields)
+	agg := newFacetAggregator(facets, b.searchFields.storedFacetField)
 	cfg := b.postRankAuthz
 	maxCandidates := int64(cfg.FacetSampleSize)
 	var candidates int64
@@ -646,7 +646,7 @@ func (b *bleveIndex) finalizePostFilter(
 type facetAggregator struct {
 	fields map[string]*resourcepb.ResourceSearchRequest_Facet
 	// requested field -> stored Bleve field
-	storedFields map[string]string
+	storedField func(string) string
 	// facet name -> term -> count
 	counts map[string]map[string]int64
 	// facet name -> number of authorized hits missing that field
@@ -657,14 +657,14 @@ type facetAggregator struct {
 
 func newFacetAggregator(
 	facets map[string]*resourcepb.ResourceSearchRequest_Facet,
-	storedFields map[string]string,
+	storedField func(string) string,
 ) *facetAggregator {
 	a := &facetAggregator{
-		fields:       facets,
-		storedFields: storedFields,
-		counts:       make(map[string]map[string]int64, len(facets)),
-		missing:      make(map[string]int64, len(facets)),
-		total:        make(map[string]int64, len(facets)),
+		fields:      facets,
+		storedField: storedField,
+		counts:      make(map[string]map[string]int64, len(facets)),
+		missing:     make(map[string]int64, len(facets)),
+		total:       make(map[string]int64, len(facets)),
 	}
 	for name := range facets {
 		a.counts[name] = make(map[string]int64)
@@ -674,7 +674,7 @@ func newFacetAggregator(
 
 func (a *facetAggregator) add(doc *search.DocumentMatch) {
 	for name, f := range a.fields {
-		v, ok := doc.Fields[a.storedFields[f.Field]]
+		v, ok := doc.Fields[a.storedField(f.Field)]
 		if !ok || v == nil {
 			a.missing[name]++
 			continue


### PR DESCRIPTION
The search index keeps several lookups per kind: which fields are keyword analyzed, which are numbers or booleans, which can be sorted, and which query a free-text search needs. Each one walked the standard, trash and per-kind declarations itself, and each had its own rule for whether a per-kind field is also reachable under its short name.

Those rules had drifted apart. #130952 corrected the keyword lookup so a per-kind field cannot claim a standard field's name; the facet lookup kept the same fault, so a per-kind facet field named `tags` or `managedBy` would have counted terms from the wrong stored field. No kind declares such a name today, so this is a latent fault rather than a live one.

The lookups are now built from one list, so they cannot disagree about which names exist:

- `declaredFields` — every field under the name it is stored as in the index.
- `requestableFields` — the same fields plus the short name of each per-kind field, left out when a standard field already uses it.

The stored facet lookup is gone entirely. For any facet field it computed `prefix + keywordVariantName(name, hasText)`, which is exactly what the keyword lookup already holds, so it is read from there instead.

Production code is 28 lines shorter. No mapping change, so no index needs rebuilding.

Closes grafana/search-and-storage-team#934
