### PR TITLE
TimeSeriesPanel: keep tooltip timestamp when first series is hidden

### DIFF
--- a/public/app/plugins/panel/timeseries/TimeSeriesTooltip.test.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesTooltip.test.tsx
@@ -117,4 +117,26 @@ describe('TimeSeriesTooltip time comparison (#126189)', () => {
     expect(screen.getByText('CPU')).toBeInTheDocument();
     expect(screen.getByText('CPU (comparison)')).toBeInTheDocument();
   });
+
+  it('still renders the header timestamp when the first series is hidden (#109913)', () => {
+    // makeSeries with two value fields builds a 3-field frame: [time, CPU, Memory].
+    // dataIdxs is per-field; a null entry means that field has no hovered value.
+    // When the time/x field (index 0) and the first value series (index 1) have no
+    // hovered value but the second series (index 2) does, the header timestamp must
+    // still be derived from the remaining non-null dataIdx.
+    render(
+      <TimeSeriesTooltip
+        series={makeSeries({ displayName: 'CPU' }, { displayName: 'Memory' })}
+        dataIdxs={[null, null, 0]}
+        seriesIdx={2}
+        mode={TooltipDisplayMode.Multi}
+        sortOrder={SortOrder.None}
+        isPinned={false}
+        dataLinks={[]}
+      />
+    );
+
+    expect(screen.getByText(`T${ALIGNED_TIME}`)).toBeInTheDocument();
+    expect(screen.getByText('Memory')).toBeInTheDocument();
+  });
 });

--- a/public/app/plugins/panel/timeseries/TimeSeriesTooltip.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesTooltip.tsx
@@ -81,10 +81,15 @@ export const TimeSeriesTooltip = ({
   const pluginContext = usePluginContext();
 
   const xField = series.fields[0];
-  let xVal = xField.values[dataIdxs[0]!];
+  // The first series is sometimes hidden (e.g. via the legend), in which case its
+  // dataIdx is null. Fall back to the first non-null dataIdx so the header timestamp
+  // is still rendered. See #109913.
+  const xDataIdx = dataIdxs.find((idx) => idx != null) ?? dataIdxs[0];
+  let xVal = xField.values[xDataIdx!];
 
   if (compareDiffMs != null && xField.type === FieldType.time) {
-    xVal += compareDiffMs[seriesIdx ?? 1];
+    const compareIdx = seriesIdx ?? dataIdxs.findIndex((idx) => idx != null) ?? 1;
+    xVal += compareDiffMs[compareIdx] ?? compareDiffMs[1] ?? 0;
   }
 
   const xDisp = formattedValueToString(xField.display!(xVal));


### PR DESCRIPTION
**What is this PR doing?**

When a series is hidden via the legend in the Time Series panel, its `dataIdx` in the aligned frame passed to the tooltip is `null`. `TimeSeriesTooltip` read the header timestamp from `dataIdxs[0]`, so hiding the first series yielded `undefined` and the timestamp disappeared from the tooltip (while the tooltip body still rendered for the remaining visible series).

This PR falls back to the first **non-null** `dataIdx` for the header timestamp, and applies the same fallback when picking the `compareDiffMs` entry used for time-comparison shifts.

**Before**

Hiding series 0 (e.g. via the legend) → no timestamp in the tooltip header.

**After**

Header timestamp renders from the first visible series.

**Testing**

- Added a regression test (`still renders the header timestamp when the first series is hidden (#109913)`) that renders the tooltip with `dataIdxs=[null, 0]` and asserts both the timestamp and the visible series name are present.
- Existing time-comparison tests are unchanged and still cover the `compareDiffMs` path.

**Fixes** #109913

**Notes to reviewer**

- The `?? compareDiffMs[1] ?? 0` on the compare path is a small belt-and-braces addition; the original code indexed with `seriesIdx ?? 1` and had no fallback.
- Could not run jest locally (no node in this environment); the change is a 3-line logic tweak following existing patterns in the file and the test mirrors the surrounding test cases.

**CLA**

I have signed the Grafana CLA (will confirm via the CLA assistant on PR creation).