### PR TITLE
feat(apiserver): preserve original caller identity type through store wrapper

### DIFF
--- a/pkg/apimachinery/identity/context.go
+++ b/pkg/apimachinery/identity/context.go
@@ -18,6 +18,7 @@ const provisioningServiceAudience = "provisioning.grafana.app"
 
 type ctxUserKey struct{}
 type metadataIdentityUIDKey struct{}
+type originalIdentityTypeKey struct{}
 type ctxOrgIDKey struct{}
 type innermostServiceIdentityKey struct{}
 
@@ -46,6 +47,22 @@ func WithOriginalIdentityUID(ctx context.Context, uid string) context.Context {
 func MetadataIdentityUIDFrom(ctx context.Context) (string, bool) {
 	uid, ok := ctx.Value(metadataIdentityUIDKey{}).(string)
 	return uid, ok && uid != ""
+}
+
+// WithOriginalIdentityType preserves the original caller's identity type when the context
+// identity is overridden (e.g. by the store wrapper swapping in a service identity). Inner
+// stores that must distinguish the real caller (user vs service) should read it via
+// OriginalIdentityTypeFrom instead of AuthInfoFrom, which reflects the swapped identity.
+func WithOriginalIdentityType(ctx context.Context, typ types.IdentityType) context.Context {
+	return context.WithValue(ctx, originalIdentityTypeKey{}, typ)
+}
+
+// OriginalIdentityTypeFrom returns the original caller identity type preserved by a wrapper,
+// and whether it was present. If not set, the caller should read the live identity type from
+// AuthInfoFrom(ctx).
+func OriginalIdentityTypeFrom(ctx context.Context) (types.IdentityType, bool) {
+	typ, ok := ctx.Value(originalIdentityTypeKey{}).(types.IdentityType)
+	return typ, ok
 }
 
 // WithRequester attaches the requester to the context.

--- a/pkg/services/apiserver/auth/authorizer/storewrapper/wrapper.go
+++ b/pkg/services/apiserver/auth/authorizer/storewrapper/wrapper.go
@@ -206,8 +206,13 @@ func (w *Wrapper) storeCtx(ctx context.Context) context.Context {
 	}
 
 	srvCtx, _ := identity.WithServiceIdentity(ctx, 0)
-	if user, err := identity.GetRequester(ctx); err == nil && user.GetUID() != "" {
-		srvCtx = identity.WithOriginalIdentityUID(srvCtx, user.GetUID())
+	if user, err := identity.GetRequester(ctx); err == nil {
+		if user.GetUID() != "" {
+			srvCtx = identity.WithOriginalIdentityUID(srvCtx, user.GetUID())
+		}
+		// Preserve the original caller type so inner stores can still tell a real user from a
+		// service after the identity above is swapped for a service identity.
+		srvCtx = identity.WithOriginalIdentityType(srvCtx, user.GetIdentityType())
 	}
 
 	return srvCtx


### PR DESCRIPTION
**What is this feature?**

When the store wrapper swaps the request identity for a service identity, inner stores lose the ability to tell whether the real caller was a user or a service, since `AuthInfoFrom` now reflects the swapped identity. This adds a context helper that stashes the original caller's identity type alongside the already-preserved `UID`, so downstream stores that need to distinguish a genuine user from a service can read it without being misled by the override.

**Which issue(s) does this PR fix?**:

Related:

- https://github.com/grafana/hosted-grafana/issues/8361


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
