### PR TITLE
Chore: Remove jQuery, Flot, whatwg-fetch, and file-saver from boot path

### DIFF
--- a/package.json
+++ b/package.json
@@ -269,6 +269,7 @@
     "webpack-merge": "6.0.1",
     "webpack-subresource-integrity": "^5.2.0-rc.1",
     "webpackbar": "^7.0.0",
+    "whatwg-fetch": "3.6.20",
     "yargs": "^18.0.0",
     "zod": "^4.3.0"
   },
@@ -429,8 +430,7 @@
     "type-fest": "^4.18.2",
     "uplot": "1.6.32",
     "vis-data": "^8.0.0",
-    "vis-network": "10.0.2",
-    "whatwg-fetch": "3.6.20"
+    "vis-network": "10.0.2"
   },
   "resolutions": {
     "underscore": "1.13.8",

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -1,10 +1,6 @@
 import 'symbol-observable';
 import 'regenerator-runtime/runtime';
 
-import 'whatwg-fetch'; // fetch polyfill needed for PhantomJs rendering
-import 'file-saver';
-import 'jquery';
-
 import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 

--- a/public/app/features/plugins/loader/sharedDependencies.test.ts
+++ b/public/app/features/plugins/loader/sharedDependencies.test.ts
@@ -1,0 +1,27 @@
+import { sharedDependenciesMap } from './sharedDependencies';
+
+describe('sharedDependenciesMap', () => {
+  it('loads jQuery only when a plugin requests it', () => {
+    expect(sharedDependenciesMap.jquery).toEqual(expect.any(Function));
+  });
+
+  it('loads Flot only when a plugin requests a Flot dependency', () => {
+    const dependencies = sharedDependenciesMap as Record<string, unknown>;
+    const flotDependencies = [
+      'jquery.flot.crosshair',
+      'jquery.flot.events',
+      'jquery.flot.fillbelow',
+      'jquery.flot.gauge',
+      'jquery.flot.pie',
+      'jquery.flot.selection',
+      'jquery.flot.stack',
+      'jquery.flot.stackpercent',
+      'jquery.flot.time',
+      'jquery.flot',
+    ];
+
+    for (const dependency of flotDependencies) {
+      expect(dependencies[dependency]).toEqual(expect.any(Function));
+    }
+  });
+});

--- a/public/app/features/plugins/loader/sharedDependencies.ts
+++ b/public/app/features/plugins/loader/sharedDependencies.ts
@@ -1,14 +1,3 @@
-import jquery from 'jquery';
-import 'vendor/flot/jquery.flot';
-import 'vendor/flot/jquery.flot.selection';
-import 'vendor/flot/jquery.flot.time';
-import 'vendor/flot/jquery.flot.stack';
-import 'vendor/flot/jquery.flot.stackpercent';
-import 'vendor/flot/jquery.flot.fillbelow';
-import 'vendor/flot/jquery.flot.crosshair';
-import 'vendor/flot/jquery.flot.dashes';
-import 'vendor/flot/jquery.flot.gauge';
-
 import * as grafanaData from '@grafana/data';
 import * as grafanaRuntime from '@grafana/runtime';
 // eslint-disable-next-line no-restricted-imports
@@ -34,6 +23,30 @@ grafanaUI.DataSourcePlugin = grafanaData.DataSourcePlugin;
 grafanaUI.AppPlugin = grafanaData.AppPlugin;
 grafanaUI.DataSourceApi = grafanaData.DataSourceApi;
 
+const loadJQuery = () =>
+  import('jquery').then((module) => ({
+    default: module.default,
+    __useDefault: true,
+  }));
+
+async function loadJQueryFlot() {
+  await loadJQuery();
+  // Flot extensions register themselves on the base plugin, so the base module must load first.
+  await import('vendor/flot/jquery.flot');
+  await Promise.all([
+    import('vendor/flot/jquery.flot.selection'),
+    import('vendor/flot/jquery.flot.time'),
+    import('vendor/flot/jquery.flot.stack'),
+    import('vendor/flot/jquery.flot.stackpercent'),
+    import('vendor/flot/jquery.flot.fillbelow'),
+    import('vendor/flot/jquery.flot.crosshair'),
+    import('vendor/flot/jquery.flot.dashes'),
+    import('vendor/flot/jquery.flot.gauge'),
+  ]);
+
+  return { fakeDep: 1 };
+}
+
 const jQueryFlotDeps = [
   'jquery.flot.crosshair',
   'jquery.flot.events',
@@ -45,7 +58,7 @@ const jQueryFlotDeps = [
   'jquery.flot.stackpercent',
   'jquery.flot.time',
   'jquery.flot',
-].reduce((acc, flotDep) => ({ ...acc, [flotDep]: { fakeDep: 1 } }), {});
+].reduce<Record<string, typeof loadJQueryFlot>>((acc, flotDep) => ({ ...acc, [flotDep]: loadJQueryFlot }), {});
 
 export const sharedDependenciesMap = {
   '@emotion/css': () => import('@emotion/css'),
@@ -91,10 +104,7 @@ export const sharedDependenciesMap = {
   emotion: () => import('@emotion/css'),
   // bundling grafana-ui in plugins requires sharing i18next state
   i18next: () => import('@grafana/i18n/internal').then((module) => module.getI18nInstance()),
-  jquery: {
-    default: jquery,
-    __useDefault: true,
-  },
+  jquery: loadJQuery,
   ...jQueryFlotDeps,
   // add move to lodash for backward compatabilty with plugins
   lodash: () => import('lodash').then((module) => ({ ...module, move: arrayMove, __useDefault: true })),


### PR DESCRIPTION
- since the Gauge panel rewrite, we no longer need Flot (or jQuery) any more in core
- load jQuery on demand for plugins
- load Flot on demand for plugins
- PhantomJS has been gone since 7.0, we don't need `whatwg-fetch` any more
- code that needs `file-saver` already imports it explicitly