### PR TITLE
Alerting: Show Auto-sync support in the import wizard picker

### DIFF
--- a/public/app/features/alerting/unified/components/import-to-gma/steps/Step1AlertmanagerResources.test.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/steps/Step1AlertmanagerResources.test.tsx
@@ -2,7 +2,7 @@ import userEvent from '@testing-library/user-event';
 import { HttpResponse, http } from 'msw';
 import React, { useCallback, useEffect } from 'react';
 import { FormProvider, useForm, useFormContext } from 'react-hook-form';
-import { act, render, screen, testWithFeatureToggles, waitFor } from 'test/test-utils';
+import { act, render, screen, testWithFeatureToggles, waitFor, within } from 'test/test-utils';
 
 import { mockBoundingClientRect } from '@grafana/test-utils';
 import { setupMswServer } from 'app/features/alerting/unified/mockApi';
@@ -70,17 +70,6 @@ function ValidationHookWrapper({ canImport, onResult }: { canImport: boolean; on
   useEffect(() => {
     onResult(isValid);
   }, [isValid, onResult]);
-  return null;
-}
-
-// Surfaces a watched field's value via a callback, so a test can assert on internal form state
-// without depending on how a given field happens to render.
-function FieldWatcher({ name, onChange }: { name: keyof ImportFormValues; onChange: (value: unknown) => void }) {
-  const { watch } = useFormContext<ImportFormValues>();
-  const value = watch(name);
-  useEffect(() => {
-    onChange(value);
-  }, [value, onChange]);
   return null;
 }
 
@@ -500,6 +489,30 @@ describe('Step1AlertmanagerResources', () => {
       url: 'http://localhost:9009',
       jsonData: { implementation: 'mimir' },
     };
+    const MIMIR_DS_2 = {
+      id: 11,
+      uid: 'mimir-uid-2',
+      orgId: 1,
+      name: 'Mimir Alertmanager 2',
+      type: 'alertmanager',
+      url: 'http://localhost:9010',
+      jsonData: { implementation: 'mimir' },
+    };
+
+    // Mirrors MIMIR_DS/MIMIR_DS_2 in the frontend datasource list, so the same datasource is both
+    // selectable in the picker and recognized as Auto-sync-capable via the backend-sourced list.
+    const mimirDataSource = mockDataSource<AlertManagerDataSourceJsonData>({
+      name: MIMIR_DS.name,
+      uid: MIMIR_DS.uid,
+      type: 'alertmanager' as SupportedRulesSourceType,
+      jsonData: { implementation: AlertManagerImplementation.mimir, handleGrafanaManagedAlerts: true },
+    });
+    const mimirDataSource2 = mockDataSource<AlertManagerDataSourceJsonData>({
+      name: MIMIR_DS_2.name,
+      uid: MIMIR_DS_2.uid,
+      type: 'alertmanager' as SupportedRulesSourceType,
+      jsonData: { implementation: AlertManagerImplementation.mimir, handleGrafanaManagedAlerts: true },
+    });
 
     beforeEach(() => {
       setupAlertmanagersStatus(server);
@@ -518,6 +531,15 @@ describe('Step1AlertmanagerResources', () => {
 
     describe('with the feature toggle on', () => {
       testWithFeatureToggles({ enable: ['alerting.syncExternalAlertmanager'] });
+
+      beforeEach(() => {
+        setupDataSources(alertmanagerDataSource, mimirDataSource);
+        // Step1Content calls useAutoSyncConfiguration() unconditionally, so every admin+toggle-on
+        // render below fires these two queries regardless of what the test exercises — mock them
+        // by default for the whole block rather than per test.
+        setupAdminConfigGet(server, null);
+        setupDatasourcesEndpoint(server, [MIMIR_DS]);
+      });
 
       it('is not rendered for non-admins', () => {
         grantUserRole('Editor');
@@ -543,8 +565,6 @@ describe('Step1AlertmanagerResources', () => {
 
       it('is rendered for admins on the datasource source', () => {
         grantUserRole('Admin');
-        setupAdminConfigGet(server, null);
-        setupDatasourcesEndpoint(server, [MIMIR_DS]);
         render(
           <TestWrapper defaultValues={{ notificationsSource: 'datasource' }}>
             <Step1Content {...defaultStep1Props} />
@@ -556,19 +576,16 @@ describe('Step1AlertmanagerResources', () => {
 
       it('disables Policy Tree Name and skips the dry-run once checked', async () => {
         grantUserRole('Admin');
-        setupAdminConfigGet(server, null);
-        setupDatasourcesEndpoint(server, [MIMIR_DS]);
         const user = userEvent.setup();
         const onTriggerDryRun = jest.fn();
 
         render(
-          <TestWrapper
-            defaultValues={{ notificationsSource: 'datasource', notificationsDatasourceUID: 'alertmanager-uid' }}
-          >
+          <TestWrapper defaultValues={{ notificationsSource: 'datasource', notificationsDatasourceUID: MIMIR_DS.uid }}>
             <Step1Content {...defaultStep1Props} onTriggerDryRun={onTriggerDryRun} />
           </TestWrapper>
         );
 
+        await waitFor(() => expect(screen.getByRole('switch', { name: /auto-sync/i })).toBeEnabled());
         onTriggerDryRun.mockClear();
         await user.click(screen.getByRole('switch', { name: /auto-sync/i }));
 
@@ -576,31 +593,29 @@ describe('Step1AlertmanagerResources', () => {
         expect(onTriggerDryRun).not.toHaveBeenCalled();
       });
 
-      it('narrows the data source list to Mimir/Cortex once checked, clearing an incompatible selection', async () => {
+      it('always lists every Alertmanager datasource regardless of auto-sync checked state', async () => {
         grantUserRole('Admin');
-        setupAdminConfigGet(server, null);
-        setupDatasourcesEndpoint(server, [MIMIR_DS]);
         const user = userEvent.setup();
 
         render(
-          <TestWrapper
-            defaultValues={{ notificationsSource: 'datasource', notificationsDatasourceUID: 'alertmanager-uid' }}
-          >
+          <TestWrapper defaultValues={{ notificationsSource: 'datasource', notificationsDatasourceUID: MIMIR_DS.uid }}>
             <Step1Content {...defaultStep1Props} />
           </TestWrapper>
         );
 
+        await waitFor(() => expect(screen.getByRole('switch', { name: /auto-sync/i })).toBeEnabled());
         await user.click(screen.getByRole('switch', { name: /auto-sync/i }));
+        expect(screen.getByRole('switch', { name: /auto-sync/i })).toBeChecked();
 
-        const select = await screen.findByRole('combobox');
-        await user.click(select);
-        expect(await screen.findByText('Mimir Alertmanager')).toBeInTheDocument();
-        expect(screen.queryByText('Alertmanager')).not.toBeInTheDocument();
+        await user.click(screen.getByRole('combobox'));
+        expect(await screen.findByText('Alertmanager')).toBeInTheDocument();
+        // role="option" excludes the current-value display shown outside the menu, and the prefix
+        // match tolerates the badge/URL text also picked up in the option's accessible name.
+        expect(screen.getByRole('option', { name: /^Mimir Alertmanager/ })).toBeInTheDocument();
       });
 
-      it('does not clear an already-valid selection while the datasource list is still loading', async () => {
+      it('keeps the auto-sync switch disabled and the datasource options unbadged while the auto-sync capability query is loading, even for a Mimir datasource', async () => {
         grantUserRole('Admin');
-        setupAdminConfigGet(server, null);
         let resolveDatasources = (_response: unknown) => {};
         const datasourcesResponse = new Promise((resolve) => {
           resolveDatasources = resolve;
@@ -612,28 +627,156 @@ describe('Step1AlertmanagerResources', () => {
           })
         );
         const user = userEvent.setup();
-        const onDatasourceUIDChange = jest.fn();
 
         render(
           <TestWrapper defaultValues={{ notificationsSource: 'datasource', notificationsDatasourceUID: MIMIR_DS.uid }}>
             <Step1Content {...defaultStep1Props} />
-            <FieldWatcher name="notificationsDatasourceUID" onChange={onDatasourceUIDChange} />
           </TestWrapper>
         );
 
-        onDatasourceUIDChange.mockClear();
-        await user.click(screen.getByRole('switch', { name: /auto-sync/i }));
+        expect(screen.getByRole('switch', { name: /auto-sync/i })).toBeDisabled();
 
-        // The datasources request is still pending — the pre-existing, actually-valid selection must
-        // survive rather than being cleared against the momentarily-empty list.
-        expect(onDatasourceUIDChange).not.toHaveBeenCalledWith(undefined);
+        await user.click(screen.getByRole('combobox'));
+        const mimirOption = await screen.findByRole('option', { name: /^Mimir Alertmanager/ });
+        // Scope to the option itself — "Auto-sync" is also the checkbox's own (unconditional) label.
+        expect(within(mimirOption).queryByText('Auto-sync')).not.toBeInTheDocument();
 
         resolveDatasources(undefined);
+
+        await waitFor(() => expect(screen.getByRole('switch', { name: /auto-sync/i })).toBeEnabled());
+        const mimirOptionAfterLoad = await screen.findByRole('option', { name: /^Mimir Alertmanager/ });
+        expect(within(mimirOptionAfterLoad).getByText('Auto-sync')).toBeInTheDocument();
+      });
+
+      it('does not uncheck an already-enabled Auto-sync while the capability query is still loading', async () => {
+        grantUserRole('Admin');
+        let resolveDatasources = (_response: unknown) => {};
+        const datasourcesResponse = new Promise((resolve) => {
+          resolveDatasources = resolve;
+        });
+        server.use(
+          http.get('/api/datasources', async () => {
+            await datasourcesResponse;
+            return HttpResponse.json([MIMIR_DS]);
+          })
+        );
+
+        render(
+          <TestWrapper
+            defaultValues={{
+              notificationsSource: 'datasource',
+              notificationsDatasourceUID: MIMIR_DS.uid,
+              autoSyncNotificationsEnabled: true,
+            }}
+          >
+            <Step1Content {...defaultStep1Props} />
+          </TestWrapper>
+        );
+
+        // The reset effect must not race ahead and clear a persisted, still-valid selection just
+        // because the query hasn't resolved yet.
+        expect(screen.getByRole('switch', { name: /auto-sync/i })).toBeChecked();
+
+        resolveDatasources(undefined);
+
+        await waitFor(() => expect(screen.getByRole('switch', { name: /auto-sync/i })).toBeEnabled());
+        expect(screen.getByRole('switch', { name: /auto-sync/i })).toBeChecked();
+      });
+
+      it('disables the auto-sync switch when a non-Mimir/Cortex datasource is selected', async () => {
+        grantUserRole('Admin');
+
+        render(
+          <TestWrapper
+            defaultValues={{
+              notificationsSource: 'datasource',
+              notificationsDatasourceUID: alertmanagerDataSource.uid,
+            }}
+          >
+            <Step1Content {...defaultStep1Props} />
+          </TestWrapper>
+        );
+
+        await waitFor(() => expect(screen.getByRole('switch', { name: /auto-sync/i })).toBeDisabled());
+      });
+
+      it('enables the auto-sync switch when a Mimir/Cortex datasource is selected', async () => {
+        grantUserRole('Admin');
+
+        render(
+          <TestWrapper defaultValues={{ notificationsSource: 'datasource', notificationsDatasourceUID: MIMIR_DS.uid }}>
+            <Step1Content {...defaultStep1Props} />
+          </TestWrapper>
+        );
+
+        await waitFor(() => expect(screen.getByRole('switch', { name: /auto-sync/i })).toBeEnabled());
+      });
+
+      it('unchecks and disables auto-sync when switching to a datasource that does not support it', async () => {
+        grantUserRole('Admin');
+        const user = userEvent.setup();
+
+        render(
+          <TestWrapper defaultValues={{ notificationsSource: 'datasource', notificationsDatasourceUID: MIMIR_DS.uid }}>
+            <Step1Content {...defaultStep1Props} />
+          </TestWrapper>
+        );
+
+        await waitFor(() => expect(screen.getByRole('switch', { name: /auto-sync/i })).toBeEnabled());
+        await user.click(screen.getByRole('switch', { name: /auto-sync/i }));
+        expect(screen.getByRole('switch', { name: /auto-sync/i })).toBeChecked();
+
         await user.click(screen.getByRole('combobox'));
-        // The pre-existing selection survived, so it's already shown as the current value — meaning
-        // it now also appears a second time as the highlighted option in the open menu.
-        expect(await screen.findByRole('option', { name: 'Mimir Alertmanager' })).toBeInTheDocument();
-        expect(onDatasourceUIDChange).not.toHaveBeenCalledWith(undefined);
+        await user.click(screen.getByText('Alertmanager'));
+
+        await waitFor(() => expect(screen.getByRole('switch', { name: /auto-sync/i })).not.toBeChecked());
+        expect(screen.getByRole('switch', { name: /auto-sync/i })).toBeDisabled();
+      });
+
+      it('keeps auto-sync checked when switching between two Mimir/Cortex datasources', async () => {
+        grantUserRole('Admin');
+        setupDataSources(alertmanagerDataSource, mimirDataSource, mimirDataSource2);
+        setupDatasourcesEndpoint(server, [MIMIR_DS, MIMIR_DS_2]);
+        const user = userEvent.setup();
+
+        render(
+          <TestWrapper defaultValues={{ notificationsSource: 'datasource', notificationsDatasourceUID: MIMIR_DS.uid }}>
+            <Step1Content {...defaultStep1Props} />
+          </TestWrapper>
+        );
+
+        await waitFor(() => expect(screen.getByRole('switch', { name: /auto-sync/i })).toBeEnabled());
+        await user.click(screen.getByRole('switch', { name: /auto-sync/i }));
+        expect(screen.getByRole('switch', { name: /auto-sync/i })).toBeChecked();
+
+        await user.click(screen.getByRole('combobox'));
+        await user.click(screen.getByText('Mimir Alertmanager 2'));
+
+        // Give any (incorrect) reset effect a chance to fire before asserting it didn't.
+        await waitFor(() =>
+          expect(screen.getByPlaceholderText(/prometheus-prod/i)).toHaveValue('mimir-alertmanager-2')
+        );
+        expect(screen.getByRole('switch', { name: /auto-sync/i })).toBeChecked();
+        expect(screen.getByRole('switch', { name: /auto-sync/i })).toBeEnabled();
+      });
+
+      it('labels each datasource option with its auto-sync support', async () => {
+        grantUserRole('Admin');
+        const user = userEvent.setup();
+
+        render(
+          <TestWrapper defaultValues={{ notificationsSource: 'datasource' }}>
+            <Step1Content {...defaultStep1Props} />
+          </TestWrapper>
+        );
+
+        await user.click(screen.getByRole('combobox'));
+
+        const mimirOption = await screen.findByRole('option', { name: /Mimir Alertmanager/i });
+        expect(within(mimirOption).getByText('Auto-sync')).toBeInTheDocument();
+
+        const plainOption = screen.getByRole('option', { name: /^Alertmanager/i });
+        expect(within(plainOption).queryByText('Auto-sync')).not.toBeInTheDocument();
       });
     });
   });

--- a/public/app/features/alerting/unified/components/import-to-gma/steps/Step1AlertmanagerResources.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/steps/Step1AlertmanagerResources.tsx
@@ -1,13 +1,14 @@
 import { kebabCase } from 'lodash';
-import { useCallback, useEffect, useMemo } from 'react';
+import { type ComponentProps, useCallback, useEffect, useMemo } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 
-import { OrgRole, type SelectableValue } from '@grafana/data';
+import { type DataSourceSettings, OrgRole, type SelectableValue } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import {
   Alert,
+  Badge,
   Box,
   Divider,
   Field,
@@ -21,11 +22,13 @@ import {
   Label,
   RadioButtonList,
   Select,
+  SelectMenuOptions,
   Stack,
   Text,
   Tooltip,
 } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
+import { type AlertManagerDataSourceJsonData } from 'app/plugins/datasource/alertmanager/types';
 
 import { getAlertManagerDataSources } from '../../../utils/datasource';
 import { useAutoSyncConfiguration } from '../../settings/useAutoSyncConfiguration';
@@ -96,6 +99,12 @@ export function Step1Content({
   // Auto-sync mirrors the source directly, skipping Policy Tree Name and the dry-run.
   const autoSyncActive = isAutoSyncSelected(autoSyncNotificationsEnabled ?? false, notificationsSource);
 
+  // Called unconditionally (even for the YAML source) so the Auto-sync checkbox always knows
+  // whether the selected datasource qualifies; its own queries stay skipped for non-admins/toggle-off.
+  const { mimirCortexDatasources, isLoading: isLoadingAutoSyncConfig } = useAutoSyncConfiguration();
+  const isSelectedDatasourceAutoSyncCapable =
+    !isLoadingAutoSyncConfig && mimirCortexDatasources.some((ds) => ds.uid === notificationsDatasourceUID);
+
   const duplicateTemplateFileName = findDuplicateTemplateFileName(notificationsTemplateFiles);
 
   // Whether we have enough data to run a dry-run validation
@@ -131,6 +140,15 @@ export function Step1Content({
       clearErrors('policyTreeName');
     }
   }, [autoSyncActive, clearErrors]);
+
+  // Don't leave a stale checked Auto-sync flag pointing at a datasource that doesn't support it.
+  // Skip while loading so a legitimately-checked, still-valid selection isn't cleared against the
+  // momentarily-empty Mimir/Cortex list.
+  useEffect(() => {
+    if (!isLoadingAutoSyncConfig && !isSelectedDatasourceAutoSyncCapable && autoSyncNotificationsEnabled) {
+      setValue('autoSyncNotificationsEnabled', false);
+    }
+  }, [isLoadingAutoSyncConfig, isSelectedDatasourceAutoSyncCapable, autoSyncNotificationsEnabled, setValue]);
 
   // Trigger validation + dry-run when the policy tree name input loses focus
   const handlePolicyTreeNameBlur = useCallback(async () => {
@@ -281,16 +299,24 @@ export function Step1Content({
 
             {notificationsSource === 'datasource' && (
               <Stack direction="column" gap={2}>
-                <AlertmanagerDataSourceSelect autoSyncActive={autoSyncActive} />
+                <AlertmanagerDataSourceSelect mimirCortexDatasources={mimirCortexDatasources} />
                 {isAutoSyncSegmentEnabled() && (
                   <InlineField
                     transparent
                     label={t('alerting.import-to-gma.step1.autosync-label', 'Auto-sync')}
                     labelWidth={30}
-                    tooltip={t(
-                      'alerting.import-to-gma.step1.autosync-tooltip',
-                      'Continuously sync alert configuration from this data source instead of importing once. Alert rules are not synced automatically — import them separately in the next step if needed.'
-                    )}
+                    disabled={!isSelectedDatasourceAutoSyncCapable}
+                    tooltip={
+                      isSelectedDatasourceAutoSyncCapable
+                        ? t(
+                            'alerting.import-to-gma.step1.autosync-tooltip',
+                            'Continuously sync alert configuration from this data source instead of importing once. Alert rules are not synced automatically — import them separately in the next step if needed.'
+                          )
+                        : t(
+                            'alerting.import-to-gma.step1.autosync-tooltip-unsupported',
+                            "Auto-sync isn't available for this Alertmanager type. Select a Mimir or Cortex data source to enable it."
+                          )
+                    }
                   >
                     <InlineSwitch
                       transparent
@@ -418,23 +444,43 @@ export function useStep1Validation(canImport: boolean): boolean {
 }
 
 interface AlertmanagerDataSourceSelectProps {
-  /** Narrows the option list to Mimir/Cortex only, the sources Auto-sync can mirror. */
-  autoSyncActive: boolean;
+  /** Used to badge options that support Auto-sync. */
+  mimirCortexDatasources: Array<DataSourceSettings<AlertManagerDataSourceJsonData>>;
 }
 
-/** Dispatches to the Mimir/Cortex-only variant when Auto-sync is active, so its admin-only queries only run then. */
-function AlertmanagerDataSourceSelect({ autoSyncActive }: AlertmanagerDataSourceSelectProps) {
-  return autoSyncActive ? <MimirCortexDataSourceSelect /> : <AnyAlertmanagerDataSourceSelect />;
+/** Every Alertmanager data source (same source as AlertManagerPicker), badging the ones Auto-sync can mirror. */
+function AlertmanagerDataSourceSelect({ mimirCortexDatasources }: AlertmanagerDataSourceSelectProps) {
+  // Only annotate options for users who can ever see the Auto-sync segment at all — otherwise the
+  // badge would be noise with no checkbox to explain it. No separate loading guard is needed here:
+  // while the Mimir/Cortex query is in flight, mimirCortexDatasources is empty, so nothing gets
+  // badged yet regardless.
+  const shouldAnnotateAutoSync = isAutoSyncSegmentEnabled();
+
+  const alertmanagerOptions: Array<SelectableValue<string>> = useMemo(() => {
+    return getAlertManagerDataSources().map((ds) => ({
+      label: ds.name,
+      value: ds.uid,
+      imgUrl: ds.meta.info.logos.small,
+      description: ds.url || undefined,
+      supportsAutoSync: shouldAnnotateAutoSync ? mimirCortexDatasources.some((m) => m.uid === ds.uid) : undefined,
+    }));
+  }, [mimirCortexDatasources, shouldAnnotateAutoSync]);
+
+  return (
+    <DataSourceSelectField
+      options={alertmanagerOptions}
+      noOptionsMessage={t('alerting.import-to-gma.step1.no-datasources', 'No Alertmanager data sources found')}
+    />
+  );
 }
 
 interface DataSourceSelectFieldProps {
   options: Array<SelectableValue<string>>;
   noOptionsMessage: string;
-  description?: string;
 }
 
-/** Shared Select + autofill logic for both the broad and Mimir/Cortex-only data source pickers. */
-function DataSourceSelectField({ options, noOptionsMessage, description }: DataSourceSelectFieldProps) {
+/** Select + autofill logic for the Alertmanager data source picker. */
+function DataSourceSelectField({ options, noOptionsMessage }: DataSourceSelectFieldProps) {
   const {
     control,
     setValue,
@@ -445,7 +491,6 @@ function DataSourceSelectField({ options, noOptionsMessage, description }: DataS
   return (
     <Field
       label={t('alerting.import-to-gma.step1.datasource', 'Alertmanager data source')}
-      description={description}
       invalid={!!errors.notificationsDatasourceUID}
       error={errors.notificationsDatasourceUID?.message}
       noMargin
@@ -473,6 +518,7 @@ function DataSourceSelectField({ options, noOptionsMessage, description }: DataS
             placeholder={t('alerting.import-to-gma.step1.select-datasource', 'Select data source')}
             width={40}
             noOptionsMessage={noOptionsMessage}
+            components={{ Option: CustomOption }}
           />
         )}
         control={control}
@@ -482,60 +528,18 @@ function DataSourceSelectField({ options, noOptionsMessage, description }: DataS
   );
 }
 
-/** Broad Alertmanager data source list (excludes Grafana built-in), same source used by AlertManagerPicker. */
-function AnyAlertmanagerDataSourceSelect() {
-  const alertmanagerOptions: Array<SelectableValue<string>> = useMemo(() => {
-    const alertmanagerDataSources = getAlertManagerDataSources();
-    return alertmanagerDataSources.map((ds) => ({
-      label: ds.name,
-      value: ds.uid,
-      imgUrl: ds.meta.info.logos.small,
-      description: ds.url || undefined,
-    }));
-  }, []);
-
+/** Adds an inline "Auto-sync" badge next to datasources that support it — mirrors AlertManagerPicker's CustomOption. */
+function CustomOption(props: ComponentProps<typeof SelectMenuOptions>) {
   return (
-    <DataSourceSelectField
-      options={alertmanagerOptions}
-      noOptionsMessage={t('alerting.import-to-gma.step1.no-datasources', 'No Alertmanager data sources found')}
-    />
-  );
-}
-
-/** Mimir/Cortex-only data source list for Auto-sync. Mounted only while checked, so its admin-only queries don't otherwise run. */
-function MimirCortexDataSourceSelect() {
-  const { watch, setValue } = useFormContext<ImportFormValues>();
-  const notificationsDatasourceUID = watch('notificationsDatasourceUID');
-  const { mimirCortexDatasources, isLoading } = useAutoSyncConfiguration();
-
-  const options: Array<SelectableValue<string>> = useMemo(
-    () => mimirCortexDatasources.map((ds) => ({ value: ds.uid, label: ds.name, imgUrl: ds.typeLogoUrl })),
-    [mimirCortexDatasources]
-  );
-
-  // Clears a selection no longer in the narrowed list. Skip while loading — the list is also
-  // empty before the first response, which would wrongly clear a selection that's actually valid.
-  useEffect(() => {
-    if (
-      !isLoading &&
-      notificationsDatasourceUID &&
-      !mimirCortexDatasources.some((ds) => ds.uid === notificationsDatasourceUID)
-    ) {
-      setValue('notificationsDatasourceUID', undefined);
-      setValue('notificationsDatasourceName', null);
-    }
-  }, [isLoading, notificationsDatasourceUID, mimirCortexDatasources, setValue]);
-
-  return (
-    <DataSourceSelectField
-      options={options}
-      noOptionsMessage={t(
-        'alerting.import-to-gma.step1.no-mimir-cortex-datasources',
-        'No Mimir or Cortex data sources found'
-      )}
-      description={t(
-        'alerting.import-to-gma.step1.autosync-datasource-filtered',
-        'Auto-sync can only mirror from Mimir or Cortex Alertmanager data sources.'
+    <SelectMenuOptions
+      {...props}
+      renderOptionLabel={({ label, supportsAutoSync }) => (
+        <Stack direction="row" alignItems="center" gap={1}>
+          <span>{label}</span>
+          {supportsAutoSync && (
+            <Badge text={t('alerting.import-to-gma.step1.datasource-autosync-badge', 'Auto-sync')} color="green" />
+          )}
+        </Stack>
       )}
     />
   );

--- a/public/app/features/alerting/unified/components/import-to-gma/steps/Step1AlertmanagerResources.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/steps/Step1AlertmanagerResources.tsx
@@ -101,9 +101,9 @@ export function Step1Content({
 
   // Called unconditionally (even for the YAML source) so the Auto-sync checkbox always knows
   // whether the selected datasource qualifies; its own queries stay skipped for non-admins/toggle-off.
-  const { mimirCortexDatasources, isLoading: isLoadingAutoSyncConfig } = useAutoSyncConfiguration();
+  const { autoSyncEligibleAlertmanagers, isLoading: isLoadingAutoSyncConfig } = useAutoSyncConfiguration();
   const isSelectedDatasourceAutoSyncCapable =
-    !isLoadingAutoSyncConfig && mimirCortexDatasources.some((ds) => ds.uid === notificationsDatasourceUID);
+    !isLoadingAutoSyncConfig && autoSyncEligibleAlertmanagers.some((ds) => ds.uid === notificationsDatasourceUID);
 
   const duplicateTemplateFileName = findDuplicateTemplateFileName(notificationsTemplateFiles);
 
@@ -299,7 +299,7 @@ export function Step1Content({
 
             {notificationsSource === 'datasource' && (
               <Stack direction="column" gap={2}>
-                <AlertmanagerDataSourceSelect mimirCortexDatasources={mimirCortexDatasources} />
+                <AlertmanagerDataSourceSelect autoSyncEligibleAlertmanagers={autoSyncEligibleAlertmanagers} />
                 {isAutoSyncSegmentEnabled() && (
                   <InlineField
                     transparent
@@ -445,14 +445,14 @@ export function useStep1Validation(canImport: boolean): boolean {
 
 interface AlertmanagerDataSourceSelectProps {
   /** Used to badge options that support Auto-sync. */
-  mimirCortexDatasources: Array<DataSourceSettings<AlertManagerDataSourceJsonData>>;
+  autoSyncEligibleAlertmanagers: Array<DataSourceSettings<AlertManagerDataSourceJsonData>>;
 }
 
 /** Every Alertmanager data source (same source as AlertManagerPicker), badging the ones Auto-sync can mirror. */
-function AlertmanagerDataSourceSelect({ mimirCortexDatasources }: AlertmanagerDataSourceSelectProps) {
+function AlertmanagerDataSourceSelect({ autoSyncEligibleAlertmanagers }: AlertmanagerDataSourceSelectProps) {
   // Only annotate options for users who can ever see the Auto-sync segment at all — otherwise the
   // badge would be noise with no checkbox to explain it. No separate loading guard is needed here:
-  // while the Mimir/Cortex query is in flight, mimirCortexDatasources is empty, so nothing gets
+  // while the Mimir/Cortex query is in flight, autoSyncEligibleAlertmanagers is empty, so nothing gets
   // badged yet regardless.
   const shouldAnnotateAutoSync = isAutoSyncSegmentEnabled();
 
@@ -462,9 +462,11 @@ function AlertmanagerDataSourceSelect({ mimirCortexDatasources }: AlertmanagerDa
       value: ds.uid,
       imgUrl: ds.meta.info.logos.small,
       description: ds.url || undefined,
-      supportsAutoSync: shouldAnnotateAutoSync ? mimirCortexDatasources.some((m) => m.uid === ds.uid) : undefined,
+      supportsAutoSync: shouldAnnotateAutoSync
+        ? autoSyncEligibleAlertmanagers.some((m) => m.uid === ds.uid)
+        : undefined,
     }));
-  }, [mimirCortexDatasources, shouldAnnotateAutoSync]);
+  }, [autoSyncEligibleAlertmanagers, shouldAnnotateAutoSync]);
 
   return (
     <DataSourceSelectField

--- a/public/app/features/alerting/unified/components/settings/AutoSyncConfiguration.tsx
+++ b/public/app/features/alerting/unified/components/settings/AutoSyncConfiguration.tsx
@@ -15,19 +15,19 @@ interface AutoSyncConfigurationProps {
 
 export function AutoSyncConfiguration({ stagedConfigIdentifier }: AutoSyncConfigurationProps) {
   const styles = useStyles2(getStyles);
-  const { state, mimirCortexDatasources, selectedUid, setSelectedUid, save, disableSync, isPending, isLoading } =
+  const { state, autoSyncEligibleAlertmanagers, selectedUid, setSelectedUid, save, disableSync, isPending, isLoading } =
     useAutoSyncConfiguration();
 
   const [showDisableConfirm, setShowDisableConfirm] = useState(false);
 
   const options = useMemo<Array<SelectableValue<string>>>(
     () =>
-      mimirCortexDatasources.map((ds) => ({
+      autoSyncEligibleAlertmanagers.map((ds) => ({
         value: ds.uid,
         label: ds.name,
         imgUrl: ds.typeLogoUrl,
       })),
-    [mimirCortexDatasources]
+    [autoSyncEligibleAlertmanagers]
   );
 
   const operatorManaged = isOperatorManaged(state);

--- a/public/app/features/alerting/unified/components/settings/useAutoSyncConfiguration.test.tsx
+++ b/public/app/features/alerting/unified/components/settings/useAutoSyncConfiguration.test.tsx
@@ -133,7 +133,7 @@ describe('useAutoSyncConfiguration — state resolution', () => {
 
     const { result } = renderHook(() => useAutoSyncConfiguration(), { wrapper: wrapper() });
     await waitFor(() => expect(result.current.state.kind).toBe('no-datasources'));
-    expect(result.current.mimirCortexDatasources).toHaveLength(0);
+    expect(result.current.autoSyncEligibleAlertmanagers).toHaveLength(0);
   });
 
   it('returns `unconfigured` when no UID is configured even if 404 is returned from admin_config', async () => {

--- a/public/app/features/alerting/unified/components/settings/useAutoSyncConfiguration.tsx
+++ b/public/app/features/alerting/unified/components/settings/useAutoSyncConfiguration.tsx
@@ -24,7 +24,7 @@ export type AutoSyncState =
 
 export interface UseAutoSyncConfigurationResult {
   state: AutoSyncState;
-  mimirCortexDatasources: Array<DataSourceSettings<AlertManagerDataSourceJsonData>>;
+  autoSyncEligibleAlertmanagers: Array<DataSourceSettings<AlertManagerDataSourceJsonData>>;
   selectedUid: string;
   setSelectedUid: (uid: string) => void;
   /** Persists the given UID (or the current selection). Resolves to true on success. */
@@ -71,13 +71,13 @@ export function useAutoSyncConfiguration(): UseAutoSyncConfigurationResult {
 
   const [operatorManagedUid, setOperatorManagedUid] = useState<string | null>(null);
 
-  const mimirCortexDatasources = useMemo(
+  const autoSyncEligibleAlertmanagers = useMemo(
     () => (allDatasources ?? []).filter(isAlertmanagerDataSource).filter(isMimirOrCortex),
     [allDatasources]
   );
 
   const configuredUid = configuration?.external_alertmanager_uid ?? '';
-  const hasMatchingDatasource = mimirCortexDatasources.some((ds) => ds.uid === configuredUid);
+  const hasMatchingDatasource = autoSyncEligibleAlertmanagers.some((ds) => ds.uid === configuredUid);
 
   // Track user-edited selection separately from the saved value so a background refetch
   // doesn't overwrite an in-flight choice. Null means "follow the saved value".
@@ -94,11 +94,11 @@ export function useAutoSyncConfiguration(): UseAutoSyncConfigurationResult {
     if (configuredUid) {
       return { kind: 'orphan-uid', uid: configuredUid };
     }
-    if (mimirCortexDatasources.length === 0) {
+    if (autoSyncEligibleAlertmanagers.length === 0) {
       return { kind: 'no-datasources' };
     }
     return { kind: 'unconfigured' };
-  }, [operatorManagedUid, configuredUid, hasMatchingDatasource, mimirCortexDatasources.length]);
+  }, [operatorManagedUid, configuredUid, hasMatchingDatasource, autoSyncEligibleAlertmanagers.length]);
 
   const notify = useAppNotification();
 
@@ -134,7 +134,7 @@ export function useAutoSyncConfiguration(): UseAutoSyncConfigurationResult {
 
   return {
     state,
-    mimirCortexDatasources,
+    autoSyncEligibleAlertmanagers,
     selectedUid,
     setSelectedUid: (uid: string) => setSelectedOverride(uid),
     save: (uidOverride?: string, opts?: { silent?: boolean }) => persist(uidOverride ?? selectedUid, opts),

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1745,14 +1745,14 @@
         "yaml-description": "Import rules from a Prometheus YAML file."
       },
       "step1": {
-        "autosync-datasource-filtered": "Auto-sync can only mirror from Mimir or Cortex Alertmanager data sources.",
         "autosync-label": "Auto-sync",
         "autosync-tooltip": "Continuously sync alert configuration from this data source instead of importing once. Alert rules are not synced automatically — import them separately in the next step if needed.",
+        "autosync-tooltip-unsupported": "Auto-sync isn't available for this Alertmanager type. Select a Mimir or Cortex data source to enable it.",
         "datasource": "Alertmanager data source",
+        "datasource-autosync-badge": "Auto-sync",
         "heading": "Import Notification Resources",
         "next-disabled-tooltip": "Complete the required fields and wait for validation to pass before continuing.",
         "no-datasources": "No Alertmanager data sources found",
-        "no-mimir-cortex-datasources": "No Mimir or Cortex data sources found",
         "no-permission-desc": "You do not have permission to import notification resources. You need the <strong>alerting.notifications:write</strong> permission. You can skip this step.",
         "no-permission-title": "Insufficient permissions",
         "policy-tree-autosync-disabled": "Not needed. Auto-sync mirrors the source directly, so there's no policy tree to name.",


### PR DESCRIPTION
**What is this feature?**

Step 1 of the GMA import wizard used two different Alertmanager datasource dropdowns. It showed every Alertmanager when Auto-sync was unchecked, and only Mimir or Cortex ones when checked. This replaces both with one dropdown that always lists every Alertmanager datasource. Each entry that supports Auto-sync gets a small badge.

The Auto-sync checkbox now disables itself with a tooltip when the selected datasource does not support Auto-sync. It enables once a supported datasource is selected. It unchecks automatically if you switch to a datasource that does not support Auto-sync. It stays checked if you switch between two datasources that both support it.


https://github.com/user-attachments/assets/294b5045-8ffe-4a9a-bf8c-5f9d4c9d6472



**Why do we need this feature?**

The old two-dropdown design hid which datasources supported Auto-sync until you checked the box. Toggling the checkbox could also silently clear or narrow your selection. This makes support visible up front and keeps the selection stable.

**Who is this feature for?**

Alerting users migrating to GMA

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
