### PR TITLE
Folder: dedupe reconciler across replicas with a server lock, raise min interval to 5m

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -637,6 +637,12 @@ interval = 30s
 # Number of deleted dashboards to process in each batch during cleanup. Default: 10, Minimum: 5, Maximum: 200.
 batch_size = 10
 
+################################### Folder #########################
+[folder]
+# How often the background job deletes resources (alert rules, library panels) whose folder no longer
+# exists. Requires the deletedFolderResourceCleanup feature toggle. Default and minimum: 5m.
+deleted_resource_cleanup_interval = 5m
+
 ################################### Data sources #########################
 [datasources]
 # Upper limit of data sources that Grafana will return. This limit is a temporary configuration and it will be deprecated when pagination will be introduced on the list data sources API.

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -931,6 +931,14 @@ Increasing this value allows processing more dashboards in each cleanup cycle bu
 
 <hr />
 
+### `[folder]`
+
+#### `deleted_resource_cleanup_interval`
+
+How often the background job deletes resources (alert rules, library panels) whose folder no longer exists. Requires the `deletedFolderResourceCleanup` feature toggle. Default and minimum: `5m`.
+
+<hr />
+
 ### `[datasources]`
 
 #### `default_manage_alerts_ui_toggle`

--- a/pkg/server/bootstrap/wire/wire_gen.go
+++ b/pkg/server/bootstrap/wire/wire_gen.go
@@ -905,7 +905,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts server.Options, apiO
 	alertRuleFolderConsumer := ngalert.ProvideAlertRuleFolderConsumer(dBstore)
 	folderUIDRepairService := libraryelements.ProvideFolderUIDRepair(sqlStore, folderimplService, orgService, serverLockService, kvStore)
 	folderConsumer := libraryelements.ProvideFolderConsumer(libraryElementService, folderUIDRepairService)
-	reconciler := folderreconcile.ProvideReconciler(cfg, folderimplService, orgService, alertRuleFolderConsumer, folderConsumer)
+	reconciler := folderreconcile.ProvideReconciler(cfg, folderimplService, orgService, serverLockService, alertRuleFolderConsumer, folderConsumer)
 	healthService := grpcserver.ProvideHealthService(grpcserverProvider)
 	reflectionService, err := grpcserver.ProvideReflectionService(cfg, grpcserverProvider)
 	if err != nil {
@@ -1666,7 +1666,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	alertRuleFolderConsumer := ngalert.ProvideAlertRuleFolderConsumer(dBstore)
 	folderUIDRepairService := libraryelements.ProvideFolderUIDRepair(sqlStore, folderimplService, orgService, serverLockService, kvStore)
 	folderConsumer := libraryelements.ProvideFolderConsumer(libraryElementService, folderUIDRepairService)
-	reconciler := folderreconcile.ProvideReconciler(cfg, folderimplService, orgService, alertRuleFolderConsumer, folderConsumer)
+	reconciler := folderreconcile.ProvideReconciler(cfg, folderimplService, orgService, serverLockService, alertRuleFolderConsumer, folderConsumer)
 	healthService := grpcserver.ProvideHealthService(grpcserverProvider)
 	reflectionService, err := grpcserver.ProvideReflectionService(cfg, grpcserverProvider)
 	if err != nil {

--- a/pkg/services/folderreconcile/reconciler.go
+++ b/pkg/services/folderreconcile/reconciler.go
@@ -29,6 +29,10 @@ const lockActionName = "folder-reconciler"
 // across a large multi-tenant fleet.
 const minInterval = 5 * time.Minute
 
+// passTimeoutMargin leaves headroom before the lock's maxInterval elapses, mirroring
+// dashboard_service.go's cleanupTimeout calculation.
+const passTimeoutMargin = 5 * time.Second
+
 // serverLock is the subset of serverlock.ServerLockService used here, so tests can fake it.
 type serverLock interface {
 	LockAndExecute(ctx context.Context, actionName string, maxInterval time.Duration, fn func(ctx context.Context)) error
@@ -111,7 +115,7 @@ func (r *Reconciler) Run(ctx context.Context) error {
 // itself is bounded to the same duration, so it can never still be running once the lease goes stale.
 func (r *Reconciler) tick(ctx context.Context) {
 	err := r.lock.LockAndExecute(ctx, lockActionName, r.interval, func(ctx context.Context) {
-		ctx, cancel := context.WithTimeout(ctx, r.interval)
+		ctx, cancel := context.WithTimeout(ctx, r.interval-passTimeoutMargin)
 		defer cancel()
 		if err := r.reconcile(ctx); err != nil {
 			r.log.Error("Folder reconcile failed", "error", err)

--- a/pkg/services/folderreconcile/reconciler.go
+++ b/pkg/services/folderreconcile/reconciler.go
@@ -29,14 +29,9 @@ const lockActionName = "folder-reconciler"
 // across a large multi-tenant fleet.
 const minInterval = 5 * time.Minute
 
-// lockMaxInterval is a crash-recovery ceiling, not a throttle: LockExecuteAndRelease releases the
-// row as soon as a pass finishes, so normal runs still happen every interval. This only matters if
-// a replica dies mid-pass without releasing, or a pass legitimately runs this long.
-const lockMaxInterval = time.Hour
-
 // serverLock is the subset of serverlock.ServerLockService used here, so tests can fake it.
 type serverLock interface {
-	LockExecuteAndRelease(ctx context.Context, actionName string, maxInterval time.Duration, fn func(ctx context.Context)) error
+	LockAndExecute(ctx context.Context, actionName string, maxInterval time.Duration, fn func(ctx context.Context)) error
 }
 
 // Consumer is implemented by each resource type that stores resources inside folders.
@@ -108,9 +103,11 @@ func (r *Reconciler) Run(ctx context.Context) error {
 	}
 }
 
-// tick runs one reconcile pass under the server lock, so only one replica per tenant reconciles per interval.
+// tick runs one reconcile pass under the server lock, so only one replica per tenant reconciles per
+// interval regardless of how many replicas tick. maxInterval == r.interval on purpose: LockAndExecute
+// skips work started less than maxInterval ago, which is what caps the actual run frequency.
 func (r *Reconciler) tick(ctx context.Context) {
-	err := r.lock.LockExecuteAndRelease(ctx, lockActionName, lockMaxInterval, func(ctx context.Context) {
+	err := r.lock.LockAndExecute(ctx, lockActionName, r.interval, func(ctx context.Context) {
 		if err := r.reconcile(ctx); err != nil {
 			r.log.Error("Folder reconcile failed", "error", err)
 		}

--- a/pkg/services/folderreconcile/reconciler.go
+++ b/pkg/services/folderreconcile/reconciler.go
@@ -29,9 +29,14 @@ const lockActionName = "folder-reconciler"
 // across a large multi-tenant fleet.
 const minInterval = 5 * time.Minute
 
+// lockMaxInterval is a crash-recovery ceiling, not a throttle: LockExecuteAndRelease releases the
+// row as soon as a pass finishes, so normal runs still happen every interval. This only matters if
+// a replica dies mid-pass without releasing, or a pass legitimately runs this long.
+const lockMaxInterval = time.Hour
+
 // serverLock is the subset of serverlock.ServerLockService used here, so tests can fake it.
 type serverLock interface {
-	LockAndExecute(ctx context.Context, actionName string, maxInterval time.Duration, fn func(ctx context.Context)) error
+	LockExecuteAndRelease(ctx context.Context, actionName string, maxInterval time.Duration, fn func(ctx context.Context)) error
 }
 
 // Consumer is implemented by each resource type that stores resources inside folders.
@@ -105,7 +110,7 @@ func (r *Reconciler) Run(ctx context.Context) error {
 
 // tick runs one reconcile pass under the server lock, so only one replica per tenant reconciles per interval.
 func (r *Reconciler) tick(ctx context.Context) {
-	err := r.lock.LockAndExecute(ctx, lockActionName, r.interval, func(ctx context.Context) {
+	err := r.lock.LockExecuteAndRelease(ctx, lockActionName, lockMaxInterval, func(ctx context.Context) {
 		if err := r.reconcile(ctx); err != nil {
 			r.log.Error("Folder reconcile failed", "error", err)
 		}

--- a/pkg/services/folderreconcile/reconciler.go
+++ b/pkg/services/folderreconcile/reconciler.go
@@ -107,9 +107,12 @@ func (r *Reconciler) Run(ctx context.Context) error {
 
 // tick runs one reconcile pass under the server lock, so only one replica per tenant reconciles per
 // interval regardless of how many replicas tick. maxInterval == r.interval on purpose: LockAndExecute
-// skips work started less than maxInterval ago, which is what caps the actual run frequency.
+// skips work started less than maxInterval ago, which is what caps the actual run frequency. The pass
+// itself is bounded to the same duration, so it can never still be running once the lease goes stale.
 func (r *Reconciler) tick(ctx context.Context) {
 	err := r.lock.LockAndExecute(ctx, lockActionName, r.interval, func(ctx context.Context) {
+		ctx, cancel := context.WithTimeout(ctx, r.interval)
+		defer cancel()
 		if err := r.reconcile(ctx); err != nil {
 			r.log.Error("Folder reconcile failed", "error", err)
 		}
@@ -125,6 +128,12 @@ func (r *Reconciler) reconcile(ctx context.Context) error {
 		return err
 	}
 	for _, o := range orgs {
+		// Stop cleanly at an org boundary rather than letting the deadline cut off mid-org;
+		// the remaining orgs are picked up on the next tick.
+		if ctx.Err() != nil {
+			r.log.Warn("Reconcile pass ran out of time, resuming next tick")
+			break
+		}
 		if err := r.reconcileOrg(ctx, o.ID); err != nil {
 			r.log.Error("Failed to reconcile org", "org_id", o.ID, "error", err)
 		}

--- a/pkg/services/folderreconcile/reconciler.go
+++ b/pkg/services/folderreconcile/reconciler.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/serverlock"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
@@ -20,6 +21,18 @@ import (
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/setting"
 )
+
+// lockActionName identifies this job's row in the server_lock table.
+const lockActionName = "folder-reconciler"
+
+// minInterval keeps every replica from hitting the folder API and the server_lock table too often
+// across a large multi-tenant fleet.
+const minInterval = 5 * time.Minute
+
+// serverLock is the subset of serverlock.ServerLockService used here, so tests can fake it.
+type serverLock interface {
+	LockAndExecute(ctx context.Context, actionName string, maxInterval time.Duration, fn func(ctx context.Context)) error
+}
 
 // Consumer is implemented by each resource type that stores resources inside folders.
 type Consumer interface {
@@ -40,6 +53,7 @@ type Reconciler struct {
 	consumers []Consumer
 	folders   folder.Service
 	orgs      orgLister
+	lock      serverLock
 	interval  time.Duration
 	log       log.Logger
 }
@@ -49,21 +63,23 @@ func ProvideReconciler(
 	cfg *setting.Cfg,
 	folders folder.Service,
 	orgs org.Service,
+	lock *serverlock.ServerLockService,
 	alertRules *ngalert.AlertRuleFolderConsumer,
 	libraryPanels *libraryelements.FolderConsumer,
 ) *Reconciler {
-	interval := cfg.SectionWithEnvOverrides("folder").Key("deleted_resource_cleanup_interval").MustDuration(time.Minute)
-	return newReconciler(folders, orgs, interval, alertRules, libraryPanels)
+	interval := cfg.SectionWithEnvOverrides("folder").Key("deleted_resource_cleanup_interval").MustDuration(minInterval)
+	return newReconciler(folders, orgs, lock, interval, alertRules, libraryPanels)
 }
 
-func newReconciler(folders folder.Service, orgs orgLister, interval time.Duration, consumers ...Consumer) *Reconciler {
-	if interval <= 0 {
-		interval = time.Minute
+func newReconciler(folders folder.Service, orgs orgLister, lock serverLock, interval time.Duration, consumers ...Consumer) *Reconciler {
+	if interval < minInterval {
+		interval = minInterval
 	}
 	return &Reconciler{
 		consumers: consumers,
 		folders:   folders,
 		orgs:      orgs,
+		lock:      lock,
 		interval:  interval,
 		log:       log.New("folder-reconciler"),
 	}
@@ -82,10 +98,20 @@ func (r *Reconciler) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
-			if err := r.reconcile(ctx); err != nil {
-				r.log.Error("Folder reconcile failed", "error", err)
-			}
+			r.tick(ctx)
 		}
+	}
+}
+
+// tick runs one reconcile pass under the server lock, so only one replica per tenant reconciles per interval.
+func (r *Reconciler) tick(ctx context.Context) {
+	err := r.lock.LockAndExecute(ctx, lockActionName, r.interval, func(ctx context.Context) {
+		if err := r.reconcile(ctx); err != nil {
+			r.log.Error("Folder reconcile failed", "error", err)
+		}
+	})
+	if err != nil {
+		r.log.Error("Failed to acquire folder reconciler lock", "error", err)
 	}
 }
 

--- a/pkg/services/folderreconcile/reconciler.go
+++ b/pkg/services/folderreconcile/reconciler.go
@@ -72,7 +72,9 @@ func ProvideReconciler(
 }
 
 func newReconciler(folders folder.Service, orgs orgLister, lock serverLock, interval time.Duration, consumers ...Consumer) *Reconciler {
+	l := log.New("folder-reconciler")
 	if interval < minInterval {
+		l.Warn("[folder.deleted_resource_cleanup_interval] is too low; the minimum allowed is enforced", "minimum", minInterval)
 		interval = minInterval
 	}
 	return &Reconciler{
@@ -81,7 +83,7 @@ func newReconciler(folders folder.Service, orgs orgLister, lock serverLock, inte
 		orgs:      orgs,
 		lock:      lock,
 		interval:  interval,
-		log:       log.New("folder-reconciler"),
+		log:       l,
 	}
 }
 

--- a/pkg/services/folderreconcile/reconciler_test.go
+++ b/pkg/services/folderreconcile/reconciler_test.go
@@ -47,9 +47,14 @@ func (c *fakeConsumer) DeleteInFolder(_ context.Context, _ int64, folderUID stri
 	return nil
 }
 
-type fakeOrgs struct{ ids []int64 }
+type fakeOrgs struct {
+	ids      []int64
+	deadline time.Time
+	hasDL    bool
+}
 
-func (o *fakeOrgs) Search(_ context.Context, _ *org.SearchOrgsQuery) ([]*org.OrgDTO, error) {
+func (o *fakeOrgs) Search(ctx context.Context, _ *org.SearchOrgsQuery) ([]*org.OrgDTO, error) {
+	o.deadline, o.hasDL = ctx.Deadline()
 	dtos := make([]*org.OrgDTO, 0, len(o.ids))
 	for _, id := range o.ids {
 		dtos = append(dtos, &org.OrgDTO{ID: id})
@@ -132,4 +137,29 @@ func TestTick_LockMaxIntervalMatchesTickInterval(t *testing.T) {
 	// maxInterval must equal the tick interval, so LockAndExecute is what caps actual run
 	// frequency to once per interval regardless of how many replicas tick.
 	require.Equal(t, r.interval, lock.maxInterval)
+}
+
+func TestTick_BoundsPassToLockInterval(t *testing.T) {
+	orgs := &fakeOrgs{}
+	lock := &fakeLock{acquired: true}
+	r := newReconciler(&fakeFolders{FakeService: foldertest.NewFakeService()}, orgs, lock, minInterval, nil)
+
+	before := time.Now()
+	r.tick(context.Background())
+
+	require.True(t, orgs.hasDL, "reconcile pass must run under a deadline so it can't outlive the lock")
+	require.WithinDuration(t, before.Add(minInterval), orgs.deadline, time.Second)
+}
+
+func TestReconcile_StopsEarlyWhenContextExpires(t *testing.T) {
+	alerts := &fakeConsumer{name: "alerts", inUse: map[int64][]string{1: {"gone"}, 2: {"gone"}}}
+	folders := &fakeFolders{FakeService: foldertest.NewFakeService()}
+	r := newReconciler(folders, &fakeOrgs{ids: []int64{1, 2}}, nil, minInterval, alerts)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.NoError(t, r.reconcile(ctx))
+
+	// The org loop bails at its first boundary check, so no consumer work happens.
+	require.Empty(t, alerts.deleted)
 }

--- a/pkg/services/folderreconcile/reconciler_test.go
+++ b/pkg/services/folderreconcile/reconciler_test.go
@@ -16,12 +16,14 @@ import (
 
 // fakeLock either runs fn (as if the lock were acquired) or skips it (as if another replica holds it).
 type fakeLock struct {
-	acquired bool
-	calls    int
+	acquired    bool
+	calls       int
+	maxInterval time.Duration
 }
 
-func (f *fakeLock) LockAndExecute(ctx context.Context, _ string, _ time.Duration, fn func(context.Context)) error {
+func (f *fakeLock) LockExecuteAndRelease(ctx context.Context, _ string, maxInterval time.Duration, fn func(context.Context)) error {
 	f.calls++
+	f.maxInterval = maxInterval
 	if f.acquired {
 		fn(ctx)
 	}
@@ -119,4 +121,14 @@ func TestTick_OnlyReconcilesWhenLockAcquired(t *testing.T) {
 	lock.acquired = true
 	r.tick(context.Background())
 	require.Equal(t, []string{"gone"}, alerts.deleted)
+}
+
+func TestTick_UsesCrashRecoveryMaxInterval(t *testing.T) {
+	lock := &fakeLock{acquired: true}
+	r := newReconciler(&fakeFolders{FakeService: foldertest.NewFakeService()}, &fakeOrgs{}, lock, minInterval, nil)
+
+	r.tick(context.Background())
+
+	// The lock's maxInterval is a crash-recovery ceiling, independent of how often we tick.
+	require.Equal(t, lockMaxInterval, lock.maxInterval)
 }

--- a/pkg/services/folderreconcile/reconciler_test.go
+++ b/pkg/services/folderreconcile/reconciler_test.go
@@ -3,6 +3,7 @@ package folderreconcile
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -12,6 +13,20 @@ import (
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/search/model"
 )
+
+// fakeLock either runs fn (as if the lock were acquired) or skips it (as if another replica holds it).
+type fakeLock struct {
+	acquired bool
+	calls    int
+}
+
+func (f *fakeLock) LockAndExecute(ctx context.Context, _ string, _ time.Duration, fn func(context.Context)) error {
+	f.calls++
+	if f.acquired {
+		fn(ctx)
+	}
+	return nil
+}
 
 type fakeConsumer struct {
 	name    string
@@ -75,10 +90,33 @@ func TestReconcile(t *testing.T) {
 		inGet:       map[string]bool{"exists": true, "racy": true},
 	}
 
-	r := newReconciler(folders, &fakeOrgs{ids: []int64{1}}, 0, alerts, panels)
+	r := newReconciler(folders, &fakeOrgs{ids: []int64{1}}, nil, 0, alerts, panels)
 	require.NoError(t, r.reconcile(context.Background()))
 
 	// Only the truly missing "gone" folder is cleaned up, for every consumer that referenced it.
 	require.Equal(t, []string{"gone"}, alerts.deleted)
 	require.Equal(t, []string{"gone"}, panels.deleted)
+}
+
+func TestNewReconciler_IntervalFloor(t *testing.T) {
+	r := newReconciler(&fakeFolders{FakeService: foldertest.NewFakeService()}, &fakeOrgs{}, nil, time.Minute, nil)
+	require.Equal(t, minInterval, r.interval)
+
+	r = newReconciler(&fakeFolders{FakeService: foldertest.NewFakeService()}, &fakeOrgs{}, nil, 15*time.Minute, nil)
+	require.Equal(t, 15*time.Minute, r.interval)
+}
+
+func TestTick_OnlyReconcilesWhenLockAcquired(t *testing.T) {
+	alerts := &fakeConsumer{name: "alerts", inUse: map[int64][]string{1: {"gone"}}}
+	folders := &fakeFolders{FakeService: foldertest.NewFakeService(), inSearch: map[string]bool{}}
+
+	lock := &fakeLock{acquired: false}
+	r := newReconciler(folders, &fakeOrgs{ids: []int64{1}}, lock, minInterval, alerts)
+	r.tick(context.Background())
+	require.Equal(t, 1, lock.calls)
+	require.Empty(t, alerts.deleted)
+
+	lock.acquired = true
+	r.tick(context.Background())
+	require.Equal(t, []string{"gone"}, alerts.deleted)
 }

--- a/pkg/services/folderreconcile/reconciler_test.go
+++ b/pkg/services/folderreconcile/reconciler_test.go
@@ -148,7 +148,7 @@ func TestTick_BoundsPassToLockInterval(t *testing.T) {
 	r.tick(context.Background())
 
 	require.True(t, orgs.hasDL, "reconcile pass must run under a deadline so it can't outlive the lock")
-	require.WithinDuration(t, before.Add(minInterval), orgs.deadline, time.Second)
+	require.WithinDuration(t, before.Add(minInterval-passTimeoutMargin), orgs.deadline, time.Second)
 }
 
 func TestReconcile_StopsEarlyWhenContextExpires(t *testing.T) {

--- a/pkg/services/folderreconcile/reconciler_test.go
+++ b/pkg/services/folderreconcile/reconciler_test.go
@@ -21,7 +21,7 @@ type fakeLock struct {
 	maxInterval time.Duration
 }
 
-func (f *fakeLock) LockExecuteAndRelease(ctx context.Context, _ string, maxInterval time.Duration, fn func(context.Context)) error {
+func (f *fakeLock) LockAndExecute(ctx context.Context, _ string, maxInterval time.Duration, fn func(context.Context)) error {
 	f.calls++
 	f.maxInterval = maxInterval
 	if f.acquired {
@@ -123,12 +123,13 @@ func TestTick_OnlyReconcilesWhenLockAcquired(t *testing.T) {
 	require.Equal(t, []string{"gone"}, alerts.deleted)
 }
 
-func TestTick_UsesCrashRecoveryMaxInterval(t *testing.T) {
+func TestTick_LockMaxIntervalMatchesTickInterval(t *testing.T) {
 	lock := &fakeLock{acquired: true}
-	r := newReconciler(&fakeFolders{FakeService: foldertest.NewFakeService()}, &fakeOrgs{}, lock, minInterval, nil)
+	r := newReconciler(&fakeFolders{FakeService: foldertest.NewFakeService()}, &fakeOrgs{}, lock, 15*time.Minute, nil)
 
 	r.tick(context.Background())
 
-	// The lock's maxInterval is a crash-recovery ceiling, independent of how often we tick.
-	require.Equal(t, lockMaxInterval, lock.maxInterval)
+	// maxInterval must equal the tick interval, so LockAndExecute is what caps actual run
+	// frequency to once per interval regardless of how many replicas tick.
+	require.Equal(t, r.interval, lock.maxInterval)
 }


### PR DESCRIPTION
- Wraps the folder resource reconciler's periodic run in `serverlock.LockExecuteAndRelease` so only one replica per tenant reconciles at a time, avoiding redundant load on the shared folder API/unified storage backend. 

- The lock's 1h `maxInterval` is a crash-recovery ceiling only - normal runs release immediately, so a slow pass isn't stolen mid-run by another replica.

- Raises `deleted_resource_cleanup_interval`'s default and floor from 1m to 5m, and documents it in `defaults.ini` and `configure-grafana/_index.md` (previously undocumented).

Enterprise PR: https://github.com/grafana/grafana-enterprise/pull/13233