### PR TITLE
PanelEdit: Tweak the pane header styles

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/ContentHeader.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/ContentHeader.tsx
@@ -310,7 +310,6 @@ const getStyles = (
   return {
     container: css({
       position: 'relative',
-      backgroundColor: theme.colors.background.secondary,
       padding: theme.spacing(0.5),
       paddingLeft: `calc(${theme.spacing(0.5)} + 4px)`,
       borderTopLeftRadius: theme.shape.radius.default,
@@ -320,6 +319,7 @@ const getStyles = (
       justifyContent: 'space-between',
       gap: theme.spacing(1),
       minHeight: theme.spacing(5),
+      borderBottom: `1px solid ${theme.colors.border.weak}`,
 
       // psuedo-element to show the border color on the left of the header
       '&::before': {
@@ -353,7 +353,6 @@ const getDatasourceSectionStyles = (theme: GrafanaTheme2) => ({
     // Target the Input component inside the picker
     input: {
       border: 'none',
-      backgroundColor: theme.colors.background.secondary,
     },
     // Remove borders from all nested divs
     '& > div, & div': {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarHeaderActions.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarHeaderActions.tsx
@@ -57,11 +57,11 @@ export function SidebarHeaderActions({
 function getStyles(theme: GrafanaTheme2) {
   return {
     header: css({
-      background: theme.colors.background.secondary,
       padding: theme.spacing(0.5, 1.5),
       minHeight: theme.spacing(5),
       display: 'flex',
       alignItems: 'center',
+      borderBottom: `1px solid ${theme.colors.border.weak}`,
     }),
     inner: css({
       display: 'flex',

--- a/public/app/features/datasources/components/picker/DataSourcePicker.tsx
+++ b/public/app/features/datasources/components/picker/DataSourcePicker.tsx
@@ -364,6 +364,7 @@ function getStylesDropdown(theme: GrafanaTheme2, props: DataSourcePickerProps) {
       pointerEvents: props.disabled ? 'none' : 'auto',
     }),
     input: css({
+      cursor: 'pointer',
       'input::placeholder': {
         color: props.disabled ? theme.colors.action.disabledText : theme.colors.text.primary,
       },


### PR DESCRIPTION
Problem

* Feel the headers for the sidebar and query/transform pane having a background (but no bottom border) looks a bit off, no other pane (panel or options pane) has this header. So feel it would be cleaner. / simplify the UI to remove this background and replace it with a bottom border. 

Before

<img width="1510" height="861" alt="Screenshot 2026-08-20 at 15 39 21" src="https://github.com/user-attachments/assets/18013e8c-0691-4f0d-832e-5452f98ec00b" />

After: 
<img width="1512" height="859" alt="Screenshot 2026-08-20 at 15 41 31" src="https://github.com/user-attachments/assets/09bdcbcc-b5f8-439b-8b90-889530c00f1f" />

