### PR TITLE
Nav: Avoid escaped HTML entities in nav tooltips

### DIFF
--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuItemText.test.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuItemText.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from 'test/test-utils';
+
+import { contextSrv } from 'app/core/services/context_srv';
+
+import { MegaMenuItemText, type Props } from './MegaMenuItemText';
+
+const renderItemText = (props: Partial<Props> = {}) => {
+  return render(
+    <MegaMenuItemText
+      url="/explore"
+      itemName="Explore"
+      onPin={() => {}}
+      isPinned={false}
+      canCustomise={false}
+      editMode={false}
+      isHideable={false}
+      isHidden={false}
+      onToggleHidden={() => {}}
+      {...props}
+    >
+      <span>Explore & Test</span>
+    </MegaMenuItemText>
+  );
+};
+
+describe('MegaMenuItemText', () => {
+  beforeEach(() => {
+    contextSrv.isSignedIn = true;
+  });
+
+  afterEach(() => {
+    contextSrv.isSignedIn = false;
+  });
+
+  it('keeps ampersands unescaped in the legacy bookmark tooltip', async () => {
+    const { user } = renderItemText({ itemName: 'Explore & Test', canCustomise: false });
+
+    await user.hover(screen.getByLabelText('Bookmark Explore & Test'));
+    const tooltip = await screen.findByRole('tooltip');
+
+    expect(tooltip).toHaveTextContent('Bookmark Explore & Test');
+    expect(tooltip).not.toHaveTextContent('Bookmark Explore &amp; Test');
+  });
+
+  it('keeps ampersands unescaped in pin and hide tooltips when customising an unpinned visible item', async () => {
+    const { user } = renderItemText({
+      itemName: 'Explore & Test',
+      canCustomise: true,
+      editMode: true,
+      isPinned: false,
+      isHideable: true,
+      isHidden: false,
+    });
+
+    await user.hover(screen.getByLabelText('Pin Explore & Test'));
+    const pinTooltip = await screen.findByRole('tooltip');
+    expect(pinTooltip).toHaveTextContent('Pin Explore & Test');
+    expect(pinTooltip).not.toHaveTextContent('Pin Explore &amp; Test');
+
+    await user.hover(screen.getByLabelText('Hide Explore & Test'));
+    const hideTooltip = await screen.findByRole('tooltip');
+    expect(hideTooltip).toHaveTextContent('Hide Explore & Test');
+    expect(hideTooltip).not.toHaveTextContent('Hide Explore &amp; Test');
+  });
+
+  it('keeps ampersands unescaped in unpin and show tooltips when customising a pinned hidden item', async () => {
+    const { user } = renderItemText({
+      itemName: 'Explore & Test',
+      canCustomise: true,
+      editMode: true,
+      isPinned: true,
+      isHideable: true,
+      isHidden: true,
+    });
+
+    await user.hover(screen.getByLabelText('Unpin Explore & Test'));
+    const unpinTooltip = await screen.findByRole('tooltip');
+    expect(unpinTooltip).toHaveTextContent('Unpin Explore & Test');
+    expect(unpinTooltip).not.toHaveTextContent('Unpin Explore &amp; Test');
+
+    await user.hover(screen.getByLabelText('Show Explore & Test'));
+    const showTooltip = await screen.findByRole('tooltip');
+    expect(showTooltip).toHaveTextContent('Show Explore & Test');
+    expect(showTooltip).not.toHaveTextContent('Show Explore &amp; Test');
+  });
+});

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuItemText.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuItemText.tsx
@@ -57,11 +57,20 @@ export function MegaMenuItemText({
   const LinkComponent = !target && url.startsWith('/') ? Link : 'a';
 
   // Flag on: pin/unpin wording. Flag off: the legacy "Bookmark" wording.
-  let pinTooltip = t('navigation.item.bookmark.tooltip', 'Bookmark {{itemName}}', { itemName });
+  let pinTooltip = t('navigation.item.bookmark.tooltip', 'Bookmark {{itemName}}', {
+    itemName,
+    interpolation: { escapeValue: false },
+  });
   if (canCustomise) {
     pinTooltip = isPinned
-      ? t('navigation.item.unpin.tooltip', 'Unpin {{itemName}}', { itemName })
-      : t('navigation.item.pin.tooltip', 'Pin {{itemName}}', { itemName });
+      ? t('navigation.item.unpin.tooltip', 'Unpin {{itemName}}', {
+          itemName,
+          interpolation: { escapeValue: false },
+        })
+      : t('navigation.item.pin.tooltip', 'Pin {{itemName}}', {
+          itemName,
+          interpolation: { escapeValue: false },
+        });
   }
 
   // Pinning is a customisation action, so with customisation on the pin control only appears while
@@ -110,8 +119,14 @@ export function MegaMenuItemText({
       disabled={disabled}
       tooltip={
         isHidden
-          ? t('navigation.item.show.tooltip', 'Show {{itemName}}', { itemName })
-          : t('navigation.item.hide.tooltip', 'Hide {{itemName}}', { itemName })
+          ? t('navigation.item.show.tooltip', 'Show {{itemName}}', {
+              itemName,
+              interpolation: { escapeValue: false },
+            })
+          : t('navigation.item.hide.tooltip', 'Hide {{itemName}}', {
+              itemName,
+              interpolation: { escapeValue: false },
+            })
       }
     />
   );

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuPinnedItem.test.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuPinnedItem.test.tsx
@@ -7,12 +7,13 @@ import { type PinnedLine } from './utils';
 
 const renderItem = (
   activeItem?: NavModelItem,
-  item: NavModelItem = { text: 'Explore', url: '/explore', id: 'explore' }
+  item: NavModelItem = { text: 'Explore', url: '/explore', id: 'explore' },
+  options?: { editMode?: boolean }
 ) => {
   const line: PinnedLine = { item, ancestors: [], icon: 'compass' };
   return render(
     <ul>
-      <MegaMenuPinnedItem line={line} activeItem={activeItem} onUnpin={() => {}} />
+      <MegaMenuPinnedItem line={line} activeItem={activeItem} editMode={options?.editMode} onUnpin={() => {}} />
     </ul>
   );
 };
@@ -34,5 +35,16 @@ describe('MegaMenuPinnedItem', () => {
     renderItem(item, item);
 
     expect(screen.getByRole('link', { name: /Explore/ })).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('keeps ampersands unescaped in the unpin tooltip content', async () => {
+    const item: NavModelItem = { text: 'Explore & Test', url: '/explore', id: 'explore' };
+    const { user } = renderItem(undefined, item, { editMode: true });
+
+    await user.hover(screen.getByRole('button', { name: 'Unpin Explore & Test' }));
+    const tooltip = await screen.findByRole('tooltip');
+
+    expect(tooltip).toHaveTextContent('Unpin Explore & Test');
+    expect(tooltip).not.toHaveTextContent('Unpin Explore &amp; Test');
   });
 });

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuPinnedItem.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuPinnedItem.tsx
@@ -98,7 +98,10 @@ export function MegaMenuPinnedItem({
                 onClick={onUnpin}
                 aria-pressed
                 disabled={disabled}
-                tooltip={t('navigation.item.unpin.tooltip', 'Unpin {{itemName}}', { itemName: label })}
+                tooltip={t('navigation.item.unpin.tooltip', 'Unpin {{itemName}}', {
+                  itemName: label,
+                  interpolation: { escapeValue: false },
+                })}
               />
             </span>
             <span className={styles.trailingSpacer} />


### PR DESCRIPTION
**What is this feature?**

<img width="322" height="74" alt="image" src="https://github.com/user-attachments/assets/4568b210-58e4-4306-8e5d-fcdabff339f5" />

**Why do we need this feature?**

<img width="329" height="76" alt="image" src="https://github.com/user-attachments/assets/e365fc11-cea8-4a18-8602-97f45dbbdd29" />

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
