### PR TITLE
Provisioning: add resource operation duration metric and log

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/export/folders.go
+++ b/pkg/registry/apis/provisioning/jobs/export/folders.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -67,8 +68,8 @@ func writeFolderTree(ctx context.Context, options provisioning.ExportJobOptions,
 		Ref:                  options.Branch,
 		Path:                 options.Path,
 		GenerateNewFolderIDs: options.GenerateNewFolderIDs,
-		OnFolder: func(folder resources.Folder, created bool, err error) error {
-			resultBuilder := jobs.NewFolderResult(folder.Path).WithName(folder.ID).WithAction(repository.FileActionCreated)
+		OnFolder: func(folder resources.Folder, created bool, startedAt time.Time, err error) error {
+			resultBuilder := jobs.NewFolderResult(folder.Path).WithName(folder.ID).WithAction(repository.FileActionCreated).WithStartTime(startedAt)
 
 			// A folder that failed to write must keep a non-ignored action: the
 			// recorder discards errors on FileActionIgnored results, so labelling

--- a/pkg/registry/apis/provisioning/jobs/export/folders_test.go
+++ b/pkg/registry/apis/provisioning/jobs/export/folders_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	v0alpha1 "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
@@ -144,8 +145,8 @@ func TestExportFolders(t *testing.T) {
 				}), mock.MatchedBy(func(opts resources.EnsureFolderTreeExistsOptions) bool {
 					require.Equal(t, "feature/branch", opts.Ref)
 					require.Equal(t, "grafana", opts.Path)
-					require.NoError(t, opts.OnFolder(resources.Folder{ID: "folder-1-uid", Path: "grafana/folder-1"}, true, nil))
-					require.NoError(t, opts.OnFolder(resources.Folder{ID: "folder-2-uid", Path: "grafana/folder-2"}, true, nil))
+					require.NoError(t, opts.OnFolder(resources.Folder{ID: "folder-1-uid", Path: "grafana/folder-1"}, true, time.Time{}, nil))
+					require.NoError(t, opts.OnFolder(resources.Folder{ID: "folder-2-uid", Path: "grafana/folder-2"}, true, time.Time{}, nil))
 
 					return true
 				})).Return(nil)
@@ -207,8 +208,8 @@ func TestExportFolders(t *testing.T) {
 				}), mock.MatchedBy(func(opts resources.EnsureFolderTreeExistsOptions) bool {
 					require.Equal(t, "feature/branch", opts.Ref)
 					require.Equal(t, "grafana", opts.Path)
-					require.NoError(t, opts.OnFolder(resources.Folder{ID: "folder-1-uid", Path: "grafana/folder-1"}, false, errors.New("didn't work")))
-					require.NoError(t, opts.OnFolder(resources.Folder{ID: "folder-2-uid", Path: "grafana/folder-2"}, true, nil))
+					require.NoError(t, opts.OnFolder(resources.Folder{ID: "folder-1-uid", Path: "grafana/folder-1"}, false, time.Time{}, errors.New("didn't work")))
+					require.NoError(t, opts.OnFolder(resources.Folder{ID: "folder-2-uid", Path: "grafana/folder-2"}, true, time.Time{}, nil))
 
 					return true
 				})).Return(nil)
@@ -252,7 +253,7 @@ func TestExportFolders(t *testing.T) {
 				}), mock.MatchedBy(func(opts resources.EnsureFolderTreeExistsOptions) bool {
 					require.Equal(t, "feature/branch", opts.Ref)
 					require.Equal(t, "grafana", opts.Path)
-					require.Error(t, opts.OnFolder(resources.Folder{ID: "folder-1-uid", Path: "grafana/folder-1"}, true, nil), "too many errors encountered")
+					require.Error(t, opts.OnFolder(resources.Folder{ID: "folder-1-uid", Path: "grafana/folder-1"}, true, time.Time{}, nil), "too many errors encountered")
 					return true
 				})).Return(fmt.Errorf("too many errors encountered"))
 			},
@@ -320,8 +321,8 @@ func TestExportFolders(t *testing.T) {
 				}), mock.MatchedBy(func(opts resources.EnsureFolderTreeExistsOptions) bool {
 					require.Equal(t, "feature/branch", opts.Ref)
 					require.Equal(t, "grafana", opts.Path)
-					require.NoError(t, opts.OnFolder(resources.Folder{ID: "parent-folder", Path: "grafana/parent-folder"}, true, nil))
-					require.NoError(t, opts.OnFolder(resources.Folder{ID: "child-folder", Path: "grafana/parent-folder/child-folder"}, true, nil))
+					require.NoError(t, opts.OnFolder(resources.Folder{ID: "parent-folder", Path: "grafana/parent-folder"}, true, time.Time{}, nil))
+					require.NoError(t, opts.OnFolder(resources.Folder{ID: "child-folder", Path: "grafana/parent-folder/child-folder"}, true, time.Time{}, nil))
 
 					return true
 				})).Return(nil)

--- a/pkg/registry/apis/provisioning/jobs/export/resources_specific_test.go
+++ b/pkg/registry/apis/provisioning/jobs/export/resources_specific_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	mock "github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -295,8 +296,8 @@ func TestExportSpecificResources_FolderKindIsExported(t *testing.T) {
 	}), mock.MatchedBy(func(opts resources.EnsureFolderTreeExistsOptions) bool {
 		require.Equal(t, "feature/branch", opts.Ref)
 		require.Empty(t, opts.Path)
-		require.NoError(t, opts.OnFolder(resources.Folder{ID: "parent", Path: "parent"}, true, nil))
-		require.NoError(t, opts.OnFolder(resources.Folder{ID: "child", Path: "parent/child"}, true, nil))
+		require.NoError(t, opts.OnFolder(resources.Folder{ID: "parent", Path: "parent"}, true, time.Time{}, nil))
+		require.NoError(t, opts.OnFolder(resources.Folder{ID: "child", Path: "parent/child"}, true, time.Time{}, nil))
 		return true
 	})).Return(nil)
 
@@ -347,8 +348,8 @@ func TestExportSpecificResources_GeneratesFolderForDashboard(t *testing.T) {
 	}), mock.MatchedBy(func(opts resources.EnsureFolderTreeExistsOptions) bool {
 		require.Equal(t, "feature/branch", opts.Ref)
 		require.Empty(t, opts.Path)
-		require.NoError(t, opts.OnFolder(resources.Folder{ID: "parent", Path: "parent"}, true, nil))
-		require.NoError(t, opts.OnFolder(resources.Folder{ID: "child", Path: "parent/child"}, true, nil))
+		require.NoError(t, opts.OnFolder(resources.Folder{ID: "parent", Path: "parent"}, true, time.Time{}, nil))
+		require.NoError(t, opts.OnFolder(resources.Folder{ID: "child", Path: "parent/child"}, true, time.Time{}, nil))
 		return true
 	})).Return(nil)
 	repoResources.On("WriteResourceFileFromObject", mock.Anything, mock.MatchedBy(func(obj *unstructured.Unstructured) bool {

--- a/pkg/registry/apis/provisioning/jobs/fixfoldermetadata/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/fixfoldermetadata/worker.go
@@ -131,13 +131,15 @@ func (w *Worker) Process(ctx context.Context, repo repository.Repository, job pr
 				continue
 			}
 
+			// Build the result before the write so its recorded duration covers it.
+			rb := jobs.NewFolderResult(folder.Path).
+				WithName(folder.ID).
+				WithAction(repository.FileActionCreated)
+
 			manifest := resources.NewFolderManifest(util.GenerateShortUID(), safepath.Base(folder.Path), folderGVK)
 			_, writeErr := resources.WriteFolderMetadata(ctx, rw, folder.Path, manifest, ref,
 				fmt.Sprintf("Add folder metadata for %s", folder.Path))
 
-			rb := jobs.NewFolderResult(folder.Path).
-				WithName(folder.ID).
-				WithAction(repository.FileActionCreated)
 			if writeErr != nil {
 				wrappedErr := fmt.Errorf("writing folder metadata for %s: %w", folder.Path, writeErr)
 				rb.WithError(wrappedErr)

--- a/pkg/registry/apis/provisioning/jobs/job_resource_result.go
+++ b/pkg/registry/apis/provisioning/jobs/job_resource_result.go
@@ -2,6 +2,7 @@ package jobs
 
 import (
 	"errors"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
@@ -131,6 +132,7 @@ type JobResourceResult struct {
 	reason       string // explicit reason, takes precedence over classifyWarning
 	err          error
 	warning      error
+	startedAt    time.Time // stamped when the builder is created; used to derive the operation duration at record time
 }
 
 // jobResourceResultBuilder is a builder for creating JobResourceResult instances using a fluent API.
@@ -138,10 +140,13 @@ type jobResourceResultBuilder struct {
 	result JobResourceResult
 }
 
-// NewResourceResult creates a new builder for JobResourceResult.
+// NewResourceResult creates a new builder for JobResourceResult. The creation
+// time is stamped now so the recorder can derive how long the operation took:
+// callers build the result immediately before performing the resource operation,
+// then record it once the operation completes.
 func NewResourceResult() *jobResourceResultBuilder {
 	return &jobResourceResultBuilder{
-		result: JobResourceResult{},
+		result: JobResourceResult{startedAt: time.Now()},
 	}
 }
 
@@ -300,6 +305,17 @@ func (r JobResourceResult) PreviousPath() string {
 // Action returns the action performed on the resource.
 func (r JobResourceResult) Action() repository.FileAction {
 	return r.action
+}
+
+// elapsed returns how long the operation took, measured from when the result's
+// builder was created (see NewResourceResult) until now. It returns zero if the
+// start time was never stamped, so results built outside the builder are simply
+// treated as untimed.
+func (r JobResourceResult) elapsed() time.Duration {
+	if r.startedAt.IsZero() {
+		return 0
+	}
+	return time.Since(r.startedAt)
 }
 
 // Error returns the error associated with the resource operation.

--- a/pkg/registry/apis/provisioning/jobs/job_resource_result.go
+++ b/pkg/registry/apis/provisioning/jobs/job_resource_result.go
@@ -230,6 +230,16 @@ func (b *jobResourceResultBuilder) WithAction(action repository.FileAction) *job
 	return b
 }
 
+// WithStartTime overrides the operation start stamped at construction. Use it
+// on callback paths where the result can only be built after the operation has
+// run (e.g. per-folder callbacks): pass the time captured before the operation
+// so the recorded duration still reflects the work rather than just the
+// construction-to-record gap.
+func (b *jobResourceResultBuilder) WithStartTime(t time.Time) *jobResourceResultBuilder {
+	b.result.startedAt = t
+	return b
+}
+
 // WithReason sets an explicit reason on the result. This takes precedence over
 // the reason derived from classifyWarning and can be used on success results
 // to explain why an operation happened (e.g., UID migration).

--- a/pkg/registry/apis/provisioning/jobs/metrics.go
+++ b/pkg/registry/apis/provisioning/jobs/metrics.go
@@ -21,9 +21,10 @@ type JobMetrics struct {
 	fullSyncPhaseDurationHist        *prometheus.HistogramVec // phases of full sync
 	syncDurationHist                 *prometheus.HistogramVec // total sync durations
 
-	resourceOpsTotal *prometheus.CounterVec // per-resource outcome counter
-	inFlight         *prometheus.GaugeVec   // jobs currently being processed, by driver + action
-	busySeconds      *prometheus.CounterVec // job duration credited at completion, by driver + action
+	resourceOpsTotal   *prometheus.CounterVec   // per-resource outcome counter
+	resourceOpDuration *prometheus.HistogramVec // per-resource operation duration
+	inFlight           *prometheus.GaugeVec     // jobs currently being processed, by driver + action
+	busySeconds        *prometheus.CounterVec   // job duration credited at completion, by driver + action
 }
 
 // claimTrigger records what enqueued the work-queue key that a worker is now
@@ -224,6 +225,16 @@ func RegisterJobMetrics(registry prometheus.Registerer) JobMetrics {
 		)
 		registry.MustRegister(resourceOpsTotal)
 
+		resourceOpDuration := prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    "grafana_provisioning_jobs_resource_operation_duration_seconds",
+				Help:    "Duration of individual resource operations performed during provisioning job runs",
+				Buckets: []float64{0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0},
+			},
+			[]string{"action", "operation", "outcome", "group", "kind"},
+		)
+		registry.MustRegister(resourceOpDuration)
+
 		inFlight := prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Name: "grafana_provisioning_jobs_in_flight",
@@ -250,6 +261,7 @@ func RegisterJobMetrics(registry prometheus.Registerer) JobMetrics {
 			fullSyncPhaseDurationHist:        fullSyncPhaseDurationHist,
 			syncDurationHist:                 syncDurationHist,
 			resourceOpsTotal:                 resourceOpsTotal,
+			resourceOpDuration:               resourceOpDuration,
 			inFlight:                         inFlight,
 			busySeconds:                      busySeconds,
 		}
@@ -311,8 +323,10 @@ func (m *JobMetrics) RecordSyncDuration(syncType SyncType, duration time.Duratio
 }
 
 // RecordResourceOperation derives outcome, operation, and reason from the
-// result and increments the resource operations counter.
-func (m *JobMetrics) RecordResourceOperation(action provisioning.JobAction, result JobResourceResult) {
+// result and increments the resource operations counter. dur is the time the
+// operation took, measured by the progress recorder from result construction to
+// this call; it is observed in the duration histogram for real operations.
+func (m *JobMetrics) RecordResourceOperation(action provisioning.JobAction, result JobResourceResult, dur time.Duration) {
 	var outcome ResourceOutcome
 	reason := result.Reason()
 
@@ -326,7 +340,14 @@ func (m *JobMetrics) RecordResourceOperation(action provisioning.JobAction, resu
 		outcome = OutcomeSuccess
 	}
 
-	m.resourceOpsTotal.WithLabelValues(string(action), string(fileActionToOperation(result.Action())), string(outcome), reason, result.Group(), result.Kind()).Inc()
+	operation := fileActionToOperation(result.Action())
+	m.resourceOpsTotal.WithLabelValues(string(action), string(operation), string(outcome), reason, result.Group(), result.Kind()).Inc()
+
+	// Ignored operations are no-ops (nothing was written), so keep them out of the
+	// duration histogram; everything else is a real resource operation worth timing.
+	if m.resourceOpDuration != nil && dur > 0 && operation != OperationIgnored {
+		m.resourceOpDuration.WithLabelValues(string(action), string(operation), string(outcome), result.Group(), result.Kind()).Observe(dur.Seconds())
+	}
 }
 
 func fileActionToOperation(action repository.FileAction) ResourceOperation {

--- a/pkg/registry/apis/provisioning/jobs/metrics.go
+++ b/pkg/registry/apis/provisioning/jobs/metrics.go
@@ -343,9 +343,11 @@ func (m *JobMetrics) RecordResourceOperation(action provisioning.JobAction, resu
 	operation := fileActionToOperation(result.Action())
 	m.resourceOpsTotal.WithLabelValues(string(action), string(operation), string(outcome), reason, result.Group(), result.Kind()).Inc()
 
-	// Ignored operations are no-ops (nothing was written), so keep them out of the
-	// duration histogram; everything else is a real resource operation worth timing.
-	if m.resourceOpDuration != nil && dur > 0 && operation != OperationIgnored {
+	// Ignored operations are no-ops (nothing was written), and an empty operation
+	// means the result carried no file action at all (e.g. a quota pre-check or a
+	// client-resolution failure), so neither did real work worth timing. Keep both
+	// out of the duration histogram.
+	if m.resourceOpDuration != nil && dur > 0 && operation != OperationIgnored && operation != "" {
 		m.resourceOpDuration.WithLabelValues(string(action), string(operation), string(outcome), result.Group(), result.Kind()).Observe(dur.Seconds())
 	}
 }

--- a/pkg/registry/apis/provisioning/jobs/metrics_test.go
+++ b/pkg/registry/apis/provisioning/jobs/metrics_test.go
@@ -3,6 +3,7 @@ package jobs
 import (
 	"errors"
 	"testing"
+	"time"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
@@ -58,12 +59,12 @@ func TestRecordResourceOperation(t *testing.T) {
 		WithGroup("dashboard.grafana.app").WithKind("Dashboard").
 		WithAction(repository.FileActionDeleted).Build()
 
-	m.RecordResourceOperation(provisioning.JobActionPull, successCreated)
-	m.RecordResourceOperation(provisioning.JobActionPull, successCreated)
-	m.RecordResourceOperation(provisioning.JobActionPull, successUpdated)
-	m.RecordResourceOperation(provisioning.JobActionPull, warningCreated)
-	m.RecordResourceOperation(provisioning.JobActionPull, errorCreated)
-	m.RecordResourceOperation(provisioning.JobActionPush, successDeleted)
+	m.RecordResourceOperation(provisioning.JobActionPull, successCreated, 0)
+	m.RecordResourceOperation(provisioning.JobActionPull, successCreated, 0)
+	m.RecordResourceOperation(provisioning.JobActionPull, successUpdated, 0)
+	m.RecordResourceOperation(provisioning.JobActionPull, warningCreated, 0)
+	m.RecordResourceOperation(provisioning.JobActionPull, errorCreated, 0)
+	m.RecordResourceOperation(provisioning.JobActionPush, successDeleted, 0)
 
 	metrics, err := reg.Gather()
 	require.NoError(t, err)
@@ -100,7 +101,67 @@ func TestRecordResourceOperation(t *testing.T) {
 	})], 0.001)
 }
 
+func TestRecordResourceOperationDuration(t *testing.T) {
+	reg := testRegistry
+	m := testMetrics
+
+	// Unique group/kind so this test's series don't collide with other tests
+	// sharing the singleton registry.
+	const group = "durationtest.grafana.app"
+	const kind = "DurationProbe"
+
+	created := NewResourceResult().
+		WithGroup(group).WithKind(kind).
+		WithAction(repository.FileActionCreated).Build()
+	ignored := NewResourceResult().
+		WithGroup(group).WithKind(kind).
+		WithAction(repository.FileActionIgnored).Build()
+
+	m.RecordResourceOperation(provisioning.JobActionPull, created, 50*time.Millisecond)
+	m.RecordResourceOperation(provisioning.JobActionPull, created, 50*time.Millisecond)
+	m.RecordResourceOperation(provisioning.JobActionPull, created, 0)                   // zero duration -> not observed
+	m.RecordResourceOperation(provisioning.JobActionPull, ignored, 10*time.Millisecond) // ignored op -> not observed
+
+	metrics, err := reg.Gather()
+	require.NoError(t, err)
+
+	hist := findMetric(metrics, "grafana_provisioning_jobs_resource_operation_duration_seconds")
+	require.NotNil(t, hist, "resource_operation_duration_seconds histogram should be registered")
+
+	createdCount := histogramSampleCount(hist, map[string]string{
+		"action": "pull", "operation": "created", "outcome": "success",
+		"group": group, "kind": kind,
+	})
+	assert.Equal(t, uint64(2), createdCount, "only the two non-zero-duration created ops should be observed")
+
+	ignoredCount := histogramSampleCount(hist, map[string]string{
+		"action": "pull", "operation": "ignored", "outcome": "success",
+		"group": group, "kind": kind,
+	})
+	assert.Equal(t, uint64(0), ignoredCount, "ignored operations must not be observed")
+}
+
 // --- helpers ---
+
+func histogramSampleCount(mf *dto.MetricFamily, labels map[string]string) uint64 {
+	for _, m := range mf.GetMetric() {
+		got := make(map[string]string)
+		for _, lp := range m.GetLabel() {
+			got[lp.GetName()] = lp.GetValue()
+		}
+		match := len(got) == len(labels)
+		for k, v := range labels {
+			if got[k] != v {
+				match = false
+				break
+			}
+		}
+		if match {
+			return m.GetHistogram().GetSampleCount()
+		}
+	}
+	return 0
+}
 
 func findMetric(families []*dto.MetricFamily, name string) *dto.MetricFamily {
 	for _, mf := range families {

--- a/pkg/registry/apis/provisioning/jobs/migrate/exported_resource_collector_test.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/exported_resource_collector_test.go
@@ -19,18 +19,22 @@ func TestExportedResourceCollector(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("captures successfully exported resources", func(t *testing.T) {
+		// Build each result once and use it for both the expectation and the call:
+		// the result carries a construction timestamp, so a freshly rebuilt copy
+		// would not compare equal.
+		dash1 := jobs.NewGVKResult("dash-1", dashboardGVK).
+			WithAction(repository.FileActionCreated).Build()
+		dash2 := jobs.NewGVKResult("dash-2", dashboardGVK).
+			WithAction(repository.FileActionCreated).Build()
+
 		inner := jobs.NewMockJobProgressRecorder(t)
-		inner.EXPECT().Record(ctx, jobs.NewGVKResult("dash-1", dashboardGVK).
-			WithAction(repository.FileActionCreated).Build())
-		inner.EXPECT().Record(ctx, jobs.NewGVKResult("dash-2", dashboardGVK).
-			WithAction(repository.FileActionCreated).Build())
+		inner.EXPECT().Record(ctx, dash1)
+		inner.EXPECT().Record(ctx, dash2)
 
 		collector := newExportedResourceCollector(inner)
 
-		collector.Record(ctx, jobs.NewGVKResult("dash-1", dashboardGVK).
-			WithAction(repository.FileActionCreated).Build())
-		collector.Record(ctx, jobs.NewGVKResult("dash-2", dashboardGVK).
-			WithAction(repository.FileActionCreated).Build())
+		collector.Record(ctx, dash1)
+		collector.Record(ctx, dash2)
 
 		allowlist := collector.ExportedResources()
 		require.NotNil(t, allowlist)
@@ -40,44 +44,46 @@ func TestExportedResourceCollector(t *testing.T) {
 	})
 
 	t.Run("ignores failed exports", func(t *testing.T) {
-		inner := jobs.NewMockJobProgressRecorder(t)
-		inner.EXPECT().Record(ctx, jobs.NewGVKResult("dash-1", dashboardGVK).
+		dash1 := jobs.NewGVKResult("dash-1", dashboardGVK).
 			WithAction(repository.FileActionIgnored).
-			WithError(assert.AnError).Build())
+			WithError(assert.AnError).Build()
+
+		inner := jobs.NewMockJobProgressRecorder(t)
+		inner.EXPECT().Record(ctx, dash1)
 
 		collector := newExportedResourceCollector(inner)
 
-		collector.Record(ctx, jobs.NewGVKResult("dash-1", dashboardGVK).
-			WithAction(repository.FileActionIgnored).
-			WithError(assert.AnError).Build())
+		collector.Record(ctx, dash1)
 
 		allowlist := collector.ExportedResources()
 		assert.False(t, allowlist.Contains(resources.ResourceIdentifier{Name: "dash-1", Group: "dashboard.grafana.app", Kind: "Dashboard"}))
 	})
 
 	t.Run("ignores ignored resources", func(t *testing.T) {
+		dash1 := jobs.NewGVKResult("dash-1", dashboardGVK).
+			WithAction(repository.FileActionIgnored).Build()
+
 		inner := jobs.NewMockJobProgressRecorder(t)
-		inner.EXPECT().Record(ctx, jobs.NewGVKResult("dash-1", dashboardGVK).
-			WithAction(repository.FileActionIgnored).Build())
+		inner.EXPECT().Record(ctx, dash1)
 
 		collector := newExportedResourceCollector(inner)
 
-		collector.Record(ctx, jobs.NewGVKResult("dash-1", dashboardGVK).
-			WithAction(repository.FileActionIgnored).Build())
+		collector.Record(ctx, dash1)
 
 		allowlist := collector.ExportedResources()
 		assert.False(t, allowlist.Contains(resources.ResourceIdentifier{Name: "dash-1", Group: "dashboard.grafana.app", Kind: "Dashboard"}))
 	})
 
 	t.Run("ignores results without a name", func(t *testing.T) {
+		noName := jobs.NewResourceResult().
+			WithAction(repository.FileActionCreated).Build()
+
 		inner := jobs.NewMockJobProgressRecorder(t)
-		inner.EXPECT().Record(ctx, jobs.NewResourceResult().
-			WithAction(repository.FileActionCreated).Build())
+		inner.EXPECT().Record(ctx, noName)
 
 		collector := newExportedResourceCollector(inner)
 
-		collector.Record(ctx, jobs.NewResourceResult().
-			WithAction(repository.FileActionCreated).Build())
+		collector.Record(ctx, noName)
 
 		allowlist := collector.ExportedResources()
 		assert.False(t, allowlist.Contains(resources.ResourceIdentifier{Name: "", Group: "", Kind: ""}))

--- a/pkg/registry/apis/provisioning/jobs/progress.go
+++ b/pkg/registry/apis/provisioning/jobs/progress.go
@@ -158,11 +158,13 @@ func (r *jobProgressRecorder) Record(ctx context.Context, result JobResourceResu
 	r.updateSummary(result)
 	r.mu.Unlock()
 
+	// Measure once so the metric and the log line agree on the operation duration.
+	duration := result.elapsed()
 	if r.metrics != nil {
-		r.metrics.RecordResourceOperation(r.action, result)
+		r.metrics.RecordResourceOperation(r.action, result, duration)
 	}
 
-	logger := logging.FromContext(ctx).With("path", result.Path(), "group", result.Group(), "kind", result.Kind(), "action", result.Action(), "name", result.Name())
+	logger := logging.FromContext(ctx).With("path", result.Path(), "group", result.Group(), "kind", result.Kind(), "action", result.Action(), "name", result.Name(), "duration", duration)
 	if shouldLogError {
 		logger.Error("job resource operation failed", "err", logErr)
 	} else if shouldLogWarning {

--- a/pkg/registry/apis/provisioning/jobs/sync/full.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full.go
@@ -295,6 +295,10 @@ func applyChange(
 		return
 	}
 
+	// Create the result builder before the write so its duration reflects the
+	// write itself; name and GVK are filled in from the result below.
+	resultBuilder := jobs.NewResourceResult().WithAction(change.Action).WithPath(change.Path)
+
 	writeCtx, writeSpan := tracer.Start(ctx, "provisioning.sync.full.apply_changes.write_resource_from_file")
 	var name string
 	var gvk schema.GroupVersionKind
@@ -319,7 +323,7 @@ func applyChange(
 	} else {
 		name, gvk, err = repositoryResources.WriteResourceFromFile(writeCtx, change.Path, currentRef, writeOpts...)
 	}
-	resultBuilder := jobs.NewGVKResult(name, gvk).WithAction(change.Action).WithPath(change.Path)
+	resultBuilder.WithName(name).WithGVK(gvk)
 	if err != nil {
 		writeSpan.RecordError(err)
 		resultBuilder.WithError(fmt.Errorf("writing resource from file %s: %w", change.Path, err))

--- a/pkg/registry/apis/provisioning/jobs/sync/full_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full_test.go
@@ -26,6 +26,29 @@ import (
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
 )
 
+// matchesResult builds a testify matcher that compares a recorded
+// JobResourceResult against want on every identity field, ignoring the
+// non-deterministic operation duration set by the sync workers.
+func matchesResult(want jobs.JobResourceResult) interface{} {
+	errMsg := func(err error) string {
+		if err == nil {
+			return ""
+		}
+		return err.Error()
+	}
+	return mock.MatchedBy(func(got jobs.JobResourceResult) bool {
+		return got.Name() == want.Name() &&
+			got.Group() == want.Group() &&
+			got.Kind() == want.Kind() &&
+			got.Path() == want.Path() &&
+			got.PreviousPath() == want.PreviousPath() &&
+			got.Action() == want.Action() &&
+			got.Reason() == want.Reason() &&
+			errMsg(got.Error()) == errMsg(want.Error()) &&
+			errMsg(got.Warning()) == errMsg(want.Warning())
+	})
+}
+
 func TestFullSync_ContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -297,8 +320,8 @@ func TestFullSync_ApplyChanges(t *testing.T) { //nolint:gocyclo
 				repoResources.On("WriteResourceFromFile", mock.Anything, "dashboards/test.json", "current-ref").
 					Return("test-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, nil)
 
-				progress.On("Record", mock.Anything, jobs.NewGroupKindResult(
-					"test-dashboard", "dashboards", "Dashboard").WithAction(repository.FileActionCreated).WithPath("dashboards/test.json").Build()).Return()
+				progress.On("Record", mock.Anything, matchesResult(jobs.NewGroupKindResult(
+					"test-dashboard", "dashboards", "Dashboard").WithAction(repository.FileActionCreated).WithPath("dashboards/test.json").Build())).Return()
 			},
 		},
 		{
@@ -344,13 +367,13 @@ func TestFullSync_ApplyChanges(t *testing.T) { //nolint:gocyclo
 				repoResources.On("WriteResourceFromFile", mock.Anything, "dashboards/test.json", "current-ref").
 					Return("test-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, nil)
 
-				progress.On("Record", mock.Anything, jobs.NewGroupKindResult(
+				progress.On("Record", mock.Anything, matchesResult(jobs.NewGroupKindResult(
 					"test-dashboard",
 					"dashboards",
 					"Dashboard",
 				).WithPath("dashboards/test.json").
 					WithAction(repository.FileActionUpdated).
-					Build()).Return()
+					Build())).Return()
 			},
 		},
 		{
@@ -394,13 +417,13 @@ func TestFullSync_ApplyChanges(t *testing.T) { //nolint:gocyclo
 				progress.On("HasDirPathFailedCreation", "one/two/three/").Return(false)
 
 				repoResources.On("EnsureFolderPathExist", mock.Anything, "one/two/three/", "current-ref").Return("some-folder", nil)
-				progress.On("Record", mock.Anything, jobs.NewGroupKindResult(
+				progress.On("Record", mock.Anything, matchesResult(jobs.NewGroupKindResult(
 					"some-folder",
 					"folder.grafana.app",
 					"Folder",
 				).WithPath("one/two/three/").
 					WithAction(repository.FileActionCreated).
-					Build()).Return()
+					Build())).Return()
 			},
 		},
 		{
@@ -482,13 +505,13 @@ func TestFullSync_ApplyChanges(t *testing.T) { //nolint:gocyclo
 					Version: "v1",
 				}, nil)
 
-				progress.On("Record", mock.Anything, jobs.NewGroupKindResult(
+				progress.On("Record", mock.Anything, matchesResult(jobs.NewGroupKindResult(
 					"test-dashboard",
 					"dashboards",
 					"Dashboard",
 				).WithPath("dashboards/test.json").
 					WithAction(repository.FileActionDeleted).
-					Build()).Return()
+					Build())).Return()
 			},
 		},
 		{
@@ -613,14 +636,14 @@ func TestFullSync_ApplyChanges(t *testing.T) { //nolint:gocyclo
 					Resource: "dashboards",
 				}).Return(nil, schema.GroupVersionKind{}, errors.New("didn't work"))
 
-				progress.On("Record", mock.Anything, jobs.NewGroupKindResult(
+				progress.On("Record", mock.Anything, matchesResult(jobs.NewGroupKindResult(
 					"test-dashboard",
 					"dashboards",
 					"dashboards", // could not find a real kind
 				).WithPath("dashboards/test.json").
 					WithAction(repository.FileActionDeleted).
 					WithError(fmt.Errorf("get client for deleted object: %w", errors.New("didn't work"))).
-					Build()).Return()
+					Build())).Return()
 			},
 		},
 		{
@@ -676,13 +699,13 @@ func TestFullSync_ApplyChanges(t *testing.T) { //nolint:gocyclo
 
 				repoResources.On("RemoveFolderFromTree", "test-folder").Return()
 
-				progress.On("Record", mock.Anything, jobs.NewGroupKindResult(
+				progress.On("Record", mock.Anything, matchesResult(jobs.NewGroupKindResult(
 					"test-folder",
 					"folders",
 					"Folder",
 				).WithPath("to-be-deleted/").
 					WithAction(repository.FileActionDeleted).
-					Build()).Return()
+					Build())).Return()
 			},
 		},
 		{
@@ -735,13 +758,13 @@ func TestFullSync_ApplyChanges(t *testing.T) { //nolint:gocyclo
 					Version: "v1",
 				}, nil)
 
-				progress.On("Record", mock.Anything, jobs.NewGroupKindResult(
+				progress.On("Record", mock.Anything, matchesResult(jobs.NewGroupKindResult(
 					"test-folder",
 					"folders",
 					"Folder",
 				).WithPath("to-be-deleted/").
 					WithAction(repository.FileActionDeleted).
-					Build()).Return()
+					Build())).Return()
 			},
 			verifyMocks: func(t *testing.T, repoResources *resources.MockRepositoryResources) {
 				repoResources.AssertNotCalled(t, "RemoveFolderFromTree", "test-folder")

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental.go
@@ -203,19 +203,22 @@ func applyIncrementalChanges(
 			}
 
 			if safeSegment != "" && resources.IsPathSupported(safeSegment) == nil {
-				folder, err := repositoryResources.EnsureFolderPathExist(ensureFolderCtx, safeSegment, change.Ref)
+				// Build the result before the operation so its recorded duration
+				// reflects the folder write rather than just the record call.
+				folderResultBuilder := jobs.NewFolderResult(change.Path)
+				_, err := repositoryResources.EnsureFolderPathExist(ensureFolderCtx, safeSegment, change.Ref)
 				if err != nil {
 					ensureFolderSpan.RecordError(err)
 					ensureFolderSpan.End()
 
-					progress.Record(ensureFolderCtx, jobs.NewFolderResult(change.Path).
+					progress.Record(ensureFolderCtx, folderResultBuilder.
 						WithError(err).
 						WithAction(repository.FileActionIgnored).
 						Build())
 					continue
 				}
 
-				progress.Record(ensureFolderCtx, jobs.NewFolderResult(folder).
+				progress.Record(ensureFolderCtx, folderResultBuilder.
 					WithPath(safeSegment).
 					WithAction(repository.FileActionCreated).
 					Build())

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental_test.go
@@ -176,9 +176,9 @@ func TestIncrementalSync(t *testing.T) {
 				repoResources.On("EnsureFolderPathExist", mock.Anything, "unsupported/path/", "new-ref").
 					Return("test-folder", nil)
 
-				progress.On("Record", mock.Anything, jobs.NewFolderResult("unsupported/path/").
+				progress.On("Record", mock.Anything, matchesResult(jobs.NewFolderResult("unsupported/path/").
 					WithAction(repository.FileActionCreated).
-					Build()).Return()
+					Build())).Return()
 
 				progress.On("TooManyErrors").Return(nil)
 			},
@@ -205,10 +205,10 @@ func TestIncrementalSync(t *testing.T) {
 
 				progress.On("HasDirPathFailedCreation", ".unsupported/path/file.txt").Return(false)
 
-				progress.On("Record", mock.Anything, jobs.NewPathOnlyResult(
+				progress.On("Record", mock.Anything, matchesResult(jobs.NewPathOnlyResult(
 					".unsupported/path/file.txt",
 				).WithAction(repository.FileActionIgnored).
-					Build()).Return()
+					Build())).Return()
 				progress.On("TooManyErrors").Return(nil)
 			},
 			previousRef: "old-ref",
@@ -233,13 +233,13 @@ func TestIncrementalSync(t *testing.T) {
 				repoResources.On("RemoveResourceFromFile", mock.Anything, "dashboards/old.json", "old-ref").
 					Return("old-dashboard", "", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, nil)
 
-				progress.On("Record", mock.Anything, jobs.NewGroupKindResult(
+				progress.On("Record", mock.Anything, matchesResult(jobs.NewGroupKindResult(
 					"old-dashboard",
 					"dashboards",
 					"Dashboard",
 				).WithPath("dashboards/old.json").
 					WithAction(repository.FileActionDeleted).
-					Build()).Return()
+					Build())).Return()
 
 				progress.On("TooManyErrors").Return(nil)
 			},
@@ -269,14 +269,14 @@ func TestIncrementalSync(t *testing.T) {
 				repoResources.On("RenameResourceFile", mock.Anything, "dashboards/old.json", "old-ref", "dashboards/new.json", "new-ref").
 					Return("renamed-dashboard", "", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, nil)
 
-				progress.On("Record", mock.Anything, jobs.NewGroupKindResult(
+				progress.On("Record", mock.Anything, matchesResult(jobs.NewGroupKindResult(
 					"renamed-dashboard",
 					"dashboards",
 					"Dashboard",
 				).WithPath("dashboards/new.json").
 					WithPreviousPath("dashboards/old.json").
 					WithAction(repository.FileActionRenamed).
-					Build()).Return()
+					Build())).Return()
 
 				progress.On("TooManyErrors").Return(nil)
 			},
@@ -367,9 +367,9 @@ func TestIncrementalSync(t *testing.T) {
 
 				progress.On("HasDirPathFailedCreation", "dashboards/ignored.json").Return(false)
 
-				progress.On("Record", mock.Anything, jobs.NewPathOnlyResult(
+				progress.On("Record", mock.Anything, matchesResult(jobs.NewPathOnlyResult(
 					"dashboards/ignored.json",
-				).WithAction(repository.FileActionIgnored).Build()).Return()
+				).WithAction(repository.FileActionIgnored).Build())).Return()
 				progress.On("TooManyErrors").Return(nil)
 			},
 			previousRef: "old-ref",

--- a/pkg/registry/apis/provisioning/resources/folders.go
+++ b/pkg/registry/apis/provisioning/resources/folders.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -570,8 +571,9 @@ type EnsureFolderTreeExistsOptions struct {
 	GenerateNewFolderIDs bool
 	// OnFolder is called for each folder in the tree. It is called with created
 	// set to false when the folder already exists in the repository, and true
-	// when the folder is created.
-	OnFolder func(folder Folder, created bool, err error) error
+	// when the folder is created. startedAt is the time processing of this folder
+	// began, so callers can record how long the folder operation took.
+	OnFolder func(folder Folder, created bool, startedAt time.Time, err error) error
 }
 
 // EnsureFolderTreeExists replicates the folder tree to the repository.
@@ -589,6 +591,11 @@ type EnsureFolderTreeExistsOptions struct {
 // materialized then.
 func (fm *FolderManager) EnsureFolderTreeExists(ctx context.Context, tree FolderTree, opts EnsureFolderTreeExistsOptions) error {
 	return tree.Walk(ctx, func(ctx context.Context, folder Folder, parent string) error {
+		// Capture when this folder's processing began so OnFolder can record the
+		// duration: it is invoked after the read/write below, so it cannot time
+		// the operation itself.
+		startedAt := time.Now()
+
 		p := folder.Path
 		if opts.Path != "" {
 			p = safepath.Join(opts.Path, p)
@@ -601,16 +608,16 @@ func (fm *FolderManager) EnsureFolderTreeExists(ctx context.Context, tree Folder
 		// absolute, too deep) before it reaches the backend, using the same
 		// validation enforced on the import side.
 		if err := IsPathSupported(p); err != nil {
-			return opts.OnFolder(folder, false, fmt.Errorf("unsafe folder path %q: %w", p, err))
+			return opts.OnFolder(folder, false, startedAt, fmt.Errorf("unsafe folder path %q: %w", p, err))
 		}
 
 		_, err := fm.repo.Read(ctx, p, opts.Ref)
 		if err != nil && (!errors.Is(err, repository.ErrFileNotFound) && !apierrors.IsNotFound(err)) {
-			return opts.OnFolder(folder, false, fmt.Errorf("check if folder exists before writing: %w", err))
+			return opts.OnFolder(folder, false, startedAt, fmt.Errorf("check if folder exists before writing: %w", err))
 		} else if err == nil {
 			// Folder already exists in repository, add it to tree so resources can find it
 			fm.tree.Add(folder, parent)
-			return opts.OnFolder(folder, false, nil)
+			return opts.OnFolder(folder, false, startedAt, nil)
 		}
 
 		if fm.folderMetadataEnabled {
@@ -621,17 +628,17 @@ func (fm *FolderManager) EnsureFolderTreeExists(ctx context.Context, tree Folder
 			msg := fmt.Sprintf("Add folder and folder metadata %s", p)
 			manifest := NewFolderManifest(manifestID, folder.Title, fm.folderGVK)
 			if _, err := WriteFolderMetadata(ctx, fm.repo, p, manifest, opts.Ref, msg); err != nil {
-				return opts.OnFolder(folder, true, err)
+				return opts.OnFolder(folder, true, startedAt, err)
 			}
 		} else {
 			msg := fmt.Sprintf("Add folder %s", p)
 			if err := fm.repo.Create(ctx, p, opts.Ref, nil, msg); err != nil {
-				return opts.OnFolder(folder, true, fmt.Errorf("write folder in repo: %w", err))
+				return opts.OnFolder(folder, true, startedAt, fmt.Errorf("write folder in repo: %w", err))
 			}
 		}
 		// Add it to the existing tree
 		fm.tree.Add(folder, parent)
 
-		return opts.OnFolder(folder, true, nil)
+		return opts.OnFolder(folder, true, startedAt, nil)
 	})
 }

--- a/pkg/registry/apis/provisioning/resources/folders_test.go
+++ b/pkg/registry/apis/provisioning/resources/folders_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
@@ -2165,8 +2166,8 @@ func TestEnsureFolderTreeExists(t *testing.T) {
 	}
 
 	// recordingFn returns an fn callback that records its invocations and propagates any error it receives.
-	recordingFn := func(calls *[]fnCall) func(Folder, bool, error) error {
-		return func(f Folder, created bool, err error) error {
+	recordingFn := func(calls *[]fnCall) func(Folder, bool, time.Time, error) error {
+		return func(f Folder, created bool, _ time.Time, err error) error {
 			*calls = append(*calls, fnCall{f, created, err})
 			return err
 		}


### PR DESCRIPTION
## What
Adds a histogram that tracks how long individual resource operations (create/update/delete/rename/folder writes) take during provisioning job runs, and adds that duration to the per-resource log line.

New metric: `grafana_provisioning_jobs_resource_operation_duration_seconds` — histogram, labels `action, operation, outcome, group, kind`.

## Why
Provisioning jobs already expose whole-job and sync-phase durations, plus a `..._resource_operations_total` counter, but nothing captured the latency of a *single* resource operation. That granularity is needed to spot slow individual writes/deletes and to correlate latency with kind/outcome.

## How
- The result builder stamps a start time when the result is created (`NewResourceResult`). The progress recorder derives the duration once at record time and shares the same value between the new histogram and the log line, so they always agree.
- The metric is emitted from the existing `RecordResourceOperation` chokepoint, right next to the operations counter. `ignored` no-op operations are excluded from the histogram.
- Two call sites that built the result *after* the operation (`sync/full.go` write, `fixfoldermetadata` write) now build it *before*, so the write latency is actually captured.
- Buckets: 10ms → 30s.

Semantic note: because the start is stamped at result construction, the duration is the per-resource end-to-end handling time (start of building the result → record), not purely the storage-call time.

## Testing
- `go test ./pkg/registry/apis/provisioning/jobs/...` — all packages pass.
- `go vet` and `gofmt` clean.
- Added `TestRecordResourceOperationDuration` covering timed, zero-duration, and ignored cases.
- Updated exact-match mock expectations (now non-deterministic due to the stamped start): `sync` tests use a `matchesResult` matcher that ignores the timestamp; `exported_resource_collector_test.go` reuses one built result for both expectation and call.

## Checklist
- [x] Tests added/updated
- [ ] Documentation updated (metric will surface automatically; no docs change needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)