### PR TITLE
Alerting: Fix ngalert swagger doc leaks and add missing 409 responses

### DIFF
--- a/packages/grafana-openapi/src/api/openapi3.json
+++ b/packages/grafana-openapi/src/api/openapi3.json
@@ -2685,6 +2685,11 @@
             },
             "type": "array"
           },
+          "policy": {
+            "description": "Name of the notification policy to route alerts through.\nMutually exclusive with all other fields, cannot be used with contact point routing via the \"receiver\" field.",
+            "example": "\"Alerting Team\"",
+            "type": "string"
+          },
           "receiver": {
             "description": "Name of the receiver to send notifications to.",
             "example": "grafana-default-email",
@@ -3850,6 +3855,26 @@
           "$ref": "#/components/schemas/EmbeddedContactPoint"
         },
         "type": "array"
+      },
+      "ConvertAlertmanagerResponse": {
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "errorType": {
+            "type": "string"
+          },
+          "rename_resources": {
+            "$ref": "#/components/schemas/RenameResources"
+          },
+          "stats": {
+            "$ref": "#/components/schemas/MergeStats"
+          },
+          "status": {
+            "type": "string"
+          }
+        },
+        "type": "object"
       },
       "ConvertPrometheusResponse": {
         "properties": {
@@ -5261,7 +5286,6 @@
           },
           "uptime": {
             "description": "uptime",
-            "format": "date-time",
             "type": "string"
           },
           "versionInfo": {
@@ -5279,8 +5303,9 @@
           "identifier": {
             "type": "string"
           },
-          "merge_matchers": {
-            "$ref": "#/components/schemas/Matchers"
+          "managed_by": {
+            "description": "ManagedBy is \"manual\" or \"auto-sync\", computed server-side so callers don't need configs:get\nto tell the two apart.",
+            "type": "string"
           },
           "template_files": {
             "additionalProperties": {
@@ -6047,6 +6072,9 @@
           },
           "uid": {
             "type": "string"
+          },
+          "version": {
+            "type": "string"
           }
         },
         "type": "object"
@@ -6147,7 +6175,6 @@
             "type": "integer"
           },
           "last_applied": {
-            "format": "date-time",
             "type": "string"
           },
           "template_file_provenances": {
@@ -6169,6 +6196,10 @@
         "properties": {
           "alertmanagersChoice": {
             "enum": ["all", "internal", "external"],
+            "type": "string"
+          },
+          "external_alertmanager_uid": {
+            "description": "ExternalAlertmanagerUID is the UID of the Mimir/Cortex Alertmanager datasource being\nsynced, or empty if sync is not configured for this org.",
             "type": "string"
           }
         },
@@ -6238,7 +6269,6 @@
           },
           "uptime": {
             "description": "uptime",
-            "format": "date-time",
             "type": "string"
           },
           "versionInfo": {
@@ -6359,6 +6389,9 @@
             "$ref": "#/components/schemas/URL"
           }
         },
+        "type": "object"
+      },
+      "Gone": {
         "type": "object"
       },
       "HTTPClientConfig": {
@@ -6704,6 +6737,52 @@
         },
         "type": "object"
       },
+      "InhibitionRule": {
+        "description": "It embeds the upstream Alertmanager InhibitRule and adds Grafana-specific fields.",
+        "properties": {
+          "equal": {
+            "description": "A set of labels that must be equal between the source and target alert\nfor them to be a match.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          },
+          "provenance": {
+            "$ref": "#/components/schemas/Provenance"
+          },
+          "source_match": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "SourceMatch defines a set of labels that have to equal the given\nvalue for source alerts. Deprecated. Remove before v1.0 release.",
+            "type": "object"
+          },
+          "source_match_re": {
+            "$ref": "#/components/schemas/MatchRegexps"
+          },
+          "source_matchers": {
+            "$ref": "#/components/schemas/Matchers"
+          },
+          "target_match": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "TargetMatch defines a set of labels that have to equal the given\nvalue for target alerts. Deprecated. Remove before v1.0 release.",
+            "type": "object"
+          },
+          "target_match_re": {
+            "$ref": "#/components/schemas/MatchRegexps"
+          },
+          "target_matchers": {
+            "$ref": "#/components/schemas/Matchers"
+          }
+        },
+        "title": "InhibitionRule is the domain model for inhibition rules with metadata.",
+        "type": "object"
+      },
       "InspectType": {
         "format": "int64",
         "title": "InspectType is a type for the Inspect property of a Notice.",
@@ -6713,7 +6792,6 @@
         "properties": {
           "lastNotifyAttempt": {
             "description": "A timestamp indicating the last attempt to deliver a notification regardless of the outcome.\nFormat: date-time",
-            "format": "date-time",
             "type": "string"
           },
           "lastNotifyAttemptDuration": {
@@ -6866,21 +6944,10 @@
         "format": "int64",
         "type": "integer"
       },
-      "Label": {
-        "properties": {
-          "Name": {
-            "type": "string"
-          }
-        },
-        "title": "Label is a key/value pair of strings.",
-        "type": "object"
-      },
       "Labels": {
-        "description": "Labels is a sorted set of labels. Order has to be guaranteed upon\ninstantiation.",
-        "items": {
-          "$ref": "#/components/schemas/Label"
-        },
-        "type": "array"
+        "description": "Each name and value is preceded by its length, encoded as a single byte\nfor size 0-254, or the following 3 bytes little-endian, if the first byte is 255.\nMaximum length allowed is 2^24 or 16MB.\nNames are in order.",
+        "title": "Labels is implemented by a single flat string holding name/value pairs.",
+        "type": "object"
       },
       "LibraryElementArrayResponse": {
         "properties": {
@@ -7144,6 +7211,19 @@
         },
         "type": "object"
       },
+      "ManagedInhibitionRules": {
+        "additionalProperties": {
+          "$ref": "#/components/schemas/InhibitionRule"
+        },
+        "type": "object"
+      },
+      "ManagedRoutes": {
+        "additionalProperties": {
+          "$ref": "#/components/schemas/Route"
+        },
+        "description": "ManagedRoutes this type exists purely to ensure unmarshalling upstream Routes will call Validate and populate\nGroupBy and GroupByAll. Eventually, we will want this to be a separate type and make the conversion to\ndefinitions.Route explicit.",
+        "type": "object"
+      },
       "ManagerKind": {
         "description": "It can be a user or a tool or a generic API client.\n+enum",
         "title": "ManagerKind is the type of manager, which is responsible for managing the resource.",
@@ -7202,6 +7282,44 @@
           "$ref": "#/components/schemas/Matcher"
         },
         "type": "array"
+      },
+      "MergeStats": {
+        "properties": {
+          "added_inhibition_rules": {
+            "description": "AddedInhibitionRules contains the names of inhibition rules added",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "added_receivers": {
+            "description": "AddedReceivers contains the names of receivers added (post-rename if renamed)",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "added_route": {
+            "description": "AddedRoute is the identifier of the routing sub-tree added to the configuration",
+            "type": "string"
+          },
+          "added_templates": {
+            "description": "AddedTemplates contains the names of templates added",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "added_time_intervals": {
+            "description": "AddedTimeIntervals contains the names of time intervals added (post-rename if renamed)",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "title": "MergeStats describes which resources were added during configuration merge.",
+        "type": "object"
       },
       "Metadata": {
         "additionalProperties": {
@@ -8341,105 +8459,29 @@
       "PostableApiReceiver": {
         "description": "nolint:revive",
         "properties": {
-          "discord_configs": {
-            "items": {
-              "$ref": "#/components/schemas/DiscordConfig"
-            },
-            "type": "array"
-          },
-          "email_configs": {
-            "items": {
-              "$ref": "#/components/schemas/EmailConfig"
-            },
-            "type": "array"
-          },
           "grafana_managed_receiver_configs": {
             "items": {
               "$ref": "#/components/schemas/PostableGrafanaReceiver"
             },
             "type": "array"
           },
-          "jira_configs": {
-            "items": {
-              "$ref": "#/components/schemas/JiraConfig"
-            },
-            "type": "array"
-          },
-          "msteams_configs": {
-            "items": {
-              "$ref": "#/components/schemas/MSTeamsConfig"
-            },
-            "type": "array"
-          },
-          "msteamsv2_configs": {
-            "items": {
-              "$ref": "#/components/schemas/MSTeamsV2Config"
-            },
-            "type": "array"
-          },
           "name": {
-            "description": "A unique identifier for this receiver.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "PostableApiTemplate": {
+        "description": "nolint:revive",
+        "properties": {
+          "content": {
             "type": "string"
           },
-          "opsgenie_configs": {
-            "items": {
-              "$ref": "#/components/schemas/OpsGenieConfig"
-            },
-            "type": "array"
+          "kind": {
+            "$ref": "#/components/schemas/TemplateKind"
           },
-          "pagerduty_configs": {
-            "items": {
-              "$ref": "#/components/schemas/PagerdutyConfig"
-            },
-            "type": "array"
-          },
-          "pushover_configs": {
-            "items": {
-              "$ref": "#/components/schemas/PushoverConfig"
-            },
-            "type": "array"
-          },
-          "slack_configs": {
-            "items": {
-              "$ref": "#/components/schemas/SlackConfig"
-            },
-            "type": "array"
-          },
-          "sns_configs": {
-            "items": {
-              "$ref": "#/components/schemas/SNSConfig"
-            },
-            "type": "array"
-          },
-          "telegram_configs": {
-            "items": {
-              "$ref": "#/components/schemas/TelegramConfig"
-            },
-            "type": "array"
-          },
-          "victorops_configs": {
-            "items": {
-              "$ref": "#/components/schemas/VictorOpsConfig"
-            },
-            "type": "array"
-          },
-          "webex_configs": {
-            "items": {
-              "$ref": "#/components/schemas/WebexConfig"
-            },
-            "type": "array"
-          },
-          "webhook_configs": {
-            "items": {
-              "$ref": "#/components/schemas/WebhookConfig"
-            },
-            "type": "array"
-          },
-          "wechat_configs": {
-            "items": {
-              "$ref": "#/components/schemas/WechatConfig"
-            },
-            "type": "array"
+          "name": {
+            "type": "string"
           }
         },
         "type": "object"
@@ -8522,6 +8564,9 @@
           },
           "uid": {
             "type": "string"
+          },
+          "version": {
+            "type": "string"
           }
         },
         "type": "object"
@@ -8588,6 +8633,10 @@
           "alertmanagersChoice": {
             "enum": ["all", "internal", "external"],
             "type": "string"
+          },
+          "external_alertmanager_uid": {
+            "description": "ExternalAlertmanagerUID is the UID of the Mimir/Cortex Alertmanager datasource to sync\nconfiguration from. Empty string disables sync for this org.",
+            "type": "string"
           }
         },
         "type": "object"
@@ -8650,6 +8699,18 @@
               "$ref": "#/components/schemas/ExtraConfiguration"
             },
             "type": "array"
+          },
+          "managed_inhibition_rules": {
+            "$ref": "#/components/schemas/ManagedInhibitionRules"
+          },
+          "managed_routes": {
+            "$ref": "#/components/schemas/ManagedRoutes"
+          },
+          "managed_templates": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/PostableApiTemplate"
+            },
+            "type": "object"
           },
           "template_files": {
             "additionalProperties": {
@@ -9641,6 +9702,26 @@
         "properties": {
           "url": {
             "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "RenameResources": {
+        "description": "RenameResources describes which resources were renamed to avoid conflicts",
+        "properties": {
+          "receivers": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Receivers maps old receiver names to new receiver names",
+            "type": "object"
+          },
+          "time_intervals": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "TimeIntervals maps old time interval names to new time interval names",
+            "type": "object"
           }
         },
         "type": "object"
@@ -11543,6 +11624,9 @@
       "TempUserStatus": {
         "type": "string"
       },
+      "TemplateKind": {
+        "type": "string"
+      },
       "TestRulePayload": {
         "properties": {
           "expr": {
@@ -11574,6 +11658,9 @@
               "$ref": "#/components/schemas/postableAlert"
             },
             "type": "array"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/TemplateKind"
           },
           "name": {
             "description": "Name of the template file.",
@@ -12738,7 +12825,6 @@
         "properties": {
           "generatorURL": {
             "description": "generator URL\nFormat: uri",
-            "format": "uri",
             "type": "string"
           },
           "labels": {
@@ -12823,7 +12909,6 @@
           },
           "uptime": {
             "description": "uptime",
-            "format": "date-time",
             "type": "string"
           },
           "versionInfo": {
@@ -12892,7 +12977,6 @@
           },
           "endsAt": {
             "description": "ends at",
-            "format": "date-time",
             "type": "string"
           },
           "fingerprint": {
@@ -12901,7 +12985,6 @@
           },
           "generatorURL": {
             "description": "generator URL\nFormat: uri",
-            "format": "uri",
             "type": "string"
           },
           "labels": {
@@ -12916,7 +12999,6 @@
           },
           "startsAt": {
             "description": "starts at",
-            "format": "date-time",
             "type": "string"
           },
           "status": {
@@ -12924,7 +13006,6 @@
           },
           "updatedAt": {
             "description": "updated at",
-            "format": "date-time",
             "type": "string"
           }
         },
@@ -12961,7 +13042,6 @@
           },
           "endsAt": {
             "description": "ends at",
-            "format": "date-time",
             "type": "string"
           },
           "id": {
@@ -12976,7 +13056,6 @@
           },
           "startsAt": {
             "description": "starts at",
-            "format": "date-time",
             "type": "string"
           },
           "status": {
@@ -12984,7 +13063,6 @@
           },
           "updatedAt": {
             "description": "updated at",
-            "format": "date-time",
             "type": "string"
           }
         },
@@ -13010,7 +13088,6 @@
           },
           "endsAt": {
             "description": "ends at",
-            "format": "date-time",
             "type": "string"
           },
           "id": {
@@ -13022,7 +13099,6 @@
           },
           "startsAt": {
             "description": "starts at",
-            "format": "date-time",
             "type": "string"
           },
           "status": {
@@ -13030,7 +13106,6 @@
           },
           "updatedAt": {
             "description": "updated at",
-            "format": "date-time",
             "type": "string"
           }
         },
@@ -13133,12 +13208,10 @@
           },
           "endsAt": {
             "description": "ends at\nFormat: date-time",
-            "format": "date-time",
             "type": "string"
           },
           "generatorURL": {
             "description": "generator URL\nFormat: uri",
-            "format": "uri",
             "type": "string"
           },
           "labels": {
@@ -13146,7 +13219,6 @@
           },
           "startsAt": {
             "description": "starts at\nFormat: date-time",
-            "format": "date-time",
             "type": "string"
           }
         },
@@ -13173,7 +13245,6 @@
           },
           "endsAt": {
             "description": "ends at",
-            "format": "date-time",
             "type": "string"
           },
           "id": {
@@ -13185,7 +13256,6 @@
           },
           "startsAt": {
             "description": "starts at",
-            "format": "date-time",
             "type": "string"
           }
         },
@@ -13319,7 +13389,6 @@
           },
           "endsAt": {
             "description": "ends at",
-            "format": "date-time",
             "type": "string"
           },
           "matchers": {
@@ -13327,7 +13396,6 @@
           },
           "startsAt": {
             "description": "starts at",
-            "format": "date-time",
             "type": "string"
           }
         },
@@ -24734,6 +24802,16 @@
               }
             },
             "description": "ForbiddenError"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicError"
+                }
+              }
+            },
+            "description": "PublicError"
           }
         },
         "summary": "Create a contact point.",
@@ -24875,6 +24953,16 @@
               }
             },
             "description": "ForbiddenError"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicError"
+                }
+              }
+            },
+            "description": "PublicError"
           }
         },
         "summary": "Delete a contact point.",
@@ -24941,6 +25029,16 @@
               }
             },
             "description": "ForbiddenError"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicError"
+                }
+              }
+            },
+            "description": "PublicError"
           }
         },
         "summary": "Update an existing contact point.",
@@ -25310,6 +25408,16 @@
               }
             },
             "description": "ForbiddenError"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicError"
+                }
+              }
+            },
+            "description": "PublicError"
           }
         },
         "summary": "Create a new mute timing.",
@@ -25706,6 +25814,16 @@
               }
             },
             "description": "ForbiddenError"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicError"
+                }
+              }
+            },
+            "description": "PublicError"
           }
         },
         "summary": "Clears the notification policy tree.",
@@ -25792,6 +25910,16 @@
               }
             },
             "description": "ForbiddenError"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicError"
+                }
+              }
+            },
+            "description": "PublicError"
           }
         },
         "summary": "Sets the notification policy tree.",

--- a/pkg/services/ngalert/api/authorization_test.go
+++ b/pkg/services/ngalert/api/authorization_test.go
@@ -41,7 +41,7 @@ func TestAuthorize(t *testing.T) {
 		}
 		paths[p] = methods
 	}
-	require.Len(t, paths, 64)
+	require.Len(t, paths, 65)
 
 	ac := acmock.New()
 	api := &API{AccessControl: ac, FeatureManager: featuremgmt.WithFeatures()}

--- a/pkg/services/ngalert/api/tooling/Makefile
+++ b/pkg/services/ngalert/api/tooling/Makefile
@@ -27,8 +27,22 @@ ifneq ($(OS),Windows_NT)
 	endif
 endif
 
+# -x excludes vendored Prometheus/Alertmanager packages from annotation scanning. They're only
+# reachable transitively (via github.com/grafana/alerting/notify, and via config/matchers types
+# embedded in our own definitions) as implementation baggage, not because Grafana exposes their
+# routes or models - but api/v2/restapi (and its operations subpackages) carries its own
+# swagger:meta/route/response annotations for endpoints Grafana doesn't expose, and scanning it
+# leaks them into this spec. We deliberately do NOT exclude api/v2/models: Grafana embeds/aliases
+# several of its types (GettableAlert, ClusterStatus, PostableSilence, ...) without re-declaring
+# their own swagger:model annotation, so that package must stay scanned for those to resolve.
+# go's RE2 has no negative-lookahead, so "everything under prometheus/ except api/v2/models" has
+# to be listed as separate patterns rather than one blanket exclude.
+EXCLUDE_PROMETHEUS = -x 'prometheus/alertmanager/api/v2/(restapi|client)' \
+	-x 'prometheus/alertmanager/(cluster|dispatch|notify|silence|nflog|inhibit|flushlog|store|provider|template|asset|matchers|featurecontrol|timeinterval|tracing|types|config|pkg/labels|api/metrics)' \
+	-x 'prometheus/(prometheus|common|client_golang|client_model|procfs|exporter-toolkit)'
+
 spec.json spec-stable.json: $(GO_PKG_FILES)
-	SWAGGER_GENERATE_EXTENSION=false $(SWAGGER) generate spec -m -w $(API_DIR) -o spec.json && SWAGGER_GENERATE_EXTENSION=false $(SWAGGER) generate spec -m --include-tag=stable -o spec-stable.json
+	SWAGGER_GENERATE_EXTENSION=false $(SWAGGER) generate spec -m -w $(API_DIR) $(EXCLUDE_PROMETHEUS) -o spec.json && SWAGGER_GENERATE_EXTENSION=false $(SWAGGER) generate spec -m --include-tag=stable $(EXCLUDE_PROMETHEUS) -o spec-stable.json
 
 # Prometheus URL type collides with the net/url.URL type, so we need to fix the spec if the descriptions are not correct
 # to make the spec generation consistent.

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -815,6 +815,26 @@
    },
    "type": "array"
   },
+  "ConvertAlertmanagerResponse": {
+   "properties": {
+    "error": {
+     "type": "string"
+    },
+    "errorType": {
+     "type": "string"
+    },
+    "rename_resources": {
+     "$ref": "#/definitions/RenameResources"
+    },
+    "stats": {
+     "$ref": "#/definitions/MergeStats"
+    },
+    "status": {
+     "type": "string"
+    }
+   },
+   "type": "object"
+  },
   "ConvertPrometheusResponse": {
    "properties": {
     "error": {
@@ -2474,6 +2494,44 @@
    },
    "type": "array"
   },
+  "MergeStats": {
+   "properties": {
+    "added_inhibition_rules": {
+     "description": "AddedInhibitionRules contains the names of inhibition rules added",
+     "items": {
+      "type": "string"
+     },
+     "type": "array"
+    },
+    "added_receivers": {
+     "description": "AddedReceivers contains the names of receivers added (post-rename if renamed)",
+     "items": {
+      "type": "string"
+     },
+     "type": "array"
+    },
+    "added_route": {
+     "description": "AddedRoute is the identifier of the routing sub-tree added to the configuration",
+     "type": "string"
+    },
+    "added_templates": {
+     "description": "AddedTemplates contains the names of templates added",
+     "items": {
+      "type": "string"
+     },
+     "type": "array"
+    },
+    "added_time_intervals": {
+     "description": "AddedTimeIntervals contains the names of time intervals added (post-rename if renamed)",
+     "items": {
+      "type": "string"
+     },
+     "type": "array"
+    }
+   },
+   "title": "MergeStats describes which resources were added during configuration merge.",
+   "type": "object"
+  },
   "MultiStatus": {
    "type": "object"
   },
@@ -3898,6 +3956,26 @@
    },
    "type": "object"
   },
+  "RenameResources": {
+   "description": "RenameResources describes which resources were renamed to avoid conflicts",
+   "properties": {
+    "receivers": {
+     "additionalProperties": {
+      "type": "string"
+     },
+     "description": "Receivers maps old receiver names to new receiver names",
+     "type": "object"
+    },
+    "time_intervals": {
+     "additionalProperties": {
+      "type": "string"
+     },
+     "description": "TimeIntervals maps old time interval names to new time interval names",
+     "type": "object"
+    }
+   },
+   "type": "object"
+  },
   "ResponseDetails": {
    "properties": {
     "msg": {
@@ -3915,6 +3993,7 @@
    "type": "object"
   },
   "Route": {
+   "description": "A Route is a node that contains definitions of how to handle alerts. This is modified\nfrom the upstream alertmanager in that it adds the ObjectMatchers property.",
    "properties": {
     "active_time_intervals": {
      "items": {
@@ -3956,6 +4035,12 @@
      },
      "type": "array"
     },
+    "object_matchers": {
+     "$ref": "#/definitions/ObjectMatchers"
+    },
+    "provenance": {
+     "$ref": "#/definitions/Provenance"
+    },
     "receiver": {
      "type": "string"
     },
@@ -3969,7 +4054,6 @@
      "type": "array"
     }
    },
-   "title": "A Route is a node that contains definitions of how to handle alerts.",
    "type": "object"
   },
   "RouteExport": {

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -360,6 +360,11 @@
      },
      "type": "array"
     },
+    "policy": {
+     "description": "Name of the notification policy to route alerts through.\nMutually exclusive with all other fields, cannot be used with contact point routing via the \"receiver\" field.",
+     "example": "\"Alerting Team\"",
+     "type": "string"
+    },
     "receiver": {
      "description": "Name of the receiver to send notifications to.",
      "example": "grafana-default-email",
@@ -1169,7 +1174,6 @@
     },
     "uptime": {
      "description": "uptime",
-     "format": "date-time",
      "type": "string"
     },
     "versionInfo": {
@@ -1192,8 +1196,9 @@
     "identifier": {
      "type": "string"
     },
-    "merge_matchers": {
-     "$ref": "#/definitions/Matchers"
+    "managed_by": {
+     "description": "ManagedBy is \"manual\" or \"auto-sync\", computed server-side so callers don't need configs:get\nto tell the two apart.",
+     "type": "string"
     },
     "template_files": {
      "additionalProperties": {
@@ -1720,6 +1725,9 @@
     },
     "uid": {
      "type": "string"
+    },
+    "version": {
+     "type": "string"
     }
    },
    "type": "object"
@@ -1828,7 +1836,6 @@
      "type": "integer"
     },
     "last_applied": {
-     "format": "date-time",
      "type": "string"
     },
     "template_file_provenances": {
@@ -1854,6 +1861,10 @@
       "internal",
       "external"
      ],
+     "type": "string"
+    },
+    "external_alertmanager_uid": {
+     "description": "ExternalAlertmanagerUID is the UID of the Mimir/Cortex Alertmanager datasource being\nsynced, or empty if sync is not configured for this org.",
      "type": "string"
     }
    },
@@ -1923,7 +1934,6 @@
     },
     "uptime": {
      "description": "uptime",
-     "format": "date-time",
      "type": "string"
     },
     "versionInfo": {
@@ -2049,6 +2059,9 @@
      "$ref": "#/definitions/URL"
     }
    },
+   "type": "object"
+  },
+  "Gone": {
    "type": "object"
   },
   "HTTPClientConfig": {
@@ -2188,6 +2201,52 @@
    },
    "type": "object"
   },
+  "InhibitionRule": {
+   "description": "It embeds the upstream Alertmanager InhibitRule and adds Grafana-specific fields.",
+   "properties": {
+    "equal": {
+     "description": "A set of labels that must be equal between the source and target alert\nfor them to be a match.",
+     "items": {
+      "type": "string"
+     },
+     "type": "array"
+    },
+    "name": {
+     "type": "string"
+    },
+    "provenance": {
+     "$ref": "#/definitions/Provenance"
+    },
+    "source_match": {
+     "additionalProperties": {
+      "type": "string"
+     },
+     "description": "SourceMatch defines a set of labels that have to equal the given\nvalue for source alerts. Deprecated. Remove before v1.0 release.",
+     "type": "object"
+    },
+    "source_match_re": {
+     "$ref": "#/definitions/MatchRegexps"
+    },
+    "source_matchers": {
+     "$ref": "#/definitions/Matchers"
+    },
+    "target_match": {
+     "additionalProperties": {
+      "type": "string"
+     },
+     "description": "TargetMatch defines a set of labels that have to equal the given\nvalue for target alerts. Deprecated. Remove before v1.0 release.",
+     "type": "object"
+    },
+    "target_match_re": {
+     "$ref": "#/definitions/MatchRegexps"
+    },
+    "target_matchers": {
+     "$ref": "#/definitions/Matchers"
+    }
+   },
+   "title": "InhibitionRule is the domain model for inhibition rules with metadata.",
+   "type": "object"
+  },
   "InspectType": {
    "format": "int64",
    "title": "InspectType is a type for the Inspect property of a Notice.",
@@ -2197,7 +2256,6 @@
    "properties": {
     "lastNotifyAttempt": {
      "description": "A timestamp indicating the last attempt to deliver a notification regardless of the outcome.\nFormat: date-time",
-     "format": "date-time",
      "type": "string"
     },
     "lastNotifyAttemptDuration": {
@@ -2298,21 +2356,10 @@
   "Json": {
    "type": "object"
   },
-  "Label": {
-   "properties": {
-    "Name": {
-     "type": "string"
-    }
-   },
-   "title": "Label is a key/value pair of strings.",
-   "type": "object"
-  },
   "Labels": {
-   "description": "Labels is a sorted set of labels. Order has to be guaranteed upon\ninstantiation.",
-   "items": {
-    "$ref": "#/definitions/Label"
-   },
-   "type": "array"
+   "description": "Each name and value is preceded by its length, encoded as a single byte\nfor size 0-254, or the following 3 bytes little-endian, if the first byte is 255.\nMaximum length allowed is 2^24 or 16MB.\nNames are in order.",
+   "title": "Labels is implemented by a single flat string holding name/value pairs.",
+   "type": "object"
   },
   "LinkTransformationConfig": {
    "properties": {
@@ -2378,6 +2425,19 @@
      "type": "string"
     }
    },
+   "type": "object"
+  },
+  "ManagedInhibitionRules": {
+   "additionalProperties": {
+    "$ref": "#/definitions/InhibitionRule"
+   },
+   "type": "object"
+  },
+  "ManagedRoutes": {
+   "additionalProperties": {
+    "$ref": "#/definitions/Route"
+   },
+   "description": "ManagedRoutes this type exists purely to ensure unmarshalling upstream Routes will call Validate and populate\nGroupBy and GroupByAll. Eventually, we will want this to be a separate type and make the conversion to\ndefinitions.Route explicit.",
    "type": "object"
   },
   "MatchRegexps": {
@@ -2924,105 +2984,29 @@
   "PostableApiReceiver": {
    "description": "nolint:revive",
    "properties": {
-    "discord_configs": {
-     "items": {
-      "$ref": "#/definitions/DiscordConfig"
-     },
-     "type": "array"
-    },
-    "email_configs": {
-     "items": {
-      "$ref": "#/definitions/EmailConfig"
-     },
-     "type": "array"
-    },
     "grafana_managed_receiver_configs": {
      "items": {
       "$ref": "#/definitions/PostableGrafanaReceiver"
      },
      "type": "array"
     },
-    "jira_configs": {
-     "items": {
-      "$ref": "#/definitions/JiraConfig"
-     },
-     "type": "array"
-    },
-    "msteams_configs": {
-     "items": {
-      "$ref": "#/definitions/MSTeamsConfig"
-     },
-     "type": "array"
-    },
-    "msteamsv2_configs": {
-     "items": {
-      "$ref": "#/definitions/MSTeamsV2Config"
-     },
-     "type": "array"
-    },
     "name": {
-     "description": "A unique identifier for this receiver.",
+     "type": "string"
+    }
+   },
+   "type": "object"
+  },
+  "PostableApiTemplate": {
+   "description": "nolint:revive",
+   "properties": {
+    "content": {
      "type": "string"
     },
-    "opsgenie_configs": {
-     "items": {
-      "$ref": "#/definitions/OpsGenieConfig"
-     },
-     "type": "array"
+    "kind": {
+     "$ref": "#/definitions/TemplateKind"
     },
-    "pagerduty_configs": {
-     "items": {
-      "$ref": "#/definitions/PagerdutyConfig"
-     },
-     "type": "array"
-    },
-    "pushover_configs": {
-     "items": {
-      "$ref": "#/definitions/PushoverConfig"
-     },
-     "type": "array"
-    },
-    "slack_configs": {
-     "items": {
-      "$ref": "#/definitions/SlackConfig"
-     },
-     "type": "array"
-    },
-    "sns_configs": {
-     "items": {
-      "$ref": "#/definitions/SNSConfig"
-     },
-     "type": "array"
-    },
-    "telegram_configs": {
-     "items": {
-      "$ref": "#/definitions/TelegramConfig"
-     },
-     "type": "array"
-    },
-    "victorops_configs": {
-     "items": {
-      "$ref": "#/definitions/VictorOpsConfig"
-     },
-     "type": "array"
-    },
-    "webex_configs": {
-     "items": {
-      "$ref": "#/definitions/WebexConfig"
-     },
-     "type": "array"
-    },
-    "webhook_configs": {
-     "items": {
-      "$ref": "#/definitions/WebhookConfig"
-     },
-     "type": "array"
-    },
-    "wechat_configs": {
-     "items": {
-      "$ref": "#/definitions/WechatConfig"
-     },
-     "type": "array"
+    "name": {
+     "type": "string"
     }
    },
    "type": "object"
@@ -3107,6 +3091,9 @@
     },
     "uid": {
      "type": "string"
+    },
+    "version": {
+     "type": "string"
     }
    },
    "type": "object"
@@ -3185,6 +3172,10 @@
       "external"
      ],
      "type": "string"
+    },
+    "external_alertmanager_uid": {
+     "description": "ExternalAlertmanagerUID is the UID of the Mimir/Cortex Alertmanager datasource to sync\nconfiguration from. Empty string disables sync for this org.",
+     "type": "string"
     }
    },
    "type": "object"
@@ -3247,6 +3238,18 @@
       "$ref": "#/definitions/ExtraConfiguration"
      },
      "type": "array"
+    },
+    "managed_inhibition_rules": {
+     "$ref": "#/definitions/ManagedInhibitionRules"
+    },
+    "managed_routes": {
+     "$ref": "#/definitions/ManagedRoutes"
+    },
+    "managed_templates": {
+     "additionalProperties": {
+      "$ref": "#/definitions/PostableApiTemplate"
+     },
+     "type": "object"
     },
     "template_files": {
      "additionalProperties": {
@@ -3912,7 +3915,6 @@
    "type": "object"
   },
   "Route": {
-   "description": "A Route is a node that contains definitions of how to handle alerts. This is modified\nfrom the upstream alertmanager in that it adds the ObjectMatchers property.",
    "properties": {
     "active_time_intervals": {
      "items": {
@@ -3954,12 +3956,6 @@
      },
      "type": "array"
     },
-    "object_matchers": {
-     "$ref": "#/definitions/ObjectMatchers"
-    },
-    "provenance": {
-     "$ref": "#/definitions/Provenance"
-    },
     "receiver": {
      "type": "string"
     },
@@ -3973,6 +3969,7 @@
      "type": "array"
     }
    },
+   "title": "A Route is a node that contains definitions of how to handle alerts.",
    "type": "object"
   },
   "RouteExport": {
@@ -4606,6 +4603,9 @@
    "title": "TelegramConfig configures notifications via Telegram.",
    "type": "object"
   },
+  "TemplateKind": {
+   "type": "string"
+  },
   "TestRulePayload": {
    "properties": {
     "expr": {
@@ -4637,6 +4637,9 @@
       "$ref": "#/definitions/postableAlert"
      },
      "type": "array"
+    },
+    "kind": {
+     "$ref": "#/definitions/TemplateKind"
     },
     "name": {
      "description": "Name of the template file.",
@@ -4825,6 +4828,7 @@
   "URL": {
    "properties": {
     "ForceQuery": {
+     "description": "ForceQuery indicates whether the original URL contained a query ('?') character.\nWhen set, the String method will include a trailing '?', even when RawQuery is empty.",
      "type": "boolean"
     },
     "Fragment": {
@@ -4834,6 +4838,7 @@
      "type": "string"
     },
     "OmitHost": {
+     "description": "OmitHost indicates the URL has an empty host (authority).\nWhen set, the String method will not include the host when it is empty.",
      "type": "boolean"
     },
     "Opaque": {
@@ -4843,12 +4848,15 @@
      "type": "string"
     },
     "RawFragment": {
+     "description": "RawFragment is an optional field containing an encoded fragment hint.\nSee the EscapedFragment method for more details.\n\nIn general, code should call EscapedFragment instead of reading RawFragment.",
      "type": "string"
     },
     "RawPath": {
+     "description": "RawPath is an optional field containing an encoded path hint.\nSee the EscapedPath method for more details.\n\nIn general, code should call EscapedPath instead of reading RawPath.",
      "type": "string"
     },
     "RawQuery": {
+     "description": "RawQuery contains the encoded query values, without the initial '?'.\nUse URL.Query to decode the query.",
      "type": "string"
     },
     "Scheme": {
@@ -5082,7 +5090,6 @@
    "properties": {
     "generatorURL": {
      "description": "generator URL\nFormat: uri",
-     "format": "uri",
      "type": "string"
     },
     "labels": {
@@ -5182,7 +5189,6 @@
     },
     "uptime": {
      "description": "uptime",
-     "format": "date-time",
      "type": "string"
     },
     "versionInfo": {
@@ -5232,7 +5238,6 @@
     },
     "endsAt": {
      "description": "ends at",
-     "format": "date-time",
      "type": "string"
     },
     "fingerprint": {
@@ -5241,7 +5246,6 @@
     },
     "generatorURL": {
      "description": "generator URL\nFormat: uri",
-     "format": "uri",
      "type": "string"
     },
     "labels": {
@@ -5256,7 +5260,6 @@
     },
     "startsAt": {
      "description": "starts at",
-     "format": "date-time",
      "type": "string"
     },
     "status": {
@@ -5264,7 +5267,6 @@
     },
     "updatedAt": {
      "description": "updated at",
-     "format": "date-time",
      "type": "string"
     }
    },
@@ -5311,7 +5313,6 @@
     },
     "endsAt": {
      "description": "ends at",
-     "format": "date-time",
      "type": "string"
     },
     "id": {
@@ -5326,7 +5327,6 @@
     },
     "startsAt": {
      "description": "starts at",
-     "format": "date-time",
      "type": "string"
     },
     "status": {
@@ -5334,7 +5334,6 @@
     },
     "updatedAt": {
      "description": "updated at",
-     "format": "date-time",
      "type": "string"
     }
    },
@@ -5369,7 +5368,6 @@
     },
     "endsAt": {
      "description": "ends at",
-     "format": "date-time",
      "type": "string"
     },
     "id": {
@@ -5381,7 +5379,6 @@
     },
     "startsAt": {
      "description": "starts at",
-     "format": "date-time",
      "type": "string"
     },
     "status": {
@@ -5389,7 +5386,6 @@
     },
     "updatedAt": {
      "description": "updated at",
-     "format": "date-time",
      "type": "string"
     }
    },
@@ -5489,12 +5485,10 @@
     },
     "endsAt": {
      "description": "ends at\nFormat: date-time",
-     "format": "date-time",
      "type": "string"
     },
     "generatorURL": {
      "description": "generator URL\nFormat: uri",
-     "format": "uri",
      "type": "string"
     },
     "labels": {
@@ -5502,7 +5496,6 @@
     },
     "startsAt": {
      "description": "starts at\nFormat: date-time",
-     "format": "date-time",
      "type": "string"
     }
    },
@@ -5531,7 +5524,6 @@
     },
     "endsAt": {
      "description": "ends at",
-     "format": "date-time",
      "type": "string"
     },
     "id": {
@@ -5543,7 +5535,6 @@
     },
     "startsAt": {
      "description": "starts at",
-     "format": "date-time",
      "type": "string"
     }
    },
@@ -5582,7 +5573,6 @@
     },
     "endsAt": {
      "description": "ends at",
-     "format": "date-time",
      "type": "string"
     },
     "matchers": {
@@ -5590,7 +5580,6 @@
     },
     "startsAt": {
      "description": "starts at",
-     "format": "date-time",
      "type": "string"
     }
    },
@@ -6246,8 +6235,8 @@
   },
   "/v1/provisioning/alert-rules": {
    "get": {
-    "operationId": "RouteGetAlertRules",
     "deprecated": true,
+    "operationId": "RouteGetAlertRules",
     "responses": {
      "200": {
       "description": "ProvisionedAlertRules",
@@ -6271,8 +6260,8 @@
     "consumes": [
      "application/json"
     ],
-    "operationId": "RoutePostAlertRule",
     "deprecated": true,
+    "operationId": "RoutePostAlertRule",
     "parameters": [
      {
       "in": "body",
@@ -6390,8 +6379,8 @@
   },
   "/v1/provisioning/alert-rules/{UID}": {
    "delete": {
-    "operationId": "RouteDeleteAlertRule",
     "deprecated": true,
+    "operationId": "RouteDeleteAlertRule",
     "parameters": [
      {
       "description": "Alert rule UID",
@@ -6423,8 +6412,8 @@
     ]
    },
    "get": {
-    "operationId": "RouteGetAlertRule",
     "deprecated": true,
+    "operationId": "RouteGetAlertRule",
     "parameters": [
      {
       "description": "Alert rule UID",
@@ -6460,8 +6449,8 @@
     "consumes": [
      "application/json"
     ],
-    "operationId": "RoutePutAlertRule",
     "deprecated": true,
+    "operationId": "RoutePutAlertRule",
     "parameters": [
      {
       "description": "Alert rule UID",
@@ -6572,6 +6561,7 @@
   },
   "/v1/provisioning/contact-points": {
    "get": {
+    "deprecated": true,
     "operationId": "RouteGetContactpoints",
     "parameters": [
      {
@@ -6598,13 +6588,13 @@
     "summary": "Get all the contact points.",
     "tags": [
      "provisioning"
-    ],
-    "deprecated": true
+    ]
    },
    "post": {
     "consumes": [
      "application/json"
     ],
+    "deprecated": true,
     "operationId": "RoutePostContactpoints",
     "parameters": [
      {
@@ -6643,8 +6633,7 @@
     "summary": "Create a contact point.",
     "tags": [
      "provisioning"
-    ],
-    "deprecated": true
+    ]
    }
   },
   "/v1/provisioning/contact-points/export": {
@@ -6716,6 +6705,7 @@
     "consumes": [
      "application/json"
     ],
+    "deprecated": true,
     "operationId": "RouteDeleteContactpoints",
     "parameters": [
      {
@@ -6740,13 +6730,13 @@
     "summary": "Delete a contact point.",
     "tags": [
      "provisioning"
-    ],
-    "deprecated": true
+    ]
    },
    "put": {
     "consumes": [
      "application/json"
     ],
+    "deprecated": true,
     "operationId": "RoutePutContactpoint",
     "parameters": [
      {
@@ -6792,15 +6782,14 @@
     "summary": "Update an existing contact point.",
     "tags": [
      "provisioning"
-    ],
-    "deprecated": true
+    ]
    }
   },
   "/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}": {
    "delete": {
+    "deprecated": true,
     "description": "Delete rule group",
     "operationId": "RouteDeleteAlertRuleGroup",
-    "deprecated": true,
     "parameters": [
      {
       "in": "path",
@@ -6837,8 +6826,8 @@
     ]
    },
    "get": {
-    "operationId": "RouteGetAlertRuleGroup",
     "deprecated": true,
+    "operationId": "RouteGetAlertRuleGroup",
     "parameters": [
      {
       "in": "path",
@@ -6879,8 +6868,8 @@
     "consumes": [
      "application/json"
     ],
-    "operationId": "RoutePutAlertRuleGroup",
     "deprecated": true,
+    "operationId": "RoutePutAlertRuleGroup",
     "parameters": [
      {
       "in": "header",
@@ -7001,6 +6990,7 @@
   },
   "/v1/provisioning/mute-timings": {
    "get": {
+    "deprecated": true,
     "operationId": "RouteGetMuteTimings",
     "responses": {
      "200": {
@@ -7019,13 +7009,13 @@
     "summary": "Get all the mute timings.",
     "tags": [
      "provisioning"
-    ],
-    "deprecated": true
+    ]
    },
    "post": {
     "consumes": [
      "application/json"
     ],
+    "deprecated": true,
     "operationId": "RoutePostMuteTiming",
     "parameters": [
      {
@@ -7064,8 +7054,7 @@
     "summary": "Create a new mute timing.",
     "tags": [
      "provisioning"
-    ],
-    "deprecated": true
+    ]
    }
   },
   "/v1/provisioning/mute-timings/export": {
@@ -7121,6 +7110,7 @@
   },
   "/v1/provisioning/mute-timings/{name}": {
    "delete": {
+    "deprecated": true,
     "operationId": "RouteDeleteMuteTiming",
     "parameters": [
      {
@@ -7162,10 +7152,10 @@
     "summary": "Delete a mute timing.",
     "tags": [
      "provisioning"
-    ],
-    "deprecated": true
+    ]
    },
    "get": {
+    "deprecated": true,
     "operationId": "RouteGetMuteTiming",
     "parameters": [
      {
@@ -7196,13 +7186,13 @@
     "summary": "Get a mute timing.",
     "tags": [
      "provisioning"
-    ],
-    "deprecated": true
+    ]
    },
    "put": {
     "consumes": [
      "application/json"
     ],
+    "deprecated": true,
     "operationId": "RoutePutMuteTiming",
     "parameters": [
      {
@@ -7254,8 +7244,7 @@
     "summary": "Replace an existing mute timing.",
     "tags": [
      "provisioning"
-    ],
-    "deprecated": true
+    ]
    }
   },
   "/v1/provisioning/mute-timings/{name}/export": {
@@ -7321,6 +7310,7 @@
     "consumes": [
      "application/json"
     ],
+    "deprecated": true,
     "operationId": "RouteResetPolicyTree",
     "responses": {
      "202": {
@@ -7339,10 +7329,10 @@
     "summary": "Clears the notification policy tree.",
     "tags": [
      "provisioning"
-    ],
-    "deprecated": true
+    ]
    },
    "get": {
+    "deprecated": true,
     "operationId": "RouteGetPolicyTree",
     "responses": {
      "200": {
@@ -7361,13 +7351,13 @@
     "summary": "Get the notification policy tree.",
     "tags": [
      "provisioning"
-    ],
-    "deprecated": true
+    ]
    },
    "put": {
     "consumes": [
      "application/json"
     ],
+    "deprecated": true,
     "operationId": "RoutePutPolicyTree",
     "parameters": [
      {
@@ -7407,8 +7397,7 @@
     "summary": "Sets the notification policy tree.",
     "tags": [
      "provisioning"
-    ],
-    "deprecated": true
+    ]
    }
   },
   "/v1/provisioning/policies/export": {
@@ -7449,6 +7438,7 @@
   },
   "/v1/provisioning/templates": {
    "get": {
+    "deprecated": true,
     "operationId": "RouteGetTemplates",
     "responses": {
      "200": {
@@ -7467,12 +7457,12 @@
     "summary": "Get all notification template groups.",
     "tags": [
      "provisioning"
-    ],
-    "deprecated": true
+    ]
    }
   },
   "/v1/provisioning/templates/{name}": {
    "delete": {
+    "deprecated": true,
     "operationId": "RouteDeleteTemplate",
     "parameters": [
      {
@@ -7509,10 +7499,10 @@
     "summary": "Delete a notification template group.",
     "tags": [
      "provisioning"
-    ],
-    "deprecated": true
+    ]
    },
    "get": {
+    "deprecated": true,
     "operationId": "RouteGetTemplate",
     "parameters": [
      {
@@ -7546,13 +7536,13 @@
     "summary": "Get a notification template group.",
     "tags": [
      "provisioning"
-    ],
-    "deprecated": true
+    ]
    },
    "put": {
     "consumes": [
      "application/json"
     ],
+    "deprecated": true,
     "operationId": "RoutePutTemplate",
     "parameters": [
      {
@@ -7604,8 +7594,7 @@
     "summary": "Updates an existing notification template group.",
     "tags": [
      "provisioning"
-    ],
-    "deprecated": true
+    ]
    }
   }
  },

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -6712,6 +6712,12 @@
       "schema": {
        "$ref": "#/definitions/ForbiddenError"
       }
+     },
+     "409": {
+      "description": "PublicError",
+      "schema": {
+       "$ref": "#/definitions/PublicError"
+      }
      }
     },
     "summary": "Create a contact point.",
@@ -6809,6 +6815,12 @@
       "schema": {
        "$ref": "#/definitions/ForbiddenError"
       }
+     },
+     "409": {
+      "description": "PublicError",
+      "schema": {
+       "$ref": "#/definitions/PublicError"
+      }
      }
     },
     "summary": "Delete a contact point.",
@@ -6860,6 +6872,12 @@
       "description": "ForbiddenError",
       "schema": {
        "$ref": "#/definitions/ForbiddenError"
+      }
+     },
+     "409": {
+      "description": "PublicError",
+      "schema": {
+       "$ref": "#/definitions/PublicError"
       }
      }
     },
@@ -7132,6 +7150,12 @@
       "description": "ForbiddenError",
       "schema": {
        "$ref": "#/definitions/ForbiddenError"
+      }
+     },
+     "409": {
+      "description": "PublicError",
+      "schema": {
+       "$ref": "#/definitions/PublicError"
       }
      }
     },
@@ -7408,6 +7432,12 @@
       "schema": {
        "$ref": "#/definitions/ForbiddenError"
       }
+     },
+     "409": {
+      "description": "PublicError",
+      "schema": {
+       "$ref": "#/definitions/PublicError"
+      }
      }
     },
     "summary": "Clears the notification policy tree.",
@@ -7475,6 +7505,12 @@
       "description": "ForbiddenError",
       "schema": {
        "$ref": "#/definitions/ForbiddenError"
+      }
+     },
+     "409": {
+      "description": "PublicError",
+      "schema": {
+       "$ref": "#/definitions/PublicError"
       }
      }
     },

--- a/pkg/services/ngalert/api/tooling/cmd/clean-swagger/main.go
+++ b/pkg/services/ngalert/api/tooling/cmd/clean-swagger/main.go
@@ -21,7 +21,7 @@ func main() {
 		log.Fatal("no file specified, input", input, ", output", output)
 	}
 
-	//nolint
+	// nolint
 	b, err := os.ReadFile(input)
 	if err != nil {
 		log.Fatal(err)
@@ -41,18 +41,8 @@ func main() {
 	}
 
 	if info["title"] == nil {
-		info["title"] = "Unified Alerting API"
+		info["title"] = "Grafana Alerting API."
 	}
-
-	// The alertmanager dependency (api/v2/restapi/doc.go) contains its own
-	// swagger:meta block that go-swagger picks up during spec generation.
-	// This injects the alertmanager's host, basePath, and license into the
-	// ngalert spec, overriding the values from our own swagger:meta in
-	// definitions/api.go. Strip these so the ngalert sub-spec doesn't
-	// pollute the merged Grafana API spec with incorrect values.
-	delete(info, "license")
-	delete(data, "host")
-	data["basePath"] = "/api"
 
 	definitions, ok := data["definitions"]
 	if !ok {

--- a/pkg/services/ngalert/api/tooling/definitions/convert_prometheus_api.go
+++ b/pkg/services/ngalert/api/tooling/definitions/convert_prometheus_api.go
@@ -327,6 +327,7 @@ type ConvertPrometheusResponse struct {
 	Error     string `json:"error"`
 }
 
+// swagger:model
 type ConvertAlertmanagerResponse struct {
 	Status    string `json:"status"`
 	ErrorType string `json:"errorType"`

--- a/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
+++ b/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
@@ -107,7 +107,7 @@ import (
 //     Responses:
 //       202: UpdateNamespaceRulesResponse
 //       403: ForbiddenError
-//       404: NotFound.
+//       404: NotFound
 //
 
 // swagger:route POST /ruler/grafana/api/v1/rules/{Namespace}/export ruler RoutePostRulesGroupForExport

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_contactpoints.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_contactpoints.go
@@ -42,6 +42,7 @@ import (
 //       202: EmbeddedContactPoint
 //       400: ValidationError
 //       403: ForbiddenError
+//       409: PublicError
 
 // swagger:route PUT /v1/provisioning/contact-points/{UID} provisioning stable RoutePutContactpoint
 //
@@ -56,6 +57,7 @@ import (
 //       202: Ack
 //       400: ValidationError
 //       403: ForbiddenError
+//       409: PublicError
 
 // swagger:route DELETE /v1/provisioning/contact-points/{UID} provisioning stable RouteDeleteContactpoints
 //
@@ -69,6 +71,7 @@ import (
 //     Responses:
 //       202: description: The contact point was deleted successfully.
 //       403: ForbiddenError
+//       409: PublicError
 
 // swagger:parameters RoutePutContactpoint RouteDeleteContactpoints
 type ContactPointUIDReference struct {

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_mute_timings.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_mute_timings.go
@@ -68,6 +68,7 @@ import (
 //       201: MuteTimeInterval
 //       400: ValidationError
 //       403: ForbiddenError
+//       409: PublicError
 
 // swagger:route PUT /v1/provisioning/mute-timings/{name} provisioning stable RoutePutMuteTiming
 //

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_policies.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_policies.go
@@ -28,6 +28,7 @@ import (
 //       202: Ack
 //       400: ValidationError
 //       403: ForbiddenError
+//       409: PublicError
 
 // swagger:route DELETE /v1/provisioning/policies provisioning stable RouteResetPolicyTree
 //
@@ -41,6 +42,7 @@ import (
 //     Responses:
 //       202: Ack
 //       403: ForbiddenError
+//       409: PublicError
 
 // swagger:route GET /v1/provisioning/policies/export provisioning stable RouteGetPolicyTreeExport
 //

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -815,6 +815,26 @@
    },
    "type": "array"
   },
+  "ConvertAlertmanagerResponse": {
+   "properties": {
+    "error": {
+     "type": "string"
+    },
+    "errorType": {
+     "type": "string"
+    },
+    "rename_resources": {
+     "$ref": "#/definitions/RenameResources"
+    },
+    "stats": {
+     "$ref": "#/definitions/MergeStats"
+    },
+    "status": {
+     "type": "string"
+    }
+   },
+   "type": "object"
+  },
   "ConvertPrometheusResponse": {
    "properties": {
     "error": {
@@ -2474,6 +2494,44 @@
    },
    "type": "array"
   },
+  "MergeStats": {
+   "properties": {
+    "added_inhibition_rules": {
+     "description": "AddedInhibitionRules contains the names of inhibition rules added",
+     "items": {
+      "type": "string"
+     },
+     "type": "array"
+    },
+    "added_receivers": {
+     "description": "AddedReceivers contains the names of receivers added (post-rename if renamed)",
+     "items": {
+      "type": "string"
+     },
+     "type": "array"
+    },
+    "added_route": {
+     "description": "AddedRoute is the identifier of the routing sub-tree added to the configuration",
+     "type": "string"
+    },
+    "added_templates": {
+     "description": "AddedTemplates contains the names of templates added",
+     "items": {
+      "type": "string"
+     },
+     "type": "array"
+    },
+    "added_time_intervals": {
+     "description": "AddedTimeIntervals contains the names of time intervals added (post-rename if renamed)",
+     "items": {
+      "type": "string"
+     },
+     "type": "array"
+    }
+   },
+   "title": "MergeStats describes which resources were added during configuration merge.",
+   "type": "object"
+  },
   "MultiStatus": {
    "type": "object"
   },
@@ -3898,6 +3956,26 @@
    },
    "type": "object"
   },
+  "RenameResources": {
+   "description": "RenameResources describes which resources were renamed to avoid conflicts",
+   "properties": {
+    "receivers": {
+     "additionalProperties": {
+      "type": "string"
+     },
+     "description": "Receivers maps old receiver names to new receiver names",
+     "type": "object"
+    },
+    "time_intervals": {
+     "additionalProperties": {
+      "type": "string"
+     },
+     "description": "TimeIntervals maps old time interval names to new time interval names",
+     "type": "object"
+    }
+   },
+   "type": "object"
+  },
   "ResponseDetails": {
    "properties": {
     "msg": {
@@ -3915,7 +3993,6 @@
    "type": "object"
   },
   "Route": {
-   "description": "A Route is a node that contains definitions of how to handle alerts. This is modified\nfrom the upstream alertmanager in that it adds the ObjectMatchers property.",
    "properties": {
     "active_time_intervals": {
      "items": {
@@ -3957,12 +4034,6 @@
      },
      "type": "array"
     },
-    "object_matchers": {
-     "$ref": "#/definitions/ObjectMatchers"
-    },
-    "provenance": {
-     "$ref": "#/definitions/Provenance"
-    },
     "receiver": {
      "type": "string"
     },
@@ -3976,6 +4047,7 @@
      "type": "array"
     }
    },
+   "title": "A Route is a node that contains definitions of how to handle alerts.",
    "type": "object"
   },
   "RouteExport": {
@@ -7082,7 +7154,10 @@
     ],
     "responses": {
      "202": {
-      "$ref": "#/responses/ConvertAlertmanagerResponse"
+      "description": "ConvertAlertmanagerResponse",
+      "schema": {
+       "$ref": "#/definitions/ConvertAlertmanagerResponse"
+      }
      },
      "403": {
       "description": "ForbiddenError",
@@ -7932,7 +8007,10 @@
       }
      },
      "404": {
-      "$ref": "#/responses/NotFound."
+      "description": "NotFound",
+      "schema": {
+       "$ref": "#/definitions/NotFound"
+      }
      }
     },
     "tags": [

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -3993,6 +3993,7 @@
    "type": "object"
   },
   "Route": {
+   "description": "A Route is a node that contains definitions of how to handle alerts. This is modified\nfrom the upstream alertmanager in that it adds the ObjectMatchers property.",
    "properties": {
     "active_time_intervals": {
      "items": {
@@ -4034,6 +4035,12 @@
      },
      "type": "array"
     },
+    "object_matchers": {
+     "$ref": "#/definitions/ObjectMatchers"
+    },
+    "provenance": {
+     "$ref": "#/definitions/Provenance"
+    },
     "receiver": {
      "type": "string"
     },
@@ -4047,7 +4054,6 @@
      "type": "array"
     }
    },
-   "title": "A Route is a node that contains definitions of how to handle alerts.",
    "type": "object"
   },
   "RouteExport": {
@@ -9106,6 +9112,12 @@
       "schema": {
        "$ref": "#/definitions/ForbiddenError"
       }
+     },
+     "409": {
+      "description": "PublicError",
+      "schema": {
+       "$ref": "#/definitions/PublicError"
+      }
      }
     },
     "summary": "Create a contact point.",
@@ -9203,6 +9215,12 @@
       "schema": {
        "$ref": "#/definitions/ForbiddenError"
       }
+     },
+     "409": {
+      "description": "PublicError",
+      "schema": {
+       "$ref": "#/definitions/PublicError"
+      }
      }
     },
     "summary": "Delete a contact point.",
@@ -9254,6 +9272,12 @@
       "description": "ForbiddenError",
       "schema": {
        "$ref": "#/definitions/ForbiddenError"
+      }
+     },
+     "409": {
+      "description": "PublicError",
+      "schema": {
+       "$ref": "#/definitions/PublicError"
       }
      }
     },
@@ -9526,6 +9550,12 @@
       "description": "ForbiddenError",
       "schema": {
        "$ref": "#/definitions/ForbiddenError"
+      }
+     },
+     "409": {
+      "description": "PublicError",
+      "schema": {
+       "$ref": "#/definitions/PublicError"
       }
      }
     },
@@ -9802,6 +9832,12 @@
       "schema": {
        "$ref": "#/definitions/ForbiddenError"
       }
+     },
+     "409": {
+      "description": "PublicError",
+      "schema": {
+       "$ref": "#/definitions/PublicError"
+      }
      }
     },
     "summary": "Clears the notification policy tree.",
@@ -9869,6 +9905,12 @@
       "description": "ForbiddenError",
       "schema": {
        "$ref": "#/definitions/ForbiddenError"
+      }
+     },
+     "409": {
+      "description": "PublicError",
+      "schema": {
+       "$ref": "#/definitions/PublicError"
       }
      }
     },

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -360,6 +360,11 @@
      },
      "type": "array"
     },
+    "policy": {
+     "description": "Name of the notification policy to route alerts through.\nMutually exclusive with all other fields, cannot be used with contact point routing via the \"receiver\" field.",
+     "example": "\"Alerting Team\"",
+     "type": "string"
+    },
     "receiver": {
      "description": "Name of the receiver to send notifications to.",
      "example": "grafana-default-email",
@@ -1169,7 +1174,6 @@
     },
     "uptime": {
      "description": "uptime",
-     "format": "date-time",
      "type": "string"
     },
     "versionInfo": {
@@ -1192,8 +1196,9 @@
     "identifier": {
      "type": "string"
     },
-    "merge_matchers": {
-     "$ref": "#/definitions/Matchers"
+    "managed_by": {
+     "description": "ManagedBy is \"manual\" or \"auto-sync\", computed server-side so callers don't need configs:get\nto tell the two apart.",
+     "type": "string"
     },
     "template_files": {
      "additionalProperties": {
@@ -1720,6 +1725,9 @@
     },
     "uid": {
      "type": "string"
+    },
+    "version": {
+     "type": "string"
     }
    },
    "type": "object"
@@ -1828,7 +1836,6 @@
      "type": "integer"
     },
     "last_applied": {
-     "format": "date-time",
      "type": "string"
     },
     "template_file_provenances": {
@@ -1854,6 +1861,10 @@
       "internal",
       "external"
      ],
+     "type": "string"
+    },
+    "external_alertmanager_uid": {
+     "description": "ExternalAlertmanagerUID is the UID of the Mimir/Cortex Alertmanager datasource being\nsynced, or empty if sync is not configured for this org.",
      "type": "string"
     }
    },
@@ -1923,7 +1934,6 @@
     },
     "uptime": {
      "description": "uptime",
-     "format": "date-time",
      "type": "string"
     },
     "versionInfo": {
@@ -2052,7 +2062,7 @@
    "type": "object"
   },
   "Gone": {
-    "type": "object"
+   "type": "object"
   },
   "HTTPClientConfig": {
    "properties": {
@@ -2191,6 +2201,52 @@
    },
    "type": "object"
   },
+  "InhibitionRule": {
+   "description": "It embeds the upstream Alertmanager InhibitRule and adds Grafana-specific fields.",
+   "properties": {
+    "equal": {
+     "description": "A set of labels that must be equal between the source and target alert\nfor them to be a match.",
+     "items": {
+      "type": "string"
+     },
+     "type": "array"
+    },
+    "name": {
+     "type": "string"
+    },
+    "provenance": {
+     "$ref": "#/definitions/Provenance"
+    },
+    "source_match": {
+     "additionalProperties": {
+      "type": "string"
+     },
+     "description": "SourceMatch defines a set of labels that have to equal the given\nvalue for source alerts. Deprecated. Remove before v1.0 release.",
+     "type": "object"
+    },
+    "source_match_re": {
+     "$ref": "#/definitions/MatchRegexps"
+    },
+    "source_matchers": {
+     "$ref": "#/definitions/Matchers"
+    },
+    "target_match": {
+     "additionalProperties": {
+      "type": "string"
+     },
+     "description": "TargetMatch defines a set of labels that have to equal the given\nvalue for target alerts. Deprecated. Remove before v1.0 release.",
+     "type": "object"
+    },
+    "target_match_re": {
+     "$ref": "#/definitions/MatchRegexps"
+    },
+    "target_matchers": {
+     "$ref": "#/definitions/Matchers"
+    }
+   },
+   "title": "InhibitionRule is the domain model for inhibition rules with metadata.",
+   "type": "object"
+  },
   "InspectType": {
    "format": "int64",
    "title": "InspectType is a type for the Inspect property of a Notice.",
@@ -2200,7 +2256,6 @@
    "properties": {
     "lastNotifyAttempt": {
      "description": "A timestamp indicating the last attempt to deliver a notification regardless of the outcome.\nFormat: date-time",
-     "format": "date-time",
      "type": "string"
     },
     "lastNotifyAttemptDuration": {
@@ -2301,21 +2356,10 @@
   "Json": {
    "type": "object"
   },
-  "Label": {
-   "properties": {
-    "Name": {
-     "type": "string"
-    }
-   },
-   "title": "Label is a key/value pair of strings.",
-   "type": "object"
-  },
   "Labels": {
-   "description": "Labels is a sorted set of labels. Order has to be guaranteed upon\ninstantiation.",
-   "items": {
-    "$ref": "#/definitions/Label"
-   },
-   "type": "array"
+   "description": "Each name and value is preceded by its length, encoded as a single byte\nfor size 0-254, or the following 3 bytes little-endian, if the first byte is 255.\nMaximum length allowed is 2^24 or 16MB.\nNames are in order.",
+   "title": "Labels is implemented by a single flat string holding name/value pairs.",
+   "type": "object"
   },
   "LinkTransformationConfig": {
    "properties": {
@@ -2381,6 +2425,19 @@
      "type": "string"
     }
    },
+   "type": "object"
+  },
+  "ManagedInhibitionRules": {
+   "additionalProperties": {
+    "$ref": "#/definitions/InhibitionRule"
+   },
+   "type": "object"
+  },
+  "ManagedRoutes": {
+   "additionalProperties": {
+    "$ref": "#/definitions/Route"
+   },
+   "description": "ManagedRoutes this type exists purely to ensure unmarshalling upstream Routes will call Validate and populate\nGroupBy and GroupByAll. Eventually, we will want this to be a separate type and make the conversion to\ndefinitions.Route explicit.",
    "type": "object"
   },
   "MatchRegexps": {
@@ -2927,105 +2984,29 @@
   "PostableApiReceiver": {
    "description": "nolint:revive",
    "properties": {
-    "discord_configs": {
-     "items": {
-      "$ref": "#/definitions/DiscordConfig"
-     },
-     "type": "array"
-    },
-    "email_configs": {
-     "items": {
-      "$ref": "#/definitions/EmailConfig"
-     },
-     "type": "array"
-    },
     "grafana_managed_receiver_configs": {
      "items": {
       "$ref": "#/definitions/PostableGrafanaReceiver"
      },
      "type": "array"
     },
-    "jira_configs": {
-     "items": {
-      "$ref": "#/definitions/JiraConfig"
-     },
-     "type": "array"
-    },
-    "msteams_configs": {
-     "items": {
-      "$ref": "#/definitions/MSTeamsConfig"
-     },
-     "type": "array"
-    },
-    "msteamsv2_configs": {
-     "items": {
-      "$ref": "#/definitions/MSTeamsV2Config"
-     },
-     "type": "array"
-    },
     "name": {
-     "description": "A unique identifier for this receiver.",
+     "type": "string"
+    }
+   },
+   "type": "object"
+  },
+  "PostableApiTemplate": {
+   "description": "nolint:revive",
+   "properties": {
+    "content": {
      "type": "string"
     },
-    "opsgenie_configs": {
-     "items": {
-      "$ref": "#/definitions/OpsGenieConfig"
-     },
-     "type": "array"
+    "kind": {
+     "$ref": "#/definitions/TemplateKind"
     },
-    "pagerduty_configs": {
-     "items": {
-      "$ref": "#/definitions/PagerdutyConfig"
-     },
-     "type": "array"
-    },
-    "pushover_configs": {
-     "items": {
-      "$ref": "#/definitions/PushoverConfig"
-     },
-     "type": "array"
-    },
-    "slack_configs": {
-     "items": {
-      "$ref": "#/definitions/SlackConfig"
-     },
-     "type": "array"
-    },
-    "sns_configs": {
-     "items": {
-      "$ref": "#/definitions/SNSConfig"
-     },
-     "type": "array"
-    },
-    "telegram_configs": {
-     "items": {
-      "$ref": "#/definitions/TelegramConfig"
-     },
-     "type": "array"
-    },
-    "victorops_configs": {
-     "items": {
-      "$ref": "#/definitions/VictorOpsConfig"
-     },
-     "type": "array"
-    },
-    "webex_configs": {
-     "items": {
-      "$ref": "#/definitions/WebexConfig"
-     },
-     "type": "array"
-    },
-    "webhook_configs": {
-     "items": {
-      "$ref": "#/definitions/WebhookConfig"
-     },
-     "type": "array"
-    },
-    "wechat_configs": {
-     "items": {
-      "$ref": "#/definitions/WechatConfig"
-     },
-     "type": "array"
+    "name": {
+     "type": "string"
     }
    },
    "type": "object"
@@ -3110,6 +3091,9 @@
     },
     "uid": {
      "type": "string"
+    },
+    "version": {
+     "type": "string"
     }
    },
    "type": "object"
@@ -3188,6 +3172,10 @@
       "external"
      ],
      "type": "string"
+    },
+    "external_alertmanager_uid": {
+     "description": "ExternalAlertmanagerUID is the UID of the Mimir/Cortex Alertmanager datasource to sync\nconfiguration from. Empty string disables sync for this org.",
+     "type": "string"
     }
    },
    "type": "object"
@@ -3250,6 +3238,18 @@
       "$ref": "#/definitions/ExtraConfiguration"
      },
      "type": "array"
+    },
+    "managed_inhibition_rules": {
+     "$ref": "#/definitions/ManagedInhibitionRules"
+    },
+    "managed_routes": {
+     "$ref": "#/definitions/ManagedRoutes"
+    },
+    "managed_templates": {
+     "additionalProperties": {
+      "$ref": "#/definitions/PostableApiTemplate"
+     },
+     "type": "object"
     },
     "template_files": {
      "additionalProperties": {
@@ -4609,6 +4609,9 @@
    "title": "TelegramConfig configures notifications via Telegram.",
    "type": "object"
   },
+  "TemplateKind": {
+   "type": "string"
+  },
   "TestRulePayload": {
    "properties": {
     "expr": {
@@ -4640,6 +4643,9 @@
       "$ref": "#/definitions/postableAlert"
      },
      "type": "array"
+    },
+    "kind": {
+     "$ref": "#/definitions/TemplateKind"
     },
     "name": {
      "description": "Name of the template file.",
@@ -4828,6 +4834,7 @@
   "URL": {
    "properties": {
     "ForceQuery": {
+     "description": "ForceQuery indicates whether the original URL contained a query ('?') character.\nWhen set, the String method will include a trailing '?', even when RawQuery is empty.",
      "type": "boolean"
     },
     "Fragment": {
@@ -4837,6 +4844,7 @@
      "type": "string"
     },
     "OmitHost": {
+     "description": "OmitHost indicates the URL has an empty host (authority).\nWhen set, the String method will not include the host when it is empty.",
      "type": "boolean"
     },
     "Opaque": {
@@ -4846,12 +4854,15 @@
      "type": "string"
     },
     "RawFragment": {
+     "description": "RawFragment is an optional field containing an encoded fragment hint.\nSee the EscapedFragment method for more details.\n\nIn general, code should call EscapedFragment instead of reading RawFragment.",
      "type": "string"
     },
     "RawPath": {
+     "description": "RawPath is an optional field containing an encoded path hint.\nSee the EscapedPath method for more details.\n\nIn general, code should call EscapedPath instead of reading RawPath.",
      "type": "string"
     },
     "RawQuery": {
+     "description": "RawQuery contains the encoded query values, without the initial '?'.\nUse URL.Query to decode the query.",
      "type": "string"
     },
     "Scheme": {
@@ -5085,7 +5096,6 @@
    "properties": {
     "generatorURL": {
      "description": "generator URL\nFormat: uri",
-     "format": "uri",
      "type": "string"
     },
     "labels": {
@@ -5185,7 +5195,6 @@
     },
     "uptime": {
      "description": "uptime",
-     "format": "date-time",
      "type": "string"
     },
     "versionInfo": {
@@ -5235,7 +5244,6 @@
     },
     "endsAt": {
      "description": "ends at",
-     "format": "date-time",
      "type": "string"
     },
     "fingerprint": {
@@ -5244,7 +5252,6 @@
     },
     "generatorURL": {
      "description": "generator URL\nFormat: uri",
-     "format": "uri",
      "type": "string"
     },
     "labels": {
@@ -5259,7 +5266,6 @@
     },
     "startsAt": {
      "description": "starts at",
-     "format": "date-time",
      "type": "string"
     },
     "status": {
@@ -5267,7 +5273,6 @@
     },
     "updatedAt": {
      "description": "updated at",
-     "format": "date-time",
      "type": "string"
     }
    },
@@ -5314,7 +5319,6 @@
     },
     "endsAt": {
      "description": "ends at",
-     "format": "date-time",
      "type": "string"
     },
     "id": {
@@ -5329,7 +5333,6 @@
     },
     "startsAt": {
      "description": "starts at",
-     "format": "date-time",
      "type": "string"
     },
     "status": {
@@ -5337,7 +5340,6 @@
     },
     "updatedAt": {
      "description": "updated at",
-     "format": "date-time",
      "type": "string"
     }
    },
@@ -5372,7 +5374,6 @@
     },
     "endsAt": {
      "description": "ends at",
-     "format": "date-time",
      "type": "string"
     },
     "id": {
@@ -5384,7 +5385,6 @@
     },
     "startsAt": {
      "description": "starts at",
-     "format": "date-time",
      "type": "string"
     },
     "status": {
@@ -5392,7 +5392,6 @@
     },
     "updatedAt": {
      "description": "updated at",
-     "format": "date-time",
      "type": "string"
     }
    },
@@ -5492,12 +5491,10 @@
     },
     "endsAt": {
      "description": "ends at\nFormat: date-time",
-     "format": "date-time",
      "type": "string"
     },
     "generatorURL": {
      "description": "generator URL\nFormat: uri",
-     "format": "uri",
      "type": "string"
     },
     "labels": {
@@ -5505,7 +5502,6 @@
     },
     "startsAt": {
      "description": "starts at\nFormat: date-time",
-     "format": "date-time",
      "type": "string"
     }
    },
@@ -5534,7 +5530,6 @@
     },
     "endsAt": {
      "description": "ends at",
-     "format": "date-time",
      "type": "string"
     },
     "id": {
@@ -5546,7 +5541,6 @@
     },
     "startsAt": {
      "description": "starts at",
-     "format": "date-time",
      "type": "string"
     }
    },
@@ -5585,7 +5579,6 @@
     },
     "endsAt": {
      "description": "ends at",
-     "format": "date-time",
      "type": "string"
     },
     "matchers": {
@@ -5593,7 +5586,6 @@
     },
     "startsAt": {
      "description": "starts at",
-     "format": "date-time",
      "type": "string"
     }
    },
@@ -5988,18 +5980,21 @@
   },
   "/alertmanager/grafana/config/api/v1/receivers/test": {
    "post": {
-    "description": "This endpoint has been removed. Please use `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/receivers/{uid}/test` instead.",
-    "tags": [
-     "alertmanager"
-    ],
-    "summary": "Test Grafana managed receivers without saving them.",
-    "operationId": "RoutePostTestGrafanaReceivers",
     "deprecated": true,
+    "description": "This endpoint has been removed. Please use `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/receivers/{uid}/test` instead.",
+    "operationId": "RoutePostTestGrafanaReceivers",
     "responses": {
      "410": {
-      "$ref": "#/definitions/Gone"
+      "description": "Gone",
+      "schema": {
+       "$ref": "#/definitions/Gone"
+      }
      }
-    }
+    },
+    "summary": "Test Grafana managed receivers without saving them.",
+    "tags": [
+     "alertmanager"
+    ]
    }
   },
   "/alertmanager/grafana/config/api/v1/templates/test": {
@@ -6511,9 +6506,9 @@
     ],
     "responses": {
      "200": {
-      "description": "GettableStatus",
+      "description": "ExternalAlertmanagerStatus",
       "schema": {
-       "$ref": "#/definitions/GettableStatus"
+       "$ref": "#/definitions/ExternalAlertmanagerStatus"
       }
      },
      "400": {
@@ -6585,9 +6580,9 @@
     ],
     "responses": {
      "200": {
-      "description": "GettableUserConfig",
+      "description": "ExternalAlertmanagerConfig",
       "schema": {
-       "$ref": "#/definitions/GettableUserConfig"
+       "$ref": "#/definitions/ExternalAlertmanagerConfig"
       }
      },
      "400": {
@@ -6615,7 +6610,7 @@
       "in": "body",
       "name": "Body",
       "schema": {
-       "$ref": "#/definitions/PostableUserConfig"
+       "$ref": "#/definitions/ExternalAlertmanagerConfig"
       }
      },
      {
@@ -7019,11 +7014,22 @@
       "type": "string"
      },
      {
-      "description": "Comma-separated list of label matchers in 'key=value' format.\nThese matchers determine which alerts this configuration should handle.",
-      "example": "'environment=production,team=backend' will only apply this",
+      "description": "If true, the configuration will replace an existing configuration regardless of its identifier",
       "in": "header",
-      "name": "x-grafana-alerting-merge-matchers",
-      "type": "string"
+      "name": "x-grafana-alerting-config-force-replace",
+      "type": "boolean"
+     },
+     {
+      "description": "If true, validates the configuration without saving it",
+      "in": "header",
+      "name": "x-grafana-alerting-dry-run",
+      "type": "boolean"
+     },
+     {
+      "description": "If true, immediately promotes the configuration into the main Grafana config, making it editable via regular APIs.",
+      "in": "header",
+      "name": "x-grafana-alerting-promote",
+      "type": "boolean"
      },
      {
       "description": "Alertmanager configuration including routing rules, receivers, and template files",
@@ -7056,6 +7062,45 @@
      "convert_prometheus"
     ],
     "x-raw-request": "true"
+   }
+  },
+  "/convert/api/v1/alerts/{Identifier}/promote": {
+   "post": {
+    "description": "The staged import is permanently merged: receivers, routes, time intervals, templates, and\ninhibition rules are folded into the main config and become editable via regular APIs.\nAfter promotion the ExtraConfiguration entry is removed.",
+    "operationId": "RouteConvertPrometheusPromoteAlertmanagerConfig",
+    "parameters": [
+     {
+      "description": "Unique identifier for the Alertmanager configuration to promote.",
+      "in": "path",
+      "name": "Identifier",
+      "required": true,
+      "type": "string"
+     }
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "responses": {
+     "202": {
+      "$ref": "#/responses/ConvertAlertmanagerResponse"
+     },
+     "403": {
+      "description": "ForbiddenError",
+      "schema": {
+       "$ref": "#/definitions/ForbiddenError"
+      }
+     },
+     "404": {
+      "description": "NotFound",
+      "schema": {
+       "$ref": "#/definitions/NotFound"
+      }
+     }
+    },
+    "summary": "Promote an extra Alertmanager configuration into the main Grafana Alertmanager configuration.",
+    "tags": [
+     "convert_prometheus"
+    ]
    }
   },
   "/convert/prometheus/config/v1/rules": {
@@ -8590,13 +8635,19 @@
   },
   "/v1/provisioning/alert-rules": {
    "get": {
-    "operationId": "RouteGetAlertRules",
     "deprecated": true,
+    "operationId": "RouteGetAlertRules",
     "responses": {
      "200": {
       "description": "ProvisionedAlertRules",
       "schema": {
        "$ref": "#/definitions/ProvisionedAlertRules"
+      }
+     },
+     "403": {
+      "description": "ForbiddenError",
+      "schema": {
+       "$ref": "#/definitions/ForbiddenError"
       }
      }
     },
@@ -8609,8 +8660,8 @@
     "consumes": [
      "application/json"
     ],
-    "operationId": "RoutePostAlertRule",
     "deprecated": true,
+    "operationId": "RoutePostAlertRule",
     "parameters": [
      {
       "in": "body",
@@ -8636,6 +8687,12 @@
       "description": "ValidationError",
       "schema": {
        "$ref": "#/definitions/ValidationError"
+      }
+     },
+     "403": {
+      "description": "ForbiddenError",
+      "schema": {
+       "$ref": "#/definitions/ForbiddenError"
       }
      }
     },
@@ -8704,6 +8761,12 @@
        "$ref": "#/definitions/AlertingFileExport"
       }
      },
+     "403": {
+      "description": "ForbiddenError",
+      "schema": {
+       "$ref": "#/definitions/ForbiddenError"
+      }
+     },
      "404": {
       "description": " Not found."
      }
@@ -8716,8 +8779,8 @@
   },
   "/v1/provisioning/alert-rules/{UID}": {
    "delete": {
-    "operationId": "RouteDeleteAlertRule",
     "deprecated": true,
+    "operationId": "RouteDeleteAlertRule",
     "parameters": [
      {
       "description": "Alert rule UID",
@@ -8735,6 +8798,12 @@
     "responses": {
      "204": {
       "description": " The alert rule was deleted successfully."
+     },
+     "403": {
+      "description": "ForbiddenError",
+      "schema": {
+       "$ref": "#/definitions/ForbiddenError"
+      }
      }
     },
     "summary": "Delete a specific alert rule by UID.",
@@ -8743,8 +8812,8 @@
     ]
    },
    "get": {
-    "operationId": "RouteGetAlertRule",
     "deprecated": true,
+    "operationId": "RouteGetAlertRule",
     "parameters": [
      {
       "description": "Alert rule UID",
@@ -8761,6 +8830,12 @@
        "$ref": "#/definitions/ProvisionedAlertRule"
       }
      },
+     "403": {
+      "description": "ForbiddenError",
+      "schema": {
+       "$ref": "#/definitions/ForbiddenError"
+      }
+     },
      "404": {
       "description": " Not found."
      }
@@ -8774,8 +8849,8 @@
     "consumes": [
      "application/json"
     ],
-    "operationId": "RoutePutAlertRule",
     "deprecated": true,
+    "operationId": "RoutePutAlertRule",
     "parameters": [
      {
       "description": "Alert rule UID",
@@ -8808,6 +8883,12 @@
       "description": "ValidationError",
       "schema": {
        "$ref": "#/definitions/ValidationError"
+      }
+     },
+     "403": {
+      "description": "ForbiddenError",
+      "schema": {
+       "$ref": "#/definitions/ForbiddenError"
       }
      }
     },
@@ -8862,6 +8943,12 @@
        "$ref": "#/definitions/AlertingFileExport"
       }
      },
+     "403": {
+      "description": "ForbiddenError",
+      "schema": {
+       "$ref": "#/definitions/ForbiddenError"
+      }
+     },
      "404": {
       "description": " Not found."
      }
@@ -8874,6 +8961,7 @@
   },
   "/v1/provisioning/contact-points": {
    "get": {
+    "deprecated": true,
     "operationId": "RouteGetContactpoints",
     "parameters": [
      {
@@ -8889,18 +8977,24 @@
       "schema": {
        "$ref": "#/definitions/ContactPoints"
       }
+     },
+     "403": {
+      "description": "ForbiddenError",
+      "schema": {
+       "$ref": "#/definitions/ForbiddenError"
+      }
      }
     },
     "summary": "Get all the contact points.",
     "tags": [
      "provisioning"
-    ],
-    "deprecated": true
+    ]
    },
    "post": {
     "consumes": [
      "application/json"
     ],
+    "deprecated": true,
     "operationId": "RoutePostContactpoints",
     "parameters": [
      {
@@ -8928,13 +9022,18 @@
       "schema": {
        "$ref": "#/definitions/ValidationError"
       }
+     },
+     "403": {
+      "description": "ForbiddenError",
+      "schema": {
+       "$ref": "#/definitions/ForbiddenError"
+      }
      }
     },
     "summary": "Create a contact point.",
     "tags": [
      "provisioning"
-    ],
-    "deprecated": true
+    ]
    }
   },
   "/v1/provisioning/contact-points/export": {
@@ -9006,6 +9105,7 @@
     "consumes": [
      "application/json"
     ],
+    "deprecated": true,
     "operationId": "RouteDeleteContactpoints",
     "parameters": [
      {
@@ -9019,18 +9119,24 @@
     "responses": {
      "202": {
       "description": " The contact point was deleted successfully."
+     },
+     "403": {
+      "description": "ForbiddenError",
+      "schema": {
+       "$ref": "#/definitions/ForbiddenError"
+      }
      }
     },
     "summary": "Delete a contact point.",
     "tags": [
      "provisioning"
-    ],
-    "deprecated": true
+    ]
    },
    "put": {
     "consumes": [
      "application/json"
     ],
+    "deprecated": true,
     "operationId": "RoutePutContactpoint",
     "parameters": [
      {
@@ -9065,20 +9171,25 @@
       "schema": {
        "$ref": "#/definitions/ValidationError"
       }
+     },
+     "403": {
+      "description": "ForbiddenError",
+      "schema": {
+       "$ref": "#/definitions/ForbiddenError"
+      }
      }
     },
     "summary": "Update an existing contact point.",
     "tags": [
      "provisioning"
-    ],
-    "deprecated": true
+    ]
    }
   },
   "/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}": {
    "delete": {
+    "deprecated": true,
     "description": "Delete rule group",
     "operationId": "RouteDeleteAlertRuleGroup",
-    "deprecated": true,
     "parameters": [
      {
       "in": "path",
@@ -9115,8 +9226,8 @@
     ]
    },
    "get": {
-    "operationId": "RouteGetAlertRuleGroup",
     "deprecated": true,
+    "operationId": "RouteGetAlertRuleGroup",
     "parameters": [
      {
       "in": "path",
@@ -9138,6 +9249,12 @@
        "$ref": "#/definitions/AlertRuleGroup"
       }
      },
+     "403": {
+      "description": "ForbiddenError",
+      "schema": {
+       "$ref": "#/definitions/ForbiddenError"
+      }
+     },
      "404": {
       "description": " Not found."
      }
@@ -9151,8 +9268,8 @@
     "consumes": [
      "application/json"
     ],
-    "operationId": "RoutePutAlertRuleGroup",
     "deprecated": true,
+    "operationId": "RoutePutAlertRuleGroup",
     "parameters": [
      {
       "in": "header",
@@ -9190,6 +9307,12 @@
       "description": "ValidationError",
       "schema": {
        "$ref": "#/definitions/ValidationError"
+      }
+     },
+     "403": {
+      "description": "ForbiddenError",
+      "schema": {
+       "$ref": "#/definitions/ForbiddenError"
       }
      }
     },
@@ -9249,6 +9372,12 @@
        "$ref": "#/definitions/AlertingFileExport"
       }
      },
+     "403": {
+      "description": "ForbiddenError",
+      "schema": {
+       "$ref": "#/definitions/ForbiddenError"
+      }
+     },
      "404": {
       "description": " Not found."
      }
@@ -9261,6 +9390,7 @@
   },
   "/v1/provisioning/mute-timings": {
    "get": {
+    "deprecated": true,
     "operationId": "RouteGetMuteTimings",
     "responses": {
      "200": {
@@ -9268,18 +9398,24 @@
       "schema": {
        "$ref": "#/definitions/MuteTimings"
       }
+     },
+     "403": {
+      "description": "ForbiddenError",
+      "schema": {
+       "$ref": "#/definitions/ForbiddenError"
+      }
      }
     },
     "summary": "Get all the mute timings.",
     "tags": [
      "provisioning"
-    ],
-    "deprecated": true
+    ]
    },
    "post": {
     "consumes": [
      "application/json"
     ],
+    "deprecated": true,
     "operationId": "RoutePostMuteTiming",
     "parameters": [
      {
@@ -9307,13 +9443,18 @@
       "schema": {
        "$ref": "#/definitions/ValidationError"
       }
+     },
+     "403": {
+      "description": "ForbiddenError",
+      "schema": {
+       "$ref": "#/definitions/ForbiddenError"
+      }
      }
     },
     "summary": "Create a new mute timing.",
     "tags": [
      "provisioning"
-    ],
-    "deprecated": true
+    ]
    }
   },
   "/v1/provisioning/mute-timings/export": {
@@ -9369,6 +9510,7 @@
   },
   "/v1/provisioning/mute-timings/{name}": {
    "delete": {
+    "deprecated": true,
     "operationId": "RouteDeleteMuteTiming",
     "parameters": [
      {
@@ -9394,6 +9536,12 @@
      "204": {
       "description": " The mute timing was deleted successfully."
      },
+     "403": {
+      "description": "ForbiddenError",
+      "schema": {
+       "$ref": "#/definitions/ForbiddenError"
+      }
+     },
      "409": {
       "description": "PublicError",
       "schema": {
@@ -9404,10 +9552,10 @@
     "summary": "Delete a mute timing.",
     "tags": [
      "provisioning"
-    ],
-    "deprecated": true
+    ]
    },
    "get": {
+    "deprecated": true,
     "operationId": "RouteGetMuteTiming",
     "parameters": [
      {
@@ -9425,6 +9573,12 @@
        "$ref": "#/definitions/MuteTimeInterval"
       }
      },
+     "403": {
+      "description": "ForbiddenError",
+      "schema": {
+       "$ref": "#/definitions/ForbiddenError"
+      }
+     },
      "404": {
       "description": " Not found."
      }
@@ -9432,13 +9586,13 @@
     "summary": "Get a mute timing.",
     "tags": [
      "provisioning"
-    ],
-    "deprecated": true
+    ]
    },
    "put": {
     "consumes": [
      "application/json"
     ],
+    "deprecated": true,
     "operationId": "RoutePutMuteTiming",
     "parameters": [
      {
@@ -9474,6 +9628,12 @@
        "$ref": "#/definitions/ValidationError"
       }
      },
+     "403": {
+      "description": "ForbiddenError",
+      "schema": {
+       "$ref": "#/definitions/ForbiddenError"
+      }
+     },
      "409": {
       "description": "PublicError",
       "schema": {
@@ -9484,8 +9644,7 @@
     "summary": "Replace an existing mute timing.",
     "tags": [
      "provisioning"
-    ],
-    "deprecated": true
+    ]
    }
   },
   "/v1/provisioning/mute-timings/{name}/export": {
@@ -9551,6 +9710,7 @@
     "consumes": [
      "application/json"
     ],
+    "deprecated": true,
     "operationId": "RouteResetPolicyTree",
     "responses": {
      "202": {
@@ -9558,15 +9718,21 @@
       "schema": {
        "$ref": "#/definitions/Ack"
       }
+     },
+     "403": {
+      "description": "ForbiddenError",
+      "schema": {
+       "$ref": "#/definitions/ForbiddenError"
+      }
      }
     },
     "summary": "Clears the notification policy tree.",
     "tags": [
      "provisioning"
-    ],
-    "deprecated": true
+    ]
    },
    "get": {
+    "deprecated": true,
     "operationId": "RouteGetPolicyTree",
     "responses": {
      "200": {
@@ -9574,18 +9740,24 @@
       "schema": {
        "$ref": "#/definitions/Route"
       }
+     },
+     "403": {
+      "description": "ForbiddenError",
+      "schema": {
+       "$ref": "#/definitions/ForbiddenError"
+      }
      }
     },
     "summary": "Get the notification policy tree.",
     "tags": [
      "provisioning"
-    ],
-    "deprecated": true
+    ]
    },
    "put": {
     "consumes": [
      "application/json"
     ],
+    "deprecated": true,
     "operationId": "RoutePutPolicyTree",
     "parameters": [
      {
@@ -9614,13 +9786,18 @@
       "schema": {
        "$ref": "#/definitions/ValidationError"
       }
+     },
+     "403": {
+      "description": "ForbiddenError",
+      "schema": {
+       "$ref": "#/definitions/ForbiddenError"
+      }
      }
     },
     "summary": "Sets the notification policy tree.",
     "tags": [
      "provisioning"
-    ],
-    "deprecated": true
+    ]
    }
   },
   "/v1/provisioning/policies/export": {
@@ -9640,6 +9817,12 @@
        "$ref": "#/definitions/AlertingFileExport"
       }
      },
+     "403": {
+      "description": "ForbiddenError",
+      "schema": {
+       "$ref": "#/definitions/ForbiddenError"
+      }
+     },
      "404": {
       "description": "NotFound",
       "schema": {
@@ -9655,6 +9838,7 @@
   },
   "/v1/provisioning/templates": {
    "get": {
+    "deprecated": true,
     "operationId": "RouteGetTemplates",
     "responses": {
      "200": {
@@ -9662,17 +9846,23 @@
       "schema": {
        "$ref": "#/definitions/NotificationTemplates"
       }
+     },
+     "403": {
+      "description": "ForbiddenError",
+      "schema": {
+       "$ref": "#/definitions/ForbiddenError"
+      }
      }
     },
     "summary": "Get all notification template groups.",
     "tags": [
      "provisioning"
-    ],
-    "deprecated": true
+    ]
    }
   },
   "/v1/provisioning/templates/{name}": {
    "delete": {
+    "deprecated": true,
     "operationId": "RouteDeleteTemplate",
     "parameters": [
      {
@@ -9693,6 +9883,12 @@
      "204": {
       "description": " The template was deleted successfully."
      },
+     "403": {
+      "description": "ForbiddenError",
+      "schema": {
+       "$ref": "#/definitions/ForbiddenError"
+      }
+     },
      "409": {
       "description": "PublicError",
       "schema": {
@@ -9703,10 +9899,10 @@
     "summary": "Delete a notification template group.",
     "tags": [
      "provisioning"
-    ],
-    "deprecated": true
+    ]
    },
    "get": {
+    "deprecated": true,
     "operationId": "RouteGetTemplate",
     "parameters": [
      {
@@ -9724,6 +9920,12 @@
        "$ref": "#/definitions/NotificationTemplate"
       }
      },
+     "403": {
+      "description": "ForbiddenError",
+      "schema": {
+       "$ref": "#/definitions/ForbiddenError"
+      }
+     },
      "404": {
       "description": "PublicError",
       "schema": {
@@ -9734,13 +9936,13 @@
     "summary": "Get a notification template group.",
     "tags": [
      "provisioning"
-    ],
-    "deprecated": true
+    ]
    },
    "put": {
     "consumes": [
      "application/json"
     ],
+    "deprecated": true,
     "operationId": "RoutePutTemplate",
     "parameters": [
      {
@@ -9776,6 +9978,12 @@
        "$ref": "#/definitions/PublicError"
       }
      },
+     "403": {
+      "description": "ForbiddenError",
+      "schema": {
+       "$ref": "#/definitions/ForbiddenError"
+      }
+     },
      "409": {
       "description": "PublicError",
       "schema": {
@@ -9786,8 +9994,7 @@
     "summary": "Updates an existing notification template group.",
     "tags": [
      "provisioning"
-    ],
-    "deprecated": true
+    ]
    }
   },
   "/v1/rule/backtest": {

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -3419,6 +3419,12 @@
             "schema": {
               "$ref": "#/definitions/ForbiddenError"
             }
+          },
+          "409": {
+            "description": "PublicError",
+            "schema": {
+              "$ref": "#/definitions/PublicError"
+            }
           }
         }
       }
@@ -3539,6 +3545,12 @@
             "schema": {
               "$ref": "#/definitions/ForbiddenError"
             }
+          },
+          "409": {
+            "description": "PublicError",
+            "schema": {
+              "$ref": "#/definitions/PublicError"
+            }
           }
         }
       },
@@ -3570,6 +3582,12 @@
             "description": "ForbiddenError",
             "schema": {
               "$ref": "#/definitions/ForbiddenError"
+            }
+          },
+          "409": {
+            "description": "PublicError",
+            "schema": {
+              "$ref": "#/definitions/PublicError"
             }
           }
         }
@@ -3848,6 +3866,12 @@
             "description": "ForbiddenError",
             "schema": {
               "$ref": "#/definitions/ForbiddenError"
+            }
+          },
+          "409": {
+            "description": "PublicError",
+            "schema": {
+              "$ref": "#/definitions/PublicError"
             }
           }
         }
@@ -4174,6 +4198,12 @@
             "schema": {
               "$ref": "#/definitions/ForbiddenError"
             }
+          },
+          "409": {
+            "description": "PublicError",
+            "schema": {
+              "$ref": "#/definitions/PublicError"
+            }
           }
         }
       },
@@ -4199,6 +4229,12 @@
             "description": "ForbiddenError",
             "schema": {
               "$ref": "#/definitions/ForbiddenError"
+            }
+          },
+          "409": {
+            "description": "PublicError",
+            "schema": {
+              "$ref": "#/definitions/PublicError"
             }
           }
         }
@@ -8595,8 +8631,8 @@
       }
     },
     "Route": {
+      "description": "A Route is a node that contains definitions of how to handle alerts. This is modified\nfrom the upstream alertmanager in that it adds the ObjectMatchers property.",
       "type": "object",
-      "title": "A Route is a node that contains definitions of how to handle alerts.",
       "properties": {
         "active_time_intervals": {
           "type": "array",
@@ -8637,6 +8673,12 @@
           "items": {
             "type": "string"
           }
+        },
+        "object_matchers": {
+          "$ref": "#/definitions/ObjectMatchers"
+        },
+        "provenance": {
+          "$ref": "#/definitions/Provenance"
         },
         "receiver": {
           "type": "string"

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -1451,7 +1451,10 @@
         ],
         "responses": {
           "202": {
-            "$ref": "#/responses/ConvertAlertmanagerResponse"
+            "description": "ConvertAlertmanagerResponse",
+            "schema": {
+              "$ref": "#/definitions/ConvertAlertmanagerResponse"
+            }
           },
           "403": {
             "description": "ForbiddenError",
@@ -2348,7 +2351,10 @@
             }
           },
           "404": {
-            "$ref": "#/responses/NotFound."
+            "description": "NotFound",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
           }
         }
       }
@@ -5409,6 +5415,26 @@
         "$ref": "#/definitions/EmbeddedContactPoint"
       }
     },
+    "ConvertAlertmanagerResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "string"
+        },
+        "errorType": {
+          "type": "string"
+        },
+        "rename_resources": {
+          "$ref": "#/definitions/RenameResources"
+        },
+        "stats": {
+          "$ref": "#/definitions/MergeStats"
+        },
+        "status": {
+          "type": "string"
+        }
+      }
+    },
     "ConvertPrometheusResponse": {
       "type": "object",
       "properties": {
@@ -7070,6 +7096,44 @@
       },
       "$ref": "#/definitions/Matchers"
     },
+    "MergeStats": {
+      "type": "object",
+      "title": "MergeStats describes which resources were added during configuration merge.",
+      "properties": {
+        "added_inhibition_rules": {
+          "description": "AddedInhibitionRules contains the names of inhibition rules added",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "added_receivers": {
+          "description": "AddedReceivers contains the names of receivers added (post-rename if renamed)",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "added_route": {
+          "description": "AddedRoute is the identifier of the routing sub-tree added to the configuration",
+          "type": "string"
+        },
+        "added_templates": {
+          "description": "AddedTemplates contains the names of templates added",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "added_time_intervals": {
+          "description": "AddedTimeIntervals contains the names of time intervals added (post-rename if renamed)",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "MultiStatus": {
       "type": "object"
     },
@@ -8494,6 +8558,26 @@
         }
       }
     },
+    "RenameResources": {
+      "description": "RenameResources describes which resources were renamed to avoid conflicts",
+      "type": "object",
+      "properties": {
+        "receivers": {
+          "description": "Receivers maps old receiver names to new receiver names",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "time_intervals": {
+          "description": "TimeIntervals maps old time interval names to new time interval names",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "ResponseDetails": {
       "type": "object",
       "properties": {
@@ -8511,8 +8595,8 @@
       }
     },
     "Route": {
-      "description": "A Route is a node that contains definitions of how to handle alerts. This is modified\nfrom the upstream alertmanager in that it adds the ObjectMatchers property.",
       "type": "object",
+      "title": "A Route is a node that contains definitions of how to handle alerts.",
       "properties": {
         "active_time_intervals": {
           "type": "array",
@@ -8553,12 +8637,6 @@
           "items": {
             "type": "string"
           }
-        },
-        "object_matchers": {
-          "$ref": "#/definitions/ObjectMatchers"
-        },
-        "provenance": {
-          "$ref": "#/definitions/Provenance"
         },
         "receiver": {
           "type": "string"

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -347,7 +347,10 @@
         "deprecated": true,
         "responses": {
           "410": {
-            "$ref": "#/responses/Gone"
+            "description": "Gone",
+            "schema": {
+              "$ref": "#/definitions/Gone"
+            }
           }
         }
       }
@@ -1350,10 +1353,21 @@
             "in": "header"
           },
           {
-            "type": "string",
-            "example": "'environment=production,team=backend' will only apply this",
-            "description": "Comma-separated list of label matchers in 'key=value' format.\nThese matchers determine which alerts this configuration should handle.",
-            "name": "x-grafana-alerting-merge-matchers",
+            "type": "boolean",
+            "description": "If true, the configuration will replace an existing configuration regardless of its identifier",
+            "name": "x-grafana-alerting-config-force-replace",
+            "in": "header"
+          },
+          {
+            "type": "boolean",
+            "description": "If true, validates the configuration without saving it",
+            "name": "x-grafana-alerting-dry-run",
+            "in": "header"
+          },
+          {
+            "type": "boolean",
+            "description": "If true, immediately promotes the configuration into the main Grafana config, making it editable via regular APIs.",
+            "name": "x-grafana-alerting-promote",
             "in": "header"
           },
           {
@@ -1410,6 +1424,45 @@
             "description": "ForbiddenError",
             "schema": {
               "$ref": "#/definitions/ForbiddenError"
+            }
+          }
+        }
+      }
+    },
+    "/convert/api/v1/alerts/{Identifier}/promote": {
+      "post": {
+        "description": "The staged import is permanently merged: receivers, routes, time intervals, templates, and\ninhibition rules are folded into the main config and become editable via regular APIs.\nAfter promotion the ExtraConfiguration entry is removed.",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "convert_prometheus"
+        ],
+        "summary": "Promote an extra Alertmanager configuration into the main Grafana Alertmanager configuration.",
+        "operationId": "RouteConvertPrometheusPromoteAlertmanagerConfig",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique identifier for the Alertmanager configuration to promote.",
+            "name": "Identifier",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "202": {
+            "$ref": "#/responses/ConvertAlertmanagerResponse"
+          },
+          "403": {
+            "description": "ForbiddenError",
+            "schema": {
+              "$ref": "#/definitions/ForbiddenError"
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
             }
           }
         }
@@ -4905,6 +4958,11 @@
             "maintenance"
           ]
         },
+        "policy": {
+          "description": "Name of the notification policy to route alerts through.\nMutually exclusive with all other fields, cannot be used with contact point routing via the \"receiver\" field.",
+          "type": "string",
+          "example": "\"Alerting Team\""
+        },
         "receiver": {
           "description": "Name of the receiver to send notifications to.",
           "type": "string",
@@ -5718,8 +5776,7 @@
         },
         "uptime": {
           "description": "uptime",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         },
         "versionInfo": {
           "$ref": "#/definitions/versionInfo"
@@ -5735,8 +5792,9 @@
         "identifier": {
           "type": "string"
         },
-        "merge_matchers": {
-          "$ref": "#/definitions/Matchers"
+        "managed_by": {
+          "description": "ManagedBy is \"manual\" or \"auto-sync\", computed server-side so callers don't need configs:get\nto tell the two apart.",
+          "type": "string"
         },
         "template_files": {
           "type": "object",
@@ -6263,6 +6321,9 @@
         },
         "uid": {
           "type": "string"
+        },
+        "version": {
+          "type": "string"
         }
       }
     },
@@ -6371,8 +6432,7 @@
           "format": "int64"
         },
         "last_applied": {
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         },
         "template_file_provenances": {
           "type": "object",
@@ -6398,6 +6458,10 @@
             "internal",
             "external"
           ]
+        },
+        "external_alertmanager_uid": {
+          "description": "ExternalAlertmanagerUID is the UID of the Mimir/Cortex Alertmanager datasource being\nsynced, or empty if sync is not configured for this org.",
+          "type": "string"
         }
       }
     },
@@ -6472,8 +6536,7 @@
         },
         "uptime": {
           "description": "uptime",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         },
         "versionInfo": {
           "$ref": "#/definitions/versionInfo"
@@ -6733,6 +6796,52 @@
         }
       }
     },
+    "InhibitionRule": {
+      "description": "It embeds the upstream Alertmanager InhibitRule and adds Grafana-specific fields.",
+      "type": "object",
+      "title": "InhibitionRule is the domain model for inhibition rules with metadata.",
+      "properties": {
+        "equal": {
+          "description": "A set of labels that must be equal between the source and target alert\nfor them to be a match.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "name": {
+          "type": "string"
+        },
+        "provenance": {
+          "$ref": "#/definitions/Provenance"
+        },
+        "source_match": {
+          "description": "SourceMatch defines a set of labels that have to equal the given\nvalue for source alerts. Deprecated. Remove before v1.0 release.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "source_match_re": {
+          "$ref": "#/definitions/MatchRegexps"
+        },
+        "source_matchers": {
+          "$ref": "#/definitions/Matchers"
+        },
+        "target_match": {
+          "description": "TargetMatch defines a set of labels that have to equal the given\nvalue for target alerts. Deprecated. Remove before v1.0 release.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "target_match_re": {
+          "$ref": "#/definitions/MatchRegexps"
+        },
+        "target_matchers": {
+          "$ref": "#/definitions/Matchers"
+        }
+      }
+    },
     "InspectType": {
       "type": "integer",
       "format": "int64",
@@ -6743,8 +6852,7 @@
       "properties": {
         "lastNotifyAttempt": {
           "description": "A timestamp indicating the last attempt to deliver a notification regardless of the outcome.\nFormat: date-time",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         },
         "lastNotifyAttemptDuration": {
           "description": "Duration of the last attempt to deliver a notification in humanized format (`1s` or `15ms`, etc).",
@@ -6843,21 +6951,10 @@
     "Json": {
       "type": "object"
     },
-    "Label": {
-      "type": "object",
-      "title": "Label is a key/value pair of strings.",
-      "properties": {
-        "Name": {
-          "type": "string"
-        }
-      }
-    },
     "Labels": {
-      "description": "Labels is a sorted set of labels. Order has to be guaranteed upon\ninstantiation.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/Label"
-      }
+      "description": "Each name and value is preceded by its length, encoded as a single byte\nfor size 0-254, or the following 3 bytes little-endian, if the first byte is 255.\nMaximum length allowed is 2^24 or 16MB.\nNames are in order.",
+      "type": "object",
+      "title": "Labels is implemented by a single flat string holding name/value pairs."
     },
     "LinkTransformationConfig": {
       "type": "object",
@@ -6923,6 +7020,19 @@
         "webhook_url_file": {
           "type": "string"
         }
+      }
+    },
+    "ManagedInhibitionRules": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/InhibitionRule"
+      }
+    },
+    "ManagedRoutes": {
+      "description": "ManagedRoutes this type exists purely to ensure unmarshalling upstream Routes will call Validate and populate\nGroupBy and GroupByAll. Eventually, we will want this to be a separate type and make the conversion to\ndefinitions.Route explicit.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/Route"
       }
     },
     "MatchRegexps": {
@@ -7471,105 +7581,29 @@
       "description": "nolint:revive",
       "type": "object",
       "properties": {
-        "discord_configs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/DiscordConfig"
-          }
-        },
-        "email_configs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/EmailConfig"
-          }
-        },
         "grafana_managed_receiver_configs": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/PostableGrafanaReceiver"
           }
         },
-        "jira_configs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/JiraConfig"
-          }
-        },
-        "msteams_configs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/MSTeamsConfig"
-          }
-        },
-        "msteamsv2_configs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/MSTeamsV2Config"
-          }
-        },
         "name": {
-          "description": "A unique identifier for this receiver.",
+          "type": "string"
+        }
+      }
+    },
+    "PostableApiTemplate": {
+      "description": "nolint:revive",
+      "type": "object",
+      "properties": {
+        "content": {
           "type": "string"
         },
-        "opsgenie_configs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/OpsGenieConfig"
-          }
+        "kind": {
+          "$ref": "#/definitions/TemplateKind"
         },
-        "pagerduty_configs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/PagerdutyConfig"
-          }
-        },
-        "pushover_configs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/PushoverConfig"
-          }
-        },
-        "slack_configs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/SlackConfig"
-          }
-        },
-        "sns_configs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/SNSConfig"
-          }
-        },
-        "telegram_configs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/TelegramConfig"
-          }
-        },
-        "victorops_configs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/VictorOpsConfig"
-          }
-        },
-        "webex_configs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/WebexConfig"
-          }
-        },
-        "webhook_configs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/WebhookConfig"
-          }
-        },
-        "wechat_configs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/WechatConfig"
-          }
+        "name": {
+          "type": "string"
         }
       }
     },
@@ -7654,6 +7688,9 @@
         },
         "uid": {
           "type": "string"
+        },
+        "version": {
+          "type": "string"
         }
       }
     },
@@ -7732,6 +7769,10 @@
             "internal",
             "external"
           ]
+        },
+        "external_alertmanager_uid": {
+          "description": "ExternalAlertmanagerUID is the UID of the Mimir/Cortex Alertmanager datasource to sync\nconfiguration from. Empty string disables sync for this org.",
+          "type": "string"
         }
       }
     },
@@ -7793,6 +7834,18 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/ExtraConfiguration"
+          }
+        },
+        "managed_inhibition_rules": {
+          "$ref": "#/definitions/ManagedInhibitionRules"
+        },
+        "managed_routes": {
+          "$ref": "#/definitions/ManagedRoutes"
+        },
+        "managed_templates": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/PostableApiTemplate"
           }
         },
         "template_files": {
@@ -9152,6 +9205,9 @@
         }
       }
     },
+    "TemplateKind": {
+      "type": "string"
+    },
     "TestRulePayload": {
       "type": "object",
       "properties": {
@@ -9184,6 +9240,9 @@
           "items": {
             "$ref": "#/definitions/postableAlert"
           }
+        },
+        "kind": {
+          "$ref": "#/definitions/TemplateKind"
         },
         "name": {
           "description": "Name of the template file.",
@@ -9373,6 +9432,7 @@
       "title": "URL is a custom URL type that allows validation at configuration load time.",
       "properties": {
         "ForceQuery": {
+          "description": "ForceQuery indicates whether the original URL contained a query ('?') character.\nWhen set, the String method will include a trailing '?', even when RawQuery is empty.",
           "type": "boolean"
         },
         "Fragment": {
@@ -9382,6 +9442,7 @@
           "type": "string"
         },
         "OmitHost": {
+          "description": "OmitHost indicates the URL has an empty host (authority).\nWhen set, the String method will not include the host when it is empty.",
           "type": "boolean"
         },
         "Opaque": {
@@ -9391,12 +9452,15 @@
           "type": "string"
         },
         "RawFragment": {
+          "description": "RawFragment is an optional field containing an encoded fragment hint.\nSee the EscapedFragment method for more details.\n\nIn general, code should call EscapedFragment instead of reading RawFragment.",
           "type": "string"
         },
         "RawPath": {
+          "description": "RawPath is an optional field containing an encoded path hint.\nSee the EscapedPath method for more details.\n\nIn general, code should call EscapedPath instead of reading RawPath.",
           "type": "string"
         },
         "RawQuery": {
+          "description": "RawQuery contains the encoded query values, without the initial '?'.\nUse URL.Query to decode the query.",
           "type": "string"
         },
         "Scheme": {
@@ -9632,8 +9696,7 @@
       "properties": {
         "generatorURL": {
           "description": "generator URL\nFormat: uri",
-          "type": "string",
-          "format": "uri"
+          "type": "string"
         },
         "labels": {
           "$ref": "#/definitions/labelSet"
@@ -9735,8 +9798,7 @@
         },
         "uptime": {
           "description": "uptime",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         },
         "versionInfo": {
           "$ref": "#/definitions/versionInfo"
@@ -9789,8 +9851,7 @@
         },
         "endsAt": {
           "description": "ends at",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         },
         "fingerprint": {
           "description": "fingerprint",
@@ -9798,8 +9859,7 @@
         },
         "generatorURL": {
           "description": "generator URL\nFormat: uri",
-          "type": "string",
-          "format": "uri"
+          "type": "string"
         },
         "labels": {
           "$ref": "#/definitions/labelSet"
@@ -9813,16 +9873,14 @@
         },
         "startsAt": {
           "description": "starts at",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         },
         "status": {
           "$ref": "#/definitions/alertStatus"
         },
         "updatedAt": {
           "description": "updated at",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         }
       }
     },
@@ -9868,8 +9926,7 @@
         },
         "endsAt": {
           "description": "ends at",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         },
         "id": {
           "description": "id",
@@ -9883,16 +9940,14 @@
         },
         "startsAt": {
           "description": "starts at",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         },
         "status": {
           "$ref": "#/definitions/silenceStatus"
         },
         "updatedAt": {
           "description": "updated at",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         }
       }
     },
@@ -9926,8 +9981,7 @@
         },
         "endsAt": {
           "description": "ends at",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         },
         "id": {
           "description": "id",
@@ -9938,16 +9992,14 @@
         },
         "startsAt": {
           "description": "starts at",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         },
         "status": {
           "$ref": "#/definitions/silenceStatus"
         },
         "updatedAt": {
           "description": "updated at",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         }
       }
     },
@@ -10039,21 +10091,18 @@
         },
         "endsAt": {
           "description": "ends at\nFormat: date-time",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         },
         "generatorURL": {
           "description": "generator URL\nFormat: uri",
-          "type": "string",
-          "format": "uri"
+          "type": "string"
         },
         "labels": {
           "$ref": "#/definitions/labelSet"
         },
         "startsAt": {
           "description": "starts at\nFormat: date-time",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         }
       }
     },
@@ -10085,8 +10134,7 @@
         },
         "endsAt": {
           "description": "ends at",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         },
         "id": {
           "description": "id",
@@ -10097,8 +10145,7 @@
         },
         "startsAt": {
           "description": "starts at",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         }
       }
     },
@@ -10136,16 +10183,14 @@
         },
         "endsAt": {
           "description": "ends at",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         },
         "matchers": {
           "$ref": "#/definitions/matchers"
         },
         "startsAt": {
           "description": "starts at",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         }
       }
     },

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -10960,6 +10960,12 @@
             "schema": {
               "$ref": "#/definitions/ForbiddenError"
             }
+          },
+          "409": {
+            "description": "PublicError",
+            "schema": {
+              "$ref": "#/definitions/PublicError"
+            }
           }
         }
       }
@@ -11078,6 +11084,12 @@
             "schema": {
               "$ref": "#/definitions/ForbiddenError"
             }
+          },
+          "409": {
+            "description": "PublicError",
+            "schema": {
+              "$ref": "#/definitions/PublicError"
+            }
           }
         }
       },
@@ -11108,6 +11120,12 @@
             "description": "ForbiddenError",
             "schema": {
               "$ref": "#/definitions/ForbiddenError"
+            }
+          },
+          "409": {
+            "description": "PublicError",
+            "schema": {
+              "$ref": "#/definitions/PublicError"
             }
           }
         }
@@ -11380,6 +11398,12 @@
             "description": "ForbiddenError",
             "schema": {
               "$ref": "#/definitions/ForbiddenError"
+            }
+          },
+          "409": {
+            "description": "PublicError",
+            "schema": {
+              "$ref": "#/definitions/PublicError"
             }
           }
         }
@@ -11699,6 +11723,12 @@
             "schema": {
               "$ref": "#/definitions/ForbiddenError"
             }
+          },
+          "409": {
+            "description": "PublicError",
+            "schema": {
+              "$ref": "#/definitions/PublicError"
+            }
           }
         }
       },
@@ -11723,6 +11753,12 @@
             "description": "ForbiddenError",
             "schema": {
               "$ref": "#/definitions/ForbiddenError"
+            }
+          },
+          "409": {
+            "description": "PublicError",
+            "schema": {
+              "$ref": "#/definitions/PublicError"
             }
           }
         }

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -22370,52 +22370,11 @@
         }
       }
     },
-    "URL": {
-      "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nThe Host field contains the host and port subcomponents of the URL.\nWhen the port is present, it is separated from the host with a colon.\nWhen the host is an IPv6 address, it must be enclosed in square brackets:\n\"[fe80::1]:80\". The [net.JoinHostPort] function combines a host and port\ninto a string suitable for the Host field, adding square brackets to\nthe host when necessary.\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use the [URL.EscapedPath] method, which preserves\nthe original encoding of Path. The Fragment field is also stored in decoded form,\nuse [URL.EscapedFragment] to retrieve the original encoding.\n\nThe [URL.String] method uses the [URL.EscapedPath] method to obtain the path.",
-      "type": "object",
-      "title": "A URL represents a parsed URL (technically, a URI reference).",
-      "properties": {
-        "ForceQuery": {
-          "description": "ForceQuery indicates whether the original URL contained a query ('?') character.\nWhen set, the String method will include a trailing '?', even when RawQuery is empty.",
-          "type": "boolean"
-        },
-        "Fragment": {
-          "type": "string"
-        },
-        "Host": {
-          "type": "string"
-        },
-        "OmitHost": {
-          "description": "OmitHost indicates the URL has an empty host (authority).\nWhen set, the String method will not include the host when it is empty.",
-          "type": "boolean"
-        },
-        "Opaque": {
-          "type": "string"
-        },
-        "Path": {
-          "type": "string"
-        },
-        "RawFragment": {
-          "description": "RawFragment is an optional field containing an encoded fragment hint.\nSee the EscapedFragment method for more details.\n\nIn general, code should call EscapedFragment instead of reading RawFragment.",
-          "type": "string"
-        },
-        "RawPath": {
-          "description": "RawPath is an optional field containing an encoded path hint.\nSee the EscapedPath method for more details.\n\nIn general, code should call EscapedPath instead of reading RawPath.",
-          "type": "string"
-        },
-        "RawQuery": {
-          "description": "RawQuery contains the encoded query values, without the initial '?'.\nUse URL.Query to decode the query.",
-          "type": "string"
-        },
-        "Scheme": {
-          "type": "string"
-        },
-        "User": {
-          "$ref": "#/definitions/Userinfo"
-        }
-      }
-    },
-    "Unstructured": {
+    "URL": { 
+			"type": "string", 
+			"format": "url" 
+		},
+		"Unstructured": {
       "description": "Unstructured allows objects that do not have Golang structs registered to be manipulated\ngenerically.",
       "type": "object",
       "properties": {

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -14018,6 +14018,26 @@
         "$ref": "#/definitions/EmbeddedContactPoint"
       }
     },
+    "ConvertAlertmanagerResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "string"
+        },
+        "errorType": {
+          "type": "string"
+        },
+        "rename_resources": {
+          "$ref": "#/definitions/RenameResources"
+        },
+        "stats": {
+          "$ref": "#/definitions/MergeStats"
+        },
+        "status": {
+          "type": "string"
+        }
+      }
+    },
     "ConvertPrometheusResponse": {
       "type": "object",
       "properties": {
@@ -17482,6 +17502,44 @@
         "$ref": "#/definitions/Matcher"
       }
     },
+    "MergeStats": {
+      "type": "object",
+      "title": "MergeStats describes which resources were added during configuration merge.",
+      "properties": {
+        "added_inhibition_rules": {
+          "description": "AddedInhibitionRules contains the names of inhibition rules added",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "added_receivers": {
+          "description": "AddedReceivers contains the names of receivers added (post-rename if renamed)",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "added_route": {
+          "description": "AddedRoute is the identifier of the routing sub-tree added to the configuration",
+          "type": "string"
+        },
+        "added_templates": {
+          "description": "AddedTemplates contains the names of templates added",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "added_time_intervals": {
+          "description": "AddedTimeIntervals contains the names of time intervals added (post-rename if renamed)",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "Metadata": {
       "description": "Metadata contains user accesses for a given resource\nEx: map[string]bool{\"create\":true, \"delete\": true}",
       "type": "object",
@@ -19916,6 +19974,26 @@
         }
       }
     },
+    "RenameResources": {
+      "description": "RenameResources describes which resources were renamed to avoid conflicts",
+      "type": "object",
+      "properties": {
+        "receivers": {
+          "description": "Receivers maps old receiver names to new receiver names",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "time_intervals": {
+          "description": "TimeIntervals maps old time interval names to new time interval names",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "Report": {
       "type": "object",
       "properties": {
@@ -20393,8 +20471,8 @@
       }
     },
     "Route": {
+      "description": "A Route is a node that contains definitions of how to handle alerts. This is modified\nfrom the upstream alertmanager in that it adds the ObjectMatchers property.",
       "type": "object",
-      "title": "A Route is a node that contains definitions of how to handle alerts.",
       "properties": {
         "active_time_intervals": {
           "type": "array",
@@ -20435,6 +20513,12 @@
           "items": {
             "type": "string"
           }
+        },
+        "object_matchers": {
+          "$ref": "#/definitions/ObjectMatchers"
+        },
+        "provenance": {
+          "$ref": "#/definitions/Provenance"
         },
         "receiver": {
           "type": "string"

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -12829,6 +12829,11 @@
             "maintenance"
           ]
         },
+        "policy": {
+          "description": "Name of the notification policy to route alerts through.\nMutually exclusive with all other fields, cannot be used with contact point routing via the \"receiver\" field.",
+          "type": "string",
+          "example": "\"Alerting Team\""
+        },
         "receiver": {
           "description": "Name of the receiver to send notifications to.",
           "type": "string",
@@ -15465,8 +15470,7 @@
         },
         "uptime": {
           "description": "uptime",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         },
         "versionInfo": {
           "$ref": "#/definitions/versionInfo"
@@ -15482,8 +15486,9 @@
         "identifier": {
           "type": "string"
         },
-        "merge_matchers": {
-          "$ref": "#/definitions/Matchers"
+        "managed_by": {
+          "description": "ManagedBy is \"manual\" or \"auto-sync\", computed server-side so callers don't need configs:get\nto tell the two apart.",
+          "type": "string"
         },
         "template_files": {
           "type": "object",
@@ -16250,6 +16255,9 @@
         },
         "uid": {
           "type": "string"
+        },
+        "version": {
+          "type": "string"
         }
       }
     },
@@ -16358,8 +16366,7 @@
           "format": "int64"
         },
         "last_applied": {
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         },
         "template_file_provenances": {
           "type": "object",
@@ -16385,6 +16392,10 @@
             "internal",
             "external"
           ]
+        },
+        "external_alertmanager_uid": {
+          "description": "ExternalAlertmanagerUID is the UID of the Mimir/Cortex Alertmanager datasource being\nsynced, or empty if sync is not configured for this org.",
+          "type": "string"
         }
       }
     },
@@ -16459,8 +16470,7 @@
         },
         "uptime": {
           "description": "uptime",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         },
         "versionInfo": {
           "$ref": "#/definitions/versionInfo"
@@ -16579,6 +16589,9 @@
           "$ref": "#/definitions/URL"
         }
       }
+    },
+    "Gone": {
+      "type": "object"
     },
     "HTTPClientConfig": {
       "type": "object",
@@ -16923,6 +16936,52 @@
         }
       }
     },
+    "InhibitionRule": {
+      "description": "It embeds the upstream Alertmanager InhibitRule and adds Grafana-specific fields.",
+      "type": "object",
+      "title": "InhibitionRule is the domain model for inhibition rules with metadata.",
+      "properties": {
+        "equal": {
+          "description": "A set of labels that must be equal between the source and target alert\nfor them to be a match.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "name": {
+          "type": "string"
+        },
+        "provenance": {
+          "$ref": "#/definitions/Provenance"
+        },
+        "source_match": {
+          "description": "SourceMatch defines a set of labels that have to equal the given\nvalue for source alerts. Deprecated. Remove before v1.0 release.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "source_match_re": {
+          "$ref": "#/definitions/MatchRegexps"
+        },
+        "source_matchers": {
+          "$ref": "#/definitions/Matchers"
+        },
+        "target_match": {
+          "description": "TargetMatch defines a set of labels that have to equal the given\nvalue for target alerts. Deprecated. Remove before v1.0 release.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "target_match_re": {
+          "$ref": "#/definitions/MatchRegexps"
+        },
+        "target_matchers": {
+          "$ref": "#/definitions/Matchers"
+        }
+      }
+    },
     "InspectType": {
       "type": "integer",
       "format": "int64",
@@ -16933,8 +16992,7 @@
       "properties": {
         "lastNotifyAttempt": {
           "description": "A timestamp indicating the last attempt to deliver a notification regardless of the outcome.\nFormat: date-time",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         },
         "lastNotifyAttemptDuration": {
           "description": "Duration of the last attempt to deliver a notification in humanized format (`1s` or `15ms`, etc).",
@@ -17085,21 +17143,10 @@
       "type": "integer",
       "format": "int64"
     },
-    "Label": {
-      "type": "object",
-      "title": "Label is a key/value pair of strings.",
-      "properties": {
-        "Name": {
-          "type": "string"
-        }
-      }
-    },
     "Labels": {
-      "description": "Labels is a sorted set of labels. Order has to be guaranteed upon\ninstantiation.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/Label"
-      }
+      "description": "Each name and value is preceded by its length, encoded as a single byte\nfor size 0-254, or the following 3 bytes little-endian, if the first byte is 255.\nMaximum length allowed is 2^24 or 16MB.\nNames are in order.",
+      "type": "object",
+      "title": "Labels is implemented by a single flat string holding name/value pairs."
     },
     "LibraryElementArrayResponse": {
       "type": "object",
@@ -17361,6 +17408,19 @@
         "webhook_url_file": {
           "type": "string"
         }
+      }
+    },
+    "ManagedInhibitionRules": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/InhibitionRule"
+      }
+    },
+    "ManagedRoutes": {
+      "description": "ManagedRoutes this type exists purely to ensure unmarshalling upstream Routes will call Validate and populate\nGroupBy and GroupByAll. Eventually, we will want this to be a separate type and make the conversion to\ndefinitions.Route explicit.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/Route"
       }
     },
     "ManagerKind": {
@@ -18582,105 +18642,29 @@
       "description": "nolint:revive",
       "type": "object",
       "properties": {
-        "discord_configs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/DiscordConfig"
-          }
-        },
-        "email_configs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/EmailConfig"
-          }
-        },
         "grafana_managed_receiver_configs": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/PostableGrafanaReceiver"
           }
         },
-        "jira_configs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/JiraConfig"
-          }
-        },
-        "msteams_configs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/MSTeamsConfig"
-          }
-        },
-        "msteamsv2_configs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/MSTeamsV2Config"
-          }
-        },
         "name": {
-          "description": "A unique identifier for this receiver.",
+          "type": "string"
+        }
+      }
+    },
+    "PostableApiTemplate": {
+      "description": "nolint:revive",
+      "type": "object",
+      "properties": {
+        "content": {
           "type": "string"
         },
-        "opsgenie_configs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/OpsGenieConfig"
-          }
+        "kind": {
+          "$ref": "#/definitions/TemplateKind"
         },
-        "pagerduty_configs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/PagerdutyConfig"
-          }
-        },
-        "pushover_configs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/PushoverConfig"
-          }
-        },
-        "slack_configs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/SlackConfig"
-          }
-        },
-        "sns_configs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/SNSConfig"
-          }
-        },
-        "telegram_configs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/TelegramConfig"
-          }
-        },
-        "victorops_configs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/VictorOpsConfig"
-          }
-        },
-        "webex_configs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/WebexConfig"
-          }
-        },
-        "webhook_configs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/WebhookConfig"
-          }
-        },
-        "wechat_configs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/WechatConfig"
-          }
+        "name": {
+          "type": "string"
         }
       }
     },
@@ -18765,6 +18749,9 @@
         },
         "uid": {
           "type": "string"
+        },
+        "version": {
+          "type": "string"
         }
       }
     },
@@ -18843,6 +18830,10 @@
             "internal",
             "external"
           ]
+        },
+        "external_alertmanager_uid": {
+          "description": "ExternalAlertmanagerUID is the UID of the Mimir/Cortex Alertmanager datasource to sync\nconfiguration from. Empty string disables sync for this org.",
+          "type": "string"
         }
       }
     },
@@ -18904,6 +18895,18 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/ExtraConfiguration"
+          }
+        },
+        "managed_inhibition_rules": {
+          "$ref": "#/definitions/ManagedInhibitionRules"
+        },
+        "managed_routes": {
+          "$ref": "#/definitions/ManagedRoutes"
+        },
+        "managed_templates": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/PostableApiTemplate"
           }
         },
         "template_files": {
@@ -20390,8 +20393,8 @@
       }
     },
     "Route": {
-      "description": "A Route is a node that contains definitions of how to handle alerts. This is modified\nfrom the upstream alertmanager in that it adds the ObjectMatchers property.",
       "type": "object",
+      "title": "A Route is a node that contains definitions of how to handle alerts.",
       "properties": {
         "active_time_intervals": {
           "type": "array",
@@ -20432,12 +20435,6 @@
           "items": {
             "type": "string"
           }
-        },
-        "object_matchers": {
-          "$ref": "#/definitions/ObjectMatchers"
-        },
-        "provenance": {
-          "$ref": "#/definitions/Provenance"
         },
         "receiver": {
           "type": "string"
@@ -21848,6 +21845,9 @@
     "TempUserStatus": {
       "type": "string"
     },
+    "TemplateKind": {
+      "type": "string"
+    },
     "TestRulePayload": {
       "type": "object",
       "properties": {
@@ -21880,6 +21880,9 @@
           "items": {
             "$ref": "#/definitions/postableAlert"
           }
+        },
+        "kind": {
+          "$ref": "#/definitions/TemplateKind"
         },
         "name": {
           "description": "Name of the template file.",
@@ -22247,11 +22250,52 @@
         }
       }
     },
-    "URL": { 
-			"type": "string", 
-			"format": "url" 
-		},
-		"Unstructured": {
+    "URL": {
+      "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nThe Host field contains the host and port subcomponents of the URL.\nWhen the port is present, it is separated from the host with a colon.\nWhen the host is an IPv6 address, it must be enclosed in square brackets:\n\"[fe80::1]:80\". The [net.JoinHostPort] function combines a host and port\ninto a string suitable for the Host field, adding square brackets to\nthe host when necessary.\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use the [URL.EscapedPath] method, which preserves\nthe original encoding of Path. The Fragment field is also stored in decoded form,\nuse [URL.EscapedFragment] to retrieve the original encoding.\n\nThe [URL.String] method uses the [URL.EscapedPath] method to obtain the path.",
+      "type": "object",
+      "title": "A URL represents a parsed URL (technically, a URI reference).",
+      "properties": {
+        "ForceQuery": {
+          "description": "ForceQuery indicates whether the original URL contained a query ('?') character.\nWhen set, the String method will include a trailing '?', even when RawQuery is empty.",
+          "type": "boolean"
+        },
+        "Fragment": {
+          "type": "string"
+        },
+        "Host": {
+          "type": "string"
+        },
+        "OmitHost": {
+          "description": "OmitHost indicates the URL has an empty host (authority).\nWhen set, the String method will not include the host when it is empty.",
+          "type": "boolean"
+        },
+        "Opaque": {
+          "type": "string"
+        },
+        "Path": {
+          "type": "string"
+        },
+        "RawFragment": {
+          "description": "RawFragment is an optional field containing an encoded fragment hint.\nSee the EscapedFragment method for more details.\n\nIn general, code should call EscapedFragment instead of reading RawFragment.",
+          "type": "string"
+        },
+        "RawPath": {
+          "description": "RawPath is an optional field containing an encoded path hint.\nSee the EscapedPath method for more details.\n\nIn general, code should call EscapedPath instead of reading RawPath.",
+          "type": "string"
+        },
+        "RawQuery": {
+          "description": "RawQuery contains the encoded query values, without the initial '?'.\nUse URL.Query to decode the query.",
+          "type": "string"
+        },
+        "Scheme": {
+          "type": "string"
+        },
+        "User": {
+          "$ref": "#/definitions/Userinfo"
+        }
+      }
+    },
+    "Unstructured": {
       "description": "Unstructured allows objects that do not have Golang structs registered to be manipulated\ngenerically.",
       "type": "object",
       "properties": {
@@ -23080,8 +23124,7 @@
       "properties": {
         "generatorURL": {
           "description": "generator URL\nFormat: uri",
-          "type": "string",
-          "format": "uri"
+          "type": "string"
         },
         "labels": {
           "$ref": "#/definitions/labelSet"
@@ -23183,8 +23226,7 @@
         },
         "uptime": {
           "description": "uptime",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         },
         "versionInfo": {
           "$ref": "#/definitions/versionInfo"
@@ -23265,8 +23307,7 @@
         },
         "endsAt": {
           "description": "ends at",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         },
         "fingerprint": {
           "description": "fingerprint",
@@ -23274,8 +23315,7 @@
         },
         "generatorURL": {
           "description": "generator URL\nFormat: uri",
-          "type": "string",
-          "format": "uri"
+          "type": "string"
         },
         "labels": {
           "$ref": "#/definitions/labelSet"
@@ -23289,16 +23329,14 @@
         },
         "startsAt": {
           "description": "starts at",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         },
         "status": {
           "$ref": "#/definitions/alertStatus"
         },
         "updatedAt": {
           "description": "updated at",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         }
       }
     },
@@ -23344,8 +23382,7 @@
         },
         "endsAt": {
           "description": "ends at",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         },
         "id": {
           "description": "id",
@@ -23359,16 +23396,14 @@
         },
         "startsAt": {
           "description": "starts at",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         },
         "status": {
           "$ref": "#/definitions/silenceStatus"
         },
         "updatedAt": {
           "description": "updated at",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         }
       }
     },
@@ -23402,8 +23437,7 @@
         },
         "endsAt": {
           "description": "ends at",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         },
         "id": {
           "description": "id",
@@ -23414,16 +23448,14 @@
         },
         "startsAt": {
           "description": "starts at",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         },
         "status": {
           "$ref": "#/definitions/silenceStatus"
         },
         "updatedAt": {
           "description": "updated at",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         }
       }
     },
@@ -23535,21 +23567,18 @@
         },
         "endsAt": {
           "description": "ends at\nFormat: date-time",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         },
         "generatorURL": {
           "description": "generator URL\nFormat: uri",
-          "type": "string",
-          "format": "uri"
+          "type": "string"
         },
         "labels": {
           "$ref": "#/definitions/labelSet"
         },
         "startsAt": {
           "description": "starts at\nFormat: date-time",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         }
       }
     },
@@ -23581,8 +23610,7 @@
         },
         "endsAt": {
           "description": "ends at",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         },
         "id": {
           "description": "id",
@@ -23593,8 +23621,7 @@
         },
         "startsAt": {
           "description": "starts at",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         }
       }
     },
@@ -23738,16 +23765,14 @@
         },
         "endsAt": {
           "description": "ends at",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         },
         "matchers": {
           "$ref": "#/definitions/matchers"
         },
         "startsAt": {
           "description": "starts at",
-          "type": "string",
-          "format": "date-time"
+          "type": "string"
         }
       }
     },

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -2756,6 +2756,11 @@
             },
             "type": "array"
           },
+          "policy": {
+            "description": "Name of the notification policy to route alerts through.\nMutually exclusive with all other fields, cannot be used with contact point routing via the \"receiver\" field.",
+            "example": "\"Alerting Team\"",
+            "type": "string"
+          },
           "receiver": {
             "description": "Name of the receiver to send notifications to.",
             "example": "grafana-default-email",
@@ -3943,6 +3948,26 @@
           "$ref": "#/components/schemas/EmbeddedContactPoint"
         },
         "type": "array"
+      },
+      "ConvertAlertmanagerResponse": {
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "errorType": {
+            "type": "string"
+          },
+          "rename_resources": {
+            "$ref": "#/components/schemas/RenameResources"
+          },
+          "stats": {
+            "$ref": "#/components/schemas/MergeStats"
+          },
+          "status": {
+            "type": "string"
+          }
+        },
+        "type": "object"
       },
       "ConvertPrometheusResponse": {
         "properties": {
@@ -5389,7 +5414,6 @@
           },
           "uptime": {
             "description": "uptime",
-            "format": "date-time",
             "type": "string"
           },
           "versionInfo": {
@@ -5412,8 +5436,9 @@
           "identifier": {
             "type": "string"
           },
-          "merge_matchers": {
-            "$ref": "#/components/schemas/Matchers"
+          "managed_by": {
+            "description": "ManagedBy is \"manual\" or \"auto-sync\", computed server-side so callers don't need configs:get\nto tell the two apart.",
+            "type": "string"
           },
           "template_files": {
             "additionalProperties": {
@@ -6180,6 +6205,9 @@
           },
           "uid": {
             "type": "string"
+          },
+          "version": {
+            "type": "string"
           }
         },
         "type": "object"
@@ -6288,7 +6316,6 @@
             "type": "integer"
           },
           "last_applied": {
-            "format": "date-time",
             "type": "string"
           },
           "template_file_provenances": {
@@ -6314,6 +6341,10 @@
               "internal",
               "external"
             ],
+            "type": "string"
+          },
+          "external_alertmanager_uid": {
+            "description": "ExternalAlertmanagerUID is the UID of the Mimir/Cortex Alertmanager datasource being\nsynced, or empty if sync is not configured for this org.",
             "type": "string"
           }
         },
@@ -6383,7 +6414,6 @@
           },
           "uptime": {
             "description": "uptime",
-            "format": "date-time",
             "type": "string"
           },
           "versionInfo": {
@@ -6509,6 +6539,9 @@
             "$ref": "#/components/schemas/URL"
           }
         },
+        "type": "object"
+      },
+      "Gone": {
         "type": "object"
       },
       "HTTPClientConfig": {
@@ -6854,6 +6887,52 @@
         },
         "type": "object"
       },
+      "InhibitionRule": {
+        "description": "It embeds the upstream Alertmanager InhibitRule and adds Grafana-specific fields.",
+        "properties": {
+          "equal": {
+            "description": "A set of labels that must be equal between the source and target alert\nfor them to be a match.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          },
+          "provenance": {
+            "$ref": "#/components/schemas/Provenance"
+          },
+          "source_match": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "SourceMatch defines a set of labels that have to equal the given\nvalue for source alerts. Deprecated. Remove before v1.0 release.",
+            "type": "object"
+          },
+          "source_match_re": {
+            "$ref": "#/components/schemas/MatchRegexps"
+          },
+          "source_matchers": {
+            "$ref": "#/components/schemas/Matchers"
+          },
+          "target_match": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "TargetMatch defines a set of labels that have to equal the given\nvalue for target alerts. Deprecated. Remove before v1.0 release.",
+            "type": "object"
+          },
+          "target_match_re": {
+            "$ref": "#/components/schemas/MatchRegexps"
+          },
+          "target_matchers": {
+            "$ref": "#/components/schemas/Matchers"
+          }
+        },
+        "title": "InhibitionRule is the domain model for inhibition rules with metadata.",
+        "type": "object"
+      },
       "InspectType": {
         "format": "int64",
         "title": "InspectType is a type for the Inspect property of a Notice.",
@@ -6863,7 +6942,6 @@
         "properties": {
           "lastNotifyAttempt": {
             "description": "A timestamp indicating the last attempt to deliver a notification regardless of the outcome.\nFormat: date-time",
-            "format": "date-time",
             "type": "string"
           },
           "lastNotifyAttemptDuration": {
@@ -7016,21 +7094,10 @@
         "format": "int64",
         "type": "integer"
       },
-      "Label": {
-        "properties": {
-          "Name": {
-            "type": "string"
-          }
-        },
-        "title": "Label is a key/value pair of strings.",
-        "type": "object"
-      },
       "Labels": {
-        "description": "Labels is a sorted set of labels. Order has to be guaranteed upon\ninstantiation.",
-        "items": {
-          "$ref": "#/components/schemas/Label"
-        },
-        "type": "array"
+        "description": "Each name and value is preceded by its length, encoded as a single byte\nfor size 0-254, or the following 3 bytes little-endian, if the first byte is 255.\nMaximum length allowed is 2^24 or 16MB.\nNames are in order.",
+        "title": "Labels is implemented by a single flat string holding name/value pairs.",
+        "type": "object"
       },
       "LibraryElementArrayResponse": {
         "properties": {
@@ -7294,6 +7361,19 @@
         },
         "type": "object"
       },
+      "ManagedInhibitionRules": {
+        "additionalProperties": {
+          "$ref": "#/components/schemas/InhibitionRule"
+        },
+        "type": "object"
+      },
+      "ManagedRoutes": {
+        "additionalProperties": {
+          "$ref": "#/components/schemas/Route"
+        },
+        "description": "ManagedRoutes this type exists purely to ensure unmarshalling upstream Routes will call Validate and populate\nGroupBy and GroupByAll. Eventually, we will want this to be a separate type and make the conversion to\ndefinitions.Route explicit.",
+        "type": "object"
+      },
       "ManagerKind": {
         "description": "It can be a user or a tool or a generic API client.\n+enum",
         "title": "ManagerKind is the type of manager, which is responsible for managing the resource.",
@@ -7352,6 +7432,44 @@
           "$ref": "#/components/schemas/Matcher"
         },
         "type": "array"
+      },
+      "MergeStats": {
+        "properties": {
+          "added_inhibition_rules": {
+            "description": "AddedInhibitionRules contains the names of inhibition rules added",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "added_receivers": {
+            "description": "AddedReceivers contains the names of receivers added (post-rename if renamed)",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "added_route": {
+            "description": "AddedRoute is the identifier of the routing sub-tree added to the configuration",
+            "type": "string"
+          },
+          "added_templates": {
+            "description": "AddedTemplates contains the names of templates added",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "added_time_intervals": {
+            "description": "AddedTimeIntervals contains the names of time intervals added (post-rename if renamed)",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "title": "MergeStats describes which resources were added during configuration merge.",
+        "type": "object"
       },
       "Metadata": {
         "additionalProperties": {
@@ -8512,105 +8630,29 @@
       "PostableApiReceiver": {
         "description": "nolint:revive",
         "properties": {
-          "discord_configs": {
-            "items": {
-              "$ref": "#/components/schemas/DiscordConfig"
-            },
-            "type": "array"
-          },
-          "email_configs": {
-            "items": {
-              "$ref": "#/components/schemas/EmailConfig"
-            },
-            "type": "array"
-          },
           "grafana_managed_receiver_configs": {
             "items": {
               "$ref": "#/components/schemas/PostableGrafanaReceiver"
             },
             "type": "array"
           },
-          "jira_configs": {
-            "items": {
-              "$ref": "#/components/schemas/JiraConfig"
-            },
-            "type": "array"
-          },
-          "msteams_configs": {
-            "items": {
-              "$ref": "#/components/schemas/MSTeamsConfig"
-            },
-            "type": "array"
-          },
-          "msteamsv2_configs": {
-            "items": {
-              "$ref": "#/components/schemas/MSTeamsV2Config"
-            },
-            "type": "array"
-          },
           "name": {
-            "description": "A unique identifier for this receiver.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "PostableApiTemplate": {
+        "description": "nolint:revive",
+        "properties": {
+          "content": {
             "type": "string"
           },
-          "opsgenie_configs": {
-            "items": {
-              "$ref": "#/components/schemas/OpsGenieConfig"
-            },
-            "type": "array"
+          "kind": {
+            "$ref": "#/components/schemas/TemplateKind"
           },
-          "pagerduty_configs": {
-            "items": {
-              "$ref": "#/components/schemas/PagerdutyConfig"
-            },
-            "type": "array"
-          },
-          "pushover_configs": {
-            "items": {
-              "$ref": "#/components/schemas/PushoverConfig"
-            },
-            "type": "array"
-          },
-          "slack_configs": {
-            "items": {
-              "$ref": "#/components/schemas/SlackConfig"
-            },
-            "type": "array"
-          },
-          "sns_configs": {
-            "items": {
-              "$ref": "#/components/schemas/SNSConfig"
-            },
-            "type": "array"
-          },
-          "telegram_configs": {
-            "items": {
-              "$ref": "#/components/schemas/TelegramConfig"
-            },
-            "type": "array"
-          },
-          "victorops_configs": {
-            "items": {
-              "$ref": "#/components/schemas/VictorOpsConfig"
-            },
-            "type": "array"
-          },
-          "webex_configs": {
-            "items": {
-              "$ref": "#/components/schemas/WebexConfig"
-            },
-            "type": "array"
-          },
-          "webhook_configs": {
-            "items": {
-              "$ref": "#/components/schemas/WebhookConfig"
-            },
-            "type": "array"
-          },
-          "wechat_configs": {
-            "items": {
-              "$ref": "#/components/schemas/WechatConfig"
-            },
-            "type": "array"
+          "name": {
+            "type": "string"
           }
         },
         "type": "object"
@@ -8695,6 +8737,9 @@
           },
           "uid": {
             "type": "string"
+          },
+          "version": {
+            "type": "string"
           }
         },
         "type": "object"
@@ -8773,6 +8818,10 @@
               "external"
             ],
             "type": "string"
+          },
+          "external_alertmanager_uid": {
+            "description": "ExternalAlertmanagerUID is the UID of the Mimir/Cortex Alertmanager datasource to sync\nconfiguration from. Empty string disables sync for this org.",
+            "type": "string"
           }
         },
         "type": "object"
@@ -8835,6 +8884,18 @@
               "$ref": "#/components/schemas/ExtraConfiguration"
             },
             "type": "array"
+          },
+          "managed_inhibition_rules": {
+            "$ref": "#/components/schemas/ManagedInhibitionRules"
+          },
+          "managed_routes": {
+            "$ref": "#/components/schemas/ManagedRoutes"
+          },
+          "managed_templates": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/PostableApiTemplate"
+            },
+            "type": "object"
           },
           "template_files": {
             "additionalProperties": {
@@ -9840,6 +9901,26 @@
         "properties": {
           "url": {
             "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "RenameResources": {
+        "description": "RenameResources describes which resources were renamed to avoid conflicts",
+        "properties": {
+          "receivers": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Receivers maps old receiver names to new receiver names",
+            "type": "object"
+          },
+          "time_intervals": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "TimeIntervals maps old time interval names to new time interval names",
+            "type": "object"
           }
         },
         "type": "object"
@@ -11778,6 +11859,9 @@
       "TempUserStatus": {
         "type": "string"
       },
+      "TemplateKind": {
+        "type": "string"
+      },
       "TestRulePayload": {
         "properties": {
           "expr": {
@@ -11809,6 +11893,9 @@
               "$ref": "#/components/schemas/postableAlert"
             },
             "type": "array"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/TemplateKind"
           },
           "name": {
             "description": "Name of the template file.",
@@ -13006,7 +13093,6 @@
         "properties": {
           "generatorURL": {
             "description": "generator URL\nFormat: uri",
-            "format": "uri",
             "type": "string"
           },
           "labels": {
@@ -13105,7 +13191,6 @@
           },
           "uptime": {
             "description": "uptime",
-            "format": "date-time",
             "type": "string"
           },
           "versionInfo": {
@@ -13183,7 +13268,6 @@
           },
           "endsAt": {
             "description": "ends at",
-            "format": "date-time",
             "type": "string"
           },
           "fingerprint": {
@@ -13192,7 +13276,6 @@
           },
           "generatorURL": {
             "description": "generator URL\nFormat: uri",
-            "format": "uri",
             "type": "string"
           },
           "labels": {
@@ -13207,7 +13290,6 @@
           },
           "startsAt": {
             "description": "starts at",
-            "format": "date-time",
             "type": "string"
           },
           "status": {
@@ -13215,7 +13297,6 @@
           },
           "updatedAt": {
             "description": "updated at",
-            "format": "date-time",
             "type": "string"
           }
         },
@@ -13261,7 +13342,6 @@
           },
           "endsAt": {
             "description": "ends at",
-            "format": "date-time",
             "type": "string"
           },
           "id": {
@@ -13276,7 +13356,6 @@
           },
           "startsAt": {
             "description": "starts at",
-            "format": "date-time",
             "type": "string"
           },
           "status": {
@@ -13284,7 +13363,6 @@
           },
           "updatedAt": {
             "description": "updated at",
-            "format": "date-time",
             "type": "string"
           }
         },
@@ -13319,7 +13397,6 @@
           },
           "endsAt": {
             "description": "ends at",
-            "format": "date-time",
             "type": "string"
           },
           "id": {
@@ -13331,7 +13408,6 @@
           },
           "startsAt": {
             "description": "starts at",
-            "format": "date-time",
             "type": "string"
           },
           "status": {
@@ -13339,7 +13415,6 @@
           },
           "updatedAt": {
             "description": "updated at",
-            "format": "date-time",
             "type": "string"
           }
         },
@@ -13458,12 +13533,10 @@
           },
           "endsAt": {
             "description": "ends at\nFormat: date-time",
-            "format": "date-time",
             "type": "string"
           },
           "generatorURL": {
             "description": "generator URL\nFormat: uri",
-            "format": "uri",
             "type": "string"
           },
           "labels": {
@@ -13471,7 +13544,6 @@
           },
           "startsAt": {
             "description": "starts at\nFormat: date-time",
-            "format": "date-time",
             "type": "string"
           }
         },
@@ -13500,7 +13572,6 @@
           },
           "endsAt": {
             "description": "ends at",
-            "format": "date-time",
             "type": "string"
           },
           "id": {
@@ -13512,7 +13583,6 @@
           },
           "startsAt": {
             "description": "starts at",
-            "format": "date-time",
             "type": "string"
           }
         },
@@ -13657,7 +13727,6 @@
           },
           "endsAt": {
             "description": "ends at",
-            "format": "date-time",
             "type": "string"
           },
           "matchers": {
@@ -13665,7 +13734,6 @@
           },
           "startsAt": {
             "description": "starts at",
-            "format": "date-time",
             "type": "string"
           }
         },
@@ -25796,6 +25864,16 @@
               }
             },
             "description": "ForbiddenError"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicError"
+                }
+              }
+            },
+            "description": "PublicError"
           }
         },
         "summary": "Create a contact point.",
@@ -25945,6 +26023,16 @@
               }
             },
             "description": "ForbiddenError"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicError"
+                }
+              }
+            },
+            "description": "PublicError"
           }
         },
         "summary": "Delete a contact point.",
@@ -26013,6 +26101,16 @@
               }
             },
             "description": "ForbiddenError"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicError"
+                }
+              }
+            },
+            "description": "PublicError"
           }
         },
         "summary": "Update an existing contact point.",
@@ -26398,6 +26496,16 @@
               }
             },
             "description": "ForbiddenError"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicError"
+                }
+              }
+            },
+            "description": "PublicError"
           }
         },
         "summary": "Create a new mute timing.",
@@ -26814,6 +26922,16 @@
               }
             },
             "description": "ForbiddenError"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicError"
+                }
+              }
+            },
+            "description": "PublicError"
           }
         },
         "summary": "Clears the notification policy tree.",
@@ -26904,6 +27022,16 @@
               }
             },
             "description": "ForbiddenError"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicError"
+                }
+              }
+            },
+            "description": "PublicError"
           }
         },
         "summary": "Sets the notification policy tree.",


### PR DESCRIPTION
## Summary
- Stop the vendored Prometheus Alertmanager REST API (`api/v2/restapi` and other transitively-imported alertmanager/prometheus packages, pulled in via `github.com/grafana/alerting/notify`) from leaking into the ngalert swagger spec's `info` block, paths, and responses. Excludes those packages from go-swagger's codescan while keeping `api/v2/models` scannable, since Grafana aliases several of its own types from there. Removes the now-redundant info-block masking in `clean-swagger`.
- Fix two pre-existing dangling `$ref` bugs found while cross-checking the regenerated spec against the real routes: `ConvertAlertmanagerResponse` was missing its `swagger:model` annotation, and a stray trailing period in a `404: NotFound.` reference in `cortex-ruler.go` broke that response ref. Both were masked from the shipped `api.json` only because neither route carries the `stable` tag.
- Add `409: PublicError` to the notification-provisioning write endpoints (contact-points POST/PUT/DELETE, mute-timings POST, policies PUT/DELETE) that were missing it, matching the existing convention already used on templates and mute-timings PUT/DELETE.

## Test plan
- [x] `make swagger-validate` passes on the merged spec after each commit
- [x] Verified no dangling `$ref`s remain in `api.json`/`post.json`/`spec.json`
- [x] Cross-checked every `swagger:route` annotation in `definitions/*.go` against the generated spec's paths/operationIds — exact match, nothing missing or leaked
- [x] Confirmed the leaked vendor paths (`/alerts`, `/alerts/groups`, `/receivers`, `/silence/{silenceID}`, `/silences`, `/status`) and info-block override (`title`/`description`/`host`/`basePath`/`license`) no longer appear
- [x] Confirmed the 10 affected provisioning routes now carry a 409 response