### PR TITLE
Plugins: add advisor.json to crowdin uploader

### DIFF
--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -7,6 +7,7 @@ on:
       - 'public/locales/en-US/grafana.json'
       - 'public/app/plugins/datasource/azuremonitor/locales/en-US/grafana-azure-monitor-datasource.json'
       - 'packages/grafana-sql/src/locales/en-US/grafana-sql.json'
+      - 'apps/advisor/pkg/translations/en-US/grafana-advisor.json'
     branches:
       - main
 


### PR DESCRIPTION
Follow up for adding translation to advisor-app on backend side https://github.com/grafana/grafana/pull/127654
We had a gap to upload the json we need to translate to crowdin 
