### PR TITLE
Dashboards: Enable group by by default on new adhoc filter variables

### DIFF
--- a/public/app/features/dashboard-scene/settings/variables/components/AdHocVariableForm.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/AdHocVariableForm.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
 import { selectors } from '@grafana/e2e-selectors';
+import { config } from '@grafana/runtime';
 import { mockBoundingClientRect } from '@grafana/test-utils';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
 
@@ -150,6 +151,28 @@ describe('AdHocVariableForm', () => {
     expect(dataSourcePicker).toBeInTheDocument();
     expect(allowCustomValueCheckbox).not.toBeInTheDocument();
     expect(alertText).toBeInTheDocument();
+  });
+
+  describe('enable group by', () => {
+    afterEach(() => {
+      config.featureToggles.dashboardUnifiedDrilldownControls = false;
+    });
+
+    it('should show Enable group by toggle as on when no datasource is selected', async () => {
+      config.featureToggles.dashboardUnifiedDrilldownControls = true;
+
+      const { renderer } = await setup({
+        ...defaultProps,
+        datasource: undefined,
+        enableGroupBy: true,
+        onEnableGroupByChange: jest.fn(),
+      });
+
+      expect(renderer.getByText('Enable group by')).toBeInTheDocument();
+      expect(
+        renderer.getByTestId(selectors.pages.Dashboard.Settings.Variables.Edit.AdHocFiltersVariable.enableGroupByToggle)
+      ).toBeChecked();
+    });
   });
 });
 

--- a/public/app/features/dashboard-scene/settings/variables/components/AdHocVariableForm.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/AdHocVariableForm.tsx
@@ -115,10 +115,8 @@ export function AdHocVariableForm({
         )}
 
         {config.featureToggles.dashboardUnifiedDrilldownControls &&
-          datasource &&
-          datasourceSupported &&
-          datasourceSupportsGroupBy &&
-          onEnableGroupByChange && (
+          onEnableGroupByChange &&
+          (!datasource || (datasourceSupported && datasourceSupportsGroupBy)) && (
             <Field
               label={t('dashboard-scene.ad-hoc-variable-form.name-enable-group-by', 'Enable group by')}
               description={t(

--- a/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.test.tsx
@@ -237,6 +237,30 @@ describe('AdHocFiltersVariableEditor', () => {
 
       expect(variable.state.enableGroupBy).toBe(false);
     });
+
+    it('should show Enable group by toggle as on when no datasource is selected', async () => {
+      config.featureToggles.dashboardUnifiedDrilldownControls = true;
+
+      const { renderer } = await setup(undefined, { datasource: null });
+
+      await waitFor(() => {
+        expect(renderer.getByText('Enable group by')).toBeInTheDocument();
+      });
+      expect(
+        renderer.getByTestId(selectors.pages.Dashboard.Settings.Variables.Edit.AdHocFiltersVariable.enableGroupByToggle)
+      ).toBeChecked();
+    });
+
+    it('should not show default group by editor when no datasource is selected', async () => {
+      config.featureToggles.dashboardUnifiedDrilldownControls = true;
+
+      const { renderer } = await setup(undefined, { datasource: null, enableGroupBy: true });
+
+      await waitFor(() => {
+        expect(renderer.getByText('Enable group by')).toBeInTheDocument();
+      });
+      expect(renderer.queryByTestId('default-groupby-editor')).not.toBeInTheDocument();
+    });
   });
 
   describe('default group-by origin', () => {
@@ -348,17 +372,22 @@ describe('AdHocFiltersVariableEditor', () => {
 interface SetupOptions {
   withDefaultKeys?: boolean;
   enableGroupBy?: boolean;
+  datasource?: { uid: string; type: string } | null;
 }
 
 async function setup(props?: React.ComponentProps<typeof AdHocFiltersVariableEditor>, options: SetupOptions = {}) {
-  const { withDefaultKeys = false, enableGroupBy } = options;
+  const {
+    withDefaultKeys = false,
+    enableGroupBy,
+    datasource = { uid: defaultDatasource.uid, type: defaultDatasource.type },
+  } = options;
   const onRunQuery = jest.fn();
   const variable = new AdHocFiltersVariable({
     name: 'adhocVariable',
     type: 'adhoc',
     label: 'Filter',
     description: 'Filters are applied automatically to all queries that target this data source',
-    datasource: { uid: defaultDatasource.uid, type: defaultDatasource.type },
+    datasource,
     filters: [
       {
         key: 'test',

--- a/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.tsx
@@ -48,7 +48,9 @@ export function AdHocFiltersVariableEditor(props: AdHocFiltersVariableEditorProp
 
   const groupByOriginFilters = useMemo(() => originalFilters.filter(isGroupByOriginFilter), [originalFilters]);
 
-  const groupByEnabled = config.featureToggles.dashboardUnifiedDrilldownControls && enableGroupBy;
+  const groupByEnabled = Boolean(
+    config.featureToggles.dashboardUnifiedDrilldownControls && enableGroupBy && datasourceRef
+  );
 
   const updateOriginalFilters = useCallback(
     (filters: AdHocFilterWithLabels[]) => {
@@ -155,7 +157,7 @@ export function AdHocFiltersVariableEditor(props: AdHocFiltersVariableEditorProp
       datasource={datasourceRef ?? undefined}
       infoText={message}
       allowCustomValue={allowCustomValue}
-      enableGroupBy={enableGroupBy}
+      enableGroupBy={enableGroupBy ?? !datasourceRef}
       onDataSourceChange={onDataSourceChange}
       defaultKeys={defaultKeys}
       onDefaultKeysChange={onDefaultKeysChange}

--- a/public/app/features/dashboard-scene/settings/variables/utils.test.ts
+++ b/public/app/features/dashboard-scene/settings/variables/utils.test.ts
@@ -349,6 +349,26 @@ describe('getVariableScene', () => {
     expect(sceneVariable.state.name).toBe(initialState.name);
     expect(sceneVariable.state.hide).toBe(VariableHide.hideVariable);
   });
+
+  describe('adhoc enableGroupBy default', () => {
+    afterEach(() => {
+      config.featureToggles.dashboardUnifiedDrilldownControls = false;
+    });
+
+    it('enables group by on new adhoc variables when dashboardUnifiedDrilldownControls is on', async () => {
+      config.featureToggles.dashboardUnifiedDrilldownControls = true;
+
+      const variable = await getVariableScene('adhoc', { name: 'filter0' });
+
+      expect(variable.state.enableGroupBy).toBe(true);
+    });
+
+    it('does not enable group by on new adhoc variables when dashboardUnifiedDrilldownControls is off', async () => {
+      const variable = await getVariableScene('adhoc', { name: 'filter0' });
+
+      expect(variable.state.enableGroupBy).toBeUndefined();
+    });
+  });
 });
 
 describe('hasVariableOptions', () => {

--- a/public/app/features/dashboard-scene/settings/variables/utils.test.ts
+++ b/public/app/features/dashboard-scene/settings/variables/utils.test.ts
@@ -360,13 +360,13 @@ describe('getVariableScene', () => {
 
       const variable = await getVariableScene('adhoc', { name: 'filter0' });
 
-      expect(variable.state.enableGroupBy).toBe(true);
+      expect((variable as AdHocFiltersVariable).state.enableGroupBy).toBe(true);
     });
 
     it('does not enable group by on new adhoc variables when dashboardUnifiedDrilldownControls is off', async () => {
       const variable = await getVariableScene('adhoc', { name: 'filter0' });
 
-      expect(variable.state.enableGroupBy).toBeUndefined();
+      expect((variable as AdHocFiltersVariable).state.enableGroupBy).toBeUndefined();
     });
   });
 });

--- a/public/app/features/dashboard-scene/settings/variables/utils.ts
+++ b/public/app/features/dashboard-scene/settings/variables/utils.ts
@@ -258,6 +258,7 @@ export async function getVariableScene(type: EditableVariableType, initialState:
     case 'adhoc':
       return new AdHocFiltersVariable({
         ...initialState,
+        ...(config.featureToggles.dashboardUnifiedDrilldownControls ? { enableGroupBy: true } : {}),
       });
     case 'groupby':
       return new GroupByVariable(initialState);


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

When adding a new adhoc "Filter and Group by" variable, group by is now enabled by default. The "Enable group by" toggle shows as on while no data source is selected, and the setting is seeded into the variable's state on creation so it persists on save. 