### PR TITLE
Unified storage: Fix escaped dashboard JSON during migration

### DIFF
--- a/pkg/registry/apis/dashboard/legacy/query_dashboards.sql
+++ b/pkg/registry/apis/dashboard/legacy/query_dashboards.sql
@@ -28,7 +28,12 @@ SELECT
   COALESCE(dashboard_version.created_by, dashboard.updated_by) as updated_by_id,
   COALESCE(dashboard_version.version, dashboard.version) as version,
   COALESCE(dashboard_version.message, '') as message,
+  {{ if .Query.SelectRawDataColumns }}
+  dashboard_version.data as version_data,
+  dashboard.data as dashboard_data,
+  {{ else }}
   COALESCE(dashboard_version.data, dashboard.data) as data,
+  {{ end }}
   COALESCE(dashboard_version.api_version, dashboard.api_version) as api_version
   {{ end }}
   {{ else }}

--- a/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
+++ b/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
@@ -149,9 +149,10 @@ func (a *dashboardSqlAccess) getRows(ctx context.Context, helper *legacysql.Lega
 		rows = nil
 	}
 	return &rowsWrapper{
-		rows:    rows,
-		a:       a,
-		history: query.GetHistory,
+		rows:           rows,
+		a:              a,
+		history:        query.GetHistory,
+		rawDataColumns: query.SelectRawDataColumns(),
 	}, err
 }
 
@@ -380,10 +381,11 @@ func (a *dashboardSqlAccess) MigrateLibraryPanels(ctx context.Context, orgId int
 }
 
 type rowsWrapper struct {
-	a       *dashboardSqlAccess
-	rows    *sql.Rows
-	history bool
-	count   int
+	a              *dashboardSqlAccess
+	rows           *sql.Rows
+	history        bool
+	rawDataColumns bool
+	count          int
 
 	// Current
 	row *dashboardRow
@@ -413,7 +415,7 @@ func (r *rowsWrapper) Next() bool {
 	for r.rows.Next() {
 		r.count++
 
-		r.row, err = r.a.scanRow(r.rows, r.history)
+		r.row, err = r.a.scanRow(r.rows, r.history, r.rawDataColumns)
 		if err != nil {
 			r.a.log.Error("error scanning dashboard", "error", err)
 			if len(r.rejected) > 100 || r.row == nil {
@@ -485,7 +487,7 @@ func (a *dashboardSqlAccess) parseDashboard(dash *dashboardV1.Dashboard, data []
 	return nil
 }
 
-func (a *dashboardSqlAccess) scanRow(rows *sql.Rows, history bool) (*dashboardRow, error) {
+func (a *dashboardSqlAccess) scanRow(rows *sql.Rows, history, rawDataColumns bool) (*dashboardRow, error) {
 	dash := &dashboardV1.Dashboard{
 		TypeMeta:   dashboardV1.DashboardResourceInfo.TypeMeta(),
 		ObjectMeta: metav1.ObjectMeta{Annotations: make(map[string]string)},
@@ -512,16 +514,32 @@ func (a *dashboardSqlAccess) scanRow(rows *sql.Rows, history bool) (*dashboardRo
 	var origin_path sql.NullString
 	var origin_ts sql.NullInt64
 	var origin_hash sql.NullString
+	var versionData []byte
+	var dashboardData []byte
 	var data []byte // the dashboard JSON
 	var version int64
 
-	err := rows.Scan(&orgId, &dashboard_id, &dash.Name, &title, &folder_uid,
+	destinations := []any{&orgId, &dashboard_id, &dash.Name, &title, &folder_uid,
 		&deleted, &plugin_id,
 		&origin_name, &origin_path, &origin_hash, &origin_ts,
 		&created, &createdBy, &createdByID,
 		&updated, &updatedBy, &updatedByID,
-		&version, &message, &data, &apiVersion,
-	)
+		&version, &message}
+	if rawDataColumns {
+		destinations = append(destinations, &versionData, &dashboardData)
+	} else {
+		destinations = append(destinations, &data)
+	}
+	destinations = append(destinations, &apiVersion)
+	err := rows.Scan(destinations...)
+	if rawDataColumns {
+		// Match COALESCE's NULL precedence in Go so both JSON values are read
+		// directly from their source columns without a SQL expression.
+		data = dashboardData
+		if versionData != nil {
+			data = versionData
+		}
+	}
 
 	switch apiVersion.String {
 	case "":

--- a/pkg/registry/apis/dashboard/legacy/sql_dashboards_test.go
+++ b/pkg/registry/apis/dashboard/legacy/sql_dashboards_test.go
@@ -37,6 +37,7 @@ func TestScanRow(t *testing.T) {
 	}
 
 	columns := []string{"orgId", "dashboard_id", "name", "title", "folder_uid", "deleted", "plugin_id", "origin_name", "origin_path", "origin_hash", "origin_ts", "created", "createdBy", "createdByID", "updated", "updatedBy", "updatedByID", "version", "message", "data", "api_version"}
+	fallbackColumns := []string{"orgId", "dashboard_id", "name", "title", "folder_uid", "deleted", "plugin_id", "origin_name", "origin_path", "origin_hash", "origin_ts", "created", "createdBy", "createdByID", "updated", "updatedBy", "updatedByID", "version", "message", "version_data", "dashboard_data", "api_version"}
 	id := int64(100)
 	uid := "someuid"
 	title := "Test Dashboard"
@@ -56,7 +57,7 @@ func TestScanRow(t *testing.T) {
 		defer resultRows.Close() // nolint:errcheck
 		resultRows.Next()
 
-		row, err := store.scanRow(resultRows, false)
+		row, err := store.scanRow(resultRows, false, false)
 		require.NoError(t, err)
 		require.NotNil(t, row)
 		require.Equal(t, uid, row.Dash.Name)
@@ -87,7 +88,7 @@ func TestScanRow(t *testing.T) {
 		defer resultRows.Close() // nolint:errcheck
 		resultRows.Next()
 
-		row, err := store.scanRow(resultRows, false)
+		row, err := store.scanRow(resultRows, false, false)
 		require.NoError(t, err)
 		require.NotNil(t, row)
 
@@ -115,7 +116,7 @@ func TestScanRow(t *testing.T) {
 		defer resultRows.Close() // nolint:errcheck
 		resultRows.Next()
 
-		row, err := store.scanRow(resultRows, false)
+		row, err := store.scanRow(resultRows, false, false)
 		require.NoError(t, err)
 		require.NotNil(t, row)
 
@@ -129,9 +130,9 @@ func TestScanRow(t *testing.T) {
 		require.Equal(t, "", meta.GetAnnotations()[utils.AnnoKeySourceChecksum]) // hash is not used on plugins
 	})
 
-	t.Run("Migration scenario should use COALESCE logic with AllowFallback=true", func(t *testing.T) {
+	t.Run("Migration scenario should use fallback data with AllowFallback=true", func(t *testing.T) {
 		// This specifically tests the migration use case where GetHistory=true but AllowFallback=true
-		// allows the query to use COALESCE logic to fall back to dashboard table data when
+		// allows the reader to fall back to dashboard table data when
 		// dashboard_version entries are missing.
 
 		migrationTimestamp := timestamp.Add(2 * time.Hour) // Migration scenario timestamp
@@ -141,14 +142,14 @@ func TestScanRow(t *testing.T) {
 		migrationData := []byte(`{"migration": "data", "title": "Migrated Dashboard"}`)
 		migrationAPIVersion := "v0alpha1"
 
-		// In migration scenario, COALESCE functions return dashboard table values
-		// when dashboard_version values are NULL, ensuring all dashboards are migrated
-		rows := sqlmock.NewRows(columns).AddRow(
+		// In a migration, scalar fields are coalesced by SQL and raw JSON data is selected
+		// by the reader, ensuring dashboards without version rows are still migrated.
+		rows := sqlmock.NewRows(fallbackColumns).AddRow(
 			1, id, uid, title, folderUID, nil, "", // basic dashboard fields
 			"", "", "", 0, // origin fields
 			timestamp, createdUser, 0, // created fields
-			// These represent COALESCED values from dashboard table (not version table)
-			migrationTimestamp, migrationUpdatedUser, 0, migrationVersion, migrationMessage, migrationData, migrationAPIVersion,
+			// The nil version data causes the reader to select the dashboard table data.
+			migrationTimestamp, migrationUpdatedUser, 0, migrationVersion, migrationMessage, nil, migrationData, migrationAPIVersion,
 		)
 
 		mock.ExpectQuery("SELECT *").WillReturnRows(rows)
@@ -157,8 +158,8 @@ func TestScanRow(t *testing.T) {
 		defer resultRows.Close() // nolint:errcheck
 		resultRows.Next()
 
-		// Test with history=true (migration scenario) - should work with COALESCED values
-		row, err := store.scanRow(resultRows, true)
+		// Test with history=true and raw fallback data columns.
+		row, err := store.scanRow(resultRows, true, true)
 		require.NoError(t, err)
 		require.NotNil(t, row)
 
@@ -189,6 +190,24 @@ func TestScanRow(t *testing.T) {
 		require.Equal(t, "dashboard.grafana.app/"+migrationAPIVersion, row.Dash.APIVersion)
 	})
 
+	t.Run("preserves escaped regexes in dashboard JSON", func(t *testing.T) {
+		data := []byte(`{"templating":{"list":[{"regex":"/^(.*)-(?:[0-9a-fA-F]{7,10}-[0-9a-zA-Z]{4,5}|\\d+)$/"}]}}`)
+		rows := sqlmock.NewRows(fallbackColumns).AddRow(1, id, uid, title, folderUID, nil, "", "", "", "", 0, timestamp, createdUser, 0, timestamp, updatedUser, 0, version, message, data, []byte(`{"templating":{"list":[]}}`), "vXyz")
+		mock.ExpectQuery("SELECT *").WillReturnRows(rows)
+		resultRows, err := mockDB.Query("SELECT *")
+		require.NoError(t, err)
+		defer resultRows.Close() // nolint:errcheck
+		resultRows.Next()
+
+		row, err := store.scanRow(resultRows, true, true)
+		require.NoError(t, err)
+
+		templating := row.Dash.Spec.Object["templating"].(map[string]interface{})
+		variables := templating["list"].([]interface{})
+		variable := variables[0].(map[string]interface{})
+		require.Equal(t, `/^(.*)-(?:[0-9a-fA-F]{7,10}-[0-9a-zA-Z]{4,5}|\d+)$/`, variable["regex"])
+	})
+
 	t.Run("should follow dashboard template when failing to unmarshal dashboard", func(t *testing.T) {
 		// row with bad data
 		badData := []byte(`{"rows":[{"panels":[{"targets":[{"refId":"A","target":"aliasSub(alias, '^(.{27}).+', '\1...')"}]}]}]}`)
@@ -207,7 +226,7 @@ func TestScanRow(t *testing.T) {
 			log:          log.New("test"),
 		}
 
-		row, err := store.scanRow(resultRows, false)
+		row, err := store.scanRow(resultRows, false, false)
 		require.NoError(t, err)
 		require.NotNil(t, row)
 		require.Equal(t, uid, row.Dash.Name)
@@ -527,8 +546,8 @@ func TestDashboardMigrationQuery(t *testing.T) {
 		require.True(t, historyQuery.GetHistory, "History query should get history")
 	})
 
-	t.Run("Migration query template produces COALESCE SQL", func(t *testing.T) {
-		// Test that the SQL template produces COALESCE logic for migration queries
+	t.Run("Migration query template keeps dashboard JSON raw", func(t *testing.T) {
+		// Test that scalar fallback remains in SQL while dashboard JSON fallback happens in Go.
 		migrationQuery := &DashboardQuery{
 			OrgID:         1,
 			GetHistory:    true,
@@ -545,14 +564,17 @@ func TestDashboardMigrationQuery(t *testing.T) {
 
 		sql := rawQuery
 
-		// Verify that COALESCE functions are present in the generated SQL
-		// These should be used when GetHistory=true AND AllowFallback=true
+		// Scalar fields still use SQL fallback when GetHistory=true AND AllowFallback=true.
 		require.Contains(t, sql, "COALESCE(dashboard_version.created, dashboard.updated)",
 			"Migration SQL should contain COALESCE for updated timestamp")
 		require.Contains(t, sql, "COALESCE(dashboard_version.version, dashboard.version)",
 			"Migration SQL should contain COALESCE for version")
-		require.Contains(t, sql, "COALESCE(dashboard_version.data, dashboard.data)",
-			"Migration SQL should contain COALESCE for data")
+		require.Contains(t, sql, "dashboard_version.data as version_data",
+			"Migration SQL should return raw history data")
+		require.Contains(t, sql, "dashboard.data as dashboard_data",
+			"Migration SQL should return raw fallback data")
+		require.NotContains(t, sql, "COALESCE(dashboard_version.data, dashboard.data)",
+			"Migration SQL should not transform dashboard JSON")
 		require.Contains(t, sql, "COALESCE(dashboard_version.api_version, dashboard.api_version)",
 			"Migration SQL should contain COALESCE for api_version")
 		require.Contains(t, sql, "COALESCE(dashboard_version.message, '')",
@@ -567,6 +589,23 @@ func TestDashboardMigrationQuery(t *testing.T) {
 		// Verify it doesn't have the strict history table filter that would exclude NULL version entries
 		require.NotContains(t, sql, "dashboard_version.id IS NOT NULL",
 			"Migration SQL should not exclude dashboards without version entries")
+	})
+
+	t.Run("Version query retains a single data column", func(t *testing.T) {
+		versionQuery := &DashboardQuery{
+			OrgID:   1,
+			UID:     "dashboard-uid",
+			Version: 2,
+		}
+
+		req := newQueryReq(nodb, versionQuery)
+		req.SQLTemplate = mocks.NewTestingSQLTemplate()
+
+		rawQuery, err := sqltemplate.Execute(sqlQueryDashboards, &req)
+		require.NoError(t, err)
+		require.Contains(t, rawQuery, "COALESCE(dashboard_version.data, dashboard.data) as data")
+		require.NotContains(t, rawQuery, "dashboard_version.data as version_data")
+		require.False(t, versionQuery.SelectRawDataColumns())
 	})
 
 	t.Run("Regular history query produces strict SQL", func(t *testing.T) {

--- a/pkg/registry/apis/dashboard/legacy/testdata/mysql--query_dashboards-migration_with_fallback.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/mysql--query_dashboards-migration_with_fallback.sql
@@ -18,7 +18,8 @@ SELECT
   COALESCE(dashboard_version.created_by, dashboard.updated_by) as updated_by_id,
   COALESCE(dashboard_version.version, dashboard.version) as version,
   COALESCE(dashboard_version.message, '') as message,
-  COALESCE(dashboard_version.data, dashboard.data) as data,
+  dashboard_version.data as version_data,
+  dashboard.data as dashboard_data,
   COALESCE(dashboard_version.api_version, dashboard.api_version) as api_version
 FROM `grafana`.`dashboard` as dashboard
 LEFT OUTER JOIN `grafana`.`dashboard_version` as dashboard_version ON dashboard.id = dashboard_version.dashboard_id

--- a/pkg/registry/apis/dashboard/legacy/testdata/postgres--query_dashboards-migration_with_fallback.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/postgres--query_dashboards-migration_with_fallback.sql
@@ -18,7 +18,8 @@ SELECT
   COALESCE(dashboard_version.created_by, dashboard.updated_by) as updated_by_id,
   COALESCE(dashboard_version.version, dashboard.version) as version,
   COALESCE(dashboard_version.message, '') as message,
-  COALESCE(dashboard_version.data, dashboard.data) as data,
+  dashboard_version.data as version_data,
+  dashboard.data as dashboard_data,
   COALESCE(dashboard_version.api_version, dashboard.api_version) as api_version
 FROM "grafana"."dashboard" as dashboard
 LEFT OUTER JOIN "grafana"."dashboard_version" as dashboard_version ON dashboard.id = dashboard_version.dashboard_id

--- a/pkg/registry/apis/dashboard/legacy/testdata/sqlite--query_dashboards-migration_with_fallback.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/sqlite--query_dashboards-migration_with_fallback.sql
@@ -18,7 +18,8 @@ SELECT
   COALESCE(dashboard_version.created_by, dashboard.updated_by) as updated_by_id,
   COALESCE(dashboard_version.version, dashboard.version) as version,
   COALESCE(dashboard_version.message, '') as message,
-  COALESCE(dashboard_version.data, dashboard.data) as data,
+  dashboard_version.data as version_data,
+  dashboard.data as dashboard_data,
   COALESCE(dashboard_version.api_version, dashboard.api_version) as api_version
 FROM "grafana"."dashboard" as dashboard
 LEFT OUTER JOIN "grafana"."dashboard_version" as dashboard_version ON dashboard.id = dashboard_version.dashboard_id

--- a/pkg/registry/apis/dashboard/legacy/types.go
+++ b/pkg/registry/apis/dashboard/legacy/types.go
@@ -51,6 +51,12 @@ func (r *DashboardQuery) UseHistoryTable() bool {
 	return r.GetHistory || r.Version > 0
 }
 
+// SelectRawDataColumns avoids applying SQL fallback expressions to dashboard JSON.
+// The reader applies the same NULL fallback after scanning both values.
+func (r *DashboardQuery) SelectRawDataColumns() bool {
+	return r.UseHistoryTable() && r.AllowFallback
+}
+
 type LibraryPanelQuery struct {
 	OrgID int64
 	UID   string // to select a single dashboard


### PR DESCRIPTION
**What is this feature?**

Fixes escaped dashboard JSON becoming invalid while it is read by the unified storage migration fallback query.

For migration queries that allow dashboards without version rows, the query now returns `dashboard_version.data` and `dashboard.data` as separate columns. The accessor selects the non-NULL version value in Go and falls back to the dashboard value when no version value exists. This preserves the existing fallback semantics while keeping dashboard JSON out of the SQL `COALESCE` expression.

Scalar metadata fields continue to use their existing SQL fallback behavior. Ordinary dashboard reads, strict history reads, and version-specific reads retain their existing query and scan shapes.

**Why do we need this feature?**

The reported migration reads a valid regex escape (`\\d`) as an invalid JSON escape (`\d`), causing dashboard unmarshalling to fail and producing an invalid-dashboard placeholder. The affected path is the migration fallback query introduced to handle dashboards without `dashboard_version` entries; other history reads select the JSON column directly.

Selecting both source values directly and applying NULL precedence in Go removes the JSON-specific difference from that migration path without removing support for dashboards that lack version rows.

**Who is this feature for?**

Grafana users migrating legacy dashboards to unified storage, particularly dashboards containing escaped expressions in their JSON model.

**Which issue(s) does this PR fix?**:

Fixes #131373

The dual-column scan is controlled by the same `SelectRawDataColumns` predicate used by the SQL template. This keeps the selected column count synchronized and ensures `Version > 0` queries continue to return one data column.
