### PR TITLE
Dashboards: Consistent order for query variable modal buttons

### DIFF
--- a/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/ModalEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/ModalEditor.tsx
@@ -175,19 +175,19 @@ export function ModalEditor(props: ModalEditorProps) {
       </div>
       <Modal.ButtonRow>
         <Button
-          variant="primary"
-          onClick={onClickApply}
-          data-testid={selectors.pages.Dashboard.Settings.Variables.Edit.QueryVariable.applyButton}
-        >
-          <Trans i18nKey="dashboard-scene.query-variable-editor.modal.apply">Apply</Trans>
-        </Button>
-        <Button
           variant="secondary"
           fill="outline"
           onClick={onCloseModal}
           data-testid={selectors.pages.Dashboard.Settings.Variables.Edit.QueryVariable.closeButton}
         >
           <Trans i18nKey="dashboard-scene.query-variable-editor.modal.discard">Discard</Trans>
+        </Button>
+        <Button
+          variant="primary"
+          onClick={onClickApply}
+          data-testid={selectors.pages.Dashboard.Settings.Variables.Edit.QueryVariable.applyButton}
+        >
+          <Trans i18nKey="dashboard-scene.query-variable-editor.modal.apply">Apply</Trans>
         </Button>
       </Modal.ButtonRow>
     </Modal>


### PR DESCRIPTION
A small PR to swap "Apply" and "Discard" in the query variable editor modal so "Discard" is on the left.

This matches [Grafana Modal docs](https://developers.grafana.com/ui/latest/index.html?path=/docs/overlays-modal--docs) and the custom variable editor:

<img width="754" height="391" alt="image" src="https://github.com/user-attachments/assets/895edcbf-fab8-42e8-975f-3ef7a22aeb84" />

