### PR TITLE
CloudMigrations: Fix NPE in test

### DIFF
--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
@@ -443,7 +443,7 @@ func Test_OnlyQueriesStatusFromGMSWhenRequired(t *testing.T) {
 			t,
 			func() bool {
 				cms, _ := s.store.GetSnapshotByUID(context.Background(), sess.OrgID, sess.UID, snapshotUID, cloudmigration.SnapshotResultQueryParams{})
-				return cms.Status == cloudmigration.SnapshotStatusFinished
+				return cms != nil && cms.Status == cloudmigration.SnapshotStatusFinished
 			},
 			5*time.Second,
 			100*time.Millisecond,


### PR DESCRIPTION
As seen in another test run:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x513d15c]

goroutine 66489 [running]:
github.com/grafana/grafana/pkg/services/cloudmigration/cloudmigrationimpl.Test_OnlyQueriesStatusFromGMSWhenRequired.func2()
	/opt/actions-runner/_work/grafana/grafana/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go:446 +0x5c
github.com/stretchr/testify/assert.Eventually.func1()
	/home/ubuntu/go/pkg/mod/github.com/stretchr/testify@v1.12.1/assert/assertions.go:2013 +0x23
created by github.com/stretchr/testify/assert.Eventually in goroutine 163
	/home/ubuntu/go/pkg/mod/github.com/stretchr/testify@v1.12.1/assert/assertions.go:2032 +0x21c
FAIL	github.com/grafana/grafana/pkg/services/cloudmigration/cloudmigrationimpl	19.311s
```

Avoid the NPE by asserting that `cms` is not `nil`.