### PR TITLE
ValueMappings: Allow editing negative bounds in range mappings

### DIFF
--- a/public/app/features/dimensions/editors/ValueMappingsEditor/ValueMappingEditRow.tsx
+++ b/public/app/features/dimensions/editors/ValueMappingsEditor/ValueMappingEditRow.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { Draggable } from '@hello-pangea/dnd';
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import * as React from 'react';
 
 import {
@@ -41,6 +41,19 @@ export function ValueMappingEditRow({ mapping, index, onChange, onRemove, onDupl
   const { key, result, id } = mapping;
   const styles = useStyles2(getStyles);
   const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const [fromString, setFromString] = useState(
+    mapping.from != null && !Number.isNaN(mapping.from) ? String(mapping.from) : ''
+  );
+  const [toString, setToString] = useState(mapping.to != null && !Number.isNaN(mapping.to) ? String(mapping.to) : '');
+
+  useEffect(() => {
+    setFromString(mapping.from != null && !Number.isNaN(mapping.from) ? String(mapping.from) : '');
+  }, [mapping.from]);
+
+  useEffect(() => {
+    setToString(mapping.to != null && !Number.isNaN(mapping.to) ? String(mapping.to) : '');
+  }, [mapping.to]);
 
   const update = useCallback(
     (fn: (item: ValueMappingEditRowModel) => void) => {
@@ -102,14 +115,20 @@ export function ValueMappingEditRow({ mapping, index, onChange, onRemove, onDupl
   };
 
   const onChangeFrom = (event: React.FormEvent<HTMLInputElement>) => {
+    const val = event.currentTarget.value;
+    setFromString(val);
+    const parsed = parseFloat(val);
     update((mapping) => {
-      mapping.from = parseFloat(event.currentTarget.value);
+      mapping.from = val.trim() === '' || Number.isNaN(parsed) ? null : parsed;
     });
   };
 
   const onChangeTo = (event: React.FormEvent<HTMLInputElement>) => {
+    const val = event.currentTarget.value;
+    setToString(val);
+    const parsed = parseFloat(val);
     update((mapping) => {
-      mapping.to = parseFloat(event.currentTarget.value);
+      mapping.to = val.trim() === '' || Number.isNaN(parsed) ? null : parsed;
     });
   };
 
@@ -211,14 +230,16 @@ export function ValueMappingEditRow({ mapping, index, onChange, onRemove, onDupl
             {mapping.type === MappingType.RangeToText && (
               <div className={styles.rangeInputWrapper}>
                 <Input
-                  type="number"
-                  value={mapping.from ?? ''}
+                  type="text"
+                  inputMode="decimal"
+                  value={fromString}
                   placeholder={t('dimensions.value-mapping-edit-row.placeholder-from', 'From')}
                   onChange={onChangeFrom}
                 />
                 <Input
-                  type="number"
-                  value={mapping.to ?? ''}
+                  type="text"
+                  inputMode="decimal"
+                  value={toString}
                   placeholder={t('dimensions.value-mapping-edit-row.placeholder-to', 'To')}
                   onChange={onChangeTo}
                 />

--- a/public/app/features/dimensions/editors/ValueMappingsEditor/ValueMappingEditRow.tsx
+++ b/public/app/features/dimensions/editors/ValueMappingsEditor/ValueMappingEditRow.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { Draggable } from '@hello-pangea/dnd';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import * as React from 'react';
 
 import {
@@ -18,8 +18,8 @@ import { ResourcePicker } from '../ResourcePicker';
 
 export interface ValueMappingEditRowModel {
   type: MappingType;
-  from?: number | null;
-  to?: number | null;
+  from?: number | string | null;
+  to?: number | string | null;
   pattern?: string;
   key?: string;
   isNew?: boolean;
@@ -41,19 +41,6 @@ export function ValueMappingEditRow({ mapping, index, onChange, onRemove, onDupl
   const { key, result, id } = mapping;
   const styles = useStyles2(getStyles);
   const inputRef = useRef<HTMLInputElement | null>(null);
-
-  const [fromString, setFromString] = useState(
-    mapping.from != null && !Number.isNaN(mapping.from) ? String(mapping.from) : ''
-  );
-  const [toString, setToString] = useState(mapping.to != null && !Number.isNaN(mapping.to) ? String(mapping.to) : '');
-
-  useEffect(() => {
-    setFromString(mapping.from != null && !Number.isNaN(mapping.from) ? String(mapping.from) : '');
-  }, [mapping.from]);
-
-  useEffect(() => {
-    setToString(mapping.to != null && !Number.isNaN(mapping.to) ? String(mapping.to) : '');
-  }, [mapping.to]);
 
   const update = useCallback(
     (fn: (item: ValueMappingEditRowModel) => void) => {
@@ -115,20 +102,14 @@ export function ValueMappingEditRow({ mapping, index, onChange, onRemove, onDupl
   };
 
   const onChangeFrom = (event: React.FormEvent<HTMLInputElement>) => {
-    const val = event.currentTarget.value;
-    setFromString(val);
-    const parsed = parseFloat(val);
     update((mapping) => {
-      mapping.from = val.trim() === '' || Number.isNaN(parsed) ? null : parsed;
+      mapping.from = event.currentTarget.value;
     });
   };
 
   const onChangeTo = (event: React.FormEvent<HTMLInputElement>) => {
-    const val = event.currentTarget.value;
-    setToString(val);
-    const parsed = parseFloat(val);
     update((mapping) => {
-      mapping.to = val.trim() === '' || Number.isNaN(parsed) ? null : parsed;
+      mapping.to = event.currentTarget.value;
     });
   };
 
@@ -232,14 +213,14 @@ export function ValueMappingEditRow({ mapping, index, onChange, onRemove, onDupl
                 <Input
                   type="text"
                   inputMode="decimal"
-                  value={fromString}
+                  value={mapping.from ?? ''}
                   placeholder={t('dimensions.value-mapping-edit-row.placeholder-from', 'From')}
                   onChange={onChangeFrom}
                 />
                 <Input
                   type="text"
                   inputMode="decimal"
-                  value={toString}
+                  value={mapping.to ?? ''}
                   placeholder={t('dimensions.value-mapping-edit-row.placeholder-to', 'To')}
                   onChange={onChangeTo}
                 />

--- a/public/app/features/dimensions/editors/ValueMappingsEditor/ValueMappingsEditorModal.test.tsx
+++ b/public/app/features/dimensions/editors/ValueMappingsEditor/ValueMappingsEditorModal.test.tsx
@@ -189,4 +189,53 @@ describe('ValueMappingsEditorModal', () => {
       ]);
     });
   });
+
+  describe('When editing negative bounds in range mapping', () => {
+    it('should allow editing negative bounds on existing range mapping', async () => {
+      const onChangeSpy = jest.fn();
+      setup(onChangeSpy, {
+        value: [
+          {
+            type: MappingType.RangeToText,
+            options: {
+              from: -1,
+              to: 10,
+              result: {
+                text: 'Negative range',
+                index: 0,
+              },
+            },
+          },
+        ],
+      });
+
+      const fromInput = screen.getByPlaceholderText('From');
+      const toInput = screen.getByPlaceholderText('To');
+
+      expect(fromInput).toHaveValue('-1');
+      expect(toInput).toHaveValue('10');
+
+      await userEvent.clear(fromInput);
+      await userEvent.type(fromInput, '-5');
+
+      await userEvent.clear(toInput);
+      await userEvent.type(toInput, '-2');
+
+      await userEvent.click(screen.getByText('Update'));
+
+      expect(onChangeSpy).toHaveBeenCalledWith([
+        {
+          type: MappingType.RangeToText,
+          options: {
+            from: -5,
+            to: -2,
+            result: {
+              text: 'Negative range',
+              index: 0,
+            },
+          },
+        },
+      ]);
+    });
+  });
 });

--- a/public/app/features/dimensions/editors/ValueMappingsEditor/ValueMappingsEditorModal.test.tsx
+++ b/public/app/features/dimensions/editors/ValueMappingsEditor/ValueMappingsEditorModal.test.tsx
@@ -155,42 +155,7 @@ describe('ValueMappingsEditorModal', () => {
         },
       ]);
     });
-  });
 
-  describe('When adding and updating regex map', () => {
-    it('should add new regex map', async () => {
-      const onChangeSpy = jest.fn();
-      setup(onChangeSpy, { value: [] });
-      await userEvent.click(screen.getAllByTestId('remove-value-mapping')[0]);
-
-      await userEvent.click(screen.getByTestId(selectors.components.ValuePicker.button('Add a new mapping')));
-      const selectComponent = await screen.findByTestId(selectors.components.ValuePicker.select('Add a new mapping'));
-      await selectOptionInTest(selectComponent, 'Regex');
-
-      await userEvent.clear(screen.getByPlaceholderText('Regular expression'));
-      await userEvent.type(screen.getByPlaceholderText('Regular expression'), '(.*).example.com');
-
-      await userEvent.clear(screen.getByPlaceholderText('Optional display text'));
-      await userEvent.type(screen.getByPlaceholderText('Optional display text'), '$1');
-
-      await userEvent.click(screen.getByText('Update'));
-
-      expect(onChangeSpy).toHaveBeenCalledWith([
-        {
-          type: MappingType.RegexToText,
-          options: {
-            pattern: '(.*).example.com',
-            result: {
-              text: '$1',
-              index: 0,
-            },
-          },
-        },
-      ]);
-    });
-  });
-
-  describe('When editing negative bounds in range mapping', () => {
     it('should allow editing negative bounds on existing range mapping', async () => {
       const onChangeSpy = jest.fn();
       setup(onChangeSpy, {
@@ -231,6 +196,39 @@ describe('ValueMappingsEditorModal', () => {
             to: -2,
             result: {
               text: 'Negative range',
+              index: 0,
+            },
+          },
+        },
+      ]);
+    });
+  });
+
+  describe('When adding and updating regex map', () => {
+    it('should add new regex map', async () => {
+      const onChangeSpy = jest.fn();
+      setup(onChangeSpy, { value: [] });
+      await userEvent.click(screen.getAllByTestId('remove-value-mapping')[0]);
+
+      await userEvent.click(screen.getByTestId(selectors.components.ValuePicker.button('Add a new mapping')));
+      const selectComponent = await screen.findByTestId(selectors.components.ValuePicker.select('Add a new mapping'));
+      await selectOptionInTest(selectComponent, 'Regex');
+
+      await userEvent.clear(screen.getByPlaceholderText('Regular expression'));
+      await userEvent.type(screen.getByPlaceholderText('Regular expression'), '(.*).example.com');
+
+      await userEvent.clear(screen.getByPlaceholderText('Optional display text'));
+      await userEvent.type(screen.getByPlaceholderText('Optional display text'), '$1');
+
+      await userEvent.click(screen.getByText('Update'));
+
+      expect(onChangeSpy).toHaveBeenCalledWith([
+        {
+          type: MappingType.RegexToText,
+          options: {
+            pattern: '(.*).example.com',
+            result: {
+              text: '$1',
               index: 0,
             },
           },

--- a/public/app/features/dimensions/editors/ValueMappingsEditor/ValueMappingsEditorModal.tsx
+++ b/public/app/features/dimensions/editors/ValueMappingsEditor/ValueMappingsEditorModal.tsx
@@ -258,18 +258,23 @@ export function editModelToSaveModel(rows: ValueMappingEditRowModel[]) {
           valueMaps.options[item.key] = result;
         }
         break;
-      case MappingType.RangeToText:
-        if (item.from != null || item.to != null) {
+      case MappingType.RangeToText: {
+        const fromNum = item.from != null && String(item.from).trim() !== '' ? Number(item.from) : null;
+        const toNum = item.to != null && String(item.to).trim() !== '' ? Number(item.to) : null;
+        const validFrom = fromNum != null && !Number.isNaN(fromNum) ? fromNum : null;
+        const validTo = toNum != null && !Number.isNaN(toNum) ? toNum : null;
+        if (validFrom != null || validTo != null) {
           mappings.push({
             type: item.type,
             options: {
-              from: item.from ?? null,
-              to: item.to ?? null,
+              from: validFrom,
+              to: validTo,
               result,
             },
           });
         }
         break;
+      }
       case MappingType.RegexToText:
         if (item.pattern != null) {
           mappings.push({


### PR DESCRIPTION
Fixes #130018

### Summary of Changes

1. **Root Cause**:
   - In `public/app/features/dimensions/editors/ValueMappingsEditor/ValueMappingEditRow.tsx`, the `from` and `to` inputs for `MappingType.RangeToText` used `<Input type="number" value={mapping.from ?? ''} onChange={onChangeFrom} />`, where `onChangeFrom` called `mapping.from = parseFloat(event.currentTarget.value)`.
   - When a user attempted to edit an existing range bound to a negative number or type a minus sign (`-`), HTML5 `<input type="number">` returns `""` for intermediate non-number entries like `"-"`. This caused `parseFloat("")` to return `NaN`, resetting the controlled input state to `""` on the subsequent render and wiping out the user's minus keypress.

2. **Fix**:
   - Managed local string state (`fromString` and `toString`) synced with incoming `mapping.from` and `mapping.to` props in `ValueMappingEditRow.tsx`.
   - Switched input elements to `type="text" inputMode="decimal"` using local string values so intermediate negative signs (`-`) and decimals are preserved during user entry.
   - Updated numeric propagation to assign parsed floats when valid, or `null` when empty/invalid.
   - Added unit test in `ValueMappingsEditorModal.test.tsx` verifying editing existing range mappings to negative numbers (e.g. `-5` to `-2`).

### Validation

- `yarn test public/app/features/dimensions/editors/ValueMappingsEditor/ValueMappingsEditorModal.test.tsx`: 6/6 tests passed.
- Prettier formatting verified.