### PR TITLE
Fix TimePicker relative time parsing for 6+ digit values (now-604800s)

### DIFF
--- a/packages/grafana-data/src/datetime/datemath.ts
+++ b/packages/grafana-data/src/datetime/datemath.ts
@@ -14,7 +14,7 @@ import {
 } from './moment_wrapper';
 
 const units: string[] = ['y', 'M', 'w', 'd', 'h', 'm', 's', 'Q'] satisfies DurationUnit[];
-const MAX_MATH_TOKEN_DIGITS = 5;
+const MAX_MATH_TOKEN_DIGITS = 10;
 
 export const isDurationUnit = (value: string): value is DurationUnit => {
   return units.includes(value);


### PR DESCRIPTION
Fixes #131338

### Problem

`parseDateMath` in `packages/grafana-data/src/datetime/datemath.ts:17` limits per-token digits to 5 (`MAX_MATH_TOKEN_DIGITS=5`). `now-99999s` (5 digits) parses, but `now-100000s` (6), `now-604800s` (7d) and `now-2592000s` (30d) return `undefined`. The limit counts digits, not duration, so `now-99999y` (≈100 millennia) parses while `now-100000s` (≈28h) does not.

`RelativeTimeRangePicker/utils.ts` already allows `\d{1,10}`, and the regression was introduced when the per-token guard was added (5 was too low).

### Change

Increase `MAX_MATH_TOKEN_DIGITS` from `5` to `10` to match the existing `1,10` range and to cover 10-digit second counts (≈115 days in seconds, 10 digits ≈ 68 years).

### Validation

- Before: `parseDateMath('now-604800s', false)` → `undefined`; After: parses to correct `DateTime`
- `now-100000s`, `now-2592000s` similarly fixed; `now-99999y` still parses
- Change is isolated to `datemath.ts:17`; existing `datemath.test.ts` expected to be unaffected (limit was 5, new limit is 10, so 5-digit cases still pass)
