### PR TITLE
E2E: Select datasource variable type from listbox

### DIFF
--- a/e2e-playwright/dashboard-new-layouts/page-objects/sidebar/VariableOptions.ts
+++ b/e2e-playwright/dashboard-new-layouts/page-objects/sidebar/VariableOptions.ts
@@ -57,7 +57,7 @@ export class VariableOptions extends PageObject {
           this.selectors.pages.Dashboard.Settings.Variables.Edit.DatasourceVariable.datasourceSelect
         );
         await datasourceSelect.fill(dsType);
-        await datasourceSelect.press('Enter');
+        await this.page.getByRole('listbox').getByRole('option', { name: dsType, exact: true }).click();
       });
     },
     /** Sets the datasource name filter */


### PR DESCRIPTION
## What

- Select the datasource variable type by clicking the exact option in the portalled listbox instead of pressing Enter immediately after filtering.

## Why

Datasource type options are loaded asynchronously. The Enter-based interaction races the combobox update: the visible `TestData` option can fail to commit, leaving the datasource variable empty and making the chained query-variable preview return no values. This caused unrelated Playwright failures on grafana/grafana#130513 and grafana/grafana-enterprise#13022.

The explicit option click matches the dashboard-new-layouts page-object convention for portalled combobox options and waits for the option to be actionable.

## Verification

- `yarn eslint e2e-playwright/dashboard-new-layouts/page-objects/sidebar/VariableOptions.ts`
- Control run with the original Enter interaction: reproduced the chained-variable failure in 1 of 3 repetitions.
- Updated full spec: 7/7 tests passed across 3 repetitions.
- Updated focused chained-variable test: 11/11 tests passed across 10 repetitions (including authentication setup).
