### PR TITLE
Provisioning: Navigate folder README markdown links in-app

### DIFF
--- a/public/app/features/provisioning/components/Folders/FolderReadmePanel.test.tsx
+++ b/public/app/features/provisioning/components/Folders/FolderReadmePanel.test.tsx
@@ -351,17 +351,44 @@ describe('FolderReadmePanel', () => {
       expect(pushSpy).not.toHaveBeenCalledWith('/d/aaa');
     });
 
-    it('records a host outcome for a non-resource link (markdown doc) and never pushes', async () => {
+    it('navigates in-app to the containing folder doc tab when a markdown link maps to a synced folder', async () => {
+      // A folder is keyed by its directory; the doc's containing folder resolves it.
+      setResources([{ path: 'dashboards/team-a', resource: 'folders', name: 'fold1', group: '', hash: '' }]);
+      setReadmeResult({ markdownContent: 'See [contributing](./CONTRIBUTING.md)' });
+
+      const { user } = setup();
+      const pushSpy = jest.spyOn(locationService, 'push').mockImplementation();
+      await user.click(screen.getByRole('link', { name: 'contributing' }));
+
+      await waitFor(() => expect(pushSpy).toHaveBeenCalledWith('/dashboards/f/fold1?docTab=CONTRIBUTING.md'));
+      expect(linkClickedSpy).toHaveBeenCalledWith({ repositoryType: 'github', outcome: 'in_app' });
+    });
+
+    it('navigates the current tab to the host URL when a markdown link has no synced folder', async () => {
+      setResources([]);
+      const assignMock = jest.fn();
       setReadmeResult({ markdownContent: 'See [notes](./notes.md)' });
 
       const { user } = setup();
       const pushSpy = jest.spyOn(locationService, 'push').mockImplementation();
-      const link = screen.getByRole('link', { name: 'notes' });
-      expect(link).toHaveAttribute('href', 'https://github.com/owner/repo/blob/main/dashboards/team-a/notes.md');
-      await user.click(link);
+      // window.location.assign is read-only in jsdom; replace it after render.
+      const originalLocation = Object.getOwnPropertyDescriptor(window, 'location');
+      Object.defineProperty(window, 'location', { configurable: true, value: { assign: assignMock } });
+      try {
+        const link = screen.getByRole('link', { name: 'notes' });
+        expect(link).toHaveAttribute('href', 'https://github.com/owner/repo/blob/main/dashboards/team-a/notes.md');
+        await user.click(link);
 
-      expect(pushSpy).not.toHaveBeenCalled();
-      expect(linkClickedSpy).toHaveBeenCalledWith({ repositoryType: 'github', outcome: 'host' });
+        await waitFor(() =>
+          expect(assignMock).toHaveBeenCalledWith('https://github.com/owner/repo/blob/main/dashboards/team-a/notes.md')
+        );
+        expect(pushSpy).not.toHaveBeenCalled();
+        expect(linkClickedSpy).toHaveBeenCalledWith({ repositoryType: 'github', outcome: 'host' });
+      } finally {
+        if (originalLocation) {
+          Object.defineProperty(window, 'location', originalLocation);
+        }
+      }
     });
   });
 

--- a/public/app/features/provisioning/components/Folders/FolderReadmePanel.tsx
+++ b/public/app/features/provisioning/components/Folders/FolderReadmePanel.tsx
@@ -30,7 +30,13 @@ import { useQueryParams } from 'app/core/hooks/useQueryParams';
 
 import { useFolderDocs } from '../../hooks/useFolderDocs';
 import { type FolderReadmeStatus, useFolderReadme } from '../../hooks/useFolderReadme';
-import { type FolderDoc, ensureReadmeTab, getDocTabLabel, README_CONVENTION } from '../../utils/folderDocConventions';
+import {
+  type FolderDoc,
+  ensureReadmeTab,
+  FOLDER_DOC_TAB_PARAM,
+  getDocTabLabel,
+  README_CONVENTION,
+} from '../../utils/folderDocConventions';
 import { getRepoEditFileUrl, getRepoNewFileUrl } from '../../utils/git';
 import { RESOURCE_PATH_ATTR, rewriteRelativeMarkdownLinks } from '../../utils/markdownLinks';
 import { createGrafanaLinkResolver } from '../../utils/markdownResourceLinks';
@@ -38,9 +44,6 @@ import { createGrafanaLinkResolver } from '../../utils/markdownResourceLinks';
 import { FolderReadmeEvents } from './analytics/main';
 
 export const FOLDER_README_ANCHOR_ID = 'folder-readme';
-
-/** Query param that persists the selected doc tab in the URL (by file name). */
-const FOLDER_DOC_TAB_PARAM = 'docTab';
 
 /** Slack subtracted from the tab bar width so rounding never clips the last tab / More. */
 const TAB_OVERFLOW_BUFFER_PX = 8;

--- a/public/app/features/provisioning/utils/folderDocConventions.ts
+++ b/public/app/features/provisioning/utils/folderDocConventions.ts
@@ -8,6 +8,13 @@ import { t } from '@grafana/i18n';
  */
 export type FolderDocKey = 'readme' | 'contributing' | 'security';
 
+/**
+ * Query param that selects a folder doc tab by its file name (e.g.
+ * `?docTab=CONTRIBUTING.md`). Shared so links that resolve to a doc in another
+ * folder can deep-link straight to the right tab.
+ */
+export const FOLDER_DOC_TAB_PARAM = 'docTab';
+
 interface FolderDocConvention {
   key: FolderDocKey;
   /** Canonical file name, used when creating the file from the empty state. */
@@ -88,7 +95,7 @@ export function listFolderDocs(filePaths: string[], sourceDir: string): FolderDo
   }
 
   const others = inDir
-    .filter((file) => !usedPaths.has(file.path) && isMarkdown(file.fileName))
+    .filter((file) => !usedPaths.has(file.path) && isMarkdownFile(file.fileName))
     .sort((a, b) => {
       const an = a.fileName.toLowerCase();
       const bn = b.fileName.toLowerCase();
@@ -116,7 +123,8 @@ export function ensureReadmeTab(docs: FolderDoc[], sourceDir: string): FolderDoc
   return [{ key: README_CONVENTION.key, path, fileName: README_CONVENTION.fileName }, ...docs];
 }
 
-function isMarkdown(fileName: string): boolean {
+/** Whether a file name is a markdown doc (`.md` / `.markdown`). */
+export function isMarkdownFile(fileName: string): boolean {
   return /\.(md|markdown)$/i.test(fileName);
 }
 

--- a/public/app/features/provisioning/utils/markdownLinks.test.ts
+++ b/public/app/features/provisioning/utils/markdownLinks.test.ts
@@ -173,11 +173,12 @@ describe('rewriteRelativeMarkdownLinks', () => {
       expect(out).toContain(`${RESOURCE_PATH_ATTR}="ops/resources/GTM/"`);
     });
 
-    it('does not tag a markdown link', () => {
+    it('tags a markdown link so it can resolve to its folder doc tab, keeping the host href', () => {
       const html = `<p><a href="./notes.md">notes</a></p>`;
       const out = rewriteRelativeMarkdownLinks(html, { repository: githubRepo, baseDirInRepo: baseDir });
 
-      expect(out).not.toContain(RESOURCE_PATH_ATTR);
+      expect(out).toContain(`${RESOURCE_PATH_ATTR}="ops/resources/RnD/notes.md"`);
+      expect(out).toContain('href="https://github.com/grafana/grafana-manifests/blob/main/ops/resources/RnD/notes.md"');
     });
 
     it('does not tag images', () => {
@@ -211,13 +212,17 @@ describe('rewriteRelativeMarkdownLinks', () => {
   });
 
   describe('isResourceLinkCandidate', () => {
-    it.each(['a/dash.json', 'a/pl.yaml', 'a/pl.yml', 'a/DASH.JSON', 'a/sub/', 'sub/'])('accepts %s', (path) => {
-      expect(isResourceLinkCandidate(path)).toBe(true);
-    });
+    it.each(['a/dash.json', 'a/pl.yaml', 'a/pl.yml', 'a/DASH.JSON', 'a/notes.md', 'a/GUIDE.markdown', 'a/sub/', 'sub/'])(
+      'accepts %s',
+      (path) => {
+        expect(isResourceLinkCandidate(path)).toBe(true);
+      }
+    );
 
-    // Extensionless paths (README, LICENSE, a folder link without a trailing
-    // slash) are not tagged, so they never trigger a resource lookup on click.
-    it.each(['a/notes.md', 'a/logo.png', 'a/archive.tar.gz', 'a/README', 'a/sub', 'sub', ''])('rejects %s', (path) => {
+    // Non-resource files (images, archives) and extensionless paths (README,
+    // LICENSE, a folder link without a trailing slash) are not tagged, so they
+    // never trigger a lookup on click.
+    it.each(['a/logo.png', 'a/archive.tar.gz', 'a/README', 'a/sub', 'sub', ''])('rejects %s', (path) => {
       expect(isResourceLinkCandidate(path)).toBe(false);
     });
   });

--- a/public/app/features/provisioning/utils/markdownLinks.ts
+++ b/public/app/features/provisioning/utils/markdownLinks.ts
@@ -1,5 +1,6 @@
 import { type RepositoryView } from 'app/api/clients/provisioning/v0alpha1';
 
+import { isMarkdownFile } from './folderDocConventions';
 import { getRepoFileUrl, getRepoRawFileUrl } from './git';
 
 interface RewriteOptions {
@@ -11,10 +12,11 @@ interface RewriteOptions {
 const SCHEME_RE = /^[a-z][a-z0-9+\-.]*:/i;
 
 /**
- * Attribute stamped on links whose target could be a Grafana resource (JSON/YAML
- * files or folder directories), carrying the resolved repo path. The README click
- * handler reads it to lazily resolve the link to the in-app page — untagged links
- * (docs, images, external) always open the host URL.
+ * Attribute stamped on links whose target could be viewed in-app: a Grafana
+ * resource (JSON/YAML files or folder directories) or a markdown doc (which opens
+ * as a tab on its containing folder's page). It carries the resolved repo path;
+ * the README click handler reads it to lazily resolve the link to the in-app page
+ * — untagged links (images, other files, external) always open the host URL.
  */
 export const RESOURCE_PATH_ATTR = 'data-provisioning-repo-path';
 
@@ -66,9 +68,9 @@ export function rewriteRelativeMarkdownLinks(html: string, options: RewriteOptio
       anchor.removeAttribute('href');
     }
 
-    // Tag JSON/YAML/folder links so the README click handler can resolve them to
-    // the in-app Grafana page. Done regardless of the host URL so links in repos
-    // without one (local/git) still resolve via the resource listing.
+    // Tag JSON/YAML/folder/markdown links so the README click handler can resolve
+    // them to the in-app Grafana page. Done regardless of the host URL so links in
+    // repos without one (local/git) still resolve via the resource listing.
     if (isResourceLinkCandidate(result.path)) {
       anchor.setAttribute(RESOURCE_PATH_ATTR, result.path);
     }
@@ -159,17 +161,18 @@ function stripLeadingSlashes(s: string): string {
 }
 
 /**
- * Whether a resolved repo path could map to a Grafana resource: a JSON/YAML file
- * (dashboard, playlist, folder metadata, ...) or a folder directory. Folders are
- * matched by their trailing slash — which the resolver preserves for directory
- * links — rather than by "no extension", so extensionless files (README,
- * LICENSE, Makefile) aren't tagged and never trigger a resource lookup. Links
- * that fail this (docs, images, arbitrary files) are left as plain host links.
+ * Whether a resolved repo path could be viewed in-app: a JSON/YAML file
+ * (dashboard, playlist, folder metadata, ...), a folder directory, or a markdown
+ * doc (which opens as a tab on its containing folder's page). Folders are matched
+ * by their trailing slash — which the resolver preserves for directory links —
+ * rather than by "no extension", so extensionless files (README, LICENSE,
+ * Makefile) aren't tagged and never trigger a lookup. Links that fail this
+ * (images, arbitrary files) are left as plain host links.
  */
 export function isResourceLinkCandidate(path: string): boolean {
   if (path.endsWith('/')) {
     return true;
   }
   const lastSegment = path.slice(path.lastIndexOf('/') + 1);
-  return /\.(json|ya?ml)$/i.test(lastSegment);
+  return /\.(json|ya?ml)$/i.test(lastSegment) || isMarkdownFile(lastSegment);
 }

--- a/public/app/features/provisioning/utils/markdownResourceLinks.test.ts
+++ b/public/app/features/provisioning/utils/markdownResourceLinks.test.ts
@@ -133,4 +133,53 @@ describe('createGrafanaLinkResolver', () => {
     expect(resolve('grafana/team-a/cpu.json')).toBe('/d/abc');
     expect(resolve('team-a/cpu.json')).toBeUndefined();
   });
+
+  describe('markdown docs', () => {
+    it('resolves a markdown doc to its containing folder page with a docTab param', () => {
+      const resolve = createGrafanaLinkResolver(
+        [resource({ resource: 'folders', name: 'fold1', path: 'team-a' })],
+        undefined
+      );
+
+      expect(resolve('team-a/CONTRIBUTING.md')).toBe('/dashboards/f/fold1?docTab=CONTRIBUTING.md');
+    });
+
+    it('resolves a README in the repository root to the root folder page', () => {
+      const resolve = createGrafanaLinkResolver(
+        [resource({ resource: 'folders', name: 'root-folder', path: '' })],
+        undefined
+      );
+
+      expect(resolve('README.md')).toBe('/dashboards/f/root-folder?docTab=README.md');
+    });
+
+    it('encodes a doc file name with spaces in the docTab param', () => {
+      const resolve = createGrafanaLinkResolver(
+        [resource({ resource: 'folders', name: 'fold1', path: 'team-a' })],
+        undefined
+      );
+
+      expect(resolve('team-a/Release Notes.md')).toBe('/dashboards/f/fold1?docTab=Release%20Notes.md');
+    });
+
+    it('joins the configured repository path when resolving a doc folder', () => {
+      const resolve = createGrafanaLinkResolver(
+        [resource({ resource: 'folders', name: 'fold1', path: 'team-a' })],
+        'grafana'
+      );
+
+      expect(resolve('grafana/team-a/SECURITY.md')).toBe('/dashboards/f/fold1?docTab=SECURITY.md');
+    });
+
+    it('returns undefined when the doc folder is not a synced folder', () => {
+      // Only a dashboard is synced here; the doc's directory has no folder resource,
+      // so the caller falls back to the host link.
+      const resolve = createGrafanaLinkResolver(
+        [resource({ resource: 'dashboards', name: 'abc', path: 'team-a/cpu.json' })],
+        undefined
+      );
+
+      expect(resolve('team-a/NOTES.md')).toBeUndefined();
+    });
+  });
 });

--- a/public/app/features/provisioning/utils/markdownResourceLinks.ts
+++ b/public/app/features/provisioning/utils/markdownResourceLinks.ts
@@ -2,16 +2,19 @@ import { type ResourceListItem } from 'app/api/clients/provisioning/v0alpha1';
 
 import { FOLDER_METADATA_FILE } from '../constants';
 
-import { getKindInfoByResource } from './resourceKinds';
+import { FOLDER_DOC_TAB_PARAM, isMarkdownFile } from './folderDocConventions';
+import { getKindInfoByResource, resourceKindInfos } from './resourceKinds';
 
 /**
  * Builds a resolver that maps a repo file/directory path to the in-app Grafana
  * route of the resource synced from it (dashboard, folder, playlist, ...), or
  * `undefined` when the path has no synced resource or the kind has no per-item
- * view route (e.g. library panels). Callers fall back to the host repository
- * link in that case, so a README reads as file links on GitHub and as Grafana
- * pages when browsed in Grafana. The route is app-relative (e.g. `/d/uid`) for
- * SPA navigation via `locationService`.
+ * view route (e.g. library panels). Markdown docs resolve to their containing
+ * folder's page with a `docTab` param (they render as tabs there rather than
+ * being resources of their own). Callers fall back to the host repository link
+ * in that case, so a README reads as file links on GitHub and as Grafana pages
+ * when browsed in Grafana. The route is app-relative (e.g. `/d/uid`) for SPA
+ * navigation via `locationService`.
  *
  * `repositoryPath` is the repository's configured root. Resource paths from the
  * API are relative to it, whereas the paths passed to the resolver are full
@@ -35,6 +38,14 @@ export function createGrafanaLinkResolver(
   return (repoPath) => {
     const normalized = trimSlashes(repoPath);
 
+    // Markdown docs aren't resources of their own — they're rendered as tabs on
+    // their containing folder's page. Resolve to that folder's route plus a
+    // `docTab` param so the link opens the doc in-app, exactly like a folder or
+    // dashboard link; a doc whose folder isn't synced falls back to the host.
+    if (isMarkdownFile(normalized)) {
+      return resolveMarkdownDocRoute(byPath, normalized);
+    }
+
     // A link may point straight at a folder's _folder.json, but the folder
     // resource is keyed by its directory (empty for the repo root) — fall back to
     // it. Returns undefined for non-metadata paths so an unrelated file can't
@@ -49,6 +60,25 @@ export function createGrafanaLinkResolver(
 
     return getKindInfoByResource(resource.resource)?.getRoute?.(resource.name);
   };
+}
+
+/**
+ * In-app route for a markdown doc: its containing folder's page with a `docTab`
+ * param selecting the doc. Only a folder resource is keyed by a bare directory,
+ * so a lookup miss (or a non-folder hit) means the doc's folder isn't synced and
+ * the caller falls back to the host link.
+ */
+function resolveMarkdownDocRoute(byPath: Map<string, ResourceListItem>, path: string): string | undefined {
+  const lastSlash = path.lastIndexOf('/');
+  const dir = lastSlash >= 0 ? path.slice(0, lastSlash) : '';
+  const fileName = path.slice(lastSlash + 1);
+
+  const folder = byPath.get(dir);
+  if (folder?.resource !== resourceKindInfos.folder.resource || !folder.name) {
+    return undefined;
+  }
+
+  return `${resourceKindInfos.folder.getRoute(folder.name)}?${FOLDER_DOC_TAB_PARAM}=${encodeURIComponent(fileName)}`;
 }
 
 function joinRepoPath(prefix: string | undefined, path: string): string {


### PR DESCRIPTION
## What this does

Makes `.md` / `.markdown` links inside a folder README **clickable and navigable within Grafana**, the same way folder and dashboard links already resolve.

Today a markdown link in a README only ever points out to the host repository (GitHub/GitLab/…). With this change, a markdown link resolves to that doc **inside Grafana**: the containing folder's page with a `?docTab=<file>` query param that opens the doc's tab (the folder-doc tabs added by the base PR). When the doc's folder isn't a synced Grafana folder, it falls back to the host link, exactly like the existing resource-link behavior.

## How

- `markdownLinks.ts` — `isResourceLinkCandidate` now also matches markdown files, so `.md`/`.markdown` links get tagged with `RESOURCE_PATH_ATTR` for in-app resolution (host href preserved as the fallback).
- `markdownResourceLinks.ts` — `createGrafanaLinkResolver` resolves a markdown path to its containing folder's route + `docTab` param. Only a folder resource is keyed by a bare directory, so a miss (or non-folder hit) means the folder isn't synced → host fallback.
- `folderDocConventions.ts` — extracts the shared `FOLDER_DOC_TAB_PARAM` (`docTab`) and exports `isMarkdownFile`, reused by the panel and the resolver.

The README click handler is unchanged: it already resolves tagged links via `createGrafanaLinkResolver` and navigates in-app (`locationService.push`) or falls back to the host, recording the `in_app` / `host` outcome.

## Stacking

This is **stacked on #129073** (`MissingRoberto/folder-readme-tabs`, which itself carries #128455). Review/merge that first — the base will collapse to `main` once it lands, leaving only this change.

## Tests

- `markdownLinks.test.ts` — markdown links are now tagged; `isResourceLinkCandidate` accepts markdown.
- `markdownResourceLinks.test.ts` — markdown → folder `docTab` route, root README, spaces encoding, configured-path join, host fallback when unsynced.
- `FolderReadmePanel.test.tsx` — in-app navigation to the folder doc tab; host fallback when the folder isn't synced.

All affected suites pass; `yarn typecheck` and `eslint` clean.