### PR TITLE
Alert: Exploring new look and variants 

### DIFF
--- a/packages/grafana-ui/src/components/Alert/Alert.story.tsx
+++ b/packages/grafana-ui/src/components/Alert/Alert.story.tsx
@@ -8,7 +8,7 @@ import { Stack } from '../Layout/Stack/Stack';
 import { Alert, type AlertVariant } from './Alert';
 import mdx from './Alert.mdx';
 
-const severities: AlertVariant[] = ['error', 'warning', 'info', 'success'];
+const severities: AlertVariant[] = ['error', 'warning', 'info', 'success', 'tertiary', 'accent'];
 
 const meta: Meta = {
   title: 'Information/Alert',
@@ -122,6 +122,19 @@ Toast.args = {
   severity: 'error',
   onRemove: action('Remove button clicked'),
   elevated: true,
+};
+
+export const Sizes: StoryFn<typeof Alert> = () => {
+  const sizes = ['sm', 'md', 'lg'] as const;
+  return (
+    <Stack direction="column">
+      {sizes.map((size) => (
+        <Alert title={`Size: ${size}`} size={size} key={size} severity="info">
+          Child content
+        </Alert>
+      ))}
+    </Stack>
+  );
 };
 
 export default meta;

--- a/packages/grafana-ui/src/components/Alert/Alert.story.tsx
+++ b/packages/grafana-ui/src/components/Alert/Alert.story.tsx
@@ -125,14 +125,17 @@ Toast.args = {
 };
 
 export const Sizes: StoryFn<typeof Alert> = () => {
-  const sizes = ['sm', 'md', 'lg'] as const;
   return (
     <Stack direction="column">
-      {sizes.map((size) => (
-        <Alert title={`Size: ${size}`} size={size} key={size} severity="info">
-          Child content
-        </Alert>
-      ))}
+      <Alert title={`Size: sm`} size={'sm'} severity="error" onRemove={() => {}}>
+        Child content
+      </Alert>
+      <Alert title={`Size: md`} size={'md'} severity="info" action={<Button variant="secondary">Action</Button>}>
+        Child content
+      </Alert>
+      <Alert title={`Size: lg`} size={'lg'} severity="accent" action={<Button variant="primary">Sign up</Button>}>
+        Child content
+      </Alert>
     </Stack>
   );
 };

--- a/packages/grafana-ui/src/components/Alert/Alert.tsx
+++ b/packages/grafana-ui/src/components/Alert/Alert.tsx
@@ -67,19 +67,8 @@ export const Alert = React.forwardRef<HTMLDivElement, Props>(
 
     return (
       <div ref={ref} className={cx(styles.wrapper, className)} role={role} aria-label={ariaLabel} {...restProps}>
-        <Box
-          data-testid={selectors.components.Alert.alertV2(severity)}
-          display="flex"
-          backgroundColor={severity}
-          borderRadius="lg"
-          paddingY={1}
-          paddingX={2}
-          borderStyle="solid"
-          borderColor={severity}
-          alignItems="stretch"
-          boxShadow={elevated ? 'z3' : undefined}
-        >
-          <Box paddingTop={1} paddingRight={2}>
+        <div data-testid={selectors.components.Alert.alertV2(severity)} className={styles.box}>
+          <Box display="flex" alignItems="flex-start" justifyContent="flex-start">
             <div className={styles.icon}>
               <Icon size="xl" name={getIconFromSeverity(severity)} />
             </div>
@@ -114,7 +103,7 @@ export const Alert = React.forwardRef<HTMLDivElement, Props>(
               />
             </div>
           )}
-        </Box>
+        </div>
       </div>
     );
   }
@@ -164,14 +153,29 @@ const getStyles = (
         zIndex: -1,
       },
     }),
+    box: css({
+      display: 'flex',
+      borderRadius: theme.shape.radius.lg,
+      boxShadow: elevated ? theme.shadows.z3 : undefined,
+      padding: theme.spacing(2),
+      background: `linear-gradient(169deg, ${theme.components.card.background} 20%, color-mix(in oklab, ${theme.components.card.background} 70%, ${color.background}))`,
+      border: `1px solid color-mix(in oklab, ${theme.colors.background.page} 50%, ${color.border})`,
+      gap: theme.spacing(2),
+    }),
     icon: css({
       color: color.text,
+      backgroundColor: color.background,
       position: 'relative',
-      top: '-1px',
+      width: '40px',
+      height: '40px',
+      padding: theme.spacing(1.2),
+      borderRadius: theme.spacing(1),
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
     }),
     content: css({
       color: theme.colors.text.primary,
-      paddingTop: hasTitle ? theme.spacing(0.5) : 0,
       maxHeight: '50vh',
       overflowY: 'auto',
     }),

--- a/packages/grafana-ui/src/components/Alert/Alert.tsx
+++ b/packages/grafana-ui/src/components/Alert/Alert.tsx
@@ -2,18 +2,18 @@ import { css, cx } from '@emotion/css';
 import { type AriaRole, type HTMLAttributes, type ReactNode } from 'react';
 import * as React from 'react';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { type ThemeTypographyVariantTypes, type GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 
 import { useTheme2 } from '../../themes/ThemeContext';
-import { type IconName } from '../../types/icon';
+import { type IconName, type IconSize } from '../../types/icon';
 import { Button } from '../Button/Button';
 import { Icon } from '../Icon/Icon';
 import { Box } from '../Layout/Box/Box';
 import { Stack } from '../Layout/Stack/Stack';
 import { Text } from '../Text/Text';
-export type AlertVariant = 'success' | 'warning' | 'error' | 'info';
+export type AlertVariant = 'success' | 'warning' | 'error' | 'info' | 'tertiary' | 'accent';
 
 export interface Props extends HTMLAttributes<HTMLDivElement> {
   title: string;
@@ -27,6 +27,7 @@ export interface Props extends HTMLAttributes<HTMLDivElement> {
   topSpacing?: number;
   /** Custom action element rendered in the alert's button area, independently from the dismiss button. */
   action?: ReactNode;
+  size?: 'sm' | 'md' | 'lg';
 }
 
 /**
@@ -47,18 +48,21 @@ export const Alert = React.forwardRef<HTMLDivElement, Props>(
       className,
       severity = 'error',
       action,
+      size = 'md',
       ...restProps
     },
     ref
   ) => {
     const theme = useTheme2();
     const hasTitle = Boolean(title);
-    const styles = getStyles(theme, severity, hasTitle, elevated, bottomSpacing, topSpacing);
+    const styles = getStyles(theme, severity, hasTitle, elevated, bottomSpacing, topSpacing, size);
     const rolesBySeverity: Record<AlertVariant, AriaRole> = {
       error: 'alert',
       warning: 'alert',
       info: 'status',
       success: 'status',
+      tertiary: 'status',
+      accent: 'status',
     };
     const role = restProps['role'] || rolesBySeverity[severity];
     const ariaLabel = restProps['aria-label'] || title;
@@ -70,13 +74,13 @@ export const Alert = React.forwardRef<HTMLDivElement, Props>(
         <div data-testid={selectors.components.Alert.alertV2(severity)} className={styles.box}>
           <Box display="flex" alignItems="flex-start" justifyContent="flex-start">
             <div className={styles.icon}>
-              <Icon size="xl" name={getIconFromSeverity(severity)} />
+              <Icon size={styles.iconSize} name={getIconFromSeverity(severity)} />
             </div>
           </Box>
 
           <Stack alignItems="center" flex={1} wrap="wrap" columnGap={1} rowGap={0}>
             <Box flex={1} minWidth="50%">
-              <Text color={severity} weight="medium">
+              <Text color={severity} variant={styles.titleVariant} weight="medium">
                 {title}
               </Text>
               {children && <div className={styles.content}>{children}</div>}
@@ -121,8 +125,28 @@ const getIconFromSeverity = (severity: AlertVariant): IconName => {
       return 'info-circle';
     case 'success':
       return 'check';
+    case 'tertiary':
+      return 'info-circle';
+    case 'accent':
+      return 'info-circle';
   }
 };
+
+function getSpacing(size: 'sm' | 'md' | 'lg'): {
+  padding: number;
+  iconWidth: number;
+  iconSize: IconSize;
+  titleVariant: keyof ThemeTypographyVariantTypes;
+} {
+  switch (size) {
+    case 'sm':
+      return { padding: 1, iconWidth: 4, iconSize: 'md', titleVariant: 'h6' };
+    case 'md':
+      return { padding: 2, iconWidth: 5, iconSize: 'xl', titleVariant: 'h5' };
+    case 'lg':
+      return { padding: 3, iconWidth: 7, iconSize: 'xxl', titleVariant: 'h4' };
+  }
+}
 
 const getStyles = (
   theme: GrafanaTheme2,
@@ -130,9 +154,11 @@ const getStyles = (
   hasTitle: boolean,
   elevated?: boolean,
   bottomSpacing?: number,
-  topSpacing?: number
+  topSpacing?: number,
+  size: 'sm' | 'md' | 'lg' = 'md'
 ) => {
   const color = theme.colors[severity];
+  const sizing = getSpacing(size);
 
   return {
     wrapper: css({
@@ -153,28 +179,29 @@ const getStyles = (
         zIndex: -1,
       },
     }),
+    titleVariant: sizing.titleVariant,
     box: css({
       display: 'flex',
       borderRadius: theme.shape.radius.lg,
       boxShadow: elevated ? theme.shadows.z3 : undefined,
-      padding: theme.spacing(2),
-      background: `linear-gradient(345deg, ${theme.components.card.background} 20%, color-mix(in oklab, ${theme.components.card.background} 41%, ${color.background}))`,
-      //border: `1px solid ${theme.colors.border.weak}`,
-      border: `1px solid color-mix(in oklab, ${theme.colors.background.page} 50%, ${color.border})`,
-      gap: theme.spacing(2),
+      padding: theme.spacing(sizing.padding),
+      //background: `linear-gradient(345deg, ${theme.components.card.background} 20%, color-mix(in oklab, ${theme.components.card.background} 41%, ${color.background}))`,
+      background: `color-mix(in oklab, ${theme.components.card.background} 60%, ${color.background})`,
+      border: `1px solid color-mix(in oklab, ${theme.colors.background.page} 55%, ${color.border})`,
+      gap: theme.spacing(sizing.padding),
     }),
     icon: css({
       color: color.text,
       backgroundColor: `color-mix(in oklab, ${theme.components.card.background} 40%, ${color.backgroundEmphasis})`,
       position: 'relative',
-      width: '40px',
-      height: '40px',
-      padding: theme.spacing(1.2),
-      borderRadius: theme.spacing(1),
+      width: theme.spacing(sizing.iconWidth),
+      height: theme.spacing(sizing.iconWidth),
+      borderRadius: theme.shape.radius.default,
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',
     }),
+    iconSize: sizing.iconSize,
     content: css({
       color: theme.colors.text.primary,
       maxHeight: '50vh',

--- a/packages/grafana-ui/src/components/Alert/Alert.tsx
+++ b/packages/grafana-ui/src/components/Alert/Alert.tsx
@@ -75,8 +75,8 @@ export const Alert = React.forwardRef<HTMLDivElement, Props>(
           </Box>
 
           <Stack alignItems="center" flex={1} wrap="wrap" columnGap={1} rowGap={0}>
-            <Box paddingY={1} flex={1} minWidth="50%">
-              <Text color="primary" weight="medium">
+            <Box flex={1} minWidth="50%">
+              <Text color={severity} weight="medium">
                 {title}
               </Text>
               {children && <div className={styles.content}>{children}</div>}
@@ -158,13 +158,14 @@ const getStyles = (
       borderRadius: theme.shape.radius.lg,
       boxShadow: elevated ? theme.shadows.z3 : undefined,
       padding: theme.spacing(2),
-      background: `linear-gradient(169deg, ${theme.components.card.background} 20%, color-mix(in oklab, ${theme.components.card.background} 70%, ${color.background}))`,
+      background: `linear-gradient(345deg, ${theme.components.card.background} 20%, color-mix(in oklab, ${theme.components.card.background} 41%, ${color.background}))`,
+      //border: `1px solid ${theme.colors.border.weak}`,
       border: `1px solid color-mix(in oklab, ${theme.colors.background.page} 50%, ${color.border})`,
       gap: theme.spacing(2),
     }),
     icon: css({
       color: color.text,
-      backgroundColor: color.background,
+      backgroundColor: `color-mix(in oklab, ${theme.components.card.background} 40%, ${color.backgroundEmphasis})`,
       position: 'relative',
       width: '40px',
       height: '40px',
@@ -184,8 +185,6 @@ const getStyles = (
       color: theme.colors.text.secondary,
       background: 'none',
       display: 'flex',
-      top: '-6px',
-      right: '-14px',
     }),
   };
 };

--- a/packages/grafana-ui/src/components/Alert/Alert.tsx
+++ b/packages/grafana-ui/src/components/Alert/Alert.tsx
@@ -2,7 +2,7 @@ import { css, cx } from '@emotion/css';
 import { type AriaRole, type HTMLAttributes, type ReactNode } from 'react';
 import * as React from 'react';
 
-import { type ThemeTypographyVariantTypes, type GrafanaTheme2 } from '@grafana/data';
+import { type ThemeTypographyVariantTypes, type GrafanaTheme2, type ThemeSpacingTokens } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 
@@ -79,7 +79,7 @@ export const Alert = React.forwardRef<HTMLDivElement, Props>(
           </Box>
 
           <Stack alignItems="center" flex={1} wrap="wrap" columnGap={1} rowGap={0}>
-            <Box flex={1} minWidth="50%">
+            <Box display={'flex'} direction={'column'} flex={1} minWidth="50%" gap={styles.titleGap}>
               <Text color={severity} variant={styles.titleVariant} weight="medium">
                 {title}
               </Text>
@@ -137,14 +137,15 @@ function getSpacing(size: 'sm' | 'md' | 'lg'): {
   iconWidth: number;
   iconSize: IconSize;
   titleVariant: keyof ThemeTypographyVariantTypes;
+  titleGap: ThemeSpacingTokens;
 } {
   switch (size) {
     case 'sm':
-      return { padding: 1, iconWidth: 4, iconSize: 'md', titleVariant: 'h6' };
+      return { padding: 1, iconWidth: 4, iconSize: 'md', titleVariant: 'h6', titleGap: 0 };
     case 'md':
-      return { padding: 2, iconWidth: 5, iconSize: 'xl', titleVariant: 'h5' };
+      return { padding: 2, iconWidth: 5, iconSize: 'xl', titleVariant: 'h5', titleGap: 0.25 };
     case 'lg':
-      return { padding: 3, iconWidth: 7, iconSize: 'xxl', titleVariant: 'h4' };
+      return { padding: 3, iconWidth: 7, iconSize: 'xxl', titleVariant: 'h4', titleGap: 1 };
   }
 }
 
@@ -180,6 +181,7 @@ const getStyles = (
       },
     }),
     titleVariant: sizing.titleVariant,
+    titleGap: sizing.titleGap,
     box: css({
       display: 'flex',
       borderRadius: theme.shape.radius.lg,

--- a/packages/grafana-ui/src/components/ColorCard/ColorCard.mdx
+++ b/packages/grafana-ui/src/components/ColorCard/ColorCard.mdx
@@ -1,0 +1,14 @@
+import { Meta, ArgTypes } from '@storybook/addon-docs/blocks';
+import { ColorCard } from './ColorCard';
+
+<Meta title="MDX|ColorCard" component={ColorCard} />
+
+# ColorCard
+
+ColorCard is a fundamental element used for displaying important messages or notifications to users.
+
+---
+
+About ColorCard component:
+
+<ArgTypes of={Alert} />

--- a/packages/grafana-ui/src/components/ColorCard/ColorCard.mdx
+++ b/packages/grafana-ui/src/components/ColorCard/ColorCard.mdx
@@ -5,10 +5,37 @@ import { ColorCard } from './ColorCard';
 
 # ColorCard
 
-ColorCard is a fundamental element used for displaying important messages or notifications to users.
+ColorCard displays information in a way that attracts the user's attention without interrupting their task.
+
+It is composed from sub components so the consumer controls what the card contains and how it is labelled:
+
+- `ColorCard.Icon` — the leading icon
+- `ColorCard.Title` — the title row
+- `ColorCard.Content` — the body
+- `ColorCard.Actions` — buttons/links on the trailing edge
+
+`variant` and `size` are set once on `ColorCard` and read by the sub components through context, so they never
+have to be repeated.
+
+```tsx
+<ColorCard size="sm" variant="error">
+  <ColorCard.Icon name="exclamation-circle" />
+  <ColorCard.Title>My title</ColorCard.Title>
+  <ColorCard.Content>Some long content</ColorCard.Content>
+  <ColorCard.Actions>
+    <Button variant="secondary">Close</Button>
+  </ColorCard.Actions>
+</ColorCard>
+```
+
+For the simple case, `title` can be passed as a prop and any plain children are rendered as content:
+
+```tsx
+<ColorCard variant="error" title="Basic">
+  Child content
+</ColorCard>
+```
 
 ---
 
-About ColorCard component:
-
-<ArgTypes of={Alert} />
+<ArgTypes of={ColorCard} />

--- a/packages/grafana-ui/src/components/ColorCard/ColorCard.story.tsx
+++ b/packages/grafana-ui/src/components/ColorCard/ColorCard.story.tsx
@@ -1,0 +1,56 @@
+import { type StoryFn, type Meta } from '@storybook/react-webpack5';
+import { action } from 'storybook/actions';
+
+import { StoryExample } from '../../utils/storybook/StoryExample';
+import { Button } from '../Button/Button';
+import { Stack } from '../Layout/Stack/Stack';
+
+import { ColorCard } from './ColorCard';
+import mdx from './ColorCard.mdx';
+
+const meta: Meta = {
+  title: 'Information/ColorCard',
+  component: ColorCard,
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
+  argTypes: {},
+};
+
+export const Basic: StoryFn<typeof ColorCard> = (args) => {
+  return (
+    <div>
+      <ColorCard {...args}>
+        Child content that includes some alert details, like maybe what actually happened.
+      </ColorCard>
+    </div>
+  );
+};
+
+Basic.args = {
+  variant: 'error',
+  title: 'Basic',
+};
+
+export const Examples: StoryFn<typeof ColorCard> = () => {
+  return (
+    <Stack direction="column">
+      <StoryExample name="With buttonContent and children">
+        <ColorCard size="sm" variant="error">
+          <ColorCard.Icon name="exclamation-circle" />
+          <ColorCard.Title>My title</ColorCard.Title>
+          <ColorCard.Content>Some long content</ColorCard.Content>
+          <ColorCard.Actions>
+            <Button variant="secondary" onClick={action('Remove button clicked')}>
+              Close
+            </Button>
+          </ColorCard.Actions>
+        </ColorCard>
+      </StoryExample>
+    </Stack>
+  );
+};
+
+export default meta;

--- a/packages/grafana-ui/src/components/ColorCard/ColorCard.test.tsx
+++ b/packages/grafana-ui/src/components/ColorCard/ColorCard.test.tsx
@@ -1,0 +1,1 @@
+describe('ColorCard', () => {});

--- a/packages/grafana-ui/src/components/ColorCard/ColorCard.test.tsx
+++ b/packages/grafana-ui/src/components/ColorCard/ColorCard.test.tsx
@@ -1,1 +1,37 @@
-describe('ColorCard', () => {});
+import { render, screen } from '@testing-library/react';
+
+import { ColorCard } from './ColorCard';
+
+describe('ColorCard', () => {
+  it('renders the title prop and plain children as content', () => {
+    render(<ColorCard title="Something broke">It happened at 10:45</ColorCard>);
+
+    expect(screen.getByText('Something broke')).toBeInTheDocument();
+    expect(screen.getByText('It happened at 10:45')).toBeInTheDocument();
+  });
+
+  it('renders sub components', () => {
+    render(
+      <ColorCard variant="warning" size="sm">
+        <ColorCard.Icon name="exclamation-triangle" />
+        <ColorCard.Title>My title</ColorCard.Title>
+        <ColorCard.Content>Some long content</ColorCard.Content>
+        <ColorCard.Actions>
+          <button type="button">Close</button>
+        </ColorCard.Actions>
+      </ColorCard>
+    );
+
+    expect(screen.getByText('My title')).toBeInTheDocument();
+    expect(screen.getByText('Some long content')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
+  });
+
+  it('uses an assertive role for error and warning, and a polite one otherwise', () => {
+    const { rerender } = render(<ColorCard variant="error" title="Boom" />);
+    expect(screen.getByRole('alert')).toHaveAccessibleName('Boom');
+
+    rerender(<ColorCard variant="info" title="FYI" />);
+    expect(screen.getByRole('status')).toHaveAccessibleName('FYI');
+  });
+});

--- a/packages/grafana-ui/src/components/ColorCard/ColorCard.tsx
+++ b/packages/grafana-ui/src/components/ColorCard/ColorCard.tsx
@@ -1,53 +1,147 @@
 import { css, cx } from '@emotion/css';
-import { type AriaRole, type HTMLAttributes } from 'react';
+import { type AriaRole, type HTMLAttributes, type ReactNode, createContext, useContext } from 'react';
 import * as React from 'react';
 
 import { type ThemeTypographyVariantTypes, type GrafanaTheme2, type ThemeSpacingTokens } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 
-import { useTheme2 } from '../../themes/ThemeContext';
-import { type IconSize } from '../../types/icon';
+import { useStyles2 } from '../../themes/ThemeContext';
+import { type IconName, type IconSize } from '../../types/icon';
+import { Icon } from '../Icon/Icon';
 
 export type ColorCardVariant = 'success' | 'warning' | 'error' | 'info' | 'tertiary' | 'accent';
+export type ColorCardSize = 'sm' | 'md' | 'lg';
 
 export interface Props extends HTMLAttributes<HTMLDivElement> {
-  variant: ColorCardVariant;
-  size?: 'sm' | 'md' | 'lg';
+  variant?: ColorCardVariant;
+  size?: ColorCardSize;
   elevated?: boolean;
+  /** Convenience shorthand for a single `ColorCard.Title` child */
+  title?: string;
+  children?: ReactNode;
 }
 
-/**
- * A color card displays information in a way that attracts the user's attention without interrupting the user's task.
- *
- * https://developers.grafana.com/ui/latest/index.html?path=/docs/information-alert--docs
- */
-export const ColorCard = React.forwardRef<HTMLDivElement, Props>(
+export interface ColorCardInterface
+  extends React.ForwardRefExoticComponent<Props & React.RefAttributes<HTMLDivElement>> {
+  Icon: typeof ColorCardIcon;
+  Title: typeof ColorCardTitle;
+  Content: typeof ColorCardContent;
+  Actions: typeof ColorCardActions;
+}
+
+interface ColorCardContextValue {
+  variant: ColorCardVariant;
+  size: ColorCardSize;
+}
+
+const ColorCardContext = createContext<ColorCardContextValue>({ variant: 'error', size: 'md' });
+
+/** Sub components read variant/size from the card instead of taking them as props */
+function useColorCardContext() {
+  return useContext(ColorCardContext);
+}
+
+const rolesByVariant: Record<ColorCardVariant, AriaRole> = {
+  error: 'alert',
+  warning: 'alert',
+  info: 'status',
+  success: 'status',
+  tertiary: 'status',
+  accent: 'status',
+};
+
+const ColorCardComponent = React.forwardRef<HTMLDivElement, Props>(
   ({ title, children, elevated, className, variant = 'error', size = 'md', ...restProps }, ref) => {
-    const theme = useTheme2();
-    const styles = getStyles(theme, variant, elevated, size);
-    const rolesByVariant: Record<ColorCardVariant, AriaRole> = {
-      error: 'alert',
-      warning: 'alert',
-      info: 'status',
-      success: 'status',
-      tertiary: 'status',
-      accent: 'status',
-    };
+    const styles = useStyles2(getStyles, variant, size, elevated);
 
     const role = restProps['role'] || rolesByVariant[variant];
     const ariaLabel = restProps['aria-label'] || title;
 
+    // Children that are not one of the slot components are treated as card content, so that
+    // `<ColorCard title="x">some text</ColorCard>` works without reaching for ColorCard.Content.
+    const slots: ReactNode[] = [];
+    const loose: ReactNode[] = [];
+
+    for (const child of React.Children.toArray(children)) {
+      if (React.isValidElement(child) && SLOT_COMPONENTS.has(child.type)) {
+        slots.push(child);
+      } else {
+        loose.push(child);
+      }
+    }
+
     return (
-      <div ref={ref} className={cx(styles.wrapper, className)} role={role} aria-label={ariaLabel} {...restProps}>
-        <div data-testid={selectors.components.Alert.alertV2(variant)} className={styles.box}></div>
-      </div>
+      <ColorCardContext.Provider value={{ variant, size }}>
+        <div ref={ref} className={cx(styles.wrapper, className)} role={role} aria-label={ariaLabel} {...restProps}>
+          <div data-testid={selectors.components.Alert.alertV2(variant)} className={styles.box}>
+            {title && <ColorCardTitle>{title}</ColorCardTitle>}
+            {slots}
+            {loose.length > 0 && <ColorCardContent>{loose}</ColorCardContent>}
+          </div>
+        </div>
+      </ColorCardContext.Provider>
     );
   }
 );
 
-ColorCard.displayName = 'ColorCard';
+ColorCardComponent.displayName = 'ColorCard';
 
-function getSpacing(size: 'sm' | 'md' | 'lg'): {
+interface SlotProps {
+  className?: string;
+  children?: ReactNode;
+}
+
+const ColorCardIcon = ({ name, className }: { name: IconName; className?: string }) => {
+  const { variant, size } = useColorCardContext();
+  const styles = useStyles2(getStyles, variant, size);
+
+  return (
+    <div className={cx(styles.icon, className)}>
+      <Icon name={name} size={styles.iconSize} />
+    </div>
+  );
+};
+ColorCardIcon.displayName = 'ColorCardIcon';
+
+const ColorCardTitle = ({ children, className }: SlotProps) => {
+  const { variant, size } = useColorCardContext();
+  const styles = useStyles2(getStyles, variant, size);
+
+  return <div className={cx(styles.title, className)}>{children}</div>;
+};
+ColorCardTitle.displayName = 'ColorCardTitle';
+
+const ColorCardContent = ({ children, className }: SlotProps) => {
+  const { variant, size } = useColorCardContext();
+  const styles = useStyles2(getStyles, variant, size);
+
+  return <div className={cx(styles.content, className)}>{children}</div>;
+};
+ColorCardContent.displayName = 'ColorCardContent';
+
+const ColorCardActions = ({ children, className }: SlotProps) => {
+  const { variant, size } = useColorCardContext();
+  const styles = useStyles2(getStyles, variant, size);
+
+  return <div className={cx(styles.actions, className)}>{children}</div>;
+};
+ColorCardActions.displayName = 'ColorCardActions';
+
+const SLOT_COMPONENTS: ReadonlySet<unknown> = new Set([
+  ColorCardIcon,
+  ColorCardTitle,
+  ColorCardContent,
+  ColorCardActions,
+]);
+
+export const ColorCard: ColorCardInterface = Object.assign(ColorCardComponent, {
+  Icon: ColorCardIcon,
+  Title: ColorCardTitle,
+  Content: ColorCardContent,
+  Actions: ColorCardActions,
+});
+
+function getSpacing(size: ColorCardSize): {
   padding: number;
   iconWidth: number;
   iconSize: IconSize;
@@ -64,20 +158,13 @@ function getSpacing(size: 'sm' | 'md' | 'lg'): {
   }
 }
 
-const getStyles = (
-  theme: GrafanaTheme2,
-  variant: ColorCardVariant,
-  elevated?: boolean,
-  size: 'sm' | 'md' | 'lg' = 'md'
-) => {
+const getStyles = (theme: GrafanaTheme2, variant: ColorCardVariant, size: ColorCardSize, elevated?: boolean) => {
   const color = theme.colors[variant];
   const sizing = getSpacing(size);
 
   return {
     wrapper: css({
       flexGrow: 1,
-      marginBottom: theme.spacing(bottomSpacing ?? 2),
-      marginTop: theme.spacing(topSpacing ?? 0),
       position: 'relative',
 
       '&:before': {
@@ -92,19 +179,24 @@ const getStyles = (
         zIndex: -1,
       },
     }),
-    titleVariant: sizing.titleVariant,
-    titleGap: sizing.titleGap,
     box: css({
-      display: 'flex',
+      display: 'grid',
+      gridTemplateAreas: `
+        "Icon Title Actions"
+        "Icon Content Actions"
+      `,
+      gridTemplateColumns: 'auto 1fr auto',
+      columnGap: theme.spacing(sizing.padding),
+      rowGap: theme.spacing(sizing.titleGap),
+      alignItems: 'start',
       borderRadius: theme.shape.radius.lg,
       boxShadow: elevated ? theme.shadows.z3 : undefined,
       padding: theme.spacing(sizing.padding),
-      //background: `linear-gradient(345deg, ${theme.components.card.background} 20%, color-mix(in oklab, ${theme.components.card.background} 41%, ${color.background}))`,
       background: `color-mix(in oklab, ${theme.components.card.background} 60%, ${color.background})`,
       border: `1px solid color-mix(in oklab, ${theme.colors.background.page} 55%, ${color.border})`,
-      gap: theme.spacing(sizing.padding),
     }),
     icon: css({
+      gridArea: 'Icon',
       color: color.text,
       backgroundColor: `color-mix(in oklab, ${theme.components.card.background} 40%, ${color.backgroundEmphasis})`,
       position: 'relative',
@@ -116,16 +208,27 @@ const getStyles = (
       justifyContent: 'center',
     }),
     iconSize: sizing.iconSize,
+    title: css({
+      gridArea: 'Title',
+      alignSelf: 'center',
+      ...theme.typography[sizing.titleVariant],
+      color: color.text,
+      fontWeight: theme.typography.fontWeightMedium,
+      margin: 0,
+    }),
     content: css({
+      gridArea: 'Content',
       color: theme.colors.text.primary,
       maxHeight: '50vh',
       overflowY: 'auto',
     }),
-    close: css({
-      position: 'relative',
-      color: theme.colors.text.secondary,
-      background: 'none',
+    actions: css({
+      gridArea: 'Actions',
+      alignSelf: 'center',
       display: 'flex',
+      flexWrap: 'wrap',
+      alignItems: 'center',
+      gap: theme.spacing(1),
     }),
   };
 };

--- a/packages/grafana-ui/src/components/ColorCard/ColorCard.tsx
+++ b/packages/grafana-ui/src/components/ColorCard/ColorCard.tsx
@@ -1,0 +1,131 @@
+import { css, cx } from '@emotion/css';
+import { type AriaRole, type HTMLAttributes } from 'react';
+import * as React from 'react';
+
+import { type ThemeTypographyVariantTypes, type GrafanaTheme2, type ThemeSpacingTokens } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
+
+import { useTheme2 } from '../../themes/ThemeContext';
+import { type IconSize } from '../../types/icon';
+
+export type ColorCardVariant = 'success' | 'warning' | 'error' | 'info' | 'tertiary' | 'accent';
+
+export interface Props extends HTMLAttributes<HTMLDivElement> {
+  variant: ColorCardVariant;
+  size?: 'sm' | 'md' | 'lg';
+  elevated?: boolean;
+}
+
+/**
+ * A color card displays information in a way that attracts the user's attention without interrupting the user's task.
+ *
+ * https://developers.grafana.com/ui/latest/index.html?path=/docs/information-alert--docs
+ */
+export const ColorCard = React.forwardRef<HTMLDivElement, Props>(
+  ({ title, children, elevated, className, variant = 'error', size = 'md', ...restProps }, ref) => {
+    const theme = useTheme2();
+    const styles = getStyles(theme, variant, elevated, size);
+    const rolesByVariant: Record<ColorCardVariant, AriaRole> = {
+      error: 'alert',
+      warning: 'alert',
+      info: 'status',
+      success: 'status',
+      tertiary: 'status',
+      accent: 'status',
+    };
+
+    const role = restProps['role'] || rolesByVariant[variant];
+    const ariaLabel = restProps['aria-label'] || title;
+
+    return (
+      <div ref={ref} className={cx(styles.wrapper, className)} role={role} aria-label={ariaLabel} {...restProps}>
+        <div data-testid={selectors.components.Alert.alertV2(variant)} className={styles.box}></div>
+      </div>
+    );
+  }
+);
+
+ColorCard.displayName = 'ColorCard';
+
+function getSpacing(size: 'sm' | 'md' | 'lg'): {
+  padding: number;
+  iconWidth: number;
+  iconSize: IconSize;
+  titleVariant: keyof ThemeTypographyVariantTypes;
+  titleGap: ThemeSpacingTokens;
+} {
+  switch (size) {
+    case 'sm':
+      return { padding: 1, iconWidth: 4, iconSize: 'md', titleVariant: 'h6', titleGap: 0 };
+    case 'md':
+      return { padding: 2, iconWidth: 5, iconSize: 'xl', titleVariant: 'h5', titleGap: 0.25 };
+    case 'lg':
+      return { padding: 3, iconWidth: 7, iconSize: 'xxl', titleVariant: 'h4', titleGap: 1 };
+  }
+}
+
+const getStyles = (
+  theme: GrafanaTheme2,
+  variant: ColorCardVariant,
+  elevated?: boolean,
+  size: 'sm' | 'md' | 'lg' = 'md'
+) => {
+  const color = theme.colors[variant];
+  const sizing = getSpacing(size);
+
+  return {
+    wrapper: css({
+      flexGrow: 1,
+      marginBottom: theme.spacing(bottomSpacing ?? 2),
+      marginTop: theme.spacing(topSpacing ?? 0),
+      position: 'relative',
+
+      '&:before': {
+        content: '""',
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        bottom: 0,
+        right: 0,
+        background: theme.colors.background.primary,
+        borderRadius: theme.shape.radius.lg,
+        zIndex: -1,
+      },
+    }),
+    titleVariant: sizing.titleVariant,
+    titleGap: sizing.titleGap,
+    box: css({
+      display: 'flex',
+      borderRadius: theme.shape.radius.lg,
+      boxShadow: elevated ? theme.shadows.z3 : undefined,
+      padding: theme.spacing(sizing.padding),
+      //background: `linear-gradient(345deg, ${theme.components.card.background} 20%, color-mix(in oklab, ${theme.components.card.background} 41%, ${color.background}))`,
+      background: `color-mix(in oklab, ${theme.components.card.background} 60%, ${color.background})`,
+      border: `1px solid color-mix(in oklab, ${theme.colors.background.page} 55%, ${color.border})`,
+      gap: theme.spacing(sizing.padding),
+    }),
+    icon: css({
+      color: color.text,
+      backgroundColor: `color-mix(in oklab, ${theme.components.card.background} 40%, ${color.backgroundEmphasis})`,
+      position: 'relative',
+      width: theme.spacing(sizing.iconWidth),
+      height: theme.spacing(sizing.iconWidth),
+      borderRadius: theme.shape.radius.default,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+    }),
+    iconSize: sizing.iconSize,
+    content: css({
+      color: theme.colors.text.primary,
+      maxHeight: '50vh',
+      overflowY: 'auto',
+    }),
+    close: css({
+      position: 'relative',
+      color: theme.colors.text.secondary,
+      background: 'none',
+      display: 'flex',
+    }),
+  };
+};

--- a/packages/grafana-ui/src/components/Text/Text.tsx
+++ b/packages/grafana-ui/src/components/Text/Text.tsx
@@ -18,7 +18,7 @@ export interface TextProps extends Omit<React.HTMLAttributes<HTMLElement>, 'clas
   /** Override the default weight for the used variant */
   weight?: 'light' | 'regular' | 'medium' | 'bold';
   /** Color to use for text */
-  color?: keyof GrafanaTheme2['colors']['text'] | 'error' | 'success' | 'warning' | 'info';
+  color?: keyof GrafanaTheme2['colors']['text'] | 'error' | 'success' | 'warning' | 'info' | 'accent' | 'tertiary';
   /** Use to cut the text off with ellipsis if there isn't space to show all of it. On hover shows the rest of the text */
   truncate?: boolean;
   /** If true, show the text as italic. False by default */

--- a/packages/grafana-ui/src/components/Text/utils.ts
+++ b/packages/grafana-ui/src/components/Text/utils.ts
@@ -16,7 +16,10 @@ export const customWeight = (weight: TextProps['weight'], theme: GrafanaTheme2):
   }
 };
 
-export const customColor = (color: TextProps['color'], theme: GrafanaTheme2): string | undefined => {
+export const customColor = (
+  color: TextProps['color'] | 'accent' | 'tertiary',
+  theme: GrafanaTheme2
+): string | undefined => {
   switch (color) {
     case 'error':
       return theme.colors.error.text;
@@ -26,6 +29,10 @@ export const customColor = (color: TextProps['color'], theme: GrafanaTheme2): st
       return theme.colors.info.text;
     case 'warning':
       return theme.colors.warning.text;
+    case 'accent':
+      return theme.colors.accent.text;
+    case 'tertiary':
+      return theme.colors.tertiary.text;
     default:
       return color ? theme.colors.text[color] : undefined;
   }

--- a/packages/grafana-ui/src/index.ts
+++ b/packages/grafana-ui/src/index.ts
@@ -340,6 +340,12 @@ export { TimeRangeInput } from './components/DateTimePickers/TimeRangeInput';
 export { RelativeTimeRangePicker } from './components/DateTimePickers/RelativeTimeRangePicker/RelativeTimeRangePicker';
 export { Card, type Props as CardProps, getCardStyles } from './components/Card/Card';
 export { CardContainer, type CardContainerProps } from './components/Card/CardContainer';
+export {
+  ColorCard,
+  type ColorCardVariant,
+  type ColorCardSize,
+  type Props as ColorCardProps,
+} from './components/ColorCard/ColorCard';
 export { FormattedValueDisplay } from './components/FormattedValueDisplay/FormattedValueDisplay';
 export { ButtonSelect } from './components/Dropdown/ButtonSelect';
 export { Dropdown } from './components/Dropdown/Dropdown';

--- a/packages/grafana-ui/src/utils/storybook/withTheme.tsx
+++ b/packages/grafana-ui/src/utils/storybook/withTheme.tsx
@@ -24,7 +24,7 @@ const ThemeableStory = ({ children, handleSassThemeChange, themeId }: React.Prop
   }
 
   body {
-    background: ${theme.colors.background.primary};
+    background: ${theme.colors.background.page};
   }
   `;
 

--- a/public/app/core/components/AppNotifications/AppNotificationItem.tsx
+++ b/public/app/core/components/AppNotifications/AppNotificationItem.tsx
@@ -29,6 +29,7 @@ export default function AppNotificationItem({ appNotification, onClearNotificati
       title={appNotification.title}
       onRemove={() => onClearNotification(appNotification.id)}
       elevated
+      bottomSpacing={0}
     >
       {hasBody && (
         <div className={styles.wrapper}>

--- a/public/app/core/components/AppNotifications/AppNotificationList.tsx
+++ b/public/app/core/components/AppNotifications/AppNotificationList.tsx
@@ -92,7 +92,7 @@ export function AppNotificationList() {
     <Portal>
       <div className={styles.wrapper}>
         <div className="sr-only" role="log" aria-live="polite" aria-atomic="true" aria-label={liveRegionMessage} />
-        <Stack direction="column">
+        <Stack direction="column" gap={2}>
           {appNotifications.map((appNotification, index) => {
             return (
               <AppNotificationItem
@@ -116,8 +116,8 @@ function getStyles(theme: GrafanaTheme2) {
       minWidth: 400,
       maxWidth: 600,
       position: 'fixed',
-      right: 6,
-      top: 88,
+      right: theme.spacing(2),
+      bottom: theme.spacing(2),
     }),
   };
 }

--- a/public/app/types/appNotifications.ts
+++ b/public/app/types/appNotifications.ts
@@ -18,9 +18,9 @@ export enum AppNotificationSeverity {
 }
 
 enum AppNotificationTimeout {
-  Success = 3000,
-  Warning = 5000,
-  Error = 7000,
+  Success = 300000,
+  Warning = 500000,
+  Error = 700000,
 }
 
 export const timeoutMap = {


### PR DESCRIPTION
## Problem: 

Current (new visual refresh) alerts can be very high contrast and distracting, especially for large info or error boxes (which we have many). 

One reason for this is that we now use the same background for solid buttons as we do for Alerts (I think this could be a big future problem, locking us into this outline-style solid button look). 

<img width="821" height="836" alt="Screenshot 2026-08-22 at 09 29 03" src="https://github.com/user-attachments/assets/aed7e7b1-15b0-49d7-a462-c3dfee47c026" /> <br>

<img width="1515" height="1334" alt="Screenshot 2026-08-22 at 10 03 36" src="https://github.com/user-attachments/assets/9094e4ea-acc1-4e26-8fcf-3f64e2dd440c" />

<img width="1348" height="855" alt="Screenshot 2026-08-22 at 10 07 44" src="https://github.com/user-attachments/assets/205d4c37-9f3c-4330-87cd-b93fbd636f47" />

<img width="1231" height="828" alt="Screenshot 2026-08-23 at 08 15 36" src="https://github.com/user-attachments/assets/85d6887c-79ef-4699-bfea-eefe849c2535" />


We also have many uses of large info boxes in page headings where a more neutral or calm look could be needed (and different sizes).


<img width="1221" height="160" alt="Screenshot 2026-08-23 at 08 12 40" src="https://github.com/user-attachments/assets/9ce3e347-bb62-492d-99b2-43ac7e2932ea" />
<img width="1164" height="126" alt="Screenshot 2026-08-23 at 08 12 42" src="https://github.com/user-attachments/assets/32d2a811-10c7-4e16-97c3-6b4526dca3a7" />

### So would like to 

* Have less strong/bright backgrounds on these alerts
* Introduce sizes 
* Add more variants (colors), for accent & tertiary and (and card/neutral). With custom icon options. 

I think this probably warrants a new component that breaks up the parts a bit to give more control (ie similar to Card). Anyway, just exploring the styles here

### First tries (discarded, but could revisit, uses gradients so more stylized). They are almost borderless and so feel very calm / less screamy. 

<img width="790" height="818" alt="Screenshot 2026-08-22 at 15 19 09" src="https://github.com/user-attachments/assets/6248aa60-bf04-4c7a-9fda-691ab3f3b876" />
<img width="788" height="819" alt="Screenshot 2026-08-22 at 15 41 53" src="https://github.com/user-attachments/assets/4959476a-a0e5-44b8-8452-519ddb302bdd" />

### Direction that looks promising 

<img width="881" height="724" alt="Screenshot 2026-08-23 at 08 22 59" src="https://github.com/user-attachments/assets/f236b34d-17e7-4bd3-a02f-e09b9d04d4f6" /> <br>
<img width="1201" height="452" alt="Screenshot 2026-08-23 at 08 20 39" src="https://github.com/user-attachments/assets/5d60855f-eaf3-4a3e-843a-75542b476c07" />  <br>

Sizes (sm for app notification toasts), lg for large page header boxes 

<img width="893" height="385" alt="Screenshot 2026-08-23 at 08 21 10" src="https://github.com/user-attachments/assets/91d414a1-74d1-46a7-b162-02282f079ed5" /> <br>


### Light theme: 

<img width="864" height="695" alt="Screenshot 2026-08-23 at 08 25 46" src="https://github.com/user-attachments/assets/9ad1b1c2-46ea-4ded-a93b-1401b939b983" />

