### PR TITLE
Logs: Invert the orientation of the arrow in the Logs Table and Logs Panel

### DIFF
--- a/public/app/features/logs/components/panel/LogListControls.tsx
+++ b/public/app/features/logs/components/panel/LogListControls.tsx
@@ -281,7 +281,7 @@ export const LogListControls = ({ eventBus, logLevels = FILTER_LEVELS, visualisa
         <>
           <LogListControlsOption
             expanded={controlsExpanded}
-            name={sortOrder === LogsSortOrder.Descending ? 'sort-amount-up' : 'sort-amount-down'}
+            name={sortOrder === LogsSortOrder.Descending ? 'sort-amount-down' : 'sort-amount-up'}
             className={styles.controlButton}
             onClick={onSortOrderClick}
             label={

--- a/public/app/features/logs/components/panel/LogTableControls.tsx
+++ b/public/app/features/logs/components/panel/LogTableControls.tsx
@@ -110,7 +110,7 @@ export const LogTableControls = ({
 
       <LogListControlsOption
         expanded={controlsExpanded}
-        name={sortOrder === LogsSortOrder.Descending ? 'sort-amount-up' : 'sort-amount-down'}
+        name={sortOrder === LogsSortOrder.Descending ? 'sort-amount-down' : 'sort-amount-up'}
         className={styles.controlButton}
         onClick={onSortOrderClick}
         label={


### PR DESCRIPTION
This PR addresses an inconsistency in the direction of the sorting arrow between the Logs controls and what Grafana generally uses.

This was particularly noticeable in the Logs Table, where the controls and the table headers pointed in opposite directions.

Before:

<img width="1444" height="217" alt="Before" src="https://github.com/user-attachments/assets/d93630a1-71ee-497d-b050-3d3648783bf9" />

After:

<img width="1447" height="226" alt="After" src="https://github.com/user-attachments/assets/6bc3a1e1-61cf-4d90-a610-7df7af92b068" />

Independent of the arrow direction, a very verbose tooltip has been used to let the user know of the current state and the next state if they click it.

<img width="367" height="76" alt="imagen" src="https://github.com/user-attachments/assets/779d2c80-6e32-42a1-87d2-937a03c881bf" />

<img width="349" height="79" alt="imagen" src="https://github.com/user-attachments/assets/beb5a56d-a24c-40d2-8e31-83b831ba763c" />
