### PR TITLE
Notebooks: Add fixed RBAC roles

### DIFF
--- a/pkg/api/accesscontrol.go
+++ b/pkg/api/accesscontrol.go
@@ -362,13 +362,14 @@ func FixedRoleRegistrations(viewersCanEdit, dsPermissionsEnforced bool) []ac.Rol
 		Grants: []string{"Admin"},
 	}
 
-	// Notebooks (experimental) have no folder UI yet, so they are created at the root and folder
-	// inheritance cannot reach them. These flat org-wide roles keep notebooks visible/usable under
-	// Unified Storage enforcement: read on the notebooks:* object scope (reaches folderless
-	// notebooks), and create on folders:* (the create verb resolves root to the general folder).
-	// MVP-only: once a folder UI exists, narrow these to folder-scoped grants and lean on the
-	// folder-inheritance action sets instead (a Viewer wildcard would otherwise expose notebooks in
-	// restricted folders).
+	// Notebooks (experimental) are flat and folderless for the MVP: notebook storage has
+	// EnableFolderSupport=false (pkg/registry/apis/dashboard/register.go), so a notebook cannot be
+	// placed in a folder and folder inheritance never applies. These org-wide roles grant notebook
+	// access under Unified Storage enforcement: read/write/delete on the notebooks:* object scope,
+	// and create on folders:* (the create verb resolves root to the general folder). The Viewer read
+	// wildcard is safe precisely because no folder-scoped notebook can exist, so it cannot bypass any
+	// folder ACL. At GA, folder support is enabled and these narrow to folder-scoped grants (dropping
+	// the Viewer wildcard), matching dashboards.
 	notebooksReaderRole := ac.RoleRegistration{
 		Role: ac.RoleDTO{
 			Name:        "fixed:notebooks:reader",

--- a/pkg/api/accesscontrol.go
+++ b/pkg/api/accesscontrol.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/libraryelements"
+	"github.com/grafana/grafana/pkg/services/notebooks"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginaccesscontrol"
 	"github.com/grafana/grafana/pkg/services/publicdashboards"
@@ -361,6 +362,41 @@ func FixedRoleRegistrations(viewersCanEdit, dsPermissionsEnforced bool) []ac.Rol
 		Grants: []string{"Admin"},
 	}
 
+	// Notebooks (experimental) have no folder UI yet, so they are created at the root and folder
+	// inheritance cannot reach them. These flat org-wide roles keep notebooks visible/usable under
+	// Unified Storage enforcement: read on the notebooks:* object scope (reaches folderless
+	// notebooks), and create on folders:* (the create verb resolves root to the general folder).
+	// MVP-only: once a folder UI exists, narrow these to folder-scoped grants and lean on the
+	// folder-inheritance action sets instead (a Viewer wildcard would otherwise expose notebooks in
+	// restricted folders).
+	notebooksReaderRole := ac.RoleRegistration{
+		Role: ac.RoleDTO{
+			Name:        "fixed:notebooks:reader",
+			DisplayName: "Reader",
+			Group:       "Notebooks",
+			Description: "Read all notebooks.",
+			Permissions: []ac.Permission{
+				{Action: notebooks.ActionNotebooksRead, Scope: notebooks.ScopeNotebooksAll},
+			},
+		},
+		Grants: []string{string(org.RoleViewer)},
+	}
+
+	notebooksWriterRole := ac.RoleRegistration{
+		Role: ac.RoleDTO{
+			Name:        "fixed:notebooks:writer",
+			DisplayName: "Writer",
+			Group:       "Notebooks",
+			Description: "Create, read, write or delete all notebooks.",
+			Permissions: ac.ConcatPermissions(notebooksReaderRole.Role.Permissions, []ac.Permission{
+				{Action: notebooks.ActionNotebooksWrite, Scope: notebooks.ScopeNotebooksAll},
+				{Action: notebooks.ActionNotebooksDelete, Scope: notebooks.ScopeNotebooksAll},
+				{Action: notebooks.ActionNotebooksCreate, Scope: folder.ScopeFoldersAll},
+			}),
+		},
+		Grants: []string{string(org.RoleEditor)},
+	}
+
 	foldersCreatorRole := ac.RoleRegistration{
 		Role: ac.RoleDTO{
 			Name:        "fixed:folders:creator",
@@ -658,6 +694,7 @@ func FixedRoleRegistrations(viewersCanEdit, dsPermissionsEnforced bool) []ac.Rol
 		orgMaintainerRole, teamsCreatorRole, teamsWriterRole, teamsReaderRole, datasourcesExplorerRole,
 		annotationsReaderRole, annotationsWriterRole,
 		dashboardsCreatorRole, dashboardsReaderRole, dashboardsWriterRole,
+		notebooksReaderRole, notebooksWriterRole,
 		foldersCreatorRole, foldersReaderRole, generalFolderReaderRole, foldersWriterRole,
 		publicDashboardsWriterRole, featuremgmtReaderRole, featuremgmtWriterRole, libraryPanelsCreatorRole,
 		libraryPanelsReaderRole, libraryPanelsWriterRole, libraryPanelsGeneralReaderRole, libraryPanelsGeneralWriterRole,

--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -1027,8 +1027,16 @@ func (b *DashboardsAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver
 	// Notebook storage is always registered so FlagDashboardNotebooks can be
 	// evaluated per request (and targeted per tenant) via OpenFeature in the
 	// authorizer, without requiring a restart. See GetAuthorizer.
+	//
+	// EnableFolderSupport is deliberately OFF for the MVP: notebook RBAC is a flat, org-wide
+	// grant (fixed:notebooks:reader/writer on notebooks:*, see pkg/api/accesscontrol.go), and
+	// there is no folder UI. If folder-scoped notebooks could exist (e.g. created via API or
+	// provisioning with a grafana.app/folder annotation), that wildcard would let every Viewer
+	// read them regardless of the folder's permissions. Forbidding a folder annotation keeps
+	// every notebook folderless, so the wildcard cannot bypass any folder ACL. Flip this back to
+	// true at GA, when a folder UI and folder-scoped notebook RBAC replace the flat grants.
 	opts.StorageOptsRegister(dashv2beta1.NotebookResourceInfo.GroupResource(), apistore.StorageOptions{
-		EnableFolderSupport: true,
+		EnableFolderSupport: false,
 	})
 
 	nbStore, err := grafanaregistry.NewRegistryStore(opts.Scheme, dashv2beta1.NotebookResourceInfo, opts.OptsGetter)

--- a/pkg/services/accesscontrol/permreg/permreg.go
+++ b/pkg/services/accesscontrol/permreg/permreg.go
@@ -85,6 +85,7 @@ func newPermissionRegistry() *permissionRegistry {
 		"datasources":                    "datasources:uid:",
 		"dashboards":                     "dashboards:uid:",
 		"folders":                        "folders:uid:",
+		"notebooks":                      "notebooks:uid:",
 		"annotations":                    "annotations:type:",
 		"orgs":                           "orgs:id:",
 		"plugins":                        "plugins:id:",

--- a/pkg/services/accesscontrol/permreg/permreg_test.go
+++ b/pkg/services/accesscontrol/permreg/permreg_test.go
@@ -199,6 +199,43 @@ func Test_permissionRegistry_IsPermissionValid(t *testing.T) {
 	}
 }
 
+// Guards the notebooks kind registration: the fixed:notebooks:* roles declare notebooks:*-scoped
+// permissions, and without the kindScopePrefix entry RegisterPermission fails and startup aborts.
+func Test_permissionRegistry_Notebooks(t *testing.T) {
+	pr := newPermissionRegistry()
+
+	require.Equal(t, "notebooks:uid:", pr.kindScopePrefix["notebooks"], "notebooks kind must be registered")
+
+	// Mirrors the grants declared by fixed:notebooks:reader/writer.
+	require.NoError(t, pr.RegisterPermission("notebooks:read", "notebooks:*"))
+	require.NoError(t, pr.RegisterPermission("notebooks:write", "notebooks:*"))
+	require.NoError(t, pr.RegisterPermission("notebooks:delete", "notebooks:*"))
+	require.NoError(t, pr.RegisterPermission("notebooks:create", "folders:*"))
+
+	tests := []struct {
+		name    string
+		action  string
+		scope   string
+		wantErr bool
+	}{
+		{name: "read on an object uid", action: "notebooks:read", scope: "notebooks:uid:abc", wantErr: false},
+		{name: "read on the kind wildcard", action: "notebooks:read", scope: "notebooks:*", wantErr: false},
+		{name: "create on the folder wildcard", action: "notebooks:create", scope: "folders:*", wantErr: false},
+		{name: "create on the general folder", action: "notebooks:create", scope: "folders:uid:general", wantErr: false},
+		{name: "read rejects a foreign kind scope", action: "notebooks:read", scope: "dashboards:uid:abc", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := pr.IsPermissionValid(tt.action, tt.scope)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
 func Test_permissionRegistry_GetScopePrefixes(t *testing.T) {
 	pr := newPermissionRegistry()
 	err := pr.RegisterPermission("folders:read", "folders:uid:")

--- a/pkg/services/notebooks/accesscontrol.go
+++ b/pkg/services/notebooks/accesscontrol.go
@@ -6,6 +6,10 @@ package notebooks
 // later with the notebook resource-permission service.
 const (
 	ScopeNotebooksRoot = "notebooks"
+	// ScopeNotebooksAll is the wildcard object scope (mirrors dashboards.ScopeDashboardsAll). It is
+	// what reaches notebooks by their own uid, including folderless (root) notebooks that no
+	// folder-inherited grant covers.
+	ScopeNotebooksAll = "notebooks:*"
 
 	ActionNotebooksCreate = "notebooks:create"
 	ActionNotebooksRead   = "notebooks:read"


### PR DESCRIPTION
  **What is this feature?**

  Flat, org-wide RBAC for notebooks so they remain usable under Unified Storage enforcement:
  - `fixed:notebooks:reader` (Viewer) → `notebooks:read` on `notebooks:*`
  - `fixed:notebooks:writer` (Editor) → read/write/delete on `notebooks:*` and `notebooks:create` on `folders:*`
  - Registers the `notebooks` kind in the permission registry (`notebooks:uid:`) so the grants validate.
  - Sets `EnableFolderSupport: false` on the notebook storage so notebooks stay folderless in the MVP.

<img width="706" height="453" alt="image" src="https://github.com/user-attachments/assets/abe5f628-15ca-435e-a7cd-01b7e0a5c97a" />

  **Why do we need this feature?**

  Notebooks got RBAC plumbing in #130985 (authz mapper + folder-inheritance action sets), but there is no folder UI, so notebooks are created at the root (folderless). Folder inheritance can't reach folderless objects, so under opt-out enforcement notebooks silently disappear from every non-admin's list. These flat grants keep notebooks readable/creatable org-wide: `notebooks:*` reaches folderless notebooks by object scope, and
  `notebooks:create` on `folders:*` covers root creation (the create verb resolves root → General). They mirror `fixed:dashboards:reader/writer`.

  **Who is this feature for?**
  Operators running the experimental `dashboard.notebooks` feature under RBAC enforcement.

  **Special notes for your reviewer:**
  The Viewer read grant is a wildcard (`notebooks:*`), which would bypass a folder's ACL for any folder-scoped notebook. Rather than rely on  "there's no folder UI" (a notebook could still be foldered via API/provisioning), this PR sets `EnableFolderSupport: false` on the notebook storage: a `grafana.app/folder` annotation is rejected, so no folder-scoped notebook can exist and the wildcard has nothing to bypass. At GA — with a folder UI and folder-scoped notebook RBAC — we flip `EnableFolderSupport` back to true and narrow these to folder-scoped grants (dropping
  the Viewer wildcard), matching dashboards. Backend-only, no frontend change; the notebook resource itself stays gated by the `dashboard.notebooks` toggle.