### PR TITLE
Metrics: Enable standard client-go rest_client_* metrics

### DIFF
--- a/pkg/infra/metrics/service.go
+++ b/pkg/infra/metrics/service.go
@@ -11,6 +11,20 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"k8s.io/component-base/metrics/legacyregistry"
 
+	// Enable the ecosystem-standard client-go REST client metrics. This blank
+	// import's init() does two process-global things: it registers the collectors
+	// (rest_client_request_duration_seconds{verb,host},
+	// rest_client_requests_total{code,method,host}, retries, sizes, ...) on
+	// legacyregistry, and it installs adapters into client-go's global metric hooks
+	// (k8s.io/client-go/tools/metrics.RequestLatency/RequestResult/...), which are
+	// no-ops until something registers them. Every REST client built from a
+	// *rest.Config — dynamic, clientset, discovery — calls those hooks on each
+	// request (client-go/rest/request.go), so this instruments all of Grafana's
+	// outbound Kubernetes API traffic, not just one caller. ProvideGatherer below
+	// gathers legacyregistry and addPrefixWrapper adds the grafana_ prefix, so these
+	// surface on /metrics as grafana_rest_client_*.
+	_ "k8s.io/component-base/metrics/prometheus/restclient"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/metrics/graphitebridge"
 	"github.com/grafana/grafana/pkg/setting"


### PR DESCRIPTION
## What

Grafana now emits the ecosystem-standard client-go `rest_client_*` metric families for its outbound Kubernetes API traffic. Surfaced on `/metrics` (through Grafana's `grafana_` prefixing) as:

- `grafana_rest_client_request_duration_seconds{verb,host}` — per-attempt request latency histogram
- `grafana_rest_client_requests_total{code,method,host}` — request counter carrying real HTTP status codes
- `grafana_rest_client_request_retries_total`, `..._request_size_bytes`, `..._response_size_bytes`, `..._rate_limiter_duration_seconds`, and the transport/exec-plugin families

## Why

These are the de-facto OSS-standard `rest_client_*` metrics that every k8s controller, kubelet, kube-apiserver, and kubectl already emits — the ones community dashboards, mixins, and runbooks query by default. Grafana wasn't emitting them at all: nothing in `pkg/` or `apps/` imported the adapter, so all of Grafana's client-go REST traffic was uninstrumented at the HTTP layer.

Enabling them gives SREs the metric they already know (`rate(rest_client_requests_total{code=~"5.."}[5m])`, etc.) and adds real HTTP status codes + retry counts, which a binary success/error outcome can't express.

## How

A single blank import of the upstream adapter in the metrics composition root (`pkg/infra/metrics/service.go`):

```go
_ "k8s.io/component-base/metrics/prometheus/restclient"
```

The adapter's `init()` does two process-global (`sync.Once`-guarded) things:

1. Registers the Prometheus collectors on component-base's `legacyregistry` — which `ProvideGatherer` already gathers and `addPrefixWrapper` prefixes to `grafana_`.
2. Installs adapters into client-go's global metric hooks (`k8s.io/client-go/tools/metrics.RequestLatency`/`RequestResult`/...), which are no-ops until registered.

Every REST client built from a `*rest.Config` (dynamic, clientset, discovery) calls those hooks on each request, so this instruments all of Grafana's outbound Kubernetes API traffic from one import — no per-caller wiring.

These **complement, not replace**, the operation-level `grafana_apiserver_client_request_duration_seconds` metric: that one is resource-scoped and end-to-end (including retries/backoff); these are per-attempt and carry HTTP status codes.

**Caveat — standalone operator:** `pkg/operators/provisioning` builds its own pedantic registry and doesn't gather `legacyregistry`, so `rest_client_*` won't surface on its `/metrics` yet (a pre-existing gap for its other metrics too). The client-go hooks are global, so these light up there for free once that `/metrics` path gathers `legacyregistry`.

## Testing

- `go build ./pkg/infra/metrics/` — OK
- `go test ./pkg/infra/metrics/` — OK (per prior verification)
- `gofmt` / `goimports -local github.com/grafana/grafana` — clean
- Verified end-to-end that a simulated `RequestLatency.Observe` surfaces as `grafana_rest_client_request_duration_seconds` through the gather+prefix path

## Checklist

- [ ] Tests added/updated — n/a (single blank import; behavior is upstream-provided)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)