### PR TITLE
Dashboards: Apply default_preload to newly created dashboards

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -613,9 +613,10 @@ dashboard_performance_metrics =
 # Maximum number of series that will be showed in a single panel. Users can opt in to rendering all series. Default is 0 (unlimited).
 panel_series_limit =
 
-# Instance-wide default for panel preloading, used only for dashboards that do not explicitly set the "preload" property in their JSON.
-# When true, all panels start loading as soon as the dashboard loads instead of lazy loading as they scroll into view.
-# An explicit "preload" value in the dashboard JSON always takes precedence over this default. Default is false.
+# The "preload" value given to newly created dashboards. When true, a new dashboard starts with all
+# panels loading as soon as it opens, instead of lazy loading them as they scroll into view.
+# The value is saved into the dashboard, so authors can change it afterwards and their choice wins.
+# This only affects dashboards created from now on. Existing dashboards are never changed. Default is false.
 default_preload = false
 
 ################################### Dashboard cleanup ####################

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -512,8 +512,8 @@
 # Path to a custom default home dashboard. If empty, Grafana uses the unified homepage.
 ;default_home_dashboard_path =
 
-# Instance-wide default for panel preloading, used only for dashboards that do not explicitly set the "preload" property.
-# An explicit "preload" value in the dashboard JSON always takes precedence. Default is false.
+# The "preload" value given to newly created dashboards. Saved into the dashboard, so authors can
+# change it afterwards. Existing dashboards are never changed. Default is false.
 ;default_preload = false
 
 ################################### Dashboard cleanup ####################

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -902,7 +902,11 @@ The file may contain either a classic dashboard JSON or a Kubernetes-format dash
 
 #### `default_preload`
 
-Instance-wide default for panel preloading, applied only to dashboards that do not explicitly set the `preload` property in their JSON. When `true`, all panels start loading as soon as the dashboard loads instead of lazy loading as they scroll into view. An explicit `preload` value in the dashboard JSON always takes precedence over this default. Default is `false`.
+The `preload` value given to newly created dashboards. When `true`, a new dashboard starts with all panels loading as soon as it opens, instead of lazy loading them as they scroll into view. Default is `false`.
+
+The value is written into the dashboard when it is created, so authors can change it in dashboard settings afterwards and their choice wins.
+
+This setting only applies to dashboards created after you set it. Existing dashboards keep whatever `preload` value they already have, so turning it on never changes how they behave. It applies to dashboards created in the UI; dashboards created through the API or provisioning use the `preload` value in the payload.
 
 ### `[dashboard_cleanup]`
 

--- a/public/app/features/dashboard-scene/scene/layouts-shared/utils.test.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/utils.test.ts
@@ -17,21 +17,24 @@ describe('getIsLazy', () => {
     config.dashboardDefaultPreload = originalDefault;
   });
 
-  it('is not lazy when preload is explicitly true', () => {
+  it('is not lazy when preload is true', () => {
     expect(getIsLazy(true)).toBe(false);
   });
 
-  it('is lazy when preload is explicitly false, regardless of the instance default', () => {
-    config.dashboardDefaultPreload = true;
+  it('is lazy when preload is false', () => {
     expect(getIsLazy(false)).toBe(true);
   });
 
-  it('falls back to the instance default when preload is undefined', () => {
-    config.dashboardDefaultPreload = false;
+  it('is lazy when preload is undefined', () => {
     expect(getIsLazy(undefined)).toBe(true);
+  });
 
+  // default_preload seeds new dashboards at creation time only. If it were read here, switching it
+  // on would silently change every existing dashboard that has no preload value.
+  it('ignores the instance default', () => {
     config.dashboardDefaultPreload = true;
-    expect(getIsLazy(undefined)).toBe(false);
+    expect(getIsLazy(undefined)).toBe(true);
+    expect(getIsLazy(false)).toBe(true);
   });
 
   it('is never lazy for the image renderer user', () => {

--- a/public/app/features/dashboard-scene/scene/layouts-shared/utils.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/utils.ts
@@ -1,6 +1,5 @@
 import { useEffect, useRef } from 'react';
 
-import { config } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 
 import { type RowItem } from '../layout-rows/RowItem';
@@ -97,11 +96,11 @@ export function ungroupLayout(layout: DashboardLayoutManager, innerLayout: Dashb
 }
 
 export function getIsLazy(preload: boolean | undefined): boolean {
-  // When a dashboard does not explicitly set preload, fall back to the instance-wide default.
-  // Nullish coalescing keeps an explicit `false` authoritative - only undefined defers to the config default.
-  const shouldPreload = preload ?? config.dashboardDefaultPreload;
+  // The dashboard's own value is the only input. [dashboards] default_preload seeds this value when
+  // a dashboard is created; it deliberately has no effect at load time, so turning it on never
+  // changes how existing dashboards behave.
   // We don't want to lazy load panels in the case of image renderer
-  return !(shouldPreload || (contextSrv.user && contextSrv.user.authenticatedBy === 'render'));
+  return !(preload || (contextSrv.user && contextSrv.user.authenticatedBy === 'render'));
 }
 
 export enum GridLayoutType {

--- a/public/app/features/dashboard-scene/serialization/buildNewDashboardSaveModel.test.ts
+++ b/public/app/features/dashboard-scene/serialization/buildNewDashboardSaveModel.test.ts
@@ -65,6 +65,21 @@ describe('buildNewDashboardSaveModelV1', () => {
     expect(result.dashboard.templating).toBeUndefined();
   });
 
+  describe('preload', () => {
+    const originalDefault = config.dashboardDefaultPreload;
+    afterEach(() => {
+      config.dashboardDefaultPreload = originalDefault;
+    });
+
+    it('seeds preload from the instance default', async () => {
+      config.dashboardDefaultPreload = true;
+      expect((await buildNewDashboardSaveModel()).dashboard.preload).toBe(true);
+
+      config.dashboardDefaultPreload = false;
+      expect((await buildNewDashboardSaveModel()).dashboard.preload).toBe(false);
+    });
+  });
+
   describe('when featureToggles.newDashboardWithFiltersAndGroupBy is true', () => {
     beforeAll(() => {
       config.featureToggles.newDashboardWithFiltersAndGroupBy = true;
@@ -91,6 +106,22 @@ describe('buildNewDashboardSaveModelV2', () => {
   it('should not have template variables defined by default', async () => {
     const result = await buildNewDashboardSaveModelV2();
     expect(result.spec.variables).toEqual([]);
+  });
+
+  describe('preload', () => {
+    const originalDefault = config.dashboardDefaultPreload;
+    afterEach(() => {
+      config.dashboardDefaultPreload = originalDefault;
+    });
+
+    // The v2 schema default is a hardcoded false, so this has to win over the spread.
+    it('seeds preload from the instance default', async () => {
+      config.dashboardDefaultPreload = true;
+      expect((await buildNewDashboardSaveModelV2()).spec.preload).toBe(true);
+
+      config.dashboardDefaultPreload = false;
+      expect((await buildNewDashboardSaveModelV2()).spec.preload).toBe(false);
+    });
   });
 
   describe('when featureToggles.newDashboardWithFiltersAndGroupBy is true', () => {

--- a/public/app/features/dashboard-scene/serialization/buildNewDashboardSaveModel.ts
+++ b/public/app/features/dashboard-scene/serialization/buildNewDashboardSaveModel.ts
@@ -67,6 +67,9 @@ export async function buildNewDashboardSaveModel(urlFolderUid?: string): Promise
       title: t('dashboard-scene.build-new-dashboard-save-model.data.title.new-dashboard', 'New dashboard'),
       panels: [],
       timezone: contextSrv.user?.timezone || defaultDashboard.timezone,
+      // Seed from the instance default so the value is persisted on first save. Authors can flip it
+      // afterwards and their choice wins, because nothing reads the config again after creation.
+      preload: config.dashboardDefaultPreload,
     },
   };
 
@@ -137,6 +140,9 @@ export async function buildNewDashboardSaveModelV2(
         ...defaultTimeSettingsSpec(),
         timezone: contextSrv.user?.timezone || defaultTimeSettingsSpec().timezone,
       },
+      // Overrides the schema default, which is a hardcoded false. v2 requires a concrete boolean, so
+      // seeding here is what lets the instance default reach v2 dashboards at all.
+      preload: config.dashboardDefaultPreload,
     },
     access: {
       canStar: false,

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.test.ts
@@ -164,7 +164,8 @@ describe('transformSaveModelToScene', () => {
       const oldModel = new DashboardModel(dash);
       const scene = createDashboardSceneFromDashboardModel(oldModel, dash);
 
-      // Unset preload must stay undefined so getIsLazy can defer to the instance-wide default.
+      // Unset preload must stay undefined so a later save does not pin an explicit `false` onto a
+      // dashboard that never expressed a preference.
       expect(scene.state.preload).toBeUndefined();
     });
 

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
@@ -408,9 +408,9 @@ export function createDashboardSceneFromDashboardModel(
       uid,
       description: oldModel.description,
       editable: oldModel.editable,
-      // Keep preload undefined when the dashboard JSON omits it, so getIsLazy can fall back to
-      // the instance-wide default. Baking in `false` here would ignore [dashboards] default_preload
-      // and would persist an explicit `false` on the next save.
+      // Keep preload undefined when the dashboard JSON omits it. Baking in `false` here would
+      // persist an explicit `false` on the next save, pinning a dashboard that never expressed a
+      // preference. New dashboards get a concrete value seeded at creation instead.
       preload: dto.preload,
       isDirty: false,
       links: [...(options?.defaultLinks ?? []), ...(oldModel.links ?? [])],

--- a/public/app/features/dashboard-scene/settings/GeneralSettingsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/GeneralSettingsEditView.tsx
@@ -2,7 +2,6 @@ import { type ChangeEvent } from 'react';
 
 import { PageLayoutType } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
 import { type SceneComponentProps, SceneObjectBase, behaviors, sceneGraph } from '@grafana/scenes';
 import { type TimeZone } from '@grafana/schema';
 import {
@@ -388,8 +387,7 @@ function GeneralSettingsEditViewComponent({ model }: SceneComponentProps<General
             >
               <Switch
                 id="preload-panels-dashboards-toggle"
-                // Reflect the effective value: when the dashboard has no explicit preload, show the instance default.
-                value={dashboard.state.preload ?? config.dashboardDefaultPreload}
+                value={dashboard.state.preload ?? false}
                 onChange={(e) => model.onPreloadChange(e.currentTarget.checked)}
               />
             </Field>


### PR DESCRIPTION
`default_preload` now sets the `preload` value written into a dashboard when it is created, instead of being read at load time.

Before, it only applied to dashboards with no `preload` value, and nearly every dashboard has one, so it did nothing. Existing dashboards are unaffected and the author's toggle still wins.

Labelled `no-check-mt-service-compatibility` because the only backend changes are comments in `conf/*.ini` - the `default_preload` key and its plumbing are unchanged, so there is nothing to sequence.

Follow-up to #129522.

