### PR TITLE
Docs: split Git Sync cherry-pick vs full migration; warn on folder deletion

### DIFF
--- a/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
@@ -27,14 +27,47 @@ Git Sync functionalities are constantly evolving. [Contact Grafana](https://graf
 
 {{< /admonition >}}
 
-You can add dashboards to Git Sync using any of the following options:
+This page walks you through migrating existing, non-provisioned dashboards and folders in Grafana so they're managed by Git Sync.
+
+The migration follows the same three steps regardless of which method you use:
+
+1. [Before you begin](#before-you-begin): Back up your instance and understand what Git Sync manages.
+1. [Add the resources to your Git repository](#step-1-add-the-resources-to-your-git-repository): Choose one of the available methods.
+1. [Delete the original unmanaged resources](#step-2-delete-the-original-unmanaged-resources): Required so Git Sync can adopt the resource under its original UID.
+1. [Validate the result](#step-3-validate-the-migration): Confirm the resource is synced before moving on.
+
+## Before you begin
+
+Git Sync only manages dashboards and folders. Alerts, data sources, library panels, and other resources are **not** supported yet. Migrating to Git Sync involves deleting the original resources so Git Sync can adopt them, so plan the migration carefully before you start.
+
+{{< admonition type="caution" >}}
+
+**Deleting a folder deletes everything it contains, including unsupported resources such as alert rules and library panels.**
+
+Git Sync recreates dashboards and folders, but it does not recreate alerts, library panels, or any other unsupported resource. If you delete or recreate a folder to match your repository structure, any alert rules or library panels stored in that folder are deleted permanently and are not restored by Git Sync.
+
+Before deleting any folder, move its alert rules, library panels, and other unsupported resources somewhere safe.
+
+{{< /admonition >}}
+
+To migrate safely, we recommend that you:
+
+- **Back up your instance first.** Export or snapshot your dashboards, folders, alert rules, and library panels before you delete anything. Deleted resources can't be restored from the Grafana UI.
+- **Migrate folder by folder.** Start with a single folder, complete the full migration for it, and validate the result before moving to the next one. This limits the impact if something goes wrong and lets you get comfortable with the process.
+- **Delete resources, not folders, where possible.** You only need to delete the individual dashboards you're migrating so Git Sync can adopt them by UID. Avoid deleting or recreating folders unless you're certain they contain no unsupported resources.
+
+## Step 1: Add the resources to your Git repository
+
+You can add dashboards to Git Sync using any of the following methods:
 
 - [Add a dashboard using Import dashboards](#add-a-dashboard-using-import-dashboards)
-- [Export an existing dashboard from the Grafana UI as a copy](#copy-an-existing-dashboard-from-the-grafana-ui)
-- [Add a dashboard with Grafana CLI](#add-a-dashboard-with-the-grafana-cli)
-- [Copy a dashboard as JSON and commit to the provisioned repository](#add-a-dashboard-via-json-export)
+- [Copy an existing dashboard from the Grafana UI](#copy-an-existing-dashboard-from-the-grafana-ui)
+- [Add a dashboard with the Grafana CLI](#add-a-dashboard-with-the-grafana-cli)
+- [Add a dashboard via JSON export](#add-a-dashboard-via-json-export)
 
-## Add a dashboard using Import dashboards
+The Import and Copy methods add the dashboard through the Grafana UI and don't require you to delete the original resource. The Grafana CLI and JSON export methods preserve the original UID, so they require you to delete the original resource in [Step 2](#step-2-delete-the-original-unmanaged-resources).
+
+### Add a dashboard using Import dashboards
 
 You can import dashboards directly into your Git Sync provisioned folders using the Grafana UI or the HTTP API.
 
@@ -62,7 +95,7 @@ It may take a few minutes for your changes to reflect on your screen. If they do
 
 {{< /admonition >}}
 
-## Copy an existing dashboard from the Grafana UI
+### Copy an existing dashboard from the Grafana UI
 
 You can also save a copy of dashboard directly from the Grafana UI to your provisioned folder.
 
@@ -78,7 +111,7 @@ To do so, follow these steps:
 1. Click **Save**.
 1. In your synced GitHub repository, merge the branch with the dashboard you want to sync.
 
-## Add a dashboard with the Grafana CLI
+### Add a dashboard with the Grafana CLI
 
 You can also export an existing dashboard from the terminal or from agentic coding tools using the CLI `gcx`. With `gcx` you can download the resources you want to sync from Grafana, and then commit and push those files to your provisioned Git repository. Git Sync will then detect the commit, and synchronize with Grafana.
 
@@ -109,32 +142,19 @@ To add a dashboard with `gcx`, follow these steps:
    - _<GIT_REPO>_: The path to the repository synced with Git Sync
    - _<DASHBOARDS_PATH>_: The path where the dashboards you want to export are located. The dashboards path must be under the repository
 
-1. Delete the original unmanaged resources you want to sync from Grafana. This step is required because Git Sync will not adopt a resource while an unmanaged resource with the same UID (`metadata.name`) still exists in Grafana.
-1. Trigger a new pull to complete the sync. The resources are recreated as provisioned, with their original UIDs, so existing links keep working.
+After you commit the resources, continue to [Step 2](#step-2-delete-the-original-unmanaged-resources) to delete the original resources so Git Sync can adopt them.
 
-{{< admonition type="note" >}}
-
-Deleting resources implies certain operational caveats. Refer to [How to delete existing resources in Grafana](#how-to-delete-existing-resources-in-grafana) for more information.
-
-{{< /admonition >}}
-
-## Add a dashboard via JSON export
+### Add a dashboard via JSON export
 
 To add an existing dashboard to Git Sync via JSON export, you need to:
 
 1. Export the dashboard as JSON.
 1. Convert it to the Custom Resource Definition (CRD) format required by the Grafana App Platform.
 1. Commit the converted file to your Git repository.
-1. Delete the original unmanaged resources you want to sync from Grafana. This step is required because Git Sync will not adopt a resource while an unmanaged resource with the same UID (`metadata.name`) still exists in Grafana.
-1. Trigger a new pull to complete the sync. The resources are recreated as provisioned, with their original UIDs, so existing links keep working.
 
-{{< admonition type="note" >}}
+After you commit the file, continue to [Step 2](#step-2-delete-the-original-unmanaged-resources) to delete the original resources so Git Sync can adopt them.
 
-Deleting resources implies certain operational caveats. Refer to [How to delete existing resources in Grafana](#how-to-delete-existing-resources-in-grafana) for more information.
-
-{{< /admonition >}}
-
-### Required JSON format
+#### Required JSON format
 
 To export a dashboard as a JSON file it must follow this CRD structure:
 
@@ -154,17 +174,31 @@ The structure includes:
 - `metadata`: Contains the dashboard identifier `uid`. You can find the identifier in the dashboard's URL or in the exported JSON.
 - `spec`: Wraps your original dashboard JSON.
 
-## How to delete existing resources in Grafana
+## Step 2: Delete the original unmanaged resources
 
-If you add existing resources using `gcx` or via JSON import, the resource UID is kept, so you need to manually delete the original resource in Grafana to provision it with Git Sync.
+If you added resources using the [Grafana CLI](#add-a-dashboard-with-the-grafana-cli) or [via JSON export](#add-a-dashboard-via-json-export), the resource UID is kept, so you need to manually delete the original resource in Grafana. Git Sync will not adopt a resource while an unmanaged resource with the same UID (`metadata.name`) still exists in Grafana.
+
+{{< admonition type="caution" >}}
+
+Delete only the individual dashboards you're migrating. **Don't delete or recreate folders to match your repository structure if they contain alert rules, library panels, or other unsupported resources** — those resources are deleted permanently and Git Sync does not recreate them. Move any unsupported resources out of the folder before deleting it.
+
+{{< /admonition >}}
 
 When you delete a resource, keep in mind the following:
 
 - You cannot restore deleted resources from the UI.
 - Dashboard version history does not carry over.
 - You need to reapply custom folder permissions. Refer to [Git Sync permissions and access control](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/permissions-grafana) for more details.
-- Git Sync does not support alerts for the moment.
-- Deleting a folder deletes its alert rules. Move them out before deleting the folder.
+- Git Sync does not support alerts for the moment. Deleting a folder deletes its alert rules; move them out before deleting the folder.
+- Git Sync does not support library panels. Deleting a folder deletes its library panels; move them out before deleting the folder.
+
+## Step 3: Validate the migration
+
+1. Trigger a new pull to complete the sync. The resources are recreated as provisioned, with their original UIDs, so existing links keep working.
+1. Confirm the dashboard appears in the provisioned folder and opens correctly. It may take a few minutes for changes to appear; if they don't, refresh the UI manually.
+1. Confirm that any alert rules, library panels, or other resources you moved out before deleting a folder are still present and working.
+
+After you've validated one folder, repeat the process for the next one until the migration is complete.
 
 ## Work with Git-managed dashboards
 

--- a/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
@@ -122,7 +122,7 @@ To migrate safely, we recommend that you:
 
 - **Back up your instance first.** Export or snapshot your dashboards, folders, alert rules, and library panels before you delete anything. Deleted resources can't be restored from the Grafana UI.
 - **Migrate folder by folder.** Start with a single folder, complete the full migration for it, and validate the result before moving to the next one. This limits the impact if something goes wrong and lets you get comfortable with the process.
-- **Keep your original folders, and set them apart.** After a migration you'll have your original folder (holding any alerts and library panels) alongside the new Git Sync folder of the same name. To avoid confusion, rename your original folders or move them under a single top-level **Alerts & Library Panels** folder. This keeps the unsupported resources intact and clearly separated from the provisioned dashboards.
+- **Keep your original folders, and set them apart.** After a migration you'll have your original folder (holding any alerts and library panels) alongside the new Git Sync folder of the same name. To avoid confusion, rename your original folders or move them under a single top-level **Alerts & Library Panels** folder. This keeps the unsupported resources intact and clearly separated from the provisioned dashboards. If you instead need links to your original folders to keep working, refer to [Preserve links to the original folders](#preserve-links-to-the-original-folders).
 
 ### Step 1: Export the resources to your repository
 
@@ -215,6 +215,43 @@ When you delete a dashboard, keep in mind the following:
 1. Confirm that the alert rules and library panels in your original folders are still present and working.
 
 After you've validated one folder, repeat the process for the next one until the migration is complete.
+
+### Preserve links to the original folders
+
+By default, Git Sync gives each synced folder a new UID derived from its path in the repository. This means links and URLs that point to your original folders keep pointing to the original folders, not the new provisioned ones.
+
+If you need existing folder links and URLs to resolve to the provisioned folders instead, you can pin a folder's UID with a folder metadata file so Git Sync reuses the original folder's UID.
+
+{{< admonition type="note" >}}
+
+Folder metadata requires the `provisioningFolderMetadata` feature, which is enabled by default. If your administrator has disabled it, `metadata.name` is ignored and folders always get a path-derived UID.
+
+{{< /admonition >}}
+
+To reuse an original folder's UID, add a `_folder.json` file to that folder's directory in the repository:
+
+```json
+{
+  "apiVersion": "folder.grafana.app/v1beta1",
+  "kind": "Folder",
+  "metadata": { "name": "<ORIGINAL_FOLDER_UID>" },
+  "spec": { "title": "<FOLDER_TITLE>" }
+}
+```
+
+Where `<ORIGINAL_FOLDER_UID>` is the UID of your existing folder. You can find it in the folder's URL.
+
+Because this reuses the original folder's UID, the synced folder collides with your existing unmanaged folder — Git Sync can't take over a UID that still belongs to an unmanaged folder, and the sync fails with a conflict. To avoid losing unsupported resources, complete these steps for each folder **before** you sync:
+
+1. Create a new folder and move all alert rules, library panels, and other unsupported resources out of the original folder into it.
+1. Delete the original folder. Its dashboards should already be exported to the repository from [Step 1](#step-1-export-the-resources-to-your-repository).
+1. Reapply any custom permissions on the new provisioned folder — folder permissions don't carry over. Refer to [Git Sync permissions and access control](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/permissions-grafana).
+
+{{< admonition type="caution" >}}
+
+Move alert rules and library panels out of the folder **before** you delete it. Deleting a folder deletes everything it contains, and Git Sync does not recreate alerts or library panels.
+
+{{< /admonition >}}
 
 ## Work with Git-managed dashboards
 

--- a/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
@@ -27,45 +27,23 @@ Git Sync functionalities are constantly evolving. [Contact Grafana](https://graf
 
 {{< /admonition >}}
 
-This page walks you through migrating existing, non-provisioned dashboards and folders in Grafana so they're managed by Git Sync.
+There are two different things you might want to do with existing, non-provisioned resources, and they behave differently:
 
-The migration follows the same three steps regardless of which method you use:
+- [Cherry-pick individual dashboards](#cherry-pick-individual-dashboards): Add a copy of a selected dashboard to a provisioned folder. Grafana creates a **new** dashboard with a **new UID**; the original is left untouched and existing links keep pointing to it. This is the simplest option and doesn't require deleting anything.
+- [Migrate existing dashboards](#migrate-existing-dashboards-to-git-sync): Move existing dashboards under Git Sync while **keeping their UID**, so existing links and references keep working. This adopts the resource in place, which requires deleting the original and needs more care.
 
-1. [Before you begin](#before-you-begin): Back up your instance and understand what Git Sync manages.
-1. [Add the resources to your Git repository](#step-1-add-the-resources-to-your-git-repository): Choose one of the available methods.
-1. [Delete the original unmanaged resources](#step-2-delete-the-original-unmanaged-resources): Required so Git Sync can adopt the resource under its original UID.
-1. [Validate the result](#step-3-validate-the-migration): Confirm the resource is synced before moving on.
+{{< admonition type="note" >}}
 
-## Before you begin
-
-Git Sync only manages dashboards and folders. Alerts, data sources, library panels, and other resources are **not** supported yet. Migrating to Git Sync involves deleting the original resources so Git Sync can adopt them, so plan the migration carefully before you start.
-
-{{< admonition type="caution" >}}
-
-**Deleting a folder deletes everything it contains, including unsupported resources such as alert rules and library panels.**
-
-Git Sync recreates dashboards and folders, but it does not recreate alerts, library panels, or any other unsupported resource. If you delete or recreate a folder to match your repository structure, any alert rules or library panels stored in that folder are deleted permanently and are not restored by Git Sync.
-
-Before deleting any folder, move its alert rules, library panels, and other unsupported resources somewhere safe.
+Git Sync only manages dashboards and folders. Alerts, data sources, and library panels are **not** supported yet. Keep this in mind when migrating — see [Before you begin](#before-you-begin).
 
 {{< /admonition >}}
 
-To migrate safely, we recommend that you:
+## Cherry-pick individual dashboards
 
-- **Back up your instance first.** Export or snapshot your dashboards, folders, alert rules, and library panels before you delete anything. Deleted resources can't be restored from the Grafana UI.
-- **Migrate folder by folder.** Start with a single folder, complete the full migration for it, and validate the result before moving to the next one. This limits the impact if something goes wrong and lets you get comfortable with the process.
-- **Delete resources, not folders, where possible.** You only need to delete the individual dashboards you're migrating so Git Sync can adopt them by UID. Avoid deleting or recreating folders unless you're certain they contain no unsupported resources.
-
-## Step 1: Add the resources to your Git repository
-
-You can add dashboards to Git Sync using any of the following methods:
+Use these methods to add a copy of one or more dashboards to a provisioned folder. Each copy is created with a new UID, so the original dashboards stay exactly as they are and nothing needs to be deleted. Existing links continue to point to the original dashboards, not the copies.
 
 - [Add a dashboard using Import dashboards](#add-a-dashboard-using-import-dashboards)
 - [Copy an existing dashboard from the Grafana UI](#copy-an-existing-dashboard-from-the-grafana-ui)
-- [Add a dashboard with the Grafana CLI](#add-a-dashboard-with-the-grafana-cli)
-- [Add a dashboard via JSON export](#add-a-dashboard-via-json-export)
-
-The Import and Copy methods add the dashboard through the Grafana UI and don't require you to delete the original resource. The Grafana CLI and JSON export methods preserve the original UID, so they require you to delete the original resource in [Step 2](#step-2-delete-the-original-unmanaged-resources).
 
 ### Add a dashboard using Import dashboards
 
@@ -84,6 +62,7 @@ To access the Import dashboard tool from the Git Sync UI:
 
 Keep in mind the following:
 
+- Importing an ordinary dashboard JSON creates a new dashboard with a new UID. To preserve the original UID instead (for a migration), provide a UID in the wizard or import a resource file that already sets `metadata.name`. Refer to [Migrate existing dashboards](#migrate-existing-dashboards-to-git-sync).
 - UIDs are globally unique per org. Two repositories with dashboards sharing a UID will conflict.
 - Two dashboards can share a title as long as they live at different paths in the repo. If a file with the same name already exists at the target path, the import is stopped before it overwrites anything.
 
@@ -97,7 +76,7 @@ It may take a few minutes for your changes to reflect on your screen. If they do
 
 ### Copy an existing dashboard from the Grafana UI
 
-You can also save a copy of dashboard directly from the Grafana UI to your provisioned folder.
+You can also save a copy of dashboard directly from the Grafana UI to your provisioned folder. This creates a new dashboard with a new UID and leaves the original in place.
 
 To do so, follow these steps:
 
@@ -111,9 +90,50 @@ To do so, follow these steps:
 1. Click **Save**.
 1. In your synced GitHub repository, merge the branch with the dashboard you want to sync.
 
-### Add a dashboard with the Grafana CLI
+## Migrate existing dashboards to Git Sync
 
-You can also export an existing dashboard from the terminal or from agentic coding tools using the CLI `gcx`. With `gcx` you can download the resources you want to sync from Grafana, and then commit and push those files to your provisioned Git repository. Git Sync will then detect the commit, and synchronize with Grafana.
+Migrating moves your existing dashboards under Git Sync while keeping their UIDs, so existing links, references, and bookmarks keep working. Because the UID is preserved, Git Sync adopts the resource in place, and you must delete the original resource so Git Sync can take over its UID.
+
+The migration follows these steps:
+
+1. [Before you begin](#before-you-begin): Back up your instance and understand what Git Sync manages.
+1. [Step 1: Export the resources to your repository](#step-1-export-the-resources-to-your-repository): Export with UIDs preserved and commit.
+1. [Step 2: Delete the original dashboards](#step-2-delete-the-original-dashboards): Required so Git Sync can adopt each dashboard by UID.
+1. [Step 3: Validate the migration](#step-3-validate-the-migration): Confirm the resources are synced before moving on.
+
+### Before you begin
+
+Git Sync only manages dashboards and folders. Alerts, data sources, library panels, and other resources are **not** supported yet, and Git Sync will not recreate them. Because migrating involves deleting resources, plan carefully before you start.
+
+Git Sync creates its own folders when it syncs your repository. It derives each folder's UID from the folder's **path in the repository**, so the folders it creates are **new folders**, separate from your existing ones — even when they share the same name. As a result:
+
+- You **don't** need to delete your original folders to migrate the dashboards inside them.
+- You **shouldn't** delete a folder that contains alerts or library panels — Git Sync doesn't manage those, and deleting the folder deletes them permanently.
+
+{{< admonition type="caution" >}}
+
+**Deleting a folder deletes everything it contains, including unsupported resources such as alert rules and library panels.** Git Sync recreates dashboards and folders, but it does not recreate alerts or library panels. Deleting or recreating a folder to match your repository structure permanently deletes any alert rules and library panels it holds, and they are not restored.
+
+Only delete the individual **dashboards** you're migrating — never delete the folders.
+
+{{< /admonition >}}
+
+To migrate safely, we recommend that you:
+
+- **Back up your instance first.** Export or snapshot your dashboards, folders, alert rules, and library panels before you delete anything. Deleted resources can't be restored from the Grafana UI.
+- **Migrate folder by folder.** Start with a single folder, complete the full migration for it, and validate the result before moving to the next one. This limits the impact if something goes wrong and lets you get comfortable with the process.
+- **Keep your original folders, and set them apart.** After a migration you'll have your original folder (holding any alerts and library panels) alongside the new Git Sync folder of the same name. To avoid confusion, rename your original folders or move them under a single top-level **Alerts & Library Panels** folder. This keeps the unsupported resources intact and clearly separated from the provisioned dashboards.
+
+### Step 1: Export the resources to your repository
+
+Export the dashboards you want to migrate so that each file keeps the dashboard's original UID (`metadata.name`), then commit the files to your Git repository. You can use either of the following:
+
+- [Export with the Grafana CLI](#export-with-the-grafana-cli)
+- [Export as a JSON resource file](#export-as-a-json-resource-file)
+
+#### Export with the Grafana CLI
+
+You can export existing dashboards from the terminal or from agentic coding tools using the CLI `gcx`. With `gcx` you can download the resources you want to sync from Grafana, and then commit and push those files to your provisioned Git repository. Git Sync will then detect the commit, and synchronize with Grafana.
 
 {{< admonition type="note" >}}
 
@@ -121,7 +141,7 @@ For more information refer to the [`gcx` documentation](https://grafana.com/docs
 
 {{< /admonition >}}
 
-To add a dashboard with `gcx`, follow these steps:
+To export dashboards with `gcx`, follow these steps:
 
 1. Set up the `gcx` context to point to your instance as documented in [Defining contexts](https://github.com/grafana/gcx/#1-authenticate).
 1. Pull the resources you want to sync from the instance to your local repository:
@@ -142,19 +162,17 @@ To add a dashboard with `gcx`, follow these steps:
    - _<GIT_REPO>_: The path to the repository synced with Git Sync
    - _<DASHBOARDS_PATH>_: The path where the dashboards you want to export are located. The dashboards path must be under the repository
 
-After you commit the resources, continue to [Step 2](#step-2-delete-the-original-unmanaged-resources) to delete the original resources so Git Sync can adopt them.
+After you commit the resources, continue to [Step 2](#step-2-delete-the-original-dashboards).
 
-### Add a dashboard via JSON export
+#### Export as a JSON resource file
 
-To add an existing dashboard to Git Sync via JSON export, you need to:
+To export a dashboard as a JSON resource file, you need to:
 
 1. Export the dashboard as JSON.
 1. Convert it to the Custom Resource Definition (CRD) format required by the Grafana App Platform.
 1. Commit the converted file to your Git repository.
 
-After you commit the file, continue to [Step 2](#step-2-delete-the-original-unmanaged-resources) to delete the original resources so Git Sync can adopt them.
-
-#### Required JSON format
+After you commit the file, continue to [Step 2](#step-2-delete-the-original-dashboards).
 
 To export a dashboard as a JSON file it must follow this CRD structure:
 
@@ -171,32 +189,30 @@ The structure includes:
 
 - `apiVersion`: Specifies the API version. Both classic and `v2` JSON models are supported. For more information, refer to [Dashboard JSON model](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/view-dashboard-json-model/).
 - `kind`: Identifies the resource type. For example, dashboard.
-- `metadata`: Contains the dashboard identifier `uid`. You can find the identifier in the dashboard's URL or in the exported JSON.
+- `metadata`: Contains the dashboard identifier `name`, which must match the original dashboard UID so Git Sync can adopt it. You can find the identifier in the dashboard's URL or in the exported JSON.
 - `spec`: Wraps your original dashboard JSON.
 
-## Step 2: Delete the original unmanaged resources
+### Step 2: Delete the original dashboards
 
-If you added resources using the [Grafana CLI](#add-a-dashboard-with-the-grafana-cli) or [via JSON export](#add-a-dashboard-via-json-export), the resource UID is kept, so you need to manually delete the original resource in Grafana. Git Sync will not adopt a resource while an unmanaged resource with the same UID (`metadata.name`) still exists in Grafana.
+Because the exported files keep the original UID, Git Sync will not adopt a dashboard while an unmanaged dashboard with the same UID (`metadata.name`) still exists in Grafana. Delete each original dashboard you're migrating so Git Sync can take over its UID.
 
 {{< admonition type="caution" >}}
 
-Delete only the individual dashboards you're migrating. **Don't delete or recreate folders to match your repository structure if they contain alert rules, library panels, or other unsupported resources** — those resources are deleted permanently and Git Sync does not recreate them. Move any unsupported resources out of the folder before deleting it.
+Delete only the individual **dashboards** you're migrating. Folders don't need to be deleted — Git Sync creates its own folders with new, path-derived UIDs. **Don't delete or recreate folders that contain alert rules or library panels**: those resources are deleted permanently and Git Sync does not recreate them. See [Before you begin](#before-you-begin) for how to keep and set apart your original folders.
 
 {{< /admonition >}}
 
-When you delete a resource, keep in mind the following:
+When you delete a dashboard, keep in mind the following:
 
 - You cannot restore deleted resources from the UI.
 - Dashboard version history does not carry over.
 - You need to reapply custom folder permissions. Refer to [Git Sync permissions and access control](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/permissions-grafana) for more details.
-- Git Sync does not support alerts for the moment. Deleting a folder deletes its alert rules; move them out before deleting the folder.
-- Git Sync does not support library panels. Deleting a folder deletes its library panels; move them out before deleting the folder.
 
-## Step 3: Validate the migration
+### Step 3: Validate the migration
 
-1. Trigger a new pull to complete the sync. The resources are recreated as provisioned, with their original UIDs, so existing links keep working.
-1. Confirm the dashboard appears in the provisioned folder and opens correctly. It may take a few minutes for changes to appear; if they don't, refresh the UI manually.
-1. Confirm that any alert rules, library panels, or other resources you moved out before deleting a folder are still present and working.
+1. Trigger a new pull to complete the sync. The dashboards are recreated as provisioned, with their original UIDs, so existing links keep working.
+1. Confirm each dashboard appears in the provisioned folder and opens correctly. It may take a few minutes for changes to appear; if they don't, refresh the UI manually.
+1. Confirm that the alert rules and library panels in your original folders are still present and working.
 
 After you've validated one folder, repeat the process for the next one until the migration is complete.
 

--- a/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
@@ -30,11 +30,11 @@ Git Sync functionalities are constantly evolving. [Contact Grafana](https://graf
 There are two different things you might want to do with existing, non-provisioned resources, and they behave differently:
 
 - [Cherry-pick individual dashboards](#cherry-pick-individual-dashboards): Add a copy of a selected dashboard to a provisioned folder. Grafana creates a **new** dashboard with a **new UID**; the original is left untouched and existing links keep pointing to it. This is the simplest option and doesn't require deleting anything.
-- [Migrate existing dashboards](#migrate-existing-dashboards-to-git-sync): Move existing dashboards under Git Sync while **keeping their UID**, so existing links and references keep working. This adopts the resource in place, which requires deleting the original and needs more care.
+- [Migrate existing dashboards](#migrate-existing-dashboards-to-git-sync): Move existing dashboards under Git Sync while **keeping their UID**, so existing links and references keep working. This option requires additional care since it adopts the resource in place and requires deleting the original resource.
 
 {{< admonition type="note" >}}
 
-Git Sync only manages dashboards and folders. Alerts, data sources, and library panels are **not** supported yet. Keep this in mind when migrating — see [Before you begin](#before-you-begin).
+Git Sync only manages dashboards and folders. Alerts, data sources, and library panels are **not** supported yet. Keep this in mind when migrating. Refer to [Before you begin](#before-you-begin) for details.
 
 {{< /admonition >}}
 
@@ -92,7 +92,7 @@ To do so, follow these steps:
 
 ## Migrate existing dashboards to Git Sync
 
-Migrating moves your existing dashboards under Git Sync while keeping their UIDs, so existing links, references, and bookmarks keep working. Because the UID is preserved, Git Sync adopts the resource in place, and you must delete the original resource so Git Sync can take over its UID.
+The migrating option moves your existing dashboards under Git Sync while keeping their UIDs, so existing links, references, and bookmarks keep working. Because the UID is preserved, Git Sync adopts the resource in place, and you must delete the original resource so Git Sync can take over its UID.
 
 The migration follows these steps:
 
@@ -105,20 +105,20 @@ The migration follows these steps:
 
 Git Sync only manages dashboards and folders. Alerts, data sources, library panels, and other resources are **not** supported yet, and Git Sync will not recreate them. Because migrating involves deleting resources, plan carefully before you start.
 
-Git Sync creates its own folders when it syncs your repository. It derives each folder's UID from the folder's **path in the repository**, so the folders it creates are **new folders**, separate from your existing ones — even when they share the same name. As a result:
+Git Sync creates its own folders when it syncs with your existing repository. It derives each folder's UID from the folder's **path in the repository**, so the folders it creates are **new folders**, independent from your existing ones, even if they share the same name. As a result:
 
 - You **don't** need to delete your original folders to migrate the dashboards inside them.
-- You **shouldn't** delete a folder that contains alerts or library panels — Git Sync doesn't manage those, and deleting the folder deletes them permanently.
+- **Do not** delete a folder that contains alerts or library panels. Git Sync doesn't manage those, and deleting the folder deletes them permanently.
 
 {{< admonition type="caution" >}}
 
 **Deleting a folder deletes everything it contains, including unsupported resources such as alert rules and library panels.** Git Sync recreates dashboards and folders, but it does not recreate alerts or library panels. Deleting or recreating a folder to match your repository structure permanently deletes any alert rules and library panels it holds, and they are not restored.
 
-Only delete the individual **dashboards** you're migrating — never delete the folders.
+With a folder or folderless sync, only delete the individual dashboards you're migrating, never the folders. Full-instance migrations have different cleanup behavior and can delete unmanaged folders, so follow the full-instance migration guidance instead.
 
 {{< /admonition >}}
 
-To migrate safely, we recommend that you:
+To migrate safely, keep in mind the following:
 
 - **Back up your instance first.** Export or snapshot your dashboards, folders, alert rules, and library panels before you delete anything. Deleted resources can't be restored from the Grafana UI.
 - **Migrate folder by folder.** Start with a single folder, complete the full migration for it, and validate the result before moving to the next one. This limits the impact if something goes wrong and lets you get comfortable with the process.
@@ -198,7 +198,7 @@ Because the exported files keep the original UID, Git Sync will not adopt a dash
 
 {{< admonition type="caution" >}}
 
-Delete only the individual **dashboards** you're migrating. Folders don't need to be deleted — Git Sync creates its own folders with new, path-derived UIDs. **Don't delete or recreate folders that contain alert rules or library panels**: those resources are deleted permanently and Git Sync does not recreate them. See [Before you begin](#before-you-begin) for how to keep and set apart your original folders.
+Delete only the individual dashboards you're migrating. Folders don't need to be deleted, as Git Sync creates its own folders with new, path-derived UIDs. **Don't delete or recreate folders that contain alert rules or library panels**, since those resources are deleted permanently and Git Sync does not recreate them. See [Before you begin](#before-you-begin) for how to keep and set apart your original folders.
 
 {{< /admonition >}}
 
@@ -241,7 +241,7 @@ To reuse an original folder's UID, add a `_folder.json` file to that folder's di
 
 Where `<ORIGINAL_FOLDER_UID>` is the UID of your existing folder. You can find it in the folder's URL.
 
-Because this reuses the original folder's UID, the synced folder collides with your existing unmanaged folder — Git Sync can't take over a UID that still belongs to an unmanaged folder, and the sync fails with a conflict. To avoid losing unsupported resources, complete these steps for each folder **before** you sync:
+Because this option reuses the original folder's UID, the synced folder collides with your existing unmanaged folder, and Git Sync can't take over a UID that still belongs to an unmanaged folder, with the sync failing with a conflict. To avoid losing unsupported resources, complete these steps for each folder **before** you sync:
 
 1. Create a new folder and move all alert rules, library panels, and other unsupported resources out of the original folder into it.
 1. Delete the original folder. Its dashboards should already be exported to the repository from [Step 1](#step-1-export-the-resources-to-your-repository).

--- a/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
@@ -64,7 +64,7 @@ Keep in mind the following:
 
 - Importing an ordinary dashboard JSON creates a new dashboard with a new UID. To preserve the original UID instead (for a migration), provide a UID in the wizard or import a resource file that already sets `metadata.name`. Refer to [Migrate existing dashboards](#migrate-existing-dashboards-to-git-sync).
 - UIDs are globally unique per org. Two repositories with dashboards sharing a UID will conflict.
-- Two dashboards can share a title as long as they live at different paths in the repo. If a file with the same name already exists at the target path, the import is stopped before it overwrites anything.
+- Two dashboards can share a title as long as they live at different paths in the repository. If a file with the same name already exists at the target path, the import is stopped before it overwrites anything.
 
 For more information refer to [Import dashboards](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/import-dashboards/) in the Data Visualization documentation.
 


### PR DESCRIPTION
## What

Reshapes the **Add non-provisioned resources from Grafana** Git Sync doc around the two distinct things users actually do, and fixes guidance that could cause data loss:

- **Cherry-pick individual dashboards** — Import / Save-as-copy. These create a **new dashboard with a new UID**; the original is untouched and no deletion is needed. Clarified that this is not a migration and existing links keep pointing to the originals.
- **Migrate existing dashboards** — `gcx` pull / JSON CRD export, which **preserve the UID** and adopt the resource in place. This is the only path that requires deleting originals, and it now carries the safety guidance.

Key corrections vs. the previous version:
- Git Sync creates its **own folders with path-derived UIDs**, so synced folders coexist with your existing folders even when names match. Therefore **only the original dashboards need deleting — never the folders**.
- New **Before you begin** section: back up first, migrate folder by folder (validate between each), and a `caution` that deleting a folder permanently deletes its alert rules and library panels (which Git Sync does not restore).
- Recommends **keeping original folders** and setting them apart — rename them or move them under a top-level **Alerts & Library Panels** folder — so unsupported resources stay intact and separated from the provisioned dashboards.
- Import section now notes the UID nuance: ordinary dashboard JSON → new UID; a resource file that sets `metadata.name` → UID preserved (migration).

## Why

A customer migrating dashboards to Git Sync deleted and recreated folders to match their repo structure. Because folders also contain alert rules, this cascade-deleted ~500 alerts, noticed only after the fact. The old doc lumped copy/import together with true migration and implied folders should be deleted. Since Git Sync creates its own path-derived folders, deleting the originals is unnecessary and actively dangerous when they hold alerts or library panels.

Behavior verified against the code:
- Folder UID is a deterministic hash of `repositoryName + "/" + path` — `pkg/registry/apis/provisioning/resources/id.go` (`ParseFolder`), so synced folders never collide with legacy folders; sync never deletes original folders.
- Copy/Save-as always generates a new UID (`generateName`); Import preserves the UID only when the JSON carries `metadata.name` (CRD export) — `public/app/features/dashboard-scene` and `public/app/features/provisioning`.

## How

Documentation-only change to `docs/sources/as-code/observability-as-code/git-sync/export-resources.md`. Split into two top-level sections (cherry-pick vs. migrate), added `caution` admonitions matching existing Git Sync docs conventions, and folded the export methods (`gcx`, JSON CRD) under the migration flow.

## Testing

- Documentation-only; no code changes.
- Verified admonition types (`caution`/`note`) and shortcode syntax match existing usage in the Git Sync docs directory.

## Checklist
- [ ] Tests added/updated (n/a — docs only)
- [x] Documentation updated
- [x] No breaking changes

🤖 Generated with Claude Code