### PR TITLE
Annotations: add composite index for dashboard_uid time-range queries

### DIFF
--- a/pkg/services/annotations/annotationsimpl/annotation_index_test.go
+++ b/pkg/services/annotations/annotationsimpl/annotation_index_test.go
@@ -1,0 +1,73 @@
+package annotationsimpl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/util/testutil"
+)
+
+// TestIntegrationAnnotationDashboardUIDIndexExists guards against issue
+// #126504: annotation queries filter on dashboard_uid with an org_id /
+// epoch_end / epoch time-range shape, which degrades to a full org scan when
+// the dashboard_uid composite index is missing.
+func TestIntegrationAnnotationDashboardUIDIndexExists(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	sqlStore := db.InitTestDB(t) //nolint:staticcheck // legacy shared-DB test setup; migrate to NewTestStore
+
+	const indexName = "IDX_annotation_org_id_dashboard_uid_epoch_end_epoch"
+
+	var count int
+	switch {
+	case db.IsTestDbSQLite():
+		err := sqlStore.WithDbSession(context.Background(), func(sess *db.Session) error {
+			has, err := sess.SQL(
+				`SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = ?`, indexName,
+			).Get(&count)
+			if err != nil {
+				return err
+			}
+			if !has {
+				count = 0
+			}
+			return nil
+		})
+		require.NoError(t, err)
+	case db.IsTestDbMySQL():
+		err := sqlStore.WithDbSession(context.Background(), func(sess *db.Session) error {
+			has, err := sess.SQL(
+				`SELECT COUNT(*) FROM information_schema.statistics WHERE table_name = 'annotation' AND index_name = ?`, indexName,
+			).Get(&count)
+			if err != nil {
+				return err
+			}
+			if !has {
+				count = 0
+			}
+			return nil
+		})
+		require.NoError(t, err)
+	case db.IsTestDbPostgres():
+		err := sqlStore.WithDbSession(context.Background(), func(sess *db.Session) error {
+			has, err := sess.SQL(
+				`SELECT COUNT(*) FROM pg_indexes WHERE indexname = $1`, indexName,
+			).Get(&count)
+			if err != nil {
+				return err
+			}
+			if !has {
+				count = 0
+			}
+			return nil
+		})
+		require.NoError(t, err)
+	default:
+		t.Skipf("unsupported test database")
+	}
+
+	require.NotZero(t, count, "index %s must exist so dashboard_uid time-range queries do not scan the whole org", indexName)
+}

--- a/pkg/services/annotations/annotationsimpl/annotation_index_test.go
+++ b/pkg/services/annotations/annotationsimpl/annotation_index_test.go
@@ -26,7 +26,7 @@ func TestIntegrationAnnotationDashboardUIDIndexExists(t *testing.T) {
 	case db.IsTestDbSQLite():
 		err := sqlStore.WithDbSession(context.Background(), func(sess *db.Session) error {
 			has, err := sess.SQL(
-				`SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = ?`, indexName,
+				`SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND tbl_name = 'annotation' AND name = ?`, indexName,
 			).Get(&count)
 			if err != nil {
 				return err
@@ -40,7 +40,7 @@ func TestIntegrationAnnotationDashboardUIDIndexExists(t *testing.T) {
 	case db.IsTestDbMySQL():
 		err := sqlStore.WithDbSession(context.Background(), func(sess *db.Session) error {
 			has, err := sess.SQL(
-				`SELECT COUNT(*) FROM information_schema.statistics WHERE table_name = 'annotation' AND index_name = ?`, indexName,
+				`SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'annotation' AND index_name = ?`, indexName,
 			).Get(&count)
 			if err != nil {
 				return err
@@ -54,7 +54,7 @@ func TestIntegrationAnnotationDashboardUIDIndexExists(t *testing.T) {
 	case db.IsTestDbPostgres():
 		err := sqlStore.WithDbSession(context.Background(), func(sess *db.Session) error {
 			has, err := sess.SQL(
-				`SELECT COUNT(*) FROM pg_indexes WHERE indexname = $1`, indexName,
+				`SELECT COUNT(*) FROM pg_indexes WHERE schemaname = current_schema() AND tablename = 'annotation' AND indexname = $1`, indexName,
 			).Get(&count)
 			if err != nil {
 				return err

--- a/pkg/services/sqlstore/migrations/annotation_mig.go
+++ b/pkg/services/sqlstore/migrations/annotation_mig.go
@@ -202,6 +202,10 @@ func addAnnotationMig(mg *Migrator) {
 	}))
 
 	mg.AddMigration("Add missing dashboard_uid to annotation table", &SetDashboardUIDMigration{})
+
+	mg.AddMigration("Add index for org_id_dashboard_uid_epoch_end_epoch on annotation table", NewAddIndexMigration(table, &Index{
+		Cols: []string{"org_id", "dashboard_uid", "epoch_end", "epoch"}, Type: IndexType,
+	}))
 }
 
 type AddMakeRegionSingleRowMigration struct {

--- a/pkg/services/sqlstore/migrations/testdata/migration_ids.txt
+++ b/pkg/services/sqlstore/migrations/testdata/migration_ids.txt
@@ -284,6 +284,7 @@
 "Increase new_state column to length 40 not null"
 "Add dashboard_uid column to annotation table"
 "Add missing dashboard_uid to annotation table"
+"Add index for org_id_dashboard_uid_epoch_end_epoch on annotation table"
 "create test_data table"
 "create dashboard_version table v1"
 "add index dashboard_version.dashboard_id"


### PR DESCRIPTION
**What is this feature?**

A new annotation-table index \IDX_annotation_org_id_dashboard_uid_epoch_end_epoch\ (\org_id, dashboard_uid, epoch_end, epoch\), mirroring the existing \dashboard_id\ index added in 6.6.1.

**Why do we need this feature?**

Reported in #126504: annotation reads filter on \dashboard_uid\ with an org/time-range shape — \org_id = ? AND dashboard_uid = ? AND epoch <= ? AND epoch_end >= ? ORDER BY epoch_end DESC, epoch DESC\ (see \xorm_store.Get\, the access-control filters, and \Delete\) — but no index covers \dashboard_uid\. Since #106676 the API resolves numeric ids to uids, so even legacy callers emit uid predicates; the planner falls back to the \(org_id, epoch_end, epoch)\ index and effectively scans an org's annotations. On a 18M-row Aurora table this saturated CPU and broke alert-history reads; a maintainer-thread commenter confirmed adding exactly this shape of index fixed it.

The regression arrived with #106676 (uid column + query flip) which never revisited the 6.6.1 index set; fresh installs are equally affected.

**How was this fixed / tested?**

- One additive, idempotent migration via \NewAddIndexMigration\ (\IfIndexNotExistsCondition\), so operators who already created a workaround index (as suggested in the issue) get no conflict. Registered after the \dashboard_uid\ backfill migrations.
- New integration test \TestIntegrationAnnotationDashboardUIDIndexExists\ asserts the index exists after migrations on SQLite, MySQL and Postgres test databases; verified it **fails without the migration** and passes with it.
- \TestOSSMigrationIDsGolden\: \	estdata/migration_ids.txt\ regenerated with \go test ./pkg/services/sqlstore/migrations/ -run TestOSSMigrationIDsGolden -update-golden\.
- Full \./pkg/services/sqlstore/migrations\ and \./pkg/services/annotations/...\ suites pass; gofmt/go vet clean.

Operational note: first startup after upgrade will build the index on existing data (minutes of I/O on very large tables); subsequent writes pay the usual secondary-index cost.

Fixes #126504

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.