### PR TITLE
Fix: Increase timeout for flaky azuremonitor unit test

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/components/TracesQueryEditor/TracesQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/TracesQueryEditor/TracesQueryEditor.test.tsx
@@ -77,7 +77,7 @@ describe('TracesQueryEditor', () => {
         }),
       })
     );
-  });
+  }, 10000);
 
   it('should disable other resource types when selecting multiple resources', async () => {
     const mockDatasource = createMockDatasource({ resourcePickerData: createMockResourcePickerData() });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
The "Decoupled plugin tests" step is failing occasionally in CI but mostly succeeds, apparently due to timeouts in the tests for the Azure Monitor plugin. This bumps the timeout for the test in an attempt to fix the flakiness. We'll be removing this core plugin and the associated tests soon.
