### PR TITLE
Storage: only reject reserved names when saving, not when reading

### DIFF
--- a/pkg/apimachinery/validation/validation.go
+++ b/pkg/apimachinery/validation/validation.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"regexp"
+	"slices"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -50,20 +51,30 @@ func IsValidGrafanaName(name string) []string {
 		return []string{"name is too long"}
 	}
 
-	// If this list is longer, we should compile regexp
-	if strings.EqualFold(name, "search") ||
-		strings.EqualFold(name, "trash") ||
-		strings.EqualFold(name, "history") ||
-		strings.EqualFold(name, "query") {
-		return []string{"name is reserved"}
-	}
-
 	if !grafanaNameRegexp(name) {
 		return []string{"name " + validation.RegexError(grafanaNameErrMsg, grafanaNameFmt, "MyName", "my.name", "abc-123")}
 	}
 	// In standard k8s, it must not start with a number
 	// however that would force us to update many many many existing resources
 	// so we will be slightly more lenient than standard k8s
+	return nil
+}
+
+// reservedNames would collide with the subresource paths mounted next to an
+// object, for example .../folders/trash.
+var reservedNames = []string{"search", "trash", "history", "query"}
+
+// IsReservedName checks if the name is one a new resource may not be saved under.
+//
+// Kept out of IsValidGrafanaName because that also validates the keys of stored
+// data as it is read. Some resources were saved under these names before they
+// were reserved, and they have to stay readable so they can be moved or deleted.
+func IsReservedName(name string) []string {
+	if slices.ContainsFunc(reservedNames, func(reserved string) bool {
+		return strings.EqualFold(name, reserved)
+	}) {
+		return []string{"name is reserved"}
+	}
 	return nil
 }
 

--- a/pkg/apimachinery/validation/validation_test.go
+++ b/pkg/apimachinery/validation/validation_test.go
@@ -29,13 +29,11 @@ func TestValidation(t *testing.T) {
 			input:  []string{strings.Repeat("0", 254)},
 			expect: []string{"name is too long"},
 		}, {
-			name:   "reserved",
-			input:  []string{"search", "TRASH", "History", "QuErY"},
-			expect: []string{"name is reserved"},
-		}, {
 			name: "ok",
 			input: []string{
 				"hello",
+				"trash", // reserved for new resources, but still a readable name
+				"search",
 				strings.Repeat("0", 253), // very long starts with number
 				"hello-world",
 				"hello.world",
@@ -232,4 +230,18 @@ func TestValidation(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestIsReservedName(t *testing.T) {
+	for _, name := range []string{"search", "TRASH", "History", "QuErY"} {
+		require.Equal(t, []string{"name is reserved"}, validation.IsReservedName(name), "input: %s", name)
+	}
+
+	for _, name := range []string{"hello", "trash-old", "searching", "my.query", ""} {
+		require.Nil(t, validation.IsReservedName(name), "input: %s", name)
+	}
+
+	// Reserved names have to stay valid so data already saved under them can
+	// still be read, moved or deleted.
+	require.Nil(t, validation.IsValidGrafanaName("trash"))
 }

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -951,6 +951,9 @@ func (s *server) newEvent(ctx context.Context, user claims.AuthInfo, key *resour
 	if errs := validation.IsValidGrafanaName(obj.GetName()); errs != nil {
 		return nil, NewBadRequestError(errs[0])
 	}
+	if errs := validation.IsReservedName(obj.GetName()); errs != nil {
+		return nil, NewBadRequestError(errs[0])
+	}
 
 	// For folder moves, we need to check permissions on both folders
 	if s.isFolderMove(event) {

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/apimachinery/validation"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/resource/kv"
@@ -2892,6 +2893,15 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 					Key:    req.Key,
 					Action: req.Action,
 					Error:  fmt.Sprintf("failed to save resource: invalid data key: %s", err),
+				})
+				continue
+			}
+
+			if errs := validation.IsReservedName(dataKey.Name); errs != nil {
+				rsp.Rejected = append(rsp.Rejected, &resourcepb.BulkResponse_Rejected{
+					Key:    req.Key,
+					Action: req.Action,
+					Error:  fmt.Sprintf("failed to save resource: %s", errs[0]),
 				})
 				continue
 			}


### PR DESCRIPTION
#131241 added the reserved names `search`/`trash`/`history`/`query` to `IsValidGrafanaName`, which also validates the keys of stored data as it is read. Resources saved under those names before the rule existed became unreadable, and because `BatchGet` fails a whole batch on the first invalid key, one such object makes every List in the namespace return 500.

This moves the reserved list into `IsReservedName` and calls it from the write paths — create, update and bulk import — so saving is still blocked but existing objects can be read, moved or deleted. Only an object's own name is checked, not its folder reference, so writing into a folder that already carries a reserved name works.

Found on `dev.grafana-dev.net`, where every List of folders and dashboards returns 500: the stack has a folder with the UID `trash` (title "» Trash") holding 8+ folders that predate the rule. Search is unaffected, since it answers from the index and never parses these keys.
