### PR TITLE
[release-12.4.10] MSSQL: Don't send twice to the result channel when `processResponse` fails

### DIFF
--- a/pkg/tsdb/mssql/sqleng/sql_engine.go
+++ b/pkg/tsdb/mssql/sqleng/sql_engine.go
@@ -375,6 +375,10 @@ func (e *DataSourceHandler) executeQuery(query backend.DataQuery, wg *sync.WaitG
 	}
 
 	frame := e.processResponse(qm, rows, interpolatedQuery, errAppendDebug)
+	if frame == nil {
+		// processResponse failed and handled the query result with errAppendDebug
+		return
+	}
 
 	queryResult.dataResponse.Frames = data.Frames{frame}
 	ch <- queryResult


### PR DESCRIPTION
Manual backport of https://github.com/grafana/grafana-mssql-datasource/pull/74 - this datasource has been externalized and its code no longer lives in core Grafana