### PR TITLE
OFREP: Serve deprecated /apis/features.grafana.app path on standalone mux

### DIFF
--- a/pkg/services/ofrep/http_routes.go
+++ b/pkg/services/ofrep/http_routes.go
@@ -43,8 +43,11 @@ func (b *APIBuilder) Setup(m *k8smux.PathRecorderMux) {
 	r := mux.NewRouter()
 	r.Methods(http.MethodPost).Path("/ofrep/v1/evaluate/flags").HandlerFunc(b.allFlagsHandler)
 	r.Methods(http.MethodPost).Path("/ofrep/v1/evaluate/flags/{flagKey}").HandlerFunc(b.oneFlagHandler)
+	r.Methods(http.MethodPost).Path("/apis/features.grafana.app/v0alpha1/namespaces/{namespace}/ofrep/v1/evaluate/flags").HandlerFunc(b.allFlagsHandler)
+	r.Methods(http.MethodPost).Path("/apis/features.grafana.app/v0alpha1/namespaces/{namespace}/ofrep/v1/evaluate/flags/{flagKey}").HandlerFunc(b.oneFlagHandler)
 
 	m.HandlePrefix("/ofrep/", r)
+	m.HandlePrefix("/apis/features.grafana.app/", r)
 }
 
 // grafanaHTTPHandler adapts an OFREP http.HandlerFunc to Grafana's router. It injects the

--- a/pkg/services/ofrep/http_routes_test.go
+++ b/pkg/services/ofrep/http_routes_test.go
@@ -382,4 +382,9 @@ func TestSetup_RegistersRoutesOnStandaloneMux(t *testing.T) {
 	w := httptest.NewRecorder()
 	m.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
+
+	deprecated := httptest.NewRequest(http.MethodPost, "/apis/features.grafana.app/v0alpha1/namespaces/stacks-1/ofrep/v1/evaluate/flags", bytes.NewBufferString(`{}`))
+	w = httptest.NewRecorder()
+	m.ServeHTTP(w, deprecated)
+	assert.Equal(t, http.StatusOK, w.Code)
 }


### PR DESCRIPTION
**What is this feature?**

`APIBuilder.Setup()` now registers the deprecated namespaced OFREP path on the standalone mux, in addition to `/ofrep/`:

`POST /apis/features.grafana.app/v0alpha1/namespaces/{namespace}/ofrep/v1/evaluate/flags[/{flagKey}]`

**Why do we need this feature?**

grafana#129067 moved OFREP off the dummy k8s API group. MTFF (`features-grafana-app-main`) only served `/ofrep/`, so the aggregator discovery check 404s and plugin callers of the old path get 503. This restores the old path on the standalone server so hg-gateway can direct-route it to MTFF without a path rewrite.

**Who is this feature for?**

Grafana Cloud (MTFF / plugins still on the deprecated OFREP URL).

**Which issue(s) does this PR fix?**:

Fixes the grafana-dev OFREP 503 on `/apis/features.grafana.app/.../ofrep/v1/evaluate/flags` (Slack `#grafana-feature-flags`).

**Special notes for your reviewer:**

Paired with grafana-enterprise authorizer allow for the same path (unauth public-flag eval), plus hg-gateway direct-route jsonnet.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.