### PR TITLE
Alerting: Show nested route count and use route terminology in policy delete/reset dialogs

### DIFF
--- a/public/app/features/alerting/unified/NotificationPoliciesPage.test.tsx
+++ b/public/app/features/alerting/unified/NotificationPoliciesPage.test.tsx
@@ -191,7 +191,7 @@ const ui = {
   groupRepeatContainer: byTestId('am-repeat-interval'),
 
   confirmDeleteModal: byRole('dialog'),
-  confirmDeleteButton: byRole('button', { name: /yes, delete policy/i }),
+  confirmDeleteButton: byRole('button', { name: /yes, delete route/i }),
 };
 
 const getRootRoute = async () => {

--- a/public/app/features/alerting/unified/components/notification-policies/Modals.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/Modals.tsx
@@ -2,7 +2,7 @@ import { groupBy } from 'lodash';
 import { type FC, type JSX, useCallback, useMemo, useState } from 'react';
 
 import { Trans, t } from '@grafana/i18n';
-import { Button, Icon, Modal, type ModalProps, Spinner, Stack } from '@grafana/ui';
+import { Button, Icon, Modal, type ModalProps, Spinner, Stack, Text } from '@grafana/ui';
 import {
   AlertState,
   type AlertmanagerGroup,
@@ -12,7 +12,7 @@ import {
 
 import { type FormAmRoute } from '../../types/amroutes';
 import { type MatcherFormatter } from '../../utils/matchers';
-import { type InsertPosition } from '../../utils/routeTree';
+import { type InsertPosition, countChildRoutes } from '../../utils/routeTree';
 import { AlertGroup } from '../alert-groups/AlertGroup';
 
 import { AlertGroupsSummary } from './AlertGroupsSummary';
@@ -186,6 +186,8 @@ const useDeletePolicyModal = (
     setShowModal(true);
   }, []);
 
+  const childRouteCount = route ? countChildRoutes(route) : 0;
+
   const modalElement = useMemo(
     () =>
       loading ? (
@@ -196,19 +198,30 @@ const useDeletePolicyModal = (
           onDismiss={handleDismiss}
           closeOnBackdropClick={true}
           closeOnEscape={true}
-          title={t(
-            'alerting.use-delete-policy-modal.modal-element.title-delete-notification-policy',
-            'Delete notification policy'
-          )}
+          title={t('alerting.use-delete-policy-modal.modal-element.title-delete-notification-policy', 'Delete route')}
         >
           {error && <NotificationPoliciesErrorAlert error={error} />}
           <Trans i18nKey="alerting.policies.delete.warning-1">
-            Deleting this notification policy will permanently remove it.
+            Deleting this route will permanently remove it.
           </Trans>{' '}
-          <Trans i18nKey="alerting.policies.delete.warning-2">Are you sure you want to delete this policy?</Trans>
+          {childRouteCount > 0 && (
+            <Text element="p" color="error" weight="bold">
+              <Trans
+                i18nKey="alerting.policies.delete.warning-child-routes"
+                count={childRouteCount}
+                tOptions={{
+                  defaultValue_one: 'This will also remove {{count}} child route.',
+                  defaultValue_other: 'This will also remove {{count}} child routes.',
+                }}
+              >
+                This will also remove {{ count: childRouteCount }} child routes.
+              </Trans>
+            </Text>
+          )}{' '}
+          <Trans i18nKey="alerting.policies.delete.warning-2">Are you sure you want to delete this route?</Trans>
           <Modal.ButtonRow>
             <Button type="button" variant="destructive" onClick={() => route && handleDelete(route).catch(setError)}>
-              <Trans i18nKey="alerting.policies.delete.confirm">Yes, delete policy</Trans>
+              <Trans i18nKey="alerting.policies.delete.confirm">Yes, delete route</Trans>
             </Button>
             <Button type="button" variant="secondary" onClick={handleDismiss}>
               <Trans i18nKey="alerting.common.cancel">Cancel</Trans>
@@ -216,7 +229,7 @@ const useDeletePolicyModal = (
           </Modal.ButtonRow>
         </Modal>
       ),
-    [handleDismiss, loading, showModal, error, route, handleDelete]
+    [handleDismiss, loading, showModal, error, route, handleDelete, childRouteCount]
   );
 
   return [modalElement, handleShow, handleDismiss];

--- a/public/app/features/alerting/unified/components/notification-policies/PoliciesTree.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/PoliciesTree.tsx
@@ -348,6 +348,7 @@ export const PoliciesTree = ({
           setResetRoute(null);
         }}
         routeName={resetRoute?.[ROUTES_META_SYMBOL]?.name ?? resetRoute?.name ?? ''}
+        route={resetRoute}
         isActualDefaultPolicy={isDefaultRoutingTreeName(routeName)}
       />
     </>

--- a/public/app/features/alerting/unified/components/notification-policies/components/Modals.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/components/Modals.tsx
@@ -10,78 +10,16 @@ import { type FormAmRoute } from '../../../types/amroutes';
 import { defaultGroupBy } from '../../../utils/amroutes';
 import { GRAFANA_RULES_SOURCE_NAME } from '../../../utils/datasource';
 import { stringifyErrorLike } from '../../../utils/misc';
+import { countChildRoutes } from '../../../utils/routeTree';
 import { ErrorModal } from '../../ErrorModal';
 import { AmRootRouteForm } from '../EditDefaultPolicyForm';
 import { NotificationPoliciesErrorAlert } from '../PolicyUpdateErrorAlert';
 import {
   trackNotificationPolicyCreateError,
   trackNotificationPolicyCreated,
-  trackNotificationPolicyDeleteError,
-  trackNotificationPolicyDeleted,
   trackNotificationPolicyReset,
   trackNotificationPolicyResetError,
 } from '../notificationPolicyAnalytics';
-
-interface DeleteModalProps {
-  isOpen: boolean;
-  onConfirm: () => Promise<unknown>;
-  onDismiss: () => void;
-  routeName: string;
-}
-
-const DeleteModal = React.memo(({ onConfirm, onDismiss, isOpen, routeName }: DeleteModalProps) => {
-  const [isDeleting, setIsDeleting] = useState(false);
-  const [error, setError] = useState<unknown | undefined>();
-
-  const onDeleteDismiss = () => {
-    onDismiss();
-    setError(undefined);
-  };
-
-  const onDeleteConfirm = async () => {
-    setIsDeleting(true);
-    onConfirm()
-      .then(() => {
-        trackNotificationPolicyDeleted();
-        onDeleteDismiss();
-      })
-      .catch((err) => {
-        trackNotificationPolicyDeleteError({ error: stringifyErrorLike(err) });
-        setError(err);
-      })
-      .finally(() => {
-        setIsDeleting(false);
-      });
-  };
-  if (error) {
-    return <ErrorModal isOpen={isOpen} onDismiss={onDeleteDismiss} error={error} />;
-  }
-
-  return (
-    <ConfirmModal
-      body={
-        <>
-          <Text element="p">
-            <Trans
-              i18nKey="alerting.policies.delete-modal.permanently-remove"
-              values={{ routeName: isDefaultRoutingTreeName(routeName) ? 'Default Policy' : routeName }}
-            >
-              This action will permanently remove the <code>{'{{routeName}}'}</code> notification policy.
-            </Trans>
-          </Text>
-          <Space v={2} />
-        </>
-      }
-      confirmationText={t('alerting.common.delete', 'Delete')}
-      confirmText={isDeleting ? t('alerting.common.deleting', 'Deleting...') : t('alerting.common.delete', 'Delete')}
-      onDismiss={onDeleteDismiss}
-      onConfirm={onDeleteConfirm}
-      title={t('alerting.policies.delete-modal.title-delete-notification-policy', 'Delete notification policy')}
-      isOpen={isOpen}
-    />
-  );
-});
-DeleteModal.displayName = 'DeleteModal';
 
 function getConfirmText(isResetting: boolean, isActualDefaultPolicy: boolean): string {
   if (isResetting) {
@@ -99,14 +37,16 @@ export interface ResetModalProps {
   onConfirm: () => Promise<unknown>;
   onDismiss: () => void;
   routeName: string;
+  route: RouteWithID | null;
   /** When true (default), shows "Reset" language. When false, shows "Delete" language for non-default policy trees. */
   isActualDefaultPolicy?: boolean;
 }
 
 export const ResetModal = React.memo(
-  ({ onConfirm, onDismiss, isOpen, routeName, isActualDefaultPolicy = true }: ResetModalProps) => {
+  ({ onConfirm, onDismiss, isOpen, routeName, route, isActualDefaultPolicy = true }: ResetModalProps) => {
     const [isResetting, setIsResetting] = useState(false);
     const [error, setError] = useState<unknown | undefined>();
+    const childRouteCount = route ? countChildRoutes(route) : 0;
 
     const onResetDismiss = () => {
       onDismiss();
@@ -150,6 +90,23 @@ export const ResetModal = React.memo(
                 </Trans>
               )}
             </Text>
+            {childRouteCount > 0 && (
+              <>
+                <Space v={2} />
+                <Text element="p" color="error" weight="bold">
+                  <Trans
+                    i18nKey="alerting.policies.reset-modal.warning-child-routes"
+                    count={childRouteCount}
+                    tOptions={{
+                      defaultValue_one: 'This will also remove {{count}} child route.',
+                      defaultValue_other: 'This will also remove {{count}} child routes.',
+                    }}
+                  >
+                    This will also remove {{ count: childRouteCount }} child routes.
+                  </Trans>
+                </Text>
+              </>
+            )}
             <Space v={2} />
           </>
         }

--- a/public/app/features/alerting/unified/components/notification-policies/notificationPolicyAnalytics.ts
+++ b/public/app/features/alerting/unified/components/notification-policies/notificationPolicyAnalytics.ts
@@ -8,14 +8,6 @@ export function trackNotificationPolicyCreateError(payload: { error: string }) {
   reportInteraction('grafana_alerting_notification_policy_create_error', payload);
 }
 
-export function trackNotificationPolicyDeleted() {
-  reportInteraction('grafana_alerting_notification_policy_deleted');
-}
-
-export function trackNotificationPolicyDeleteError(payload: { error: string }) {
-  reportInteraction('grafana_alerting_notification_policy_delete_error', payload);
-}
-
 export function trackNotificationPolicyReset() {
   reportInteraction('grafana_alerting_notification_policy_reset');
 }

--- a/public/app/features/alerting/unified/settings/import/PromoteConfirmModal.test.tsx
+++ b/public/app/features/alerting/unified/settings/import/PromoteConfirmModal.test.tsx
@@ -122,7 +122,7 @@ describe('PromoteConfirmModal', () => {
     expect(dialog).toHaveTextContent('4 templates added');
     expect(dialog).toHaveTextContent('2 time intervals added');
     expect(dialog).toHaveTextContent('3 inhibition rules added');
-    expect(dialog).toHaveTextContent('1 notification route added');
+    expect(dialog).toHaveTextContent('1 route added');
 
     // Rename-to-avoid-conflicts list and the "rules already active" note.
     expect(dialog).toHaveTextContent('Renamed to avoid conflicts');

--- a/public/app/features/alerting/unified/settings/import/StagedPromotePreview.tsx
+++ b/public/app/features/alerting/unified/settings/import/StagedPromotePreview.tsx
@@ -97,11 +97,7 @@ function MergePreview({ stats }: { stats: PromoteStatsSummary }) {
         />
       )}
       {stats.route && (
-        <MergeRow
-          icon="sitemap"
-          count={1}
-          noun={t('alerting.settings.import.promote.merge-route', 'notification route added')}
-        />
+        <MergeRow icon="sitemap" count={1} noun={t('alerting.settings.import.promote.merge-route', 'route added')} />
       )}
     </Stack>
   );

--- a/public/app/features/alerting/unified/utils/routeTree.ts
+++ b/public/app/features/alerting/unified/utils/routeTree.ts
@@ -170,6 +170,12 @@ export function findExistingRoute(id: string, routeTree: RouteWithID): RouteWith
   return routeTree.id === id ? routeTree : routeTree.routes?.find((route) => findExistingRoute(id, route));
 }
 
+// counts every route nested under this one, so callers can warn before removing a route with children
+export function countChildRoutes(route: RouteWithID): number {
+  const children = route.routes ?? [];
+  return children.reduce((total, child) => total + 1 + countChildRoutes(child), 0);
+}
+
 /**
  * This function converts an object into a unique hash by sorting the keys and applying a simple integer hash
  */

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -890,7 +890,6 @@
       "close": "Close",
       "create": "Create",
       "delete": "Delete",
-      "deleting": "Deleting...",
       "edit": "Edit",
       "export": "Export",
       "export-all": "Export all",
@@ -2495,13 +2494,11 @@
         "update": "Update policy"
       },
       "delete": {
-        "confirm": "Yes, delete policy",
-        "warning-1": "Deleting this notification policy will permanently remove it.",
-        "warning-2": "Are you sure you want to delete this policy?"
-      },
-      "delete-modal": {
-        "permanently-remove": "This action will permanently remove the <1>{{routeName}}</1> notification policy.",
-        "title-delete-notification-policy": "Delete notification policy"
+        "confirm": "Yes, delete route",
+        "warning-1": "Deleting this route will permanently remove it.",
+        "warning-2": "Are you sure you want to delete this route?",
+        "warning-child-routes_one": "This will also remove {{count}} child route.",
+        "warning-child-routes_other": "This will also remove {{count}} child routes."
       },
       "filter-description": "Filter routes by using a comma separated list of matchers, e.g.:<1>severity=critical, region=EMEA</1>",
       "generated-policies": "Auto-generated policies",
@@ -2548,7 +2545,9 @@
         "reset": "Reset",
         "resetting": "Resetting...",
         "title-delete-notification-policy": "Delete notification policy",
-        "title-reset-notification-policy": "Reset notification policy"
+        "title-reset-notification-policy": "Reset notification policy",
+        "warning-child-routes_one": "This will also remove {{count}} child route.",
+        "warning-child-routes_other": "This will also remove {{count}} child routes."
       },
       "update": {
         "please-wait": "Please wait while we update your notification policies.",
@@ -3300,7 +3299,7 @@
           "merge-info": "Promoting merges this configuration into your live Grafana Alertmanager. This is a one-time action and can't be undone.",
           "merge-inhibition-rules_one": "inhibition rule added",
           "merge-inhibition-rules_other": "inhibition rules added",
-          "merge-route": "notification route added",
+          "merge-route": "route added",
           "merge-templates_one": "template added",
           "merge-templates_other": "templates added",
           "merge-time-intervals_one": "time interval added",
@@ -3832,7 +3831,7 @@
     },
     "use-delete-policy-modal": {
       "modal-element": {
-        "title-delete-notification-policy": "Delete notification policy"
+        "title-delete-notification-policy": "Delete route"
       }
     },
     "use-edit-configuration-drawer": {


### PR DESCRIPTION
**What is this feature?**

When deleting or resetting a notification policy tree, the confirmation dialog now warns how many nested routes will also be removed. The individual route delete dialog wording was also switched from "policy" to "route". Removed the unused `DeleteModal` component and its dead analytics functions.

**Why do we need this feature?**

Users could unknowingly wipe out nested routes without any warning of the blast radius.

**Who is this feature for?**

Grafana Alerting users managing notification policies.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

I've also removed a `DeleteModal` that wasn't being used anywhere :)
 
Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.