### PR TITLE
[release-13.2.1] Middleware: Fix goroutine leak when gzip compression is enabled

### DIFF
--- a/pkg/middleware/gziper.go
+++ b/pkg/middleware/gziper.go
@@ -3,17 +3,23 @@ package middleware
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"strings"
+	"sync"
 
 	gzip "github.com/klauspost/pgzip"
 
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/web"
 )
 
+var gzipLogger = log.New("middleware.gzip")
+
 type gzipResponseWriter struct {
-	w *gzip.Writer
+	w    *gzip.Writer
+	sink *gzipSink
 	web.ResponseWriter
 }
 
@@ -22,19 +28,110 @@ func (grw *gzipResponseWriter) WriteHeader(c int) {
 	grw.ResponseWriter.WriteHeader(c)
 }
 
-func (grw gzipResponseWriter) Write(p []byte) (int, error) {
-	if grw.Header().Get("Content-Type") == "" {
-		grw.Header().Set("Content-Type", http.DetectContentType(p))
+func (grw *gzipResponseWriter) Write(p []byte) (int, error) {
+	prepareCompressedHeaders(grw.Header(), p)
+
+	n, err := grw.w.Write(p)
+	if err == nil {
+		// The sink hides write failures from pgzip, so report them here instead,
+		// otherwise a handler streaming a response would never learn that the
+		// client it is writing to is gone.
+		err = grw.sink.err()
 	}
-	grw.Header().Del("Content-Length")
-	return grw.w.Write(p)
+	return n, err
 }
 
-func (grw gzipResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
-	if hijacker, ok := grw.ResponseWriter.(http.Hijacker); ok {
+func (grw *gzipResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return hijack(grw.ResponseWriter)
+}
+
+// headResponseWriter serves a HEAD request that would have been compressed. The
+// response has no body, so there is nothing to compress, but the headers still
+// have to describe the response the equivalent GET would return
+// (RFC 9110 §9.3.2) - including the missing Content-Length, since the size of a
+// compressed body is not known ahead of time.
+type headResponseWriter struct {
+	web.ResponseWriter
+}
+
+func (hrw *headResponseWriter) WriteHeader(c int) {
+	hrw.Header().Del("Content-Length")
+	hrw.ResponseWriter.WriteHeader(c)
+}
+
+func (hrw *headResponseWriter) Write(p []byte) (int, error) {
+	prepareCompressedHeaders(hrw.Header(), p)
+	return hrw.ResponseWriter.Write(p)
+}
+
+func (hrw *headResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return hijack(hrw.ResponseWriter)
+}
+
+func prepareCompressedHeaders(h http.Header, p []byte) {
+	if h.Get("Content-Type") == "" {
+		h.Set("Content-Type", http.DetectContentType(p))
+	}
+	// The length of the compressed body is unknown until it has been written.
+	h.Del("Content-Length")
+}
+
+func hijack(rw web.ResponseWriter) (net.Conn, *bufio.ReadWriter, error) {
+	if hijacker, ok := rw.(http.Hijacker); ok {
 		return hijacker.Hijack()
 	}
 	return nil, nil, fmt.Errorf("GZIP ResponseWriter doesn't implement the Hijacker interface")
+}
+
+// gzipSink sits between the pgzip writer and the response writer it compresses
+// into, and reports every write to pgzip as complete.
+//
+// pgzip hands its compressed blocks to a goroutine of its own, and that
+// goroutine only exits when Close closes the channel it listens on. Close
+// returns before it gets that far if a write to the underlying writer failed or
+// reported fewer bytes than it was handed, leaving the goroutine parked on that
+// channel for the lifetime of the process, holding its block buffers - one
+// leaked per request, without bound (#130649). Reporting complete writes keeps
+// pgzip on the path where Close releases the goroutine.
+//
+// The first failure is recorded instead, so that the handler and the middleware
+// still see it, and nothing more is written to a writer that has already failed.
+type gzipSink struct {
+	w io.Writer
+
+	mu       sync.Mutex
+	firstErr error
+}
+
+func (s *gzipSink) Write(p []byte) (int, error) {
+	if s.err() != nil {
+		return len(p), nil
+	}
+
+	n, err := s.w.Write(p)
+	switch {
+	case err != nil:
+		s.setErr(err)
+	case n != len(p):
+		s.setErr(fmt.Errorf("wrote %d bytes of %d to the response", n, len(p)))
+	default:
+		return n, nil
+	}
+	return len(p), nil
+}
+
+func (s *gzipSink) err() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.firstErr
+}
+
+func (s *gzipSink) setErr(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.firstErr == nil {
+		s.firstErr = err
+	}
 }
 
 type matcher func(s string) bool
@@ -71,13 +168,40 @@ func Gziper() func(http.Handler) http.Handler {
 				return
 			}
 
-			grw := &gzipResponseWriter{gzip.NewWriter(rw), rw.(web.ResponseWriter)}
+			// A HEAD response has no body, so running one through a compressor is
+			// pure overhead.
+			if req.Method == http.MethodHead {
+				hrw := &headResponseWriter{rw.(web.ResponseWriter)}
+				hrw.Header().Set("Content-Encoding", "gzip")
+				hrw.Header().Set("Vary", "Accept-Encoding")
+
+				next.ServeHTTP(hrw, req)
+				return
+			}
+
+			sink := &gzipSink{w: rw}
+			grw := &gzipResponseWriter{gzip.NewWriter(sink), sink, rw.(web.ResponseWriter)}
 			grw.Header().Set("Content-Encoding", "gzip")
 			grw.Header().Set("Vary", "Accept-Encoding")
 
 			next.ServeHTTP(grw, req)
-			// We can't really handle close errors at this point and we can't report them to the caller
-			_ = grw.w.Close()
+
+			// A failed response write cannot be reported to the caller at this
+			// point, and this is the only signal it produces, so log it rather than
+			// discard it.
+			err := grw.w.Close()
+			if err == nil {
+				err = sink.err()
+			}
+			if err != nil {
+				logger := gzipLogger.FromContext(req.Context())
+				if req.Context().Err() != nil {
+					// The client hung up. Expected traffic, not a server problem.
+					logger.Debug("Failed to write gzipped response", "path", req.URL.Path, "error", err)
+				} else {
+					logger.Warn("Failed to write gzipped response", "path", req.URL.Path, "error", err)
+				}
+			}
 		})
 	}
 }

--- a/pkg/middleware/gziper_test.go
+++ b/pkg/middleware/gziper_test.go
@@ -1,0 +1,200 @@
+package middleware
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	gzip "github.com/klauspost/pgzip"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/grafana/grafana/pkg/web"
+)
+
+// Larger than pgzip's block size, so that the compressor writes to the response
+// while the handler is still running.
+var gzipTestBody = []byte(strings.Repeat("grafana dashboard payload ", 20000))
+
+func gzipTestHandler(t *testing.T) http.Handler {
+	t.Helper()
+
+	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Set("Content-Type", "application/json")
+		rw.Header().Set("Content-Length", "1234")
+		_, err := rw.Write(gzipTestBody)
+		require.NoError(t, err)
+	})
+}
+
+// serveGzipped runs a request through the gzip middleware the way the HTTP
+// server does, with a web.ResponseWriter underneath it.
+func serveGzipped(t *testing.T, method, url string, rw http.ResponseWriter) {
+	t.Helper()
+
+	req, err := http.NewRequest(method, url, nil)
+	require.NoError(t, err)
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	Gziper()(gzipTestHandler(t)).ServeHTTP(web.NewResponseWriter(method, rw), req)
+}
+
+func TestGziper(t *testing.T) {
+	t.Run("compresses a GET response", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+
+		serveGzipped(t, http.MethodGet, "/d/abc/dash", rec)
+
+		require.Equal(t, "gzip", rec.Header().Get("Content-Encoding"))
+		require.Equal(t, "Accept-Encoding", rec.Header().Get("Vary"))
+		require.Empty(t, rec.Header().Get("Content-Length"), "the compressed length is not known in advance")
+		require.Less(t, rec.Body.Len(), len(gzipTestBody))
+
+		reader, err := gzip.NewReader(rec.Body)
+		require.NoError(t, err)
+		body, err := io.ReadAll(reader)
+		require.NoError(t, err)
+		require.Equal(t, gzipTestBody, body)
+	})
+
+	t.Run("does not compress a HEAD response, but keeps the headers a GET would return", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+
+		serveGzipped(t, http.MethodHead, "/d/abc/dash", rec)
+
+		require.Equal(t, "gzip", rec.Header().Get("Content-Encoding"))
+		require.Equal(t, "Accept-Encoding", rec.Header().Get("Vary"))
+		require.Empty(t, rec.Header().Get("Content-Length"))
+		require.Zero(t, rec.Body.Len(), "a HEAD response has no body")
+	})
+
+	t.Run("does not compress when the client does not accept gzip", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req, err := http.NewRequest(http.MethodGet, "/d/abc/dash", nil)
+		require.NoError(t, err)
+
+		Gziper()(gzipTestHandler(t)).ServeHTTP(web.NewResponseWriter(http.MethodGet, rec), req)
+
+		require.Empty(t, rec.Header().Get("Content-Encoding"))
+		require.Equal(t, gzipTestBody, rec.Body.Bytes())
+	})
+
+	t.Run("does not compress ignored paths", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+
+		serveGzipped(t, http.MethodGet, "/metrics", rec)
+
+		require.Empty(t, rec.Header().Get("Content-Encoding"))
+		require.Equal(t, gzipTestBody, rec.Body.Bytes())
+	})
+}
+
+// The compressor runs a goroutine that is only released when it is closed
+// cleanly, and a response it cannot write leaves that goroutine parked forever -
+// one per request, for as long as the process lives (#130649).
+func TestGziperDoesNotLeakGoroutines(t *testing.T) {
+	const requests = 20
+
+	t.Run("HEAD requests", func(t *testing.T) {
+		defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+		for range requests {
+			serveGzipped(t, http.MethodHead, "/d/abc/dash", httptest.NewRecorder())
+		}
+	})
+
+	t.Run("responses the client disconnects from", func(t *testing.T) {
+		defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+		for range requests {
+			serveGzipped(t, http.MethodGet, "/d/abc/dash", &brokenResponseWriter{failAfter: 1})
+		}
+	})
+
+	t.Run("responses that are written short", func(t *testing.T) {
+		defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+		for range requests {
+			serveGzipped(t, http.MethodGet, "/d/abc/dash", &brokenResponseWriter{failAfter: 1, short: true})
+		}
+	})
+}
+
+func TestGzipSink(t *testing.T) {
+	t.Run("reports a failed write as complete and remembers the error", func(t *testing.T) {
+		failed := &brokenResponseWriter{}
+		sink := &gzipSink{w: failed}
+
+		n, err := sink.Write([]byte("compressed"))
+		require.NoError(t, err, "the error must not reach the compressor")
+		require.Equal(t, len("compressed"), n, "a short write must not reach the compressor")
+		require.ErrorIs(t, sink.err(), errClientGone)
+	})
+
+	t.Run("reports a short write as complete and remembers it", func(t *testing.T) {
+		sink := &gzipSink{w: &brokenResponseWriter{short: true}}
+
+		n, err := sink.Write([]byte("compressed"))
+		require.NoError(t, err)
+		require.Equal(t, len("compressed"), n)
+		require.ErrorContains(t, sink.err(), "wrote 0 bytes of 10")
+	})
+
+	t.Run("keeps the first error and stops writing once a write failed", func(t *testing.T) {
+		failed := &brokenResponseWriter{}
+		sink := &gzipSink{w: failed}
+
+		_, err := sink.Write([]byte("first"))
+		require.NoError(t, err)
+		_, err = sink.Write([]byte("second"))
+		require.NoError(t, err)
+
+		require.ErrorIs(t, sink.err(), errClientGone)
+		require.Equal(t, 1, failed.writes, "a writer that failed is not written to again")
+	})
+
+	t.Run("passes successful writes through", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		sink := &gzipSink{w: rec}
+
+		n, err := sink.Write([]byte("compressed"))
+		require.NoError(t, err)
+		require.Equal(t, len("compressed"), n)
+		require.NoError(t, sink.err())
+		require.Equal(t, "compressed", rec.Body.String())
+	})
+}
+
+var errClientGone = errors.New("write tcp 10.0.0.1:3000->10.0.0.2:54321: write: broken pipe")
+
+// brokenResponseWriter stops accepting writes after failAfter of them, the way
+// the response writer of a client that has gone away does.
+type brokenResponseWriter struct {
+	failAfter int
+	short     bool
+	writes    int
+	header    http.Header
+}
+
+func (w *brokenResponseWriter) Header() http.Header {
+	if w.header == nil {
+		w.header = http.Header{}
+	}
+	return w.header
+}
+
+func (w *brokenResponseWriter) Write(b []byte) (int, error) {
+	w.writes++
+	if w.writes <= w.failAfter {
+		return len(b), nil
+	}
+	if w.short {
+		return 0, nil
+	}
+	return 0, errClientGone
+}
+
+func (w *brokenResponseWriter) WriteHeader(int) {}

--- a/pkg/web/response_writer.go
+++ b/pkg/web/response_writer.go
@@ -96,10 +96,18 @@ func (rw *responseWriter) Write(b []byte) (size int, err error) {
 		// The status will be StatusOK if WriteHeader has not been called yet
 		rw.WriteHeader(http.StatusOK)
 	}
-	if rw.method != "HEAD" {
-		size, err = rw.ResponseWriter.Write(b)
-		rw.size += size
+	if rw.method == "HEAD" {
+		// A HEAD response carries no body, so the body is dropped here. It is
+		// still reported as fully written, the way net/http does it: a writer
+		// that reports a short write without an error breaks everything wrapped
+		// around it, from io.Copy (io.ErrShortWrite) to the gzip middleware,
+		// which leaked a goroutine per HEAD request over it (#130649).
+		// Size() keeps reporting what actually went out on the wire.
+		return len(b), nil
 	}
+
+	size, err = rw.ResponseWriter.Write(b)
+	rw.size += size
 	return size, err
 }
 

--- a/pkg/web/response_writer_test.go
+++ b/pkg/web/response_writer_test.go
@@ -1,7 +1,10 @@
 package web
 
 import (
+	"bytes"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -22,6 +25,43 @@ func Test_responseWriter_WriteHeader(t *testing.T) {
 		rw.WriteHeader(0)
 		require.Equal(t, 500, rw.Status())
 		require.Equal(t, 500, f.Status)
+	})
+}
+
+func Test_responseWriter_Write(t *testing.T) {
+	body := []byte("a response body")
+
+	t.Run("it should write the body and count its size", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		rw := NewResponseWriter("GET", rec)
+
+		size, err := rw.Write(body)
+		require.NoError(t, err)
+		require.Equal(t, len(body), size)
+		require.Equal(t, body, rec.Body.Bytes())
+		require.Equal(t, len(body), rw.Size())
+	})
+
+	t.Run("it should drop the body of a HEAD response but report it as written", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		rw := NewResponseWriter("HEAD", rec)
+
+		// Reporting fewer bytes than it was given makes every writer wrapped
+		// around this one treat the response as a short write, which is how the
+		// gzip middleware used to leak a goroutine per request (#130649).
+		size, err := rw.Write(body)
+		require.NoError(t, err)
+		require.Equal(t, len(body), size)
+		require.Zero(t, rec.Body.Len(), "a HEAD response carries no body")
+		require.Zero(t, rw.Size(), "nothing was written to the wire")
+	})
+
+	t.Run("it should not fail an io.Copy of a HEAD response", func(t *testing.T) {
+		rw := NewResponseWriter("HEAD", httptest.NewRecorder())
+
+		written, err := io.Copy(rw, bytes.NewReader(body))
+		require.NoError(t, err)
+		require.Equal(t, int64(len(body)), written)
 	})
 }
 


### PR DESCRIPTION
Manual backport of https://github.com/grafana/grafana/pull/130893

With enable_gzip = true, every HEAD request carrying Accept-Encoding: gzip leaked one goroutine permanently, and so did any response whose write to the client failed part-way through.

pgzip compresses on a goroutine of its own and only releases it when Close closes the channel that goroutine listens on. Close returns before it gets that far as soon as a write to the underlying writer failed or came back short, leaving the goroutine parked for the lifetime of the process, holding its block buffers. web.ResponseWriter drops the body of a HEAD response and reports zero bytes written, which is how ordinary HEAD traffic reaches it.

Gziper now skips the compressor for HEAD, which has no body to compress, while keeping the headers the equivalent GET would return. Compressed writes go through a sink that reports complete writes to pgzip and remembers the first failure, so Close always releases the goroutine; the failure is reported to the handler and logged rather than discarded. web.ResponseWriter reports the dropped body of a HEAD response as fully written, the way net/http does, so nothing wrapped around it sees a short write.

Fixes #130649

(cherry picked from commit 711b5915e8374228bb3f7a7f60fdf33d5563f58e)