### PR TITLE
Explore: Widen single-value raw Prometheus results

### DIFF
--- a/public/app/features/explore/PrometheusListView/ItemLabels.tsx
+++ b/public/app/features/explore/PrometheusListView/ItemLabels.tsx
@@ -4,12 +4,12 @@ import { type Field, type GrafanaTheme2 } from '@grafana/data';
 import { InstantQueryRefIdIndex } from '@grafana/prometheus';
 import { useStyles2 } from '@grafana/ui';
 
-import { rawListItemColumnWidth } from './RawListItem';
+import { getRawListItemColumnWidth } from './RawListItem';
 
-const getItemLabelsStyles = (theme: GrafanaTheme2, expanded: boolean) => {
+const getItemLabelsStyles = (theme: GrafanaTheme2, expanded: boolean, totalNumberOfValues: number) => {
   return {
     valueNavigation: css({
-      width: rawListItemColumnWidth,
+      width: getRawListItemColumnWidth(totalNumberOfValues),
       fontWeight: 'bold',
     }),
     valueNavigationWrapper: css({
@@ -30,7 +30,7 @@ export const formatValueName = (name: string): string => {
 };
 
 export const ItemLabels = ({ valueLabels, expanded }: { valueLabels: Field[]; expanded: boolean }) => {
-  const styles = useStyles2(getItemLabelsStyles, expanded);
+  const styles = useStyles2(getItemLabelsStyles, expanded, valueLabels.length);
 
   return (
     <div className={styles.itemLabelsWrap}>

--- a/public/app/features/explore/PrometheusListView/ItemValues.test.tsx
+++ b/public/app/features/explore/PrometheusListView/ItemValues.test.tsx
@@ -35,6 +35,7 @@ describe('ItemValues', () => {
     const itemValues = render(<ItemValues {...defaultProps} />);
     expect(screen.getByText(value1)).toBeVisible();
     expect(screen.getByText(value2)).toBeVisible();
+    expect(screen.getByText(value1).parentElement).toHaveStyle({ minWidth: '80px' });
     expect(itemValues?.baseElement?.children?.item(0)?.children?.item(0)?.children.length).toBe(3);
   });
 

--- a/public/app/features/explore/PrometheusListView/ItemValues.tsx
+++ b/public/app/features/explore/PrometheusListView/ItemValues.tsx
@@ -3,13 +3,13 @@ import { css } from '@emotion/css';
 import { type GrafanaTheme2 } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
 
-import { rawListItemColumnWidth, rawListPaddingToHoldSpaceForCopyIcon, type RawListValue } from './RawListItem';
+import { getRawListItemColumnWidth, rawListPaddingToHoldSpaceForCopyIcon, type RawListValue } from './RawListItem';
 import { RawPrometheusListItemEmptyValue } from './utils/getRawPrometheusListItemsFromDataFrame';
 
 const getStyles = (theme: GrafanaTheme2, totalNumberOfValues: number) => ({
   rowWrapper: css({
     position: 'relative',
-    minWidth: rawListItemColumnWidth,
+    minWidth: getRawListItemColumnWidth(totalNumberOfValues),
     paddingRight: '5px',
   }),
   rowValue: css({
@@ -37,7 +37,7 @@ const getStyles = (theme: GrafanaTheme2, totalNumberOfValues: number) => ({
   }),
   rowValuesWrap: css({
     paddingLeft: rawListPaddingToHoldSpaceForCopyIcon,
-    width: `calc(${totalNumberOfValues} * ${rawListItemColumnWidth})`,
+    width: `calc(${totalNumberOfValues} * ${getRawListItemColumnWidth(totalNumberOfValues)})`,
     display: 'flex',
   }),
 });

--- a/public/app/features/explore/PrometheusListView/RawListItem.test.tsx
+++ b/public/app/features/explore/PrometheusListView/RawListItem.test.tsx
@@ -30,5 +30,6 @@ describe('RawListItem', () => {
     expect(screen.getAllByText(`instanceValue`)[0]).toBeVisible();
     expect(screen.getAllByText(`metric_name_here`)[0]).toBeVisible();
     expect(screen.getAllByText(`1234556677888`)[0]).toBeVisible();
+    expect(screen.getByText('1234556677888').parentElement).toHaveStyle({ minWidth: '128px' });
   });
 });

--- a/public/app/features/explore/PrometheusListView/RawListItem.tsx
+++ b/public/app/features/explore/PrometheusListView/RawListItem.tsx
@@ -22,8 +22,12 @@ export interface RawListProps {
 
 export type RawListValue = { key: string; value: string };
 const rawListExtraSpaceAtEndOfLine = '20px';
-export const rawListItemColumnWidth = '80px';
+const rawListItemColumnWidth = '80px';
+const RAW_LIST_ITEM_SINGLE_VALUE_COLUMN_WIDTH = '128px';
 export const rawListPaddingToHoldSpaceForCopyIcon = '25px';
+
+export const getRawListItemColumnWidth = (totalNumberOfValues: number): string =>
+  totalNumberOfValues === 1 ? RAW_LIST_ITEM_SINGLE_VALUE_COLUMN_WIDTH : rawListItemColumnWidth;
 
 const getStyles = (theme: GrafanaTheme2, totalNumberOfValues: number, isExpandedView: boolean) => ({
   rowWrapper: css({
@@ -46,7 +50,7 @@ const getStyles = (theme: GrafanaTheme2, totalNumberOfValues: number, isExpanded
   }),
   rowLabelWrapWrap: css({
     position: 'relative',
-    width: `calc(100% - (${totalNumberOfValues} * ${rawListItemColumnWidth}) - ${rawListPaddingToHoldSpaceForCopyIcon})`,
+    width: `calc(100% - (${totalNumberOfValues} * ${getRawListItemColumnWidth(totalNumberOfValues)}) - ${rawListPaddingToHoldSpaceForCopyIcon})`,
   }),
   rowLabelWrap: css({
     whiteSpace: 'nowrap',


### PR DESCRIPTION
## Related Issue

Fixes #124845, Fixes DPRO-96

## Description

Widens the value column for single-value raw Prometheus instant-query results so ordinary long numeric values are readable without awkward horizontal scrolling.

## Changes

* Use a 128px value column for single-value raw results while retaining the existing 80px columns for multi-value results.
* Apply the same width calculation to values, value headers, and remaining label space so the layout stays aligned.
* Add focused coverage for single- and multi-value widths.

## Risks

The wider single-value column reduces the available label space by 48px. Multi-value layouts retain their existing 80px-per-column behavior.

## Demo
Before:
<img width="1728" height="1074" alt="CleanShot 2026-08-20 at 16 13 30@2x" src="https://github.com/user-attachments/assets/5767cc2c-7a6a-40d7-9b01-5c0815c94d86" />

After:
<img width="1722" height="1064" alt="CleanShot 2026-08-20 at 16 13 22@2x" src="https://github.com/user-attachments/assets/340aa06f-525c-45e7-821f-784963a442f1" />

## Testing Instructions

* In Explore, select a Prometheus data source.
* Run `vector(1234556677888)` as an instant query.
* Select Raw view and confirm the full value is visible without horizontal scrolling.

## Reviewer Checklist

- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable
