### PR TITLE
docs: clarify Convert field type multiply-by-1000 for X format

### DIFF
--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/transform-data/index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/transform-data/index.md
@@ -317,7 +317,7 @@ This transformation has the following options:
   - **Time** - attempts to parse the values as time
     - The input will be parsed according to the [Moment.js parsing format](https://momentjs.com/docs/#/parsing/)
     - It will parse the numeric input as a Unix epoch timestamp in milliseconds.
-      You must multiply your input by 1000 if it's in seconds.
+      If you set **Input format** to `X` (seconds), Grafana multiplies by 1000 for you — do not pre-multiply. Without a format, multiply seconds by 1000 yourself.
     - Will show an option to specify a DateFormat as input by a string like yyyy-mm-dd or DD MM YYYY hh:mm:ss
     - The **Timezone** option determines how Grafana interprets input strings without timezone information. If not set, Grafana uses the browser timezone or your configured default timezone.
   - **Boolean** - will make the values booleans

--- a/public/app/features/transformers/docs/content.ts
+++ b/public/app/features/transformers/docs/content.ts
@@ -201,7 +201,7 @@ This transformation has the following options:
   - **Time** - attempts to parse the values as time
     - The input will be parsed according to the [Moment.js parsing format](https://momentjs.com/docs/#/parsing/)
     - It will parse the numeric input as a Unix epoch timestamp in milliseconds.
-      You must multiply your input by 1000 if it's in seconds.
+      If you set **Input format** to `X` (seconds), Grafana multiplies by 1000 for you — do not pre-multiply. Without a format, multiply seconds by 1000 yourself.
     - Will show an option to specify a DateFormat as input by a string like yyyy-mm-dd or DD MM YYYY hh:mm:ss
     - The **Timezone** option determines how Grafana interprets input strings without timezone information. If not set, Grafana uses the browser timezone or your configured default timezone.
   - **Boolean** - will make the values booleans


### PR DESCRIPTION
Fixes #131316

## Problem

Transformation docs at `transform-data/index.md:318-321` says "multiply input by 1000 if in seconds" globally, but `convertFieldType.ts:138` already does `convertToMS = typeof firstDefined === 'number' && dateFormat === 'X'` (X = seconds). Users following both get date `+055840-11-08` (seconds ×1000 + X). Issue provides table: `1700000000` + `X` → `2023-11-14` ✅, but `1700000000000` + `X` → `+055840` ❌.

## Change

- Restructure bullet to "If Input format X: do NOT multiply; else if no format: multiply" in both `docs/sources/visualizations/panels-visualizations/query-transform-data/transform-data/index.md` and `public/app/features/transformers/docs/content.ts` (in-app helper docs)
- Keep unrelated cleanup out of this PR

## Why this approach

Docs now match code: `convertFieldType` handles X → ms internally (`parsed * 1000` when `convertToMS`), so pre-multiplying is wrong for X but correct without a format.

## Testing

```text
command: git diff --check
result: clean

command: grep -n "Input format" docs/sources/visualizations/panels-visualizations/query-transform-data/transform-data/index.md
result: bullet now mentions Input format X

command: grep -n "convertToMS" packages/grafana-data/src/transformations/transformers/convertFieldType.ts
result: convertToMS logic unchanged, docs now consistent
```

## Documentation and release impact

- [x] User-facing documentation updated
- [x] Changelog/release note needed: docs fix
- [ ] Migration or compatibility note needed
- [ ] No documentation impact

## Review notes

- Known limitations: none
- Follow-up issue, if any: none
- Security/licensing considerations: none
