### PR TITLE
IAM: Add validation logic for creating Service Account Tokens

### DIFF
--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -732,7 +732,13 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateServiceAccountsAPIGroup(opts 
 	}
 
 	if enableServiceAccountTokensApi {
-		storage[saResource.StoragePath("tokens")] = serviceaccounttoken.NewTokensREST(saStore, b.store, b.tracing)
+		storage[saResource.StoragePath("tokens")] = serviceaccounttoken.NewTokensREST(
+			saStore,
+			b.store,
+			b.tracing,
+			b.cfgProvider,
+			b.settingService,
+		)
 	}
 
 	return nil

--- a/pkg/registry/apis/iam/serviceaccounttoken/expiration.go
+++ b/pkg/registry/apis/iam/serviceaccounttoken/expiration.go
@@ -1,0 +1,116 @@
+package serviceaccounttoken
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	authSection                 = "auth"
+	apiKeyMaxSecondsToLiveKey   = "api_key_max_seconds_to_live"
+	serviceAccountsSection      = "service_accounts"
+	tokenExpirationDayLimitKey  = "token_expiration_day_limit"
+	defaultTokenExpirationLimit = int64(-1)
+)
+
+var tokenExpirationSettingsSelector = metav1.LabelSelector{
+	MatchExpressions: []metav1.LabelSelectorRequirement{
+		{
+			Key:      "section",
+			Operator: metav1.LabelSelectorOpIn,
+			Values:   []string{authSection, serviceAccountsSection},
+		},
+		{
+			Key:      "key",
+			Operator: metav1.LabelSelectorOpIn,
+			Values:   []string{apiKeyMaxSecondsToLiveKey, tokenExpirationDayLimitKey},
+		},
+	},
+}
+
+type expirationSettings struct {
+	apiKeyMaxSecondsToLive int64
+	saTokenExpirationDays  int64
+}
+
+func (s *TokensREST) resolveExpirationSettings(ctx context.Context) (expirationSettings, error) {
+	if s.cfgProvider != nil {
+		cfg, err := s.cfgProvider.Get(ctx)
+		if err != nil {
+			return expirationSettings{}, err
+		}
+		if cfg == nil {
+			return expirationSettings{}, errors.New("config provider returned nil configuration")
+		}
+		return expirationSettings{
+			apiKeyMaxSecondsToLive: cfg.ApiKeyMaxSecondsToLive,
+			saTokenExpirationDays:  int64(cfg.SATokenExpirationDayLimit),
+		}, nil
+	}
+
+	if s.settingService != nil {
+		resolved := expirationSettings{
+			apiKeyMaxSecondsToLive: defaultTokenExpirationLimit,
+			saTokenExpirationDays:  defaultTokenExpirationLimit,
+		}
+		settings, err := s.settingService.List(ctx, tokenExpirationSettingsSelector)
+		if err != nil {
+			return expirationSettings{}, err
+		}
+		for _, setting := range settings {
+			if setting == nil || strings.TrimSpace(setting.Value) == "" {
+				continue
+			}
+
+			var target *int64
+			switch {
+			case setting.Section == authSection && setting.Key == apiKeyMaxSecondsToLiveKey:
+				target = &resolved.apiKeyMaxSecondsToLive
+			case setting.Section == serviceAccountsSection && setting.Key == tokenExpirationDayLimitKey:
+				target = &resolved.saTokenExpirationDays
+			default:
+				continue
+			}
+
+			value, err := strconv.ParseInt(strings.TrimSpace(setting.Value), 10, 64)
+			if err != nil {
+				return expirationSettings{}, fmt.Errorf("invalid setting %s.%s: %w", setting.Section, setting.Key, err)
+			}
+			*target = value
+		}
+		return resolved, nil
+	}
+
+	return expirationSettings{}, errors.New("service account token REST: neither cfgProvider nor settingService is configured")
+}
+
+func validateExpiration(expiresInSeconds int64, settings expirationSettings, now time.Time) error {
+	if settings.apiKeyMaxSecondsToLive != defaultTokenExpirationLimit {
+		if expiresInSeconds == 0 {
+			return errors.New("expiresInSeconds is required when auth.api_key_max_seconds_to_live is set")
+		}
+		if expiresInSeconds > settings.apiKeyMaxSecondsToLive {
+			return errors.New("expiresInSeconds exceeds auth.api_key_max_seconds_to_live")
+		}
+	}
+
+	if settings.saTokenExpirationDays > 0 {
+		if expiresInSeconds == 0 {
+			return errors.New("expiresInSeconds is required when service_accounts.token_expiration_day_limit is set")
+		}
+
+		dayExpireLimit := now.Add(time.Duration(settings.saTokenExpirationDays) * 24 * time.Hour).Truncate(24 * time.Hour)
+		expirationDate := now.Add(time.Duration(expiresInSeconds) * time.Second).Truncate(24 * time.Hour)
+		if expirationDate.After(dayExpireLimit) {
+			return errors.New("expiration date exceeds service_accounts.token_expiration_day_limit")
+		}
+	}
+
+	return nil
+}

--- a/pkg/registry/apis/iam/serviceaccounttoken/rest_tokens.go
+++ b/pkg/registry/apis/iam/serviceaccounttoken/rest_tokens.go
@@ -23,10 +23,12 @@ import (
 
 	iamv0alpha1 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/components/satokengen"
+	"github.com/grafana/grafana/pkg/configprovider"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/common"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/legacy"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
+	settingsvc "github.com/grafana/grafana/pkg/services/setting"
 )
 
 const (
@@ -58,20 +60,30 @@ var (
 // NewTokensREST creates the /tokens subresource handler on ServiceAccount.
 //   - saGetter: the registered storage for ServiceAccount (DualWriter or UniStore).
 //   - legacyStore: reads/writes tokens in the legacy api_key table.
-func NewTokensREST(saGetter rest.Getter, legacyStore legacy.LegacyIdentityStore, tracer trace.Tracer) *TokensREST {
+func NewTokensREST(
+	saGetter rest.Getter,
+	legacyStore legacy.LegacyIdentityStore,
+	tracer trace.Tracer,
+	cfgProvider configprovider.ConfigProvider,
+	settingService settingsvc.Service,
+) *TokensREST {
 	return &TokensREST{
-		saGetter:    saGetter,
-		legacyStore: legacyStore,
-		logger:      log.New("grafana-apiserver.serviceaccounttokens.api"),
-		tracer:      tracer,
+		saGetter:       saGetter,
+		legacyStore:    legacyStore,
+		logger:         log.New("grafana-apiserver.serviceaccounttokens.api"),
+		tracer:         tracer,
+		cfgProvider:    cfgProvider,
+		settingService: settingService,
 	}
 }
 
 type TokensREST struct {
-	logger      log.Logger
-	tracer      trace.Tracer
-	saGetter    rest.Getter                // reads ServiceAccount from DualWriter / UniStore
-	legacyStore legacy.LegacyIdentityStore // reads/writes tokens in legacy api_key
+	logger         log.Logger
+	tracer         trace.Tracer
+	saGetter       rest.Getter                // reads ServiceAccount from DualWriter / UniStore
+	legacyStore    legacy.LegacyIdentityStore // reads/writes tokens in legacy api_key
+	cfgProvider    configprovider.ConfigProvider
+	settingService settingsvc.Service
 }
 
 func (s *TokensREST) New() runtime.Object {
@@ -248,10 +260,24 @@ func (s *TokensREST) handleCreate(ctx context.Context, ns claims.NamespaceInfo, 
 		return
 	}
 
+	expirationSettings, err := s.resolveExpirationSettings(ctx)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "failed to load token expiration settings")
+		ctxLogger.Error("failed to load service account token expiration settings", "error", err, "serviceAccount", saName)
+		responder.Error(apierrors.NewInternalError(fmt.Errorf("failed to load token expiration settings: %w", err)))
+		return
+	}
+	now := time.Now()
+	if err := validateExpiration(req.ExpiresInSeconds, expirationSettings, now); err != nil {
+		responder.Error(apierrors.NewBadRequest(err.Error()))
+		return
+	}
+
 	// 0 means "never expires" — only compute an absolute timestamp when positive.
 	var expires int64
 	if req.ExpiresInSeconds > 0 {
-		expires = time.Now().Unix() + req.ExpiresInSeconds
+		expires = now.Unix() + req.ExpiresInSeconds
 	}
 
 	// Generate the token ONCE — the same hash goes to both stores.

--- a/pkg/registry/apis/iam/serviceaccounttoken/rest_tokens_test.go
+++ b/pkg/registry/apis/iam/serviceaccounttoken/rest_tokens_test.go
@@ -1,0 +1,294 @@
+package serviceaccounttoken
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+	"gopkg.in/ini.v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8srequest "k8s.io/apiserver/pkg/endpoints/request"
+
+	claims "github.com/grafana/authlib/types"
+	"github.com/grafana/grafana/pkg/configprovider"
+	"github.com/grafana/grafana/pkg/registry/apis/iam/legacy"
+	settingsvc "github.com/grafana/grafana/pkg/services/setting"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func TestResolveExpirationSettingsFromConfigProvider(t *testing.T) {
+	provider := &fakeConfigProvider{cfg: &setting.Cfg{
+		ApiKeyMaxSecondsToLive:    3600,
+		SATokenExpirationDayLimit: 7,
+	}}
+	settingService := &fakeSettingService{}
+	rest := NewTokensREST(nil, nil, noop.NewTracerProvider().Tracer("test"), provider, settingService)
+
+	resolved, err := rest.resolveExpirationSettings(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, expirationSettings{apiKeyMaxSecondsToLive: 3600, saTokenExpirationDays: 7}, resolved)
+	assert.False(t, settingService.called)
+}
+
+func TestResolveExpirationSettingsFromSettingService(t *testing.T) {
+	ctx := k8srequest.WithNamespace(context.Background(), "stacks-123")
+	settingService := &fakeSettingService{
+		settings: []*settingsvc.Setting{
+			{Section: serviceAccountsSection, Key: tokenExpirationDayLimitKey, Value: " 14 "},
+			{Section: "auth", Key: "unrelated", Value: "99"},
+			{Section: authSection, Key: apiKeyMaxSecondsToLiveKey, Value: "7200"},
+		},
+	}
+	rest := NewTokensREST(nil, nil, noop.NewTracerProvider().Tracer("test"), nil, settingService)
+
+	resolved, err := rest.resolveExpirationSettings(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, expirationSettings{apiKeyMaxSecondsToLive: 7200, saTokenExpirationDays: 14}, resolved)
+	assert.Equal(t, tokenExpirationSettingsSelector, settingService.selector)
+	assert.Equal(t, "stacks-123", settingService.namespace)
+}
+
+func TestResolveExpirationSettingsDefaultsForMissingOrBlankMTSettings(t *testing.T) {
+	settingService := &fakeSettingService{
+		settings: []*settingsvc.Setting{
+			{Section: authSection, Key: apiKeyMaxSecondsToLiveKey, Value: "  "},
+		},
+	}
+	rest := NewTokensREST(nil, nil, noop.NewTracerProvider().Tracer("test"), nil, settingService)
+
+	resolved, err := rest.resolveExpirationSettings(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, expirationSettings{
+		apiKeyMaxSecondsToLive: defaultTokenExpirationLimit,
+		saTokenExpirationDays:  defaultTokenExpirationLimit,
+	}, resolved)
+}
+
+func TestResolveExpirationSettingsErrors(t *testing.T) {
+	loadErr := errors.New("load failed")
+	tests := []struct {
+		name           string
+		cfgProvider    configprovider.ConfigProvider
+		settingService settingsvc.Service
+		errorContains  string
+	}{
+		{
+			name:          "config provider error",
+			cfgProvider:   &fakeConfigProvider{err: loadErr},
+			errorContains: loadErr.Error(),
+		},
+		{
+			name:          "config provider returns nil configuration",
+			cfgProvider:   &fakeConfigProvider{},
+			errorContains: "config provider returned nil configuration",
+		},
+		{
+			name:           "setting service error",
+			settingService: &fakeSettingService{err: loadErr},
+			errorContains:  loadErr.Error(),
+		},
+		{
+			name: "invalid multi-tenant value",
+			settingService: &fakeSettingService{settings: []*settingsvc.Setting{
+				{Section: authSection, Key: apiKeyMaxSecondsToLiveKey, Value: "not-a-number"},
+			}},
+			errorContains: "invalid setting auth.api_key_max_seconds_to_live",
+		},
+		{
+			name:          "no configuration source",
+			errorContains: "neither cfgProvider nor settingService is configured",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rest := NewTokensREST(nil, nil, noop.NewTracerProvider().Tracer("test"), tt.cfgProvider, tt.settingService)
+			_, err := rest.resolveExpirationSettings(context.Background())
+			require.ErrorContains(t, err, tt.errorContains)
+		})
+	}
+}
+
+func TestValidateExpiration(t *testing.T) {
+	now := time.Date(2026, time.August, 18, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name             string
+		expiresInSeconds int64
+		settings         expirationSettings
+		wantError        bool
+	}{
+		{
+			name:             "defaults allow no expiration",
+			expiresInSeconds: 0,
+			settings:         expirationSettings{apiKeyMaxSecondsToLive: -1, saTokenExpirationDays: -1},
+		},
+		{
+			name:             "global maximum requires expiration",
+			expiresInSeconds: 0,
+			settings:         expirationSettings{apiKeyMaxSecondsToLive: 60, saTokenExpirationDays: -1},
+			wantError:        true,
+		},
+		{
+			name:             "global maximum rejects value over limit",
+			expiresInSeconds: 61,
+			settings:         expirationSettings{apiKeyMaxSecondsToLive: 60, saTokenExpirationDays: -1},
+			wantError:        true,
+		},
+		{
+			name:             "global maximum accepts value at limit",
+			expiresInSeconds: 60,
+			settings:         expirationSettings{apiKeyMaxSecondsToLive: 60, saTokenExpirationDays: -1},
+		},
+		{
+			name:             "explicit zero global maximum permits no positive lifetime",
+			expiresInSeconds: 1,
+			settings:         expirationSettings{apiKeyMaxSecondsToLive: 0, saTokenExpirationDays: -1},
+			wantError:        true,
+		},
+		{
+			name:             "day limit requires expiration",
+			expiresInSeconds: 0,
+			settings:         expirationSettings{apiKeyMaxSecondsToLive: -1, saTokenExpirationDays: 1},
+			wantError:        true,
+		},
+		{
+			name:             "day limit rejects expiration date over limit",
+			expiresInSeconds: 36 * 60 * 60,
+			settings:         expirationSettings{apiKeyMaxSecondsToLive: -1, saTokenExpirationDays: 1},
+			wantError:        true,
+		},
+		{
+			name:             "day limit accepts expiration date within limit",
+			expiresInSeconds: 24 * 60 * 60,
+			settings:         expirationSettings{apiKeyMaxSecondsToLive: -1, saTokenExpirationDays: 1},
+		},
+		{
+			name:             "explicit zero day limit is disabled",
+			expiresInSeconds: 0,
+			settings:         expirationSettings{apiKeyMaxSecondsToLive: -1, saTokenExpirationDays: 0},
+		},
+		{
+			name:             "global maximum remains enforced when both enabled",
+			expiresInSeconds: 25 * 60 * 60,
+			settings:         expirationSettings{apiKeyMaxSecondsToLive: 24 * 60 * 60, saTokenExpirationDays: 2},
+			wantError:        true,
+		},
+		{
+			name:             "day limit remains enforced when both enabled",
+			expiresInSeconds: 36 * 60 * 60,
+			settings:         expirationSettings{apiKeyMaxSecondsToLive: 48 * 60 * 60, saTokenExpirationDays: 1},
+			wantError:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateExpiration(tt.expiresInSeconds, tt.settings, now)
+			if tt.wantError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestHandleCreateDoesNotStoreRejectedToken(t *testing.T) {
+	loadErr := errors.New("load failed")
+	tests := []struct {
+		name       string
+		provider   configprovider.ConfigProvider
+		isExpected func(error) bool
+	}{
+		{
+			name: "expiration validation failure returns bad request",
+			provider: &fakeConfigProvider{cfg: &setting.Cfg{
+				ApiKeyMaxSecondsToLive:    60,
+				SATokenExpirationDayLimit: -1,
+			}},
+			isExpected: apierrors.IsBadRequest,
+		},
+		{
+			name:       "configuration failure returns internal error",
+			provider:   &fakeConfigProvider{err: loadErr},
+			isExpected: apierrors.IsInternalError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &fakeLegacyStore{}
+			rest := NewTokensREST(nil, store, noop.NewTracerProvider().Tracer("test"), tt.provider, nil)
+			req, err := http.NewRequest(http.MethodPost, "/tokens", bytes.NewBufferString(`{"tokenName":"test-token","expiresInSeconds":61}`))
+			require.NoError(t, err)
+			responder := &fakeResponder{}
+
+			rest.handleCreate(context.Background(), claims.NamespaceInfo{OrgID: 1}, "sa-uid", req, responder)
+
+			require.Error(t, responder.err)
+			assert.True(t, tt.isExpected(responder.err))
+			assert.False(t, store.createCalled)
+		})
+	}
+}
+
+type fakeConfigProvider struct {
+	configprovider.ConfigProvider
+	cfg *setting.Cfg
+	err error
+}
+
+func (f *fakeConfigProvider) Get(context.Context) (*setting.Cfg, error) {
+	return f.cfg, f.err
+}
+
+type fakeSettingService struct {
+	settings  []*settingsvc.Setting
+	err       error
+	called    bool
+	selector  metav1.LabelSelector
+	namespace string
+}
+
+func (f *fakeSettingService) List(ctx context.Context, selector metav1.LabelSelector) ([]*settingsvc.Setting, error) {
+	f.called = true
+	f.selector = selector
+	f.namespace, _ = k8srequest.NamespaceFrom(ctx)
+	return f.settings, f.err
+}
+
+func (f *fakeSettingService) ListAsIni(context.Context, metav1.LabelSelector) (*ini.File, error) {
+	return nil, f.err
+}
+
+func (f *fakeSettingService) Describe(chan<- *prometheus.Desc) {}
+func (f *fakeSettingService) Collect(chan<- prometheus.Metric) {}
+
+type fakeLegacyStore struct {
+	legacy.LegacyIdentityStore
+	createCalled bool
+}
+
+func (f *fakeLegacyStore) CreateServiceAccountTokenWithHash(context.Context, claims.NamespaceInfo, legacy.CreateServiceAccountTokenWithHashCommand) error {
+	f.createCalled = true
+	return nil
+}
+
+type fakeResponder struct {
+	err error
+}
+
+func (f *fakeResponder) Object(int, runtime.Object) {}
+
+func (f *fakeResponder) Error(err error) {
+	f.err = err
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Adds configuration-driven expiration validation to the k8s-style Service Account Token create endpoint.

The endpoint now honors:

  - `[auth] api_key_max_seconds_to_live`
  - `[service_accounts] token_expiration_day_limit`
  - The existing five-year API maximum

Configuration is resolved through the single-tenant config provider or the namespace-scoped multi-tenant settings service. Invalid requests are rejected before a token is generated or stored.

**Why do we need this feature?**
The k8s-style endpoint did not enforce the expiration limits already applied by the legacy Service Account Token endpoint. This could allow clients using the new endpoint to create tokens without a required expiration or with a lifetime exceeding configured limits.

This change brings the new endpoint into parity with the existing expiration contract.

**Who is this feature for?**
Grafana admins who configure Service Account Token expiration policies, and clients using the k8s-style IAM API to create Service Account Tokens.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Closes https://github.com/grafana/identity-access-team/issues/2027

