### PR TITLE
Dashboards: Fix flaky datasource variable E2E test by awaiting async type options

### DIFF
--- a/e2e-playwright/dashboard-new-layouts/page-objects/sidebar/VariableOptions.ts
+++ b/e2e-playwright/dashboard-new-layouts/page-objects/sidebar/VariableOptions.ts
@@ -57,7 +57,7 @@ export class VariableOptions extends PageObject {
           this.selectors.pages.Dashboard.Settings.Variables.Edit.DatasourceVariable.datasourceSelect
         );
         await datasourceSelect.fill(dsType);
-        await datasourceSelect.press('Enter');
+        await this.page.getByRole('option', { name: dsType }).click();
       });
     },
     /** Sets the datasource name filter */


### PR DESCRIPTION
**What is this feature?**

Fixes a deterministic failure in the `dashboards-edit-query-variables.spec.ts` E2E test ("can add a new query variable that references other variables").
