### PR TITLE
Canvas: Remove unused legacy canvasExternalPlugin feature flag

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -325,11 +325,6 @@ export interface FeatureToggles {
   */
   canvasPanelPanZoom?: boolean;
   /**
-  * Load Canvas panel from an external plugin instead of the bundled core plugin
-  * @default false
-  */
-  canvasExternalPlugin?: boolean;
-  /**
   * Enables time comparison option in supported panels
   * @default false
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -712,14 +712,6 @@ var (
 			Expression:  "false",
 		},
 		{
-			Name:        "canvasExternalPlugin",
-			Description: "Load Canvas panel from an external plugin instead of the bundled core plugin",
-			Stage:       FeatureStageExperimental,
-			Owner:       grafanaDatavizSquad,
-			Expression:  "false",
-			Generate:    Generate{LegacyGo: true, LegacyFrontend: true},
-		},
-		{
 			Name:        "timeComparison",
 			Description: "Enables time comparison option in supported panels",
 			Stage:       FeatureStagePublicPreview,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -81,7 +81,6 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-05-22,reportRenderBinding,experimental,@grafana/grafana-operator-experience-squad,false,false,false
 2026-08-13,reportRenderQueryDebounce,experimental,@grafana/grafana-operator-experience-squad,false,false,true
 2024-01-02,canvasPanelPanZoom,preview,@grafana/dataviz-squad,false,false,true
-2026-06-08,canvasExternalPlugin,experimental,@grafana/dataviz-squad,false,false,false
 2025-07-24,timeComparison,preview,@grafana/dataviz-squad,false,false,true
 2023-12-13,tableSharedCrosshair,experimental,@grafana/dataviz-squad,false,false,true
 2026-05-22,stateTimeline.nameAboveBars,experimental,@grafana/dataviz-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -239,10 +239,6 @@ const (
 	// Enables render binding support for report rendering
 	FlagReportRenderBinding = "reportRenderBinding"
 
-	// FlagCanvasExternalPlugin
-	// Load Canvas panel from an external plugin instead of the bundled core plugin
-	FlagCanvasExternalPlugin = "canvasExternalPlugin"
-
 	// FlagCloudRBACRoles
 	// Enabled grafana cloud specific RBAC roles
 	FlagCloudRBACRoles = "cloudRBACRoles"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1345,19 +1345,6 @@
     },
     {
       "metadata": {
-        "name": "canvasExternalPlugin",
-        "resourceVersion": "1780948766147",
-        "creationTimestamp": "2026-06-08T19:59:26Z"
-      },
-      "spec": {
-        "description": "Load Canvas panel from an external plugin instead of the bundled core plugin",
-        "stage": "experimental",
-        "codeowner": "@grafana/dataviz-squad",
-        "expression": "false"
-      }
-    },
-    {
-      "metadata": {
         "name": "canvasPanelNesting",
         "resourceVersion": "1779440584464",
         "creationTimestamp": "2022-05-31T19:03:34Z"


### PR DESCRIPTION
Fixes 🎟️ https://github.com/grafana/grafana/issues/129145
