### PR TITLE
Frontend: Resolve build-directory assets through a window global

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ awsconfig
 /.awcache
 /dist
 /public/build
-/public/build-rspack
 /public/build-swagger
 /public/build-swagger-rspack
 /emails/dist

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -133,7 +133,6 @@ module.exports = [
       'public/vendor/',
       'scripts/grafana-server/tmp',
       'packages/grafana-ui/src/graveyard', // deprecated UI components slated for removal
-      'public/build-rspack', // build output (rspack)
       'public/build-swagger', // swagger build output
       'public/build-swagger-rspack', // swagger build output (rspack)
       'apps/plugins/plugin/src/generated/meta/v0alpha1',

--- a/packages/grafana-ui/src/components/Icon/utils.test.ts
+++ b/packages/grafana-ui/src/components/Icon/utils.test.ts
@@ -22,22 +22,22 @@ describe('Icon utils', () => {
       jest.resetModules();
     });
 
-    describe('when public path is configured', () => {
+    describe('when the build path is configured', () => {
       beforeAll(() => {
         //@ts-ignore
-        window.__grafana_public_path__ = 'somepath/public/';
+        window.__grafana_build_path__ = 'somepath/public/build/rspack/';
       });
 
-      it('should return icon root based on __grafana_public_path__', () => {
+      it('should return icon root based on __grafana_build_path__', () => {
         const { getIconRoot } = require('./utils');
-        expect(getIconRoot()).toEqual('somepath/public/build/img/icons/');
+        expect(getIconRoot()).toEqual('somepath/public/build/rspack/img/icons/');
       });
     });
 
-    describe('when public path is not configured', () => {
+    describe('when the build path is not configured', () => {
       beforeAll(() => {
         //@ts-ignore
-        window.__grafana_public_path__ = undefined;
+        window.__grafana_build_path__ = undefined;
       });
 
       it('should return default icon root', () => {

--- a/packages/grafana-ui/src/components/Icon/utils.ts
+++ b/packages/grafana-ui/src/components/Icon/utils.ts
@@ -51,10 +51,14 @@ export function getIconRoot(): string {
     return iconRoot;
   }
 
-  const grafanaPublicPath = typeof window !== 'undefined' && window.__grafana_public_path__;
-  if (grafanaPublicPath) {
-    iconRoot = grafanaPublicPath + 'build/img/icons/';
+  // Read through a window global rather than __webpack_public_path__: in a plugin bundle
+  // that resolves to the plugin's public path, not Grafana's.
+  const buildPath = typeof window !== 'undefined' && window.__grafana_build_path__;
+  if (buildPath) {
+    iconRoot = buildPath + 'img/icons/';
   } else {
+    // No entry point has run (server-side rendering, unit tests), so assume the default
+    // build directory.
     iconRoot = 'public/build/img/icons/';
   }
 

--- a/public/app/core/components/Upgrade/UpgradeBox.tsx
+++ b/public/app/core/components/Upgrade/UpgradeBox.tsx
@@ -271,5 +271,5 @@ const getImgUrl = (urlOrId: string) => {
     return urlOrId;
   }
 
-  return '/public/build/img/enterprise/highlights/' + urlOrId;
+  return `${window.__grafana_build_path__}img/enterprise/highlights/${urlOrId}`;
 };

--- a/public/app/core/services/theme.test.ts
+++ b/public/app/core/services/theme.test.ts
@@ -26,6 +26,7 @@ describe('changeTheme', () => {
   afterEach(() => {
     contextSrv.isSignedIn = originalSignedIn;
     contextSrv.user.uid = originalUid;
+    document.head.querySelectorAll('link[rel="stylesheet"]').forEach((link) => link.remove());
     setTestFlags({});
     jest.restoreAllMocks();
   });
@@ -59,5 +60,27 @@ describe('changeTheme', () => {
       name: 'user',
       patch: { spec: { theme: 'light' } },
     });
+  });
+
+  // The build directory name differs per bundler, so the old stylesheet has to be matched by
+  // the URL the backend published rather than by a hardcoded path fragment.
+  it.each([
+    ['webpack', 'public/build/grafana.dark.abc123.css', 'public/build/grafana.light.def456.css'],
+    ['rspack', 'public/build/rspack/grafana.dark.abc123.css', 'public/build/rspack/grafana.light.def456.css'],
+  ])('removes the previous theme stylesheet under %s', async (_bundler, darkHref, lightHref) => {
+    config.bootData.assets = { ...config.bootData.assets, dark: darkHref, light: lightHref };
+    const oldLink = document.createElement('link');
+    oldLink.rel = 'stylesheet';
+    oldLink.href = darkHref;
+    document.head.appendChild(oldLink);
+
+    await changeTheme('light', true);
+
+    const newLink = document.head.querySelector<HTMLLinkElement>(`link[href="${lightHref}"]`);
+    expect(newLink).not.toBeNull();
+    newLink!.onload!(new Event('load'));
+
+    expect(document.head.querySelector(`link[href="${darkHref}"]`)).toBeNull();
+    expect(document.head.querySelector(`link[href="${lightHref}"]`)).not.toBeNull();
   });
 });

--- a/public/app/core/services/theme.ts
+++ b/public/app/core/services/theme.ts
@@ -15,6 +15,9 @@ export async function changeTheme(themeId: string, runtimeOnly?: boolean) {
 
   // Add css file for new theme
   if (oldTheme.colors.mode !== newTheme.colors.mode) {
+    // Match the URL the backend gave us rather than a path fragment: the build directory name
+    // differs per bundler and the URL may carry a CDN origin.
+    const oldCssHref = config.bootData.assets[oldTheme.colors.mode];
     const newCssLink = document.createElement('link');
     newCssLink.rel = 'stylesheet';
     newCssLink.href = config.bootData.assets[newTheme.colors.mode];
@@ -24,7 +27,7 @@ export async function changeTheme(themeId: string, runtimeOnly?: boolean) {
       for (let i = 0; i < bodyLinks.length; i++) {
         const link = bodyLinks[i];
 
-        if (link.href && link.href.includes(`build/grafana.${oldTheme.colors.mode}`)) {
+        if (oldCssHref && link.href.endsWith(oldCssHref)) {
           // Remove existing link once the new css has loaded to avoid flickering
           // If we add new css at the same time we remove current one the page will be rendered without css
           // As the new css file is loading

--- a/public/app/features/dimensions/editors/FolderPickerTab.tsx
+++ b/public/app/features/dimensions/editors/FolderPickerTab.tsx
@@ -95,7 +95,7 @@ export const FolderPickerTab = (props: Props) => {
                 value: `${folder}/${item.name}`,
                 label: item.name,
                 search: (idx ? item.name.substring(0, idx) : item.name).toLowerCase(),
-                imgUrl: `${window.__grafana_public_path__}build/${folder}/${item.name}`,
+                imgUrl: `${window.__grafana_build_path__}${folder}/${item.name}`,
               });
             }
           });

--- a/public/app/features/dimensions/editors/ResourcePicker.tsx
+++ b/public/app/features/dimensions/editors/ResourcePicker.tsx
@@ -144,7 +144,9 @@ export const ResourcePicker = (props: Props) => {
 
 // strip the SVG off icons in the icons folder
 function getDisplayName(src?: string, name?: string): string | undefined {
-  if (src?.startsWith('public/build/img/icons')) {
+  // `src` is a resolved URL, so match on the folder rather than on a build directory that
+  // varies by bundler and CDN.
+  if (src?.includes('img/icons/')) {
     const idx = name?.lastIndexOf('.svg') ?? 0;
     if (idx > 0) {
       return name!.substring(0, idx);

--- a/public/app/features/dimensions/resource.test.ts
+++ b/public/app/features/dimensions/resource.test.ts
@@ -4,9 +4,9 @@ import { ResourceDimensionMode } from '@grafana/schema';
 import { getPublicOrAbsoluteUrl, getResourceDimension } from './resource';
 
 describe('getResourceDimension', () => {
-  const publicPath = 'https://grafana.fake/public/';
+  const buildPath = 'https://grafana.fake/public/build/';
   beforeAll(() => {
-    window.__grafana_public_path__ = publicPath;
+    window.__grafana_build_path__ = buildPath;
   });
 
   it('fixed relative path', () => {
@@ -14,7 +14,7 @@ describe('getResourceDimension', () => {
     const fixedValue = 'img/icons/unicons/question-circle.svg';
     const config = { mode: ResourceDimensionMode.Fixed, fixed: fixedValue };
 
-    expect(getResourceDimension(frame, config).value()).toEqual(`${publicPath}build/${fixedValue}`);
+    expect(getResourceDimension(frame, config).value()).toEqual(`${buildPath}${fixedValue}`);
   });
 
   it('fixed full URL path', () => {
@@ -104,7 +104,6 @@ describe('getResourceDimension', () => {
   });
 
   it('should handle numeric field values with icon from value mapping', () => {
-    const publicPath = 'https://grafana.fake/public/';
     const frame = createDataFrame({
       fields: [
         {
@@ -125,11 +124,11 @@ describe('getResourceDimension', () => {
     });
     const config = { mode: ResourceDimensionMode.Field, field: 'status_field', fixed: '' };
 
-    expect(getResourceDimension(frame, config).get(0)).toEqual(`${publicPath}build/img/icons/unicons/check-circle.svg`);
+    expect(getResourceDimension(frame, config).get(0)).toEqual(`${buildPath}img/icons/unicons/check-circle.svg`);
     expect(getResourceDimension(frame, config).get(1)).toEqual(
-      `${publicPath}build/img/icons/unicons/exclamation-triangle.svg`
+      `${buildPath}img/icons/unicons/exclamation-triangle.svg`
     );
-    expect(getResourceDimension(frame, config).get(2)).toEqual(`${publicPath}build/img/icons/unicons/times-circle.svg`);
+    expect(getResourceDimension(frame, config).get(2)).toEqual(`${buildPath}img/icons/unicons/times-circle.svg`);
   });
 
   it('should return empty string for unmapped numeric values without icon', () => {
@@ -153,7 +152,6 @@ describe('getResourceDimension', () => {
   });
 
   it('should handle mixed numeric values with partial mappings', () => {
-    const publicPath = 'https://grafana.fake/public/';
     const frame = createDataFrame({
       fields: [
         {
@@ -174,10 +172,10 @@ describe('getResourceDimension', () => {
     });
     const config = { mode: ResourceDimensionMode.Field, field: 'status_field', fixed: '' };
 
-    expect(getResourceDimension(frame, config).get(0)).toEqual(`${publicPath}build/img/icons/unicons/check-circle.svg`);
+    expect(getResourceDimension(frame, config).get(0)).toEqual(`${buildPath}img/icons/unicons/check-circle.svg`);
     expect(getResourceDimension(frame, config).get(1)).toEqual('');
     expect(getResourceDimension(frame, config).get(2)).toEqual(
-      `${publicPath}build/img/icons/unicons/exclamation-triangle.svg`
+      `${buildPath}img/icons/unicons/exclamation-triangle.svg`
     );
   });
 
@@ -185,13 +183,13 @@ describe('getResourceDimension', () => {
 });
 
 describe('getPublicOrAbsoluteUrl', () => {
-  const publicPath = 'https://grafana.fake/public/';
+  const buildPath = 'https://grafana.fake/public/build/';
   beforeAll(() => {
-    window.__grafana_public_path__ = publicPath;
+    window.__grafana_build_path__ = buildPath;
   });
 
   it('should handle string paths correctly', () => {
-    expect(getPublicOrAbsoluteUrl('icon.png')).toEqual(`${publicPath}build/icon.png`);
+    expect(getPublicOrAbsoluteUrl('icon.png')).toEqual(`${buildPath}icon.png`);
     expect(getPublicOrAbsoluteUrl('https://example.com/icon.png')).toEqual('https://example.com/icon.png');
   });
 
@@ -204,24 +202,24 @@ describe('getPublicOrAbsoluteUrl', () => {
     expect(getPublicOrAbsoluteUrl(['icon.png'])).toEqual('');
   });
 
-  it('should handle undefined publicPath gracefully', () => {
-    const originalPath = window.__grafana_public_path__;
+  it('should handle an undefined build path gracefully', () => {
+    const originalPath = window.__grafana_build_path__;
 
     // @ts-ignore - Intentionally testing runtime edge case
-    window.__grafana_public_path__ = undefined;
+    window.__grafana_build_path__ = undefined;
 
-    expect(getPublicOrAbsoluteUrl('icon.png')).toEqual('/build/icon.png');
+    expect(getPublicOrAbsoluteUrl('icon.png')).toEqual('public/build/icon.png');
 
-    window.__grafana_public_path__ = originalPath;
+    window.__grafana_build_path__ = originalPath;
   });
 
-  it('should handle empty string publicPath gracefully', () => {
-    const originalPath = window.__grafana_public_path__;
+  it('should handle an empty string build path gracefully', () => {
+    const originalPath = window.__grafana_build_path__;
 
-    window.__grafana_public_path__ = '';
+    window.__grafana_build_path__ = '';
 
-    expect(getPublicOrAbsoluteUrl('icon.png')).toEqual('/build/icon.png');
+    expect(getPublicOrAbsoluteUrl('icon.png')).toEqual('public/build/icon.png');
 
-    window.__grafana_public_path__ = originalPath;
+    window.__grafana_build_path__ = originalPath;
   });
 });

--- a/public/app/features/dimensions/resource.ts
+++ b/public/app/features/dimensions/resource.ts
@@ -15,9 +15,10 @@ export function getPublicOrAbsoluteUrl(path: unknown): string {
   // NOTE: The value of `path` could be either an URL string or a relative
   //       path to a Grafana CDN asset served from the CDN.
   const isUrl = path.indexOf(':/') > 0;
-  const publicPath = window.__grafana_public_path__ || '/';
+  // Falls back to the default build directory when no entry point has set the global.
+  const buildPath = window.__grafana_build_path__ || 'public/build/';
 
-  return isUrl ? path : `${publicPath}build/${path}`;
+  return isUrl ? path : `${buildPath}${path}`;
 }
 
 export function getResourceDimension(

--- a/public/app/features/geo/gazetteer/gazetteer.test.ts
+++ b/public/app/features/geo/gazetteer/gazetteer.test.ts
@@ -46,11 +46,11 @@ const geojsonObject = {
   ],
 };
 
-const publicPath = 'https://grafana.fake/public/';
+const buildPath = 'https://grafana.fake/public/build/';
 
 describe('Legacy path rewriting', () => {
   beforeAll(() => {
-    window.__grafana_public_path__ = publicPath;
+    window.__grafana_build_path__ = buildPath;
   });
 
   beforeEach(() => {
@@ -62,20 +62,20 @@ describe('Legacy path rewriting', () => {
   });
 
   it.each([
-    ['public/gazetteer/countries.json', `${publicPath}build/gazetteer/countries.json`],
-    ['public/gazetteer/usa-states.json', `${publicPath}build/gazetteer/usa-states.json`],
-    ['public/gazetteer/airports.geojson', `${publicPath}build/gazetteer/airports.geojson`],
-    ['public/gazetteer/custom.json', `${publicPath}build/gazetteer/custom.json`],
+    ['public/gazetteer/countries.json', `${buildPath}gazetteer/countries.json`],
+    ['public/gazetteer/usa-states.json', `${buildPath}gazetteer/usa-states.json`],
+    ['public/gazetteer/airports.geojson', `${buildPath}gazetteer/airports.geojson`],
+    ['public/gazetteer/custom.json', `${buildPath}gazetteer/custom.json`],
   ])('rewrites "%s" to "%s"', async (legacyPath, expectedUrl) => {
     const gaz = await getGazetteer(legacyPath);
     expect(fetch).toHaveBeenCalledWith(expectedUrl);
     expect(gaz.path).toBe(expectedUrl);
   });
 
-  it('resolves GAZETTEER_OPTIONS paths using the public path', () => {
-    expect(GAZETTEER_OPTIONS.countries.path).toBe(`${publicPath}build/gazetteer/countries.json`);
-    expect(GAZETTEER_OPTIONS.usaStates.path).toBe(`${publicPath}build/gazetteer/usa-states.json`);
-    expect(GAZETTEER_OPTIONS.airports.path).toBe(`${publicPath}build/gazetteer/airports.geojson`);
+  it('resolves GAZETTEER_OPTIONS paths using the build path', () => {
+    expect(GAZETTEER_OPTIONS.countries.path).toBe(`${buildPath}gazetteer/countries.json`);
+    expect(GAZETTEER_OPTIONS.usaStates.path).toBe(`${buildPath}gazetteer/usa-states.json`);
+    expect(GAZETTEER_OPTIONS.airports.path).toBe(`${buildPath}gazetteer/airports.geojson`);
   });
 
   it('does not rewrite absolute http URLs', async () => {

--- a/public/app/features/geo/gazetteer/gazetteer.ts
+++ b/public/app/features/geo/gazetteer/gazetteer.ts
@@ -185,21 +185,21 @@ export const GAZETTEER_OPTIONS = {
     label: 'Countries',
     description: 'Lookup countries by name, two letter code, or three letter code',
     get path() {
-      return `${window.__grafana_public_path__}build/gazetteer/countries.json`;
+      return `${window.__grafana_build_path__}gazetteer/countries.json`;
     },
   },
   usaStates: {
     label: 'USA States',
     description: 'Lookup states by name or 2-letter code',
     get path() {
-      return `${window.__grafana_public_path__}build/gazetteer/usa-states.json`;
+      return `${window.__grafana_build_path__}gazetteer/usa-states.json`;
     },
   },
   airports: {
     label: 'Airports',
     description: 'Lookup airports by id or code',
     get path() {
-      return `${window.__grafana_public_path__}build/gazetteer/airports.geojson`;
+      return `${window.__grafana_build_path__}gazetteer/airports.geojson`;
     },
   },
 };
@@ -216,7 +216,7 @@ export async function getGazetteer(path?: string): Promise<Gazetteer> {
   // Rewrite legacy relative paths (e.g. "public/gazetteer/usa-states.json") saved by older
   // dashboards to the correct absolute build URL, matching how geojsonLayer resolves URLs.
   if (!path.startsWith('http') && path.startsWith('public/gazetteer/')) {
-    path = `${window.__grafana_public_path__}build/gazetteer/${path.slice('public/gazetteer/'.length)}`;
+    path = `${window.__grafana_build_path__}gazetteer/${path.slice('public/gazetteer/'.length)}`;
   }
 
   let lookup = registry[path];

--- a/public/app/features/plugins/admin/helpers.ts
+++ b/public/app/features/plugins/admin/helpers.ts
@@ -231,8 +231,8 @@ export function mapToCatalogPlugin(local?: LocalPlugin, remote?: RemotePlugin, e
   const keywords = remote?.keywords || local?.info.keywords || [];
 
   let logos = {
-    small: `/public/build/img/icn-${type}.svg`,
-    large: `/public/build/img/icn-${type}.svg`,
+    small: `${window.__grafana_build_path__}img/icn-${type}.svg`,
+    large: `${window.__grafana_build_path__}img/icn-${type}.svg`,
   };
 
   if (remote) {

--- a/public/app/features/transformers/lookupGazetteer/fieldLookup.test.ts
+++ b/public/app/features/transformers/lookupGazetteer/fieldLookup.test.ts
@@ -14,14 +14,14 @@ afterEach(() => {
 });
 
 describe('Lookup gazetteer from the worldmap format', () => {
-  const publicPath = window.__grafana_public_path__;
+  const buildPath = window.__grafana_build_path__;
 
   beforeAll(() => {
-    window.__grafana_public_path__ = 'https://grafana.fake/public/';
+    window.__grafana_build_path__ = 'https://grafana.fake/public/build/';
   });
 
   afterAll(() => {
-    window.__grafana_public_path__ = publicPath;
+    window.__grafana_build_path__ = buildPath;
   });
 
   beforeEach(() => {

--- a/public/app/index.ts
+++ b/public/app/index.ts
@@ -16,6 +16,9 @@ if (window.public_cdn_path) {
 window.__grafana_public_path__ =
   __webpack_public_path__.substring(0, __webpack_public_path__.lastIndexOf('build/')) || __webpack_public_path__;
 
+// This is the path to the build directory of the bundler that produced this bundle.
+window.__grafana_build_path__ = __webpack_public_path__;
+
 if (window.nonce) {
   __webpack_nonce__ = window.nonce;
 }

--- a/public/app/plugins/panel/geomap/components/MarkersLegend.tsx
+++ b/public/app/plugins/panel/geomap/components/MarkersLegend.tsx
@@ -37,7 +37,7 @@ export function MarkersLegend({ layerName, styleConfig }: MarkersLegendProps) {
         <div className={style.layerName}>{layerName}</div>
         <div className={cx(style.layerBody, style.fixedColorContainer)}>
           <SanitizedSVG
-            src={`${window.__grafana_public_path__}build/${symbol}`}
+            src={`${window.__grafana_build_path__}${symbol}`}
             className={style.legendSymbol}
             title={t('geomap.markers-legend.title-symbol', 'Symbol')}
             style={{ fill: color, opacity: opacity }}

--- a/public/app/types/window.d.ts
+++ b/public/app/types/window.d.ts
@@ -3,7 +3,16 @@ export declare global {
   interface Window {
     __grafanaSceneContext: SceneObject;
     __grafana_app_bundle_loaded: boolean;
+    /** Path to the public folder, without the build directory. */
     __grafana_public_path__: string;
+
+    /**
+     * URL prefix the active bundler compiled its asset references against, including the
+     * build directory: 'public/build/' under webpack, 'public/build/rspack/' under rspack,
+     * prefixed with the CDN origin when one is configured. Use it for assets the bundler
+     * emits or copies into that directory (icons, maps, gazetteers).
+     */
+    __grafana_build_path__: string;
     __grafana_load_failed: (err: unknown) => void;
     grafanaBootData: BootData;
     __grafanaPublicDashboardAccessToken?: string;

--- a/public/swagger/index.tsx
+++ b/public/swagger/index.tsx
@@ -12,6 +12,10 @@ window.__grafana_public_path__ =
   __webpack_public_path__.substring(0, __webpack_public_path__.lastIndexOf('build-swagger/')) ||
   __webpack_public_path__;
 
+// The swagger bundle copies no images of its own, so assets read from the build directory
+// (icons) come from the app build rather than from '/build-swagger'.
+window.__grafana_build_path__ = `${window.__grafana_public_path__}build/`;
+
 if (window.nonce) {
   __webpack_nonce__ = window.nonce;
 }


### PR DESCRIPTION
**What is this feature?**

`window.__grafana_build_path__`: the active bundler's build directory, CDN origin included, read wherever code appended a literal `build/` to `window.__grafana_public_path__`.

**Why do we need this feature?**

grafana/grafana#130425 gave rspack its own output directory; these sites still pointed into webpack's. With `grafana.rspackBuild` on and no webpack build on disk, icons, gazetteers, geomap symbols and the resource picker all 404. `yarn build` makes both directories, so it only surfaces on an rspack-only build.

Two path comparisons keyed on the old layout too — the `theme.ts` one never matched the rspack stylesheet, so the outgoing one stayed in the DOM.

**Who is this feature for?**

Anyone running an rspack build. Unblocks grafana/grafana#129734.

**Which issue(s) does this PR fix?**:

Fixes grafana/grafana#131186

**Special notes for your reviewer:**

`grafana-ui` can't read `__webpack_public_path__` — in a plugin's bundle it resolves to the plugin's path. Hence the `window` global.

Browser-verified on an rspack-only build, and unchanged with the flag off.

Please check that:

- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](<https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new>), it's added to our [What's New](<https://grafana.com/docs/writers-toolkit/contribute/release-notes/>) doc.