### PR TITLE
SSO settings: inject legacy database provider

### DIFF
--- a/pkg/login/social/socialimpl/service_test.go
+++ b/pkg/login/social/socialimpl/service_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ssosettings/ssosettingstests"
 	"github.com/grafana/grafana/pkg/services/supportbundles/supportbundlestest"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
@@ -76,7 +77,7 @@ func TestIntegrationSocialService_ProvideService(t *testing.T) {
 	ssoSettingsSvc := ssosettingsimpl.ProvideService(
 		cfg,
 		mustConfigProvider(t, cfg),
-		sqlStore,
+		legacysql.NewDatabaseProvider(sqlStore),
 		accessControl,
 		routing.NewRouteRegister(),
 		featuremgmt.WithFeatures(),
@@ -303,7 +304,7 @@ func TestIntegrationSocialService_ProvideService_GrafanaComGrafanaNet(t *testing
 			ssoSettingsSvc := ssosettingsimpl.ProvideService(
 				cfg,
 				mustConfigProvider(t, cfg),
-				sqlStore,
+				legacysql.NewDatabaseProvider(sqlStore),
 				accessControl,
 				routing.NewRouteRegister(),
 				featuremgmt.WithFeatures(),

--- a/pkg/server/bootstrap/wire/wire_gen.go
+++ b/pkg/server/bootstrap/wire/wire_gen.go
@@ -431,7 +431,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts server.Options, apiO
 		return nil, err
 	}
 	licensingService := licensing2.ProvideLicensing(cfg, ossLicensingService)
-	ssosettingsimplService := ssosettingsimpl.ProvideService(cfg, configProvider, sqlStore, accessControl, routeRegisterImpl, featureToggles, secretsService, usageStats, registerer, ossImpl, ossLicensingService)
+	ssosettingsimplService := ssosettingsimpl.ProvideService(cfg, configProvider, legacyDatabaseProvider, accessControl, routeRegisterImpl, featureToggles, secretsService, usageStats, registerer, ossImpl, ossLicensingService)
 	defaultSettingsProvider := pluginsso.ProvideDefaultSettingsProvider(ssosettingsimplService)
 	marketplacelicensingLicensing := marketplacelicensing.Provide(cfg)
 	envVarsProvider := pluginconfig.NewEnvVarsProvider(pluginInstanceCfg, licensingService, defaultSettingsProvider, marketplacelicensingLicensing)
@@ -1182,7 +1182,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 		return nil, err
 	}
 	licensingService := licensing2.ProvideLicensing(cfg, ossLicensingService)
-	ssosettingsimplService := ssosettingsimpl.ProvideService(cfg, configProvider, sqlStore, accessControl, routeRegisterImpl, featureToggles, secretsService, usageStats, registerer, ossImpl, ossLicensingService)
+	ssosettingsimplService := ssosettingsimpl.ProvideService(cfg, configProvider, legacyDatabaseProvider, accessControl, routeRegisterImpl, featureToggles, secretsService, usageStats, registerer, ossImpl, ossLicensingService)
 	defaultSettingsProvider := pluginsso.ProvideDefaultSettingsProvider(ssosettingsimplService)
 	marketplacelicensingLicensing := marketplacelicensing.Provide(cfg)
 	envVarsProvider := pluginconfig.NewEnvVarsProvider(pluginInstanceCfg, licensingService, defaultSettingsProvider, marketplacelicensingLicensing)

--- a/pkg/services/ssosettings/database/database.go
+++ b/pkg/services/ssosettings/database/database.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -10,6 +11,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ssosettings"
 	"github.com/grafana/grafana/pkg/services/ssosettings/models"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
 )
 
 const (
@@ -19,14 +21,14 @@ const (
 )
 
 type SSOSettingsStore struct {
-	sqlStore db.DB
-	log      log.Logger
+	sql legacysql.LegacyDatabaseProvider
+	log log.Logger
 }
 
-func ProvideStore(sqlStore db.DB) *SSOSettingsStore {
+func ProvideStore(sql legacysql.LegacyDatabaseProvider) *SSOSettingsStore {
 	return &SSOSettingsStore{
-		sqlStore: sqlStore,
-		log:      log.New("ssosettings.store"),
+		sql: sql,
+		log: log.New("ssosettings.store"),
 	}
 }
 
@@ -42,8 +44,13 @@ func (s *SSOSettingsStore) Get(ctx context.Context, provider string) (*models.SS
 		IsDeleted: false,
 	}
 
-	err := s.sqlStore.WithDbSession(ctx, func(sess *db.Session) error {
-		found, err := sess.UseBool(isDeletedColumn).Get(&result)
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
+		found, err := sess.Table(dbHelper.Table("sso_setting")).UseBool(isDeletedColumn).Get(&result)
 		if err != nil {
 			return err
 		}
@@ -65,12 +72,17 @@ func (s *SSOSettingsStore) Get(ctx context.Context, provider string) (*models.SS
 func (s *SSOSettingsStore) List(ctx context.Context) ([]*models.SSOSettings, error) {
 	result := make([]*models.SSOSettings, 0)
 
-	err := s.sqlStore.WithDbSession(ctx, func(sess *db.Session) error {
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
 		condition := &models.SSOSettings{
 			IsDeleted: false,
 		}
 
-		err := sess.UseBool(isDeletedColumn).Find(&result, condition)
+		err := sess.Table(dbHelper.Table("sso_setting")).UseBool(isDeletedColumn).Find(&result, condition)
 		if err != nil {
 			return err
 		}
@@ -90,13 +102,18 @@ func (s *SSOSettingsStore) Upsert(ctx context.Context, settings *models.SSOSetti
 		return ssosettings.ErrNotFound
 	}
 
-	return s.sqlStore.WithDbSession(ctx, func(sess *db.Session) error {
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	return dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
 		existing := &models.SSOSettings{
 			Provider:  settings.Provider,
 			IsDeleted: false,
 		}
 
-		found, err := sess.UseBool(isDeletedColumn).Exist(existing)
+		found, err := sess.Table(dbHelper.Table("sso_setting")).UseBool(isDeletedColumn).Exist(existing)
 		if err != nil {
 			return err
 		}
@@ -109,12 +126,12 @@ func (s *SSOSettingsStore) Upsert(ctx context.Context, settings *models.SSOSetti
 				Updated:   now,
 				IsDeleted: false,
 			}
-			_, err = sess.UseBool(isDeletedColumn).Update(updated, existing)
+			_, err = sess.Table(dbHelper.Table("sso_setting")).UseBool(isDeletedColumn).Update(updated, existing)
 		} else {
 			settings.ID = uuid.New().String()
 			settings.Created = now
 			settings.Updated = now
-			_, err = sess.Insert(settings)
+			_, err = sess.Table(dbHelper.Table("sso_setting")).Insert(settings)
 		}
 
 		return err
@@ -126,13 +143,18 @@ func (s *SSOSettingsStore) Delete(ctx context.Context, provider string) error {
 		return ssosettings.ErrNotFound
 	}
 
-	return s.sqlStore.WithDbSession(ctx, func(sess *db.Session) error {
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	return dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
 		existing := &models.SSOSettings{
 			Provider:  provider,
 			IsDeleted: false,
 		}
 
-		found, err := sess.UseBool(isDeletedColumn).Get(existing)
+		found, err := sess.Table(dbHelper.Table("sso_setting")).UseBool(isDeletedColumn).Get(existing)
 		if err != nil {
 			return err
 		}
@@ -147,7 +169,7 @@ func (s *SSOSettingsStore) Delete(ctx context.Context, provider string) error {
 		// We must explicitly omit ID column from updates, because some databases don't allow updating
 		// primary key. Xorm ignores autoincrement columns during updates, but since ID column here is a string,
 		// it's not ignored by default.
-		_, err = sess.ID(existing.ID).Omit(idColumn).MustCols(updatedColumn, isDeletedColumn).Update(existing)
+		_, err = sess.Table(dbHelper.Table("sso_setting")).ID(existing.ID).Omit(idColumn).MustCols(updatedColumn, isDeletedColumn).Update(existing)
 		return err
 	})
 }

--- a/pkg/services/ssosettings/database/database_test.go
+++ b/pkg/services/ssosettings/database/database_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/ssosettings"
 	"github.com/grafana/grafana/pkg/services/ssosettings/models"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
@@ -31,7 +32,7 @@ func TestIntegrationGetSSOSettings(t *testing.T) {
 
 	setup := func() {
 		sqlStore = db.InitTestDB(t) //nolint:staticcheck // legacy shared-DB test setup; migrate to NewTestStore
-		ssoSettingsStore = ProvideStore(sqlStore)
+		ssoSettingsStore = ProvideStore(legacysql.NewDatabaseProvider(sqlStore))
 
 		template := models.SSOSettings{
 			Settings: map[string]any{"enabled": true},
@@ -92,7 +93,7 @@ func TestIntegrationUpsertSSOSettings(t *testing.T) {
 
 	setup := func() {
 		sqlStore = db.InitTestDB(t) //nolint:staticcheck // legacy shared-DB test setup; migrate to NewTestStore
-		ssoSettingsStore = ProvideStore(sqlStore)
+		ssoSettingsStore = ProvideStore(legacysql.NewDatabaseProvider(sqlStore))
 	}
 
 	t.Run("insert a new SSO setting successfully", func(t *testing.T) {
@@ -269,7 +270,7 @@ func TestIntegrationListSSOSettings(t *testing.T) {
 
 	setup := func() {
 		sqlStore = db.InitTestDB(t) //nolint:staticcheck // legacy shared-DB test setup; migrate to NewTestStore
-		ssoSettingsStore = ProvideStore(sqlStore)
+		ssoSettingsStore = ProvideStore(legacysql.NewDatabaseProvider(sqlStore))
 	}
 
 	t.Run("returns every SSO settings successfully", func(t *testing.T) {
@@ -333,7 +334,7 @@ func TestIntegrationDeleteSSOSettings(t *testing.T) {
 
 	setup := func() {
 		sqlStore = db.InitTestDB(t) //nolint:staticcheck // legacy shared-DB test setup; migrate to NewTestStore
-		ssoSettingsStore = ProvideStore(sqlStore)
+		ssoSettingsStore = ProvideStore(legacysql.NewDatabaseProvider(sqlStore))
 	}
 
 	t.Run("soft deletes the settings successfully", func(t *testing.T) {

--- a/pkg/services/ssosettings/database/provider_test.go
+++ b/pkg/services/ssosettings/database/provider_test.go
@@ -1,0 +1,128 @@
+package database
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"sync"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/db/dbtest"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+	"github.com/grafana/grafana/pkg/services/ssosettings"
+	"github.com/grafana/grafana/pkg/services/ssosettings/models"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
+	"github.com/grafana/grafana/pkg/util/xorm"
+	"github.com/grafana/grafana/pkg/util/xorm/core"
+)
+
+var registerSSOSQLMockXormDriverOnce sync.Once
+
+type ssoSQLMockXormDriver struct{}
+
+func (ssoSQLMockXormDriver) Parse(string, string) (*core.Uri, error) {
+	return &core.Uri{DbType: core.SQLITE}, nil
+}
+
+type sqlmockSSODB struct {
+	dbtest.FakeDB
+	engine *xorm.Engine
+}
+
+func (d *sqlmockSSODB) WithDbSession(_ context.Context, callback sqlstore.DBTransactionFunc) error {
+	sess := &sqlstore.DBSession{Session: d.engine.NewSession()}
+	defer sess.Close()
+	return callback(sess)
+}
+
+func (d *sqlmockSSODB) WithTransactionalDbSession(ctx context.Context, callback sqlstore.DBTransactionFunc) error {
+	return d.WithDbSession(ctx, callback)
+}
+
+func (d *sqlmockSSODB) GetDBType() core.DbType {
+	return core.SQLITE
+}
+
+func (d *sqlmockSSODB) GetDialect() migrator.Dialect {
+	return migrator.NewSQLite3Dialect()
+}
+
+func (d *sqlmockSSODB) Quote(value string) string {
+	return d.engine.Quote(value)
+}
+
+func TestStoreUsesProviderTables(t *testing.T) {
+	registerSSOSQLMockXormDriverOnce.Do(func() {
+		if core.QueryDriver("sqlmock") == nil {
+			core.RegisterDriver("sqlmock", ssoSQLMockXormDriver{})
+		}
+	})
+
+	dsn := "ssosettings-database-store"
+	mockDB, mock, err := sqlmock.NewWithDSN(dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mockDB.Close() })
+
+	engine, err := xorm.NewEngine("sqlmock", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = engine.Close() })
+
+	legacyDB := &sqlmockSSODB{engine: engine}
+	type contextKey struct{}
+	ctx := context.WithValue(context.Background(), contextKey{}, "provider context")
+	providerCalls := 0
+	provider := func(gotCtx context.Context) (*legacysql.LegacyDatabaseHelper, error) {
+		require.Equal(t, "provider context", gotCtx.Value(contextKey{}))
+		providerCalls++
+		return &legacysql.LegacyDatabaseHelper{
+			DB: legacyDB,
+			Table: func(name string) string {
+				return "test_schema." + name
+			},
+		}, nil
+	}
+	store := ProvideStore(provider)
+
+	mock.ExpectQuery(regexp.QuoteMeta("FROM `test_schema`.`sso_setting`")).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+	_, err = store.Get(ctx, "github")
+	require.ErrorIs(t, err, ssosettings.ErrNotFound)
+
+	mock.ExpectQuery(regexp.QuoteMeta("FROM `test_schema`.`sso_setting`")).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+	settings, err := store.List(ctx)
+	require.NoError(t, err)
+	require.Empty(t, settings)
+
+	mock.ExpectQuery(regexp.QuoteMeta("FROM `test_schema`.`sso_setting`")).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO `test_schema`.`sso_setting`")).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	err = store.Upsert(ctx, &models.SSOSettings{
+		Provider: "github",
+		Settings: map[string]any{"enabled": true},
+	})
+	require.NoError(t, err)
+
+	mock.ExpectQuery(regexp.QuoteMeta("FROM `test_schema`.`sso_setting`")).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+	err = store.Delete(ctx, "github")
+	require.ErrorIs(t, err, ssosettings.ErrNotFound)
+
+	require.Equal(t, 4, providerCalls)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestStoreReturnsProviderErrorBeforeDatabaseAccess(t *testing.T) {
+	providerErr := errors.New("provider unavailable")
+	store := ProvideStore(func(context.Context) (*legacysql.LegacyDatabaseHelper, error) {
+		return nil, providerErr
+	})
+
+	_, err := store.List(context.Background())
+	require.ErrorIs(t, err, providerErr)
+}

--- a/pkg/services/ssosettings/ssosettingsimpl/service.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service.go
@@ -20,7 +20,6 @@ import (
 	legacyiamv0 "github.com/grafana/grafana/pkg/apis/iam/v0alpha1"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/configprovider"
-	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
@@ -35,6 +34,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ssosettings/models"
 	"github.com/grafana/grafana/pkg/services/ssosettings/strategies"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
 )
 
 var _ ssosettings.Service = (*Service)(nil)
@@ -62,7 +62,7 @@ type Service struct {
 	mtReadAuthoritative bool
 }
 
-func ProvideService(cfg *setting.Cfg, cfgProvider configprovider.ConfigProvider, sqlStore db.DB, ac ac.AccessControl,
+func ProvideService(cfg *setting.Cfg, cfgProvider configprovider.ConfigProvider, sql legacysql.LegacyDatabaseProvider, ac ac.AccessControl,
 	routeRegister routing.RouteRegister, features featuremgmt.FeatureToggles,
 	secrets secrets.Service, //nolint:staticcheck // SA1019: Legacy envelope encryption for single-tenant feature
 	usageStats usagestats.Service, registerer prometheus.Registerer,
@@ -119,7 +119,7 @@ func ProvideService(cfg *setting.Cfg, cfgProvider configprovider.ConfigProvider,
 		configurableProviders[social.SAMLProviderName] = true
 	}
 
-	store := database.ProvideStore(sqlStore)
+	store := database.ProvideStore(sql)
 
 	svc := &Service{
 		logger:                logger,
@@ -151,7 +151,7 @@ func ProvideService(cfg *setting.Cfg, cfgProvider configprovider.ConfigProvider,
 // database with the tenant configuration as fallback.
 //
 //nolint:staticcheck // SA1019: legacy tenant databases still use the deprecated secrets service
-func ProvideReadOnlyService(cfgProvider configprovider.ConfigProvider, sqlStore db.DB, secretsSvc secrets.Service) *Service {
+func ProvideReadOnlyService(cfgProvider configprovider.ConfigProvider, sql legacysql.LegacyDatabaseProvider, secretsSvc secrets.Service) *Service {
 	configurableProviders := make(map[string]bool, len(ssosettings.AllOAuthProviders))
 	for _, provider := range ssosettings.AllOAuthProviders {
 		configurableProviders[provider] = true
@@ -159,7 +159,7 @@ func ProvideReadOnlyService(cfgProvider configprovider.ConfigProvider, sqlStore 
 
 	return &Service{
 		logger:                log.New("ssosettings.service"),
-		store:                 database.ProvideStore(sqlStore),
+		store:                 database.ProvideStore(sql),
 		secrets:               secretsSvc,
 		fbStrategies:          []ssosettings.FallbackStrategy{strategies.NewOAuthStrategy(cfgProvider)},
 		providersList:         slices.Clone(ssosettings.AllOAuthProviders),

--- a/pkg/services/ssosettings/ssosettingsimpl/service_test.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/setting/settingtest"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 )
 
@@ -2612,7 +2613,7 @@ func setupTestEnv(t *testing.T, isLicensingEnabled, keepFallbackStratergies bool
 	svc := ProvideService(
 		cfg,
 		mustConfigProvider(t, cfg),
-		&dbtest.FakeDB{},
+		legacysql.NewDatabaseProvider(&dbtest.FakeDB{}),
 		accessControl,
 		routing.NewRouteRegister(),
 		featureManager,


### PR DESCRIPTION
## What changed

- `SSOSettingsStore` now accepts a `LegacyDatabaseProvider` instead of a `db.DB`.
- Each store operation resolves the database helper from its context.
- All `sso_setting` XORM operations use the table returned by the helper.
- SSO service constructors and fixed-database callers now use the provider.
- Added a SQLMock test for qualified tables and provider context.

## Why

OAuth login reads SSO settings for the current request. For MT authn the store must use the table selected for that request instead of a database captured when the service is built.

This PR keeps the existing XORM query style. SQL-template changes are separate work.

## Related

Parent issue: https://github.com/grafana/identity-access-team/issues/2326
Enterprise wiring: https://github.com/grafana/grafana-enterprise/pull/13281