### PR TITLE
Chore: clear xorm session statement when a query is not run

### DIFF
--- a/pkg/util/xorm/rows.go
+++ b/pkg/util/xorm/rows.go
@@ -113,6 +113,9 @@ func (rows *Rows) Close() error {
 		defer rows.session.Close()
 	}
 
+	// Scan puts the scanned table back on the statement, so clear it once we are done reading.
+	defer rows.session.resetStatement()
+
 	if rows.rows != nil {
 		return rows.rows.Close()
 	}

--- a/pkg/util/xorm/session_delete.go
+++ b/pkg/util/xorm/session_delete.go
@@ -16,6 +16,8 @@ func (session *Session) Delete(bean any) (int64, error) {
 		defer session.Close()
 	}
 
+	defer session.resetStatement()
+
 	if session.statement.lastError != nil {
 		return 0, session.statement.lastError
 	}

--- a/pkg/util/xorm/session_exist.go
+++ b/pkg/util/xorm/session_exist.go
@@ -19,6 +19,8 @@ func (session *Session) Exist(bean ...any) (bool, error) {
 		defer session.Close()
 	}
 
+	defer session.resetStatement()
+
 	if session.statement.lastError != nil {
 		return false, session.statement.lastError
 	}

--- a/pkg/util/xorm/session_insert.go
+++ b/pkg/util/xorm/session_insert.go
@@ -270,6 +270,8 @@ func (session *Session) InsertMulti(rowsSlicePtr any) (int64, error) {
 		defer session.Close()
 	}
 
+	defer session.resetStatement()
+
 	sliceValue := reflect.Indirect(reflect.ValueOf(rowsSlicePtr))
 	if sliceValue.Kind() != reflect.Slice {
 		return 0, ErrParamsType
@@ -564,6 +566,8 @@ func (session *Session) InsertOne(bean any) (int64, error) {
 	if session.isAutoClose {
 		defer session.Close()
 	}
+
+	defer session.resetStatement()
 
 	return session.innerInsert(bean)
 }

--- a/pkg/util/xorm/session_iterate.go
+++ b/pkg/util/xorm/session_iterate.go
@@ -30,6 +30,9 @@ func (session *Session) Iterate(bean interface{}, fun IterFunc) error {
 		defer session.Close()
 	}
 
+	// Runs after bufferIterate has restored autoResetStatement, so the buffered path is covered too.
+	defer session.resetStatement()
+
 	if session.statement.lastError != nil {
 		return session.statement.lastError
 	}

--- a/pkg/util/xorm/session_iterate.go
+++ b/pkg/util/xorm/session_iterate.go
@@ -14,7 +14,12 @@ type IterFunc func(idx int, bean interface{}) error
 // Rows return sql.Rows compatible Rows obj, as a forward Iterator object for iterating record by record, bean's non-empty fields
 // are conditions.
 func (session *Session) Rows(bean interface{}) (*Rows, error) {
-	return newRows(session, bean)
+	rows, err := newRows(session, bean)
+	if err != nil {
+		// A successful query clears the statement itself, a failed one before the query does not.
+		session.resetStatement()
+	}
+	return rows, err
 }
 
 // Iterate record by record handle records from table, condiBeans's non-empty fields

--- a/pkg/util/xorm/session_query.go
+++ b/pkg/util/xorm/session_query.go
@@ -83,6 +83,8 @@ func (session *Session) Query(sqlOrArgs ...interface{}) ([]map[string][]byte, er
 		defer session.Close()
 	}
 
+	defer session.resetStatement()
+
 	sqlStr, args, err := session.genQuerySQL(sqlOrArgs...)
 	if err != nil {
 		return nil, err
@@ -238,6 +240,8 @@ func (session *Session) QueryString(sqlOrArgs ...interface{}) ([]map[string]stri
 		defer session.Close()
 	}
 
+	defer session.resetStatement()
+
 	sqlStr, args, err := session.genQuerySQL(sqlOrArgs...)
 	if err != nil {
 		return nil, err
@@ -257,6 +261,8 @@ func (session *Session) QuerySliceString(sqlOrArgs ...interface{}) ([][]string, 
 	if session.isAutoClose {
 		defer session.Close()
 	}
+
+	defer session.resetStatement()
 
 	sqlStr, args, err := session.genQuerySQL(sqlOrArgs...)
 	if err != nil {
@@ -313,6 +319,8 @@ func (session *Session) QueryInterface(sqlOrArgs ...interface{}) ([]map[string]i
 	if session.isAutoClose {
 		defer session.Close()
 	}
+
+	defer session.resetStatement()
 
 	sqlStr, args, err := session.genQuerySQL(sqlOrArgs...)
 	if err != nil {

--- a/pkg/util/xorm/session_reset_test.go
+++ b/pkg/util/xorm/session_reset_test.go
@@ -1,0 +1,127 @@
+package xorm
+
+import (
+	"testing"
+
+	_ "github.com/grafana/grafana/pkg/util/sqlite"
+	"github.com/grafana/grafana/pkg/util/xorm/core"
+	"github.com/stretchr/testify/require"
+)
+
+type LeakRule struct {
+	Id    int64
+	Guid  string
+	Title string
+}
+
+type LeakUser struct {
+	Id  int64
+	Uid string
+}
+
+func newLeakEngine(t *testing.T) *Engine {
+	t.Helper()
+
+	eng, err := NewEngine("sqlite3", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, eng.Close()) })
+
+	_, err = eng.Exec("CREATE TABLE leak_rule (id INTEGER PRIMARY KEY, guid TEXT, title TEXT)")
+	require.NoError(t, err)
+	_, err = eng.Exec("CREATE TABLE leak_user (id INTEGER PRIMARY KEY, uid TEXT)")
+	require.NoError(t, err)
+	_, err = eng.Exec("INSERT INTO leak_rule (id, guid, title) VALUES (1, 'g1', 't1')")
+	require.NoError(t, err)
+	_, err = eng.Exec("INSERT INTO leak_user (id, uid) VALUES (1, 'u1')")
+	require.NoError(t, err)
+
+	return eng
+}
+
+// Sessions are shared between services through the request context, so state left
+// on the session by one query must not change the next query on an unrelated table.
+func TestSessionStateDoesNotLeakBetweenOperations(t *testing.T) {
+	t.Run("after Rows", func(t *testing.T) {
+		eng := newLeakEngine(t)
+		sess := eng.NewSession()
+		defer sess.Close()
+
+		rows, err := sess.Table("leak_rule").Rows(new(LeakRule))
+		require.NoError(t, err)
+		require.True(t, rows.Next())
+		require.NoError(t, rows.Close())
+
+		var users []LeakUser
+		require.NoError(t, sess.Table("leak_user").Find(&users))
+		require.Len(t, users, 1)
+	})
+
+	t.Run("after Update", func(t *testing.T) {
+		eng := newLeakEngine(t)
+		sess := eng.NewSession()
+		defer sess.Close()
+
+		updated, err := sess.Table(LeakRule{}).ID(1).AllCols().Omit("guid").Update(&LeakRule{Title: "t2"})
+		require.NoError(t, err)
+		require.Equal(t, int64(1), updated)
+
+		var users []LeakUser
+		require.NoError(t, sess.Table("leak_user").Find(&users))
+		require.Len(t, users, 1)
+	})
+
+	t.Run("after Delete", func(t *testing.T) {
+		eng := newLeakEngine(t)
+		sess := eng.NewSession()
+		defer sess.Close()
+
+		_, err := sess.Table(LeakRule{}).ID(1).Delete(&LeakRule{})
+		require.NoError(t, err)
+
+		var users []LeakUser
+		require.NoError(t, sess.Table("leak_user").Find(&users))
+		require.Len(t, users, 1)
+	})
+
+	// These operations return before they reach the database, which used to leave the
+	// table and column list behind on the session.
+	t.Run("after Update that has nothing to update", func(t *testing.T) {
+		eng := newLeakEngine(t)
+		sess := eng.NewSession()
+		defer sess.Close()
+
+		_, err := sess.Table(LeakRule{}).ID(1).Cols("unknown_column").Update(&LeakRule{})
+		require.Error(t, err)
+
+		var users []LeakUser
+		require.NoError(t, sess.Table("leak_user").Find(&users))
+		require.Len(t, users, 1)
+	})
+
+	t.Run("after Rows that fails to build a query", func(t *testing.T) {
+		eng := newLeakEngine(t)
+		sess := eng.NewSession()
+		defer sess.Close()
+
+		_, err := sess.Table(LeakRule{}).ID(core.PK{1, 2}).Rows(new(LeakRule))
+		require.Error(t, err)
+
+		var users []LeakUser
+		require.NoError(t, sess.Table("leak_user").Find(&users))
+		require.Len(t, users, 1)
+	})
+
+	t.Run("after Count", func(t *testing.T) {
+		eng := newLeakEngine(t)
+		sess := eng.NewSession()
+		defer sess.Close()
+
+		count, err := sess.Table(LeakRule{}).Where("guid = ?", "g1").Count()
+		require.NoError(t, err)
+		require.Equal(t, int64(1), count)
+
+		var users []LeakUser
+		require.NoError(t, sess.Table("leak_user").Find(&users))
+		require.Len(t, users, 1)
+	})
+}

--- a/pkg/util/xorm/session_reset_test.go
+++ b/pkg/util/xorm/session_reset_test.go
@@ -49,6 +49,7 @@ func TestSessionStateDoesNotLeakBetweenOperations(t *testing.T) {
 		rows, err := sess.Table("leak_rule").Rows(new(LeakRule))
 		require.NoError(t, err)
 		require.True(t, rows.Next())
+		require.NoError(t, rows.Scan(new(LeakRule)))
 		require.NoError(t, rows.Close())
 
 		var users []LeakUser
@@ -98,6 +99,20 @@ func TestSessionStateDoesNotLeakBetweenOperations(t *testing.T) {
 		require.Len(t, users, 1)
 	})
 
+	t.Run("after InsertMulti with nothing to insert", func(t *testing.T) {
+		eng := newLeakEngine(t)
+		sess := eng.NewSession()
+		defer sess.Close()
+
+		inserted, err := sess.Table(LeakRule{}).Cols("guid").InsertMulti(&[]LeakRule{})
+		require.NoError(t, err)
+		require.Zero(t, inserted)
+
+		var users []LeakUser
+		require.NoError(t, sess.Table("leak_user").Find(&users))
+		require.Len(t, users, 1)
+	})
+
 	t.Run("after Rows that fails to build a query", func(t *testing.T) {
 		eng := newLeakEngine(t)
 		sess := eng.NewSession()
@@ -105,6 +120,24 @@ func TestSessionStateDoesNotLeakBetweenOperations(t *testing.T) {
 
 		_, err := sess.Table(LeakRule{}).ID(core.PK{1, 2}).Rows(new(LeakRule))
 		require.Error(t, err)
+
+		var users []LeakUser
+		require.NoError(t, sess.Table("leak_user").Find(&users))
+		require.Len(t, users, 1)
+	})
+
+	t.Run("after buffered Iterate", func(t *testing.T) {
+		eng := newLeakEngine(t)
+		sess := eng.NewSession()
+		defer sess.Close()
+
+		visited := 0
+		err := sess.Table(LeakRule{}).Cols("guid").BufferSize(1).Iterate(new(LeakRule), func(int, interface{}) error {
+			visited++
+			return nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, 1, visited)
 
 		var users []LeakUser
 		require.NoError(t, sess.Table("leak_user").Find(&users))

--- a/pkg/util/xorm/session_stats.go
+++ b/pkg/util/xorm/session_stats.go
@@ -17,6 +17,8 @@ func (session *Session) Count(bean ...interface{}) (int64, error) {
 		defer session.Close()
 	}
 
+	defer session.resetStatement()
+
 	var sqlStr string
 	var args []interface{}
 	var err error
@@ -44,6 +46,8 @@ func (session *Session) sum(res interface{}, bean interface{}, columnNames ...st
 	if session.isAutoClose {
 		defer session.Close()
 	}
+
+	defer session.resetStatement()
 
 	v := reflect.ValueOf(res)
 	if v.Kind() != reflect.Pointer {

--- a/pkg/util/xorm/session_update.go
+++ b/pkg/util/xorm/session_update.go
@@ -26,6 +26,10 @@ func (session *Session) Update(bean any, condiBean ...any) (int64, error) {
 		defer session.Close()
 	}
 
+	// Sessions are shared between callers, so the statement must be cleared even when
+	// we return before running the query, otherwise the next query reuses this table and columns.
+	defer session.resetStatement()
+
 	if session.statement.lastError != nil {
 		return 0, session.statement.lastError
 	}


### PR DESCRIPTION
Database sessions are shared between callers through the request context. A query that reaches the database clears the session statement on its way out, but several operations left the table name, column list and conditions behind: those that return early before any SQL runs, `Rows.Close` after `Scan` has put the scanned table back on the statement, and the buffered `Iterate` path. The next query on that session inherited them and asked a different table for columns it does not have. On Postgres that fails and aborts the surrounding transaction, so an unrelated write fails right after it.

Clear the statement on every exit path of `Update`, `Delete`, `Count`, `Exist`, `InsertOne`, `InsertMulti`, the `Query` variants and the sum helpers, when `Rows` fails to build a query and when it closes, and after `Iterate`. `Find`, `Get`, `Insert` and `Exec` already did this.

The new test drives each of these and checks that the next query on the same session is unaffected. Every case fails without the fix.

Confirmed against #127899: on v13.1.1 with Postgres, a UI-created folder and four provisioned rule groups, provisioning fails with `column "guid" does not exist (42703)` followed by `current transaction is aborted (25P02)` and Grafana exits. With this change cherry-picked onto the same tag and the same database, provisioning finishes and all four groups are applied.

Fixes #127899
