### PR TITLE
IAM: Add the AuthInfo search route to the OpenAPI snapshot

### DIFF
--- a/packages/grafana-openapi/src/apis/iam.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/iam.grafana.app-v0alpha1.json
@@ -29,6 +29,37 @@
         }
       }
     },
+    "/authinfos/search": {
+      "post": {
+        "tags": ["Search"],
+        "description": "Search AuthInfo resources in a namespace.",
+        "operationId": "listAuthInfoSearchV0alpha1",
+        "parameters": [],
+        "requestBody": {
+          "description": "A SearchQuery describing what to match, sort and return.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A SearchResults envelope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResults"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/display": {
       "get": {
         "tags": ["Display"],

--- a/pkg/tests/apis/openapi_snapshots/iam.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/iam.grafana.app-v0alpha1.json
@@ -31,6 +31,50 @@
         }
       }
     },
+    "/apis/iam.grafana.app/v0alpha1/namespaces/{namespace}/authinfos/search": {
+      "post": {
+        "tags": [
+          "Search"
+        ],
+        "description": "Search AuthInfo resources in a namespace.",
+        "operationId": "listAuthInfoSearchV0alpha1",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "workspace",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "default"
+          }
+        ],
+        "requestBody": {
+          "description": "A SearchQuery describing what to match, sort and return.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A SearchResults envelope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchResults"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/apis/iam.grafana.app/v0alpha1/namespaces/{namespace}/display": {
       "get": {
         "tags": [


### PR DESCRIPTION
**What is this feature?**

Adds the `authinfos/search` route to the IAM OpenAPI snapshot, plus the `yarn generate-apis` output for it. No RTK client changes (per-resource search is filtered out of client generation).

**Why do we need this feature?**

`TestIntegrationOpenAPIs` is failing on `main` ([job](https://github.com/grafana/grafana/actions/runs/32763846759/job/97552586709)). [#131140](https://github.com/grafana/grafana/pull/131140) added the `AuthInfo` kind with `searchFields`, so the served spec gained a search route the snapshot doesn't have.

**Special notes for your reviewer:**



_Assisted by Cursor_