### PR TITLE
Annotations: always serialize alertId in API responses

### DIFF
--- a/pkg/services/annotations/models.go
+++ b/pkg/services/annotations/models.go
@@ -114,8 +114,11 @@ func (i Item) TableName() string {
 
 // swagger:model Annotation
 type ItemDTO struct {
-	ID        int64  `json:"id,omitempty" xorm:"id"`
-	AlertID   int64  `json:"alertId,omitempty" xorm:"alert_id"`
+	ID int64 `json:"id,omitempty" xorm:"id"`
+	// AlertID must always be serialized, including its zero value: API
+	// consumers key on the field's presence and the documented response
+	// format contains "alertId": 0 for manual annotations.
+	AlertID   int64  `json:"alertId" xorm:"alert_id"`
 	AlertName string `json:"alertName,omitempty"`
 	// Deprecated: Use DashboardUID and OrgID instead
 	DashboardID  int64            `json:"dashboardId,omitempty" xorm:"dashboard_id"`

--- a/pkg/services/annotations/models_test.go
+++ b/pkg/services/annotations/models_test.go
@@ -1,0 +1,31 @@
+package annotations
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestItemDTO_MarshalJSON(t *testing.T) {
+	t.Run("always serializes alertId, including zero for manual annotations", func(t *testing.T) {
+		b, err := json.Marshal(ItemDTO{ID: 1})
+		require.NoError(t, err)
+
+		var decoded map[string]any
+		require.NoError(t, json.Unmarshal(b, &decoded))
+
+		require.Contains(t, decoded, "alertId", "API consumers rely on the documented response shape")
+		require.Equal(t, float64(0), decoded["alertId"])
+	})
+
+	t.Run("keeps internal-only fields omitted when unset", func(t *testing.T) {
+		b, err := json.Marshal(ItemDTO{ID: 1})
+		require.NoError(t, err)
+
+		var decoded map[string]any
+		require.NoError(t, json.Unmarshal(b, &decoded))
+
+		require.NotContains(t, decoded, "dashboardId")
+	})
+}


### PR DESCRIPTION
**What is this feature?**

`/api/annotations` responses again always contain `alertId` — including `"alertId": 0` for manual annotations — matching the documented response format.

**Why do we need this feature?**

Reported in #117304: between 12.1.0 and 12.3.1 the field disappeared from responses whenever its value was 0, breaking clients that access `annotation["alertId"]` directly (Python `KeyError`). The regression came from #111535, which added `omitempty` to the `ItemDTO` tags to stop exposing the internal numeric dashboard id for uid-saved annotations — `alertId` was swept up unintentionally, even though the [API reference](https://github.com/grafana/grafana/blob/main/docs/sources/developer-resources/api-reference/http-api/api-legacy/annotations.md) shows `"alertId": 0` in every response example.

**How did we fix it?**

Drop `omitempty` from `ItemDTO.AlertID` only; internal-only fields (`dashboardId`, etc.) stay omitted as #111535 intended. A comment on the field records why it must stay unconditional.

**Testing**

- New unit test `TestItemDTO_MarshalJSON`: zero-value `ItemDTO` marshals with `"alertId": 0` present, while `dashboardId` remains omitted when unset. Verified it fails against unpatched code and passes with this change.
- Full `./pkg/services/annotations/...` suite passes; `pkg/api` builds; gofmt/go vet clean.

An earlier community PR (#117309) took the same approach and was closed unmerged by the stale bot.

Fixes #117304

Please check that:

- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.
