### PR TITLE
add trace span to sleepAfterSuccessfulWriteOperation

### DIFF
--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -1155,6 +1155,10 @@ func (s *server) sleepAfterSuccessfulWriteOperation(ctx context.Context, operati
 		}
 	}
 
+	ctx, span := tracer.Start(ctx, "resource.server.sleepAfterSuccessfulWriteOperation")
+	span.SetAttributes(attribute.Float64("artificialSuccessfulWriteDelaySeconds", s.artificialSuccessfulWriteDelay.Seconds()))
+	defer span.End()
+
 	s.log.Debug("sleeping after successful write operation",
 		"operation", operation,
 		"delay", s.artificialSuccessfulWriteDelay,


### PR DESCRIPTION
Adds a trace span to `sleepAfterSuccessfulWriteOperation`. Reason for the change is that the current trace of a delete does not have any kind of information around this artificial sleep and makes debugging a slow call much harder.