### PR TITLE
Provisioning: Style branch/target-branch as GitHub-like pills in preview banner

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/pages.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/pages.ts
@@ -1341,6 +1341,14 @@ export const versionedPages = {
         '13.2.0': 'data-testid Provisioning repository overview jobs card',
       },
     },
+    PreviewBanner: {
+      sourceBranchLink: {
+        '13.3.0': 'data-testid Provisioning preview banner source branch link',
+      },
+      targetBranchLink: {
+        '13.3.0': 'data-testid Provisioning preview banner target branch link',
+      },
+    },
   },
   SearchDashboards: {
     table: {

--- a/public/app/features/provisioning/components/Shared/BranchDisplay.test.tsx
+++ b/public/app/features/provisioning/components/Shared/BranchDisplay.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from 'test/test-utils';
+import { render, screen, within } from 'test/test-utils';
 
 import { setupProvisioningMswServer } from '../../mocks/server';
 
@@ -19,7 +19,7 @@ describe('BranchDisplay', () => {
     const link = screen.getByRole('link', { name: /feature\/foo/ });
     expect(link).toHaveAttribute('href', 'https://github.com/org/repo/tree/feature/foo');
     expect(link).toHaveAttribute('target', '_blank');
-    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(link).toHaveAttribute('rel', 'noreferrer');
   });
 
   it('builds the correct branch URL for GitLab repos', () => {
@@ -70,7 +70,8 @@ describe('BranchDisplay', () => {
       />
     );
 
-    expect(screen.getByTestId('branch-pill')).toBe(screen.getByRole('link', { name: /feature\/foo/ }));
+    const pill = screen.getByTestId('branch-pill');
+    expect(within(pill).getByRole('link', { name: /feature\/foo/ })).toBeInTheDocument();
   });
 
   it('wires the provided e2e selector onto the plain-text pill', () => {

--- a/public/app/features/provisioning/components/Shared/BranchDisplay.test.tsx
+++ b/public/app/features/provisioning/components/Shared/BranchDisplay.test.tsx
@@ -59,4 +59,18 @@ describe('BranchDisplay', () => {
     expect(screen.queryByRole('link')).not.toBeInTheDocument();
     expect(screen.getByText('feature/foo')).toBeInTheDocument();
   });
+
+  it('wires the provided e2e selector onto the link pill', () => {
+    render(
+      <BranchDisplay baseUrl="https://github.com/org/repo" branch="feature/foo" repoType="github" dataTestId="branch-pill" />
+    );
+
+    expect(screen.getByTestId('branch-pill')).toBe(screen.getByRole('link', { name: /feature\/foo/ }));
+  });
+
+  it('wires the provided e2e selector onto the plain-text pill', () => {
+    render(<BranchDisplay baseUrl="https://github.com/org/repo" branch="feature/foo" repoType="local" dataTestId="branch-pill" />);
+
+    expect(screen.getByTestId('branch-pill')).toHaveTextContent('feature/foo');
+  });
 });

--- a/public/app/features/provisioning/components/Shared/BranchDisplay.test.tsx
+++ b/public/app/features/provisioning/components/Shared/BranchDisplay.test.tsx
@@ -62,14 +62,26 @@ describe('BranchDisplay', () => {
 
   it('wires the provided e2e selector onto the link pill', () => {
     render(
-      <BranchDisplay baseUrl="https://github.com/org/repo" branch="feature/foo" repoType="github" dataTestId="branch-pill" />
+      <BranchDisplay
+        baseUrl="https://github.com/org/repo"
+        branch="feature/foo"
+        repoType="github"
+        dataTestId="branch-pill"
+      />
     );
 
     expect(screen.getByTestId('branch-pill')).toBe(screen.getByRole('link', { name: /feature\/foo/ }));
   });
 
   it('wires the provided e2e selector onto the plain-text pill', () => {
-    render(<BranchDisplay baseUrl="https://github.com/org/repo" branch="feature/foo" repoType="local" dataTestId="branch-pill" />);
+    render(
+      <BranchDisplay
+        baseUrl="https://github.com/org/repo"
+        branch="feature/foo"
+        repoType="local"
+        dataTestId="branch-pill"
+      />
+    );
 
     expect(screen.getByTestId('branch-pill')).toHaveTextContent('feature/foo');
   });

--- a/public/app/features/provisioning/components/Shared/BranchDisplay.test.tsx
+++ b/public/app/features/provisioning/components/Shared/BranchDisplay.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+
+import { textUtil } from '@grafana/data';
+
+import { BranchDisplay } from './BranchDisplay';
+
+jest.mock('@grafana/data', () => ({
+  ...jest.requireActual('@grafana/data'),
+  textUtil: {
+    sanitizeUrl: jest.fn(),
+  },
+}));
+
+const mockTextUtil = jest.mocked(textUtil);
+
+describe('BranchDisplay', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockTextUtil.sanitizeUrl.mockImplementation((url) => url);
+  });
+
+  it('renders the branch name', () => {
+    render(<BranchDisplay baseUrl="https://github.com/org/repo" branch="feature/foo" repoType="github" />);
+
+    expect(screen.getByText('feature/foo')).toBeInTheDocument();
+  });
+
+  it('renders as a link opening the branch in a new tab for GitHub repos', () => {
+    render(<BranchDisplay baseUrl="https://github.com/org/repo" branch="feature/foo" repoType="github" />);
+
+    const link = screen.getByRole('link', { name: /feature\/foo/ });
+    expect(link).toHaveAttribute('href', 'https://github.com/org/repo/tree/feature/foo');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('builds the correct branch URL for GitLab repos', () => {
+    render(<BranchDisplay baseUrl="https://gitlab.com/org/repo" branch="develop" repoType="gitlab" />);
+
+    expect(screen.getByRole('link', { name: /develop/ })).toHaveAttribute(
+      'href',
+      'https://gitlab.com/org/repo/-/tree/develop'
+    );
+  });
+
+  it('builds the correct branch URL for Bitbucket repos', () => {
+    render(<BranchDisplay baseUrl="https://bitbucket.org/org/repo" branch="main" repoType="bitbucket" />);
+
+    expect(screen.getByRole('link', { name: /main/ })).toHaveAttribute(
+      'href',
+      'https://bitbucket.org/org/repo/src/main'
+    );
+  });
+
+  it('sanitizes the branch URL before using it as href', () => {
+    mockTextUtil.sanitizeUrl.mockReturnValue('safe-url');
+
+    render(<BranchDisplay baseUrl="https://github.com/org/repo" branch="feature/foo" repoType="github" />);
+
+    expect(mockTextUtil.sanitizeUrl).toHaveBeenCalledWith('https://github.com/org/repo/tree/feature/foo');
+    expect(screen.getByRole('link', { name: /feature\/foo/ })).toHaveAttribute('href', 'safe-url');
+  });
+
+  it('renders as plain text (no link) for local repos', () => {
+    render(<BranchDisplay baseUrl="https://github.com/org/repo" branch="feature/foo" repoType="local" />);
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.getByText('feature/foo')).toBeInTheDocument();
+  });
+
+  it('renders as plain text (no link) for unknown repo types', () => {
+    render(<BranchDisplay baseUrl="https://github.com/org/repo" branch="feature/foo" />);
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.getByText('feature/foo')).toBeInTheDocument();
+  });
+});

--- a/public/app/features/provisioning/components/Shared/BranchDisplay.test.tsx
+++ b/public/app/features/provisioning/components/Shared/BranchDisplay.test.tsx
@@ -1,24 +1,12 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen } from 'test/test-utils';
 
-import { textUtil } from '@grafana/data';
+import { setupProvisioningMswServer } from '../../mocks/server';
 
 import { BranchDisplay } from './BranchDisplay';
 
-jest.mock('@grafana/data', () => ({
-  ...jest.requireActual('@grafana/data'),
-  textUtil: {
-    sanitizeUrl: jest.fn(),
-  },
-}));
-
-const mockTextUtil = jest.mocked(textUtil);
+setupProvisioningMswServer();
 
 describe('BranchDisplay', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockTextUtil.sanitizeUrl.mockImplementation((url) => url);
-  });
-
   it('renders the branch name', () => {
     render(<BranchDisplay baseUrl="https://github.com/org/repo" branch="feature/foo" repoType="github" />);
 
@@ -52,13 +40,10 @@ describe('BranchDisplay', () => {
     );
   });
 
-  it('sanitizes the branch URL before using it as href', () => {
-    mockTextUtil.sanitizeUrl.mockReturnValue('safe-url');
+  it('sanitizes unsafe branch URLs', () => {
+    render(<BranchDisplay baseUrl="javascript:alert(1)" branch="x" repoType="github" />);
 
-    render(<BranchDisplay baseUrl="https://github.com/org/repo" branch="feature/foo" repoType="github" />);
-
-    expect(mockTextUtil.sanitizeUrl).toHaveBeenCalledWith('https://github.com/org/repo/tree/feature/foo');
-    expect(screen.getByRole('link', { name: /feature\/foo/ })).toHaveAttribute('href', 'safe-url');
+    expect(screen.getByRole('link', { name: /x/ })).toHaveAttribute('href', 'about:blank');
   });
 
   it('renders as plain text (no link) for local repos', () => {

--- a/public/app/features/provisioning/components/Shared/BranchDisplay.tsx
+++ b/public/app/features/provisioning/components/Shared/BranchDisplay.tsx
@@ -1,0 +1,80 @@
+import { css, cx } from '@emotion/css';
+
+import { type GrafanaTheme2, textUtil } from '@grafana/data';
+import { Icon, useStyles2 } from '@grafana/ui';
+
+import { getBranchUrl } from '../utils/url';
+
+interface Props {
+  baseUrl: string;
+  branch: string;
+  repoType?: string;
+}
+
+/**
+ * @description Renders a branch name as a GitHub-like pill. When the repo type resolves to a
+ * browsable branch URL the pill is a link that opens the branch in a new tab; otherwise it is
+ * rendered as plain, non-interactive text.
+ */
+export function BranchDisplay({ baseUrl, branch, repoType }: Props) {
+  const styles = useStyles2(getStyles);
+  const link = getBranchUrl(baseUrl, branch, repoType);
+
+  const content = (
+    <>
+      <Icon name="code-branch" size="xs" className={styles.branchIcon} />
+      <span className={styles.branchName}>{branch}</span>
+    </>
+  );
+
+  if (link.length) {
+    return (
+      <a
+        href={textUtil.sanitizeUrl(link)}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={cx(styles.branchPill, styles.branchPillLink)}
+      >
+        {content}
+      </a>
+    );
+  }
+
+  return <span className={styles.branchPill}>{content}</span>;
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  branchPill: css({
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+    maxWidth: '100%',
+    padding: theme.spacing(0.25, 0.75),
+    borderRadius: theme.shape.radius.default,
+    border: `1px solid ${theme.colors.border.weak}`,
+    backgroundColor: theme.colors.background.secondary,
+    fontFamily: theme.typography.fontFamilyMonospace,
+    fontSize: theme.typography.bodySmall.fontSize,
+    lineHeight: theme.typography.bodySmall.lineHeight,
+    color: theme.colors.text.primary,
+    verticalAlign: 'middle',
+  }),
+  branchPillLink: css({
+    color: theme.colors.text.link,
+    textDecoration: 'none',
+    '&:hover': {
+      textDecoration: 'none',
+      borderColor: theme.colors.border.medium,
+      backgroundColor: theme.colors.action.hover,
+    },
+  }),
+  branchIcon: css({
+    flexShrink: 0,
+    color: theme.colors.text.secondary,
+  }),
+  branchName: css({
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  }),
+});

--- a/public/app/features/provisioning/components/Shared/BranchDisplay.tsx
+++ b/public/app/features/provisioning/components/Shared/BranchDisplay.tsx
@@ -9,6 +9,8 @@ interface Props {
   baseUrl: string;
   branch: string;
   repoType?: string;
+  /** Stable e2e selector wired onto the rendered pill (link or text). */
+  dataTestId?: string;
 }
 
 /**
@@ -16,7 +18,7 @@ interface Props {
  * browsable branch URL the pill is a link that opens the branch in a new tab; otherwise it is
  * rendered as plain, non-interactive text.
  */
-export function BranchDisplay({ baseUrl, branch, repoType }: Props) {
+export function BranchDisplay({ baseUrl, branch, repoType, dataTestId }: Props) {
   const styles = useStyles2(getStyles);
   const link = getBranchUrl(baseUrl, branch, repoType);
 
@@ -27,6 +29,7 @@ export function BranchDisplay({ baseUrl, branch, repoType }: Props) {
         target="_blank"
         rel="noopener noreferrer"
         className={cx(styles.branchPill, styles.branchPillLink)}
+        data-testid={dataTestId}
       >
         <Icon name="code-branch" size="xs" className={styles.branchIcon} />
         <span className={styles.branchName}>{branch}</span>
@@ -36,7 +39,7 @@ export function BranchDisplay({ baseUrl, branch, repoType }: Props) {
   }
 
   return (
-    <span className={styles.branchPill}>
+    <span className={styles.branchPill} data-testid={dataTestId}>
       <Icon name="code-branch" size="xs" className={styles.branchIcon} />
       <span className={styles.branchName}>{branch}</span>
     </span>

--- a/public/app/features/provisioning/components/Shared/BranchDisplay.tsx
+++ b/public/app/features/provisioning/components/Shared/BranchDisplay.tsx
@@ -1,7 +1,6 @@
-import { css, cx } from '@emotion/css';
+import { css } from '@emotion/css';
 
-import { type GrafanaTheme2, textUtil } from '@grafana/data';
-import { Icon, useStyles2 } from '@grafana/ui';
+import { Badge, TextLink, useStyles2 } from '@grafana/ui';
 
 import { getBranchUrl } from '../utils/url';
 
@@ -9,75 +8,33 @@ interface Props {
   baseUrl: string;
   branch: string;
   repoType?: string;
-  /** Stable e2e selector wired onto the rendered pill (link or text). */
+  /** Stable e2e selector wired onto the rendered pill. */
   dataTestId?: string;
 }
 
 /**
- * @description Renders a branch name as a GitHub-like pill. When the repo type resolves to a
- * browsable branch URL the pill is a link that opens the branch in a new tab; otherwise it is
- * rendered as plain, non-interactive text.
+ * @description Renders a branch name as a badge. When the repo type resolves to a browsable
+ * branch URL the badge contains a link that opens the branch in a new tab; otherwise the branch
+ * name is rendered as plain, non-interactive text.
  */
 export function BranchDisplay({ baseUrl, branch, repoType, dataTestId }: Props) {
   const styles = useStyles2(getStyles);
   const link = getBranchUrl(baseUrl, branch, repoType);
 
-  if (link.length) {
-    return (
-      <a
-        href={textUtil.sanitizeUrl(link)}
-        target="_blank"
-        rel="noopener noreferrer"
-        className={cx(styles.branchPill, styles.branchPillLink)}
-        data-testid={dataTestId}
-      >
-        <Icon name="code-branch" size="xs" className={styles.branchIcon} />
-        <span className={styles.branchName}>{branch}</span>
-        <Icon name="external-link-alt" size="xs" className={styles.branchIcon} />
-      </a>
-    );
-  }
-
-  return (
-    <span className={styles.branchPill} data-testid={dataTestId}>
-      <Icon name="code-branch" size="xs" className={styles.branchIcon} />
-      <span className={styles.branchName}>{branch}</span>
-    </span>
+  const text = link.length ? (
+    <TextLink href={link} external inline={false} variant="bodySmall" color="secondary">
+      {branch}
+    </TextLink>
+  ) : (
+    branch
   );
+
+  return <Badge color="darkgrey" icon="code-branch" text={text} data-testid={dataTestId} className={styles.badge} />;
 }
 
-const getStyles = (theme: GrafanaTheme2) => ({
-  branchPill: css({
-    display: 'inline-flex',
+const getStyles = () => ({
+  // Vertically center the branch/external icons with the branch name.
+  badge: css({
     alignItems: 'center',
-    gap: theme.spacing(0.5),
-    maxWidth: '100%',
-    padding: theme.spacing(0.25, 0.75),
-    borderRadius: theme.shape.radius.default,
-    border: `1px solid ${theme.colors.border.weak}`,
-    backgroundColor: theme.colors.background.secondary,
-    fontFamily: theme.typography.fontFamilyMonospace,
-    fontSize: theme.typography.bodySmall.fontSize,
-    lineHeight: theme.typography.bodySmall.lineHeight,
-    color: theme.colors.text.primary,
-    verticalAlign: 'middle',
-  }),
-  branchPillLink: css({
-    color: theme.colors.text.primary,
-    textDecoration: 'none',
-    '&:hover': {
-      textDecoration: 'none',
-      borderColor: theme.colors.border.medium,
-      backgroundColor: theme.colors.action.hover,
-    },
-  }),
-  branchIcon: css({
-    flexShrink: 0,
-    color: theme.colors.text.secondary,
-  }),
-  branchName: css({
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
   }),
 });

--- a/public/app/features/provisioning/components/Shared/BranchDisplay.tsx
+++ b/public/app/features/provisioning/components/Shared/BranchDisplay.tsx
@@ -20,13 +20,6 @@ export function BranchDisplay({ baseUrl, branch, repoType }: Props) {
   const styles = useStyles2(getStyles);
   const link = getBranchUrl(baseUrl, branch, repoType);
 
-  const content = (
-    <>
-      <Icon name="code-branch" size="xs" className={styles.branchIcon} />
-      <span className={styles.branchName}>{branch}</span>
-    </>
-  );
-
   if (link.length) {
     return (
       <a
@@ -35,12 +28,19 @@ export function BranchDisplay({ baseUrl, branch, repoType }: Props) {
         rel="noopener noreferrer"
         className={cx(styles.branchPill, styles.branchPillLink)}
       >
-        {content}
+        <Icon name="code-branch" size="xs" className={styles.branchIcon} />
+        <span className={styles.branchName}>{branch}</span>
+        <Icon name="external-link-alt" size="xs" className={styles.branchIcon} />
       </a>
     );
   }
 
-  return <span className={styles.branchPill}>{content}</span>;
+  return (
+    <span className={styles.branchPill}>
+      <Icon name="code-branch" size="xs" className={styles.branchIcon} />
+      <span className={styles.branchName}>{branch}</span>
+    </span>
+  );
 }
 
 const getStyles = (theme: GrafanaTheme2) => ({
@@ -60,7 +60,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     verticalAlign: 'middle',
   }),
   branchPillLink: css({
-    color: theme.colors.text.link,
+    color: theme.colors.text.primary,
     textDecoration: 'none',
     '&:hover': {
       textDecoration: 'none',

--- a/public/app/features/provisioning/components/Shared/PreviewBannerViewPR.test.tsx
+++ b/public/app/features/provisioning/components/Shared/PreviewBannerViewPR.test.tsx
@@ -1,12 +1,13 @@
 import { render, screen } from 'test/test-utils';
 
+import { selectors } from '@grafana/e2e-selectors';
 import { type RepoType } from 'app/features/provisioning/Wizard/types';
 import { usePullRequestParam } from 'app/features/provisioning/hooks/usePullRequestParam';
 
 import { isValidRepoType } from '../../guards';
 import { setupProvisioningMswServer } from '../../mocks/server';
 
-import { PreviewBannerViewPR } from './PreviewBannerViewPR';
+import { PreviewBannerViewPR, type PreviewBranchInfo } from './PreviewBannerViewPR';
 
 jest.mock('app/features/provisioning/hooks/usePullRequestParam', () => ({
   usePullRequestParam: jest.fn(),
@@ -17,7 +18,14 @@ const mockUsePullRequestParam = jest.mocked(usePullRequestParam);
 setupProvisioningMswServer();
 
 function setup(
-  options: { prURL: string; isNewPr?: boolean; repoType?: RepoType; action?: string; prTitle?: string } = {
+  options: {
+    prURL: string;
+    isNewPr?: boolean;
+    repoType?: RepoType;
+    action?: string;
+    prTitle?: string;
+    branchInfo?: PreviewBranchInfo;
+  } = {
     prURL: 'test-url',
     repoType: 'github',
   }
@@ -25,6 +33,7 @@ function setup(
   const componentProps = {
     prURL: options.prURL,
     isNewPr: options.isNewPr || false,
+    branchInfo: options.branchInfo,
   };
 
   mockUsePullRequestParam.mockReturnValue({
@@ -184,6 +193,32 @@ describe('PreviewBannerViewPR', () => {
       setup({ prURL: 'test-url', isNewPr: true, action: 'delete' });
 
       expect(screen.getByText('Open pull request in GitHub')).toBeInTheDocument();
+    });
+  });
+
+  describe('Branch information', () => {
+    const branchInfo: PreviewBranchInfo = {
+      repoBaseUrl: 'https://github.com/org/repo',
+      targetBranch: 'dashboard/2026-08-20-abcde',
+      configuredBranch: 'develop',
+    };
+
+    it('renders source and target branch pills with stable selectors', () => {
+      setup({ prURL: 'test-url', isNewPr: true, repoType: 'github', branchInfo });
+
+      const source = screen.getByTestId(selectors.pages.Provisioning.PreviewBanner.sourceBranchLink);
+      const target = screen.getByTestId(selectors.pages.Provisioning.PreviewBanner.targetBranchLink);
+
+      expect(source).toHaveTextContent('dashboard/2026-08-20-abcde');
+      expect(source).toHaveAttribute('href', 'https://github.com/org/repo/tree/dashboard/2026-08-20-abcde');
+      expect(target).toHaveTextContent('develop');
+      expect(target).toHaveAttribute('href', 'https://github.com/org/repo/tree/develop');
+    });
+
+    it('exposes the branch-direction arrow to assistive technology', () => {
+      setup({ prURL: 'test-url', isNewPr: true, repoType: 'github', branchInfo });
+
+      expect(screen.getByLabelText('targets')).toBeInTheDocument();
     });
   });
 

--- a/public/app/features/provisioning/components/Shared/PreviewBannerViewPR.test.tsx
+++ b/public/app/features/provisioning/components/Shared/PreviewBannerViewPR.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from 'test/test-utils';
+import { render, screen, within } from 'test/test-utils';
 
 import { selectors } from '@grafana/e2e-selectors';
 import { type RepoType } from 'app/features/provisioning/Wizard/types';
@@ -210,9 +210,12 @@ describe('PreviewBannerViewPR', () => {
       const target = screen.getByTestId(selectors.pages.Provisioning.PreviewBanner.targetBranchLink);
 
       expect(source).toHaveTextContent('dashboard/2026-08-20-abcde');
-      expect(source).toHaveAttribute('href', 'https://github.com/org/repo/tree/dashboard/2026-08-20-abcde');
+      expect(within(source).getByRole('link')).toHaveAttribute(
+        'href',
+        'https://github.com/org/repo/tree/dashboard/2026-08-20-abcde'
+      );
       expect(target).toHaveTextContent('develop');
-      expect(target).toHaveAttribute('href', 'https://github.com/org/repo/tree/develop');
+      expect(within(target).getByRole('link')).toHaveAttribute('href', 'https://github.com/org/repo/tree/develop');
     });
 
     it('exposes the branch-direction arrow to assistive technology', () => {

--- a/public/app/features/provisioning/components/Shared/PreviewBannerViewPR.test.tsx
+++ b/public/app/features/provisioning/components/Shared/PreviewBannerViewPR.test.tsx
@@ -1,28 +1,20 @@
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen } from 'test/test-utils';
 
-import { textUtil } from '@grafana/data';
 import { type RepoType } from 'app/features/provisioning/Wizard/types';
 import { usePullRequestParam } from 'app/features/provisioning/hooks/usePullRequestParam';
 
 import { isValidRepoType } from '../../guards';
+import { setupProvisioningMswServer } from '../../mocks/server';
 
 import { PreviewBannerViewPR } from './PreviewBannerViewPR';
-
-jest.mock('@grafana/data', () => ({
-  ...jest.requireActual('@grafana/data'),
-  textUtil: {
-    sanitizeUrl: jest.fn(),
-  },
-}));
 
 jest.mock('app/features/provisioning/hooks/usePullRequestParam', () => ({
   usePullRequestParam: jest.fn(),
 }));
 
-const mockTextUtil = jest.mocked(textUtil);
-
 const mockUsePullRequestParam = jest.mocked(usePullRequestParam);
+
+setupProvisioningMswServer();
 
 function setup(
   options: { prURL: string; isNewPr?: boolean; repoType?: RepoType; action?: string; prTitle?: string } = {
@@ -45,9 +37,7 @@ function setup(
     prTitle: options.prTitle,
   });
 
-  const renderResult = render(<PreviewBannerViewPR {...componentProps} />);
-
-  return { renderResult, props: componentProps };
+  return { ...render(<PreviewBannerViewPR {...componentProps} />), props: componentProps };
 }
 
 describe('PreviewBannerViewPR', () => {
@@ -63,7 +53,6 @@ describe('PreviewBannerViewPR', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockTextUtil.sanitizeUrl.mockImplementation((url) => url);
   });
 
   afterEach(() => {
@@ -141,10 +130,10 @@ describe('PreviewBannerViewPR', () => {
   describe('Button functionality', () => {
     it('should open URL in new tab when button is clicked', async () => {
       const testUrl = 'https://GitHub.com/test/repo/pull/123';
-      setup({ prURL: testUrl });
+      const { user } = setup({ prURL: testUrl });
 
       const button = screen.getByRole('button', { name: /close alert/i });
-      await userEvent.click(button);
+      await user.click(button);
 
       expect(windowOpenSpy).toHaveBeenCalledWith(testUrl, '_blank');
     });
@@ -202,18 +191,18 @@ describe('PreviewBannerViewPR', () => {
     const githubPrURL = 'https://github.com/org/repo/compare/main...feature?quick_pull=1&labels=grafana';
 
     it('appends an encoded title param to a GitHub PR URL when pr_title is present', async () => {
-      setup({ prURL: githubPrURL, repoType: 'github', prTitle: 'update: My Dashboard' });
+      const { user } = setup({ prURL: githubPrURL, repoType: 'github', prTitle: 'update: My Dashboard' });
 
-      await userEvent.click(screen.getByRole('button', { name: /close alert/i }));
+      await user.click(screen.getByRole('button', { name: /close alert/i }));
 
       expect(windowOpenSpy).toHaveBeenCalledWith(`${githubPrURL}&title=update%3A%20My%20Dashboard`, '_blank');
     });
 
     it('uses merge_request[title] for GitLab', async () => {
       const gitlabPrURL = 'https://gitlab.com/org/repo/-/merge_requests/new?merge_request[source_branch]=feature';
-      setup({ prURL: gitlabPrURL, repoType: 'gitlab', prTitle: 'update: My Dashboard' });
+      const { user } = setup({ prURL: gitlabPrURL, repoType: 'gitlab', prTitle: 'update: My Dashboard' });
 
-      await userEvent.click(screen.getByRole('button', { name: /close alert/i }));
+      await user.click(screen.getByRole('button', { name: /close alert/i }));
 
       expect(windowOpenSpy).toHaveBeenCalledWith(
         `${gitlabPrURL}&merge_request[title]=update%3A%20My%20Dashboard`,
@@ -222,9 +211,9 @@ describe('PreviewBannerViewPR', () => {
     });
 
     it('leaves the PR URL unchanged when no pr_title is present', async () => {
-      setup({ prURL: githubPrURL, repoType: 'github' });
+      const { user } = setup({ prURL: githubPrURL, repoType: 'github' });
 
-      await userEvent.click(screen.getByRole('button', { name: /close alert/i }));
+      await user.click(screen.getByRole('button', { name: /close alert/i }));
 
       expect(windowOpenSpy).toHaveBeenCalledWith(githubPrURL, '_blank');
     });

--- a/public/app/features/provisioning/components/Shared/PreviewBannerViewPR.tsx
+++ b/public/app/features/provisioning/components/Shared/PreviewBannerViewPR.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/css';
 
 import { type GrafanaTheme2, textUtil } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { Alert, Box, Icon, Stack, useStyles2 } from '@grafana/ui';
 import { RepoTypeDisplay } from 'app/features/provisioning/Wizard/types';
@@ -102,10 +103,25 @@ export function PreviewBannerViewPR({ prURL, isNewPr, behindBranch, repoUrl, bra
         <Box marginTop={1}>
           <span className={styles.branchRow}>
             {/* branch that changes pushed to */}
-            <BranchDisplay baseUrl={branchInfo.repoBaseUrl} branch={branchInfo.targetBranch} repoType={repoType} />
-            <Icon name="arrow-right" size="sm" className={styles.arrow} />
+            <BranchDisplay
+              baseUrl={branchInfo.repoBaseUrl}
+              branch={branchInfo.targetBranch}
+              repoType={repoType}
+              dataTestId={selectors.pages.Provisioning.PreviewBanner.sourceBranchLink}
+            />
+            <Icon
+              name="arrow-right"
+              size="sm"
+              className={styles.arrow}
+              aria-label={t('provisioned-resource-preview-banner.preview-banner.branch-targets', 'targets')}
+            />
             {/* Target branch (configured branch) */}
-            <BranchDisplay baseUrl={branchInfo.repoBaseUrl} branch={branchInfo.configuredBranch} repoType={repoType} />
+            <BranchDisplay
+              baseUrl={branchInfo.repoBaseUrl}
+              branch={branchInfo.configuredBranch}
+              repoType={repoType}
+              dataTestId={selectors.pages.Provisioning.PreviewBanner.targetBranchLink}
+            />
           </span>
         </Box>
       )}

--- a/public/app/features/provisioning/components/Shared/PreviewBannerViewPR.tsx
+++ b/public/app/features/provisioning/components/Shared/PreviewBannerViewPR.tsx
@@ -1,13 +1,16 @@
-import { textUtil } from '@grafana/data';
+import { css } from '@emotion/css';
+
+import { type GrafanaTheme2, textUtil } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { Alert, Box, Icon, Stack, TextLink, Text } from '@grafana/ui';
+import { Alert, Box, Icon, Stack, Text, useStyles2 } from '@grafana/ui';
 import { RepoTypeDisplay } from 'app/features/provisioning/Wizard/types';
 import { isValidRepoType } from 'app/features/provisioning/guards';
 import { usePullRequestParam } from 'app/features/provisioning/hooks/usePullRequestParam';
 
 import { appendPullRequestTitleParam } from '../../utils/pullRequestTitle';
 import { isGitProvider } from '../../utils/repositoryTypes';
-import { getBranchUrl } from '../utils/url';
+
+import { BranchDisplay } from './BranchDisplay';
 
 interface Props {
   /* PR url either from url param or BE response. It is used to open the pull request in a new tab. */
@@ -29,24 +32,11 @@ const commonAlertProps = {
   style: { flex: 0 } as const,
 };
 
-function BranchDisplay({ baseUrl, branch, repoType }: { baseUrl: string; branch: string; repoType?: string }) {
-  const link = getBranchUrl(baseUrl, branch, repoType);
-
-  if (link.length) {
-    return (
-      <TextLink href={link} external>
-        {branch}
-      </TextLink>
-    );
-  }
-
-  return <Text color="info">{branch}</Text>;
-}
-
 /**
  * @description This component is used to display a banner when a provisioned dashboard/folder is created, deleted, or loaded from a new branch in repo.
  */
 export function PreviewBannerViewPR({ prURL, isNewPr, behindBranch, repoUrl, branchInfo }: Props) {
+  const styles = useStyles2(getStyles);
   const { repoType, action, prTitle } = usePullRequestParam();
 
   const capitalizedRepoType = isValidRepoType(repoType) ? RepoTypeDisplay[repoType] : 'repository';
@@ -110,11 +100,16 @@ export function PreviewBannerViewPR({ prURL, isNewPr, behindBranch, repoUrl, bra
       {/* when the repo type is a valid provider, we show branch information */}
       {showBranchInfo(repoType, branchInfo) && (
         <Box marginTop={1}>
-          <Trans i18nKey="provisioned-resource-preview-banner.preview-banner.branch-text">branch:</Trans>{' '}
-          {/* branch that changes pushed to */}
-          <BranchDisplay baseUrl={branchInfo.repoBaseUrl} branch={branchInfo.targetBranch} repoType={repoType} />
-          {'\u2192'} {/* Target branch (configured branch) */}
-          <BranchDisplay baseUrl={branchInfo.repoBaseUrl} branch={branchInfo.configuredBranch} repoType={repoType} />
+          <span className={styles.branchRow}>
+            <Text color="secondary" variant="bodySmall">
+              <Trans i18nKey="provisioned-resource-preview-banner.preview-banner.branch-text">branch:</Trans>
+            </Text>
+            {/* branch that changes pushed to */}
+            <BranchDisplay baseUrl={branchInfo.repoBaseUrl} branch={branchInfo.targetBranch} repoType={repoType} />
+            <Icon name="arrow-right" size="sm" className={styles.arrow} />
+            {/* Target branch (configured branch) */}
+            <BranchDisplay baseUrl={branchInfo.repoBaseUrl} branch={branchInfo.configuredBranch} repoType={repoType} />
+          </span>
         </Box>
       )}
     </Alert>
@@ -208,3 +203,16 @@ function showBranchInfo(
 
   return false;
 }
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  branchRow: css({
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.75),
+    flexWrap: 'wrap',
+  }),
+  arrow: css({
+    flexShrink: 0,
+    color: theme.colors.text.secondary,
+  }),
+});

--- a/public/app/features/provisioning/components/Shared/PreviewBannerViewPR.tsx
+++ b/public/app/features/provisioning/components/Shared/PreviewBannerViewPR.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 
 import { type GrafanaTheme2, textUtil } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { Alert, Box, Icon, Stack, Text, useStyles2 } from '@grafana/ui';
+import { Alert, Box, Icon, Stack, useStyles2 } from '@grafana/ui';
 import { RepoTypeDisplay } from 'app/features/provisioning/Wizard/types';
 import { isValidRepoType } from 'app/features/provisioning/guards';
 import { usePullRequestParam } from 'app/features/provisioning/hooks/usePullRequestParam';
@@ -101,9 +101,6 @@ export function PreviewBannerViewPR({ prURL, isNewPr, behindBranch, repoUrl, bra
       {showBranchInfo(repoType, branchInfo) && (
         <Box marginTop={1}>
           <span className={styles.branchRow}>
-            <Text color="secondary" variant="bodySmall">
-              <Trans i18nKey="provisioned-resource-preview-banner.preview-banner.branch-text">branch:</Trans>
-            </Text>
             {/* branch that changes pushed to */}
             <BranchDisplay baseUrl={branchInfo.repoBaseUrl} branch={branchInfo.targetBranch} repoType={repoType} />
             <Icon name="arrow-right" size="sm" className={styles.arrow} />

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13601,7 +13601,6 @@
   "provisioned-resource-preview-banner": {
     "preview-banner": {
       "behind-branch-text": "This resource is behind the branch in {{repoType}}.",
-      "branch-text": "branch:",
       "delete-from-branch": "The rest of Grafana users in your organization will still see this resource until this branch is merged",
       "not-saved": "The rest of Grafana users in your organization will still see the current version saved to configured default branch until this branch is merged",
       "open-in-repo-button": "Open in {{repoType}}",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13601,6 +13601,7 @@
   "provisioned-resource-preview-banner": {
     "preview-banner": {
       "behind-branch-text": "This resource is behind the branch in {{repoType}}.",
+      "branch-targets": "targets",
       "delete-from-branch": "The rest of Grafana users in your organization will still see this resource until this branch is merged",
       "not-saved": "The rest of Grafana users in your organization will still see the current version saved to configured default branch until this branch is merged",
       "open-in-repo-button": "Open in {{repoType}}",


### PR DESCRIPTION
## What

Restyles the branch → configured-target-branch display in the provisioned-resource **preview banner** to a GitHub-like look. Each branch now renders as a bordered **pill** (a `code-branch` icon + the branch name in a monospace font), with an arrow icon between the two — instead of two plain inline text links separated by a bare unicode arrow.

Linked branches keep their click-through to the repo (open in a new tab) and gain a hover state; non-browsable repo types (e.g. `local`) render as plain, non-interactive pills.

Before: 

<img width="1719" height="115" alt="Screenshot 2026-08-20 at 10 16 42" src="https://github.com/user-attachments/assets/4611b845-4384-4b2c-9c4e-a901efa0b527" />


After:
<img width="1714" height="120" alt="Screenshot 2026-08-20 at 10 42 30" src="https://github.com/user-attachments/assets/a3558feb-95d5-44b7-8d0a-a2f46d8ce77e" />



<img width="1397" height="85" alt="Screenshot 2026-08-20 at 10 17 45" src="https://github.com/user-attachments/assets/50d108d0-33b8-4e16-abf0-7c9c7576824c" />


## Why

The previous rendering (`branch: <link> → <link>`) read as loose inline text and didn't visually distinguish the two branch names or communicate the "source → target" relationship. Grafana users are already familiar with GitHub's branch-pill styling on the compare/PR views, so mirroring it makes the banner easier to scan and more consistent with the provider it links out to.

## How

- Extracted the pill into a reusable **`BranchDisplay`** component (`components/Shared/BranchDisplay.tsx`) with its own `useStyles2` styles, using theme tokens (`border.weak`, `background.secondary`, `fontFamilyMonospace`, `radius.default`) so it adapts to light/dark. Linkable branches render a sanitized `<a target="_blank" rel="noopener noreferrer">`; others render plain text.
- `PreviewBannerViewPR.tsx` now imports `BranchDisplay` and keeps only the layout-specific `branchRow` container + `arrow-right` icon; the branch URL logic (`getBranchUrl`) is unchanged.
- Branch URLs continue to be run through `textUtil.sanitizeUrl` before use.

## Testing

- New `BranchDisplay.test.tsx` (7 tests): renders the name; renders as a new-tab link for GitHub; correct branch URL for GitHub/GitLab/Bitbucket; sanitizes the URL before setting `href`; renders plain text (no link) for `local` and unknown repo types.
- `yarn jest` — **26/26 pass** (7 new + 19 existing `PreviewBannerViewPR`).
- `yarn eslint` — clean on all three files.

## Screenshots

_UI change — before/after screenshots to be added._

## Checklist

- [x] Tests added/updated
- [x] No breaking changes
- [ ] Screenshots added

🤖 Generated with [Claude Code](https://claude.com/claude-code)