### PR TITLE
FolderDetailsAction: Smaller screen style fix

### DIFF
--- a/public/app/features/browse-dashboards/components/FolderDetailsActions/FolderDetailsActions.tsx
+++ b/public/app/features/browse-dashboards/components/FolderDetailsActions/FolderDetailsActions.tsx
@@ -45,7 +45,7 @@ export const FolderDetailsActions = ({ folderDTO }: { folderDTO?: CombinedFolder
   const canReadTeams = contextSrv.hasPermission(AccessControlAction.ActionTeamsRead);
 
   return (
-    <Stack alignItems="center">
+    <Stack alignItems="center" wrap>
       {starredFoldersEnabled() && folderDTO && (
         <StarToolbarButton
           group="folder.grafana.app"


### PR DESCRIPTION
**What is this feature?**

FolderDetailsAction: Pass `wrap` to Stack  component so folder actions wrap properly 

| Before | After |
| --- | --- |
| <img width="554" height="549" alt="image" src="https://github.com/user-attachments/assets/54d2bab5-7306-4f51-bc40-c2fa56bcebfa" /> | <img width="576" height="591" alt="image" src="https://github.com/user-attachments/assets/bf600dd8-8351-4059-8b8f-89583c2bd123" /> |

**Why do we need this feature?**

Responsiveness

**Which issue(s) does this PR fix?**:

Fixes N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
