### PR TITLE
Storybook: Fix background color

### DIFF
--- a/packages/grafana-ui/.storybook/storybookTheme.ts
+++ b/packages/grafana-ui/.storybook/storybookTheme.ts
@@ -9,9 +9,8 @@ export const createStorybookTheme = (theme: GrafanaTheme2) => {
 
     // UI
     appBg: theme.colors.background.canvas,
-    appContentBg: theme.colors.background.primary,
-    appBorderColor: theme.colors.border.medium,
-    appBorderRadius: 0,
+    appContentBg: theme.colors.background.page,
+    appBorderColor: theme.colors.border.weak,
 
     // Typography
     fontBase: theme.typography.fontFamily,

--- a/packages/grafana-ui/src/utils/storybook/withTheme.tsx
+++ b/packages/grafana-ui/src/utils/storybook/withTheme.tsx
@@ -22,10 +22,6 @@ const ThemeableStory = ({ children, handleSassThemeChange, themeId }: React.Prop
   #storybook-root {
     padding: ${theme.spacing(2)};
   }
-
-  body {
-    background: ${theme.colors.background.primary};
-  }
   `;
 
   return (

--- a/packages/grafana-ui/src/utils/storybook/withTheme.tsx
+++ b/packages/grafana-ui/src/utils/storybook/withTheme.tsx
@@ -22,6 +22,10 @@ const ThemeableStory = ({ children, handleSassThemeChange, themeId }: React.Prop
   #storybook-root {
     padding: ${theme.spacing(2)};
   }
+
+  body {
+    background: ${theme.colors.background.page};
+  }
   `;
 
   return (


### PR DESCRIPTION
Fixes the storybook background color so that it's theme.background.page as default (was primary). 

It's good to have the correct background when testing inputs, alerts, cards etc 