### PR TITLE
Chore: avoid k8s.io/client-go v12.0.0+incompatible

### DIFF
--- a/apps/advisor/go.mod
+++ b/apps/advisor/go.mod
@@ -358,3 +358,7 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 	xorm.io/builder v0.3.13 // indirect
 )
+
+// This was retracted, but seems to be known by the Go module proxy, and is
+// otherwise pulled in as a transitive dependency.
+exclude k8s.io/client-go v12.0.0+incompatible

--- a/apps/advisor/go.mod
+++ b/apps/advisor/go.mod
@@ -359,6 +359,6 @@ require (
 	xorm.io/builder v0.3.13 // indirect
 )
 
-// This was retracted, but seems to be known by the Go module proxy, and is
-// otherwise pulled in as a transitive dependency.
+// This was retracted, but seems to be known by the Go module proxy, 
+// and is otherwise pulled in as a transitive dependency.
 exclude k8s.io/client-go v12.0.0+incompatible

--- a/apps/advisor/go.mod
+++ b/apps/advisor/go.mod
@@ -359,6 +359,6 @@ require (
 	xorm.io/builder v0.3.13 // indirect
 )
 
-// This was retracted, but seems to be known by the Go module proxy, 
+// This was retracted, but seems to be known by the Go module proxy,
 // and is otherwise pulled in as a transitive dependency.
 exclude k8s.io/client-go v12.0.0+incompatible

--- a/apps/dashvalidator/go.mod
+++ b/apps/dashvalidator/go.mod
@@ -350,3 +350,7 @@ replace (
 
 	github.com/prometheus/alertmanager => github.com/grafana/prometheus-alertmanager v0.25.1-0.20260225120258-18275ca76b0c
 )
+
+// This was retracted, but seems to be known by the Go module proxy, and is
+// otherwise pulled in as a transitive dependency.
+exclude k8s.io/client-go v12.0.0+incompatible

--- a/apps/quotas/go.mod
+++ b/apps/quotas/go.mod
@@ -431,3 +431,7 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 	xorm.io/builder v0.3.13 // indirect
 )
+
+// This was retracted, but seems to be known by the Go module proxy, and is
+// otherwise pulled in as a transitive dependency.
+exclude k8s.io/client-go v12.0.0+incompatible

--- a/apps/quotas/go.mod
+++ b/apps/quotas/go.mod
@@ -432,6 +432,6 @@ require (
 	xorm.io/builder v0.3.13 // indirect
 )
 
-// This was retracted, but seems to be known by the Go module proxy, and is
-// otherwise pulled in as a transitive dependency.
+// This was retracted, but seems to be known by the Go module proxy, 
+// and is otherwise pulled in as a transitive dependency.
 exclude k8s.io/client-go v12.0.0+incompatible

--- a/apps/quotas/go.mod
+++ b/apps/quotas/go.mod
@@ -432,6 +432,6 @@ require (
 	xorm.io/builder v0.3.13 // indirect
 )
 
-// This was retracted, but seems to be known by the Go module proxy, 
+// This was retracted, but seems to be known by the Go module proxy,
 // and is otherwise pulled in as a transitive dependency.
 exclude k8s.io/client-go v12.0.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -723,6 +723,6 @@ replace (
 	github.com/prometheus/alertmanager => github.com/grafana/prometheus-alertmanager v0.25.1-0.20260225120258-18275ca76b0c
 )
 
-// This was retracted, but seems to be known by the Go module proxy, 
+// This was retracted, but seems to be known by the Go module proxy,
 // and is otherwise pulled in as a transitive dependency.
 exclude k8s.io/client-go v12.0.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -723,6 +723,6 @@ replace (
 	github.com/prometheus/alertmanager => github.com/grafana/prometheus-alertmanager v0.25.1-0.20260225120258-18275ca76b0c
 )
 
-// This was retracted, but seems to be known by the Go module proxy, and is
-// otherwise pulled in as a transitive dependency.
+// This was retracted, but seems to be known by the Go module proxy, 
+// and is otherwise pulled in as a transitive dependency.
 exclude k8s.io/client-go v12.0.0+incompatible


### PR DESCRIPTION
When building with go1.27, a transitive dependency on `k8s.io/client-go v12.0.0+incompatible` breaks things.