### PR TITLE
Home: polish overview cards and harden solution queries

### DIFF
--- a/public/app/features/home/Overview/Overview.test.tsx
+++ b/public/app/features/home/Overview/Overview.test.tsx
@@ -127,6 +127,36 @@ describe('Overview', () => {
     }
   });
 
+  it('handles the hash once and never overrides a later filter pick', async () => {
+    const scrollIntoView = jest.fn();
+    const originalScrollIntoView = window.HTMLElement.prototype.scrollIntoView;
+    window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+
+    try {
+      mockUseGuides.mockReturnValue(undefined);
+      const { user, rerender } = render(<Overview solutions={EMPTY_SOLUTIONS} />, {
+        historyOptions: { initialEntries: ['/#needs-attention'] },
+      });
+
+      await screen.findByText('No solutions need attention.');
+      expect(scrollIntoView).toHaveBeenCalledTimes(1);
+
+      await user.click(screen.getByRole('button', { name: /needs attention/i }));
+      await user.click(screen.getByRole('menuitem', { name: 'All solutions' }));
+      await screen.findByText('No solutions were found.');
+
+      // Guides settling rebuilds the options; the already-handled hash must not re-apply.
+      mockUseGuides.mockReturnValue([]);
+      rerender(<Overview solutions={EMPTY_SOLUTIONS} />);
+
+      expect(await screen.findByText('No solutions were found.')).toBeInTheDocument();
+      expect(screen.queryByText('No solutions need attention.')).not.toBeInTheDocument();
+      expect(scrollIntoView).toHaveBeenCalledTimes(1);
+    } finally {
+      window.HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+    }
+  });
+
   it('tracks overview filter changes from the dropdown', async () => {
     mockUseGuides.mockReturnValue([]);
 

--- a/public/app/features/home/Overview/Overview.test.tsx
+++ b/public/app/features/home/Overview/Overview.test.tsx
@@ -1,6 +1,7 @@
 import { act, render, screen, waitFor, within } from 'test/test-utils';
 
 import { type DataSourceInstanceListItem } from '@grafana/data';
+import { locationService } from '@grafana/runtime';
 
 import { ctaClicked } from '../analytics/main';
 import { type Solution, type SolutionId } from '../solutions/types';
@@ -152,6 +153,34 @@ describe('Overview', () => {
       expect(await screen.findByText('No solutions were found.')).toBeInTheDocument();
       expect(screen.queryByText('No solutions need attention.')).not.toBeInTheDocument();
       expect(scrollIntoView).toHaveBeenCalledTimes(1);
+    } finally {
+      window.HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+    }
+  });
+
+  it('clears the hash on an explicit filter pick and honors the next deep link', async () => {
+    const scrollIntoView = jest.fn();
+    const originalScrollIntoView = window.HTMLElement.prototype.scrollIntoView;
+    window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+
+    try {
+      const { user } = render(<Overview solutions={EMPTY_SOLUTIONS} />, {
+        historyOptions: { initialEntries: ['/#needs-attention'] },
+      });
+
+      await screen.findByText('No solutions need attention.');
+      expect(locationService.getLocation().hash).toBe('#needs-attention');
+
+      await user.click(screen.getByRole('button', { name: /needs attention/i }));
+      await user.click(screen.getByRole('menuitem', { name: 'All solutions' }));
+
+      await screen.findByText('No solutions were found.');
+      expect(locationService.getLocation().hash).toBe('');
+
+      // The cleared anchor must work again as a fresh deep link.
+      act(() => locationService.push('/#needs-attention'));
+      expect(await screen.findByText('No solutions need attention.')).toBeInTheDocument();
+      expect(scrollIntoView).toHaveBeenCalledTimes(2);
     } finally {
       window.HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
     }

--- a/public/app/features/home/Overview/Overview.test.tsx
+++ b/public/app/features/home/Overview/Overview.test.tsx
@@ -186,6 +186,22 @@ describe('Overview', () => {
     }
   });
 
+  it('clears an unrecognized anchor on an explicit filter pick', async () => {
+    const { user } = render(<Overview solutions={EMPTY_SOLUTIONS} />, {
+      historyOptions: { initialEntries: ['/?orgId=1#needs-aattention'] },
+    });
+
+    // The typo'd anchor selects nothing.
+    await screen.findByText('No solutions were found.');
+
+    await user.click(screen.getByRole('button', { name: /all solutions/i }));
+    await user.click(screen.getByRole('menuitem', { name: 'Enabled solutions' }));
+
+    await screen.findByText('No enabled solutions with recent activity were found.');
+    expect(locationService.getLocation().hash).toBe('');
+    expect(locationService.getLocation().search).toContain('orgId=1');
+  });
+
   it('tracks overview filter changes from the dropdown', async () => {
     mockUseGuides.mockReturnValue([]);
 

--- a/public/app/features/home/Overview/Overview.tsx
+++ b/public/app/features/home/Overview/Overview.tsx
@@ -5,6 +5,7 @@ import { useAsync } from 'react-use';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
+import { locationService } from '@grafana/runtime';
 import { type IconName, Button, Icon, Stack, Text, Dropdown, Menu, useTheme2, useStyles2 } from '@grafana/ui';
 import { useStoredString } from 'app/core/hooks/useStored';
 
@@ -110,9 +111,10 @@ export function Overview({ solutions }: OverviewProps) {
     if (location.hash === handledHash.current) {
       return;
     }
+    // Record even without a match so clearing the hash re-arms the same anchor for a later visit.
+    handledHash.current = location.hash;
     const match = options.find((o) => o.value === location.hash.slice(1));
     if (match) {
-      handledHash.current = location.hash;
       setStored(match.value);
       ref.current?.scrollIntoView({ behavior: 'smooth' });
     }
@@ -137,6 +139,12 @@ export function Overview({ solutions }: OverviewProps) {
               label={label}
               onClick={() => {
                 setStored(value);
+                // The hash is a one-shot deep link; an explicit pick supersedes it so a reload
+                // or shared URL does not resurrect the linked filter.
+                const current = locationService.getLocation();
+                if (options.some((o) => `#${o.value}` === current.hash)) {
+                  locationService.replace({ ...current, hash: '' });
+                }
                 ctaClicked({
                   surface: 'overview',
                   action: 'change_overview_filter',

--- a/public/app/features/home/Overview/Overview.tsx
+++ b/public/app/features/home/Overview/Overview.tsx
@@ -105,7 +105,7 @@ export function Overview({ solutions }: OverviewProps) {
   const location = useLocation();
   // Handle each hash value once: `options` rebuilds as cards and guides settle, and re-running
   // the match would re-scroll the page and override a filter the user picked in the meantime.
-  const handledHash = useRef<string>();
+  const handledHash = useRef<string | undefined>(undefined);
   useEffect(() => {
     if (location.hash === handledHash.current) {
       return;

--- a/public/app/features/home/Overview/Overview.tsx
+++ b/public/app/features/home/Overview/Overview.tsx
@@ -103,9 +103,16 @@ export function Overview({ solutions }: OverviewProps) {
 
   const ref = useRef<HTMLDivElement>(null);
   const location = useLocation();
+  // Handle each hash value once: `options` rebuilds as cards and guides settle, and re-running
+  // the match would re-scroll the page and override a filter the user picked in the meantime.
+  const handledHash = useRef<string>();
   useEffect(() => {
+    if (location.hash === handledHash.current) {
+      return;
+    }
     const match = options.find((o) => o.value === location.hash.slice(1));
     if (match) {
+      handledHash.current = location.hash;
       setStored(match.value);
       ref.current?.scrollIntoView({ behavior: 'smooth' });
     }

--- a/public/app/features/home/Overview/Overview.tsx
+++ b/public/app/features/home/Overview/Overview.tsx
@@ -139,10 +139,11 @@ export function Overview({ solutions }: OverviewProps) {
               label={label}
               onClick={() => {
                 setStored(value);
-                // The hash is a one-shot deep link; an explicit pick supersedes it so a reload
-                // or shared URL does not resurrect the linked filter.
+                // The hash is a one-shot deep link and nothing else on this route reads
+                // fragments, so an explicit pick clears whatever anchor is present — including
+                // typo'd or outdated ones that would otherwise linger looking broken.
                 const current = locationService.getLocation();
-                if (options.some((o) => `#${o.value}` === current.hash)) {
+                if (current.hash) {
                   locationService.replace({ ...current, hash: '' });
                 }
                 ctaClicked({

--- a/public/app/features/home/Overview/SolutionCard.tsx
+++ b/public/app/features/home/Overview/SolutionCard.tsx
@@ -82,7 +82,6 @@ export function SolutionCard({ solution, needsAttention }: SolutionCardProps) {
         ) : cta ? (
           <LinkButton
             href={cta.href}
-
             fill="text"
             size="sm"
             icon="angle-right"

--- a/public/app/features/home/Overview/SolutionCard.tsx
+++ b/public/app/features/home/Overview/SolutionCard.tsx
@@ -22,6 +22,7 @@ export function SolutionCard({ solution, needsAttention }: SolutionCardProps) {
     [needsAttention, solution]
   );
   const { value: cta = null, loading: ctaLoading } = useAsync(() => solution.cta(), [solution]);
+  const { value: datasource = null } = useAsync(() => solution.datasource(), [solution]);
   const styles = useStyles2(getStyles, needsAttention);
   const isAttentionCta = cta?.action === 'view_alerts';
   const status = needsAttention
@@ -44,6 +45,13 @@ export function SolutionCard({ solution, needsAttention }: SolutionCardProps) {
               <Text variant="bodySmall" color="secondary">
                 {status}
               </Text>
+              {datasource && (
+                <span className={styles.viaDatasource}>
+                  <Text variant="bodySmall" color="secondary" truncate>
+                    {t('home.solutions.via-datasource', 'via {{name}}', { name: datasource.name })}
+                  </Text>
+                </span>
+              )}
             </Stack>
           </Stack>
         </Stack>
@@ -234,6 +242,17 @@ const getStyles = (theme: GrafanaTheme2, needsAttention: boolean) => ({
     borderRadius: theme.shape.radius.circle,
     background: needsAttention ? theme.colors.warning.main : theme.colors.success.main,
     flexShrink: 0,
+  }),
+  viaDatasource: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    minWidth: 0,
+
+    '&::before': {
+      content: '"·"',
+      color: theme.colors.text.secondary,
+    },
   }),
   content: css({
     display: 'flex',

--- a/public/app/features/home/Overview/SolutionCard.tsx
+++ b/public/app/features/home/Overview/SolutionCard.tsx
@@ -37,7 +37,7 @@ export function SolutionCard({ solution, needsAttention }: SolutionCardProps) {
             <Icon name={solution.icon} size="lg" />
           </div>
           <Stack direction="column" gap={0}>
-            <Text element="h3" variant="h5">
+            <Text element="h3" variant="h6">
               {solution.title}
             </Text>
             <Stack direction="row" gap={1} alignItems="center">
@@ -62,6 +62,7 @@ export function SolutionCard({ solution, needsAttention }: SolutionCardProps) {
           stats={solution.stats}
           refinedStats={solution.refinedStats}
           sparkline={solution.sparkline}
+          compact
           gap={3}
         />
 
@@ -81,6 +82,7 @@ export function SolutionCard({ solution, needsAttention }: SolutionCardProps) {
         ) : cta ? (
           <LinkButton
             href={cta.href}
+
             fill="text"
             size="sm"
             icon="angle-right"
@@ -124,7 +126,7 @@ export function AvailableSolutionCard({ solution, offer }: AvailableSolutionCard
             <Icon name={solution.icon} size="lg" />
           </div>
           <Stack direction="column" gap={0}>
-            <Text element="h3" variant="h5">
+            <Text element="h3" variant="h6">
               {solution.title}
             </Text>
             <Text variant="bodySmall" color="secondary">
@@ -183,13 +185,13 @@ export function SolutionCardSkeleton() {
         <Stack direction="row" gap={1.5} alignItems="center">
           <Skeleton width={32} height={32} />
           <Stack direction="column" gap={0}>
-            <Skeleton width={180} height={20} />
+            <Skeleton width={180} height={18} />
             <Skeleton width={80} />
           </Stack>
         </Stack>
       </Card.Heading>
       <Card.Description className={styles.content}>
-        <Skeleton width={130} height={32} />
+        <Skeleton width={130} height={24} />
         <Skeleton width="100%" height={20} />
       </Card.Description>
       <Card.Actions>
@@ -202,7 +204,7 @@ export function SolutionCardSkeleton() {
 const getStyles = (theme: GrafanaTheme2, needsAttention: boolean) => ({
   card: css({
     height: '100%',
-    minHeight: theme.spacing(30),
+    minHeight: theme.spacing(22),
     background: theme.colors.background.canvas,
     border: `1px solid ${theme.colors.border.weak}`,
     ...(needsAttention && {

--- a/public/app/features/home/Overview/SolutionCard.tsx
+++ b/public/app/features/home/Overview/SolutionCard.tsx
@@ -145,31 +145,33 @@ export function AvailableSolutionCard({ solution, offer }: AvailableSolutionCard
 
       {(cta || offer.learnMore) && (
         <Card.Actions>
-          {cta && (
-            <LinkButton
-              href={cta.href}
-              variant="secondary"
-              size="sm"
-              onClick={() =>
-                ctaClicked({
-                  surface: 'overview',
-                  action: cta.action,
-                  placement: 'card',
-                  solution: solution.id,
-                })
-              }
-            >
-              {cta.label}
-            </LinkButton>
-          )}
-          {offer.learnMore && (
-            <LearnMoreLink
-              {...offer.learnMore}
-              onClick={() =>
-                ctaClicked({ surface: 'overview', action: 'learn_more', placement: 'card', solution: solution.id })
-              }
-            />
-          )}
+          <Stack gap={2} alignItems="center">
+            {cta && (
+              <LinkButton
+                href={cta.href}
+                variant="secondary"
+                size="sm"
+                onClick={() =>
+                  ctaClicked({
+                    surface: 'overview',
+                    action: cta.action,
+                    placement: 'card',
+                    solution: solution.id,
+                  })
+                }
+              >
+                {cta.label}
+              </LinkButton>
+            )}
+            {offer.learnMore && (
+              <LearnMoreLink
+                {...offer.learnMore}
+                onClick={() =>
+                  ctaClicked({ surface: 'overview', action: 'learn_more', placement: 'card', solution: solution.id })
+                }
+              />
+            )}
+          </Stack>
         </Card.Actions>
       )}
     </Card>

--- a/public/app/features/home/Overview/useGuides.ts
+++ b/public/app/features/home/Overview/useGuides.ts
@@ -125,7 +125,7 @@ export function useGuides() {
         icon: 'open-telemetry',
         color: theme.visualization.getColorByName('blue'),
         cta: t('home.overview.get-started.cards.opentelemetry.cta', 'Start setup'),
-        href: '/a/grafana-setupguide-app/getting-started/opentelemetry',
+        href: '/a/grafana-setupguide-app/getting-started/otel',
       },
       {
         id: 'kubernetes',

--- a/public/app/features/home/solutions/SolutionStatsRow.tsx
+++ b/public/app/features/home/solutions/SolutionStatsRow.tsx
@@ -13,6 +13,8 @@ interface SolutionStatsRowProps {
   /** Optional replacement for the base stats when richer data resolves. */
   refinedStats: () => Promise<SolutionStats | null>;
   sparkline: () => Promise<SolutionSparklineData | null>;
+  /** Overview cards render denser stats; the recommendations card keeps the large defaults. */
+  compact?: boolean;
   gap?: ComponentProps<typeof Stack>['gap'];
   statsTestId?: string;
   sparklineTestId?: string;
@@ -23,6 +25,7 @@ export function SolutionStatsRow({
   refinedStats,
   sparkline,
   gap = 2,
+  compact = false,
   statsTestId,
   sparklineTestId,
 }: SolutionStatsRowProps) {
@@ -45,16 +48,16 @@ export function SolutionStatsRow({
         <div className={styles.stats}>
           {resolvedStats === null ? (
             <Stack direction="column" gap={0} data-testid={statsTestId}>
-              <Skeleton width={96} height={28} />
+              <Skeleton width={96} height={compact ? 22 : 28} />
               <Skeleton width={72} />
             </Stack>
           ) : (
             <Stack direction="column" gap={0}>
-              <Text variant="h2" color="primary">
+              <Text variant={compact ? 'h3' : 'h2'} color="primary">
                 {resolvedStats.primary}
               </Text>
               {resolvedStats.secondary && (
-                <Text variant="body" color="secondary">
+                <Text variant={compact ? 'bodySmall' : 'body'} color="secondary">
                   {resolvedStats.secondary}
                 </Text>
               )}

--- a/public/app/features/home/solutions/kubernetesSolution.ts
+++ b/public/app/features/home/solutions/kubernetesSolution.ts
@@ -14,6 +14,7 @@ import {
   type KubernetesHealth,
 } from './kubernetesData';
 import { accessibleAppPage, openAppLabel, openExploreLabel } from './pluginPages';
+import { datasourceFact } from './probeUtils';
 import { solutionOffer } from './solutionOffer';
 import { detectSignal } from './solutionState';
 import { type Solution } from './types';
@@ -61,18 +62,9 @@ export function kubernetesSolution(): Solution {
   const detect = memoize(() => detectSignal(resolveKubernetesDatasource));
   const datasource = async () => (await detect()).datasource;
 
-  const inventory = memoize(async () => {
-    const ds = await datasource();
-    return ds ? fetchKubernetesInventory(ds) : null;
-  });
-  const health = memoize(async () => {
-    const ds = await datasource();
-    return ds ? fetchKubernetesHealth(ds) : null;
-  });
-  const clusterCpu = memoize(async () => {
-    const ds = await datasource();
-    return ds ? fetchClusterCpuSeries(ds) : null;
-  });
+  const inventory = datasourceFact(datasource, fetchKubernetesInventory);
+  const health = datasourceFact(datasource, fetchKubernetesHealth);
+  const clusterCpu = datasourceFact(datasource, fetchClusterCpuSeries);
   const alert = memoize(async () => {
     const status = await health();
     if (!status || hasHealthProblems(status) !== true) {

--- a/public/app/features/home/solutions/logsSolution.ts
+++ b/public/app/features/home/solutions/logsSolution.ts
@@ -5,6 +5,7 @@ import { t } from '@grafana/i18n';
 
 import { LOGS_DRILLDOWN_APP_ID } from './appPluginIds';
 import { drilldownActiveCta } from './pluginPages';
+import { datasourceFact } from './probeUtils';
 import { CLOUD_UTILITY_LOKI_DATASOURCE_UIDS, labelRecencyProbe, probeFound } from './solutionDataProbes';
 import { solutionOffer } from './solutionOffer';
 import { detectSignal } from './solutionState';
@@ -21,10 +22,7 @@ export function logsSolution(): Solution {
   );
   const datasource = async () => (await detect()).datasource;
 
-  const activity = memoize(async () => {
-    const ds = await datasource();
-    return ds ? fetchLogsActivity(ds) : null;
-  });
+  const activity = datasourceFact(datasource, fetchLogsActivity);
 
   const signal = async () => (await detect()).status;
 

--- a/public/app/features/home/solutions/metricsSolution.ts
+++ b/public/app/features/home/solutions/metricsSolution.ts
@@ -13,6 +13,7 @@ import { t } from '@grafana/i18n';
 import { METRICS_DRILLDOWN_APP_ID } from './appPluginIds';
 import { resolveKubernetesDatasource } from './kubernetesData';
 import { drilldownActiveCta } from './pluginPages';
+import { datasourceFact } from './probeUtils';
 import { CLOUD_UTILITY_PROM_DATASOURCE_UIDS, probeFound, prometheusHasRecentMetrics } from './solutionDataProbes';
 import { solutionOffer } from './solutionOffer';
 import { detectSignal, type SignalDetection } from './solutionState';
@@ -71,14 +72,8 @@ export function metricsSolution(): Solution {
   });
   const datasource = async () => (await detect()).datasource;
 
-  const activity = memoize(async () => {
-    const ds = await datasource();
-    return ds ? fetchMetricsActivity(ds) : null;
-  });
-  const diskPressure = memoize(async () => {
-    const ds = await datasource();
-    return ds ? fetchMetricsDiskPressure(ds) : null;
-  });
+  const activity = datasourceFact(datasource, fetchMetricsActivity);
+  const diskPressure = datasourceFact(datasource, fetchMetricsDiskPressure);
   const diskHoursToFull = memoize(async () => {
     const ds = await datasource();
     const disk = await diskPressure();

--- a/public/app/features/home/solutions/metricsSolution.ts
+++ b/public/app/features/home/solutions/metricsSolution.ts
@@ -13,7 +13,7 @@ import { t } from '@grafana/i18n';
 import { METRICS_DRILLDOWN_APP_ID } from './appPluginIds';
 import { resolveKubernetesDatasource } from './kubernetesData';
 import { drilldownActiveCta } from './pluginPages';
-import { CLOUD_UTILITY_PROM_DATASOURCE_UIDS, labelRecencyProbe, probeFound } from './solutionDataProbes';
+import { CLOUD_UTILITY_PROM_DATASOURCE_UIDS, probeFound, prometheusHasRecentMetrics } from './solutionDataProbes';
 import { solutionOffer } from './solutionOffer';
 import { detectSignal, type SignalDetection } from './solutionState';
 import {
@@ -26,8 +26,6 @@ import { getTelemetrySetupCta, getTelemetrySetupLearnMore } from './telemetrySet
 import { type Solution } from './types';
 
 const formatUsageNumber = getValueFormat('short');
-
-const prometheusHasRecentLabels = labelRecencyProbe('api/v1/labels', (ms) => Math.floor(ms / 1000));
 
 function diskPressureExploreHref(ds: Pick<DataSourceInstanceListItem, 'uid' | 'type'>): string {
   return urlUtil.renderUrl(locationUtil.assureBaseUrl('/explore'), {
@@ -47,7 +45,7 @@ function diskPressureExploreHref(ds: Pick<DataSourceInstanceListItem, 'uid' | 't
 
 export function metricsSolution(): Solution {
   const prometheus = memoize(() =>
-    detectSignal(() => probeFound('prometheus', prometheusHasRecentLabels, CLOUD_UTILITY_PROM_DATASOURCE_UIDS))
+    detectSignal(() => probeFound('prometheus', prometheusHasRecentMetrics, CLOUD_UTILITY_PROM_DATASOURCE_UIDS))
   );
   // Kubernetes telemetry is Prometheus data, so it proves metrics too. Keep this as an independent
   // probe so the metrics solution does not depend on the Kubernetes card.

--- a/public/app/features/home/solutions/probeUtils.ts
+++ b/public/app/features/home/solutions/probeUtils.ts
@@ -1,6 +1,32 @@
+import memoize from 'micro-memoize';
+
 import { type DataSourceInstanceListItem } from '@grafana/data';
 import { DataSourceWithBackend, getBackendSrv } from '@grafana/runtime';
 import { getDataSourceInstance, getDataSourceInstanceList } from '@grafana/runtime/unstable';
+
+/**
+ * A lazily-started, shared solution fact derived from the solution's datasource: the first read
+ * resolves the datasource and starts `fetch`; every reader shares that one run. No datasource
+ * (solution not live) reads as null without starting the query.
+ */
+export function datasourceFact<T>(
+  datasource: () => Promise<DataSourceInstanceListItem | null>,
+  fetch: (ds: DataSourceInstanceListItem) => Promise<T | null>,
+  {
+    retryOnError = false,
+  }: {
+    /** Evict rejections so a later reader retries instead of sharing the cached failure. */
+    retryOnError?: boolean;
+  } = {}
+): () => Promise<T | null> {
+  return memoize(
+    async () => {
+      const ds = await datasource();
+      return ds ? fetch(ds) : null;
+    },
+    { isPromise: retryOnError }
+  );
+}
 
 /** Cap the probe fan-out: only the first N candidates (in priority order) are probed per page load. */
 export const MAX_PROBED_DATASOURCES = 10;

--- a/public/app/features/home/solutions/probeUtils.ts
+++ b/public/app/features/home/solutions/probeUtils.ts
@@ -37,9 +37,14 @@ export async function resolveBackendInstance(uid: string): Promise<DataSourceWit
  * GET through the classic datasource proxy, timeout-bounded, never toasts. Some datasource
  * backends (e.g. Tempo) serve their HTTP API only here, not on the resource router.
  */
-export async function probeProxyGet<T>(uid: string, path: string, params: Record<string, unknown>): Promise<T> {
+export async function probeProxyGet<T>(
+  uid: string,
+  path: string,
+  params: Record<string, unknown>,
+  timeoutMs = PROBE_TIMEOUT_MS
+): Promise<T> {
   const url = `/api/datasources/proxy/uid/${encodeURIComponent(uid)}/${path}`;
-  return withTimeout(getBackendSrv().get<T>(url, params, undefined, { showErrorAlert: false }), PROBE_TIMEOUT_MS);
+  return withTimeout(getBackendSrv().get<T>(url, params, undefined, { showErrorAlert: false }), timeoutMs);
 }
 
 /** Rejects when `promise` outlasts `ms`; the underlying request keeps running but stops gating the caller. */

--- a/public/app/features/home/solutions/probeUtils.ts
+++ b/public/app/features/home/solutions/probeUtils.ts
@@ -44,13 +44,10 @@ const HEALTH_CHECK_TIMEOUT_MS = 3000;
 // (billing/ML) carry exact unprefixed names; Loki utilities (query logs, alert history) are
 // provisioned with stack-prefixed names (grafanacloud-<slug>-usage-insights) over stable
 // unprefixed uids, so the name check matches both forms.
-const CLOUD_UTILITY_DATASOURCE_NAMES: Record<string, true> = {
-  'grafanacloud-usage': true,
-  'grafanacloud-ml-metrics': true,
-};
+const CLOUD_UTILITY_DATASOURCE_NAMES: ReadonlySet<string> = new Set(['grafanacloud-usage', 'grafanacloud-ml-metrics']);
 const CLOUD_UTILITY_LOKI_NAME_PATTERN = /^grafanacloud-(.+-)?(usage-insights|alert-state-history)$/;
 function isCloudUtilityDatasourceName(name: string): boolean {
-  return Boolean(CLOUD_UTILITY_DATASOURCE_NAMES[name]) || CLOUD_UTILITY_LOKI_NAME_PATTERN.test(name);
+  return CLOUD_UTILITY_DATASOURCE_NAMES.has(name) || CLOUD_UTILITY_LOKI_NAME_PATTERN.test(name);
 }
 
 /** Backend-capable datasource instance for `uid`, or null when it cannot serve resource calls. */

--- a/public/app/features/home/solutions/solutionDataProbes.test.ts
+++ b/public/app/features/home/solutions/solutionDataProbes.test.ts
@@ -3,7 +3,7 @@ import { type BackendSrv, DataSourceWithBackend, getBackendSrv } from '@grafana/
 import { getDataSourceInstance, getDataSourceInstanceList } from '@grafana/runtime/unstable';
 
 import { resetProbeCandidates } from './probeUtils';
-import { labelRecencyProbe, probeFound, tempoHasTraces } from './solutionDataProbes';
+import { labelRecencyProbe, probeFound, prometheusHasRecentMetrics, tempoHasTraces } from './solutionDataProbes';
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
@@ -151,6 +151,25 @@ describe('labelRecencyProbe', () => {
     const hasRecentLabels = labelRecencyProbe('labels', (ms) => ms);
 
     await expect(hasRecentLabels(datasource('loki'))).resolves.toBe(false);
+  });
+});
+
+describe('prometheusHasRecentMetrics', () => {
+  it('ignores alert-state series but counts real telemetry', async () => {
+    const getResource = jest.fn().mockResolvedValue({ data: ['ALERTS', 'ALERTS_FOR_STATE', 'GRAFANA_ALERTS'] });
+    mockInstance.mockResolvedValue(backendInstance(getResource));
+
+    await expect(prometheusHasRecentMetrics(datasource('prometheus'))).resolves.toBe(false);
+
+    getResource.mockResolvedValue({ data: ['ALERTS', 'node_uname_info'] });
+    await expect(prometheusHasRecentMetrics(datasource('prometheus'))).resolves.toBe(true);
+  });
+
+  it('counts metric names that collide with Object.prototype properties', async () => {
+    const getResource = jest.fn().mockResolvedValue({ data: ['constructor'] });
+    mockInstance.mockResolvedValue(backendInstance(getResource));
+
+    await expect(prometheusHasRecentMetrics(datasource('prometheus'))).resolves.toBe(true);
   });
 });
 

--- a/public/app/features/home/solutions/solutionDataProbes.ts
+++ b/public/app/features/home/solutions/solutionDataProbes.ts
@@ -60,7 +60,7 @@ export function labelRecencyProbe(path: string, toEpoch: (ms: number) => number)
 
 // Rule-evaluation output, not ingested telemetry: Prometheus writes these for its own alert
 // rules, and Grafana's alert-state export can be the only content of an otherwise empty tenant.
-const ALERT_STATE_METRIC_NAMES: Record<string, true> = { ALERTS: true, ALERTS_FOR_STATE: true };
+const ALERT_STATE_METRIC_NAMES: ReadonlySet<string> = new Set(['ALERTS', 'ALERTS_FOR_STATE']);
 
 /**
  * True when the datasource saw a recent metric name beyond alert-state series. Same index-only
@@ -80,7 +80,9 @@ export async function prometheusHasRecentMetrics(ds: DataSourceInstanceListItem)
   const grafanaAlertMetric = config.unifiedAlerting.stateHistory?.prometheusMetricName ?? 'GRAFANA_ALERTS';
   return (
     Array.isArray(res?.data) &&
-    res.data.some((name) => typeof name === 'string' && name !== grafanaAlertMetric && !ALERT_STATE_METRIC_NAMES[name])
+    res.data.some(
+      (name) => typeof name === 'string' && name !== grafanaAlertMetric && !ALERT_STATE_METRIC_NAMES.has(name)
+    )
   );
 }
 

--- a/public/app/features/home/solutions/solutionDataProbes.ts
+++ b/public/app/features/home/solutions/solutionDataProbes.ts
@@ -1,4 +1,5 @@
 import { type DataSourceInstanceListItem } from '@grafana/data';
+import { config } from '@grafana/runtime';
 
 import {
   findDatasourceWithData,
@@ -55,6 +56,32 @@ export function labelRecencyProbe(path: string, toEpoch: (ms: number) => number)
     // Loki responds data: null when empty (and Prometheus data: [] — same emptiness test).
     return Array.isArray(res?.data) && res.data.length > 0;
   };
+}
+
+// Rule-evaluation output, not ingested telemetry: Prometheus writes these for its own alert
+// rules, and Grafana's alert-state export can be the only content of an otherwise empty tenant.
+const ALERT_STATE_METRIC_NAMES: Record<string, true> = { ALERTS: true, ALERTS_FOR_STATE: true };
+
+/**
+ * True when the datasource saw a recent metric name beyond alert-state series. Same index-only
+ * cost as the labels probe, but a tenant holding only exported alert state reads as inactive.
+ */
+export async function prometheusHasRecentMetrics(ds: DataSourceInstanceListItem): Promise<boolean> {
+  const instance = await resolveBackendInstance(ds.uid);
+  if (!instance) {
+    return false;
+  }
+  const end = Math.floor(Date.now() / 1000);
+  const start = end - DATA_LOOKBACK_HOURS * 3600;
+  const res = await withTimeout(
+    instance.getResource<{ data?: unknown }>('api/v1/label/__name__/values', { start, end }, { showErrorAlert: false }),
+    PROBE_TIMEOUT_MS
+  );
+  const grafanaAlertMetric = config.unifiedAlerting.stateHistory?.prometheusMetricName ?? 'GRAFANA_ALERTS';
+  return (
+    Array.isArray(res?.data) &&
+    res.data.some((name) => typeof name === 'string' && name !== grafanaAlertMetric && !ALERT_STATE_METRIC_NAMES[name])
+  );
 }
 
 interface TempoSearchResponse {

--- a/public/app/features/home/solutions/telemetryData.test.ts
+++ b/public/app/features/home/solutions/telemetryData.test.ts
@@ -8,7 +8,7 @@ import {
 import { type BackendSrv, type DataSourceWithBackend, getBackendSrv } from '@grafana/runtime';
 import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 
-import { PROBE_TIMEOUT_MS, resolveBackendInstance } from './probeUtils';
+import { resolveBackendInstance } from './probeUtils';
 import { runInstantQueries, runRangeQuery } from './promQuery';
 import {
   fetchLogsActivity,
@@ -455,7 +455,7 @@ describe('metrics telemetry', () => {
     expect(mockRunInstantQueries).toHaveBeenCalledWith(
       { eta: expect.stringContaining('instance="web-03:9100",mountpoint="/data"') },
       prom,
-      PROBE_TIMEOUT_MS
+      30_000
     );
   });
 

--- a/public/app/features/home/solutions/telemetryData.ts
+++ b/public/app/features/home/solutions/telemetryData.ts
@@ -23,6 +23,11 @@ export const METRICS_STATS_LOOKBACK_DAYS = 7;
 const NS_IN_MS = 1e6;
 const NS_IN_S = 1e9;
 
+// Card details load after placement and only hold their own skeleton, so they get a larger
+// budget than the placement-gating probes: a cold TraceQL-metrics scan on a busy tenant
+// takes well over 10s, and the disk-pressure alert query can be similarly slow.
+const DETAIL_QUERY_TIMEOUT_MS = 30_000;
+
 export interface LogsActivity {
   bytes: number | null;
   sources: number | null;
@@ -134,10 +139,12 @@ export async function fetchLogsActivity(ds: Pick<DataSourceInstanceListItem, 'ui
 export async function fetchTracesServices(ds: Pick<DataSourceInstanceListItem, 'uid'>): Promise<number | null> {
   const end = Math.floor(Date.now() / 1000);
   const start = end - DATA_LOOKBACK_HOURS * 3600;
-  const res = await probeProxyGet<TempoTagValuesResponse>(ds.uid, 'api/v2/search/tag/resource.service.name/values', {
-    start,
-    end,
-  });
+  const res = await probeProxyGet<TempoTagValuesResponse>(
+    ds.uid,
+    'api/v2/search/tag/resource.service.name/values',
+    { start, end },
+    DETAIL_QUERY_TIMEOUT_MS
+  );
   return Array.isArray(res?.tagValues) ? res.tagValues.length : null;
 }
 
@@ -158,12 +165,17 @@ function isTempoV2MetricsDurationError(error: unknown): boolean {
 }
 
 function queryTracesActivity(dsUid: string, end: number, lookbackHours: number): Promise<TempoQueryRangeResponse> {
-  return probeProxyGet<TempoQueryRangeResponse>(dsUid, 'api/metrics/query_range', {
-    q: '{} | count_over_time()',
-    start: end - lookbackHours * 3600,
-    end,
-    step: '30m',
-  });
+  return probeProxyGet<TempoQueryRangeResponse>(
+    dsUid,
+    'api/metrics/query_range',
+    {
+      q: '{} | count_over_time()',
+      start: end - lookbackHours * 3600,
+      end,
+      step: '30m',
+    },
+    DETAIL_QUERY_TIMEOUT_MS
+  );
 }
 
 /**
@@ -229,7 +241,6 @@ export interface MetricsActivity {
 // Threshold and ETA clamp for the disk-pressure alert row (design/judgment constants).
 const DISK_PRESSURE_RATIO = 0.9;
 const DISK_ETA_MAX_HOURS = 48;
-const METRICS_ALERT_TIMEOUT_MS = 30_000;
 
 const FS_EXCLUDE = 'fstype!~"tmpfs|overlay|squashfs|iso9660|ramfs"';
 // Per-filesystem fill ratio; pseudo filesystems excluded.
@@ -290,7 +301,7 @@ export async function fetchMetricsDiskPressure(
       diskWorst: `topk(1, ${FS_USED})`,
     },
     ds,
-    METRICS_ALERT_TIMEOUT_MS,
+    DETAIL_QUERY_TIMEOUT_MS,
     true
   ).catch(() => null);
   if (!frames) {

--- a/public/app/features/home/solutions/telemetryData.ts
+++ b/public/app/features/home/solutions/telemetryData.ts
@@ -10,7 +10,7 @@ import { type DataSourceWithBackend, isFetchError } from '@grafana/runtime';
 import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { PromApplication } from 'app/types/unified-alerting-dto';
 
-import { probeProxyGet, PROBE_TIMEOUT_MS, resolveBackendInstance, withTimeout } from './probeUtils';
+import { probeProxyGet, resolveBackendInstance, withTimeout } from './probeUtils';
 import { readLabeledScalar, readScalar, readSeries, runInstantQueries, runRangeQuery } from './promQuery';
 import { DATA_LOOKBACK_HOURS } from './solutionDataProbes';
 
@@ -54,7 +54,7 @@ interface TempoTagValuesResponse {
 
 // Failures are expected (endpoint disabled, 403s) and handled by the caller; never toast.
 function getResource<T>(instance: DataSourceWithBackend, path: string, params: Record<string, unknown>): Promise<T> {
-  return withTimeout(instance.getResource<T>(path, params, { showErrorAlert: false }), PROBE_TIMEOUT_MS);
+  return withTimeout(instance.getResource<T>(path, params, { showErrorAlert: false }), DETAIL_QUERY_TIMEOUT_MS);
 }
 
 // Points are [unix ms, value]; a real trend needs at least two of them.
@@ -285,7 +285,7 @@ export async function fetchMetricsDiskHoursToFull(
       eta: `min((node_filesystem_avail_bytes${selector} / -deriv(node_filesystem_avail_bytes${selector}[6h])) > 0) / 3600`,
     },
     ds,
-    PROBE_TIMEOUT_MS
+    DETAIL_QUERY_TIMEOUT_MS
   )
     .then((frames) => readScalar(frames, 'eta'))
     .catch(() => null);

--- a/public/app/features/home/solutions/tracesSolution.ts
+++ b/public/app/features/home/solutions/tracesSolution.ts
@@ -41,14 +41,22 @@ export function tracesSolution(): Solution {
   const detect = memoize(() => detectSignal(() => probeFound('tempo', tempoHasTraces)));
   const datasource = async () => (await detect()).datasource;
 
-  const activity = memoize(async () => {
-    const ds = await datasource();
-    return ds ? fetchTracesActivity(ds) : null;
-  });
-  const services = memoize(async () => {
-    const ds = await datasource();
-    return ds ? fetchTracesServices(ds) : null;
-  });
+  // isPromise: a timed-out or failed query must not cache its rejection for the whole visit —
+  // the abandoned request still warms Tempo's query cache, so a later reader's retry succeeds.
+  const activity = memoize(
+    async () => {
+      const ds = await datasource();
+      return ds ? fetchTracesActivity(ds) : null;
+    },
+    { isPromise: true }
+  );
+  const services = memoize(
+    async () => {
+      const ds = await datasource();
+      return ds ? fetchTracesServices(ds) : null;
+    },
+    { isPromise: true }
+  );
 
   const signal = async () => (await detect()).status;
 

--- a/public/app/features/home/solutions/tracesSolution.ts
+++ b/public/app/features/home/solutions/tracesSolution.ts
@@ -5,6 +5,7 @@ import { t } from '@grafana/i18n';
 
 import { HOSTED_TRACES_APP_ID } from './appPluginIds';
 import { drilldownActiveCta } from './pluginPages';
+import { datasourceFact } from './probeUtils';
 import { probeFound, tempoHasTraces } from './solutionDataProbes';
 import { solutionOffer } from './solutionOffer';
 import { detectSignal } from './solutionState';
@@ -41,22 +42,10 @@ export function tracesSolution(): Solution {
   const detect = memoize(() => detectSignal(() => probeFound('tempo', tempoHasTraces)));
   const datasource = async () => (await detect()).datasource;
 
-  // isPromise: a timed-out or failed query must not cache its rejection for the whole visit —
+  // retryOnError: a timed-out or failed query must not cache its rejection for the whole visit —
   // the abandoned request still warms Tempo's query cache, so a later reader's retry succeeds.
-  const activity = memoize(
-    async () => {
-      const ds = await datasource();
-      return ds ? fetchTracesActivity(ds) : null;
-    },
-    { isPromise: true }
-  );
-  const services = memoize(
-    async () => {
-      const ds = await datasource();
-      return ds ? fetchTracesServices(ds) : null;
-    },
-    { isPromise: true }
-  );
+  const activity = datasourceFact(datasource, fetchTracesActivity, { retryOnError: true });
+  const services = datasourceFact(datasource, fetchTracesServices, { retryOnError: true });
 
   const signal = async () => (await detect()).status;
 


### PR DESCRIPTION
**What is this feature?**

Follow-up to https://github.com/grafana/grafana/pull/130439:

- Give post-placement detail queries (stats, sparklines, Tempo service counts, disk pressure) their own 30s budget, separate from the 10s placement-gating probes; `probeProxyGet` and the resource-router helpers now take a per-call timeout.
- Show the backing datasource ("via <name>") on live overview solution cards.
- Compact the cards to the visual-refresh mockup: h6 titles, smaller stats row, small CTA, tighter min-height; align the available-card action row.
- Detect metrics by recent metric names and ignore alert-state series (`ALERTS`, `ALERTS_FOR_STATE`, and Grafana's alert-state export), so a Mimir tenant holding only exported alert state no longer classifies as active metrics.
- Handle overview hash anchors (`/#needs-attention`, `/#get-started`) exactly once: cards/guides settling no longer re-scrolls the page or overrides a filter the user picked while loading.
- Clear the hash when the user explicitly picks a filter — the hash is a one-shot deep link, so a reload or shared URL no longer resurrects the linked filter; the same anchor works again as a fresh deep link afterwards.
