### PR TITLE
Provisioning: Test connection type configuration

### DIFF
--- a/pkg/operators/provisioning/config_test.go
+++ b/pkg/operators/provisioning/config_test.go
@@ -7,7 +7,29 @@ import (
 
 	apisprovisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/connection"
+	"github.com/grafana/grafana/pkg/setting"
 )
+
+func TestConnectionFactoryUsesConfiguredTypes(t *testing.T) {
+	configuredType := apisprovisioning.ConnectionType("configured")
+	extras := make([]connection.Extra, 0, 2)
+	for _, connectionType := range []apisprovisioning.ConnectionType{
+		apisprovisioning.GithubConnectionType,
+		configuredType,
+	} {
+		extra := connection.NewMockExtra(t)
+		extra.On("Type").Return(connectionType)
+		extras = append(extras, extra)
+	}
+
+	cfg := ControllerConfig{
+		Settings:         &setting.Cfg{ProvisioningConnectionTypes: []string{string(configuredType)}},
+		connectionExtras: extras,
+	}
+	factory, err := cfg.ConnectionFactory()
+	require.NoError(t, err)
+	require.ElementsMatch(t, []apisprovisioning.ConnectionType{configuredType}, factory.Types())
+}
 
 func TestDefaultConnectionTypes(t *testing.T) {
 	registeredTypes := []apisprovisioning.ConnectionType{

--- a/pkg/registry/apis/provisioning/extras/register_test.go
+++ b/pkg/registry/apis/provisioning/extras/register_test.go
@@ -1,0 +1,48 @@
+package extras
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/apps/provisioning/pkg/connection"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func TestProvideConnectionFactoryFromConfig(t *testing.T) {
+	configuredType := provisioning.ConnectionType("configured")
+	tests := []struct {
+		name     string
+		types    []string
+		expected []provisioning.ConnectionType
+	}{
+		{
+			name:     "defaults to GitHub",
+			expected: []provisioning.ConnectionType{provisioning.GithubConnectionType},
+		},
+		{
+			name:     "uses configured connection types",
+			types:    []string{string(configuredType)},
+			expected: []provisioning.ConnectionType{configuredType},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			extras := make([]connection.Extra, 0, 2)
+			for _, connectionType := range []provisioning.ConnectionType{
+				provisioning.GithubConnectionType,
+				configuredType,
+			} {
+				extra := connection.NewMockExtra(t)
+				extra.On("Type").Return(connectionType)
+				extras = append(extras, extra)
+			}
+
+			factory, err := ProvideConnectionFactoryFromConfig(&setting.Cfg{ProvisioningConnectionTypes: tt.types}, extras)
+			require.NoError(t, err)
+			require.ElementsMatch(t, tt.expected, factory.Types())
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Verifies that explicit connection type configuration is honored by both the API service and standalone operator while preserving safe defaults.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

PR description generated by Pi.