### PR TITLE
Dashboards: Fix missing await on createDefaultAnnotationLayer in ControlsAddButton

### DIFF
--- a/public/app/features/dashboard-scene/scene/ControlsAddButton.tsx
+++ b/public/app/features/dashboard-scene/scene/ControlsAddButton.tsx
@@ -30,12 +30,12 @@ export function AddControlsButton({ dashboard }: { dashboard: DashboardScene }) 
     DashboardInteractions.addFilterButtonClicked({ source: 'variable_controls' });
   }, [dashboard]);
 
-  const handleAddAnnotationQuery = useCallback(() => {
+  const handleAddAnnotationQuery = useCallback(async () => {
     const dataLayers = sceneGraph.getData(dashboard);
     if (!(dataLayers instanceof DashboardDataLayerSet)) {
       return;
     }
-    const newAnnotation = dataLayers.createDefaultAnnotationLayer();
+    const newAnnotation = await dataLayers.createDefaultAnnotationLayer();
     annotationEditActions.addAnnotation({ source: dataLayers, addedObject: newAnnotation });
     DashboardInteractions.addAnnotationButtonClicked({ source: 'variable_controls' });
   }, [dashboard]);


### PR DESCRIPTION
`createDefaultAnnotationLayer()` is async, but `ControlsAddButton`'s `handleAddAnnotationQuery` wasn't awaiting it, so a `Promise<DashboardAnnotationsDataLayer>` was passed where `addAnnotation` expects a `DataLayer` — causing a `tsc` build error (TS2322) on main since #130841.

Mirrors the existing correct pattern in `AddAnnotationQuery.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)