### PR TITLE
CodeMirror: Replace dashboard export viewer

### DIFF
--- a/e2e-playwright/dashboards-suite/dashboard-export-json.spec.ts
+++ b/e2e-playwright/dashboards-suite/dashboard-export-json.spec.ts
@@ -39,7 +39,10 @@ test.describe(
       ).toBeChecked({
         checked: false,
       });
-      await expect(dashboardPage.getByGrafanaSelector(selectors.components.CodeEditor.container)).toBeVisible();
+      const codeEditor = dashboardPage.getByGrafanaSelector(
+        selectors.pages.ExportDashboardDrawer.ExportAsJson.codeEditor
+      );
+      await expect(codeEditor.locator('.cm-editor')).toBeVisible();
 
       await expect(
         dashboardPage.getByGrafanaSelector(selectors.pages.ExportDashboardDrawer.ExportAsJson.saveToFileButton)

--- a/e2e-playwright/dashboards-suite/dashboard-export-json.spec.ts
+++ b/e2e-playwright/dashboards-suite/dashboard-export-json.spec.ts
@@ -42,7 +42,7 @@ test.describe(
       const codeEditor = dashboardPage.getByGrafanaSelector(
         selectors.pages.ExportDashboardDrawer.ExportAsJson.codeEditor
       );
-      await expect(codeEditor.locator('.cm-editor')).toBeVisible();
+      await expect(codeEditor.getByRole('textbox', { name: 'Dashboard definition' })).toBeVisible();
 
       await expect(
         dashboardPage.getByGrafanaSelector(selectors.pages.ExportDashboardDrawer.ExportAsJson.saveToFileButton)

--- a/public/app/features/dashboard-scene/sharing/ExportButton/ExportAsCode.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/ExportAsCode.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { type Props as AutoSizerProps } from 'react-virtualized-auto-sizer';
+
+import { type Dashboard } from '@grafana/schema';
+
+import { ExportAsCode } from './ExportAsCode';
+
+let mockAutoSizerHeight = 320;
+
+jest.mock('react-virtualized-auto-sizer', () => ({
+  __esModule: true,
+  default: ({ children }: AutoSizerProps) =>
+    children({
+      height: mockAutoSizerHeight,
+      scaledHeight: mockAutoSizerHeight,
+      scaledWidth: 800,
+      width: 800,
+    }),
+}));
+
+jest.mock('@grafana/ui', () => ({
+  ...jest.requireActual('@grafana/ui'),
+  CodeEditor: () => <div data-testid="monaco-editor" />,
+}));
+
+jest.mock('@grafana/ui/unstable', () => ({
+  ...jest.requireActual('@grafana/ui/unstable'),
+  __esModule: true,
+  CodeMirrorEditor: ({
+    value,
+    language,
+    height,
+    readOnly,
+    'aria-label': ariaLabel,
+  }: {
+    value: string;
+    language?: string;
+    height?: string;
+    readOnly?: boolean;
+    'aria-label'?: string;
+  }) => (
+    <textarea aria-label={ariaLabel} data-height={height} data-language={language} readOnly={readOnly} value={value} />
+  ),
+}));
+
+const dashboard = { title: 'Test dashboard' } as Dashboard;
+const dashboardJson = '{\n  "title": "Test dashboard"\n}';
+const dashboardYAML = 'title: Test dashboard\n';
+
+function setup({ isViewingYAML = false, height = 320 } = {}) {
+  mockAutoSizerHeight = height;
+
+  const model = new ExportAsCode({ isViewingYAML });
+  jest.spyOn(model, 'getExportableDashboardJson').mockResolvedValue({
+    json: dashboard,
+    hasLibraryPanels: false,
+    initialSaveModelVersion: 'v1',
+  });
+  const onSaveAsFile = jest.spyOn(model, 'onSaveAsFile').mockResolvedValue();
+  const onClipboardCopy = jest.spyOn(model, 'onClipboardCopy').mockResolvedValue();
+
+  render(<model.Component model={model} />);
+
+  return { onClipboardCopy, onSaveAsFile };
+}
+
+describe('ExportAsCode', () => {
+  beforeEach(() => {
+    Object.defineProperty(document, 'execCommand', { configurable: true, value: jest.fn() });
+  });
+
+  it('renders autosized JSON in a read-only CodeMirror editor', async () => {
+    setup({ height: 480 });
+
+    const editor = await screen.findByRole('textbox', { name: 'Dashboard definition' });
+
+    expect(editor).toHaveValue(dashboardJson);
+    expect(editor).toHaveAttribute('data-language', 'json');
+    expect(editor).toHaveAttribute('data-height', '480px');
+    expect(editor).toHaveAttribute('readonly');
+    expect(screen.queryByTestId('monaco-editor')).not.toBeInTheDocument();
+  });
+
+  it('renders YAML when the YAML format is selected', async () => {
+    setup({ isViewingYAML: true });
+
+    const editor = await screen.findByRole('textbox', { name: 'Dashboard definition' });
+
+    expect(editor).toHaveValue(dashboardYAML);
+    expect(editor).toHaveAttribute('data-language', 'yaml');
+  });
+
+  it('copies the rendered dashboard definition', async () => {
+    const { onClipboardCopy } = setup();
+    await screen.findByRole('textbox', { name: 'Dashboard definition' });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Copy to clipboard' }));
+
+    expect(onClipboardCopy).toHaveBeenCalledWith(dashboardJson);
+  });
+
+  it('preserves the dashboard download action', async () => {
+    const { onSaveAsFile } = setup();
+    await screen.findByRole('textbox', { name: 'Dashboard definition' });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Download file' }));
+
+    expect(onSaveAsFile).toHaveBeenCalledTimes(1);
+  });
+});

--- a/public/app/features/dashboard-scene/sharing/ExportButton/ExportAsCode.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/ExportAsCode.test.tsx
@@ -32,15 +32,19 @@ jest.mock('@grafana/ui/unstable', () => ({
     language,
     height,
     readOnly,
-    'aria-label': ariaLabel,
   }: {
     value: string;
     language?: string;
     height?: string;
     readOnly?: boolean;
-    'aria-label'?: string;
   }) => (
-    <textarea aria-label={ariaLabel} data-height={height} data-language={language} readOnly={readOnly} value={value} />
+    <textarea
+      data-testid="code-mirror-editor"
+      data-height={height}
+      data-language={language}
+      readOnly={readOnly}
+      value={value}
+    />
   ),
 }));
 
@@ -73,7 +77,7 @@ describe('ExportAsCode', () => {
   it('renders autosized JSON in a read-only CodeMirror editor', async () => {
     setup({ height: 480 });
 
-    const editor = await screen.findByRole('textbox', { name: 'Dashboard definition' });
+    const editor = await screen.findByTestId('code-mirror-editor');
 
     expect(editor).toHaveValue(dashboardJson);
     expect(editor).toHaveAttribute('data-language', 'json');
@@ -85,7 +89,7 @@ describe('ExportAsCode', () => {
   it('renders YAML when the YAML format is selected', async () => {
     setup({ isViewingYAML: true });
 
-    const editor = await screen.findByRole('textbox', { name: 'Dashboard definition' });
+    const editor = await screen.findByTestId('code-mirror-editor');
 
     expect(editor).toHaveValue(dashboardYAML);
     expect(editor).toHaveAttribute('data-language', 'yaml');
@@ -93,7 +97,7 @@ describe('ExportAsCode', () => {
 
   it('copies the rendered dashboard definition', async () => {
     const { onClipboardCopy } = setup();
-    await screen.findByRole('textbox', { name: 'Dashboard definition' });
+    await screen.findByTestId('code-mirror-editor');
 
     await userEvent.click(screen.getByRole('button', { name: 'Copy to clipboard' }));
 
@@ -102,7 +106,7 @@ describe('ExportAsCode', () => {
 
   it('preserves the dashboard download action', async () => {
     const { onSaveAsFile } = setup();
-    await screen.findByRole('textbox', { name: 'Dashboard definition' });
+    await screen.findByTestId('code-mirror-editor');
 
     await userEvent.click(screen.getByRole('button', { name: 'Download file' }));
 

--- a/public/app/features/dashboard-scene/sharing/ExportButton/ExportAsCode.tsx
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/ExportAsCode.tsx
@@ -77,7 +77,6 @@ function ExportAsCodeRenderer({ model }: SceneComponentProps<ExportAsCode>) {
                   height={`${height}px`}
                   onChange={() => {}}
                   readOnly
-                  aria-label={t('export.json.dashboard-definition', 'Dashboard definition')}
                 />
               );
             }

--- a/public/app/features/dashboard-scene/sharing/ExportButton/ExportAsCode.tsx
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/ExportAsCode.tsx
@@ -7,7 +7,8 @@ import { type GrafanaTheme2 } from '@grafana/data';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { type SceneComponentProps } from '@grafana/scenes';
-import { Button, ClipboardButton, CodeEditor, Spinner, Stack, useStyles2 } from '@grafana/ui';
+import { Button, ClipboardButton, Spinner, Stack, useStyles2 } from '@grafana/ui';
+import { CodeMirrorEditor } from '@grafana/ui/unstable';
 import { createSuccessNotification } from 'app/core/copy/appNotification';
 import { notifyApp } from 'app/core/reducers/appNotification';
 import { ExportFormat } from 'app/features/dashboard/api/types';
@@ -70,14 +71,13 @@ function ExportAsCodeRenderer({ model }: SceneComponentProps<ExportAsCode>) {
           {({ height }) => {
             if (stringifiedDashboard) {
               return (
-                <CodeEditor
+                <CodeMirrorEditor
                   value={stringifiedDashboard}
                   language={isViewingYAML ? 'yaml' : 'json'}
-                  showLineNumbers={true}
-                  showMiniMap={false}
-                  height={height}
-                  width="100%"
-                  readOnly={true}
+                  height={`${height}px`}
+                  onChange={() => {}}
+                  readOnly
+                  aria-label={t('export.json.dashboard-definition', 'Dashboard definition')}
                 />
               );
             }

--- a/public/app/features/dashboard-scene/sharing/ExportButton/ExportAsCode.tsx
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/ExportAsCode.tsx
@@ -75,6 +75,7 @@ function ExportAsCodeRenderer({ model }: SceneComponentProps<ExportAsCode>) {
                   value={stringifiedDashboard}
                   language={isViewingYAML ? 'yaml' : 'json'}
                   height={`${height}px`}
+                  aria-label={t('export.json.dashboard-definition', 'Dashboard definition')}
                   onChange={() => {}}
                   readOnly
                 />

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9147,6 +9147,7 @@
     "json": {
       "cancel-button": "Cancel",
       "copy-button": "Copy to clipboard",
+      "dashboard-definition": "Dashboard definition",
       "download-button": "Download file",
       "download-successful_toast_message": "Your JSON has been downloaded",
       "export-format": "Format",


### PR DESCRIPTION
## Related Issue
<!--- Put both the github and linear issue here, "Fixes #123, Fixes DPRO-123" -->

Fixes #130710, Fixes DPRO-319

## Description
<!--- A high level description of what this PR is doing -->

Replaces the Monaco-backed editor in the dashboard export-as-code drawer with the lazy CodeMirror editor. The viewer remains read-only and continues to support JSON and YAML exports without a feature flag.

## Changes
<!--- Describe your changes in detail -->
* Use `CodeMirrorEditor` from `@grafana/ui/unstable` in the dashboard export viewer.
* Preserve AutoSizer-driven height, syntax selection, clipboard copy, and file download behavior.
* Add focused coverage for JSON, YAML, read-only rendering, dynamic height, copy, download, and the absence of Monaco.

## Risks
<!--- Describe what risks you've considered i.e. what features are most likely to break -->

The main risks are regressions in export formatting, sizing, or read-only editor behavior. Focused tests cover those paths, and the workflow was exercised locally in light and dark themes at multiple viewport heights.

## Demo
<!--- Attach a demo gif/video or screenshots of the changes if applicable -->
<img width="1631" height="1221" alt="CleanShot 2026-08-21 at 10 52 50" src="https://github.com/user-attachments/assets/b1f5fb68-c1ed-4762-b4df-9ca3d4b2447c" />

## Testing Instructions
<!--- Provide step by step instructions on how a reviewer can reproduce this manually and the dashboard if applicable -->
* Open a dashboard and select **Export > Export as code**.
* Switch between JSON and YAML, copy the definition, download the file, and resize the browser vertically.
* Repeat in light and dark themes.

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable
