### PR TITLE
Explore: show equivalent samples read for metric queries

### DIFF
--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -397,6 +397,7 @@ export class Explore extends PureComponent<Props, ExploreState> {
       <ContentOutlineItem panelId="Graph" title={t('explore.explore.title-graph', 'Graph')} icon="graph-bar">
         <GraphContainer
           data={graphResult!}
+          allSeries={queryResponse.series}
           height={showFlameGraph ? 180 : 400}
           width={width}
           timeRange={queryResponse.timeRange}

--- a/public/app/features/explore/Graph/GraphContainer.tsx
+++ b/public/app/features/explore/Graph/GraphContainer.tsx
@@ -20,6 +20,7 @@ import { storeGraphStyle } from '../state/utils';
 
 import { ExploreGraph } from './ExploreGraph';
 import { ExploreGraphLabel } from './ExploreGraphLabel';
+import { GraphMetaInfo } from './GraphMetaInfo';
 import { loadGraphStyle } from './utils';
 
 const MAX_NUMBER_OF_TIME_SERIES = 20;
@@ -69,50 +70,55 @@ export const GraphContainer = ({
   }, [data, showAllSeries]);
 
   return (
-    <PanelChrome
-      title={t('graph.container.title', 'Graph')}
-      titleItems={[
-        !showAllSeries && MAX_NUMBER_OF_TIME_SERIES < data.length && (
-          <LimitedDataDisclaimer
-            key="disclaimer"
-            toggleShowAllSeries={toggleShowAllSeries}
-            info={
-              <Trans i18nKey={'graph.container.show-only-series'}>
-                Showing only {{ MAX_NUMBER_OF_TIME_SERIES }} series
-              </Trans>
-            }
-            buttonLabel={<Trans i18nKey={'graph.container.show-all-series'}>Show all {{ length: data.length }}</Trans>}
-            tooltip={t(
-              'graph.container.content',
-              'Rendering too many series in a single panel may impact performance and make data harder to read. Consider refining your queries.'
-            )}
+    <>
+      <GraphMetaInfo data={data} />
+      <PanelChrome
+        title={t('graph.container.title', 'Graph')}
+        titleItems={[
+          !showAllSeries && MAX_NUMBER_OF_TIME_SERIES < data.length && (
+            <LimitedDataDisclaimer
+              key="disclaimer"
+              toggleShowAllSeries={toggleShowAllSeries}
+              info={
+                <Trans i18nKey={'graph.container.show-only-series'}>
+                  Showing only {{ MAX_NUMBER_OF_TIME_SERIES }} series
+                </Trans>
+              }
+              buttonLabel={
+                <Trans i18nKey={'graph.container.show-all-series'}>Show all {{ length: data.length }}</Trans>
+              }
+              tooltip={t(
+                'graph.container.content',
+                'Rendering too many series in a single panel may impact performance and make data harder to read. Consider refining your queries.'
+              )}
+            />
+          ),
+        ].filter(Boolean)}
+        width={width}
+        height={height}
+        loadingState={loadingState}
+        statusMessage={statusMessage}
+        actions={<ExploreGraphLabel graphStyle={graphStyle} onChangeGraphStyle={onGraphStyleChange} />}
+      >
+        {(innerWidth, innerHeight) => (
+          <ExploreGraph
+            graphStyle={graphStyle}
+            data={slicedData}
+            height={innerHeight}
+            width={innerWidth}
+            timeRange={timeRange}
+            onChangeTime={onChangeTime}
+            timeZone={timeZone}
+            annotations={annotations}
+            splitOpenFn={splitOpenFn}
+            loadingState={loadingState}
+            thresholdsConfig={thresholdsConfig}
+            thresholdsStyle={thresholdsStyle}
+            eventBus={eventBus}
+            queriesChangedIndexAtRun={queriesChangedIndexAtRun}
           />
-        ),
-      ].filter(Boolean)}
-      width={width}
-      height={height}
-      loadingState={loadingState}
-      statusMessage={statusMessage}
-      actions={<ExploreGraphLabel graphStyle={graphStyle} onChangeGraphStyle={onGraphStyleChange} />}
-    >
-      {(innerWidth, innerHeight) => (
-        <ExploreGraph
-          graphStyle={graphStyle}
-          data={slicedData}
-          height={innerHeight}
-          width={innerWidth}
-          timeRange={timeRange}
-          onChangeTime={onChangeTime}
-          timeZone={timeZone}
-          annotations={annotations}
-          splitOpenFn={splitOpenFn}
-          loadingState={loadingState}
-          thresholdsConfig={thresholdsConfig}
-          thresholdsStyle={thresholdsStyle}
-          eventBus={eventBus}
-          queriesChangedIndexAtRun={queriesChangedIndexAtRun}
-        />
-      )}
-    </PanelChrome>
+        )}
+      </PanelChrome>
+    </>
   );
 };

--- a/public/app/features/explore/Graph/GraphContainer.tsx
+++ b/public/app/features/explore/Graph/GraphContainer.tsx
@@ -29,6 +29,10 @@ interface Props extends Pick<PanelChromeProps, 'statusMessage'> {
   width: number;
   height: number;
   data: DataFrame[];
+  // All series from the query response, unfiltered by visualisation type, so
+  // stats from query types not rendered by the graph (e.g. instant, exemplar)
+  // are still available to GraphMetaInfo.
+  allSeries: DataFrame[];
   annotations?: DataFrame[];
   eventBus: EventBus;
   timeRange: TimeRange;
@@ -43,6 +47,7 @@ interface Props extends Pick<PanelChromeProps, 'statusMessage'> {
 
 export const GraphContainer = ({
   data,
+  allSeries,
   eventBus,
   height,
   width,
@@ -100,7 +105,7 @@ export const GraphContainer = ({
       {(innerWidth, innerHeight) => (
         <>
           <div ref={metaInfoRef}>
-            <GraphMetaInfo data={data} />
+            <GraphMetaInfo data={allSeries} />
           </div>
           <ExploreGraph
             graphStyle={graphStyle}

--- a/public/app/features/explore/Graph/GraphContainer.tsx
+++ b/public/app/features/explore/Graph/GraphContainer.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
-import { useToggle } from 'react-use';
+import { useMeasure, useToggle } from 'react-use';
 
 import {
   type DataFrame,
@@ -59,6 +59,7 @@ export const GraphContainer = ({
 }: Props) => {
   const [showAllSeries, toggleShowAllSeries] = useToggle(false);
   const [graphStyle, setGraphStyle] = useState(loadGraphStyle);
+  const [metaInfoRef, { height: metaInfoHeight }] = useMeasure<HTMLDivElement>();
 
   const onGraphStyleChange = useCallback((graphStyle: ExploreGraphStyle) => {
     storeGraphStyle(graphStyle);
@@ -70,41 +71,41 @@ export const GraphContainer = ({
   }, [data, showAllSeries]);
 
   return (
-    <>
-      <GraphMetaInfo data={data} />
-      <PanelChrome
-        title={t('graph.container.title', 'Graph')}
-        titleItems={[
-          !showAllSeries && MAX_NUMBER_OF_TIME_SERIES < data.length && (
-            <LimitedDataDisclaimer
-              key="disclaimer"
-              toggleShowAllSeries={toggleShowAllSeries}
-              info={
-                <Trans i18nKey={'graph.container.show-only-series'}>
-                  Showing only {{ MAX_NUMBER_OF_TIME_SERIES }} series
-                </Trans>
-              }
-              buttonLabel={
-                <Trans i18nKey={'graph.container.show-all-series'}>Show all {{ length: data.length }}</Trans>
-              }
-              tooltip={t(
-                'graph.container.content',
-                'Rendering too many series in a single panel may impact performance and make data harder to read. Consider refining your queries.'
-              )}
-            />
-          ),
-        ].filter(Boolean)}
-        width={width}
-        height={height}
-        loadingState={loadingState}
-        statusMessage={statusMessage}
-        actions={<ExploreGraphLabel graphStyle={graphStyle} onChangeGraphStyle={onGraphStyleChange} />}
-      >
-        {(innerWidth, innerHeight) => (
+    <PanelChrome
+      title={t('graph.container.title', 'Graph')}
+      titleItems={[
+        !showAllSeries && MAX_NUMBER_OF_TIME_SERIES < data.length && (
+          <LimitedDataDisclaimer
+            key="disclaimer"
+            toggleShowAllSeries={toggleShowAllSeries}
+            info={
+              <Trans i18nKey={'graph.container.show-only-series'}>
+                Showing only {{ MAX_NUMBER_OF_TIME_SERIES }} series
+              </Trans>
+            }
+            buttonLabel={<Trans i18nKey={'graph.container.show-all-series'}>Show all {{ length: data.length }}</Trans>}
+            tooltip={t(
+              'graph.container.content',
+              'Rendering too many series in a single panel may impact performance and make data harder to read. Consider refining your queries.'
+            )}
+          />
+        ),
+      ].filter(Boolean)}
+      width={width}
+      height={height}
+      loadingState={loadingState}
+      statusMessage={statusMessage}
+      actions={<ExploreGraphLabel graphStyle={graphStyle} onChangeGraphStyle={onGraphStyleChange} />}
+    >
+      {(innerWidth, innerHeight) => (
+        <>
+          <div ref={metaInfoRef}>
+            <GraphMetaInfo data={data} />
+          </div>
           <ExploreGraph
             graphStyle={graphStyle}
             data={slicedData}
-            height={innerHeight}
+            height={innerHeight - metaInfoHeight}
             width={innerWidth}
             timeRange={timeRange}
             onChangeTime={onChangeTime}
@@ -117,8 +118,8 @@ export const GraphContainer = ({
             eventBus={eventBus}
             queriesChangedIndexAtRun={queriesChangedIndexAtRun}
           />
-        )}
-      </PanelChrome>
-    </>
+        </>
+      )}
+    </PanelChrome>
   );
 };

--- a/public/app/features/explore/Graph/GraphMetaInfo.test.tsx
+++ b/public/app/features/explore/Graph/GraphMetaInfo.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+
+import { toDataFrame, FieldType } from '@grafana/data';
+
+import { GraphMetaInfo } from './GraphMetaInfo';
+
+function graphFrame(refId: string, queryType?: 'Exemplar' | 'Instant' | 'Range', samples?: number) {
+  return toDataFrame({
+    refId,
+    fields: [
+      { name: 'Time', type: FieldType.time, values: [0] },
+      { name: 'Value', type: FieldType.number, values: [1] },
+    ],
+    meta:
+      queryType === undefined || samples === undefined
+        ? undefined
+        : { stats: [{ displayName: `${queryType}: Equivalent samples read`, unit: 'short', value: samples }] },
+  });
+}
+
+describe('GraphMetaInfo', () => {
+  it('renders the formatted equivalent samples read stat', () => {
+    render(<GraphMetaInfo data={[graphFrame('A', 'Range', 17647)]} />);
+
+    expect(screen.getByText('Equivalent samples read:')).toBeInTheDocument();
+    expect(screen.getByText('17.6 K')).toBeInTheDocument();
+  });
+
+  it('sums the stat across duplicate frames for the same query, deduping by refId and query type', () => {
+    render(
+      <GraphMetaInfo
+        data={[graphFrame('A', 'Range', 1000), graphFrame('A', 'Range', 1000), graphFrame('B', 'Range', 1000)]}
+      />
+    );
+
+    expect(screen.getByText('2 K')).toBeInTheDocument();
+  });
+
+  it('sums the stat across query types for the same refId', () => {
+    render(
+      <GraphMetaInfo
+        data={[graphFrame('A', 'Range', 1000), graphFrame('A', 'Instant', 500), graphFrame('A', 'Exemplar', 250)]}
+      />
+    );
+
+    expect(screen.getByText('1.75 K')).toBeInTheDocument();
+  });
+
+  it('renders nothing when no frame carries the stat', () => {
+    const { container } = render(<GraphMetaInfo data={[graphFrame('A')]} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/public/app/features/explore/Graph/GraphMetaInfo.tsx
+++ b/public/app/features/explore/Graph/GraphMetaInfo.tsx
@@ -1,0 +1,59 @@
+import { type DataFrame, formattedValueToString, getValueFormat } from '@grafana/data';
+import { t } from '@grafana/i18n';
+
+import { MetaInfoText } from '../MetaInfoText';
+
+// Display name set by the Prometheus/Mimir backend (promlib) for the
+// equivalent-samples-read query stat parsed from the Server-Timing header.
+// A query can run as a range, instant, and exemplar request at once, each
+// carrying its own stat prefixed with its query type, so all three are
+// matched. In practice only range/instant reach `data` here — exemplar
+// frames are routed to Explore's annotations, not the series this component
+// reads — but matching all three keeps this in step with the backend.
+const EQUIVALENT_SAMPLES_READ_STAT = /^(Exemplar|Instant|Range): Equivalent samples read$/;
+
+interface Props {
+  data: DataFrame[];
+}
+
+export function GraphMetaInfo({ data }: Props) {
+  let totalSamples = 0;
+  let unit = 'short';
+  // Keyed by refId + stat name, since one refId can carry a stat per query type.
+  const statsVisited: Record<string, boolean> = {};
+
+  for (const frame of data) {
+    const { refId } = frame;
+    if (!refId) {
+      continue;
+    }
+    const stat = frame.meta?.stats?.find((s) => EQUIVALENT_SAMPLES_READ_STAT.test(s.displayName ?? ''));
+    if (!stat) {
+      continue;
+    }
+    const statKey = `${refId}:${stat.displayName}`;
+    if (statsVisited[statKey]) {
+      continue;
+    }
+    statsVisited[statKey] = true;
+    totalSamples += stat.value;
+    if (stat.unit) {
+      unit = stat.unit;
+    }
+  }
+
+  if (totalSamples <= 0) {
+    return null;
+  }
+
+  return (
+    <MetaInfoText
+      metaItems={[
+        {
+          label: t('graph.meta-info.equivalent-samples-read', 'Equivalent samples read'),
+          value: formattedValueToString(getValueFormat(unit)(totalSamples)),
+        },
+      ]}
+    />
+  );
+}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10815,6 +10815,9 @@
       "show-all-series": "Show all {{length}}",
       "show-only-series": "Showing only {{MAX_NUMBER_OF_TIME_SERIES}} series",
       "title": "Graph"
+    },
+    "meta-info": {
+      "equivalent-samples-read": "Equivalent samples read"
     }
   },
   "heatmap": {


### PR DESCRIPTION
Show equivalent samples read for metric queries in Explore.
Gives users visibility into how heavy their query is, so they can spot and tune it.

- add meta info line above the Explore graph panel
- sum the equivalent-samples-read stat across range, instant, and exemplar queries for the same query, deduped per query and query type

Depends on grafana/grafana-prometheus-datasource#319 to populate the stat.

<img width="2036" height="1560" alt="image" src="https://github.com/user-attachments/assets/5781846a-5667-4adb-9758-f4958f715723" />
