### PR TITLE
Apiserver: add openapi_v2_enabled to skip building the v2 swagger

### DIFF
--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -263,6 +263,15 @@ func (s *service) RegisterAppInstaller(i appsdkapiserver.AppInstaller) {
 	s.appInstallers = append(s.appInstallers, i)
 }
 
+// applyOpenAPIV2Setting drops the v2 OpenAPI config when a deployment has turned
+// /openapi/v2 off. OpenAPIV3Config is left alone.
+func applyOpenAPIV2Setting(serverConfig *genericapiserver.RecommendedConfig, apiserverSection *setting.DynamicSection) {
+	if apiserverSection.Key("openapi_v2_enabled").MustBool(true) {
+		return
+	}
+	serverConfig.OpenAPIConfig = nil
+}
+
 // nolint:gocyclo
 func (s *service) start(ctx context.Context) error {
 	// Get the list of groups the server will support
@@ -424,6 +433,8 @@ func (s *service) start(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	applyOpenAPIV2Setting(serverConfig, apiserverSection)
 
 	serverConfig.AdmissionControl, err = appinstaller.RegisterAdmission(
 		serverConfig.AdmissionControl,

--- a/pkg/services/apiserver/service_test.go
+++ b/pkg/services/apiserver/service_test.go
@@ -13,6 +13,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	discoveryendpoint "k8s.io/apiserver/pkg/endpoints/discovery/aggregated"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	openapicommon "k8s.io/kube-openapi/pkg/common"
+
+	"github.com/grafana/grafana/pkg/registry/apis/search"
+	"github.com/grafana/grafana/pkg/setting"
 
 	"github.com/grafana/grafana/pkg/services/apiserver/versionpolicy"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -167,4 +172,67 @@ func TestReprioritizeDiscovery_ServedOrder(t *testing.T) {
 func TestReprioritizeDiscovery_NoManagerNoop(t *testing.T) {
 	s := &service{vpRegistry: newTestRegistry(nil), groupPriority: testDiscoveryScheme(t).PrioritizedVersionsForGroup}
 	require.NotPanics(t, s.reprioritizeDiscovery)
+}
+
+// configWithBothOpenAPIVersions mirrors what builder.SetupConfig leaves behind: a v2
+// and a v3 OpenAPI config, both non-nil.
+func configWithBothOpenAPIVersions() *genericapiserver.RecommendedConfig {
+	cfg := &genericapiserver.RecommendedConfig{}
+	cfg.OpenAPIConfig = &openapicommon.Config{}
+	cfg.OpenAPIV3Config = &openapicommon.OpenAPIV3Config{}
+	return cfg
+}
+
+func sectionFromINI(t *testing.T, ini string) *setting.DynamicSection {
+	t.Helper()
+	cfg, err := setting.NewCfgFromBytes([]byte(ini))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cfg.SectionWithEnvOverrides(search.ConfigSection)
+}
+
+// The point of the setting is to drop v2 *only*. v3 has to survive, because the
+// frontend reads /openapi/v3/apis/<group>/<version> and genericapiserver's
+// SkipOpenAPIInstallation would have taken both versions down.
+func TestApplyOpenAPIV2Setting(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		ini       string
+		wantV2Nil bool
+	}{
+		{
+			name:      "absent defaults to enabled",
+			ini:       "",
+			wantV2Nil: false,
+		},
+		{
+			name:      "explicitly enabled",
+			ini:       "[grafana-apiserver]\nopenapi_v2_enabled = true\n",
+			wantV2Nil: false,
+		},
+		{
+			name:      "disabled drops v2",
+			ini:       "[grafana-apiserver]\nopenapi_v2_enabled = false\n",
+			wantV2Nil: true,
+		},
+		{
+			name:      "unrelated keys in the section do not disable it",
+			ini:       "[grafana-apiserver]\nenable_search_api = false\n",
+			wantV2Nil: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			serverConfig := configWithBothOpenAPIVersions()
+
+			applyOpenAPIV2Setting(serverConfig, sectionFromINI(t, tc.ini))
+
+			if gotNil := serverConfig.OpenAPIConfig == nil; gotNil != tc.wantV2Nil {
+				t.Errorf("OpenAPIConfig nil = %v, want %v", gotNil, tc.wantV2Nil)
+			}
+			if serverConfig.OpenAPIV3Config == nil {
+				t.Error("OpenAPIV3Config was cleared: /openapi/v3 must keep working, the frontend depends on it")
+			}
+		})
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Delegate half of `[grafana-apiserver] openapi_v2_enabled`. Companion to grafana/grafana-enterprise#13257 (same branch name, so enterprise CI pairs against it).

The delegate builds a full OpenAPI v2 swagger for every installed group during `PrepareRun` and keeps it for the process lifetime (`routes.OpenAPI.InstallV2`) — 1.9% of a production ST Grafana pod's `inuse_space`. Nothing in Grafana's frontend reads `/openapi/v2`; the schema fetchers use `/openapi/v3/apis/<group>/<version>` (`public/app/features/dashboard-scene/v2schema/dashboardSchemaFetcher.ts`).

```ini
[grafana-apiserver]
openapi_v2_enabled = false
```

leaves `OpenAPIConfig` nil, which `genericapiserver` guards on, so neither the v2 spec nor its handler is built. `OpenAPIV3Config` is untouched, so `/openapi/v3` is unaffected — `SkipOpenAPIInstallation` cannot be used here because it gates both versions (`genericapiserver.go:447` and `:453`).

Defaults to `true`, so behaviour is unchanged unless it is set. `kubectl explain` has defaulted to v3 since 1.29 (KEP-3515, stable), but v2 remains reachable via `kubectl explain --output plaintext-openapiv2`, client-go's `OpenAPISchema()`, and clients older than 1.29 — hence opt-in per deployment. The enterprise PR has the full client analysis.

**Which issue(s) this PR fixes**:

**Test coverage**:

The setting is applied by `applyOpenAPIV2Setting`, extracted from `(*service).start` so it can actually be exercised — `start` builds the whole apiserver and is not unit-testable. `TestApplyOpenAPIV2Setting` in `service_test.go` drives it from real ini bytes via `setting.NewCfgFromBytes`:

| case | expectation |
|---|---|
| key absent | v2 kept (default is enabled) |
| `openapi_v2_enabled = true` | v2 kept |
| `openapi_v2_enabled = false` | **v2 dropped** |
| unrelated key in the same section | v2 kept |

Every case also asserts `OpenAPIV3Config` is still non-nil, which is the actual point of this change: drop v2 *only*. Both assertions are mutation-verified — making the helper a no-op fails the disable case, and having it also clear `OpenAPIV3Config` fails every case.

**Special notes for your reviewer**:

The enterprise counterpart disables the aggregator's v2 handler and aggregation controller; this one stops the delegate building its own document. Either can merge alone.


Standalone — not stacked on anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
