### PR TITLE
Docs: remove stale grafanactl archive date

### DIFF
--- a/docs/sources/as-code/observability-as-code/grafana-cli/grafanactl/_index.md
+++ b/docs/sources/as-code/observability-as-code/grafana-cli/grafanactl/_index.md
@@ -27,7 +27,7 @@ aliases:
 
 {{< admonition type="caution" >}}
 
-`grafanactl` is being deprecated, and we're bringing all our learning and experience into the new, improved CLI tool [`gcx`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/grafana-cli/gcx). The `grafanactl` repository in GitHub will be archived on June 1, 2026.
+`grafanactl` is being deprecated, and we're bringing all our learning and experience into the new, improved CLI tool [`gcx`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/grafana-cli/gcx). The `grafanactl` repository in GitHub is scheduled to be archived; check the [repository](https://github.com/grafana/grafanactl) for its current status.
 
 To migrate from `grafanactl` to `gcx`, search-and-replace `grafanactl` with `gcx`. For `grafanactl resources serve`, use `gcx dev serve` instead.
 

--- a/docs/sources/as-code/observability-as-code/grafana-cli/grafanactl/grafanacli-workflows.md
+++ b/docs/sources/as-code/observability-as-code/grafana-cli/grafanactl/grafanacli-workflows.md
@@ -24,7 +24,7 @@ aliases:
 
 {{< admonition type="caution" >}}
 
-`grafanactl` is being deprecated, and we're bringing all our learning and experience into the new, improved CLI tool [`gcx`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/grafana-cli/gcx). The `grafanactl` repository in GitHub will be archived on June 1, 2026.
+`grafanactl` is being deprecated, and we're bringing all our learning and experience into the new, improved CLI tool [`gcx`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/grafana-cli/gcx). The `grafanactl` repository in GitHub is scheduled to be archived; check the [repository](https://github.com/grafana/grafanactl) for its current status.
 
 To migrate from `grafanactl` to `gcx`, search-and-replace `grafanactl` with `gcx`. For `grafanactl resources serve`, use `gcx dev serve` instead.
 


### PR DESCRIPTION
## What is this feature?

The deprecation admonition on both `grafanactl` pages currently reads:

> The `grafanactl` repository in GitHub will be archived on June 1, 2026.

That date is nearly three months in the past, and the repository is not archived. `grafana/grafanactl` reports `"archived": false` and had commits as recently as **2026-08-22**.

So a reader landing on either page today is told, in a caution admonition, that a tool they may be actively running was retired months ago. The two plausible readings — "this is already dead, stop using it" and "the docs are stale, so maybe the deprecation isn't real either" — are both wrong and both unhelpful.

This replaces the fixed date with a pointer to the repository, so the notice stays true whenever the archive actually happens:

> The `grafanactl` repository in GitHub is scheduled to be archived; check the [repository](https://github.com/grafana/grafanactl) for its current status.

**I deliberately did not invent a new date.** I have no way to know whether the archive was postponed, cancelled, or is imminent. If there's a revised date, it belongs here instead of my wording and I'll happily change it — that's a better fix than mine.

## Why do we need this feature?

The rest of the admonition is genuinely useful — the `gcx` migration instruction is one line and does the job. The stale date is the only part that misinforms, and it undercuts the credibility of the advice next to it.

## Which issue(s) does this PR fix?

None — found while verifying [#127015](https://github.com/grafana/grafana/issues/127015), which I've commented on separately as already resolved.

## Special notes for your reviewer

The same sentence with the same date is also in [`grafana/grafanactl`'s README](https://github.com/grafana/grafanactl/blob/main/README.md), which I can't fix from this repo. Worth a follow-up there.

Both changed files are `docs/sources/as-code/observability-as-code/grafana-cli/grafanactl/` — `_index.md` and `grafanacli-workflows.md`. Identical one-sentence change in each.
