### PR TITLE
Search: stop sending QueryField.type from in-tree clients

### DIFF
--- a/pkg/registry/apis/dashboard/search.go
+++ b/pkg/registry/apis/dashboard/search.go
@@ -998,15 +998,12 @@ func convertHttpSearchRequestToResourceSearchRequest(queryParams url.Values, use
 		searchRequest.QueryFields = []*resourcepb.ResourceSearchRequest_QueryField{
 			{
 				Name:  resource.SEARCH_FIELD_TITLE_PHRASE,
-				Type:  resourcepb.QueryFieldType_KEYWORD,
 				Boost: 10, // exact title match (case-insensitive via pre-lowered title_phrase)
 			}, {
 				Name:  resource.SEARCH_FIELD_TITLE,
-				Type:  resourcepb.QueryFieldType_TEXT,
 				Boost: 2, // standard analyzer (word-level matching)
 			}, {
 				Name:  resource.SEARCH_FIELD_TITLE_NGRAM,
-				Type:  resourcepb.QueryFieldType_TEXT,
 				Boost: 1, // ngram analyzer (partial/prefix matching)
 			},
 		}
@@ -1014,7 +1011,6 @@ func convertHttpSearchRequestToResourceSearchRequest(queryParams url.Values, use
 		if queryParams.Has("panelTitleSearch") && queryParams.Get("panelTitleSearch") != "false" {
 			searchRequest.QueryFields = append(searchRequest.QueryFields, &resourcepb.ResourceSearchRequest_QueryField{
 				Name:  builders.DASHBOARD_PANEL_TITLE,
-				Type:  resourcepb.QueryFieldType_TEXT,
 				Boost: 5,
 			})
 		}

--- a/pkg/registry/apis/iam/user/search.go
+++ b/pkg/registry/apis/iam/user/search.go
@@ -297,8 +297,8 @@ func (s *SearchHandler) DoSearch(w http.ResponseWriter, r *http.Request) {
 		Query:  searchQuery,
 		Fields: []string{resource.SEARCH_FIELD_TITLE, fieldEmail, fieldLogin, fieldLastSeenAt, fieldRole, fieldDisabled, fieldExternalAuthModules, resource.SEARCH_FIELD_CREATED, legacyIDField},
 		// The query is a wildcard (*...*), so only Name is used from each
-		// QueryField to specify which fields to search in (Type and Boost
-		// are ignored for wildcard queries).
+		// QueryField to specify which fields to search in (Boost is ignored
+		// for wildcard queries).
 		QueryFields: []*resourcepb.ResourceSearchRequest_QueryField{
 			{Name: resource.SEARCH_FIELD_TITLE},
 			{Name: fieldEmail},

--- a/pkg/registry/apis/search/translate.go
+++ b/pkg/registry/apis/search/translate.go
@@ -581,7 +581,6 @@ func applyText(req *resourcepb.ResourceSearchRequest, t *searchv0.TextPredicate)
 	for _, f := range fields {
 		req.QueryFields = append(req.QueryFields, &resourcepb.ResourceSearchRequest_QueryField{
 			Name: f,
-			Type: resourcepb.QueryFieldType_TEXT,
 			// The backend applies boost unconditionally, so a zero value would
 			// zero-score every hit. v1 has no per-leaf boost, so use a neutral 1.
 			Boost: 1,

--- a/pkg/registry/apis/search/translate_test.go
+++ b/pkg/registry/apis/search/translate_test.go
@@ -13,7 +13,6 @@ import (
 
 	searchv0 "github.com/grafana/grafana/pkg/apis/search/v0alpha1"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
-	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
 
 var dashboardsGVR = schema.GroupVersionResource{
@@ -108,7 +107,6 @@ func TestTranslateSearchQuery_TextAndFilters(t *testing.T) {
 	require.Len(t, req.QueryFields, 2)
 	assert.Equal(t, "title", req.QueryFields[0].Name)
 	assert.Equal(t, "panel_title", req.QueryFields[1].Name)
-	assert.Equal(t, resourcepb.QueryFieldType_TEXT, req.QueryFields[0].Type)
 	// neutral boost so hits are scored (backend applies boost unconditionally).
 	assert.Equal(t, float32(1), req.QueryFields[0].Boost)
 	assert.Equal(t, float32(1), req.QueryFields[1].Boost)


### PR DESCRIPTION
The search backend derives the query type and analyzer from how a field is mapped in the index (grafana/grafana#129305, released in 13.2), and ignores the `type` a client sends in `ResourceSearchRequest.QueryField`. This stops the in-tree clients from setting it: the dashboard search handler and the Search v1 translator. IAM search already sent field names only.

`Boost` is kept. That is a real query-time preference, not an index detail.

No ranking change: the server has ignored the value since 13.2, and the BM25 score snapshots in `pkg/tests/apis/dashboard/testdata/searchV0/` are unchanged.

Follow-up PR will remove the field from the proto and reserve its number, once this one is released so no client still sets it.

Part of grafana/search-and-storage-team#806.
