### PR TITLE
Alerting: Return 409 Conflict for Alertmanager config version mismatch

### DIFF
--- a/pkg/services/ngalert/models/errors.go
+++ b/pkg/services/ngalert/models/errors.go
@@ -58,6 +58,12 @@ var (
 	)
 )
 
+// Alertmanager configuration errors.
+var (
+	ErrVersionLockedObjectNotFound = errutil.Conflict("alerting.notifications.alertmanager.versionConflict",
+		errutil.WithPublicMessage("The Alertmanager configuration has changed since it was last loaded. Reload and try again."))
+)
+
 // Route errors.
 var (
 	ErrRouteNotFound = errutil.NotFound("alerting.notifications.routes.notFound", errutil.WithPublicMessage("Route not found"))

--- a/pkg/services/ngalert/store/alertmanager.go
+++ b/pkg/services/ngalert/store/alertmanager.go
@@ -13,9 +13,6 @@ import (
 var (
 	// ErrNoAlertmanagerConfiguration is an error for when no alertmanager configuration is found.
 	ErrNoAlertmanagerConfiguration = fmt.Errorf("could not find an Alertmanager configuration")
-	// ErrVersionLockedObjectNotFound is returned when an object is not
-	// found using the current hash.
-	ErrVersionLockedObjectNotFound = fmt.Errorf("could not find object using provided id and hash")
 	// ConfigRecordsLimit defines the limit of how many alertmanager configuration versions
 	// should be stored in the database for each organization including the current one.
 	// Has to be > 0
@@ -121,7 +118,7 @@ func (st *DBstore) UpdateAlertmanagerConfiguration(ctx context.Context, cmd *mod
 				return err
 			}
 			if !ok {
-				return ErrVersionLockedObjectNotFound
+				return models.ErrVersionLockedObjectNotFound.Errorf("could not find object using provided id and hash")
 			}
 			return nil
 		}
@@ -140,7 +137,7 @@ func (st *DBstore) UpdateAlertmanagerConfiguration(ctx context.Context, cmd *mod
 			return err
 		}
 		if rows == 0 {
-			return ErrVersionLockedObjectNotFound
+			return models.ErrVersionLockedObjectNotFound.Errorf("could not find object using provided id and hash")
 		}
 
 		historicConfig := models.HistoricConfigFromAlertConfig(config)

--- a/pkg/services/ngalert/store/alertmanager_test.go
+++ b/pkg/services/ngalert/store/alertmanager_test.go
@@ -112,7 +112,7 @@ func TestIntegrationAlertmanagerStore(t *testing.T) {
 		cmd.FetchedConfigurationHash = fmt.Sprintf("%x", md5.Sum([]byte("my-config")))
 		err := store.UpdateAlertmanagerConfiguration(context.Background(), &cmd)
 
-		require.ErrorIs(t, err, ErrVersionLockedObjectNotFound)
+		require.ErrorIs(t, err, models.ErrVersionLockedObjectNotFound)
 	})
 
 	t.Run("UpdateAlertmanagerConfiguration doesn't update the db if the update is a no-op", func(t *testing.T) {
@@ -137,8 +137,7 @@ func TestIntegrationAlertmanagerStore(t *testing.T) {
 		cmd := buildSaveConfigCmd(t, configRaw, 1)
 		cmd.FetchedConfigurationHash = configHash
 		err := store.UpdateAlertmanagerConfiguration(context.Background(), &cmd)
-		require.Error(t, err)
-		require.EqualError(t, err, ErrVersionLockedObjectNotFound.Error())
+		require.ErrorIs(t, err, models.ErrVersionLockedObjectNotFound)
 	})
 }
 
@@ -183,8 +182,7 @@ func TestIntegrationAlertmanagerHash(t *testing.T) {
 			Default:                   false,
 			OrgID:                     1,
 		})
-		require.Error(t, err)
-		require.EqualError(t, ErrVersionLockedObjectNotFound, err.Error())
+		require.ErrorIs(t, err, models.ErrVersionLockedObjectNotFound)
 	})
 }
 


### PR DESCRIPTION
## Summary
`UpdateAlertmanagerConfiguration`'s optimistic-lock failure (`ErrVersionLockedObjectNotFound`) was a plain `fmt.Errorf`, so it surfaced as an opaque 500 instead of a 409. Converted it to an `errutil.Conflict` error (`alerting.notifications.alertmanager.versionConflict`) so it maps to HTTP 409 automatically wherever it propagates, letting API clients/automation detect and retry the conflict instead of treating it as an internal error.

## Test plan
- [x] `go test ./pkg/services/ngalert/store/... -run TestIntegrationAlertmanager -v`
- [x] `golangci-lint run ./pkg/services/ngalert/models/... ./pkg/services/ngalert/store/...`