### PR TITLE
fix(triage): post the contributor checklist when the agent review runs

### DIFF
--- a/.github/workflows/external-pr-notify-handler.yml
+++ b/.github/workflows/external-pr-notify-handler.yml
@@ -474,8 +474,10 @@ jobs:
           SLOP_REASON: ${{ needs.triage.outputs.slop_reason }}
         run: node ./community-triage/.github/workflows/scripts/pr-notify.mts notify
 
-      - name: Post fallback comment
-        if: needs.review.outputs.review_line == '' && steps.notify.outputs.notification_sent == 'true'
+      # The script skips the greeting when the review already delivered it, and
+      # comments nothing when there is nothing outstanding.
+      - name: Post welcome comment and contributor checklist
+        if: steps.notify.outputs.notification_sent == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ needs.triage.outputs.pr_number }}


### PR DESCRIPTION
The step only ran when the agent review produced nothing, so on teams with agent review enabled the contributor checklist was never posted. The script already skips the greeting when the review has delivered it, and comments nothing when there is nothing outstanding.