### PR TITLE
Provisioning: Add resources_dryrun_bucket to track PR job duration

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/driver.go
+++ b/pkg/registry/apis/provisioning/jobs/driver.go
@@ -251,6 +251,7 @@ func (d *jobProcessor) processKey(ctx context.Context, namespace, name string, t
 			string(d.currentJob.Spec.Action),
 			string(d.currentJob.Status.State),
 			sumTotalChanges(d.currentJob.Status.Summary),
+			sumTotalDryRun(d.currentJob.Spec.Action, d.currentJob.Status.Summary),
 			duration.Seconds(),
 		)
 	}
@@ -527,6 +528,22 @@ func sumTotalChanges(summaries []*provisioning.JobResourceSummary) int {
 			continue
 		}
 		total += int(s.TotalChanges)
+	}
+	return total
+}
+
+// sumTotalDryRun totals the resources a job processed while doing its work.
+func sumTotalDryRun(action provisioning.JobAction, summaries []*provisioning.JobResourceSummary) int {
+	total := 0
+	for _, s := range summaries {
+		if s == nil {
+			continue
+		}
+		if action == provisioning.JobActionPullRequest {
+			total += int(s.Create + s.Update + s.Delete + s.Noop)
+		} else {
+			total += int(s.TotalChanges)
+		}
 	}
 	return total
 }

--- a/pkg/registry/apis/provisioning/jobs/driver_test.go
+++ b/pkg/registry/apis/provisioning/jobs/driver_test.go
@@ -41,6 +41,31 @@ func TestSumTotalChanges(t *testing.T) {
 	require.Equal(t, 8, sumTotalChanges(summaries))
 }
 
+// TestSumTotalDryRun verifies pull request jobs count viewed-but-not-actionable
+// (Noop) files alongside changes, while every other action falls back to
+// TotalChanges (identical to sumTotalChanges), skipping nil entries.
+func TestSumTotalDryRun(t *testing.T) {
+	require.Equal(t, 0, sumTotalDryRun(provisioning.JobActionPullRequest, nil))
+
+	prSummaries := []*provisioning.JobResourceSummary{
+		{Create: 2, Update: 1, Delete: 1, Noop: 3},
+		nil,
+		{Create: 1},
+	}
+	require.Equal(t, 8, sumTotalDryRun(provisioning.JobActionPullRequest, prSummaries))
+
+	prSummariesLarge := []*provisioning.JobResourceSummary{
+		{Create: 8, Update: 5, Noop: 2}, // all 15 files are evaluated, uncapped
+	}
+	require.Equal(t, 15, sumTotalDryRun(provisioning.JobActionPullRequest, prSummariesLarge))
+
+	pullSummaries := []*provisioning.JobResourceSummary{
+		{TotalChanges: 5, Noop: 10},
+		{TotalChanges: 3},
+	}
+	require.Equal(t, 8, sumTotalDryRun(provisioning.JobActionPull, pullSummaries))
+}
+
 func makeTestJob(rv string) *provisioning.Job {
 	return &provisioning.Job{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/registry/apis/provisioning/jobs/job_progress_recorder_mock.go
+++ b/pkg/registry/apis/provisioning/jobs/job_progress_recorder_mock.go
@@ -289,6 +289,40 @@ func (_c *MockJobProgressRecorder_Record_Call) RunAndReturn(run func(context.Con
 	return _c
 }
 
+// RecordDryRun provides a mock function with given fields: ctx, result
+func (_m *MockJobProgressRecorder) RecordDryRun(ctx context.Context, result JobResourceResult) {
+	_m.Called(ctx, result)
+}
+
+// MockJobProgressRecorder_RecordDryRun_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RecordDryRun'
+type MockJobProgressRecorder_RecordDryRun_Call struct {
+	*mock.Call
+}
+
+// RecordDryRun is a helper method to define mock.On call
+//   - ctx context.Context
+//   - result JobResourceResult
+func (_e *MockJobProgressRecorder_Expecter) RecordDryRun(ctx interface{}, result interface{}) *MockJobProgressRecorder_RecordDryRun_Call {
+	return &MockJobProgressRecorder_RecordDryRun_Call{Call: _e.mock.On("RecordDryRun", ctx, result)}
+}
+
+func (_c *MockJobProgressRecorder_RecordDryRun_Call) Run(run func(ctx context.Context, result JobResourceResult)) *MockJobProgressRecorder_RecordDryRun_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(JobResourceResult))
+	})
+	return _c
+}
+
+func (_c *MockJobProgressRecorder_RecordDryRun_Call) Return() *MockJobProgressRecorder_RecordDryRun_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockJobProgressRecorder_RecordDryRun_Call) RunAndReturn(run func(context.Context, JobResourceResult)) *MockJobProgressRecorder_RecordDryRun_Call {
+	_c.Run(run)
+	return _c
+}
+
 // ResetResults provides a mock function with given fields: keepWarnings
 func (_m *MockJobProgressRecorder) ResetResults(keepWarnings bool) {
 	_m.Called(keepWarnings)

--- a/pkg/registry/apis/provisioning/jobs/metrics.go
+++ b/pkg/registry/apis/provisioning/jobs/metrics.go
@@ -13,9 +13,10 @@ import (
 )
 
 type JobMetrics struct {
-	registry       prometheus.Registerer
-	processedTotal *prometheus.CounterVec
-	durationHist   *prometheus.HistogramVec
+	registry           prometheus.Registerer
+	processedTotal     *prometheus.CounterVec
+	durationHist       *prometheus.HistogramVec // duration bucketed by resources changed
+	dryRunDurationHist *prometheus.HistogramVec // duration bucketed by resources dry-run (viewed)
 
 	incrementalSyncPhaseDurationHist *prometheus.HistogramVec // phases of incremental sync
 	fullSyncPhaseDurationHist        *prometheus.HistogramVec // phases of full sync
@@ -55,9 +56,9 @@ type QueueMetrics struct {
 	claimRoundsCont *prometheus.CounterVec // lost to another worker — job already claimed, or all CAS retries exhausted
 }
 
-// durationBucketUnknown is the resources_changed_bucket used when a job did not
-// succeed: the resource count is partial and not meaningful, so failed durations are
-// grouped here instead of a misleading count bucket.
+// durationBucketUnknown is the resources_changed_bucket/resources_dryrun_bucket used
+// when a job did not succeed: the resource count is partial and not meaningful, so
+// failed durations are grouped here instead of a misleading count bucket.
 const durationBucketUnknown = "unknown"
 
 var (
@@ -180,12 +181,22 @@ func RegisterJobMetrics(registry prometheus.Registerer) JobMetrics {
 		durationHist := prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
 				Name:    "grafana_provisioning_jobs_duration_seconds",
-				Help:    "Duration of job",
+				Help:    "Duration of job, bucketed by the number of resources changed",
 				Buckets: []float64{5.0, 10.0, 30.0, 60.0, 120.0, 300.0},
 			},
 			[]string{"action", "resources_changed_bucket", "outcome"},
 		)
 		registry.MustRegister(durationHist)
+
+		dryRunDurationHist := prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    "grafana_provisioning_jobs_dryrun_duration_seconds",
+				Help:    "Duration of job, bucketed by the number of resources dry-run (viewed)",
+				Buckets: []float64{5.0, 10.0, 30.0, 60.0, 120.0, 300.0},
+			},
+			[]string{"action", "resources_dryrun_bucket", "outcome"},
+		)
+		registry.MustRegister(dryRunDurationHist)
 
 		incrementalSyncPhaseDurationHist := prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
@@ -270,6 +281,7 @@ func RegisterJobMetrics(registry prometheus.Registerer) JobMetrics {
 			registry:                         registry,
 			processedTotal:                   processedTotal,
 			durationHist:                     durationHist,
+			dryRunDurationHist:               dryRunDurationHist,
 			incrementalSyncPhaseDurationHist: incrementalSyncPhaseDurationHist,
 			fullSyncPhaseDurationHist:        fullSyncPhaseDurationHist,
 			syncDurationHist:                 syncDurationHist,
@@ -310,18 +322,25 @@ func (m *JobMetrics) RecordBusySeconds(driverID, action string, seconds float64)
 	m.busySeconds.WithLabelValues(driverID, action).Add(seconds)
 }
 
-func (m *JobMetrics) RecordJob(jobAction string, outcome string, resourceCountChanged int, duration float64) {
+func (m *JobMetrics) RecordJob(jobAction string, outcome string, resourceCountChanged int, resourceCountDryRun int, duration float64) {
 	m.processedTotal.WithLabelValues(jobAction, outcome).Inc()
 
 	// Record duration for every outcome so slow-but-failing jobs are visible (a job
 	// that runs to the timeout then errors is exactly what we want to catch). Only a
 	// failed job's resource count is unreliable (partial work), so bucket errors under
 	// a sentinel; success and warning keep their size bucket.
-	bucket := utils.GetResourceCountBucket(resourceCountChanged)
+	changedBucket := utils.GetResourceCountBucket(resourceCountChanged)
+	dryRunBucket := utils.GetResourceCountBucket(resourceCountDryRun)
 	if outcome == utils.ErrorOutcome {
-		bucket = durationBucketUnknown
+		changedBucket = durationBucketUnknown
+		dryRunBucket = durationBucketUnknown
 	}
-	m.durationHist.WithLabelValues(jobAction, bucket, outcome).Observe(duration)
+
+	if jobAction == string(provisioning.JobActionPullRequest) {
+		m.dryRunDurationHist.WithLabelValues(jobAction, dryRunBucket, outcome).Observe(duration)
+	} else {
+		m.durationHist.WithLabelValues(jobAction, changedBucket, outcome).Observe(duration)
+	}
 }
 
 func (m *JobMetrics) RecordIncrementalSyncPhase(phase IncrementalSyncPhase, duration time.Duration) {

--- a/pkg/registry/apis/provisioning/jobs/metrics_inflight_test.go
+++ b/pkg/registry/apis/provisioning/jobs/metrics_inflight_test.go
@@ -8,6 +8,7 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/utils"
 )
 
@@ -113,11 +114,14 @@ func TestJobMetrics_RecordJobDurationOnAllOutcomes(t *testing.T) {
 		durationHist: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{Name: "test_jobs_duration_seconds", Buckets: []float64{5, 10}},
 			[]string{"action", "resources_changed_bucket", "outcome"}),
+		dryRunDurationHist: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{Name: "test_jobs_dryrun_duration_seconds", Buckets: []float64{5, 10}},
+			[]string{"action", "resources_dryrun_bucket", "outcome"}),
 	}
 
-	m.RecordJob("pull", utils.SuccessOutcome, 3, 2.0)
-	m.RecordJob("pull", utils.ErrorOutcome, 0, 7.0)
-	m.RecordJob("pull", "warning", 5, 3.0) // string(provisioning.JobStateWarning)
+	m.RecordJob("pull", utils.SuccessOutcome, 3, 3, 2.0)
+	m.RecordJob("pull", utils.ErrorOutcome, 0, 0, 7.0)
+	m.RecordJob("pull", "warning", 5, 5, 3.0) // string(provisioning.JobStateWarning)
 
 	// All three outcomes recorded a duration series (before, only success did).
 	require.Equal(t, 3, testutil.CollectAndCount(m.durationHist))
@@ -125,4 +129,28 @@ func TestJobMetrics_RecordJobDurationOnAllOutcomes(t *testing.T) {
 	require.Equal(t, uint64(1), histSampleCount(t, m.durationHist, "pull", utils.GetResourceCountBucket(3), utils.SuccessOutcome))
 	require.Equal(t, uint64(1), histSampleCount(t, m.durationHist, "pull", utils.GetResourceCountBucket(5), "warning"))
 	require.Equal(t, uint64(1), histSampleCount(t, m.durationHist, "pull", durationBucketUnknown, utils.ErrorOutcome))
+
+	require.Equal(t, 0, testutil.CollectAndCount(m.dryRunDurationHist))
+}
+
+// TestJobMetrics_RecordJob_PullRequestUsesDryRunBucketOnly verifies pull request jobs
+// skip the resources_changed histogram (they never write anything, so "changed"
+// undercounts files that were only viewed) and record solely into resources_dryrun.
+func TestJobMetrics_RecordJob_PullRequestUsesDryRunBucketOnly(t *testing.T) {
+	m := &JobMetrics{
+		processedTotal: prometheus.NewCounterVec(
+			prometheus.CounterOpts{Name: "test_jobs_processed_total"}, []string{"action", "outcome"}),
+		durationHist: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{Name: "test_jobs_duration_seconds", Buckets: []float64{5, 10}},
+			[]string{"action", "resources_changed_bucket", "outcome"}),
+		dryRunDurationHist: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{Name: "test_jobs_dryrun_duration_seconds", Buckets: []float64{5, 10}},
+			[]string{"action", "resources_dryrun_bucket", "outcome"}),
+	}
+
+	m.RecordJob(string(provisioning.JobActionPullRequest), utils.SuccessOutcome, 3, 7, 2.0)
+
+	require.Equal(t, 0, testutil.CollectAndCount(m.durationHist))
+	require.Equal(t, 1, testutil.CollectAndCount(m.dryRunDurationHist))
+	require.Equal(t, uint64(1), histSampleCount(t, m.dryRunDurationHist, string(provisioning.JobActionPullRequest), utils.GetResourceCountBucket(7), utils.SuccessOutcome))
 }

--- a/pkg/registry/apis/provisioning/jobs/progress.go
+++ b/pkg/registry/apis/provisioning/jobs/progress.go
@@ -82,6 +82,34 @@ func (r *jobProgressRecorder) Started() time.Time {
 }
 
 func (r *jobProgressRecorder) Record(ctx context.Context, result JobResourceResult) {
+	r.record(ctx, result, false)
+}
+
+// RecordDryRun tallies result into the job summary without the write-assuming
+// side effects Record has: no resource-operation metric, no per-file success/
+// failure log, and no contribution to errors/errorCount (so a preview failure
+// cannot flip the job's own state to error/warning in Complete). Use it for
+// previews (e.g. pull request evaluation) that never actually change anything.
+func (r *jobProgressRecorder) RecordDryRun(ctx context.Context, result JobResourceResult) {
+	r.record(ctx, result, true)
+}
+
+// record is the shared implementation behind Record and RecordDryRun. The
+// summary tally (updateSummary) always runs; isDryRun gates everything that
+// assumes a real write happened -- the resource-operation metric, the per-file
+// success/failure log, and error/warning bookkeeping (errors, errorCount,
+// failedCreations/Deletions/Updates) that would otherwise let a preview
+// failure flip the job's own state in Complete.
+func (r *jobProgressRecorder) record(ctx context.Context, result JobResourceResult, isDryRun bool) {
+	if isDryRun {
+		r.mu.Lock()
+		r.updateSummary(result)
+		r.mu.Unlock()
+
+		r.maybeNotify(ctx)
+		return
+	}
+
 	var (
 		shouldLogError   bool
 		shouldLogWarning bool

--- a/pkg/registry/apis/provisioning/jobs/queue.go
+++ b/pkg/registry/apis/provisioning/jobs/queue.go
@@ -22,6 +22,13 @@ type RepoGetter interface {
 type JobProgressRecorder interface {
 	Started() time.Time
 	Record(ctx context.Context, result JobResourceResult)
+	// RecordDryRun tallies a result into the job summary (the same bookkeeping
+	// as Record) without the side effects that assume a real write happened:
+	// no resource-operation counter/duration observation, no per-file success
+	// log, and no contribution to the job's own error/warning state. Use it for
+	// previews (e.g. pull request evaluation) that never actually change
+	// anything.
+	RecordDryRun(ctx context.Context, result JobResourceResult)
 	ResetResults(keepWarnings bool)
 	SetFinalMessage(ctx context.Context, msg string)
 	SetMessage(ctx context.Context, msg string)

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/changes.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/changes.go
@@ -141,6 +141,7 @@ func (e *evaluator) Evaluate(ctx context.Context, repo repository.Reader, opts p
 	screenshotBaseURL := e.urls.Public(ctx, cfg.Namespace)
 
 	logger := logging.FromContext(ctx)
+	progress.SetTotal(ctx, len(changes))
 
 	for _, change := range changes {
 		if ctx.Err() != nil {
@@ -151,10 +152,29 @@ func (e *evaluator) Evaluate(ctx context.Context, repo repository.Reader, opts p
 
 		progress.SetMessage(ctx, fmt.Sprintf("process %s", change.Path))
 		logger.With("action", change.Action).With("path", change.Path)
-		info.Changes = append(info.Changes, e.evaluateFile(ctx, repo, info.GrafanaBaseURL, screenshotBaseURL, orgID, change, opts, parser, shouldRender))
+		fileInfo := e.evaluateFile(ctx, repo, info.GrafanaBaseURL, screenshotBaseURL, orgID, change, opts, parser, shouldRender)
+		info.Changes = append(info.Changes, fileInfo)
+		progress.RecordDryRun(ctx, previewResult(fileInfo))
 	}
 
 	return info, nil
+}
+
+func previewResult(info fileChangeInfo) jobs.JobResourceResult {
+	action := info.Change.Action
+	if info.Error != "" && info.Parsed == nil {
+		action = repository.FileActionIgnored
+	}
+
+	result := jobs.NewPathOnlyResult(info.Change.Path).
+		WithAction(action).
+		WithPreviousPath(info.Change.PreviousPath)
+
+	if info.Parsed != nil && info.Parsed.Obj != nil {
+		result.WithGVK(info.Parsed.GVK).WithName(info.Parsed.Obj.GetName())
+	}
+
+	return result.Build()
 }
 
 var dashboardKind = dashboard.DashboardResourceInfo.GroupVersionKind().Kind

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 
+	dashboard "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
 	folder "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
@@ -24,6 +25,13 @@ import (
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
 )
+
+// stubPreviewProgress allows the progress bookkeeping Evaluate does for every
+// change, so cases that only care about the comment don't have to expect it.
+func stubPreviewProgress(progress *jobs.MockJobProgressRecorder) {
+	progress.On("SetTotal", mock.Anything, mock.Anything).Return().Maybe()
+	progress.On("RecordDryRun", mock.Anything, mock.Anything).Return().Maybe()
+}
 
 func TestCalculateChanges(t *testing.T) {
 	tests := []struct {
@@ -1389,6 +1397,7 @@ func TestCalculateChanges(t *testing.T) {
 			parser := resources.NewMockParser(t)
 			reader := repository.NewMockReader(t)
 			progress := jobs.NewMockJobProgressRecorder(t)
+			stubPreviewProgress(progress)
 			renderer := NewMockScreenshotRenderer(t)
 			parserFactory := resources.NewMockParserFactory(t)
 
@@ -1496,6 +1505,7 @@ func TestEvaluate_PopulatesSourceAndRepositoryURLs(t *testing.T) {
 	renderer.On("IsAvailable", mock.Anything).Return(false)
 
 	progress := jobs.NewMockJobProgressRecorder(t)
+	stubPreviewProgress(progress)
 	progress.On("SetMessage", mock.Anything, "process path/to/file.json").Return()
 
 	evaluator := NewEvaluator(renderer, parserFactory, URLProvider{
@@ -1559,6 +1569,7 @@ func TestEvaluate_StripsCredentialsFromURLs(t *testing.T) {
 	renderer.On("IsAvailable", mock.Anything).Return(false)
 
 	progress := jobs.NewMockJobProgressRecorder(t)
+	stubPreviewProgress(progress)
 	progress.On("SetMessage", mock.Anything, "process path/to/file.json").Return()
 
 	evaluator := NewEvaluator(renderer, parserFactory, URLProvider{
@@ -1635,6 +1646,7 @@ func TestEvaluate_FolderGetsGrafanaAndSourceURL(t *testing.T) {
 	renderer.On("IsAvailable", mock.Anything).Return(false)
 
 	progress := jobs.NewMockJobProgressRecorder(t)
+	stubPreviewProgress(progress)
 	progress.On("SetMessage", mock.Anything, "process team/_folder.json").Return()
 
 	evaluator := NewEvaluator(renderer, parserFactory, URLProvider{
@@ -1720,6 +1732,7 @@ func TestEvaluate_DeletedFilePopulatesSourceURL(t *testing.T) {
 	renderer.On("IsAvailable", mock.Anything).Return(false)
 
 	progress := jobs.NewMockJobProgressRecorder(t)
+	stubPreviewProgress(progress)
 	progress.On("SetMessage", mock.Anything, "process team/_folder.json").Return()
 
 	evaluator := NewEvaluator(renderer, parserFactory, URLProvider{
@@ -1789,6 +1802,7 @@ func TestEvaluate_GitHubEnterpriseDoesNotPanic(t *testing.T) {
 	renderer.On("IsAvailable", mock.Anything).Return(true)
 
 	progress := jobs.NewMockJobProgressRecorder(t)
+	stubPreviewProgress(progress)
 	progress.On("SetMessage", mock.Anything, "process playlist.json").Return()
 
 	evaluator := NewEvaluator(renderer, parserFactory, URLProvider{
@@ -1824,6 +1838,7 @@ func TestEvaluate_StopsWhenContextIsCanceled(t *testing.T) {
 	renderer.On("IsAvailable", mock.Anything).Return(false)
 
 	progress := jobs.NewMockJobProgressRecorder(t)
+	stubPreviewProgress(progress)
 
 	evaluator := NewEvaluator(renderer, parserFactory, URLProvider{
 		Internal: func(_ context.Context, _ string) string { return "http://host/" },
@@ -1893,6 +1908,7 @@ func TestEvaluate_TracksUnprocessedFilesWhenCanceledMidway(t *testing.T) {
 	renderer.On("IsAvailable", mock.Anything).Return(false)
 
 	progress := jobs.NewMockJobProgressRecorder(t)
+	stubPreviewProgress(progress)
 	progress.On("SetMessage", mock.Anything, mock.Anything).Return()
 
 	evaluator := NewEvaluator(renderer, parserFactory, URLProvider{
@@ -2206,4 +2222,212 @@ func TestOrgIDForLinks(t *testing.T) {
 			require.Equal(t, tt.want, orgIDForLinks(tt.namespace))
 		})
 	}
+}
+
+// recordPreviewedResults captures every result Evaluate records, so tests can
+// assert on the job summary a pull request preview produces.
+func recordPreviewedResults(progress *jobs.MockJobProgressRecorder) *[]jobs.JobResourceResult {
+	recorded := &[]jobs.JobResourceResult{}
+	progress.On("SetTotal", mock.Anything, mock.Anything).Return()
+	progress.On("RecordDryRun", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		*recorded = append(*recorded, args.Get(1).(jobs.JobResourceResult))
+	}).Return()
+	return recorded
+}
+
+func dashboardObject(name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": resources.DashboardResource.GroupVersion().String(),
+			"kind":       dashboardKind,
+			"metadata":   map[string]interface{}{"name": name, "namespace": "x"},
+			"spec":       map[string]interface{}{"title": name},
+		},
+	}
+}
+
+// A preview applies nothing, but the job summary should still report which
+// resources the pull request would create, update and delete — that count is
+// what the duration histogram buckets on.
+func TestEvaluate_RecordsWhatThePullRequestWouldChange(t *testing.T) {
+	reader := repository.NewMockReader(t)
+	reader.On("Config").Return(&provisioning.Repository{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-repo", Namespace: "x"},
+		Spec:       provisioning.RepositorySpec{Type: provisioning.GitHubRepositoryType},
+	})
+
+	parser := resources.NewMockParser(t)
+	for _, tc := range []struct {
+		path string
+		ref  string
+		name string
+	}{
+		{"created.json", "ref", "uid-created"},
+		{"updated.json", "ref", "uid-updated"},
+		{"deleted.json", "base", "uid-deleted"},
+	} {
+		finfo := &repository.FileInfo{Path: tc.path, Ref: tc.ref, Data: []byte("xxxx")}
+		obj := dashboardObject(tc.name)
+		meta, _ := utils.MetaAccessor(obj)
+
+		reader.On("Read", mock.Anything, tc.path, tc.ref).Return(finfo, nil)
+		parser.On("Parse", mock.Anything, finfo).Return(&resources.ParsedResource{
+			Info:           finfo,
+			Repo:           provisioning.ResourceRepositoryInfo{Namespace: "x", Name: "y"},
+			GVK:            schema.GroupVersionKind{Group: dashboard.GROUP, Kind: dashboardKind},
+			Obj:            obj,
+			Meta:           meta,
+			DryRunResponse: obj,
+		}, nil)
+	}
+	// Reading the base revision drives the stripped-metadata check on updates only.
+	reader.On("Read", mock.Anything, "updated.json", "").Return(nil, repository.ErrFileNotFound)
+	// The unreadable file is the one that cannot be previewed at all.
+	reader.On("Read", mock.Anything, "broken.json", "ref").Return(nil, repository.ErrFileNotFound)
+
+	parserFactory := resources.NewMockParserFactory(t)
+	parserFactory.On("GetParser", mock.Anything, mock.Anything).Return(parser, nil)
+
+	renderer := NewMockScreenshotRenderer(t)
+	renderer.On("IsAvailable", mock.Anything).Return(false)
+
+	progress := jobs.NewMockJobProgressRecorder(t)
+	progress.On("SetMessage", mock.Anything, mock.Anything).Return()
+	recorded := recordPreviewedResults(progress)
+
+	evaluator := NewEvaluator(renderer, parserFactory, URLProvider{
+		Internal: func(_ context.Context, _ string) string { return "http://host/" },
+		Public:   func(_ context.Context, _ string) string { return "http://host/" },
+	}, prometheus.NewPedanticRegistry())
+
+	_, err := evaluator.Evaluate(context.Background(), reader, provisioning.PullRequestJobOptions{Ref: "ref"}, []repository.VersionedFileChange{
+		{Action: repository.FileActionCreated, Path: "created.json", Ref: "ref"},
+		{Action: repository.FileActionUpdated, Path: "updated.json", Ref: "ref"},
+		{Action: repository.FileActionDeleted, Path: "deleted.json", PreviousRef: "base"},
+		{Action: repository.FileActionCreated, Path: "broken.json", Ref: "ref"},
+	}, progress)
+	require.NoError(t, err)
+
+	require.Len(t, *recorded, 4)
+	for _, result := range *recorded {
+		require.NoError(t, result.Error(), "a preview must not fail the job")
+		require.NoError(t, result.Warning(), "a preview must not warn")
+	}
+
+	byPath := map[string]jobs.JobResourceResult{}
+	for _, result := range *recorded {
+		byPath[result.Path()] = result
+	}
+
+	require.Equal(t, repository.FileActionCreated, byPath["created.json"].Action())
+	require.Equal(t, "uid-created", byPath["created.json"].Name())
+	require.Equal(t, dashboardKind, byPath["created.json"].Kind())
+	require.Equal(t, dashboard.GROUP, byPath["created.json"].Group())
+
+	require.Equal(t, repository.FileActionUpdated, byPath["updated.json"].Action())
+	require.Equal(t, repository.FileActionDeleted, byPath["deleted.json"].Action())
+
+	// Unreadable: it counts as neither a change nor a failure.
+	require.Equal(t, repository.FileActionIgnored, byPath["broken.json"].Action())
+}
+
+// A file that parses successfully but fails its dry-run validation still
+// describes a real create/update/delete -- previewResult must not misclassify
+// it as Ignored (which would undercount the job summary as a Noop instead).
+// Only a file that was never parsed at all has a genuinely unknown action.
+func TestEvaluate_RecordsRealActionWhenDryRunFails(t *testing.T) {
+	reader := repository.NewMockReader(t)
+	reader.On("Config").Return(&provisioning.Repository{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-repo", Namespace: "x"},
+		Spec:       provisioning.RepositorySpec{Type: provisioning.GitHubRepositoryType},
+	})
+
+	finfo := &repository.FileInfo{Path: "invalid.json", Ref: "ref", Data: []byte("xxxx")}
+	obj := dashboardObject("uid-invalid")
+	meta, _ := utils.MetaAccessor(obj)
+
+	reader.On("Read", mock.Anything, "invalid.json", "ref").Return(finfo, nil)
+
+	parser := resources.NewMockParser(t)
+	parser.On("Parse", mock.Anything, finfo).Return(&resources.ParsedResource{
+		Info: finfo,
+		Repo: provisioning.ResourceRepositoryInfo{Namespace: "x", Name: "y"},
+		GVK:  schema.GroupVersionKind{Group: dashboard.GROUP, Kind: dashboardKind},
+		Obj:  obj,
+		Meta: meta,
+		// No Client and no DryRunResponse: DryRun fails with "no client configured".
+	}, nil)
+
+	parserFactory := resources.NewMockParserFactory(t)
+	parserFactory.On("GetParser", mock.Anything, mock.Anything).Return(parser, nil)
+
+	renderer := NewMockScreenshotRenderer(t)
+	renderer.On("IsAvailable", mock.Anything).Return(false)
+
+	progress := jobs.NewMockJobProgressRecorder(t)
+	progress.On("SetMessage", mock.Anything, mock.Anything).Return()
+	recorded := recordPreviewedResults(progress)
+
+	evaluator := NewEvaluator(renderer, parserFactory, URLProvider{
+		Internal: func(_ context.Context, _ string) string { return "http://host/" },
+		Public:   func(_ context.Context, _ string) string { return "http://host/" },
+	}, prometheus.NewPedanticRegistry())
+
+	info, err := evaluator.Evaluate(context.Background(), reader, provisioning.PullRequestJobOptions{Ref: "ref"}, []repository.VersionedFileChange{
+		{Action: repository.FileActionCreated, Path: "invalid.json", Ref: "ref"},
+	}, progress)
+	require.NoError(t, err)
+
+	require.Len(t, info.Changes, 1)
+	require.NotEmpty(t, info.Changes[0].Error, "dry-run failure should surface as a comment error")
+
+	require.Len(t, *recorded, 1)
+	require.Equal(t, repository.FileActionCreated, (*recorded)[0].Action(), "a dry-run failure is a real create, not Ignored")
+}
+
+// Only the first few files make it into the rendered comment table (see
+// changeInfo.DisplayedChanges in comment.go), but Evaluate itself still
+// evaluates and records every file — so the resources-dryrun bucket reflects
+// the whole diff, not just what the comment displays.
+func TestEvaluate_RecordsEveryFileForJobSummary(t *testing.T) {
+	reader := repository.NewMockReader(t)
+	reader.On("Config").Return(&provisioning.Repository{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-repo", Namespace: "x"},
+		Spec:       provisioning.RepositorySpec{Type: provisioning.GitHubRepositoryType},
+	})
+	// Deletions we cannot read still describe a resource the merge would remove.
+	reader.On("Read", mock.Anything, mock.Anything, "base").Return(nil, repository.ErrFileNotFound)
+
+	parserFactory := resources.NewMockParserFactory(t)
+	parserFactory.On("GetParser", mock.Anything, mock.Anything).Return(resources.NewMockParser(t), nil)
+
+	renderer := NewMockScreenshotRenderer(t)
+	renderer.On("IsAvailable", mock.Anything).Return(false)
+
+	progress := jobs.NewMockJobProgressRecorder(t)
+	progress.On("SetMessage", mock.Anything, mock.Anything).Return()
+	recorded := recordPreviewedResults(progress)
+
+	changes := make([]repository.VersionedFileChange, 0, 12)
+	for i := 0; i < 12; i++ {
+		changes = append(changes, repository.VersionedFileChange{
+			Action:      repository.FileActionDeleted,
+			Path:        fmt.Sprintf("dashboards/%d.json", i),
+			PreviousRef: "base",
+		})
+	}
+
+	evaluator := NewEvaluator(renderer, parserFactory, URLProvider{
+		Internal: func(_ context.Context, _ string) string { return "http://host/" },
+		Public:   func(_ context.Context, _ string) string { return "http://host/" },
+	}, prometheus.NewPedanticRegistry())
+
+	info, err := evaluator.Evaluate(context.Background(), reader, provisioning.PullRequestJobOptions{Ref: "ref"}, changes, progress)
+	require.NoError(t, err)
+
+	require.Len(t, info.Changes, 12, "every file is evaluated")
+
+	require.Len(t, *recorded, 12, "every file in the diff is recorded")
+	require.Equal(t, "dashboards/11.json", (*recorded)[11].Path())
+	require.Equal(t, repository.FileActionDeleted, (*recorded)[11].Action())
 }


### PR DESCRIPTION
**What is this feature?**
Add new metric `resources_dryrun_bucket` to see how many resources were processed in the job. Currently this only applies to `PullRequest` jobs since all other jobs actually make changes to the resource. In the future, if a job has a DryRun mode, they can use this metric. 

**Why do we need this feature?**
Seeing long-running/large jobs even if nothing has changed. 

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/1273

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>