### PR TITLE
Dashboards: Add the alert rule ID to panel alert state

### DIFF
--- a/packages/grafana-data/src/types/alerts.ts
+++ b/packages/grafana-data/src/types/alerts.ts
@@ -19,4 +19,6 @@ export interface AlertStateInfo {
   dashboardUID: string | undefined;
   panelId: number;
   state: AlertState;
+  /** UID of the Grafana-managed alert rule linked to this panel, when known. */
+  ruleUID?: string;
 }

--- a/public/app/features/dashboard-scene/scene/AlertStatesDataLayer.test.ts
+++ b/public/app/features/dashboard-scene/scene/AlertStatesDataLayer.test.ts
@@ -1,0 +1,112 @@
+import { DataFrameView, DataTopic, type AlertStateInfo, AlertState, LoadingState } from '@grafana/data';
+import { config } from '@grafana/runtime';
+import {
+  grantUserPermissions,
+  mockGrafanaPromAlertingRule,
+  mockPromRuleGroup,
+  mockPromRuleNamespace,
+} from 'app/features/alerting/unified/mocks';
+import { Annotation } from 'app/features/alerting/unified/utils/constants';
+import * as store from 'app/store/store';
+import { AccessControlAction } from 'app/types/accessControl';
+import { PromAlertingRuleState } from 'app/types/unified-alerting-dto';
+
+import { AlertStatesDataLayer } from './AlertStatesDataLayer';
+
+jest.mock('../utils/utils', () => ({
+  ...jest.requireActual('../utils/utils'),
+  getDashboardSceneFor: () => ({ state: { uid: 'a uid' } }),
+}));
+
+function getTestContext() {
+  jest.clearAllMocks();
+  config.publicDashboardAccessToken = '';
+  grantUserPermissions(Object.values(AccessControlAction));
+  const dispatchMock = jest.spyOn(store, 'dispatch');
+  return { dispatchMock };
+}
+
+describe('AlertStatesDataLayer', () => {
+  it('publishes the ruleUID of the most severe alert linked to a panel', (done) => {
+    const nameSpaces = [
+      mockPromRuleNamespace({
+        groups: [
+          mockPromRuleGroup({
+            name: 'group1',
+            rules: [
+              mockGrafanaPromAlertingRule({
+                uid: 'rule-ok',
+                name: 'alert-ok',
+                state: PromAlertingRuleState.Inactive,
+                annotations: { [Annotation.panelID]: '1' },
+              }),
+              mockGrafanaPromAlertingRule({
+                uid: 'rule-firing',
+                name: 'alert-firing',
+                state: PromAlertingRuleState.Firing,
+                annotations: { [Annotation.panelID]: '1' },
+              }),
+            ],
+          }),
+        ],
+      }),
+    ];
+
+    const { dispatchMock } = getTestContext();
+    dispatchMock.mockResolvedValue({ data: nameSpaces });
+
+    const layer = new AlertStatesDataLayer({ name: 'Alert States' });
+    layer.activate();
+
+    layer.getResultsStream().subscribe((result) => {
+      if (result.data.state !== LoadingState.Done) {
+        return;
+      }
+
+      const frame = result.data.series[0];
+      expect(frame.meta?.dataTopic).toBe(DataTopic.AlertStates);
+
+      const [row] = new DataFrameView<AlertStateInfo>(frame);
+      expect(row.panelId).toBe(1);
+      expect(row.state).toBe(AlertState.Alerting);
+      expect(row.ruleUID).toBe('rule-firing');
+      done();
+    });
+  });
+
+  it('does not set a ruleUID when the linked rule has none', (done) => {
+    const nameSpaces = [
+      mockPromRuleNamespace({
+        groups: [
+          mockPromRuleGroup({
+            name: 'group1',
+            rules: [
+              mockGrafanaPromAlertingRule({
+                uid: undefined,
+                name: 'alert-ok',
+                state: PromAlertingRuleState.Inactive,
+                annotations: { [Annotation.panelID]: '1' },
+              }),
+            ],
+          }),
+        ],
+      }),
+    ];
+
+    const { dispatchMock } = getTestContext();
+    dispatchMock.mockResolvedValue({ data: nameSpaces });
+
+    const layer = new AlertStatesDataLayer({ name: 'Alert States' });
+    layer.activate();
+
+    layer.getResultsStream().subscribe((result) => {
+      if (result.data.state !== LoadingState.Done) {
+        return;
+      }
+
+      const [row] = new DataFrameView<AlertStateInfo>(result.data.series[0]);
+      expect(row.ruleUID).toBeUndefined();
+      done();
+    });
+  });
+});

--- a/public/app/features/dashboard-scene/scene/AlertStatesDataLayer.ts
+++ b/public/app/features/dashboard-scene/scene/AlertStatesDataLayer.ts
@@ -100,6 +100,8 @@ export class AlertStatesDataLayer
               this.hasAlertRules = true;
               const panelId = Number(rule.annotations[Annotation.panelID]);
               const state = promAlertStateToAlertState(rule.state);
+              // rule.uid is only present on the narrower Grafana-rule type, not the generic Prometheus one
+              const ruleUID = prometheusRuleType.grafana.alertingRule(rule) ? rule.uid : undefined;
 
               // there can be multiple alerts per panel, so we make sure we get the most severe state:
               // alerting > pending > ok
@@ -109,15 +111,18 @@ export class AlertStatesDataLayer
                   id: Object.keys(panelIdToAlertState).length,
                   panelId,
                   dashboardUID: uid,
+                  ruleUID,
                 };
               } else if (state === AlertState.Alerting && panelIdToAlertState[panelId].state !== AlertState.Alerting) {
                 panelIdToAlertState[panelId].state = AlertState.Alerting;
+                panelIdToAlertState[panelId].ruleUID = ruleUID;
               } else if (
                 state === AlertState.Pending &&
                 panelIdToAlertState[panelId].state !== AlertState.Alerting &&
                 panelIdToAlertState[panelId].state !== AlertState.Pending
               ) {
                 panelIdToAlertState[panelId].state = AlertState.Pending;
+                panelIdToAlertState[panelId].ruleUID = ruleUID;
               }
             }
           })


### PR DESCRIPTION
A panel alert icon shows the alert state, but not which rule it is. This change adds the rule ID to that state.

A companion change in [grafana/scenes#1619](https://github.com/grafana/scenes/pull/1619) uses this ID. It turns the alert icon into a real link to the rule page. That PR needs to merge and publish first, then this repo can update `@grafana/scenes` to use it.