### PR TITLE
I18n: Mark up Explore command palette actions for translations

### DIFF
--- a/public/app/features/explore/ExploreActions.tsx
+++ b/public/app/features/explore/ExploreActions.tsx
@@ -1,6 +1,7 @@
 import { useRegisterActions, useKBar, type Action, Priority } from 'kbar';
 import { useEffect, useState } from 'react';
 
+import { t } from '@grafana/i18n';
 import { contextSrv } from 'app/core/services/context_srv';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
 import { AccessControlAction } from 'app/types/accessControl';
@@ -23,7 +24,7 @@ export const ExploreActions = () => {
   useEffect(() => {
     const keys = Object.keys(panes);
     const exploreSection = {
-      name: 'Explore',
+      name: t('explore.explore-actions.section-explore', 'Explore'),
       priority: Priority.HIGH + 1,
     };
 
@@ -32,7 +33,7 @@ export const ExploreActions = () => {
     if (splitted) {
       actionsArr.push({
         id: 'explore/run-query-left',
-        name: 'Run query (left)',
+        name: t('explore.explore-actions.run-query-left', 'Run query (left)'),
         keywords: 'query left',
         perform: () => {
           dispatch(runQueries({ exploreId: keys[0] }));
@@ -43,7 +44,7 @@ export const ExploreActions = () => {
         // we should always have the right exploreId if split
         actionsArr.push({
           id: 'explore/run-query-right',
-          name: 'Run query (right)',
+          name: t('explore.explore-actions.run-query-right', 'Run query (right)'),
           keywords: 'query right',
           perform: () => {
             dispatch(runQueries({ exploreId: keys[1] }));
@@ -52,7 +53,7 @@ export const ExploreActions = () => {
         });
         actionsArr.push({
           id: 'explore/split-view-close-left',
-          name: 'Close split view left',
+          name: t('explore.explore-actions.close-split-view-left', 'Close split view left'),
           keywords: 'split',
           perform: () => {
             dispatch(splitClose(keys[0]));
@@ -61,7 +62,7 @@ export const ExploreActions = () => {
         });
         actionsArr.push({
           id: 'explore/split-view-close-right',
-          name: 'Close split view right',
+          name: t('explore.explore-actions.close-split-view-right', 'Close split view right'),
           keywords: 'split',
           perform: () => {
             dispatch(splitClose(keys[1]));
@@ -78,7 +79,7 @@ export const ExploreActions = () => {
       if (canWriteCorrelations && !hasMixed) {
         actionsArr.push({
           id: 'explore/correlations-editor',
-          name: 'Correlations editor',
+          name: t('explore.explore-actions.correlations-editor', 'Correlations editor'),
           perform: () => {
             dispatch(changeCorrelationEditorDetails({ editorMode: true }));
             dispatch(runQueries({ exploreId: keys[0] }));
@@ -89,7 +90,7 @@ export const ExploreActions = () => {
 
       actionsArr.push({
         id: 'explore/run-query',
-        name: 'Run query',
+        name: t('explore.explore-actions.run-query', 'Run query'),
         keywords: 'query',
         perform: () => {
           dispatch(runQueries({ exploreId: keys[0] }));
@@ -98,7 +99,7 @@ export const ExploreActions = () => {
       });
       actionsArr.push({
         id: 'explore/split-view-open',
-        name: 'Open split view',
+        name: t('explore.explore-actions.open-split-view', 'Open split view'),
         keywords: 'split',
         perform: () => {
           dispatch(splitOpen());

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8520,6 +8520,16 @@
       "title-table": "Table",
       "title-traces": "Traces"
     },
+    "explore-actions": {
+      "close-split-view-left": "Close split view left",
+      "close-split-view-right": "Close split view right",
+      "correlations-editor": "Correlations editor",
+      "open-split-view": "Open split view",
+      "run-query": "Run query",
+      "run-query-left": "Run query (left)",
+      "run-query-right": "Run query (right)",
+      "section-explore": "Explore"
+    },
     "explore-query-inspector": {
       "data-tab": {
         "label": {


### PR DESCRIPTION
**What is this feature?**

This PR adds internationalization (i18n) markup to `ExploreActions` in `public/app/features/explore/`.

This component registers Explore's entries in the command palette (kbar). The section label and all seven action names were hardcoded English strings, and are now wrapped with the `t()` macro from `@grafana/i18n`. The extracted keys have been added to the `en-US` catalog by running the extractor.

Strings marked up:

| Key | String |
| --- | --- |
| `explore.explore-actions.section-explore` | Explore |
| `explore.explore-actions.run-query` | Run query |
| `explore.explore-actions.run-query-left` | Run query (left) |
| `explore.explore-actions.run-query-right` | Run query (right) |
| `explore.explore-actions.open-split-view` | Open split view |
| `explore.explore-actions.close-split-view-left` | Close split view left |
| `explore.explore-actions.close-split-view-right` | Close split view right |
| `explore.explore-actions.correlations-editor` | Correlations editor |

`t()` is used rather than `<Trans />` because these strings are assigned to the `name` property of kbar action objects rather than rendered as JSX, per the guidance in `contribute/internationalization.md`.

**Why do we need this feature?**

When a user switches their Grafana profile language, the command palette still lists Explore's actions in hardcoded English. Marking these up allows the palette entries to be localized along with the rest of the UI.

Note that the `keywords` fields (e.g. `'query left'`) are intentionally left untouched — they are kbar search hints rather than displayed text, and marking them up is a separate concern.

**Who is this feature for?**

Grafana users who use the interface in a language other than English.

**Which issue(s) does this PR fix?**:

Part of the `/explore` internationalization effort under the epic issue #73984.

Following the maintainer guidance on that issue to split the work into small PRs covering one or two components each, this PR covers `ExploreActions` only. Companion PR #130981 covers `ErrorContainer`; `NoData` is already covered by #126913.

**Special notes for your reviewer:**

- Only `en-US/grafana.json` was touched among the translation files, and it was updated by running the extractor rather than by hand.
- The existing `ExploreActions.test.tsx` suite passes unchanged (2/2).
- `yarn typecheck`, `eslint`, and `prettier --check` all pass on the changed files.
