### PR TITLE
Snapshots: Fix empty panels when a transformation uses a repeat variable

### DIFF
--- a/public/app/features/dashboard-scene/serialization/snapshotRepeatTitle.test.ts
+++ b/public/app/features/dashboard-scene/serialization/snapshotRepeatTitle.test.ts
@@ -1,7 +1,22 @@
+import { type DataTransformerConfig, DataTransformerID, ValueMatcherID } from '@grafana/data';
+import {
+  FilterByValueMatch,
+  type FilterByValueTransformerOptions,
+  FilterByValueType,
+  type OrganizeFieldsTransformerOptions,
+} from '@grafana/data/internal';
 import { getPanelPlugin } from '@grafana/data/test';
 import { setPluginImportUtils } from '@grafana/runtime';
-import { CustomVariable, SceneGridLayout, SceneVariableSet, VizPanel } from '@grafana/scenes';
+import {
+  CustomVariable,
+  SceneDataTransformer,
+  SceneGridLayout,
+  SceneQueryRunner,
+  SceneVariableSet,
+  VizPanel,
+} from '@grafana/scenes';
 
+import { type PanelKind } from '../../../../../packages/grafana-schema/src/schema/dashboard/v2';
 import { DashboardScene } from '../scene/DashboardScene';
 import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
 import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLayoutManager';
@@ -51,5 +66,136 @@ describe('snapshot repeated panel titles (realistic, activated)', () => {
     expect(titles).toEqual(expect.arrayContaining(['pod = Bob', 'pod = Rob']));
     expect(titles).not.toContain('pod = 1');
     expect(titles).not.toContain('pod = 2');
+  });
+});
+
+describe('snapshot repeated panel transformations', () => {
+  const AS_SNAPSHOT = true;
+  const AS_DASHBOARD = false;
+
+  // Returns a filterByValue config that keeps only rows where the pod field equals ${pod}. Typed with
+  // the real options interface, so this test stops compiling if that interface changes.
+  function filterOnPod(): DataTransformerConfig<FilterByValueTransformerOptions> {
+    return {
+      id: DataTransformerID.filterByValue,
+      options: {
+        filters: [{ fieldName: 'pod', config: { id: ValueMatcherID.equal, options: { value: '${pod}' } } }],
+        type: FilterByValueType.include,
+        match: FilterByValueMatch.any,
+      },
+    };
+  }
+
+  // Returns an organize config that hides the field named pod-${pod}. organize holds field names in
+  // excludeByName keys, which is why baking has to reach keys and not only values.
+  function hidePodField(): DataTransformerConfig<OrganizeFieldsTransformerOptions> {
+    return {
+      id: DataTransformerID.organize,
+      options: {
+        excludeByName: { 'pod-${pod}': true },
+        includeByName: {},
+        indexByName: {},
+        renameByName: {},
+      },
+    };
+  }
+
+  // pod is a key:value custom variable: label "Bob"/"Rob", value "1"/"2". Keeping the label and the
+  // value different is what shows which of the two the options end up with.
+  function buildScene(transformations: DataTransformerConfig[], variableName?: string) {
+    const pod = new CustomVariable({
+      name: 'pod',
+      query: 'Bob : 1, Rob : 2',
+      isMulti: true,
+      includeAll: true,
+      value: ['1', '2'],
+      text: ['Bob', 'Rob'],
+    });
+
+    const repeater = new DashboardGridItem({
+      key: 'grid-item-1',
+      variableName,
+      body: new VizPanel({
+        key: 'panel-1',
+        pluginId: 'timeseries',
+        title: 'pod = $pod',
+        $data: new SceneDataTransformer({
+          transformations,
+          $data: new SceneQueryRunner({ queries: [] }),
+        }),
+      }),
+    });
+
+    const scene = new DashboardScene({
+      title: 'Repeat',
+      $variables: new SceneVariableSet({ variables: [pod] }),
+      body: new DefaultGridLayoutManager({
+        grid: new SceneGridLayout({ children: [repeater] }),
+      }),
+    });
+
+    activateFullSceneTree(scene);
+
+    return scene;
+  }
+
+  function savedPanels(result: ReturnType<typeof transformSceneToSaveModelSchemaV2>) {
+    return Object.values(result.elements).filter((element): element is PanelKind => element.kind === 'Panel');
+  }
+
+  function savedFilterValues(result: ReturnType<typeof transformSceneToSaveModelSchemaV2>) {
+    return savedPanels(result).map(
+      (panel) => panel.spec.data.spec.transformations[0].spec.options.filters[0].config.options.value
+    );
+  }
+
+  it('filters each copy on its own pod value, while the title shows the pod label', () => {
+    const scene = buildScene([filterOnPod()], 'pod');
+
+    const result = transformSceneToSaveModelSchemaV2(scene, AS_SNAPSHOT);
+
+    expect(
+      savedPanels(result)
+        .map((panel) => panel.spec.title)
+        .sort()
+    ).toEqual(['pod = Bob', 'pod = Rob']);
+    expect(savedFilterValues(result).sort()).toEqual(['1', '2']);
+  });
+
+  it('hides a field whose name comes from the repeat variable', () => {
+    const scene = buildScene([hidePodField()], 'pod');
+
+    const result = transformSceneToSaveModelSchemaV2(scene, AS_SNAPSHOT);
+    const hiddenFields = savedPanels(result).map(
+      (panel) => Object.keys(panel.spec.data.spec.transformations[0].spec.options.excludeByName)[0]
+    );
+
+    expect(hiddenFields.sort()).toEqual(['pod-1', 'pod-2']);
+  });
+
+  it('keeps the variable when saving the dashboard instead of a snapshot', () => {
+    const scene = buildScene([filterOnPod()], 'pod');
+
+    const result = transformSceneToSaveModelSchemaV2(scene, AS_DASHBOARD);
+
+    expect(savedFilterValues(result)).toEqual(['${pod}']);
+  });
+
+  it('does not change the dashboard the user is still looking at', () => {
+    const scene = buildScene([filterOnPod()], 'pod');
+
+    transformSceneToSaveModelSchemaV2(scene, AS_SNAPSHOT);
+    const afterSnapshot = transformSceneToSaveModelSchemaV2(scene, AS_DASHBOARD);
+
+    expect(savedFilterValues(afterSnapshot)).toEqual(['${pod}']);
+  });
+
+  it('keeps the variable in a panel that is not repeated', () => {
+    const scene = buildScene([filterOnPod()]);
+
+    const result = transformSceneToSaveModelSchemaV2(scene, AS_SNAPSHOT);
+
+    expect(savedPanels(result)).toHaveLength(1);
+    expect(savedFilterValues(result)).toEqual(['${pod}']);
   });
 });

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -366,7 +366,7 @@ export function vizPanelToSchemaV2(
         kind: 'QueryGroup',
         spec: {
           queries: getVizPanelQueries(vizPanel, dsReferencesMapping, isSnapshot),
-          transformations: getVizPanelTransformations(vizPanel),
+          transformations: getVizPanelTransformations(vizPanel, bakeRepeatValues),
           queryOptions: getVizPanelQueryOptions(vizPanel),
         },
       },
@@ -559,7 +559,8 @@ export function getDataQueryKind(query: SceneDataQuery | string | undefined, que
   return defaultDS?.type || '';
 }
 
-function getVizPanelTransformations(vizPanel: VizPanel): TransformationKind[] {
+// bakeRepeatValues is true only when saving a snapshot of a panel that sits inside a repeat.
+function getVizPanelTransformations(vizPanel: VizPanel, bakeRepeatValues = false): TransformationKind[] {
   let transformations: TransformationKind[] = [];
   const dataProvider = vizPanel.state.$data;
   if (dataProvider instanceof SceneDataTransformer) {
@@ -577,7 +578,9 @@ function getVizPanelTransformations(vizPanel: VizPanel): TransformationKind[] {
           disabled: transformation.disabled,
           filter: transformation.filter,
           ...(transformation.topic && { topic: transformation.topic }),
-          options: transformation.options,
+          options: bakeRepeatValues
+            ? interpolateRepeatValues(dataProvider, transformation.options)
+            : transformation.options,
         };
 
         transformations.push({
@@ -591,6 +594,33 @@ function getVizPanelTransformations(vizPanel: VizPanel): TransformationKind[] {
     }
   }
   return transformations;
+}
+
+// A repeat gives each copy a private value for its variable. That value only exists while the
+// dashboard is running, so it is not part of what gets saved. Any transformation using $var has to be
+// handed the value at save time. Without this the snapshot interpolates against the dashboard
+// variable, and a multi-value one gives back the whole array instead of this copy's value.
+// Keys too, not just values: organize transformation keeps field names in excludeByName.
+// Copies rather than mutates, because the dashboard stays open after saving.
+function interpolateRepeatValues(sceneObject: SceneObject, value: unknown): unknown {
+  if (typeof value === 'string') {
+    return sceneGraph.interpolate(sceneObject, value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => interpolateRepeatValues(sceneObject, item));
+  }
+
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [
+        sceneGraph.interpolate(sceneObject, key),
+        interpolateRepeatValues(sceneObject, item),
+      ])
+    );
+  }
+
+  return value;
 }
 
 function getVizPanelQueryOptions(vizPanel: VizPanel): QueryOptionsSpec {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

**Creating snapshot left panels empty when the panel sat inside a repeat and one of its transformations referenced the repeat variable**. They showed "No data" or "Data is missing a number field" while the dashboard itself was fine. 

Missed in #117208, and again in #129140. Both PRs write out the repeat copies when the snapshot is created and drop the `repeat` field. #117208 did it for repeated panels, #129140 for rows and tabs.

Dropping `repeat` removes the private value each copy was using. A transformation referencing that variable then falls back to the dashboard-wide one, which holds every selected value at once in multi-value cases (it shows `No Data` as is matches nothing)

Affects repeated panels since v13.0.0, rows and tabs since v13.2.0.

**Fix**

Interpolate the variables a transformation references when the panel sits inside a repeat, reusing `bakeRepeatValues`.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related https://github.com/grafana/support-escalations/issues/23878


https://github.com/user-attachments/assets/a4173a2f-bf6b-48ff-9cce-d38ec4728052


### How to test
- Enable `gdev-prometheus` locally
- Import this dashboard json (change the .txt to .json) 
[Panels in repeated rows that use filter transformations-1787576781196.txt](https://github.com/user-attachments/files/31376346/Panels.in.repeated.rows.that.use.filter.transformations-1787576781196.txt)

- Create a snapshot from the dashboard
- You should see data in the panels 