### PR TITLE
FeatureControl: Lazy load Feature Control button + UI

### DIFF
--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -24,7 +24,7 @@ import {
   MIN_EXTENSION_SIDEBAR_WIDTH,
 } from './ExtensionSidebar/ExtensionSidebar';
 import { useExtensionSidebarContext } from './ExtensionSidebar/ExtensionSidebarProvider';
-import { FeatureControlFloating } from './FeatureControl/FeatureControlFloating';
+import { LazyFeatureControlFloating } from './FeatureControl/LazyFeatureControl';
 import { FullscreenWorkspacePlatformBar } from './FullscreenWorkspace/FullscreenWorkspacePlatformBar';
 import { FullscreenWorkspaceShell } from './FullscreenWorkspace/FullscreenWorkspaceShell';
 import { useFullscreenWorkspace } from './FullscreenWorkspace/useFullscreenWorkspace';
@@ -223,7 +223,7 @@ export function AppChrome({ children }: Props) {
       {!state.chromeless && !state.megaMenuDocked && <AppChromeMenu />}
       {!state.chromeless && <CommandPalette />}
       {!state.chromeless && isSplashScreenEnabled && <SplashScreenModal />}
-      {!state.chromeless && <FeatureControlFloating />}
+      {!state.chromeless && <LazyFeatureControlFloating />}
       {shouldShowReturnToPrevious && state.returnToPrevious && (
         <ReturnToPrevious href={state.returnToPrevious.href} title={state.returnToPrevious.title} />
       )}

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlButton.test.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlButton.test.tsx
@@ -59,14 +59,6 @@ describe('FeatureControlButton', () => {
     useFeatureControlContextMock.mockReturnValue(buildContext());
   });
 
-  it('does not render when feature control is not accessible', () => {
-    useFeatureControlContextMock.mockReturnValue(buildContext({ isAccessible: false }));
-
-    render(<FeatureControlButton />);
-
-    expect(screen.queryByRole('button', { name: 'Feature control' })).not.toBeInTheDocument();
-  });
-
   it('renders a collapsed button when feature control is closed', () => {
     render(<FeatureControlButton />);
 

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlButton.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlButton.tsx
@@ -5,12 +5,9 @@ import { ToolbarButton } from '@grafana/ui';
 
 import { useFeatureControlContext } from './FeatureControlProvider';
 
+// Rendered via LazyFeatureControlButton, which owns the `isAccessible` check.
 export const FeatureControlButton = memo(function FeatureControlButton() {
-  const { isAccessible, isOpen, setIsOpen } = useFeatureControlContext();
-
-  if (!isAccessible) {
-    return null;
-  }
+  const { isOpen, setIsOpen } = useFeatureControlContext();
 
   return (
     <ToolbarButton

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlFloating.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlFloating.tsx
@@ -4,16 +4,11 @@ import type { GrafanaTheme2 } from '@grafana/data';
 import { Portal, useStyles2, useTheme2 } from '@grafana/ui';
 
 import { FeatureControlFlags } from './FeatureControlFlags';
-import { useFeatureControlContext } from './FeatureControlProvider';
 
+// Rendered via LazyFeatureControlFloating, which owns the `isOpen` check.
 export const FeatureControlFloating = () => {
-  const { isOpen } = useFeatureControlContext();
   const theme = useTheme2();
   const styles = useStyles2(getStyles);
-
-  if (!isOpen) {
-    return null;
-  }
 
   return (
     <Portal zIndex={theme.zIndex.modal}>

--- a/public/app/core/components/AppChrome/FeatureControl/LazyFeatureControl.test.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/LazyFeatureControl.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import { getLocalStorageProvider } from '@grafana/runtime/internal';
+
+import { FeatureControlContext, type FeatureControlContextType } from './FeatureControlProvider';
+import { LazyFeatureControlButton, LazyFeatureControlFloating } from './LazyFeatureControl';
+
+const renderWithContext = (ui: ReactNode, context: Partial<FeatureControlContextType> = {}) =>
+  render(
+    <FeatureControlContext.Provider
+      value={{
+        isAccessible: false,
+        setIsAccessible: jest.fn(),
+        isOpen: false,
+        setIsOpen: jest.fn(),
+        ...context,
+      }}
+    >
+      {ui}
+    </FeatureControlContext.Provider>
+  );
+
+describe('LazyFeatureControl', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    getLocalStorageProvider().clearFlags();
+  });
+
+  describe('LazyFeatureControlButton', () => {
+    it('renders nothing when feature control is not accessible', () => {
+      const { container } = renderWithContext(<LazyFeatureControlButton />, { isAccessible: false });
+
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('loads the button when feature control is accessible', async () => {
+      renderWithContext(<LazyFeatureControlButton />, { isAccessible: true });
+
+      expect(await screen.findByRole('button', { name: 'Feature control' })).toBeInTheDocument();
+    });
+  });
+
+  describe('LazyFeatureControlFloating', () => {
+    it('renders nothing when the panel is closed', () => {
+      const { container } = renderWithContext(<LazyFeatureControlFloating />, { isOpen: false });
+
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('loads the panel when it is open', async () => {
+      renderWithContext(<LazyFeatureControlFloating />, { isOpen: true });
+
+      expect(await screen.findByText('Feature control')).toBeInTheDocument();
+    });
+  });
+});

--- a/public/app/core/components/AppChrome/FeatureControl/LazyFeatureControl.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/LazyFeatureControl.tsx
@@ -1,0 +1,49 @@
+import { Suspense, lazy } from 'react';
+
+import { useFeatureControlContext } from './FeatureControlProvider';
+
+const FeatureControlButton = lazy(() =>
+  import('./FeatureControlButton').then((module) => ({ default: module.FeatureControlButton }))
+);
+
+const FeatureControlFloating = lazy(() =>
+  import('./FeatureControlFloating').then((module) => ({ default: module.FeatureControlFloating }))
+);
+
+/*
+ * Feature control is a developer tool that almost nobody has switched on, so all of it — the
+ * button, the panel, the animated flask — is kept out of the main bundle. Only this module and
+ * FeatureControlProvider are loaded up front.
+ *
+ * These components own the `isAccessible`/`isOpen` checks rather than the components they wrap:
+ * rendering a lazy component is what triggers its chunk to download, so a component that
+ * fetched its own code only to return null would download it for everybody.
+ */
+
+export const LazyFeatureControlButton = () => {
+  const { isAccessible } = useFeatureControlContext();
+
+  if (!isAccessible) {
+    return null;
+  }
+
+  return (
+    <Suspense fallback={null}>
+      <FeatureControlButton />
+    </Suspense>
+  );
+};
+
+export const LazyFeatureControlFloating = () => {
+  const { isOpen } = useFeatureControlContext();
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <Suspense fallback={null}>
+      <FeatureControlFloating />
+    </Suspense>
+  );
+};

--- a/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
+++ b/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
@@ -19,7 +19,7 @@ import { HomeLogo } from '../../Branding/Branding';
 import { Breadcrumbs } from '../../Breadcrumbs/Breadcrumbs';
 import { buildBreadcrumbs } from '../../Breadcrumbs/utils';
 import { ExtensionToolbarItem } from '../ExtensionSidebar/ExtensionToolbarItem';
-import { FeatureControlButton } from '../FeatureControl/FeatureControlButton';
+import { LazyFeatureControlButton } from '../FeatureControl/LazyFeatureControl';
 import { AssistantToolbarButtons } from '../FullscreenWorkspace/AssistantToolbarButtons';
 import { NavToolbarSeparator } from '../NavToolbar/NavToolbarSeparator';
 import { QuickAdd } from '../QuickAdd/QuickAdd';
@@ -103,7 +103,7 @@ export const SingleTopBar = memo(function SingleTopBar({
           <TopBarExtensionPoint />
           <TopSearchBarCommandPaletteTrigger />
           {!isSmallScreen && <QuickAdd />}
-          <FeatureControlButton />
+          <LazyFeatureControlButton />
           <HelpTopBarButton isSmallScreen={isSmallScreen} />
           <NavToolbarSeparator />
           {!isSmallScreen && <ExtensionToolbarItem compact={isSmallScreen} />}


### PR DESCRIPTION
**What is this feature?**

Extracted from #130672, makes the feature control button + UI lazy chunks.

**Why do we need this feature?**

Feature control is only used by developers and is only accessible if a specific URL param is set. Drops approximately 8.5kb from the initial bundle.


```patch
# mkdir -p stats

# git switch main
# yarn build
# yarn bundle-size:stats > stats/main.txt

# git switch MattIPv4/lazy-feature-control
# yarn build
# yarn bundle-size:stats > stats/lazy.txt

# git diff --no-index stats/main.txt stats/lazy.txt

diff --git a/stats/main.txt b/stats/lazy.txt
index 184e4e86950..b0b9c51ba05 100644
--- a/stats/main.txt
+++ b/stats/lazy.txt
@@ -1,7 +1,7 @@
-default.entrypoints.app.js 8761892
+default.entrypoints.app.js 8753000
 default.entrypoints.app.css 41791
 default.entrypoints.boot.js 4637
-default.entrypoints.dark.js 58454
+default.entrypoints.dark.js 58668
 default.entrypoints.dark.css 60330
-default.entrypoints.light.js 58454
+default.entrypoints.light.js 58668
 default.entrypoints.light.css 60294
```

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
