### PR TITLE
Swagger: Fix global styles (and body margin)

### DIFF
--- a/public/swagger/SwaggerPage.tsx
+++ b/public/swagger/SwaggerPage.tsx
@@ -1,3 +1,4 @@
+import { Global } from '@emotion/react';
 import { OpenFeatureProvider } from '@openfeature/react-sdk';
 import getDefaultMonacoLanguages from 'lib/monaco-languages';
 import { useState } from 'react';
@@ -7,7 +8,7 @@ import SwaggerUI from 'swagger-ui-react';
 import { createTheme, monacoLanguageRegistry, type SelectableValue } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { getFeatureFlagClient } from '@grafana/runtime/internal';
-import { Icon, Stack, Select, UserIcon, type UserView, Button } from '@grafana/ui';
+import { Button, Icon, Select, Stack, UserIcon, type UserView } from '@grafana/ui';
 import { setMonacoEnv } from 'app/core/monacoEnv';
 import { ThemeProvider } from 'app/core/utils/ConfigProvider';
 
@@ -84,9 +85,20 @@ export const Page = () => {
     <div>
       <OpenFeatureProvider client={getFeatureFlagClient()}>
         <ThemeProvider value={theme}>
+          <Global
+            styles={{
+              html: {
+                fontSize: `${theme.typography.htmlFontSize}px`,
+              },
+              body: {
+                margin: 0,
+                ...theme.typography.body,
+              },
+            }}
+          />
           <NamespaceContext.Provider value={namespace.value}>
             <div style={{ backgroundColor: '#000', padding: '10px' }}>
-              <Stack justifyContent={'space-between'}>
+              <Stack alignItems="center" justifyContent="space-between">
                 <Icon name="grafana" size="xxl" />
                 <Select
                   options={urls.value}
@@ -105,7 +117,7 @@ export const Page = () => {
                   value={url}
                   isLoading={urls.loading}
                 />
-                <div style={{ marginTop: '5px' }}>
+                <div>
                   {userView ? (
                     <UserIcon userView={userView} />
                   ) : (


### PR DESCRIPTION
When swagger was moved to its own bundle, the theme was no longer included.  This adds the light theme manually.

<img width="1654" height="1204" alt="CleanShot 2026-08-21 at 13 44 08@2x" src="https://github.com/user-attachments/assets/b17ed63e-f8dd-4414-b8c4-1b6f6aa68f41" />
