### PR TITLE
Provisioning: register unistore client metrics on the shared registry

### DIFF
--- a/pkg/operators/provisioning/config.go
+++ b/pkg/operators/provisioning/config.go
@@ -191,7 +191,7 @@ func (c *ControllerConfig) UnifiedStorageClient() (resources.ResourceStore, erro
 		TokenExchangeURL: gRPCAuth.Key("token_exchange_url").String(),
 		Namespace:        gRPCAuth.Key("token_namespace").String(),
 	}
-	unified, err := setupUnifiedStorageClient(c.Settings, tracer, resourceClientCfg)
+	unified, err := setupUnifiedStorageClient(c.Settings, tracer, c.Registry(), resourceClientCfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup unified storage: %w", err)
 	}
@@ -698,15 +698,13 @@ func setupDecryptService(cfg *setting.Cfg, tracer tracing.Tracer, tokenExchangeC
 // HACK: This logic directly connects to unified storage. We are doing this for now as there is no global
 // search endpoint. But controllers, in general, should not connect directly to unified storage and instead
 // go through the api server. Once there is a global search endpoint, we will switch to that here as well.
-func setupUnifiedStorageClient(cfg *setting.Cfg, tracer tracing.Tracer, resourceClientCfg resource.RemoteResourceClientConfig) (resources.ResourceStore, error) {
+func setupUnifiedStorageClient(cfg *setting.Cfg, tracer tracing.Tracer, registry prometheus.Registerer, resourceClientCfg resource.RemoteResourceClientConfig) (resources.ResourceStore, error) {
 	unifiedStorageSec := cfg.SectionWithEnvOverrides("unified_storage")
 	// Connect to Server
 	address := unifiedStorageSec.Key("grpc_address").String()
 	if address == "" {
 		return nil, fmt.Errorf("grpc_address is required in [unified_storage] section")
 	}
-	// FIXME: These metrics are not going to show up in /metrics
-	registry := prometheus.NewPedanticRegistry()
 	conn, err := unified.GrpcConn(address, registry)
 	if err != nil {
 		return nil, fmt.Errorf("create unified storage gRPC connection: %w", err)
@@ -716,10 +714,9 @@ func setupUnifiedStorageClient(cfg *setting.Cfg, tracer tracing.Tracer, resource
 	indexConn := conn
 	indexAddress := unifiedStorageSec.Key("grpc_index_address").String()
 	if indexAddress != "" {
-		// FIXME: These metrics are not going to show up in /metrics. We will also need to wrap these metrics
-		// to start with something else so it doesn't collide with the storage api metrics.
-		registry2 := prometheus.NewPedanticRegistry()
-		indexConn, err = unified.GrpcConn(indexAddress, registry2)
+		// The index connection registers the same client metrics as the storage connection, so
+		// prefix them to avoid a duplicate-registration collision on the shared registry.
+		indexConn, err = unified.GrpcConn(indexAddress, prometheus.WrapRegistererWithPrefix("index_", registry))
 		if err != nil {
 			return nil, fmt.Errorf("create unified storage index gRPC connection: %w", err)
 		}


### PR DESCRIPTION
## What

The provisioning operator's `setupUnifiedStorageClient` now registers the unified-storage gRPC client metrics (`resource_server_client_request_duration_seconds`, `resource_server_client_request_retries_total`) on the operator's shared Prometheus registry instead of throwaway pedantic registries. As a result these metrics now actually appear on `/metrics`.

## Why

The code created a fresh `prometheus.NewPedanticRegistry()` per gRPC connection and never wired it to anything exported. Two pre-existing FIXMEs flagged exactly this: *"These metrics are not going to show up in /metrics."* So the unistore client o11y was silently dropped in the operators.

Fixes grafana/git-ui-sync-project#527.

## How

- Threaded the operator's shared registry (`c.Registry()`) into `setupUnifiedStorageClient(cfg, tracer, registry, resourceClientCfg)`.
- Used it directly for the main storage connection.
- Wrapped it with `prometheus.WrapRegistererWithPrefix("index_", registry)` for the optional index connection — the index connection registers the same client metric names, so without a prefix the shared registry would panic on duplicate registration (the second FIXME's concern).
- Removed both resolved FIXME comments.

Backend-only change under `pkg/operators/`; does not touch the unified-storage service-compatibility surface in `pkg/storage/unified/`.

## Testing

- `go build ./pkg/operators/provisioning/`
- `go vet ./pkg/operators/provisioning/`
- `go test ./pkg/operators/provisioning/` — passing

## Note for reviewers

Operators configured with a separate `unified_storage.grpc_index_address` will emit new `index_`-prefixed client metric series. Nothing previously depended on these (they weren't exported at all), but worth a glance from whoever owns operator dashboards/alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)