### PR TITLE
Dashboards: publish the search results schema as DashboardSearchResults

### DIFF
--- a/packages/grafana-api-clients/src/clients/rtkq/dashboard/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/dashboard/v0alpha1/endpoints.gen.ts
@@ -471,7 +471,7 @@ export type UpdateLibraryPanelApiArg = {
   force?: boolean;
   patch: Patch;
 };
-export type SearchDashboardsAndFoldersApiResponse = /** status 200 undefined */ SearchResults;
+export type SearchDashboardsAndFoldersApiResponse = /** status 200 undefined */ DashboardSearchResults;
 export type SearchDashboardsAndFoldersApiArg = {
   /** user query string */
   query?: string;
@@ -1046,7 +1046,7 @@ export type SortBy = {
   desc?: boolean;
   field: string;
 };
-export type SearchResults = {
+export type DashboardSearchResults = {
   /** APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources */
   apiVersion?: string;
   facets?: {

--- a/packages/grafana-openapi/src/apis/dashboard.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/dashboard.grafana.app-v0alpha1.json
@@ -1337,7 +1337,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SearchResults"
+                  "$ref": "#/components/schemas/DashboardSearchResults"
                 }
               }
             }
@@ -1877,44 +1877,7 @@
           }
         }
       },
-      "FacetResult": {
-        "type": "object",
-        "properties": {
-          "field": {
-            "type": "string"
-          },
-          "missing": {
-            "description": "The number of documents that do *not* have this field",
-            "type": "integer",
-            "format": "int64"
-          },
-          "terms": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TermFacet"
-            }
-          },
-          "total": {
-            "description": "The distinct terms",
-            "type": "integer",
-            "format": "int64"
-          }
-        }
-      },
-      "ManagedBy": {
-        "type": "object",
-        "required": ["kind"],
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "kind": {
-            "type": "string",
-            "default": ""
-          }
-        }
-      },
-      "SearchResults": {
+      "DashboardSearchResults": {
         "type": "object",
         "required": ["totalHits", "hits"],
         "properties": {
@@ -1961,6 +1924,43 @@
             "type": "integer",
             "format": "int64",
             "default": 0
+          }
+        }
+      },
+      "FacetResult": {
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "missing": {
+            "description": "The number of documents that do *not* have this field",
+            "type": "integer",
+            "format": "int64"
+          },
+          "terms": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TermFacet"
+            }
+          },
+          "total": {
+            "description": "The distinct terms",
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "ManagedBy": {
+        "type": "object",
+        "required": ["kind"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string",
+            "default": ""
           }
         }
       },

--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -1369,6 +1369,10 @@ func (b *DashboardsAPIBuilder) GetOpenAPIDefinitions() common.GetOpenAPIDefiniti
 	}
 }
 
+// dashboardSearchResultsSchema is the published name for dashv0.SearchResults. The Go
+// type and the kind on the wire are unchanged.
+const dashboardSearchResultsSchema = "DashboardSearchResults"
+
 func (b *DashboardsAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.OpenAPI, error) {
 	oas.Info.Description = "Grafana dashboards as resources"
 
@@ -1378,6 +1382,16 @@ func (b *DashboardsAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.Op
 		refsBase := dashv0.OpenAPIPrefix
 
 		kinds := []string{"SearchResults", "DashboardHit", "ManagedBy", "FacetResult", "TermFacet", "SortBy"}
+
+		// The per-resource search endpoints publish a SearchResults of their own, and the
+		// API client generator keys components by the segment after the version, so the two
+		// cannot share a name.
+		published := func(k string) string {
+			if k == "SearchResults" {
+				return dashboardSearchResultsSchema
+			}
+			return k
+		}
 
 		// Add any missing definitions
 		//-----------------------------
@@ -1403,7 +1417,7 @@ func (b *DashboardsAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.Op
 						spec.RefProperty("#/components/schemas/TermFacet"),
 					)
 				}
-				oas.Components.Schemas[k] = &v.Schema // use the short key (without the full package path)
+				oas.Components.Schemas[published(k)] = &v.Schema // use the short key (without the full package path)
 			}
 		}
 
@@ -1413,7 +1427,7 @@ func (b *DashboardsAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.Op
 				Content: map[string]*spec3.MediaType{
 					"application/json": {
 						MediaTypeProps: spec3.MediaTypeProps{
-							Schema: spec.RefSchema("#/components/schemas/SearchResults"),
+							Schema: spec.RefSchema("#/components/schemas/" + dashboardSearchResultsSchema),
 						},
 					},
 				},

--- a/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v0alpha1.json
@@ -1439,7 +1439,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SearchResults"
+                  "$ref": "#/components/schemas/DashboardSearchResults"
                 }
               }
             }
@@ -2076,46 +2076,7 @@
           }
         }
       },
-      "FacetResult": {
-        "type": "object",
-        "properties": {
-          "field": {
-            "type": "string"
-          },
-          "missing": {
-            "description": "The number of documents that do *not* have this field",
-            "type": "integer",
-            "format": "int64"
-          },
-          "terms": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TermFacet"
-            }
-          },
-          "total": {
-            "description": "The distinct terms",
-            "type": "integer",
-            "format": "int64"
-          }
-        }
-      },
-      "ManagedBy": {
-        "type": "object",
-        "required": [
-          "kind"
-        ],
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "kind": {
-            "type": "string",
-            "default": ""
-          }
-        }
-      },
-      "SearchResults": {
+      "DashboardSearchResults": {
         "type": "object",
         "required": [
           "totalHits",
@@ -2165,6 +2126,45 @@
             "type": "integer",
             "format": "int64",
             "default": 0
+          }
+        }
+      },
+      "FacetResult": {
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "missing": {
+            "description": "The number of documents that do *not* have this field",
+            "type": "integer",
+            "format": "int64"
+          },
+          "terms": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TermFacet"
+            }
+          },
+          "total": {
+            "description": "The distinct terms",
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "ManagedBy": {
+        "type": "object",
+        "required": [
+          "kind"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string",
+            "default": ""
           }
         }
       },


### PR DESCRIPTION
`dashboard.grafana.app/v0alpha1` publishes a schema called `SearchResults` for the group-root dashboard search. The new per-resource search endpoints publish a `SearchResults` of their own, a different shape from `pkg/apis/search/v0alpha1`.

Both can sit in one document and every reference resolves, so the server serves it correctly. The API client generator rejects it: it keys components by the segment after the version and discards the package path, so the two collapse into one key and generation fails.

This is the dashboard-shaped one, wrapping `DashboardHit`, so it takes the qualified name and the generic envelope keeps the plain one. Published name only — the Go type and the `kind` on the wire are unchanged, and nothing imports the generated type.

Prerequisite for #131128, which serves the search endpoints by default.
