### PR TITLE
oauth: fix access token leak from the log

### DIFF
--- a/pkg/login/social/connectors/social_base.go
+++ b/pkg/login/social/connectors/social_base.go
@@ -17,7 +17,7 @@ import (
 	"sync"
 	"time"
 
-	jose "github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
 	"golang.org/x/oauth2"
 	"golang.org/x/text/cases"
@@ -266,7 +266,7 @@ func (s *SocialBase) retrieveRawJWTPayload(token any) ([]byte, error) {
 	jwtRegexp := regexp.MustCompile("^([-_a-zA-Z0-9=]+)[.]([-_a-zA-Z0-9=]+)[.]([-_a-zA-Z0-9=]+)$")
 	matched := jwtRegexp.FindStringSubmatch(tokenString)
 	if matched == nil {
-		return nil, fmt.Errorf("token is not in JWT format: %s", tokenString)
+		return nil, fmt.Errorf("token is not in JWT format: %s", util.RedactSecret(tokenString))
 	}
 
 	rawJSON, err := base64.RawURLEncoding.DecodeString(matched[2])

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -285,3 +285,16 @@ func stripBOMReflect(v reflect.Value) {
 		return
 	}
 }
+
+// RedactSecret truncates the middle of the secret with '...', keeping 3 characters at the start and end.
+// If the secret is shorter than 8 characters, the special string '<redacted>' is returned instead.
+func RedactSecret(secret string) string {
+	runes := []rune(secret)
+	l := len(runes)
+
+	if l < 8 {
+		return "<redacted>"
+	}
+
+	return string(runes[:3]) + "..." + string(runes[l-3:])
+}

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -287,12 +287,12 @@ func stripBOMReflect(v reflect.Value) {
 }
 
 // RedactSecret truncates the middle of the secret with '...', keeping 3 characters at the start and end.
-// If the secret is shorter than 8 characters, the special string '<redacted>' is returned instead.
+// If the secret is shorter than 16 characters, the special string '<redacted>' is returned instead.
 func RedactSecret(secret string) string {
 	runes := []rune(secret)
 	l := len(runes)
 
-	if l < 8 {
+	if l < 16 {
 		return "<redacted>"
 	}
 

--- a/pkg/util/strings_test.go
+++ b/pkg/util/strings_test.go
@@ -590,3 +590,34 @@ func BenchmarkStripBOMFromStruct(b *testing.B) {
 		}
 	})
 }
+
+func TestRedactString(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "basic secret",
+			input: "secret-value",
+			want:  "sec...lue",
+		},
+		{
+			name:  "small secret",
+			input: "abc",
+			want:  "<redacted>",
+		},
+		{
+			name:  "secret with minimal length",
+			input: "12345678",
+			want:  "123...678",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RedactSecret(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/util/strings_test.go
+++ b/pkg/util/strings_test.go
@@ -591,7 +591,7 @@ func BenchmarkStripBOMFromStruct(b *testing.B) {
 	})
 }
 
-func TestRedactString(t *testing.T) {
+func TestRedactSecret(t *testing.T) {
 	tests := []struct {
 		name  string
 		input string

--- a/pkg/util/strings_test.go
+++ b/pkg/util/strings_test.go
@@ -599,8 +599,8 @@ func TestRedactSecret(t *testing.T) {
 	}{
 		{
 			name:  "basic secret",
-			input: "secret-value",
-			want:  "sec...lue",
+			input: "my-secret-value-that-should-be-redacted",
+			want:  "my-...ted",
 		},
 		{
 			name:  "small secret",
@@ -609,8 +609,8 @@ func TestRedactSecret(t *testing.T) {
 		},
 		{
 			name:  "secret with minimal length",
-			input: "12345678",
-			want:  "123...678",
+			input: "123456789abcdefg",
+			want:  "123...efg",
 		},
 	}
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this fix?**

During the OAuth Flow, if the access token doesn't follow the JWT format, then a log with the token is produced.

**Why do we need this feature?**

Security measure, even if the access token doesn't follow the JWT, it's still a valid token that shouldn't be share

**Who is this feature for?**

Users with SSO configured

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #111494

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
