### PR TITLE
PanelEdit: Minor override category spacing fix

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/OverrideCategoryTitle.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OverrideCategoryTitle.tsx
@@ -30,7 +30,7 @@ export const OverrideCategoryTitle = ({
 
   return (
     <div>
-      <Stack justifyContent="space-between">
+      <Stack justifyContent="space-between" alignItems="center">
         <div>{overrideName}</div>
         <Button
           variant="secondary"


### PR DESCRIPTION
Before: 
<img width="370" height="352" alt="Screenshot 2026-08-20 at 16 16 03" src="https://github.com/user-attachments/assets/548421dc-430f-4c39-b9fb-b4a0f1e65f82" />


After: 
<img width="336" height="225" alt="Screenshot 2026-08-20 at 16 16 23" src="https://github.com/user-attachments/assets/1d005e10-c884-441f-a1ce-5b887b627102" />
