### PR TITLE
Search: serve the per-resource search endpoints by default

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,7 @@
 *_gen.csv linguist-generated
 *_gen.json linguist-generated
 **/openapi_snapshots/*.json linguist-generated
+packages/grafana-openapi/src/apis/*.json linguist-generated
 apps/**/pkg/apis/*_manifest.go linguist-generated
 public/openapi3.json linguist-generated
 public/api-merged.json linguist-generated

--- a/packages/grafana-api-clients/src/scripts/generate-rtk-apis.test.ts
+++ b/packages/grafana-api-clients/src/scripts/generate-rtk-apis.test.ts
@@ -1,0 +1,42 @@
+import { withoutPerResourceSearch, type OperationDefinition } from './generate-rtk-apis';
+
+const operation = (path: string) => ({ path }) as OperationDefinition;
+
+describe('withoutPerResourceSearch', () => {
+  const filter = withoutPerResourceSearch();
+  const include = (path: string) => (typeof filter === 'function' ? filter('anyName', operation(path)) : false);
+
+  it('drops the per-resource search and trash endpoints', () => {
+    expect(include('/dashboards/search')).toBe(false);
+    expect(include('/folders/search')).toBe(false);
+    expect(include('/users/trash')).toBe(false);
+  });
+
+  // The dashboard search at the group root is a different, older endpoint that the
+  // frontend does call.
+  it('keeps the group-root search', () => {
+    expect(include('/search')).toBe(true);
+    expect(include('/search/sortable')).toBe(true);
+  });
+
+  it('keeps everything else', () => {
+    expect(include('/dashboards')).toBe(true);
+    expect(include('/dashboards/{name}')).toBe(true);
+    expect(include('/namespaces/{namespace}/dashboards/search/other')).toBe(true);
+  });
+
+  it('leaves a whitelist alone, since it already excludes what it does not name', () => {
+    expect(withoutPerResourceSearch(['getSession'])).toEqual(['getSession']);
+  });
+
+  it('keeps a caller-supplied filter as well as its own', () => {
+    const onlyDashboards = withoutPerResourceSearch((_name, op) => op.path.startsWith('/dashboards'));
+    if (typeof onlyDashboards !== 'function') {
+      throw new Error('expected a function');
+    }
+
+    expect(onlyDashboards('anyName', operation('/dashboards'))).toBe(true);
+    expect(onlyDashboards('anyName', operation('/folders'))).toBe(false);
+    expect(onlyDashboards('anyName', operation('/dashboards/search'))).toBe(false);
+  });
+});

--- a/packages/grafana-api-clients/src/scripts/generate-rtk-apis.ts
+++ b/packages/grafana-api-clients/src/scripts/generate-rtk-apis.ts
@@ -23,6 +23,19 @@ const defaultHooksOptions = {
   mutations: true,
 };
 
+// Every namespaced kind can serve /search and /trash, and no frontend calls them yet, so
+// generating a hook per kind would add clients nobody imports. The dashboard search at
+// `/search` is a different, older endpoint and stays.
+const perResourceSearch = /^\/[^/]+\/(search|trash)$/;
+
+const withoutPerResourceSearch = (filterEndpoints?: EndpointMatcher): EndpointMatcher => {
+  if (Array.isArray(filterEndpoints)) {
+    return filterEndpoints;
+  }
+  return (name, operation) =>
+    !perResourceSearch.test(operation.path) && (filterEndpoints ? filterEndpoints(name, operation) : true);
+};
+
 /**
  * Helper to return consistent base API generation config
  */
@@ -32,7 +45,7 @@ const createAPIConfig = (app: string, version: string, filterEndpoints?: Endpoin
     [filePath]: {
       schemaFile: path.join(basePath, `packages/grafana-openapi/src/apis/${app}.grafana.app-${version}.json`),
       apiFile: `../clients/rtkq/${app}/${version}/baseAPI.ts`,
-      filterEndpoints,
+      filterEndpoints: withoutPerResourceSearch(filterEndpoints),
       tag: true,
       hooks: defaultHooksOptions,
       ...additional,

--- a/packages/grafana-api-clients/src/scripts/generate-rtk-apis.ts
+++ b/packages/grafana-api-clients/src/scripts/generate-rtk-apis.ts
@@ -9,13 +9,13 @@ const basePath = path.resolve(__dirname, '../../../..');
 // Include some types that are used inside the @rtk-query/codegen-openapi package
 // but not exported
 declare const operationKeys: readonly ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
-type OperationDefinition = {
+export type OperationDefinition = {
   path: string;
   verb: (typeof operationKeys)[number];
   pathItem: OpenAPIV3.PathItemObject;
   operation: OpenAPIV3.OperationObject;
 };
-type EndpointMatcher = string[] | ((operationName: string, operationDefinition: OperationDefinition) => boolean);
+export type EndpointMatcher = string[] | ((operationName: string, operationDefinition: OperationDefinition) => boolean);
 
 const defaultHooksOptions = {
   queries: true,
@@ -28,7 +28,7 @@ const defaultHooksOptions = {
 // `/search` is a different, older endpoint and stays.
 const perResourceSearch = /^\/[^/]+\/(search|trash)$/;
 
-const withoutPerResourceSearch = (filterEndpoints?: EndpointMatcher): EndpointMatcher => {
+export const withoutPerResourceSearch = (filterEndpoints?: EndpointMatcher): EndpointMatcher => {
   if (Array.isArray(filterEndpoints)) {
     return filterEndpoints;
   }

--- a/packages/grafana-openapi/src/apis/dashboard.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/dashboard.grafana.app-v0alpha1.json
@@ -242,6 +242,37 @@
         }
       ]
     },
+    "/dashboards/search": {
+      "post": {
+        "tags": ["Search"],
+        "description": "Search Dashboard resources in a namespace.",
+        "operationId": "listDashboardSearchV0alpha1",
+        "parameters": [],
+        "requestBody": {
+          "description": "A SearchQuery describing what to match, sort and return.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A SearchResults envelope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResults"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/dashboards/{name}": {
       "get": {
         "tags": ["Dashboard"],
@@ -2742,6 +2773,315 @@
         "additionalProperties": true,
         "x-kubernetes-preserve-unknown-fields": true
       },
+      "ExistsPredicate": {
+        "description": "ExistsPredicate is a future field-existence predicate. Modelled for schema stability; always rejected in v1.",
+        "type": "object",
+        "required": ["field"],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "FacetTerm": {
+        "description": "FacetTerm is a single facet term and its count.",
+        "type": "object",
+        "required": ["value", "count"],
+        "properties": {
+          "count": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "FilterPredicate": {
+        "description": "FilterPredicate is an exact / set-based predicate against a single field. Values are strings whatever the field's declared type, so a boolean field takes \"true\" or \"false\" and a numeric field takes the number written out.\n\nNumbers are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a filter can both match a neighbour and miss the value asked for.",
+        "type": "object",
+        "required": ["field", "operator", "values"],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          },
+          "operator": {
+            "description": "Operator is \"In\" or \"NotIn\" in v1.",
+            "type": "string",
+            "default": ""
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        }
+      },
+      "RangePredicate": {
+        "description": "RangePredicate compares a numeric field against one or two bounds. At least one bound is required, gt cannot be combined with gte, and lt cannot be combined with lte. Boolean and string fields are rejected: only numbers have the order a range asks about. On an integer field a bound must be whole.\n\nBounds are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a bound can both admit a neighbour and exclude the value asked for.",
+        "type": "object",
+        "required": ["field"],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          },
+          "gt": {
+            "type": "number",
+            "format": "double"
+          },
+          "gte": {
+            "type": "number",
+            "format": "double"
+          },
+          "lt": {
+            "type": "number",
+            "format": "double"
+          },
+          "lte": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "ResourceRef": {
+        "description": "ResourceRef is the full identity of a returned item. Namespace is implicit from the URL and omitted.",
+        "type": "object",
+        "required": ["group", "resource", "kind", "name"],
+        "properties": {
+          "group": {
+            "type": "string",
+            "default": ""
+          },
+          "kind": {
+            "type": "string",
+            "default": ""
+          },
+          "name": {
+            "type": "string",
+            "default": ""
+          },
+          "resource": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "ResultItem": {
+        "description": "ResultItem is one search or trash hit. The item shape is identical on both endpoints; only which fields the Fields map can carry differs.",
+        "type": "object",
+        "required": ["resource"],
+        "properties": {
+          "fields": {
+            "description": "Fields holds the JSON values for the requested (or default) fields. Array-typed fields are returned as JSON arrays. Absent fields are omitted.",
+            "$ref": "#/components/schemas/Unstructured"
+          },
+          "resource": {
+            "default": {},
+            "$ref": "#/components/schemas/ResourceRef"
+          },
+          "score": {
+            "description": "Score is present only when a text query was evaluated. A pointer so a real score of 0 is still distinguishable from \"no text query\" (absent).",
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "ResultsMetadata": {
+        "description": "ResultsMetadata carries the pagination token and the total hit count.",
+        "type": "object",
+        "required": ["totalHits", "totalHitsRelation"],
+        "properties": {
+          "continue": {
+            "type": "string"
+          },
+          "totalHits": {
+            "description": "TotalHits counts the resources matching the query. Always read it together with TotalHitsRelation, which says whether the count is exact.",
+            "type": "integer",
+            "format": "int64",
+            "default": 0
+          },
+          "totalHitsRelation": {
+            "description": "TotalHitsRelation is \"eq\" when TotalHits is exact and \"lte\" when it is an upper bound.",
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "SearchQuery": {
+        "description": "SearchQuery is the request body for POST .../{resource}/search.",
+        "type": "object",
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "continue": {
+            "description": "Continue is an opaque pagination token from a previous page.",
+            "type": "string"
+          },
+          "facetLimit": {
+            "description": "FacetLimit caps the number of terms returned per facet. It applies to every entry in Facets. Zero uses the server default; values above the server cap are clamped.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "facets": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "labelSelector": {
+            "description": "LabelSelector filters on metadata.labels, ANDed with Where.",
+            "$ref": "#/components/schemas/LabelSelector"
+          },
+          "limit": {
+            "description": "Limit is the page size. Zero uses the default; values above the maximum are clamped.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "sort": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/SortField"
+            }
+          },
+          "where": {
+            "description": "Where is the search predicate tree. Omitting it matches all resources of the kind (subject to labelSelector and per-item authz).",
+            "$ref": "#/components/schemas/WhereNode"
+          }
+        }
+      },
+      "SearchResults": {
+        "description": "SearchResults is the response body for POST .../{resource}/search.",
+        "type": "object",
+        "required": ["metadata", "items"],
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "facets": {
+            "description": "Facets holds term counts per requested facet field. Counts are computed over a bounded sample window, so they are best-effort/approximate.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "default": {},
+                "$ref": "#/components/schemas/FacetTerm"
+              }
+            }
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/ResultItem"
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "metadata": {
+            "default": {},
+            "$ref": "#/components/schemas/ResultsMetadata"
+          }
+        }
+      },
+      "SortField": {
+        "description": "SortField names a field to sort by and a direction (\"asc\" or \"desc\"). V1 allows sorting only on scalar string and numeric fields that declare the sort capability.",
+        "type": "object",
+        "required": ["field"],
+        "properties": {
+          "direction": {
+            "type": "string"
+          },
+          "field": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "TextPredicate": {
+        "description": "TextPredicate is a free-text predicate against one or more text-capable fields. When Fields is empty it defaults to the kind's searchTextFields (currently [\"title\"]).",
+        "type": "object",
+        "required": ["value"],
+        "properties": {
+          "boost": {
+            "description": "Boost is a future per-leaf score multiplier. Setting it is rejected in v1.",
+            "type": "number",
+            "format": "double"
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "WhereNode": {
+        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+        "type": "object",
+        "properties": {
+          "and": {
+            "description": "Combinators.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/WhereNode"
+            }
+          },
+          "exists": {
+            "$ref": "#/components/schemas/ExistsPredicate"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/FilterPredicate"
+          },
+          "not": {
+            "$ref": "#/components/schemas/WhereNode"
+          },
+          "or": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/WhereNode"
+            }
+          },
+          "range": {
+            "$ref": "#/components/schemas/RangePredicate"
+          },
+          "text": {
+            "description": "Leaves.",
+            "$ref": "#/components/schemas/TextPredicate"
+          }
+        }
+      },
       "APIResource": {
         "description": "APIResource specifies the name of a resource and whether it is namespaced.",
         "type": "object",
@@ -2891,6 +3231,56 @@
       "FieldsV1": {
         "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
         "type": "object"
+      },
+      "LabelSelector": {
+        "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+        "type": "object",
+        "properties": {
+          "matchExpressions": {
+            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/LabelSelectorRequirement"
+            },
+            "x-kubernetes-list-type": "atomic"
+          },
+          "matchLabels": {
+            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        },
+        "x-kubernetes-map-type": "atomic"
+      },
+      "LabelSelectorRequirement": {
+        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+        "type": "object",
+        "required": ["key", "operator"],
+        "properties": {
+          "key": {
+            "description": "key is the label key that the selector applies to.",
+            "type": "string",
+            "default": ""
+          },
+          "operator": {
+            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+            "type": "string",
+            "default": ""
+          },
+          "values": {
+            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            },
+            "x-kubernetes-list-type": "atomic"
+          }
+        }
       },
       "ListMeta": {
         "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",

--- a/packages/grafana-openapi/src/apis/dashboard.grafana.app-v1beta1.json
+++ b/packages/grafana-openapi/src/apis/dashboard.grafana.app-v1beta1.json
@@ -242,6 +242,37 @@
         }
       ]
     },
+    "/dashboards/search": {
+      "post": {
+        "tags": ["Search"],
+        "description": "Search Dashboard resources in a namespace.",
+        "operationId": "listDashboardSearchV1beta1",
+        "parameters": [],
+        "requestBody": {
+          "description": "A SearchQuery describing what to match, sort and return.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A SearchResults envelope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResults"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/dashboards/{name}": {
       "get": {
         "tags": ["Dashboard"],
@@ -885,6 +916,315 @@
         "additionalProperties": true,
         "x-kubernetes-preserve-unknown-fields": true
       },
+      "ExistsPredicate": {
+        "description": "ExistsPredicate is a future field-existence predicate. Modelled for schema stability; always rejected in v1.",
+        "type": "object",
+        "required": ["field"],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "FacetTerm": {
+        "description": "FacetTerm is a single facet term and its count.",
+        "type": "object",
+        "required": ["value", "count"],
+        "properties": {
+          "count": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "FilterPredicate": {
+        "description": "FilterPredicate is an exact / set-based predicate against a single field. Values are strings whatever the field's declared type, so a boolean field takes \"true\" or \"false\" and a numeric field takes the number written out.\n\nNumbers are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a filter can both match a neighbour and miss the value asked for.",
+        "type": "object",
+        "required": ["field", "operator", "values"],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          },
+          "operator": {
+            "description": "Operator is \"In\" or \"NotIn\" in v1.",
+            "type": "string",
+            "default": ""
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        }
+      },
+      "RangePredicate": {
+        "description": "RangePredicate compares a numeric field against one or two bounds. At least one bound is required, gt cannot be combined with gte, and lt cannot be combined with lte. Boolean and string fields are rejected: only numbers have the order a range asks about. On an integer field a bound must be whole.\n\nBounds are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a bound can both admit a neighbour and exclude the value asked for.",
+        "type": "object",
+        "required": ["field"],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          },
+          "gt": {
+            "type": "number",
+            "format": "double"
+          },
+          "gte": {
+            "type": "number",
+            "format": "double"
+          },
+          "lt": {
+            "type": "number",
+            "format": "double"
+          },
+          "lte": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "ResourceRef": {
+        "description": "ResourceRef is the full identity of a returned item. Namespace is implicit from the URL and omitted.",
+        "type": "object",
+        "required": ["group", "resource", "kind", "name"],
+        "properties": {
+          "group": {
+            "type": "string",
+            "default": ""
+          },
+          "kind": {
+            "type": "string",
+            "default": ""
+          },
+          "name": {
+            "type": "string",
+            "default": ""
+          },
+          "resource": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "ResultItem": {
+        "description": "ResultItem is one search or trash hit. The item shape is identical on both endpoints; only which fields the Fields map can carry differs.",
+        "type": "object",
+        "required": ["resource"],
+        "properties": {
+          "fields": {
+            "description": "Fields holds the JSON values for the requested (or default) fields. Array-typed fields are returned as JSON arrays. Absent fields are omitted.",
+            "$ref": "#/components/schemas/Unstructured"
+          },
+          "resource": {
+            "default": {},
+            "$ref": "#/components/schemas/ResourceRef"
+          },
+          "score": {
+            "description": "Score is present only when a text query was evaluated. A pointer so a real score of 0 is still distinguishable from \"no text query\" (absent).",
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "ResultsMetadata": {
+        "description": "ResultsMetadata carries the pagination token and the total hit count.",
+        "type": "object",
+        "required": ["totalHits", "totalHitsRelation"],
+        "properties": {
+          "continue": {
+            "type": "string"
+          },
+          "totalHits": {
+            "description": "TotalHits counts the resources matching the query. Always read it together with TotalHitsRelation, which says whether the count is exact.",
+            "type": "integer",
+            "format": "int64",
+            "default": 0
+          },
+          "totalHitsRelation": {
+            "description": "TotalHitsRelation is \"eq\" when TotalHits is exact and \"lte\" when it is an upper bound.",
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "SearchQuery": {
+        "description": "SearchQuery is the request body for POST .../{resource}/search.",
+        "type": "object",
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "continue": {
+            "description": "Continue is an opaque pagination token from a previous page.",
+            "type": "string"
+          },
+          "facetLimit": {
+            "description": "FacetLimit caps the number of terms returned per facet. It applies to every entry in Facets. Zero uses the server default; values above the server cap are clamped.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "facets": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "labelSelector": {
+            "description": "LabelSelector filters on metadata.labels, ANDed with Where.",
+            "$ref": "#/components/schemas/LabelSelector"
+          },
+          "limit": {
+            "description": "Limit is the page size. Zero uses the default; values above the maximum are clamped.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "sort": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/SortField"
+            }
+          },
+          "where": {
+            "description": "Where is the search predicate tree. Omitting it matches all resources of the kind (subject to labelSelector and per-item authz).",
+            "$ref": "#/components/schemas/WhereNode"
+          }
+        }
+      },
+      "SearchResults": {
+        "description": "SearchResults is the response body for POST .../{resource}/search.",
+        "type": "object",
+        "required": ["metadata", "items"],
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "facets": {
+            "description": "Facets holds term counts per requested facet field. Counts are computed over a bounded sample window, so they are best-effort/approximate.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "default": {},
+                "$ref": "#/components/schemas/FacetTerm"
+              }
+            }
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/ResultItem"
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "metadata": {
+            "default": {},
+            "$ref": "#/components/schemas/ResultsMetadata"
+          }
+        }
+      },
+      "SortField": {
+        "description": "SortField names a field to sort by and a direction (\"asc\" or \"desc\"). V1 allows sorting only on scalar string and numeric fields that declare the sort capability.",
+        "type": "object",
+        "required": ["field"],
+        "properties": {
+          "direction": {
+            "type": "string"
+          },
+          "field": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "TextPredicate": {
+        "description": "TextPredicate is a free-text predicate against one or more text-capable fields. When Fields is empty it defaults to the kind's searchTextFields (currently [\"title\"]).",
+        "type": "object",
+        "required": ["value"],
+        "properties": {
+          "boost": {
+            "description": "Boost is a future per-leaf score multiplier. Setting it is rejected in v1.",
+            "type": "number",
+            "format": "double"
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "WhereNode": {
+        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+        "type": "object",
+        "properties": {
+          "and": {
+            "description": "Combinators.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/WhereNode"
+            }
+          },
+          "exists": {
+            "$ref": "#/components/schemas/ExistsPredicate"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/FilterPredicate"
+          },
+          "not": {
+            "$ref": "#/components/schemas/WhereNode"
+          },
+          "or": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/WhereNode"
+            }
+          },
+          "range": {
+            "$ref": "#/components/schemas/RangePredicate"
+          },
+          "text": {
+            "description": "Leaves.",
+            "$ref": "#/components/schemas/TextPredicate"
+          }
+        }
+      },
       "APIResource": {
         "description": "APIResource specifies the name of a resource and whether it is namespaced.",
         "type": "object",
@@ -1034,6 +1374,56 @@
       "FieldsV1": {
         "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
         "type": "object"
+      },
+      "LabelSelector": {
+        "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+        "type": "object",
+        "properties": {
+          "matchExpressions": {
+            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/LabelSelectorRequirement"
+            },
+            "x-kubernetes-list-type": "atomic"
+          },
+          "matchLabels": {
+            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        },
+        "x-kubernetes-map-type": "atomic"
+      },
+      "LabelSelectorRequirement": {
+        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+        "type": "object",
+        "required": ["key", "operator"],
+        "properties": {
+          "key": {
+            "description": "key is the label key that the selector applies to.",
+            "type": "string",
+            "default": ""
+          },
+          "operator": {
+            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+            "type": "string",
+            "default": ""
+          },
+          "values": {
+            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            },
+            "x-kubernetes-list-type": "atomic"
+          }
+        }
       },
       "ListMeta": {
         "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",

--- a/packages/grafana-openapi/src/apis/dashboard.grafana.app-v2.json
+++ b/packages/grafana-openapi/src/apis/dashboard.grafana.app-v2.json
@@ -242,6 +242,37 @@
         }
       ]
     },
+    "/dashboards/search": {
+      "post": {
+        "tags": ["Search"],
+        "description": "Search Dashboard resources in a namespace.",
+        "operationId": "listDashboardSearchV2",
+        "parameters": [],
+        "requestBody": {
+          "description": "A SearchQuery describing what to match, sort and return.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A SearchResults envelope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResults"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/dashboards/{name}": {
       "get": {
         "tags": ["Dashboard"],
@@ -3928,6 +3959,320 @@
           }
         ]
       },
+      "Unstructured": {
+        "type": "object",
+        "additionalProperties": true,
+        "x-kubernetes-preserve-unknown-fields": true
+      },
+      "ExistsPredicate": {
+        "description": "ExistsPredicate is a future field-existence predicate. Modelled for schema stability; always rejected in v1.",
+        "type": "object",
+        "required": ["field"],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "FacetTerm": {
+        "description": "FacetTerm is a single facet term and its count.",
+        "type": "object",
+        "required": ["value", "count"],
+        "properties": {
+          "count": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "FilterPredicate": {
+        "description": "FilterPredicate is an exact / set-based predicate against a single field. Values are strings whatever the field's declared type, so a boolean field takes \"true\" or \"false\" and a numeric field takes the number written out.\n\nNumbers are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a filter can both match a neighbour and miss the value asked for.",
+        "type": "object",
+        "required": ["field", "operator", "values"],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          },
+          "operator": {
+            "description": "Operator is \"In\" or \"NotIn\" in v1.",
+            "type": "string",
+            "default": ""
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        }
+      },
+      "RangePredicate": {
+        "description": "RangePredicate compares a numeric field against one or two bounds. At least one bound is required, gt cannot be combined with gte, and lt cannot be combined with lte. Boolean and string fields are rejected: only numbers have the order a range asks about. On an integer field a bound must be whole.\n\nBounds are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a bound can both admit a neighbour and exclude the value asked for.",
+        "type": "object",
+        "required": ["field"],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          },
+          "gt": {
+            "type": "number",
+            "format": "double"
+          },
+          "gte": {
+            "type": "number",
+            "format": "double"
+          },
+          "lt": {
+            "type": "number",
+            "format": "double"
+          },
+          "lte": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "ResourceRef": {
+        "description": "ResourceRef is the full identity of a returned item. Namespace is implicit from the URL and omitted.",
+        "type": "object",
+        "required": ["group", "resource", "kind", "name"],
+        "properties": {
+          "group": {
+            "type": "string",
+            "default": ""
+          },
+          "kind": {
+            "type": "string",
+            "default": ""
+          },
+          "name": {
+            "type": "string",
+            "default": ""
+          },
+          "resource": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "ResultItem": {
+        "description": "ResultItem is one search or trash hit. The item shape is identical on both endpoints; only which fields the Fields map can carry differs.",
+        "type": "object",
+        "required": ["resource"],
+        "properties": {
+          "fields": {
+            "description": "Fields holds the JSON values for the requested (or default) fields. Array-typed fields are returned as JSON arrays. Absent fields are omitted.",
+            "$ref": "#/components/schemas/Unstructured"
+          },
+          "resource": {
+            "default": {},
+            "$ref": "#/components/schemas/ResourceRef"
+          },
+          "score": {
+            "description": "Score is present only when a text query was evaluated. A pointer so a real score of 0 is still distinguishable from \"no text query\" (absent).",
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "ResultsMetadata": {
+        "description": "ResultsMetadata carries the pagination token and the total hit count.",
+        "type": "object",
+        "required": ["totalHits", "totalHitsRelation"],
+        "properties": {
+          "continue": {
+            "type": "string"
+          },
+          "totalHits": {
+            "description": "TotalHits counts the resources matching the query. Always read it together with TotalHitsRelation, which says whether the count is exact.",
+            "type": "integer",
+            "format": "int64",
+            "default": 0
+          },
+          "totalHitsRelation": {
+            "description": "TotalHitsRelation is \"eq\" when TotalHits is exact and \"lte\" when it is an upper bound.",
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "SearchQuery": {
+        "description": "SearchQuery is the request body for POST .../{resource}/search.",
+        "type": "object",
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "continue": {
+            "description": "Continue is an opaque pagination token from a previous page.",
+            "type": "string"
+          },
+          "facetLimit": {
+            "description": "FacetLimit caps the number of terms returned per facet. It applies to every entry in Facets. Zero uses the server default; values above the server cap are clamped.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "facets": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "labelSelector": {
+            "description": "LabelSelector filters on metadata.labels, ANDed with Where.",
+            "$ref": "#/components/schemas/LabelSelector"
+          },
+          "limit": {
+            "description": "Limit is the page size. Zero uses the default; values above the maximum are clamped.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "sort": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/SortField"
+            }
+          },
+          "where": {
+            "description": "Where is the search predicate tree. Omitting it matches all resources of the kind (subject to labelSelector and per-item authz).",
+            "$ref": "#/components/schemas/WhereNode"
+          }
+        }
+      },
+      "SearchResults": {
+        "description": "SearchResults is the response body for POST .../{resource}/search.",
+        "type": "object",
+        "required": ["metadata", "items"],
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "facets": {
+            "description": "Facets holds term counts per requested facet field. Counts are computed over a bounded sample window, so they are best-effort/approximate.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "default": {},
+                "$ref": "#/components/schemas/FacetTerm"
+              }
+            }
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/ResultItem"
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "metadata": {
+            "default": {},
+            "$ref": "#/components/schemas/ResultsMetadata"
+          }
+        }
+      },
+      "SortField": {
+        "description": "SortField names a field to sort by and a direction (\"asc\" or \"desc\"). V1 allows sorting only on scalar string and numeric fields that declare the sort capability.",
+        "type": "object",
+        "required": ["field"],
+        "properties": {
+          "direction": {
+            "type": "string"
+          },
+          "field": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "TextPredicate": {
+        "description": "TextPredicate is a free-text predicate against one or more text-capable fields. When Fields is empty it defaults to the kind's searchTextFields (currently [\"title\"]).",
+        "type": "object",
+        "required": ["value"],
+        "properties": {
+          "boost": {
+            "description": "Boost is a future per-leaf score multiplier. Setting it is rejected in v1.",
+            "type": "number",
+            "format": "double"
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "WhereNode": {
+        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+        "type": "object",
+        "properties": {
+          "and": {
+            "description": "Combinators.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/WhereNode"
+            }
+          },
+          "exists": {
+            "$ref": "#/components/schemas/ExistsPredicate"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/FilterPredicate"
+          },
+          "not": {
+            "$ref": "#/components/schemas/WhereNode"
+          },
+          "or": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/WhereNode"
+            }
+          },
+          "range": {
+            "$ref": "#/components/schemas/RangePredicate"
+          },
+          "text": {
+            "description": "Leaves.",
+            "$ref": "#/components/schemas/TextPredicate"
+          }
+        }
+      },
       "APIResource": {
         "description": "APIResource specifies the name of a resource and whether it is namespaced.",
         "type": "object",
@@ -4077,6 +4422,56 @@
       "FieldsV1": {
         "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
         "type": "object"
+      },
+      "LabelSelector": {
+        "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+        "type": "object",
+        "properties": {
+          "matchExpressions": {
+            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/LabelSelectorRequirement"
+            },
+            "x-kubernetes-list-type": "atomic"
+          },
+          "matchLabels": {
+            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        },
+        "x-kubernetes-map-type": "atomic"
+      },
+      "LabelSelectorRequirement": {
+        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+        "type": "object",
+        "required": ["key", "operator"],
+        "properties": {
+          "key": {
+            "description": "key is the label key that the selector applies to.",
+            "type": "string",
+            "default": ""
+          },
+          "operator": {
+            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+            "type": "string",
+            "default": ""
+          },
+          "values": {
+            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            },
+            "x-kubernetes-list-type": "atomic"
+          }
+        }
       },
       "ListMeta": {
         "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",

--- a/packages/grafana-openapi/src/apis/dashboard.grafana.app-v2alpha1.json
+++ b/packages/grafana-openapi/src/apis/dashboard.grafana.app-v2alpha1.json
@@ -242,6 +242,37 @@
         }
       ]
     },
+    "/dashboards/search": {
+      "post": {
+        "tags": ["Search"],
+        "description": "Search Dashboard resources in a namespace.",
+        "operationId": "listDashboardSearchV2alpha1",
+        "parameters": [],
+        "requestBody": {
+          "description": "A SearchQuery describing what to match, sort and return.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A SearchResults envelope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResults"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/dashboards/{name}": {
       "get": {
         "tags": ["Dashboard"],
@@ -3754,6 +3785,320 @@
           }
         ]
       },
+      "Unstructured": {
+        "type": "object",
+        "additionalProperties": true,
+        "x-kubernetes-preserve-unknown-fields": true
+      },
+      "ExistsPredicate": {
+        "description": "ExistsPredicate is a future field-existence predicate. Modelled for schema stability; always rejected in v1.",
+        "type": "object",
+        "required": ["field"],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "FacetTerm": {
+        "description": "FacetTerm is a single facet term and its count.",
+        "type": "object",
+        "required": ["value", "count"],
+        "properties": {
+          "count": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "FilterPredicate": {
+        "description": "FilterPredicate is an exact / set-based predicate against a single field. Values are strings whatever the field's declared type, so a boolean field takes \"true\" or \"false\" and a numeric field takes the number written out.\n\nNumbers are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a filter can both match a neighbour and miss the value asked for.",
+        "type": "object",
+        "required": ["field", "operator", "values"],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          },
+          "operator": {
+            "description": "Operator is \"In\" or \"NotIn\" in v1.",
+            "type": "string",
+            "default": ""
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        }
+      },
+      "RangePredicate": {
+        "description": "RangePredicate compares a numeric field against one or two bounds. At least one bound is required, gt cannot be combined with gte, and lt cannot be combined with lte. Boolean and string fields are rejected: only numbers have the order a range asks about. On an integer field a bound must be whole.\n\nBounds are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a bound can both admit a neighbour and exclude the value asked for.",
+        "type": "object",
+        "required": ["field"],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          },
+          "gt": {
+            "type": "number",
+            "format": "double"
+          },
+          "gte": {
+            "type": "number",
+            "format": "double"
+          },
+          "lt": {
+            "type": "number",
+            "format": "double"
+          },
+          "lte": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "ResourceRef": {
+        "description": "ResourceRef is the full identity of a returned item. Namespace is implicit from the URL and omitted.",
+        "type": "object",
+        "required": ["group", "resource", "kind", "name"],
+        "properties": {
+          "group": {
+            "type": "string",
+            "default": ""
+          },
+          "kind": {
+            "type": "string",
+            "default": ""
+          },
+          "name": {
+            "type": "string",
+            "default": ""
+          },
+          "resource": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "ResultItem": {
+        "description": "ResultItem is one search or trash hit. The item shape is identical on both endpoints; only which fields the Fields map can carry differs.",
+        "type": "object",
+        "required": ["resource"],
+        "properties": {
+          "fields": {
+            "description": "Fields holds the JSON values for the requested (or default) fields. Array-typed fields are returned as JSON arrays. Absent fields are omitted.",
+            "$ref": "#/components/schemas/Unstructured"
+          },
+          "resource": {
+            "default": {},
+            "$ref": "#/components/schemas/ResourceRef"
+          },
+          "score": {
+            "description": "Score is present only when a text query was evaluated. A pointer so a real score of 0 is still distinguishable from \"no text query\" (absent).",
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "ResultsMetadata": {
+        "description": "ResultsMetadata carries the pagination token and the total hit count.",
+        "type": "object",
+        "required": ["totalHits", "totalHitsRelation"],
+        "properties": {
+          "continue": {
+            "type": "string"
+          },
+          "totalHits": {
+            "description": "TotalHits counts the resources matching the query. Always read it together with TotalHitsRelation, which says whether the count is exact.",
+            "type": "integer",
+            "format": "int64",
+            "default": 0
+          },
+          "totalHitsRelation": {
+            "description": "TotalHitsRelation is \"eq\" when TotalHits is exact and \"lte\" when it is an upper bound.",
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "SearchQuery": {
+        "description": "SearchQuery is the request body for POST .../{resource}/search.",
+        "type": "object",
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "continue": {
+            "description": "Continue is an opaque pagination token from a previous page.",
+            "type": "string"
+          },
+          "facetLimit": {
+            "description": "FacetLimit caps the number of terms returned per facet. It applies to every entry in Facets. Zero uses the server default; values above the server cap are clamped.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "facets": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "labelSelector": {
+            "description": "LabelSelector filters on metadata.labels, ANDed with Where.",
+            "$ref": "#/components/schemas/LabelSelector"
+          },
+          "limit": {
+            "description": "Limit is the page size. Zero uses the default; values above the maximum are clamped.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "sort": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/SortField"
+            }
+          },
+          "where": {
+            "description": "Where is the search predicate tree. Omitting it matches all resources of the kind (subject to labelSelector and per-item authz).",
+            "$ref": "#/components/schemas/WhereNode"
+          }
+        }
+      },
+      "SearchResults": {
+        "description": "SearchResults is the response body for POST .../{resource}/search.",
+        "type": "object",
+        "required": ["metadata", "items"],
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "facets": {
+            "description": "Facets holds term counts per requested facet field. Counts are computed over a bounded sample window, so they are best-effort/approximate.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "default": {},
+                "$ref": "#/components/schemas/FacetTerm"
+              }
+            }
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/ResultItem"
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "metadata": {
+            "default": {},
+            "$ref": "#/components/schemas/ResultsMetadata"
+          }
+        }
+      },
+      "SortField": {
+        "description": "SortField names a field to sort by and a direction (\"asc\" or \"desc\"). V1 allows sorting only on scalar string and numeric fields that declare the sort capability.",
+        "type": "object",
+        "required": ["field"],
+        "properties": {
+          "direction": {
+            "type": "string"
+          },
+          "field": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "TextPredicate": {
+        "description": "TextPredicate is a free-text predicate against one or more text-capable fields. When Fields is empty it defaults to the kind's searchTextFields (currently [\"title\"]).",
+        "type": "object",
+        "required": ["value"],
+        "properties": {
+          "boost": {
+            "description": "Boost is a future per-leaf score multiplier. Setting it is rejected in v1.",
+            "type": "number",
+            "format": "double"
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "WhereNode": {
+        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+        "type": "object",
+        "properties": {
+          "and": {
+            "description": "Combinators.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/WhereNode"
+            }
+          },
+          "exists": {
+            "$ref": "#/components/schemas/ExistsPredicate"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/FilterPredicate"
+          },
+          "not": {
+            "$ref": "#/components/schemas/WhereNode"
+          },
+          "or": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/WhereNode"
+            }
+          },
+          "range": {
+            "$ref": "#/components/schemas/RangePredicate"
+          },
+          "text": {
+            "description": "Leaves.",
+            "$ref": "#/components/schemas/TextPredicate"
+          }
+        }
+      },
       "APIResource": {
         "description": "APIResource specifies the name of a resource and whether it is namespaced.",
         "type": "object",
@@ -3903,6 +4248,56 @@
       "FieldsV1": {
         "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
         "type": "object"
+      },
+      "LabelSelector": {
+        "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+        "type": "object",
+        "properties": {
+          "matchExpressions": {
+            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/LabelSelectorRequirement"
+            },
+            "x-kubernetes-list-type": "atomic"
+          },
+          "matchLabels": {
+            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        },
+        "x-kubernetes-map-type": "atomic"
+      },
+      "LabelSelectorRequirement": {
+        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+        "type": "object",
+        "required": ["key", "operator"],
+        "properties": {
+          "key": {
+            "description": "key is the label key that the selector applies to.",
+            "type": "string",
+            "default": ""
+          },
+          "operator": {
+            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+            "type": "string",
+            "default": ""
+          },
+          "values": {
+            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            },
+            "x-kubernetes-list-type": "atomic"
+          }
+        }
       },
       "ListMeta": {
         "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",

--- a/packages/grafana-openapi/src/apis/dashboard.grafana.app-v2beta1.json
+++ b/packages/grafana-openapi/src/apis/dashboard.grafana.app-v2beta1.json
@@ -242,6 +242,37 @@
         }
       ]
     },
+    "/dashboards/search": {
+      "post": {
+        "tags": ["Search"],
+        "description": "Search Dashboard resources in a namespace.",
+        "operationId": "listDashboardSearchV2beta1",
+        "parameters": [],
+        "requestBody": {
+          "description": "A SearchQuery describing what to match, sort and return.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A SearchResults envelope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResults"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/dashboards/{name}": {
       "get": {
         "tags": ["Dashboard"],
@@ -981,6 +1012,37 @@
           }
         }
       ]
+    },
+    "/notebooks/search": {
+      "post": {
+        "tags": ["Search"],
+        "description": "Search Notebook resources in a namespace.",
+        "operationId": "listNotebookSearchV2beta1",
+        "parameters": [],
+        "requestBody": {
+          "description": "A SearchQuery describing what to match, sort and return.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A SearchResults envelope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResults"
+                }
+              }
+            }
+          }
+        }
+      }
     },
     "/notebooks/{name}": {
       "get": {
@@ -6829,6 +6891,320 @@
           }
         }
       },
+      "Unstructured": {
+        "type": "object",
+        "additionalProperties": true,
+        "x-kubernetes-preserve-unknown-fields": true
+      },
+      "ExistsPredicate": {
+        "description": "ExistsPredicate is a future field-existence predicate. Modelled for schema stability; always rejected in v1.",
+        "type": "object",
+        "required": ["field"],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "FacetTerm": {
+        "description": "FacetTerm is a single facet term and its count.",
+        "type": "object",
+        "required": ["value", "count"],
+        "properties": {
+          "count": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "FilterPredicate": {
+        "description": "FilterPredicate is an exact / set-based predicate against a single field. Values are strings whatever the field's declared type, so a boolean field takes \"true\" or \"false\" and a numeric field takes the number written out.\n\nNumbers are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a filter can both match a neighbour and miss the value asked for.",
+        "type": "object",
+        "required": ["field", "operator", "values"],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          },
+          "operator": {
+            "description": "Operator is \"In\" or \"NotIn\" in v1.",
+            "type": "string",
+            "default": ""
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        }
+      },
+      "RangePredicate": {
+        "description": "RangePredicate compares a numeric field against one or two bounds. At least one bound is required, gt cannot be combined with gte, and lt cannot be combined with lte. Boolean and string fields are rejected: only numbers have the order a range asks about. On an integer field a bound must be whole.\n\nBounds are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a bound can both admit a neighbour and exclude the value asked for.",
+        "type": "object",
+        "required": ["field"],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          },
+          "gt": {
+            "type": "number",
+            "format": "double"
+          },
+          "gte": {
+            "type": "number",
+            "format": "double"
+          },
+          "lt": {
+            "type": "number",
+            "format": "double"
+          },
+          "lte": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "ResourceRef": {
+        "description": "ResourceRef is the full identity of a returned item. Namespace is implicit from the URL and omitted.",
+        "type": "object",
+        "required": ["group", "resource", "kind", "name"],
+        "properties": {
+          "group": {
+            "type": "string",
+            "default": ""
+          },
+          "kind": {
+            "type": "string",
+            "default": ""
+          },
+          "name": {
+            "type": "string",
+            "default": ""
+          },
+          "resource": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "ResultItem": {
+        "description": "ResultItem is one search or trash hit. The item shape is identical on both endpoints; only which fields the Fields map can carry differs.",
+        "type": "object",
+        "required": ["resource"],
+        "properties": {
+          "fields": {
+            "description": "Fields holds the JSON values for the requested (or default) fields. Array-typed fields are returned as JSON arrays. Absent fields are omitted.",
+            "$ref": "#/components/schemas/Unstructured"
+          },
+          "resource": {
+            "default": {},
+            "$ref": "#/components/schemas/ResourceRef"
+          },
+          "score": {
+            "description": "Score is present only when a text query was evaluated. A pointer so a real score of 0 is still distinguishable from \"no text query\" (absent).",
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "ResultsMetadata": {
+        "description": "ResultsMetadata carries the pagination token and the total hit count.",
+        "type": "object",
+        "required": ["totalHits", "totalHitsRelation"],
+        "properties": {
+          "continue": {
+            "type": "string"
+          },
+          "totalHits": {
+            "description": "TotalHits counts the resources matching the query. Always read it together with TotalHitsRelation, which says whether the count is exact.",
+            "type": "integer",
+            "format": "int64",
+            "default": 0
+          },
+          "totalHitsRelation": {
+            "description": "TotalHitsRelation is \"eq\" when TotalHits is exact and \"lte\" when it is an upper bound.",
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "SearchQuery": {
+        "description": "SearchQuery is the request body for POST .../{resource}/search.",
+        "type": "object",
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "continue": {
+            "description": "Continue is an opaque pagination token from a previous page.",
+            "type": "string"
+          },
+          "facetLimit": {
+            "description": "FacetLimit caps the number of terms returned per facet. It applies to every entry in Facets. Zero uses the server default; values above the server cap are clamped.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "facets": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "labelSelector": {
+            "description": "LabelSelector filters on metadata.labels, ANDed with Where.",
+            "$ref": "#/components/schemas/LabelSelector"
+          },
+          "limit": {
+            "description": "Limit is the page size. Zero uses the default; values above the maximum are clamped.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "sort": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/SortField"
+            }
+          },
+          "where": {
+            "description": "Where is the search predicate tree. Omitting it matches all resources of the kind (subject to labelSelector and per-item authz).",
+            "$ref": "#/components/schemas/WhereNode"
+          }
+        }
+      },
+      "SearchResults": {
+        "description": "SearchResults is the response body for POST .../{resource}/search.",
+        "type": "object",
+        "required": ["metadata", "items"],
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "facets": {
+            "description": "Facets holds term counts per requested facet field. Counts are computed over a bounded sample window, so they are best-effort/approximate.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "default": {},
+                "$ref": "#/components/schemas/FacetTerm"
+              }
+            }
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/ResultItem"
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "metadata": {
+            "default": {},
+            "$ref": "#/components/schemas/ResultsMetadata"
+          }
+        }
+      },
+      "SortField": {
+        "description": "SortField names a field to sort by and a direction (\"asc\" or \"desc\"). V1 allows sorting only on scalar string and numeric fields that declare the sort capability.",
+        "type": "object",
+        "required": ["field"],
+        "properties": {
+          "direction": {
+            "type": "string"
+          },
+          "field": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "TextPredicate": {
+        "description": "TextPredicate is a free-text predicate against one or more text-capable fields. When Fields is empty it defaults to the kind's searchTextFields (currently [\"title\"]).",
+        "type": "object",
+        "required": ["value"],
+        "properties": {
+          "boost": {
+            "description": "Boost is a future per-leaf score multiplier. Setting it is rejected in v1.",
+            "type": "number",
+            "format": "double"
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "WhereNode": {
+        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+        "type": "object",
+        "properties": {
+          "and": {
+            "description": "Combinators.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/WhereNode"
+            }
+          },
+          "exists": {
+            "$ref": "#/components/schemas/ExistsPredicate"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/FilterPredicate"
+          },
+          "not": {
+            "$ref": "#/components/schemas/WhereNode"
+          },
+          "or": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/WhereNode"
+            }
+          },
+          "range": {
+            "$ref": "#/components/schemas/RangePredicate"
+          },
+          "text": {
+            "description": "Leaves.",
+            "$ref": "#/components/schemas/TextPredicate"
+          }
+        }
+      },
       "APIResource": {
         "description": "APIResource specifies the name of a resource and whether it is namespaced.",
         "type": "object",
@@ -6978,6 +7354,56 @@
       "FieldsV1": {
         "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
         "type": "object"
+      },
+      "LabelSelector": {
+        "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+        "type": "object",
+        "properties": {
+          "matchExpressions": {
+            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/LabelSelectorRequirement"
+            },
+            "x-kubernetes-list-type": "atomic"
+          },
+          "matchLabels": {
+            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        },
+        "x-kubernetes-map-type": "atomic"
+      },
+      "LabelSelectorRequirement": {
+        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+        "type": "object",
+        "required": ["key", "operator"],
+        "properties": {
+          "key": {
+            "description": "key is the label key that the selector applies to.",
+            "type": "string",
+            "default": ""
+          },
+          "operator": {
+            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+            "type": "string",
+            "default": ""
+          },
+          "values": {
+            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            },
+            "x-kubernetes-list-type": "atomic"
+          }
+        }
       },
       "ListMeta": {
         "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",

--- a/packages/grafana-openapi/src/apis/folder.grafana.app-v1.json
+++ b/packages/grafana-openapi/src/apis/folder.grafana.app-v1.json
@@ -242,6 +242,37 @@
         }
       ]
     },
+    "/folders/search": {
+      "post": {
+        "tags": ["Search"],
+        "description": "Search Folder resources in a namespace.",
+        "operationId": "listFolderSearchV1",
+        "parameters": [],
+        "requestBody": {
+          "description": "A SearchQuery describing what to match, sort and return.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A SearchResults envelope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResults"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/folders/{name}": {
       "get": {
         "tags": ["Folder"],
@@ -1012,6 +1043,320 @@
           }
         }
       },
+      "Unstructured": {
+        "type": "object",
+        "additionalProperties": true,
+        "x-kubernetes-preserve-unknown-fields": true
+      },
+      "ExistsPredicate": {
+        "description": "ExistsPredicate is a future field-existence predicate. Modelled for schema stability; always rejected in v1.",
+        "type": "object",
+        "required": ["field"],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "FacetTerm": {
+        "description": "FacetTerm is a single facet term and its count.",
+        "type": "object",
+        "required": ["value", "count"],
+        "properties": {
+          "count": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "FilterPredicate": {
+        "description": "FilterPredicate is an exact / set-based predicate against a single field. Values are strings whatever the field's declared type, so a boolean field takes \"true\" or \"false\" and a numeric field takes the number written out.\n\nNumbers are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a filter can both match a neighbour and miss the value asked for.",
+        "type": "object",
+        "required": ["field", "operator", "values"],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          },
+          "operator": {
+            "description": "Operator is \"In\" or \"NotIn\" in v1.",
+            "type": "string",
+            "default": ""
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        }
+      },
+      "RangePredicate": {
+        "description": "RangePredicate compares a numeric field against one or two bounds. At least one bound is required, gt cannot be combined with gte, and lt cannot be combined with lte. Boolean and string fields are rejected: only numbers have the order a range asks about. On an integer field a bound must be whole.\n\nBounds are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a bound can both admit a neighbour and exclude the value asked for.",
+        "type": "object",
+        "required": ["field"],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          },
+          "gt": {
+            "type": "number",
+            "format": "double"
+          },
+          "gte": {
+            "type": "number",
+            "format": "double"
+          },
+          "lt": {
+            "type": "number",
+            "format": "double"
+          },
+          "lte": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "ResourceRef": {
+        "description": "ResourceRef is the full identity of a returned item. Namespace is implicit from the URL and omitted.",
+        "type": "object",
+        "required": ["group", "resource", "kind", "name"],
+        "properties": {
+          "group": {
+            "type": "string",
+            "default": ""
+          },
+          "kind": {
+            "type": "string",
+            "default": ""
+          },
+          "name": {
+            "type": "string",
+            "default": ""
+          },
+          "resource": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "ResultItem": {
+        "description": "ResultItem is one search or trash hit. The item shape is identical on both endpoints; only which fields the Fields map can carry differs.",
+        "type": "object",
+        "required": ["resource"],
+        "properties": {
+          "fields": {
+            "description": "Fields holds the JSON values for the requested (or default) fields. Array-typed fields are returned as JSON arrays. Absent fields are omitted.",
+            "$ref": "#/components/schemas/Unstructured"
+          },
+          "resource": {
+            "default": {},
+            "$ref": "#/components/schemas/ResourceRef"
+          },
+          "score": {
+            "description": "Score is present only when a text query was evaluated. A pointer so a real score of 0 is still distinguishable from \"no text query\" (absent).",
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "ResultsMetadata": {
+        "description": "ResultsMetadata carries the pagination token and the total hit count.",
+        "type": "object",
+        "required": ["totalHits", "totalHitsRelation"],
+        "properties": {
+          "continue": {
+            "type": "string"
+          },
+          "totalHits": {
+            "description": "TotalHits counts the resources matching the query. Always read it together with TotalHitsRelation, which says whether the count is exact.",
+            "type": "integer",
+            "format": "int64",
+            "default": 0
+          },
+          "totalHitsRelation": {
+            "description": "TotalHitsRelation is \"eq\" when TotalHits is exact and \"lte\" when it is an upper bound.",
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "SearchQuery": {
+        "description": "SearchQuery is the request body for POST .../{resource}/search.",
+        "type": "object",
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "continue": {
+            "description": "Continue is an opaque pagination token from a previous page.",
+            "type": "string"
+          },
+          "facetLimit": {
+            "description": "FacetLimit caps the number of terms returned per facet. It applies to every entry in Facets. Zero uses the server default; values above the server cap are clamped.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "facets": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "labelSelector": {
+            "description": "LabelSelector filters on metadata.labels, ANDed with Where.",
+            "$ref": "#/components/schemas/LabelSelector"
+          },
+          "limit": {
+            "description": "Limit is the page size. Zero uses the default; values above the maximum are clamped.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "sort": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/SortField"
+            }
+          },
+          "where": {
+            "description": "Where is the search predicate tree. Omitting it matches all resources of the kind (subject to labelSelector and per-item authz).",
+            "$ref": "#/components/schemas/WhereNode"
+          }
+        }
+      },
+      "SearchResults": {
+        "description": "SearchResults is the response body for POST .../{resource}/search.",
+        "type": "object",
+        "required": ["metadata", "items"],
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "facets": {
+            "description": "Facets holds term counts per requested facet field. Counts are computed over a bounded sample window, so they are best-effort/approximate.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "default": {},
+                "$ref": "#/components/schemas/FacetTerm"
+              }
+            }
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/ResultItem"
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "metadata": {
+            "default": {},
+            "$ref": "#/components/schemas/ResultsMetadata"
+          }
+        }
+      },
+      "SortField": {
+        "description": "SortField names a field to sort by and a direction (\"asc\" or \"desc\"). V1 allows sorting only on scalar string and numeric fields that declare the sort capability.",
+        "type": "object",
+        "required": ["field"],
+        "properties": {
+          "direction": {
+            "type": "string"
+          },
+          "field": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "TextPredicate": {
+        "description": "TextPredicate is a free-text predicate against one or more text-capable fields. When Fields is empty it defaults to the kind's searchTextFields (currently [\"title\"]).",
+        "type": "object",
+        "required": ["value"],
+        "properties": {
+          "boost": {
+            "description": "Boost is a future per-leaf score multiplier. Setting it is rejected in v1.",
+            "type": "number",
+            "format": "double"
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "WhereNode": {
+        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+        "type": "object",
+        "properties": {
+          "and": {
+            "description": "Combinators.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/WhereNode"
+            }
+          },
+          "exists": {
+            "$ref": "#/components/schemas/ExistsPredicate"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/FilterPredicate"
+          },
+          "not": {
+            "$ref": "#/components/schemas/WhereNode"
+          },
+          "or": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/WhereNode"
+            }
+          },
+          "range": {
+            "$ref": "#/components/schemas/RangePredicate"
+          },
+          "text": {
+            "description": "Leaves.",
+            "$ref": "#/components/schemas/TextPredicate"
+          }
+        }
+      },
       "APIResource": {
         "description": "APIResource specifies the name of a resource and whether it is namespaced.",
         "type": "object",
@@ -1161,6 +1506,56 @@
       "FieldsV1": {
         "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
         "type": "object"
+      },
+      "LabelSelector": {
+        "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+        "type": "object",
+        "properties": {
+          "matchExpressions": {
+            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/LabelSelectorRequirement"
+            },
+            "x-kubernetes-list-type": "atomic"
+          },
+          "matchLabels": {
+            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        },
+        "x-kubernetes-map-type": "atomic"
+      },
+      "LabelSelectorRequirement": {
+        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+        "type": "object",
+        "required": ["key", "operator"],
+        "properties": {
+          "key": {
+            "description": "key is the label key that the selector applies to.",
+            "type": "string",
+            "default": ""
+          },
+          "operator": {
+            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+            "type": "string",
+            "default": ""
+          },
+          "values": {
+            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            },
+            "x-kubernetes-list-type": "atomic"
+          }
+        }
       },
       "ListMeta": {
         "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",

--- a/packages/grafana-openapi/src/apis/folder.grafana.app-v1beta1.json
+++ b/packages/grafana-openapi/src/apis/folder.grafana.app-v1beta1.json
@@ -242,6 +242,37 @@
         }
       ]
     },
+    "/folders/search": {
+      "post": {
+        "tags": ["Search"],
+        "description": "Search Folder resources in a namespace.",
+        "operationId": "listFolderSearchV1beta1",
+        "parameters": [],
+        "requestBody": {
+          "description": "A SearchQuery describing what to match, sort and return.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A SearchResults envelope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResults"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/folders/{name}": {
       "get": {
         "tags": ["Folder"],
@@ -1012,6 +1043,320 @@
           }
         }
       },
+      "Unstructured": {
+        "type": "object",
+        "additionalProperties": true,
+        "x-kubernetes-preserve-unknown-fields": true
+      },
+      "ExistsPredicate": {
+        "description": "ExistsPredicate is a future field-existence predicate. Modelled for schema stability; always rejected in v1.",
+        "type": "object",
+        "required": ["field"],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "FacetTerm": {
+        "description": "FacetTerm is a single facet term and its count.",
+        "type": "object",
+        "required": ["value", "count"],
+        "properties": {
+          "count": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "FilterPredicate": {
+        "description": "FilterPredicate is an exact / set-based predicate against a single field. Values are strings whatever the field's declared type, so a boolean field takes \"true\" or \"false\" and a numeric field takes the number written out.\n\nNumbers are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a filter can both match a neighbour and miss the value asked for.",
+        "type": "object",
+        "required": ["field", "operator", "values"],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          },
+          "operator": {
+            "description": "Operator is \"In\" or \"NotIn\" in v1.",
+            "type": "string",
+            "default": ""
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        }
+      },
+      "RangePredicate": {
+        "description": "RangePredicate compares a numeric field against one or two bounds. At least one bound is required, gt cannot be combined with gte, and lt cannot be combined with lte. Boolean and string fields are rejected: only numbers have the order a range asks about. On an integer field a bound must be whole.\n\nBounds are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a bound can both admit a neighbour and exclude the value asked for.",
+        "type": "object",
+        "required": ["field"],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          },
+          "gt": {
+            "type": "number",
+            "format": "double"
+          },
+          "gte": {
+            "type": "number",
+            "format": "double"
+          },
+          "lt": {
+            "type": "number",
+            "format": "double"
+          },
+          "lte": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "ResourceRef": {
+        "description": "ResourceRef is the full identity of a returned item. Namespace is implicit from the URL and omitted.",
+        "type": "object",
+        "required": ["group", "resource", "kind", "name"],
+        "properties": {
+          "group": {
+            "type": "string",
+            "default": ""
+          },
+          "kind": {
+            "type": "string",
+            "default": ""
+          },
+          "name": {
+            "type": "string",
+            "default": ""
+          },
+          "resource": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "ResultItem": {
+        "description": "ResultItem is one search or trash hit. The item shape is identical on both endpoints; only which fields the Fields map can carry differs.",
+        "type": "object",
+        "required": ["resource"],
+        "properties": {
+          "fields": {
+            "description": "Fields holds the JSON values for the requested (or default) fields. Array-typed fields are returned as JSON arrays. Absent fields are omitted.",
+            "$ref": "#/components/schemas/Unstructured"
+          },
+          "resource": {
+            "default": {},
+            "$ref": "#/components/schemas/ResourceRef"
+          },
+          "score": {
+            "description": "Score is present only when a text query was evaluated. A pointer so a real score of 0 is still distinguishable from \"no text query\" (absent).",
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "ResultsMetadata": {
+        "description": "ResultsMetadata carries the pagination token and the total hit count.",
+        "type": "object",
+        "required": ["totalHits", "totalHitsRelation"],
+        "properties": {
+          "continue": {
+            "type": "string"
+          },
+          "totalHits": {
+            "description": "TotalHits counts the resources matching the query. Always read it together with TotalHitsRelation, which says whether the count is exact.",
+            "type": "integer",
+            "format": "int64",
+            "default": 0
+          },
+          "totalHitsRelation": {
+            "description": "TotalHitsRelation is \"eq\" when TotalHits is exact and \"lte\" when it is an upper bound.",
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "SearchQuery": {
+        "description": "SearchQuery is the request body for POST .../{resource}/search.",
+        "type": "object",
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "continue": {
+            "description": "Continue is an opaque pagination token from a previous page.",
+            "type": "string"
+          },
+          "facetLimit": {
+            "description": "FacetLimit caps the number of terms returned per facet. It applies to every entry in Facets. Zero uses the server default; values above the server cap are clamped.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "facets": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "labelSelector": {
+            "description": "LabelSelector filters on metadata.labels, ANDed with Where.",
+            "$ref": "#/components/schemas/LabelSelector"
+          },
+          "limit": {
+            "description": "Limit is the page size. Zero uses the default; values above the maximum are clamped.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "sort": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/SortField"
+            }
+          },
+          "where": {
+            "description": "Where is the search predicate tree. Omitting it matches all resources of the kind (subject to labelSelector and per-item authz).",
+            "$ref": "#/components/schemas/WhereNode"
+          }
+        }
+      },
+      "SearchResults": {
+        "description": "SearchResults is the response body for POST .../{resource}/search.",
+        "type": "object",
+        "required": ["metadata", "items"],
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "facets": {
+            "description": "Facets holds term counts per requested facet field. Counts are computed over a bounded sample window, so they are best-effort/approximate.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "default": {},
+                "$ref": "#/components/schemas/FacetTerm"
+              }
+            }
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/ResultItem"
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "metadata": {
+            "default": {},
+            "$ref": "#/components/schemas/ResultsMetadata"
+          }
+        }
+      },
+      "SortField": {
+        "description": "SortField names a field to sort by and a direction (\"asc\" or \"desc\"). V1 allows sorting only on scalar string and numeric fields that declare the sort capability.",
+        "type": "object",
+        "required": ["field"],
+        "properties": {
+          "direction": {
+            "type": "string"
+          },
+          "field": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "TextPredicate": {
+        "description": "TextPredicate is a free-text predicate against one or more text-capable fields. When Fields is empty it defaults to the kind's searchTextFields (currently [\"title\"]).",
+        "type": "object",
+        "required": ["value"],
+        "properties": {
+          "boost": {
+            "description": "Boost is a future per-leaf score multiplier. Setting it is rejected in v1.",
+            "type": "number",
+            "format": "double"
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "WhereNode": {
+        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+        "type": "object",
+        "properties": {
+          "and": {
+            "description": "Combinators.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/WhereNode"
+            }
+          },
+          "exists": {
+            "$ref": "#/components/schemas/ExistsPredicate"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/FilterPredicate"
+          },
+          "not": {
+            "$ref": "#/components/schemas/WhereNode"
+          },
+          "or": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/WhereNode"
+            }
+          },
+          "range": {
+            "$ref": "#/components/schemas/RangePredicate"
+          },
+          "text": {
+            "description": "Leaves.",
+            "$ref": "#/components/schemas/TextPredicate"
+          }
+        }
+      },
       "APIResource": {
         "description": "APIResource specifies the name of a resource and whether it is namespaced.",
         "type": "object",
@@ -1161,6 +1506,56 @@
       "FieldsV1": {
         "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
         "type": "object"
+      },
+      "LabelSelector": {
+        "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+        "type": "object",
+        "properties": {
+          "matchExpressions": {
+            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/LabelSelectorRequirement"
+            },
+            "x-kubernetes-list-type": "atomic"
+          },
+          "matchLabels": {
+            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        },
+        "x-kubernetes-map-type": "atomic"
+      },
+      "LabelSelectorRequirement": {
+        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+        "type": "object",
+        "required": ["key", "operator"],
+        "properties": {
+          "key": {
+            "description": "key is the label key that the selector applies to.",
+            "type": "string",
+            "default": ""
+          },
+          "operator": {
+            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+            "type": "string",
+            "default": ""
+          },
+          "values": {
+            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            },
+            "x-kubernetes-list-type": "atomic"
+          }
+        }
       },
       "ListMeta": {
         "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",

--- a/packages/grafana-openapi/src/apis/iam.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/iam.grafana.app-v0alpha1.json
@@ -63,6 +63,37 @@
         }
       }
     },
+    "/externalgroupmappings/search": {
+      "post": {
+        "tags": ["Search"],
+        "description": "Search ExternalGroupMapping resources in a namespace.",
+        "operationId": "listExternalGroupMappingSearchV0alpha1",
+        "parameters": [],
+        "requestBody": {
+          "description": "A SearchQuery describing what to match, sort and return.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A SearchResults envelope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResults"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/searchExternalGroupMappings": {
       "post": {
         "tags": ["Search"],
@@ -1075,6 +1106,37 @@
         }
       ]
     },
+    "/teambindings/search": {
+      "post": {
+        "tags": ["Search"],
+        "description": "Search TeamBinding resources in a namespace.",
+        "operationId": "listTeamBindingSearchV0alpha1",
+        "parameters": [],
+        "requestBody": {
+          "description": "A SearchQuery describing what to match, sort and return.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A SearchResults envelope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResults"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/teams": {
       "get": {
         "tags": ["Team"],
@@ -1287,6 +1349,37 @@
           }
         }
       ]
+    },
+    "/teams/search": {
+      "post": {
+        "tags": ["Search"],
+        "description": "Search Team resources in a namespace.",
+        "operationId": "listTeamSearchV0alpha1",
+        "parameters": [],
+        "requestBody": {
+          "description": "A SearchQuery describing what to match, sort and return.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A SearchResults envelope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResults"
+                }
+              }
+            }
+          }
+        }
+      }
     },
     "/teams/{name}": {
       "get": {
@@ -2046,6 +2139,37 @@
           }
         }
       ]
+    },
+    "/users/search": {
+      "post": {
+        "tags": ["Search"],
+        "description": "Search User resources in a namespace.",
+        "operationId": "listUserSearchV0alpha1",
+        "parameters": [],
+        "requestBody": {
+          "description": "A SearchQuery describing what to match, sort and return.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A SearchResults envelope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResults"
+                }
+              }
+            }
+          }
+        }
+      }
     },
     "/users/{name}": {
       "get": {
@@ -4530,6 +4654,11 @@
           }
         }
       },
+      "Unstructured": {
+        "type": "object",
+        "additionalProperties": true,
+        "x-kubernetes-preserve-unknown-fields": true
+      },
       "Display": {
         "type": "object",
         "required": ["identity", "displayName"],
@@ -4804,6 +4933,315 @@
           },
           "metadata": {
             "default": {}
+          }
+        }
+      },
+      "ExistsPredicate": {
+        "description": "ExistsPredicate is a future field-existence predicate. Modelled for schema stability; always rejected in v1.",
+        "type": "object",
+        "required": ["field"],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "FacetTerm": {
+        "description": "FacetTerm is a single facet term and its count.",
+        "type": "object",
+        "required": ["value", "count"],
+        "properties": {
+          "count": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "FilterPredicate": {
+        "description": "FilterPredicate is an exact / set-based predicate against a single field. Values are strings whatever the field's declared type, so a boolean field takes \"true\" or \"false\" and a numeric field takes the number written out.\n\nNumbers are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a filter can both match a neighbour and miss the value asked for.",
+        "type": "object",
+        "required": ["field", "operator", "values"],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          },
+          "operator": {
+            "description": "Operator is \"In\" or \"NotIn\" in v1.",
+            "type": "string",
+            "default": ""
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        }
+      },
+      "RangePredicate": {
+        "description": "RangePredicate compares a numeric field against one or two bounds. At least one bound is required, gt cannot be combined with gte, and lt cannot be combined with lte. Boolean and string fields are rejected: only numbers have the order a range asks about. On an integer field a bound must be whole.\n\nBounds are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a bound can both admit a neighbour and exclude the value asked for.",
+        "type": "object",
+        "required": ["field"],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          },
+          "gt": {
+            "type": "number",
+            "format": "double"
+          },
+          "gte": {
+            "type": "number",
+            "format": "double"
+          },
+          "lt": {
+            "type": "number",
+            "format": "double"
+          },
+          "lte": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "ResourceRef": {
+        "description": "ResourceRef is the full identity of a returned item. Namespace is implicit from the URL and omitted.",
+        "type": "object",
+        "required": ["group", "resource", "kind", "name"],
+        "properties": {
+          "group": {
+            "type": "string",
+            "default": ""
+          },
+          "kind": {
+            "type": "string",
+            "default": ""
+          },
+          "name": {
+            "type": "string",
+            "default": ""
+          },
+          "resource": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "ResultItem": {
+        "description": "ResultItem is one search or trash hit. The item shape is identical on both endpoints; only which fields the Fields map can carry differs.",
+        "type": "object",
+        "required": ["resource"],
+        "properties": {
+          "fields": {
+            "description": "Fields holds the JSON values for the requested (or default) fields. Array-typed fields are returned as JSON arrays. Absent fields are omitted.",
+            "$ref": "#/components/schemas/Unstructured"
+          },
+          "resource": {
+            "default": {},
+            "$ref": "#/components/schemas/ResourceRef"
+          },
+          "score": {
+            "description": "Score is present only when a text query was evaluated. A pointer so a real score of 0 is still distinguishable from \"no text query\" (absent).",
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "ResultsMetadata": {
+        "description": "ResultsMetadata carries the pagination token and the total hit count.",
+        "type": "object",
+        "required": ["totalHits", "totalHitsRelation"],
+        "properties": {
+          "continue": {
+            "type": "string"
+          },
+          "totalHits": {
+            "description": "TotalHits counts the resources matching the query. Always read it together with TotalHitsRelation, which says whether the count is exact.",
+            "type": "integer",
+            "format": "int64",
+            "default": 0
+          },
+          "totalHitsRelation": {
+            "description": "TotalHitsRelation is \"eq\" when TotalHits is exact and \"lte\" when it is an upper bound.",
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "SearchQuery": {
+        "description": "SearchQuery is the request body for POST .../{resource}/search.",
+        "type": "object",
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "continue": {
+            "description": "Continue is an opaque pagination token from a previous page.",
+            "type": "string"
+          },
+          "facetLimit": {
+            "description": "FacetLimit caps the number of terms returned per facet. It applies to every entry in Facets. Zero uses the server default; values above the server cap are clamped.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "facets": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "labelSelector": {
+            "description": "LabelSelector filters on metadata.labels, ANDed with Where.",
+            "$ref": "#/components/schemas/LabelSelector"
+          },
+          "limit": {
+            "description": "Limit is the page size. Zero uses the default; values above the maximum are clamped.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "sort": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/SortField"
+            }
+          },
+          "where": {
+            "description": "Where is the search predicate tree. Omitting it matches all resources of the kind (subject to labelSelector and per-item authz).",
+            "$ref": "#/components/schemas/WhereNode"
+          }
+        }
+      },
+      "SearchResults": {
+        "description": "SearchResults is the response body for POST .../{resource}/search.",
+        "type": "object",
+        "required": ["metadata", "items"],
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "facets": {
+            "description": "Facets holds term counts per requested facet field. Counts are computed over a bounded sample window, so they are best-effort/approximate.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "default": {},
+                "$ref": "#/components/schemas/FacetTerm"
+              }
+            }
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/ResultItem"
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "metadata": {
+            "default": {},
+            "$ref": "#/components/schemas/ResultsMetadata"
+          }
+        }
+      },
+      "SortField": {
+        "description": "SortField names a field to sort by and a direction (\"asc\" or \"desc\"). V1 allows sorting only on scalar string and numeric fields that declare the sort capability.",
+        "type": "object",
+        "required": ["field"],
+        "properties": {
+          "direction": {
+            "type": "string"
+          },
+          "field": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "TextPredicate": {
+        "description": "TextPredicate is a free-text predicate against one or more text-capable fields. When Fields is empty it defaults to the kind's searchTextFields (currently [\"title\"]).",
+        "type": "object",
+        "required": ["value"],
+        "properties": {
+          "boost": {
+            "description": "Boost is a future per-leaf score multiplier. Setting it is rejected in v1.",
+            "type": "number",
+            "format": "double"
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "WhereNode": {
+        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+        "type": "object",
+        "properties": {
+          "and": {
+            "description": "Combinators.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/WhereNode"
+            }
+          },
+          "exists": {
+            "$ref": "#/components/schemas/ExistsPredicate"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/FilterPredicate"
+          },
+          "not": {
+            "$ref": "#/components/schemas/WhereNode"
+          },
+          "or": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/WhereNode"
+            }
+          },
+          "range": {
+            "$ref": "#/components/schemas/RangePredicate"
+          },
+          "text": {
+            "description": "Leaves.",
+            "$ref": "#/components/schemas/TextPredicate"
           }
         }
       },
@@ -5127,6 +5565,56 @@
       "FieldsV1": {
         "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
         "type": "object"
+      },
+      "LabelSelector": {
+        "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+        "type": "object",
+        "properties": {
+          "matchExpressions": {
+            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/LabelSelectorRequirement"
+            },
+            "x-kubernetes-list-type": "atomic"
+          },
+          "matchLabels": {
+            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        },
+        "x-kubernetes-map-type": "atomic"
+      },
+      "LabelSelectorRequirement": {
+        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+        "type": "object",
+        "required": ["key", "operator"],
+        "properties": {
+          "key": {
+            "description": "key is the label key that the selector applies to.",
+            "type": "string",
+            "default": ""
+          },
+          "operator": {
+            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+            "type": "string",
+            "default": ""
+          },
+          "values": {
+            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            },
+            "x-kubernetes-list-type": "atomic"
+          }
+        }
       },
       "ListMeta": {
         "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",

--- a/packages/grafana-openapi/src/apis/rules.alerting.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/rules.alerting.grafana.app-v0alpha1.json
@@ -241,6 +241,37 @@
         }
       ]
     },
+    "/alertrules/search": {
+      "post": {
+        "tags": ["Search"],
+        "description": "Search AlertRule resources in a namespace.",
+        "operationId": "listAlertRuleSearchV0alpha1",
+        "parameters": [],
+        "requestBody": {
+          "description": "A SearchQuery describing what to match, sort and return.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A SearchResults envelope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResults"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/alertrules/{name}": {
       "get": {
         "tags": ["AlertRule"],
@@ -1187,6 +1218,37 @@
           }
         }
       ]
+    },
+    "/recordingrules/search": {
+      "post": {
+        "tags": ["Search"],
+        "description": "Search RecordingRule resources in a namespace.",
+        "operationId": "listRecordingRuleSearchV0alpha1",
+        "parameters": [],
+        "requestBody": {
+          "description": "A SearchQuery describing what to match, sort and return.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A SearchResults envelope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResults"
+                }
+              }
+            }
+          }
+        }
+      }
     },
     "/recordingrules/{name}": {
       "get": {
@@ -3769,6 +3831,320 @@
         },
         "additionalProperties": false
       },
+      "Unstructured": {
+        "type": "object",
+        "additionalProperties": true,
+        "x-kubernetes-preserve-unknown-fields": true
+      },
+      "ExistsPredicate": {
+        "description": "ExistsPredicate is a future field-existence predicate. Modelled for schema stability; always rejected in v1.",
+        "type": "object",
+        "required": ["field"],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "FacetTerm": {
+        "description": "FacetTerm is a single facet term and its count.",
+        "type": "object",
+        "required": ["value", "count"],
+        "properties": {
+          "count": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "FilterPredicate": {
+        "description": "FilterPredicate is an exact / set-based predicate against a single field. Values are strings whatever the field's declared type, so a boolean field takes \"true\" or \"false\" and a numeric field takes the number written out.\n\nNumbers are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a filter can both match a neighbour and miss the value asked for.",
+        "type": "object",
+        "required": ["field", "operator", "values"],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          },
+          "operator": {
+            "description": "Operator is \"In\" or \"NotIn\" in v1.",
+            "type": "string",
+            "default": ""
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        }
+      },
+      "RangePredicate": {
+        "description": "RangePredicate compares a numeric field against one or two bounds. At least one bound is required, gt cannot be combined with gte, and lt cannot be combined with lte. Boolean and string fields are rejected: only numbers have the order a range asks about. On an integer field a bound must be whole.\n\nBounds are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a bound can both admit a neighbour and exclude the value asked for.",
+        "type": "object",
+        "required": ["field"],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          },
+          "gt": {
+            "type": "number",
+            "format": "double"
+          },
+          "gte": {
+            "type": "number",
+            "format": "double"
+          },
+          "lt": {
+            "type": "number",
+            "format": "double"
+          },
+          "lte": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "ResourceRef": {
+        "description": "ResourceRef is the full identity of a returned item. Namespace is implicit from the URL and omitted.",
+        "type": "object",
+        "required": ["group", "resource", "kind", "name"],
+        "properties": {
+          "group": {
+            "type": "string",
+            "default": ""
+          },
+          "kind": {
+            "type": "string",
+            "default": ""
+          },
+          "name": {
+            "type": "string",
+            "default": ""
+          },
+          "resource": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "ResultItem": {
+        "description": "ResultItem is one search or trash hit. The item shape is identical on both endpoints; only which fields the Fields map can carry differs.",
+        "type": "object",
+        "required": ["resource"],
+        "properties": {
+          "fields": {
+            "description": "Fields holds the JSON values for the requested (or default) fields. Array-typed fields are returned as JSON arrays. Absent fields are omitted.",
+            "$ref": "#/components/schemas/Unstructured"
+          },
+          "resource": {
+            "default": {},
+            "$ref": "#/components/schemas/ResourceRef"
+          },
+          "score": {
+            "description": "Score is present only when a text query was evaluated. A pointer so a real score of 0 is still distinguishable from \"no text query\" (absent).",
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "ResultsMetadata": {
+        "description": "ResultsMetadata carries the pagination token and the total hit count.",
+        "type": "object",
+        "required": ["totalHits", "totalHitsRelation"],
+        "properties": {
+          "continue": {
+            "type": "string"
+          },
+          "totalHits": {
+            "description": "TotalHits counts the resources matching the query. Always read it together with TotalHitsRelation, which says whether the count is exact.",
+            "type": "integer",
+            "format": "int64",
+            "default": 0
+          },
+          "totalHitsRelation": {
+            "description": "TotalHitsRelation is \"eq\" when TotalHits is exact and \"lte\" when it is an upper bound.",
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "SearchQuery": {
+        "description": "SearchQuery is the request body for POST .../{resource}/search.",
+        "type": "object",
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "continue": {
+            "description": "Continue is an opaque pagination token from a previous page.",
+            "type": "string"
+          },
+          "facetLimit": {
+            "description": "FacetLimit caps the number of terms returned per facet. It applies to every entry in Facets. Zero uses the server default; values above the server cap are clamped.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "facets": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "labelSelector": {
+            "description": "LabelSelector filters on metadata.labels, ANDed with Where.",
+            "$ref": "#/components/schemas/LabelSelector"
+          },
+          "limit": {
+            "description": "Limit is the page size. Zero uses the default; values above the maximum are clamped.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "sort": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/SortField"
+            }
+          },
+          "where": {
+            "description": "Where is the search predicate tree. Omitting it matches all resources of the kind (subject to labelSelector and per-item authz).",
+            "$ref": "#/components/schemas/WhereNode"
+          }
+        }
+      },
+      "SearchResults": {
+        "description": "SearchResults is the response body for POST .../{resource}/search.",
+        "type": "object",
+        "required": ["metadata", "items"],
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "facets": {
+            "description": "Facets holds term counts per requested facet field. Counts are computed over a bounded sample window, so they are best-effort/approximate.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "default": {},
+                "$ref": "#/components/schemas/FacetTerm"
+              }
+            }
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/ResultItem"
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "metadata": {
+            "default": {},
+            "$ref": "#/components/schemas/ResultsMetadata"
+          }
+        }
+      },
+      "SortField": {
+        "description": "SortField names a field to sort by and a direction (\"asc\" or \"desc\"). V1 allows sorting only on scalar string and numeric fields that declare the sort capability.",
+        "type": "object",
+        "required": ["field"],
+        "properties": {
+          "direction": {
+            "type": "string"
+          },
+          "field": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "TextPredicate": {
+        "description": "TextPredicate is a free-text predicate against one or more text-capable fields. When Fields is empty it defaults to the kind's searchTextFields (currently [\"title\"]).",
+        "type": "object",
+        "required": ["value"],
+        "properties": {
+          "boost": {
+            "description": "Boost is a future per-leaf score multiplier. Setting it is rejected in v1.",
+            "type": "number",
+            "format": "double"
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "WhereNode": {
+        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+        "type": "object",
+        "properties": {
+          "and": {
+            "description": "Combinators.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/WhereNode"
+            }
+          },
+          "exists": {
+            "$ref": "#/components/schemas/ExistsPredicate"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/FilterPredicate"
+          },
+          "not": {
+            "$ref": "#/components/schemas/WhereNode"
+          },
+          "or": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/WhereNode"
+            }
+          },
+          "range": {
+            "$ref": "#/components/schemas/RangePredicate"
+          },
+          "text": {
+            "description": "Leaves.",
+            "$ref": "#/components/schemas/TextPredicate"
+          }
+        }
+      },
       "APIResource": {
         "description": "APIResource specifies the name of a resource and whether it is namespaced.",
         "type": "object",
@@ -3918,6 +4294,56 @@
       "FieldsV1": {
         "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
         "type": "object"
+      },
+      "LabelSelector": {
+        "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+        "type": "object",
+        "properties": {
+          "matchExpressions": {
+            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/LabelSelectorRequirement"
+            },
+            "x-kubernetes-list-type": "atomic"
+          },
+          "matchLabels": {
+            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        },
+        "x-kubernetes-map-type": "atomic"
+      },
+      "LabelSelectorRequirement": {
+        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+        "type": "object",
+        "required": ["key", "operator"],
+        "properties": {
+          "key": {
+            "description": "key is the label key that the selector applies to.",
+            "type": "string",
+            "default": ""
+          },
+          "operator": {
+            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+            "type": "string",
+            "default": ""
+          },
+          "values": {
+            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            },
+            "x-kubernetes-list-type": "atomic"
+          }
+        }
       },
       "ListMeta": {
         "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",

--- a/pkg/registry/apis/search/route.go
+++ b/pkg/registry/apis/search/route.go
@@ -11,7 +11,7 @@ import (
 )
 
 // ConfigSection and ConfigKey name the ini setting that turns these endpoints
-// on. The endpoints are off by default while the API is being built out.
+// on. Search is on by default, trash is not.
 //
 // Trash has its own key rather than sharing ConfigKey. It authorizes on a
 // different rule -- folder admin, or whoever deleted the object -- that has not been

--- a/pkg/services/apiserver/options/extra.go
+++ b/pkg/services/apiserver/options/extra.go
@@ -24,8 +24,6 @@ type ExtraOptions struct {
 	RequestTimeout  time.Duration
 	// EnableSearchAPI is the flag equivalent of [grafana-apiserver]
 	// enable_search_api, for servers configured by flags rather than an ini file.
-	// Temporary, while the per-resource search endpoints are being built out; it
-	// goes away once kinds opt in through their manifest.
 	EnableSearchAPI bool
 
 	// EnableTrashAPI is the flag equivalent of [grafana-apiserver]
@@ -37,9 +35,10 @@ type ExtraOptions struct {
 
 func NewExtraOptions() *ExtraOptions {
 	return &ExtraOptions{
-		DevMode:        false,
-		Verbosity:      0,
-		RequestTimeout: 10 * time.Minute,
+		DevMode:         false,
+		Verbosity:       0,
+		RequestTimeout:  10 * time.Minute,
+		EnableSearchAPI: true,
 	}
 }
 

--- a/pkg/services/apiserver/options/extra_test.go
+++ b/pkg/services/apiserver/options/extra_test.go
@@ -1,0 +1,26 @@
+package options
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+)
+
+// The multi-tenant apiserver takes its defaults from here, so changing them changes
+// behaviour in another repository.
+func TestNewExtraOptions_SearchDefaults(t *testing.T) {
+	o := NewExtraOptions()
+
+	require.True(t, o.EnableSearchAPI, "search endpoints should be served by default")
+	require.False(t, o.EnableTrashAPI, "trash authorizes on a rule that has not been reviewed")
+}
+
+func TestExtraOptions_SearchAPICanBeTurnedOff(t *testing.T) {
+	o := NewExtraOptions()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	o.AddFlags(fs)
+
+	require.NoError(t, fs.Parse([]string{"--grafana-apiserver-enable-search-api=false"}))
+	require.False(t, o.EnableSearchAPI)
+}

--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -408,7 +408,7 @@ func (s *service) start(ctx context.Context) error {
 	// Built once and used twice: the routes have to reach both the OpenAPI spec
 	// and the served WebServices, or the endpoint works but is undiscoverable.
 	apiserverSection := s.cfg.SectionWithEnvOverrides(searchapi.ConfigSection)
-	searchAPIEnabled := apiserverSection.Key(searchapi.ConfigKey).MustBool(false)
+	searchAPIEnabled := apiserverSection.Key(searchapi.ConfigKey).MustBool(true)
 	trashAPIEnabled := apiserverSection.Key(searchapi.ConfigKeyTrash).MustBool(false)
 	searchRoutes := searchroutes.Build(searchAPIEnabled, trashAPIEnabled, s.tracing, s.unified, builders, s.appInstallers)
 

--- a/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v0alpha1.json
@@ -258,6 +258,50 @@
         }
       ]
     },
+    "/apis/dashboard.grafana.app/v0alpha1/namespaces/{namespace}/dashboards/search": {
+      "post": {
+        "tags": [
+          "Search"
+        ],
+        "description": "Search Dashboard resources in a namespace.",
+        "operationId": "listDashboardSearchV0alpha1",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "workspace",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "default"
+          }
+        ],
+        "requestBody": {
+          "description": "A SearchQuery describing what to match, sort and return.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A SearchResults envelope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchResults"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/apis/dashboard.grafana.app/v0alpha1/namespaces/{namespace}/dashboards/{name}": {
       "get": {
         "tags": [
@@ -3007,6 +3051,343 @@
         "additionalProperties": true,
         "x-kubernetes-preserve-unknown-fields": true
       },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.ExistsPredicate": {
+        "description": "ExistsPredicate is a future field-existence predicate. Modelled for schema stability; always rejected in v1.",
+        "type": "object",
+        "required": [
+          "field"
+        ],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.FacetTerm": {
+        "description": "FacetTerm is a single facet term and its count.",
+        "type": "object",
+        "required": [
+          "value",
+          "count"
+        ],
+        "properties": {
+          "count": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.FilterPredicate": {
+        "description": "FilterPredicate is an exact / set-based predicate against a single field. Values are strings whatever the field's declared type, so a boolean field takes \"true\" or \"false\" and a numeric field takes the number written out.\n\nNumbers are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a filter can both match a neighbour and miss the value asked for.",
+        "type": "object",
+        "required": [
+          "field",
+          "operator",
+          "values"
+        ],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          },
+          "operator": {
+            "description": "Operator is \"In\" or \"NotIn\" in v1.",
+            "type": "string",
+            "default": ""
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.RangePredicate": {
+        "description": "RangePredicate compares a numeric field against one or two bounds. At least one bound is required, gt cannot be combined with gte, and lt cannot be combined with lte. Boolean and string fields are rejected: only numbers have the order a range asks about. On an integer field a bound must be whole.\n\nBounds are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a bound can both admit a neighbour and exclude the value asked for.",
+        "type": "object",
+        "required": [
+          "field"
+        ],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          },
+          "gt": {
+            "type": "number",
+            "format": "double"
+          },
+          "gte": {
+            "type": "number",
+            "format": "double"
+          },
+          "lt": {
+            "type": "number",
+            "format": "double"
+          },
+          "lte": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResourceRef": {
+        "description": "ResourceRef is the full identity of a returned item. Namespace is implicit from the URL and omitted.",
+        "type": "object",
+        "required": [
+          "group",
+          "resource",
+          "kind",
+          "name"
+        ],
+        "properties": {
+          "group": {
+            "type": "string",
+            "default": ""
+          },
+          "kind": {
+            "type": "string",
+            "default": ""
+          },
+          "name": {
+            "type": "string",
+            "default": ""
+          },
+          "resource": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResultItem": {
+        "description": "ResultItem is one search or trash hit. The item shape is identical on both endpoints; only which fields the Fields map can carry differs.",
+        "type": "object",
+        "required": [
+          "resource"
+        ],
+        "properties": {
+          "fields": {
+            "description": "Fields holds the JSON values for the requested (or default) fields. Array-typed fields are returned as JSON arrays. Absent fields are omitted.",
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apimachinery.apis.common.v0alpha1.Unstructured"
+          },
+          "resource": {
+            "default": {},
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResourceRef"
+          },
+          "score": {
+            "description": "Score is present only when a text query was evaluated. A pointer so a real score of 0 is still distinguishable from \"no text query\" (absent).",
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResultsMetadata": {
+        "description": "ResultsMetadata carries the pagination token and the total hit count.",
+        "type": "object",
+        "required": [
+          "totalHits",
+          "totalHitsRelation"
+        ],
+        "properties": {
+          "continue": {
+            "type": "string"
+          },
+          "totalHits": {
+            "description": "TotalHits counts the resources matching the query. Always read it together with TotalHitsRelation, which says whether the count is exact.",
+            "type": "integer",
+            "format": "int64",
+            "default": 0
+          },
+          "totalHitsRelation": {
+            "description": "TotalHitsRelation is \"eq\" when TotalHits is exact and \"lte\" when it is an upper bound.",
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery": {
+        "description": "SearchQuery is the request body for POST .../{resource}/search.",
+        "type": "object",
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "continue": {
+            "description": "Continue is an opaque pagination token from a previous page.",
+            "type": "string"
+          },
+          "facetLimit": {
+            "description": "FacetLimit caps the number of terms returned per facet. It applies to every entry in Facets. Zero uses the server default; values above the server cap are clamped.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "facets": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "labelSelector": {
+            "description": "LabelSelector filters on metadata.labels, ANDed with Where.",
+            "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+          },
+          "limit": {
+            "description": "Limit is the page size. Zero uses the default; values above the maximum are clamped.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "sort": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SortField"
+            }
+          },
+          "where": {
+            "description": "Where is the search predicate tree. Omitting it matches all resources of the kind (subject to labelSelector and per-item authz).",
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode"
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchResults": {
+        "description": "SearchResults is the response body for POST .../{resource}/search.",
+        "type": "object",
+        "required": [
+          "metadata",
+          "items"
+        ],
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "facets": {
+            "description": "Facets holds term counts per requested facet field. Counts are computed over a bounded sample window, so they are best-effort/approximate.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "default": {},
+                "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.FacetTerm"
+              }
+            }
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResultItem"
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "metadata": {
+            "default": {},
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResultsMetadata"
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.SortField": {
+        "description": "SortField names a field to sort by and a direction (\"asc\" or \"desc\"). V1 allows sorting only on scalar string and numeric fields that declare the sort capability.",
+        "type": "object",
+        "required": [
+          "field"
+        ],
+        "properties": {
+          "direction": {
+            "type": "string"
+          },
+          "field": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.TextPredicate": {
+        "description": "TextPredicate is a free-text predicate against one or more text-capable fields. When Fields is empty it defaults to the kind's searchTextFields (currently [\"title\"]).",
+        "type": "object",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "boost": {
+            "description": "Boost is a future per-leaf score multiplier. Setting it is rejected in v1.",
+            "type": "number",
+            "format": "double"
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode": {
+        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+        "type": "object",
+        "properties": {
+          "and": {
+            "description": "Combinators.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode"
+            }
+          },
+          "exists": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.ExistsPredicate"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.FilterPredicate"
+          },
+          "not": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode"
+          },
+          "or": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode"
+            }
+          },
+          "range": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.RangePredicate"
+          },
+          "text": {
+            "description": "Leaves.",
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.TextPredicate"
+          }
+        }
+      },
       "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource": {
         "description": "APIResource specifies the name of a resource and whether it is namespaced.",
         "type": "object",
@@ -3165,6 +3546,59 @@
       "io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1": {
         "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:\u003cname\u003e', where \u003cname\u003e is the name of a field in a struct, or key in a map 'v:\u003cvalue\u003e', where \u003cvalue\u003e is the exact json formatted value of a list item 'i:\u003cindex\u003e', where \u003cindex\u003e is position of a item in a list 'k:\u003ckeys\u003e', where \u003ckeys\u003e is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
         "type": "object"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+        "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+        "type": "object",
+        "properties": {
+          "matchExpressions": {
+            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement"
+            },
+            "x-kubernetes-list-type": "atomic"
+          },
+          "matchLabels": {
+            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        },
+        "x-kubernetes-map-type": "atomic"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement": {
+        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+        "type": "object",
+        "required": [
+          "key",
+          "operator"
+        ],
+        "properties": {
+          "key": {
+            "description": "key is the label key that the selector applies to.",
+            "type": "string",
+            "default": ""
+          },
+          "operator": {
+            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+            "type": "string",
+            "default": ""
+          },
+          "values": {
+            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            },
+            "x-kubernetes-list-type": "atomic"
+          }
+        }
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta": {
         "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",

--- a/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v1beta1.json
+++ b/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v1beta1.json
@@ -258,6 +258,50 @@
         }
       ]
     },
+    "/apis/dashboard.grafana.app/v1beta1/namespaces/{namespace}/dashboards/search": {
+      "post": {
+        "tags": [
+          "Search"
+        ],
+        "description": "Search Dashboard resources in a namespace.",
+        "operationId": "listDashboardSearchV1beta1",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "workspace",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "default"
+          }
+        ],
+        "requestBody": {
+          "description": "A SearchQuery describing what to match, sort and return.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A SearchResults envelope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchResults"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/apis/dashboard.grafana.app/v1beta1/namespaces/{namespace}/dashboards/{name}": {
       "get": {
         "tags": [
@@ -959,6 +1003,343 @@
         "additionalProperties": true,
         "x-kubernetes-preserve-unknown-fields": true
       },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.ExistsPredicate": {
+        "description": "ExistsPredicate is a future field-existence predicate. Modelled for schema stability; always rejected in v1.",
+        "type": "object",
+        "required": [
+          "field"
+        ],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.FacetTerm": {
+        "description": "FacetTerm is a single facet term and its count.",
+        "type": "object",
+        "required": [
+          "value",
+          "count"
+        ],
+        "properties": {
+          "count": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.FilterPredicate": {
+        "description": "FilterPredicate is an exact / set-based predicate against a single field. Values are strings whatever the field's declared type, so a boolean field takes \"true\" or \"false\" and a numeric field takes the number written out.\n\nNumbers are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a filter can both match a neighbour and miss the value asked for.",
+        "type": "object",
+        "required": [
+          "field",
+          "operator",
+          "values"
+        ],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          },
+          "operator": {
+            "description": "Operator is \"In\" or \"NotIn\" in v1.",
+            "type": "string",
+            "default": ""
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.RangePredicate": {
+        "description": "RangePredicate compares a numeric field against one or two bounds. At least one bound is required, gt cannot be combined with gte, and lt cannot be combined with lte. Boolean and string fields are rejected: only numbers have the order a range asks about. On an integer field a bound must be whole.\n\nBounds are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a bound can both admit a neighbour and exclude the value asked for.",
+        "type": "object",
+        "required": [
+          "field"
+        ],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          },
+          "gt": {
+            "type": "number",
+            "format": "double"
+          },
+          "gte": {
+            "type": "number",
+            "format": "double"
+          },
+          "lt": {
+            "type": "number",
+            "format": "double"
+          },
+          "lte": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResourceRef": {
+        "description": "ResourceRef is the full identity of a returned item. Namespace is implicit from the URL and omitted.",
+        "type": "object",
+        "required": [
+          "group",
+          "resource",
+          "kind",
+          "name"
+        ],
+        "properties": {
+          "group": {
+            "type": "string",
+            "default": ""
+          },
+          "kind": {
+            "type": "string",
+            "default": ""
+          },
+          "name": {
+            "type": "string",
+            "default": ""
+          },
+          "resource": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResultItem": {
+        "description": "ResultItem is one search or trash hit. The item shape is identical on both endpoints; only which fields the Fields map can carry differs.",
+        "type": "object",
+        "required": [
+          "resource"
+        ],
+        "properties": {
+          "fields": {
+            "description": "Fields holds the JSON values for the requested (or default) fields. Array-typed fields are returned as JSON arrays. Absent fields are omitted.",
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apimachinery.apis.common.v0alpha1.Unstructured"
+          },
+          "resource": {
+            "default": {},
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResourceRef"
+          },
+          "score": {
+            "description": "Score is present only when a text query was evaluated. A pointer so a real score of 0 is still distinguishable from \"no text query\" (absent).",
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResultsMetadata": {
+        "description": "ResultsMetadata carries the pagination token and the total hit count.",
+        "type": "object",
+        "required": [
+          "totalHits",
+          "totalHitsRelation"
+        ],
+        "properties": {
+          "continue": {
+            "type": "string"
+          },
+          "totalHits": {
+            "description": "TotalHits counts the resources matching the query. Always read it together with TotalHitsRelation, which says whether the count is exact.",
+            "type": "integer",
+            "format": "int64",
+            "default": 0
+          },
+          "totalHitsRelation": {
+            "description": "TotalHitsRelation is \"eq\" when TotalHits is exact and \"lte\" when it is an upper bound.",
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery": {
+        "description": "SearchQuery is the request body for POST .../{resource}/search.",
+        "type": "object",
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "continue": {
+            "description": "Continue is an opaque pagination token from a previous page.",
+            "type": "string"
+          },
+          "facetLimit": {
+            "description": "FacetLimit caps the number of terms returned per facet. It applies to every entry in Facets. Zero uses the server default; values above the server cap are clamped.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "facets": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "labelSelector": {
+            "description": "LabelSelector filters on metadata.labels, ANDed with Where.",
+            "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+          },
+          "limit": {
+            "description": "Limit is the page size. Zero uses the default; values above the maximum are clamped.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "sort": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SortField"
+            }
+          },
+          "where": {
+            "description": "Where is the search predicate tree. Omitting it matches all resources of the kind (subject to labelSelector and per-item authz).",
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode"
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchResults": {
+        "description": "SearchResults is the response body for POST .../{resource}/search.",
+        "type": "object",
+        "required": [
+          "metadata",
+          "items"
+        ],
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "facets": {
+            "description": "Facets holds term counts per requested facet field. Counts are computed over a bounded sample window, so they are best-effort/approximate.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "default": {},
+                "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.FacetTerm"
+              }
+            }
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResultItem"
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "metadata": {
+            "default": {},
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResultsMetadata"
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.SortField": {
+        "description": "SortField names a field to sort by and a direction (\"asc\" or \"desc\"). V1 allows sorting only on scalar string and numeric fields that declare the sort capability.",
+        "type": "object",
+        "required": [
+          "field"
+        ],
+        "properties": {
+          "direction": {
+            "type": "string"
+          },
+          "field": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.TextPredicate": {
+        "description": "TextPredicate is a free-text predicate against one or more text-capable fields. When Fields is empty it defaults to the kind's searchTextFields (currently [\"title\"]).",
+        "type": "object",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "boost": {
+            "description": "Boost is a future per-leaf score multiplier. Setting it is rejected in v1.",
+            "type": "number",
+            "format": "double"
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode": {
+        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+        "type": "object",
+        "properties": {
+          "and": {
+            "description": "Combinators.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode"
+            }
+          },
+          "exists": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.ExistsPredicate"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.FilterPredicate"
+          },
+          "not": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode"
+          },
+          "or": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode"
+            }
+          },
+          "range": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.RangePredicate"
+          },
+          "text": {
+            "description": "Leaves.",
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.TextPredicate"
+          }
+        }
+      },
       "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource": {
         "description": "APIResource specifies the name of a resource and whether it is namespaced.",
         "type": "object",
@@ -1117,6 +1498,59 @@
       "io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1": {
         "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:\u003cname\u003e', where \u003cname\u003e is the name of a field in a struct, or key in a map 'v:\u003cvalue\u003e', where \u003cvalue\u003e is the exact json formatted value of a list item 'i:\u003cindex\u003e', where \u003cindex\u003e is position of a item in a list 'k:\u003ckeys\u003e', where \u003ckeys\u003e is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
         "type": "object"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+        "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+        "type": "object",
+        "properties": {
+          "matchExpressions": {
+            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement"
+            },
+            "x-kubernetes-list-type": "atomic"
+          },
+          "matchLabels": {
+            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        },
+        "x-kubernetes-map-type": "atomic"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement": {
+        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+        "type": "object",
+        "required": [
+          "key",
+          "operator"
+        ],
+        "properties": {
+          "key": {
+            "description": "key is the label key that the selector applies to.",
+            "type": "string",
+            "default": ""
+          },
+          "operator": {
+            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+            "type": "string",
+            "default": ""
+          },
+          "values": {
+            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            },
+            "x-kubernetes-list-type": "atomic"
+          }
+        }
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta": {
         "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",

--- a/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v2.json
+++ b/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v2.json
@@ -258,6 +258,50 @@
         }
       ]
     },
+    "/apis/dashboard.grafana.app/v2/namespaces/{namespace}/dashboards/search": {
+      "post": {
+        "tags": [
+          "Search"
+        ],
+        "description": "Search Dashboard resources in a namespace.",
+        "operationId": "listDashboardSearchV2",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "workspace",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "default"
+          }
+        ],
+        "requestBody": {
+          "description": "A SearchQuery describing what to match, sort and return.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A SearchResults envelope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchResults"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/apis/dashboard.grafana.app/v2/namespaces/{namespace}/dashboards/{name}": {
       "get": {
         "tags": [
@@ -4293,6 +4337,348 @@
           }
         ]
       },
+      "com.github.grafana.grafana.pkg.apimachinery.apis.common.v0alpha1.Unstructured": {
+        "type": "object",
+        "additionalProperties": true,
+        "x-kubernetes-preserve-unknown-fields": true
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.ExistsPredicate": {
+        "description": "ExistsPredicate is a future field-existence predicate. Modelled for schema stability; always rejected in v1.",
+        "type": "object",
+        "required": [
+          "field"
+        ],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.FacetTerm": {
+        "description": "FacetTerm is a single facet term and its count.",
+        "type": "object",
+        "required": [
+          "value",
+          "count"
+        ],
+        "properties": {
+          "count": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.FilterPredicate": {
+        "description": "FilterPredicate is an exact / set-based predicate against a single field. Values are strings whatever the field's declared type, so a boolean field takes \"true\" or \"false\" and a numeric field takes the number written out.\n\nNumbers are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a filter can both match a neighbour and miss the value asked for.",
+        "type": "object",
+        "required": [
+          "field",
+          "operator",
+          "values"
+        ],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          },
+          "operator": {
+            "description": "Operator is \"In\" or \"NotIn\" in v1.",
+            "type": "string",
+            "default": ""
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.RangePredicate": {
+        "description": "RangePredicate compares a numeric field against one or two bounds. At least one bound is required, gt cannot be combined with gte, and lt cannot be combined with lte. Boolean and string fields are rejected: only numbers have the order a range asks about. On an integer field a bound must be whole.\n\nBounds are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a bound can both admit a neighbour and exclude the value asked for.",
+        "type": "object",
+        "required": [
+          "field"
+        ],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          },
+          "gt": {
+            "type": "number",
+            "format": "double"
+          },
+          "gte": {
+            "type": "number",
+            "format": "double"
+          },
+          "lt": {
+            "type": "number",
+            "format": "double"
+          },
+          "lte": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResourceRef": {
+        "description": "ResourceRef is the full identity of a returned item. Namespace is implicit from the URL and omitted.",
+        "type": "object",
+        "required": [
+          "group",
+          "resource",
+          "kind",
+          "name"
+        ],
+        "properties": {
+          "group": {
+            "type": "string",
+            "default": ""
+          },
+          "kind": {
+            "type": "string",
+            "default": ""
+          },
+          "name": {
+            "type": "string",
+            "default": ""
+          },
+          "resource": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResultItem": {
+        "description": "ResultItem is one search or trash hit. The item shape is identical on both endpoints; only which fields the Fields map can carry differs.",
+        "type": "object",
+        "required": [
+          "resource"
+        ],
+        "properties": {
+          "fields": {
+            "description": "Fields holds the JSON values for the requested (or default) fields. Array-typed fields are returned as JSON arrays. Absent fields are omitted.",
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apimachinery.apis.common.v0alpha1.Unstructured"
+          },
+          "resource": {
+            "default": {},
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResourceRef"
+          },
+          "score": {
+            "description": "Score is present only when a text query was evaluated. A pointer so a real score of 0 is still distinguishable from \"no text query\" (absent).",
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResultsMetadata": {
+        "description": "ResultsMetadata carries the pagination token and the total hit count.",
+        "type": "object",
+        "required": [
+          "totalHits",
+          "totalHitsRelation"
+        ],
+        "properties": {
+          "continue": {
+            "type": "string"
+          },
+          "totalHits": {
+            "description": "TotalHits counts the resources matching the query. Always read it together with TotalHitsRelation, which says whether the count is exact.",
+            "type": "integer",
+            "format": "int64",
+            "default": 0
+          },
+          "totalHitsRelation": {
+            "description": "TotalHitsRelation is \"eq\" when TotalHits is exact and \"lte\" when it is an upper bound.",
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery": {
+        "description": "SearchQuery is the request body for POST .../{resource}/search.",
+        "type": "object",
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "continue": {
+            "description": "Continue is an opaque pagination token from a previous page.",
+            "type": "string"
+          },
+          "facetLimit": {
+            "description": "FacetLimit caps the number of terms returned per facet. It applies to every entry in Facets. Zero uses the server default; values above the server cap are clamped.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "facets": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "labelSelector": {
+            "description": "LabelSelector filters on metadata.labels, ANDed with Where.",
+            "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+          },
+          "limit": {
+            "description": "Limit is the page size. Zero uses the default; values above the maximum are clamped.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "sort": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SortField"
+            }
+          },
+          "where": {
+            "description": "Where is the search predicate tree. Omitting it matches all resources of the kind (subject to labelSelector and per-item authz).",
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode"
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchResults": {
+        "description": "SearchResults is the response body for POST .../{resource}/search.",
+        "type": "object",
+        "required": [
+          "metadata",
+          "items"
+        ],
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "facets": {
+            "description": "Facets holds term counts per requested facet field. Counts are computed over a bounded sample window, so they are best-effort/approximate.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "default": {},
+                "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.FacetTerm"
+              }
+            }
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResultItem"
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "metadata": {
+            "default": {},
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResultsMetadata"
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.SortField": {
+        "description": "SortField names a field to sort by and a direction (\"asc\" or \"desc\"). V1 allows sorting only on scalar string and numeric fields that declare the sort capability.",
+        "type": "object",
+        "required": [
+          "field"
+        ],
+        "properties": {
+          "direction": {
+            "type": "string"
+          },
+          "field": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.TextPredicate": {
+        "description": "TextPredicate is a free-text predicate against one or more text-capable fields. When Fields is empty it defaults to the kind's searchTextFields (currently [\"title\"]).",
+        "type": "object",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "boost": {
+            "description": "Boost is a future per-leaf score multiplier. Setting it is rejected in v1.",
+            "type": "number",
+            "format": "double"
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode": {
+        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+        "type": "object",
+        "properties": {
+          "and": {
+            "description": "Combinators.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode"
+            }
+          },
+          "exists": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.ExistsPredicate"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.FilterPredicate"
+          },
+          "not": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode"
+          },
+          "or": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode"
+            }
+          },
+          "range": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.RangePredicate"
+          },
+          "text": {
+            "description": "Leaves.",
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.TextPredicate"
+          }
+        }
+      },
       "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource": {
         "description": "APIResource specifies the name of a resource and whether it is namespaced.",
         "type": "object",
@@ -4451,6 +4837,59 @@
       "io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1": {
         "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:\u003cname\u003e', where \u003cname\u003e is the name of a field in a struct, or key in a map 'v:\u003cvalue\u003e', where \u003cvalue\u003e is the exact json formatted value of a list item 'i:\u003cindex\u003e', where \u003cindex\u003e is position of a item in a list 'k:\u003ckeys\u003e', where \u003ckeys\u003e is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
         "type": "object"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+        "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+        "type": "object",
+        "properties": {
+          "matchExpressions": {
+            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement"
+            },
+            "x-kubernetes-list-type": "atomic"
+          },
+          "matchLabels": {
+            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        },
+        "x-kubernetes-map-type": "atomic"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement": {
+        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+        "type": "object",
+        "required": [
+          "key",
+          "operator"
+        ],
+        "properties": {
+          "key": {
+            "description": "key is the label key that the selector applies to.",
+            "type": "string",
+            "default": ""
+          },
+          "operator": {
+            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+            "type": "string",
+            "default": ""
+          },
+          "values": {
+            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            },
+            "x-kubernetes-list-type": "atomic"
+          }
+        }
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta": {
         "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",

--- a/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v2alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v2alpha1.json
@@ -258,6 +258,50 @@
         }
       ]
     },
+    "/apis/dashboard.grafana.app/v2alpha1/namespaces/{namespace}/dashboards/search": {
+      "post": {
+        "tags": [
+          "Search"
+        ],
+        "description": "Search Dashboard resources in a namespace.",
+        "operationId": "listDashboardSearchV2alpha1",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "workspace",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "default"
+          }
+        ],
+        "requestBody": {
+          "description": "A SearchQuery describing what to match, sort and return.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A SearchResults envelope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchResults"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/apis/dashboard.grafana.app/v2alpha1/namespaces/{namespace}/dashboards/{name}": {
       "get": {
         "tags": [
@@ -4110,6 +4154,348 @@
           }
         ]
       },
+      "com.github.grafana.grafana.pkg.apimachinery.apis.common.v0alpha1.Unstructured": {
+        "type": "object",
+        "additionalProperties": true,
+        "x-kubernetes-preserve-unknown-fields": true
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.ExistsPredicate": {
+        "description": "ExistsPredicate is a future field-existence predicate. Modelled for schema stability; always rejected in v1.",
+        "type": "object",
+        "required": [
+          "field"
+        ],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.FacetTerm": {
+        "description": "FacetTerm is a single facet term and its count.",
+        "type": "object",
+        "required": [
+          "value",
+          "count"
+        ],
+        "properties": {
+          "count": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.FilterPredicate": {
+        "description": "FilterPredicate is an exact / set-based predicate against a single field. Values are strings whatever the field's declared type, so a boolean field takes \"true\" or \"false\" and a numeric field takes the number written out.\n\nNumbers are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a filter can both match a neighbour and miss the value asked for.",
+        "type": "object",
+        "required": [
+          "field",
+          "operator",
+          "values"
+        ],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          },
+          "operator": {
+            "description": "Operator is \"In\" or \"NotIn\" in v1.",
+            "type": "string",
+            "default": ""
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.RangePredicate": {
+        "description": "RangePredicate compares a numeric field against one or two bounds. At least one bound is required, gt cannot be combined with gte, and lt cannot be combined with lte. Boolean and string fields are rejected: only numbers have the order a range asks about. On an integer field a bound must be whole.\n\nBounds are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a bound can both admit a neighbour and exclude the value asked for.",
+        "type": "object",
+        "required": [
+          "field"
+        ],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          },
+          "gt": {
+            "type": "number",
+            "format": "double"
+          },
+          "gte": {
+            "type": "number",
+            "format": "double"
+          },
+          "lt": {
+            "type": "number",
+            "format": "double"
+          },
+          "lte": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResourceRef": {
+        "description": "ResourceRef is the full identity of a returned item. Namespace is implicit from the URL and omitted.",
+        "type": "object",
+        "required": [
+          "group",
+          "resource",
+          "kind",
+          "name"
+        ],
+        "properties": {
+          "group": {
+            "type": "string",
+            "default": ""
+          },
+          "kind": {
+            "type": "string",
+            "default": ""
+          },
+          "name": {
+            "type": "string",
+            "default": ""
+          },
+          "resource": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResultItem": {
+        "description": "ResultItem is one search or trash hit. The item shape is identical on both endpoints; only which fields the Fields map can carry differs.",
+        "type": "object",
+        "required": [
+          "resource"
+        ],
+        "properties": {
+          "fields": {
+            "description": "Fields holds the JSON values for the requested (or default) fields. Array-typed fields are returned as JSON arrays. Absent fields are omitted.",
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apimachinery.apis.common.v0alpha1.Unstructured"
+          },
+          "resource": {
+            "default": {},
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResourceRef"
+          },
+          "score": {
+            "description": "Score is present only when a text query was evaluated. A pointer so a real score of 0 is still distinguishable from \"no text query\" (absent).",
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResultsMetadata": {
+        "description": "ResultsMetadata carries the pagination token and the total hit count.",
+        "type": "object",
+        "required": [
+          "totalHits",
+          "totalHitsRelation"
+        ],
+        "properties": {
+          "continue": {
+            "type": "string"
+          },
+          "totalHits": {
+            "description": "TotalHits counts the resources matching the query. Always read it together with TotalHitsRelation, which says whether the count is exact.",
+            "type": "integer",
+            "format": "int64",
+            "default": 0
+          },
+          "totalHitsRelation": {
+            "description": "TotalHitsRelation is \"eq\" when TotalHits is exact and \"lte\" when it is an upper bound.",
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery": {
+        "description": "SearchQuery is the request body for POST .../{resource}/search.",
+        "type": "object",
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "continue": {
+            "description": "Continue is an opaque pagination token from a previous page.",
+            "type": "string"
+          },
+          "facetLimit": {
+            "description": "FacetLimit caps the number of terms returned per facet. It applies to every entry in Facets. Zero uses the server default; values above the server cap are clamped.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "facets": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "labelSelector": {
+            "description": "LabelSelector filters on metadata.labels, ANDed with Where.",
+            "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+          },
+          "limit": {
+            "description": "Limit is the page size. Zero uses the default; values above the maximum are clamped.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "sort": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SortField"
+            }
+          },
+          "where": {
+            "description": "Where is the search predicate tree. Omitting it matches all resources of the kind (subject to labelSelector and per-item authz).",
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode"
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchResults": {
+        "description": "SearchResults is the response body for POST .../{resource}/search.",
+        "type": "object",
+        "required": [
+          "metadata",
+          "items"
+        ],
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "facets": {
+            "description": "Facets holds term counts per requested facet field. Counts are computed over a bounded sample window, so they are best-effort/approximate.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "default": {},
+                "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.FacetTerm"
+              }
+            }
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResultItem"
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "metadata": {
+            "default": {},
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResultsMetadata"
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.SortField": {
+        "description": "SortField names a field to sort by and a direction (\"asc\" or \"desc\"). V1 allows sorting only on scalar string and numeric fields that declare the sort capability.",
+        "type": "object",
+        "required": [
+          "field"
+        ],
+        "properties": {
+          "direction": {
+            "type": "string"
+          },
+          "field": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.TextPredicate": {
+        "description": "TextPredicate is a free-text predicate against one or more text-capable fields. When Fields is empty it defaults to the kind's searchTextFields (currently [\"title\"]).",
+        "type": "object",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "boost": {
+            "description": "Boost is a future per-leaf score multiplier. Setting it is rejected in v1.",
+            "type": "number",
+            "format": "double"
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode": {
+        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+        "type": "object",
+        "properties": {
+          "and": {
+            "description": "Combinators.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode"
+            }
+          },
+          "exists": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.ExistsPredicate"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.FilterPredicate"
+          },
+          "not": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode"
+          },
+          "or": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode"
+            }
+          },
+          "range": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.RangePredicate"
+          },
+          "text": {
+            "description": "Leaves.",
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.TextPredicate"
+          }
+        }
+      },
       "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource": {
         "description": "APIResource specifies the name of a resource and whether it is namespaced.",
         "type": "object",
@@ -4268,6 +4654,59 @@
       "io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1": {
         "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:\u003cname\u003e', where \u003cname\u003e is the name of a field in a struct, or key in a map 'v:\u003cvalue\u003e', where \u003cvalue\u003e is the exact json formatted value of a list item 'i:\u003cindex\u003e', where \u003cindex\u003e is position of a item in a list 'k:\u003ckeys\u003e', where \u003ckeys\u003e is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
         "type": "object"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+        "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+        "type": "object",
+        "properties": {
+          "matchExpressions": {
+            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement"
+            },
+            "x-kubernetes-list-type": "atomic"
+          },
+          "matchLabels": {
+            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        },
+        "x-kubernetes-map-type": "atomic"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement": {
+        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+        "type": "object",
+        "required": [
+          "key",
+          "operator"
+        ],
+        "properties": {
+          "key": {
+            "description": "key is the label key that the selector applies to.",
+            "type": "string",
+            "default": ""
+          },
+          "operator": {
+            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+            "type": "string",
+            "default": ""
+          },
+          "values": {
+            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            },
+            "x-kubernetes-list-type": "atomic"
+          }
+        }
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta": {
         "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",

--- a/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v2beta1.json
+++ b/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v2beta1.json
@@ -258,6 +258,50 @@
         }
       ]
     },
+    "/apis/dashboard.grafana.app/v2beta1/namespaces/{namespace}/dashboards/search": {
+      "post": {
+        "tags": [
+          "Search"
+        ],
+        "description": "Search Dashboard resources in a namespace.",
+        "operationId": "listDashboardSearchV2beta1",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "workspace",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "default"
+          }
+        ],
+        "requestBody": {
+          "description": "A SearchQuery describing what to match, sort and return.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A SearchResults envelope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchResults"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/apis/dashboard.grafana.app/v2beta1/namespaces/{namespace}/dashboards/{name}": {
       "get": {
         "tags": [
@@ -1043,6 +1087,50 @@
           }
         }
       ]
+    },
+    "/apis/dashboard.grafana.app/v2beta1/namespaces/{namespace}/notebooks/search": {
+      "post": {
+        "tags": [
+          "Search"
+        ],
+        "description": "Search Notebook resources in a namespace.",
+        "operationId": "listNotebookSearchV2beta1",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "workspace",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "default"
+          }
+        ],
+        "requestBody": {
+          "description": "A SearchQuery describing what to match, sort and return.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A SearchResults envelope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchResults"
+                }
+              }
+            }
+          }
+        }
+      }
     },
     "/apis/dashboard.grafana.app/v2beta1/namespaces/{namespace}/notebooks/{name}": {
       "get": {
@@ -7430,6 +7518,348 @@
           }
         }
       },
+      "com.github.grafana.grafana.pkg.apimachinery.apis.common.v0alpha1.Unstructured": {
+        "type": "object",
+        "additionalProperties": true,
+        "x-kubernetes-preserve-unknown-fields": true
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.ExistsPredicate": {
+        "description": "ExistsPredicate is a future field-existence predicate. Modelled for schema stability; always rejected in v1.",
+        "type": "object",
+        "required": [
+          "field"
+        ],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.FacetTerm": {
+        "description": "FacetTerm is a single facet term and its count.",
+        "type": "object",
+        "required": [
+          "value",
+          "count"
+        ],
+        "properties": {
+          "count": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.FilterPredicate": {
+        "description": "FilterPredicate is an exact / set-based predicate against a single field. Values are strings whatever the field's declared type, so a boolean field takes \"true\" or \"false\" and a numeric field takes the number written out.\n\nNumbers are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a filter can both match a neighbour and miss the value asked for.",
+        "type": "object",
+        "required": [
+          "field",
+          "operator",
+          "values"
+        ],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          },
+          "operator": {
+            "description": "Operator is \"In\" or \"NotIn\" in v1.",
+            "type": "string",
+            "default": ""
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.RangePredicate": {
+        "description": "RangePredicate compares a numeric field against one or two bounds. At least one bound is required, gt cannot be combined with gte, and lt cannot be combined with lte. Boolean and string fields are rejected: only numbers have the order a range asks about. On an integer field a bound must be whole.\n\nBounds are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a bound can both admit a neighbour and exclude the value asked for.",
+        "type": "object",
+        "required": [
+          "field"
+        ],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          },
+          "gt": {
+            "type": "number",
+            "format": "double"
+          },
+          "gte": {
+            "type": "number",
+            "format": "double"
+          },
+          "lt": {
+            "type": "number",
+            "format": "double"
+          },
+          "lte": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResourceRef": {
+        "description": "ResourceRef is the full identity of a returned item. Namespace is implicit from the URL and omitted.",
+        "type": "object",
+        "required": [
+          "group",
+          "resource",
+          "kind",
+          "name"
+        ],
+        "properties": {
+          "group": {
+            "type": "string",
+            "default": ""
+          },
+          "kind": {
+            "type": "string",
+            "default": ""
+          },
+          "name": {
+            "type": "string",
+            "default": ""
+          },
+          "resource": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResultItem": {
+        "description": "ResultItem is one search or trash hit. The item shape is identical on both endpoints; only which fields the Fields map can carry differs.",
+        "type": "object",
+        "required": [
+          "resource"
+        ],
+        "properties": {
+          "fields": {
+            "description": "Fields holds the JSON values for the requested (or default) fields. Array-typed fields are returned as JSON arrays. Absent fields are omitted.",
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apimachinery.apis.common.v0alpha1.Unstructured"
+          },
+          "resource": {
+            "default": {},
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResourceRef"
+          },
+          "score": {
+            "description": "Score is present only when a text query was evaluated. A pointer so a real score of 0 is still distinguishable from \"no text query\" (absent).",
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResultsMetadata": {
+        "description": "ResultsMetadata carries the pagination token and the total hit count.",
+        "type": "object",
+        "required": [
+          "totalHits",
+          "totalHitsRelation"
+        ],
+        "properties": {
+          "continue": {
+            "type": "string"
+          },
+          "totalHits": {
+            "description": "TotalHits counts the resources matching the query. Always read it together with TotalHitsRelation, which says whether the count is exact.",
+            "type": "integer",
+            "format": "int64",
+            "default": 0
+          },
+          "totalHitsRelation": {
+            "description": "TotalHitsRelation is \"eq\" when TotalHits is exact and \"lte\" when it is an upper bound.",
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery": {
+        "description": "SearchQuery is the request body for POST .../{resource}/search.",
+        "type": "object",
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "continue": {
+            "description": "Continue is an opaque pagination token from a previous page.",
+            "type": "string"
+          },
+          "facetLimit": {
+            "description": "FacetLimit caps the number of terms returned per facet. It applies to every entry in Facets. Zero uses the server default; values above the server cap are clamped.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "facets": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "labelSelector": {
+            "description": "LabelSelector filters on metadata.labels, ANDed with Where.",
+            "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+          },
+          "limit": {
+            "description": "Limit is the page size. Zero uses the default; values above the maximum are clamped.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "sort": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SortField"
+            }
+          },
+          "where": {
+            "description": "Where is the search predicate tree. Omitting it matches all resources of the kind (subject to labelSelector and per-item authz).",
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode"
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchResults": {
+        "description": "SearchResults is the response body for POST .../{resource}/search.",
+        "type": "object",
+        "required": [
+          "metadata",
+          "items"
+        ],
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "facets": {
+            "description": "Facets holds term counts per requested facet field. Counts are computed over a bounded sample window, so they are best-effort/approximate.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "default": {},
+                "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.FacetTerm"
+              }
+            }
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResultItem"
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "metadata": {
+            "default": {},
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResultsMetadata"
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.SortField": {
+        "description": "SortField names a field to sort by and a direction (\"asc\" or \"desc\"). V1 allows sorting only on scalar string and numeric fields that declare the sort capability.",
+        "type": "object",
+        "required": [
+          "field"
+        ],
+        "properties": {
+          "direction": {
+            "type": "string"
+          },
+          "field": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.TextPredicate": {
+        "description": "TextPredicate is a free-text predicate against one or more text-capable fields. When Fields is empty it defaults to the kind's searchTextFields (currently [\"title\"]).",
+        "type": "object",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "boost": {
+            "description": "Boost is a future per-leaf score multiplier. Setting it is rejected in v1.",
+            "type": "number",
+            "format": "double"
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode": {
+        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+        "type": "object",
+        "properties": {
+          "and": {
+            "description": "Combinators.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode"
+            }
+          },
+          "exists": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.ExistsPredicate"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.FilterPredicate"
+          },
+          "not": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode"
+          },
+          "or": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode"
+            }
+          },
+          "range": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.RangePredicate"
+          },
+          "text": {
+            "description": "Leaves.",
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.TextPredicate"
+          }
+        }
+      },
       "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource": {
         "description": "APIResource specifies the name of a resource and whether it is namespaced.",
         "type": "object",
@@ -7588,6 +8018,59 @@
       "io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1": {
         "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:\u003cname\u003e', where \u003cname\u003e is the name of a field in a struct, or key in a map 'v:\u003cvalue\u003e', where \u003cvalue\u003e is the exact json formatted value of a list item 'i:\u003cindex\u003e', where \u003cindex\u003e is position of a item in a list 'k:\u003ckeys\u003e', where \u003ckeys\u003e is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
         "type": "object"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+        "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+        "type": "object",
+        "properties": {
+          "matchExpressions": {
+            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement"
+            },
+            "x-kubernetes-list-type": "atomic"
+          },
+          "matchLabels": {
+            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        },
+        "x-kubernetes-map-type": "atomic"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement": {
+        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+        "type": "object",
+        "required": [
+          "key",
+          "operator"
+        ],
+        "properties": {
+          "key": {
+            "description": "key is the label key that the selector applies to.",
+            "type": "string",
+            "default": ""
+          },
+          "operator": {
+            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+            "type": "string",
+            "default": ""
+          },
+          "values": {
+            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            },
+            "x-kubernetes-list-type": "atomic"
+          }
+        }
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta": {
         "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",

--- a/pkg/tests/apis/openapi_snapshots/folder.grafana.app-v1.json
+++ b/pkg/tests/apis/openapi_snapshots/folder.grafana.app-v1.json
@@ -258,6 +258,50 @@
         }
       ]
     },
+    "/apis/folder.grafana.app/v1/namespaces/{namespace}/folders/search": {
+      "post": {
+        "tags": [
+          "Search"
+        ],
+        "description": "Search Folder resources in a namespace.",
+        "operationId": "listFolderSearchV1",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "workspace",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "default"
+          }
+        ],
+        "requestBody": {
+          "description": "A SearchQuery describing what to match, sort and return.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A SearchResults envelope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchResults"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/apis/folder.grafana.app/v1/namespaces/{namespace}/folders/{name}": {
       "get": {
         "tags": [
@@ -1120,6 +1164,348 @@
           }
         }
       },
+      "com.github.grafana.grafana.pkg.apimachinery.apis.common.v0alpha1.Unstructured": {
+        "type": "object",
+        "additionalProperties": true,
+        "x-kubernetes-preserve-unknown-fields": true
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.ExistsPredicate": {
+        "description": "ExistsPredicate is a future field-existence predicate. Modelled for schema stability; always rejected in v1.",
+        "type": "object",
+        "required": [
+          "field"
+        ],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.FacetTerm": {
+        "description": "FacetTerm is a single facet term and its count.",
+        "type": "object",
+        "required": [
+          "value",
+          "count"
+        ],
+        "properties": {
+          "count": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.FilterPredicate": {
+        "description": "FilterPredicate is an exact / set-based predicate against a single field. Values are strings whatever the field's declared type, so a boolean field takes \"true\" or \"false\" and a numeric field takes the number written out.\n\nNumbers are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a filter can both match a neighbour and miss the value asked for.",
+        "type": "object",
+        "required": [
+          "field",
+          "operator",
+          "values"
+        ],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          },
+          "operator": {
+            "description": "Operator is \"In\" or \"NotIn\" in v1.",
+            "type": "string",
+            "default": ""
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.RangePredicate": {
+        "description": "RangePredicate compares a numeric field against one or two bounds. At least one bound is required, gt cannot be combined with gte, and lt cannot be combined with lte. Boolean and string fields are rejected: only numbers have the order a range asks about. On an integer field a bound must be whole.\n\nBounds are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a bound can both admit a neighbour and exclude the value asked for.",
+        "type": "object",
+        "required": [
+          "field"
+        ],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          },
+          "gt": {
+            "type": "number",
+            "format": "double"
+          },
+          "gte": {
+            "type": "number",
+            "format": "double"
+          },
+          "lt": {
+            "type": "number",
+            "format": "double"
+          },
+          "lte": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResourceRef": {
+        "description": "ResourceRef is the full identity of a returned item. Namespace is implicit from the URL and omitted.",
+        "type": "object",
+        "required": [
+          "group",
+          "resource",
+          "kind",
+          "name"
+        ],
+        "properties": {
+          "group": {
+            "type": "string",
+            "default": ""
+          },
+          "kind": {
+            "type": "string",
+            "default": ""
+          },
+          "name": {
+            "type": "string",
+            "default": ""
+          },
+          "resource": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResultItem": {
+        "description": "ResultItem is one search or trash hit. The item shape is identical on both endpoints; only which fields the Fields map can carry differs.",
+        "type": "object",
+        "required": [
+          "resource"
+        ],
+        "properties": {
+          "fields": {
+            "description": "Fields holds the JSON values for the requested (or default) fields. Array-typed fields are returned as JSON arrays. Absent fields are omitted.",
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apimachinery.apis.common.v0alpha1.Unstructured"
+          },
+          "resource": {
+            "default": {},
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResourceRef"
+          },
+          "score": {
+            "description": "Score is present only when a text query was evaluated. A pointer so a real score of 0 is still distinguishable from \"no text query\" (absent).",
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResultsMetadata": {
+        "description": "ResultsMetadata carries the pagination token and the total hit count.",
+        "type": "object",
+        "required": [
+          "totalHits",
+          "totalHitsRelation"
+        ],
+        "properties": {
+          "continue": {
+            "type": "string"
+          },
+          "totalHits": {
+            "description": "TotalHits counts the resources matching the query. Always read it together with TotalHitsRelation, which says whether the count is exact.",
+            "type": "integer",
+            "format": "int64",
+            "default": 0
+          },
+          "totalHitsRelation": {
+            "description": "TotalHitsRelation is \"eq\" when TotalHits is exact and \"lte\" when it is an upper bound.",
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery": {
+        "description": "SearchQuery is the request body for POST .../{resource}/search.",
+        "type": "object",
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "continue": {
+            "description": "Continue is an opaque pagination token from a previous page.",
+            "type": "string"
+          },
+          "facetLimit": {
+            "description": "FacetLimit caps the number of terms returned per facet. It applies to every entry in Facets. Zero uses the server default; values above the server cap are clamped.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "facets": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "labelSelector": {
+            "description": "LabelSelector filters on metadata.labels, ANDed with Where.",
+            "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+          },
+          "limit": {
+            "description": "Limit is the page size. Zero uses the default; values above the maximum are clamped.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "sort": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SortField"
+            }
+          },
+          "where": {
+            "description": "Where is the search predicate tree. Omitting it matches all resources of the kind (subject to labelSelector and per-item authz).",
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode"
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchResults": {
+        "description": "SearchResults is the response body for POST .../{resource}/search.",
+        "type": "object",
+        "required": [
+          "metadata",
+          "items"
+        ],
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "facets": {
+            "description": "Facets holds term counts per requested facet field. Counts are computed over a bounded sample window, so they are best-effort/approximate.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "default": {},
+                "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.FacetTerm"
+              }
+            }
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResultItem"
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "metadata": {
+            "default": {},
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResultsMetadata"
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.SortField": {
+        "description": "SortField names a field to sort by and a direction (\"asc\" or \"desc\"). V1 allows sorting only on scalar string and numeric fields that declare the sort capability.",
+        "type": "object",
+        "required": [
+          "field"
+        ],
+        "properties": {
+          "direction": {
+            "type": "string"
+          },
+          "field": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.TextPredicate": {
+        "description": "TextPredicate is a free-text predicate against one or more text-capable fields. When Fields is empty it defaults to the kind's searchTextFields (currently [\"title\"]).",
+        "type": "object",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "boost": {
+            "description": "Boost is a future per-leaf score multiplier. Setting it is rejected in v1.",
+            "type": "number",
+            "format": "double"
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode": {
+        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+        "type": "object",
+        "properties": {
+          "and": {
+            "description": "Combinators.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode"
+            }
+          },
+          "exists": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.ExistsPredicate"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.FilterPredicate"
+          },
+          "not": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode"
+          },
+          "or": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode"
+            }
+          },
+          "range": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.RangePredicate"
+          },
+          "text": {
+            "description": "Leaves.",
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.TextPredicate"
+          }
+        }
+      },
       "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource": {
         "description": "APIResource specifies the name of a resource and whether it is namespaced.",
         "type": "object",
@@ -1278,6 +1664,59 @@
       "io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1": {
         "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:\u003cname\u003e', where \u003cname\u003e is the name of a field in a struct, or key in a map 'v:\u003cvalue\u003e', where \u003cvalue\u003e is the exact json formatted value of a list item 'i:\u003cindex\u003e', where \u003cindex\u003e is position of a item in a list 'k:\u003ckeys\u003e', where \u003ckeys\u003e is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
         "type": "object"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+        "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+        "type": "object",
+        "properties": {
+          "matchExpressions": {
+            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement"
+            },
+            "x-kubernetes-list-type": "atomic"
+          },
+          "matchLabels": {
+            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        },
+        "x-kubernetes-map-type": "atomic"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement": {
+        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+        "type": "object",
+        "required": [
+          "key",
+          "operator"
+        ],
+        "properties": {
+          "key": {
+            "description": "key is the label key that the selector applies to.",
+            "type": "string",
+            "default": ""
+          },
+          "operator": {
+            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+            "type": "string",
+            "default": ""
+          },
+          "values": {
+            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            },
+            "x-kubernetes-list-type": "atomic"
+          }
+        }
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta": {
         "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",

--- a/pkg/tests/apis/openapi_snapshots/folder.grafana.app-v1beta1.json
+++ b/pkg/tests/apis/openapi_snapshots/folder.grafana.app-v1beta1.json
@@ -258,6 +258,50 @@
         }
       ]
     },
+    "/apis/folder.grafana.app/v1beta1/namespaces/{namespace}/folders/search": {
+      "post": {
+        "tags": [
+          "Search"
+        ],
+        "description": "Search Folder resources in a namespace.",
+        "operationId": "listFolderSearchV1beta1",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "workspace",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "default"
+          }
+        ],
+        "requestBody": {
+          "description": "A SearchQuery describing what to match, sort and return.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A SearchResults envelope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchResults"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/apis/folder.grafana.app/v1beta1/namespaces/{namespace}/folders/{name}": {
       "get": {
         "tags": [
@@ -1120,6 +1164,348 @@
           }
         }
       },
+      "com.github.grafana.grafana.pkg.apimachinery.apis.common.v0alpha1.Unstructured": {
+        "type": "object",
+        "additionalProperties": true,
+        "x-kubernetes-preserve-unknown-fields": true
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.ExistsPredicate": {
+        "description": "ExistsPredicate is a future field-existence predicate. Modelled for schema stability; always rejected in v1.",
+        "type": "object",
+        "required": [
+          "field"
+        ],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.FacetTerm": {
+        "description": "FacetTerm is a single facet term and its count.",
+        "type": "object",
+        "required": [
+          "value",
+          "count"
+        ],
+        "properties": {
+          "count": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.FilterPredicate": {
+        "description": "FilterPredicate is an exact / set-based predicate against a single field. Values are strings whatever the field's declared type, so a boolean field takes \"true\" or \"false\" and a numeric field takes the number written out.\n\nNumbers are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a filter can both match a neighbour and miss the value asked for.",
+        "type": "object",
+        "required": [
+          "field",
+          "operator",
+          "values"
+        ],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          },
+          "operator": {
+            "description": "Operator is \"In\" or \"NotIn\" in v1.",
+            "type": "string",
+            "default": ""
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.RangePredicate": {
+        "description": "RangePredicate compares a numeric field against one or two bounds. At least one bound is required, gt cannot be combined with gte, and lt cannot be combined with lte. Boolean and string fields are rejected: only numbers have the order a range asks about. On an integer field a bound must be whole.\n\nBounds are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a bound can both admit a neighbour and exclude the value asked for.",
+        "type": "object",
+        "required": [
+          "field"
+        ],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          },
+          "gt": {
+            "type": "number",
+            "format": "double"
+          },
+          "gte": {
+            "type": "number",
+            "format": "double"
+          },
+          "lt": {
+            "type": "number",
+            "format": "double"
+          },
+          "lte": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResourceRef": {
+        "description": "ResourceRef is the full identity of a returned item. Namespace is implicit from the URL and omitted.",
+        "type": "object",
+        "required": [
+          "group",
+          "resource",
+          "kind",
+          "name"
+        ],
+        "properties": {
+          "group": {
+            "type": "string",
+            "default": ""
+          },
+          "kind": {
+            "type": "string",
+            "default": ""
+          },
+          "name": {
+            "type": "string",
+            "default": ""
+          },
+          "resource": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResultItem": {
+        "description": "ResultItem is one search or trash hit. The item shape is identical on both endpoints; only which fields the Fields map can carry differs.",
+        "type": "object",
+        "required": [
+          "resource"
+        ],
+        "properties": {
+          "fields": {
+            "description": "Fields holds the JSON values for the requested (or default) fields. Array-typed fields are returned as JSON arrays. Absent fields are omitted.",
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apimachinery.apis.common.v0alpha1.Unstructured"
+          },
+          "resource": {
+            "default": {},
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResourceRef"
+          },
+          "score": {
+            "description": "Score is present only when a text query was evaluated. A pointer so a real score of 0 is still distinguishable from \"no text query\" (absent).",
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResultsMetadata": {
+        "description": "ResultsMetadata carries the pagination token and the total hit count.",
+        "type": "object",
+        "required": [
+          "totalHits",
+          "totalHitsRelation"
+        ],
+        "properties": {
+          "continue": {
+            "type": "string"
+          },
+          "totalHits": {
+            "description": "TotalHits counts the resources matching the query. Always read it together with TotalHitsRelation, which says whether the count is exact.",
+            "type": "integer",
+            "format": "int64",
+            "default": 0
+          },
+          "totalHitsRelation": {
+            "description": "TotalHitsRelation is \"eq\" when TotalHits is exact and \"lte\" when it is an upper bound.",
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery": {
+        "description": "SearchQuery is the request body for POST .../{resource}/search.",
+        "type": "object",
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "continue": {
+            "description": "Continue is an opaque pagination token from a previous page.",
+            "type": "string"
+          },
+          "facetLimit": {
+            "description": "FacetLimit caps the number of terms returned per facet. It applies to every entry in Facets. Zero uses the server default; values above the server cap are clamped.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "facets": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "labelSelector": {
+            "description": "LabelSelector filters on metadata.labels, ANDed with Where.",
+            "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+          },
+          "limit": {
+            "description": "Limit is the page size. Zero uses the default; values above the maximum are clamped.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "sort": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SortField"
+            }
+          },
+          "where": {
+            "description": "Where is the search predicate tree. Omitting it matches all resources of the kind (subject to labelSelector and per-item authz).",
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode"
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchResults": {
+        "description": "SearchResults is the response body for POST .../{resource}/search.",
+        "type": "object",
+        "required": [
+          "metadata",
+          "items"
+        ],
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "facets": {
+            "description": "Facets holds term counts per requested facet field. Counts are computed over a bounded sample window, so they are best-effort/approximate.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "default": {},
+                "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.FacetTerm"
+              }
+            }
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResultItem"
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "metadata": {
+            "default": {},
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResultsMetadata"
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.SortField": {
+        "description": "SortField names a field to sort by and a direction (\"asc\" or \"desc\"). V1 allows sorting only on scalar string and numeric fields that declare the sort capability.",
+        "type": "object",
+        "required": [
+          "field"
+        ],
+        "properties": {
+          "direction": {
+            "type": "string"
+          },
+          "field": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.TextPredicate": {
+        "description": "TextPredicate is a free-text predicate against one or more text-capable fields. When Fields is empty it defaults to the kind's searchTextFields (currently [\"title\"]).",
+        "type": "object",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "boost": {
+            "description": "Boost is a future per-leaf score multiplier. Setting it is rejected in v1.",
+            "type": "number",
+            "format": "double"
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode": {
+        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+        "type": "object",
+        "properties": {
+          "and": {
+            "description": "Combinators.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode"
+            }
+          },
+          "exists": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.ExistsPredicate"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.FilterPredicate"
+          },
+          "not": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode"
+          },
+          "or": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode"
+            }
+          },
+          "range": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.RangePredicate"
+          },
+          "text": {
+            "description": "Leaves.",
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.TextPredicate"
+          }
+        }
+      },
       "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource": {
         "description": "APIResource specifies the name of a resource and whether it is namespaced.",
         "type": "object",
@@ -1278,6 +1664,59 @@
       "io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1": {
         "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:\u003cname\u003e', where \u003cname\u003e is the name of a field in a struct, or key in a map 'v:\u003cvalue\u003e', where \u003cvalue\u003e is the exact json formatted value of a list item 'i:\u003cindex\u003e', where \u003cindex\u003e is position of a item in a list 'k:\u003ckeys\u003e', where \u003ckeys\u003e is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
         "type": "object"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+        "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+        "type": "object",
+        "properties": {
+          "matchExpressions": {
+            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement"
+            },
+            "x-kubernetes-list-type": "atomic"
+          },
+          "matchLabels": {
+            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        },
+        "x-kubernetes-map-type": "atomic"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement": {
+        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+        "type": "object",
+        "required": [
+          "key",
+          "operator"
+        ],
+        "properties": {
+          "key": {
+            "description": "key is the label key that the selector applies to.",
+            "type": "string",
+            "default": ""
+          },
+          "operator": {
+            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+            "type": "string",
+            "default": ""
+          },
+          "values": {
+            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            },
+            "x-kubernetes-list-type": "atomic"
+          }
+        }
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta": {
         "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",

--- a/pkg/tests/apis/openapi_snapshots/iam.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/iam.grafana.app-v0alpha1.json
@@ -77,6 +77,50 @@
         }
       }
     },
+    "/apis/iam.grafana.app/v0alpha1/namespaces/{namespace}/externalgroupmappings/search": {
+      "post": {
+        "tags": [
+          "Search"
+        ],
+        "description": "Search ExternalGroupMapping resources in a namespace.",
+        "operationId": "listExternalGroupMappingSearchV0alpha1",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "workspace",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "default"
+          }
+        ],
+        "requestBody": {
+          "description": "A SearchQuery describing what to match, sort and return.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A SearchResults envelope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchResults"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/apis/iam.grafana.app/v0alpha1/namespaces/{namespace}/searchExternalGroupMappings": {
       "post": {
         "tags": [
@@ -1185,6 +1229,50 @@
         }
       ]
     },
+    "/apis/iam.grafana.app/v0alpha1/namespaces/{namespace}/teambindings/search": {
+      "post": {
+        "tags": [
+          "Search"
+        ],
+        "description": "Search TeamBinding resources in a namespace.",
+        "operationId": "listTeamBindingSearchV0alpha1",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "workspace",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "default"
+          }
+        ],
+        "requestBody": {
+          "description": "A SearchQuery describing what to match, sort and return.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A SearchResults envelope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchResults"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/apis/iam.grafana.app/v0alpha1/namespaces/{namespace}/teams": {
       "get": {
         "tags": [
@@ -1411,6 +1499,50 @@
           }
         }
       ]
+    },
+    "/apis/iam.grafana.app/v0alpha1/namespaces/{namespace}/teams/search": {
+      "post": {
+        "tags": [
+          "Search"
+        ],
+        "description": "Search Team resources in a namespace.",
+        "operationId": "listTeamSearchV0alpha1",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "workspace",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "default"
+          }
+        ],
+        "requestBody": {
+          "description": "A SearchQuery describing what to match, sort and return.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A SearchResults envelope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchResults"
+                }
+              }
+            }
+          }
+        }
+      }
     },
     "/apis/iam.grafana.app/v0alpha1/namespaces/{namespace}/teams/{name}": {
       "get": {
@@ -2250,6 +2382,50 @@
           }
         }
       ]
+    },
+    "/apis/iam.grafana.app/v0alpha1/namespaces/{namespace}/users/search": {
+      "post": {
+        "tags": [
+          "Search"
+        ],
+        "description": "Search User resources in a namespace.",
+        "operationId": "listUserSearchV0alpha1",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "workspace",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "default"
+          }
+        ],
+        "requestBody": {
+          "description": "A SearchQuery describing what to match, sort and return.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A SearchResults envelope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchResults"
+                }
+              }
+            }
+          }
+        }
+      }
     },
     "/apis/iam.grafana.app/v0alpha1/namespaces/{namespace}/users/{name}": {
       "get": {
@@ -5065,6 +5241,11 @@
           }
         }
       },
+      "com.github.grafana.grafana.pkg.apimachinery.apis.common.v0alpha1.Unstructured": {
+        "type": "object",
+        "additionalProperties": true,
+        "x-kubernetes-preserve-unknown-fields": true
+      },
       "com.github.grafana.grafana.pkg.apis.iam.v0alpha1.Display": {
         "type": "object",
         "required": [
@@ -5374,6 +5555,343 @@
           },
           "metadata": {
             "default": {}
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.ExistsPredicate": {
+        "description": "ExistsPredicate is a future field-existence predicate. Modelled for schema stability; always rejected in v1.",
+        "type": "object",
+        "required": [
+          "field"
+        ],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.FacetTerm": {
+        "description": "FacetTerm is a single facet term and its count.",
+        "type": "object",
+        "required": [
+          "value",
+          "count"
+        ],
+        "properties": {
+          "count": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.FilterPredicate": {
+        "description": "FilterPredicate is an exact / set-based predicate against a single field. Values are strings whatever the field's declared type, so a boolean field takes \"true\" or \"false\" and a numeric field takes the number written out.\n\nNumbers are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a filter can both match a neighbour and miss the value asked for.",
+        "type": "object",
+        "required": [
+          "field",
+          "operator",
+          "values"
+        ],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          },
+          "operator": {
+            "description": "Operator is \"In\" or \"NotIn\" in v1.",
+            "type": "string",
+            "default": ""
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.RangePredicate": {
+        "description": "RangePredicate compares a numeric field against one or two bounds. At least one bound is required, gt cannot be combined with gte, and lt cannot be combined with lte. Boolean and string fields are rejected: only numbers have the order a range asks about. On an integer field a bound must be whole.\n\nBounds are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a bound can both admit a neighbour and exclude the value asked for.",
+        "type": "object",
+        "required": [
+          "field"
+        ],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          },
+          "gt": {
+            "type": "number",
+            "format": "double"
+          },
+          "gte": {
+            "type": "number",
+            "format": "double"
+          },
+          "lt": {
+            "type": "number",
+            "format": "double"
+          },
+          "lte": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResourceRef": {
+        "description": "ResourceRef is the full identity of a returned item. Namespace is implicit from the URL and omitted.",
+        "type": "object",
+        "required": [
+          "group",
+          "resource",
+          "kind",
+          "name"
+        ],
+        "properties": {
+          "group": {
+            "type": "string",
+            "default": ""
+          },
+          "kind": {
+            "type": "string",
+            "default": ""
+          },
+          "name": {
+            "type": "string",
+            "default": ""
+          },
+          "resource": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResultItem": {
+        "description": "ResultItem is one search or trash hit. The item shape is identical on both endpoints; only which fields the Fields map can carry differs.",
+        "type": "object",
+        "required": [
+          "resource"
+        ],
+        "properties": {
+          "fields": {
+            "description": "Fields holds the JSON values for the requested (or default) fields. Array-typed fields are returned as JSON arrays. Absent fields are omitted.",
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apimachinery.apis.common.v0alpha1.Unstructured"
+          },
+          "resource": {
+            "default": {},
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResourceRef"
+          },
+          "score": {
+            "description": "Score is present only when a text query was evaluated. A pointer so a real score of 0 is still distinguishable from \"no text query\" (absent).",
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResultsMetadata": {
+        "description": "ResultsMetadata carries the pagination token and the total hit count.",
+        "type": "object",
+        "required": [
+          "totalHits",
+          "totalHitsRelation"
+        ],
+        "properties": {
+          "continue": {
+            "type": "string"
+          },
+          "totalHits": {
+            "description": "TotalHits counts the resources matching the query. Always read it together with TotalHitsRelation, which says whether the count is exact.",
+            "type": "integer",
+            "format": "int64",
+            "default": 0
+          },
+          "totalHitsRelation": {
+            "description": "TotalHitsRelation is \"eq\" when TotalHits is exact and \"lte\" when it is an upper bound.",
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery": {
+        "description": "SearchQuery is the request body for POST .../{resource}/search.",
+        "type": "object",
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "continue": {
+            "description": "Continue is an opaque pagination token from a previous page.",
+            "type": "string"
+          },
+          "facetLimit": {
+            "description": "FacetLimit caps the number of terms returned per facet. It applies to every entry in Facets. Zero uses the server default; values above the server cap are clamped.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "facets": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "labelSelector": {
+            "description": "LabelSelector filters on metadata.labels, ANDed with Where.",
+            "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+          },
+          "limit": {
+            "description": "Limit is the page size. Zero uses the default; values above the maximum are clamped.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "sort": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SortField"
+            }
+          },
+          "where": {
+            "description": "Where is the search predicate tree. Omitting it matches all resources of the kind (subject to labelSelector and per-item authz).",
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode"
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchResults": {
+        "description": "SearchResults is the response body for POST .../{resource}/search.",
+        "type": "object",
+        "required": [
+          "metadata",
+          "items"
+        ],
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "facets": {
+            "description": "Facets holds term counts per requested facet field. Counts are computed over a bounded sample window, so they are best-effort/approximate.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "default": {},
+                "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.FacetTerm"
+              }
+            }
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResultItem"
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "metadata": {
+            "default": {},
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResultsMetadata"
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.SortField": {
+        "description": "SortField names a field to sort by and a direction (\"asc\" or \"desc\"). V1 allows sorting only on scalar string and numeric fields that declare the sort capability.",
+        "type": "object",
+        "required": [
+          "field"
+        ],
+        "properties": {
+          "direction": {
+            "type": "string"
+          },
+          "field": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.TextPredicate": {
+        "description": "TextPredicate is a free-text predicate against one or more text-capable fields. When Fields is empty it defaults to the kind's searchTextFields (currently [\"title\"]).",
+        "type": "object",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "boost": {
+            "description": "Boost is a future per-leaf score multiplier. Setting it is rejected in v1.",
+            "type": "number",
+            "format": "double"
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode": {
+        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+        "type": "object",
+        "properties": {
+          "and": {
+            "description": "Combinators.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode"
+            }
+          },
+          "exists": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.ExistsPredicate"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.FilterPredicate"
+          },
+          "not": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode"
+          },
+          "or": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode"
+            }
+          },
+          "range": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.RangePredicate"
+          },
+          "text": {
+            "description": "Leaves.",
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.TextPredicate"
           }
         }
       },
@@ -5724,6 +6242,59 @@
       "io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1": {
         "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:\u003cname\u003e', where \u003cname\u003e is the name of a field in a struct, or key in a map 'v:\u003cvalue\u003e', where \u003cvalue\u003e is the exact json formatted value of a list item 'i:\u003cindex\u003e', where \u003cindex\u003e is position of a item in a list 'k:\u003ckeys\u003e', where \u003ckeys\u003e is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
         "type": "object"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+        "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+        "type": "object",
+        "properties": {
+          "matchExpressions": {
+            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement"
+            },
+            "x-kubernetes-list-type": "atomic"
+          },
+          "matchLabels": {
+            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        },
+        "x-kubernetes-map-type": "atomic"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement": {
+        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+        "type": "object",
+        "required": [
+          "key",
+          "operator"
+        ],
+        "properties": {
+          "key": {
+            "description": "key is the label key that the selector applies to.",
+            "type": "string",
+            "default": ""
+          },
+          "operator": {
+            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+            "type": "string",
+            "default": ""
+          },
+          "values": {
+            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            },
+            "x-kubernetes-list-type": "atomic"
+          }
+        }
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta": {
         "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",

--- a/pkg/tests/apis/openapi_snapshots/rules.alerting.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/rules.alerting.grafana.app-v0alpha1.json
@@ -257,6 +257,50 @@
         }
       ]
     },
+    "/apis/rules.alerting.grafana.app/v0alpha1/namespaces/{namespace}/alertrules/search": {
+      "post": {
+        "tags": [
+          "Search"
+        ],
+        "description": "Search AlertRule resources in a namespace.",
+        "operationId": "listAlertRuleSearchV0alpha1",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "workspace",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "default"
+          }
+        ],
+        "requestBody": {
+          "description": "A SearchQuery describing what to match, sort and return.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A SearchResults envelope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchResults"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/apis/rules.alerting.grafana.app/v0alpha1/namespaces/{namespace}/alertrules/{name}": {
       "get": {
         "tags": [
@@ -1253,6 +1297,50 @@
           }
         }
       ]
+    },
+    "/apis/rules.alerting.grafana.app/v0alpha1/namespaces/{namespace}/recordingrules/search": {
+      "post": {
+        "tags": [
+          "Search"
+        ],
+        "description": "Search RecordingRule resources in a namespace.",
+        "operationId": "listRecordingRuleSearchV0alpha1",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "workspace",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "default"
+          }
+        ],
+        "requestBody": {
+          "description": "A SearchQuery describing what to match, sort and return.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A SearchResults envelope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchResults"
+                }
+              }
+            }
+          }
+        }
+      }
     },
     "/apis/rules.alerting.grafana.app/v0alpha1/namespaces/{namespace}/recordingrules/{name}": {
       "get": {
@@ -4058,6 +4146,348 @@
         },
         "additionalProperties": false
       },
+      "com.github.grafana.grafana.pkg.apimachinery.apis.common.v0alpha1.Unstructured": {
+        "type": "object",
+        "additionalProperties": true,
+        "x-kubernetes-preserve-unknown-fields": true
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.ExistsPredicate": {
+        "description": "ExistsPredicate is a future field-existence predicate. Modelled for schema stability; always rejected in v1.",
+        "type": "object",
+        "required": [
+          "field"
+        ],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.FacetTerm": {
+        "description": "FacetTerm is a single facet term and its count.",
+        "type": "object",
+        "required": [
+          "value",
+          "count"
+        ],
+        "properties": {
+          "count": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.FilterPredicate": {
+        "description": "FilterPredicate is an exact / set-based predicate against a single field. Values are strings whatever the field's declared type, so a boolean field takes \"true\" or \"false\" and a numeric field takes the number written out.\n\nNumbers are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a filter can both match a neighbour and miss the value asked for.",
+        "type": "object",
+        "required": [
+          "field",
+          "operator",
+          "values"
+        ],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          },
+          "operator": {
+            "description": "Operator is \"In\" or \"NotIn\" in v1.",
+            "type": "string",
+            "default": ""
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.RangePredicate": {
+        "description": "RangePredicate compares a numeric field against one or two bounds. At least one bound is required, gt cannot be combined with gte, and lt cannot be combined with lte. Boolean and string fields are rejected: only numbers have the order a range asks about. On an integer field a bound must be whole.\n\nBounds are held as float64, so only integers up to 2^53 are compared exactly. Past that, values a whole number apart share one representation, and a bound can both admit a neighbour and exclude the value asked for.",
+        "type": "object",
+        "required": [
+          "field"
+        ],
+        "properties": {
+          "field": {
+            "type": "string",
+            "default": ""
+          },
+          "gt": {
+            "type": "number",
+            "format": "double"
+          },
+          "gte": {
+            "type": "number",
+            "format": "double"
+          },
+          "lt": {
+            "type": "number",
+            "format": "double"
+          },
+          "lte": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResourceRef": {
+        "description": "ResourceRef is the full identity of a returned item. Namespace is implicit from the URL and omitted.",
+        "type": "object",
+        "required": [
+          "group",
+          "resource",
+          "kind",
+          "name"
+        ],
+        "properties": {
+          "group": {
+            "type": "string",
+            "default": ""
+          },
+          "kind": {
+            "type": "string",
+            "default": ""
+          },
+          "name": {
+            "type": "string",
+            "default": ""
+          },
+          "resource": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResultItem": {
+        "description": "ResultItem is one search or trash hit. The item shape is identical on both endpoints; only which fields the Fields map can carry differs.",
+        "type": "object",
+        "required": [
+          "resource"
+        ],
+        "properties": {
+          "fields": {
+            "description": "Fields holds the JSON values for the requested (or default) fields. Array-typed fields are returned as JSON arrays. Absent fields are omitted.",
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apimachinery.apis.common.v0alpha1.Unstructured"
+          },
+          "resource": {
+            "default": {},
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResourceRef"
+          },
+          "score": {
+            "description": "Score is present only when a text query was evaluated. A pointer so a real score of 0 is still distinguishable from \"no text query\" (absent).",
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResultsMetadata": {
+        "description": "ResultsMetadata carries the pagination token and the total hit count.",
+        "type": "object",
+        "required": [
+          "totalHits",
+          "totalHitsRelation"
+        ],
+        "properties": {
+          "continue": {
+            "type": "string"
+          },
+          "totalHits": {
+            "description": "TotalHits counts the resources matching the query. Always read it together with TotalHitsRelation, which says whether the count is exact.",
+            "type": "integer",
+            "format": "int64",
+            "default": 0
+          },
+          "totalHitsRelation": {
+            "description": "TotalHitsRelation is \"eq\" when TotalHits is exact and \"lte\" when it is an upper bound.",
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery": {
+        "description": "SearchQuery is the request body for POST .../{resource}/search.",
+        "type": "object",
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "continue": {
+            "description": "Continue is an opaque pagination token from a previous page.",
+            "type": "string"
+          },
+          "facetLimit": {
+            "description": "FacetLimit caps the number of terms returned per facet. It applies to every entry in Facets. Zero uses the server default; values above the server cap are clamped.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "facets": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "labelSelector": {
+            "description": "LabelSelector filters on metadata.labels, ANDed with Where.",
+            "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+          },
+          "limit": {
+            "description": "Limit is the page size. Zero uses the default; values above the maximum are clamped.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "sort": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SortField"
+            }
+          },
+          "where": {
+            "description": "Where is the search predicate tree. Omitting it matches all resources of the kind (subject to labelSelector and per-item authz).",
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode"
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchResults": {
+        "description": "SearchResults is the response body for POST .../{resource}/search.",
+        "type": "object",
+        "required": [
+          "metadata",
+          "items"
+        ],
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "facets": {
+            "description": "Facets holds term counts per requested facet field. Counts are computed over a bounded sample window, so they are best-effort/approximate.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "default": {},
+                "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.FacetTerm"
+              }
+            }
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResultItem"
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "metadata": {
+            "default": {},
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.ResultsMetadata"
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.SortField": {
+        "description": "SortField names a field to sort by and a direction (\"asc\" or \"desc\"). V1 allows sorting only on scalar string and numeric fields that declare the sort capability.",
+        "type": "object",
+        "required": [
+          "field"
+        ],
+        "properties": {
+          "direction": {
+            "type": "string"
+          },
+          "field": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.TextPredicate": {
+        "description": "TextPredicate is a free-text predicate against one or more text-capable fields. When Fields is empty it defaults to the kind's searchTextFields (currently [\"title\"]).",
+        "type": "object",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "boost": {
+            "description": "Boost is a future per-leaf score multiplier. Setting it is rejected in v1.",
+            "type": "number",
+            "format": "double"
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode": {
+        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+        "type": "object",
+        "properties": {
+          "and": {
+            "description": "Combinators.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode"
+            }
+          },
+          "exists": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.ExistsPredicate"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.FilterPredicate"
+          },
+          "not": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode"
+          },
+          "or": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode"
+            }
+          },
+          "range": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.RangePredicate"
+          },
+          "text": {
+            "description": "Leaves.",
+            "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.TextPredicate"
+          }
+        }
+      },
       "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource": {
         "description": "APIResource specifies the name of a resource and whether it is namespaced.",
         "type": "object",
@@ -4216,6 +4646,59 @@
       "io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1": {
         "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:\u003cname\u003e', where \u003cname\u003e is the name of a field in a struct, or key in a map 'v:\u003cvalue\u003e', where \u003cvalue\u003e is the exact json formatted value of a list item 'i:\u003cindex\u003e', where \u003cindex\u003e is position of a item in a list 'k:\u003ckeys\u003e', where \u003ckeys\u003e is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
         "type": "object"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+        "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+        "type": "object",
+        "properties": {
+          "matchExpressions": {
+            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement"
+            },
+            "x-kubernetes-list-type": "atomic"
+          },
+          "matchLabels": {
+            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        },
+        "x-kubernetes-map-type": "atomic"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement": {
+        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+        "type": "object",
+        "required": [
+          "key",
+          "operator"
+        ],
+        "properties": {
+          "key": {
+            "description": "key is the label key that the selector applies to.",
+            "type": "string",
+            "default": ""
+          },
+          "operator": {
+            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+            "type": "string",
+            "default": ""
+          },
+          "values": {
+            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            },
+            "x-kubernetes-list-type": "atomic"
+          }
+        }
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta": {
         "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",


### PR DESCRIPTION
Enabling `/search` per environment meant setting a flag on several components and on the Grafana instance itself, which is more work than the change is worth. Which kinds serve it is already decided by their manifest, so the setting only has to cover an operator who wants none of them.

Nine kinds are enrolled, gated for now on the kind declaring search fields — a temporary stand-in for the owning team having looked at it. No enterprise kind declares any, so none are enrolled there.

Both switches read their default from `NewExtraOptions`, which the multi-tenant apiserver also reads, so no matching change is needed in grafana-enterprise.

To turn it off: `enable_search_api = false` under `[grafana-apiserver]`, or `--grafana-apiserver-enable-search-api=false`.

Trash stays off — it authorizes on a rule that has not been reviewed for kinds with no folder to scope to.

A kind whose data is not in unified storage returns an empty result rather than an error, and the first request for a kind waits on the index build.

The dashboard group-root search published a `SearchResults` schema of its own, which the API client generator rejects alongside ours. #131138 renamed it to `DashboardSearchResults` and is merged, so this needs no workaround.

Two things keep the generated output out of the way. The per-resource endpoints are excluded from the RTK Query clients, because every namespaced kind can serve them and no frontend calls them, so a hook per kind would be a client nobody imports — the older `searchDashboardsAndFolders` is unaffected. And the processed OpenAPI specs are marked as generated, so a review does not have to read them.

Of the 24 files, 6 are hand written. The rest are 13 search paths across 9 group-versions, each document repeating the same 12 envelope schemas because a group-version spec is self-contained.
