### PR TITLE
Datasources: Make dataSources required on DataSourceList

### DIFF
--- a/public/app/features/datasources/components/picker/DataSourceList.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceList.tsx
@@ -3,19 +3,14 @@ import { useMemo } from 'react';
 import * as React from 'react';
 import { type Observable } from 'rxjs';
 
-import {
-  type DataSourceInstanceSettings,
-  type DataSourceJsonData,
-  type DataSourceRef,
-  type GrafanaTheme2,
-} from '@grafana/data';
+import { type DataSourceInstanceSettings, type DataSourceRef, type GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { type FavoriteDatasources, getTemplateSrv } from '@grafana/runtime';
 import { useStyles2 } from '@grafana/ui';
 import { SearchStatus } from '@grafana/ui/internal';
 
-import { useDatasources, useRecentlyUsedDataSources } from '../../hooks';
+import { useRecentlyUsedDataSources } from '../../hooks';
 
 import { AddNewDataSourceButton } from './AddNewDataSourceButton';
 import { VirtualizedList } from './VirtualizedList';
@@ -30,18 +25,6 @@ export interface DataSourceListProps {
   className?: string;
   onChange: (ds: DataSourceInstanceSettings) => void;
   current: DataSourceRef | DataSourceInstanceSettings | string | null | undefined;
-  /** Would be nicer if these parameters were part of a filtering object */
-  tracing?: boolean;
-  mixed?: boolean;
-  dashboard?: boolean;
-  metrics?: boolean;
-  type?: string | string[];
-  annotations?: boolean;
-  variables?: boolean;
-  alerting?: boolean;
-  pluginId?: string;
-  /** If true,we show only DSs with logs; and if true, pluginId shouldnt be passed in */
-  logs?: boolean;
   width?: number;
   keyboardEvents?: Observable<React.KeyboardEvent>;
   inputId?: string;
@@ -49,7 +32,7 @@ export interface DataSourceListProps {
   onClear?: () => void;
   onClickEmptyStateCTA?: () => void;
   enableKeyboardNavigation?: boolean;
-  dataSources?: Array<DataSourceInstanceSettings<DataSourceJsonData>>;
+  dataSources: DataSourceInstanceSettings[];
   favoriteDataSources: FavoriteDatasources;
   /** Ref to the scroll container element, used by the virtualizer */
   scrollRef: React.RefObject<HTMLDivElement | null>;
@@ -66,6 +49,8 @@ export function DataSourceList(props: DataSourceListProps) {
     className,
     current,
     onChange,
+    dataSources,
+    filter,
     enableKeyboardNavigation,
     onClickEmptyStateCTA,
     favoriteDataSources,
@@ -75,7 +60,13 @@ export function DataSourceList(props: DataSourceListProps) {
   } = props;
 
   const [recentlyUsedDataSources, pushRecentlyUsedDataSource] = useRecentlyUsedDataSources();
-  const sortedDataSources = useSortedDataSources(props, current, recentlyUsedDataSources, favoriteDataSources);
+  const sortedDataSources = useSortedDataSources(
+    dataSources,
+    filter,
+    current,
+    recentlyUsedDataSources,
+    favoriteDataSources
+  );
 
   const searchStatusMessage =
     sortedDataSources.length === 0
@@ -109,28 +100,13 @@ export function DataSourceList(props: DataSourceListProps) {
 }
 
 function useSortedDataSources(
-  props: DataSourceListProps,
+  dataSources: DataSourceInstanceSettings[],
+  filter: DataSourceListProps['filter'],
   current: DataSourceRef | DataSourceInstanceSettings | string | null | undefined,
   recentlyUsedDataSources: string[],
   favoriteDataSources: FavoriteDatasources
 ) {
-  const dataSources = useDatasources(
-    {
-      alerting: props.alerting,
-      annotations: props.annotations,
-      dashboard: props.dashboard,
-      logs: props.logs,
-      metrics: props.metrics,
-      mixed: props.mixed,
-      pluginId: props.pluginId,
-      tracing: props.tracing,
-      type: props.type,
-      variables: props.variables,
-    },
-    props.dataSources
-  );
-
-  const filteredDataSources = props.filter ? dataSources.filter(props.filter) : dataSources;
+  const filteredDataSources = filter ? dataSources.filter(filter) : dataSources;
 
   return useMemo(
     () =>

--- a/public/app/features/datasources/components/picker/DataSourceModal.test.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceModal.test.tsx
@@ -132,7 +132,6 @@ describe('DataSourceDropdown', () => {
         onDismiss: () => {},
         current: mockDS1.name,
         ...filters,
-        dataSources: mockDSList,
       };
 
       getListMock.mockClear();
@@ -145,6 +144,15 @@ describe('DataSourceDropdown', () => {
           ...filters,
         })
       );
+    });
+
+    it('should render the provided dataSources instead of fetching a list', async () => {
+      const onlyPassedIn = createDS('only.passed.in', 4, false);
+
+      setup({ dataSources: [onlyPassedIn] });
+
+      expect(await screen.findByText(onlyPassedIn.name, { selector: 'span' })).toBeInTheDocument();
+      expect(screen.queryByText(mockDS1.name, { selector: 'span' })).toBeNull();
     });
   });
 

--- a/public/app/features/datasources/components/picker/DataSourceModal.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceModal.tsx
@@ -32,6 +32,8 @@ export interface DataSourceModalProps {
   onDismiss: () => void;
   recentlyUsed?: string[];
   reportedInteractionFrom?: string;
+  /** When set, this list is rendered as-is instead of fetching one with the filters below */
+  dataSources?: DataSourceInstanceSettings[];
 
   // DS filters
   filter?: (ds: DataSourceInstanceSettings) => boolean;
@@ -63,6 +65,7 @@ export function DataSourceModal({
   current,
   onDismiss,
   reportedInteractionFrom,
+  dataSources: dataSourcesProp,
 }: DataSourceModalProps) {
   const styles = useStyles2(getDataSourceModalStyles);
   const [search, setSearch] = useState('');
@@ -85,18 +88,21 @@ export function DataSourceModal({
   };
 
   // Get all datasources to report total_configured count
-  const dataSources = useDatasources({
-    tracing,
-    dashboard,
-    mixed,
-    metrics,
-    type,
-    annotations,
-    variables,
-    alerting,
-    pluginId,
-    logs,
-  });
+  const dataSources = useDatasources(
+    {
+      tracing,
+      dashboard,
+      mixed,
+      metrics,
+      type,
+      annotations,
+      variables,
+      alerting,
+      pluginId,
+      logs,
+    },
+    dataSourcesProp
+  );
 
   // Report interaction when modal is opened
   useEffect(() => {
@@ -178,16 +184,6 @@ export function DataSourceModal({
               })
             }
             filter={(ds) => (filter ? filter?.(ds) : true) && matchDataSourceWithSearch(ds, search) && !ds.meta.builtIn}
-            variables={variables}
-            tracing={tracing}
-            metrics={metrics}
-            type={type}
-            annotations={annotations}
-            alerting={alerting}
-            pluginId={pluginId}
-            logs={logs}
-            dashboard={dashboard}
-            mixed={mixed}
             dataSources={dataSources}
             favoriteDataSources={favoriteDataSources}
             scrollRef={scrollRef}

--- a/public/app/features/datasources/components/picker/DataSourcePicker.tsx
+++ b/public/app/features/datasources/components/picker/DataSourcePicker.tsx
@@ -387,7 +387,17 @@ interface PickerContentProps extends DataSourcePickerProps {
 }
 
 const PickerContent = React.forwardRef<HTMLDivElement, PickerContentProps>((props, ref) => {
-  const { filterTerm, onChange, current, filter, dataSources, favoriteDataSources } = props;
+  const {
+    filterTerm,
+    onChange,
+    current,
+    filter,
+    dataSources,
+    favoriteDataSources,
+    keyboardEvents,
+    listboxId,
+    onActiveItemChange,
+  } = props;
   const scrollRef = useRef<HTMLDivElement>(null);
 
   const changeCallback = useCallback(
@@ -403,9 +413,9 @@ const PickerContent = React.forwardRef<HTMLDivElement, PickerContentProps>((prop
     <div style={props.style} ref={ref} className={styles.container}>
       <ScrollContainer showScrollIndicators ref={scrollRef}>
         <DataSourceList
-          {...props}
           favoriteDataSources={favoriteDataSources}
           enableKeyboardNavigation
+          keyboardEvents={keyboardEvents}
           className={styles.dataSourceList}
           current={current}
           onChange={changeCallback}
@@ -417,6 +427,8 @@ const PickerContent = React.forwardRef<HTMLDivElement, PickerContentProps>((prop
           }
           dataSources={dataSources}
           scrollRef={scrollRef}
+          listboxId={listboxId}
+          onActiveItemChange={onActiveItemChange}
         ></DataSourceList>
       </ScrollContainer>
       <FocusScope>


### PR DESCRIPTION
**What is this feature?**

`DataSourceList` no longer fetches its own data — the `dataSources` prop is now required, so it renders whatever list it is handed, and the DS-filter props that only existed to feed that fetch (`tracing`, `mixed`, `metrics`, …) are gone. `dataSources` is now also a declared prop on `DataSourceModalProps`: the picker's footer was already passing it, but because the prop was undeclared the modal silently refetched.

**Why do we need this feature?**

The `useDatasources()` call inside `DataSourceList` was already dead — the hook short-circuits when given a list, and both render sites already passed one — so dropping it removes the leaf component's dependency on the synchronous `DataSourceSrv` and lets `DataSourcePicker`, `DataSourceModal` and `BuiltInDataSourceList` migrate to `useDataSourceInstanceList()` independently in follow-ups.

**Who is this feature for?**

Grafana developers; no user-facing change.

**Which issue(s) does this PR fix?**:

Part of #127035

**Special notes for your reviewer:**

`DataSourceList` is unexported from any package barrel and had only two render sites, both of which already passed `dataSources` — but if grafana-enterprise imports it directly, requiring the prop is breaking there and needs a companion PR. `DataSourceModal.test.tsx` was passing a `dataSources` prop that used to be ignored; I removed it from the filter-consistency test so it keeps exercising the fetch path, and added a case covering the now-live prop.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)