### PR TITLE
RadioButtonGroup: Support dataTestId on options

### DIFF
--- a/packages/grafana-data/src/types/select.ts
+++ b/packages/grafana-data/src/types/select.ts
@@ -14,5 +14,7 @@ export interface SelectableValue<T = any> {
   // Optional component that will be shown together with other options. Does not get passed any props.
   component?: React.ComponentType;
   isDisabled?: boolean;
+  // Optional data-testid attribute that will be added to the option element. If not provided, a default value will be generated based on the label or value.
+  dataTestId?: string;
   [key: string]: any;
 }

--- a/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup.test.tsx
+++ b/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 
 import { selectors } from '@grafana/e2e-selectors';
 
-import { RadioButtonGroup } from './RadioButtonGroup';
+import { getDataTestId, RadioButtonGroup } from './RadioButtonGroup';
 
 describe('RadioButtonGroup', () => {
   it('exposes the RadioGroup container data-testid', () => {
@@ -57,5 +57,68 @@ describe('RadioButtonGroup', () => {
     expect(radio).toHaveAttribute('title', 'Fallback option');
     const label = radio.nextElementSibling;
     expect(label).toHaveAttribute('title', 'Fallback option');
+  });
+
+  it('uses option dataTestId as "data-testid" attribute on each radio button', () => {
+    render(
+      <RadioButtonGroup
+        value="both"
+        options={[
+          { label: 'Candles', value: 'candles', dataTestId: 'data-testid order-form option candles' },
+          { label: 'Volume', value: 'volume', dataTestId: 'data-testid order-form option volume' },
+          {
+            label: 'Candles and volume',
+            value: 'both',
+            dataTestId: 'data-testid order-form option candles and volumes',
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByTestId('data-testid order-form option candles')).toBeInTheDocument();
+    expect(screen.getByTestId('data-testid order-form option volume')).toBeInTheDocument();
+    expect(screen.getByTestId('data-testid order-form option candles and volumes')).toBeInTheDocument();
+  });
+
+  it('uses default selector if dataTestId is missing as "data-testid" attribute on each radio button', () => {
+    render(
+      <RadioButtonGroup
+        value="both"
+        options={[
+          { label: 'Candles', value: 'candles' },
+          { label: 'Volume', value: 'volume' },
+          { label: 'Candles and volume', value: 'both' },
+        ]}
+      />
+    );
+
+    expect(screen.getByTestId(selectors.components.RadioButton.option('candles'))).toBeInTheDocument();
+    expect(screen.getByTestId(selectors.components.RadioButton.option('volume'))).toBeInTheDocument();
+    expect(screen.getByTestId(selectors.components.RadioButton.option('both'))).toBeInTheDocument();
+  });
+});
+
+describe('getDataTestId', () => {
+  it('should return dataTestId from option if present', () => {
+    expect(getDataTestId({ dataTestId: 'a data test id' })).toBe('a data test id');
+  });
+
+  it('should use generic selector from a "string" value on the option if present', () => {
+    expect(getDataTestId({ value: 'a data test id' })).toBe('data-testid radio-button-option a data test id');
+  });
+
+  it('should use generic selector from a "number" value on the option if present', () => {
+    expect(getDataTestId({ value: 0 })).toBe('data-testid radio-button-option 0');
+  });
+
+  it('should use generic selector from a "boolean" value on the option if present', () => {
+    expect(getDataTestId({ value: false })).toBe('data-testid radio-button-option false');
+  });
+
+  it('should return undefined when dataTestId is missing and value is not a "string", "number" or "boolean"', () => {
+    expect(getDataTestId({ value: {} })).toBeUndefined();
+    expect(getDataTestId({ value: () => {} })).toBeUndefined();
+    expect(getDataTestId({ value: undefined })).toBeUndefined();
+    expect(getDataTestId({ value: null })).toBeUndefined();
   });
 });

--- a/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup.tsx
@@ -103,12 +103,6 @@ export function RadioButtonGroup<T>({
         const icon = opt.icon ? toIconName(opt.icon) : undefined;
         const hasNonIconPart = Boolean(opt.imgUrl || opt.label || opt.component);
         const labelTitle = typeof opt.label === 'string' ? opt.label : undefined;
-        // Keyed on the option's value, not its label, so the selector survives translation.
-        // Skipped for objects and undefined, which have no meaningful string form.
-        const testIdValue =
-          typeof opt.value === 'string' || typeof opt.value === 'number' || typeof opt.value === 'boolean'
-            ? String(opt.value)
-            : undefined;
 
         return (
           <RadioButton
@@ -116,7 +110,7 @@ export function RadioButtonGroup<T>({
             disabled={isItemDisabled || disabled}
             active={value === opt.value}
             key={`o.label-${i}`}
-            data-testid={testIdValue === undefined ? undefined : selectors.components.RadioButton.option(testIdValue)}
+            data-testid={getDataTestId(opt)}
             aria-label={opt.ariaLabel}
             aria-invalid={!!invalid}
             aria-describedby={ariaDescribedBy}
@@ -182,3 +176,17 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
   };
 };
+
+export function getDataTestId(option: SelectableValue): string | undefined {
+  if (option.dataTestId) {
+    return option.dataTestId;
+  }
+
+  // Keyed on the option's value, not its label, so the selector survives translation.
+  // Skipped for objects and undefined, which have no meaningful string form.
+  if (typeof option.value !== 'string' && typeof option.value !== 'number' && typeof option.value !== 'boolean') {
+    return;
+  }
+
+  return selectors.components.RadioButton.option(String(option.value));
+}


### PR DESCRIPTION
**What is this feature?**

Adds a `dataTestId` property to `SelectableValue` so consumers of `RadioButtonGroup` can set their own `data-testid` on each option instead of relying on the generated value-based selector.

```ts
const options: Array<SelectableValue<string>> = [
  {
    label: 'Root spans',
    value: 'nestedSetParent<0',
    dataTestId: `data-testid primary signal option Root spans`,
  },
];
```

When `dataTestId` is set it wins, otherwise the existing `selectors.components.RadioButton.option(value)` fallback is used, so nothing changes for current callers.

**Why do we need this feature?**

So plugins can attach stable `data-testid` selectors to radio options that don't break when the underlying option value changes.

**Who is this feature for?**

Plugin developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

For https://github.com/grafana/traces-drilldown/issues/844

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
