### PR TITLE
Chore: Remove unused optional props in app code

### DIFF
--- a/public/app/core/components/PanelTypeFilter/PanelTypeFilter.tsx
+++ b/public/app/core/components/PanelTypeFilter/PanelTypeFilter.tsx
@@ -8,12 +8,11 @@ import { Icon, Button, MultiSelect, useStyles2 } from '@grafana/ui';
 
 export interface Props {
   onChange: (plugins: PanelPluginMeta[]) => void;
-  maxMenuHeight?: number;
 }
 
 const collator = new Intl.Collator();
 
-export const PanelTypeFilter = ({ onChange: propsOnChange, maxMenuHeight }: Props): JSX.Element => {
+export const PanelTypeFilter = ({ onChange: propsOnChange}: Props): JSX.Element => {
   const { value: plugins = [] } = useListedPanelPluginMetas();
   const options = useMemo(
     () =>
@@ -39,7 +38,6 @@ export const PanelTypeFilter = ({ onChange: propsOnChange, maxMenuHeight }: Prop
     getOptionValue: (i: SelectableValue<PanelPluginMeta>) => i.value,
     noOptionsMessage: t('panel-type-filter.select-no-options', 'No panel types found'),
     placeholder: t('panel-type-filter.select-placeholder', 'Filter by type'),
-    maxMenuHeight,
     options,
     value,
     onChange,

--- a/public/app/core/components/QueryOperationRow/OperationRowHelp.tsx
+++ b/public/app/core/components/QueryOperationRow/OperationRowHelp.tsx
@@ -7,13 +7,12 @@ import { useStyles2 } from '@grafana/ui';
 export interface Props extends React.HTMLAttributes<HTMLDivElement> {
   children?: React.ReactNode;
   markdown?: string;
-  onRemove?: () => void;
   styleOverrides?: { [key: string]: string };
 }
 
 export const OperationRowHelp = React.memo(
   React.forwardRef<HTMLDivElement, Props>(
-    ({ className, children, markdown, styleOverrides, onRemove, ...otherProps }, ref) => {
+    ({ className, children, markdown, styleOverrides, ...otherProps }, ref) => {
       const styles = useStyles2((theme) => getStyles(theme, styleOverrides?.borderTop));
 
       return (

--- a/public/app/core/components/RolePicker/RoleMenuGroupsSection.tsx
+++ b/public/app/core/components/RolePicker/RoleMenuGroupsSection.tsx
@@ -22,7 +22,6 @@ interface RoleMenuGroupsSectionProps {
   onGroupChange: (value: string) => void;
   groupSelected: (group: string) => boolean;
   groupPartiallySelected: (group: string) => boolean;
-  disabled?: boolean;
   subMenuNode?: HTMLDivElement;
   selectedOptions: Role[];
   onRoleChange: (option: Role) => void;

--- a/public/app/features/dashboard-scene/inspect/HelpWizard/HelpWizard.tsx
+++ b/public/app/features/dashboard-scene/inspect/HelpWizard/HelpWizard.tsx
@@ -15,7 +15,6 @@ import {
   Field,
   InlineSwitch,
   Button,
-  Spinner,
   Alert,
   FeatureBadge,
   Select,
@@ -40,7 +39,6 @@ export function HelpWizard({ panel, onClose }: Props) {
 
   const {
     currentTab,
-    loading,
     error,
     options,
     showMessage,
@@ -110,7 +108,6 @@ export function HelpWizard({ panel, onClose }: Props) {
         </TabsBar>
       }
     >
-      {loading && <Spinner />}
       {error && <Alert title={error.title}>{error.message}</Alert>}
 
       {currentTab === SnapshotTab.Data && (

--- a/public/app/features/dashboard-scene/inspect/HelpWizard/SupportSnapshotService.ts
+++ b/public/app/features/dashboard-scene/inspect/HelpWizard/SupportSnapshotService.ts
@@ -18,7 +18,6 @@ interface SupportSnapshotState {
   markdownText: string;
   snapshotSize?: string;
   randomize: Randomize;
-  loading?: boolean;
   error?: {
     title: string;
     message: string;

--- a/public/app/features/dashboard-scene/inspect/PanelInspectDrawer.tsx
+++ b/public/app/features/dashboard-scene/inspect/PanelInspectDrawer.tsx
@@ -32,7 +32,6 @@ interface PanelInspectDrawerState extends SceneObjectState {
   currentTab: InspectTab;
   panelRef: SceneObjectRef<VizPanel>;
   pluginNotLoaded?: boolean;
-  canEdit?: boolean;
 }
 
 export class PanelInspectDrawer extends SceneObjectBase<PanelInspectDrawerState> {

--- a/public/app/features/dashboard-scene/settings/variables/components/CustomVariableForm.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/CustomVariableForm.tsx
@@ -21,8 +21,6 @@ interface CustomVariableFormProps {
   onMultiChange: (event: FormEvent<HTMLInputElement>) => void;
   onIncludeAllChange: (event: FormEvent<HTMLInputElement>) => void;
   onAllValueChange: (event: FormEvent<HTMLInputElement>) => void;
-  onQueryBlur?: (event: FormEvent<HTMLTextAreaElement>) => void;
-  onAllValueBlur?: (event: FormEvent<HTMLInputElement>) => void;
   onAllowCustomValueChange?: (event: FormEvent<HTMLInputElement>) => void;
   onValuesFormatChange?: (format: CustomVariableModel['valuesFormat']) => void;
 }

--- a/public/app/features/dashboard-scene/settings/variables/components/DataSourceVariableForm.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/DataSourceVariableForm.tsx
@@ -24,8 +24,6 @@ interface DataSourceVariableFormProps {
   onIncludeAllChange: (event: FormEvent<HTMLInputElement>) => void;
   onAllValueChange: (event: FormEvent<HTMLInputElement>) => void;
   onAllowCustomValueChange?: (event: FormEvent<HTMLInputElement>) => void;
-  onQueryBlur?: (event: FormEvent<HTMLTextAreaElement>) => void;
-  onAllValueBlur?: (event: FormEvent<HTMLInputElement>) => void;
 }
 
 export function DataSourceVariableForm({

--- a/public/app/features/dashboard/components/HelpWizard/HelpWizard.tsx
+++ b/public/app/features/dashboard/components/HelpWizard/HelpWizard.tsx
@@ -14,7 +14,6 @@ import {
   Field,
   InlineSwitch,
   Button,
-  Spinner,
   Alert,
   Select,
   ClipboardButton,
@@ -39,7 +38,6 @@ export function HelpWizard({ panel, plugin, onClose }: Props) {
 
   const {
     currentTab,
-    loading,
     error,
     options,
     showMessage,
@@ -108,7 +106,6 @@ export function HelpWizard({ panel, plugin, onClose }: Props) {
         </TabsBar>
       }
     >
-      {loading && <Spinner />}
       {error && <Alert title={error.title}>{error.message}</Alert>}
 
       {currentTab === SnapshotTab.Data && (

--- a/public/app/features/dashboard/components/HelpWizard/SupportSnapshotService.ts
+++ b/public/app/features/dashboard/components/HelpWizard/SupportSnapshotService.ts
@@ -21,7 +21,6 @@ interface SupportSnapshotState {
   markdownText: string;
   snapshotSize?: string;
   randomize: Randomize;
-  loading?: boolean;
   error?: {
     title: string;
     message: string;

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/api/dashboardLibraryApi.ts
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/api/dashboardLibraryApi.ts
@@ -37,8 +37,6 @@ export interface FetchCommunityDashboardsParams {
 export interface GnetDashboardDependency {
   pluginSlug: string;
   pluginTypeCode: 'app' | 'panel' | 'datasource' | 'grafana';
-  pluginName?: string;
-  pluginVersion?: string;
   [key: string]: unknown;
 }
 

--- a/public/app/features/explore/Logs/LogsTableActionButtons.tsx
+++ b/public/app/features/explore/Logs/LogsTableActionButtons.tsx
@@ -18,14 +18,12 @@ import { getState } from 'app/store/store';
 
 import { getExploreBaseUrl } from './utils/url';
 interface Props extends CustomCellRendererProps {
-  logId?: string;
   logsFrame?: LogsFrame;
   exploreId?: string;
   panelState?: ExploreLogsPanelState;
   displayedFields?: string[];
   absoluteRange?: AbsoluteTimeRange;
   logRows?: LogRowModel[];
-  index?: number;
 }
 
 export const LogsTableActionButtons = memo((props: Props) => {

--- a/public/app/features/plugins/extensions/registry/AddedComponentsRegistry.ts
+++ b/public/app/features/plugins/extensions/registry/AddedComponentsRegistry.ts
@@ -25,7 +25,6 @@ export class AddedComponentsRegistry extends Registry<
     apps: AppPluginConfig[],
     options: {
       registrySubject?: ReplaySubject<RegistryType<AddedComponentRegistryItem[]>>;
-      initialState?: RegistryType<AddedComponentRegistryItem[]>;
     } = {}
   ) {
     super(apps, options);

--- a/public/app/features/plugins/extensions/registry/AddedFunctionsRegistry.ts
+++ b/public/app/features/plugins/extensions/registry/AddedFunctionsRegistry.ts
@@ -23,7 +23,6 @@ export class AddedFunctionsRegistry extends Registry<AddedFunctionsRegistryItem[
     apps: AppPluginConfig[],
     options: {
       registrySubject?: ReplaySubject<RegistryType<AddedFunctionsRegistryItem[]>>;
-      initialState?: RegistryType<AddedFunctionsRegistryItem[]>;
     } = {}
   ) {
     super(apps, options);

--- a/public/app/features/plugins/extensions/registry/AddedLinksRegistry.ts
+++ b/public/app/features/plugins/extensions/registry/AddedLinksRegistry.ts
@@ -30,7 +30,6 @@ export class AddedLinksRegistry extends Registry<AddedLinkRegistryItem[], Plugin
     apps: AppPluginConfig[],
     options: {
       registrySubject?: ReplaySubject<RegistryType<AddedLinkRegistryItem[]>>;
-      initialState?: RegistryType<AddedLinkRegistryItem[]>;
     } = {}
   ) {
     super(apps, options);

--- a/public/app/features/plugins/extensions/registry/ExposedComponentsRegistry.ts
+++ b/public/app/features/plugins/extensions/registry/ExposedComponentsRegistry.ts
@@ -25,7 +25,6 @@ export class ExposedComponentsRegistry extends Registry<
     apps: AppPluginConfig[],
     options: {
       registrySubject?: ReplaySubject<RegistryType<ExposedComponentRegistryItem>>;
-      initialState?: RegistryType<ExposedComponentRegistryItem>;
     } = {}
   ) {
     super(apps, options);

--- a/public/app/features/provisioning/Wizard/Stepper.tsx
+++ b/public/app/features/provisioning/Wizard/Stepper.tsx
@@ -13,7 +13,6 @@ export interface Step<T> {
 
 export interface Props<T extends string | number> {
   activeStep?: T;
-  reportId?: string;
   visitedSteps?: T[];
   steps: Array<Step<T>>;
 }

--- a/public/app/features/provisioning/components/BulkActions/utils.ts
+++ b/public/app/features/provisioning/components/BulkActions/utils.ts
@@ -19,7 +19,6 @@ export type BulkActionFormData = {
 export interface BulkActionProvisionResourceProps {
   folderUid?: string;
   selectedItems: Omit<DashboardTreeSelection, 'panel' | '$all'>;
-  onActionComplete?: () => void;
   onDismiss?: () => void;
 }
 

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -99,7 +99,6 @@ interface State<TQuery extends DataQuery> {
   /** DatasourceUid or ds variable expression used to resolve current datasource */
   queriedDataSourceIdentifier?: string | null;
   datasource: DataSourceApi<TQuery> | null;
-  datasourceUid?: string | null;
   data?: PanelData;
   isOpen?: boolean;
   showingHelp: boolean;

--- a/public/app/features/transformers/FilterByValueTransformer/ValueMatchers/types.ts
+++ b/public/app/features/transformers/FilterByValueTransformer/ValueMatchers/types.ts
@@ -12,5 +12,4 @@ export interface ValueMatcherUIProps<TOptions> {
 }
 export interface ValueMatcherEditorConfig {
   validator: (value: any) => boolean;
-  converter?: (value: any, field: Field) => any;
 }

--- a/public/app/features/transformers/suggestionsInput/SuggestionsInput.tsx
+++ b/public/app/features/transformers/suggestionsInput/SuggestionsInput.tsx
@@ -30,7 +30,6 @@ interface SuggestionsInputProps {
   placeholder?: string;
   invalid?: boolean;
   error?: string;
-  width?: number;
   type?: HTMLElementType;
   style?: React.CSSProperties;
   autoFocus?: boolean;


### PR DESCRIPTION
Hey folks, I'm working on an experimental CLI which uses the tsgo toolchain to find optional component and function signatures that are in practice never passed. This is essentially dead code elimination, and a complementary workflow to run alongside a tool like knip.

The changeset in this PR has been done using the script as the reporting tool, and an agent validator loop walking through each reported line one by one to first inspect the report, analyze the call sites, removing them, and later re-running ts. If done correctly, the code that has been removed should have been effectively dead.

The reporting script heavily relies on type quality and only reports on types whos members are statically enumerable.

Scope notes:
- Only `public/app` is touched, and deliberately only the mechanically safe subset. The scanner reported ~380 candidates in app code; anything that required inlining default values, touching `packages/*` (published as @grafana/*), `public/app/plugins`, or plugin-facing API surface was left out.
- Everything here passes a clean `tsc --noEmit`.

I'm opening this PR in an effort to help you eliminate dead code, but also to gain feedback on the script and the detection mechanisms. There are always risks of false positive reports, and removal of code that is actually still required at runtime.

Some references of PRs opened to other repositories that have been merged or are still open:
✅ [Sentry (4k loc removed)](https://github.com/getsentry/sentry/pull/122234/)
⏳ [Sentry (followup 1k loc removed)](https://github.com/getsentry/sentry/pull/122373)
⏳ [Tanstack](https://github.com/TanStack/tanstack.com/pull/1173)
⏳ [npmx](https://github.com/npmx-dev/npmx.dev/pull/3195)
⏳ [Signal Desktop](https://github.com/signalapp/Signal-Desktop/pull/7997)
⏳ [Cal.com](https://github.com/calcom/cal.diy/pull/30023)

Would love to hear your feedback 🙏🏼

Made with [Cursor](https://cursor.com)