### PR TITLE
Dashboards: keep row options open when closing repeat selector

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
@@ -863,13 +863,29 @@ describe('Combobox', () => {
   });
 
   describe('Escape key behavior in overlays', () => {
-    it('should not close a Modal when pressing Escape while the menu is open', async () => {
-      const onDismiss = jest.fn();
-      render(
-        <Modal title="Test Modal" isOpen onDismiss={onDismiss}>
+    function ModalWithCombobox({ onDismiss }: { onDismiss: () => void }) {
+      const [open, setOpen] = React.useState(true);
+      if (!open) {
+        return null;
+      }
+
+      return (
+        <Modal
+          title="Test Modal"
+          isOpen
+          onDismiss={() => {
+            onDismiss();
+            setOpen(false);
+          }}
+        >
           <Combobox options={options} value={null} onChange={jest.fn()} />
         </Modal>
       );
+    }
+
+    it('should not close a Modal when pressing Escape while the menu is open', async () => {
+      const onDismiss = jest.fn();
+      render(<ModalWithCombobox onDismiss={onDismiss} />);
 
       // Modal auto-focuses the close button on open — wait for focus to settle
       await waitFor(() => expect(screen.getByRole('button', { name: 'Close' })).toHaveFocus());
@@ -877,9 +893,39 @@ describe('Combobox', () => {
       const input = screen.getByRole('combobox');
       await user.click(input);
       expect(await screen.findByRole('option', { name: 'Option 1' })).toBeInTheDocument();
+      expect(input).toHaveAttribute('aria-expanded', 'true');
 
       await user.keyboard('{Escape}');
+
+      await waitFor(() => {
+        expect(screen.queryByRole('option', { name: 'Option 1' })).not.toBeInTheDocument();
+      });
+      expect(input).toHaveAttribute('aria-expanded', 'false');
+      expect(input).toHaveFocus();
+      expect(screen.getByRole('dialog', { name: 'Test Modal' })).toBeInTheDocument();
       expect(onDismiss).not.toHaveBeenCalled();
+    });
+
+    it('should close a Modal on a subsequent Escape after the menu closes', async () => {
+      const onDismiss = jest.fn();
+      render(<ModalWithCombobox onDismiss={onDismiss} />);
+
+      await waitFor(() => expect(screen.getByRole('button', { name: 'Close' })).toHaveFocus());
+
+      const input = screen.getByRole('combobox');
+      await user.click(input);
+      expect(await screen.findByRole('option', { name: 'Option 1' })).toBeInTheDocument();
+
+      await user.keyboard('{Escape}');
+      await waitFor(() => {
+        expect(screen.queryByRole('option', { name: 'Option 1' })).not.toBeInTheDocument();
+      });
+      expect(onDismiss).not.toHaveBeenCalled();
+      expect(input).toHaveFocus();
+
+      await user.keyboard('{Escape}');
+      expect(onDismiss).toHaveBeenCalledTimes(1);
+      expect(screen.queryByRole('dialog', { name: 'Test Modal' })).not.toBeInTheDocument();
     });
 
     it('should not close a Drawer when pressing Escape while the menu is open', async () => {

--- a/public/app/features/dashboard-scene/scene/layout-default/row-actions/RowOptionsModal.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/row-actions/RowOptionsModal.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { useState } from 'react';
+import { TestProvider } from 'test/helpers/TestProvider';
+import { userEvent } from 'test/test-utils';
+
+import { CustomVariable, SceneVariableSet } from '@grafana/scenes';
+import { mockComboboxRect } from '@grafana/test-utils';
+
+import { activateFullSceneTree } from '../../../utils/test-utils';
+import { DashboardScene } from '../../DashboardScene';
+
+import { RowOptionsModal } from './RowOptionsModal';
+
+function renderRowOptions() {
+  const scene = new DashboardScene({
+    title: 'hello',
+    uid: 'dash-1',
+    meta: {
+      canEdit: true,
+    },
+    $variables: new SceneVariableSet({
+      variables: [
+        new CustomVariable({
+          name: 'testVar',
+          query: 'a,b',
+          value: 'a',
+          text: 'a',
+        }),
+      ],
+    }),
+  });
+
+  activateFullSceneTree(scene);
+
+  const onDismiss = jest.fn();
+  const user = userEvent.setup();
+
+  function Harness() {
+    const [open, setOpen] = useState(true);
+    if (!open) {
+      return null;
+    }
+
+    return (
+      <TestProvider>
+        <RowOptionsModal
+          title="Row 1"
+          parent={scene}
+          onDismiss={() => {
+            onDismiss();
+            setOpen(false);
+          }}
+          onUpdate={jest.fn()}
+          isUsingDashboardDS={false}
+        />
+      </TestProvider>
+    );
+  }
+
+  render(<Harness />);
+  return { user, onDismiss };
+}
+
+describe('RowOptionsModal', () => {
+  beforeAll(() => {
+    mockComboboxRect();
+  });
+
+  it('closes only Repeat for on Escape and keeps Row options open', async () => {
+    const { user, onDismiss } = renderRowOptions();
+
+    const dialog = screen.getByRole('dialog', { name: 'Row options' });
+    expect(dialog).toBeInTheDocument();
+
+    // Modal auto-focuses the close button on open — wait for focus to settle
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Close' })).toHaveFocus());
+
+    const combobox = screen.getByRole('combobox', { name: 'Repeat for' });
+    await user.click(combobox);
+
+    expect(await screen.findByRole('option', { name: 'testVar' })).toBeInTheDocument();
+    expect(combobox).toHaveAttribute('aria-expanded', 'true');
+
+    await user.keyboard('{Escape}');
+
+    await waitFor(() => {
+      expect(screen.queryByRole('option', { name: 'testVar' })).not.toBeInTheDocument();
+    });
+    expect(combobox).toHaveAttribute('aria-expanded', 'false');
+    expect(combobox).toHaveFocus();
+    expect(dialog).toBeInTheDocument();
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('closes Row options on Escape when Repeat for is not open', async () => {
+    const { user, onDismiss } = renderRowOptions();
+
+    expect(screen.getByRole('dialog', { name: 'Row options' })).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Close' })).toHaveFocus());
+
+    await user.keyboard('{Escape}');
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('dialog', { name: 'Row options' })).not.toBeInTheDocument();
+  });
+
+  it('closes Row options on a second Escape after Repeat for closes', async () => {
+    const { user, onDismiss } = renderRowOptions();
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Close' })).toHaveFocus());
+
+    const combobox = screen.getByRole('combobox', { name: 'Repeat for' });
+    await user.click(combobox);
+    expect(await screen.findByRole('option', { name: 'testVar' })).toBeInTheDocument();
+
+    await user.keyboard('{Escape}');
+    await waitFor(() => {
+      expect(screen.queryByRole('option', { name: 'testVar' })).not.toBeInTheDocument();
+    });
+    expect(onDismiss).not.toHaveBeenCalled();
+    expect(combobox).toHaveFocus();
+
+    await user.keyboard('{Escape}');
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('dialog', { name: 'Row options' })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
**What is this feature?**

Regression tests for nested Escape handling in Row options. Opening Repeat for and pressing Escape must close only the combobox. The Row options modal stays open, focus returns to the combobox, and `aria-expanded` is false. A later Escape still dismisses Row options.

**Why do we need this feature?**

Keyboard users lost the Row options dialog when they used Escape to collapse Repeat for. The same Escape event was reaching the parent Modal.

**Who is this feature for?**

Keyboard and screen reader users editing dashboard rows.

**Which issue(s) does this PR fix?**:

Fixes #72806

**Special notes for your reviewer:**

Row options renders Repeat for as `Combobox` inside `Modal`. `Modal` uses floating-ui `useDismiss`, which listens for Escape on the dialog node and on `document`. It does not check `defaultPrevented` and Combobox is not in a FloatingTree, so the child must stop the event.

`Combobox` already calls `stopPropagation()` for Escape while the menu is open (`#122133`). That is the correct boundary: only the open listbox consumes Escape, then a following Escape can dismiss Row options. Downshift still receives the key on the same input, so the menu closes and focus stays on the combobox. Assistive tech still sees `aria-expanded` flip to false.

This PR does not change that handler. It pins the Row options flow and tightens the Combobox overlay tests so they assert the menu closed, expanded state, restored focus, and that the parent still dismisses on a second Escape.

Removing the Combobox `stopPropagation` makes these tests fail.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

**Validation**

- `yarn prettier --write` on the changed files
- `yarn eslint` on the changed files
- `yarn jest --watchAll=false packages/grafana-ui/src/components/Combobox/Combobox.test.tsx public/app/features/dashboard-scene/scene/layout-default/row-actions/RowOptionsModal.test.tsx public/app/features/dashboard-scene/scene/layout-default/row-actions/RowOptionsForm.test.tsx`
- `yarn jest --watchAll=false public/app/features/dashboard/components/RepeatRowSelect/RepeatRowSelect.test.tsx packages/grafana-ui/src/components/Modal/Modal.test.tsx`