### PR TITLE
Server: notify systemd readiness only after startup succeeds

### DIFF
--- a/pkg/server/module_server.go
+++ b/pkg/server/module_server.go
@@ -238,7 +238,6 @@ func (s *ModuleServer) Run() error {
 		return err
 	}
 
-	s.notifySystemd("READY=1")
 	s.log.Debug("Waiting on services...")
 
 	m := modules.New(s.log, s.cfg.Target)
@@ -317,7 +316,18 @@ func (s *ModuleServer) Run() error {
 	// Register modules provided by other builds (e.g. enterprise).
 	s.moduleRegisterer.RegisterModules(m)
 
-	return m.Run(s.context)
+	// Start all modules and wait until they are running before notifying
+	// systemd: READY=1 tells systemd that startup succeeded, so a module
+	// failing during startup must abort the start instead of being
+	// acknowledged first.
+	if err := m.StartAsync(s.context); err != nil {
+		return err
+	}
+	if err := m.AwaitRunning(s.context); err != nil {
+		return err
+	}
+	s.notifySystemd("READY=1")
+	return m.AwaitTerminated(context.Background())
 }
 
 func (s *ModuleServer) initNATSModule() (services.Service, error) {

--- a/pkg/server/module_server.go
+++ b/pkg/server/module_server.go
@@ -320,10 +320,14 @@ func (s *ModuleServer) Run() error {
 	// systemd: READY=1 tells systemd that startup succeeded, so a module
 	// failing during startup must abort the start instead of being
 	// acknowledged first.
+	//
+	// Both waits use a background context because Shutdown cancels
+	// s.context: an aborted wait would make Run return and close
+	// shutdownFinished while modules are still stopping.
 	if err := m.StartAsync(s.context); err != nil {
 		return err
 	}
-	if err := m.AwaitRunning(s.context); err != nil {
+	if err := m.AwaitRunning(context.Background()); err != nil {
 		return err
 	}
 	s.notifySystemd("READY=1")

--- a/pkg/server/module_server.go
+++ b/pkg/server/module_server.go
@@ -321,17 +321,19 @@ func (s *ModuleServer) Run() error {
 	// failing during startup must abort the start instead of being
 	// acknowledged first.
 	//
-	// Both waits use a background context because Shutdown cancels
-	// s.context: an aborted wait would make Run return and close
-	// shutdownFinished while modules are still stopping.
+	// StartAsync uses s.context so Shutdown cancellation propagates to module startup.
+	// The lifecycle waits use a WithoutCancel-wrapped context so that a Shutdown
+	// cancel does not make Run return and close shutdownFinished while modules
+	// are still stopping (see hairyhenderson review on PR #131352).
+	waitCtx := context.WithoutCancel(s.context)
 	if err := m.StartAsync(s.context); err != nil {
 		return err
 	}
-	if err := m.AwaitRunning(context.Background()); err != nil {
+	if err := m.AwaitRunning(waitCtx); err != nil {
 		return err
 	}
 	s.notifySystemd("READY=1")
-	return m.AwaitTerminated(context.Background())
+	return m.AwaitTerminated(waitCtx)
 }
 
 func (s *ModuleServer) initNATSModule() (services.Service, error) {

--- a/pkg/server/module_server_test.go
+++ b/pkg/server/module_server_test.go
@@ -7,9 +7,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/dskit/services"
 	"github.com/grafana/grafana/pkg/api"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/modules"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 	"github.com/grafana/grafana/pkg/util/testutil"
 	"github.com/stretchr/testify/require"
@@ -17,6 +19,103 @@ import (
 
 func TestMain(m *testing.M) {
 	testsuite.Run(m)
+}
+
+type moduleRegistererFunc func(modules.Registry)
+
+func (f moduleRegistererFunc) RegisterModules(registry modules.Registry) {
+	f(registry)
+}
+
+func TestModuleServerRunWaitsForModulesToStopDuringStartup(t *testing.T) {
+	const (
+		fastModuleName = "test-fast-shutdown-module"
+		slowModuleName = "test-slow-startup-module"
+	)
+
+	fastRunning := make(chan struct{})
+	slowStarted := make(chan struct{})
+	stopping := make(chan struct{})
+	releaseStopping := make(chan struct{})
+
+	cfg := setting.NewCfg()
+	cfg.Target = []string{fastModuleName, slowModuleName}
+	ms, err := InitializeModuleServer(cfg, Options{}, api.ServerOptions{})
+	require.NoError(t, err)
+
+	ms.moduleRegisterer = moduleRegistererFunc(func(registry modules.Registry) {
+		registry.RegisterModule(fastModuleName, func() (services.Service, error) {
+			return services.NewBasicService(
+				nil,
+				func(ctx context.Context) error {
+					close(fastRunning)
+					<-ctx.Done()
+					return nil
+				},
+				func(error) error {
+					close(stopping)
+					<-releaseStopping
+					return nil
+				},
+			).WithName(fastModuleName), nil
+		})
+		registry.RegisterModule(slowModuleName, func() (services.Service, error) {
+			return services.NewBasicService(
+				func(ctx context.Context) error {
+					close(slowStarted)
+					<-ctx.Done()
+					return ctx.Err()
+				},
+				nil,
+				nil,
+			).WithName(slowModuleName), nil
+		})
+	})
+
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- ms.Run()
+	}()
+
+	select {
+	case <-fastRunning:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for fast module to run")
+	}
+	select {
+	case <-slowStarted:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for slow module startup")
+	}
+
+	shutdownErr := make(chan error, 1)
+	go func() {
+		shutdownErr <- ms.Shutdown(context.Background(), "test shutdown")
+	}()
+
+	select {
+	case <-stopping:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for module stopping")
+	}
+
+	select {
+	case err := <-runErr:
+		t.Fatalf("module server returned before module stopping completed: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(releaseStopping)
+
+	select {
+	case err := <-runErr:
+		require.Error(t, err)
+		require.ErrorContains(t, err, context.Canceled.Error())
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for module server to stop")
+	}
+
+	require.NoError(t, <-shutdownErr)
 }
 
 func TestIntegrationWillRunInstrumentationServerWhenTargetHasNoHttpServer(t *testing.T) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/grafana/grafana/pkg/api"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -144,8 +145,19 @@ func (s *Server) Run() error {
 
 	ctx, span := s.tracerProvider.Start(s.context, "server.Run")
 	defer span.End()
+	// Start background services and wait until they are running before
+	// notifying systemd: READY=1 tells systemd that startup succeeded, so a
+	// failing service (e.g. broken provisioning configuration) must abort
+	// the start instead of being acknowledged first.
+	if err := s.managerAdapter.StartAsync(ctx); err != nil {
+		return err
+	}
+	if err := s.managerAdapter.AwaitRunning(ctx); err != nil {
+		return err
+	}
 	s.notifySystemd("READY=1")
-	return s.managerAdapter.Run(ctx)
+	stopCtx := trace.ContextWithSpan(context.Background(), trace.SpanFromContext(ctx))
+	return s.managerAdapter.AwaitTerminated(stopCtx)
 }
 
 // Shutdown initiates Grafana graceful shutdown. This shuts down all

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -156,7 +156,10 @@ func (s *Server) Run() error {
 		return err
 	}
 	s.notifySystemd("READY=1")
-	stopCtx := trace.ContextWithSpan(context.Background(), trace.SpanFromContext(ctx))
+	// Detach from the request-scoped context so a Shutdown call that cancels
+	// ctx does not abort the await below before modules have had a chance to
+	// stop (see hairyhenderson review on PR #131352).
+	stopCtx := trace.ContextWithSpan(context.WithoutCancel(ctx), trace.SpanFromContext(ctx))
 	return s.managerAdapter.AwaitTerminated(stopCtx)
 }
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
+	"path/filepath"
+	"runtime"
+	"sync"
 	"testing"
 	"time"
 
@@ -146,5 +150,102 @@ func TestServer_Shutdown(t *testing.T) {
 
 		err = <-ch
 		require.NoError(t, err)
+	})
+}
+
+// startSystemdNotifyRecorder listens on a unix datagram socket like systemd's
+// NOTIFY_SOCKET and records every state notification sent to it. It skips the
+// test when unixgram sockets are unavailable (systemd only exists on linux).
+func startSystemdNotifyRecorder(t *testing.T) (received func() []string) {
+	t.Helper()
+
+	socketPath := filepath.Join(t.TempDir(), "notify.sock")
+	addr := &net.UnixAddr{Name: socketPath, Net: "unixgram"}
+	listener, err := net.ListenUnixgram("unixgram", addr)
+	if err != nil {
+		t.Skipf("unixgram sockets are not available on %s: %v", runtime.GOOS, err)
+	}
+	t.Cleanup(func() {
+		require.NoError(t, listener.Close())
+	})
+
+	var mu sync.Mutex
+	var messages []string
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		buf := make([]byte, 128)
+		for {
+			n, _, err := listener.ReadFrom(buf)
+			if err != nil {
+				return
+			}
+			mu.Lock()
+			messages = append(messages, string(buf[:n]))
+			mu.Unlock()
+		}
+	}()
+	t.Cleanup(func() {
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+		}
+	})
+
+	t.Setenv("NOTIFY_SOCKET", socketPath)
+
+	return func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]string(nil), messages...)
+	}
+}
+
+// TestServer_Run_NotifiesSystemdOnlyAfterServicesAreRunning guards against
+// issue #126879: READY=1 tells systemd startup succeeded, so it must not be sent
+// while a background service can still fail the startup.
+func TestServer_Run_NotifiesSystemdOnlyAfterServicesAreRunning(t *testing.T) {
+	received := startSystemdNotifyRecorder(t)
+
+	t.Run("does not notify when a background service fails to start", func(t *testing.T) {
+		testErr := errors.New("provisioning failed")
+		boom := newBoomService(testErr)
+		s := testServer(t, newTestService(nil, false, boom), boom)
+
+		err := s.Run()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), testErr.Error())
+
+		require.Empty(t, received(), "systemd must not be notified when startup fails")
+	})
+
+	t.Run("notifies readiness once services are running", func(t *testing.T) {
+		s := testServer(t, newTestService(nil, false, nil))
+
+		runErr := make(chan error, 1)
+		go func() { runErr <- s.Run() }()
+
+		waitMsg := make(chan string, 1)
+		go func() {
+			for {
+				msgs := received()
+				if len(msgs) > 0 {
+					waitMsg <- msgs[len(msgs)-1]
+					return
+				}
+			}
+		}()
+
+		select {
+		case msg := <-waitMsg:
+			require.Equal(t, "READY=1", msg)
+		case err := <-runErr:
+			t.Fatalf("server exited before notifying systemd: %v", err)
+		case <-time.After(10 * time.Second):
+			t.Fatal("timed out waiting for the systemd readiness notification")
+		}
+
+		require.NoError(t, s.Shutdown(context.Background(), "test done"))
+		require.NoError(t, <-runErr)
 	})
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -225,14 +225,23 @@ func TestServer_Run_NotifiesSystemdOnlyAfterServicesAreRunning(t *testing.T) {
 		runErr := make(chan error, 1)
 		go func() { runErr <- s.Run() }()
 
+		stopPolling := make(chan struct{})
+		defer close(stopPolling)
+
 		waitMsg := make(chan string, 1)
 		go func() {
 			for {
+				select {
+				case <-stopPolling:
+					return
+				default:
+				}
 				msgs := received()
 				if len(msgs) > 0 {
 					waitMsg <- msgs[len(msgs)-1]
 					return
 				}
+				time.Sleep(10 * time.Millisecond)
 			}
 		}()
 


### PR DESCRIPTION
**What is this feature?**

Grafana now sends the systemd readiness notification (\READY=1\) only after all background services (and, in module mode, all modules) report running. Previously it was sent before any of them started.

**Why do we need this feature?**

Reported in #126879: with a broken provisioning YAML on a \Type=notify\ install, \systemctl restart grafana-server\ reported success while Grafana died moments later parsing that file, and systemd restarted it endlessly. The root cause is an ordering gap: \ProvisioningServiceImpl.RunInitProvisioners\ has been a no-op since provisioners were moved to require the \/apis\ endpoints (they query folders/dashboards), so provisioning configuration is parsed when background services start — which happened *after* the readiness notification in both server paths:

- \Server.Run\ notified before \managerAdapter.Run\ started anything; a failing service aborts startup inside \StartAsync\/\AwaitRunning\, i.e. after the notification.
- \ModuleServer.Run\ notified before any module was constructed or started.

A broken \grafana.ini\ fails correctly because config loading happens in the bootstrap phase, before \Run\.

**How did we fix it?**

Both paths now split the blocking run into its dskit phases and notify between health and wait-for-termination:

- \Server.Run\: \managerAdapter.StartAsync\ → \managerAdapter.AwaitRunning\ → \READY=1\ → \AwaitTerminated\ (same span-derived stop context \ManagerAdapter.Run\ used internally).
- \ModuleServer.Run\: \m.StartAsync\ → \m.AwaitRunning\ → \READY=1\ → \m.AwaitTerminated(context.Background())\ (matching the contexts \modules.Manager.Run\ used).

When a service or module fails during startup, \Run\ now returns the failure *before* notifying, so systemd sees a failed start and reports it to the operator instead of masking it.

**Testing**

- New regression test \TestServer_Run_NotifiesSystemdOnlyAfterServicesAreRunning\: records datagrams on a local unixgram socket bound to \NOTIFY_SOCKET\.
  - with a failing background service: \Run\ returns the service error and **no** notification was sent;
  - with healthy services: exactly \READY=1\ arrives once services are running, then shutdown completes cleanly.
  - The test skips where unixgram sockets are unavailable (e.g. Windows dev machines); it runs on linux CI.
- Existing suite passes (\go test ./pkg/server/\), plus \go build ./pkg/...\ for the cmd tree, \go vet\, gofmt.

Behavior note for release notes: on \Type=notify\ installs, systemd's start timeout now genuinely bounds startup (including provisioning and plugin loading) instead of being satisfied immediately.

Fixes #126879

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.