### PR TITLE
Timeseries: Skip null timestamps in OutsideRangePlugin to prevent zoom crash

### DIFF
--- a/public/app/plugins/panel/timeseries/plugins/OutsideRangePlugin.test.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/OutsideRangePlugin.test.tsx
@@ -195,5 +195,38 @@ describe('OutsideRangePlugin', () => {
       applyScale([[1, 2, 3]], { x: { time: true, min: 2000, max: 3000 } });
       expect(container).toBeEmptyDOMElement();
     });
+
+    it('handles null time cells and zooms to valid data points', async () => {
+      const onChangeTimeRange = jest.fn();
+      const { getByText } = renderPlugin(onChangeTimeRange);
+
+      applyScale(
+        [
+          [null as unknown as number, 1000, 2000, 3000, null as unknown as number],
+          [10, 20, 30, 40, 50],
+        ],
+        { x: { time: true, min: 4000, max: 5000 } }
+      );
+
+      expect(getByText('Data outside time range')).toBeInTheDocument();
+
+      const button = getByText('Zoom to data');
+      await userEvent.click(button);
+      expect(onChangeTimeRange).toHaveBeenCalledWith({ from: 1000, to: 3000 });
+    });
+
+    it('does not render when all time cells are null', () => {
+      const { container } = renderPlugin();
+
+      applyScale(
+        [
+          [null as unknown as number, null as unknown as number],
+          [1, 2],
+        ],
+        { x: { time: true, min: 4000, max: 5000 } }
+      );
+
+      expect(container).toBeEmptyDOMElement();
+    });
   });
 });

--- a/public/app/plugins/panel/timeseries/plugins/OutsideRangePlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/OutsideRangePlugin.tsx
@@ -49,16 +49,16 @@ export const OutsideRangePlugin = memo(({ config, onChangeTimeRange }: Threshold
   let i = 0,
     j = timeValues.length - 1;
 
-  while (i <= j && allValuesNullAtIndex(i)) {
+  while (i <= j && (timeValues[i] == null || allValuesNullAtIndex(i))) {
     i++;
   }
 
-  while (j >= 0 && allValuesNullAtIndex(j)) {
+  while (j >= 0 && (timeValues[j] == null || allValuesNullAtIndex(j))) {
     j--;
   }
 
-  // never found any non null values
-  if (allValuesNullAtIndex(i) || allValuesNullAtIndex(j)) {
+  // never found any valid points with non-null time and value
+  if (i > j || timeValues[i] == null || timeValues[j] == null) {
     return null;
   }
 


### PR DESCRIPTION
Fixes #130379

### Summary of Changes

1. **Root Cause**:
   - In `public/app/plugins/panel/timeseries/plugins/OutsideRangePlugin.tsx` (used across Timeseries, State Timeline, Status History, Heatmap, and Candlestick panels), PR #117278 updated the boundary scan loop to check `allValuesNullAtIndex(i)` instead of checking for null timestamps in `timeValues[i]`.
   - When queries return rows containing `null` time cells (such as SQL left joins or sparse series), `allValuesNullAtIndex(i)` returns `false` because the value column at index `i` is non-null. The scan loop stops on the null time cell, assigning `first = timeValues[i]` as `undefined`.
   - The range check `(first <= timeRange.max && last >= timeRange.min)` evaluates to `false` (since `undefined <= max` is false), causing the "Zoom to data" button to render with `{ from: undefined, to: last }`. Clicking the button passes `undefined` to the time range service, crashing with `TypeError: Cannot read properties of undefined (reading 'valueOf')`.

2. **Fix**:
   - Updated the scan while loops in `OutsideRangePlugin.tsx` to skip both null timestamps and all-null series values: `while (i <= j && (timeValues[i] == null || allValuesNullAtIndex(i)))`.
   - Added early return if no valid points with non-null timestamps exist (`if (i > j || timeValues[i] == null || timeValues[j] == null) return null;`), ensuring `first` and `last` are guaranteed non-null timestamps.
   - Added unit tests in `OutsideRangePlugin.test.tsx` covering datasets with leading/trailing null time cells as well as all-null time data.

### Validation

- `yarn test public/app/plugins/panel/timeseries/plugins/OutsideRangePlugin.test.tsx`: 13/13 tests passed.
- Prettier style checks verified.