### PR TITLE
Fix panel relative time TypeError and 6+ digit parsing (now-604800s)

### DIFF
--- a/packages/grafana-data/src/datetime/datemath.ts
+++ b/packages/grafana-data/src/datetime/datemath.ts
@@ -14,7 +14,7 @@ import {
 } from './moment_wrapper';
 
 const units: string[] = ['y', 'M', 'w', 'd', 'h', 'm', 's', 'Q'] satisfies DurationUnit[];
-const MAX_MATH_TOKEN_DIGITS = 5;
+const MAX_MATH_TOKEN_DIGITS = 10;
 
 export const isDurationUnit = (value: string): value is DurationUnit => {
   return units.includes(value);

--- a/packages/grafana-data/src/datetime/rangeutil.ts
+++ b/packages/grafana-data/src/datetime/rangeutil.ts
@@ -411,7 +411,7 @@ export function describeTextRange(expr: string): TimeOption {
     opt = { from: 'now', to: expr, display: '' };
   }
 
-  const parts = /^now([-+])(\d+)(f[Qy]|[yMwdhmsQ])/.exec(expr);
+  const parts = /^now([-+])(\d{1,10})(f[Qy]|[yMwdhmsQ])$/.exec(expr);
   if (parts) {
     const unit = parts[3];
     const amount = parseInt(parts[2], 10);
@@ -578,6 +578,10 @@ export function msRangeToTimeString(rangeMs: number): string {
 }
 
 export function calculateInterval(range: TimeRange, resolution: number, lowLimitInterval?: string): IntervalValues {
+  if (!isDateTime(range.from) || !isDateTime(range.to)) {
+    throw new Error(`failed to parse relative time "${String(range.from)}"`);
+  }
+
   let lowLimitMs = 1; // 1 millisecond default low limit
   if (lowLimitInterval) {
     lowLimitMs = intervalToMs(lowLimitInterval);


### PR DESCRIPTION
Fixes #131339

### Problem

When a panel `Relative time` fails to parse, `from: undefined` reaches `calculateInterval` at `rangeutil.ts:586`:

```ts
range.to.valueOf() - range.from.valueOf() // TypeError: Q.from.valueOf
```

`isValidTimeSpan` delegates to `describeTextRange` which used `/^now([-+])(\d+)(f[Qy]|[yMwdhmsQ])/` without `$` or digit bound, so values that `dateMath.parse` rejects (e.g. 6+ digits before the `MAX_MATH_TOKEN_DIGITS` fix) still pass validation and become `from: undefined`. The panel shows a badge and `PanelQueryRunner Error TypeError…` with no panel/field/value context.

Related: #131338 (`MAX_MATH_TOKEN_DIGITS 5→10`).

### Change

- `datemath.ts:17` `MAX_MATH_TOKEN_DIGITS 5→10` (same as #131338) so `now-604800s` parses
- `rangeutil.ts:414` `describeTextRange` regex `(\d+)` → `(\d{1,10})` + `$` anchor to match parser and `RelativeTimeRangePicker` `\d{1,10}`
- `rangeutil.ts:580` `calculateInterval` now throws `failed to parse relative time "<from>"` when `from`/`to` is not a `DateTime`, instead of `TypeError`

### Validation

- `now-604800s` / `now-2592000s` now parse; `isValidTimeSpan('604800s')` true, `describeTextRange('now-604800s')` valid, `calculateInterval` no longer throws `Q.from.valueOf` for `from: undefined` (throws descriptive error)
