### PR TITLE
IAM: record the AuthInfo search endpoint in the openapi snapshot

### DIFF
--- a/packages/grafana-openapi/src/apis/iam.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/iam.grafana.app-v0alpha1.json
@@ -29,6 +29,37 @@
         }
       }
     },
+    "/authinfos/search": {
+      "post": {
+        "tags": ["Search"],
+        "description": "Search AuthInfo resources in a namespace.",
+        "operationId": "listAuthInfoSearchV0alpha1",
+        "parameters": [],
+        "requestBody": {
+          "description": "A SearchQuery describing what to match, sort and return.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A SearchResults envelope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResults"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/display": {
       "get": {
         "tags": ["Display"],

--- a/pkg/tests/apis/openapi_snapshots/iam.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/iam.grafana.app-v0alpha1.json
@@ -31,6 +31,50 @@
         }
       }
     },
+    "/apis/iam.grafana.app/v0alpha1/namespaces/{namespace}/authinfos/search": {
+      "post": {
+        "tags": [
+          "Search"
+        ],
+        "description": "Search AuthInfo resources in a namespace.",
+        "operationId": "listAuthInfoSearchV0alpha1",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "workspace",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "default"
+          }
+        ],
+        "requestBody": {
+          "description": "A SearchQuery describing what to match, sort and return.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A SearchResults envelope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchResults"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/apis/iam.grafana.app/v0alpha1/namespaces/{namespace}/display": {
       "get": {
         "tags": [


### PR DESCRIPTION
`main` is red in two places. `AuthInfo` (#131140) declares `searchFields`, so it is served the generic search endpoint, and neither generated artifact has that path:

- `pkg/tests/apis/openapi_snapshots/iam.grafana.app-v0alpha1.json` fails `TestIntegrationOpenAPIs`
- `packages/grafana-openapi/src/apis/iam.grafana.app-v0alpha1.json` fails "Verify API clients"

Both files here are generator output — the test rewrites the first, `yarn generate-apis` the second. Nothing hand-written.
