### PR TITLE
Home: Guard solution CTA destinations by permission

### DIFF
--- a/public/app/features/home/Overview/SolutionCard.tsx
+++ b/public/app/features/home/Overview/SolutionCard.tsx
@@ -76,10 +76,13 @@ export function SolutionCard({ solution, needsAttention }: SolutionCardProps) {
         )}
       </Card.Description>
 
-      <Card.Actions>
-        {ctaLoading ? (
+      {ctaLoading && (
+        <Card.Actions>
           <Skeleton width={120} height={24} />
-        ) : cta ? (
+        </Card.Actions>
+      )}
+      {!ctaLoading && cta && (
+        <Card.Actions>
           <LinkButton
             href={cta.href}
             fill="text"
@@ -98,8 +101,8 @@ export function SolutionCard({ solution, needsAttention }: SolutionCardProps) {
           >
             {cta.label}
           </LinkButton>
-        ) : null}
-      </Card.Actions>
+        </Card.Actions>
+      )}
     </Card>
   );
 }

--- a/public/app/features/home/Overview/SolutionCard.tsx
+++ b/public/app/features/home/Overview/SolutionCard.tsx
@@ -76,31 +76,32 @@ export function SolutionCard({ solution, needsAttention }: SolutionCardProps) {
         )}
       </Card.Description>
 
-      {ctaLoading && (
+      {(ctaLoading || cta) && (
         <Card.Actions>
-          <Skeleton width={120} height={24} />
-        </Card.Actions>
-      )}
-      {!ctaLoading && cta && (
-        <Card.Actions>
-          <LinkButton
-            href={cta.href}
-            fill="text"
-            size="sm"
-            icon="angle-right"
-            iconPlacement="right"
-            className={cx(styles.textAction, isAttentionCta && styles.attentionAction)}
-            onClick={() =>
-              ctaClicked({
-                surface: 'overview',
-                action: cta.action,
-                placement: 'card',
-                solution: solution.id,
-              })
-            }
-          >
-            {cta.label}
-          </LinkButton>
+          {ctaLoading ? (
+            <Skeleton width={120} height={24} />
+          ) : (
+            cta && (
+              <LinkButton
+                href={cta.href}
+                fill="text"
+                size="sm"
+                icon="angle-right"
+                iconPlacement="right"
+                className={cx(styles.textAction, isAttentionCta && styles.attentionAction)}
+                onClick={() =>
+                  ctaClicked({
+                    surface: 'overview',
+                    action: cta.action,
+                    placement: 'card',
+                    solution: solution.id,
+                  })
+                }
+              >
+                {cta.label}
+              </LinkButton>
+            )
+          )}
         </Card.Actions>
       )}
     </Card>

--- a/public/app/features/home/solutions/kubernetesSolution.test.ts
+++ b/public/app/features/home/solutions/kubernetesSolution.test.ts
@@ -1,4 +1,5 @@
 import { type DataSourceInstanceListItem, type FieldSparkline } from '@grafana/data';
+import { contextSrv } from 'app/core/services/context_srv';
 
 import {
   fetchClusterCpuSeries,
@@ -55,6 +56,7 @@ beforeEach(() => {
   mockSetupGuideEnabled.mockResolvedValue(false);
   mockAccessibleAppPage.mockReset();
   mockAccessibleAppPage.mockImplementation(async (appId, path) => `/a/${appId}${path}`);
+  jest.spyOn(contextSrv, 'hasAccessToExplore').mockReturnValue(true);
 });
 
 describe('kubernetesSolution', () => {
@@ -234,6 +236,13 @@ describe('kubernetesSolution CTA and offer', () => {
     expect(cta?.href).toMatch(/^\/explore\?left=/);
     expect(cta?.action).toBe('open_solution');
     expect(decodeURIComponent(cta!.href)).toContain('k8s-prom');
+  });
+
+  it('omits the CTA when neither the app nor Explore is accessible', async () => {
+    mockAccessibleAppPage.mockResolvedValue(null);
+    jest.spyOn(contextSrv, 'hasAccessToExplore').mockReturnValue(false);
+
+    await expect(kubernetesSolution().cta()).resolves.toBeNull();
   });
 
   it('offers the accessible setup flow after a definitive no-data result', async () => {

--- a/public/app/features/home/solutions/kubernetesSolution.ts
+++ b/public/app/features/home/solutions/kubernetesSolution.ts
@@ -2,6 +2,7 @@ import memoize from 'micro-memoize';
 
 import { formattedValueToString, getValueFormat, locationUtil, type DataSourceInstanceListItem } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { contextSrv } from 'app/core/services/context_srv';
 import { constructDataSourceExploreUrl } from 'app/features/datasources/utils';
 
 import {
@@ -166,13 +167,17 @@ export function kubernetesSolution(): Solution {
         }
       }
       const href = await accessibleAppHref('/home', ds);
-      return href
-        ? { label: openAppLabel('Kubernetes Monitoring'), href, action: 'open_solution' }
-        : {
-            label: openExploreLabel(),
-            href: constructDataSourceExploreUrl({ name: ds.name }),
-            action: 'open_solution',
-          };
+      if (href) {
+        return { label: openAppLabel('Kubernetes Monitoring'), href, action: 'open_solution' };
+      }
+      if (contextSrv.hasAccessToExplore()) {
+        return {
+          label: openExploreLabel(),
+          href: constructDataSourceExploreUrl({ name: ds.name }),
+          action: 'open_solution',
+        };
+      }
+      return null;
     },
   };
 }

--- a/public/app/features/home/solutions/kubernetesSolution.ts
+++ b/public/app/features/home/solutions/kubernetesSolution.ts
@@ -2,8 +2,6 @@ import memoize from 'micro-memoize';
 
 import { formattedValueToString, getValueFormat, locationUtil, type DataSourceInstanceListItem } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { contextSrv } from 'app/core/services/context_srv';
-import { constructDataSourceExploreUrl } from 'app/features/datasources/utils';
 
 import {
   fetchClusterCpuSeries,
@@ -14,7 +12,7 @@ import {
   KUBERNETES_APP_ID,
   type KubernetesHealth,
 } from './kubernetesData';
-import { accessibleAppPage, openAppLabel, openExploreLabel } from './pluginPages';
+import { accessibleAppPage, exploreFallbackCta, openAppLabel } from './pluginPages';
 import { datasourceFact } from './probeUtils';
 import { solutionOffer } from './solutionOffer';
 import { detectSignal } from './solutionState';
@@ -170,14 +168,7 @@ export function kubernetesSolution(): Solution {
       if (href) {
         return { label: openAppLabel('Kubernetes Monitoring'), href, action: 'open_solution' };
       }
-      if (contextSrv.hasAccessToExplore()) {
-        return {
-          label: openExploreLabel(),
-          href: constructDataSourceExploreUrl({ name: ds.name }),
-          action: 'open_solution',
-        };
-      }
-      return null;
+      return exploreFallbackCta(ds);
     },
   };
 }

--- a/public/app/features/home/solutions/metricsSolution.test.ts
+++ b/public/app/features/home/solutions/metricsSolution.test.ts
@@ -1,4 +1,5 @@
 import { type DataSourceInstanceListItem } from '@grafana/data';
+import { contextSrv } from 'app/core/services/context_srv';
 
 import { METRICS_DRILLDOWN_APP_ID } from './appPluginIds';
 import { metricsSolution } from './metricsSolution';
@@ -62,6 +63,7 @@ beforeEach(() => {
     href: '/metrics',
     action: 'open_solution',
   });
+  jest.spyOn(contextSrv, 'hasAccessToExplore').mockReturnValue(true);
 });
 
 describe('metricsSolution', () => {
@@ -246,6 +248,24 @@ describe('metricsSolution', () => {
     });
     expect(mockFetchDiskHoursToFull).not.toHaveBeenCalled();
     expect(mockDrilldownActiveCta).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the active CTA without checking attention when Explore is inaccessible', async () => {
+    mockFetchDiskPressure.mockResolvedValue({
+      hostsAbove: 1,
+      worstInstance: 'web-03:9100',
+      worstMount: '/data',
+      worstRatio: 0.96,
+    });
+    jest.spyOn(contextSrv, 'hasAccessToExplore').mockReturnValue(false);
+
+    await expect(metricsSolution().cta()).resolves.toEqual({
+      label: 'Open Metrics Drilldown',
+      href: '/metrics',
+      action: 'open_solution',
+    });
+    expect(mockFetchDiskPressure).not.toHaveBeenCalled();
+    expect(mockDrilldownActiveCta).toHaveBeenCalled();
   });
 
   it('builds the active CTA from the datasource that proved usage', async () => {

--- a/public/app/features/home/solutions/metricsSolution.ts
+++ b/public/app/features/home/solutions/metricsSolution.ts
@@ -9,6 +9,7 @@ import {
   urlUtil,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { contextSrv } from 'app/core/services/context_srv';
 
 import { METRICS_DRILLDOWN_APP_ID } from './appPluginIds';
 import { resolveKubernetesDatasource } from './kubernetesData';
@@ -195,7 +196,7 @@ export function metricsSolution(): Solution {
       if (!ds) {
         return null;
       }
-      if (await needsAttention().catch(() => false)) {
+      if (contextSrv.hasAccessToExplore() && (await needsAttention().catch(() => false))) {
         return {
           label: t('home.solutions.metrics.investigate-disk', 'Investigate disk usage in Explore'),
           href: diskPressureExploreHref(ds),

--- a/public/app/features/home/solutions/pluginPages.test.ts
+++ b/public/app/features/home/solutions/pluginPages.test.ts
@@ -1,4 +1,5 @@
 import { type DataSourceInstanceListItem, type PluginMeta } from '@grafana/data';
+import { contextSrv } from 'app/core/services/context_srv';
 import { canAccessPluginPage, isPluginEnabled, probePlugin } from 'app/features/alerting/unified/hooks/usePluginBridge';
 import { constructDataSourceExploreUrl } from 'app/features/datasources/utils';
 
@@ -34,6 +35,7 @@ beforeEach(() => {
   isPluginEnabledMock.mockReset();
   canAccessPluginPageMock.mockReset();
   constructDataSourceExploreUrlMock.mockReset();
+  jest.spyOn(contextSrv, 'hasAccessToExplore').mockReturnValue(true);
   isPluginEnabledMock.mockReturnValue(true);
   canAccessPluginPageMock.mockReturnValue(true);
   constructDataSourceExploreUrlMock.mockReturnValue('/explore?left=prometheus');
@@ -81,6 +83,17 @@ it('falls back to Explore with the proving datasource when the deep page is inac
     drilldownActiveCta(datasource, 'inaccessible-app', 'Metrics Drilldown', '/a/inaccessible-app/explore')
   ).resolves.toEqual({ label: 'Open in Explore', href: '/explore?left=prometheus', action: 'open_solution' });
   expect(constructDataSourceExploreUrlMock).toHaveBeenCalledWith({ name: 'Prometheus' });
+});
+
+it('omits the CTA when neither the drilldown page nor Explore is accessible', async () => {
+  probePluginMock.mockResolvedValue({ settings: settings('inaccessible-app') });
+  canAccessPluginPageMock.mockReturnValue(false);
+  jest.spyOn(contextSrv, 'hasAccessToExplore').mockReturnValue(false);
+
+  await expect(
+    drilldownActiveCta(datasource, 'inaccessible-app', 'Metrics Drilldown', '/a/inaccessible-app/explore')
+  ).resolves.toBeNull();
+  expect(constructDataSourceExploreUrlMock).not.toHaveBeenCalled();
 });
 
 it('returns a bridge path only when that app page is accessible', async () => {

--- a/public/app/features/home/solutions/pluginPages.ts
+++ b/public/app/features/home/solutions/pluginPages.ts
@@ -1,5 +1,6 @@
 import { locationUtil, type DataSourceInstanceListItem, type PluginMeta } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { contextSrv } from 'app/core/services/context_srv';
 import { createBridgeURL } from 'app/features/alerting/unified/components/PluginBridge';
 import { canAccessPluginPage, isPluginEnabled, probePlugin } from 'app/features/alerting/unified/hooks/usePluginBridge';
 import { constructDataSourceExploreUrl } from 'app/features/datasources/utils';
@@ -38,10 +39,20 @@ export async function drilldownActiveCta(
   appId: string,
   appName: string,
   appPath: string
-): Promise<SolutionCta<'open_solution'>> {
-  return (await isDrilldownAvailable(appId, appPath))
-    ? { label: openAppLabel(appName), href: locationUtil.assureBaseUrl(appPath), action: 'open_solution' }
-    : { label: openExploreLabel(), href: constructDataSourceExploreUrl({ name: ds.name }), action: 'open_solution' };
+): Promise<SolutionCta<'open_solution'> | null> {
+  if (await isDrilldownAvailable(appId, appPath)) {
+    return { label: openAppLabel(appName), href: locationUtil.assureBaseUrl(appPath), action: 'open_solution' };
+  }
+
+  if (contextSrv.hasAccessToExplore()) {
+    return {
+      label: openExploreLabel(),
+      href: constructDataSourceExploreUrl({ name: ds.name }),
+      action: 'open_solution',
+    };
+  }
+
+  return null;
 }
 
 // Product names are not translated.

--- a/public/app/features/home/solutions/pluginPages.ts
+++ b/public/app/features/home/solutions/pluginPages.ts
@@ -44,15 +44,7 @@ export async function drilldownActiveCta(
     return { label: openAppLabel(appName), href: locationUtil.assureBaseUrl(appPath), action: 'open_solution' };
   }
 
-  if (contextSrv.hasAccessToExplore()) {
-    return {
-      label: openExploreLabel(),
-      href: constructDataSourceExploreUrl({ name: ds.name }),
-      action: 'open_solution',
-    };
-  }
-
-  return null;
+  return exploreFallbackCta(ds);
 }
 
 // Product names are not translated.
@@ -62,4 +54,14 @@ export function openAppLabel(appName: string): string {
 
 export function openExploreLabel(): string {
   return t('home.solutions.cta.open-explore', 'Open in Explore');
+}
+
+export function exploreFallbackCta(ds: DataSourceInstanceListItem): SolutionCta<'open_solution'> | null {
+  return contextSrv.hasAccessToExplore()
+    ? {
+        label: openExploreLabel(),
+        href: constructDataSourceExploreUrl({ name: ds.name }),
+        action: 'open_solution',
+      }
+    : null;
 }


### PR DESCRIPTION
**What is this feature?**

Guards homepage solution CTAs by their actual destination:

- Only uses Explore fallbacks when the current user can access Explore.
- Lets the Metrics attention CTA fall through to Metrics Drilldown when Explore is unavailable.
- Keeps solution cards visible even when there is no destination the current user can open.
- Omits resolved-empty action rows from Overview cards. Recommendations intentionally keep their existing layout.

**Why do we need this feature?**

Permission matrix testing found that a Viewer could be offered **Open in Explore** even though the Explore route denied access and left them on the homepage. The card still contains useful stack information, but its CTA should not send the user to a dead end.

**Special notes for your reviewer:**

The permission matrix covers Viewer, Editor, Admin, denied datasources, plugin inventory failures, and each visible in-app CTA destination.
