### PR TITLE
Plugins: make the CLI resolve the plugin directory from configuration like the server does

### DIFF
--- a/docs/sources/administration/cli.md
+++ b/docs/sources/administration/cli.md
@@ -76,9 +76,11 @@ grafana cli -h
 grafana cli -v
 ```
 
-### Override default plugin directory
+### Override the plugin directory
 
-`--pluginsDir value` overrides the path to where your local Grafana instance stores plugins. Use this option if you want to install, update, or remove a plugin somewhere other than the default directory ("/var/lib/grafana/plugins") [$GF_PLUGIN_DIR].
+`--pluginsDir value` overrides the path to where your local Grafana instance stores plugins. Use this option if you want to install, update, or remove a plugin somewhere other than the configured plugin directory [$GF_PLUGIN_DIR].
+
+When you don't set `--pluginsDir` or `GF_PLUGIN_DIR`, the CLI uses the server's `paths.plugins` configuration. You can set this value with the `GF_PATHS_PLUGINS` environment variable, a `cfg:default.paths.plugins` entry passed through `--configOverrides`, or the `[paths] plugins` setting in the configuration file passed with `--config` (or in `conf/custom.ini`). If no configuration can be resolved, the CLI falls back to the built-in default for your operating system.
 
 **Example:**
 

--- a/packaging/wrappers/grafana
+++ b/packaging/wrappers/grafana
@@ -39,11 +39,6 @@ if [ "$1" = cli ] || [ "$1" = server ]; then
     "--config=${CONF_FILE}"
     "--configOverrides=cfg:default.paths.provisioning=${PROVISIONING_CFG_DIR} cfg:default.paths.data=${DATA_DIR} cfg:default.paths.logs=${LOG_DIR} cfg:default.paths.plugins=${PLUGINS_DIR} cfg:default.paths.bundled_plugins=${DATA_DIR}/plugins-bundled"
   )
-  # special handling to pass --pluginsDir to cli
-  # can remove once it fully supports cfg:default.paths.plugins
-  if [ "$CMD" = cli ]; then
-    OPTS+=("--pluginsDir=${PLUGINS_DIR}")
-  fi
   exec "$EXECUTABLE" "$CMD" "${OPTS[@]}" "$@"
 fi
 

--- a/pkg/cmd/grafana-cli/utils/command_line.go
+++ b/pkg/cmd/grafana-cli/utils/command_line.go
@@ -1,8 +1,11 @@
 package utils
 
 import (
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 
 	"github.com/urfave/cli/v2"
 
@@ -37,6 +40,12 @@ type ApiClient interface {
 
 type ContextCommandLine struct {
 	*cli.Context
+
+	// Config() parses the full configuration, which is too costly to repeat
+	// for every lookup; memoize it per command invocation.
+	cfgOnce   sync.Once
+	parsedCfg *setting.Cfg
+	cfgErr    error
 }
 
 func (c *ContextCommandLine) ShowHelp() error {
@@ -55,8 +64,58 @@ func (c *ContextCommandLine) HomePath() string { return c.String("homepath") }
 
 func (c *ContextCommandLine) ConfigFile() string { return c.String("config") }
 
+/*
+The plugin directory is determined in the following order:
+1. --pluginsDir flag value if it is specified
+2. --pluginsDir flag value if set via the environment variable called "GF_PLUGIN_DIR"
+3. paths.plugins from configuration (GF_PATHS_PLUGINS environment variable,
+   cfg:* overrides, config file, or conf/defaults.ini)
+4. fallback to default value which depends on the operating system
+**/
+
 func (c *ContextCommandLine) PluginDirectory() string {
+	// since the pluginsDir flag always has a value set by default we are checking in the flag lists
+	// if the --pluginsDir flag was provided at all.
+	if slices.Contains(c.FlagNames(), "pluginsDir") {
+		return c.String("pluginsDir")
+	}
+
+	// Only parse configuration when it can be resolved: NewCfgFromArgs exits
+	// when conf/defaults.ini cannot be found, which must not turn config-less
+	// invocations into hard errors.
+	if c.configResolvable() {
+		cfg, err := c.Config()
+		if err != nil {
+			logger.Debug("Could not parse config file", err)
+		} else if len(cfg.PluginsPaths) > 0 && cfg.PluginsPaths[0] != "" {
+			// PluginsPaths[0] is the writable plugin dir, matching what the
+			// server-side installer uses; [1] is the bundled plugins dir.
+			return cfg.PluginsPaths[0]
+		}
+	}
+
+	// fallback to flag value
 	return c.String("pluginsDir")
+}
+
+// configResolvable reports whether loading the full configuration can succeed.
+// setting.loadConfiguration exits the process when <homepath>/conf/defaults.ini
+// is missing, so probe for that file using the same homepath resolution as
+// setHomePath before attempting a load.
+func (c *ContextCommandLine) configResolvable() bool {
+	home := c.HomePath()
+	if home == "" {
+		home = "."
+	}
+	for _, p := range []string{
+		filepath.Join(home, "conf", "defaults.ini"),
+		filepath.Join(home, "..", "conf", "defaults.ini"),
+	} {
+		if _, err := os.Stat(p); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 /*
@@ -90,12 +149,15 @@ func (c *ContextCommandLine) PluginRepoURL() string {
 }
 
 func (c *ContextCommandLine) Config() (*setting.Cfg, error) {
-	configOptions := strings.Split(c.String("configOverrides"), " ")
-	return setting.NewCfgFromArgs(setting.CommandLineArgs{
-		Config:   c.ConfigFile(),
-		HomePath: c.HomePath(),
-		Args:     append(configOptions, c.Args().Slice()...),
+	c.cfgOnce.Do(func() {
+		configOptions := strings.Split(c.String("configOverrides"), " ")
+		c.parsedCfg, c.cfgErr = setting.NewCfgFromArgs(setting.CommandLineArgs{
+			Config:   c.ConfigFile(),
+			HomePath: c.HomePath(),
+			Args:     append(configOptions, c.Args().Slice()...),
+		})
 	})
+	return c.parsedCfg, c.cfgErr
 }
 
 func (c *ContextCommandLine) GcomToken() string {

--- a/pkg/cmd/grafana-cli/utils/command_line.go
+++ b/pkg/cmd/grafana-cli/utils/command_line.go
@@ -82,7 +82,10 @@ func (c *ContextCommandLine) PluginDirectory() string {
 
 	// Only parse configuration when the defaults file is resolvable:
 	// setting.loadConfiguration exits when conf/defaults.ini cannot be found,
-	// which must not turn config-less invocations into hard errors.
+	// which must not turn config-less invocations into hard errors. When a
+	// resolvable configuration is invalid (--config missing or malformed,
+	// corrupt defaults.ini), loading still terminates like every other
+	// Config()-based lookup in this file.
 	if c.configResolvable() {
 		cfg, err := c.Config()
 		if err != nil {

--- a/pkg/cmd/grafana-cli/utils/command_line.go
+++ b/pkg/cmd/grafana-cli/utils/command_line.go
@@ -100,17 +100,21 @@ func (c *ContextCommandLine) PluginDirectory() string {
 
 // configResolvable reports whether loading the full configuration can succeed.
 // setting.loadConfiguration exits the process when <homepath>/conf/defaults.ini
-// is missing, so probe for that file using the same homepath resolution as
-// setHomePath before attempting a load.
+// is missing, so probe for that file before attempting a load. The candidates
+// must mirror setHomePath exactly: an explicit --homepath is used verbatim,
+// while an empty one falls back to the working directory and then its parent.
 func (c *ContextCommandLine) configResolvable() bool {
 	home := c.HomePath()
-	if home == "" {
-		home = "."
+	var candidates []string
+	if home != "" {
+		candidates = []string{filepath.Join(home, "conf", "defaults.ini")}
+	} else {
+		candidates = []string{
+			filepath.Join(".", "conf", "defaults.ini"),
+			filepath.Join("..", "conf", "defaults.ini"),
+		}
 	}
-	for _, p := range []string{
-		filepath.Join(home, "conf", "defaults.ini"),
-		filepath.Join(home, "..", "conf", "defaults.ini"),
-	} {
+	for _, p := range candidates {
 		if _, err := os.Stat(p); err == nil {
 			return true
 		}

--- a/pkg/cmd/grafana-cli/utils/command_line.go
+++ b/pkg/cmd/grafana-cli/utils/command_line.go
@@ -80,9 +80,9 @@ func (c *ContextCommandLine) PluginDirectory() string {
 		return c.String("pluginsDir")
 	}
 
-	// Only parse configuration when it can be resolved: NewCfgFromArgs exits
-	// when conf/defaults.ini cannot be found, which must not turn config-less
-	// invocations into hard errors.
+	// Only parse configuration when the defaults file is resolvable:
+	// setting.loadConfiguration exits when conf/defaults.ini cannot be found,
+	// which must not turn config-less invocations into hard errors.
 	if c.configResolvable() {
 		cfg, err := c.Config()
 		if err != nil {

--- a/pkg/cmd/grafana-cli/utils/command_line_test.go
+++ b/pkg/cmd/grafana-cli/utils/command_line_test.go
@@ -104,6 +104,24 @@ func TestPluginDirectory_HonorsEnvVar(t *testing.T) {
 	require.Equal(t, configDir, c.PluginDirectory())
 }
 
+func TestPluginDirectory_PluginDirEnvVarBeatsConfig(t *testing.T) {
+	flagEnvDir := t.TempDir()
+	configDir := t.TempDir()
+	home := writeGrafDir(t, map[string]string{"plugins": "data/plugins"})
+
+	c, err := newTestFlagContext(map[string]string{
+		"pluginsDir":      flagEnvDir,
+		"homepath":        home,
+		"configOverrides": "cfg:paths.plugins=" + configDir,
+	})
+	require.NoError(t, err)
+
+	// GF_PLUGIN_DIR binds to the --pluginsDir flag (urfave marks env-set flags
+	// as explicitly set), so it must win over any configuration value.
+	t.Setenv("GF_PLUGIN_DIR", flagEnvDir)
+	require.Equal(t, flagEnvDir, c.PluginDirectory())
+}
+
 func TestPluginDirectory_FallsBackWhenNoConfigSources(t *testing.T) {
 	emptyHome := t.TempDir()
 

--- a/pkg/cmd/grafana-cli/utils/command_line_test.go
+++ b/pkg/cmd/grafana-cli/utils/command_line_test.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -18,10 +19,23 @@ import (
 // how commands/commandstest constructs one (kept local to avoid an import
 // cycle: commandstest imports this package).
 func newTestFlagContext(flags map[string]string) (*ContextCommandLine, error) {
+	return newTestFlagContextWithDefaults(nil, flags)
+}
+
+// newTestFlagContextWithDefaults registers flags with default values without
+// marking them as explicitly set (urfave only records Set() calls in
+// FlagNames), reproducing how production flags carry defaults the user never
+// passed.
+func newTestFlagContextWithDefaults(defaults, set map[string]string) (*ContextCommandLine, error) {
 	app := cli.App{Name: "Test"}
 	flagSet := flag.NewFlagSet("Test", 0)
-	for name, value := range flags {
-		flagSet.String(name, "", "")
+	for name, value := range defaults {
+		flagSet.String(name, value, "")
+	}
+	for name, value := range set {
+		if flagSet.Lookup(name) == nil {
+			flagSet.String(name, "", "")
+		}
 		if err := flagSet.Set(name, value); err != nil {
 			return nil, err
 		}
@@ -35,6 +49,11 @@ func newTestFlagContext(flags map[string]string) (*ContextCommandLine, error) {
 func writeGrafDir(t *testing.T, paths map[string]string) string {
 	t.Helper()
 	home := t.TempDir()
+	return writeGrafDirIn(t, home, paths)
+}
+
+func writeGrafDirIn(t *testing.T, home string, paths map[string]string) string {
+	t.Helper()
 	confDir := filepath.Join(home, "conf")
 	require.NoError(t, os.MkdirAll(confDir, 0o750))
 
@@ -125,13 +144,36 @@ func TestPluginDirectory_PluginDirEnvVarBeatsConfig(t *testing.T) {
 func TestPluginDirectory_FallsBackWhenNoConfigSources(t *testing.T) {
 	emptyHome := t.TempDir()
 
+	// pluginsDir must NOT be marked as set here: with the flag explicitly set
+	// PluginDirectory returns before consulting configuration at all, so this
+	// test would never exercise the unresolvable-config fallback. The flag is
+	// registered with its production default instead, mirroring cli.go.
+	def := GetGrafanaPluginDir(runtime.GOOS)
+	c, err := newTestFlagContextWithDefaults(
+		map[string]string{"pluginsDir": def},
+		map[string]string{"homepath": emptyHome},
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, def, c.PluginDirectory())
+}
+
+func TestPluginDirectory_ExplicitHomepathDoesNotWalkUp(t *testing.T) {
+	// An explicit --homepath without conf/defaults.ini must fall back to the
+	// flag value even when the parent directory contains a defaults.ini:
+	// setHomePath only walks up for an empty homepath, so probing the parent
+	// here would let NewCfgFromArgs exit the process.
+	parent := t.TempDir()
+	writeGrafDirIn(t, parent, map[string]string{"plugins": "data/plugins"})
+	emptyHome := filepath.Join(parent, "child")
+	require.NoError(t, os.MkdirAll(emptyHome, 0o750))
+
 	c, err := newTestFlagContext(map[string]string{
-		"pluginsDir": "/from/flag/default",
-		"homepath":   emptyHome,
+		"homepath": emptyHome,
 	})
 	require.NoError(t, err)
 
-	require.Equal(t, "/from/flag/default", c.PluginDirectory())
+	require.False(t, c.configResolvable())
 }
 
 func TestPluginDirectory_MemoizesConfig(t *testing.T) {

--- a/pkg/cmd/grafana-cli/utils/command_line_test.go
+++ b/pkg/cmd/grafana-cli/utils/command_line_test.go
@@ -1,0 +1,136 @@
+package utils
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+// Regression tests for grafana/grafana#119284: the plugin directory must
+// follow the configuration precedence the server uses instead of only looking
+// at the raw --pluginsDir flag.
+
+// newTestFlagContext builds a ContextCommandLine from a flag map, mirroring
+// how commands/commandstest constructs one (kept local to avoid an import
+// cycle: commandstest imports this package).
+func newTestFlagContext(flags map[string]string) (*ContextCommandLine, error) {
+	app := cli.App{Name: "Test"}
+	flagSet := flag.NewFlagSet("Test", 0)
+	for name, value := range flags {
+		flagSet.String(name, "", "")
+		if err := flagSet.Set(name, value); err != nil {
+			return nil, err
+		}
+	}
+	return &ContextCommandLine{Context: cli.NewContext(&app, flagSet, nil)}, nil
+}
+
+// writeGrafDir creates a minimal home directory whose conf/defaults.ini
+// declares the given [paths] keys, so config resolution has a baseline to
+// override (applyCommandLineDefaultProperties only touches existing keys).
+func writeGrafDir(t *testing.T, paths map[string]string) string {
+	t.Helper()
+	home := t.TempDir()
+	confDir := filepath.Join(home, "conf")
+	require.NoError(t, os.MkdirAll(confDir, 0o750))
+
+	content := "[paths]\n"
+	for k, v := range paths {
+		content += k + " = " + v + "\n"
+	}
+	// initLogging resolves the default "console" log mode, which requires a
+	// log.console section to exist in the parsed configuration.
+	content += "\n[log]\nmode = console\n\n[log.console]\nlevel = warn\n"
+	require.NoError(t, os.WriteFile(filepath.Join(confDir, "defaults.ini"), []byte(content), 0o640))
+	return home
+}
+
+func TestPluginDirectory_ExplicitFlagBeatsConfig(t *testing.T) {
+	flagDir := t.TempDir()
+	configDir := t.TempDir()
+	home := writeGrafDir(t, map[string]string{"plugins": "data/plugins"})
+
+	c, err := newTestFlagContext(map[string]string{
+		"pluginsDir":      flagDir,
+		"homepath":        home,
+		"configOverrides": "cfg:default.paths.plugins=" + configDir,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, flagDir, c.PluginDirectory())
+}
+
+func TestPluginDirectory_HonorsConfigOverride(t *testing.T) {
+	configDir := t.TempDir()
+	home := writeGrafDir(t, map[string]string{"plugins": "data/plugins"})
+
+	c, err := newTestFlagContext(map[string]string{
+		"homepath":        home,
+		"configOverrides": "cfg:default.paths.plugins=" + configDir,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, configDir, c.PluginDirectory())
+}
+
+func TestPluginDirectory_HonorsConfigFile(t *testing.T) {
+	configDir := t.TempDir()
+	home := writeGrafDir(t, map[string]string{"plugins": "data/plugins"})
+
+	customIni := filepath.Join(t.TempDir(), "custom.ini")
+	require.NoError(t, os.WriteFile(customIni, []byte("[paths]\nplugins = "+configDir+"\n"), 0o640))
+
+	c, err := newTestFlagContext(map[string]string{
+		"homepath": home,
+		"config":   customIni,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, configDir, c.PluginDirectory())
+}
+
+func TestPluginDirectory_HonorsEnvVar(t *testing.T) {
+	configDir := t.TempDir()
+	home := writeGrafDir(t, map[string]string{"plugins": "data/plugins"})
+
+	c, err := newTestFlagContext(map[string]string{"homepath": home})
+	require.NoError(t, err)
+
+	t.Setenv("GF_PATHS_PLUGINS", configDir)
+	require.Equal(t, configDir, c.PluginDirectory())
+}
+
+func TestPluginDirectory_FallsBackWhenNoConfigSources(t *testing.T) {
+	emptyHome := t.TempDir()
+
+	c, err := newTestFlagContext(map[string]string{
+		"pluginsDir": "/from/flag/default",
+		"homepath":   emptyHome,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, "/from/flag/default", c.PluginDirectory())
+}
+
+func TestPluginDirectory_MemoizesConfig(t *testing.T) {
+	configDir := t.TempDir()
+	home := writeGrafDir(t, map[string]string{"plugins": "data/plugins"})
+
+	c, err := newTestFlagContext(map[string]string{
+		"homepath":        home,
+		"configOverrides": "cfg:default.paths.plugins=" + configDir,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, configDir, c.PluginDirectory())
+
+	first, err := c.Config()
+	require.NoError(t, err)
+	second, err := c.Config()
+	require.NoError(t, err)
+	require.Same(t, first, second)
+}

--- a/pkg/cmd/grafana-cli/utils/command_line_test.go
+++ b/pkg/cmd/grafana-cli/utils/command_line_test.go
@@ -70,13 +70,12 @@ func writeGrafDirIn(t *testing.T, home string, paths map[string]string) string {
 
 func TestPluginDirectory_ExplicitFlagBeatsConfig(t *testing.T) {
 	flagDir := t.TempDir()
-	configDir := t.TempDir()
 	home := writeGrafDir(t, map[string]string{"plugins": "data/plugins"})
 
 	c, err := newTestFlagContext(map[string]string{
 		"pluginsDir":      flagDir,
 		"homepath":        home,
-		"configOverrides": "cfg:default.paths.plugins=" + configDir,
+		"configOverrides": "cfg:default.paths.plugins=override/plugins",
 	})
 	require.NoError(t, err)
 
@@ -84,12 +83,12 @@ func TestPluginDirectory_ExplicitFlagBeatsConfig(t *testing.T) {
 }
 
 func TestPluginDirectory_HonorsConfigOverride(t *testing.T) {
-	configDir := t.TempDir()
 	home := writeGrafDir(t, map[string]string{"plugins": "data/plugins"})
+	configDir := filepath.Join(home, "override", "plugins")
 
 	c, err := newTestFlagContext(map[string]string{
 		"homepath":        home,
-		"configOverrides": "cfg:default.paths.plugins=" + configDir,
+		"configOverrides": "cfg:default.paths.plugins=override/plugins",
 	})
 	require.NoError(t, err)
 
@@ -125,20 +124,35 @@ func TestPluginDirectory_HonorsEnvVar(t *testing.T) {
 
 func TestPluginDirectory_PluginDirEnvVarBeatsConfig(t *testing.T) {
 	flagEnvDir := t.TempDir()
-	configDir := t.TempDir()
 	home := writeGrafDir(t, map[string]string{"plugins": "data/plugins"})
 
-	c, err := newTestFlagContext(map[string]string{
-		"pluginsDir":      flagEnvDir,
-		"homepath":        home,
-		"configOverrides": "cfg:paths.plugins=" + configDir,
+	t.Setenv("GF_PLUGIN_DIR", flagEnvDir)
+
+	var pluginDir string
+	app := cli.App{
+		Name: "Test",
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "homepath"},
+			&cli.StringFlag{Name: "configOverrides"},
+			&cli.StringFlag{
+				Name:    "pluginsDir",
+				Value:   GetGrafanaPluginDir(runtime.GOOS),
+				EnvVars: []string{"GF_PLUGIN_DIR"},
+			},
+		},
+		Action: func(ctx *cli.Context) error {
+			pluginDir = (&ContextCommandLine{Context: ctx}).PluginDirectory()
+			return nil
+		},
+	}
+
+	err := app.Run([]string{
+		"Test",
+		"--homepath", home,
+		"--configOverrides", "cfg:default.paths.plugins=override/plugins",
 	})
 	require.NoError(t, err)
-
-	// GF_PLUGIN_DIR binds to the --pluginsDir flag (urfave marks env-set flags
-	// as explicitly set), so it must win over any configuration value.
-	t.Setenv("GF_PLUGIN_DIR", flagEnvDir)
-	require.Equal(t, flagEnvDir, c.PluginDirectory())
+	require.Equal(t, flagEnvDir, pluginDir)
 }
 
 func TestPluginDirectory_FallsBackWhenNoConfigSources(t *testing.T) {
@@ -177,12 +191,12 @@ func TestPluginDirectory_ExplicitHomepathDoesNotWalkUp(t *testing.T) {
 }
 
 func TestPluginDirectory_MemoizesConfig(t *testing.T) {
-	configDir := t.TempDir()
 	home := writeGrafDir(t, map[string]string{"plugins": "data/plugins"})
+	configDir := filepath.Join(home, "override", "plugins")
 
 	c, err := newTestFlagContext(map[string]string{
 		"homepath":        home,
-		"configOverrides": "cfg:default.paths.plugins=" + configDir,
+		"configOverrides": "cfg:default.paths.plugins=override/plugins",
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
**What is this feature?**

`grafana cli` now resolves the plugin directory the same way `grafana server` does. Previously every plugin subcommand (`plugins ls`, `plugins install`, `plugins remove`, `plugins upgrade`, `plugins upgrade-all`) looked *only* at its own `--pluginsDir` flag and silently ignored:

- `--configOverrides=cfg:default.paths.plugins=...`
- `GF_PATHS_PLUGINS`
- `[paths] plugins` in the config file (`--config` / `conf/custom.ini`)

so the CLI could list, install into, or remove from a completely different directory than the server uses, without any warning.

The resolution order is now:

1. `--pluginsDir` flag (or `GF_PLUGIN_DIR`, which binds to that flag)
2. configuration — `GF_PATHS_PLUGINS` env var, `cfg:*` overrides, config file, `conf/defaults.ini` — using the same precedence rules as the server
3. built-in OS default (unchanged fallback when no config can be resolved)

**Why do we need this feature?**

Reported in #119284: operators who configure plugin paths through config files or environment variables (common in containers and systemd units) get confusing results because CLI-side commands ignore those settings while server-side behavior honors them. The flag was accepted but never applied, with no warning emitted.

**Who is this feature for?**

Anyone administering Grafana through configuration management — packaged installs, Docker, systemd, IaC — who runs `grafana cli plugins ...` against a configured plugin directory.

**Which issue(s) does this PR fix?**

Fixes #119284

**Special notes for your reviewer:**

- The change follows the existing pattern in `PluginRepoURL()` in the same file (explicit-flag detection via `FlagNames()`, graceful fallback on config parse errors).
- Config parsing is memoized per invocation (`sync.Once`) since `PluginDirectory()` can be called multiple times per command.
- A guard avoids calling into config loading when `<homepath>/conf/defaults.ini` cannot be found at all — `setting.loadConfiguration` exits the process in that case, which would turn previously-working bare invocations into hard errors.
- Only the writable plugin dir (`PluginsPaths[0]`) is used, matching what the server-side installer does; bundled plugins are untouched.
- Behavior change worth noting in release notes: config-declared plugin dirs are now honored by the CLI when no explicit `--pluginsDir`/`GF_PLUGIN_DIR` is given.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.

**Testing**

New unit tests in `pkg/cmd/grafana-cli/utils/command_line_test.go` cover each resolution tier and were verified to fail before the fix and pass after:

- explicit `--pluginsDir` beats config
- `cfg:default.paths.plugins` override honored
- config file `[paths] plugins` honored
- `GF_PATHS_PLUGINS` env var honored
- graceful fallback when no config sources exist
- config parsing memoized across calls

Also verified manually with a locally built binary (Windows): `plugins ls` and `plugins remove` now follow `--configOverrides` and `GF_PATHS_PLUGINS`, explicit flag still wins, and invocations without any config behave exactly as before.

```
go test ./pkg/cmd/grafana-cli/...
go test -race ./pkg/cmd/grafana-cli/...
go vet ./pkg/cmd/grafana-cli/...
```
