### PR TITLE
Dashboards: Add a diff pane and expose it to plugins

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2571,6 +2571,7 @@ fail_tests_on_console = true
 
 [plugins.restricted_apis_allowlist]
 dashboardMutationAPI = grafana-assistant-app
+dashboardEditorAPI = grafana-assistant-app
 
 [plugins.restricted_apis_blocklist]
 # Example: Block specific plugins from accessing an API

--- a/packages/grafana-data/src/context/plugins/RestrictedGrafanaApis.tsx
+++ b/packages/grafana-data/src/context/plugins/RestrictedGrafanaApis.tsx
@@ -25,7 +25,9 @@ export interface DashboardEditorAPI {
   hasUnsavedChanges(): boolean;
   /** True when the open dashboard is in edit mode. */
   isEditing(): boolean;
-  /** Calls back whenever the answer to `hasUnsavedChanges()` or `isEditing()` may have changed. Returns an unsubscribe. */
+  /** True when the dashboard sidebar's diff pane is the open pane. */
+  isDiffViewOpen(): boolean;
+  /** Calls back whenever the answer to any of the above may have changed. Returns an unsubscribe. */
   subscribeToChanges(cb: () => void): () => void;
   /** Opens the dashboard sidebar's diff pane. No-op when no dashboard is open. */
   openDiffView(): void;

--- a/packages/grafana-data/src/context/plugins/RestrictedGrafanaApis.tsx
+++ b/packages/grafana-data/src/context/plugins/RestrictedGrafanaApis.tsx
@@ -20,11 +20,23 @@ export interface DashboardMutationAPI {
   getAvailableCommands(): string[];
 }
 
+export interface DashboardEditorAPI {
+  /** True when the open dashboard differs from its last saved version. */
+  hasUnsavedChanges(): boolean;
+  /** True when the open dashboard is in edit mode. */
+  isEditing(): boolean;
+  /** Calls back whenever the answer to `hasUnsavedChanges()` or `isEditing()` may have changed. Returns an unsubscribe. */
+  subscribeToChanges(cb: () => void): () => void;
+  /** Opens the dashboard sidebar's diff pane. No-op when no dashboard is open. */
+  openDiffView(): void;
+}
+
 interface RestrictedGrafanaApisContextTypeInternal {
   // Add types for restricted Grafana APIs here
   // (Make sure that they are typed as optional properties)
   alertingAlertRuleFormSchema?: ZodSchema;
   dashboardMutationAPI?: DashboardMutationAPI;
+  dashboardEditorAPI?: DashboardEditorAPI;
 }
 
 // We are exposing this through a "type validation", to make sure that all APIs are optional (which helps plugins catering for scenarios when they are not available).

--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -475,6 +475,7 @@ export {
   type RestrictedGrafanaApisAllowList,
   type DashboardMutationAPI,
   type DashboardMutationResult,
+  type DashboardEditorAPI,
   RestrictedGrafanaApisContext,
   RestrictedGrafanaApisContextProvider,
   useRestrictedGrafanaApis,

--- a/public/app/features/dashboard-scene/sidebar/DashboardDiffPane.test.tsx
+++ b/public/app/features/dashboard-scene/sidebar/DashboardDiffPane.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { Sidebar, useSidebar } from '@grafana/ui';
+
+import { DashboardDiffPane } from './DashboardDiffPane';
+import { getDashboardDiffTexts, getDashboardResourceText } from './codePaneUtils';
+
+jest.mock('../utils/utils', () => ({
+  getDashboardSceneFor: jest.fn(() => ({})),
+}));
+
+jest.mock('app/core/components/MonacoDiffEditor/MonacoDiffEditor', () => ({
+  MonacoDiffEditor: () => <div data-testid="diff-viewer" />,
+}));
+
+jest.mock('./codePaneUtils', () => ({
+  getDashboardDiffTexts: jest.fn(),
+  getDashboardResourceText: jest.fn(() => '{"spec":{}}'),
+}));
+
+function WrapSidebar({ children }: { children: React.ReactNode }) {
+  const sidebarContext = useSidebar({});
+  return <Sidebar contextValue={sidebarContext}>{children}</Sidebar>;
+}
+
+function setup() {
+  const pane = new DashboardDiffPane({});
+  const Component = DashboardDiffPane.Component;
+  return render(
+    <WrapSidebar>
+      <Component model={pane} />
+    </WrapSidebar>
+  );
+}
+
+describe('DashboardDiffPane', () => {
+  beforeEach(() => {
+    jest.mocked(getDashboardDiffTexts).mockReset();
+    jest.mocked(getDashboardResourceText).mockReset().mockReturnValue('{"spec":{}}');
+  });
+
+  it('has a stable pane id and the wide pane width', () => {
+    const pane = new DashboardDiffPane({});
+
+    expect(pane.getId()).toBe('diff');
+    expect(pane.minWidth).toBe(700);
+  });
+
+  it('renders the diff without any interaction', () => {
+    jest.mocked(getDashboardDiffTexts).mockReturnValue({ original: 'a', current: 'b', migratedFromV1: false });
+
+    setup();
+
+    expect(screen.getByTestId('diff-viewer')).toBeInTheDocument();
+  });
+
+  it('compares the current resource text against the last saved version in the selected format', () => {
+    jest.mocked(getDashboardDiffTexts).mockReturnValue({ original: 'a', current: 'b', migratedFromV1: false });
+
+    setup();
+
+    expect(getDashboardResourceText).toHaveBeenCalledWith(expect.anything(), 'json');
+    expect(getDashboardDiffTexts).toHaveBeenCalledWith(expect.anything(), '{"spec":{}}', 'json');
+  });
+
+  it('re-renders the diff in yaml without re-reading the scene', async () => {
+    jest.mocked(getDashboardDiffTexts).mockReturnValue({ original: 'a', current: 'b', migratedFromV1: false });
+
+    setup();
+    jest.mocked(getDashboardResourceText).mockClear();
+
+    await userEvent.click(screen.getByRole('radio', { name: 'YAML' }));
+
+    expect(getDashboardDiffTexts).toHaveBeenLastCalledWith(expect.anything(), '{"spec":{}}', 'yaml');
+    expect(getDashboardResourceText).not.toHaveBeenCalled();
+  });
+
+  it('shows a migration notice when the last saved version was converted from v1', () => {
+    jest.mocked(getDashboardDiffTexts).mockReturnValue({ original: 'a', current: 'b', migratedFromV1: true });
+
+    setup();
+
+    expect(screen.getByText(/migration to the new dashboard format/)).toBeInTheDocument();
+    expect(screen.getByTestId('diff-viewer')).toBeInTheDocument();
+  });
+
+  it('shows no migration notice for a v2 dashboard', () => {
+    jest.mocked(getDashboardDiffTexts).mockReturnValue({ original: 'a', current: 'b', migratedFromV1: false });
+
+    setup();
+
+    expect(screen.queryByText(/migration to the new dashboard format/)).not.toBeInTheDocument();
+  });
+
+  it('shows an empty state when there are no changes', () => {
+    jest.mocked(getDashboardDiffTexts).mockReturnValue({ original: 'a', current: 'a', migratedFromV1: false });
+
+    setup();
+
+    expect(screen.getByText('No changes to show')).toBeInTheDocument();
+    expect(screen.queryByTestId('diff-viewer')).not.toBeInTheDocument();
+  });
+
+  it('shows an unavailable message when no diff can be produced', () => {
+    jest.mocked(getDashboardDiffTexts).mockReturnValue(null);
+
+    setup();
+
+    expect(screen.getByText('Cannot show changes')).toBeInTheDocument();
+    expect(screen.queryByTestId('diff-viewer')).not.toBeInTheDocument();
+  });
+
+  it('hides the format and layout toggles when there is nothing to compare', () => {
+    jest.mocked(getDashboardDiffTexts).mockReturnValue({ original: 'a', current: 'a', migratedFromV1: false });
+
+    setup();
+
+    expect(screen.queryByRole('radio', { name: 'YAML' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('radio', { name: 'Inline' })).not.toBeInTheDocument();
+  });
+
+  it('offers side-by-side and inline layouts while a diff is shown', () => {
+    jest.mocked(getDashboardDiffTexts).mockReturnValue({ original: 'a', current: 'b', migratedFromV1: false });
+
+    setup();
+
+    expect(screen.getByRole('radio', { name: 'Inline' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Side by side' })).toBeChecked();
+  });
+});

--- a/public/app/features/dashboard-scene/sidebar/DashboardDiffPane.tsx
+++ b/public/app/features/dashboard-scene/sidebar/DashboardDiffPane.tsx
@@ -1,0 +1,140 @@
+import { css } from '@emotion/css';
+import { useMemo, useState } from 'react';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { type SceneComponentProps, SceneObjectBase } from '@grafana/scenes';
+import { Alert, EmptyState, RadioButtonGroup, Sidebar, Stack, useStyles2 } from '@grafana/ui';
+import { MonacoDiffEditor } from 'app/core/components/MonacoDiffEditor/MonacoDiffEditor';
+import { InlineDiffToggle, useInlineDiffPreference } from 'app/core/components/MonacoDiffEditor/inlineDiffPreference';
+
+import { getDashboardSceneFor } from '../utils/utils';
+import { type SchemaEditorFormat } from '../v2schema/DashboardSchemaEditor';
+
+import { getDashboardDiffTexts, getDashboardResourceText } from './codePaneUtils';
+
+export class DashboardDiffPane extends SceneObjectBase {
+  public static Component = DashboardDiffPaneRenderer;
+  public minWidth = 700;
+
+  public getId() {
+    return 'diff' as const;
+  }
+}
+
+function DashboardDiffPaneRenderer({ model }: SceneComponentProps<DashboardDiffPane>) {
+  const styles = useStyles2(getStyles);
+  const dashboard = getDashboardSceneFor(model);
+
+  const [format, setFormat] = useState<SchemaEditorFormat>('json');
+  const [inlineDiff, setInlineDiff] = useInlineDiffPreference();
+
+  // Serialize the scene once, on mount. A new pane instance is constructed on every open, so this
+  // always reflects the current dashboard - no scene graph subscription needed to stay fresh.
+  const [currentJsonText] = useState(() => getDashboardResourceText(dashboard, 'json'));
+
+  const diffTexts = useMemo(
+    () => getDashboardDiffTexts(dashboard, currentJsonText, format),
+    [dashboard, currentJsonText, format]
+  );
+
+  const formatOptions: Array<{ label: string; value: SchemaEditorFormat }> = [
+    { label: t('dashboard.sidebar.diff.format-json', 'JSON'), value: 'json' },
+    { label: t('dashboard.sidebar.diff.format-yaml', 'YAML'), value: 'yaml' },
+  ];
+
+  const hasDiff = diffTexts !== null && diffTexts.original !== diffTexts.current;
+
+  let content: React.ReactNode;
+  if (!diffTexts) {
+    // No comparable original: the dashboard has no initial save model, or it was loaded as v1 and
+    // the v1->v2 conversion of the original failed.
+    content = (
+      <Alert
+        severity="info"
+        title={t('dashboard.sidebar.diff.unavailable', 'Cannot show changes')}
+        topSpacing={0}
+        bottomSpacing={0}
+      >
+        {t('dashboard.sidebar.diff.unavailable-body', 'The last saved dashboard is not available for comparison.')}
+      </Alert>
+    );
+  } else if (!hasDiff) {
+    content = (
+      <EmptyState variant="completed" message={t('dashboard.sidebar.diff.no-changes', 'No changes to show')}>
+        {t('dashboard.sidebar.diff.no-changes-body', 'The dashboard matches the last saved version.')}
+      </EmptyState>
+    );
+  } else {
+    content = (
+      <>
+        {diffTexts.migratedFromV1 && (
+          <Alert
+            severity="info"
+            topSpacing={0}
+            bottomSpacing={0}
+            title={t(
+              'dashboard.sidebar.diff.migrated',
+              'Note: The diff also includes changes resulting from migration to the new dashboard format.'
+            )}
+          />
+        )}
+        <div className={styles.diffContainer}>
+          <MonacoDiffEditor
+            original={diffTexts.original}
+            modified={diffTexts.current}
+            language={format}
+            height="100%"
+            inline={inlineDiff}
+          />
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <div className={styles.wrapper}>
+      <Sidebar.PaneHeader title={t('dashboard.sidebar.diff.pane-header', 'Changes')} />
+      <div className={styles.content}>
+        {hasDiff && (
+          <div className={styles.toolbar}>
+            <Stack direction="row" gap={1} alignItems="center">
+              <RadioButtonGroup options={formatOptions} value={format} onChange={setFormat} />
+              <InlineDiffToggle value={inlineDiff} onChange={setInlineDiff} />
+            </Stack>
+          </div>
+        )}
+        {content}
+      </div>
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  wrapper: css({
+    display: 'flex',
+    flexDirection: 'column',
+    flex: '1 1 0',
+    height: '100%',
+  }),
+  content: css({
+    display: 'flex',
+    flexDirection: 'column',
+    flex: 1,
+    minHeight: 0,
+    padding: theme.spacing(1),
+    gap: theme.spacing(1),
+  }),
+  toolbar: css({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    flex: '0 0 auto',
+  }),
+  diffContainer: css({
+    height: '100%',
+    flex: '1 1 0',
+    minHeight: 0,
+    overflow: 'auto',
+  }),
+});

--- a/public/app/features/plugins/components/restrictedGrafanaApis/RestrictedGrafanaApisProvider.test.tsx
+++ b/public/app/features/plugins/components/restrictedGrafanaApis/RestrictedGrafanaApisProvider.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from '@testing-library/react';
+
+import { useRestrictedGrafanaApis } from '@grafana/data';
+import { config } from '@grafana/runtime';
+
+import { RestrictedGrafanaApisProvider } from './RestrictedGrafanaApisProvider';
+
+// The exposed API set is built when RestrictedGrafanaApisProvider is first evaluated, so the
+// toggle has to be on before that import runs.
+jest.mock('@grafana/runtime', () => {
+  const actual = jest.requireActual('@grafana/runtime');
+  return {
+    ...actual,
+    config: {
+      ...actual.config,
+      featureToggles: { ...actual.config.featureToggles, restrictedPluginApis: true },
+      bootData: { ...actual.config.bootData, settings: { ...actual.config.bootData.settings } },
+    },
+  };
+});
+
+jest.mock('./alerting/alertRuleFormSchema', () => ({
+  alertingAlertRuleFormSchemaApi: { alertingAlertRuleFormSchema: { parse: jest.fn(), safeParse: jest.fn() } },
+}));
+
+jest.mock('./dashboardMutation/dashboardMutationApi', () => ({
+  dashboardMutationApi: {},
+}));
+
+jest.mock('./dashboardEditor/dashboardEditorApi', () => ({
+  dashboardEditorApi: {
+    hasUnsavedChanges: jest.fn(() => false),
+    subscribeToChanges: jest.fn(() => jest.fn()),
+    openDiffView: jest.fn(),
+  },
+}));
+
+const PLUGIN_ID = 'grafana-assistant-app';
+
+function ApiProbe() {
+  const { dashboardEditorAPI } = useRestrictedGrafanaApis();
+
+  if (!dashboardEditorAPI) {
+    return <div data-testid="probe">unavailable</div>;
+  }
+
+  return (
+    <div data-testid="probe">
+      {typeof dashboardEditorAPI.hasUnsavedChanges} {typeof dashboardEditorAPI.subscribeToChanges}{' '}
+      {typeof dashboardEditorAPI.openDiffView}
+    </div>
+  );
+}
+
+function renderProvider() {
+  return render(
+    <RestrictedGrafanaApisProvider pluginId={PLUGIN_ID}>
+      <ApiProbe />
+    </RestrictedGrafanaApisProvider>
+  );
+}
+
+describe('RestrictedGrafanaApisProvider', () => {
+  afterEach(() => {
+    config.bootData.settings.pluginRestrictedAPIsAllowList = undefined;
+    config.bootData.settings.pluginRestrictedAPIsBlockList = undefined;
+  });
+
+  it('exposes the full dashboardEditorAPI contract to an allow-listed plugin', () => {
+    config.bootData.settings.pluginRestrictedAPIsAllowList = { dashboardEditorAPI: [PLUGIN_ID] };
+
+    renderProvider();
+
+    expect(screen.getByTestId('probe')).toHaveTextContent('function function function');
+  });
+
+  it('does not expose dashboardEditorAPI to a plugin that is not allow-listed', () => {
+    config.bootData.settings.pluginRestrictedAPIsAllowList = { dashboardEditorAPI: ['some-other-app'] };
+
+    renderProvider();
+
+    expect(screen.getByTestId('probe')).toHaveTextContent('unavailable');
+  });
+
+  it('does not expose dashboardEditorAPI to a blocked plugin', () => {
+    config.bootData.settings.pluginRestrictedAPIsBlockList = { dashboardEditorAPI: [PLUGIN_ID] };
+
+    renderProvider();
+
+    expect(screen.getByTestId('probe')).toHaveTextContent('unavailable');
+  });
+
+  it('does not expose dashboardEditorAPI when neither list mentions it', () => {
+    renderProvider();
+
+    expect(screen.getByTestId('probe')).toHaveTextContent('unavailable');
+  });
+});

--- a/public/app/features/plugins/components/restrictedGrafanaApis/RestrictedGrafanaApisProvider.tsx
+++ b/public/app/features/plugins/components/restrictedGrafanaApis/RestrictedGrafanaApisProvider.tsx
@@ -4,12 +4,14 @@ import { RestrictedGrafanaApisContextProvider, type RestrictedGrafanaApisContext
 import { config } from '@grafana/runtime';
 import { alertingAlertRuleFormSchemaApi } from 'app/features/plugins/components/restrictedGrafanaApis/alerting/alertRuleFormSchema';
 
+import { dashboardEditorApi } from './dashboardEditor/dashboardEditorApi';
 import { dashboardMutationApi } from './dashboardMutation/dashboardMutationApi';
 
 const restrictedGrafanaApis: RestrictedGrafanaApisContextType = config.featureToggles.restrictedPluginApis
   ? {
       alertingAlertRuleFormSchema: alertingAlertRuleFormSchemaApi.alertingAlertRuleFormSchema,
       dashboardMutationAPI: dashboardMutationApi,
+      dashboardEditorAPI: dashboardEditorApi,
     }
   : {};
 

--- a/public/app/features/plugins/components/restrictedGrafanaApis/dashboardEditor/dashboardEditorApi.test.ts
+++ b/public/app/features/plugins/components/restrictedGrafanaApis/dashboardEditor/dashboardEditorApi.test.ts
@@ -1,0 +1,270 @@
+import { SceneObjectBase, type SceneObjectState } from '@grafana/scenes';
+import { StateManagerBase } from 'app/core/services/StateManagerBase';
+import { getDashboardScenePageStateManager } from 'app/features/dashboard-scene/pages/DashboardScenePageStateManager';
+import { DashboardDiffPane } from 'app/features/dashboard-scene/sidebar/DashboardDiffPane';
+
+import { dashboardEditorApi } from './dashboardEditorApi';
+
+jest.mock('app/features/dashboard-scene/pages/DashboardScenePageStateManager', () => ({
+  getDashboardScenePageStateManager: jest.fn(),
+}));
+
+interface FakeDashboardState extends SceneObjectState {
+  isDirty?: boolean;
+  isEditing?: boolean;
+  sidebar: { openPane: jest.Mock; state: { openPane?: { getId: () => string } } };
+}
+
+/**
+ * A real SceneObjectBase so subscribeToState / isActive behave exactly as they do on
+ * DashboardScene, with only the two members the API touches stubbed out.
+ */
+class FakeDashboardScene extends SceneObjectBase<FakeDashboardState> {
+  public getDashboardChanges = jest.fn(() => ({
+    diffCount: 0,
+    hasFolderChanges: false,
+    hasPredefinedVariablesChanges: false,
+  }));
+}
+
+function setup({ activate = true }: { activate?: boolean } = {}) {
+  const scene = new FakeDashboardScene({ isDirty: false, sidebar: { openPane: jest.fn(), state: {} } });
+  if (activate) {
+    scene.activate();
+  }
+
+  const stateManager = new StateManagerBase<{ dashboard?: FakeDashboardScene }>({ dashboard: scene });
+  jest.mocked(getDashboardScenePageStateManager).mockReturnValue(stateManager as never);
+
+  return { scene, stateManager };
+}
+
+function setupWithoutDashboard() {
+  const stateManager = new StateManagerBase<{ dashboard?: FakeDashboardScene }>({});
+  jest.mocked(getDashboardScenePageStateManager).mockReturnValue(stateManager as never);
+  return { stateManager };
+}
+
+describe('dashboardEditorApi', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('hasUnsavedChanges', () => {
+    it('reports no changes when the dashboard matches its last saved version', () => {
+      setup();
+
+      expect(dashboardEditorApi.hasUnsavedChanges()).toBe(false);
+    });
+
+    it.each([
+      ['spec changes', { diffCount: 3, hasFolderChanges: false, hasPredefinedVariablesChanges: false }],
+      ['a folder move', { diffCount: 0, hasFolderChanges: true, hasPredefinedVariablesChanges: false }],
+      ['predefined variable changes', { diffCount: 0, hasFolderChanges: false, hasPredefinedVariablesChanges: true }],
+    ])('reports changes for %s', (_name, changes) => {
+      const { scene } = setup();
+      scene.getDashboardChanges.mockReturnValue(changes);
+
+      expect(dashboardEditorApi.hasUnsavedChanges()).toBe(true);
+    });
+
+    it('reports no changes when no dashboard is loaded', () => {
+      setupWithoutDashboard();
+
+      expect(dashboardEditorApi.hasUnsavedChanges()).toBe(false);
+    });
+
+    it('reports no changes when the loaded dashboard is no longer on screen', () => {
+      const { scene } = setup({ activate: false });
+      scene.getDashboardChanges.mockReturnValue({
+        diffCount: 3,
+        hasFolderChanges: false,
+        hasPredefinedVariablesChanges: false,
+      });
+
+      expect(dashboardEditorApi.hasUnsavedChanges()).toBe(false);
+      expect(scene.getDashboardChanges).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('subscribeToChanges', () => {
+    it('fires when the dashboard becomes dirty and when it is saved again', () => {
+      const { scene } = setup();
+      const cb = jest.fn();
+
+      dashboardEditorApi.subscribeToChanges(cb);
+
+      scene.setState({ isDirty: true });
+      expect(cb).toHaveBeenCalledTimes(1);
+
+      scene.setState({ isDirty: false });
+      expect(cb).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not serialize the dashboard while it stays clean', () => {
+      const { scene } = setup();
+      const cb = jest.fn();
+
+      dashboardEditorApi.subscribeToChanges(cb);
+
+      scene.setState({ key: 'a' });
+      scene.setState({ key: 'b' });
+      scene.setState({ isDirty: false });
+
+      expect(cb).not.toHaveBeenCalled();
+      expect(scene.getDashboardChanges).not.toHaveBeenCalled();
+    });
+
+    it('fires when the dashboard enters or leaves edit mode', () => {
+      const { scene } = setup();
+      const cb = jest.fn();
+
+      dashboardEditorApi.subscribeToChanges(cb);
+
+      scene.setState({ isEditing: true });
+      scene.setState({ isEditing: false });
+
+      expect(cb).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not fire again while the dashboard stays dirty', () => {
+      const { scene } = setup();
+      const cb = jest.fn();
+
+      dashboardEditorApi.subscribeToChanges(cb);
+
+      scene.setState({ isDirty: true });
+      scene.setState({ key: 'a' });
+      scene.setState({ isDirty: true });
+
+      expect(cb).toHaveBeenCalledTimes(1);
+    });
+
+    it('follows the active dashboard when the user opens another one', () => {
+      const { scene, stateManager } = setup();
+      const cb = jest.fn();
+
+      dashboardEditorApi.subscribeToChanges(cb);
+
+      const nextScene = new FakeDashboardScene({ isDirty: false, sidebar: { openPane: jest.fn(), state: {} } });
+      nextScene.activate();
+      stateManager.setState({ dashboard: nextScene });
+      expect(cb).toHaveBeenCalledTimes(1);
+
+      nextScene.setState({ isDirty: true });
+      expect(cb).toHaveBeenCalledTimes(2);
+
+      // The dashboard that was replaced must no longer reach the subscriber.
+      scene.setState({ isDirty: true });
+      expect(cb).toHaveBeenCalledTimes(2);
+    });
+
+    it('ignores unrelated page state changes', () => {
+      const { stateManager } = setup();
+      const cb = jest.fn();
+
+      dashboardEditorApi.subscribeToChanges(cb);
+
+      stateManager.setState({});
+
+      expect(cb).not.toHaveBeenCalled();
+    });
+
+    it('subscribes without a dashboard loaded and picks one up when it arrives', () => {
+      const { stateManager } = setupWithoutDashboard();
+      const cb = jest.fn();
+
+      dashboardEditorApi.subscribeToChanges(cb);
+
+      const scene = new FakeDashboardScene({ isDirty: false, sidebar: { openPane: jest.fn(), state: {} } });
+      scene.activate();
+      stateManager.setState({ dashboard: scene });
+      expect(cb).toHaveBeenCalledTimes(1);
+
+      scene.setState({ isDirty: true });
+      expect(cb).toHaveBeenCalledTimes(2);
+    });
+
+    it('stops firing once unsubscribed', () => {
+      const { scene, stateManager } = setup();
+      const cb = jest.fn();
+
+      const unsubscribe = dashboardEditorApi.subscribeToChanges(cb);
+      unsubscribe();
+
+      scene.setState({ isDirty: true });
+      stateManager.setState({ dashboard: undefined });
+
+      expect(cb).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('isEditing', () => {
+    it.each([
+      [true, true],
+      [false, false],
+      [undefined, false],
+    ])('reports %s as %s', (isEditing, expected) => {
+      const { scene } = setup();
+      scene.setState({ isEditing });
+
+      expect(dashboardEditorApi.isEditing()).toBe(expected);
+    });
+
+    it('reports false when no dashboard is on screen', () => {
+      setupWithoutDashboard();
+
+      expect(dashboardEditorApi.isEditing()).toBe(false);
+    });
+
+    it('reports false when the loaded dashboard is no longer on screen', () => {
+      const { scene } = setup({ activate: false });
+      scene.setState({ isEditing: true });
+
+      expect(dashboardEditorApi.isEditing()).toBe(false);
+    });
+  });
+
+  describe('openDiffView', () => {
+    it('opens the diff pane in the dashboard sidebar', () => {
+      const { scene } = setup();
+
+      dashboardEditorApi.openDiffView();
+
+      expect(scene.state.sidebar.openPane).toHaveBeenCalledTimes(1);
+      expect(scene.state.sidebar.openPane.mock.calls[0][0]).toBeInstanceOf(DashboardDiffPane);
+    });
+
+    it('does nothing when no dashboard is loaded', () => {
+      setupWithoutDashboard();
+
+      expect(() => dashboardEditorApi.openDiffView()).not.toThrow();
+    });
+
+    it('does nothing when the loaded dashboard is no longer on screen', () => {
+      const { scene } = setup({ activate: false });
+
+      dashboardEditorApi.openDiffView();
+
+      expect(scene.state.sidebar.openPane).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when the diff pane is already open', () => {
+      const { scene } = setup();
+      scene.state.sidebar.state.openPane = { getId: () => 'diff' };
+
+      dashboardEditorApi.openDiffView();
+
+      expect(scene.state.sidebar.openPane).not.toHaveBeenCalled();
+    });
+
+    it('opens the diff pane when a different pane is open', () => {
+      const { scene } = setup();
+      scene.state.sidebar.state.openPane = { getId: () => 'code' };
+
+      dashboardEditorApi.openDiffView();
+
+      expect(scene.state.sidebar.openPane).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/public/app/features/plugins/components/restrictedGrafanaApis/dashboardEditor/dashboardEditorApi.test.ts
+++ b/public/app/features/plugins/components/restrictedGrafanaApis/dashboardEditor/dashboardEditorApi.test.ts
@@ -12,12 +12,21 @@ jest.mock('app/features/dashboard-scene/pages/DashboardScenePageStateManager', (
 interface FakeDashboardState extends SceneObjectState {
   isDirty?: boolean;
   isEditing?: boolean;
-  sidebar: { openPane: jest.Mock; state: { openPane?: { getId: () => string } } };
+  sidebar: FakeSidebar;
+}
+
+interface FakeSidebarState extends SceneObjectState {
+  openPane?: { getId: () => string };
+}
+
+/** A real SceneObjectBase so the api's openPane subscription behaves as it does on DashboardSidebar. */
+class FakeSidebar extends SceneObjectBase<FakeSidebarState> {
+  public openPane = jest.fn();
 }
 
 /**
  * A real SceneObjectBase so subscribeToState / isActive behave exactly as they do on
- * DashboardScene, with only the two members the API touches stubbed out.
+ * DashboardScene, with only the members the API touches stubbed out.
  */
 class FakeDashboardScene extends SceneObjectBase<FakeDashboardState> {
   public getDashboardChanges = jest.fn(() => ({
@@ -28,7 +37,7 @@ class FakeDashboardScene extends SceneObjectBase<FakeDashboardState> {
 }
 
 function setup({ activate = true }: { activate?: boolean } = {}) {
-  const scene = new FakeDashboardScene({ isDirty: false, sidebar: { openPane: jest.fn(), state: {} } });
+  const scene = new FakeDashboardScene({ isDirty: false, sidebar: new FakeSidebar({}) });
   if (activate) {
     scene.activate();
   }
@@ -115,6 +124,18 @@ describe('dashboardEditorApi', () => {
       expect(scene.getDashboardChanges).not.toHaveBeenCalled();
     });
 
+    it('fires when the open sidebar pane changes', () => {
+      const { scene } = setup();
+      const cb = jest.fn();
+
+      dashboardEditorApi.subscribeToChanges(cb);
+
+      scene.state.sidebar.setState({ openPane: { getId: () => 'diff' } });
+      scene.state.sidebar.setState({ openPane: undefined });
+
+      expect(cb).toHaveBeenCalledTimes(2);
+    });
+
     it('fires when the dashboard enters or leaves edit mode', () => {
       const { scene } = setup();
       const cb = jest.fn();
@@ -146,7 +167,7 @@ describe('dashboardEditorApi', () => {
 
       dashboardEditorApi.subscribeToChanges(cb);
 
-      const nextScene = new FakeDashboardScene({ isDirty: false, sidebar: { openPane: jest.fn(), state: {} } });
+      const nextScene = new FakeDashboardScene({ isDirty: false, sidebar: new FakeSidebar({}) });
       nextScene.activate();
       stateManager.setState({ dashboard: nextScene });
       expect(cb).toHaveBeenCalledTimes(1);
@@ -176,7 +197,7 @@ describe('dashboardEditorApi', () => {
 
       dashboardEditorApi.subscribeToChanges(cb);
 
-      const scene = new FakeDashboardScene({ isDirty: false, sidebar: { openPane: jest.fn(), state: {} } });
+      const scene = new FakeDashboardScene({ isDirty: false, sidebar: new FakeSidebar({}) });
       scene.activate();
       stateManager.setState({ dashboard: scene });
       expect(cb).toHaveBeenCalledTimes(1);
@@ -225,6 +246,26 @@ describe('dashboardEditorApi', () => {
     });
   });
 
+  describe('isDiffViewOpen', () => {
+    it('reports true only while the diff pane is the open pane', () => {
+      const { scene } = setup();
+
+      expect(dashboardEditorApi.isDiffViewOpen()).toBe(false);
+
+      scene.state.sidebar.setState({ openPane: { getId: () => 'code' } });
+      expect(dashboardEditorApi.isDiffViewOpen()).toBe(false);
+
+      scene.state.sidebar.setState({ openPane: { getId: () => 'diff' } });
+      expect(dashboardEditorApi.isDiffViewOpen()).toBe(true);
+    });
+
+    it('reports false when no dashboard is on screen', () => {
+      setupWithoutDashboard();
+
+      expect(dashboardEditorApi.isDiffViewOpen()).toBe(false);
+    });
+  });
+
   describe('openDiffView', () => {
     it('opens the diff pane in the dashboard sidebar', () => {
       const { scene } = setup();
@@ -251,7 +292,7 @@ describe('dashboardEditorApi', () => {
 
     it('does nothing when the diff pane is already open', () => {
       const { scene } = setup();
-      scene.state.sidebar.state.openPane = { getId: () => 'diff' };
+      scene.state.sidebar.setState({ openPane: { getId: () => 'diff' } });
 
       dashboardEditorApi.openDiffView();
 
@@ -260,7 +301,7 @@ describe('dashboardEditorApi', () => {
 
     it('opens the diff pane when a different pane is open', () => {
       const { scene } = setup();
-      scene.state.sidebar.state.openPane = { getId: () => 'code' };
+      scene.state.sidebar.setState({ openPane: { getId: () => 'code' } });
 
       dashboardEditorApi.openDiffView();
 

--- a/public/app/features/plugins/components/restrictedGrafanaApis/dashboardEditor/dashboardEditorApi.ts
+++ b/public/app/features/plugins/components/restrictedGrafanaApis/dashboardEditor/dashboardEditorApi.ts
@@ -1,0 +1,81 @@
+/**
+ * Dashboard Editor API -- restricted API for plugins that need to reason about, and surface, the
+ * unsaved state of the dashboard the user is editing.
+ *
+ * The dashboard page state manager owns the scene that is currently on screen, so it is both the
+ * source of truth for "which dashboard" and the signal for "the dashboard was swapped". Plugins
+ * access this through the RestrictedGrafanaApis context -- they cannot import this module directly
+ * because it lives inside the core bundle.
+ */
+
+import { type Unsubscribable } from 'rxjs';
+
+import type { DashboardEditorAPI } from '@grafana/data';
+import { getDashboardScenePageStateManager } from 'app/features/dashboard-scene/pages/DashboardScenePageStateManager';
+import type { DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
+import { DashboardDiffPane } from 'app/features/dashboard-scene/sidebar/DashboardDiffPane';
+import { hasActualSaveChanges } from 'app/features/dashboard-scene/utils/utils';
+
+function getActiveDashboard(): DashboardScene | undefined {
+  const { dashboard } = getDashboardScenePageStateManager().state;
+  // The state manager keeps the last loaded dashboard after the user navigates elsewhere, so an
+  // inactive scene means there is no dashboard on screen to report on or open a pane in.
+  return dashboard?.isActive ? dashboard : undefined;
+}
+
+export const dashboardEditorApi: DashboardEditorAPI = {
+  hasUnsavedChanges: () => {
+    const dashboard = getActiveDashboard();
+    return dashboard ? hasActualSaveChanges(dashboard) : false;
+  },
+
+  isEditing: () => getActiveDashboard()?.state.isEditing ?? false,
+
+  subscribeToChanges: (cb: () => void) => {
+    const stateManager = getDashboardScenePageStateManager();
+
+    let sceneSub: Unsubscribable | undefined;
+    let subscribedScene: DashboardScene | undefined;
+
+    const followScene = (dashboard: DashboardScene | undefined) => {
+      sceneSub?.unsubscribe();
+      sceneSub = undefined;
+      subscribedScene = dashboard;
+
+      // `isDirty` is the cheap gate: hasActualSaveChanges() serializes the whole dashboard, so
+      // notifying on every scene state change would run it on every keystroke in a panel editor.
+      sceneSub = dashboard?.subscribeToState((newState, prevState) => {
+        if (newState.isDirty !== prevState.isDirty || newState.isEditing !== prevState.isEditing) {
+          cb();
+        }
+      });
+    };
+
+    followScene(stateManager.state.dashboard);
+
+    const stateManagerSub = stateManager.subscribeToState({
+      next: (state) => {
+        if (state.dashboard === subscribedScene) {
+          return;
+        }
+        followScene(state.dashboard);
+        cb();
+      },
+    });
+
+    return () => {
+      stateManagerSub.unsubscribe();
+      sceneSub?.unsubscribe();
+    };
+  },
+
+  openDiffView: () => {
+    const sidebar = getActiveDashboard()?.state.sidebar;
+    // openPane() closes the pane when the requested id already matches, so calling it
+    // unconditionally would make a second click hide the diff.
+    if (!sidebar || sidebar.state.openPane?.getId() === 'diff') {
+      return;
+    }
+    sidebar.openPane(new DashboardDiffPane({}));
+  },
+};

--- a/public/app/features/plugins/components/restrictedGrafanaApis/dashboardEditor/dashboardEditorApi.ts
+++ b/public/app/features/plugins/components/restrictedGrafanaApis/dashboardEditor/dashboardEditorApi.ts
@@ -23,6 +23,10 @@ function getActiveDashboard(): DashboardScene | undefined {
   return dashboard?.isActive ? dashboard : undefined;
 }
 
+function isDiffPaneOpen(dashboard: DashboardScene | undefined): boolean {
+  return dashboard?.state.sidebar.state.openPane?.getId() === 'diff';
+}
+
 export const dashboardEditorApi: DashboardEditorAPI = {
   hasUnsavedChanges: () => {
     const dashboard = getActiveDashboard();
@@ -31,10 +35,13 @@ export const dashboardEditorApi: DashboardEditorAPI = {
 
   isEditing: () => getActiveDashboard()?.state.isEditing ?? false,
 
+  isDiffViewOpen: () => isDiffPaneOpen(getActiveDashboard()),
+
   subscribeToChanges: (cb: () => void) => {
     const stateManager = getDashboardScenePageStateManager();
 
     let sceneSub: Unsubscribable | undefined;
+    let sidebarSub: Unsubscribable | undefined;
     let subscribedScene: DashboardScene | undefined;
 
     const followScene = (dashboard: DashboardScene | undefined) => {
@@ -46,6 +53,14 @@ export const dashboardEditorApi: DashboardEditorAPI = {
       // notifying on every scene state change would run it on every keystroke in a panel editor.
       sceneSub = dashboard?.subscribeToState((newState, prevState) => {
         if (newState.isDirty !== prevState.isDirty || newState.isEditing !== prevState.isEditing) {
+          cb();
+        }
+      });
+
+      // The open pane lives on the sidebar, not the dashboard, so it needs its own subscription.
+      sidebarSub?.unsubscribe();
+      sidebarSub = dashboard?.state.sidebar.subscribeToState((newState, prevState) => {
+        if (newState.openPane !== prevState.openPane) {
           cb();
         }
       });
@@ -66,16 +81,17 @@ export const dashboardEditorApi: DashboardEditorAPI = {
     return () => {
       stateManagerSub.unsubscribe();
       sceneSub?.unsubscribe();
+      sidebarSub?.unsubscribe();
     };
   },
 
   openDiffView: () => {
-    const sidebar = getActiveDashboard()?.state.sidebar;
+    const dashboard = getActiveDashboard();
     // openPane() closes the pane when the requested id already matches, so calling it
     // unconditionally would make a second click hide the diff.
-    if (!sidebar || sidebar.state.openPane?.getId() === 'diff') {
+    if (!dashboard || isDiffPaneOpen(dashboard)) {
       return;
     }
-    sidebar.openPane(new DashboardDiffPane({}));
+    dashboard.state.sidebar.openPane(new DashboardDiffPane({}));
   },
 };

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6311,6 +6311,16 @@
         "tooltip": "Dashboard options",
         "variables": "Variables"
       },
+      "diff": {
+        "format-json": "JSON",
+        "format-yaml": "YAML",
+        "migrated": "Note: The diff also includes changes resulting from migration to the new dashboard format.",
+        "no-changes": "No changes to show",
+        "no-changes-body": "The dashboard matches the last saved version.",
+        "pane-header": "Changes",
+        "unavailable": "Cannot show changes",
+        "unavailable-body": "The last saved dashboard is not available for comparison."
+      },
       "drag-to-reorder": "Drag to reorder",
       "edit-schema": {
         "apply-button": "Apply changes",


### PR DESCRIPTION
This adds a Diff pane to the dashboard sidebar and a new restricted plugin API called `dashboardEditorAPI`. The pane compares the dashboard you are edit
ing with its last saved version, and it reuses the Monaco diff viewer that #130656 added. The new API lets an allowlisted plugin ask whether the dashboard has unsaved changes, ask whether it is in edit mode, subscribe to either answer changing, and open the pane. `isDirty` gates the unsaved-changes check, because `hasActualSaveChanges` serializes the whole dashboard and would otherwise run on every keystroke in a panel editor. The pane has no sidebar button, so it opens only when a plugin asks for it. Grafana Assistant is the first user: it shows a "Show changes" button in its chat that opens this pane, in a companion PR in its own repo.