### PR TITLE
Folder: return 404 instead of 500 when a folder is not found during parent lookup

### DIFF
--- a/pkg/services/folder/folderimpl/unifiedstore.go
+++ b/pkg/services/folder/folderimpl/unifiedstore.go
@@ -2,6 +2,7 @@ package folderimpl
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -196,18 +197,25 @@ func (ss *FolderUnifiedStoreImpl) GetParents(ctx context.Context, q folder.GetPa
 
 	parentUID := q.UID
 	for parentUID != "" {
-		folder, err := ss.Get(ctx, folder.GetFolderQuery{UID: &parentUID, OrgID: q.OrgID})
+		f, err := ss.Get(ctx, folder.GetFolderQuery{UID: &parentUID, OrgID: q.OrgID})
 		if err != nil {
 			if apierrors.IsForbidden(err) {
 				// If we get a Forbidden error when requesting the parent folder, it means the user does not have access
 				// to it, nor its parents. So we can stop looping
 				break
 			}
+			// ss.Get surfaces a missing folder as dashboards.ErrFolderNotFound,
+			// which scope resolvers cannot recognize as "not found" and would
+			// otherwise turn into an internal error; normalize it so callers
+			// see the canonical not-found error.
+			if errors.Is(err, dashboards.ErrFolderNotFound) {
+				return nil, folder.ErrFolderNotFound
+			}
 			return nil, err
 		}
 
-		parentUID = folder.ParentUID
-		hits = append(hits, folder)
+		parentUID = f.ParentUID
+		hits = append(hits, f)
 	}
 
 	if len(hits) == 0 {

--- a/pkg/services/folder/folderimpl/unifiedstore.go
+++ b/pkg/services/folder/folderimpl/unifiedstore.go
@@ -207,9 +207,12 @@ func (ss *FolderUnifiedStoreImpl) GetParents(ctx context.Context, q folder.GetPa
 			// ss.Get surfaces a missing folder as dashboards.ErrFolderNotFound,
 			// which scope resolvers cannot recognize as "not found" and would
 			// otherwise turn into an internal error; normalize it so callers
-			// see the canonical not-found error.
+			// see the canonical not-found error. Instantiate with Errorf (as
+			// ossaccesscontrol does) because only the instantiated errutil.Error
+			// carries APIStatus/errors.As metadata, which response renderers
+			// need to emit a 404 instead of falling back to 500.
 			if errors.Is(err, dashboards.ErrFolderNotFound) {
-				return nil, folder.ErrFolderNotFound
+				return nil, folder.ErrFolderNotFound.Errorf("folder not found")
 			}
 			return nil, err
 		}

--- a/pkg/services/folder/folderimpl/unifiedstore_test.go
+++ b/pkg/services/folder/folderimpl/unifiedstore_test.go
@@ -195,7 +195,10 @@ func TestGetParents(t *testing.T) {
 			OrgID: orgID,
 		})
 
-		require.ErrorIs(t, err, dashboards.ErrFolderNotFound)
+		// The not-found error must be the canonical folder.ErrFolderNotFound so
+		// scope resolvers and API handlers can recognize it and respond with a
+		// 404 instead of an internal error.
+		require.ErrorIs(t, err, folder.ErrFolderNotFound)
 	})
 }
 


### PR DESCRIPTION
**What is this feature?**

The folders API now returns **404 Not Found** instead of **500 Internal Server Error** when a user without folder-admin wildcard permissions requests a folder that does not exist. The fix normalizes the not-found error inside `FolderUnifiedStoreImpl.GetParents`, at the point where the mismatched error sentinel originates: the k8s client surfaces a missing folder as `dashboards.ErrFolderNotFound` (a plain `"folder not found"` sentinel), but `GetInheritedScopes` — which walks the ancestor chain during RBAC scope resolution for non-admins — only recognizes `folder.ErrFolderNotFound`, the errutil-based not-found error that renders as HTTP 404. Any missing folder therefore fell into the catch-all internal-error branch. The one-line normalization (`errors.Is(err, dashboards.ErrFolderNotFound)` → return `folder.ErrFolderNotFound`) makes every scope resolver and API handler see a not-found error they already know how to map to 404.

**Why do we need this feature?**

Fixes #109608. Since folders moved to unified storage, any editor/viewer hitting a missing or deleted folder UID through the new folders API got a server error in their face — noisy for clients, misleading in logs and dashboards of error rates, and inconsistent with the legacy `/api/folders/:uid` endpoint, which correctly returns 404 because its error mapper (`ToFolderErrorResponse`) already accepts both sentinels. Admins were unaffected, which is why it went unnoticed internally.

**Who is this feature for?**

Any Grafana user or API consumer resolving folder UIDs without admin-wide wildcard permissions: editors and viewers using the UI, automation/scripts probing folder existence (which can now simply check for 404), and plugin/tooling authors against the folders API.

**Which issue(s) does this PR fix?**:

Fixes #109608

**Special notes for your reviewer:**

- The fix is intentionally tiny (+16/−5 across two commits): sentinel normalization where the wrong error originates, plus a loop-variable rename (`folder` → `f`) that was required because the old name shadowed the `folder` package import and made the canonical-sentinel return unrepresentable.
- Follow-up commit `3a25c37` (from automated review, verified empirically): the not-found error is returned **instantiated** via `ErrFolderNotFound.Errorf("folder not found")`, because a bare `errutil.Base` template implements neither `errors.As(err, &errutil.Error{})` nor k8s `APIStatus` — renderers could have fallen back to a generic 500 despite correct sentinel identity. `errors.Is(err, folder.ErrFolderNotFound)` still holds (`Error.Unwrap` exposes the underlying `Base`); mirroring existing usage in `ossaccesscontrol/folder.go`.
- Blast radius audited across all 11 callers of `GetParents`/`GetInheritedScopes` (annotations scopes, dashboard/folder/library-element scope resolvers, ossaccesscontrol resolvers, folder create/move paths, legacy API handlers): every site either propagates the now-canonical 404-class error, log-and-continues (`getFolderParentsAndDTO`), or already handles both sentinels via its own `isFolderNotFound` helper (variable UID resolver). The Forbidden early-break behavior is untouched. The legacy `/api/folders` mapper accepting both sentinels means existing consumers see no change.
- Regression proof: `TestGetParents/should_stop_if_parent_folder_is_not_found` was updated to pin the new contract; verified it **fails** against unfixed code (expected `[folder.notFound]`, got `folder not found`) and passes with the fix. Full `folderimpl` + `folder` package suites green, dashboard service consumer suite green, `go vet`/`gofmt` clean, `go build ./pkg/...` OK on Windows/Go 1.26.x.
- Follow-up candidate (deliberately out of scope here): `GetChildren`/`GetDescendants` still surface the plain `dashboards.ErrFolderNotFound`; normalizing them would be scope creep for this fix but could hit future callers the same way.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. *(N/A — bug fix, no toggle)*
- [x] The docs are updated, and if this is a notable improvement, it's added to our What's New doc. *(N/A — no user-facing config/API surface change beyond correct status code)*
