### PR TITLE
Search: pass bare field names from API-layer search callers

### DIFF
--- a/pkg/registry/apis/dashboard/search.go
+++ b/pkg/registry/apis/dashboard/search.go
@@ -891,27 +891,16 @@ func convertHttpSearchRequestToResourceSearchRequest(queryParams url.Values, use
 		return nil, err
 	}
 
-	// Add sorting. Dashboard-specific fields live under the fields.*
-	// sub-document inside bleve; clients pass the bare name (e.g.
-	// ?sort=views_total) and the search backend needs the prefixed form
-	// (fields.views_total) to find them. The leading "-" descending marker
-	// is stripped first so the dashboard-field lookup sees the bare name
-	// regardless of direction.
+	// Add sorting. Field names are passed through as the client sent them; the
+	// search backend knows where each field lives in the index. The leading "-"
+	// descending marker is stripped first.
 	if queryParams.Has("sort") {
-		isDashboardField := func(name string) bool {
-			return slices.ContainsFunc(builders.DashboardSearchFields, func(def resource.SearchFieldDefinition) bool {
-				return def.Name == name
-			})
-		}
 		for _, raw := range queryParams["sort"] {
 			field := raw
 			desc := false
 			if strings.HasPrefix(field, "-") {
 				desc = true
 				field = field[1:]
-			}
-			if isDashboardField(field) {
-				field = resource.SEARCH_FIELD_PREFIX + field
 			}
 			searchRequest.SortBy = append(searchRequest.SortBy, &resourcepb.ResourceSearchRequest_Sort{
 				Field: field,
@@ -949,7 +938,7 @@ func convertHttpSearchRequestToResourceSearchRequest(queryParams url.Values, use
 
 	if v, ok := queryParams["panelType"]; ok {
 		searchRequest.Options.Fields = append(searchRequest.Options.Fields, &resourcepb.Requirement{
-			Key:      resource.SEARCH_FIELD_PREFIX + builders.DASHBOARD_PANEL_TYPES,
+			Key:      builders.DASHBOARD_PANEL_TYPES,
 			Operator: "=",
 			Values:   v,
 		})
@@ -957,7 +946,7 @@ func convertHttpSearchRequestToResourceSearchRequest(queryParams url.Values, use
 
 	if v, ok := queryParams["dataSourceType"]; ok {
 		searchRequest.Options.Fields = append(searchRequest.Options.Fields, &resourcepb.Requirement{
-			Key:      resource.SEARCH_FIELD_PREFIX + builders.DASHBOARD_DS_TYPES,
+			Key:      builders.DASHBOARD_DS_TYPES,
 			Operator: "=",
 			Values:   v,
 		})
@@ -1024,7 +1013,7 @@ func convertHttpSearchRequestToResourceSearchRequest(queryParams url.Values, use
 
 		if queryParams.Has("panelTitleSearch") && queryParams.Get("panelTitleSearch") != "false" {
 			searchRequest.QueryFields = append(searchRequest.QueryFields, &resourcepb.ResourceSearchRequest_QueryField{
-				Name:  resource.SEARCH_FIELD_PREFIX + builders.DASHBOARD_PANEL_TITLE, // fields.panel_title
+				Name:  builders.DASHBOARD_PANEL_TITLE,
 				Type:  resourcepb.QueryFieldType_TEXT,
 				Boost: 5,
 			})

--- a/pkg/registry/apis/dashboard/search_test.go
+++ b/pkg/registry/apis/dashboard/search_test.go
@@ -1111,7 +1111,7 @@ func TestConvertHttpSearchRequestToResourceSearchRequest(t *testing.T) {
 				Page:      1,
 				Explain:   false,
 				Fields:    defaultFields,
-				SortBy:    []*resourcepb.ResourceSearchRequest_Sort{{Field: "fields.views_total", Desc: false}},
+				SortBy:    []*resourcepb.ResourceSearchRequest_Sort{{Field: "views_total", Desc: false}},
 				Federated: []*resourcepb.ResourceKey{folderKey},
 			},
 		},
@@ -1125,7 +1125,7 @@ func TestConvertHttpSearchRequestToResourceSearchRequest(t *testing.T) {
 				Page:      1,
 				Explain:   false,
 				Fields:    defaultFields,
-				SortBy:    []*resourcepb.ResourceSearchRequest_Sort{{Field: "fields.views_total", Desc: true}},
+				SortBy:    []*resourcepb.ResourceSearchRequest_Sort{{Field: "views_total", Desc: true}},
 				Federated: []*resourcepb.ResourceKey{folderKey},
 			},
 		},
@@ -1183,6 +1183,38 @@ func TestConvertHttpSearchRequestToResourceSearchRequest(t *testing.T) {
 				Options: &resourcepb.ListOptions{
 					Key:    dashboardKey,
 					Fields: []*resourcepb.Requirement{{Key: "tags", Operator: "=", Values: []string{"tag1", "tag2"}}},
+				},
+				Query:     "",
+				Limit:     50,
+				Offset:    0,
+				Page:      1,
+				Explain:   false,
+				Fields:    defaultFields,
+				Federated: []*resourcepb.ResourceKey{folderKey},
+			},
+		},
+		"panel type filter": {
+			queryString: "panelType=timeseries",
+			expected: &resourcepb.ResourceSearchRequest{
+				Options: &resourcepb.ListOptions{
+					Key:    dashboardKey,
+					Fields: []*resourcepb.Requirement{{Key: "panel_types", Operator: "=", Values: []string{"timeseries"}}},
+				},
+				Query:     "",
+				Limit:     50,
+				Offset:    0,
+				Page:      1,
+				Explain:   false,
+				Fields:    defaultFields,
+				Federated: []*resourcepb.ResourceKey{folderKey},
+			},
+		},
+		"data source type filter": {
+			queryString: "dataSourceType=prometheus",
+			expected: &resourcepb.ResourceSearchRequest{
+				Options: &resourcepb.ListOptions{
+					Key:    dashboardKey,
+					Fields: []*resourcepb.Requirement{{Key: "ds_types", Operator: "=", Values: []string{"prometheus"}}},
 				},
 				Query:     "",
 				Limit:     50,
@@ -1385,6 +1417,23 @@ func TestConvertHttpSearchRequestToResourceSearchRequest(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+
+	t.Run("panel title search asks for the panel_title field", func(t *testing.T) {
+		queryParams, err := url.ParseQuery("query=cpu&panelTitleSearch=true")
+		require.NoError(t, err)
+
+		result, err := convertHttpSearchRequestToResourceSearchRequest(queryParams, testUser, func(dashboardaccess.PermissionType) ([]string, error) {
+			return nil, nil
+		})
+
+		require.NoError(t, err)
+		require.NotEmpty(t, result.QueryFields)
+		names := make([]string, 0, len(result.QueryFields))
+		for _, f := range result.QueryFields {
+			names = append(names, f.Name)
+		}
+		assert.Contains(t, names, "panel_title")
+	})
 
 	t.Run("rejects unsupported facet fields", func(t *testing.T) {
 		queryParams, err := url.ParseQuery("facet=folder")

--- a/pkg/registry/apis/iam/display/search.go
+++ b/pkg/registry/apis/iam/display/search.go
@@ -31,8 +31,8 @@ func NewSearchDisplayProvider(client resourcepb.ResourceIndexClient) *SearchDisp
 
 var searchDisplayFields = []string{
 	resource.SEARCH_FIELD_TITLE,
-	resource.SEARCH_FIELD_PREFIX + builders.USER_EMAIL,
-	resource.SEARCH_FIELD_PREFIX + builders.USER_LOGIN,
+	builders.USER_EMAIL,
+	builders.USER_LOGIN,
 	resource.SEARCH_FIELD_LEGACY_ID,
 }
 

--- a/pkg/registry/apis/iam/legacysort/sort.go
+++ b/pkg/registry/apis/iam/legacysort/sort.go
@@ -6,11 +6,12 @@ import (
 	"strings"
 
 	"github.com/grafana/grafana/pkg/services/search/model"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
 
 // ConvertToSortOptions translates unified search sort fields into legacy SQL sort options.
-// fieldMapping maps unified field names (e.g. "title", "fields.email") to legacy sort key names (e.g. "name", "email").
+// fieldMapping maps unified field names (e.g. "title", "email") to legacy sort key names (e.g. "name", "email").
 // sortOptions is the resource-specific SortOptionsByQueryParam map.
 func ConvertToSortOptions(
 	sortBy []*resourcepb.ResourceSearchRequest_Sort,
@@ -19,7 +20,8 @@ func ConvertToSortOptions(
 ) []model.SortOption {
 	opts := []model.SortOption{}
 	for _, s := range sortBy {
-		field := s.Field
+		// Older callers may still name a per-kind field as "fields.<name>".
+		field := strings.TrimPrefix(s.Field, resource.SEARCH_FIELD_PREFIX)
 		if mapped, ok := fieldMapping[field]; ok {
 			field = mapped
 		}
@@ -41,7 +43,7 @@ func ConvertToSortOptions(
 }
 
 // ConvertToSortParams translates legacy SQL sort options into K8s search sort query parameters.
-// fieldMapping is the same unified→legacy map used in ConvertToSortOptions (e.g. "title" to "name", "fields.email" to "email").
+// fieldMapping is the same unified→legacy map used in ConvertToSortOptions (e.g. "title" to "name", "email" to "email").
 // It is reversed internally, stripping the "fields." prefix to produce bare K8s sort param names.
 // Sort options that cannot be mapped (e.g. member_count) are silently skipped.
 func ConvertToSortParams(
@@ -51,7 +53,7 @@ func ConvertToSortParams(
 	// Build reverse mapping: legacy sort key to K8s sort param field name
 	reverseMapping := make(map[string]string, len(fieldMapping))
 	for unified, legacy := range fieldMapping {
-		reverseMapping[legacy] = strings.TrimPrefix(unified, "fields.")
+		reverseMapping[legacy] = strings.TrimPrefix(unified, resource.SEARCH_FIELD_PREFIX)
 	}
 
 	params := make([]string, 0, len(sortOpts))

--- a/pkg/registry/apis/iam/team/legacy_members_search.go
+++ b/pkg/registry/apis/iam/team/legacy_members_search.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"strings"
 
 	claims "github.com/grafana/authlib/types"
 	"go.opentelemetry.io/otel/codes"
@@ -184,9 +185,9 @@ func userUIDFilter(req *resourcepb.ResourceSearchRequest) string {
 	if req == nil || req.Options == nil {
 		return ""
 	}
-	key := resource.SEARCH_FIELD_PREFIX + builders.TEAM_SEARCH_MEMBERS
 	for _, r := range req.Options.Fields {
-		if r != nil && r.Key == key && len(r.Values) > 0 {
+		// Accept the bare name and the fields.-prefixed spelling an older caller may send.
+		if r != nil && strings.TrimPrefix(r.Key, resource.SEARCH_FIELD_PREFIX) == builders.TEAM_SEARCH_MEMBERS && len(r.Values) > 0 {
 			return r.Values[0]
 		}
 	}

--- a/pkg/registry/apis/iam/team/legacy_members_search_test.go
+++ b/pkg/registry/apis/iam/team/legacy_members_search_test.go
@@ -21,7 +21,7 @@ import (
 func TestLegacyUserTeamsSearchClient_Search(t *testing.T) {
 	memberFilter := func(userUID string) []*resourcepb.Requirement {
 		return []*resourcepb.Requirement{{
-			Key:    res.SEARCH_FIELD_PREFIX + builders.TEAM_SEARCH_MEMBERS,
+			Key:    builders.TEAM_SEARCH_MEMBERS,
 			Values: []string{userUID},
 		}}
 	}
@@ -65,6 +65,28 @@ func TestLegacyUserTeamsSearchClient_Search(t *testing.T) {
 		require.Equal(t, "member", string(resp.Results.Rows[1].Cells[0]))
 		require.Equal(t, "true", string(resp.Results.Rows[1].Cells[1]))
 		require.Equal(t, []string{"team-b"}, resp.Results.Rows[1].SortFields)
+	})
+
+	t.Run("accepts the fields.-prefixed members filter", func(t *testing.T) {
+		store := &fakeUserTeamsStore{
+			pages: []*legacy.ListUserTeamsResult{{
+				Items: []legacy.UserTeam{{UID: "team-a", Permission: team.PermissionTypeAdmin}},
+			}},
+		}
+		client := NewLegacyUserTeamsSearchClient(store, tracing.InitializeTracerForTest())
+
+		req := &resourcepb.ResourceSearchRequest{
+			Limit: 10,
+			Options: &resourcepb.ListOptions{Key: keyWithNamespace, Fields: []*resourcepb.Requirement{{
+				Key:    res.SEARCH_FIELD_PREFIX + builders.TEAM_SEARCH_MEMBERS,
+				Values: []string{"alice"},
+			}}},
+		}
+
+		resp, err := client.Search(context.Background(), req)
+		require.NoError(t, err)
+		require.Equal(t, "alice", store.lastQuery.UserUID)
+		require.Len(t, resp.Results.Rows, 1)
 	})
 
 	t.Run("SortFields[0] equals Key.Name for every row (continue-token contract)", func(t *testing.T) {

--- a/pkg/registry/apis/iam/team/legacy_search.go
+++ b/pkg/registry/apis/iam/team/legacy_search.go
@@ -33,7 +33,7 @@ const (
 func TeamSortFieldMapping() map[string]string {
 	return map[string]string{
 		resource.SEARCH_FIELD_TITLE: "name",
-		fmt.Sprintf("%s%s", resource.SEARCH_FIELD_PREFIX, builders.TEAM_SEARCH_EMAIL): "email",
+		builders.TEAM_SEARCH_EMAIL:  "email",
 	}
 }
 

--- a/pkg/registry/apis/iam/team/search.go
+++ b/pkg/registry/apis/iam/team/search.go
@@ -310,9 +310,9 @@ func (s *SearchHandler) DoTeamSearch(w http.ResponseWriter, r *http.Request) {
 		Explain: queryParams.Has("explain") && queryParams.Get("explain") != "false",
 		Fields: []string{
 			resource.SEARCH_FIELD_TITLE,
-			resource.SEARCH_FIELD_PREFIX + builders.TEAM_SEARCH_EMAIL,
-			resource.SEARCH_FIELD_PREFIX + builders.TEAM_SEARCH_PROVISIONED,
-			resource.SEARCH_FIELD_PREFIX + builders.TEAM_SEARCH_EXTERNAL_UID,
+			builders.TEAM_SEARCH_EMAIL,
+			builders.TEAM_SEARCH_PROVISIONED,
+			builders.TEAM_SEARCH_EXTERNAL_UID,
 			teamsearch.LegacyIDField,
 		},
 	}
@@ -331,13 +331,8 @@ func (s *SearchHandler) DoTeamSearch(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			sortField := currField
-			if slices.Contains(builders.TeamSortableExtraFields, currField) {
-				sortField = resource.SEARCH_FIELD_PREFIX + currField
-			}
-
 			s := &resourcepb.ResourceSearchRequest_Sort{
-				Field: sortField,
+				Field: currField,
 				Desc:  desc,
 			}
 			searchRequest.SortBy = append(searchRequest.SortBy, s)

--- a/pkg/registry/apis/iam/team/search_test.go
+++ b/pkg/registry/apis/iam/team/search_test.go
@@ -101,9 +101,9 @@ func TestSearchHandler(t *testing.T) {
 		}
 		expectedFields := []string{
 			resource.SEARCH_FIELD_TITLE,
-			resource.SEARCH_FIELD_PREFIX + builders.TEAM_SEARCH_EMAIL,
-			resource.SEARCH_FIELD_PREFIX + builders.TEAM_SEARCH_PROVISIONED,
-			resource.SEARCH_FIELD_PREFIX + builders.TEAM_SEARCH_EXTERNAL_UID,
+			builders.TEAM_SEARCH_EMAIL,
+			builders.TEAM_SEARCH_PROVISIONED,
+			builders.TEAM_SEARCH_EXTERNAL_UID,
 			teamsearch.LegacyIDField,
 		}
 		if fmt.Sprintf("%v", mockClient.LastSearchRequest.Fields) != fmt.Sprintf("%v", expectedFields) {

--- a/pkg/registry/apis/iam/user/legacy_search.go
+++ b/pkg/registry/apis/iam/user/legacy_search.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -31,12 +32,12 @@ const (
 
 var (
 	_                        resourcepb.ResourceIndexClient = (*UserLegacySearchClient)(nil)
-	fieldLogin                                              = fmt.Sprintf("%s%s", resource.SEARCH_FIELD_PREFIX, builders.USER_LOGIN)
-	fieldEmail                                              = fmt.Sprintf("%s%s", resource.SEARCH_FIELD_PREFIX, builders.USER_EMAIL)
-	fieldLastSeenAt                                         = fmt.Sprintf("%s%s", resource.SEARCH_FIELD_PREFIX, builders.USER_LAST_SEEN_AT)
-	fieldRole                                               = fmt.Sprintf("%s%s", resource.SEARCH_FIELD_PREFIX, builders.USER_ROLE)
-	fieldDisabled                                           = fmt.Sprintf("%s%s", resource.SEARCH_FIELD_PREFIX, builders.USER_DISABLED)
-	fieldExternalAuthModules                                = fmt.Sprintf("%s%s", resource.SEARCH_FIELD_PREFIX, builders.USER_EXTERNAL_AUTH_MODULES)
+	fieldLogin                                              = builders.USER_LOGIN
+	fieldEmail                                              = builders.USER_EMAIL
+	fieldLastSeenAt                                         = builders.USER_LAST_SEEN_AT
+	fieldRole                                               = builders.USER_ROLE
+	fieldDisabled                                           = builders.USER_DISABLED
+	fieldExternalAuthModules                                = builders.USER_EXTERNAL_AUTH_MODULES
 	legacyIDField                                           = resource.SEARCH_FIELD_LABELS + "." + resource.SEARCH_FIELD_LEGACY_ID
 	wildcardsMatcher                                        = regexp.MustCompile(`[\*\?\\]`)
 
@@ -117,7 +118,7 @@ func (c *UserLegacySearchClient) Search(ctx context.Context, req *resourcepb.Res
 		if len(vals) != 1 {
 			logger.Warn("only single value fields are supported for legacy search, using first value", "field", field.Key, "values", vals)
 		}
-		switch field.Key {
+		switch publicFieldName(field.Key) {
 		case resource.SEARCH_FIELD_TITLE:
 			title = vals[0]
 		case fieldLogin:
@@ -201,11 +202,17 @@ func getResourceKey(item *org.OrgUserDTO, namespace string) *resourcepb.Resource
 
 var userColumns = resource.TableColumnsByName(builders.UserSearchFields)
 
+// publicFieldName drops the fields. prefix a caller may still add to a
+// per-kind field name, so both spellings map to the same legacy column.
+func publicFieldName(name string) string {
+	return strings.TrimPrefix(name, resource.SEARCH_FIELD_PREFIX)
+}
+
 func getColumns(fields []string) []*resourcepb.ResourceTableColumnDefinition {
 	cols := make([]*resourcepb.ResourceTableColumnDefinition, 0, len(fields))
 	standardSearchFields := resource.StandardSearchFields()
 	for _, field := range fields {
-		switch field {
+		switch publicFieldName(field) {
 		case resource.SEARCH_FIELD_TITLE:
 			cols = append(cols, standardSearchFields.Field(resource.SEARCH_FIELD_TITLE))
 		case fieldLastSeenAt:
@@ -236,7 +243,7 @@ func getColumns(fields []string) []*resourcepb.ResourceTableColumnDefinition {
 func createCells(u *org.OrgUserDTO, fields []string) [][]byte {
 	cells := make([][]byte, 0, len(fields))
 	for _, field := range fields {
-		switch field {
+		switch publicFieldName(field) {
 		case resource.SEARCH_FIELD_TITLE:
 			cells = append(cells, []byte(u.Name))
 		case fieldEmail:

--- a/pkg/registry/apis/iam/user/legacy_search_test.go
+++ b/pkg/registry/apis/iam/user/legacy_search_test.go
@@ -43,12 +43,24 @@ func TestUserLegacySearchClient_Search(t *testing.T) {
 		},
 		{
 			name:          "search by login",
-			fieldKey:      "fields.login",
+			fieldKey:      builders.USER_LOGIN,
 			fieldValues:   []string{"testlogin"},
 			expectedQuery: "testlogin",
 		},
 		{
 			name:          "search by email",
+			fieldKey:      builders.USER_EMAIL,
+			fieldValues:   []string{"test@example.com"},
+			expectedQuery: "test@example.com",
+		},
+		{
+			name:          "search by login, prefixed key",
+			fieldKey:      "fields.login",
+			fieldValues:   []string{"testlogin"},
+			expectedQuery: "testlogin",
+		},
+		{
+			name:          "search by email, prefixed key",
 			fieldKey:      "fields.email",
 			fieldValues:   []string{"test@example.com"},
 			expectedQuery: "test@example.com",

--- a/pkg/registry/apis/iam/user/rest_user_team.go
+++ b/pkg/registry/apis/iam/user/rest_user_team.go
@@ -145,7 +145,7 @@ func (s *UserTeamREST) Connect(ctx context.Context, name string, _ runtime.Objec
 					Namespace: requester.GetNamespace(),
 				},
 				Fields: []*resourcepb.Requirement{{
-					Key:      resource.SEARCH_FIELD_PREFIX + builders.TEAM_SEARCH_MEMBERS,
+					Key:      builders.TEAM_SEARCH_MEMBERS,
 					Operator: string(selection.Equals),
 					Values:   []string{name},
 				}},

--- a/pkg/registry/apis/iam/user/rest_user_team_test.go
+++ b/pkg/registry/apis/iam/user/rest_user_team_test.go
@@ -464,7 +464,7 @@ func TestUserTeamREST_Connect(t *testing.T) {
 		require.Equal(t, iamv0alpha1.TeamResourceInfo.GroupResource().Resource, mockClient.LastSearchRequest.Options.Key.Resource)
 		require.Equal(t, "test-namespace", mockClient.LastSearchRequest.Options.Key.Namespace)
 		require.Len(t, mockClient.LastSearchRequest.Options.Fields, 1)
-		require.Equal(t, resource.SEARCH_FIELD_PREFIX+builders.TEAM_SEARCH_MEMBERS, mockClient.LastSearchRequest.Options.Fields[0].Key)
+		require.Equal(t, builders.TEAM_SEARCH_MEMBERS, mockClient.LastSearchRequest.Options.Fields[0].Key)
 		require.Equal(t, []string{"alice"}, mockClient.LastSearchRequest.Options.Fields[0].Values)
 	})
 

--- a/pkg/registry/apis/iam/user/search.go
+++ b/pkg/registry/apis/iam/user/search.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -340,20 +339,15 @@ func (s *SearchHandler) DoSearch(w http.ResponseWriter, r *http.Request) {
 				currField = sort[1:]
 				desc = true
 			}
-			if slices.Contains(builders.UserSortableExtraFields, currField) {
-				sort = resource.SEARCH_FIELD_PREFIX + currField
-			} else {
-				sort = currField
-			}
 			s := &resourcepb.ResourceSearchRequest_Sort{
-				Field: sort,
+				Field: currField,
 				Desc:  desc,
 			}
 			request.SortBy = append(request.SortBy, s)
 		}
 	} else {
 		request.SortBy = append(request.SortBy, &resourcepb.ResourceSearchRequest_Sort{
-			Field: resource.SEARCH_FIELD_PREFIX + builders.USER_LOGIN,
+			Field: builders.USER_LOGIN,
 		})
 	}
 

--- a/pkg/registry/apis/iam/user/search_test.go
+++ b/pkg/registry/apis/iam/user/search_test.go
@@ -187,8 +187,8 @@ func mockClientWithHits() *MockClient {
 }
 
 func TestSearchSort(t *testing.T) {
-	loginField := resource.SEARCH_FIELD_PREFIX + builders.USER_LOGIN
-	emailField := resource.SEARCH_FIELD_PREFIX + builders.USER_EMAIL
+	loginField := builders.USER_LOGIN
+	emailField := builders.USER_EMAIL
 
 	tests := []struct {
 		name     string

--- a/pkg/registry/apis/iam/user/validate.go
+++ b/pkg/registry/apis/iam/user/validate.go
@@ -159,11 +159,11 @@ func validateRole(obj *iamv0alpha1.User) error {
 func validateEmail(ctx context.Context, searchClient resourcepb.ResourceIndexClient, namespace, name, email string) error {
 	req := createUserSearchRequest(namespace, []*resourcepb.Requirement{
 		{
-			Key:      "fields.email",
+			Key:      fieldEmail,
 			Operator: string(selection.Equals),
 			Values:   []string{email},
 		},
-	}, []string{"fields.email", "fields.login"})
+	}, []string{fieldEmail, fieldLogin})
 
 	resp, err := searchClient.Search(ctx, req)
 	if err != nil {
@@ -190,11 +190,11 @@ func validateEmail(ctx context.Context, searchClient resourcepb.ResourceIndexCli
 func validateLogin(ctx context.Context, searchClient resourcepb.ResourceIndexClient, namespace, name, login string) error {
 	req := createUserSearchRequest(namespace, []*resourcepb.Requirement{
 		{
-			Key:      "fields.login",
+			Key:      fieldLogin,
 			Operator: string(selection.Equals),
 			Values:   []string{login},
 		},
-	}, []string{"fields.email", "fields.login"})
+	}, []string{fieldEmail, fieldLogin})
 	resp, err := searchClient.Search(ctx, req)
 	if err != nil {
 		return err


### PR DESCRIPTION
Search documents store per-kind fields under a `fields.*` sub-document in the index. Callers used to build keys like `"fields." + "panel_type"` themselves, and several still do even though they no longer need to: #129080 (shipped in 13.2) made the backend resolve a public field name to its physical index name for filter keys, returned field lists, sort fields and text query fields. It accepts both spellings, so this cleanup is a no-op in behaviour.

This drops the leftover client-side prefixing in the dashboard and IAM search handlers, so only the backend knows where fields live. Affected callers: dashboard sort fields plus the `panelType` / `dataSourceType` / panel-title parameters, IAM user and team search, user create/update validation, the user-teams subresource, and the display-name provider.

The IAM legacy SQL search clients matched requests on the prefixed spelling, so they now accept both spellings too. Without that, dropping the prefix would silently break dual-writer modes 0 and 1, where those clients serve the request instead of the search backend.

Ref: grafana/search-and-storage-team#869
