### PR TITLE
ShortURL: Return numeric org ID from compatibility API

### DIFF
--- a/pkg/api/short_url.go
+++ b/pkg/api/short_url.go
@@ -236,7 +236,11 @@ func (sk8s *shortURLK8sHandler) createKubernetesShortURLsHandler(c *contextmodel
 	}
 
 	c.Logger.Info("Successfully created short URL", "path", cmd.Path, "uid", out.GetName())
-	c.JSON(http.StatusOK, shorturl.UnstructuredToLegacyShortURLDTO(*out, sk8s.cfg.AppURL))
+	var orgID *int64
+	if sk8s.cfg.StackID == "" {
+		orgID = &c.OrgID
+	}
+	c.JSON(http.StatusOK, shorturl.UnstructuredToLegacyShortURLDTO(*out, sk8s.cfg.AppURL, orgID))
 }
 
 //-----------------------------------------------------------------------------------------

--- a/pkg/api/short_url_k8s_test.go
+++ b/pkg/api/short_url_k8s_test.go
@@ -2,7 +2,9 @@ package api
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,9 +12,105 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/grafana/grafana/apps/shorturl/pkg/apis/shorturl/v1beta1"
+	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	"github.com/grafana/grafana/pkg/setting"
 )
+
+func TestCreateKubernetesShortURLsHandler(t *testing.T) {
+	const validUID = "abcdef1234"
+	const requestBody = `{"path":"explore"}`
+
+	tests := []struct {
+		name      string
+		stackID   string
+		orgID     int64
+		namespace string
+		appURL    string
+		wantURL   string
+	}{
+		{
+			name:      "default namespace uses the active organization ID",
+			orgID:     1,
+			namespace: "default",
+			appURL:    "http://localhost:3000/",
+			wantURL:   "http://localhost:3000/goto/abcdef1234?orgId=1",
+		},
+		{
+			name:      "organization namespace uses the active organization ID and preserves subpath",
+			orgID:     5,
+			namespace: "org-5",
+			appURL:    "https://grafana.example.com/grafana/",
+			wantURL:   "https://grafana.example.com/grafana/goto/abcdef1234?orgId=5",
+		},
+		{
+			name:      "resource namespace cannot override the active organization ID",
+			orgID:     5,
+			namespace: "org-999",
+			appURL:    "https://grafana.example.com/",
+			wantURL:   "https://grafana.example.com/goto/abcdef1234?orgId=5",
+		},
+		{
+			name:      "cloud namespace omits populated organization ID",
+			stackID:   "123",
+			orgID:     1,
+			namespace: "stacks-123",
+			appURL:    "https://grafana.example.com/",
+			wantURL:   "https://grafana.example.com/goto/abcdef1234",
+		},
+		{
+			name:      "cloud namespace omits missing organization ID",
+			stackID:   "123",
+			orgID:     0,
+			namespace: "stacks-123",
+			appURL:    "https://grafana.example.com/",
+			wantURL:   "https://grafana.example.com/goto/abcdef1234",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := setting.NewCfg()
+			cfg.AppURL = tt.appURL
+			cfg.StackID = tt.stackID
+
+			responseBody := mustMarshal(t, v1beta1.ShortURL{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: v1beta1.APIGroup + "/" + v1beta1.APIVersion,
+					Kind:       "ShortURL",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      validUID,
+					Namespace: tt.namespace,
+				},
+				Spec: v1beta1.ShortURLSpec{Path: "explore"},
+			})
+
+			handler := &shortURLK8sHandler{
+				gvr:        v1beta1.ShortURLKind().GroupVersionResource(),
+				namespacer: request.GetNamespaceMapper(cfg),
+				clientConfigProvider: &mockDirectRestConfigProvider{
+					host:      "http://localhost",
+					transport: &mockRoundTripper{statusCode: http.StatusCreated, responseBody: responseBody},
+				},
+				cfg: cfg,
+			}
+
+			ctx, recorder := newTestContext(t, http.MethodPost, "/api/short-urls", nil)
+			ctx.OrgID = tt.orgID
+			ctx.Req.Body = io.NopCloser(strings.NewReader(requestBody))
+			ctx.Req.ContentLength = int64(len(requestBody))
+
+			handler.createKubernetesShortURLsHandler(ctx)
+
+			require.Equal(t, http.StatusOK, recorder.Code)
+			var got dtos.ShortURL
+			require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &got))
+			require.Equal(t, validUID, got.UID)
+			require.Equal(t, tt.wantURL, got.URL)
+		})
+	}
+}
 
 func TestGetKubernetesRedirectFromShortURL(t *testing.T) {
 	const appURL = "http://localhost:3000/"

--- a/pkg/registry/apps/shorturl/conversions.go
+++ b/pkg/registry/apps/shorturl/conversions.go
@@ -55,8 +55,11 @@ func LegacyCreateCommandToUnstructured(cmd dtos.CreateShortURLCmd) unstructured.
 	return obj
 }
 
-func UnstructuredToLegacyShortURLDTO(item unstructured.Unstructured, appURL string) *dtos.ShortURL {
-	url := fmt.Sprintf("%s/goto/%s?orgId=%s", strings.TrimSuffix(appURL, "/"), item.GetName(), item.GetNamespace())
+func UnstructuredToLegacyShortURLDTO(item unstructured.Unstructured, appURL string, orgID *int64) *dtos.ShortURL {
+	url := fmt.Sprintf("%s/goto/%s", strings.TrimSuffix(appURL, "/"), item.GetName())
+	if orgID != nil {
+		url = fmt.Sprintf("%s?orgId=%d", url, *orgID)
+	}
 
 	return &dtos.ShortURL{
 		UID: item.GetName(),


### PR DESCRIPTION
**What is this feature?**

The compatibility `POST /api/short-urls` response now builds short-link URLs from the authenticated request's numeric organization ID instead of the Kubernetes resource namespace.

On Grafana Cloud, where multi-organization switching is not supported, the response omits the `orgId` query parameter. This matches the behavior of the direct Kubernetes frontend path.

**Why do we need this feature?**

Kubernetes namespaces such as `default`, `org-5`, and `stacks-123` are not numeric organization IDs. Returning them as `orgId` produces malformed links that Grafana's organization redirect middleware cannot use.

The regression test exercises the complete compatibility handler for default and named organizations, a conflicting namespace, Cloud with populated and absent organization IDs, and an application subpath.

**Who is this feature for?**

Users and API callers creating short URLs through the compatibility endpoint, especially multi-organization Grafana installations.

**Which issue(s) does this PR fix?**:

Fixes #130873

**Special notes for your reviewer:**

The change deliberately preserves existing `AppURL` concatenation so configured subpaths remain intact. It does not parse organization IDs from namespaces.

Validation:

- `go test ./pkg/api -run '^TestCreateKubernetesShortURLsHandler$' -count=20`

- `go test ./pkg/api ./pkg/registry/apps/shorturl -count=1`

- `make lint-go-diff GIT_BASE=origin/main`

Please check that:

- [x] It works as expected from a user's perspective.

- [x] This is not a pre-GA feature.

- [x] No documentation change is required; this restores the established compatibility API contract.
