### PR TITLE
Datasources: Make dataSources required on BuiltInDataSourceList

### DIFF
--- a/public/app/features/datasources/components/picker/BuiltInDataSourceList.tsx
+++ b/public/app/features/datasources/components/picker/BuiltInDataSourceList.tsx
@@ -3,8 +3,6 @@ import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { type DataSourceRef } from '@grafana/schema';
 
-import { useDatasources } from '../../hooks';
-
 import { DataSourceCard } from './DataSourceCard';
 import { isDataSourceMatch } from './utils';
 
@@ -28,51 +26,18 @@ interface BuiltInDataSourceListProps {
   className?: string;
   current: DataSourceRef | string | null | undefined;
   onChange: (ds: DataSourceInstanceSettings) => void;
-
-  // DS filters
+  dataSources: DataSourceInstanceSettings[];
   filter?: (ds: DataSourceInstanceSettings) => boolean;
-  tracing?: boolean;
-  mixed?: boolean;
-  dashboard?: boolean;
-  metrics?: boolean;
-  type?: string | string[];
-  annotations?: boolean;
-  variables?: boolean;
-  alerting?: boolean;
-  pluginId?: string;
-  logs?: boolean;
 }
 
 export function BuiltInDataSourceList({
   className,
   current,
   onChange,
-  tracing,
-  dashboard,
-  mixed,
-  metrics,
-  type,
-  annotations,
-  variables,
-  alerting,
-  pluginId,
-  logs,
+  dataSources,
   filter,
 }: BuiltInDataSourceListProps) {
-  const grafanaDataSources = useDatasources({
-    tracing,
-    dashboard,
-    mixed,
-    metrics,
-    type,
-    annotations,
-    variables,
-    alerting,
-    pluginId,
-    logs,
-  });
-
-  const filteredResults = grafanaDataSources.filter((ds) => (filter ? filter?.(ds) : true) && !!ds.meta.builtIn);
+  const filteredResults = dataSources.filter((ds) => (filter ? filter(ds) : true) && !!ds.meta.builtIn);
 
   return (
     <div className={className} data-testid={selectors.components.DataSourcePicker.advancedModal.builtInDataSourceList}>

--- a/public/app/features/datasources/components/picker/DataSourceModal.test.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import {
@@ -9,6 +9,7 @@ import {
   PluginType,
   locationUtil,
 } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { mockBoundingClientRect } from '@grafana/test-utils';
 
 import { DataSourceModal, type DataSourceModalProps } from './DataSourceModal';
@@ -113,7 +114,7 @@ describe('DataSourceDropdown', () => {
       });
     });
 
-    it('should fetch the DS applying the correct filters consistently across lists', async () => {
+    it('should fetch the DS list once, applying the correct filters', async () => {
       const filters = {
         mixed: true,
         tracing: true,
@@ -137,13 +138,9 @@ describe('DataSourceDropdown', () => {
       getListMock.mockClear();
       render(<DataSourceModal {...props}></DataSourceModal>);
 
-      // Every call to the service must contain same filters
-      expect(getListMock).toHaveBeenCalled();
-      getListMock.mock.calls.forEach((call) =>
-        expect(call[0]).toMatchObject({
-          ...filters,
-        })
-      );
+      // The modal is the only place fetching the list, and all lists it renders share it
+      expect(getListMock).toHaveBeenCalledTimes(1);
+      expect(getListMock.mock.calls[0][0]).toMatchObject({ ...filters });
     });
 
     it('should render the provided dataSources instead of fetching a list', async () => {
@@ -153,6 +150,22 @@ describe('DataSourceDropdown', () => {
 
       expect(await screen.findByText(onlyPassedIn.name, { selector: 'span' })).toBeInTheDocument();
       expect(screen.queryByText(mockDS1.name, { selector: 'span' })).toBeNull();
+    });
+
+    it('should render built-in data sources from the provided list', async () => {
+      const passedInBuiltIn = createDS('only.passed.in.builtin', 5, true);
+
+      setup({ dataSources: [passedInBuiltIn] });
+
+      // Rendered twice - the desktop column and the list appended for the mobile layout
+      const builtInLists = screen.getAllByTestId(
+        selectors.components.DataSourcePicker.advancedModal.builtInDataSourceList
+      );
+      expect(builtInLists).toHaveLength(2);
+      for (const list of builtInLists) {
+        expect(await within(list).findByText(passedInBuiltIn.name, { selector: 'span' })).toBeInTheDocument();
+        expect(within(list).queryByText(mockDSBuiltIn.name, { selector: 'span' })).toBeNull();
+      }
     });
   });
 

--- a/public/app/features/datasources/components/picker/DataSourceModal.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceModal.tsx
@@ -135,16 +135,7 @@ export function DataSourceModal({
         onChange={onChangeDataSource}
         current={current}
         filter={filter}
-        variables={variables}
-        tracing={tracing}
-        metrics={metrics}
-        type={type}
-        annotations={annotations}
-        alerting={alerting}
-        pluginId={pluginId}
-        logs={logs}
-        dashboard={dashboard}
-        mixed={mixed}
+        dataSources={dataSources}
       />
     );
   };


### PR DESCRIPTION
**What is this feature?**

`BuiltInDataSourceList` no longer fetches its own list — it takes a required `dataSources` prop and drops the ten DS filter props it only carried to forward to `useDatasources()`. `DataSourceModal` passes down the list it already has, so it becomes the single fetch site for the whole picker tree.

**Why do we need this feature?**

The modal renders the built-in list twice for the mobile layout, so this removed two redundant `getDataSourceSrv().getList()` calls per render, and it leaves one call site to migrate to the async data source APIs instead of three. A caller-supplied `dataSources` prop now also drives the built-in column, which previously ignored it.

**Who is this feature for?**

Grafana developers — no user-facing change; the built-in list renders exactly the same data sources, since the modal fetches with the identical filters the list used to pass.

**Which issue(s) does this PR fix?**:

Part of #127035

**Special notes for your reviewer:**

Stacked on #131153 (same pattern, applied to `DataSourceList`) — please review that one first; this PR will be retargeted to `main` once it merges. Test coverage: the existing filter test is tightened to assert the list is fetched exactly once, plus a new test that the built-in column renders from a passed-in list; both fail without the source change.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)