### PR TITLE
Dashboards: name the title field once in search requests

### DIFF
--- a/pkg/registry/apis/dashboard/search.go
+++ b/pkg/registry/apis/dashboard/search.go
@@ -994,18 +994,10 @@ func convertHttpSearchRequestToResourceSearchRequest(queryParams url.Values, use
 	if searchRequest.Query == "*" {
 		searchRequest.Query = "" // will match everything
 	} else if searchRequest.Query != "" {
-		// Explicitly configure the query for dashboard+folder matching.
+		// Name the title field once. The server picks which stored form of the
+		// title to query, and how to weight each one.
 		searchRequest.QueryFields = []*resourcepb.ResourceSearchRequest_QueryField{
-			{
-				Name:  resource.SEARCH_FIELD_TITLE_PHRASE,
-				Boost: 10, // exact title match (case-insensitive via pre-lowered title_phrase)
-			}, {
-				Name:  resource.SEARCH_FIELD_TITLE,
-				Boost: 2, // standard analyzer (word-level matching)
-			}, {
-				Name:  resource.SEARCH_FIELD_TITLE_NGRAM,
-				Boost: 1, // ngram analyzer (partial/prefix matching)
-			},
+			{Name: resource.SEARCH_FIELD_TITLE},
 		}
 
 		if queryParams.Has("panelTitleSearch") && queryParams.Get("panelTitleSearch") != "false" {

--- a/pkg/registry/apis/dashboard/search_test.go
+++ b/pkg/registry/apis/dashboard/search_test.go
@@ -1418,6 +1418,23 @@ func TestConvertHttpSearchRequestToResourceSearchRequest(t *testing.T) {
 		})
 	}
 
+	t.Run("names the logical title field once", func(t *testing.T) {
+		queryParams, err := url.ParseQuery("query=cpu")
+		require.NoError(t, err)
+
+		result, err := convertHttpSearchRequestToResourceSearchRequest(queryParams, testUser, func(dashboardaccess.PermissionType) ([]string, error) {
+			return nil, nil
+		})
+
+		require.NoError(t, err)
+		names := make([]string, 0, len(result.QueryFields))
+		for _, f := range result.QueryFields {
+			names = append(names, f.Name)
+		}
+		// The stored forms of the title and their weights are the server's business.
+		assert.Equal(t, []string{"title"}, names)
+	})
+
 	t.Run("panel title search asks for the panel_title field", func(t *testing.T) {
 		queryParams, err := url.ParseQuery("query=cpu&panelTitleSearch=true")
 		require.NoError(t, err)

--- a/pkg/tests/apis/dashboard/search_test.go
+++ b/pkg/tests/apis/dashboard/search_test.go
@@ -185,6 +185,24 @@ func TestIntegrationSearchDevDashboards(t *testing.T) {
 				"explain":          "true",
 			},
 		},
+		{
+			// Queries below the ngram minimum are matched as prefix wildcards, so
+			// they find titles with a word starting with the query.
+			name: "short-query-word-prefix",
+			user: helper.Org1.Admin,
+			params: map[string]string{
+				"query": "ze", // should match "Zero Decimals Y Ticks"
+			},
+		},
+		{
+			// The same short query does not match inside a word: "ec" must not
+			// find "Zero Decimals Y Ticks" via "decimals".
+			name: "short-query-mid-word",
+			user: helper.Org1.Admin,
+			params: map[string]string{
+				"query": "ec",
+			},
+		},
 	}
 	for i, tc := range testCases {
 		if testCase != "" && testCase != tc.name {

--- a/pkg/tests/apis/dashboard/testdata/searchV0/t07-short-query-word-prefix.json
+++ b/pkg/tests/apis/dashboard/testdata/searchV0/t07-short-query-word-prefix.json
@@ -1,0 +1,16 @@
+{
+  "totalHits": 1,
+  "hits": [
+    {
+      "resource": "dashboards",
+      "name": "timeseries-y-ticks-zero-decimals",
+      "title": "Zero Decimals Y Ticks",
+      "tags": [
+        "gdev",
+        "panel-tests",
+        "graph-ng"
+      ]
+    }
+  ],
+  "maxScore": 0.843
+}

--- a/pkg/tests/apis/dashboard/testdata/searchV0/t08-short-query-mid-word.json
+++ b/pkg/tests/apis/dashboard/testdata/searchV0/t08-short-query-mid-word.json
@@ -1,0 +1,4 @@
+{
+  "totalHits": 0,
+  "hits": []
+}


### PR DESCRIPTION
The dashboard search handler listed the three stored forms of a title — `title_phrase`, `title`, `title_ngram` — with a weight for each. Those names and weights are index details the server already knows, so this names `title` once and lets the server pick. Follows on from #131268, which removed the query type from the same requests.

This also lines up short-query behaviour with what was intended. #126863 rewrites queries below the ngram minimum into a prefix wildcard so that search-as-you-type returns prefix matches, and grafana/search-and-storage-team#832 argued against short queries matching inside words ("fi matching traffic is probably not what users want"). Because the handler named the ngram copy of the title explicitly, the wildcard ran against ngram terms too, so typing `ec` matched "Decimals" anyway. Naming `title` alone gives prefix matching, as intended, and drops one wildcard clause per query.

User-visible: a one or two character query now matches word prefixes only. `ze` still finds "Zero Decimals Y Ticks", `ec` no longer does. Three characters or more is unchanged, scores included — existing search snapshots are untouched.

Two snapshot cases cover this, appended so existing snapshot indices stay put.
