### PR TITLE
Docs: expand Git Sync folder README documentation

### DIFF
--- a/docs/sources/as-code/observability-as-code/git-sync/provisioned-dashboards.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/provisioned-dashboards.md
@@ -108,6 +108,12 @@ To restore a deleted dashboard, raise a PR directly in your Git repository. Rest
 
 You can document the contents or any other relevant piece of information of your provisioned folder in a `README.md` file stored alongside its resources in the repository. Grafana renders the README inline on the folder page, below the list of dashboards, so your team can see what's in the folder, how it's organized, and where to find the right dashboard without leaving Grafana.
 
+Common uses include:
+
+- **Runbooks**: Document how to respond to an alert or investigate an incident, with links to the dashboards teammates need.
+- **Architectural diagrams**: Show how the system a folder monitors fits together, using [Mermaid](#render-mermaid-diagrams) diagrams that render inline.
+- **Onboarding guidelines**: Explain what each dashboard is for and how a new team member should navigate the folder.
+
 - When the folder contains a `README.md` file, Grafana renders its Markdown content. Relative links and images in the README resolve against the host repository.
 - If the folder has no `README.md`, or if the folder is empty, you're prompted to action with an **Add README** button.
 - You can edit the README any time. Select the edit pencil in the README header to open the file in your Git provider's editor and commit changes through your usual workflow. When you have several documents, the edit pencil targets the document that's currently open.
@@ -127,7 +133,7 @@ A folder can hold more than one Markdown document. When it does, Grafana shows a
 - The README renders by default. Select a tab to load that document.
 - When there are more tabs than fit the width of the page, the extra tabs collapse into a **More** menu.
 
-Use this to keep related documentation, such as contribution guidelines or ownership details, next to the dashboards it describes.
+Use this to keep related documentation next to the dashboards it describes, such as a runbook, an onboarding guide, or contribution and ownership details in separate documents.
 
 ### Navigate to resources from Markdown links
 
@@ -139,7 +145,7 @@ Markdown links are context-aware. A link that points to a provisioned resource f
 
 ### Render Mermaid diagrams
 
-Grafana renders [Mermaid](https://mermaid.js.org/) diagrams defined in your Markdown documents. Use a fenced code block with the `mermaid` language to include a diagram:
+Grafana renders [Mermaid](https://mermaid.js.org/) diagrams defined in your Markdown documents. Use them to embed architectural diagrams, incident runbook flows, or data pipeline overviews next to the dashboards that monitor them. Use a fenced code block with the `mermaid` language to include a diagram:
 
 ````markdown
 ```mermaid
@@ -160,6 +166,6 @@ Follow these recommendations when working with provisioned dashboards:
 - **Provide clear commit messages**: Describe your changes to help with tracking and collaboration.
 - **Regularly sync your repository**: Keep Grafana up to date with the latest changes.
 - **Review the Events tab**: Monitor sync status to ensure changes are applied correctly.
-- **Add a folder README**: Document each folder's contents with a `README.md` so your teammates can find the right dashboard quickly.
+- **Add a folder README**: Document each folder's contents with a `README.md` so your teammates can find the right dashboard quickly. Use additional documents for runbooks, architectural diagrams, or onboarding guidelines that belong next to the dashboards.
 
 Refer to [Work with provisioned repositories](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/use-git-sync) for general guidance about using Git Sync.

--- a/docs/sources/as-code/observability-as-code/git-sync/provisioned-dashboards.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/provisioned-dashboards.md
@@ -154,7 +154,7 @@ flowchart LR
 ```
 ````
 
-Grafana replaces the code block with the rendered diagram and matches it to your light or dark theme. Documents without a Mermaid block aren't affected.
+Grafana replaces the code block with the rendered diagram and matches it to your light or dark theme.
 
 ## Best practices
 

--- a/docs/sources/as-code/observability-as-code/git-sync/provisioned-dashboards.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/provisioned-dashboards.md
@@ -109,14 +109,48 @@ To restore a deleted dashboard, raise a PR directly in your Git repository. Rest
 You can document the contents or any other relevant piece of information of your provisioned folder in a `README.md` file stored alongside its resources in the repository. Grafana renders the README inline on the folder page, below the list of dashboards, so your team can see what's in the folder, how it's organized, and where to find the right dashboard without leaving Grafana.
 
 - When the folder contains a `README.md` file, Grafana renders its Markdown content. Relative links and images in the README resolve against the host repository.
-- If the folder has no `README.md`, or if the folder is empty, you'll be prompted to action with a **Add README** button.
-- You can edit the README any time. Select the edit pencil in the README header to open the file in your Git provider's editor and commit changes through your usual workflow.
+- If the folder has no `README.md`, or if the folder is empty, you're prompted to action with an **Add README** button.
+- You can edit the README any time. Select the edit pencil in the README header to open the file in your Git provider's editor and commit changes through your usual workflow. When you have several documents, the edit pencil targets the document that's currently open.
 
 {{< admonition type="note" >}}
 
 It may take a few minutes for your changes to reflect on your screen. If they don't, refresh the UI manually.
 
 {{< /admonition >}}
+
+### Browse multiple documents with tabs
+
+A folder can hold more than one Markdown document. When it does, Grafana shows a tab for each document above the rendered content, similar to how a Git provider presents documentation files.
+
+- Grafana lists any `.md` and `.markdown` files stored alongside the folder's resources.
+- The `README`, `CONTRIBUTING.md`, and `SECURITY.md` files appear first, in that order, when they're present. All other documents follow in alphabetical order.
+- The README renders by default. Select a tab to load that document.
+- When there are more tabs than fit the width of the page, the extra tabs collapse into a **More** menu.
+
+Use this to keep related documentation, such as contribution guidelines or ownership details, next to the dashboards it describes.
+
+### Navigate to resources from Markdown links
+
+Markdown links are context-aware. A link that points to a provisioned resource file, such as a dashboard JSON file or a folder, resolves to the matching page inside Grafana when you select it. This lets you move between documentation and dashboards the same way you move between provisioned resources.
+
+- Links to resource files, such as dashboard JSON or YAML files and folder paths, open the corresponding dashboard or folder in Grafana.
+- Grafana resolves the link the first time you select a candidate link, then reuses that result for subsequent clicks. The resolved list refreshes after a sync completes, so links to newly added or renamed resources keep working.
+- When a link doesn't match a provisioned resource, Grafana falls back to the file in the host repository, so the same README still works when viewed on GitHub or GitLab.
+
+### Render Mermaid diagrams
+
+Grafana renders [Mermaid](https://mermaid.js.org/) diagrams defined in your Markdown documents. Use a fenced code block with the `mermaid` language to include a diagram:
+
+````markdown
+```mermaid
+flowchart LR
+  A[Ingest] --> B[Store]
+  B --> C[Query]
+  C --> D[Dashboard]
+```
+````
+
+Grafana replaces the code block with the rendered diagram and matches it to your light or dark theme. Documents without a Mermaid block aren't affected.
 
 ## Best practices
 

--- a/docs/sources/as-code/observability-as-code/git-sync/provisioned-dashboards.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/provisioned-dashboards.md
@@ -137,11 +137,9 @@ Use this to keep related documentation next to the dashboards it describes, such
 
 ### Navigate to resources from Markdown links
 
-Markdown links are context-aware. A link that points to a provisioned resource file, such as a dashboard JSON file or a folder, resolves to the matching page inside Grafana when you select it. This lets you move between documentation and dashboards the same way you move between provisioned resources.
+Markdown links are context-aware. A link that points to a provisioned resource file, such as a dashboard JSON file or a folder, opens the matching page inside Grafana when you select it. This lets you move between documentation and dashboards the same way you move between provisioned resources.
 
-- Links to resource files, such as dashboard JSON or YAML files and folder paths, open the corresponding dashboard or folder in Grafana.
-- Grafana resolves the link the first time you select a candidate link, then reuses that result for subsequent clicks. The resolved list refreshes after a sync completes, so links to newly added or renamed resources keep working.
-- When a link doesn't match a provisioned resource, Grafana falls back to the file in the host repository, so the same README still works when viewed on GitHub or GitLab.
+When a link doesn't match a provisioned resource, Grafana opens the file in the host repository, so the same README still works when viewed on GitHub or GitLab.
 
 ### Render Mermaid diagrams
 


### PR DESCRIPTION
## What

Expands the "Document folders with a README" section of the Git Sync provisioned dashboards docs to cover three upcoming enhancements to the provisioned-folder README feature:

- **Browse multiple documents with tabs** — GitHub-style doc tabs (`README`, `CONTRIBUTING.md`, `SECURITY.md` first, then alphabetical) with a **More** overflow menu.
- **Navigate to resources from Markdown links** — context-aware links that resolve to in-app dashboard/folder pages when clicked inside Grafana, with fallback to the host repository.
- **Render Mermaid diagrams** — theme-aware rendering of `mermaid` fenced code blocks, with an example.

Also clarifies that the edit pencil targets the currently open document.

## Why

The README feature is expanding across several PRs that improve in-app documentation and navigation. The user docs only described the base README rendering, so users had no guidance on tabs, in-app link navigation, or diagrams. This documents those capabilities ahead of the following PRs:

- grafana/grafana#128455 — context-aware Markdown links
- grafana/grafana#129073 — GitHub-style doc tabs
- grafana/grafana#129096 — Mermaid diagram rendering

The link-navigation change is the fourth PR in the series, giving Markdown links the same click-to-navigate behavior as provisioned resources.

## How

Documentation-only change. Restructured the single README section into subsections and followed the repository docs style guide (`docs/AGENTS.md`): sentence-case headings, present tense, active voice, and dash lists with bolded lead-ins.

## Testing

- Docs-only; no code paths affected.
- Verified Markdown structure and Hugo shortcodes render as expected.

## Checklist

- [ ] Tests added/updated (N/A — docs only)
- [x] Documentation updated
- [x] No breaking changes

🤖 Generated with Claude Code