### PR TITLE
Plugins: Return CDN relative core plugin asset paths when a CDN is configured

### DIFF
--- a/apps/plugins/pkg/app/meta/core_test.go
+++ b/apps/plugins/pkg/app/meta/core_test.go
@@ -380,6 +380,46 @@ func TestAssetProvider(t *testing.T) {
 	})
 }
 
+func TestCoreProvider_decoupledCoreAssetPaths(t *testing.T) {
+	const pluginID = "graphite"
+
+	newStaticRoot := func(t *testing.T) string {
+		t.Helper()
+		staticRootPath := filepath.Join(t.TempDir(), "public")
+		distDir := filepath.Join(staticRootPath, "app", "plugins", "datasource", pluginID, "dist")
+		require.NoError(t, os.MkdirAll(distDir, 0750))
+
+		pluginJSON := `{"id":"graphite","name":"Graphite","type":"datasource","info":{"version":"1.0.0"}}`
+		require.NoError(t, os.WriteFile(filepath.Join(distDir, "plugin.json"), []byte(pluginJSON), 0644))
+
+		return staticRootPath
+	}
+
+	loadMeta := func(t *testing.T, cdnAssets bool) pluginsv0alpha1.MetaSpec {
+		t.Helper()
+		provider := NewCoreProviderWithTTL(&logging.NoOpLogger{}, newStaticRoot(t), cdnAssets, defaultCoreTTL)
+		require.NoError(t, provider.loadPlugins(context.Background()))
+
+		meta, found := provider.loadedPlugins[pluginID]
+		require.True(t, found, "decoupled core plugin should be discovered under the static root")
+		return meta
+	}
+
+	t.Run("cdn assets", func(t *testing.T) {
+		meta := loadMeta(t, true)
+
+		assert.Equal(t, "app/plugins/datasource/graphite/dist/module.js", meta.Module.Path)
+		assert.Equal(t, "app/plugins/datasource/graphite/dist", meta.BaseURL)
+	})
+
+	t.Run("non-cdn assets", func(t *testing.T) {
+		meta := loadMeta(t, false)
+
+		assert.Equal(t, "plugins/graphite/module.js", meta.Module.Path)
+		assert.Equal(t, "plugins/graphite", meta.BaseURL)
+	})
+}
+
 func TestJsonDataToMeta(t *testing.T) {
 	t.Run("converts basic plugin JSON data", func(t *testing.T) {
 		jsonData := plugins.JSONData{

--- a/pkg/registry/apps/plugins/register.go
+++ b/pkg/registry/apps/plugins/register.go
@@ -57,11 +57,7 @@ func ProvideAppInstaller(
 	logger := logging.DefaultLogger.With("app", "plugins.app")
 
 	localProvider := meta.NewLocalProvider(pluginStore, moduleHashCalc)
-	coreProvider, err := meta.NewCoreProvider(logger, meta.CoreProviderOpts{
-		StaticRootPath: func() (string, error) {
-			return getStaticRootPath(cfgProvider, logger)
-		},
-	})
+	coreProvider, err := meta.NewCoreProvider(logger, coreProviderOpts(cfgProvider, logger))
 	if err != nil {
 		return nil, err
 	}
@@ -85,6 +81,35 @@ func ProvideAppInstaller(
 		restConfigProvider: restConfigProvider,
 		PluginAppInstaller: i,
 	}, nil
+}
+
+func coreProviderOpts(cfgProvider configprovider.ConfigProvider, logger logging.Logger) meta.CoreProviderOpts {
+	return meta.CoreProviderOpts{
+		StaticRootPath: func() (string, error) {
+			return getStaticRootPath(cfgProvider, logger)
+		},
+		CDNAssets: cdnAssetsEnabled(cfgProvider, logger),
+	}
+}
+
+func cdnAssetsEnabled(cfgProvider configprovider.ConfigProvider, logger logging.Logger) bool {
+	cfg, err := cfgProvider.Get(context.Background())
+	if err != nil {
+		logger.Warn("Could not read config to detect a content delivery URL, serving core plugin assets from Grafana", "error", err)
+		return false
+	}
+	if cfg == nil {
+		logger.Warn("Config provider returned no config, serving core plugin assets from Grafana")
+		return false
+	}
+
+	cdnURL, err := cfg.GetContentDeliveryURL("")
+	if err != nil {
+		logger.Warn("Could not resolve content delivery URL, serving core plugin assets from Grafana", "error", err)
+		return false
+	}
+
+	return cdnURL != ""
 }
 
 func getStaticRootPath(cfgProvider configprovider.ConfigProvider, logger logging.Logger) (string, error) {

--- a/pkg/registry/apps/plugins/register_test.go
+++ b/pkg/registry/apps/plugins/register_test.go
@@ -1,0 +1,163 @@
+package plugins
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/grafana/grafana-app-sdk/logging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/ini.v1"
+
+	"github.com/grafana/grafana/apps/plugins/pkg/app/meta"
+	"github.com/grafana/grafana/pkg/configprovider"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func testConfigProvider(t *testing.T, cfg *setting.Cfg) configprovider.ConfigProvider {
+	t.Helper()
+	provider, err := configprovider.ProvideService(cfg)
+	require.NoError(t, err)
+	return provider
+}
+
+type failingConfigProvider struct{}
+
+func (failingConfigProvider) Get(context.Context) (*setting.Cfg, error) {
+	return nil, errors.New("config unavailable")
+}
+
+func (failingConfigProvider) GetSections(context.Context, ...string) (*ini.File, error) {
+	return nil, errors.New("config unavailable")
+}
+
+type nilConfigProvider struct{}
+
+func (nilConfigProvider) Get(context.Context) (*setting.Cfg, error) {
+	return nil, nil
+}
+
+func (nilConfigProvider) GetSections(context.Context, ...string) (*ini.File, error) {
+	return ini.Empty(), nil
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	return u
+}
+
+func TestCDNAssetsEnabled(t *testing.T) {
+	logger := &logging.NoOpLogger{}
+
+	t.Run("cdn_url and build version set", func(t *testing.T) {
+		cfg := &setting.Cfg{
+			CDNRootURL:   mustParseURL(t, "http://cdn.grafana.com"),
+			BuildVersion: "v7.5.0-11124",
+		}
+
+		assert.True(t, cdnAssetsEnabled(testConfigProvider(t, cfg), logger))
+	})
+
+	t.Run("cdn_url with a path prefix", func(t *testing.T) {
+		cfg := &setting.Cfg{
+			CDNRootURL:   mustParseURL(t, "http://cdn.grafana.com/sub"),
+			BuildVersion: "v7.5.0-11124",
+		}
+
+		assert.True(t, cdnAssetsEnabled(testConfigProvider(t, cfg), logger))
+	})
+
+	t.Run("no cdn_url configured", func(t *testing.T) {
+		cfg := &setting.Cfg{BuildVersion: "v7.5.0-11124"}
+
+		assert.False(t, cdnAssetsEnabled(testConfigProvider(t, cfg), logger))
+	})
+
+	t.Run("cdn_url set but build version missing", func(t *testing.T) {
+		cfg := &setting.Cfg{CDNRootURL: mustParseURL(t, "http://cdn.grafana.com")}
+
+		assert.False(t, cdnAssetsEnabled(testConfigProvider(t, cfg), logger))
+	})
+
+	t.Run("config provider fails", func(t *testing.T) {
+		assert.False(t, cdnAssetsEnabled(failingConfigProvider{}, logger))
+	})
+
+	t.Run("config provider returns no config", func(t *testing.T) {
+		assert.False(t, cdnAssetsEnabled(nilConfigProvider{}, logger))
+	})
+}
+
+func TestCoreProviderOpts(t *testing.T) {
+	logger := &logging.NoOpLogger{}
+
+	newStaticRoot := func(t *testing.T) string {
+		t.Helper()
+		staticRootPath := filepath.Join(t.TempDir(), "public")
+		distDir := filepath.Join(staticRootPath, "app", "plugins", "datasource", "graphite", "dist")
+		require.NoError(t, os.MkdirAll(distDir, 0750))
+
+		pluginJSON := `{"id":"graphite","name":"Graphite","type":"datasource","info":{"version":"1.0.0"}}`
+		require.NoError(t, os.WriteFile(filepath.Join(distDir, "plugin.json"), []byte(pluginJSON), 0644))
+
+		return staticRootPath
+	}
+
+	emitted := func(t *testing.T, cfg *setting.Cfg) (meta.CoreProviderOpts, *meta.Result) {
+		t.Helper()
+		opts := coreProviderOpts(testConfigProvider(t, cfg), logger)
+
+		provider, err := meta.NewCoreProvider(logger, opts)
+		require.NoError(t, err)
+
+		result, err := provider.GetMeta(context.Background(), meta.PluginRef{ID: "graphite"})
+		require.NoError(t, err)
+
+		return opts, result
+	}
+
+	t.Run("cdn hosted instance", func(t *testing.T) {
+		staticRootPath := newStaticRoot(t)
+		cfg := &setting.Cfg{
+			StaticRootPath: staticRootPath,
+			CDNRootURL:     mustParseURL(t, "http://cdn.grafana.com"),
+			BuildVersion:   "v7.5.0-11124",
+		}
+
+		opts, result := emitted(t, cfg)
+
+		assert.True(t, opts.CDNAssets)
+		assert.Equal(t, "app/plugins/datasource/graphite/dist/module.js", result.Meta.Module.Path)
+		assert.Equal(t, "app/plugins/datasource/graphite/dist", result.Meta.BaseURL)
+		assert.NotContains(t, result.Meta.Module.Path, "cdn.grafana.com")
+		assert.NotContains(t, result.Meta.BaseURL, "cdn.grafana.com")
+
+		resolved, err := opts.StaticRootPath()
+		require.NoError(t, err)
+		assert.Equal(t, staticRootPath, resolved)
+	})
+
+	t.Run("self hosted instance", func(t *testing.T) {
+		staticRootPath := newStaticRoot(t)
+		cfg := &setting.Cfg{
+			StaticRootPath: staticRootPath,
+			BuildVersion:   "v7.5.0-11124",
+		}
+
+		opts, result := emitted(t, cfg)
+
+		assert.False(t, opts.CDNAssets)
+		assert.Equal(t, "plugins/graphite/module.js", result.Meta.Module.Path)
+		assert.Equal(t, "plugins/graphite", result.Meta.BaseURL)
+
+		resolved, err := opts.StaticRootPath()
+		require.NoError(t, err)
+		assert.Equal(t, staticRootPath, resolved)
+	})
+}


### PR DESCRIPTION
**What is this feature?**

The plugins meta app is registered in-process without `CDNAssets` set, so it always returns Grafana-relative asset paths for core plugins, for example `plugins/graphite/module.js`. This derives the option from whether a content delivery URL is configured, so instances that serve static assets from a CDN get paths relative to the static root instead.

The condition uses `cfg.GetContentDeliveryURL`, the same call `webassets` makes when deciding whether to render `index.html` with a content delivery URL, so the two cannot drift apart.

**Why do we need this feature?**

The `plugins/<id>/...` shape only resolves through Grafana's `/public/plugins/:pluginId` route, which exists on the Grafana origin. When a content delivery URL is configured, `prependPublicPathToCorePlugins` prepends it, so the browser asks the static asset bucket for that path instead. The bucket has no `public/plugins/<id>/` directory, because core plugin assets live under `public/app/plugins/<type>/<id>/`, so the request 404s.

That produces two symptoms on an affected instance:

- Decoupled core datasources fail to load, because `module` is prepended for them. On a current build that is `graphite`, `grafana-testdata-datasource`, `cloudwatch`, and `grafana-azure-monitor-datasource`.
- `baseUrl` and the logo paths are prepended for *every* core plugin, not only decoupled ones, so core panel icons 404 as well.

Verified against a CDN-backed instance: all 38 core plugin metas currently emit paths that 404 on the asset host, and the static-root-relative equivalents return the assets.

The standalone apiserver already passes `CDNAssets: true`, so only the in-process path changes. Instances with no content delivery URL configured, which includes self-hosted, evaluate to false and keep their current behavior exactly.

**Who is this feature for?**

Grafana Cloud users on instances that serve static assets from a CDN and have the plugins meta API enabled.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

This is only reachable with `plugins.useMTPlugins` enabled, which is what routes the frontend through the plugins meta API.

Tests added:

- `cdnAssetsEnabled` and `coreProviderOpts` in `pkg/registry/apps/plugins/register_test.go`, covering a configured CDN, a CDN with a path prefix, no CDN, a missing build version, a failing config provider, and a config provider returning no config.
- `TestCoreProvider_decoupledCoreAssetPaths` in `apps/plugins/pkg/app/meta/core_test.go`, pinning the emitted meta for a built decoupled core plugin in both modes.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated. No docs change needed here, this is a bug fix with no user-facing configuration.
