### PR TITLE
GrafanaBootData: Fix stale eslint-disable rule id for config.datasources

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -359,11 +359,6 @@
       "count": 9
     }
   },
-  "packages/grafana-runtime/src/services/pluginMeta/datasources.ts": {
-    "@grafana/no-config-datasources": {
-      "count": 2
-    }
-  },
   "packages/grafana-runtime/src/utils/DataSourceWithBackend.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
@@ -761,11 +756,6 @@
   "packages/grafana-ui/src/utils/useAsyncDependency.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
-    }
-  },
-  "public/app/app.ts": {
-    "@grafana/no-config-datasources": {
-      "count": 2
     }
   },
   "public/app/core/TableModel.ts": {
@@ -2307,9 +2297,6 @@
     }
   },
   "public/app/features/plugins/datasource_srv.ts": {
-    "@grafana/no-config-datasources": {
-      "count": 1
-    },
     "@grafana/no-get-data-source-srv": {
       "count": 1
     },

--- a/packages/grafana-runtime/src/services/pluginMeta/datasources.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/datasources.ts
@@ -82,7 +82,7 @@ function setMetas(metas: PluginMetasResponse | null) {
   if (!metas?.items.length) {
     // null means plugin meta failed to load, empty items means the API had nothing
     const message = metas ? FALLBACK_TO_BOOTDATA_WARNING : FALLBACK_TO_BOOTDATA_ERROR_WARNING;
-    // eslint-disable-next-line no-restricted-syntax
+    // eslint-disable-next-line @grafana/no-config-datasources
     setDatasourcesAndAliases(extractFromConfig(config.datasources));
     logPluginMetaWarning(message, { pluginType: PluginType.datasource, requestUrl: getPluginMetasUrl() });
     return;
@@ -95,7 +95,7 @@ function setMetas(metas: PluginMetasResponse | null) {
 
 async function initDatasourcePluginMetas(): Promise<void> {
   if (!getFeatureFlagClient().getBooleanValue(FlagKeys.PluginsUseMTPlugins, false)) {
-    // eslint-disable-next-line no-restricted-syntax
+    // eslint-disable-next-line @grafana/no-config-datasources
     setDatasourcesAndAliases(extractFromConfig(config.datasources));
     logPluginMetaDebug('PluginMeta: initializing datasource plugins cache with bootdata values', {});
     return;

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -303,11 +303,13 @@ export class GrafanaApp {
       // new `getInstanceSettings` / `getInstanceSettingsList` callers don't
       // need to wait on a network round trip).
       setExpressionDataSourceInstance(expressionDatasource);
+      // eslint-disable-next-line @grafana/no-config-datasources -- boot data is the seed for the instance settings cache
       initDataSourceInstanceSettings(config.datasources, config.defaultDatasource);
       setDataSourcePluginImporter(pluginImporter.importDataSource.bind(pluginImporter));
 
       // Init DataSourceSrv (legacy sync API; retained for backwards compatibility)
       const dataSourceSrv = new DatasourceSrv();
+      // eslint-disable-next-line @grafana/no-config-datasources -- legacy DataSourceSrv is seeded from boot data
       dataSourceSrv.init(config.datasources, config.defaultDatasource);
       setDataSourceSrv(dataSourceSrv);
       initWindowRuntime();

--- a/public/app/features/plugins/datasource_srv.ts
+++ b/public/app/features/plugins/datasource_srv.ts
@@ -392,6 +392,7 @@ export class DatasourceSrv implements DataSourceService {
 
   async reload() {
     const settings = await getBackendSrv().get('/api/frontend/settings');
+    // eslint-disable-next-line @grafana/no-config-datasources -- reload() intentionally refreshes boot data for legacy sync consumers
     config.datasources = settings.datasources;
     config.defaultDatasource = settings.defaultDatasource;
     this.init(settings.datasources, settings.defaultDatasource);


### PR DESCRIPTION
## Summary
- Follow-up to #130661. Josh flagged that the two inline `eslint-disable-next-line` comments in `datasources.ts` named the wrong rule (`no-restricted-syntax` instead of `@grafana/no-config-datasources`), a stale copy from before #121659 split those rules apart. As a result they never actually suppressed anything and the sites landed in `eslint-suppressions.json` as bulk debt rather than explicit, intentional exceptions.
- Corrects the rule id in `datasources.ts` to match the pattern already used in `apps.ts`/`panels.ts`.
- Also inline-disables the three other permanent-by-design boot-data sinks (`app.ts` seeding the instance-settings cache and legacy `DatasourceSrv`, `datasource_srv.ts`'s `reload()`), so they read as explicit exceptions instead of anonymous suppressions.
- Regenerated `eslint-suppressions.json` via `yarn lint:prune`; it now only drops the 5 suppression counts across these three files, leaving the real `config.datasources` migration surface (#125089) untouched.

## Test plan
- [x] `yarn eslint packages/grafana-runtime/src/services/pluginMeta/datasources.ts public/app/app.ts public/app/features/plugins/datasource_srv.ts` — 0 errors
- [x] `yarn lint:ts` — passes with no stale suppressions
- [x] `yarn jest --no-watch packages/grafana-runtime/src/services/pluginMeta` — 940 tests pass