### PR TITLE
Provisioning: Add apiserver client request duration metric

### DIFF
--- a/pkg/operators/provisioning/config.go
+++ b/pkg/operators/provisioning/config.go
@@ -295,7 +295,7 @@ func (c *ControllerConfig) Clients() (resources.ClientFactory, error) {
 		configProviders[group] = NewDirectConfigProvider(config)
 	}
 
-	clients := resources.NewClientFactoryForMultipleAPIServers(configProviders, c.registry, resources.ComponentProvisioning, supportedResources...)
+	clients := resources.NewClientFactoryForMultipleAPIServers(configProviders, c.registry, supportedResources...)
 	c.clients = clients
 	return clients, nil
 }

--- a/pkg/operators/provisioning/config.go
+++ b/pkg/operators/provisioning/config.go
@@ -295,7 +295,7 @@ func (c *ControllerConfig) Clients() (resources.ClientFactory, error) {
 		configProviders[group] = NewDirectConfigProvider(config)
 	}
 
-	clients := resources.NewClientFactoryForMultipleAPIServers(configProviders, supportedResources...)
+	clients := resources.NewClientFactoryForMultipleAPIServers(configProviders, c.registry, supportedResources...)
 	c.clients = clients
 	return clients, nil
 }

--- a/pkg/operators/provisioning/config.go
+++ b/pkg/operators/provisioning/config.go
@@ -295,7 +295,7 @@ func (c *ControllerConfig) Clients() (resources.ClientFactory, error) {
 		configProviders[group] = NewDirectConfigProvider(config)
 	}
 
-	clients := resources.NewClientFactoryForMultipleAPIServers(configProviders, c.registry, supportedResources...)
+	clients := resources.NewClientFactoryForMultipleAPIServers(configProviders, c.registry, resources.ComponentProvisioning, supportedResources...)
 	c.clients = clients
 	return clients, nil
 }

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -229,7 +229,7 @@ func NewAPIBuilder(
 	if newStandaloneClientFactoryFunc != nil {
 		clients = newStandaloneClientFactoryFunc(configProvider)
 	} else {
-		clients = resources.NewClientFactory(configProvider, supportedResources...)
+		clients = resources.NewClientFactory(configProvider, registry, supportedResources...)
 	}
 	if gv.Version == "" {
 		return nil, fmt.Errorf("invalid provisioning group/version")

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -229,7 +229,7 @@ func NewAPIBuilder(
 	if newStandaloneClientFactoryFunc != nil {
 		clients = newStandaloneClientFactoryFunc(configProvider)
 	} else {
-		clients = resources.NewClientFactory(configProvider, registry, supportedResources...)
+		clients = resources.NewClientFactory(configProvider, registry, resources.ComponentProvisioning, supportedResources...)
 	}
 	if gv.Version == "" {
 		return nil, fmt.Errorf("invalid provisioning group/version")

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -229,7 +229,7 @@ func NewAPIBuilder(
 	if newStandaloneClientFactoryFunc != nil {
 		clients = newStandaloneClientFactoryFunc(configProvider)
 	} else {
-		clients = resources.NewClientFactory(configProvider, registry, resources.ComponentProvisioning, supportedResources...)
+		clients = resources.NewClientFactory(configProvider, registry, supportedResources...)
 	}
 	if gv.Version == "" {
 		return nil, fmt.Errorf("invalid provisioning group/version")

--- a/pkg/registry/apis/provisioning/resources/client.go
+++ b/pkg/registry/apis/provisioning/resources/client.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/prometheus/client_golang/prometheus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -165,6 +166,8 @@ type clientFactory struct {
 	clientsProvider clientsProvider
 	// supportedResources is the merged base + registered set, computed once.
 	supportedResources []SupportedResource
+	// metrics records API server request latency; may be nil (no registry).
+	metrics *clientMetrics
 }
 
 // TODO: Rename to NamespacedClients
@@ -247,21 +250,23 @@ func (p *singleAPIClients) GetClientsForResource(ctx context.Context, _ schema.G
 // NewClientFactory creates a ClientFactory. The supported set is the configured list of
 // resources that can be managed from the UI; the ResourceClients it produces expose only
 // the enabled subset via SupportedResources(). When none is provided it falls back to the
-// static SupportedProvisioningResources base set.
-func NewClientFactory(configProvider apiserver.RestConfigProvider, supported ...SupportedResource) ClientFactory {
+// static SupportedProvisioningResources base set. reg receives the API server request
+// metrics and may be nil to skip registration.
+func NewClientFactory(configProvider apiserver.RestConfigProvider, reg prometheus.Registerer, supported ...SupportedResource) ClientFactory {
 	return &clientFactory{
 		clientsProvider:    newSingleAPIClients(configProvider),
 		supportedResources: activeResources(defaultSupportedResources(supported)),
+		metrics:            newClientMetrics(reg),
 	}
 }
 
 // NewClientFactoryForMultipleAPIServers creates a ClientFactory for multiple API servers.
 // The supported set behaves as described on NewClientFactory.
-func NewClientFactoryForMultipleAPIServers(configProviders map[string]apiserver.RestConfigProvider, supported ...SupportedResource) ClientFactory {
+func NewClientFactoryForMultipleAPIServers(configProviders map[string]apiserver.RestConfigProvider, reg prometheus.Registerer, supported ...SupportedResource) ClientFactory {
 	clientFactories := make(map[string]ClientFactory)
 
 	for api, configProvider := range configProviders {
-		clientFactory := NewClientFactory(configProvider, supported...)
+		clientFactory := NewClientFactory(configProvider, reg, supported...)
 		clientFactories[api] = clientFactory
 	}
 
@@ -320,6 +325,7 @@ func (f *clientFactory) Clients(ctx context.Context, namespace string) (Resource
 		namespace:          namespace,
 		clientsProvider:    f.clientsProvider,
 		supportedResources: f.supportedResources,
+		metrics:            f.metrics,
 		byKind:             make(map[schema.GroupVersionKind]*clientInfo),
 		byResource:         make(map[schema.GroupVersionResource]*clientInfo),
 	}, nil
@@ -329,6 +335,8 @@ type resourceClients struct {
 	namespace          string
 	clientsProvider    clientsProvider
 	supportedResources []SupportedResource
+	// metrics is passed to each resource client for API server request timing.
+	metrics *clientMetrics
 
 	// ResourceInterface cache for this context + namespace
 	mutex      sync.Mutex
@@ -386,7 +394,7 @@ func (c *resourceClients) ForKind(ctx context.Context, gvk schema.GroupVersionKi
 	info = &clientInfo{
 		gvk:    gvk,
 		gvr:    gvr,
-		client: newRetryResourceInterface(baseClient, defaultRetryBackoff()),
+		client: newRetryResourceInterface(baseClient, defaultRetryBackoff(), gvr, c.metrics),
 	}
 	c.byKind[gvk] = info
 	c.byResource[gvr] = info
@@ -440,7 +448,7 @@ func (c *resourceClients) ForResource(ctx context.Context, gvr schema.GroupVersi
 	info = &clientInfo{
 		gvk:    gvk,
 		gvr:    gvr,
-		client: newRetryResourceInterface(baseClient, defaultRetryBackoff()),
+		client: newRetryResourceInterface(baseClient, defaultRetryBackoff(), gvr, c.metrics),
 	}
 	c.byKind[gvk] = info
 	c.byResource[gvr] = info

--- a/pkg/registry/apis/provisioning/resources/client.go
+++ b/pkg/registry/apis/provisioning/resources/client.go
@@ -251,22 +251,24 @@ func (p *singleAPIClients) GetClientsForResource(ctx context.Context, _ schema.G
 // resources that can be managed from the UI; the ResourceClients it produces expose only
 // the enabled subset via SupportedResources(). When none is provided it falls back to the
 // static SupportedProvisioningResources base set. reg receives the API server request
-// metrics and may be nil to skip registration.
-func NewClientFactory(configProvider apiserver.RestConfigProvider, reg prometheus.Registerer, supported ...SupportedResource) ClientFactory {
+// metrics and may be nil to skip registration. component names the calling subsystem and
+// labels those metrics — this factory is shared, so pick an existing ComponentID rather
+// than inventing a value.
+func NewClientFactory(configProvider apiserver.RestConfigProvider, reg prometheus.Registerer, component ComponentID, supported ...SupportedResource) ClientFactory {
 	return &clientFactory{
 		clientsProvider:    newSingleAPIClients(configProvider),
 		supportedResources: activeResources(defaultSupportedResources(supported)),
-		metrics:            newClientMetrics(reg),
+		metrics:            newClientMetrics(reg, component),
 	}
 }
 
 // NewClientFactoryForMultipleAPIServers creates a ClientFactory for multiple API servers.
-// The supported set behaves as described on NewClientFactory.
-func NewClientFactoryForMultipleAPIServers(configProviders map[string]apiserver.RestConfigProvider, reg prometheus.Registerer, supported ...SupportedResource) ClientFactory {
+// The supported set, reg and component behave as described on NewClientFactory.
+func NewClientFactoryForMultipleAPIServers(configProviders map[string]apiserver.RestConfigProvider, reg prometheus.Registerer, component ComponentID, supported ...SupportedResource) ClientFactory {
 	clientFactories := make(map[string]ClientFactory)
 
 	for api, configProvider := range configProviders {
-		clientFactory := NewClientFactory(configProvider, reg, supported...)
+		clientFactory := NewClientFactory(configProvider, reg, component, supported...)
 		clientFactories[api] = clientFactory
 	}
 

--- a/pkg/registry/apis/provisioning/resources/client.go
+++ b/pkg/registry/apis/provisioning/resources/client.go
@@ -251,24 +251,22 @@ func (p *singleAPIClients) GetClientsForResource(ctx context.Context, _ schema.G
 // resources that can be managed from the UI; the ResourceClients it produces expose only
 // the enabled subset via SupportedResources(). When none is provided it falls back to the
 // static SupportedProvisioningResources base set. reg receives the API server request
-// metrics and may be nil to skip registration. component names the calling subsystem and
-// labels those metrics — this factory is shared, so pick an existing ComponentID rather
-// than inventing a value.
-func NewClientFactory(configProvider apiserver.RestConfigProvider, reg prometheus.Registerer, component ComponentID, supported ...SupportedResource) ClientFactory {
+// metrics and may be nil to skip registration.
+func NewClientFactory(configProvider apiserver.RestConfigProvider, reg prometheus.Registerer, supported ...SupportedResource) ClientFactory {
 	return &clientFactory{
 		clientsProvider:    newSingleAPIClients(configProvider),
 		supportedResources: activeResources(defaultSupportedResources(supported)),
-		metrics:            newClientMetrics(reg, component),
+		metrics:            newClientMetrics(reg),
 	}
 }
 
 // NewClientFactoryForMultipleAPIServers creates a ClientFactory for multiple API servers.
-// The supported set, reg and component behave as described on NewClientFactory.
-func NewClientFactoryForMultipleAPIServers(configProviders map[string]apiserver.RestConfigProvider, reg prometheus.Registerer, component ComponentID, supported ...SupportedResource) ClientFactory {
+// The supported set and reg behave as described on NewClientFactory.
+func NewClientFactoryForMultipleAPIServers(configProviders map[string]apiserver.RestConfigProvider, reg prometheus.Registerer, supported ...SupportedResource) ClientFactory {
 	clientFactories := make(map[string]ClientFactory)
 
 	for api, configProvider := range configProviders {
-		clientFactory := NewClientFactory(configProvider, reg, component, supported...)
+		clientFactory := NewClientFactory(configProvider, reg, supported...)
 		clientFactories[api] = clientFactory
 	}
 

--- a/pkg/registry/apis/provisioning/resources/client_test.go
+++ b/pkg/registry/apis/provisioning/resources/client_test.go
@@ -20,7 +20,7 @@ var (
 
 func TestResourceClients_SupportedResources(t *testing.T) {
 	t.Run("falls back to the static base set when none is configured", func(t *testing.T) {
-		clients, err := NewClientFactory(nil).Clients(context.Background(), "default")
+		clients, err := NewClientFactory(nil, nil).Clients(context.Background(), "default")
 		require.NoError(t, err)
 
 		assert.Equal(t, SupportedProvisioningResources, clients.SupportedResources())
@@ -30,7 +30,7 @@ func TestResourceClients_SupportedResources(t *testing.T) {
 		active := SupportedResource{GroupKind: DashboardKind.GroupKind(), Capabilities: sets.New(CapabilityFolder)}
 		disabled := SupportedResource{GroupKind: playlistKind, Capabilities: sets.New(CapabilityDisabled)}
 
-		clients, err := NewClientFactory(nil, active, disabled).Clients(context.Background(), "default")
+		clients, err := NewClientFactory(nil, nil, active, disabled).Clients(context.Background(), "default")
 		require.NoError(t, err)
 
 		// Disabled resources are not acted on, so they are excluded from the active set.

--- a/pkg/registry/apis/provisioning/resources/client_test.go
+++ b/pkg/registry/apis/provisioning/resources/client_test.go
@@ -20,7 +20,7 @@ var (
 
 func TestResourceClients_SupportedResources(t *testing.T) {
 	t.Run("falls back to the static base set when none is configured", func(t *testing.T) {
-		clients, err := NewClientFactory(nil, nil, ComponentProvisioning).Clients(context.Background(), "default")
+		clients, err := NewClientFactory(nil, nil).Clients(context.Background(), "default")
 		require.NoError(t, err)
 
 		assert.Equal(t, SupportedProvisioningResources, clients.SupportedResources())
@@ -30,7 +30,7 @@ func TestResourceClients_SupportedResources(t *testing.T) {
 		active := SupportedResource{GroupKind: DashboardKind.GroupKind(), Capabilities: sets.New(CapabilityFolder)}
 		disabled := SupportedResource{GroupKind: playlistKind, Capabilities: sets.New(CapabilityDisabled)}
 
-		clients, err := NewClientFactory(nil, nil, ComponentProvisioning, active, disabled).Clients(context.Background(), "default")
+		clients, err := NewClientFactory(nil, nil, active, disabled).Clients(context.Background(), "default")
 		require.NoError(t, err)
 
 		// Disabled resources are not acted on, so they are excluded from the active set.

--- a/pkg/registry/apis/provisioning/resources/client_test.go
+++ b/pkg/registry/apis/provisioning/resources/client_test.go
@@ -20,7 +20,7 @@ var (
 
 func TestResourceClients_SupportedResources(t *testing.T) {
 	t.Run("falls back to the static base set when none is configured", func(t *testing.T) {
-		clients, err := NewClientFactory(nil, nil).Clients(context.Background(), "default")
+		clients, err := NewClientFactory(nil, nil, ComponentProvisioning).Clients(context.Background(), "default")
 		require.NoError(t, err)
 
 		assert.Equal(t, SupportedProvisioningResources, clients.SupportedResources())
@@ -30,7 +30,7 @@ func TestResourceClients_SupportedResources(t *testing.T) {
 		active := SupportedResource{GroupKind: DashboardKind.GroupKind(), Capabilities: sets.New(CapabilityFolder)}
 		disabled := SupportedResource{GroupKind: playlistKind, Capabilities: sets.New(CapabilityDisabled)}
 
-		clients, err := NewClientFactory(nil, nil, active, disabled).Clients(context.Background(), "default")
+		clients, err := NewClientFactory(nil, nil, ComponentProvisioning, active, disabled).Clients(context.Background(), "default")
 		require.NoError(t, err)
 
 		// Disabled resources are not acted on, so they are excluded from the active set.

--- a/pkg/registry/apis/provisioning/resources/metrics.go
+++ b/pkg/registry/apis/provisioning/resources/metrics.go
@@ -7,8 +7,19 @@ import (
 	"github.com/grafana/dskit/instrument"
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+)
 
-	"github.com/grafana/grafana/pkg/registry/apis/provisioning/utils"
+// ComponentID identifies the Grafana subsystem that owns a client factory. It
+// becomes the "component" label on the request-duration metric, so subsystems
+// sharing one registry — and therefore one collector — stay distinguishable.
+// Adding a construction site means picking a value here rather than inventing a
+// string, so the label's value set stays enumerable.
+type ComponentID string
+
+const (
+	ComponentProvisioning         ComponentID = "provisioning"
+	ComponentProvisioningWebhooks ComponentID = "provisioning_webhooks"
+	ComponentZanzana              ComponentID = "zanzana"
 )
 
 // Operation labels for the request-duration metric. They name the resource
@@ -26,29 +37,56 @@ const (
 	operationApplyStatus      = "apply_status"
 )
 
-// clientMetrics measures the Kubernetes API server requests provisioning issues
-// against the resources it manages (dashboards, folders, and any other
-// configured kinds). Latency is labelled by resource, operation and outcome so
-// slow or failing verbs can be told apart per resource type. Durations cover the
-// whole retried operation, including backoff waits, since that is the latency
-// the caller actually sees.
+// Outcome labels for the request-duration metric. These deliberately match the
+// values in provisioning's utils package so queries can join this metric with
+// grafana_provisioning_* ones; they are redeclared here rather than imported so
+// this package carries no provisioning-specific dependency — it is shared with
+// zanzana. Nothing but this comment keeps the two in sync.
+const (
+	outcomeSuccess = "success"
+	outcomeError   = "error"
+)
+
+// clientMetrics measures the outbound Kubernetes API server requests a Grafana
+// subsystem makes through this package's dynamic client factory. The factory is
+// shared — provisioning, its webhooks and zanzana all use it, and in a
+// single-binary Grafana they are handed the same registry — so every observation
+// carries a "component" label naming the caller. Latency is further labelled by
+// resource group, resource, operation and outcome, so a slow or failing verb can
+// be told apart per resource type per caller. Durations cover the whole retried
+// operation, including backoff waits, since that is the latency the caller
+// actually sees.
+//
+// The metric is grafana_apiserver_client_request_duration_seconds. The "client"
+// infix is load-bearing, not stylistic: k8s.io/apiserver registers the
+// server-side apiserver_request_duration_seconds on the same legacy registry,
+// and pkg/infra/metrics renames un-prefixed families to grafana_* when
+// gathering, so grafana_apiserver_request_duration_seconds already exists in
+// Grafana's /metrics output. Reusing that name would not collide at
+// registration — the fqName on our registry differs — but would emit two metric
+// families under one name in the scrape body, which fails the parse for the
+// whole endpoint. Keep the infix.
 type clientMetrics struct {
+	// component identifies the owning subsystem. It labels every observation, so
+	// callers sharing one collector remain distinguishable.
+	component       ComponentID
 	requestDuration *prometheus.HistogramVec
 }
 
-// newClientMetrics builds the client metrics on reg, reusing collectors already
-// registered there so factories sharing a registry share one collector. A nil
-// reg leaves the collectors unregistered but usable.
-func newClientMetrics(reg prometheus.Registerer) *clientMetrics {
+// newClientMetrics builds the client metrics on reg for the given component,
+// reusing collectors already registered there so factories sharing a registry
+// share one collector. A nil reg leaves the collectors unregistered but usable.
+func newClientMetrics(reg prometheus.Registerer, component ComponentID) *clientMetrics {
 	return &clientMetrics{
+		component: component,
 		requestDuration: registerOrReuse(reg, prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name:                            "grafana_provisioning_apiserver_request_duration_seconds",
-			Help:                            "Duration of the Kubernetes API server requests provisioning issues for the resources it manages, by resource group, resource, operation and outcome. Includes retry/backoff time.",
+			Name:                            "grafana_apiserver_client_request_duration_seconds",
+			Help:                            "Duration of the outbound Kubernetes API server requests a Grafana subsystem makes for the resources it manages, by calling component, resource group, resource, operation and outcome. Includes retry/backoff time. This is the client-side counterpart to the server-side grafana_apiserver_request_duration_seconds.",
 			Buckets:                         instrument.DefBuckets,
 			NativeHistogramBucketFactor:     1.1,
 			NativeHistogramMaxBucketNumber:  160,
 			NativeHistogramMinResetDuration: time.Hour,
-		}, []string{"group", "resource", "operation", "outcome"})),
+		}, []string{"component", "group", "resource", "operation", "outcome"})),
 	}
 }
 
@@ -58,11 +96,13 @@ func (m *clientMetrics) observe(gvr schema.GroupVersionResource, operation strin
 	if m == nil {
 		return
 	}
-	outcome := utils.SuccessOutcome
+	outcome := outcomeSuccess
 	if err != nil {
-		outcome = utils.ErrorOutcome
+		outcome = outcomeError
 	}
-	m.requestDuration.WithLabelValues(gvr.Group, gvr.Resource, operation, outcome).Observe(time.Since(start).Seconds())
+	// WithLabelValues is positional: the order here must match the label names
+	// declared in newClientMetrics.
+	m.requestDuration.WithLabelValues(string(m.component), gvr.Group, gvr.Resource, operation, outcome).Observe(time.Since(start).Seconds())
 }
 
 // registerOrReuse registers c on reg, returning the collector already registered
@@ -74,7 +114,14 @@ func registerOrReuse[C prometheus.Collector](reg prometheus.Registerer, c C) C {
 	if err := reg.Register(c); err != nil {
 		are := prometheus.AlreadyRegisteredError{}
 		if errors.As(err, &are) {
-			return are.ExistingCollector.(C)
+			// A wrapping registerer (prometheus.WrapRegistererWith) hands back a
+			// wrapped collector rather than one of type C, so the assertion is
+			// checked: fall back to the unregistered collector instead of panicking
+			// in a path that runs on every API server call.
+			if existing, ok := are.ExistingCollector.(C); ok {
+				return existing
+			}
+			return c
 		}
 		panic(err)
 	}

--- a/pkg/registry/apis/provisioning/resources/metrics.go
+++ b/pkg/registry/apis/provisioning/resources/metrics.go
@@ -1,0 +1,82 @@
+package resources
+
+import (
+	"errors"
+	"time"
+
+	"github.com/grafana/dskit/instrument"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/grafana/grafana/pkg/registry/apis/provisioning/utils"
+)
+
+// Operation labels for the request-duration metric. They name the resource
+// client verb, so a slow or failing verb can be told apart from the others.
+const (
+	operationCreate           = "create"
+	operationUpdate           = "update"
+	operationUpdateStatus     = "update_status"
+	operationDelete           = "delete"
+	operationDeleteCollection = "delete_collection"
+	operationGet              = "get"
+	operationList             = "list"
+	operationPatch            = "patch"
+	operationApply            = "apply"
+	operationApplyStatus      = "apply_status"
+)
+
+// clientMetrics measures the Kubernetes API server requests provisioning issues
+// against the resources it manages (dashboards, folders, and any other
+// configured kinds). Latency is labelled by resource, operation and outcome so
+// slow or failing verbs can be told apart per resource type. Durations cover the
+// whole retried operation, including backoff waits, since that is the latency
+// the caller actually sees.
+type clientMetrics struct {
+	requestDuration *prometheus.HistogramVec
+}
+
+// newClientMetrics builds the client metrics on reg, reusing collectors already
+// registered there so factories sharing a registry share one collector. A nil
+// reg leaves the collectors unregistered but usable.
+func newClientMetrics(reg prometheus.Registerer) *clientMetrics {
+	return &clientMetrics{
+		requestDuration: registerOrReuse(reg, prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:                            "grafana_provisioning_apiserver_request_duration_seconds",
+			Help:                            "Duration of the Kubernetes API server requests provisioning issues for the resources it manages, by resource group, resource, operation and outcome. Includes retry/backoff time.",
+			Buckets:                         instrument.DefBuckets,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  160,
+			NativeHistogramMinResetDuration: time.Hour,
+		}, []string{"group", "resource", "operation", "outcome"})),
+	}
+}
+
+// observe records one API server request. It is safe to call on a nil
+// *clientMetrics: a client factory built without a registry produces one.
+func (m *clientMetrics) observe(gvr schema.GroupVersionResource, operation string, start time.Time, err error) {
+	if m == nil {
+		return
+	}
+	outcome := utils.SuccessOutcome
+	if err != nil {
+		outcome = utils.ErrorOutcome
+	}
+	m.requestDuration.WithLabelValues(gvr.Group, gvr.Resource, operation, outcome).Observe(time.Since(start).Seconds())
+}
+
+// registerOrReuse registers c on reg, returning the collector already registered
+// under the same descriptor when there is one. A nil reg returns c unregistered.
+func registerOrReuse[C prometheus.Collector](reg prometheus.Registerer, c C) C {
+	if reg == nil {
+		return c
+	}
+	if err := reg.Register(c); err != nil {
+		are := prometheus.AlreadyRegisteredError{}
+		if errors.As(err, &are) {
+			return are.ExistingCollector.(C)
+		}
+		panic(err)
+	}
+	return c
+}

--- a/pkg/registry/apis/provisioning/resources/metrics.go
+++ b/pkg/registry/apis/provisioning/resources/metrics.go
@@ -9,19 +9,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// ComponentID identifies the Grafana subsystem that owns a client factory. It
-// becomes the "component" label on the request-duration metric, so subsystems
-// sharing one registry — and therefore one collector — stay distinguishable.
-// Adding a construction site means picking a value here rather than inventing a
-// string, so the label's value set stays enumerable.
-type ComponentID string
-
-const (
-	ComponentProvisioning         ComponentID = "provisioning"
-	ComponentProvisioningWebhooks ComponentID = "provisioning_webhooks"
-	ComponentZanzana              ComponentID = "zanzana"
-)
-
 // Operation labels for the request-duration metric. They name the resource
 // client verb, so a slow or failing verb can be told apart from the others.
 const (
@@ -49,13 +36,14 @@ const (
 
 // clientMetrics measures the outbound Kubernetes API server requests a Grafana
 // subsystem makes through this package's dynamic client factory. The factory is
-// shared — provisioning, its webhooks and zanzana all use it, and in a
-// single-binary Grafana they are handed the same registry — so every observation
-// carries a "component" label naming the caller. Latency is further labelled by
-// resource group, resource, operation and outcome, so a slow or failing verb can
-// be told apart per resource type per caller. Durations cover the whole retried
-// operation, including backoff waits, since that is the latency the caller
-// actually sees.
+// shared — provisioning, its webhooks and zanzana all build one — so the metric
+// is named for the layer rather than any one caller. Which subsystem issued a
+// request is not a metric label: the callers are separate deployments, so the
+// scrape target labels (job, pod, container) already separate them. Latency is
+// labelled by resource group, resource, operation and outcome, so a slow or
+// failing verb can be told apart per resource type. Durations cover the whole
+// retried operation, including backoff waits, since that is the latency the
+// caller actually sees.
 //
 // The metric is grafana_apiserver_client_request_duration_seconds. The "client"
 // infix is load-bearing, not stylistic: k8s.io/apiserver registers the
@@ -67,26 +55,22 @@ const (
 // families under one name in the scrape body, which fails the parse for the
 // whole endpoint. Keep the infix.
 type clientMetrics struct {
-	// component identifies the owning subsystem. It labels every observation, so
-	// callers sharing one collector remain distinguishable.
-	component       ComponentID
 	requestDuration *prometheus.HistogramVec
 }
 
-// newClientMetrics builds the client metrics on reg for the given component,
-// reusing collectors already registered there so factories sharing a registry
-// share one collector. A nil reg leaves the collectors unregistered but usable.
-func newClientMetrics(reg prometheus.Registerer, component ComponentID) *clientMetrics {
+// newClientMetrics builds the client metrics on reg, reusing collectors already
+// registered there so factories sharing a registry share one collector. A nil
+// reg leaves the collectors unregistered but usable.
+func newClientMetrics(reg prometheus.Registerer) *clientMetrics {
 	return &clientMetrics{
-		component: component,
 		requestDuration: registerOrReuse(reg, prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:                            "grafana_apiserver_client_request_duration_seconds",
-			Help:                            "Duration of the outbound Kubernetes API server requests a Grafana subsystem makes for the resources it manages, by calling component, resource group, resource, operation and outcome. Includes retry/backoff time. This is the client-side counterpart to the server-side grafana_apiserver_request_duration_seconds.",
+			Help:                            "Duration of the outbound Kubernetes API server requests a Grafana subsystem makes for the resources it manages, by resource group, resource, operation and outcome. Includes retry/backoff time. This is the client-side counterpart to the server-side grafana_apiserver_request_duration_seconds.",
 			Buckets:                         instrument.DefBuckets,
 			NativeHistogramBucketFactor:     1.1,
 			NativeHistogramMaxBucketNumber:  160,
 			NativeHistogramMinResetDuration: time.Hour,
-		}, []string{"component", "group", "resource", "operation", "outcome"})),
+		}, []string{"group", "resource", "operation", "outcome"})),
 	}
 }
 
@@ -102,7 +86,7 @@ func (m *clientMetrics) observe(gvr schema.GroupVersionResource, operation strin
 	}
 	// WithLabelValues is positional: the order here must match the label names
 	// declared in newClientMetrics.
-	m.requestDuration.WithLabelValues(string(m.component), gvr.Group, gvr.Resource, operation, outcome).Observe(time.Since(start).Seconds())
+	m.requestDuration.WithLabelValues(gvr.Group, gvr.Resource, operation, outcome).Observe(time.Since(start).Seconds())
 }
 
 // registerOrReuse registers c on reg, returning the collector already registered

--- a/pkg/registry/apis/provisioning/resources/metrics_test.go
+++ b/pkg/registry/apis/provisioning/resources/metrics_test.go
@@ -1,0 +1,75 @@
+package resources
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/grafana/grafana/pkg/registry/apis/provisioning/utils"
+)
+
+func TestClientMetrics_NilSafe(t *testing.T) {
+	var m *clientMetrics
+	assert.NotPanics(t, func() {
+		m.observe(schema.GroupVersionResource{Resource: "dashboards"}, operationCreate, time.Now(), nil)
+	})
+}
+
+func TestClientMetrics_Observe(t *testing.T) {
+	reg := prometheus.NewPedanticRegistry()
+	m := newClientMetrics(reg)
+
+	gvr := schema.GroupVersionResource{Group: "dashboard.grafana.app", Version: "v1", Resource: "dashboards"}
+	m.observe(gvr, operationCreate, time.Now(), nil)
+	m.observe(gvr, operationCreate, time.Now(), errors.New("boom"))
+
+	assert.Equal(t, uint64(1), histogramCountFor(t, reg,
+		"dashboard.grafana.app", "dashboards", operationCreate, utils.SuccessOutcome))
+	assert.Equal(t, uint64(1), histogramCountFor(t, reg,
+		"dashboard.grafana.app", "dashboards", operationCreate, utils.ErrorOutcome))
+}
+
+// histogramCountFor returns the sample count of the request-duration histogram
+// for the given {group, resource, operation, outcome} label set.
+func histogramCountFor(t *testing.T, reg *prometheus.Registry, group, resource, operation, outcome string) uint64 {
+	t.Helper()
+
+	families, err := reg.Gather()
+	require.NoError(t, err)
+
+	for _, mf := range families {
+		if mf.GetName() != "grafana_provisioning_apiserver_request_duration_seconds" {
+			continue
+		}
+		for _, metric := range mf.GetMetric() {
+			if labelsMatch(metric.GetLabel(), map[string]string{
+				"group":     group,
+				"resource":  resource,
+				"operation": operation,
+				"outcome":   outcome,
+			}) {
+				return metric.GetHistogram().GetSampleCount()
+			}
+		}
+	}
+	return 0
+}
+
+func labelsMatch(labels []*dto.LabelPair, want map[string]string) bool {
+	got := make(map[string]string, len(labels))
+	for _, l := range labels {
+		got[l.GetName()] = l.GetValue()
+	}
+	for k, v := range want {
+		if got[k] != v {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/registry/apis/provisioning/resources/metrics_test.go
+++ b/pkg/registry/apis/provisioning/resources/metrics_test.go
@@ -28,20 +28,18 @@ func TestClientMetrics_NilSafe(t *testing.T) {
 
 func TestClientMetrics_Observe(t *testing.T) {
 	reg := prometheus.NewPedanticRegistry()
-	m := newClientMetrics(reg, ComponentProvisioning)
+	m := newClientMetrics(reg)
 
 	m.observe(dashboardGVR, operationCreate, time.Now(), nil)
 	m.observe(dashboardGVR, operationCreate, time.Now(), errors.New("boom"))
 
 	assert.Equal(t, uint64(1), histogramCount(t, reg, prometheus.Labels{
-		"component": string(ComponentProvisioning),
 		"group":     dashboardGVR.Group,
 		"resource":  dashboardGVR.Resource,
 		"operation": operationCreate,
 		"outcome":   outcomeSuccess,
 	}))
 	assert.Equal(t, uint64(1), histogramCount(t, reg, prometheus.Labels{
-		"component": string(ComponentProvisioning),
 		"group":     dashboardGVR.Group,
 		"resource":  dashboardGVR.Resource,
 		"operation": operationCreate,
@@ -49,42 +47,18 @@ func TestClientMetrics_Observe(t *testing.T) {
 	}))
 }
 
-// TestClientMetrics_SharedRegistryDistinguishesComponents is the regression guard
-// for the defect this label exists to fix: provisioning and zanzana share this
-// package's client factory and, in a single-binary Grafana, one registry. Both
-// list folders, so without the component label their requests merge into one
-// indistinguishable series.
-func TestClientMetrics_SharedRegistryDistinguishesComponents(t *testing.T) {
-	reg := prometheus.NewPedanticRegistry()
-	provisioning := newClientMetrics(reg, ComponentProvisioning)
-	zanzana := newClientMetrics(reg, ComponentZanzana)
-
-	// The same resource and operation, from two different subsystems.
-	provisioning.observe(folderGVR, operationList, time.Now(), nil)
-	zanzana.observe(folderGVR, operationList, time.Now(), nil)
-	zanzana.observe(folderGVR, operationList, time.Now(), nil)
-
-	base := prometheus.Labels{
-		"group":     folderGVR.Group,
-		"resource":  folderGVR.Resource,
-		"operation": operationList,
-		"outcome":   outcomeSuccess,
-	}
-	assert.Equal(t, uint64(1), histogramCount(t, reg, withComponent(base, ComponentProvisioning)))
-	assert.Equal(t, uint64(2), histogramCount(t, reg, withComponent(base, ComponentZanzana)))
-}
-
-// TestClientMetrics_RepeatConstructionOnSameRegistry covers the real wiring:
-// NewAPIBuilder is called once per API version (v0alpha1 and v1beta1) with the
-// same registry, so newClientMetrics runs more than once against it. The second
-// construction must reuse the registered collector rather than panic.
+// TestClientMetrics_RepeatConstructionOnSameRegistry covers the real wiring: this
+// factory is built several times against one registry — NewAPIBuilder runs once
+// per API version (v0alpha1 and v1beta1), the webhooks builder likewise, and
+// zanzana builds its own — so newClientMetrics must reuse the registered
+// collector rather than panic, and every instance must write to one series.
 func TestClientMetrics_RepeatConstructionOnSameRegistry(t *testing.T) {
 	reg := prometheus.NewPedanticRegistry()
 
 	var first, second *clientMetrics
 	require.NotPanics(t, func() {
-		first = newClientMetrics(reg, ComponentProvisioning)
-		second = newClientMetrics(reg, ComponentProvisioning)
+		first = newClientMetrics(reg)
+		second = newClientMetrics(reg)
 	})
 
 	first.observe(dashboardGVR, operationGet, time.Now(), nil)
@@ -92,7 +66,6 @@ func TestClientMetrics_RepeatConstructionOnSameRegistry(t *testing.T) {
 
 	// Both instances share one collector, so the observations land on one series.
 	assert.Equal(t, uint64(2), histogramCount(t, reg, prometheus.Labels{
-		"component": string(ComponentProvisioning),
 		"group":     dashboardGVR.Group,
 		"resource":  dashboardGVR.Resource,
 		"operation": operationGet,
@@ -105,11 +78,10 @@ func TestClientMetrics_RepeatConstructionOnSameRegistry(t *testing.T) {
 // otherwise silently mislabel every observation.
 func TestClientMetrics_LabelContract(t *testing.T) {
 	reg := prometheus.NewPedanticRegistry()
-	m := newClientMetrics(reg, ComponentZanzana)
+	m := newClientMetrics(reg)
 	m.observe(folderGVR, operationDeleteCollection, time.Now(), errors.New("boom"))
 
 	metric := findMetric(t, reg, prometheus.Labels{
-		"component": string(ComponentZanzana),
 		"group":     folderGVR.Group,
 		"resource":  folderGVR.Resource,
 		"operation": operationDeleteCollection,
@@ -122,7 +94,7 @@ func TestClientMetrics_LabelContract(t *testing.T) {
 		got = append(got, l.GetName())
 	}
 	// Gathered labels are sorted by name.
-	assert.Equal(t, []string{"component", "group", "operation", "outcome", "resource"}, got)
+	assert.Equal(t, []string{"group", "operation", "outcome", "resource"}, got)
 }
 
 func TestRegisterOrReuse(t *testing.T) {
@@ -143,21 +115,13 @@ func TestRegisterOrReuse(t *testing.T) {
 		// prometheus does not unwrap AlreadyRegisteredError through a wrapping
 		// registerer, so ExistingCollector is not of the requested type. That must
 		// degrade rather than panic: this path runs on every API server call.
-		reg := prometheus.WrapRegistererWith(prometheus.Labels{"component": "x"}, prometheus.NewPedanticRegistry())
+		reg := prometheus.WrapRegistererWith(prometheus.Labels{"wrapped": "yes"}, prometheus.NewPedanticRegistry())
 		opts := prometheus.CounterOpts{Name: "test_total"}
 		require.NotPanics(t, func() {
 			registerOrReuse(reg, prometheus.NewCounter(opts))
 			registerOrReuse(reg, prometheus.NewCounter(opts))
 		})
 	})
-}
-
-func withComponent(base prometheus.Labels, component ComponentID) prometheus.Labels {
-	out := prometheus.Labels{"component": string(component)}
-	for k, v := range base {
-		out[k] = v
-	}
-	return out
 }
 
 // histogramCount returns the sample count of the request-duration histogram for

--- a/pkg/registry/apis/provisioning/resources/metrics_test.go
+++ b/pkg/registry/apis/provisioning/resources/metrics_test.go
@@ -10,58 +10,189 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+)
 
-	"github.com/grafana/grafana/pkg/registry/apis/provisioning/utils"
+const requestDurationMetric = "grafana_apiserver_client_request_duration_seconds"
+
+var (
+	dashboardGVR = schema.GroupVersionResource{Group: "dashboard.grafana.app", Version: "v1", Resource: "dashboards"}
+	folderGVR    = schema.GroupVersionResource{Group: "folder.grafana.app", Version: "v1", Resource: "folders"}
 )
 
 func TestClientMetrics_NilSafe(t *testing.T) {
 	var m *clientMetrics
 	assert.NotPanics(t, func() {
-		m.observe(schema.GroupVersionResource{Resource: "dashboards"}, operationCreate, time.Now(), nil)
+		m.observe(dashboardGVR, operationCreate, time.Now(), nil)
 	})
 }
 
 func TestClientMetrics_Observe(t *testing.T) {
 	reg := prometheus.NewPedanticRegistry()
-	m := newClientMetrics(reg)
+	m := newClientMetrics(reg, ComponentProvisioning)
 
-	gvr := schema.GroupVersionResource{Group: "dashboard.grafana.app", Version: "v1", Resource: "dashboards"}
-	m.observe(gvr, operationCreate, time.Now(), nil)
-	m.observe(gvr, operationCreate, time.Now(), errors.New("boom"))
+	m.observe(dashboardGVR, operationCreate, time.Now(), nil)
+	m.observe(dashboardGVR, operationCreate, time.Now(), errors.New("boom"))
 
-	assert.Equal(t, uint64(1), histogramCountFor(t, reg,
-		"dashboard.grafana.app", "dashboards", operationCreate, utils.SuccessOutcome))
-	assert.Equal(t, uint64(1), histogramCountFor(t, reg,
-		"dashboard.grafana.app", "dashboards", operationCreate, utils.ErrorOutcome))
+	assert.Equal(t, uint64(1), histogramCount(t, reg, prometheus.Labels{
+		"component": string(ComponentProvisioning),
+		"group":     dashboardGVR.Group,
+		"resource":  dashboardGVR.Resource,
+		"operation": operationCreate,
+		"outcome":   outcomeSuccess,
+	}))
+	assert.Equal(t, uint64(1), histogramCount(t, reg, prometheus.Labels{
+		"component": string(ComponentProvisioning),
+		"group":     dashboardGVR.Group,
+		"resource":  dashboardGVR.Resource,
+		"operation": operationCreate,
+		"outcome":   outcomeError,
+	}))
 }
 
-// histogramCountFor returns the sample count of the request-duration histogram
-// for the given {group, resource, operation, outcome} label set.
-func histogramCountFor(t *testing.T, reg *prometheus.Registry, group, resource, operation, outcome string) uint64 {
+// TestClientMetrics_SharedRegistryDistinguishesComponents is the regression guard
+// for the defect this label exists to fix: provisioning and zanzana share this
+// package's client factory and, in a single-binary Grafana, one registry. Both
+// list folders, so without the component label their requests merge into one
+// indistinguishable series.
+func TestClientMetrics_SharedRegistryDistinguishesComponents(t *testing.T) {
+	reg := prometheus.NewPedanticRegistry()
+	provisioning := newClientMetrics(reg, ComponentProvisioning)
+	zanzana := newClientMetrics(reg, ComponentZanzana)
+
+	// The same resource and operation, from two different subsystems.
+	provisioning.observe(folderGVR, operationList, time.Now(), nil)
+	zanzana.observe(folderGVR, operationList, time.Now(), nil)
+	zanzana.observe(folderGVR, operationList, time.Now(), nil)
+
+	base := prometheus.Labels{
+		"group":     folderGVR.Group,
+		"resource":  folderGVR.Resource,
+		"operation": operationList,
+		"outcome":   outcomeSuccess,
+	}
+	assert.Equal(t, uint64(1), histogramCount(t, reg, withComponent(base, ComponentProvisioning)))
+	assert.Equal(t, uint64(2), histogramCount(t, reg, withComponent(base, ComponentZanzana)))
+}
+
+// TestClientMetrics_RepeatConstructionOnSameRegistry covers the real wiring:
+// NewAPIBuilder is called once per API version (v0alpha1 and v1beta1) with the
+// same registry, so newClientMetrics runs more than once against it. The second
+// construction must reuse the registered collector rather than panic.
+func TestClientMetrics_RepeatConstructionOnSameRegistry(t *testing.T) {
+	reg := prometheus.NewPedanticRegistry()
+
+	var first, second *clientMetrics
+	require.NotPanics(t, func() {
+		first = newClientMetrics(reg, ComponentProvisioning)
+		second = newClientMetrics(reg, ComponentProvisioning)
+	})
+
+	first.observe(dashboardGVR, operationGet, time.Now(), nil)
+	second.observe(dashboardGVR, operationGet, time.Now(), nil)
+
+	// Both instances share one collector, so the observations land on one series.
+	assert.Equal(t, uint64(2), histogramCount(t, reg, prometheus.Labels{
+		"component": string(ComponentProvisioning),
+		"group":     dashboardGVR.Group,
+		"resource":  dashboardGVR.Resource,
+		"operation": operationGet,
+		"outcome":   outcomeSuccess,
+	}))
+}
+
+// TestClientMetrics_LabelContract pins the exact label set. WithLabelValues is
+// positional and unchecked, so a label added or reordered on one side only would
+// otherwise silently mislabel every observation.
+func TestClientMetrics_LabelContract(t *testing.T) {
+	reg := prometheus.NewPedanticRegistry()
+	m := newClientMetrics(reg, ComponentZanzana)
+	m.observe(folderGVR, operationDeleteCollection, time.Now(), errors.New("boom"))
+
+	metric := findMetric(t, reg, prometheus.Labels{
+		"component": string(ComponentZanzana),
+		"group":     folderGVR.Group,
+		"resource":  folderGVR.Resource,
+		"operation": operationDeleteCollection,
+		"outcome":   outcomeError,
+	})
+	require.NotNil(t, metric, "no series matched the expected label set")
+
+	got := make([]string, 0, len(metric.GetLabel()))
+	for _, l := range metric.GetLabel() {
+		got = append(got, l.GetName())
+	}
+	// Gathered labels are sorted by name.
+	assert.Equal(t, []string{"component", "group", "operation", "outcome", "resource"}, got)
+}
+
+func TestRegisterOrReuse(t *testing.T) {
+	t.Run("returns the collector unregistered when reg is nil", func(t *testing.T) {
+		c := prometheus.NewCounter(prometheus.CounterOpts{Name: "test_total"})
+		assert.Equal(t, c, registerOrReuse(nil, c))
+	})
+
+	t.Run("reuses an already-registered collector", func(t *testing.T) {
+		reg := prometheus.NewPedanticRegistry()
+		opts := prometheus.CounterOpts{Name: "test_total"}
+		first := registerOrReuse(reg, prometheus.NewCounter(opts))
+		second := registerOrReuse(reg, prometheus.NewCounter(opts))
+		assert.Same(t, first, second)
+	})
+
+	t.Run("does not panic when a wrapping registerer returns a wrapped collector", func(t *testing.T) {
+		// prometheus does not unwrap AlreadyRegisteredError through a wrapping
+		// registerer, so ExistingCollector is not of the requested type. That must
+		// degrade rather than panic: this path runs on every API server call.
+		reg := prometheus.WrapRegistererWith(prometheus.Labels{"component": "x"}, prometheus.NewPedanticRegistry())
+		opts := prometheus.CounterOpts{Name: "test_total"}
+		require.NotPanics(t, func() {
+			registerOrReuse(reg, prometheus.NewCounter(opts))
+			registerOrReuse(reg, prometheus.NewCounter(opts))
+		})
+	})
+}
+
+func withComponent(base prometheus.Labels, component ComponentID) prometheus.Labels {
+	out := prometheus.Labels{"component": string(component)}
+	for k, v := range base {
+		out[k] = v
+	}
+	return out
+}
+
+// histogramCount returns the sample count of the request-duration histogram for
+// the series matching want, or 0 when no series matches.
+func histogramCount(t *testing.T, reg *prometheus.Registry, want prometheus.Labels) uint64 {
+	t.Helper()
+	if m := findMetric(t, reg, want); m != nil {
+		return m.GetHistogram().GetSampleCount()
+	}
+	return 0
+}
+
+// findMetric locates the request-duration series whose labels match want. Labels
+// are matched by name via a map so the test cannot reproduce the positional
+// WithLabelValues footgun it exists to catch.
+func findMetric(t *testing.T, reg *prometheus.Registry, want prometheus.Labels) *dto.Metric {
 	t.Helper()
 
 	families, err := reg.Gather()
 	require.NoError(t, err)
 
 	for _, mf := range families {
-		if mf.GetName() != "grafana_provisioning_apiserver_request_duration_seconds" {
+		if mf.GetName() != requestDurationMetric {
 			continue
 		}
 		for _, metric := range mf.GetMetric() {
-			if labelsMatch(metric.GetLabel(), map[string]string{
-				"group":     group,
-				"resource":  resource,
-				"operation": operation,
-				"outcome":   outcome,
-			}) {
-				return metric.GetHistogram().GetSampleCount()
+			if labelsMatch(metric.GetLabel(), want) {
+				return metric
 			}
 		}
 	}
-	return 0
+	return nil
 }
 
-func labelsMatch(labels []*dto.LabelPair, want map[string]string) bool {
+func labelsMatch(labels []*dto.LabelPair, want prometheus.Labels) bool {
 	got := make(map[string]string, len(labels))
 	for _, l := range labels {
 		got[l.GetName()] = l.GetValue()

--- a/pkg/registry/apis/provisioning/resources/retry_client.go
+++ b/pkg/registry/apis/provisioning/resources/retry_client.go
@@ -10,6 +10,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
@@ -54,13 +55,21 @@ func defaultRetryBackoff() wait.Backoff {
 type retryResourceInterface struct {
 	client  dynamic.ResourceInterface
 	backoff wait.Backoff
+	// gvr and metrics label and record the API server request latency. metrics
+	// may be nil (factory built without a registry); observe tolerates that.
+	gvr     schema.GroupVersionResource
+	metrics *clientMetrics
 }
 
-// newRetryResourceInterface creates a new ResourceInterface wrapper with retry logic
-func newRetryResourceInterface(client dynamic.ResourceInterface, backoff wait.Backoff) dynamic.ResourceInterface {
+// newRetryResourceInterface creates a new ResourceInterface wrapper with retry
+// logic. gvr labels the request-duration metric; metrics may be nil, in which
+// case no metrics are recorded.
+func newRetryResourceInterface(client dynamic.ResourceInterface, backoff wait.Backoff, gvr schema.GroupVersionResource, metrics *clientMetrics) dynamic.ResourceInterface {
 	return &retryResourceInterface{
 		client:  client,
 		backoff: backoff,
+		gvr:     gvr,
+		metrics: metrics,
 	}
 }
 
@@ -105,8 +114,13 @@ func isTransientError(err error) bool {
 	return errors.As(err, &opErr)
 }
 
-// retryWithBackoff executes a function with exponential backoff retry logic using wait.ExponentialBackoff
-func (r *retryResourceInterface) retryWithBackoff(ctx context.Context, fn func() error) error {
+// retryWithBackoff executes a function with exponential backoff retry logic using wait.ExponentialBackoff.
+// It records the operation's latency and outcome, timing the whole retried call
+// (including backoff waits) as that is the latency the caller observes.
+func (r *retryResourceInterface) retryWithBackoff(ctx context.Context, operation string, fn func() error) (retErr error) {
+	start := time.Now()
+	defer func() { r.metrics.observe(r.gvr, operation, start, retErr) }()
+
 	var lastErr error
 	attempt := 0
 	logger := logging.FromContext(ctx)
@@ -160,7 +174,7 @@ func (r *retryResourceInterface) Create(ctx context.Context, obj *unstructured.U
 	var result *unstructured.Unstructured
 	var err error
 
-	retryErr := r.retryWithBackoff(ctx, func() error {
+	retryErr := r.retryWithBackoff(ctx, operationCreate, func() error {
 		result, err = r.client.Create(ctx, obj, options, subresources...)
 		return err
 	})
@@ -176,7 +190,7 @@ func (r *retryResourceInterface) Update(ctx context.Context, obj *unstructured.U
 	var result *unstructured.Unstructured
 	var err error
 
-	retryErr := r.retryWithBackoff(ctx, func() error {
+	retryErr := r.retryWithBackoff(ctx, operationUpdate, func() error {
 		result, err = r.client.Update(ctx, obj, options, subresources...)
 		return err
 	})
@@ -192,7 +206,7 @@ func (r *retryResourceInterface) UpdateStatus(ctx context.Context, obj *unstruct
 	var result *unstructured.Unstructured
 	var err error
 
-	retryErr := r.retryWithBackoff(ctx, func() error {
+	retryErr := r.retryWithBackoff(ctx, operationUpdateStatus, func() error {
 		result, err = r.client.UpdateStatus(ctx, obj, options)
 		return err
 	})
@@ -205,14 +219,14 @@ func (r *retryResourceInterface) UpdateStatus(ctx context.Context, obj *unstruct
 
 // Delete implements dynamic.ResourceInterface
 func (r *retryResourceInterface) Delete(ctx context.Context, name string, options metav1.DeleteOptions, subresources ...string) error {
-	return r.retryWithBackoff(ctx, func() error {
+	return r.retryWithBackoff(ctx, operationDelete, func() error {
 		return r.client.Delete(ctx, name, options, subresources...)
 	})
 }
 
 // DeleteCollection implements dynamic.ResourceInterface
 func (r *retryResourceInterface) DeleteCollection(ctx context.Context, options metav1.DeleteOptions, listOptions metav1.ListOptions) error {
-	return r.retryWithBackoff(ctx, func() error {
+	return r.retryWithBackoff(ctx, operationDeleteCollection, func() error {
 		return r.client.DeleteCollection(ctx, options, listOptions)
 	})
 }
@@ -222,7 +236,7 @@ func (r *retryResourceInterface) Get(ctx context.Context, name string, options m
 	var result *unstructured.Unstructured
 	var err error
 
-	retryErr := r.retryWithBackoff(ctx, func() error {
+	retryErr := r.retryWithBackoff(ctx, operationGet, func() error {
 		result, err = r.client.Get(ctx, name, options, subresources...)
 		return err
 	})
@@ -238,7 +252,7 @@ func (r *retryResourceInterface) List(ctx context.Context, opts metav1.ListOptio
 	var result *unstructured.UnstructuredList
 	var err error
 
-	retryErr := r.retryWithBackoff(ctx, func() error {
+	retryErr := r.retryWithBackoff(ctx, operationList, func() error {
 		result, err = r.client.List(ctx, opts)
 		return err
 	})
@@ -261,7 +275,7 @@ func (r *retryResourceInterface) Patch(ctx context.Context, name string, pt type
 	var result *unstructured.Unstructured
 	var err error
 
-	retryErr := r.retryWithBackoff(ctx, func() error {
+	retryErr := r.retryWithBackoff(ctx, operationPatch, func() error {
 		result, err = r.client.Patch(ctx, name, pt, data, options, subresources...)
 		return err
 	})
@@ -277,7 +291,7 @@ func (r *retryResourceInterface) Apply(ctx context.Context, name string, obj *un
 	var result *unstructured.Unstructured
 	var err error
 
-	retryErr := r.retryWithBackoff(ctx, func() error {
+	retryErr := r.retryWithBackoff(ctx, operationApply, func() error {
 		result, err = r.client.Apply(ctx, name, obj, options, subresources...)
 		return err
 	})
@@ -293,7 +307,7 @@ func (r *retryResourceInterface) ApplyStatus(ctx context.Context, name string, o
 	var result *unstructured.Unstructured
 	var err error
 
-	retryErr := r.retryWithBackoff(ctx, func() error {
+	retryErr := r.retryWithBackoff(ctx, operationApplyStatus, func() error {
 		result, err = r.client.ApplyStatus(ctx, name, obj, options)
 		return err
 	})

--- a/pkg/registry/apis/provisioning/resources/retry_client_test.go
+++ b/pkg/registry/apis/provisioning/resources/retry_client_test.go
@@ -16,7 +16,14 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
 )
+
+// newTestRetryClient builds a retry client without a GVR or metrics — the retry
+// tests exercise backoff behaviour, not the request-duration metric.
+func newTestRetryClient(client dynamic.ResourceInterface, backoff wait.Backoff) dynamic.ResourceInterface {
+	return newRetryResourceInterface(client, backoff, schema.GroupVersionResource{}, nil)
+}
 
 func TestIsTransientError(t *testing.T) {
 	tests := []struct {
@@ -174,7 +181,7 @@ func TestRetryResourceInterface_Create(t *testing.T) {
 			mockClient := &MockDynamicResourceInterface{}
 			tt.setupMock(mockClient)
 
-			retryClient := newRetryResourceInterface(mockClient, tt.backoff)
+			retryClient := newTestRetryClient(mockClient, tt.backoff)
 			obj := &unstructured.Unstructured{}
 			_, err := retryClient.Create(context.Background(), obj, metav1.CreateOptions{})
 
@@ -195,7 +202,7 @@ func TestRetryResourceInterface_Update(t *testing.T) {
 	mockClient.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(&unstructured.Unstructured{}, nil).Once()
 
-	retryClient := newRetryResourceInterface(mockClient, wait.Backoff{
+	retryClient := newTestRetryClient(mockClient, wait.Backoff{
 		Duration: 10 * time.Millisecond,
 		Factor:   2.0,
 		Jitter:   0.1,
@@ -218,7 +225,7 @@ func TestRetryResourceInterface_Get(t *testing.T) {
 	mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(&unstructured.Unstructured{}, nil).Once()
 
-	retryClient := newRetryResourceInterface(mockClient, wait.Backoff{
+	retryClient := newTestRetryClient(mockClient, wait.Backoff{
 		Duration: 10 * time.Millisecond,
 		Factor:   2.0,
 		Jitter:   0.1,
@@ -240,7 +247,7 @@ func TestRetryResourceInterface_Delete(t *testing.T) {
 	mockClient.On("Delete", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil).Once()
 
-	retryClient := newRetryResourceInterface(mockClient, wait.Backoff{
+	retryClient := newTestRetryClient(mockClient, wait.Backoff{
 		Duration: 10 * time.Millisecond,
 		Factor:   2.0,
 		Jitter:   0.1,
@@ -261,7 +268,7 @@ func TestRetryResourceInterface_List(t *testing.T) {
 	mockClient.On("List", mock.Anything, mock.Anything).
 		Return(&unstructured.UnstructuredList{}, nil).Once()
 
-	retryClient := newRetryResourceInterface(mockClient, wait.Backoff{
+	retryClient := newTestRetryClient(mockClient, wait.Backoff{
 		Duration: 10 * time.Millisecond,
 		Factor:   2.0,
 		Jitter:   0.1,
@@ -283,7 +290,7 @@ func TestRetryResourceInterface_Patch(t *testing.T) {
 	mockClient.On("Patch", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(&unstructured.Unstructured{}, nil).Once()
 
-	retryClient := newRetryResourceInterface(mockClient, wait.Backoff{
+	retryClient := newTestRetryClient(mockClient, wait.Backoff{
 		Duration: 10 * time.Millisecond,
 		Factor:   2.0,
 		Jitter:   0.1,
@@ -305,7 +312,7 @@ func TestRetryResourceInterface_Apply(t *testing.T) {
 	mockClient.On("Apply", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(&unstructured.Unstructured{}, nil).Once()
 
-	retryClient := newRetryResourceInterface(mockClient, wait.Backoff{
+	retryClient := newTestRetryClient(mockClient, wait.Backoff{
 		Duration: 10 * time.Millisecond,
 		Factor:   2.0,
 		Jitter:   0.1,
@@ -328,7 +335,7 @@ func TestRetryResourceInterface_UpdateStatus(t *testing.T) {
 	mockClient.On("UpdateStatus", mock.Anything, mock.Anything, mock.Anything).
 		Return(&unstructured.Unstructured{}, nil).Once()
 
-	retryClient := newRetryResourceInterface(mockClient, wait.Backoff{
+	retryClient := newTestRetryClient(mockClient, wait.Backoff{
 		Duration: 10 * time.Millisecond,
 		Factor:   2.0,
 		Jitter:   0.1,
@@ -351,7 +358,7 @@ func TestRetryResourceInterface_ApplyStatus(t *testing.T) {
 	mockClient.On("ApplyStatus", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(&unstructured.Unstructured{}, nil).Once()
 
-	retryClient := newRetryResourceInterface(mockClient, wait.Backoff{
+	retryClient := newTestRetryClient(mockClient, wait.Backoff{
 		Duration: 10 * time.Millisecond,
 		Factor:   2.0,
 		Jitter:   0.1,
@@ -374,7 +381,7 @@ func TestRetryResourceInterface_DeleteCollection(t *testing.T) {
 	mockClient.On("DeleteCollection", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil).Once()
 
-	retryClient := newRetryResourceInterface(mockClient, wait.Backoff{
+	retryClient := newTestRetryClient(mockClient, wait.Backoff{
 		Duration: 10 * time.Millisecond,
 		Factor:   2.0,
 		Jitter:   0.1,
@@ -393,7 +400,7 @@ func TestRetryResourceInterface_Watch(t *testing.T) {
 	mockWatch := &mockWatch{}
 	mockClient.On("Watch", mock.Anything, mock.Anything).Return(mockWatch, nil).Once()
 
-	retryClient := newRetryResourceInterface(mockClient, defaultRetryBackoff())
+	retryClient := newTestRetryClient(mockClient, defaultRetryBackoff())
 
 	watch, err := retryClient.Watch(context.Background(), metav1.ListOptions{})
 
@@ -408,7 +415,7 @@ func TestRetryResourceInterface_ContextCancellation(t *testing.T) {
 	mockClient.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, apierrors.NewServiceUnavailable("service unavailable")).Maybe()
 
-	retryClient := newRetryResourceInterface(mockClient, wait.Backoff{
+	retryClient := newTestRetryClient(mockClient, wait.Backoff{
 		Duration: 100 * time.Millisecond,
 		Factor:   2.0,
 		Jitter:   0.1,
@@ -445,7 +452,7 @@ func TestRetryResourceInterface_ExponentialBackoff(t *testing.T) {
 		Return(&unstructured.Unstructured{}, nil).Once()
 
 	start := time.Now()
-	retryClient := newRetryResourceInterface(mockClient, wait.Backoff{
+	retryClient := newTestRetryClient(mockClient, wait.Backoff{
 		Duration: 50 * time.Millisecond,
 		Factor:   2.0,
 		Jitter:   0.1,
@@ -478,7 +485,7 @@ func TestRetryResourceInterface_MaxDelayRespected(t *testing.T) {
 		Return(nil, apierrors.NewServiceUnavailable("service unavailable")).
 		Maybe() // Allow unlimited calls
 
-	retryClient := newRetryResourceInterface(mockClient, wait.Backoff{
+	retryClient := newTestRetryClient(mockClient, wait.Backoff{
 		Duration: 50 * time.Millisecond,
 		Factor:   2.0,
 		Jitter:   0.1,

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/worker.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/worker.go
@@ -45,7 +45,7 @@ func ProvidePullRequestWorker(
 
 	// FIXME: we should create providers for client and parsers, so that we don't have
 	// multiple connections for webhooks
-	clients := resources.NewClientFactory(configProvider, registry)
+	clients := resources.NewClientFactory(configProvider, registry, resources.ComponentProvisioningWebhooks)
 	parsers := resources.NewParserFactory(clients, resources.IsFolderMetadataEnabled(cfg))
 	screenshotRenderer := NewScreenshotRenderer(renderer, blobstore)
 	evaluator := NewEvaluator(screenshotRenderer, parsers, urls, registry)

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/worker.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/worker.go
@@ -45,7 +45,7 @@ func ProvidePullRequestWorker(
 
 	// FIXME: we should create providers for client and parsers, so that we don't have
 	// multiple connections for webhooks
-	clients := resources.NewClientFactory(configProvider)
+	clients := resources.NewClientFactory(configProvider, registry)
 	parsers := resources.NewParserFactory(clients, resources.IsFolderMetadataEnabled(cfg))
 	screenshotRenderer := NewScreenshotRenderer(renderer, blobstore)
 	evaluator := NewEvaluator(screenshotRenderer, parsers, urls, registry)

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/worker.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/worker.go
@@ -45,7 +45,7 @@ func ProvidePullRequestWorker(
 
 	// FIXME: we should create providers for client and parsers, so that we don't have
 	// multiple connections for webhooks
-	clients := resources.NewClientFactory(configProvider, registry, resources.ComponentProvisioningWebhooks)
+	clients := resources.NewClientFactory(configProvider, registry)
 	parsers := resources.NewParserFactory(clients, resources.IsFolderMetadataEnabled(cfg))
 	screenshotRenderer := NewScreenshotRenderer(renderer, blobstore)
 	evaluator := NewEvaluator(screenshotRenderer, parsers, urls, registry)

--- a/pkg/registry/apis/provisioning/webhooks/register.go
+++ b/pkg/registry/apis/provisioning/webhooks/register.go
@@ -145,7 +145,7 @@ func ProvideWebhooksWithImages(
 		isPublic:    isPublic,
 		urlProvider: urls.Public,
 		ExtraBuilder: func(b *provisioningapis.APIBuilder) provisioningapis.Extra {
-			clients := resources.NewClientFactory(configProvider)
+			clients := resources.NewClientFactory(configProvider, registry)
 			parsers := resources.NewParserFactory(clients, resources.IsFolderMetadataEnabled(cfg))
 
 			screenshotRenderer := pullrequest.NewScreenshotRenderer(renderer, blobstore)

--- a/pkg/registry/apis/provisioning/webhooks/register.go
+++ b/pkg/registry/apis/provisioning/webhooks/register.go
@@ -145,7 +145,7 @@ func ProvideWebhooksWithImages(
 		isPublic:    isPublic,
 		urlProvider: urls.Public,
 		ExtraBuilder: func(b *provisioningapis.APIBuilder) provisioningapis.Extra {
-			clients := resources.NewClientFactory(configProvider, registry, resources.ComponentProvisioningWebhooks)
+			clients := resources.NewClientFactory(configProvider, registry)
 			parsers := resources.NewParserFactory(clients, resources.IsFolderMetadataEnabled(cfg))
 
 			screenshotRenderer := pullrequest.NewScreenshotRenderer(renderer, blobstore)

--- a/pkg/registry/apis/provisioning/webhooks/register.go
+++ b/pkg/registry/apis/provisioning/webhooks/register.go
@@ -145,7 +145,7 @@ func ProvideWebhooksWithImages(
 		isPublic:    isPublic,
 		urlProvider: urls.Public,
 		ExtraBuilder: func(b *provisioningapis.APIBuilder) provisioningapis.Extra {
-			clients := resources.NewClientFactory(configProvider, registry)
+			clients := resources.NewClientFactory(configProvider, registry, resources.ComponentProvisioningWebhooks)
 			parsers := resources.NewParserFactory(clients, resources.IsFolderMetadataEnabled(cfg))
 
 			screenshotRenderer := pullrequest.NewScreenshotRenderer(renderer, blobstore)

--- a/pkg/services/authz/zanzana/server/server.go
+++ b/pkg/services/authz/zanzana/server/server.go
@@ -120,7 +120,7 @@ func newServer(cfg *setting.Cfg, openfga OpenFGAServer, store storage.OpenFGADat
 	if cfg.ZanzanaReconciler.Mode == setting.ZanzanaReconcilerModeMT {
 		if restConfig != nil {
 			// Embedded mode: use LoopbackClientConfig via the eventual provider
-			clientFactory = resources.NewClientFactory(restConfig, reg)
+			clientFactory = resources.NewClientFactory(restConfig, reg, resources.ComponentZanzana)
 		} else {
 			// Standalone mode: use explicit URLs with token exchange
 			if cfg.ZanzanaReconciler.FolderAPIServerURL == "" {
@@ -182,7 +182,7 @@ func newServer(cfg *setting.Cfg, openfga OpenFGAServer, store storage.OpenFGADat
 				})
 			}
 
-			clientFactory = resources.NewClientFactoryForMultipleAPIServers(configProviders, reg)
+			clientFactory = resources.NewClientFactoryForMultipleAPIServers(configProviders, reg, resources.ComponentZanzana)
 		}
 	}
 

--- a/pkg/services/authz/zanzana/server/server.go
+++ b/pkg/services/authz/zanzana/server/server.go
@@ -120,7 +120,7 @@ func newServer(cfg *setting.Cfg, openfga OpenFGAServer, store storage.OpenFGADat
 	if cfg.ZanzanaReconciler.Mode == setting.ZanzanaReconcilerModeMT {
 		if restConfig != nil {
 			// Embedded mode: use LoopbackClientConfig via the eventual provider
-			clientFactory = resources.NewClientFactory(restConfig)
+			clientFactory = resources.NewClientFactory(restConfig, reg)
 		} else {
 			// Standalone mode: use explicit URLs with token exchange
 			if cfg.ZanzanaReconciler.FolderAPIServerURL == "" {
@@ -182,7 +182,7 @@ func newServer(cfg *setting.Cfg, openfga OpenFGAServer, store storage.OpenFGADat
 				})
 			}
 
-			clientFactory = resources.NewClientFactoryForMultipleAPIServers(configProviders)
+			clientFactory = resources.NewClientFactoryForMultipleAPIServers(configProviders, reg)
 		}
 	}
 

--- a/pkg/services/authz/zanzana/server/server.go
+++ b/pkg/services/authz/zanzana/server/server.go
@@ -120,7 +120,7 @@ func newServer(cfg *setting.Cfg, openfga OpenFGAServer, store storage.OpenFGADat
 	if cfg.ZanzanaReconciler.Mode == setting.ZanzanaReconcilerModeMT {
 		if restConfig != nil {
 			// Embedded mode: use LoopbackClientConfig via the eventual provider
-			clientFactory = resources.NewClientFactory(restConfig, reg, resources.ComponentZanzana)
+			clientFactory = resources.NewClientFactory(restConfig, reg)
 		} else {
 			// Standalone mode: use explicit URLs with token exchange
 			if cfg.ZanzanaReconciler.FolderAPIServerURL == "" {
@@ -182,7 +182,7 @@ func newServer(cfg *setting.Cfg, openfga OpenFGAServer, store storage.OpenFGADat
 				})
 			}
 
-			clientFactory = resources.NewClientFactoryForMultipleAPIServers(configProviders, reg, resources.ComponentZanzana)
+			clientFactory = resources.NewClientFactoryForMultipleAPIServers(configProviders, reg)
 		}
 	}
 

--- a/pkg/tests/apis/provisioning/client_test.go
+++ b/pkg/tests/apis/provisioning/client_test.go
@@ -14,7 +14,7 @@ import (
 func TestIntegrationProvisioning_Client(t *testing.T) {
 	helper := sharedHelper(t)
 
-	clientFactory := resources.NewClientFactory(&helper.Org1.Admin, nil, resources.ComponentProvisioning)
+	clientFactory := resources.NewClientFactory(&helper.Org1.Admin, nil)
 	clients, err := clientFactory.Clients(t.Context(), "default")
 	require.NoError(t, err)
 

--- a/pkg/tests/apis/provisioning/client_test.go
+++ b/pkg/tests/apis/provisioning/client_test.go
@@ -14,7 +14,7 @@ import (
 func TestIntegrationProvisioning_Client(t *testing.T) {
 	helper := sharedHelper(t)
 
-	clientFactory := resources.NewClientFactory(&helper.Org1.Admin, nil)
+	clientFactory := resources.NewClientFactory(&helper.Org1.Admin, nil, resources.ComponentProvisioning)
 	clients, err := clientFactory.Clients(t.Context(), "default")
 	require.NoError(t, err)
 

--- a/pkg/tests/apis/provisioning/client_test.go
+++ b/pkg/tests/apis/provisioning/client_test.go
@@ -14,7 +14,7 @@ import (
 func TestIntegrationProvisioning_Client(t *testing.T) {
 	helper := sharedHelper(t)
 
-	clientFactory := resources.NewClientFactory(&helper.Org1.Admin)
+	clientFactory := resources.NewClientFactory(&helper.Org1.Admin, nil)
 	clients, err := clientFactory.Clients(t.Context(), "default")
 	require.NoError(t, err)
 


### PR DESCRIPTION
## What

Adds **`grafana_apiserver_client_request_duration_seconds`** — a histogram measuring the outbound Kubernetes API server requests a Grafana subsystem makes through the shared dynamic client factory in `pkg/registry/apis/provisioning/resources`. Labels:

- **`group`** + **`resource`** — the resource type (`dashboard.grafana.app`/`dashboards`, `folder.grafana.app`/`folders`, …)
- **`operation`** — the verb: `create`, `update`, `update_status`, `delete`, `delete_collection`, `get`, `list`, `patch`, `apply`, `apply_status`
- **`outcome`** — `success` / `error`

Native-histogram enabled, using the same bucket config (`instrument.DefBuckets`) as the sibling provisioning informer metrics.

## Why

Provisioning issues a large number of API server requests when reconciling repositories, but there was no visibility into how many, how slow, or how they split across resource types and operations — making it hard to spot a slow or failing resource kind, or to size/alert on the load placed on the API server.

Two constraints shaped the final shape of this, both worth knowing before reviewing:

**The factory is shared, so the metric can't be provisioning-scoped.** `pkg/registry/apis/provisioning/resources` is not provisioning-exclusive — zanzana builds a client factory from it too (`zanzana/server/server.go`), as do the webhooks and the standalone operator. A `grafana_provisioning_`-prefixed name would mislabel every non-provisioning caller, so the metric is named for the layer instead. Which subsystem issued a request is deliberately **not** a metric label: these callers run as separate deployments, so the scrape target labels (`job`, `pod`, `container`) already separate their series, and a `component` label would only duplicate scrape metadata.

**The `_client_` infix is load-bearing, not stylistic.** `k8s.io/apiserver` registers the server-side `apiserver_request_duration_seconds` on the same legacy registry, and `pkg/infra/metrics` renames un-prefixed families to `grafana_*` at gather time — so `grafana_apiserver_request_duration_seconds` *already exists* in Grafana's `/metrics`. Reusing that name would not collide at registration (the fqName on our registry differs) but would emit two metric families under one name in the scrape body, failing the parse for the whole endpoint. This reasoning is recorded in a code comment so it survives a future "simplify the name" pass.

## How

All resource CRUD funnels through `retryResourceInterface` (`resources/retry_client.go`), and every non-watch operation goes through its single `retryWithBackoff` method — the natural chokepoint. Instrumenting there covers all resource types and operations in one place, and times the whole retried call including backoff, i.e. the latency the caller actually experiences. `Watch` is intentionally left out (long-lived, not retried).

- `resources/metrics.go` (new) — the collector, a nil-safe `observe`, and a local `registerOrReuse` so the several factories built against one registry share a single collector.
- `resources/client.go` — threads a `prometheus.Registerer` through both constructors into the retry client. `retry_client.go` carries the GVR so observations are labelled without touching any call site.
- Callers pass their existing registerer; a `nil` registry leaves the collectors unregistered but keeps the code working (used by tests).
- Also hardened `registerOrReuse`: its unchecked `ExistingCollector.(C)` assertion would panic at startup if a caller passed a `prometheus.WrapRegistererWith` registry, because client_golang does not unwrap `AlreadyRegisteredError`. It now degrades instead — this path runs on every API server call.

### Considered and rejected: client-go's built-in instrumentation

`client-go/tools/metrics.Register` is the canonical mechanism, but it cannot express this metric. The upstream adapter (`component-base/.../restclient`) deliberately discards the URL path, yielding `{verb, host}` with **no resource label**. A hand-written adapter is `sync.Once` process-global — it breaks the per-test pedantic-registry pattern and cannot serve the operator binaries that own their own registry — and `ResultMetric` receives no URL, so per-resource `outcome` is structurally impossible. It also misclassifies watch as `list` and collapses `apply` into `patch`. grafana-app-sdk's `Subsystem: "kubernetes_client"` was rejected too: its collectors are currently dead in core (zero callers) and its labels mean different things under the same name (`verb` = HTTP method), so adopting it risks a hard registration conflict if they are ever wired up.

## Testing

- `resources/metrics_test.go` — nil-safety, label/outcome recording, and a label-contract test pinning the exact label set (`WithLabelValues` is positional and unchecked, so a one-sided reorder would silently mislabel everything).
- `TestClientMetrics_RepeatConstructionOnSameRegistry` — this factory is built several times against one registry (`NewAPIBuilder` runs once per API version, the webhooks builder likewise, zanzana builds its own), so `newClientMetrics` must reuse the registered collector rather than panic, and all instances must write to one series.
- `TestRegisterOrReuse` covers the wrapping-registerer path that previously panicked.
- `go build ./pkg/...` and `go vet` clean (vet includes the integration-tagged `pkg/tests/apis/provisioning`, which `go build` skips); all affected suites pass; gofmt clean.

Manual check: `curl -s localhost:3000/metrics | grep apiserver_client_request_duration` — and confirm only one `grafana_apiserver_request_duration_seconds` family (the upstream server-side one) is present.

## Notes for review

- **Requires a paired grafana-enterprise change.** `NewClientFactory`/`NewClientFactoryForMultipleAPIServers` gained a `prometheus.Registerer` parameter, and enterprise calls the latter at `pkg/extensions/apiserver/registry/provisioning/clientfactory.go:98`, where the enclosing `NewClientsFactory` has no `Registerer` in its signature at all — it needs one threaded from `factory.go` (`f.registerer` is in scope there). All currently-failing checks are this single build error; a same-named enterprise branch is what turns CI green.
- Complementary to #131240 (`grafana_provisioning_jobs_resource_operation_duration_seconds`) — that one measures job-level resource operations and correctly uses `kind`; this one is the transport layer underneath and uses `resource`, matching the upstream server-side label.

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated — provisioning metrics are conventionally undocumented outside Go (all ~30 `grafana_provisioning_*` metrics are absent from `docs/`, the mixin and dashboards); tracked in grafana/git-ui-sync-project#1330
- [x] No breaking changes to any released metric — this metric has never merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
