### PR TITLE
Transformations: Prevent stale help content while loading

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/TransformationHelpDisplay.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/TransformationHelpDisplay.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import type { DataTransformerInfo, TransformerRegistryItem } from '@grafana/data';
@@ -6,6 +6,7 @@ import { selectors } from '@grafana/e2e-selectors';
 import { getTransformationContent } from 'app/features/transformers/docs/getTransformationContent';
 
 import { TransformationHelpDisplay } from './TransformationHelpDisplay';
+import * as QueryEditorContext from './QueryEditorContext';
 import { mockTransformToggles, renderWithQueryEditorProvider } from './testUtils';
 import type { Transformation } from './types';
 
@@ -45,6 +46,10 @@ describe('TransformationHelpDisplay', () => {
       name: 'Test Transform',
       helperDocs: 'Test help content',
     });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it('does not render when showHelp is false', () => {
@@ -94,6 +99,43 @@ describe('TransformationHelpDisplay', () => {
 
     expect(mockGetTransformationContent).toHaveBeenCalledWith('test-transform');
     await screen.findByText('Test help content');
+  });
+
+  it('does not show help from the previous transformation while new help loads', async () => {
+    const nextRegistryItem = {
+      ...mockRegistryItem,
+      id: 'next-transform',
+      name: 'Next Transform',
+    };
+    let resolveNextHelp!: (content: { name: string; helperDocs: string }) => void;
+
+    mockGetTransformationContent.mockImplementation(id => {
+      if (id === mockRegistryItem.id) {
+        return Promise.resolve({ name: mockRegistryItem.name, helperDocs: 'Previous help content' });
+      }
+
+      return new Promise(resolve => {
+        resolveNextHelp = resolve;
+      });
+    });
+
+    const context = {
+      selectedTransformation: makeTransformation(),
+      transformToggles: { ...mockTransformToggles, showHelp: true },
+    } as ReturnType<typeof QueryEditorContext.useQueryEditorUIContext>;
+    const contextSpy = jest.spyOn(QueryEditorContext, 'useQueryEditorUIContext').mockReturnValue(context);
+    const { rerender } = render(<TransformationHelpDisplay />);
+
+    await screen.findByText('Previous help content');
+
+    context.selectedTransformation = makeTransformation(nextRegistryItem);
+    rerender(<TransformationHelpDisplay />);
+
+    expect(screen.queryByText('Previous help content')).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /transformation documentation/i })).toBeInTheDocument();
+
+    resolveNextHelp({ name: nextRegistryItem.name, helperDocs: 'Next help content' });
+    await screen.findByText('Next help content');
   });
 
   it('shows fallback content when fetch fails', async () => {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/TransformationHelpDisplay.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/TransformationHelpDisplay.tsx
@@ -7,12 +7,15 @@ import { getTransformationContent } from 'app/features/transformers/docs/getTran
 
 import { useQueryEditorUIContext } from './QueryEditorContext';
 
+const fallbackHelpHtml = renderMarkdown(FALLBACK_DOCS_LINK);
+
 /**
  * Displays transformation help in a drawer when toggled from the actions menu.
  */
 export function TransformationHelpDisplay() {
   const { selectedTransformation, transformToggles } = useQueryEditorUIContext();
-  const [helpHtml, setHelpHtml] = useState<string>(renderMarkdown(FALLBACK_DOCS_LINK));
+  const transformationId = selectedTransformation?.registryItem?.id;
+  const [helpContent, setHelpContent] = useState<{ transformationId: string; html: string }>();
 
   useEffect(() => {
     if (!transformToggles.showHelp || !selectedTransformation?.registryItem) {
@@ -21,15 +24,17 @@ export function TransformationHelpDisplay() {
 
     let cancelled = false;
 
-    getTransformationContent(selectedTransformation.registryItem.id)
+    const requestedTransformationId = selectedTransformation.registryItem.id;
+
+    getTransformationContent(requestedTransformationId)
       .then(({ helperDocs }) => {
         if (!cancelled) {
-          setHelpHtml(renderMarkdown(helperDocs));
+          setHelpContent({ transformationId: requestedTransformationId, html: renderMarkdown(helperDocs) });
         }
       })
       .catch(() => {
         if (!cancelled) {
-          setHelpHtml(renderMarkdown(FALLBACK_DOCS_LINK));
+          setHelpContent({ transformationId: requestedTransformationId, html: fallbackHelpHtml });
         }
       });
 
@@ -41,6 +46,8 @@ export function TransformationHelpDisplay() {
   if (!transformToggles.showHelp || !selectedTransformation?.registryItem) {
     return null;
   }
+
+  const helpHtml = helpContent?.transformationId === transformationId ? helpContent.html : fallbackHelpHtml;
 
   return (
     <Drawer


### PR DESCRIPTION
**What is this feature?**

This change keeps loaded transformation help associated with the transformation it belongs to. When a user switches transformations while the next help document is loading, the drawer now shows the fallback documentation link instead of content from the previous transformation.

A focused React Testing Library regression test covers switching transformations while the second help request remains pending.

**Why do we need this feature?**

The drawer title updates immediately when a different transformation is selected, but the previous help body remained visible until the new asynchronous request resolved. This could pair one transformation's title with another transformation's documentation.

**Who is this feature for?**

Dashboard authors who configure transformations and use the transformation help drawer.

**Which issue(s) does this PR fix?**:

Fixes #130946

**Special notes for your reviewer:**

- The implementation stores the transformation id together with the rendered help HTML, so stale content is excluded during render rather than reset after paint.
- Local tests were not run; the focused regression test is included for CI.
- This change was prepared with assistance from OpenAI Codex and reviewed by the contributor before submission.

Please check that:
- [ ] It works as expected from a user's perspective.
- [x] This is not a pre-GA feature or configuration option.
- [x] No documentation update is needed because this corrects existing UI behavior.
