### PR TITLE
Storage: do not allow saving resources named search/trash/history/query

### DIFF
--- a/pkg/apimachinery/validation/validation.go
+++ b/pkg/apimachinery/validation/validation.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"regexp"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/util/validation"
 )
@@ -47,6 +48,14 @@ func IsValidGrafanaName(name string) []string {
 		return []string{"name may not be empty"}
 	case s > maxNameLength:
 		return []string{"name is too long"}
+	}
+
+	// If this list is longer, we should compile regexp
+	if strings.EqualFold(name, "search") ||
+		strings.EqualFold(name, "trash") ||
+		strings.EqualFold(name, "history") ||
+		strings.EqualFold(name, "query") {
+		return []string{"name is reserved"}
 	}
 
 	if !grafanaNameRegexp(name) {

--- a/pkg/apimachinery/validation/validation_test.go
+++ b/pkg/apimachinery/validation/validation_test.go
@@ -29,6 +29,10 @@ func TestValidation(t *testing.T) {
 			input:  []string{strings.Repeat("0", 254)},
 			expect: []string{"name is too long"},
 		}, {
+			name:   "reserved",
+			input:  []string{"search", "TRASH", "History", "QuErY"},
+			expect: []string{"name is reserved"},
+		}, {
 			name: "ok",
 			input: []string{
 				"hello",


### PR DESCRIPTION
With https://github.com/grafana/grafana/pull/131128 -- we should not allow saving values with the special names