### PR TITLE
Search: let a host mount search routes for the group versions it serves

### DIFF
--- a/pkg/services/apiserver/searchroutes/searchroutes.go
+++ b/pkg/services/apiserver/searchroutes/searchroutes.go
@@ -67,6 +67,8 @@ func Build(
 //
 // The provider is built from the manifests passed in, so a route can only ever
 // validate against the declarations it was mounted from.
+//
+// Panics on a bad declaration, because in a compiled-in manifest that is a bug.
 func BuildFromManifests(
 	manifests []app.Manifest,
 	searchEnabled bool,
@@ -76,16 +78,47 @@ func BuildFromManifests(
 	builders []builder.APIGroupBuilder,
 	installers []appsdkapiserver.AppInstaller,
 ) []builder.GroupVersionRoutes {
+	routes, err := BuildForServedGroupVersions(
+		manifests,
+		servedGroupVersions(builders, installers),
+		searchEnabled,
+		trashEnabled,
+		tracer,
+		index,
+	)
+	if err != nil {
+		panic(err.Error())
+	}
+	return routes
+}
+
+// BuildForServedGroupVersions is BuildFromManifests for a host that has no
+// builders or installers to derive the served group versions from, such as one
+// serving its kinds as custom resource definitions.
+//
+// Returns an error rather than panicking, because manifests read at runtime can
+// be malformed without this build being at fault.
+func BuildForServedGroupVersions(
+	manifests []app.Manifest,
+	served map[schema.GroupVersion]bool,
+	searchEnabled bool,
+	trashEnabled bool,
+	tracer tracing.Tracer,
+	index resourcepb.ResourceIndexClient,
+) ([]builder.GroupVersionRoutes, error) {
 	// Whether an endpoint is on is read by the caller, because the two servers
 	// that mount them are configured differently: one from an ini file, one from
 	// flags.
 	if (!searchEnabled && !trashEnabled) || index == nil {
-		return nil
+		return nil, nil
 	}
 
-	handler := searchapi.NewHandler(index, resource.NewManifestBackedProvider(manifests), tracer)
+	provider, err := resource.ManifestBackedProvider(manifests)
+	if err != nil {
+		return nil, err
+	}
+	handler := searchapi.NewHandler(index, provider, tracer)
 
-	served := servedGroupVersions(builders, installers)
 	byGroupVersion := map[schema.GroupVersion][]searchapi.Route{}
 
 	for _, m := range manifests {
@@ -122,7 +155,7 @@ func BuildFromManifests(
 		}
 	}
 
-	return toGroupVersionRoutes(byGroupVersion)
+	return toGroupVersionRoutes(byGroupVersion), nil
 }
 
 // servedGroupVersions reports which group versions this process actually serves.

--- a/pkg/services/apiserver/searchroutes/searchroutes_test.go
+++ b/pkg/services/apiserver/searchroutes/searchroutes_test.go
@@ -321,3 +321,60 @@ func TestServedGroupVersions_CoversBothRegistrationPaths(t *testing.T) {
 	assert.True(t, served[fromBuilder])
 	assert.False(t, served[schema.GroupVersion{Group: "other.grafana.app", Version: "v1"}])
 }
+
+// todoManifest is an ext app group, which no builder or installer knows about.
+func todoManifest(gv schema.GroupVersion, fieldType, capability string) []app.Manifest {
+	return []app.Manifest{{ManifestData: &app.ManifestData{
+		Group: gv.Group,
+		Versions: []app.ManifestVersion{{
+			Name:   gv.Version,
+			Served: true,
+			Kinds: []app.ManifestVersionKind{{
+				Kind:   "Todo",
+				Plural: "todos",
+				Scope:  "Namespaced",
+				SearchFields: []app.ManifestVersionKindSearchField{
+					{Name: "title", Path: "spec.title", Type: fieldType, Capabilities: []string{capability}},
+				},
+			}},
+		}},
+	}}}
+}
+
+func TestBuildForServedGroupVersions_MountsWithoutBuildersOrInstallers(t *testing.T) {
+	gv := schema.GroupVersion{Group: "exampletodoapp.ext.grafana.app", Version: "v1alpha1"}
+	manifests := todoManifest(gv, "string", "filter")
+
+	t.Run("mounted when the caller serves the group version", func(t *testing.T) {
+		served := map[schema.GroupVersion]bool{gv: true}
+
+		routes, err := BuildForServedGroupVersions(manifests, served, true, true, nil, fakeClient{})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"todos/search", "todos/trash"}, paths(routes)[gv.String()])
+	})
+
+	t.Run("nothing mounted for a group version the caller does not serve", func(t *testing.T) {
+		routes, err := BuildForServedGroupVersions(manifests, nil, true, true, nil, fakeClient{})
+		require.NoError(t, err)
+		assert.Empty(t, paths(routes))
+	})
+
+	t.Run("nothing mounted when both endpoints are off", func(t *testing.T) {
+		served := map[schema.GroupVersion]bool{gv: true}
+
+		routes, err := BuildForServedGroupVersions(manifests, served, false, false, nil, fakeClient{})
+		require.NoError(t, err)
+		assert.Nil(t, routes)
+	})
+}
+
+// Runtime declarations are refused rather than fatal.
+func TestBuildForServedGroupVersions_RejectsAMalformedDeclaration(t *testing.T) {
+	gv := schema.GroupVersion{Group: "exampletodoapp.ext.grafana.app", Version: "v1alpha1"}
+	served := map[schema.GroupVersion]bool{gv: true}
+
+	// Full-text search over a number is not something the index can serve.
+	routes, err := BuildForServedGroupVersions(todoManifest(gv, "int64", "text"), served, true, true, nil, fakeClient{})
+	require.Error(t, err)
+	assert.Nil(t, routes)
+}

--- a/pkg/storage/unified/resource/search_field_manifest.go
+++ b/pkg/storage/unified/resource/search_field_manifest.go
@@ -18,19 +18,21 @@ var manifestMergeLogger = log.New("search-manifest-merge")
 // same map-backed provider NewMapProvider produces, so the per-field and
 // cross-version consistency checks apply here too.
 //
-// Panics on an invalid declaration, like NewMapProvider. Runtime callers use
-// newManifestBackedProvider instead.
+// Panics on an invalid declaration, like NewMapProvider, because in a
+// compiled-in manifest that is a bug. Runtime callers use
+// ManifestBackedProvider instead.
 func NewManifestBackedProvider(manifests []app.Manifest) SearchFieldsProvider {
-	p, err := newManifestBackedProvider(manifests)
+	p, err := ManifestBackedProvider(manifests)
 	if err != nil {
 		panic(err.Error())
 	}
 	return p
 }
 
-// newManifestBackedProvider is NewManifestBackedProvider's error-returning
-// core, so a runtime manifest source can reject a bad set instead of crashing.
-func newManifestBackedProvider(manifests []app.Manifest) (SearchFieldsProvider, error) {
+// ManifestBackedProvider is NewManifestBackedProvider's error-returning form,
+// for manifests read at runtime, which can be malformed without this build
+// being at fault.
+func ManifestBackedProvider(manifests []app.Manifest) (SearchFieldsProvider, error) {
 	fields := map[schema.GroupVersionResource][]SearchFieldDefinition{}
 	preferred := map[schema.GroupResource]string{}
 
@@ -133,7 +135,7 @@ func SearchFieldProviders(manifests []app.Manifest) (map[LowerGroupResource]Sear
 
 	// A single manifest-backed provider covers every declared kind; each map
 	// entry queries it for its own (group, resource).
-	manifestProvider, err := newManifestBackedProvider(manifests)
+	manifestProvider, err := ManifestBackedProvider(manifests)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/unified/resource/search_field_manifest_test.go
+++ b/pkg/storage/unified/resource/search_field_manifest_test.go
@@ -142,6 +142,11 @@ func TestSearchFieldProviders_InvalidManifestReturnsError(t *testing.T) {
 	got, err := SearchFieldProviders([]app.Manifest{invalid})
 	require.Error(t, err)
 	assert.Nil(t, got)
+
+	// Same set through the constructor a runtime caller uses.
+	p, err := ManifestBackedProvider([]app.Manifest{invalid})
+	require.Error(t, err)
+	assert.Nil(t, p)
 }
 
 func mergeTestManifest(appName, group string, versions ...app.ManifestVersion) app.Manifest {
@@ -161,7 +166,7 @@ func mergeTestKind(kind, field string) app.ManifestVersionKind {
 // fieldNames lets a test assert whose declaration of a kind survived a merge.
 func fieldNames(t *testing.T, manifests []app.Manifest, group, version, resource string) []string {
 	t.Helper()
-	p, err := newManifestBackedProvider(manifests)
+	p, err := ManifestBackedProvider(manifests)
 	require.NoError(t, err)
 	fields := p.Fields(schema.GroupVersionResource{Group: group, Version: version, Resource: resource})
 	names := make([]string, 0, len(fields))


### PR DESCRIPTION
**Why:** we want `/search` to work for ext app kinds (`*.ext.grafana.app`), which are registered while the process runs and served as custom resource definitions by the apiextensions server. That server has no API group builders and no app-sdk installers for them, so the served group versions cannot be derived the way they are today, and nothing gets mounted.

Adds `searchroutes.BuildForServedGroupVersions`, which takes the served set from the caller. `Build` and `BuildFromManifests` are unchanged and now call it. It returns an error rather than panicking on a bad field declaration, since a host reading declarations at runtime can be handed a malformed one through no fault of the build; the field provider's error-returning constructor is exported for that.

Groundwork only, no behaviour change. The apiextensions side is a separate change.

Labelled `no-check-unified-storage-compatibility`: the two halves cannot be split usefully, because the new API layer entry point calls the exported constructor added on the storage side. Nothing here crosses a service boundary — both are in-process Go APIs, and neither the gRPC contract nor the index format changes, so an old and a new binary interoperate exactly as before.
