### PR TITLE
Dashboards: Migrate annotation settings to async DataSource APIs

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1546,39 +1546,14 @@
       "count": 1
     }
   },
-  "public/app/features/dashboard-scene/settings/AnnotationsEditView.tsx": {
-    "@grafana/no-get-data-source-srv": {
-      "count": 1
-    }
-  },
   "public/app/features/dashboard-scene/settings/AutoRefreshIntervals.tsx": {
     "@grafana/require-no-margin": {
-      "count": 1
-    }
-  },
-  "public/app/features/dashboard-scene/settings/ProvisionedControlsSection.tsx": {
-    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
   "public/app/features/dashboard-scene/settings/TimePickerSettings.tsx": {
     "@grafana/require-no-margin": {
       "count": 5
-    }
-  },
-  "public/app/features/dashboard-scene/settings/annotations/AnnotationQueryOptions.tsx": {
-    "@grafana/no-get-data-source-srv": {
-      "count": 1
-    }
-  },
-  "public/app/features/dashboard-scene/settings/annotations/AnnotationSettingsEdit.tsx": {
-    "@grafana/no-get-data-source-srv": {
-      "count": 1
-    }
-  },
-  "public/app/features/dashboard-scene/settings/annotations/AnnotationSettingsList.tsx": {
-    "@grafana/no-get-data-source-srv": {
-      "count": 1
     }
   },
   "public/app/features/dashboard-scene/settings/variables/VariableEditableElement.tsx": {

--- a/public/app/features/dashboard-scene/settings/AnnotationsEditView.test.tsx
+++ b/public/app/features/dashboard-scene/settings/AnnotationsEditView.test.tsx
@@ -93,6 +93,19 @@ jest.mock('@grafana/runtime', () => ({
   },
 }));
 
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstanceSettings: jest.fn(async (ref: DataSourceRef | string | null) => {
+    if (!ref) {
+      return noAnnotationsDsInstanceSettings;
+    }
+    if (getDataSourceUID(ref) === '-- Grafana --') {
+      return grafanaDsInstanceSettings;
+    }
+    return { uid: 'ds1' };
+  }),
+}));
+
 describe('AnnotationsEditView', () => {
   describe('Dashboard annotations state', () => {
     let annotationsView: AnnotationsEditView;
@@ -107,27 +120,27 @@ describe('AnnotationsEditView', () => {
       expect(annotationsView.getUrlKey()).toBe('annotations');
     });
 
-    it('should return undefined when datasource does not support annotations', () => {
-      const ds = annotationsView.getDataSourceRefForAnnotation();
+    it('should return undefined when datasource does not support annotations', async () => {
+      const ds = await annotationsView.getDataSourceRefForAnnotation();
       expect(ds).toBe(undefined);
       expect(console.error).toHaveBeenCalledWith('Default datasource does not support annotations');
     });
 
-    it('should add a new annotation and group it with the other annotations', () => {
+    it('should add a new annotation and group it with the other annotations', async () => {
       const dataLayers = dashboardSceneGraph.getDataLayers(annotationsView.getDashboard());
 
       expect(dataLayers?.state.annotationLayers.length).toBe(1);
-      annotationsView.onNew();
+      await annotationsView.onNew();
 
       expect(dataLayers?.state.annotationLayers.length).toBe(2);
       expect(dataLayers?.state.annotationLayers[1].state.name).toBe(NEW_ANNOTATION_NAME);
       expect(dataLayers?.state.annotationLayers[1].isActive).toBe(true);
     });
 
-    it('should move an annotation up one position', () => {
+    it('should move an annotation up one position', async () => {
       const dataLayers = dashboardSceneGraph.getDataLayers(annotationsView.getDashboard());
 
-      annotationsView.onNew();
+      await annotationsView.onNew();
 
       expect(dataLayers?.state.annotationLayers.length).toBe(2);
       expect(dataLayers?.state.annotationLayers[0].state.name).toBe('test');
@@ -138,10 +151,10 @@ describe('AnnotationsEditView', () => {
       expect(dataLayers?.state.annotationLayers[0].state.name).toBe(NEW_ANNOTATION_NAME);
     });
 
-    it('should move an annotation down one position', () => {
+    it('should move an annotation down one position', async () => {
       const dataLayers = dashboardSceneGraph.getDataLayers(annotationsView.getDashboard());
 
-      annotationsView.onNew();
+      await annotationsView.onNew();
 
       expect(dataLayers?.state.annotationLayers.length).toBe(2);
       expect(dataLayers?.state.annotationLayers[0].state.name).toBe('test');

--- a/public/app/features/dashboard-scene/settings/AnnotationsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/AnnotationsEditView.tsx
@@ -6,8 +6,9 @@ import {
   PageLayoutType,
 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
-import { config, getDataSourceSrv, locationService } from '@grafana/runtime';
+import { config, locationService } from '@grafana/runtime';
 import { useFlagGrafanaDashboardSettingsRedesign } from '@grafana/runtime/internal';
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { type SceneComponentProps, SceneObjectBase, type VizPanel, dataLayers } from '@grafana/scenes';
 import { Alert, Button } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
@@ -67,10 +68,10 @@ export class AnnotationsEditView extends SceneObjectBase<AnnotationsEditViewStat
     return this._dashboard;
   }
 
-  public getDataSourceRefForAnnotation = () => {
+  public getDataSourceRefForAnnotation = async () => {
     // get current default datasource ref from instance settings
     // null is passed to get the default datasource
-    const defaultInstanceDS = getDataSourceSrv().getInstanceSettings(null);
+    const defaultInstanceDS = await getDataSourceInstanceSettings(null);
     // check for an annotation flag in the plugin json to see if it supports annotations
     if (!defaultInstanceDS || !defaultInstanceDS.meta.annotations) {
       console.error('Default datasource does not support annotations');
@@ -83,7 +84,7 @@ export class AnnotationsEditView extends SceneObjectBase<AnnotationsEditViewStat
     const newAnnotationQuery: AnnotationQuery = {
       name: NEW_ANNOTATION_NAME,
       enable: true,
-      datasource: this.getDataSourceRefForAnnotation(),
+      datasource: await this.getDataSourceRefForAnnotation(),
       iconColor: 'red',
     };
 

--- a/public/app/features/dashboard-scene/settings/ProvisionedControlsSection.tsx
+++ b/public/app/features/dashboard-scene/settings/ProvisionedControlsSection.tsx
@@ -1,10 +1,10 @@
 import { css } from '@emotion/css';
 import classNames from 'clsx';
-import { type ReactNode, useMemo, useState } from 'react';
+import { type ReactNode, useState } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { useDatasourcePluginMeta } from '@grafana/runtime/internal';
 import { type ControlSourceRef } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { CollapsableSection, Icon, Stack, Text, Tooltip, useStyles2 } from '@grafana/ui';
 
@@ -100,15 +100,14 @@ function getSourceTooltip(pluginName: string | undefined): string {
 }
 
 function usePluginName(origin: ControlSourceRef | undefined): string | undefined {
-  return useMemo(() => {
-    if (!origin?.group) {
-      return undefined;
-    }
+  const pluginId = origin?.group ?? '';
+  const { value: meta } = useDatasourcePluginMeta(pluginId);
 
-    const list = getDataSourceSrv().getList({});
-    const ds = list.find((d) => d.meta.id === origin.group);
-    return ds?.meta.name ?? origin.group;
-  }, [origin?.group]);
+  if (!pluginId) {
+    return undefined;
+  }
+
+  return meta?.name ?? pluginId;
 }
 
 const getStyles = (theme: GrafanaTheme2) => ({

--- a/public/app/features/dashboard-scene/settings/annotations/AnnotationQueryOptions.tsx
+++ b/public/app/features/dashboard-scene/settings/annotations/AnnotationQueryOptions.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useState } from 'react';
-import { useAsync } from 'react-use';
 
 import { AppEvents } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
-import { getAppEvents, getDataSourceSrv } from '@grafana/runtime';
+import { getAppEvents } from '@grafana/runtime';
+import { useDataSourceInstance } from '@grafana/runtime/unstable';
 import { type DataQuery } from '@grafana/schema';
 import { Box, Button, ButtonGroup } from '@grafana/ui';
 import { updateAnnotationFromSavedQuery } from 'app/features/annotations/utils/savedQueryUtils';
@@ -43,9 +43,7 @@ function QueryLibraryButton({ layer, onQuerySelected }: { layer: AnnotationLayer
   const { openDrawer, closeDrawer } = useQueryLibraryContext();
 
   const { query } = layer.useState();
-  const { value: datasource } = useAsync(() => {
-    return getDataSourceSrv().get(query?.datasource);
-  }, [query?.datasource]);
+  const { dataSource: datasource } = useDataSourceInstance(query?.datasource);
 
   const onSelectFromQueryLibrary = useCallback(() => {
     openDrawer({

--- a/public/app/features/dashboard-scene/settings/annotations/AnnotationSettingsEdit.test.tsx
+++ b/public/app/features/dashboard-scene/settings/annotations/AnnotationSettingsEdit.test.tsx
@@ -45,6 +45,19 @@ jest.mock('@grafana/runtime', () => ({
   }),
 }));
 
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstance: jest.fn(async () => ({
+    ...defaultDatasource,
+    variables: {
+      getType: () => VariableSupportType.Custom,
+      query: jest.fn(),
+      editor: jest.fn().mockImplementation(LegacyVariableQueryEditor),
+    },
+  })),
+  getDataSourceInstanceSettings: jest.fn(async () => ({ ...defaultDatasource })),
+}));
+
 const runRequestMock = jest.fn().mockReturnValue(
   of<PanelData>({
     state: LoadingState.Done,

--- a/public/app/features/dashboard-scene/settings/annotations/AnnotationSettingsEdit.tsx
+++ b/public/app/features/dashboard-scene/settings/annotations/AnnotationSettingsEdit.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/css';
 import { useId, useMemo } from 'react';
 import * as React from 'react';
-import { useAsync } from 'react-use';
 
 import {
   type AnnotationQuery,
@@ -12,8 +11,8 @@ import {
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
-import { getDataSourceSrv } from '@grafana/runtime';
 import { usePanelPluginMetasMap } from '@grafana/runtime/internal';
+import { useDataSourceInstance, useDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { type VizPanel } from '@grafana/scenes';
 import { type AnnotationPanelFilter } from '@grafana/schema';
 import {
@@ -65,11 +64,8 @@ export const AnnotationSettingsEdit = ({ annotation, editIndex, panels, onUpdate
     return annotation.filter.exclude ? PanelFilterType.ExcludePanels : PanelFilterType.IncludePanels;
   }, [annotation.filter]);
 
-  const { value: ds } = useAsync(() => {
-    return getDataSourceSrv().get(annotation.datasource);
-  }, [annotation.datasource]);
-
-  const dsi = getDataSourceSrv().getInstanceSettings(annotation.datasource);
+  const { isLoading: isDsLoading, dataSource: ds } = useDataSourceInstance(annotation.datasource);
+  const { settings: dsi } = useDataSourceInstanceSettings(annotation.datasource);
 
   const AnnotationControlsDisplayOptions = useMemo(
     () => [
@@ -271,7 +267,7 @@ export const AnnotationSettingsEdit = ({ annotation, editIndex, panels, onUpdate
           >
             <DataSourcePicker annotations variables current={annotation.datasource} onChange={onDataSourceChange} />
           </Field>
-          {!ds?.meta.annotations && (
+          {!isDsLoading && !ds?.meta.annotations && (
             <Alert
               title={t(
                 'dashboard-scene.annotation-settings-edit.title-annotation-support-source',

--- a/public/app/features/dashboard-scene/settings/annotations/AnnotationSettingsList.test.tsx
+++ b/public/app/features/dashboard-scene/settings/annotations/AnnotationSettingsList.test.tsx
@@ -14,11 +14,9 @@ const defaultDatasource = mockDataSource({
   type: 'test',
 });
 
-jest.mock('@grafana/runtime', () => ({
-  ...jest.requireActual('@grafana/runtime'),
-  getDataSourceSrv: () => ({
-    getInstanceSettings: () => ({ ...defaultDatasource }),
-  }),
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstanceSettings: jest.fn(async () => ({ ...defaultDatasource })),
 }));
 
 describe('AnnotationSettingsEdit', () => {

--- a/public/app/features/dashboard-scene/settings/annotations/AnnotationSettingsList.tsx
+++ b/public/app/features/dashboard-scene/settings/annotations/AnnotationSettingsList.tsx
@@ -3,7 +3,7 @@ import { css } from '@emotion/css';
 import { type AnnotationQuery } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { useDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { Button, DeleteButton, EmptyState, IconButton, Stack, TextLink, useStyles2 } from '@grafana/ui';
 
 import { MoveDirection } from '../AnnotationsEditView';
@@ -49,7 +49,6 @@ export const AnnotationSettingsList = ({ annotations, onNew, onEdit, onMove, onD
     return <>{anno.name}</>;
   };
 
-  const dataSourceSrv = getDataSourceSrv();
   return (
     <Stack direction="column">
       {annotations.length > 0 && (
@@ -83,7 +82,7 @@ export const AnnotationSettingsList = ({ annotations, onNew, onEdit, onMove, onD
                     </td>
                   )}
                   <td role="gridcell" className="pointer" onClick={() => onEdit(idx)}>
-                    {dataSourceSrv.getInstanceSettings(annotation.datasource)?.name || annotation.datasource?.uid}
+                    <AnnotationDataSourceName datasource={annotation.datasource} />
                   </td>
                   <td role="gridcell" style={{ width: '1%' }}>
                     {idx !== 0 && (
@@ -167,6 +166,11 @@ export const AnnotationSettingsList = ({ annotations, onNew, onEdit, onMove, onD
     </Stack>
   );
 };
+
+function AnnotationDataSourceName({ datasource }: { datasource: AnnotationQuery['datasource'] }) {
+  const { settings } = useDataSourceInstanceSettings(datasource);
+  return <>{settings?.name || datasource?.uid}</>;
+}
 
 const getStyles = () => ({
   table: css({


### PR DESCRIPTION
Migrates dashboard annotation settings and provisioned controls off the deprecated sync `DataSourceSrv` APIs onto the async replacements.

Part of https://github.com/grafana/grafana/issues/127032

Made with [Cursor](https://cursor.com)