### PR TITLE
Search: let a caller supply the manifest set for search routes

### DIFF
--- a/pkg/services/apiserver/searchroutes/searchroutes.go
+++ b/pkg/services/apiserver/searchroutes/searchroutes.go
@@ -54,21 +54,20 @@ func Build(
 	builders []builder.APIGroupBuilder,
 	installers []appsdkapiserver.AppInstaller,
 ) []builder.GroupVersionRoutes {
-	// Whether an endpoint is on is read by the caller, because the two servers
-	// that mount them are configured differently: one from an ini file, one from
-	// flags.
-	if (!searchEnabled && !trashEnabled) || index == nil {
-		return nil
-	}
-
 	// Search fields come from the compiled-in app manifests, the same
 	// declarations the index mapping is built from.
-	return build(resource.AppManifests(), searchEnabled, trashEnabled, tracer, index, builders, installers)
+	return BuildFromManifests(resource.AppManifests(), searchEnabled, trashEnabled, tracer, index, builders, installers)
 }
 
-// build takes the manifests as an argument so a test can describe a kind that
-// opts out. No compiled-in manifest does yet.
-func build(
+// BuildFromManifests is Build with the kind declarations supplied by the caller.
+//
+// A host that learns about apps after it starts can pass those manifests here,
+// merged with the compiled-in set, and their kinds are mounted like any other.
+// Build is the same call with only the compiled-in set.
+//
+// The provider is built from the manifests passed in, so a route can only ever
+// validate against the declarations it was mounted from.
+func BuildFromManifests(
 	manifests []app.Manifest,
 	searchEnabled bool,
 	trashEnabled bool,
@@ -77,6 +76,13 @@ func build(
 	builders []builder.APIGroupBuilder,
 	installers []appsdkapiserver.AppInstaller,
 ) []builder.GroupVersionRoutes {
+	// Whether an endpoint is on is read by the caller, because the two servers
+	// that mount them are configured differently: one from an ini file, one from
+	// flags.
+	if (!searchEnabled && !trashEnabled) || index == nil {
+		return nil
+	}
+
 	handler := searchapi.NewHandler(index, resource.NewManifestBackedProvider(manifests), tracer)
 
 	served := servedGroupVersions(builders, installers)

--- a/pkg/services/apiserver/searchroutes/searchroutes_test.go
+++ b/pkg/services/apiserver/searchroutes/searchroutes_test.go
@@ -103,12 +103,12 @@ func TestBuild_SearchFieldsEnrolAKind(t *testing.T) {
 	}
 
 	t.Run("no fields, not enrolled", func(t *testing.T) {
-		assert.Empty(t, paths(build(playlists(nil), true, true, nil, fakeClient{}, builders, nil)))
+		assert.Empty(t, paths(BuildFromManifests(playlists(nil), true, true, nil, fakeClient{}, builders, nil)))
 	})
 
 	t.Run("one field, gets both endpoints", func(t *testing.T) {
 		fields := []app.ManifestVersionKindSearchField{{Name: "interval", Path: "spec.interval", Type: "string"}}
-		got := paths(build(playlists(fields), true, true, nil, fakeClient{}, builders, nil))
+		got := paths(BuildFromManifests(playlists(fields), true, true, nil, fakeClient{}, builders, nil))
 		assert.ElementsMatch(t, []string{"playlists/search", "playlists/trash"}, got[gv.String()])
 	})
 }
@@ -291,25 +291,25 @@ func TestBuild_ManifestOptOutIsHonoured(t *testing.T) {
 	optOut := func(v bool) *bool { return &v }
 
 	t.Run("says nothing, so gets both", func(t *testing.T) {
-		got := paths(build(dashboards(nil), true, true, nil, fakeClient{}, builders, nil))
+		got := paths(BuildFromManifests(dashboards(nil), true, true, nil, fakeClient{}, builders, nil))
 		assert.ElementsMatch(t, []string{"dashboards/search", "dashboards/trash"}, got[gv.String()])
 	})
 
 	t.Run("declines search, keeps trash", func(t *testing.T) {
 		search := &app.ManifestVersionKindSearch{Endpoint: optOut(false)}
-		got := paths(build(dashboards(search), true, true, nil, fakeClient{}, builders, nil))
+		got := paths(BuildFromManifests(dashboards(search), true, true, nil, fakeClient{}, builders, nil))
 		assert.Equal(t, []string{"dashboards/trash"}, got[gv.String()])
 	})
 
 	t.Run("declines trash, keeps search", func(t *testing.T) {
 		search := &app.ManifestVersionKindSearch{Trash: optOut(false)}
-		got := paths(build(dashboards(search), true, true, nil, fakeClient{}, builders, nil))
+		got := paths(BuildFromManifests(dashboards(search), true, true, nil, fakeClient{}, builders, nil))
 		assert.Equal(t, []string{"dashboards/search"}, got[gv.String()])
 	})
 
 	t.Run("declines both", func(t *testing.T) {
 		search := &app.ManifestVersionKindSearch{Endpoint: optOut(false), Trash: optOut(false)}
-		assert.Empty(t, paths(build(dashboards(search), true, true, nil, fakeClient{}, builders, nil)))
+		assert.Empty(t, paths(BuildFromManifests(dashboards(search), true, true, nil, fakeClient{}, builders, nil)))
 	})
 }
 


### PR DESCRIPTION
Search and trash routes are mounted from the app manifests compiled into the binary, so a server that learns about apps after it starts cannot mount routes for their kinds.

This exports the function that already took the manifests as an argument, so a caller can pass its own set. `Build` keeps its signature and passes the compiled-in set, so nothing changes for either server today. The on/off and nil-client guard moved into the exported function so an external caller cannot skip it.

First user will be the multi-tenant apiserver in grafana-enterprise, in a separate change.