### PR TITLE
Secrets: Promote Keeper UI and AWS keeper flags to Public Preview

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -95,6 +95,8 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `canvasPanelPanZoom`               | Allow pan and zoom in canvas panel                                                                                             |
 | `timeComparison`                   | Enables time comparison option in supported panels                                                                             |
 | `secretsManagementAppPlatformUI`   | Enable the secrets management app platform UI                                                                                  |
+| `secretsKeeperUI`                  | Enable the Secrets Keeper management UI for configuring external secret storage                                                |
+| `grafana.secretsReferenceValueUI`  | Enable referencing an existing secret in an active keeper when creating a secure value                                         |
 | `dashboardTemplates`               | Enables a flow to get started with a new dashboard from a template                                                             |
 | `alertRuleRestore`                 | Enables the alert rule restore feature                                                                                         |
 | `alertingMigrationWizardUI`        | Enables the migration wizard UI to migrate alert rules and notification resources from external sources to Grafana Alerting    |

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -784,7 +784,7 @@ var (
 		{
 			Name:        "secretsKeeperUI",
 			Description: "Enable the Secrets Keeper management UI for configuring external secret storage",
-			Stage:       FeatureStageExperimental,
+			Stage:       FeatureStagePublicPreview,
 			Generate:    Generate{LegacyFrontend: true},
 			Owner:       grafanaOperatorExperienceSquad,
 			Expression:  "false",
@@ -792,7 +792,7 @@ var (
 		{
 			Name:        "grafana.secretsReferenceValueUI",
 			Description: "Enable referencing an existing secret in an active keeper when creating a secure value",
-			Stage:       FeatureStageExperimental,
+			Stage:       FeatureStagePublicPreview,
 			Generate:    Generate{React: true},
 			Owner:       grafanaOperatorExperienceSquad,
 			Expression:  "false",
@@ -2267,7 +2267,7 @@ var (
 		{
 			Name:         "secretsManagementAppPlatformAwsKeeper",
 			Description:  "Enables the creation of keepers that manage secrets stored on AWS secrets manager",
-			Stage:        FeatureStageExperimental,
+			Stage:        FeatureStagePublicPreview,
 			HideFromDocs: true,
 			Generate:     Generate{LegacyGo: true, LegacyFrontend: true},
 			Owner:        grafanaOperatorExperienceSquad,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -89,8 +89,8 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2024-01-18,jitterAlertRulesWithinGroups,preview,@grafana/alerting-squad,false,true,false
 2025-12-29,auditLoggingAppPlatform,preview,@grafana/grafana-operator-experience-squad,false,true,false
 2025-07-31,secretsManagementAppPlatformUI,preview,@grafana/grafana-operator-experience-squad,false,false,false
-2026-05-22,secretsKeeperUI,experimental,@grafana/grafana-operator-experience-squad,false,false,true
-2026-06-26,grafana.secretsReferenceValueUI,experimental,@grafana/grafana-operator-experience-squad,false,false,true
+2026-05-22,secretsKeeperUI,preview,@grafana/grafana-operator-experience-squad,false,false,true
+2026-06-26,grafana.secretsReferenceValueUI,preview,@grafana/grafana-operator-experience-squad,false,false,true
 2024-01-23,alertingSaveStatePeriodic,privatePreview,@grafana/alerting-squad,false,false,false
 2024-11-27,scopeApi,experimental,@grafana/grafana-app-platform-squad,false,false,false
 2024-11-11,logQLScope,privatePreview,@grafana/data-sources-plugins,false,false,false
@@ -263,7 +263,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-05-22,globalDashboardVariables,experimental,@grafana/dashboards-squad,false,true,false
 2026-07-30,grafana.dashboardGlobalVariables,experimental,@grafana/dashboards-squad,false,false,false
 2026-01-05,smoothingTransformation,experimental,@grafana/datapro,false,false,true
-2026-01-06,secretsManagementAppPlatformAwsKeeper,experimental,@grafana/grafana-operator-experience-squad,false,false,false
+2026-01-06,secretsManagementAppPlatformAwsKeeper,preview,@grafana/grafana-operator-experience-squad,false,false,false
 2026-01-07,profilesExemplars,GA,@grafana/observability-traces-and-profiling,false,false,false
 2026-05-22,pyroscopeUTF8LabelNames,preview,@grafana/observability-traces-and-profiling,false,false,false
 2026-01-14,alertingSyncDispatchTimer,experimental,@grafana/alerting-squad,false,true,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -3351,12 +3351,15 @@
     {
       "metadata": {
         "name": "grafana.secretsReferenceValueUI",
-        "resourceVersion": "1782512869856",
-        "creationTimestamp": "2026-06-26T22:27:49Z"
+        "resourceVersion": "1787262357315",
+        "creationTimestamp": "2026-06-26T22:27:49Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-08-20 21:45:57.315448368 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable referencing an existing secret in an active keeper when creating a secure value",
-        "stage": "experimental",
+        "stage": "preview",
         "codeowner": "@grafana/grafana-operator-experience-squad",
         "frontend": true,
         "expression": "false"
@@ -6059,12 +6062,15 @@
     {
       "metadata": {
         "name": "secretsKeeperUI",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1787262357315",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-08-20 21:45:57.315448368 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable the Secrets Keeper management UI for configuring external secret storage",
-        "stage": "experimental",
+        "stage": "preview",
         "codeowner": "@grafana/grafana-operator-experience-squad",
         "frontend": true,
         "expression": "false"
@@ -6073,12 +6079,15 @@
     {
       "metadata": {
         "name": "secretsManagementAppPlatformAwsKeeper",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-01-06T14:30:04Z"
+        "resourceVersion": "1787262357315",
+        "creationTimestamp": "2026-01-06T14:30:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-08-20 21:45:57.315448368 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the creation of keepers that manage secrets stored on AWS secrets manager",
-        "stage": "experimental",
+        "stage": "preview",
         "codeowner": "@grafana/grafana-operator-experience-squad",
         "hideFromDocs": true,
         "expression": "false"


### PR DESCRIPTION
## What this does

Bumps `Stage` from Experimental to PublicPreview for three flags in `pkg/services/featuremgmt/registry.go`: `secretsKeeperUI`, `grafana.secretsReferenceValueUI`, and `secretsManagementAppPlatformAwsKeeper`. `Expression` stays `"false"` on all three, so on-prem defaults are unchanged. Regenerated `toggles_gen.csv`, `toggles_gen.json`, and the docs feature-toggles index via `make gen-feature-toggles`.

This is part of the Secrets Keeper UI GA rollout tracked in grafana/grafana-operator-experience-squad#1972. The stage bump matches the QA test plan's "Public Preview" release label and pairs with the deployment_tools wave PRs that enable these flags in each environment: grafana/deployment_tools#695930, grafana/deployment_tools#695977, grafana/deployment_tools#695980, grafana/deployment_tools#695982.

## Notes

- `secretsManagementAppPlatformAwsKeeper` keeps `HideFromDocs: true`. This is assumed to be covered by the parent flag release comms.
- No other fields changed on any of the three flags.

Related: grafana/grafana-operator-experience-squad#1972