### PR TITLE
Docs: Update release schedule and version support tables

### DIFF
--- a/docs/sources/upgrade-guide/when-to-upgrade/index.md
+++ b/docs/sources/upgrade-guide/when-to-upgrade/index.md
@@ -46,19 +46,18 @@ We provide release documentation in multiple places to address different needs:
 
 ## When to expect releases
 
-Grafana currently follows a monthly release schedule. Below are the planned releases for the end of 2025 and the first part of 2026. However, these dates may be subject to change:
+Grafana releases a new minor version every other month, with patching releases in between. Below are the planned releases for the rest of 2026. However, these dates may be subject to change:
 
 | **Release date** | **Grafana versions**      | **Release type** |
 | ---------------- | ------------------------- | ---------------- |
-| Sept. 23, 2025   | 12.2 & Supported versions | Minor & patching |
-| Oct. 21, 2025    | Supported versions        | Patching         |
-| Nov. 18, 2025    | 12.3 & Supported versions | Minor & patching |
-| Dec. 16, 2025    | Supported versions        | Patching         |
-| Jan. 13, 2026    | Supported versions        | Patching         |
 | Feb. 24, 2026    | 12.4 & Supported versions | Minor & patching |
-| Mar. 24, 2026    | Supported versions        | Patching         |
 | Apr. 14, 2026    | Grafana 13                | Major            |
 | Jun. 23, 2026    | 13.1 & Supported versions | Minor & patching |
+| Jul. 21, 2026    | Supported versions        | Patching         |
+| Aug. 4, 2026     | Supported versions        | Patching         |
+| Aug. 18, 2026    | 13.2 & Supported versions | Minor & patching |
+| Sept. 1, 2026    | Supported versions        | Patching         |
+| Oct. 20, 2026    | 13.3 & Supported versions | Minor & patching |
 
 ### A few important notes
 
@@ -96,7 +95,7 @@ For self-managed Grafana (both Enterprise and OSS), the support for versions fol
   - **Patch Support**: Individual minor versions receive patch releases (bug fixes and security patches) until end of life
   - **Not Supported**: Versions beyond their support period receive no updates
 
-Here is an overview of version support through 2026:
+Here is an overview of version support through 2027:
 
 | **Version**               | **Release date**   | **Support end date** | **Support level** |
 | ------------------------- | ------------------ | -------------------- | ----------------- |
@@ -106,10 +105,12 @@ Here is an overview of version support through 2026:
 | 12.0.x                    | May 5, 2025        | February 5, 2026     | Not Supported     |
 | 12.1.x                    | July 22, 2025      | April 22, 2026       | Not Supported     |
 | 12.2.x                    | September 23, 2025 | June 23, 2026        | Not Supported     |
-| 12.3.x                    | November 19, 2025  | August 19, 2026      | Patch Support     |
+| 12.3.x                    | November 19, 2025  | August 19, 2026      | Not Supported     |
 | 12.4.x (Last minor of 12) | February 24, 2026  | May 24, 2027         | Patch Support     |
-| 13.0.0                    | April 14, 2026     | January 9, 2027      | Patch Support     |
-| 13.1.x                    | June 22, 2026      | March 20, 2027       | Patch Support     |
+| 13.0.x                    | April 14, 2026     | January 9, 2027      | Patch Support     |
+| 13.1.x                    | June 23, 2026      | March 20, 2027       | Patch Support     |
+| 13.2.x                    | August 18, 2026    | May 18, 2027         | Patch Support     |
+| 13.3.x                    | October 20, 2026   | July 20, 2027        | Patch Support     |
 
 ## How are these versions supported?
 


### PR DESCRIPTION
**What is this feature?**

Updates the two tables on the [Upgrade strategies](https://grafana.com/docs/grafana/latest/upgrade-guide/when-to-upgrade/) page so they match the predeclared release dates that act as the source of truth for our release and patch tooling.

**When to expect releases**

- Drops the stale 2025 rows and the Mar. 24, 2026 patching release, which is no longer scheduled.
- Adds the Jul. 21, Aug. 4, and Sept. 1, 2026 patching releases.
- Adds 13.2 (Aug. 18, 2026) and 13.3 (Oct. 20, 2026).
- Reworded the intro: patching releases now land between minors rather than monthly, so "monthly release schedule" was inaccurate.

**Version support**

- Moves 12.3.x to Not Supported — it reached end of life on Aug. 19, 2026.
- Adds support windows for 13.2.x and 13.3.x.
- Corrects the 13.1.x release date to June 23, 2026 (the table said June 22, and disagreed with the schedule table above it).
- Normalizes `13.0.0` to `13.0.x` for consistency with every other row.
- Heading now reads "through 2027" since the table extends past 2026.

**Why do we need this feature?**

Both tables had gone stale. The release schedule ended at June 2026 and still listed 2025 dates, and the support table listed 12.3.x as receiving patches after its end of life while omitting 13.2.x entirely — the version that just shipped.

**Who is this feature for?**

Self-managed Grafana OSS and Enterprise users planning their upgrade cadence.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Two things I left alone that may deserve a follow-up:

- The "What to expect from each release type" section still describes patching as "at least every month". Biweekly satisfies that literally, so I didn't touch it, but it could be stated explicitly if the two-week cadence is now official.
- There are public dates for 12.4.8, 13.0.6, and 13.1.3 on Aug. 6, 2026, off the biweekly rhythm and looking like an ad-hoc security release. I left it out of the planned-schedule table, since the notes below it already explain that ad-hoc releases aren't scheduled ahead of time. Happy to add it if you'd rather it were listed.

Nothing beyond Oct. 20, 2026 is derivable yet — there are no predeclared dates past Sept. 1 and no minors after 13.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)