### PR TITLE
Provisioning: record resource byte size metric and log

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/export/resources.go
+++ b/pkg/registry/apis/provisioning/jobs/export/resources.go
@@ -287,11 +287,12 @@ func exportItem(ctx context.Context,
 
 	if err == nil {
 		var path string
-		path, err = repositoryResources.WriteResourceFileFromObject(ctx, item, resources.WriteOptions{
+		var size int
+		path, size, err = repositoryResources.WriteResourceFileFromObject(ctx, item, resources.WriteOptions{
 			Path: options.Path,
 			Ref:  options.Branch,
 		})
-		resultBuilder.WithPath(path)
+		resultBuilder.WithPath(path).WithBytes(size)
 	}
 
 	if errors.Is(err, resources.ErrAlreadyInRepository) {

--- a/pkg/registry/apis/provisioning/jobs/export/resources_specific_test.go
+++ b/pkg/registry/apis/provisioning/jobs/export/resources_specific_test.go
@@ -125,10 +125,10 @@ func TestExportSpecificResources_Success(t *testing.T) {
 	writeOpts := resources.WriteOptions{Path: "grafana", Ref: "feature/branch"}
 	repoResources.On("WriteResourceFileFromObject", mock.Anything, mock.MatchedBy(func(obj *unstructured.Unstructured) bool {
 		return obj.GetName() == "dash-1"
-	}), writeOpts).Return("dash-1.json", nil)
+	}), writeOpts).Return("dash-1.json", 0, nil)
 	repoResources.On("WriteResourceFileFromObject", mock.Anything, mock.MatchedBy(func(obj *unstructured.Unstructured) bool {
 		return obj.GetName() == "dash-2"
-	}), writeOpts).Return("dash-2.json", nil)
+	}), writeOpts).Return("dash-2.json", 0, nil)
 
 	progress := jobs.NewMockJobProgressRecorder(t)
 	progress.On("SetMessage", mock.Anything, "start selective resource export").Return()
@@ -258,7 +258,7 @@ func TestExportSpecificResources_NewUIDsSetsRandomName(t *testing.T) {
 	repoResources.On("WriteResourceFileFromObject", mock.Anything, mock.MatchedBy(func(obj *unstructured.Unstructured) bool {
 		writtenName = obj.GetName()
 		return true
-	}), mock.Anything).Return("generated.json", nil)
+	}), mock.Anything).Return("generated.json", 0, nil)
 
 	progress := jobs.NewMockJobProgressRecorder(t)
 	progress.On("SetMessage", mock.Anything, mock.Anything).Return()
@@ -354,7 +354,7 @@ func TestExportSpecificResources_GeneratesFolderForDashboard(t *testing.T) {
 	})).Return(nil)
 	repoResources.On("WriteResourceFileFromObject", mock.Anything, mock.MatchedBy(func(obj *unstructured.Unstructured) bool {
 		return obj.GetName() == "dash-1"
-	}), mock.Anything).Return("parent/child/dash-1.json", nil)
+	}), mock.Anything).Return("parent/child/dash-1.json", 0, nil)
 
 	progress := jobs.NewMockJobProgressRecorder(t)
 	progress.On("SetMessage", mock.Anything, "start selective resource export").Return()
@@ -404,7 +404,7 @@ func TestExportSpecificResources_ManagedFolderAncestryIsSkipped(t *testing.T) {
 	})).Return(nil)
 	repoResources.On("WriteResourceFileFromObject", mock.Anything, mock.MatchedBy(func(obj *unstructured.Unstructured) bool {
 		return obj.GetName() == "dash-1"
-	}), mock.Anything).Return("dash-1.json", nil)
+	}), mock.Anything).Return("dash-1.json", 0, nil)
 
 	progress := jobs.NewMockJobProgressRecorder(t)
 	progress.On("SetMessage", mock.Anything, mock.Anything).Return()
@@ -443,7 +443,7 @@ func TestExportSpecificResources_NonDashboardKindIsExported(t *testing.T) {
 	repoResources := resources.NewMockRepositoryResources(t)
 	repoResources.On("WriteResourceFileFromObject", mock.Anything, mock.MatchedBy(func(obj *unstructured.Unstructured) bool {
 		return obj.GetName() == "playlist-1" && obj.GetKind() == "Playlist"
-	}), mock.Anything).Return("playlist-1.json", nil)
+	}), mock.Anything).Return("playlist-1.json", 0, nil)
 
 	progress := jobs.NewMockJobProgressRecorder(t)
 	progress.On("SetMessage", mock.Anything, "start selective resource export").Return()

--- a/pkg/registry/apis/provisioning/jobs/export/resources_test.go
+++ b/pkg/registry/apis/provisioning/jobs/export/resources_test.go
@@ -107,11 +107,11 @@ func TestExportResources_Dashboards_Success(t *testing.T) {
 
 		repoResources.On("WriteResourceFileFromObject", mock.Anything, mock.MatchedBy(func(obj *unstructured.Unstructured) bool {
 			return obj.GetName() == "dashboard-1"
-		}), options).Return("dashboard-1.json", nil)
+		}), options).Return("dashboard-1.json", 0, nil)
 
 		repoResources.On("WriteResourceFileFromObject", mock.Anything, mock.MatchedBy(func(obj *unstructured.Unstructured) bool {
 			return obj.GetName() == "dashboard-2"
-		}), options).Return("dashboard-2.json", nil)
+		}), options).Return("dashboard-2.json", 0, nil)
 	}
 
 	err := runExportTest(t, mockItems, setupProgress, setupResources)
@@ -160,11 +160,11 @@ func TestExportResources_Dashboards_WithErrors(t *testing.T) {
 
 		repoResources.On("WriteResourceFileFromObject", mock.Anything, mock.MatchedBy(func(obj *unstructured.Unstructured) bool {
 			return obj.GetName() == "dashboard-1"
-		}), options).Return("", fmt.Errorf("failed to export dashboard"))
+		}), options).Return("", 0, fmt.Errorf("failed to export dashboard"))
 
 		repoResources.On("WriteResourceFileFromObject", mock.Anything, mock.MatchedBy(func(obj *unstructured.Unstructured) bool {
 			return obj.GetName() == "dashboard-2"
-		}), options).Return("dashboard-2.json", nil)
+		}), options).Return("dashboard-2.json", 0, nil)
 	}
 
 	err := runExportTest(t, mockItems, setupProgress, setupResources)
@@ -194,7 +194,7 @@ func TestExportResources_Dashboards_TooManyErrors(t *testing.T) {
 
 		repoResources.On("WriteResourceFileFromObject", mock.Anything, mock.MatchedBy(func(obj *unstructured.Unstructured) bool {
 			return obj.GetName() == "dashboard-1"
-		}), options).Return("", fmt.Errorf("failed to export dashboard"))
+		}), options).Return("", 0, fmt.Errorf("failed to export dashboard"))
 	}
 
 	err := runExportTest(t, mockItems, setupProgress, setupResources)
@@ -224,7 +224,7 @@ func TestExportResources_Dashboards_IgnoresExisting(t *testing.T) {
 
 		repoResources.On("WriteResourceFileFromObject", mock.Anything, mock.MatchedBy(func(obj *unstructured.Unstructured) bool {
 			return obj.GetName() == "existing-dashboard"
-		}), options).Return("", resources.ErrAlreadyInRepository)
+		}), options).Return("", 0, resources.ErrAlreadyInRepository)
 	}
 
 	err := runExportTest(t, mockItems, setupProgress, setupResources)
@@ -301,7 +301,7 @@ func TestExportResources_Dashboards_V0StoredVersionExportsAsV1(t *testing.T) {
 			// The exported object must carry the v1 apiVersion, not v0alpha1.
 			return obj.GetName() == "existing-dashboard" &&
 				obj.GetAPIVersion() == resources.DashboardResource.GroupVersion().String()
-		}), options).Return("existing-dashboard.json", nil)
+		}), options).Return("existing-dashboard.json", 0, nil)
 	}
 
 	err := runExportTest(t, mockItems, setupProgress, setupResources)
@@ -521,7 +521,7 @@ func TestExportResources_Dashboards_Versions(t *testing.T) {
 						Path: "grafana",
 						Ref:  "feature/branch",
 					}
-					repoResources.On("WriteResourceFileFromObject", mock.Anything, &dashboard, options).Return(fmt.Sprintf("%s.json", tt.dashboardName), nil)
+					repoResources.On("WriteResourceFileFromObject", mock.Anything, &dashboard, options).Return(fmt.Sprintf("%s.json", tt.dashboardName), 0, nil)
 				}
 			}
 
@@ -627,7 +627,7 @@ func TestExportResources_Dashboards_SkipsAppGeneratedResources(t *testing.T) {
 		// matcher and the mock fails on an unexpected call.
 		repoResources.On("WriteResourceFileFromObject", mock.Anything, mock.MatchedBy(func(obj *unstructured.Unstructured) bool {
 			return obj.GetName() == "regular-dashboard"
-		}), mock.Anything).Return("regular-dashboard.json", nil)
+		}), mock.Anything).Return("regular-dashboard.json", 0, nil)
 	}
 
 	err := runExportTest(t, mockItems, setupProgress, setupResources)
@@ -664,7 +664,7 @@ func TestExportResources_GenerateNewUIDs(t *testing.T) {
 	repoResources.On("WriteResourceFileFromObject", mock.Anything, mock.MatchedBy(func(obj *unstructured.Unstructured) bool {
 		name := obj.GetName()
 		return name != "original-name-1" && name != "original-name-2" && name != ""
-	}), resources.WriteOptions{Path: "grafana", Ref: "feature/branch"}).Return("exported.json", nil).Times(2)
+	}), resources.WriteOptions{Path: "grafana", Ref: "feature/branch"}).Return("exported.json", 0, nil).Times(2)
 
 	options := provisioningV0.ExportJobOptions{
 		Path:   "grafana",
@@ -703,7 +703,7 @@ func TestExportResources_GenerateNewUIDs_UniquePerResource(t *testing.T) {
 		Run(func(args mock.Arguments) {
 			obj := args.Get(1).(*unstructured.Unstructured)
 			generatedNames = append(generatedNames, obj.GetName())
-		}).Return("exported.json", nil)
+		}).Return("exported.json", 0, nil)
 
 	options := provisioningV0.ExportJobOptions{
 		Path:   "grafana",
@@ -831,9 +831,9 @@ func TestExportResources_Dashboards_MultipleVersions(t *testing.T) {
 			Path: "grafana",
 			Ref:  "feature/branch",
 		}
-		repoResources.On("WriteResourceFileFromObject", mock.Anything, &v2alphaDashboard, options).Return("v2alpha-dashboard.json", nil)
-		repoResources.On("WriteResourceFileFromObject", mock.Anything, &v2betaDashboard, options).Return("v2beta-dashboard.json", nil)
-		repoResources.On("WriteResourceFileFromObject", mock.Anything, &v3Dashboard, options).Return("v3-dashboard.json", nil)
+		repoResources.On("WriteResourceFileFromObject", mock.Anything, &v2alphaDashboard, options).Return("v2alpha-dashboard.json", 0, nil)
+		repoResources.On("WriteResourceFileFromObject", mock.Anything, &v2betaDashboard, options).Return("v2beta-dashboard.json", 0, nil)
+		repoResources.On("WriteResourceFileFromObject", mock.Anything, &v3Dashboard, options).Return("v3-dashboard.json", 0, nil)
 	}
 
 	err := runExportTest(t, mockItems, setupProgress, setupResources)

--- a/pkg/registry/apis/provisioning/jobs/job_resource_result.go
+++ b/pkg/registry/apis/provisioning/jobs/job_resource_result.go
@@ -133,6 +133,7 @@ type JobResourceResult struct {
 	err          error
 	warning      error
 	startedAt    time.Time // stamped when the builder is created; used to derive the operation duration at record time
+	bytes        int       // size in bytes of the resource content written; 0 when unknown or not a content write
 }
 
 // jobResourceResultBuilder is a builder for creating JobResourceResult instances using a fluent API.
@@ -240,6 +241,15 @@ func (b *jobResourceResultBuilder) WithStartTime(t time.Time) *jobResourceResult
 	return b
 }
 
+// WithBytes records the size in bytes of the resource content involved in the
+// operation (e.g. the file read on a sync write, or the content written on
+// export). It is observed in the resource-size histogram at record time. Leave
+// it unset for operations without meaningful content (deletes, folders).
+func (b *jobResourceResultBuilder) WithBytes(n int) *jobResourceResultBuilder {
+	b.result.bytes = n
+	return b
+}
+
 // WithReason sets an explicit reason on the result. This takes precedence over
 // the reason derived from classifyWarning and can be used on success results
 // to explain why an operation happened (e.g., UID migration).
@@ -315,6 +325,12 @@ func (r JobResourceResult) PreviousPath() string {
 // Action returns the action performed on the resource.
 func (r JobResourceResult) Action() repository.FileAction {
 	return r.action
+}
+
+// Bytes returns the size in bytes of the resource content involved in the
+// operation, or 0 when unknown or not a content write.
+func (r JobResourceResult) Bytes() int {
+	return r.bytes
 }
 
 // elapsed returns how long the operation took, measured from when the result's

--- a/pkg/registry/apis/provisioning/jobs/metrics.go
+++ b/pkg/registry/apis/provisioning/jobs/metrics.go
@@ -23,6 +23,7 @@ type JobMetrics struct {
 
 	resourceOpsTotal   *prometheus.CounterVec   // per-resource outcome counter
 	resourceOpDuration *prometheus.HistogramVec // per-resource operation duration
+	resourceOpBytes    *prometheus.HistogramVec // per-resource content size in bytes
 	inFlight           *prometheus.GaugeVec     // jobs currently being processed, by driver + action
 	busySeconds        *prometheus.CounterVec   // job duration credited at completion, by driver + action
 }
@@ -235,6 +236,18 @@ func RegisterJobMetrics(registry prometheus.Registerer) JobMetrics {
 		)
 		registry.MustRegister(resourceOpDuration)
 
+		resourceOpBytes := prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name: "grafana_provisioning_jobs_resource_operation_bytes",
+				Help: "Size in bytes of individual resources written during provisioning job runs",
+				// 512B -> 32MB. Resources can be several MB today (large dashboards);
+				// the top buckets leave headroom past the ~20MB range as sizes grow.
+				Buckets: []float64{512, 2048, 8192, 32768, 131072, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, 33554432},
+			},
+			[]string{"action", "operation", "outcome", "group", "kind"},
+		)
+		registry.MustRegister(resourceOpBytes)
+
 		inFlight := prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Name: "grafana_provisioning_jobs_in_flight",
@@ -262,6 +275,7 @@ func RegisterJobMetrics(registry prometheus.Registerer) JobMetrics {
 			syncDurationHist:                 syncDurationHist,
 			resourceOpsTotal:                 resourceOpsTotal,
 			resourceOpDuration:               resourceOpDuration,
+			resourceOpBytes:                  resourceOpBytes,
 			inFlight:                         inFlight,
 			busySeconds:                      busySeconds,
 		}
@@ -347,8 +361,16 @@ func (m *JobMetrics) RecordResourceOperation(action provisioning.JobAction, resu
 	// means the result carried no file action at all (e.g. a quota pre-check or a
 	// client-resolution failure), so neither did real work worth timing. Keep both
 	// out of the duration histogram.
-	if m.resourceOpDuration != nil && dur > 0 && operation != OperationIgnored && operation != "" {
+	realOp := operation != OperationIgnored && operation != ""
+	if m.resourceOpDuration != nil && dur > 0 && realOp {
 		m.resourceOpDuration.WithLabelValues(string(action), string(operation), string(outcome), result.Group(), result.Kind()).Observe(dur.Seconds())
+	}
+
+	// Resource size is only known for content writes (the write paths stamp it via
+	// WithBytes). Deletes, folders and no-op operations carry no size, so a zero
+	// byte count is excluded rather than recorded as a 0-byte resource.
+	if m.resourceOpBytes != nil && result.Bytes() > 0 && realOp {
+		m.resourceOpBytes.WithLabelValues(string(action), string(operation), string(outcome), result.Group(), result.Kind()).Observe(float64(result.Bytes()))
 	}
 }
 

--- a/pkg/registry/apis/provisioning/jobs/metrics.go
+++ b/pkg/registry/apis/provisioning/jobs/metrics.go
@@ -366,9 +366,11 @@ func (m *JobMetrics) RecordResourceOperation(action provisioning.JobAction, resu
 		m.resourceOpDuration.WithLabelValues(string(action), string(operation), string(outcome), result.Group(), result.Kind()).Observe(dur.Seconds())
 	}
 
-	// Resource size is only known for content writes (the write paths stamp it via
-	// WithBytes). Deletes, folders and no-op operations carry no size, so a zero
-	// byte count is excluded rather than recorded as a 0-byte resource.
+	// Resource size is only known for operations that read or write the file
+	// content (creates, updates, renames, and file-based deletes stamp it via
+	// WithBytes). Operations without a file body — folders, no-ops, and deletes
+	// that only had the cluster object to go on — report 0 and are excluded
+	// rather than recorded as a 0-byte resource.
 	if m.resourceOpBytes != nil && result.Bytes() > 0 && realOp {
 		m.resourceOpBytes.WithLabelValues(string(action), string(operation), string(outcome), result.Group(), result.Kind()).Observe(float64(result.Bytes()))
 	}

--- a/pkg/registry/apis/provisioning/jobs/metrics_test.go
+++ b/pkg/registry/apis/provisioning/jobs/metrics_test.go
@@ -141,6 +141,62 @@ func TestRecordResourceOperationDuration(t *testing.T) {
 	assert.Equal(t, uint64(0), ignoredCount, "ignored operations must not be observed")
 }
 
+func TestRecordResourceOperationBytes(t *testing.T) {
+	reg := testRegistry
+	m := testMetrics
+
+	// Unique group/kind so this test's series don't collide with other tests
+	// sharing the singleton registry.
+	const group = "bytestest.grafana.app"
+	const kind = "ByteProbe"
+
+	created := NewResourceResult().
+		WithGroup(group).WithKind(kind).
+		WithAction(repository.FileActionCreated).
+		WithBytes(2048).Build()
+	zeroBytes := NewResourceResult().
+		WithGroup(group).WithKind(kind).
+		WithAction(repository.FileActionCreated).Build() // no WithBytes -> 0
+	deleted := NewResourceResult().
+		WithGroup(group).WithKind(kind).
+		WithAction(repository.FileActionDeleted).
+		WithBytes(4096).Build() // deletes still carry no meaningful size, but exercise the real-op gate
+	ignored := NewResourceResult().
+		WithGroup(group).WithKind(kind).
+		WithAction(repository.FileActionIgnored).
+		WithBytes(4096).Build()
+
+	m.RecordResourceOperation(provisioning.JobActionPull, created, 10*time.Millisecond)
+	m.RecordResourceOperation(provisioning.JobActionPull, created, 10*time.Millisecond)
+	m.RecordResourceOperation(provisioning.JobActionPull, zeroBytes, 10*time.Millisecond) // zero bytes -> not observed
+	m.RecordResourceOperation(provisioning.JobActionPull, ignored, 10*time.Millisecond)   // ignored op -> not observed
+	m.RecordResourceOperation(provisioning.JobActionPush, deleted, 10*time.Millisecond)
+
+	metrics, err := reg.Gather()
+	require.NoError(t, err)
+
+	hist := findMetric(metrics, "grafana_provisioning_jobs_resource_operation_bytes")
+	require.NotNil(t, hist, "resource_operation_bytes histogram should be registered")
+
+	createdCount := histogramSampleCount(hist, map[string]string{
+		"action": "pull", "operation": "created", "outcome": "success",
+		"group": group, "kind": kind,
+	})
+	assert.Equal(t, uint64(2), createdCount, "only the two non-zero-byte created ops should be observed")
+
+	ignoredCount := histogramSampleCount(hist, map[string]string{
+		"action": "pull", "operation": "ignored", "outcome": "success",
+		"group": group, "kind": kind,
+	})
+	assert.Equal(t, uint64(0), ignoredCount, "ignored operations must not be observed")
+
+	deletedCount := histogramSampleCount(hist, map[string]string{
+		"action": "push", "operation": "deleted", "outcome": "success",
+		"group": group, "kind": kind,
+	})
+	assert.Equal(t, uint64(1), deletedCount, "a delete with a byte count is still a real op and observed")
+}
+
 // --- helpers ---
 
 func histogramSampleCount(mf *dto.MetricFamily, labels map[string]string) uint64 {

--- a/pkg/registry/apis/provisioning/jobs/progress.go
+++ b/pkg/registry/apis/provisioning/jobs/progress.go
@@ -164,7 +164,7 @@ func (r *jobProgressRecorder) Record(ctx context.Context, result JobResourceResu
 		r.metrics.RecordResourceOperation(r.action, result, duration)
 	}
 
-	logger := logging.FromContext(ctx).With("path", result.Path(), "group", result.Group(), "kind", result.Kind(), "action", result.Action(), "name", result.Name(), "duration", duration)
+	logger := logging.FromContext(ctx).With("path", result.Path(), "group", result.Group(), "kind", result.Kind(), "action", result.Action(), "name", result.Name(), "duration", duration, "bytes", result.Bytes())
 	if shouldLogError {
 		logger.Error("job resource operation failed", "err", logErr)
 	} else if shouldLogWarning {

--- a/pkg/registry/apis/provisioning/jobs/sync/full.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full.go
@@ -302,6 +302,7 @@ func applyChange(
 	writeCtx, writeSpan := tracer.Start(ctx, "provisioning.sync.full.apply_changes.write_resource_from_file")
 	var name string
 	var gvk schema.GroupVersionKind
+	var size int
 	var err error
 
 	// Pass the existing resource's content hash so the write can skip strict
@@ -319,11 +320,11 @@ func applyChange(
 			Group:    change.Existing.Group,
 			Resource: change.Existing.Resource,
 		}
-		name, gvk, err = repositoryResources.ReplaceResourceFromFile(writeCtx, change.Path, currentRef, change.Existing.Name, oldGVR, writeOpts...)
+		name, gvk, size, err = repositoryResources.ReplaceResourceFromFile(writeCtx, change.Path, currentRef, change.Existing.Name, oldGVR, writeOpts...)
 	} else {
-		name, gvk, err = repositoryResources.WriteResourceFromFile(writeCtx, change.Path, currentRef, writeOpts...)
+		name, gvk, size, err = repositoryResources.WriteResourceFromFile(writeCtx, change.Path, currentRef, writeOpts...)
 	}
-	resultBuilder.WithName(name).WithGVK(gvk)
+	resultBuilder.WithName(name).WithGVK(gvk).WithBytes(size)
 	if err != nil {
 		writeSpan.RecordError(err)
 		resultBuilder.WithError(fmt.Errorf("writing resource from file %s: %w", change.Path, err))

--- a/pkg/registry/apis/provisioning/jobs/sync/full_hierarchical_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full_hierarchical_test.go
@@ -69,7 +69,7 @@ func TestFullSync_HierarchicalErrorHandling(t *testing.T) { // nolint:gocyclo
 				// WriteResourceFromFile fails with PathCreationError for folder1/
 				folderErr := &resources.PathCreationError{Path: "folder1/", Err: fmt.Errorf("permission denied")}
 				repoResources.On("WriteResourceFromFile", mock.Anything, "folder1/file.json", "ref").
-					Return("", schema.GroupVersionKind{}, folderErr).Once()
+					Return("", schema.GroupVersionKind{}, 0, folderErr).Once()
 
 				// File will be recorded with error, triggering automatic tracking of folder1/ failure
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
@@ -90,7 +90,7 @@ func TestFullSync_HierarchicalErrorHandling(t *testing.T) { // nolint:gocyclo
 				progress.On("HasDirPathFailedCreation", "folder1/file1.json").Return(false).Once()
 				folderErr := &resources.PathCreationError{Path: "folder1/", Err: fmt.Errorf("permission denied")}
 				repoResources.On("WriteResourceFromFile", mock.Anything, "folder1/file1.json", "ref").
-					Return("", schema.GroupVersionKind{}, folderErr).Once()
+					Return("", schema.GroupVersionKind{}, 0, folderErr).Once()
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
 					return r.Path() == "folder1/file1.json" && r.Error() != nil
@@ -169,7 +169,7 @@ func TestFullSync_HierarchicalErrorHandling(t *testing.T) { // nolint:gocyclo
 				progress.On("HasDirPathFailedCreation", "folder1/file1.json").Return(false).Once()
 				folderErr := &resources.PathCreationError{Path: "folder1/", Err: fmt.Errorf("permission denied")}
 				repoResources.On("WriteResourceFromFile", mock.Anything, "folder1/file1.json", "ref").
-					Return("", schema.GroupVersionKind{}, folderErr).Once()
+					Return("", schema.GroupVersionKind{}, 0, folderErr).Once()
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
 					return r.Path() == "folder1/file1.json" && r.Error() != nil
@@ -205,7 +205,7 @@ func TestFullSync_HierarchicalErrorHandling(t *testing.T) { // nolint:gocyclo
 				progress.On("HasDirPathFailedCreation", "level1/file1.json").Return(false).Once()
 				folderErr := &resources.PathCreationError{Path: "level1/", Err: fmt.Errorf("permission denied")}
 				repoResources.On("WriteResourceFromFile", mock.Anything, "level1/file1.json", "ref").
-					Return("", schema.GroupVersionKind{}, folderErr).Once()
+					Return("", schema.GroupVersionKind{}, 0, folderErr).Once()
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
 					return r.Path() == "level1/file1.json" && r.Error() != nil
@@ -232,7 +232,7 @@ func TestFullSync_HierarchicalErrorHandling(t *testing.T) { // nolint:gocyclo
 				// Success path works
 				progress.On("HasDirPathFailedCreation", "success/file1.json").Return(false).Once()
 				repoResources.On("WriteResourceFromFile", mock.Anything, "success/file1.json", "ref").
-					Return("resource1", schema.GroupVersionKind{Kind: "Dashboard"}, nil).Once()
+					Return("resource1", schema.GroupVersionKind{Kind: "Dashboard"}, 0, nil).Once()
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
 					return r.Path() == "success/file1.json" && r.Error() == nil
 				})).Return().Once()
@@ -241,7 +241,7 @@ func TestFullSync_HierarchicalErrorHandling(t *testing.T) { // nolint:gocyclo
 				progress.On("HasDirPathFailedCreation", "failure/file2.json").Return(false).Once()
 				folderErr := &resources.PathCreationError{Path: "failure/", Err: fmt.Errorf("disk full")}
 				repoResources.On("WriteResourceFromFile", mock.Anything, "failure/file2.json", "ref").
-					Return("", schema.GroupVersionKind{}, folderErr).Once()
+					Return("", schema.GroupVersionKind{}, 0, folderErr).Once()
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
 					return r.Path() == "failure/file2.json" && r.Error() != nil
 				})).Return().Once()

--- a/pkg/registry/apis/provisioning/jobs/sync/full_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full_test.go
@@ -295,7 +295,7 @@ func TestFullSync_ApplyChanges(t *testing.T) { //nolint:gocyclo
 
 				repoResources.On("WriteResourceFromFile", mock.Anything, mock.MatchedBy(func(path string) bool {
 					return path == "dashboards/one.json" || path == "dashboards/two.json" || path == "dashboards/three.json"
-				}), "current-ref").Return("test-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, nil).Maybe()
+				}), "current-ref").Return("test-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, 0, nil).Maybe()
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
 					return result.Action() == repository.FileActionCreated &&
@@ -318,7 +318,7 @@ func TestFullSync_ApplyChanges(t *testing.T) { //nolint:gocyclo
 				progress.On("HasDirPathFailedCreation", "dashboards/test.json").Return(false)
 
 				repoResources.On("WriteResourceFromFile", mock.Anything, "dashboards/test.json", "current-ref").
-					Return("test-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, nil)
+					Return("test-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, 0, nil)
 
 				progress.On("Record", mock.Anything, matchesResult(jobs.NewGroupKindResult(
 					"test-dashboard", "dashboards", "Dashboard").WithAction(repository.FileActionCreated).WithPath("dashboards/test.json").Build())).Return()
@@ -338,7 +338,7 @@ func TestFullSync_ApplyChanges(t *testing.T) { //nolint:gocyclo
 				progress.On("HasDirPathFailedCreation", "dashboards/test.json").Return(false)
 
 				repoResources.On("WriteResourceFromFile", mock.Anything, "dashboards/test.json", "current-ref").
-					Return("test-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, fmt.Errorf("write error"))
+					Return("test-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, 0, fmt.Errorf("write error"))
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
 					return result.Action() == repository.FileActionCreated &&
@@ -365,7 +365,7 @@ func TestFullSync_ApplyChanges(t *testing.T) { //nolint:gocyclo
 				progress.On("HasDirPathFailedCreation", "dashboards/test.json").Return(false)
 
 				repoResources.On("WriteResourceFromFile", mock.Anything, "dashboards/test.json", "current-ref").
-					Return("test-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, nil)
+					Return("test-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, 0, nil)
 
 				progress.On("Record", mock.Anything, matchesResult(jobs.NewGroupKindResult(
 					"test-dashboard",
@@ -390,7 +390,7 @@ func TestFullSync_ApplyChanges(t *testing.T) { //nolint:gocyclo
 				progress.On("HasDirPathFailedCreation", "dashboards/test.json").Return(false)
 
 				repoResources.On("WriteResourceFromFile", mock.Anything, "dashboards/test.json", "current-ref").
-					Return("test-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, fmt.Errorf("write error"))
+					Return("test-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, 0, fmt.Errorf("write error"))
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
 					return result.Action() == repository.FileActionUpdated &&
@@ -858,7 +858,7 @@ func TestFullSync_ApplyChanges(t *testing.T) { //nolint:gocyclo
 							return
 						}
 					}).
-					Return("", schema.GroupVersionKind{}, context.DeadlineExceeded)
+					Return("", schema.GroupVersionKind{}, 0, context.DeadlineExceeded)
 
 				// applyChange records the error from WriteResourceFromFile
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
@@ -1194,7 +1194,7 @@ func TestFullSync_QuotaTrackerSkipsCreationsAtLimit(t *testing.T) {
 	// First file: allowed, write succeeds
 	progress.On("HasDirPathFailedCreation", "dashboards/a.json").Return(false)
 	repoResources.On("WriteResourceFromFile", mock.Anything, "dashboards/a.json", "ref").
-		Return("dash-a", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, nil)
+		Return("dash-a", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, 0, nil)
 	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
 		return r.Path() == "dashboards/a.json" && r.Action() == repository.FileActionCreated && r.Error() == nil
 	})).Return().Once()
@@ -1239,7 +1239,7 @@ func TestFullSync_QuotaTrackerAllowsUpdatesRegardlessOfQuota(t *testing.T) {
 	progress.On("HasDirPathFailedCreation", "dashboards/existing.json").Return(false)
 
 	repoResources.On("WriteResourceFromFile", mock.Anything, "dashboards/existing.json", "ref").
-		Return("dash-existing", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, nil)
+		Return("dash-existing", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, 0, nil)
 	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
 		return r.Path() == "dashboards/existing.json" && r.Action() == repository.FileActionUpdated && r.Error() == nil
 	})).Return()
@@ -1291,7 +1291,7 @@ func TestFullSync_MissingFolderMetadata_FlagEnabled(t *testing.T) {
 	})).Return()
 
 	repoResources.On("WriteResourceFromFile", mock.Anything, "myfolder/dashboard.json", "ref").
-		Return("dash1", schema.GroupVersionKind{Kind: "Dashboard"}, nil)
+		Return("dash1", schema.GroupVersionKind{Kind: "Dashboard"}, 0, nil)
 	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
 		return r.Path() == "myfolder/dashboard.json"
 	})).Return()
@@ -1323,7 +1323,7 @@ func TestFullSync_MissingFolderMetadata_FlagDisabled(t *testing.T) {
 	progress.On("HasDirPathFailedCreation", mock.Anything).Return(false)
 
 	repoResources.On("WriteResourceFromFile", mock.Anything, "myfolder/dashboard.json", "ref").
-		Return("dash1", schema.GroupVersionKind{Kind: "Dashboard"}, nil)
+		Return("dash1", schema.GroupVersionKind{Kind: "Dashboard"}, 0, nil)
 	// Only expect Record for the dashboard write, NOT for folder metadata warning
 	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
 		return r.Path() == "myfolder/dashboard.json"
@@ -1458,7 +1458,7 @@ func TestApplyChanges_DefersOldFolderDeletion(t *testing.T) {
 	// File phase: dashboard creation
 	repoResources.On("WriteResourceFromFile", mock.Anything, "myfolder/dashboard.json", "test-ref").Run(func(args mock.Arguments) {
 		recordCall("WriteResourceFromFile")
-	}).Return("dash-1", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, nil)
+	}).Return("dash-1", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, 0, nil)
 
 	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
 		return r.Path() == "myfolder/dashboard.json"
@@ -1534,7 +1534,7 @@ func TestApplyChanges_DefersOrphanFolderDeletion(t *testing.T) {
 		Resource: "dashboards",
 	}).Run(func(args mock.Arguments) {
 		recordCall("ReplaceResourceFromFile")
-	}).Return("dash-uid", schema.GroupVersionKind{Group: "dashboard.grafana.app", Kind: "Dashboard"}, nil)
+	}).Return("dash-uid", schema.GroupVersionKind{Group: "dashboard.grafana.app", Kind: "Dashboard"}, 0, nil)
 
 	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
 		return r.Path() == "myfolder/dashboard.json" &&
@@ -1691,7 +1691,7 @@ func TestApplyChanges_DefersBothRenamedAndOrphanFolderDeletion(t *testing.T) {
 		Resource: "dashboards",
 	}).Run(func(args mock.Arguments) {
 		recordCall("ReplaceResourceFromFile")
-	}).Return("dash-uid", schema.GroupVersionKind{Group: "dashboard.grafana.app", Kind: "Dashboard"}, nil)
+	}).Return("dash-uid", schema.GroupVersionKind{Group: "dashboard.grafana.app", Kind: "Dashboard"}, 0, nil)
 
 	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
 		return r.Path() == "myfolder/dashboard.json"
@@ -1752,7 +1752,7 @@ func TestApplyChanges_ExistingHashPassedToWrite(t *testing.T) {
 			mock.Anything, "myfolder/dashboard.json", "test-ref", "dash-uid",
 			schema.GroupVersionResource{Group: "dashboard.grafana.app", Resource: "dashboards"},
 			mock.MatchedBy(func(opt resources.WriteResourceOption) bool { return opt != nil }),
-		).Return("dash-uid", schema.GroupVersionKind{Group: "dashboard.grafana.app", Kind: "Dashboard"}, nil)
+		).Return("dash-uid", schema.GroupVersionKind{Group: "dashboard.grafana.app", Kind: "Dashboard"}, 0, nil)
 
 		progress.On("Record", mock.Anything, mock.Anything).Return()
 
@@ -1791,7 +1791,7 @@ func TestApplyChanges_ExistingHashPassedToWrite(t *testing.T) {
 		repoResources.On("ReplaceResourceFromFile",
 			mock.Anything, "myfolder/dashboard.json", "test-ref", "dash-uid",
 			schema.GroupVersionResource{Group: "dashboard.grafana.app", Resource: "dashboards"},
-		).Return("dash-uid", schema.GroupVersionKind{Group: "dashboard.grafana.app", Kind: "Dashboard"}, nil)
+		).Return("dash-uid", schema.GroupVersionKind{Group: "dashboard.grafana.app", Kind: "Dashboard"}, 0, nil)
 
 		progress.On("Record", mock.Anything, mock.Anything).Return()
 

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental.go
@@ -310,14 +310,14 @@ func applyIncrementalChanges(
 			}
 		case repository.FileActionDeleted:
 			removeCtx, removeSpan := tracer.Start(ctx, "provisioning.sync.incremental.remove_resource_from_file")
-			name, folderName, gvk, err := repositoryResources.RemoveResourceFromFile(removeCtx, change.Path, change.PreviousRef)
+			name, folderName, gvk, size, err := repositoryResources.RemoveResourceFromFile(removeCtx, change.Path, change.PreviousRef)
 			if err != nil {
 				removeSpan.RecordError(err)
 				resultBuilder.WithError(fmt.Errorf("removing resource from file %s: %w", change.Path, err))
 			} else {
 				quotaTracker.Release()
 			}
-			resultBuilder.WithName(name).WithGVK(gvk)
+			resultBuilder.WithName(name).WithGVK(gvk).WithBytes(size)
 
 			if folderName != "" {
 				affectedFolders[safepath.Dir(change.Path)] = folderName
@@ -351,12 +351,12 @@ func applyIncrementalChanges(
 						renameOpts = append(renameOpts, resources.WithRelocatingUIDs(uids...))
 					}
 				}
-				name, oldFolderName, gvk, err := repositoryResources.RenameResourceFile(renameCtx, change.PreviousPath, change.PreviousRef, change.Path, change.Ref, renameOpts...)
+				name, oldFolderName, gvk, size, err := repositoryResources.RenameResourceFile(renameCtx, change.PreviousPath, change.PreviousRef, change.Path, change.Ref, renameOpts...)
 				if err != nil {
 					renameSpan.RecordError(err)
 					resultBuilder.WithError(fmt.Errorf("renaming resource file from %s to %s: %w", change.PreviousPath, change.Path, err))
 				}
-				resultBuilder.WithName(name).WithGVK(gvk)
+				resultBuilder.WithName(name).WithGVK(gvk).WithBytes(size)
 
 				if oldFolderName != "" {
 					affectedFolders[safepath.Dir(change.PreviousPath)] = oldFolderName

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental.go
@@ -272,24 +272,24 @@ func applyIncrementalChanges(
 		switch change.Action {
 		case repository.FileActionCreated:
 			writeCtx, writeSpan := tracer.Start(ctx, "provisioning.sync.incremental.write_resource_from_file")
-			name, gvk, err := repositoryResources.WriteResourceFromFile(writeCtx, change.Path, change.Ref)
+			name, gvk, size, err := repositoryResources.WriteResourceFromFile(writeCtx, change.Path, change.Ref)
 			if err != nil {
 				writeSpan.RecordError(err)
 				resultBuilder.WithError(fmt.Errorf("writing resource from file %s: %w", change.Path, err))
 			}
-			resultBuilder.WithName(name).WithGVK(gvk)
+			resultBuilder.WithName(name).WithGVK(gvk).WithBytes(size)
 			writeSpan.End()
 		case repository.FileActionUpdated:
 			if change.PreviousRef != "" {
 				// ReplaceResourceFromFileByRef reads both old and new files internally
 				// and automatically skips strict validation when their hashes match.
 				writeCtx, writeSpan := tracer.Start(ctx, "provisioning.sync.incremental.replace_resource_from_file")
-				name, gvk, err := repositoryResources.ReplaceResourceFromFileByRef(writeCtx, change.Path, change.Ref, change.PreviousRef)
+				name, gvk, size, err := repositoryResources.ReplaceResourceFromFileByRef(writeCtx, change.Path, change.Ref, change.PreviousRef)
 				if err != nil {
 					writeSpan.RecordError(err)
 					resultBuilder.WithError(fmt.Errorf("replacing resource from file %s: %w", change.Path, err))
 				}
-				resultBuilder.WithName(name).WithGVK(gvk)
+				resultBuilder.WithName(name).WithGVK(gvk).WithBytes(size)
 				writeSpan.End()
 			} else {
 				// Synthetic updates emitted for re-parenting (no PreviousRef).
@@ -300,12 +300,12 @@ func applyIncrementalChanges(
 				if h, ok := existingHashes[change.Path]; ok {
 					writeOpts = append(writeOpts, resources.WithExistingHash(h))
 				}
-				name, gvk, err := repositoryResources.WriteResourceFromFile(writeCtx, change.Path, change.Ref, writeOpts...)
+				name, gvk, size, err := repositoryResources.WriteResourceFromFile(writeCtx, change.Path, change.Ref, writeOpts...)
 				if err != nil {
 					writeSpan.RecordError(err)
 					resultBuilder.WithError(fmt.Errorf("writing resource from file %s: %w", change.Path, err))
 				}
-				resultBuilder.WithName(name).WithGVK(gvk)
+				resultBuilder.WithName(name).WithGVK(gvk).WithBytes(size)
 				writeSpan.End()
 			}
 		case repository.FileActionDeleted:

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental_hierarchical_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental_hierarchical_test.go
@@ -103,7 +103,7 @@ func TestIncrementalSync_HierarchicalErrorHandling(t *testing.T) { // nolint:goc
 				progress.On("HasDirPathFailedCreation", "folder1/file1.json").Return(false).Once()
 				folderErr := &resources.PathCreationError{Path: "folder1/", Err: fmt.Errorf("permission denied")}
 				repoResources.On("WriteResourceFromFile", mock.Anything, "folder1/file1.json", "new-ref").
-					Return("", schema.GroupVersionKind{}, folderErr).Once()
+					Return("", schema.GroupVersionKind{}, 0, folderErr).Once()
 
 				// First file recorded with error, automatically tracked
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
@@ -170,7 +170,7 @@ func TestIncrementalSync_HierarchicalErrorHandling(t *testing.T) { // nolint:goc
 				progress.On("HasDirPathFailedCreation", "folder1/new.json").Return(false).Once()
 				folderErr := &resources.PathCreationError{Path: "folder1/", Err: fmt.Errorf("permission denied")}
 				repoResources.On("WriteResourceFromFile", mock.Anything, "folder1/new.json", "new-ref").
-					Return("", schema.GroupVersionKind{}, folderErr).Once()
+					Return("", schema.GroupVersionKind{}, 0, folderErr).Once()
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
 					return r.Path() == "folder1/new.json" && r.Error() != nil
@@ -231,14 +231,14 @@ func TestIncrementalSync_HierarchicalErrorHandling(t *testing.T) { // nolint:goc
 				// Success path works
 				progress.On("HasDirPathFailedCreation", "success/file1.json").Return(false).Once()
 				repoResources.On("WriteResourceFromFile", mock.Anything, "success/file1.json", "new-ref").
-					Return("resource-1", schema.GroupVersionKind{Kind: "Dashboard"}, nil).Once()
+					Return("resource-1", schema.GroupVersionKind{Kind: "Dashboard"}, 0, nil).Once()
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
 					return r.Path() == "success/file1.json" && r.Error() == nil
 				})).Return().Once()
 
 				progress.On("HasDirPathFailedCreation", "success/nested/file2.json").Return(false).Once()
 				repoResources.On("WriteResourceFromFile", mock.Anything, "success/nested/file2.json", "new-ref").
-					Return("resource-2", schema.GroupVersionKind{Kind: "Dashboard"}, nil).Once()
+					Return("resource-2", schema.GroupVersionKind{Kind: "Dashboard"}, 0, nil).Once()
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
 					return r.Path() == "success/nested/file2.json" && r.Error() == nil
 				})).Return().Once()
@@ -423,7 +423,7 @@ func TestIncrementalSync_HierarchicalErrorHandling_FailedFolderCreation(t *testi
 
 	progress.On("HasDirPathFailedCreation", "other/file.json").Return(false).Once()
 	repoResources.On("WriteResourceFromFile", mock.Anything, "other/file.json", "new-ref").
-		Return("test-resource", schema.GroupVersionKind{Kind: "Dashboard"}, nil).Once()
+		Return("test-resource", schema.GroupVersionKind{Kind: "Dashboard"}, 0, nil).Once()
 	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
 		return r.Path() == "other/file.json" && r.Action() == repository.FileActionCreated && r.Error() == nil
 	})).Return().Once()
@@ -499,7 +499,7 @@ func TestIncrementalSync_HierarchicalErrorHandling_DeletionNotAffectedByCreation
 	// Creation fails
 	progress.On("HasDirPathFailedCreation", "folder1/file.json").Return(false).Once()
 	repoResources.On("WriteResourceFromFile", mock.Anything, "folder1/file.json", "new-ref").
-		Return("", schema.GroupVersionKind{}, &resources.PathCreationError{Path: "folder1/", Err: fmt.Errorf("permission denied")}).Once()
+		Return("", schema.GroupVersionKind{}, 0, &resources.PathCreationError{Path: "folder1/", Err: fmt.Errorf("permission denied")}).Once()
 
 	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
 		return r.Path() == "folder1/file.json" && r.Error() != nil
@@ -584,14 +584,14 @@ func TestIncrementalSync_HierarchicalErrorHandling_MixedSuccessAndFailure(t *tes
 
 	progress.On("HasDirPathFailedCreation", "success/file1.json").Return(false).Once()
 	repoResources.On("WriteResourceFromFile", mock.Anything, "success/file1.json", "new-ref").
-		Return("resource-1", schema.GroupVersionKind{Kind: "Dashboard"}, nil).Once()
+		Return("resource-1", schema.GroupVersionKind{Kind: "Dashboard"}, 0, nil).Once()
 	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
 		return r.Path() == "success/file1.json" && r.Action() == repository.FileActionCreated && r.Error() == nil
 	})).Return().Once()
 
 	progress.On("HasDirPathFailedCreation", "success/nested/file2.json").Return(false).Once()
 	repoResources.On("WriteResourceFromFile", mock.Anything, "success/nested/file2.json", "new-ref").
-		Return("resource-2", schema.GroupVersionKind{Kind: "Dashboard"}, nil).Once()
+		Return("resource-2", schema.GroupVersionKind{Kind: "Dashboard"}, 0, nil).Once()
 	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
 		return r.Path() == "success/nested/file2.json" && r.Action() == repository.FileActionCreated && r.Error() == nil
 	})).Return().Once()

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental_hierarchical_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental_hierarchical_test.go
@@ -135,7 +135,7 @@ func TestIncrementalSync_HierarchicalErrorHandling(t *testing.T) { // nolint:goc
 			setupMocks: func(repo *repository.MockVersioned, repoResources *resources.MockRepositoryResources, progress *jobs.MockJobProgressRecorder) {
 				// File deletion fails (deletions don't check HasDirPathFailedCreation)
 				repoResources.On("RemoveResourceFromFile", mock.Anything, "dashboards/file1.json", "old-ref").
-					Return("dashboard-1", "folder-uid", schema.GroupVersionKind{Kind: "Dashboard"}, fmt.Errorf("permission denied")).Once()
+					Return("dashboard-1", "folder-uid", schema.GroupVersionKind{Kind: "Dashboard"}, 0, fmt.Errorf("permission denied")).Once()
 
 				// Error recorded, automatically tracked in failedDeletions
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
@@ -178,7 +178,7 @@ func TestIncrementalSync_HierarchicalErrorHandling(t *testing.T) { // nolint:goc
 
 				// Deletion proceeds (NOT checking HasDirPathFailedCreation for deletions)
 				repoResources.On("RemoveResourceFromFile", mock.Anything, "folder1/old.json", "old-ref").
-					Return("old-resource", "", schema.GroupVersionKind{Kind: "Dashboard"}, nil).Once()
+					Return("old-resource", "", schema.GroupVersionKind{Kind: "Dashboard"}, 0, nil).Once()
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
 					return r.Path() == "folder1/old.json" &&
@@ -277,7 +277,7 @@ func TestIncrementalSync_HierarchicalErrorHandling(t *testing.T) { // nolint:goc
 				progress.On("HasDirPathFailedCreation", "newfolder/file.json").Return(false).Once()
 				folderErr := &resources.PathCreationError{Path: "newfolder/", Err: fmt.Errorf("permission denied")}
 				repoResources.On("RenameResourceFile", mock.Anything, "oldfolder/file.json", "old-ref", "newfolder/file.json", "new-ref").
-					Return("", "", schema.GroupVersionKind{}, folderErr).Once()
+					Return("", "", schema.GroupVersionKind{}, 0, folderErr).Once()
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
 					return r.Path() == "newfolder/file.json" &&
@@ -453,7 +453,7 @@ func TestIncrementalSync_HierarchicalErrorHandling_FailedFileDeletion(t *testing
 
 	// Deletions don't check HasDirPathFailedCreation, they go straight to removal
 	repoResources.On("RemoveResourceFromFile", mock.Anything, "dashboards/file1.json", "old-ref").
-		Return("dashboard-1", "folder-uid", schema.GroupVersionKind{Kind: "Dashboard"}, fmt.Errorf("permission denied")).Once()
+		Return("dashboard-1", "folder-uid", schema.GroupVersionKind{Kind: "Dashboard"}, 0, fmt.Errorf("permission denied")).Once()
 
 	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
 		return r.Path() == "dashboards/file1.json" && r.Action() == repository.FileActionDeleted &&
@@ -508,7 +508,7 @@ func TestIncrementalSync_HierarchicalErrorHandling_DeletionNotAffectedByCreation
 	// Deletion should NOT be skipped (not checking HasDirPathFailedCreation for deletions)
 	// Deletions don't check HasDirPathFailedCreation, they go straight to removal
 	repoResources.On("RemoveResourceFromFile", mock.Anything, "folder1/old.json", "old-ref").
-		Return("old-resource", "", schema.GroupVersionKind{Kind: "Dashboard"}, nil).Once()
+		Return("old-resource", "", schema.GroupVersionKind{Kind: "Dashboard"}, 0, nil).Once()
 
 	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
 		return r.Path() == "folder1/old.json" && r.Action() == repository.FileActionDeleted && r.Error() == nil

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental_test.go
@@ -231,7 +231,7 @@ func TestIncrementalSync(t *testing.T) {
 				progress.On("SetMessage", mock.Anything, "versioned changes replicated").Return()
 
 				repoResources.On("RemoveResourceFromFile", mock.Anything, "dashboards/old.json", "old-ref").
-					Return("old-dashboard", "", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, nil)
+					Return("old-dashboard", "", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, 0, nil)
 
 				progress.On("Record", mock.Anything, matchesResult(jobs.NewGroupKindResult(
 					"old-dashboard",
@@ -267,7 +267,7 @@ func TestIncrementalSync(t *testing.T) {
 				progress.On("HasDirPathFailedCreation", "dashboards/new.json").Return(false)
 
 				repoResources.On("RenameResourceFile", mock.Anything, "dashboards/old.json", "old-ref", "dashboards/new.json", "new-ref").
-					Return("renamed-dashboard", "", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, nil)
+					Return("renamed-dashboard", "", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, 0, nil)
 
 				progress.On("Record", mock.Anything, matchesResult(jobs.NewGroupKindResult(
 					"renamed-dashboard",
@@ -616,7 +616,7 @@ func TestIncrementalSync_ErrorHandling(t *testing.T) {
 				progress.On("SetMessage", mock.Anything, "versioned changes replicated").Return()
 
 				repoResources.On("RemoveResourceFromFile", mock.Anything, "dashboards/old.json", "old-ref").
-					Return("old-dashboard", "", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, fmt.Errorf("delete failed"))
+					Return("old-dashboard", "", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, 0, fmt.Errorf("delete failed"))
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
 					return result.Action() == repository.FileActionDeleted &&
@@ -737,7 +737,7 @@ func TestIncrementalSync_QuotaEnforcement(t *testing.T) {
 				progress.On("HasDirPathFailedCreation", "dashboards/new.json").Return(false)
 
 				repoResources.On("RemoveResourceFromFile", mock.Anything, "dashboards/old.json", "old-ref").
-					Return("old-dashboard", "", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, nil)
+					Return("old-dashboard", "", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, 0, nil)
 
 				repoResources.On("WriteResourceFromFile", mock.Anything, "dashboards/new.json", "new-ref").
 					Return("new-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, 0, nil)
@@ -810,7 +810,7 @@ func TestIncrementalSync_QuotaEnforcement(t *testing.T) {
 				progress.On("HasDirPathFailedCreation", "dashboards/new.json").Return(false)
 
 				repoResources.On("RemoveResourceFromFile", mock.Anything, "dashboards/old.json", "old-ref").
-					Return("old-dashboard", "", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, nil)
+					Return("old-dashboard", "", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, 0, nil)
 
 				repoResources.On("WriteResourceFromFile", mock.Anything, "dashboards/new.json", "new-ref").
 					Return("new-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, 0, nil)
@@ -851,7 +851,7 @@ func TestIncrementalSync_QuotaEnforcement(t *testing.T) {
 				progress.On("HasDirPathFailedCreation", "dashboards/new.json").Return(false)
 
 				repoResources.On("RemoveResourceFromFile", mock.Anything, "dashboards/old.json", "old-ref").
-					Return("old-dashboard", "", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, fmt.Errorf("delete failed"))
+					Return("old-dashboard", "", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, 0, fmt.Errorf("delete failed"))
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
 					return result.Action() == repository.FileActionDeleted && result.Path() == "dashboards/old.json" && result.Error() != nil
@@ -946,7 +946,7 @@ func TestIncrementalSync_CleanupOrphanedFolders(t *testing.T) {
 				progress.On("SetMessage", mock.Anything, "replicating versioned changes").Return()
 				progress.On("SetMessage", mock.Anything, "versioned changes replicated").Return()
 				repoResources.On("RemoveResourceFromFile", mock.Anything, "dashboards/old.json", "old-ref").
-					Return("old-dashboard", "folder-uid", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, nil)
+					Return("old-dashboard", "folder-uid", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, 0, nil)
 
 				// if the folder is not found in git, there should be a call to remove the folder from grafana
 				repo.MockReader.On("Read", mock.Anything, "dashboards/", "new-ref").
@@ -976,7 +976,7 @@ func TestIncrementalSync_CleanupOrphanedFolders(t *testing.T) {
 				progress.On("SetMessage", mock.Anything, "replicating versioned changes").Return()
 				progress.On("SetMessage", mock.Anything, "versioned changes replicated").Return()
 				repoResources.On("RemoveResourceFromFile", mock.Anything, "dashboards/old.json", "old-ref").
-					Return("old-dashboard", "folder-uid", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, nil)
+					Return("old-dashboard", "folder-uid", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, 0, nil)
 
 				// if the folder still exists in git, there should not be a call to delete it from grafana
 				repo.MockReader.On("Read", mock.Anything, "dashboards/", "new-ref").
@@ -1006,9 +1006,9 @@ func TestIncrementalSync_CleanupOrphanedFolders(t *testing.T) {
 				progress.On("SetMessage", mock.Anything, "replicating versioned changes").Return()
 				progress.On("SetMessage", mock.Anything, "versioned changes replicated").Return()
 				repoResources.On("RemoveResourceFromFile", mock.Anything, "dashboards/old.json", "old-ref").
-					Return("old-dashboard", "folder-uid-1", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, nil)
+					Return("old-dashboard", "folder-uid-1", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, 0, nil)
 				repoResources.On("RemoveResourceFromFile", mock.Anything, "alerts/old-alert.yaml", "old-ref").
-					Return("old-alert", "folder-uid-2", schema.GroupVersionKind{Kind: "Alert", Group: "alerts"}, nil)
+					Return("old-alert", "folder-uid-2", schema.GroupVersionKind{Kind: "Alert", Group: "alerts"}, 0, nil)
 
 				progress.On("Record", mock.Anything, mock.Anything).Return()
 				progress.On("TooManyErrors").Return(nil)

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental_test.go
@@ -138,9 +138,9 @@ func TestIncrementalSync(t *testing.T) {
 
 				// Mock successful resource writes
 				repoResources.On("WriteResourceFromFile", mock.Anything, "dashboards/test.json", "new-ref").
-					Return("test-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, nil)
+					Return("test-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, 0, nil)
 				repoResources.On("WriteResourceFromFile", mock.Anything, "alerts/alert.yaml", "new-ref").
-					Return("test-alert", schema.GroupVersionKind{Kind: "Alert", Group: "alerts"}, nil)
+					Return("test-alert", schema.GroupVersionKind{Kind: "Alert", Group: "alerts"}, 0, nil)
 
 				// Mock progress recording
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
@@ -302,7 +302,7 @@ func TestIncrementalSync(t *testing.T) {
 				progress.On("HasDirPathFailedCreation", "dashboards/dash.json").Return(false)
 
 				repoResources.On("ReplaceResourceFromFileByRef", mock.Anything, "dashboards/dash.json", "new-ref", "old-ref").
-					Return("replaced-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, nil)
+					Return("replaced-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, 0, nil)
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
 					return result.Action() == repository.FileActionUpdated &&
@@ -336,7 +336,7 @@ func TestIncrementalSync(t *testing.T) {
 				progress.On("HasDirPathFailedCreation", "dashboards/dash.json").Return(false)
 
 				repoResources.On("WriteResourceFromFile", mock.Anything, "dashboards/dash.json", "new-ref").
-					Return("written-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, nil)
+					Return("written-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, 0, nil)
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
 					return result.Action() == repository.FileActionUpdated &&
@@ -546,7 +546,7 @@ func TestIncrementalSync_ErrorHandling(t *testing.T) {
 				progress.On("HasDirPathFailedCreation", "dashboards/test.json").Return(false)
 
 				repoResources.On("WriteResourceFromFile", mock.Anything, "dashboards/test.json", "new-ref").
-					Return("test-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, fmt.Errorf("write failed"))
+					Return("test-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, 0, fmt.Errorf("write failed"))
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
 					return result.Action() == repository.FileActionCreated &&
@@ -582,7 +582,7 @@ func TestIncrementalSync_ErrorHandling(t *testing.T) {
 				progress.On("HasDirPathFailedCreation", "dashboards/dash.json").Return(false)
 
 				repoResources.On("ReplaceResourceFromFileByRef", mock.Anything, "dashboards/dash.json", "new-ref", "old-ref").
-					Return("dash-name", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, fmt.Errorf("replace failed"))
+					Return("dash-name", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, 0, fmt.Errorf("replace failed"))
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
 					return result.Action() == repository.FileActionUpdated &&
@@ -694,7 +694,7 @@ func TestIncrementalSync_QuotaEnforcement(t *testing.T) {
 				progress.On("HasDirPathFailedCreation", "dashboards/second.json").Return(false)
 
 				repoResources.On("WriteResourceFromFile", mock.Anything, "dashboards/first.json", "new-ref").
-					Return("first-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, nil)
+					Return("first-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, 0, nil)
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
 					return result.Action() == repository.FileActionCreated && result.Path() == "dashboards/first.json" && result.Error() == nil
@@ -740,7 +740,7 @@ func TestIncrementalSync_QuotaEnforcement(t *testing.T) {
 					Return("old-dashboard", "", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, nil)
 
 				repoResources.On("WriteResourceFromFile", mock.Anything, "dashboards/new.json", "new-ref").
-					Return("new-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, nil)
+					Return("new-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, 0, nil)
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
 					return result.Action() == repository.FileActionDeleted && result.Path() == "dashboards/old.json"
@@ -773,7 +773,7 @@ func TestIncrementalSync_QuotaEnforcement(t *testing.T) {
 				progress.On("HasDirPathFailedCreation", "dashboards/existing.json").Return(false)
 
 				repoResources.On("WriteResourceFromFile", mock.Anything, "dashboards/existing.json", "new-ref").
-					Return("existing-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, nil)
+					Return("existing-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, 0, nil)
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
 					return result.Action() == repository.FileActionUpdated &&
@@ -813,7 +813,7 @@ func TestIncrementalSync_QuotaEnforcement(t *testing.T) {
 					Return("old-dashboard", "", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, nil)
 
 				repoResources.On("WriteResourceFromFile", mock.Anything, "dashboards/new.json", "new-ref").
-					Return("new-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, nil)
+					Return("new-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, 0, nil)
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
 					return result.Action() == repository.FileActionDeleted && result.Path() == "dashboards/old.json"
@@ -1078,7 +1078,7 @@ func TestIncrementalSync_MissingFolderMetadata(t *testing.T) {
 		progress.On("SetMessage", mock.Anything, "versioned changes replicated").Return()
 		progress.On("HasDirPathFailedCreation", "myfolder/dashboard.json").Return(false)
 		repoResources.On("WriteResourceFromFile", mock.Anything, "myfolder/dashboard.json", "new-ref").
-			Return("test-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, nil)
+			Return("test-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, 0, nil)
 		progress.On("TooManyErrors").Return(nil)
 
 		// ReadTree returns a folder without _folder.json
@@ -1139,7 +1139,7 @@ func TestIncrementalSync_MissingFolderMetadata(t *testing.T) {
 		progress.On("SetMessage", mock.Anything, "versioned changes replicated").Return()
 		progress.On("HasDirPathFailedCreation", "dashboards/test.json").Return(false)
 		repoResources.On("WriteResourceFromFile", mock.Anything, "dashboards/test.json", "new-ref").
-			Return("test-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, nil)
+			Return("test-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, 0, nil)
 		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
 			return result.Action() == repository.FileActionCreated && result.Path() == "dashboards/test.json"
 		})).Return()
@@ -1358,7 +1358,7 @@ func TestIncrementalSync_FolderRouting(t *testing.T) {
 		progress.On("TooManyErrors").Return(nil)
 
 		repoResources.On("WriteResourceFromFile", mock.Anything, "alpha/_folder.json", "new-ref").
-			Return("folder-resource", schema.GroupVersionKind{Kind: "Folder", Group: "folders"}, nil)
+			Return("folder-resource", schema.GroupVersionKind{Kind: "Folder", Group: "folders"}, 0, nil)
 
 		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
 			return result.Action() == repository.FileActionUpdated &&
@@ -1442,7 +1442,7 @@ func TestIncrementalSync_FolderMetadataDeletion(t *testing.T) {
 		// when the content is unchanged.
 		repoResources.On("WriteResourceFromFile", mock.Anything, "alpha/dash.json", "new-ref",
 			mock.MatchedBy(func(opt resources.WriteResourceOption) bool { return opt != nil }),
-		).Return("dash1", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboard.grafana.app"}, nil)
+		).Return("dash1", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboard.grafana.app"}, 0, nil)
 		repoResources.On("RemoveFolder", mock.Anything, "stable-uid").Return(nil)
 
 		progress.On("Record", mock.Anything, mock.Anything).Return()
@@ -1494,7 +1494,7 @@ func TestIncrementalSync_FolderMetadataDeletion(t *testing.T) {
 			Return("hash-uid", nil)
 		// No hash in resource list → WriteResourceFromFile called without options.
 		repoResources.On("WriteResourceFromFile", mock.Anything, "gamma/dash.json", "new-ref").
-			Return("dash1", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboard.grafana.app"}, nil)
+			Return("dash1", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboard.grafana.app"}, 0, nil)
 		repoResources.On("RemoveFolder", mock.Anything, "gamma-uid").Return(nil)
 
 		progress.On("Record", mock.Anything, mock.Anything).Return()
@@ -1532,7 +1532,7 @@ func TestIncrementalSync_FolderMetadataDeletion(t *testing.T) {
 		progress.On("HasDirPathFailedCreation", mock.Anything).Return(false)
 
 		repoResources.On("WriteResourceFromFile", mock.Anything, "beta/new-dash.json", "new-ref").
-			Return("new-dash", schema.GroupVersionKind{Kind: "Dashboard"}, nil)
+			Return("new-dash", schema.GroupVersionKind{Kind: "Dashboard"}, 0, nil)
 
 		progress.On("Record", mock.Anything, mock.Anything).Return()
 
@@ -1593,7 +1593,7 @@ func TestIncrementalSync_FolderUIDChange(t *testing.T) {
 		// Child dashboard has hash in resource list → WithExistingHash passed.
 		repoResources.On("WriteResourceFromFile", mock.Anything, "alpha/dash.json", "new-ref",
 			mock.MatchedBy(func(opt resources.WriteResourceOption) bool { return opt != nil }),
-		).Return("dash1", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboard.grafana.app"}, nil)
+		).Return("dash1", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboard.grafana.app"}, 0, nil)
 		repoResources.On("RemoveFolder", mock.Anything, "old-alpha-uid").Return(nil)
 
 		progress.On("Record", mock.Anything, mock.Anything).Return()

--- a/pkg/registry/apis/provisioning/resources/repository.go
+++ b/pkg/registry/apis/provisioning/resources/repository.go
@@ -32,11 +32,11 @@ type RepositoryResources interface {
 	RemoveFolder(ctx context.Context, folderName string) error
 	RenameFolderPath(ctx context.Context, previousPath, previousRef, newPath, newRef string, opts ...EnsurePathOption) (string, error)
 	// File from Resource
-	WriteResourceFileFromObject(ctx context.Context, obj *unstructured.Unstructured, options WriteOptions) (string, error)
+	WriteResourceFileFromObject(ctx context.Context, obj *unstructured.Unstructured, options WriteOptions) (string, int, error)
 	// Resource from file
-	WriteResourceFromFile(ctx context.Context, path, ref string, opts ...WriteResourceOption) (string, schema.GroupVersionKind, error)
-	ReplaceResourceFromFile(ctx context.Context, path, ref string, oldName string, oldGVR schema.GroupVersionResource, opts ...WriteResourceOption) (string, schema.GroupVersionKind, error)
-	ReplaceResourceFromFileByRef(ctx context.Context, path, ref, previousRef string, opts ...WriteResourceOption) (string, schema.GroupVersionKind, error)
+	WriteResourceFromFile(ctx context.Context, path, ref string, opts ...WriteResourceOption) (string, schema.GroupVersionKind, int, error)
+	ReplaceResourceFromFile(ctx context.Context, path, ref string, oldName string, oldGVR schema.GroupVersionResource, opts ...WriteResourceOption) (string, schema.GroupVersionKind, int, error)
+	ReplaceResourceFromFileByRef(ctx context.Context, path, ref, previousRef string, opts ...WriteResourceOption) (string, schema.GroupVersionKind, int, error)
 	RemoveResourceFromFile(ctx context.Context, path, ref string) (string, string, schema.GroupVersionKind, error)
 	FindResourcePath(ctx context.Context, name string, gvk schema.GroupVersionKind) (string, error)
 	RenameResourceFile(ctx context.Context, path, previousRef, newPath, newRef string, folderOpts ...EnsurePathOption) (string, string, schema.GroupVersionKind, error)

--- a/pkg/registry/apis/provisioning/resources/repository.go
+++ b/pkg/registry/apis/provisioning/resources/repository.go
@@ -37,9 +37,9 @@ type RepositoryResources interface {
 	WriteResourceFromFile(ctx context.Context, path, ref string, opts ...WriteResourceOption) (string, schema.GroupVersionKind, int, error)
 	ReplaceResourceFromFile(ctx context.Context, path, ref string, oldName string, oldGVR schema.GroupVersionResource, opts ...WriteResourceOption) (string, schema.GroupVersionKind, int, error)
 	ReplaceResourceFromFileByRef(ctx context.Context, path, ref, previousRef string, opts ...WriteResourceOption) (string, schema.GroupVersionKind, int, error)
-	RemoveResourceFromFile(ctx context.Context, path, ref string) (string, string, schema.GroupVersionKind, error)
+	RemoveResourceFromFile(ctx context.Context, path, ref string) (string, string, schema.GroupVersionKind, int, error)
 	FindResourcePath(ctx context.Context, name string, gvk schema.GroupVersionKind) (string, error)
-	RenameResourceFile(ctx context.Context, path, previousRef, newPath, newRef string, folderOpts ...EnsurePathOption) (string, string, schema.GroupVersionKind, error)
+	RenameResourceFile(ctx context.Context, path, previousRef, newPath, newRef string, folderOpts ...EnsurePathOption) (string, string, schema.GroupVersionKind, int, error)
 	// Stats
 	Stats(ctx context.Context) (*provisioning.ResourceStats, error)
 	List(ctx context.Context) (*provisioning.ResourceList, error)

--- a/pkg/registry/apis/provisioning/resources/repository_resources_mock.go
+++ b/pkg/registry/apis/provisioning/resources/repository_resources_mock.go
@@ -625,7 +625,7 @@ func (_c *MockRepositoryResources_RenameResourceFile_Call) RunAndReturn(run func
 }
 
 // ReplaceResourceFromFile provides a mock function with given fields: ctx, path, ref, oldName, oldGVR, opts
-func (_m *MockRepositoryResources) ReplaceResourceFromFile(ctx context.Context, path string, ref string, oldName string, oldGVR schema.GroupVersionResource, opts ...WriteResourceOption) (string, schema.GroupVersionKind, error) {
+func (_m *MockRepositoryResources) ReplaceResourceFromFile(ctx context.Context, path string, ref string, oldName string, oldGVR schema.GroupVersionResource, opts ...WriteResourceOption) (string, schema.GroupVersionKind, int, error) {
 	_ca := []interface{}{ctx, path, ref, oldName, oldGVR}
 	for _, opt := range opts {
 		_ca = append(_ca, opt)
@@ -638,8 +638,9 @@ func (_m *MockRepositoryResources) ReplaceResourceFromFile(ctx context.Context, 
 
 	var r0 string
 	var r1 schema.GroupVersionKind
-	var r2 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, schema.GroupVersionResource, ...WriteResourceOption) (string, schema.GroupVersionKind, error)); ok {
+	var r2 int
+	var r3 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, schema.GroupVersionResource, ...WriteResourceOption) (string, schema.GroupVersionKind, int, error)); ok {
 		return rf(ctx, path, ref, oldName, oldGVR, opts...)
 	}
 	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, schema.GroupVersionResource, ...WriteResourceOption) string); ok {
@@ -654,13 +655,19 @@ func (_m *MockRepositoryResources) ReplaceResourceFromFile(ctx context.Context, 
 		r1 = ret.Get(1).(schema.GroupVersionKind)
 	}
 
-	if rf, ok := ret.Get(2).(func(context.Context, string, string, string, schema.GroupVersionResource, ...WriteResourceOption) error); ok {
+	if rf, ok := ret.Get(2).(func(context.Context, string, string, string, schema.GroupVersionResource, ...WriteResourceOption) int); ok {
 		r2 = rf(ctx, path, ref, oldName, oldGVR, opts...)
 	} else {
-		r2 = ret.Error(2)
+		r2 = ret.Get(2).(int)
 	}
 
-	return r0, r1, r2
+	if rf, ok := ret.Get(3).(func(context.Context, string, string, string, schema.GroupVersionResource, ...WriteResourceOption) error); ok {
+		r3 = rf(ctx, path, ref, oldName, oldGVR, opts...)
+	} else {
+		r3 = ret.Error(3)
+	}
+
+	return r0, r1, r2, r3
 }
 
 // MockRepositoryResources_ReplaceResourceFromFile_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ReplaceResourceFromFile'
@@ -692,18 +699,18 @@ func (_c *MockRepositoryResources_ReplaceResourceFromFile_Call) Run(run func(ctx
 	return _c
 }
 
-func (_c *MockRepositoryResources_ReplaceResourceFromFile_Call) Return(_a0 string, _a1 schema.GroupVersionKind, _a2 error) *MockRepositoryResources_ReplaceResourceFromFile_Call {
-	_c.Call.Return(_a0, _a1, _a2)
+func (_c *MockRepositoryResources_ReplaceResourceFromFile_Call) Return(_a0 string, _a1 schema.GroupVersionKind, _a2 int, _a3 error) *MockRepositoryResources_ReplaceResourceFromFile_Call {
+	_c.Call.Return(_a0, _a1, _a2, _a3)
 	return _c
 }
 
-func (_c *MockRepositoryResources_ReplaceResourceFromFile_Call) RunAndReturn(run func(context.Context, string, string, string, schema.GroupVersionResource, ...WriteResourceOption) (string, schema.GroupVersionKind, error)) *MockRepositoryResources_ReplaceResourceFromFile_Call {
+func (_c *MockRepositoryResources_ReplaceResourceFromFile_Call) RunAndReturn(run func(context.Context, string, string, string, schema.GroupVersionResource, ...WriteResourceOption) (string, schema.GroupVersionKind, int, error)) *MockRepositoryResources_ReplaceResourceFromFile_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // ReplaceResourceFromFileByRef provides a mock function with given fields: ctx, path, ref, previousRef, opts
-func (_m *MockRepositoryResources) ReplaceResourceFromFileByRef(ctx context.Context, path string, ref string, previousRef string, opts ...WriteResourceOption) (string, schema.GroupVersionKind, error) {
+func (_m *MockRepositoryResources) ReplaceResourceFromFileByRef(ctx context.Context, path string, ref string, previousRef string, opts ...WriteResourceOption) (string, schema.GroupVersionKind, int, error) {
 	_ca := []interface{}{ctx, path, ref, previousRef}
 	for _, opt := range opts {
 		_ca = append(_ca, opt)
@@ -716,8 +723,9 @@ func (_m *MockRepositoryResources) ReplaceResourceFromFileByRef(ctx context.Cont
 
 	var r0 string
 	var r1 schema.GroupVersionKind
-	var r2 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, ...WriteResourceOption) (string, schema.GroupVersionKind, error)); ok {
+	var r2 int
+	var r3 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, ...WriteResourceOption) (string, schema.GroupVersionKind, int, error)); ok {
 		return rf(ctx, path, ref, previousRef, opts...)
 	}
 	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, ...WriteResourceOption) string); ok {
@@ -732,13 +740,19 @@ func (_m *MockRepositoryResources) ReplaceResourceFromFileByRef(ctx context.Cont
 		r1 = ret.Get(1).(schema.GroupVersionKind)
 	}
 
-	if rf, ok := ret.Get(2).(func(context.Context, string, string, string, ...WriteResourceOption) error); ok {
+	if rf, ok := ret.Get(2).(func(context.Context, string, string, string, ...WriteResourceOption) int); ok {
 		r2 = rf(ctx, path, ref, previousRef, opts...)
 	} else {
-		r2 = ret.Error(2)
+		r2 = ret.Get(2).(int)
 	}
 
-	return r0, r1, r2
+	if rf, ok := ret.Get(3).(func(context.Context, string, string, string, ...WriteResourceOption) error); ok {
+		r3 = rf(ctx, path, ref, previousRef, opts...)
+	} else {
+		r3 = ret.Error(3)
+	}
+
+	return r0, r1, r2, r3
 }
 
 // MockRepositoryResources_ReplaceResourceFromFileByRef_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ReplaceResourceFromFileByRef'
@@ -769,12 +783,12 @@ func (_c *MockRepositoryResources_ReplaceResourceFromFileByRef_Call) Run(run fun
 	return _c
 }
 
-func (_c *MockRepositoryResources_ReplaceResourceFromFileByRef_Call) Return(_a0 string, _a1 schema.GroupVersionKind, _a2 error) *MockRepositoryResources_ReplaceResourceFromFileByRef_Call {
-	_c.Call.Return(_a0, _a1, _a2)
+func (_c *MockRepositoryResources_ReplaceResourceFromFileByRef_Call) Return(_a0 string, _a1 schema.GroupVersionKind, _a2 int, _a3 error) *MockRepositoryResources_ReplaceResourceFromFileByRef_Call {
+	_c.Call.Return(_a0, _a1, _a2, _a3)
 	return _c
 }
 
-func (_c *MockRepositoryResources_ReplaceResourceFromFileByRef_Call) RunAndReturn(run func(context.Context, string, string, string, ...WriteResourceOption) (string, schema.GroupVersionKind, error)) *MockRepositoryResources_ReplaceResourceFromFileByRef_Call {
+func (_c *MockRepositoryResources_ReplaceResourceFromFileByRef_Call) RunAndReturn(run func(context.Context, string, string, string, ...WriteResourceOption) (string, schema.GroupVersionKind, int, error)) *MockRepositoryResources_ReplaceResourceFromFileByRef_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -871,7 +885,7 @@ func (_c *MockRepositoryResources_Stats_Call) RunAndReturn(run func(context.Cont
 }
 
 // WriteResourceFileFromObject provides a mock function with given fields: ctx, obj, options
-func (_m *MockRepositoryResources) WriteResourceFileFromObject(ctx context.Context, obj *unstructured.Unstructured, options WriteOptions) (string, error) {
+func (_m *MockRepositoryResources) WriteResourceFileFromObject(ctx context.Context, obj *unstructured.Unstructured, options WriteOptions) (string, int, error) {
 	ret := _m.Called(ctx, obj, options)
 
 	if len(ret) == 0 {
@@ -879,8 +893,9 @@ func (_m *MockRepositoryResources) WriteResourceFileFromObject(ctx context.Conte
 	}
 
 	var r0 string
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *unstructured.Unstructured, WriteOptions) (string, error)); ok {
+	var r1 int
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context, *unstructured.Unstructured, WriteOptions) (string, int, error)); ok {
 		return rf(ctx, obj, options)
 	}
 	if rf, ok := ret.Get(0).(func(context.Context, *unstructured.Unstructured, WriteOptions) string); ok {
@@ -889,13 +904,19 @@ func (_m *MockRepositoryResources) WriteResourceFileFromObject(ctx context.Conte
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, *unstructured.Unstructured, WriteOptions) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, *unstructured.Unstructured, WriteOptions) int); ok {
 		r1 = rf(ctx, obj, options)
 	} else {
-		r1 = ret.Error(1)
+		r1 = ret.Get(1).(int)
 	}
 
-	return r0, r1
+	if rf, ok := ret.Get(2).(func(context.Context, *unstructured.Unstructured, WriteOptions) error); ok {
+		r2 = rf(ctx, obj, options)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
 // MockRepositoryResources_WriteResourceFileFromObject_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'WriteResourceFileFromObject'
@@ -918,18 +939,18 @@ func (_c *MockRepositoryResources_WriteResourceFileFromObject_Call) Run(run func
 	return _c
 }
 
-func (_c *MockRepositoryResources_WriteResourceFileFromObject_Call) Return(_a0 string, _a1 error) *MockRepositoryResources_WriteResourceFileFromObject_Call {
-	_c.Call.Return(_a0, _a1)
+func (_c *MockRepositoryResources_WriteResourceFileFromObject_Call) Return(_a0 string, _a1 int, _a2 error) *MockRepositoryResources_WriteResourceFileFromObject_Call {
+	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *MockRepositoryResources_WriteResourceFileFromObject_Call) RunAndReturn(run func(context.Context, *unstructured.Unstructured, WriteOptions) (string, error)) *MockRepositoryResources_WriteResourceFileFromObject_Call {
+func (_c *MockRepositoryResources_WriteResourceFileFromObject_Call) RunAndReturn(run func(context.Context, *unstructured.Unstructured, WriteOptions) (string, int, error)) *MockRepositoryResources_WriteResourceFileFromObject_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // WriteResourceFromFile provides a mock function with given fields: ctx, path, ref, opts
-func (_m *MockRepositoryResources) WriteResourceFromFile(ctx context.Context, path string, ref string, opts ...WriteResourceOption) (string, schema.GroupVersionKind, error) {
+func (_m *MockRepositoryResources) WriteResourceFromFile(ctx context.Context, path string, ref string, opts ...WriteResourceOption) (string, schema.GroupVersionKind, int, error) {
 	_ca := []interface{}{ctx, path, ref}
 	for _, opt := range opts {
 		_ca = append(_ca, opt)
@@ -942,8 +963,9 @@ func (_m *MockRepositoryResources) WriteResourceFromFile(ctx context.Context, pa
 
 	var r0 string
 	var r1 schema.GroupVersionKind
-	var r2 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, ...WriteResourceOption) (string, schema.GroupVersionKind, error)); ok {
+	var r2 int
+	var r3 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, ...WriteResourceOption) (string, schema.GroupVersionKind, int, error)); ok {
 		return rf(ctx, path, ref, opts...)
 	}
 	if rf, ok := ret.Get(0).(func(context.Context, string, string, ...WriteResourceOption) string); ok {
@@ -958,13 +980,19 @@ func (_m *MockRepositoryResources) WriteResourceFromFile(ctx context.Context, pa
 		r1 = ret.Get(1).(schema.GroupVersionKind)
 	}
 
-	if rf, ok := ret.Get(2).(func(context.Context, string, string, ...WriteResourceOption) error); ok {
+	if rf, ok := ret.Get(2).(func(context.Context, string, string, ...WriteResourceOption) int); ok {
 		r2 = rf(ctx, path, ref, opts...)
 	} else {
-		r2 = ret.Error(2)
+		r2 = ret.Get(2).(int)
 	}
 
-	return r0, r1, r2
+	if rf, ok := ret.Get(3).(func(context.Context, string, string, ...WriteResourceOption) error); ok {
+		r3 = rf(ctx, path, ref, opts...)
+	} else {
+		r3 = ret.Error(3)
+	}
+
+	return r0, r1, r2, r3
 }
 
 // MockRepositoryResources_WriteResourceFromFile_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'WriteResourceFromFile'
@@ -994,12 +1022,12 @@ func (_c *MockRepositoryResources_WriteResourceFromFile_Call) Run(run func(ctx c
 	return _c
 }
 
-func (_c *MockRepositoryResources_WriteResourceFromFile_Call) Return(_a0 string, _a1 schema.GroupVersionKind, _a2 error) *MockRepositoryResources_WriteResourceFromFile_Call {
-	_c.Call.Return(_a0, _a1, _a2)
+func (_c *MockRepositoryResources_WriteResourceFromFile_Call) Return(_a0 string, _a1 schema.GroupVersionKind, _a2 int, _a3 error) *MockRepositoryResources_WriteResourceFromFile_Call {
+	_c.Call.Return(_a0, _a1, _a2, _a3)
 	return _c
 }
 
-func (_c *MockRepositoryResources_WriteResourceFromFile_Call) RunAndReturn(run func(context.Context, string, string, ...WriteResourceOption) (string, schema.GroupVersionKind, error)) *MockRepositoryResources_WriteResourceFromFile_Call {
+func (_c *MockRepositoryResources_WriteResourceFromFile_Call) RunAndReturn(run func(context.Context, string, string, ...WriteResourceOption) (string, schema.GroupVersionKind, int, error)) *MockRepositoryResources_WriteResourceFromFile_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/registry/apis/provisioning/resources/repository_resources_mock.go
+++ b/pkg/registry/apis/provisioning/resources/repository_resources_mock.go
@@ -465,7 +465,7 @@ func (_c *MockRepositoryResources_RemoveFolderFromTree_Call) RunAndReturn(run fu
 }
 
 // RemoveResourceFromFile provides a mock function with given fields: ctx, path, ref
-func (_m *MockRepositoryResources) RemoveResourceFromFile(ctx context.Context, path string, ref string) (string, string, schema.GroupVersionKind, error) {
+func (_m *MockRepositoryResources) RemoveResourceFromFile(ctx context.Context, path string, ref string) (string, string, schema.GroupVersionKind, int, error) {
 	ret := _m.Called(ctx, path, ref)
 
 	if len(ret) == 0 {
@@ -475,8 +475,9 @@ func (_m *MockRepositoryResources) RemoveResourceFromFile(ctx context.Context, p
 	var r0 string
 	var r1 string
 	var r2 schema.GroupVersionKind
-	var r3 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) (string, string, schema.GroupVersionKind, error)); ok {
+	var r3 int
+	var r4 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) (string, string, schema.GroupVersionKind, int, error)); ok {
 		return rf(ctx, path, ref)
 	}
 	if rf, ok := ret.Get(0).(func(context.Context, string, string) string); ok {
@@ -497,13 +498,19 @@ func (_m *MockRepositoryResources) RemoveResourceFromFile(ctx context.Context, p
 		r2 = ret.Get(2).(schema.GroupVersionKind)
 	}
 
-	if rf, ok := ret.Get(3).(func(context.Context, string, string) error); ok {
+	if rf, ok := ret.Get(3).(func(context.Context, string, string) int); ok {
 		r3 = rf(ctx, path, ref)
 	} else {
-		r3 = ret.Error(3)
+		r3 = ret.Get(3).(int)
 	}
 
-	return r0, r1, r2, r3
+	if rf, ok := ret.Get(4).(func(context.Context, string, string) error); ok {
+		r4 = rf(ctx, path, ref)
+	} else {
+		r4 = ret.Error(4)
+	}
+
+	return r0, r1, r2, r3, r4
 }
 
 // MockRepositoryResources_RemoveResourceFromFile_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemoveResourceFromFile'
@@ -526,18 +533,18 @@ func (_c *MockRepositoryResources_RemoveResourceFromFile_Call) Run(run func(ctx 
 	return _c
 }
 
-func (_c *MockRepositoryResources_RemoveResourceFromFile_Call) Return(_a0 string, _a1 string, _a2 schema.GroupVersionKind, _a3 error) *MockRepositoryResources_RemoveResourceFromFile_Call {
-	_c.Call.Return(_a0, _a1, _a2, _a3)
+func (_c *MockRepositoryResources_RemoveResourceFromFile_Call) Return(_a0 string, _a1 string, _a2 schema.GroupVersionKind, _a3 int, _a4 error) *MockRepositoryResources_RemoveResourceFromFile_Call {
+	_c.Call.Return(_a0, _a1, _a2, _a3, _a4)
 	return _c
 }
 
-func (_c *MockRepositoryResources_RemoveResourceFromFile_Call) RunAndReturn(run func(context.Context, string, string) (string, string, schema.GroupVersionKind, error)) *MockRepositoryResources_RemoveResourceFromFile_Call {
+func (_c *MockRepositoryResources_RemoveResourceFromFile_Call) RunAndReturn(run func(context.Context, string, string) (string, string, schema.GroupVersionKind, int, error)) *MockRepositoryResources_RemoveResourceFromFile_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // RenameResourceFile provides a mock function with given fields: ctx, path, previousRef, newPath, newRef, folderOpts
-func (_m *MockRepositoryResources) RenameResourceFile(ctx context.Context, path string, previousRef string, newPath string, newRef string, folderOpts ...EnsurePathOption) (string, string, schema.GroupVersionKind, error) {
+func (_m *MockRepositoryResources) RenameResourceFile(ctx context.Context, path string, previousRef string, newPath string, newRef string, folderOpts ...EnsurePathOption) (string, string, schema.GroupVersionKind, int, error) {
 	_va := make([]interface{}, len(folderOpts))
 	for _i := range folderOpts {
 		_va[_i] = folderOpts[_i]
@@ -554,8 +561,9 @@ func (_m *MockRepositoryResources) RenameResourceFile(ctx context.Context, path 
 	var r0 string
 	var r1 string
 	var r2 schema.GroupVersionKind
-	var r3 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, ...EnsurePathOption) (string, string, schema.GroupVersionKind, error)); ok {
+	var r3 int
+	var r4 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, ...EnsurePathOption) (string, string, schema.GroupVersionKind, int, error)); ok {
 		return rf(ctx, path, previousRef, newPath, newRef, folderOpts...)
 	}
 	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, ...EnsurePathOption) string); ok {
@@ -576,13 +584,19 @@ func (_m *MockRepositoryResources) RenameResourceFile(ctx context.Context, path 
 		r2 = ret.Get(2).(schema.GroupVersionKind)
 	}
 
-	if rf, ok := ret.Get(3).(func(context.Context, string, string, string, string, ...EnsurePathOption) error); ok {
+	if rf, ok := ret.Get(3).(func(context.Context, string, string, string, string, ...EnsurePathOption) int); ok {
 		r3 = rf(ctx, path, previousRef, newPath, newRef, folderOpts...)
 	} else {
-		r3 = ret.Error(3)
+		r3 = ret.Get(3).(int)
 	}
 
-	return r0, r1, r2, r3
+	if rf, ok := ret.Get(4).(func(context.Context, string, string, string, string, ...EnsurePathOption) error); ok {
+		r4 = rf(ctx, path, previousRef, newPath, newRef, folderOpts...)
+	} else {
+		r4 = ret.Error(4)
+	}
+
+	return r0, r1, r2, r3, r4
 }
 
 // MockRepositoryResources_RenameResourceFile_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RenameResourceFile'
@@ -614,12 +628,12 @@ func (_c *MockRepositoryResources_RenameResourceFile_Call) Run(run func(ctx cont
 	return _c
 }
 
-func (_c *MockRepositoryResources_RenameResourceFile_Call) Return(_a0 string, _a1 string, _a2 schema.GroupVersionKind, _a3 error) *MockRepositoryResources_RenameResourceFile_Call {
-	_c.Call.Return(_a0, _a1, _a2, _a3)
+func (_c *MockRepositoryResources_RenameResourceFile_Call) Return(_a0 string, _a1 string, _a2 schema.GroupVersionKind, _a3 int, _a4 error) *MockRepositoryResources_RenameResourceFile_Call {
+	_c.Call.Return(_a0, _a1, _a2, _a3, _a4)
 	return _c
 }
 
-func (_c *MockRepositoryResources_RenameResourceFile_Call) RunAndReturn(run func(context.Context, string, string, string, string, ...EnsurePathOption) (string, string, schema.GroupVersionKind, error)) *MockRepositoryResources_RenameResourceFile_Call {
+func (_c *MockRepositoryResources_RenameResourceFile_Call) RunAndReturn(run func(context.Context, string, string, string, string, ...EnsurePathOption) (string, string, schema.GroupVersionKind, int, error)) *MockRepositoryResources_RenameResourceFile_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/registry/apis/provisioning/resources/resources.go
+++ b/pkg/registry/apis/provisioning/resources/resources.go
@@ -127,14 +127,17 @@ func (r *ResourcesManager) addResource(id resourceID, path string) {
 }
 
 // CreateResource writes an object to the repository
-func (r *ResourcesManager) WriteResourceFileFromObject(ctx context.Context, obj *unstructured.Unstructured, options WriteOptions) (string, error) {
+// WriteResourceFileFromObject serialises obj and writes it to the repository.
+// The returned size is the number of bytes written, so callers can record how
+// large the exported resource was.
+func (r *ResourcesManager) WriteResourceFileFromObject(ctx context.Context, obj *unstructured.Unstructured, options WriteOptions) (string, int, error) {
 	if err := ctx.Err(); err != nil {
-		return "", fmt.Errorf("context error: %w", err)
+		return "", 0, fmt.Errorf("context error: %w", err)
 	}
 
 	meta, err := utils.MetaAccessor(obj)
 	if err != nil {
-		return "", fmt.Errorf("extract meta accessor: %w", err)
+		return "", 0, fmt.Errorf("extract meta accessor: %w", err)
 	}
 
 	// Message from annotations
@@ -150,7 +153,7 @@ func (r *ResourcesManager) WriteResourceFileFromObject(ctx context.Context, obj 
 
 	name := meta.GetName()
 	if name == "" {
-		return "", ErrMissingName
+		return "", 0, ErrMissingName
 	}
 
 	manager, _ := meta.GetManagerProperties()
@@ -159,7 +162,7 @@ func (r *ResourcesManager) WriteResourceFileFromObject(ctx context.Context, obj 
 	// matching on identity alone would misclassify other manager kinds.
 	if manager.Kind == utils.ManagerKindRepo && manager.Identity == r.repo.Config().GetName() {
 		// If it's already in the repository, we don't need to write it
-		return "", ErrAlreadyInRepository
+		return "", 0, ErrAlreadyInRepository
 	}
 
 	title := meta.FindTitle("")
@@ -184,7 +187,7 @@ func (r *ResourcesManager) WriteResourceFileFromObject(ctx context.Context, obj 
 			// TODO: should we build the tree in a different way?
 			fid, ok = r.folders.Tree().DirPath(folder, "")
 			if !ok {
-				return "", fmt.Errorf("folder %s NOT found in tree", folder)
+				return "", 0, fmt.Errorf("folder %s NOT found in tree", folder)
 			}
 		}
 	}
@@ -202,7 +205,7 @@ func (r *ResourcesManager) WriteResourceFileFromObject(ctx context.Context, obj 
 	// Reject any unsafe path (traversal, absolute, too deep) before it reaches
 	// the backend, using the same validation enforced on the import side.
 	if err := IsPathSupported(fileName); err != nil {
-		return "", fmt.Errorf("unsafe export path %q: %w", fileName, err)
+		return "", 0, fmt.Errorf("unsafe export path %q: %w", fileName, err)
 	}
 
 	parsed := ParsedResource{
@@ -214,15 +217,15 @@ func (r *ResourcesManager) WriteResourceFileFromObject(ctx context.Context, obj 
 	}
 	body, err := parsed.ToSaveBytes()
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 
 	err = r.repo.Write(ctx, fileName, options.Ref, body, commitMessage)
 	if err != nil {
-		return "", fmt.Errorf("failed to write file: %s, %w", fileName, err)
+		return "", 0, fmt.Errorf("failed to write file: %s, %w", fileName, err)
 	}
 
-	return fileName, nil
+	return fileName, len(body), nil
 }
 
 // WriteResourceOption configures optional behavior for resource write operations.
@@ -241,7 +244,10 @@ func WithExistingHash(hash string) WriteResourceOption {
 	}
 }
 
-func (r *ResourcesManager) WriteResourceFromFile(ctx context.Context, path string, ref string, opts ...WriteResourceOption) (string, schema.GroupVersionKind, error) {
+// WriteResourceFromFile reads, parses and writes the resource at path/ref. The
+// returned size is the number of raw bytes read from the repository file, so
+// callers can record how large the written resource was.
+func (r *ResourcesManager) WriteResourceFromFile(ctx context.Context, path string, ref string, opts ...WriteResourceOption) (string, schema.GroupVersionKind, int, error) {
 	var cfg writeResourceConfig
 	for _, o := range opts {
 		o(&cfg)
@@ -253,16 +259,18 @@ func (r *ResourcesManager) WriteResourceFromFile(ctx context.Context, path strin
 	if err != nil {
 		readSpan.RecordError(err)
 		readSpan.End()
-		return "", schema.GroupVersionKind{}, fmt.Errorf("failed to read file: %w", err)
+		return "", schema.GroupVersionKind{}, 0, fmt.Errorf("failed to read file: %w", err)
 	}
 	readSpan.End()
+
+	size := len(fileInfo.Data)
 
 	parseCtx, parseSpan := tracing.Start(ctx, "provisioning.resources.write_resource_from_file.parse_file")
 	parsed, err := r.parser.Parse(parseCtx, fileInfo)
 	if err != nil {
 		parseSpan.RecordError(err)
 		parseSpan.End()
-		return "", schema.GroupVersionKind{}, fmt.Errorf("failed to parse file: %w", err)
+		return "", schema.GroupVersionKind{}, size, fmt.Errorf("failed to parse file: %w", err)
 	}
 	parseSpan.End()
 
@@ -274,7 +282,8 @@ func (r *ResourcesManager) WriteResourceFromFile(ctx context.Context, path strin
 		parsed.SkipStrictValidation = true
 	}
 
-	return r.writeResourceFromParsed(ctx, path, ref, parsed)
+	name, gvk, err := r.writeResourceFromParsed(ctx, path, ref, parsed)
+	return name, gvk, size, err
 }
 
 func (r *ResourcesManager) writeResourceFromParsed(ctx context.Context, path, ref string, parsed *ParsedResource, folderOpts ...EnsurePathOption) (string, schema.GroupVersionKind, error) {
@@ -334,28 +343,28 @@ func (r *ResourcesManager) writeResourceFromParsed(ctx context.Context, path, re
 // ReplaceResourceFromFile writes a resource from file and, if the resource name
 // changed compared to oldName, deletes the old resource to prevent orphans.
 // Used by full sync where the old identity is known from Changes().Existing.
-func (r *ResourcesManager) ReplaceResourceFromFile(ctx context.Context, path, ref string, oldName string, oldGVR schema.GroupVersionResource, opts ...WriteResourceOption) (string, schema.GroupVersionKind, error) {
-	newName, gvk, err := r.WriteResourceFromFile(ctx, path, ref, opts...)
+func (r *ResourcesManager) ReplaceResourceFromFile(ctx context.Context, path, ref string, oldName string, oldGVR schema.GroupVersionResource, opts ...WriteResourceOption) (string, schema.GroupVersionKind, int, error) {
+	newName, gvk, size, err := r.WriteResourceFromFile(ctx, path, ref, opts...)
 	if err != nil || oldName == "" || oldName == newName {
-		return newName, gvk, err
+		return newName, gvk, size, err
 	}
 
-	return newName, gvk, r.deleteOldResource(ctx, path, oldName, oldGVR, newName)
+	return newName, gvk, size, r.deleteOldResource(ctx, path, oldName, oldGVR, newName)
 }
 
 // ReplaceResourceFromFileByRef writes a resource from the file at path/ref and,
 // if the resource identity changed compared to the previous version at
 // path/previousRef, deletes the old resource to prevent orphans.
 // Used by incremental sync where the previous git ref is available.
-func (r *ResourcesManager) ReplaceResourceFromFileByRef(ctx context.Context, path, ref, previousRef string, opts ...WriteResourceOption) (string, schema.GroupVersionKind, error) {
+func (r *ResourcesManager) ReplaceResourceFromFileByRef(ctx context.Context, path, ref, previousRef string, opts ...WriteResourceOption) (string, schema.GroupVersionKind, int, error) {
 	oldInfo, err := r.repo.Read(ctx, path, previousRef)
 	if err != nil {
-		return "", schema.GroupVersionKind{}, fmt.Errorf("reading previous file: %w", err)
+		return "", schema.GroupVersionKind{}, 0, fmt.Errorf("reading previous file: %w", err)
 	}
 
 	oldParsed, err := r.parser.Parse(ctx, oldInfo)
 	if err != nil {
-		return "", schema.GroupVersionKind{}, fmt.Errorf("parsing previous file: %w", err)
+		return "", schema.GroupVersionKind{}, 0, fmt.Errorf("parsing previous file: %w", err)
 	}
 
 	// Inject the previous file's hash so WriteResourceFromFile can skip strict
@@ -363,17 +372,17 @@ func (r *ResourcesManager) ReplaceResourceFromFileByRef(ctx context.Context, pat
 	if oldInfo.Hash != "" {
 		opts = append(opts, WithExistingHash(oldInfo.Hash))
 	}
-	newName, gvk, writeErr := r.WriteResourceFromFile(ctx, path, ref, opts...)
+	newName, gvk, size, writeErr := r.WriteResourceFromFile(ctx, path, ref, opts...)
 	if writeErr != nil {
-		return newName, gvk, writeErr
+		return newName, gvk, size, writeErr
 	}
 
 	oldName := oldParsed.Obj.GetName()
 	if oldName == "" || oldName == newName {
-		return newName, gvk, nil
+		return newName, gvk, size, nil
 	}
 
-	return newName, gvk, r.deleteOldResource(ctx, path, oldName, oldParsed.GVR, newName)
+	return newName, gvk, size, r.deleteOldResource(ctx, path, oldName, oldParsed.GVR, newName)
 }
 
 // deleteOldResource deletes the previous resource when a name change is

--- a/pkg/registry/apis/provisioning/resources/resources.go
+++ b/pkg/registry/apis/provisioning/resources/resources.go
@@ -222,7 +222,10 @@ func (r *ResourcesManager) WriteResourceFileFromObject(ctx context.Context, obj 
 
 	err = r.repo.Write(ctx, fileName, options.Ref, body, commitMessage)
 	if err != nil {
-		return "", 0, fmt.Errorf("failed to write file: %s, %w", fileName, err)
+		// The body was already serialized, so report its size even on failure:
+		// this lets the bytes metric's outcome=error series surface size-related
+		// write rejections (e.g. an oversized resource exceeding a backend limit).
+		return "", len(body), fmt.Errorf("failed to write file: %s, %w", fileName, err)
 	}
 
 	return fileName, len(body), nil

--- a/pkg/registry/apis/provisioning/resources/resources.go
+++ b/pkg/registry/apis/provisioning/resources/resources.go
@@ -433,23 +433,26 @@ func (r *ResourcesManager) deleteOldResource(ctx context.Context, sourcePath, ol
 	return nil
 }
 
-func (r *ResourcesManager) RenameResourceFile(ctx context.Context, previousPath, previousRef, newPath, newRef string, folderOpts ...EnsurePathOption) (string, string, schema.GroupVersionKind, error) {
+// RenameResourceFile moves the resource at previousPath to newPath. The returned
+// size is the number of bytes of the new file content written at newPath.
+func (r *ResourcesManager) RenameResourceFile(ctx context.Context, previousPath, previousRef, newPath, newRef string, folderOpts ...EnsurePathOption) (string, string, schema.GroupVersionKind, int, error) {
 	oldInfo, err := r.repo.Read(ctx, previousPath, previousRef)
 	if err != nil {
-		return "", "", schema.GroupVersionKind{}, fmt.Errorf("failed to read previous file: %w", err)
+		return "", "", schema.GroupVersionKind{}, 0, fmt.Errorf("failed to read previous file: %w", err)
 	}
 	oldParsed, err := r.parser.Parse(ctx, oldInfo)
 	if err != nil {
-		return "", "", schema.GroupVersionKind{}, fmt.Errorf("failed to parse previous file: %w", err)
+		return "", "", schema.GroupVersionKind{}, 0, fmt.Errorf("failed to parse previous file: %w", err)
 	}
 
 	newInfo, err := r.repo.Read(ctx, newPath, newRef)
 	if err != nil {
-		return "", "", schema.GroupVersionKind{}, fmt.Errorf("failed to read new file: %w", err)
+		return "", "", schema.GroupVersionKind{}, 0, fmt.Errorf("failed to read new file: %w", err)
 	}
+	size := len(newInfo.Data)
 	newParsed, err := r.parser.Parse(ctx, newInfo)
 	if err != nil {
-		return "", "", schema.GroupVersionKind{}, fmt.Errorf("failed to parse new file: %w", err)
+		return "", "", schema.GroupVersionKind{}, size, fmt.Errorf("failed to parse new file: %w", err)
 	}
 
 	// Delete the old resource when the identity changed (name or resource kind).
@@ -457,14 +460,14 @@ func (r *ResourcesManager) RenameResourceFile(ctx context.Context, previousPath,
 	if !oldParsed.SameIdentity(newParsed) {
 		oldParsed.Action = provisioning.ResourceActionDelete
 		if err := oldParsed.Run(ctx); err != nil {
-			return oldParsed.Obj.GetName(), oldParsed.ExistingFolder(), oldParsed.GVK, fmt.Errorf("failed to delete old resource: %w", err)
+			return oldParsed.Obj.GetName(), oldParsed.ExistingFolder(), oldParsed.GVK, size, fmt.Errorf("failed to delete old resource: %w", err)
 		}
 	} else {
 		// Delete dry-run fetches the existing object (with ownership validation)
 		// without mutating it, populating oldParsed.Existing for identity comparison.
 		oldParsed.Action = provisioning.ResourceActionDelete
 		if err := oldParsed.DryRun(ctx); err != nil {
-			return "", "", schema.GroupVersionKind{}, err
+			return "", "", schema.GroupVersionKind{}, size, err
 		}
 		// Pure path-only rename (git blob hash unchanged): the file content is
 		// byte-identical, so the UPDATE we are about to send carries the same
@@ -484,7 +487,7 @@ func (r *ResourcesManager) RenameResourceFile(ctx context.Context, previousPath,
 
 	newName, gvk, err := r.writeResourceFromParsed(ctx, newPath, newRef, newParsed, folderOpts...)
 	if err != nil {
-		return oldParsed.Obj.GetName(), oldFolderName, gvk, fmt.Errorf("failed to write resource: %w", err)
+		return oldParsed.Obj.GetName(), oldFolderName, gvk, size, fmt.Errorf("failed to write resource: %w", err)
 	}
 
 	// When the resource's parent folder didn't change (e.g. the entire
@@ -495,18 +498,22 @@ func (r *ResourcesManager) RenameResourceFile(ctx context.Context, previousPath,
 		oldFolderName = ""
 	}
 
-	return newName, oldFolderName, gvk, nil
+	return newName, oldFolderName, gvk, size, nil
 }
 
-func (r *ResourcesManager) RemoveResourceFromFile(ctx context.Context, path string, ref string) (string, string, schema.GroupVersionKind, error) {
+// RemoveResourceFromFile deletes the resource described by the file at path/ref.
+// The returned size is the number of bytes of the removed file's content.
+func (r *ResourcesManager) RemoveResourceFromFile(ctx context.Context, path string, ref string) (string, string, schema.GroupVersionKind, int, error) {
 	info, err := r.repo.Read(ctx, path, ref)
 	if err != nil {
-		return "", "", schema.GroupVersionKind{}, fmt.Errorf("failed to read file: %w", err)
+		return "", "", schema.GroupVersionKind{}, 0, fmt.Errorf("failed to read file: %w", err)
 	}
+
+	size := len(info.Data)
 
 	parsed, err := r.parser.Parse(ctx, info)
 	if err != nil {
-		return "", "", schema.GroupVersionKind{}, err
+		return "", "", schema.GroupVersionKind{}, size, err
 	}
 
 	parsed.Action = provisioning.ResourceActionDelete
@@ -517,8 +524,8 @@ func (r *ResourcesManager) RemoveResourceFromFile(ctx context.Context, path stri
 	folderName := parsed.ExistingFolder()
 
 	if err != nil {
-		return objName, folderName, parsed.GVK, fmt.Errorf("failed to delete: %w", err)
+		return objName, folderName, parsed.GVK, size, fmt.Errorf("failed to delete: %w", err)
 	}
 
-	return objName, folderName, parsed.GVK, nil
+	return objName, folderName, parsed.GVK, size, nil
 }

--- a/pkg/registry/apis/provisioning/resources/resources_remove_test.go
+++ b/pkg/registry/apis/provisioning/resources/resources_remove_test.go
@@ -685,7 +685,7 @@ func TestWriteResourceFromFile_ExistingHashSkipsValidation(t *testing.T) {
 			Return(obj, nil)
 
 		mgr := NewResourcesManager(repo, nil, mockParser, emptyClients(t))
-		name, _, err := mgr.WriteResourceFromFile(context.Background(), "folder/resource.json", "ref", WithExistingHash("content-hash"))
+		name, _, _, err := mgr.WriteResourceFromFile(context.Background(), "folder/resource.json", "ref", WithExistingHash("content-hash"))
 
 		require.NoError(t, err)
 		require.Equal(t, "my-resource", name)
@@ -698,7 +698,7 @@ func TestWriteResourceFromFile_ExistingHashSkipsValidation(t *testing.T) {
 			Return(obj, nil)
 
 		mgr := NewResourcesManager(repo, nil, mockParser, emptyClients(t))
-		name, _, err := mgr.WriteResourceFromFile(context.Background(), "folder/resource.json", "ref", WithExistingHash("old-hash"))
+		name, _, _, err := mgr.WriteResourceFromFile(context.Background(), "folder/resource.json", "ref", WithExistingHash("old-hash"))
 
 		require.NoError(t, err)
 		require.Equal(t, "my-resource", name)
@@ -711,7 +711,7 @@ func TestWriteResourceFromFile_ExistingHashSkipsValidation(t *testing.T) {
 			Return(obj, nil)
 
 		mgr := NewResourcesManager(repo, nil, mockParser, emptyClients(t))
-		name, _, err := mgr.WriteResourceFromFile(context.Background(), "folder/resource.json", "ref")
+		name, _, _, err := mgr.WriteResourceFromFile(context.Background(), "folder/resource.json", "ref")
 
 		require.NoError(t, err)
 		require.Equal(t, "my-resource", name)
@@ -724,7 +724,7 @@ func TestWriteResourceFromFile_ExistingHashSkipsValidation(t *testing.T) {
 			Return(obj, nil)
 
 		mgr := NewResourcesManager(repo, nil, mockParser, emptyClients(t))
-		name, _, err := mgr.WriteResourceFromFile(context.Background(), "folder/resource.json", "ref", WithExistingHash(""))
+		name, _, _, err := mgr.WriteResourceFromFile(context.Background(), "folder/resource.json", "ref", WithExistingHash(""))
 
 		require.NoError(t, err)
 		require.Equal(t, "my-resource", name)
@@ -790,7 +790,7 @@ func TestReplaceResourceFromFileByRef_HashComparison(t *testing.T) {
 			Return(newObj, nil)
 
 		mgr := NewResourcesManager(repo, nil, mockParser, emptyClients(t))
-		name, _, err := mgr.ReplaceResourceFromFileByRef(context.Background(), "resource.json", "new-ref", "old-ref")
+		name, _, _, err := mgr.ReplaceResourceFromFileByRef(context.Background(), "resource.json", "new-ref", "old-ref")
 
 		require.NoError(t, err)
 		require.Equal(t, "my-resource", name)
@@ -803,7 +803,7 @@ func TestReplaceResourceFromFileByRef_HashComparison(t *testing.T) {
 			Return(newObj, nil)
 
 		mgr := NewResourcesManager(repo, nil, mockParser, emptyClients(t))
-		name, _, err := mgr.ReplaceResourceFromFileByRef(context.Background(), "resource.json", "new-ref", "old-ref")
+		name, _, _, err := mgr.ReplaceResourceFromFileByRef(context.Background(), "resource.json", "new-ref", "old-ref")
 
 		require.NoError(t, err)
 		require.Equal(t, "my-resource", name)
@@ -816,7 +816,7 @@ func TestReplaceResourceFromFileByRef_HashComparison(t *testing.T) {
 			Return(newObj, nil)
 
 		mgr := NewResourcesManager(repo, nil, mockParser, emptyClients(t))
-		name, _, err := mgr.ReplaceResourceFromFileByRef(context.Background(), "resource.json", "new-ref", "old-ref")
+		name, _, _, err := mgr.ReplaceResourceFromFileByRef(context.Background(), "resource.json", "new-ref", "old-ref")
 
 		require.NoError(t, err)
 		require.Equal(t, "my-resource", name)
@@ -859,7 +859,7 @@ func TestReplaceResourceFromFile_PassesExistingHash(t *testing.T) {
 		Return(obj, nil)
 
 	mgr := NewResourcesManager(repo, nil, mockParser, emptyClients(t))
-	name, _, err := mgr.ReplaceResourceFromFile(context.Background(), "resource.json", "ref", "my-resource", fakeGVR, WithExistingHash("matching-hash"))
+	name, _, _, err := mgr.ReplaceResourceFromFile(context.Background(), "resource.json", "ref", "my-resource", fakeGVR, WithExistingHash("matching-hash"))
 
 	require.NoError(t, err)
 	require.Equal(t, "my-resource", name)

--- a/pkg/registry/apis/provisioning/resources/resources_remove_test.go
+++ b/pkg/registry/apis/provisioning/resources/resources_remove_test.go
@@ -77,7 +77,7 @@ func TestRemoveResourceFromFile(t *testing.T) {
 		mockClient.On("Delete", mock.Anything, "my-dashboard", metav1.DeleteOptions{}, mock.Anything).Return(nil)
 
 		mgr := NewResourcesManager(repo, nil, mockParser, emptyClients(t))
-		name, folderName, gvk, err := mgr.RemoveResourceFromFile(context.Background(), "dashboards/my-dashboard.json", "abc123")
+		name, folderName, gvk, _, err := mgr.RemoveResourceFromFile(context.Background(), "dashboards/my-dashboard.json", "abc123")
 
 		require.NoError(t, err)
 		require.Equal(t, "my-dashboard", name)
@@ -96,7 +96,7 @@ func TestRemoveResourceFromFile(t *testing.T) {
 			Return(nil, NewResourceValidationError(errors.New("cannot declare folders through files")))
 
 		mgr := NewResourcesManager(repo, nil, mockParser, emptyClients(t))
-		_, _, _, err := mgr.RemoveResourceFromFile(context.Background(), "folders/my-folder.json", "abc123")
+		_, _, _, _, err := mgr.RemoveResourceFromFile(context.Background(), "folders/my-folder.json", "abc123")
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "cannot declare folders through files")
@@ -116,7 +116,7 @@ func TestRemoveResourceFromFile(t *testing.T) {
 			Return(nil, NewResourceValidationError(fmt.Errorf("file does not contain a valid resource")))
 
 		mgr := NewResourcesManager(repo, nil, mockParser, emptyClients(t))
-		_, _, _, err := mgr.RemoveResourceFromFile(context.Background(), "config/settings.json", "abc123")
+		_, _, _, _, err := mgr.RemoveResourceFromFile(context.Background(), "config/settings.json", "abc123")
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "file does not contain a valid resource")
@@ -133,7 +133,7 @@ func TestRemoveResourceFromFile(t *testing.T) {
 			Return((*repository.FileInfo)(nil), repository.ErrFileNotFound)
 
 		mgr := NewResourcesManager(repo, nil, mockParser, emptyClients(t))
-		_, _, _, err := mgr.RemoveResourceFromFile(context.Background(), "dashboards/missing.json", "abc123")
+		_, _, _, _, err := mgr.RemoveResourceFromFile(context.Background(), "dashboards/missing.json", "abc123")
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to read file")
@@ -163,7 +163,7 @@ func TestRemoveResourceFromFile(t *testing.T) {
 			Return(nil, apierrors.NewNotFound(schema.GroupResource{}, "deleted-dashboard"))
 
 		mgr := NewResourcesManager(repo, nil, mockParser, emptyClients(t))
-		name, _, gvk, err := mgr.RemoveResourceFromFile(context.Background(), "dashboards/deleted.json", "abc123")
+		name, _, gvk, _, err := mgr.RemoveResourceFromFile(context.Background(), "dashboards/deleted.json", "abc123")
 
 		require.NoError(t, err)
 		require.Equal(t, "deleted-dashboard", name)
@@ -198,7 +198,7 @@ func TestRemoveResourceFromFile(t *testing.T) {
 			Return(fmt.Errorf("Folder cannot be deleted: folder is not empty"))
 
 		mgr := NewResourcesManager(repo, nil, mockParser, emptyClients(t))
-		name, folderName, gvk, err := mgr.RemoveResourceFromFile(context.Background(), "dashboards/fail.json", "abc123")
+		name, folderName, gvk, _, err := mgr.RemoveResourceFromFile(context.Background(), "dashboards/fail.json", "abc123")
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to delete")
@@ -260,7 +260,7 @@ func TestRenameResourceFile(t *testing.T) {
 		mockClient.On("Get", mock.Anything, "same-uid", metav1.GetOptions{}, mock.Anything).Return(grafanaObj, nil)
 
 		mgr := NewResourcesManager(repo, nil, mockParser, emptyClients(t))
-		_, folderName, _, err := mgr.RenameResourceFile(context.Background(), "old-path/dash.json", "old-ref", "new-path/dash.json", "new-ref")
+		_, folderName, _, _, err := mgr.RenameResourceFile(context.Background(), "old-path/dash.json", "old-ref", "new-path/dash.json", "new-ref")
 
 		require.Error(t, err, "write step is expected to fail (no client)")
 		require.Contains(t, err.Error(), "failed to write resource")
@@ -315,7 +315,7 @@ func TestRenameResourceFile(t *testing.T) {
 		mockClient.On("Delete", mock.Anything, "old-uid", metav1.DeleteOptions{}, mock.Anything).Return(nil)
 
 		mgr := NewResourcesManager(repo, nil, mockParser, emptyClients(t))
-		_, folderName, _, err := mgr.RenameResourceFile(context.Background(), "old-path/dash.json", "old-ref", "new-path/dash.json", "new-ref")
+		_, folderName, _, _, err := mgr.RenameResourceFile(context.Background(), "old-path/dash.json", "old-ref", "new-path/dash.json", "new-ref")
 
 		require.Error(t, err, "write step fails (no client)")
 		require.Contains(t, err.Error(), "failed to write resource")
@@ -350,7 +350,7 @@ func TestRenameResourceFile(t *testing.T) {
 			Return(nil, fmt.Errorf("invalid json"))
 
 		mgr := NewResourcesManager(repo, nil, mockParser, emptyClients(t))
-		_, _, _, err := mgr.RenameResourceFile(context.Background(), "old-path/dash.json", "old-ref", "new-path/dash.json", "new-ref")
+		_, _, _, _, err := mgr.RenameResourceFile(context.Background(), "old-path/dash.json", "old-ref", "new-path/dash.json", "new-ref")
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to parse new file")
@@ -366,7 +366,7 @@ func TestRenameResourceFile(t *testing.T) {
 			Return((*repository.FileInfo)(nil), repository.ErrFileNotFound)
 
 		mgr := NewResourcesManager(repo, nil, mockParser, emptyClients(t))
-		_, _, _, err := mgr.RenameResourceFile(context.Background(), "old-path/dash.json", "old-ref", "new-path/dash.json", "new-ref")
+		_, _, _, _, err := mgr.RenameResourceFile(context.Background(), "old-path/dash.json", "old-ref", "new-path/dash.json", "new-ref")
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to read previous file")
@@ -412,7 +412,7 @@ func TestRenameResourceFile(t *testing.T) {
 			Return(nil, apierrors.NewNotFound(schema.GroupResource{}, "dash-uid"))
 
 		mgr := NewResourcesManager(repo, nil, mockParser, emptyClients(t))
-		_, folderName, _, err := mgr.RenameResourceFile(context.Background(), "old-path/dash.json", "old-ref", "new-path/dash.json", "new-ref")
+		_, folderName, _, _, err := mgr.RenameResourceFile(context.Background(), "old-path/dash.json", "old-ref", "new-path/dash.json", "new-ref")
 
 		require.Error(t, err, "write step fails (no client on newParsed)")
 		require.Contains(t, err.Error(), "failed to write resource")
@@ -474,7 +474,7 @@ func TestRenameResourceFile(t *testing.T) {
 		dashClient.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(newObj, nil)
 
 		mgr := NewResourcesManager(repo, folderMgr, mockParser, authTestClients(t))
-		name, folderName, gvk, err := mgr.RenameResourceFile(context.Background(), "team/old-dash.json", "old-ref", "team/new-dash.json", "new-ref")
+		name, folderName, gvk, _, err := mgr.RenameResourceFile(context.Background(), "team/old-dash.json", "old-ref", "team/new-dash.json", "new-ref")
 
 		require.NoError(t, err)
 		require.Equal(t, "dash-uid", name)
@@ -537,7 +537,7 @@ func TestRenameResourceFile(t *testing.T) {
 		dashClient.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(newObj, nil)
 
 		mgr := NewResourcesManager(repo, folderMgr, mockParser, authTestClients(t))
-		name, folderName, gvk, err := mgr.RenameResourceFile(context.Background(), "a-team/dash.json", "old-ref", "b-team/dash.json", "new-ref")
+		name, folderName, gvk, _, err := mgr.RenameResourceFile(context.Background(), "a-team/dash.json", "old-ref", "b-team/dash.json", "new-ref")
 
 		require.NoError(t, err)
 		require.Equal(t, "dash-uid", name)
@@ -603,7 +603,7 @@ func TestRenameResourceFile(t *testing.T) {
 			Return(newObj, nil)
 
 		mgr := NewResourcesManager(repo, nil, mockParser, emptyClients(t))
-		name, _, _, err := mgr.RenameResourceFile(context.Background(), "old/x.json", "old-ref", "new/x.json", "new-ref")
+		name, _, _, _, err := mgr.RenameResourceFile(context.Background(), "old/x.json", "old-ref", "new/x.json", "new-ref")
 
 		require.NoError(t, err)
 		require.Equal(t, "same-name", name)
@@ -617,7 +617,7 @@ func TestRenameResourceFile(t *testing.T) {
 			Return(newObj, nil)
 
 		mgr := NewResourcesManager(repo, nil, mockParser, emptyClients(t))
-		name, _, _, err := mgr.RenameResourceFile(context.Background(), "old/x.json", "old-ref", "new/x.json", "new-ref")
+		name, _, _, _, err := mgr.RenameResourceFile(context.Background(), "old/x.json", "old-ref", "new/x.json", "new-ref")
 
 		require.NoError(t, err)
 		require.Equal(t, "same-name", name)
@@ -633,7 +633,7 @@ func TestRenameResourceFile(t *testing.T) {
 			Return(newObj, nil)
 
 		mgr := NewResourcesManager(repo, nil, mockParser, emptyClients(t))
-		name, _, _, err := mgr.RenameResourceFile(context.Background(), "old/x.json", "old-ref", "new/x.json", "new-ref")
+		name, _, _, _, err := mgr.RenameResourceFile(context.Background(), "old/x.json", "old-ref", "new/x.json", "new-ref")
 
 		require.NoError(t, err)
 		require.Equal(t, "same-name", name)

--- a/pkg/registry/apis/provisioning/resources/resources_test.go
+++ b/pkg/registry/apis/provisioning/resources/resources_test.go
@@ -98,6 +98,37 @@ func TestWriteResourceFileFromObject_RejectsPathTraversal(t *testing.T) {
 	require.ErrorIs(t, err, safepath.ErrPathTraversalAttempt)
 }
 
+func TestWriteResourceFileFromObject_PreservesSizeOnWriteError(t *testing.T) {
+	// The body is serialized before repo.Write is called, so a write failure
+	// (e.g. an oversized resource rejected by the backend) must still report the
+	// real size — that is what lets the bytes metric's outcome=error series
+	// expose size-related failures instead of hiding them behind bytes=0.
+	repo := repository.NewMockReaderWriter(t)
+	repo.On("Config").Return(replaceRepoConfig())
+
+	// No folder set → resolves to the (empty) root folder, so no tree lookup runs.
+	folderMgr := NewFolderManager(repo, nil, NewEmptyFolderTree(), FolderKind)
+	mgr := NewResourcesManager(repo, folderMgr, nil, NewMockResourceClients(t))
+
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "dashboard.grafana.app/v1beta1",
+		"kind":       "Dashboard",
+		"metadata":   map[string]any{"name": "dash-1"},
+	}}
+
+	var writtenBody []byte
+	repo.On("Write", mock.Anything, "dash-1.json", "", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			writtenBody = args.Get(3).([]byte)
+		}).
+		Return(fmt.Errorf("resource too large"))
+
+	_, size, err := mgr.WriteResourceFileFromObject(context.Background(), obj, WriteOptions{})
+	require.Error(t, err)
+	require.Positive(t, size, "size should be reported even when the write fails")
+	require.Equal(t, len(writtenBody), size, "reported size must match the serialized body length")
+}
+
 func TestWriteResourceFromParsed_FolderAnnotation(t *testing.T) {
 	// replaceTestGVR (alertrules) is used as the resource under test; whether it
 	// carries the folder annotation is driven entirely by what the clients report

--- a/pkg/registry/apis/provisioning/resources/resources_test.go
+++ b/pkg/registry/apis/provisioning/resources/resources_test.go
@@ -93,7 +93,7 @@ func TestWriteResourceFileFromObject_RejectsPathTraversal(t *testing.T) {
 	require.NoError(t, err)
 	meta.SetFolder("evil")
 
-	_, err = mgr.WriteResourceFileFromObject(context.Background(), obj, WriteOptions{})
+	_, _, err = mgr.WriteResourceFileFromObject(context.Background(), obj, WriteOptions{})
 	require.Error(t, err)
 	require.ErrorIs(t, err, safepath.ErrPathTraversalAttempt)
 }
@@ -121,7 +121,7 @@ func TestWriteResourceFromParsed_FolderAnnotation(t *testing.T) {
 		// would dereference the nil FolderManager and panic, so a clean run proves
 		// the branch was skipped.
 		mgr := NewResourcesManager(repo, nil, mockParser, clients)
-		_, _, err := mgr.WriteResourceFromFile(context.Background(), "alerts/rule.json", "")
+		_, _, _, err := mgr.WriteResourceFromFile(context.Background(), "alerts/rule.json", "")
 
 		require.NoError(t, err)
 		require.Empty(t, parsed.Meta.GetFolder(), "no folder annotation should be written for a resource that does not support folders")
@@ -151,7 +151,7 @@ func TestWriteResourceFromParsed_FolderAnnotation(t *testing.T) {
 
 		folderMgr := NewFolderManager(repo, nil, NewEmptyFolderTree(), FolderKind)
 		mgr := NewResourcesManager(repo, folderMgr, mockParser, clients)
-		_, _, err := mgr.WriteResourceFromFile(context.Background(), "rule.json", "")
+		_, _, _, err := mgr.WriteResourceFromFile(context.Background(), "rule.json", "")
 
 		require.NoError(t, err)
 		require.Equal(t, RootFolder(config), parsed.Meta.GetFolder(), "the resource should be annotated with the resolved folder")
@@ -169,7 +169,7 @@ func TestReplaceResourceFromFile(t *testing.T) {
 		mockParser.On("Parse", mock.Anything, fileInfo).Return(parsed, nil)
 
 		mgr := NewResourcesManager(repo, nil, mockParser, emptyClients(t))
-		name, gvk, err := mgr.ReplaceResourceFromFile(context.Background(), "alerts/rule.json", "", "same-uid", replaceTestGVR)
+		name, gvk, _, err := mgr.ReplaceResourceFromFile(context.Background(), "alerts/rule.json", "", "same-uid", replaceTestGVR)
 
 		require.NoError(t, err)
 		require.Equal(t, "same-uid", name)
@@ -186,7 +186,7 @@ func TestReplaceResourceFromFile(t *testing.T) {
 		mockParser.On("Parse", mock.Anything, fileInfo).Return(parsed, nil)
 
 		mgr := NewResourcesManager(repo, nil, mockParser, emptyClients(t))
-		name, gvk, err := mgr.ReplaceResourceFromFile(context.Background(), "alerts/rule.json", "", "", replaceTestGVR)
+		name, gvk, _, err := mgr.ReplaceResourceFromFile(context.Background(), "alerts/rule.json", "", "", replaceTestGVR)
 
 		require.NoError(t, err)
 		require.Equal(t, "new-uid", name)
@@ -212,7 +212,7 @@ func TestReplaceResourceFromFile(t *testing.T) {
 		deleteClient.On("Delete", mock.Anything, "old-uid", metav1.DeleteOptions{}, mock.Anything).Return(nil)
 
 		mgr := NewResourcesManager(repo, nil, mockParser, mockClients)
-		name, gvk, err := mgr.ReplaceResourceFromFile(context.Background(), "alerts/rule.json", "", "old-uid", replaceTestGVR)
+		name, gvk, _, err := mgr.ReplaceResourceFromFile(context.Background(), "alerts/rule.json", "", "old-uid", replaceTestGVR)
 
 		require.NoError(t, err)
 		require.Equal(t, "new-uid", name)
@@ -228,7 +228,7 @@ func TestReplaceResourceFromFile(t *testing.T) {
 			Return((*repository.FileInfo)(nil), fmt.Errorf("file not found"))
 
 		mgr := NewResourcesManager(repo, nil, mockParser, emptyClients(t))
-		_, _, err := mgr.ReplaceResourceFromFile(context.Background(), "alerts/rule.json", "", "old-uid", replaceTestGVR)
+		_, _, _, err := mgr.ReplaceResourceFromFile(context.Background(), "alerts/rule.json", "", "old-uid", replaceTestGVR)
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to read file")
@@ -254,7 +254,7 @@ func TestReplaceResourceFromFile(t *testing.T) {
 			Return(fmt.Errorf("forbidden"))
 
 		mgr := NewResourcesManager(repo, nil, mockParser, mockClients)
-		name, gvk, err := mgr.ReplaceResourceFromFile(context.Background(), "alerts/rule.json", "", "old-uid", replaceTestGVR)
+		name, gvk, _, err := mgr.ReplaceResourceFromFile(context.Background(), "alerts/rule.json", "", "old-uid", replaceTestGVR)
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to delete old resource old-uid")
@@ -276,7 +276,7 @@ func TestReplaceResourceFromFile(t *testing.T) {
 			Return(nil, schema.GroupVersionKind{}, fmt.Errorf("unknown resource"))
 
 		mgr := NewResourcesManager(repo, nil, mockParser, mockClients)
-		name, _, err := mgr.ReplaceResourceFromFile(context.Background(), "alerts/rule.json", "", "old-uid", replaceTestGVR)
+		name, _, _, err := mgr.ReplaceResourceFromFile(context.Background(), "alerts/rule.json", "", "old-uid", replaceTestGVR)
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to delete old resource old-uid")
@@ -300,7 +300,7 @@ func TestReplaceResourceFromFileByRef(t *testing.T) {
 		mockParser.On("Parse", mock.Anything, newFileInfo).Return(newParsed, nil)
 
 		mgr := NewResourcesManager(repo, nil, mockParser, emptyClients(t))
-		name, gvk, err := mgr.ReplaceResourceFromFileByRef(context.Background(), "alerts/rule.json", "new-ref", "old-ref")
+		name, gvk, _, err := mgr.ReplaceResourceFromFileByRef(context.Background(), "alerts/rule.json", "new-ref", "old-ref")
 
 		require.NoError(t, err)
 		require.Equal(t, "same-uid", name)
@@ -331,7 +331,7 @@ func TestReplaceResourceFromFileByRef(t *testing.T) {
 		deleteClient.On("Delete", mock.Anything, "old-uid", metav1.DeleteOptions{}, mock.Anything).Return(nil)
 
 		mgr := NewResourcesManager(repo, nil, mockParser, mockClients)
-		name, gvk, err := mgr.ReplaceResourceFromFileByRef(context.Background(), "alerts/rule.json", "new-ref", "old-ref")
+		name, gvk, _, err := mgr.ReplaceResourceFromFileByRef(context.Background(), "alerts/rule.json", "new-ref", "old-ref")
 
 		require.NoError(t, err)
 		require.Equal(t, "new-uid", name)
@@ -347,7 +347,7 @@ func TestReplaceResourceFromFileByRef(t *testing.T) {
 			Return((*repository.FileInfo)(nil), fmt.Errorf("ref not found"))
 
 		mgr := NewResourcesManager(repo, nil, mockParser, emptyClients(t))
-		_, _, err := mgr.ReplaceResourceFromFileByRef(context.Background(), "alerts/rule.json", "new-ref", "old-ref")
+		_, _, _, err := mgr.ReplaceResourceFromFileByRef(context.Background(), "alerts/rule.json", "new-ref", "old-ref")
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "reading previous file")
@@ -363,7 +363,7 @@ func TestReplaceResourceFromFileByRef(t *testing.T) {
 			Return(nil, fmt.Errorf("invalid JSON"))
 
 		mgr := NewResourcesManager(repo, nil, mockParser, emptyClients(t))
-		_, _, err := mgr.ReplaceResourceFromFileByRef(context.Background(), "alerts/rule.json", "new-ref", "old-ref")
+		_, _, _, err := mgr.ReplaceResourceFromFileByRef(context.Background(), "alerts/rule.json", "new-ref", "old-ref")
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "parsing previous file")
@@ -382,7 +382,7 @@ func TestReplaceResourceFromFileByRef(t *testing.T) {
 		mockParser.On("Parse", mock.Anything, oldFileInfo).Return(oldParsed, nil)
 
 		mgr := NewResourcesManager(repo, nil, mockParser, emptyClients(t))
-		_, _, err := mgr.ReplaceResourceFromFileByRef(context.Background(), "alerts/rule.json", "new-ref", "old-ref")
+		_, _, _, err := mgr.ReplaceResourceFromFileByRef(context.Background(), "alerts/rule.json", "new-ref", "old-ref")
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to read file")
@@ -413,7 +413,7 @@ func TestReplaceResourceFromFileByRef(t *testing.T) {
 			Return(fmt.Errorf("forbidden"))
 
 		mgr := NewResourcesManager(repo, nil, mockParser, mockClients)
-		name, gvk, err := mgr.ReplaceResourceFromFileByRef(context.Background(), "alerts/rule.json", "new-ref", "old-ref")
+		name, gvk, _, err := mgr.ReplaceResourceFromFileByRef(context.Background(), "alerts/rule.json", "new-ref", "old-ref")
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to delete old resource old-uid")
@@ -436,7 +436,7 @@ func TestReplaceResourceFromFileByRef(t *testing.T) {
 		mockParser.On("Parse", mock.Anything, newFileInfo).Return(newParsed, nil)
 
 		mgr := NewResourcesManager(repo, nil, mockParser, emptyClients(t))
-		name, _, err := mgr.ReplaceResourceFromFileByRef(context.Background(), "alerts/rule.json", "new-ref", "old-ref")
+		name, _, _, err := mgr.ReplaceResourceFromFileByRef(context.Background(), "alerts/rule.json", "new-ref", "old-ref")
 
 		require.NoError(t, err)
 		require.Equal(t, "new-uid", name)


### PR DESCRIPTION
## What
Adds a histogram tracking the size in bytes of individual resources read/written during provisioning job runs, and includes that size on the per-resource log line.

New metric: `grafana_provisioning_jobs_resource_operation_bytes` — histogram, labels `action, operation, outcome, group, kind`.

## Why
The recently added `..._resource_operation_duration_seconds` metric (#131240) captures per-resource latency, but nothing captured how *large* each resource is. Byte size makes big writes visible and lets latency be correlated with resource size per kind/outcome — useful for spotting oversized dashboards and understanding slow operations.

## How
- The size is sourced from the real content at the operation chokepoints (no extra reads); every `RepositoryResources` method that reads or writes a resource file now returns the byte count:
  - `WriteResourceFromFile` / `ReplaceResourceFromFile` / `ReplaceResourceFromFileByRef` → bytes read from the repo file (`len(fileInfo.Data)`) — full & incremental sync creates/updates/replaces.
  - `RenameResourceFile` → bytes of the new content written at the destination — incremental rename.
  - `RemoveResourceFromFile` → bytes of the removed file's content — incremental file-based delete.
  - `WriteResourceFileFromObject` → bytes written (`len(body)`) — export path.
- The result builder stamps the size via a new `WithBytes(n)`; the progress recorder observes it in the new histogram from the existing `RecordResourceOperation` chokepoint, right next to the duration observation, so both stay consistent.
- Operations with no file body report 0 and are excluded from the histogram, matching how the duration metric gates its observations.
- `bytes` added to the per-resource log line alongside `duration`.
- Buckets: 512B → 32MB, leaving headroom past the ~20MB range as resources grow.

Stacked conceptually on #131240 (now merged to `main`); this mirrors that metric's shape and plumbing.

## Scope / what is intentionally excluded
- **Full-sync deletes** act on the cluster object using the existing reference and never read the file, so they report 0 and are excluded. (Incremental deletes go through `RemoveResourceFromFile`, which does read the file, so they are sized.)
- **Folder tree operations** (`EnsureFolderPathExist`, `RenameFolderPath`, `EnsureFolderExists`, `RemoveFolder`, `EnsureFolderTreeExists`) are not instrumented on purpose:
  - They operate on the cluster folder object, which has no file body.
  - `EnsureFolderPathExist` only reads `_folder.json` when folder metadata is enabled, and a single call reads 0..N files during its ancestor walk while recording just one result — so there is no single, unambiguous size to attribute.
  - `_folder.json` files are tiny and near-constant, so a `Folder` series would add cardinality with no real signal.
  - When `_folder.json` is written/deleted/renamed as an actual resource file (metadata-disabled path, or an explicit `_folder.json` change), it already flows through the resource-file methods above and is sized.

## Testing
- `go test ./pkg/registry/apis/provisioning/jobs/...` and `./resources/...` — all pass.
- `go vet` and `gofmt` clean.
- Added `TestRecordResourceOperationBytes` covering sized, zero-byte, ignored, and (sized) delete cases.
- Updated the write/rename/remove mock methods in `repository_resources_mock.go` and all affected mock/direct call sites in the sync, export and resources test packages for the new return value.

## Checklist
- [x] Tests added/updated
- [ ] Documentation updated (metric surfaces automatically; no docs change needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)