### PR TITLE
Provisioning: Remove file cap when running PR jobs

### DIFF
--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/changes.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/changes.go
@@ -41,8 +41,10 @@ type changeInfo struct {
 	// Files we tried to read
 	Changes []fileChangeInfo
 
-	// More files changed than we processed
-	SkippedFiles int
+	// UnprocessedFiles is how many changed files Evaluate never got to -- e.g.
+	// because the job's context was canceled/expired partway through a large
+	// PR. Zero means every file in the diff was evaluated.
+	UnprocessedFiles int
 
 	// Requested image render, but it is not available
 	MissingImageRenderer bool
@@ -140,11 +142,10 @@ func (e *evaluator) Evaluate(ctx context.Context, repo repository.Reader, opts p
 
 	logger := logging.FromContext(ctx)
 
-	for i, change := range changes {
-		// process maximum 10 files
-		if i >= 10 {
-			info.SkippedFiles = len(changes) - i
-			logger.Info("skipping remaining files", "count", info.SkippedFiles)
+	for _, change := range changes {
+		if ctx.Err() != nil {
+			info.UnprocessedFiles = len(changes) - len(info.Changes)
+			logger.Error("stopping pull request evaluation early", "reason", ctx.Err(), "processed", len(info.Changes), "unprocessed", info.UnprocessedFiles)
 			break
 		}
 

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
@@ -568,7 +568,7 @@ func TestCalculateChanges(t *testing.T) {
 			},
 		},
 		{
-			name: "process first 10 files",
+			name: "process all files",
 			setupMocks: func(parser *resources.MockParser, reader *repository.MockReader, progress *jobs.MockJobProgressRecorder, renderer *MockScreenshotRenderer, parserFactory *resources.MockParserFactory) {
 				finfo := &repository.FileInfo{
 					Path: "path/to/file.json",
@@ -633,10 +633,9 @@ func TestCalculateChanges(t *testing.T) {
 				return changes
 			}(),
 			expectedInfo: changeInfo{
-				SkippedFiles: 5,
 				Changes: func() []fileChangeInfo {
-					changes := make([]fileChangeInfo, 0, 10)
-					for range 10 {
+					changes := make([]fileChangeInfo, 0, 15)
+					for range 15 {
 						changes = append(changes, fileChangeInfo{
 							Change: repository.VersionedFileChange{
 								Action: repository.FileActionCreated,
@@ -1422,7 +1421,6 @@ func TestCalculateChanges(t *testing.T) {
 
 			require.NoError(t, err)
 			require.Equal(t, len(tt.expectedInfo.Changes), len(info.Changes))
-			require.Equal(t, tt.expectedInfo.SkippedFiles, info.SkippedFiles)
 
 			// compare change URLs
 			for i, change := range info.Changes {
@@ -1806,6 +1804,111 @@ func TestEvaluate_GitHubEnterpriseDoesNotPanic(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Len(t, info.Changes, 1)
+}
+
+// A canceled context must stop the loop before it touches any file -- reader/parser
+// mocks below have no expectations set, so a call past the cancellation check would
+// panic. This guards against burning through a large PR's file list (and filling the
+// comment with spurious "context canceled" errors) once the job's context expires.
+func TestEvaluate_StopsWhenContextIsCanceled(t *testing.T) {
+	reader := repository.NewMockReader(t)
+	reader.On("Config").Return(&provisioning.Repository{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-repo", Namespace: "x"},
+		Spec:       provisioning.RepositorySpec{Type: provisioning.GitHubRepositoryType},
+	})
+
+	parserFactory := resources.NewMockParserFactory(t)
+	parserFactory.On("GetParser", mock.Anything, mock.Anything).Return(resources.NewMockParser(t), nil)
+
+	renderer := NewMockScreenshotRenderer(t)
+	renderer.On("IsAvailable", mock.Anything).Return(false)
+
+	progress := jobs.NewMockJobProgressRecorder(t)
+
+	evaluator := NewEvaluator(renderer, parserFactory, URLProvider{
+		Internal: func(_ context.Context, _ string) string { return "http://host/" },
+		Public:   func(_ context.Context, _ string) string { return "http://host/" },
+	}, prometheus.NewPedanticRegistry())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	info, err := evaluator.Evaluate(ctx, reader, provisioning.PullRequestJobOptions{Ref: "ref"}, []repository.VersionedFileChange{
+		{Action: repository.FileActionCreated, Path: "a.json", Ref: "ref"},
+		{Action: repository.FileActionCreated, Path: "b.json", Ref: "ref"},
+		{Action: repository.FileActionCreated, Path: "c.json", Ref: "ref"},
+	}, progress)
+
+	require.NoError(t, err)
+	require.Empty(t, info.Changes, "canceled context should stop the loop before any file is evaluated")
+	require.Equal(t, 3, info.UnprocessedFiles, "every file is unprocessed when canceled before the loop starts")
+}
+
+// The context expires partway through the diff (simulated by canceling from
+// inside the mock reader as it reads the second file). The first file, already
+// in flight, still completes; the loop then sees the canceled context at the
+// top of the next iteration and stops, leaving the last file unprocessed.
+func TestEvaluate_TracksUnprocessedFilesWhenCanceledMidway(t *testing.T) {
+	obj := func(name string) *unstructured.Unstructured {
+		return &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": resources.DashboardResource.GroupVersion().String(),
+				"kind":       dashboardKind,
+				"metadata":   map[string]interface{}{"name": name},
+				"spec":       map[string]interface{}{"title": name},
+			},
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	reader := repository.NewMockReader(t)
+	reader.On("Config").Return(&provisioning.Repository{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-repo", Namespace: "x"},
+		Spec:       provisioning.RepositorySpec{Type: provisioning.GitHubRepositoryType},
+	})
+
+	aInfo := &repository.FileInfo{Path: "a.json", Ref: "ref", Data: []byte("xxxx")}
+	bInfo := &repository.FileInfo{Path: "b.json", Ref: "ref", Data: []byte("xxxx")}
+	reader.On("Read", mock.Anything, "a.json", "ref").Return(aInfo, nil)
+	// Canceling here simulates the job's context expiring while this file is
+	// being read; the read itself (a mock) still succeeds, matching a real
+	// cancellation racing with an in-flight request rather than preempting it.
+	reader.On("Read", mock.Anything, "b.json", "ref").Run(func(mock.Arguments) { cancel() }).Return(bInfo, nil)
+
+	aMeta, _ := utils.MetaAccessor(obj("a"))
+	bMeta, _ := utils.MetaAccessor(obj("b"))
+	parser := resources.NewMockParser(t)
+	parser.On("Parse", mock.Anything, aInfo).Return(&resources.ParsedResource{
+		Info: aInfo, GVK: schema.GroupVersionKind{Kind: dashboardKind}, Obj: obj("a"), Meta: aMeta, DryRunResponse: obj("a"),
+	}, nil)
+	parser.On("Parse", mock.Anything, bInfo).Return(&resources.ParsedResource{
+		Info: bInfo, GVK: schema.GroupVersionKind{Kind: dashboardKind}, Obj: obj("b"), Meta: bMeta, DryRunResponse: obj("b"),
+	}, nil)
+
+	parserFactory := resources.NewMockParserFactory(t)
+	parserFactory.On("GetParser", mock.Anything, mock.Anything).Return(parser, nil)
+
+	renderer := NewMockScreenshotRenderer(t)
+	renderer.On("IsAvailable", mock.Anything).Return(false)
+
+	progress := jobs.NewMockJobProgressRecorder(t)
+	progress.On("SetMessage", mock.Anything, mock.Anything).Return()
+
+	evaluator := NewEvaluator(renderer, parserFactory, URLProvider{
+		Internal: func(_ context.Context, _ string) string { return "http://host/" },
+		Public:   func(_ context.Context, _ string) string { return "http://host/" },
+	}, prometheus.NewPedanticRegistry())
+
+	info, err := evaluator.Evaluate(ctx, reader, provisioning.PullRequestJobOptions{Ref: "ref"}, []repository.VersionedFileChange{
+		{Action: repository.FileActionCreated, Path: "a.json", Ref: "ref"},
+		{Action: repository.FileActionCreated, Path: "b.json", Ref: "ref"},
+		{Action: repository.FileActionCreated, Path: "c.json", Ref: "ref"},
+	}, progress)
+
+	require.NoError(t, err)
+	require.Len(t, info.Changes, 2, "a and b were already in flight/complete when the context expired")
+	require.Equal(t, 1, info.UnprocessedFiles, "c never started")
 }
 
 func TestDummyImageURL(t *testing.T) {

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/comment.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/comment.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"text/template"
 
@@ -12,6 +13,11 @@ import (
 
 const maxErrorLength = 256
 
+// maxDisplayedChanges caps how many rows the comment table renders. PR jobs now
+// process every changed file, but a very large PR would otherwise produce an
+// unreadably long comment.
+const maxDisplayedChanges = 10
+
 type commenter struct {
 	templateDashboard        *template.Template
 	templateTable            *template.Template
@@ -19,6 +25,7 @@ type commenter struct {
 	templateFooter           *template.Template
 	templateValidationErrors *template.Template
 	templateMetadataNotice   *template.Template
+	templateUnprocessedFiles *template.Template
 	showImageRendererNote    bool
 }
 
@@ -30,6 +37,7 @@ func NewCommenter(showImageRendererNote bool) Commenter {
 		templateFooter:           template.Must(template.New("footer").Parse(commentTemplateFooter)),
 		templateValidationErrors: template.Must(template.New("errors").Parse(commentTemplateValidationErrors)),
 		templateMetadataNotice:   template.Must(template.New("metadata").Parse(commentTemplateMetadataNotice)),
+		templateUnprocessedFiles: template.Must(template.New("unprocessed").Parse(commentTemplateUnprocessedFiles)),
 		showImageRendererNote:    showImageRendererNote,
 	}
 }
@@ -50,21 +58,33 @@ func (c *commenter) Comment(ctx context.Context, prRepo repository.PullRequestRe
 func (c *commenter) generateComment(_ context.Context, info changeInfo) (string, error) {
 	var buf bytes.Buffer
 
-	// TODO: should we comment even if there are no changes?
-	if len(info.Changes) == 0 {
+	switch {
+	case len(info.Changes) == 0 && info.UnprocessedFiles > 0:
+
+		buf.WriteString(fmt.Sprintf("This pull request was interrupted. %d / %d files were not processed.", info.UnprocessedFiles, info.TotalFilesInDiff()))
+	case len(info.Changes) == 0:
 		buf.WriteString("Grafana didn't find any changes in this pull request.")
-	} else if len(info.Changes) == 1 && info.Changes[0].Parsed != nil && info.Changes[0].Parsed.GVK.Kind == dashboardKind {
+	case len(info.Changes) == 1 && info.Changes[0].Parsed != nil && info.Changes[0].Parsed.GVK.Kind == dashboardKind:
 		if err := c.templateDashboard.Execute(&buf, &info.Changes[0]); err != nil {
 			return "", fmt.Errorf("unable to execute template: %w", err)
 		}
-	} else {
+	default:
 		if err := c.templateTable.Execute(&buf, &info); err != nil {
 			return "", fmt.Errorf("unable to execute template: %w", err)
 		}
-		if info.HasErrors() {
+		if len(info.ErrorIndexes()) > 0 {
 			if err := c.templateValidationErrors.Execute(&buf, &info); err != nil {
 				return "", fmt.Errorf("unable to execute validation errors template: %w", err)
 			}
+		}
+	}
+
+	// Changes were already shown above with their own (possibly misleading) counts;
+	// this appends the caveat rather than replacing the body. The empty case above
+	// already states the interruption directly, so it's excluded here.
+	if len(info.Changes) > 0 && info.UnprocessedFiles > 0 {
+		if err := c.templateUnprocessedFiles.Execute(&buf, &info); err != nil {
+			return "", fmt.Errorf("unable to execute unprocessed files template: %w", err)
 		}
 	}
 
@@ -123,18 +143,21 @@ const commentTemplateSingleDashboard = `{{define "title"}}{{if .SourceURL}}[**{{
 {{- end}}
 `
 
-const commentTemplateTable = `📋 Grafana detected **{{.TotalChanges}}** resource change{{if ne .TotalChanges 1}}s{{end}} in this pull request{{- if .HasErrors}} — ⚠️ {{.ErrorCount}} need{{if eq .ErrorCount 1}}s{{end}} attention{{- end}}.
+const commentTemplateTable = `📋 Grafana detected **{{.TotalChanges}}** resource change{{if ne .TotalChanges 1}}s{{end}} in this pull request{{- if gt (len .ErrorIndexes) 0}} — ⚠️ {{len .ErrorIndexes}} need{{if eq (len .ErrorIndexes) 1}}s{{end}} attention{{- end}}.
+
+**By action:** {{range $i, $e := .ActionCounts}}{{if $i}}, {{end}}{{$e.Label}} ({{$e.Count}}){{end}}
+**By kind:** {{range $i, $e := .KindCounts}}{{if $i}}, {{end}}{{$e.Label}} ({{$e.Count}}){{end}}
+{{- if gt .TotalChanges .DisplayedCount}}
+
+{{.DisplayedCount}} / {{.TotalChanges}} change details shown below
+{{- end}}
 
 | Action | Kind | Resource | File | Preview | Status |
 |--------|------|----------|------|---------|--------|
-{{- range .Changes}}
+{{- range .DisplayedChanges}}
 | {{.ActionLabel}} | {{.Kind}} | {{.ExistingLink}} | {{ if .SourceURL}}[source]({{.SourceURL}}){{ else }}{{.SafeFilePath}}{{ end }} | {{ if .PreviewURL}}[preview]({{.PreviewURL}}){{ end }} | {{.StatusIcon}} |
 {{- end -}}
-{{- if .SkippedFiles}}
-
-and {{ .SkippedFiles }} more files.
-{{- end}}
-{{- if not .HasErrors}}
+{{- if eq (len .ErrorIndexes) 0}}
 
 All resources passed validation. ✅
 {{- end}}`
@@ -145,9 +168,13 @@ const commentTemplateValidationErrors = `
 
 | File | Error |
 |------|-------|
-{{- range .Changes}}{{ if .Error}}
+{{- range .ValidationIssues}}
 | ` + "`{{.Change.Path}}`" + ` | {{.TruncatedError}} |
-{{- end}}{{ end}}
+{{- end}}
+{{- if gt .HiddenErrorCount 0}}
+
+{{.HiddenErrorCount}} more error{{if ne .HiddenErrorCount 1}}s{{end}} not displayed
+{{- end}}
 `
 
 // TODO(ferruvich): let's discuss this text with the team
@@ -158,6 +185,10 @@ const commentTemplateMetadataNotice = `
 const commentTemplateMissingImageRenderer = `
 
 💡 **Tip:** To enable dashboard previews in pull requests, refer to the [image rendering setup documentation](https://grafana.com/docs/grafana/latest/observability-as-code/provision-resources/git-sync-setup/#configure-webhooks-and-image-rendering).`
+
+const commentTemplateUnprocessedFiles = `
+
+⚠️ **Evaluation stopped early:** {{.UnprocessedFiles}} / {{.TotalFilesInDiff}} file{{if ne .UnprocessedFiles 1}}s{{end}} in this pull request {{if eq .UnprocessedFiles 1}}was{{else}}were{{end}} not evaluated (the job ran out of time).`
 
 const commentTemplateFooter = `
 
@@ -276,15 +307,6 @@ func (c changeInfo) SafeRepositoryTitle() string {
 	return escapeMarkdown(c.RepositoryTitle)
 }
 
-func (c *changeInfo) HasErrors() bool {
-	for i := range c.Changes {
-		if c.Changes[i].Error != "" {
-			return true
-		}
-	}
-	return false
-}
-
 func (c *changeInfo) HasRemovedMetadataChanges() bool {
 	for i := range c.Changes {
 		if c.Changes[i].HasRemovedMetadata {
@@ -298,12 +320,111 @@ func (c *changeInfo) TotalChanges() int {
 	return len(c.Changes)
 }
 
-func (c *changeInfo) ErrorCount() int {
-	n := 0
+// TotalFilesInDiff is the size of the whole PR diff Evaluate was given,
+// including files it never got to (UnprocessedFiles). It's TotalChanges when
+// nothing was left unprocessed.
+func (c *changeInfo) TotalFilesInDiff() int {
+	return len(c.Changes) + c.UnprocessedFiles
+}
+
+// DisplayedChanges returns the changes rendered as table rows, capped at
+// maxDisplayedChanges.
+func (c *changeInfo) DisplayedChanges() []fileChangeInfo {
+	if len(c.Changes) <= maxDisplayedChanges {
+		return c.Changes
+	}
+	return c.Changes[:maxDisplayedChanges]
+}
+
+func (c *changeInfo) DisplayedCount() int {
+	return len(c.DisplayedChanges())
+}
+
+// ErrorIndexes returns the indexes into Changes of every change that failed
+// (has a non-empty Error).
+func (c *changeInfo) ErrorIndexes() []int {
+	var indexes []int
 	for i := range c.Changes {
 		if c.Changes[i].Error != "" {
-			n++
+			indexes = append(indexes, i)
 		}
 	}
-	return n
+	return indexes
+}
+
+// ValidationIssues returns the changes that failed, capped at maxDisplayedChanges
+// (the first 10 entries from ErrorIndexes), for the validation issues table.
+func (c *changeInfo) ValidationIssues() []fileChangeInfo {
+	indexes := c.ErrorIndexes()
+	if len(indexes) > maxDisplayedChanges {
+		indexes = indexes[:maxDisplayedChanges]
+	}
+
+	issues := make([]fileChangeInfo, 0, len(indexes))
+	for _, i := range indexes {
+		issues = append(issues, c.Changes[i])
+	}
+	return issues
+}
+
+// HiddenErrorCount returns how many failed changes are not shown in
+// ValidationIssues because the table is capped at maxDisplayedChanges.
+func (c *changeInfo) HiddenErrorCount() int {
+	return len(c.ErrorIndexes()) - len(c.ValidationIssues())
+}
+
+type countEntry struct {
+	Label string
+	Count int
+}
+
+// actionLabelOrder mirrors the case order in fileChangeInfo.ActionLabel, so the
+// per-action breakdown reads in the same create/update/delete/move/rename/ignore
+// sequence reviewers already see in the table above it.
+var actionLabelOrder = []string{"➕ Added", "✏️ Updated", "🗑️ Deleted", "➡️ Moved", "📝 Renamed", "🚫 Ignored"}
+
+// ActionCounts groups Changes by ActionLabel and counts files in each group.
+func (c *changeInfo) ActionCounts() []countEntry {
+	counts := map[string]int{}
+	for i := range c.Changes {
+		counts[c.Changes[i].ActionLabel()]++
+	}
+	return orderedCounts(counts, actionLabelOrder)
+}
+
+// KindCounts groups Changes by resource kind (info.Parsed.GVK.Kind) and counts
+// files in each group.
+func (c *changeInfo) KindCounts() []countEntry {
+	counts := map[string]int{}
+	for i := range c.Changes {
+		counts[c.Changes[i].Kind()]++
+	}
+	return orderedCounts(counts, nil)
+}
+
+// orderedCounts returns one countEntry per label in counts: labels listed in
+// priority come first in that order, followed by any remaining labels sorted
+// alphabetically.
+func orderedCounts(counts map[string]int, priority []string) []countEntry {
+	var entries []countEntry
+	seen := make(map[string]bool, len(priority))
+	for _, label := range priority {
+		if n, ok := counts[label]; ok {
+			entries = append(entries, countEntry{Label: label, Count: n})
+			seen[label] = true
+		}
+	}
+
+	rest := make([]string, 0, len(counts)-len(seen))
+	for label := range counts {
+		if !seen[label] {
+			rest = append(rest, label)
+		}
+	}
+	sort.Strings(rest)
+	for _, label := range rest {
+		entries = append(entries, countEntry{Label: label, Count: counts[label]})
+	}
+
+	return entries
 }

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/comment_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/comment_test.go
@@ -3,6 +3,7 @@ package pullrequest
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -140,7 +141,6 @@ func TestGenerateComment(t *testing.T) {
 			RepositoryName:     "my-repo",
 			RepositoryTitle:    "My Repo",
 			RepositoryAdminURL: "http://host/admin/provisioning/my-repo",
-			SkippedFiles:       5,
 			Changes: []fileChangeInfo{
 				{
 					Parsed: &resources.ParsedResource{
@@ -296,6 +296,64 @@ func TestGenerateComment(t *testing.T) {
 					Error: "strict decoding error: unknown field \"spec.extra\"",
 				},
 			},
+		}},
+		{"many files", changeInfo{
+			GrafanaBaseURL: "http://host/",
+			Changes: func() []fileChangeInfo {
+				changes := make([]fileChangeInfo, 0, 12)
+				for i := 1; i <= 12; i++ {
+					path := fmt.Sprintf("file%02d.json", i)
+					changes = append(changes, fileChangeInfo{
+						Parsed: &resources.ParsedResource{
+							Info:   &repository.FileInfo{Path: path},
+							Action: v0alpha1.ResourceActionCreate,
+							GVK:    schema.GroupVersionKind{Kind: "Dashboard"},
+						},
+						Title:     fmt.Sprintf("Dashboard %02d", i),
+						SourceURL: fmt.Sprintf("https://github.com/example/repo/blob/pr/%s", path),
+					})
+				}
+				return changes
+			}(),
+		}},
+		{"many files with errors", changeInfo{
+			GrafanaBaseURL: "http://host/",
+			Changes: func() []fileChangeInfo {
+				changes := make([]fileChangeInfo, 0, 12)
+				for i := 1; i <= 12; i++ {
+					path := fmt.Sprintf("file%02d.json", i)
+					changes = append(changes, fileChangeInfo{
+						Change: repository.VersionedFileChange{Path: path},
+						Parsed: &resources.ParsedResource{
+							Info:   &repository.FileInfo{Path: path},
+							Action: v0alpha1.ResourceActionCreate,
+							GVK:    schema.GroupVersionKind{Kind: "Dashboard"},
+						},
+						Title: fmt.Sprintf("Dashboard %02d", i),
+						Error: "strict decoding error: unknown field \"spec.extra\"",
+					})
+				}
+				return changes
+			}(),
+		}},
+		{"multiple files with unprocessed", changeInfo{
+			GrafanaBaseURL:   "http://host/",
+			UnprocessedFiles: 2,
+			Changes: []fileChangeInfo{
+				{
+					Parsed: &resources.ParsedResource{
+						Info:   &repository.FileInfo{Path: "aaa.json"},
+						Action: v0alpha1.ResourceActionCreate,
+						GVK:    schema.GroupVersionKind{Kind: "Dashboard"},
+					},
+					Title:     "Dash A",
+					SourceURL: "https://github.com/example/repo/blob/pr/aaa.json",
+				},
+			},
+		}},
+		{"interrupted before any file", changeInfo{
+			GrafanaBaseURL:   "http://host/",
+			UnprocessedFiles: 5,
 		}},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/interrupted-before-any-file.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/interrupted-before-any-file.md
@@ -1,0 +1,4 @@
+This pull request was interrupted. 5 / 5 files were not processed.
+
+---
+_Posted by [host](http://host/)_

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/many-files-with-errors.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/many-files-with-errors.md
@@ -1,0 +1,39 @@
+📋 Grafana detected **12** resource changes in this pull request — ⚠️ 12 need attention.
+
+**By action:** ➕ Added (12)
+**By kind:** Dashboard (12)
+
+10 / 12 change details shown below
+
+| Action | Kind | Resource | File | Preview | Status |
+|--------|------|----------|------|---------|--------|
+| ➕ Added | Dashboard | Dashboard 01 | file01.json |  | ⚠️ |
+| ➕ Added | Dashboard | Dashboard 02 | file02.json |  | ⚠️ |
+| ➕ Added | Dashboard | Dashboard 03 | file03.json |  | ⚠️ |
+| ➕ Added | Dashboard | Dashboard 04 | file04.json |  | ⚠️ |
+| ➕ Added | Dashboard | Dashboard 05 | file05.json |  | ⚠️ |
+| ➕ Added | Dashboard | Dashboard 06 | file06.json |  | ⚠️ |
+| ➕ Added | Dashboard | Dashboard 07 | file07.json |  | ⚠️ |
+| ➕ Added | Dashboard | Dashboard 08 | file08.json |  | ⚠️ |
+| ➕ Added | Dashboard | Dashboard 09 | file09.json |  | ⚠️ |
+| ➕ Added | Dashboard | Dashboard 10 | file10.json |  | ⚠️ |
+
+### ⚠️ Validation Issues
+
+| File | Error |
+|------|-------|
+| `file01.json` | strict decoding error: unknown field "spec.extra" |
+| `file02.json` | strict decoding error: unknown field "spec.extra" |
+| `file03.json` | strict decoding error: unknown field "spec.extra" |
+| `file04.json` | strict decoding error: unknown field "spec.extra" |
+| `file05.json` | strict decoding error: unknown field "spec.extra" |
+| `file06.json` | strict decoding error: unknown field "spec.extra" |
+| `file07.json` | strict decoding error: unknown field "spec.extra" |
+| `file08.json` | strict decoding error: unknown field "spec.extra" |
+| `file09.json` | strict decoding error: unknown field "spec.extra" |
+| `file10.json` | strict decoding error: unknown field "spec.extra" |
+
+2 more errors not displayed
+
+---
+_Posted by [host](http://host/)_

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/many-files.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/many-files.md
@@ -1,0 +1,24 @@
+📋 Grafana detected **12** resource changes in this pull request.
+
+**By action:** ➕ Added (12)
+**By kind:** Dashboard (12)
+
+10 / 12 change details shown below
+
+| Action | Kind | Resource | File | Preview | Status |
+|--------|------|----------|------|---------|--------|
+| ➕ Added | Dashboard | Dashboard 01 | [source](https://github.com/example/repo/blob/pr/file01.json) |  | ✅ |
+| ➕ Added | Dashboard | Dashboard 02 | [source](https://github.com/example/repo/blob/pr/file02.json) |  | ✅ |
+| ➕ Added | Dashboard | Dashboard 03 | [source](https://github.com/example/repo/blob/pr/file03.json) |  | ✅ |
+| ➕ Added | Dashboard | Dashboard 04 | [source](https://github.com/example/repo/blob/pr/file04.json) |  | ✅ |
+| ➕ Added | Dashboard | Dashboard 05 | [source](https://github.com/example/repo/blob/pr/file05.json) |  | ✅ |
+| ➕ Added | Dashboard | Dashboard 06 | [source](https://github.com/example/repo/blob/pr/file06.json) |  | ✅ |
+| ➕ Added | Dashboard | Dashboard 07 | [source](https://github.com/example/repo/blob/pr/file07.json) |  | ✅ |
+| ➕ Added | Dashboard | Dashboard 08 | [source](https://github.com/example/repo/blob/pr/file08.json) |  | ✅ |
+| ➕ Added | Dashboard | Dashboard 09 | [source](https://github.com/example/repo/blob/pr/file09.json) |  | ✅ |
+| ➕ Added | Dashboard | Dashboard 10 | [source](https://github.com/example/repo/blob/pr/file10.json) |  | ✅ |
+
+All resources passed validation. ✅
+
+---
+_Posted by [host](http://host/)_

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files-with-errors.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files-with-errors.md
@@ -1,5 +1,8 @@
 📋 Grafana detected **3** resource changes in this pull request — ⚠️ 2 need attention.
 
+**By action:** ➕ Added (2), ✏️ Updated (1)
+**By kind:** Dashboard (2), Playlist (1)
+
 | Action | Kind | Resource | File | Preview | Status |
 |--------|------|----------|------|---------|--------|
 | ➕ Added | Dashboard | Good Dashboard | good.json | [preview](http://grafana/admin/preview) | ✅ |

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files-with-stripped-metadata.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files-with-stripped-metadata.md
@@ -1,5 +1,8 @@
 📋 Grafana detected **2** resource changes in this pull request.
 
+**By action:** ➕ Added (1), ✏️ Updated (1)
+**By kind:** Dashboard (2)
+
 | Action | Kind | Resource | File | Preview | Status |
 |--------|------|----------|------|---------|--------|
 | ➕ Added | Dashboard | Dashboard A | [source](https://github.com/example/repo/blob/pr/good.json) | [preview](http://grafana/admin/preview) | ✅ |

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files-with-unprocessed.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files-with-unprocessed.md
@@ -1,0 +1,6 @@
+📊 Grafana detected dashboard changes in this pull request.
+
+⚠️ **Evaluation stopped early:** 2 / 3 files in this pull request were not evaluated (the job ran out of time).
+
+---
+_Posted by [host](http://host/)_

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files.md
@@ -1,12 +1,13 @@
 📋 Grafana detected **3** resource changes in this pull request.
 
+**By action:** ➕ Added (2), ✏️ Updated (1)
+**By kind:** Dashboard (2), Playlist (1)
+
 | Action | Kind | Resource | File | Preview | Status |
 |--------|------|----------|------|---------|--------|
 | ➕ Added | Dashboard | Dash A | [source](https://github.com/example/repo/blob/pr/aaa.json) | [preview](http://grafana/admin/preview) | ✅ |
 | ✏️ Updated | Dashboard | [Dash B](http://grafana/d/bbb) | [source](https://github.com/example/repo/blob/pr/bbb.json) | [preview](http://grafana/admin/preview) | ✅ |
 | ➕ Added | Playlist | My Playlist | [source](https://github.com/example/repo/blob/pr/ccc.json) |  | ✅ |
-
-and 5 more files.
 
 All resources passed validation. ✅
 

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/worker.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/worker.go
@@ -160,13 +160,31 @@ func (c *PullRequestWorker) Process(ctx context.Context,
 		return fmt.Errorf("calculate changes: %w", err)
 	}
 
-	if err := c.commenter.Comment(ctx, prRepo, opts.PR, changeInfo); err != nil {
+	commentCtx := ctx
+	if changeInfo.UnprocessedFiles > 0 {
+		// Context may already be cancelled but we want to make the comment
+		// to give a preview anyways
+		var cancel context.CancelFunc
+		commentCtx, cancel = context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cancel()
+	}
+
+	if err := c.commenter.Comment(commentCtx, prRepo, opts.PR, changeInfo); err != nil {
 		c.metrics.recordCommentPosted(utils.ErrorOutcome)
 		return fmt.Errorf("comment pull request: %w", err)
 	}
 	outcome = utils.SuccessOutcome
 	c.metrics.recordCommentPosted(utils.SuccessOutcome)
 	logger.Info("preview comment added")
+
+	if changeInfo.UnprocessedFiles > 0 {
+		// The comment already posted (with a caveat) covering whatever was evaluated
+		// before the context expired -- that's a successful outcome for this worker.
+		// Still surface it as a job-level warning so an incomplete evaluation is
+		// visible in job history, not indistinguishable from a normal success.
+		logger.Warn("pull request evaluation did not cover the whole diff", "unprocessedFiles", changeInfo.UnprocessedFiles)
+		return jobs.AsWarning(fmt.Errorf("evaluation stopped early: %d file(s) not processed", changeInfo.UnprocessedFiles))
+	}
 
 	return nil
 }

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/worker_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/worker_test.go
@@ -342,6 +342,55 @@ func TestPullRequestWorker_Process(t *testing.T) {
 	}
 }
 
+// When Evaluate stops early (UnprocessedFiles > 0), it's because ctx is
+// already canceled/expired. Process must still post the comment -- reusing
+// the dead ctx for that GitHub API call would make it fail immediately,
+// silently dropping the very comment meant to explain the partial result.
+func TestPullRequestWorker_Process_PostsCommentOnCanceledContext(t *testing.T) {
+	evaluator := NewMockEvaluator(t)
+	commenter := NewMockCommenter(t)
+	repo := mockPullRequestRepo{
+		MockRepository:      repository.NewMockRepository(t),
+		MockPullRequestRepo: repository.NewMockPullRequestRepo(t),
+	}
+	progress := jobs.NewMockJobProgressRecorder(t)
+
+	progress.On("SetMessage", mock.Anything, "listing pull request files").Return()
+	files := []repository.VersionedFileChange{{Path: "test.yaml"}}
+	repo.MockPullRequestRepo.On("MergeBase", mock.Anything, "test-ref").Return("merge-base-sha", nil)
+	repo.MockPullRequestRepo.On("CompareFiles", mock.Anything, "merge-base-sha", "test-ref").Return(files, nil)
+	evaluator.On("Evaluate", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(changeInfo{UnprocessedFiles: 2}, nil)
+	commenter.On("Comment", mock.MatchedBy(func(ctx context.Context) bool {
+		return ctx.Err() == nil // proves Comment did not reuse the canceled ctx
+	}), mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	worker := NewPullRequestWorker(evaluator, commenter, prometheus.NewPedanticRegistry())
+	job := provisioning.Job{
+		Spec: provisioning.JobSpec{
+			Action: provisioning.JobActionPullRequest,
+			PullRequest: &provisioning.PullRequestJobOptions{
+				PR:  123,
+				Ref: "test-ref",
+			},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(logging.Context(t.Context(), logging.DefaultLogger))
+	cancel()
+
+	// Use cancelled ctx above
+	err := worker.Process(ctx, repo, job, progress)
+	require.Error(t, err)
+	require.True(t, jobs.IsWarning(err), "an incomplete-but-commented evaluation is a warning, not a failure")
+	require.Contains(t, err.Error(), "evaluation stopped early: 2 file(s) not processed")
+
+	evaluator.AssertExpectations(t)
+	commenter.AssertExpectations(t)
+	repo.AssertExpectations(t)
+	progress.AssertExpectations(t)
+}
+
 type mockPullRequestRepo struct {
 	*repository.MockRepository
 	*repository.MockPullRequestRepo


### PR DESCRIPTION
**What is this feature?**
Previously we capped the PullRequest job to only view the first 10 changed files. We now process all changed files and give a more detailed summary (i.e. how many of each resource was changed, which were updated, deleted, created) and give a preview of max 10 files to preview.  

In ops, some PR jobs read as many as 450 resources but we only process 10 of them. 
Query: `{job=~"grafana-apps/provisioning.*"} |= "skipping remaining files"` 

**Why do we need this feature?**
Giving a bit more detail in the PR comment.

