### PR TITLE
Alerting: add plugin actions for alert instances

### DIFF
--- a/public/app/features/alerting/unified/components/extensions/AlertInstanceExtensionPoint.tsx
+++ b/public/app/features/alerting/unified/components/extensions/AlertInstanceExtensionPoint.tsx
@@ -1,0 +1,59 @@
+import { type ReactElement, useMemo, useState } from 'react';
+
+import { type PluginExtensionLink, PluginExtensionPoints } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { usePluginLinks } from '@grafana/runtime';
+import { Dropdown, IconButton } from '@grafana/ui';
+import { type Alert, type CombinedRule } from 'app/types/unified-alerting';
+
+import { ConfirmNavigationModal } from './ConfirmationNavigationModal';
+import { AlertingRuleExtensionPointMenu } from './AlertingRuleExtensionPointMenu';
+
+interface Props {
+  rule?: CombinedRule;
+  instance: Alert;
+}
+
+export type PluginExtensionAlertInstanceContext = {
+  rule?: CombinedRule;
+  instance: Alert;
+};
+
+export function AlertInstanceExtensionPoint({ rule, instance }: Props): ReactElement | null {
+  const [selectedExtension, setSelectedExtension] = useState<PluginExtensionLink | undefined>();
+
+  const context = useMemo<PluginExtensionAlertInstanceContext>(() => ({ rule, instance }), [rule, instance]);
+
+  const { links } = usePluginLinks({
+    extensionPointId: PluginExtensionPoints.AlertInstanceAction,
+    context,
+    limitPerPlugin: 3,
+  });
+
+  if (links.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <Dropdown
+        placement="bottom-start"
+        overlay={<AlertingRuleExtensionPointMenu extensions={links} onSelect={setSelectedExtension} />}
+      >
+        <IconButton
+          name="ellipsis-v"
+          aria-label={t('alerting.alert-instance-extension-point.actions', 'Alert instance actions')}
+          variant="secondary"
+        />
+      </Dropdown>
+
+      {!!selectedExtension?.path && (
+        <ConfirmNavigationModal
+          path={selectedExtension.path}
+          title={selectedExtension.title}
+          onDismiss={() => setSelectedExtension(undefined)}
+        />
+      )}
+    </>
+  );
+}

--- a/public/app/features/alerting/unified/components/extensions/AlertInstanceExtensionPoint.tsx
+++ b/public/app/features/alerting/unified/components/extensions/AlertInstanceExtensionPoint.tsx
@@ -5,6 +5,7 @@ import { t } from '@grafana/i18n';
 import { usePluginLinks } from '@grafana/runtime';
 import { Dropdown, IconButton } from '@grafana/ui';
 import { type Alert, type CombinedRule } from 'app/types/unified-alerting';
+import { PromRuleType } from 'app/types/unified-alerting-dto';
 
 import { ConfirmNavigationModal } from './ConfirmationNavigationModal';
 import { AlertingRuleExtensionPointMenu } from './AlertingRuleExtensionPointMenu';
@@ -15,14 +16,47 @@ interface Props {
 }
 
 export type PluginExtensionAlertInstanceContext = {
-  rule?: CombinedRule;
-  instance: Alert;
+  rule?: {
+    name: string;
+    query: string;
+    labels: Record<string, string>;
+    annotations: Record<string, string>;
+    uid?: string;
+  };
+  instance: {
+    activeAt: string;
+    annotations: Record<string, string>;
+    labels: Record<string, string>;
+    state: string;
+    value: string;
+  };
 };
 
 export function AlertInstanceExtensionPoint({ rule, instance }: Props): ReactElement | null {
   const [selectedExtension, setSelectedExtension] = useState<PluginExtensionLink | undefined>();
 
-  const context = useMemo<PluginExtensionAlertInstanceContext>(() => ({ rule, instance }), [rule, instance]);
+  const context = useMemo<PluginExtensionAlertInstanceContext>(() => {
+    const flatRuleData = rule
+      ? {
+          name: rule.name,
+          query: rule.query,
+          labels: rule.labels ?? {},
+          annotations: rule.annotations ?? {},
+          uid: rule.promRule?.uid,
+        }
+      : undefined;
+
+    return {
+      rule: flatRuleData,
+      instance: {
+        activeAt: instance.activeAt,
+        annotations: instance.annotations,
+        labels: instance.labels,
+        state: instance.state,
+        value: instance.value,
+      },
+    };
+  }, [rule, instance]);
 
   const { links } = usePluginLinks({
     extensionPointId: PluginExtensionPoints.AlertInstanceAction,

--- a/public/app/features/alerting/unified/components/extensions/AlertInstanceExtensionPoint.tsx
+++ b/public/app/features/alerting/unified/components/extensions/AlertInstanceExtensionPoint.tsx
@@ -1,14 +1,14 @@
-import { type ReactElement, useMemo, useState } from 'react';
+import { type ReactElement, useEffect, useMemo, useRef, useState } from 'react';
+import { combineLatest } from 'rxjs';
 
 import { type PluginExtensionLink, PluginExtensionPoints } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { usePluginLinks } from '@grafana/runtime';
+import { getObservablePluginLinks, usePluginLinks } from '@grafana/runtime';
 import { Dropdown, IconButton } from '@grafana/ui';
 import { type Alert, type CombinedRule } from 'app/types/unified-alerting';
-import { PromRuleType } from 'app/types/unified-alerting-dto';
 
-import { ConfirmNavigationModal } from './ConfirmationNavigationModal';
 import { AlertingRuleExtensionPointMenu } from './AlertingRuleExtensionPointMenu';
+import { ConfirmNavigationModal } from './ConfirmationNavigationModal';
 
 interface Props {
   rule?: CombinedRule;
@@ -32,37 +32,95 @@ export type PluginExtensionAlertInstanceContext = {
   };
 };
 
-export function AlertInstanceExtensionPoint({ rule, instance }: Props): ReactElement | null {
-  const [selectedExtension, setSelectedExtension] = useState<PluginExtensionLink | undefined>();
-
-  const context = useMemo<PluginExtensionAlertInstanceContext>(() => {
-    const flatRuleData = rule
+/** Build the flat serializable context for a single alert instance. */
+export function buildAlertInstancePluginContext(
+  rule: CombinedRule | undefined,
+  instance: Alert
+): PluginExtensionAlertInstanceContext {
+  return {
+    rule: rule
       ? {
           name: rule.name,
           query: rule.query,
           labels: rule.labels ?? {},
           annotations: rule.annotations ?? {},
-          uid: rule.promRule?.uid,
+          uid: rule.uid,
         }
-      : undefined;
+      : undefined,
+    instance: {
+      activeAt: instance.activeAt,
+      annotations: instance.annotations,
+      labels: instance.labels,
+      state: instance.state,
+      value: instance.value,
+    },
+  };
+}
 
-    return {
-      rule: flatRuleData,
-      instance: {
-        activeAt: instance.activeAt,
-        annotations: instance.annotations,
-        labels: instance.labels,
-        state: instance.state,
-        value: instance.value,
-      },
-    };
-  }, [rule, instance]);
+export function useAlertInstancePluginLinks(rule: CombinedRule | undefined, instance: Alert): PluginExtensionLink[] {
+  const emptyResponse = useRef<PluginExtensionLink[]>([]);
+
+  const context = useMemo<PluginExtensionAlertInstanceContext>(
+    () => buildAlertInstancePluginContext(rule, instance),
+    [rule, instance]
+  );
 
   const { links } = usePluginLinks({
     extensionPointId: PluginExtensionPoints.AlertInstanceAction,
     context,
     limitPerPlugin: 3,
   });
+
+  return links.length > 0 ? links : emptyResponse.current;
+}
+
+/**
+ * Table-level hook: determines whether any of the visible instances has at least one applicable
+ * plugin link.  Uses `getObservablePluginLinks` so that `configure()` is called with the real
+ * per-instance context and the result re-evaluates whenever the extension registry changes.
+ *
+ * Returns { hasLinks, isLoading }.  While isLoading is true the caller should not conclude that
+ * no plugin actions exist.
+ */
+export function useHasAlertInstancePluginLinks(
+  rule: CombinedRule | undefined,
+  instances: Alert[]
+): { hasLinks: boolean; isLoading: boolean } {
+  const [state, setState] = useState<{ hasLinks: boolean; isLoading: boolean }>({
+    hasLinks: false,
+    isLoading: true,
+  });
+
+  useEffect(() => {
+    if (instances.length === 0) {
+      setState({ hasLinks: false, isLoading: false });
+      return;
+    }
+
+    setState((prev) => ({ ...prev, isLoading: true }));
+
+    const observables = instances.map((instance) =>
+      getObservablePluginLinks({
+        extensionPointId: PluginExtensionPoints.AlertInstanceAction,
+        context: buildAlertInstancePluginContext(rule, instance),
+        limitPerPlugin: 3,
+      })
+    );
+
+    const subscription = combineLatest(observables).subscribe((allLinks) => {
+      setState({ hasLinks: allLinks.some((links) => links.length > 0), isLoading: false });
+    });
+
+    return () => subscription.unsubscribe();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rule, instances]);
+
+  return state;
+}
+
+export function AlertInstanceExtensionPoint({ rule, instance }: Props): ReactElement | null {
+  const [selectedExtension, setSelectedExtension] = useState<PluginExtensionLink | undefined>();
+  const links = useAlertInstancePluginLinks(rule, instance);
 
   if (links.length === 0) {
     return null;

--- a/public/app/features/alerting/unified/components/rules/AlertInstancesTable.tsx
+++ b/public/app/features/alerting/unified/components/rules/AlertInstancesTable.tsx
@@ -8,6 +8,7 @@ import { type Alert, type CombinedRule, type PaginationProps } from 'app/types/u
 
 import { alertInstanceKey } from '../../utils/rules';
 import { DynamicTable, type DynamicTableColumnProps, type DynamicTableItemProps } from '../DynamicTable';
+import { AlertInstanceExtensionPoint } from '../extensions/AlertInstanceExtensionPoint';
 
 import { AlertInstanceDetails } from './AlertInstanceDetails';
 import { AlertInstanceNotificationAction } from './AlertInstanceNotificationAction';
@@ -84,6 +85,15 @@ export const AlertInstancesTable = ({ rule, instances, pagination, footerRow, sh
           } satisfies AlertTableColumnProps,
         ]
       : []),
+    {
+      id: 'plugin-actions',
+      label: '',
+      // eslint-disable-next-line react/display-name
+      renderCell: ({ data: { alert, rule } }: AlertTableItemProps) => (
+        <AlertInstanceExtensionPoint rule={rule} instance={alert} />
+      ),
+      size: '40px',
+    },
   ];
 
   return (

--- a/public/app/features/alerting/unified/components/rules/AlertInstancesTable.tsx
+++ b/public/app/features/alerting/unified/components/rules/AlertInstancesTable.tsx
@@ -5,6 +5,8 @@ import { AlertLabels } from '@grafana/alerting/unstable';
 import { dateTime } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { type Alert, type CombinedRule, type PaginationProps } from 'app/types/unified-alerting';
+import { PluginExtensionPoints } from '@grafana/data';
+import { usePluginLinks } from '@grafana/runtime';
 
 import { alertInstanceKey } from '../../utils/rules';
 import { DynamicTable, type DynamicTableColumnProps, type DynamicTableItemProps } from '../DynamicTable';
@@ -39,6 +41,15 @@ export const AlertInstancesTable = ({ rule, instances, pagination, footerRow, sh
       })),
     [instances, rule]
   );
+
+  // Detect if any plugins have registered alert instance actions at all. If none are registered,
+  // we avoid adding the plugin-actions column so the table doesn't reserve an empty 40px column.
+  const { links: anyInstanceActionLinks } = usePluginLinks({
+    extensionPointId: PluginExtensionPoints.AlertInstanceAction,
+    limitPerPlugin: 1,
+  });
+
+  const showPluginActionsColumn = anyInstanceActionLinks.length > 0;
 
   const columns: AlertTableColumnProps[] = [
     {
@@ -85,15 +96,20 @@ export const AlertInstancesTable = ({ rule, instances, pagination, footerRow, sh
           } satisfies AlertTableColumnProps,
         ]
       : []),
-    {
-      id: 'plugin-actions',
-      label: '',
-      // eslint-disable-next-line react/display-name
-      renderCell: ({ data: { alert, rule } }: AlertTableItemProps) => (
-        <AlertInstanceExtensionPoint rule={rule} instance={alert} />
-      ),
-      size: '40px',
-    },
+    // Only include the plugin actions column when there are registered plugins that can provide actions.
+    ...(showPluginActionsColumn
+      ? [
+          {
+            id: 'plugin-actions',
+            label: '',
+            // eslint-disable-next-line react/display-name
+            renderCell: ({ data: { alert, rule } }: AlertTableItemProps) => (
+              <AlertInstanceExtensionPoint rule={rule} instance={alert} />
+            ),
+            size: '40px',
+          },
+        ]
+      : []),
   ];
 
   return (

--- a/public/app/features/alerting/unified/components/rules/AlertInstancesTable.tsx
+++ b/public/app/features/alerting/unified/components/rules/AlertInstancesTable.tsx
@@ -2,11 +2,10 @@ import * as React from 'react';
 import { useMemo } from 'react';
 
 import { AlertLabels } from '@grafana/alerting/unstable';
-import { dateTime } from '@grafana/data';
+import { dateTime, PluginExtensionPoints } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { type Alert, type CombinedRule, type PaginationProps } from 'app/types/unified-alerting';
-import { PluginExtensionPoints } from '@grafana/data';
 import { usePluginLinks } from '@grafana/runtime';
+import { type Alert, type CombinedRule, type PaginationProps } from 'app/types/unified-alerting';
 
 import { alertInstanceKey } from '../../utils/rules';
 import { DynamicTable, type DynamicTableColumnProps, type DynamicTableItemProps } from '../DynamicTable';

--- a/public/app/features/alerting/unified/components/rules/AlertInstancesTable.tsx
+++ b/public/app/features/alerting/unified/components/rules/AlertInstancesTable.tsx
@@ -2,14 +2,13 @@ import * as React from 'react';
 import { useMemo } from 'react';
 
 import { AlertLabels } from '@grafana/alerting/unstable';
-import { dateTime, PluginExtensionPoints } from '@grafana/data';
+import { dateTime } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { usePluginLinks } from '@grafana/runtime';
 import { type Alert, type CombinedRule, type PaginationProps } from 'app/types/unified-alerting';
 
 import { alertInstanceKey } from '../../utils/rules';
 import { DynamicTable, type DynamicTableColumnProps, type DynamicTableItemProps } from '../DynamicTable';
-import { AlertInstanceExtensionPoint } from '../extensions/AlertInstanceExtensionPoint';
+import { AlertInstanceExtensionPoint, useHasAlertInstancePluginLinks } from '../extensions/AlertInstanceExtensionPoint';
 
 import { AlertInstanceDetails } from './AlertInstanceDetails';
 import { AlertInstanceNotificationAction } from './AlertInstanceNotificationAction';
@@ -32,6 +31,8 @@ type AlertTableColumnProps = DynamicTableColumnProps<RuleAndAlert>;
 type AlertTableItemProps = DynamicTableItemProps<RuleAndAlert>;
 
 export const AlertInstancesTable = ({ rule, instances, pagination, footerRow, showNotificationColumn }: Props) => {
+  const { hasLinks: hasPluginLinks, isLoading: isPluginLinksLoading } = useHasAlertInstancePluginLinks(rule, instances);
+
   const items = useMemo(
     (): AlertTableItemProps[] =>
       instances.map((instance) => ({
@@ -40,15 +41,6 @@ export const AlertInstancesTable = ({ rule, instances, pagination, footerRow, sh
       })),
     [instances, rule]
   );
-
-  // Detect if any plugins have registered alert instance actions at all. If none are registered,
-  // we avoid adding the plugin-actions column so the table doesn't reserve an empty 40px column.
-  const { links: anyInstanceActionLinks } = usePluginLinks({
-    extensionPointId: PluginExtensionPoints.AlertInstanceAction,
-    limitPerPlugin: 1,
-  });
-
-  const showPluginActionsColumn = anyInstanceActionLinks.length > 0;
 
   const columns: AlertTableColumnProps[] = [
     {
@@ -95,8 +87,7 @@ export const AlertInstancesTable = ({ rule, instances, pagination, footerRow, sh
           } satisfies AlertTableColumnProps,
         ]
       : []),
-    // Only include the plugin actions column when there are registered plugins that can provide actions.
-    ...(showPluginActionsColumn
+    ...(hasPluginLinks || isPluginLinksLoading
       ? [
           {
             id: 'plugin-actions',
@@ -105,8 +96,7 @@ export const AlertInstancesTable = ({ rule, instances, pagination, footerRow, sh
             renderCell: ({ data: { alert, rule } }: AlertTableItemProps) => (
               <AlertInstanceExtensionPoint rule={rule} instance={alert} />
             ),
-            size: '40px',
-          },
+          } satisfies AlertTableColumnProps,
         ]
       : []),
   ];

--- a/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.test.tsx
@@ -25,6 +25,7 @@ const mocks = {
 
 const ui = {
   stateFilter: byTestId('alert-instance-state-filter'),
+  actionsButton: byLabelText('Alert instance actions'),
   stateButton: byRole('radio'),
   grafanaStateButton: {
     normal: byLabelText(/^Normal/),
@@ -58,6 +59,13 @@ describe('RuleDetailsMatchingInstances', () => {
       ],
       isLoading: false,
     });
+  });
+  it('should render plugin actions for alert instances when extensions are available', () => {
+    const rule = mockCombinedRule();
+
+    render(<RuleDetailsMatchingInstances rule={rule} />);
+
+    expect(ui.actionsButton.getAll()).toHaveLength(rule.promRule.alerts.length);
   });
 
   describe('Filtering', () => {

--- a/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.test.tsx
@@ -60,6 +60,7 @@ describe('RuleDetailsMatchingInstances', () => {
       isLoading: false,
     });
   });
+
   it('should render plugin actions for alert instances when extensions are available', () => {
     const rule = mockCombinedRule();
 

--- a/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.test.tsx
@@ -1,13 +1,15 @@
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { times } from 'lodash';
+import { Subject, of } from 'rxjs';
 import { byLabelText, byRole, byTestId } from 'testing-library-selector';
 
-import { PluginExtensionTypes } from '@grafana/data';
+import { type PluginExtensionLink, PluginExtensionTypes } from '@grafana/data';
 import { usePluginLinks } from '@grafana/runtime';
+import { setGetObservablePluginLinks } from '@grafana/runtime/internal';
 
 import { type CombinedRuleNamespace } from '../../../../../types/unified-alerting';
-import { GrafanaAlertState, PromAlertingRuleState } from '../../../../../types/unified-alerting-dto';
+import { GrafanaAlertState, PromAlertingRuleState, PromRuleType } from '../../../../../types/unified-alerting-dto';
 import { mockCombinedRule, mockDataSource, mockPromAlert, mockPromAlertingRule } from '../../mocks';
 import { alertStateToReadable } from '../../utils/rules';
 
@@ -21,6 +23,18 @@ jest.mock('@grafana/runtime', () => ({
 
 const mocks = {
   usePluginLinksMock: jest.mocked(usePluginLinks),
+};
+
+// Default mock link returned by both usePluginLinks (per-row rendering) and
+// getObservablePluginLinks (table-level column visibility).
+const defaultLink: PluginExtensionLink = {
+  pluginId: 'grafana-ml-app',
+  id: '1',
+  type: PluginExtensionTypes.link,
+  title: 'Run investigation',
+  category: 'Sift',
+  description: 'Run a Sift investigation for this alert',
+  onClick: jest.fn(),
 };
 
 const ui = {
@@ -45,28 +59,129 @@ const ui = {
 
 describe('RuleDetailsMatchingInstances', () => {
   beforeEach(() => {
+    // Per-row rendering: usePluginLinks returns a link by default
     mocks.usePluginLinksMock.mockReturnValue({
-      links: [
-        {
-          pluginId: 'grafana-ml-app',
-          id: '1',
-          type: PluginExtensionTypes.link,
-          title: 'Run investigation',
-          category: 'Sift',
-          description: 'Run a Sift investigation for this alert',
-          onClick: jest.fn(),
-        },
-      ],
+      links: [defaultLink],
       isLoading: false,
     });
+
+    // Table-level column visibility: getObservablePluginLinks returns a link by default
+    setGetObservablePluginLinks(jest.fn().mockReturnValue(of([defaultLink])));
   });
 
   it('should render plugin actions for alert instances when extensions are available', () => {
     const rule = mockCombinedRule();
+    const alerts = rule.promRule?.type === PromRuleType.Alerting ? (rule.promRule.alerts ?? []) : [];
 
     render(<RuleDetailsMatchingInstances rule={rule} />);
 
-    expect(ui.actionsButton.getAll()).toHaveLength(rule.promRule.alerts.length);
+    expect(ui.actionsButton.getAll()).toHaveLength(alerts.length);
+  });
+
+  describe('plugin-actions column visibility', () => {
+    // Case A: no applicable plugin links → column must not appear
+    it('does not render plugin-actions column when no instance has applicable plugin links', async () => {
+      // Both the observable (column visibility) and usePluginLinks (per-row) return no links
+      setGetObservablePluginLinks(jest.fn().mockReturnValue(of([])));
+      mocks.usePluginLinksMock.mockReturnValue({ links: [], isLoading: false });
+
+      const rule = mockCombinedRule();
+      render(<RuleDetailsMatchingInstances rule={rule} />);
+
+      await waitFor(() => {
+        expect(ui.actionsButton.query()).not.toBeInTheDocument();
+      });
+    });
+
+    // Case B: context-dependent link — plugin returns a link only when context matches
+    it('renders plugin action only for the matching instance', async () => {
+      const specialLabel = 'special-instance';
+
+      // getObservablePluginLinks: return a link only for the instance whose labels contain specialLabel
+      setGetObservablePluginLinks(
+        jest.fn().mockImplementation(({ context }) => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const hasSpecialLabel = (context as any)?.instance?.labels?.role === specialLabel;
+          return of(hasSpecialLabel ? [defaultLink] : []);
+        })
+      );
+
+      // usePluginLinks: return a link only for instances whose context matches
+      mocks.usePluginLinksMock.mockImplementation(({ context }) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const hasSpecialLabel = (context as any)?.instance?.labels?.role === specialLabel;
+        return { links: hasSpecialLabel ? [defaultLink] : [], isLoading: false };
+      });
+
+      const rule = mockCombinedRule({
+        promRule: mockPromAlertingRule({
+          alerts: [
+            mockPromAlert({ labels: { alertname: 'a', role: specialLabel } }),
+            mockPromAlert({ labels: { alertname: 'b', role: 'other' } }),
+          ],
+        }),
+      });
+
+      render(<RuleDetailsMatchingInstances rule={rule} />);
+
+      // Column appears because at least one instance has a link
+      await waitFor(() => {
+        expect(ui.actionsButton.getAll()).toHaveLength(1);
+      });
+    });
+
+    // Case C: multiple instances — links resolved per instance
+    it('renders the correct number of plugin actions for multiple matching instances', async () => {
+      const rule = mockCombinedRule({
+        promRule: mockPromAlertingRule({
+          alerts: [
+            mockPromAlert({ labels: { alertname: 'a' } }),
+            mockPromAlert({ labels: { alertname: 'b' } }),
+            mockPromAlert({ labels: { alertname: 'c' } }),
+          ],
+        }),
+      });
+
+      // All instances match
+      setGetObservablePluginLinks(jest.fn().mockReturnValue(of([defaultLink])));
+      mocks.usePluginLinksMock.mockReturnValue({ links: [defaultLink], isLoading: false });
+
+      render(<RuleDetailsMatchingInstances rule={rule} />);
+
+      await waitFor(() => {
+        expect(ui.actionsButton.getAll()).toHaveLength(3);
+      });
+    });
+
+    // Case D: isLoading — column should not be hidden while links are still loading
+    it('preserves plugin-actions column while links are loading', async () => {
+      // Use a Subject that never emits — the observable is pending (loading)
+      const pending$ = new Subject<PluginExtensionLink[]>();
+      setGetObservablePluginLinks(jest.fn().mockReturnValue(pending$));
+
+      // Per-row rendering: return a link (so action buttons appear once column is visible)
+      mocks.usePluginLinksMock.mockReturnValue({ links: [defaultLink], isLoading: true });
+
+      const rule = mockCombinedRule();
+      render(<RuleDetailsMatchingInstances rule={rule} />);
+
+      // While observable hasn't emitted, isLoading=true → column is included defensively
+      // The action buttons come from usePluginLinks (per-row), which does return links
+      await waitFor(() => {
+        const alerts = rule.promRule?.type === PromRuleType.Alerting ? (rule.promRule.alerts ?? []) : [];
+        expect(ui.actionsButton.getAll()).toHaveLength(alerts.length);
+      });
+    });
+
+    // Case E: existing test — plugin actions render for matching instances
+    it('renders plugin actions for all instances when extensions are available (preserved test)', () => {
+      const rule = mockCombinedRule();
+      const alerts = rule.promRule?.type === PromRuleType.Alerting ? (rule.promRule.alerts ?? []) : [];
+
+      render(<RuleDetailsMatchingInstances rule={rule} />);
+
+      expect(ui.actionsButton.getAll()).toHaveLength(alerts.length);
+    });
   });
 
   describe('Filtering', () => {

--- a/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.tsx
@@ -106,11 +106,15 @@ export function RuleDetailsMatchingInstances(props: Props) {
     [promRule, alertState, queryString]
   );
 
+  // Memoize the sliced result so callers receive a stable array reference when
+  // the content has not changed. Without this, every parent re-render produces a
+  // new array from .slice() and unnecessarily re-triggers effects that depend on
+  // the instances identity (e.g. useHasAlertInstancePluginLinks).
+  const visibleInstances = useMemo(() => alerts.slice(0, itemsDisplayLimit), [alerts, itemsDisplayLimit]);
+
   if (!prometheusRuleType.alertingRule(promRule)) {
     return null;
   }
-
-  const visibleInstances = alerts.slice(0, itemsDisplayLimit);
 
   // Count All By State is used only when filtering is enabled and we have access to all instances
   const countAllByState = countBy(promRule.alerts, (alert) => mapStateWithReasonToBaseState(alert.state));


### PR DESCRIPTION
## What does this PR do?

Adds a new extension point for alert instances that allows plugins to provide custom actions for individual alert instances.

This introduces `AlertInstanceExtensionPoint`, which can be used by plugins to extend the actions available for alert instances in the unified alerting UI.

## Why is this needed?

Plugins may need to provide additional actions or integrations for specific alert instances. The existing alerting UI did not provide an extension point for plugins to add such actions.

This change provides a dedicated extension point so plugin-provided alert instance actions can be integrated into the alerting experience without coupling the core UI to individual plugins.

## What does this change?

* Adds `AlertInstanceExtensionPoint`.
* Provides a dedicated extension point for plugin actions associated with alert instances.
* Integrates the extension point into the alert instance UI.
* Keeps the extension mechanism reusable for plugins that need to provide custom alert instance actions.

## Testing

* Verified the changes locally.
* Existing Grafana checks/tests should validate the affected alerting components.

## Screenshots / Videos

N/A — this change adds an extension point for plugin-provided actions and does not introduce a standalone visual change.

## Checklist

* [x] I have performed a self-review of my own code.
* [x] I have tested the changes locally.
* [x] I have added/updated relevant documentation where necessary.
* [x] I have considered potential backwards compatibility concerns.
