### PR TITLE
Team LBAC: Add rules-for-subject subresource

### DIFF
--- a/apps/iam/kinds/teamlbac.cue
+++ b/apps/iam/kinds/teamlbac.cue
@@ -17,4 +17,17 @@ teamlbacrulev0alpha1: teamlbacruleKind & {
 	schema: {
 		spec: v0alpha1.TeamLBACRuleSpec
 	}
+	routes: {
+		"/for-subject/{type}/{uid}": {
+			"GET": {
+				// App SDK client generation does not yet interpolate path parameters.
+				// A hand-written client method exposes this route with typed arguments.
+				name: "getTeamLBACRulesForSubjectRoute"
+				response: {
+					team_filters: [string]: [...string]
+				}
+				responseMetadata: objectMeta: false
+			}
+		}
+	}
 }

--- a/apps/iam/pkg/apis/iam/v0alpha1/register.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/register.go
@@ -327,6 +327,7 @@ func AddTeamLBACRuleTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&TeamLBACRule{},
 		&TeamLBACRuleList{},
+		&GetTeamLBACRulesForSubjectRouteResponse{},
 
 		// What is this about?
 		&metav1.PartialObjectMetadata{},

--- a/apps/iam/pkg/apis/iam/v0alpha1/teamlbacrule_client.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/teamlbacrule_client.go
@@ -1,0 +1,47 @@
+package v0alpha1
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/grafana/grafana-app-sdk/resource"
+)
+
+type GetTeamLBACRulesForSubjectRequest struct {
+	SubjectType string
+	SubjectUID  string
+	Headers     http.Header
+}
+
+// GetTeamLBACRulesForSubjectResponse hides the generated Route suffix from callers.
+// The CUE operation needs a distinct generated name because its generated client
+// cannot interpolate path parameters and would otherwise collide with the
+// hand-written GetTeamLBACRulesForSubject method below.
+type GetTeamLBACRulesForSubjectResponse = GetTeamLBACRulesForSubjectRouteResponse
+
+func NewGetTeamLBACRulesForSubjectResponse() *GetTeamLBACRulesForSubjectResponse {
+	return &GetTeamLBACRulesForSubjectResponse{}
+}
+
+// GetTeamLBACRulesForSubject is hand-written because App SDK client generation
+// currently preserves path placeholders instead of interpolating their values.
+func (c *TeamLBACRuleClient) GetTeamLBACRulesForSubject(ctx context.Context, identifier resource.Identifier, request GetTeamLBACRulesForSubjectRequest) (*GetTeamLBACRulesForSubjectResponse, error) {
+	path := "/for-subject/" + url.PathEscape(request.SubjectType) + "/" + url.PathEscape(request.SubjectUID)
+	response, err := c.client.SubresourceRequest(ctx, identifier, resource.CustomRouteRequestOptions{
+		Path:    path,
+		Verb:    http.MethodGet,
+		Headers: request.Headers,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	result := GetTeamLBACRulesForSubjectResponse{}
+	if err := json.Unmarshal(response, &result); err != nil {
+		return nil, fmt.Errorf("unmarshal TeamLBAC rules for subject response: %w", err)
+	}
+	return &result, nil
+}

--- a/apps/iam/pkg/apis/iam/v0alpha1/teamlbacrule_client_gen.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/teamlbacrule_client_gen.go
@@ -2,6 +2,9 @@ package v0alpha1
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
 
 	"github.com/grafana/grafana-app-sdk/resource"
 )
@@ -77,4 +80,25 @@ func (c *TeamLBACRuleClient) Patch(ctx context.Context, identifier resource.Iden
 
 func (c *TeamLBACRuleClient) Delete(ctx context.Context, identifier resource.Identifier, opts resource.DeleteOptions) error {
 	return c.client.Delete(ctx, identifier, opts)
+}
+
+type GetTeamLBACRulesForSubjectRouteRequest struct {
+	Headers http.Header
+}
+
+func (c *TeamLBACRuleClient) GetTeamLBACRulesForSubjectRoute(ctx context.Context, identifier resource.Identifier, request GetTeamLBACRulesForSubjectRouteRequest) (*GetTeamLBACRulesForSubjectRouteResponse, error) {
+	resp, err := c.client.SubresourceRequest(ctx, identifier, resource.CustomRouteRequestOptions{
+		Path:    "/for-subject/{type}/{uid}",
+		Verb:    "GET",
+		Headers: request.Headers,
+	})
+	if err != nil {
+		return nil, err
+	}
+	cast := GetTeamLBACRulesForSubjectRouteResponse{}
+	err = json.Unmarshal(resp, &cast)
+	if err != nil {
+		return nil, fmt.Errorf("unable to unmarshal response bytes into GetTeamLBACRulesForSubjectRouteResponse: %w", err)
+	}
+	return &cast, nil
 }

--- a/apps/iam/pkg/apis/iam/v0alpha1/teamlbacrule_client_test.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/teamlbacrule_client_test.go
@@ -1,0 +1,32 @@
+package v0alpha1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana-app-sdk/resource"
+)
+
+func TestTeamLBACRuleClientGetTeamLBACRulesForSubject(t *testing.T) {
+	transport := &recordingResourceClient{responses: [][]byte{
+		[]byte(`{"team_filters":{"team-a":["foo=\"bar\""]}}`),
+	}}
+	client := NewTeamLBACRuleClient(transport)
+
+	response, err := client.GetTeamLBACRulesForSubject(
+		context.Background(),
+		resource.Identifier{Namespace: "org-1", Name: "prometheus.datasource-a"},
+		GetTeamLBACRulesForSubjectRequest{
+			SubjectType: "user",
+			SubjectUID:  "user-a",
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, map[string][]string{"team-a": {`foo="bar"`}}, response.TeamFilters)
+	require.Len(t, transport.requests, 1)
+	require.Equal(t, "/for-subject/user/user-a", transport.requests[0].Path)
+	require.Equal(t, "GET", transport.requests[0].Verb)
+	require.Empty(t, transport.requests[0].Query)
+}

--- a/apps/iam/pkg/apis/iam/v0alpha1/teamlbacrule_getteamlbacrulesforsubjectroute_response_body_types_gen.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/teamlbacrule_getteamlbacrulesforsubjectroute_response_body_types_gen.go
@@ -1,0 +1,20 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v0alpha1
+
+// +k8s:openapi-gen=true
+type GetTeamLBACRulesForSubjectRouteBody struct {
+	TeamFilters map[string][]string `json:"team_filters"`
+}
+
+// NewGetTeamLBACRulesForSubjectRouteBody creates a new GetTeamLBACRulesForSubjectRouteBody object.
+func NewGetTeamLBACRulesForSubjectRouteBody() *GetTeamLBACRulesForSubjectRouteBody {
+	return &GetTeamLBACRulesForSubjectRouteBody{
+		TeamFilters: map[string][]string{},
+	}
+}
+
+// OpenAPIModelName returns the OpenAPI model name for GetTeamLBACRulesForSubjectRouteBody.
+func (GetTeamLBACRulesForSubjectRouteBody) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.iam.pkg.apis.iam.v0alpha1.GetTeamLBACRulesForSubjectRouteBody"
+}

--- a/apps/iam/pkg/apis/iam/v0alpha1/teamlbacrule_getteamlbacrulesforsubjectroute_response_object_types_gen.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/teamlbacrule_getteamlbacrulesforsubjectroute_response_object_types_gen.go
@@ -1,0 +1,41 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v0alpha1
+
+import (
+	"github.com/grafana/grafana-app-sdk/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// +k8s:openapi-gen=true
+type GetTeamLBACRulesForSubjectRouteResponse struct {
+	metav1.TypeMeta                     `json:",inline"`
+	GetTeamLBACRulesForSubjectRouteBody `json:",inline"`
+}
+
+func NewGetTeamLBACRulesForSubjectRouteResponse() *GetTeamLBACRulesForSubjectRouteResponse {
+	return &GetTeamLBACRulesForSubjectRouteResponse{}
+}
+
+func (t *GetTeamLBACRulesForSubjectRouteBody) DeepCopyInto(dst *GetTeamLBACRulesForSubjectRouteBody) {
+	_ = resource.CopyObjectInto(dst, t)
+}
+
+func (o *GetTeamLBACRulesForSubjectRouteResponse) DeepCopyObject() runtime.Object {
+	dst := NewGetTeamLBACRulesForSubjectRouteResponse()
+	o.DeepCopyInto(dst)
+	return dst
+}
+
+func (o *GetTeamLBACRulesForSubjectRouteResponse) DeepCopyInto(dst *GetTeamLBACRulesForSubjectRouteResponse) {
+	dst.TypeMeta.APIVersion = o.TypeMeta.APIVersion
+	dst.TypeMeta.Kind = o.TypeMeta.Kind
+	o.GetTeamLBACRulesForSubjectRouteBody.DeepCopyInto(&dst.GetTeamLBACRulesForSubjectRouteBody)
+}
+
+func (GetTeamLBACRulesForSubjectRouteResponse) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.iam.pkg.apis.iam.v0alpha1.GetTeamLBACRulesForSubjectRouteResponse"
+}
+
+var _ runtime.Object = NewGetTeamLBACRulesForSubjectRouteResponse()

--- a/apps/iam/pkg/apis/iam/v0alpha1/zz_openapi_gen.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/zz_openapi_gen.go
@@ -32,6 +32,8 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		GetServiceAccountTokenToken{}.OpenAPIModelName():                                    schema_pkg_apis_iam_v0alpha1_GetServiceAccountTokenToken(ref),
 		GetTeamGroupsBody{}.OpenAPIModelName():                                              schema_pkg_apis_iam_v0alpha1_GetTeamGroupsBody(ref),
 		GetTeamGroupsResponse{}.OpenAPIModelName():                                          schema_pkg_apis_iam_v0alpha1_GetTeamGroupsResponse(ref),
+		GetTeamLBACRulesForSubjectRouteBody{}.OpenAPIModelName():                            schema_pkg_apis_iam_v0alpha1_GetTeamLBACRulesForSubjectRouteBody(ref),
+		GetTeamLBACRulesForSubjectRouteResponse{}.OpenAPIModelName():                        schema_pkg_apis_iam_v0alpha1_GetTeamLBACRulesForSubjectRouteResponse(ref),
 		GetTeamMembersBody{}.OpenAPIModelName():                                             schema_pkg_apis_iam_v0alpha1_GetTeamMembersBody(ref),
 		GetTeamMembersResponse{}.OpenAPIModelName():                                         schema_pkg_apis_iam_v0alpha1_GetTeamMembersResponse(ref),
 		GetTeamMembersTeamUser{}.OpenAPIModelName():                                         schema_pkg_apis_iam_v0alpha1_GetTeamMembersTeamUser(ref),
@@ -1167,6 +1169,88 @@ func schema_pkg_apis_iam_v0alpha1_GetTeamGroupsResponse(ref common.ReferenceCall
 					},
 				},
 				Required: []string{"externalGroups"},
+			},
+		},
+	}
+}
+
+func schema_pkg_apis_iam_v0alpha1_GetTeamLBACRulesForSubjectRouteBody(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"team_filters": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"array"},
+										Items: &spec.SchemaOrArray{
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type:   []string{"string"},
+													Format: "",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"team_filters"},
+			},
+		},
+	}
+}
+
+func schema_pkg_apis_iam_v0alpha1_GetTeamLBACRulesForSubjectRouteResponse(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"kind": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"apiVersion": {
+						SchemaProps: spec.SchemaProps{
+							Description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"team_filters": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"array"},
+										Items: &spec.SchemaOrArray{
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type:   []string{"string"},
+													Format: "",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"team_filters"},
 			},
 		},
 	}

--- a/apps/iam/pkg/apis/iam_manifest.go
+++ b/apps/iam/pkg/apis/iam_manifest.go
@@ -633,6 +633,71 @@ var appManifestData = app.ManifestData{
 					Plural:     "TeamLBACRules",
 					Scope:      "Namespaced",
 					Conversion: false,
+					Routes: map[string]spec3.PathProps{
+						"/for-subject/{type}/{uid}": {
+							Get: &spec3.Operation{
+								OperationProps: spec3.OperationProps{
+
+									OperationId: "getTeamLBACRulesForSubjectRoute",
+
+									Responses: &spec3.Responses{
+										ResponsesProps: spec3.ResponsesProps{
+											Default: &spec3.Response{
+												ResponseProps: spec3.ResponseProps{
+													Description: "Default OK response",
+													Content: map[string]*spec3.MediaType{
+														"application/json": {
+															MediaTypeProps: spec3.MediaTypeProps{
+																Schema: &spec.Schema{
+																	SchemaProps: spec.SchemaProps{
+																		Type: []string{"object"},
+																		Properties: map[string]spec.Schema{
+																			"apiVersion": {
+																				SchemaProps: spec.SchemaProps{
+																					Type:        []string{"string"},
+																					Description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+																				},
+																			},
+																			"kind": {
+																				SchemaProps: spec.SchemaProps{
+																					Type:        []string{"string"},
+																					Description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+																				},
+																			},
+																			"team_filters": {
+																				SchemaProps: spec.SchemaProps{
+																					Type: []string{"object"},
+																					AdditionalProperties: &spec.SchemaOrBool{
+																						Schema: &spec.Schema{
+																							SchemaProps: spec.SchemaProps{
+																								Type: []string{"array"},
+																								Items: &spec.SchemaOrArray{
+																									Schema: &spec.Schema{
+																										SchemaProps: spec.SchemaProps{
+																											Type: []string{"string"},
+																										}},
+																								},
+																							},
+																						},
+																					},
+																				},
+																			},
+																		},
+																		Required: []string{
+																			"team_filters",
+																			"apiVersion",
+																			"kind",
+																		},
+																	}},
+															}},
+													},
+												},
+											},
+										}},
+								},
+							},
+						},
+					},
 				},
 
 				{
@@ -1528,6 +1593,8 @@ var customRouteToGoResponseType = map[string]any{
 	"v0alpha1|Team|members|GET": v0alpha1.GetTeamMembersResponse{},
 
 	"v0alpha1|Team|removemember|POST": v0alpha1.DeleteTeamMemberResponse{},
+
+	"v0alpha1|TeamLBACRule|for-subject/{type}/{uid}|GET": v0alpha1.GetTeamLBACRulesForSubjectRouteResponse{},
 
 	"v0alpha1|ServiceAccount|tokens|GET":  v0alpha1.ListServiceAccountTokensResponse{},
 	"v0alpha1|ServiceAccount|tokens|POST": v0alpha1.CreateServiceAccountTokenResponse{},

--- a/packages/grafana-openapi/src/apis/iam.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/iam.grafana.app-v0alpha1.json
@@ -3330,6 +3330,44 @@
           }
         ]
       },
+      "GetTeamLBACRulesForSubjectRouteBody": {
+        "type": "object",
+        "required": ["team_filters"],
+        "properties": {
+          "team_filters": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "GetTeamLBACRulesForSubjectRouteResponse": {
+        "type": "object",
+        "required": ["team_filters"],
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "team_filters": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
       "GetTeamMembersBody": {
         "type": "object",
         "required": ["items"],

--- a/pkg/registry/apis/iam/authorizer.go
+++ b/pkg/registry/apis/iam/authorizer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	authzlib "github.com/grafana/authlib/authz"
 	authlib "github.com/grafana/authlib/types"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 
@@ -72,7 +73,7 @@ func newIAMAuthorizer(
 
 	// Access specific resources
 	resourceAuthorizer[iamv0.RoleInfo.GetName()] = roleApiInstaller.GetAuthorizer()
-	resourceAuthorizer[iamv0.TeamLBACRuleInfo.GetName()] = teamLbacApiInstaller.GetAuthorizer()
+	resourceAuthorizer[iamv0.TeamLBACRuleInfo.GetName()] = newTeamLBACRuleAuthorizer(teamLbacApiInstaller.GetAuthorizer())
 	resourceAuthorizer[iamv0.ResourcePermissionInfo.GetName()] = blockWatchAuthorizer // Block Watch, allow others (storage-layer handles authorization)
 	resourceAuthorizer[iamv0.RoleBindingInfo.GetName()] = roleBindingsApiInstaller.GetAuthorizer()
 	resourceAuthorizer[iamv0.ServiceAccountResourceInfo.GetName()] = newServiceAccountAuthorizer(accessClient)
@@ -99,6 +100,37 @@ func newIAMAuthorizer(
 	resourceAuthorizer[iamv0.GlobalRoleInfo.GetName()] = globalRoleApiInstaller.GetAuthorizer()
 
 	return &iamAuthorizer{resourceAuthorizer: resourceAuthorizer}
+}
+
+func newTeamLBACRuleAuthorizer(base authorizer.Authorizer) authorizer.Authorizer {
+	return authorizer.AuthorizerFunc(func(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+		if attr.GetSubresource() != "for-subject" {
+			// Base CRUD is authorized by the storage wrapper after it resolves the
+			// TeamLBACRule to the datasource whose permissions must be checked.
+			return base.Authorize(ctx, attr)
+		}
+
+		// The caller chooses the subject evaluated by this subresource, so user
+		// requests must not reach it even when they carry delegated service
+		// permissions. Only a direct service call with TeamLBACRule read access
+		// may evaluate rules for another identity.
+		authInfo, ok := authlib.AuthInfoFrom(ctx)
+		if !ok {
+			return authorizer.DecisionDeny, "for-subject requires an authenticated service identity", nil
+		}
+		// for-subject lets a service select which user's rules are returned. Check
+		// the exact TeamLBACRule read permission instead of trusting attr to
+		// describe the permission this sensitive operation requires.
+		resource := iamv0.TeamLBACRuleInfo.GroupResource()
+		servicePermission := authzlib.CheckServicePermissions(authInfo, resource.Group, resource.Resource, utils.VerbGet)
+		if !servicePermission.ServiceCall {
+			return authorizer.DecisionDeny, "for-subject only accepts direct service calls", nil
+		}
+		if !servicePermission.Allowed {
+			return authorizer.DecisionDeny, "calling service lacks TeamLBACRule read permission", nil
+		}
+		return authorizer.DecisionAllow, "", nil
+	})
 }
 
 func (s *iamAuthorizer) Authorize(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {

--- a/pkg/registry/apis/iam/authorizer_test.go
+++ b/pkg/registry/apis/iam/authorizer_test.go
@@ -87,6 +87,82 @@ func newTestAuthInfo() types.AuthInfo {
 	)
 }
 
+func TestTeamLBACRuleAuthorizer(t *testing.T) {
+	baseCalled := false
+	base := authorizer.AuthorizerFunc(func(context.Context, authorizer.Attributes) (authorizer.Decision, string, error) {
+		baseCalled = true
+		return authorizer.DecisionAllow, "", nil
+	})
+	authz := newTeamLBACRuleAuthorizer(base)
+	forSubject := authorizer.AttributesRecord{
+		ResourceRequest: true,
+		Verb:            "get",
+		APIGroup:        "iam.grafana.app",
+		Resource:        "teamlbacrules",
+		Subresource:     "for-subject",
+		Namespace:       "default",
+		Name:            "prometheus.datasource-a",
+	}
+
+	t.Run("denies a request without an authenticated identity", func(t *testing.T) {
+		decision, reason, err := authz.Authorize(context.Background(), forSubject)
+		require.NoError(t, err)
+		require.Equal(t, authorizer.DecisionDeny, decision)
+		require.Equal(t, "for-subject requires an authenticated service identity", reason)
+	})
+
+	t.Run("allows the internal Grafana service permission", func(t *testing.T) {
+		authInfo := authn.NewAccessTokenAuthInfo(authn.Claims[authn.AccessTokenClaims]{
+			Rest: authn.AccessTokenClaims{Permissions: []string{"iam.grafana.app:*"}},
+		})
+		decision, _, err := authz.Authorize(types.WithAuthInfo(context.Background(), authInfo), forSubject)
+		require.NoError(t, err)
+		require.Equal(t, authorizer.DecisionAllow, decision)
+	})
+
+	t.Run("allows an MT service with TeamLBACRule read permission", func(t *testing.T) {
+		authInfo := authn.NewAccessTokenAuthInfo(authn.Claims[authn.AccessTokenClaims]{
+			Rest: authn.AccessTokenClaims{Permissions: []string{"iam.grafana.app/teamlbacrules:get"}},
+		})
+		decision, _, err := authz.Authorize(types.WithAuthInfo(context.Background(), authInfo), forSubject)
+		require.NoError(t, err)
+		require.Equal(t, authorizer.DecisionAllow, decision)
+	})
+
+	t.Run("denies a service without TeamLBACRule read permission", func(t *testing.T) {
+		authInfo := authn.NewAccessTokenAuthInfo(authn.Claims[authn.AccessTokenClaims]{
+			Rest: authn.AccessTokenClaims{Permissions: []string{"iam.grafana.app/teams:get"}},
+		})
+		decision, reason, err := authz.Authorize(types.WithAuthInfo(context.Background(), authInfo), forSubject)
+		require.NoError(t, err)
+		require.Equal(t, authorizer.DecisionDeny, decision)
+		require.Equal(t, "calling service lacks TeamLBACRule read permission", reason)
+	})
+
+	t.Run("denies a user even with delegated TeamLBACRule read permission", func(t *testing.T) {
+		authInfo := authn.NewIDTokenAuthInfo(
+			authn.Claims[authn.AccessTokenClaims]{
+				Rest: authn.AccessTokenClaims{DelegatedPermissions: []string{"iam.grafana.app/teamlbacrules:get"}},
+			},
+			&authn.Claims[authn.IDTokenClaims]{Rest: authn.IDTokenClaims{Type: types.TypeUser}},
+		)
+		decision, reason, err := authz.Authorize(types.WithAuthInfo(context.Background(), authInfo), forSubject)
+		require.NoError(t, err)
+		require.Equal(t, authorizer.DecisionDeny, decision)
+		require.Equal(t, "for-subject only accepts direct service calls", reason)
+	})
+
+	t.Run("keeps base CRUD delegated to its existing authorizer", func(t *testing.T) {
+		baseCalled = false
+		baseGet := forSubject
+		baseGet.Subresource = ""
+		decision, _, err := authz.Authorize(context.Background(), baseGet)
+		require.NoError(t, err)
+		require.Equal(t, authorizer.DecisionAllow, decision)
+		require.True(t, baseCalled)
+	})
+}
+
 // TestAuthorizerCheckRequest verifies that each authorizer builds the correct
 // CheckRequest when its custom subresources are accessed.
 func TestAuthorizerCheckRequest(t *testing.T) {

--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -491,45 +491,9 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *ge
 	}
 
 	if enableTeamLBACRuleApi {
-		// TeamLBACRule registration is delegated to the TeamLBACApiInstaller
-		if err := b.teamLBACApiInstaller.RegisterStorage(apiGroupInfo, &opts, storage); err != nil {
+		if err := b.UpdateTeamLBACRulesAPIGroup(apiGroupInfo, opts, storage); err != nil {
 			return err
 		}
-
-		teamLBACRuleGetter, ok := storage[iamv0.TeamLBACRuleInfo.StoragePath()].(rest.Getter)
-		if !ok {
-			return fmt.Errorf("TeamLBACRule storage does not implement rest.Getter")
-		}
-
-		// TeamLBAC can be enabled in ST without serving the Team Kubernetes API.
-		// Prefer the registered Team storage when present because it already
-		// reflects the configured dual-write mode; otherwise evaluate membership
-		// through the internal legacy Team store.
-		teamStorage := storage[iamv0.TeamResourceInfo.StoragePath()]
-		if teamStorage == nil && b.legacyTeamStore != nil {
-			teamStorage = b.legacyTeamStore
-		}
-		teamGetter, ok := teamStorage.(rest.Getter)
-		if !ok {
-			return fmt.Errorf("TeamLBACRule for-subject subresource requires Team getter storage")
-		}
-		teamLister, ok := teamStorage.(rest.Lister)
-		if !ok {
-			return fmt.Errorf("TeamLBACRule for-subject subresource requires Team lister storage")
-		}
-		// Kubernetes requires a separate storage-map entry for each named
-		// subresource. Its value is a Connect handler, not another persistence
-		// store: the handler delegates rule reads to teamLBACRuleGetter, the
-		// mode-aware CRUD storage already registered at "teamlbacrules" above.
-		// Team's addmember/removemember subresources use the same pattern. This
-		// entry therefore adds only GET
-		// /teamlbacrules/{name}/for-subject/{type}/{uid}.
-		storage[iamv0.TeamLBACRuleInfo.StoragePath("for-subject")] = teamlbacapi.NewRulesForSubjectREST(
-			teamLBACRuleGetter,
-			teamGetter,
-			teamLister,
-			b.tracing,
-		)
 	}
 
 	if enableRoleBindingsApi {
@@ -558,6 +522,53 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *ge
 	}
 
 	apiGroupInfo.VersionedResourcesStorageMap[legacyiamv0.VERSION] = storage
+	return nil
+}
+
+func (b *IdentityAccessManagementAPIBuilder) UpdateTeamLBACRulesAPIGroup(
+	apiGroupInfo *genericapiserver.APIGroupInfo,
+	opts builder.APIGroupOptions,
+	storage map[string]rest.Storage,
+) error {
+	// TeamLBACRule registration is delegated to the TeamLBACApiInstaller.
+	if err := b.teamLBACApiInstaller.RegisterStorage(apiGroupInfo, &opts, storage); err != nil {
+		return err
+	}
+
+	teamLBACRuleGetter, ok := storage[iamv0.TeamLBACRuleInfo.StoragePath()].(rest.Getter)
+	if !ok {
+		return fmt.Errorf("TeamLBACRule storage does not implement rest.Getter")
+	}
+
+	// TeamLBAC can be enabled in ST without serving the Team Kubernetes API.
+	// Prefer the registered Team storage when present because it already
+	// reflects the configured dual-write mode; otherwise evaluate membership
+	// through the internal legacy Team store.
+	teamStorage := storage[iamv0.TeamResourceInfo.StoragePath()]
+	if teamStorage == nil && b.legacyTeamStore != nil {
+		teamStorage = b.legacyTeamStore
+	}
+	teamGetter, ok := teamStorage.(rest.Getter)
+	if !ok {
+		return fmt.Errorf("TeamLBACRule for-subject subresource requires Team getter storage")
+	}
+	teamLister, ok := teamStorage.(rest.Lister)
+	if !ok {
+		return fmt.Errorf("TeamLBACRule for-subject subresource requires Team lister storage")
+	}
+	// Kubernetes requires a separate storage-map entry for each named
+	// subresource. Its value is a Connect handler, not another persistence
+	// store: the handler delegates rule reads to teamLBACRuleGetter, the
+	// mode-aware CRUD storage already registered at "teamlbacrules" above.
+	// Team's addmember/removemember subresources use the same pattern. This
+	// entry therefore adds only GET
+	// /teamlbacrules/{name}/for-subject/{type}/{uid}.
+	storage[iamv0.TeamLBACRuleInfo.StoragePath("for-subject")] = teamlbacapi.NewRulesForSubjectREST(
+		teamLBACRuleGetter,
+		teamGetter,
+		teamLister,
+		b.tracing,
+	)
 	return nil
 }
 

--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -45,6 +45,7 @@ import (
 	"github.com/grafana/grafana/pkg/registry/apis/iam/sso"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/team"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/teambinding"
+	teamlbacapi "github.com/grafana/grafana/pkg/registry/apis/iam/teamlbac"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/user"
 	"github.com/grafana/grafana/pkg/registry/fieldselectors"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -494,6 +495,41 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *ge
 		if err := b.teamLBACApiInstaller.RegisterStorage(apiGroupInfo, &opts, storage); err != nil {
 			return err
 		}
+
+		teamLBACRuleGetter, ok := storage[iamv0.TeamLBACRuleInfo.StoragePath()].(rest.Getter)
+		if !ok {
+			return fmt.Errorf("TeamLBACRule storage does not implement rest.Getter")
+		}
+
+		// TeamLBAC can be enabled in ST without serving the Team Kubernetes API.
+		// Prefer the registered Team storage when present because it already
+		// reflects the configured dual-write mode; otherwise evaluate membership
+		// through the internal legacy Team store.
+		teamStorage := storage[iamv0.TeamResourceInfo.StoragePath()]
+		if teamStorage == nil && b.legacyTeamStore != nil {
+			teamStorage = b.legacyTeamStore
+		}
+		teamGetter, ok := teamStorage.(rest.Getter)
+		if !ok {
+			return fmt.Errorf("TeamLBACRule for-subject subresource requires Team getter storage")
+		}
+		teamLister, ok := teamStorage.(rest.Lister)
+		if !ok {
+			return fmt.Errorf("TeamLBACRule for-subject subresource requires Team lister storage")
+		}
+		// Kubernetes requires a separate storage-map entry for each named
+		// subresource. Its value is a Connect handler, not another persistence
+		// store: the handler delegates rule reads to teamLBACRuleGetter, the
+		// mode-aware CRUD storage already registered at "teamlbacrules" above.
+		// Team's addmember/removemember subresources use the same pattern. This
+		// entry therefore adds only GET
+		// /teamlbacrules/{name}/for-subject/{type}/{uid}.
+		storage[iamv0.TeamLBACRuleInfo.StoragePath("for-subject")] = teamlbacapi.NewRulesForSubjectREST(
+			teamLBACRuleGetter,
+			teamGetter,
+			teamLister,
+			b.tracing,
+		)
 	}
 
 	if enableRoleBindingsApi {

--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -219,7 +219,7 @@ func NewAPIService(
 	roleAuthorizer := roleApiInstaller.GetAuthorizer()
 	roleBindingsAuthorizer := roleBindingsApiInstaller.GetAuthorizer()
 	serviceAccountAuthorizer := newServiceAccountAuthorizer(accessClient)
-	teamLBACAuthorizer := teamLBACApiInstaller.GetAuthorizer()
+	teamLBACAuthorizer := newTeamLBACRuleAuthorizer(teamLBACApiInstaller.GetAuthorizer())
 	resourceAuthorizer := gfauthorizer.NewResourceAuthorizer(accessClient)
 	userAuthorizer := newUserAuthorizer(accessClient)
 

--- a/pkg/registry/apis/iam/teamlbac/rest_rules_for_subject.go
+++ b/pkg/registry/apis/iam/teamlbac/rest_rules_for_subject.go
@@ -1,0 +1,216 @@
+package teamlbac
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"go.opentelemetry.io/otel/trace"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8srequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
+
+	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	apiutils "github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/registry/apis/iam/common"
+)
+
+const userSubjectType = "user"
+
+var (
+	_ rest.Storage   = (*RulesForSubjectREST)(nil)
+	_ rest.Scoper    = (*RulesForSubjectREST)(nil)
+	_ rest.Connecter = (*RulesForSubjectREST)(nil)
+)
+
+// RulesForSubjectREST evaluates a TeamLBACRule for a subject while IAM still
+// owns both rule and team storage selection. Callers receive Kubernetes-style
+// filters and remain responsible for converting them to a datasource-specific
+// representation.
+type RulesForSubjectREST struct {
+	ruleGetter rest.Getter
+	teamGetter rest.Getter
+	teamLister teamLister
+	tracer     trace.Tracer
+	logger     log.Logger
+}
+
+type teamLister interface {
+	List(ctx context.Context, options *metainternalversion.ListOptions) (runtime.Object, error)
+}
+
+func NewRulesForSubjectREST(ruleGetter rest.Getter, teamGetter rest.Getter, teamLister teamLister, tracer trace.Tracer) *RulesForSubjectREST {
+	return &RulesForSubjectREST{
+		ruleGetter: ruleGetter,
+		teamGetter: teamGetter,
+		teamLister: teamLister,
+		tracer:     tracer,
+		logger:     log.New("teamlbac.for-subject"),
+	}
+}
+
+func (s *RulesForSubjectREST) New() runtime.Object {
+	return iamv0.NewGetTeamLBACRulesForSubjectResponse()
+}
+
+func (s *RulesForSubjectREST) Destroy() {}
+
+func (s *RulesForSubjectREST) NamespaceScoped() bool {
+	return true
+}
+
+func (s *RulesForSubjectREST) NewConnectOptions() (runtime.Object, bool, string) {
+	return nil, true, ""
+}
+
+func (s *RulesForSubjectREST) ConnectMethods() []string {
+	return []string{http.MethodGet}
+}
+
+func (s *RulesForSubjectREST) Connect(ctx context.Context, datasourceName string, _ runtime.Object, responder rest.Responder) (http.Handler, error) {
+	return http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+		ctx, span := s.tracer.Start(req.Context(), "teamlbac.for-subject")
+		defer span.End()
+
+		requestInfo, ok := k8srequest.RequestInfoFrom(req.Context())
+		if !ok || len(requestInfo.Parts) != 5 || requestInfo.Parts[2] != "for-subject" {
+			responder.Error(apierrors.NewBadRequest("expected /for-subject/{type}/{uid}"))
+			return
+		}
+		subjectType := requestInfo.Parts[3]
+		subjectUID := requestInfo.Parts[4]
+		if subjectType != userSubjectType {
+			responder.Error(apierrors.NewBadRequest(fmt.Sprintf("unsupported subjectType %q", subjectType)))
+			return
+		}
+		if subjectUID == "" {
+			responder.Error(apierrors.NewBadRequest("subjectUID is required"))
+			return
+		}
+
+		response, err := s.getRulesForUser(common.WithSubresourceNamespace(ctx), datasourceName, subjectUID)
+		if err != nil {
+			responder.Error(err)
+			return
+		}
+		responder.Object(http.StatusOK, response)
+	}), nil
+}
+
+func (s *RulesForSubjectREST) getRulesForUser(ctx context.Context, datasourceName, userUID string) (*iamv0.GetTeamLBACRulesForSubjectResponse, error) {
+	// TeamLBACRule metadata.name identifies the datasource as
+	// "<datasource type>.<datasource UID>".
+	logger := s.logger.FromContext(ctx)
+	namespace := k8srequest.NamespaceValue(ctx)
+	obj, err := s.ruleGetter.Get(ctx, datasourceName, &metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	allRules, ok := obj.(*iamv0.TeamLBACRule)
+	if !ok {
+		return nil, apierrors.NewInternalError(fmt.Errorf("unexpected TeamLBACRule object type %T", obj))
+	}
+
+	response := iamv0.NewGetTeamLBACRulesForSubjectResponse()
+	response.TeamFilters = make(map[string][]string)
+	if len(allRules.Spec.TeamFilters) == 0 {
+		return response, nil
+	}
+
+	// Membership evaluation is internal IAM work. Use a service identity so a
+	// subject does not need permission to read Team resources merely to have
+	// their own datasource policy evaluated.
+	//
+	// Looking up only the teams referenced by this rule keeps work proportional
+	// to the datasource policy and works through the same mode-aware Team store.
+	// The tradeoff is one Team read, including its full membership list, per key.
+	// A reverse membership lookup can therefore be cheaper when a rule references
+	// many teams, but it returns every team for the user and legacy numeric rule
+	// keys would still need separate resolution.
+	teamCtx, _ := identity.WithServiceIdentity(ctx, 0)
+	missingTeamKeys := make([]string, 0)
+	for teamKey, filters := range allRules.Spec.TeamFilters {
+		if _, err := strconv.ParseInt(teamKey, 10, 64); err == nil {
+			// Numeric keys are retained only for rules written before team UIDs
+			// were normalized. Keep each compatibility lookup visible until those
+			// rules have been migrated.
+			logger.Warn("TeamLBACRule contains numeric team key; using legacy-ID compatibility lookup",
+				"namespace", namespace, "datasource", datasourceName, "teamKey", teamKey)
+		}
+		team, err := s.getTeam(teamCtx, teamKey)
+		if err != nil {
+			return nil, err
+		}
+		if team == nil {
+			missingTeamKeys = append(missingTeamKeys, teamKey)
+			continue
+		}
+		if !hasMember(team, userUID) {
+			continue
+		}
+		response.TeamFilters[teamKey] = append([]string(nil), filters...)
+	}
+	if len(missingTeamKeys) > 0 {
+		// Admission removes references to missing teams, so seeing one here
+		// means the stored rule predates cleanup or bypassed normal writes.
+		logger.Warn("TeamLBACRule references teams that do not exist",
+			"namespace", namespace, "datasource", datasourceName, "teamKeys", missingTeamKeys)
+	}
+	return response, nil
+}
+
+func (s *RulesForSubjectREST) getTeam(ctx context.Context, teamKey string) (*iamv0.Team, error) {
+	// Non-numeric keys are canonical Team UIDs, which are also the Team resource names.
+	if _, err := strconv.ParseInt(teamKey, 10, 64); err != nil {
+		obj, err := s.teamGetter.Get(ctx, teamKey, &metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+		team, ok := obj.(*iamv0.Team)
+		if !ok {
+			return nil, apierrors.NewInternalError(fmt.Errorf("unexpected Team object type %T", obj))
+		}
+		return team, nil
+	}
+
+	selector := labels.SelectorFromSet(labels.Set{
+		apiutils.LabelKeyDeprecatedInternalID: teamKey, //nolint:staticcheck // compatibility for pre-normalization TeamLBACRules
+	})
+	obj, err := s.teamLister.List(ctx, &metainternalversion.ListOptions{
+		LabelSelector: selector,
+		Limit:         2,
+	})
+	if err != nil {
+		return nil, err
+	}
+	teams, ok := obj.(*iamv0.TeamList)
+	if !ok {
+		return nil, apierrors.NewInternalError(fmt.Errorf("unexpected Team list object type %T", obj))
+	}
+	if len(teams.Items) == 0 {
+		return nil, nil
+	}
+	if len(teams.Items) > 1 {
+		return nil, apierrors.NewInternalError(fmt.Errorf("legacy team ID %q resolved to more than one team", teamKey))
+	}
+	return &teams.Items[0], nil
+}
+
+func hasMember(team *iamv0.Team, userUID string) bool {
+	for _, member := range team.Spec.Members {
+		if member.Name == userUID {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/registry/apis/iam/teamlbac/rest_rules_for_subject_test.go
+++ b/pkg/registry/apis/iam/teamlbac/rest_rules_for_subject_test.go
@@ -1,0 +1,213 @@
+package teamlbac
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8srequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
+
+	claims "github.com/grafana/authlib/types"
+	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	apiutils "github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/infra/tracing"
+)
+
+type getterFunc func(context.Context, string, *metav1.GetOptions) (runtime.Object, error)
+
+func (f getterFunc) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	return f(ctx, name, options)
+}
+
+type listerFunc func(context.Context, *metainternalversion.ListOptions) (runtime.Object, error)
+
+func (f listerFunc) List(ctx context.Context, options *metainternalversion.ListOptions) (runtime.Object, error) {
+	return f(ctx, options)
+}
+
+type testResponder struct {
+	status int
+	obj    runtime.Object
+	err    error
+}
+
+func (r *testResponder) Object(status int, obj runtime.Object) {
+	r.status = status
+	r.obj = obj
+}
+
+func (r *testResponder) Error(err error) {
+	r.err = err
+}
+
+func TestRulesForSubjectRESTGetRulesForUser(t *testing.T) {
+	rule := &iamv0.TeamLBACRule{
+		Spec: iamv0.TeamLBACRuleSpec{
+			TeamFilters: map[string][]string{
+				"team-a": {`foo="a"`},
+				"team-b": {`foo="b"`},
+				"42":     {`legacy="yes"`},
+			},
+		},
+	}
+	ruleGetter := getterFunc(func(_ context.Context, name string, _ *metav1.GetOptions) (runtime.Object, error) {
+		require.Equal(t, "prometheus.datasource-a", name)
+		return rule, nil
+	})
+	teamGetter := getterFunc(func(ctx context.Context, name string, _ *metav1.GetOptions) (runtime.Object, error) {
+		requester, err := identity.GetRequester(ctx)
+		require.NoError(t, err)
+		require.True(t, requester.IsIdentityType(claims.TypeAccessPolicy))
+
+		switch name {
+		case "team-a":
+			return teamWithMembers(name, "user-a"), nil
+		case "team-b":
+			return teamWithMembers(name, "another-user"), nil
+		default:
+			return nil, apierrors.NewNotFound(iamv0.TeamResourceInfo.GroupResource(), name)
+		}
+	})
+	teamLister := listerFunc(func(_ context.Context, options *metainternalversion.ListOptions) (runtime.Object, error) {
+		require.Equal(t, int64(2), options.Limit)
+		require.True(t, options.LabelSelector.Matches(labels.Set{
+			apiutils.LabelKeyDeprecatedInternalID: "42", //nolint:staticcheck // compatibility for pre-normalization TeamLBACRules
+		}))
+		return &iamv0.TeamList{Items: []iamv0.Team{*teamWithMembers("team-old", "user-a")}}, nil
+	})
+
+	handler := NewRulesForSubjectREST(ruleGetter, teamGetter, teamLister, tracing.NewNoopTracerService())
+	response, err := handler.getRulesForUser(context.Background(), "prometheus.datasource-a", "user-a")
+	require.NoError(t, err)
+	require.Equal(t, map[string][]string{
+		"team-a": {`foo="a"`},
+		"42":     {`legacy="yes"`},
+	}, response.TeamFilters)
+}
+
+func TestRulesForSubjectRESTIgnoresMissingTeams(t *testing.T) {
+	ruleGetter := getterFunc(func(context.Context, string, *metav1.GetOptions) (runtime.Object, error) {
+		return &iamv0.TeamLBACRule{Spec: iamv0.TeamLBACRuleSpec{
+			TeamFilters: map[string][]string{"deleted-team": {`foo="bar"`}},
+		}}, nil
+	})
+	teamGetter := getterFunc(func(_ context.Context, name string, _ *metav1.GetOptions) (runtime.Object, error) {
+		return nil, apierrors.NewNotFound(iamv0.TeamResourceInfo.GroupResource(), name)
+	})
+	teamLister := listerFunc(func(context.Context, *metainternalversion.ListOptions) (runtime.Object, error) {
+		return &iamv0.TeamList{}, nil
+	})
+
+	handler := NewRulesForSubjectREST(ruleGetter, teamGetter, teamLister, tracing.NewNoopTracerService())
+	response, err := handler.getRulesForUser(context.Background(), "prometheus.datasource-a", "user-a")
+	require.NoError(t, err)
+	require.Empty(t, response.TeamFilters)
+}
+
+func TestRulesForSubjectRESTPropagatesRuleReadErrors(t *testing.T) {
+	wantErr := errors.New("rule read failed")
+	ruleGetter := getterFunc(func(context.Context, string, *metav1.GetOptions) (runtime.Object, error) {
+		return nil, wantErr
+	})
+	unusedGetter := getterFunc(func(context.Context, string, *metav1.GetOptions) (runtime.Object, error) {
+		t.Fatal("team getter should not be called")
+		return nil, nil
+	})
+	unusedLister := listerFunc(func(context.Context, *metainternalversion.ListOptions) (runtime.Object, error) {
+		t.Fatal("team lister should not be called")
+		return nil, nil
+	})
+
+	handler := NewRulesForSubjectREST(ruleGetter, unusedGetter, unusedLister, tracing.NewNoopTracerService())
+	response, err := handler.getRulesForUser(context.Background(), "prometheus.datasource-a", "user-a")
+	require.ErrorIs(t, err, wantErr)
+	require.Nil(t, response)
+}
+
+func TestRulesForSubjectRESTValidatesSubject(t *testing.T) {
+	unusedGetter := getterFunc(func(context.Context, string, *metav1.GetOptions) (runtime.Object, error) {
+		t.Fatal("storage should not be called")
+		return nil, nil
+	})
+	unusedLister := listerFunc(func(context.Context, *metainternalversion.ListOptions) (runtime.Object, error) {
+		t.Fatal("storage should not be called")
+		return nil, nil
+	})
+	handler := NewRulesForSubjectREST(unusedGetter, unusedGetter, unusedLister, tracing.NewNoopTracerService())
+
+	tests := []struct {
+		name  string
+		parts []string
+	}{
+		{name: "missing path parameters", parts: []string{"teamlbacrules", "prometheus.datasource-a", "for-subject"}},
+		{name: "unsupported subject type", parts: subjectRequestParts("service-account", "sa-a")},
+		{name: "missing subject UID", parts: subjectRequestParts("user", "")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			responder := &testResponder{}
+			httpHandler, err := handler.Connect(context.Background(), "prometheus.datasource-a", nil, responder)
+			require.NoError(t, err)
+			ctx := k8srequest.WithRequestInfo(context.Background(), &k8srequest.RequestInfo{Parts: tt.parts})
+			req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+			httpHandler.ServeHTTP(httptest.NewRecorder(), req)
+			require.True(t, apierrors.IsBadRequest(responder.err))
+			require.Nil(t, responder.obj)
+		})
+	}
+}
+
+func TestRulesForSubjectRESTConnectReturnsRules(t *testing.T) {
+	ruleGetter := getterFunc(func(ctx context.Context, _ string, _ *metav1.GetOptions) (runtime.Object, error) {
+		require.Equal(t, "org-1", k8srequest.NamespaceValue(ctx))
+		return &iamv0.TeamLBACRule{Spec: iamv0.TeamLBACRuleSpec{
+			TeamFilters: map[string][]string{"team-a": {`foo="bar"`}},
+		}}, nil
+	})
+	teamGetter := getterFunc(func(context.Context, string, *metav1.GetOptions) (runtime.Object, error) {
+		return teamWithMembers("team-a", "user-a"), nil
+	})
+	unusedLister := listerFunc(func(context.Context, *metainternalversion.ListOptions) (runtime.Object, error) {
+		t.Fatal("numeric team lister should not be called")
+		return nil, nil
+	})
+	handler := NewRulesForSubjectREST(ruleGetter, teamGetter, unusedLister, tracing.NewNoopTracerService())
+	responder := &testResponder{}
+	httpHandler, err := handler.Connect(context.Background(), "prometheus.datasource-a", nil, responder)
+	require.NoError(t, err)
+
+	ctx := identity.WithRequester(context.Background(), &identity.StaticRequester{Namespace: "org-1"})
+	ctx = k8srequest.WithRequestInfo(ctx, &k8srequest.RequestInfo{Parts: subjectRequestParts("user", "user-a")})
+	req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+	httpHandler.ServeHTTP(httptest.NewRecorder(), req)
+
+	require.NoError(t, responder.err)
+	require.Equal(t, http.StatusOK, responder.status)
+	response, ok := responder.obj.(*iamv0.GetTeamLBACRulesForSubjectResponse)
+	require.True(t, ok)
+	require.Equal(t, map[string][]string{"team-a": {`foo="bar"`}}, response.TeamFilters)
+}
+
+func subjectRequestParts(subjectType, subjectUID string) []string {
+	return []string{"teamlbacrules", "prometheus.datasource-a", "for-subject", subjectType, subjectUID}
+}
+
+func teamWithMembers(name string, members ...string) *iamv0.Team {
+	team := &iamv0.Team{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	for _, member := range members {
+		team.Spec.Members = append(team.Spec.Members, iamv0.TeamTeamMember{Name: member})
+	}
+	return team
+}
+
+var _ rest.Responder = (*testResponder)(nil)

--- a/pkg/tests/apis/openapi_snapshots/iam.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/iam.grafana.app-v0alpha1.json
@@ -3679,6 +3679,48 @@
           }
         ]
       },
+      "com.github.grafana.grafana.apps.iam.pkg.apis.iam.v0alpha1.GetTeamLBACRulesForSubjectRouteBody": {
+        "type": "object",
+        "required": [
+          "team_filters"
+        ],
+        "properties": {
+          "team_filters": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "com.github.grafana.grafana.apps.iam.pkg.apis.iam.v0alpha1.GetTeamLBACRulesForSubjectRouteResponse": {
+        "type": "object",
+        "required": [
+          "team_filters"
+        ],
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "team_filters": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
       "com.github.grafana.grafana.apps.iam.pkg.apis.iam.v0alpha1.GetTeamMembersBody": {
         "type": "object",
         "required": [


### PR DESCRIPTION
**What is this feature?**

Adds a TeamLBACRule subresource that returns the filters applicable to a specific subject:

GET /apis/iam.grafana.app/v0alpha1/namespaces/{namespace}/teamlbacrules/{datasource}/for-subject/{type}/{uid}

The initial supported subject type is user. IAM reads the TeamLBACRule through its existing mode-aware CRUD storage, resolves the referenced Teams through the registered Team storage, and returns only filters for Teams containing that user. It retains read compatibility for legacy numeric team IDs and logs legacy or missing Team references.

This also adds a typed client method. The method is handwritten because current App SDK client generation preserves path placeholders instead of interpolating them.

**Why do we need this feature?**

Team LBAC middleware currently has to coordinate rule reads, Team membership, legacy numeric-ID compatibility, and storage migration behavior itself. Centralizing subject evaluation in IAM provides one storage-aware API that both single-tenant and multi-tenant middleware can consume, allowing them to share an implementation in a follow-up change.

**Who is this feature for?**

This is an internal API for Grafana datasource query paths that apply Team LBAC policy before sending requests to datasource plugins.

**Special notes for your reviewer:**

- The subresource is registered only when the existing TeamLBACRule API feature toggle is enabled.
- Its Connect handler is a separate Kubernetes subresource entry, but delegates rule reads to the same mode-aware storage used by TeamLBACRule CRUD.
- ST was tested with direct requests for matching and non-matching users.
- MT was tested with normal, legacy-only, numeric-ID, Tempo, and non-member fixtures after temporarily making legacy Team storage available to the MT Team API. That temporary wiring is not included. The missing MT Team storage integration has been reported to its maintainer.
- A follow-up will replace the separate MT membership/reconciliation middleware flow with this single subresource call.

Tests:

- go test ./apps/iam/pkg/apis/iam/v0alpha1
- go test ./pkg/registry/apis/iam/teamlbac
- go test ./pkg/registry/apis/iam

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] No documentation update is needed for this internal API.