### PR TITLE
Alerting: Fix rule groups missing from a folder until "Show more" is clicked

### DIFF
--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -188,4 +188,6 @@ func (oss *OSSMigrations) AddMigration(mg *Migrator) {
 	ualert.AddAlertRuleStateBigIntMigration(mg)
 
 	mg.AddObsoleteMigration(obsolete.PlaylistMigrations())
+
+	ualert.CollateBinAlertRuleFolderFullpath(mg)
 }

--- a/pkg/services/sqlstore/migrations/testdata/migration_ids.txt
+++ b/pkg/services/sqlstore/migrations/testdata/migration_ids.txt
@@ -732,3 +732,4 @@
 "Change key_path collation of nats_discovery_peers in postgres"
 "alter alert_rule_state id column to bigint for postgres"
 "alter alert_rule_state id sequence to bigint for postgres"
+"ensure folder_fullpath column sorts the same way as golang"

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule_folder_fullpath_collation_bin.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule_folder_fullpath_collation_bin.go
@@ -1,0 +1,12 @@
+package ualert
+
+import "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+
+// CollateBinAlertRuleFolderFullpath ensures that folder_fullpath column collates in
+// the same way go sorts strings, matching CollateBinAlertRuleGroup and
+// CollateBinAlertRuleNamespace.
+func CollateBinAlertRuleFolderFullpath(mg *migrator.Migrator) {
+	mg.AddMigration("ensure folder_fullpath column sorts the same way as golang", migrator.NewRawSQLMigration("").
+		Mysql("ALTER TABLE alert_rule MODIFY folder_fullpath VARCHAR(512) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NULL;").
+		Postgres(`ALTER TABLE alert_rule ALTER COLUMN folder_fullpath SET DATA TYPE varchar(512) COLLATE "C";`))
+}


### PR DESCRIPTION
`rule_group` and `namespace_uid` are both pinned to a binary collation so that `SQL ORDER BY` matches Go's `strings.Compare`, but `folder_fullpath` was added later without the same pinning.

On MySQL/Postgres it silently uses the default collation, so when `alertingRuleGroupSortByFolderFullpath` FF is enabled, the DB-level pagination cursor and `getGroupedRules'` in-memory re-sort can disagree on ordering. A folder can then appear complete in the wrong position, or incomplete until "Show more" is clicked, because the page boundary and the display order were computed with two different collations.

Adds a migration collating `folder_fullpath` the same way as its sibling columns.

<details><summary>Example bug:</summary>
<p>

https://github.com/user-attachments/assets/b17973ce-37fb-4e37-ab7a-e941c0ecb468

</p>
</details> 


<details><summary>Fixed:</summary>
<p>

https://github.com/user-attachments/assets/e0d7d093-13b6-499d-9d3e-7f992ebde0af

</p>
</details> 