### PR TITLE
Plugins: Allow extra labels on the plugin request counter

### DIFF
--- a/pkg/services/pluginsintegration/clientmiddleware/metrics_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/metrics_middleware.go
@@ -16,6 +16,36 @@ import (
 	"github.com/grafana/grafana/pkg/plugins/manager/registry"
 )
 
+// ExtraLabels supplies additional labels for the plugin request counter, for
+// facts the middleware cannot resolve on its own -- for example the tenant a
+// request belongs to, or the service that called it, in a multi-tenant
+// deployment.
+//
+// Names must be constant for the life of the process. Values must return one
+// value per name, in the same order. A value that cannot be resolved should be
+// the empty string, which Prometheus drops at ingestion, so a deployment that
+// does not populate a label keeps exactly the series it has today.
+type ExtraLabels interface {
+	Names() []string
+	Values(ctx context.Context, pluginCtx backend.PluginContext) []string
+}
+
+// MetricsMiddlewareOption configures the metrics middleware.
+type MetricsMiddlewareOption func(*metricsMiddlewareOptions)
+
+type metricsMiddlewareOptions struct {
+	extraLabels ExtraLabels
+}
+
+// WithExtraLabels adds labels to the plugin request counter, resolved per
+// request by extra. Only the counter is extended: adding a label to the
+// duration and size histograms would multiply it by their bucket count.
+func WithExtraLabels(extra ExtraLabels) MetricsMiddlewareOption {
+	return func(o *metricsMiddlewareOptions) {
+		o.extraLabels = extra
+	}
+}
+
 // pluginMetrics contains the prometheus metrics used by the MetricsMiddleware.
 type pluginMetrics struct {
 	pluginRequestCounter                      *prometheus.CounterVec
@@ -31,15 +61,30 @@ type MetricsMiddleware struct {
 	backend.BaseHandler
 	pluginMetrics
 	pluginRegistry registry.Service
+
+	extraLabels     ExtraLabels
+	extraLabelNames []string
 }
 
-func newMetricsMiddleware(promRegisterer prometheus.Registerer, pluginRegistry registry.Service) *MetricsMiddleware {
+func newMetricsMiddleware(promRegisterer prometheus.Registerer, pluginRegistry registry.Service, opts ...MetricsMiddlewareOption) *MetricsMiddleware {
+	var cfg metricsMiddlewareOptions
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	var extraLabelNames []string
+	if cfg.extraLabels != nil {
+		extraLabelNames = cfg.extraLabels.Names()
+	}
+
 	additionalLabels := []string{"status_source"}
+	counterLabels := append([]string{"plugin_id", "endpoint", "status", "target", "plugin_version"}, additionalLabels...)
+	counterLabels = append(counterLabels, extraLabelNames...)
 	pluginRequestCounter := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "grafana",
 		Name:      "plugin_request_total",
 		Help:      "The total amount of plugin requests",
-	}, append([]string{"plugin_id", "endpoint", "status", "target", "plugin_version"}, additionalLabels...))
+	}, counterLabels)
 	pluginRequestDuration := prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "grafana",
 		Name:      "plugin_request_duration_milliseconds",
@@ -81,20 +126,42 @@ func newMetricsMiddleware(promRegisterer prometheus.Registerer, pluginRegistry r
 			pluginRequestDurationSeconds:              pluginRequestDurationSeconds,
 			pluginRequestConnectionUnavailableCounter: pluginRequestConnectionUnavailableCounter,
 		},
-		pluginRegistry: pluginRegistry,
+		pluginRegistry:  pluginRegistry,
+		extraLabels:     cfg.extraLabels,
+		extraLabelNames: extraLabelNames,
 	}
 }
 
 // NewMetricsMiddleware returns a new MetricsMiddleware.
-func NewMetricsMiddleware(promRegisterer prometheus.Registerer, pluginRegistry registry.Service) backend.HandlerMiddleware {
-	metrics := newMetricsMiddleware(promRegisterer, pluginRegistry)
+func NewMetricsMiddleware(promRegisterer prometheus.Registerer, pluginRegistry registry.Service, opts ...MetricsMiddlewareOption) backend.HandlerMiddleware {
+	metrics := newMetricsMiddleware(promRegisterer, pluginRegistry, opts...)
 	return backend.HandlerMiddlewareFunc(func(next backend.Handler) backend.Handler {
 		return &MetricsMiddleware{
-			BaseHandler:    backend.NewBaseHandler(next),
-			pluginMetrics:  metrics.pluginMetrics,
-			pluginRegistry: metrics.pluginRegistry,
+			BaseHandler:     backend.NewBaseHandler(next),
+			pluginMetrics:   metrics.pluginMetrics,
+			pluginRegistry:  metrics.pluginRegistry,
+			extraLabels:     metrics.extraLabels,
+			extraLabelNames: metrics.extraLabelNames,
 		}
 	})
+}
+
+// extraValues resolves the extra label values for a request. It always returns
+// exactly len(extraLabelNames) values, so a provider returning the wrong number
+// of values cannot panic the request path.
+func (m *MetricsMiddleware) extraValues(ctx context.Context, pluginCtx backend.PluginContext) []string {
+	if m.extraLabels == nil || len(m.extraLabelNames) == 0 {
+		return nil
+	}
+
+	values := m.extraLabels.Values(ctx, pluginCtx)
+	if len(values) == len(m.extraLabelNames) {
+		return values
+	}
+
+	padded := make([]string, len(m.extraLabelNames))
+	copy(padded, values)
+	return padded
 }
 
 // pluginTarget returns the value for the "target" Prometheus label for the given plugin ID.
@@ -139,7 +206,9 @@ func (m *MetricsMiddleware) instrumentPluginRequest(ctx context.Context, pluginC
 	}
 
 	pluginRequestDurationWithLabels := m.pluginRequestDuration.WithLabelValues(pluginCtx.PluginID, string(endpoint), target, pluginCtx.PluginVersion, string(statusSource))
-	pluginRequestCounterWithLabels := m.pluginRequestCounter.WithLabelValues(pluginCtx.PluginID, string(endpoint), status.String(), target, pluginCtx.PluginVersion, string(statusSource))
+	counterValues := []string{pluginCtx.PluginID, string(endpoint), status.String(), target, pluginCtx.PluginVersion, string(statusSource)}
+	counterValues = append(counterValues, m.extraValues(ctx, pluginCtx)...)
+	pluginRequestCounterWithLabels := m.pluginRequestCounter.WithLabelValues(counterValues...)
 	pluginRequestDurationSecondsWithLabels := m.pluginRequestDurationSeconds.WithLabelValues("grafana-backend", pluginCtx.PluginID, string(endpoint), status.String(), target, pluginCtx.PluginVersion, string(statusSource))
 
 	if traceID := tracing.TraceIDFromContext(ctx, true); traceID != "" {

--- a/pkg/services/pluginsintegration/clientmiddleware/metrics_middleware_extralabels_test.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/metrics_middleware_extralabels_test.go
@@ -1,0 +1,112 @@
+package clientmiddleware
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/handlertest"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/common/expfmt"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/plugins"
+	"github.com/grafana/grafana/pkg/plugins/manager/pluginfakes"
+)
+
+type stubExtraLabels struct {
+	names  []string
+	values []string
+}
+
+func (s stubExtraLabels) Names() []string { return s.names }
+func (s stubExtraLabels) Values(context.Context, backend.PluginContext) []string {
+	return s.values
+}
+
+func TestMetricsMiddlewareExtraLabels(t *testing.T) {
+	pCtx := backend.PluginContext{PluginID: pluginID, PluginVersion: "1.0.0"}
+
+	queryDataWith := func(t *testing.T, opts ...MetricsMiddlewareOption) *prometheus.Registry {
+		t.Helper()
+
+		promRegistry := prometheus.NewRegistry()
+		pluginsRegistry := pluginfakes.NewFakePluginRegistry()
+		require.NoError(t, pluginsRegistry.Add(context.Background(), &plugins.Plugin{
+			JSONData: plugins.JSONData{ID: pluginID, Backend: true},
+		}))
+
+		mw := newMetricsMiddleware(promRegistry, pluginsRegistry, opts...)
+		cdt := handlertest.NewHandlerMiddlewareTest(t, handlertest.WithMiddlewares(
+			backend.HandlerMiddlewareFunc(func(next backend.Handler) backend.Handler {
+				mw.BaseHandler = backend.NewBaseHandler(next)
+				return mw
+			}),
+		))
+		_, err := cdt.MiddlewareHandler.QueryData(context.Background(), &backend.QueryDataRequest{PluginContext: pCtx})
+		require.NoError(t, err)
+
+		return promRegistry
+	}
+
+	render := func(t *testing.T, reg *prometheus.Registry, metric string) string {
+		t.Helper()
+
+		out, err := testutil.CollectAndFormat(reg, expfmt.TypeTextPlain, metric)
+		require.NoError(t, err)
+		return string(out)
+	}
+
+	t.Run("without a provider the label set is unchanged", func(t *testing.T) {
+		got := render(t, queryDataWith(t), metricRequestTotal)
+
+		require.Contains(t, got, metricRequestTotal+"{")
+		require.NotContains(t, got, "slug=")
+		require.NotContains(t, got, "caller=")
+	})
+
+	t.Run("with a provider the values are attached", func(t *testing.T) {
+		got := render(t, queryDataWith(t, WithExtraLabels(stubExtraLabels{
+			names:  []string{"slug", "caller"},
+			values: []string{"some-tenant", "some-service"},
+		})), metricRequestTotal)
+
+		require.Contains(t, got, `slug="some-tenant"`)
+		require.Contains(t, got, `caller="some-service"`)
+	})
+
+	t.Run("unresolved values stay empty so Prometheus drops them", func(t *testing.T) {
+		got := render(t, queryDataWith(t, WithExtraLabels(stubExtraLabels{
+			names:  []string{"slug", "caller"},
+			values: []string{"", ""},
+		})), metricRequestTotal)
+
+		require.Contains(t, got, `slug=""`)
+		require.Contains(t, got, `caller=""`)
+	})
+
+	t.Run("a provider returning too few values cannot panic the request", func(t *testing.T) {
+		got := render(t, queryDataWith(t, WithExtraLabels(stubExtraLabels{
+			names:  []string{"slug", "caller"},
+			values: []string{"some-tenant"},
+		})), metricRequestTotal)
+
+		require.Contains(t, got, `slug="some-tenant"`)
+		require.Contains(t, got, `caller=""`)
+	})
+
+	t.Run("only the counter gains the labels, not the histograms", func(t *testing.T) {
+		reg := queryDataWith(t, WithExtraLabels(stubExtraLabels{
+			names:  []string{"slug", "caller"},
+			values: []string{"some-tenant", "some-service"},
+		}))
+
+		for _, metric := range []string{metricRequestDurationMs, metricRequestDurationS, metricRequestSize} {
+			got := render(t, reg, metric)
+			require.False(t, strings.Contains(got, "slug="),
+				"%s must not gain the extra labels:\n%s", metric, got)
+		}
+	})
+}


### PR DESCRIPTION
## What this does

Adds an optional `ExtraLabels` provider to `clientmiddleware.NewMetricsMiddleware`, so a caller can contribute labels to `grafana_plugin_request_total` that the middleware resolves per request:

```go
NewMetricsMiddleware(reg, pluginRegistry, WithExtraLabels(myProvider))
```

```go
type ExtraLabels interface {
	Names() []string
	Values(ctx context.Context, pluginCtx backend.PluginContext) []string
}
```

## Why

`grafana_plugin_request_total` is instrumented at the top of the plugin client chain, so it already sees failures from every middleware below it. What it cannot do is say which tenant a request belonged to, or which service issued it — facts the middleware has no way to resolve on its own, and which only exist in some deployments. In Grafana Cloud we want to attribute datasource request failures to a tenant and a calling service; that resolution needs code the OSS package cannot import, so it has to be injected.

## Design notes

- **Existing callers are untouched.** The option is variadic, and with no provider the label set is exactly what it is today. `pluginsintegration.go` needs no change.
- **Only the request counter is extended.** Adding a label to `plugin_request_duration_milliseconds`, `plugin_request_duration_seconds` or `plugin_request_size_bytes` would multiply it by their bucket count, so `additionalLabels` still feeds those unchanged.
- **Unresolved values should be the empty string.** Prometheus drops empty label values at ingestion, so a deployment that declares a label but does not populate it keeps precisely the series it has today.
- **A misbehaving provider cannot break requests.** `extraValues` always returns `len(Names())` values, padding with empty strings rather than panicking `WithLabelValues`.

## Tests

Five new subtests in `metrics_middleware_extralabels_test.go` covering: unchanged label set with no provider, values attached with one, empty values staying empty, a provider returning too few values, and the histograms not gaining the labels. The existing `TestInstrumentationMiddleware` and `TestInstrumentationMiddlewareStatusSource` pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)