### PR TITLE
A11y: Give the query row drag handle its own accessible name

### DIFF
--- a/public/app/core/components/QueryOperationRow/QueryOperationRowHeader.test.tsx
+++ b/public/app/core/components/QueryOperationRow/QueryOperationRowHeader.test.tsx
@@ -19,6 +19,17 @@ describe('QueryOperationRowHeader', () => {
     expect(() => setup()).not.toThrow();
   });
 
+  describe('drag handle', () => {
+    test('should carry its own accessible name rather than relying on the icon', () => {
+      setup();
+      expect(screen.getByLabelText('Drag and drop to reorder')).toBeInTheDocument();
+    });
+    test('should not render the drag handle when the row is not draggable', () => {
+      setup({ draggable: false });
+      expect(screen.queryByLabelText('Drag and drop to reorder')).not.toBeInTheDocument();
+    });
+  });
+
   describe('collapsable property', () => {
     test('should show the button to collapse the query row by default', () => {
       setup();

--- a/public/app/core/components/QueryOperationRow/QueryOperationRowHeader.tsx
+++ b/public/app/core/components/QueryOperationRow/QueryOperationRowHeader.tsx
@@ -79,8 +79,10 @@ export const QueryOperationRowHeader = ({
 
       <Stack gap={1} alignItems="center">
         {actionsElement}
+        {/* The handle is labelled directly rather than through the icon: dragHandleProps makes it a
+            button, and the icon's <title> only exists once the SVG has loaded asynchronously. */}
         {draggable && (
-          <div className={styles.dragHandle} {...dragHandleProps}>
+          <div className={styles.dragHandle} {...dragHandleProps} aria-label={dragAndDropLabel}>
             <Icon title={dragAndDropLabel} name="draggabledots" size="lg" className={styles.dragIcon} />
           </div>
         )}


### PR DESCRIPTION
**What is this feature?**

Adds `aria-label` to the query row drag handle in `QueryOperationRowHeader`, so its accessible name no longer depends on the icon's `<title>`.

**Why do we need this feature?**

`dragHandleProps` (from `@hello-pangea/dnd`) turns the handle into a `role="button"`, but its only name came from `<Icon title={...}/>` — and `react-inlinesvg` injects that `<title>` element only *after* the SVG has loaded asynchronously, which `Icon` itself notes happens "even if the icon is in the cache(!)" (`Icon.tsx:141`). Until it lands, the handle is an unnamed button, so Axe's `aria-command-name` rule fails whenever the panel-edit a11y smoke test happens to scan inside that window — an intermittent CI failure (typically 1 hard failure plus 2-3 flaky retries in the same shard) that has nothing to do with whatever PR it lands on.

**Who is this feature for?**

Screen reader users, who currently get an unnamed button until the icon finishes loading — and anyone whose PR gets a red `Playwright E2E tests` shard from this flake.

**Which issue(s) does this PR fix?**:

None filed — found while investigating a red e2e shard on #131054.

**Special notes for your reviewer:**

The label reuses the existing `query-operation.header.drag-and-drop` string, so there is no i18n change. This follows the pattern the MegaMenu drag handles already use (`MegaMenuItem.tsx:188`, `MegaMenuPinnedItem.tsx:63`). The icon keeps its `title` so the hover tooltip is unchanged.

The same latent pattern (drag handle named only via an async icon `title`) exists in `PlaylistTableRows.tsx:115`, `EnumMappingRow.tsx:91` and `OrganizeFieldsTransformerEditor.tsx:369,427` — left alone here to keep this fix scoped to the one the a11y suite actually covers.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)