### PR TITLE
Chore: fix eslint suppressions — require-no-margin in CloudEvaluationBehavior

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1078,11 +1078,6 @@
       "count": 3
     }
   },
-  "public/app/features/alerting/unified/components/rule-editor/CloudEvaluationBehavior.tsx": {
-    "@grafana/require-no-margin": {
-      "count": 2
-    }
-  },
   "public/app/features/alerting/unified/components/rule-editor/ExpressionEditor.tsx": {
     "@grafana/no-get-data-source-srv": {
       "count": 1

--- a/public/app/features/alerting/unified/components/rule-editor/CloudEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/CloudEvaluationBehavior.tsx
@@ -1,9 +1,7 @@
-import { css } from '@emotion/css';
 import { Controller, useFormContext } from 'react-hook-form';
 
-import { type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { Field, Input, Select, useStyles2 } from '@grafana/ui';
+import { Box, Field, Input, Select, Stack } from '@grafana/ui';
 
 import { RuleFormType, type RuleFormValues } from '../../types/rule-form';
 import { timeOptions } from '../../utils/time';
@@ -13,7 +11,6 @@ import { PreviewRule } from './PreviewRule';
 import { RuleEditorSection } from './RuleEditorSection';
 
 export const CloudEvaluationBehavior = () => {
-  const styles = useStyles2(getStyles);
   const {
     register,
     control,
@@ -29,43 +26,40 @@ export const CloudEvaluationBehavior = () => {
       stepNo={3}
       title={t('alerting.cloud-evaluation-behavior.title-set-evaluation-behavior', 'Set evaluation behavior')}
     >
-      <Field
-        label={t('alerting.cloud-evaluation-behavior.label-pending-period', 'Pending period')}
-        description={t(
-          'alerting.cloud-evaluation-behavior.description-pending-period',
-          'Period during which the threshold condition must be met to trigger an alert. Selecting "None" triggers the alert immediately once the condition is met.'
-        )}
-      >
-        <div className={styles.flexRow}>
-          <Field invalid={!!errors.forTime?.message} error={errors.forTime?.message} className={styles.inlineField}>
-            <Input
-              {...register('forTime', {
-                pattern: {
-                  value: /^\d+$/,
-                  message: t(
-                    'alerting.cloud-evaluation-behavior.message.must-be-a-positive-integer',
-                    'Must be a positive integer.'
-                  ),
-                },
-              })}
-              width={8}
-            />
-          </Field>
-          <Controller
-            name="forTimeUnit"
-            render={({ field: { onChange, ref, ...field } }) => (
-              <Select
-                {...field}
-                options={timeOptions}
-                onChange={(value) => onChange(value?.value)}
-                width={15}
-                className={styles.timeUnit}
+      <Box marginBottom={2}>
+        <Field
+          noMargin
+          label={t('alerting.cloud-evaluation-behavior.label-pending-period', 'Pending period')}
+          description={t(
+            'alerting.cloud-evaluation-behavior.description-pending-period',
+            'Period during which the threshold condition must be met to trigger an alert. Selecting "None" triggers the alert immediately once the condition is met.'
+          )}
+        >
+          <Stack direction="row" gap={0.5} alignItems="flex-start">
+            <Field noMargin invalid={!!errors.forTime?.message} error={errors.forTime?.message}>
+              <Input
+                {...register('forTime', {
+                  pattern: {
+                    value: /^\d+$/,
+                    message: t(
+                      'alerting.cloud-evaluation-behavior.message.must-be-a-positive-integer',
+                      'Must be a positive integer.'
+                    ),
+                  },
+                })}
+                width={8}
               />
-            )}
-            control={control}
-          />
-        </div>
-      </Field>
+            </Field>
+            <Controller
+              name="forTimeUnit"
+              render={({ field: { onChange, ref, ...field } }) => (
+                <Select {...field} options={timeOptions} onChange={(value) => onChange(value?.value)} width={15} />
+              )}
+              control={control}
+            />
+          </Stack>
+        </Field>
+      </Box>
       {type === RuleFormType.cloudAlerting && dataSourceName && (
         <GroupAndNamespaceFields rulesSourceName={dataSourceName} />
       )}
@@ -74,18 +68,3 @@ export const CloudEvaluationBehavior = () => {
     </RuleEditorSection>
   );
 };
-
-const getStyles = (theme: GrafanaTheme2) => ({
-  inlineField: css({
-    marginBottom: 0,
-  }),
-  flexRow: css({
-    display: 'flex',
-    flexDirection: 'row',
-    justifyContent: 'flex-start',
-    alignItems: 'flex-start',
-  }),
-  timeUnit: css({
-    marginLeft: theme.spacing(0.5),
-  }),
-});


### PR DESCRIPTION
**What is this feature?**

Removes the two `@grafana/require-no-margin` suppressions in `CloudEvaluationBehavior.tsx`, following the same approach as #131007 and #131126.

- Both `Field`s get `noMargin`. The inner one was already cancelling its margin with a `marginBottom: 0` class, so that class goes away.
- The outer field's spacing moves to `<Box marginBottom={2}>`, which is the same amount `Field` was applying itself (`theme.spacing(2)`), so the layout is unchanged whether or not the group/namespace fields are rendered.
- The flex row and the select's `marginLeft` become a `<Stack gap={0.5} alignItems="flex-start">`, which leaves the component with no styles of its own, so `useStyles2` and `getStyles` are gone.

**Why do we need this feature?**

`Field`'s built-in margin is being retired in favour of layout components, and this file was one of the remaining suppressions. Net effect here is 26 fewer lines and one less bespoke flex container in the rule editor.

**Who is this feature for?**

Grafana developers.

**Which issue(s) does this PR fix?**

No issue, this is part of the eslint-suppressions burn-down.

**Special notes for your reviewer:**

`yarn eslint`, `yarn prettier --check` and `yarn typecheck` are clean, and `yarn jest public/app/features/alerting/unified/components/rule-editor` passes (235 tests). The spacing is meant to be pixel-identical, so it's worth a quick look at the "Set evaluation behavior" step of a Mimir/Loki rule to confirm nothing shifted.
